### PR TITLE
fix: resolve subagent context per agent defaultContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ AGENTS.md
 node_modules/
 .fallow/
 
+context.md
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-05-28
+
+### Changed
+- Updated the local pi development baseline to `@earendil-works/*` `0.77.0` in package metadata.
+- Declared all pi-bundled runtime packages (`@earendil-works/pi-*`, `typebox`) as optional wildcard peers and kept them only as development dependencies, so npm peer ranges do not block future pi releases.
+- Added explicit `subagent` tool prompt snippet/guidelines so Pi 0.77+ tool metadata attribution has concise delegation guidance separate from the full schema description.
+- Switched the local TypeScript test loader to `jiti` so validation does not depend on Node's removed `--experimental-transform-types` flag on newer Node releases.
+
 ## [0.25.0] - 2026-05-21
 
 ### Added

--- a/docs/upstream-issue-per-agent-context.md
+++ b/docs/upstream-issue-per-agent-context.md
@@ -1,0 +1,45 @@
+# Issue: Whole-invocation fork promotion ignores per-agent `defaultContext: fresh`
+
+## Summary
+
+When `context` is omitted on a `subagent(...)` call, pi-subagents currently promotes the **entire** invocation to `fork` if **any** requested agent has `defaultContext: "fork"`.
+
+That causes read-only agents configured with `defaultContext: fresh` (for example `scout`, `reviewer`) to inherit the full parent transcript when batched with `worker` or `oracle` in parallel or chain mode.
+
+## Reproduction
+
+1. Configure `scout` with `defaultContext: fresh`.
+2. Configure `worker` with `defaultContext: fork`.
+3. Run parallel subagent call without explicit `context`:
+
+```json
+{
+  "tasks": [
+    { "agent": "scout", "task": "Find relevant files" },
+    { "agent": "worker", "task": "Implement fix" }
+  ]
+}
+```
+
+4. Observe both tasks run with forked/inherited parent context.
+
+Root cause: `applyAgentDefaultContext()` in `src/runs/foreground/subagent-executor.ts`.
+
+## Expected behavior
+
+When caller omits top-level `context`:
+
+- Each agent/task/step should use **its own** `defaultContext`.
+- Explicit `context: "fresh"` or `context: "fork"` should override all agents in that call.
+- Parallel scout + worker should fork only the worker task, not the scout.
+
+## Proposed fix
+
+- Remove whole-invocation fork promotion.
+- Resolve context per flat task index via agent `defaultContext`.
+- Fork session files and `wrapForkTask()` only for indices whose resolved context is `fork`.
+- Update tool docs/schema descriptions accordingly.
+
+## Impact
+
+Users relying on implicit whole-invocation fork when mixing fork-default and fresh-default agents in one call would need to pass explicit `context: "fork"` for that behavior.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-subagents",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Pi extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification",
   "author": "Nico Bailon",
   "license": "MIT",
@@ -36,8 +36,8 @@
   ],
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "node --experimental-strip-types --test test/unit/*.test.ts",
-    "test:integration": "node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/*.test.ts",
+    "test:unit": "node --import jiti/register --test test/unit/*.test.ts",
+    "test:integration": "node --import jiti/register --import ./test/support/register-loader.mjs --test test/integration/*.test.ts",
     "test:all": "npm run test:unit && npm run test:integration"
   },
   "pi": {
@@ -54,7 +54,9 @@
   "peerDependencies": {
     "@earendil-works/pi-agent-core": "*",
     "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-agent-core": {
@@ -65,16 +67,23 @@
     },
     "@earendil-works/pi-coding-agent": {
       "optional": true
+    },
+    "@earendil-works/pi-tui": {
+      "optional": true
+    },
+    "typebox": {
+      "optional": true
     }
   },
   "dependencies": {
-    "@earendil-works/pi-tui": "^0.74.0",
-    "jiti": "^2.7.0",
-    "typebox": "^1.1.24"
+    "jiti": "^2.7.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-agent-core": "^0.74.0",
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.74.0"
-  }
+    "@earendil-works/pi-agent-core": "^0.77.0",
+    "@earendil-works/pi-ai": "^0.77.0",
+    "@earendil-works/pi-coding-agent": "^0.77.0",
+    "@earendil-works/pi-tui": "^0.77.0",
+    "typebox": "^1.1.39"
+  },
+  "packageManager": "npm@11.16.0"
 }

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -159,6 +159,12 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 			"Allowed management/control actions: list, get, status, interrupt, resume, doctor.",
 			"Agent config mutation actions create, update, and delete are blocked in this mode.",
 		].join("\n"),
