### PR TITLE
fix: avoid duplicate fanout child tool registration

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -33,8 +33,7 @@ import { registerSlashSubagentBridge } from "../slash/slash-bridge.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
 import registerSubagentNotify, { type SubagentNotifyDetails } from "../runs/background/notify.ts";
-import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../runs/shared/pi-args.ts";
-import registerFanoutChildSubagentExtension from "./fanout-child.ts";
+import { SUBAGENT_CHILD_ENV } from "../runs/shared/pi-args.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import { loadConfig } from "./config.ts";
 import {
@@ -209,7 +208,6 @@ class SubagentControlNoticeComponent implements Component {
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	if (process.env[SUBAGENT_CHILD_ENV] === "1") {
-		if (process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1") registerFanoutChildSubagentExtension(pi);
 		return;
 	}
 	const globalStore = globalThis as Record<string, unknown>;

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -144,19 +144,14 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
-	it("registers only the child-safe subagent tool for fanout children", () => {
+	it("returns before registering anything for fanout children", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./src/extension/index.ts";
 			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
 			process.env[SUBAGENT_CHILD_ENV] = "1";
 			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
 			const calls = [];
-			let registeredTool;
-			const fakePi = new Proxy({
-				events: { on() { calls.push("events.on"); return () => {}; }, emit() { calls.push("events.emit"); } },
-				registerTool(tool) { calls.push("registerTool"); registeredTool = tool; },
-				getSessionName() { return undefined; },
-			}, {
+			const fakePi = new Proxy({}, {
 				get(target, prop) {
 					if (prop in target) return target[prop];
 					return (..._args) => {
@@ -166,9 +161,54 @@ describe("subagent extension child mode", () => {
 				},
 			});
 			registerSubagentExtension(fakePi);
-			if (!registeredTool || registeredTool.name !== "subagent") throw new Error("child-safe subagent tool not registered");
-			const unexpected = calls.filter((call) => call !== "registerTool");
-			if (unexpected.length > 0) throw new Error("Unexpected parent-surface registrations: " + unexpected.join(", "));
+			if (calls.length > 0) {
+				throw new Error("Unexpected child-mode registrations: " + calls.join(", "));
+			}
+		`;
+
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-transform-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, stdio: "pipe" },
+		);
+	});
+
+	it("does not double-register the child-safe subagent tool when index and fanout-child both load", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./src/extension/index.ts";
+			import registerFanoutChildSubagentExtension from "./src/extension/fanout-child.ts";
+			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
+			process.env[SUBAGENT_CHILD_ENV] = "1";
+			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
+
+			const registeredNames = new Set();
+			const registrations = [];
+			function makePi(source) {
+				return {
+					events: { on() { return () => {}; }, emit() {} },
+					registerTool(tool) {
+						if (registeredNames.has(tool.name)) {
+							throw new Error("Tool " + tool.name + " conflicts with " + source);
+						}
+						registeredNames.add(tool.name);
+						registrations.push({ source, name: tool.name });
+					},
+					getSessionName() { return undefined; },
+				};
+			}
+
+			registerSubagentExtension(makePi("index.ts"));
+			registerFanoutChildSubagentExtension(makePi("fanout-child.ts"));
+			if (registrations.length !== 1 || registrations[0].name !== "subagent" || registrations[0].source !== "fanout-child.ts") {
+				throw new Error("expected only fanout-child.ts to register subagent, got " + JSON.stringify(registrations));
+			}
 		`;
 
 		execFileSync(


### PR DESCRIPTION
## Summary
- keep the package-loaded index extension inert in child processes
- leave the child-safe subagent tool registration to the explicit fanout-child extension
- add a portable regression for the index + fanout-child double-load conflict path

Fixes #279
Refs #208, #205

## Tests
- `node --experimental-strip-types --test test/unit/index-child-registration.test.ts`
- `node --experimental-strip-types --test test/unit/nested-control.test.ts`
- `npm run test:unit`
- `node --experimental-strip-types --check src/extension/index.ts`