### PR TITLE
feat: env overrides to load bundled agents/intercom from read-only dirs

### DIFF
--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -768,6 +768,22 @@ function resolveNearestProjectChainDirs(cwd: string): { readDirs: string[]; pref
 }
 const BUILTIN_AGENTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "agents");
 
+export const EXTRA_AGENT_DIRS_ENV = "PI_SUBAGENT_EXTRA_AGENT_DIRS";
+
+// Additional read-only directories to scan for agent definitions, supplied by the
+// launcher via PI_SUBAGENT_EXTRA_AGENT_DIRS (PATH-style, split on os/path delimiter).
+// Lets a hermetic wrapper (e.g. a Nix-store install) expose bundled agents without
+// copying or symlinking them into the writable agent dir. Loaded as "user" source,
+// at lower precedence than agents the user placed in their own agent dir.
+function extraUserAgentDirs(): string[] {
+	const raw = process.env[EXTRA_AGENT_DIRS_ENV];
+	if (!raw) return [];
+	return raw
+		.split(path.delimiter)
+		.map((dir) => dir.trim())
+		.filter((dir) => dir.length > 0);
+}
+
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
 	const userDirOld = path.join(getAgentDir(), "agents");
 	const userDirNew = path.join(os.homedir(), ".agents");
@@ -785,9 +801,10 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 		projectSettingsPath,
 	);
 
+	const userAgentsExtra = scope === "project" ? [] : extraUserAgentDirs().flatMap((dir) => loadAgentsFromDir(dir, "user"));
 	const userAgentsOld = scope === "project" ? [] : loadAgentsFromDir(userDirOld, "user");
 	const userAgentsNew = scope === "project" ? [] : loadAgentsFromDir(userDirNew, "user");
-	const userAgents = [...userAgentsOld, ...userAgentsNew];
+	const userAgents = [...userAgentsExtra, ...userAgentsOld, ...userAgentsNew];
 
 	const projectAgents = scope === "user" ? [] : projectAgentDirs.flatMap((dir) => loadAgentsFromDir(dir, "project"));
 	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents)
@@ -827,6 +844,7 @@ export function discoverAgentsAll(cwd: string): {
 		projectSettingsPath,
 	);
 	const user = [
+		...extraUserAgentDirs().flatMap((dir) => loadAgentsFromDir(dir, "user")),
 		...loadAgentsFromDir(userDirOld, "user"),
 		...loadAgentsFromDir(userDirNew, "user"),
 	];

--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -17,6 +17,16 @@ function defaultIntercomExtensionDir(agentDir = defaultAgentDir()): string {
 	return path.join(agentDir, "extensions", PI_INTERCOM_PACKAGE_NAME);
 }
 
+export const INTERCOM_EXTENSION_DIR_ENV = "PI_INTERCOM_EXTENSION_DIR";
+
+// Launcher-provided override for the pi-intercom package directory. Lets a hermetic
+// wrapper point the subagent intercom bridge at a read-only install (e.g. a Nix-store
+// path) instead of seeding the package into the writable agent dir.
+function envIntercomExtensionDir(): string | undefined {
+	const dir = process.env[INTERCOM_EXTENSION_DIR_ENV]?.trim();
+	return dir ? dir : undefined;
+}
+
 function defaultIntercomConfigPath(agentDir = defaultAgentDir()): string {
 	return path.join(agentDir, "intercom", "config.json");
 }
@@ -224,7 +234,7 @@ function configuredPiIntercomPackageDir(input: ResolveIntercomBridgeInput, agent
 }
 
 function resolveIntercomExtensionDir(input: ResolveIntercomBridgeInput, agentDir: string): string {
-	const legacyDir = path.resolve(input.extensionDir ?? defaultIntercomExtensionDir(agentDir));
+	const legacyDir = path.resolve(input.extensionDir ?? envIntercomExtensionDir() ?? defaultIntercomExtensionDir(agentDir));
 	if (fs.existsSync(legacyDir)) return legacyDir;
 	return configuredPiIntercomPackageDir(input, agentDir) ?? legacyDir;
 }

--- a/test/unit/extra-agent-dirs.test.ts
+++ b/test/unit/extra-agent-dirs.test.ts
@@ -9,7 +9,7 @@ let tempDir = "";
 let agentDir = "";
 let cwd = "";
 const saved: Record<string, string | undefined> = {};
