### PR TITLE
fix: resolve skill discovery from settings.packages and cwd

### DIFF
--- a/async-execution.ts
+++ b/async-execution.ts
@@ -15,7 +15,7 @@ import { injectSingleOutputInstruction, resolveSingleOutputPath } from "./single
 import { isParallelStep, resolveStepBehavior, type ChainStep, type ParallelStep, type SequentialStep, type StepOverrides } from "./settings.js";
 import type { RunnerStep } from "./parallel-utils.js";
 import { resolvePiPackageRoot } from "./pi-spawn.js";
-import { buildSkillInjection, normalizeSkillInput, resolveSkills } from "./skills.js";
+import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "./skills.js";
 import {
 	type ArtifactConfig,
 	type Details,
@@ -151,7 +151,11 @@ export function executeAsyncChain(
 		const behavior = resolveStepBehavior(a, stepOverrides, chainSkills);
 		const skillNames = behavior.skills === false ? [] : behavior.skills;
 		const skillCwd = s.cwd ?? cwd ?? ctx.cwd;
-		const { resolved: resolvedSkills } = resolveSkills(skillNames, skillCwd);
+		const { resolved: resolvedSkills } = resolveSkillsWithFallback(
+			skillNames,
+			skillCwd,
+			ctx.cwd,
+		);
 
 		let systemPrompt = a.systemPrompt?.trim() || null;
 		if (resolvedSkills.length > 0) {
@@ -262,7 +266,11 @@ export function executeAsyncSingle(
 	const { agent, task, agentConfig, ctx, cwd, maxOutput, artifactsDir, artifactConfig, shareEnabled, sessionRoot } = params;
 	const skillNames = params.skills ?? agentConfig.skills ?? [];
 	const skillCwd = cwd ?? ctx.cwd;
-	const { resolved: resolvedSkills } = resolveSkills(skillNames, skillCwd);
+	const { resolved: resolvedSkills } = resolveSkillsWithFallback(
+		skillNames,
+		skillCwd,
+		ctx.cwd,
+	);
 	let systemPrompt = agentConfig.systemPrompt?.trim() || null;
 	if (resolvedSkills.length > 0) {
 		const injection = buildSkillInjection(resolvedSkills);

--- a/async-execution.ts
+++ b/async-execution.ts
@@ -150,7 +150,8 @@ export function executeAsyncChain(
 		const stepOverrides: StepOverrides = { skills: stepSkillInput };
 		const behavior = resolveStepBehavior(a, stepOverrides, chainSkills);
 		const skillNames = behavior.skills === false ? [] : behavior.skills;
-		const { resolved: resolvedSkills } = resolveSkills(skillNames, ctx.cwd);
+		const skillCwd = s.cwd ?? cwd ?? ctx.cwd;
+		const { resolved: resolvedSkills } = resolveSkills(skillNames, skillCwd);
 
 		let systemPrompt = a.systemPrompt?.trim() || null;
 		if (resolvedSkills.length > 0) {
@@ -260,7 +261,8 @@ export function executeAsyncSingle(
 ): AsyncExecutionResult {
 	const { agent, task, agentConfig, ctx, cwd, maxOutput, artifactsDir, artifactConfig, shareEnabled, sessionRoot } = params;
 	const skillNames = params.skills ?? agentConfig.skills ?? [];
-	const { resolved: resolvedSkills } = resolveSkills(skillNames, ctx.cwd);
+	const skillCwd = cwd ?? ctx.cwd;
+	const { resolved: resolvedSkills } = resolveSkills(skillNames, skillCwd);
 	let systemPrompt = agentConfig.systemPrompt?.trim() || null;
 	if (resolvedSkills.length > 0) {
 		const injection = buildSkillInjection(resolvedSkills);

--- a/execution.ts
+++ b/execution.ts
@@ -31,7 +31,7 @@ import {
 	extractToolArgsPreview,
 	extractTextFromContent,
 } from "./utils.js";
-import { buildSkillInjection, resolveSkills } from "./skills.js";
+import { buildSkillInjection, resolveSkillsWithFallback } from "./skills.js";
 import { getPiSpawnCommand } from "./pi-spawn.js";
 import { createJsonlWriter } from "./jsonl-writer.js";
 
@@ -112,7 +112,11 @@ export async function runSync(
 
 	const skillNames = options.skills ?? agent.skills ?? [];
 	const skillCwd = cwd ?? runtimeCwd;
-	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkills(skillNames, skillCwd);
+	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
+		skillNames,
+		skillCwd,
+		runtimeCwd,
+	);
 
 	let systemPrompt = agent.systemPrompt?.trim() || "";
 	if (resolvedSkills.length > 0) {

--- a/execution.ts
+++ b/execution.ts
@@ -111,7 +111,8 @@ export async function runSync(
 	}
 
 	const skillNames = options.skills ?? agent.skills ?? [];
-	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkills(skillNames, runtimeCwd);
+	const skillCwd = cwd ?? runtimeCwd;
+	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkills(skillNames, skillCwd);
 
 	let systemPrompt = agent.systemPrompt?.trim() || "";
 	if (resolvedSkills.length > 0) {

--- a/skills.ts
+++ b/skills.ts
@@ -303,8 +303,8 @@ function inferSkillSource(rawSource: unknown, filePath: string, cwd: string): Sk
 	if (source === "extension") return "extension";
 	if (source === "builtin") return "builtin";
 
-	if (isProjectPackageScoped) return "project-package";
 	if (isProjectScoped) return "project";
+	if (isProjectPackageScoped) return "project-package";
 	if (isUserScoped) return "user";
 	if (isGlobalPackage) return "user-package";
 	return "unknown";

--- a/skills.ts
+++ b/skills.ts
@@ -96,10 +96,6 @@ function extractSkillPathsFromPackageRoot(packageRoot: string): string[] {
 		.map((s: string) => path.resolve(packageRoot, s));
 }
 
-function getPackageSkillPaths(packageRoot: string): string[] {
-	return extractSkillPathsFromPackageRoot(packageRoot);
-}
-
 let cachedGlobalNpmRoot: string | null = null;
 
 function getGlobalNpmRoot(): string | null {
@@ -146,7 +142,7 @@ function collectPackageSourcesFromSettings(settingsPath: string, baseDir: string
 	const entries = (settings as { packages?: unknown }).packages;
 	if (!Array.isArray(entries)) return [];
 
-	const packageRoots: string[] = [];
+	const skillPaths: string[] = [];
 	for (const entry of entries) {
 		const source =
 			typeof entry === "string"
@@ -157,14 +153,8 @@ function collectPackageSourcesFromSettings(settingsPath: string, baseDir: string
 		if (!source) continue;
 
 		const packageRoot = resolveSettingsPackageRoot(source, baseDir);
-		if (packageRoot) {
-			packageRoots.push(packageRoot);
-		}
-	}
-
-	const skillPaths: string[] = [];
-	for (const packageRoot of packageRoots) {
-		skillPaths.push(...getPackageSkillPaths(packageRoot));
+		if (!packageRoot) continue;
+		skillPaths.push(...extractSkillPathsFromPackageRoot(packageRoot));
 	}
 	return skillPaths;
 }
@@ -208,13 +198,13 @@ function collectPackageSkillPaths(cwd: string): string[] {
 					if (scopeEntry.name.startsWith(".")) continue;
 					if (!scopeEntry.isDirectory() && !scopeEntry.isSymbolicLink()) continue;
 					const pkgRoot = path.join(scopeDir, scopeEntry.name);
-					results.push(...getPackageSkillPaths(pkgRoot));
+					results.push(...extractSkillPathsFromPackageRoot(pkgRoot));
 				}
 				continue;
 			}
 
 			const pkgRoot = path.join(dir, entry.name);
-			results.push(...getPackageSkillPaths(pkgRoot));
+			results.push(...extractSkillPathsFromPackageRoot(pkgRoot));
 		}
 	}
 
@@ -229,22 +219,21 @@ function collectSettingsSkillPaths(cwd: string): string[] {
 	];
 
 	for (const { file, base } of settingsFiles) {
-		try {
-			const content = fs.readFileSync(file, "utf-8");
-			const settings = JSON.parse(content);
-			const skills = settings?.skills;
-			if (!Array.isArray(skills)) continue;
-			for (const entry of skills) {
-				if (typeof entry !== "string") continue;
-				let resolved = entry;
-				if (resolved.startsWith("~/")) {
-					resolved = path.join(os.homedir(), resolved.slice(2));
-				} else if (!path.isAbsolute(resolved)) {
-					resolved = path.resolve(base, resolved);
-				}
-				results.push(resolved);
+		const settings = readJsonFile(file);
+		if (!settings || typeof settings !== "object" || settings === null) continue;
+		const skills = (settings as { skills?: unknown }).skills;
+		if (!Array.isArray(skills)) continue;
+
+		for (const entry of skills) {
+			if (typeof entry !== "string") continue;
+			let resolved = entry;
+			if (resolved.startsWith("~/")) {
+				resolved = path.join(os.homedir(), resolved.slice(2));
+			} else if (!path.isAbsolute(resolved)) {
+				resolved = path.resolve(base, resolved);
 			}
-		} catch {}
+			results.push(resolved);
+		}
 	}
 
 	return results;
@@ -257,10 +246,6 @@ function collectSettingsPackageSkillPaths(cwd: string): string[] {
 	];
 }
 
-function collectCurrentPackageSkillPaths(cwd: string): string[] {
-	return extractSkillPathsFromPackageRoot(cwd);
-}
-
 function buildSkillPaths(cwd: string): string[] {
 	const defaultSkillPaths = [
 		path.join(cwd, CONFIG_DIR, "skills"),
@@ -268,13 +253,12 @@ function buildSkillPaths(cwd: string): string[] {
 	];
 	const packagePaths = collectPackageSkillPaths(cwd);
 	const settingsPackagePaths = collectSettingsPackageSkillPaths(cwd);
-	const cwdPackagePaths = collectCurrentPackageSkillPaths(cwd);
 	const settingsPaths = collectSettingsSkillPaths(cwd);
 	return [...new Set([
 		...defaultSkillPaths,
 		...packagePaths,
 		...settingsPackagePaths,
-		...cwdPackagePaths,
+		...extractSkillPathsFromPackageRoot(cwd),
 		...settingsPaths,
 	])];
 }

--- a/skills.ts
+++ b/skills.ts
@@ -282,31 +282,33 @@ function buildSkillPaths(cwd: string): string[] {
 function inferSkillSource(rawSource: unknown, filePath: string, cwd: string): SkillSource {
 	const source = typeof rawSource === "string" ? rawSource : "";
 	const projectRoot = path.resolve(cwd, CONFIG_DIR);
+	const isUserScoped = isWithinPath(filePath, AGENT_DIR);
 	const isProjectScoped = isWithinPath(filePath, projectRoot);
 	const isProjectPackageScoped = isWithinPath(filePath, path.resolve(cwd));
-	const isUserScoped = isWithinPath(filePath, AGENT_DIR);
 	const globalRoot = getGlobalNpmRoot();
 	const isGlobalPackage = globalRoot ? isWithinPath(filePath, globalRoot) : false;
 
-	if (source === "project") return "project";
+	if (source === "project") {
+		return isUserScoped ? "user" : "project";
+	}
 	if (source === "user") return "user";
 	if (source === "settings") {
-		if (isProjectScoped) return "project-settings";
 		if (isUserScoped) return "user-settings";
+		if (isProjectScoped) return "project-settings";
 		return "unknown";
 	}
 	if (source === "package") {
-		if (isProjectPackageScoped) return "project-package";
 		if (isUserScoped || isGlobalPackage) return "user-package";
+		if (isProjectPackageScoped) return "project-package";
 		return "unknown";
 	}
 	if (source === "extension") return "extension";
 	if (source === "builtin") return "builtin";
 
-	if (isProjectScoped) return "project";
-	if (isProjectPackageScoped) return "project-package";
 	if (isUserScoped) return "user";
+	if (isProjectScoped) return "project";
 	if (isGlobalPackage) return "user-package";
+	if (isProjectPackageScoped) return "project-package";
 	return "unknown";
 }
 
@@ -416,6 +418,26 @@ export function resolveSkills(
 	}
 
 	return { resolved, missing };
+}
+
+export function resolveSkillsWithFallback(
+	skillNames: string[],
+	primaryCwd: string,
+	fallbackCwd?: string,
+): { resolved: ResolvedSkill[]; missing: string[] } {
+	const primary = resolveSkills(skillNames, primaryCwd);
+	if (!fallbackCwd || primary.missing.length === 0) {
+		return primary;
+	}
+	if (path.resolve(primaryCwd) === path.resolve(fallbackCwd)) {
+		return primary;
+	}
+
+	const fallback = resolveSkills(primary.missing, fallbackCwd);
+	return {
+		resolved: [...primary.resolved, ...fallback.resolved],
+		missing: fallback.missing,
+	};
 }
 
 export function buildSkillInjection(skills: ResolvedSkill[]): string {

--- a/skills.ts
+++ b/skills.ts
@@ -75,19 +75,29 @@ function isWithinPath(filePath: string, dir: string): boolean {
 	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
-function getPackageSkillPaths(packageRoot: string): string[] {
-	const pkgJsonPath = path.join(packageRoot, "package.json");
+function readJsonFile(filePath: string): unknown {
 	try {
-		const content = fs.readFileSync(pkgJsonPath, "utf-8");
-		const pkg = JSON.parse(content);
-		const piSkills = pkg?.pi?.skills;
-		if (!Array.isArray(piSkills)) return [];
-		return piSkills
-			.filter((s: unknown) => typeof s === "string")
-			.map((s: string) => path.resolve(packageRoot, s));
+		const content = fs.readFileSync(filePath, "utf-8");
+		return JSON.parse(content);
 	} catch {
-		return [];
+		return null;
 	}
+}
+
+function extractSkillPathsFromPackageRoot(packageRoot: string): string[] {
+	const pkgJsonPath = path.join(packageRoot, "package.json");
+	const pkg = readJsonFile(pkgJsonPath);
+	if (!pkg || typeof pkg !== "object" || pkg === null) return [];
+	const pi = (pkg as { pi?: unknown }).pi;
+	const piSkills = (pi && typeof pi === "object" && !Array.isArray(pi)) ? (pi as { skills?: unknown }).skills : undefined;
+	if (!Array.isArray(piSkills)) return [];
+	return piSkills
+		.filter((s: unknown) => typeof s === "string")
+		.map((s: string) => path.resolve(packageRoot, s));
+}
+
+function getPackageSkillPaths(packageRoot: string): string[] {
+	return extractSkillPathsFromPackageRoot(packageRoot);
 }
 
 let cachedGlobalNpmRoot: string | null = null;
@@ -103,18 +113,74 @@ function getGlobalNpmRoot(): string | null {
 	}
 }
 
+function isLocalPathCandidate(source: string): boolean {
+	if (!source) return false;
+	if (source === "~" || source.startsWith("~/")) return true;
+	if (source.startsWith("./") || source.startsWith("../") || source === "." || source === "..") return true;
+	if (path.isAbsolute(source)) return true;
+	if (/^[A-Za-z]:[\\/]/.test(source) || source.startsWith("\\\\")) return true;
+	if (/[A-Za-z]:[\\/]/i.test(source)) return true;
+	if (/^[A-Za-z]+:/.test(source)) return false;
+	return true;
+}
+
+function resolveSettingsPackageRoot(source: string, baseDir: string): string | undefined {
+	const trimmed = source.trim();
+	if (!trimmed) return undefined;
+	if (trimmed.startsWith("npm:")) return undefined;
+	if (trimmed.startsWith("git:") || /^(https?|ssh|git):\/\//i.test(trimmed)) return undefined;
+
+	const normalized = trimmed.startsWith("file:")
+		? trimmed.slice(5)
+		: trimmed;
+	if (!isLocalPathCandidate(normalized)) return undefined;
+	if (normalized === "~") return os.homedir();
+	if (normalized.startsWith("~")) return path.join(os.homedir(), normalized.slice(1));
+	if (path.isAbsolute(normalized)) return normalized;
+	return path.resolve(baseDir, normalized);
+}
+
+function collectPackageSourcesFromSettings(settingsPath: string, baseDir: string): string[] {
+	const settings = readJsonFile(settingsPath);
+	if (!settings || typeof settings !== "object" || settings === null) return [];
+	const entries = (settings as { packages?: unknown }).packages;
+	if (!Array.isArray(entries)) return [];
+
+	const packageRoots: string[] = [];
+	for (const entry of entries) {
+		const source =
+			typeof entry === "string"
+				? entry
+				: typeof entry === "object" && entry !== null && typeof (entry as { source?: unknown }).source === "string"
+					? (entry as { source: string }).source
+					: undefined;
+		if (!source) continue;
+
+		const packageRoot = resolveSettingsPackageRoot(source, baseDir);
+		if (packageRoot) {
+			packageRoots.push(packageRoot);
+		}
+	}
+
+	const skillPaths: string[] = [];
+	for (const packageRoot of packageRoots) {
+		skillPaths.push(...getPackageSkillPaths(packageRoot));
+	}
+	return skillPaths;
+}
+
 function collectPackageSkillPaths(cwd: string): string[] {
 	const dirs = [
 		path.join(cwd, CONFIG_DIR, "npm", "node_modules"),
 		path.join(AGENT_DIR, "npm", "node_modules"),
 	];
-	
+
 	// Add global npm root if available (where pi installs global packages)
 	const globalRoot = getGlobalNpmRoot();
 	if (globalRoot) {
 		dirs.push(globalRoot);
 	}
-	
+
 	const results: string[] = [];
 
 	for (const dir of dirs) {
@@ -184,20 +250,40 @@ function collectSettingsSkillPaths(cwd: string): string[] {
 	return results;
 }
 
+function collectSettingsPackageSkillPaths(cwd: string): string[] {
+	return [
+		...collectPackageSourcesFromSettings(path.join(cwd, CONFIG_DIR, "settings.json"), path.join(cwd, CONFIG_DIR)),
+		...collectPackageSourcesFromSettings(path.join(AGENT_DIR, "settings.json"), AGENT_DIR),
+	];
+}
+
+function collectCurrentPackageSkillPaths(cwd: string): string[] {
+	return extractSkillPathsFromPackageRoot(cwd);
+}
+
 function buildSkillPaths(cwd: string): string[] {
 	const defaultSkillPaths = [
 		path.join(cwd, CONFIG_DIR, "skills"),
 		path.join(AGENT_DIR, "skills"),
 	];
 	const packagePaths = collectPackageSkillPaths(cwd);
+	const settingsPackagePaths = collectSettingsPackageSkillPaths(cwd);
+	const cwdPackagePaths = collectCurrentPackageSkillPaths(cwd);
 	const settingsPaths = collectSettingsSkillPaths(cwd);
-	return [...new Set([...defaultSkillPaths, ...packagePaths, ...settingsPaths])];
+	return [...new Set([
+		...defaultSkillPaths,
+		...packagePaths,
+		...settingsPackagePaths,
+		...cwdPackagePaths,
+		...settingsPaths,
+	])];
 }
 
 function inferSkillSource(rawSource: unknown, filePath: string, cwd: string): SkillSource {
 	const source = typeof rawSource === "string" ? rawSource : "";
 	const projectRoot = path.resolve(cwd, CONFIG_DIR);
 	const isProjectScoped = isWithinPath(filePath, projectRoot);
+	const isProjectPackageScoped = isWithinPath(filePath, path.resolve(cwd));
 	const isUserScoped = isWithinPath(filePath, AGENT_DIR);
 	const globalRoot = getGlobalNpmRoot();
 	const isGlobalPackage = globalRoot ? isWithinPath(filePath, globalRoot) : false;
@@ -210,13 +296,14 @@ function inferSkillSource(rawSource: unknown, filePath: string, cwd: string): Sk
 		return "unknown";
 	}
 	if (source === "package") {
-		if (isProjectScoped) return "project-package";
+		if (isProjectPackageScoped) return "project-package";
 		if (isUserScoped || isGlobalPackage) return "user-package";
 		return "unknown";
 	}
 	if (source === "extension") return "extension";
 	if (source === "builtin") return "builtin";
 
+	if (isProjectPackageScoped) return "project-package";
 	if (isProjectScoped) return "project";
 	if (isUserScoped) return "user";
 	if (isGlobalPackage) return "user-package";

--- a/test/single-execution.test.ts
+++ b/test/single-execution.test.ts
@@ -24,10 +24,60 @@ import {
 	tryImport,
 } from "./helpers.ts";
 
+function writeSkillPackage(pkgDir: string, skillName: string): string {
+	const skillDir = path.join(pkgDir, "skills", skillName);
+	fs.mkdirSync(skillDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(pkgDir, "package.json"),
+		JSON.stringify(
+			{
+				name: `pkg-${skillName}`,
+				version: "1.0.0",
+				pi: { skills: [`./skills/${skillName}`] },
+			},
+			null,
+			2,
+		),
+		"utf-8",
+	);
+	fs.writeFileSync(
+		path.join(skillDir, "SKILL.md"),
+		`---
+name: ${skillName}
+description: cwd override skill\n
+---
+Loaded for cwd override test\n`,
+		"utf-8",
+	);
+	return path.join(skillDir, "SKILL.md");
+}
 // Top-level await: try importing pi-dependent modules
 const execution = await tryImport<any>("./execution.ts");
 const utils = await tryImport<any>("./utils.ts");
 const available = !!(execution && utils);
+
+function writePackageSkillAtRoot(packageRoot: string, skillName: string): void {
+	const skillDir = path.join(packageRoot, "skills", skillName);
+	fs.mkdirSync(skillDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(packageRoot, "package.json"),
+		JSON.stringify(
+			{
+				name: `${skillName}-pkg`,
+				version: "1.0.0",
+				pi: {
+					skills: [`./skills/${skillName}`],
+				},
+			},
+			null,
+			2,
+		),
+	);
+	fs.writeFileSync(
+		path.join(skillDir, "SKILL.md"),
+		`---\nname: ${skillName}\ndescription: cwd-scoped test skill\n---\n`,
+	);
+}
 
 const runSync = execution?.runSync;
 const getFinalOutput = utils?.getFinalOutput;
@@ -175,6 +225,27 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.progress.toolCount, 1, "should count tool calls");
 	});
 
+	it("resolves skills from execution-cwd override", async () => {
+		const taskDir = createTempDir("pi-subagent-task-cwd-");
+		const runCwd = createTempDir("pi-subagent-run-cwd-");
+		mockPi.onCall({ output: "Done" });
+		writeSkillPackage(taskDir, "cwd-override-skill");
+
+		const agents = [makeAgent("echo", { skills: ["cwd-override-skill"] })];
+		const result = await runSync(runCwd, agents, "echo", "Task", {
+			cwd: taskDir,
+		});
+
+		try {
+			assert.equal(result.exitCode, 0);
+			assert.deepEqual(result.skills, ["cwd-override-skill"]);
+			assert.equal(result.skillsWarning, undefined);
+		} finally {
+			removeTempDir(taskDir);
+			removeTempDir(runCwd);
+		}
+	});
+
 	it("writes artifacts when configured", async () => {
 		mockPi.onCall({ output: "Result text" });
 		const agents = makeAgentConfigs(["echo"]);
@@ -208,6 +279,24 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		// proving the abort signal terminated the process early.
 		assert.ok(elapsed < 5000, `should abort early, took ${elapsed}ms`);
 		// Exit code is platform-dependent (Windows: often 1 or 0, Linux: null/143)
+	});
+
+	it("resolves skills from effective task cwd package", async () => {
+		const taskCwd = createTempDir("pi-subagent-task-cwd-");
+		const taskSkill = `task-cwd-skill-${Date.now()}`;
+		writePackageSkillAtRoot(taskCwd, taskSkill);
+		mockPi.onCall({ output: "Done" });
+		const agents = [makeAgent("echo", { skills: [taskSkill] })];
+
+		const result = await runSync(tempDir, agents, "echo", "Use task cwd skill", {
+			cwd: taskCwd,
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.skills?.[0], taskSkill);
+		assert.equal(result.skillsWarning, undefined);
+
+		removeTempDir(taskCwd);
 	});
 
 	it("handles stderr without exit code as info (not error)", async () => {

--- a/test/single-execution.test.ts
+++ b/test/single-execution.test.ts
@@ -24,7 +24,7 @@ import {
 	tryImport,
 } from "./helpers.ts";
 
-function writeSkillPackage(pkgDir: string, skillName: string): string {
+function writeSkillPackage(pkgDir: string, skillName: string): void {
 	const skillDir = path.join(pkgDir, "skills", skillName);
 	fs.mkdirSync(skillDir, { recursive: true });
 	fs.writeFileSync(
@@ -49,7 +49,6 @@ description: cwd override skill\n
 Loaded for cwd override test\n`,
 		"utf-8",
 	);
-	return path.join(skillDir, "SKILL.md");
 }
 // Top-level await: try importing pi-dependent modules
 const execution = await tryImport<any>("./execution.ts");
@@ -244,6 +243,23 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			removeTempDir(taskDir);
 			removeTempDir(runCwd);
 		}
+	});
+
+	it("falls back to runtime cwd skills when execution cwd lacks them", async () => {
+		const taskCwd = path.join(tempDir, "nested");
+		const fallbackSkill = `runtime-fallback-skill-${Date.now()}`;
+		fs.mkdirSync(taskCwd, { recursive: true });
+		writePackageSkillAtRoot(tempDir, fallbackSkill);
+		mockPi.onCall({ output: "Done" });
+		const agents = [makeAgent("echo", { skills: [fallbackSkill] })];
+
+		const result = await runSync(tempDir, agents, "echo", "Task", {
+			cwd: taskCwd,
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.skills?.[0], fallbackSkill);
+		assert.equal(result.skillsWarning, undefined);
 	});
 
 	it("writes artifacts when configured", async () => {

--- a/test/single-execution.test.ts
+++ b/test/single-execution.test.ts
@@ -24,11 +24,16 @@ import {
 	tryImport,
 } from "./helpers.ts";
 
-function writeSkillPackage(pkgDir: string, skillName: string): void {
-	const skillDir = path.join(pkgDir, "skills", skillName);
+function writePackageSkill(
+	packageRoot: string,
+	skillName: string,
+	description = "cwd-scoped test skill",
+	body = "",
+): void {
+	const skillDir = path.join(packageRoot, "skills", skillName);
 	fs.mkdirSync(skillDir, { recursive: true });
 	fs.writeFileSync(
-		path.join(pkgDir, "package.json"),
+		path.join(packageRoot, "package.json"),
 		JSON.stringify(
 			{
 				name: `pkg-${skillName}`,
@@ -42,41 +47,15 @@ function writeSkillPackage(pkgDir: string, skillName: string): void {
 	);
 	fs.writeFileSync(
 		path.join(skillDir, "SKILL.md"),
-		`---
-name: ${skillName}
-description: cwd override skill\n
----
-Loaded for cwd override test\n`,
+		`---\nname: ${skillName}\ndescription: ${description}\n---\n${body}`,
 		"utf-8",
 	);
 }
+
 // Top-level await: try importing pi-dependent modules
 const execution = await tryImport<any>("./execution.ts");
 const utils = await tryImport<any>("./utils.ts");
 const available = !!(execution && utils);
-
-function writePackageSkillAtRoot(packageRoot: string, skillName: string): void {
-	const skillDir = path.join(packageRoot, "skills", skillName);
-	fs.mkdirSync(skillDir, { recursive: true });
-	fs.writeFileSync(
-		path.join(packageRoot, "package.json"),
-		JSON.stringify(
-			{
-				name: `${skillName}-pkg`,
-				version: "1.0.0",
-				pi: {
-					skills: [`./skills/${skillName}`],
-				},
-			},
-			null,
-			2,
-		),
-	);
-	fs.writeFileSync(
-		path.join(skillDir, "SKILL.md"),
-		`---\nname: ${skillName}\ndescription: cwd-scoped test skill\n---\n`,
-	);
-}
 
 const runSync = execution?.runSync;
 const getFinalOutput = utils?.getFinalOutput;
@@ -228,7 +207,12 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const taskDir = createTempDir("pi-subagent-task-cwd-");
 		const runCwd = createTempDir("pi-subagent-run-cwd-");
 		mockPi.onCall({ output: "Done" });
-		writeSkillPackage(taskDir, "cwd-override-skill");
+		writePackageSkill(
+			taskDir,
+			"cwd-override-skill",
+			"cwd override skill",
+			"Loaded for cwd override test\n",
+		);
 
 		const agents = [makeAgent("echo", { skills: ["cwd-override-skill"] })];
 		const result = await runSync(runCwd, agents, "echo", "Task", {
@@ -249,7 +233,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const taskCwd = path.join(tempDir, "nested");
 		const fallbackSkill = `runtime-fallback-skill-${Date.now()}`;
 		fs.mkdirSync(taskCwd, { recursive: true });
-		writePackageSkillAtRoot(tempDir, fallbackSkill);
+		writePackageSkill(tempDir, fallbackSkill);
 		mockPi.onCall({ output: "Done" });
 		const agents = [makeAgent("echo", { skills: [fallbackSkill] })];
 
@@ -300,7 +284,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 	it("resolves skills from effective task cwd package", async () => {
 		const taskCwd = createTempDir("pi-subagent-task-cwd-");
 		const taskSkill = `task-cwd-skill-${Date.now()}`;
-		writePackageSkillAtRoot(taskCwd, taskSkill);
+		writePackageSkill(taskCwd, taskSkill);
 		mockPi.onCall({ output: "Done" });
 		const agents = [makeAgent("echo", { skills: [taskSkill] })];
 

--- a/test/skill-resolution.test.ts
+++ b/test/skill-resolution.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Focused tests for skill discovery sources.
+ *
+ * - settings.packages entries (project) are expanded and read via package.json
+ * - task-level cwd resolves local package skills from cwd/package.json
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { MockPi } from "./helpers.ts";
+import {
+	createMockPi,
+	createTempDir,
+	makeAgent,
+	removeTempDir,
+	tryImport,
+} from "./helpers.ts";
+
+const skillsMod = await tryImport<any>("./skills.ts");
+const executionMod = await tryImport<any>("./execution.ts");
+const available = !!(skillsMod && executionMod);
+
+const { resolveSkills, clearSkillCache } = skillsMod ?? {};
+const runSync = executionMod?.runSync;
+
+function makePkgWithSkill(packageRoot: string, skillName: string) {
+	const packageJsonPath = path.join(packageRoot, "package.json");
+	const skillDir = path.join(packageRoot, "skills", skillName);
+	const skillPath = path.join(skillDir, "SKILL.md");
+
+	fs.mkdirSync(skillDir, { recursive: true });
+	fs.writeFileSync(
+		packageJsonPath,
+		JSON.stringify({ name: `${skillName}-pkg`, pi: { skills: ["skills"] }, version: "1.0.0" }),
+		"utf-8",
+	);
+	fs.writeFileSync(
+		skillPath,
+		`---\nname: ${skillName}\ndescription: Test skill ${skillName}\n---\nContent\n`,
+		"utf-8",
+	);
+}
+
+if (available) {
+	describe("resolveSkills with settings.packages", () => {
+		it("discovers skills from project settings packages", () => {
+			const cwd = createTempDir("subagent-skill-settings-");
+			const pkgRoot = path.join(cwd, ".pi", "packages", "local-skill-pkg");
+			makePkgWithSkill(pkgRoot, "settings-package-skill");
+
+			const settingsDir = path.join(cwd, ".pi");
+			fs.mkdirSync(settingsDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(settingsDir, "settings.json"),
+				JSON.stringify({
+					packages: [
+						{
+							source: "./packages/local-skill-pkg",
+						},
+					],
+				}, null, 2),
+				"utf-8",
+			);
+
+			clearSkillCache?.();
+			try {
+				const result = resolveSkills(["settings-package-skill"], cwd);
+
+				assert.equal(result.missing.length, 0, "should not miss settings package skill");
+				assert.equal(result.resolved.length, 1, "should resolve one skill");
+				assert.equal(result.resolved[0]!.name, "settings-package-skill");
+				assert.ok(result.resolved[0]!.path.includes("skills"));
+			} finally {
+				removeTempDir(cwd);
+			}
+		});
+	});
+
+	describe("resolveSkills with execution cwd override", () => {
+		it("uses effective step cwd for skill lookup in runSync", async () => {
+			const mockPi: MockPi = createMockPi();
+			mockPi.install();
+			mockPi.onCall({ output: "ok" });
+			let runtimeCwd: string | undefined;
+			try {
+				runtimeCwd = createTempDir("subagent-runtime-");
+				const taskCwd = path.join(runtimeCwd, "step");
+				fs.mkdirSync(taskCwd, { recursive: true });
+				makePkgWithSkill(taskCwd, "runtime-package-skill");
+
+				const agents = [makeAgent("worker", { skills: ["runtime-package-skill"] })];
+				const result = await runSync(runtimeCwd, agents, "worker", "Run", {
+					cwd: taskCwd,
+				});
+
+				assert.equal(result.exitCode, 0);
+				assert.ok(result.skills?.includes("runtime-package-skill"));
+			} finally {
+				mockPi.uninstall();
+				clearSkillCache?.();
+				if (runtimeCwd) removeTempDir(runtimeCwd);
+			}
+		});
+	});
+}

--- a/test/skills-discovery.test.ts
+++ b/test/skills-discovery.test.ts
@@ -109,5 +109,47 @@ describe(
 				removeTempDir(tempDir);
 			}
 		});
+
+		it("keeps user scope when cwd includes the user agent dir", async () => {
+			const tempDir = createTempDir("skill-discovery-home-overlap-");
+			const fakeHome = path.join(tempDir, "fake-home");
+			const userAgentDir = path.join(fakeHome, ".pi", "agent");
+			const userSettingsPath = path.join(userAgentDir, "settings.json");
+			const userSkill = "user-home-overlap-skill";
+			const customSkillDir = path.join(userAgentDir, "custom", userSkill);
+			const previousHome = process.env.HOME;
+			const previousUserProfile = process.env.USERPROFILE;
+
+			try {
+				process.env.HOME = fakeHome;
+				process.env.USERPROFILE = fakeHome;
+
+				fs.mkdirSync(customSkillDir, { recursive: true });
+				fs.writeFileSync(
+					path.join(customSkillDir, "SKILL.md"),
+					`---\nname: ${userSkill}\ndescription: overlap test skill\n---\nbody\n`,
+					"utf-8",
+				);
+				fs.mkdirSync(path.dirname(userSettingsPath), { recursive: true });
+				fs.writeFileSync(
+					userSettingsPath,
+					JSON.stringify({ skills: ["./custom"] }, null, 2),
+					"utf-8",
+				);
+
+				const fresh = await importSkillsFresh();
+				fresh.clearSkillCache?.();
+				const discovered = fresh.discoverAvailableSkills(fakeHome);
+				const overlapSkill = discovered.find((s: any) => s.name === userSkill);
+				assert.ok(overlapSkill, "should include overlap user skill");
+				assert.equal(overlapSkill.source, "user");
+			} finally {
+				if (previousHome === undefined) delete process.env.HOME;
+				else process.env.HOME = previousHome;
+				if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+				else process.env.USERPROFILE = previousUserProfile;
+				removeTempDir(tempDir);
+			}
+		});
 	},
 );

--- a/test/skills-discovery.test.ts
+++ b/test/skills-discovery.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for skill discovery inputs from settings and package paths.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	createTempDir,
+	removeTempDir,
+	tryImport,
+} from "./helpers.ts";
+
+const skills = await tryImport<any>("./skills.ts");
+const available = !!skills;
+
+const discoverAvailableSkills = skills?.discoverAvailableSkills;
+const clearSkillCache = skills?.clearSkillCache;
+
+function writeSkillPackage(packageRoot: string, skillName: string): void {
+	const skillDir = path.join(packageRoot, "skills", skillName);
+	fs.mkdirSync(skillDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(packageRoot, "package.json"),
+		JSON.stringify(
+			{
+				name: `${skillName}-pkg`,
+				version: "1.0.0",
+				pi: {
+					skills: ["skills"],
+				},
+			},
+			null,
+			2,
+		),
+		"utf-8",
+	);
+	fs.writeFileSync(path.join(skillDir, "SKILL.md"), `---\nname: ${skillName}\ndescription: test skill\n---\n`, "utf-8");
+}
+
+describe(
+	"discoverAvailableSkills",
+	{ skip: !available ? "pi packages not available" : undefined },
+	() => {
+		it("loads local package skills from project and user settings", () => {
+			const tempDir = createTempDir("skill-discovery-project-");
+			const projectRoot = path.join(tempDir, "project");
+			const projectPackageRoot = path.join(projectRoot, ".pi", "project-pkg");
+			const projectSettingsPath = path.join(projectRoot, ".pi", "settings.json");
+
+			const userAgentDir = path.join(os.homedir(), ".pi", "agent");
+			const userPackageRoot = path.join(userAgentDir, "user-pkg");
+			const userSettingsPath = path.join(userAgentDir, "settings.json");
+
+			const projectSkill = "proj-settings-skill";
+			const userSkill = "user-settings-skill";
+			const originalUserSettings = fs.existsSync(userSettingsPath)
+				? fs.readFileSync(userSettingsPath, "utf-8")
+				: undefined;
+
+			try {
+				writeSkillPackage(projectPackageRoot, projectSkill);
+				fs.mkdirSync(path.dirname(projectSettingsPath), { recursive: true });
+				fs.writeFileSync(
+					projectSettingsPath,
+					JSON.stringify(
+						{
+							packages: ["./project-pkg"],
+						},
+						null,
+						2,
+					),
+					"utf-8",
+				);
+
+				writeSkillPackage(userPackageRoot, userSkill);
+				fs.mkdirSync(path.dirname(userSettingsPath), { recursive: true });
+				fs.writeFileSync(
+					userSettingsPath,
+					JSON.stringify({ packages: [{ source: "./user-pkg" }] }, null, 2),
+					"utf-8",
+				);
+
+				clearSkillCache?.();
+				const discovered = discoverAvailableSkills(projectRoot).map((s: any) => s.name);
+				assert.ok(
+					discovered.includes(projectSkill),
+					"should include project package skill",
+				);
+				assert.ok(
+					discovered.includes(userSkill),
+					"should include user package skill",
+				);
+			} finally {
+				if (originalUserSettings === undefined) {
+					fs.rmSync(userSettingsPath, { force: true });
+				} else {
+					fs.writeFileSync(userSettingsPath, originalUserSettings, "utf-8");
+				}
+				fs.rmSync(userPackageRoot, { recursive: true, force: true });
+				removeTempDir(tempDir);
+				clearSkillCache?.();
+			}
+		});
+	},
+);

--- a/test/skills-discovery.test.ts
+++ b/test/skills-discovery.test.ts
@@ -5,8 +5,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
 	createTempDir,
 	removeTempDir,
@@ -16,8 +16,12 @@ import {
 const skills = await tryImport<any>("./skills.ts");
 const available = !!skills;
 
-const discoverAvailableSkills = skills?.discoverAvailableSkills;
-const clearSkillCache = skills?.clearSkillCache;
+async function importSkillsFresh(): Promise<any> {
+	const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+	const modulePath = path.resolve(projectRoot, "skills.ts");
+	const bust = `${Date.now()}-${Math.random()}`;
+	return await import(`${pathToFileURL(modulePath).href}?bust=${bust}`);
+}
 
 function writeSkillPackage(packageRoot: string, skillName: string): void {
 	const skillDir = path.join(packageRoot, "skills", skillName);
@@ -44,23 +48,26 @@ describe(
 	"discoverAvailableSkills",
 	{ skip: !available ? "pi packages not available" : undefined },
 	() => {
-		it("loads local package skills from project and user settings", () => {
+		it("loads local package skills from project and user settings", async () => {
 			const tempDir = createTempDir("skill-discovery-project-");
 			const projectRoot = path.join(tempDir, "project");
 			const projectPackageRoot = path.join(projectRoot, ".pi", "project-pkg");
 			const projectSettingsPath = path.join(projectRoot, ".pi", "settings.json");
 
-			const userAgentDir = path.join(os.homedir(), ".pi", "agent");
+			const fakeHome = path.join(tempDir, "fake-home");
+			const userAgentDir = path.join(fakeHome, ".pi", "agent");
 			const userPackageRoot = path.join(userAgentDir, "user-pkg");
 			const userSettingsPath = path.join(userAgentDir, "settings.json");
 
 			const projectSkill = "proj-settings-skill";
 			const userSkill = "user-settings-skill";
-			const originalUserSettings = fs.existsSync(userSettingsPath)
-				? fs.readFileSync(userSettingsPath, "utf-8")
-				: undefined;
+			const previousHome = process.env.HOME;
+			const previousUserProfile = process.env.USERPROFILE;
 
 			try {
+				process.env.HOME = fakeHome;
+				process.env.USERPROFILE = fakeHome;
+
 				writeSkillPackage(projectPackageRoot, projectSkill);
 				fs.mkdirSync(path.dirname(projectSettingsPath), { recursive: true });
 				fs.writeFileSync(
@@ -83,8 +90,9 @@ describe(
 					"utf-8",
 				);
 
-				clearSkillCache?.();
-				const discovered = discoverAvailableSkills(projectRoot).map((s: any) => s.name);
+				const fresh = await importSkillsFresh();
+				fresh.clearSkillCache?.();
+				const discovered = fresh.discoverAvailableSkills(projectRoot).map((s: any) => s.name);
 				assert.ok(
 					discovered.includes(projectSkill),
 					"should include project package skill",
@@ -94,14 +102,11 @@ describe(
 					"should include user package skill",
 				);
 			} finally {
-				if (originalUserSettings === undefined) {
-					fs.rmSync(userSettingsPath, { force: true });
-				} else {
-					fs.writeFileSync(userSettingsPath, originalUserSettings, "utf-8");
-				}
-				fs.rmSync(userPackageRoot, { recursive: true, force: true });
+				if (previousHome === undefined) delete process.env.HOME;
+				else process.env.HOME = previousHome;
+				if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+				else process.env.USERPROFILE = previousUserProfile;
 				removeTempDir(tempDir);
-				clearSkillCache?.();
 			}
 		});
 	},

--- a/test/skills-resolution.test.ts
+++ b/test/skills-resolution.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for skill discovery from local package declarations.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createTempDir, removeTempDir, tryImport } from "./helpers.ts";
+
+const skillsModule = await tryImport<any>("./skills.ts");
+const available = !!skillsModule;
+const resolveSkills = skillsModule?.resolveSkills;
+const clearSkillCache = skillsModule?.clearSkillCache;
+
+function writeSkillPackage(pkgDir: string, skillName: string): void {
+	const skillDir = path.join(pkgDir, "skills", skillName);
+	fs.mkdirSync(skillDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(pkgDir, "package.json"),
+		JSON.stringify(
+			{
+				name: `pkg-${skillName}`,
+				version: "1.0.0",
+				pi: { skills: [`./skills/${skillName}`] },
+			},
+			null,
+			2,
+		),
+		"utf-8",
+	);
+	fs.writeFileSync(
+		path.join(skillDir, "SKILL.md"),
+		`---
+name: ${skillName}
+description: Package skill for ${skillName}
+---
+Loaded from package\n`,
+		"utf-8",
+	);
+}
+
+function writeProjectSettings(dir: string, value: string): void {
+	const piDir = path.join(dir, ".pi");
+	fs.mkdirSync(piDir, { recursive: true });
+	fs.writeFileSync(path.join(piDir, "settings.json"), value, "utf-8");
+}
+
+describe("settings.packages local package discovery", { skip: !available ? "pi packages not available" : undefined }, () => {
+	it("discovers skills from settings.packages string form", () => {
+		const tempDir = createTempDir("pi-subagent-pkg-");
+		try {
+			const localPackage = path.join(tempDir, ".pi", "local-package");
+			writeSkillPackage(localPackage, "pkg-settings-string");
+			writeProjectSettings(
+				tempDir,
+				JSON.stringify({ packages: ["./local-package"] }),
+			);
+			clearSkillCache?.();
+
+			const result = resolveSkills(["pkg-settings-string"], tempDir);
+			assert.equal(result.missing.length, 0);
+			assert.equal(result.resolved.length, 1);
+			assert.equal(result.resolved[0]!.name, "pkg-settings-string");
+		} finally {
+			removeTempDir(tempDir);
+		}
+	});
+
+	it("discovers skills from settings.packages object form", () => {
+		const tempDir = createTempDir("pi-subagent-pkg-");
+		try {
+			const localPackage = path.join(tempDir, ".pi", "local-package-obj");
+			writeSkillPackage(localPackage, "pkg-settings-object");
+			writeProjectSettings(
+				tempDir,
+				JSON.stringify({ packages: [{ source: "./local-package-obj" }] }),
+			);
+			clearSkillCache?.();
+
+			const result = resolveSkills(["pkg-settings-object"], tempDir);
+			assert.equal(result.missing.length, 0);
+			assert.equal(result.resolved.length, 1);
+			assert.equal(result.resolved[0]!.name, "pkg-settings-object");
+		} finally {
+			removeTempDir(tempDir);
+		}
+	});
+
+	it("discovers skills from settings.packages file URI form", () => {
+		const tempDir = createTempDir("pi-subagent-pkg-");
+		try {
+			const localPackage = path.join(tempDir, ".pi", "local-package-file-uri");
+			writeSkillPackage(localPackage, "pkg-settings-file-uri");
+			writeProjectSettings(
+				tempDir,
+				JSON.stringify({ packages: ["file:./local-package-file-uri"] }),
+			);
+			clearSkillCache?.();
+
+			const result = resolveSkills(["pkg-settings-file-uri"], tempDir);
+			assert.equal(result.missing.length, 0);
+			assert.equal(result.resolved.length, 1);
+			assert.equal(result.resolved[0]!.name, "pkg-settings-file-uri");
+		} finally {
+			removeTempDir(tempDir);
+		}
+	});
+
+	it("discovers skills from cwd package.json pi.skills", () => {
+		const tempDir = createTempDir("pi-subagent-cwd-pkg-");
+		try {
+			writeSkillPackage(tempDir, "cwd-package-skill");
+			clearSkillCache?.();
+
+			const result = resolveSkills(["cwd-package-skill"], tempDir);
+			assert.equal(result.missing.length, 0);
+			assert.equal(result.resolved.length, 1);
+			assert.equal(result.resolved[0]!.name, "cwd-package-skill");
+		} finally {
+			removeTempDir(tempDir);
+		}
+	});
+
+	it("marks cwd package skills with project-package source", () => {
+		const tempDir = createTempDir("pi-subagent-cwd-pkg-src-");
+		const sourceSkill = `cwd-package-source-${Date.now()}`;
+		try {
+			writeSkillPackage(tempDir, sourceSkill);
+			clearSkillCache?.();
+
+			const result = resolveSkills([sourceSkill], tempDir);
+			assert.equal(result.missing.length, 0);
+			assert.equal(result.resolved.length, 1);
+			assert.equal(result.resolved[0]!.name, sourceSkill);
+			assert.equal(result.resolved[0]!.source, "project-package");
+		} finally {
+			removeTempDir(tempDir);
+		}
+	});
+});


### PR DESCRIPTION
Summary
- include skills declared by local package sources in project and user settings packages
- include cwd package.json pi.skills in discovery
- resolve skills from effective execution cwd (sync and async)
- add runtime cwd fallback for unresolved skills
- fix skill source inference precedence for user/project overlap
- simplify related helper code and test fixtures

Testing
- npm run -s test:integration
- npm run -s test:all

Closes #48