### PR TITLE
Configurable agent manager keybinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+- Project/user settings support for extension config under `.pi/settings.json` and `~/.pi/agent/settings.json` via the `"pi-subagents"` namespace, while preserving the legacy `~/.pi/agent/extensions/subagent/config.json` fallback.
+- Configurable Agents Manager "new agent" shortcut via `keybindings.agentManagerNew`.
+
+### Fixed
+- Agents Manager list view now responds to `Ctrl+N` by default, matching the README. `Alt+N` remains accepted as a backward-compatible fallback.
+
 ## [0.11.12] - 2026-03-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Press **Ctrl+Shift+A** or type `/agents` to open the Agents Manager overlay — 
 - `Enter` — view detail
 - Type any character — search/filter
 - `Tab` — toggle selection (agents only)
-- `Ctrl+N` — new agent from template
+- `Ctrl+N` — new agent from template (configurable via `keybindings.agentManagerNew`)
 - `Ctrl+K` — clone current item
 - `Ctrl+D` or `Del` — delete current item
 - `Ctrl+R` — run selected (1 agent: launch, 2+: sequential chain)
@@ -660,11 +660,25 @@ This aggregated output becomes `{previous}` for the next step.
 
 ## Extension Configuration
 
-`pi-subagents` reads optional JSON config from `~/.pi/agent/extensions/subagent/config.json`.
+`pi-subagents` reads optional JSON config from these locations, in precedence order:
+
+1. Project settings: `.pi/settings.json -> "pi-subagents"`
+2. User settings: `~/.pi/agent/settings.json -> "pi-subagents"`
+3. Legacy extension config: `~/.pi/agent/extensions/subagent/config.json`
 
 ### `defaultSessionDir`
 
