### PR TITLE
Support package-provided subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,11 @@ Agent locations, lowest to highest priority:
 | Scope | Path |
 |-------|------|
 | Builtin | `~/.pi/agent/extensions/subagent/agents/` |
+| Installed package | `package.json` `pi-subagents.agents` or `pi.subagents.agents` |
 | User | `~/.pi/agent/agents/**/*.md` |
 | Project | `.pi/agents/**/*.md` |
 
-Project discovery also reads legacy `.agents/**/*.md` files. Nested subdirectories are discovered recursively. `.chain.md` files do not define agents. If both `.agents/` and `.pi/agents/` define the same parsed runtime agent name, `.pi/agents/` wins. Use `agentScope: "user" | "project" | "both"` to control discovery; `both` is the default and project definitions win runtime-name collisions.
+Project discovery also reads legacy `.agents/**/*.md` files. Nested subdirectories are discovered recursively. `.chain.md` files do not define agents. Installed Pi packages can expose agent directories from either `{"pi-subagents":{"agents":["./agents"]}}` or `{"pi":{"subagents":{"agents":["./agents"]}}}` in their package manifest. Package agents load above builtins and below user/project agents. If both `.agents/` and `.pi/agents/` define the same parsed runtime agent name, `.pi/agents/` wins. Use `agentScope: "user" | "project" | "both"` to control discovery; `both` is the default and project definitions win runtime-name collisions.
 
 Builtin agents load at the lowest priority, so a user or project agent with the same name overrides them. They do not pin a provider model; they inherit your current Pi default model unless you set `subagents.agentOverrides.<name>.model`. `oracle` is an advisory reviewer that critiques direction and proposes an execution prompt without editing files. `worker` is the implementation agent for normal tasks and approved oracle handoffs.
 
