### PR TITLE
Show model badges in compact multi-result view

### DIFF
--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1024,7 +1024,8 @@ function renderMultiCompact(d: Details, theme: Theme): Component {
 		const glyph = rPending ? theme.fg("dim", "◦") : resultGlyph(r, output, theme, rRunning, progressRunningSeed(rProg));
 		const pendingLabel = rPending ? ` ${theme.fg("dim", "· pending")}` : "";
 		const stepLabel = resultRowLabel(d, multiLabel, i, stepNumber);
-		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
+		const modelDisplay = modelThinkingBadge(theme, r.model);
+		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${modelDisplay}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
 		c.addChild(new Text(truncLine(`  ${line}`, width), 0, 0));
 		if (rRunning && rProg && "status" in rProg) {
 			const activity = compactCurrentActivity(rProg);


### PR DESCRIPTION
Fixes #222.

## What changed
- add `modelThinkingBadge(theme, r.model)` to `renderMultiCompact()` row rendering
- keep compact multi-result output consistent with single compact and expanded multi-result views

## Why
Parallel/chain compact view was the only place that omitted the subagent model badge, which made it hard to see which model each child run used at a glance.

## Validation
- manually verified locally in compact parallel/chain rendering
- confirmed each row now shows the model badge, e.g. `reviewer (claude-sonnet-4-6)`