### PR TITLE
feat: scope subagent runtime storage paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,7 +806,27 @@ Forces depth-0 single, parallel, and chain runs into background mode and bypasse
 { "defaultSessionDir": "~/.pi/agent/sessions/subagent/" }
 ```
 
-Session directory precedence is: `params.sessionDir`, then `config.defaultSessionDir`, then a directory derived from the parent session. Sessions are always enabled.
+Session directory precedence is: `params.sessionDir`, then an agent frontmatter `defaultSessionDir`, then `subagents.agentDefaults.<agent>.defaultSessionDir`, then project/global `config.defaultSessionDir`, then a directory derived from the parent session. Sessions are always enabled.
+
+Project-local runtime config can live in `.pi/settings.json`:
+
+```json
+{
+  "subagents": {
+    "defaultSessionDir": ".pi/subagents/sessions",
+    "worktreeRoot": ".pi/subagents/worktrees",
+    "agentDefaults": {
+      "worker": {
+        "defaultSessionDir": ".pi/subagents/sessions/{agent}",
+        "worktreeRoot": ".pi/subagents/worktrees/{agent}",
+        "keepWorktrees": true
+      }
+    }
+  }
+}
+```
+
+Supported path template variables are `{projectRoot}`, `{cwd}`, `{agent}`, `{runId}`, and `{index}`. Relative paths resolve from the nearest project root (`.pi/` or `.agents/`) when available, otherwise from the request cwd.
 
 ### `maxSubagentDepth`
 
@@ -838,14 +858,18 @@ Bridge activation also requires `pi-intercom` to be installed and enabled throug
 
 The default injected guidance tells children to use `contact_supervisor` with `reason: "need_decision"` when blocked or needing a decision, `reason: "progress_update"` only for meaningful blocked/progress updates, generic `intercom` as fallback plumbing, and avoid routine completion handoffs.
 
-### `worktreeSetupHook`
+### `worktreeRoot`, `worktreeSetupHook`, and `keepWorktrees`
 
 ```json
 {
+  "worktreeRoot": ".pi/subagents/worktrees",
   "worktreeSetupHook": "./scripts/setup-worktree.mjs",
-  "worktreeSetupHookTimeoutMs": 45000
+  "worktreeSetupHookTimeoutMs": 45000,
+  "keepWorktrees": true
 }
 ```
+
+`worktreeRoot` changes where `worktree: true` creates temporary worktrees. Without it, worktrees still use the OS temp directory. `keepWorktrees` leaves created worktrees in place after diff capture so humans can inspect them directly. These fields can be configured globally, project-wide in `.pi/settings.json`, per-agent through `subagents.agentDefaults.<agent>`, or directly in agent frontmatter. More specific config wins.
 
 The hook runs once per created worktree. Paths must be absolute, `~/...`, or repo-relative; bare command names are rejected.
 

--- a/README.md
+++ b/README.md
@@ -817,8 +817,8 @@ Project-local runtime config can live in `.pi/settings.json`:
     "worktreeRoot": ".pi/subagents/worktrees",
     "agentDefaults": {
       "worker": {
-        "defaultSessionDir": ".pi/subagents/sessions/{agent}/{model}",
-        "worktreeRoot": ".pi/subagents/worktrees/{agent}/{model}",
+        "defaultSessionDir": ".pi/subagents/sessions/{agent}/{provider}/{model}",
+        "worktreeRoot": ".pi/subagents/worktrees/{agent}/{provider}/{model}",
         "keepWorktrees": true
       }
     }
@@ -826,7 +826,7 @@ Project-local runtime config can live in `.pi/settings.json`:
 }
 ```
 
-Supported path template variables are `{projectRoot}`, `{cwd}`, `{agent}`, `{model}`, `{runId}`, and `{index}`. Relative paths resolve from the nearest project root (`.pi/` or `.agents/`) when available, otherwise from the request cwd. `{agent}` and `{model}` are sanitized as path segments, so provider/model IDs such as `openai/gpt-5.5` become `openai__gpt-5.5`.
+Supported path template variables are `{projectRoot}`, `{cwd}`, `{agent}`, `{provider}`, `{model}`, `{runId}`, and `{index}`. Relative paths resolve from the nearest project root (`.pi/` or `.agents/`) when available, otherwise from the request cwd. `{provider}` and `{model}` can split provider/model IDs such as `openai/gpt-5.5` into `openai/gpt-5.5`; only path separators and NUL bytes inside a single segment are escaped.
 
 ### `maxSubagentDepth`
 

--- a/README.md
+++ b/README.md
@@ -817,8 +817,8 @@ Project-local runtime config can live in `.pi/settings.json`:
     "worktreeRoot": ".pi/subagents/worktrees",
     "agentDefaults": {
       "worker": {
-        "defaultSessionDir": ".pi/subagents/sessions/{agent}",
-        "worktreeRoot": ".pi/subagents/worktrees/{agent}",
+        "defaultSessionDir": ".pi/subagents/sessions/{agent}/{model}",
+        "worktreeRoot": ".pi/subagents/worktrees/{agent}/{model}",
         "keepWorktrees": true
       }
     }
