### PR TITLE
Fix slash result finalization and add subagents admin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- Added `/subagents` as the primary administration command for the Subagents Manager. The existing `/agents` command remains as an alias.
+- Agent detail screens now expose metadata fields and a direct `m` shortcut that opens the model picker and saves the selected model for user/project agents.
+
 ## [0.11.12] - 2026-03-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added `/subagents` as the primary administration command for the Subagents Manager. The existing `/agents` command remains as an alias.
 - Agent detail screens now expose metadata fields and a direct `m` shortcut that opens the model picker and saves the selected model for user/project agents.
 
+### Fixed
+- Subagent model selection now uses `--model` instead of `--models`, so configured agent models are honored even when a forked child session restores the parent conversation's model.
+
 ## [0.11.12] - 2026-03-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ Subagents only get direct MCP tools when `mcp:` items are explicitly listed. Eve
 | `/run <agent> <task>` | Run a single agent with a task |
 | `/chain agent1 "task1" -> agent2 "task2"` | Run agents in sequence with per-step tasks |
 | `/parallel agent1 "task1" -> agent2 "task2"` | Run agents in parallel with per-step tasks |
-| `/agents` | Open the Agents Manager overlay |
+| `/agents` | Open the Subagents Manager overlay |
+| `/subagents` | Open the Subagents Manager overlay for metadata/model administration |
 
 All commands validate agent names locally and tab-complete them, then route through the tool framework for full live progress rendering. Results are sent to the conversation for the LLM to discuss.
 
@@ -211,14 +212,14 @@ You can combine `--fork` and `--bg` in any order:
 
 ## Agents Manager
 
-Press **Ctrl+Shift+A** or type `/agents` to open the Agents Manager overlay — a TUI for browsing, viewing, editing, creating, and launching agents and chains.
+Press **Ctrl+Shift+A** or type `/subagents` (alias: `/agents`) to open the Subagents Manager overlay — a TUI for browsing, viewing metadata, editing, creating, and launching agents and chains.
 
 **Screens:**
 
 | Screen | Description |
 |--------|-------------|
 | List | Browse all agents and chains with search/filter, scope badges, chain badges |
-| Detail | View resolved prompt, frontmatter fields, recent run history |
+| Detail | View metadata, resolved prompt, frontmatter fields, recent run history; press `m` to update the model directly |
 | Edit | Edit fields with specialized pickers (model, thinking, skills, prompt editor) |
 | Chain Detail | View chain steps with flow visualization and dependency map |
 | Parallel Builder | Build parallel execution slots, add same agent multiple times, per-slot task overrides |
@@ -236,6 +237,13 @@ Press **Ctrl+Shift+A** or type `/agents` to open the Agents Manager overlay — 
 - `Ctrl+R` — run selected (1 agent: launch, 2+: sequential chain)
 - `Ctrl+P` — open parallel builder (from selection or cursor agent)
 - `Esc` — clear query, then selection, then close overlay
+
+**Detail screen keybindings:**
+- `m` — open the model picker and save the selected model to the subagent
+- `e` — edit all metadata/frontmatter fields (user/project agents only)
+- `v` — toggle raw/resolved prompt view
+- `l` — launch the selected subagent
+- `Esc` — back to list
 
 **Parallel builder keybindings:**
 - `↑↓` — navigate slots

