### PR TITLE
feat: force top-level async mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,33 @@ This aggregated output becomes `{previous}` for the next step.
 
 `pi-subagents` reads optional JSON config from `~/.pi/agent/extensions/subagent/config.json`.
 
+### `asyncByDefault`
+
+`asyncByDefault` makes top-level subagent calls use background execution when the request does not explicitly set `async`.
+
+```json
+{
+  "asyncByDefault": true
+}
+```
+
+This only changes the default. Callers can still force foreground execution by setting `async: false` unless `forceTopLevelAsync` is also enabled.
+
+### `forceTopLevelAsync`
+
+`forceTopLevelAsync` forces depth-0 subagent execution into background mode. This is useful for automation setups that never want the top-level orchestrator to block on child runs.
+
+```json
+{
+  "forceTopLevelAsync": true
+}
+```
+
+When enabled:
+- top-level single, parallel, and chain runs are forced to `async: true`
+- top-level clarify UI is bypassed by forcing `clarify: false`
+- nested subagent calls still follow their own inherited depth and async settings
+
 ### `parallel`
 
 `parallel` controls top-level `tasks` mode defaults and limits.

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@
  * Toggle: async parameter (default: false, configurable via config.json)
  *
  * Config file: ~/.pi/agent/extensions/subagent/config.json
- *   { "asyncByDefault": true, "maxSubagentDepth": 1, "intercomBridge": { "mode": "always", "instructionFile": "./intercom-bridge.md" }, "worktreeSetupHook": "./scripts/setup-worktree.mjs" }
+ *   { "asyncByDefault": true, "forceTopLevelAsync": true, "maxSubagentDepth": 1, "intercomBridge": { "mode": "always", "instructionFile": "./intercom-bridge.md" }, "worktreeSetupHook": "./scripts/setup-worktree.mjs" }
  */
 
 import * as fs from "node:fs";

--- a/subagent-executor.ts
+++ b/subagent-executor.ts
@@ -1250,20 +1250,24 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return toExecutionErrorResult(normalizedParams, error);
 		}
 
-		const requestedAsync = normalizedParams.async ?? deps.asyncByDefault;
-		const backgroundRequestedWhileClarifying = hasTasks && requestedAsync && normalizedParams.clarify === true;
+		const forceTopLevelAsync = depth === 0 && deps.config.forceTopLevelAsync === true;
+		const effectiveParams = forceTopLevelAsync
+			? { ...normalizedParams, async: true, clarify: false }
+			: normalizedParams;
+		const requestedAsync = effectiveParams.async ?? deps.asyncByDefault;
+		const backgroundRequestedWhileClarifying = hasTasks && requestedAsync && effectiveParams.clarify === true;
 		const effectiveAsync = requestedAsync
-			&& (hasChain ? normalizedParams.clarify === false : normalizedParams.clarify !== true);
+			&& (hasChain ? effectiveParams.clarify === false : effectiveParams.clarify !== true);
 
 		const artifactConfig: ArtifactConfig = {
 			...DEFAULT_ARTIFACT_CONFIG,
-			enabled: normalizedParams.artifacts !== false,
+			enabled: effectiveParams.artifacts !== false,
 		};
 		const artifactsDir = effectiveAsync ? deps.tempArtifactsDir : getArtifactsDir(parentSessionFile);
 
 		let sessionRoot: string;
