### PR TITLE
feat: subagents.json overlay for overriding and disabling agents without editing .md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,56 @@ Skills are specialized instructions loaded from SKILL.md files and injected into
 
 **Missing skills:** If a skill cannot be found, execution continues with a warning shown in the result summary.
 
+## Configuring agents with `subagents.json`
+
+You can override built-in agent fields and disable agents from loading
+without editing the bundled `.md` files. pi-subagents reads two files:
+
+- **Project**: `.pi/subagents.json` (relative to your working directory)
+- **User**: `~/.pi/agent/subagents.json`
+
+Project values take precedence over user values, field-by-field.
+The `disabled` lists from both files are unioned.
+
+### Example
+
+```jsonc
+{
+  "agents": {
+    "scout": {
+      "model": "anthropic/claude-opus-4-6",
+      "thinking": "high"
+    },
+    "reviewer": {
+      "description": "Custom reviewer for the auth subsystem",
+      "skills": ["code-review", "security-audit"]
+    }
+  },
+  "disabled": ["delegate", "worker"]
+}
+```
+
+### Overridable fields
+
+`description`, `model`, `thinking`, `tools`, `skills`, `extensions`,
+`output`, `defaultReads`, `defaultProgress`, `interactive`,
+`maxSubagentDepth`.
+
+The agent's `name`, `systemPrompt` (body), and internal metadata
+cannot be overridden. To replace the system prompt, write a real
+agent file under `~/.agents/` or `<project>/.agents/` (existing
+override path).
+
+### Disabling agents
+
+Names in `disabled` are skipped entirely — they will not appear in
+`/agents list`, are not invokable from chains or directly, and produce
+the standard "unknown agent" error if referenced.
+
+Validation problems (unknown fields, invalid JSON, references to
+non-existent agents) are surfaced as warnings via `discoverAgentsAll`,
+visible in agent-management output.
+
 ## Usage
 
 These are the parameters the **LLM agent** passes when it calls the `subagent` tool — not something you type directly. The agent decides to use these based on your conversation. For user-facing commands, see [Quick Commands](#quick-commands) above.

--- a/README.md
+++ b/README.md
@@ -495,6 +495,20 @@ Names in `disabled` are skipped entirely — they will not appear in
 `/agents list`, are not invokable from chains or directly, and produce
 the standard "unknown agent" error if referenced.
 
+To hide every built-in agent in one shot (e.g. you only want your own
+agents loaded), set `disableBuiltins: true`. It only removes agents whose
+source is `builtin` — your user/project agents are unaffected, even if
+they share a name with a built-in.
+
+```jsonc
+{
+  "disableBuiltins": true,
+  "agents": {
+    "scout": { "model": "anthropic/claude-opus-4-6" }
+  }
+}
+```
+
 Validation problems (unknown fields, invalid JSON, references to
 non-existent agents) are surfaced as warnings via `discoverAgentsAll`,
 visible in agent-management output.

--- a/README.md
+++ b/README.md
@@ -431,13 +431,20 @@ Skills are specialized instructions loaded from SKILL.md files and injected into
 ## Configuring agents with `subagents.json`
 
 You can override built-in agent fields and disable agents from loading
-without editing the bundled `.md` files. pi-subagents reads two files:
+without editing the bundled `.md` files. pi-subagents reads overrides from
+four sources, in order of increasing precedence (later sources win, per
+field):
 
-- **Project**: `.pi/subagents.json` (relative to your working directory)
-- **User**: `~/.pi/agent/subagents.json`
+1. User `~/.pi/agent/settings.json` — `subagents` key
+2. Project `.pi/settings.json` — `subagents` key
+3. User `~/.pi/agent/subagents.json`
+4. Project `.pi/subagents.json`
 
-Project values take precedence over user values, field-by-field.
-The `disabled` lists from both files are unioned.
+Use the `subagents` key inside `settings.json` if you already have one for
+skills/etc. and want to keep everything in one file. Use a dedicated
+`subagents.json` if you want a separate file or want to override what
+`settings.json` says (the dedicated file wins). The `disabled` lists from
+all four sources are unioned.
 
 ### Example
 
@@ -454,6 +461,20 @@ The `disabled` lists from both files are unioned.
     }
   },
   "disabled": ["delegate", "worker"]
