### PR TITLE
Add lightweight /subagents admin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Added `/subagents` as a lightweight administration command for inspecting subagent metadata and updating configured models via Pi's available model list. User/project agents are updated in markdown; builtin agents are updated through settings-backed `subagents.agentOverrides`.
+
 ## [0.24.0] - 2026-05-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -241,9 +241,10 @@ Skip this section until you want exact syntax.
 | `/chain agent1 "task1" -> agent2 "task2"` | Run agents in sequence |
 | `/parallel agent1 "task1" -> agent2 "task2"` | Run agents in parallel |
 | `/run-chain <chainName> -- <task>` | Launch a saved `.chain.md` workflow |
+| `/subagents [agent] [model]` | Inspect subagent metadata and interactively update its configured model |
 | `/subagents-doctor` | Show read-only setup diagnostics |
 
-Commands validate agent names locally, support tab completion, and send results back into the conversation.
+Commands validate agent names locally, support tab completion, and send results back into the conversation. `/subagents` opens a lightweight admin flow: pick an agent, review its metadata, then choose a model from Pi's available model list. User/project agents are updated in their markdown file; builtin agents are updated through `subagents.agentOverrides` in settings.
 
 ### Per-step tasks
 

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -7,6 +7,7 @@ import { discoverAgents, discoverAgentsAll, type ChainConfig } from "../agents/a
 import type { SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { isParallelStep, type ChainStep } from "../shared/settings.ts";
 import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.ts";
+import { openSubagentsAdmin } from "./subagents-admin.ts";
 import {
 	applySlashUpdate,
 	buildSlashInitialResult,
@@ -404,6 +405,13 @@ export function registerSlashCommands(
 	pi: ExtensionAPI,
 	state: SubagentState,
 ): void {
+	pi.registerCommand("subagents", {
+		description: "Administer subagents: inspect metadata and update configured models",
+		handler: async (args, ctx) => {
+			await openSubagentsAdmin(pi, ctx, args);
+		},
+	});
+
 	pi.registerCommand("run", {
 		description: "Run a subagent directly: /run agent[output=file] [task] [--bg] [--fork]",
 		getArgumentCompletions: makeAgentCompletions(state, false),

--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -1,0 +1,196 @@
+import * as fs from "node:fs";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+	buildBuiltinOverrideConfig,
+	discoverAgentsAll,
+	frontmatterNameForConfig,
+	removeBuiltinAgentOverride,
+	saveBuiltinAgentOverride,
+	type AgentConfig,
+	type BuiltinAgentOverrideBase,
+} from "../agents/agents.ts";
+import { serializeAgent } from "../agents/agent-serializer.ts";
+
+const ADMIN_MESSAGE_TYPE = "subagents-admin";
+const INHERIT_MODEL_CHOICE = "Default / inherit session model";
+
+type ModelInfo = { provider: string; id: string };
+
+function sourceRank(source: AgentConfig["source"]): number {
+	if (source === "project") return 0;
+	if (source === "user") return 1;
+	return 2;
+}
+
+function allVisibleAgents(cwd: string): AgentConfig[] {
+	const d = discoverAgentsAll(cwd);
+	return [...d.project, ...d.user, ...d.builtin]
+		.filter((agent) => !agent.disabled)
+		.sort((a, b) => a.name.localeCompare(b.name) || sourceRank(a.source) - sourceRank(b.source));
+}
+
+function agentLabel(agent: AgentConfig): string {
+	const model = agent.model ? ` · ${agent.model}` : "";
+	return `${agent.name} [${agent.source}]${model} — ${agent.description}`;
+}
+
+function agentMatches(agent: AgentConfig, rawName: string): boolean {
+	const name = rawName.trim();
+	return agent.name === name || frontmatterNameForConfig(agent) === name;
+}
+
+function sendAdminMessage(pi: ExtensionAPI, content: string): void {
+	pi.sendMessage({
+		customType: ADMIN_MESSAGE_TYPE,
+		content,
+		display: true,
+	});
+}
+
+function modelFullId(model: ModelInfo): string {
+	return `${model.provider}/${model.id}`;
+}
+
+function buildBuiltinBase(agent: AgentConfig): BuiltinAgentOverrideBase {
+	return {
+		model: agent.model,
+		fallbackModels: agent.fallbackModels ? [...agent.fallbackModels] : undefined,
+		thinking: agent.thinking,
+		systemPromptMode: agent.systemPromptMode,
+		inheritProjectContext: agent.inheritProjectContext,
+		inheritSkills: agent.inheritSkills,
+		defaultContext: agent.defaultContext,
+		disabled: agent.disabled,
+		systemPrompt: agent.systemPrompt,
+		skills: agent.skills ? [...agent.skills] : undefined,
+		tools: agent.tools ? [...agent.tools] : undefined,
+		mcpDirectTools: agent.mcpDirectTools ? [...agent.mcpDirectTools] : undefined,
+	};
+}
+
+async function selectAgent(ctx: ExtensionContext, args: string): Promise<AgentConfig | undefined> {
+	const agents = allVisibleAgents(ctx.cwd);
+	if (agents.length === 0) return undefined;
+
+	const requestedName = args.trim().split(/\s+/)[0] ?? "";
+	if (requestedName) {
+		const matches = agents.filter((agent) => agentMatches(agent, requestedName));
+		if (matches.length === 1 || !ctx.hasUI) return matches[0];
+		if (matches.length > 1) {
+			const byLabel = new Map(matches.map((agent) => [agentLabel(agent), agent] as const));
+			const choice = await ctx.ui.select(`Multiple subagents named '${requestedName}'`, [...byLabel.keys()]);
+			return choice ? byLabel.get(choice) : undefined;
+		}
+		return undefined;
+	}
+
+	if (!ctx.hasUI) return undefined;
+	const byLabel = new Map(agents.map((agent) => [agentLabel(agent), agent] as const));
+	const choice = await ctx.ui.select("Select subagent", [...byLabel.keys()]);
+	return choice ? byLabel.get(choice) : undefined;
+}
+
+function metadataFor(agent: AgentConfig): string {
+	const tools = [...(agent.tools ?? []), ...(agent.mcpDirectTools ?? []).map((tool) => `mcp:${tool}`)];
+	const lines = [
+		`Agent: ${agent.name} (${agent.source})`,
+		`Path: ${agent.filePath}`,
+		`Description: ${agent.description}`,
+	];
+	if (agent.packageName) {
+		lines.push(`Local name: ${frontmatterNameForConfig(agent)}`);
+		lines.push(`Package: ${agent.packageName}`);
+	}
+	lines.push(`Model: ${agent.model ?? "default / inherit"}`);
+	if (agent.fallbackModels?.length) lines.push(`Fallback models: ${agent.fallbackModels.join(", ")}`);
+	if (agent.thinking) lines.push(`Thinking: ${agent.thinking}`);
+	if (tools.length) lines.push(`Tools: ${tools.join(", ")}`);
+	if (agent.skills?.length) lines.push(`Skills: ${agent.skills.join(", ")}`);
+	lines.push(`System prompt mode: ${agent.systemPromptMode}`);
+	lines.push(`Inherit project context: ${agent.inheritProjectContext ? "true" : "false"}`);
+	lines.push(`Inherit skills: ${agent.inheritSkills ? "true" : "false"}`);
+	if (agent.defaultContext) lines.push(`Default context: ${agent.defaultContext}`);
+	if (agent.output) lines.push(`Output: ${agent.output}`);
+	if (agent.defaultReads?.length) lines.push(`Reads: ${agent.defaultReads.join(", ")}`);
+	if (agent.defaultProgress) lines.push("Progress: true");
+	if (agent.maxSubagentDepth !== undefined) lines.push(`Max subagent depth: ${agent.maxSubagentDepth}`);
+	if (agent.source === "builtin") lines.push(`Disabled: ${agent.disabled ? "true" : "false"}`);
+	if (agent.override) lines.push(`Override: ${agent.override.scope} (${agent.override.path})`);
+	if (agent.systemPrompt.trim()) lines.push("", "System Prompt:", agent.systemPrompt);
+	return lines.join("\n");
+}
+
+async function chooseModel(ctx: ExtensionContext, agent: AgentConfig): Promise<string | undefined | null> {
+	const models = ctx.modelRegistry.getAvailable().map((model) => modelFullId(model));
+	const current = agent.model ?? INHERIT_MODEL_CHOICE;
+	const choices = [INHERIT_MODEL_CHOICE, ...models.filter((model) => model !== agent.model)];
+	if (agent.model && !choices.includes(agent.model)) choices.splice(1, 0, agent.model);
+	const choice = await ctx.ui.select(`Select model for ${agent.name}\nCurrent: ${current}`, choices);
+	if (!choice) return null;
+	return choice === INHERIT_MODEL_CHOICE ? undefined : choice;
+}
+
+async function chooseBuiltinOverrideScope(ctx: ExtensionContext, agent: AgentConfig): Promise<"user" | "project" | undefined> {
+	if (agent.override?.scope) return agent.override.scope;
+	const d = discoverAgentsAll(ctx.cwd);
+	if (!d.projectSettingsPath || !ctx.hasUI) return "user";
+	const choice = await ctx.ui.select(`Save builtin override for ${agent.name}`, ["user", "project"]);
+	return choice === "user" || choice === "project" ? choice : undefined;
+}
+
+async function saveAgentModel(ctx: ExtensionContext, agent: AgentConfig, selectedModel: string | undefined): Promise<string> {
+	if (agent.source === "builtin") {
+		const scope = await chooseBuiltinOverrideScope(ctx, agent);
+		if (!scope) return "Cancelled.";
+		const base = agent.override?.base ?? buildBuiltinBase(agent);
+		const draft: AgentConfig = { ...agent, model: selectedModel };
+		const override = buildBuiltinOverrideConfig(base, draft);
+		const filePath = override
+			? saveBuiltinAgentOverride(ctx.cwd, agent.name, scope, override)
+			: removeBuiltinAgentOverride(ctx.cwd, agent.name, scope);
+		return selectedModel
+			? `Saved ${scope} override for builtin '${agent.name}' with model '${selectedModel}' in ${filePath}.`
+			: `Cleared model override for builtin '${agent.name}' in ${filePath}.`;
+	}
+
+	const updated: AgentConfig = { ...agent, model: selectedModel };
+	fs.writeFileSync(updated.filePath, serializeAgent(updated), "utf-8");
+	return selectedModel
+		? `Updated '${agent.name}' model to '${selectedModel}' in ${updated.filePath}.`
+		: `Cleared '${agent.name}' model in ${updated.filePath}.`;
+}
+
+export async function openSubagentsAdmin(pi: ExtensionAPI, ctx: ExtensionContext, args = ""): Promise<void> {
+	const agent = await selectAgent(ctx, args);
+	if (!agent) {
+		const agents = allVisibleAgents(ctx.cwd);
+		const requestedName = args.trim().split(/\s+/)[0];
+		const text = requestedName
+			? `Subagent '${requestedName}' not found.\n\nAvailable subagents:\n${agents.map((a) => `- ${a.name} (${a.source})`).join("\n") || "- (none)"}`
+			: `Available subagents:\n${agents.map((a) => `- ${a.name} (${a.source})`).join("\n") || "- (none)"}`;
+		sendAdminMessage(pi, text);
+		return;
+	}
+
+	sendAdminMessage(pi, metadataFor(agent));
+	if (!ctx.hasUI) return;
+
+	const requestedAction = args.trim().split(/\s+/)[1];
+	let action = requestedAction === "model" ? "Change model" : undefined;
+	if (!action) {
+		action = await ctx.ui.select(`Administer ${agent.name}`, ["Change model", "Done"]);
+	}
+	if (action !== "Change model") return;
+
+	const selectedModel = await chooseModel(ctx, agent);
+	if (selectedModel === null) return;
+	try {
+		const message = await saveAgentModel(ctx, agent, selectedModel);
+		ctx.ui.notify(message, "info");
+		sendAdminMessage(pi, message);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		ctx.ui.notify(message, "error");
+		sendAdminMessage(pi, `Failed to update '${agent.name}': ${message}`);
+	}
+}

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -127,6 +127,8 @@ function createCommandContext(
 		setStatus: (key: string, text: string | undefined) => void;
 		setToolsExpanded: (expanded: boolean) => void;
 		sessionManager: unknown;
+		select: (title: string, choices: string[]) => Promise<string | undefined>;
+		models: Array<{ provider: string; id: string }>;
 	}> = {},
 ) {
 	return {
@@ -138,8 +140,9 @@ function createCommandContext(
 			setToolsExpanded: overrides.setToolsExpanded ?? ((_expanded: boolean) => {}),
 			onTerminalInput: () => () => {},
 			custom: overrides.custom ?? (async () => undefined),
+			select: overrides.select ?? (async (_title: string, _choices: string[]) => undefined),
 		},
-		modelRegistry: { getAvailable: () => [] },
+		modelRegistry: { getAvailable: () => overrides.models ?? [] },
 		sessionManager: overrides.sessionManager ?? {
 			getSessionFile: () => null,
 			getSessionId: () => "session-test",
@@ -762,6 +765,111 @@ Gather context
 				skill: ["research", "audit"],
 				model: "openai/gpt-5.5",
 			});
+		});
+	});
+});
+
+
+describe("subagents admin slash command", { skip: !available ? "slash-commands.ts not importable" : undefined }, () => {
+	beforeEach(() => {
+		clearSlashSnapshots?.();
+	});
+
+	it("registers /subagents", async () => {
+		await withIsolatedHome(async () => {
+			const commands = new Map<string, RegisteredSlashCommand>();
+			const pi = {
+				events: createEventBus(),
+				registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+				registerShortcut() {},
+				sendMessage(_message: unknown) {},
+			};
+
+			registerSlashCommands!(pi, createState(process.cwd()));
+			assert.equal(commands.has("subagents"), true);
+		});
+	});
+
+	it("shows selected subagent metadata and updates a project agent model", async () => {
+		await withTempProject("pi-subagents-admin-model-", async (root) => {
+			const agentPath = path.join(root, ".pi", "agents", "worker.md");
+			fs.writeFileSync(agentPath, `---
+name: worker
+description: Test worker
+model: github-copilot/claude-sonnet-4
+systemPromptMode: replace
+inheritProjectContext: false
+inheritSkills: false
+---
+
+Do work.
+`, "utf-8");
+
+			const sent: unknown[] = [];
+			const notifications: string[] = [];
+			const selections = [
+				"worker [project] · github-copilot/claude-sonnet-4 — Test worker",
+				"Change model",
+				"github-copilot/gpt-5.5",
+			];
+			const commands = new Map<string, RegisteredSlashCommand>();
+			const pi = {
+				events: createEventBus(),
+				registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+				registerShortcut() {},
+				sendMessage(message: unknown) { sent.push(message); },
+			};
+
+			registerSlashCommands!(pi, createState(root));
+			await commands.get("subagents")!.handler("", createCommandContext({
+				cwd: root,
+				hasUI: true,
+				models: [{ provider: "github-copilot", id: "gpt-5.5" }],
+				notify: (message) => notifications.push(message),
+				select: async (_title, choices) => {
+					const next = selections.shift();
+					assert.ok(next, "unexpected select call");
+					assert.ok(choices.includes(next), `choice '${next}' was not offered`);
+					return next;
+				},
+			}));
+
+			const updated = fs.readFileSync(agentPath, "utf-8");
+			assert.match(updated, /^model: github-copilot\/gpt-5\.5$/m);
+			assert.match((sent[0] as { content?: string }).content ?? "", /Agent: worker \(project\)/);
+			assert.match((sent[1] as { content?: string }).content ?? "", /Updated 'worker' model to 'github-copilot\/gpt-5\.5'/);
+			assert.match(notifications[0] ?? "", /Updated 'worker' model/);
+		});
+	});
+
+	it("shows metadata for a named subagent without requiring UI", async () => {
+		await withTempProject("pi-subagents-admin-metadata-", async (root) => {
+			fs.writeFileSync(path.join(root, ".pi", "agents", "auditor.md"), `---
+name: auditor
+description: Audit things
+systemPromptMode: replace
+inheritProjectContext: false
+inheritSkills: false
+---
+
+Audit.
+`, "utf-8");
+
+			const sent: unknown[] = [];
+			const commands = new Map<string, RegisteredSlashCommand>();
+			const pi = {
+				events: createEventBus(),
+				registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+				registerShortcut() {},
+				sendMessage(message: unknown) { sent.push(message); },
+			};
+
+			registerSlashCommands!(pi, createState(root));
+			await commands.get("subagents")!.handler("auditor", createCommandContext({ cwd: root }));
+
+			assert.equal(sent.length, 1);
+			assert.match((sent[0] as { content?: string }).content ?? "", /Agent: auditor \(project\)/);
+			assert.match((sent[0] as { content?: string }).content ?? "", /Description: Audit things/);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Adds `/subagents` as a lightweight administration command on top of current `main`.
- Lets users inspect selected subagent metadata directly in the conversation.
- In interactive/RPC UI contexts, lets users update the selected subagent model from Pi's available model list.
- Saves user/project agents back to their markdown files; saves builtin model changes through settings-backed `subagents.agentOverrides`.

This intentionally avoids reintroducing the removed manager overlay; it uses Pi's existing dialog primitives instead.

## Usage

- `/subagents` — select a subagent, view metadata, optionally change model.
- `/subagents <agent>` — show metadata for a named subagent.
- `/subagents <agent> model` — jump straight to model selection for that subagent.

## Testing

Focused:

```bash
node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/slash-commands.test.ts
```

Full suite with isolated HOME/USERPROFILE to avoid local user-agent overrides affecting builtin-discovery tests:

```bash
tmp_home=$(mktemp -d) && HOME=$tmp_home USERPROFILE=$tmp_home npm run test:all
```

Result:

```text
# pass 317
# fail 0
```