@@ -496,10 +497,11 @@ Chains are reusable workflows stored separately from agent files. Use `.chain.md
 
 | Scope | Path |
 |-------|------|
+| Installed package | `package.json` `pi-subagents.chains` or `pi.subagents.chains` |
 | User | `~/.pi/agent/chains/**/*.chain.md`, `~/.pi/agent/chains/**/*.chain.json` |
 | Project | `.pi/chains/**/*.chain.md`, `.pi/chains/**/*.chain.json` |
 
-Nested subdirectories are discovered recursively. If both `.chain.md` and `.chain.json` define the same parsed runtime chain name in the same scope, `.chain.json` wins. If user and project scopes define the same parsed runtime chain name, the project chain wins. Chains support the same optional `package` frontmatter as agents; `name: review-flow` plus `package: code-analysis` runs as `code-analysis.review-flow`.
+Nested subdirectories are discovered recursively. Installed Pi packages can expose chain directories from either `{"pi-subagents":{"chains":["./chains"]}}` or `{"pi":{"subagents":{"chains":["./chains"]}}}` in their package manifest. Package chains load below user/project chains. If both `.chain.md` and `.chain.json` define the same parsed runtime chain name in the same scope, `.chain.json` wins. If user and project scopes define the same parsed runtime chain name, the project chain wins. Chains support the same optional `package` frontmatter as agents; `name: review-flow` plus `package: code-analysis` runs as `code-analysis.review-flow`.
 
 Example:
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -78,8 +78,8 @@ function parsePackageConfig(value: unknown): { packageName?: string; error?: str
 	return parsePackageName(value, "config.package");
 }
 
-function allAgents(d: { builtin: AgentConfig[]; user: AgentConfig[]; project: AgentConfig[] }): AgentConfig[] {
-	return [...d.builtin, ...d.user, ...d.project];
+function allAgents(d: { builtin: AgentConfig[]; package: AgentConfig[]; user: AgentConfig[]; project: AgentConfig[] }): AgentConfig[] {
+	return [...d.builtin, ...d.package, ...d.user, ...d.project];
 }
 
 function availableNames(cwd: string, kind: "agent" | "chain"): string[] {
@@ -114,6 +114,10 @@ function nameExistsInScope(cwd: string, scope: ManagementScope, name: string, ex
 		if (c.source === scope && c.name === name && c.filePath !== excludePath) return true;
 	}
 	return false;
+}
+
+function isMutableSource(source: AgentSource): source is ManagementScope {
+	return source === "user" || source === "project";
 }
 
 function unknownChainAgents(cwd: string, steps: ChainStepConfig[]): string[] {
@@ -327,10 +331,10 @@ function resolveTarget<T extends { source: AgentSource; filePath: string }>(
 	cwd: string,
 	scopeHint?: string,
 ): T | AgentToolResult<Details> {
-	const mutable = matches.filter((m) => m.source !== "builtin");
+	const mutable = matches.filter((m): m is T & { source: ManagementScope } => isMutableSource(m.source));
 	if (mutable.length === 0) {
 		if (matches.length > 0) {
-			return result(`${kind === "agent" ? "Agent" : "Chain"} '${name}' is builtin and cannot be modified. Create a same-named ${kind} in user or project scope to override it.`, true);
+			return result(`${kind === "agent" ? "Agent" : "Chain"} '${name}' is read-only and cannot be modified. Create a same-named ${kind} in user or project scope to override it.`, true);
 		}
 		const available = availableNames(cwd, kind);
 		return result(`${kind === "agent" ? "Agent" : "Chain"} '${name}' not found. Available: ${available.join(", ") || "none"}.`, true);
@@ -442,9 +446,9 @@ function formatChainDetail(chain: ChainConfig): string {
 export function handleList(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
 	const scope = normalizeListScope(params.agentScope) ?? "both";
 	const d = discoverAgentsAll(ctx.cwd);
-	const scopedAgents = allAgents(d).filter((a) => scope === "both" || a.source === "builtin" || a.source === scope).sort((a, b) => a.name.localeCompare(b.name));
+	const scopedAgents = allAgents(d).filter((a) => scope === "both" || a.source === "builtin" || a.source === "package" || a.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const agents = scopedAgents.filter((a) => !a.disabled);
-	const chains = d.chains.filter((c) => scope === "both" || c.source === scope).sort((a, b) => a.name.localeCompare(b.name));
+	const chains = d.chains.filter((c) => scope === "both" || c.source === "package" || c.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const diagnostics = d.chainDiagnostics.filter((entry) => scope === "both" || entry.source === scope);
 	const lines = [
 		"Executable agents:",

--- a/src/agents/agent-selection.ts
+++ b/src/agents/agent-selection.ts
@@ -5,10 +5,12 @@ export function mergeAgentsForScope(
 	userAgents: AgentConfig[],
 	projectAgents: AgentConfig[],
 	builtinAgents: AgentConfig[] = [],
+	packageAgents: AgentConfig[] = [],
 ): AgentConfig[] {
 	const agentMap = new Map<string, AgentConfig>();
 
 	for (const agent of builtinAgents) agentMap.set(agent.name, agent);
+	for (const agent of packageAgents) agentMap.set(agent.name, agent);
 
 	if (scope === "both") {
 		for (const agent of userAgents) agentMap.set(agent.name, agent);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -2,6 +2,7 @@
  * Agent discovery and configuration
  */
 
+import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -17,7 +18,7 @@ export { buildRuntimeName, frontmatterNameForConfig, parsePackageName } from "./
 
 export type AgentScope = "user" | "project" | "both";
 
-export type AgentSource = "builtin" | "user" | "project";
+export type AgentSource = "builtin" | "package" | "user" | "project";
 type SystemPromptMode = "append" | "replace";
 export type AgentDefaultContext = "fresh" | "fork";
 
@@ -141,7 +142,7 @@ export interface ChainConfig {
 }
 
 export interface ChainDiscoveryDiagnostic {
-	source: "user" | "project";
+	source: AgentSource;
 	filePath: string;
 	error: string;
 }
@@ -153,6 +154,256 @@ interface AgentDiscoveryResult {
 
 function getUserChainDir(): string {
 	return path.join(getAgentDir(), "chains");
+}
+
+interface PackageSubagentPaths {
+	agents: string[];
+	chains: string[];
+}
+
+let cachedGlobalNpmRoot: string | null = null;
+
+function readJsonFileBestEffort(filePath: string): unknown {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+	} catch {
+		// Installed package scans are opportunistic; bad third-party manifests
+		// should not break local agent discovery.
+		return null;
+	}
+}
+
+function readOptionalJsonFile(filePath: string): unknown {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+	} catch (error) {
+		const code = typeof error === "object" && error !== null && "code" in error
+			? (error as { code?: unknown }).code
+			: undefined;
+		if (code === "ENOENT") return null;
+		throw error;
+	}
+}
+
+function isSafePackagePath(value: string): boolean {
+	return value.length > 0
+		&& !path.isAbsolute(value)
+		&& value.split(/[\\/]/).every((part) => part.length > 0 && part !== "." && part !== "..");
+}
+
+function parseNpmPackageName(source: string): string | undefined {
+	const spec = source.slice(4).trim();
+	if (!spec) return undefined;
+	const match = spec.match(/^(@?[^@]+(?:\/[^@]+)?)(?:@(.+))?$/);
+	const packageName = match?.[1] ?? spec;
+	return isSafePackagePath(packageName) ? packageName : undefined;
+}
+
+function stripGitRef(repoPath: string): string {
+	const atIndex = repoPath.indexOf("@");
+	const hashIndex = repoPath.indexOf("#");
+	const refIndex = [atIndex, hashIndex].filter((index) => index >= 0).sort((a, b) => a - b)[0];
+	return refIndex === undefined ? repoPath : repoPath.slice(0, refIndex);
+}
+
+function parseGitPackagePath(source: string): { host: string; repoPath: string } | undefined {
+	const spec = source.slice(4).trim();
+	if (!spec) return undefined;
+
+	let host = "";
+	let repoPath = "";
+	const scpLike = spec.match(/^git@([^:]+):(.+)$/);
+	if (scpLike) {
+		host = scpLike[1] ?? "";
+		repoPath = scpLike[2] ?? "";
+	} else if (/^[a-z][a-z0-9+.-]*:\/\//i.test(spec)) {
+		try {
+			const url = new URL(spec);
+			host = url.hostname;
+			repoPath = url.pathname.replace(/^\/+/, "");
+		} catch {
+			return undefined;
+		}
+	} else {
+		const slashIndex = spec.indexOf("/");
+		if (slashIndex < 0) return undefined;
+		host = spec.slice(0, slashIndex);
+		repoPath = spec.slice(slashIndex + 1);
+	}
+
+	const normalizedPath = stripGitRef(repoPath).replace(/\.git$/, "").replace(/^\/+/, "");
+	if (!host || !isSafePackagePath(host) || !isSafePackagePath(normalizedPath) || normalizedPath.split(/[\\/]/).length < 2) {
+		return undefined;
+	}
+	return { host, repoPath: normalizedPath };
+}
+
+function resolveSettingsPackageRoot(source: string, baseDir: string): string | undefined {
+	const trimmed = source.trim();
+	if (!trimmed) return undefined;
+	if (trimmed.startsWith("git:")) {
+		const parsed = parseGitPackagePath(trimmed);
+		return parsed ? path.join(baseDir, "git", parsed.host, parsed.repoPath) : undefined;
+	}
+	if (trimmed.startsWith("npm:")) {
+		const packageName = parseNpmPackageName(trimmed);
+		return packageName ? path.join(baseDir, "npm", "node_modules", packageName) : undefined;
+	}
+	const normalized = trimmed.startsWith("file:") ? trimmed.slice(5) : trimmed;
+	if (normalized === "~") return os.homedir();
+	if (normalized.startsWith("~/")) return path.join(os.homedir(), normalized.slice(2));
+	if (path.isAbsolute(normalized)) return normalized;
+	if (normalized === "." || normalized === ".." || normalized.startsWith("./") || normalized.startsWith("../")) {
+		return path.resolve(baseDir, normalized);
+	}
+	return undefined;
+}
+
+function getGlobalNpmRoot(): string | null {
+	if (cachedGlobalNpmRoot !== null) return cachedGlobalNpmRoot;
+	try {
+		cachedGlobalNpmRoot = fs.realpathSync(execSync("npm root -g", { encoding: "utf-8", timeout: 5000 }).trim());
+		return cachedGlobalNpmRoot;
+	} catch {
+		cachedGlobalNpmRoot = "";
+		return null;
+	}
+}
+
+function stringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0);
+}
+
+function extractSubagentPathsFromPackageRoot(packageRoot: string): PackageSubagentPaths {
+	const packageJsonPath = path.join(packageRoot, "package.json");
+	const pkg = readJsonFileBestEffort(packageJsonPath);
+	if (!pkg || typeof pkg !== "object" || Array.isArray(pkg)) return { agents: [], chains: [] };
+
+	const roots: Record<string, unknown>[] = [];
+	const piSubagents = (pkg as { "pi-subagents"?: unknown })["pi-subagents"];
+	if (piSubagents && typeof piSubagents === "object" && !Array.isArray(piSubagents)) {
+		roots.push(piSubagents as Record<string, unknown>);
+	}
+
+	const pi = (pkg as { pi?: unknown }).pi;
+	if (pi && typeof pi === "object" && !Array.isArray(pi)) {
+		const subagents = (pi as { subagents?: unknown }).subagents;
+		if (subagents && typeof subagents === "object" && !Array.isArray(subagents)) {
+			roots.push(subagents as Record<string, unknown>);
+		}
+	}
+
+	const agents: string[] = [];
+	const chains: string[] = [];
+	for (const root of roots) {
+		for (const entry of stringArray(root.agents)) agents.push(path.resolve(packageRoot, entry));
+		for (const entry of stringArray(root.chains)) chains.push(path.resolve(packageRoot, entry));
+	}
+	return { agents, chains };
+}
+
+function collectPackageRootsFromNodeModules(nodeModulesDir: string): string[] {
+	const roots: string[] = [];
+	if (!fs.existsSync(nodeModulesDir)) return roots;
+
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(nodeModulesDir, { withFileTypes: true });
+	} catch {
+		return roots;
+	}
+
+	for (const entry of entries) {
+		if (entry.name.startsWith(".")) continue;
+		if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+
+		if (entry.name.startsWith("@")) {
+			const scopeDir = path.join(nodeModulesDir, entry.name);
+			let scopeEntries: fs.Dirent[];
+			try {
+				scopeEntries = fs.readdirSync(scopeDir, { withFileTypes: true });
+			} catch {
+				continue;
+			}
+			for (const scopeEntry of scopeEntries) {
+				if (scopeEntry.name.startsWith(".")) continue;
+				if (!scopeEntry.isDirectory() && !scopeEntry.isSymbolicLink()) continue;
+				roots.push(path.join(scopeDir, scopeEntry.name));
+			}
+			continue;
+		}
+
+		roots.push(path.join(nodeModulesDir, entry.name));
+	}
+	return roots;
+}
+
+function collectSettingsPackageRoots(settingsFile: string, baseDir: string): string[] {
+	const settings = readOptionalJsonFile(settingsFile);
+	if (!settings || typeof settings !== "object" || Array.isArray(settings)) return [];
+	const packages = (settings as { packages?: unknown }).packages;
+	if (!Array.isArray(packages)) return [];
+
+	const roots: string[] = [];
+	for (const entry of packages) {
+		const packageSource = typeof entry === "string"
+			? entry
+			: typeof entry === "object" && entry !== null && typeof (entry as { source?: unknown }).source === "string"
+				? (entry as { source: string }).source
+				: undefined;
+		if (!packageSource) continue;
+		const packageRoot = resolveSettingsPackageRoot(packageSource, baseDir);
+		if (packageRoot) roots.push(packageRoot);
+	}
+	return roots;
+}
+
+function collectPackageSubagentPaths(cwd: string, options: { includeUser: boolean; includeProject: boolean } = { includeUser: true, includeProject: true }): PackageSubagentPaths {
+	const agentDir = getAgentDir();
+	const packageRoots = [
+		cwd,
+	];
+
+	if (options.includeProject) {
+		packageRoots.push(
+			...collectPackageRootsFromNodeModules(path.join(cwd, ".pi", "npm", "node_modules")),
+			...collectSettingsPackageRoots(path.join(cwd, ".pi", "settings.json"), path.join(cwd, ".pi")),
+		);
+	}
+
+	if (options.includeUser) {
+		packageRoots.push(
+			...collectPackageRootsFromNodeModules(path.join(agentDir, "npm", "node_modules")),
+			...collectSettingsPackageRoots(path.join(agentDir, "settings.json"), agentDir),
+		);
+	}
+
+	const globalRoot = getGlobalNpmRoot();
+	if (globalRoot && options.includeUser) packageRoots.push(...collectPackageRootsFromNodeModules(globalRoot));
+
+	const seenRoots = new Set<string>();
+	const seenAgents = new Set<string>();
+	const seenChains = new Set<string>();
+	const agents: string[] = [];
+	const chains: string[] = [];
+	for (const packageRoot of packageRoots) {
+		const resolvedRoot = path.resolve(packageRoot);
+		if (seenRoots.has(resolvedRoot)) continue;
+		seenRoots.add(resolvedRoot);
+		const paths = extractSubagentPathsFromPackageRoot(resolvedRoot);
+		for (const agentDir of paths.agents) {
+			if (seenAgents.has(agentDir)) continue;
+			seenAgents.add(agentDir);
+			agents.push(agentDir);
+		}
+		for (const chainDir of paths.chains) {
+			if (seenChains.has(chainDir)) continue;
+			seenChains.add(chainDir);
+			chains.push(chainDir);
+		}
+	}
+	return { agents, chains };
 }
 
 function splitToolList(rawTools: string[] | undefined): { tools?: string[]; mcpDirectTools?: string[] } {
@@ -706,7 +957,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	return agents;
 }
 
-function loadChainsFromDir(dir: string, source: "user" | "project"): { chains: ChainConfig[]; diagnostics: ChainDiscoveryDiagnostic[] } {
+function loadChainsFromDir(dir: string, source: AgentSource): { chains: ChainConfig[]; diagnostics: ChainDiscoveryDiagnostic[] } {
 	const chains = new Map<string, ChainConfig>();
 	const diagnostics: ChainDiscoveryDiagnostic[] = [];
 
@@ -776,6 +1027,10 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const projectSettingsPath = getProjectAgentSettingsPath(cwd);
 	const userSettings = scope === "project" ? EMPTY_SUBAGENT_SETTINGS : readSubagentSettings(userSettingsPath);
 	const projectSettings = scope === "user" ? EMPTY_SUBAGENT_SETTINGS : readSubagentSettings(projectSettingsPath);
+	const packageSubagentPaths = collectPackageSubagentPaths(cwd, {
+		includeUser: scope !== "project",
+		includeProject: scope !== "user",
+	});
 
 	const builtinAgents = applyBuiltinOverrides(
 		loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin"),
@@ -790,7 +1045,8 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const userAgents = [...userAgentsOld, ...userAgentsNew];
 
 	const projectAgents = scope === "user" ? [] : projectAgentDirs.flatMap((dir) => loadAgentsFromDir(dir, "project"));
-	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents)
+	const packageAgents = packageSubagentPaths.agents.flatMap((dir) => loadAgentsFromDir(dir, "package"));
+	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents, packageAgents)
 		.filter((agent) => agent.disabled !== true);
 
 	return { agents, projectAgentsDir };
@@ -798,6 +1054,7 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 
 export function discoverAgentsAll(cwd: string): {
 	builtin: AgentConfig[];
+	package: AgentConfig[];
 	user: AgentConfig[];
 	project: AgentConfig[];
 	chains: ChainConfig[];
@@ -818,6 +1075,7 @@ export function discoverAgentsAll(cwd: string): {
 	const projectSettingsPath = getProjectAgentSettingsPath(cwd);
 	const userSettings = readSubagentSettings(userSettingsPath);
 	const projectSettings = readSubagentSettings(projectSettingsPath);
+	const packageSubagentPaths = collectPackageSubagentPaths(cwd);
 
 	const builtin = applyBuiltinOverrides(
 		loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin"),
@@ -830,6 +1088,13 @@ export function discoverAgentsAll(cwd: string): {
 		...loadAgentsFromDir(userDirOld, "user"),
 		...loadAgentsFromDir(userDirNew, "user"),
 	];
+	const packageMap = new Map<string, AgentConfig>();
+	for (const dir of packageSubagentPaths.agents) {
+		for (const agent of loadAgentsFromDir(dir, "package")) {
+			if (!packageMap.has(agent.name)) packageMap.set(agent.name, agent);
+		}
+	}
+	const packageAgents = Array.from(packageMap.values());
 	const projectMap = new Map<string, AgentConfig>();
 	for (const dir of projectDirs) {
 		for (const agent of loadAgentsFromDir(dir, "project")) {
@@ -839,6 +1104,15 @@ export function discoverAgentsAll(cwd: string): {
 	const project = Array.from(projectMap.values());
 
 	const chainMap = new Map<string, ChainConfig>();
+	const packageChainDiagnostics: ChainDiscoveryDiagnostic[] = [];
+	const packageChainMap = new Map<string, ChainConfig>();
+	for (const dir of packageSubagentPaths.chains) {
+		const loaded = loadChainsFromDir(dir, "package");
+		packageChainDiagnostics.push(...loaded.diagnostics);
+		for (const chain of loaded.chains) {
+			if (!packageChainMap.has(chain.name)) packageChainMap.set(chain.name, chain);
+		}
+	}
 	const projectChainDiagnostics: ChainDiscoveryDiagnostic[] = [];
 	for (const dir of projectChainDirs) {
 		const loaded = loadChainsFromDir(dir, "project");
@@ -849,15 +1123,17 @@ export function discoverAgentsAll(cwd: string): {
 	}
 	const userChains = loadChainsFromDir(userChainDir, "user");
 	const chains = [
+		...Array.from(packageChainMap.values()),
 		...userChains.chains,
 		...Array.from(chainMap.values()),
 	];
 	const chainDiagnostics = [
+		...packageChainDiagnostics,
 		...userChains.diagnostics,
 		...projectChainDiagnostics,
 	];
 
 	const userDir = process.env.PI_CODING_AGENT_DIR ? userDirOld : fs.existsSync(userDirNew) ? userDirNew : userDirOld;
 
-	return { builtin, user, project, chains, chainDiagnostics, userDir, projectDir, userChainDir, projectChainDir, userSettingsPath, projectSettingsPath };
+	return { builtin, package: packageAgents, user, project, chains, chainDiagnostics, userDir, projectDir, userChainDir, projectChainDir, userSettingsPath, projectSettingsPath };
 }

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -361,14 +361,15 @@ function collectSettingsPackageRoots(settingsFile: string, baseDir: string): str
 
 function collectPackageSubagentPaths(cwd: string, options: { includeUser: boolean; includeProject: boolean } = { includeUser: true, includeProject: true }): PackageSubagentPaths {
 	const agentDir = getAgentDir();
+	const projectRoot = findNearestProjectRoot(cwd) ?? cwd;
 	const packageRoots = [
-		cwd,
+		projectRoot,
 	];
 
 	if (options.includeProject) {
 		packageRoots.push(
-			...collectPackageRootsFromNodeModules(path.join(cwd, ".pi", "npm", "node_modules")),
-			...collectSettingsPackageRoots(path.join(cwd, ".pi", "settings.json"), path.join(cwd, ".pi")),
+			...collectPackageRootsFromNodeModules(path.join(projectRoot, ".pi", "npm", "node_modules")),
+			...collectSettingsPackageRoots(path.join(projectRoot, ".pi", "settings.json"), path.join(projectRoot, ".pi")),
 		);
 	}
 
@@ -379,8 +380,10 @@ function collectPackageSubagentPaths(cwd: string, options: { includeUser: boolea
 		);
 	}
 
-	const globalRoot = getGlobalNpmRoot();
-	if (globalRoot && options.includeUser) packageRoots.push(...collectPackageRootsFromNodeModules(globalRoot));
+	if (options.includeUser) {
+		const globalRoot = getGlobalNpmRoot();
+		if (globalRoot) packageRoots.push(...collectPackageRootsFromNodeModules(globalRoot));
+	}
 
 	const seenRoots = new Set<string>();
 	const seenAgents = new Set<string>();

--- a/src/agents/chain-serializer.ts
+++ b/src/agents/chain-serializer.ts
@@ -4,6 +4,7 @@ import { parseFrontmatter } from "./frontmatter.ts";
 import { ChainOutputValidationError, validateChainOutputBindings } from "../runs/shared/chain-outputs.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import type { ChainStep } from "../shared/settings.ts";
+import type { AgentSource } from "./agents.ts";
 
 function parseStepBody(agent: string, sectionBody: string): ChainStepConfig {
 	const lines = sectionBody.split("\n");
@@ -83,7 +84,7 @@ function parseStepBody(agent: string, sectionBody: string): ChainStepConfig {
 	return step;
 }
 
-export function parseChain(content: string, source: "user" | "project", filePath: string): ChainConfig {
+export function parseChain(content: string, source: AgentSource, filePath: string): ChainConfig {
 	const { frontmatter, body } = parseFrontmatter(content);
 	if (!frontmatter.name || !frontmatter.description) {
 		throw new Error("Chain frontmatter must include name and description");
@@ -124,7 +125,7 @@ export function parseChain(content: string, source: "user" | "project", filePath
 	};
 }
 
-export function parseJsonChain(content: string, source: "user" | "project", filePath: string): ChainConfig {
+export function parseJsonChain(content: string, source: AgentSource, filePath: string): ChainConfig {
 	let parsed: unknown;
 	try {
 		parsed = JSON.parse(content);

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -81,7 +81,7 @@ function formatExistingDirectory(label: string, dirPath: string): string {
 }
 
 function formatSourceCounts(counts: Record<AgentSource, number>): string {
-	return `builtin ${counts.builtin}, user ${counts.user}, project ${counts.project}`;
+	return `builtin ${counts.builtin}, package ${counts.package}, user ${counts.user}, project ${counts.project}`;
 }
 
 function formatSkillSourceCounts(skills: Array<{ source: SkillSource }>): string {
@@ -132,15 +132,16 @@ function formatDiscovery(input: DoctorReportInput, deps: DoctorDeps): string[] {
 			const discovered = deps.discoverAgentsAll(input.cwd);
 			const agentCounts = {
 				builtin: discovered.builtin.length,
+				package: discovered.package?.length ?? 0,
 				user: discovered.user.length,
 				project: discovered.project.length,
 			};
 			const chainCounts = discovered.chains.reduce<Record<AgentSource, number>>((counts, chain) => {
 				counts[chain.source] += 1;
 				return counts;
-			}, { builtin: 0, user: 0, project: 0 });
+			}, { builtin: 0, package: 0, user: 0, project: 0 });
 			return [
-				`- agents: total ${agentCounts.builtin + agentCounts.user + agentCounts.project} (${formatSourceCounts(agentCounts)})`,
+				`- agents: total ${agentCounts.builtin + agentCounts.package + agentCounts.user + agentCounts.project} (${formatSourceCounts(agentCounts)})`,
 				`- chains: total ${discovered.chains.length} (${formatSourceCounts(chainCounts)})`,
 			].join("\n");
 		}),

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -3,11 +3,39 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
+import { handleManagementAction } from "../../src/agents/agent-management.ts";
 import { serializeAgent } from "../../src/agents/agent-serializer.ts";
 import { parseChain, serializeChain } from "../../src/agents/chain-serializer.ts";
 import { discoverAgents, discoverAgentsAll, type AgentConfig } from "../../src/agents/agents.ts";
 
 const tempDirs: string[] = [];
+
+function writeJson(filePath: string, value: unknown): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function writeAgent(filePath: string, body: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, body, "utf-8");
+}
+
+function withTempHome<T>(fn: (home: string) => T): T {
+	const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-package-home-"));
+	tempDirs.push(home);
+	const oldHome = process.env.HOME;
+	const oldUserProfile = process.env.USERPROFILE;
+	process.env.HOME = home;
+	process.env.USERPROFILE = home;
+	try {
+		return fn(home);
+	} finally {
+		if (oldHome === undefined) delete process.env.HOME;
+		else process.env.HOME = oldHome;
+		if (oldUserProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = oldUserProfile;
+	}
+}
 
 afterEach(() => {
 	while (tempDirs.length > 0) {
@@ -105,6 +133,185 @@ Run the markdown chain
 		assert.equal(chain?.filePath.endsWith(".chain.json"), true);
 		assert.equal("expand" in (chain?.steps[1] ?? {}), true);
 	});
+});
+
+describe("package-provided agents and chains", () => {
+	it("discovers package agents and chains from installed package manifests", () => withTempHome(() => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-package-discovery-"));
+		tempDirs.push(dir);
+		const workflowRoot = path.join(dir, ".pi", "npm", "node_modules", "my-pi-workflow");
+		const chainsRoot = path.join(dir, ".pi", "npm", "node_modules", "@scope", "chain-workflow");
+		writeJson(path.join(workflowRoot, "package.json"), {
+			name: "my-pi-workflow",
+			"pi-subagents": {
+				agents: ["./agents"],
+			},
+		});
+		writeAgent(path.join(workflowRoot, "agents", "reviewer.md"), `---
+name: reviewer
+package: my-workflow
+description: Review changes for this workflow.
+---
+
+Review the workflow.
+`);
+		writeJson(path.join(chainsRoot, "package.json"), {
+			name: "@scope/chain-workflow",
+			pi: {
+				subagents: {
+					chains: ["./chains"],
+				},
+			},
+		});
+		writeAgent(path.join(chainsRoot, "chains", "review.chain.md"), `---
+name: review
+package: my-workflow
+description: Run workflow review.
+---
+
+## my-workflow.reviewer
+
+Review the task.
+`);
+
+		const all = discoverAgentsAll(dir);
+		const packagedAgent = all.package.find((agent) => agent.name === "my-workflow.reviewer");
+		assert.ok(packagedAgent);
+		assert.equal(packagedAgent.source, "package");
+		assert.equal(packagedAgent.filePath, path.join(workflowRoot, "agents", "reviewer.md"));
+		assert.equal(discoverAgents(dir, "both").agents.find((agent) => agent.name === "my-workflow.reviewer")?.source, "package");
+
+		const packagedChain = all.chains.find((chain) => chain.name === "my-workflow.review");
+		assert.ok(packagedChain);
+		assert.equal(packagedChain.source, "package");
+		assert.equal(packagedChain.steps[0]?.agent, "my-workflow.reviewer");
+	}));
+
+	it("loads packages referenced from Pi settings", () => withTempHome(() => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-settings-package-"));
+		tempDirs.push(dir);
+		const packageRoot = path.join(dir, ".pi", "vendor", "workflow");
+		writeJson(path.join(dir, ".pi", "settings.json"), {
+			packages: [{ source: "file:./vendor/workflow" }],
+		});
+		writeJson(path.join(packageRoot, "package.json"), {
+			name: "settings-workflow",
+			pi: {
+				subagents: {
+					agents: ["./agents"],
+				},
+			},
+		});
+		writeAgent(path.join(packageRoot, "agents", "planner.md"), `---
+name: planner
+package: settings-workflow
+description: Plan from a settings-installed package.
+---
+
+Plan the work.
+`);
+
+		const agent = discoverAgents(dir, "both").agents.find((candidate) => candidate.name === "settings-workflow.planner");
+		assert.ok(agent);
+		assert.equal(agent.source, "package");
+	}));
+
+	it("keeps package definitions below user and project overrides", () => withTempHome((home) => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-package-precedence-"));
+		tempDirs.push(dir);
+		const packageRoot = path.join(dir, ".pi", "npm", "node_modules", "override-workflow");
+		writeJson(path.join(packageRoot, "package.json"), {
+			name: "override-workflow",
+			"pi-subagents": {
+				agents: ["./agents"],
+				chains: ["./chains"],
+			},
+		});
+		writeAgent(path.join(packageRoot, "agents", "scout.md"), `---
+name: scout
+description: Package scout
+---
+
+Package scout.
+`);
+		writeAgent(path.join(packageRoot, "chains", "shared.chain.md"), `---
+name: shared
+description: Package chain
+---
+
+## scout
+
+Package chain.
+`);
+		writeAgent(path.join(home, ".pi", "agent", "agents", "scout.md"), `---
+name: scout
+description: User scout
+---
+
+User scout.
+`);
+		writeAgent(path.join(dir, ".pi", "agents", "scout.md"), `---
+name: scout
+description: Project scout
+---
+
+Project scout.
+`);
+		writeAgent(path.join(home, ".pi", "agent", "chains", "shared.chain.md"), `---
+name: shared
+description: User chain
+---
+
+## scout
+
+User chain.
+`);
+		writeAgent(path.join(dir, ".pi", "chains", "shared.chain.md"), `---
+name: shared
+description: Project chain
+---
+
+## scout
+
+Project chain.
+`);
+
+		assert.equal(discoverAgents(dir, "user").agents.find((agent) => agent.name === "scout")?.source, "user");
+		assert.equal(discoverAgents(dir, "project").agents.find((agent) => agent.name === "scout")?.source, "project");
+		const chainByName = new Map(discoverAgentsAll(dir).chains.map((chain) => [chain.name, chain]));
+		assert.equal(chainByName.get("shared")?.source, "project");
+	}));
+
+	it("does not allow management updates to package agents", () => withTempHome(() => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-package-readonly-"));
+		tempDirs.push(dir);
+		const packageRoot = path.join(dir, ".pi", "npm", "node_modules", "readonly-workflow");
+		writeJson(path.join(packageRoot, "package.json"), {
+			name: "readonly-workflow",
+			"pi-subagents": {
+				agents: ["./agents"],
+			},
+		});
+		writeAgent(path.join(packageRoot, "agents", "reviewer.md"), `---
+name: reviewer
+package: readonly-workflow
+description: Read-only package reviewer.
+---
+
+Review only.
+`);
+
+		const result = handleManagementAction("update", {
+			agent: "readonly-workflow.reviewer",
+			config: { description: "Changed" },
+		}, {
+			cwd: dir,
+			modelRegistry: { getAvailable: () => [] },
+		});
+
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /read-only/);
+	}));
 });
 
 describe("agent frontmatter completionGuard", () => {

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -216,6 +216,33 @@ Plan the work.
 		assert.equal(agent.source, "package");
 	}));
 
+	it("discovers project package agents when cwd is nested below the project root", () => withTempHome(() => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-nested-package-discovery-"));
+		tempDirs.push(dir);
+		const nested = path.join(dir, "packages", "app", "src");
+		const packageRoot = path.join(dir, ".pi", "npm", "node_modules", "nested-workflow");
+		fs.mkdirSync(nested, { recursive: true });
+		writeJson(path.join(packageRoot, "package.json"), {
+			name: "nested-workflow",
+			"pi-subagents": {
+				agents: ["./agents"],
+			},
+		});
+		writeAgent(path.join(packageRoot, "agents", "reviewer.md"), `---
+name: reviewer
+package: nested-workflow
+description: Review from a project package.
+---
+
+Review nested project work.
+`);
+
+		const agent = discoverAgents(nested, "both").agents.find((candidate) => candidate.name === "nested-workflow.reviewer");
+		assert.ok(agent);
+		assert.equal(agent.source, "package");
+		assert.equal(agent.filePath, path.join(packageRoot, "agents", "reviewer.md"));
+	}));
+
 	it("keeps package definitions below user and project overrides", () => withTempHome((home) => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-package-precedence-"));
 		tempDirs.push(dir);

--- a/test/unit/agent-selection.test.ts
+++ b/test/unit/agent-selection.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "node:test";
 import { mergeAgentsForScope } from "../../src/agents/agent-selection.ts";
 import type { AgentConfig } from "../../src/agents/agents.ts";
 
-function makeAgent(name: string, source: "builtin" | "user" | "project", systemPrompt: string): AgentConfig {
+function makeAgent(name: string, source: "builtin" | "package" | "user" | "project", systemPrompt: string): AgentConfig {
 	return {
 		name,
 		description: `${name} agent`,
@@ -65,6 +65,17 @@ describe("mergeAgentsForScope", () => {
 		assert.equal(result.length, 1);
 		assert.equal(result[0]?.source, "user");
 		assert.equal(result[0]?.systemPrompt, "custom prompt");
+	});
+
+	it("package agents override builtins but not user or project agents", () => {
+		const builtinAgents = [makeAgent("scout", "builtin", "builtin prompt")];
+		const packageAgents = [makeAgent("scout", "package", "package prompt")];
+		const userAgents = [makeAgent("scout", "user", "user prompt")];
+		const projectAgents = [makeAgent("scout", "project", "project prompt")];
+
+		assert.equal(mergeAgentsForScope("both", [], [], builtinAgents, packageAgents)[0]?.source, "package");
+		assert.equal(mergeAgentsForScope("user", userAgents, [], builtinAgents, packageAgents)[0]?.source, "user");
+		assert.equal(mergeAgentsForScope("project", [], projectAgents, builtinAgents, packageAgents)[0]?.source, "project");
 	});
 
 	it("project agents override builtins with the same name", () => {

--- a/test/unit/doctor.test.ts
+++ b/test/unit/doctor.test.ts
@@ -106,8 +106,8 @@ describe("buildDoctorReport", () => {
 			assert.match(report, /- configured session dir: .*subagent-sessions/);
 			assert.match(report, /- current session file: .*parent\.jsonl/);
 			assert.match(report, /- temp root: ok /);
-			assert.match(report, /- agents: total 4 \(builtin 1, user 1, project 2\)/);
-			assert.match(report, /- chains: total 2 \(builtin 0, user 1, project 1\)/);
+			assert.match(report, /- agents: total 4 \(builtin 1, package 0, user 1, project 2\)/);
+			assert.match(report, /- chains: total 2 \(builtin 0, package 0, user 1, project 1\)/);
 			assert.match(report, /- skills: total 2 \(project 1, user-package 1\)/);
 			assert.match(report, /- bridge: inactive \(pi-intercom extension was not found\)/);
 			assert.match(report, /- pi-intercom: unavailable /);


### PR DESCRIPTION
## Summary
- discover package-provided agents and chains from `pi-subagents` and `pi.subagents` package manifest entries
- load package definitions above builtins and below user/project overrides, while keeping package definitions read-only in management actions
- document the manifest shape and show package counts in doctor output

Fixes #278

## Tests
- `node --experimental-strip-types --test test/unit/agent-frontmatter.test.ts test/unit/agent-selection.test.ts test/unit/agent-overrides.test.ts test/unit/doctor.test.ts`
- `npm run test:unit`
- `npm run test:integration`