### PR TITLE
Fix: `mcp:` direct tools missing from `--tools` allowlist

### DIFF
--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -12,6 +12,51 @@ export const SUBAGENT_RUN_ID_ENV = "PI_SUBAGENT_RUN_ID";
 export const SUBAGENT_CHILD_AGENT_ENV = "PI_SUBAGENT_CHILD_AGENT";
 export const SUBAGENT_CHILD_INDEX_ENV = "PI_SUBAGENT_CHILD_INDEX";
 
+function resolveMcpDirectToolNames(serverNames: string[]): string[] {
+	const agentDir = process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".pi", "agent");
+	const cachePath = path.join(agentDir, "mcp-cache.json");
+	const configPath = path.join(agentDir, "mcp.json");
+
+	let cache: Record<string, unknown>;
+	try {
+		cache = JSON.parse(fs.readFileSync(cachePath, "utf-8"));
+	} catch {
+		return [];
+	}
+
+	let prefix: "server" | "none" | "short" = "server";
+	try {
+		const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+		if (config?.settings?.toolPrefix === "none" || config?.settings?.toolPrefix === "short") {
+			prefix = config.settings.toolPrefix;
+		}
+	} catch {
+		// Config is optional; default prefix is "server".
+	}
+
+	const servers = (cache as { servers?: Record<string, { tools?: Array<{ name: string }> }> }).servers;
+	if (!servers) return [];
+
+	const names: string[] = [];
+	for (const serverName of serverNames) {
+		const serverCache = servers[serverName];
+		if (!serverCache?.tools) continue;
+
+		const serverPrefix = prefix === "none"
+			? ""
+			: prefix === "short"
+				? (serverName.replace(/-?mcp$/i, "").replace(/-/g, "_") || "mcp")
+				: serverName.replace(/-/g, "_");
+
+		for (const tool of serverCache.tools) {
+			const prefixedName = serverPrefix ? `${serverPrefix}_${tool.name}` : tool.name;
+			names.push(prefixedName);
+		}
+	}
+
+	return names;
+}
+
 interface BuildPiArgsInput {
 	baseArgs: string[];
 	task: string;
@@ -70,13 +115,20 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	}
 
 	const toolExtensionPaths: string[] = [];
-	if (input.tools?.length) {
+	if (input.tools?.length || input.mcpDirectTools?.length) {
 		const builtinTools: string[] = [];
-		for (const tool of input.tools) {
+		for (const tool of input.tools ?? []) {
 			if (tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")) {
 				toolExtensionPaths.push(tool);
 			} else {
 				builtinTools.push(tool);
+			}
+		}
+		if (input.mcpDirectTools?.length) {
+			for (const name of resolveMcpDirectToolNames(input.mcpDirectTools)) {
+				if (!builtinTools.includes(name)) {
+					builtinTools.push(name);
+				}
 			}
 		}
 		if (builtinTools.length > 0) {

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -207,3 +207,50 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.ok(args.includes("--system-prompt"));
 	});
 });
