### PR TITLE
fix: disable completion guard for delegate

### DIFF
--- a/agents/delegate.md
+++ b/agents/delegate.md
@@ -4,6 +4,7 @@ description: Lightweight subagent that inherits the parent model with no default
 systemPromptMode: append
 inheritProjectContext: true
 tools: read, grep, find, ls, bash, edit, write, contact_supervisor
+completionGuard: false
 inheritSkills: false
 ---
 

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -64,6 +64,15 @@ Do work
 			assert.equal(agent?.defaultContext, "fork", `${name} should default to fork context`);
 		}
 	});
+
+	it("loads packaged delegate with completion guard disabled", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-builtin-delegate-guard-"));
+		tempDirs.push(dir);
+		const agents = discoverAgentsAll(dir).builtin;
+		const delegate = agents.find((candidate) => candidate.name === "delegate");
+
+		assert.equal(delegate?.completionGuard, false);
+	});
 });
 
 describe("chain discovery", () => {


### PR DESCRIPTION
## Summary

- Marks the packaged `delegate` agent with `completionGuard: false`.
- Keeps mutation completion-guard behavior available on implementation-oriented agents like `worker` while making generic delegated read-only/output-artifact tasks safe by default.
- Adds coverage that packaged `delegate` loads with the guard disabled.

## Validation

- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/agent-frontmatter.test.ts test/unit/completion-guard.test.ts`

## Context

Jo hit a false red on an async read-only `delegate` task with an output artifact: the child completed successfully, but the background runner reported `Subagent completed without making edits for an implementation task.` A Jo-side override works as a stopgap, but this is a better package-level default for the generic `delegate` agent.