### PR TITLE
feat: expose thinking level parameter to /run, /chain, and /parallel

### DIFF
--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -196,6 +196,11 @@ function parseStepList(raw: unknown): { steps?: ChainStepConfig[]; error?: strin
 			if (typeof s.progress === "boolean") step.progress = s.progress;
 			else return { error: `config.steps[${i}].progress must be a boolean.` };
 		}
+		if (hasKey(s, "thinking")) {
+			if (s.thinking === false) step.thinking = false;
+			else if (typeof s.thinking === "string") step.thinking = s.thinking;
+			else return { error: `config.steps[${i}].thinking must be a string or false.` };
+		}
 		steps.push(step);
 	}
 	return { steps };

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -112,6 +112,7 @@ export interface ChainStepConfig {
 	model?: string;
 	skills?: string[] | false;
 	progress?: boolean;
+	thinking?: string | false;
 }
 
 export interface ChainConfig {

--- a/src/agents/chain-serializer.ts
+++ b/src/agents/chain-serializer.ts
@@ -56,6 +56,10 @@ function parseStepBody(agent: string, sectionBody: string): ChainStepConfig {
 			if (rawValue === "true") step.progress = true;
 			else if (rawValue === "false") step.progress = false;
 		}
+		if (key === "thinking") {
+			if (rawValue === "false") step.thinking = false;
+			else if (rawValue) step.thinking = rawValue;
+		}
 	}
 
 	return step;
