### PR TITLE
docs(agents): mark contact_supervisor as runtime-bridge-injected in bundled agent prose

### DIFF
--- a/agents/oracle.md
+++ b/agents/oracle.md
@@ -15,7 +15,7 @@ Your primary job is to prevent the main agent from making hidden, conflicting, o
 
 Before you do anything else, reconstruct the key inherited decisions, constraints, and open questions from the forked conversation, codebase state, and task. Those decisions form your baseline contract. Preserve them unless there is strong evidence they should be overturned.
 
-If you need clarification from the main agent and runtime bridge instructions are present, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for concise updates when blocked, explicitly asked for progress, or when a recommendation or concern would benefit from immediate discussion. Keep coordination traffic tight and purposeful. Do not narrate your whole review through `contact_supervisor`.
+If you need clarification from the main agent and runtime bridge instructions are present, use the bridge-injected `contact_supervisor` (provided at runtime, so it is not in this agent's `tools:` list) with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for concise updates when blocked, explicitly asked for progress, or when a recommendation or concern would benefit from immediate discussion. Keep coordination traffic tight and purposeful. Do not narrate your whole review through `contact_supervisor`.
 
 Do not send routine completion handoffs. If no coordination is needed, return the final oracle recommendation normally. Fall back to generic `intercom` only if `contact_supervisor` is unavailable and the runtime bridge instructions identify a safe target.
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -52,4 +52,4 @@ Anything likely to go wrong, need clarification, or need careful verification.
 Keep the plan concrete. Another agent should be able to execute it without guessing what you meant.
 
 ## Supervisor coordination
-If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries that change the plan. Do not send routine completion handoffs; return the completed plan normally.
+If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use the bridge-injected `contact_supervisor` (provided at runtime, so it is not in this agent's `tools:` list) with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries that change the plan. Do not send routine completion handoffs; return the completed plan normally.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -49,4 +49,4 @@ Numbered findings with inline source citations.
 What could not be answered confidently. Suggested next steps.
 
 ## Supervisor coordination
-If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries that change the plan. Do not send routine completion handoffs; return the completed research brief normally.
+If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use the bridge-injected `contact_supervisor` (provided at runtime, so it is not in this agent's `tools:` list) with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries that change the plan. Do not send routine completion handoffs; return the completed research brief normally.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -61,7 +61,7 @@ Review a PR or issue by understanding the context, then verifying:
 - If review-only or no-edit instructions conflict with progress-writing instructions, review-only/no-edit wins. Do not write `progress.md`; mention the conflict in your final review only if it matters.
 
 ## Supervisor coordination
-If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Do not ask for clarification when the only conflict is review-only/no-edit versus progress-writing; no-edit wins. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries that change the review plan. Do not send routine completion handoffs; return the completed review normally.
+If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use the bridge-injected `contact_supervisor` (provided at runtime, so it is not in this agent's `tools:` list) with `reason: "need_decision"` and wait for the reply. Do not ask for clarification when the only conflict is review-only/no-edit versus progress-writing; no-edit wins. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries that change the review plan. Do not send routine completion handoffs; return the completed review normally.
 
 Fall back to generic `intercom` only if `contact_supervisor` is unavailable and the runtime bridge instructions identify a safe target. If no safe target is discoverable, do not guess.
 

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -47,4 +47,4 @@ Explain how the pieces connect.
 Name the first file another agent should open and why.
 
 ## Supervisor coordination
-If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries that change the plan. Do not send routine completion handoffs; return the completed scout findings normally.
+If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use the bridge-injected `contact_supervisor` (provided at runtime, so it is not in this agent's `tools:` list) with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries that change the plan. Do not send routine completion handoffs; return the completed scout findings normally.


### PR DESCRIPTION
The bundled `scout` / `planner` / `reviewer` / `oracle` / `researcher` agents reference `contact_supervisor` in their **Supervisor coordination** prose, but it is intentionally absent from their `tools:` frontmatter. The intercom runtime bridge injects `contact_supervisor` at dispatch time (`intercom-bridge.ts`), so the runtime behavior is correct — only the prose was silent about *why* the tool is not declared, which reads as a lying contract against the frontmatter.

This marks each first mention as bridge-injected (one line per file, `+5/-5` total):

> use the bridge-injected `contact_supervisor` (provided at runtime, so it is not in this agent's `tools:` list) ...

No behavior change — documentation only.