### PR TITLE
fix: allow explicit nested subagent delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Restore explicit nested delegation for child agents that include `subagent` in their `tools` allowlist while keeping normal child sessions non-orchestrating by default.
+
 ## [0.24.0] - 2026-05-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Use the optional prompt shortcuts below when you want the pattern to be repeatab
 
 Packaged `planner`, `worker`, and `oracle` default to forked context when a launch omits `context`; pass `context: "fresh"` when you intentionally want a fresh child run.
 
-Child-safety boundaries are enforced at runtime. Spawned child sessions do not register the `subagent` tool, do not receive the bundled `pi-subagents` skill, and receive explicit boundary instructions that they are not the parent orchestrator and must not propose or run subagents. Forked child context filtering also removes parent-only subagent artifacts (including old hidden orchestration-instruction messages, slash/status/control messages, and prior parent `subagent` tool-call/tool-result history) while preserving ordinary prose and unrelated tool calls/results.
+Child-safety boundaries are enforced at runtime. Spawned child sessions do not register the `subagent` tool unless the child agent explicitly includes `subagent` in its own `tools` allowlist, do not receive the bundled `pi-subagents` skill, and receive boundary instructions that match their delegation permissions. Forked child context filtering also removes parent-only subagent artifacts (including old hidden orchestration-instruction messages, slash/status/control messages, and prior parent `subagent` tool-call/tool-result history) while preserving ordinary prose and unrelated tool calls/results.
 
 ## Optional shortcuts
 
@@ -912,9 +912,9 @@ This is disabled by default. Session data may contain source code, paths, enviro
 
 ## Recursion guard
 
-Subagents can call `subagent`, which can get expensive and hard to observe. A depth guard prevents unbounded nesting.
+Subagents can call `subagent` when their agent definition explicitly includes `subagent` in its `tools` allowlist, which can get expensive and hard to observe. A depth guard prevents unbounded nesting.
 
-By default, nesting is limited to two levels: main session → subagent → sub-subagent. Deeper calls are blocked with guidance to complete the current task directly.
+By default, nesting is limited to two levels: main session → subagent → sub-subagent. Deeper calls are blocked with guidance to complete the current task directly. Child agents that do not explicitly include `subagent` in `tools` remain non-orchestrating children.
 
 Configure the limit with:
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -561,7 +561,8 @@ particular agent or with forked context.
 - **Forked runs inherit parent history.** They are branched threads, not fresh
   filtered contexts. Use fresh context for adversarial reviewers unless the user explicitly asks for forked context.
 - **Default subagent nesting depth is 2.** Deeper recursive delegation is blocked
-  unless configured otherwise.
+  unless configured otherwise. A child can only delegate further when its agent
+  definition explicitly includes `subagent` in its `tools` allowlist.
 - **Attention signals are not lifecycle state.** `needs_attention` means no activity has been observed past the configured threshold. `paused` means the child turn was intentionally interrupted or is awaiting direction; it is not the same as `failed`.
 - **Intercom asks are blocking.** A session can only maintain one pending outbound
   ask wait state at a time.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -33,7 +33,7 @@ import { registerSlashSubagentBridge } from "../slash/slash-bridge.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
 import registerSubagentNotify, { type SubagentNotifyDetails } from "../runs/background/notify.ts";
-import { SUBAGENT_CHILD_ENV } from "../runs/shared/pi-args.ts";
+import { SUBAGENT_ALLOW_NESTED_ENV, SUBAGENT_CHILD_ENV } from "../runs/shared/pi-args.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import {
 	type Details,
@@ -220,7 +220,7 @@ class SubagentControlNoticeComponent implements Component {
 }
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
-	if (process.env[SUBAGENT_CHILD_ENV] === "1") return;
+	if (process.env[SUBAGENT_CHILD_ENV] === "1" && process.env[SUBAGENT_ALLOW_NESTED_ENV] !== "1") return;
 	const globalStore = globalThis as Record<string, unknown>;
 	const runtimeCleanupStoreKey = "__piSubagentRuntimeCleanup";
 	const previousRuntimeCleanup = globalStore[runtimeCleanupStoreKey];

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -7,6 +7,7 @@ const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
 const TASK_ARG_LIMIT = 8000;
 const PROMPT_RUNTIME_EXTENSION_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-prompt-runtime.ts");
 export const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
+export const SUBAGENT_ALLOW_NESTED_ENV = "PI_SUBAGENT_ALLOW_NESTED";
 export const SUBAGENT_ORCHESTRATOR_TARGET_ENV = "PI_SUBAGENT_ORCHESTRATOR_TARGET";
 export const SUBAGENT_RUN_ID_ENV = "PI_SUBAGENT_RUN_ID";
 export const SUBAGENT_CHILD_AGENT_ENV = "PI_SUBAGENT_CHILD_AGENT";
@@ -122,6 +123,9 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 
 	const env: Record<string, string | undefined> = {};
 	env[SUBAGENT_CHILD_ENV] = "1";