@@ -128,6 +132,8 @@ export function serializeChain(config: ChainConfig): string {
 		if (step.skills === false) lines.push("skills: false");
 		else if (Array.isArray(step.skills) && step.skills.length > 0) lines.push(`skills: ${step.skills.join(", ")}`);
 		if (step.progress !== undefined) lines.push(`progress: ${step.progress ? "true" : "false"}`);
+		if (step.thinking === false) lines.push("thinking: false");
+		else if (step.thinking) lines.push(`thinking: ${step.thinking}`);
 		lines.push("");
 		lines.push(step.task ?? "");
 		if (i < config.steps.length - 1) lines.push("");

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -248,6 +248,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				availableModels: input.availableModels,
 				preferredModelProvider: input.ctx.model?.provider,
 				skills: behavior.skills === false ? [] : behavior.skills,
+				thinking: task.thinking,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
 						const stepResults = progressUpdate.details?.results || [];
@@ -797,6 +798,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				availableModels,
 				preferredModelProvider: ctx.model?.provider,
 				skills: behavior.skills === false ? [] : behavior.skills,
+				thinking: seqStep.thinking,
 				onUpdate: onUpdate
 					? (p) => {
 						const stepResults = p.details?.results || [];

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -135,7 +135,9 @@ async function runSingleAttempt(
 		outputSnapshot?: SingleOutputSnapshot;
 	},
 ): Promise<SingleResult> {
-	const modelArg = applyThinkingSuffix(model, agent.thinking);
+	const effectiveThinking = options.thinking !== undefined ? options.thinking : agent.thinking;
+	const thinkingForSuffix = effectiveThinking === false ? undefined : effectiveThinking;
+	const modelArg = applyThinkingSuffix(model, thinkingForSuffix);
 	const { args, env: sharedEnv, tempDir } = buildPiArgs({
 		baseArgs: ["--mode", "json", "-p"],
 		task,
@@ -143,7 +145,7 @@ async function runSingleAttempt(
 		sessionDir: options.sessionDir,
 		sessionFile: options.sessionFile,
 		model,
-		thinking: agent.thinking,
+		thinking: effectiveThinking === false ? undefined : effectiveThinking,
 		systemPromptMode: agent.systemPromptMode,
 		inheritProjectContext: agent.inheritProjectContext,
 		inheritSkills: agent.inheritSkills,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1315,6 +1315,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			availableModels: input.availableModels,
 			preferredModelProvider: input.ctx.model?.provider,
 			skills: effectiveSkills === false ? [] : effectiveSkills,
+				thinking: task.thinking,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
 						const stepResults = progressUpdate.details?.results || [];

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -51,6 +51,7 @@ export interface SequentialStep {
 	progress?: boolean;
 	skill?: string | string[] | false;
 	model?: string;
+	thinking?: string | false;
 }
 
 /** Parallel task item within a parallel step */
@@ -65,6 +66,7 @@ interface ParallelTaskItem {
 	progress?: boolean;
 	skill?: string | string[] | false;
 	model?: string;
+	thinking?: string | false;
 }
 
 /** Parallel step: multiple agents running concurrently */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -479,6 +479,8 @@ export interface RunSyncOptions {
 	availableModels?: Array<{ provider: string; id: string; fullId: string }>;
 	/** Current parent-session provider to prefer for ambiguous bare model ids */
 	preferredModelProvider?: string;
+	/** Override the agent's default thinking level */
+	thinking?: string | false;
 	/** Skills to inject (overrides agent default if provided) */
 	skills?: string[];
 }

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -31,6 +31,7 @@ interface InlineConfig {
 	model?: string;
 	skill?: string[] | false;
 	progress?: boolean;
+	thinking?: string | false;
 }
 
 const parseInlineConfig = (raw: string): InlineConfig => {
@@ -41,6 +42,7 @@ const parseInlineConfig = (raw: string): InlineConfig => {
 		const eq = trimmed.indexOf("=");
 		if (eq === -1) {
 			if (trimmed === "progress") config.progress = true;
+			else if (trimmed === "thinking") config.thinking = "concise";
 			continue;
 		}
 		const key = trimmed.slice(0, eq).trim();
@@ -52,6 +54,7 @@ const parseInlineConfig = (raw: string): InlineConfig => {
 			case "model": config.model = val || undefined; break;
 			case "skill": case "skills": config.skill = val === "false" ? false : val.split("+").filter(Boolean); break;
 			case "progress": config.progress = val !== "false"; break;
+			case "thinking": config.thinking = val === "false" ? false : val; break;
 		}
 	}
 	return config;
@@ -135,6 +138,7 @@ const mapSavedChainSteps = (chain: ChainConfig, worktree = false): ChainStep[] =
 			progress: step.progress,
 			skill: step.skill ?? step.skills,
 			model: step.model,
+			thinking: step.thinking,
 		};
 	});
 };
@@ -433,6 +437,7 @@ export function registerSlashCommands(
 			if (inline.outputMode !== undefined) params.outputMode = inline.outputMode;
 			if (inline.skill !== undefined) params.skill = inline.skill;
 			if (inline.model) params.model = inline.model;
+			if (inline.thinking !== undefined) params.thinking = inline.thinking;
 			if (bg) params.async = true;
 			if (fork) params.context = "fork";
 			await runSlashSubagent(pi, ctx, params);
@@ -455,6 +460,7 @@ export function registerSlashCommands(
 				...(config.model ? { model: config.model } : {}),
 				...(config.skill !== undefined ? { skill: config.skill } : {}),
 				...(config.progress !== undefined ? { progress: config.progress } : {}),
+				...(config.thinking !== undefined ? { thinking: config.thinking } : {}),
 			}));
 			const params: SubagentParamsLike = { chain, task: parsed.task, clarify: false, agentScope: "both" };
 			if (bg) params.async = true;
@@ -509,6 +515,7 @@ export function registerSlashCommands(
 				...(config.model ? { model: config.model } : {}),
 				...(config.skill !== undefined ? { skill: config.skill } : {}),
 				...(config.progress !== undefined ? { progress: config.progress } : {}),
+				...(config.thinking !== undefined ? { thinking: config.thinking } : {}),
 			}));
 			const params: SubagentParamsLike = { tasks, clarify: false, agentScope: "both" };
 			if (bg) params.async = true;


### PR DESCRIPTION
Add support for overriding agent thinking level at invocation time via inline configuration. Users can now specify thinking level directly in slash commands:

```
  /run researcher[thinking=extended] Analyze this complex problem
  /chain scout[thinking=on] -> planner[thinking=extended] Plan and execute
  /parallel agent1[thinking=false] + agent2[thinking=high] Parallel tasks
```

and agents can spawn subagents with a specified thinking level.

This allows control over reasoning depth per-invocation without modifying agent configurations. Specifically, it allows using models for subagents that support a disjunct set of thinking levels.

---

My use case: I have my worker agent default to `mistral-medium-3.5:high`, and I'd like to be able to switch around to no thinking, or to another model on xhigh or no thinking level.

This is mostly vibe-coded (and vibe-tested by running it and letting agent test it out). I'll be happy to fix up this PR until mergeable.