### PR TITLE
fix(executor): inherit parent ctx.model instead of global settings.json fallback

### DIFF
--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1091,9 +1091,15 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 
 	if (hasTasks && params.tasks) {
 		const agentConfigs = params.tasks.map((task) => agents.find((agent) => agent.name === task.agent));
-		const modelOverrides = params.tasks.map((task, index) =>
-			resolveModelCandidate(task.model ?? agentConfigs[index]?.model, availableModels, currentProvider),
-		);
+		const modelOverrides = params.tasks.map((task, index) => {
+			const rawModel = (task.model ?? agentConfigs[index]?.model) || undefined;
+			// "inherit" or no model specified → use parent session's actual model to avoid
+			// falling back to the global settings.json default (cross-session contamination).
+			if ((rawModel === "inherit" || rawModel === undefined) && ctx.model) {
+				return `${ctx.model.provider}/${ctx.model.id}`;
+			}
+			return resolveModelCandidate(rawModel, availableModels, currentProvider);
+		});
 		const skillOverrides = params.tasks.map((task) => normalizeSkillInput(task.skill));
 		const parallelTasks = params.tasks.map((task, index) => ({
 			agent: task.agent,
@@ -1179,7 +1185,12 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const normalizedSkills = normalizeSkillInput(params.skill);
 		const skills = normalizedSkills === false ? [] : normalizedSkills;
 		const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, a.maxSubagentDepth);
-		const modelOverride = resolveModelCandidate((params.model as string | undefined) ?? a.model, availableModels, currentProvider);
+		const rawModelSingle = ((params.model as string | undefined) ?? (a.model || undefined));
+		// "inherit" or no model specified → use parent session's actual model to avoid
+		// falling back to the global settings.json default (cross-session contamination).
+		const modelOverride = (rawModelSingle === "inherit" || rawModelSingle === undefined) && ctx.model
+			? `${ctx.model.provider}/${ctx.model.id}`
+			: resolveModelCandidate(rawModelSingle, availableModels, currentProvider);
 		return executeAsyncSingle(id, {
 			agent: params.agent!,
 			task: params.context === "fork" ? wrapForkTask(params.task ?? "") : (params.task ?? ""),


### PR DESCRIPTION
Fixes #266

## Problem

When multiple PI sessions are open with different models, subagents spawned from Session B inherit Session A's model because:
1. `model: "inherit"` is not handled — returned as the literal string, passed as `--model inherit` to child process
2. Child process fails to resolve `"inherit"` as a model, falls back to `~/.pi/agent/settings.json` default
3. `settings.json` is a **shared global file** written by any session's TUI model switch — causing cross-session contamination
4. Same bug affects `delegate` agent (`model: false`): no model is passed to child, same global fallback occurs

See issue #266 for full root cause analysis with code references.

## Changes

`src/runs/foreground/subagent-executor.ts`:
- **Parallel path**: convert `modelOverrides` map from arrow-expression to block, detect `undefined`/`"inherit"`, use `ctx.model.provider/id` directly
- **Single-agent path**: same logic inline before `executeAsyncSingle`

Both changes use `ctx.model` (parent session's in-memory model) instead of letting the child fall through to the global settings default.