### PR TITLE
fix: scope skill discovery when agent defines explicit skills

### DIFF
--- a/execution.ts
+++ b/execution.ts
@@ -113,6 +113,13 @@ export async function runSync(
 	const skillNames = options.skills ?? agent.skills ?? [];
 	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkills(skillNames, runtimeCwd);
 
+	// When explicit skills are specified (via options or agent config), disable
+	// pi's own skill discovery so the spawned process doesn't inject the full
+	// <available_skills> catalog.  This mirrors how extensions are scoped above.
+	if (skillNames.length > 0) {
+		args.push("--no-skills");
+	}
+
 	let systemPrompt = agent.systemPrompt?.trim() || "";
 	if (resolvedSkills.length > 0) {
 		const skillInjection = buildSkillInjection(resolvedSkills);


### PR DESCRIPTION
## Problem

When an agent defines explicit skills in its frontmatter (e.g., `skills: exa, firecrawl, context7`), the subagent runner correctly resolves and injects their content via `--append-system-prompt`. However, the spawned `pi` process **also** runs its own skill discovery, injecting the full `<available_skills>` catalog into the agent's context.

This means every subagent sees **all** installed skills regardless of what was specified in its frontmatter. For example, a researcher agent with `skills: exa, firecrawl, context7` would see all 7 installed skills instead of just those 3.

### Impact
- **Wasted tokens** — full skills catalog injected into every subagent's context
- **Potential confusion** — agent sees skills it wasn't intended to use (e.g., `skill-creator` on a researcher)
- **Redundancy** — specified skills appear both in the `<available_skills>` catalog and as injected `<skill>` content blocks

## Fix

Pass `--no-skills` to the spawned `pi` process when explicit skills are defined. This mirrors the existing pattern already used for extensions in the same file:

```typescript
// Extensions (existing pattern — lines 102-110)
if (agent.extensions !== undefined) {
    args.push("--no-extensions");
    for (const extPath of agent.extensions) {
        args.push("--extension", extPath);
    }
}

// Skills (new fix)
if (skillNames.length > 0) {
    args.push("--no-skills");
}
```

When no skills are specified (field omitted), discovery runs normally and the agent inherits all available skills — preserving backward compatibility.

## Behavior Matrix (after fix)

| `skills` field | Discovery | What the agent sees |
|---|---|---|
| **Omitted** | Runs normally | All available skills (inherits) |
| **Empty** | Runs normally | All available skills (collapses to omitted) |
| **Explicit** (`exa, firecrawl`) | Disabled (`--no-skills`) | Only specified skill content |

## Testing

Verified by launching a fresh `pi` instance with the patched extension and invoking the researcher subagent. Before the fix it reported 7 skills; after the fix it correctly reported only the 3 defined in its frontmatter.