### PR TITLE
Add forked async notification handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,27 @@ Bridge activation also requires `pi-intercom` to be installed and enabled throug
 
 The default injected guidance tells children to use `contact_supervisor` with `reason: "need_decision"` when blocked or needing a decision, `reason: "progress_update"` only for meaningful blocked/progress updates, generic `intercom` as fallback plumbing, and avoid routine completion handoffs.
 
+### `backgroundForkHandlers`
+
+```json
+{
+  "backgroundForkHandlers": {
+    "enabled": true,
+    "notify": "ack-and-summary",
+    "triggerParentOnSummary": false
+  }
+}
+```
+
+Async subagent completions and async control notices default to a sibling Pi handler instead of triggering the active parent feed. Successful and failed per-step completion records are coalesced into the aggregate async completion handler to avoid duplicate step + final summaries; actionable in-progress problems should use control notices. The parent receives passive handler ack/summary messages only; set `triggerParentOnSummary: true` only when summaries should start a parent turn. Set `enabled: false` to opt out of sibling handling; fallback delivery is still display-only and does not trigger a parent turn.
+
+Fields:
+
+- `enabled`: default `true`; route interrupting background notifications through a sibling handler.
+- `notify`: default `ack-and-summary`; accepts `ack-and-summary`, `summary`, or `none`.
+- `triggerParentOnSummary`: default `false`; keep summaries display-only unless explicitly enabled.
+- `piCommand`: optional Pi executable override for tests or custom installs.
+
 ### `worktreeSetupHook`
 
 ```json

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test": "npm run test:unit",
     "test:unit": "node --experimental-strip-types --test test/unit/*.test.ts",
     "test:integration": "node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/*.test.ts",
-    "test:all": "npm run test:unit && npm run test:integration"
+    "test:all": "npm run test:unit && npm run test:integration",
+    "logs:scan": "node scripts/scan-subagent-logs.mjs"
   },
   "pi": {
     "extensions": [
@@ -55,9 +56,13 @@
     "@earendil-works/pi-agent-core": "*",
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*"
+    "@earendil-works/pi-tui": "*",
+    "pi-forks": "^0.1.0"
   },
   "peerDependenciesMeta": {
+    "pi-forks": {
+      "optional": true
+    },
     "@earendil-works/pi-agent-core": {
       "optional": true
     },

--- a/scripts/scan-subagent-logs.mjs
+++ b/scripts/scan-subagent-logs.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const uid = typeof process.getuid === "function" ? process.getuid() : "unknown";
+const defaultRoot = path.join(os.tmpdir(), `pi-subagents-uid-${uid}`, "async-subagent-runs");
+const defaultState = path.join(os.homedir(), ".cache", "pi-subagents-log-scan.json");
+
+const args = process.argv.slice(2);
+const opts = {
+  root: process.env.PI_SUBAGENTS_ASYNC_DIR || defaultRoot,
+  state: process.env.PI_SUBAGENTS_SCAN_STATE || defaultState,
+  sinceMs: 24 * 60 * 60 * 1000,
+  all: false,
+  json: false,
+  noState: false,
+  includeTests: false,
+  includeOutput: false,
+  run: undefined,
+};
+
+function usage(exitCode = 0) {
+  console.log(`Usage: node scripts/scan-subagent-logs.mjs [options]\n\nScan pi-subagents async run logs for new failures, attention events, stale-run repairs, and suspicious output.\n\nOptions:\n  --root <dir>       Async runs dir (default: ${defaultRoot})\n  --run <id|prefix>  Scan only one run id/prefix\n  --since <duration> Only scan runs updated in this window (default: 24h). Examples: 30m, 6h, 2d\n  --all              Report already-seen issues too\n  --no-state         Do not read/write the seen-issues state file\n  --state <file>     Seen-issues state file (default: ${defaultState})\n  --include-tests    Include test/debug runs whose ids start with async- or debug-\n  --include-output   Grep output-*.log for suspicious words (can be noisy for review tasks)\n  --json             Emit JSON\n  -h, --help         Show help\n\nTypical use:\n  npm run logs:scan\n  npm run logs:scan -- --all --since 7d\n  npm run logs:scan -- --run ff3fc44b\n`);
+  process.exit(exitCode);
+}
+
+function parseDuration(value) {
+  const match = String(value).trim().match(/^(\d+(?:\.\d+)?)(ms|s|m|h|d)?$/i);
+  if (!match) throw new Error(`Invalid duration: ${value}`);
+  const n = Number(match[1]);
+  const unit = (match[2] || "ms").toLowerCase();
+  return n * ({ ms: 1, s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[unit]);
+}
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === "-h" || arg === "--help") usage(0);
+  else if (arg === "--root") opts.root = args[++i];
+  else if (arg === "--run") opts.run = args[++i];
+  else if (arg === "--since") opts.sinceMs = parseDuration(args[++i]);
+  else if (arg === "--all") opts.all = true;
+  else if (arg === "--json") opts.json = true;
+  else if (arg === "--no-state") opts.noState = true;
+  else if (arg === "--include-tests") opts.includeTests = true;
+  else if (arg === "--include-output") opts.includeOutput = true;
+  else if (arg === "--state") opts.state = args[++i];
+  else throw new Error(`Unknown argument: ${arg}`);
+}
+
+function readJson(file) {
+  try { return JSON.parse(fs.readFileSync(file, "utf8")); } catch { return undefined; }
+}
+
+function readLines(file, maxBytes = 2 * 1024 * 1024) {
+  try {
+    const stat = fs.statSync(file);
+    const start = Math.max(0, stat.size - maxBytes);
+    const length = stat.size - start;
+    const fd = fs.openSync(file, "r");
+    try {
+      const buffer = Buffer.alloc(length);
+      fs.readSync(fd, buffer, 0, length, start);
+      let text = buffer.toString("utf8");
+      if (start > 0) text = text.slice(text.indexOf("\n") + 1);
+      return text.split(/\r?\n/).filter(Boolean);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch { return []; }
+}
+
+function safeStat(file) {
+  try { return fs.statSync(file); } catch { return undefined; }
+}
+
+function truncate(text, max = 600) {
+  const s = String(text ?? "").trim();
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}
+
+function loadSeen() {
+  if (opts.noState || opts.all) return new Set();
+  const data = readJson(opts.state);
+  return new Set(Array.isArray(data?.seen) ? data.seen : []);
+}
+
+function saveSeen(seen) {
+  if (opts.noState || opts.all) return;
+  fs.mkdirSync(path.dirname(opts.state), { recursive: true });
+  const recent = [...seen].slice(-5000);
+  fs.writeFileSync(opts.state, JSON.stringify({ updatedAt: new Date().toISOString(), seen: recent }, null, 2));
+}
+
+function listRuns(root) {
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(root, entry.name));
+}
+
+function issue(id, runId, severity, title, detail = {}, ts) {
+  return { id, runId, severity, title, ts, ...detail };
+}
+
+function scanRun(runDir) {
+  const runId = path.basename(runDir);
+  const statusPath = path.join(runDir, "status.json");
+  const eventsPath = path.join(runDir, "events.jsonl");
+  const status = readJson(statusPath) || {};
+  const stat = safeStat(statusPath) || safeStat(eventsPath) || safeStat(runDir);
+  const updatedMs = status.lastUpdate || status.endedAt || status.startedAt || stat?.mtimeMs || 0;
+  const findings = [];
+
+  if (status.state === "failed" || status.state === "paused") {
+    findings.push(issue(`status:${runId}:${status.state}:${status.lastUpdate || ""}`, runId, status.state === "failed" ? "high" : "medium", `run ${status.state}`, {
+      error: truncate(status.error || status.steps?.find?.((s) => s.error)?.error || status.summary || ""),
+      statusPath,
+    }, updatedMs));
+  }
+
+  for (const [index, step] of Object.entries(status.steps || [])) {
+    const failedOrPaused = step?.status === "failed" || step?.status === "paused";
+    const needsAttention = step?.activityState === "needs_attention" && !["complete", "completed", "failed", "paused"].includes(step?.status);
+    if (failedOrPaused || needsAttention) {
+      const label = failedOrPaused ? step.status : step.activityState;
+      const issueId = needsAttention
+        ? `step:${runId}:${index}:needs_attention`
+        : `step:${runId}:${index}:${label}:${step.endedAt || step.lastActivityAt || ""}`;
+      findings.push(issue(issueId, runId, step.status === "failed" ? "high" : "medium", `step ${Number(index) + 1} ${label}: ${step.agent || "unknown"}`, {
+        agent: step.agent,
+        stepIndex: Number(index),
+        exitCode: step.exitCode,
+        error: truncate(step.error || step.recentOutput?.join?.("\n") || ""),
+        sessionFile: step.sessionFile,
+      }, step.endedAt || step.lastActivityAt || updatedMs));
+    }
+  }
+
+  readLines(eventsPath).forEach((line, lineIndex) => {
+    let record;
+    try { record = JSON.parse(line); } catch {
+      findings.push(issue(`event:${runId}:${lineIndex}:malformed`, runId, "medium", "malformed events.jsonl line", { line: truncate(line, 300), eventsPath }, updatedMs));
+      return;
+    }
+    const type = record.type;
+    if (type === "subagent.step.failed") {
+      findings.push(issue(`event:${runId}:${lineIndex}:${type}`, runId, "high", `step failed event: ${record.agent || "unknown"}`, {
+        stepIndex: record.stepIndex,
+        exitCode: record.exitCode,
+        summary: truncate(record.summary),
+        sessionFile: record.sessionFile,
+      }, record.ts));
+    } else if (type === "subagent.run.repaired_stale") {
+      findings.push(issue(`event:${runId}:${lineIndex}:${type}`, runId, "high", "stale run repaired as failed", { message: truncate(record.message), pid: record.pid }, record.ts));
+    } else if (type === "subagent.control" && record.event?.type === "needs_attention") {
+      findings.push(issue(`event:${runId}:${lineIndex}:needs_attention`, runId, "medium", `needs attention: ${record.event.agent || "unknown"}`, {
+        reason: record.event.reason,
+        notice: truncate(record.noticeText || record.event.message),
+      }, record.ts));
+    }
+  });
+
+  if (opts.includeOutput) {
+    for (const entry of fs.readdirSync(runDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !/^output-\d+\.log$/.test(entry.name)) continue;
+      const file = path.join(runDir, entry.name);
+      const text = fs.readFileSync(file, "utf8");
+      const matches = text.match(/(^|\n).{0,120}(error|exception|traceback|failed|cannot find module|enoent|eacces).{0,240}/gi) || [];
+      if (matches.length) {
+        findings.push(issue(`output:${runId}:${entry.name}:${entry.size}:${matches.length}`, runId, "low", `suspicious output in ${entry.name}`, {
+          outputFile: file,
+          matches: matches.slice(-3).map((m) => truncate(m.replace(/^\n/, ""), 300)),
+        }, safeStat(file)?.mtimeMs || updatedMs));
+      }
+    }
+  }
+
+  return { runId, runDir, state: status.state || "unknown", updatedMs, findings };
+}
+
+const cutoff = Date.now() - opts.sinceMs;
+const seen = loadSeen();
+const looksLikeTestRun = (runId) => /^(async-|debug-)/.test(runId);
+const runs = listRuns(opts.root)
+  .filter((dir) => !opts.run || path.basename(dir).startsWith(opts.run))
+  .filter((dir) => opts.includeTests || opts.run || !looksLikeTestRun(path.basename(dir)))
+  .map(scanRun)
+  .filter((run) => opts.run || run.updatedMs >= cutoff)
+  .sort((a, b) => b.updatedMs - a.updatedMs);
+
+const newFindings = [];
+for (const run of runs) {
+  for (const finding of run.findings) {
+    if (opts.all || !seen.has(finding.id)) newFindings.push(finding);
+    seen.add(finding.id);
+  }
+}
+saveSeen(seen);
+
+if (opts.json) {
+  console.log(JSON.stringify({ root: opts.root, scannedRuns: runs.length, newIssues: newFindings.length, findings: newFindings }, null, 2));
+} else {
+  console.log(`Scanned ${runs.length} async run(s) in ${opts.root}`);
+  console.log(`${opts.all ? "Total" : "New"} issue(s): ${newFindings.length}`);
+  for (const finding of newFindings) {
+    const when = finding.ts ? new Date(finding.ts).toISOString() : "unknown time";
+    console.log(`\n[${finding.severity}] ${finding.runId} · ${when}\n  ${finding.title}`);
+    for (const [key, value] of Object.entries(finding)) {
+      if (["id", "runId", "severity", "title", "ts"].includes(key) || value === undefined || value === "") continue;
+      console.log(`  ${key}: ${Array.isArray(value) ? value.join(" | ") : value}`);
+    }
+  }
+  if (!newFindings.length) console.log("No new issues found. Use --all to reprint previously seen issues.");
+}

--- a/src/extension/control-notices.ts
+++ b/src/extension/control-notices.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { deliverBackgroundForkEvent } from "../runs/background/fork-handler.ts";
 import { controlNotificationKey, formatControlNoticeMessage } from "../runs/shared/subagent-control.ts";
-import type { ControlEvent, SubagentState } from "../shared/types.ts";
+import type { BackgroundForkHandlersConfig, ControlEvent, SubagentState } from "../shared/types.ts";
 
 export const SUBAGENT_CONTROL_MESSAGE_TYPE = "subagent_control_notice";
 
@@ -36,23 +37,38 @@ export function clearPendingForegroundControlNotices(state: SubagentState, runId
 }
 
 function deliverControlNotice(input: {
-	pi: Pick<ExtensionAPI, "sendMessage">;
+	pi: Pick<ExtensionAPI, "sendMessage" | "getSessionName">;
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;
+	backgroundForkHandlers?: BackgroundForkHandlersConfig;
+	getParentSessionFile?: () => string | null | undefined;
+	getParentIntercomTarget?: () => string | null | undefined;
 }): void {
 	const childIntercomTarget = controlNoticeTarget(input.details);
 	const key = controlNotificationKey(input.details.event, childIntercomTarget);
 	if (input.visibleControlNotices.has(key)) return;
 	input.visibleControlNotices.add(key);
 	const noticeText = input.details.noticeText ?? formatControlNoticeMessage(input.details.event, childIntercomTarget);
+	const messageDetails = { ...input.details, childIntercomTarget, noticeText };
+	if (input.details.source !== "foreground") {
+		void deliverBackgroundForkEvent(input.pi, input.backgroundForkHandlers, {
+			type: "control-notice",
+			title: `Subagent needs attention: ${input.details.event.agent}`,
+			content: noticeText,
+			parentSessionFile: input.getParentSessionFile?.() ?? undefined,
+			parentIntercomTarget: input.getParentIntercomTarget?.() ?? undefined,
+			details: messageDetails,
+		});
+		return;
+	}
 	input.pi.sendMessage(
 		{
 			customType: SUBAGENT_CONTROL_MESSAGE_TYPE,
 			content: noticeText,
 			display: true,
-			details: { ...input.details, childIntercomTarget, noticeText },
+			details: messageDetails,
 		},
-		{ triggerTurn: input.details.source !== "foreground" },
+		{ triggerTurn: false },
 	);
 }
 
@@ -65,11 +81,14 @@ function isForegroundNoticeStillActionable(state: SubagentState, details: Subage
 }
 
 export function handleSubagentControlNotice(input: {
-	pi: Pick<ExtensionAPI, "sendMessage">;
+	pi: Pick<ExtensionAPI, "sendMessage" | "getSessionName">;
 	state: SubagentState;
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;
 	foregroundDelayMs?: number;
+	backgroundForkHandlers?: BackgroundForkHandlersConfig;
+	getParentSessionFile?: () => string | null | undefined;
+	getParentIntercomTarget?: () => string | null | undefined;
 }): void {
 	if (!input.details?.event || input.details.event.type === "active_long_running") return;
 	if (input.details.source !== "foreground") {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -162,7 +162,7 @@ function createSlashResultComponent(
 function parseSubagentNotifyContent(content: string): SubagentNotifyDetails | undefined {
 	const lines = content.split("\n");
 	const header = lines[0] ?? "";
-	const match = header.match(/^Background task (completed|failed|paused): \*\*(.+?)\*\*(?:\s+(\([^)]*\)))?$/);
+	const match = header.match(/^Background (?:task|step) (completed|failed|paused): \*\*(.+?)\*\*(?:\s+(\([^)]*\)|#[^\s]+))?$/);
 	if (!match) return undefined;
 	const body = lines.slice(2);
 	let sessionIndex = -1;
@@ -429,6 +429,12 @@ CONTROL:
 
 DIAGNOSTICS:
 • { action: "doctor" } - read-only report for runtime paths, discovery, sessions, and intercom`,
