### PR TITLE
Fix legacy skill files being discovered as subagents

### DIFF
--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -552,7 +552,11 @@ export function removeBuiltinAgentOverride(cwd: string, name: string, scope: "us
 	return filePath;
 }
 
-function listFilesRecursive(dir: string, predicate: (fileName: string) => boolean): string[] {
+function listFilesRecursive(
+	dir: string,
+	predicate: (fileName: string) => boolean,
+	options: { skipDirs?: Set<string> } = {},
+): string[] {
 	const files: string[] = [];
 	if (!fs.existsSync(dir)) return files;
 
@@ -566,7 +570,8 @@ function listFilesRecursive(dir: string, predicate: (fileName: string) => boolea
 	for (const entry of entries) {
 		const filePath = path.join(dir, entry.name);
 		if (entry.isDirectory()) {
-			files.push(...listFilesRecursive(filePath, predicate));
+			if (options.skipDirs?.has(path.resolve(filePath))) continue;
+			files.push(...listFilesRecursive(filePath, predicate, options));
 			continue;
 		}
 		if (!entry.isFile() && !entry.isSymbolicLink()) continue;
@@ -576,10 +581,15 @@ function listFilesRecursive(dir: string, predicate: (fileName: string) => boolea
 	return files;
 }
 
+function legacyAgentSkipDirs(dir: string): Set<string> | undefined {
+	return path.basename(dir) === ".agents" ? new Set([path.resolve(dir, "skills")]) : undefined;
+}
+
 function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	const agents: AgentConfig[] = [];
+	const skipDirs = legacyAgentSkipDirs(dir);
 
-	for (const filePath of listFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"))) {
+	for (const filePath of listFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"), { skipDirs })) {
 		let content: string;
 		try {
 			content = fs.readFileSync(filePath, "utf-8");

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -662,6 +662,66 @@ Canonical prompt
 		assert.equal(result.projectAgentsDir, path.join(dir, ".pi", "agents"));
 	});
 
+	it("does not discover project legacy skills as agents", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-project-legacy-skills-"));
+		tempDirs.push(dir);
+		fs.mkdirSync(path.join(dir, ".agents", "skills", "legacy-skill"), { recursive: true });
+		fs.writeFileSync(path.join(dir, ".agents", "legacy.md"), `---
+name: legacy
+description: Legacy
+---
+
+Legacy prompt
+`, "utf-8");
+		fs.writeFileSync(path.join(dir, ".agents", "skills", "legacy-skill", "SKILL.md"), `---
+name: legacy-skill
+description: Legacy skill
+---
+
+Legacy skill prompt
+`, "utf-8");
+
+		const result = discoverAgents(dir, "project");
+		assert.ok(result.agents.find((agent) => agent.name === "legacy"));
+		assert.equal(result.agents.find((agent) => agent.name === "legacy-skill"), undefined);
+	});
+
+	it("does not discover user legacy skills as agents", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-user-legacy-skills-project-"));
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-user-legacy-skills-home-"));
+		tempDirs.push(dir, home);
+		const previousHome = process.env.HOME;
+		const previousUserProfile = process.env.USERPROFILE;
+		try {
+			process.env.HOME = home;
+			process.env.USERPROFILE = home;
+			fs.mkdirSync(path.join(home, ".agents", "skills", "legacy-skill"), { recursive: true });
+			fs.writeFileSync(path.join(home, ".agents", "legacy.md"), `---
+name: legacy-user
+description: Legacy user
+---
+
+Legacy user prompt
+`, "utf-8");
+			fs.writeFileSync(path.join(home, ".agents", "skills", "legacy-skill", "SKILL.md"), `---
+name: legacy-user-skill
+description: Legacy user skill
+---
+
+Legacy user skill prompt
+`, "utf-8");
+
+			const result = discoverAgents(dir, "user");
+			assert.ok(result.agents.find((agent) => agent.name === "legacy-user"));
+			assert.equal(result.agents.find((agent) => agent.name === "legacy-user-skill"), undefined);
+		} finally {
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+			else process.env.USERPROFILE = previousUserProfile;
+		}
+	});
+
 	it("prefers .pi/agents over .agents on project agent name collisions", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-project-agent-collision-"));
 		tempDirs.push(dir);


### PR DESCRIPTION
## Summary

Fixes an issue where skill files under legacy `.agents/skills/**` and `~/.agents/skills/**` could be misrepresented as subagents.

Legacy agent discovery recursively scans `.agents/**/*.md` and `~/.agents/**/*.md`. Because legacy skill files also live under those roots, a `SKILL.md` file with normal skill frontmatter (`name` and `description`) could be parsed as an agent. Canonical paths do not have this overlap because `.pi/agents/**` and `.pi/skills/**` are separate directories.

## Solution

Skip the top-level `skills/` directory when scanning legacy `.agents` roots for agents. This keeps normal legacy agent discovery working while matching canonical behavior where skills are not discoverable as subagents.

Added unit coverage for both:
- project legacy skills under `.agents/skills/**`
- user legacy skills under `~/.agents/skills/**`

## Validation

- `node --experimental-strip-types --test test/unit/agent-frontmatter.test.ts` passes
- `npm run test:unit` was run; unrelated environment-sensitive tests failed due local Node flag support and local `pi-intercom` availability expectations