@@ -826,7 +826,7 @@ Project-local runtime config can live in `.pi/settings.json`:
 }
 ```
 
-Supported path template variables are `{projectRoot}`, `{cwd}`, `{agent}`, `{runId}`, and `{index}`. Relative paths resolve from the nearest project root (`.pi/` or `.agents/`) when available, otherwise from the request cwd.
+Supported path template variables are `{projectRoot}`, `{cwd}`, `{agent}`, `{model}`, `{runId}`, and `{index}`. Relative paths resolve from the nearest project root (`.pi/` or `.agents/`) when available, otherwise from the request cwd. `{agent}` and `{model}` are sanitized as path segments, so provider/model IDs such as `openai/gpt-5.5` become `openai__gpt-5.5`.
 
 ### `maxSubagentDepth`
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -185,8 +185,8 @@ Scoped runtime config example:
     "worktreeRoot": ".pi/subagents/worktrees",
     "agentDefaults": {
       "worker": {
-        "defaultSessionDir": ".pi/subagents/sessions/{agent}/{model}",
-        "worktreeRoot": ".pi/subagents/worktrees/{agent}/{model}",
+        "defaultSessionDir": ".pi/subagents/sessions/{agent}/{provider}/{model}",
+        "worktreeRoot": ".pi/subagents/worktrees/{agent}/{provider}/{model}",
         "keepWorktrees": true
       }
     }
@@ -199,9 +199,9 @@ Session directory precedence is: run `sessionDir`, agent frontmatter
 project/global `defaultSessionDir`, then the parent-session-derived fallback.
 Worktree runtime precedence is: agent frontmatter, `agentDefaults.<agent>`,
 project/global config, then built-in defaults. Supported path template variables
-are `{projectRoot}`, `{cwd}`, `{agent}`, `{model}`, `{runId}`, and `{index}`. Relative paths
+are `{projectRoot}`, `{cwd}`, `{agent}`, `{provider}`, `{model}`, `{runId}`, and `{index}`. Relative paths
 resolve from the nearest project root (`.pi/` or `.agents/`) when available,
-otherwise from the request cwd. `{agent}` and `{model}` are sanitized as path segments, so provider/model IDs such as `openai/gpt-5.5` become `openai__gpt-5.5`.
+otherwise from the request cwd. `{provider}` and `{model}` can split provider/model IDs such as `openai/gpt-5.5` into `openai/gpt-5.5`; only path separators and NUL bytes inside a single segment are escaped.
 
 ## Discovery and Scope Rules
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -170,8 +170,38 @@ Direct settings example:
 
 Useful override fields: `model`, `fallbackModels`, `thinking`,
 `systemPromptMode`, `inheritProjectContext`, `inheritSkills`, `defaultContext`,
-`disabled`, `skills`, `tools`, and `systemPrompt`. Create a user or project
+`disabled`, `skills`, `tools`, and `systemPrompt`. Runtime path fields can also
+be scoped globally, project-wide, per agent, or in agent frontmatter:
+`defaultSessionDir`, `worktreeRoot`, `worktreeSetupHook`,
+`worktreeSetupHookTimeoutMs`, and `keepWorktrees`. Create a user or project
 agent with the same name only when you want a substantially different agent.
+
+Scoped runtime config example:
+
+```json
+{
+  "subagents": {
+    "defaultSessionDir": ".pi/subagents/sessions",
+    "worktreeRoot": ".pi/subagents/worktrees",
+    "agentDefaults": {
+      "worker": {
+        "defaultSessionDir": ".pi/subagents/sessions/{agent}",
+        "worktreeRoot": ".pi/subagents/worktrees/{agent}",
+        "keepWorktrees": true
+      }
+    }
+  }
+}
+```
+
+Session directory precedence is: run `sessionDir`, agent frontmatter
+`defaultSessionDir`, `subagents.agentDefaults.<agent>.defaultSessionDir`,
+project/global `defaultSessionDir`, then the parent-session-derived fallback.
+Worktree runtime precedence is: agent frontmatter, `agentDefaults.<agent>`,
+project/global config, then built-in defaults. Supported path template variables
+are `{projectRoot}`, `{cwd}`, `{agent}`, `{runId}`, and `{index}`. Relative paths
+resolve from the nearest project root (`.pi/` or `.agents/`) when available,
+otherwise from the request cwd.
 
 ## Discovery and Scope Rules
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -185,8 +185,8 @@ Scoped runtime config example:
     "worktreeRoot": ".pi/subagents/worktrees",
     "agentDefaults": {
       "worker": {
-        "defaultSessionDir": ".pi/subagents/sessions/{agent}",
-        "worktreeRoot": ".pi/subagents/worktrees/{agent}",
+        "defaultSessionDir": ".pi/subagents/sessions/{agent}/{model}",
+        "worktreeRoot": ".pi/subagents/worktrees/{agent}/{model}",
         "keepWorktrees": true
       }
     }
@@ -199,9 +199,9 @@ Session directory precedence is: run `sessionDir`, agent frontmatter
 project/global `defaultSessionDir`, then the parent-session-derived fallback.
 Worktree runtime precedence is: agent frontmatter, `agentDefaults.<agent>`,
 project/global config, then built-in defaults. Supported path template variables
-are `{projectRoot}`, `{cwd}`, `{agent}`, `{runId}`, and `{index}`. Relative paths
+are `{projectRoot}`, `{cwd}`, `{agent}`, `{model}`, `{runId}`, and `{index}`. Relative paths
 resolve from the nearest project root (`.pi/` or `.agents/`) when available,
-otherwise from the request cwd.
+otherwise from the request cwd. `{agent}` and `{model}` are sanitized as path segments, so provider/model IDs such as `openai/gpt-5.5` become `openai__gpt-5.5`.
 
 ## Discovery and Scope Rules
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -291,6 +291,22 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 		if (typeof cfg.progress !== "boolean") return "config.progress must be a boolean when provided.";
 		target.defaultProgress = cfg.progress;
 	}
+	for (const key of ["defaultSessionDir", "worktreeRoot", "worktreeSetupHook"] as const) {
+		if (!hasKey(cfg, key)) continue;
+		if (cfg[key] === false || cfg[key] === "") target[key] = undefined;
+		else if (typeof cfg[key] === "string") target[key] = cfg[key] as string;
+		else return `config.${key} must be a string or false when provided.`;
+	}
+	if (hasKey(cfg, "worktreeSetupHookTimeoutMs")) {
+		if (cfg.worktreeSetupHookTimeoutMs === false || cfg.worktreeSetupHookTimeoutMs === "") target.worktreeSetupHookTimeoutMs = undefined;
+		else if (typeof cfg.worktreeSetupHookTimeoutMs === "number" && Number.isInteger(cfg.worktreeSetupHookTimeoutMs) && cfg.worktreeSetupHookTimeoutMs > 0) {
+			target.worktreeSetupHookTimeoutMs = cfg.worktreeSetupHookTimeoutMs;
+		} else return "config.worktreeSetupHookTimeoutMs must be an integer > 0 or false when provided.";
+	}
+	if (hasKey(cfg, "keepWorktrees")) {
+		if (typeof cfg.keepWorktrees !== "boolean") return "config.keepWorktrees must be a boolean when provided.";
+		target.keepWorktrees = cfg.keepWorktrees;
+	}
 	if (hasKey(cfg, "maxSubagentDepth")) {
 		if (cfg.maxSubagentDepth === false || cfg.maxSubagentDepth === "") target.maxSubagentDepth = undefined;
 		else if (typeof cfg.maxSubagentDepth === "number" && Number.isInteger(cfg.maxSubagentDepth) && cfg.maxSubagentDepth >= 0) {
@@ -365,6 +381,11 @@ function formatAgentDetail(agent: AgentConfig): string {
 	if (agent.output) lines.push(`Output: ${agent.output}`);
 	if (agent.defaultReads?.length) lines.push(`Reads: ${agent.defaultReads.join(", ")}`);
 	if (agent.defaultProgress) lines.push("Progress: true");
+	if (agent.defaultSessionDir) lines.push(`Default session dir: ${agent.defaultSessionDir}`);
+	if (agent.worktreeRoot) lines.push(`Worktree root: ${agent.worktreeRoot}`);
+	if (agent.worktreeSetupHook) lines.push(`Worktree setup hook: ${agent.worktreeSetupHook}`);
+	if (agent.worktreeSetupHookTimeoutMs !== undefined) lines.push(`Worktree setup hook timeout: ${agent.worktreeSetupHookTimeoutMs}ms`);
+	if (agent.keepWorktrees) lines.push("Keep worktrees: true");
 	if (agent.maxSubagentDepth !== undefined) lines.push(`Max subagent depth: ${agent.maxSubagentDepth}`);
 	if (agent.systemPrompt.trim()) lines.push("", "System Prompt:", agent.systemPrompt);
 	return lines.join("\n");

--- a/src/agents/agent-serializer.ts
+++ b/src/agents/agent-serializer.ts
@@ -19,6 +19,11 @@ export const KNOWN_FIELDS = new Set([
 	"output",
 	"defaultReads",
 	"defaultProgress",
+	"defaultSessionDir",
+	"worktreeRoot",
+	"worktreeSetupHook",
+	"worktreeSetupHookTimeoutMs",
+	"keepWorktrees",
 	"interactive",
 	"maxSubagentDepth",
 ]);
@@ -65,6 +70,13 @@ export function serializeAgent(config: AgentConfig): string {
 	if (readsValue) lines.push(`defaultReads: ${readsValue}`);
 
 	if (config.defaultProgress) lines.push("defaultProgress: true");
+	if (config.defaultSessionDir) lines.push(`defaultSessionDir: ${config.defaultSessionDir}`);
+	if (config.worktreeRoot) lines.push(`worktreeRoot: ${config.worktreeRoot}`);
+	if (config.worktreeSetupHook) lines.push(`worktreeSetupHook: ${config.worktreeSetupHook}`);
+	if (Number.isInteger(config.worktreeSetupHookTimeoutMs) && config.worktreeSetupHookTimeoutMs! > 0) {
+		lines.push(`worktreeSetupHookTimeoutMs: ${config.worktreeSetupHookTimeoutMs}`);
+	}
+	if (config.keepWorktrees) lines.push("keepWorktrees: true");
 	if (config.interactive) lines.push("interactive: true");
 	if (Number.isInteger(config.maxSubagentDepth) && config.maxSubagentDepth >= 0) {
 		lines.push(`maxSubagentDepth: ${config.maxSubagentDepth}`);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -635,6 +635,9 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 		}
 
 		const parsedMaxSubagentDepth = Number(frontmatter.maxSubagentDepth);
+		const keepWorktrees = frontmatter.keepWorktrees === undefined
+			? undefined
+			: frontmatter.keepWorktrees === "true";
 
 		agents.push({
 			name: runtimeName,
@@ -664,7 +667,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			worktreeSetupHookTimeoutMs: Number.isInteger(Number(frontmatter.worktreeSetupHookTimeoutMs)) && Number(frontmatter.worktreeSetupHookTimeoutMs) > 0
 				? Number(frontmatter.worktreeSetupHookTimeoutMs)
 				: undefined,
-			keepWorktrees: frontmatter.keepWorktrees === "true",
+			keepWorktrees,
 			interactive: frontmatter.interactive === "true",
 			maxSubagentDepth:
 				Number.isInteger(parsedMaxSubagentDepth) && parsedMaxSubagentDepth >= 0

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -88,7 +88,12 @@ export interface AgentConfig {
 	extensions?: string[];
 	output?: string;
 	defaultReads?: string[];
-	defaultProgress?: boolean;
+	defaultProgress?: boolean;	
+	defaultSessionDir?: string;
+	worktreeRoot?: string;
+	worktreeSetupHook?: string;
+	worktreeSetupHookTimeoutMs?: number;
+	keepWorktrees?: boolean;
 	interactive?: boolean;
 	maxSubagentDepth?: number;
 	disabled?: boolean;
@@ -653,6 +658,13 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			output: frontmatter.output,
 			defaultReads: defaultReads && defaultReads.length > 0 ? defaultReads : undefined,
 			defaultProgress: frontmatter.defaultProgress === "true",
+			defaultSessionDir: frontmatter.defaultSessionDir,
+			worktreeRoot: frontmatter.worktreeRoot,
+			worktreeSetupHook: frontmatter.worktreeSetupHook,
+			worktreeSetupHookTimeoutMs: Number.isInteger(Number(frontmatter.worktreeSetupHookTimeoutMs)) && Number(frontmatter.worktreeSetupHookTimeoutMs) > 0
+				? Number(frontmatter.worktreeSetupHookTimeoutMs)
+				: undefined,
+			keepWorktrees: frontmatter.keepWorktrees === "true",
 			interactive: frontmatter.interactive === "true",
 			maxSubagentDepth:
 				Number.isInteger(parsedMaxSubagentDepth) && parsedMaxSubagentDepth >= 0

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -312,7 +312,7 @@ export function executeAsyncChain(
 			maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, a.maxSubagentDepth),
 			worktreeRoot: runtime.worktreeRoot,
 			worktreeSetupHook: runtime.worktreeSetupHook
-				? expandRuntimePath(runtime.worktreeSetupHook, { cwd: runnerCwd, baseDir: params.projectBaseDir, agent: s.agent })
+				? expandRuntimePath(runtime.worktreeSetupHook, { cwd: runnerCwd, baseDir: params.projectBaseDir, agent: s.agent, model: primaryModel })
 				: undefined,
 			worktreeSetupHookTimeoutMs: runtime.worktreeSetupHookTimeoutMs,
 			keepWorktrees: runtime.keepWorktrees,
@@ -346,8 +346,9 @@ export function executeAsyncChain(
 							try {
 								const agent = agents.find((candidate) => candidate.name === t.agent);
 								const runtime = resolveAgentRuntimeConfig(params.runtimeConfig ?? {}, t.agent, agent);
+								const model = resolveModelCandidate(parallelBehaviors[taskIndex]?.model ?? agent?.model, availableModels, ctx.currentModelProvider);
 								const worktreeRoot = runtime.worktreeRoot
-									? expandRuntimePath(runtime.worktreeRoot, { cwd: runnerCwd, baseDir: params.projectBaseDir, agent: t.agent, runId: `${id}-s${stepIndex}`, index: taskIndex })
+									? expandRuntimePath(runtime.worktreeRoot, { cwd: runnerCwd, baseDir: params.projectBaseDir, agent: t.agent, model, runId: `${id}-s${stepIndex}`, index: taskIndex })
 									: undefined;
 								behaviorCwd = resolveExpectedWorktreeAgentCwd(runnerCwd, `${id}-s${stepIndex}`, taskIndex, worktreeRoot);
 							} catch {
@@ -356,7 +357,7 @@ export function executeAsyncChain(
 						}
 						const step = buildSeqStep(t, nextSessionFile(), behaviorCwd, progressPrecreated, parallelBehaviors[taskIndex]);
 						if (step.worktreeRoot) {
-							step.worktreeRoot = expandRuntimePath(step.worktreeRoot, { cwd: runnerCwd, baseDir: params.projectBaseDir, agent: t.agent, runId: `${id}-s${stepIndex}`, index: taskIndex });
+							step.worktreeRoot = expandRuntimePath(step.worktreeRoot, { cwd: runnerCwd, baseDir: params.projectBaseDir, agent: t.agent, model: step.model, runId: `${id}-s${stepIndex}`, index: taskIndex });
 						}
 						return step;
 					}),

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -18,10 +18,12 @@ import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../../agents/skills.ts";
 import { resolveChildCwd } from "../../shared/utils.ts";
 import { buildModelCandidates, resolveModelCandidate, type AvailableModelInfo } from "../shared/model-fallback.ts";
+import { expandRuntimePath, resolveAgentRuntimeConfig } from "../../shared/scoped-runtime-config.ts";
 import { resolveExpectedWorktreeAgentCwd } from "../shared/worktree.ts";
 import {
 	type ArtifactConfig,
 	type Details,
+	type ExtensionConfig,
 	type MaxOutputConfig,
 	type ResolvedControlConfig,
 	type SubagentRunMode,
@@ -81,6 +83,8 @@ interface AsyncChainParams {
 	maxSubagentDepth: number;
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
+	runtimeConfig?: ExtensionConfig;
+	projectBaseDir?: string;
 	controlConfig?: ResolvedControlConfig;
 	controlIntercomTarget?: string;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
@@ -106,6 +110,8 @@ interface AsyncSingleParams {
 	maxSubagentDepth: number;
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
+	runtimeConfig?: ExtensionConfig;
+	projectBaseDir?: string;
 	controlConfig?: ResolvedControlConfig;
 	controlIntercomTarget?: string;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
@@ -260,6 +266,7 @@ export function executeAsyncChain(
 	};
 	const buildSeqStep = (s: SequentialStep, sessionFile?: string, behaviorCwd?: string, progressPrecreated = false, resolvedBehavior?: ResolvedStepBehavior) => {
 		const a = agents.find((x) => x.name === s.agent)!;
+		const runtime = resolveAgentRuntimeConfig(params.runtimeConfig ?? {}, s.agent, a);
 		const stepCwd = resolveChildCwd(runnerCwd, s.cwd);
 		const instructionCwd = behaviorCwd ?? stepCwd;
 		const behavior = suppressProgressForReadOnlyTask(resolvedBehavior ?? resolveStepBehavior(a, buildStepOverrides(s), chainSkills), s.task, originalTask);
@@ -303,6 +310,12 @@ export function executeAsyncChain(
 			outputMode: behavior.outputMode,
 			sessionFile,
 			maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, a.maxSubagentDepth),
+			worktreeRoot: runtime.worktreeRoot,
+			worktreeSetupHook: runtime.worktreeSetupHook
+				? expandRuntimePath(runtime.worktreeSetupHook, { cwd: runnerCwd, baseDir: params.projectBaseDir, agent: s.agent })
+				: undefined,
+			worktreeSetupHookTimeoutMs: runtime.worktreeSetupHookTimeoutMs,
+			keepWorktrees: runtime.keepWorktrees,
 		};
 	};
 
@@ -331,12 +344,21 @@ export function executeAsyncChain(
 						let behaviorCwd: string | undefined;
 						if (s.worktree) {
 							try {
-								behaviorCwd = resolveExpectedWorktreeAgentCwd(runnerCwd, `${id}-s${stepIndex}`, taskIndex);
+								const agent = agents.find((candidate) => candidate.name === t.agent);
+								const runtime = resolveAgentRuntimeConfig(params.runtimeConfig ?? {}, t.agent, agent);
+								const worktreeRoot = runtime.worktreeRoot
+									? expandRuntimePath(runtime.worktreeRoot, { cwd: runnerCwd, baseDir: params.projectBaseDir, agent: t.agent, runId: `${id}-s${stepIndex}`, index: taskIndex })
+									: undefined;
+								behaviorCwd = resolveExpectedWorktreeAgentCwd(runnerCwd, `${id}-s${stepIndex}`, taskIndex, worktreeRoot);
 							} catch {
 								behaviorCwd = undefined;
 							}
 						}
-						return buildSeqStep(t, nextSessionFile(), behaviorCwd, progressPrecreated, parallelBehaviors[taskIndex]);
+						const step = buildSeqStep(t, nextSessionFile(), behaviorCwd, progressPrecreated, parallelBehaviors[taskIndex]);
+						if (step.worktreeRoot) {
+							step.worktreeRoot = expandRuntimePath(step.worktreeRoot, { cwd: runnerCwd, baseDir: params.projectBaseDir, agent: t.agent, runId: `${id}-s${stepIndex}`, index: taskIndex });
+						}
+						return step;
 					}),
 					concurrency: s.concurrency,
 					failFast: s.failFast,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1248,9 +1248,14 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				try {
 					worktreeSetup = createWorktrees(cwd, `${id}-s${stepIndex}`, group.parallel.length, {
 						agents: group.parallel.map((task) => task.agent),
+						worktreeRoots: group.parallel.map((task) => task.worktreeRoot),
+						setupHooks: group.parallel.map((task) => task.worktreeSetupHook
+							? { hookPath: task.worktreeSetupHook, timeoutMs: task.worktreeSetupHookTimeoutMs }
+							: undefined),
 						setupHook: config.worktreeSetupHook
 							? { hookPath: config.worktreeSetupHook, timeoutMs: config.worktreeSetupHookTimeoutMs }
 							: undefined,
+						keepWorktrees: group.parallel.some((task) => task.keepWorktrees === true),
 					});
 				} catch (error) {
 					const setupError = error instanceof Error ? error.message : String(error);

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -525,15 +525,17 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 						worktreeRoots: step.parallel.map((task, taskIndex) => {
 							const agent = agents.find((candidate) => candidate.name === task.agent);
 							const runtime = resolveAgentRuntimeConfig(runtimeConfig, task.agent, agent);
+							const model = resolveModelCandidate(task.model ?? agent?.model, availableModels, ctx.model?.provider);
 							return runtime.worktreeRoot
-								? expandRuntimePath(runtime.worktreeRoot, { cwd: parallelCwd, baseDir: params.projectBaseDir, agent: task.agent, runId: `${runId}-s${stepIndex}`, index: taskIndex })
+								? expandRuntimePath(runtime.worktreeRoot, { cwd: parallelCwd, baseDir: params.projectBaseDir, agent: task.agent, model, runId: `${runId}-s${stepIndex}`, index: taskIndex })
 								: undefined;
 						}),
-						setupHooks: step.parallel.map((task) => {
+						setupHooks: step.parallel.map((task, taskIndex) => {
 							const agent = agents.find((candidate) => candidate.name === task.agent);
 							const runtime = resolveAgentRuntimeConfig(runtimeConfig, task.agent, agent);
+							const model = resolveModelCandidate(task.model ?? agent?.model, availableModels, ctx.model?.provider);
 							return runtime.worktreeSetupHook
-								? { hookPath: expandRuntimePath(runtime.worktreeSetupHook, { cwd: parallelCwd, baseDir: params.projectBaseDir, agent: task.agent, runId: `${runId}-s${stepIndex}` }), timeoutMs: runtime.worktreeSetupHookTimeoutMs }
+								? { hookPath: expandRuntimePath(runtime.worktreeSetupHook, { cwd: parallelCwd, baseDir: params.projectBaseDir, agent: task.agent, model, runId: `${runId}-s${stepIndex}`, index: taskIndex }), timeoutMs: runtime.worktreeSetupHookTimeoutMs }
 								: undefined;
 						}),
 						setupHook: params.worktreeSetupHook

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -55,9 +55,11 @@ import {
 	type SingleResult,
 	MAX_CONCURRENCY,
 	resolveChildMaxSubagentDepth,
+	type ExtensionConfig,
 } from "../../shared/types.ts";
 import { resolveModelCandidate } from "../shared/model-fallback.ts";
 import { validateFileOnlyOutputMode } from "../shared/single-output.ts";
+import { expandRuntimePath, resolveAgentRuntimeConfig } from "../../shared/scoped-runtime-config.ts";
 
 interface ChainExecutionDetailsInput {
 	results: SingleResult[];
@@ -333,6 +335,8 @@ interface ChainExecutionParams {
 	maxSubagentDepth: number;
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
+	runtimeConfig?: ExtensionConfig;
+	projectBaseDir?: string;
 }
 
 interface ChainExecutionResult {
@@ -515,11 +519,27 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					);
 				}
 				try {
+					const runtimeConfig = params.runtimeConfig ?? {};
 					worktreeSetup = createWorktrees(parallelCwd, `${runId}-s${stepIndex}`, step.parallel.length, {
 						agents: step.parallel.map((task) => task.agent),
+						worktreeRoots: step.parallel.map((task, taskIndex) => {
+							const agent = agents.find((candidate) => candidate.name === task.agent);
+							const runtime = resolveAgentRuntimeConfig(runtimeConfig, task.agent, agent);
+							return runtime.worktreeRoot
+								? expandRuntimePath(runtime.worktreeRoot, { cwd: parallelCwd, baseDir: params.projectBaseDir, agent: task.agent, runId: `${runId}-s${stepIndex}`, index: taskIndex })
+								: undefined;
+						}),
+						setupHooks: step.parallel.map((task) => {
+							const agent = agents.find((candidate) => candidate.name === task.agent);
+							const runtime = resolveAgentRuntimeConfig(runtimeConfig, task.agent, agent);
+							return runtime.worktreeSetupHook
+								? { hookPath: expandRuntimePath(runtime.worktreeSetupHook, { cwd: parallelCwd, baseDir: params.projectBaseDir, agent: task.agent, runId: `${runId}-s${stepIndex}` }), timeoutMs: runtime.worktreeSetupHookTimeoutMs }
+								: undefined;
+						}),
 						setupHook: params.worktreeSetupHook
 							? { hookPath: params.worktreeSetupHook, timeoutMs: params.worktreeSetupHookTimeoutMs }
 							: undefined,
+						keepWorktrees: step.parallel.some((task) => resolveAgentRuntimeConfig(runtimeConfig, task.agent, agents.find((candidate) => candidate.name === task.agent)).keepWorktrees === true),
 					});
 				} catch (error) {
 					const message = error instanceof Error ? error.message : String(error);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -803,6 +803,36 @@ function collectRequestedAgentNames(params: SubagentParamsLike): string[] {
 	return params.agent ? [params.agent] : [];
 }
 
+function currentModelPathName(ctx: ExtensionContext): string | undefined {
+	return ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+}
+
+function collectRequestedModelNames(
+	params: SubagentParamsLike,
+	agents: AgentConfig[],
+	availableModels: ModelInfo[],
+	preferredProvider: string | undefined,
+	currentModel: string | undefined,
+): (string | undefined)[] {
+	const resolve = (agentName: string | undefined, overrideModel: string | undefined) => {
+		const agentConfig = agentName ? agents.find((agent) => agent.name === agentName) : undefined;
+		return resolveModelCandidate(overrideModel ?? agentConfig?.model, availableModels, preferredProvider) ?? currentModel;
+	};
+	if (params.tasks?.length) {
+		return params.tasks.flatMap((task) => Array.from({ length: task.count ?? 1 }, () => resolve(task.agent, task.model)));
+	}
+	if (params.chain?.length) {
+		return params.chain.flatMap((step) => {
+			const chainStep = step as ChainStep;
+			if (isParallelStep(chainStep)) {
+				return chainStep.parallel.map((task) => resolve(task.agent, task.model));
+			}
+			return [resolve(chainStep.agent, chainStep.model)];
+		});
+	}
+	return params.agent ? [resolve(params.agent, params.model as string | undefined)] : [];
+}
+
 function collectChainSessionFiles(
 	chain: ChainStep[],
 	sessionFileForIndex: (idx?: number) => string | undefined,
@@ -1192,7 +1222,8 @@ function createParallelWorktreeSetup(
 	tasks: TaskParam[],
 	agents: AgentConfig[],
 	config: ExtensionConfig,
-	projectBaseDir?: string,
+	projectBaseDir: string | undefined,
+	modelNames: (string | undefined)[] = [],
 ): { setup?: WorktreeSetup; errorResult?: AgentToolResult<Details> } {
 	if (!enabled) return {};
 	try {
@@ -1200,14 +1231,14 @@ function createParallelWorktreeSetup(
 			const agentConfig = agents.find((agent) => agent.name === task.agent);
 			const runtime = resolveAgentRuntimeConfig(config, task.agent, agentConfig);
 			return runtime.worktreeRoot
-				? expandRuntimePath(runtime.worktreeRoot, { cwd, baseDir: projectBaseDir, agent: task.agent, runId, index })
+				? expandRuntimePath(runtime.worktreeRoot, { cwd, baseDir: projectBaseDir, agent: task.agent, model: modelNames[index], runId, index })
 				: undefined;
 		});
-		const setupHooks = tasks.map((task) => {
+		const setupHooks = tasks.map((task, index) => {
 			const agentConfig = agents.find((agent) => agent.name === task.agent);
 			const runtime = resolveAgentRuntimeConfig(config, task.agent, agentConfig);
 			return runtime.worktreeSetupHook
-				? { hookPath: expandRuntimePath(runtime.worktreeSetupHook, { cwd, baseDir: projectBaseDir, agent: task.agent, runId }), timeoutMs: runtime.worktreeSetupHookTimeoutMs }
+				? { hookPath: expandRuntimePath(runtime.worktreeSetupHook, { cwd, baseDir: projectBaseDir, agent: task.agent, model: modelNames[index], runId, index }), timeoutMs: runtime.worktreeSetupHookTimeoutMs }
 				: undefined;
 		});
 		return {
@@ -1575,6 +1606,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		agents,
 		deps.config,
 		data.projectBaseDir,
+		modelOverrides.map((model) => model ?? currentModelPathName(ctx)),
 	);
 	if (errorResult) return errorResult;
 
@@ -2178,13 +2210,17 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			enabled: effectiveParams.artifacts !== false,
 		};
 
+		const availableModelsForRuntimePaths: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
+		const currentProviderForRuntimePaths = ctx.model?.provider;
+		const currentModelForRuntimePaths = currentModelPathName(ctx);
+
 		let sessionRoot: string;
 		if (effectiveParams.sessionDir) {
 			sessionRoot = path.resolve(deps.expandTilde(effectiveParams.sessionDir));
 		} else {
 			const baseSessionDir = runtimeConfig.defaultSessionDir;
 			const baseSessionRoot = baseSessionDir
-				? expandRuntimePath(baseSessionDir, { cwd: requestCwd, baseDir: projectRuntime.baseDir, runId })
+				? expandRuntimePath(baseSessionDir, { cwd: requestCwd, baseDir: projectRuntime.baseDir, model: currentModelForRuntimePaths, runId })
 				: deps.getSubagentSessionRoot(parentSessionFile);
 			sessionRoot = path.join(baseSessionRoot, runId);
 		}
@@ -2199,6 +2235,13 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		}
 		const artifactsDir = effectiveAsync ? deps.tempArtifactsDir : path.join(sessionRoot, "subagent-artifacts");
 		const requestedAgentNames = collectRequestedAgentNames(effectiveParams);
+		const requestedModelNames = collectRequestedModelNames(
+			effectiveParams,
+			agents,
+			availableModelsForRuntimePaths,
+			currentProviderForRuntimePaths,
+			currentModelForRuntimePaths,
+		);
 		const sessionDirForIndex = (idx?: number) => {
 			const index = idx ?? 0;
 			const agentName = requestedAgentNames[index];
@@ -2209,6 +2252,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					cwd: requestCwd,
 					baseDir: projectRuntime.baseDir,
 					agent: agentName,
+					model: requestedModelNames[index],
 					runId,
 					index,
 				});

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4,7 +4,6 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { type AgentConfig, type AgentScope } from "../../agents/agents.ts";
-import { getArtifactsDir } from "../../shared/artifacts.ts";
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
 import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import { executeChain } from "./chain-execution.ts";
@@ -37,6 +36,7 @@ import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBrid
 import { formatControlIntercomMessage, formatControlNoticeMessage, resolveControlConfig, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
 import { finalizeSingleOutput, injectSingleOutputInstruction, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, readStatus, resolveChildCwd } from "../../shared/utils.ts";
+import { expandRuntimePath, mergeRuntimeConfig, readProjectRuntimeConfig, resolveAgentRuntimeConfig } from "../../shared/scoped-runtime-config.ts";
 import {
 	buildSubagentResultIntercomPayload,
 	deliverSubagentIntercomMessageEvent,
@@ -158,6 +158,7 @@ interface ExecutionContextData {
 	effectiveAsync: boolean;
 	controlConfig: ResolvedControlConfig;
 	intercomBridge: IntercomBridgeState;
+	projectBaseDir?: string;
 }
 
 function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefined): string {
@@ -796,6 +797,12 @@ function toExecutionErrorResult(params: SubagentParamsLike, error: unknown): Age
 	);
 }
 
+function collectRequestedAgentNames(params: SubagentParamsLike): string[] {
+	if (params.tasks?.length) return params.tasks.flatMap((task) => Array.from({ length: task.count ?? 1 }, () => task.agent));
+	if (params.chain?.length) return params.chain.flatMap((step) => getStepAgents(step as ChainStep));
+	return params.agent ? [params.agent] : [];
+}
+
 function collectChainSessionFiles(
 	chain: ChainStep[],
 	sessionFileForIndex: (idx?: number) => string | undefined,
@@ -936,6 +943,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			maxSubagentDepth: currentMaxSubagentDepth,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
+			runtimeConfig: deps.config,
+			projectBaseDir: data.projectBaseDir,
 			controlConfig,
 			controlIntercomTarget,
 			childIntercomTarget,
@@ -963,6 +972,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			maxSubagentDepth: currentMaxSubagentDepth,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
+			runtimeConfig: deps.config,
+			projectBaseDir: data.projectBaseDir,
 			controlConfig,
 			controlIntercomTarget,
 			childIntercomTarget,
@@ -1005,6 +1016,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			maxSubagentDepth,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
+			runtimeConfig: deps.config,
+			projectBaseDir: data.projectBaseDir,
 			controlConfig,
 			controlIntercomTarget,
 			childIntercomTarget: childIntercomTarget ? (agent, index) => childIntercomTarget(agent, index) : undefined,
@@ -1065,6 +1078,8 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		maxSubagentDepth: currentMaxSubagentDepth,
 		worktreeSetupHook: deps.config.worktreeSetupHook,
 		worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
+		runtimeConfig: deps.config,
+		projectBaseDir: data.projectBaseDir,
 	});
 
 	if (chainResult.requestedAsync) {
@@ -1100,6 +1115,8 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			maxSubagentDepth: currentMaxSubagentDepth,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
+			runtimeConfig: deps.config,
+			projectBaseDir: data.projectBaseDir,
 			controlConfig,
 			controlIntercomTarget: data.intercomBridge.active ? data.intercomBridge.orchestratorTarget : undefined,
 			childIntercomTarget: data.intercomBridge.active ? (agent, index) => resolveSubagentIntercomTarget(id, agent, index) : undefined,
@@ -1173,17 +1190,32 @@ function createParallelWorktreeSetup(
 	cwd: string,
 	runId: string,
 	tasks: TaskParam[],
-	setupHook: ExtensionConfig["worktreeSetupHook"],
-	setupHookTimeoutMs: ExtensionConfig["worktreeSetupHookTimeoutMs"],
+	agents: AgentConfig[],
+	config: ExtensionConfig,
+	projectBaseDir?: string,
 ): { setup?: WorktreeSetup; errorResult?: AgentToolResult<Details> } {
 	if (!enabled) return {};
 	try {
+		const worktreeRoots = tasks.map((task, index) => {
+			const agentConfig = agents.find((agent) => agent.name === task.agent);
+			const runtime = resolveAgentRuntimeConfig(config, task.agent, agentConfig);
+			return runtime.worktreeRoot
+				? expandRuntimePath(runtime.worktreeRoot, { cwd, baseDir: projectBaseDir, agent: task.agent, runId, index })
+				: undefined;
+		});
+		const setupHooks = tasks.map((task) => {
+			const agentConfig = agents.find((agent) => agent.name === task.agent);
+			const runtime = resolveAgentRuntimeConfig(config, task.agent, agentConfig);
+			return runtime.worktreeSetupHook
+				? { hookPath: expandRuntimePath(runtime.worktreeSetupHook, { cwd, baseDir: projectBaseDir, agent: task.agent, runId }), timeoutMs: runtime.worktreeSetupHookTimeoutMs }
+				: undefined;
+		});
 		return {
 			setup: createWorktrees(cwd, runId, tasks.length, {
 				agents: tasks.map((task) => task.agent),
-				setupHook: setupHook
-					? { hookPath: setupHook, timeoutMs: setupHookTimeoutMs }
-					: undefined,
+				worktreeRoots,
+				setupHooks,
+				keepWorktrees: tasks.some((task) => resolveAgentRuntimeConfig(config, task.agent, agents.find((agent) => agent.name === task.agent)).keepWorktrees === true),
 			}),
 		};
 	} catch (error) {
@@ -1540,8 +1572,9 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		effectiveCwd,
 		runId,
 		tasks,
-		deps.config.worktreeSetupHook,
-		deps.config.worktreeSetupHookTimeoutMs,
+		agents,
+		deps.config,
+		data.projectBaseDir,
 	);
 	if (errorResult) return errorResult;
 
@@ -1978,6 +2011,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		deps.state.lastForegroundControlId ??= null;
 		const requestCwd = resolveRequestedCwd(ctx.cwd, params.cwd);
 		const paramsWithResolvedCwd = params.cwd === undefined ? params : { ...params, cwd: requestCwd };
+		let projectRuntime;
+		try {
+			projectRuntime = readProjectRuntimeConfig(requestCwd);
+		} catch (error) {
+			return toExecutionErrorResult(paramsWithResolvedCwd, error);
+		}
+		const runtimeConfig = mergeRuntimeConfig(deps.config, projectRuntime.config);
+		const runtimeDeps: ExecutorDeps = { ...deps, config: runtimeConfig };
 		if (params.action) {
 			if (params.action === "doctor") {
 				let currentSessionFile: string | null = null;
@@ -1998,7 +2039,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						type: "text",
 						text: buildDoctorReport({
 							cwd: requestCwd,
-							config: deps.config,
+							config: runtimeConfig,
 							state: deps.state,
 							context: paramsWithResolvedCwd.context,
 							requestedSessionDir: paramsWithResolvedCwd.sessionDir,
@@ -2018,7 +2059,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				return inspectSubagentStatus(paramsWithResolvedCwd);
 			}
 			if (params.action === "resume") {
-				return resumeAsyncRun({ params: paramsWithResolvedCwd, requestCwd, ctx, deps });
+				return resumeAsyncRun({ params: paramsWithResolvedCwd, requestCwd, ctx, deps: runtimeDeps });
 			}
 			if (params.action === "interrupt") {
 				const targetRunId = paramsWithResolvedCwd.runId ?? paramsWithResolvedCwd.id;
@@ -2057,7 +2098,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return handleManagementAction(params.action, paramsWithResolvedCwd, { ...ctx, cwd: requestCwd });
 		}
 
-		const { blocked, depth, maxDepth } = checkSubagentDepth(deps.config.maxSubagentDepth);
+		const { blocked, depth, maxDepth } = checkSubagentDepth(runtimeConfig.maxSubagentDepth);
 		if (blocked) {
 			return {
 				content: [
@@ -2081,7 +2122,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		let effectiveParams = applyForceTopLevelAsyncOverride(
 			normalizedParams,
 			depth,
-			deps.config.forceTopLevelAsync === true,
+			runtimeConfig.forceTopLevelAsync === true,
 		);
 
 		const scope: AgentScope = resolveExecutionAgentScope(effectiveParams.agentScope);
@@ -2092,7 +2133,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		effectiveParams = applyAgentDefaultContext(effectiveParams, discoveredAgents);
 		const sessionName = resolveIntercomSessionTarget(deps.pi.getSessionName(), ctx.sessionManager.getSessionId());
 		const intercomBridge = resolveIntercomBridge({
-			config: deps.config.intercomBridge,
+			config: runtimeConfig.intercomBridge,
 			context: effectiveParams.context,
 			orchestratorTarget: sessionName,
 			cwd: effectiveCwd,
@@ -2126,24 +2167,24 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		} catch (error) {
 			return toExecutionErrorResult(effectiveParams, error);
 		}
-		const requestedAsync = effectiveParams.async ?? deps.asyncByDefault;
+		const requestedAsync = effectiveParams.async ?? (runtimeConfig.asyncByDefault === true);
 		const backgroundRequestedWhileClarifying = hasTasks && requestedAsync && effectiveParams.clarify === true;
 		const effectiveAsync = requestedAsync
 			&& (hasChain ? effectiveParams.clarify === false : effectiveParams.clarify !== true);
-		const controlConfig = resolveControlConfig(deps.config.control, effectiveParams.control);
+		const controlConfig = resolveControlConfig(runtimeConfig.control, effectiveParams.control);
 
 		const artifactConfig: ArtifactConfig = {
 			...DEFAULT_ARTIFACT_CONFIG,
 			enabled: effectiveParams.artifacts !== false,
 		};
-		const artifactsDir = effectiveAsync ? deps.tempArtifactsDir : getArtifactsDir(parentSessionFile);
 
 		let sessionRoot: string;
 		if (effectiveParams.sessionDir) {
 			sessionRoot = path.resolve(deps.expandTilde(effectiveParams.sessionDir));
 		} else {
-			const baseSessionRoot = deps.config.defaultSessionDir
-				? path.resolve(deps.expandTilde(deps.config.defaultSessionDir))
+			const baseSessionDir = runtimeConfig.defaultSessionDir;
+			const baseSessionRoot = baseSessionDir
+				? expandRuntimePath(baseSessionDir, { cwd: requestCwd, baseDir: projectRuntime.baseDir, runId })
 				: deps.getSubagentSessionRoot(parentSessionFile);
 			sessionRoot = path.join(baseSessionRoot, runId);
 		}
@@ -2156,8 +2197,25 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				new Error(`Failed to create session directory '${sessionRoot}': ${message}`),
 			);
 		}
-		const sessionDirForIndex = (idx?: number) =>
-			path.join(sessionRoot, `run-${idx ?? 0}`);
+		const artifactsDir = effectiveAsync ? deps.tempArtifactsDir : path.join(sessionRoot, "subagent-artifacts");
+		const requestedAgentNames = collectRequestedAgentNames(effectiveParams);
+		const sessionDirForIndex = (idx?: number) => {
+			const index = idx ?? 0;
+			const agentName = requestedAgentNames[index];
+			const agentConfig = agentName ? agents.find((agent) => agent.name === agentName) : undefined;
+			const agentRuntime = resolveAgentRuntimeConfig(runtimeConfig, agentName, agentConfig);
+			if (!effectiveParams.sessionDir && agentRuntime.defaultSessionDir) {
+				const agentSessionRoot = expandRuntimePath(agentRuntime.defaultSessionDir, {
+					cwd: requestCwd,
+					baseDir: projectRuntime.baseDir,
+					agent: agentName,
+					runId,
+					index,
+				});
+				return path.join(agentSessionRoot, runId, `run-${index}`);
+			}
+			return path.join(sessionRoot, `run-${index}`);
+		};
 		const childSessionFileForIndex = (idx?: number) =>
 			sessionFileForIndex(idx) ?? path.join(sessionDirForIndex(idx), "session.jsonl");
 
@@ -2183,6 +2241,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			effectiveAsync,
 			controlConfig,
 			intercomBridge,
+			projectBaseDir: projectRuntime.baseDir,
 		};
 
 		const foregroundMode: "single" | "parallel" | "chain" = hasChain ? "chain" : hasTasks ? "parallel" : "single";
@@ -2204,11 +2263,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		}
 
 		try {
-			const asyncResult = runAsyncPath(execData, deps);
+			const asyncResult = runAsyncPath(execData, runtimeDeps);
 			if (asyncResult) return withForkContext(asyncResult, effectiveParams.context);
-			if (hasChain && effectiveParams.chain) return withForkContext(await runChainPath(execData, deps), effectiveParams.context);
-			if (hasTasks && effectiveParams.tasks) return withForkContext(await runParallelPath(execData, deps), effectiveParams.context);
-			if (hasSingle) return withForkContext(await runSinglePath(execData, deps), effectiveParams.context);
+			if (hasChain && effectiveParams.chain) return withForkContext(await runChainPath(execData, runtimeDeps), effectiveParams.context);
+			if (hasTasks && effectiveParams.tasks) return withForkContext(await runParallelPath(execData, runtimeDeps), effectiveParams.context);
+			if (hasSingle) return withForkContext(await runSinglePath(execData, runtimeDeps), effectiveParams.context);
 		} catch (error) {
 			return toExecutionErrorResult(effectiveParams, error);
 		} finally {

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -16,6 +16,10 @@ export interface RunnerSubagentStep {
 	outputMode?: "inline" | "file-only";
 	sessionFile?: string;
 	maxSubagentDepth?: number;
+	worktreeRoot?: string;
+	worktreeSetupHook?: string;
+	worktreeSetupHookTimeoutMs?: number;
+	keepWorktrees?: boolean;
 }
 
 export interface ParallelStepGroup {

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -7,6 +7,7 @@ export interface WorktreeSetup {
 	cwd: string;
 	worktrees: WorktreeInfo[];
 	baseCommit: string;
+	keepWorktrees?: boolean;
 }
 
 interface WorktreeInfo {
@@ -43,6 +44,10 @@ interface WorktreeSetupHookConfig {
 interface CreateWorktreesOptions {
 	agents?: string[];
 	setupHook?: WorktreeSetupHookConfig;
+	setupHooks?: Array<WorktreeSetupHookConfig | undefined>;
+	worktreeRoot?: string;
+	worktreeRoots?: Array<string | undefined>;
+	keepWorktrees?: boolean;
 }
 
 interface ResolvedWorktreeSetupHook {
@@ -152,8 +157,9 @@ function buildWorktreeBranch(runId: string, index: number): string {
 	return `pi-parallel-${runId}-${index}`;
 }
 
-function buildWorktreePath(runId: string, index: number): string {
-	return path.join(os.tmpdir(), `pi-worktree-${runId}-${index}`);
+function buildWorktreePath(runId: string, index: number, worktreeRoot?: string): string {
+	if (worktreeRoot) fs.mkdirSync(worktreeRoot, { recursive: true });
+	return path.join(worktreeRoot ?? os.tmpdir(), `pi-worktree-${runId}-${index}`);
 }
 
 function resolveRepoCwdRelative(cwd: string): string {
@@ -168,9 +174,9 @@ function resolveRepoCwdRelative(cwd: string): string {
 	return normalizedPrefix === "." ? "" : normalizedPrefix;
 }
 
-export function resolveExpectedWorktreeAgentCwd(cwd: string, runId: string, index: number): string {
+export function resolveExpectedWorktreeAgentCwd(cwd: string, runId: string, index: number, worktreeRoot?: string): string {
 	const cwdRelative = resolveRepoCwdRelative(cwd);
-	const worktreePath = buildWorktreePath(runId, index);
+	const worktreePath = buildWorktreePath(runId, index, worktreeRoot);
 	return cwdRelative ? path.join(worktreePath, cwdRelative) : worktreePath;
 }
 
@@ -320,9 +326,10 @@ function createSingleWorktree(
 	baseCommit: string,
 	setupHook: ResolvedWorktreeSetupHook | undefined,
 	agent: string | undefined,
+	worktreeRoot: string | undefined,
 ): WorktreeInfo {
 	const branch = buildWorktreeBranch(runId, index);
-	const worktreePath = buildWorktreePath(runId, index);
+	const worktreePath = buildWorktreePath(runId, index, worktreeRoot);
 	const add = runGit(toplevel, ["worktree", "add", worktreePath, "-b", branch, "HEAD"]);
 	if (add.status !== 0) {
 		const message = add.stderr.trim() || add.stdout.trim() || `failed to create worktree ${worktreePath}`;
@@ -492,6 +499,7 @@ function hasWorktreeChanges(diff: WorktreeDiff): boolean {
 export function createWorktrees(cwd: string, runId: string, count: number, options?: CreateWorktreesOptions): WorktreeSetup {
 	const repo = resolveRepoState(cwd);
 	const setupHook = resolveWorktreeSetupHook(repo.toplevel, options?.setupHook);
+	const setupHooks = options?.setupHooks?.map((hook) => resolveWorktreeSetupHook(repo.toplevel, hook));
 	const worktrees: WorktreeInfo[] = [];
 
 	try {
@@ -502,8 +510,9 @@ export function createWorktrees(cwd: string, runId: string, count: number, optio
 				runId,
 				index,
 				repo.baseCommit,
-				setupHook,
+				setupHooks?.[index] ?? setupHook,
 				options?.agents?.[index],
+				options?.worktreeRoots?.[index] ?? options?.worktreeRoot,
 			));
 		}
 	} catch (error) {
@@ -519,6 +528,7 @@ export function createWorktrees(cwd: string, runId: string, count: number, optio
 		cwd: repo.toplevel,
 		worktrees,
 		baseCommit: repo.baseCommit,
+		keepWorktrees: options?.keepWorktrees === true,
 	};
 }
 
@@ -547,7 +557,8 @@ export function diffWorktrees(setup: WorktreeSetup, agents: string[], diffsDir: 
 	return diffs;
 }
 
-export function cleanupWorktrees(setup: WorktreeSetup): void {
+export function cleanupWorktrees(setup: WorktreeSetup, options?: { keep?: boolean }): void {
+	if (options?.keep || setup.keepWorktrees) return;
 	for (let index = setup.worktrees.length - 1; index >= 0; index--) {
 		cleanupSingleWorktree(setup.cwd, setup.worktrees[index]!);
 	}

--- a/src/shared/scoped-runtime-config.ts
+++ b/src/shared/scoped-runtime-config.ts
@@ -93,14 +93,43 @@ export function readProjectRuntimeConfig(cwd: string): ProjectRuntimeConfig {
 	}
 }
 
+function pickScopedRuntimeConfig(config: Partial<ScopedRuntimeConfig>): ScopedRuntimeConfig {
+	return {
+		...(config.defaultSessionDir !== undefined ? { defaultSessionDir: config.defaultSessionDir } : {}),
+		...(config.worktreeRoot !== undefined ? { worktreeRoot: config.worktreeRoot } : {}),
+		...(config.worktreeSetupHook !== undefined ? { worktreeSetupHook: config.worktreeSetupHook } : {}),
+		...(config.worktreeSetupHookTimeoutMs !== undefined ? { worktreeSetupHookTimeoutMs: config.worktreeSetupHookTimeoutMs } : {}),
+		...(config.keepWorktrees !== undefined ? { keepWorktrees: config.keepWorktrees } : {}),
+	};
+}
+
+function mergeAgentDefaults(
+	globalConfig: ExtensionConfig,
+	projectConfig: Partial<ExtensionConfig>,
+): Record<string, ScopedRuntimeConfig> | undefined {
+	const globalDefaults = globalConfig.agentDefaults;
+	const projectDefaults = projectConfig.agentDefaults;
+	if (!globalDefaults && !projectDefaults) return undefined;
+	const globalScoped = pickScopedRuntimeConfig(globalConfig);
+	const projectScoped = pickScopedRuntimeConfig(projectConfig);
+	const merged: Record<string, ScopedRuntimeConfig> = {};
+	for (const agent of new Set([...Object.keys(globalDefaults ?? {}), ...Object.keys(projectDefaults ?? {})])) {
+		merged[agent] = {
+			...globalScoped,
+			...(globalDefaults?.[agent] ?? {}),
+			...projectScoped,
+			...(projectDefaults?.[agent] ?? {}),
+		};
+	}
+	return merged;
+}
+
 export function mergeRuntimeConfig(globalConfig: ExtensionConfig, projectConfig: Partial<ExtensionConfig>): ExtensionConfig {
+	const agentDefaults = mergeAgentDefaults(globalConfig, projectConfig);
 	return {
 		...globalConfig,
 		...projectConfig,
-		agentDefaults: {
-			...(globalConfig.agentDefaults ?? {}),
-			...(projectConfig.agentDefaults ?? {}),
-		},
+		...(agentDefaults ? { agentDefaults } : {}),
 	};
 }
 

--- a/src/shared/scoped-runtime-config.ts
+++ b/src/shared/scoped-runtime-config.ts
@@ -23,6 +23,7 @@ export interface RuntimePathContext {
 	cwd: string;
 	baseDir?: string;
 	agent?: string;
+	provider?: string;
 	model?: string;
 	runId?: string;
 	index?: number;
@@ -114,16 +115,31 @@ export function resolveAgentRuntimeConfig(config: ExtensionConfig, agent: string
 	};
 }
 
+function splitProviderModel(model: string | undefined): { provider?: string; model?: string } {
+	const raw = model?.trim();
+	if (!raw) return {};
+	const slashIndex = raw.indexOf("/");
+	if (slashIndex === -1) return { model: raw };
+	return {
+		provider: raw.slice(0, slashIndex) || undefined,
+		model: raw.slice(slashIndex + 1) || undefined,
+	};
+}
+
 function toPathSegment(value: string | undefined, fallback: string): string {
-	return (value?.trim() || fallback).replace(/[\\/\0:*?"<>|]+/g, "__");
+	return (value?.trim() || fallback).replace(/[\\/\0]+/g, "__");
 }
 
 export function expandRuntimePath(rawPath: string, context: RuntimePathContext): string {
+	const modelParts = splitProviderModel(context.model);
+	const provider = context.provider ?? modelParts.provider;
+	const model = modelParts.model ?? context.model;
 	const expanded = rawPath
 		.replaceAll("{cwd}", context.cwd)
 		.replaceAll("{projectRoot}", context.baseDir ?? context.cwd)
 		.replaceAll("{agent}", toPathSegment(context.agent, "agent"))
-		.replaceAll("{model}", toPathSegment(context.model, "model"))
+		.replaceAll("{provider}", toPathSegment(provider, "provider"))
+		.replaceAll("{model}", toPathSegment(model, "model"))
 		.replaceAll("{runId}", context.runId ?? "run")
 		.replaceAll("{index}", String(context.index ?? 0));
 	const withHome = expanded.startsWith("~/") ? path.join(os.homedir(), expanded.slice(2)) : expanded;

--- a/src/shared/scoped-runtime-config.ts
+++ b/src/shared/scoped-runtime-config.ts
@@ -23,6 +23,7 @@ export interface RuntimePathContext {
 	cwd: string;
 	baseDir?: string;
 	agent?: string;
+	model?: string;
 	runId?: string;
 	index?: number;
 }
@@ -113,11 +114,16 @@ export function resolveAgentRuntimeConfig(config: ExtensionConfig, agent: string
 	};
 }
 
+function toPathSegment(value: string | undefined, fallback: string): string {
+	return (value?.trim() || fallback).replace(/[\\/\0:*?"<>|]+/g, "__");
+}
+
 export function expandRuntimePath(rawPath: string, context: RuntimePathContext): string {
 	const expanded = rawPath
 		.replaceAll("{cwd}", context.cwd)
 		.replaceAll("{projectRoot}", context.baseDir ?? context.cwd)
-		.replaceAll("{agent}", context.agent ?? "agent")
+		.replaceAll("{agent}", toPathSegment(context.agent, "agent"))
+		.replaceAll("{model}", toPathSegment(context.model, "model"))
 		.replaceAll("{runId}", context.runId ?? "run")
 		.replaceAll("{index}", String(context.index ?? 0));
 	const withHome = expanded.startsWith("~/") ? path.join(os.homedir(), expanded.slice(2)) : expanded;

--- a/src/shared/scoped-runtime-config.ts
+++ b/src/shared/scoped-runtime-config.ts
@@ -1,0 +1,125 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentConfig } from "../agents/agents.ts";
+import type { ExtensionConfig, ScopedRuntimeConfig } from "./types.ts";
+
+const SCOPED_KEYS = [
+	"defaultSessionDir",
+	"worktreeRoot",
+	"worktreeSetupHook",
+	"worktreeSetupHookTimeoutMs",
+	"keepWorktrees",
+] as const;
+
+type ScopedKey = (typeof SCOPED_KEYS)[number];
+
+export interface ProjectRuntimeConfig {
+	config: Partial<ExtensionConfig>;
+	baseDir?: string;
+}
+
+export interface RuntimePathContext {
+	cwd: string;
+	baseDir?: string;
+	agent?: string;
+	runId?: string;
+	index?: number;
+}
+
+function isDirectory(filePath: string): boolean {
+	try {
+		return fs.statSync(filePath).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function findNearestProjectRoot(cwd: string): string | undefined {
+	let current = path.resolve(cwd);
+	while (true) {
+		if (isDirectory(path.join(current, ".pi")) || isDirectory(path.join(current, ".agents"))) return current;
+		const parent = path.dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> | undefined {
+	if (!fs.existsSync(filePath)) return undefined;
+	const parsed: unknown = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+	return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : undefined;
+}
+
+function readScopedConfig(input: unknown): ScopedRuntimeConfig | undefined {
+	if (!input || typeof input !== "object" || Array.isArray(input)) return undefined;
+	const source = input as Record<string, unknown>;
+	const out: ScopedRuntimeConfig = {};
+	for (const key of SCOPED_KEYS) {
+		const value = source[key];
+		if (typeof value === "string" && value.trim()) (out as Record<ScopedKey, unknown>)[key] = value.trim();
+		else if (key === "worktreeSetupHookTimeoutMs" && typeof value === "number" && Number.isInteger(value) && value > 0) out.worktreeSetupHookTimeoutMs = value;
+		else if (key === "keepWorktrees" && typeof value === "boolean") out.keepWorktrees = value;
+	}
+	return Object.keys(out).length ? out : undefined;
+}
+
+function readAgentDefaults(input: unknown): Record<string, ScopedRuntimeConfig> | undefined {
+	if (!input || typeof input !== "object" || Array.isArray(input)) return undefined;
+	const out: Record<string, ScopedRuntimeConfig> = {};
+	for (const [name, value] of Object.entries(input)) {
+		const scoped = readScopedConfig(value);
+		if (scoped) out[name] = scoped;
+	}
+	return Object.keys(out).length ? out : undefined;
+}
+
+export function readProjectRuntimeConfig(cwd: string): ProjectRuntimeConfig {
+	const projectRoot = findNearestProjectRoot(cwd);
+	if (!projectRoot) return { config: {} };
+	const settingsPath = path.join(projectRoot, ".pi", "settings.json");
+	try {
+		const settings = readJsonObject(settingsPath);
+		const subagents = settings?.subagents;
+		if (!subagents || typeof subagents !== "object" || Array.isArray(subagents)) return { config: {}, baseDir: projectRoot };
+		const scoped = readScopedConfig(subagents) ?? {};
+		const agentDefaults = readAgentDefaults((subagents as Record<string, unknown>).agentDefaults);
+		return { config: { ...scoped, ...(agentDefaults ? { agentDefaults } : {}) }, baseDir: projectRoot };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Failed to read project subagent runtime config '${settingsPath}': ${message}`, { cause: error });
+	}
+}
+
+export function mergeRuntimeConfig(globalConfig: ExtensionConfig, projectConfig: Partial<ExtensionConfig>): ExtensionConfig {
+	return {
+		...globalConfig,
+		...projectConfig,
+		agentDefaults: {
+			...(globalConfig.agentDefaults ?? {}),
+			...(projectConfig.agentDefaults ?? {}),
+		},
+	};
+}
+
+export function resolveAgentRuntimeConfig(config: ExtensionConfig, agent: string | undefined, agentConfig?: AgentConfig): ScopedRuntimeConfig {
+	const agentDefaults = agent ? config.agentDefaults?.[agent] : undefined;
+	return {
+		defaultSessionDir: agentConfig?.defaultSessionDir ?? agentDefaults?.defaultSessionDir ?? config.defaultSessionDir,
+		worktreeRoot: agentConfig?.worktreeRoot ?? agentDefaults?.worktreeRoot ?? config.worktreeRoot,
+		worktreeSetupHook: agentConfig?.worktreeSetupHook ?? agentDefaults?.worktreeSetupHook ?? config.worktreeSetupHook,
+		worktreeSetupHookTimeoutMs: agentConfig?.worktreeSetupHookTimeoutMs ?? agentDefaults?.worktreeSetupHookTimeoutMs ?? config.worktreeSetupHookTimeoutMs,
+		keepWorktrees: agentConfig?.keepWorktrees ?? agentDefaults?.keepWorktrees ?? config.keepWorktrees,
+	};
+}
+
+export function expandRuntimePath(rawPath: string, context: RuntimePathContext): string {
+	const expanded = rawPath
+		.replaceAll("{cwd}", context.cwd)
+		.replaceAll("{projectRoot}", context.baseDir ?? context.cwd)
+		.replaceAll("{agent}", context.agent ?? "agent")
+		.replaceAll("{runId}", context.runId ?? "run")
+		.replaceAll("{index}", String(context.index ?? 0));
+	const withHome = expanded.startsWith("~/") ? path.join(os.homedir(), expanded.slice(2)) : expanded;
+	return path.isAbsolute(withHome) ? withHome : path.resolve(context.baseDir ?? context.cwd, withHome);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -494,16 +494,25 @@ interface TopLevelParallelConfig {
 	concurrency?: number;
 }
 
-export interface ExtensionConfig {
+export interface WorktreeRuntimeConfig {
+	worktreeRoot?: string;
+	worktreeSetupHook?: string;
+	worktreeSetupHookTimeoutMs?: number;
+	keepWorktrees?: boolean;
+}
+
+export interface ScopedRuntimeConfig extends WorktreeRuntimeConfig {
+	defaultSessionDir?: string;
+}
+
+export interface ExtensionConfig extends ScopedRuntimeConfig {
 	asyncByDefault?: boolean;
 	forceTopLevelAsync?: boolean;
-	defaultSessionDir?: string;
 	maxSubagentDepth?: number;
 	control?: ControlConfig;
 	parallel?: TopLevelParallelConfig;
-	worktreeSetupHook?: string;
-	worktreeSetupHookTimeoutMs?: number;
 	intercomBridge?: IntercomBridgeConfig;
+	agentDefaults?: Record<string, ScopedRuntimeConfig>;
 }
 
 // ============================================================================

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -272,6 +272,24 @@ Do work
 		assert.equal(worker?.worktreeSetupHookTimeoutMs, 45000);
 		assert.equal(worker?.keepWorktrees, true);
 	});
