### PR TITLE
fix: prevent detectSubagentError false positive on recovered tool errors

### DIFF
--- a/detect-error.test.ts
+++ b/detect-error.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { detectSubagentError } from "./utils.ts";
+
+/**
+ * Helper to create a tool result message (success or error).
+ */
+function toolResult(toolName: string, text: string, isError = false): any {
+	return {
+		role: "toolResult",
+		toolCallId: `call-${Math.random().toString(36).slice(2, 8)}`,
+		toolName,
+		content: [{ type: "text", text }],
+		isError,
+	};
+}
+
+function assistantMsg(text: string): any {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "test",
+		provider: "test",
+		model: "test",
+	};
+}
+
+/** Assistant message with only a tool call, no text content */
+function assistantToolCall(toolName: string): any {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", name: toolName, input: {} }],
+		api: "test",
+		provider: "test",
+		model: "test",
+	};
+}
+
+describe("detectSubagentError", () => {
+	// ---- Basic detection (must still work) ----
+
+	it("returns no error for empty messages", () => {
+		assert.equal(detectSubagentError([]).hasError, false);
+	});
+
+	it("returns no error when all tool results succeed", () => {
+		const messages = [
+			toolResult("read", "file contents here"),
+			toolResult("bash", "ls output"),
+			toolResult("read", "more contents"),
+		];
+		assert.equal(detectSubagentError(messages).hasError, false);
+	});
+
+	it("detects isError tool result as failure (no assistant response)", () => {
+		const messages = [
+			toolResult("read", "file contents"),
+			toolResult("read", "EISDIR: illegal operation on a directory, read", true),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, true);
+		assert.equal(result.errorType, "read");
+		assert.match(result.details!, /EISDIR/);
+	});
+
+	it("detects bash fatal pattern (permission denied, no assistant response)", () => {
+		const messages = [
+			toolResult("bash", "ls: permission denied: /root/secret"),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, true);
+		assert.equal(result.errorType, "bash");
+	});
+
+	it("detects bash exit code in output", () => {
+		const messages = [
+			toolResult("bash", "error: process exited with code 127"),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, true);
+		assert.equal(result.exitCode, 127);
+	});
+
+	// ---- Recovery: errors before the agent's final response are forgiven ----
+
+	it("ignores error when agent recovered and continued", () => {
+		const messages = [
+			toolResult("read", "file contents"),
+			toolResult("bash", "ok"),
+			toolResult("read", "EISDIR: illegal operation on a directory", true),
+			toolResult("bash", "directory listing via bash"),
+			assistantMsg("Here is my complete review..."),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, false,
+			"error before agent's final text response should be ignored");
+	});
+
+	it("ignores error as final tool result when agent produced text response after", () => {
+		// The exact scenario from our review run: agent did all work, last tool
+		// call was read on directory → EISDIR, but agent produced 13.5KB review.
+		const messages = [
+			toolResult("read", "file contents of index.ts"),
+			toolResult("read", "file contents of utils.ts"),
+			toolResult("bash", "npm test output: 46 pass"),
+			toolResult("read", "file contents of settings.ts"),
+			toolResult("read", "EISDIR: illegal operation on a directory, read", true),
+			assistantMsg("## Complete Review\n\nHere are all my findings..."),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, false,
+			"agent produced substantive output after error — not a failure");
+	});
+
+	it("ignores bash fatal pattern when agent responded after", () => {
+		const messages = [
+			toolResult("bash", "ls: permission denied: /root/secret"),
+			assistantMsg("I couldn't access /root/secret, but I found the data elsewhere."),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, false,
+			"fatal pattern before agent's text response = recovered");
+	});
+
+	// ---- Errors AFTER the last assistant text response are still caught ----
+
+	it("detects error after agent's last text response", () => {
+		const messages = [
+			assistantMsg("Here is my analysis..."),
+			toolResult("bash", "rm -rf /important", false),
+			toolResult("bash", "error: process exited with code 1", false),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, true);
+		assert.equal(result.exitCode, 1);
+	});
+
+	it("detects isError after agent's last text response", () => {
+		const messages = [
+			toolResult("read", "file ok"),
+			assistantMsg("Let me try one more thing..."),
+			toolResult("write", "Permission denied", true),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, true);
+		assert.equal(result.errorType, "write");
+	});
+
+	// ---- Edge cases ----
+
+	it("flags error when no assistant messages at all", () => {
+		const messages = [
+			toolResult("read", "ok"),
+			toolResult("bash", "segmentation fault"),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, true,
+			"no assistant response = no recovery evidence");
+	});
+
+	it("does not treat tool-call-only assistant message as recovery", () => {
+		// Assistant message that only contains a tool call, no text
+		const messages = [
+			toolResult("bash", "permission denied: /etc/shadow"),
+			assistantToolCall("bash"),
+			toolResult("bash", "permission denied: /etc/shadow"),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, true,
+			"tool-call assistant message without text is not a recovery");
+	});
+
+	it("does not treat empty/whitespace assistant message as recovery", () => {
+		const messages = [
+			toolResult("read", "EISDIR: illegal operation on a directory", true),
+			assistantMsg("   "),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, true,
+			"whitespace-only assistant message is not a recovery");
+	});
+
+	it("returns no error when only assistant messages (no tool results)", () => {
+		const messages = [
+			assistantMsg("Hello, I'm ready to help."),
+			assistantMsg("Here's my analysis."),
+		];
+		assert.equal(detectSubagentError(messages).hasError, false);
+	});
+
+	it("handles multiple errors with recovery between them", () => {
+		// Error → recovery → error → recovery
+		const messages = [
+			toolResult("read", "ENOENT: no such file", true),
+			assistantMsg("File not found, trying alternative..."),
+			toolResult("read", "file contents"),
+			toolResult("read", "EISDIR: illegal operation on a directory", true),
+			assistantMsg("Got what I needed. Here's the full review."),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, false,
+			"all errors have recovery — agent completed successfully");
+	});
+
+	// ---- Real-world regression test ----
+
+	it("real-world: 19-read review run with trailing EISDIR", () => {
+		// Simulate the actual _impl-reviewer run that produced a false positive
+		const readResults = Array.from({ length: 18 }, (_, i) =>
+			toolResult("read", `contents of file ${i + 1}`),
+		);
+		const messages = [
+			...readResults,
+			toolResult("bash", "npm test\n46 pass\n2 fail\nTests 48"),
+			toolResult("read", "EISDIR: illegal operation on a directory, read", true),
+			assistantMsg("## Implementation Review\n\n" + "x".repeat(13000)),
+		];
+		const result = detectSubagentError(messages);
+		assert.equal(result.hasError, false,
+			"complete review with trailing EISDIR must not be flagged as failure");
+	});
+});


