### PR TITLE
feat: add --dir flag to /run, /chain, /parallel commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ The MCP adapter's metadata cache must be populated for direct tools to work. On 
 
 | Command | Description |
 |---------|-------------|
-| `/run <agent> <task>` | Run a single agent with a task |
-| `/chain agent1 "task1" -> agent2 "task2"` | Run agents in sequence with per-step tasks |
-| `/parallel agent1 "task1" -> agent2 "task2"` | Run agents in parallel with per-step tasks |
+| `/run <agent> <task> [--bg] [--dir <path>]` | Run a single agent with a task |
+| `/chain agent1 "task1" -> agent2 "task2" [--bg] [--dir <path>]` | Run agents in sequence with per-step tasks |
+| `/parallel agent1 "task1" -> agent2 "task2" [--bg] [--dir <path>]` | Run agents in parallel with per-step tasks |
 | `/agents` | Open the Agents Manager overlay |
 
 All commands validate agent names locally and tab-complete them, then route through the tool framework for full live progress rendering. Results are sent to the conversation for the LLM to discuss.
@@ -173,6 +173,25 @@ Add `--bg` at the end of any slash command to run in the background:
 ```
 
 Background tasks run asynchronously and notify you when complete. Check status with `subagent_status`.
+
+### Workflow directories with `--dir`
+
+All slash commands also support a trailing `--dir <path>` to pin command outputs into your task workspace (and can be combined with `--bg`).
+
+- `/run ... --dir <TASK_DIR>/` keeps that run's workspace-specific directory context.
+- `/chain ... --dir <TASK_DIR>/` and `/parallel ... --dir <TASK_DIR>/` inject `chainDir`, so chain artifacts land in that directory.
+
+`--dir` is optional and **opt-in** for chain artifacts; when omitted, chain/parallel keep their default behavior.
+
+```text
+/run scout "collect architecture notes" --dir <TASK_DIR>/
+/chain scout "analyze auth system" -> planner "draft migration plan" --dir <TASK_DIR>/
+/parallel scout "scan frontend" -> reviewer "spot security issues" --dir <TASK_DIR>/
+```
+
+Backward compatibility:
+- `/chain` and `/parallel` still write artifacts under `<tmpdir>/pi-chain-runs/{runId}/` when `--dir` is not used.
+- `/run` default session behavior is unchanged when `--dir` is not used.
 
 ## Agents Manager
 
@@ -608,7 +627,7 @@ This aggregated output becomes `{previous}` for the next step.
 
 Each chain run creates `<tmpdir>/pi-chain-runs/{runId}/` containing:
 - `context.md` - Scout/context-builder output
-- `plan.md` - Planner output  
+- `plan.md` - Planner output
 - `progress.md` - Worker/reviewer shared progress
 - `parallel-{stepIndex}/` - Subdirectories for parallel step outputs
   - `0-{agent}/output.md` - First parallel task output

--- a/index.ts
+++ b/index.ts
@@ -305,7 +305,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			// - Chains default to TUI (clarify: true), so async requires explicit clarify: false
 			// - Single defaults to no TUI, so async is allowed unless clarify: true is passed
 			const effectiveAsync = requestedAsync && !hasTasks && (
-				hasChain 
+				hasChain
 					? params.clarify === false    // chains: only async if TUI explicitly disabled
 					: params.clarify !== true     // single: async unless TUI explicitly enabled
 			);
@@ -525,7 +525,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				let tasks = params.tasks.map(t => t.task);
 				const modelOverrides: (string | undefined)[] = params.tasks.map(t => (t as { model?: string }).model);
 				// Initialize skill overrides from task-level skill params (may be overridden by TUI)
-				const skillOverrides: (string[] | false | undefined)[] = params.tasks.map(t => 
+				const skillOverrides: (string[] | false | undefined)[] = params.tasks.map(t =>
 					normalizeSkillInput((t as { skill?: string | string[] | boolean }).skill)
 				);
 
@@ -539,7 +539,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 					}));
 
 					// Resolve behaviors with task-level skill overrides for TUI display
-					const behaviors = agentConfigs.map((c, i) => 
+					const behaviors = agentConfigs.map((c, i) =>
 						resolveStepBehavior(c, { skills: skillOverrides[i] })
 					);
 					const availableSkills = discoverAvailableSkills(ctx.cwd);
@@ -1043,6 +1043,17 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		return { arg: input.slice(start, end), start };
 	};
 
+	const applyInlineConfigToStep = (
+		step: Record<string, unknown>,
+		config: InlineConfig,
+	): void => {
+		if (config.output !== undefined) step.output = config.output;
+		if (config.reads !== undefined) step.reads = config.reads;
+		if (config.model) step.model = config.model;
+		if (config.skill !== undefined) step.skill = config.skill;
+		if (config.progress !== undefined) step.progress = config.progress;
+	};
+
 	/** Extract trailing --bg and --dir flags from args, return cleaned args and parsed values */
 	const extractTrailingFlags = (args: string, commandCwd: string): { args: string; bg: boolean; dir?: string } => {
 		let working = args.trim();
@@ -1206,17 +1217,17 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 	});
 
 	pi.registerCommand("run", {
-		description: "Run a subagent directly: /run agent[output=file] task [--bg]",
+		description: "Run a subagent directly: /run agent[output=file] task [--bg] [--dir <path>]",
 		getArgumentCompletions: makeAgentCompletions(false),
 		handler: async (args, ctx) => {
 			const commandCwd = ctx.cwd ?? baseCwd;
 			const { args: cleanedArgs, bg, dir } = extractTrailingFlags(args, commandCwd);
 			const input = cleanedArgs.trim();
 			const firstSpace = input.indexOf(" ");
-			if (firstSpace === -1) { ctx.ui.notify("Usage: /run <agent> <task> [--bg]", "error"); return; }
+			if (firstSpace === -1) { ctx.ui.notify("Usage: /run <agent> <task> [--bg] [--dir <path>]", "error"); return; }
 			const { name: agentName, config: inline } = parseAgentToken(input.slice(0, firstSpace));
 			const task = input.slice(firstSpace + 1).trim();
-			if (!task) { ctx.ui.notify("Usage: /run <agent> <task> [--bg]", "error"); return; }
+			if (!task) { ctx.ui.notify("Usage: /run <agent> <task> [--bg] [--dir <path>]", "error"); return; }
 
 			const agents = discoverAgents(baseCwd, "both").agents;
 			if (!agents.find((a) => a.name === agentName)) { ctx.ui.notify(`Unknown agent: ${agentName}`, "error"); return; }
@@ -1236,6 +1247,27 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 	});
 
 	interface ParsedStep { name: string; config: InlineConfig; task?: string }
+
+	const buildChainStep = (step: ParsedStep, fallbackTask?: string): Record<string, unknown> => {
+		const chainStep: Record<string, unknown> = { agent: step.name };
+		if (step.task) {
+			chainStep.task = step.task;
+		} else if (fallbackTask) {
+			chainStep.task = fallbackTask;
+		}
+		applyInlineConfigToStep(chainStep, step.config);
+		return chainStep;
+	};
+
+	const buildParallelTask = (step: ParsedStep, fallbackTask?: string): Record<string, unknown> => {
+		const parallelTask: Record<string, unknown> = { agent: step.name };
+		const task = step.task ?? fallbackTask;
+		if (task !== undefined) {
+			parallelTask.task = task;
+		}
+		applyInlineConfigToStep(parallelTask, step.config);
+		return parallelTask;
+	};
 
 	const parseAgentArgs = (args: string, command: string, ctx: ExtensionContext): { steps: ParsedStep[]; task: string } | null => {
 		const input = args.trim();
@@ -1308,22 +1340,14 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 	};
 
 	pi.registerCommand("chain", {
-		description: "Run agents in sequence: /chain scout \"task\" -> planner [--bg]",
+		description: "Run agents in sequence: /chain scout \"task\" -> planner [--bg] [--dir <path>]",
 		getArgumentCompletions: makeAgentCompletions(true),
 		handler: async (args, ctx) => {
 			const commandCwd = ctx.cwd ?? baseCwd;
 			const { args: cleanedArgs, bg, dir } = extractTrailingFlags(args, commandCwd);
 			const parsed = parseAgentArgs(cleanedArgs, "chain", ctx);
 			if (!parsed) return;
-			const chain = parsed.steps.map(({ name, config, task: stepTask }, i) => ({
-				agent: name,
-				...(stepTask ? { task: stepTask } : i === 0 && parsed.task ? { task: parsed.task } : {}),
-				...(config.output !== undefined ? { output: config.output } : {}),
-				...(config.reads !== undefined ? { reads: config.reads } : {}),
-				...(config.model ? { model: config.model } : {}),
-				...(config.skill !== undefined ? { skill: config.skill } : {}),
-				...(config.progress !== undefined ? { progress: config.progress } : {}),
-			}));
+			const chain = parsed.steps.map((step, i) => buildChainStep(step, i === 0 ? parsed.task : undefined));
 			const params: Record<string, unknown> = { chain, task: parsed.task, clarify: false, agentScope: "both" };
 			if (dir) params.chainDir = dir;
 			if (bg) params.async = true;
@@ -1332,7 +1356,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 	});
 
 	pi.registerCommand("parallel", {
-		description: "Run agents in parallel: /parallel scout \"task1\" -> reviewer \"task2\" [--bg]",
+		description: "Run agents in parallel: /parallel scout \"task1\" -> reviewer \"task2\" [--bg] [--dir <path>]",
 		getArgumentCompletions: makeAgentCompletions(true),
 		handler: async (args, ctx) => {
 			const commandCwd = ctx.cwd ?? baseCwd;
@@ -1340,15 +1364,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			const parsed = parseAgentArgs(cleanedArgs, "parallel", ctx);
 			if (!parsed) return;
 			if (parsed.steps.length > MAX_PARALLEL) { ctx.ui.notify(`Max ${MAX_PARALLEL} parallel tasks`, "error"); return; }
-			const tasks = parsed.steps.map(({ name, config, task: stepTask }) => ({
-				agent: name,
-				task: stepTask ?? parsed.task,
-				...(config.output !== undefined ? { output: config.output } : {}),
-				...(config.reads !== undefined ? { reads: config.reads } : {}),
-				...(config.model ? { model: config.model } : {}),
-				...(config.skill !== undefined ? { skill: config.skill } : {}),
-				...(config.progress !== undefined ? { progress: config.progress } : {}),
-			}));
+			const tasks = parsed.steps.map((step) => buildParallelTask(step, parsed.task));
 			const params: Record<string, unknown> = { chain: [{ parallel: tasks }], task: parsed.task, clarify: false, agentScope: "both" };
 			if (dir) params.chainDir = dir;
 			if (bg) params.async = true;

--- a/index.ts
+++ b/index.ts
@@ -1240,7 +1240,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			if (inline.output !== undefined) params.output = inline.output;
 			if (inline.skill !== undefined) params.skill = inline.skill;
 			if (inline.model) params.model = inline.model;
-			if (dir) params.dir = dir;
+			if (dir) params.cwd = dir;
 			if (bg) params.async = true;
 			pi.sendUserMessage(`Call the subagent tool with these exact parameters: ${JSON.stringify({ ...params, agentScope: "both" })}`);
 		},

--- a/index.ts
+++ b/index.ts
@@ -1325,7 +1325,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				...(config.progress !== undefined ? { progress: config.progress } : {}),
 			}));
 			const params: Record<string, unknown> = { chain, task: parsed.task, clarify: false, agentScope: "both" };
-			if (dir) params.dir = dir;
+			if (dir) params.chainDir = dir;
 			if (bg) params.async = true;
 			pi.sendUserMessage(`Call the subagent tool with these exact parameters: ${JSON.stringify(params)}`);
 		},
@@ -1350,7 +1350,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				...(config.progress !== undefined ? { progress: config.progress } : {}),
 			}));
 			const params: Record<string, unknown> = { chain: [{ parallel: tasks }], task: parsed.task, clarify: false, agentScope: "both" };
-			if (dir) params.dir = dir;
+			if (dir) params.chainDir = dir;
 			if (bg) params.async = true;
 			pi.sendUserMessage(`Call the subagent tool with these exact parameters: ${JSON.stringify(params)}`);
 		},

--- a/index.ts
+++ b/index.ts
@@ -1078,7 +1078,8 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			break;
 		}
 
-		return { args: working, bg, dir: dir ? path.resolve(commandCwd, dir) : undefined };
+		const resolvedDir = dir ? path.resolve(commandCwd, dir) : undefined;
+		return { args: working, bg, dir: resolvedDir };
 	};
 
 	const setupDirectRun = (ctx: ExtensionContext) => {

--- a/index.ts
+++ b/index.ts
@@ -1008,13 +1008,77 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		return { name: token.slice(0, bracket), config: parseInlineConfig(token.slice(bracket + 1, end !== -1 ? end : undefined)) };
 	};
 
-	/** Extract --bg flag from end of args, return cleaned args and whether flag was present */
-	const extractBgFlag = (args: string): { args: string; bg: boolean } => {
-		// Only match --bg at the very end to avoid false positives in quoted strings
-		if (args.endsWith(" --bg") || args === "--bg") {
-			return { args: args.slice(0, args.length - (args === "--bg" ? 4 : 5)).trim(), bg: true };
+	const stripSurroundingQuotes = (value: string): string => {
+		if (
+			value.length >= 2 &&
+			((value[0] === '"' && value[value.length - 1] === '"') || (value[0] === "'" && value[value.length - 1] === "'"))
+		) {
+			return value.slice(1, -1);
 		}
-		return { args, bg: false };
+		return value;
+	};
+
+	const takeTrailingArg = (input: string): { arg: string; start: number } | null => {
+		let end = input.length;
+		while (end > 0 && /\s/.test(input[end - 1])) end--;
+		if (end === 0) return null;
+
+		let i = end - 1;
+		let quote: "'" | '"' | null = null;
+		while (i >= 0) {
+			const ch = input[i];
+			if (quote === null) {
+				if (ch === '"' || ch === "'") {
+					quote = ch;
+				} else if (/\s/.test(ch)) {
+					break;
+				}
+			} else if (ch === quote) {
+				quote = null;
+			}
+			i--;
+		}
+
+		const start = i + 1;
+		return { arg: input.slice(start, end), start };
+	};
+
+	/** Extract trailing --bg and --dir flags from args, return cleaned args and parsed values */
+	const extractTrailingFlags = (args: string, commandCwd: string): { args: string; bg: boolean; dir?: string } => {
+		let working = args.trim();
+		let bg = false;
+		let dir: string | undefined;
+
+		while (true) {
+			const trailing = takeTrailingArg(working);
+			if (!trailing) break;
+			const token = trailing.arg;
+
+			if (token === "--bg") {
+				bg = true;
+				working = working.slice(0, trailing.start).trim();
+				continue;
+			}
+
+			if (token.startsWith("--dir=")) {
+				const rawDir = stripSurroundingQuotes(token.slice("--dir=".length));
+				if (dir === undefined) dir = rawDir;
+				working = working.slice(0, trailing.start).trim();
+				continue;
+			}
+
+			const before = working.slice(0, trailing.start).trim();
+			const previous = takeTrailingArg(before);
+			if (previous && previous.arg === "--dir" && !token.startsWith("--") && dir === undefined) {
+				dir = stripSurroundingQuotes(token);
+				working = before.slice(0, previous.start).trim();
+				continue;
+			}
+
+			break;
+		}
+
+		return { args: working, bg, dir: dir ? path.resolve(commandCwd, dir) : undefined };
 	};
 
 	const setupDirectRun = (ctx: ExtensionContext) => {
@@ -1144,7 +1208,8 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		description: "Run a subagent directly: /run agent[output=file] task [--bg]",
 		getArgumentCompletions: makeAgentCompletions(false),
 		handler: async (args, ctx) => {
-			const { args: cleanedArgs, bg } = extractBgFlag(args);
+			const commandCwd = ctx.cwd ?? baseCwd;
+			const { args: cleanedArgs, bg, dir } = extractTrailingFlags(args, commandCwd);
 			const input = cleanedArgs.trim();
 			const firstSpace = input.indexOf(" ");
 			if (firstSpace === -1) { ctx.ui.notify("Usage: /run <agent> <task> [--bg]", "error"); return; }
@@ -1163,6 +1228,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 			if (inline.output !== undefined) params.output = inline.output;
 			if (inline.skill !== undefined) params.skill = inline.skill;
 			if (inline.model) params.model = inline.model;
+			if (dir) params.dir = dir;
 			if (bg) params.async = true;
 			pi.sendUserMessage(`Call the subagent tool with these exact parameters: ${JSON.stringify({ ...params, agentScope: "both" })}`);
 		},
@@ -1244,7 +1310,8 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		description: "Run agents in sequence: /chain scout \"task\" -> planner [--bg]",
 		getArgumentCompletions: makeAgentCompletions(true),
 		handler: async (args, ctx) => {
-			const { args: cleanedArgs, bg } = extractBgFlag(args);
+			const commandCwd = ctx.cwd ?? baseCwd;
+			const { args: cleanedArgs, bg, dir } = extractTrailingFlags(args, commandCwd);
 			const parsed = parseAgentArgs(cleanedArgs, "chain", ctx);
 			if (!parsed) return;
 			const chain = parsed.steps.map(({ name, config, task: stepTask }, i) => ({
@@ -1257,6 +1324,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				...(config.progress !== undefined ? { progress: config.progress } : {}),
 			}));
 			const params: Record<string, unknown> = { chain, task: parsed.task, clarify: false, agentScope: "both" };
+			if (dir) params.dir = dir;
 			if (bg) params.async = true;
 			pi.sendUserMessage(`Call the subagent tool with these exact parameters: ${JSON.stringify(params)}`);
 		},
@@ -1266,7 +1334,8 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 		description: "Run agents in parallel: /parallel scout \"task1\" -> reviewer \"task2\" [--bg]",
 		getArgumentCompletions: makeAgentCompletions(true),
 		handler: async (args, ctx) => {
-			const { args: cleanedArgs, bg } = extractBgFlag(args);
+			const commandCwd = ctx.cwd ?? baseCwd;
+			const { args: cleanedArgs, bg, dir } = extractTrailingFlags(args, commandCwd);
 			const parsed = parseAgentArgs(cleanedArgs, "parallel", ctx);
 			if (!parsed) return;
 			if (parsed.steps.length > MAX_PARALLEL) { ctx.ui.notify(`Max ${MAX_PARALLEL} parallel tasks`, "error"); return; }
@@ -1280,6 +1349,7 @@ MANAGEMENT (use action field — omit agent/task/chain/tasks):
 				...(config.progress !== undefined ? { progress: config.progress } : {}),
 			}));
 			const params: Record<string, unknown> = { chain: [{ parallel: tasks }], task: parsed.task, clarify: false, agentScope: "both" };
+			if (dir) params.dir = dir;
 			if (bg) params.async = true;
 			pi.sendUserMessage(`Call the subagent tool with these exact parameters: ${JSON.stringify(params)}`);
 		},

--- a/path-handling.test.ts
+++ b/path-handling.test.ts
@@ -139,17 +139,10 @@ const parseToolCallPayload = (messages: string[]): CommandPayload => {
 	return JSON.parse(rawPayload) as CommandPayload;
 };
 
-const extractDirField = (payload: CommandPayload): string | undefined => {
-	for (const key of ["dir", "chainDir", "sessionDir", "cwd"] as const) {
-		const value = payload[key];
-		if (typeof value === "string") return value;
-	}
-	return undefined;
-};
-
-const expectedDirValue = (value: string | undefined, expected: string): boolean => {
-	if (!value) return false;
-	return value === expected || value === path.resolve(process.cwd(), expected);
+const assertRunDirAliases = (payload: CommandPayload): void => {
+	assert.equal(payload.dir, undefined);
+	assert.equal(payload.chainDir, undefined);
+	assert.equal(payload.sessionDir, undefined);
 };
 
 
@@ -195,7 +188,8 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(payload.clarify, false);
 		assert.equal(payload.async, undefined);
 		assert.equal(payload.agentScope, "both");
-		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/dir-space"));
+		assert.equal(payload.cwd, path.resolve(process.cwd(), ".agents/plans/dir-space"));
+		assertRunDirAliases(payload);
 	});
 
 	it("/run parses --dir=<path> without disturbing task text", async () => {
@@ -205,7 +199,8 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(payload.agent, "scout");
 		assert.equal(payload.task, "collect architecture notes");
 		assert.equal(payload.async, undefined);
-		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/dir-eq"));
+		assert.equal(payload.cwd, path.resolve(process.cwd(), ".agents/plans/dir-eq"));
+		assertRunDirAliases(payload);
 	});
 
 	it("/run preserves legacy /bg behavior when --dir is absent", async () => {
@@ -216,7 +211,8 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(payload.task, "legacy mode run");
 		assert.equal(payload.async, true);
 		assert.equal(payload.agentScope, "both");
-		assert.equal(extractDirField(payload), undefined);
+		assert.equal(payload.cwd, undefined);
+		assertRunDirAliases(payload);
 	});
 
 	it("/run preserves quoted task text that includes --dir while supporting --bg", async () => {
@@ -226,8 +222,8 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(payload.agent, "scout");
 		assert.equal(payload.task, "mention --dir inside quote and keep --bg text");
 		assert.equal(payload.async, true);
-		assert.equal(payload.dir, undefined);
-		assert.equal(extractDirField(payload), undefined);
+		assert.equal(payload.cwd, undefined);
+		assertRunDirAliases(payload);
 	});
 
 	it("/run handles /run with both --bg and --dir while preserving quoted flag-like substrings", async () => {
@@ -238,8 +234,9 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(payload.task, "mention --dir and --bg in quoted task");
 		assert.equal(payload.async, true);
 		assert.equal(payload.agentScope, "both");
+		assert.equal(payload.cwd, path.resolve(process.cwd(), ".agents/plans/run-dir-bg"));
 		assert.equal(payload.chainDir, undefined);
-		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/run-dir-bg"));
+		assertRunDirAliases(payload);
 	});
 
 	it("/chain preserves quoted per-step task text when --bg is present", async () => {
@@ -256,7 +253,9 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(payload.async, true);
 		assert.equal(payload.task, "inspect --dir token in quote");
 		assert.equal(payload.chainDir, undefined);
-		assert.equal(extractDirField(payload), undefined);
+		assert.equal(payload.cwd, undefined);
+		assert.equal(payload.dir, undefined);
+		assert.equal(payload.sessionDir, undefined);
 	});
 
 	it("/chain parses combined --bg + --dir and preserves quoted flag-like task text", async () => {
@@ -273,8 +272,9 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(payload.async, true);
 		assert.equal(payload.task, "inspect --dir token in quote");
 		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/chain-dir-bg"));
+		assert.equal(payload.cwd, undefined);
 		assert.equal(payload.dir, undefined);
-		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/chain-dir-bg"));
+		assert.equal(payload.sessionDir, undefined);
 	});
 
 	it("/chain injects chainDir when --dir is provided", async () => {
@@ -282,9 +282,10 @@ describe("slash command parsing for --dir and quoted task text", {
 		const payload = parseToolCallPayload(messages);
 
 		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/chain-dir"));
+		assert.equal(payload.cwd, undefined);
 		assert.equal(payload.dir, undefined);
+		assert.equal(payload.sessionDir, undefined);
 		assert.equal(payload.async, undefined);
-		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/chain-dir"));
 	});
 
 	it("/parallel preserves legacy parse when --dir is absent", async () => {
@@ -300,9 +301,10 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(parallelStep[0]?.parallel[1]?.task, "spot --bg text");
 		assert.equal(payload.async, undefined);
 		assert.equal(payload.task, "scan API surface");
+		assert.equal(payload.cwd, undefined);
 		assert.equal(payload.dir, undefined);
+		assert.equal(payload.sessionDir, undefined);
 		assert.equal(payload.chainDir, undefined);
-		assert.equal(extractDirField(payload), undefined);
 	});
 
 	it("/parallel parses --dir and keeps quoted task text intact", async () => {
@@ -318,9 +320,10 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(parallelStep[0]?.parallel[1]?.task, "spot --dir mentions");
 		assert.equal(payload.async, undefined);
 		assert.equal(payload.task, "scan API surface");
+		assert.equal(payload.cwd, undefined);
 		assert.equal(payload.dir, undefined);
+		assert.equal(payload.sessionDir, undefined);
 		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/parallel-dir"));
-		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/parallel-dir"));
 	});
 
 	it("/parallel parses combined --bg + --dir while preserving quoted flag-like subtasks", async () => {
@@ -336,8 +339,9 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(parallelStep[0]?.parallel[1]?.task, "summarize --bg token");
 		assert.equal(payload.async, true);
 		assert.equal(payload.task, "scan --dir token in quote");
-		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/parallel-dir-bg"));
+		assert.equal(payload.cwd, undefined);
 		assert.equal(payload.dir, undefined);
-		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/parallel-dir-bg"));
+		assert.equal(payload.sessionDir, undefined);
+		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/parallel-dir-bg"));
 	});
 });

--- a/path-handling.test.ts
+++ b/path-handling.test.ts
@@ -245,6 +245,15 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(extractDirField(payload), undefined);
 	});
 
+	it("/chain injects chainDir when --dir is provided", async () => {
+		await commandHandlers.chain.handler('scout "draft structure" -> planner "finalize" --dir .agents/plans/chain-dir', ctx);
+		const payload = parseToolCallPayload(messages);
+
+		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/chain-dir"));
+		assert.equal(payload.dir, undefined);
+		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/chain-dir"));
+	});
+
 	it("/parallel parses --dir and keeps quoted task text intact", async () => {
 		await commandHandlers.parallel.handler('scout "scan API surface" -> reviewer "spot --dir mentions" --dir .agents/plans/parallel-dir', ctx);
 		const payload = parseToolCallPayload(messages);
@@ -258,6 +267,8 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(parallelStep[0]?.parallel[1]?.task, "spot --dir mentions");
 		assert.equal(payload.async, undefined);
 		assert.equal(payload.task, "scan API surface");
+		assert.equal(payload.dir, undefined);
+		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/parallel-dir"));
 		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/parallel-dir"));
 	});
 });

--- a/path-handling.test.ts
+++ b/path-handling.test.ts
@@ -226,7 +226,20 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(payload.agent, "scout");
 		assert.equal(payload.task, "mention --dir inside quote and keep --bg text");
 		assert.equal(payload.async, true);
+		assert.equal(payload.dir, undefined);
 		assert.equal(extractDirField(payload), undefined);
+	});
+
+	it("/run handles /run with both --bg and --dir while preserving quoted flag-like substrings", async () => {
+		await commandHandlers.run.handler('scout "mention --dir and --bg in quoted task" --bg --dir .agents/plans/run-dir-bg', ctx);
+		const payload = parseToolCallPayload(messages);
+
+		assert.equal(payload.agent, "scout");
+		assert.equal(payload.task, "mention --dir and --bg in quoted task");
+		assert.equal(payload.async, true);
+		assert.equal(payload.agentScope, "both");
+		assert.equal(payload.chainDir, undefined);
+		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/run-dir-bg"));
 	});
 
 	it("/chain preserves quoted per-step task text when --bg is present", async () => {
@@ -242,7 +255,26 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(chain[1]?.task, "summarize with --bg text");
 		assert.equal(payload.async, true);
 		assert.equal(payload.task, "inspect --dir token in quote");
+		assert.equal(payload.chainDir, undefined);
 		assert.equal(extractDirField(payload), undefined);
+	});
+
+	it("/chain parses combined --bg + --dir and preserves quoted flag-like task text", async () => {
+		await commandHandlers.chain.handler('scout "inspect --dir token in quote" -> planner "summarize with --bg text" --bg --dir .agents/plans/chain-dir-bg', ctx);
+		const payload = parseToolCallPayload(messages);
+
+		const chain = payload.chain as Array<{ agent: string; task?: string }>;
+		assert.equal(Array.isArray(chain), true);
+		assert.equal(chain.length, 2);
+		assert.equal(chain[0]?.agent, "scout");
+		assert.equal(chain[0]?.task, "inspect --dir token in quote");
+		assert.equal(chain[1]?.agent, "planner");
+		assert.equal(chain[1]?.task, "summarize with --bg text");
+		assert.equal(payload.async, true);
+		assert.equal(payload.task, "inspect --dir token in quote");
+		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/chain-dir-bg"));
+		assert.equal(payload.dir, undefined);
+		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/chain-dir-bg"));
 	});
 
 	it("/chain injects chainDir when --dir is provided", async () => {
@@ -251,7 +283,26 @@ describe("slash command parsing for --dir and quoted task text", {
 
 		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/chain-dir"));
 		assert.equal(payload.dir, undefined);
+		assert.equal(payload.async, undefined);
 		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/chain-dir"));
+	});
+
+	it("/parallel preserves legacy parse when --dir is absent", async () => {
+		await commandHandlers.parallel.handler('scout "scan API surface" -> reviewer "spot --bg text"', ctx);
+		const payload = parseToolCallPayload(messages);
+
+		assert.equal(Array.isArray(payload.chain), true);
+		const parallelStep = payload.chain as Array<{ parallel: Array<{ agent: string; task?: string }> }>;
+		assert.equal(Array.isArray(parallelStep[0]?.parallel), true);
+		assert.equal(parallelStep[0]?.parallel[0]?.agent, "scout");
+		assert.equal(parallelStep[0]?.parallel[0]?.task, "scan API surface");
+		assert.equal(parallelStep[0]?.parallel[1]?.agent, "reviewer");
+		assert.equal(parallelStep[0]?.parallel[1]?.task, "spot --bg text");
+		assert.equal(payload.async, undefined);
+		assert.equal(payload.task, "scan API surface");
+		assert.equal(payload.dir, undefined);
+		assert.equal(payload.chainDir, undefined);
+		assert.equal(extractDirField(payload), undefined);
 	});
 
 	it("/parallel parses --dir and keeps quoted task text intact", async () => {
@@ -270,5 +321,23 @@ describe("slash command parsing for --dir and quoted task text", {
 		assert.equal(payload.dir, undefined);
 		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/parallel-dir"));
 		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/parallel-dir"));
+	});
+
+	it("/parallel parses combined --bg + --dir while preserving quoted flag-like subtasks", async () => {
+		await commandHandlers.parallel.handler('scout "scan --dir token in quote" -> reviewer "summarize --bg token" --bg --dir .agents/plans/parallel-dir-bg', ctx);
+		const payload = parseToolCallPayload(messages);
+
+		assert.equal(Array.isArray(payload.chain), true);
+		const parallelStep = payload.chain as Array<{ parallel: Array<{ agent: string; task?: string }> }>;
+		assert.equal(Array.isArray(parallelStep[0]?.parallel), true);
+		assert.equal(parallelStep[0]?.parallel[0]?.agent, "scout");
+		assert.equal(parallelStep[0]?.parallel[0]?.task, "scan --dir token in quote");
+		assert.equal(parallelStep[0]?.parallel[1]?.agent, "reviewer");
+		assert.equal(parallelStep[0]?.parallel[1]?.task, "summarize --bg token");
+		assert.equal(payload.async, true);
+		assert.equal(payload.task, "scan --dir token in quote");
+		assert.equal(payload.chainDir, path.resolve(process.cwd(), ".agents/plans/parallel-dir-bg"));
+		assert.equal(payload.dir, undefined);
+		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/parallel-dir-bg"));
 	});
 });

--- a/path-handling.test.ts
+++ b/path-handling.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import * as path from "node:path";
-import { describe, it } from "node:test";
+import { beforeEach, describe, it } from "node:test";
 
 /**
  * Tests for cross-platform path handling patterns used throughout the codebase.
@@ -107,5 +107,157 @@ describe("path.join vs template string concatenation", () => {
 		const windowsJoin = path.join(windowsSubdir, output);
 		// Consistent: all native separators
 		assert.equal(windowsJoin, path.join("parallel-0", "0-_code-reviewer", output));
+	});
+});
+
+
+type CommandPayload = Record<string, unknown>;
+
+let registerSubagentExtension: ((pi: any) => void) | null = null;
+let extensionImportError: string | null = null;
+
+try {
+	const extensionModule = await import(new URL("./index.ts", import.meta.url));
+	registerSubagentExtension = extensionModule.default;
+} catch (error: unknown) {
+	const err = error as { code?: string; message?: string };
+	if (err?.code === "ERR_MODULE_NOT_FOUND" || err?.code === "MODULE_NOT_FOUND") {
+		extensionImportError = err.message ? `Dependency import unavailable: ${err.message}` : "Dependency import unavailable";
+	} else {
+		throw error;
+	}
+}
+
+const TOOL_CALL_PREFIX = "Call the subagent tool with these exact parameters: ";
+
+const parseToolCallPayload = (messages: string[]): CommandPayload => {
+	const lastMessage = messages.at(-1);
+	assert.ok(typeof lastMessage === "string", "slash command handlers should emit a tool-call message");
+	const markerIndex = lastMessage!.indexOf(TOOL_CALL_PREFIX);
+	assert.notEqual(markerIndex, -1, `message should contain expected tool-call prefix: ${lastMessage!.slice(0, 120)}...`);
+	const rawPayload = lastMessage!.slice(markerIndex + TOOL_CALL_PREFIX.length);
+	return JSON.parse(rawPayload) as CommandPayload;
+};
+
+const extractDirField = (payload: CommandPayload): string | undefined => {
+	for (const key of ["dir", "chainDir", "sessionDir", "cwd"] as const) {
+		const value = payload[key];
+		if (typeof value === "string") return value;
+	}
+	return undefined;
+};
+
+const expectedDirValue = (value: string | undefined, expected: string): boolean => {
+	if (!value) return false;
+	return value === expected || value === path.resolve(process.cwd(), expected);
+};
+
+
+describe("slash command parsing for --dir and quoted task text", {
+	skip: extensionImportError ? extensionImportError : undefined,
+}, () => {
+	let commandHandlers: Record<string, { handler: (args: string, ctx: { ui: { notify: (message: string) => void } }) => void | Promise<void> }>;
+	let messages: string[];
+
+	beforeEach(() => {
+		messages = [];
+		const handlers: Record<string, any> = {};
+		const pi: any = {
+			registerTool: () => {},
+			registerCommand: (name: string, def: any) => {
+				handlers[name] = def;
+			},
+			registerShortcut: () => {},
+			on: () => {},
+			events: {
+				on: () => {},
+			},
+			sendUserMessage: (text: string) => {
+				messages.push(text);
+			},
+		};
+		registerSubagentExtension!(pi);
+		commandHandlers = handlers;
+	});
+
+	const ctx = {
+		ui: {
+			notify: () => {},
+		},
+	};
+
+	it("/run parses --dir <path> without disturbing task text", async () => {
+		await commandHandlers.run.handler("scout \"collect architecture notes\" --dir .agents/plans/dir-space", ctx);
+		const payload = parseToolCallPayload(messages);
+
+		assert.equal(payload.agent, "scout");
+		assert.equal(payload.task, "collect architecture notes");
+		assert.equal(payload.clarify, false);
+		assert.equal(payload.async, undefined);
+		assert.equal(payload.agentScope, "both");
+		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/dir-space"));
+	});
+
+	it("/run parses --dir=<path> without disturbing task text", async () => {
+		await commandHandlers.run.handler("scout \"collect architecture notes\" --dir=.agents/plans/dir-eq", ctx);
+		const payload = parseToolCallPayload(messages);
+
+		assert.equal(payload.agent, "scout");
+		assert.equal(payload.task, "collect architecture notes");
+		assert.equal(payload.async, undefined);
+		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/dir-eq"));
+	});
+
+	it("/run preserves legacy /bg behavior when --dir is absent", async () => {
+		await commandHandlers.run.handler('scout "legacy mode run" --bg', ctx);
+		const payload = parseToolCallPayload(messages);
+
+		assert.equal(payload.agent, "scout");
+		assert.equal(payload.task, "legacy mode run");
+		assert.equal(payload.async, true);
+		assert.equal(payload.agentScope, "both");
+		assert.equal(extractDirField(payload), undefined);
+	});
+
+	it("/run preserves quoted task text that includes --dir while supporting --bg", async () => {
+		await commandHandlers.run.handler('scout "mention --dir inside quote and keep --bg text" --bg', ctx);
+		const payload = parseToolCallPayload(messages);
+
+		assert.equal(payload.agent, "scout");
+		assert.equal(payload.task, "mention --dir inside quote and keep --bg text");
+		assert.equal(payload.async, true);
+		assert.equal(extractDirField(payload), undefined);
+	});
+
+	it("/chain preserves quoted per-step task text when --bg is present", async () => {
+		await commandHandlers.chain.handler('scout "inspect --dir token in quote" -> planner "summarize with --bg text" --bg', ctx);
+		const payload = parseToolCallPayload(messages);
+
+		const chain = payload.chain as Array<{ agent: string; task?: string }>; 
+		assert.equal(Array.isArray(chain), true);
+		assert.equal(chain.length, 2);
+		assert.equal(chain[0]?.agent, "scout");
+		assert.equal(chain[0]?.task, "inspect --dir token in quote");
+		assert.equal(chain[1]?.agent, "planner");
+		assert.equal(chain[1]?.task, "summarize with --bg text");
+		assert.equal(payload.async, true);
+		assert.equal(payload.task, "inspect --dir token in quote");
+		assert.equal(extractDirField(payload), undefined);
+	});
+
+	it("/parallel parses --dir and keeps quoted task text intact", async () => {
+		await commandHandlers.parallel.handler('scout "scan API surface" -> reviewer "spot --dir mentions" --dir .agents/plans/parallel-dir', ctx);
+		const payload = parseToolCallPayload(messages);
+
+		assert.equal(Array.isArray(payload.chain), true);
+		const parallelStep = payload.chain as Array<{ parallel: Array<{ agent: string; task?: string }> }>;
+		assert.equal(Array.isArray(parallelStep[0]?.parallel), true);
+		assert.equal(parallelStep[0]?.parallel[0]?.agent, "scout");
+		assert.equal(parallelStep[0]?.parallel[0]?.task, "scan API surface");
+		assert.equal(parallelStep[0]?.parallel[1]?.agent, "reviewer");
+		assert.equal(parallelStep[0]?.parallel[1]?.task, "spot --dir mentions");
+		assert.equal(payload.async, undefined);
+		assert.equal(payload.task, "scan API surface");
+		assert.ok(expectedDirValue(extractDirField(payload), ".agents/plans/parallel-dir"));
 	});
 });


### PR DESCRIPTION
## Summary
Adds optional `--dir <path>` flag to `/run`, `/chain`, and `/parallel` slash commands to control working directories and isolate artifacts in task-specific folders.

## Changes
- **index.ts**:
  - Added `extractTrailingFlags()` helper to parse `--dir` and `--bg` flags with quote-aware reverse-scanning
  - Added `stripSurroundingQuotes()` to handle quoted path values
  - Added `takeTrailingArg()` for robust argument extraction
  - Added `applyInlineConfigToStep()`, `buildChainStep()`, `buildParallelTask()` helpers to reduce duplication
  - Updated `/run` handler to set `cwd` when `--dir` provided
  - Updated `/chain` handler to inject `chainDir` when `--dir` provided
  - Updated `/parallel` handler to inject `chainDir` when `--dir` provided
  - Updated command descriptions to include `--dir` flag
- **path-handling.test.ts**: Added 11 comprehensive tests for slash command parsing
- **README.md**: Added documentation and examples for `--dir` usage
- Added investigation document `session-persistence-investigation.md` for reference

## Behavior
- `/run ... --dir <path>`: Sets `cwd` parameter for the subagent run
- `/chain ... --dir <path>`: Injects `chainDir` for chain artifacts
- `/parallel ... --dir <path>`: Injects `chainDir` for parallel artifacts
- Relative paths resolved against `ctx.cwd`
- When `--dir` omitted, existing default behavior preserved
- Quoted task text containing `--dir` or `--bg` substrings correctly handled

## Examples
```bash
# Isolate outputs in task-specific directory
/run scout "analyze auth system" --dir 20260304T145245--auth-audit/

# Chain with artifacts in workspace directory
/chain scout "collect context" -> planner "draft plan" --dir task-123/

# Parallel runs with shared directory
/parallel scout "scan frontend" -> reviewer "check security" --dir code-review/
```

## Related Issue

Closes: #45