### PR TITLE
fix: animate spinner in foreground and async subagent widgets

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -179,6 +179,11 @@ function parseSubagentNotifyContent(content: string): SubagentNotifyDetails | un
 	};
 }
 
+interface ResultRenderContext {
+	state: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> };
+	invalidate?: () => void;
+}
+
 class SubagentControlNoticeComponent implements Component {
 	constructor(
 		private readonly details: SubagentControlMessageDetails,
@@ -456,7 +461,23 @@ DIAGNOSTICS:
 
 		renderResult(result, options, theme, context) {
 			clearLegacyResultAnimationTimer(context);
-			return renderSubagentResult(result, options, theme);
+			const component = renderSubagentResult(result, options, theme);
+			const hasRunning = result.details?.progress?.some((p: { status?: string }) => p.status === "running")
+				|| result.details?.results.some((r: { progress?: { status?: string } }) => r.progress?.status === "running");
+			const renderCtx = context as ResultRenderContext;
+			if (hasRunning && renderCtx.invalidate) {
+				const timer = setInterval(() => {
+					renderCtx.invalidate?.();
+				}, 120);
+				timer.unref?.();
+				renderCtx.state.subagentResultAnimationTimer = timer;
+				const originalDispose = (component as { dispose?: () => void }).dispose;
+				(component as { dispose?: () => void }).dispose = () => {
+					clearInterval(timer);
+					originalDispose?.();
+				};
+			}
+			return component;
 		},
 
 	};

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -104,7 +104,8 @@ function runningSeed(...values: Array<number | undefined>): number | undefined {
 
 function runningGlyph(seed?: number): string {
 	if (seed === undefined) return STATIC_RUNNING_GLYPH;
-	return RUNNING_FRAMES[Math.abs(seed) % RUNNING_FRAMES.length]!;
+	const timeSeed = Math.floor(Date.now() / 120);
+	return RUNNING_FRAMES[Math.abs(seed + timeSeed) % RUNNING_FRAMES.length]!;
 }
 
 function progressRunningSeed(progress: ProgressSeedSource | undefined): number | undefined {
@@ -915,15 +916,17 @@ function fitWidgetLineBudget(lines: string[], theme: Theme, width: number, expan
 
 function buildWidgetComponent(jobs: AsyncJobState[], expanded: boolean): (_tui: unknown, theme: Theme) => Component {
 	return (_tui, theme) => {
-		const width = getTermWidth();
-		const lines = expanded
-			? buildWidgetLines(jobs, theme, width, true)
-			: jobs.length === 1
-				? compactSingleWidgetLines(jobs[0]!, theme, width)
-				: buildWidgetLines(jobs, theme, width, false);
-		const container = new Container();
-		for (const line of fitWidgetLineBudget(lines, theme, width, expanded)) container.addChild(new Text(line, 1, 0));
-		return container;
+		return {
+			render: (width: number) => {
+				const lines = expanded
+					? buildWidgetLines(jobs, theme, width, true)
+					: jobs.length === 1
+						? compactSingleWidgetLines(jobs[0]!, theme, width)
+						: buildWidgetLines(jobs, theme, width, false);
+				return fitWidgetLineBudget(lines, theme, width, expanded);
+			},
+			invalidate: () => {},
+		};
 	};
 }
 
@@ -997,10 +1000,38 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 	return lines;
 }
 
+let widgetAnimationTimer: ReturnType<typeof setInterval> | undefined;
+let widgetAnimationCtx: ExtensionContext | undefined;
+
+function clearWidgetAnimationTimer(): void {
+	if (widgetAnimationTimer) {
+		clearInterval(widgetAnimationTimer);
+		widgetAnimationTimer = undefined;
+		widgetAnimationCtx = undefined;
+	}
+}
+
+function ensureWidgetAnimationTimer(ctx: ExtensionContext, jobs: AsyncJobState[]): void {
+	const hasRunning = jobs.some((job) => job.status === "running");
+	if (!hasRunning) {
+		clearWidgetAnimationTimer();
+		return;
+	}
+	if (widgetAnimationTimer) return;
+	widgetAnimationCtx = ctx;
+	widgetAnimationTimer = setInterval(() => {
+		if (widgetAnimationCtx?.hasUI) {
+			widgetAnimationCtx.ui.requestRender?.();
+		}
+	}, 120);
+	widgetAnimationTimer.unref?.();
+}
+
 /**
  * Render the async jobs widget
  */
 export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void {
+	ensureWidgetAnimationTimer(ctx, jobs);
 	if (jobs.length === 0) {
 		if (ctx.hasUI) ctx.ui.setWidget(WIDGET_KEY, undefined);
 		return;


### PR DESCRIPTION
## Problem

The spinner (running glyph) in both foreground subagent results and async widget frequently freezes during long-running subagent tasks — especially when the child agent is waiting for LLM responses with no status file updates.

## Root Cause

1. **No animation driver**: The spinner glyph was computed from static state values (seed = sum of toolCount/durationMs/etc). When the subagent went idle waiting for LLM, none of these values changed, so the rendered glyph stayed frozen on the same frame.
2. **Static component tree**:  created a  of  nodes at render time. The text content was baked in and never refreshed unless  changed (which only happens on status file updates).
3. **Missing foreground timer**: The foreground  had no mechanism to trigger periodic re-renders while the subagent was running.

## Changes

### 
- ****: Now mixes  into the seed, so the selected Braille frame rotates continuously (~8fps) even when underlying state is unchanged.
- ****: Returns a dynamic component whose  callback recalculates all lines on every TUI frame, instead of pre-computing a static .
- **Widget animation timer**: Added  / . When any async job is , a  calls  to keep the widget refreshing. Cleared automatically when all jobs finish.
- ****: Added to the widget component for pi-tui contract compliance.

### 
- ****: Extracted a typed interface for the render context, replacing scattered  assertions.
- ****: When the result still has running children, creates a  that calls . The timer is automatically cleaned up via a  hook on the returned component (called by pi-tui when the tool result is removed from the chat).

## Verification

- Async widget spinner rotates smoothly during 20–30 second LLM waits.
- Foreground result spinner rotates smoothly while the child agent streams output.
- Both timers are cleaned up after the subagent completes (no leaks observed in session logs).
