### PR TITLE
Raise default parallel concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+### Changed
+- Raise default top-level and chain parallel concurrency from 4 to 5, and default max parallel tasks from 8 to 10.
+
 ### Fixed
 
 ## [0.24.4] - 2026-05-20

--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ Agent definitions are not loaded into context by default. Management actions let
 | `skill` | `string \| string[] \| false` | agent default | Override skills or disable all. |
 | `model` | string | agent default | Override model. |
 | `tasks` | array | - | Top-level parallel tasks. Supports `agent`, `task`, `cwd`, `count`, `output`, `outputMode`, `reads`, `progress`, `skill`, and `model`. |
-| `concurrency` | number | config or `4` | Top-level parallel concurrency. |
+| `concurrency` | number | config or `5` | Top-level parallel concurrency. |
 | `worktree` | boolean | false | Create isolated git worktrees for parallel tasks. |
 | `chain` | array | - | Sequential and parallel chain steps. |
 | `context` | `fresh \| fork` | agent default or `fresh` | `fork` creates real branched sessions from the parent leaf. Packaged `planner`, `worker`, and `oracle` default to `fork`. |
@@ -806,7 +806,7 @@ Forces depth-0 single, parallel, and chain runs into background mode and bypasse
 }
 ```
 
-`maxTasks` defaults to `8`; `concurrency` defaults to `4`. Per-call `concurrency` takes precedence.
+`maxTasks` defaults to `10`; `concurrency` defaults to `5`. Per-call `concurrency` takes precedence.
 
 ### `defaultSessionDir`
 

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -76,7 +76,7 @@ const ChainItem = Type.Object({
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for this step" })),
 	parallel: Type.Optional(Type.Array(ParallelTaskSchema, { minItems: 1, description: "Tasks to run in parallel" })),
-	concurrency: Type.Optional(Type.Number({ description: "Max concurrent tasks (default: 4)" })),
+	concurrency: Type.Optional(Type.Number({ description: "Max concurrent tasks (default: 5)" })),
 	failFast: Type.Optional(Type.Boolean({ description: "Stop on first failure (default: false)" })),
 	worktree: Type.Optional(Type.Boolean({
 		description: "Create isolated git worktrees for each parallel task."
@@ -130,7 +130,7 @@ export const SubagentParams = Type.Object({
 		description: "Agent or chain config for create/update. Agent: name, package (optional namespace; runtime name becomes package.name), description, scope ('user'|'project', default 'user'), systemPrompt, systemPromptMode, inheritProjectContext, inheritSkills, defaultContext ('fresh'|'fork'), model, tools (comma-separated), extensions (comma-separated), skills (comma-separated), thinking, output, reads, progress, maxSubagentDepth. Chain: name, package, description, scope, steps (array of {agent, task?, output?, outputMode?, reads?, model?, skill?, progress?}). Presence of 'steps' creates a chain instead of an agent. String values must be valid JSON."
 	})),
 	tasks: Type.Optional(Type.Array(TaskItem, { description: "PARALLEL mode: [{agent, task, count?, output?, outputMode?, reads?, progress?}, ...]" })),
-	concurrency: Type.Optional(Type.Integer({ minimum: 1, description: "Top-level PARALLEL mode only: max concurrent tasks. Defaults to config.parallel.concurrency or 4." })),
+	concurrency: Type.Optional(Type.Integer({ minimum: 1, description: "Top-level PARALLEL mode only: max concurrent tasks. Defaults to config.parallel.concurrency or 5." })),
 	worktree: Type.Optional(Type.Boolean({
 		description: "Create isolated git worktrees for each parallel task. " +
 			"Prevents filesystem conflicts. Requires clean git state. " +

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -106,4 +106,4 @@ export function aggregateParallelOutputs(
 		.join("\n\n");
 }
 
-export const MAX_PARALLEL_CONCURRENCY = 4;
+export const MAX_PARALLEL_CONCURRENCY = 5;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -578,8 +578,8 @@ export function resolveTempScopeId(options?: {
 	return "shared";
 }
 
-const MAX_PARALLEL = 8;
-export const MAX_CONCURRENCY = 4;
+const MAX_PARALLEL = 10;
+export const MAX_CONCURRENCY = 5;
 export const TEMP_ROOT_DIR = path.join(os.tmpdir(), `pi-subagents-${resolveTempScopeId()}`);
 export const RESULTS_DIR = path.join(TEMP_ROOT_DIR, "async-subagent-results");
 export const ASYNC_DIR = path.join(TEMP_ROOT_DIR, "async-subagent-runs");

--- a/test/unit/parallel-utils.test.ts
+++ b/test/unit/parallel-utils.test.ts
@@ -196,7 +196,7 @@ describe("aggregateParallelOutputs", () => {
 });
 
 describe("MAX_PARALLEL_CONCURRENCY", () => {
-	it("is 4", () => {
-		assert.equal(MAX_PARALLEL_CONCURRENCY, 4);
+	it("is 5", () => {
+		assert.equal(MAX_PARALLEL_CONCURRENCY, 5);
 	});
 });

--- a/test/unit/recursion-guard.test.ts
+++ b/test/unit/recursion-guard.test.ts
@@ -67,16 +67,16 @@ describe("resolveCurrentMaxSubagentDepth", () => {
 describe("top-level parallel config helpers", () => {
 	it("resolves maxTasks from config or falls back to the default", () => {
 		assert.equal(resolveTopLevelParallelMaxTasks(12), 12);
-		assert.equal(resolveTopLevelParallelMaxTasks(undefined), 8);
-		assert.equal(resolveTopLevelParallelMaxTasks(0), 8);
-		assert.equal(resolveTopLevelParallelMaxTasks("oops"), 8);
+		assert.equal(resolveTopLevelParallelMaxTasks(undefined), 10);
+		assert.equal(resolveTopLevelParallelMaxTasks(0), 10);
+		assert.equal(resolveTopLevelParallelMaxTasks("oops"), 10);
 	});
 
 	it("resolves concurrency from per-call override, config, or default", () => {
 		assert.equal(resolveTopLevelParallelConcurrency(2, 6), 2);
 		assert.equal(resolveTopLevelParallelConcurrency(undefined, 6), 6);
 		assert.equal(resolveTopLevelParallelConcurrency(0, 6), 6);
-		assert.equal(resolveTopLevelParallelConcurrency(undefined, 0), 4);
+		assert.equal(resolveTopLevelParallelConcurrency(undefined, 0), 5);
 	});
 });
 


### PR DESCRIPTION
## Summary
- raise default top-level and chain parallel concurrency from 4 to 5
- raise default top-level parallel max tasks from 8 to 10
- update schema descriptions, README, changelog, and unit expectations

## Tests
- `node --experimental-strip-types --test test/unit/parallel-utils.test.ts test/unit/recursion-guard.test.ts test/unit/schemas.test.ts`
- `npm run test:unit`