### PR TITLE
Allow bounded nested subagent delegation

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -33,7 +33,7 @@ import { registerSlashSubagentBridge } from "../slash/slash-bridge.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
 import registerSubagentNotify, { type SubagentNotifyDetails } from "../runs/background/notify.ts";
-import { SUBAGENT_CHILD_ENV } from "../runs/shared/pi-args.ts";
+import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_ENV } from "../runs/shared/pi-args.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import { loadConfig } from "./config.ts";
 import {
@@ -207,7 +207,11 @@ class SubagentControlNoticeComponent implements Component {
 }
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
-	if (process.env[SUBAGENT_CHILD_ENV] === "1") return;
+	if (process.env[SUBAGENT_CHILD_ENV] === "1") {
+		const depth = Number(process.env.PI_SUBAGENT_DEPTH ?? "0");
+		const maxDepth = Number(process.env.PI_SUBAGENT_MAX_DEPTH ?? "0");
+		if (Number.isFinite(depth) && Number.isFinite(maxDepth) && depth >= maxDepth) return;
+	}
 	const globalStore = globalThis as Record<string, unknown>;
 	const runtimeCleanupStoreKey = "__piSubagentRuntimeCleanup";
 	const previousRuntimeCleanup = globalStore[runtimeCleanupStoreKey];
@@ -322,7 +326,37 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		return new SubagentControlNoticeComponent({ ...details, noticeText: formatSubagentControlNotice(details, content) }, theme);
 	});
 
