### PR TITLE
Apply agentOverrides to user/project custom agents (frontmatter wins per field)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Apply `subagents.agentOverrides[name]` to user-scope and project-scope custom agents in addition to builtins. Frontmatter wins per-field — overrides only fill fields the agent's frontmatter left unset, so existing custom agents that pin their own model/thinking/etc. are unaffected. Lets shared persona files (`.pi/agents/<name>.md`) stay version-controlled while per-harness `settings.json` supplies the local model. `disableBuiltins` continues to apply only to builtins.
+
 ## [0.25.0] - 2026-05-21
 
 ### Added

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -460,6 +460,105 @@ function applyBuiltinOverrides(
 	});
 }
 
+// Custom (user/project) agents pre-fill fields from their frontmatter, so
+// agentOverrides[name] only fills fields the frontmatter left unset. This
+// keeps frontmatter as the per-agent source of truth and lets settings.json
+// supply per-harness defaults (model, thinking, ...) for shared personas.
+// Bulk disableBuiltins intentionally does not touch custom agents.
+function applyCustomAgentOverride(
+	agent: AgentConfig,
+	override: BuiltinAgentOverrideConfig,
+	meta: { scope: "user" | "project"; path: string },
+): AgentConfig {
+	const next: AgentConfig = { ...agent };
+	let anyFilled = false;
+
+	const fill = <T>(field: keyof AgentConfig, currentlyUnset: boolean, value: T) => {
+		if (!currentlyUnset) return;
+		(next as Record<string, unknown>)[field as string] = value;
+		anyFilled = true;
+	};
+
+	if (override.model !== undefined) {
+		fill("model", agent.model === undefined, override.model === false ? undefined : override.model);
+	}
+	if (override.fallbackModels !== undefined) {
+		fill(
+			"fallbackModels",
+			agent.fallbackModels === undefined,
+			override.fallbackModels === false ? undefined : [...override.fallbackModels],
+		);
+	}
+	if (override.thinking !== undefined) {
+		fill("thinking", agent.thinking === undefined, override.thinking === false ? undefined : override.thinking);
+	}
+	if (override.systemPromptMode !== undefined) {
+		fill("systemPromptMode", agent.systemPromptMode === undefined, override.systemPromptMode);
+	}
+	if (override.inheritProjectContext !== undefined) {
+		fill("inheritProjectContext", agent.inheritProjectContext === undefined, override.inheritProjectContext);
+	}
+	if (override.inheritSkills !== undefined) {
+		fill("inheritSkills", agent.inheritSkills === undefined, override.inheritSkills);
+	}
+	if (override.defaultContext !== undefined) {
+		fill(
+			"defaultContext",
+			agent.defaultContext === undefined,
+			override.defaultContext === false ? undefined : override.defaultContext,
+		);
+	}
+	if (override.disabled !== undefined) {
+		fill("disabled", agent.disabled === undefined, override.disabled);
+	}
+	if (override.systemPrompt !== undefined) {
+		fill("systemPrompt", agent.systemPrompt === undefined, override.systemPrompt);
+	}
+	if (override.skills !== undefined) {
+		fill(
+			"skills",
+			agent.skills === undefined,
+			override.skills === false ? undefined : [...override.skills],
+		);
+	}
+	if (override.tools !== undefined) {
+		const toolsUnset = agent.tools === undefined && agent.mcpDirectTools === undefined;
+		if (toolsUnset) {
+			const { tools, mcpDirectTools } = splitToolList(override.tools === false ? [] : override.tools);
+			next.tools = tools;
+			next.mcpDirectTools = mcpDirectTools;
+			anyFilled = true;
+		}
+	}
+	if (override.completionGuard !== undefined) {
+		fill("completionGuard", agent.completionGuard === undefined, override.completionGuard);
+	}
+
+	if (!anyFilled) return agent;
+	next.override = { ...meta, base: cloneOverrideBase(agent) };
+	return next;
+}
+
+function applyCustomAgentOverrides(
+	agents: AgentConfig[],
+	userSettings: SubagentSettings,
+	projectSettings: SubagentSettings,
+	userSettingsPath: string,
+	projectSettingsPath: string | null,
+): AgentConfig[] {
+	return agents.map((agent) => {
+		const projectOverride = projectSettings.overrides[agent.name];
+		if (projectOverride && projectSettingsPath) {
+			return applyCustomAgentOverride(agent, projectOverride, { scope: "project", path: projectSettingsPath });
+		}
+		const userOverride = userSettings.overrides[agent.name];
+		if (userOverride) {
+			return applyCustomAgentOverride(agent, userOverride, { scope: "user", path: userSettingsPath });
+		}
+		return agent;
+	});
+}
+
 export function buildBuiltinOverrideConfig(
 	base: BuiltinAgentOverrideBase,
 	draft: Pick<AgentConfig, "model" | "fallbackModels" | "thinking" | "systemPromptMode" | "inheritProjectContext" | "inheritSkills" | "defaultContext" | "disabled" | "systemPrompt" | "skills" | "tools" | "mcpDirectTools" | "completionGuard">,
@@ -765,9 +864,21 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 
 	const userAgentsOld = scope === "project" ? [] : loadAgentsFromDir(userDirOld, "user");
 	const userAgentsNew = scope === "project" ? [] : loadAgentsFromDir(userDirNew, "user");
-	const userAgents = [...userAgentsOld, ...userAgentsNew];
+	const userAgents = applyCustomAgentOverrides(
+		[...userAgentsOld, ...userAgentsNew],
+		userSettings,
+		projectSettings,
+		userSettingsPath,
+		projectSettingsPath,
+	);
 
-	const projectAgents = scope === "user" ? [] : projectAgentDirs.flatMap((dir) => loadAgentsFromDir(dir, "project"));
+	const projectAgents = applyCustomAgentOverrides(
+		scope === "user" ? [] : projectAgentDirs.flatMap((dir) => loadAgentsFromDir(dir, "project")),
+		userSettings,
+		projectSettings,
+		userSettingsPath,
+		projectSettingsPath,
+	);
 	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents)
 		.filter((agent) => agent.disabled !== true);
 
