### PR TITLE
Use requester context for slash bridge runs

### DIFF
--- a/src/slash/slash-bridge.ts
+++ b/src/slash/slash-bridge.ts
@@ -13,6 +13,8 @@ import {
 interface SlashSubagentRequest {
 	requestId: string;
 	params: SubagentParamsLike;
+	/** Optional requester context for in-process extension bridge calls. */
+	ctx?: ExtensionContext;
 }
 
 export interface SlashSubagentResponse {
@@ -77,7 +79,7 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
 		if (typeof request.requestId !== "string" || !request.params) return;
 		const { requestId, params } = request as SlashSubagentRequest;
 
-		const ctx = options.getContext();
+		const ctx = request.ctx ?? options.getContext();
 		if (!ctx) {
 			const response: SlashSubagentResponse = {
 				requestId,

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -245,7 +245,7 @@ async function requestSlashRun(
 			next();
 		};
 
-		pi.events.emit(SLASH_SUBAGENT_REQUEST_EVENT, { requestId, params });
+		pi.events.emit(SLASH_SUBAGENT_REQUEST_EVENT, { requestId, params, ctx });
 
 		// Bridge emits STARTED synchronously during REQUEST emit.
 		// If not started, no bridge received the request.

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -218,6 +218,7 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
 		const events = createEventBus();
 		let requestedParams: unknown;
+		let requestedCtx: unknown;
 		const sessionManager = {
 			flushed: false,
 			rewrites: 0,
@@ -227,8 +228,9 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 			},
 		};
 		events.on(SLASH_SUBAGENT_REQUEST_EVENT, (data) => {
-			const payload = data as { requestId: string; params?: unknown };
+			const payload = data as { requestId: string; params?: unknown; ctx?: unknown };
 			requestedParams = payload.params;
+			requestedCtx = payload.ctx;
 			events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId: payload.requestId });
 			events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, {
 				requestId: payload.requestId,
@@ -251,10 +253,12 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 			},
 		};
 
+		const ctx = createCommandContext({ sessionManager });
 		registerSlashCommands!(pi, createState(process.cwd()));
-		await commands.get("run")!.handler("scout", createCommandContext({ sessionManager }));
+		await commands.get("run")!.handler("scout", ctx);
 
 		assert.deepEqual(requestedParams, { agent: "scout", task: "", clarify: false, agentScope: "both" });
+		assert.equal(requestedCtx, ctx);
 		assert.equal(sent.length, 2);
 		assert.equal((sent[0] as { display?: boolean }).display, true);
 		assert.equal((sent[0] as { content?: string }).content, "Running subagent...");

--- a/test/unit/slash-bridge.test.ts
+++ b/test/unit/slash-bridge.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { registerSlashSubagentBridge } from "../../src/slash/slash-bridge.ts";
+
+const REQUEST = "subagent:slash:request";
+const RESPONSE = "subagent:slash:response";
+
+function eventBus() {
+  const handlers = new Map<string, Array<(data: unknown) => void>>();
+  return {
+    on(event: string, handler: (data: unknown) => void) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+      return () => handlers.set(event, (handlers.get(event) ?? []).filter((h) => h !== handler));
+    },
+    emit(event: string, data: unknown) {
+      for (const handler of handlers.get(event) ?? []) handler(data);
+    },
+  };
+}
+
+describe("slash subagent bridge requester context", () => {
+  it("uses request ctx instead of stale fallback context when provided", async () => {
+    const events = eventBus();
+    const fallbackCtx = { cwd: "/fallback" } as any;
+    const requestCtx = { cwd: "/request" } as any;
+    let executedCtx: any;
+
+    registerSlashSubagentBridge({
+      events,
+      getContext: () => fallbackCtx,
+      execute: async (_id, _params, _signal, _onUpdate, ctx) => {
+        executedCtx = ctx;
+        return { content: [{ type: "text", text: "ok" }], details: { mode: "single", results: [] } } as any;
+      },
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      events.on(RESPONSE, (data: any) => {
+        try {
+          assert.equal(data.isError, false);
+          assert.equal(executedCtx, requestCtx);
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+
+    events.emit(REQUEST, { requestId: "ctx-test", params: { action: "list" }, ctx: requestCtx });
+    await done;
+  });
+});


### PR DESCRIPTION
## Summary
- Pass the slash command caller `ExtensionContext` through the in-process slash bridge request.
- Prefer request-scoped context in the bridge while preserving the existing `lastUiContext` fallback for older/programmatic callers.
- Add regression coverage for both sides of the fix: bridge context selection and slash command request emission.

## Why
Slash invocations can originate from a different session/cwd than the last active UI context. If the bridge only falls back to `lastUiContext`, a normal slash run can execute in the wrong repo/session or fail when no UI context is cached.

## Review feedback addressed
- The in-repo slash caller now emits `{ requestId, params, ctx }`, so the primary `/run`, `/chain`, `/parallel`, `/run-chain`, and doctor slash paths use the caller context instead of relying on fallback state.

## Test plan
- `node --experimental-strip-types --test test/unit/slash-bridge.test.ts`
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/slash-commands.test.ts`
- `npm run test:all` — 503/504 passed locally; one unrelated local-environment failure in `test/unit/intercom-bridge.test.ts` because this machine has `pi-intercom` installed where that test expects it missing.
