### PR TITLE
Track message_update events as subagent progress

### DIFF
--- a/async-job-tracker.ts
+++ b/async-job-tracker.ts
@@ -121,6 +121,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 						job.lastActivityAt = status.lastActivityAt ?? job.lastActivityAt;
 						job.currentTool = status.currentTool ?? job.currentTool;
 						job.currentToolStartedAt = status.currentToolStartedAt ?? job.currentToolStartedAt;
+						job.recentOutput = status.recentOutput ?? status.steps?.[status.currentStep ?? 0]?.recentOutput ?? job.recentOutput;
 						job.mode = status.mode;
 						job.currentStep = status.currentStep ?? job.currentStep;
 						job.stepsTotal = status.steps?.length ?? job.stepsTotal;

--- a/async-status.ts
+++ b/async-status.ts
@@ -13,6 +13,7 @@ export interface AsyncRunStepSummary {
 	lastActivityAt?: number;
 	currentTool?: string;
 	currentToolStartedAt?: number;
+	recentOutput?: string[];
 	durationMs?: number;
 	tokens?: TokenUsage;
 	skills?: string[];
@@ -29,6 +30,7 @@ export interface AsyncRunSummary {
 	lastActivityAt?: number;
 	currentTool?: string;
 	currentToolStartedAt?: number;
+	recentOutput?: string[];
 	mode: "single" | "chain";
 	cwd?: string;
 	startedAt: number;
@@ -109,6 +111,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		lastActivityAt,
 		currentTool: status.currentTool,
 		currentToolStartedAt: status.currentToolStartedAt,
+		recentOutput: status.recentOutput,
 		mode: status.mode,
 		cwd: status.cwd,
 		startedAt: status.startedAt,
@@ -126,6 +129,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 				...(stepLastActivityAt ? { lastActivityAt: stepLastActivityAt } : {}),
 				...(step.currentTool ? { currentTool: step.currentTool } : {}),
 				...(step.currentToolStartedAt ? { currentToolStartedAt: step.currentToolStartedAt } : {}),
+				...(step.recentOutput ? { recentOutput: step.recentOutput } : {}),
 				...(step.durationMs !== undefined ? { durationMs: step.durationMs } : {}),
 				...(step.tokens ? { tokens: step.tokens } : {}),
 				...(step.skills ? { skills: step.skills } : {}),

--- a/execution.ts
+++ b/execution.ts
@@ -73,6 +73,35 @@ function appendRecentOutput(progress: AgentProgress, lines: string[]): void {
 	}
 }
 
+function extractAssistantProgressPreview(message: Message): string {
+	const text = extractTextFromContent(message.content).trim();
+	if (text) {
+		const lines = text.split("\n").map((line) => line.trim()).filter(Boolean);
+		const tail = lines.slice(-3).join(" / ");
+		return tail.length > 240 ? `${tail.slice(0, 237)}...` : tail;
+	}
+	if (Array.isArray(message.content) && message.content.some((part) => part && typeof part === "object" && (part as { type?: string }).type === "thinking")) {
+		return "thinking…";
+	}
+	return "";
+}
+
+function setRecentOutputPreview(progress: AgentProgress, previewIndex: number | undefined, text: string): number | undefined {
+	const trimmed = text.trim();
+	if (!trimmed) return previewIndex;
+	if (previewIndex !== undefined && previewIndex >= 0 && previewIndex < progress.recentOutput.length) {
+		progress.recentOutput[previewIndex] = trimmed;
+		return previewIndex;
+	}
+	progress.recentOutput.push(trimmed);
+	if (progress.recentOutput.length > 50) {
+		const removed = progress.recentOutput.length - 50;
+		progress.recentOutput.splice(0, removed);
+		return Math.max(0, progress.recentOutput.length - 1);
+	}
+	return progress.recentOutput.length - 1;
+}
+
 function snapshotProgress(progress: AgentProgress): AgentProgress {
 	return {
 		...progress,
@@ -156,6 +185,7 @@ async function runSingleAttempt(
 	let interruptedByControl = false;
 	const allControlEvents: ControlEvent[] = [];
 	let pendingControlEvents: ControlEvent[] = [];
+	let streamingPreviewIndex: number | undefined;
 
 	const progress: AgentProgress = {
 		index: options.index ?? 0,
@@ -345,7 +375,14 @@ async function runSingleAttempt(
 			progress.lastActivityAt = now;
 			updateActivityState(now);
 
+			if (evt.type === "message_update" && evt.message?.role === "assistant") {
+				const preview = extractAssistantProgressPreview(evt.message);
+				streamingPreviewIndex = setRecentOutputPreview(progress, streamingPreviewIndex, preview);
+				fireUpdate();
+			}
+
 			if (evt.type === "tool_execution_start") {
+				streamingPreviewIndex = undefined;
 				if (options.allowIntercomDetach && evt.toolName === "intercom") {
 					intercomStarted = true;
 				}
@@ -371,6 +408,7 @@ async function runSingleAttempt(
 			}
 
 			if (evt.type === "message_end" && evt.message) {
+				streamingPreviewIndex = undefined;
 				result.messages.push(evt.message);
 				if (evt.message.role === "assistant") {
 					result.usage.turns++;
@@ -398,6 +436,7 @@ async function runSingleAttempt(
 			}
 
 			if (evt.type === "tool_result_end" && evt.message) {
+				streamingPreviewIndex = undefined;
 				result.messages.push(evt.message);
 				appendRecentOutput(progress, extractTextFromContent(evt.message.content).split("\n").slice(-10));
 				fireUpdate();

--- a/render.ts
+++ b/render.ts
@@ -198,8 +198,8 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 
 		lines.push(truncLine(`- ${id} ${status} | ${agentLabel} | ${stepText}${elapsed ? ` | ${elapsed}` : ""}${tokenText}${activitySuffix}`, w));
 
-		if ((job.status === "running" || job.status === "paused") && job.outputFile) {
-			const tail = getOutputTail(job.outputFile, 3);
+		if (job.status === "running" || job.status === "paused") {
+			const tail = job.recentOutput?.length ? job.recentOutput.slice(-3) : job.outputFile ? getOutputTail(job.outputFile, 3) : [];
 			for (const line of tail) {
 				lines.push(truncLine(theme.fg("dim", `  > ${line}`), w));
 			}

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -122,6 +122,28 @@ function tokenUsageFromAttempts(attempts: ModelAttempt[] | undefined): TokenUsag
 	return total > 0 ? { input, output, total } : null;
 }
 
+function extractAssistantProgressPreview(message: Message): string {
+	const text = extractTextFromContent(message.content).trim();
+	if (text) {
+		const lines = text.split("\n").map((line) => line.trim()).filter(Boolean);
+		const tail = lines.slice(-3).join(" / ");
+		return tail.length > 240 ? `${tail.slice(0, 237)}...` : tail;
+	}
+	if (Array.isArray(message.content) && message.content.some((part) => part && typeof part === "object" && (part as { type?: string }).type === "thinking")) {
+		return "thinking…";
+	}
+	return "";
+}
+
+function setRecentOutputPreview(lines: string[] | undefined, text: string): string[] | undefined {
+	const trimmed = text.trim();
+	if (!trimmed) return lines;
+	const next = lines ? [...lines] : [];
+	if (next.length === 0) next.push(trimmed);
+	else next[next.length - 1] = trimmed;
+	return next.slice(-5);
+}
+
 interface ChildEventContext {
 	eventsPath: string;
 	runId: string;
@@ -173,6 +195,7 @@ function runPiStreaming(
 	maxSubagentDepth?: number,
 	childEventContext?: ChildEventContext,
 	registerInterrupt?: (interrupt: (() => void) | undefined) => void,
+	onMessageUpdate?: (event: ChildEvent) => void,
 ): Promise<RunPiStreamingResult> {
 	return new Promise((resolve) => {
 		const outputStream = fs.createWriteStream(outputFile, { flags: "w" });
@@ -232,6 +255,11 @@ function runPiStreaming(
 			}
 
 			appendChildEvent(event);
+
+			if (event.type === "message_update" && event.message?.role === "assistant") {
+				onMessageUpdate?.(event);
+				return;
+			}
 
 			if (event.type === "tool_execution_start" && event.toolName) {
 				const toolArgs = extractToolArgsPreview(event.args ?? {});
@@ -525,6 +553,7 @@ interface SingleStepContext {
 	piArgv1?: string;
 	registerInterrupt?: (interrupt: (() => void) | undefined) => void;
 	childIntercomTarget?: string;
+	onMessageUpdate?: (event: ChildEvent) => void;
 }
 
 /** Run a single pi agent step, returning output and metadata */
@@ -598,6 +627,7 @@ async function runSingleStep(
 			step.maxSubagentDepth,
 			{ eventsPath, runId: ctx.id, stepIndex: ctx.flatIndex, agent: step.agent },
 			ctx.registerInterrupt,
+			ctx.onMessageUpdate,
 		);
 		cleanupTempDir(tempDir);
 
@@ -686,6 +716,7 @@ type RunnerStatusPayload = {
 	lastActivityAt?: number;
 	currentTool?: string;
 	currentToolStartedAt?: number;
+	recentOutput?: string[];
 	startedAt: number;
 	endedAt?: number;
 	lastUpdate: number;
@@ -699,6 +730,7 @@ type RunnerStatusPayload = {
 		lastActivityAt?: number;
 		currentTool?: string;
 		currentToolStartedAt?: number;
+		recentOutput?: string[];
 		startedAt?: number;
 		endedAt?: number;
 		durationMs?: number;
@@ -772,10 +804,12 @@ function markParallelGroupRunning(input: {
 		input.statusPayload.steps[flatTaskIndex].status = "running";
 		input.statusPayload.steps[flatTaskIndex].startedAt = input.groupStartTime;
 		input.statusPayload.steps[flatTaskIndex].lastActivityAt = input.groupStartTime;
+		input.statusPayload.steps[flatTaskIndex].recentOutput = undefined;
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.activityState = undefined;
 	input.statusPayload.lastActivityAt = input.groupStartTime;
+	input.statusPayload.recentOutput = undefined;
 	input.statusPayload.lastUpdate = input.groupStartTime;
 	input.statusPayload.outputFile = path.join(input.asyncDir, `output-${input.groupStartFlatIndex}.log`);
 	writeJson(input.statusPath, input.statusPayload);
@@ -870,8 +904,9 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		const runningIndexes = statusPayload.steps
 			.map((step, index) => step.status === "running" ? index : -1)
 			.filter((index) => index >= 0);
-		let lastActivityAt = statusPayload.steps[statusPayload.currentStep]?.startedAt ?? overallStartTime;
+		let lastActivityAt = statusPayload.lastActivityAt ?? statusPayload.steps[statusPayload.currentStep]?.lastActivityAt ?? statusPayload.steps[statusPayload.currentStep]?.startedAt ?? overallStartTime;
 		for (const index of runningIndexes.length > 0 ? runningIndexes : [statusPayload.currentStep]) {
+			lastActivityAt = Math.max(lastActivityAt, statusPayload.steps[index]?.lastActivityAt ?? 0);
 			try {
 				lastActivityAt = Math.max(lastActivityAt, fs.statSync(path.join(asyncDir, `output-${index}.log`)).mtimeMs);
 			} catch {
@@ -941,6 +976,23 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		}, 1000);
 		activityTimer.unref?.();
 	}
+
+	const recordMessageUpdateActivity = (stepIndex: number, event: ChildEvent) => {
+		if (event.message?.role !== "assistant") return;
+		const now = Date.now();
+		const step = statusPayload.steps[stepIndex];
+		if (!step || step.status !== "running") return;
+		const preview = extractAssistantProgressPreview(event.message);
+		statusPayload.lastActivityAt = now;
+		statusPayload.lastUpdate = now;
+		statusPayload.activityState = undefined;
+		statusPayload.recentOutput = setRecentOutputPreview(statusPayload.recentOutput, preview);
+		step.lastActivityAt = now;
+		step.activityState = undefined;
+		step.recentOutput = setRecentOutputPreview(step.recentOutput, preview);
+		currentActivityState = undefined;
+		writeJson(statusPath, statusPayload);
+	};
 
 	const interruptRunner = () => {
 		if (interrupted || statusPayload.state !== "running") return;
@@ -1083,6 +1135,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 							registerInterrupt: (interrupt) => {
 								activeChildInterrupt = interrupt;
 							},
+							onMessageUpdate: (event) => recordMessageUpdateActivity(fi, event),
 						});
 						if (task.sessionFile) {
 							latestSessionFile = task.sessionFile;
@@ -1182,7 +1235,9 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			statusPayload.steps[flatIndex].skills = seqStep.skills;
 			statusPayload.steps[flatIndex].startedAt = stepStartTime;
 			statusPayload.steps[flatIndex].lastActivityAt = stepStartTime;
+			statusPayload.steps[flatIndex].recentOutput = undefined;
 			statusPayload.lastActivityAt = stepStartTime;
+			statusPayload.recentOutput = undefined;
 			statusPayload.lastUpdate = stepStartTime;
 			statusPayload.outputFile = path.join(asyncDir, `output-${flatIndex}.log`);
 			writeJson(statusPath, statusPayload);
@@ -1207,6 +1262,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				registerInterrupt: (interrupt) => {
 					activeChildInterrupt = interrupt;
 				},
+				onMessageUpdate: (event) => recordMessageUpdateActivity(flatIndex, event),
 			});
 			if (seqStep.sessionFile) {
 				latestSessionFile = seqStep.sessionFile;

--- a/types.ts
+++ b/types.ts
@@ -200,6 +200,7 @@ export interface AsyncStatus {
 	lastActivityAt?: number;
 	currentTool?: string;
 	currentToolStartedAt?: number;
+	recentOutput?: string[];
 	startedAt: number;
 	endedAt?: number;
 	lastUpdate?: number;
@@ -213,6 +214,7 @@ export interface AsyncStatus {
 		lastActivityAt?: number;
 		currentTool?: string;
 		currentToolStartedAt?: number;
+		recentOutput?: string[];
 		startedAt?: number;
 		endedAt?: number;
 		durationMs?: number;
@@ -237,6 +239,7 @@ export interface AsyncJobState {
 	lastActivityAt?: number;
 	currentTool?: string;
 	currentToolStartedAt?: number;
+	recentOutput?: string[];
 	mode?: "single" | "chain";
 	agents?: string[];
 	currentStep?: number;


### PR DESCRIPTION
## Summary\n- treat child assistant message_update events as live foreground subagent progress\n- persist async message_update activity/recent output into status.json\n- show async recent output from status before falling back to output log tails\n\n## Why\nTool-less or long-thinking providers can stream assistant updates without tool events. Counting message_update as activity keeps foreground/async subagents visibly alive and avoids false needs-attention notices without injecting synthetic text into final output.\n\n## Validation\n- npm test\n- local claude-cli provider smoke confirmed message_update events\n- foreground claude-cli reviewer returned PATCHED_FOREGROUND_OK\n- async claude-cli reviewer returned PATCHED_ASYNC_OK\n