### PR TITLE
feat: support disabling builtin agents via settings.json

### DIFF
--- a/agent-manager.ts
+++ b/agent-manager.ts
@@ -115,7 +115,7 @@ export class AgentManagerComponent implements Component {
 
 	private loadEntries(): void {
 		const overridden = new Set([...this.agentData.user, ...this.agentData.project].map((c) => c.name));
-		const agents: AgentEntry[] = []; for (const config of this.agentData.builtin) { if (!overridden.has(config.name)) agents.push({ id: `a${this.nextId++}`, kind: "agent", config: cloneConfig(config), isNew: false }); } for (const config of this.agentData.user) agents.push({ id: `a${this.nextId++}`, kind: "agent", config: cloneConfig(config), isNew: false }); for (const config of this.agentData.project) agents.push({ id: `a${this.nextId++}`, kind: "agent", config: cloneConfig(config), isNew: false }); this.agents = agents;
+		const agents: AgentEntry[] = []; for (const config of this.agentData.builtin) { if (!overridden.has(config.name) && config.disabled !== true) agents.push({ id: `a${this.nextId++}`, kind: "agent", config: cloneConfig(config), isNew: false }); } for (const config of this.agentData.user) agents.push({ id: `a${this.nextId++}`, kind: "agent", config: cloneConfig(config), isNew: false }); for (const config of this.agentData.project) agents.push({ id: `a${this.nextId++}`, kind: "agent", config: cloneConfig(config), isNew: false }); this.agents = agents;
 		const chains: ChainEntry[] = []; for (const config of this.agentData.chains) chains.push({ id: `c${this.nextId++}`, kind: "chain", config: cloneChainConfig(config) }); this.chains = chains;
 	}
 

--- a/agents.ts
+++ b/agents.ts
@@ -23,6 +23,7 @@ export interface BuiltinAgentOverrideBase {
 	skills?: string[];
 	tools?: string[];
 	mcpDirectTools?: string[];
+	disabled?: boolean;
 }
 
 export interface BuiltinAgentOverrideConfig {
@@ -32,6 +33,7 @@ export interface BuiltinAgentOverrideConfig {
 	systemPrompt?: string;
 	skills?: string[] | false;
 	tools?: string[] | false;
+	disabled?: boolean;
 }
 
 export interface BuiltinAgentOverrideInfo {
@@ -58,6 +60,7 @@ export interface AgentConfig {
 	defaultProgress?: boolean;
 	interactive?: boolean;
 	maxSubagentDepth?: number;
+	disabled?: boolean;
 	extraFields?: Record<string, string>;
 	override?: BuiltinAgentOverrideInfo;
 }
@@ -129,6 +132,7 @@ function cloneOverrideBase(agent: AgentConfig): BuiltinAgentOverrideBase {
 		skills: agent.skills ? [...agent.skills] : undefined,
 		tools: agent.tools ? [...agent.tools] : undefined,
 		mcpDirectTools: agent.mcpDirectTools ? [...agent.mcpDirectTools] : undefined,
+		disabled: agent.disabled,
 	};
 }
 
@@ -142,6 +146,7 @@ function cloneOverrideValue(override: BuiltinAgentOverrideConfig): BuiltinAgentO
 		...(override.systemPrompt !== undefined ? { systemPrompt: override.systemPrompt } : {}),
 		...(override.skills !== undefined ? { skills: override.skills === false ? false : [...override.skills] } : {}),
 		...(override.tools !== undefined ? { tools: override.tools === false ? false : [...override.tools] } : {}),
+		...(override.disabled !== undefined ? { disabled: override.disabled } : {}),
 	};
 }
 
@@ -212,23 +217,69 @@ function parseBuiltinOverrideEntry(value: unknown): BuiltinAgentOverrideConfig |
 	const tools = parseStringArrayOrFalse(input.tools);
 	if (tools !== undefined) override.tools = tools;
 
+	if (typeof input.disabled === "boolean") override.disabled = input.disabled;
+
 	return Object.keys(override).length > 0 ? override : undefined;
 }
 
