### PR TITLE
fix: resolve output path correctly instead of always wrapping in /tmp

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -3,11 +3,12 @@
  */
 
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentConfig } from "./agents.js";
 import { normalizeSkillInput } from "./skills.js";
 
-const CHAIN_RUNS_DIR = "/tmp/pi-chain-runs";
+const CHAIN_RUNS_DIR = path.join(os.tmpdir(), "pi-chain-runs");
 const CHAIN_DIR_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 // =============================================================================


### PR DESCRIPTION
## Problem

When using the `output` parameter in single-mode subagent calls, files are always written inside a temp directory instead of the user-specified path. Both absolute and relative paths are affected.

```
output: "C:/dev/project/reviews/review-arch.md"
→ saved to: /tmp/pi-_arch-reviewer-f56f4e02/C:/dev/project/reviews/review-arch.md

output: "reviews/review-arch.md"
→ saved to: /tmp/pi-_arch-reviewer-3be00f0a/reviews/review-arch.md
```

Additionally, the output path instruction is injected into the agent's task (`Write your findings to: ...`), but agents with only `read` tool can't write files. The output saving must happen in the caller.

On Windows, `/tmp` doesn't exist natively — files are created under MSYS path translation but are effectively lost to the user.

## Fix

**`index.ts`** — Output path resolution (2 changes):

1. **Resolve paths properly** instead of wrapping in temp dir:
   - Absolute path → use as-is
   - Relative path → resolve against `params.cwd ?? ctx.cwd`
   
2. **Save agent response to outputPath after run completes** — ensures output capture works even with read-only agents (e.g., reviewers with `tools: read`). The text instruction is still injected for agents that can write, but the extension now also saves the response as a safety net.

**`settings.ts`** — Use `os.tmpdir()` instead of hardcoded `/tmp` for chain runs directory.

## Changes

| File | Change |
|------|--------|
| `index.ts` | Resolve absolute/relative output paths correctly |
| `index.ts` | Write agent response to outputPath after successful run |
| `settings.ts` | `os.tmpdir()` instead of `/tmp` for chain dir |

2 files, 12 insertions, 4 deletions.

## Testing

Tested on Windows 11 (Git Bash / Scoop):
- Absolute output path → file created at specified location ✅
- Relative output path → resolved against cwd ✅
- Read-only agent → response saved by extension ✅
- Chain dir uses `os.tmpdir()` → correct temp directory on Windows ✅