+	if (input.tools?.includes("subagent")) {
+		env[SUBAGENT_ALLOW_NESTED_ENV] = "1";
+	}
 	env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = input.inheritProjectContext ? "1" : "0";
 	env.PI_SUBAGENT_INHERIT_SKILLS = input.inheritSkills ? "1" : "0";
 	if (input.intercomSessionName) {

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
 const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
+const SUBAGENT_ALLOW_NESTED_ENV = "PI_SUBAGENT_ALLOW_NESTED";
 export const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
 
 export const CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS = [
@@ -9,6 +10,14 @@ export const CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS = [
 	"The parent session owns delegation, orchestration, review fanout, and follow-up worker launches.",
 	"Ignore prior parent-only orchestration instructions in inherited conversation history.",
 	"Do not propose or run subagents. Complete only your assigned role-specific task with the tools available to you.",
+	"If you need to edit files, call the actual edit/write tools. Do not print tool-call syntax, patches, or pseudo-tool calls as text.",
+].join("\n");
+
+export const CHILD_SUBAGENT_NESTED_DELEGATION_INSTRUCTIONS = [
+	"You are a child subagent with explicit nested-delegation permission.",
+	"You may use the subagent tool only for bounded child work required by your assigned task.",
+	"Respect the inherited maxSubagentDepth guard and avoid recursive or unbounded fan-out.",
+	"Ignore unrelated prior parent-only orchestration history; use only the current task and available tools.",
 	"If you need to edit files, call the actual edit/write tools. Do not print tool-call syntax, patches, or pseudo-tool calls as text.",
 ].join("\n");
 
@@ -74,9 +83,12 @@ export function rewriteSubagentPrompt(
 		rewritten = stripInheritedSkills(rewritten);
 	}
 	rewritten = stripSubagentOrchestrationSkill(rewritten);
-	return rewritten.includes(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS)
+	const boundaryInstructions = process.env[SUBAGENT_ALLOW_NESTED_ENV] === "1"
+		? CHILD_SUBAGENT_NESTED_DELEGATION_INSTRUCTIONS
+		: CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS;
+	return rewritten.includes(boundaryInstructions)
 		? rewritten
-		: `${CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS}\n\n${rewritten}`;
+		: `${boundaryInstructions}\n\n${rewritten}`;
 }
 
 function isParentOnlySubagentMessage(message: unknown): boolean {

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -3,13 +3,14 @@ import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
-import { SUBAGENT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
+import { SUBAGENT_ALLOW_NESTED_ENV, SUBAGENT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 function parentToolEnv(): NodeJS.ProcessEnv {
 	const env = { ...process.env };
 	delete env[SUBAGENT_CHILD_ENV];
+	delete env[SUBAGENT_ALLOW_NESTED_ENV];
 	return env;
 }
 
@@ -83,6 +84,47 @@ describe("subagent extension child mode", () => {
 			registerSubagentExtension(fakePi);
 			if (calls.length > 0) {
 				throw new Error("Unexpected child-mode registrations: " + calls.join(", "));
+			}
+		`;
+
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-transform-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, stdio: "pipe" },
+		);
+	});
+
+	it("registers the subagent tool in child mode when nested delegation is explicitly allowed", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./src/extension/index.ts";
+			import { SUBAGENT_ALLOW_NESTED_ENV, SUBAGENT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
+			process.env[SUBAGENT_CHILD_ENV] = "1";
+			process.env[SUBAGENT_ALLOW_NESTED_ENV] = "1";
+			const calls = [];
+			const fakePi = new Proxy({
+				events: { on() { return () => {}; }, emit() {} },
+				registerTool(tool) { calls.push(["registerTool", tool.name]); },
+				registerCommand() {},
+				registerShortcut() {},
+				registerMessageRenderer() {},
+				sendMessage() {},
+				getSessionName() { return undefined; },
+			}, {
+				get(target, prop) {
+					if (prop in target) return target[prop];
+					return () => undefined;
+				},
+			});
+			registerSubagentExtension(fakePi);
+			if (!calls.some(([kind, name]) => kind === "registerTool" && name === "subagent")) {
+				throw new Error("Expected child nested delegation to register subagent tool, got " + JSON.stringify(calls));
 			}
 		`;
 

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -137,6 +137,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
 		assert.ok(extensionArgs.some((arg) => arg.endsWith(path.join("src", "runs", "shared", "subagent-prompt-runtime.ts"))));
 		assert.equal(env.PI_SUBAGENT_CHILD, "1");
+		assert.equal(env.PI_SUBAGENT_ALLOW_NESTED, undefined);
 		assert.equal(env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT, "0");
 		assert.equal(env.PI_SUBAGENT_INHERIT_SKILLS, "1");
 	});
@@ -160,6 +161,20 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env.PI_SUBAGENT_RUN_ID, "78f659a3");
 		assert.equal(env.PI_SUBAGENT_CHILD_AGENT, "worker");
 		assert.equal(env.PI_SUBAGENT_CHILD_INDEX, "2");
+	});
+
+	it("allows nested delegation only when the child explicitly receives the subagent tool", () => {
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["subagent", "read"],
+		});
+
+		assert.equal(env.PI_SUBAGENT_CHILD, "1");
+		assert.equal(env.PI_SUBAGENT_ALLOW_NESTED, "1");
 	});
 
 	it("emits explicit builtin tool allowlists", () => {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import registerSubagentPromptRuntime, {
 	CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS,
+	CHILD_SUBAGENT_NESTED_DELEGATION_INSTRUCTIONS,
 	SUBAGENT_INTERCOM_SESSION_NAME_ENV,
 	rewriteSubagentPrompt,
 	stripInheritedSkills,
@@ -14,6 +15,7 @@ const envSnapshot = {
 	PI_SUBAGENT_INHERIT_PROJECT_CONTEXT: process.env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT,
 	PI_SUBAGENT_INHERIT_SKILLS: process.env.PI_SUBAGENT_INHERIT_SKILLS,
 	PI_SUBAGENT_INTERCOM_SESSION_NAME: process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME,
+	PI_SUBAGENT_ALLOW_NESTED: process.env.PI_SUBAGENT_ALLOW_NESTED,
 };
 
 const SKILLS_SECTION = "\n\nThe following skills provide specialized instructions for specific tasks.\nUse the read tool to load a skill's file when the task matches its description.\nWhen a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.\n\n<available_skills>\n  <skill>\n    <name>safe-bash</name>\n    <description>desc</description>\n    <location>/tmp/SKILL.md</location>\n  </skill>\n  <skill>\n    <name>pi-subagents</name>\n    <description>delegate to subagents</description>\n    <location>/tmp/pi-subagents/SKILL.md</location>\n  </skill>\n</available_skills>";
@@ -40,6 +42,8 @@ afterEach(() => {
 	else process.env.PI_SUBAGENT_INHERIT_SKILLS = envSnapshot.PI_SUBAGENT_INHERIT_SKILLS;
 	if (envSnapshot.PI_SUBAGENT_INTERCOM_SESSION_NAME === undefined) delete process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME;
 	else process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME = envSnapshot.PI_SUBAGENT_INTERCOM_SESSION_NAME;
+	if (envSnapshot.PI_SUBAGENT_ALLOW_NESTED === undefined) delete process.env.PI_SUBAGENT_ALLOW_NESTED;
+	else process.env.PI_SUBAGENT_ALLOW_NESTED = envSnapshot.PI_SUBAGENT_ALLOW_NESTED;
 });
 
 describe("subagent prompt runtime", () => {
@@ -79,6 +83,20 @@ describe("subagent prompt runtime", () => {
 		assert.ok(rewritten.includes("Do not print tool-call syntax, patches, or pseudo-tool calls as text."));
 		assert.equal(rewriteSubagentPrompt(rewritten, { inheritProjectContext: true, inheritSkills: true }).indexOf(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS), 0);
 		assert.equal(rewriteSubagentPrompt(rewritten, { inheritProjectContext: true, inheritSkills: true }).lastIndexOf(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS), 0);
+	});
+
+	it("injects a nested-delegation boundary when explicitly allowed", () => {
+		process.env.PI_SUBAGENT_ALLOW_NESTED = "1";
+		const rewritten = rewriteSubagentPrompt(BASE_PROMPT, {
+			inheritProjectContext: true,
+			inheritSkills: true,
+		});
+
+		assert.ok(rewritten.startsWith(CHILD_SUBAGENT_NESTED_DELEGATION_INSTRUCTIONS));
+		assert.ok(rewritten.includes("You may use the subagent tool only for bounded child work"));
+		assert.ok(!rewritten.includes("Do not propose or run subagents."));
+		assert.equal(rewriteSubagentPrompt(rewritten, { inheritProjectContext: true, inheritSkills: true }).indexOf(CHILD_SUBAGENT_NESTED_DELEGATION_INSTRUCTIONS), 0);
+		assert.equal(rewriteSubagentPrompt(rewritten, { inheritProjectContext: true, inheritSkills: true }).lastIndexOf(CHILD_SUBAGENT_NESTED_DELEGATION_INSTRUCTIONS), 0);
 	});
 
 	it("keeps explicitly injected skill content when inherited skills are stripped", () => {


### PR DESCRIPTION
## Summary\n- restore opt-in nested delegation for child agents that explicitly include `subagent` in their tools allowlist\n- keep normal child sessions non-orchestrating by default\n- adjust child prompt boundaries and docs to distinguish safe child mode from explicit nested delegation\n- add unit coverage for nested-delegation env wiring and prompt rewriting\n\n## Why\nThe docs/changelog describe bounded recursion (main → subagent → sub-subagent), but current child-mode registration unconditionally returns when `PI_SUBAGENT_CHILD=1`, so even explicitly configured manager-like agents cannot delegate. This makes `maxSubagentDepth` ineffective for real nested delegation.\n\n## Validation\n- PASS: `node --experimental-strip-types --test test/unit/pi-args.test.ts test/unit/subagent-prompt-runtime.test.ts`\n- PARTIAL: `npm test` currently fails in this local clone on unrelated existing environment/flaky issues:\n  - packaged planner/worker/oracle defaultContext assertion\n  - post-exit stdio guard clean-exit timing\n  - index-child-registration tests cannot resolve peer package `@mariozechner/pi-coding-agent/index.js` in this temp clone\n