### PR TITLE
[Feature Request] Configurable minimum timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Added `minForegroundTimeoutMs` config for the foreground `timeoutMs`/`maxRuntimeMs` floor, defaulting to 300000 ms (5 min), and raise shorter caller-provided values instead of letting foreground subagent runs time out too early.
+
 ## [0.28.0] - 2026-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Use `~/.pi/agent/settings.json` for a user override or `.pi/settings.json` for a
 
 ## Where running subagents show up
 
-Foreground runs stream progress in the conversation while they run. Use `timeoutMs` or its alias `maxRuntimeMs` when a foreground run must return within a wall-clock budget. When the timeout expires, running children are soft-interrupted, completed children stay in the result, and timed-out children return `timedOut: true` with a stable timeout message.
+Foreground runs stream progress in the conversation while they run. Foreground runs default to the configured minimum foreground wall-clock budget: 300000 ms (5 min) unless `minForegroundTimeoutMs` is set in config. Use `timeoutMs` or its alias `maxRuntimeMs` to override that budget for a single foreground run; values below the configured minimum are raised to that minimum. When the timeout expires, running children are soft-interrupted, completed children stay in the result, and timed-out children return `timedOut: true` with a stable timeout message.
 
 Background runs keep working after control returns to you. Inspect active runs with `subagent({ action: "status" })`, or a specific run with `subagent({ action: "status", id: "..." })`.
 
@@ -797,7 +797,7 @@ Agent definitions are not loaded into context by default. Management actions let
 | `model` | string | agent default | Override model. |
 | `tasks` | array | - | Top-level parallel tasks. Supports `agent`, `task`, `cwd`, `count`, `output`, `outputMode`, `reads`, `progress`, `skill`, `model`, and `acceptance`. |
 | `concurrency` | number | config or `4` | Top-level parallel concurrency. |
-| `timeoutMs` / `maxRuntimeMs` | number | - | Foreground wall-clock timeout for single, parallel, and chain runs. Timed-out children return `timedOut: true`; async/background runs reject it. |
+| `timeoutMs` / `maxRuntimeMs` | number | `minForegroundTimeoutMs` | Foreground wall-clock timeout for single, parallel, and chain runs. Minimum/effective floor is configured by `minForegroundTimeoutMs` (`300000` ms by default); shorter values are raised. Timed-out children return `timedOut: true`; async/background runs reject it. |
 | `worktree` | boolean | false | Create isolated git worktrees for parallel tasks. |
 | `chain` | array | - | Sequential, static parallel, and dynamic fanout chain steps. Sequential steps and parallel child tasks support `phase`, `label`, `as`, `outputSchema`, and `acceptance` in addition to the usual execution fields. Dynamic fanout uses `expand`, one child `parallel` template, and `collect`; group-level acceptance is not supported because there is no child session to finalize. |
 | `context` | `fresh \| fork` | agent default or `fresh` | `fork` creates real branched sessions from the parent leaf. Packaged `planner`, `worker`, and `oracle` default to `fork`. |
