### PR TITLE
fix: retry Windows atomic JSON renames

### DIFF
--- a/src/shared/atomic-json.ts
+++ b/src/shared/atomic-json.ts
@@ -1,16 +1,73 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-export function writeAtomicJson(filePath: string, payload: object): void {
-	fs.mkdirSync(path.dirname(filePath), { recursive: true });
-	const tempPath = path.join(
-		path.dirname(filePath),
-		`.${path.basename(filePath)}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`,
-	);
-	try {
-		fs.writeFileSync(tempPath, JSON.stringify(payload, null, 2), "utf-8");
-		fs.renameSync(tempPath, filePath);
-	} finally {
-		fs.rmSync(tempPath, { force: true });
+type AtomicJsonFs = Pick<typeof fs, "mkdirSync" | "writeFileSync" | "renameSync" | "rmSync">;
+
+type AtomicJsonWriterOptions = {
+	fs?: AtomicJsonFs;
+	now?: () => number;
+	pid?: number;
+	random?: () => number;
+	retryRenameErrors?: boolean;
+	retryDelaysMs?: readonly number[];
+	wait?: (delayMs: number) => void;
+};
+
+const DEFAULT_RENAME_RETRY_DELAYS_MS = [10, 25, 50, 100, 200] as const;
+const RETRYABLE_RENAME_ERROR_CODES = new Set(["EACCES", "EBUSY", "EPERM"]);
+
+function waitSync(delayMs: number): void {
+	const end = Date.now() + delayMs;
+	while (Date.now() < end) {
+		// writeAtomicJson is synchronous because callers often update status from sync callbacks.
 	}
 }
+
+function isRetryableRenameError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_RENAME_ERROR_CODES.has(code);
+}
+
+function renameWithRetry(
+	fsImpl: AtomicJsonFs,
+	sourcePath: string,
+	targetPath: string,
+	retryDelaysMs: readonly number[],
+	wait: (delayMs: number) => void,
+): void {
+	for (let attempt = 0; ; attempt++) {
+		try {
+			fsImpl.renameSync(sourcePath, targetPath);
+			return;
+		} catch (error) {
+			const delayMs = retryDelaysMs[attempt];
+			if (delayMs === undefined || !isRetryableRenameError(error)) throw error;
+			wait(delayMs);
+		}
+	}
+}
+
+export function createAtomicJsonWriter(options: AtomicJsonWriterOptions = {}): (filePath: string, payload: object) => void {
+	const fsImpl = options.fs ?? fs;
+	const now = options.now ?? Date.now;
+	const pid = options.pid ?? process.pid;
+	const random = options.random ?? Math.random;
+	const retryRenameErrors = options.retryRenameErrors ?? process.platform === "win32";
+	const retryDelaysMs = retryRenameErrors ? options.retryDelaysMs ?? DEFAULT_RENAME_RETRY_DELAYS_MS : [];
+	const wait = options.wait ?? waitSync;
+	return (filePath: string, payload: object): void => {
+		fsImpl.mkdirSync(path.dirname(filePath), { recursive: true });
+		const tempPath = path.join(
+			path.dirname(filePath),
+			`.${path.basename(filePath)}.${pid}.${now()}.${random().toString(36).slice(2)}.tmp`,
+		);
+		try {
+			fsImpl.writeFileSync(tempPath, JSON.stringify(payload, null, 2), "utf-8");
+			renameWithRetry(fsImpl, tempPath, filePath, retryDelaysMs, wait);
+		} finally {
+			fsImpl.rmSync(tempPath, { force: true });
+		}
+	};
+}
+
+export const writeAtomicJson = createAtomicJsonWriter();

--- a/test/unit/atomic-json.test.ts
+++ b/test/unit/atomic-json.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { createAtomicJsonWriter } from "../../src/shared/atomic-json.ts";
+
+class FakeFs {
+	files = new Map<string, string>();
+	madeDirs: string[] = [];
+	renameCalls = 0;
+	failRenameCodes: string[] = [];
+
+	mkdirSync(dirPath: string): void {
+		this.madeDirs.push(dirPath);
+	}
+
+	writeFileSync(filePath: string, contents: string): void {
+		this.files.set(filePath, contents);
+	}
+
+	renameSync(sourcePath: string, targetPath: string): void {
+		this.renameCalls++;
+		const failureCode = this.failRenameCodes.shift();
+		if (failureCode) {
+			const error = new Error(`rename failed with ${failureCode}`) as NodeJS.ErrnoException;
+			error.code = failureCode;
+			throw error;
+		}
+		const contents = this.files.get(sourcePath);
+		if (contents === undefined) throw new Error(`missing source file: ${sourcePath}`);
+		this.files.delete(sourcePath);
+		this.files.set(targetPath, contents);
+	}
+
+	rmSync(filePath: string): void {
+		this.files.delete(filePath);
+	}
+}
+
+function createWriter(fakeFs: FakeFs, waits: number[]) {
+	return createAtomicJsonWriter({
+		fs: fakeFs,
+		now: () => 12345,
+		pid: 678,
+		random: () => 0.5,
+		retryRenameErrors: true,
+		retryDelaysMs: [1, 2, 3],
+		wait: (delayMs) => waits.push(delayMs),
+	});
+}
+
+describe("writeAtomicJson", () => {
+	it("retries transient rename failures before replacing the target", () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failRenameCodes = ["EPERM", "EBUSY"];
+		const waits: number[] = [];
+		const writeAtomicJson = createWriter(fakeFs, waits);
+		const targetPath = path.join("/tmp", "status.json");
+
+		writeAtomicJson(targetPath, { state: "running" });
+
+		assert.equal(fakeFs.renameCalls, 3);
+		assert.deepEqual(waits, [1, 2]);
+		assert.deepEqual(fakeFs.madeDirs, [path.dirname(targetPath)]);
+		assert.equal(fakeFs.files.get(targetPath), JSON.stringify({ state: "running" }, null, 2));
+		assert.equal(fakeFs.files.size, 1);
+	});
+
+	it("throws non-retryable rename failures without retrying", () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failRenameCodes = ["ENOENT"];
+		const waits: number[] = [];
+		const writeAtomicJson = createWriter(fakeFs, waits);
+
+		assert.throws(() => writeAtomicJson(path.join("/tmp", "status.json"), { state: "running" }), /ENOENT/);
+		assert.equal(fakeFs.renameCalls, 1);
+		assert.deepEqual(waits, []);
+		assert.equal(fakeFs.files.size, 0);
+	});
+
+	it("cleans up the temp file after retryable failures are exhausted", () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failRenameCodes = ["EPERM", "EPERM", "EPERM", "EPERM"];
+		const waits: number[] = [];
+		const writeAtomicJson = createWriter(fakeFs, waits);
+		const targetPath = path.join("/tmp", "status.json");
+
+		assert.throws(() => writeAtomicJson(targetPath, { state: "running" }), /EPERM/);
+		assert.equal(fakeFs.renameCalls, 4);
+		assert.deepEqual(waits, [1, 2, 3]);
+		assert.equal(fakeFs.files.has(targetPath), false);
+		assert.equal(fakeFs.files.size, 0);
+	});
+});


### PR DESCRIPTION
## Summary
- retry transient Windows rename failures in `writeAtomicJson` for `EPERM`, `EBUSY`, and `EACCES`
- keep non-Windows behavior unchanged by default
- add fake-filesystem unit coverage for retry success, non-retryable errors, and cleanup after exhausted retries

Fixes #269.

This is a narrow maintainer-owned alternative to #272: it addresses the shared atomic JSON failure path with portable coverage, without changing async-runner interrupt or crash handling in the same PR.

## Tests
- `node --experimental-strip-types --test test/unit/atomic-json.test.ts`
- `npm run test:unit`
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts`
- `npm run test:integration`