+
+	it("leaves optional runtime booleans unset when omitted from frontmatter", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-runtime-optional-bool-"));
+		tempDirs.push(dir);
+		const agentsDir = path.join(dir, ".pi", "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(path.join(agentsDir, "worker.md"), `---
+name: worker
+description: Worker
+---
+
+Do work
+`, "utf-8");
+
+		const result = discoverAgents(dir, "project");
+		const worker = result.agents.find((agent) => agent.name === "worker");
+		assert.equal(worker?.keepWorktrees, undefined);
+	});
 });
 
 describe("agent frontmatter prompt assembly defaults", () => {

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -219,6 +219,61 @@ Do work
 	});
 });
 
+
+describe("agent frontmatter runtime scoping", () => {
+	it("serializes runtime scoping fields into agent frontmatter", () => {
+		const agent: AgentConfig = {
+			name: "worker",
+			description: "Worker",
+			systemPrompt: "Do work",
+			systemPromptMode: "replace",
+			inheritProjectContext: false,
+			inheritSkills: false,
+			source: "project",
+			filePath: "/tmp/worker.md",
+			defaultSessionDir: ".pi/subagents/sessions/{agent}",
+			worktreeRoot: ".pi/subagents/worktrees/{agent}",
+			worktreeSetupHook: ".pi/subagents/setup-worktree.mjs",
+			worktreeSetupHookTimeoutMs: 45000,
+			keepWorktrees: true,
+		};
+
+		const serialized = serializeAgent(agent);
+		assert.match(serialized, /defaultSessionDir: \.pi\/subagents\/sessions\/\{agent\}/);
+		assert.match(serialized, /worktreeRoot: \.pi\/subagents\/worktrees\/\{agent\}/);
+		assert.match(serialized, /worktreeSetupHook: \.pi\/subagents\/setup-worktree\.mjs/);
+		assert.match(serialized, /worktreeSetupHookTimeoutMs: 45000/);
+		assert.match(serialized, /keepWorktrees: true/);
+	});
+
+	it("parses runtime scoping fields from discovered agent frontmatter", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-runtime-scope-"));
+		tempDirs.push(dir);
+		const agentsDir = path.join(dir, ".pi", "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(path.join(agentsDir, "worker.md"), `---
+name: worker
+description: Worker
+defaultSessionDir: .pi/subagents/sessions/{agent}
+worktreeRoot: .pi/subagents/worktrees/{agent}
+worktreeSetupHook: .pi/subagents/setup-worktree.mjs
+worktreeSetupHookTimeoutMs: 45000
+keepWorktrees: true
+---
+
+Do work
+`, "utf-8");
+
+		const result = discoverAgents(dir, "project");
+		const worker = result.agents.find((agent) => agent.name === "worker");
+		assert.equal(worker?.defaultSessionDir, ".pi/subagents/sessions/{agent}");
+		assert.equal(worker?.worktreeRoot, ".pi/subagents/worktrees/{agent}");
+		assert.equal(worker?.worktreeSetupHook, ".pi/subagents/setup-worktree.mjs");
+		assert.equal(worker?.worktreeSetupHookTimeoutMs, 45000);
+		assert.equal(worker?.keepWorktrees, true);
+	});
+});
+
 describe("agent frontmatter prompt assembly defaults", () => {
 	it("defaults ordinary agents to replace mode with no inherited context or skills", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-default-prompt-settings-"));

--- a/test/unit/scoped-runtime-config.test.ts
+++ b/test/unit/scoped-runtime-config.test.ts
@@ -80,13 +80,14 @@ describe("scoped runtime config", () => {
 	});
 
 	it("expands runtime path templates relative to the project root", () => {
-		const expanded = expandRuntimePath(".pi/subagents/{agent}/{runId}/{index}", {
+		const expanded = expandRuntimePath(".pi/subagents/{agent}/{model}/{runId}/{index}", {
 			cwd: "/repo/packages/app",
 			baseDir: "/repo",
 			agent: "worker",
+			model: "openai/gpt-5.5",
 			runId: "abc123",
 			index: 2,
 		});
-		assert.equal(expanded, path.join("/repo", ".pi", "subagents", "worker", "abc123", "2"));
+		assert.equal(expanded, path.join("/repo", ".pi", "subagents", "worker", "openai__gpt-5.5", "abc123", "2"));
 	});
 });

--- a/test/unit/scoped-runtime-config.test.ts
+++ b/test/unit/scoped-runtime-config.test.ts
@@ -59,7 +59,15 @@ describe("scoped runtime config", () => {
 			{
 				defaultSessionDir: "~/global-sessions",
 				worktreeRoot: "~/global-worktrees",
-				agentDefaults: { worker: { worktreeRoot: "~/global-worker-worktrees" } },
+				keepWorktrees: true,
+				agentDefaults: {
+					worker: {
+						defaultSessionDir: "~/global-worker-sessions",
+						worktreeRoot: "~/global-worker-worktrees",
+						worktreeSetupHook: "~/global-worker-hook.mjs",
+					},
+					reviewer: { worktreeRoot: "~/global-reviewer-worktrees" },
+				},
 			},
 			{
 				defaultSessionDir: ".pi/subagents/sessions",
@@ -70,10 +78,12 @@ describe("scoped runtime config", () => {
 		assert.deepEqual(resolveAgentRuntimeConfig(merged, "worker"), {
 			defaultSessionDir: ".pi/subagents/sessions",
 			worktreeRoot: ".pi/subagents/worktrees/worker",
-			worktreeSetupHook: undefined,
+			worktreeSetupHook: "~/global-worker-hook.mjs",
 			worktreeSetupHookTimeoutMs: undefined,
-			keepWorktrees: undefined,
+			keepWorktrees: true,
 		});
+		assert.equal(resolveAgentRuntimeConfig(merged, "reviewer").worktreeRoot, "~/global-reviewer-worktrees");
+		assert.equal(resolveAgentRuntimeConfig(merged, "delegate").worktreeRoot, "~/global-worktrees");
 
 		const agent = makeAgent({ worktreeRoot: ".pi/subagents/worktrees/frontmatter" });
 		assert.equal(resolveAgentRuntimeConfig(merged, "worker", agent).worktreeRoot, ".pi/subagents/worktrees/frontmatter");

--- a/test/unit/scoped-runtime-config.test.ts
+++ b/test/unit/scoped-runtime-config.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import {
+	expandRuntimePath,
+	mergeRuntimeConfig,
+	readProjectRuntimeConfig,
+	resolveAgentRuntimeConfig,
+} from "../../src/shared/scoped-runtime-config.ts";
+import type { AgentConfig } from "../../src/agents/agents.ts";
+
+function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+	return {
+		name: "worker",
+		description: "Worker",
+		systemPrompt: "Do work",
+		systemPromptMode: "replace",
+		inheritProjectContext: false,
+		inheritSkills: false,
+		source: "project",
+		filePath: "/tmp/worker.md",
+		...overrides,
+	};
+}
+
+describe("scoped runtime config", () => {
+	it("reads project-level and per-agent subagent runtime config from .pi/settings.json", () => {
+		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-project-runtime-"));
+		try {
+			fs.mkdirSync(path.join(project, ".pi"), { recursive: true });
+			fs.writeFileSync(path.join(project, ".pi", "settings.json"), JSON.stringify({
+				subagents: {
+					defaultSessionDir: ".pi/subagents/sessions",
+					worktreeRoot: ".pi/subagents/worktrees",
+					agentDefaults: {
+						worker: {
+							defaultSessionDir: ".pi/subagents/sessions/{agent}",
+							keepWorktrees: true,
+						},
+					},
+				},
+			}, null, 2), "utf-8");
+
+			const projectConfig = readProjectRuntimeConfig(path.join(project, "packages", "app"));
+			assert.equal(projectConfig.baseDir, project);
+			assert.equal(projectConfig.config.defaultSessionDir, ".pi/subagents/sessions");
+			assert.equal(projectConfig.config.worktreeRoot, ".pi/subagents/worktrees");
+			assert.equal(projectConfig.config.agentDefaults?.worker?.defaultSessionDir, ".pi/subagents/sessions/{agent}");
+			assert.equal(projectConfig.config.agentDefaults?.worker?.keepWorktrees, true);
+		} finally {
+			fs.rmSync(project, { recursive: true, force: true });
+		}
+	});
+
+	it("merges global, project, settings agentDefaults, and agent frontmatter in priority order", () => {
+		const merged = mergeRuntimeConfig(
+			{
+				defaultSessionDir: "~/global-sessions",
+				worktreeRoot: "~/global-worktrees",
+				agentDefaults: { worker: { worktreeRoot: "~/global-worker-worktrees" } },
+			},
+			{
+				defaultSessionDir: ".pi/subagents/sessions",
+				agentDefaults: { worker: { worktreeRoot: ".pi/subagents/worktrees/worker" } },
+			},
+		);
+
+		assert.deepEqual(resolveAgentRuntimeConfig(merged, "worker"), {
+			defaultSessionDir: ".pi/subagents/sessions",
+			worktreeRoot: ".pi/subagents/worktrees/worker",
+			worktreeSetupHook: undefined,
+			worktreeSetupHookTimeoutMs: undefined,
+			keepWorktrees: undefined,
+		});
+
+		const agent = makeAgent({ worktreeRoot: ".pi/subagents/worktrees/frontmatter" });
+		assert.equal(resolveAgentRuntimeConfig(merged, "worker", agent).worktreeRoot, ".pi/subagents/worktrees/frontmatter");
+	});
+
+	it("expands runtime path templates relative to the project root", () => {
+		const expanded = expandRuntimePath(".pi/subagents/{agent}/{runId}/{index}", {
+			cwd: "/repo/packages/app",
+			baseDir: "/repo",
+			agent: "worker",
+			runId: "abc123",
+			index: 2,
+		});
+		assert.equal(expanded, path.join("/repo", ".pi", "subagents", "worker", "abc123", "2"));
+	});
+});

--- a/test/unit/scoped-runtime-config.test.ts
+++ b/test/unit/scoped-runtime-config.test.ts
@@ -80,7 +80,7 @@ describe("scoped runtime config", () => {
 	});
 
 	it("expands runtime path templates relative to the project root", () => {
-		const expanded = expandRuntimePath(".pi/subagents/{agent}/{model}/{runId}/{index}", {
+		const expanded = expandRuntimePath(".pi/subagents/{agent}/{provider}/{model}/{runId}/{index}", {
 			cwd: "/repo/packages/app",
 			baseDir: "/repo",
 			agent: "worker",
@@ -88,6 +88,6 @@ describe("scoped runtime config", () => {
 			runId: "abc123",
 			index: 2,
 		});
-		assert.equal(expanded, path.join("/repo", ".pi", "subagents", "worker", "openai__gpt-5.5", "abc123", "2"));
+		assert.equal(expanded, path.join("/repo", ".pi", "subagents", "worker", "openai", "gpt-5.5", "abc123", "2"));
 	});
 });

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -110,6 +110,37 @@ describe("worktree", () => {
 		}
 	});
 
+	it("createWorktrees can create worktrees under a custom root", () => {
+		const repoDir = createRepo("pi-worktree-custom-root-");
+		const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-root-"));
+		let setup: WorktreeSetup | undefined;
+		try {
+			setup = createWorktrees(repoDir, "custom-root", 1, { worktreeRoot });
+			assert.equal(path.dirname(setup.worktrees[0]!.path), worktreeRoot);
+			assert.ok(fs.existsSync(setup.worktrees[0]!.path));
+		} finally {
+			if (setup) cleanupWorktrees(setup);
+			cleanupRepo(repoDir);
+			fs.rmSync(worktreeRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("cleanupWorktrees keeps worktrees when the setup is marked keepWorktrees", () => {
+		const repoDir = createRepo("pi-worktree-keep-");
+		let setup: WorktreeSetup | undefined;
+		try {
+			setup = createWorktrees(repoDir, "keep", 1, { keepWorktrees: true });
+			const worktreePath = setup.worktrees[0]!.path;
+			cleanupWorktrees(setup);
+			assert.equal(fs.existsSync(worktreePath), true, "worktree should remain for manual review");
+		} finally {
+			if (setup) {
+				cleanupWorktrees({ ...setup, keepWorktrees: false });
+			}
+			cleanupRepo(repoDir);
+		}
+	});
+
 	it("createWorktrees rejects dirty repositories", () => {
 		const repoDir = createRepo("pi-worktree-dirty-");
 		try {


### PR DESCRIPTION
## Summary

Adds scoped runtime storage configuration for delegated subagents so child session traces and worktrees can be kept under predictable project-local paths.

This is useful for debugging, agent-engineering research, enterprise auditability, token-budget estimation, and model evaluation because runs can be grouped by agent role, provider, and model instead of being scattered under temp or parent-derived directories.

## What changed

- Add project-local `.pi/settings.json` support for `subagents` runtime storage fields:
  - `defaultSessionDir`
  - `worktreeRoot`
  - `worktreeSetupHook`
  - `worktreeSetupHookTimeoutMs`
  - `keepWorktrees`
  - `agentDefaults.<agent>` overrides
- Preserve and test scoped precedence:
  - global runtime config is used when project config omits a value
  - project runtime config overrides global defaults
  - per-agent config can inherit from global/project scoped defaults and override selected fields
  - agent frontmatter remains the most specific override
  - run `sessionDir` still wins for session storage
- Add runtime path template variables:
  - `{projectRoot}`
  - `{cwd}`
  - `{agent}`
  - `{provider}`
  - `{model}`
  - `{runId}`
  - `{index}`
- Support provider/model directory splitting, e.g. `openai/gpt-5.5` can map to `{provider}/{model}` -> `openai/gpt-5.5`.
- Document the behavior in `README.md` and the packaged `pi-subagents` skill.
- Add/extend unit coverage for scoped runtime config and worktree path behavior.

Example project config:

```json
{
  "subagents": {
    "defaultSessionDir": ".pi/subagents/sessions/{agent}/{provider}/{model}",
    "worktreeRoot": ".pi/subagents/worktrees/{agent}/{provider}/{model}"
  }
}
```

## Follow-up fixes included

- Fixes #155: `keepWorktrees` now remains `undefined` when omitted from agent frontmatter, so runtime config precedence works as intended. Explicit `keepWorktrees: true` in frontmatter still parses as `true`.
- Deep-merges scoped runtime defaults so global config, project config, per-agent config, and frontmatter compose by precedence instead of replacing whole nested agent defaults.

## Notes

- Default behavior is unchanged when no scoped runtime config is provided.
- Directories are created lazily when a subagent session or worktree is launched.
- Path segment escaping is intentionally minimal: only path separators and NUL bytes inside a single template segment are escaped.

## Validation

```bash
git diff --check
node --experimental-strip-types --test \
  test/unit/scoped-runtime-config.test.ts \
  test/unit/agent-frontmatter.test.ts \
  test/unit/worktree.test.ts
```