### PR DESCRIPTION
## Problem

`detectSubagentError()` overrides `exitCode 0 → 1` when a non-fatal tool error happens to be the last `toolResult` in the conversation — even if the agent successfully recovered and produced complete output.

### Real-world scenario

Our `_impl-reviewer` agent read 19 files, ran tests, and produced a complete 13.5KB review. Its very last tool call was `read` on a directory → `EISDIR` error (harmless exploratory read). `detectSubagentError` saw `isError: true` on the last tool result and overrode the exit code to 1, marking the entire successful run as failed.

## Root cause

The current algorithm (lines 188-252 of `utils.ts`) completely ignores assistant messages. It:

1. Finds the last successful tool result (scanning backwards)
2. Scans backwards from end, flags any error at or after that index

This means if the error IS the last tool result, it's always flagged — regardless of whether the agent produced a complete text response afterwards.

Additionally, when `lastSuccessfulToolIndex = -1` (no successful tools), the guard `if (i < lastSuccessfulToolIndex)` becomes `if (i < -1)` which never triggers, causing the scan to examine the entire message history.

## Fix

Find the last assistant message **with text content** and only scan tool results AFTER that index. Errors before the agent's final text response are considered recovered.

```typescript
// Find last assistant message with text content
let lastAssistantTextIndex = -1;
for (let i = messages.length - 1; i >= 0; i--) {
    if (messages[i].role === "assistant") {
        const hasText = messages[i].content?.some(
            c => c.type === "text" && c.text?.trim().length > 0
        );
        if (hasText) { lastAssistantTextIndex = i; break; }
    }
}

// Only scan tool results AFTER the last assistant text message
const scanStart = lastAssistantTextIndex >= 0 ? lastAssistantTextIndex + 1 : 0;
```

