### PR TITLE
fix: remove duplicate fanout-child subagent registration

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -209,7 +209,6 @@ class SubagentControlNoticeComponent implements Component {
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	if (process.env[SUBAGENT_CHILD_ENV] === "1") {
-		if (process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1") registerFanoutChildSubagentExtension(pi);
 		return;
 	}
 	const globalStore = globalThis as Record<string, unknown>;


### PR DESCRIPTION
Removes the registerFanoutChildSubagentExtension(pi) call from index.ts child branch. Pi auto-discovers fanout-child.ts in src/extension/ and loads it as a separate extension — registering twice causes a conflict that breaks nested subagent delegation.