--- a/agent-manager-detail.ts
+++ b/agent-manager-detail.ts
@@ -17,6 +17,7 @@ export interface DetailState {
 export type DetailAction =
 	| { type: "back" }
 	| { type: "edit" }
+	| { type: "model" }
 	| { type: "launch" };
 
 const DETAIL_VIEWPORT_HEIGHT = 12;
@@ -59,6 +60,10 @@ function buildDetailLines(
 	const reads = agent.defaultReads && agent.defaultReads.length > 0 ? agent.defaultReads.join(", ") : "(none)";
 	const progress = agent.defaultProgress ? "on" : "off";
 
+	lines.push(renderFieldLine("Name:", agent.name, contentWidth, theme));
+	lines.push(renderFieldLine("Desc:", agent.description || "(none)", contentWidth, theme));
+	lines.push(renderFieldLine("Source:", agent.source, contentWidth, theme));
+	lines.push(renderFieldLine("File:", formatPath(agent.filePath), contentWidth, theme));
 	lines.push(renderFieldLine("Model:", agent.model ?? "default", contentWidth, theme));
 	lines.push(renderFieldLine("Thinking:", agent.thinking ?? "off", contentWidth, theme));
 	lines.push(renderFieldLine("Tools:", tools, contentWidth, theme));
@@ -112,6 +117,7 @@ function buildDetailLines(
 export function handleDetailInput(state: DetailState, data: string): DetailAction | undefined {
 	if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c")) return { type: "back" };
 	if (data === "e") return { type: "edit" };
+	if (data === "m") return { type: "model" };
 	if (data === "l") return { type: "launch" };
 	if (data === "v") { state.resolved = !state.resolved; state.scrollOffset = 0; return; }
 	if (matchesKey(data, "up")) { state.scrollOffset--; return; }
@@ -151,7 +157,7 @@ export function renderDetail(
 
 	const footer = agent.source === "builtin"
 		? " [l]aunch  [v] raw/resolved  [↑↓] scroll  [esc] back "
-		: " [l]aunch  [e]dit  [v] raw/resolved  [↑↓] scroll  [esc] back ";
+		: " [l]aunch  [m] model  [e]dit  [v] raw/resolved  [↑↓] scroll  [esc] back ";
 	lines.push(renderFooter(footer, width, theme));
 	return lines;
 }

--- a/agent-manager-edit.ts
+++ b/agent-manager-edit.ts
@@ -68,7 +68,7 @@ function applyFieldValue(field: EditField, state: EditState, value: string): voi
 	}
 }
 
-function openModelPicker(state: EditState, models: ModelInfo[]): void {
+export function openModelPicker(state: EditState, models: ModelInfo[]): void {
 	state.fieldIndex = FIELD_ORDER.indexOf("model"); state.fieldMode = "model"; state.modelSearchQuery = ""; state.filteredModels = [...models];
 	const idx = state.filteredModels.findIndex((m) => m.fullId === state.draft.model || m.id === state.draft.model); state.modelCursor = idx >= 0 ? idx : 0;
 }

--- a/agent-manager.ts
+++ b/agent-manager.ts
@@ -11,7 +11,7 @@ import { renderList, handleListInput, type ListAgent, type ListState, type ListA
 import { createParallelState, handleParallelInput, renderParallel, formatParallelTitle, type ParallelState, type AgentOption } from "./agent-manager-parallel.js";
 import { renderDetail, handleDetailInput, renderTaskInput, type DetailState, type DetailAction } from "./agent-manager-detail.js";
 import { renderChainDetail, handleChainDetailInput, type ChainDetailAction, type ChainDetailState } from "./agent-manager-chain-detail.js";
-import { createEditState, handleEditInput, renderEdit, type EditScreen, type EditState, type ModelInfo, type SkillInfo } from "./agent-manager-edit.js";
+import { createEditState, handleEditInput, openModelPicker, renderEdit, type EditScreen, type EditState, type ModelInfo, type SkillInfo } from "./agent-manager-edit.js";
 import { createEditorState, ensureCursorVisible, getCursorDisplayPos, handleEditorInput, renderEditor, wrapText } from "./text-editor.js";
 import type { TextEditorState } from "./text-editor.js";
 import { loadRunsForAgent } from "./run-history.js";
@@ -57,6 +57,8 @@ export class AgentManagerComponent implements Component {
 	private chainLaunchId: string | null = null;
 	private parallelMode = false;
 	private parallelState: ParallelState | null = null;
+	private quickModelEdit = false;
+	private quickModelOriginalModel: string | undefined;
 	private taskBackScreen: ManagerScreen = "list";
 	private templateCursor = 0;
 	private statusMessage?: StatusMessage;
@@ -80,7 +82,8 @@ export class AgentManagerComponent implements Component {
 
 	private enterDetail(entry: AgentEntry): void { this.currentAgentId = entry.id; this.detailState = { resolved: true, scrollOffset: 0, recentRuns: loadRunsForAgent(entry.config.name).slice(0, 5) }; this.screen = "detail"; }
 	private enterChainDetail(entry: ChainEntry): void { this.currentChainId = entry.id; this.chainDetailState = { scrollOffset: 0 }; this.screen = "chain-detail"; }
-	private enterEdit(entry: AgentEntry): void { this.currentAgentId = entry.id; this.editState = createEditState(entry.config, entry.isNew, this.models, this.skills); this.screen = "edit"; }
+	private enterEdit(entry: AgentEntry): void { this.quickModelEdit = false; this.quickModelOriginalModel = undefined; this.currentAgentId = entry.id; this.editState = createEditState(entry.config, entry.isNew, this.models, this.skills); this.screen = "edit"; }
+	private enterModelPicker(entry: AgentEntry): void { this.currentAgentId = entry.id; this.editState = createEditState(entry.config, entry.isNew, this.models, this.skills); this.quickModelEdit = true; this.quickModelOriginalModel = entry.config.model; openModelPicker(this.editState, this.models); this.screen = "edit-field"; }
 	private enterParallelBuilder(ids: string[]): void {
 		const names = ids.map((id) => this.getAgentEntry(id)?.config.name).filter((n): n is string => Boolean(n));
 		if (names.length === 0) return;
@@ -321,18 +324,42 @@ export class AgentManagerComponent implements Component {
 			}
 			case "edit": case "edit-field": case "edit-prompt": {
 				if (!this.editState) { this.screen = "list"; this.tui.requestRender(); return; }
+				const previousScreen = this.screen;
 				const result = handleEditInput(this.screen as EditScreen, this.editState, data, this.overlayWidth, this.models, this.skills);
 				if (result?.action === "discard") { this.handleEditDiscard(); return; }
 				if (result?.action === "save") { const ok = this.saveEdit(); if (ok) { const entry = this.getAgentEntry(this.currentAgentId); if (entry) this.enterDetail(entry); } this.tui.requestRender(); return; }
+				if (this.quickModelEdit && previousScreen === "edit-field" && result?.nextScreen === "edit") {
+					const changed = this.editState.draft.model !== this.quickModelOriginalModel;
+					if (changed) {
+						const ok = this.saveEdit();
+						if (ok) {
+							const entry = this.getAgentEntry(this.currentAgentId);
+							this.quickModelEdit = false;
+							this.quickModelOriginalModel = undefined;
+							if (entry) this.enterDetail(entry);
+						} else {
+							this.quickModelEdit = false;
+							this.quickModelOriginalModel = undefined;
+							this.screen = "edit";
+						}
+					} else {
+						const entry = this.getAgentEntry(this.currentAgentId);
+						this.quickModelEdit = false;
+						this.quickModelOriginalModel = undefined;
+						if (entry) this.enterDetail(entry); else this.screen = "list";
+					}
+					this.tui.requestRender();
+					return;
+				}
 				if (result?.nextScreen) this.screen = result.nextScreen; this.tui.requestRender(); return;
 			}
 		}
 	}
 
 	private handleEditDiscard(): void {
-		const entry = this.getAgentEntry(this.currentAgentId); if (!entry) { this.screen = "list"; this.editState = null; this.tui.requestRender(); return; }
-		if (entry.isNew) { this.removeAgentEntry(entry); this.editState = null; this.screen = "list"; this.tui.requestRender(); return; }
-		this.editState = null; this.enterDetail(entry); this.tui.requestRender();
+		const entry = this.getAgentEntry(this.currentAgentId); if (!entry) { this.screen = "list"; this.editState = null; this.quickModelEdit = false; this.quickModelOriginalModel = undefined; this.tui.requestRender(); return; }
+		if (entry.isNew) { this.removeAgentEntry(entry); this.editState = null; this.quickModelEdit = false; this.quickModelOriginalModel = undefined; this.screen = "list"; this.tui.requestRender(); return; }
+		this.editState = null; this.quickModelEdit = false; this.quickModelOriginalModel = undefined; this.enterDetail(entry); this.tui.requestRender();
 	}
 
 	private isBuiltin(id: string): boolean { const a = this.getAgentEntry(id); return a?.config.source === "builtin"; }
@@ -352,6 +379,7 @@ export class AgentManagerComponent implements Component {
 	private handleDetailAction(action: DetailAction, entry: AgentEntry): void {
 		if (action.type === "back") { this.screen = "list"; return; }
 		if (action.type === "edit") { if (entry.config.source === "builtin") { this.statusMessage = { text: "Builtin agents cannot be edited. Clone to user scope to override.", type: "error" }; this.screen = "list"; return; } this.enterEdit(entry); return; }
+		if (action.type === "model") { if (entry.config.source === "builtin") { this.statusMessage = { text: "Builtin agents cannot be edited. Clone to user scope to override.", type: "error" }; this.screen = "list"; return; } this.enterModelPicker(entry); return; }
 		if (action.type === "launch") { this.enterTaskInput([entry.id], "detail"); return; }
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "pi-subagents",
-  "version": "0.11.2",
+  "version": "0.11.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-subagents",
-      "version": "0.11.2",
+      "version": "0.11.12",
       "license": "MIT",
       "bin": {
         "pi-subagents": "install.mjs"
       },
       "devDependencies": {
         "@marcfargas/pi-test-harness": "^0.5.0",
-        "@mariozechner/pi-agent-core": "^0.54.0",
-        "@mariozechner/pi-ai": "^0.54.0",
-        "@mariozechner/pi-coding-agent": "^0.54.0"
+        "@mariozechner/pi-agent-core": "^0.62.0",
+        "@mariozechner/pi-ai": "^0.62.0",
+        "@mariozechner/pi-coding-agent": "^0.62.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -1156,36 +1156,34 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.54.2.tgz",
-      "integrity": "sha512-dSg5tl3SGdrTFeTxfifvHjZ39M8k4jQ0ogTDtVeP7Pi3A3Whw4W1o6pYzTjX285CLxxqKiJS6MkwoElQHFwH1A==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.62.0.tgz",
+      "integrity": "sha512-SBjqgDrgKOaC+IGzFGB3jXQErv9H1QMYnWFvUg6ra6dG0ZgWFBUZb6unidngWLsmaxSDWes6KeKiVFMsr2VSEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.54.2"
+        "@mariozechner/pi-ai": "^0.62.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.54.2.tgz",
-      "integrity": "sha512-QKQV8iT7afwdaOiLDPTPyQcsGw4ulxBjAI0GvgvowAuqy9UbDeKFSdQYLmjVt7CtnJD1Z8zMjQQ4SLigdZ6dRQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.62.0.tgz",
+      "integrity": "sha512-mJgryZ5RgBQG++tiETMtCQQJoH2MAhKetCfqI98NMvGydu7L9x2qC2JekQlRaAgIlTgv4MRH1UXHMEs4UweE/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
         "@aws-sdk/client-bedrock-runtime": "^3.983.0",
         "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "1.10.0",
+        "@mistralai/mistralai": "1.14.1",
         "@sinclair/typebox": "^0.34.41",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "chalk": "^5.6.2",
-        "openai": "6.10.0",
+        "openai": "6.26.0",
         "partial-json": "^0.1.7",
         "proxy-agent": "^6.5.0",
         "undici": "^7.19.1",
@@ -1199,76 +1197,100 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.54.2.tgz",
-      "integrity": "sha512-m4xozDZ7GdB9iXy8/ykaLZ7aCcINxOPhA9WYY+zd6Mb8DWoeo7YmXNBAfemACGlAAGsUW2cSKI66tboczA2Uag==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.62.0.tgz",
+      "integrity": "sha512-f1NnExqsHuA6w8UVlBtPsvTBhdkMc0h1JD9SzGCdWTLou5GHJr2JIP6DlwV9IKWAnM+sAelaoFez+14wLP2zOQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.54.2",
-        "@mariozechner/pi-ai": "^0.54.2",
-        "@mariozechner/pi-tui": "^0.54.2",
+        "@mariozechner/pi-agent-core": "^0.62.0",
+        "@mariozechner/pi-ai": "^0.62.0",
+        "@mariozechner/pi-tui": "^0.62.0",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
         "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
         "file-type": "^21.1.1",
         "glob": "^13.0.1",
         "hosted-git-info": "^9.0.2",
         "ignore": "^7.0.5",
         "marked": "^15.0.12",
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.2.3",
         "proper-lockfile": "^4.1.2",
+        "strip-ansi": "^7.1.0",
+        "undici": "^7.19.1",
         "yaml": "^2.8.2"
       },
       "bin": {
         "pi": "dist/cli.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.6.0"
       },
       "optionalDependencies": {
         "@mariozechner/clipboard": "^0.3.2"
       }
     },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.54.2.tgz",
-      "integrity": "sha512-ekk7x69qvESE7NMRO+VIduVV1T/kH+Ghroh8yqZ1y0IF4U85nzZ4jwV8JECuiGUvtFE0MMwWfJc9KdEur4xF6A==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.62.0.tgz",
+      "integrity": "sha512-/At11PPe8l319MnUoK4wN5L/uVCU6bDdiIUzH8Ez0stOkjSF6isRXScZ+RMM+6iCKsD4muBTX8Cmcif+3/UWHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
         "chalk": "^5.5.0",
         "get-east-asian-width": "^1.3.0",
-        "koffi": "^2.9.0",
         "marked": "^15.0.12",
         "mime-types": "^3.0.1"
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
       }
     },
     "node_modules/@mistralai/mistralai": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.10.0.tgz",
-      "integrity": "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
       "dev": true,
       "dependencies": {
-        "zod": "^3.20.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.24.1"
-      }
-    },
-    "node_modules/@mistralai/mistralai/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2121,6 +2143,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2281,6 +2314,16 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2466,6 +2509,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2539,6 +2592,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2597,6 +2671,16 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fetch-blob": {
@@ -2734,6 +2818,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3007,12 +3107,13 @@
       }
     },
     "node_modules/koffi": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.2.tgz",
-      "integrity": "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
+      "integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://liberapay.com/Koromix"
       }
@@ -3179,10 +3280,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/openai": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.10.0.tgz",
-      "integrity": "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3330,6 +3441,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -3413,6 +3531,17 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3899,13 +4028,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3977,6 +4112,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/yoctocolors": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
@@ -3996,19 +4142,18 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/pi-args.test.ts
+++ b/pi-args.test.ts
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { buildPiArgs } from "./pi-args.ts";
 
+function valueAfter(args: string[], flag: string): string | undefined {
+	const idx = args.indexOf(flag);
+	return idx === -1 ? undefined : args[idx + 1];
+}
+
 describe("buildPiArgs session wiring", () => {
 	it("uses --session when sessionFile is provided", () => {
 		const { args } = buildPiArgs({
@@ -29,5 +34,30 @@ describe("buildPiArgs session wiring", () => {
 		assert.ok(args.includes("--session-dir"));
 		assert.ok(args.includes("/tmp/subagent-sessions"));
 		assert.ok(!args.includes("--session"));
+	});
+
+	it("uses --model (not --models) so configured agent models override restored fork sessions", () => {
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: true,
+			sessionFile: "/tmp/forked-session.jsonl",
+			model: "github-copilot/gpt-5.5",
+		});
+
+		assert.equal(valueAfter(args, "--model"), "github-copilot/gpt-5.5");
+		assert.ok(!args.includes("--models"), "--models only scopes cycling and should not be used to select subagent models");
+	});
+
+	it("preserves thinking suffix on forced model selection", () => {
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			model: "anthropic/claude-opus-4-6",
+			thinking: "high",
+		});
+
+		assert.equal(valueAfter(args, "--model"), "anthropic/claude-opus-4-6:high");
 	});
 });

--- a/pi-args.ts
+++ b/pi-args.ts
@@ -51,10 +51,10 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 
 	const modelArg = applyThinkingSuffix(input.model, input.thinking);
 	if (modelArg) {
-		// Use --models (not --model) because pi CLI silently ignores --model
-		// without a companion --provider flag. --models resolves the provider
-		// automatically via resolveModelScope. See: #8
-		args.push("--models", modelArg);
+		// Use --model to force the subagent's configured model even when the
+		// child process opens an existing/forked session. --models only scopes
+		// model cycling and does not override the restored session model.
+		args.push("--model", modelArg);
 	}
 
 	const toolExtensionPaths: string[] = [];

--- a/slash-commands.test.ts
+++ b/slash-commands.test.ts
@@ -83,13 +83,13 @@ function createState(cwd: string) {
 	};
 }
 