+	const nestedChildExecutionBudget = process.env[SUBAGENT_CHILD_ENV] === "1"
+		? Number(process.env.PI_SUBAGENT_NESTED_EXECUTION_BUDGET ?? process.env.PI_SUBAGENT_NESTED_CALL_BUDGET ?? "1")
+		: Number.POSITIVE_INFINITY;
+	let nestedChildExecutionCalls = 0;
+	let nestedChildManagementCalls = 0;
+	const terminateNestedSubagentViolation = (message: string): never => {
+		console.error(message);
+		process.exit(2);
+	};
 	const executeSubagentCollapsed = (id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((result: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => {
+		if (process.env[SUBAGENT_CHILD_ENV] === "1") {
+			const childAgent = process.env[SUBAGENT_CHILD_AGENT_ENV] || "unknown";
+			const budget = Number.isInteger(nestedChildExecutionBudget) && nestedChildExecutionBudget >= 0 ? nestedChildExecutionBudget : 1;
+			const isExecutionCall = !params.action;
+			if (isExecutionCall) {
+				if (nestedChildExecutionCalls >= budget) {
+					terminateNestedSubagentViolation(`Nested subagent execution blocked for child '${childAgent}': execution budget ${budget} already used. The child process is terminating to prevent repeated fanout.`);
+				}
+				nestedChildExecutionCalls += 1;
+			} else {
+				if (nestedChildExecutionCalls > 0 || nestedChildManagementCalls >= 1) {
+					terminateNestedSubagentViolation(`Nested subagent management call blocked for child '${childAgent}' after a prior subagent call. The child process is terminating to prevent repeated fanout.`);
+				}
+				nestedChildManagementCalls += 1;
+				return Promise.resolve({
+					content: [{ type: "text", text: `Nested subagent management actions are disabled for child '${childAgent}'. If you have enough information, answer now; otherwise make exactly one parallel execution call.` }],
+					isError: true,
+					details: { mode: "management", results: [] },
+				});
+			}
+		}
 		if (ctx.hasUI) ctx.ui.setToolsExpanded(false);
 		return executor.execute(id, params, signal, onUpdate, ctx);
 	};
@@ -385,8 +419,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		label: "Subagent",
 		description: `Delegate to subagents or manage agent definitions.
 
+CHILD SESSION RULE: If you are a child subagent, do not use management actions such as action=list/get/status. Make at most one execution call, then answer from that result.
+
 EXECUTION (use exactly ONE mode):
-• Before executing, use { action: "list" } to inspect configured agents/chains. Only execute agents listed as executable/non-disabled.
+• Optional discovery: { action: "list" } inspects configured agents/chains. Do not call it unless discovery is actually needed; execution can run directly with known agent names.
 • SINGLE: { agent, task? } - one task; omit task for self-contained agents
 • CHAIN: { chain: [{agent:"agent-a"}, {parallel:[{agent:"agent-b",count:3}]}] } - sequential pipeline with optional parallel fan-out
 • PARALLEL: { tasks: [{agent,task,count?,output?,reads?,progress?}, ...], concurrency?: number, worktree?: true } - concurrent execution (worktree: isolate each task in a git worktree)

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -2,13 +2,15 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
 const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
+const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
 export const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
 
 export const CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS = [
 	"You are a child subagent, not the parent orchestrator.",
-	"The parent session owns delegation, orchestration, review fanout, and follow-up worker launches.",
+	"The parent session usually owns delegation, orchestration, review fanout, and follow-up worker launches.",
 	"Ignore prior parent-only orchestration instructions in inherited conversation history.",
-	"Do not propose or run subagents. Complete only your assigned role-specific task with the tools available to you.",
+	"Do not propose or run subagents unless your assigned agent prompt explicitly defines you as an orchestrator/conductor/reviewer and the subagent tool is available.",
+	"If your assigned role explicitly requires orchestration, use subagents only within the available maxSubagentDepth and only for the assigned task.",
 	"If you need to edit files, call the actual edit/write tools. Do not print tool-call syntax, patches, or pseudo-tool calls as text.",
 ].join("\n");
 
@@ -96,7 +98,8 @@ function isSubagentToolCallBlock(block: unknown): boolean {
 	return b?.type === "toolCall" && b.name === "subagent";
 }
 
-function stripAssistantSubagentToolCallBlocks(message: unknown): unknown | undefined {
+function stripAssistantSubagentToolCallBlocks(message: unknown, options: { preserveSubagentToolMessages: boolean }): unknown | undefined {
+	if (options.preserveSubagentToolMessages) return message;
 	const m = message as { role?: string; content?: unknown };
 	if (m?.role !== "assistant" || !Array.isArray(m.content)) return message;
 	const filteredContent = m.content.filter((block) => !isSubagentToolCallBlock(block));
@@ -105,15 +108,23 @@ function stripAssistantSubagentToolCallBlocks(message: unknown): unknown | undef
 	return { ...m, content: filteredContent };
 }
 
-export function stripParentOnlySubagentMessages(messages: unknown[]): unknown[] {
+function nestedSubagentAvailableInThisChild(): boolean {
+	if (process.env[SUBAGENT_CHILD_ENV] !== "1") return false;
+	const depth = Number(process.env.PI_SUBAGENT_DEPTH ?? "0");
+	const maxDepth = Number(process.env.PI_SUBAGENT_MAX_DEPTH ?? "0");
+	return Number.isFinite(depth) && Number.isFinite(maxDepth) && depth < maxDepth;
+}
+
+export function stripParentOnlySubagentMessages(messages: unknown[], options: { preserveSubagentToolMessages?: boolean } = {}): unknown[] {
+	const preserveSubagentToolMessages = options.preserveSubagentToolMessages === true;
 	let changed = false;
 	const filtered: unknown[] = [];
 	for (const message of messages) {
-		if (isParentOnlySubagentMessage(message) || isSubagentToolResultMessage(message)) {
+		if (isParentOnlySubagentMessage(message) || (!preserveSubagentToolMessages && isSubagentToolResultMessage(message))) {
 			changed = true;
 			continue;
 		}
-		const stripped = stripAssistantSubagentToolCallBlocks(message);
+		const stripped = stripAssistantSubagentToolCallBlocks(message, { preserveSubagentToolMessages });
 		if (stripped === undefined) {
 			changed = true;
 			continue;
@@ -126,7 +137,9 @@ export function stripParentOnlySubagentMessages(messages: unknown[]): unknown[] 
 
 export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 	pi.on("context", (event) => {
-		const messages = stripParentOnlySubagentMessages(event.messages);
+		const messages = stripParentOnlySubagentMessages(event.messages, {
+			preserveSubagentToolMessages: nestedSubagentAvailableInThisChild(),
+		});
 		if (messages === event.messages) return undefined;
 		return { messages };
 	});

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -3,13 +3,25 @@ import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
-import { SUBAGENT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
+import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 function parentToolEnv(): NodeJS.ProcessEnv {
 	const env = { ...process.env };
 	delete env[SUBAGENT_CHILD_ENV];
+	delete env[SUBAGENT_CHILD_AGENT_ENV];
+	delete env.PI_SUBAGENT_DEPTH;
+	delete env.PI_SUBAGENT_MAX_DEPTH;
+	return env;
+}
+
+function childToolEnv(depth: string, maxDepth: string): NodeJS.ProcessEnv {
+	const env = parentToolEnv();
+	env[SUBAGENT_CHILD_ENV] = "1";
+	env[SUBAGENT_CHILD_AGENT_ENV] = "reviewer";
+	env.PI_SUBAGENT_DEPTH = depth;
+	env.PI_SUBAGENT_MAX_DEPTH = maxDepth;
 	return env;
 }
 
@@ -108,11 +120,9 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
-	it("returns before registering parent tools, slash commands, renderers, or event handlers", () => {
+	it("returns before registering tools when child depth is exhausted", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./src/extension/index.ts";
-			import { SUBAGENT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
-			process.env[SUBAGENT_CHILD_ENV] = "1";
 			const calls = [];
 			const fakePi = new Proxy({}, {
 				get(_target, prop) {
@@ -138,7 +148,55 @@ describe("subagent extension child mode", () => {
 				"--eval",
 				script,
 			],
-			{ cwd: projectRoot, stdio: "pipe" },
+			{ cwd: projectRoot, env: childToolEnv("2", "2"), stdio: "pipe" },
+		);
+	});
+
+	it("registers a constrained subagent tool for child sessions below max depth", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./src/extension/index.ts";
+			const events = { on() { return () => {}; }, emit() {} };
+			let registeredTool;
+			const fakePi = new Proxy({
+				events,
+				registerTool(tool) { registeredTool = tool; },
+				registerCommand() {},
+				registerShortcut() {},
+				registerMessageRenderer() {},
+				sendMessage() {},
+				getSessionName() { return undefined; },
+			}, {
+				get(target, prop) {
+					if (prop in target) return target[prop];
+					return () => undefined;
+				},
+			});
+			registerSubagentExtension(fakePi);
+			if (!registeredTool) throw new Error("expected child subagent tool registration");
+			if (!registeredTool.description.includes("CHILD SESSION RULE")) throw new Error("missing child session rule");
+			const result = await registeredTool.execute(
+				"child-management-check",
+				{ action: "list" },
+				new AbortController().signal,
+				undefined,
+				{ cwd: process.cwd(), hasUI: false, sessionManager: { getSessionId() { return "session-test"; }, getSessionFile() { return null; } }, modelRegistry: { getAvailable() { return []; } } },
+			);
+			if (result?.isError !== true) throw new Error("expected child management call to be rejected");
+			const text = result.content?.[0]?.text ?? "";
+			if (!text.includes("Nested subagent management actions are disabled")) throw new Error("unexpected result: " + text);
+		`;
+
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-transform-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, env: childToolEnv("1", "2"), stdio: "pipe" },
 		);
 	});
 });

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -14,6 +14,9 @@ const envSnapshot = {
 	PI_SUBAGENT_INHERIT_PROJECT_CONTEXT: process.env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT,
 	PI_SUBAGENT_INHERIT_SKILLS: process.env.PI_SUBAGENT_INHERIT_SKILLS,
 	PI_SUBAGENT_INTERCOM_SESSION_NAME: process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME,
+	PI_SUBAGENT_CHILD: process.env.PI_SUBAGENT_CHILD,
+	PI_SUBAGENT_DEPTH: process.env.PI_SUBAGENT_DEPTH,
+	PI_SUBAGENT_MAX_DEPTH: process.env.PI_SUBAGENT_MAX_DEPTH,
 };
 
 const SKILLS_SECTION = "\n\nThe following skills provide specialized instructions for specific tasks.\nUse the read tool to load a skill's file when the task matches its description.\nWhen a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.\n\n<available_skills>\n  <skill>\n    <name>safe-bash</name>\n    <description>desc</description>\n    <location>/tmp/SKILL.md</location>\n  </skill>\n  <skill>\n    <name>pi-subagents</name>\n    <description>delegate to subagents</description>\n    <location>/tmp/pi-subagents/SKILL.md</location>\n  </skill>\n</available_skills>";
