### PR TITLE
fix: inherit parent instance's active model in subagents

### DIFF
--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1069,7 +1069,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 	if (hasTasks && params.tasks) {
 		const agentConfigs = params.tasks.map((task) => agents.find((agent) => agent.name === task.agent));
 		const modelOverrides = params.tasks.map((task, index) =>
-			resolveModelCandidate(task.model ?? agentConfigs[index]?.model, availableModels, currentProvider),
+			resolveModelCandidate(task.model ?? agentConfigs[index]?.model ?? ctx.model?.fullId, availableModels, currentProvider),
 		);
 		const skillOverrides = params.tasks.map((task) => normalizeSkillInput(task.skill));
 		const parallelTasks = params.tasks.map((task, index) => ({
@@ -1154,7 +1154,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const normalizedSkills = normalizeSkillInput(params.skill);
 		const skills = normalizedSkills === false ? [] : normalizedSkills;
 		const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, a.maxSubagentDepth);
-		const modelOverride = resolveModelCandidate((params.model as string | undefined) ?? a.model, availableModels, currentProvider);
+		const modelOverride = resolveModelCandidate((params.model as string | undefined) ?? a.model ?? ctx.model?.fullId, availableModels, currentProvider);
 		return executeAsyncSingle(id, {
 			agent: params.agent!,
 			task: params.context === "fork" ? wrapForkTask(params.task ?? "") : (params.task ?? ""),
@@ -1605,7 +1605,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		...(task.model ? { model: task.model } : {}),
 	}));
 	const modelOverrides: (string | undefined)[] = tasks.map((_, i) =>
-		resolveModelCandidate(behaviorOverrides[i]?.model ?? agentConfigs[i]?.model, availableModels, currentProvider),
+		resolveModelCandidate(behaviorOverrides[i]?.model ?? agentConfigs[i]?.model ?? ctx.model?.fullId, availableModels, currentProvider),
 	);
 
 	if (params.clarify === true && ctx.hasUI) {
@@ -1888,7 +1888,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	let task = params.task ?? "";
 	let modelOverride: string | undefined = resolveModelCandidate(
-		(params.model as string | undefined) ?? agentConfig.model,
+		(params.model as string | undefined) ?? agentConfig.model ?? ctx.model?.fullId,
 		availableModels,
 		currentProvider,
 	);


### PR DESCRIPTION
Fixes #209

## Problem

When multiple Pi instances run simultaneously with different models, subagents always fall back to `settings.json` (shared on disk). Whichever instance last changed its model wins — not the instance that spawned the subagent.

The parent's active model (`ctx.model?.fullId`) was available but only used for provider disambiguation, never forwarded to the child.

## Fix

Add `ctx.model?.fullId` as a final fallback in all four `resolveModelCandidate` call sites (single, async single, parallel, chain) in `subagent-executor.ts`:

```ts
// Before
resolveModelCandidate(task.model ?? agentConfig.model, availableModels, currentProvider)

// After
resolveModelCandidate(task.model ?? agentConfig.model ?? ctx.model?.fullId, availableModels, currentProvider)
```

## Priority order after fix

1. Explicit `model` in subagent call params
2. `model:` in agent frontmatter  
3. **Current instance's active model** ← new
4. Nothing → child reads `settings.json`

Since `ctx.model?.fullId` is already fully qualified (e.g. `anthropic/claude-sonnet-4`), it passes through `resolveModelCandidate` unchanged via the existing `model.includes("/")` early return.

## Testing

Pre-existing test suite: 415 pass, 9 fail — identical before and after (failures are due to missing peer dependency in test environment, unrelated to this change).