### PR TITLE
fix: respect PI_CODING_AGENT_DIR instead of hardcoding ~/.pi/agent/

### DIFF
--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -7,6 +7,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { OutputMode } from "../shared/types.ts";
+import { getAgentDir } from "../shared/utils.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain } from "./chain-serializer.ts";
 import { mergeAgentsForScope } from "./agent-selection.ts";
@@ -131,7 +132,7 @@ interface AgentDiscoveryResult {
 }
 
 function getUserChainDir(): string {
-	return path.join(os.homedir(), ".pi", "agent", "chains");
+	return path.join(getAgentDir(), "chains");
 }
 
 function splitToolList(rawTools: string[] | undefined): { tools?: string[]; mcpDirectTools?: string[] } {
@@ -217,7 +218,7 @@ function findNearestProjectRoot(cwd: string): string | null {
 }
 
 function getUserAgentSettingsPath(): string {
-	return path.join(os.homedir(), ".pi", "agent", "settings.json");
+	return path.join(getAgentDir(), "settings.json");
 }
 
 function getProjectAgentSettingsPath(cwd: string): string | null {
@@ -723,7 +724,7 @@ function resolveNearestProjectChainDirs(cwd: string): { readDirs: string[]; pref
 const BUILTIN_AGENTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "agents");
 
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
-	const userDirOld = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDirOld = path.join(getAgentDir(), "agents");
 	const userDirNew = path.join(os.homedir(), ".agents");
 	const { readDirs: projectAgentDirs, preferredDir: projectAgentsDir } = resolveNearestProjectAgentDirs(cwd);
 	const userSettingsPath = getUserAgentSettingsPath();
@@ -762,7 +763,7 @@ export function discoverAgentsAll(cwd: string): {
 	userSettingsPath: string;
 	projectSettingsPath: string | null;
 } {
-	const userDirOld = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDirOld = path.join(getAgentDir(), "agents");
 	const userDirNew = path.join(os.homedir(), ".agents");
 	const userChainDir = getUserChainDir();
 	const { readDirs: projectDirs, preferredDir: projectDir } = resolveNearestProjectAgentDirs(cwd);

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -6,6 +6,7 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getAgentDir } from "../shared/utils.ts";
 
 export type SkillSource =
 	| "project"
@@ -50,7 +51,7 @@ let loadSkillsCache: { cwd: string; skills: CachedSkillEntry[]; timestamp: numbe
 const LOAD_SKILLS_CACHE_TTL_MS = 5000;
 
 const CONFIG_DIR = ".pi";
-const AGENT_DIR = path.join(os.homedir(), ".pi", "agent");
+const AGENT_DIR = getAgentDir();
 const SUBAGENT_ORCHESTRATION_SKILL = "pi-subagents";
 
 const SOURCE_PRIORITY: Record<SkillSource, number> = {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -21,6 +21,7 @@ import { Box, Container, Spacer, Text, truncateToWidth, visibleWidth, wrapTextWi
 import { discoverAgents } from "../agents/agents.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
+import { getAgentDir } from "../shared/utils.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
 import { renderWidget, renderSubagentResult, stopResultAnimations, stopWidgetAnimation, syncResultAnimation } from "../tui/render.ts";
 import { SubagentParams } from "./schemas.ts";
@@ -73,7 +74,7 @@ function getSubagentSessionRoot(parentSessionFile: string | null): string {
 }
 
 function loadConfig(): ExtensionConfig {
-	const configPath = path.join(os.homedir(), ".pi", "agent", "extensions", "subagent", "config.json");
+	const configPath = path.join(getAgentDir(), "extensions", "subagent", "config.json");
 	try {
 		if (fs.existsSync(configPath)) {
 			return JSON.parse(fs.readFileSync(configPath, "utf-8")) as ExtensionConfig;

--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -4,12 +4,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentConfig } from "../agents/agents.ts";
 import type { ExtensionConfig, IntercomBridgeConfig, IntercomBridgeMode } from "../shared/types.ts";
+import { getAgentDir } from "../shared/utils.ts";
 
 const PI_INTERCOM_PACKAGE_NAME = "pi-intercom";
 const CONFIG_DIR = ".pi";
 
 function defaultAgentDir(): string {
-	return path.join(os.homedir(), ".pi", "agent");
+	return getAgentDir();
 }
 
 function defaultIntercomExtensionDir(agentDir = defaultAgentDir()): string {

--- a/src/runs/shared/run-history.ts
+++ b/src/runs/shared/run-history.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getAgentDir } from "../../shared/utils.ts";
 
 export interface RunEntry {
 	agent: string;
@@ -11,7 +12,7 @@ export interface RunEntry {
 	exit?: number;
 }
 
-const HISTORY_PATH = path.join(os.homedir(), ".pi", "agent", "run-history.jsonl");
+const HISTORY_PATH = path.join(getAgentDir(), "run-history.jsonl");
 const ROTATE_READ_THRESHOLD = 1200;
 const ROTATE_KEEP = 1000;
 

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { TEMP_ARTIFACTS_DIR, type ArtifactPaths } from "./types.ts";
+import { getAgentDir } from "./utils.ts";
 const CLEANUP_MARKER_FILE = ".last-cleanup";
 
 export function getArtifactsDir(sessionFile: string | null): string {
@@ -74,7 +75,7 @@ export function cleanupOldArtifacts(dir: string, maxAgeDays: number): void {
 export function cleanupAllArtifactDirs(maxAgeDays: number): void {
 	cleanupOldArtifacts(TEMP_ARTIFACTS_DIR, maxAgeDays);
 
-	const sessionsBase = path.join(os.homedir(), ".pi", "agent", "sessions");
+	const sessionsBase = path.join(getAgentDir(), "sessions");
 	if (!fs.existsSync(sessionsBase)) return;
 
 	let dirs: string[];

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -10,6 +10,17 @@ import { formatToolCall } from "./formatters.ts";
 import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, SingleResult, ToolCallSummary } from "./types.ts";
 
 // ============================================================================
+// Agent Directory Resolution
+// ============================================================================
+
+/** Resolve the pi agent config directory, respecting PI_CODING_AGENT_DIR. */
+export function getAgentDir(): string {
+	const envDir = process.env.PI_CODING_AGENT_DIR;
+	if (envDir) return envDir;
+	return path.join(os.homedir(), ".pi", "agent");
+}
+
+// ============================================================================
 // File System Utilities
 // ============================================================================
 


### PR DESCRIPTION
Pi core respects the `PI_CODING_AGENT_DIR` environment variable to override the default config directory (`~/.pi/agent`). pi-subagents hardcoded `~/.pi/agent/` in **9 locations across 6 files**, ignoring it entirely.

### Problem

When `PI_CODING_AGENT_DIR` is set (e.g. to `~/.config/pi/agent` for XDG compliance), pi-subagents still writes `run-history.jsonl`, reads `config.json`, discovers agents/skills/chains, and cleans up artifacts from the default `~/.pi/agent/` path — creating a split-brain between Pi core config and subagent data.

### Fix

Add a shared `getAgentDir()` helper in `src/shared/utils.ts` that checks `PI_CODING_AGENT_DIR` first and falls back to `~/.pi/agent`. Replace all 9 hardcoded `os.homedir()/.pi/agent` paths.

### Affected locations

| File | Change |
|---|---|
| `src/runs/shared/run-history.ts` | `HISTORY_PATH` → `getAgentDir()` |
| `src/intercom/intercom-bridge.ts` | `defaultAgentDir()` → `getAgentDir()` |
| `src/agents/skills.ts` | `AGENT_DIR` const → `getAgentDir()` |
| `src/agents/agents.ts` | chains/settings/agents dirs (×4) |
| `src/shared/artifacts.ts` | `sessionsBase` → `getAgentDir()` |
| `src/extension/index.ts` | `configPath` → `getAgentDir()` |

Plannotator's `config.ts` already implements the same pattern — this aligns pi-subagents with the rest of the ecosystem.