### PR TITLE
fix: check pi-intercom availability via pi.getAllTools() instead of filesystem path

### DIFF
--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -25,6 +25,7 @@ interface DoctorDeps {
 	discoverAgentsAll: typeof discoverAgentsAll;
 	discoverAvailableSkills: typeof discoverAvailableSkills;
 	diagnoseIntercomBridge: typeof diagnoseIntercomBridge;
+	getAllTools: () => { name: string }[];
 }
 
 interface DoctorReportInput {
@@ -54,6 +55,7 @@ const DEFAULT_DEPS: DoctorDeps = {
 	discoverAgentsAll,
 	discoverAvailableSkills,
 	diagnoseIntercomBridge,
+	getAllTools: () => [],
 };
 
 function errorText(error: unknown): string {
@@ -192,6 +194,7 @@ export function buildDoctorReport(input: DoctorReportInput): string {
 			config: input.config.intercomBridge,
 			context: input.context,
 			orchestratorTarget: input.orchestratorTarget,
+			hasIntercom: () => deps.getAllTools().some((t) => t.name === "intercom"),
 		}), input.context).join("\n")).split("\n"),
 	];
 	return lines.join("\n");

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -156,7 +156,7 @@ function formatIntercomDiagnostic(diagnostic: IntercomBridgeDiagnostic, context:
 		`- bridge: ${diagnostic.active ? "active" : "inactive"}${diagnostic.reason ? ` (${diagnostic.reason})` : ""}`,
 		`- mode: ${diagnostic.mode}; context: ${context ?? "unspecified"}`,
 		`- orchestrator target: ${diagnostic.orchestratorTarget ?? "not available"}`,
-		`- pi-intercom: ${diagnostic.piIntercomAvailable ? "available (npm package)" : "unavailable"}`,
+		`- pi-intercom: ${diagnostic.piIntercomAvailable ? "available" : "not loaded"}`,
 	];
 	if (diagnostic.configPath && diagnostic.intercomConfigEnabled !== undefined) {
 		lines.push(`- intercom config: ${diagnostic.intercomConfigEnabled === false ? "disabled" : "enabled or absent"} (${diagnostic.configPath})`);

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -156,7 +156,7 @@ function formatIntercomDiagnostic(diagnostic: IntercomBridgeDiagnostic, context:
 		`- bridge: ${diagnostic.active ? "active" : "inactive"}${diagnostic.reason ? ` (${diagnostic.reason})` : ""}`,
 		`- mode: ${diagnostic.mode}; context: ${context ?? "unspecified"}`,
 		`- orchestrator target: ${diagnostic.orchestratorTarget ?? "not available"}`,
-		`- pi-intercom: ${diagnostic.piIntercomAvailable ? "available" : "unavailable"} at ${diagnostic.extensionDir}`,
+		`- pi-intercom: ${diagnostic.piIntercomAvailable ? "available (npm package)" : "unavailable"}`,
 	];
 	if (diagnostic.configPath && diagnostic.intercomConfigEnabled !== undefined) {
 		lines.push(`- intercom config: ${diagnostic.intercomConfigEnabled === false ? "disabled" : "enabled or absent"} (${diagnostic.configPath})`);

--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -148,13 +148,12 @@ export function diagnoseIntercomBridge(input: ResolveIntercomBridgeInput): Inter
 	const orchestratorTarget = input.orchestratorTarget?.trim();
 	const configPath = path.resolve(input.configPath ?? defaultIntercomConfigPath());
 	const wantsIntercom = mode !== "off" && !(mode === "fork-only" && input.context !== "fork");
-	const piIntercomAvailable = fs.existsSync(extensionDir);
+	const piIntercomAvailable = true; // Always available via npm package; no longer checks hardcoded filesystem path
 	let configStatus: ReturnType<typeof intercomConfigStatus> | undefined;
 	let reason: string | undefined;
 	if (mode === "off") reason = "bridge mode is off";
 	else if (mode === "fork-only" && input.context !== "fork") reason = "bridge mode is fork-only and context is not fork";
 	else if (!orchestratorTarget) reason = "orchestrator target is not available";
-	else if (!piIntercomAvailable) reason = "pi-intercom extension was not found";
 	else {
 		configStatus = intercomConfigStatus(configPath);
 		if (!configStatus.enabled) reason = "intercom config is disabled";
@@ -197,9 +196,6 @@ export function resolveIntercomBridge(input: ResolveIntercomBridgeInput): Interc
 		return { active: false, mode, extensionDir, instruction: defaultInstruction };
 	}
 	if (!orchestratorTarget) {
-		return { active: false, mode, extensionDir, instruction: defaultInstruction };
-	}
-	if (!fs.existsSync(extensionDir)) {
 		return { active: false, mode, extensionDir, instruction: defaultInstruction };
 	}
 

--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -52,6 +52,7 @@ interface ResolveIntercomBridgeInput {
 	config: ExtensionConfig["intercomBridge"];
 	context: "fresh" | "fork" | undefined;
 	orchestratorTarget?: string;
+	hasIntercom?: () => boolean;
 	extensionDir?: string;
 	configPath?: string;
 	settingsDir?: string;
@@ -148,12 +149,13 @@ export function diagnoseIntercomBridge(input: ResolveIntercomBridgeInput): Inter
 	const orchestratorTarget = input.orchestratorTarget?.trim();
 	const configPath = path.resolve(input.configPath ?? defaultIntercomConfigPath());
 	const wantsIntercom = mode !== "off" && !(mode === "fork-only" && input.context !== "fork");
-	const piIntercomAvailable = true; // Always available via npm package; no longer checks hardcoded filesystem path
+	const piIntercomAvailable = input.hasIntercom ? input.hasIntercom() : true; // fallback to true for backwards compat
 	let configStatus: ReturnType<typeof intercomConfigStatus> | undefined;
 	let reason: string | undefined;
 	if (mode === "off") reason = "bridge mode is off";
 	else if (mode === "fork-only" && input.context !== "fork") reason = "bridge mode is fork-only and context is not fork";
 	else if (!orchestratorTarget) reason = "orchestrator target is not available";
+	else if (!piIntercomAvailable) reason = "pi-intercom extension is not loaded";
 	else {
 		configStatus = intercomConfigStatus(configPath);
 		if (!configStatus.enabled) reason = "intercom config is disabled";
@@ -196,6 +198,9 @@ export function resolveIntercomBridge(input: ResolveIntercomBridgeInput): Interc
 		return { active: false, mode, extensionDir, instruction: defaultInstruction };
 	}
 	if (!orchestratorTarget) {
+		return { active: false, mode, extensionDir, instruction: defaultInstruction };
+	}
+	if (input.hasIntercom && !input.hasIntercom()) {
 		return { active: false, mode, extensionDir, instruction: defaultInstruction };
 	}
 

--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -52,7 +52,7 @@ interface ResolveIntercomBridgeInput {
 	config: ExtensionConfig["intercomBridge"];
 	context: "fresh" | "fork" | undefined;
 	orchestratorTarget?: string;
-	hasIntercom?: () => boolean;
+	hasIntercom: () => boolean;
 	extensionDir?: string;
 	configPath?: string;
 	settingsDir?: string;
@@ -149,7 +149,7 @@ export function diagnoseIntercomBridge(input: ResolveIntercomBridgeInput): Inter
 	const orchestratorTarget = input.orchestratorTarget?.trim();
 	const configPath = path.resolve(input.configPath ?? defaultIntercomConfigPath());
 	const wantsIntercom = mode !== "off" && !(mode === "fork-only" && input.context !== "fork");
-	const piIntercomAvailable = input.hasIntercom ? input.hasIntercom() : true; // fallback to true for backwards compat
+	const piIntercomAvailable = input.hasIntercom();
 	let configStatus: ReturnType<typeof intercomConfigStatus> | undefined;
 	let reason: string | undefined;
 	if (mode === "off") reason = "bridge mode is off";
@@ -200,7 +200,7 @@ export function resolveIntercomBridge(input: ResolveIntercomBridgeInput): Interc
 	if (!orchestratorTarget) {
 		return { active: false, mode, extensionDir, instruction: defaultInstruction };
 	}
-	if (input.hasIntercom && !input.hasIntercom()) {
+	if (!input.hasIntercom()) {
 		return { active: false, mode, extensionDir, instruction: defaultInstruction };
 	}
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -344,6 +344,7 @@ async function resumeAsyncRun(input: {
 		config: input.deps.config.intercomBridge,
 		context: input.params.context,
 		orchestratorTarget: sessionName,
+		hasIntercom: () => input.deps.pi.getAllTools().some((t) => t.name === "intercom"),
 	});
 	const agents = intercomBridge.active
 		? discoveredAgents.map((agent) => applyIntercomBridgeToAgent(agent, intercomBridge))
@@ -1957,6 +1958,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			config: deps.config.intercomBridge,
 			context: effectiveParams.context,
 			orchestratorTarget: sessionName,
+			hasIntercom: () => deps.pi.getAllTools().some((t) => t.name === "intercom"),
 		});
 		const agents = intercomBridge.active
 			? discoveredAgents.map((agent) => applyIntercomBridgeToAgent(agent, intercomBridge))


### PR DESCRIPTION
## Problem

The intercom bridge checks `fs.existsSync(~/.pi/agent/extensions/pi-intercom)` to determine if pi-intercom is available. But pi-intercom installed via `pi install npm:pi-intercom` (the standard method) lives in node_modules and never creates that directory. Bridge permanently inactive for all npm package users.

**Repro:**
1. `pi install npm:pi-subagents && pi install npm:pi-intercom`
2. Launch any subagent with intercom in tools
3. `subagent({action:"doctor"})` → `bridge: inactive (pi-intercom extension was not found)`
4. Child targets show `(if registered)` — never appear in session list

**Before:**
```
Intercom bridge
- bridge: inactive (pi-intercom extension was not found)
- pi-intercom: unavailable at ~/.pi/agent/extensions/pi-intercom
```

**After:**
```
Intercom bridge
- bridge: active
- pi-intercom: available
```

## Root cause

`defaultIntercomExtensionDir()` returns a hardcoded filesystem path. Both `resolveIntercomBridge` and `diagnoseIntercomBridge` check `fs.existsSync(extensionDir)`. Only works for file-based extensions, not npm packages.

## Fix

Use the pi SDK's `getAllTools()` to check if the `intercom` tool is registered — the authoritative signal that pi-intercom is loaded. A `hasIntercom` callback is passed from the executor:

```typescript
// Before: hardcoded filesystem path
const piIntercomAvailable = fs.existsSync(extensionDir);

// After: check via pi SDK
hasIntercom: () => deps.pi.getAllTools().some((t) => t.name === "intercom")
```

## Files

- `src/intercom/intercom-bridge.ts` — `hasIntercom` callback replaces `fs.existsSync` check
- `src/runs/foreground/subagent-executor.ts` — passes `hasIntercom` callback at 2 call sites
- `src/extension/doctor.ts` — diagnostic shows `available` vs `not loaded`