### What counts as "recovery"

An assistant message with **non-empty text content**. This excludes:
- Tool-call-only assistant messages (agent still working, not responding)
- Empty/whitespace-only assistant messages

### What does NOT count as recovery

No content length threshold is enforced. If the agent produced any text after the error and pi exited 0, we trust that. Rationale:

1. **The function only fires when `exitCode === 0 && !result.error`** — pi already told us the run succeeded
2. **A length threshold is arbitrary** — "All 3 tests pass." (22 chars) is a legitimate success
3. **Even "I couldn't complete the task" is useful** — the caller gets the agent's explanation rather than a synthetic error

## Alternatives considered

| Approach | Description | Why not |
|----------|-------------|---------|
| **B: Content length threshold** | Only trust assistant messages >200 chars | Arbitrary cutoff, breaks short legitimate responses |
| **C: Only check last N tool results** | Ignore errors more than 2 positions from end | Doesn't handle recovery semantics — just reduces window |
| **D: Require multiple consecutive errors** | Single error = ok, 3+ = failure | Doesn't match reality — one critical error IS a failure |
| **E: Only check bash, not isError** | Skip `isError` tool results entirely | Too aggressive — real tool failures would be missed |
| **F: Combined weighting** | Error recency + output length + pattern | Overengineered for this PR, could be a future enhancement |

**Chosen: Approach A with text-content check** — simplest, most principled, backwards compatible.

## Test coverage

16 test scenarios covering:

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Empty messages | `hasError: false` |
| 2 | All tools succeed | `hasError: false` |
| 3 | isError, no assistant response | `hasError: true` ✅ |
| 4 | Fatal bash pattern, no assistant response | `hasError: true` ✅ |
| 5 | Bash exit code 127 | `hasError: true` ✅ |
| 6 | Error → agent recovered and continued | `hasError: false` |
| 7 | Error as final tool, agent responded after | `hasError: false` ← **the fix** |
| 8 | Fatal pattern, agent responded after | `hasError: false` |
| 9 | Error AFTER agent's last response | `hasError: true` ✅ |
| 10 | isError AFTER agent's last response | `hasError: true` ✅ |
| 11 | No assistant messages at all | `hasError: true` ✅ |
| 12 | Tool-call-only assistant ≠ recovery | `hasError: true` ✅ |
| 13 | Whitespace-only assistant ≠ recovery | `hasError: true` ✅ |
| 14 | Only assistant messages, no tools | `hasError: false` |
| 15 | Multiple error→recovery cycles | `hasError: false` |
| 16 | Real-world: 19 reads + EISDIR + 13.5KB review | `hasError: false` ← **regression test** |

## Risks

**False negatives** (missing real failures): Low risk. The function is a safety net for silent failures — it only fires when pi reports success (`exitCode === 0`). If the agent truly failed, pi should set non-zero. If the agent said "I failed" in text, that's still more useful than a synthetic error override.

**Chain steps with polite failures**: Medium risk. An agent that says "I couldn't do X" (30 chars) would not be flagged. But the chain orchestrator receives the agent's text output and can detect this at a higher level.

## Known limitation (out of scope)

The `fatalPatterns` list includes `/timeout/i`, `/killed/i`, `/connection refused/i` which can match legitimate bash output. The assistant-message check mitigates most false positives (the agent responds after the match), but this remains a known limitation for a future PR.
