### PR TITLE
Skip legacy non-agent subtrees during agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Agent locations, lowest to highest priority:
 | User | `~/.pi/agent/agents/**/*.md` |
 | Project | `.pi/agents/**/*.md` |
 
-Project discovery also reads legacy `.agents/**/*.md` files. Nested subdirectories are discovered recursively. `.chain.md` files do not define agents. If both `.agents/` and `.pi/agents/` define the same parsed runtime agent name, `.pi/agents/` wins. Use `agentScope: "user" | "project" | "both"` to control discovery; `both` is the default and project definitions win runtime-name collisions.
+Project discovery also reads legacy `.agents/**/*.md` files. Nested subdirectories are discovered recursively, except the legacy `.agents/skills/`, `.agents/prompts/`, and `.agents/commands/` subtrees are reserved for non-agent content and are not scanned as agents. `.chain.md` files do not define agents. If both `.agents/` and `.pi/agents/` define the same parsed runtime agent name, `.pi/agents/` wins. Use `agentScope: "user" | "project" | "both"` to control discovery; `both` is the default and project definitions win runtime-name collisions.
 
 Builtin agents load at the lowest priority, so a user or project agent with the same name overrides them. They do not pin a provider model; they inherit your current Pi default model unless you set `subagents.agentOverrides.<name>.model`. `oracle` is an advisory reviewer that critiques direction and proposes an execution prompt without editing files. `worker` is the implementation agent for normal tasks and approved oracle handoffs.
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -178,13 +178,13 @@ agent with the same name only when you want a substantially different agent.
 Agent files can live in:
 - `~/.pi/agent/agents/**/*.md` — user scope
 - `.pi/agents/**/*.md` — canonical project scope
-- legacy `.agents/**/*.md` — still read for compatibility, but `.pi/agents/` wins on conflicts
+- legacy `.agents/**/*.md` — still read for compatibility, but `.pi/agents/` wins on conflicts; `.agents/skills/`, `.agents/prompts/`, and `.agents/commands/` are reserved for non-agent content and are not scanned as agents
 
 Chains live in:
 - `~/.pi/agent/chains/**/*.chain.md` — user scope
 - `.pi/chains/**/*.chain.md` — project scope
 
-Discovery is recursive. `.chain.md` files do not define agents. Agents and chains can set optional frontmatter `package: code-analysis`; `name: scout` plus `package: code-analysis` registers as runtime name `code-analysis.scout` while serialization keeps `name` and `package` separate.
+Discovery is recursive, except the reserved legacy `.agents/skills/`, `.agents/prompts/`, and `.agents/commands/` subtrees are skipped during agent discovery. `.chain.md` files do not define agents. Agents and chains can set optional frontmatter `package: code-analysis`; `name: scout` plus `package: code-analysis` registers as runtime name `code-analysis.scout` while serialization keeps `name` and `package` separate.
 
 Precedence is by parsed runtime name:
 1. project scope

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -517,34 +517,47 @@ export function removeBuiltinAgentOverride(cwd: string, name: string, scope: "us
 	return filePath;
 }
 
