### PR TITLE
feat: apply agentOverrides to user agents + fix disableBuiltins priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- `agentOverrides` in settings now applies to user and project agents, not just builtins. This enables per-repo model/thinking overrides without copying full agent `.md` files. Project `.pi/agents/` files still take highest priority.
+
+### Fixed
+- `disableBuiltins: true` now correctly hides builtins even when `agentOverrides` entries exist for them. Previously, any override for a builtin name would implicitly keep it visible. Use `disabled: false` in an override to explicitly opt a specific builtin out of bulk disable.
+
 ## [0.24.0] - 2026-05-03
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -3845,7 +3845,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -425,6 +425,11 @@ function applyBuiltinOverrides(
 	return builtinAgents.map((agent) => {
 		const projectOverride = projectSettings.overrides[agent.name];
 		if (projectOverride && projectSettingsPath) {
+			// If disableBuiltins is true and the override doesn't explicitly keep it enabled,
+			// merge disabled: true into the override so the builtin is still hidden.
+			if (projectBulkDisabled && projectOverride.disabled !== false) {
+				return applyBuiltinOverride(agent, { ...projectOverride, disabled: true }, { scope: "project", path: projectSettingsPath });
+			}
 			return applyBuiltinOverride(agent, projectOverride, { scope: "project", path: projectSettingsPath });
 		}
 
@@ -434,6 +439,9 @@ function applyBuiltinOverrides(
 
 		const userOverride = userSettings.overrides[agent.name];
 		if (userOverride) {
+			if (userBulkDisabled && userOverride.disabled !== false) {
+				return applyBuiltinOverride(agent, { ...userOverride, disabled: true }, { scope: "user", path: userSettingsPath });
+			}
 			return applyBuiltinOverride(agent, userOverride, { scope: "user", path: userSettingsPath });
 		}
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -445,6 +445,36 @@ function applyBuiltinOverrides(
 	});
 }
 
+/**
+ * Apply agentOverrides from settings to user/project agents (not just builtins).
+ * This allows per-repo model/thinking overrides without copying full agent files.
+ * Project overrides take priority over user overrides.
+ * Only non-builtin agents are affected (builtins are handled by applyBuiltinOverrides).
+ * Project-scoped agents (.pi/agents/) are NOT overridden by project settings —
+ * a full project agent file is the most explicit override and always wins.
+ */
+function applyAgentOverrides(
+	agents: AgentConfig[],
+	userSettings: SubagentSettings,
+	projectSettings: SubagentSettings,
+	userSettingsPath: string,
+	projectSettingsPath: string | null,
+): AgentConfig[] {
+	return agents.map((agent) => {
+		if (agent.source === "builtin") return agent; // already handled
+		if (agent.source === "project") return agent; // full project agent file wins over settings
+		const projectOverride = projectSettingsPath ? projectSettings.overrides[agent.name] : undefined;
+		if (projectOverride) {
+			return applyBuiltinOverride(agent, projectOverride, { scope: "project", path: projectSettingsPath! });
+		}
+		const userOverride = userSettings.overrides[agent.name];
+		if (userOverride) {
+			return applyBuiltinOverride(agent, userOverride, { scope: "user", path: userSettingsPath });
+		}
+		return agent;
+	});
+}
+
 export function buildBuiltinOverrideConfig(
 	base: BuiltinAgentOverrideBase,
 	draft: Pick<AgentConfig, "model" | "fallbackModels" | "thinking" | "systemPromptMode" | "inheritProjectContext" | "inheritSkills" | "defaultContext" | "disabled" | "systemPrompt" | "skills" | "tools" | "mcpDirectTools">,
@@ -744,7 +774,8 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const userAgents = [...userAgentsOld, ...userAgentsNew];
 
 	const projectAgents = scope === "user" ? [] : projectAgentDirs.flatMap((dir) => loadAgentsFromDir(dir, "project"));
-	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents)
+	const merged = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents);
+	const agents = applyAgentOverrides(merged, userSettings, projectSettings, userSettingsPath, projectSettingsPath)
 		.filter((agent) => agent.disabled !== true);
 
 	return { agents, projectAgentsDir };
@@ -779,17 +810,18 @@ export function discoverAgentsAll(cwd: string): {
 		userSettingsPath,
 		projectSettingsPath,
 	);
-	const user = [
+	const userRaw = [
 		...loadAgentsFromDir(userDirOld, "user"),
 		...loadAgentsFromDir(userDirNew, "user"),
 	];
+	const user = applyAgentOverrides(userRaw, userSettings, projectSettings, userSettingsPath, projectSettingsPath);
 	const projectMap = new Map<string, AgentConfig>();
 	for (const dir of projectDirs) {
 		for (const agent of loadAgentsFromDir(dir, "project")) {
 			projectMap.set(agent.name, agent);
 		}
 	}
-	const project = Array.from(projectMap.values());
+	const project = Array.from(projectMap.values()); // project agents are not overridden by settings
 
 	const chainMap = new Map<string, ChainConfig>();
 	for (const dir of projectChainDirs) {

--- a/test/unit/agent-disabled.test.ts
+++ b/test/unit/agent-disabled.test.ts
@@ -92,19 +92,19 @@ describe("builtin agent disabling", () => {
 		assert.ok(allBuiltins.every((agent) => agent.override?.scope === "user"));
 	});
 
-	it("an explicit user override opts a builtin out of user-scope bulk disable", () => {
+	it("an explicit user override with disabled:false opts a builtin out of user-scope bulk disable", () => {
 		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
 			subagents: {
 				disableBuiltins: true,
 				agentOverrides: {
-					reviewer: { model: "openai/gpt-5.4" },
+					reviewer: { model: "openai/gpt-5.4", disabled: false },
 				},
 			},
 		});
 
 		const reviewer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "reviewer");
 		assert.ok(reviewer);
-		assert.equal(reviewer.disabled, undefined);
+		assert.equal(reviewer.disabled, false);
 		assert.equal(reviewer.model, "openai/gpt-5.4");
 		assert.equal(reviewer.override?.scope, "user");
 	});

--- a/test/unit/agent-overrides.test.ts
+++ b/test/unit/agent-overrides.test.ts
@@ -243,3 +243,88 @@ describe("builtin agent overrides", () => {
 		});
 	});
 });
