### PR TITLE
Make default output paths unique and authoritative across all run modes

### DIFF
--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -7,7 +7,7 @@ systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
 output: research.md
-defaultProgress: true
+defaultProgress: false
 ---
 
 You are a research subagent.

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -7,7 +7,7 @@ systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
 output: context.md
-defaultProgress: true
+defaultProgress: false
 ---
 
 You are a scouting subagent running inside pi.

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -8,7 +8,7 @@ inheritSkills: false
 tools: read, grep, find, ls, bash, edit, write, contact_supervisor
 defaultContext: fork
 defaultReads: context.md, plan.md
-defaultProgress: true
+defaultProgress: false
 ---
 
 You are `worker`: the implementation subagent.

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -19,7 +19,7 @@ const OutputOverride = Type.Unsafe({
 		{ type: "string" },
 		{ type: "boolean" },
 	],
-	description: "Output filename/path (string), or false to disable file output",
+	description: "Output filename/path (string), or false to disable file output. If explicitly setting a path, prefer an absolute /tmp/... path; omit output to use the agent default auto-unique output path.",
 });
 
 const OutputModeOverride = Type.String({
@@ -160,7 +160,7 @@ export const SubagentParams = Type.Object({
 			{ type: "string" },
 			{ type: "boolean" },
 		],
-		description: "Output file for single agent (string), or false to disable. Relative paths resolve against cwd.",
+		description: "Output file for single agent (string), or false to disable. If explicitly setting a path, prefer an absolute /tmp/... path; relative paths resolve against cwd and may write into the current/home directory. Omit output to use the agent default auto-unique output path.",
 	})),
 	outputMode: Type.Optional(OutputModeOverride),
 	skill: Type.Optional(SkillOverride),

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -19,7 +19,7 @@ const OutputOverride = Type.Unsafe({
 		{ type: "string" },
 		{ type: "boolean" },
 	],
-	description: "Output filename/path (string), or false to disable file output. If explicitly setting a path, prefer an absolute /tmp/... path; omit output to use the agent default auto-unique output path.",
+	description: "Output filename/path (string), or false to disable file output. Prefer explicit, descriptive output filenames so results are easy to identify; use absolute /tmp/... paths (not relative paths) for explicit outputs.",
 });
 
 const OutputModeOverride = Type.String({
@@ -160,7 +160,7 @@ export const SubagentParams = Type.Object({
 			{ type: "string" },
 			{ type: "boolean" },
 		],
-		description: "Output file for single agent (string), or false to disable. If explicitly setting a path, prefer an absolute /tmp/... path; relative paths resolve against cwd and may write into the current/home directory. Omit output to use the agent default auto-unique output path.",
+		description: "Output file for single agent (string), or false to disable. Prefer explicit, descriptive output filenames so results are easy to identify; use absolute /tmp/... paths (not relative paths) for explicit outputs because relative paths resolve against cwd and may write into the current/home directory.",
 	})),
 	outputMode: Type.Optional(OutputModeOverride),
 	skill: Type.Optional(SkillOverride),

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -11,7 +11,7 @@ import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { applyThinkingSuffix } from "../shared/pi-args.ts";
-import { injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
+import { injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode, buildUniqueOutputPath } from "../shared/single-output.ts";
 import { buildChainInstructions, isParallelStep, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
@@ -312,7 +312,13 @@ export function executeAsyncChain(
 		const readInstructions = buildChainInstructions({ ...behavior, output: false, progress: false }, instructionCwd, false);
 		const isFirstProgressAgent = behavior.progress && !progressPrecreated && !progressInstructionCreated;
 		if (behavior.progress) progressInstructionCreated = true;
-		const progressInstructions = buildChainInstructions({ ...behavior, output: false, reads: false }, runnerCwd, isFirstProgressAgent);
+		// Progress uses output dir when output comes from agent default
+		const progressCwd = (behavior.output && s.output === undefined) ? path.dirname(behavior.output) : runnerCwd;
+		const progressInstructions = buildChainInstructions({ ...behavior, output: false, reads: false }, progressCwd, isFirstProgressAgent);
+		// Add unique suffix when output comes from agent default, not step override
+		if (behavior.output && s.output === undefined) {
+			behavior.output = buildUniqueOutputPath(behavior.output, id, 0);
+		}
 		const outputPath = resolveSingleOutputPath(behavior.output, ctx.cwd, instructionCwd);
 		const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Async step (${s.agent})`);
 		if (validationError) throw new AsyncStartValidationError(validationError);
@@ -580,7 +586,10 @@ export function executeAsyncSingle(
 		};
 	}
 
-	const effectiveOutput = normalizeSingleOutputOverride(params.output, agentConfig.output);
+	let effectiveOutput = normalizeSingleOutputOverride(params.output, agentConfig.output);
+	if (effectiveOutput && params.output === undefined) {
+		effectiveOutput = buildUniqueOutputPath(effectiveOutput, id, 0);
+	}
 	const outputPath = resolveSingleOutputPath(effectiveOutput, ctx.cwd, runnerCwd);
 	const outputMode = params.outputMode ?? "inline";
 	const validationError = validateFileOnlyOutputMode(outputMode, outputPath, `Async single run (${agent})`);

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -11,7 +11,7 @@ import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { applyThinkingSuffix } from "../shared/pi-args.ts";
-import { injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode, buildUniqueOutputPath } from "../shared/single-output.ts";
+import { injectOutputPathSystemPrompt, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode, buildUniqueOutputPath } from "../shared/single-output.ts";
 import { buildChainInstructions, isParallelStep, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
@@ -321,6 +321,7 @@ export function executeAsyncChain(
 			behavior.output = buildUniqueOutputPath(behavior.output, id, outputIndex);
 		}
 		const outputPath = resolveSingleOutputPath(behavior.output, ctx.cwd, instructionCwd);
+		systemPrompt = injectOutputPathSystemPrompt(systemPrompt, outputPath);
 		const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Async step (${s.agent})`);
 		if (validationError) throw new AsyncStartValidationError(validationError);
 		const task = injectSingleOutputInstruction(`${readInstructions.prefix}${s.task ?? "{previous}"}${progressInstructions.suffix}`, outputPath);
@@ -594,6 +595,7 @@ export function executeAsyncSingle(
 		effectiveOutput = buildUniqueOutputPath(effectiveOutput, id, 0);
 	}
 	const outputPath = resolveSingleOutputPath(effectiveOutput, ctx.cwd, runnerCwd);
+	systemPrompt = injectOutputPathSystemPrompt(systemPrompt, outputPath);
 	const outputMode = params.outputMode ?? "inline";
 	const validationError = validateFileOnlyOutputMode(outputMode, outputPath, `Async single run (${agent})`);
 	if (validationError) return formatAsyncStartError("single", validationError);

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -130,6 +130,7 @@ interface AsyncSingleParams {
 	sessionFile?: string;
 	skills?: string[];
 	output?: string | boolean;
+	outputFromAgentDefault?: boolean;
 	outputMode?: "inline" | "file-only";
 	modelOverride?: string;
 	availableModels?: AvailableModelInfo[];
@@ -294,7 +295,7 @@ export function executeAsyncChain(
 			...(s.model ? { model: s.model } : {}),
 		};
 	};
-	const buildSeqStep = (s: SequentialStep, sessionFile?: string, behaviorCwd?: string, progressPrecreated = false, resolvedBehavior?: ResolvedStepBehavior) => {
+	const buildSeqStep = (s: SequentialStep, sessionFile?: string, behaviorCwd?: string, progressPrecreated = false, resolvedBehavior?: ResolvedStepBehavior, outputIndex = 0) => {
 		const a = agents.find((x) => x.name === s.agent)!;
 		const stepCwd = resolveChildCwd(runnerCwd, s.cwd);
 		const instructionCwd = behaviorCwd ?? stepCwd;
@@ -317,7 +318,7 @@ export function executeAsyncChain(
 		const progressInstructions = buildChainInstructions({ ...behavior, output: false, reads: false }, progressCwd, isFirstProgressAgent);
 		// Add unique suffix when output comes from agent default, not step override
 		if (behavior.output && s.output === undefined) {
-			behavior.output = buildUniqueOutputPath(behavior.output, id, 0);
+			behavior.output = buildUniqueOutputPath(behavior.output, id, outputIndex);
 		}
 		const outputPath = resolveSingleOutputPath(behavior.output, ctx.cwd, instructionCwd);
 		const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Async step (${s.agent})`);
@@ -381,14 +382,16 @@ export function executeAsyncChain(
 								behaviorCwd = undefined;
 							}
 						}
-						return buildSeqStep(t, nextSessionFile(), behaviorCwd, progressPrecreated, parallelBehaviors[taskIndex]);
+						const outputIndex = flatStepIndex;
+						return buildSeqStep(t, nextSessionFile(), behaviorCwd, progressPrecreated, parallelBehaviors[taskIndex], outputIndex);
 					}),
 					concurrency: s.concurrency,
 					failFast: s.failFast,
 					worktree: s.worktree,
 				};
 			}
-			return buildSeqStep(s as SequentialStep, nextSessionFile());
+			const outputIndex = flatStepIndex;
+			return buildSeqStep(s as SequentialStep, nextSessionFile(), undefined, false, undefined, outputIndex);
 		});
 	} catch (error) {
 		if (error instanceof UnavailableSubagentSkillError || error instanceof AsyncStartValidationError) return formatAsyncStartError(resultMode, error.message);
@@ -587,7 +590,7 @@ export function executeAsyncSingle(
 	}
 
 	let effectiveOutput = normalizeSingleOutputOverride(params.output, agentConfig.output);
-	if (effectiveOutput && params.output === undefined) {
+	if (effectiveOutput && params.outputFromAgentDefault) {
 		effectiveOutput = buildUniqueOutputPath(effectiveOutput, id, 0);
 	}
 	const outputPath = resolveSingleOutputPath(effectiveOutput, ctx.cwd, runnerCwd);

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -397,7 +397,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 	const chainDir = createChainDir(runId, chainDirBase);
 	const hasParallelSteps = chainSteps.some(isParallelStep);
 	let templates: ResolvedTemplates = resolveChainTemplates(chainSteps);
-	const shouldClarify = clarify !== false && ctx.hasUI && !hasParallelSteps;
+	const shouldClarify = clarify === true && ctx.hasUI && !hasParallelSteps;
 	let tuiBehaviorOverrides: (BehaviorOverride | undefined)[] | undefined;
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const availableSkills = discoverAvailableSkills(cwd ?? ctx.cwd);

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -58,7 +58,7 @@ import {
 	resolveChildMaxSubagentDepth,
 } from "../../shared/types.ts";
 import { resolveModelCandidate } from "../shared/model-fallback.ts";
-import { validateFileOnlyOutputMode } from "../shared/single-output.ts";
+import { buildUniqueOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 
 interface ChainExecutionDetailsInput {
 	results: SingleResult[];
@@ -544,6 +544,12 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				const agentNames = step.parallel.map((task) => task.agent);
 				const parallelBehaviors = resolveParallelBehaviors(step.parallel, agents, stepIndex, chainSkills)
 					.map((behavior, taskIndex) => suppressProgressForReadOnlyTask(behavior, parallelTemplates[taskIndex] ?? step.parallel[taskIndex]?.task, originalTask));
+				for (let taskIndex = 0; taskIndex < parallelBehaviors.length; taskIndex++) {
+					const behavior = parallelBehaviors[taskIndex]!;
+					if (behavior.output && step.parallel[taskIndex]?.output === undefined) {
+						behavior.output = buildUniqueOutputPath(behavior.output, runId, globalTaskIndex + taskIndex);
+					}
+				}
 				for (let taskIndex = 0; taskIndex < step.parallel.length; taskIndex++) {
 					const behavior = parallelBehaviors[taskIndex]!;
 					const outputPath = typeof behavior.output === "string"
@@ -720,6 +726,9 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 						: normalizeSkillInput(seqStep.skill),
 			};
 			const behavior = suppressProgressForReadOnlyTask(resolveStepBehavior(agentConfig, stepOverride, chainSkills), stepTemplate, originalTask);
+			if (behavior.output && stepOverride.output === undefined) {
+				behavior.output = buildUniqueOutputPath(behavior.output, runId, globalTaskIndex);
+			}
 
 			const isFirstProgress = behavior.progress && !progressCreated;
 			if (isFirstProgress) {

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -46,7 +46,7 @@ import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir } from "../shared/pi-args.ts";
-import { captureSingleOutputSnapshot, formatSavedOutputReference, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
+import { captureSingleOutputSnapshot, formatSavedOutputReference, injectOutputPathSystemPrompt, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
 import {
 	buildModelCandidates,
 	formatModelAttemptNote,
@@ -783,6 +783,7 @@ export async function runSync(
 		const skillInjection = buildSkillInjection(resolvedSkills);
 		systemPrompt = systemPrompt ? `${systemPrompt}\n\n${skillInjection}` : skillInjection;
 	}
+	systemPrompt = injectOutputPathSystemPrompt(systemPrompt, options.outputPath);
 
 	const candidates = buildModelCandidates(
 		options.modelOverride ?? agent.model,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1078,7 +1078,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			cwd: task.cwd,
 			...(modelOverrides[index] ? { model: modelOverrides[index] } : {}),
 			...(skillOverrides[index] !== undefined ? { skill: skillOverrides[index] } : {}),
-			...(task.output === true ? (agentConfigs[index]?.output ? { output: agentConfigs[index]!.output } : {}) : task.output !== undefined ? { output: task.output } : {}),
+			...(task.output !== undefined && task.output !== true ? { output: task.output } : {}),
 			...(task.outputMode !== undefined ? { outputMode: task.outputMode } : {}),
 			...(task.reads !== undefined && task.reads !== true ? { reads: task.reads } : {}),
 			...(task.progress !== undefined ? { progress: task.progress } : {}),
@@ -1148,6 +1148,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 				details: { mode: "single" as const, results: [] },
 			};
 		}
+		const outputFromAgentDefault = params.output === undefined || params.output === true;
 		const rawOutput = params.output !== undefined ? params.output : a.output;
 		const effectiveOutput = normalizeSingleOutputOverride(rawOutput, a.output);
 		const effectiveOutputMode = params.outputMode ?? "inline";
@@ -1170,6 +1171,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			sessionFile: sessionFileForIndex(0),
 			skills,
 			output: effectiveOutput,
+			outputFromAgentDefault,
 			outputMode: effectiveOutputMode,
 			modelOverride,
 			maxSubagentDepth,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -35,7 +35,7 @@ import { createForkContextResolver } from "../../shared/fork-context.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBridge, resolveIntercomSessionTarget, resolveSubagentIntercomTarget, type IntercomBridgeState } from "../../intercom/intercom-bridge.ts";
 import { formatControlIntercomMessage, formatControlNoticeMessage, resolveControlConfig, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
-import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
+import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode, buildUniqueOutputPath } from "../shared/single-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, readStatus, resolveChildCwd } from "../../shared/utils.ts";
 import {
 	attachNestedChildrenToResultChildren,
@@ -1318,6 +1318,7 @@ interface ForegroundParallelRunInput {
 	artifactsDir: string;
 	maxOutput?: MaxOutputConfig;
 	paramsCwd: string;
+	progressDir?: string;
 	maxSubagentDepths: number[];
 	availableModels: ModelInfo[];
 	modelOverrides: (string | undefined)[];
@@ -1442,8 +1443,9 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		const readInstructions = behavior
 			? buildChainInstructions({ ...behavior, output: false, progress: false }, taskCwd, false)
 			: { prefix: "", suffix: "" };
+		const progressCwd = input.progressDir ?? input.paramsCwd;
 		const progressInstructions = behavior
-			? buildChainInstructions({ ...behavior, output: false, reads: false }, input.paramsCwd, index === input.firstProgressIndex)
+			? buildChainInstructions({ ...behavior, output: false, reads: false }, progressCwd, index === input.firstProgressIndex)
 			: { prefix: "", suffix: "" };
 		const outputPath = resolveSingleOutputPath(behavior?.output, input.ctx.cwd, taskCwd);
 		const taskText = injectSingleOutputInstruction(
@@ -1707,6 +1709,13 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 	}
 
 	const behaviors = agentConfigs.map((config, index) => suppressProgressForReadOnlyTask(resolveStepBehavior(config, behaviorOverrides[index]!), taskTexts[index]));
+	// Add unique suffix to agent-default outputs (not task-level overrides) to prevent parallel collisions
+	for (let i = 0; i < behaviors.length; i++) {
+		const b = behaviors[i];
+		if (b.output && (tasks[i]!.output === undefined || tasks[i]!.output === true)) {
+			b.output = buildUniqueOutputPath(b.output, runId, i);
+		}
+	}
 	const firstProgressIndex = behaviors.findIndex((behavior) => behavior.progress);
 	const liveResults: (SingleResult | undefined)[] = new Array(tasks.length).fill(undefined);
 	const liveProgress: (AgentProgress | undefined)[] = new Array(tasks.length).fill(undefined);
@@ -1738,7 +1747,13 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		}
 
 		const parallelProgressPrecreated = firstProgressIndex !== -1;
-		if (parallelProgressPrecreated) writeInitialProgressFile(effectiveCwd);
+		const progressAgent = behaviors.find((b) => b.progress);
+		const progressOutputDir = progressAgent?.output ? path.dirname(progressAgent.output) : effectiveCwd;
+		const parallelProgressDir = progressOutputDir === effectiveCwd ? effectiveCwd : path.join(progressOutputDir, `.progress_${runId}`);
+		if (parallelProgressPrecreated) {
+			if (parallelProgressDir !== effectiveCwd) fs.mkdirSync(parallelProgressDir, { recursive: true });
+			writeInitialProgressFile(parallelProgressDir);
+		}
 
 		if (params.context === "fork") {
 			for (let i = 0; i < taskTexts.length; i++) {
@@ -1761,6 +1776,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			artifactsDir,
 			maxOutput: params.maxOutput,
 			paramsCwd: effectiveCwd,
+			progressDir: parallelProgressDir,
 			availableModels,
 			modelOverrides,
 			behaviors,
@@ -1895,6 +1911,10 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
 	const rawOutput = params.output !== undefined ? params.output : agentConfig.output;
 	let effectiveOutput = normalizeSingleOutputOverride(rawOutput, agentConfig.output);
+	// When output comes from agent default (not task override), add unique suffix
+	if (effectiveOutput && params.output === undefined) {
+		effectiveOutput = buildUniqueOutputPath(effectiveOutput, runId, 0);
+	}
 	const effectiveOutputMode = params.outputMode ?? "inline";
 	const currentMaxSubagentDepth = resolveCurrentMaxSubagentDepth(deps.config.maxSubagentDepth);
 	const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, agentConfig.maxSubagentDepth);

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -84,7 +84,7 @@ function stripFrameworkInstructions(task: string): string {
 	return task
 		.split("\n")
 		.filter((line) => !/^\s*\[(?:Write to|Read from):/i.test(line))
-		.filter((line) => !/^\s*(?:Create and maintain progress at:|Update progress at:|Write your findings to:)/i.test(line))
+		.filter((line) => !/^\s*(?:Create and maintain progress at:|Update progress at:|\*\*Output:\*\*|Runtime output path override:|Write your findings to(?: exactly this path)?:|This path is authoritative for this run\.|Ignore any other filename mentioned elsewhere)/i.test(line))
 		.join("\n");
 }
 

--- a/src/runs/shared/single-output.ts
+++ b/src/runs/shared/single-output.ts
@@ -31,9 +31,23 @@ export function resolveSingleOutputPath(
 	return path.resolve(baseCwd, output);
 }
 
+function formatOutputPathInstruction(outputPath: string): string {
+	return [
+		`Write your findings to exactly this path: ${outputPath}`,
+		"This path is authoritative for this run.",
+		"Ignore any other filename mentioned elsewhere, including filenames in the base agent prompt, system prompt, or task instructions.",
+	].join("\n");
+}
+
 export function injectSingleOutputInstruction(task: string, outputPath: string | undefined): string {
 	if (!outputPath) return task;
-	return `${task}\n\n---\n**Output:** Write your findings to: ${outputPath}`;
+	return `${task}\n\n---\n**Output:**\n${formatOutputPathInstruction(outputPath)}`;
+}
+
+export function injectOutputPathSystemPrompt(systemPrompt: string, outputPath: string | undefined): string {
+	if (!outputPath) return systemPrompt;
+	const instruction = `Runtime output path override:\n${formatOutputPathInstruction(outputPath)}`;
+	return systemPrompt ? `${systemPrompt}\n\n${instruction}` : instruction;
 }
 
 function countLines(text: string): number {

--- a/src/runs/shared/single-output.ts
+++ b/src/runs/shared/single-output.ts
@@ -54,6 +54,13 @@ function formatByteSize(bytes: number): string {
 	return `${value.toFixed(1)} ${units[unitIndex]}`;
 }
 
+export function buildUniqueOutputPath(outputPath: string, runId: string, index: number): string {
+	const dir = path.dirname(outputPath);
+	const ext = path.extname(outputPath);
+	const base = path.basename(outputPath, ext);
+	return path.join(dir, `${base}_${runId}_${index}${ext}`);
+}
+
 export function formatSavedOutputReference(savedPath: string, fullOutput: string): SavedOutputReference {
 	const absolutePath = path.resolve(savedPath);
 	const bytes = Buffer.byteLength(fullOutput, "utf-8");

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -133,7 +133,7 @@ export function clearLegacyResultAnimationTimer(context: LegacyResultAnimationCo
 function extractOutputTarget(task: string): string | undefined {
 	const writeToMatch = task.match(/\[Write to:\s*([^\]\n]+)\]/i);
 	if (writeToMatch?.[1]?.trim()) return writeToMatch[1].trim();
-	const findingsMatch = task.match(/Write your findings to:\s*(\S+)/i);
+	const findingsMatch = task.match(/Write your findings to(?: exactly this path)?:\s*(\S+)/i);
 	if (findingsMatch?.[1]?.trim()) return findingsMatch[1].trim();
 	const outputMatch = task.match(/[Oo]utput(?:\s+to)?\s*:\s*(\S+)/i);
 	if (outputMatch?.[1]?.trim()) return outputMatch[1].trim();

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1024,7 +1024,8 @@ function renderMultiCompact(d: Details, theme: Theme): Component {
 		const glyph = rPending ? theme.fg("dim", "◦") : resultGlyph(r, output, theme, rRunning, progressRunningSeed(rProg));
 		const pendingLabel = rPending ? ` ${theme.fg("dim", "· pending")}` : "";
 		const stepLabel = resultRowLabel(d, multiLabel, i, stepNumber);
-		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
+		const modelDisplay = modelThinkingBadge(theme, r.model);
+		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${modelDisplay}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
 		c.addChild(new Text(truncLine(`  ${line}`, width), 0, 0));
 		if (rRunning && rProg && "status" in rProg) {
 			const activity = compactCurrentActivity(rProg);

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -310,7 +310,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const taskArg = args.at(-1) ?? "";
 		assert.ok(taskArg.includes(`[Read from: ${path.join(tempDir, "input.md")}]`));
 		assert.ok(taskArg.includes(`Update progress at: ${path.join(tempDir, "progress.md")}`));
-		assert.ok(taskArg.includes(`Write your findings to: ${outputPath}`));
+		assert.ok(taskArg.includes(`Write your findings to exactly this path: ${outputPath}`));
 		assert.equal(fs.existsSync(path.join(tempDir, "progress.md")), true);
 	});
 
@@ -405,7 +405,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			const args = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
 			const taskArg = args.at(-1) ?? "";
 			assert.ok(taskArg.includes(`[Read from: ${path.join(worktreeCwd, "input.md")}]`));
-			assert.ok(taskArg.includes(`Write your findings to: ${path.join(worktreeCwd, "report.md")}`));
+			assert.ok(taskArg.includes(`Write your findings to exactly this path: ${path.join(worktreeCwd, "report.md")}`));
 		} finally {
 			removeTempDir(repoDir);
 		}
@@ -725,7 +725,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.doesNotMatch(payload.summary ?? "", /Output saved to:/);
 		assert.equal(fs.existsSync(path.join(tempDir, "false")), false);
 		assert.equal(fs.existsSync(path.join(tempDir, "default-report.md")), false);
-		assert.doesNotMatch(readLastMockPiArgs(mockPi).at(-1) ?? "", /Write your findings to:/);
+		assert.doesNotMatch(readLastMockPiArgs(mockPi).at(-1) ?? "", /Write your findings to(?: exactly this path)?:/);
 	});
 
 	it("background runs detect hidden tool failures even when the child exits 0", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -901,7 +901,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.doesNotMatch(result.content[0]?.text ?? "", /Output saved to:/);
 		assert.equal(fs.existsSync(path.join(tempDir, "false")), false);
 		assert.equal(fs.existsSync(path.join(tempDir, "default-report.md")), false);
-		assert.doesNotMatch(readCallArgs().at(-1) ?? "", /Write your findings to:/);
+		assert.doesNotMatch(readCallArgs().at(-1) ?? "", /Write your findings to(?: exactly this path)?:/);
 	});
 
 	it("rejects file-only mode without an output path before spawning", async () => {

--- a/test/unit/single-output.test.ts
+++ b/test/unit/single-output.test.ts
@@ -76,7 +76,9 @@ describe("resolveSingleOutputPath", () => {
 describe("injectSingleOutputInstruction", () => {
 	it("appends output instruction with resolved path", () => {
 		const output = injectSingleOutputInstruction("Analyze this", "/tmp/report.md");
-		assert.match(output, /Write your findings to: \/tmp\/report.md/);
+		assert.match(output, /Write your findings to exactly this path: \/tmp\/report.md/);
+		assert.match(output, /This path is authoritative for this run\./);
+		assert.match(output, /Ignore any other filename mentioned elsewhere/);
 	});
 });
 


### PR DESCRIPTION
## Summary

This PR fixes several output-path and UI issues across foreground, async, parallel, and chain subagent execution paths.

It makes runtime output paths authoritative and unique when they come from agent defaults, while preserving exact user-specified output paths.

## Fixes

### 1. Prevent output collisions for default agent outputs

When an agent default output path is used, the runtime now appends a unique suffix:

```txt
/tmp/research.md -> /tmp/research_<runId>_<index>.md
```

This prevents multiple subagents from writing to the same file in parallel/chain runs.

Covered paths:

- foreground single
- foreground top-level parallel
- foreground chain sequential steps
- foreground chain parallel steps
- async single
- async chain
- async parallel

Explicit user output paths remain exact and are not modified:

```ts
subagent({ agent: "researcher", output: "/tmp/custom.md", task: "..." })
```

### 2. Fix async parallel index collision

Previously, async parallel default outputs all used index `0`, causing two researchers to write to the same file:

```txt
/tmp/research_<runId>_0.md
/tmp/research_<runId>_0.md
```

This PR passes the real flat step index, producing:

```txt
/tmp/research_<runId>_0.md
/tmp/research_<runId>_1.md
```

### 3. Fix async single default-output suffixing

Async single runs pre-normalized the output before calling `executeAsyncSingle`, so the lower layer could not tell whether the path came from an agent default or an explicit user override.

This PR adds an `outputFromAgentDefault` flag so async single can suffix default outputs correctly without changing explicit outputs.

### 4. Make runtime output paths authoritative in prompts

Agent prompts may mention static filenames such as `research.md`, `context.md`, or `plan.md`. Runtime-generated paths must override these static filenames.

This PR strengthens task output instructions from:

```md
**Output:** Write your findings to: /tmp/research_xxx_0.md
```

to:

```md
**Output:**
Write your findings to exactly this path: /tmp/research_xxx_0.md
This path is authoritative for this run.
Ignore any other filename mentioned elsewhere, including filenames in the base agent prompt, system prompt, or task instructions.
```

It also injects the same runtime output override into the child system prompt, so the system prompt and task prompt agree on the authoritative output path.

### 5. Disable default progress files for built-in writer agents

The built-in `researcher`, `scout`, and `worker` agents now set:

```yaml
defaultProgress: false
```

This avoids automatic progress file creation unless the caller explicitly asks for progress.

### 6. Disable chain clarify UI by default

Sequential foreground chains previously opened the clarify UI by default. This PR changes chain clarify behavior so the UI only opens when explicitly requested:

```ts
clarify: true
```

Default behavior now matches single/parallel runs: execute directly unless clarify is requested.

### 7. Show model badge in compact multi-result view

Compact multi-result rendering now includes the model/thinking badge for each result row.

## Validation

Manual validation performed locally:

- foreground parallel with 3 researchers created unique files:
  - `/tmp/research_<runId>_0.md`
  - `/tmp/research_<runId>_1.md`
  - `/tmp/research_<runId>_2.md`
- async parallel with 2 researchers now injects and saves to `_0.md` and `_1.md` respectively
- async single now injects and saves to `_0.md`
- foreground chain no longer opens clarify UI by default
- foreground chain step 1 wrote to `_0.md`, and step 2 received `_1.md` in its task instructions
- task prompt contains authoritative output instruction
- system prompt injection path is wired through foreground `runSync` and async step construction
- TypeScript syntax checks passed for changed files

## Notes

This PR intentionally preserves backwards compatibility:

- explicit `output` paths are used exactly as provided
- `output: false` disables output
- `output: true` means “use the agent default” and receives the runtime suffix