@@ -40,6 +43,12 @@ afterEach(() => {
 	else process.env.PI_SUBAGENT_INHERIT_SKILLS = envSnapshot.PI_SUBAGENT_INHERIT_SKILLS;
 	if (envSnapshot.PI_SUBAGENT_INTERCOM_SESSION_NAME === undefined) delete process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME;
 	else process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME = envSnapshot.PI_SUBAGENT_INTERCOM_SESSION_NAME;
+	if (envSnapshot.PI_SUBAGENT_CHILD === undefined) delete process.env.PI_SUBAGENT_CHILD;
+	else process.env.PI_SUBAGENT_CHILD = envSnapshot.PI_SUBAGENT_CHILD;
+	if (envSnapshot.PI_SUBAGENT_DEPTH === undefined) delete process.env.PI_SUBAGENT_DEPTH;
+	else process.env.PI_SUBAGENT_DEPTH = envSnapshot.PI_SUBAGENT_DEPTH;
+	if (envSnapshot.PI_SUBAGENT_MAX_DEPTH === undefined) delete process.env.PI_SUBAGENT_MAX_DEPTH;
+	else process.env.PI_SUBAGENT_MAX_DEPTH = envSnapshot.PI_SUBAGENT_MAX_DEPTH;
 });
 
 describe("subagent prompt runtime", () => {
@@ -67,14 +76,15 @@ describe("subagent prompt runtime", () => {
 		assert.ok(rewritten.includes("Current working directory: /repo"));
 	});
 
-	it("injects a child-only boundary that forbids proposing or running subagents", () => {
+	it("injects a child-only boundary that defaults against running subagents", () => {
 		const rewritten = rewriteSubagentPrompt(BASE_PROMPT, {
 			inheritProjectContext: true,
 			inheritSkills: true,
 		});
 
 		assert.ok(rewritten.startsWith(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS));
-		assert.ok(rewritten.includes("Do not propose or run subagents."));
+		assert.ok(rewritten.includes("Do not propose or run subagents unless your assigned agent prompt explicitly defines you as an orchestrator/conductor/reviewer"));
+		assert.ok(rewritten.includes("use subagents only within the available maxSubagentDepth"));
 		assert.ok(rewritten.includes("If you need to edit files, call the actual edit/write tools."));
 		assert.ok(rewritten.includes("Do not print tool-call syntax, patches, or pseudo-tool calls as text."));
 		assert.equal(rewriteSubagentPrompt(rewritten, { inheritProjectContext: true, inheritSkills: true }).indexOf(CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS), 0);
@@ -152,6 +162,11 @@ describe("subagent prompt runtime", () => {
 				},
 			],
 		);
+
+		assert.deepEqual(
+			stripParentOnlySubagentMessages([user, subagentResult, readResult, mixedAssistant, pureSubagentCall], { preserveSubagentToolMessages: true }),
+			[user, subagentResult, readResult, mixedAssistant, pureSubagentCall],
+		);
 	});
 
 	it("sets the child intercom session name from env during agent startup", async () => {
@@ -210,6 +225,28 @@ describe("subagent prompt runtime", () => {
 
 		assert.deepEqual(contextHandler?.({ messages: [priorParentTurn, instruction, slashResult, subagentCall, subagentResult, otherCustom, currentTask] }), {
 			messages: [priorParentTurn, otherCustom, currentTask],
+		});
+	});
+
+	it("preserves subagent tool calls and results in child context when nested depth remains", () => {
+		process.env.PI_SUBAGENT_CHILD = "1";
+		process.env.PI_SUBAGENT_DEPTH = "1";
+		process.env.PI_SUBAGENT_MAX_DEPTH = "2";
+		let contextHandler: ((event: { messages: unknown[] }) => { messages: unknown[] } | undefined) | undefined;
+		registerSubagentPromptRuntime({
+			on(event: string, handler: (payload: { messages: unknown[] }) => { messages: unknown[] } | undefined) {
+				if (event === "context") contextHandler = handler;
+			},
+		} as { on(event: string, handler: (payload: { messages: unknown[] }) => { messages: unknown[] } | undefined): void });
+
+		const user = { role: "user", content: "Run nested reviewers." };
+		const instruction = { role: "custom", customType: "subagent-orchestration-instructions", content: "parent-only" };
+		const subagentCall = { role: "assistant", content: [{ type: "toolCall", name: "subagent", input: { agent: "reviewer" } }] };
+		const subagentResult = { role: "toolResult", toolName: "subagent", content: "nested results" };
+		const currentTask = { role: "user", content: "Synthesize." };
+
+		assert.deepEqual(contextHandler?.({ messages: [user, instruction, subagentCall, subagentResult, currentTask] }), {
+			messages: [user, subagentCall, subagentResult, currentTask],
 		});
 	});
 

--- a/test/unit/tool-description.test.ts
+++ b/test/unit/tool-description.test.ts
@@ -19,8 +19,8 @@ describe("registered subagent tool description", () => {
 		for (const builtinName of ["scout", "worker", "planner"]) {
 			assert.doesNotMatch(description, new RegExp(`\\b${builtinName}\\b`));
 		}
-		assert.match(description, /use \{ action: "list" \} to inspect configured agents\/chains/i);
-		assert.match(description, /executable\/non-disabled/i);
+		assert.match(description, /Optional discovery: \{ action: "list" \} inspects configured agents\/chains/i);
+		assert.match(description, /CHILD SESSION RULE/i);
 		assert.doesNotMatch(description, /disabled builtins/i);
 		assert.match(description, /output\?,reads\?,progress\?/i);
 	});


### PR DESCRIPTION
## Summary
- allow child subagent sessions to register the subagent tool when their current depth is still below maxSubagentDepth
- keep nested child use bounded with a default single execution-call budget and disabled management actions
- preserve nested subagent tool calls/results in child context so conductor-style agents can synthesize nested outputs

## Tests
- `node --experimental-strip-types --test test/unit/index-child-registration.test.ts test/unit/subagent-prompt-runtime.test.ts test/unit/tool-description.test.ts`
- `npm run test:unit`