### PR TITLE
Add configurable subagent live widget placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,6 +882,24 @@ Makes top-level calls use background execution when the request does not explici
 
 Forces depth-0 single, parallel, and chain runs into background mode and bypasses clarify UI by forcing `clarify: false`. Nested calls keep their own inherited settings.
 
+### `ui`
+
+```json
+{
+  "ui": {
+    "widgetPlacement": "belowEditor",
+    "slashLiveResult": "widget"
+  }
+}
+```
+
+`widgetPlacement` controls where live subagent widgets render. Use `belowEditor` to keep the async/background widget near the prompt instead of above it; omit it or use `aboveEditor` for Pi's default widget placement.
+
+`slashLiveResult` controls slash-command live progress cards for `/run`, `/chain`, `/parallel`, and `/run-chain`:
+
+- `inline` (default): show the live card in the conversation history.
+- `widget`: show the live card as a widget using `widgetPlacement`, then keep only the final result in conversation history.
+
 ### `parallel`
 
 ```json

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -271,7 +271,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	};
 	globalStore[runtimeCleanupStoreKey] = runtimeCleanup;
 
-	const { ensurePoller, handleStarted, handleComplete, resetJobs } = createAsyncJobTracker(pi, state, ASYNC_DIR);
+	const { ensurePoller, handleStarted, handleComplete, resetJobs } = createAsyncJobTracker(pi, state, ASYNC_DIR, {
+		widgetPlacement: config.ui?.widgetPlacement,
+	});
 	const executor = createSubagentExecutor({
 		pi,
 		state,
@@ -462,7 +464,7 @@ DIAGNOSTICS:
 	};
 
 	pi.registerTool(tool);
-	registerSlashCommands(pi, state);
+	registerSlashCommands(pi, state, config);
 
 	const eventUnsubscribeStoreKey = "__piSubagentEventUnsubscribes";
 	const controlNoticeSeenStoreKey = "__piSubagentVisibleControlNotices";
@@ -502,7 +504,7 @@ DIAGNOSTICS:
 		if (!ctx.hasUI) return;
 		state.lastUiContext = ctx;
 		if (state.asyncJobs.size > 0) {
-			renderWidget(ctx, Array.from(state.asyncJobs.values()));
+			renderWidget(ctx, Array.from(state.asyncJobs.values()), { placement: config.ui?.widgetPlacement });
 			ctx.ui.requestRender?.();
 			ensurePoller();
 		}

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -7,6 +7,7 @@ import {
 	type AsyncJobState,
 	type AsyncStartedEvent,
 	type ControlEvent,
+	type WidgetPlacement,
 	type SubagentState,
 	POLL_INTERVAL_MS,
 	RESULTS_DIR,
@@ -24,6 +25,7 @@ interface AsyncJobTrackerOptions {
 	resultsDir?: string;
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 	now?: () => number;
+	widgetPlacement?: WidgetPlacement;
 }
 
 export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: SubagentState, asyncDirRoot: string, options: AsyncJobTrackerOptions = {}): {
@@ -36,7 +38,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
 	const resultsDir = options.resultsDir ?? RESULTS_DIR;
 	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
-		renderWidget(ctx, jobs);
+		renderWidget(ctx, jobs, { placement: options.widgetPlacement });
 		ctx.ui.requestRender?.();
 	};
 	const cancelCleanup = (asyncId: string) => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -815,6 +815,14 @@ interface ExtensionChainConfig {
 	};
 }
 
+export type WidgetPlacement = "aboveEditor" | "belowEditor";
+export type SlashLiveResultMode = "inline" | "widget";
+
+interface ExtensionUiConfig {
+	widgetPlacement?: WidgetPlacement;
+	slashLiveResult?: SlashLiveResultMode;
+}
+
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
 	forceTopLevelAsync?: boolean;
@@ -823,6 +831,7 @@ export interface ExtensionConfig {
 	control?: ControlConfig;
 	parallel?: TopLevelParallelConfig;
 	chain?: ExtensionChainConfig;
+	ui?: ExtensionUiConfig;
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
 	intercomBridge?: IntercomBridgeConfig;

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -8,11 +8,13 @@ import type { SubagentParamsLike } from "../runs/foreground/subagent-executor.ts
 import { isDynamicParallelStep, isParallelStep, type ChainStep } from "../shared/settings.ts";
 import { assertJsonSchemaObject } from "../runs/shared/structured-output.ts";
 import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.ts";
+import { renderSubagentResult } from "../tui/render.ts";
 import {
 	applySlashUpdate,
 	buildSlashInitialResult,
 	failSlashResult,
 	finalizeSlashResult,
+	getSlashRenderableSnapshot,
 } from "./slash-live-state.ts";
 import {
 	SLASH_RESULT_TYPE,
@@ -21,9 +23,11 @@ import {
 	SLASH_SUBAGENT_RESPONSE_EVENT,
 	SLASH_SUBAGENT_STARTED_EVENT,
 	SLASH_SUBAGENT_UPDATE_EVENT,
+	type ExtensionConfig,
 	type JsonSchemaObject,
 	type SingleResult,
 	type SubagentState,
+	type WidgetPlacement,
 } from "../shared/types.ts";
 
 interface InlineConfig {
@@ -219,6 +223,7 @@ async function requestSlashRun(
 			const tool = update.currentTool ? ` ${update.currentTool}` : "";
 			const count = update.toolCount ?? 0;
 			ctx.ui.setStatus("subagent-slash", `${count} tools${tool} | Ctrl+O live detail`);
+			ctx.ui.requestRender?.();
 		};
 
 		const onTerminalInput = ctx.hasUI
@@ -307,22 +312,58 @@ function persistSlashSessionSnapshot(ctx: ExtensionContext): void {
 	}
 }
 
+function widgetPlacementOptions(placement: WidgetPlacement | undefined): { placement: "belowEditor" } | undefined {
+	return placement === "belowEditor" ? { placement } : undefined;
+}
+
+function shouldRenderSlashLiveWidget(config: ExtensionConfig | undefined): boolean {
+	return config?.ui?.slashLiveResult === "widget";
+}
+
+function installSlashLiveWidget(ctx: ExtensionContext, details: ReturnType<typeof buildSlashInitialResult>, config: ExtensionConfig | undefined): void {
+	if (!ctx.hasUI || !shouldRenderSlashLiveWidget(config)) return;
+	ctx.ui.setWidget(
+		"subagent-slash-live",
+		(_tui, theme) => ({
+			render(width: number): string[] {
+				const snapshot = getSlashRenderableSnapshot(details);
+				return renderSubagentResult(snapshot.result, { expanded: ctx.ui.getToolsExpanded?.() ?? false }, theme).render(width);
+			},
+			invalidate() {},
+		}),
+		widgetPlacementOptions(config?.ui?.widgetPlacement),
+	);
+	ctx.ui.requestRender?.();
+}
+
+function clearSlashLiveWidget(ctx: ExtensionContext, config: ExtensionConfig | undefined): void {
+	if (!ctx.hasUI || !shouldRenderSlashLiveWidget(config)) return;
+	ctx.ui.setWidget("subagent-slash-live", undefined);
+	ctx.ui.requestRender?.();
+}
+
 async function runSlashSubagent(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	params: SubagentParamsLike,
+	config?: ExtensionConfig,
 ): Promise<void> {
 	if (ctx.hasUI) ctx.ui.setToolsExpanded(false);
 	const requestId = randomUUID();
 	const initialDetails = buildSlashInitialResult(requestId, params);
+	const useLiveWidget = ctx.hasUI && shouldRenderSlashLiveWidget(config);
 	const initialText = extractSlashMessageText(initialDetails.result.content) || "Running subagent...";
-	pi.sendMessage({
-		customType: SLASH_RESULT_TYPE,
-		content: initialText,
-		display: true,
-		details: initialDetails,
-	});
-	persistSlashSessionSnapshot(ctx);
+	if (useLiveWidget) {
+		installSlashLiveWidget(ctx, initialDetails, config);
+	} else {
+		pi.sendMessage({
+			customType: SLASH_RESULT_TYPE,
+			content: initialText,
+			display: true,
+			details: initialDetails,
+		});
+		persistSlashSessionSnapshot(ctx);
+	}
 
 	try {
 		const response = await requestSlashRun(pi, ctx, requestId, params);
@@ -337,6 +378,7 @@ async function runSlashSubagent(
 		if (ctx.hasUI) {
 			ctx.ui.setStatus("subagent-slash", undefined);
 		}
+		clearSlashLiveWidget(ctx, config);
 		if (response.isError && ctx.hasUI) {
 			ctx.ui.notify(response.errorText || "Subagent failed", "error");
 		}
@@ -353,6 +395,7 @@ async function runSlashSubagent(
 		if (ctx.hasUI) {
 			ctx.ui.setStatus("subagent-slash", undefined);
 		}
+		clearSlashLiveWidget(ctx, config);
 		if (message === "Cancelled") {
 			if (ctx.hasUI) ctx.ui.notify("Cancelled", "warning");
 			return;
@@ -446,6 +489,7 @@ const parseAgentArgs = (
 export function registerSlashCommands(
 	pi: ExtensionAPI,
 	state: SubagentState,
+	config?: ExtensionConfig,
 ): void {
 	pi.registerCommand("run", {
 		description: "Run a subagent directly: /run agent[output=file] [task] [--bg] [--fork]",
@@ -473,7 +517,7 @@ export function registerSlashCommands(
 			if (inline.model) params.model = inline.model;
 			if (bg) params.async = true;
 			if (fork) params.context = "fork";
-			await runSlashSubagent(pi, ctx, params);
+			await runSlashSubagent(pi, ctx, params, config);
 		},
 	});
 
@@ -497,7 +541,7 @@ export function registerSlashCommands(
 			const params: SubagentParamsLike = { chain, task: parsed.task, clarify: false, agentScope: "both" };
 			if (bg) params.async = true;
 			if (fork) params.context = "fork";
-			await runSlashSubagent(pi, ctx, params);
+			await runSlashSubagent(pi, ctx, params, config);
 		},
 	});
 
@@ -527,7 +571,7 @@ export function registerSlashCommands(
 			const params: SubagentParamsLike = { chain: mapSavedChainSteps(chain), task, clarify: false, agentScope: "both" };
 			if (bg) params.async = true;
 			if (fork) params.context = "fork";
-			await runSlashSubagent(pi, ctx, params);
+			await runSlashSubagent(pi, ctx, params, config);
 		},
 	});
 
@@ -551,7 +595,7 @@ export function registerSlashCommands(
 			const params: SubagentParamsLike = { tasks, clarify: false, agentScope: "both" };
 			if (bg) params.async = true;
 			if (fork) params.context = "fork";
-			await runSlashSubagent(pi, ctx, params);
+			await runSlashSubagent(pi, ctx, params, config);
 		},
 	});
 
@@ -559,7 +603,7 @@ export function registerSlashCommands(
 	pi.registerCommand("subagents-doctor", {
 		description: "Show subagent diagnostics",
 		handler: async (_args, ctx) => {
-			await runSlashSubagent(pi, ctx, { action: "doctor" });
+			await runSlashSubagent(pi, ctx, { action: "doctor" }, config);
 		},
 	});
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -14,6 +14,7 @@ import {
 	type Details,
 	type NestedRunSummary,
 	type NestedStepSummary,
+	type WidgetPlacement,
 	type WorkflowNodeStatus,
 	MAX_WIDGET_JOBS,
 	WIDGET_KEY,
@@ -1000,13 +1001,17 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 /**
  * Render the async jobs widget
  */
-export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void {
+function widgetPlacementOptions(placement: WidgetPlacement | undefined): { placement: "belowEditor" } | undefined {
+	return placement === "belowEditor" ? { placement } : undefined;
+}
+
+export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[], options: { placement?: WidgetPlacement } = {}): void {
 	if (jobs.length === 0) {
 		if (ctx.hasUI) ctx.ui.setWidget(WIDGET_KEY, undefined);
 		return;
 	}
 	if (!ctx.hasUI) return;
-	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, ctx.ui.getToolsExpanded?.() ?? false));
+	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, ctx.ui.getToolsExpanded?.() ?? false), widgetPlacementOptions(options.placement));
 }
 
 function renderSingleCompact(d: Details, r: Details["results"][number], theme: Theme): Component {

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 const { buildWidgetLines, clearLegacyResultAnimationTimer, renderWidget } = await import("../../src/tui/render.ts") as {
 	buildWidgetLines: (jobs: Array<Record<string, unknown>>, theme: { fg(name: string, text: string): string; bold(text: string): string }, width?: number, expanded?: boolean) => string[];
 	clearLegacyResultAnimationTimer: (context: { state: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> } }) => void;
-	renderWidget: (ctx: Record<string, unknown>, jobs: Array<Record<string, unknown>>) => void;
+	renderWidget: (ctx: Record<string, unknown>, jobs: Array<Record<string, unknown>>, options?: { placement?: "aboveEditor" | "belowEditor" }) => void;
 };
 
 const theme = {
@@ -37,8 +37,8 @@ function createUiContext() {
 		hasUI: true,
 		ui: {
 			theme,
-			setWidget: (_key: string, value: unknown) => {
-				widgets.push(value);
+			setWidget: (_key: string, value: unknown, options?: unknown) => {
+				widgets.push({ value, options });
 			},
 			requestRender: () => {
 				renderRequests += 1;
@@ -55,6 +55,13 @@ function createUiContext() {
 }
 
 describe("subagent async widget rendering", () => {
+	it("can place the async widget below the editor", () => {
+		const ui = createUiContext();
+		renderWidget(ui.ctx as never, [{ asyncId: "run-1", asyncDir: "/tmp/1", status: "running", agents: ["scout"] }], { placement: "belowEditor" });
+
+		assert.deepEqual((ui.widgets.at(-1) as { options?: unknown }).options, { placement: "belowEditor" });
+	});
+
 	it("orders running jobs before queued summaries and completions", () => {
 		const lines = buildWidgetLines([
 			{ asyncId: "done-1", asyncDir: "/tmp/done", status: "complete", agents: ["reviewer"], startedAt: 0, updatedAt: 1000 },
@@ -112,9 +119,9 @@ describe("subagent async widget rendering", () => {
 				{ index: 2, agent: "reviewer", status: "running", currentTool: "grep", currentToolStartedAt: now - 1000, turnCount: 3, toolCount: 11, tokens: { input: 14_000, output: 3_000, cache: 2_000, total: 19_000 } },
 			],
 		}]);
-		const widget = ui.widgets.at(-1);
-		assert.equal(typeof widget, "function", "renderWidget should install a component widget, not a capped string-array widget");
-		const lines = (widget as (_tui: unknown, widgetTheme: typeof theme) => { render(width: number): string[] })(undefined, theme).render(180).map((line) => line.trimEnd());
+		const widget = ui.widgets.at(-1) as { value: unknown };
+		assert.equal(typeof widget.value, "function", "renderWidget should install a component widget, not a capped string-array widget");
+		const lines = (widget.value as (_tui: unknown, widgetTheme: typeof theme) => { render(width: number): string[] })(undefined, theme).render(180).map((line) => line.trimEnd());
 		const text = lines.join("\n");
 		assert.match(text, /async subagent parallel \(3\) · background/);
 		assert.match(text, /Agent 1\/3: reviewer · running · active now · 5 turns · 18 tool uses · 44k token/);
@@ -510,6 +517,6 @@ describe("subagent async widget rendering", () => {
 		const afterClearCount = ui.widgets.length;
 		await new Promise((resolve) => setTimeout(resolve, 190));
 		assert.equal(ui.widgets.length, afterClearCount, "cleared widget should stay quiet");
-		assert.equal(ui.widgets.at(-1), undefined);
+		assert.equal((ui.widgets.at(-1) as { value?: unknown }).value, undefined);
 	});
 });

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -41,6 +41,7 @@ interface RegisterSlashCommandsModule {
 			watcherRestartTimer: ReturnType<typeof setTimeout> | null;
 			resultFileCoalescer: { schedule(file: string, delayMs?: number): boolean; clear(): void };
 		},
+		config?: unknown,
 	) => void;
 }
 
@@ -126,6 +127,9 @@ function createCommandContext(
 		notify: (message: string, type?: string) => void;
 		setStatus: (key: string, text: string | undefined) => void;
 		setToolsExpanded: (expanded: boolean) => void;
+		setWidget: (key: string, value: unknown, options?: unknown) => void;
+		requestRender: () => void;
+		getToolsExpanded: () => boolean;
 		sessionManager: unknown;
 	}> = {},
 ) {
@@ -136,6 +140,9 @@ function createCommandContext(
 			notify: overrides.notify ?? ((_message: string) => {}),
 			setStatus: overrides.setStatus ?? ((_key: string, _text: string | undefined) => {}),
 			setToolsExpanded: overrides.setToolsExpanded ?? ((_expanded: boolean) => {}),
+			setWidget: overrides.setWidget ?? ((_key: string, _value: unknown, _options?: unknown) => {}),
+			requestRender: overrides.requestRender ?? (() => {}),
+			getToolsExpanded: overrides.getToolsExpanded ?? (() => false),
 			onTerminalInput: () => () => {},
 			custom: overrides.custom ?? (async () => undefined),
 		},
@@ -262,6 +269,49 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		assert.match((sent[1] as { content?: string }).content ?? "", /Commit finished/);
 		assert.equal(sessionManager.rewrites, 2);
 		assert.equal(sessionManager.flushed, true);
+	});
+
+	it("/run can render the live slash result as a below-editor widget", async () => {
+		const sent: unknown[] = [];
+		const widgets: Array<{ value: unknown; options?: unknown }> = [];
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const events = createEventBus();
+		events.on(SLASH_SUBAGENT_REQUEST_EVENT, (data) => {
+			const requestId = (data as { requestId: string }).requestId;
+			events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId });
+			events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, {
+				requestId,
+				result: {
+					content: [{ type: "text", text: "Scout finished" }],
+					details: { mode: "single", results: [] },
+				},
+				isError: false,
+			});
+		});
+
+		const pi = {
+			events,
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage(message: unknown) {
+				sent.push(message);
+			},
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()), { ui: { slashLiveResult: "widget", widgetPlacement: "belowEditor" } });
+		await commands.get("run")!.handler("scout inspect this", createCommandContext({
+			hasUI: true,
+			setWidget: (_key, value, options) => widgets.push({ value, options }),
+		}));
+
+		assert.equal(sent.length, 1);
+		assert.match((sent[0] as { content?: string }).content ?? "", /Scout finished/);
+		assert.ok(widgets.length >= 2, "slash widget should be installed and then cleared");
+		assert.deepEqual(widgets[0]?.options, { placement: "belowEditor" });
+		assert.equal(typeof widgets[0]?.value, "function");
+		assert.equal(widgets.at(-1)?.value, undefined);
 	});
 
 	it("/run finalizes the slash snapshot before the last UI redraw on success", async () => {


### PR DESCRIPTION
## Summary
- Add a new ui.widgetPlacement option for async/background subagent widgets.
- Add ui.slashLiveResult = "widget" so /run, /chain, /parallel, and /run-chain can show live progress below the editor while keeping the final result in conversation history.
- Document the new ui configuration and cover async widget plus slash live widget behavior with integration tests.

## Tests
- npm run test:integration ✅ (367 passing)
- node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts test/integration/slash-commands.test.ts ✅ (41 passing)
- npm run test:unit ⚠️ one environment-sensitive existing failure locally: test/unit/intercom-bridge.test.ts expects pi-intercom to be missing, but this machine has pi-intercom installed globally/configured. No changed files are in that area.