### PR TITLE
fix: async widget state and token totals

### DIFF
--- a/async-job-tracker.ts
+++ b/async-job-tracker.ts
@@ -7,18 +7,42 @@ import {
 } from "./types.ts";
 import { readStatus } from "./utils.ts";
 
-export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string): {
+interface AsyncJobTrackerOptions {
+	completionRetentionMs?: number;
+	pollIntervalMs?: number;
+}
+
+export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string, options: AsyncJobTrackerOptions = {}): {
 	ensurePoller: () => void;
 	handleStarted: (data: unknown) => void;
 	handleComplete: (data: unknown) => void;
 	resetJobs: (ctx?: ExtensionContext) => void;
 } {
+	const completionRetentionMs = options.completionRetentionMs ?? 10000;
+	const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
+		renderWidget(ctx, jobs);
+		ctx.ui.requestRender?.();
+	};
+	const scheduleCleanup = (asyncId: string) => {
+		const existingTimer = state.cleanupTimers.get(asyncId);
+		if (existingTimer) clearTimeout(existingTimer);
+		const timer = setTimeout(() => {
+			state.cleanupTimers.delete(asyncId);
+			state.asyncJobs.delete(asyncId);
+			if (state.lastUiContext) {
+				rerenderWidget(state.lastUiContext);
+			}
+		}, completionRetentionMs);
+		state.cleanupTimers.set(asyncId, timer);
+	};
+
 	const ensurePoller = () => {
 		if (state.poller) return;
 		state.poller = setInterval(() => {
 			if (!state.lastUiContext || !state.lastUiContext.hasUI) return;
 			if (state.asyncJobs.size === 0) {
-				renderWidget(state.lastUiContext, []);
+				rerenderWidget(state.lastUiContext, []);
 				if (state.poller) {
 					clearInterval(state.poller);
 					state.poller = null;
@@ -27,12 +51,10 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 			}
 
 			for (const job of state.asyncJobs.values()) {
-				if (job.status === "complete" || job.status === "failed") {
-					continue;
-				}
 				try {
 					const status = readStatus(job.asyncDir);
 					if (status) {
+						const previousStatus = job.status;
 						job.status = status.state;
 						job.mode = status.mode;
 						job.currentStep = status.currentStep ?? job.currentStep;
@@ -46,6 +68,9 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 						job.outputFile = status.outputFile ?? job.outputFile;
 						job.totalTokens = status.totalTokens ?? job.totalTokens;
 						job.sessionFile = status.sessionFile ?? job.sessionFile;
+						if ((job.status === "complete" || job.status === "failed") && previousStatus !== job.status) {
+							scheduleCleanup(job.asyncId);
+						}
 						continue;
 					}
 					job.status = job.status === "queued" ? "running" : job.status;
@@ -57,8 +82,8 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 				}
 			}
 
-			renderWidget(state.lastUiContext, Array.from(state.asyncJobs.values()));
-		}, POLL_INTERVAL_MS);
+			rerenderWidget(state.lastUiContext);
+		}, pollIntervalMs);
 		state.poller.unref?.();
 	};
 
@@ -84,7 +109,7 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 			updatedAt: now,
 		});
 		if (state.lastUiContext) {
-			renderWidget(state.lastUiContext, Array.from(state.asyncJobs.values()));
+			rerenderWidget(state.lastUiContext);
 			ensurePoller();
 		}
 	};
@@ -100,16 +125,9 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 			if (result.asyncDir) job.asyncDir = result.asyncDir;
 		}
 		if (state.lastUiContext) {
-			renderWidget(state.lastUiContext, Array.from(state.asyncJobs.values()));
+			rerenderWidget(state.lastUiContext);
 		}
