### PR TITLE
Localize subagent slash flow strings

### DIFF
--- a/src/extension/i18n.ts
+++ b/src/extension/i18n.ts
@@ -1,0 +1,126 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Params = Record<string, string | number>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+	if (!params) return text;
+	return text.replace(/\{(\w+)\}/g, (_match, key: string) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+	return translate(key, fallback, params);
+}
+
+const bundles = [
+	{
+		locale: "ja",
+		namespace: "pi-subagents",
+		messages: {
+			"slash.bridge.startTimeout": "スラッシュ subagent ブリッジが15秒以内に開始しませんでした。拡張機能が正しく読み込まれていることを確認してください。",
+			"slash.status.running": "実行中...",
+			"slash.status.liveDetail": "{count} 個のツール{tool} | Ctrl+O でライブ詳細",
+			"slash.cancelled": "キャンセルされました",
+			"slash.bridge.noResponse": "スラッシュ subagent ブリッジが応答しませんでした。subagent 拡張機能が正しく読み込まれていることを確認してください。",
+			"slash.result.running": "Subagent を実行中...",
+			"slash.result.heading": "Subagent の結果",
+			"slash.result.noOutput": "(出力なし)",
+			"slash.result.childSessions": "子セッションのエクスポート",
+			"slash.result.savedOutputs": "保存された出力",
+			"slash.result.artifactOutputs": "成果物の出力",
+			"slash.result.failed": "Subagent が失敗しました",
+			"slash.usage.chain": "使用方法: /{command} agent1 \"task1\" -> agent2 \"task2\"",
+			"slash.error.unknownAgent": "不明なエージェント: {agent}",
+			"slash.error.firstStepTask": "最初のステップにはタスクが必要です: /chain agent \"task\" -> agent2",
+			"slash.error.atLeastOneTask": "少なくとも1つのステップにタスクが必要です",
+			"slash.cmd.agents": "Agents Manager を開く",
+			"slash.cmd.run": "subagent を直接実行: /run agent[output=file] [task] [--bg] [--fork]",
+			"slash.usage.run": "使用方法: /run <agent> [task] [--bg] [--fork]",
+			"slash.cmd.chain": "エージェントを順番に実行: /chain scout \"task\" -> planner [--bg] [--fork]",
+			"slash.cmd.runChain": "保存済みチェーンを実行: /run-chain chainName -- task [--bg] [--fork]",
+			"slash.usage.runChain": "使用方法: /run-chain <chainName> -- <task> [--bg] [--fork]",
+			"slash.error.unknownChain": "不明なチェーン: {chain}",
+			"slash.cmd.parallel": "エージェントを並列実行: /parallel scout \"task1\" -> reviewer \"task2\" [--bg] [--fork]",
+			"slash.cmd.status": "アクティブまたは最近の非同期 subagent 実行を表示",
+			"slash.cmd.doctor": "subagent 診断を表示",
+		},
+	},
+	{
+		locale: "zh-CN",
+		namespace: "pi-subagents",
+		messages: {
+			"slash.bridge.startTimeout": "Slash subagent 桥接在 15 秒内未启动。请确认扩展已正确加载。",
+			"slash.status.running": "运行中...",
+			"slash.status.liveDetail": "{count} 个工具{tool} | Ctrl+O 查看实时详情",
+			"slash.cancelled": "已取消",
+			"slash.bridge.noResponse": "没有 slash subagent 桥接响应。请确认 subagent 扩展已正确加载。",
+			"slash.result.running": "正在运行 subagent...",
+			"slash.result.heading": "Subagent 结果",
+			"slash.result.noOutput": "（无输出）",
+			"slash.result.childSessions": "子会话导出",
+			"slash.result.savedOutputs": "已保存输出",
+			"slash.result.artifactOutputs": "产物输出",
+			"slash.result.failed": "Subagent 失败",
+			"slash.usage.chain": "用法: /{command} agent1 \"task1\" -> agent2 \"task2\"",
+			"slash.error.unknownAgent": "未知 agent: {agent}",
+			"slash.error.firstStepTask": "第一步必须有任务: /chain agent \"task\" -> agent2",
+			"slash.error.atLeastOneTask": "至少一个步骤必须有任务",
+			"slash.cmd.agents": "打开 Agents Manager",
+			"slash.cmd.run": "直接运行 subagent: /run agent[output=file] [task] [--bg] [--fork]",
+			"slash.usage.run": "用法: /run <agent> [task] [--bg] [--fork]",
+			"slash.cmd.chain": "按顺序运行 agent: /chain scout \"task\" -> planner [--bg] [--fork]",
+			"slash.cmd.runChain": "运行已保存的 chain: /run-chain chainName -- task [--bg] [--fork]",
+			"slash.usage.runChain": "用法: /run-chain <chainName> -- <task> [--bg] [--fork]",
+			"slash.error.unknownChain": "未知 chain: {chain}",
+			"slash.cmd.parallel": "并行运行 agent: /parallel scout \"task1\" -> reviewer \"task2\" [--bg] [--fork]",
+			"slash.cmd.status": "显示活跃和最近的异步 subagent 运行",
+			"slash.cmd.doctor": "显示 subagent 诊断信息",
+		},
+	},
+	{
+		locale: "es",
+		namespace: "pi-subagents",
+		messages: {
+			"slash.bridge.startTimeout": "El puente de slash subagent no se inició en 15 s. Comprueba que la extensión esté cargada correctamente.",
+			"slash.status.running": "ejecutando...",
+			"slash.status.liveDetail": "{count} herramientas{tool} | Ctrl+O para detalle en vivo",
+			"slash.cancelled": "Cancelado",
+			"slash.bridge.noResponse": "Ningún puente de slash subagent respondió. Comprueba que la extensión subagent esté cargada correctamente.",
+			"slash.result.running": "Ejecutando subagent...",
+			"slash.result.heading": "Resultado de subagent",
+			"slash.result.noOutput": "(sin salida)",
+			"slash.result.childSessions": "Exportaciones de sesiones hijas",
+			"slash.result.savedOutputs": "Salidas guardadas",
+			"slash.result.artifactOutputs": "Salidas de artefactos",
+			"slash.result.failed": "Subagent falló",
+			"slash.usage.chain": "Uso: /{command} agent1 \"task1\" -> agent2 \"task2\"",
+			"slash.error.unknownAgent": "Agente desconocido: {agent}",
+			"slash.error.firstStepTask": "El primer paso debe tener una tarea: /chain agent \"task\" -> agent2",
+			"slash.error.atLeastOneTask": "Al menos un paso debe tener una tarea",
+			"slash.cmd.agents": "Abrir Agents Manager",
+			"slash.cmd.run": "Ejecutar un subagent directamente: /run agent[output=file] [task] [--bg] [--fork]",
+			"slash.usage.run": "Uso: /run <agent> [task] [--bg] [--fork]",
+			"slash.cmd.chain": "Ejecutar agentes en secuencia: /chain scout \"task\" -> planner [--bg] [--fork]",
+			"slash.cmd.runChain": "Ejecutar una chain guardada: /run-chain chainName -- task [--bg] [--fork]",
+			"slash.usage.runChain": "Uso: /run-chain <chainName> -- <task> [--bg] [--fork]",
+			"slash.error.unknownChain": "Chain desconocida: {chain}",
+			"slash.cmd.parallel": "Ejecutar agentes en paralelo: /parallel scout \"task1\" -> reviewer \"task2\" [--bg] [--fork]",
+			"slash.cmd.status": "Mostrar ejecuciones async de subagent activas y recientes",
+			"slash.cmd.doctor": "Mostrar diagnósticos de subagent",
+		},
+	},
+];
+
+export function initI18n(pi: ExtensionAPI): void {
+	const events = pi.events;
+	if (!events) return;
+	for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+	events.emit("pi-core/i18n/requestApi", {
+		namespace: "pi-subagents",
+		callback(api: { t?: Translate } | undefined) {
+			if (typeof api?.t === "function") translate = api.t;
+		},
+	});
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -47,6 +47,7 @@ import {
 	SUBAGENT_CONTROL_EVENT,
 	WIDGET_KEY,
 } from "../shared/types.ts";
+import { initI18n } from "./i18n.ts";
 import {
 	clearPendingForegroundControlNotices,
 	formatSubagentControlNotice,
@@ -220,6 +221,7 @@ class SubagentControlNoticeComponent implements Component {
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	if (process.env[SUBAGENT_CHILD_ENV] === "1") return;
+	initI18n(pi);
 	const globalStore = globalThis as Record<string, unknown>;
 	const runtimeCleanupStoreKey = "__piSubagentRuntimeCleanup";
 	const previousRuntimeCleanup = globalStore[runtimeCleanupStoreKey];

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -16,6 +16,7 @@ import {
 	failSlashResult,
 	finalizeSlashResult,
 } from "./slash-live-state.ts";
+import { t } from "../extension/i18n.ts";
 import {
 	SLASH_RESULT_TYPE,
 	SLASH_SUBAGENT_CANCEL_EVENT,
@@ -152,7 +153,7 @@ async function requestSlashRun(
 		const startTimeoutMs = 15_000;
 		const startTimeout = setTimeout(() => {
 			finish(() => reject(new Error(
-				"Slash subagent bridge did not start within 15s. Ensure the extension is loaded correctly.",
+				t("slash.bridge.startTimeout", "Slash subagent bridge did not start within 15s. Ensure the extension is loaded correctly."),
 			)));
 		}, startTimeoutMs);
 
@@ -161,7 +162,7 @@ async function requestSlashRun(
 			if ((data as { requestId?: unknown }).requestId !== requestId) return;
 			started = true;
 			clearTimeout(startTimeout);
-			if (ctx.hasUI) ctx.ui.setStatus("subagent-slash", "running...");
+			if (ctx.hasUI) ctx.ui.setStatus("subagent-slash", t("slash.status.running", "running..."));
 		};
 
 		const onResponse = (data: unknown) => {
@@ -180,14 +181,14 @@ async function requestSlashRun(
 			if (!ctx.hasUI) return;
 			const tool = update.currentTool ? ` ${update.currentTool}` : "";
 			const count = update.toolCount ?? 0;
-			ctx.ui.setStatus("subagent-slash", `${count} tools${tool} | Ctrl+O live detail`);
+			ctx.ui.setStatus("subagent-slash", t("slash.status.liveDetail", `${count} tools${tool} | Ctrl+O live detail`, { count, tool }));
 		};
 
 		const onTerminalInput = ctx.hasUI
 			? ctx.ui.onTerminalInput((input) => {
 				if (!matchesKey(input, Key.escape)) return undefined;
 				pi.events.emit(SLASH_SUBAGENT_CANCEL_EVENT, { requestId });
-				finish(() => reject(new Error("Cancelled")));
+				finish(() => reject(new Error(t("slash.cancelled", "Cancelled"))));
 				return { consume: true };
 			})
 			: undefined;
@@ -214,7 +215,7 @@ async function requestSlashRun(
 		if (!started && done) return;
 		if (!started) {
 			finish(() => reject(new Error(
-				"No slash subagent bridge responded. Ensure the subagent extension is loaded correctly.",
+				t("slash.bridge.noResponse", "No slash subagent bridge responded. Ensure the subagent extension is loaded correctly."),
 			)));
 		}
 	});
@@ -240,15 +241,15 @@ function collectResultPaths(results: SingleResult[], getPath: (result: SingleRes
 }
 
 function buildSlashExportText(response: SlashSubagentResponse): string {
-	const output = extractSlashMessageText(response.result.content) || response.errorText || "(no output)";
+	const output = extractSlashMessageText(response.result.content) || response.errorText || t("slash.result.noOutput", "(no output)");
 	const results = response.result.details?.results ?? [];
 	const sessionFiles = collectResultPaths(results, (result) => result.sessionFile);
 	const savedOutputs = collectResultPaths(results, (result) => result.savedOutputPath);
 	const artifactOutputs = collectResultPaths(results, (result) => result.artifactPaths?.outputPath);
-	const sections = ["## Subagent result", output];
-	if (sessionFiles.length > 0) sections.push("## Child session exports", formatExportPathList(sessionFiles));
-	if (savedOutputs.length > 0) sections.push("## Saved outputs", formatExportPathList(savedOutputs));
-	if (artifactOutputs.length > 0) sections.push("## Artifact outputs", formatExportPathList(artifactOutputs));
+	const sections = [`## ${t("slash.result.heading", "Subagent result")}`, output];
+	if (sessionFiles.length > 0) sections.push(`## ${t("slash.result.childSessions", "Child session exports")}`, formatExportPathList(sessionFiles));
+	if (savedOutputs.length > 0) sections.push(`## ${t("slash.result.savedOutputs", "Saved outputs")}`, formatExportPathList(savedOutputs));
+	if (artifactOutputs.length > 0) sections.push(`## ${t("slash.result.artifactOutputs", "Artifact outputs")}`, formatExportPathList(artifactOutputs));
 	return sections.join("\n\n");
 }
 
@@ -276,7 +277,7 @@ async function runSlashSubagent(
 ): Promise<void> {
 	const requestId = randomUUID();
 	const initialDetails = buildSlashInitialResult(requestId, params);
-	const initialText = extractSlashMessageText(initialDetails.result.content) || "Running subagent...";
+	const initialText = extractSlashMessageText(initialDetails.result.content) || t("slash.result.running", "Running subagent...");
 	pi.sendMessage({
 		customType: SLASH_RESULT_TYPE,
 		content: initialText,
@@ -299,14 +300,14 @@ async function runSlashSubagent(
 			ctx.ui.setStatus("subagent-slash", undefined);
 		}
 		if (response.isError && ctx.hasUI) {
-			ctx.ui.notify(response.errorText || "Subagent failed", "error");
+			ctx.ui.notify(response.errorText || t("slash.result.failed", "Subagent failed"), "error");
 		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		const failedDetails = failSlashResult(requestId, params, message);
 		pi.sendMessage({
 			customType: SLASH_RESULT_TYPE,
-			content: `## Subagent result\n\n${message}`,
+			content: `## ${t("slash.result.heading", "Subagent result")}\n\n${message}`,
 			display: true,
 			details: failedDetails,
 		});
@@ -314,8 +315,8 @@ async function runSlashSubagent(
 		if (ctx.hasUI) {
 			ctx.ui.setStatus("subagent-slash", undefined);
 		}
-		if (message === "Cancelled") {
-			if (ctx.hasUI) ctx.ui.notify("Cancelled", "warning");
+		if (message === t("slash.cancelled", "Cancelled")) {
+			if (ctx.hasUI) ctx.ui.notify(t("slash.cancelled", "Cancelled"), "warning");
 			return;
 		}
 		if (ctx.hasUI) ctx.ui.notify(message, "error");
@@ -379,7 +380,7 @@ const parseAgentArgs = (
 	ctx: ExtensionContext,
 ): { steps: ParsedStep[]; task: string } | null => {
 	const input = args.trim();
-	const usage = `Usage: /${command} agent1 "task1" -> agent2 "task2"`;
+	const usage = t("slash.usage.chain", `Usage: /${command} agent1 "task1" -> agent2 "task2"`, { command });
 	let steps: ParsedStep[];
 	let sharedTask: string;
 	let perStep = false;
@@ -432,16 +433,16 @@ const parseAgentArgs = (
 	const agents = discoverAgents(state.baseCwd, "both").agents;
 	for (const step of steps) {
 		if (!agents.find((a) => a.name === step.name)) {
-			ctx.ui.notify(`Unknown agent: ${step.name}`, "error");
+			ctx.ui.notify(t("slash.error.unknownAgent", `Unknown agent: ${step.name}`, { agent: step.name }), "error");
 			return null;
 		}
 	}
 	if (command === "chain" && !steps[0]?.task && (perStep || !sharedTask)) {
-		ctx.ui.notify(`First step must have a task: /chain agent "task" -> agent2`, "error");
+		ctx.ui.notify(t("slash.error.firstStepTask", `First step must have a task: /chain agent "task" -> agent2`), "error");
 		return null;
 	}
 	if (command === "parallel" && !steps.some((s) => s.task) && !sharedTask) {
-		ctx.ui.notify("At least one step must have a task", "error");
+		ctx.ui.notify(t("slash.error.atLeastOneTask", "At least one step must have a task"), "error");
 		return null;
 	}
 	return { steps, task: sharedTask };
@@ -453,25 +454,25 @@ export function registerSlashCommands(
 	config: ExtensionConfig = {},
 ): void {
 	pi.registerCommand("agents", {
-		description: "Open the Agents Manager",
+		description: t("slash.cmd.agents", "Open the Agents Manager"),
 		handler: async (_args, ctx) => {
 			await openAgentManager(pi, ctx, config);
 		},
 	});
 
 	pi.registerCommand("run", {
-		description: "Run a subagent directly: /run agent[output=file] [task] [--bg] [--fork]",
+		description: t("slash.cmd.run", "Run a subagent directly: /run agent[output=file] [task] [--bg] [--fork]"),
 		getArgumentCompletions: makeAgentCompletions(state, false),
 		handler: async (args, ctx) => {
 			const { args: cleanedArgs, bg, fork } = extractExecutionFlags(args);
 			const input = cleanedArgs.trim();
 			const firstSpace = input.indexOf(" ");
-			if (!input) { ctx.ui.notify("Usage: /run <agent> [task] [--bg] [--fork]", "error"); return; }
+			if (!input) { ctx.ui.notify(t("slash.usage.run", "Usage: /run <agent> [task] [--bg] [--fork]"), "error"); return; }
 			const { name: agentName, config: inline } = parseAgentToken(firstSpace === -1 ? input : input.slice(0, firstSpace));
 			const task = firstSpace === -1 ? "" : input.slice(firstSpace + 1).trim();
 
 			const agents = discoverAgents(state.baseCwd, "both").agents;
-			if (!agents.find((a) => a.name === agentName)) { ctx.ui.notify(`Unknown agent: ${agentName}`, "error"); return; }
+			if (!agents.find((a) => a.name === agentName)) { ctx.ui.notify(t("slash.error.unknownAgent", `Unknown agent: ${agentName}`, { agent: agentName }), "error"); return; }
 
 			let finalTask = task;
 			if (inline.reads && Array.isArray(inline.reads) && inline.reads.length > 0) {
@@ -488,7 +489,7 @@ export function registerSlashCommands(
 	});
 
 	pi.registerCommand("chain", {
-		description: "Run agents in sequence: /chain scout \"task\" -> planner [--bg] [--fork]",
+		description: t("slash.cmd.chain", "Run agents in sequence: /chain scout \"task\" -> planner [--bg] [--fork]"),
 		getArgumentCompletions: makeAgentCompletions(state, true),
 		handler: async (args, ctx) => {
 			const { args: cleanedArgs, bg, fork } = extractExecutionFlags(args);
@@ -511,12 +512,12 @@ export function registerSlashCommands(
 	});
 
 	pi.registerCommand("run-chain", {
-		description: "Run a saved chain: /run-chain chainName -- task [--bg] [--fork]",
+		description: t("slash.cmd.runChain", "Run a saved chain: /run-chain chainName -- task [--bg] [--fork]"),
 		getArgumentCompletions: makeChainCompletions(state),
 		handler: async (args, ctx) => {
 			const { args: cleanedArgs, bg, fork } = extractExecutionFlags(args);
 			const delimiterIndex = cleanedArgs.indexOf(" -- ");
-			const usage = "Usage: /run-chain <chainName> -- <task> [--bg] [--fork]";
+			const usage = t("slash.usage.runChain", "Usage: /run-chain <chainName> -- <task> [--bg] [--fork]");
 			if (delimiterIndex === -1) {
 				ctx.ui.notify(usage, "error");
 				return;
@@ -529,7 +530,7 @@ export function registerSlashCommands(
 			}
 			const chain = discoverSavedChains(state.baseCwd).find((candidate) => candidate.name === chainName);
 			if (!chain) {
-				ctx.ui.notify(`Unknown chain: ${chainName}`, "error");
+				ctx.ui.notify(t("slash.error.unknownChain", `Unknown chain: ${chainName}`, { chain: chainName }), "error");
 				return;
 			}
 			const params: SubagentParamsLike = { chain: mapSavedChainSteps(chain), task, clarify: false, agentScope: "both" };
@@ -540,7 +541,7 @@ export function registerSlashCommands(
 	});
 
 	pi.registerCommand("parallel", {
-		description: "Run agents in parallel: /parallel scout \"task1\" -> reviewer \"task2\" [--bg] [--fork]",
+		description: t("slash.cmd.parallel", "Run agents in parallel: /parallel scout \"task1\" -> reviewer \"task2\" [--bg] [--fork]"),
 		getArgumentCompletions: makeAgentCompletions(state, true),
 		handler: async (args, ctx) => {
 			const { args: cleanedArgs, bg, fork } = extractExecutionFlags(args);
@@ -563,7 +564,7 @@ export function registerSlashCommands(
 	});
 
 	pi.registerCommand("subagents-status", {
-		description: "Show active and recent async subagent runs",
+		description: t("slash.cmd.status", "Show active and recent async subagent runs"),
 		handler: async (_args, ctx) => {
 			await ctx.ui.custom<void>(
 				(tui, theme, _kb, done) => new SubagentsStatusComponent(tui, theme, () => done(undefined)),
@@ -573,7 +574,7 @@ export function registerSlashCommands(
 	});
 
 	pi.registerCommand("subagents-doctor", {
-		description: "Show subagent diagnostics",
+		description: t("slash.cmd.doctor", "Show subagent diagnostics"),
 		handler: async (_args, ctx) => {
 			await runSlashSubagent(pi, ctx, { action: "doctor" });
 		},


### PR DESCRIPTION
I found one focused UX issue: the slash-command path has dense delegation/status text exactly where users choose between direct, chain, parallel, background, and forked subagent runs. If those messages are misread, users can launch the wrong orchestration shape or miss the live-detail/status path.

This PR makes that path optionally localizable while preserving the current English strings as fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: ja, zh-CN, es — broad developer workflow locales for delegation/status copy
- Covers slash command descriptions, usage/errors, run status, and result headings

Validation:
- npm pack --dry-run
- npx -y node@22 --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/slash-commands.test.ts

Note: this machine's default Node does not support --experimental-strip-types, so npm test cannot run directly here. With node@22, the full unit suite has existing environment failures unrelated to this change: missing optional @mariozechner/pi-tui for TUI tests and Windows path expectations in pi-args tests.