### PR TITLE
fix: include agent outputs in parallel result content

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -509,8 +509,13 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 
 				const ok = results.filter((r) => r.exitCode === 0).length;
 				const downgradeNote = parallelDowngraded ? " (async not supported for parallel)" : "";
+				const outputs = results.map((r) => {
+					const output = r.truncation?.text || getFinalOutput(r.messages);
+					const status = r.exitCode === 0 ? "completed" : "FAILED";
+					return `## [${r.agent}] ${status}\n\n${output || "(no output)"}`;
+				});
 				return {
-					content: [{ type: "text", text: `${ok}/${results.length} succeeded${downgradeNote}` }],
+					content: [{ type: "text", text: `${ok}/${results.length} succeeded${downgradeNote}\n\n${outputs.join("\n\n---\n\n")}` }],
 					details: {
 						mode: "parallel",
 						results,


### PR DESCRIPTION
Parallel mode returns only a status count in `content`:

For example:
```
3/3 succeeded
```

The full agent outputs go into `details`, which is session metadata -- the model never sees it. After a parallel run, the model has no results to work with and either calls `subagent_status` (which fails for sync runs) or redoes the work manually.

Single mode already returns `getFinalOutput(r.messages)` in `content`. Chain mode passes outputs between steps via `getFinalOutput`. Only parallel mode drops them.

My Fix:
Extract each agent's final output and include it in `content`, separated by headers:

```
3/3 succeeded

## [scout] completed

<full output from agent 0>

---

## [scout] completed

<full output from agent 1>

---

## [scout] completed

<full output from agent 2>
```

Respects truncation via `r.truncation?.text || getFinalOutput(r.messages)`, same as single mode.

## Reproduction

1. Run 3 scouts in parallel via `{ tasks: [...] }`
2. All 3 complete with substantial output
3. Model receives `3/3 succeeded` -- 13 characters
4. Model calls `subagent_status({})` -- fails
5. Model falls back to exploring the codebases itself