### PR TITLE
Normalize output boolean strings and surface child exit errors

### DIFF
--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -494,7 +494,8 @@ export function executeAsyncSingle(
 		};
 	}
 
-	const outputPath = resolveSingleOutputPath(params.output, ctx.cwd, runnerCwd);
+	const normalizedOutput = params.output === "false" ? false : params.output === "true" ? agentConfig.output : params.output;
+	const outputPath = resolveSingleOutputPath(normalizedOutput, ctx.cwd, runnerCwd);
 	const outputMode = params.outputMode ?? "inline";
 	const validationError = validateFileOnlyOutputMode(outputMode, outputPath, `Async single run (${agent})`);
 	if (validationError) return formatAsyncStartError("single", validationError);

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -636,6 +636,10 @@ async function runSingleAttempt(
 	if (result.error && result.exitCode === 0) {
 		result.exitCode = 1;
 	}
+	if (result.exitCode !== 0 && !result.error) {
+		const signalHint = result.exitCode === 143 ? " (SIGTERM)" : result.exitCode === 137 ? " (SIGKILL)" : "";
+		result.error = `Subagent process exited with code ${result.exitCode}${signalHint}.`;
+	}
 	if (result.exitCode === 0 && !result.error) {
 		const errInfo = detectSubagentError(result.messages);
 		if (errInfo.hasError) {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -979,7 +979,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			};
 		}
 		const rawOutput = params.output !== undefined ? params.output : a.output;
-		const effectiveOutput: string | false | undefined = rawOutput === true ? a.output : (rawOutput as string | false | undefined);
+		const effectiveOutput: string | false | undefined = rawOutput === "false" ? false : (rawOutput === true || rawOutput === "true") ? a.output : (rawOutput as string | false | undefined);
 		const effectiveOutputMode = params.outputMode ?? "inline";
 		const normalizedSkills = normalizeSkillInput(params.skill);
 		const skills = normalizedSkills === false ? [] : normalizedSkills;
@@ -1716,7 +1716,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	);
 	let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
 	const rawOutput = params.output !== undefined ? params.output : agentConfig.output;
-	let effectiveOutput: string | false | undefined = rawOutput === true ? agentConfig.output : (rawOutput as string | false | undefined);
+	let effectiveOutput: string | false | undefined = rawOutput === "false" ? false : (rawOutput === true || rawOutput === "true") ? agentConfig.output : (rawOutput as string | false | undefined);
 	const effectiveOutputMode = params.outputMode ?? "inline";
 	const currentMaxSubagentDepth = resolveCurrentMaxSubagentDepth(deps.config.maxSubagentDepth);
 	const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, agentConfig.maxSubagentDepth);

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -238,6 +238,24 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		await waitForAsyncResultFile(chainId, 10_000);
 	});
 
+	it("async single treats string false as disabled output", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "async review done" });
+		const id = `async-string-false-output-${Date.now().toString(36)}`;
+		const result = executeAsyncSingle(id, {
+			agent: "reviewer",
+			task: "Review only",
+			agentConfig: makeAgent("reviewer"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			output: "false",
+		});
+		assert.equal(result.isError, undefined);
+		await waitForAsyncResultFile(id, 10_000);
+		assert.equal(fs.existsSync(path.join(tempDir, "false")), false);
+	});
+
 	it("top-level async parallel conversion preserves output, reads, and progress", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
 		mockPi.onCall({ output: "Async top-level report" });
 		const executor = createSubagentExecutor!({

--- a/test/integration/parallel-execution.test.ts
+++ b/test/integration/parallel-execution.test.ts
@@ -271,6 +271,41 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 		assert.equal(fs.existsSync(path.join(tempDir, "false")), false);
 	});
 
+	it("treats string false as disabled output in single runs", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "Single review done" });
+		const executor = makeExecutor();
+
+		const result = await executor.execute(
+			"single-string-false-output",
+			{ agent: "echo", task: "Review", output: "false" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.equal(fs.existsSync(path.join(tempDir, "false")), false);
+	});
+
+	it("treats string true as the agent default output path in single runs", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "Saved via default path" });
+		const defaultOutput = "default-output.md";
+		const executor = makeExecutor([makeAgent("echo", { output: defaultOutput })]);
+
+		const result = await executor.execute(
+			"single-string-true-output",
+			{ agent: "echo", task: "Review", output: "true" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		const outputPath = path.join(tempDir, defaultOutput);
+		assert.equal(result.isError, undefined);
+		assert.equal(fs.readFileSync(outputPath, "utf-8"), "Saved via default path");
+		assert.equal(result.details?.results?.[0]?.savedOutputPath, outputPath);
+	});
+
 	it("top-level parallel reads are injected once with chain-style prefix", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "Read done" });
 		const executor = makeExecutor();

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -223,6 +223,17 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.finalOutput, "Applied edit");
 	});
 
+	it("reports a clear error when the child exits non-zero without stderr", async () => {
+		mockPi.onCall({ exitCode: 143 });
+		const agents = makeAgentConfigs(["echo"]);
+
+		const result = await runSync(tempDir, agents, "echo", "Do something", {});
+
+		assert.equal(result.exitCode, 143);
+		assert.match(result.error ?? "", /Subagent process exited with code 143 \(SIGTERM\)/);
+		assert.equal(result.progress.status, "failed");
+	});
+
 	it("returns error for unknown agent", async () => {
 		const agents = makeAgentConfigs(["echo"]);
 		const result = await runSync(tempDir, agents, "nonexistent", "Do something", {});


### PR DESCRIPTION
## Summary
- Treat provider-coerced `output: "false"` as disabled output for foreground single, top-level async, and async single runs.
- Treat `output: "true"` like boolean true, using the agent default output path when available.
- Return a clear error for child processes that exit non-zero without stderr, including SIGTERM/SIGKILL hints.

## Why
Some tool schemas/providers can coerce booleans to strings. When `output:false` arrives as `"false"`, subagents currently create a file literally named `false` and inject misleading output instructions. Also, killed children can bubble up as a generic `Failed` instead of the useful exit-code signal.

## Validation
- `npm test`
- `npm run test:integration -- test/integration/parallel-execution.test.ts test/integration/single-execution.test.ts test/integration/async-execution.test.ts`