### PR TITLE
fix: fallback empty async completion text

### DIFF
--- a/notify.ts
+++ b/notify.ts
@@ -54,10 +54,11 @@ export default function registerSubagentNotify(pi: ExtensionAPI): void {
 			extra.push(`Session file: ${result.sessionFile}`);
 		}
 
+		const summary = result.summary.trim() ? result.summary : "(no output)";
 		const content = [
 			`Background task ${status}: **${agent}**${taskInfo}`,
 			"",
-			result.summary,
+			summary,
 			extra.length ? "" : undefined,
 			extra.length ? extra.join("\n") : undefined,
 		]

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { describe, it } from "node:test";
+import registerSubagentNotify from "../../notify.ts";
+
+function createPi() {
+	const events = new EventEmitter();
+	const sent: Array<{ message: unknown; options: unknown }> = [];
+	const pi = {
+		events,
+		sendMessage(message: unknown, options: unknown) {
+			sent.push({ message, options });
+		},
+	};
+
+	registerSubagentNotify(pi as never);
+
+	return { events, sent };
+}
+
+describe("registerSubagentNotify", () => {
+	it("uses a fallback summary when a background completion is empty", () => {
+		const { events, sent } = createPi();
+
+		events.emit("subagent:complete", {
+			id: "notify-empty-1",
+			agent: "worker",
+			success: true,
+			summary: "",
+			exitCode: 0,
+			timestamp: 123,
+		});
+
+		assert.equal(sent.length, 1);
+		assert.deepEqual(sent[0], {
+			message: {
+				customType: "subagent-notify",
+				content: "Background task completed: **worker**\n\n(no output)",
+				display: true,
+			},
+			options: { triggerTurn: true },
+		});
+	});
+
+	it("preserves non-empty completion summaries", () => {
+		const { events, sent } = createPi();
+		const summary = "  Done streaming\nAll clear  ";
+
+		events.emit("subagent:complete", {
+			id: "notify-summary-1",
+			agent: "worker",
+			success: true,
+			summary,
+			exitCode: 0,
+			timestamp: 456,
+			taskIndex: 1,
+			totalTasks: 3,
+		});
+
+		assert.equal(sent.length, 1);
+		assert.deepEqual(sent[0], {
+			message: {
+				customType: "subagent-notify",
+				content: `Background task completed: **worker** (2/3)\n\n${summary}`,
+				display: true,
+			},
+			options: { triggerTurn: true },
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- use `(no output)` when a background completion summary is empty
- leave non-empty completion summaries unchanged
- add unit coverage for both paths

Closes #104.

## Testing
- `node --experimental-strip-types --test test/unit/notify.test.ts`