-function createCommandContext() {
+function createCommandContext(hasUI = false, statusEvents?: Array<string | undefined>) {
 	return {
 		cwd: process.cwd(),
-		hasUI: false,
+		hasUI,
 		ui: {
 			notify: (_message: string) => {},
-			setStatus: (_key: string, _text: string | undefined) => {},
+			setStatus: (_key: string, text: string | undefined) => { statusEvents?.push(text); },
 			onTerminalInput: () => () => {},
 			custom: async () => undefined,
 		},
@@ -97,7 +97,47 @@ function createCommandContext() {
 	};
 }
 
+function assertSlashMessage(
+	message: unknown,
+	{
+		content,
+		display,
+		expectedResultDetails,
+	}: { content: string; display: boolean; expectedResultDetails?: unknown },
+) {
+	const m = message as {
+		customType?: string;
+		content?: string;
+		display?: boolean;
+		details?: { requestId?: string; result?: { content?: Array<{ type?: string; text?: string }>; details?: unknown } };
+	};
+	assert.equal(m.customType, SLASH_RESULT_TYPE);
+	assert.equal(m.content, content);
+	assert.equal(m.display, display);
+	assert.equal(typeof m.details?.requestId, "string");
+	assert.equal(m.details?.result?.content?.[0]?.text, content);
+	if (expectedResultDetails !== undefined) {
+		assert.deepEqual(m.details?.result?.details, expectedResultDetails);
+	}
+}
+
 describe("slash command custom message delivery", { skip: !available ? "slash-commands.ts not importable" : undefined }, () => {
+	it("registers /subagents as the administration command", () => {
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const pi = {
+			events: createEventBus(),
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage() {},
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()));
+		assert.equal(commands.has("subagents"), true);
+		assert.equal(commands.has("agents"), true);
+	});
+
 	it("/run sends an inline slash result message after a successful bridge response", async () => {
 		const sent: unknown[] = [];
 		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
@@ -129,14 +169,63 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		registerSlashCommands!(pi, createState(process.cwd()));
 		await commands.get("run")!.handler("scout inspect this", createCommandContext());
 
-		assert.deepEqual(sent, [
-			{
-				customType: SLASH_RESULT_TYPE,
-				content: "Scout finished",
-				display: true,
-				details: { mode: "single", results: [] },
+		assert.equal(sent.length, 1);
+		assertSlashMessage(sent[0], {
+			content: "Scout finished",
+			display: true,
+			expectedResultDetails: { mode: "single", results: [] },
+		});
+	});
+
+	it("/run sends a visible live message and hidden final snapshot when UI rendering is available", async () => {
+		const sent: unknown[] = [];
+		const statusEvents: Array<string | undefined> = [];
+		const timeline: string[] = [];
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const events = createEventBus();
+		events.on(SLASH_SUBAGENT_REQUEST_EVENT, (data) => {
+			const requestId = (data as { requestId: string }).requestId;
+			events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId });
+			events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, {
+				requestId,
+				result: {
+					content: [{ type: "text", text: "Scout finished" }],
+					details: { mode: "single", results: [] },
+				},
+				isError: false,
+			});
+		});
+
+		const pi = {
+			events,
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
 			},
-		]);
+			registerShortcut() {},
+			sendMessage(message: unknown) {
+				sent.push(message);
+				timeline.push((message as { display?: boolean }).display === false ? "hidden-message" : "visible-message");
+			},
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()));
+		const ctx = createCommandContext(true, statusEvents);
+		const originalSetStatus = ctx.ui.setStatus;
+		ctx.ui.setStatus = (key: string, text: string | undefined) => {
+			originalSetStatus(key, text);
+			timeline.push(text === undefined ? "status-clear" : "status-set");
+		};
+		await commands.get("run")!.handler("scout inspect this", ctx);
+
+		assert.equal(sent.length, 2);
+		assertSlashMessage(sent[0], { content: "inspect this", display: true, expectedResultDetails: undefined });
+		assertSlashMessage(sent[1], {
+			content: "Scout finished",
+			display: false,
+			expectedResultDetails: { mode: "single", results: [] },
+		});
+		assert.deepEqual(statusEvents, ["running...", undefined]);
+		assert.deepEqual(timeline, ["visible-message", "status-set", "hidden-message", "status-clear"]);
 	});
 
 	it("/run still sends an inline slash result message when the bridge returns an error", async () => {
@@ -171,13 +260,11 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		registerSlashCommands!(pi, createState(process.cwd()));
 		await commands.get("run")!.handler("scout inspect this", createCommandContext());
 
-		assert.deepEqual(sent, [
-			{
-				customType: SLASH_RESULT_TYPE,
-				content: "Subagent failed",
-				display: true,
-				details: { mode: "single", results: [] },
-			},
-		]);
+		assert.equal(sent.length, 1);
+		assertSlashMessage(sent[0], {
+			content: "Subagent failed",
+			display: true,
+			expectedResultDetails: { mode: "single", results: [] },
+		});
 	});
 });

