### PR TITLE
fix: sanitize forked session tool IDs and thinking signatures for Anthropic compatibility

### DIFF
--- a/src/shared/fork-context.ts
+++ b/src/shared/fork-context.ts
@@ -1,6 +1,75 @@
 import * as fs from "node:fs";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 
+const VALID_TOOL_ID = /^[a-zA-Z0-9_-]+$/;
+
+function sanitizeForkedSession(sessionFile: string): void {
+	const lines = fs.readFileSync(sessionFile, "utf-8").split("\n");
+	const mapping = new Map<string, string>();
+	const seen = new Set<string>();
+
+	function getSanitized(id: string): string {
+		if (VALID_TOOL_ID.test(id)) return id;
+		if (mapping.has(id)) return mapping.get(id)!;
+		let sanitized = id.replace(/[^a-zA-Z0-9_-]/g, "_");
+		let counter = 1;
+		const base = sanitized;
+		while (seen.has(sanitized)) {
+			sanitized = `${base}_${counter++}`;
+		}
+		seen.add(sanitized);
+		mapping.set(id, sanitized);
+		return sanitized;
+	}
+
+	function sanitizeValue(value: unknown): unknown {
+		if (Array.isArray(value)) {
+			return value.map(sanitizeValue);
+		}
+		if (value && typeof value === "object") {
+			const result: Record<string, unknown> = {};
+			for (const [key, val] of Object.entries(value)) {
+				if (
+					key === "toolCallId" ||
+					key === "tool_use_id" ||
+					(key === "id" && typeof val === "string" && !VALID_TOOL_ID.test(val))
+				) {
+					result[key] = getSanitized(val);
+				} else if (key === "thinkingSignature") {
+					// Strip thinkingSignature — Pi maps this to `signature` in the Anthropic
+					// API payload, but the value (e.g. "reasoning") is not a valid cryptographic
+					// signature. Anthropic rejects it with:
+					// "Invalid `signature` in `thinking` block"
+					continue;
+				} else {
+					result[key] = sanitizeValue(val);
+				}
+			}
+			return result;
+		}
+		return value;
+	}
+
+	const sanitizedLines: string[] = [];
+	for (const line of lines) {
+		if (!line.trim()) {
+			sanitizedLines.push(line);
+			continue;
+		}
+		try {
+			const entry = JSON.parse(line);
+			if (entry.type === "message" && entry.message) {
+				entry.message = sanitizeValue(entry.message);
+			}
+			sanitizedLines.push(JSON.stringify(entry));
+		} catch {
+			sanitizedLines.push(line);
+		}
+	}
+
+	fs.writeFileSync(sessionFile, sanitizedLines.join("\n"), "utf-8");
+}
+
 type SubagentExecutionContext = "fresh" | "fork";
 
 interface ForkableSessionManager {
@@ -65,6 +134,7 @@ export function createForkContextResolver(
 				if (!fs.existsSync(sessionFile)) {
 					throw new Error(`Session manager returned a forked session file that does not exist: ${sessionFile}`);
 				}
+				sanitizeForkedSession(sessionFile);
 				cachedSessionFiles.set(index, sessionFile);
 				return sessionFile;
 			} catch (error) {


### PR DESCRIPTION
When a subagent worker runs in forked context with an Anthropic model, the inherited session file contains tool call IDs with colons (e.g. `read:0`, `todo_md:7`) and invalid thinking signatures (e.g. `"reasoning"`). Anthropic's API rejects these with:

- `400: String should match pattern '^[a-zA-Z0-9_-]+$'` (tool_use.id)
- `400: Invalid signature in thinking block` (thinking signature)

## Changes

- Add `sanitizeForkedSession()` that scans forked session JSONL entries
- Replace characters outside `[a-zA-Z0-9_-]` with `_` in tool call IDs
- Strip `thinkingSignature` fields from assistant messages (the value is not a valid cryptographic signature)
- Preserve ID consistency between `toolCall.id` and `toolCallId` references
- Only affects forked subagent sessions; the orchestrator session is unchanged