### PR TITLE
fix: return final assistant text part for multi-part responses

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -192,7 +192,8 @@ export function getFinalOutput(messages: Message[]): string {
 			const hasAssistantError = ("errorMessage" in msg && typeof msg.errorMessage === "string" && msg.errorMessage.length > 0)
 				|| ("stopReason" in msg && msg.stopReason === "error");
 			if (hasAssistantError) continue;
-			for (const part of msg.content) {
+			for (let j = msg.content.length - 1; j >= 0; j--) {
+				const part = msg.content[j];
 				if (part.type === "text" && part.text.trim().length > 0) return part.text;
 			}
 		}

--- a/test/unit/get-final-output.test.ts
+++ b/test/unit/get-final-output.test.ts
@@ -8,13 +8,23 @@ function assistantContent(content: unknown[]): Message {
 }
 
 describe("getFinalOutput", () => {
-	it("uses the first non-empty text part in the latest assistant message", () => {
+	it("uses the last non-empty text part in the latest assistant message", () => {
 		const messages = [assistantContent([
 			{ type: "text", text: "" },
 			{ type: "text", text: "Summary" },
 		])];
 
 		assert.equal(getFinalOutput(messages), "Summary");
+	});
+
+	it("prefers final text over progress text in a multi-part assistant message", () => {
+		const messages = [assistantContent([
+			{ type: "text", text: "Working on the fix..." },
+			{ type: "thinking", thinking: "Cursor shell: shell $ npm test" },
+			{ type: "text", text: "Implemented: patch applied." },
+		])];
+
+		assert.equal(getFinalOutput(messages), "Implemented: patch applied.");
 	});
 
 	it("falls back to an older assistant message when the latest text is whitespace-only", () => {


### PR DESCRIPTION
## Summary

- Return the last non-empty text part from the latest non-error assistant message.
- Add a regression test for multi-part assistant messages with progress text before final text.

## Why

Cursor Composer can emit one assistant message with multiple content parts: early progress text, thinking/tool metadata, then the final answer as a later text part. `getFinalOutput()` currently scans content forwards, so parent output/artifacts can capture the progress text instead of the final result.

Observed locally with a Composer worker smoke test: before this fix, the artifact captured only progress text like `Running diagnostic smoke...`; after scanning backwards, the artifact contained the final `LIVE TEST PASS` report.

## Tests

- `node --experimental-strip-types --test test/unit/get-final-output.test.ts`
- `npm test` attempted: 501 pass / 2 fail. Existing environment-sensitive failures in `agent-frontmatter.test.ts` and `intercom-bridge.test.ts` unrelated to this change.
