### PR TITLE
fix: treat final drain after assistant output as success

### DIFF
--- a/execution.ts
+++ b/execution.ts
@@ -212,6 +212,8 @@ async function runSingleAttempt(
 		const HARD_KILL_MS = 3000;
 		let childExited = false;
 		let forcedTerminationSignal = false;
+		let finalAssistantDelivered = false;
+		let finalDrainCleanupWarning: string | undefined;
 		let finalDrainTimer: NodeJS.Timeout | undefined;
 		let finalHardKillTimer: NodeJS.Timeout | undefined;
 		const clearFinalDrainTimers = () => {
@@ -231,8 +233,8 @@ async function runSingleAttempt(
 				const termSent = trySignalChild(proc, "SIGTERM");
 				if (!termSent) return;
 				forcedTerminationSignal = true;
-				result.error = result.error
-					?? `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
+				finalDrainCleanupWarning = `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
+				if (!finalAssistantDelivered) result.error = result.error ?? finalDrainCleanupWarning;
 				finalHardKillTimer = setTimeout(() => {
 					if (settled || processClosed || detached) return;
 					forcedTerminationSignal = trySignalChild(proc, "SIGKILL") || forcedTerminationSignal;
@@ -389,7 +391,9 @@ async function runSingleAttempt(
 					const stopReason = (evt.message as { stopReason?: string }).stopReason;
 					const hasToolCall = Array.isArray(evt.message.content)
 						&& evt.message.content.some((part) => (part as { type?: string }).type === "toolCall");
+					const finalText = extractTextFromContent(evt.message.content).trim();
 					if (stopReason === "stop" && !hasToolCall) {
+						finalAssistantDelivered ||= !evt.message.errorMessage && finalText.length > 0;
 						startFinalDrain();
 					}
 				}
@@ -444,10 +448,14 @@ async function runSingleAttempt(
 			}
 			processClosed = true;
 			if (buf.trim()) processLine(buf);
-			if (code !== 0 && stderrBuf.trim() && !result.error) {
+			const forcedDrainAfterFinalSuccess = forcedTerminationSignal && finalAssistantDelivered;
+			if (code !== 0 && stderrBuf.trim() && !result.error && !forcedDrainAfterFinalSuccess) {
 				result.error = stderrBuf.trim();
 			}
-			const finalCode = forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
+			if (forcedDrainAfterFinalSuccess && finalDrainCleanupWarning) {
+				appendRecentOutput(progress, [`Warning: ${finalDrainCleanupWarning}`]);
+			}
+			const finalCode = forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
 			finish(finalCode);
 		});
 		proc.on("error", (error) => {

--- a/subagent-runner.ts
+++ b/subagent-runner.ts
@@ -260,7 +260,11 @@ function runPiStreaming(
 				const stopReason = (event.message as { stopReason?: string }).stopReason;
 				const hasToolCall = Array.isArray(event.message.content)
 					&& event.message.content.some((part) => (part as { type?: string }).type === "toolCall");
-				if (stopReason === "stop" && !hasToolCall) startFinalDrain();
+				const finalText = extractTextFromContent(event.message.content).trim();
+				if (stopReason === "stop" && !hasToolCall) {
+					finalAssistantDelivered ||= !event.message.errorMessage && finalText.length > 0;
+					startFinalDrain();
+				}
 			}
 		};
 
@@ -283,6 +287,8 @@ function runPiStreaming(
 		const HARD_KILL_MS = 3000;
 		let childExited = false;
 		let forcedTerminationSignal = false;
+		let finalAssistantDelivered = false;
+		let finalDrainCleanupWarning: string | undefined;
 		let finalDrainTimer: NodeJS.Timeout | undefined;
 		let finalHardKillTimer: NodeJS.Timeout | undefined;
 		let settled = false;
@@ -324,8 +330,9 @@ function runPiStreaming(
 				const termSent = trySignalChild(child, "SIGTERM");
 				if (!termSent) return;
 				forcedTerminationSignal = true;
-				if (!error) {
-					error = `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
+				finalDrainCleanupWarning = `Subagent process did not exit within ${FINAL_DRAIN_MS}ms after its final message. Forcing termination.`;
+				if (!finalAssistantDelivered && !error) {
+					error = finalDrainCleanupWarning;
 				}
 				finalHardKillTimer = setTimeout(() => {
 					if (settled) return;
@@ -348,13 +355,14 @@ function runPiStreaming(
 			if (stderrBuf.trim()) appendChildLine("subagent.child.stderr", stderrBuf);
 			outputStream.end();
 			const finalOutput = getFinalOutput(messages) || rawStdoutLines.join("\n").trim();
+			const forcedDrainAfterFinalSuccess = forcedTerminationSignal && finalAssistantDelivered;
 			resolve({
 				stderr,
-				exitCode: interrupted ? 0 : forcedTerminationSignal || signal ? (exitCode ?? 1) : exitCode,
+				exitCode: interrupted || forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (exitCode ?? 1) : exitCode,
 				messages,
 				usage,
 				model,
-				error: interrupted ? undefined : error,
+				error: interrupted || forcedDrainAfterFinalSuccess ? undefined : error,
 				finalOutput,
 				interrupted,
 			});

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -669,6 +669,50 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(result.content[0]?.text ?? "", /async-cfg-/);
 	});
 
+	it("background forced drain after final assistant output is cleanup success", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [events.assistantMessage("async-done-before-drain")],
+			stderr: "Done after 1 turn(s). Ready for input.\n",
+			keepAliveAfterFinalMessageMs: 10000,
+		});
+
+		const id = `async-final-drain-${Date.now().toString(36)}`;
+		const resultPath = path.join(RESULTS_DIR, `${id}.json`);
+		const sessionRoot = path.join(tempDir, "sessions");
+
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot,
+			maxSubagentDepth: 2,
+		});
+
+		const deadline = Date.now() + 10_000;
+		while (!fs.existsSync(resultPath)) {
+			if (Date.now() > deadline) {
+				assert.fail(`Timed out waiting for async result file: ${resultPath}`);
+			}
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+		assert.equal(payload.success, true);
+		assert.equal(payload.exitCode, 0);
+		assert.equal(payload.results[0].success, true);
+		assert.equal(payload.results[0].output, "async-done-before-drain");
+	});
+
 	it("background runs stream child events and live output while active", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			steps: [

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -507,6 +507,47 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok(extensionArgs.includes("./allowed-ext.ts"));
 	});
 
+
+	it("treats forced drain after final assistant output as cleanup success", async () => {
+		mockPi.onCall({
+			jsonl: [events.assistantMessage("done-before-drain")],
+			stderr: "Done after 1 turn(s). Ready for input.\n",
+			keepAliveAfterFinalMessageMs: 10000,
+		});
+		const agents = makeAgentConfigs(["echo"]);
+
+		const start = Date.now();
+		const result = await runSync(tempDir, agents, "echo", "Task", {});
+		const elapsed = Date.now() - start;
+
+		assert.ok(elapsed < 9000, `should force-drain instead of hanging, took ${elapsed}ms`);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.error, undefined);
+		assert.equal(result.finalOutput, "done-before-drain");
+	});
+
+	it("keeps forced drain after empty assistant output as failure", async () => {
+		mockPi.onCall({
+			jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "" }],
+					model: "mock/test-model",
+					stopReason: "stop",
+					usage: { input: 100, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+				},
+			}],
+			keepAliveAfterFinalMessageMs: 10000,
+		});
+		const agents = makeAgentConfigs(["echo"]);
+
+		const result = await runSync(tempDir, agents, "echo", "Task", {});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /did not exit within 5000ms after its final message/);
+	});
+
 	it("handles abort signal (completes faster than delay)", async () => {
 		mockPi.onCall({ delay: 10000 }); // Long delay — process should be killed before this
 		const agents = makeAgentConfigs(["slow"]);

--- a/test/support/mock-pi-script.mjs
+++ b/test/support/mock-pi-script.mjs
@@ -139,6 +139,10 @@ async function main() {
 		process.stderr.write(response.stderr);
 	}
 
+	if (typeof response.keepAliveAfterFinalMessageMs === "number" && response.keepAliveAfterFinalMessageMs > 0) {
+		await new Promise((resolve) => setTimeout(resolve, response.keepAliveAfterFinalMessageMs));
+	}
+
 	process.exit(typeof response.exitCode === "number" ? response.exitCode : 0);
 }
 

--- a/test/support/mock-pi.ts
+++ b/test/support/mock-pi.ts
@@ -8,6 +8,7 @@ export interface MockPiResponse {
 	stderr?: string;
 	exitCode?: number;
 	delay?: number;
+	keepAliveAfterFinalMessageMs?: number;
 	jsonl?: unknown[];
 	steps?: Array<{
 		delay?: number;


### PR DESCRIPTION
## Summary

- Treat forced runner drain after a valid final assistant response as cleanup success instead of task failure.
- Keep forced drain as failure when the final assistant response has no usable output or reports an error.
- Add sync and async/background regression coverage using the mock Pi fixture.

## Why

#96 added final-message drain logic so stuck child processes do not hang the runner indefinitely. There is one remaining edge case: if the child emits a valid final assistant response and then stays alive until the drain timer terminates it, the forced termination can be reported as a task failure even though the final output was already delivered.

Example shape:

```text
assistant message_end: stopReason="stop", text="matrix-ok"
stderr: Done after 1 turn(s). Ready for input.
subagent.step.failed exitCode:1
```

That can incorrectly mark a successful run as failed and can stop chains after a valid handoff.

## Fix

The sync and async runners now latch whether a final assistant response has already been semantically delivered:

- assistant `message_end`
- `stopReason === "stop"`
- no `toolCall` block
- no `errorMessage`
- non-empty final text

If the final-drain timer later terminates the child, that termination is treated as process cleanup (`exitCode: 0`) only when that valid final response was already delivered. Empty/error final outputs still fail.

## Tests

```bash
env -u PI_SUBAGENT_DEPTH -u PI_SUBAGENT_MAX_DEPTH node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts --test-name-pattern='forced drain'
```

Passes: sync forced-drain success and empty-output failure regressions.

```bash
env -u PI_SUBAGENT_DEPTH -u PI_SUBAGENT_MAX_DEPTH node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts --test-name-pattern='forced drain'
```

Passes: async/background forced-drain success regression.

```bash
node --experimental-strip-types --check execution.ts
node --experimental-strip-types --check subagent-runner.ts
git diff --check
```

Passes.