+
+function writeUserAgent(home: string, name: string, body: string): void {
+	const filePath = path.join(home, ".pi", "agent", "agents", `${name}.md`);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, body, "utf-8");
+}
+
+describe("user agent overrides", () => {
+	beforeEach(() => {
+		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-home-"));
+		tempProject = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-project-"));
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+	});
+
+	afterEach(() => {
+		process.env.HOME = originalHome;
+		process.env.USERPROFILE = originalUserProfile;
+		fs.rmSync(tempHome, { recursive: true, force: true });
+		fs.rmSync(tempProject, { recursive: true, force: true });
+	});
+
+	it("applies project settings overrides to user agents", () => {
+		writeUserAgent(tempHome, "worker", `---\nname: worker\ndescription: My worker\nmodel: openai/gpt-5\nthinking: medium\n---\n\nYou are a worker.\n`);
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { agentOverrides: { worker: { model: "anthropic/claude-sonnet-4", thinking: "high" } } },
+		});
+
+		const worker = discoverAgents(tempProject, "both").agents.find((a) => a.name === "worker");
+		assert.ok(worker);
+		assert.equal(worker.source, "user");
+		assert.equal(worker.model, "anthropic/claude-sonnet-4");
+		assert.equal(worker.thinking, "high");
+		assert.equal(worker.systemPrompt, "You are a worker.");
+	});
+
+	it("applies user settings overrides to user agents when no project override exists", () => {
+		writeUserAgent(tempHome, "worker", `---\nname: worker\ndescription: My worker\nmodel: openai/gpt-5\n---\n\nYou are a worker.\n`);
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { worker: { model: "fireworks/deepseek-v4" } } },
+		});
+
+		const worker = discoverAgents(tempProject, "both").agents.find((a) => a.name === "worker");
+		assert.ok(worker);
+		assert.equal(worker.model, "fireworks/deepseek-v4");
+	});
+
+	it("project settings override beats user settings override for user agents", () => {
+		writeUserAgent(tempHome, "worker", `---\nname: worker\ndescription: My worker\nmodel: openai/gpt-5\n---\n\nYou are a worker.\n`);
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { worker: { model: "fireworks/deepseek-v4" } } },
+		});
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { agentOverrides: { worker: { model: "anthropic/claude-sonnet-4" } } },
+		});
+
+		const worker = discoverAgents(tempProject, "both").agents.find((a) => a.name === "worker");
+		assert.ok(worker);
+		assert.equal(worker.model, "anthropic/claude-sonnet-4");
+	});
+
+	it("does not apply settings overrides to project agents (full file wins)", () => {
+		writeProjectAgent(tempProject, "worker", `---\nname: worker\ndescription: Project worker\nmodel: google/gemini-3-pro\n---\n\nProject worker.\n`);
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { agentOverrides: { worker: { model: "anthropic/claude-sonnet-4" } } },
+		});
+
+		const worker = discoverAgents(tempProject, "both").agents.find((a) => a.name === "worker");
+		assert.ok(worker);
+		assert.equal(worker.source, "project");
+		assert.equal(worker.model, "google/gemini-3-pro");
+	});
+
+	it("user agents overridden in discoverAgentsAll too", () => {
+		writeUserAgent(tempHome, "worker", `---\nname: worker\ndescription: My worker\nmodel: openai/gpt-5\n---\n\nYou are a worker.\n`);
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { agentOverrides: { worker: { model: "anthropic/claude-sonnet-4" } } },
+		});
+
+		const d = discoverAgentsAll(tempProject);
+		const worker = d.user.find((a) => a.name === "worker");
+		assert.ok(worker);
+		assert.equal(worker.model, "anthropic/claude-sonnet-4");
+	});
+});

