### PR TITLE
fix: fall back when async result fs.watch is unavailable

### DIFF
--- a/result-watcher.ts
+++ b/result-watcher.ts
@@ -5,11 +5,36 @@ import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.js";
 import { createFileCoalescer } from "./file-coalescer.js";
 import { SUBAGENT_ASYNC_COMPLETE_EVENT, type SubagentState } from "./types.js";
 
+const WATCHER_RESTART_DELAY_MS = 3000;
+const POLL_INTERVAL_MS = 3000;
+
+type ResultWatcherFs = Pick<typeof fs, "existsSync" | "readFileSync" | "unlinkSync" | "readdirSync" | "mkdirSync" | "watch">;
+
+type ResultWatcherTimers = {
+	setTimeout: typeof setTimeout;
+	clearTimeout: typeof clearTimeout;
+	setInterval: typeof setInterval;
+	clearInterval: typeof clearInterval;
+};
+
+type ResultWatcherDeps = {
+	fs?: ResultWatcherFs;
+	timers?: ResultWatcherTimers;
+};
+
+function getErrorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error
+		? (error as NodeJS.ErrnoException).code
+		: undefined;
+}
+
 function isNotFoundError(error: unknown): boolean {
-	return typeof error === "object"
-		&& error !== null
-		&& "code" in error
-		&& (error as NodeJS.ErrnoException).code === "ENOENT";
+	return getErrorCode(error) === "ENOENT";
+}
+
+function shouldFallBackToPolling(error: unknown): boolean {
+	const code = getErrorCode(error);
+	return code === "EMFILE" || code === "ENOSPC";
 }
 
 export function createResultWatcher(
@@ -17,16 +42,20 @@ export function createResultWatcher(
 	state: SubagentState,
 	resultsDir: string,
 	completionTtlMs: number,
+	deps: ResultWatcherDeps = {},
 ): {
 	startResultWatcher: () => void;
 	primeExistingResults: () => void;
 	stopResultWatcher: () => void;
 } {
+	const fsApi = deps.fs ?? fs;
+	const timers = deps.timers ?? { setTimeout, clearTimeout, setInterval, clearInterval };
+
 	const handleResult = (file: string) => {
 		const resultPath = path.join(resultsDir, file);
-		if (!fs.existsSync(resultPath)) return;
+		if (!fsApi.existsSync(resultPath)) return;
 		try {
-			const data = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as {
+			const data = JSON.parse(fsApi.readFileSync(resultPath, "utf-8").toString()) as {
 				sessionId?: string;
 				cwd?: string;
 			};
@@ -36,12 +65,12 @@ export function createResultWatcher(
 			const now = Date.now();
 			const completionKey = buildCompletionKey(data, `result:${file}`);
 			if (markSeenWithTtl(state.completionSeen, completionKey, now, completionTtlMs)) {
-				fs.unlinkSync(resultPath);
+				fsApi.unlinkSync(resultPath);
 				return;
 			}
 
 			pi.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, data);
-			fs.unlinkSync(resultPath);
+			fsApi.unlinkSync(resultPath);
 		} catch (error) {
 			if (isNotFoundError(error)) return;
 			console.error(`Failed to process subagent result file '${resultPath}':`, error);
@@ -50,50 +79,91 @@ export function createResultWatcher(
 
 	state.resultFileCoalescer = createFileCoalescer(handleResult, 50);
 
+	const primeExistingResults = () => {
+		try {
+			fsApi.readdirSync(resultsDir)
+				.filter((f) => f.endsWith(".json"))
+				.forEach((file) => state.resultFileCoalescer.schedule(file, 0));
+		} catch (error) {
+			if (isNotFoundError(error)) return;
+			console.error(`Failed to scan subagent result directory '${resultsDir}':`, error);
+		}
+	};
+
+	const startPollingFallback = (reason: unknown) => {
+		state.watcher?.close();
+		state.watcher = null;
+		if (state.watcherRestartTimer) return;
+
+		console.error(
+			`Subagent result watcher for '${resultsDir}' fell back to polling because native fs.watch is unavailable (${getErrorCode(reason) ?? "unknown error"}).`,
+		);
+		primeExistingResults();
+		state.watcherRestartTimer = timers.setInterval(primeExistingResults, POLL_INTERVAL_MS);
+		state.watcherRestartTimer.unref?.();
+	};
+
 	const scheduleRestart = () => {
-		state.watcherRestartTimer = setTimeout(() => {
+		if (state.watcherRestartTimer) return;
+		state.watcherRestartTimer = timers.setTimeout(() => {
+			state.watcherRestartTimer = null;
 			try {
-				fs.mkdirSync(resultsDir, { recursive: true });
+				fsApi.mkdirSync(resultsDir, { recursive: true });
 				startResultWatcher();
 			} catch (error) {
+				if (shouldFallBackToPolling(error)) {
+					startPollingFallback(error);
+					return;
+				}
 				console.error(`Failed to restart subagent result watcher for '${resultsDir}':`, error);
+				scheduleRestart();
 			}
-		}, 3000);
+		}, WATCHER_RESTART_DELAY_MS);
+		state.watcherRestartTimer.unref?.();
 	};
 
 	const startResultWatcher = () => {
-		state.watcherRestartTimer = null;
+		if (state.watcher) return;
+		if (state.watcherRestartTimer) {
+			timers.clearTimeout(state.watcherRestartTimer);
+			timers.clearInterval(state.watcherRestartTimer);
+			state.watcherRestartTimer = null;
+		}
 		try {
-			state.watcher = fs.watch(resultsDir, (ev, file) => {
+			state.watcher = fsApi.watch(resultsDir, (ev, file) => {
 				if (ev !== "rename" || !file) return;
 				const fileName = file.toString();
 				if (!fileName.endsWith(".json")) return;
 				state.resultFileCoalescer.schedule(fileName);
 			});
 			state.watcher.on("error", (error) => {
+				if (shouldFallBackToPolling(error)) {
+					startPollingFallback(error);
+					return;
+				}
 				console.error(`Subagent result watcher failed for '${resultsDir}':`, error);
+				state.watcher?.close();
 				state.watcher = null;
 				scheduleRestart();
 			});
 			state.watcher.unref?.();
 		} catch (error) {
+			if (shouldFallBackToPolling(error)) {
+				startPollingFallback(error);
+				return;
+			}
 			console.error(`Failed to start subagent result watcher for '${resultsDir}':`, error);
 			state.watcher = null;
 			scheduleRestart();
 		}
 	};
 
-	const primeExistingResults = () => {
-		fs.readdirSync(resultsDir)
-			.filter((f) => f.endsWith(".json"))
-			.forEach((file) => state.resultFileCoalescer.schedule(file, 0));
-	};
-
 	const stopResultWatcher = () => {
 		state.watcher?.close();
 		state.watcher = null;
 		if (state.watcherRestartTimer) {
-			clearTimeout(state.watcherRestartTimer);
+			timers.clearTimeout(state.watcherRestartTimer);
+			timers.clearInterval(state.watcherRestartTimer);
 		}
 		state.watcherRestartTimer = null;
 		state.resultFileCoalescer.clear();

--- a/result-watcher.ts
+++ b/result-watcher.ts
@@ -34,6 +34,9 @@ function isNotFoundError(error: unknown): boolean {
 
 function shouldFallBackToPolling(error: unknown): boolean {
 	const code = getErrorCode(error);
+	// fs.watch can throw EMFILE/ENOSPC when the host exhausts file
+	// descriptors or inotify resources. Async completions are already
+	// persisted as result files, so polling is a safe degradation path.
 	return code === "EMFILE" || code === "ENOSPC";
 }
 

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { createResultWatcher } from "../../result-watcher.ts";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT } from "../../types.ts";
 
 function createState() {
 	return {
@@ -56,6 +58,59 @@ describe("result watcher", () => {
 				logged.some((entry) => /Failed to process subagent result file/.test(String(entry[0] ?? ""))),
 				"expected watcher error to be logged",
 			);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to polling result files when fs.watch hits EMFILE", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-"));
+		try {
+			const state = createState();
+			state.currentSessionId = "session-1";
+			const events = new EventEmitter();
+			const emitted: unknown[] = [];
+			events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, (data) => emitted.push(data));
+
+			let poll: (() => void) | undefined;
+			const emfile = new Error("too many open files") as NodeJS.ErrnoException;
+			emfile.code = "EMFILE";
+			const watcher = createResultWatcher({ events } as never, state as never, resultsDir, 60_000, {
+				fs: {
+					...fs,
+					watch: () => {
+						throw emfile;
+					},
+				},
+				timers: {
+					...globalThis,
+					setInterval: (handler: () => void) => {
+						poll = handler;
+						return { unref() {} } as NodeJS.Timeout;
+					},
+					clearInterval: () => {},
+				},
+			});
+
+			const originalError = console.error;
+			console.error = () => {};
+			try {
+				watcher.startResultWatcher();
+				assert.equal(state.watcher, null);
+				assert.notEqual(state.watcherRestartTimer, null);
+
+				const resultPath = path.join(resultsDir, "done.json");
+				fs.writeFileSync(resultPath, JSON.stringify({ sessionId: "session-1", summary: "done" }));
+				poll?.();
+				await new Promise((resolve) => setTimeout(resolve, 75));
+
+				assert.equal(emitted.length, 1);
+				assert.deepEqual(emitted[0], { sessionId: "session-1", summary: "done" });
+				assert.equal(fs.existsSync(resultPath), false);
+			} finally {
+				console.error = originalError;
+				watcher.stopResultWatcher();
+			}
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary
- fall back from native `fs.watch` to lightweight polling when the async result watcher hits `EMFILE`/`ENOSPC`
- avoid an infinite restart/error loop under file descriptor or inotify pressure
- keep async completion delivery working by scanning the existing result-file directory during fallback
- make result watcher fs/timer dependencies injectable for focused tests

## Why
`pi-subagents` only needs a single native watcher for `/tmp/pi-subagents-<scope>/async-subagent-results`, but `fs.watch()` can still fail when the host is already under resource pressure. On Linux, Node may surface exhausted file descriptors or inotify resources as errors like:

```text
EMFILE: too many open files, watch '/tmp/pi-subagents-uid-1000/async-subagent-results'
```

In the observed case this happened after the machine had accumulated orphaned headless Chromium/chromedp processes. The important part for this package is that async completion delivery should not depend on native watcher availability: completions are already persisted as `.json` result files, so polling is a safe degradation path.

Before this change, the watcher retried every few seconds and repeatedly printed the same startup failure. After this change, `EMFILE`/`ENOSPC` switches the watcher into polling mode and async completions continue to be consumed.

## Verification
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/result-watcher.test.ts`

## Notes
- This does not claim to fix the host-level resource leak. It makes `pi-subagents` robust when the host cannot allocate a native watcher.