### PR TITLE
feat: generic piArgs pass-through for CLI arg forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,14 @@ Skills are specialized instructions loaded from SKILL.md files and injected into
 { agent: "worker", task: "refactor auth" }
 { agent: "scout", task: "find todos", maxOutput: { lines: 1000 } }
 { agent: "scout", task: "investigate", output: false }  // disable file output
+{ agent: "scout", task: "find auth", piArgs: ["--sandbox-profile", "intro-sec"] } // pass extra pi CLI args
 
 // Parallel (sync only)
 { tasks: [{ agent: "scout", task: "a" }, { agent: "scout", task: "b" }] }
+{ tasks: [
+  { agent: "scout", task: "recon", piArgs: ["--sandbox-profile", "intro"] },
+  { agent: "worker", task: "implement", piArgs: ["--sandbox-profile", "engineering"] }
+] }
 
 // Chain with TUI clarification (default)
 { chain: [
@@ -413,8 +418,8 @@ Skills are specialized instructions loaded from SKILL.md files and injected into
 
 // Chain with behavior overrides
 { chain: [
-  { agent: "scout", task: "find issues", output: false },  // text-only, no file
-  { agent: "worker", progress: false }  // disable progress tracking
+  { agent: "scout", task: "find issues", output: false, piArgs: ["--sandbox-profile", "intro"] },  // text-only, no file
+  { agent: "worker", progress: false, piArgs: ["--sandbox-profile", "engineering"] }  // disable progress tracking
 ]}
 
 // Chain with parallel step (fan-out/fan-in)
@@ -527,8 +532,9 @@ Notes:
 | `output` | `string \| false` | agent default | Override output file for single agent (absolute path as-is, relative path resolved against cwd) |
 | `skill` | `string \| string[] \| false` | agent default | Override skills (comma-separated string, array, or false to disable) |
 | `model` | string | agent default | Override model for single agent |
-| `tasks` | `{agent, task, cwd?, skill?}[]` | - | Parallel tasks (sync only) |
-| `chain` | ChainItem[] | - | Sequential steps with behavior overrides (see below) |
+| `piArgs` | `string[]` | - | Extra CLI args passed to child `pi` process (single mode) |
+| `tasks` | `{agent, task, cwd?, model?, skill?, piArgs?}[]` | - | Parallel tasks (sync only) |
+| `chain` | ChainItem[] | - | Sequential steps with behavior overrides (including per-step `piArgs`) |
 | `chainDir` | string | `<tmpdir>/pi-chain-runs/` | Persistent directory for chain artifacts (default auto-cleaned after 24h) |
 | `clarify` | boolean | true (chains) | Show TUI to preview/edit chain; implies sync mode |
 | `agentScope` | `"user" \| "project" \| "both"` | `both` | Agent discovery scope (project wins on name collisions) |
@@ -539,6 +545,8 @@ Notes:
 | `includeProgress` | boolean | false | Include full progress in result |
 | `share` | boolean | false | Upload session to GitHub Gist (see [Session Sharing](#session-sharing)) |
 | `sessionDir` | string | temp | Directory to store session logs |
+
+`piArgs` rejects reserved internal flags: `--mode`, `-p`, `--print`, `--no-session`, `--session`.
 
 **ChainItem** can be either a sequential step or a parallel step:
 
@@ -554,6 +562,7 @@ Notes:
 | `progress` | boolean | agent default | Override progress.md tracking |
 | `skill` | `string \| string[] \| false` | agent default | Override skills or disable all |
 | `model` | string | agent default | Override model for this step |
+| `piArgs` | `string[]` | - | Extra CLI args passed to child `pi` process for this step |
 
 *Parallel step fields:*
 
@@ -575,6 +584,7 @@ Notes:
 | `progress` | boolean | agent default | Override progress tracking |
 | `skill` | `string \| string[] \| false` | agent default | Override skills or disable all |
 | `model` | string | agent default | Override model for this task |
+| `piArgs` | `string[]` | - | Extra CLI args passed to child `pi` process for this task |
 
 Status tool:
 

--- a/chain-execution.ts
+++ b/chain-execution.ts
@@ -338,6 +338,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 						artifactConfig,
 						modelOverride: effectiveModel,
 						skills: behavior.skills === false ? [] : behavior.skills,
+						piArgs: task.piArgs,
 						onUpdate: onUpdate
 							? (p) => {
 									// Use concat instead of spread for better performance
@@ -494,6 +495,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				artifactConfig,
 				modelOverride: effectiveModel,
 				skills: behavior.skills === false ? [] : behavior.skills,
+				piArgs: seqStep.piArgs,
 				onUpdate: onUpdate
 					? (p) => {
 							// Use concat instead of spread for better performance

--- a/execution.ts
+++ b/execution.ts
@@ -8,6 +8,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@mariozechner/pi-ai";
 import type { AgentConfig } from "./agents.js";
+import { validatePiArgs } from "./pi-args-validation.js";
 import {
 	ensureArtifactsDir,
 	getArtifactPaths,
@@ -124,6 +125,12 @@ export async function runSync(
 		const tmp = writePrompt(agent.name, systemPrompt);
 		tmpDir = tmp.dir;
 		args.push("--append-system-prompt", tmp.path);
+	}
+
+	// Generic piArgs pass-through
+	if (options.piArgs?.length) {
+		validatePiArgs(options.piArgs);
+		args.push(...options.piArgs);
 	}
 
 	// When the task is too long for a CLI argument (Windows ENAMETOOLONG),

--- a/index.ts
+++ b/index.ts
@@ -440,6 +440,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 							return normalized;
 						})(),
 						output: effectiveOutput,
+						piArgs: params.piArgs,
 					});
 				}
 			}
@@ -626,6 +627,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 						maxOutput: params.maxOutput,
 						modelOverride: modelOverrides[i],
 						skills: effectiveSkills === false ? [] : effectiveSkills,
+						piArgs: t.piArgs,
 						onUpdate: onUpdate
 							? (p) => {
 									const stepResults = p.details?.results || [];
@@ -802,6 +804,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 					onUpdate,
 					modelOverride,
 					skills: effectiveSkills,
+					piArgs: params.piArgs,
 				});
 				recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
 

