### PR TITLE
Fix: Support .agents and ~/.agents directories for skills and agents

### DIFF
--- a/agents.ts
+++ b/agents.ts
@@ -205,6 +205,9 @@ function isDirectory(p: string): boolean {
 function findNearestProjectAgentsDir(cwd: string): string | null {
 	let currentDir = cwd;
 	while (true) {
+		const candidateAlt = path.join(currentDir, ".agents");
+		if (isDirectory(candidateAlt)) return candidateAlt;
+
 		const candidate = path.join(currentDir, ".pi", "agents");
 		if (isDirectory(candidate)) return candidate;
 
@@ -217,11 +220,16 @@ function findNearestProjectAgentsDir(cwd: string): string | null {
 const BUILTIN_AGENTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "agents");
 
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
-	const userDir = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDirOld = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDirNew = path.join(os.homedir(), ".agents");
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
 
 	const builtinAgents = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
-	const userAgents = scope === "project" ? [] : loadAgentsFromDir(userDir, "user");
+	
+	const userAgentsOld = scope === "project" ? [] : loadAgentsFromDir(userDirOld, "user");
+	const userAgentsNew = scope === "project" ? [] : loadAgentsFromDir(userDirNew, "user");
+	const userAgents = [...userAgentsOld, ...userAgentsNew];
+
 	const projectAgents = scope === "user" || !projectAgentsDir ? [] : loadAgentsFromDir(projectAgentsDir, "project");
 	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents);
 
@@ -236,16 +244,23 @@ export function discoverAgentsAll(cwd: string): {
 	userDir: string;
 	projectDir: string | null;
 } {
-	const userDir = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDirOld = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDirNew = path.join(os.homedir(), ".agents");
 	const projectDir = findNearestProjectAgentsDir(cwd);
 
 	const builtin = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
-	const user = loadAgentsFromDir(userDir, "user");
+	const user = [
+		...loadAgentsFromDir(userDirOld, "user"),
+		...loadAgentsFromDir(userDirNew, "user"),
+	];
 	const project = projectDir ? loadAgentsFromDir(projectDir, "project") : [];
 	const chains = [
-		...loadChainsFromDir(userDir, "user"),
+		...loadChainsFromDir(userDirOld, "user"),
+		...loadChainsFromDir(userDirNew, "user"),
 		...(projectDir ? loadChainsFromDir(projectDir, "project") : []),
 	];
+
+	const userDir = fs.existsSync(userDirNew) ? userDirNew : userDirOld;
 
 	return { builtin, user, project, chains, userDir, projectDir };
 }

--- a/path-resolution.test.ts
+++ b/path-resolution.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, before, after } from "node:test";
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { discoverAgents, discoverAgentsAll } from "./agents.js";
+import { resolveSkillPath, clearSkillCache, discoverAvailableSkills } from "./skills.js";
+
+const tmpDir = path.join(os.tmpdir(), "pi-path-resolution-test");
+const cwdDir = path.join(tmpDir, "cwd");
+
+const realHomeDir = os.homedir();
+const realUserAgentsDir = path.join(realHomeDir, ".agents");
+const userAgentsDirBackup = path.join(tmpDir, ".agents_backup");
+
+before(() => {
+	fs.mkdirSync(cwdDir, { recursive: true });
+	
+	// Backup existing ~/.agents if any
+	if (fs.existsSync(realUserAgentsDir)) {
+		fs.cpSync(realUserAgentsDir, userAgentsDirBackup, { recursive: true });
+	}
+});
+
+after(() => {
+	// Restore ~/.agents
+	if (fs.existsSync(userAgentsDirBackup)) {
+		fs.rmSync(realUserAgentsDir, { recursive: true, force: true });
+		fs.cpSync(userAgentsDirBackup, realUserAgentsDir, { recursive: true });
+	} else {
+		// If it didn't exist before, just remove what we created
+		fs.rmSync(realUserAgentsDir, { recursive: true, force: true });
+	}
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("Path resolution for .agents and ~/.agents", () => {
+	test("should resolve skills in .agents/skills", () => {
+		const skillsDir = path.join(cwdDir, ".agents", "skills");
+		fs.mkdirSync(skillsDir, { recursive: true });
+		fs.writeFileSync(path.join(skillsDir, "test-skill-1.md"), "---\nname: test-skill-1\ndescription: test desc\n---\nSkill content");
+
+		clearSkillCache();
+		const resolved = resolveSkillPath("test-skill-1", cwdDir);
+		if (!resolved) {
+			console.error("DEBUG SKILLS:", discoverAvailableSkills(cwdDir));
+			console.error("EXPECTED DIR:", skillsDir);
+		}
+		assert.ok(resolved);
+		assert.strictEqual(resolved?.path, path.join(skillsDir, "test-skill-1.md"));
+	});
+
+	test("should resolve skills in ~/.agents/skills", () => {
+		const userSkillsDir = path.join(realHomeDir, ".agents", "skills");
+		fs.mkdirSync(userSkillsDir, { recursive: true });
+		fs.writeFileSync(path.join(userSkillsDir, "test-skill-2.md"), "---\nname: test-skill-2\ndescription: test desc\n---\nSkill content");
+
+		clearSkillCache();
+		const resolved = resolveSkillPath("test-skill-2", cwdDir);
+		if (!resolved) {
+			console.error("DEBUG SKILLS 2:", discoverAvailableSkills(cwdDir));
+			console.error("EXPECTED DIR 2:", userSkillsDir);
+		}
+		assert.ok(resolved);
+		assert.strictEqual(resolved?.path, path.join(userSkillsDir, "test-skill-2.md"));
+	});
+
+	test("should resolve agents in .agents", () => {
+		const agentsDir = path.join(cwdDir, ".agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(agentsDir, "test-agent-1.md"),
+			"---\nname: test-agent-1\ndescription: Test agent\n---\nAgent content"
+		);
+
+		const result = discoverAgents(cwdDir, "project");
+		const agent = result.agents.find((a) => a.name === "test-agent-1");
+		assert.ok(agent);
+		assert.strictEqual(agent?.filePath, path.join(agentsDir, "test-agent-1.md"));
+	});
+
+	test("should resolve agents in ~/.agents", () => {
+		const userAgentsDir = path.join(realHomeDir, ".agents");
+		fs.mkdirSync(userAgentsDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(userAgentsDir, "test-agent-2.md"),
+			"---\nname: test-agent-2\ndescription: Test agent\n---\nAgent content"
+		);
+
+		const result = discoverAgents(cwdDir, "user");
+		const agent = result.agents.find((a) => a.name === "test-agent-2");
+		assert.ok(agent);
+		assert.strictEqual(agent?.filePath, path.join(userAgentsDir, "test-agent-2.md"));
+	});
+});

--- a/skills.ts
+++ b/skills.ts
@@ -187,7 +187,9 @@ function collectSettingsSkillPaths(cwd: string): string[] {
 function buildSkillPaths(cwd: string): string[] {
 	const defaultSkillPaths = [
 		path.join(cwd, CONFIG_DIR, "skills"),
+		path.join(cwd, ".agents", "skills"),
 		path.join(AGENT_DIR, "skills"),
+		path.join(os.homedir(), ".agents", "skills"),
 	];
 	const packagePaths = collectPackageSkillPaths(cwd);
 	const settingsPaths = collectSettingsSkillPaths(cwd);
@@ -203,10 +205,11 @@ function inferSkillSource(sourceInfo: { source: string; scope: string }, filePat
 	// Fallback: infer from file path when sourceInfo isn't specific enough
 	// (e.g. scope === "temporary" for skills loaded via explicit skillPaths)
 	const projectRoot = path.resolve(cwd, CONFIG_DIR);
-	const isProjectScoped = isWithinPath(filePath, projectRoot);
+	const altProjectRoot = path.resolve(cwd, ".agents");
+	const isProjectScoped = isWithinPath(filePath, projectRoot) || isWithinPath(filePath, altProjectRoot);
 	if (isProjectScoped) return "project";
 
-	const isUserScoped = isWithinPath(filePath, AGENT_DIR);
+	const isUserScoped = isWithinPath(filePath, AGENT_DIR) || isWithinPath(filePath, path.join(os.homedir(), ".agents"));
 	if (isUserScoped) return "user";
 
 	const globalRoot = getGlobalNpmRoot();


### PR DESCRIPTION
Fixes #65. Allows pi to automatically discover skills and agents stored in the project-level .agents directory or the user-level ~/.agents directory, restoring parity with pi's core functionality.