### PR TITLE
feat: add extensions frontmatter field for extension sandboxing

### DIFF
--- a/agent-management.ts
+++ b/agent-management.ts
@@ -203,6 +203,12 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 		else if (typeof cfg.skills === "string") { const skills = parseCsv(cfg.skills); target.skills = skills.length ? skills : undefined; }
 		else return "config.skills must be a comma-separated string or false when provided.";
 	}
+	if (hasKey(cfg, "extensions")) {
+		if (cfg.extensions === false) target.extensions = undefined;
+		else if (cfg.extensions === "") target.extensions = [];
+		else if (typeof cfg.extensions === "string") { target.extensions = parseCsv(cfg.extensions); }
+		else return "config.extensions must be a comma-separated string, empty string, or false when provided.";
+	}
 	if (hasKey(cfg, "thinking")) {
 		if (cfg.thinking === false || cfg.thinking === "") target.thinking = undefined;
 		else if (typeof cfg.thinking === "string") target.thinking = cfg.thinking.trim() || undefined;
@@ -273,6 +279,7 @@ export function formatAgentDetail(agent: AgentConfig): string {
 	if (agent.model) lines.push(`Model: ${agent.model}`);
 	if (tools.length) lines.push(`Tools: ${tools.join(", ")}`);
 	if (agent.skills?.length) lines.push(`Skills: ${agent.skills.join(", ")}`);
+	if (agent.extensions !== undefined) lines.push(`Extensions: ${agent.extensions.length ? agent.extensions.join(", ") : "(none)"}`);
 	if (agent.thinking) lines.push(`Thinking: ${agent.thinking}`);
 	if (agent.output) lines.push(`Output: ${agent.output}`);
 	if (agent.defaultReads?.length) lines.push(`Reads: ${agent.defaultReads.join(", ")}`);

--- a/agent-manager-detail.ts
+++ b/agent-manager-detail.ts
@@ -64,6 +64,10 @@ function buildDetailLines(
 	lines.push(renderFieldLine("Tools:", tools, contentWidth, theme));
 	lines.push(renderFieldLine("MCP:", mcp, contentWidth, theme));
 	lines.push(renderFieldLine("Skills:", skillsList, contentWidth, theme));
+	const extensionsList = agent.extensions !== undefined
+		? (agent.extensions.length > 0 ? agent.extensions.join(", ") : "(none)")
+		: "(all)";
+	lines.push(renderFieldLine("Extensions:", extensionsList, contentWidth, theme));
 	lines.push(renderFieldLine("Output:", output, contentWidth, theme));
 	lines.push(renderFieldLine("Reads:", reads, contentWidth, theme));
 	lines.push(renderFieldLine("Progress:", progress, contentWidth, theme));

--- a/agent-manager-edit.ts
+++ b/agent-manager-edit.ts
@@ -16,7 +16,7 @@ export interface EditState {
 export interface EditInputResult { action?: "save" | "discard"; nextScreen?: EditScreen; }
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
-const FIELD_ORDER = ["name", "description", "model", "thinking", "tools", "skills", "output", "reads", "progress", "interactive", "prompt"] as const;
+const FIELD_ORDER = ["name", "description", "model", "thinking", "tools", "extensions", "skills", "output", "reads", "progress", "interactive", "prompt"] as const;
 type EditField = typeof FIELD_ORDER[number];
 type ThinkingLevel = typeof THINKING_LEVELS[number];
 const PROMPT_VIEWPORT_HEIGHT = 16;
@@ -29,7 +29,7 @@ function parseCommaList(value: string): string[] | undefined { const items = val
 
 export function createEditState(draft: AgentConfig, isNew: boolean, models: ModelInfo[], skills: SkillInfo[]): EditState {
 	return {
-		draft: { ...draft, tools: draft.tools ? [...draft.tools] : undefined, mcpDirectTools: draft.mcpDirectTools ? [...draft.mcpDirectTools] : undefined, skills: draft.skills ? [...draft.skills] : undefined, defaultReads: draft.defaultReads ? [...draft.defaultReads] : undefined, extraFields: draft.extraFields ? { ...draft.extraFields } : undefined },
+		draft: { ...draft, tools: draft.tools ? [...draft.tools] : undefined, mcpDirectTools: draft.mcpDirectTools ? [...draft.mcpDirectTools] : undefined, skills: draft.skills ? [...draft.skills] : undefined, extensions: draft.extensions ? [...draft.extensions] : draft.extensions, defaultReads: draft.defaultReads ? [...draft.defaultReads] : undefined, extraFields: draft.extraFields ? { ...draft.extraFields } : undefined },
 		isNew, fieldIndex: 0, fieldMode: null, fieldEditor: createEditorState(), promptEditor: createEditorState(draft.systemPrompt ?? ""),
 		modelSearchQuery: "", modelCursor: 0, filteredModels: [...models], thinkingCursor: 0, skillSearchQuery: "", skillCursor: 0, filteredSkills: [...skills], skillSelected: new Set(draft.skills ?? []),
 	};
@@ -43,6 +43,7 @@ function renderFieldValue(field: EditField, state: EditState): string {
 		case "model": return draft.model ?? "default";
 		case "thinking": return draft.thinking ?? "off";
 		case "tools": return formatTools(draft);
+		case "extensions": return draft.extensions !== undefined ? (draft.extensions.length > 0 ? draft.extensions.join(", ") : "") : "(all)";
 		case "skills": return draft.skills && draft.skills.length > 0 ? draft.skills.join(", ") : "";
 		case "output": return draft.output ?? "";
 		case "reads": return draft.defaultReads && draft.defaultReads.length > 0 ? draft.defaultReads.join(", ") : "";
@@ -59,6 +60,7 @@ function applyFieldValue(field: EditField, state: EditState, value: string): voi
 		case "description": draft.description = value.trim(); break;
 		case "model": draft.model = value.trim() || undefined; break;
 		case "tools": { const parsed = parseTools(value); draft.tools = parsed.tools; draft.mcpDirectTools = parsed.mcp; break; }
+		case "extensions": { const trimmed = value.trim(); draft.extensions = trimmed === "(all)" ? undefined : parseCommaList(trimmed) ?? []; break; }
 		case "skills": draft.skills = parseCommaList(value); break;
 		case "output": { const trimmed = value.trim(); draft.output = trimmed.length > 0 ? trimmed : undefined; break; }
 		case "reads": draft.defaultReads = parseCommaList(value); break;

--- a/agent-serializer.ts
+++ b/agent-serializer.ts
@@ -9,6 +9,7 @@ export const KNOWN_FIELDS = new Set([
 	"thinking",
 	"skill",
 	"skills",
+	"extensions",
 	"output",
 	"defaultReads",
 	"defaultProgress",
@@ -38,6 +39,11 @@ export function serializeAgent(config: AgentConfig): string {
 
 	const skillsValue = joinComma(config.skills);
 	if (skillsValue) lines.push(`skills: ${skillsValue}`);
+
+	if (config.extensions !== undefined) {
+		const extensionsValue = joinComma(config.extensions);
+		lines.push(`extensions: ${extensionsValue ?? ""}`);
+	}
 
 	if (config.output) lines.push(`output: ${config.output}`);
 

--- a/agents.ts
+++ b/agents.ts
@@ -21,6 +21,7 @@ export interface AgentConfig {
 	source: "user" | "project";
 	filePath: string;
 	skills?: string[];
+	extensions?: string[];
 	// Chain behavior fields
 	output?: string;
 	defaultReads?: string[];
@@ -145,6 +146,18 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
 			.map((s) => s.trim())
 			.filter(Boolean);
 
+		// Extensions whitelist (controls --no-extensions behavior)
+		// undefined = field absent = all extensions load (backward compat)
+		// [] = field present but empty = --no-extensions only
+		// ["path1", ...] = --no-extensions + --extension for each path
+		let extensions: string[] | undefined;
+		if (frontmatter.extensions !== undefined) {
+			extensions = frontmatter.extensions
+				.split(",")
+				.map((e) => e.trim())
+				.filter(Boolean);
+		}
+
 		const extraFields: Record<string, string> = {};
 		for (const [key, value] of Object.entries(frontmatter)) {
 			if (!KNOWN_FIELDS.has(key)) extraFields[key] = value;
@@ -161,6 +174,7 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
 			source,
 			filePath,
 			skills: skills && skills.length > 0 ? skills : undefined,
+			extensions,
 			// Chain behavior fields
 			output: frontmatter.output,
 			defaultReads: defaultReads && defaultReads.length > 0 ? defaultReads : undefined,

--- a/execution.ts
+++ b/execution.ts
@@ -95,6 +95,15 @@ export async function runSync(
 			args.push("--extension", extPath);
 		}
 	}
+	// Extensions whitelist: when the agent defines an `extensions` field,
+	// disable auto-discovered extensions and load only the listed ones.
+	// If `extensions` is absent (undefined), all extensions load (backward compat).
+	if (agent.extensions !== undefined) {
+		args.push("--no-extensions");
+		for (const extPath of agent.extensions) {
+			args.push("--extension", extPath);
+		}
+	}
 
 	const skillNames = options.skills ?? agent.skills ?? [];
 	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkills(skillNames, runtimeCwd);


### PR DESCRIPTION
## Problem

Subagents inherit **all** globally configured pi extensions (todo, brain, etc.) even when they only need built-in tools like `read` and `bash`. The `--tools` flag only gates built-in tools, not extensions. This causes subagents to access tools they shouldn't have — for example, a scout agent claiming TODO items via an inherited `todo` extension.

## Solution

New `extensions` frontmatter field that controls which pi extensions are available to a subagent. Follows the same pattern as `tools` and `skills`:

```yaml
# No extensions (clean sandbox)
extensions:

# Only specific extensions
extensions: /path/to/brain-graph, /path/to/other-ext

# Field absent = all extensions load (backward compat, no breaking change)
```

### Semantics

| Field state | `agent.extensions` | CLI args |
|---|---|---|
| Absent | `undefined` | (nothing — all extensions load) |
| Empty (`extensions:`) | `[]` | `--no-extensions` |
| With paths | `["/path/to/ext"]` | `--no-extensions --extension /path/to/ext` |

Uses pi's existing `--no-extensions` and `--extension` CLI flags.

## Changes

6 files, 44 insertions:

| File | Change |
|------|--------|
| `agents.ts` | `extensions?: string[]` on AgentConfig + frontmatter parsing |
| `agent-serializer.ts` | Added to KNOWN_FIELDS + serialization |
| `execution.ts` | `--no-extensions` + `--extension <path>` when field is present |
| `agent-management.ts` | create/update/get support |
| `agent-manager-detail.ts` | TUI detail view |
| `agent-manager-edit.ts` | TUI edit form (FIELD_ORDER, render, apply, clone) |

## Backward Compatibility

**Zero breaking changes.** When the `extensions` field is absent from an agent definition, behavior is identical to current — all extensions load via auto-discovery. The field is purely opt-in.

## Testing

Tested on Windows 11 with pi extensions (`todos`, `brain-graph`):

- Agent with `extensions:` (empty) → only built-in tools, zero extensions ✅
- Agent with `extensions: /path/to/brain-graph` → brain tools only, no todo ✅
- Agent without `extensions` field → all extensions load (backward compat) ✅
- Chain execution with sandboxed agents ✅
- Agent create/update via management actions ✅
- TUI detail view and edit form ✅