--- a/parallel-utils.ts
+++ b/parallel-utils.ts
@@ -15,6 +15,7 @@ export interface RunnerSubagentStep {
 	mcpDirectTools?: string[];
 	systemPrompt?: string | null;
 	skills?: string[];
+	piArgs?: string[];
 	outputPath?: string;
 }
 

--- a/pi-args-validation.test.ts
+++ b/pi-args-validation.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { validatePiArgs } from "./pi-args-validation.ts";
+
+describe("validatePiArgs", () => {
+	it("allows empty piArgs", () => {
+		assert.doesNotThrow(() => validatePiArgs([]));
+	});
+
+	it("allows non-reserved args", () => {
+		assert.doesNotThrow(() =>
+			validatePiArgs(["--sandbox-profile", "intro-sec", "--model", "anthropic/claude-sonnet-4-5"]),
+		);
+	});
+
+	it("does not block args that only contain reserved tokens as substrings", () => {
+		assert.doesNotThrow(() => validatePiArgs(["--mode-lite", "--session-name", "-print"]));
+	});
+
+	it("rejects exact reserved args", () => {
+		assert.throws(
+			() => validatePiArgs(["--mode"]),
+			/piArgs conflict: "--mode" is reserved/,
+		);
+		assert.throws(
+			() => validatePiArgs(["-p"]),
+			/piArgs conflict: "-p" is reserved/,
+		);
+		assert.throws(
+			() => validatePiArgs(["--print"]),
+			/piArgs conflict: "--print" is reserved/,
+		);
+		assert.throws(
+			() => validatePiArgs(["--no-session"]),
+			/piArgs conflict: "--no-session" is reserved/,
+		);
+		assert.throws(
+			() => validatePiArgs(["--session"]),
+			/piArgs conflict: "--session" is reserved/,
+		);
+	});
+
+	it("rejects reserved args passed with equals syntax", () => {
+		assert.throws(
+			() => validatePiArgs(["--mode=json"]),
+			/piArgs conflict: "--mode=json" is reserved/,
+		);
+		assert.throws(
+			() => validatePiArgs(["--session=abc"]),
+			/piArgs conflict: "--session=abc" is reserved/,
+		);
+	});
+
+	it("includes reserved args list in the error message", () => {
+		try {
+			validatePiArgs(["--mode"]);
+			assert.fail("expected validatePiArgs to throw");
+		} catch (error) {
+			const message = (error as Error).message;
+			assert.match(message, /Reserved args:/);
+			assert.match(message, /--mode/);
+			assert.match(message, /-p/);
+			assert.match(message, /--print/);
+			assert.match(message, /--no-session/);
+			assert.match(message, /--session/);
+		}
+	});
+});

--- a/pi-args-validation.ts
+++ b/pi-args-validation.ts
@@ -1,0 +1,14 @@
+const RESERVED_ARGS = ["--mode", "-p", "--print", "--no-session", "--session"];
+
+export function validatePiArgs(piArgs: string[]): void {
+	for (const arg of piArgs) {
+		for (const reserved of RESERVED_ARGS) {
+			if (arg === reserved || arg.startsWith(`${reserved}=`)) {
+				throw new Error(
+					`piArgs conflict: "${arg}" is reserved (internal to subagent spawning). ` +
+					`Reserved args: ${RESERVED_ARGS.join(", ")}`
+				);
+			}
+		}
+	}
+}

