### PR TITLE
Cover parallel funnel fanout chains

### DIFF
--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -163,6 +163,18 @@ function readMockPiArgs(mockPi: MockPi, index: number): string[] {
 	return payload.args;
 }
 
+function readMockPiArgsMatching(mockPi: MockPi, text: string): string[] {
+	const callFiles = fs.readdirSync(mockPi.dir)
+		.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
+		.sort();
+	for (const callFile of callFiles) {
+		const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as { args?: string[] };
+		assert.ok(Array.isArray(payload.args), "expected recorded args");
+		if (payload.args.join("\n").includes(text)) return payload.args;
+	}
+	assert.fail(`expected recorded call containing ${text}`);
+}
+
 describe("async execution utilities", { skip: !available ? "pi packages not available" : undefined }, () => {
 	let tempDir: string;
 	let mockPi: MockPi;
@@ -483,6 +495,70 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.workflowGraph?.nodes?.[0]?.outputName, "data");
 		assert.equal(payload.workflowGraph?.nodes?.[0]?.status, "completed");
 		assert.equal(payload.workflowGraph?.nodes?.[1]?.status, "completed");
+	});
+
+	it("async chains can start parallel, funnel into one step, then fan back out", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ matchArgIncludes: "Scout API", output: "Scout A async findings" });
+		mockPi.onCall({ matchArgIncludes: "Scout UI", output: "Scout B async findings" });
+		mockPi.onCall({ matchArgIncludes: "Synthesize:", output: "Async funnel synthesis" });
+		mockPi.onCall({ matchArgIncludes: "Review funnel A:", output: "Async reviewer A done" });
+		mockPi.onCall({ matchArgIncludes: "Review funnel B:", output: "Async reviewer B done" });
+		const id = `async-parallel-funnel-fanout-${Date.now().toString(36)}`;
+		const result = executeAsyncChain(id, {
+			chain: [
+				{
+					parallel: [
+						{ agent: "scout-a", task: "Scout API" },
+						{ agent: "scout-b", task: "Scout UI" },
+					],
+					concurrency: 2,
+				},
+				{ agent: "synthesizer", task: "Synthesize:\n{previous}" },
+				{
+					parallel: [
+						{ agent: "review-a", task: "Review funnel A:\n{previous}" },
+						{ agent: "review-b", task: "Review funnel B:\n{previous}" },
+					],
+					concurrency: 2,
+				},
+			],
+			agents: [makeAgent("scout-a"), makeAgent("scout-b"), makeAgent("synthesizer"), makeAgent("review-a"), makeAgent("review-b")],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-parallel-funnel-fanout" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		assert.ok(!result.isError, `should launch: ${JSON.stringify(result.content)}`);
+		const resultPath = await waitForAsyncResultFile(id, 10_000);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
+		assert.equal(payload.success, true);
+		assert.deepEqual(payload.results.map((entry) => entry.output), [
+			"Scout A async findings",
+			"Scout B async findings",
+			"Async funnel synthesis",
+			"Async reviewer A done",
+			"Async reviewer B done",
+		]);
+		assert.deepEqual(status.steps?.map((step) => step.status), ["complete", "complete", "complete", "complete", "complete"]);
+		assert.deepEqual(status.parallelGroups, [
+			{ start: 0, count: 2, stepIndex: 0 },
+			{ start: 3, count: 2, stepIndex: 2 },
+		]);
+		const funnelTask = readMockPiArgsMatching(mockPi, "Synthesize:").at(-1) ?? "";
+		assert.match(funnelTask, /=== Parallel Task 1 \(scout-a\) ===/);
+		assert.match(funnelTask, /Scout A async findings/);
+		assert.match(funnelTask, /=== Parallel Task 2 \(scout-b\) ===/);
+		assert.match(funnelTask, /Scout B async findings/);
+		assert.match(readMockPiArgsMatching(mockPi, "Review funnel A:").at(-1) ?? "", /Review funnel A:\nAsync funnel synthesis/);
+		assert.match(readMockPiArgsMatching(mockPi, "Review funnel B:").at(-1) ?? "", /Review funnel B:\nAsync funnel synthesis/);
+		assert.equal(payload.workflowGraph?.nodes?.[0]?.kind, "parallel-group");
+		assert.equal(payload.workflowGraph?.nodes?.[0]?.status, "completed");
+		assert.equal(payload.workflowGraph?.nodes?.[1]?.kind, "step");
+		assert.equal(payload.workflowGraph?.nodes?.[1]?.status, "completed");
+		assert.equal(payload.workflowGraph?.nodes?.[2]?.kind, "parallel-group");
+		assert.equal(payload.workflowGraph?.nodes?.[2]?.status, "completed");
 	});
 
 	it("async dynamic status shows a placeholder before materialization", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -64,6 +64,18 @@ function pidGone(): never {
 	throw error;
 }
 
+async function waitForCondition(
+	condition: () => boolean,
+	description: string,
+	timeoutMs = 1000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!condition()) {
+		if (Date.now() > deadline) assert.fail(`Timed out waiting for ${description}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
 function createUiContext() {
 	const widgets: unknown[] = [];
 	let renderRequests = 0;
@@ -314,7 +326,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			tracker.resetJobs(ui.ctx as never);
 			tracker.handleStarted({ id: "run-stale", asyncDir: runDir, agent: "worker" });
 
-			await new Promise((resolve) => setTimeout(resolve, 80));
+			await waitForCondition(() => state.asyncJobs.size === 0, "stale async job cleanup");
 
 			assert.equal(state.asyncJobs.size, 0);
 			assert.equal(JSON.parse(fs.readFileSync(path.join(runDir, "status.json"), "utf-8")).state, "failed");

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -1041,6 +1041,17 @@ describe("chain execution — parallel steps", { skip: !available ? "pi packages
 		return JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
 	}
 
+	function readCallArgsMatching(text: string): string[] {
+		const callFiles = fs.readdirSync(mockPi.dir)
+			.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
+			.sort();
+		for (const callFile of callFiles) {
+			const args = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
+			if (args.join("\n").includes(text)) return args;
+		}
+		assert.fail(`expected recorded call containing ${text}`);
+	}
+
 	it("runs parallel tasks within a chain step", async () => {
 		mockPi.onCall({ output: "Parallel task done" });
 		const agents = [makeAgent("reviewer-a"), makeAgent("reviewer-b")];
@@ -1120,6 +1131,52 @@ describe("chain execution — parallel steps", { skip: !available ? "pi packages
 		const finalTask = readCallArgs(2).at(-1) ?? "";
 		assert.match(finalTask, /Alpha named output/);
 		assert.match(finalTask, /Beta named output/);
+	});
+
+	it("funnels an initial parallel step through one agent, then fans the funnel output back out", async () => {
+		mockPi.onCall({ matchArgIncludes: "Scout API", output: "Scout A findings" });
+		mockPi.onCall({ matchArgIncludes: "Scout UI", output: "Scout B findings" });
+		mockPi.onCall({ matchArgIncludes: "Synthesize:", output: "Funnel synthesis" });
+		mockPi.onCall({ matchArgIncludes: "Review funnel A:", output: "Reviewer A done" });
+		mockPi.onCall({ matchArgIncludes: "Review funnel B:", output: "Reviewer B done" });
+		const agents = [makeAgent("scout-a"), makeAgent("scout-b"), makeAgent("synthesizer"), makeAgent("review-a"), makeAgent("review-b")];
+
+		const result = await executeChain(
+			makeChainParams(
+				[
+					{
+						parallel: [
+							{ agent: "scout-a", task: "Scout API" },
+							{ agent: "scout-b", task: "Scout UI" },
+						],
+					},
+					{ agent: "synthesizer", task: "Synthesize:\n{previous}" },
+					{
+						parallel: [
+							{ agent: "review-a", task: "Review funnel A:\n{previous}" },
+							{ agent: "review-b", task: "Review funnel B:\n{previous}" },
+						],
+					},
+				],
+				agents,
+			),
+		);
+
+		assert.ok(!result.isError, `should succeed: ${JSON.stringify(result.content)}`);
+		assert.deepEqual(result.details.results.map((entry) => entry.agent), ["scout-a", "scout-b", "synthesizer", "review-a", "review-b"]);
+		assert.equal(result.details.totalSteps, 3);
+		const funnelTask = readCallArgsMatching("Synthesize:").at(-1) ?? "";
+		assert.match(funnelTask, /=== Parallel Task 1 \(scout-a\) ===/);
+		assert.match(funnelTask, /Scout A findings/);
+		assert.match(funnelTask, /=== Parallel Task 2 \(scout-b\) ===/);
+		assert.match(funnelTask, /Scout B findings/);
+		const fanoutTaskA = readCallArgsMatching("Review funnel A:").at(-1) ?? "";
+		const fanoutTaskB = readCallArgsMatching("Review funnel B:").at(-1) ?? "";
+		assert.match(fanoutTaskA, /Review funnel A:\nFunnel synthesis/);
+		assert.match(fanoutTaskB, /Review funnel B:\nFunnel synthesis/);
+		assert.equal(result.details.workflowGraph?.nodes[0]?.kind, "parallel-group");
+		assert.equal(result.details.workflowGraph?.nodes[1]?.kind, "step");
+		assert.equal(result.details.workflowGraph?.nodes[2]?.kind, "parallel-group");
 	});
 
 	it("aggregates file-only parallel outputs as file references for the next step", async () => {


### PR DESCRIPTION
Adds coverage for chain flows that begin with a parallel group, merge those child results into one synthesizer step, and then fan the synthesizer output back out to another parallel group.

The tests lock down both foreground and async behavior: parallel outputs are aggregated into `{previous}` for the funnel step, the funnel output is passed to every downstream parallel child, and async status/graph metadata keeps the expected flat ordering and parallel group spans.