### PR TITLE
fix: async parallel crash on Windows when concurrency > 1

### DIFF
--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -965,7 +965,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 	const eventsPath = path.join(asyncDir, "events.jsonl");
 	const logPath = path.join(asyncDir, `subagent-log-${id}.md`);
 	const controlConfig = config.controlConfig ?? DEFAULT_CONTROL_CONFIG;
-	let activeChildInterrupt: (() => void) | undefined;
+	const activeChildInterrupts = new Map<number, () => void>();
 	let interrupted = false;
 	let currentActivityState: ActivityState | undefined;
 	let activityTimer: NodeJS.Timeout | undefined;
@@ -1055,6 +1055,34 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 
 	fs.mkdirSync(asyncDir, { recursive: true });
 	writeAtomicJson(statusPath, statusPayload);
+
+	const writeCrashResult = (reason: string) => {
+		try {
+			const crashResult = {
+				id,
+				agent: flatSteps[0]?.agent ?? "unknown",
+				mode: config.resultMode ?? statusPayload.mode,
+				success: false,
+				exitCode: 1,
+				error: `Runner crashed: ${reason}`,
+				timestamp: Date.now(),
+				durationMs: Date.now() - overallStartTime,
+				asyncDir,
+				cwd,
+			};
+			fs.mkdirSync(path.dirname(resultPath), { recursive: true });
+			fs.writeFileSync(resultPath, JSON.stringify(crashResult, null, 2));
+		} catch {}
+	};
+	process.on("uncaughtException", (err) => {
+		writeCrashResult(`uncaughtException: ${err?.message ?? err}`);
+		process.exit(1);
+	});
+	process.on("unhandledRejection", (reason) => {
+		writeCrashResult(`unhandledRejection: ${reason}`);
+		process.exit(1);
+	});
+
 	const emitNestedSelfEvent = (type: "subagent.nested.updated" | "subagent.nested.completed"): void => {
 		if (!config.nestedRoute || !config.nestedSelf) return;
 		try {
@@ -1297,7 +1325,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		statusPayload.lastActivityAt = now;
 		statusPayload.lastUpdate = now;
 		maybeEmitActiveLongRunning(flatIndex, now);
-		writeStatusPayload();
+		try { writeStatusPayload(); } catch {}
 	};
 	const updateRunnerActivityState = (now: number): boolean => {
 		if (!controlConfig.enabled) return false;
@@ -1358,8 +1386,10 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 	if (controlConfig.enabled) {
 		activityTimer = setInterval(() => {
 			if (statusPayload.state !== "running") return;
-			const now = Date.now();
-			updateRunnerActivityState(now);
+			try {
+				const now = Date.now();
+				updateRunnerActivityState(now);
+			} catch {}
 		}, 1000);
 		activityTimer.unref?.();
 	}
@@ -1387,7 +1417,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			ts: now,
 			runId: id,
 		}));
