### PR TITLE
Validate long worker/reviewer chains

### DIFF
--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -101,7 +101,7 @@ interface ChainExecutionResult {
 		chainAgents?: string[];
 		totalSteps?: number;
 		workflowGraph?: {
-			nodes: Array<{ kind?: string; outputName?: string; status?: string; error?: string; acceptanceStatus?: string; children?: Array<{ itemKey?: string; label?: string; status?: string; acceptanceStatus?: string }> }>;
+			nodes: Array<{ kind?: string; agent?: string; flatIndex?: number; outputName?: string; status?: string; error?: string; acceptanceStatus?: string; children?: Array<{ itemKey?: string; label?: string; status?: string; acceptanceStatus?: string }> }>;
 		};
 		currentStepIndex?: number;
 		outputs?: Record<string, { text: string; structured?: unknown }>;
@@ -892,6 +892,39 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 		assert.ok(!result.isError);
 		assert.equal(result.details.results.length, 3);
 		assert.ok(result.details.results.every((r) => r.exitCode === 0));
+	});
+
+	it("runs a 40-step alternating worker and reviewer chain", async () => {
+		const chainLength = 40;
+		for (let i = 0; i < chainLength; i++) {
+			mockPi.onCall({ output: `step-${i}-output` });
+		}
+		const chain = Array.from({ length: chainLength }, (_, i): TestSequentialStep => ({
+			agent: i % 2 === 0 ? "worker" : "reviewer",
+			...(i === 0 ? { task: "Start long worker/reviewer chain" } : {}),
+		}));
+		const agents = [makeAgent("worker"), makeAgent("reviewer")];
+
+		const result = await executeChain(makeChainParams(chain, agents));
+
+		assert.ok(!result.isError, `long chain should succeed: ${JSON.stringify(result.content)}`);
+		assert.equal(mockPi.callCount(), chainLength);
+		assert.equal(result.details.results.length, chainLength);
+		assert.equal(result.details.totalSteps, chainLength);
+		assert.equal(result.details.chainAgents?.length, chainLength);
+		assert.equal(result.details.workflowGraph?.nodes.length, chainLength);
+		assert.equal(result.details.workflowGraph?.nodes.at(-1)?.agent, "reviewer");
+		assert.equal(result.details.workflowGraph?.nodes.at(-1)?.flatIndex, chainLength - 1);
+		assert.ok(result.details.results.every((r) => r.exitCode === 0));
+		assert.deepEqual(
+			result.details.results.map((r) => r.agent),
+			chain.map((step) => step.agent),
+		);
+
+		const finalTaskArg = readCallArgs(chainLength - 1).at(-1) ?? "";
+		assert.match(finalTaskArg, /step-38-output/);
+		assert.doesNotMatch(finalTaskArg, /step-37-output/);
+		assert.match(result.content[0]?.text ?? "", /40 steps/);
 	});
 
 	it("returns error for unknown agent in chain", async () => {

--- a/test/integration/slash-live-state.test.ts
+++ b/test/integration/slash-live-state.test.ts
@@ -63,6 +63,26 @@ describe("slash live state", { skip: !available ? "slash-live-state.ts not impor
 		assert.equal(snapshot.version > 0, true);
 	});
 
+	it("creates stable placeholders for a 40-step worker/reviewer chain", () => {
+		clearSlashSnapshots!();
+		const chain = Array.from({ length: 40 }, (_, index) => ({
+			agent: index % 2 === 0 ? "worker" : "reviewer",
+			...(index === 0 ? { task: "Start long chain" } : {}),
+		}));
+
+		const details = buildSlashInitialResult!("req-long-chain", { chain });
+
+		assert.equal(details.result.details.mode, "chain");
+		assert.equal(details.result.details.results.length, 40);
+		assert.equal(details.result.details.progress?.length, 40);
+		assert.equal(details.result.details.chainAgents?.length, 40);
+		assert.equal(details.result.details.totalSteps, 40);
+		assert.equal(details.result.details.currentStepIndex, 0);
+		assert.equal(details.result.details.results[0]?.progress?.status, "running");
+		assert.equal(details.result.details.results[39]?.agent, "reviewer");
+		assert.equal(details.result.details.results[39]?.progress?.index, 39);
+	});
+
 	it("prefers finalized snapshots and restores them from persisted custom messages", () => {
 		clearSlashSnapshots!();
 		const details = buildSlashInitialResult!("req-2", {

--- a/test/unit/workflow-graph.test.ts
+++ b/test/unit/workflow-graph.test.ts
@@ -25,6 +25,32 @@ describe("workflow graph snapshots", () => {
 		]);
 	});
 
+	it("maps a long alternating worker and reviewer chain without losing indexes", () => {
+		const steps = Array.from({ length: 40 }, (_, index) => ({
+			agent: index % 2 === 0 ? "worker" : "reviewer",
+			task: index === 0 ? "Start" : "{previous}",
+		}));
+		const results = steps.map(() => ({ exitCode: 0 }));
+		const graph = buildWorkflowGraphSnapshot({
+			runId: "run-long",
+			steps,
+			results,
+			currentFlatIndex: 37,
+			currentStepIndex: 37,
+		});
+
+		assert.equal(graph.nodes.length, 40);
+		assert.equal(graph.nodes[0]?.id, "step-0");
+		assert.equal(graph.nodes[0]?.flatIndex, 0);
+		assert.equal(graph.nodes[37]?.id, "step-37");
+		assert.equal(graph.nodes[37]?.agent, "reviewer");
+		assert.equal(graph.nodes[37]?.flatIndex, 37);
+		assert.equal(graph.nodes[39]?.id, "step-39");
+		assert.equal(graph.nodes[39]?.agent, "reviewer");
+		assert.equal(graph.nodes[39]?.flatIndex, 39);
+		assert.equal(graph.currentNodeId, "step-37");
+	});
+
 	it("maps parallel chain steps with stable group and child indexes", () => {
 		const graph = buildWorkflowGraphSnapshot({
 			runId: "run-2",


### PR DESCRIPTION
Adds regression coverage for long sequential chains, specifically a 40-step worker/reviewer flow that mirrors worker -> reviewer repeated 20 times. The tests cover foreground execution, workflow graph indexing, and slash live-state placeholders so long chains keep stable state across execution and UI surfaces.