+
+describe("buildPiArgs MCP direct tool allowlist", () => {
+	it("includes prefixed MCP direct tool names in --tools", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-args-mcp-"));
+		const origEnv = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		try {
+			fs.writeFileSync(path.join(agentDir, "mcp-cache.json"), JSON.stringify({
+				servers: {
+					"chrome-devtools": {
+						configHash: "abc",
+						tools: [
+							{ name: "take_screenshot", description: "Take a screenshot" },
+							{ name: "navigate", description: "Navigate to URL" },
+						],
+						resources: [],
+						cachedAt: new Date().toISOString(),
+					},
+				},
+			}));
+
+			const { args } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				tools: ["read", "bash"],
+				mcpDirectTools: ["chrome-devtools"],
+			});
+
+			const toolsIdx = args.indexOf("--tools");
+			assert.ok(toolsIdx !== -1, "--tools should be present");
+			const toolsList = args[toolsIdx + 1]!.split(",");
+
+			assert.ok(toolsList.includes("read"));
+			assert.ok(toolsList.includes("bash"));
+			assert.ok(toolsList.includes("chrome_devtools_take_screenshot"),
+				`should include chrome_devtools_take_screenshot in --tools, got: ${toolsList}`);
+			assert.ok(toolsList.includes("chrome_devtools_navigate"),
+				`should include chrome_devtools_navigate in --tools, got: ${toolsList}`);
+		} finally {
+			process.env.PI_CODING_AGENT_DIR = origEnv;
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -209,25 +209,49 @@ describe("buildPiArgs system prompt mode wiring", () => {
 });
 
 describe("buildPiArgs MCP direct tool allowlist", () => {
-	it("includes prefixed MCP direct tool names in --tools", () => {
-		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-args-mcp-"));
-		const origEnv = process.env.PI_CODING_AGENT_DIR;
-		process.env.PI_CODING_AGENT_DIR = agentDir;
-		try {
-			fs.writeFileSync(path.join(agentDir, "mcp-cache.json"), JSON.stringify({
-				servers: {
-					"chrome-devtools": {
-						configHash: "abc",
-						tools: [
-							{ name: "take_screenshot", description: "Take a screenshot" },
-							{ name: "navigate", description: "Navigate to URL" },
-						],
-						resources: [],
-						cachedAt: new Date().toISOString(),
-					},
-				},
-			}));
+	let agentDir: string;
+	let origEnv: string | undefined;
 
+	function setup(cacheContent?: object, mcpConfig?: object) {
+		agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-args-mcp-"));
+		origEnv = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		if (cacheContent) {
+			fs.writeFileSync(path.join(agentDir, "mcp-cache.json"), JSON.stringify(cacheContent));
+		}
+		if (mcpConfig) {
+			fs.writeFileSync(path.join(agentDir, "mcp.json"), JSON.stringify(mcpConfig));
+		}
+	}
+
+	function teardown() {
+		process.env.PI_CODING_AGENT_DIR = origEnv;
+		fs.rmSync(agentDir, { recursive: true, force: true });
+	}
+
+	const cacheWithChromeDevtools = {
+		servers: {
+			"chrome-devtools": {
+				configHash: "abc",
+				tools: [
+					{ name: "take_screenshot", description: "Take a screenshot" },
+					{ name: "navigate", description: "Navigate to URL" },
+				],
+				resources: [],
+				cachedAt: new Date().toISOString(),
+			},
+		},
+	};
+
+	function getToolsList(args: string[]): string[] {
+		const idx = args.indexOf("--tools");
+		if (idx === -1) return [];
+		return args[idx + 1]!.split(",");
+	}
+
+	it("includes prefixed MCP direct tool names in --tools (default server prefix)", () => {
+		setup(cacheWithChromeDevtools);
+		try {
 			const { args } = buildPiArgs({
 				baseArgs: ["-p"],
 				task: "hello",
@@ -238,19 +262,136 @@ describe("buildPiArgs MCP direct tool allowlist", () => {
 				mcpDirectTools: ["chrome-devtools"],
 			});
 
-			const toolsIdx = args.indexOf("--tools");
-			assert.ok(toolsIdx !== -1, "--tools should be present");
-			const toolsList = args[toolsIdx + 1]!.split(",");
-
+			const toolsList = getToolsList(args);
 			assert.ok(toolsList.includes("read"));
 			assert.ok(toolsList.includes("bash"));
 			assert.ok(toolsList.includes("chrome_devtools_take_screenshot"),
-				`should include chrome_devtools_take_screenshot in --tools, got: ${toolsList}`);
+				`expected chrome_devtools_take_screenshot, got: ${toolsList}`);
 			assert.ok(toolsList.includes("chrome_devtools_navigate"),
-				`should include chrome_devtools_navigate in --tools, got: ${toolsList}`);
+				`expected chrome_devtools_navigate, got: ${toolsList}`);
 		} finally {
-			process.env.PI_CODING_AGENT_DIR = origEnv;
-			fs.rmSync(agentDir, { recursive: true, force: true });
+			teardown();
+		}
+	});
+
+	it("uses short prefix (strips -mcp suffix, replaces dashes)", () => {
+		const cache = {
+			servers: {
+				"firebase-mcp": {
+					configHash: "x",
+					tools: [{ name: "deploy", description: "Deploy" }],
+					resources: [],
+					cachedAt: new Date().toISOString(),
+				},
+			},
+		};
+		setup(cache, { settings: { toolPrefix: "short" } });
+		try {
+			const { args } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				tools: ["read"],
+				mcpDirectTools: ["firebase-mcp"],
+			});
+
+			const toolsList = getToolsList(args);
+			assert.ok(toolsList.includes("firebase_deploy"),
+				`expected firebase_deploy, got: ${toolsList}`);
+		} finally {
+			teardown();
+		}
+	});
+
+	it("uses no prefix when toolPrefix is none", () => {
+		setup(cacheWithChromeDevtools, { settings: { toolPrefix: "none" } });
+		try {
+			const { args } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				tools: ["read"],
+				mcpDirectTools: ["chrome-devtools"],
+			});
+
+			const toolsList = getToolsList(args);
+			assert.ok(toolsList.includes("take_screenshot"),
+				`expected take_screenshot, got: ${toolsList}`);
+			assert.ok(toolsList.includes("navigate"),
+				`expected navigate, got: ${toolsList}`);
+		} finally {
+			teardown();
+		}
+	});
+
+	it("includes MCP tools in --tools even without explicit builtin tools", () => {
+		setup(cacheWithChromeDevtools);
+		try {
+			const { args } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				mcpDirectTools: ["chrome-devtools"],
+			});
+
+			const toolsList = getToolsList(args);
+			assert.ok(toolsList.includes("chrome_devtools_take_screenshot"),
+				`expected chrome_devtools_take_screenshot, got: ${toolsList}`);
+			assert.ok(toolsList.includes("chrome_devtools_navigate"),
+				`expected chrome_devtools_navigate, got: ${toolsList}`);
+			// Should NOT include random builtins — only MCP tools
+			assert.ok(!toolsList.includes("read"));
+			assert.ok(!toolsList.includes("bash"));
+		} finally {
+			teardown();
+		}
+	});
+
+	it("falls back gracefully when mcp-cache.json is missing", () => {
+		setup(); // no cache file
+		try {
+			const { args } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				tools: ["read", "bash"],
+				mcpDirectTools: ["chrome-devtools"],
+			});
+
+			const toolsList = getToolsList(args);
+			// Only explicit tools, no MCP tools resolved
+			assert.deepEqual(toolsList, ["read", "bash"]);
+		} finally {
+			teardown();
+		}
+	});
+
+	it("ignores server not present in cache", () => {
+		setup(cacheWithChromeDevtools);
+		try {
+			const { args } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				tools: ["read"],
+				mcpDirectTools: ["nonexistent-server"],
+			});
+
+			const toolsList = getToolsList(args);
+			// Only explicit tools, unknown server silently ignored
+			assert.deepEqual(toolsList, ["read"]);
+		} finally {
+			teardown();
 		}
 	});
 });