-		if (normalizedParams.sessionDir) {
-			sessionRoot = path.resolve(deps.expandTilde(normalizedParams.sessionDir));
+		if (effectiveParams.sessionDir) {
+			sessionRoot = path.resolve(deps.expandTilde(effectiveParams.sessionDir));
 		} else {
 			const baseSessionRoot = deps.config.defaultSessionDir
 				? path.resolve(deps.expandTilde(deps.config.defaultSessionDir))
@@ -1287,7 +1291,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			: undefined;
 
 		const execData: ExecutionContextData = {
-			params: normalizedParams,
+			params: effectiveParams,
 			effectiveCwd,
 			ctx,
 			signal,

--- a/subagent-executor.ts
+++ b/subagent-executor.ts
@@ -26,6 +26,7 @@ import { createForkContextResolver } from "./fork-context.ts";
 import { applyIntercomBridgeToAgent, resolveIntercomBridge, resolveIntercomSessionTarget } from "./intercom-bridge.ts";
 import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutputPath } from "./single-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, resolveChildCwd } from "./utils.ts";
+import { applyForceTopLevelAsyncOverride } from "./top-level-async.ts";
 import {
 	cleanupWorktrees,
 	createWorktrees,
@@ -1209,32 +1210,38 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		if (normalized.error) return normalized.error;
 		const normalizedParams = normalized.params!;
 
-		const scope: AgentScope = resolveExecutionAgentScope(normalizedParams.agentScope);
-		const effectiveCwd = normalizedParams.cwd ?? ctx.cwd;
+		const effectiveParams = applyForceTopLevelAsyncOverride(
+			normalizedParams,
+			depth,
+			deps.config.forceTopLevelAsync === true,
+		);
+
+		const scope: AgentScope = resolveExecutionAgentScope(effectiveParams.agentScope);
+		const effectiveCwd = effectiveParams.cwd ?? ctx.cwd;
 		const parentSessionFile = ctx.sessionManager.getSessionFile() ?? null;
 		deps.state.currentSessionId = parentSessionFile ?? `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 		const discoveredAgents = deps.discoverAgents(effectiveCwd, scope).agents;
 		const sessionName = resolveIntercomSessionTarget(deps.pi.getSessionName(), ctx.sessionManager.getSessionId());
 		const intercomBridge = resolveIntercomBridge({
 			config: deps.config.intercomBridge,
-			context: normalizedParams.context,
+			context: effectiveParams.context,
 			orchestratorTarget: sessionName,
 		});
 		const agents = intercomBridge.active
 			? discoveredAgents.map((agent) => applyIntercomBridgeToAgent(agent, intercomBridge))
 			: discoveredAgents;
 		const runId = randomUUID().slice(0, 8);
-		const shareEnabled = normalizedParams.share === true;
-		const hasChain = (normalizedParams.chain?.length ?? 0) > 0;
-		const hasTasks = (normalizedParams.tasks?.length ?? 0) > 0;
-		const hasSingle = Boolean(normalizedParams.agent && normalizedParams.task);
+		const shareEnabled = effectiveParams.share === true;
+		const hasChain = (effectiveParams.chain?.length ?? 0) > 0;
+		const hasTasks = (effectiveParams.tasks?.length ?? 0) > 0;
+		const hasSingle = Boolean(effectiveParams.agent && effectiveParams.task);
 		const allowClarifyTaskPrompt = hasChain
-			&& normalizedParams.clarify === true
+			&& effectiveParams.clarify === true
 			&& ctx.hasUI
-			&& !(normalizedParams.chain?.some(isParallelStep) ?? false);
+			&& !(effectiveParams.chain?.some(isParallelStep) ?? false);
 
 		const validationError = validateExecutionInput(
-			normalizedParams,
+			effectiveParams,
 			agents,
 			hasChain,
 			hasTasks,
@@ -1245,15 +1252,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 
 		let sessionFileForIndex: (idx?: number) => string | undefined = () => undefined;
 		try {
-			sessionFileForIndex = createForkContextResolver(ctx.sessionManager, normalizedParams.context).sessionFileForIndex;
+			sessionFileForIndex = createForkContextResolver(ctx.sessionManager, effectiveParams.context).sessionFileForIndex;
 		} catch (error) {
-			return toExecutionErrorResult(normalizedParams, error);
+			return toExecutionErrorResult(effectiveParams, error);
 		}
-
-		const forceTopLevelAsync = depth === 0 && deps.config.forceTopLevelAsync === true;
-		const effectiveParams = forceTopLevelAsync
-			? { ...normalizedParams, async: true, clarify: false }
-			: normalizedParams;
 		const requestedAsync = effectiveParams.async ?? deps.asyncByDefault;
 		const backgroundRequestedWhileClarifying = hasTasks && requestedAsync && effectiveParams.clarify === true;
 		const effectiveAsync = requestedAsync
@@ -1279,7 +1281,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			return toExecutionErrorResult(
-				normalizedParams,
+				effectiveParams,
 				new Error(`Failed to create session directory '${sessionRoot}': ${message}`),
 			);
 		}
@@ -1287,7 +1289,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			path.join(sessionRoot, `run-${idx ?? 0}`);
 
 		const onUpdateWithContext = onUpdate
-			? (r: AgentToolResult<Details>) => onUpdate(withForkContext(r, normalizedParams.context))
+			? (r: AgentToolResult<Details>) => onUpdate(withForkContext(r, effectiveParams.context))
 			: undefined;
 
 		const execData: ExecutionContextData = {
@@ -1310,18 +1312,18 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 
 		try {
 			const asyncResult = runAsyncPath(execData, deps);
-			if (asyncResult) return withForkContext(asyncResult, normalizedParams.context);
+			if (asyncResult) return withForkContext(asyncResult, effectiveParams.context);
 
-			if (hasChain && normalizedParams.chain) {
-				return withForkContext(await runChainPath(execData, deps), normalizedParams.context);
+			if (hasChain && effectiveParams.chain) {
+				return withForkContext(await runChainPath(execData, deps), effectiveParams.context);
 			}
 
-			if (hasTasks && normalizedParams.tasks) {
-				return withForkContext(await runParallelPath(execData, deps), normalizedParams.context);
+			if (hasTasks && effectiveParams.tasks) {
+				return withForkContext(await runParallelPath(execData, deps), effectiveParams.context);
 			}
 
 			if (hasSingle) {
-				return withForkContext(await runSinglePath(execData, deps), normalizedParams.context);
+				return withForkContext(await runSinglePath(execData, deps), effectiveParams.context);
 			}
 		} catch (error) {
 			return toExecutionErrorResult(normalizedParams, error);
@@ -1331,7 +1333,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			content: [{ type: "text", text: "Invalid params" }],
 			isError: true,
 			details: { mode: "single" as const, results: [] },
-		}, normalizedParams.context);
+		}, effectiveParams.context);
 	};
 
 	return { execute };

--- a/test/integration/top-level-async.test.ts
+++ b/test/integration/top-level-async.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { tryImport } from "../support/helpers.ts";
+
+interface TopLevelAsyncModule {
+	applyForceTopLevelAsyncOverride<T extends { async?: boolean; clarify?: boolean }>(
+		params: T,
+		depth: number,
+		forceTopLevelAsync: boolean,
+	): T;
+}
+
+const mod = await tryImport<TopLevelAsyncModule>("./top-level-async.ts");
+const available = !!mod;
+
+describe("force top-level async helper", { skip: !available ? "pi packages not available" : undefined }, () => {
+	it("forces top-level calls async and disables clarify", () => {
+		const params = { async: false, clarify: true, agent: "worker" };
+		const next = mod!.applyForceTopLevelAsyncOverride(params, 0, true);
+		assert.notEqual(next, params);
+		assert.equal(next.async, true);
+		assert.equal(next.clarify, false);
+		assert.equal(next.agent, "worker");
+	});
+
+	it("leaves nested calls unchanged", () => {
+		const params = { async: false, clarify: true };
+		const next = mod!.applyForceTopLevelAsyncOverride(params, 1, true);
+		assert.equal(next, params);
+	});
+
+	it("leaves top-level calls unchanged when the feature is off", () => {
+		const params = { async: false, clarify: true };
+		const next = mod!.applyForceTopLevelAsyncOverride(params, 0, false);
+		assert.equal(next, params);
+	});
+});

--- a/top-level-async.ts
+++ b/top-level-async.ts
@@ -1,0 +1,13 @@
+export interface AsyncOverrideParams {
+	async?: boolean;
+	clarify?: boolean;
+}
+
+export function applyForceTopLevelAsyncOverride<T extends AsyncOverrideParams>(
+	params: T,
+	depth: number,
+	forceTopLevelAsync: boolean,
+): T {
+	if (!(depth === 0 && forceTopLevelAsync)) return params;
+	return { ...params, async: true, clarify: false };
+}

--- a/types.ts
+++ b/types.ts
@@ -288,6 +288,7 @@ export interface TopLevelParallelConfig {
 
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
+	forceTopLevelAsync?: boolean;
 	defaultSessionDir?: string;
 	maxSubagentDepth?: number;
 	parallel?: TopLevelParallelConfig;


### PR DESCRIPTION
## Summary
- add `forceTopLevelAsync` to the extension config
- force depth-0 runs to `async: true` and `clarify: false`
- apply the override before validation and fork/session setup
- add focused coverage for the override helper

Closes #101.

## Testing
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/top-level-async.test.ts`