+		promptSnippet: "Delegate nested child-safe subagent work from an explicitly allowed fanout child.",
+		promptGuidelines: [
+			"Use subagent in child-safe fanout mode only for explicitly assigned nested delegation or control inspection.",
+			"Use subagent action:list before nested execution unless the executable nested agent is already known from the task context.",
+			"Do not use subagent child-safe mode for agent config mutation actions; create, update, and delete are blocked here.",
+		],
 		parameters: SubagentParams,
 		execute(id, params, signal, onUpdate, ctx) {
 			return executor.execute(id, params as SubagentParamsLike, signal, onUpdate, ctx);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -394,7 +394,7 @@ EXECUTION (use exactly ONE mode):
 • SINGLE: { agent, task? } - one task; omit task for self-contained agents
 • CHAIN: { chain: [{agent:"agent-a"}, {parallel:[{agent:"agent-b",count:3}]}] } - sequential pipeline with optional parallel fan-out
 • PARALLEL: { tasks: [{agent,task,count?,output?,reads?,progress?}, ...], concurrency?: number, worktree?: true } - concurrent execution (worktree: isolate each task in a git worktree)
-• Optional context: { context: "fresh" | "fork" } (default: if any requested agent has defaultContext: "fork", the whole invocation uses fork; otherwise "fresh"; inspect agent defaults via { action: "list" })
+• Optional context: { context: "fresh" | "fork" } (explicit override for all agents in the call; when omitted, each agent uses its own defaultContext from { action: "list" })
 
 CHAIN TEMPLATE VARIABLES (use in task strings):
 • {task} - The original task/request from the user

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -418,6 +418,13 @@ CONTROL:
 
 DIAGNOSTICS:
 • { action: "doctor" } - read-only report for runtime paths, discovery, sessions, and intercom`,
+		promptSnippet: "Delegate bounded work to configured subagents, chains, or parallel reviewers while the parent session stays in control.",
+		promptGuidelines: [
+			"Use subagent for materially parallelizable scouting, review, or implementation work where another focused agent adds value.",
+			"Before executing subagent runs, call subagent with { action: \"list\" } unless the requested executable agent or chain is already known from this conversation.",
+			"Keep the parent session responsible for final decisions, verification, and user-facing status; treat subagent output as evidence to review, not automatic truth.",
+			"Do not use subagent when a direct local tool call or small edit is cheaper than delegation.",
+		],
 		parameters: SubagentParams,
 
 		execute(id, params, signal, onUpdate, ctx) {

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -139,7 +139,7 @@ export const SubagentParams = Type.Object({
 	chain: Type.Optional(Type.Array(ChainItem, { description: "CHAIN mode: sequential pipeline where each step's response becomes {previous} for the next. Use {task}, {previous}, {chain_dir} in task templates." })),
 	context: Type.Optional(Type.String({
 		enum: ["fresh", "fork"],
-		description: "'fresh' or 'fork' to branch from parent session. If omitted, any requested agent with defaultContext: 'fork' makes the whole invocation forked; otherwise the default is 'fresh'.",
+		description: "'fresh' or 'fork' to branch from parent session. Explicit value overrides all agents in the call. When omitted, each agent uses its own defaultContext.",
 	})),
 	chainDir: Type.Optional(Type.String({ description: "Persistent directory for chain artifacts. Default: a user-scoped temp directory under <tmpdir>/ (auto-cleaned after 24h)" })),
 	async: Type.Optional(Type.Boolean({ description: "Run in background (default: false, or per config)" })),

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -31,7 +31,15 @@ import {
 } from "../../shared/settings.ts";
 import { discoverAvailableSkills, normalizeSkillInput } from "../../agents/skills.ts";
 import { executeAsyncChain, executeAsyncSingle, formatAsyncStartedMessage, isAsyncAvailable } from "../background/async-execution.ts";
-import { createForkContextResolver } from "../../shared/fork-context.ts";
+import {
+	buildFlatAgentNameResolver,
+	collectInvocationAgentNames,
+	createPerAgentForkContextResolver,
+	invocationUsesForkContext,
+	resolveAgentContext,
+	wrapChainTasksForAgentContext,
+	wrapTaskForAgentContext,
+} from "../../shared/agent-context-policy.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBridge, resolveIntercomSessionTarget, resolveSubagentIntercomTarget, type IntercomBridgeState } from "../../intercom/intercom-bridge.ts";
 import { formatControlIntercomMessage, formatControlNoticeMessage, resolveControlConfig, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
@@ -855,17 +863,6 @@ function getRequestedModeLabel(params: SubagentParamsLike): Details["mode"] {
 	return "single";
 }
 
-function applyAgentDefaultContext(params: SubagentParamsLike, agents: AgentConfig[]): SubagentParamsLike {
-	if (params.context !== undefined) return params;
-	const byName = new Map(agents.map((agent) => [agent.name, agent]));
-	const names: string[] = [];
-	if (params.agent) names.push(params.agent);
-	for (const task of params.tasks ?? []) names.push(task.agent);
-	for (const step of params.chain ?? []) names.push(...getStepAgents(step));
-	return names.some((name) => byName.get(name)?.defaultContext === "fork")
-		? { ...params, context: "fork" }
-		: params;
-}
 
 function buildRequestedModeError(params: SubagentParamsLike, message: string): AgentToolResult<Details> {
 	return withForkContext(
@@ -951,7 +948,11 @@ function withForkContext(
 	};
 }
 
-function toExecutionErrorResult(params: SubagentParamsLike, error: unknown): AgentToolResult<Details> {
+function toExecutionErrorResult(
+	params: SubagentParamsLike,
+	error: unknown,
+	context: SubagentParamsLike["context"] = params.context,
+): AgentToolResult<Details> {
 	const message = error instanceof Error ? error.message : String(error);
 	return withForkContext(
 		{
@@ -959,7 +960,7 @@ function toExecutionErrorResult(params: SubagentParamsLike, error: unknown): Age
 			isError: true,
 			details: { mode: getRequestedModeLabel(params), results: [] },
 		},
-		params.context,
+		context,
 	);
 }
 
@@ -983,25 +984,6 @@ function collectChainSessionFiles(
 	return sessionFiles;
 }
 
-function wrapChainTasksForFork(chain: ChainStep[], context: SubagentParamsLike["context"]): ChainStep[] {
-	if (context !== "fork") return chain;
-	return chain.map((step, stepIndex) => {
-		if (isParallelStep(step)) {
-			return {
-				...step,
-				parallel: step.parallel.map((task) => ({
-					...task,
-					task: wrapForkTask(task.task ?? "{previous}"),
-				})),
-			};
-		}
-		const sequential = step as SequentialStep;
-		return {
-			...sequential,
-			task: wrapForkTask(sequential.task ?? (stepIndex === 0 ? "{task}" : "{previous}")),
-		};
-	});
-}
 
 function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentToolResult<Details> | null {
 	const {
@@ -1074,7 +1056,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const skillOverrides = params.tasks.map((task) => normalizeSkillInput(task.skill));
 		const parallelTasks = params.tasks.map((task, index) => ({
 			agent: task.agent,
-			task: params.context === "fork" ? wrapForkTask(task.task) : task.task,
+			task: wrapTaskForAgentContext(task.task, params.context, task.agent, agents),
 			cwd: task.cwd,
 			...(modelOverrides[index] ? { model: modelOverrides[index] } : {}),
 			...(skillOverrides[index] !== undefined ? { skill: skillOverrides[index] } : {}),
@@ -1114,7 +1096,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 	if (hasChain && params.chain) {
 		const normalized = normalizeSkillInput(params.skill);
 		const chainSkills = normalized === false ? [] : (normalized ?? []);
-		const chain = wrapChainTasksForFork(params.chain as ChainStep[], params.context);
+		const chain = wrapChainTasksForAgentContext(params.chain as ChainStep[], params.context, agents);
 		return executeAsyncChain(id, {
 			chain,
 			task: params.task,
@@ -1157,7 +1139,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const modelOverride = resolveModelCandidate((params.model as string | undefined) ?? a.model, availableModels, currentProvider);
 		return executeAsyncSingle(id, {
 			agent: params.agent!,
-			task: params.context === "fork" ? wrapForkTask(params.task ?? "") : (params.task ?? ""),
+			task: wrapTaskForAgentContext(params.task ?? "", params.context, params.agent, agents),
 			agentConfig: a,
 			ctx: asyncCtx,
 			availableModels,
@@ -1207,7 +1189,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 	const foregroundControl = deps.state.foregroundControls.get(runId);
 	const normalized = normalizeSkillInput(params.skill);
 	const chainSkills = normalized === false ? [] : (normalized ?? []);
-	const chain = wrapChainTasksForFork(params.chain as ChainStep[], params.context);
+	const chain = wrapChainTasksForAgentContext(params.chain as ChainStep[], params.context, agents);
 	const currentMaxSubagentDepth = resolveCurrentMaxSubagentDepth(deps.config.maxSubagentDepth);
 	const chainResult = await executeChain({
 		chain,
@@ -1254,7 +1236,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			currentSessionId: deps.state.currentSessionId!,
 			currentModelProvider: ctx.model?.provider,
 		};
-		const asyncChain = wrapChainTasksForFork(chainResult.requestedAsync.chain, params.context);
+		const asyncChain = wrapChainTasksForAgentContext(chainResult.requestedAsync.chain, params.context, agents);
 		return executeAsyncChain(id, {
 			chain: asyncChain,
 			task: params.task,
@@ -1668,7 +1650,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				currentModelProvider: ctx.model?.provider,
 			};
 			const parallelTasks = tasks.map((t, i) => {
-				const taskText = params.context === "fork" ? wrapForkTask(taskTexts[i]!) : taskTexts[i]!;
+				const taskText = wrapTaskForAgentContext(taskTexts[i]!, params.context, t.agent, agents);
 				const progress = taskDisallowsFileUpdates(taskText) ? false : behaviorOverrides[i]?.progress;
 				return {
 					agent: t.agent,
@@ -1740,10 +1722,8 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		const parallelProgressPrecreated = firstProgressIndex !== -1;
 		if (parallelProgressPrecreated) writeInitialProgressFile(effectiveCwd);
 
-		if (params.context === "fork") {
-			for (let i = 0; i < taskTexts.length; i++) {
-				taskTexts[i] = wrapForkTask(taskTexts[i]!);
-			}
+		for (let i = 0; i < taskTexts.length; i++) {
+			taskTexts[i] = wrapTaskForAgentContext(taskTexts[i]!, params.context, tasks[i]!.agent, agents);
 		}
 
 		const results = await runForegroundParallelTasks({
@@ -1948,7 +1928,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			};
 			return executeAsyncSingle(id, {
 				agent: params.agent!,
-				task: params.context === "fork" ? wrapForkTask(task) : task,
+				task: wrapTaskForAgentContext(task, params.context, params.agent, agents),
 				agentConfig,
 				ctx: asyncCtx,
 				availableModels,
@@ -1973,9 +1953,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		}
 	}
 
-	if (params.context === "fork") {
-		task = wrapForkTask(task);
-	}
+	task = wrapTaskForAgentContext(task, params.context, params.agent, agents);
 	const cleanTask = task;
 	const outputPath = resolveSingleOutputPath(effectiveOutput, ctx.cwd, effectiveCwd);
 	const validationError = validateFileOnlyOutputMode(effectiveOutputMode, outputPath, `Single run (${params.agent})`);
@@ -2302,17 +2280,27 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const parentSessionFile = ctx.sessionManager.getSessionFile() ?? null;
 		deps.state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
 		const discoveredAgents = deps.discoverAgents(effectiveCwd, scope).agents;
-		effectiveParams = applyAgentDefaultContext(effectiveParams, discoveredAgents);
+		const invocationAgentNames = collectInvocationAgentNames(effectiveParams);
+		const invocationContext: SubagentParamsLike["context"] = invocationUsesForkContext(
+			effectiveParams.context,
+			invocationAgentNames,
+			discoveredAgents,
+		)
+			? "fork"
+			: undefined;
 		const sessionName = resolveIntercomSessionTarget(deps.pi.getSessionName(), ctx.sessionManager.getSessionId());
 		const intercomBridge = resolveIntercomBridge({
 			config: deps.config.intercomBridge,
-			context: effectiveParams.context,
+			context: invocationContext,
 			orchestratorTarget: sessionName,
 			cwd: effectiveCwd,
 		});
 		const agents = intercomBridge.active
 			? discoveredAgents.map((agent) => applyIntercomBridgeToAgent(agent, intercomBridge))
 			: discoveredAgents;
+		const agentNameAtIndex = buildFlatAgentNameResolver(effectiveParams);
+		const resolveContextForIndex = (index?: number) =>
+			resolveAgentContext(effectiveParams.context, agentNameAtIndex(index ?? 0), agents);
 		const runId = randomUUID().slice(0, 8);
 		const inheritedNestedRoute = resolveInheritedNestedRouteFromEnv();
 		const nestedParentAddress = inheritedNestedRoute ? resolveNestedParentAddressFromEnv() : undefined;
@@ -2338,9 +2326,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 
 		let sessionFileForIndex: (idx?: number) => string | undefined = () => undefined;
 		try {
-			sessionFileForIndex = createForkContextResolver(ctx.sessionManager, effectiveParams.context).sessionFileForIndex;
+			sessionFileForIndex = createPerAgentForkContextResolver(ctx.sessionManager, resolveContextForIndex).sessionFileForIndex;
 		} catch (error) {
-			return toExecutionErrorResult(effectiveParams, error);
+			return toExecutionErrorResult(effectiveParams, error, invocationContext);
 		}
 		const requestedAsync = effectiveParams.async ?? deps.asyncByDefault;
 		const backgroundRequestedWhileClarifying = (hasChain || hasTasks) && requestedAsync && effectiveParams.clarify === true;
@@ -2369,6 +2357,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return toExecutionErrorResult(
 				effectiveParams,
 				new Error(`Failed to create session directory '${sessionRoot}': ${message}`),
+				invocationContext,
 			);
 		}
 		const sessionDirForIndex = (idx?: number) =>
@@ -2377,7 +2366,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			sessionFileForIndex(idx) ?? path.join(sessionDirForIndex(idx), "session.jsonl");
 
 		const onUpdateWithContext = onUpdate
-			? (r: AgentToolResult<Details>) => onUpdate(withForkContext(r, effectiveParams.context))
+			? (r: AgentToolResult<Details>) => onUpdate(withForkContext(r, invocationContext))
 			: undefined;
 
 		const execData: ExecutionContextData = {
@@ -2482,7 +2471,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		let nestedForegroundStarted = false;
 		try {
 			const asyncResult = runAsyncPath(execData, deps);
-			if (asyncResult) return withForkContext(asyncResult, effectiveParams.context);
+			if (asyncResult) return withForkContext(asyncResult, invocationContext);
 			if (foregroundControl) {
 				writeNestedForegroundEvent("subagent.nested.started");
 				nestedForegroundStarted = true;
@@ -2490,20 +2479,20 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			if (hasChain && effectiveParams.chain) {
 				const result = await runChainPath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return withForkContext(result, effectiveParams.context);
+				return withForkContext(result, invocationContext);
 			}
 			if (hasTasks && effectiveParams.tasks) {
 				const result = await runParallelPath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return withForkContext(result, effectiveParams.context);
+				return withForkContext(result, invocationContext);
 			}
 			if (hasSingle) {
 				const result = await runSinglePath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return withForkContext(result, effectiveParams.context);
+				return withForkContext(result, invocationContext);
 			}
 		} catch (error) {
-			const errorResult = toExecutionErrorResult(effectiveParams, error);
+			const errorResult = toExecutionErrorResult(effectiveParams, error, invocationContext);
 			if (nestedForegroundStarted) writeNestedForegroundEvent("subagent.nested.completed", errorResult);
 			return errorResult;
 		} finally {
@@ -2520,7 +2509,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			content: [{ type: "text", text: "Invalid params" }],
 			isError: true,
 			details: { mode: "single" as const, results: [] },
-		}, effectiveParams.context);
+		}, invocationContext);
 	};
 
 	return { execute };

--- a/src/shared/agent-context-policy.ts
+++ b/src/shared/agent-context-policy.ts
@@ -1,0 +1,127 @@
+import type { AgentConfig } from "../agents/agents.ts";
+import type { ChainStep, SequentialStep } from "./settings.ts";
+import { getStepAgents, isParallelStep } from "./settings.ts";
+import { createForkContextResolver, resolveSubagentContext, type ForkContextResolverOptions } from "./fork-context.ts";
+import { wrapForkTask } from "./types.ts";
+
+export type SubagentExecutionContext = "fresh" | "fork";
+
+interface ForkableSessionManager {
+	getSessionFile(): string | undefined;
+	getLeafId(): string | null;
+	getSessionDir?(): string;
+	openSession?: (path: string, sessionDir?: string) => { createBranchedSession(leafId: string): string | undefined };
+}
+
+export interface SubagentParamsLikeForContext {
+	agent?: string;
+	tasks?: Array<{ agent: string }>;
+	chain?: ChainStep[];
+	context?: SubagentExecutionContext;
+}
+
+export function resolveAgentContext(
+	explicitContext: unknown,
+	agentName: string | undefined,
+	agents: readonly AgentConfig[],
+): SubagentExecutionContext {
+	if (explicitContext !== undefined) {
+		return resolveSubagentContext(explicitContext);
+	}
+	if (!agentName) return "fresh";
+	const agent = agents.find((entry) => entry.name === agentName);
+	return agent?.defaultContext === "fork" ? "fork" : "fresh";
+}
+
+export function collectInvocationAgentNames(params: SubagentParamsLikeForContext): string[] {
+	const names: string[] = [];
+	if (params.agent) names.push(params.agent);
+	for (const task of params.tasks ?? []) names.push(task.agent);
+	for (const step of params.chain ?? []) names.push(...getStepAgents(step));
+	return names;
+}
+
+export function invocationUsesForkContext(
+	explicitContext: unknown,
+	agentNames: readonly string[],
+	agents: readonly AgentConfig[],
+): boolean {
+	if (explicitContext !== undefined) {
+		return resolveSubagentContext(explicitContext) === "fork";
+	}
+	return agentNames.some((name) => resolveAgentContext(undefined, name, agents) === "fork");
+}
+
+export function buildFlatAgentNameResolver(params: SubagentParamsLikeForContext): (index: number) => string | undefined {
+	if (params.agent && !params.tasks?.length && !params.chain?.length) {
+		return () => params.agent;
+	}
+	if (params.tasks?.length) {
+		return (index) => params.tasks![index]?.agent;
+	}
+	if (params.chain?.length) {
+		const flatAgents: string[] = [];
+		for (const step of params.chain) {
+			if (isParallelStep(step)) {
+				for (const task of step.parallel) flatAgents.push(task.agent);
+				continue;
+			}
+			flatAgents.push(...getStepAgents(step));
+		}
+		return (index) => flatAgents[index];
+	}
+	return () => undefined;
+}
+
+export function wrapTaskForAgentContext(
+	task: string,
+	explicitContext: unknown,
+	agentName: string | undefined,
+	agents: readonly AgentConfig[],
+): string {
+	return resolveAgentContext(explicitContext, agentName, agents) === "fork" ? wrapForkTask(task) : task;
+}
+
+export function wrapChainTasksForAgentContext(
+	chain: ChainStep[],
+	explicitContext: unknown,
+	agents: readonly AgentConfig[],
+): ChainStep[] {
+	return chain.map((step, stepIndex) => {
+		if (isParallelStep(step)) {
+			return {
+				...step,
+				parallel: step.parallel.map((task) => ({
+					...task,
+					task: wrapTaskForAgentContext(task.task ?? "{previous}", explicitContext, task.agent, agents),
+				})),
+			};
+		}
+		const sequential = step as SequentialStep;
+		const agentName = getStepAgents(step)[0];
+		return {
+			...sequential,
+			task: wrapTaskForAgentContext(
+				sequential.task ?? (stepIndex === 0 ? "{task}" : "{previous}"),
+				explicitContext,
+				agentName,
+				agents,
+			),
+		};
+	});
+}
+
+export function createPerAgentForkContextResolver(
+	sessionManager: ForkableSessionManager,
+	resolveContextForIndex: (index?: number) => SubagentExecutionContext,
+	options: ForkContextResolverOptions = {},
+): { sessionFileForIndex(index?: number): string | undefined } {
+	let forkResolver: ReturnType<typeof createForkContextResolver> | undefined;
+	return {
+		sessionFileForIndex(index = 0): string | undefined {
+			if (resolveContextForIndex(index) !== "fork") return undefined;
+			if (!forkResolver) forkResolver = createForkContextResolver(sessionManager, "fork", options);
+			return forkResolver.sessionFileForIndex(index);
+		},
+	};
+}

--- a/src/shared/fork-context.ts
+++ b/src/shared/fork-context.ts
@@ -10,7 +10,7 @@ interface ForkableSessionManager {
 	openSession?: (path: string, sessionDir?: string) => { createBranchedSession(leafId: string): string | undefined };
 }
 
-interface ForkContextResolverOptions {
+export interface ForkContextResolverOptions {
 	openSession?: (path: string, sessionDir?: string) => { createBranchedSession(leafId: string): string | undefined };
 }
 

--- a/test/integration/fork-context-execution.test.ts
+++ b/test/integration/fork-context-execution.test.ts
@@ -188,6 +188,16 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 			.filter((sessionFile): sessionFile is string => Boolean(sessionFile));
 	}
 
+	function forkedSessionFile(index: number): string {
+		return path.join(tempDir, `fork-${index}.jsonl`);
+	}
+
+	function countForkedSessionFiles(sessionArgs: string[]): number {
+		return sessionArgs.filter((sessionFile) =>
+			path.dirname(sessionFile) === tempDir && /^fork-\d+\.jsonl$/.test(path.basename(sessionFile)),
+		).length;
+	}
+
 	function makeForkingSessionManagerRecorder(options: { sessionFile: string; leafId: string }) {
 		const openedPaths: string[] = [];
 		const branchedLeafIds: string[] = [];
@@ -371,7 +381,7 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		assert.notEqual(readSessionArgsFromCalls()[0], path.join(tempDir, "fork-1.jsonl"));
 	});
 
-	it("uses agent defaultContext fork for top-level parallel when launch context is omitted", async () => {
+	it("forks only fork-default agents in top-level parallel when launch context is omitted", async () => {
 		const parentSessionFile = path.join(tempDir, "parent.jsonl");
 		const { manager } = makeForkingSessionManagerRecorder({ sessionFile: parentSessionFile, leafId: "leaf-current" });
 		const executor = makeExecutorWithDiscoverAgents(() => ({
@@ -392,7 +402,37 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 
 		assert.equal(result.isError, undefined);
 		assert.equal(result.details?.context, "fork");
-		assert.deepEqual(readSessionArgsFromCalls().sort(), [path.join(tempDir, "fork-1.jsonl"), path.join(tempDir, "fork-2.jsonl")]);
+		const sessionArgs = readSessionArgsFromCalls();
+		assert.equal(sessionArgs.length, 2);
+		assert.equal(countForkedSessionFiles(sessionArgs), 1);
+		assert.ok(sessionArgs.includes(forkedSessionFile(1)));
+	});
+
+	it("keeps fresh-default agents on fresh context when mixed with fork-default agents in parallel", async () => {
+		const parentSessionFile = path.join(tempDir, "parent.jsonl");
+		const { manager } = makeForkingSessionManagerRecorder({ sessionFile: parentSessionFile, leafId: "leaf-current" });
+		const executor = makeExecutorWithDiscoverAgents(() => ({
+			agents: [
+				{ name: "scout", description: "Scout", defaultContext: "fresh" },
+				{ name: "worker", description: "Worker", defaultContext: "fork" },
+			],
+			projectAgentsDir: null,
+		}));
+
+		const result = await executor.execute(
+			"id",
+			{ tasks: [{ agent: "scout", task: "find files" }, { agent: "worker", task: "implement fix" }] },
+			new AbortController().signal,
+			undefined,
+			makeCtx(manager),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details?.context, "fork");
+		const sessionArgs = readSessionArgsFromCalls();
+		assert.equal(sessionArgs.length, 2);
+		assert.equal(countForkedSessionFiles(sessionArgs), 1);
+		assert.ok(sessionArgs.includes(forkedSessionFile(1)));
 	});
 
 	it("keeps explicit fresh context over top-level parallel agent defaultContext fork", async () => {
@@ -419,7 +459,7 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		assert.deepEqual(openedPaths, []);
 	});
 
-	it("uses agent defaultContext fork for chain runs when launch context is omitted", async () => {
+	it("forks only fork-default chain steps when launch context is omitted", async () => {
 		const parentSessionFile = path.join(tempDir, "parent.jsonl");
 		const { manager } = makeForkingSessionManagerRecorder({ sessionFile: parentSessionFile, leafId: "leaf-current" });
 		const executor = makeExecutorWithDiscoverAgents(() => ({
@@ -440,7 +480,10 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 
 		assert.equal(result.isError, undefined);
 		assert.equal(result.details?.context, "fork");
-		assert.deepEqual(readSessionArgsFromCalls(), [path.join(tempDir, "fork-1.jsonl"), path.join(tempDir, "fork-2.jsonl")]);
+		const sessionArgs = readSessionArgsFromCalls();
+		assert.equal(sessionArgs.length, 2);
+		assert.equal(countForkedSessionFiles(sessionArgs), 1);
+		assert.ok(sessionArgs.includes(forkedSessionFile(1)));
 	});
 
 	it("reports unknown top-level parallel agents before default-fork preconditions", async () => {

--- a/test/support/register-loader.mjs
+++ b/test/support/register-loader.mjs
@@ -1,13 +1,13 @@
 /**
  * Register the .js → .ts loader hook for integration tests.
  *
- * Usage: node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/*.test.ts
+ * Usage: node --import jiti/register --import ./test/support/register-loader.mjs --test test/integration/*.test.ts
  *
  * Handles two issues:
  * 1. Source files use .js import extensions (TypeScript ESM convention) but
  *    files on disk are .ts — the loader rewrites .js → .ts at resolve time.
- * 2. Some source files use TypeScript parameter properties (constructor(private x: T))
- *    which require --experimental-transform-types (not just strip-types).
+ * 2. `jiti/register` transforms TypeScript syntax such as parameter
+ *    properties that Node's strip-only loader cannot execute.
  */
 
 import { register } from "node:module";

--- a/test/unit/agent-context-policy.test.ts
+++ b/test/unit/agent-context-policy.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import type { AgentConfig } from "../../src/agents/agents.ts";
+import {
+	buildFlatAgentNameResolver,
+	collectInvocationAgentNames,
+	createPerAgentForkContextResolver,
+	invocationUsesForkContext,
+	resolveAgentContext,
+	wrapChainTasksForAgentContext,
+	wrapTaskForAgentContext,
+} from "../../src/shared/agent-context-policy.ts";
+
+const agents: AgentConfig[] = [
+	makeAgent("scout", "fresh"),
+	makeAgent("worker", "fork"),
+	makeAgent("oracle", "fork"),
+];
+
+function makeAgent(name: string, defaultContext: "fresh" | "fork"): AgentConfig {
+	return {
+		name,
+		description: `${name} agent`,
+		systemPromptMode: "replace",
+		inheritProjectContext: false,
+		inheritSkills: false,
+		defaultContext,
+		systemPrompt: `${name} prompt`,
+		source: "user",
+		filePath: `/user/${name}.md`,
+	};
+}
+
+describe("resolveAgentContext", () => {
+	it("uses explicit caller context when provided", () => {
+		assert.equal(resolveAgentContext("fresh", "worker", agents), "fresh");
+		assert.equal(resolveAgentContext("fork", "scout", agents), "fork");
+	});
+
+	it("falls back to agent defaultContext when caller context is omitted", () => {
+		assert.equal(resolveAgentContext(undefined, "scout", agents), "fresh");
+		assert.equal(resolveAgentContext(undefined, "worker", agents), "fork");
+	});
+});
+
+describe("invocationUsesForkContext", () => {
+	it("reports fork usage when any agent defaults to fork", () => {
+		const names = collectInvocationAgentNames({
+			tasks: [
+				{ agent: "scout" },
+				{ agent: "worker" },
+			],
+		});
+		assert.deepEqual(names, ["scout", "worker"]);
+		assert.equal(invocationUsesForkContext(undefined, names, agents), true);
+	});
+
+	it("stays fresh when no agent defaults to fork", () => {
+		assert.equal(invocationUsesForkContext(undefined, ["scout"], agents), false);
+	});
+});
+
+describe("wrapTaskForAgentContext", () => {
+	it("wraps only fork-default agents when caller context is omitted", () => {
+		const scoutTask = wrapTaskForAgentContext("find files", undefined, "scout", agents);
+		const workerTask = wrapTaskForAgentContext("implement fix", undefined, "worker", agents);
+		assert.equal(scoutTask, "find files");
+		assert.match(workerTask, /delegated subagent/i);
+	});
+
+	it("honors explicit fresh override for fork-default agents", () => {
+		const workerTask = wrapTaskForAgentContext("implement fix", "fresh", "worker", agents);
+		assert.equal(workerTask, "implement fix");
+	});
+});
+
+describe("wrapChainTasksForAgentContext", () => {
+	it("applies fork wrapping per chain step agent", () => {
+		const wrapped = wrapChainTasksForAgentContext(
+			[
+				{ agent: "scout", task: "scout task" },
+				{ agent: "worker", task: "worker task" },
+			],
+			undefined,
+			agents,
+		);
+		assert.equal((wrapped[0] as { task?: string }).task, "scout task");
+		assert.match((wrapped[1] as { task?: string }).task ?? "", /delegated subagent/i);
+	});
+});
+
+describe("createPerAgentForkContextResolver", () => {
+	it("forks only indices whose agent defaults to fork", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-per-agent-fork-"));
+		try {
+			const parentSessionFile = path.join(tempDir, "parent.jsonl");
+			fs.mkdirSync(path.dirname(parentSessionFile), { recursive: true });
+			fs.writeFileSync(
+				parentSessionFile,
+				'{"type":"session","version":1,"id":"parent","timestamp":"2026-04-16T00:00:00.000Z","cwd":"/tmp"}\n',
+				"utf-8",
+			);
+
+			let forkCalls = 0;
+			const resolver = createPerAgentForkContextResolver(
+				{
+					getSessionFile: () => parentSessionFile,
+					getLeafId: () => "leaf-1",
+				},
+				(index = 0) => (index === 1 ? "fork" : "fresh"),
+				{
+					openSession: () => ({
+						createBranchedSession: () => {
+							forkCalls++;
+							const childSessionFile = path.join(tempDir, `child-${forkCalls}.jsonl`);
+							fs.writeFileSync(
+								childSessionFile,
+								`{"type":"session","version":1,"id":"child-${forkCalls}","timestamp":"2026-04-16T00:00:00.000Z","cwd":"/tmp"}\n`,
+								"utf-8",
+							);
+							return childSessionFile;
+						},
+					}),
+				},
+			);
+
+			assert.equal(resolver.sessionFileForIndex(0), undefined);
+			assert.equal(resolver.sessionFileForIndex(1), path.join(tempDir, "child-1.jsonl"));
+			assert.equal(forkCalls, 1);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("buildFlatAgentNameResolver", () => {
+	it("maps parallel task indices to agent names", () => {
+		const resolve = buildFlatAgentNameResolver({
+			tasks: [{ agent: "scout" }, { agent: "worker" }],
+		});
+		assert.equal(resolve(0), "scout");
+		assert.equal(resolve(1), "worker");
+	});
+});

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -6,7 +6,6 @@ import { describe, it } from "node:test";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
-
 function parentToolEnv(): NodeJS.ProcessEnv {
 	const env = { ...process.env };
 	delete env[SUBAGENT_CHILD_ENV];
@@ -14,10 +13,24 @@ function parentToolEnv(): NodeJS.ProcessEnv {
 	return env;
 }
 
+function runProbe(script: string, options: { env?: NodeJS.ProcessEnv } = {}): void {
+	execFileSync(
+		process.execPath,
+		[
+			"--input-type=module",
+			"--eval",
+			String.raw`import { createJiti } from "jiti";
+const jiti = createJiti(import.meta.url);
+${script}`,
+		],
+		{ cwd: projectRoot, stdio: "pipe", ...options },
+	);
+}
+
 describe("subagent extension child mode", () => {
 	it("collapses tool detail before direct subagent tool execution", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
+			const { default: registerSubagentExtension } = await jiti.import("./src/extension/index.ts");
 			const events = { on() { return () => {}; }, emit() {} };
 			let registeredTool;
 			const fakePi = new Proxy({
@@ -36,6 +49,10 @@ describe("subagent extension child mode", () => {
 			});
 			registerSubagentExtension(fakePi);
 			if (!registeredTool) throw new Error("tool not registered");
+			if (!registeredTool.promptSnippet?.includes("Delegate bounded work")) throw new Error("missing parent promptSnippet");
+			const parentGuidelines = registeredTool.promptGuidelines ?? [];
+			if (!parentGuidelines.some((line) => line.includes("action: \"list\""))) throw new Error("missing list-before-execute guideline");
+			if (!parentGuidelines.some((line) => line.includes("parent session responsible"))) throw new Error("missing parent-owns-final-decision guideline");
 			const calls = [];
 			const ctx = {
 				cwd: process.cwd(),
@@ -53,23 +70,12 @@ describe("subagent extension child mode", () => {
 			if (calls[0] !== false) throw new Error("expected setToolsExpanded(false), got " + JSON.stringify(calls));
 		`;
 
-		execFileSync(
-			process.execPath,
-			[
-				"--experimental-transform-types",
-				"--import",
-				"./test/support/register-loader.mjs",
-				"--input-type=module",
-				"--eval",
-				script,
-			],
-			{ cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" },
-		);
+		runProbe(script, { env: parentToolEnv() });
 	});
 
 	it("does not show async badge for explicit foreground clarify chain calls", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
+			const { default: registerSubagentExtension } = await jiti.import("./src/extension/index.ts");
 			const events = { on() { return () => {}; }, emit() {} };
 			let registeredTool;
 			const fakePi = new Proxy({
@@ -95,24 +101,13 @@ describe("subagent extension child mode", () => {
 			if (clarifyChain.includes("[async]")) throw new Error("unexpected clarify async badge: " + clarifyChain);
 		`;
 
-		execFileSync(
-			process.execPath,
-			[
-				"--experimental-transform-types",
-				"--import",
-				"./test/support/register-loader.mjs",
-				"--input-type=module",
-				"--eval",
-				script,
-			],
-			{ cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" },
-		);
+		runProbe(script, { env: parentToolEnv() });
 	});
 
 	it("returns before registering anything for non-fanout children", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
-			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
+			const { default: registerSubagentExtension } = await jiti.import("./src/extension/index.ts");
+			const { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } = await jiti.import("./src/runs/shared/pi-args.ts");
 			process.env[SUBAGENT_CHILD_ENV] = "1";
 			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "0";
 			const calls = [];
@@ -130,24 +125,13 @@ describe("subagent extension child mode", () => {
 			}
 		`;
 
-		execFileSync(
-			process.execPath,
-			[
-				"--experimental-transform-types",
-				"--import",
-				"./test/support/register-loader.mjs",
-				"--input-type=module",
-				"--eval",
-				script,
-			],
-			{ cwd: projectRoot, stdio: "pipe" },
-		);
+		runProbe(script);
 	});
 
 	it("registers only the child-safe subagent tool for fanout children", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
-			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
+			const { default: registerSubagentExtension } = await jiti.import("./src/extension/index.ts");
+			const { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } = await jiti.import("./src/runs/shared/pi-args.ts");
 			process.env[SUBAGENT_CHILD_ENV] = "1";
 			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
 			const calls = [];
@@ -167,28 +151,21 @@ describe("subagent extension child mode", () => {
 			});
 			registerSubagentExtension(fakePi);
 			if (!registeredTool || registeredTool.name !== "subagent") throw new Error("child-safe subagent tool not registered");
+			if (!registeredTool.promptSnippet?.includes("child-safe")) throw new Error("missing child-safe promptSnippet");
+			const childGuidelines = registeredTool.promptGuidelines ?? [];
+			if (!childGuidelines.some((line) => line.includes("child-safe fanout mode"))) throw new Error("missing child-safe fanout guideline");
+			if (!childGuidelines.some((line) => line.includes("create, update, and delete are blocked"))) throw new Error("missing child-safe mutation-block guideline");
 			const unexpected = calls.filter((call) => call !== "registerTool");
 			if (unexpected.length > 0) throw new Error("Unexpected parent-surface registrations: " + unexpected.join(", "));
 		`;
 
-		execFileSync(
-			process.execPath,
-			[
-				"--experimental-transform-types",
-				"--import",
-				"./test/support/register-loader.mjs",
-				"--input-type=module",
-				"--eval",
-				script,
-			],
-			{ cwd: projectRoot, stdio: "pipe" },
-		);
+		runProbe(script);
 	});
 
 	it("lets fanout children call read-only list but blocks mutating management actions", () => {
 		const script = String.raw`
-			import registerFanoutChildSubagentExtension from "./src/extension/fanout-child.ts";
-			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
+			const { default: registerFanoutChildSubagentExtension } = await jiti.import("./src/extension/fanout-child.ts");
+			const { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } = await jiti.import("./src/runs/shared/pi-args.ts");
 			process.env[SUBAGENT_CHILD_ENV] = "1";
 			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
 			let registeredTool;
@@ -213,17 +190,6 @@ describe("subagent extension child mode", () => {
 			if (!text.includes("not available from child-safe subagent fanout mode")) throw new Error("unexpected create error: " + text);
 		`;
 
-		execFileSync(
-			process.execPath,
-			[
-				"--experimental-transform-types",
-				"--import",
-				"./test/support/register-loader.mjs",
-				"--input-type=module",
-				"--eval",
-				script,
-			],
-			{ cwd: projectRoot, stdio: "pipe" },
-		);
+		runProbe(script);
 	});
 });

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -13,6 +13,10 @@ function errno(code: string): NodeJS.ErrnoException {
 	return error;
 }
 
+function rmrf(target: string): void {
+	fs.rmSync(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+}
+
 function textContent(result: ReturnType<typeof inspectSubagentStatus>): string {
 	const first = result.content[0];
 	return first?.type === "text" ? first.text : "";
@@ -58,7 +62,7 @@ describe("async run status inspection", () => {
 			assert.equal(resultJson.success, false);
 			assert.equal(resultJson.results[0].sessionFile, sessionFile);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 
@@ -110,7 +114,7 @@ describe("async run status inspection", () => {
 			assert.match(text, new RegExp(`  Output: ${secondStepOutputPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
 			assert.doesNotMatch(text, /Step 1: reviewer/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 
@@ -161,8 +165,8 @@ describe("async run status inspection", () => {
 			assert.match(text, /↳ reviewer \[nested-status-child\] running \| tool read/);
 			assert.match(text, /Status: subagent\(\{ action: "status", id: "nested-status-child" \}\)/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
-			fs.rmSync(path.dirname(route.eventSink), { recursive: true, force: true });
+			rmrf(root);
+			rmrf(path.dirname(route.eventSink));
 		}
 	});
 
@@ -225,9 +229,9 @@ describe("async run status inspection", () => {
 			assert.match(text, /1\. reviewer failed \| error: Async runner process 54321 exited or disappeared/);
 			assert.ok(fs.existsSync(path.join(resultsDir, "nested", "run-stale-nested-root", "nested-stale.json")));
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
-			fs.rmSync(path.dirname(route.eventSink), { recursive: true, force: true });
-			fs.rmSync(nestedAsyncDir, { recursive: true, force: true });
+			rmrf(root);
+			rmrf(path.dirname(route.eventSink));
+			rmrf(nestedAsyncDir);
 		}
 	});
 
@@ -255,8 +259,8 @@ describe("async run status inspection", () => {
 			assert.equal(result.isError, undefined);
 			assert.match(textContent(result), /Warning: Nested status unavailable:/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
-			fs.rmSync(path.dirname(route.eventSink), { recursive: true, force: true });
+			rmrf(root);
+			rmrf(path.dirname(route.eventSink));
 		}
 	});
 
@@ -284,8 +288,8 @@ describe("async run status inspection", () => {
 			assert.equal(result.isError, undefined);
 			assert.match(textContent(result), /Warning: Nested status unavailable:/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
-			fs.rmSync(path.dirname(route.eventSink), { recursive: true, force: true });
+			rmrf(root);
+			rmrf(path.dirname(route.eventSink));
 		}
 	});
 
@@ -327,8 +331,8 @@ describe("async run status inspection", () => {
 			assert.match(text, /Interrupt: subagent\(\{ action: "interrupt", id: "nested-exact-child" \}\)/);
 			assert.match(text, /Resume: subagent\(\{ action: "resume", id: "nested-exact-child", message: "\.\.\." \}\)/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
-			fs.rmSync(path.dirname(route.eventSink), { recursive: true, force: true });
+			rmrf(root);
+			rmrf(path.dirname(route.eventSink));
 		}
 	});
 
@@ -363,7 +367,7 @@ describe("async run status inspection", () => {
 			assert.match(text, /Revive child: subagent\(\{ action: "resume", id: "run-multi", index: 0, message: "\.\.\." \}\)/);
 			assert.doesNotMatch(text, /unsupported for multi-child/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 
@@ -390,7 +394,7 @@ describe("async run status inspection", () => {
 			const text = textContent(result);
 			assert.match(text, /Revive child: subagent\(\{ action: "resume", id: "run-result-index", index: 1, message: "\.\.\." \}\)/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 
@@ -431,7 +435,7 @@ describe("async run status inspection", () => {
 			assert.match(text, /Step 2\/3 Agent 2\/2: auditor pending/);
 			assert.match(text, /Step 3\/3: writer pending/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 
@@ -462,7 +466,7 @@ describe("async run status inspection", () => {
 			assert.match(text, /Step 1: scout running/);
 			assert.match(text, /Intercom target: subagent-scout-run-live-1 \(if registered\)/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 
@@ -481,7 +485,7 @@ describe("async run status inspection", () => {
 			assert.equal(result.isError, true);
 			assert.match(textContent(result), /Ambiguous subagent run id prefix 'run-a' matched: async:run-aa, async:run-ab/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 
@@ -496,7 +500,7 @@ describe("async run status inspection", () => {
 			assert.equal(result.isError, true);
 			assert.match(textContent(result), /id must be a non-empty safe id token/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 
@@ -527,7 +531,7 @@ describe("async run status inspection", () => {
 			assert.match(text, /Resume: unavailable/);
 			assert.doesNotMatch(text, /Revive:/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 
@@ -561,7 +565,7 @@ describe("async run status inspection", () => {
 			assert.match(text, /Revive: subagent\(\{ action: "resume", id: "run-result-only", message: "\.\.\." \}\)/);
 			assert.match(text, /result survived missing status/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			rmrf(root);
 		}
 	});
 });

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -114,7 +114,7 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		const description = String(contextSchema.description ?? "");
 		assert.match(description, /fresh/);
 		assert.match(description, /fork/);
-		assert.match(description, /whole invocation/);
+		assert.match(description, /defaultContext/);
 	});
 
 	it("includes count and concurrency on top-level parallel mode", () => {

--- a/test/unit/tool-description.test.ts
+++ b/test/unit/tool-description.test.ts
@@ -7,7 +7,7 @@ import { describe, it } from "node:test";
 function readRegisteredSubagentDescription(): string {
 	const testDir = path.dirname(fileURLToPath(import.meta.url));
 	const indexSource = fs.readFileSync(path.resolve(testDir, "..", "..", "src/extension/index.ts"), "utf-8");
-	const match = indexSource.match(/name:\s*"subagent",[\s\S]*?description:\s*`([\s\S]*?)`,\r?\n\s*parameters: SubagentParams,/);
+	const match = indexSource.match(/name:\s*"subagent",[\s\S]*?description:\s*`([\s\S]*?)`,\r?\n\s*(?:promptSnippet|parameters):/);
 	assert.ok(match, "expected to find the registered subagent tool description");
 	return match[1]!;
 }


### PR DESCRIPTION
Fixes #228

## Summary

- Remove whole-invocation fork promotion when any agent in a parallel/chain call has `defaultContext: fork`.
- Resolve context per flat task index from each agent's `defaultContext` (or explicit caller `context`).
- Fork session files and `wrapForkTask()` only for indices whose resolved context is `fork`.
- Keep invocation-level fork metadata when any agent uses fork (intercom/TUI badge behavior).
- Update the local Pi development baseline to `@earendil-works/*` `0.77.0` and `typebox` `1.1.39`.
- Add Pi 0.77 tool prompt metadata (`promptSnippet` / `promptGuidelines`) for parent and child-safe `subagent` tool registrations.
- Switch the local TS test loader to `jiti/register` so tests keep working on Node releases where `--experimental-transform-types` is removed.
- Keep Pi runtime packages as optional wildcard peers so future Pi versions are not blocked by npm peer ranges.

## Why

Mixed scout + worker invocations were inheriting the full parent transcript for read-only scouts, inflating input tokens and cost even when scout frontmatter already specified `defaultContext: fresh`.

The Pi 0.77 refresh keeps the branch current with the latest package and tool-metadata guidance while preserving forward-open install behavior.

## Test plan

- [x] `npm test` / `npm run test:unit` (472 unit tests)
- [x] `npm pack --dry-run`
- [x] `npm publish --dry-run`
- [x] `pi install git:github.com/fitchmultz/pi-subagents@fix/per-agent-context-policy` verified `pi-subagents@0.25.1`

## Release / publish note

`pi-subagents@0.25.1` is ready from this branch, but npm publish is maintainer-gated. Publishing with the available `fitchmultz` npm token fails with:

```text
npm error code E403
npm error 403 Forbidden - PUT https://registry.npmjs.org/pi-subagents - You do not have permission to publish "pi-subagents".
```

Current npm maintainer is `nicopreme <nico.bailon@gmail.com>`, so the upstream maintainer needs to publish `pi-subagents@0.25.1` after merge.

## Related issue

https://github.com/nicobailon/pi-subagents/issues/228

Made with [Cursor](https://cursor.com)
