### PR TITLE
fix: remove allOf/anyOf/const/if/then from tool schemas for provider compat

### DIFF
--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -77,37 +77,59 @@ const AcceptanceReviewGateSchema = Type.Object({
 	required: Type.Optional(Type.Boolean()),
 }, { additionalProperties: false });
 
+// Uses type unions (type:[...]) instead of anyOf/allOf/const to avoid
+// JSON Schema keywords that some provider APIs (kimi/Moonshot,
+// Antigravity proxy) do not support in tool function.parameters.
+// Validation for malformed inputs is handled at runtime by
+// validateAcceptanceInput() / normalizeAcceptanceInput().
 const AcceptanceOverride = Type.Unsafe({
-	anyOf: [
-		{ type: "string", enum: ["auto", "none", "attested", "checked", "verified", "reviewed"] },
-		{ const: false },
-		{
-			type: "object",
+	type: ["string", "boolean", "object"],
+	properties: {
+		level: { type: "string", enum: ["auto", "none", "attested", "checked", "verified", "reviewed"] },
+		criteria: {
+			type: "array",
+			items: {
+				type: ["string", "object"],
+				properties: {
+					id: { type: "string" },
+					must: { type: "string" },
+					evidence: { type: "array", items: { type: "string", enum: ["changed-files", "tests-added", "commands-run", "validation-output", "residual-risks", "no-staged-files", "diff-summary", "review-findings", "manual-notes"] } },
+					severity: { type: "string", enum: ["required", "recommended"] },
+				},
+				required: ["id", "must"],
+				additionalProperties: false,
+			},
+		},
+		evidence: { type: "array", items: { type: "string", enum: ["changed-files", "tests-added", "commands-run", "validation-output", "residual-risks", "no-staged-files", "diff-summary", "review-findings", "manual-notes"] } },
+		verify: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					id: { type: "string" },
+					command: { type: "string" },
+					timeoutMs: { type: "integer", minimum: 1 },
+					cwd: { type: "string" },
+					env: { type: "object", additionalProperties: { type: "string" } },
+					allowFailure: { type: "boolean" },
+				},
+				required: ["id", "command"],
+				additionalProperties: false,
+			},
+		},
+		review: {
+			type: ["boolean", "object"],
 			properties: {
-				level: { type: "string", enum: ["auto", "none", "attested", "checked", "verified", "reviewed"] },
-				criteria: {
-					type: "array",
-					items: {
-						anyOf: [
-							{ type: "string" },
-							AcceptanceGateSchema,
-						],
-					},
-				},
-				evidence: { type: "array", items: AcceptanceEvidenceKind },
-				verify: { type: "array", items: AcceptanceVerifyCommandSchema },
-				review: {
-					anyOf: [
-						{ const: false },
-						AcceptanceReviewGateSchema,
-					],
-				},
-				stopRules: { type: "array", items: { type: "string" } },
-				reason: { type: "string" },
+				agent: { type: "string" },
+				focus: { type: "string" },
+				required: { type: "boolean" },
 			},
 			additionalProperties: false,
 		},
-	],
+		stopRules: { type: "array", items: { type: "string" } },
+		reason: { type: "string" },
+	},
+	additionalProperties: false,
 	description: "Optional acceptance policy. Omitted means auto-inferred; verified requires configured runtime commands.",
 });
 
@@ -210,12 +232,7 @@ const ChainItem = Type.Object({
 	})),
 }, {
 	description: "Chain step: use {agent, task?, ...} for sequential, {parallel: [...]} for static concurrent execution, or {expand, parallel: {...}, collect} for dynamic fanout.",
-	additionalProperties: false,
-	allOf: [
-		{ if: { required: ["expand"] }, then: { required: ["parallel", "collect"], properties: { parallel: { type: "object" } } } },
-		{ if: { required: ["collect"] }, then: { required: ["expand", "parallel"], properties: { parallel: { type: "object" } } } },
-		{ not: { required: ["expand"], properties: { parallel: { type: "array", items: {} } } } },
-	],
+	additionalProperties: true,
 });
 
 const ControlOverrides = Type.Object({


### PR DESCRIPTION
## Problem

Providers with limited JSON Schema support (kimi/Moonshot, Antigravity proxy, and potentially others) reject the `subagent` tool registration because the parameter schema contains keywords not supported by their minimal JSON Schema parsers:

- **`AcceptanceOverride`**: Uses `anyOf` with 3 alternatives (string enum, `const: false`, nested object with nested `anyOf` in criteria.items and review)
- **`ChainItem`**: Uses `allOf` with `if`/`then`/`not` conditional constraints

kimi returns:
```
Error: 400 Error from provider: JSON Schema not supported: could not understand the instance {required: [criteria]}
```
then:
```
Error: 400 Error from provider: Conflict in schema definitions for key if. Previous: {required: [expand]}, New: {required: [collect]}
```

Antigravity proxy (Google Cloud Code Assist): same class of error with `anyOf`/`const` (previously noted in CHANGELOG).

## Fix

Two changes in `src/extension/schemas.ts`:

### 1. `AcceptanceOverride` — no `anyOf`/`allOf`/`const` keywords

| Before | After |
|---|---|
| Top-level `anyOf` with 3 alternatives (string, `const: false`, object) | `type: ["string", "boolean", "object"]` — same expressiveness, basic JSON Schema |
| `criteria.items.anyOf` with string/AcceptanceGateSchema | `type: ["string", "object"]` with inline properties (`id`, `must`, `evidence`, `severity`) and `required: ["id", "must"]` |
| `review.anyOf` with `const: false` / AcceptaceReviewGateSchema | `type: ["boolean", "object"]` with inline properties (`agent`, `focus`, `required`) |

All field-level type constraints are **preserved** — `verify` must be array, `stopRules` must be array, `criteria` items must be string or object with `id`+`must`, etc. A malformed input like `{ verify: "npm test" }` still fails schema validation because `verify.type` is `"array"`.

### 2. `ChainItem` — remove `allOf` with `if`/`then`/`not`

Replace the conditional schema (expand requires parallel+collect, collect requires expand+parallel, expand without parallel type=array) with `additionalProperties: true`. The expand/collect/parallel conditional logic is enforced by runtime execution code.

## Verification

- Tested with kimi (moonshot/kimi-k2.6) via OpenCode Go subscription: `subagent()` calls with acceptance blocks work without 400 errors
- Structural validation preserved: malformed acceptance objects (wrong types) still rejected by schema
- All runtime validation paths (`validateAcceptanceInput()`, `normalizeAcceptanceInput()`) unchanged
- No `allOf`/`anyOf`/`const`/`if`/`then`/`not` in AcceptanceOverride or ChainItem schemas

## Related

- CHANGELOG previously noted `anyOf`/`const` issues with Antigravity proxy
- This extends the fix to cover `allOf`/`if`/`then`/`not` keywords and applies to the acceptance schema