### PR TITLE
fix: move @earendil-works/pi-tui from optional peer dep to direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
   "peerDependencies": {
     "@earendil-works/pi-agent-core": "*",
     "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*"
+    "@earendil-works/pi-coding-agent": "*"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-agent-core": {
@@ -66,19 +65,16 @@
     },
     "@earendil-works/pi-coding-agent": {
       "optional": true
-    },
-    "@earendil-works/pi-tui": {
-      "optional": true
     }
   },
   "dependencies": {
+    "@earendil-works/pi-tui": "^0.74.0",
     "jiti": "^2.7.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {
     "@earendil-works/pi-agent-core": "^0.74.0",
     "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.74.0",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   }
 }


### PR DESCRIPTION
## Fix for #182

`@earendil-works/pi-tui` was listed as an optional peer dependency, so `npm install -g pi-subagents` skipped it. Since `src/extension/index.ts` imports it unconditionally at runtime, this caused a `Cannot find module '@earendil-works/pi-tui'` crash at startup.

### Changes
- **Moved `@earendil-works/pi-tui`** from `devDependencies` → `dependencies` (ensures it's installed as a required runtime dependency with `npm install -g`)
- **Removed `@earendil-works/pi-tui`** from `peerDependencies` and `peerDependenciesMeta.optional` (removing the contradictory optional peer dep entry)

### Verification
- All 378 unit tests pass with this change
- No code changes needed — the runtime import was always unconditional