### PR TITLE
Allow child subagents to dispatch when their tools declare subagent

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -1,0 +1,63 @@
+# Upstream fork notes
+
+This fork of [`nicobailon/pi-subagents`](https://github.com/nicobailon/pi-subagents) carries one patch series, `fanout-children`, that re-enables subagent dispatch for child agents whose own `tools` declaration includes `subagent`. The strict child boundary remains the default for every other child.
+
+## Why the fork exists
+
+pi-subagents 0.24.3 unconditionally:
+
+1. Skips registering the `subagent` tool in any child process (`src/extension/index.ts` early return).
+2. Prepends `CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS` to every child's system prompt, including the clause "Do not propose or run subagents."
+3. Strips all `subagent` tool-call blocks and tool-result messages from inherited history (`stripParentOnlySubagentMessages`).
+
+Together these three sites make it impossible for any child subagent to run its own fanout, even if the agent definition explicitly declares the `subagent` tool. This blocks the canonical use of agents like `wave-review-orchestrator`, whose entire role is to dispatch persona and toolkit reviewers in parallel.
+
+Upstream maintenance has paused, so the fix lives here instead.
+
+## What the `fanout-children` branch changes
+
+The branch adds a new env var, `PI_SUBAGENT_FANOUT_CHILD`, set by the parent in `buildPiArgs` whenever the child agent's `tools` list includes `subagent`. Three sites consult that env:
+
+| Site | Old behavior | New behavior |
+| --- | --- | --- |
+| `src/runs/shared/pi-args.ts` | sets `PI_SUBAGENT_CHILD=1` on every child | also sets `PI_SUBAGENT_FANOUT_CHILD=1` when `tools` declares `subagent` |
+| `src/extension/index.ts` (early return) | returns for any child | returns only when `PI_SUBAGENT_FANOUT_CHILD` is not set |
+| `src/runs/shared/subagent-prompt-runtime.ts` (`rewriteSubagentPrompt`) | always prepends the strict boundary text | injects a softer fanout-aware boundary text for fanout children, strict text otherwise. Also drops any inherited copy of the other boundary so a polluted history does not contradict the child's permission. |
+| `src/runs/shared/subagent-prompt-runtime.ts` (`stripParentOnlySubagentMessages`) | strips every inherited `subagent` tool call and tool result | strips them only for non-fanout children. Always strips parent-only custom message types (`subagent-notify`, control notices, slash result) for both. |
+
+The softer fanout boundary text is at `CHILD_FANOUT_BOUNDARY_INSTRUCTIONS` in `subagent-prompt-runtime.ts`. It keeps the load-bearing framing (you are a child, parent owns final orchestration, do not propose dispatching agents you were not granted) and drops only the unconditional "do not propose or run subagents" clause.
+
+The `maxSubagentDepth` cap in `pi-subagents/src/shared/types.ts` is untouched and continues to bound global recursion.
+
+## Test coverage added
+
+Three new test cases in `test/unit/index-child-registration.test.ts` and `test/unit/pi-args.test.ts`, five new cases in `test/unit/subagent-prompt-runtime.test.ts`. All exercise the env-gated behavior so a future upstream sync that diverges from this contract will surface as a test failure.
+
+Full suite: 387 tests, 0 failing on the `fanout-children` branch.
+
+## Resync procedure
+
+When upstream releases a new version:
+
+```sh
+cd ~/work/pi-subagents-fork
+git fetch upstream
+git log v0.24.3..upstream/main --oneline      # see what's new
+git checkout fanout-children
+git rebase upstream/main                      # bring patches forward
+# resolve conflicts (touchpoints are tiny: 4 hunks across 3 files)
+git push --force-with-lease origin fanout-children
+npm run test:unit                             # verify
+```
+
+The three patch hunks are intentionally minimal so conflicts are rare. If the upstream author later accepts a PR that addresses this same constraint, drop the branch and switch the `packages` entry in `~/pi-dotfiles/settings.json` back to `"npm:pi-subagents"`.
+
+## Install path
+
+`~/pi-dotfiles/settings.json` packages entry:
+
+```json
+"git+https://github.com/longweekendprojects/pi-subagents.git#fanout-children"
+```
+
+Pi resolves this via its `parseGitUrl` branch in the package manager. The install lands under `~/.pi/agent/git/` (or equivalent) and pi loads `src/extension/index.ts` as the registered extension per the package's `pi.extensions` manifest.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -33,7 +33,7 @@ import { registerSlashSubagentBridge } from "../slash/slash-bridge.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
 import registerSubagentNotify, { type SubagentNotifyDetails } from "../runs/background/notify.ts";
-import { SUBAGENT_CHILD_ENV } from "../runs/shared/pi-args.ts";
+import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../runs/shared/pi-args.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import {
 	type Details,
@@ -220,7 +220,7 @@ class SubagentControlNoticeComponent implements Component {
 }
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
-	if (process.env[SUBAGENT_CHILD_ENV] === "1") return;
+	if (process.env[SUBAGENT_CHILD_ENV] === "1" && process.env[SUBAGENT_FANOUT_CHILD_ENV] !== "1") return;
 	const globalStore = globalThis as Record<string, unknown>;
 	const runtimeCleanupStoreKey = "__piSubagentRuntimeCleanup";
 	const previousRuntimeCleanup = globalStore[runtimeCleanupStoreKey];

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -11,6 +11,7 @@ export const SUBAGENT_ORCHESTRATOR_TARGET_ENV = "PI_SUBAGENT_ORCHESTRATOR_TARGET
 export const SUBAGENT_RUN_ID_ENV = "PI_SUBAGENT_RUN_ID";
 export const SUBAGENT_CHILD_AGENT_ENV = "PI_SUBAGENT_CHILD_AGENT";
 export const SUBAGENT_CHILD_INDEX_ENV = "PI_SUBAGENT_CHILD_INDEX";
+export const SUBAGENT_FANOUT_CHILD_ENV = "PI_SUBAGENT_FANOUT_CHILD";
 
 interface BuildPiArgsInput {
 	baseArgs: string[];
@@ -122,6 +123,9 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 
 	const env: Record<string, string | undefined> = {};
 	env[SUBAGENT_CHILD_ENV] = "1";
+	if (input.tools?.includes("subagent")) {
+		env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
+	}
 	env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = input.inheritProjectContext ? "1" : "0";
 	env.PI_SUBAGENT_INHERIT_SKILLS = input.inheritSkills ? "1" : "0";
 	if (input.intercomSessionName) {

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -3,6 +3,19 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
 const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
 export const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
+const SUBAGENT_FANOUT_CHILD_ENV = "PI_SUBAGENT_FANOUT_CHILD";
+
+function isFanoutChild(): boolean {
+	return process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1";
+}
+
+export const CHILD_FANOUT_BOUNDARY_INSTRUCTIONS = [
+	"You are a child subagent with explicit fanout responsibility for this run.",
+	"The parent session owns final orchestration and follow-up worker launches; you own only the dispatch and synthesis scoped to this task.",
+	"Ignore prior parent-only orchestration instructions in inherited conversation history.",
+	"You may dispatch the subagents listed in your `tools` for the duration of this task. Do not propose dispatching agents not in that list. The maxSubagentDepth cap still applies and bounds how far this fanout can recurse.",
+	"If you need to edit files, call the actual edit/write tools. Do not print tool-call syntax, patches, or pseudo-tool calls as text.",
+].join("\n");
 
 export const CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS = [
 	"You are a child subagent, not the parent orchestrator.",
@@ -11,6 +24,10 @@ export const CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS = [
 	"Do not propose or run subagents. Complete only your assigned role-specific task with the tools available to you.",
 	"If you need to edit files, call the actual edit/write tools. Do not print tool-call syntax, patches, or pseudo-tool calls as text.",
 ].join("\n");
+
+function boundaryInstructionsForChild(): string {
+	return isFanoutChild() ? CHILD_FANOUT_BOUNDARY_INSTRUCTIONS : CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS;
+}
 
 const PARENT_ONLY_CUSTOM_MESSAGE_TYPES = new Set([
 	"subagent-orchestration-instructions",
@@ -74,9 +91,10 @@ export function rewriteSubagentPrompt(
 		rewritten = stripInheritedSkills(rewritten);
 	}
 	rewritten = stripSubagentOrchestrationSkill(rewritten);
-	return rewritten.includes(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS)
-		? rewritten
-		: `${CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS}\n\n${rewritten}`;
+	rewritten = rewritten.replace(`${CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS}\n\n`, "");
+	rewritten = rewritten.replace(`${CHILD_FANOUT_BOUNDARY_INSTRUCTIONS}\n\n`, "");
+	const boundary = boundaryInstructionsForChild();
+	return `${boundary}\n\n${rewritten}`;
 }
 
 function isParentOnlySubagentMessage(message: unknown): boolean {
@@ -106,20 +124,29 @@ function stripAssistantSubagentToolCallBlocks(message: unknown): unknown | undef
 }
 
 export function stripParentOnlySubagentMessages(messages: unknown[]): unknown[] {
+	const stripSubagentToolHistory = !isFanoutChild();
 	let changed = false;
 	const filtered: unknown[] = [];
 	for (const message of messages) {
-		if (isParentOnlySubagentMessage(message) || isSubagentToolResultMessage(message)) {
+		if (isParentOnlySubagentMessage(message)) {
 			changed = true;
 			continue;
 		}
-		const stripped = stripAssistantSubagentToolCallBlocks(message);
-		if (stripped === undefined) {
+		if (stripSubagentToolHistory && isSubagentToolResultMessage(message)) {
 			changed = true;
 			continue;
 		}
-		if (stripped !== message) changed = true;
-		filtered.push(stripped);
+		if (stripSubagentToolHistory) {
+			const stripped = stripAssistantSubagentToolCallBlocks(message);
+			if (stripped === undefined) {
+				changed = true;
+				continue;
+			}
+			if (stripped !== message) changed = true;
+			filtered.push(stripped);
+		} else {
+			filtered.push(message);
+		}
 	}
 	return changed ? filtered : messages;
 }

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
-import { SUBAGENT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
+import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -125,6 +125,48 @@ describe("subagent extension child mode", () => {
 			registerSubagentExtension(fakePi);
 			if (calls.length > 0) {
 				throw new Error("Unexpected child-mode registrations: " + calls.join(", "));
+			}
+		`;
+
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-transform-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, stdio: "pipe" },
+		);
+	});
+
+	it("registers the subagent tool in a fanout child (PI_SUBAGENT_FANOUT_CHILD=1)", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./src/extension/index.ts";
+			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
+			process.env[SUBAGENT_CHILD_ENV] = "1";
+			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
+			let registered = false;
+			const events = { on() { return () => {}; }, emit() {} };
+			const fakePi = new Proxy({
+				events,
+				registerTool(tool) { if (tool && tool.name === "subagent") registered = true; },
+				registerCommand() {},
+				registerShortcut() {},
+				registerMessageRenderer() {},
+				sendMessage() {},
+				getSessionName() { return undefined; },
+			}, {
+				get(target, prop) {
+					if (prop in target) return target[prop];
+					return () => undefined;
+				},
+			});
+			registerSubagentExtension(fakePi);
+			if (!registered) {
+				throw new Error("expected subagent tool to be registered in fanout child mode");
 			}
 		`;
 

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -206,4 +206,39 @@ describe("buildPiArgs system prompt mode wiring", () => {
 
 		assert.ok(args.includes("--system-prompt"));
 	});
+
+	it("sets PI_SUBAGENT_FANOUT_CHILD when the child agent's tools include subagent", () => {
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: true,
+			inheritSkills: true,
+			tools: ["read", "grep", "find", "ls", "bash", "subagent"],
+		});
+		assert.equal(env.PI_SUBAGENT_FANOUT_CHILD, "1");
+	});
+
+	it("does not set PI_SUBAGENT_FANOUT_CHILD when subagent is not in the tools list", () => {
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: true,
+			inheritSkills: true,
+			tools: ["read", "grep", "bash"],
+		});
+		assert.equal(env.PI_SUBAGENT_FANOUT_CHILD, undefined);
+	});
+
+	it("does not set PI_SUBAGENT_FANOUT_CHILD when no tools list is provided", () => {
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: true,
+			inheritSkills: true,
+		});
+		assert.equal(env.PI_SUBAGENT_FANOUT_CHILD, undefined);
+	});
 });

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import registerSubagentPromptRuntime, {
+	CHILD_FANOUT_BOUNDARY_INSTRUCTIONS,
 	CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS,
 	SUBAGENT_INTERCOM_SESSION_NAME_ENV,
 	rewriteSubagentPrompt,
@@ -14,6 +15,7 @@ const envSnapshot = {
 	PI_SUBAGENT_INHERIT_PROJECT_CONTEXT: process.env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT,
 	PI_SUBAGENT_INHERIT_SKILLS: process.env.PI_SUBAGENT_INHERIT_SKILLS,
 	PI_SUBAGENT_INTERCOM_SESSION_NAME: process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME,
+	PI_SUBAGENT_FANOUT_CHILD: process.env.PI_SUBAGENT_FANOUT_CHILD,
 };
 
 const SKILLS_SECTION = "\n\nThe following skills provide specialized instructions for specific tasks.\nUse the read tool to load a skill's file when the task matches its description.\nWhen a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.\n\n<available_skills>\n  <skill>\n    <name>safe-bash</name>\n    <description>desc</description>\n    <location>/tmp/SKILL.md</location>\n  </skill>\n  <skill>\n    <name>pi-subagents</name>\n    <description>delegate to subagents</description>\n    <location>/tmp/pi-subagents/SKILL.md</location>\n  </skill>\n</available_skills>";
@@ -40,6 +42,8 @@ afterEach(() => {
 	else process.env.PI_SUBAGENT_INHERIT_SKILLS = envSnapshot.PI_SUBAGENT_INHERIT_SKILLS;
 	if (envSnapshot.PI_SUBAGENT_INTERCOM_SESSION_NAME === undefined) delete process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME;
 	else process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME = envSnapshot.PI_SUBAGENT_INTERCOM_SESSION_NAME;
+	if (envSnapshot.PI_SUBAGENT_FANOUT_CHILD === undefined) delete process.env.PI_SUBAGENT_FANOUT_CHILD;
+	else process.env.PI_SUBAGENT_FANOUT_CHILD = envSnapshot.PI_SUBAGENT_FANOUT_CHILD;
 });
 
 describe("subagent prompt runtime", () => {
@@ -228,5 +232,62 @@ describe("subagent prompt runtime", () => {
 		];
 
 		assert.equal(contextHandler?.({ messages }), undefined);
+	});
+
+	it("injects the softer fanout boundary when PI_SUBAGENT_FANOUT_CHILD=1 and does not forbid dispatch", () => {
+		process.env.PI_SUBAGENT_FANOUT_CHILD = "1";
+		const rewritten = rewriteSubagentPrompt(BASE_PROMPT, {
+			inheritProjectContext: true,
+			inheritSkills: true,
+		});
+		assert.ok(rewritten.startsWith(CHILD_FANOUT_BOUNDARY_INSTRUCTIONS));
+		assert.ok(!rewritten.includes("Do not propose or run subagents."));
+		assert.ok(rewritten.includes("explicit fanout responsibility"));
+		assert.ok(rewritten.includes("You may dispatch the subagents listed in your `tools`"));
+	});
+
+	it("keeps the strict boundary for non-fanout children", () => {
+		delete process.env.PI_SUBAGENT_FANOUT_CHILD;
+		const rewritten = rewriteSubagentPrompt(BASE_PROMPT, {
+			inheritProjectContext: true,
+			inheritSkills: true,
+		});
+		assert.ok(rewritten.startsWith(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS));
+		assert.ok(rewritten.includes("Do not propose or run subagents."));
+	});
+
+	it("replaces an inherited strict boundary with the fanout boundary for fanout children", () => {
+		process.env.PI_SUBAGENT_FANOUT_CHILD = "1";
+		const polluted = `${CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS}\n\n${BASE_PROMPT}`;
+		const rewritten = rewriteSubagentPrompt(polluted, {
+			inheritProjectContext: true,
+			inheritSkills: true,
+		});
+		assert.ok(rewritten.startsWith(CHILD_FANOUT_BOUNDARY_INSTRUCTIONS));
+		assert.ok(!rewritten.includes("Do not propose or run subagents."));
+	});
+
+	it("preserves subagent tool calls and tool results in fanout child history", () => {
+		process.env.PI_SUBAGENT_FANOUT_CHILD = "1";
+		const messages = [
+			{ role: "user", content: "Task" },
+			{ role: "assistant", content: [{ type: "toolCall", name: "subagent", input: { action: "list" } }] },
+			{ role: "toolResult", toolName: "subagent", content: "Executable agents: ..." },
+			{ role: "assistant", content: [{ type: "toolCall", name: "read", input: { path: "README.md" } }] },
+		];
+		const filtered = stripParentOnlySubagentMessages(messages);
+		assert.equal(filtered, messages, "messages should pass through unchanged for fanout children");
+	});
+
+	it("still strips parent-only custom messages from fanout child history", () => {
+		process.env.PI_SUBAGENT_FANOUT_CHILD = "1";
+		const messages = [
+			{ role: "user", content: "Task" },
+			{ role: "custom", customType: "subagent-notify", content: "parent-only artifact" },
+			{ role: "assistant", content: [{ type: "toolCall", name: "subagent", input: { action: "list" } }] },
+		];
+		const filtered = stripParentOnlySubagentMessages(messages);
+		assert.equal(filtered.length, 2);
+		assert.ok(!filtered.some((m) => (m as { customType?: string }).customType === "subagent-notify"));
 	});
 });


### PR DESCRIPTION
## Purpose

Allow child subagents to dispatch their own subagents when the child agent definition explicitly declares the `subagent` tool. This re-enables the canonical use of agents like `wave-review-orchestrator` whose role is to run a parallel reviewer fanout, without weakening the strict child boundary for every other child.

## Summary of changes

- **Env-var gate** (`src/runs/shared/pi-args.ts`): adds `PI_SUBAGENT_FANOUT_CHILD`, set on the spawned child whenever `input.tools?.includes("subagent")` is true. The agent's own tools declaration is the authority; no new opt-in flag.
- **Tool registration** (`src/extension/index.ts`): the early return that blocks `registerTool` in every child now skips only when `PI_SUBAGENT_FANOUT_CHILD` is not set, so fanout children get the `subagent` tool registered.
- **Boundary text** (`src/runs/shared/subagent-prompt-runtime.ts`): adds `CHILD_FANOUT_BOUNDARY_INSTRUCTIONS`, a fanout-aware boundary used in place of the strict text when the gate is set. The softer text keeps "you are a child, parent owns final orchestration, do not propose dispatching agents not in your tools list", and drops only the unconditional "do not propose or run subagents" clause that contradicts the agent's own tools declaration.
- **History stripping** (`stripParentOnlySubagentMessages`): inherited `subagent` tool-call and tool-result messages are now preserved for fanout children. Parent-only custom message types (`subagent-notify`, control notices, slash result) are still stripped for both fanout and non-fanout children.
- **Tests**: 8 new cases across `test/unit/index-child-registration.test.ts`, `test/unit/pi-args.test.ts`, and `test/unit/subagent-prompt-runtime.test.ts`. Full suite passes: 387 tests, 0 failing.
- **Backward compatibility**: the strict `CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS` remains the default for any child whose tools list does not declare `subagent`, and `maxSubagentDepth` continues to bound global recursion in both modes.

## Changes to review

- **Gate authority**: the env var is set from `input.tools?.includes("subagent")` rather than a new frontmatter flag. The agent's tools list already exists as the load-bearing declaration; coupling fanout permission to it avoids API surface bloat. If you would prefer an explicit `allowSubagentFanout: true` frontmatter flag, that is a one-line swap on the gate site in `pi-args.ts`.
- **Softer boundary wording** in `CHILD_FANOUT_BOUNDARY_INSTRUCTIONS`. Specifically the line "You may dispatch the subagents listed in your `tools` for the duration of this task. Do not propose dispatching agents not in that list." Confirm this matches the contract you want the child to follow.
- **History stripping change** in `stripParentOnlySubagentMessages`: for fanout children, inherited subagent tool-call and tool-result blocks pass through. This is the right default when the child is meant to continue an in-flight fanout, but it does mean a fanout child sees more of the parent's earlier orchestration than a strict child would. Confirm this is acceptable.
- **No depth-cap interaction**: the patches do not touch `maxSubagentDepth` or `checkSubagentDepth`. A fanout child at the configured cap still gets blocked by the existing depth check when it attempts to dispatch.