@@ -803,17 +914,29 @@ export function discoverAgentsAll(cwd: string): {
 		userSettingsPath,
 		projectSettingsPath,
 	);
-	const user = [
-		...loadAgentsFromDir(userDirOld, "user"),
-		...loadAgentsFromDir(userDirNew, "user"),
-	];
+	const user = applyCustomAgentOverrides(
+		[
+			...loadAgentsFromDir(userDirOld, "user"),
+			...loadAgentsFromDir(userDirNew, "user"),
+		],
+		userSettings,
+		projectSettings,
+		userSettingsPath,
+		projectSettingsPath,
+	);
 	const projectMap = new Map<string, AgentConfig>();
 	for (const dir of projectDirs) {
 		for (const agent of loadAgentsFromDir(dir, "project")) {
 			projectMap.set(agent.name, agent);
 		}
 	}
-	const project = Array.from(projectMap.values());
+	const project = applyCustomAgentOverrides(
+		Array.from(projectMap.values()),
+		userSettings,
+		projectSettings,
+		userSettingsPath,
+		projectSettingsPath,
+	);
 
 	const chainMap = new Map<string, ChainConfig>();
 	for (const dir of projectChainDirs) {

--- a/test/unit/agent-overrides.test.ts
+++ b/test/unit/agent-overrides.test.ts
@@ -21,6 +21,12 @@ function writeProjectAgent(cwd: string, name: string, body: string): void {
 	fs.writeFileSync(filePath, body, "utf-8");
 }
 
+function writeUserAgent(home: string, name: string, body: string): void {
+	const filePath = path.join(home, ".pi", "agent", "agents", `${name}.md`);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, body, "utf-8");
+}
+
 describe("builtin agent overrides", () => {
 	beforeEach(() => {
 		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-home-"));
@@ -136,7 +142,7 @@ describe("builtin agent overrides", () => {
 		assert.equal(reviewer.override?.scope, "project");
 	});
 
-	it("does not apply builtin settings overrides when a full project agent overrides the builtin", () => {
+	it("frontmatter wins per-field over agentOverrides for a shadowing project agent", () => {
 		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
 		writeJson(path.join(tempProject, ".pi", "settings.json"), {
 			subagents: { agentOverrides: { reviewer: { model: "openai/gpt-5.4" } } },
@@ -148,6 +154,86 @@ describe("builtin agent overrides", () => {
 		assert.equal(reviewer.source, "project");
 		assert.equal(reviewer.model, "google/gemini-3-pro");
 		assert.equal(reviewer.override, undefined);
+	});
+
+	it("fills in unset fields on a custom project agent from project agentOverrides", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { agentOverrides: { implementer: { model: "anthropic/claude-sonnet-4-6", thinking: "high" } } },
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.source, "project");
+		assert.equal(implementer.model, "anthropic/claude-sonnet-4-6");
+		assert.equal(implementer.thinking, "high");
+		assert.equal(implementer.override?.scope, "project");
+	});
+
+	it("fills in unset fields on a custom user agent from user agentOverrides", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { implementer: { model: "anthropic/claude-sonnet-4-6" } } },
+		});
+		writeUserAgent(tempHome, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.source, "user");
+		assert.equal(implementer.model, "anthropic/claude-sonnet-4-6");
+		assert.equal(implementer.override?.scope, "user");
+	});
+
+	it("applies user agentOverrides to a custom project agent when project settings have no entry", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { implementer: { model: "anthropic/claude-sonnet-4-6" } } },
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.source, "project");
+		assert.equal(implementer.model, "anthropic/claude-sonnet-4-6");
+		assert.equal(implementer.override?.scope, "user");
+	});
+
+	it("prefers project agentOverrides over user agentOverrides on a custom project agent", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { implementer: { model: "anthropic/claude-sonnet-4-6" } } },
+		});
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { agentOverrides: { implementer: { model: "openai/gpt-5.4" } } },
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.model, "openai/gpt-5.4");
+		assert.equal(implementer.override?.scope, "project");
+	});
+
+	it("leaves a custom agent untouched when no agentOverrides entry matches its name", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { reviewer: { model: "openai/gpt-5.4" } } },
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.model, undefined);
+		assert.equal(implementer.override, undefined);
+	});
+
+	it("disableBuiltins does not disable custom agents", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { disableBuiltins: true },
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.notEqual(implementer.disabled, true);
 	});
 
 	it("does not create a settings file when removing a non-existent override", () => {


### PR DESCRIPTION
# Apply `agentOverrides` to user/project custom agents (frontmatter wins per field)

Fixes nicobailon/pi-subagents#218.

## What this changes

`subagents.agentOverrides.<name>` now resolves against any agent with a matching name — user-scope, project-scope, or builtin. Previously it resolved only against builtins; matches against custom agents were silently dropped.

One safety rule for custom agents: **frontmatter wins per-field**. The override fills only fields the agent's frontmatter left unset. Builtins continue to behave exactly as before because they ship with no frontmatter values, so per-field fill-in collapses to the existing overwrite behavior.

## Why

Detailed motivation in the linked issue. The short version: teams ship a custom persona in `.pi/agents/<name>.md` so the prompt is shared and version-controlled, while individual developers run different Pi distributions (direct Anthropic, Bedrock, ...) whose model identifiers differ. There's no clean way today to keep the persona body shared and let each harness pick its own model — `agentOverrides` looks like it should do exactly that, but doesn't reach custom agents.

## Implementation

Single source file: `src/agents/agents.ts`. New helpers, sibling to the existing `applyBuiltinOverride` / `applyBuiltinOverrides`:

```ts
function applyCustomAgentOverride(agent, override, meta): AgentConfig {
    // For each field: if override sets it AND agent's frontmatter didn't, fill it in.
    // If frontmatter set it, keep frontmatter.
    // If override matched but didn't fill anything, return the original agent unchanged
    // (so the `override` annotation stays absent, matching existing test semantics).
}

function applyCustomAgentOverrides(agents, userSettings, projectSettings, ...): AgentConfig[] {
    // Per-agent: project override (if project settings.json exists) wins over user override.
    // Same precedence as builtin path.
}
```

Wired into both discovery entry points:

```diff
-const userAgents = [...userAgentsOld, ...userAgentsNew];
-const projectAgents = scope === "user" ? [] : projectAgentDirs.flatMap(...);
+const userAgents = applyCustomAgentOverrides([...userAgentsOld, ...userAgentsNew], ...);
+const projectAgents = applyCustomAgentOverrides(
+    scope === "user" ? [] : projectAgentDirs.flatMap(...),
+    ...,
+);
```

`disableBuiltins` deliberately stays out of the custom path — bulk-disabling builtins shouldn't bulk-disable a user's hand-written agents.

The helper name `applyBuiltinOverrides` is now slightly misleading since a sibling function does the same for non-builtins. A rename (`applyAgentOverridesBuiltin` / `applyAgentOverridesCustom`, or merging the two) is a clean follow-up; kept out of this PR to keep the diff focused on behavior.

## Behavior summary

| Agent shape | `agentOverrides[name]` entry | Before | After |
|---|---|---|---|
| Builtin, no override | — | bundled defaults | unchanged |
| Builtin, override matches | sets `model` | override applied | unchanged |
| Custom agent, no override entry | — | as-loaded | unchanged |
| Custom agent, override matches, frontmatter has the field | sets `model` | override silently dropped | unchanged — frontmatter still wins |
| Custom agent, override matches, frontmatter left field unset | sets `model` | override silently dropped, falls through to `defaultModel` | **override now applied** |
| Custom agent + `disableBuiltins: true` | — | custom agent unaffected | unchanged |

Only the bold row is new behavior.

## Tests

6 new unit tests in `test/unit/agent-overrides.test.ts`:

- `fills in unset fields on a custom project agent from project agentOverrides`
- `fills in unset fields on a custom user agent from user agentOverrides`
- `applies user agentOverrides to a custom project agent when project settings have no entry`
- `prefers project agentOverrides over user agentOverrides on a custom project agent`
- `leaves a custom agent untouched when no agentOverrides entry matches its name`
- `disableBuiltins does not disable custom agents`

The pre-existing test asserting "frontmatter wins when a project agent shadows a builtin" stays green; renamed to `frontmatter wins per-field over agentOverrides for a shadowing project agent` to spell out the rule that's now generalized.

All 19 tests in `agent-overrides.test.ts` pass. Pre-existing failures in unrelated test files (`fork-context`, `nested-control`, `render-helpers`, `widget-nested-render`) are identical before and after this PR — verified with `git stash; git checkout main; node --test ...` and back.

## Test isolation caveat

`agent-overrides.test.ts` resets `HOME` per-test but doesn't unset `PI_CODING_AGENT_DIR`. If a developer has that env var pointing to a real `~/.pi/agent.*/settings.json` with `agentOverrides` entries (typical when running tests from inside a Pi session), several existing tests fail because the suite reads real config instead of the temp fixture. Workaround:

```bash
env -u PI_CODING_AGENT_DIR node --test test/unit/agent-overrides.test.ts
```

All 19 pass under that invocation. Worth tightening `beforeEach` to also clear `PI_CODING_AGENT_DIR`, but I left it out of this PR — it's an orthogonal cleanup and would muddy the diff.

## CHANGELOG

Entry added under `[Unreleased] / Added`:

> Apply `subagents.agentOverrides[name]` to user-scope and project-scope custom agents in addition to builtins. Frontmatter wins per-field — overrides only fill fields the agent's frontmatter left unset, so existing custom agents that pin their own model/thinking/etc. are unaffected. Lets shared persona files (`.pi/agents/<name>.md`) stay version-controlled while per-harness `settings.json` supplies the local model. `disableBuiltins` continues to apply only to builtins.

Happy to move it under `Changed` or `Fixed` if you prefer — the behavior change is small enough that all three are defensible.

## Out of scope

- Renaming `applyBuiltinOverrides` → `applyAgentOverridesBuiltin` (mechanical follow-up).
- Warning the user when an `agentOverrides[name]` entry matches zero agents anywhere.
- Tightening `beforeEach` in `agent-overrides.test.ts` to clear `PI_CODING_AGENT_DIR`.

Each is small and unrelated; happy to send separate PRs.

## Verification

Reproduced locally against a real project-scope custom agent (`gridstrong/.pi/agents/implementer.md`, no `model:` in frontmatter) with a user-scope `agentOverrides.implementer.model = "anthropic/claude-sonnet-4-6"`.

**Before:** `discoverAgents(...)` returns `{ source: "project", model: undefined, override: undefined }`, subagent dispatch runs on `claude-opus-4-7` (the default).

**After:** `discoverAgents(...)` returns `{ source: "project", model: "anthropic/claude-sonnet-4-6", override: { scope: "user", ... } }`, subagent dispatch runs on `claude-sonnet-4-6`. Builtin overrides for `worker`/`reviewer` continue to apply identically.