@@ -886,6 +886,14 @@ Makes top-level calls use background execution when the request does not explici
 ```
 
 Forces depth-0 single, parallel, and chain runs into background mode and bypasses clarify UI by forcing `clarify: false`. Nested calls keep their own inherited settings.
+
+### `minForegroundTimeoutMs`
+
+```json
+{ "minForegroundTimeoutMs": 300000 }
+```
+
+Sets the default and minimum foreground wall-clock timeout for single, parallel, and chain runs. The default is `300000` ms (5 min). Use a positive integer; invalid values fall back to the default. If a foreground tool call provides `timeoutMs` or `maxRuntimeMs` below this value, `pi-subagents` raises the effective timeout to `minForegroundTimeoutMs`. Async/background runs still reject `timeoutMs`/`maxRuntimeMs` because they should be controlled with `interrupt`.
 
 ### `parallel`
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -302,7 +302,7 @@ call `structured_output` with schema-valid JSON, or the step fails.
 
 ### Async/background
 
-Prefer async mode for every subagent launch. Set `async: true` no matter the task unless there is a specific reason to opt into a foreground/blocking run. This applies to scouts, researchers, workers, reviewers, validators, oracle checks, one-off delegates, chains, and parallel groups. Keep the write path single-threaded even when the run is async.
+Prefer async mode for every subagent launch. Set `async: true` no matter the task unless there is a specific reason to opt into a foreground/blocking run. This applies to scouts, researchers, workers, reviewers, validators, oracle checks, one-off delegates, chains, and parallel groups. Keep the write path single-threaded even when the run is async. If you intentionally use a foreground run, omit `timeoutMs`/`maxRuntimeMs` or set at least the configured `minForegroundTimeoutMs` (`300000` ms by default); the runtime raises shorter values to that floor.
 
 Async does not mean parallel writes. Do not edit the same active worktree while an async worker is changing it. Parent-side overlap should be reading, validation prep, synthesis, command planning, or review of unaffected context unless the writer is isolated in a separate worktree.
 

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -9,6 +9,7 @@ import {
 	CHAIN_RUNS_DIR,
 	RESULTS_DIR,
 	TEMP_ROOT_DIR,
+	resolveMinForegroundTimeoutMs,
 	type ExtensionConfig,
 	type SubagentState,
 } from "../shared/types.ts";
@@ -176,6 +177,7 @@ export function buildDoctorReport(input: DoctorReportInput): string {
 		"Runtime",
 		`- cwd: ${input.cwd}`,
 		lineFromCheck("async support", () => `- async support: ${deps.isAsyncAvailable() ? "available" : "unavailable"}`),
+		lineFromCheck("min foreground timeout", () => `- min foreground timeout: ${resolveMinForegroundTimeoutMs(input.config)}ms`),
 		...formatSessionLines(input),
 		"",
 		"Filesystem",

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -9,7 +9,7 @@
  * Toggle: async parameter (default: false, configurable via config.json)
  *
  * Config file: ~/.pi/agent/extensions/subagent/config.json
- *   { "asyncByDefault": true, "forceTopLevelAsync": true, "maxSubagentDepth": 1, "intercomBridge": { "mode": "always", "instructionFile": "./intercom-bridge.md" }, "worktreeSetupHook": "./scripts/setup-worktree.mjs" }
+ *   { "asyncByDefault": true, "forceTopLevelAsync": true, "minForegroundTimeoutMs": 300000, "maxSubagentDepth": 1, "intercomBridge": { "mode": "always", "instructionFile": "./intercom-bridge.md" }, "worktreeSetupHook": "./scripts/setup-worktree.mjs" }
  */
 
 import * as fs from "node:fs";
@@ -42,7 +42,9 @@ import {
 	type SubagentState,
 	ASYNC_DIR,
 	DEFAULT_ARTIFACT_CONFIG,
+	normalizeForegroundTimeoutMs,
 	RESULTS_DIR,
+	resolveMinForegroundTimeoutMs,
 	SLASH_RESULT_TYPE,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_ASYNC_STARTED_EVENT,
@@ -229,6 +231,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	const config = loadConfig();
 	const asyncByDefault = config.asyncByDefault === true;
+	const minForegroundTimeoutMs = resolveMinForegroundTimeoutMs(config);
 	const tempArtifactsDir = getArtifactsDir(null);
 	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
 
@@ -384,6 +387,32 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}, 0);
 	}
 
+	function prepareSubagentArguments(args: unknown): unknown {
+		if (typeof args !== "object" || args === null || Array.isArray(args)) return args;
+		const next = { ...(args as Record<string, unknown>) };
+		const numericValues: Partial<Record<"timeoutMs" | "maxRuntimeMs", number>> = {};
+		for (const key of ["timeoutMs", "maxRuntimeMs"] as const) {
+			const value = next[key];
+			const numericValue = typeof value === "number"
+				? value
+				: typeof value === "string" && value.trim() !== ""
+					? Number(value)
+					: undefined;
+			if (typeof numericValue === "number") numericValues[key] = numericValue;
+		}
+		if (numericValues.timeoutMs !== undefined && numericValues.maxRuntimeMs !== undefined && numericValues.timeoutMs !== numericValues.maxRuntimeMs) {
+			return next;
+		}
+		for (const key of ["timeoutMs", "maxRuntimeMs"] as const) {
+			const numericValue = numericValues[key];
+			if (typeof numericValue === "number" && Number.isInteger(numericValue) && numericValue > 0) {
+				const normalizedValue = normalizeForegroundTimeoutMs(numericValue, minForegroundTimeoutMs);
+				if (normalizedValue !== numericValue) next[key] = normalizedValue;
+			}
+		}
+		return next;
+	}
+
 	const tool: ToolDefinition<typeof SubagentParams, Details> = {
 		name: "subagent",
 		label: "Subagent",
@@ -394,7 +423,7 @@ EXECUTION (use exactly ONE mode):
 • SINGLE: { agent, task? } - one task; omit task for self-contained agents
 • CHAIN: { chain: [{agent:"agent-a"}, {parallel:[{agent:"agent-b",count:3}]}] } - sequential pipeline with optional parallel fan-out
 • PARALLEL: { tasks: [{agent,task,count?,output?,reads?,progress?}, ...], concurrency?: number, worktree?: true } - concurrent execution (worktree: isolate each task in a git worktree)
-• Foreground timeout: { timeoutMs } or { maxRuntimeMs } - wall-clock limit for foreground single, parallel, and chain runs. Timed-out children return timedOut:true with completed sibling/prior results preserved. Not for async/background runs.
+• Foreground timeout: { timeoutMs } or { maxRuntimeMs } - wall-clock limit for foreground single, parallel, and chain runs. Defaults to the configured minimum (${minForegroundTimeoutMs} ms) when omitted; shorter values are raised to that minimum. Timed-out children return timedOut:true with completed sibling/prior results preserved. Not for async/background runs.
 • Optional context: { context: "fresh" | "fork" } (default: if any requested agent has defaultContext: "fork", the whole invocation uses fork; otherwise "fresh"; inspect agent defaults via { action: "list" })
 • Goal-style requests: when the user says “/goal”, “goal”, “active goal”, “work until evidence says done”, or “verify against a goal”, model that as explicit acceptance. Use acceptance.criteria for the target, acceptance.evidence/verify for proof, acceptance.stopRules for constraints, and acceptance.maxFinalizationTurns for the bounded loop.
 • Plan/spec implementation handoffs: when delegating a plan, PRD, spec, issue, or broad fix to an editing-capable child, prefer structured acceptance instead of burying validation requirements in task prose. Put the implementation instructions and plan paths in task; put the definition of done, evidence, verification commands, constraints, and loop cap in acceptance.
@@ -422,6 +451,7 @@ CONTROL:
 DIAGNOSTICS:
 • { action: "doctor" } - read-only report for runtime paths, discovery, sessions, and intercom`,
 		parameters: SubagentParams,
