### PR TITLE
fix: prevent duplicate 'subagent' tool registration in child processes

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -208,8 +208,14 @@ class SubagentControlNoticeComponent implements Component {
 }
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
+	// When running as a child subagent (SUBAGENT_CHILD_ENV=1):
+	// - The fanout-child extension is loaded independently via --extension when fanoutAuthorized.
+	// - Calling registerFanoutChildSubagentExtension here would register tool "subagent"
+	//   on BOTH this extension's api AND the fanout-child extension's api, causing the
+	//   pi resource-loader to detect a conflict between the two extension files.
+	// - Instead, we simply return early and let the independent fanout-child.ts extension
+	//   handle registration.
 	if (process.env[SUBAGENT_CHILD_ENV] === "1") {
-		if (process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1") registerFanoutChildSubagentExtension(pi);
 		return;
 	}
 	const globalStore = globalThis as Record<string, unknown>;


### PR DESCRIPTION
## Problema

Quando um subagente child tem `tools: subagent` no frontmatter (ex: agentes orquestradores que fazem fan-out), a extensão `pi-subagents` é carregada de duas formas:

1. **Via `package.json` manifest** → `./src/extension/index.ts`
2. **Via `--extension` flag** → `./src/extension/fanout-child.ts`

Ambos os caminhos chamavam `registerFanoutChildSubagentExtension(pi)`, que registrava uma tool chamada `"subagent"` nas duas APIs de extensão. O `detectExtensionConflicts()` do resource-loader do pi detectava duas extensões com paths diferentes registrando a mesma tool e rejeitava o carregamento com:

```
Error: Tool "subagent" conflicts with .../fanout-child.ts
```

## Causa raiz

Em `src/runs/shared/pi-args.ts`, quando `fanoutAuthorized = true` (porque `declaredBuiltinTools.includes("subagent")`):
- `FANOUT_CHILD_EXTENSION_PATH` é adicionado ao array `runtimeExtensions`
- O child recebe `--extension /path/to/fanout-child.ts` na linha de comando
- O child também carrega `index.ts` via descoberta normal de pacotes (`package.json`)

Em `index.ts`:
```ts
if (process.env[SUBAGENT_CHILD_ENV] === "1") {
    if (process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1") registerFanoutChildSubagentExtension(pi);
    return;
}
```

Quando `SUBAGENT_FANOUT_CHILD_ENV=1`, ele chamava `registerFanoutChildSubagentExtension(pi)`, que registrava `"subagent"` no API do `index.ts`. Simultaneamente, o `fanout-child.ts` carregado como extensão independente também registrava `"subagent"` no seu próprio API. Conflito.

## Correção

No `index.ts`, quando `SUBAGENT_CHILD_ENV=1`, retornar cedo sem chamar `registerFanoutChildSubagentExtension`. O `fanout-child.ts` já é carregado como extensão independente via `--extension` e faz o registro sozinho.

## Testes

Testado com `masterpi.orchestrator` (agente com `tools: subagent`). Antes da correção: falha com conflito. Depois: executou 9 turns com sucesso, listando ~63 agentes sem erros.