### PR TITLE
fix: use os.tmpdir() instead of hardcoded /tmp for Termux compatibility

### DIFF
--- a/artifacts.ts
+++ b/artifacts.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { ArtifactPaths } from "./types.js";
 
-const TEMP_ARTIFACTS_DIR = "/tmp/pi-subagent-artifacts";
+const TEMP_ARTIFACTS_DIR = path.join(os.tmpdir(), "pi-subagent-artifacts");
 const CLEANUP_MARKER_FILE = ".last-cleanup";
 
 export function getArtifactsDir(sessionFile: string | null): string {

--- a/index.ts
+++ b/index.ts
@@ -158,7 +158,7 @@ EXECUTION (use exactly ONE mode):
 CHAIN TEMPLATE VARIABLES (use in task strings):
 • {task} - The original task/request from the user
 • {previous} - Text response from the previous step (empty for first step)
-• {chain_dir} - Shared directory for chain files (e.g., /tmp/pi-chain-runs/abc123/)
+• {chain_dir} - Shared directory for chain files (e.g., <tmpdir>/pi-chain-runs/abc123/)
 
 CHAIN DATA FLOW:
 1. Each step's text response automatically becomes {previous} for the next step
@@ -583,7 +583,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				const cleanTask = task;
 				let outputPath: string | undefined;
 				if (typeof effectiveOutput === 'string' && effectiveOutput) {
-					const outputDir = `/tmp/pi-${agentConfig.name}-${runId}`;
+					const outputDir = path.join(os.tmpdir(), `pi-${agentConfig.name}-${runId}`);
 					fs.mkdirSync(outputDir, { recursive: true });
 					outputPath = `${outputDir}/${effectiveOutput}`;
 

--- a/schemas.ts
+++ b/schemas.ts
@@ -75,7 +75,7 @@ export const SubagentParams = Type.Object({
 	})),
 	tasks: Type.Optional(Type.Array(TaskItem, { description: "PARALLEL mode: [{agent, task}, ...]" })),
 	chain: Type.Optional(Type.Array(ChainItem, { description: "CHAIN mode: sequential pipeline where each step's response becomes {previous} for the next. Use {task}, {previous}, {chain_dir} in task templates." })),
-	chainDir: Type.Optional(Type.String({ description: "Persistent directory for chain artifacts. Default: /tmp/pi-chain-runs/ (auto-cleaned after 24h)" })),
+	chainDir: Type.Optional(Type.String({ description: "Persistent directory for chain artifacts. Default: <tmpdir>/pi-chain-runs/ (auto-cleaned after 24h)" })),
 	async: Type.Optional(Type.Boolean({ description: "Run in background (default: false, or per config)" })),
 	agentScope: Type.Optional(Type.String({ description: "Agent discovery scope: 'user', 'project', or 'both' (default: 'user')" })),
 	cwd: Type.Optional(Type.String()),

--- a/settings.ts
+++ b/settings.ts
@@ -3,11 +3,12 @@
  */
 
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentConfig } from "./agents.js";
 import { normalizeSkillInput } from "./skills.js";
 
-const CHAIN_RUNS_DIR = "/tmp/pi-chain-runs";
+const CHAIN_RUNS_DIR = path.join(os.tmpdir(), "pi-chain-runs");
 const CHAIN_DIR_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 // =============================================================================

--- a/types.ts
+++ b/types.ts
@@ -2,6 +2,8 @@
  * Type definitions for the subagent extension
  */
 
+import * as os from "node:os";
+import * as path from "node:path";
 import type { Message } from "@mariozechner/pi-ai";
 
 // ============================================================================
@@ -237,8 +239,8 @@ export const DEFAULT_ARTIFACT_CONFIG: ArtifactConfig = {
 
 export const MAX_PARALLEL = 8;
 export const MAX_CONCURRENCY = 4;
-export const RESULTS_DIR = "/tmp/pi-async-subagent-results";
-export const ASYNC_DIR = "/tmp/pi-async-subagent-runs";
+export const RESULTS_DIR = path.join(os.tmpdir(), "pi-async-subagent-results");
+export const ASYNC_DIR = path.join(os.tmpdir(), "pi-async-subagent-runs");
 export const WIDGET_KEY = "subagent-async";
 export const POLL_INTERVAL_MS = 250;
 export const MAX_WIDGET_JOBS = 4;


### PR DESCRIPTION
Fixes #18

## Problem

On Android/Termux, `/tmp` is not writable. The extension fails to load with:

```
EACCES: permission denied, mkdir '/tmp/pi-async-subagent-results'
```

Termux uses a different temp directory (e.g., `/data/data/com.termux/files/usr/tmp`), exposed via `$TMPDIR`.

## Fix

Replace all hardcoded `/tmp/` paths with `path.join(os.tmpdir(), ...)`. Node's `os.tmpdir()` already handles this cross-platform — it respects `$TMPDIR` on Linux/Termux, and returns the correct path on macOS/Windows too.

### Files changed

| File | Change |
|------|--------|
| `types.ts` | `RESULTS_DIR` and `ASYNC_DIR` constants |
| `settings.ts` | `CHAIN_RUNS_DIR` constant |
| `artifacts.ts` | `TEMP_ARTIFACTS_DIR` constant |
| `index.ts` | Inline `outputDir` path + docs |
| `schemas.ts` | Description string (cosmetic) |

No behavioral change on standard Linux/macOS where `os.tmpdir()` returns `/tmp`.