### PR TITLE
Trim repeated schema descriptions -> save tokens -> profit 

### DIFF
--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -10,16 +10,18 @@ function keepTopLevelParameterDescriptions<T>(schema: T): T {
 }
 
 function pruneNestedDescriptions(value: unknown, path: string[]): unknown {
-	if (Array.isArray(value)) return value.map((item, index) => pruneNestedDescriptions(item, [...path, String(index)]));
 	if (!value || typeof value !== "object") return value;
 
-	const result: Record<string | symbol, unknown> = {};
-	for (const [key, childValue] of Object.entries(value)) {
+	const result = Array.isArray(value) ? [] : Object.create(Object.getPrototypeOf(value));
+	for (const key of Reflect.ownKeys(value)) {
+		const descriptor = Object.getOwnPropertyDescriptor(value, key);
+		if (!descriptor) continue;
 		if (key === "description" && !isTopLevelParameterDescription(path)) continue;
-		result[key] = pruneNestedDescriptions(childValue, [...path, key]);
-	}
-	for (const symbol of Object.getOwnPropertySymbols(value)) {
-		result[symbol] = (value as Record<symbol, unknown>)[symbol];
+		if ("value" in descriptor) {
+			const nextPath = typeof key === "string" ? [...path, key] : path;
+			descriptor.value = pruneNestedDescriptions(descriptor.value, nextPath);
+		}
+		Object.defineProperty(result, key, descriptor);
 	}
 	return result;
 }

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -5,6 +5,29 @@
 import { Type } from "typebox";
 import { SUBAGENT_ACTIONS } from "../shared/types.ts";
 
+function keepTopLevelParameterDescriptions<T>(schema: T): T {
+	return pruneNestedDescriptions(schema, []) as T;
+}
+
+function pruneNestedDescriptions(value: unknown, path: string[]): unknown {
+	if (Array.isArray(value)) return value.map((item, index) => pruneNestedDescriptions(item, [...path, String(index)]));
+	if (!value || typeof value !== "object") return value;
+
+	const result: Record<string | symbol, unknown> = {};
+	for (const [key, childValue] of Object.entries(value)) {
+		if (key === "description" && !isTopLevelParameterDescription(path)) continue;
+		result[key] = pruneNestedDescriptions(childValue, [...path, key]);
+	}
+	for (const symbol of Object.getOwnPropertySymbols(value)) {
+		result[symbol] = (value as Record<symbol, unknown>)[symbol];
+	}
+	return result;
+}
+
+function isTopLevelParameterDescription(path: string[]): boolean {
+	return path.length === 2 && path[0] === "properties";
+}
+
 const SkillOverride = Type.Unsafe({
 	anyOf: [
 		{ type: "array", items: { type: "string" } },
@@ -221,7 +244,7 @@ const ControlOverrides = Type.Object({
 	})),
 });
 
-export const SubagentParams = Type.Object({
+const SubagentParamsSchema = Type.Object({
 	agent: Type.Optional(Type.String({ description: "Agent name (SINGLE mode) or target for management get/update/delete" })),
 	task: Type.Optional(Type.String({ description: "Task (SINGLE mode, optional for self-contained agents)" })),
 	// Management action (when present, tool operates in management mode)
@@ -292,3 +315,5 @@ export const SubagentParams = Type.Object({
 	model: Type.Optional(Type.String({ description: "Override model for single agent (e.g. 'anthropic/claude-sonnet-4')" })),
 	acceptance: Type.Optional(AcceptanceOverride),
 });
+
+export const SubagentParams = keepTopLevelParameterDescriptions(SubagentParamsSchema);

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -100,6 +100,17 @@ function isRequiredOnlySchema(value: unknown): boolean {
 	return keys.length === 1 && keys[0] === "required";
 }
 
+function getPropertySchema(schema: JsonSchemaNode | undefined, path: string[]): JsonSchemaNode | undefined {
+	let current: unknown = schema;
+	for (const key of path) {
+		if (!current || typeof current !== "object") return undefined;
+		current = (current as JsonSchemaNode).properties;
+		if (!current || typeof current !== "object") return undefined;
+		current = (current as Record<string, unknown>)[key];
+	}
+	return current && typeof current === "object" ? current as JsonSchemaNode : undefined;
+}
+
 let schemas: Record<string, JsonSchemaNode> = {};
 let SubagentParams: SubagentParamsSchema | undefined;
 let schemasAvailable = true;
@@ -262,22 +273,27 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 
 	it("does not encode acceptance contract presence with required-only schema nodes", () => {
 		const rejectedPaths: string[] = [];
+		const acceptanceRootPaths: string[] = [];
 
 		for (const [name, schema] of Object.entries(schemas)) {
 			const stack: Array<{ path: string; value: unknown; insideAcceptance: boolean }> = [{ path: name, value: schema, insideAcceptance: false }];
 			while (stack.length > 0) {
 				const current = stack.pop()!;
-				const insideAcceptance = current.insideAcceptance
-					|| (current.value && typeof current.value === "object" && !Array.isArray(current.value) && String((current.value as JsonSchemaNode).description ?? "").startsWith("Optional acceptance contract."));
-				if (insideAcceptance && isRequiredOnlySchema(current.value)) rejectedPaths.push(current.path);
+				if (current.insideAcceptance && isRequiredOnlySchema(current.value)) rejectedPaths.push(current.path);
 				if (Array.isArray(current.value)) {
-					current.value.forEach((value, index) => stack.push({ path: `${current.path}[${index}]`, value, insideAcceptance }));
+					current.value.forEach((value, index) => stack.push({ path: `${current.path}[${index}]`, value, insideAcceptance: current.insideAcceptance }));
 				} else if (current.value && typeof current.value === "object") {
-					for (const [key, value] of Object.entries(current.value)) stack.push({ path: `${current.path}.${key}`, value, insideAcceptance });
+					for (const [key, value] of Object.entries(current.value)) {
+						const startsAcceptance = key === "acceptance";
+						const nextPath = `${current.path}.${key}`;
+						if (startsAcceptance) acceptanceRootPaths.push(nextPath);
+						stack.push({ path: nextPath, value, insideAcceptance: current.insideAcceptance || startsAcceptance });
+					}
 				}
 			}
 		}
 
+		assert.ok(acceptanceRootPaths.length >= 5, `expected to inspect nested acceptance schemas, got ${acceptanceRootPaths.join(", ")}`);
 		assert.deepEqual(rejectedPaths, []);
 	});
 
@@ -308,6 +324,26 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 			}
 		}
 		assert.deepEqual(nestedDescriptionPaths, []);
+	});
+
+	it("preserves TypeBox metadata while pruning provider-visible descriptions", () => {
+		assert.ok(SubagentParams, "SubagentParams schema should exist");
+		const schema = SubagentParams as unknown as JsonSchemaNode;
+		const rootKind = Object.getOwnPropertyDescriptor(schema, "~kind");
+		assert.equal(rootKind?.value, "Object");
+		assert.equal(rootKind?.enumerable, false);
+
+		const agentSchema = getPropertySchema(schema, ["agent"]);
+		assert.equal(Object.getOwnPropertyDescriptor(agentSchema, "~kind")?.enumerable, false);
+		assert.equal(Object.getOwnPropertyDescriptor(agentSchema, "~optional")?.value, true);
+		assert.equal(Object.getOwnPropertyDescriptor(agentSchema, "~optional")?.enumerable, false);
+
+		const tasksSchema = getPropertySchema(schema, ["tasks"]);
+		const taskItemsSchema = tasksSchema?.items as JsonSchemaNode | undefined;
+		const taskCountSchema = getPropertySchema(taskItemsSchema, ["count"]);
+		assert.equal(Object.getOwnPropertyDescriptor(taskCountSchema, "~kind")?.enumerable, false);
+		assert.equal(Object.getOwnPropertyDescriptor(taskCountSchema, "~optional")?.value, true);
+		assert.equal(Object.getOwnPropertyDescriptor(taskCountSchema, "~optional")?.enumerable, false);
 	});
 
 	it("does not emit provider-rejected union schema shapes", () => {

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -136,7 +136,6 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		const taskCountSchema = taskSchema?.count;
 		assert.ok(taskCountSchema, "tasks[].count schema should exist");
 		assert.equal(taskCountSchema.minimum, 1);
-		assert.match(String(taskCountSchema.description ?? ""), /repeat/i);
 		const outputSchema = taskSchema?.output as JsonSchemaNode | undefined;
 		assert.equal(outputSchema?.type, undefined);
 		assert.equal(hasAnyOfType(outputSchema, "string"), true);
@@ -282,6 +281,35 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		assert.deepEqual(rejectedPaths, []);
 	});
 
+	it("keeps only top-level parameter descriptions to keep the provider payload compact", () => {
+		assert.ok(SubagentParams, "SubagentParams schema should exist");
+		const schema = SubagentParams as unknown as JsonSchemaNode;
+		const serialized = JSON.stringify(schema);
+		assert.ok(serialized.length < 17_000, `expected compact schema under 17k chars, got ${serialized.length}`);
+		assert.equal(serialized.includes('"$ref"'), false);
+		assert.equal(serialized.includes('"$defs"'), false);
+		assert.equal(serialized.split("Optional acceptance contract. Use this for goal-style").length - 1, 1);
+		assert.match(String((schema.properties as Record<string, JsonSchemaNode> | undefined)?.agent?.description ?? ""), /SINGLE mode/);
+		assert.match(String((schema.properties as Record<string, JsonSchemaNode> | undefined)?.acceptance?.description ?? ""), /acceptance contract/);
+
+		const nestedDescriptionPaths: string[] = [];
+		const stack: Array<{ path: string; value: unknown }> = [{ path: "SubagentParams", value: schema }];
+		while (stack.length > 0) {
+			const current = stack.pop()!;
+			if (!current.value || typeof current.value !== "object") continue;
+			const node = current.value as JsonSchemaNode;
+			const pathParts = current.path.split(".");
+			const isTopLevelParameter = pathParts.length === 3 && pathParts[0] === "SubagentParams" && pathParts[1] === "properties";
+			if (typeof node.description === "string" && !isTopLevelParameter) nestedDescriptionPaths.push(`${current.path}.description`);
+			if (Array.isArray(current.value)) {
+				current.value.forEach((value, index) => stack.push({ path: `${current.path}[${index}]`, value }));
+			} else {
+				for (const [key, value] of Object.entries(node)) stack.push({ path: `${current.path}.${key}`, value });
+			}
+		}
+		assert.deepEqual(nestedDescriptionPaths, []);
+	});
+
 	it("does not emit provider-rejected union schema shapes", () => {
 		const rejectedPaths: string[] = [];
 
@@ -402,6 +430,10 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 			{ agent: "worker", task: "Fix", acceptance: { criteria: ["Patch the bug"], evidence: ["changed-files"], maxFinalizationTurns: 2 } },
 			{ agent: "worker", task: "Fix", acceptance: { verify: [{ id: "unit", command: "npm test" }] } },
 			{ agent: "worker", task: "Fix", acceptance: {} },
+			{ tasks: [{ agent: "worker", task: "Fix", acceptance: { verify: [{ id: "unit", command: "npm test" }] } }] },
+			{ chain: [{ agent: "worker", acceptance: { criteria: ["Patch the bug"] } }] },
+			{ chain: [{ parallel: [{ agent: "worker", acceptance: { evidence: ["diff-summary"] } }] }] },
+			{ chain: [{ expand: { from: { output: "targets", path: "/items" }, maxItems: 4 }, parallel: { agent: "worker", acceptance: { review: { required: true } } }, collect: { as: "reviews" } }] },
 			{ config: { name: "reviewer", description: "Review things" } },
 			{ config: JSON.stringify({ name: "reviewer", description: "Review things" }) },
 		];
@@ -425,6 +457,10 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 			{ agent: "worker", task: "Fix", acceptance: false },
 			{ agent: "worker", task: "Fix", acceptance: { level: "checked" } },
 			{ agent: "worker", task: "Fix", acceptance: { criteria: ["Patch"], review: true } },
+			{ tasks: [{ agent: "worker", task: "Fix", acceptance: true }] },
+			{ chain: [{ agent: "worker", acceptance: { level: "checked" } }] },
+			{ chain: [{ parallel: [{ agent: "worker", acceptance: { criteria: ["Patch"], review: true } }] }] },
+			{ chain: [{ expand: { from: { output: "targets", path: "/items" }, maxItems: 4 }, parallel: { agent: "worker", acceptance: { level: "checked" } }, collect: { as: "reviews" } }] },
 			{ config: [] },
 			{ config: null },
 		];


### PR DESCRIPTION
⚠️ ⚠️ **Targets `feat/acceptance-finalization` / `v0.28.0`, which looks newer than `main`. Happy to rebase** ⚠️ ⚠️

Hey Nico!

I was doing a context scrub for my Pi and noticed the `subagent` tool schema has quite a bit of repeated nested description text esp. for `acceptance`, chain steps, parallel & dynamic fanout.

It looks like this was mostly added around 0.26/27 dynamic fanout + acceptance-contract.

Adding this small PR to keep the same behaviour but trim nested description fields. 

Gets 32% fewer chars (25k->17k). Comparing OpenAI+Ant reported before/after tokens, I get:
- 13% saving for openai (3.0k->2.6k tokens)
- 21% saving for opus-4-8 (11.6k->9.1k tokens)

Used/tested it a bunch locally today and seems to be working well. Let me know what you think!

Thomas

Pi description: 
## Summary
- prune nested `description` fields from the exported `SubagentParams` tool schema while keeping top-level parameter descriptions
- preserve TypeBox non-enumerable metadata/property descriptors while pruning provider-visible descriptions
- keep the provider payload inline and portable: no `$ref` / `$defs`
- add regression coverage for schema compactness, TypeBox metadata preservation, and nested acceptance validation paths

## Size impact
- `SubagentParams` serialized schema: `24,359` → `16,564` chars
- saves `7,795` chars (~32.0%) in the source JSON Schema
- measured live-provider token impact with Pi CLI, thinking off, prompt `hi`, and only the `subagent` tool enabled:
  - Anthropic Claude Opus 4.8: `11,604` → `9,142` total tokens (`11.6k` → `9.1k`), saving `2,462` tokens (~21.2%)
  - Anthropic reports this schema-heavy portion as prompt cache write: `11,598` → `9,136` cache-write tokens
  - OpenAI-Codex GPT-5.5 showed provider-side accounting variance; the stable lower-regime comparison was `2,967` → `2,576` input tokens (`3.0k` → `2.6k`), saving `391` tokens (~13.2%), while some old-schema runs counted as high as `5,006` input tokens
- long acceptance-contract prose appears once instead of being duplicated through nested schema copies
## Test plan
- `mise x node@24.16.0 -- npm test` — 510/510 passing
- `mise x node@24.16.0 -- npm run test:integration` — 377/377 passing
- `mise x node@24.16.0 -- npm run test:all` — unit + integration passing
- `mise x node@24.16.0 -- npm pack --dry-run`

## Notes
- This targets `feat/acceptance-finalization` because that branch contains `v0.28.0`; `main` currently appears to lag at `v0.26.0`, which would make the PR unnecessarily noisy.

