### PR TITLE
fix: prevent skill files from being registered as subagents

### DIFF
--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -576,6 +576,14 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			continue;
 		}
 
+		// Skip skill files that are masquerading as agent definitions.
+		// Skill files typically contain a `metadata` or `version` frontmatter
+		// key that agent definitions do not use. If either is present, treat
+		// the file as a skill and skip agent registration.
+		if ("metadata" in frontmatter || "version" in frontmatter) {
+			continue;
+		}
+
 		const localName = frontmatter.name;
 		const parsedPackage = parsePackageName(frontmatter.package, `Agent '${localName}' package`);
 		if (parsedPackage.error) continue;


### PR DESCRIPTION
## Problem

The agent discovery scanner recursively walks the user agent directory tree looking for agent definition files. Because skill packages install their sub-skills under the same tree, the scanner treats `SKILL.md` files as agent definitions and registers them as executable subagents.

This causes two problems:

1. **Concept conflation**: Skills (prompt fragments meant to be injected into an agent's system prompt) are registered as agents (independent sub-processes with their own model/tools/context).
2. **Registry bloat**: `subagent list` output inflates from ~10 real agents to 100+ entries, making it unreadable and polluting the agent namespace.

## Root cause

`loadAgentsFromDir` validates that a `.md` file has `name` and `description` frontmatter, then registers it as an agent. Skill files also contain `name` and `description`, so they pass validation and get registered.

## Fix

After validating `name` and `description`, check whether the frontmatter also contains a `metadata` or `version` key. These keys are standard in skill files but not used in agent definitions. If either is present, skip the file instead of registering it as an agent.

This is robust regardless of where skill files live in the directory tree — no hard-coded directory names needed.

### Changes

- `src/agents/agents.ts`:
  - `loadAgentsFromDir`: added frontmatter check for `metadata` or `version` keys to filter out skill files

## Verification

- All 463 existing unit tests pass.
- The fix is surgical: only the agent discovery path is affected; skill resolution (`skills.ts`) remains unchanged.

Fixes #257