### PR TITLE
feat: enable code preview shell for subagent tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "dependencies": {
     "jiti": "^2.7.0",
+    "pi-code-previews": "^0.1.25",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "jiti": "^2.7.0",
-    "pi-code-previews": "^0.1.25",
+    "pi-code-previews": "^0.1.28",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,27 +1,26 @@
 {
   "name": "pi-subagents",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "Pi extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification",
-  "author": "Nico Bailon",
-  "license": "MIT",
-  "type": "module",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nicobailon/pi-subagents.git"
-  },
+  "keywords": [
+    "agents",
+    "ai",
+    "cli",
+    "pi",
+    "pi-coding-agent",
+    "pi-package",
+    "subagents"
+  ],
   "homepage": "https://github.com/nicobailon/pi-subagents#readme",
   "bugs": {
     "url": "https://github.com/nicobailon/pi-subagents/issues"
   },
-  "keywords": [
-    "pi-package",
-    "pi",
-    "pi-coding-agent",
-    "subagents",
-    "ai",
-    "agents",
-    "cli"
-  ],
+  "license": "MIT",
+  "author": "Nico Bailon",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nicobailon/pi-subagents.git"
+  },
   "bin": {
     "pi-subagents": "install.mjs"
   },
@@ -34,22 +33,23 @@
     "README.md",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "test": "npm run test:unit",
     "test:unit": "node --experimental-strip-types --test test/unit/*.test.ts",
     "test:integration": "node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/*.test.ts",
     "test:all": "npm run test:unit && npm run test:integration"
   },
-  "pi": {
-    "extensions": [
-      "./src/extension/index.ts"
-    ],
-    "skills": [
-      "./skills"
-    ],
-    "prompts": [
-      "./prompts"
-    ]
+  "dependencies": {
+    "jiti": "^2.7.0",
+    "pi-code-previews": "^0.1.25",
+    "typebox": "^1.1.24"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-agent-core": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-agent-core": "*",
@@ -71,15 +71,15 @@
       "optional": true
     }
   },
-  "dependencies": {
-    "jiti": "^2.7.0",
-    "pi-code-previews": "^0.1.25",
-    "typebox": "^1.1.24"
-  },
-  "devDependencies": {
-    "@earendil-works/pi-agent-core": "^0.74.0",
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.74.0",
-    "@earendil-works/pi-tui": "^0.74.0"
+  "pi": {
+    "extensions": [
+      "./src/extension/index.ts"
+    ],
+    "skills": [
+      "./skills"
+    ],
+    "prompts": [
+      "./prompts"
+    ]
   }
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -18,6 +18,7 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { type ExtensionAPI, type ExtensionContext, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Box, Container, Spacer, Text, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
+import { loadCodePreviewSettings, withCodePreviewShell } from "pi-code-previews";
 import { discoverAgents } from "../agents/agents.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
@@ -218,6 +219,8 @@ class SubagentControlNoticeComponent implements Component {
 		return lines;
 	}
 }
+
+await loadCodePreviewSettings();
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	if (process.env[SUBAGENT_CHILD_ENV] === "1") return;
@@ -472,7 +475,7 @@ DIAGNOSTICS:
 
 	};
 
-	pi.registerTool(tool);
+	pi.registerTool(withCodePreviewShell(tool));
 	registerSlashCommands(pi, state);
 
 	const eventUnsubscribeStoreKey = "__piSubagentEventUnsubscribes";


### PR DESCRIPTION
Add [`pi-code-preview`](https://github.com/mattleong/pi-code-previews) support

<img width="1202" height="607" alt="Screenshot 2026-05-10 at 12 58 49 PM" src="https://github.com/user-attachments/assets/15692098-0c5a-483a-bda3-55492f91ee46" />
