### PR TITLE
fix(runtime): support direct TypeScript loading

### DIFF
--- a/agent-management.ts
+++ b/agent-management.ts
@@ -9,11 +9,11 @@ import {
 	type ChainConfig,
 	type ChainStepConfig,
 	discoverAgentsAll,
-} from "./agents.js";
-import { serializeAgent } from "./agent-serializer.js";
-import { serializeChain } from "./chain-serializer.js";
-import { discoverAvailableSkills } from "./skills.js";
-import type { Details } from "./types.js";
+} from "./agents.ts";
+import { serializeAgent } from "./agent-serializer.ts";
+import { serializeChain } from "./chain-serializer.ts";
+import { discoverAvailableSkills } from "./skills.ts";
+import type { Details } from "./types.ts";
 
 type ManagementAction = "list" | "get" | "create" | "update" | "delete";
 type ManagementScope = "user" | "project";

--- a/agent-manager-chain-detail.ts
+++ b/agent-manager-chain-detail.ts
@@ -1,7 +1,7 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
-import type { ChainConfig, ChainStepConfig } from "./agents.js";
-import { row, renderFooter, renderHeader, formatPath, formatScrollInfo } from "./render-helpers.js";
+import type { ChainConfig, ChainStepConfig } from "./agents.ts";
+import { row, renderFooter, renderHeader, formatPath, formatScrollInfo } from "./render-helpers.ts";
 
 export interface ChainDetailState {
 	scrollOffset: number;

--- a/agent-manager-detail.ts
+++ b/agent-manager-detail.ts
@@ -1,12 +1,12 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
-import type { AgentConfig } from "./agents.js";
-import { formatDuration } from "./formatters.js";
-import type { RunEntry } from "./run-history.js";
-import { buildSkillInjection, resolveSkills } from "./skills.js";
-import { ensureCursorVisible, getCursorDisplayPos, renderEditor, wrapText } from "./text-editor.js";
-import type { TextEditorState } from "./text-editor.js";
-import { pad, row, renderHeader, renderFooter, formatPath, formatScrollInfo } from "./render-helpers.js";
+import type { AgentConfig } from "./agents.ts";
+import { formatDuration } from "./formatters.ts";
+import type { RunEntry } from "./run-history.ts";
+import { buildSkillInjection, resolveSkills } from "./skills.ts";
+import { ensureCursorVisible, getCursorDisplayPos, renderEditor, wrapText } from "./text-editor.ts";
+import type { TextEditorState } from "./text-editor.ts";
+import { pad, row, renderHeader, renderFooter, formatPath, formatScrollInfo } from "./render-helpers.ts";
 
 export interface DetailState {
 	resolved: boolean;

--- a/agent-manager-edit.ts
+++ b/agent-manager-edit.ts
@@ -1,9 +1,9 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
-import type { AgentConfig } from "./agents.js";
-import { createEditorState, ensureCursorVisible, getCursorDisplayPos, handleEditorInput, renderEditor, wrapText } from "./text-editor.js";
-import type { TextEditorState } from "./text-editor.js";
-import { pad, row, renderHeader, renderFooter, formatScrollInfo } from "./render-helpers.js";
+import type { AgentConfig } from "./agents.ts";
+import { createEditorState, ensureCursorVisible, getCursorDisplayPos, handleEditorInput, renderEditor, wrapText } from "./text-editor.ts";
+import type { TextEditorState } from "./text-editor.ts";
+import { pad, row, renderHeader, renderFooter, formatScrollInfo } from "./render-helpers.ts";
 
 export interface ModelInfo { provider: string; id: string; fullId: string; }
 export interface SkillInfo { name: string; source: string; description?: string; }

--- a/agent-manager-list.ts
+++ b/agent-manager-list.ts
@@ -1,7 +1,7 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
-import type { AgentSource } from "./agents.js";
+import type { AgentSource } from "./agents.ts";
 import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import { pad, row, renderHeader, renderFooter, fuzzyFilter, formatScrollInfo } from "./render-helpers.js";
+import { pad, row, renderHeader, renderFooter, fuzzyFilter, formatScrollInfo } from "./render-helpers.ts";
 
 export interface ListAgent {
 	id: string;

--- a/agent-manager-parallel.ts
+++ b/agent-manager-parallel.ts
@@ -1,8 +1,8 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import type { TextEditorState } from "./text-editor.js";
-import { createEditorState, handleEditorInput, renderEditor, wrapText, getCursorDisplayPos, ensureCursorVisible } from "./text-editor.js";
-import { pad, row, renderHeader, renderFooter, fuzzyFilter } from "./render-helpers.js";
+import type { TextEditorState } from "./text-editor.ts";
+import { createEditorState, handleEditorInput, renderEditor, wrapText, getCursorDisplayPos, ensureCursorVisible } from "./text-editor.ts";
+import { pad, row, renderHeader, renderFooter, fuzzyFilter } from "./render-helpers.ts";
 
 export interface ParallelSlot {
 	agentName: string;

--- a/agent-manager.ts
+++ b/agent-manager.ts
@@ -3,19 +3,19 @@ import * as path from "node:path";
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import type { Component, TUI } from "@mariozechner/pi-tui";
 import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import type { AgentConfig, ChainConfig } from "./agents.js";
-import { serializeAgent } from "./agent-serializer.js";
-import { TEMPLATE_ITEMS, type AgentTemplate, type TemplateItem } from "./agent-templates.js";
-import { parseChain, serializeChain } from "./chain-serializer.js";
-import { renderList, handleListInput, type ListAgent, type ListState, type ListAction } from "./agent-manager-list.js";
-import { createParallelState, handleParallelInput, renderParallel, formatParallelTitle, type ParallelState, type AgentOption } from "./agent-manager-parallel.js";
-import { renderDetail, handleDetailInput, renderTaskInput, type DetailState, type DetailAction } from "./agent-manager-detail.js";
-import { renderChainDetail, handleChainDetailInput, type ChainDetailAction, type ChainDetailState } from "./agent-manager-chain-detail.js";
-import { createEditState, handleEditInput, renderEdit, type EditScreen, type EditState, type ModelInfo, type SkillInfo } from "./agent-manager-edit.js";
-import { createEditorState, ensureCursorVisible, getCursorDisplayPos, handleEditorInput, renderEditor, wrapText } from "./text-editor.js";
-import type { TextEditorState } from "./text-editor.js";
-import { loadRunsForAgent } from "./run-history.js";
-import { pad, row, renderHeader, renderFooter } from "./render-helpers.js";
+import type { AgentConfig, ChainConfig } from "./agents.ts";
+import { serializeAgent } from "./agent-serializer.ts";
+import { TEMPLATE_ITEMS, type AgentTemplate, type TemplateItem } from "./agent-templates.ts";
+import { parseChain, serializeChain } from "./chain-serializer.ts";
+import { renderList, handleListInput, type ListAgent, type ListState, type ListAction } from "./agent-manager-list.ts";
+import { createParallelState, handleParallelInput, renderParallel, formatParallelTitle, type ParallelState, type AgentOption } from "./agent-manager-parallel.ts";
+import { renderDetail, handleDetailInput, renderTaskInput, type DetailState, type DetailAction } from "./agent-manager-detail.ts";
+import { renderChainDetail, handleChainDetailInput, type ChainDetailAction, type ChainDetailState } from "./agent-manager-chain-detail.ts";
+import { createEditState, handleEditInput, renderEdit, type EditScreen, type EditState, type ModelInfo, type SkillInfo } from "./agent-manager-edit.ts";
+import { createEditorState, ensureCursorVisible, getCursorDisplayPos, handleEditorInput, renderEditor, wrapText } from "./text-editor.ts";
+import type { TextEditorState } from "./text-editor.ts";
+import { loadRunsForAgent } from "./run-history.ts";
+import { pad, row, renderHeader, renderFooter } from "./render-helpers.ts";
 
 export type ManagerResult =
 	| { action: "launch"; agent: string; task: string; skipClarify?: boolean }
@@ -61,8 +61,22 @@ export class AgentManagerComponent implements Component {
 	private templateCursor = 0;
 	private statusMessage?: StatusMessage;
 	private nextId = 1;
+	private tui: TUI;
+	private theme: Theme;
+	private agentData: AgentData;
+	private models: ModelInfo[];
+	private skills: SkillInfo[];
+	private done: (result: ManagerResult) => void;
 
-	constructor(private tui: TUI, private theme: Theme, private agentData: AgentData, private models: ModelInfo[], private skills: SkillInfo[], private done: (result: ManagerResult) => void) { this.loadEntries(); }
+	constructor(tui: TUI, theme: Theme, agentData: AgentData, models: ModelInfo[], skills: SkillInfo[], done: (result: ManagerResult) => void) {
+		this.tui = tui;
+		this.theme = theme;
+		this.agentData = agentData;
+		this.models = models;
+		this.skills = skills;
+		this.done = done;
+		this.loadEntries();
+	}
 
 	private loadEntries(): void {
 		const overridden = new Set([...this.agentData.user, ...this.agentData.project].map((c) => c.name));

--- a/agent-scope.ts
+++ b/agent-scope.ts
@@ -1,4 +1,4 @@
-import type { AgentScope } from "./agents.js";
+import type { AgentScope } from "./agents.ts";
 
 export function resolveExecutionAgentScope(scope: unknown): AgentScope {
 	if (scope === "user" || scope === "project" || scope === "both") return scope;

--- a/agent-selection.ts
+++ b/agent-selection.ts
@@ -1,4 +1,4 @@
-import type { AgentScope, AgentConfig } from "./agents.js";
+import type { AgentScope, AgentConfig } from "./agents.ts";
 
 export function mergeAgentsForScope(
 	scope: AgentScope,

--- a/agent-serializer.ts
+++ b/agent-serializer.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import type { AgentConfig } from "./agents.js";
+import type { AgentConfig } from "./agents.ts";
 
 export const KNOWN_FIELDS = new Set([
 	"name",

--- a/agent-templates.ts
+++ b/agent-templates.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig } from "./agents.js";
+import type { AgentConfig } from "./agents.ts";
 
 export interface AgentTemplate {
 	name: string;

--- a/agents.ts
+++ b/agents.ts
@@ -6,9 +6,9 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { KNOWN_FIELDS } from "./agent-serializer.js";
-import { parseChain } from "./chain-serializer.js";
-import { mergeAgentsForScope } from "./agent-selection.js";
+import { KNOWN_FIELDS } from "./agent-serializer.ts";
+import { parseChain } from "./chain-serializer.ts";
+import { mergeAgentsForScope } from "./agent-selection.ts";
 
 export type AgentScope = "user" | "project" | "both";
 

--- a/artifacts.ts
+++ b/artifacts.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ArtifactPaths } from "./types.js";
+import type { ArtifactPaths } from "./types.ts";
 
 const TEMP_ARTIFACTS_DIR = path.join(os.tmpdir(), "pi-subagent-artifacts");
 const CLEANUP_MARKER_FILE = ".last-cleanup";

--- a/async-execution.ts
+++ b/async-execution.ts
@@ -9,20 +9,20 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import type { AgentConfig } from "./agents.js";
-import { applyThinkingSuffix } from "./execution.js";
-import { injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.js";
-import { isParallelStep, resolveStepBehavior, type ChainStep, type ParallelStep, type SequentialStep, type StepOverrides } from "./settings.js";
-import type { RunnerStep } from "./parallel-utils.js";
-import { resolvePiPackageRoot } from "./pi-spawn.js";
-import { buildSkillInjection, normalizeSkillInput, resolveSkills } from "./skills.js";
+import type { AgentConfig } from "./agents.ts";
+import { applyThinkingSuffix } from "./execution.ts";
+import { injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.ts";
+import { isParallelStep, resolveStepBehavior, type ChainStep, type ParallelStep, type SequentialStep, type StepOverrides } from "./settings.ts";
+import type { RunnerStep } from "./parallel-utils.ts";
+import { resolvePiPackageRoot } from "./pi-spawn.ts";
+import { buildSkillInjection, normalizeSkillInput, resolveSkills } from "./skills.ts";
 import {
 	type ArtifactConfig,
 	type Details,
 	type MaxOutputConfig,
 	ASYNC_DIR,
 	RESULTS_DIR,
-} from "./types.js";
+} from "./types.ts";
 
 const require = createRequire(import.meta.url);
 const piPackageRoot = resolvePiPackageRoot();

--- a/chain-clarify.ts
+++ b/chain-clarify.ts
@@ -11,12 +11,12 @@ import { matchesKey, visibleWidth, truncateToWidth } from "@mariozechner/pi-tui"
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentConfig, ChainConfig, ChainStepConfig } from "./agents.js";
-import type { ResolvedStepBehavior } from "./settings.js";
-import type { TextEditorState } from "./text-editor.js";
-import { createEditorState, ensureCursorVisible, getCursorDisplayPos, handleEditorInput, renderEditor, wrapText } from "./text-editor.js";
-import { updateFrontmatterField } from "./agent-serializer.js";
-import { serializeChain } from "./chain-serializer.js";
+import type { AgentConfig, ChainConfig, ChainStepConfig } from "./agents.ts";
+import type { ResolvedStepBehavior } from "./settings.ts";
+import type { TextEditorState } from "./text-editor.ts";
+import { createEditorState, ensureCursorVisible, getCursorDisplayPos, handleEditorInput, renderEditor, wrapText } from "./text-editor.ts";
+import { updateFrontmatterField } from "./agent-serializer.ts";
+import { serializeChain } from "./chain-serializer.ts";
 
 /** Clarify TUI mode */
 export type ClarifyMode = 'single' | 'parallel' | 'chain';
@@ -92,20 +92,42 @@ export class ChainClarifyComponent implements Component {
 	private savingChain = false;
 	/** Run in background (async) mode */
 	private runInBackground = false;
+	private tui: TUI;
+	private theme: Theme;
+	private agentConfigs: AgentConfig[];
+	private templates: string[];
+	private originalTask: string;
+	private chainDir: string | undefined;
+	private resolvedBehaviors: ResolvedStepBehavior[];
+	private availableModels: ModelInfo[];
+	private availableSkills: Array<{ name: string; source: string; description?: string }>;
+	private done: (result: ChainClarifyResult) => void;
+	private mode: ClarifyMode;
 
 	constructor(
-		private tui: TUI,
-		private theme: Theme,
-		private agentConfigs: AgentConfig[],
-		private templates: string[],
-		private originalTask: string,
-		private chainDir: string | undefined,  // undefined for single/parallel modes
-		private resolvedBehaviors: ResolvedStepBehavior[],
-		private availableModels: ModelInfo[],
-		private availableSkills: Array<{ name: string; source: string; description?: string }>,
-		private done: (result: ChainClarifyResult) => void,
-		private mode: ClarifyMode = 'chain',   // Mode: 'single', 'parallel', or 'chain'
+		tui: TUI,
+		theme: Theme,
+		agentConfigs: AgentConfig[],
+		templates: string[],
+		originalTask: string,
+		chainDir: string | undefined,  // undefined for single/parallel modes
+		resolvedBehaviors: ResolvedStepBehavior[],
+		availableModels: ModelInfo[],
+		availableSkills: Array<{ name: string; source: string; description?: string }>,
+		done: (result: ChainClarifyResult) => void,
+		mode: ClarifyMode = 'chain',   // Mode: 'single', 'parallel', or 'chain'
 	) {
+		this.tui = tui;
+		this.theme = theme;
+		this.agentConfigs = agentConfigs;
+		this.templates = templates;
+		this.originalTask = originalTask;
+		this.chainDir = chainDir;
+		this.resolvedBehaviors = resolvedBehaviors;
+		this.availableModels = availableModels;
+		this.availableSkills = availableSkills;
+		this.done = done;
+		this.mode = mode;
 		// Initialize filtered models
 		this.filteredModels = [...availableModels];
 		this.filteredSkills = [...availableSkills];

--- a/chain-execution.ts
+++ b/chain-execution.ts
@@ -6,8 +6,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import type { AgentConfig } from "./agents.js";
-import { ChainClarifyComponent, type ChainClarifyResult, type BehaviorOverride, type ModelInfo } from "./chain-clarify.js";
+import type { AgentConfig } from "./agents.ts";
+import { ChainClarifyComponent, type ChainClarifyResult, type BehaviorOverride, type ModelInfo } from "./chain-clarify.ts";
 import {
 	resolveChainTemplates,
 	createChainDir,
@@ -23,12 +23,12 @@ import {
 	type SequentialStep,
 	type ParallelTaskResult,
 	type ResolvedTemplates,
-} from "./settings.js";
-import { discoverAvailableSkills, normalizeSkillInput } from "./skills.js";
-import { runSync } from "./execution.js";
-import { buildChainSummary } from "./formatters.js";
-import { getFinalOutput, mapConcurrent } from "./utils.js";
-import { recordRun } from "./run-history.js";
+} from "./settings.ts";
+import { discoverAvailableSkills, normalizeSkillInput } from "./skills.ts";
+import { runSync } from "./execution.ts";
+import { buildChainSummary } from "./formatters.ts";
+import { getFinalOutput, mapConcurrent } from "./utils.ts";
+import { recordRun } from "./run-history.ts";
 import {
 	type AgentProgress,
 	type ArtifactConfig,
@@ -36,7 +36,7 @@ import {
 	type Details,
 	type SingleResult,
 	MAX_CONCURRENCY,
-} from "./types.js";
+} from "./types.ts";
 
 /** Resolve a model name to its full provider/model format */
 function resolveModelFullId(modelName: string | undefined, availableModels: ModelInfo[]): string | undefined {

--- a/chain-serializer.ts
+++ b/chain-serializer.ts
@@ -1,4 +1,4 @@
-import type { ChainConfig, ChainStepConfig } from "./agents.js";
+import type { ChainConfig, ChainStepConfig } from "./agents.ts";
 
 function parseFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
 	const frontmatter: Record<string, string> = {};

--- a/execution.ts
+++ b/execution.ts
@@ -7,13 +7,13 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@mariozechner/pi-ai";
-import type { AgentConfig } from "./agents.js";
+import type { AgentConfig } from "./agents.ts";
 import {
 	ensureArtifactsDir,
 	getArtifactPaths,
 	writeArtifact,
 	writeMetadata,
-} from "./artifacts.js";
+} from "./artifacts.ts";
 import {
 	type AgentProgress,
 	type ArtifactPaths,
@@ -22,7 +22,7 @@ import {
 	DEFAULT_MAX_OUTPUT,
 	truncateOutput,
 	getSubagentDepthEnv,
-} from "./types.js";
+} from "./types.ts";
 import {
 	writePrompt,
 	getFinalOutput,
@@ -30,10 +30,10 @@ import {
 	detectSubagentError,
 	extractToolArgsPreview,
 	extractTextFromContent,
-} from "./utils.js";
-import { buildSkillInjection, resolveSkills } from "./skills.js";
-import { getPiSpawnCommand } from "./pi-spawn.js";
-import { createJsonlWriter } from "./jsonl-writer.js";
+} from "./utils.ts";
+import { buildSkillInjection, resolveSkills } from "./skills.ts";
+import { getPiSpawnCommand } from "./pi-spawn.ts";
+import { createJsonlWriter } from "./jsonl-writer.ts";
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
 

--- a/formatters.ts
+++ b/formatters.ts
@@ -4,9 +4,9 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { Usage, SingleResult } from "./types.js";
-import type { ChainStep, SequentialStep } from "./settings.js";
-import { isParallelStep } from "./settings.js";
+import type { Usage, SingleResult } from "./types.ts";
+import type { ChainStep, SequentialStep } from "./settings.ts";
+import { isParallelStep } from "./settings.ts";
 
 /**
  * Format token count with k suffix for large numbers

--- a/index.ts
+++ b/index.ts
@@ -18,11 +18,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { type ExtensionAPI, type ExtensionContext, type ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
-import { type AgentConfig, type AgentScope, discoverAgents, discoverAgentsAll } from "./agents.js";
-import { resolveExecutionAgentScope } from "./agent-scope.js";
-import { cleanupOldChainDirs, getStepAgents, isParallelStep, resolveStepBehavior, type ChainStep, type SequentialStep } from "./settings.js";
-import { ChainClarifyComponent, type ChainClarifyResult, type ModelInfo } from "./chain-clarify.js";
-import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "./artifacts.js";
+import { type AgentConfig, type AgentScope, discoverAgents, discoverAgentsAll } from "./agents.ts";
+import { resolveExecutionAgentScope } from "./agent-scope.ts";
+import { cleanupOldChainDirs, getStepAgents, isParallelStep, resolveStepBehavior, type ChainStep, type SequentialStep } from "./settings.ts";
+import { ChainClarifyComponent, type ChainClarifyResult, type ModelInfo } from "./chain-clarify.ts";
+import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "./artifacts.ts";
 import {
 	type AgentProgress,
 	type ArtifactConfig,
@@ -40,20 +40,20 @@ import {
 	RESULTS_DIR,
 	WIDGET_KEY,
 	checkSubagentDepth,
-} from "./types.js";
-import { readStatus, findByPrefix, getFinalOutput, mapConcurrent } from "./utils.js";
-import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.js";
-import { createFileCoalescer } from "./file-coalescer.js";
-import { runSync } from "./execution.js";
-import { renderWidget, renderSubagentResult } from "./render.js";
-import { SubagentParams, StatusParams } from "./schemas.js";
-import { executeChain } from "./chain-execution.js";
-import { isAsyncAvailable, executeAsyncChain, executeAsyncSingle } from "./async-execution.js";
-import { discoverAvailableSkills, normalizeSkillInput } from "./skills.js";
-import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.js";
-import { AgentManagerComponent, type ManagerResult } from "./agent-manager.js";
-import { recordRun } from "./run-history.js";
-import { handleManagementAction } from "./agent-management.js";
+} from "./types.ts";
+import { readStatus, findByPrefix, getFinalOutput, mapConcurrent } from "./utils.ts";
+import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.ts";
+import { createFileCoalescer } from "./file-coalescer.ts";
+import { runSync } from "./execution.ts";
+import { renderWidget, renderSubagentResult } from "./render.ts";
+import { SubagentParams, StatusParams } from "./schemas.ts";
+import { executeChain } from "./chain-execution.ts";
+import { isAsyncAvailable, executeAsyncChain, executeAsyncSingle } from "./async-execution.ts";
+import { discoverAvailableSkills, normalizeSkillInput } from "./skills.ts";
+import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.ts";
+import { AgentManagerComponent, type ManagerResult } from "./agent-manager.ts";
+import { recordRun } from "./run-history.ts";
+import { handleManagementAction } from "./agent-management.ts";
 
 // ExtensionConfig is now imported from ./types.js
 

--- a/notify.ts
+++ b/notify.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { buildCompletionKey, getGlobalSeenMap, markSeenWithTtl } from "./completion-dedupe.js";
+import { buildCompletionKey, getGlobalSeenMap, markSeenWithTtl } from "./completion-dedupe.ts";
 
 interface ChainStepResult {
 	agent: string;

--- a/package.json
+++ b/package.json
@@ -45,10 +45,19 @@
       "./notify.ts"
     ]
   },
+  "peerDependencies": {
+    "@mariozechner/pi-agent-core": "*",
+    "@mariozechner/pi-ai": "*",
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-tui": "*",
+    "@sinclair/typebox": "*"
+  },
   "devDependencies": {
     "@marcfargas/pi-test-harness": "^0.5.0",
     "@mariozechner/pi-agent-core": "^0.54.0",
     "@mariozechner/pi-ai": "^0.54.0",
-    "@mariozechner/pi-coding-agent": "^0.54.0"
+    "@mariozechner/pi-coding-agent": "^0.54.0",
+    "@mariozechner/pi-tui": "^0.54.0",
+    "@sinclair/typebox": "^0.34.41"
   }
 }

--- a/render.ts
+++ b/render.ts
@@ -10,9 +10,9 @@ import {
 	type Details,
 	MAX_WIDGET_JOBS,
 	WIDGET_KEY,
-} from "./types.js";
-import { formatTokens, formatUsage, formatDuration, formatToolCall, shortenPath } from "./formatters.js";
-import { getFinalOutput, getDisplayItems, getOutputTail, getLastActivity } from "./utils.js";
+} from "./types.ts";
+import { formatTokens, formatUsage, formatDuration, formatToolCall, shortenPath } from "./formatters.ts";
+import { getFinalOutput, getDisplayItems, getOutputTail, getLastActivity } from "./utils.ts";
 
 type Theme = ExtensionContext["ui"]["theme"];
 

--- a/settings.ts
+++ b/settings.ts
@@ -5,8 +5,8 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentConfig } from "./agents.js";
-import { normalizeSkillInput } from "./skills.js";
+import type { AgentConfig } from "./agents.ts";
+import { normalizeSkillInput } from "./skills.ts";
 
 const CHAIN_RUNS_DIR = path.join(os.tmpdir(), "pi-chain-runs");
 const CHAIN_DIR_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -4,9 +4,9 @@ import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { appendJsonl, getArtifactPaths } from "./artifacts.js";
-import { getPiSpawnCommand } from "./pi-spawn.js";
-import { persistSingleOutput } from "./single-output.js";
+import { appendJsonl, getArtifactPaths } from "./artifacts.ts";
+import { getPiSpawnCommand } from "./pi-spawn.ts";
+import { persistSingleOutput } from "./single-output.ts";
 import {
 	type ArtifactConfig,
 	type ArtifactPaths,
@@ -14,7 +14,7 @@ import {
 	type MaxOutputConfig,
 	truncateOutput,
 	getSubagentDepthEnv,
-} from "./types.js";
+} from "./types.ts";
 import {
 	type RunnerSubagentStep as SubagentStep,
 	type RunnerStep,
@@ -23,7 +23,7 @@ import {
 	mapConcurrent,
 	aggregateParallelOutputs,
 	MAX_PARALLEL_CONCURRENCY,
-} from "./parallel-utils.js";
+} from "./parallel-utils.ts";
 
 interface SubagentRunConfig {
 	id: string;

--- a/utils.ts
+++ b/utils.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@mariozechner/pi-ai";
-import type { AsyncStatus, DisplayItem, ErrorInfo } from "./types.js";
+import type { AsyncStatus, DisplayItem, ErrorInfo } from "./types.ts";
 
 // ============================================================================
 // File System Utilities


### PR DESCRIPTION
## Summary
- switch internal relative imports from `.js` to `.ts` for source-loaded runtime compatibility
- replace Node strip-types incompatible parameter properties with explicit field assignments
- declare the Pi core peer dependencies the package imports

## Why
Pi can dogfood packages directly from a local checkout. In that mode there is no compiled `.js` tree, and Node's strip-types loader rejects parameter properties. This PR makes the package load cleanly from source as well as after publish/build.

## Verification
- `pnpm test:all`
- `node --input-type=module -e "import("./index.ts")"`