--- a/slash-commands.ts
+++ b/slash-commands.ts
@@ -118,7 +118,7 @@ async function requestSlashRun(
 		const startTimeout = setTimeout(() => {
 			finish(() => reject(new Error(
 				"Slash subagent bridge did not start within 15s. Ensure the extension is loaded correctly.",
-			)));
+			)), false);
 		}, startTimeoutMs);
 
 		const onStarted = (data: unknown) => {
@@ -134,7 +134,10 @@ async function requestSlashRun(
 			const response = data as Partial<SlashSubagentResponse>;
 			if (response.requestId !== requestId) return;
 			clearTimeout(startTimeout);
-			finish(() => resolve(response as SlashSubagentResponse));
+			// Keep the status line alive until the caller records the final snapshot.
+			// Clearing it before finalizeSlashResult() can trigger the last TUI redraw
+			// while the visible result card still points at the live "running" state.
+			finish(() => resolve(response as SlashSubagentResponse), false);
 		};
 
 		const onUpdate = (data: unknown) => {
@@ -152,7 +155,7 @@ async function requestSlashRun(
 			? ctx.ui.onTerminalInput((input) => {
 				if (!matchesKey(input, Key.escape)) return undefined;
 				pi.events.emit(SLASH_SUBAGENT_CANCEL_EVENT, { requestId });
-				finish(() => reject(new Error("Cancelled")));
+				finish(() => reject(new Error("Cancelled")), false);
 				return { consume: true };
 			})
 			: undefined;
@@ -161,7 +164,7 @@ async function requestSlashRun(
 		const unsubResponse = pi.events.on(SLASH_SUBAGENT_RESPONSE_EVENT, onResponse);
 		const unsubUpdate = pi.events.on(SLASH_SUBAGENT_UPDATE_EVENT, onUpdate);
 
-		const finish = (next: () => void) => {
+		const finish = (next: () => void, clearStatus = true) => {
 			if (done) return;
 			done = true;
 			clearTimeout(startTimeout);
@@ -169,7 +172,7 @@ async function requestSlashRun(
 			unsubResponse();
 			unsubUpdate();
 			onTerminalInput?.();
-			if (ctx.hasUI) ctx.ui.setStatus("subagent-slash", undefined);
+			if (clearStatus && ctx.hasUI) ctx.ui.setStatus("subagent-slash", undefined);
 			next();
 		};
 
@@ -181,7 +184,7 @@ async function requestSlashRun(
 		if (!started) {
 			finish(() => reject(new Error(
 				"No slash subagent bridge responded. Ensure the subagent extension is loaded correctly.",
-			)));
+			)), false);
 		}
 	});
 }
@@ -201,14 +204,16 @@ async function runSlashSubagent(
 	params: SubagentParamsLike,
 ): Promise<void> {
 	const requestId = randomUUID();
-	const initialDetails = buildSlashInitialResult(requestId, params);
-	const initialText = extractSlashMessageText(initialDetails.result.content) || "Running subagent...";
-	pi.sendMessage({
-		customType: SLASH_RESULT_TYPE,
-		content: initialText,
-		display: true,
-		details: initialDetails,
-	});
+	if (ctx.hasUI) {
+		const initialDetails = buildSlashInitialResult(requestId, params);
+		const initialText = extractSlashMessageText(initialDetails.result.content) || "Running subagent...";
+		pi.sendMessage({
+			customType: SLASH_RESULT_TYPE,
+			content: initialText,
+			display: true,
+			details: initialDetails,
+		});
+	}
 
 	try {
 		const response = await requestSlashRun(pi, ctx, requestId, params);
@@ -217,9 +222,10 @@ async function runSlashSubagent(
 		pi.sendMessage({
 			customType: SLASH_RESULT_TYPE,
 			content: text,
-			display: false,
+			display: !ctx.hasUI,
 			details: finalDetails,
 		});
+		if (ctx.hasUI) ctx.ui.setStatus("subagent-slash", undefined);
 		if (response.isError && ctx.hasUI) {
 			ctx.ui.notify(response.errorText || "Subagent failed", "error");
 		}
@@ -229,9 +235,10 @@ async function runSlashSubagent(
 		pi.sendMessage({
 			customType: SLASH_RESULT_TYPE,
 			content: message,
-			display: false,
+			display: !ctx.hasUI,
 			details: failedDetails,
 		});
+		if (ctx.hasUI) ctx.ui.setStatus("subagent-slash", undefined);
 		if (message === "Cancelled") {
 			if (ctx.hasUI) ctx.ui.notify("Cancelled", "warning");
 			return;
@@ -385,11 +392,18 @@ export function registerSlashCommands(
 	pi: ExtensionAPI,
 	state: SubagentState,
 ): void {
+	const openSubagentsManagerCommand = async (_args: string, ctx: ExtensionContext) => {
+		await openAgentManager(pi, ctx);
+	};
+
 	pi.registerCommand("agents", {
-		description: "Open the Agents Manager",
-		handler: async (_args, ctx) => {
-			await openAgentManager(pi, ctx);
-		},
+		description: "Open the Subagents Manager",
+		handler: openSubagentsManagerCommand,
+	});
+
+	pi.registerCommand("subagents", {
+		description: "Administer subagents: inspect metadata, edit prompts/settings, and update models",
+		handler: openSubagentsManagerCommand,
 	});
 
 	pi.registerCommand("run", {


### PR DESCRIPTION
## Summary

- Fix slash-launched subagent result cards staying visually stuck in the running state by finalizing the hidden result snapshot before clearing the live status/redrawing.
- Keep slash-command final results visible in non-UI contexts, while preserving live visible cards + hidden final snapshots in TUI mode.
- Add `/subagents` as the primary administration command for the Subagents Manager; `/agents` remains as an alias.
- Extend the manager detail screen with metadata and a direct `m` shortcut to update user/project subagent models via the existing model picker.
- Refresh `package-lock.json` to match current package metadata/dev dependency versions so `npm ci` works cleanly.

## Testing

```bash
npm run test:all
```

Result:

```text
# tests 212
# pass 212
# fail 0
```
