### PR TITLE
fix: disable single-run output when override is false

### DIFF
--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -35,7 +35,7 @@ import { createForkContextResolver } from "../../shared/fork-context.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBridge, resolveIntercomSessionTarget, resolveSubagentIntercomTarget, type IntercomBridgeState } from "../../intercom/intercom-bridge.ts";
 import { formatControlIntercomMessage, formatControlNoticeMessage, resolveControlConfig, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
-import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
+import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeOutputSetting, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, readStatus, resolveChildCwd } from "../../shared/utils.ts";
 import {
 	buildSubagentResultIntercomPayload,
@@ -970,25 +970,26 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 	}
 
 	if (hasSingle) {
-		const a = agents.find((x) => x.name === params.agent);
-		if (!a) {
+		const agentConfig = agents.find((candidate) => candidate.name === params.agent);
+		if (!agentConfig) {
 			return {
 				content: [{ type: "text", text: `Unknown agent: ${params.agent}` }],
 				isError: true,
 				details: { mode: "single" as const, results: [] },
 			};
 		}
-		const rawOutput = params.output !== undefined ? params.output : a.output;
-		const effectiveOutput: string | false | undefined = rawOutput === true ? a.output : (rawOutput as string | false | undefined);
+		const rawOutput = params.output !== undefined ? params.output : agentConfig.output;
+		const effectiveOutput: string | false | undefined = rawOutput === true ? agentConfig.output : normalizeOutputSetting(rawOutput as string | false | undefined);
 		const effectiveOutputMode = params.outputMode ?? "inline";
 		const normalizedSkills = normalizeSkillInput(params.skill);
 		const skills = normalizedSkills === false ? [] : normalizedSkills;
-		const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, a.maxSubagentDepth);
-		const modelOverride = resolveModelCandidate((params.model as string | undefined) ?? a.model, availableModels, currentProvider);
+		const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, agentConfig.maxSubagentDepth);
+		const modelOverride = resolveModelCandidate((params.model as string | undefined) ?? agentConfig.model, availableModels, currentProvider);
+		const task = params.task ?? "";
 		return executeAsyncSingle(id, {
 			agent: params.agent!,
-			task: params.context === "fork" ? wrapForkTask(params.task ?? "") : (params.task ?? ""),
-			agentConfig: a,
+			task: params.context === "fork" ? wrapForkTask(task) : task,
+			agentConfig,
 			ctx: asyncCtx,
 			availableModels,
 			cwd: effectiveCwd,
@@ -1716,7 +1717,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	);
 	let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
 	const rawOutput = params.output !== undefined ? params.output : agentConfig.output;
-	let effectiveOutput: string | false | undefined = rawOutput === true ? agentConfig.output : (rawOutput as string | false | undefined);
+	let effectiveOutput: string | false | undefined = rawOutput === true ? agentConfig.output : normalizeOutputSetting(rawOutput as string | false | undefined);
 	const effectiveOutputMode = params.outputMode ?? "inline";
 	const currentMaxSubagentDepth = resolveCurrentMaxSubagentDepth(deps.config.maxSubagentDepth);
 	const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, agentConfig.maxSubagentDepth);
@@ -1750,7 +1751,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		task = result.templates[0]!;
 		const override = result.behaviorOverrides[0];
 		if (override?.model) modelOverride = override.model;
-		if (override?.output !== undefined) effectiveOutput = override.output;
+		if (override?.output !== undefined) effectiveOutput = normalizeOutputSetting(override.output);
 		if (override?.skills !== undefined) skillOverride = override.skills;
 
 		if (result.runInBackground) {

--- a/src/runs/shared/single-output.ts
+++ b/src/runs/shared/single-output.ts
@@ -8,17 +8,24 @@ export interface SingleOutputSnapshot {
 	size?: number;
 }
 
+export function normalizeOutputSetting(output: string | false | undefined): string | false | undefined {
+	return output === "false" ? false : output;
+}
+
+function resolveOutputBaseCwd(runtimeCwd: string, requestedCwd?: string): string {
+	if (!requestedCwd) return runtimeCwd;
+	return path.isAbsolute(requestedCwd) ? requestedCwd : path.resolve(runtimeCwd, requestedCwd);
+}
+
 export function resolveSingleOutputPath(
 	output: string | false | undefined,
 	runtimeCwd: string,
 	requestedCwd?: string,
 ): string | undefined {
-	if (typeof output !== "string" || !output) return undefined;
-	if (path.isAbsolute(output)) return output;
-	const baseCwd = requestedCwd
-		? (path.isAbsolute(requestedCwd) ? requestedCwd : path.resolve(runtimeCwd, requestedCwd))
-		: runtimeCwd;
-	return path.resolve(baseCwd, output);
+	const normalizedOutput = normalizeOutputSetting(output);
+	if (typeof normalizedOutput !== "string" || !normalizedOutput) return undefined;
+	if (path.isAbsolute(normalizedOutput)) return normalizedOutput;
+	return path.resolve(resolveOutputBaseCwd(runtimeCwd, requestedCwd), normalizedOutput);
 }
 
 export function injectSingleOutputInstruction(task: string, outputPath: string | undefined): string {
@@ -74,6 +81,10 @@ export function captureSingleOutputSnapshot(outputPath: string | undefined): Sin
 	}
 }
 
