### PR TITLE
fix(tui): render assistant turn count as plain text in single-compact (avoid U+27F3 overlap)

### DIFF
--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -206,6 +206,10 @@ function formatToolUseStat(count: number): string {
 	return `${count} tool use${count === 1 ? "" : "s"}`;
 }
 
+function formatTurnStat(count: number): string {
+	return `${count} turn${count === 1 ? "" : "s"}`;
+}
+
 function formatProgressStats(theme: Theme, progress: Pick<AgentProgress, "toolCount" | "tokens" | "durationMs"> | undefined, includeDuration = true): string {
 	if (!progress) return "";
 	const parts: string[] = [];
@@ -274,7 +278,7 @@ function widgetActivity(job: AsyncJobState): string {
 	if (job.currentTool && job.currentToolStartedAt !== undefined) facts.push(`${job.currentTool} ${formatDuration(Math.max(0, Date.now() - job.currentToolStartedAt))}`);
 	else if (job.currentTool) facts.push(job.currentTool);
 	if (job.currentPath) facts.push(shortenPath(job.currentPath));
-	if (job.turnCount !== undefined) facts.push(`${job.turnCount} turns`);
+	if (job.turnCount !== undefined) facts.push(formatTurnStat(job.turnCount));
 	if (job.toolCount !== undefined) facts.push(`${job.toolCount} tools`);
 	const activity = formatActivityLabel(job.lastActivityAt, job.activityState)
 		?? (job.status === "running" ? getCachedLastActivity(job.outputFile) : "");
@@ -317,7 +321,7 @@ function widgetStepActivity(step: NonNullable<AsyncJobState["steps"]>[number]): 
 	if (step.currentTool && step.currentToolStartedAt !== undefined) facts.push(`${step.currentTool} ${formatDuration(Math.max(0, Date.now() - step.currentToolStartedAt))}`);
 	else if (step.currentTool) facts.push(step.currentTool);
 	if (step.currentPath) facts.push(shortenPath(step.currentPath));
-	if (step.turnCount !== undefined) facts.push(`${step.turnCount} turns`);
+	if (step.turnCount !== undefined) facts.push(formatTurnStat(step.turnCount));
 	if (step.toolCount !== undefined) facts.push(`${step.toolCount} tools`);
 	if (step.tokens?.total) facts.push(formatTokenStat(step.tokens.total));
 	const activity = formatActivityLabel(step.lastActivityAt, step.activityState);
@@ -569,7 +573,7 @@ function widgetStats(job: AsyncJobState, theme: Theme): string {
 
 function widgetStepStats(theme: Theme, step: NonNullable<AsyncJobState["steps"]>[number]): string {
 	return statJoin(theme, [
-		step.turnCount !== undefined ? `${step.turnCount} turns` : "",
+		step.turnCount !== undefined ? formatTurnStat(step.turnCount) : "",
 		step.toolCount !== undefined ? formatToolUseStat(step.toolCount) : "",
 		step.tokens?.total ? formatTokenStat(step.tokens.total) : "",
 		step.durationMs !== undefined ? formatDuration(step.durationMs) : "",
@@ -833,7 +837,7 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 	const isRunning = r.progress?.status === "running";
 	const contextBadge = d.context === "fork" ? theme.fg("warning", " [fork]") : "";
 	const stats = statJoin(theme, [
-		r.usage?.turns ? `⟳${r.usage.turns}` : "",
+		r.usage?.turns ? formatTurnStat(r.usage.turns) : "",
 		formatProgressStats(theme, progress),
 	]);
 	const c = new Container();

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -153,7 +153,8 @@ describe("renderSubagentResult fork indicator", () => {
 
 		const text = widget.render(120).join("\n");
 		assert.match(text, /^✓ reviewer/);
-		assert.match(text, /⟳2/);
+		assert.match(text, /2 turns/);
+		assert.doesNotMatch(text, /⟳/);
 		assert.match(text, /3 tool uses/);
 		assert.match(text, /1\.2k token/);
 		assert.match(text, /⎿  Done/);

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-const { buildWidgetLines, renderWidget, stopResultAnimations, stopWidgetAnimation, syncResultAnimation } = await import("../../src/tui/render.ts") as {
+interface RenderableComponent {
+	render(width: number): string[];
+}
+
+const { buildWidgetLines, renderSubagentResult, renderWidget, stopResultAnimations, stopWidgetAnimation, syncResultAnimation } = await import("../../src/tui/render.ts") as {
 	buildWidgetLines: (jobs: Array<Record<string, unknown>>, theme: { fg(name: string, text: string): string; bold(text: string): string }, width?: number, expanded?: boolean) => string[];
+	renderSubagentResult: (result: Record<string, unknown>, options: { expanded: boolean }, theme: { fg(name: string, text: string): string; bold(text: string): string }) => RenderableComponent;
 	renderWidget: (ctx: Record<string, unknown>, jobs: Array<Record<string, unknown>>) => void;
 	stopResultAnimations: () => void;
 	stopWidgetAnimation: () => void;
@@ -459,5 +464,50 @@ describe("subagent async widget rendering", () => {
 		} finally {
 			stopWidgetAnimation();
 		}
+	});
+});
+
+describe("renderSubagentResult single-compact stat line", () => {
+	function renderSingleResult(usage: { turns: number } | undefined, progress: { toolCount: number; tokens: number; durationMs: number }): string {
+		const result = {
+			content: [{ type: "text", text: "ok" }],
+			details: {
+				mode: "single",
+				context: "fresh",
+				results: [{
+					agent: "worker",
+					task: "do the thing",
+					exitCode: 0,
+					usage,
+					progress: { status: "running", ...progress },
+				}],
+			},
+		};
+		const component = renderSubagentResult(result, { expanded: false }, theme);
+		return component.render(160).map((line) => line.trimEnd()).join("\n");
+	}
+
+	it("renders the assistant turn count as plain text rather than a wide-glyph prefix", () => {
+		// Regression: U+27F3 (CLOCKWISE GAPPED CIRCLE ARROW) has east-asian-width Neutral
+		// (1 cell), but most macOS / iTerm2 / Apple-Color-Emoji font stacks draw it 2 cells
+		// wide. The layout reserved 1 cell, so the next character (the digit) was painted
+		// over the right half of the circle. Use the same `${n} turn(s)` text the widget
+		// path uses so width is unambiguous.
+		const text = renderSingleResult({ turns: 4 }, { toolCount: 8, tokens: 1900, durationMs: 15_500 });
+		assert.doesNotMatch(text, /\u27f3/, "single-compact line must not emit U+27F3");
+		assert.match(text, /worker · 4 turns · 8 tool uses · 1\.9k token · 15\.5s/);
+	});
+
+	it("uses singular 'turn' for a single assistant turn", () => {
+		const text = renderSingleResult({ turns: 1 }, { toolCount: 1, tokens: 100, durationMs: 1_000 });
+		assert.match(text, /worker · 1 turn · 1 tool use · /);
+		assert.doesNotMatch(text, /1 turns/);
+	});
+
+	it("omits the turn segment entirely when usage.turns is zero or missing", () => {
+		const withZero = renderSingleResult({ turns: 0 }, { toolCount: 2, tokens: 200, durationMs: 2_000 });
+		assert.doesNotMatch(withZero, /turn/);
+		const withNone = renderSingleResult(undefined, { toolCount: 2, tokens: 200, durationMs: 2_000 });
+		assert.doesNotMatch(withNone, /turn/);
 	});
 });


### PR DESCRIPTION
## Summary

The compact subagent worker line prefixes the assistant-turn count with `⟳` (U+27F3, *Clockwise Gapped Circle Arrow*) — e.g. `⟳4`. On macOS terminal stacks that fall back to Apple Color Emoji for non-monospace codepoints, the glyph is drawn **2 cells wide**, but the layout reserved only **1 cell**, so the digit is painted over the right half of the circle. Visually it looks like a circle with a number stamped through it.

This PR fixes the rendering by using the same `${n} turn(s)` text the rest of the file (`widgetActivity`, `widgetStepActivity`, `widgetStepStats`) already uses. Width becomes unambiguous, the symbol disappears, and a small `formatTurnStat` helper now keeps all four turn-count callsites in sync.

## Repro (real screenshot, pi-subagents 0.24.0, macOS — Supacode terminal, which embeds [libghostty](https://ghostty.org))

![worker-line-overlap](https://raw.githubusercontent.com/KickingTheTV/pi-subagents/media/turn-glyph-overlap/media/turn-glyph-overlap-before.png)

The glyph between **`worker ·`** and **`· 8 tool uses`** is `⟳4`, but `⟳` is drawn full-width-emoji-style and the `4` lands inside it.

```
  before (this PR fixes):  ✓ worker · ⟳4 · 8 tool uses · 1.9k token · 15.5s
  after  (this PR ships):  ✓ worker · 4 turns · 8 tool uses · 1.9k token · 15.5s
```

## Root cause

`U+27F3` lives in the `Supplemental Arrows-A` block. Per [UAX #11 East Asian Width](https://www.unicode.org/reports/tr11/), it has property `N` (Neutral → 1 cell). Width libraries agree:

```js
import { visibleWidth } from "@mariozechner/pi-tui";
visibleWidth("⟳")     // 1   ← what the layout assumed
visibleWidth("⟳4")    // 2
```

But on macOS, Apple Color Emoji draws this codepoint at the same width as a real emoji glyph (~2 cells). There is no Variation Selector that fixes this for `U+27F3` — it is not in the official emoji list, just commonly drawn as one. The terminal's grid reserves 1 cell, the glyph claims 2, and `column N+1` ends up containing both `⟳` pixels and the digit's pixels.

This is a known class of issue and not specific to the worker line — it's the same shape as [ghostty#1071 ("Overlapping Nerd Fonts Characters")](https://github.com/ghostty-org/ghostty/issues/1071), where Mitchell explained:

> According to the UCD (Unicode Database), all of the codepoint ranges presented are `width = 1` so we render into one grid cell (whether or not grapheme mode 2027 is on). The font itself is defining a glyph that is larger than the cell width so it is overflowing.

It also overlaps with [ghostty#10465](https://github.com/ghostty-org/ghostty/issues/10465), which extended cell-widening logic for grapheme clusters that flip from text-presentation to emoji-presentation (e.g. `<text> + VS16 → emoji`). `U+27F3` carries no VS16 and is not part of an emoji ZWJ sequence, so the terminal has no signal to widen the cell — the conformant behavior of every well-implemented terminal here is to render 1 cell, and any TUI that puts a digit in the next cell collides with the over-drawn glyph.

The robust fix is for the TUI not to place visible characters in the column adjacent to a font-overflow-prone codepoint. In this case, replacing the symbol with plain text (`${n} turn(s)`) sidesteps the entire class of issue.

## Fix

`renderSingleCompact` was the only callsite in `src/tui/render.ts` using the symbol-prefixed form. Three other turn-count sites (`widgetActivity` line 278, `widgetStepActivity` line 321, `widgetStepStats` line 573) already used `${count} turns`. This PR:

1. Adds a `formatTurnStat(count)` helper next to the existing `formatTokenStat` / `formatToolUseStat` siblings.
2. Routes all four turn-count callsites through it.
3. As a free byproduct, fixes a latent pluralization bug at the three widget sites: they previously rendered `1 turns` for a single turn.

Diff is ~6 source lines plus the helper.

## Test plan

- **`npm run test:unit`** → 370 pass / 0 fail
- **`npm run test:integration`** → 317 pass / 0 fail
- New regression tests in `test/integration/render-widget.test.ts` (`describe("renderSubagentResult single-compact stat line")`) cover:
  - `usage.turns: 4` → asserts `4 turns` is present **and** `U+27F3` is absent.
  - `usage.turns: 1` → asserts singular `1 turn` (not `1 turns`).
  - `usage.turns: 0` and `usage` undefined → asserts the turn segment is omitted entirely (preserves prior behavior).
- Updated one existing assertion in `test/integration/render-fork-badge.test.ts` (`uses glyph-first compact rendering for completed subagents`) — it explicitly asserted `⟳2`, now asserts `2 turns` and that `U+27F3` is absent.

## Notes for review

- No public API change. `formatTurnStat` is module-private (matches `formatTokenStat`, `formatToolUseStat`).
- No behavior change when `usage.turns` is falsy/undefined — same falsy-skip logic at every site.
- Existing widget tests like `Agent 1/3: reviewer · running · active now · 5 turns · 18 tool uses · 44k token` continue to pass unchanged because the widget path was already producing this exact format; the helper just centralizes it.
- Three render sites that would have rendered `1 turns` (singular case) now correctly render `1 turn`. If you'd prefer to preserve the existing pluralization at those three sites and only touch the bug site, happy to scope down — but the helper makes both nicer.
- Overlap is reproducible in any macOS terminal whose emoji font fallback is Apple Color Emoji (Ghostty/libghostty by default, plus Terminal.app, iTerm2 in many configs, kitty default profile). The original screenshot above is from Supacode, which embeds libghostty.

## Reproducing without this PR

On macOS, with the installed extension:

```bash
cat > /tmp/repro.mjs <<'EOF'
const turns = 4;
console.log(`worker · \u27F3${turns} · 8 tool uses · 1.9k token · 15.5s`);
EOF
node /tmp/repro.mjs
```

In any terminal whose emoji fallback is Apple Color Emoji (Ghostty/libghostty default, Terminal.app, iTerm2 default config, etc.), the `⟳` and the `4` overlap.
