### PR TITLE
generate-config command

### DIFF
--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -16,7 +16,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
 			{ providers: [ "opencode", "opencode-go" ], model: "kimi-k2.6" },
 			{ providers: [ "opencode", "opencode-go" ], model: "kimi-k2.5" },
 			{ providers: [ "openai-codex", "github-copilot", "opencode", "opencode-go" ], model: "gpt-5.5", thinking: "medium" },
-			{ providers: [ "zai-coding-plan", "opencode", "opencode-go" ], model: "glm-5" },
+			{ providers: [ "opencode", "opencode-go" ], model: "glm-5" },
 			{ providers: [ "opencode", "opencode-go" ], model: "big-pickle" },
 		],
 	},

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -1,0 +1,74 @@
+export type FallbackEntry = {
+  providers: string[];
+  model: string;
+  thinking?: string; // Entry-specific thinking level (e.g., GPT→high, Opus→max)
+};
+
+export type ModelRequirement = {
+  fallbackChain: FallbackEntry[];
+  thinking?: string; // Default thinking level (used when entry doesn't specify one)
+};
+
+export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
+	"context-builder": {
+		fallbackChain: [
+			{ providers: [ "anthropic", "github-copilot", "opencode", "opencode-go" ], model: "claude-opus-4-7", thinking: "max" },
+			{ providers: [ "opencode", "opencode-go" ], model: "kimi-k2.6" },
+			{ providers: [ "opencode", "opencode-go" ], model: "kimi-k2.5" },
+			{ providers: [ "openai-codex", "github-copilot", "opencode", "opencode-go" ], model: "gpt-5.5", thinking: "medium" },
+			{ providers: [ "zai-coding-plan", "opencode", "opencode-go" ], model: "glm-5" },
+			{ providers: [ "opencode", "opencode-go" ], model: "big-pickle" },
+		],
+	},
+	oracle: {
+		fallbackChain: [
+			{ providers: [ "openai-codex", "github-copilot", "opencode", "opencode-go" ], model: "gpt-5.5", thinking: "high" },
+			{ providers: [ "google", "github-copilot", "opencode", "opencode-go" ], model: "gemini-3.1-pro", thinking: "high" },
+			{ providers: [ "anthropic", "github-copilot", "opencode", "opencode-go" ], model: "claude-opus-4-7", thinking: "max" },
+			{ providers: [ "opencode", "opencode-go" ], model: "glm-5.1" },
+		],
+	},
+	researcher: {
+		fallbackChain: [
+			{ providers: [ "openai-codex" ], model: "gpt-5.4-mini-fast" },
+			{ providers: [ "opencode", "opencode-go" ], model: "qwen3.5-plus" },
+			{ providers: [ "opencode", "opencode-go" ], model: "minimax-m2.7" },
+			{ providers: [ "anthropic", "opencode", "opencode-go" ], model: "claude-haiku-4-5" },
+			{ providers: [ "openai-codex", "opencode", "opencode-go" ], model: "gpt-5.4-nano" },
+		],
+	},
+	scout: {
+		fallbackChain: [
+			{ providers: [ "openai-codex" ], model: "gpt-5.4-mini-fast" },
+			{ providers: [ "opencode", "opencode-go" ], model: "qwen3.5-plus" },
+			{ providers: [ "opencode", "opencode-go" ], model: "minimax-m2.7" },
+			{ providers: [ "anthropic", "opencode", "opencode-go" ], model: "claude-haiku-4-5" },
+			{ providers: [ "openai-codex", "opencode", "opencode-go" ], model: "gpt-5.4-nano" },
+		],
+	},
+	planner: {
+		fallbackChain: [
+			{ providers: [ "anthropic", "github-copilot", "opencode", "opencode-go" ], model: "claude-opus-4-7", thinking: "max" },
+			{ providers: [ "openai-codex", "github-copilot", "opencode", "opencode-go" ], model: "gpt-5.5", thinking: "high" },
+			{ providers: [ "opencode", "opencode-go" ], model: "glm-5.1" },
+			{ providers: [ "google", "github-copilot", "opencode", "opencode-go" ], model: "gemini-3.1-pro" },
+		],
+	},
+	reviewer: {
+		fallbackChain: [
+			{ providers: [ "openai-codex", "github-copilot", "opencode", "opencode-go" ], model: "gpt-5.5", thinking: "xhigh" },
+			{ providers: [ "anthropic", "github-copilot", "opencode", "opencode-go" ], model: "claude-opus-4-7", thinking: "max" },
+			{ providers: [ "google", "github-copilot", "opencode", "opencode-go" ], model: "gemini-3.1-pro", thinking: "high" },
+			{ providers: [ "opencode", "opencode-go" ], model: "glm-5.1" },
+		],
+	},
+	worker: {
+		fallbackChain: [
+			{ providers: [ "anthropic", "github-copilot", "opencode", "opencode-go" ], model: "claude-sonnet-4-6" },
+			{ providers: [ "opencode", "opencode-go" ], model: "kimi-k2.6" },
+			{ providers: [ "openai-codex", "github-copilot", "opencode", "opencode-go" ], model: "gpt-5.5", thinking: "medium" },
+			{ providers: [ "opencode", "opencode-go" ], model: "minimax-m2.7" },
+			{ providers: [ "opencode", "opencode-go" ], model: "big-pickle" },
+		],
+	},
+};

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -1,3 +1,9 @@
+export interface AgentConfig {
+  model: string;
+  thinking?: string;
+  fallbackModels?: string[];
+}
+
 export type FallbackEntry = {
   providers: string[];
   model: string;

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -23,6 +23,9 @@ import {
 	type SingleResult,
 	type SubagentState,
 } from "../shared/types.ts";
+import {
+	AGENT_MODEL_REQUIREMENTS,
+} from "../shared/model-requirements.ts";
 
 interface InlineConfig {
 	output?: string | false;
@@ -522,6 +525,62 @@ export function registerSlashCommands(
 		description: "Show subagent diagnostics",
 		handler: async (_args, ctx) => {
 			await runSlashSubagent(pi, ctx, { action: "doctor" });
+		},
+	});
+
+	pi.registerCommand("generate-config", {
+		description: "Generate subagent config",
+		handler: async (_args, ctx) => {
+			const models = ctx.modelRegistry.getAvailable();
+			const availableProviders = new Set(models.map((m) => m.provider));
+			const agents: Record<string, AgentConfig> = {};
+			for (const [role, req] of Object.entries(AGENT_MODEL_REQUIREMENTS)) {
+				let resolved;
+				resolveLoop:
+				for (const entry of req.fallbackChain) {
+					for (const provider of entry.providers) {
+						if (availableProviders.has(provider)) {
+							resolved = {
+								model: `${provider}/${entry.model}`,
+								thinking: entry.thinking,
+							};
+							break resolveLoop;
+						}
+					}
+				}
+				if (resolved) {
+					const thinking = resolved.thinking ?? req.thinking;
+					const agentConfig = thinking ? { model: resolved.model, thinking } : { model: resolved.model };
+					const expandedFallbacks = req.fallbackChain.flatMap((entry) =>
+						entry.providers
+							.filter((provider) => availableProviders.has(provider))
+							.map((provider) => ({ model: `${provider}/${entry.model}`, ...(entry.thinking ? { thinking: entry.thinking } : {}) }))
+						);
+					const uniqueFallbacks = expandedFallbacks.filter((entry, index, allEntries) =>
+						allEntries.findIndex((candidate) =>
+							candidate.model === entry.model &&
+							candidate.thinking === entry.thinking
+						) === index
+						);
+					const primaryIndex = uniqueFallbacks.findIndex((entry) => entry.model === agentConfig.model)
+					if (primaryIndex === -1) {
+						agents[role] = agentConfig
+						continue;
+					}
+					const fallbackModels = uniqueFallbacks.slice(primaryIndex + 1)
+					if (fallbackModels.length === 0) {
+						agents[role] = agentConfig
+						continue;
+					}
+					agents[role] = {
+						...agentConfig,
+						fallbackModels: fallbackModels.map((entry) => entry.model + (entry.thinking ? `:${entry.thinking}` : "")),
+					};
+				} else {
+					agents[role] = { model: "opencode/gpt-5-nano" }
+				}
+			}
+			ctx.ui.notify(JSON.stringify({subagents: {agentOverrides: agents}}, null, 2), "info");
 		},
 	});
 

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -25,6 +25,7 @@ import {
 } from "../shared/types.ts";
 import {
 	AGENT_MODEL_REQUIREMENTS,
+	type AgentConfig
 } from "../shared/model-requirements.ts";
 
 interface InlineConfig {


### PR DESCRIPTION
Adds a simple generate-config command that generates a configuration for agents with fallback.
Configuration example:
``` 
 "subagents": {
    "agentOverrides": {
      "context-builder": {
        "model": "github-copilot/claude-opus-4-7",
        "thinking": "max",
        "fallbackModels": [
          "openai-codex/gpt-5.5:medium",
          "github-copilot/gpt-5.5:medium"
        ]
      },
      "oracle": {
        "model": "openai-codex/gpt-5.5",
        "thinking": "high",
        "fallbackModels": [
          "github-copilot/gpt-5.5:high",
          "github-copilot/gemini-3.1-pro:high",
          "github-copilot/claude-opus-4-7:max"
        ]
      },
      "researcher": {
        "model": "openai-codex/gpt-5.4-mini-fast",
        "fallbackModels": [
          "openai-codex/gpt-5.4-nano"
        ]
      },
      "scout": {
        "model": "openai-codex/gpt-5.4-mini-fast",
        "fallbackModels": [
          "openai-codex/gpt-5.4-nano"
        ]
      },
      "planner": {
        "model": "github-copilot/claude-opus-4-7",
        "thinking": "max",
        "fallbackModels": [
          "openai-codex/gpt-5.5:high",
          "github-copilot/gpt-5.5:high",
          "github-copilot/gemini-3.1-pro"
        ]
      },
      "reviewer": {
        "model": "openai-codex/gpt-5.5",
        "thinking": "xhigh",
        "fallbackModels": [
          "github-copilot/gpt-5.5:xhigh",
          "github-copilot/claude-opus-4-7:max",
          "github-copilot/gemini-3.1-pro:high"
        ]
      },
      "worker": {
        "model": "github-copilot/claude-sonnet-4-6",
        "fallbackModels": [
          "openai-codex/gpt-5.5:medium",
          "github-copilot/gpt-5.5:medium"
        ]
      }
    }
  },
```