+		promptGuidelines: [
+			"Sync (default) blocks the calling agent until the subagent finishes. Prefer async: true (or PARALLEL with multiple long tasks) so the turn can end and the parent is woken via intercom on completion.",
+			"Use sync only when the parent must consume the subagent's output before its next tool call (e.g., chain composition, immediate code-review verdict). Anything that takes longer than a couple of minutes should be async.",
+			"For waiting on external state (file appears, process exits, port opens, url ready, log line matches), use return_on rather than spinning a subagent.",
+			"After async dispatch, do not poll subagent({action:'status'}) in a loop. Either wait for the intercom completion message or register a return_on watcher on the run's result file.",
+		],
 		parameters: SubagentParams,
 
 		execute(id, params, signal, onUpdate, ctx) {
@@ -488,7 +494,13 @@ DIAGNOSTICS:
 			}
 		}
 	}
-	registerSubagentNotify(pi);
+	const getParentSessionFile = () => state.lastUiContext?.sessionManager.getSessionFile() ?? undefined;
+	const getParentIntercomTarget = () => {
+		const sessionName = pi.getSessionName?.()?.trim();
+		if (sessionName) return sessionName;
+		return state.lastUiContext?.sessionManager.getSessionId() ?? state.currentSessionId ?? undefined;
+	};
+	registerSubagentNotify(pi, config.backgroundForkHandlers, getParentSessionFile, getParentIntercomTarget);
 
 	const existingVisibleControlNotices = globalStore[controlNoticeSeenStoreKey];
 	const visibleControlNotices = existingVisibleControlNotices instanceof Set ? existingVisibleControlNotices as Set<string> : new Set<string>();
