### PR TITLE
fix: resolve named extension allowlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Important fields:
 |-------|-------|
 | `package` | Optional package identifier. A file with `name: scout` and `package: code-analysis` registers as `code-analysis.scout`; serialization keeps `name` and `package` separate. |
 | `tools` | Builtin tool allowlist. `mcp:` entries select direct MCP tools when `pi-mcp-adapter` is installed. |
-| `extensions` | Omitted means normal extensions; empty means no extensions; comma-separated values allowlist specific extensions. |
+| `extensions` | Omitted means normal extensions; empty means no extensions; comma-separated names or paths allowlist specific extensions. |
 | `model` | Default model. Bare ids prefer the current provider when possible, then unique registry matches. |
 | `fallbackModels` | Ordered backup models for provider/model failures such as quota, auth, timeout, or unavailable model. Ordinary task failures do not trigger fallback. |
 | `thinking` | Appended as a `:level` suffix at runtime unless a suffix is already present. |
@@ -484,9 +484,11 @@ Direct MCP tools require [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-a
 # Empty: no extensions
 extensions:
 
-# Allowlist
-extensions: /abs/path/to/ext-a.ts, /abs/path/to/ext-b.ts
+# Allowlist by installed package name, npm-prefixed package name, or path
+extensions: pi-intercom, npm:@scope/ext-package, /abs/path/to/ext-a.ts, ./local-ext.ts
 ```
+
+Named entries resolve installed Pi packages from the user agent directory (for example `~/.pi/agent/npm/node_modules/<name>`). Packages with `pi.extensions` expand to those extension entry files; path entries are passed through unchanged.
 
 When `extensions` is present, it takes precedence over extension paths implied by `tools` entries.
 

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -6,6 +6,7 @@ import { encodeNestedPathEnv, parseNestedPathEnv, type NestedPathEntry } from ".
 import { resolveMcpDirectToolNames } from "./mcp-direct-tool-allowlist.ts";
 import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "./structured-output.ts";
 import type { JsonSchemaObject } from "../../shared/types.ts";
+import { getAgentDir } from "../../shared/utils.ts";
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
 const TASK_ARG_LIMIT = 8000;
@@ -76,6 +77,62 @@ export function applyThinkingSuffix(model: string | undefined, thinking: string 
 	return `${model}:${thinking}`;
 }
 
+function isPathLikeExtensionRef(ref: string): boolean {
+	return path.isAbsolute(ref)
+		|| ref.startsWith("./")
+		|| ref.startsWith("../")
+		|| ref.startsWith("~/")
+		|| ref.startsWith("file:")
+		|| ref.endsWith(".ts")
+		|| ref.endsWith(".js")
+		|| ref.endsWith(".mjs")
+		|| ref.endsWith(".cjs");
+}
+
+function readJsonBestEffort(filePath: string): unknown {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+	} catch {
+		return null;
+	}
+}
+
+function packageExtensionEntries(packageRoot: string): string[] {
+	const pkg = readJsonBestEffort(path.join(packageRoot, "package.json"));
+	if (!pkg || typeof pkg !== "object" || Array.isArray(pkg)) return [];
+	const pi = (pkg as { pi?: unknown }).pi;
+	if (!pi || typeof pi !== "object" || Array.isArray(pi)) return [];
+	const extensions = (pi as { extensions?: unknown }).extensions;
+	if (!Array.isArray(extensions)) return [];
+	return extensions.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "");
+}
+
+function resolvePackageExtensionRef(ref: string): string[] | null {
+	const packageName = ref.startsWith("npm:") ? ref.slice("npm:".length) : ref;
+	if (!packageName || isPathLikeExtensionRef(packageName)) return null;
+
+	const agentDir = getAgentDir();
+	const candidates = [
+		path.join(agentDir, "npm", "node_modules", packageName),
+		path.join(agentDir, "node_modules", packageName),
+		path.join(agentDir, "extensions", packageName),
+	];
+
+	for (const packageRoot of candidates) {
+		if (!fs.existsSync(packageRoot)) continue;
+		const entries = packageExtensionEntries(packageRoot);
+		if (entries.length > 0) {
+			return entries.map((entry) => path.resolve(packageRoot, entry));
+		}
+		return [packageRoot];
+	}
+	return null;
+}
+
+export function resolveExtensionRefs(refs: string[]): string[] {
+	return refs.flatMap((ref) => resolvePackageExtensionRef(ref) ?? [ref]);
+}
+
 export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	const args = [...input.baseArgs];
 
@@ -118,9 +175,10 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	const runtimeExtensions = fanoutAuthorized
 		? [PROMPT_RUNTIME_EXTENSION_PATH, FANOUT_CHILD_EXTENSION_PATH]
 		: [PROMPT_RUNTIME_EXTENSION_PATH];
-	if (input.extensions !== undefined) {
+	const explicitExtensionRefs = input.extensions !== undefined ? resolveExtensionRefs(input.extensions) : undefined;
+	if (explicitExtensionRefs !== undefined) {
 		args.push("--no-extensions");
-		for (const extPath of [...new Set([...runtimeExtensions, ...toolExtensionPaths, ...input.extensions])]) {
+		for (const extPath of [...new Set([...runtimeExtensions, ...toolExtensionPaths, ...explicitExtensionRefs])]) {
 			args.push("--extension", extPath);
 		}
 	} else {

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -465,6 +465,70 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.ok(extensionArgs.includes("./allowed-ext.ts"));
 	});
 
+	it("resolves named npm extension packages in explicit extension allowlists", () => {
+		const fixture = createMcpFixture();
+		const packageRoot = path.join(fixture.agentDir, "npm", "node_modules", "pi-intercom");
+		writeJson(path.join(packageRoot, "package.json"), {
+			name: "pi-intercom",
+			pi: { extensions: ["./index.ts"] },
+		});
+		fs.writeFileSync(path.join(packageRoot, "index.ts"), "export default {};\n", "utf-8");
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			extensions: ["pi-intercom", "./allowed-ext.ts"],
+		});
+
+		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
+		assert.ok(args.includes("--no-extensions"));
+		assert.ok(extensionArgs.includes(path.join(packageRoot, "index.ts")));
+		assert.ok(extensionArgs.includes("./allowed-ext.ts"));
+		assert.ok(!extensionArgs.includes("pi-intercom"));
+	});
+
+	it("resolves npm-prefixed and scoped extension package names", () => {
+		const fixture = createMcpFixture();
+		const packageRoot = path.join(fixture.agentDir, "npm", "node_modules", "@scope", "named-ext");
+		writeJson(path.join(packageRoot, "package.json"), {
+			name: "@scope/named-ext",
+			pi: { extensions: ["./src/extension.ts"] },
+		});
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			extensions: ["npm:@scope/named-ext"],
+		});
+
+		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
+		assert.ok(extensionArgs.includes(path.join(packageRoot, "src", "extension.ts")));
+		assert.ok(!extensionArgs.includes("npm:@scope/named-ext"));
+	});
+
+	it("keeps unresolved extension refs unchanged so Pi can report the final load error", () => {
+		const fixture = createMcpFixture();
+		void fixture;
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			extensions: ["missing-extension"],
+		});
+
+		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
+		assert.ok(extensionArgs.includes("missing-extension"));
+	});
+
 	it("authorizes child fanout only from exact declared builtin subagent", () => {
 		const { args, env } = buildPiArgs({
 			baseArgs: ["-p"],


### PR DESCRIPTION
## Summary
- resolve explicit subagent `extensions` entries by installed package name as well as paths
- support `npm:<package>` and scoped package names
- document name/path extension allowlists

## Verification
- `node --experimental-strip-types --test test/unit/pi-args.test.ts`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH HOME=$(mktemp -d /tmp/pi-home-test-XXXXXX) USERPROFILE=$HOME npm test` (506/506 pass; run used an isolated temp home)
