### PR TITLE
fix: report actual subagent result model

### DIFF
--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -101,6 +101,7 @@ interface StepResult {
 	skipped?: boolean;
 	intercomTarget?: string;
 	model?: string;
+	preferredModel?: string;
 	attemptedModels?: string[];
 	modelAttempts?: ModelAttempt[];
 	artifactPaths?: ArtifactPaths;
@@ -550,6 +551,7 @@ async function runSingleStep(
 	exitCode: number | null;
 	error?: string;
 	model?: string;
+	preferredModel?: string;
 	attemptedModels?: string[];
 	modelAttempts?: ModelAttempt[];
 	artifactPaths?: ArtifactPaths;
@@ -583,10 +585,12 @@ async function runSingleStep(
 	const attemptNotes: string[] = [];
 	const eventsPath = path.join(path.dirname(ctx.outputFile), "events.jsonl");
 	let finalResult: RunPiStreamingResult | undefined;
+	let finalPreferredModel: string | undefined;
 	let completionGuardTriggeredFinal = false;
 
 	for (let index = 0; index < candidates.length; index++) {
 		const candidate = candidates[index];
+		const preferredModel = candidate ?? step.model;
 		const { args, env, tempDir } = buildPiArgs({
 			baseArgs: ["--mode", "json", "-p"],
 			task,
@@ -642,7 +646,7 @@ async function runSingleStep(
 					: `${hiddenError.errorType} failed with exit code ${effectiveExitCode}`
 				: run.error || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined));
 		const attempt: ModelAttempt = {
-			model: candidate ?? run.model ?? step.model ?? "default",
+			model: preferredModel ?? run.model ?? "default",
 			success: effectiveExitCode === 0 && !error,
 			exitCode: effectiveExitCode,
 			error,
@@ -651,7 +655,8 @@ async function runSingleStep(
 		modelAttempts.push(attempt);
 		if (candidate) attemptedModels.push(candidate);
 		completionGuardTriggeredFinal = completionGuardTriggered;
-		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error };
+		finalPreferredModel = preferredModel;
+		finalResult = { ...run, exitCode: effectiveExitCode, model: run.model ?? preferredModel, error };
 		if (attempt.success || completionGuardTriggered) break;
 		if (!isRetryableModelFailure(error) || index === candidates.length - 1) break;
 		attemptNotes.push(formatModelAttemptNote(attempt, candidates[index + 1]));
@@ -689,6 +694,7 @@ async function runSingleStep(
 					task,
 					exitCode: finalResult?.exitCode,
 					model: finalResult?.model,
+					preferredModel: finalPreferredModel,
 					attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
 					modelAttempts,
 					skills: step.skills,
@@ -706,6 +712,7 @@ async function runSingleStep(
 		error: finalResult?.error,
 		intercomTarget: ctx.childIntercomTarget,
 		model: finalResult?.model,
+		preferredModel: finalPreferredModel,
 		attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
 		modelAttempts,
 		artifactPaths,
@@ -1371,6 +1378,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 						skipped: pr.skipped,
 						intercomTarget: pr.intercomTarget,
 						model: pr.model,
+						preferredModel: pr.preferredModel,
 						attemptedModels: pr.attemptedModels,
 						modelAttempts: pr.modelAttempts,
 						artifactPaths: pr.artifactPaths,
@@ -1452,6 +1460,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				success: singleResult.exitCode === 0,
 				intercomTarget: singleResult.intercomTarget,
 				model: singleResult.model,
+				preferredModel: singleResult.preferredModel,
 				attemptedModels: singleResult.attemptedModels,
 				modelAttempts: singleResult.modelAttempts,
 				artifactPaths: singleResult.artifactPaths,
@@ -1637,6 +1646,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				skipped: r.skipped || undefined,
 				intercomTarget: r.intercomTarget,
 				model: r.model,
+				preferredModel: r.preferredModel,
 				attemptedModels: r.attemptedModels,
 				modelAttempts: r.modelAttempts,
 				artifactPaths: r.artifactPaths,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -158,7 +158,7 @@ async function runSingleAttempt(
 		exitCode: 0,
 		messages: [],
 		usage: emptyUsage(),
-		model: modelArg,
+		preferredModel: modelArg,
 		artifactPaths: shared.artifactPaths,
 		skills: shared.resolvedSkillNames,
 		skillsWarning: shared.skillsWarning,
@@ -457,7 +457,7 @@ async function runSingleAttempt(
 						result.usage.cost += u.cost?.total || 0;
 						progress.tokens = result.usage.input + result.usage.output;
 					}
-					if (!result.model && evt.message.model) result.model = evt.message.model;
+					if (evt.message.model) result.model = evt.message.model;
 					if (evt.message.errorMessage) result.error = evt.message.errorMessage;
 					appendRecentOutput(progress, extractTextFromContent(evt.message.content).split("\n").slice(-10));
 					// Final assistant message: start the exit drain window.
@@ -605,6 +605,7 @@ async function runSingleAttempt(
 		}
 	});
 	result.exitCode = exitCode;
+	result.model ??= modelArg;
 	if (interruptedByControl) {
 		result.exitCode = 0;
 		result.interrupted = true;
@@ -839,6 +840,7 @@ export async function runSync(
 				exitCode: result.exitCode,
 				usage: result.usage,
 				model: result.model,
+				preferredModel: result.preferredModel,
 				attemptedModels: result.attemptedModels,
 				modelAttempts: result.modelAttempts,
 				durationMs: result.progressSummary?.durationMs,

--- a/src/shared/formatters.ts
+++ b/src/shared/formatters.ts
@@ -18,7 +18,11 @@ export function formatTokens(n: number): string {
 /**
  * Format usage statistics into a compact string
  */
-export function formatUsage(u: Usage, model?: string): string {
+function stripThinkingSuffix(model: string): string {
+	return model.replace(/:(?:off|minimal|low|medium|high|xhigh)$/, "");
+}
+
+export function formatUsage(u: Usage, model?: string, preferredModel?: string): string {
 	const parts: string[] = [];
 	if (u.turns) parts.push(`${u.turns} turn${u.turns > 1 ? "s" : ""}`);
 	if (u.input) parts.push(`in:${formatTokens(u.input)}`);
@@ -26,7 +30,10 @@ export function formatUsage(u: Usage, model?: string): string {
 	if (u.cacheRead) parts.push(`R${formatTokens(u.cacheRead)}`);
 	if (u.cacheWrite) parts.push(`W${formatTokens(u.cacheWrite)}`);
 	if (u.cost) parts.push(`$${u.cost.toFixed(4)}`);
-	if (model) parts.push(model);
+	if (model) {
+		const differs = preferredModel && stripThinkingSuffix(preferredModel) !== stripThinkingSuffix(model);
+		parts.push(differs ? `${model} (requested ${preferredModel})` : model);
+	}
 	return parts.join(" ");
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -176,6 +176,7 @@ export interface SingleResult {
 	messages?: Message[];
 	usage: Usage;
 	model?: string;
+	preferredModel?: string;
 	attemptedModels?: string[];
 	modelAttempts?: ModelAttempt[];
 	controlEvents?: ControlEvent[];

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -811,7 +811,7 @@ export function renderSubagentResult(
 		if (r.attemptedModels && r.attemptedModels.length > 1) {
 			c.addChild(new Text(fit(theme.fg("dim", `Fallbacks: ${r.attemptedModels.join(" → ")}`)), 0, 0));
 		}
-		c.addChild(new Text(fit(theme.fg("dim", formatUsage(r.usage, r.model))), 0, 0));
+		c.addChild(new Text(fit(theme.fg("dim", formatUsage(r.usage, r.model, r.preferredModel))), 0, 0));
 		if (r.sessionFile) {
 			c.addChild(new Text(fit(theme.fg("dim", `Session: ${shortenPath(r.sessionFile)}`)), 0, 0));
 		}

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -321,7 +321,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			}],
 			exitCode: 1,
 		});
-		mockPi.onCall({ output: "Recovered asynchronously" });
+		mockPi.onCall({ jsonl: [events.assistantMessage("Recovered asynchronously", "anthropic/claude-sonnet-4")] });
 		const id = `async-fallback-${Date.now().toString(36)}`;
 		const sessionRoot = path.join(tempDir, "sessions");
 		const asyncDir = path.join(ASYNC_DIR, id);
@@ -364,6 +364,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
 		assert.equal(payload.success, true);
 		assert.equal(payload.results[0].model, "anthropic/claude-sonnet-4");
+		assert.equal(payload.results[0].preferredModel, "anthropic/claude-sonnet-4");
 		assert.deepEqual(payload.results[0].attemptedModels, ["openai/gpt-5-mini", "anthropic/claude-sonnet-4"]);
 		assert.equal(payload.results[0].modelAttempts.length, 2);
 		const statusPayload = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
@@ -463,7 +464,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	});
 
 	it("background runs prefer the parent session provider for ambiguous bare model ids", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
-		mockPi.onCall({ output: "Done asynchronously" });
+		mockPi.onCall({ jsonl: [events.assistantMessage("Done asynchronously", "github-copilot/gpt-5-mini")] });
 
 		const id = `async-provider-${Date.now().toString(36)}`;
 		const resultPath = path.join(RESULTS_DIR, `${id}.json`);
@@ -507,6 +508,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
 		assert.equal(payload.success, true);
 		assert.equal(payload.results[0].model, "github-copilot/gpt-5-mini");
+		assert.equal(payload.results[0].preferredModel, "github-copilot/gpt-5-mini");
 		assert.deepEqual(payload.results[0].attemptedModels, ["github-copilot/gpt-5-mini"]);
 	});
 

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -58,6 +58,8 @@ type TestChainStep = TestSequentialStep | {
 interface ChainResultItem {
 	agent: string;
 	exitCode: number;
+	model?: string;
+	preferredModel?: string;
 	finalOutput?: string;
 	detached?: boolean;
 	attemptedModels?: string[];
@@ -171,7 +173,7 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 			}],
 			exitCode: 1,
 		});
-		mockPi.onCall({ output: "Step 1 recovered" });
+		mockPi.onCall({ jsonl: [events.assistantMessage("Step 1 recovered", "anthropic/claude-sonnet-4")] });
 		mockPi.onCall({ output: "Step 2 ran" });
 		const agents = [
 			makeAgent("step1", { model: "openai/gpt-5-mini", fallbackModels: ["anthropic/claude-sonnet-4"] }),
@@ -192,7 +194,7 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 	});
 
 	it("prefers the parent session provider for ambiguous bare chain step models", async () => {
-		mockPi.onCall({ output: "Step 1 ran" });
+		mockPi.onCall({ jsonl: [events.assistantMessage("Step 1 ran", "github-copilot/gpt-5-mini")] });
 		mockPi.onCall({ output: "Step 2 ran" });
 		const agents = [makeAgent("step1", { model: "gpt-5-mini" }), makeAgent("step2")];
 
@@ -217,6 +219,7 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 
 		assert.ok(!result.isError, `chain should succeed: ${JSON.stringify(result.content)}`);
 		assert.equal(result.details.results[0].model, "github-copilot/gpt-5-mini");
+		assert.equal(result.details.results[0].preferredModel, "github-copilot/gpt-5-mini");
 		assert.deepEqual(result.details.results[0].attemptedModels, ["github-copilot/gpt-5-mini"]);
 	});
 

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -99,6 +99,27 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(text, /npm test -- --watch --runInBand --reporter=dot/);
 	});
 
+	it("shows actual and requested models when they differ", () => {
+		const widget = renderSubagentResult!({
+			content: [{ type: "text", text: "done" }],
+			details: {
+				mode: "single",
+				results: [{
+					agent: "reviewer",
+					task: "review",
+					exitCode: 0,
+					messages: [],
+					usage: { ...emptyUsage, turns: 1, input: 10, output: 5 },
+					model: "anthropic/claude-sonnet-4-actual",
+					preferredModel: "openai/gpt-4o",
+				}],
+			},
+		}, { expanded: true }, theme);
+
+		const text = widget.render(120).join("\n");
+		assert.match(text, /anthropic\/claude-sonnet-4-actual \(requested openai\/gpt-4o\)/);
+	});
+
 	it("shows the full task in expanded mode", () => {
 		const longTask = "Review the auth flow, trace the race condition, and document the precise failing tool sequence at the end.";
 		const collapsed = withTerminalWidth(40, () => renderSubagentResult!({

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -58,6 +58,7 @@ interface RunSyncResult {
 	model?: string;
 	skills?: string[];
 	skillsWarning?: string;
+	preferredModel?: string;
 	attemptedModels?: string[];
 	modelAttempts?: ModelAttempt[];
 	usage: { turns: number; input: number; output: number };
@@ -329,21 +330,30 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(output, "Got it");
 	});
 
-	it("uses agent model config", async () => {
-		mockPi.onCall({ output: "Done" });
+	it("records the actual CLI-emitted model separately from the preferred model", async () => {
+		mockPi.onCall({ jsonl: [events.assistantMessage("Done", "anthropic/claude-sonnet-4-actual")] });
+		const agents = [makeAgent("echo", { model: "openai/gpt-4o" })];
+
+		const result = await runSync(tempDir, agents, "echo", "Task", {});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.model, "anthropic/claude-sonnet-4-actual");
+		assert.equal(result.preferredModel, "openai/gpt-4o");
+	});
+
+	it("uses agent model config as preferred model", async () => {
+		mockPi.onCall({ jsonl: [events.assistantMessage("Done", "anthropic/claude-sonnet-4")] });
 		const agents = [makeAgent("echo", { model: "anthropic/claude-sonnet-4" })];
 
 		const result = await runSync(tempDir, agents, "echo", "Task", {});
 
 		assert.equal(result.exitCode, 0);
-		// result.model is set from agent config via applyThinkingSuffix, then
-		// overwritten by the first message_end event only if result.model is unset.
-		// Since agent has model config, it stays as the configured value.
 		assert.equal(result.model, "anthropic/claude-sonnet-4");
+		assert.equal(result.preferredModel, "anthropic/claude-sonnet-4");
 	});
 
-	it("model override from options takes precedence", async () => {
-		mockPi.onCall({ output: "Done" });
+	it("model override from options is the preferred model", async () => {
+		mockPi.onCall({ jsonl: [events.assistantMessage("Done", "openai/gpt-4o")] });
 		const agents = [makeAgent("echo", { model: "anthropic/claude-sonnet-4" })];
 
 		const result = await runSync(tempDir, agents, "echo", "Task", {
@@ -352,10 +362,11 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.exitCode, 0);
 		assert.equal(result.model, "openai/gpt-4o");
+		assert.equal(result.preferredModel, "openai/gpt-4o");
 	});
 
 	it("prefers the parent session provider for ambiguous bare model ids", async () => {
-		mockPi.onCall({ output: "Done" });
+		mockPi.onCall({ jsonl: [events.assistantMessage("Done", "github-copilot/gpt-5-mini")] });
 		const agents = [makeAgent("echo", { model: "gpt-5-mini" })];
 
 		const result = await runSync(tempDir, agents, "echo", "Task", {
@@ -396,7 +407,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			}],
 			exitCode: 1,
 		});
-		mockPi.onCall({ output: "Recovered on fallback" });
+		mockPi.onCall({ jsonl: [events.assistantMessage("Recovered on fallback", "anthropic/claude-sonnet-4")] });
 		const agents = [makeAgent("echo", {
 			model: "openai/gpt-5-mini",
 			fallbackModels: ["anthropic/claude-sonnet-4"],

--- a/test/unit/formatters.test.ts
+++ b/test/unit/formatters.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatUsage } from "../../src/shared/formatters.ts";
+
+const usage = {
+	input: 10,
+	output: 5,
+	cacheRead: 0,
+	cacheWrite: 0,
+	cost: 0,
+	turns: 1,
+};
+
+describe("formatUsage", () => {
+	it("does not show a requested-model mismatch for thinking suffix differences", () => {
+		assert.equal(
+			formatUsage(usage, "openai/gpt-5.5", "openai/gpt-5.5:high"),
+			"1 turn in:10 out:5 openai/gpt-5.5",
+		);
+	});
+});


### PR DESCRIPTION
Fixes #72.

`SingleResult.model` now uses the model reported by the child CLI when available, instead of the requested model. The requested model for the final attempt is kept separately as `preferredModel`.

If the child does not report a model, `model` falls back to the requested model to preserve existing behavior.

Expanded rendering now shows mismatches as:

```text
actual-model (requested preferred-model)
```

Thinking suffixes are ignored for that comparison, so `model` and `model:high` do not render as different requested/actual models.

## Tests

```sh
npm test
npm run test:integration
```
