### PR TITLE
Expose stable chainId and chainDir on chain execution events

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,8 @@ Each chain run creates `<tmpdir>/pi-chain-runs/{runId}/` containing:
 
 Directories older than 24 hours are cleaned up on extension startup.
 
+For slash-command driven chain runs, `subagent:slash:started` and `subagent:slash:response` now include optional `chainId` and `chainDir` fields. `chainId` reuses the stable request/run identifier, and `chainDir` points at the shared chain artifacts directory so downstream tooling can bind to the active chain deterministically.
+
 ## Artifacts
 
 Location: `{sessionDir}/subagent-artifacts/` or `<tmpdir>/pi-subagent-artifacts/`

--- a/settings.ts
+++ b/settings.ts
@@ -9,6 +9,10 @@ import type { AgentConfig } from "./agents.ts";
 import { normalizeSkillInput } from "./skills.ts";
 
 const CHAIN_RUNS_DIR = path.join(os.tmpdir(), "pi-chain-runs");
+
+export function resolveChainDirPath(runId: string, baseDir?: string): string {
+	return path.join(baseDir ? path.resolve(baseDir) : CHAIN_RUNS_DIR, runId);
+}
 const CHAIN_DIR_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 // =============================================================================
@@ -92,7 +96,7 @@ export function getStepAgents(step: ChainStep): string[] {
 // =============================================================================
 
 export function createChainDir(runId: string, baseDir?: string): string {
-	const chainDir = path.join(baseDir ? path.resolve(baseDir) : CHAIN_RUNS_DIR, runId);
+	const chainDir = resolveChainDirPath(runId, baseDir);
 	fs.mkdirSync(chainDir, { recursive: true });
 	return chainDir;
 }

--- a/slash-bridge.ts
+++ b/slash-bridge.ts
@@ -9,6 +9,7 @@ import {
 	SLASH_SUBAGENT_UPDATE_EVENT,
 	type Details,
 } from "./types.js";
+import { resolveChainDirPath } from "./settings.js";
 
 export interface SlashSubagentRequest {
 	requestId: string;
@@ -17,6 +18,8 @@ export interface SlashSubagentRequest {
 
 export interface SlashSubagentResponse {
 	requestId: string;
+	chainId?: string;
+	chainDir?: string;
 	result: AgentToolResult<Details>;
 	isError: boolean;
 	errorText?: string;
@@ -27,6 +30,11 @@ export interface SlashSubagentUpdate {
 	progress?: Details["progress"];
 	currentTool?: string;
 	toolCount?: number;
+}
+
+interface SlashChainMetadata {
+	chainId?: string;
+	chainDir?: string;
 }
 
 interface EventBus {
@@ -53,6 +61,14 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
 	const controllers = new Map<string, AbortController>();
 	const pendingCancels = new Set<string>();
 	const subscriptions: Array<() => void> = [];
+
+	const getChainMetadata = (requestId: string, params: SubagentParamsLike): SlashChainMetadata => {
+		if (!params.chain || params.chain.length === 0) return {};
+		return {
+			chainId: requestId,
+			chainDir: resolveChainDirPath(requestId, params.chainDir),
+		};
+	};
 
 	const subscribe = (event: string, handler: (data: unknown) => void): void => {
 		const unsubscribe = options.events.on(event, handler);
@@ -81,6 +97,7 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
 		if (!ctx) {
 			const response: SlashSubagentResponse = {
 				requestId,
+				...getChainMetadata(requestId, params),
 				result: {
 					content: [{ type: "text", text: "No active extension context for slash subagent execution." }],
 					details: { mode: "single" as const, results: [] },
@@ -99,6 +116,7 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
 			controller.abort();
 			const response: SlashSubagentResponse = {
 				requestId,
+				...getChainMetadata(requestId, params),
 				result: {
 					content: [{ type: "text", text: "Cancelled." }],
 					details: { mode: "single" as const, results: [] },
@@ -111,7 +129,7 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
 			return;
 		}
 
-		options.events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId });
+		options.events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId, ...getChainMetadata(requestId, params) });
 
 		try {
 			const result = await options.execute(
@@ -134,6 +152,7 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
 
 			const response: SlashSubagentResponse = {
 				requestId,
+				...getChainMetadata(requestId, params),
 				result,
 				isError: (result as { isError?: boolean }).isError === true,
 				errorText: (result as { isError?: boolean }).isError
@@ -144,6 +163,7 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
 		} catch (error) {
 			const response: SlashSubagentResponse = {
 				requestId,
+				...getChainMetadata(requestId, params),
 				result: {
 					content: [{ type: "text", text: error instanceof Error ? error.message : String(error) }],
 					details: { mode: "single" as const, results: [] },

--- a/test/integration/slash-bridge.test.ts
+++ b/test/integration/slash-bridge.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { registerSlashSubagentBridge } from "../../slash-bridge.ts";
+import { resolveChainDirPath } from "../../settings.ts";
+import {
+	SLASH_SUBAGENT_REQUEST_EVENT,
+	SLASH_SUBAGENT_RESPONSE_EVENT,
+	SLASH_SUBAGENT_STARTED_EVENT,
+	type Details,
+} from "../../types.ts";
+
+class FakeEvents {
+	private handlers = new Map<string, Array<(data: unknown) => void>>();
+	
+	on(event: string, handler: (data: unknown) => void): () => void {
+		const handlers = this.handlers.get(event) ?? [];
+		handlers.push(handler);
+		this.handlers.set(event, handlers);
+		return () => {
+			const current = this.handlers.get(event) ?? [];
+			this.handlers.set(event, current.filter((entry) => entry !== handler));
+		};
+	}
+	
+	emit(event: string, data: unknown): void {
+		for (const handler of this.handlers.get(event) ?? []) {
+			handler(data);
+		}
+	}
+}
+
+function once(events: FakeEvents, event: string): Promise<unknown> {
+	return new Promise((resolve) => {
+		const off = events.on(event, (data) => {
+			off();
+			resolve(data);
+		});
+	});
+}
+
+describe("slash bridge chain metadata", () => {
+	afterEach(() => {
+		for (const entry of fs.readdirSync(os.tmpdir())) {
+			if (entry.startsWith("pi-chain-runs-test-")) {
+				fs.rmSync(path.join(os.tmpdir(), entry), { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("emits chainId and chainDir on started and response events for chain runs", async () => {
+		const events = new FakeEvents();
+		const chainBase = fs.mkdtempSync(path.join(os.tmpdir(), "pi-chain-runs-test-"));
+		const requestId = "req-chain-123";
+		const expectedDir = resolveChainDirPath(requestId, chainBase);
+		const bridge = registerSlashSubagentBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }) as never,
+			execute: async () => {
+				fs.mkdirSync(expectedDir, { recursive: true });
+				fs.writeFileSync(path.join(expectedDir, "context.md"), "scout output\n");
+				return {
+					content: [{ type: "text", text: "done" }],
+					details: { mode: "chain", results: [] } satisfies Details,
+				};
+			},
+		});
+
+		const startedPromise = once(events, SLASH_SUBAGENT_STARTED_EVENT);
+		const responsePromise = once(events, SLASH_SUBAGENT_RESPONSE_EVENT);
+
+		events.emit(SLASH_SUBAGENT_REQUEST_EVENT, {
+			requestId,
+			params: {
+				chain: [{ agent: "worker", task: "do work" }],
+				chainDir: chainBase,
+			},
+		});
+
+		const started = await startedPromise as { requestId: string; chainId?: string; chainDir?: string };
+		assert.equal(started.requestId, requestId);
+		assert.equal(started.chainId, requestId);
+		assert.equal(started.chainDir, expectedDir);
+
+		const response = await responsePromise as { requestId: string; chainId?: string; chainDir?: string; isError: boolean };
+		assert.equal(response.requestId, requestId);
+		assert.equal(response.chainId, requestId);
+		assert.equal(response.chainDir, expectedDir);
+		assert.equal(response.isError, false);
+		assert.equal(fs.existsSync(expectedDir), true);
+		assert.equal(fs.existsSync(path.join(expectedDir, "context.md")), true);
+
+		bridge.dispose();
+	});
+});


### PR DESCRIPTION
## Summary
Adds optional `chainId` and `chainDir` fields to the `subagent:slash:started`
and `subagent:slash:response` event payloads so downstream tooling can
deterministically bind to the active chain run instead of scanning tempdirs.

## Problem
Callers today can infer the active chain directory only by scanning
`<tmpdir>/pi-chain-runs/*` for recent artifacts, which:
- races on concurrent runs
- cannot distinguish between overlapping bestOfN / consensus flows
- forces downstream tooling into filesystem locks and `unverified` fallbacks
  to avoid silent-wrong-answer modes

## Change
- Reuse the existing slash `requestId` as a stable `chainId`
- Add a pure `resolveChainDirPath(runId, baseDir?)` helper so the bridge can
  derive the shared artifact directory without side effects
- Include both as **optional** fields on the existing started/response payloads
- Document the new fields in the README

## Backwards compatibility
Both new fields are marked optional. No breaking changes to the existing
event surface, types, or handler contracts.

## Tests
- New integration test asserts `started` and `response` events carry `chainId`
  and `chainDir`, and that `chainDir` points at a real directory after
  execution
- `npm run test:unit`
- `npm run test:integration`

## Notes
- `npm run test:e2e` currently fails on upstream `main` in this environment due
  a test harness mismatch (`session.agent.setTools is not a function`); this PR
  does not change the e2e surface.
- `package.json` declares `license: MIT`, though there is no separate `LICENSE`
  file in the repo root.

## Why now
Downstream consumers currently ship workaround code (filesystem locks,
ambiguity rejection, explicit `unverified` gate outcomes) that exists only to
paper over this gap. Exposing a stable identifier removes the need for that
consumer-side complexity.
