### PR TITLE
feat: stream mode for chain execution

### DIFF
--- a/chain-execution.ts
+++ b/chain-execution.ts
@@ -541,7 +541,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 									stream: stream || undefined,
 								},
 							});
-							if (stream) updateChainStatusWidget(ctx, chainAgents, combined, stepIndex, true);
+							if (stream) { streamResults = combined; updateChainStatusWidget(ctx, chainAgents, combined, stepIndex, true); }
 						}
 					: undefined,
 			});

--- a/formatters.ts
+++ b/formatters.ts
@@ -84,7 +84,7 @@ export function buildChainSummary(
 }
 
 /**
- * Format a tool call for display
+ * Format a tool call for display (plain text)
  */
 export function formatToolCall(name: string, args: Record<string, unknown>): string {
 	switch (name) {
@@ -99,6 +99,45 @@ export function formatToolCall(name: string, args: Record<string, unknown>): str
 		default: {
 			const s = JSON.stringify(args);
 			return `${name} ${s.slice(0, 40)}${s.length > 40 ? "..." : ""}`;
+		}
+	}
+}
+
+/**
+ * Format a tool call with theme colors (matching pi-mono's tool rendering)
+ */
+export function formatToolCallThemed(name: string, args: Record<string, unknown>, theme: { fg: (color: string, text: string) => string; bold: (text: string) => string }): string {
+	const title = (n: string) => theme.fg("toolTitle", theme.bold(n));
+	const accent = (p: string) => theme.fg("accent", p);
+	const path = shortenPath((args.path || args.file_path || "") as string);
+
+	switch (name) {
+		case "bash": {
+			const cmd = ((args.command as string) || "").slice(0, 80);
+			const ellipsis = (args.command as string)?.length > 80 ? "..." : "";
+			return `${title("$")} ${cmd}${ellipsis}`;
+		}
+		case "read":
+			return `${title("read")} ${accent(path)}`;
+		case "write":
+			return `${title("write")} ${accent(path)}`;
+		case "edit":
+			return `${title("edit")} ${accent(path)}`;
+		case "grep": {
+			const pattern = (args.pattern || "") as string;
+			const grepPath = shortenPath((args.path || ".") as string);
+			return `${title("grep")} ${accent(`/${pattern}/`)} in ${grepPath}`;
+		}
+		case "find": {
+			const findPattern = (args.pattern || args.glob || "") as string;
+			const findPath = shortenPath((args.path || ".") as string);
+			return `${title("find")} ${accent(findPattern)} in ${findPath}`;
+		}
+		case "ls":
+			return `${title("ls")} ${accent(path)}`;
+		default: {
+			const s = JSON.stringify(args);
+			return `${title(name)} ${s.slice(0, 50)}${s.length > 50 ? "..." : ""}`;
 		}
 	}
 }

--- a/index.ts
+++ b/index.ts
@@ -98,6 +98,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	const config = loadConfig();
 	const asyncByDefault = config.asyncByDefault === true;
+	const streamByDefault = config.streamModeByDefault !== false;
 
 	const tempArtifactsDir = getArtifactsDir(null);
 	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
@@ -468,7 +469,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 					onUpdate,
 					chainSkills,
 					chainDir: params.chainDir,
-					stream: params.stream,
+					stream: params.stream ?? streamByDefault,
 				});
 
 				// User requested async via TUI - dispatch to async executor

