### PR TITLE
fix: show output from failed foreground subagents

### DIFF
--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -690,6 +690,19 @@ function resultSummaryForIntercom(result: SingleResult): string {
 	return output || result.error || "(no output)";
 }
 
+function formatFailedSingleRunOutput(result: SingleResult, displayOutput: string): string {
+	const error = result.error || "Failed";
+	const output = displayOutput.trim();
+	const lines = [error];
+	if (output && output !== error.trim()) {
+		lines.push("", "Output:", output);
+	}
+	if (result.artifactPaths?.outputPath) {
+		lines.push("", `Output artifact: ${result.artifactPaths.outputPath}`);
+	}
+	return lines.join("\n");
+}
+
 function createForegroundControlNotifier(data: Pick<ExecutionContextData, "controlConfig" | "intercomBridge">, deps: Pick<ExecutorDeps, "pi">): (event: ControlEvent) => void {
 	return (event) => emitControlNotification({
 		pi: deps.pi,
@@ -2160,7 +2173,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 
 	if (r.exitCode !== 0)
 		return {
-			content: [{ type: "text", text: r.error || "Failed" }],
+			content: [{ type: "text", text: formatFailedSingleRunOutput(r, finalizedOutput.displayOutput) }],
 			details,
 			isError: true,
 		};

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -213,6 +213,25 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		]);
 	});
 
+	it("returns captured output when the foreground executor fails an implementation run", async () => {
+		mockPi.onCall({ output: "Oracle review:\n- finding one\n- finding two" });
+		const executor = makeExecutor([makeAgent("oracle")]);
+
+		const result = await executor.execute(
+			"failed-single-output",
+			{ agent: "oracle", task: "Implement the approved file changes" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		const text = result.content[0]?.text ?? "";
+		assert.equal(result.isError, true);
+		assert.match(text, /completed without making edits/);
+		assert.match(text, /Output:\nOracle review:\n- finding one\n- finding two/);
+		assert.match(text, /Output artifact: /);
+	});
+
 	it("fails future-tense implementation summaries when no mutation attempt occurred", async () => {
 		mockPi.onCall({ output: "I’ll do that now and report back after implementing." });
 		const agents = [makeAgent("worker")];


### PR DESCRIPTION
## Summary
- include captured child output in failed foreground single-run tool responses
- keep the failure reason first, then show the captured output and output artifact path
- add a regression test for an implementation-guard failure returning the child output through the public executor

Fixes #277.

## Tests
- node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts --test-name-pattern "returns captured output when the foreground executor fails an implementation run"
- npm run test:integration
- npm run test:unit

## Overlap check
Checked batch PRs #270, #271, #272, #273, #276, #280, #281, #283, and #288. #270/#280/#283 touch nearby executor files but do not change the failed foreground single-run response path; they still return only the error on this case.