### PR TITLE
Fix status row overflow on multiline content

### DIFF
--- a/render-helpers.ts
+++ b/render-helpers.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
-import { visibleWidth } from "@mariozechner/pi-tui";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 
 function fuzzyScore(query: string, text: string): number {
 	const lq = query.toLowerCase();
@@ -37,7 +37,9 @@ export function pad(s: string, len: number): string {
 
 export function row(content: string, width: number, theme: Theme): string {
 	const innerW = width - 2;
-	return theme.fg("border", "│") + pad(content, innerW) + theme.fg("border", "│");
+	const singleLine = content.replace(/[\r\n]+/g, " ").replace(/\t/g, "  ");
+	const clipped = truncateToWidth(singleLine, innerW);
+	return theme.fg("border", "│") + pad(clipped, innerW) + theme.fg("border", "│");
 }
 
 export function renderHeader(text: string, width: number, theme: Theme): string {

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { row } from "../../render-helpers.ts";
+
+const theme = {
+	fg(_name: string, text: string): string {
+		return text;
+	},
+};
+
+test("row clips content to the available width", () => {
+	const rendered = row("abcdef", 6, theme as any);
+	assert.equal(visibleWidth(rendered), 6);
+});
+
+test("row normalizes multiline content before clipping", () => {
+	const rendered = row("bash failed: line 1\nline 2\tvalue", 20, theme as any);
+	assert.equal(visibleWidth(rendered), 20);
+	assert.doesNotMatch(rendered, /[\r\n\t]/);
+});
+
+test("row keeps styled multiline content within the available width", () => {
+	const rendered = row("\u001b[31merror line 1\nline 2\tvalue\u001b[39m", 18, theme as any);
+	assert.equal(visibleWidth(rendered), 18);
+	assert.doesNotMatch(rendered, /[\r\n\t]/);
+});


### PR DESCRIPTION
## Summary
- Make shared status row rendering normalize embedded newlines and tabs before rendering
- Truncate row content to the available inner width before padding
- Add regression coverage for clipped, multiline, tabbed, and ANSI-styled row content

## Validation
- `node --experimental-strip-types --test test/unit/render-helpers.test.ts`

Note: A full local `npm test` run also exercised this new test, but currently reports two unrelated existing schema test failures in `test/unit/schemas.test.ts`.