### PR TITLE
Hide disabled builtins from agent-facing list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- `subagent({ action: "list" })` no longer prints disabled builtin agents, so agents are not nudged to call names that runtime discovery will reject.
+
 ## [0.20.1] - 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Supported override fields are `model`, `fallbackModels`, `thinking`, `systemProm
 
 You can also manage builtin overrides from `/agents`. On a builtin detail screen, press `e`, choose user or project scope if needed, and save the fields you want to override.
 
-Set `disabled: true` to hide a builtin from runtime discovery while keeping it visible in `/agents`. For bulk control, set `subagents.disableBuiltins: true` in settings. Overridden builtins show badges like `[builtin+user]` or `[builtin+project]`; disabled builtins show `off` badges in the manager.
+Set `disabled: true` to hide a builtin from runtime discovery and from the agent-facing `subagent({ action: "list" })` output while keeping it visible in `/agents`. For bulk control, set `subagents.disableBuiltins: true` in settings. Overridden builtins show badges like `[builtin+user]` or `[builtin+project]`; disabled builtins show `off` badges in the manager.
 
 ### Prompt assembly
 

--- a/agent-management.ts
+++ b/agent-management.ts
@@ -372,12 +372,10 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 	const d = discoverAgentsAll(ctx.cwd);
 	const scopedAgents = allAgents(d).filter((a) => scope === "both" || a.source === "builtin" || a.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const agents = scopedAgents.filter((a) => !a.disabled);
-	const disabledBuiltins = scopedAgents.filter((a) => a.source === "builtin" && a.disabled);
 	const chains = d.chains.filter((c) => scope === "both" || c.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const lines = [
 		"Executable agents:",
 		...(agents.length ? agents.map((a) => `- ${a.name} (${a.source}): ${a.description}`) : ["- (none)"]),
-		...(disabledBuiltins.length ? ["", "Disabled builtins:", ...disabledBuiltins.map((a) => `- ${a.name} (${a.source}, disabled): ${a.description}`)] : []),
 		"",
 		"Chains:",
 		...(chains.length ? chains.map((c) => `- ${c.name} (${c.source}): ${c.description}`) : ["- (none)"]),

--- a/index.ts
+++ b/index.ts
@@ -412,7 +412,7 @@ CHAIN TEMPLATE VARIABLES (use in task strings):
 Example: { chain: [{agent:"agent-a", task:"Analyze {task}"}, {agent:"agent-b", task:"Plan based on {previous}"}] }
 
 MANAGEMENT (use action field, omit agent/task/chain/tasks):
-• { action: "list" } - discover executable agents/chains and any disabled builtins
+• { action: "list" } - discover executable agents/chains
 • { action: "get", agent: "name" } - full detail
 • { action: "create", config: { name, systemPrompt, systemPromptMode, inheritProjectContext, inheritSkills, ... } }
 • { action: "update", agent: "name", config: { ... } } - merge

--- a/test/unit/agent-disabled.test.ts
+++ b/test/unit/agent-disabled.test.ts
@@ -158,7 +158,7 @@ describe("builtin agent disabling", () => {
 		);
 	});
 
-	it("separates disabled builtins from executable agents in management list output", () => {
+	it("hides disabled builtins from the agent-facing management list output", () => {
 		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
 			subagents: { disableBuiltins: true },
 		});
@@ -170,18 +170,19 @@ describe("builtin agent disabling", () => {
 			"utf-8",
 		);
 
+		const disabledBuiltinNames = discoverAgentsAll(tempProject).builtin.map((agent) => agent.name);
+		assert.ok(disabledBuiltinNames.length > 0);
+
 		const text = readText(handleList(
 			{},
 			{ cwd: tempProject, modelRegistry: { getAvailable: () => [] } },
 		));
 
 		assert.match(text, /Executable agents:\n- helper \(project\): Helper/);
-		assert.match(text, /Disabled builtins:\n- .* \(builtin, disabled\): /);
-		const executableSection = text.slice(
-			text.indexOf("Executable agents:"),
-			text.indexOf("\n\nDisabled builtins:"),
-		);
-		assert.doesNotMatch(executableSection, /\(builtin, disabled\)/);
+		assert.doesNotMatch(text, /Disabled builtins:/);
+		for (const name of disabledBuiltinNames) {
+			assert.doesNotMatch(text, new RegExp(`^- ${name} \\(builtin`, "m"));
+		}
 	});
 
 	it("buildBuiltinOverrideConfig emits disabled false when re-enabling a builtin", () => {

--- a/test/unit/tool-description.test.ts
+++ b/test/unit/tool-description.test.ts
@@ -21,6 +21,7 @@ describe("registered subagent tool description", () => {
 		}
 		assert.match(description, /use \{ action: "list" \} to inspect configured agents\/chains/i);
 		assert.match(description, /executable\/non-disabled/i);
+		assert.doesNotMatch(description, /disabled builtins/i);
 		assert.match(description, /output\?,reads\?,progress\?/i);
 	});
 });


### PR DESCRIPTION
The execution path already excludes disabled builtin agents, but action:list still printed them under a disabled section. We observed delegated review agents treating that list as available choices, selecting disabled or unavailable names, and then receiving Unknown agent errors from execution. That makes the tool guidance contradictory: the list presents names that the executor will not run.

Remove disabled builtins from the agent-facing list and tool description while keeping them visible in /agents for humans to re-enable.