### PR TITLE
feat: add staggerMs + staggerJitter config for parallel subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,12 +807,16 @@ Forces depth-0 single, parallel, and chain runs into background mode and bypasse
 {
   "parallel": {
     "maxTasks": 12,
-    "concurrency": 6
+    "concurrency": 6,
+    "staggerMs": 100,
+    "staggerJitter": 0.2
   }
 }
 ```
 
 `maxTasks` defaults to `8`; `concurrency` defaults to `4`. Per-call `concurrency` takes precedence.
+
+`staggerMs` defaults to `0` (no delay). When set, each parallel worker waits `workerIndex × staggerMs ± staggerJitter × staggerMs` before starting, spreading out parallel worker startup to avoid synchronized API bursts. `staggerJitter` defaults to `0.2` (±20%) and accepts values between `0` (deterministic spacing) and `1`.
 
 ### `defaultSessionDir`
 

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -113,6 +113,8 @@ interface AsyncChainParams {
 	controlConfig?: ResolvedControlConfig;
 	controlIntercomTarget?: string;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
+	staggerMs?: number;
+	staggerJitter?: number;
 	nestedRoute?: NestedRouteInfo;
 }
 
@@ -420,6 +422,8 @@ export function executeAsyncChain(
 				controlIntercomTarget,
 				childIntercomTargets,
 				resultMode,
+				staggerMs: params.staggerMs,
+				staggerJitter: params.staggerJitter,
 				nestedRoute: nestedRoute ?? inheritedNestedRoute,
 				nestedSelf: inheritedNestedRoute && nestedAddress ? {
 					parentRunId: nestedAddress.parentRunId,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -94,6 +94,8 @@ interface SubagentRunConfig {
 	controlIntercomTarget?: string;
 	childIntercomTargets?: Array<string | undefined>;
 	resultMode?: SubagentRunMode;
+	staggerMs?: number;
+	staggerJitter?: number;
 	nestedRoute?: NestedRouteInfo;
 	nestedSelf?: { parentRunId: string; parentStepIndex?: number; depth: number; path?: Array<{ runId: string; stepIndex?: number; agent?: string }> };
 }
@@ -1435,6 +1437,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 						if (singleResult.exitCode !== 0 && failFast) aborted = true;
 						return { ...singleResult, skipped: false };
 					},
+					{ staggerMs: config.staggerMs, staggerJitter: config.staggerJitter },
 				);
 
 				flatIndex += group.parallel.length;

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -113,6 +113,8 @@ interface ParallelChainRunInput {
 	totalSteps: number;
 	worktreeSetup?: WorktreeSetup;
 	maxSubagentDepth: number;
+	staggerMs?: number;
+	staggerJitter?: number;
 	nestedRoute?: NestedRouteInfo;
 }
 
@@ -295,6 +297,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 			recordRun(task.agent, cleanTask, result.exitCode, result.progressSummary?.durationMs ?? 0);
 			return result;
 		},
+		{ staggerMs: input.staggerMs, staggerJitter: input.staggerJitter },
 	);
 
 	return parallelResults;
@@ -337,6 +340,8 @@ interface ChainExecutionParams {
 	nestedRoute?: NestedRouteInfo;
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
+	staggerMs?: number;
+	staggerJitter?: number;
 }
 
 interface ChainExecutionResult {
@@ -598,6 +603,8 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					nestedRoute: params.nestedRoute,
 					worktreeSetup,
 					maxSubagentDepth: params.maxSubagentDepth,
+					staggerMs: params.staggerMs,
+					staggerJitter: params.staggerJitter,
 				});
 				globalTaskIndex += step.parallel.length;
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -84,6 +84,8 @@ import {
 	checkSubagentDepth,
 	resolveTopLevelParallelConcurrency,
 	resolveTopLevelParallelMaxTasks,
+	resolveTopLevelParallelStaggerMs,
+	resolveTopLevelParallelStaggerJitter,
 	resolveChildMaxSubagentDepth,
 	resolveCurrentMaxSubagentDepth,
 	wrapForkTask,
@@ -1107,6 +1109,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			controlConfig,
 			controlIntercomTarget,
 			childIntercomTarget,
+			staggerMs: resolveTopLevelParallelStaggerMs(deps.config.parallel?.staggerMs),
+			staggerJitter: resolveTopLevelParallelStaggerJitter(deps.config.parallel?.staggerJitter),
 			nestedRoute,
 		});
 	}
@@ -1135,6 +1139,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			controlConfig,
 			controlIntercomTarget,
 			childIntercomTarget,
+			staggerMs: resolveTopLevelParallelStaggerMs(deps.config.parallel?.staggerMs),
+			staggerJitter: resolveTopLevelParallelStaggerJitter(deps.config.parallel?.staggerJitter),
 			nestedRoute,
 		});
 	}
@@ -1237,6 +1243,8 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		maxSubagentDepth: currentMaxSubagentDepth,
 		worktreeSetupHook: deps.config.worktreeSetupHook,
 		worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
+		staggerMs: resolveTopLevelParallelStaggerMs(deps.config.parallel?.staggerMs),
+		staggerJitter: resolveTopLevelParallelStaggerJitter(deps.config.parallel?.staggerJitter),
 	});
 
 	if (chainResult.requestedAsync) {
@@ -1323,6 +1331,8 @@ interface ForegroundParallelRunInput {
 	modelOverrides: (string | undefined)[];
 	behaviors: Array<ReturnType<typeof resolveStepBehavior>>;
 	firstProgressIndex: number;
+	staggerMs?: number;
+	staggerJitter?: number;
 	controlConfig: ResolvedControlConfig;
 	onControlEvent?: (event: ControlEvent) => void;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
@@ -1531,7 +1541,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 				input.foregroundControl.updatedAt = Date.now();
 			}
 		});
-	});
+	}, { staggerMs: input.staggerMs, staggerJitter: input.staggerJitter });
 }
 
 async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): Promise<AgentToolResult<Details>> {
@@ -1559,6 +1569,8 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 	const tasks = params.tasks!;
 	const maxParallelTasks = resolveTopLevelParallelMaxTasks(deps.config.parallel?.maxTasks);
 	const parallelConcurrency = resolveTopLevelParallelConcurrency(params.concurrency, deps.config.parallel?.concurrency);
+	const parallelStaggerMs = resolveTopLevelParallelStaggerMs(deps.config.parallel?.staggerMs);
+	const parallelStaggerJitter = resolveTopLevelParallelStaggerJitter(deps.config.parallel?.staggerJitter);
 
 	if (tasks.length > maxParallelTasks)
 		return {
@@ -1771,6 +1783,8 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			orchestratorIntercomTarget: data.intercomBridge.active ? data.intercomBridge.orchestratorTarget : undefined,
 			foregroundControl,
 			concurrencyLimit: parallelConcurrency,
+			staggerMs: parallelStaggerMs,
+			staggerJitter: parallelStaggerJitter,
 			maxSubagentDepths,
 			liveResults,
 			liveProgress,

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -49,12 +49,21 @@ export async function mapConcurrent<T, R>(
 	items: T[],
 	limit: number,
 	fn: (item: T, i: number) => Promise<R>,
+	stagger?: { staggerMs?: number; staggerJitter?: number },
 ): Promise<R[]> {
 	const safeLimit = Math.max(1, Math.floor(limit) || 1);
+	const effectiveStagger = stagger?.staggerMs ?? 0;
+	const effectiveJitter = stagger?.staggerJitter ?? 0.2;
 	const results: R[] = new Array(items.length);
 	let next = 0;
 
 	async function worker(_workerIndex: number): Promise<void> {
+		// Stagger worker start: worker N sleeps for N * stagger (with jitter)
+		if (effectiveStagger > 0 && _workerIndex > 0) {
+			const jitter = effectiveStagger * effectiveJitter * (Math.random() * 2 - 1);
+			const delay = Math.max(0, effectiveStagger * _workerIndex + jitter);
+			await new Promise((resolve) => setTimeout(resolve, delay));
+		}
 		while (next < items.length) {
 			const i = next++;
 			results[i] = await fn(items[i], i);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -588,6 +588,12 @@ export interface IntercomBridgeConfig {
 interface TopLevelParallelConfig {
 	maxTasks?: number;
 	concurrency?: number;
+	/** Milliseconds to wait between starting each parallel worker. Default 0 (no delay).
+	 *  Worker N sleeps for N × staggerMs ± staggerJitter × staggerMs before its first task. */
+	staggerMs?: number;
+	/** Jitter fraction applied to stagger delay (0–1). Default 0.2 (±20%).
+	 *  Only effective when staggerMs > 0. */
+	staggerJitter?: number;
 }
 
 export interface ExtensionConfig {
@@ -675,6 +681,10 @@ export function resolveTempScopeId(options?: {
 
 const MAX_PARALLEL = 8;
 export const MAX_CONCURRENCY = 4;
+/** Default stagger between parallel worker starts (ms). 0 = no delay. */
+export const DEFAULT_STAGGER_MS = 0;
+/** Default jitter fraction for stagger (0.2 = ±20%). */
+export const DEFAULT_STAGGER_JITTER = 0.2;
 export const TEMP_ROOT_DIR = path.join(os.tmpdir(), `pi-subagents-${resolveTempScopeId()}`);
 export const RESULTS_DIR = path.join(TEMP_ROOT_DIR, "async-subagent-results");
 export const ASYNC_DIR = path.join(TEMP_ROOT_DIR, "async-subagent-runs");
@@ -715,6 +725,32 @@ export function resolveTopLevelParallelConcurrency(
 	return normalizeTopLevelParallelValue(override)
 		?? normalizeTopLevelParallelValue(configValue)
 		?? MAX_CONCURRENCY;
+}
+
+function normalizeStaggerMs(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value;
+	if (typeof value === "string") {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+	}
+	return undefined;
+}
+
+export function resolveTopLevelParallelStaggerMs(configValue: unknown): number {
+	return normalizeStaggerMs(configValue) ?? DEFAULT_STAGGER_MS;
+}
+
+function normalizeStaggerJitter(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1) return value;
+	if (typeof value === "string") {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) return parsed;
+	}
+	return undefined;
+}
+
+export function resolveTopLevelParallelStaggerJitter(configValue: unknown): number {
+	return normalizeStaggerJitter(configValue) ?? DEFAULT_STAGGER_JITTER;
 }
 
 export function getAsyncConfigPath(suffix: string): string {

--- a/test/unit/parallel-utils.test.ts
+++ b/test/unit/parallel-utils.test.ts
@@ -150,6 +150,53 @@ describe("mapConcurrent", () => {
 		assert.ok(d1 < 20, `worker 1 should start immediately, got ${d1}ms delay`);
 		assert.ok(d2 < 20, `worker 2 should start immediately, got ${d2}ms delay`);
 	});
+
+	it("stagger makes total runtime longer than without stagger", async () => {
+		// With staggerMs=60, 2 workers, and 2 items that each take 20ms:
+		// Without stagger: both workers start immediately, total ~20ms.
+		// With stagger: worker 1 starts immediately, worker 2 waits ~60ms, total ~80ms.
+		const items = [1, 2];
+		const blockMs = 20;
+
+		const startNoStagger = Date.now();
+		await mapConcurrent(items, 2, async () => {
+			await new Promise((r) => setTimeout(r, blockMs));
+		});
+		const noStaggerDuration = Date.now() - startNoStagger;
+
+		const startStagger = Date.now();
+		await mapConcurrent(items, 2, async () => {
+			await new Promise((r) => setTimeout(r, blockMs));
+		}, { staggerMs: 60 });
+		const staggerDuration = Date.now() - startStagger;
+
+		// Staggered run should be meaningfully longer than non-staggered
+		assert.ok(staggerDuration >= noStaggerDuration + 25,
+			`staggered (${staggerDuration}ms) should be >= non-staggered (${noStaggerDuration}ms) + 25ms`);
+	});
+
+	it("stagger with jitter=0 is slower than with jitter=1 for small stagger", async () => {
+		// Both should still apply stagger, just with different jitter ranges.
+		// Just verify jitter=0 completes slower than no-stagger.
+		const items = [1, 2];
+		const blockMs = 20;
+
+		const start = Date.now();
+		await mapConcurrent(items, 2, async () => {
+			await new Promise((r) => setTimeout(r, blockMs));
+		}, { staggerMs: 50, staggerJitter: 0 });
+		const duration = Date.now() - start;
+
+		// With staggerMs=50 and no jitter, worker 2 waits exactly 50ms
+		assert.ok(duration >= 50,
+			`with jitter=0, duration (${duration}ms) should be >= 50ms`);
+	});
+
+	it("stagger options bag is accepted without error", async () => {
+		const items = [1, 2, 3];
+		const results = await mapConcurrent(items, 2, async (item) => item * 2, { staggerMs: 10, staggerJitter: 0.5 });
+		assert.deepEqual(results, [2, 4, 6]);
+	});
 });
 
 describe("aggregateParallelOutputs", () => {

--- a/test/unit/recursion-guard.test.ts
+++ b/test/unit/recursion-guard.test.ts
@@ -7,6 +7,8 @@ import {
 	normalizeMaxSubagentDepth,
 	resolveTopLevelParallelConcurrency,
 	resolveTopLevelParallelMaxTasks,
+	resolveTopLevelParallelStaggerMs,
+	resolveTopLevelParallelStaggerJitter,
 	resolveChildMaxSubagentDepth,
 	resolveCurrentMaxSubagentDepth,
 } from "../../src/shared/types.ts";
@@ -77,6 +79,28 @@ describe("top-level parallel config helpers", () => {
 		assert.equal(resolveTopLevelParallelConcurrency(undefined, 6), 6);
 		assert.equal(resolveTopLevelParallelConcurrency(0, 6), 6);
 		assert.equal(resolveTopLevelParallelConcurrency(undefined, 0), 4);
+	});
+
+	it("resolves staggerMs from config or falls back to default 0", () => {
+		assert.equal(resolveTopLevelParallelStaggerMs(100), 100);
+		assert.equal(resolveTopLevelParallelStaggerMs(undefined), 0);
+		assert.equal(resolveTopLevelParallelStaggerMs(0), 0);
+		assert.equal(resolveTopLevelParallelStaggerMs(-5), 0);
+		assert.equal(resolveTopLevelParallelStaggerMs(Infinity), 0);
+		assert.equal(resolveTopLevelParallelStaggerMs("oops"), 0);
+		assert.equal(resolveTopLevelParallelStaggerMs("200"), 200);
+	});
+
+	it("resolves staggerJitter from config or falls back to default 0.2", () => {
+		assert.equal(resolveTopLevelParallelStaggerJitter(0.3), 0.3);
+		assert.equal(resolveTopLevelParallelStaggerJitter(undefined), 0.2);
+		assert.equal(resolveTopLevelParallelStaggerJitter(0), 0);
+		assert.equal(resolveTopLevelParallelStaggerJitter(1), 1);
+		assert.equal(resolveTopLevelParallelStaggerJitter(1.5), 0.2);
+		assert.equal(resolveTopLevelParallelStaggerJitter(-0.1), 0.2);
+		assert.equal(resolveTopLevelParallelStaggerJitter(Infinity), 0.2);
+		assert.equal(resolveTopLevelParallelStaggerJitter("0.5"), 0.5);
+		assert.equal(resolveTopLevelParallelStaggerJitter("oops"), 0.2);
 	});
 });
 


### PR DESCRIPTION
A burst of parallel subagents hammers providers and triggers velocity rate limits, so I added these to spread things out:

- `staggerMs` — delay between each worker start (default 0, no delay)
- `staggerJitter` — randomness fraction (default 0.2 = ±20%)

Worker N sleeps for N × staggerMs ± staggerJitter × staggerMs before its first task. `mapConcurrent` now takes an options bag for stagger config.

I've set defaults to preserve existing behavior (i.e. no stagger) but I recommend sane defaults to prevent thundering herd - particularly when the parallel subagent limit is set high (5 with no stagger is OK, but 50... 429!)

A small note: #43 added something similar to resolve a different issue (file lock contention) but it was later dropped to rely on pi's lock retry behavior instead.