### PR TITLE
fix: ignore legacy skill dirs in agent discovery

### DIFF
--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -535,7 +535,11 @@ export function removeBuiltinAgentOverride(cwd: string, name: string, scope: "us
 	return filePath;
 }
 
-function listMarkdownFilesRecursive(dir: string, predicate: (fileName: string) => boolean): string[] {
+function listMarkdownFilesRecursive(
+	dir: string,
+	predicate: (fileName: string) => boolean,
+	shouldSkipDir: (dirPath: string) => boolean = () => false,
+): string[] {
 	const files: string[] = [];
 	if (!fs.existsSync(dir)) return files;
 
@@ -549,7 +553,9 @@ function listMarkdownFilesRecursive(dir: string, predicate: (fileName: string) =
 	for (const entry of entries) {
 		const filePath = path.join(dir, entry.name);
 		if (entry.isDirectory()) {
-			files.push(...listMarkdownFilesRecursive(filePath, predicate));
+			if (!shouldSkipDir(filePath)) {
+				files.push(...listMarkdownFilesRecursive(filePath, predicate, shouldSkipDir));
+			}
 			continue;
 		}
 		if (!entry.isFile() && !entry.isSymbolicLink()) continue;
@@ -559,10 +565,19 @@ function listMarkdownFilesRecursive(dir: string, predicate: (fileName: string) =
 	return files;
 }
 
+function isLegacySkillsDir(rootDir: string, dirPath: string): boolean {
+	if (path.basename(rootDir) !== ".agents") return false;
+	return path.relative(rootDir, dirPath).split(path.sep).includes("skills");
+}
+
 function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
-	for (const filePath of listMarkdownFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"))) {
+	for (const filePath of listMarkdownFilesRecursive(
+		dir,
+		(fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"),
+		(dirPath) => isLegacySkillsDir(dir, dirPath),
+	)) {
 		let content: string;
 		try {
 			content = fs.readFileSync(filePath, "utf-8");

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -614,10 +614,27 @@ description: Canonical
 
 Canonical prompt
 `, "utf-8");
+		fs.writeFileSync(path.join(dir, ".agents", "skills", "review-skill.md"), `---
+name: review-skill
+description: This is a skill, not a subagent
+---
+
+# Review Skill
+`, "utf-8");
+		fs.mkdirSync(path.join(dir, ".agents", "skills", "nested-skill"), { recursive: true });
+		fs.writeFileSync(path.join(dir, ".agents", "skills", "nested-skill", "SKILL.md"), `---
+name: nested-skill
+description: This nested skill is also not a subagent
+---
+
+# Nested Skill
+`, "utf-8");
 
 		const result = discoverAgents(dir, "project");
 		assert.ok(result.agents.find((agent) => agent.name === "legacy" && agent.filePath === path.join(dir, ".agents", "legacy.md")));
 		assert.ok(result.agents.find((agent) => agent.name === "canonical" && agent.filePath === path.join(dir, ".pi", "agents", "canonical.md")));
+		assert.equal(result.agents.some((agent) => agent.name === "review-skill"), false);
+		assert.equal(result.agents.some((agent) => agent.name === "nested-skill"), false);
 		assert.equal(result.projectAgentsDir, path.join(dir, ".pi", "agents"));
 	});
 


### PR DESCRIPTION
## Summary

Legacy `.agents/**/*.md` discovery currently treats Pi skill files under `.agents/skills/**` as executable subagents when they contain `name` and `description` frontmatter. That makes valid skill packages like `.agents/skills/foo/SKILL.md` show up in `subagent list` as runnable agents.

This keeps the legacy `.agents` compatibility behavior, but excludes `.agents/skills/**` from agent discovery. The intent is to preserve custom legacy agents under `.agents/` while respecting Pi's documented skill location under `.agents/skills/`.

## Why

Pi documents both canonical and legacy skill locations, including:

- `~/.pi/agent/skills/`
- `~/.agents/skills/`
- `.pi/skills/`
- `.agents/skills/`

Since skills also use markdown/frontmatter, broad `.agents/**/*.md` agent discovery can accidentally classify skill docs as executable agents. This is confusing in `subagent list`, where skill instruction packages can appear to be runnable subagents.

## Changes

- Add an optional directory-skip predicate to recursive markdown discovery.
- Skip `skills` subtrees only when scanning a legacy `.agents` root for agents.
- Add coverage that `.agents/skills/*.md` and `.agents/skills/*/SKILL.md` are ignored while ordinary legacy `.agents/*.md` agents still load.

## Validation

- `node --experimental-strip-types --test test/unit/agent-frontmatter.test.ts`

Note: `npm test -- test/unit/agent-frontmatter.test.ts` starts the full unit suite in this checkout and hits unrelated missing peer dependencies for TUI-related tests (`@earendil-works/pi-tui`, `@earendil-works/pi-coding-agent`). The targeted test file passes with Node's strip-types runner.
