### PR TITLE
feat: inherit parent session provider for bare model ids

### DIFF
--- a/async-execution.ts
+++ b/async-execution.ts
@@ -11,6 +11,7 @@ import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import type { AgentConfig } from "./agents.js";
 import { applyThinkingSuffix } from "./pi-args.js";
+import { resolveModelFullId } from "./model-resolution.js";
 import { injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.js";
 import { isParallelStep, resolveStepBehavior, type ChainStep, type SequentialStep, type StepOverrides } from "./settings.js";
 import type { RunnerStep } from "./parallel-utils.js";
@@ -51,6 +52,7 @@ export interface AsyncExecutionContext {
 	pi: ExtensionAPI;
 	cwd: string;
 	currentSessionId: string;
+	currentModelProvider?: string;
 }
 
 export interface AsyncChainParams {
@@ -72,6 +74,7 @@ export interface AsyncSingleParams {
 	task: string;
 	agentConfig: AgentConfig;
 	ctx: AsyncExecutionContext;
+	modelOverride?: string;
 	cwd?: string;
 	maxOutput?: MaxOutputConfig;
 	artifactsDir?: string;
@@ -185,11 +188,13 @@ export function executeAsyncChain(
 		const outputPath = resolveSingleOutputPath(s.output, ctx.cwd, s.cwd ?? cwd);
 		const task = injectSingleOutputInstruction(s.task ?? "{previous}", outputPath);
 
+		const resolvedModel = resolveModelFullId(s.model ?? a.model, [], ctx.currentModelProvider);
+
 		return {
 			agent: s.agent,
 			task,
 			cwd: s.cwd,
-			model: applyThinkingSuffix(s.model ?? a.model, a.thinking),
+			model: applyThinkingSuffix(resolvedModel, a.thinking),
 			tools: a.tools,
 			extensions: a.extensions,
 			mcpDirectTools: a.mcpDirectTools,
@@ -322,6 +327,7 @@ export function executeAsyncSingle(
 		};
 	}
 
+	const resolvedModel = params.modelOverride ?? resolveModelFullId(agentConfig.model, [], ctx.currentModelProvider);
 	const runnerCwd = cwd ?? ctx.cwd;
 	const outputPath = resolveSingleOutputPath(params.output, ctx.cwd, cwd);
 	const taskWithOutputInstruction = injectSingleOutputInstruction(task, outputPath);
@@ -333,7 +339,7 @@ export function executeAsyncSingle(
 					agent,
 					task: taskWithOutputInstruction,
 					cwd,
-					model: applyThinkingSuffix(agentConfig.model, agentConfig.thinking),
+					model: applyThinkingSuffix(resolvedModel, agentConfig.thinking),
 					tools: agentConfig.tools,
 					extensions: agentConfig.extensions,
 					mcpDirectTools: agentConfig.mcpDirectTools,

--- a/chain-clarify.ts
+++ b/chain-clarify.ts
@@ -17,6 +17,7 @@ import type { TextEditorState } from "./text-editor.js";
 import { createEditorState, ensureCursorVisible, getCursorDisplayPos, handleEditorInput, renderEditor, wrapText } from "./text-editor.js";
 import { updateFrontmatterField } from "./agent-serializer.js";
 import { serializeChain } from "./chain-serializer.js";
+import { resolveModelFullId } from "./model-resolution.js";
 
 /** Clarify TUI mode */
 export type ClarifyMode = 'single' | 'parallel' | 'chain';
@@ -102,6 +103,7 @@ export class ChainClarifyComponent implements Component {
 		private chainDir: string | undefined,  // undefined for single/parallel modes
 		private resolvedBehaviors: ResolvedStepBehavior[],
 		private availableModels: ModelInfo[],
+		private preferredProvider: string | undefined,
 		private availableSkills: Array<{ name: string; source: string; description?: string }>,
 		private done: (result: ChainClarifyResult) => void,
 		private mode: ClarifyMode = 'chain',   // Mode: 'single', 'parallel', or 'chain'
@@ -253,23 +255,7 @@ export class ChainClarifyComponent implements Component {
 
 	/** Resolve a model name to its full provider/model format */
 	private resolveModelFullId(modelName: string): string {
-		// If already in provider/model format, return as-is
-		if (modelName.includes("/")) return modelName;
-		
-		// Handle thinking level suffixes (e.g., "claude-sonnet-4-5:high")
-		// Strip the suffix for lookup, then add it back
-		const colonIdx = modelName.lastIndexOf(":");
-		const baseModel = colonIdx !== -1 ? modelName.substring(0, colonIdx) : modelName;
-		const thinkingSuffix = colonIdx !== -1 ? modelName.substring(colonIdx) : "";
-		
-		// Look up base model in available models to find provider
-		const match = this.availableModels.find(m => m.id === baseModel);
-		if (match) {
-			return thinkingSuffix ? `${match.fullId}${thinkingSuffix}` : match.fullId;
-		}
-		
-		// Fallback to just the model name if not found
-		return modelName;
+		return resolveModelFullId(modelName, this.availableModels, this.preferredProvider) ?? modelName;
 	}
 
 	/** Update a behavior override for a step */

--- a/chain-execution.ts
+++ b/chain-execution.ts
@@ -8,6 +8,7 @@ import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { AgentConfig } from "./agents.js";
 import { ChainClarifyComponent, type ChainClarifyResult, type BehaviorOverride, type ModelInfo } from "./chain-clarify.js";
+import { resolveModelFullId } from "./model-resolution.js";
 import {
 	resolveChainTemplates,
 	createChainDir,
@@ -47,23 +48,6 @@ import {
 	type SingleResult,
 	MAX_CONCURRENCY,
 } from "./types.js";
-
-/** Resolve a model name to its full provider/model format */
-function resolveModelFullId(modelName: string | undefined, availableModels: ModelInfo[]): string | undefined {
-	if (!modelName) return undefined;
-	if (modelName.includes("/")) return modelName;
-
-	const colonIdx = modelName.lastIndexOf(":");
-	const baseModel = colonIdx !== -1 ? modelName.substring(0, colonIdx) : modelName;
-	const thinkingSuffix = colonIdx !== -1 ? modelName.substring(colonIdx) : "";
-
-	const match = availableModels.find((m) => m.id === baseModel);
-	if (match) {
-		return thinkingSuffix ? `${match.fullId}${thinkingSuffix}` : match.fullId;
-	}
-
-	return modelName;
-}
 
 interface ChainExecutionDetailsInput {
 	results: SingleResult[];
@@ -189,8 +173,8 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 
 			const taskAgentConfig = input.agents.find((agent) => agent.name === task.agent);
 			const effectiveModel =
-				(task.model ? resolveModelFullId(task.model, input.availableModels) : null)
-				?? resolveModelFullId(taskAgentConfig?.model, input.availableModels);
+				(task.model ? resolveModelFullId(task.model, input.availableModels, input.ctx.model?.provider) : null)
+				?? resolveModelFullId(taskAgentConfig?.model, input.availableModels, input.ctx.model?.provider);
 
 			const taskCwd = input.worktreeSetup
 				? input.worktreeSetup.worktrees[taskIndex]!.agentCwd
@@ -379,6 +363,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					chainDir,
 					resolvedBehaviors,
 					availableModels,
+					ctx.model?.provider,
 					availableSkills,
 					done,
 				),
@@ -625,8 +610,8 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			// Resolve model: TUI override (already full format) or agent's model resolved to full format
 			const effectiveModel =
 				tuiOverride?.model
-				?? (seqStep.model ? resolveModelFullId(seqStep.model, availableModels) : null)
-				?? resolveModelFullId(agentConfig.model, availableModels);
+				?? (seqStep.model ? resolveModelFullId(seqStep.model, availableModels, ctx.model?.provider) : null)
+				?? resolveModelFullId(agentConfig.model, availableModels, ctx.model?.provider);
 
 			// Run step
 			const r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {

--- a/model-resolution.ts
+++ b/model-resolution.ts
@@ -1,0 +1,33 @@
+import type { ModelInfo } from "./chain-clarify.js";
+
+/**
+ * Resolve a model name to provider/model format.
+ *
+ * Behavior:
+ * - Full provider/model IDs are returned as-is.
+ * - Bare model IDs prefer the parent session's current provider when available.
+ * - If no preferred provider is available, fall back to the first registry match.
+ */
+export function resolveModelFullId(
+	modelName: string | undefined,
+	availableModels: ModelInfo[] = [],
+	preferredProvider?: string,
+): string | undefined {
+	if (!modelName) return undefined;
+	if (modelName.includes("/")) return modelName;
+
+	const colonIdx = modelName.lastIndexOf(":");
+	const baseModel = colonIdx !== -1 ? modelName.substring(0, colonIdx) : modelName;
+	const thinkingSuffix = colonIdx !== -1 ? modelName.substring(colonIdx) : "";
+
+	if (preferredProvider) {
+		return `${preferredProvider}/${baseModel}${thinkingSuffix}`;
+	}
+
+	const match = availableModels.find((m) => m.id === baseModel);
+	if (match) {
+		return `${match.fullId}${thinkingSuffix}`;
+	}
+
+	return modelName;
+}

--- a/pi-args.ts
+++ b/pi-args.ts
@@ -4,6 +4,13 @@ import * as path from "node:path";
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
 const TASK_ARG_LIMIT = 8000;
+const MULTI_PASS_BASE_PROVIDERS = new Set([
+	"anthropic",
+	"openai-codex",
+	"github-copilot",
+	"google-gemini-cli",
+	"google-antigravity",
+]);
 
 export interface BuildPiArgsInput {
 	baseArgs: string[];
@@ -34,6 +41,18 @@ export function applyThinkingSuffix(model: string | undefined, thinking: string 
 	return `${model}:${thinking}`;
 }
 
+function getRequiredProviderExtensions(modelArg: string | undefined): string[] {
+	if (!modelArg) return [];
+	const slashIdx = modelArg.indexOf("/");
+	if (slashIdx === -1) return [];
+	const provider = modelArg.substring(0, slashIdx);
+	const match = provider.match(/^(.*)-(\d+)$/);
+	if (!match) return [];
+	const baseProvider = match[1];
+	if (!baseProvider || !MULTI_PASS_BASE_PROVIDERS.has(baseProvider)) return [];
+	return ["npm:pi-multi-pass"];
+}
+
 export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	const args = [...input.baseArgs];
 
@@ -51,12 +70,17 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 
 	const modelArg = applyThinkingSuffix(input.model, input.thinking);
 	if (modelArg) {
-		// Use --models (not --model) because pi CLI silently ignores --model
-		// without a companion --provider flag. --models resolves the provider
-		// automatically via resolveModelScope. See: #8
-		args.push("--models", modelArg);
+		if (modelArg.includes("/")) {
+			// Full provider/model IDs are accepted directly by pi's --model flag.
+			args.push("--model", modelArg);
+		} else {
+			// Last-resort fallback when no provider is available.
+			// In normal subagent execution we prefer resolving to provider/model first.
+			args.push("--models", modelArg);
+		}
 	}
 
+	const requiredProviderExtensions = getRequiredProviderExtensions(modelArg);
 	const toolExtensionPaths: string[] = [];
 	if (input.tools?.length) {
 		const builtinTools: string[] = [];
@@ -74,7 +98,11 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 
 	if (input.extensions !== undefined) {
 		args.push("--no-extensions");
-		for (const extPath of input.extensions) {
+		const extensionSpecs = [...input.extensions];
+		for (const extPath of requiredProviderExtensions) {
+			if (!extensionSpecs.includes(extPath)) extensionSpecs.push(extPath);
+		}
+		for (const extPath of extensionSpecs) {
 			args.push("--extension", extPath);
 		}
 	} else {

--- a/subagent-executor.ts
+++ b/subagent-executor.ts
@@ -6,6 +6,7 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { type AgentConfig, type AgentScope } from "./agents.js";
 import { getArtifactsDir } from "./artifacts.js";
 import { ChainClarifyComponent, type ChainClarifyResult, type ModelInfo } from "./chain-clarify.js";
+import { resolveModelFullId } from "./model-resolution.js";
 import { executeChain } from "./chain-execution.js";
 import { resolveExecutionAgentScope } from "./agent-scope.js";
 import { handleManagementAction } from "./agent-management.js";
@@ -361,7 +362,12 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		};
 	}
 	const id = randomUUID();
-	const asyncCtx = { pi: deps.pi, cwd: ctx.cwd, currentSessionId: deps.state.currentSessionId! };
+	const asyncCtx = {
+		pi: deps.pi,
+		cwd: ctx.cwd,
+		currentSessionId: deps.state.currentSessionId!,
+		currentModelProvider: ctx.model?.provider,
+	};
 
 	if (hasChain && params.chain) {
 		const normalized = normalizeSkillInput(params.skill);
@@ -395,11 +401,18 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const effectiveOutput: string | false | undefined = rawOutput === true ? a.output : (rawOutput as string | false | undefined);
 		const normalizedSkills = normalizeSkillInput(params.skill);
 		const skills = normalizedSkills === false ? [] : normalizedSkills;
+		const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map((m) => ({
+			provider: m.provider,
+			id: m.id,
+			fullId: `${m.provider}/${m.id}`,
+		}));
+		const modelOverride = resolveModelFullId((params.model as string | undefined) ?? a.model, availableModels, ctx.model?.provider);
 		return executeAsyncSingle(id, {
 			agent: params.agent!,
 			task: params.context === "fork" ? wrapForkTask(params.task!) : params.task!,
 			agentConfig: a,
 			ctx: asyncCtx,
+			modelOverride,
 			cwd: params.cwd,
 			maxOutput: params.maxOutput,
 			artifactsDir: artifactConfig.enabled ? artifactsDir : undefined,
@@ -462,7 +475,12 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			};
 		}
 		const id = randomUUID();
-		const asyncCtx = { pi: deps.pi, cwd: ctx.cwd, currentSessionId: deps.state.currentSessionId! };
+		const asyncCtx = {
+			pi: deps.pi,
+			cwd: ctx.cwd,
+			currentSessionId: deps.state.currentSessionId!,
+			currentModelProvider: ctx.model?.provider,
+		};
 		const asyncChain = wrapChainTasksForFork(chainResult.requestedAsync.chain, params.context);
 		return executeAsyncChain(id, {
 			chain: asyncChain,
@@ -658,19 +676,22 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		if (worktreeTaskCwdError) return buildParallelModeError(worktreeTaskCwdError);
 	}
 
+	const currentProvider = ctx.model?.provider;
+	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map((m) => ({
+		provider: m.provider,
+		id: m.id,
+		fullId: `${m.provider}/${m.id}`,
+	}));
+
 	let taskTexts = tasks.map((t) => t.task);
-	const modelOverrides: (string | undefined)[] = tasks.map((t) => t.model);
+	const modelOverrides: (string | undefined)[] = tasks.map((t, i) =>
+		resolveModelFullId(t.model ?? agentConfigs[i]?.model, availableModels, currentProvider),
+	);
 	const skillOverrides: (string[] | false | undefined)[] = tasks.map((t) =>
 		normalizeSkillInput(t.skill),
 	);
 
 	if (params.clarify === true && ctx.hasUI) {
-		const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map((m) => ({
-			provider: m.provider,
-			id: m.id,
-			fullId: `${m.provider}/${m.id}`,
-		}));
-
 		const behaviors = agentConfigs.map((c, i) =>
 			resolveStepBehavior(c, { skills: skillOverrides[i] }),
 		);
@@ -686,6 +707,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 					undefined,
 					behaviors,
 					availableModels,
+					currentProvider,
 					availableSkills,
 					done,
 					"parallel",
@@ -713,7 +735,12 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				};
 			}
 			const id = randomUUID();
-			const asyncCtx = { pi: deps.pi, cwd: ctx.cwd, currentSessionId: deps.state.currentSessionId! };
+			const asyncCtx = {
+				pi: deps.pi,
+				cwd: ctx.cwd,
+				currentSessionId: deps.state.currentSessionId!,
+				currentModelProvider: ctx.model?.provider,
+			};
 			const parallelTasks = tasks.map((t, i) => ({
 				agent: t.agent,
 				task: params.context === "fork" ? wrapForkTask(taskTexts[i]!) : taskTexts[i]!,
@@ -845,19 +872,24 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		};
 	}
 
+	const currentProvider = ctx.model?.provider;
+	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map((m) => ({
+		provider: m.provider,
+		id: m.id,
+		fullId: `${m.provider}/${m.id}`,
+	}));
+
 	let task = params.task!;
-	let modelOverride: string | undefined = params.model as string | undefined;
+	let modelOverride: string | undefined = resolveModelFullId(
+		(params.model as string | undefined) ?? agentConfig.model,
+		availableModels,
+		currentProvider,
+	);
 	let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
 	const rawOutput = params.output !== undefined ? params.output : agentConfig.output;
 	let effectiveOutput: string | false | undefined = rawOutput === true ? agentConfig.output : (rawOutput as string | false | undefined);
 
 	if (params.clarify === true && ctx.hasUI) {
-		const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map((m) => ({
-			provider: m.provider,
-			id: m.id,
-			fullId: `${m.provider}/${m.id}`,
-		}));
-
 		const behavior = resolveStepBehavior(agentConfig, { output: effectiveOutput, skills: skillOverride });
 		const availableSkills = discoverAvailableSkills(ctx.cwd);
 
@@ -871,6 +903,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 					undefined,
 					[behavior],
 					availableModels,
+					currentProvider,
 					availableSkills,
 					done,
 					"single",
@@ -897,12 +930,18 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				};
 			}
 			const id = randomUUID();
-			const asyncCtx = { pi: deps.pi, cwd: ctx.cwd, currentSessionId: deps.state.currentSessionId! };
+			const asyncCtx = {
+				pi: deps.pi,
+				cwd: ctx.cwd,
+				currentSessionId: deps.state.currentSessionId!,
+				currentModelProvider: ctx.model?.provider,
+			};
 			return executeAsyncSingle(id, {
 				agent: params.agent!,
 				task: params.context === "fork" ? wrapForkTask(task) : task,
 				agentConfig,
 				ctx: asyncCtx,
+				modelOverride,
 				cwd: params.cwd,
 				maxOutput: params.maxOutput,
 				artifactsDir: artifactConfig.enabled ? artifactsDir : undefined,


### PR DESCRIPTION
## Problem

   When agent configs use bare model IDs like `claude-sonnet-4-5`, subagents do not consistently
 inherit the parent session provider.

   In practice, this can make subagent execution depend on registry order or generic CLI model
 resolution, and it also forces users to hardcode `provider/model` in every agent definition.

   ## Change

   This PR centralizes model resolution and makes bare model IDs default to the parent session
 provider while preserving the original model name.

   Examples:
   - agent model: `claude-sonnet-4-5`
   - parent session provider: `github-copilot`
   - resolved subagent model: `github-copilot/claude-sonnet-4-5`

   Explicit fully-qualified model IDs such as `anthropic/claude-sonnet-4-5` are preserved as-is.

   The resolution is now applied consistently across:
   - single execution
   - parallel execution
   - chain execution
   - clarify/TUI flow
   - async/background execution

   ## Why this is better

   - keeps subagents aligned with the parent session provider by default
   - preserves agent-authored model names
   - reduces config duplication in agent files
   - makes agents more portable across providers
   - removes duplicated model resolution logic
   - makes behavior consistent across execution modes

   ## Implementation notes

   - added a centralized `model-resolution.ts`
   - switched to `--model` when a full `provider/model` ID is available
   - kept `--models` as a fallback when only a bare model ID is available
   - added required provider extension wiring for multi-pass providers

   ## Validation

   - `npm run test:unit`
   - `npm run test:integration`
   - `npm run test:e2e`