### PR TITLE
fix: handle deferred session file writes from createBranchedSession

### DIFF
--- a/src/shared/fork-context.ts
+++ b/src/shared/fork-context.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { CURRENT_SESSION_VERSION, SessionManager, type SessionEntry } from "@earendil-works/pi-coding-agent";
 
 type SubagentExecutionContext = "fresh" | "fork";
 
@@ -49,6 +49,36 @@ export function createForkContextResolver(
 	const sessionDir = sessionManager.getSessionDir?.();
 	const cachedSessionFiles = new Map<number, string>();
 
+	/**
+	 * Write the branched session file manually.
+	 *
+	 * Called when createBranchedSession() returns a path but the file was not
+	 * written to disk. This happens when the branched path contains no assistant
+	 * messages — SessionManager defers writing until _persist() is called with
+	 * the first assistant response.
+	 *
+	 * After createBranchedSession(), the source manager's internal state has been
+	 * switched to the branched session, so getBranch() returns the correct path
+	 * and getSessionId() returns the new branched session id.
+	 *
+	 * Depends on SessionManager internals:
+	 * - getBranch() must return the branched path (relies on leafId being updated)
+	 * - getSessionId() must return the new session id (runtime-public, TS-private)
+	 */
+	function writeBranchedSessionFile(sourceManager: ForkableSessionManager & { getBranch(): SessionEntry[]; getSessionId?(): string; getCwd?(): string }, sessionFile: string): void {
+		const path = sourceManager.getBranch();
+		const header = {
+			type: "session",
+			version: CURRENT_SESSION_VERSION,
+			id: sourceManager.getSessionId?.() ?? "branched",
+			timestamp: new Date().toISOString(),
+			cwd: sourceManager.getCwd?.() ?? "",
+			parentSession: parentSessionFile,
+		};
+		const lines = [JSON.stringify(header), ...path.map((e) => JSON.stringify(e))];
+		fs.writeFileSync(sessionFile, lines.join("\n") + "\n", "utf-8");
+	}
+
 	return {
 		sessionFileForIndex(index = 0): string | undefined {
 			const cached = cachedSessionFiles.get(index);
@@ -62,8 +92,11 @@ export function createForkContextResolver(
 				if (!sessionFile) {
 					throw new Error("Session manager did not return a forked session file.");
 				}
+				// createBranchedSession() may return a path without writing the file
+				// when the branched path has no assistant messages (deferred to _persist).
+				// Write it ourselves so the file exists for the spawned subagent process.
 				if (!fs.existsSync(sessionFile)) {
-					throw new Error(`Session manager returned a forked session file that does not exist: ${sessionFile}`);
+					writeBranchedSessionFile(sourceManager as ForkableSessionManager & { getBranch(): SessionEntry[] }, sessionFile);
 				}
 				cachedSessionFiles.set(index, sessionFile);
 				return sessionFile;

--- a/test/unit/fork-context.test.ts
+++ b/test/unit/fork-context.test.ts
@@ -124,6 +124,41 @@ describe("createForkContextResolver", () => {
 		}
 	});
 
+	it("writes branched file via fallback when branched path has no assistant messages (real SessionManager)", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-no-assistant-"));
+		try {
+			const sessionDir = path.join(tempDir, "sessions");
+			// Create parent with user + assistant (so parent file is flushed)
+			const parent = SessionManager.create(tempDir, sessionDir);
+			const userMsgId = parent.appendMessage({ role: "user", content: "parent prompt" });
+			parent.appendMessage({ role: "assistant", content: "parent response" });
+			const parentSessionFile = parent.getSessionFile();
+			assert.ok(parentSessionFile);
+			assert.equal(fs.existsSync(parentSessionFile), true);
+
+			// Fork from the user message (before assistant) - branched path has no assistant
+			const resolver = createForkContextResolver({
+				getSessionFile: () => parentSessionFile,
+				getLeafId: () => userMsgId,  // fork from user message, not assistant
+				getSessionDir: () => sessionDir,
+			}, "fork");
+
+			const childSessionFile = resolver.sessionFileForIndex(0);
+			assert.ok(childSessionFile);
+			assert.notEqual(childSessionFile, parentSessionFile);
+			// File should exist thanks to the fallback writer
+			assert.equal(fs.existsSync(childSessionFile), true);
+			// Verify content: header + user message only (no assistant)
+			const content = fs.readFileSync(childSessionFile, "utf-8");
+			const lines = content.trim().split("\n");
+			assert.equal(lines.length, 2); // header + 1 message
+			assert.equal(JSON.parse(lines[0]).type, "session");
+			assert.equal(JSON.parse(lines[1]).message.role, "user");
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("fails clearly for an unflushed user-only parent", () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-user-only-"));
 		try {
@@ -212,7 +247,38 @@ describe("createForkContextResolver", () => {
 		}
 	});
 
-	it("fails clearly when branch extraction returns a missing child file", () => {
+	it("writes branched session file when createBranchedSession defers writing (no assistant messages)", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-deferred-write-"));
+		try {
+			const parentSessionFile = path.join(tempDir, "parent.jsonl");
+			const deferredChildSessionFile = path.join(tempDir, "deferred-child.jsonl");
+			writeMinimalSessionFile(parentSessionFile, "parent");
+			const resolver = createForkContextResolver({
+				getSessionFile: () => parentSessionFile,
+				getLeafId: () => "leaf-abc",
+			}, "fork", {
+				openSession: () => ({
+					createBranchedSession: () => deferredChildSessionFile,
+					getBranch: () => [],
+					getSessionId: () => "branched-session-id",
+					getCwd: () => "/tmp",
+				}),
+			});
+
+			const result = resolver.sessionFileForIndex(0);
+			assert.equal(result, deferredChildSessionFile);
+			assert.equal(fs.existsSync(deferredChildSessionFile), true);
+			// Verify the written file has a valid session header
+			const content = fs.readFileSync(deferredChildSessionFile, "utf-8");
+			const header = JSON.parse(content.split("\n")[0]);
+			assert.equal(header.type, "session");
+			assert.equal(header.parentSession, parentSessionFile);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("fails clearly when branched file is missing and getBranch is unavailable", () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-missing-child-"));
 		try {
 			const parentSessionFile = path.join(tempDir, "parent.jsonl");
@@ -224,12 +290,13 @@ describe("createForkContextResolver", () => {
 			}, "fork", {
 				openSession: () => ({
 					createBranchedSession: () => missingChildSessionFile,
+					// No getBranch — simulates a mock/old SessionManager without the method
 				}),
 			});
 
 			assert.throws(
 				() => resolver.sessionFileForIndex(0),
-				/Failed to create forked subagent session: Session manager returned a forked session file that does not exist: .*missing-child\.jsonl/,
+				/Failed to create forked subagent session: sourceManager\.getBranch is not a function/,
 			);
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
SessionManager.createBranchedSession() now defers writing the branched session file when the path contains no assistant messages (matching the newSession() contract). The file is only written when _persist() is called with the first assistant response.

This caused forked subagent sessions to fail with:
  'Session manager returned a forked session file that does not exist'

Fix: When createBranchedSession() returns a path but the file doesn't exist, write it ourselves using the source manager's getBranch() method to extract the correct branch entries. After createBranchedSession(), the source manager's internal state has been switched to the branched session, so getBranch() returns the correct path.

- Add writeBranchedSessionFile() fallback that writes the session file with a proper header and branch entries
- Import SessionEntry type from pi-coding-agent SDK
- Update tests to cover the deferred-write scenario with both mock and real SessionManager instances