@@ -499,6 +511,9 @@ DIAGNOSTICS:
 			state,
 			visibleControlNotices,
 			details: payload as SubagentControlMessageDetails,
+			backgroundForkHandlers: config.backgroundForkHandlers,
+			getParentSessionFile,
+			getParentIntercomTarget,
 		});
 	};
 	const eventUnsubscribes = [

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -10,6 +10,7 @@ import {
 	type SubagentState,
 	POLL_INTERVAL_MS,
 	RESULTS_DIR,
+	SUBAGENT_ASYNC_STEP_COMPLETE_EVENT,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 } from "../../shared/types.ts";
@@ -78,7 +79,36 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 					console.error(`Ignoring malformed async control event in '${eventsPath}':`, error);
 					continue;
 				}
-				if (!parsed || typeof parsed !== "object" || (parsed as { type?: unknown }).type !== "subagent.control") continue;
+				if (!parsed || typeof parsed !== "object") continue;
+				const eventType = (parsed as { type?: unknown }).type;
+				if (eventType === "subagent.step.completed" || eventType === "subagent.step.failed") {
+					const record = parsed as {
+						runId?: string;
+						stepIndex?: number;
+						agent?: string;
+						exitCode?: number;
+						durationMs?: number;
+						totalTasks?: number;
+						summary?: string;
+						sessionFile?: string;
+						intercomTarget?: string;
+					};
+					pi.events.emit(SUBAGENT_ASYNC_STEP_COMPLETE_EVENT, {
+						id: job.asyncId,
+						runId: record.runId ?? job.asyncId,
+						agent: record.agent,
+						index: record.stepIndex,
+						totalTasks: record.totalTasks ?? job.stepsTotal ?? job.chainStepCount,
+						success: eventType === "subagent.step.completed",
+						exitCode: record.exitCode,
+						durationMs: record.durationMs,
+						summary: record.summary,
+						sessionFile: record.sessionFile,
+						intercomTarget: record.intercomTarget,
+					});
+					continue;
+				}
+				if (eventType !== "subagent.control") continue;
 				const record = parsed as { event?: ControlEvent; channels?: string[]; childIntercomTarget?: string; noticeText?: string; intercom?: { to?: string; message?: string } };
 				if (!record.event || !Array.isArray(record.channels)) continue;
 				const payload = {

--- a/src/runs/background/fork-handler.ts
+++ b/src/runs/background/fork-handler.ts
@@ -1,0 +1,281 @@
+import * as fs from "node:fs";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { buildForkHandlerEnv, buildForkRunPaths, getForkHandlersFile, getForkStateDir, launchDetachedFork } from "../../shared/fork-runtime.ts";
+import { SUBAGENT_CHILD_ENV } from "../shared/pi-args.ts";
+import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
+import type { BackgroundForkHandlersConfig } from "../../shared/types.ts";
+
+export type BackgroundForkHandlerNotify = "ack-and-summary" | "summary" | "none";
+
+export interface ResolvedBackgroundForkHandlersConfig {
+	enabled: boolean;
+	notify: BackgroundForkHandlerNotify;
+	triggerParentOnSummary: boolean;
+	piCommand?: string;
+}
+
+export interface SubagentBackgroundForkEvent {
+	type: "async-complete" | "async-step-complete" | "control-notice";
+	title: string;
+	content: string;
+	cwd?: string;
+	parentSessionFile?: string;
+	parentIntercomTarget?: string;
+	details?: unknown;
+}
+
+interface BackgroundForkRun {
+	id: string;
+	type: SubagentBackgroundForkEvent["type"];
+	title: string;
+	cwd: string;
+	dir: string;
+	eventPath: string;
+	promptPath: string;
+	stdoutPath: string;
+	stderrPath: string;
+	sessionDir: string;
+	parentSessionFile?: string;
+	parentIntercomTarget?: string;
+	status?: "starting" | "running" | "complete" | "failed";
+	startedAt?: number;
+	endedAt?: number;
+	exitCode?: number | null;
+	signal?: NodeJS.Signals | null;
+	error?: string;
+	pid?: number;
+}
+
+interface BackgroundForkRunsState {
+	version: 1;
+	handlers: BackgroundForkRun[];
+}
+
+const STATE_DIR = getForkStateDir("subagents");
+const HANDLERS_FILE = getForkHandlersFile("subagents");
+const SUMMARY_LIMIT_BYTES = 16 * 1024;
+const MAX_PERSISTED_HANDLERS = 200;
+
+function truncateText(text: string, limitBytes: number): string {
+	const bytes = Buffer.byteLength(text, "utf8");
+	if (bytes <= limitBytes) return text;
+	const truncated = Buffer.from(text, "utf8").subarray(0, limitBytes).toString("utf8");
+	return `${truncated}\n… truncated ${bytes - limitBytes} bytes`;
+}
+
+function sanitizeSegment(value: string): string {
+	return value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40) || "event";
+}
+
+function makeRunId(event: SubagentBackgroundForkEvent): string {
+	return `sbf_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}_${sanitizeSegment(event.type)}`;
+}
+
+async function readPersistedRuns(): Promise<BackgroundForkRun[]> {
+	try {
+		const raw = await fs.promises.readFile(HANDLERS_FILE, "utf8");
+		const parsed = JSON.parse(raw) as Partial<BackgroundForkRunsState>;
+		return Array.isArray(parsed.handlers) ? parsed.handlers : [];
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		return [];
+	}
+}
+
+async function writePersistedRuns(runs: BackgroundForkRun[]): Promise<void> {
+	await fs.promises.mkdir(STATE_DIR, { recursive: true });
+	const tmp = `${HANDLERS_FILE}.${process.pid}.${Date.now()}.tmp`;
+	const state: BackgroundForkRunsState = { version: 1, handlers: runs.slice(-MAX_PERSISTED_HANDLERS) };
+	await fs.promises.writeFile(tmp, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+	await fs.promises.rename(tmp, HANDLERS_FILE);
+}
+
+async function persistRun(run: BackgroundForkRun): Promise<void> {
+	const runs = await readPersistedRuns();
+	const next = [...runs.filter((candidate) => candidate.id !== run.id), run];
+	await writePersistedRuns(next);
+}
+
+async function patchPersistedRun(id: string, patch: Partial<BackgroundForkRun>): Promise<void> {
+	const runs = await readPersistedRuns();
+	const index = runs.findIndex((candidate) => candidate.id === id);
+	if (index === -1) return;
+	runs[index] = { ...runs[index]!, ...patch };
+	await writePersistedRuns(runs);
+}
+
+export function resolveBackgroundForkHandlersConfig(config?: BackgroundForkHandlersConfig): ResolvedBackgroundForkHandlersConfig {
+	return {
+		enabled: config?.enabled ?? true,
+		notify: config?.notify ?? "ack-and-summary",
+		triggerParentOnSummary: config?.triggerParentOnSummary ?? false,
+		...(config?.piCommand ? { piCommand: config.piCommand } : {}),
+	};
+}
+
+function buildSystemPrompt(run: BackgroundForkRun): string {
+	return [
+		"You are a background pi-subagents event handler in a sibling Pi process.",
+		"Handle only the subagent event capsule in the latest user message.",
+		"Do not continue unrelated parent work. Do not interrupt the parent unless a real decision or required parent action is needed.",
+		"You may inspect referenced files, child session files, artifacts, and repo state to summarize or triage the event.",
+		"Do the safe triage/checking in this fork. Do not send optional next steps, routine success, or no-action-needed updates back to the parent.",
+		"If the event contains a concrete required parent action, blocker, or required parent follow-up, notify the parent through intercom instead of only writing a final summary.",
+		"Use intercom({ action: \"send\", to: <parent>, message: ... }) for required actionable non-blocking parent notices; use intercom.ask only for true blocking decisions.",
+		"Escalate only for destructive actions, ambiguous user preference, external side effects, security/privacy/cost risk, conflict with current parent work, or low confidence.",
+		...(run.parentIntercomTarget ? [`Parent intercom target: ${run.parentIntercomTarget}`] : []),
+		`Handler id: ${run.id}`,
+	].join("\n");
+}
+
+function buildPrompt(event: SubagentBackgroundForkEvent, run: BackgroundForkRun): string {
+	return [
+		"# pi-subagents background event",
+		"",
+		`Type: ${event.type}`,
+		`Title: ${event.title}`,
+		`Handler: ${run.id}`,
+		"",
+		"## Parent notification content",
+		"",
+		event.content,
+		"",
+		"## Event details",
+		"",
+		"```json",
+		JSON.stringify(event.details ?? {}, null, 2),
+		"```",
+		"",
+		"## Instructions",
+		"",
+		"Handle this background event without waking the parent feed for routine summaries. If the event includes a child session or artifact path, read it only when it helps triage accurately.",
+		"Do safe checks in this fork. If your conclusion is routine success, optional follow-up, or no action needed, do not send an intercom message to the parent; just state that in your final summary.",
+		...(run.parentIntercomTarget
+			? [
+				`Parent intercom target: ${run.parentIntercomTarget}`,
+				`Only if the event content includes a concrete required parent action, blocker, or required parent follow-up, call intercom({ action: \"send\", to: ${JSON.stringify(run.parentIntercomTarget)}, message: \"...\" }) with a concise action request so the parent can start it. If delivery fails because the target is stale, missing, or ambiguous, call intercom({ action: \"list\" }) and retry with the full id of the non-fork parent session that matches this event's cwd/name, excluding sessions whose status contains \"fork-handler:\". Use intercom.ask only if you need a decision before you can proceed.`,
+			]
+			: ["No parent intercom target is available; include any required parent action in your final summary."]),
+		"Final summary: state what you inspected, what you sent/escalated to the parent if anything, and whether further parent action is still needed.",
+	].join("\n");
+}
+
+function formatAck(run: BackgroundForkRun): string {
+	return [
+		`Background subagent event forked: ${run.title}`,
+		`Handler: ${run.id}${run.pid ? ` (pid ${run.pid})` : ""}`,
+		`Handler dir: ${run.dir}`,
+	].join("\n");
+}
+
+function formatSummary(run: BackgroundForkRun, status: "complete" | "failed", code: number | null, signal: NodeJS.Signals | null): string {
+	const stdout = fs.existsSync(run.stdoutPath) ? fs.readFileSync(run.stdoutPath, "utf8") : "";
+	const stderr = fs.existsSync(run.stderrPath) ? fs.readFileSync(run.stderrPath, "utf8") : "";
+	const output = stdout.trim() || stderr.trim() || "(no handler output)";
+	const exit = code !== null ? String(code) : signal ? `signal ${signal}` : "unknown";
+	return [
+		`Background subagent event handler ${status}: ${run.title}`,
+		`Handler: ${run.id}`,
+		`Exit: ${exit}`,
+		`Output: ${run.stdoutPath}`,
+		`Errors: ${run.stderrPath}`,
+		"",
+		truncateText(output, SUMMARY_LIMIT_BYTES),
+	].join("\n");
+}
+
+function sendFallback(pi: Pick<ExtensionAPI, "sendMessage">, event: SubagentBackgroundForkEvent): void {
+	pi.sendMessage(
+		{
+			customType: event.type === "control-notice" ? "subagent_control_notice" : "subagent-notify",
+			content: event.content,
+			display: true,
+			details: event.details,
+		},
+		{ triggerTurn: false },
+	);
+}
+
+export async function deliverBackgroundForkEvent(
+	pi: Pick<ExtensionAPI, "sendMessage">,
+	config: BackgroundForkHandlersConfig | undefined,
+	event: SubagentBackgroundForkEvent,
+): Promise<void> {
+	const resolved = resolveBackgroundForkHandlersConfig(config);
+	if (!resolved.enabled) {
+		sendFallback(pi, event);
+		return;
+	}
+
+	let run: BackgroundForkRun | undefined;
+	try {
+		run = (() => {
+			const id = makeRunId(event);
+			return {
+				...buildForkRunPaths("subagents", id),
+				type: event.type,
+				title: event.title,
+				cwd: event.cwd ?? process.cwd(),
+				status: "starting",
+				startedAt: Date.now(),
+				...(event.parentSessionFile ? { parentSessionFile: event.parentSessionFile } : {}),
+				...(event.parentIntercomTarget ? { parentIntercomTarget: event.parentIntercomTarget } : {}),
+			};
+		})();
+
+		await fs.promises.mkdir(run.sessionDir, { recursive: true });
+		await fs.promises.writeFile(run.eventPath, `${JSON.stringify(event, null, 2)}\n`, "utf8");
+		await fs.promises.writeFile(run.promptPath, buildPrompt(event, run), "utf8");
+		await persistRun(run);
+
+		const baseArgs = [
+			"-p",
+			"--session-dir",
+			run.sessionDir,
+			"--append-system-prompt",
+			buildSystemPrompt(run),
+			...(run.parentSessionFile ? ["--fork", run.parentSessionFile] : []),
+			`@${run.promptPath}`,
+		];
+		const command = resolved.piCommand ? { command: resolved.piCommand, args: baseArgs } : getPiSpawnCommand(baseArgs);
+		const launch = await launchDetachedFork({
+			command: command.command,
+			args: command.args,
+			cwd: run.cwd,
+			stdoutPath: run.stdoutPath,
+			stderrPath: run.stderrPath,
+			env: buildForkHandlerEnv("subagents", run.id, { ...process.env, [SUBAGENT_CHILD_ENV]: "1" }),
+			onClose: (code, signal) => {
+				const status = code === 0 ? "complete" : "failed";
+				void patchPersistedRun(run!.id, { status, endedAt: Date.now(), exitCode: code, signal }).catch((error) => {
+					console.error("[pi-subagents] Failed to persist background fork handler completion:", error);
+				});
+				if (resolved.notify !== "summary" && resolved.notify !== "ack-and-summary") return;
+				pi.sendMessage(
+					{ customType: "subagent-fork-handler", content: formatSummary(run!, status, code, signal), display: true, details: { id: run!.id, type: run!.type, status, dir: run!.dir, pid: run!.pid, exitCode: code, signal } },
+					{ triggerTurn: resolved.triggerParentOnSummary },
+				);
+			},
+		});
+		if (!launch.ok) {
+			const message = launch.error instanceof Error ? launch.error.message : String(launch.error);
+			await patchPersistedRun(run.id, { status: "failed", endedAt: Date.now(), error: message });
+			console.error("[pi-subagents] Failed to launch background fork handler:", launch.error);
+			sendFallback(pi, event);
+			return;
+		}
+		run.pid = launch.pid;
+		run.status = "running";
+		await patchPersistedRun(run.id, { pid: launch.pid, status: "running" });
+		if (resolved.notify === "ack-and-summary") {
+			pi.sendMessage(
+				{ customType: "subagent-fork-handler", content: formatAck(run), display: true, details: { id: run.id, type: run.type, status: "running", dir: run.dir, pid: run.pid } },
+				{ triggerTurn: false },
+			);
+		}
+	} catch (error) {
+		if (run) await patchPersistedRun(run.id, { status: "failed", endedAt: Date.now(), error: error instanceof Error ? error.message : String(error) });
+		console.error("[pi-subagents] Failed to start background fork handler:", error);
+		sendFallback(pi, event);
+	}
+}

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -4,7 +4,8 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { buildCompletionKey, getGlobalSeenMap, markSeenWithTtl } from "./completion-dedupe.ts";
-import { SUBAGENT_ASYNC_COMPLETE_EVENT } from "../../shared/types.ts";
+import { deliverBackgroundForkEvent } from "./fork-handler.ts";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_ASYNC_STEP_COMPLETE_EVENT, type BackgroundForkHandlersConfig } from "../../shared/types.ts";
 
 interface ChainStepResult {
 	agent: string;
@@ -40,7 +41,12 @@ interface SubagentResult {
 	totalTasks?: number;
 }
 
-export default function registerSubagentNotify(pi: ExtensionAPI): void {
+export default function registerSubagentNotify(
+	pi: ExtensionAPI,
+	backgroundForkHandlers?: BackgroundForkHandlersConfig,
+	getParentSessionFile?: () => string | null | undefined,
+	getParentIntercomTarget?: () => string | null | undefined,
+): void {
 	const unsubscribeStoreKey = "__pi_subagents_notify_unsubscribe__";
 	const globalStore = globalThis as Record<string, unknown>;
 	const previousUnsubscribe = globalStore[unsubscribeStoreKey];
@@ -94,15 +100,28 @@ export default function registerSubagentNotify(pi: ExtensionAPI): void {
 			.filter((line) => line !== undefined)
 			.join("\n");
 
-		pi.sendMessage(
-			{
-				customType: "subagent-notify",
-				content,
-				display: true,
-			},
-			{ triggerTurn: true },
-		);
+		void deliverBackgroundForkEvent(pi, backgroundForkHandlers, {
+			type: "async-complete",
+			title: `Background task ${status}: ${agent}${taskInfo}`,
+			content,
+			cwd: process.cwd(),
+			parentSessionFile: getParentSessionFile?.() ?? undefined,
+			parentIntercomTarget: getParentIntercomTarget?.() ?? undefined,
+			details: { agent, status, taskInfo, resultPreview: displaySummary, durationMs: result.durationMs, sessionLabel: sessionLine ? "session" : undefined, sessionValue: result.shareUrl ?? result.sessionFile },
+		});
 	};
 
-	globalStore[unsubscribeStoreKey] = pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, handleComplete);
+	const handleStepComplete = (_data: unknown) => {
+		// The aggregate async-complete event carries the final per-worker summaries, and
+		// control notices cover actionable in-progress attention. Suppress per-step
+		// completion handlers entirely to avoid duplicate fork summaries/escalations.
+	};
+
+	const unsubscribes = [
+		pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, handleComplete),
+		pi.events.on(SUBAGENT_ASYNC_STEP_COMPLETE_EVENT, handleStepComplete),
+	];
+	globalStore[unsubscribeStoreKey] = () => {
+		for (const unsubscribe of unsubscribes) unsubscribe();
+	};
 }

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -69,6 +69,19 @@ import {
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { writeInitialProgressFile } from "../../shared/settings.ts";
 
+const CHILD_EVENT_TYPES_OMITTED_FROM_ASYNC_LOG = new Set(["message_update", "tool_execution_update"]);
+
+function shouldPersistChildEvent(event: Record<string, unknown>): boolean {
+	return typeof event.type !== "string" || !CHILD_EVENT_TYPES_OMITTED_FROM_ASYNC_LOG.has(event.type);
+}
+
+function summarizeStepOutputForEvent(output: string | undefined, error?: string): string {
+	const text = error ? `${error}${output?.trim() ? `\n\nOutput:\n${output}` : ""}` : (output ?? "");
+	const trimmed = text.trim();
+	if (trimmed.length <= 4000) return trimmed;
+	return `${trimmed.slice(0, 4000)}\n\n… truncated per-step notification; use subagent status or the final run result for full output.`;
+}
+
 interface SubagentRunConfig {
 	id: string;
 	steps: RunnerStep[];
@@ -246,7 +259,7 @@ function runPiStreaming(
 		};
 
 		const appendChildEvent = (event: Record<string, unknown>) => {
-			if (!childEventContext) return;
+			if (!childEventContext || !shouldPersistChildEvent(event)) return;
 			appendJsonl(childEventContext.eventsPath, JSON.stringify({
 				...event,
 				subagentSource: "child",
@@ -776,7 +789,20 @@ function markParallelGroupSetupFailure(input: {
 		input.statusPayload.steps[flatTaskIndex].endedAt = input.failedAt;
 		input.statusPayload.steps[flatTaskIndex].durationMs = 0;
 		input.statusPayload.steps[flatTaskIndex].exitCode = 1;
-		input.results.push({ agent: input.group.parallel[taskIndex].agent, output: input.setupError, success: false, sessionFile: input.group.parallel[taskIndex].sessionFile });
+		const task = input.group.parallel[taskIndex];
+		input.results.push({ agent: task.agent, output: input.setupError, success: false, sessionFile: task.sessionFile });
+		appendJsonl(input.eventsPath, JSON.stringify({
+			type: "subagent.step.failed",
+			ts: input.failedAt,
+			runId: input.runId,
+			stepIndex: flatTaskIndex,
+			agent: task.agent,
+			exitCode: 1,
+			durationMs: 0,
+			totalTasks: input.statusPayload.steps.length,
+			summary: input.setupError,
+			sessionFile: task.sessionFile,
+		}));
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.lastUpdate = input.failedAt;
@@ -1370,6 +1396,10 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 							type: singleResult.exitCode === 0 ? "subagent.step.completed" : "subagent.step.failed",
 							ts: taskEndTime, runId: id, stepIndex: fi, agent: task.agent,
 							exitCode: singleResult.exitCode, durationMs: taskDuration,
+							totalTasks: flatSteps.length,
+							summary: summarizeStepOutputForEvent(singleResult.output, singleResult.error),
+							sessionFile: singleResult.sessionFile,
+							intercomTarget: singleResult.intercomTarget,
 						}));
 						if (singleResult.completionGuardTriggered) {
 							const event = buildControlEvent({
@@ -1556,7 +1586,11 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				agent: seqStep.agent,
 				exitCode: singleResult.exitCode,
 				durationMs: stepEndTime - stepStartTime,
+				totalTasks: flatSteps.length,
 				tokens: stepTokens,
+				summary: summarizeStepOutputForEvent(singleResult.output, singleResult.error),
+				sessionFile: singleResult.sessionFile,
+				intercomTarget: singleResult.intercomTarget,
 			}));
 			if (singleResult.completionGuardTriggered) {
 				const event = buildControlEvent({

--- a/src/shared/fork-runtime-fallback.ts
+++ b/src/shared/fork-runtime-fallback.ts
@@ -1,0 +1,106 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawn } from "node:child_process";
+
+export type ForkSource = "intercom" | "return_on" | "subagents";
+export type ForkHandlerKind = "intercom" | "return-on" | "subagent";
+export interface ForkHandlerIdentity { kind: ForkHandlerKind; runId?: string; statusTag: string; sessionName: string }
+
+const SOURCE_STATE_DIR: Record<ForkSource, string> = { intercom: "pi-intercom", return_on: "pi-return-on", subagents: "pi-subagents" };
+const SOURCE_ENV: Record<ForkSource, { flag: string; runId: string }> = {
+  intercom: { flag: "PI_INTERCOM_FORK_HANDLER", runId: "PI_INTERCOM_FORK_HANDLER_RUN_ID" },
+  return_on: { flag: "PI_RETURN_ON_HANDLER", runId: "PI_RETURN_ON_HANDLER_RUN_ID" },
+  subagents: { flag: "PI_SUBAGENT_BACKGROUND_HANDLER", runId: "PI_SUBAGENT_BACKGROUND_HANDLER_RUN_ID" },
+};
+
+function shortForkRunId(runId: string | undefined): string {
+  const cleaned = runId?.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "") ?? "";
+  const withoutPrefix = cleaned.replace(/^(?:icfh|roh|sbf)-?/i, "");
+  const parts = withoutPrefix.split("-").filter(Boolean);
+  const compact = parts.length >= 2 ? parts.slice(0, 2).join("-") : withoutPrefix;
+  return (compact || "handler").slice(0, 24);
+}
+
+export function forkHandlerKind(source: ForkSource): ForkHandlerKind {
+  if (source === "return_on") return "return-on";
+  if (source === "subagents") return "subagent";
+  return "intercom";
+}
+
+export function buildForkIntercomIdentity(source: ForkSource, runId?: string): ForkHandlerIdentity {
+  const kind = forkHandlerKind(source);
+  return { kind, ...(runId ? { runId } : {}), statusTag: runId ? `fork-handler:${kind}:${runId}` : `fork-handler:${kind}`, sessionName: `fork-${kind}-${shortForkRunId(runId)}` };
+}
+
+export function getForkHandlerIdentity(env: NodeJS.ProcessEnv = process.env): ForkHandlerIdentity | undefined {
+  for (const source of ["intercom", "return_on", "subagents"] as const) {
+    const keys = SOURCE_ENV[source];
+    if (env[keys.flag] !== "1") continue;
+    return buildForkIntercomIdentity(source, env[keys.runId]?.trim() || undefined);
+  }
+  return undefined;
+}
+
+export function buildForkHandlerEnv(source: ForkSource, runId: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const keys = SOURCE_ENV[source];
+  return { ...extra, [keys.flag]: "1", [keys.runId]: runId };
+}
+
+export function getForkStateDir(source: ForkSource, homeDir = os.homedir()): string {
+  return path.join(homeDir, ".local", "state", SOURCE_STATE_DIR[source]);
+}
+export function getForkHandlersDir(source: ForkSource, homeDir = os.homedir()): string {
+  return path.join(getForkStateDir(source, homeDir), "handlers");
+}
+export function getForkHandlersFile(source: ForkSource, homeDir = os.homedir()): string {
+  return path.join(getForkStateDir(source, homeDir), "handlers.json");
+}
+export function buildForkRunPaths(source: ForkSource, id: string, homeDir = os.homedir()) {
+  const dir = path.join(getForkHandlersDir(source, homeDir), id);
+  return { id, dir, eventPath: path.join(dir, "event.json"), promptPath: path.join(dir, "prompt.md"), stdoutPath: path.join(dir, "stdout.log"), stderrPath: path.join(dir, "stderr.log"), sessionDir: path.join(dir, "sessions") };
+}
+export function buildPiForkArgs(options: { sessionDir: string; systemPrompt: string; promptPath: string; forkFile?: string }): string[] {
+  const args = ["-p", "--session-dir", options.sessionDir, "--append-system-prompt", options.systemPrompt];
+  if (options.forkFile) args.push("--fork", options.forkFile);
+  args.push(`@${options.promptPath}`);
+  return args;
+}
+export async function readOptionalText(filePath: string): Promise<string> {
+  try { return await fsp.readFile(filePath, "utf8"); } catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return ""; throw error; }
+}
+export function truncateText(value: string, limitBytes: number): string {
+  const buf = Buffer.from(value);
+  return buf.length <= limitBytes ? value : `${buf.subarray(0, limitBytes).toString("utf8")}\n[truncated ${buf.length - limitBytes} bytes]`;
+}
+export async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fsp.writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await fsp.rename(tmp, filePath);
+}
+function closeFdBestEffort(fd: number | undefined): void { if (fd !== undefined) { try { fs.closeSync(fd); } catch {} } }
+export async function launchDetachedFork(options: { command: string; args: string[]; cwd: string; stdoutPath: string; stderrPath: string; env?: NodeJS.ProcessEnv; onClose?: (code: number | null, signal: NodeJS.Signals | null) => void }) {
+  let stdoutFd: number | undefined;
+  let stderrFd: number | undefined;
+  try {
+    stdoutFd = fs.openSync(options.stdoutPath, "a");
+    stderrFd = fs.openSync(options.stderrPath, "a");
+    const child = spawn(options.command, options.args, { cwd: options.cwd, detached: true, env: options.env ?? process.env, stdio: ["ignore", stdoutFd, stderrFd] });
+    closeFdBestEffort(stdoutFd); closeFdBestEffort(stderrFd); stdoutFd = undefined; stderrFd = undefined;
+    child.unref();
+    let launchError: unknown;
+    const spawned = await new Promise<boolean>((resolve) => {
+      const onSpawn = () => { child.off("error", onError); resolve(true); };
+      const onError = (error: Error) => { launchError = error; child.off("spawn", onSpawn); resolve(false); };
+      child.once("spawn", onSpawn); child.once("error", onError);
+    });
+    if (!spawned) return { ok: false as const, error: launchError };
+    if (options.onClose) child.once("close", options.onClose);
+    return { ok: true as const, pid: child.pid };
+  } catch (error) {
+    closeFdBestEffort(stdoutFd); closeFdBestEffort(stderrFd);
+    return { ok: false as const, error };
+  }
+}

--- a/src/shared/fork-runtime.ts
+++ b/src/shared/fork-runtime.ts
@@ -1,0 +1,14 @@
+import * as fallback from "./fork-runtime-fallback.ts";
+
+const runtimeModule = "pi-forks/runtime";
+const runtime = await import(runtimeModule)
+	.then((module) => module as typeof fallback)
+	.catch(() => fallback);
+
+export type ForkSource = fallback.ForkSource;
+
+export const buildForkHandlerEnv = runtime.buildForkHandlerEnv;
+export const buildForkRunPaths = runtime.buildForkRunPaths;
+export const getForkHandlersFile = runtime.getForkHandlersFile;
+export const getForkStateDir = runtime.getForkStateDir;
+export const launchDetachedFork = runtime.launchDetachedFork;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -442,6 +442,7 @@ export const INTERCOM_DETACH_REQUEST_EVENT = "pi-intercom:detach-request";
 export const INTERCOM_DETACH_RESPONSE_EVENT = "pi-intercom:detach-response";
 export const SUBAGENT_ASYNC_STARTED_EVENT = "subagent:async-started";
 export const SUBAGENT_ASYNC_COMPLETE_EVENT = "subagent:async-complete";
+export const SUBAGENT_ASYNC_STEP_COMPLETE_EVENT = "subagent:async-step-complete";
 export const SUBAGENT_CONTROL_EVENT = "subagent:control-event";
 export const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 export const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
@@ -490,6 +491,15 @@ export interface IntercomBridgeConfig {
 	instructionFile?: string;
 }
 
+export type BackgroundForkHandlerNotify = "ack-and-summary" | "summary" | "none";
+
+export interface BackgroundForkHandlersConfig {
+	enabled?: boolean;
+	notify?: BackgroundForkHandlerNotify;
+	triggerParentOnSummary?: boolean;
+	piCommand?: string;
+}
+
 interface TopLevelParallelConfig {
 	maxTasks?: number;
 	concurrency?: number;
@@ -505,6 +515,7 @@ export interface ExtensionConfig {
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
 	intercomBridge?: IntercomBridgeConfig;
+	backgroundForkHandlers?: BackgroundForkHandlersConfig;
 }
 
 // ============================================================================

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -283,7 +283,7 @@ async function runSlashSubagent(
 		content: initialText,
 		display: true,
 		details: initialDetails,
-	});
+	}, { triggerTurn: false });
 	persistSlashSessionSnapshot(ctx);
 
 	try {
@@ -294,7 +294,7 @@ async function runSlashSubagent(
 			content: buildSlashExportText(response),
 			display: true,
 			details: finalDetails,
-		});
+		}, { triggerTurn: false });
 		persistSlashSessionSnapshot(ctx);
 		if (ctx.hasUI) {
 			ctx.ui.setStatus("subagent-slash", undefined);
@@ -310,7 +310,7 @@ async function runSlashSubagent(
 			content: `## Subagent result\n\n${message}`,
 			display: true,
 			details: failedDetails,
-		});
+		}, { triggerTurn: false });
 		persistSlashSessionSnapshot(ctx);
 		if (ctx.hasUI) {
 			ctx.ui.setStatus("subagent-slash", undefined);

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -997,6 +997,52 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(chainResult.content[0]?.text ?? "", /cwd does not exist/);
 	});
 
