### PR TITLE
feat: add /subagent slash commands

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,3 @@
+{
+  "extensions": ["../index.ts"]
+}

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,3 +1,0 @@
-{
-  "extensions": ["../index.ts"]
-}

--- a/README.md
+++ b/README.md
@@ -195,6 +195,15 @@ Skills are specialized instructions loaded from SKILL.md files and injected into
 
 ## Usage
 
+### Commands
+
+The extension registers TUI slash commands for managing subagents:
+
+- `/subagent list` - list agents sorted by name with `[user]` or `[project]` tags.
+- `/subagent add <name> [global|local]` - create a new agent (defaults to local).
+- `/subagent edit [name]` - open an agent in `$EDITOR` (prompts if omitted).
+- `/subagent promote [name]` - move a project agent to the user scope (prompts if omitted).
+
 **subagent tool:**
 ```typescript
 // Single agent


### PR DESCRIPTION


https://github.com/user-attachments/assets/0ea84904-8dfd-45c7-a366-f2fd36c024b1



Implements /subagent list/add/edit/promote commands with TUI prompts and README docs. Fixes non-TTY editor error by falling back to TUI editor.

Fixes #6.
