### PR TITLE
feat: add defaultSessionDir extension config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Notes:
 | `artifacts` | boolean | true | Write debug artifacts |
 | `includeProgress` | boolean | false | Include full progress in result |
 | `share` | boolean | false | Upload session to GitHub Gist (see [Session Sharing](#session-sharing)) |
-| `sessionDir` | string | temp | Directory to store session logs |
+| `sessionDir` | string | unset | Optional directory to store session logs (overrides `defaultSessionDir`); when unset, fallback behavior applies |
 
 **ChainItem** can be either a sequential step or a parallel step:
 
@@ -604,11 +604,35 @@ Templates support three variables:
 
 This aggregated output becomes `{previous}` for the next step.
 
-## Chain Directory
+## Extension Configuration
 
+`pi-subagents` reads optional JSON config from `~/.pi/agent/extensions/subagent/config.json`.
+
+### `defaultSessionDir`
+
+`defaultSessionDir` sets the fallback directory used for session logs. Eg:
+
+```json
+{
+  "defaultSessionDir": "~/.pi/agent/sessions/subagent/"
+}
+```
+
+Session root resolution follows this precedence:
+1. `params.sessionDir` from the `subagent` tool call
+2. `config.defaultSessionDir`
+3. fallback behavior (no forced directory unless session tracking is explicitly enabled)
+
+When tracking is enabled but no directory is set (for example `share: true`), the extension falls back to a temporary directory under `<tmpdir>/pi-subagent-session-*/`.
+
+For compatibility, `--dir` omission on slash commands keeps existing defaults:
+- `/run`: existing session behavior when no explicit session override is provided.
+- `/chain`/`/parallel`: chain artifacts remain in `<tmpdir>/pi-chain-runs/{runId}/` unless `--dir` is used.
+
+## Chain Directory
 Each chain run creates `<tmpdir>/pi-chain-runs/{runId}/` containing:
 - `context.md` - Scout/context-builder output
-- `plan.md` - Planner output  
+- `plan.md` - Planner output
 - `progress.md` - Worker/reviewer shared progress
 - `parallel-{stepIndex}/` - Subdirectories for parallel step outputs
   - `0-{agent}/output.md` - First parallel task output
@@ -629,7 +653,14 @@ Files per task:
 
 ## Session Logs
 
-Session files (JSONL) are stored under a per-run session dir (temp by default). The session file path is shown in output. Set `sessionDir` to keep session logs outside `<tmpdir>`.
+Session files (JSONL) are stored under a per-run session dir when session logging is enabled. Directory selection follows the same precedence as above:
+1. explicit `sessionDir`
+2. `config.defaultSessionDir`
+3. temporary `<tmpdir>/pi-subagent-session-*/` fallback when `share: true`
+
+If none of those are set, no custom session dir is allocated (existing default behavior). The session file path is shown in output when available.
+
+Set `sessionDir` to force a specific path for one invocation.
 
 ## Session Sharing
 

--- a/index.ts
+++ b/index.ts
@@ -67,6 +67,20 @@ function loadConfig(): ExtensionConfig {
 	return {};
 }
 
+interface SessionRootInput {
+	shareEnabled: boolean;
+	sessionDir?: string;
+	defaultSessionDir?: string;
+}
+
+export function resolveSessionRoot(input: SessionRootInput): string | undefined {
+	const { sessionDir, defaultSessionDir, shareEnabled } = input;
+	if (sessionDir) return path.resolve(sessionDir);
+	if (!shareEnabled && !defaultSessionDir) return undefined;
+ 	if (defaultSessionDir) return path.resolve(defaultSessionDir);
+ 	return fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-session-"));
+ }
+
 /**
  * Create a directory and verify it is actually accessible.
  * On Windows with Azure AD/Entra ID, directories created shortly after
@@ -281,12 +295,11 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			const agents = discoverAgents(ctx.cwd, scope).agents;
 			const runId = randomUUID().slice(0, 8);
 			const shareEnabled = params.share === true;
-			const sessionEnabled = shareEnabled || Boolean(params.sessionDir);
-			const sessionRoot = sessionEnabled
-				? params.sessionDir
-					? path.resolve(params.sessionDir)
-					: fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-session-"))
-				: undefined;
+			const sessionRoot = resolveSessionRoot({
+				shareEnabled,
+				sessionDir: params.sessionDir,
+				defaultSessionDir: config.defaultSessionDir,
+			});
 			if (sessionRoot) {
 				try {
 					fs.mkdirSync(sessionRoot, { recursive: true });
@@ -305,7 +318,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			// - Chains default to TUI (clarify: true), so async requires explicit clarify: false
 			// - Single defaults to no TUI, so async is allowed unless clarify: true is passed
 			const effectiveAsync = requestedAsync && !hasTasks && (
-				hasChain 
+				hasChain
 					? params.clarify === false    // chains: only async if TUI explicitly disabled
 					: params.clarify !== true     // single: async unless TUI explicitly enabled
 			);
@@ -525,7 +538,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				let tasks = params.tasks.map(t => t.task);
 				const modelOverrides: (string | undefined)[] = params.tasks.map(t => (t as { model?: string }).model);
 				// Initialize skill overrides from task-level skill params (may be overridden by TUI)
-				const skillOverrides: (string[] | false | undefined)[] = params.tasks.map(t => 
+				const skillOverrides: (string[] | false | undefined)[] = params.tasks.map(t =>
 					normalizeSkillInput((t as { skill?: string | string[] | boolean }).skill)
 				);
 
@@ -539,7 +552,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 					}));
 
 					// Resolve behaviors with task-level skill overrides for TUI display
-					const behaviors = agentConfigs.map((c, i) => 
+					const behaviors = agentConfigs.map((c, i) =>
 						resolveStepBehavior(c, { skills: skillOverrides[i] })
 					);
 					const availableSkills = discoverAvailableSkills(ctx.cwd);

--- a/path-handling.test.ts
+++ b/path-handling.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 
@@ -13,7 +15,7 @@ import { describe, it } from "node:test";
 
 describe("path.isAbsolute vs startsWith('/')", () => {
 	// chain-execution.ts:496 uses startsWith("/") to detect absolute paths.
-	// On Windows, absolute paths look like "C:\..." or "C:/..." — neither starts with "/".
+	// On Windows, absolute paths look like "C:\\..." or "C:/..." — neither starts with "/".
 
 	it("startsWith('/') misses Windows absolute paths", () => {
 		const windowsAbsolute = "C:\\dev\\pi-subagents\\output.md";
@@ -60,10 +62,11 @@ describe("path.join vs template string concatenation", () => {
 	// This works but produces inconsistent separators on Windows.
 
 	it("template concatenation produces forward slashes regardless of platform", () => {
+		// chain-execution.ts:496 uses startsWith("/") to detect absolute paths.
 		const chainDir = "C:\\Users\\marc\\temp\\chain-abc";
 		const file = "progress.md";
 
-		// Template string: always forward slash (settings.ts:246 pattern)
+		// Template string: always forward slash
 		const templateResult = `${chainDir}/${file}`;
 		assert.equal(templateResult, "C:\\Users\\marc\\temp\\chain-abc/progress.md",
 			"template string produces mixed separators");
@@ -107,5 +110,87 @@ describe("path.join vs template string concatenation", () => {
 		const windowsJoin = path.join(windowsSubdir, output);
 		// Consistent: all native separators
 		assert.equal(windowsJoin, path.join("parallel-0", "0-_code-reviewer", output));
+	});
+});
+
+
+ type CommandPayload = Record<string, unknown>;
+
+ let registerSubagentExtension: ((pi: any) => void) | null = null;
+ let resolveSessionRoot: ((input: { shareEnabled: boolean; sessionDir?: string; defaultSessionDir?: string }) => string | undefined) | null = null;
+ let extensionImportError: string | null = null;
+
+ try {
+ 	const extensionModule = await import(new URL("./index.ts", import.meta.url));
+ 	registerSubagentExtension = extensionModule.default;
+	resolveSessionRoot = extensionModule.resolveSessionRoot;
+ } catch (error: unknown) {
+ 	const err = error as { code?: string; message?: string };
+ 	if (err?.code === "ERR_MODULE_NOT_FOUND" || err?.code === "MODULE_NOT_FOUND") {
+ 		extensionImportError = err.message ? `Dependency import unavailable: ${err.message}` : "Dependency import unavailable";
+ 	} else {
+ 		throw error;
+ 	}
+ }
+
+ const TOOL_CALL_PREFIX = "Call the subagent tool with these exact parameters: ";
+
+ const parseToolCallPayload = (messages: string[]): CommandPayload => {
+ 	const lastMessage = messages.at(-1);
+ 	assert.ok(typeof lastMessage === "string", "slash command handlers should emit a tool-call message");
+ 	const markerIndex = lastMessage!.indexOf(TOOL_CALL_PREFIX);
+ 	assert.notEqual(markerIndex, -1, `message should contain expected tool-call prefix: ${lastMessage!.slice(0, 120)}...`);
+ 	const rawPayload = lastMessage!.slice(markerIndex + TOOL_CALL_PREFIX.length);
+ 	return JSON.parse(rawPayload) as CommandPayload;
+ };
+
+ const extractDirField = (payload: CommandPayload): string | undefined => {
+ 	for (const key of ["dir", "chainDir", "sessionDir", "cwd"] as const) {
+ 		const value = payload[key];
+ 		if (typeof value === "string") return value;
+ 	}
+ 	return undefined;
+ };
+
+ const expectedDirValue = (value: string | undefined, expected: string): boolean => {
+ 	if (!value) return false;
+ 	return value === expected || value === path.resolve(process.cwd(), expected);
+ };
+
+
+describe("session root resolution", {
+	skip: extensionImportError ? extensionImportError : undefined,
+}, () => {
+	it("prefers explicit sessionDir over defaultSessionDir", () => {
+		const root = resolveSessionRoot({
+			shareEnabled: true,
+			sessionDir: "explicit-session-root",
+			defaultSessionDir: "default-session-root",
+		});
+		assert.equal(root, path.resolve("explicit-session-root"));
+	});
+
+	it("falls back to defaultSessionDir from extension config", () => {
+		const root = resolveSessionRoot({
+			shareEnabled: false,
+			defaultSessionDir: ".agents/plans/fallback-session-root",
+		});
+		assert.equal(root, path.resolve(".agents/plans/fallback-session-root"));
+	});
+
+	it("uses temp session dir fallback only when tracking is enabled", () => {
+		const root = resolveSessionRoot({
+			shareEnabled: true,
+		});
+		assert.ok(root?.startsWith(path.join(os.tmpdir(), "pi-subagent-session-")));
+		assert.ok(fs.existsSync(root!));
+		fs.rmSync(root!, { recursive: true, force: true });
+	});
+
+	it("does not allocate sessionRoot without tracking", () => {
+		const root = resolveSessionRoot({
+			shareEnabled: false,
+		});
+		assert.equal(root, undefined);
 	});
 });

--- a/types.ts
+++ b/types.ts
@@ -217,6 +217,7 @@ export interface RunSyncOptions {
 
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
+	defaultSessionDir?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Adds `defaultSessionDir` option to the extension config (`~/.pi/agent/extensions/subagent/config.json`) to enable persistent session logging without requiring explicit `sessionDir` in every tool call.

## Changes
- **types.ts**: Extended `ExtensionConfig` with `defaultSessionDir?: string`
- **index.ts**:
  - Added `resolveSessionRoot()` helper function to handle session directory precedence
  - Updated session root resolution to use the new precedence: explicit param → config default → temp fallback
- **path-handling.test.ts**: Added 4 tests for session root resolution precedence
- **README.md**: Documented `defaultSessionDir` in extension config section

## Behavior
Session directory resolution now follows:
1. `params.sessionDir` (explicit in tool call) - **highest priority**
2. `config.defaultSessionDir` (from `~/.pi/agent/extensions/subagent/config.json`)
3. Temporary directory (`<tmpdir>/pi-subagent-session-*/`) - only when session tracking enabled (e.g., `share: true`)

When no tracking is enabled (no `sessionDir`, no `defaultSessionDir`, no `share`), no session directory is allocated - preserving existing behavior.

## Example
```json
// ~/.pi/agent/extensions/subagent/config.json
{
  "asyncByDefault": true,
  "defaultSessionDir": ".agents/plans/session-logs"
}
```
## Related Issues
Closes: #44