### PR TITLE
perf: throttle subprocess UI updates to reduce TUI lag during chain execution

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -467,7 +467,7 @@ DIAGNOSTICS:
 
 		renderResult(result, options, theme, context) {
 			syncResultAnimation(result, context);
-			return renderSubagentResult(result, options, theme);
+			return renderSubagentResult(result, options, theme, context);
 		},
 
 	};

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -400,6 +400,16 @@ async function runSingleAttempt(
 			progress.durationMs = Date.now() - startTime;
 			emitUpdateSnapshot(getFinalOutput(result.messages) || "(running...)");
 		};
+		let lastThrottledFireUpdate = 0;
+		const FIRE_UPDATE_MIN_INTERVAL_MS = 100;
+		const throttledFireUpdate = () => {
+			if (!options.onUpdate || processClosed) return;
+			const now = Date.now();
+			progress.durationMs = now - startTime;
+			if (lastThrottledFireUpdate && now - lastThrottledFireUpdate < FIRE_UPDATE_MIN_INTERVAL_MS) return;
+			lastThrottledFireUpdate = now;
+			emitUpdateSnapshot(getFinalOutput(result.messages) || "(running...)");
+		};
 
 		const processLine = (line: string) => {
 			if (!line.trim()) return;
@@ -432,7 +442,7 @@ async function runSingleAttempt(
 				const mutates = isMutatingTool(evt.toolName, toolArgs);
 				observedMutationAttempt = observedMutationAttempt || mutates;
 				pendingToolResult = { tool: evt.toolName ?? "tool", path: progress.currentPath, mutates, startedAt: now };
-				fireUpdate();
+				throttledFireUpdate();
 			}
 
 			if (evt.type === "tool_execution_end") {
@@ -447,7 +457,7 @@ async function runSingleAttempt(
 				progress.currentToolArgs = undefined;
 				progress.currentToolStartedAt = undefined;
 				progress.currentPath = undefined;
-				fireUpdate();
+				throttledFireUpdate();
 			}
 
 			if (evt.type === "message_end" && evt.message) {
@@ -477,7 +487,7 @@ async function runSingleAttempt(
 					}
 				}
 				updateActivityState(now);
-				fireUpdate();
+				throttledFireUpdate();
 			}
 
 			if (evt.type === "tool_result_end" && evt.message) {
@@ -506,7 +516,7 @@ async function runSingleAttempt(
 				} else if (toolSnapshot?.mutates) {
 					resetMutatingFailureState(mutatingFailures);
 				}
-				fireUpdate();
+				throttledFireUpdate();
 			}
 		};
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -940,8 +940,24 @@ export function renderSubagentResult(
 	result: AgentToolResult<Details>,
 	options: { expanded: boolean },
 	theme: Theme,
+	context?: { state: Record<string, unknown> },
 ): Component {
 	const d = result.details;
+
+	// Memoization: if details haven't changed and result is not actively running,
+	// reuse cached component. For running results we skip caching since the spinner
+	// glyph needs rebuilding every tick. The throttle in execution.ts prevents
+	// excessive update events from the subprocess.
+	if (context) {
+		const cachedDetails = context.state._saLastDetails as Details | undefined;
+		const cachedComponent = context.state._saLastComponent as Container | undefined;
+		const isRunning = d?.progress?.some((p) => p.status === "running")
+			|| d?.results?.some((r) => r.progress?.status === "running");
+		if (!isRunning && cachedDetails === d && cachedComponent) {
+			return cachedComponent;
+		}
+	}
+
 	if (!d || !d.results.length) {
 		const t = result.content[0];
 		const text = t?.type === "text" ? t.text : "(no output)";
@@ -954,7 +970,11 @@ export function renderSubagentResult(
 
 	if (d.mode === "single" && d.results.length === 1) {
 		const r = d.results[0];
-		if (!expanded) return renderSingleCompact(d, r, theme);
+		if (!expanded) {
+			const comp = renderSingleCompact(d, r, theme);
+			if (context) { context.state._saLastDetails = d; context.state._saLastComponent = comp; }
+			return comp;
+		}
 		const isRunning = r.progress?.status === "running";
 		const icon = isRunning
 			? theme.fg("warning", "running")
@@ -1044,10 +1064,15 @@ export function renderSubagentResult(
 			c.addChild(new Spacer(1));
 			c.addChild(new Text(fit(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
 		}
+		if (context) { context.state._saLastDetails = d; context.state._saLastComponent = c; }
 		return c;
 	}
 
-	if (!expanded) return renderMultiCompact(d, theme);
+	if (!expanded) {
+		const comp = renderMultiCompact(d, theme);
+		if (context) { context.state._saLastDetails = d; context.state._saLastComponent = comp; }
+		return comp;
+	}
 
 	const hasRunning = d.progress?.some((p) => p.status === "running") 
 		|| d.results.some((r) => r.progress?.status === "running");
@@ -1244,5 +1269,6 @@ export function renderSubagentResult(
 		c.addChild(new Spacer(1));
 		c.addChild(new Text(fit(theme.fg("dim", `Artifacts dir: ${shortenPath(d.artifacts.dir)}`)), 0, 0));
 	}
+	if (context) { context.state._saLastDetails = d; context.state._saLastComponent = c; }
 	return c;
 }


### PR DESCRIPTION
When running subagent chains, the TUI lags badly — spinners barely move and time counters don't update consistently.

## Root cause

The subagent executor in `execution.ts` calls `onUpdate` on every tool start/end and message event from the child process (~24 events per chain step). Each call triggers a full `renderSubagentResult()` rebuild of the TUI component tree, plus a full terminal re-render via `doRender()`. Combined with the 80ms spinner animation interval, the rendering pipeline gets overwhelmed.

## Changes

### 1. Throttled UI updates (`src/runs/foreground/execution.ts`)
- Added `throttledFireUpdate()` with a 100ms minimum interval between UI updates
- The 4 high-frequency event handlers (`tool_execution_start`, `tool_execution_end`, `message_end`, `tool_result_end`) now use the throttled version
- Final result updates and control events (needs_attention, active_long_running) remain unthrottled via the original `fireUpdate()`

This reduces UI updates from the subprocess by ~3× during active execution.

### 2. Render memoization (`src/tui/render.ts`)
- `renderSubagentResult()` now accepts an optional `context` parameter
- When result details haven't changed (same object reference) and the result is not actively running, the previously built Container component is reused
- Running results still rebuild fully (spinner needs fresh `Date.now()` values), but the throttle limits how often this happens

### 3. Context passthrough (`src/extension/index.ts`)
- `renderResult` passes the render context through to `renderSubagentResult` so memoization state is available via `context.state`