### PR TITLE
fix: improve async subagent reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,33 @@ This aggregated output becomes `{previous}` for the next step.
 
 `pi-subagents` reads optional JSON config from `~/.pi/agent/extensions/subagent/config.json`.
 
+### `asyncByDefault`
+
+`asyncByDefault` makes top-level subagent calls use background execution when the request does not explicitly set `async`.
+
+```json
+{
+  "asyncByDefault": true
+}
+```
+
+This only changes the default. Callers can still force foreground execution by setting `async: false` unless `forceTopLevelAsync` is also enabled.
+
+### `forceTopLevelAsync`
+
+`forceTopLevelAsync` forces depth-0 subagent execution into background mode. This is useful for automation setups that never want the top-level orchestrator to block on child runs.
+
+```json
+{
+  "forceTopLevelAsync": true
+}
+```
+
+When enabled:
+- top-level single, parallel, and chain runs are forced to `async: true`
+- top-level clarify UI is bypassed by forcing `clarify: false`
+- nested subagent calls still follow their own inherited depth and async settings
+
 ### `parallel`
 
 `parallel` controls top-level `tasks` mode defaults and limits.

--- a/async-execution.ts
+++ b/async-execution.ts
@@ -114,22 +114,39 @@ export function isAsyncAvailable(): boolean {
 /**
  * Spawn the async runner process
  */
-function spawnRunner(cfg: object, suffix: string, cwd: string): number | undefined {
-	if (!jitiCliPath) return undefined;
-	
+function spawnRunner(cfg: object, suffix: string, cwd: string): { pid?: number; error?: string } {
+	if (!jitiCliPath) {
+		return { error: "jiti for TypeScript execution could not be found" };
+	}
+
+	try {
+		const cwdStats = fs.statSync(cwd);
+		if (!cwdStats.isDirectory()) {
+			return { error: `cwd is not a directory: ${cwd}` };
+		}
+	} catch {
+		return { error: `cwd does not exist: ${cwd}` };
+	}
+
 	fs.mkdirSync(TEMP_ROOT_DIR, { recursive: true });
 	const cfgPath = getAsyncConfigPath(suffix);
 	fs.writeFileSync(cfgPath, JSON.stringify(cfg));
 	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
-	
+
 	const proc = spawn(process.execPath, [jitiCliPath, runner, cfgPath], {
 		cwd,
 		detached: true,
 		stdio: "ignore",
 		windowsHide: true,
 	});
+	proc.on("error", (error) => {
+		console.error(`[pi-subagents] async spawn failed: ${error.message}`);
+	});
+	if (typeof proc.pid !== "number") {
+		return { error: `async runner did not produce a pid for cwd: ${cwd}` };
+	}
 	proc.unref();
-	return proc.pid;
+	return { pid: proc.pid };
 }
 
 function formatAsyncStartError(mode: "single" | "chain", message: string): AsyncExecutionResult {
@@ -260,9 +277,9 @@ export function executeAsyncChain(
 		return buildSeqStep(s as SequentialStep, nextSessionFile());
 	});
 
-	let pid: number | undefined;
+	let spawnResult: { pid?: number; error?: string } = {};
 	try {
-		pid = spawnRunner(
+		spawnResult = spawnRunner(
 			{
 				id,
 				steps,
@@ -289,14 +306,18 @@ export function executeAsyncChain(
 		return formatAsyncStartError("chain", `Failed to start async chain '${id}': ${message}`);
 	}
 
-	if (pid) {
+	if (spawnResult.error) {
+		return formatAsyncStartError("chain", `Failed to start async chain '${id}': ${spawnResult.error}`);
+	}
+
+	if (spawnResult.pid) {
 		const firstStep = chain[0];
 		const firstAgents = isParallelStep(firstStep)
 			? firstStep.parallel.map((t) => t.agent)
 			: [(firstStep as SequentialStep).agent];
 		ctx.pi.events.emit("subagent:started", {
 			id,
-			pid,
+			pid: spawnResult.pid,
 			agent: firstAgents[0],
 			task: isParallelStep(firstStep)
 				? firstStep.parallel[0]?.task?.slice(0, 50)
@@ -368,9 +389,9 @@ export function executeAsyncSingle(
 
 	const outputPath = resolveSingleOutputPath(params.output, ctx.cwd, runnerCwd);
 	const taskWithOutputInstruction = injectSingleOutputInstruction(task, outputPath);
-	let pid: number | undefined;
+	let spawnResult: { pid?: number; error?: string } = {};
 	try {
-		pid = spawnRunner(
+		spawnResult = spawnRunner(
 			{
 				id,
 				steps: [
@@ -418,10 +439,14 @@ export function executeAsyncSingle(
 		return formatAsyncStartError("single", `Failed to start async run '${id}': ${message}`);
 	}
 
-	if (pid) {
+	if (spawnResult.error) {
+		return formatAsyncStartError("single", `Failed to start async run '${id}': ${spawnResult.error}`);
+	}
+
+	if (spawnResult.pid) {
 		ctx.pi.events.emit("subagent:started", {
 			id,
-			pid,
+			pid: spawnResult.pid,
 			agent,
 			task: task?.slice(0, 50),
 			cwd: runnerCwd,

--- a/async-job-tracker.ts
+++ b/async-job-tracker.ts
@@ -7,18 +7,42 @@ import {
 } from "./types.ts";
 import { readStatus } from "./utils.ts";
 
-export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string): {
+interface AsyncJobTrackerOptions {
+	completionRetentionMs?: number;
+	pollIntervalMs?: number;
+}
+
+export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string, options: AsyncJobTrackerOptions = {}): {
 	ensurePoller: () => void;
 	handleStarted: (data: unknown) => void;
 	handleComplete: (data: unknown) => void;
 	resetJobs: (ctx?: ExtensionContext) => void;
 } {
+	const completionRetentionMs = options.completionRetentionMs ?? 10000;
+	const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
+		renderWidget(ctx, jobs);
+		ctx.ui.requestRender?.();
+	};
+	const scheduleCleanup = (asyncId: string) => {
+		const existingTimer = state.cleanupTimers.get(asyncId);
+		if (existingTimer) clearTimeout(existingTimer);
+		const timer = setTimeout(() => {
+			state.cleanupTimers.delete(asyncId);
+			state.asyncJobs.delete(asyncId);
+			if (state.lastUiContext) {
+				rerenderWidget(state.lastUiContext);
+			}
+		}, completionRetentionMs);
+		state.cleanupTimers.set(asyncId, timer);
+	};
+
 	const ensurePoller = () => {
 		if (state.poller) return;
 		state.poller = setInterval(() => {
 			if (!state.lastUiContext || !state.lastUiContext.hasUI) return;
 			if (state.asyncJobs.size === 0) {
-				renderWidget(state.lastUiContext, []);
+				rerenderWidget(state.lastUiContext, []);
 				if (state.poller) {
 					clearInterval(state.poller);
 					state.poller = null;
@@ -27,12 +51,10 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 			}
 
 			for (const job of state.asyncJobs.values()) {
-				if (job.status === "complete" || job.status === "failed") {
-					continue;
-				}
 				try {
 					const status = readStatus(job.asyncDir);
 					if (status) {
+						const previousStatus = job.status;
 						job.status = status.state;
 						job.mode = status.mode;
 						job.currentStep = status.currentStep ?? job.currentStep;
@@ -46,6 +68,9 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 						job.outputFile = status.outputFile ?? job.outputFile;
 						job.totalTokens = status.totalTokens ?? job.totalTokens;
 						job.sessionFile = status.sessionFile ?? job.sessionFile;
+						if ((job.status === "complete" || job.status === "failed") && previousStatus !== job.status) {
+							scheduleCleanup(job.asyncId);
+						}
 						continue;
 					}
 					job.status = job.status === "queued" ? "running" : job.status;
@@ -57,8 +82,8 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 				}
 			}
 
-			renderWidget(state.lastUiContext, Array.from(state.asyncJobs.values()));
-		}, POLL_INTERVAL_MS);
+			rerenderWidget(state.lastUiContext);
+		}, pollIntervalMs);
 		state.poller.unref?.();
 	};
 
@@ -84,7 +109,7 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 			updatedAt: now,
 		});
 		if (state.lastUiContext) {
-			renderWidget(state.lastUiContext, Array.from(state.asyncJobs.values()));
+			rerenderWidget(state.lastUiContext);
 			ensurePoller();
 		}
 	};
@@ -100,16 +125,9 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 			if (result.asyncDir) job.asyncDir = result.asyncDir;
 		}
 		if (state.lastUiContext) {
-			renderWidget(state.lastUiContext, Array.from(state.asyncJobs.values()));
+			rerenderWidget(state.lastUiContext);
 		}
-		const timer = setTimeout(() => {
-			state.cleanupTimers.delete(asyncId);
-			state.asyncJobs.delete(asyncId);
-			if (state.lastUiContext) {
-				renderWidget(state.lastUiContext, Array.from(state.asyncJobs.values()));
-			}
-		}, 10000);
-		state.cleanupTimers.set(asyncId, timer);
+		scheduleCleanup(asyncId);
 	};
 
 	const resetJobs = (ctx?: ExtensionContext) => {
@@ -121,7 +139,7 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 		state.resultFileCoalescer.clear();
 		if (ctx?.hasUI) {
 			state.lastUiContext = ctx;
-			renderWidget(ctx, []);
+			rerenderWidget(ctx, []);
 		}
 	};
 

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@
  * Toggle: async parameter (default: false, configurable via config.json)
  *
  * Config file: ~/.pi/agent/extensions/subagent/config.json
- *   { "asyncByDefault": true, "maxSubagentDepth": 1, "intercomBridge": { "mode": "always", "instructionFile": "./intercom-bridge.md" }, "worktreeSetupHook": "./scripts/setup-worktree.mjs" }
+ *   { "asyncByDefault": true, "forceTopLevelAsync": true, "maxSubagentDepth": 1, "intercomBridge": { "mode": "always", "instructionFile": "./intercom-bridge.md" }, "worktreeSetupHook": "./scripts/setup-worktree.mjs" }
  */
 
 import * as fs from "node:fs";

--- a/session-tokens.ts
+++ b/session-tokens.ts
@@ -1,0 +1,47 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface TokenUsage {
+	input: number;
+	output: number;
+	total: number;
+}
+
+function findLatestSessionFile(sessionDir: string): string | null {
+	try {
+		const files = fs.readdirSync(sessionDir)
+			.filter((f) => f.endsWith(".jsonl"))
+			.sort();
+		if (files.length === 0) return null;
+		return path.join(sessionDir, files[files.length - 1]!);
+	} catch {
+		return null;
+	}
+}
+
+export function parseSessionTokens(sessionDir: string): TokenUsage | null {
+	const sessionFile = findLatestSessionFile(sessionDir);
+	if (!sessionFile) return null;
+	try {
+		const content = fs.readFileSync(sessionFile, "utf-8");
+		let input = 0;
+		let output = 0;
+		for (const line of content.split("\n")) {
+			if (!line.trim()) continue;
+			try {
+				const entry = JSON.parse(line);
+				const usage = entry.usage ?? entry.message?.usage;
+				if (usage) {
+					input += usage.inputTokens ?? usage.input ?? 0;
+					output += usage.outputTokens ?? usage.output ?? 0;
+				}
+			} catch {
+				// Ignore malformed lines while scanning usage entries.
+			}
+		}
+		return { input, output, total: input + output };
+	} catch {
+		// Usage extraction should not fail the run.
+		return null;
+	}
+}

--- a/session-tokens.ts
+++ b/session-tokens.ts
@@ -11,9 +11,10 @@ function findLatestSessionFile(sessionDir: string): string | null {
 	try {
 		const files = fs.readdirSync(sessionDir)
 			.filter((f) => f.endsWith(".jsonl"))
-			.sort();
+			.map((f) => path.join(sessionDir, f));
 		if (files.length === 0) return null;
-		return path.join(sessionDir, files[files.length - 1]!);
+		files.sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+		return files[0] ?? null;
 	} catch {
 		return null;
 	}

--- a/subagent-executor.ts
+++ b/subagent-executor.ts
@@ -1250,20 +1250,24 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return toExecutionErrorResult(normalizedParams, error);
 		}
 
-		const requestedAsync = normalizedParams.async ?? deps.asyncByDefault;
-		const backgroundRequestedWhileClarifying = hasTasks && requestedAsync && normalizedParams.clarify === true;
+		const forceTopLevelAsync = depth === 0 && deps.config.forceTopLevelAsync === true;
+		const effectiveParams = forceTopLevelAsync
+			? { ...normalizedParams, async: true, clarify: false }
+			: normalizedParams;
+		const requestedAsync = effectiveParams.async ?? deps.asyncByDefault;
+		const backgroundRequestedWhileClarifying = hasTasks && requestedAsync && effectiveParams.clarify === true;
 		const effectiveAsync = requestedAsync
-			&& (hasChain ? normalizedParams.clarify === false : normalizedParams.clarify !== true);
+			&& (hasChain ? effectiveParams.clarify === false : effectiveParams.clarify !== true);
 
 		const artifactConfig: ArtifactConfig = {
 			...DEFAULT_ARTIFACT_CONFIG,
-			enabled: normalizedParams.artifacts !== false,
+			enabled: effectiveParams.artifacts !== false,
 		};
 		const artifactsDir = effectiveAsync ? deps.tempArtifactsDir : getArtifactsDir(parentSessionFile);
 
 		let sessionRoot: string;
-		if (normalizedParams.sessionDir) {
-			sessionRoot = path.resolve(deps.expandTilde(normalizedParams.sessionDir));
+		if (effectiveParams.sessionDir) {
+			sessionRoot = path.resolve(deps.expandTilde(effectiveParams.sessionDir));
 		} else {
 			const baseSessionRoot = deps.config.defaultSessionDir
 				? path.resolve(deps.expandTilde(deps.config.defaultSessionDir))
@@ -1287,7 +1291,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			: undefined;
 
 		const execData: ExecutionContextData = {
-			params: normalizedParams,
+			params: effectiveParams,
 			effectiveCwd,
 			ctx,
 			signal,

--- a/subagent-executor.ts
+++ b/subagent-executor.ts
@@ -26,6 +26,7 @@ import { createForkContextResolver } from "./fork-context.ts";
 import { applyIntercomBridgeToAgent, resolveIntercomBridge, resolveIntercomSessionTarget } from "./intercom-bridge.ts";
 import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, resolveChildCwd } from "./utils.ts";
+import { applyForceTopLevelAsyncOverride } from "./top-level-async.ts";
 import {
 	cleanupWorktrees,
 	createWorktrees,
@@ -1209,32 +1210,38 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		if (normalized.error) return normalized.error;
 		const normalizedParams = normalized.params!;
 
-		const scope: AgentScope = resolveExecutionAgentScope(normalizedParams.agentScope);
-		const effectiveCwd = normalizedParams.cwd ?? ctx.cwd;
+		const effectiveParams = applyForceTopLevelAsyncOverride(
+			normalizedParams,
+			depth,
+			deps.config.forceTopLevelAsync === true,
+		);
+
+		const scope: AgentScope = resolveExecutionAgentScope(effectiveParams.agentScope);
+		const effectiveCwd = effectiveParams.cwd ?? ctx.cwd;
 		const parentSessionFile = ctx.sessionManager.getSessionFile() ?? null;
 		deps.state.currentSessionId = parentSessionFile ?? `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 		const discoveredAgents = deps.discoverAgents(effectiveCwd, scope).agents;
 		const sessionName = resolveIntercomSessionTarget(deps.pi.getSessionName(), ctx.sessionManager.getSessionId());
 		const intercomBridge = resolveIntercomBridge({
 			config: deps.config.intercomBridge,
-			context: normalizedParams.context,
+			context: effectiveParams.context,
 			orchestratorTarget: sessionName,
 		});
 		const agents = intercomBridge.active
 			? discoveredAgents.map((agent) => applyIntercomBridgeToAgent(agent, intercomBridge))
 			: discoveredAgents;
 		const runId = randomUUID().slice(0, 8);
-		const shareEnabled = normalizedParams.share === true;
-		const hasChain = (normalizedParams.chain?.length ?? 0) > 0;
-		const hasTasks = (normalizedParams.tasks?.length ?? 0) > 0;
-		const hasSingle = Boolean(normalizedParams.agent && normalizedParams.task);
+		const shareEnabled = effectiveParams.share === true;
+		const hasChain = (effectiveParams.chain?.length ?? 0) > 0;
+		const hasTasks = (effectiveParams.tasks?.length ?? 0) > 0;
+		const hasSingle = Boolean(effectiveParams.agent && effectiveParams.task);
 		const allowClarifyTaskPrompt = hasChain
-			&& normalizedParams.clarify === true
+			&& effectiveParams.clarify === true
 			&& ctx.hasUI
-			&& !(normalizedParams.chain?.some(isParallelStep) ?? false);
+			&& !(effectiveParams.chain?.some(isParallelStep) ?? false);
 
 		const validationError = validateExecutionInput(
-			normalizedParams,
+			effectiveParams,
 			agents,
 			hasChain,
 			hasTasks,
@@ -1245,15 +1252,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 
 		let sessionFileForIndex: (idx?: number) => string | undefined = () => undefined;
 		try {
-			sessionFileForIndex = createForkContextResolver(ctx.sessionManager, normalizedParams.context).sessionFileForIndex;
+			sessionFileForIndex = createForkContextResolver(ctx.sessionManager, effectiveParams.context).sessionFileForIndex;
 		} catch (error) {
-			return toExecutionErrorResult(normalizedParams, error);
+			return toExecutionErrorResult(effectiveParams, error);
 		}
-
-		const forceTopLevelAsync = depth === 0 && deps.config.forceTopLevelAsync === true;
-		const effectiveParams = forceTopLevelAsync
-			? { ...normalizedParams, async: true, clarify: false }
-			: normalizedParams;
 		const requestedAsync = effectiveParams.async ?? deps.asyncByDefault;
 		const backgroundRequestedWhileClarifying = hasTasks && requestedAsync && effectiveParams.clarify === true;
 		const effectiveAsync = requestedAsync
@@ -1279,7 +1281,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			return toExecutionErrorResult(
-				normalizedParams,
+				effectiveParams,
 				new Error(`Failed to create session directory '${sessionRoot}': ${message}`),
 			);
 		}
@@ -1287,7 +1289,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			path.join(sessionRoot, `run-${idx ?? 0}`);
 
 		const onUpdateWithContext = onUpdate
-			? (r: AgentToolResult<Details>) => onUpdate(withForkContext(r, normalizedParams.context))
+			? (r: AgentToolResult<Details>) => onUpdate(withForkContext(r, effectiveParams.context))
 			: undefined;
 
 		const execData: ExecutionContextData = {
@@ -1310,18 +1312,18 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 
 		try {
 			const asyncResult = runAsyncPath(execData, deps);
-			if (asyncResult) return withForkContext(asyncResult, normalizedParams.context);
+			if (asyncResult) return withForkContext(asyncResult, effectiveParams.context);
 
-			if (hasChain && normalizedParams.chain) {
-				return withForkContext(await runChainPath(execData, deps), normalizedParams.context);
+			if (hasChain && effectiveParams.chain) {
+				return withForkContext(await runChainPath(execData, deps), effectiveParams.context);
 			}
 
-			if (hasTasks && normalizedParams.tasks) {
-				return withForkContext(await runParallelPath(execData, deps), normalizedParams.context);
+			if (hasTasks && effectiveParams.tasks) {
+				return withForkContext(await runParallelPath(execData, deps), effectiveParams.context);
 			}
 
 			if (hasSingle) {
-				return withForkContext(await runSinglePath(execData, deps), normalizedParams.context);
+				return withForkContext(await runSinglePath(execData, deps), effectiveParams.context);
 			}
 		} catch (error) {
 			return toExecutionErrorResult(normalizedParams, error);
@@ -1331,7 +1333,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			content: [{ type: "text", text: "Invalid params" }],
 			isError: true,
 			details: { mode: "single" as const, results: [] },
-		}, normalizedParams.context);
+		}, effectiveParams.context);
 	};
 
 	return { execute };

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -29,6 +29,7 @@ import {
 import { buildPiArgs, cleanupTempDir } from "./pi-args.ts";
 import { formatModelAttemptNote, isRetryableModelFailure } from "./model-fallback.ts";
 import { detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput } from "./utils.ts";
+import { parseSessionTokens, type TokenUsage } from "./session-tokens.ts";
 import {
 	cleanupWorktrees,
 	createWorktrees,
@@ -85,38 +86,6 @@ function findLatestSessionFile(sessionDir: string): string | null {
 		return files[0] ?? null;
 	} catch {
 		// Session lookup is optional metadata.
-		return null;
-	}
-}
-
-interface TokenUsage {
-	input: number;
-	output: number;
-	total: number;
-}
-
-function parseSessionTokens(sessionDir: string): TokenUsage | null {
-	const sessionFile = findLatestSessionFile(sessionDir);
-	if (!sessionFile) return null;
-	try {
-		const content = fs.readFileSync(sessionFile, "utf-8");
-		let input = 0;
-		let output = 0;
-		for (const line of content.split("\n")) {
-			if (!line.trim()) continue;
-			try {
-				const entry = JSON.parse(line);
-				if (entry.usage) {
-					input += entry.usage.inputTokens ?? entry.usage.input ?? 0;
-					output += entry.usage.outputTokens ?? entry.usage.output ?? 0;
-				}
-			} catch {
-				// Ignore malformed lines while scanning usage entries.
-			}
-		}
-		return { input, output, total: input + output };
-	} catch {
-		// Usage extraction should not fail the run.
 		return null;
 	}
 }

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -432,6 +432,88 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(result.content[0]?.text ?? "", /async-cfg-/);
 	});
 
+	it("returns a tool error when an async run uses a missing cwd", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
+		const id = `async-missing-cwd-${Date.now().toString(36)}`;
+		const missingCwd = path.join(tempDir, "missing-cwd");
+
+		const singleResult = executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			cwd: missingCwd,
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			maxSubagentDepth: 2,
+		});
+
+		assert.equal(singleResult.isError, true);
+		assert.match(singleResult.content[0]?.text ?? "", /Failed to start async run/);
+		assert.match(singleResult.content[0]?.text ?? "", /cwd does not exist/);
+
+		const chainId = `async-missing-cwd-chain-${Date.now().toString(36)}`;
+		const chainResult = executeAsyncChain(chainId, {
+			chain: [{ agent: "worker", task: "Do work" }],
+			agents: [makeAgent("worker")],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			cwd: missingCwd,
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			maxSubagentDepth: 2,
+		});
+
+		assert.equal(chainResult.isError, true);
+		assert.match(chainResult.content[0]?.text ?? "", /Failed to start async chain/);
+		assert.match(chainResult.content[0]?.text ?? "", /cwd does not exist/);
+	});
+
+	it("returns a tool error when the async runner process cannot spawn", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
+		const originalExecPath = process.execPath;
+		process.execPath = path.join(tempDir, "missing-node");
+		try {
+			const id = `async-spawn-fail-${Date.now().toString(36)}`;
+			const result = executeAsyncSingle(id, {
+				agent: "worker",
+				task: "Do work",
+				agentConfig: makeAgent("worker"),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: {
+					enabled: false,
+					includeInput: false,
+					includeOutput: false,
+					includeJsonl: false,
+					includeMetadata: false,
+					cleanupDays: 7,
+				},
+				shareEnabled: false,
+				sessionRoot: path.join(tempDir, "sessions"),
+				maxSubagentDepth: 2,
+			});
+
+			assert.equal(result.isError, true);
+			assert.match(result.content[0]?.text ?? "", /Failed to start async run/);
+			assert.match(result.content[0]?.text ?? "", /async runner did not produce a pid/);
+		} finally {
+			process.execPath = originalExecPath;
+		}
+	});
+
 	it("returns a tool error when an async chain cannot write its detached runner config", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
 		const id = `async-chain-write-fail-${Date.now().toString(36)}`;
 		assert.ok(TEMP_ROOT_DIR, "TEMP_ROOT_DIR should be available for async tests");

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -219,6 +219,9 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.results[0].model, "anthropic/claude-sonnet-4");
 		assert.deepEqual(payload.results[0].attemptedModels, ["openai/gpt-5-mini", "anthropic/claude-sonnet-4"]);
 		assert.equal(payload.results[0].modelAttempts.length, 2);
+		const statusPayload = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+		assert.ok(statusPayload.totalTokens.total > 0);
+		assert.ok(statusPayload.steps[0].tokens.total > 0);
 		assert.match(fs.readFileSync(path.join(asyncDir, "output-0.log"), "utf-8"), /Recovered asynchronously/);
 		assert.equal(mockPi.callCount(), 2);
 	});

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { createTempDir, removeTempDir, tryImport } from "../support/helpers.ts";
+
+interface AsyncJobTrackerModule {
+	createAsyncJobTracker(
+		state: Record<string, unknown>,
+		asyncDirRoot: string,
+		options?: { completionRetentionMs?: number; pollIntervalMs?: number },
+	): {
+		resetJobs(ctx?: unknown): void;
+		handleStarted(data: unknown): void;
+		handleComplete(data: unknown): void;
+	};
+}
+
+const trackerMod = await tryImport<AsyncJobTrackerModule>("./async-job-tracker.ts");
+const available = !!trackerMod;
+
+function createState() {
+	return {
+		baseCwd: "/repo",
+		currentSessionId: null,
+		asyncJobs: new Map(),
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: {
+			schedule: () => false,
+			clear: () => {},
+		},
+	};
+}
+
+function createUiContext() {
+	const widgets: unknown[] = [];
+	let renderRequests = 0;
+	const ctx = {
+		hasUI: true,
+		ui: {
+			theme: {
+				fg: (_theme: string, text: string) => text,
+			},
+			setWidget: (_key: string, value: unknown) => {
+				widgets.push(value);
+			},
+			requestRender: () => {
+				renderRequests += 1;
+			},
+		},
+	};
+	return {
+		ctx,
+		get widgets() {
+			return widgets;
+		},
+		get renderRequests() {
+			return renderRequests;
+		},
+	};
+}
+
+describe("async job tracker", { skip: !available ? "pi packages not available" : undefined }, () => {
+	it("removes completed jobs after retention and requests a rerender", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-");
+		try {
+			const state = createState();
+			const ui = createUiContext();
+			const tracker = trackerMod!.createAsyncJobTracker(state as never, asyncRoot, {
+				completionRetentionMs: 5,
+			});
+			tracker.resetJobs(ui.ctx as never);
+			tracker.handleStarted({ id: "run-1", asyncDir: path.join(asyncRoot, "run-1"), agent: "worker" });
+			tracker.handleComplete({ id: "run-1", success: true });
+
+			assert.equal(state.asyncJobs.size, 1);
+			await new Promise((resolve) => setTimeout(resolve, 40));
+
+			assert.equal(state.asyncJobs.size, 0);
+			assert.ok(ui.renderRequests > 0, "expected widget cleanup to request a rerender");
+			assert.equal(ui.widgets.at(-1), undefined);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("schedules cleanup when polling observes a completed status without a completion event", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-");
+		try {
+			const runDir = path.join(asyncRoot, "run-2");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-2",
+				mode: "single",
+				state: "complete",
+				startedAt: Date.now() - 1000,
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "complete" }],
+			}), "utf-8");
+
+			const state = createState();
+			const ui = createUiContext();
+			const tracker = trackerMod!.createAsyncJobTracker(state as never, asyncRoot, {
+				completionRetentionMs: 5,
+				pollIntervalMs: 10,
+			});
+			tracker.resetJobs(ui.ctx as never);
+			tracker.handleStarted({ id: "run-2", asyncDir: runDir, agent: "worker" });
+
+			await new Promise((resolve) => setTimeout(resolve, 80));
+
+			assert.equal(state.asyncJobs.size, 0);
+			assert.ok(ui.renderRequests > 0, "expected polling cleanup to request a rerender");
+			assert.equal(ui.widgets.at(-1), undefined);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+});

--- a/test/integration/session-tokens.test.ts
+++ b/test/integration/session-tokens.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { createTempDir, removeTempDir, tryImport } from "../support/helpers.ts";
+
+interface SessionTokensModule {
+	parseSessionTokens(sessionDir: string): { input: number; output: number; total: number } | null;
+}
+
+const tokensMod = await tryImport<SessionTokensModule>("./session-tokens.ts");
+const available = !!tokensMod;
+
+describe("session tokens", { skip: !available ? "pi packages not available" : undefined }, () => {
+	it("parses token usage from session message entries", () => {
+		const sessionDir = createTempDir("pi-subagent-session-tokens-");
+		try {
+			const sessionFile = path.join(sessionDir, "2026-01-01T00-00-00-000Z_test.jsonl");
+			const lines = [
+				JSON.stringify({
+					type: "message",
+					message: {
+						role: "assistant",
+						usage: { input: 120, output: 30 },
+					},
+				}),
+				JSON.stringify({
+					type: "message",
+					message: {
+						role: "assistant",
+						usage: { inputTokens: 80, outputTokens: 20 },
+					},
+				}),
+			].join("\n");
+			fs.writeFileSync(sessionFile, lines + "\n", "utf-8");
+
+			const tokens = tokensMod!.parseSessionTokens(sessionDir);
+			assert.deepEqual(tokens, { input: 200, output: 50, total: 250 });
+		} finally {
+			removeTempDir(sessionDir);
+		}
+	});
+});

--- a/test/integration/session-tokens.test.ts
+++ b/test/integration/session-tokens.test.ts
@@ -40,4 +40,23 @@ describe("session tokens", { skip: !available ? "pi packages not available" : un
 			removeTempDir(sessionDir);
 		}
 	});
+
+	it("uses the newest session file by mtime when multiple files exist", () => {
+		const sessionDir = createTempDir("pi-subagent-session-tokens-");
+		try {
+			const olderFile = path.join(sessionDir, "z-last-lexicographically.jsonl");
+			const newerFile = path.join(sessionDir, "a-first-lexicographically.jsonl");
+			fs.writeFileSync(olderFile, JSON.stringify({ type: "message", message: { usage: { input: 10, output: 5 } } }) + "\n", "utf-8");
+			fs.writeFileSync(newerFile, JSON.stringify({ type: "message", message: { usage: { input: 90, output: 10 } } }) + "\n", "utf-8");
+			const olderTime = new Date("2026-01-01T00:00:00.000Z");
+			const newerTime = new Date("2026-01-01T00:00:10.000Z");
+			fs.utimesSync(olderFile, olderTime, olderTime);
+			fs.utimesSync(newerFile, newerTime, newerTime);
+
+			const tokens = tokensMod!.parseSessionTokens(sessionDir);
+			assert.deepEqual(tokens, { input: 90, output: 10, total: 100 });
+		} finally {
+			removeTempDir(sessionDir);
+		}
+	});
 });

--- a/test/integration/top-level-async.test.ts
+++ b/test/integration/top-level-async.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { tryImport } from "../support/helpers.ts";
+
+interface TopLevelAsyncModule {
+	applyForceTopLevelAsyncOverride<T extends { async?: boolean; clarify?: boolean }>(
+		params: T,
+		depth: number,
+		forceTopLevelAsync: boolean,
+	): T;
+}
+
+const mod = await tryImport<TopLevelAsyncModule>("./top-level-async.ts");
+const available = !!mod;
+
+describe("force top-level async helper", { skip: !available ? "pi packages not available" : undefined }, () => {
+	it("forces top-level calls async and disables clarify", () => {
+		const params = { async: false, clarify: true, agent: "worker" };
+		const next = mod!.applyForceTopLevelAsyncOverride(params, 0, true);
+		assert.notEqual(next, params);
+		assert.equal(next.async, true);
+		assert.equal(next.clarify, false);
+		assert.equal(next.agent, "worker");
+	});
+
+	it("leaves nested calls unchanged", () => {
+		const params = { async: false, clarify: true };
+		const next = mod!.applyForceTopLevelAsyncOverride(params, 1, true);
+		assert.equal(next, params);
+	});
+
+	it("leaves top-level calls unchanged when the feature is off", () => {
+		const params = { async: false, clarify: true };
+		const next = mod!.applyForceTopLevelAsyncOverride(params, 0, false);
+		assert.equal(next, params);
+	});
+});

--- a/top-level-async.ts
+++ b/top-level-async.ts
@@ -1,0 +1,13 @@
+export interface AsyncOverrideParams {
+	async?: boolean;
+	clarify?: boolean;
+}
+
+export function applyForceTopLevelAsyncOverride<T extends AsyncOverrideParams>(
+	params: T,
+	depth: number,
+	forceTopLevelAsync: boolean,
+): T {
+	if (!(depth === 0 && forceTopLevelAsync)) return params;
+	return { ...params, async: true, clarify: false };
+}

--- a/types.ts
+++ b/types.ts
@@ -288,6 +288,7 @@ export interface TopLevelParallelConfig {
 
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
+	forceTopLevelAsync?: boolean;
 	defaultSessionDir?: string;
 	maxSubagentDepth?: number;
 	parallel?: TopLevelParallelConfig;


### PR DESCRIPTION
## Summary
- fix stale async widget entries by forcing a TUI rerender and scheduling cleanup when polling detects completion
- fix async token accounting by reading usage from session message entries and the newest session file by mtime
- add `forceTopLevelAsync` for automation setups that never want top-level subagent runs to block
- apply the top-level async override before validation and context/session resolution

## Issues
Closes #100.
Closes #101.

## Dependency
Independent of #98 and #103.

## Reproduction covered
### Stale widget / zero tokens
1. Enable background async subagents.
2. Launch a background run.
3. Wait for completion.
4. Observe that the widget can stay on screen past the retention window and can show `0 tok` even when the session log recorded usage.

### Forced top-level async
1. Set `forceTopLevelAsync: true` in `~/.pi/agent/extensions/subagent/config.json`.
2. Launch a top-level single, parallel, or chain subagent run.
3. Observe that the run is forced into background mode and top-level clarify is bypassed.
4. For chains, validation now runs against the forced-async params before launch.

## Testing
- `git diff --check`
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test --test-force-exit test/integration/async-job-tracker.test.ts test/integration/session-tokens.test.ts test/integration/top-level-async.test.ts`
- `NODE_PATH=<jiti shim> node --experimental-transform-types --import ./test/support/register-loader.mjs --test --test-force-exit --test-name-pattern='returns a tool error when an async run uses a missing cwd|returns a tool error when the async runner process cannot spawn' test/integration/async-execution.test.ts`