-const MANAGED_ENV = ["PI_CODING_AGENT_DIR", EXTRA_AGENT_DIRS_ENV];
+const MANAGED_ENV = ["PI_CODING_AGENT_DIR", "HOME", "USERPROFILE", EXTRA_AGENT_DIRS_ENV];
 
 function writeAgent(dir: string, name: string): string {
 	const filePath = path.join(dir, `${name}.md`);
@@ -22,11 +22,15 @@ describe("PI_SUBAGENT_EXTRA_AGENT_DIRS discovery", () => {
 	beforeEach(() => {
 		for (const key of MANAGED_ENV) saved[key] = process.env[key];
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-extra-agent-dirs-"));
-		// Isolate from the developer's real ~/.pi/agent so the default user dirs are empty.
+		// Isolate from the developer's real user agent dirs so defaults are empty.
 		agentDir = path.join(tempDir, "agent");
+		const homeDir = path.join(tempDir, "home");
 		cwd = path.join(tempDir, "workspace");
 		fs.mkdirSync(cwd, { recursive: true });
+		fs.mkdirSync(homeDir, { recursive: true });
 		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env.HOME = homeDir;
+		process.env.USERPROFILE = homeDir;
 		delete process.env[EXTRA_AGENT_DIRS_ENV];
 	});
 

--- a/test/unit/extra-agent-dirs.test.ts
+++ b/test/unit/extra-agent-dirs.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { discoverAgents, discoverAgentsAll, EXTRA_AGENT_DIRS_ENV } from "../../src/agents/agents.ts";
+
+let tempDir = "";
+let agentDir = "";
+let cwd = "";
+const saved: Record<string, string | undefined> = {};
+const MANAGED_ENV = ["PI_CODING_AGENT_DIR", EXTRA_AGENT_DIRS_ENV];
+
+function writeAgent(dir: string, name: string): string {
+	const filePath = path.join(dir, `${name}.md`);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, `---\nname: ${name}\ndescription: ${name} agent\n---\n\nDo ${name} work.\n`, "utf-8");
+	return filePath;
+}
+
+describe("PI_SUBAGENT_EXTRA_AGENT_DIRS discovery", () => {
+	beforeEach(() => {
+		for (const key of MANAGED_ENV) saved[key] = process.env[key];
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-extra-agent-dirs-"));
+		// Isolate from the developer's real ~/.pi/agent so the default user dirs are empty.
+		agentDir = path.join(tempDir, "agent");
+		cwd = path.join(tempDir, "workspace");
+		fs.mkdirSync(cwd, { recursive: true });
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env[EXTRA_AGENT_DIRS_ENV];
+	});
+
+	afterEach(() => {
+		for (const key of MANAGED_ENV) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
+		}
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("discovers agents from the env-provided dirs as a 'user' source", () => {
+		const bundledDir = path.join(tempDir, "store", "agents");
+		const bundledAgent = writeAgent(bundledDir, "bundled-reviewer");
+		process.env[EXTRA_AGENT_DIRS_ENV] = bundledDir;
+
+		const scoped = discoverAgents(cwd, "user");
+		const found = scoped.agents.find((agent) => agent.name === "bundled-reviewer");
+		assert.ok(found, "expected bundled agent under 'user' scope");
+		assert.equal(found?.filePath, bundledAgent);
+
+		const all = discoverAgentsAll(cwd);
+		assert.ok(all.user.find((agent) => agent.name === "bundled-reviewer" && agent.filePath === bundledAgent));
+	});
+
+	it("scans every directory listed (PATH-style delimiter)", () => {
+		const dirA = path.join(tempDir, "store-a");
+		const dirB = path.join(tempDir, "store-b");
+		writeAgent(dirA, "agent-a");
+		writeAgent(dirB, "agent-b");
+		process.env[EXTRA_AGENT_DIRS_ENV] = [dirA, dirB].join(path.delimiter);
+
+		const all = discoverAgentsAll(cwd);
+		assert.ok(all.user.find((agent) => agent.name === "agent-a"));
+		assert.ok(all.user.find((agent) => agent.name === "agent-b"));
+	});
+
+	it("lets a local user agent override a bundled one of the same name", () => {
+		const bundledDir = path.join(tempDir, "store", "agents");
+		writeAgent(bundledDir, "shared");
+		const localPath = writeAgent(path.join(agentDir, "agents"), "shared");
+		process.env[EXTRA_AGENT_DIRS_ENV] = bundledDir;
+
+		const scoped = discoverAgents(cwd, "user");
+		const matches = scoped.agents.filter((agent) => agent.name === "shared");
+		assert.equal(matches.length, 1, "name collisions must dedupe");
+		assert.equal(matches[0]?.filePath, localPath, "local user agent should win over bundled");
+	});
+
+	it("ignores the env var when unset or empty", () => {
+		process.env[EXTRA_AGENT_DIRS_ENV] = "";
+		const all = discoverAgentsAll(cwd);
+		assert.deepEqual(all.user, []);
+	});
+});

--- a/test/unit/intercom-extension-dir.test.ts
+++ b/test/unit/intercom-extension-dir.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { diagnoseIntercomBridge, INTERCOM_EXTENSION_DIR_ENV } from "../../src/intercom/intercom-bridge.ts";
+
+let tempDir = "";
+let agentDir = "";
+const saved: Record<string, string | undefined> = {};
+const MANAGED_ENV = ["PI_CODING_AGENT_DIR", INTERCOM_EXTENSION_DIR_ENV];
+
+describe("PI_INTERCOM_EXTENSION_DIR override", () => {
+	beforeEach(() => {
+		for (const key of MANAGED_ENV) saved[key] = process.env[key];
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-intercom-ext-dir-"));
+		// Point the agent dir at an empty temp dir so the default
+		// `<agentDir>/extensions/pi-intercom` location does not exist.
+		agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(agentDir, { recursive: true });
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env[INTERCOM_EXTENSION_DIR_ENV];
+	});
+
+	afterEach(() => {
+		for (const key of MANAGED_ENV) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
+		}
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("resolves the bridge extension dir from the env var", () => {
+		const storeIntercom = path.join(tempDir, "store", "node_modules", "pi-intercom");
+		fs.mkdirSync(storeIntercom, { recursive: true });
+		process.env[INTERCOM_EXTENSION_DIR_ENV] = storeIntercom;
+
+		const diagnostic = diagnoseIntercomBridge({
+			config: { mode: "always" },
+			context: "fresh",
+			orchestratorTarget: "main",
+		});
+		assert.equal(diagnostic.extensionDir, path.resolve(storeIntercom));
+	});
+
+	it("falls back to the default agent-dir location when the env var is unset", () => {
+		const defaultDir = path.join(agentDir, "extensions", "pi-intercom");
+		fs.mkdirSync(defaultDir, { recursive: true });
+
+		const diagnostic = diagnoseIntercomBridge({
+			config: { mode: "always" },
+			context: "fresh",
+			orchestratorTarget: "main",
+		});
+		assert.equal(diagnostic.extensionDir, path.resolve(defaultDir));
+	});
+
+	it("prefers an explicit input.extensionDir over the env var", () => {
+		const envDir = path.join(tempDir, "env-intercom");
+		const explicitDir = path.join(tempDir, "explicit-intercom");
+		fs.mkdirSync(envDir, { recursive: true });
+		fs.mkdirSync(explicitDir, { recursive: true });
+		process.env[INTERCOM_EXTENSION_DIR_ENV] = envDir;
+
+		const diagnostic = diagnoseIntercomBridge({
+			config: { mode: "always" },
+			context: "fresh",
+			orchestratorTarget: "main",
+			extensionDir: explicitDir,
+		});
+		assert.equal(diagnostic.extensionDir, path.resolve(explicitDir));
+	});
+});


### PR DESCRIPTION
Add PI_SUBAGENT_EXTRA_AGENT_DIRS (PATH-style, split on path.delimiter) so a launcher can expose bundled agent definitions from read-only locations (e.g. a Nix store) without copying or symlinking them into the writable agent dir. Loaded as a "user" source, below the user's own agent dir on name collisions.

Add PI_INTERCOM_EXTENSION_DIR to override the pi-intercom bridge package directory, so the same hermetic install can point the bridge at a read-only path instead of seeding it under <agentDir>/extensions.

Both are no-ops when unset. Adds unit tests for each.