### PR TITLE
fix: subagents inherit parent session model instead of global settings.json fallback (#266)

### DIFF
--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -13,7 +13,7 @@ import { handleManagementAction } from "../../agents/agent-management.ts";
 import { buildDoctorReport } from "../../extension/doctor.ts";
 import { clearPendingForegroundControlNotices } from "../../extension/control-notices.ts";
 import { runSync } from "./execution.ts";
-import { resolveModelCandidate } from "../shared/model-fallback.ts";
+import { resolveModelCandidate, resolveSubagentModelOverride } from "../shared/model-fallback.ts";
 import { aggregateParallelOutputs } from "../shared/parallel-utils.ts";
 import { recordRun } from "../shared/run-history.ts";
 import {
@@ -1092,7 +1092,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 	if (hasTasks && params.tasks) {
 		const agentConfigs = params.tasks.map((task) => agents.find((agent) => agent.name === task.agent));
 		const modelOverrides = params.tasks.map((task, index) =>
-			resolveModelCandidate(task.model ?? agentConfigs[index]?.model, availableModels, currentProvider),
+			resolveSubagentModelOverride(task.model ?? agentConfigs[index]?.model, ctx.model, availableModels, currentProvider),
 		);
 		const skillOverrides = params.tasks.map((task) => normalizeSkillInput(task.skill));
 		const parallelTasks = params.tasks.map((task, index) => ({
@@ -1179,7 +1179,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const normalizedSkills = normalizeSkillInput(params.skill);
 		const skills = normalizedSkills === false ? [] : normalizedSkills;
 		const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, a.maxSubagentDepth);
-		const modelOverride = resolveModelCandidate((params.model as string | undefined) ?? a.model, availableModels, currentProvider);
+		const modelOverride = resolveSubagentModelOverride((params.model as string | undefined) ?? a.model, ctx.model, availableModels, currentProvider);
 		return executeAsyncSingle(id, {
 			agent: params.agent!,
 			task: params.context === "fork" ? wrapForkTask(params.task ?? "") : (params.task ?? ""),
@@ -1635,7 +1635,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		...(task.model ? { model: task.model } : {}),
 	}));
 	const modelOverrides: (string | undefined)[] = tasks.map((_, i) =>
-		resolveModelCandidate(behaviorOverrides[i]?.model ?? agentConfigs[i]?.model, availableModels, currentProvider),
+		resolveSubagentModelOverride(behaviorOverrides[i]?.model ?? agentConfigs[i]?.model, ctx.model, availableModels, currentProvider),
 	);
 
 	if (params.clarify === true && ctx.hasUI) {
@@ -1918,8 +1918,9 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const currentProvider = ctx.model?.provider;
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	let task = params.task ?? "";
-	let modelOverride: string | undefined = resolveModelCandidate(
+	let modelOverride: string | undefined = resolveSubagentModelOverride(
 		(params.model as string | undefined) ?? agentConfig.model,
+		ctx.model,
 		availableModels,
 		currentProvider,
 	);

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -20,6 +20,44 @@ export function splitThinkingSuffix(model: string): { baseModel: string; thinkin
 	};
 }
 
+/** Sentinel model value requesting that a subagent inherit the parent session's model. */
+export const INHERIT_MODEL = "inherit";
+
+/** Minimal shape of the parent session's in-memory model (`ctx.model`). */
+export interface ParentModel {
+	provider: string;
+	id: string;
+}
+
+/**
+ * Resolve the `--model` override passed to a spawned subagent.
+ *
+ * When no model is requested (`undefined`, `false`, empty, or the `"inherit"`
+ * sentinel), the child must inherit the parent session's *in-memory* model
+ * (`provider/id`) instead of being left to resolve its own model. Without an
+ * explicit `provider/id`, the child falls back to the global
+ * `~/.pi/agent/settings.json` default, which is shared across every open PI
+ * session — so a different session that last changed its model in the TUI would
+ * silently contaminate this session's subagents (see issue #266). Passing an
+ * explicit `provider/id` keeps each session's children isolated to that
+ * session's model.
+ *
+ * An explicitly requested model string is resolved via {@link resolveModelCandidate}.
+ */
+export function resolveSubagentModelOverride(
+	requestedModel: string | boolean | undefined,
+	parentModel: ParentModel | undefined,
+	availableModels: AvailableModelInfo[] | undefined,
+	preferredProvider?: string,
+): string | undefined {
+	const trimmed = typeof requestedModel === "string" ? requestedModel.trim() : "";
+	const explicit = trimmed && trimmed !== INHERIT_MODEL ? trimmed : undefined;
+	if (explicit === undefined) {
+		return parentModel ? `${parentModel.provider}/${parentModel.id}` : undefined;
+	}
+	return resolveModelCandidate(explicit, availableModels, preferredProvider);
+}
+
 export function resolveModelCandidate(
 	model: string | undefined,
 	availableModels: AvailableModelInfo[] | undefined,

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -4,6 +4,7 @@ import {
 	buildModelCandidates,
 	isRetryableModelFailure,
 	resolveModelCandidate,
+	resolveSubagentModelOverride,
 } from "../../src/runs/shared/model-fallback.ts";
 
 describe("model fallback helpers", () => {
@@ -72,5 +73,76 @@ describe("model fallback helpers", () => {
 		assert.equal(isRetryableModelFailure("bash failed (exit 1): command not found"), false);
 		assert.equal(isRetryableModelFailure("read failed (exit 1): no such file or directory"), false);
 		assert.equal(isRetryableModelFailure(undefined), false);
+	});
+});
+
+describe("resolveSubagentModelOverride (cross-session inherit, issue #266)", () => {
+	const availableModels = [
+		{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" },
+		{ provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
+	];
+	const parentModel = { provider: "deepseek", id: "deepseek-v4-flash" };
+
+	it("inherits the parent session model when no model is requested", () => {
+		// The crux of the bug: an undefined model must NOT collapse to `undefined`
+		// (which leaves the child to read the shared global settings.json), but
+		// must pin the parent session's in-memory provider/id.
+		assert.equal(
+			resolveSubagentModelOverride(undefined, parentModel, availableModels),
+			"deepseek/deepseek-v4-flash",
+		);
+	});
+
+	it("inherits the parent session model when the model is the \"inherit\" sentinel", () => {
+		assert.equal(
+			resolveSubagentModelOverride("inherit", parentModel, availableModels),
+			"deepseek/deepseek-v4-flash",
+		);
+	});
+
+	it("inherits the parent session model when the agent config sets model: false (delegate)", () => {
+		assert.equal(
+			resolveSubagentModelOverride(false, parentModel, availableModels),
+			"deepseek/deepseek-v4-flash",
+		);
+	});
+
+	it("treats an empty or whitespace-only model as inherit", () => {
+		assert.equal(resolveSubagentModelOverride("", parentModel, availableModels), "deepseek/deepseek-v4-flash");
+		assert.equal(resolveSubagentModelOverride("   ", parentModel, availableModels), "deepseek/deepseek-v4-flash");
+	});
+
+	it("trims surrounding whitespace from the \"inherit\" sentinel", () => {
+		assert.equal(resolveSubagentModelOverride("  inherit  ", parentModel, availableModels), "deepseek/deepseek-v4-flash");
+	});
+
+	it("keeps an explicit provider/id model unchanged", () => {
+		assert.equal(
+			resolveSubagentModelOverride("anthropic/claude-sonnet-4", parentModel, availableModels),
+			"anthropic/claude-sonnet-4",
+		);
+	});
+
+	it("resolves an explicit bare id against the registry, not the parent", () => {
+		assert.equal(
+			resolveSubagentModelOverride("gpt-5-mini", parentModel, availableModels),
+			"openai/gpt-5-mini",
+		);
+	});
+
+	it("returns undefined when inheriting but no parent model is known", () => {
+		// No parent session model available: fall back to the prior behavior of
+		// emitting no override rather than inventing an invalid one.
+		assert.equal(resolveSubagentModelOverride(undefined, undefined, availableModels), undefined);
+		assert.equal(resolveSubagentModelOverride("inherit", undefined, availableModels), undefined);
+		assert.equal(resolveSubagentModelOverride(false, undefined, availableModels), undefined);
+	});
+
+	it("never emits the literal \"inherit\" string as a model", () => {
+		// Regression guard: the old resolveModelCandidate returned \"inherit\" verbatim
+		// (no registry match), which the child rejected and silently fell back to
+		// the global default.
+		assert.notEqual(resolveSubagentModelOverride("inherit", parentModel, availableModels), "inherit");
+		assert.notEqual(resolveSubagentModelOverride("inherit", undefined, availableModels), "inherit");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #266. Subagents spawned with no explicit model, with `model: false` (e.g. the `delegate` agent), or with `model: "inherit"` were resolving to `undefined` / the literal `"inherit"` string. The child `pi` process then received no usable `--model` arg and fell back to the **shared global** `~/.pi/agent/settings.json` default — which any open session can overwrite by changing its model in the TUI. With multiple PI sessions open, a subagent silently ran on a *different session's* model.

## Root cause

`resolveModelCandidate("inherit", …)` finds no registry match and returns `"inherit"` verbatim; `undefined`/`false` model configs return `undefined`. Neither yields the parent session's actual model, so the child resolves its own model from the global settings file.

## Fix

New helper `resolveSubagentModelOverride` (`src/runs/shared/model-fallback.ts`): when no model is explicitly requested (`undefined`, `false`, empty, or the `"inherit"` sentinel), it pins the parent session's **in-memory** `provider/id` (`ctx.model`). An explicit model string still flows through `resolveModelCandidate`. Passing an explicit `provider/id` (which `resolveModelCandidate` returns unchanged) keeps each session's children isolated to that session's model.

Applied at all four subagent dispatch sites in `subagent-executor.ts`:
- async parallel (`runAsyncPath`)
- async single (`runAsyncPath`)
- sync parallel (`runParallelPath`)
- sync single (`runSinglePath`)

This also fixes the `delegate` agent, whose documented "inherits the parent model" behavior was previously incorrect.

### Follow-up (out of scope)

The chain execution path (`chain-execution.ts`) resolves per-step models separately and the async chain ctx only carries `provider` (not `id`); inheriting there needs the full parent model threaded through. Left as a documented follow-up, consistent with the issue's note.

## Test plan

**Unit** — `test/unit/model-fallback.test.ts`, 9 new cases covering: inherit on `undefined`/`"inherit"`/`false`/empty/whitespace, explicit `provider/id` and bare-id passthrough, `undefined` when no parent model is known, and a regression guard that the literal `"inherit"` is never emitted.

- `npm run test:all` → 512 unit + 365 integration, all passing.

**Live reproduction** — ran the real coding agent (`pi -e`) in tmux with parent model `deepseek/deepseek-v4-flash` while the global `settings.json` default was `deepseek-v4-pro`, then spawned the `delegate` subagent (a "hello world" task) and inspected the subagent session JSONL:

| Code | Parent session model | Subagent session model | Result |
|------|----------------------|------------------------|--------|
| `origin/main` (before) | `deepseek-v4-flash` | `deepseek-v4-pro` | ❌ contaminated by global default |
| this branch (after) | `deepseek-v4-flash` | `deepseek-v4-flash` | ✅ inherits parent session model |

🤖 Generated with [Claude Code](https://claude.com/claude-code)