### PR TITLE
fix(parallel): stagger worker starts to avoid settings file-lock contention

### DIFF
--- a/parallel-utils.test.ts
+++ b/parallel-utils.test.ts
@@ -83,7 +83,7 @@ describe("flattenSteps", () => {
 describe("mapConcurrent", () => {
 	it("processes all items and preserves order", async () => {
 		const items = [10, 20, 30, 40];
-		const results = await mapConcurrent(items, 2, async (item) => item * 2);
+		const results = await mapConcurrent(items, 2, async (item) => item * 2, 0);
 		assert.deepEqual(results, [20, 40, 60, 80]);
 	});
 
@@ -97,13 +97,13 @@ describe("mapConcurrent", () => {
 			maxRunning = Math.max(maxRunning, running);
 			await new Promise((r) => setTimeout(r, 10));
 			running--;
-		});
+		}, 0);
 
 		assert.ok(maxRunning <= 2, `max concurrent was ${maxRunning}, expected <= 2`);
 	});
 
 	it("handles empty input", async () => {
-		const results = await mapConcurrent([], 4, async (item: number) => item);
+		const results = await mapConcurrent([], 4, async (item: number) => item, 0);
 		assert.deepEqual(results, []);
 	});
 
@@ -117,7 +117,7 @@ describe("mapConcurrent", () => {
 			await new Promise((r) => setTimeout(r, 10));
 			running--;
 			return item * 10;
-		});
+		}, 0);
 		assert.equal(maxRunning, 1, "should run sequentially with limit=0");
 	});
 
@@ -131,8 +131,41 @@ describe("mapConcurrent", () => {
 			await new Promise((r) => setTimeout(r, 10));
 			running--;
 			return item * 10;
-		});
+		}, 0);
 		assert.equal(maxRunning, 1, "should run sequentially with limit=-1");
+	});
+
+	it("staggers worker starts when staggerMs > 0", async () => {
+		const workerStarts: number[] = [];
+		const items = [1, 2, 3];
+
+		// Each item takes 500ms so workers stay busy past the stagger window
+		await mapConcurrent(items, 3, async (_item, i) => {
+			workerStarts.push(Date.now());
+			await new Promise((r) => setTimeout(r, 500));
+		}, 100);
+
+		// Worker 0 starts immediately, worker 1 after ~100ms, worker 2 after ~200ms
+		const d1 = workerStarts[1]! - workerStarts[0]!;
+		const d2 = workerStarts[2]! - workerStarts[0]!;
+		assert.ok(d1 >= 80, `worker 1 should start ~100ms after worker 0, got ${d1}ms`);
+		assert.ok(d2 >= 160, `worker 2 should start ~200ms after worker 0, got ${d2}ms`);
+	});
+
+	it("skips stagger when staggerMs is 0", async () => {
+		const startTimes: number[] = [];
+		const items = [1, 2, 3];
+
+		await mapConcurrent(items, 3, async (_item, i) => {
+			startTimes[i] = Date.now();
+			await new Promise((r) => setTimeout(r, 10));
+		}, 0);
+
+		// All workers should start nearly simultaneously
+		const d1 = startTimes[1]! - startTimes[0]!;
+		const d2 = startTimes[2]! - startTimes[0]!;
+		assert.ok(d1 < 20, `worker 1 should start immediately, got ${d1}ms delay`);
+		assert.ok(d2 < 20, `worker 2 should start immediately, got ${d2}ms delay`);
 	});
 });
 

--- a/parallel-utils.ts
+++ b/parallel-utils.ts
@@ -44,18 +44,24 @@ export function flattenSteps(steps: RunnerStep[]): RunnerSubagentStep[] {
 	return flat;
 }
 
-/** Run async tasks with bounded concurrency, preserving result order */
+/** Run async tasks with bounded concurrency, preserving result order.
+ *  `staggerMs` adds a small delay between each worker's start to avoid
+ *  file-lock contention when multiple subagents read shared config. */
 export async function mapConcurrent<T, R>(
 	items: T[],
 	limit: number,
 	fn: (item: T, i: number) => Promise<R>,
+	staggerMs = 150,
 ): Promise<R[]> {
 	// Clamp to at least 1; NaN/undefined/0/negative all become 1
 	const safeLimit = Math.max(1, Math.floor(limit) || 1);
 	const results: R[] = new Array(items.length);
 	let next = 0;
 
-	async function worker(): Promise<void> {
+	async function worker(workerIndex: number): Promise<void> {
+		if (staggerMs > 0 && workerIndex > 0) {
+			await new Promise((r) => setTimeout(r, workerIndex * staggerMs));
+		}
 		while (next < items.length) {
 			const i = next++;
 			results[i] = await fn(items[i], i);
@@ -63,7 +69,7 @@ export async function mapConcurrent<T, R>(
 	}
 
 	await Promise.all(
-		Array.from({ length: Math.min(safeLimit, items.length) }, () => worker()),
+		Array.from({ length: Math.min(safeLimit, items.length) }, (_, wi) => worker(wi)),
 	);
 	return results;
 }

--- a/utils.ts
+++ b/utils.ts
@@ -332,20 +332,24 @@ export async function mapConcurrent<T, R>(
 	items: T[],
 	limit: number,
 	fn: (item: T, i: number) => Promise<R>,
+	staggerMs = 150,
 ): Promise<R[]> {
 	// Clamp to at least 1; NaN/undefined/0/negative all become 1
 	const safeLimit = Math.max(1, Math.floor(limit) || 1);
 	const results: R[] = new Array(items.length);
 	let next = 0;
 
-	async function worker(): Promise<void> {
+	async function worker(workerIndex: number): Promise<void> {
+		if (staggerMs > 0 && workerIndex > 0) {
+			await new Promise((r) => setTimeout(r, workerIndex * staggerMs));
+		}
 		while (next < items.length) {
 			const i = next++;
 			results[i] = await fn(items[i], i);
 		}
 	}
 
-	const workers = Array.from({ length: Math.min(safeLimit, items.length) }, () => worker());
+	const workers = Array.from({ length: Math.min(safeLimit, items.length) }, (_, wi) => worker(wi));
 	await Promise.all(workers);
 	return results;
 }


### PR DESCRIPTION
When multiple subagents launch simultaneously in parallel mode, they all race to read/write the shared settings file at the same instant, causing lock contention and intermittent failures.

## Changes

Adds a `staggerMs` parameter (default 150ms) to both `mapConcurrent` implementations:
- **`parallel-utils.ts`** — used by the async runner (`subagent-runner.ts`)
- **`utils.ts`** — used by sync chain/parallel execution (`chain-execution.ts`, `index.ts`)

Worker 0 starts immediately, worker 1 after 150ms, worker 2 after 300ms, etc. The delay only applies to the initial start — once a worker begins processing items it runs at full speed with no inter-item delay.

The stagger is small enough to be imperceptible (max 600ms for 4 workers at default concurrency) but sufficient to prevent all processes from hitting the settings file simultaneously.

## Tests

- Existing tests updated to pass `staggerMs=0` where timing-sensitive
- Two new tests: verifying stagger behavior and the opt-out path (`staggerMs=0`)
- All 90 unit tests pass