### PR TITLE
fix: reuse current node and pi cli for async subagent spawns

### DIFF
--- a/async-execution.ts
+++ b/async-execution.ts
@@ -106,7 +106,7 @@ function spawnRunner(cfg: object, suffix: string, cwd: string): number | undefin
 	fs.writeFileSync(cfgPath, JSON.stringify(cfg));
 	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
 	
-	const proc = spawn("node", [jitiCliPath, runner, cfgPath], {
+	const proc = spawn(process.execPath, [jitiCliPath, runner, cfgPath], {
 		cwd,
 		detached: true,
 		stdio: "ignore",

--- a/pi-spawn.test.ts
+++ b/pi-spawn.test.ts
@@ -33,7 +33,21 @@ function makeDeps(input: {
 }
 
 describe("getPiSpawnCommand", () => {
-	it("uses plain pi command on non-Windows", () => {
+	it("uses node + argv1 script on non-Windows when argv1 is runnable JS", () => {
+		const argv1 = "/tmp/pi-entry.mjs";
+		const deps = makeDeps({
+			platform: "darwin",
+			execPath: "/usr/local/bin/node",
+			argv1,
+			existing: [argv1],
+		});
+		const args = ["--mode", "json", "Task: check output"];
+		const result = getPiSpawnCommand(args, deps);
+		assert.equal(result.command, "/usr/local/bin/node");
+		assert.deepEqual(result.args, [argv1, ...args]);
+	});
+
+	it("falls back to plain pi command on non-Windows when CLI script cannot be resolved", () => {
 		const args = ["--mode", "json", "Task: check output"];
 		const result = getPiSpawnCommand(args, { platform: "darwin" });
 		assert.deepEqual(result, { command: "pi", args });

--- a/pi-spawn.ts
+++ b/pi-spawn.ts
@@ -83,15 +83,12 @@ export function resolveWindowsPiCliScript(deps: PiSpawnDeps = {}): string | unde
 }
 
 export function getPiSpawnCommand(args: string[], deps: PiSpawnDeps = {}): PiSpawnCommand {
-	const platform = deps.platform ?? process.platform;
-	if (platform === "win32") {
-		const piCliPath = resolveWindowsPiCliScript(deps);
-		if (piCliPath) {
-			return {
-				command: deps.execPath ?? process.execPath,
-				args: [piCliPath, ...args],
-			};
-		}
+	const piCliPath = resolveWindowsPiCliScript(deps);
+	if (piCliPath) {
+		return {
+			command: deps.execPath ?? process.execPath,
+			args: [piCliPath, ...args],
+		};
 	}
 
 	return { command: "pi", args };


### PR DESCRIPTION
## Summary

Fix async subprocess spawning so background subagents reuse the current Node executable and resolved pi CLI path instead of re-resolving `node` / `pi` from PATH.

Fixes #61.
Related: #51, #13.

## Motivation

Async execution currently has two PATH-dependent launch points:

1. `async-execution.ts` spawns the detached runner with bare `node`
2. `pi-spawn.ts` uses the resolved CLI script only on Windows, but falls back to bare `pi` on macOS/Linux

That means a parent pi session launched through a pinned wrapper like:

```bash
mise exec node@25.8.0 -- pi
```

can run foreground work correctly while async subagents drift onto a different Node / pi runtime. In practice this shows up as confusing async-only startup failures with provider/tool differences, while sync execution in the same cwd still works.

## Changes

- `async-execution.ts`
  - use `process.execPath` instead of bare `node` when spawning the detached async runner
- `pi-spawn.ts`
  - prefer the resolved current pi CLI script on **all platforms**, not only Windows
  - keep the existing `pi` fallback when resolution fails
- `pi-spawn.test.ts`
  - add non-Windows coverage for the resolved-CLI path
  - keep fallback coverage for unresolved CLI lookup

## Why this is safe

- `process.execPath` is the exact Node binary running the parent session
- CLI resolution already guards against `.ts` entrypoints via `isRunnableNodeScript()` and falls back to package/bin lookup
- if CLI resolution fails, behavior remains unchanged (`pi` from PATH)

## Validation

Ran locally:

- `npm test`
- `npm run test:integration`

Also validated the real-world async scenario that motivated the fix:
- async `planner` ✅
- async `reviewer` ✅
- async `scout` ✅

where those runs had previously been failing under a `mise exec node@... -- pi` parent launch.