+	it("background parallel worktree setup failures emit step failure events", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const repoDir = createRepo("pi-subagent-async-worktree-fail-");
+		const id = `async-worktree-setup-fail-${Date.now().toString(36)}`;
+		try {
+			fs.writeFileSync(path.join(repoDir, "dirty.txt"), "dirty\n", "utf-8");
+			const result = executeAsyncChain(id, {
+				chain: [
+					{
+						parallel: [
+							{ agent: "worker", task: "Do work" },
+							{ agent: "scout", task: "Scout work" },
+						],
+						worktree: true,
+					},
+				],
+				agents: [makeAgent("worker"), makeAgent("scout")],
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				cwd: repoDir,
+				artifactConfig: {
+					enabled: false,
+					includeInput: false,
+					includeOutput: false,
+					includeJsonl: false,
+					includeMetadata: false,
+					cleanupDays: 7,
+				},
+				shareEnabled: false,
+				sessionRoot: path.join(tempDir, "sessions"),
+				maxSubagentDepth: 2,
+			});
+
+			assert.equal(result.isError, undefined);
+			await waitForAsyncResultFile(id);
+			const eventsText = fs.readFileSync(path.join(ASYNC_DIR, id, "events.jsonl"), "utf-8");
+			const records = eventsText.trim().split("\n").map((line) => JSON.parse(line));
+			const stepFailures = records.filter((record) => record.type === "subagent.step.failed");
+			assert.equal(stepFailures.length, 2);
+			assert.deepEqual(stepFailures.map((record) => record.agent), ["worker", "scout"]);
+			assert.deepEqual(stepFailures.map((record) => record.stepIndex), [0, 1]);
+			assert.deepEqual(stepFailures.map((record) => record.totalTasks), [2, 2]);
+			assert.ok(stepFailures.every((record) => /clean git working tree|dirty|uncommitted/i.test(record.summary)));
+		} finally {
+			removeTempDir(repoDir);
+		}
+	});
+
 	it("returns a tool error when the async runner process cannot spawn", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
 		const originalExecPath = process.execPath;
 		process.execPath = path.join(tempDir, "missing-node");
@@ -1302,8 +1348,21 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	it("background runs stream child events and live output while active", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			steps: [
-				{ delay: 200, jsonl: [events.toolStart("bash", { command: "ls" })] },
-				{ delay: 600, jsonl: [events.toolEnd("bash"), events.toolResult("bash", "file-a\nfile-b")] },
+				{
+					delay: 200,
+					jsonl: [
+						events.toolStart("bash", { command: "ls" }),
+						{ type: "message_update", message: { content: [{ type: "text", text: "verbose partial" }] } },
+					],
+				},
+				{
+					delay: 600,
+					jsonl: [
+						{ type: "tool_execution_update", toolName: "bash", args: { command: "ls" } },
+						events.toolEnd("bash"),
+						events.toolResult("bash", "file-a\nfile-b"),
+					],
+				},
 				{ delay: 600, jsonl: [events.assistantMessage("Done streaming")], stderr: "warning: mock stderr\n" },
 			],
 		});
