### PR TITLE
fix: fail background async launch on invalid cwd or spawn error

### DIFF
--- a/async-execution.ts
+++ b/async-execution.ts
@@ -114,22 +114,39 @@ export function isAsyncAvailable(): boolean {
 /**
  * Spawn the async runner process
  */
-function spawnRunner(cfg: object, suffix: string, cwd: string): number | undefined {
-	if (!jitiCliPath) return undefined;
-	
+function spawnRunner(cfg: object, suffix: string, cwd: string): { pid?: number; error?: string } {
+	if (!jitiCliPath) {
+		return { error: "jiti for TypeScript execution could not be found" };
+	}
+
+	try {
+		const cwdStats = fs.statSync(cwd);
+		if (!cwdStats.isDirectory()) {
+			return { error: `cwd is not a directory: ${cwd}` };
+		}
+	} catch {
+		return { error: `cwd does not exist: ${cwd}` };
+	}
+
 	fs.mkdirSync(TEMP_ROOT_DIR, { recursive: true });
 	const cfgPath = getAsyncConfigPath(suffix);
 	fs.writeFileSync(cfgPath, JSON.stringify(cfg));
 	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
-	
+
 	const proc = spawn(process.execPath, [jitiCliPath, runner, cfgPath], {
 		cwd,
 		detached: true,
 		stdio: "ignore",
 		windowsHide: true,
 	});
+	proc.on("error", (error) => {
+		console.error(`[pi-subagents] async spawn failed: ${error.message}`);
+	});
+	if (typeof proc.pid !== "number") {
+		return { error: `async runner did not produce a pid for cwd: ${cwd}` };
+	}
 	proc.unref();
-	return proc.pid;
+	return { pid: proc.pid };
 }
 
 function formatAsyncStartError(mode: "single" | "chain", message: string): AsyncExecutionResult {
@@ -260,9 +277,9 @@ export function executeAsyncChain(
 		return buildSeqStep(s as SequentialStep, nextSessionFile());
 	});
 
-	let pid: number | undefined;
+	let spawnResult: { pid?: number; error?: string } = {};
 	try {
-		pid = spawnRunner(
+		spawnResult = spawnRunner(
 			{
 				id,
 				steps,
@@ -289,14 +306,18 @@ export function executeAsyncChain(
 		return formatAsyncStartError("chain", `Failed to start async chain '${id}': ${message}`);
 	}
 
-	if (pid) {
+	if (spawnResult.error) {
+		return formatAsyncStartError("chain", `Failed to start async chain '${id}': ${spawnResult.error}`);
+	}
+
+	if (spawnResult.pid) {
 		const firstStep = chain[0];
 		const firstAgents = isParallelStep(firstStep)
 			? firstStep.parallel.map((t) => t.agent)
 			: [(firstStep as SequentialStep).agent];
 		ctx.pi.events.emit("subagent:started", {
 			id,
-			pid,
+			pid: spawnResult.pid,
 			agent: firstAgents[0],
 			task: isParallelStep(firstStep)
 				? firstStep.parallel[0]?.task?.slice(0, 50)
@@ -368,9 +389,9 @@ export function executeAsyncSingle(
 
 	const outputPath = resolveSingleOutputPath(params.output, ctx.cwd, runnerCwd);
 	const taskWithOutputInstruction = injectSingleOutputInstruction(task, outputPath);
-	let pid: number | undefined;
+	let spawnResult: { pid?: number; error?: string } = {};
 	try {
-		pid = spawnRunner(
+		spawnResult = spawnRunner(
 			{
 				id,
 				steps: [
@@ -418,10 +439,14 @@ export function executeAsyncSingle(
 		return formatAsyncStartError("single", `Failed to start async run '${id}': ${message}`);
 	}
 
-	if (pid) {
+	if (spawnResult.error) {
+		return formatAsyncStartError("single", `Failed to start async run '${id}': ${spawnResult.error}`);
+	}
+
+	if (spawnResult.pid) {
 		ctx.pi.events.emit("subagent:started", {
 			id,
-			pid,
+			pid: spawnResult.pid,
 			agent,
 			task: task?.slice(0, 50),
 			cwd: runnerCwd,

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -432,6 +432,88 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(result.content[0]?.text ?? "", /async-cfg-/);
 	});
 
+	it("returns a tool error when an async run uses a missing cwd", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
+		const id = `async-missing-cwd-${Date.now().toString(36)}`;
+		const missingCwd = path.join(tempDir, "missing-cwd");
+
+		const singleResult = executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			cwd: missingCwd,
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			maxSubagentDepth: 2,
+		});
+
+		assert.equal(singleResult.isError, true);
+		assert.match(singleResult.content[0]?.text ?? "", /Failed to start async run/);
+		assert.match(singleResult.content[0]?.text ?? "", /cwd does not exist/);
+
+		const chainId = `async-missing-cwd-chain-${Date.now().toString(36)}`;
+		const chainResult = executeAsyncChain(chainId, {
+			chain: [{ agent: "worker", task: "Do work" }],
+			agents: [makeAgent("worker")],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			cwd: missingCwd,
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			maxSubagentDepth: 2,
+		});
+
+		assert.equal(chainResult.isError, true);
+		assert.match(chainResult.content[0]?.text ?? "", /Failed to start async chain/);
+		assert.match(chainResult.content[0]?.text ?? "", /cwd does not exist/);
+	});
+
+	it("returns a tool error when the async runner process cannot spawn", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
+		const originalExecPath = process.execPath;
+		process.execPath = path.join(tempDir, "missing-node");
+		try {
+			const id = `async-spawn-fail-${Date.now().toString(36)}`;
+			const result = executeAsyncSingle(id, {
+				agent: "worker",
+				task: "Do work",
+				agentConfig: makeAgent("worker"),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: {
+					enabled: false,
+					includeInput: false,
+					includeOutput: false,
+					includeJsonl: false,
+					includeMetadata: false,
+					cleanupDays: 7,
+				},
+				shareEnabled: false,
+				sessionRoot: path.join(tempDir, "sessions"),
+				maxSubagentDepth: 2,
+			});
+
+			assert.equal(result.isError, true);
+			assert.match(result.content[0]?.text ?? "", /Failed to start async run/);
+			assert.match(result.content[0]?.text ?? "", /async runner did not produce a pid/);
+		} finally {
+			process.execPath = originalExecPath;
+		}
+	});
+
 	it("returns a tool error when an async chain cannot write its detached runner config", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
 		const id = `async-chain-write-fail-${Date.now().toString(36)}`;
 		assert.ok(TEMP_ROOT_DIR, "TEMP_ROOT_DIR should be available for async tests");


### PR DESCRIPTION
## Summary
- validate the resolved async cwd before spawning the detached runner
- return a tool error when launch fails to produce a usable child process
- log detached child-process spawn errors for diagnostics
- add regression coverage for missing cwd and spawn failure paths

Closes #99.

## Testing
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test --test-name-pattern='returns a tool error when an async run uses a missing cwd|returns a tool error when the async runner process cannot spawn' test/integration/async-execution.test.ts`
