### PR TITLE
completion-guard: skip mutation expectation when agent declares only read-only tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules/
 .fallow/
 
 package-lock.json
+
+# pi-lens local cache (committed by mistake earlier; ignored going forward)
+.pi-lens/

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -641,6 +641,8 @@ async function runSingleStep(
 				agent: step.agent,
 				task,
 				messages: run.messages,
+				tools: step.tools,
+				mcpDirectTools: step.mcpDirectTools,
 			})
 			: undefined;
 		const completionGuardTriggered = completionGuard?.triggered === true && !run.observedMutationAttempt;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -663,7 +663,13 @@ async function runSingleAttempt(
 
 	let fullOutput = getFinalOutput(result.messages);
 	const completionGuard = result.exitCode === 0 && !result.error
-		? evaluateCompletionMutationGuard({ agent: agent.name, task, messages: result.messages })
+		? evaluateCompletionMutationGuard({
+			agent: agent.name,
+			task,
+			messages: result.messages,
+			tools: agent.tools,
+			mcpDirectTools: agent.mcpDirectTools,
+		})
 		: undefined;
 	if (completionGuard?.triggered && !observedMutationAttempt) {
 		result.exitCode = 1;

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -1,5 +1,5 @@
 import type { Message } from "@earendil-works/pi-ai";
-import { isMutatingBashCommand } from "./long-running-guard.ts";
+import { isMutatingBashCommand, isReadOnlyToolName } from "./long-running-guard.ts";
 
 const REVIEW_ONLY_PATTERNS = [
 	/\breview only\b/i,
@@ -59,6 +59,24 @@ interface CompletionMutationGuardInput {
 	agent: string;
 	task: string;
 	messages: Message[];
+	/**
+	 * Frontmatter-declared tools (non-MCP). When all declared tools are
+	 * read-only the guard skips its mutation-expectation regex chain.
+	 * `undefined` means the agent omitted the field and inherits the default
+	 * tool surface — treated as possibly mutating.
+	 *
+	 * Edge case: a `tools: false` override of a builtin collapses to
+	 * `undefined` in agents.ts; that path is rare and falls through to the
+	 * prose-regex logic, which is the safe direction.
+	 */
+	tools?: string[];
+	/**
+	 * Frontmatter-declared MCP tools (`mcp:`-prefixed entries in `tools:`).
+	 * Treated as possibly mutating: we don't model individual MCP tool
+	 * capabilities, so any declared MCP tool disqualifies the read-only
+	 * short-circuit.
+	 */
+	mcpDirectTools?: string[];
 }
 
 interface CompletionMutationGuardResult {
@@ -83,7 +101,33 @@ function stripScopedNoEditConstraints(task: string): string {
 	return stripped;
 }
 
-export function expectsImplementationMutation(agent: string, task: string): boolean {
+/**
+ * An agent that declares only read-only tools cannot mutate the workspace,
+ * so no amount of "please implement this" prose in the task should make the
+ * guard expect mutation. This is the floor: declared capability is checked
+ * before any task-text inference.
+ *
+ * Future refactor (deferred): restructure the whole function as
+ * `canMutate(agent, tools) && askedToMutate(agent, task)` so the orthogonal
+ * axes are visible at the top level instead of layered short-circuits.
+ */
+function declaresOnlyReadOnlyTools(
+	tools: string[] | undefined,
+	mcpDirectTools: string[] | undefined,
+): boolean {
+	if (tools === undefined) return false;
+	if (mcpDirectTools && mcpDirectTools.length > 0) return false;
+	if (tools.length === 0) return false;
+	return tools.every(isReadOnlyToolName);
+}
+
+export function expectsImplementationMutation(
+	agent: string,
+	task: string,
+	tools?: string[],
+	mcpDirectTools?: string[],
+): boolean {
+	if (declaresOnlyReadOnlyTools(tools, mcpDirectTools)) return false;
 	const taskText = stripFrameworkInstructions(task);
 	const taskTextWithoutScopedConstraints = stripScopedNoEditConstraints(taskText);
 	if (REVIEW_ONLY_PATTERNS.some((pattern) => pattern.test(taskTextWithoutScopedConstraints))) return false;
@@ -115,7 +159,7 @@ export function hasMutationToolCall(messages: Message[]): boolean {
 }
 
 export function evaluateCompletionMutationGuard(input: CompletionMutationGuardInput): CompletionMutationGuardResult {
-	const expectedMutation = expectsImplementationMutation(input.agent, input.task);
+	const expectedMutation = expectsImplementationMutation(input.agent, input.task, input.tools, input.mcpDirectTools);
 	const attemptedMutation = hasMutationToolCall(input.messages);
 	return {
 		expectedMutation,

--- a/src/runs/shared/long-running-guard.ts
+++ b/src/runs/shared/long-running-guard.ts
@@ -38,7 +38,40 @@ const MUTATING_BASH_PATTERNS = [
 	/\b(writeFile|writeFileSync|appendFile|appendFileSync)\b/,
 	/\bwrite_text\s*\(/,
 	/\bopen\s*\([^)]*,\s*["'][wa]/,
+	// Python heredoc pattern `with open(p) as f: f.write(...)` lacks an explicit
+	// mode arg so the open() rule above doesn't match. The `.write(` call on a
+	// file-handle named `f` is the unambiguous mutation evidence.
+	/\bf\.write\s*\(/,
 ];
+
+// Tools that cannot mutate the workspace. Used by completion-guard to
+// short-circuit the mutation-expectation regex chain for agents whose
+// frontmatter declares only these tools. Unknown tool names (extensions,
+// MCP, custom) are conservatively treated as possibly mutating; add an entry
+// here only when the tool is provably read-only.
+//
+// Do NOT add capability-escalating tools (e.g. `subagent`, `delegate`,
+// `bash` with arbitrary command) here even when their direct effect is
+// non-mutating. An agent with `tools: read, grep, subagent` can spawn a
+// worker that writes to disk one hop away; classifying it as read-only
+// would hide a real category of false-negatives. The set should only contain
+// tools whose declared semantics make filesystem mutation impossible at any
+// transitive depth.
+export const READ_ONLY_TOOL_NAMES = new Set<string>([
+	"read",
+	"grep",
+	"find",
+	"ls",
+	"web_search",
+	"fetch_content",
+	"get_search_content",
+	"intercom",
+	"contact_supervisor",
+]);
+
+export function isReadOnlyToolName(name: string): boolean {
+	return READ_ONLY_TOOL_NAMES.has(name);
+}
 
 const MUTATING_FAILURE_HINTS = [
 	"failed",

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -105,3 +105,155 @@ test("implementation task with mutation attempts does not trigger", () => {
 
 	assert.equal(result.triggered, false);
 });
+
+// Frontmatter-declared tools are checked BEFORE prose inference. An agent
+// that declares only read-only tools cannot mutate the workspace, so the
+// guard must not expect mutation regardless of how implementation-y the
+// task text is.
+const READ_ONLY = ["read", "grep", "find", "ls"];
+const WORKER_TOOLS = ["read", "grep", "find", "ls", "bash", "edit", "write"];
+
+test("architect with read-only tools never expects mutation", () => {
+	// Real architect frontmatter: tools: read, grep, find, ls.
+	assert.equal(
+		expectsImplementationMutation(
+			"architect",
+			"Produce v4 proposal that implements the approved fix",
+			READ_ONLY,
+		),
+		false,
+	);
+	assert.equal(
+		expectsImplementationMutation(
+			"architect",
+			"Add the 6 new constraints to §5 and refactor the proposal",
+			READ_ONLY,
+		),
+		false,
+	);
+});
+
+test("reviewer with read-only tools is not flagged by 'must fix' prose", () => {
+	// Real reviewer-codex-xhigh frontmatter: tools: read, grep, find, ls.
+	// Even with the reviewer name and 'must fix' wording, declared capability
+	// wins: this agent cannot mutate.
+	assert.equal(
+		expectsImplementationMutation(
+			"reviewer-codex-xhigh",
+			"Find correctness bugs the reviewers must fix before signoff",
+			READ_ONLY,
+		),
+		false,
+	);
+});
+
+test("agent that omits the tools field falls through to prose inference", () => {
+	// undefined tools = inherits the default surface = could mutate.
+	assert.equal(
+		expectsImplementationMutation("worker", "Implement the approved fix", undefined),
+		true,
+	);
+});
+
+test("agent declaring an unknown tool is treated as possibly mutating", () => {
+	// Unknown tools (extensions, custom) are conservatively NOT short-circuited.
+	assert.equal(
+		expectsImplementationMutation(
+			"worker",
+			"Implement the approved fix",
+			["read", "grep", "custom_tool_we_dont_know"],
+		),
+		true,
+	);
+});
+
+test("agent declaring MCP tools is treated as possibly mutating", () => {
+	// We don't model individual MCP tool capabilities, so any declared MCP
+	// tool disqualifies the read-only short-circuit.
+	assert.equal(
+		expectsImplementationMutation(
+			"worker",
+			"Implement the approved fix",
+			READ_ONLY,
+			["apply_patch"],
+		),
+		true,
+	);
+});
+
+test("worker with edit/write/bash declared still falls through to prose path", () => {
+	// Shape A does NOT short-circuit workers — they have mutation tools.
+	assert.equal(
+		expectsImplementationMutation("worker", "Implement the approved fix", WORKER_TOOLS),
+		true,
+	);
+});
+
+test("python heredoc f.write(...) counts as a mutation attempt", () => {
+	// Worker false-positive case from handoff §8(c): edits go through bash
+	// via `python3 <<'EOF'` heredoc with `with open(p) as f: f.write(...)`,
+	// which the existing open(p, 'w') pattern misses.
+	assert.equal(
+		hasMutationToolCall([
+			assistantToolCall("bash", {
+				command: "python3 <<'EOF'\nwith open('a.ts') as f:\n    f.write('hello')\nEOF",
+			}),
+		]),
+		true,
+	);
+	// Negative: the substring "selfwrite(" must NOT match \bf\.write\(.
+	assert.equal(
+		hasMutationToolCall([
+			assistantToolCall("bash", { command: "echo 'selfwrite(thing)'" }),
+		]),
+		false,
+	);
+});
+
+test("worker with read-only tools never triggers the guard", () => {
+	// §8(a): architect-shaped run where the agent produced a design doc and no
+	// edits. Even though the task says "implement," declared capability wins.
+	const result = evaluateCompletionMutationGuard({
+		agent: "architect",
+		task: "Produce v4 proposal that implements the approved fix",
+		messages: [assistantText("# Proposal v4\n\n## Choice...\n\nLong design doc here.")],
+		tools: READ_ONLY,
+	});
+	assert.deepEqual(result, {
+		expectedMutation: false,
+		attemptedMutation: false,
+		triggered: false,
+	});
+});
+
+test("worker using python heredoc f.write does not trigger the guard", () => {
+	// §8(c): worker reports changed files via heredoc python writes.
+	const result = evaluateCompletionMutationGuard({
+		agent: "worker",
+		task: "Implement the approved fix",
+		tools: WORKER_TOOLS,
+		messages: [
+			assistantToolCall("bash", {
+				command: "python3 <<'EOF'\nwith open('a.ts') as f:\n    f.write('hello')\nEOF",
+			}),
+			assistantText("Changed files: a.ts. verify-baseline.sh passed."),
+		],
+	});
+	assert.deepEqual(result, {
+		expectedMutation: true,
+		attemptedMutation: true,
+		triggered: false,
+	});
+});
+
+test("worker with mutation tools that produces no edits still triggers", () => {
+	// §8(d): worker with edit/write/bash declared, no mutation attempted,
+	// task is clearly implementation — guard must still fire.
+	const result = evaluateCompletionMutationGuard({
+		agent: "worker",
+		task: "Implement the approved fix",
+		tools: WORKER_TOOLS,
+		messages: [assistantText("Here's my plan: ...")],
+	});
+	assert.equal(result.triggered, true);
+});


### PR DESCRIPTION
Three failure shapes share one root cause: the guard reads task prose to
infer 'is this an implementation task?' when the agent's frontmatter
`tools:` already declares whether it CAN implement. Architect (16 runs,
$21.66) and reviewer-codex-xhigh (3 runs, $14.48) both declare
`tools: read, grep, find, ls` — yet the prose-regex chain fires anyway
because their tasks contain implementation verbs.

Floor: if the agent declares only read-only tools and no MCP tools,
mutation is impossible regardless of prose. Skip the regex chain.

Concrete changes:

- long-running-guard.ts: export READ_ONLY_TOOL_NAMES (read, grep, find,
  ls, web_search, fetch_content, get_search_content, intercom,
  contact_supervisor) and isReadOnlyToolName(). Unknown tool names are
  conservatively NOT in the set — the safe direction.
- long-running-guard.ts: extend MUTATING_BASH_PATTERNS with
  `/\bf\.write\s*\(/` to catch the python heredoc shape
  `with open(p) as f: f.write(...)` (worker false-positive case from
  the handoff §8(c)).
- completion-guard.ts: add `tools?` and `mcpDirectTools?` to
  CompletionMutationGuardInput. Add declaresOnlyReadOnlyTools() helper
  and an early return at the top of expectsImplementationMutation().
- foreground/execution.ts: pass `agent.tools` and
  `agent.mcpDirectTools` into the guard call.
- background/subagent-runner.ts: same plumbing from `step.tools` /
  `step.mcpDirectTools`.

Tests (test/unit/completion-guard.test.ts):
- Architect with read-only tools never expects mutation, even for
  implementation-y task text (§8(a)).
- Reviewer with read-only tools is not flagged by 'must fix' prose
  (§8(b)).
- Worker with the new f.write pattern + 'Changed files:' output does
  not trigger (§8(c)).
- Worker with mutation tools but no edits and no f.write still
  triggers (§8(d)).
- Backward compat: omitting tools falls through to the existing prose
  path; unknown tool names are treated as possibly mutating; MCP tools
  disqualify the short-circuit; negative case for \bf\.write\( does
  not match `selfwrite(`.

Deferred (named, separate slices):

- The 'soft failure preserves artefact' corollary (single-output.ts,
  subagent-executor.ts:1946-1950 gate on exitCode === 0). Only matters
  for TRUE guard trips; this change removes the false-positive class
  first.
- Restructure expectsImplementationMutation as
  `canMutate(tools) && askedToMutate(agent, task)` — the revelation
  refactor. Code comment marks the spot.
- tools: false override collapses to undefined upstream in agents.ts.
  Edge case; documented in the new field doc comment.