+function formatIoError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
 function persistSingleOutput(
 	outputPath: string | undefined,
 	fullOutput: string,
@@ -83,8 +94,21 @@ function persistSingleOutput(
 		fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 		fs.writeFileSync(outputPath, fullOutput, "utf-8");
 		return { savedPath: outputPath };
-	} catch (err) {
-		return { error: err instanceof Error ? err.message : String(err) };
+	} catch (error) {
+		return { error: formatIoError(error) };
+	}
+}
+
+function hasOutputFileChanged(outputPath: string, beforeRun: SingleOutputSnapshot | undefined): boolean | string {
+	try {
+		const stat = fs.statSync(outputPath);
+		return !beforeRun?.exists
+			|| stat.mtimeMs !== beforeRun.mtimeMs
+			|| stat.size !== beforeRun.size;
+	} catch (error) {
+		const code = error && typeof error === "object" && "code" in error ? (error as { code?: unknown }).code : undefined;
+		if (code === "ENOENT" || code === "ENOTDIR") return false;
+		return `Failed to inspect output file: ${formatIoError(error)}`;
 	}
 }
 
@@ -95,29 +119,21 @@ export function resolveSingleOutput(
 ): { fullOutput: string; savedPath?: string; saveError?: string } {
 	if (!outputPath) return { fullOutput: fallbackOutput };
 
-	let changedSinceStart = false;
-	try {
-		const stat = fs.statSync(outputPath);
-		changedSinceStart = !beforeRun?.exists
-			|| stat.mtimeMs !== beforeRun.mtimeMs
-			|| stat.size !== beforeRun.size;
-	} catch (error) {
-		const code = error && typeof error === "object" && "code" in error ? (error as { code?: unknown }).code : undefined;
-		if (code !== "ENOENT" && code !== "ENOTDIR") {
-			return {
-				fullOutput: fallbackOutput,
-				saveError: `Failed to inspect output file: ${error instanceof Error ? error.message : String(error)}`,
-			};
-		}
+	const outputFileChange = hasOutputFileChanged(outputPath, beforeRun);
+	if (typeof outputFileChange === "string") {
+		return {
+			fullOutput: fallbackOutput,
+			saveError: outputFileChange,
+		};
 	}
 
-	if (changedSinceStart) {
+	if (outputFileChange) {
 		try {
 			return { fullOutput: fs.readFileSync(outputPath, "utf-8"), savedPath: outputPath };
 		} catch (error) {
 			return {
 				fullOutput: fallbackOutput,
-				saveError: `Failed to read changed output file: ${error instanceof Error ? error.message : String(error)}`,
+				saveError: `Failed to read changed output file: ${formatIoError(error)}`,
 			};
 		}
 	}
@@ -138,7 +154,9 @@ export function finalizeSingleOutput(params: {
 	saveError?: string;
 }): { displayOutput: string; savedPath?: string; outputReference?: SavedOutputReference; saveError?: string } {
 	let displayOutput = params.truncatedOutput || params.fullOutput;
-	if (params.exitCode === 0 && params.savedPath) {
+	if (params.exitCode !== 0) return { displayOutput };
+
+	if (params.savedPath) {
 		const outputReference = params.outputReference ?? formatSavedOutputReference(params.savedPath, params.fullOutput);
 		if (params.outputMode === "file-only") {
 			return { displayOutput: outputReference.message, savedPath: params.savedPath, outputReference };
@@ -146,9 +164,11 @@ export function finalizeSingleOutput(params: {
 		displayOutput += `\n\n${outputReference.message}`;
 		return { displayOutput, savedPath: params.savedPath, outputReference };
 	}
-	if (params.exitCode === 0 && params.saveError && params.outputPath) {
+
+	if (params.saveError && params.outputPath) {
 		displayOutput += `\n\nOutput file error: ${params.outputPath}\n${params.saveError}`;
 		return { displayOutput, saveError: params.saveError };
 	}
+
 	return { displayOutput };
 }

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -575,6 +575,40 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(fs.readFileSync(outputPath, "utf-8"), "async full output\nwith details");
 	});
 
+	it("background single runs treat string false output override as disabled", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "async no file" });
+		const id = `async-output-false-${Date.now().toString(36)}`;
+		const falsePath = path.join(tempDir, "false");
+
+		executeAsyncSingle(id, {
+			agent: "reviewer",
+			task: "Review only",
+			agentConfig: makeAgent("reviewer", { output: "pi-agent-review.md" }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			output: "false",
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		const defaultOutputPath = path.join(tempDir, "pi-agent-review.md");
+		assert.equal(payload.success, true);
+		assert.equal(fs.existsSync(falsePath), false);
+		assert.equal(fs.existsSync(defaultOutputPath), false);
+		assert.doesNotMatch(payload.summary ?? "", /Output saved to:/);
+		assert.doesNotMatch(payload.results[0]?.output ?? "", /Output saved to:/);
+	});
+
 	it("background runs detect hidden tool failures even when the child exits 0", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			jsonl: [events.toolResult("bash", "connection refused")],

--- a/test/unit/single-output.test.ts
+++ b/test/unit/single-output.test.ts
@@ -15,6 +15,12 @@ import {
 
 const tempDirs: string[] = [];
 
+function createTempOutputDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-output-test-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
 afterEach(() => {
 	while (tempDirs.length > 0) {
 		const dir = tempDirs.pop();
@@ -44,6 +50,10 @@ describe("resolveSingleOutputPath", () => {
 		const resolved = resolveSingleOutputPath("reviews/report.md", "/runtime", "nested/work");
 		assert.equal(resolved, path.resolve("/runtime", "nested/work", "reviews/report.md"));
 	});
+
+	it("treats string false as disabled output", () => {
+		assert.equal(resolveSingleOutputPath("false", "/runtime", "/requested"), undefined);
+	});
 });
 
 describe("injectSingleOutputInstruction", () => {
@@ -55,8 +65,7 @@ describe("injectSingleOutputInstruction", () => {
 
 describe("resolveSingleOutput", () => {
 	it("keeps agent-written file content when the file changed during the run", () => {
-		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-output-test-"));
-		tempDirs.push(dir);
+		const dir = createTempOutputDir();
 		const outputPath = path.join(dir, "review.md");
 		const before = captureSingleOutputSnapshot(outputPath);
 
@@ -69,8 +78,7 @@ describe("resolveSingleOutput", () => {
 	});
 
 	it("falls back to persisting the assistant output when the file was not changed", () => {
-		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-output-test-"));
-		tempDirs.push(dir);
+		const dir = createTempOutputDir();
 		const outputPath = path.join(dir, "review.md");
 
 		fs.writeFileSync(outputPath, "stale content", "utf-8");
@@ -83,8 +91,7 @@ describe("resolveSingleOutput", () => {
 	});
 
 	it("preserves read errors from changed output paths", () => {
-		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-output-test-"));
-		tempDirs.push(dir);
+		const dir = createTempOutputDir();
 		const outputPath = path.join(dir, "review.md");
 		const before = captureSingleOutputSnapshot(outputPath);
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where `output: false` could be mishandled in single-agent execution and end up behaving like a literal output path instead of disabling file output.

In the broken path, a single run could inject an instruction such as `Write your findings to: /repo/false`, which in turn could create an unwanted file literally named `false`.

Fixes #145.

## What changed

- normalize single-run output settings so stringified `"false"` is treated the same as disabled output;
- apply the normalized value when resolving output paths for foreground single-agent runs;
- keep override precedence intact when a caller explicitly disables an agent's default output file;
- refactor single-output helpers slightly to centralize normalization and IO error formatting;
- add regression coverage for unit and async single-run paths.

## Why this matters

The tool contract already documents `output: false` as the way to disable output. Parallel and template-related paths were already defensive here, but single-run behavior could still leak a string `"false"` through parsing layers.

This change makes single-agent behavior consistent with the documented contract and prevents accidental repository artifacts.

## Testing

- added unit coverage for `resolveSingleOutputPath("false", ...)`;
- added async integration coverage to confirm single-agent background runs do not write `false` or the agent default output when output is disabled.