--- a/test/unit/agent-overrides.test.ts
+++ b/test/unit/agent-overrides.test.ts
@@ -155,6 +155,33 @@ describe("builtin agent overrides", () => {
 		assert.equal(fs.existsSync(settingsPath), false);
 	});
 
+	it("disableBuiltins hides builtins even when agentOverrides exist for them", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: {
+				disableBuiltins: true,
+				agentOverrides: { reviewer: { model: "openai/gpt-5.4", thinking: "high" } },
+			},
+		});
+
+		const reviewer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "reviewer" && agent.source === "builtin");
+		assert.equal(reviewer, undefined, "builtin reviewer should be hidden when disableBuiltins is true");
+	});
+
+	it("disableBuiltins can be overridden per-agent with disabled: false", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: {
+				disableBuiltins: true,
+				agentOverrides: { reviewer: { model: "openai/gpt-5.4", disabled: false } },
+			},
+		});
+
+		const reviewer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "reviewer" && agent.source === "builtin");
+		assert.ok(reviewer, "builtin reviewer should be kept when disabled: false is explicit");
+		assert.equal(reviewer.model, "openai/gpt-5.4");
+	});
+
 	it("surfaces malformed settings files instead of silently ignoring them", () => {
 		const settingsPath = path.join(tempHome, ".pi", "agent", "settings.json");
 		fs.mkdirSync(path.dirname(settingsPath), { recursive: true });


### PR DESCRIPTION
## Summary

Two related changes that improve the `agentOverrides` settings mechanism:

### 1. `agentOverrides` now applies to user/project agents (not just builtins)

Previously, `agentOverrides` in settings only modified builtin agents. User agents (from `~/.pi/agent/agents/`) were loaded as-is with no way to override their model/thinking per-repo without copying the full `.md` file.

Now `agentOverrides` applies to user agents too, enabling per-repo model configuration:

```json
// .pi/settings.json (project)
{
  "subagents": {
    "agentOverrides": {
      "worker": { "model": "anthropic/claude-sonnet-4", "thinking": "high" }
    }
  }
}
```

**Priority order:**
1. Project `.pi/agents/worker.md` (full file, always wins)
2. Project `.pi/settings.json` `agentOverrides.worker`
3. User `~/.pi/agent/settings.json` `agentOverrides.worker`
4. User `~/.pi/agent/agents/worker.md` `model:` field (base definition)

### 2. `disableBuiltins` now takes priority over `agentOverrides` for builtins

Previously, if `disableBuiltins: true` was set but `agentOverrides` had an entry for a builtin (e.g., `worker: { model: "..." }`), the override would apply and the builtin remained visible — defeating the purpose of `disableBuiltins`.

Now: when `disableBuiltins: true` is set, builtins are disabled even if they have `agentOverrides` entries. Use `disabled: false` in an override to explicitly opt a specific builtin out of bulk disable.

## Use case

Users who define their own agents with the same names as builtins (`worker`, `planner`, etc.) want:
- `disableBuiltins: true` to hide builtins from listings
- `agentOverrides` to set per-repo models on their *user* agents
- Agent prompts/skills to stay centralized (no full file copies per repo)

Without this change, `agentOverrides` only touches builtins, and having overrides with builtin names keeps those builtins visible even with `disableBuiltins: true`.

## Tests

- 7 new tests covering user agent overrides and disableBuiltins + agentOverrides interaction
- All 377 existing tests pass (clean environment)
- Updated 1 existing test to match new behavior (explicit `disabled: false` required to opt out of bulk disable)