-		const timer = setTimeout(() => {
-			state.cleanupTimers.delete(asyncId);
-			state.asyncJobs.delete(asyncId);
-			if (state.lastUiContext) {
-				renderWidget(state.lastUiContext, Array.from(state.asyncJobs.values()));
-			}
-		}, 10000);
-		state.cleanupTimers.set(asyncId, timer);
+		scheduleCleanup(asyncId);
 	};
 
 	const resetJobs = (ctx?: ExtensionContext) => {
@@ -121,7 +139,7 @@ export function createAsyncJobTracker(state: SubagentState, asyncDirRoot: string
 		state.resultFileCoalescer.clear();
 		if (ctx?.hasUI) {
 			state.lastUiContext = ctx;
-			renderWidget(ctx, []);
+			rerenderWidget(ctx, []);
 		}
 	};
 

--- a/session-tokens.ts
+++ b/session-tokens.ts
@@ -1,0 +1,47 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface TokenUsage {
+	input: number;
+	output: number;
+	total: number;
+}
+
+function findLatestSessionFile(sessionDir: string): string | null {
+	try {
+		const files = fs.readdirSync(sessionDir)
+			.filter((f) => f.endsWith(".jsonl"))
+			.sort();
+		if (files.length === 0) return null;
+		return path.join(sessionDir, files[files.length - 1]!);
+	} catch {
+		return null;
+	}
+}
+
+export function parseSessionTokens(sessionDir: string): TokenUsage | null {
+	const sessionFile = findLatestSessionFile(sessionDir);
+	if (!sessionFile) return null;
+	try {
+		const content = fs.readFileSync(sessionFile, "utf-8");
+		let input = 0;
+		let output = 0;
+		for (const line of content.split("\n")) {
+			if (!line.trim()) continue;
+			try {
+				const entry = JSON.parse(line);
+				const usage = entry.usage ?? entry.message?.usage;
+				if (usage) {
+					input += usage.inputTokens ?? usage.input ?? 0;
+					output += usage.outputTokens ?? usage.output ?? 0;
+				}
+			} catch {
+				// Ignore malformed lines while scanning usage entries.
+			}
+		}
+		return { input, output, total: input + output };
+	} catch {
+		// Usage extraction should not fail the run.
+		return null;
+	}
+}

--- a/session-tokens.ts
+++ b/session-tokens.ts
@@ -11,9 +11,10 @@ function findLatestSessionFile(sessionDir: string): string | null {
 	try {
 		const files = fs.readdirSync(sessionDir)
 			.filter((f) => f.endsWith(".jsonl"))
-			.sort();
+			.map((f) => path.join(sessionDir, f));
 		if (files.length === 0) return null;
-		return path.join(sessionDir, files[files.length - 1]!);
+		files.sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+		return files[0] ?? null;
 	} catch {
 		return null;
 	}

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -29,6 +29,7 @@ import {
 import { buildPiArgs, cleanupTempDir } from "./pi-args.ts";
 import { formatModelAttemptNote, isRetryableModelFailure } from "./model-fallback.ts";
 import { detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput } from "./utils.ts";
+import { parseSessionTokens, type TokenUsage } from "./session-tokens.ts";
 import {
 	cleanupWorktrees,
 	createWorktrees,
@@ -85,38 +86,6 @@ function findLatestSessionFile(sessionDir: string): string | null {
 		return files[0] ?? null;
 	} catch {
 		// Session lookup is optional metadata.
-		return null;
-	}
-}
-
-interface TokenUsage {
-	input: number;
-	output: number;
-	total: number;
-}
-
-function parseSessionTokens(sessionDir: string): TokenUsage | null {
-	const sessionFile = findLatestSessionFile(sessionDir);
-	if (!sessionFile) return null;
-	try {
-		const content = fs.readFileSync(sessionFile, "utf-8");
-		let input = 0;
-		let output = 0;
-		for (const line of content.split("\n")) {
-			if (!line.trim()) continue;
-			try {
-				const entry = JSON.parse(line);
-				if (entry.usage) {
-					input += entry.usage.inputTokens ?? entry.usage.input ?? 0;
-					output += entry.usage.outputTokens ?? entry.usage.output ?? 0;
-				}
-			} catch {
-				// Ignore malformed lines while scanning usage entries.
-			}
-		}
-		return { input, output, total: input + output };
-	} catch {
-		// Usage extraction should not fail the run.
 		return null;
 	}
 }

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -219,6 +219,9 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.results[0].model, "anthropic/claude-sonnet-4");
 		assert.deepEqual(payload.results[0].attemptedModels, ["openai/gpt-5-mini", "anthropic/claude-sonnet-4"]);
 		assert.equal(payload.results[0].modelAttempts.length, 2);
+		const statusPayload = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+		assert.ok(statusPayload.totalTokens.total > 0);
+		assert.ok(statusPayload.steps[0].tokens.total > 0);
 		assert.match(fs.readFileSync(path.join(asyncDir, "output-0.log"), "utf-8"), /Recovered asynchronously/);
 		assert.equal(mockPi.callCount(), 2);
 	});

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { createTempDir, removeTempDir, tryImport } from "../support/helpers.ts";
+
+interface AsyncJobTrackerModule {
+	createAsyncJobTracker(
+		state: Record<string, unknown>,
+		asyncDirRoot: string,
+		options?: { completionRetentionMs?: number; pollIntervalMs?: number },
+	): {
+		resetJobs(ctx?: unknown): void;
+		handleStarted(data: unknown): void;
+		handleComplete(data: unknown): void;
+	};
+}
+
+const trackerMod = await tryImport<AsyncJobTrackerModule>("./async-job-tracker.ts");
+const available = !!trackerMod;
+
+function createState() {
+	return {
+		baseCwd: "/repo",
+		currentSessionId: null,
+		asyncJobs: new Map(),
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: {
+			schedule: () => false,
+			clear: () => {},
+		},
+	};
+}
+
+function createUiContext() {
+	const widgets: unknown[] = [];
+	let renderRequests = 0;
+	const ctx = {
+		hasUI: true,
+		ui: {
+			theme: {
+				fg: (_theme: string, text: string) => text,
+			},
+			setWidget: (_key: string, value: unknown) => {
+				widgets.push(value);
+			},
+			requestRender: () => {
+				renderRequests += 1;
+			},
+		},
+	};
+	return {
+		ctx,
+		get widgets() {
+			return widgets;
+		},
+		get renderRequests() {
+			return renderRequests;
+		},
+	};
+}
+
+describe("async job tracker", { skip: !available ? "pi packages not available" : undefined }, () => {
+	it("removes completed jobs after retention and requests a rerender", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-");
+		try {
+			const state = createState();
+			const ui = createUiContext();
+			const tracker = trackerMod!.createAsyncJobTracker(state as never, asyncRoot, {
+				completionRetentionMs: 5,
+			});
+			tracker.resetJobs(ui.ctx as never);
+			tracker.handleStarted({ id: "run-1", asyncDir: path.join(asyncRoot, "run-1"), agent: "worker" });
+			tracker.handleComplete({ id: "run-1", success: true });
+
+			assert.equal(state.asyncJobs.size, 1);
+			await new Promise((resolve) => setTimeout(resolve, 40));
+
+			assert.equal(state.asyncJobs.size, 0);
+			assert.ok(ui.renderRequests > 0, "expected widget cleanup to request a rerender");
+			assert.equal(ui.widgets.at(-1), undefined);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("schedules cleanup when polling observes a completed status without a completion event", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-");
+		try {
+			const runDir = path.join(asyncRoot, "run-2");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-2",
+				mode: "single",
+				state: "complete",
+				startedAt: Date.now() - 1000,
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "complete" }],
+			}), "utf-8");
+
+			const state = createState();
+			const ui = createUiContext();
+			const tracker = trackerMod!.createAsyncJobTracker(state as never, asyncRoot, {
+				completionRetentionMs: 5,
+				pollIntervalMs: 10,
+			});
+			tracker.resetJobs(ui.ctx as never);
+			tracker.handleStarted({ id: "run-2", asyncDir: runDir, agent: "worker" });
+
+			await new Promise((resolve) => setTimeout(resolve, 80));
+
+			assert.equal(state.asyncJobs.size, 0);
+			assert.ok(ui.renderRequests > 0, "expected polling cleanup to request a rerender");
+			assert.equal(ui.widgets.at(-1), undefined);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+});

