### PR TITLE
docs: list /parallel-cleanup alongside other packaged prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The package includes reusable prompt templates for common workflows. You do not 
 | `/parallel-review` | Launch fresh-context reviewers with distinct angles, then synthesize what to fix. |
 | `/parallel-research` | Combine `researcher` and `scout` for external evidence, local code context, and practical tradeoffs. |
 | `/gather-context-and-clarify` | Scout/research first, then ask the user the clarification questions that matter. |
+| `/parallel-cleanup` | Launch two fresh-context reviewers (deslop + verbosity passes) for an adversarial cleanup review of the current diff. |
 
 ## Optional pi-intercom companion
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -43,6 +43,7 @@ Packaged prompt shortcuts are also available for repeatable workflows:
 - `/parallel-review` — fresh-context reviewers with distinct review angles, then synthesis
 - `/parallel-research` — combine `researcher` and `scout` for external evidence plus local code context
 - `/gather-context-and-clarify` — scout/research first, then ask the user clarifying questions with `interview`
+- `/parallel-cleanup` — two fresh-context reviewers (deslop + verbosity passes) for an adversarial cleanup review of the current diff
 
 ## Builtin Agents
 
@@ -424,8 +425,9 @@ copying a full builtin file.
 ## Prompt Template Integration
 
 The package includes prompt shortcuts for common workflows: `/parallel-review`,
-`/parallel-research`, and `/gather-context-and-clarify`. Use them when the user
-wants repeatable review, research, or clarification patterns.
+`/parallel-research`, `/gather-context-and-clarify`, and `/parallel-cleanup`.
+Use them when the user wants repeatable review, research, clarification, or
+cleanup-review patterns.
 
 If `pi-prompt-template-model` is installed, additional user prompt templates can delegate into
 `pi-subagents`. This is useful when a slash command should always run through a


### PR DESCRIPTION
## Summary

The `/parallel-cleanup` prompt was added in 0.20.0 but never picked up
in the user-facing prompt lists. Wiring is unchanged — the prompt
ships and registers via `package.json` `pi.prompts` directory scan
identically to its peers — so this is a pure documentation fix that
syncs the three sites that enumerate packaged prompts.

## Changes

- `README.md` — add `/parallel-cleanup` row to the prompt table next to `/parallel-review`, `/parallel-research`, and `/gather-context-and-clarify`.
- `skills/pi-subagents/SKILL.md` — add it to the Tool vs Slash Commands bullet list.
- `skills/pi-subagents/SKILL.md` — mention it in the Prompt Template Integration paragraph so the prose stays in sync with the bullet list.

## Test plan

- Docs-only change; no code paths touched.
- Verified `package.json` `pi.prompts` already scans `./prompts` so `/parallel-cleanup` was already discoverable at runtime.
- Verified no test enumerates prompt names by grepping `test/` for all four prompt names — no test updates required.
- Visually confirmed the three updated sites list the four prompts consistently.