-`defaultSessionDir` sets the fallback directory used for session logs. Eg:
+`defaultSessionDir` sets the fallback directory used for session logs. Example user settings:
+
+```json
+{
+  "pi-subagents": {
+    "defaultSessionDir": "~/.pi/agent/sessions/subagent/"
+  }
+}
+```
+
+The legacy extension config file still works too:
 
 ```json
 {
@@ -676,6 +690,22 @@ Session root resolution follows this precedence:
 1. `params.sessionDir` from the `subagent` tool call
 2. `config.defaultSessionDir`
 3. Derived from parent session (stored alongside parent session file)
+
+### `keybindings.agentManagerNew`
+
+Customize the Agents Manager "new agent" shortcut. Example user settings:
+
+```json
+{
+  "pi-subagents": {
+    "keybindings": {
+      "agentManagerNew": ["ctrl+shift+n"]
+    }
+  }
+}
+```
+
+Default bindings are `ctrl+n` with `alt+n` kept as a fallback for backward compatibility.
 
 Sessions are always enabled — every subagent run gets a session directory for tracking.
 

--- a/agent-manager-keybindings.ts
+++ b/agent-manager-keybindings.ts
@@ -1,0 +1,20 @@
+export interface ListKeybindings {
+	agentManagerNew: string[];
+}
+
+export const DEFAULT_LIST_KEYBINDINGS: ListKeybindings = {
+	agentManagerNew: ["ctrl+n", "alt+n"],
+};
+
+export function normalizeListKeybindings(keybindings?: Partial<ListKeybindings>): ListKeybindings {
+	return {
+		agentManagerNew:
+			keybindings?.agentManagerNew && keybindings.agentManagerNew.length > 0
+				? [...keybindings.agentManagerNew]
+				: [...DEFAULT_LIST_KEYBINDINGS.agentManagerNew],
+	};
+}
+
+export function getPrimaryAgentManagerNewKeyLabel(keybindings: ListKeybindings): string {
+	return keybindings.agentManagerNew[0] ?? DEFAULT_LIST_KEYBINDINGS.agentManagerNew[0]!;
+}

--- a/agent-manager-list.test.ts
+++ b/agent-manager-list.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	DEFAULT_LIST_KEYBINDINGS,
+	getPrimaryAgentManagerNewKeyLabel,
+	normalizeListKeybindings,
+} from "./agent-manager-keybindings.ts";
+
+describe("normalizeListKeybindings", () => {
+	it("uses ctrl+n with alt+n fallback by default", () => {
+		assert.deepEqual(normalizeListKeybindings(), DEFAULT_LIST_KEYBINDINGS);
+	});
+
+	it("preserves configured bindings", () => {
+		assert.deepEqual(normalizeListKeybindings({ agentManagerNew: ["ctrl+shift+n"] }), {
+			agentManagerNew: ["ctrl+shift+n"],
+		});
+	});
+
+	it("falls back when configured binding list is empty", () => {
+		assert.deepEqual(normalizeListKeybindings({ agentManagerNew: [] }), DEFAULT_LIST_KEYBINDINGS);
+	});
+});
+
+describe("getPrimaryAgentManagerNewKeyLabel", () => {
+	it("shows the first configured shortcut in the footer", () => {
+		assert.equal(getPrimaryAgentManagerNewKeyLabel({ agentManagerNew: ["ctrl+shift+n", "alt+n"] }), "ctrl+shift+n");
+	});
+});

--- a/agent-manager-list.ts
+++ b/agent-manager-list.ts
@@ -1,5 +1,7 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import type { AgentSource } from "./agents.js";
+import type { ListKeybindings } from "./agent-manager-keybindings.js";
+import { DEFAULT_LIST_KEYBINDINGS, getPrimaryAgentManagerNewKeyLabel } from "./agent-manager-keybindings.js";
 import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { pad, row, renderHeader, renderFooter, fuzzyFilter, formatScrollInfo } from "./render-helpers.js";
 
@@ -55,7 +57,19 @@ function clampCursor(state: ListState, filtered: ListAgent[]): void {
 	}
 }
 
-export function handleListInput(state: ListState, agents: ListAgent[], data: string): ListAction | undefined {
+function matchesAnyKey(data: string, keys: string[]): boolean {
+	for (const key of keys) {
+		if (matchesKey(data, key)) return true;
+	}
+	return false;
+}
+
+export function handleListInput(
+	state: ListState,
+	agents: ListAgent[],
+	data: string,
+	keybindings: ListKeybindings = DEFAULT_LIST_KEYBINDINGS,
+): ListAction | undefined {
 	const filtered = fuzzyFilter(agents, state.filterQuery);
 
 	if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c")) {
@@ -96,7 +110,7 @@ export function handleListInput(state: ListState, agents: ListAgent[], data: str
 		return;
 	}
 
-	if (matchesKey(data, "alt+n")) {
+	if (matchesAnyKey(data, keybindings.agentManagerNew)) {
 		return { type: "new" };
 	}
 
@@ -158,6 +172,7 @@ export function renderList(
 	width: number,
 	theme: Theme,
 	statusMessage?: { text: string; type: "error" | "info" },
+	keybindings: ListKeybindings = DEFAULT_LIST_KEYBINDINGS,
 ): string[] {
 	const lines: string[] = [];
 	const filtered = fuzzyFilter(agents, state.filterQuery);
@@ -255,11 +270,12 @@ export function renderList(
 	lines.push(row("", width, theme));
 
 	const selCount = state.selected.length;
+	const newKeyLabel = getPrimaryAgentManagerNewKeyLabel(keybindings);
 	const footerText = selCount > 1
 		? ` [ctrl+r] chain  [ctrl+p] parallel  [tab] add  [shift+tab] remove  [esc] clear (${selCount}) `
 		: selCount === 1
 			? " [ctrl+r] run  [ctrl+p] parallel  [tab] add more  [shift+tab] remove  [esc] clear "
-			: " [enter] view  [ctrl+r] run  [tab] select  [alt+n] new  [esc] close ";
+			: ` [enter] view  [ctrl+r] run  [tab] select  [${newKeyLabel}] new  [esc] close `;
 	lines.push(renderFooter(footerText, width, theme));
 
 	return lines;

--- a/agent-manager.ts
+++ b/agent-manager.ts
@@ -7,7 +7,14 @@ import type { AgentConfig, ChainConfig } from "./agents.js";
 import { serializeAgent } from "./agent-serializer.js";
 import { TEMPLATE_ITEMS, type AgentTemplate, type TemplateItem } from "./agent-templates.js";
 import { parseChain, serializeChain } from "./chain-serializer.js";
-import { renderList, handleListInput, type ListAgent, type ListState, type ListAction } from "./agent-manager-list.js";
+import {
+	renderList,
+	handleListInput,
+	type ListAgent,
+	type ListState,
+	type ListAction,
+} from "./agent-manager-list.js";
+import type { ListKeybindings } from "./agent-manager-keybindings.js";
 import { createParallelState, handleParallelInput, renderParallel, formatParallelTitle, type ParallelState, type AgentOption } from "./agent-manager-parallel.js";
 import { renderDetail, handleDetailInput, renderTaskInput, type DetailState, type DetailAction } from "./agent-manager-detail.js";
 import { renderChainDetail, handleChainDetailInput, type ChainDetailAction, type ChainDetailState } from "./agent-manager-chain-detail.js";
@@ -62,7 +69,15 @@ export class AgentManagerComponent implements Component {
 	private statusMessage?: StatusMessage;
 	private nextId = 1;
 
-	constructor(private tui: TUI, private theme: Theme, private agentData: AgentData, private models: ModelInfo[], private skills: SkillInfo[], private done: (result: ManagerResult) => void) { this.loadEntries(); }
+	constructor(
+		private tui: TUI,
+		private theme: Theme,
+		private agentData: AgentData,
+		private models: ModelInfo[],
+		private skills: SkillInfo[],
+		private listKeybindings: ListKeybindings,
+		private done: (result: ManagerResult) => void,
+	) { this.loadEntries(); }
 
 	private loadEntries(): void {
 		const overridden = new Set([...this.agentData.user, ...this.agentData.project].map((c) => c.name));
@@ -245,7 +260,12 @@ export class AgentManagerComponent implements Component {
 		if (this.screen === "list" && this.statusMessage) this.clearStatus();
 		if (this.screen.startsWith("edit") && this.editState?.error) this.editState.error = undefined;
 		switch (this.screen) {
-			case "list": { const action = handleListInput(this.listState, this.listAgents(), data); if (action) this.handleListAction(action); this.tui.requestRender(); return; }
+			case "list": {
+				const action = handleListInput(this.listState, this.listAgents(), data, this.listKeybindings);
+				if (action) this.handleListAction(action);
+				this.tui.requestRender();
+				return;
+			}
 			case "template-select": this.handleTemplateSelectInput(data); return;
 			case "detail": {
 				const entry = this.getAgentEntry(this.currentAgentId); if (!entry) { this.screen = "list"; this.tui.requestRender(); return; }
@@ -364,13 +384,13 @@ export class AgentManagerComponent implements Component {
 	render(width: number): string[] {
 		this.overlayWidth = Math.min(width, 84); const w = this.overlayWidth;
 		switch (this.screen) {
-			case "list": return renderList(this.listState, this.listAgents(), w, this.theme, this.statusMessage);
+			case "list": return renderList(this.listState, this.listAgents(), w, this.theme, this.statusMessage, this.listKeybindings);
 			case "template-select": return this.renderTemplateSelect(w);
-			case "detail": { const entry = this.getAgentEntry(this.currentAgentId); if (!entry) return renderList(this.listState, this.listAgents(), w, this.theme, this.statusMessage); return renderDetail(this.detailState, entry.config, this.agentData.cwd, w, this.theme); }
-			case "chain-detail": { const entry = this.getChainEntry(this.currentChainId); if (!entry) return renderList(this.listState, this.listAgents(), w, this.theme, this.statusMessage); return renderChainDetail(this.chainDetailState, entry.config, w, this.theme); }
+			case "detail": { const entry = this.getAgentEntry(this.currentAgentId); if (!entry) return renderList(this.listState, this.listAgents(), w, this.theme, this.statusMessage, this.listKeybindings); return renderDetail(this.detailState, entry.config, this.agentData.cwd, w, this.theme); }
+			case "chain-detail": { const entry = this.getChainEntry(this.currentChainId); if (!entry) return renderList(this.listState, this.listAgents(), w, this.theme, this.statusMessage, this.listKeybindings); return renderChainDetail(this.chainDetailState, entry.config, w, this.theme); }
 			case "edit": case "edit-field": case "edit-prompt": return this.editState ? renderEdit(this.screen as EditScreen, this.editState, w, this.theme) : [];
 			case "parallel-builder": {
-				if (!this.parallelState) return renderList(this.listState, this.listAgents(), w, this.theme, this.statusMessage);
+				if (!this.parallelState) return renderList(this.listState, this.listAgents(), w, this.theme, this.statusMessage, this.listKeybindings);
 				const agentOptions: AgentOption[] = this.agents.map((e) => ({ name: e.config.name, description: e.config.description, model: e.config.model }));
 				return renderParallel(this.parallelState, agentOptions, w, this.theme);
 			}

--- a/config.test.ts
+++ b/config.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { loadExtensionConfig } from "./config.ts";
+
+const tempDirs: string[] = [];
+
+function makeTempHome(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-config-test-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("loadExtensionConfig", () => {
+	it("preserves legacy config.json settings", () => {
+		const homeDir = makeTempHome();
+		writeJson(path.join(homeDir, ".pi", "agent", "extensions", "subagent", "config.json"), {
+			asyncByDefault: true,
+			defaultSessionDir: "~/.pi/agent/sessions/subagent/",
+		});
+
+		const config = loadExtensionConfig(undefined, homeDir);
+		assert.equal(config.asyncByDefault, true);
+		assert.equal(config.defaultSessionDir, "~/.pi/agent/sessions/subagent/");
+		assert.deepEqual(config.keybindings?.agentManagerNew, ["ctrl+n", "alt+n"]);
+	});
+
+	it("reads namespaced user settings", () => {
+		const homeDir = makeTempHome();
+		writeJson(path.join(homeDir, ".pi", "agent", "settings.json"), {
+			"pi-subagents": {
+				asyncByDefault: true,
+				keybindings: {
+					agentManagerNew: ["ctrl+shift+n"],
+				},
+			},
+		});
+
+		const config = loadExtensionConfig(undefined, homeDir);
+		assert.equal(config.asyncByDefault, true);
+		assert.deepEqual(config.keybindings?.agentManagerNew, ["ctrl+shift+n"]);
+	});
+
+	it("lets project settings override user and legacy settings", () => {
+		const homeDir = makeTempHome();
+		const cwd = path.join(homeDir, "worktree");
+		writeJson(path.join(homeDir, ".pi", "agent", "extensions", "subagent", "config.json"), {
+			asyncByDefault: false,
+			defaultSessionDir: "legacy-dir",
+			keybindings: {
+				agentManagerNew: ["alt+n"],
+			},
+		});
+		writeJson(path.join(homeDir, ".pi", "agent", "settings.json"), {
+			"pi-subagents": {
+				asyncByDefault: true,
+				defaultSessionDir: "user-dir",
+				keybindings: {
+					agentManagerNew: ["ctrl+n"],
+				},
+			},
+		});
+		writeJson(path.join(cwd, ".pi", "settings.json"), {
+			"pi-subagents": {
+				defaultSessionDir: "project-dir",
+				keybindings: {
+					agentManagerNew: ["ctrl+shift+n"],
+				},
+			},
+		});
+
+		const config = loadExtensionConfig(cwd, homeDir);
+		assert.equal(config.asyncByDefault, true);
+		assert.equal(config.defaultSessionDir, "project-dir");
+		assert.deepEqual(config.keybindings?.agentManagerNew, ["ctrl+shift+n"]);
+	});
+});

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,74 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionConfig } from "./types.js";
+
+const DEFAULT_AGENT_MANAGER_NEW_KEYS = ["ctrl+n", "alt+n"];
+const PROJECT_CONFIG_DIR = ".pi";
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function readJsonFile(filePath: string): Record<string, unknown> | undefined {
+	try {
+		if (!fs.existsSync(filePath)) return undefined;
+		return asObject(JSON.parse(fs.readFileSync(filePath, "utf-8")));
+	} catch {
+		return undefined;
+	}
+}
+
+function readSettingsConfig(filePath: string): Record<string, unknown> | undefined {
+	const settings = readJsonFile(filePath);
+	return asObject(settings?.["pi-subagents"]);
+}
+
+function normalizeKeybindingList(value: unknown, fallback: string[]): string[] {
+	if (typeof value === "string") return [value];
+	if (Array.isArray(value)) {
+		const keys = value.filter((item): item is string => typeof item === "string" && item.length > 0);
+		if (keys.length > 0) return keys;
+	}
+	return [...fallback];
+}
+
+export function loadExtensionConfig(cwd?: string, homeDir = os.homedir()): ExtensionConfig {
+	const agentDir = path.join(homeDir, ".pi", "agent");
+	const legacyConfig = readJsonFile(path.join(agentDir, "extensions", "subagent", "config.json"));
+	const userSettings = readSettingsConfig(path.join(agentDir, "settings.json"));
+	const projectSettings = cwd ? readSettingsConfig(path.join(cwd, PROJECT_CONFIG_DIR, "settings.json")) : undefined;
+
+	const mergedKeybindings = {
+		...asObject(legacyConfig?.keybindings),
+		...asObject(userSettings?.keybindings),
+		...asObject(projectSettings?.keybindings),
+	};
+
+	const asyncByDefault =
+		typeof projectSettings?.asyncByDefault === "boolean"
+			? projectSettings.asyncByDefault
+			: typeof userSettings?.asyncByDefault === "boolean"
+				? userSettings.asyncByDefault
+				: typeof legacyConfig?.asyncByDefault === "boolean"
+					? legacyConfig.asyncByDefault
+					: undefined;
+
+	const defaultSessionDir =
+		typeof projectSettings?.defaultSessionDir === "string"
+			? projectSettings.defaultSessionDir
+			: typeof userSettings?.defaultSessionDir === "string"
+				? userSettings.defaultSessionDir
+				: typeof legacyConfig?.defaultSessionDir === "string"
+					? legacyConfig.defaultSessionDir
+					: undefined;
+
+	return {
+		...(asyncByDefault !== undefined ? { asyncByDefault } : {}),
+		...(defaultSessionDir !== undefined ? { defaultSessionDir } : {}),
+		keybindings: {
+			agentManagerNew: normalizeKeybindingList(mergedKeybindings.agentManagerNew, DEFAULT_AGENT_MANAGER_NEW_KEYS),
+		},
+	};
+}

--- a/index.ts
+++ b/index.ts
@@ -31,9 +31,9 @@ import { registerSlashCommands } from "./slash-commands.js";
 import { registerPromptTemplateDelegationBridge } from "./prompt-template-bridge.js";
 import { registerSlashSubagentBridge } from "./slash-bridge.js";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "./slash-live-state.js";
+import { loadExtensionConfig } from "./config.js";
 import {
 	type Details,
-	type ExtensionConfig,
 	type SubagentState,
 	ASYNC_DIR,
 	DEFAULT_ARTIFACT_CONFIG,
@@ -58,18 +58,7 @@ function getSubagentSessionRoot(parentSessionFile: string | null): string {
 	return fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-session-"));
 }
 
-function loadConfig(): ExtensionConfig {
-	const configPath = path.join(os.homedir(), ".pi", "agent", "extensions", "subagent", "config.json");
-	try {
-		if (fs.existsSync(configPath)) {
-			return JSON.parse(fs.readFileSync(configPath, "utf-8")) as ExtensionConfig;
-		}
-	} catch (error) {
-		console.error(`Failed to load subagent config from '${configPath}':`, error);
-	}
-	return {};
-}
-
+<<<<<<< HEAD
 function expandTilde(p: string): string {
 	return p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
 }
@@ -143,7 +132,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	ensureAccessibleDir(ASYNC_DIR);
 	cleanupOldChainDirs();
 
-	const config = loadConfig();
+	const config = loadExtensionConfig(process.cwd());
 	const asyncByDefault = config.asyncByDefault === true;
 	const tempArtifactsDir = getArtifactsDir(null);
 	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);

--- a/index.ts
+++ b/index.ts
@@ -58,7 +58,6 @@ function getSubagentSessionRoot(parentSessionFile: string | null): string {
 	return fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-session-"));
 }
 
-<<<<<<< HEAD
 function expandTilde(p: string): string {
 	return p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
 }

--- a/slash-commands.ts
+++ b/slash-commands.ts
@@ -3,6 +3,8 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { Key, matchesKey } from "@mariozechner/pi-tui";
 import { discoverAgents, discoverAgentsAll } from "./agents.js";
 import { AgentManagerComponent, type ManagerResult } from "./agent-manager.js";
+import { normalizeListKeybindings } from "./agent-manager-keybindings.js";
+import { loadExtensionConfig } from "./config.js";
 import { discoverAvailableSkills } from "./skills.js";
 import type { SubagentParamsLike } from "./subagent-executor.js";
 import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.js";
@@ -251,9 +253,19 @@ async function openAgentManager(
 		fullId: `${m.provider}/${m.id}`,
 	}));
 	const skills = discoverAvailableSkills(ctx.cwd);
+	const config = loadExtensionConfig(ctx.cwd);
+	const listKeybindings = normalizeListKeybindings(config.keybindings);
 
 	const result = await ctx.ui.custom<ManagerResult>(
-		(tui, theme, _kb, done) => new AgentManagerComponent(tui, theme, agentData, models, skills, done),
+		(tui, theme, _kb, done) => new AgentManagerComponent(
+			tui,
+			theme,
+			agentData,
+			models,
+			skills,
+			listKeybindings,
+			done,
+		),
 		{ overlay: true, overlayOptions: { anchor: "center", width: 84, maxHeight: "80%" } },
 	);
 	if (!result) return;

--- a/types.ts
+++ b/types.ts
@@ -238,6 +238,9 @@ export interface RunSyncOptions {
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
 	defaultSessionDir?: string;
+	keybindings?: {
+		agentManagerNew?: string[];
+	};
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #57 

 - Added support for reading pi-subagents config from:
     - .pi/settings.json
     - ~/.pi/agent/settings.json
     - with legacy fallback to ~/.pi/agent/extensions/subagent/config.json
 - Made the Agents Manager “new agent” shortcut configurable via:
     - "pi-subagents".keybindings.agentManagerNew
 - Default behavior now matches docs:
     - ctrl+n primary
     - alt+n retained as fallback