@@ -1365,6 +1424,18 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
 		assert.equal(payload.success, true);
 		assert.equal(payload.results[0].output, "Done streaming");
+
+		const eventsLog = fs.readFileSync(eventsPath, "utf-8");
+		assert.equal(
+			eventsLog.includes('"type":"message_update"'),
+			false,
+			"verbose message updates should not be persisted to async events.jsonl",
+		);
+		assert.equal(
+			eventsLog.includes('"type":"tool_execution_update"'),
+			false,
+			"verbose tool updates should not be persisted to async events.jsonl",
+		);
 
 		const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
 		assert.deepEqual(status.steps[0].recentTools.map((tool: { tool: string; args: string }) => ({ tool: tool.tool, args: tool.args })), [{ tool: "bash", args: "ls" }]);

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -441,6 +441,65 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
+	it("emits async step completion records from events.jsonl", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-");
+		try {
+			const runDir = path.join(asyncRoot, "run-step-complete");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-step-complete",
+				mode: "chain",
+				state: "running",
+				startedAt: Date.now() - 1000,
+				lastUpdate: Date.now(),
+				chainStepCount: 2,
+				steps: [
+					{ agent: "reviewer", status: "complete" },
+					{ agent: "worker", status: "running" },
+				],
+			}), "utf-8");
+			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
+				type: "subagent.step.completed",
+				runId: "run-step-complete",
+				stepIndex: 0,
+				totalTasks: 2,
+				agent: "reviewer",
+				exitCode: 0,
+				durationMs: 1234,
+				summary: "review complete",
+				sessionFile: "/tmp/reviewer-session.jsonl",
+			})}\n`, "utf-8");
+
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+			});
+			tracker.handleStarted({ id: "run-step-complete", asyncDir: runDir, mode: "chain", agents: ["reviewer", "worker"], chainStepCount: 2 });
+
+			await new Promise((resolve) => setTimeout(resolve, 30));
+
+			assert.deepEqual(recorder.events.find((event) => event.channel === "subagent:async-step-complete"), {
+				channel: "subagent:async-step-complete",
+				data: {
+					id: "run-step-complete",
+					runId: "run-step-complete",
+					agent: "reviewer",
+					index: 0,
+					totalTasks: 2,
+					success: true,
+					exitCode: 0,
+					durationMs: 1234,
+					summary: "review complete",
+					sessionFile: "/tmp/reviewer-session.jsonl",
+					intercomTarget: undefined,
+				},
+			});
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
 	it("honors async control notification channels", async () => {
 		const asyncRoot = createTempDir("pi-async-job-tracker-");
 		try {

--- a/test/unit/control-notices.test.ts
+++ b/test/unit/control-notices.test.ts
@@ -5,6 +5,7 @@ import {
 	handleSubagentControlNotice,
 } from "../../src/extension/control-notices.ts";
 import type { ControlEvent, SubagentState } from "../../src/shared/types.ts";
+import { createMockPi } from "../support/mock-pi.ts";
 
 function makeState(): SubagentState {
 	return {
@@ -55,20 +56,34 @@ function wait(ms: number): Promise<void> {
 }
 
 describe("subagent control notice delivery", () => {
-	it("delivers async needs-attention notices immediately", () => {
-		const state = makeState();
-		const recorder = makeRecorder();
+	it("forks async needs-attention notices without triggering the main feed", async () => {
+		const mockPi = createMockPi();
+		mockPi.install();
+		mockPi.onCall({ output: "control handled in fork" });
+		try {
+			const state = makeState();
+			const recorder = makeRecorder();
 
-		handleSubagentControlNotice({
-			pi: recorder.pi,
-			state,
-			visibleControlNotices: new Set(),
-			details: { source: "async", event: needsAttentionEvent() },
-			foregroundDelayMs: 20,
-		});
+			handleSubagentControlNotice({
+				pi: recorder.pi,
+				state,
+				visibleControlNotices: new Set(),
+				details: { source: "async", event: needsAttentionEvent() },
+				foregroundDelayMs: 20,
+			});
 
-		assert.equal(recorder.sent.length, 1);
-		assert.deepEqual(recorder.sent[0]?.options, { triggerTurn: true });
+			const start = Date.now();
+			while (Date.now() - start < 2_000 && recorder.sent.length < 2) {
+				await wait(20);
+			}
+			assert.equal(recorder.sent.length, 2);
+			assert.equal(recorder.sent.some((entry) => (entry as any).options?.triggerTurn === true), false);
+			assert.equal((recorder.sent[0] as any).message.customType, "subagent-fork-handler");
+			assert.equal((recorder.sent[1] as any).message.details.status, "complete");
+			assert.match(String((recorder.sent[1] as any).message.content), /control handled in fork/);
+		} finally {
+			mockPi.uninstall();
+		}
 	});
 
 	it("queues foreground needs-attention notices until the same step is still actionable", async () => {

--- a/test/unit/intercom-bridge.test.ts
+++ b/test/unit/intercom-bridge.test.ts
@@ -96,10 +96,19 @@ describe("diagnoseIntercomBridge", () => {
 	it("reports inactive and unavailable when pi-intercom is missing", () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-intercom-diagnostic-test-"));
 		try {
+			const agentDir = path.join(tempDir, "agent");
+			const cwd = path.join(tempDir, "workspace");
+			const globalNpmRoot = path.join(tempDir, "global-node_modules");
+			fs.mkdirSync(agentDir, { recursive: true });
+			fs.mkdirSync(cwd, { recursive: true });
+			fs.mkdirSync(globalNpmRoot, { recursive: true });
 			const diagnostic = diagnoseIntercomBridge({
 				config: { mode: "always" },
 				context: "fresh",
 				orchestratorTarget: "main",
+				agentDir,
+				cwd,
+				globalNpmRoot,
 				extensionDir: path.join(tempDir, "missing-pi-intercom"),
 				configPath: path.join(tempDir, "config.json"),
 			});

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { EventEmitter } from "node:events";
 import { describe, it } from "node:test";
+import { deliverBackgroundForkEvent } from "../../src/runs/background/fork-handler.ts";
 import registerSubagentNotify from "../../src/runs/background/notify.ts";
-import { SUBAGENT_ASYNC_COMPLETE_EVENT } from "../../src/shared/types.ts";
+import { SUBAGENT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_ASYNC_STEP_COMPLETE_EVENT, type BackgroundForkHandlersConfig } from "../../src/shared/types.ts";
+import { createMockPi } from "../support/mock-pi.ts";
 
-function createPi() {
+function createPi(backgroundForkHandlers: BackgroundForkHandlersConfig = { enabled: false }, getParentSessionFile?: () => string | null | undefined) {
 	const events = new EventEmitter();
 	const sent: Array<{ message: unknown; options: unknown }> = [];
 	const pi = {
@@ -14,9 +19,18 @@ function createPi() {
 		},
 	};
 
-	registerSubagentNotify(pi as never);
+	registerSubagentNotify(pi as never, backgroundForkHandlers, getParentSessionFile);
 
 	return { events, sent };
+}
+
+async function waitForSent(sent: unknown[], count: number, timeoutMs = 2_000): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (sent.length >= count) return;
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+	throw new Error(`timed out waiting for ${count} sent messages; saw ${sent.length}`);
 }
 
 describe("registerSubagentNotify", () => {
@@ -33,14 +47,9 @@ describe("registerSubagentNotify", () => {
 		});
 
 		assert.equal(sent.length, 1);
-		assert.deepEqual(sent[0], {
-			message: {
-				customType: "subagent-notify",
-				content: "Background task completed: **worker**\n\n(no output)",
-				display: true,
-			},
-			options: { triggerTurn: true },
-		});
+		assert.equal((sent[0] as any).message.customType, "subagent-notify");
+		assert.equal((sent[0] as any).message.content, "Background task completed: **worker**\n\n(no output)");
+		assert.deepEqual((sent[0] as any).options, { triggerTurn: false });
 	});
 
 	it("preserves non-empty completion summaries", () => {
@@ -59,14 +68,9 @@ describe("registerSubagentNotify", () => {
 		});
 
 		assert.equal(sent.length, 1);
-		assert.deepEqual(sent[0], {
-			message: {
-				customType: "subagent-notify",
-				content: `Background task completed: **worker** (2/3)\n\n${summary}`,
-				display: true,
-			},
-			options: { triggerTurn: true },
-		});
+		assert.equal((sent[0] as any).message.customType, "subagent-notify");
+		assert.equal((sent[0] as any).message.content, `Background task completed: **worker** (2/3)\n\n${summary}`);
+		assert.deepEqual((sent[0] as any).options, { triggerTurn: false });
 	});
 
 	it("preserves session paths in notification content", () => {
@@ -82,14 +86,10 @@ describe("registerSubagentNotify", () => {
 			sessionFile: "/tmp/session.jsonl",
 		});
 
-		assert.deepEqual(sent, [{
-			message: {
-				customType: "subagent-notify",
-				content: "Background task completed: **worker**\n\nDone\n\nSession file: /tmp/session.jsonl",
-				display: true,
-			},
-			options: { triggerTurn: true },
-		}]);
+		assert.equal(sent.length, 1);
+		assert.equal((sent[0] as any).message.customType, "subagent-notify");
+		assert.equal((sent[0] as any).message.content, "Background task completed: **worker**\n\nDone\n\nSession file: /tmp/session.jsonl");
+		assert.deepEqual((sent[0] as any).options, { triggerTurn: false });
 	});
 
 	it("labels paused completions as paused even without an exit code", () => {
@@ -105,13 +105,152 @@ describe("registerSubagentNotify", () => {
 		});
 
 		assert.equal(sent.length, 1);
-		assert.deepEqual(sent[0], {
-			message: {
-				customType: "subagent-notify",
-				content: "Background task paused: **worker**\n\nPaused after interrupt. Waiting for explicit next action.",
-				display: true,
-			},
-			options: { triggerTurn: true },
+		assert.equal((sent[0] as any).message.customType, "subagent-notify");
+		assert.equal((sent[0] as any).message.content, "Background task paused: **worker**\n\nPaused after interrupt. Waiting for explicit next action.");
+		assert.deepEqual((sent[0] as any).options, { triggerTurn: false });
+	});
+
+	it("suppresses failed per-step notifications because final completion covers them", () => {
+		const { events, sent } = createPi({ enabled: false });
+
+		events.emit(SUBAGENT_ASYNC_STEP_COMPLETE_EVENT, {
+			id: "async-run-1",
+			runId: "async-run-1",
+			agent: "reviewer",
+			index: 1,
+			totalTasks: 4,
+			success: false,
+			exitCode: 1,
+			summary: "Review failed with blockers.",
+			durationMs: 1200,
+			sessionFile: "/tmp/reviewer.jsonl",
 		});
+
+		assert.equal(sent.length, 0);
+	});
+
+	it("suppresses single-step notifications because final completion covers them", () => {
+		const { events, sent } = createPi({ enabled: false });
+
+		events.emit(SUBAGENT_ASYNC_STEP_COMPLETE_EVENT, {
+			id: "async-run-single",
+			runId: "async-run-single",
+			agent: "worker",
+			index: 0,
+			totalTasks: 1,
+			success: true,
+			exitCode: 0,
+			summary: "Single worker done.",
+		});
+
+		assert.equal(sent.length, 0);
+	});
+
+	it("uses non-triggering fallback when a fork handler launch fails", async () => {
+		const { events, sent } = createPi({ enabled: true, piCommand: "/definitely/missing/pi-subagents-handler" });
+
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
+			id: "notify-fork-fail-1",
+			agent: "worker",
+			success: true,
+			summary: "Done after failed fork",
+			exitCode: 0,
+			timestamp: 456,
+		});
+
+		await waitForSent(sent, 1);
+		assert.equal((sent[0] as any).message.customType, "subagent-notify");
+		assert.equal((sent[0] as any).message.content, "Background task completed: **worker**\n\nDone after failed fork");
+		assert.deepEqual((sent[0] as any).options, { triggerTurn: false });
+	});
+
+	it("forks background completions by default without triggering the main feed", async () => {
+		const mockPi = createMockPi();
+		mockPi.install();
+		mockPi.onCall({ echoEnv: [SUBAGENT_CHILD_ENV, "PI_SUBAGENT_BACKGROUND_HANDLER"] });
+		try {
+			const parentSessionFile = "/tmp/parent-session.jsonl";
+			const { events, sent } = createPi({ enabled: true }, () => parentSessionFile);
+			events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
+				id: "notify-fork-1",
+				agent: "worker",
+				success: true,
+				summary: "Done",
+				exitCode: 0,
+				timestamp: 456,
+			});
+
+			await waitForSent(sent, 2);
+			assert.equal(sent.some((entry) => (entry as any).options?.triggerTurn === true), false);
+			assert.equal((sent[0] as any).message.customType, "subagent-fork-handler");
+			assert.equal((sent[0] as any).message.details.status, "running");
+			assert.equal((sent[1] as any).message.details.status, "complete");
+			assert.match((sent[1] as any).message.content, /"PI_SUBAGENT_CHILD":"1"/);
+			assert.match((sent[1] as any).message.content, /"PI_SUBAGENT_BACKGROUND_HANDLER":"1"/);
+			const callFile = fs.readdirSync(mockPi.dir).find((name) => name.startsWith("call-"));
+			assert.ok(callFile, "mock pi was not called");
+			const call = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf8"));
+			const forkIndex = call.args.indexOf("--fork");
+			assert.notEqual(forkIndex, -1);
+			assert.equal(call.args[forkIndex + 1], parentSessionFile);
+		} finally {
+			mockPi.uninstall();
+		}
+	});
+
+	it("suppresses successful per-step completions because final completion covers them", () => {
+		const { events, sent } = createPi({ enabled: true });
+		events.emit(SUBAGENT_ASYNC_STEP_COMPLETE_EVENT, {
+			id: "async-run-2",
+			runId: "async-run-2",
+			agent: "reviewer",
+			index: 0,
+			totalTasks: 2,
+			success: true,
+			exitCode: 0,
+			summary: "Reviewed.",
+			durationMs: 1200,
+		});
+
+		assert.equal(sent.length, 0);
+	});
+
+	it("suppresses failed per-step completions because final completion covers them", () => {
+		const { events, sent } = createPi({ enabled: true });
+		events.emit(SUBAGENT_ASYNC_STEP_COMPLETE_EVENT, {
+			id: "async-run-2-failed",
+			runId: "async-run-2-failed",
+			agent: "reviewer",
+			index: 0,
+			totalTasks: 2,
+			success: false,
+			exitCode: 1,
+			summary: "Review failed.",
+			durationMs: 1200,
+		});
+
+		assert.equal(sent.length, 0);
+	});
+
+	it("falls back without throwing when fork setup serialization fails", async () => {
+		const sent: Array<{ message: unknown; options: unknown }> = [];
+		const pi = {
+			sendMessage(message: unknown, options: unknown) {
+				sent.push({ message, options });
+			},
+		};
+		const circular: Record<string, unknown> = {};
+		circular.self = circular;
+
+		await deliverBackgroundForkEvent(pi as never, { enabled: true }, {
+			type: "async-complete",
+			title: "Background task completed: worker",
+			content: "Background task completed: **worker**\n\nDone",
+			details: circular,
+		});
+
+		assert.equal(sent.length, 1);
+		assert.equal((sent[0] as any).message.customType, "subagent-notify");
+		assert.deepEqual((sent[0] as any).options, { triggerTurn: false });
 	});
 });

--- a/test/unit/tool-description.test.ts
+++ b/test/unit/tool-description.test.ts
@@ -7,7 +7,7 @@ import { describe, it } from "node:test";
 function readRegisteredSubagentDescription(): string {
 	const testDir = path.dirname(fileURLToPath(import.meta.url));
 	const indexSource = fs.readFileSync(path.resolve(testDir, "..", "..", "src/extension/index.ts"), "utf-8");
-	const match = indexSource.match(/name:\s*"subagent",[\s\S]*?description:\s*`([\s\S]*?)`,\r?\n\s*parameters: SubagentParams,/);
+	const match = indexSource.match(/name:\s*"subagent",[\s\S]*?description:\s*`([\s\S]*?)`,\r?\n[\s\S]*?parameters: SubagentParams,/);
 	assert.ok(match, "expected to find the registered subagent tool description");
 	return match[1]!;
 }


### PR DESCRIPTION
This consolidates the dataforxyz fork's async-control notification work into one squashed branch on top of current upstream main.\n\nHighlights:\n- deliver async needs-attention notices through detached fork handlers\n- add optional pi-forks runtime integration with a local fallback\n- coalesce/suppress noisy step completion notifications\n- add async log scan helper and related tests\n\nValidation performed locally on the clean branch: npm test began running unit tests; the run reached existing unit coverage but the temporary worktree lacked peer package installs, so full validation should run in CI.