### PR TITLE
fix: use process-global boolean for fanout-child dedup instead of per-pi WeakSet

### DIFF
--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -129,13 +129,9 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 	if (process.env[SUBAGENT_CHILD_ENV] !== "1" || process.env[SUBAGENT_FANOUT_CHILD_ENV] !== "1") return;
 
 	const globalStore = globalThis as Record<string, unknown>;
-	const registeredKey = "__piSubagentFanoutChildRegisteredApis";
-	const registeredApis = globalStore[registeredKey] instanceof WeakSet
-		? globalStore[registeredKey] as WeakSet<ExtensionAPI>
-		: new WeakSet<ExtensionAPI>();
-	globalStore[registeredKey] = registeredApis;
-	if (registeredApis.has(pi)) return;
-	registeredApis.add(pi);
+	const registeredKey = "__piSubagentFanoutChildRegistered";
+	if (globalStore[registeredKey] === true) return;
+	globalStore[registeredKey] = true;
 
 	const config = loadConfig();
 	const state = createChildSafeState();

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -131,7 +131,6 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 	const globalStore = globalThis as Record<string, unknown>;
 	const registeredKey = "__piSubagentFanoutChildRegistered";
 	if (globalStore[registeredKey] === true) return;
-	globalStore[registeredKey] = true;
 
 	const config = loadConfig();
 	const state = createChildSafeState();
@@ -162,5 +161,6 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 	};
 
 	pi.registerTool(tool);
+	globalStore[registeredKey] = true;
 	startNestedControlInboxListener(pi, state);
 }

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -185,6 +185,47 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
+	it("deduplicates the child-safe subagent tool when both child extension entries load", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./src/extension/index.ts";
+			import registerFanoutChildSubagentExtension from "./src/extension/fanout-child.ts";
+			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
+			process.env[SUBAGENT_CHILD_ENV] = "1";
+			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
+			const registeredNames = new Set();
+			const calls = [];
+			function makePi(source) {
+				return {
+					events: { on() { return () => {}; }, emit() {} },
+					registerTool(tool) {
+						if (registeredNames.has(tool.name)) throw new Error("Tool " + JSON.stringify(tool.name) + " conflicts with " + source);
+						registeredNames.add(tool.name);
+						calls.push(source + ":" + tool.name);
+					},
+					getSessionName() { return undefined; },
+				};
+			}
+			registerSubagentExtension(makePi("index.ts"));
+			registerFanoutChildSubagentExtension(makePi("fanout-child.ts"));
+			if (calls.length !== 1 || calls[0] !== "index.ts:subagent") {
+				throw new Error("expected exactly one child-safe subagent registration, got " + JSON.stringify(calls));
+			}
+		`;
+
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-transform-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, stdio: "pipe" },
+		);
+	});
+
 	it("lets fanout children call read-only list but blocks mutating management actions", () => {
 		const script = String.raw`
 			import registerFanoutChildSubagentExtension from "./src/extension/fanout-child.ts";

--- a/test/unit/nested-control.test.ts
+++ b/test/unit/nested-control.test.ts
@@ -29,9 +29,11 @@ const savedEnv = {
 	[SUBAGENT_PARENT_RUN_ID_ENV]: process.env[SUBAGENT_PARENT_RUN_ID_ENV],
 	[SUBAGENT_PARENT_CHILD_INDEX_ENV]: process.env[SUBAGENT_PARENT_CHILD_INDEX_ENV],
 };
+const fanoutChildRegisteredKey = "__piSubagentFanoutChildRegistered";
 
 afterEach(() => {
 	for (const root of routeRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+	delete (globalThis as Record<string, unknown>)[fanoutChildRegisteredKey];
 	for (const [key, value] of Object.entries(savedEnv)) {
 		if (value === undefined) delete process.env[key];
 		else process.env[key] = value;


### PR DESCRIPTION
## Fixes #279

### Problem
Any **fanout-authorized child** (subagent with `subagent` in its `tools:` list) fails to start with a tool-registration conflict:

```
Error: Failed to load extension ".../pi-subagents/src/extension/index.ts":
Tool "subagent" conflicts with .../pi-subagents/src/extension/fanout-child.ts
```

### Root Cause
`registerFanoutChildSubagentExtension(pi)` is called twice:
1. From `index.ts` (child-mode early-return)
2. From standalone `fanout-child.ts`

The dedup guard used a `WeakSet<ExtensionAPI>` keyed on the `pi` instance, but each extension receives a **distinct** `ExtensionAPI` instance, so the guard never matches → `pi.registerTool("subagent")` runs twice → pi rejects the duplicate.

### Fix
Key the dedup on a **process-global boolean** instead of a per-`pi` `WeakSet`. Whichever extension loads first wins; the other no-ops (the executor/state the second call would build is identical to what the first already set up).

### Verification
- `node --experimental-strip-types --check src/extension/fanout-child.ts` ✓
- The minimal repro from the issue no longer produces the conflict