+		prepareArguments: prepareSubagentArguments,
 
 		execute(id, params, signal, onUpdate, ctx) {
 			return executeSubagentCollapsed(id, params, signal, onUpdate, ctx);

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -3,7 +3,7 @@
  */
 
 import { Type } from "typebox";
-import { SUBAGENT_ACTIONS } from "../shared/types.ts";
+import { DEFAULT_MIN_FOREGROUND_TIMEOUT_MS, SUBAGENT_ACTIONS } from "../shared/types.ts";
 
 const SkillOverride = Type.Unsafe({
 	anyOf: [
@@ -254,8 +254,8 @@ export const SubagentParams = Type.Object({
 	})),
 	tasks: Type.Optional(Type.Array(TaskItem, { description: "PARALLEL mode: [{agent, task, count?, output?, outputMode?, reads?, progress?}, ...]" })),
 	concurrency: Type.Optional(Type.Integer({ minimum: 1, description: "Top-level PARALLEL mode only: max concurrent tasks. Defaults to config.parallel.concurrency or 4." })),
-	timeoutMs: Type.Optional(Type.Integer({ minimum: 1, description: "Foreground execution wall-clock timeout in milliseconds. When it expires, running children are soft-interrupted and timed-out results are returned. Foreground only; async/background runs ignore this field." })),
-	maxRuntimeMs: Type.Optional(Type.Integer({ minimum: 1, description: "Alias for timeoutMs. Use only one unless both values are identical." })),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 1, description: `Foreground execution wall-clock timeout in milliseconds. Defaults to the configured minForegroundTimeoutMs (${DEFAULT_MIN_FOREGROUND_TIMEOUT_MS} ms / 5 min by default) when omitted. Values below the configured minimum are raised to that minimum. When it expires, running children are soft-interrupted and timed-out results are returned. Foreground only; async/background runs ignore this field.` })),
+	maxRuntimeMs: Type.Optional(Type.Integer({ minimum: 1, description: `Alias for timeoutMs. Use only one unless both values are identical. Values below configured minForegroundTimeoutMs (${DEFAULT_MIN_FOREGROUND_TIMEOUT_MS} ms / 5 min by default) are raised to that minimum.` })),
 	worktree: Type.Optional(Type.Boolean({
 		description: "Create isolated git worktrees for each parallel task. " +
 			"Prevents filesystem conflicts. Requires clean git state. " +

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -81,6 +81,9 @@ import {
 	type SubagentRunMode,
 	type SubagentState,
 	DEFAULT_ARTIFACT_CONFIG,
+	DEFAULT_FOREGROUND_TIMEOUT_MS,
+	normalizeForegroundTimeoutMs,
+	resolveMinForegroundTimeoutMs,
 	SUBAGENT_ACTIONS,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
@@ -769,7 +772,7 @@ function validationErrorResult(mode: Details["mode"], text: string): AgentToolRe
 	return { content: [{ type: "text", text }], isError: true, details: { mode, results: [] } };
 }
 
-function resolveForegroundTimeoutMs(params: SubagentParamsLike): { timeoutMs?: number; error?: string } {
+function resolveForegroundTimeoutMs(params: SubagentParamsLike, defaultTimeoutMs?: number, minTimeoutMs = DEFAULT_FOREGROUND_TIMEOUT_MS): { timeoutMs?: number; error?: string } {
 	const rawTimeout = (params as { timeoutMs?: unknown }).timeoutMs;
 	const rawMaxRuntime = (params as { maxRuntimeMs?: unknown }).maxRuntimeMs;
 	for (const [name, value] of [["timeoutMs", rawTimeout], ["maxRuntimeMs", rawMaxRuntime]] as const) {
@@ -780,7 +783,7 @@ function resolveForegroundTimeoutMs(params: SubagentParamsLike): { timeoutMs?: n
 	if (rawTimeout !== undefined && rawMaxRuntime !== undefined && rawTimeout !== rawMaxRuntime) {
 		return { error: "timeoutMs and maxRuntimeMs are aliases; provide only one or use identical values." };
 	}
-	const timeoutMs = rawTimeout ?? rawMaxRuntime;
+	const timeoutMs = normalizeForegroundTimeoutMs(rawTimeout ?? rawMaxRuntime ?? defaultTimeoutMs, minTimeoutMs);
 	return timeoutMs === undefined ? {} : { timeoutMs };
 }
 
@@ -2462,7 +2465,12 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const requestedAsync = effectiveParams.async ?? deps.asyncByDefault;
 		const backgroundRequestedWhileClarifying = (hasChain || hasTasks) && requestedAsync && effectiveParams.clarify === true;
 		const effectiveAsync = requestedAsync && effectiveParams.clarify !== true;
-		const foregroundTimeout = resolveForegroundTimeoutMs(effectiveParams);
+		const minForegroundTimeoutMs = resolveMinForegroundTimeoutMs(deps.config);
+		const foregroundTimeout = resolveForegroundTimeoutMs(
+			effectiveParams,
+			effectiveAsync ? undefined : minForegroundTimeoutMs,
+			minForegroundTimeoutMs,
+		);
 		if (foregroundTimeout.error) return buildRequestedModeError(effectiveParams, foregroundTimeout.error);
 		if (effectiveAsync && foregroundTimeout.timeoutMs !== undefined) {
 			return buildRequestedModeError(effectiveParams, "timeoutMs/maxRuntimeMs only applies to foreground subagent runs. Omit async:true or use action:'interrupt' for background runs.");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -857,6 +857,7 @@ export interface ExtensionConfig {
 	asyncByDefault?: boolean;
 	forceTopLevelAsync?: boolean;
 	defaultSessionDir?: string;
+	minForegroundTimeoutMs?: number;
 	maxSubagentDepth?: number;
 	control?: ControlConfig;
 	parallel?: TopLevelParallelConfig;
@@ -869,6 +870,18 @@ export interface ExtensionConfig {
 // ============================================================================
 // Constants
 // ============================================================================
+
+export const DEFAULT_MIN_FOREGROUND_TIMEOUT_MS = 300_000;
+export const DEFAULT_FOREGROUND_TIMEOUT_MS = DEFAULT_MIN_FOREGROUND_TIMEOUT_MS;
+
+export function resolveMinForegroundTimeoutMs(config?: Pick<ExtensionConfig, "minForegroundTimeoutMs">): number {
+	const value = config?.minForegroundTimeoutMs;
+	return Number.isInteger(value) && value > 0 ? value : DEFAULT_MIN_FOREGROUND_TIMEOUT_MS;
+}
+
+export function normalizeForegroundTimeoutMs(timeoutMs: number | undefined, minTimeoutMs: number): number | undefined {
+	return timeoutMs === undefined ? undefined : Math.max(timeoutMs, minTimeoutMs);
+}
 
 export const DEFAULT_MAX_OUTPUT: Required<MaxOutputConfig> = {
 	bytes: 200 * 1024,

--- a/test/unit/foreground-timeout-config.test.ts
+++ b/test/unit/foreground-timeout-config.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	DEFAULT_MIN_FOREGROUND_TIMEOUT_MS,
+	normalizeForegroundTimeoutMs,
+	resolveMinForegroundTimeoutMs,
+} from "../../src/shared/types.ts";
+import { SubagentParams } from "../../src/extension/schemas.ts";
+
+test("foreground timeout config defaults to five minutes", () => {
+	assert.equal(resolveMinForegroundTimeoutMs({}), DEFAULT_MIN_FOREGROUND_TIMEOUT_MS);
+	assert.equal(resolveMinForegroundTimeoutMs({ minForegroundTimeoutMs: 0 }), DEFAULT_MIN_FOREGROUND_TIMEOUT_MS);
+	assert.equal(resolveMinForegroundTimeoutMs({ minForegroundTimeoutMs: 120_000.5 }), DEFAULT_MIN_FOREGROUND_TIMEOUT_MS);
+});
+
+test("foreground timeout config accepts positive integer overrides", () => {
+	assert.equal(resolveMinForegroundTimeoutMs({ minForegroundTimeoutMs: 600_000 }), 600_000);
+});
+
+test("foreground timeout values are raised to the configured floor", () => {
+	assert.equal(normalizeForegroundTimeoutMs(undefined, 300_000), undefined);
+	assert.equal(normalizeForegroundTimeoutMs(180_000, 300_000), 300_000);
+	assert.equal(normalizeForegroundTimeoutMs(600_000, 300_000), 600_000);
+});
+
+test("public timeout schema leaves the runtime floor configurable", () => {
+	assert.equal(SubagentParams.properties.timeoutMs.minimum, 1);
+	assert.equal(SubagentParams.properties.maxRuntimeMs.minimum, 1);
+});


### PR DESCRIPTION
## Summary

This PR adds `minForegroundTimeoutMs` to the subagent extension config.

For foreground runs, `timeoutMs` and `maxRuntimeMs` now have an effective lower bound. The lower bound defaults to `300000` ms (5 min). Users can change it in `~/.pi/agent/extensions/subagent/config.json`.

If a foreground call asks for a shorter timeout, `pi-subagents` raises it to the configured minimum. If it asks for a longer timeout, `pi-subagents` uses that longer value. Async/background runs are unchanged: they still reject `timeoutMs` and `maxRuntimeMs`.

## Motivation

The code that launches subagents can set one foreground timeout for many child runs. That caller often does not know which model each child will use, or how slow that model will be. A timeout like two minutes can look safe to the caller, but it is often too short for state-of-the-art reasoning models.

With a slow model, this causes predictable failures. Review, validation, and acceptance-finalization runs can time out before they finish. The child is not stuck; the caller chose a timeout without enough model-latency context.

A config-level minimum lets the installation owner set the shortest allowed foreground timeout. Per-call timeouts still work above that floor, but callers cannot set values that are too short for the models used in that installation.

## Changes

- Add `minForegroundTimeoutMs?: number` to extension config.
- Add shared helpers:
  - `resolveMinForegroundTimeoutMs(config)`
  - `normalizeForegroundTimeoutMs(timeoutMs, minTimeoutMs)`
- Use the configured floor when resolving foreground timeouts.
- Raise short timeout arguments before tool schema validation, while preserving the existing error for unequal `timeoutMs` / `maxRuntimeMs` aliases.
- Keep the public schema minimum at `1`, so runtime config controls the timeout floor.
- Show the effective minimum in `subagent({ action: "doctor" })`.
- Document the config option in the README, skill guidance, tool description, and changelog.
- Add unit coverage for default, custom, invalid, and schema behavior.

## Validation

```bash
node --experimental-strip-types --test test/unit/foreground-timeout-config.test.ts
bun build src/extension/index.ts --target=node --outdir /tmp/pi-subagents-pr-check \
  --external @earendil-works/pi-coding-agent \
  --external @earendil-works/pi-agent-core \
  --external @earendil-works/pi-ai
```