-		activeChildInterrupt?.();
+		for (const interrupt of activeChildInterrupts.values()) interrupt();
+		activeChildInterrupts.clear();
 	};
 	process.on(ASYNC_INTERRUPT_SIGNAL, interruptRunner);
 	appendJsonl(
@@ -1596,7 +1627,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 					orchestratorIntercomTarget: config.controlIntercomTarget,
 					nestedRoute: config.nestedRoute,
 					registerInterrupt: (interrupt) => {
-						activeChildInterrupt = interrupt;
+						if (interrupt) activeChildInterrupts.set(fi, interrupt);
+						else activeChildInterrupts.delete(fi);
 					},
 					onAttemptStart: (attempt) => updateStepModel(fi, attempt.model, attempt.thinking),
 					onChildEvent: (event) => updateStepFromChildEvent(fi, event),
@@ -1843,7 +1875,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 							orchestratorIntercomTarget: config.controlIntercomTarget,
 							nestedRoute: config.nestedRoute,
 							registerInterrupt: (interrupt) => {
-								activeChildInterrupt = interrupt;
+								if (interrupt) activeChildInterrupts.set(fi, interrupt);
+								else activeChildInterrupts.delete(fi);
 							},
 							onAttemptStart: (attempt) => updateStepModel(fi, attempt.model, attempt.thinking),
 							onChildEvent: (event) => updateStepFromChildEvent(fi, event),
@@ -2008,7 +2041,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				orchestratorIntercomTarget: config.controlIntercomTarget,
 				nestedRoute: config.nestedRoute,
 				registerInterrupt: (interrupt) => {
-					activeChildInterrupt = interrupt;
+					if (interrupt) activeChildInterrupts.set(flatIndex, interrupt);
+					else activeChildInterrupts.delete(flatIndex);
 				},
 				onAttemptStart: (attempt) => updateStepModel(flatIndex, attempt.model, attempt.thinking),
 				onChildEvent: (event) => updateStepFromChildEvent(flatIndex, event),

--- a/src/shared/atomic-json.ts
+++ b/src/shared/atomic-json.ts
@@ -1,6 +1,21 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+function renameWithRetry(src: string, dest: string, maxRetries: number): void {
+	for (let attempt = 0; ; attempt++) {
+		try {
+			fs.renameSync(src, dest);
+			return;
+		} catch (err: unknown) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (attempt >= maxRetries || (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES")) throw err;
+			const delayMs = 50 * (2 ** attempt);
+			const end = Date.now() + delayMs;
+			while (Date.now() < end) { /* spin-wait: sync context, cannot await */ }
+		}
+	}
+}
+
 export function writeAtomicJson(filePath: string, payload: object): void {
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
 	const tempPath = path.join(
@@ -9,7 +24,7 @@ export function writeAtomicJson(filePath: string, payload: object): void {
 	);
 	try {
 		fs.writeFileSync(tempPath, JSON.stringify(payload, null, 2), "utf-8");
-		fs.renameSync(tempPath, filePath);
+		renameWithRetry(tempPath, filePath, 3);
 	} finally {
 		fs.rmSync(tempPath, { force: true });
 	}


### PR DESCRIPTION
## Summary

Async parallel runs crash reliably when `concurrency > 1` on Windows. The detached runner process exits silently before writing a result file, and stale-run reconciliation marks all children as failed.

- Reproduces with trivial delegate tasks ("Say A" / "Say B")
- Working combinations: async single, foreground parallel, async parallel `concurrency: 1`
- Broken combination: async parallel `concurrency > 1`

## Root Cause

Two unprotected call paths where `writeStatusPayload()` throws inside event callbacks become uncaught exceptions that kill the runner process.

**Path 1 — setInterval activity timer:**

```
setInterval callback → updateRunnerActivityState() → writeStatusPayload()
  → writeAtomicJson() → fs.renameSync() THROWS → uncaught exception → crash
```

**Path 2 — child stdout data handler:**

```
child.stdout.on("data") → processStdoutLine() → onChildEvent()
  → updateStepFromChildEvent() → writeStatusPayload()
  → writeAtomicJson() → fs.renameSync() THROWS → uncaught exception → crash
```

`writeAtomicJson` does `fs.renameSync(tempPath, statusPath)`. On Windows, `MoveFileExW` throws `EPERM`/`SHARING_VIOLATION` if the target file is held by another process (parent Pi polling `status.json`, Windows Defender, file indexer). With two concurrent child streams, `writeStatusPayload()` fires in rapid bursts — higher write frequency = higher collision probability.

Foreground parallel works because it uses push-based `onUpdate` callbacks, not file writes.

The runner is spawned with `stdio: "ignore"` and the entry point `.catch()` calls `process.exit(1)` without writing a result file — so all crash diagnostics are invisible.

## Changes

### 1. `src/shared/atomic-json.ts` — retry transient Windows rename errors

Added `renameWithRetry()` that retries `fs.renameSync` up to 3 times on `EPERM`/`EBUSY`/`EACCES` with exponential backoff (50ms/100ms/200ms spin-wait). Non-retryable errors and exhausted retries re-throw.

### 2. `src/runs/background/subagent-runner.ts` — try/catch on unprotected callers

Wrapped the two unprotected `writeStatusPayload()` call sites (setInterval callback and `updateStepFromChildEvent`) with `try/catch`. These writes are purely for status display — swallowing the error is strictly better than crashing the runner.

### 3. `src/runs/background/subagent-runner.ts` — crash safety handlers

Added `uncaughtException` and `unhandledRejection` handlers that write a failure result file before exit. Future crashes produce a diagnosable result instead of relying on stale-run reconciliation.

### 4. `src/runs/background/subagent-runner.ts` — parallel interrupt fix

Changed `activeChildInterrupt` from a single shared variable to a `Map<number, () => void>` keyed by flat index. Previously, in parallel mode, the last task to register overwrote all others' interrupt handlers. Now each task registers independently and interrupt signals reach all running children.

## Verification

Tested on Windows 10 with pi-subagents v0.28.0. All 4 scenarios passed:

| Scenario | Result |
|---|---|
| Async parallel, `concurrency: 2` (previously broken) | **Pass** |
| Async single delegate | **Pass** |
| Foreground parallel, `concurrency: 2` | **Pass** |
| Async parallel, `concurrency: 1` | **Pass** |

The previously broken case — async parallel with `concurrency > 1` — completed successfully and returned both child outputs. The runner did not crash, did not fall into stale-run reconciliation, and produced normal async completion output.

## Test plan

- [x] Async parallel with `concurrency: 2` completes with correct outputs
- [x] Async single delegate still works
- [x] Foreground parallel still works
- [x] Async parallel with `concurrency: 1` still works
- [ ] Verify on Linux/macOS (rename collision is Windows-specific, but retry is safe no-op on other platforms)