-function readBuiltinOverrides(filePath: string | null): Record<string, BuiltinAgentOverrideConfig> {
-	if (!filePath || !fs.existsSync(filePath)) return {};
+interface SubagentsSettings {
+	overrides: Record<string, BuiltinAgentOverrideConfig>;
+	disableBuiltins: boolean | undefined;
+}
+
+const EMPTY_SUBAGENTS_SETTINGS: SubagentsSettings = { overrides: {}, disableBuiltins: undefined };
+
+function readSubagentsSettings(filePath: string | null): SubagentsSettings {
+	if (!filePath || !fs.existsSync(filePath)) return EMPTY_SUBAGENTS_SETTINGS;
 	const settings = readSettingsFileStrict(filePath);
 	const subagents = settings.subagents;
-	if (!subagents || typeof subagents !== "object" || Array.isArray(subagents)) return {};
-	const agentOverrides = (subagents as Record<string, unknown>).agentOverrides;
-	if (!agentOverrides || typeof agentOverrides !== "object" || Array.isArray(agentOverrides)) return {};
-
-	const parsed: Record<string, BuiltinAgentOverrideConfig> = {};
-	for (const [name, value] of Object.entries(agentOverrides)) {
-		const override = parseBuiltinOverrideEntry(value);
-		if (override) parsed[name] = override;
+	if (!subagents || typeof subagents !== "object" || Array.isArray(subagents)) {
+		return EMPTY_SUBAGENTS_SETTINGS;
 	}
-	return parsed;
+	const subagentsObj = subagents as Record<string, unknown>;
+
+	const overrides: Record<string, BuiltinAgentOverrideConfig> = {};
+	const agentOverrides = subagentsObj.agentOverrides;
+	if (agentOverrides && typeof agentOverrides === "object" && !Array.isArray(agentOverrides)) {
+		for (const [name, value] of Object.entries(agentOverrides)) {
+			const override = parseBuiltinOverrideEntry(value);
+			if (override) overrides[name] = override;
+		}
+	}
+
+	const disableBuiltins = typeof subagentsObj.disableBuiltins === "boolean"
+		? subagentsObj.disableBuiltins
+		: undefined;
+
+	return { overrides, disableBuiltins };
+}
+
+// Kept as a thin alias for call sites that only care about overrides.
+function readBuiltinOverrides(filePath: string | null): Record<string, BuiltinAgentOverrideConfig> {
+	return readSubagentsSettings(filePath).overrides;
+}
+
+/**
+ * Resolve the effective `disableBuiltins` source for the current scope.
+ *
+ * Project scope wins if it explicitly sets the flag (`true` or `false`).
+ * Otherwise user scope applies. Returns the scope + settings path used to
+ * attribute the synthetic `disabled` override on each builtin, or `null` when
+ * no bulk disable is active.
+ */
+function computeBulkDisableSource(
+	userFlag: boolean | undefined,
+	projectFlag: boolean | undefined,
+	userSettingsPath: string,
+	projectSettingsPath: string | null,
+): { scope: "user" | "project"; path: string } | null {
+	if (projectFlag !== undefined && projectSettingsPath) {
+		return projectFlag ? { scope: "project", path: projectSettingsPath } : null;
+	}
+	if (userFlag === true) {
+		return { scope: "user", path: userSettingsPath };
+	}
+	return null;
 }
 
 function applyBuiltinOverride(
@@ -253,6 +304,7 @@ function applyBuiltinOverride(
 		next.tools = tools;
 		next.mcpDirectTools = mcpDirectTools;
 	}
+	if (override.disabled !== undefined) next.disabled = override.disabled;
 
 	return next;
 }
@@ -263,6 +315,7 @@ function applyBuiltinOverrides(
 	projectOverrides: Record<string, BuiltinAgentOverrideConfig>,
 	userSettingsPath: string,
 	projectSettingsPath: string | null,
+	bulkDisableSource: { scope: "user" | "project"; path: string } | null = null,
 ): AgentConfig[] {
 	return builtinAgents.map((agent) => {
 		const projectOverride = projectOverrides[agent.name];
@@ -275,13 +328,17 @@ function applyBuiltinOverrides(
 			return applyBuiltinOverride(agent, userOverride, { scope: "user", path: userSettingsPath });
 		}
 
+		if (bulkDisableSource) {
+			return applyBuiltinOverride(agent, { disabled: true }, bulkDisableSource);
+		}
+
 		return agent;
 	});
 }
 
 export function buildBuiltinOverrideConfig(
 	base: BuiltinAgentOverrideBase,
-	draft: Pick<AgentConfig, "model" | "fallbackModels" | "thinking" | "systemPrompt" | "skills" | "tools" | "mcpDirectTools">,
+	draft: Pick<AgentConfig, "model" | "fallbackModels" | "thinking" | "systemPrompt" | "skills" | "tools" | "mcpDirectTools" | "disabled">,
 ): BuiltinAgentOverrideConfig | undefined {
 	const override: BuiltinAgentOverrideConfig = {};
 
@@ -294,6 +351,10 @@ export function buildBuiltinOverrideConfig(
 	const baseTools = joinToolList(base);
 	const draftTools = joinToolList(draft);
 	if (!arraysEqual(draftTools, baseTools)) override.tools = draftTools ? [...draftTools] : false;
+
+	if (draft.disabled !== base.disabled && draft.disabled !== undefined) {
+		override.disabled = draft.disabled;
+	}
 
 	return Object.keys(override).length > 0 ? override : undefined;
 }
@@ -516,12 +577,22 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const userSettingsPath = getUserAgentSettingsPath();
 	const projectSettingsPath = getProjectAgentSettingsPath(cwd);
 
-	const builtinAgents = applyBuiltinOverrides(
-		loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin"),
-		scope === "project" ? {} : readBuiltinOverrides(userSettingsPath),
-		scope === "user" ? {} : readBuiltinOverrides(projectSettingsPath),
+	const userSettings = scope === "project" ? EMPTY_SUBAGENTS_SETTINGS : readSubagentsSettings(userSettingsPath);
+	const projectSettings = scope === "user" ? EMPTY_SUBAGENTS_SETTINGS : readSubagentsSettings(projectSettingsPath);
+	const bulkDisableSource = computeBulkDisableSource(
+		userSettings.disableBuiltins,
+		projectSettings.disableBuiltins,
 		userSettingsPath,
 		projectSettingsPath,
+	);
+
+	const builtinAgents = applyBuiltinOverrides(
+		loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin"),
+		userSettings.overrides,
+		projectSettings.overrides,
+		userSettingsPath,
+		projectSettingsPath,
+		bulkDisableSource,
 	);
 	
 	const userAgentsOld = scope === "project" ? [] : loadAgentsFromDir(userDirOld, "user");
@@ -529,7 +600,8 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const userAgents = [...userAgentsOld, ...userAgentsNew];
 
 	const projectAgents = scope === "user" || !projectAgentsDir ? [] : loadAgentsFromDir(projectAgentsDir, "project");
-	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents);
+	const merged = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents);
+	const agents = merged.filter((agent) => agent.disabled !== true);
 
 	return { agents, projectAgentsDir };
 }
@@ -550,12 +622,22 @@ export function discoverAgentsAll(cwd: string): {
 	const userSettingsPath = getUserAgentSettingsPath();
 	const projectSettingsPath = getProjectAgentSettingsPath(cwd);
 
-	const builtin = applyBuiltinOverrides(
-		loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin"),
-		readBuiltinOverrides(userSettingsPath),
-		readBuiltinOverrides(projectSettingsPath),
+	const userSettings = readSubagentsSettings(userSettingsPath);
+	const projectSettings = readSubagentsSettings(projectSettingsPath);
+	const bulkDisableSource = computeBulkDisableSource(
+		userSettings.disableBuiltins,
+		projectSettings.disableBuiltins,
 		userSettingsPath,
 		projectSettingsPath,
+	);
+
+	const builtin = applyBuiltinOverrides(
+		loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin"),
+		userSettings.overrides,
+		projectSettings.overrides,
+		userSettingsPath,
+		projectSettingsPath,
+		bulkDisableSource,
 	);
 	const user = [
 		...loadAgentsFromDir(userDirOld, "user"),

--- a/test/unit/agent-disabled.test.ts
+++ b/test/unit/agent-disabled.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+	buildBuiltinOverrideConfig,
+	discoverAgents,
+	discoverAgentsAll,
+} from "../../agents.ts";
+
+let tempHome = "";
+let tempProject = "";
+const originalHome = process.env.HOME;
+
+function writeJson(filePath: string, value: unknown): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function writeProjectAgent(cwd: string, name: string, body: string): void {
+	const filePath = path.join(cwd, ".pi", "agents", `${name}.md`);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, body, "utf-8");
+}
+
+describe("agent disabled override", () => {
+	beforeEach(() => {
+		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-disabled-home-"));
+		tempProject = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-disabled-project-"));
+		process.env.HOME = tempHome;
+	});
+
+	afterEach(() => {
+		if (originalHome === undefined) delete process.env.HOME;
+		else process.env.HOME = originalHome;
+		fs.rmSync(tempHome, { recursive: true, force: true });
+		fs.rmSync(tempProject, { recursive: true, force: true });
+	});
+
+	it("user settings override can disable a builtin agent", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: {
+				agentOverrides: {
+					reviewer: { disabled: true },
+				},
+			},
+		});
+
+		const { agents } = discoverAgents(tempProject, "both");
+		assert.equal(agents.find((a) => a.name === "reviewer"), undefined);
+	});
+
+	it("project settings override can disable a builtin agent", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: {
+				agentOverrides: {
+					reviewer: { disabled: true },
+				},
+			},
+		});
+
+		const { agents } = discoverAgents(tempProject, "both");
+		assert.equal(agents.find((a) => a.name === "reviewer"), undefined);
+	});
+
+	it("disabled builtins are still returned by discoverAgentsAll so management UIs can re-enable them", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: {
+				agentOverrides: {
+					reviewer: { disabled: true },
+				},
+			},
+		});
+
+		const { builtin } = discoverAgentsAll(tempProject);
+		const reviewer = builtin.find((a) => a.name === "reviewer");
+		assert.ok(reviewer);
+		assert.equal(reviewer.disabled, true);
+		assert.equal(reviewer.override?.scope, "user");
+	});
+
+	it("project override disabling a builtin wins over user override re-enabling it", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { reviewer: { disabled: false } } },
+		});
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { agentOverrides: { reviewer: { disabled: true } } },
+		});
+
+		const { agents } = discoverAgents(tempProject, "both");
+		assert.equal(agents.find((a) => a.name === "reviewer"), undefined);
+	});
+
+	it("non-boolean override disabled value is ignored", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: {
+				agentOverrides: {
+					reviewer: { disabled: "true" },
+				},
+			},
+		});
+
+		const { agents } = discoverAgents(tempProject, "both");
+		assert.ok(agents.find((a) => a.name === "reviewer"));
+	});
+
+	it("omitted disabled in an override leaves the agent active", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: {
+				agentOverrides: {
+					reviewer: { model: "openai/gpt-5.4" },
+				},
+			},
+		});
+
+		const { agents } = discoverAgents(tempProject, "both");
+		const reviewer = agents.find((a) => a.name === "reviewer");
+		assert.ok(reviewer);
+		assert.equal(reviewer.disabled, undefined);
+	});
+
+	it("buildBuiltinOverrideConfig emits disabled:true when a draft disables a builtin", () => {
+		const override = buildBuiltinOverrideConfig(
+			{
+				systemPrompt: "Base prompt",
+				disabled: undefined,
+			},
+			{
+				systemPrompt: "Base prompt",
+				model: undefined,
+				fallbackModels: undefined,
+				thinking: undefined,
+				skills: undefined,
+				tools: undefined,
+				mcpDirectTools: undefined,
+				disabled: true,
+			},
+		);
+		assert.deepEqual(override, { disabled: true });
+	});
+});
+
+describe("disableBuiltins bulk flag", () => {
+	beforeEach(() => {
+		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-bulk-home-"));
+		tempProject = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-bulk-project-"));
+		process.env.HOME = tempHome;
+	});
+
+	afterEach(() => {
+		if (originalHome === undefined) delete process.env.HOME;
+		else process.env.HOME = originalHome;
+		fs.rmSync(tempHome, { recursive: true, force: true });
+		fs.rmSync(tempProject, { recursive: true, force: true });
+	});
+
+	it("user scope disableBuiltins:true hides all builtin agents", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { disableBuiltins: true },
+		});
+
+		const { agents } = discoverAgents(tempProject, "both");
+		// No builtin sources should remain.
+		assert.equal(agents.filter((a) => a.source === "builtin").length, 0);
+	});
+
+	it("disableBuiltins:true does not affect user-defined agents", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { disableBuiltins: true },
+		});
+		writeProjectAgent(
+			tempProject,
+			"myagent",
+			"---\nname: myagent\ndescription: Project agent\n---\n\nBody\n",
+		);
+
+		const { agents } = discoverAgents(tempProject, "both");
+		assert.ok(agents.find((a) => a.name === "myagent"));
+	});
+
+	it("discoverAgentsAll surfaces builtins with disabled:true when disableBuiltins is set", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { disableBuiltins: true },
+		});
+
+		const { builtin } = discoverAgentsAll(tempProject);
+		assert.ok(builtin.length > 0, "expected builtins to still be enumerated");
+		assert.ok(
+			builtin.every((a) => a.disabled === true),
+			"expected every builtin to be marked disabled",
+		);
+		assert.ok(
+			builtin.every((a) => a.override?.scope === "user"),
+			"expected every builtin to carry a user-scope override attribution",
+		);
+	});
+
+	it("project disableBuiltins:false overrides user disableBuiltins:true", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { disableBuiltins: true },
+		});
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { disableBuiltins: false },
+		});
+
+		const { agents } = discoverAgents(tempProject, "both");
+		// Builtins should be back.
+		assert.ok(agents.some((a) => a.source === "builtin"));
+	});
+
+	it("per-agent override wins over bulk disableBuiltins for that agent", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: {
+				disableBuiltins: true,
+				agentOverrides: {
+					reviewer: { model: "openai/gpt-5.4" },
+				},
+			},
+		});
+
+		const { agents } = discoverAgents(tempProject, "both");
+		const reviewer = agents.find((a) => a.name === "reviewer");
+		// The per-agent override didn't set `disabled`, so reviewer stays active.
+		assert.ok(reviewer);
+		assert.equal(reviewer.model, "openai/gpt-5.4");
+	});
+
+	it("non-boolean disableBuiltins value is ignored", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { disableBuiltins: "true" },
+		});
+
+		const { agents } = discoverAgents(tempProject, "both");
+		assert.ok(agents.some((a) => a.source === "builtin"));
+	});
+
+	it("disableBuiltins in project scope is ignored when scope is 'user'", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { disableBuiltins: true },
+		});
+
+		const { agents } = discoverAgents(tempProject, "user");
+		// Project flag ignored under user scope → builtins still visible.
+		assert.ok(agents.some((a) => a.source === "builtin"));
+	});
+});


### PR DESCRIPTION
Extends the existing `subagents.agentOverrides` schema with a `disabled` boolean so users can hide a specific builtin agent, and adds a `disableBuiltins` bulk flag at the `subagents` object level to switch every builtin off at once:
```json
  {
    "subagents": {
      "disableBuiltins": true,
      "agentOverrides": {
        "reviewer": { "disabled": true },
        "scout":    { "model": "anthropic/claude-opus-4-6" }
      }
    }
  }
```
`discoverAgents` filters disabled agents out of the runtime list. `discoverAgentsAll` keeps them (with `disabled: true` on the config and `override.scope` attribution) so management UIs can surface and re-enable them. A per-agent override without `disabled` opts the agent out of the bulk `disableBuiltins` switch. Project scope wins over user scope for the bulk flag, so a project can re-enable builtins locally even when the user's global settings disable them.

Motivation: builtin agents ship inside the package, so users can't delete the .md files. Previously there was no way to hide a builtin you don't want to use without touching the package itself.

Closes #34 