### PR TITLE
fix(runner): drain stuck child processes

### DIFF
--- a/execution.ts
+++ b/execution.ts
@@ -34,6 +34,7 @@ import {
 import { buildSkillInjection, resolveSkillsWithFallback } from "./skills.ts";
 import { getPiSpawnCommand } from "./pi-spawn.ts";
 import { createJsonlWriter } from "./jsonl-writer.ts";
+import { attachPostExitStdioGuard } from "./post-exit-stdio-guard.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir } from "./pi-args.ts";
 import { captureSingleOutputSnapshot, resolveSingleOutput, type SingleOutputSnapshot } from "./single-output.ts";
 import {
@@ -203,6 +204,7 @@ async function runSingleAttempt(
 			if (settled) return;
 			settled = true;
 			clearFinalDrainTimers();
+			clearStdioGuard();
 			unsubscribeIntercomDetach?.();
 			removeAbortListener?.();
 			resolve(code);
@@ -290,6 +292,7 @@ async function runSingleAttempt(
 
 		let stderrBuf = "";
 
+		const clearStdioGuard = attachPostExitStdioGuard(proc, { idleMs: 2000, hardMs: 8000 });
 		proc.stdout.on("data", (d) => {
 			buf += d.toString();
 			const lines = buf.split("\n");
@@ -299,24 +302,12 @@ async function runSingleAttempt(
 		proc.stderr.on("data", (d) => {
 			stderrBuf += d.toString();
 		});
-		// `close` can outlive `exit` if a grandchild still holds stdout/stderr.
-		// After `exit`, give stdio a short grace window, then destroy it.
-		let staleStdioGrace: NodeJS.Timeout | undefined;
 		proc.on("exit", () => {
 			clearFinalDrainTimers();
-			if (staleStdioGrace) return;
-			staleStdioGrace = setTimeout(() => {
-				try { proc.stdout?.destroy(); } catch {}
-				try { proc.stderr?.destroy(); } catch {}
-			}, 2000);
-			staleStdioGrace.unref?.();
 		});
 		proc.on("close", (code) => {
 			clearFinalDrainTimers();
-			if (staleStdioGrace) {
-				clearTimeout(staleStdioGrace);
-				staleStdioGrace = undefined;
-			}
+			clearStdioGuard();
 			void jsonlWriter.close().catch(() => {
 				// JSONL artifact flush is best effort.
 			});
@@ -333,6 +324,8 @@ async function runSingleAttempt(
 			finish(code ?? 0);
 		});
 		proc.on("error", (error) => {
+			clearFinalDrainTimers();
+			clearStdioGuard();
 			void jsonlWriter.close().catch(() => {
 				// JSONL artifact flush is best effort.
 			});

--- a/execution.ts
+++ b/execution.ts
@@ -161,6 +161,8 @@ async function runSingleAttempt(
 		// start a bounded drain window and force termination if needed.
 		const FINAL_DRAIN_MS = 5000;
 		const HARD_KILL_MS = 3000;
+		let childExited = false;
+		let forcedTerminationSignal = false;
 		let finalDrainTimer: NodeJS.Timeout | undefined;
 		let finalHardKillTimer: NodeJS.Timeout | undefined;
 		const clearFinalDrainTimers = () => {
@@ -174,14 +176,16 @@ async function runSingleAttempt(
 			}
 		};
 		const startFinalDrain = () => {
-			if (finalDrainTimer || settled || processClosed || detached) return;
+			if (childExited || finalDrainTimer || settled || processClosed || detached) return;
 			finalDrainTimer = setTimeout(() => {
 				if (settled || processClosed || detached) return;
 				result.error = result.error
 					?? `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
+				forcedTerminationSignal = true;
 				try { proc.kill("SIGTERM"); } catch {}
 				finalHardKillTimer = setTimeout(() => {
 					if (settled || processClosed || detached) return;
+					forcedTerminationSignal = true;
 					try { proc.kill("SIGKILL"); } catch {}
 				}, HARD_KILL_MS);
 				finalHardKillTimer.unref?.();
@@ -303,9 +307,10 @@ async function runSingleAttempt(
 			stderrBuf += d.toString();
 		});
 		proc.on("exit", () => {
+			childExited = true;
 			clearFinalDrainTimers();
 		});
-		proc.on("close", (code) => {
+		proc.on("close", (code, signal) => {
 			clearFinalDrainTimers();
 			clearStdioGuard();
 			void jsonlWriter.close().catch(() => {
@@ -321,7 +326,8 @@ async function runSingleAttempt(
 			if (code !== 0 && stderrBuf.trim() && !result.error) {
 				result.error = stderrBuf.trim();
 			}
-			finish(code ?? 0);
+			const finalCode = forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
+			finish(finalCode);
 		});
 		proc.on("error", (error) => {
 			clearFinalDrainTimers();

--- a/execution.ts
+++ b/execution.ts
@@ -34,7 +34,7 @@ import {
 import { buildSkillInjection, resolveSkillsWithFallback } from "./skills.ts";
 import { getPiSpawnCommand } from "./pi-spawn.ts";
 import { createJsonlWriter } from "./jsonl-writer.ts";
-import { attachPostExitStdioGuard } from "./post-exit-stdio-guard.ts";
+import { attachPostExitStdioGuard, trySignalChild } from "./post-exit-stdio-guard.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir } from "./pi-args.ts";
 import { captureSingleOutputSnapshot, resolveSingleOutput, type SingleOutputSnapshot } from "./single-output.ts";
 import {
@@ -179,16 +179,14 @@ async function runSingleAttempt(
 			if (childExited || finalDrainTimer || settled || processClosed || detached) return;
 			finalDrainTimer = setTimeout(() => {
 				if (settled || processClosed || detached) return;
+				const termSent = trySignalChild(proc, "SIGTERM");
+				if (!termSent) return;
+				forcedTerminationSignal = true;
 				result.error = result.error
 					?? `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
-				try {
-					forcedTerminationSignal = proc.kill("SIGTERM");
-				} catch {}
 				finalHardKillTimer = setTimeout(() => {
 					if (settled || processClosed || detached) return;
-					try {
-						forcedTerminationSignal = proc.kill("SIGKILL") || forcedTerminationSignal;
-					} catch {}
+					forcedTerminationSignal = trySignalChild(proc, "SIGKILL") || forcedTerminationSignal;
 				}, HARD_KILL_MS);
 				finalHardKillTimer.unref?.();
 			}, FINAL_DRAIN_MS);

--- a/execution.ts
+++ b/execution.ts
@@ -181,12 +181,14 @@ async function runSingleAttempt(
 				if (settled || processClosed || detached) return;
 				result.error = result.error
 					?? `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
-				forcedTerminationSignal = true;
-				try { proc.kill("SIGTERM"); } catch {}
+				try {
+					forcedTerminationSignal = proc.kill("SIGTERM");
+				} catch {}
 				finalHardKillTimer = setTimeout(() => {
 					if (settled || processClosed || detached) return;
-					forcedTerminationSignal = true;
-					try { proc.kill("SIGKILL"); } catch {}
+					try {
+						forcedTerminationSignal = proc.kill("SIGKILL") || forcedTerminationSignal;
+					} catch {}
 				}, HARD_KILL_MS);
 				finalHardKillTimer.unref?.();
 			}, FINAL_DRAIN_MS);

--- a/execution.ts
+++ b/execution.ts
@@ -156,6 +156,38 @@ async function runSingleAttempt(
 			finish(-2);
 		};
 
+		// If the child emits its final assistant message but never exits,
+		// start a bounded drain window and force termination if needed.
+		const FINAL_DRAIN_MS = 5000;
+		const HARD_KILL_MS = 3000;
+		let finalDrainTimer: NodeJS.Timeout | undefined;
+		let finalHardKillTimer: NodeJS.Timeout | undefined;
+		const clearFinalDrainTimers = () => {
+			if (finalDrainTimer) {
+				clearTimeout(finalDrainTimer);
+				finalDrainTimer = undefined;
+			}
+			if (finalHardKillTimer) {
+				clearTimeout(finalHardKillTimer);
+				finalHardKillTimer = undefined;
+			}
+		};
+		const startFinalDrain = () => {
+			if (finalDrainTimer || settled || processClosed || detached) return;
+			finalDrainTimer = setTimeout(() => {
+				if (settled || processClosed || detached) return;
+				result.error = result.error
+					?? `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
+				try { proc.kill("SIGTERM"); } catch {}
+				finalHardKillTimer = setTimeout(() => {
+					if (settled || processClosed || detached) return;
+					try { proc.kill("SIGKILL"); } catch {}
+				}, HARD_KILL_MS);
+				finalHardKillTimer.unref?.();
+			}, FINAL_DRAIN_MS);
+			finalDrainTimer.unref?.();
+		};
+
 		const unsubscribeIntercomDetach = options.intercomEvents?.on?.(INTERCOM_DETACH_REQUEST_EVENT, (payload) => {
 			if (!options.allowIntercomDetach || detached || processClosed) return;
 			if (!payload || typeof payload !== "object") return;
@@ -170,6 +202,7 @@ async function runSingleAttempt(
 		const finish = (code: number) => {
 			if (settled) return;
 			settled = true;
+			clearFinalDrainTimers();
 			unsubscribeIntercomDetach?.();
 			removeAbortListener?.();
 			resolve(code);
@@ -237,6 +270,13 @@ async function runSingleAttempt(
 					if (!result.model && evt.message.model) result.model = evt.message.model;
 					if (evt.message.errorMessage) result.error = evt.message.errorMessage;
 					appendRecentOutput(progress, extractTextFromContent(evt.message.content).split("\n").slice(-10));
+					// Final assistant message: start the exit drain window.
+					const stopReason = (evt.message as { stopReason?: string }).stopReason;
+					const hasToolCall = Array.isArray(evt.message.content)
+						&& evt.message.content.some((part) => (part as { type?: string }).type === "toolCall");
+					if (stopReason === "stop" && !hasToolCall) {
+						startFinalDrain();
+					}
 				}
 				fireUpdate();
 			}
@@ -259,7 +299,24 @@ async function runSingleAttempt(
 		proc.stderr.on("data", (d) => {
 			stderrBuf += d.toString();
 		});
+		// `close` can outlive `exit` if a grandchild still holds stdout/stderr.
+		// After `exit`, give stdio a short grace window, then destroy it.
+		let staleStdioGrace: NodeJS.Timeout | undefined;
+		proc.on("exit", () => {
+			clearFinalDrainTimers();
+			if (staleStdioGrace) return;
+			staleStdioGrace = setTimeout(() => {
+				try { proc.stdout?.destroy(); } catch {}
+				try { proc.stderr?.destroy(); } catch {}
+			}, 2000);
+			staleStdioGrace.unref?.();
+		});
 		proc.on("close", (code) => {
+			clearFinalDrainTimers();
+			if (staleStdioGrace) {
+				clearTimeout(staleStdioGrace);
+				staleStdioGrace = undefined;
+			}
 			void jsonlWriter.close().catch(() => {
 				// JSONL artifact flush is best effort.
 			});

--- a/post-exit-stdio-guard.ts
+++ b/post-exit-stdio-guard.ts
@@ -1,0 +1,73 @@
+import type { ChildProcess } from "node:child_process";
+
+interface PostExitStdioGuardOptions {
+	idleMs: number;
+	hardMs: number;
+}
+
+interface ChildWithPipedStdio {
+	stdout: ChildProcess["stdout"];
+	stderr: ChildProcess["stderr"];
+	on: ChildProcess["on"];
+}
+
+export function attachPostExitStdioGuard(
+	child: ChildWithPipedStdio,
+	options: PostExitStdioGuardOptions,
+): () => void {
+	const { idleMs, hardMs } = options;
+	let exited = false;
+	let stdoutEnded = false;
+	let stderrEnded = false;
+	let idleTimer: NodeJS.Timeout | undefined;
+	let hardTimer: NodeJS.Timeout | undefined;
+
+	const destroyUnendedStdio = () => {
+		if (!stdoutEnded) {
+			try { child.stdout?.destroy(); } catch {}
+		}
+		if (!stderrEnded) {
+			try { child.stderr?.destroy(); } catch {}
+		}
+	};
+
+	const clearTimers = () => {
+		if (idleTimer) {
+			clearTimeout(idleTimer);
+			idleTimer = undefined;
+		}
+		if (hardTimer) {
+			clearTimeout(hardTimer);
+			hardTimer = undefined;
+		}
+	};
+
+	const armIdleTimer = () => {
+		if (!exited) return;
+		if (idleTimer) clearTimeout(idleTimer);
+		idleTimer = setTimeout(destroyUnendedStdio, idleMs);
+		idleTimer.unref?.();
+	};
+
+	child.stdout?.on("data", armIdleTimer);
+	child.stderr?.on("data", armIdleTimer);
+	child.stdout?.on("end", () => {
+		stdoutEnded = true;
+		if (stdoutEnded && stderrEnded) clearTimers();
+	});
+	child.stderr?.on("end", () => {
+		stderrEnded = true;
+		if (stdoutEnded && stderrEnded) clearTimers();
+	});
+	child.on("exit", () => {
+		exited = true;
+		armIdleTimer();
+		if (hardTimer) return;
+		hardTimer = setTimeout(destroyUnendedStdio, hardMs);
+		hardTimer.unref?.();
+	});
+	child.on("close", clearTimers);
+	child.on("error", clearTimers);
+
+	return clearTimers;
+}

--- a/post-exit-stdio-guard.ts
+++ b/post-exit-stdio-guard.ts
@@ -11,6 +11,18 @@ interface ChildWithPipedStdio {
 	on: ChildProcess["on"];
 }
 
+interface ChildWithKill {
+	kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+export function trySignalChild(child: ChildWithKill, signal: NodeJS.Signals): boolean {
+	try {
+		return child.kill(signal);
+	} catch {
+		return false;
+	}
+}
+
 export function attachPostExitStdioGuard(
 	child: ChildWithPipedStdio,
 	options: PostExitStdioGuardOptions,

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -28,6 +28,7 @@ import {
 } from "./parallel-utils.ts";
 import { buildPiArgs, cleanupTempDir } from "./pi-args.ts";
 import { formatModelAttemptNote, isRetryableModelFailure } from "./model-fallback.ts";
+import { attachPostExitStdioGuard } from "./post-exit-stdio-guard.ts";
 import { detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput } from "./utils.ts";
 import {
 	cleanupWorktrees,
@@ -276,6 +277,14 @@ function runPiStreaming(
 			}
 		};
 
+		// Guard both cases that can leave the parent waiting on `close` forever:
+		// a lingering stdio holder after `exit`, or a child that never exits.
+		const FINAL_DRAIN_MS = 5000;
+		const HARD_KILL_MS = 3000;
+		let finalDrainTimer: NodeJS.Timeout | undefined;
+		let finalHardKillTimer: NodeJS.Timeout | undefined;
+		let settled = false;
+		const clearStdioGuard = attachPostExitStdioGuard(child, { idleMs: 2000, hardMs: 8000 });
 		child.stdout.on("data", (chunk: Buffer) => {
 			const text = chunk.toString();
 			stdoutBuf += text;
@@ -287,15 +296,6 @@ function runPiStreaming(
 		child.stderr.on("data", (chunk: Buffer) => {
 			processStderrText(chunk.toString());
 		});
-
-		// Guard both cases that can leave the parent waiting on `close` forever:
-		// a lingering stdio holder after `exit`, or a child that never exits.
-		const FINAL_DRAIN_MS = 5000;
-		const HARD_KILL_MS = 3000;
-		let staleStdioGrace: NodeJS.Timeout | undefined;
-		let finalDrainTimer: NodeJS.Timeout | undefined;
-		let finalHardKillTimer: NodeJS.Timeout | undefined;
-		let settled = false;
 		const clearDrainTimers = () => {
 			if (finalDrainTimer) {
 				clearTimeout(finalDrainTimer);
@@ -324,20 +324,11 @@ function runPiStreaming(
 		}
 		child.on("exit", () => {
 			clearDrainTimers();
-			if (staleStdioGrace) return;
-			staleStdioGrace = setTimeout(() => {
-				try { child.stdout?.destroy(); } catch {}
-				try { child.stderr?.destroy(); } catch {}
-			}, 2000);
-			staleStdioGrace.unref?.();
 		});
 		child.on("close", (exitCode) => {
 			settled = true;
 			clearDrainTimers();
-			if (staleStdioGrace) {
-				clearTimeout(staleStdioGrace);
-				staleStdioGrace = undefined;
-			}
+			clearStdioGuard();
 			if (stdoutBuf.trim()) processStdoutLine(stdoutBuf);
 			if (stderrBuf.trim()) appendChildLine("subagent.child.stderr", stderrBuf);
 			outputStream.end();
@@ -348,6 +339,7 @@ function runPiStreaming(
 		child.on("error", (spawnError) => {
 			settled = true;
 			clearDrainTimers();
+			clearStdioGuard();
 			outputStream.end();
 			const finalOutput = getFinalOutput(messages) || rawStdoutLines.join("\n").trim();
 			const spawnErrorMessage = spawnError instanceof Error ? spawnError.message : String(spawnError);

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -28,7 +28,7 @@ import {
 } from "./parallel-utils.ts";
 import { buildPiArgs, cleanupTempDir } from "./pi-args.ts";
 import { formatModelAttemptNote, isRetryableModelFailure } from "./model-fallback.ts";
-import { attachPostExitStdioGuard } from "./post-exit-stdio-guard.ts";
+import { attachPostExitStdioGuard, trySignalChild } from "./post-exit-stdio-guard.ts";
 import { detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput } from "./utils.ts";
 import {
 	cleanupWorktrees,
@@ -312,17 +312,15 @@ function runPiStreaming(
 			if (childExited || finalDrainTimer || settled) return;
 			finalDrainTimer = setTimeout(() => {
 				if (settled) return;
+				const termSent = trySignalChild(child, "SIGTERM");
+				if (!termSent) return;
+				forcedTerminationSignal = true;
 				if (!error) {
 					error = `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
 				}
-				try {
-					forcedTerminationSignal = child.kill("SIGTERM");
-				} catch {}
 				finalHardKillTimer = setTimeout(() => {
 					if (settled) return;
-					try {
-						forcedTerminationSignal = child.kill("SIGKILL") || forcedTerminationSignal;
-					} catch {}
+					forcedTerminationSignal = trySignalChild(child, "SIGKILL") || forcedTerminationSignal;
 				}, HARD_KILL_MS);
 				finalHardKillTimer.unref?.();
 			}, FINAL_DRAIN_MS);

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -281,6 +281,8 @@ function runPiStreaming(
 		// a lingering stdio holder after `exit`, or a child that never exits.
 		const FINAL_DRAIN_MS = 5000;
 		const HARD_KILL_MS = 3000;
+		let childExited = false;
+		let forcedTerminationSignal = false;
 		let finalDrainTimer: NodeJS.Timeout | undefined;
 		let finalHardKillTimer: NodeJS.Timeout | undefined;
 		let settled = false;
@@ -307,15 +309,17 @@ function runPiStreaming(
 			}
 		};
 		function startFinalDrain(): void {
-			if (finalDrainTimer || settled) return;
+			if (childExited || finalDrainTimer || settled) return;
 			finalDrainTimer = setTimeout(() => {
 				if (settled) return;
 				if (!error) {
 					error = `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
 				}
+				forcedTerminationSignal = true;
 				try { child.kill("SIGTERM"); } catch {}
 				finalHardKillTimer = setTimeout(() => {
 					if (settled) return;
+					forcedTerminationSignal = true;
 					try { child.kill("SIGKILL"); } catch {}
 				}, HARD_KILL_MS);
 				finalHardKillTimer.unref?.();
@@ -323,9 +327,10 @@ function runPiStreaming(
 			finalDrainTimer.unref?.();
 		}
 		child.on("exit", () => {
+			childExited = true;
 			clearDrainTimers();
 		});
-		child.on("close", (exitCode) => {
+		child.on("close", (exitCode, signal) => {
 			settled = true;
 			clearDrainTimers();
 			clearStdioGuard();
@@ -333,7 +338,15 @@ function runPiStreaming(
 			if (stderrBuf.trim()) appendChildLine("subagent.child.stderr", stderrBuf);
 			outputStream.end();
 			const finalOutput = getFinalOutput(messages) || rawStdoutLines.join("\n").trim();
-			resolve({ stderr, exitCode, messages, usage, model, error, finalOutput });
+			resolve({
+				stderr,
+				exitCode: forcedTerminationSignal || signal ? (exitCode ?? 1) : exitCode,
+				messages,
+				usage,
+				model,
+				error,
+				finalOutput,
+			});
 		});
 
 		child.on("error", (spawnError) => {

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -315,12 +315,14 @@ function runPiStreaming(
 				if (!error) {
 					error = `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
 				}
-				forcedTerminationSignal = true;
-				try { child.kill("SIGTERM"); } catch {}
+				try {
+					forcedTerminationSignal = child.kill("SIGTERM");
+				} catch {}
 				finalHardKillTimer = setTimeout(() => {
 					if (settled) return;
-					forcedTerminationSignal = true;
-					try { child.kill("SIGKILL"); } catch {}
+					try {
+						forcedTerminationSignal = child.kill("SIGKILL") || forcedTerminationSignal;
+					} catch {}
 				}, HARD_KILL_MS);
 				finalHardKillTimer.unref?.();
 			}, FINAL_DRAIN_MS);

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -248,13 +248,18 @@ function runPiStreaming(
 				if (event.message.model) model = event.message.model;
 				if (event.message.errorMessage) error = event.message.errorMessage;
 				const eventUsage = event.message.usage;
-				if (!eventUsage) return;
-				usage.turns++;
-				usage.input += eventUsage.input ?? eventUsage.inputTokens ?? 0;
-				usage.output += eventUsage.output ?? eventUsage.outputTokens ?? 0;
-				usage.cacheRead += eventUsage.cacheRead ?? 0;
-				usage.cacheWrite += eventUsage.cacheWrite ?? 0;
-				usage.cost += eventUsage.cost?.total ?? 0;
+				if (eventUsage) {
+					usage.turns++;
+					usage.input += eventUsage.input ?? eventUsage.inputTokens ?? 0;
+					usage.output += eventUsage.output ?? eventUsage.outputTokens ?? 0;
+					usage.cacheRead += eventUsage.cacheRead ?? 0;
+					usage.cacheWrite += eventUsage.cacheWrite ?? 0;
+					usage.cost += eventUsage.cost?.total ?? 0;
+				}
+				const stopReason = (event.message as { stopReason?: string }).stopReason;
+				const hasToolCall = Array.isArray(event.message.content)
+					&& event.message.content.some((part) => (part as { type?: string }).type === "toolCall");
+				if (stopReason === "stop" && !hasToolCall) startFinalDrain();
 			}
 		};
 
@@ -283,7 +288,56 @@ function runPiStreaming(
 			processStderrText(chunk.toString());
 		});
 
+		// Guard both cases that can leave the parent waiting on `close` forever:
+		// a lingering stdio holder after `exit`, or a child that never exits.
+		const FINAL_DRAIN_MS = 5000;
+		const HARD_KILL_MS = 3000;
+		let staleStdioGrace: NodeJS.Timeout | undefined;
+		let finalDrainTimer: NodeJS.Timeout | undefined;
+		let finalHardKillTimer: NodeJS.Timeout | undefined;
+		let settled = false;
+		const clearDrainTimers = () => {
+			if (finalDrainTimer) {
+				clearTimeout(finalDrainTimer);
+				finalDrainTimer = undefined;
+			}
+			if (finalHardKillTimer) {
+				clearTimeout(finalHardKillTimer);
+				finalHardKillTimer = undefined;
+			}
+		};
+		function startFinalDrain(): void {
+			if (finalDrainTimer || settled) return;
+			finalDrainTimer = setTimeout(() => {
+				if (settled) return;
+				if (!error) {
+					error = `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
+				}
+				try { child.kill("SIGTERM"); } catch {}
+				finalHardKillTimer = setTimeout(() => {
+					if (settled) return;
+					try { child.kill("SIGKILL"); } catch {}
+				}, HARD_KILL_MS);
+				finalHardKillTimer.unref?.();
+			}, FINAL_DRAIN_MS);
+			finalDrainTimer.unref?.();
+		}
+		child.on("exit", () => {
+			clearDrainTimers();
+			if (staleStdioGrace) return;
+			staleStdioGrace = setTimeout(() => {
+				try { child.stdout?.destroy(); } catch {}
+				try { child.stderr?.destroy(); } catch {}
+			}, 2000);
+			staleStdioGrace.unref?.();
+		});
 		child.on("close", (exitCode) => {
+			settled = true;
+			clearDrainTimers();
+			if (staleStdioGrace) {
+				clearTimeout(staleStdioGrace);
+				staleStdioGrace = undefined;
+			}
 			if (stdoutBuf.trim()) processStdoutLine(stdoutBuf);
 			if (stderrBuf.trim()) appendChildLine("subagent.child.stderr", stderrBuf);
 			outputStream.end();
@@ -292,6 +346,8 @@ function runPiStreaming(
 		});
 
 		child.on("error", (spawnError) => {
+			settled = true;
+			clearDrainTimers();
 			outputStream.end();
 			const finalOutput = getFinalOutput(messages) || rawStdoutLines.join("\n").trim();
 			const spawnErrorMessage = spawnError instanceof Error ? spawnError.message : String(spawnError);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -524,15 +524,24 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		});
 		const agents = makeAgentConfigs(["echo"]);
 
+		// Emit the detach request the moment we observe the intercom tool start
+		// in a progress update — this is the signal the parent has set
+		// `intercomStarted=true`. Using a fixed delay here races the mock's
+		// cold spawn and flakes under load.
+		let detachEmitted = false;
 		const runPromise = runSync(tempDir, agents, "echo", "Task", {
 			runId: "intercom-detach",
 			allowIntercomDetach: true,
 			intercomEvents: eventBus,
+			onUpdate: (update) => {
+				if (detachEmitted) return;
+				const progress = (update as { details?: { progress?: Array<{ currentTool?: string }> } }).details?.progress;
+				const sawIntercom = Array.isArray(progress) && progress.some((p) => p?.currentTool === "intercom");
+				if (!sawIntercom) return;
+				detachEmitted = true;
+				eventBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "test-request" });
+			},
 		});
-
-		setTimeout(() => {
-			eventBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "test-request" });
-		}, 100);
 
 		const result = await runPromise;
 
@@ -553,43 +562,4 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.exitCode, 0);
 	});
 
-	it("does not hang when the subagent leaves a grandchild holding stdout/stderr", async () => {
-		// Grandchild holds inherited stdio open after the child exits.
-		mockPi.onCall({
-			output: "Done",
-			leakyGrandchildSeconds: 30,
-		});
-		const agents = makeAgentConfigs(["echo"]);
-
-		const start = Date.now();
-		const result = await runSync(tempDir, agents, "echo", "Task", {});
-		const elapsed = Date.now() - start;
-
-		assert.equal(result.exitCode, 0);
-		assert.ok(
-			elapsed < 10_000,
-			`runSync should resolve in bounded time once the child exits (took ${elapsed}ms; grandchild would linger 30s)`,
-		);
-		assert.equal(getFinalOutput?.(result.messages), "Done");
-	});
-
-	it("does not hang when the subagent process keeps its event loop alive after the final message", async () => {
-		// Child emits its final message but keeps its own event loop alive.
-		mockPi.onCall({
-			output: "Done",
-			keepAliveAfterFinalMessageSeconds: 30,
-		});
-		const agents = makeAgentConfigs(["echo"]);
-
-		const start = Date.now();
-		const result = await runSync(tempDir, agents, "echo", "Task", {});
-		const elapsed = Date.now() - start;
-
-		assert.ok(
-			elapsed < 15_000,
-			`runSync should force-drain and resolve within the drain+kill budget (took ${elapsed}ms; child would linger 30s)`,
-		);
-		// Final output should still survive the forced drain.
-		assert.equal(getFinalOutput?.(result.messages), "Done");
-	});
 });

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -552,4 +552,44 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.exitCode, 0);
 	});
+
+	it("does not hang when the subagent leaves a grandchild holding stdout/stderr", async () => {
+		// Grandchild holds inherited stdio open after the child exits.
+		mockPi.onCall({
+			output: "Done",
+			leakyGrandchildSeconds: 30,
+		});
+		const agents = makeAgentConfigs(["echo"]);
+
+		const start = Date.now();
+		const result = await runSync(tempDir, agents, "echo", "Task", {});
+		const elapsed = Date.now() - start;
+
+		assert.equal(result.exitCode, 0);
+		assert.ok(
+			elapsed < 10_000,
+			`runSync should resolve in bounded time once the child exits (took ${elapsed}ms; grandchild would linger 30s)`,
+		);
+		assert.equal(getFinalOutput?.(result.messages), "Done");
+	});
+
+	it("does not hang when the subagent process keeps its event loop alive after the final message", async () => {
+		// Child emits its final message but keeps its own event loop alive.
+		mockPi.onCall({
+			output: "Done",
+			keepAliveAfterFinalMessageSeconds: 30,
+		});
+		const agents = makeAgentConfigs(["echo"]);
+
+		const start = Date.now();
+		const result = await runSync(tempDir, agents, "echo", "Task", {});
+		const elapsed = Date.now() - start;
+
+		assert.ok(
+			elapsed < 15_000,
+			`runSync should force-drain and resolve within the drain+kill budget (took ${elapsed}ms; child would linger 30s)`,
+		);
+		// Final output should still survive the forced drain.
+		assert.equal(getFinalOutput?.(result.messages), "Done");
+	});
 });

--- a/test/support/helpers.ts
+++ b/test/support/helpers.ts
@@ -141,6 +141,7 @@ export const events = {
 				role: "assistant",
 				content: [{ type: "text", text }],
 				model,
+				stopReason: "stop",
 				usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
 			},
 		};

--- a/test/support/mock-pi-script.mjs
+++ b/test/support/mock-pi-script.mjs
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -138,23 +137,6 @@ async function main() {
 
 	if (typeof response.stderr === "string" && response.stderr.length > 0) {
 		process.stderr.write(response.stderr);
-	}
-
-	// Optional grandchild that keeps inherited stdio open past our own exit.
-	if (typeof response.leakyGrandchildSeconds === "number" && response.leakyGrandchildSeconds > 0) {
-		try {
-			const leaker = spawn(
-				process.execPath,
-				["-e", `setTimeout(() => {}, ${response.leakyGrandchildSeconds * 1000});`],
-				{ stdio: ["ignore", "inherit", "inherit"], detached: true },
-			);
-			leaker.unref();
-		} catch {}
-	}
-
-	// Optionally linger after the final message to simulate a child that never exits cleanly.
-	if (typeof response.keepAliveAfterFinalMessageSeconds === "number" && response.keepAliveAfterFinalMessageSeconds > 0) {
-		await new Promise((resolve) => setTimeout(resolve, response.keepAliveAfterFinalMessageSeconds * 1000));
 	}
 
 	process.exit(typeof response.exitCode === "number" ? response.exitCode : 0);

--- a/test/support/mock-pi-script.mjs
+++ b/test/support/mock-pi-script.mjs
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -42,6 +43,7 @@ function defaultAssistantMessage(output) {
 			role: "assistant",
 			content: [{ type: "text", text: output }],
 			model: "mock/test-model",
+			stopReason: "stop",
 			usage: {
 				input: 100,
 				output: 50,
@@ -136,6 +138,23 @@ async function main() {
 
 	if (typeof response.stderr === "string" && response.stderr.length > 0) {
 		process.stderr.write(response.stderr);
+	}
+
+	// Optional grandchild that keeps inherited stdio open past our own exit.
+	if (typeof response.leakyGrandchildSeconds === "number" && response.leakyGrandchildSeconds > 0) {
+		try {
+			const leaker = spawn(
+				process.execPath,
+				["-e", `setTimeout(() => {}, ${response.leakyGrandchildSeconds * 1000});`],
+				{ stdio: ["ignore", "inherit", "inherit"], detached: true },
+			);
+			leaker.unref();
+		} catch {}
+	}
+
+	// Optionally linger after the final message to simulate a child that never exits cleanly.
+	if (typeof response.keepAliveAfterFinalMessageSeconds === "number" && response.keepAliveAfterFinalMessageSeconds > 0) {
+		await new Promise((resolve) => setTimeout(resolve, response.keepAliveAfterFinalMessageSeconds * 1000));
 	}
 
 	process.exit(typeof response.exitCode === "number" ? response.exitCode : 0);

--- a/test/support/mock-pi.ts
+++ b/test/support/mock-pi.ts
@@ -15,6 +15,10 @@ export interface MockPiResponse {
 		stderr?: string;
 	}>;
 	echoEnv?: string[];
+	/** If set, keep inherited stdout/stderr open via a lingering grandchild. */
+	leakyGrandchildSeconds?: number;
+	/** If set, keep the child alive after its final message before exit. */
+	keepAliveAfterFinalMessageSeconds?: number;
 }
 
 export interface MockPi {

--- a/test/support/mock-pi.ts
+++ b/test/support/mock-pi.ts
@@ -15,10 +15,6 @@ export interface MockPiResponse {
 		stderr?: string;
 	}>;
 	echoEnv?: string[];
-	/** If set, keep inherited stdout/stderr open via a lingering grandchild. */
-	leakyGrandchildSeconds?: number;
-	/** If set, keep the child alive after its final message before exit. */
-	keepAliveAfterFinalMessageSeconds?: number;
 }
 
 export interface MockPi {

--- a/test/unit/close-grace-timer.test.ts
+++ b/test/unit/close-grace-timer.test.ts
@@ -1,127 +1,95 @@
-/**
- * Covers the `exit` -> grace timer -> `close` path used by the runners when a
- * grandchild keeps inherited stdout/stderr open.
- */
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
+import { attachPostExitStdioGuard } from "../../post-exit-stdio-guard.ts";
 
-/**
- * Launch a synthetic child that prints once, backgrounds a sleeper that keeps
- * stdout/stderr open, then exits immediately.
- */
-function makeLeakyLauncher(sleepSeconds: number): string {
+function writeScript(name: string, lines: string[]): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-close-grace-"));
-	const script = path.join(dir, "leaky-subagent.sh");
-	fs.writeFileSync(
-		script,
-		[
-			"#!/bin/bash",
-			"set -eu",
-			'echo \'{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}\'',
-			// Background sleeper inherits fd 1 and 2 on purpose.
-			`sleep ${sleepSeconds} &`,
-			"disown || true",
-			"exit 0",
-		].join("\n"),
-		{ mode: 0o755 },
-	);
+	const script = path.join(dir, name);
+	fs.writeFileSync(script, lines.join("\n"), { mode: 0o755 });
 	return script;
+}
+
+function makeSilentLeakyScript(sleepSeconds: number): string {
+	return writeScript("silent-leak.sh", [
+		"#!/bin/bash",
+		"set -eu",
+		"echo done",
+		`sleep ${sleepSeconds} &`,
+		"disown || true",
+		"exit 0",
+	]);
+}
+
+function makeChattyLeakyScript(tickMs: number): string {
+	return writeScript("chatty-leak.sh", [
+		"#!/bin/bash",
+		"set -eu",
+		"echo start",
+		`( while true; do echo tick; sleep ${(tickMs / 1000).toFixed(3)}; done ) &`,
+		"disown || true",
+		"exit 0",
+	]);
 }
 
 interface RunResult {
 	resolvedMs: number;
 	exitCode: number | null;
-	closeFired: boolean;
-	exitFired: boolean;
 	stdout: string;
 }
 
-function runWithGrace(script: string, graceMs: number, maxWaitMs: number): Promise<RunResult> {
+function runWithGuard(script: string, idleMs: number, hardMs: number, maxWaitMs: number): Promise<RunResult> {
 	return new Promise((resolve, reject) => {
 		const start = Date.now();
 		const child = spawn("bash", [script], { stdio: ["ignore", "pipe", "pipe"] });
 		let stdout = "";
-		let exitFired = false;
-		let closeFired = false;
-		let staleStdioGrace: NodeJS.Timeout | undefined;
-
+		const clearGuard = attachPostExitStdioGuard(child, { idleMs, hardMs });
 		const hardStop = setTimeout(() => {
 			try { child.kill("SIGKILL"); } catch {}
-			reject(new Error(`promise did not resolve within ${maxWaitMs}ms (close hang reproduced)`));
+			reject(new Error(`promise did not resolve within ${maxWaitMs}ms`));
 		}, maxWaitMs);
 		hardStop.unref?.();
 
-		child.stdout.on("data", (d) => { stdout += d.toString(); });
-		// stderr is drained but not captured for this test.
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
 		child.stderr.on("data", () => {});
-
-		child.on("exit", () => {
-			exitFired = true;
-			if (staleStdioGrace) return;
-			staleStdioGrace = setTimeout(() => {
-				try { child.stdout?.destroy(); } catch {}
-				try { child.stderr?.destroy(); } catch {}
-			}, graceMs);
-			staleStdioGrace.unref?.();
-		});
-
 		child.on("close", (code) => {
-			if (staleStdioGrace) {
-				clearTimeout(staleStdioGrace);
-				staleStdioGrace = undefined;
-			}
 			clearTimeout(hardStop);
-			closeFired = true;
-			resolve({
-				resolvedMs: Date.now() - start,
-				exitCode: code,
-				closeFired,
-				exitFired,
-				stdout,
-			});
+			clearGuard();
+			resolve({ resolvedMs: Date.now() - start, exitCode: code, stdout });
 		});
-
 		child.on("error", reject);
 	});
 }
 
-describe("grace timer around child.on(\"close\")", () => {
-	it("still fast-paths when the child has no grandchildren holding stdio", async () => {
-		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-close-grace-clean-"));
-		const clean = path.join(dir, "clean-subagent.sh");
-		fs.writeFileSync(
-			clean,
-			[
-				"#!/bin/bash",
-				"set -eu",
-				"echo hello",
-				"exit 0",
-			].join("\n"),
-			{ mode: 0o755 },
-		);
-		const res = await runWithGrace(clean, 2000, 5_000);
-		assert.equal(res.exitCode, 0);
-		assert.ok(res.closeFired, "close should fire");
-		assert.ok(res.resolvedMs < 500, `fast path should resolve in well under the grace window (got ${res.resolvedMs}ms)`);
-		assert.match(res.stdout, /hello/);
+describe("attachPostExitStdioGuard", () => {
+	it("does not delay a clean exit", async () => {
+		const script = writeScript("clean.sh", ["#!/bin/bash", "set -eu", "echo hello", "exit 0"]);
+		const result = await runWithGuard(script, 2000, 8000, 5000);
+		assert.equal(result.exitCode, 0);
+		assert.match(result.stdout, /hello/);
+		assert.ok(result.resolvedMs < 500, `expected fast close, got ${result.resolvedMs}ms`);
 	});
 
-	it("resolves promptly even when a grandchild keeps stdio open past exit", async () => {
-		// Without the grace timer, `close` would wait for the full 30s sleeper.
-		const leaky = makeLeakyLauncher(30);
-		const graceMs = 1500;
-		const res = await runWithGrace(leaky, graceMs, 10_000);
-		assert.equal(res.exitCode, 0, "child exit code should still be 0");
-		assert.ok(res.exitFired, "exit should fire before close");
-		assert.ok(res.closeFired, "close should fire after grace timer destroys stdio");
-		assert.ok(
-			res.resolvedMs < graceMs + 2_000,
-			`close should resolve shortly after the grace window (got ${res.resolvedMs}ms, grace=${graceMs}ms)`,
-		);
-		assert.match(res.stdout, /message_end/);
+	it("cuts off a silent grandchild with the idle timer", async () => {
+		const idleMs = 1500;
+		const result = await runWithGuard(makeSilentLeakyScript(30), idleMs, 8000, 10000);
+		assert.equal(result.exitCode, 0);
+		assert.match(result.stdout, /done/);
+		assert.ok(result.resolvedMs >= idleMs, `resolved too early: ${result.resolvedMs}ms`);
+		assert.ok(result.resolvedMs < idleMs + 2000, `expected idle cutoff, got ${result.resolvedMs}ms`);
+	});
+
+	it("cuts off a chatty grandchild with the hard timer", async () => {
+		const hardMs = 2000;
+		const result = await runWithGuard(makeChattyLeakyScript(200), 1000, hardMs, 10000);
+		assert.equal(result.exitCode, 0);
+		assert.match(result.stdout, /start/);
+		assert.ok(result.resolvedMs >= hardMs - 500, `resolved too early: ${result.resolvedMs}ms`);
+		assert.ok(result.resolvedMs < hardMs + 2000, `expected hard cutoff, got ${result.resolvedMs}ms`);
 	});
 });

--- a/test/unit/close-grace-timer.test.ts
+++ b/test/unit/close-grace-timer.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Covers the `exit` -> grace timer -> `close` path used by the runners when a
+ * grandchild keeps inherited stdout/stderr open.
+ */
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+
+/**
+ * Launch a synthetic child that prints once, backgrounds a sleeper that keeps
+ * stdout/stderr open, then exits immediately.
+ */
+function makeLeakyLauncher(sleepSeconds: number): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-close-grace-"));
+	const script = path.join(dir, "leaky-subagent.sh");
+	fs.writeFileSync(
+		script,
+		[
+			"#!/bin/bash",
+			"set -eu",
+			'echo \'{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}\'',
+			// Background sleeper inherits fd 1 and 2 on purpose.
+			`sleep ${sleepSeconds} &`,
+			"disown || true",
+			"exit 0",
+		].join("\n"),
+		{ mode: 0o755 },
+	);
+	return script;
+}
+
+interface RunResult {
+	resolvedMs: number;
+	exitCode: number | null;
+	closeFired: boolean;
+	exitFired: boolean;
+	stdout: string;
+}
+
+function runWithGrace(script: string, graceMs: number, maxWaitMs: number): Promise<RunResult> {
+	return new Promise((resolve, reject) => {
+		const start = Date.now();
+		const child = spawn("bash", [script], { stdio: ["ignore", "pipe", "pipe"] });
+		let stdout = "";
+		let exitFired = false;
+		let closeFired = false;
+		let staleStdioGrace: NodeJS.Timeout | undefined;
+
+		const hardStop = setTimeout(() => {
+			try { child.kill("SIGKILL"); } catch {}
+			reject(new Error(`promise did not resolve within ${maxWaitMs}ms (close hang reproduced)`));
+		}, maxWaitMs);
+		hardStop.unref?.();
+
+		child.stdout.on("data", (d) => { stdout += d.toString(); });
+		// stderr is drained but not captured for this test.
+		child.stderr.on("data", () => {});
+
+		child.on("exit", () => {
+			exitFired = true;
+			if (staleStdioGrace) return;
+			staleStdioGrace = setTimeout(() => {
+				try { child.stdout?.destroy(); } catch {}
+				try { child.stderr?.destroy(); } catch {}
+			}, graceMs);
+			staleStdioGrace.unref?.();
+		});
+
+		child.on("close", (code) => {
+			if (staleStdioGrace) {
+				clearTimeout(staleStdioGrace);
+				staleStdioGrace = undefined;
+			}
+			clearTimeout(hardStop);
+			closeFired = true;
+			resolve({
+				resolvedMs: Date.now() - start,
+				exitCode: code,
+				closeFired,
+				exitFired,
+				stdout,
+			});
+		});
+
+		child.on("error", reject);
+	});
+}
+
+describe("grace timer around child.on(\"close\")", () => {
+	it("still fast-paths when the child has no grandchildren holding stdio", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-close-grace-clean-"));
+		const clean = path.join(dir, "clean-subagent.sh");
+		fs.writeFileSync(
+			clean,
+			[
+				"#!/bin/bash",
+				"set -eu",
+				"echo hello",
+				"exit 0",
+			].join("\n"),
+			{ mode: 0o755 },
+		);
+		const res = await runWithGrace(clean, 2000, 5_000);
+		assert.equal(res.exitCode, 0);
+		assert.ok(res.closeFired, "close should fire");
+		assert.ok(res.resolvedMs < 500, `fast path should resolve in well under the grace window (got ${res.resolvedMs}ms)`);
+		assert.match(res.stdout, /hello/);
+	});
+
+	it("resolves promptly even when a grandchild keeps stdio open past exit", async () => {
+		// Without the grace timer, `close` would wait for the full 30s sleeper.
+		const leaky = makeLeakyLauncher(30);
+		const graceMs = 1500;
+		const res = await runWithGrace(leaky, graceMs, 10_000);
+		assert.equal(res.exitCode, 0, "child exit code should still be 0");
+		assert.ok(res.exitFired, "exit should fire before close");
+		assert.ok(res.closeFired, "close should fire after grace timer destroys stdio");
+		assert.ok(
+			res.resolvedMs < graceMs + 2_000,
+			`close should resolve shortly after the grace window (got ${res.resolvedMs}ms, grace=${graceMs}ms)`,
+		);
+		assert.match(res.stdout, /message_end/);
+	});
+});

--- a/test/unit/close-grace-timer.test.ts
+++ b/test/unit/close-grace-timer.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { attachPostExitStdioGuard } from "../../post-exit-stdio-guard.ts";
+import { attachPostExitStdioGuard, trySignalChild } from "../../post-exit-stdio-guard.ts";
 
 function writeScript(name: string, lines: string[]): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-close-grace-"));
@@ -67,6 +67,12 @@ function runWithGuard(script: string, idleMs: number, hardMs: number, maxWaitMs:
 }
 
 describe("attachPostExitStdioGuard", () => {
+	it("reports whether a termination signal was actually delivered", () => {
+		assert.equal(trySignalChild({ kill: () => true }, "SIGTERM"), true);
+		assert.equal(trySignalChild({ kill: () => false }, "SIGTERM"), false);
+		assert.equal(trySignalChild({ kill: () => { throw new Error("gone"); } }, "SIGTERM"), false);
+	});
+
 	it("does not delay a clean exit", async () => {
 		const script = writeScript("clean.sh", ["#!/bin/bash", "set -eu", "echo hello", "exit 0"]);
 		const result = await runWithGuard(script, 2000, 8000, 5000);


### PR DESCRIPTION
Supersedes #96.

Fixes #95.

This keeps the same stuck-child drain work from #96, but includes one additional correctness fix before merge:

- only mark the run as force-terminated after a termination signal was actually delivered
- avoid false-positive failures when the final-drain timer races with a child that already exited

What this PR does:

- bounds post-exit stdio hangs with a shared post-exit stdio guard
- bounds "final message emitted but child never exits" hangs with a timed drain + TERM/KILL escalation
- applies the fix in both sync and async/background runner paths
- adds unit coverage for the stdio guard and signal-delivery helper
- keeps the existing integration coverage for the stuck-child execution path

Verified locally:

- `node --experimental-strip-types --test test/unit/close-grace-timer.test.ts`
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts`
