### PR TITLE
Add option to disable bundled slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,14 @@ Makes top-level calls use background execution when the request does not explici
 
 Forces depth-0 single, parallel, and chain runs into background mode and bypasses clarify UI by forcing `clarify: false`. Nested calls keep their own inherited settings.
 
+### `slashCommands`
+
+```json
+{ "slashCommands": false }
+```
+
+Disables the integrated `pi-subagents` slash commands registered by the extension, including `/run`, `/chain`, `/run-chain`, `/parallel`, and `/subagents-doctor`. The `subagent` tool remains available for natural-language delegation and direct tool calls.
+
 ### `parallel`
 
 ```json

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -9,7 +9,7 @@
  * Toggle: async parameter (default: false, configurable via config.json)
  *
  * Config file: ~/.pi/agent/extensions/subagent/config.json
- *   { "asyncByDefault": true, "forceTopLevelAsync": true, "maxSubagentDepth": 1, "intercomBridge": { "mode": "always", "instructionFile": "./intercom-bridge.md" }, "worktreeSetupHook": "./scripts/setup-worktree.mjs" }
+ *   { "asyncByDefault": true, "forceTopLevelAsync": true, "slashCommands": false, "maxSubagentDepth": 1, "intercomBridge": { "mode": "always", "instructionFile": "./intercom-bridge.md" }, "worktreeSetupHook": "./scripts/setup-worktree.mjs" }
  */
 
 import * as fs from "node:fs";
@@ -473,7 +473,9 @@ DIAGNOSTICS:
 	};
 
 	pi.registerTool(tool);
-	registerSlashCommands(pi, state);
+	if (config.slashCommands !== false) {
+		registerSlashCommands(pi, state);
+	}
 
 	const eventUnsubscribeStoreKey = "__piSubagentEventUnsubscribes";
 	const controlNoticeSeenStoreKey = "__piSubagentVisibleControlNotices";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -497,6 +497,7 @@ interface TopLevelParallelConfig {
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
 	forceTopLevelAsync?: boolean;
+	slashCommands?: boolean;
 	defaultSessionDir?: string;
 	maxSubagentDepth?: number;
 	control?: ControlConfig;

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -66,6 +66,55 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
+	it("does not register integrated slash commands when slashCommands is false", () => {
+		const script = String.raw`
+			import * as fs from "node:fs";
+			import * as os from "node:os";
+			import * as path from "node:path";
+			import registerSubagentExtension from "./src/extension/index.ts";
+			const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-home-"));
+			process.env.HOME = home;
+			const configDir = path.join(home, ".pi", "agent", "extensions", "subagent");
+			fs.mkdirSync(configDir, { recursive: true });
+			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ slashCommands: false }), "utf-8");
+			const commands = [];
+			const events = { on() { return () => {}; }, emit() {} };
+			const fakePi = new Proxy({
+				events,
+				registerTool() {},
+				registerCommand(name) { commands.push(name); },
+				registerShortcut() {},
+				registerMessageRenderer() {},
+				sendMessage() {},
+				getSessionName() { return undefined; },
+			}, {
+				get(target, prop) {
+					if (prop in target) return target[prop];
+					return () => undefined;
+				},
+			});
+			registerSubagentExtension(fakePi);
+			const integrated = ["run", "chain", "run-chain", "parallel", "subagents-doctor"];
+			const registeredIntegrated = commands.filter((name) => integrated.includes(name));
+			if (registeredIntegrated.length > 0) {
+				throw new Error("Unexpected slash command registrations: " + registeredIntegrated.join(", "));
+			}
+		`;
+
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-transform-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" },
+		);
+	});
+
 	it("returns before registering parent tools, slash commands, renderers, or event handlers", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./src/extension/index.ts";


### PR DESCRIPTION
Hi! 👋

This adds a small `slashCommands: false` config option for folks who want to keep the `subagent` tool available but opt out of the extension's integrated slash commands.

What changed:
- skips registering the bundled slash commands when `slashCommands === false`
- documents the new config option in the README
- adds a unit test to cover the opt-out path

Tested with:
- `npm test -- --runInBand`