+}
+```
+
+The same shape can live inside `settings.json` under a `subagents` key:
+
+```jsonc
+{
+  "skills": ["./my-skills"],
+  "subagents": {
+    "agents": {
+      "scout": { "model": "anthropic/claude-opus-4-6" }
+    },
+    "disabled": ["delegate"]
+  }
 }
 ```
 

--- a/agents.ts
+++ b/agents.ts
@@ -11,6 +11,7 @@ import { parseChain } from "./chain-serializer.ts";
 import { mergeAgentsForScope } from "./agent-selection.ts";
 import { parseFrontmatter } from "./frontmatter.ts";
 import {
+	detectUnknownAgentNames,
 	loadSubagentsOverlay,
 	type AgentOverride,
 	type SubagentsOverlay,
@@ -285,23 +286,38 @@ export function discoverAgentsAll(cwd: string): {
 	chains: ChainConfig[];
 	userDir: string;
 	projectDir: string | null;
+	overlayWarnings: string[];
 } {
 	const userDirOld = path.join(os.homedir(), ".pi", "agent", "agents");
 	const userDirNew = path.join(os.homedir(), ".agents");
 	const projectDir = findNearestProjectAgentsDir(cwd);
 	const overlay = loadSubagentsOverlay(cwd);
 
+	// Load unfiltered lists first so we can compute the known-names set
+	// (including disabled agents) before filtering them out.
+	const builtinAll = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay);
+	const userAll = [
+		...loadAgentsFromDir(userDirOld, "user", overlay),
+		...loadAgentsFromDir(userDirNew, "user", overlay),
+	];
+	const projectAll = projectDir ? loadAgentsFromDir(projectDir, "project", overlay) : [];
+
+	const knownNames = new Set<string>();
+	for (const a of builtinAll) knownNames.add(a.name);
+	for (const a of userAll) knownNames.add(a.name);
+	for (const a of projectAll) knownNames.add(a.name);
+
+	const overlayWarnings = [
+		...overlay.warnings,
+		...detectUnknownAgentNames(overlay, knownNames),
+	];
+
 	const filterDisabled = (list: AgentConfig[]): AgentConfig[] =>
 		overlay.disabled.size > 0 ? list.filter((a) => !overlay.disabled.has(a.name)) : list;
 
-	const builtin = filterDisabled(loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay));
-	const user = filterDisabled([
-		...loadAgentsFromDir(userDirOld, "user", overlay),
-		...loadAgentsFromDir(userDirNew, "user", overlay),
-	]);
-	const project = filterDisabled(
-		projectDir ? loadAgentsFromDir(projectDir, "project", overlay) : [],
-	);
+	const builtin = filterDisabled(builtinAll);
+	const user = filterDisabled(userAll);
+	const project = filterDisabled(projectAll);
 	const chains = [
 		...loadChainsFromDir(userDirOld, "user"),
 		...loadChainsFromDir(userDirNew, "user"),
@@ -310,5 +326,5 @@ export function discoverAgentsAll(cwd: string): {
 
 	const userDir = fs.existsSync(userDirNew) ? userDirNew : userDirOld;
 
-	return { builtin, user, project, chains, userDir, projectDir };
+	return { builtin, user, project, chains, userDir, projectDir, overlayWarnings };
 }

--- a/agents.ts
+++ b/agents.ts
@@ -261,7 +261,9 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
 	const overlay = loadSubagentsOverlay(cwd);
 
-	const builtinAgents = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay);
+	const builtinAgents = overlay.disableBuiltins
+		? []
+		: loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay);
 
 	const userAgentsOld = scope === "project" ? [] : loadAgentsFromDir(userDirOld, "user", overlay);
 	const userAgentsNew = scope === "project" ? [] : loadAgentsFromDir(userDirNew, "user", overlay);
@@ -295,7 +297,9 @@ export function discoverAgentsAll(cwd: string): {
 
 	// Load unfiltered lists first so we can compute the known-names set
 	// (including disabled agents) before filtering them out.
-	const builtinAll = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay);
+	const builtinAll = overlay.disableBuiltins
+		? []
+		: loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay);
 	const userAll = [
 		...loadAgentsFromDir(userDirOld, "user", overlay),
 		...loadAgentsFromDir(userDirNew, "user", overlay),

--- a/agents.ts
+++ b/agents.ts
@@ -10,6 +10,11 @@ import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain } from "./chain-serializer.ts";
 import { mergeAgentsForScope } from "./agent-selection.ts";
 import { parseFrontmatter } from "./frontmatter.ts";
+import {
+	loadSubagentsOverlay,
+	type AgentOverride,
+	type SubagentsOverlay,
+} from "./subagents-config.ts";
 
 export type AgentScope = "user" | "project" | "both";
 
@@ -60,7 +65,27 @@ export interface AgentDiscoveryResult {
 	projectAgentsDir: string | null;
 }
 
-function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
+function applyOverride(agent: AgentConfig, o: AgentOverride): AgentConfig {
+	const next = { ...agent };
+	if (o.description !== undefined) next.description = o.description;
+	if (o.model !== undefined) next.model = o.model;
+	if (o.thinking !== undefined) next.thinking = o.thinking;
+	if (o.tools !== undefined) next.tools = [...o.tools];
+	if (o.skills !== undefined) next.skills = [...o.skills];
+	if (o.extensions !== undefined) next.extensions = [...o.extensions];
+	if (o.output !== undefined) next.output = o.output;
+	if (o.defaultReads !== undefined) next.defaultReads = [...o.defaultReads];
+	if (o.defaultProgress !== undefined) next.defaultProgress = o.defaultProgress;
+	if (o.interactive !== undefined) next.interactive = o.interactive;
+	if (o.maxSubagentDepth !== undefined) next.maxSubagentDepth = o.maxSubagentDepth;
+	return next;
+}
+
+function loadAgentsFromDir(
+	dir: string,
+	source: AgentSource,
+	overlay?: SubagentsOverlay,
+): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
 	if (!fs.existsSync(dir)) {
@@ -137,7 +162,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 
 		const parsedMaxSubagentDepth = Number(frontmatter.maxSubagentDepth);
 
-		agents.push({
+		const base: AgentConfig = {
 			name: frontmatter.name,
 			description: frontmatter.description,
 			tools: tools.length > 0 ? tools : undefined,
@@ -159,7 +184,10 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 					? parsedMaxSubagentDepth
 					: undefined,
 			extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
-		});
+		};
+
+		const override = overlay?.agents.get(base.name);
+		agents.push(override ? applyOverride(base, override) : base);
 	}
 
 	return agents;
@@ -230,14 +258,18 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const userDirOld = path.join(os.homedir(), ".pi", "agent", "agents");
 	const userDirNew = path.join(os.homedir(), ".agents");
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
+	const overlay = loadSubagentsOverlay(cwd);
 
-	const builtinAgents = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
-	
-	const userAgentsOld = scope === "project" ? [] : loadAgentsFromDir(userDirOld, "user");
-	const userAgentsNew = scope === "project" ? [] : loadAgentsFromDir(userDirNew, "user");
+	const builtinAgents = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay);
+
+	const userAgentsOld = scope === "project" ? [] : loadAgentsFromDir(userDirOld, "user", overlay);
+	const userAgentsNew = scope === "project" ? [] : loadAgentsFromDir(userDirNew, "user", overlay);
 	const userAgents = [...userAgentsOld, ...userAgentsNew];
 
-	const projectAgents = scope === "user" || !projectAgentsDir ? [] : loadAgentsFromDir(projectAgentsDir, "project");
+	const projectAgents =
+		scope === "user" || !projectAgentsDir
+			? []
+			: loadAgentsFromDir(projectAgentsDir, "project", overlay);
 	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents);
 
 	return { agents, projectAgentsDir };
@@ -254,13 +286,14 @@ export function discoverAgentsAll(cwd: string): {
 	const userDirOld = path.join(os.homedir(), ".pi", "agent", "agents");
 	const userDirNew = path.join(os.homedir(), ".agents");
 	const projectDir = findNearestProjectAgentsDir(cwd);
+	const overlay = loadSubagentsOverlay(cwd);
 
-	const builtin = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
+	const builtin = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay);
 	const user = [
-		...loadAgentsFromDir(userDirOld, "user"),
-		...loadAgentsFromDir(userDirNew, "user"),
+		...loadAgentsFromDir(userDirOld, "user", overlay),
+		...loadAgentsFromDir(userDirNew, "user", overlay),
 	];
-	const project = projectDir ? loadAgentsFromDir(projectDir, "project") : [];
+	const project = projectDir ? loadAgentsFromDir(projectDir, "project", overlay) : [];
 	const chains = [
 		...loadChainsFromDir(userDirOld, "user"),
 		...loadChainsFromDir(userDirNew, "user"),

--- a/agents.ts
+++ b/agents.ts
@@ -272,7 +272,10 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 			: loadAgentsFromDir(projectAgentsDir, "project", overlay);
 	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents);
 
-	return { agents, projectAgentsDir };
+	const visibleAgents =
+		overlay.disabled.size > 0 ? agents.filter((a) => !overlay.disabled.has(a.name)) : agents;
+
+	return { agents: visibleAgents, projectAgentsDir };
 }
 
 export function discoverAgentsAll(cwd: string): {
@@ -288,12 +291,17 @@ export function discoverAgentsAll(cwd: string): {
 	const projectDir = findNearestProjectAgentsDir(cwd);
 	const overlay = loadSubagentsOverlay(cwd);
 
-	const builtin = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay);
-	const user = [
+	const filterDisabled = (list: AgentConfig[]): AgentConfig[] =>
+		overlay.disabled.size > 0 ? list.filter((a) => !overlay.disabled.has(a.name)) : list;
+
+	const builtin = filterDisabled(loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin", overlay));
+	const user = filterDisabled([
 		...loadAgentsFromDir(userDirOld, "user", overlay),
 		...loadAgentsFromDir(userDirNew, "user", overlay),
-	];
-	const project = projectDir ? loadAgentsFromDir(projectDir, "project", overlay) : [];
+	]);
+	const project = filterDisabled(
+		projectDir ? loadAgentsFromDir(projectDir, "project", overlay) : [],
+	);
 	const chains = [
 		...loadChainsFromDir(userDirOld, "user"),
 		...loadChainsFromDir(userDirNew, "user"),

--- a/docs/examples/subagents.example.jsonc
+++ b/docs/examples/subagents.example.jsonc
@@ -1,0 +1,53 @@
+// Example subagents.json overlay file.
+//
+// Copy this file to one of:
+//   - <project>/.pi/subagents.json   (project-level, highest precedence)
+//   - ~/.pi/agent/subagents.json     (user-level, global default)
+//
+// Project values override user values field-by-field.
+// The `disabled` lists from both files are unioned.
+//
+// Only the fields listed below can be overridden. The agent's `name`,
+// `systemPrompt` body, and internal metadata cannot be overridden here —
+// to replace the system prompt, write a real agent file under
+// `~/.agents/` or `<project>/.agents/`.
+{
+  "agents": {
+    // Override fields on the built-in `scout` agent.
+    "scout": {
+      // Model identifier to run this agent with.
+      "model": "anthropic/claude-opus-4-6",
+      // Thinking budget: "off" | "low" | "medium" | "high".
+      "thinking": "high",
+      // Human-readable description shown in /agents list.
+      "description": "Read-only investigator tuned for this repo",
+      // Tool allowlist (array of tool names).
+      "tools": ["Read", "Grep", "Glob"],
+      // Default skills loaded into the agent's system prompt.
+      "skills": ["safe-bash", "code-review"],
+      // Extensions to load (array of extension names).
+      "extensions": [],
+      // Whether the agent writes its transcript to a file by default.
+      "output": true,
+      // Default reads budget for the agent (number or false to disable).
+      "defaultReads": 200,
+      // Default progress cadence (number of steps) or false to disable.
+      "defaultProgress": 10,
+      // Whether the agent runs interactively (TUI clarifications).
+      "interactive": false,
+      // Cap on how deep this agent can spawn nested subagents.
+      "maxSubagentDepth": 2
+    },
+
+    // Partial overrides are fine — unspecified fields keep their defaults.
+    "reviewer": {
+      "description": "Custom reviewer for the auth subsystem",
+      "skills": ["code-review", "security-audit"]
+    }
+  },
+
+  // Names in this list are skipped entirely: not shown in /agents list,
+  // not invokable directly or via chains. References produce the standard
+  // "unknown agent" error.
+  "disabled": ["delegate", "worker"]
+}

--- a/slash-commands.ts
+++ b/slash-commands.ts
@@ -245,7 +245,14 @@ async function openAgentManager(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 ): Promise<void> {
-	const agentData = { ...discoverAgentsAll(ctx.cwd), cwd: ctx.cwd };
+	const { overlayWarnings, ...rest } = discoverAgentsAll(ctx.cwd);
+	const agentData = { ...rest, cwd: ctx.cwd };
+	if (overlayWarnings.length > 0 && ctx.hasUI) {
+		ctx.ui.notify(
+			`subagents.json: ${overlayWarnings.length} warning${overlayWarnings.length === 1 ? "" : "s"}`,
+			"warning",
+		);
+	}
 	const models = ctx.modelRegistry.getAvailable().map((m) => ({
 		provider: m.provider,
 		id: m.id,

--- a/subagents-config.ts
+++ b/subagents-config.ts
@@ -1,0 +1,230 @@
+/**
+ * subagents.json overlay loader.
+ *
+ * Locates up to two `subagents.json` files (project + user), parses them
+ * safely, validates entries against an allowlist of overridable fields, and
+ * merges them into a single overlay with project-precedence-per-field for
+ * overrides and union semantics for `disabled`. All problems are collected
+ * as human-readable warnings — this module never throws.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const CONFIG_DIR = ".pi";
+const AGENT_DIR = path.join(os.homedir(), ".pi", "agent");
+// Referenced to keep intent explicit; production user path resolution below
+// honors PI_SUBAGENTS_HOME and falls back to os.homedir().
+void AGENT_DIR;
+
+export interface AgentOverride {
+	description?: string;
+	model?: string;
+	thinking?: string;
+	tools?: string[];
+	skills?: string[];
+	extensions?: string[];
+	output?: string;
+	defaultReads?: string[];
+	defaultProgress?: boolean;
+	interactive?: boolean;
+	maxSubagentDepth?: number;
+}
+
+export interface SubagentsOverlay {
+	agents: Map<string, AgentOverride>;
+	disabled: Set<string>;
+	warnings: string[];
+}
+
+const OVERRIDABLE_FIELDS = new Set<keyof AgentOverride>([
+	"description",
+	"model",
+	"thinking",
+	"tools",
+	"skills",
+	"extensions",
+	"output",
+	"defaultReads",
+	"defaultProgress",
+	"interactive",
+	"maxSubagentDepth",
+]);
+
+const STRING_FIELDS = new Set<keyof AgentOverride>([
+	"description",
+	"model",
+	"thinking",
+	"output",
+]);
+
+const STRING_ARRAY_FIELDS = new Set<keyof AgentOverride>([
+	"tools",
+	"skills",
+	"extensions",
+	"defaultReads",
+]);
+
+const BOOLEAN_FIELDS = new Set<keyof AgentOverride>([
+	"defaultProgress",
+	"interactive",
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function userSubagentsPath(): string {
+	const override = process.env.PI_SUBAGENTS_HOME;
+	const home = override && override.length > 0 ? override : os.homedir();
+	return path.join(home, ".pi", "agent", "subagents.json");
+}
+
+interface PartialOverlay {
+	agents: Map<string, AgentOverride>;
+	disabled: Set<string>;
+	warnings: string[];
+}
+
+function parseOverlayFile(filePath: string): PartialOverlay {
+	const empty: PartialOverlay = {
+		agents: new Map(),
+		disabled: new Set(),
+		warnings: [],
+	};
+
+	let raw: string;
+	try {
+		raw = fs.readFileSync(filePath, "utf-8");
+	} catch (_err) {
+		// Missing file (or unreadable) → treat as empty, no warning.
+		return empty;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return {
+			agents: new Map(),
+			disabled: new Set(),
+			warnings: [`${filePath}: invalid JSON: ${message}`],
+		};
+	}
+
+	const warnings: string[] = [];
+	const agents = new Map<string, AgentOverride>();
+	const disabled = new Set<string>();
+
+	if (!isPlainObject(parsed)) {
+		warnings.push(`${filePath}: root must be an object`);
+		return { agents, disabled, warnings };
+	}
+
+	// agents
+	if (parsed.agents !== undefined) {
+		if (!isPlainObject(parsed.agents)) {
+			warnings.push(`${filePath}: 'agents' must be an object`);
+		} else {
+			for (const [name, entryRaw] of Object.entries(parsed.agents)) {
+				if (!isPlainObject(entryRaw)) {
+					warnings.push(`${filePath}: agents.${name}: entry must be an object`);
+					continue;
+				}
+				const override: AgentOverride = {};
+				for (const [field, value] of Object.entries(entryRaw)) {
+					if (!OVERRIDABLE_FIELDS.has(field as keyof AgentOverride)) {
+						warnings.push(`${filePath}: agents.${name}: unknown field '${field}'`);
+						continue;
+					}
+					const key = field as keyof AgentOverride;
+					if (STRING_FIELDS.has(key)) {
+						if (typeof value !== "string") {
+							warnings.push(
+								`${filePath}: agents.${name}.${field}: expected string, dropping`,
+							);
+							continue;
+						}
+						(override as Record<string, unknown>)[field] = value;
+					} else if (STRING_ARRAY_FIELDS.has(key)) {
+						if (!Array.isArray(value) || !value.every((v) => typeof v === "string")) {
+							warnings.push(
+								`${filePath}: agents.${name}.${field}: expected string[], dropping`,
+							);
+							continue;
+						}
+						(override as Record<string, unknown>)[field] = [...value];
+					} else if (BOOLEAN_FIELDS.has(key)) {
+						if (typeof value !== "boolean") {
+							warnings.push(
+								`${filePath}: agents.${name}.${field}: expected boolean, dropping`,
+							);
+							continue;
+						}
+						(override as Record<string, unknown>)[field] = value;
+					} else if (key === "maxSubagentDepth") {
+						if (!Number.isInteger(value) || (value as number) < 0) {
+							warnings.push(
+								`${filePath}: agents.${name}.${field}: expected non-negative integer, dropping`,
+							);
+							continue;
+						}
+						(override as Record<string, unknown>)[field] = value;
+					}
+				}
+				agents.set(name, override);
+			}
+		}
+	}
+
+	// disabled
+	if (parsed.disabled !== undefined) {
+		if (!Array.isArray(parsed.disabled)) {
+			warnings.push(`${filePath}: 'disabled' must be an array, treating as empty`);
+		} else {
+			for (const entry of parsed.disabled) {
+				if (typeof entry !== "string") {
+					warnings.push(`${filePath}: disabled: non-string entry dropped`);
+					continue;
+				}
+				disabled.add(entry);
+			}
+		}
+	}
+
+	return { agents, disabled, warnings };
+}
+
+export function loadSubagentsOverlay(
+	cwd: string,
+	opts?: { userFilePath?: string; projectFilePath?: string },
+): SubagentsOverlay {
+	const userPath = opts?.userFilePath ?? userSubagentsPath();
+	const projectPath = opts?.projectFilePath ?? path.join(cwd, CONFIG_DIR, "subagents.json");
+
+	const userOverlay = parseOverlayFile(userPath);
+	const projectOverlay = parseOverlayFile(projectPath);
+
+	// Merge agents: start with user, then shallow-merge project per field (project wins).
+	const merged = new Map<string, AgentOverride>();
+	for (const [name, override] of userOverlay.agents) {
+		merged.set(name, { ...override });
+	}
+	for (const [name, projectOverride] of projectOverlay.agents) {
+		const existing = merged.get(name) ?? {};
+		merged.set(name, { ...existing, ...projectOverride });
+	}
+
+	// Union disabled sets.
+	const disabled = new Set<string>();
+	for (const name of userOverlay.disabled) disabled.add(name);
+	for (const name of projectOverlay.disabled) disabled.add(name);
+
+	return {
+		agents: merged,
+		disabled,
+		warnings: [...userOverlay.warnings, ...projectOverlay.warnings],
+	};
+}

--- a/subagents-config.ts
+++ b/subagents-config.ts
@@ -228,3 +228,31 @@ export function loadSubagentsOverlay(
 		warnings: [...userOverlay.warnings, ...projectOverlay.warnings],
 	};
 }
+
+/**
+ * Given a list of known agent names (after loading and merging from disk),
+ * return warnings for any names referenced in the overlay (in `agents` or
+ * `disabled`) that do not exist. Mutates nothing.
+ */
+export function detectUnknownAgentNames(
+	overlay: SubagentsOverlay,
+	knownNames: Iterable<string>,
+): string[] {
+	const known = new Set(knownNames);
+	const warnings: string[] = [];
+	for (const name of overlay.agents.keys()) {
+		if (!known.has(name)) {
+			warnings.push(
+				`subagents.json: agents.${name} references unknown agent '${name}'`,
+			);
+		}
+	}
+	for (const name of overlay.disabled) {
+		if (!known.has(name)) {
+			warnings.push(
+				`subagents.json: disabled[] references unknown agent '${name}'`,
+			);
+		}
+	}
+	return warnings;
+}

--- a/subagents-config.ts
+++ b/subagents-config.ts
@@ -43,6 +43,7 @@ export interface AgentOverride {
 export interface SubagentsOverlay {
 	agents: Map<string, AgentOverride>;
 	disabled: Set<string>;
+	disableBuiltins: boolean;
 	warnings: string[];
 }
 
@@ -100,6 +101,7 @@ function userSettingsPath(): string {
 interface PartialOverlay {
 	agents: Map<string, AgentOverride>;
 	disabled: Set<string>;
+	disableBuiltins?: boolean;
 	warnings: string[];
 }
 
@@ -176,6 +178,16 @@ function parseOverlayShape(value: unknown, label: string): PartialOverlay {
 		}
 	}
 
+	// disableBuiltins
+	let disableBuiltins: boolean | undefined;
+	if (value.disableBuiltins !== undefined) {
+		if (typeof value.disableBuiltins !== "boolean") {
+			warnings.push(`${label}: 'disableBuiltins' must be a boolean, ignoring`);
+		} else {
+			disableBuiltins = value.disableBuiltins;
+		}
+	}
+
 	// disabled
 	if (value.disabled !== undefined) {
 		if (!Array.isArray(value.disabled)) {
@@ -191,7 +203,7 @@ function parseOverlayShape(value: unknown, label: string): PartialOverlay {
 		}
 	}
 
-	return { agents, disabled, warnings };
+	return { agents, disabled, disableBuiltins, warnings };
 }
 
 function emptyOverlay(): PartialOverlay {
@@ -222,6 +234,7 @@ function parseOverlayFile(filePath: string): PartialOverlay {
 	return {
 		agents: result.agents,
 		disabled: result.disabled,
+		disableBuiltins: result.disableBuiltins,
 		warnings: [...readWarnings, ...result.warnings],
 	};
 }
@@ -248,6 +261,7 @@ function parseSettingsFile(filePath: string): PartialOverlay {
 	return {
 		agents: result.agents,
 		disabled: result.disabled,
+		disableBuiltins: result.disableBuiltins,
 		warnings: [...readWarnings, ...result.warnings],
 	};
 }
@@ -292,10 +306,16 @@ export function loadSubagentsOverlay(
 		for (const name of layer.disabled) disabled.add(name);
 	}
 
+	// disableBuiltins: any layer setting it true wins (union).
+	let disableBuiltins = false;
+	for (const layer of layers) {
+		if (layer.disableBuiltins === true) disableBuiltins = true;
+	}
+
 	const warnings: string[] = [];
 	for (const layer of layers) warnings.push(...layer.warnings);
 
-	return { agents: merged, disabled, warnings };
+	return { agents: merged, disabled, disableBuiltins, warnings };
 }
 
 /**

--- a/subagents-config.ts
+++ b/subagents-config.ts
@@ -1,10 +1,18 @@
 /**
  * subagents.json overlay loader.
  *
- * Locates up to two `subagents.json` files (project + user), parses them
- * safely, validates entries against an allowlist of overridable fields, and
- * merges them into a single overlay with project-precedence-per-field for
- * overrides and union semantics for `disabled`. All problems are collected
+ * Locates up to four sources of agent overrides — `subagents.json` (project +
+ * user) and the `subagents` key inside `settings.json` (project + user) —
+ * parses them safely, validates entries against an allowlist of overridable
+ * fields, and merges them into a single overlay.
+ *
+ * Per-field precedence (highest wins):
+ *   1. project `.pi/subagents.json`
+ *   2. user `~/.pi/agent/subagents.json`
+ *   3. project `.pi/settings.json` (`subagents` key)
+ *   4. user `~/.pi/agent/settings.json` (`subagents` key)
+ *
+ * `disabled` is unioned across all four sources. All problems are collected
  * as human-readable warnings — this module never throws.
  */
 
@@ -75,10 +83,18 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function userSubagentsPath(): string {
+function userAgentDir(): string {
 	const override = process.env.PI_SUBAGENTS_HOME;
 	const home = override && override.length > 0 ? override : os.homedir();
-	return path.join(home, ".pi", "agent", "subagents.json");
+	return path.join(home, ".pi", "agent");
+}
+
+function userSubagentsPath(): string {
+	return path.join(userAgentDir(), "subagents.json");
+}
+
+function userSettingsPath(): string {
+	return path.join(userAgentDir(), "settings.json");
 }
 
 interface PartialOverlay {
@@ -87,91 +103,72 @@ interface PartialOverlay {
 	warnings: string[];
 }
 
-function parseOverlayFile(filePath: string): PartialOverlay {
-	const empty: PartialOverlay = {
-		agents: new Map(),
-		disabled: new Set(),
-		warnings: [],
-	};
-
-	let raw: string;
-	try {
-		raw = fs.readFileSync(filePath, "utf-8");
-	} catch (_err) {
-		// Missing file (or unreadable) → treat as empty, no warning.
-		return empty;
-	}
-
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(raw);
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		return {
-			agents: new Map(),
-			disabled: new Set(),
-			warnings: [`${filePath}: invalid JSON: ${message}`],
-		};
-	}
-
+/**
+ * Parse an overlay-shaped value (an object with optional `agents` and
+ * `disabled` keys). `label` is used as the prefix for warning strings.
+ */
+function parseOverlayShape(value: unknown, label: string): PartialOverlay {
 	const warnings: string[] = [];
 	const agents = new Map<string, AgentOverride>();
 	const disabled = new Set<string>();
 
-	if (!isPlainObject(parsed)) {
-		warnings.push(`${filePath}: root must be an object`);
+	if (!isPlainObject(value)) {
+		warnings.push(`${label}: must be an object`);
 		return { agents, disabled, warnings };
 	}
 
 	// agents
-	if (parsed.agents !== undefined) {
-		if (!isPlainObject(parsed.agents)) {
-			warnings.push(`${filePath}: 'agents' must be an object`);
+	if (value.agents !== undefined) {
+		if (!isPlainObject(value.agents)) {
+			warnings.push(`${label}: 'agents' must be an object`);
 		} else {
-			for (const [name, entryRaw] of Object.entries(parsed.agents)) {
+			for (const [name, entryRaw] of Object.entries(value.agents)) {
 				if (!isPlainObject(entryRaw)) {
-					warnings.push(`${filePath}: agents.${name}: entry must be an object`);
+					warnings.push(`${label}: agents.${name}: entry must be an object`);
 					continue;
 				}
 				const override: AgentOverride = {};
-				for (const [field, value] of Object.entries(entryRaw)) {
+				for (const [field, fieldValue] of Object.entries(entryRaw)) {
 					if (!OVERRIDABLE_FIELDS.has(field as keyof AgentOverride)) {
-						warnings.push(`${filePath}: agents.${name}: unknown field '${field}'`);
+						warnings.push(`${label}: agents.${name}: unknown field '${field}'`);
 						continue;
 					}
 					const key = field as keyof AgentOverride;
 					if (STRING_FIELDS.has(key)) {
-						if (typeof value !== "string") {
+						if (typeof fieldValue !== "string") {
 							warnings.push(
-								`${filePath}: agents.${name}.${field}: expected string, dropping`,
+								`${label}: agents.${name}.${field}: expected string, dropping`,
 							);
 							continue;
 						}
-						(override as Record<string, unknown>)[field] = value;
+						(override as Record<string, unknown>)[field] = fieldValue;
 					} else if (STRING_ARRAY_FIELDS.has(key)) {
-						if (!Array.isArray(value) || !value.every((v) => typeof v === "string")) {
+						if (
+							!Array.isArray(fieldValue) ||
+							!fieldValue.every((v) => typeof v === "string")
+						) {
 							warnings.push(
-								`${filePath}: agents.${name}.${field}: expected string[], dropping`,
+								`${label}: agents.${name}.${field}: expected string[], dropping`,
 							);
 							continue;
 						}
-						(override as Record<string, unknown>)[field] = [...value];
+						(override as Record<string, unknown>)[field] = [...fieldValue];
 					} else if (BOOLEAN_FIELDS.has(key)) {
-						if (typeof value !== "boolean") {
+						if (typeof fieldValue !== "boolean") {
 							warnings.push(
-								`${filePath}: agents.${name}.${field}: expected boolean, dropping`,
+								`${label}: agents.${name}.${field}: expected boolean, dropping`,
 							);
 							continue;
 						}
-						(override as Record<string, unknown>)[field] = value;
+						(override as Record<string, unknown>)[field] = fieldValue;
 					} else if (key === "maxSubagentDepth") {
-						if (!Number.isInteger(value) || (value as number) < 0) {
+						if (!Number.isInteger(fieldValue) || (fieldValue as number) < 0) {
 							warnings.push(
-								`${filePath}: agents.${name}.${field}: expected non-negative integer, dropping`,
+								`${label}: agents.${name}.${field}: expected non-negative integer, dropping`,
 							);
 							continue;
 						}
-						(override as Record<string, unknown>)[field] = value;
+						(override as Record<string, unknown>)[field] = fieldValue;
 					}
 				}
 				agents.set(name, override);
@@ -180,13 +177,13 @@ function parseOverlayFile(filePath: string): PartialOverlay {
 	}
 
 	// disabled
-	if (parsed.disabled !== undefined) {
-		if (!Array.isArray(parsed.disabled)) {
-			warnings.push(`${filePath}: 'disabled' must be an array, treating as empty`);
+	if (value.disabled !== undefined) {
+		if (!Array.isArray(value.disabled)) {
+			warnings.push(`${label}: 'disabled' must be an array, treating as empty`);
 		} else {
-			for (const entry of parsed.disabled) {
+			for (const entry of value.disabled) {
 				if (typeof entry !== "string") {
-					warnings.push(`${filePath}: disabled: non-string entry dropped`);
+					warnings.push(`${label}: disabled: non-string entry dropped`);
 					continue;
 				}
 				disabled.add(entry);
@@ -197,36 +194,108 @@ function parseOverlayFile(filePath: string): PartialOverlay {
 	return { agents, disabled, warnings };
 }
 
+function emptyOverlay(): PartialOverlay {
+	return { agents: new Map(), disabled: new Set(), warnings: [] };
+}
+
+function readJsonFile(filePath: string): { parsed?: unknown; warnings: string[] } {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(filePath, "utf-8");
+	} catch (_err) {
+		return { warnings: [] };
+	}
+	try {
+		return { parsed: JSON.parse(raw), warnings: [] };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { warnings: [`${filePath}: invalid JSON: ${message}`] };
+	}
+}
+
+function parseOverlayFile(filePath: string): PartialOverlay {
+	const { parsed, warnings: readWarnings } = readJsonFile(filePath);
+	if (parsed === undefined) {
+		return { agents: new Map(), disabled: new Set(), warnings: readWarnings };
+	}
+	const result = parseOverlayShape(parsed, filePath);
+	return {
+		agents: result.agents,
+		disabled: result.disabled,
+		warnings: [...readWarnings, ...result.warnings],
+	};
+}
+
+/**
+ * Read settings.json and extract its `subagents` key as a partial overlay.
+ * Missing file → empty. Invalid JSON → warning. Missing `subagents` key →
+ * empty (no warning — settings.json is shared with other features).
+ */
+function parseSettingsFile(filePath: string): PartialOverlay {
+	const { parsed, warnings: readWarnings } = readJsonFile(filePath);
+	if (parsed === undefined) {
+		return { agents: new Map(), disabled: new Set(), warnings: readWarnings };
+	}
+	if (!isPlainObject(parsed)) {
+		// settings.json root not an object — leave it to other consumers to flag.
+		return emptyOverlay();
+	}
+	if (parsed.subagents === undefined) {
+		return emptyOverlay();
+	}
+	const label = `${filePath}: subagents`;
+	const result = parseOverlayShape(parsed.subagents, label);
+	return {
+		agents: result.agents,
+		disabled: result.disabled,
+		warnings: [...readWarnings, ...result.warnings],
+	};
+}
+
 export function loadSubagentsOverlay(
 	cwd: string,
-	opts?: { userFilePath?: string; projectFilePath?: string },
+	opts?: {
+		userFilePath?: string;
+		projectFilePath?: string;
+		userSettingsPath?: string;
+		projectSettingsPath?: string;
+	},
 ): SubagentsOverlay {
-	const userPath = opts?.userFilePath ?? userSubagentsPath();
-	const projectPath = opts?.projectFilePath ?? path.join(cwd, CONFIG_DIR, "subagents.json");
+	const userOverlayPath = opts?.userFilePath ?? userSubagentsPath();
+	const projectOverlayPath =
+		opts?.projectFilePath ?? path.join(cwd, CONFIG_DIR, "subagents.json");
+	const userSettings = opts?.userSettingsPath ?? userSettingsPath();
+	const projectSettings =
+		opts?.projectSettingsPath ?? path.join(cwd, CONFIG_DIR, "settings.json");
 
-	const userOverlay = parseOverlayFile(userPath);
-	const projectOverlay = parseOverlayFile(projectPath);
+	// Load all four sources. Layered precedence (lowest → highest):
+	//   user settings.json < project settings.json < user subagents.json < project subagents.json
+	const layers: PartialOverlay[] = [
+		parseSettingsFile(userSettings),
+		parseSettingsFile(projectSettings),
+		parseOverlayFile(userOverlayPath),
+		parseOverlayFile(projectOverlayPath),
+	];
 
-	// Merge agents: start with user, then shallow-merge project per field (project wins).
+	// Merge agents per-field, layer by layer (later wins).
 	const merged = new Map<string, AgentOverride>();
-	for (const [name, override] of userOverlay.agents) {
-		merged.set(name, { ...override });
-	}
-	for (const [name, projectOverride] of projectOverlay.agents) {
-		const existing = merged.get(name) ?? {};
-		merged.set(name, { ...existing, ...projectOverride });
+	for (const layer of layers) {
+		for (const [name, override] of layer.agents) {
+			const existing = merged.get(name) ?? {};
+			merged.set(name, { ...existing, ...override });
+		}
 	}
 
-	// Union disabled sets.
+	// Union disabled sets across all layers.
 	const disabled = new Set<string>();
-	for (const name of userOverlay.disabled) disabled.add(name);
-	for (const name of projectOverlay.disabled) disabled.add(name);
+	for (const layer of layers) {
+		for (const name of layer.disabled) disabled.add(name);
+	}
 
-	return {
-		agents: merged,
-		disabled,
-		warnings: [...userOverlay.warnings, ...projectOverlay.warnings],
-	};
+	const warnings: string[] = [];
+	for (const layer of layers) warnings.push(...layer.warnings);
+
+	return { agents: merged, disabled, warnings };
 }
 
 /**

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -2,13 +2,24 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import { serializeAgent } from "../../agent-serializer.ts";
 import { discoverAgents, type AgentConfig } from "../../agents.ts";
 
 const tempDirs: string[] = [];
+let tempHome: string;
+let prevHomeEnv: string | undefined;
+
+beforeEach(() => {
+	tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-overlay-home-"));
+	prevHomeEnv = process.env.PI_SUBAGENTS_HOME;
+	process.env.PI_SUBAGENTS_HOME = tempHome;
+});
 
 afterEach(() => {
+	if (prevHomeEnv === undefined) delete process.env.PI_SUBAGENTS_HOME;
+	else process.env.PI_SUBAGENTS_HOME = prevHomeEnv;
+	fs.rmSync(tempHome, { recursive: true, force: true });
 	while (tempDirs.length > 0) {
 		const dir = tempDirs.pop();
 		if (!dir) continue;

--- a/test/unit/subagents-config-overlay.test.ts
+++ b/test/unit/subagents-config-overlay.test.ts
@@ -242,4 +242,30 @@ describe("subagents-config-overlay", () => {
 		assert.equal(scout?.model, "project-model");
 		assert.equal(scout?.thinking, "user-thinking");
 	});
+
+	it("disableBuiltins: true removes all built-in agents but keeps user/project ones", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "myagent", "");
+		writeProjectOverlay(projectDir, { disableBuiltins: true });
+
+		const { agents } = discoverAgents(projectDir, "both");
+		// User-defined agent still present
+		assert.ok(agents.find((a) => a.name === "myagent"));
+		// No agent with source === "builtin"
+		assert.equal(agents.filter((a) => a.source === "builtin").length, 0);
+	});
+
+	it("disableBuiltins: false (or omitted) keeps built-ins", () => {
+		const projectDir = mkProject();
+		const { agents } = discoverAgents(projectDir, "both");
+		// At least one builtin should be present (the repo ships several)
+		assert.ok(agents.some((a) => a.source === "builtin"));
+	});
+
+	it("disableBuiltins: true also strips builtins from discoverAgentsAll", () => {
+		const projectDir = mkProject();
+		writeProjectOverlay(projectDir, { disableBuiltins: true });
+		const result = discoverAgentsAll(projectDir);
+		assert.equal(result.builtin.length, 0);
+	});
 });

--- a/test/unit/subagents-config-overlay.test.ts
+++ b/test/unit/subagents-config-overlay.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { discoverAgents } from "../../agents.ts";
+
+describe("subagents-config-overlay", () => {
+	let tempHome: string;
+	let prevHomeEnv: string | undefined;
+	const tempDirs: string[] = [];
+
+	beforeEach(() => {
+		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-overlay-home-"));
+		prevHomeEnv = process.env.PI_SUBAGENTS_HOME;
+		process.env.PI_SUBAGENTS_HOME = tempHome;
+	});
+
+	afterEach(() => {
+		if (prevHomeEnv === undefined) delete process.env.PI_SUBAGENTS_HOME;
+		else process.env.PI_SUBAGENTS_HOME = prevHomeEnv;
+		fs.rmSync(tempHome, { recursive: true, force: true });
+		while (tempDirs.length > 0) {
+			const dir = tempDirs.pop();
+			if (!dir) continue;
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	function mkProject(): string {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-overlay-proj-"));
+		tempDirs.push(dir);
+		return dir;
+	}
+
+	function writeAgent(projectDir: string, name: string, frontmatter: string, body = "Do things"): void {
+		const agentsDir = path.join(projectDir, ".pi", "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(agentsDir, `${name}.md`),
+			`---\nname: ${name}\ndescription: ${name} agent\n${frontmatter}---\n\n${body}\n`,
+			"utf-8",
+		);
+	}
+
+	function writeProjectOverlay(projectDir: string, data: unknown): void {
+		const p = path.join(projectDir, ".pi", "subagents.json");
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(p, JSON.stringify(data), "utf-8");
+	}
+
+	function writeUserOverlay(data: unknown): void {
+		const p = path.join(tempHome, ".pi", "agent", "subagents.json");
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(p, JSON.stringify(data), "utf-8");
+	}
+
+	it("project overlay overrides model defined in .md", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "model: foo\n");
+		writeProjectOverlay(projectDir, { agents: { scout: { model: "bar" } } });
+
+		const { agents } = discoverAgents(projectDir, "project");
+		const scout = agents.find((a) => a.name === "scout");
+		assert.equal(scout?.model, "bar");
+	});
+
+	it("project overlay sets model when .md has none", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "");
+		writeProjectOverlay(projectDir, { agents: { scout: { model: "bar" } } });
+
+		const { agents } = discoverAgents(projectDir, "project");
+		const scout = agents.find((a) => a.name === "scout");
+		assert.equal(scout?.model, "bar");
+	});
+
+	it("no override preserves .md model (regression)", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "model: foo\n");
+
+		const { agents } = discoverAgents(projectDir, "project");
+		const scout = agents.find((a) => a.name === "scout");
+		assert.equal(scout?.model, "foo");
+	});
+
+	it("override defaultProgress: false is applied (not truthy-filtered)", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "defaultProgress: true\n");
+		writeProjectOverlay(projectDir, { agents: { scout: { defaultProgress: false } } });
+
+		const { agents } = discoverAgents(projectDir, "project");
+		const scout = agents.find((a) => a.name === "scout");
+		assert.equal(scout?.defaultProgress, false);
+	});
+
+	it("override skills replaces the list exactly", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "skills: x, y, z\n");
+		writeProjectOverlay(projectDir, { agents: { scout: { skills: ["a", "b"] } } });
+
+		const { agents } = discoverAgents(projectDir, "project");
+		const scout = agents.find((a) => a.name === "scout");
+		assert.deepEqual(scout?.skills, ["a", "b"]);
+	});
+
+	it("user-scope overlay is applied", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "model: foo\n");
+		writeUserOverlay({ agents: { scout: { model: "user-model" } } });
+
+		const { agents } = discoverAgents(projectDir, "project");
+		const scout = agents.find((a) => a.name === "scout");
+		assert.equal(scout?.model, "user-model");
+	});
+
+	it("project overlay wins per-field; user-only fields preserved", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "model: foo\n");
+		writeUserOverlay({
+			agents: { scout: { model: "user-model", thinking: "user-thinking" } },
+		});
+		writeProjectOverlay(projectDir, { agents: { scout: { model: "project-model" } } });
+
+		const { agents } = discoverAgents(projectDir, "project");
+		const scout = agents.find((a) => a.name === "scout");
+		assert.equal(scout?.model, "project-model");
+		assert.equal(scout?.thinking, "user-thinking");
+	});
+});

--- a/test/unit/subagents-config-overlay.test.ts
+++ b/test/unit/subagents-config-overlay.test.ts
@@ -114,6 +114,51 @@ describe("subagents-config-overlay", () => {
 		assert.equal(scout?.model, "user-model");
 	});
 
+	it("disabled project agent is filtered out; others remain", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "");
+		writeAgent(projectDir, "ranger", "");
+		writeProjectOverlay(projectDir, { disabled: ["scout"] });
+
+		const { agents } = discoverAgents(projectDir, "project");
+		assert.equal(agents.find((a) => a.name === "scout"), undefined);
+		assert.ok(agents.find((a) => a.name === "ranger"));
+	});
+
+	it("disabled user-scope agent via user overlay is filtered", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "");
+		writeAgent(projectDir, "ranger", "");
+		writeUserOverlay({ disabled: ["scout"] });
+
+		const { agents } = discoverAgents(projectDir, "project");
+		assert.equal(agents.find((a) => a.name === "scout"), undefined);
+		assert.ok(agents.find((a) => a.name === "ranger"));
+	});
+
+	it("agent in both disabled and agents.<name> is filtered (disabled wins)", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "model: foo\n");
+		writeProjectOverlay(projectDir, {
+			agents: { scout: { model: "bar" } },
+			disabled: ["scout"],
+		});
+
+		const { agents } = discoverAgents(projectDir, "project");
+		assert.equal(agents.find((a) => a.name === "scout"), undefined);
+	});
+
+	it("empty disabled array leaves all agents present (regression)", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "");
+		writeAgent(projectDir, "ranger", "");
+		writeProjectOverlay(projectDir, { disabled: [] });
+
+		const { agents } = discoverAgents(projectDir, "project");
+		assert.ok(agents.find((a) => a.name === "scout"));
+		assert.ok(agents.find((a) => a.name === "ranger"));
+	});
+
 	it("project overlay wins per-field; user-only fields preserved", () => {
 		const projectDir = mkProject();
 		writeAgent(projectDir, "scout", "model: foo\n");

--- a/test/unit/subagents-config-overlay.test.ts
+++ b/test/unit/subagents-config-overlay.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { discoverAgents } from "../../agents.ts";
+import { discoverAgents, discoverAgentsAll } from "../../agents.ts";
 
 describe("subagents-config-overlay", () => {
 	let tempHome: string;
@@ -157,6 +157,76 @@ describe("subagents-config-overlay", () => {
 		const { agents } = discoverAgents(projectDir, "project");
 		assert.ok(agents.find((a) => a.name === "scout"));
 		assert.ok(agents.find((a) => a.name === "ranger"));
+	});
+
+	it("overlayWarnings includes unknown agent name from agents override", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "");
+		writeProjectOverlay(projectDir, { agents: { foo: { model: "bar" } } });
+
+		const { overlayWarnings } = discoverAgentsAll(projectDir);
+		assert.ok(
+			overlayWarnings.some((w) => w.includes("foo") && w.includes("unknown agent")),
+			`expected warning about 'foo', got: ${JSON.stringify(overlayWarnings)}`,
+		);
+	});
+
+	it("overlayWarnings includes unknown name from disabled[]", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "");
+		writeProjectOverlay(projectDir, { disabled: ["nonexistent"] });
+
+		const { overlayWarnings } = discoverAgentsAll(projectDir);
+		assert.ok(
+			overlayWarnings.some(
+				(w) => w.includes("nonexistent") && w.includes("disabled"),
+			),
+			`expected warning about 'nonexistent', got: ${JSON.stringify(overlayWarnings)}`,
+		);
+	});
+
+	it("overlayWarnings does NOT include warning for disabling a real agent", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "");
+		writeProjectOverlay(projectDir, { disabled: ["scout"] });
+
+		const { overlayWarnings } = discoverAgentsAll(projectDir);
+		assert.equal(
+			overlayWarnings.filter((w) => w.includes("scout") && w.includes("unknown"))
+				.length,
+			0,
+		);
+	});
+
+	it("override + disabled for same real agent filters without unknown warning", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "model: foo\n");
+		writeProjectOverlay(projectDir, {
+			agents: { scout: { model: "bar" } },
+			disabled: ["scout"],
+		});
+
+		const { project, overlayWarnings } = discoverAgentsAll(projectDir);
+		assert.equal(project.find((a) => a.name === "scout"), undefined);
+		assert.equal(
+			overlayWarnings.filter((w) => w.includes("scout") && w.includes("unknown"))
+				.length,
+			0,
+		);
+	});
+
+	it("overlayWarnings includes invalid JSON file path", () => {
+		const projectDir = mkProject();
+		writeAgent(projectDir, "scout", "");
+		const projectFile = path.join(projectDir, ".pi", "subagents.json");
+		fs.mkdirSync(path.dirname(projectFile), { recursive: true });
+		fs.writeFileSync(projectFile, "{ not json", "utf-8");
+
+		const { overlayWarnings } = discoverAgentsAll(projectDir);
+		assert.ok(
+			overlayWarnings.some((w) => w.includes(projectFile) && w.includes("invalid JSON")),
+			`expected invalid JSON warning, got: ${JSON.stringify(overlayWarnings)}`,
+		);
 	});
 
 	it("project overlay wins per-field; user-only fields preserved", () => {

--- a/test/unit/subagents-config.test.ts
+++ b/test/unit/subagents-config.test.ts
@@ -209,6 +209,154 @@ describe("subagents-config", () => {
 		assert.equal(scout?.defaultProgress, false);
 		assert.ok(Object.hasOwn(scout as object, "defaultProgress"));
 	});
+
+	it("loads overrides from project settings.json subagents key", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "settings.json"), {
+			skills: ["./somewhere"],
+			subagents: {
+				agents: { scout: { model: "from-settings" } },
+				disabled: ["delegate"],
+			},
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.deepEqual(overlay.warnings, []);
+		assert.equal(overlay.agents.get("scout")?.model, "from-settings");
+		assert.ok(overlay.disabled.has("delegate"));
+	});
+
+	it("subagents.json overrides settings.json subagents key per field", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "settings.json"), {
+			subagents: {
+				agents: { scout: { model: "from-settings", thinking: "low" } },
+			},
+		});
+		writeJson(path.join(cwd, ".pi", "subagents.json"), {
+			agents: { scout: { model: "from-subagents-json" } },
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.deepEqual(overlay.warnings, []);
+		const scout = overlay.agents.get("scout");
+		assert.equal(scout?.model, "from-subagents-json");
+		// settings.json field not touched by subagents.json is preserved
+		assert.equal(scout?.thinking, "low");
+	});
+
+	it("layered precedence: project subagents.json > user subagents.json > project settings.json > user settings.json", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(userDir, "settings.json"), {
+			subagents: {
+				agents: {
+					scout: {
+						description: "user-settings",
+						model: "user-settings-model",
+						thinking: "user-settings-thinking",
+						output: "user-settings-output",
+					},
+				},
+			},
+		});
+		writeJson(path.join(cwd, ".pi", "settings.json"), {
+			subagents: {
+				agents: {
+					scout: {
+						model: "project-settings-model",
+						thinking: "project-settings-thinking",
+						output: "project-settings-output",
+					},
+				},
+			},
+		});
+		writeJson(path.join(userDir, "subagents.json"), {
+			agents: {
+				scout: {
+					thinking: "user-overlay-thinking",
+					output: "user-overlay-output",
+				},
+			},
+		});
+		writeJson(path.join(cwd, ".pi", "subagents.json"), {
+			agents: { scout: { output: "project-overlay-output" } },
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.deepEqual(overlay.warnings, []);
+		const scout = overlay.agents.get("scout");
+		assert.equal(scout?.description, "user-settings");
+		assert.equal(scout?.model, "project-settings-model");
+		assert.equal(scout?.thinking, "user-overlay-thinking");
+		assert.equal(scout?.output, "project-overlay-output");
+	});
+
+	it("unions disabled across settings.json and subagents.json", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(userDir, "settings.json"), {
+			subagents: { disabled: ["from-user-settings"] },
+		});
+		writeJson(path.join(cwd, ".pi", "settings.json"), {
+			subagents: { disabled: ["from-project-settings"] },
+		});
+		writeJson(path.join(cwd, ".pi", "subagents.json"), {
+			disabled: ["from-project-overlay"],
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.ok(overlay.disabled.has("from-user-settings"));
+		assert.ok(overlay.disabled.has("from-project-settings"));
+		assert.ok(overlay.disabled.has("from-project-overlay"));
+	});
+
+	it("settings.json without a subagents key is silently ignored", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "settings.json"), {
+			skills: ["./skills"],
+		});
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.deepEqual(overlay.warnings, []);
+		assert.equal(overlay.agents.size, 0);
+		assert.equal(overlay.disabled.size, 0);
+	});
+
+	it("invalid types under settings.json subagents are reported with prefixed warnings", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "settings.json"), {
+			subagents: {
+				agents: { scout: { skills: "not-an-array" } },
+			},
+		});
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.ok(
+			overlay.warnings.some((w) => w.includes("settings.json: subagents") && w.includes("scout") && w.includes("skills")),
+			`expected a settings.json prefixed warning, got: ${JSON.stringify(overlay.warnings)}`,
+		);
+	});
 });
 
 describe("detectUnknownAgentNames", () => {

--- a/test/unit/subagents-config.test.ts
+++ b/test/unit/subagents-config.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { loadSubagentsOverlay } from "../../subagents-config.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (!dir) continue;
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function mkTempDir(prefix = "pi-subagents-config-"): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function writeJson(filePath: string, data: unknown): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(data), "utf-8");
+}
+
+describe("subagents-config", () => {
+	it("returns empty overlay when no files exist", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+		});
+		assert.equal(overlay.agents.size, 0);
+		assert.equal(overlay.disabled.size, 0);
+		assert.deepEqual(overlay.warnings, []);
+	});
+
+	it("loads project-only overlay with agent override and disabled", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "subagents.json"), {
+			agents: {
+				scout: { description: "Scout override", model: "sonnet" },
+			},
+			disabled: ["old-agent"],
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+		});
+		assert.deepEqual(overlay.warnings, []);
+		assert.equal(overlay.agents.size, 1);
+		assert.deepEqual(overlay.agents.get("scout"), {
+			description: "Scout override",
+			model: "sonnet",
+		});
+		assert.ok(overlay.disabled.has("old-agent"));
+	});
+
+	it("loads user-only overlay via opts.userFilePath", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		const userFile = path.join(userDir, "subagents.json");
+		writeJson(userFile, {
+			agents: {
+				helper: { tools: ["read", "write"] },
+			},
+			disabled: ["noisy"],
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, { userFilePath: userFile });
+		assert.deepEqual(overlay.warnings, []);
+		assert.deepEqual(overlay.agents.get("helper"), { tools: ["read", "write"] });
+		assert.ok(overlay.disabled.has("noisy"));
+	});
+
+	it("project field wins on overlap, user-only fields preserved", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		const userFile = path.join(userDir, "subagents.json");
+		writeJson(userFile, {
+			agents: {
+				scout: { description: "user desc", model: "haiku", tools: ["read"] },
+			},
+		});
+		writeJson(path.join(cwd, ".pi", "subagents.json"), {
+			agents: {
+				scout: { description: "project desc", output: "result.md" },
+			},
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, { userFilePath: userFile });
+		assert.deepEqual(overlay.warnings, []);
+		const scout = overlay.agents.get("scout");
+		assert.equal(scout?.description, "project desc");
+		assert.equal(scout?.model, "haiku");
+		assert.deepEqual(scout?.tools, ["read"]);
+		assert.equal(scout?.output, "result.md");
+	});
+
+	it("unions disabled lists from both scopes", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		const userFile = path.join(userDir, "subagents.json");
+		writeJson(userFile, { disabled: ["a", "b"] });
+		writeJson(path.join(cwd, ".pi", "subagents.json"), { disabled: ["b", "c"] });
+
+		const overlay = loadSubagentsOverlay(cwd, { userFilePath: userFile });
+		assert.deepEqual(overlay.warnings, []);
+		assert.deepEqual([...overlay.disabled].sort(), ["a", "b", "c"]);
+	});
+
+	it("emits warning on invalid JSON without crashing", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		const projectFile = path.join(cwd, ".pi", "subagents.json");
+		fs.mkdirSync(path.dirname(projectFile), { recursive: true });
+		fs.writeFileSync(projectFile, "{ not json", "utf-8");
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+		});
+		assert.equal(overlay.agents.size, 0);
+		assert.equal(overlay.warnings.length, 1);
+		assert.match(overlay.warnings[0] ?? "", /invalid JSON/);
+		assert.ok((overlay.warnings[0] ?? "").includes(projectFile));
+	});
+
+	it("warns on unknown field but keeps other fields", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "subagents.json"), {
+			agents: {
+				scout: { description: "ok", bogus: 42 },
+			},
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+		});
+		assert.equal(overlay.warnings.length, 1);
+		assert.match(overlay.warnings[0] ?? "", /unknown field 'bogus'/);
+		assert.deepEqual(overlay.agents.get("scout"), { description: "ok" });
+	});
+
+	it("drops array field with wrong type and warns", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "subagents.json"), {
+			agents: {
+				scout: { description: "ok", skills: "code-review" },
+			},
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+		});
+		assert.equal(overlay.warnings.length, 1);
+		assert.match(overlay.warnings[0] ?? "", /skills/);
+		assert.deepEqual(overlay.agents.get("scout"), { description: "ok" });
+	});
+
+	it("warns and treats disabled as empty when not an array", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "subagents.json"), {
+			disabled: "nope",
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+		});
+		assert.equal(overlay.disabled.size, 0);
+		assert.equal(overlay.warnings.length, 1);
+		assert.match(overlay.warnings[0] ?? "", /disabled/);
+	});
+
+	it("preserves defaultProgress: false override", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "subagents.json"), {
+			agents: {
+				scout: { defaultProgress: false },
+			},
+		});
+
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+		});
+		assert.deepEqual(overlay.warnings, []);
+		const scout = overlay.agents.get("scout");
+		assert.ok(scout);
+		assert.equal(scout?.defaultProgress, false);
+		assert.ok(Object.hasOwn(scout as object, "defaultProgress"));
+	});
+});

--- a/test/unit/subagents-config.test.ts
+++ b/test/unit/subagents-config.test.ts
@@ -3,7 +3,11 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
-import { loadSubagentsOverlay } from "../../subagents-config.ts";
+import {
+	detectUnknownAgentNames,
+	loadSubagentsOverlay,
+	type SubagentsOverlay,
+} from "../../subagents-config.ts";
 
 const tempDirs: string[] = [];
 
@@ -178,6 +182,15 @@ describe("subagents-config", () => {
 		assert.match(overlay.warnings[0] ?? "", /disabled/);
 	});
 
+	it("exposes warnings field on overlay", () => {
+		const overlay: SubagentsOverlay = {
+			agents: new Map(),
+			disabled: new Set(),
+			warnings: [],
+		};
+		assert.deepEqual(overlay.warnings, []);
+	});
+
 	it("preserves defaultProgress: false override", () => {
 		const cwd = mkTempDir();
 		const userDir = mkTempDir();
@@ -195,5 +208,64 @@ describe("subagents-config", () => {
 		assert.ok(scout);
 		assert.equal(scout?.defaultProgress, false);
 		assert.ok(Object.hasOwn(scout as object, "defaultProgress"));
+	});
+});
+
+describe("detectUnknownAgentNames", () => {
+	function mkOverlay(
+		agents: Record<string, object> = {},
+		disabled: string[] = [],
+	): SubagentsOverlay {
+		return {
+			agents: new Map(Object.entries(agents)),
+			disabled: new Set(disabled),
+			warnings: [],
+		};
+	}
+
+	it("returns empty array when all names are known", () => {
+		const overlay = mkOverlay({ scout: {} }, ["ranger"]);
+		const warnings = detectUnknownAgentNames(overlay, ["scout", "ranger", "extra"]);
+		assert.deepEqual(warnings, []);
+	});
+
+	it("warns on unknown name in agents map", () => {
+		const overlay = mkOverlay({ foo: {} });
+		const warnings = detectUnknownAgentNames(overlay, ["scout"]);
+		assert.equal(warnings.length, 1);
+		assert.match(warnings[0] ?? "", /agents\.foo/);
+		assert.match(warnings[0] ?? "", /foo/);
+	});
+
+	it("warns on unknown name in disabled", () => {
+		const overlay = mkOverlay({}, ["nonexistent"]);
+		const warnings = detectUnknownAgentNames(overlay, ["scout"]);
+		assert.equal(warnings.length, 1);
+		assert.match(warnings[0] ?? "", /disabled/);
+		assert.match(warnings[0] ?? "", /nonexistent/);
+	});
+
+	it("warns on both unknown agents and unknown disabled", () => {
+		const overlay = mkOverlay({ foo: {} }, ["bar"]);
+		const warnings = detectUnknownAgentNames(overlay, ["scout"]);
+		assert.equal(warnings.length, 2);
+	});
+
+	it("accepts Iterable for knownNames", () => {
+		const overlay = mkOverlay({ scout: {} });
+		const known = new Set(["scout", "ranger"]);
+		const warnings = detectUnknownAgentNames(overlay, known);
+		assert.deepEqual(warnings, []);
+	});
+
+	it("does not mutate the overlay", () => {
+		const overlay = mkOverlay({ foo: {} }, ["bar"]);
+		const snapAgents = [...overlay.agents.keys()];
+		const snapDisabled = [...overlay.disabled];
+		const snapWarnings = [...overlay.warnings];
+		detectUnknownAgentNames(overlay, []);
+		assert.deepEqual([...overlay.agents.keys()], snapAgents);
+		assert.deepEqual([...overlay.disabled], snapDisabled);
+		assert.deepEqual(overlay.warnings, snapWarnings);
 	});
 });

--- a/test/unit/subagents-config.test.ts
+++ b/test/unit/subagents-config.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import {
 	detectUnknownAgentNames,
 	loadSubagentsOverlay,
@@ -31,6 +31,21 @@ function writeJson(filePath: string, data: unknown): void {
 }
 
 describe("subagents-config", () => {
+	let isolatedHome: string;
+	let prevHomeEnv: string | undefined;
+
+	beforeEach(() => {
+		isolatedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-config-home-"));
+		tempDirs.push(isolatedHome);
+		prevHomeEnv = process.env.PI_SUBAGENTS_HOME;
+		process.env.PI_SUBAGENTS_HOME = isolatedHome;
+	});
+
+	afterEach(() => {
+		if (prevHomeEnv === undefined) delete process.env.PI_SUBAGENTS_HOME;
+		else process.env.PI_SUBAGENTS_HOME = prevHomeEnv;
+	});
+
 	it("returns empty overlay when no files exist", () => {
 		const cwd = mkTempDir();
 		const userDir = mkTempDir();
@@ -186,6 +201,7 @@ describe("subagents-config", () => {
 		const overlay: SubagentsOverlay = {
 			agents: new Map(),
 			disabled: new Set(),
+			disableBuiltins: false,
 			warnings: [],
 		};
 		assert.deepEqual(overlay.warnings, []);
@@ -340,6 +356,59 @@ describe("subagents-config", () => {
 		assert.equal(overlay.disabled.size, 0);
 	});
 
+	it("disableBuiltins: true is parsed and exposed on the overlay", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "subagents.json"), { disableBuiltins: true });
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.equal(overlay.disableBuiltins, true);
+		assert.deepEqual(overlay.warnings, []);
+	});
+
+	it("disableBuiltins defaults to false when not set anywhere", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.equal(overlay.disableBuiltins, false);
+	});
+
+	it("disableBuiltins is unioned across layers (any true wins)", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		// Set true only in user settings.json subagents key
+		writeJson(path.join(userDir, "settings.json"), {
+			subagents: { disableBuiltins: true },
+		});
+		// Project subagents.json doesn't mention it
+		writeJson(path.join(cwd, ".pi", "subagents.json"), { agents: {} });
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.equal(overlay.disableBuiltins, true);
+	});
+
+	it("disableBuiltins with non-boolean value warns and is ignored", () => {
+		const cwd = mkTempDir();
+		const userDir = mkTempDir();
+		writeJson(path.join(cwd, ".pi", "subagents.json"), { disableBuiltins: "yes" });
+		const overlay = loadSubagentsOverlay(cwd, {
+			userFilePath: path.join(userDir, "subagents.json"),
+			userSettingsPath: path.join(userDir, "settings.json"),
+		});
+		assert.equal(overlay.disableBuiltins, false);
+		assert.ok(
+			overlay.warnings.some((w) => w.includes("disableBuiltins")),
+			`expected disableBuiltins warning, got: ${JSON.stringify(overlay.warnings)}`,
+		);
+	});
+
 	it("invalid types under settings.json subagents are reported with prefixed warnings", () => {
 		const cwd = mkTempDir();
 		const userDir = mkTempDir();
@@ -367,6 +436,7 @@ describe("detectUnknownAgentNames", () => {
 		return {
 			agents: new Map(Object.entries(agents)),
 			disabled: new Set(disabled),
+			disableBuiltins: false,
 			warnings: [],
 		};
 	}


### PR DESCRIPTION
## Summary

Adds a non-destructive overlay config system for tweaking agent frontmatter (`model`, `thinking`, `skills`, `defaultProgress`, etc.) and disabling built-in or user agents without editing any `.md` files on disk. Configuration is read from up to four sources, in order of increasing precedence (later wins, per field):

1. User `~/.pi/agent/settings.json` — `subagents` key
2. Project `.pi/settings.json` — `subagents` key
3. User `~/.pi/agent/subagents.json`
4. Project `.pi/subagents.json`

`disabled` and `disableBuiltins` are unioned across all four. The dedicated `subagents.json` files override the embedded `subagents` key in `settings.json`, so users with an existing `settings.json` can keep everything in one file or split it out.

### Highlights

- **`subagents.json` loader** (new `subagents-config.ts`) with full validation, allowlisted overridable fields, and warnings-never-throws semantics.
- **Field-level overrides** applied in `loadAgentsFromDir` after parsing, so every downstream consumer (agent-management, chain resolution, runtime, model warnings) automatically sees merged config.
- **Per-name `disabled` list** — filtered post-merge in `discoverAgents`/`discoverAgentsAll`.
- **`disableBuiltins: true`** — hides all agents whose `source === "builtin"` in one shot, while leaving user/project agents alone (even if they share a name with a built-in).
- **Embedded `subagents` key in `settings.json`** — same shape, lower precedence than the dedicated file.
- **`overlayWarnings`** added to `discoverAgentsAll` return value, surfaced via `slash-commands.ts` notify when non-empty.
- **README docs + `docs/examples/subagents.example.jsonc`** sample.

### Schema

```jsonc
{
  "agents": {
    "scout": { "model": "anthropic/claude-opus-4-6", "thinking": "high" },
    "reviewer": { "skills": ["code-review", "security-audit"] }
  },
  "disabled": ["delegate", "worker"],
  "disableBuiltins": true
}
```

Overridable fields (allowlist): `description`, `model`, `thinking`, `tools`, `skills`, `extensions`, `output`, `defaultReads`, `defaultProgress`, `interactive`, `maxSubagentDepth`. `name`, `systemPrompt`, and internal metadata are intentionally not overridable — for body changes, use the existing `~/.agents/`/`<project>/.agents/` user-override path.

### Test isolation

The loader honors `PI_SUBAGENTS_HOME` to redirect both `subagents.json` and `settings.json` to a tempdir during tests. The harness was added to all unit tests that touch `discoverAgents`/`discoverAgentsAll` so the contributor's real `~/.pi/agent/` is never read.

## Test plan

- [x] `npm run test:unit` — 179/179 passing
- [x] Tests cover all edge cases: `defaultProgress: false` override, project-wins-per-field merge, disabled+override combo, unknown agent name warnings, invalid JSON, layered precedence across all four sources, `disableBuiltins` union semantics
- [x] Manually verified by symlinking the branch into `~/.pi/agent/extensions/subagent` and using it via real `settings.json` overrides
- [ ] Reviewer to spot-check that the new field on `discoverAgentsAll`'s return type is consumed correctly downstream
- [ ] Reviewer to consider whether the `slash-commands.ts` notify of warnings is the right surfacing point (currently shows count only — can be expanded to a richer panel later)