--- a/schemas.ts
+++ b/schemas.ts
@@ -89,6 +89,7 @@ export const SubagentParams = Type.Object({
 	),
 	// Clarification TUI
 	clarify: Type.Optional(Type.Boolean({ description: "Show TUI to preview/edit before execution (default: true for chains, false for single/parallel). Implies sync mode." })),
+	stream: Type.Optional(Type.Boolean({ description: "Stream mode: show live step output instead of compact view (chains only)" })),
 	// Solo agent overrides
 	output: Type.Optional(Type.Any({ description: "Override output file for single agent (string), or false to disable (uses agent default if omitted). Absolute paths are used as-is; relative paths resolve against cwd." })),
 	skill: Type.Optional(SkillOverride),

--- a/types.ts
+++ b/types.ts
@@ -118,6 +118,7 @@ export interface Details {
 	chainAgents?: string[];      // Agent names in order, e.g., ["scout", "planner"]
 	totalSteps?: number;         // Total steps in chain
 	currentStepIndex?: number;   // 0-indexed current step (for running chains)
+	stream?: boolean;            // Stream mode: show live step output instead of compact view
 }
 
 // ============================================================================
@@ -179,9 +180,10 @@ export interface AsyncJobState {
 // Display
 // ============================================================================
 
-export type DisplayItem = 
-	| { type: "text"; text: string } 
-	| { type: "tool"; name: string; args: Record<string, unknown> };
+export type DisplayItem =
+	| { type: "text"; text: string }
+	| { type: "tool"; name: string; args: Record<string, unknown> }
+	| { type: "thinking"; thinking: string };
 
 // ============================================================================
 // Error Handling
@@ -242,6 +244,7 @@ export const MAX_CONCURRENCY = 4;
 export const RESULTS_DIR = path.join(os.tmpdir(), "pi-async-subagent-results");
 export const ASYNC_DIR = path.join(os.tmpdir(), "pi-async-subagent-runs");
 export const WIDGET_KEY = "subagent-async";
+export const CHAIN_STATUS_WIDGET_KEY = "subagent-chain-status";
 export const POLL_INTERVAL_MS = 250;
 export const MAX_WIDGET_JOBS = 4;
 export const DEFAULT_SUBAGENT_MAX_DEPTH = 2;

--- a/types.ts
+++ b/types.ts
@@ -219,6 +219,7 @@ export interface RunSyncOptions {
 
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
+	streamModeByDefault?: boolean;
 }
 
 // ============================================================================

--- a/utils.ts
+++ b/utils.ts
@@ -175,6 +175,7 @@ export function getDisplayItems(messages: Message[]): DisplayItem[] {
 		if (msg.role === "assistant") {
 			for (const part of msg.content) {
 				if (part.type === "text") items.push({ type: "text", text: part.text });
+				else if (part.type === "thinking" && "thinking" in part) items.push({ type: "thinking", thinking: (part as { thinking: string }).thinking });
 				else if (part.type === "toolCall") items.push({ type: "tool", name: part.name, args: part.arguments });
 			}
 		}


### PR DESCRIPTION
## Summary

- **Live output rendering** for chain execution — step output is rendered inline using pi-mono's `AssistantMessageComponent` and `ToolExecutionComponent`, matching the main chat look instead of showing a compact summary.
- **Chain status widget** — sticky bottom bar showing chain progress with blinking animation: `✓ scout 12s → ● planner 3s → ○ worker`
- **Multiple activation methods**: `stream` tool parameter, `--stream` CLI flag on `/chain`, `v` toggle in chain clarify TUI, and `streamModeByDefault` global config flag (defaults to `true`).

### Files changed

| File | Change |
|---|---|
| `types.ts` | `stream` on `Details`, `streamModeByDefault` on `ExtensionConfig`, `CHAIN_STATUS_WIDGET_KEY`, `thinking` display item |
| `schemas.ts` | `stream` boolean tool parameter |
| `index.ts` | `extractBgFlag` → `extractFlags` (supports `--stream`), reads config, passes stream to chain |
| `chain-execution.ts` | Accepts `stream`, manages status widget lifecycle, propagates in progress updates |
| `chain-clarify.ts` | `v` keybinding toggle, `initialStream` param, `stream` in result |
| `render.ts` | `renderStreamMode()`, `buildChainStatusLine()`, widget helpers |
| `formatters.ts` | `formatToolCallThemed()` for colored tool rendering |
| `utils.ts` | `getDisplayItems()` includes `thinking` parts |

## Test plan

- [ ] Run `/chain scout "task" -> planner` — should stream by default
- [ ] Run `/chain scout "task" -> planner --stream` — explicit stream flag
- [ ] Toggle stream mode with `v` in clarify TUI
- [ ] Set `streamModeByDefault: false` in config and verify compact view is default
- [ ] Verify status widget clears on chain completion and on errors