### PR DESCRIPTION
 ## Fix: `mcp:` direct tools missing from `--tools` allowlist

 ### Problem

 When an agent frontmatter specifies both explicit tools and `mcp:` entries:

 ```yaml
 tools: read, bash, mcp:chrome-devtools
 ```

 the child process cannot use the MCP direct tools. `pi-subagents` correctly sets `MCP_DIRECT_TOOLS=chrome-devtools` and `pi-mcp-adapter` registers
 the tools via `pi.registerTool()`, but `--tools read,bash` causes Pi core to filter them out through `allowedToolNames` because the prefixed names
 (e.g. `chrome_devtools_take_screenshot`) are never added to the allowlist.

 This contradicts the documented behavior in README:

 > `tools: read, bash, mcp:chrome-devtools`: only `read` and `bash` as builtins, **plus direct Chrome DevTools MCP tools**.

 ### Reproduction

 ```bash
 MCP_DIRECT_TOOLS="chrome-devtools" \
 pi -p --tools "read,bash" --no-session \
   "Output ONLY a comma-separated list of EVERY tool you have available."
 # Result: read, bash (no MCP tools)

 # Without --tools restriction:
 MCP_DIRECT_TOOLS="chrome-devtools" \
 pi -p --no-session \
   "Output ONLY a comma-separated list of EVERY tool you have available."
 # Result: read, bash, ..., chrome_devtools_take_screenshot, chrome_devtools_navigate, ...
 ```

 ### Fix

 `buildPiArgs` now resolves prefixed MCP tool names from the `pi-mcp-adapter` metadata cache (`mcp-cache.json`) and includes them in the `--tools`
 argument. This matches the prefix logic in `pi-mcp-adapter` (`formatToolName` / `getServerPrefix`).

 When the cache is missing or a server is not yet cached, behavior degrades gracefully — no names are added and tools fall back to proxy-only access
 via the `mcp` tool.

 ### Changes

 - `src/runs/shared/pi-args.ts` — added `resolveMcpDirectToolNames()` and integrated it into the `--tools` construction in `buildPiArgs()`
 - `test/unit/pi-args.test.ts` — added unit tests covering the fix and edge cases