### PR TITLE
fix: model override silently ignored — use --models instead of --model (fixes #8)

### DIFF
--- a/execution.ts
+++ b/execution.ts
@@ -77,7 +77,10 @@ export async function runSync(
 	}
 	const effectiveModel = modelOverride ?? agent.model;
 	const modelArg = applyThinkingSuffix(effectiveModel, agent.thinking);
-	if (modelArg) args.push("--model", modelArg);
+	// Use --models (not --model) because pi CLI silently ignores --model
+	// without a companion --provider flag. --models resolves the provider
+	// automatically via resolveModelScope. See: #8
+	if (modelArg) args.push("--models", modelArg);
 	if (agent.tools?.length) {
 		const builtinTools: string[] = [];
 		const extensionPaths: string[] = [];

--- a/index.ts
+++ b/index.ts
@@ -406,7 +406,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 
 				// Mutable copies for TUI modifications
 				let tasks = params.tasks.map(t => t.task);
-				const modelOverrides: (string | undefined)[] = new Array(params.tasks.length).fill(undefined);
+				const modelOverrides: (string | undefined)[] = params.tasks.map(t => (t as { model?: string }).model);
 				// Initialize skill overrides from task-level skill params (may be overridden by TUI)
 				const skillOverrides: (string[] | false | undefined)[] = params.tasks.map(t => 
 					normalizeSkillInput((t as { skill?: string | string[] | boolean }).skill)

--- a/schemas.ts
+++ b/schemas.ts
@@ -11,6 +11,7 @@ export const TaskItem = Type.Object({
 	agent: Type.String(), 
 	task: Type.String(), 
 	cwd: Type.Optional(Type.String()),
+	model: Type.Optional(Type.String({ description: "Override model for this task (e.g. 'google/gemini-3-pro')" })),
 	skill: Type.Optional(SkillOverride),
 });
 

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -336,7 +336,10 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			} catch {}
 			args.push("--session-dir", config.sessionDir);
 		}
-		if (step.model) args.push("--model", step.model);
+		// Use --models (not --model) because pi CLI silently ignores --model
+		// without a companion --provider flag. --models resolves the provider
+		// automatically via resolveModelScope. See: #8
+		if (step.model) args.push("--models", step.model);
 		if (step.tools?.length) {
 			const builtinTools: string[] = [];
 			const extensionPaths: string[] = [];


### PR DESCRIPTION
Implements the fix proposed by @yasuhito in #8.

## Problem

The pi CLI silently ignores `--model` without a companion `--provider` flag, falling back to the session default model. In `main.js` → `buildSessionOptions()`:

```js
if (parsed.provider && parsed.model) {   // ← both required!
```

This means **all** model specifications in pi-subagents are silently ignored:
- Agent frontmatter `model:` field
- Per-task `model` override in parallel mode
- Chain step `model` override

Every subagent runs on the parent session's default model regardless of configuration.

## Fix

Two changes:

### 1. `--model` → `--models` (fixes #8)

As @yasuhito identified, `--models` triggers `resolveModelScope` → `parseModelPattern` → `tryMatchModel`, which auto-resolves the provider from the model ID. One-line change in each spawn site:

```diff
- if (modelArg) args.push("--model", modelArg);
+ if (modelArg) args.push("--models", modelArg);
```

### 2. Add per-task `model` to parallel mode

`TaskItem` schema lacked a `model` field, so per-task overrides in parallel mode (e.g. `{ agent: "x", task: "y", model: "google/gemini-3-pro-preview" }`) were silently stripped at schema validation. And `modelOverrides` was initialized to all `undefined` instead of reading from task params.

## Changes

| File | Change |
|------|--------|
| `execution.ts` | `--model` → `--models` (sync spawn) |
| `subagent-runner.ts` | `--model` → `--models` (async chain runner) |
| `schemas.ts` | Add `model` to `TaskItem` |
| `index.ts` | Init `modelOverrides` from task params |

4 files, 10 insertions, 3 deletions.

## Verification

Tested pi CLI directly on Windows 11:

| Command | Result |
|---------|--------|
| `pi --model github-copilot/gpt-5` | ❌ Silently runs `claude-opus-4-6` |
| `pi --models github-copilot/gpt-5` | ✅ Runs `gpt-5` |
| `pi --provider github-copilot --model gpt-5` | ✅ Runs `gpt-5` |

The `--models` approach is preferred over `--provider`/`--model` splitting because it's simpler (one flag) and handles provider resolution automatically.

## Note

The silent ignore of `--model` without `--provider` is arguably a pi core bug (no warning, no error — the flag is just lost). That should be addressed upstream in pi itself. This PR works around it at the pi-subagents level using the `--models` path that already exists.