--- a/test/integration/session-tokens.test.ts
+++ b/test/integration/session-tokens.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { createTempDir, removeTempDir, tryImport } from "../support/helpers.ts";
+
+interface SessionTokensModule {
+	parseSessionTokens(sessionDir: string): { input: number; output: number; total: number } | null;
+}
+
+const tokensMod = await tryImport<SessionTokensModule>("./session-tokens.ts");
+const available = !!tokensMod;
+
+describe("session tokens", { skip: !available ? "pi packages not available" : undefined }, () => {
+	it("parses token usage from session message entries", () => {
+		const sessionDir = createTempDir("pi-subagent-session-tokens-");
+		try {
+			const sessionFile = path.join(sessionDir, "2026-01-01T00-00-00-000Z_test.jsonl");
+			const lines = [
+				JSON.stringify({
+					type: "message",
+					message: {
+						role: "assistant",
+						usage: { input: 120, output: 30 },
+					},
+				}),
+				JSON.stringify({
+					type: "message",
+					message: {
+						role: "assistant",
+						usage: { inputTokens: 80, outputTokens: 20 },
+					},
+				}),
+			].join("\n");
+			fs.writeFileSync(sessionFile, lines + "\n", "utf-8");
+
+			const tokens = tokensMod!.parseSessionTokens(sessionDir);
+			assert.deepEqual(tokens, { input: 200, output: 50, total: 250 });
+		} finally {
+			removeTempDir(sessionDir);
+		}
+	});
+});

--- a/test/integration/session-tokens.test.ts
+++ b/test/integration/session-tokens.test.ts
@@ -40,4 +40,23 @@ describe("session tokens", { skip: !available ? "pi packages not available" : un
 			removeTempDir(sessionDir);
 		}
 	});
+
+	it("uses the newest session file by mtime when multiple files exist", () => {
+		const sessionDir = createTempDir("pi-subagent-session-tokens-");
+		try {
+			const olderFile = path.join(sessionDir, "z-last-lexicographically.jsonl");
+			const newerFile = path.join(sessionDir, "a-first-lexicographically.jsonl");
+			fs.writeFileSync(olderFile, JSON.stringify({ type: "message", message: { usage: { input: 10, output: 5 } } }) + "\n", "utf-8");
+			fs.writeFileSync(newerFile, JSON.stringify({ type: "message", message: { usage: { input: 90, output: 10 } } }) + "\n", "utf-8");
+			const olderTime = new Date("2026-01-01T00:00:00.000Z");
+			const newerTime = new Date("2026-01-01T00:00:10.000Z");
+			fs.utimesSync(olderFile, olderTime, olderTime);
+			fs.utimesSync(newerFile, newerTime, newerTime);
+
+			const tokens = tokensMod!.parseSessionTokens(sessionDir);
+			assert.deepEqual(tokens, { input: 90, output: 10, total: 100 });
+		} finally {
+			removeTempDir(sessionDir);
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- rerender the async widget when cleanup state changes
- schedule cleanup when polling discovers a completed run
- read async token usage from `message.usage`
- prefer the newest session file by mtime when multiple session files exist

Closes #100.

## Testing
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/async-job-tracker.test.ts test/integration/session-tokens.test.ts`
