### PR TITLE
Limit nested subagent recursion (depth guard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,25 @@ Press **Ctrl+O** to expand the full streaming view with complete output per step
 
 > **Note:** Chain visualization (the `✓scout → ●planner` line) is only shown for sequential chains. Chains with parallel steps show per-step cards instead.
 
+## Nested subagent recursion guard
+
+`pi-subagents` can spawn `pi` processes which themselves have access to the `subagent` tool. Unbounded nesting can easily lead to runaway recursion (slow, expensive, and hard to observe).
+
+By default, nesting is limited to:
+
+- `main session → subagent → subsubagent`
+
+Further nested `subagent` calls are blocked and return guidance (no hard error).
+
+Override with an environment variable **set before starting `pi`**:
+
+```bash
+export PI_SUBAGENT_MAX_DEPTH=2  # default
+export PI_SUBAGENT_MAX_DEPTH=3  # allow one more level (use with caution)
+```
+
+> Increasing the max depth increases the chance of accidental recursion and token cost.
+
 ## Async observability
 
 Async runs write a dedicated observability folder:


### PR DESCRIPTION
## Problem
`pi-subagents` spawns child `pi` processes to run delegated work. Those child processes can themselves call the `subagent` tool, which can lead to accidental runaway recursion (slow, expensive, and difficult to observe/debug).

## Fix
Introduce a simple recursion depth guard propagated via environment variables:
- Each spawned `pi` process receives `PI_SUBAGENT_DEPTH` incremented by 1.
- A configurable limit `PI_SUBAGENT_MAX_DEPTH` is enforced (default: `2`).
  - This allows: `main session → subagent → subsubagent`
  - Further nested `subagent` calls are blocked.

### Behavior
If the depth limit is exceeded, the tool call is **soft-blocked** and returns guidance (instead of hard-failing the entire run). This prevents runaway recursion while allowing the calling agent to recover.

### Configuration
Set before starting `pi`:
```bash
export PI_SUBAGENT_MAX_DEPTH=2  # default
export PI_SUBAGENT_MAX_DEPTH=3  # allow one more level (use with caution)
```

## Files changed
- `execution.ts`: propagate depth env vars to sync-run child `pi`.
- `subagent-runner.ts`: propagate depth env vars to async-run child `pi`.
- `index.ts`: enforce guard in the tool entrypoint (soft block + guidance).
- `README.md`: document the recursion guard and env vars.
