### PR TITLE
fix: include username in temp directory names to prevent collisions

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -261,8 +261,8 @@ export const DEFAULT_ARTIFACT_CONFIG: ArtifactConfig = {
 
 export const MAX_PARALLEL = 8;
 export const MAX_CONCURRENCY = 4;
-export const RESULTS_DIR = path.join(os.tmpdir(), "pi-async-subagent-results");
-export const ASYNC_DIR = path.join(os.tmpdir(), "pi-async-subagent-runs");
+export const RESULTS_DIR = path.join(os.tmpdir(), `pi-async-subagent-results-${os.userInfo().username}`);
+export const ASYNC_DIR = path.join(os.tmpdir(), `pi-async-subagent-runs-${os.userInfo().username}`);
 export const WIDGET_KEY = "subagent-async";
 export const SLASH_RESULT_TYPE = "subagent-slash-result";
 export const SLASH_SUBAGENT_REQUEST_EVENT = "subagent:slash:request";


### PR DESCRIPTION
Fixes #53

When `pi-subagents` is installed for multiple user accounts on the same machine, both users compete for the same `/tmp/pi-async-subagent-*` directories. The second user to start Pi gets an `EACCES` error because the directory was created by the first user.

Using `os.userInfo().username` makes the paths user-scoped:
- `/tmp/pi-async-subagent-results-<username>`
- `/tmp/pi-async-subagent-runs-<username>`