### PR TITLE
fix(skills): handle JSON-encoded array strings in normalizeSkillInput

### DIFF
--- a/skills.ts
+++ b/skills.ts
@@ -347,6 +347,21 @@ export function normalizeSkillInput(
 	if (Array.isArray(input)) {
 		return [...new Set(input.map((s) => s.trim()).filter((s) => s.length > 0))];
 	}
+	// Guard against JSON-encoded arrays arriving as strings (e.g. '["a","b"]').
+	// Models sometimes serialise the skill parameter as a JSON string instead of
+	// a native array, and naively splitting on "," would embed brackets/quotes
+	// into the skill names, causing resolution to silently fail.
+	const trimmed = input.trim();
+	if (trimmed.startsWith("[")) {
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (Array.isArray(parsed)) {
+				return normalizeSkillInput(parsed);
+			}
+		} catch {
+			// Not valid JSON – fall through to comma-split
+		}
+	}
 	return [...new Set(input.split(",").map((s) => s.trim()).filter((s) => s.length > 0))];
 }
 


### PR DESCRIPTION
## Problem

When models pass the `skill` parameter as a JSON-encoded string (e.g. `'["tanstack-router","confect","commit"]'`) instead of a native array, `normalizeSkillInput` hits the string branch and splits on `,`. This embeds brackets and quotes into the skill names:

| Intended name | Actual name after split |
|---|---|
| `tanstack-router` | `["tanstack-router"` |
| `confect` | `"confect"` |
| `commit` | `"commit"]` |

These mangled names never match any skill on disk, so all skills silently fail to resolve. The subagent runs without skill content injected into its system prompt.

### How I found it

Traced a real session where a worker subagent logged `skillsWarning: "Skills not found: [\"tanstack-router\", \"confect\", \"commit\"]"` despite all three skills existing in `.pi/skills/` and `~/.pi/agent/skills/`. The bracket-and-quote format in the warning (vs the expected comma-separated format from `.join(", ")`) was the key clue — it meant the *entire JSON string* had been split on commas, preserving the brackets and quotes as part of the individual tokens.

The root cause: the model's tool call serialised `skill: ["tanstack-router", "confect", "commit"]` as a JSON string rather than a native array by the time it reached the extension.

## Fix

Add a guard in `normalizeSkillInput` before the comma-split fallback: if the input string starts with `[`, attempt `JSON.parse`. When parsing succeeds and yields an array, recurse through the existing array branch (which already handles trimming, deduplication, and empty filtering). Invalid JSON or non-array values fall through to the existing comma-split behaviour unchanged.

## Testing

- All 88 existing unit tests pass
- Manually verified with the exact input from the failing session:
  - `normalizeSkillInput('["tanstack-router","confect","commit"]')` now returns `["tanstack-router", "confect", "commit"]`
  - Edge cases: leading whitespace, invalid JSON, empty arrays, non-string arrays all handled correctly