-function listMarkdownFilesRecursive(dir: string, predicate: (fileName: string) => boolean): string[] {
+const LEGACY_AGENT_NON_AGENT_SUBTREES = ["skills", "prompts", "commands"];
+
+function legacyAgentExcludedDirs(dir: string): string[] {
+	return LEGACY_AGENT_NON_AGENT_SUBTREES.map((name) => path.join(dir, name));
+}
+
+function listMarkdownFilesRecursive(dir: string, predicate: (fileName: string) => boolean, excludedDirs: string[] = []): string[] {
 	const files: string[] = [];
-	if (!fs.existsSync(dir)) return files;
+	const excluded = new Set(excludedDirs.map((excludedDir) => path.resolve(excludedDir)));
 
-	let entries: fs.Dirent[];
-	try {
-		entries = fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
-	} catch {
-		return files;
-	}
+	function walk(currentDir: string): void {
+		if (!fs.existsSync(currentDir)) return;
+		if (excluded.has(path.resolve(currentDir))) return;
 
-	for (const entry of entries) {
-		const filePath = path.join(dir, entry.name);
-		if (entry.isDirectory()) {
-			files.push(...listMarkdownFilesRecursive(filePath, predicate));
-			continue;
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(currentDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+		} catch {
+			return;
 		}
-		if (!entry.isFile() && !entry.isSymbolicLink()) continue;
-		if (!predicate(entry.name)) continue;
-		files.push(filePath);
+
+		for (const entry of entries) {
+			const filePath = path.join(currentDir, entry.name);
+			if (entry.isDirectory()) {
+				walk(filePath);
+				continue;
+			}
+			if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+			if (!predicate(entry.name)) continue;
+			files.push(filePath);
+		}
 	}
+
+	walk(dir);
 	return files;
 }
 
-function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
+function loadAgentsFromDir(dir: string, source: AgentSource, options: { excludedDirs?: string[] } = {}): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
-	for (const filePath of listMarkdownFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"))) {
+	for (const filePath of listMarkdownFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"), options.excludedDirs)) {
 		let content: string;
 		try {
 			content = fs.readFileSync(filePath, "utf-8");
@@ -665,6 +678,10 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	return agents;
 }
 
+function loadLegacyAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
+	return loadAgentsFromDir(dir, source, { excludedDirs: legacyAgentExcludedDirs(dir) });
+}
+
 function loadChainsFromDir(dir: string, source: AgentSource): ChainConfig[] {
 	const chains: ChainConfig[] = [];
 
@@ -740,10 +757,12 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	);
 
 	const userAgentsOld = scope === "project" ? [] : loadAgentsFromDir(userDirOld, "user");
-	const userAgentsNew = scope === "project" ? [] : loadAgentsFromDir(userDirNew, "user");
+	const userAgentsNew = scope === "project" ? [] : loadLegacyAgentsFromDir(userDirNew, "user");
 	const userAgents = [...userAgentsOld, ...userAgentsNew];
 
-	const projectAgents = scope === "user" ? [] : projectAgentDirs.flatMap((dir) => loadAgentsFromDir(dir, "project"));
+	const projectAgents = scope === "user" ? [] : projectAgentDirs.flatMap((dir) =>
+		path.basename(dir) === ".agents" ? loadLegacyAgentsFromDir(dir, "project") : loadAgentsFromDir(dir, "project")
+	);
 	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents)
 		.filter((agent) => agent.disabled !== true);
 
@@ -781,11 +800,12 @@ export function discoverAgentsAll(cwd: string): {
 	);
 	const user = [
 		...loadAgentsFromDir(userDirOld, "user"),
-		...loadAgentsFromDir(userDirNew, "user"),
+		...loadLegacyAgentsFromDir(userDirNew, "user"),
 	];
 	const projectMap = new Map<string, AgentConfig>();
 	for (const dir of projectDirs) {
-		for (const agent of loadAgentsFromDir(dir, "project")) {
+		const agents = path.basename(dir) === ".agents" ? loadLegacyAgentsFromDir(dir, "project") : loadAgentsFromDir(dir, "project");
+		for (const agent of agents) {
 			projectMap.set(agent.name, agent);
 		}
 	}

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -565,6 +565,114 @@ Canonical prompt
 		assert.equal(result.projectAgentsDir, path.join(dir, ".pi", "agents"));
 	});
 
+	it("excludes known non-agent subtrees from legacy .agents discovery", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-legacy-agent-exclusions-"));
+		tempDirs.push(dir);
+		fs.mkdirSync(path.join(dir, ".agents", "nested"), { recursive: true });
+		fs.mkdirSync(path.join(dir, ".agents", "skills", "code-review"), { recursive: true });
+		fs.mkdirSync(path.join(dir, ".agents", "prompts"), { recursive: true });
+		fs.mkdirSync(path.join(dir, ".agents", "commands"), { recursive: true });
+		fs.mkdirSync(path.join(dir, ".pi", "agents", "skills"), { recursive: true });
+		fs.writeFileSync(path.join(dir, ".agents", "legacy.md"), `---
+name: legacy-allowed
+description: Legacy allowed
+---
+
+Legacy prompt
+`, "utf-8");
+		fs.writeFileSync(path.join(dir, ".agents", "nested", "nested.md"), `---
+name: legacy-nested-allowed
+description: Legacy nested allowed
+---
+
+Nested prompt
+`, "utf-8");
+		fs.writeFileSync(path.join(dir, ".agents", "skills", "code-review", "SKILL.md"), `---
+name: legacy-skill
+description: Legacy skill should not be an agent
+---
+
+Skill prompt
+`, "utf-8");
+		fs.writeFileSync(path.join(dir, ".agents", "prompts", "prompt.md"), `---
+name: legacy-prompt
+description: Legacy prompt should not be an agent
+---
+
+Prompt body
+`, "utf-8");
+		fs.writeFileSync(path.join(dir, ".agents", "commands", "command.md"), `---
+name: legacy-command
+description: Legacy command should not be an agent
+---
+
+Command body
+`, "utf-8");
+		fs.writeFileSync(path.join(dir, ".pi", "agents", "skills", "canonical.md"), `---
+name: canonical-under-skills
+description: Canonical agent under skills dir
+---
+
+Canonical prompt
+`, "utf-8");
+
+		const result = discoverAgents(dir, "project");
+		const names = new Set(result.agents.map((agent) => agent.name));
+		assert.equal(names.has("legacy-allowed"), true);
+		assert.equal(names.has("legacy-nested-allowed"), true);
+		assert.equal(names.has("canonical-under-skills"), true);
+		assert.equal(names.has("legacy-skill"), false);
+		assert.equal(names.has("legacy-prompt"), false);
+		assert.equal(names.has("legacy-command"), false);
+
+		const allProjectNames = new Set(discoverAgentsAll(dir).project.map((agent) => agent.name));
+		assert.equal(allProjectNames.has("legacy-skill"), false);
+		assert.equal(allProjectNames.has("legacy-prompt"), false);
+		assert.equal(allProjectNames.has("legacy-command"), false);
+	});
+
+	it("excludes known non-agent subtrees from user legacy .agents discovery", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-user-legacy-agent-exclusions-"));
+		const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-user-legacy-agent-home-"));
+		tempDirs.push(dir);
+		tempDirs.push(homeDir);
+		const previousHome = process.env.HOME;
+		const previousUserProfile = process.env.USERPROFILE;
+
+		try {
+			process.env.HOME = homeDir;
+			process.env.USERPROFILE = homeDir;
+			fs.mkdirSync(path.join(homeDir, ".agents", "skills"), { recursive: true });
+			fs.writeFileSync(path.join(homeDir, ".agents", "user-agent.md"), `---
+name: user-legacy-allowed
+description: User legacy allowed
+---
+
+User prompt
+`, "utf-8");
+			fs.writeFileSync(path.join(homeDir, ".agents", "skills", "SKILL.md"), `---
+name: user-legacy-skill
+description: User legacy skill should not be an agent
+---
+
+Skill prompt
+`, "utf-8");
+
+			const names = new Set(discoverAgents(dir, "user").agents.map((agent) => agent.name));
+			assert.equal(names.has("user-legacy-allowed"), true);
+			assert.equal(names.has("user-legacy-skill"), false);
+
+			const allUserNames = new Set(discoverAgentsAll(dir).user.map((agent) => agent.name));
+			assert.equal(allUserNames.has("user-legacy-allowed"), true);
+			assert.equal(allUserNames.has("user-legacy-skill"), false);
+		} finally {
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+			else process.env.USERPROFILE = previousUserProfile;
+		}
+	});
+
 	it("prefers .pi/agents over .agents on project agent name collisions", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-project-agent-collision-"));
 		tempDirs.push(dir);


### PR DESCRIPTION
## Summary

Hi! This keeps legacy `.agents` discovery from accidentally treating non-agent content as runnable agents.

- skip `.agents/skills`, `.agents/prompts`, and `.agents/commands` during legacy agent discovery
- keep recursive discovery for other nested legacy agent files and all canonical `.pi/agents` paths
- document the reserved legacy subtrees in the README and pi-subagents skill

## Validation

- `npm run test:unit`
- `bun run test:unit`