--- a/schemas.ts
+++ b/schemas.ts
@@ -13,6 +13,7 @@ export const TaskItem = Type.Object({
 	cwd: Type.Optional(Type.String()),
 	model: Type.Optional(Type.String({ description: "Override model for this task (e.g. 'google/gemini-3-pro')" })),
 	skill: Type.Optional(SkillOverride),
+	piArgs: Type.Optional(Type.Array(Type.String(), { description: "Extra CLI args passed to the child pi process" })),
 });
 
 // Sequential chain step (single agent)
@@ -27,6 +28,7 @@ export const SequentialStepSchema = Type.Object({
 	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking in {chain_dir}" })),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for this step" })),
+	piArgs: Type.Optional(Type.Array(Type.String(), { description: "Extra CLI args passed to the child pi process" })),
 });
 
 // Parallel task item (within a parallel step)
@@ -39,6 +41,7 @@ export const ParallelTaskSchema = Type.Object({
 	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking in {chain_dir}" })),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for this task" })),
+	piArgs: Type.Optional(Type.Array(Type.String(), { description: "Extra CLI args passed to the child pi process" })),
 });
 
 // Parallel chain step (multiple agents running concurrently)
@@ -93,6 +96,7 @@ export const SubagentParams = Type.Object({
 	output: Type.Optional(Type.Any({ description: "Override output file for single agent (string), or false to disable (uses agent default if omitted). Absolute paths are used as-is; relative paths resolve against cwd." })),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for single agent (e.g. 'anthropic/claude-sonnet-4')" })),
+	piArgs: Type.Optional(Type.Array(Type.String(), { description: "Extra CLI args passed to the child pi process" })),
 });
 
 export const StatusParams = Type.Object({

--- a/settings.ts
+++ b/settings.ts
@@ -45,6 +45,7 @@ export interface SequentialStep {
 	progress?: boolean;
 	skill?: string | string[] | false;
 	model?: string;
+	piArgs?: string[];
 }
 
 /** Parallel task item within a parallel step */
@@ -57,6 +58,7 @@ export interface ParallelTaskItem {
 	progress?: boolean;
 	skill?: string | string[] | false;
 	model?: string;
+	piArgs?: string[];
 }
 
 /** Parallel step: multiple agents running concurrently */

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { appendJsonl, getArtifactPaths } from "./artifacts.js";
+import { validatePiArgs } from "./pi-args-validation.js";
 import { getPiSpawnCommand } from "./pi-spawn.js";
 import { persistSingleOutput } from "./single-output.js";
 import {
@@ -310,6 +311,12 @@ async function runSingleStep(
 		const promptPath = path.join(tmpDir, "prompt.md");
 		fs.writeFileSync(promptPath, step.systemPrompt);
 		args.push("--append-system-prompt", promptPath);
+	}
+
+	// Generic piArgs pass-through
+	if (step.piArgs?.length) {
+		validatePiArgs(step.piArgs);
+		args.push(...step.piArgs);
 	}
 
 	const placeholderRegex = new RegExp(ctx.placeholder.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");

--- a/types.ts
+++ b/types.ts
@@ -213,6 +213,7 @@ export interface RunSyncOptions {
 	modelOverride?: string;
 	/** Skills to inject (overrides agent default if provided) */
 	skills?: string[];
+	piArgs?: string[];
 }
 
 export interface ExtensionConfig {


### PR DESCRIPTION
Closes #37

Supersedes #38 (rebranched to avoid coupling with my fork's main).

## Summary

Adds a `piArgs: string[]` field that passes arbitrary CLI args through to spawned `pi` processes. Available on single, parallel, chain (sequential + parallel steps), and async execution paths.

A reserved-arg denylist (`--mode`, `-p`, `--print`, `--no-session`, `--session`) prevents conflicts with flags the extension manages internally.

## Changes

- **schemas.ts / types.ts / settings.ts**: `piArgs` field on `SubagentParams`, `TaskItem`, `SequentialStep`, `ParallelTask`
- **execution.ts**: inject in sync single path
- **chain-execution.ts**: inject in sync chain (sequential + parallel steps)
- **async-execution.ts**: inject in async single + async chain
- **subagent-runner.ts**: inject in detached runner
- **parallel-utils.ts**: `piArgs` on `RunnerSubagentStep`
- **index.ts**: thread `piArgs` from params to all execution calls
- **pi-args-validation.ts**: reserved-arg validation with tests
- **README.md**: docs + parameter tables updated

## Tests

All suites pass: unit (94), integration (85), e2e (12).