### PR TITLE
Add proactive skill subagent suggestions

### DIFF
--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -20,6 +20,7 @@ Use this skill when the parent orchestrator needs to launch a specialized subage
 - **Implementation handoff**: have `oracle` advise, then `worker` implement only after an approved direction
 - **Recon and planning**: use `scout` or `context-builder`, then `planner`
 - **Parallel exploration**: run multiple non-conflicting tasks concurrently
+- **Regular skill specialists**: when discovery shows proactive skill subagent suggestions and the current work is broad enough, launch a small fresh-context fanout that asks one subagent per relevant regularly used skill to apply that skill's perspective to the task
 - **Long-running work**: launch async/background runs and inspect them later
 - **Subagent control**: watch needs-attention signals and soft-interrupt only when a delegated run is genuinely blocked
 - **Agent authoring**: create, update, or override agents and chains for a project
@@ -54,6 +55,30 @@ The prompt templates in `prompts/` encode workflows the parent agent can run on 
 ### Parallel review technique
 
 Use this when the user wants adversarial review of a diff, plan, issue, file, or implemented work. Launch fresh-context `reviewer` agents with distinct angles generated from the actual target. Common angles are correctness/regressions, tests/validation, and simplicity/maintainability; adapt for TypeScript, UI, security, docs, or large structural changes. Reviewers should inspect files and diffs directly, return concise evidence-backed findings with file/line references, and avoid edits unless the user explicitly asks for a writer pass. The parent synthesizes fixes worth doing now, optional improvements, and feedback to ignore/defer before applying anything.
+
+### Proactive skill-specialist technique
+
+Use this when `{ action: "list" }` reports proactive skill subagent suggestions and the user's task would benefit from perspectives the parent regularly uses. These suggestions are conservative: a skill is recommended only when it is available and referenced repeatedly by configured agents or saved chains. Treat the list as an opt-in hint for the current task, not a command to always fan out.
+
+Default guardrails:
+- Keep the fanout small: usually one or two skill-specialist children, never more than the listed recommendations or configured cap.
+- Prefer `context: "fresh"` and include only the files, diff, plan, URL, or request details each child needs. Use forked context only when private/session history is essential and appropriate to share.
+- Use read-only agents for analysis/review unless implementation was explicitly requested; do not create several writers in the same worktree.
+- Skip proactive skill subagents for tiny questions, direct commands, highly private requests, or when the user asks not to delegate.
+- Make cost and concurrency visible by using an ordinary `subagent(...)` call rather than hidden/background automation.
+
+Example shape:
+
+```typescript
+subagent({
+  tasks: [
+    { agent: "reviewer", task: "Apply the available 'deslop' skill to review the current diff for concrete cleanup findings only. Do not modify files.", skill: "deslop" },
+    { agent: "reviewer", task: "Apply the available 'accessibility' skill to review the UI changes for concrete issues only. Do not modify files.", skill: "accessibility" }
+  ],
+  context: "fresh",
+  concurrency: 2
+})
+```
 
 ### Review-loop technique
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -20,8 +20,7 @@ import { serializeAgent } from "./agent-serializer.ts";
 import { serializeChain, serializeJsonChain } from "./chain-serializer.ts";
 import { discoverAvailableSkills } from "./skills.ts";
 import {
-	formatProactiveSkillSubagentRecommendations,
-	recommendProactiveSkillSubagents,
+	buildProactiveSkillSubagentRecommendationLines,
 } from "./proactive-skills.ts";
 import type { Details, ExtensionConfig } from "../shared/types.ts";
 
@@ -39,14 +38,6 @@ interface ManagementParams {
 
 function result(text: string, isError = false): AgentToolResult<Details> {
 	return { content: [{ type: "text", text }], isError, details: { mode: "management", results: [] } };
-}
-
-function discoverAvailableSkillsBestEffort(cwd: string): Array<{ name: string; description?: string }> {
-	try {
-		return discoverAvailableSkills(cwd);
-	} catch {
-		return [];
-	}
 }
 
 function parseCsv(value: string): string[] {
@@ -462,12 +453,12 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 	const agents = scopedAgents.filter((a) => !a.disabled);
 	const chains = d.chains.filter((c) => scope === "both" || c.source === "package" || c.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const diagnostics = d.chainDiagnostics.filter((entry) => scope === "both" || entry.source === scope);
-	const proactiveSuggestions = formatProactiveSkillSubagentRecommendations(recommendProactiveSkillSubagents({
+	const proactiveSuggestions = buildProactiveSkillSubagentRecommendationLines({
 		agents,
 		chains,
-		availableSkills: discoverAvailableSkillsBestEffort(ctx.cwd),
 		config: ctx.config?.proactiveSkillSubagents,
-	}));
+		discoverAvailableSkills: () => discoverAvailableSkills(ctx.cwd),
+	});
 	const lines = [
 		"Executable agents:",
 		...(agents.length

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -19,11 +19,15 @@ import {
 import { serializeAgent } from "./agent-serializer.ts";
 import { serializeChain, serializeJsonChain } from "./chain-serializer.ts";
 import { discoverAvailableSkills } from "./skills.ts";
-import type { Details } from "../shared/types.ts";
+import {
+	formatProactiveSkillSubagentRecommendations,
+	recommendProactiveSkillSubagents,
+} from "./proactive-skills.ts";
+import type { Details, ExtensionConfig } from "../shared/types.ts";
 
 type ManagementAction = "list" | "get" | "create" | "update" | "delete";
 type ManagementScope = "user" | "project";
-type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry">;
+type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry"> & { config?: ExtensionConfig };
 
 interface ManagementParams {
 	action?: string;
@@ -35,6 +39,14 @@ interface ManagementParams {
 
 function result(text: string, isError = false): AgentToolResult<Details> {
 	return { content: [{ type: "text", text }], isError, details: { mode: "management", results: [] } };
+}
+
+function discoverAvailableSkillsBestEffort(cwd: string): Array<{ name: string; description?: string }> {
+	try {
+		return discoverAvailableSkills(cwd);
+	} catch {
+		return [];
+	}
 }
 
 function parseCsv(value: string): string[] {
@@ -450,6 +462,12 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 	const agents = scopedAgents.filter((a) => !a.disabled);
 	const chains = d.chains.filter((c) => scope === "both" || c.source === "package" || c.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const diagnostics = d.chainDiagnostics.filter((entry) => scope === "both" || entry.source === scope);
+	const proactiveSuggestions = formatProactiveSkillSubagentRecommendations(recommendProactiveSkillSubagents({
+		agents,
+		chains,
+		availableSkills: discoverAvailableSkillsBestEffort(ctx.cwd),
+		config: ctx.config?.proactiveSkillSubagents,
+	}));
 	const lines = [
 		"Executable agents:",
 		...(agents.length
@@ -458,6 +476,7 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 		"",
 		"Chains:",
 		...(chains.length ? chains.map((c) => `- ${c.name} (${c.source}): ${c.description}`) : ["- (none)"]),
+		...(proactiveSuggestions.length ? ["", ...proactiveSuggestions] : []),
 		...(diagnostics.length ? ["", "Chain diagnostics:", ...diagnostics.map((entry) => `- ${entry.filePath}: ${entry.error}`)] : []),
 	];
 	return result(lines.join("\n"));

--- a/src/agents/proactive-skills.ts
+++ b/src/agents/proactive-skills.ts
@@ -24,7 +24,7 @@ export interface ProactiveSkillSubagentRecommendation {
 	reason: string;
 }
 
-interface AvailableSkill {
+export interface AvailableSkill {
 	name: string;
 	description?: string;
 }
@@ -167,4 +167,25 @@ export function formatProactiveSkillSubagentRecommendations(
 		}),
 		"Guardrails: use these for broad tasks where a skill-specialist pass is useful; keep fanout small, use fresh context unless private/session context is explicitly needed, and skip when the user asks for a direct answer.",
 	];
+}
+
+export function buildProactiveSkillSubagentRecommendationLines(input: {
+	agents: AgentConfig[];
+	chains?: ChainConfig[];
+	config?: ProactiveSkillSubagentsConfig | false;
+	discoverAvailableSkills: () => AvailableSkill[];
+}): string[] {
+	if (!resolveProactiveSkillSubagentsConfig(input.config).enabled) return [];
+	let availableSkills: AvailableSkill[];
+	try {
+		availableSkills = input.discoverAvailableSkills();
+	} catch {
+		availableSkills = [];
+	}
+	return formatProactiveSkillSubagentRecommendations(recommendProactiveSkillSubagents({
+		agents: input.agents,
+		chains: input.chains,
+		availableSkills,
+		config: input.config,
+	}));
 }

--- a/src/agents/proactive-skills.ts
+++ b/src/agents/proactive-skills.ts
@@ -1,0 +1,170 @@
+import type { AgentConfig, ChainConfig, ChainStepConfig } from "./agents.ts";
+import type { ProactiveSkillSubagentsConfig } from "../shared/types.ts";
+
+const SUBAGENT_ORCHESTRATION_SKILL = "pi-subagents";
+const DEFAULT_MIN_REFERENCES = 2;
+const DEFAULT_MAX_RECOMMENDATIONS = 3;
+const DEFAULT_PREFERRED_AGENT = "reviewer";
+const FALLBACK_AGENT_ORDER = ["reviewer", "context-builder", "delegate"];
+const MAX_RECOMMENDATION_CAP = 5;
+
+export interface ResolvedProactiveSkillSubagentsConfig {
+	enabled: boolean;
+	minReferences: number;
+	maxRecommendations: number;
+	preferredAgent: string;
+}
+
+export interface ProactiveSkillSubagentRecommendation {
+	skill: string;
+	agent: string;
+	references: number;
+	sources: string[];
+	description?: string;
+	reason: string;
+}
+
+interface AvailableSkill {
+	name: string;
+	description?: string;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+	if (typeof value !== "number") return undefined;
+	if (!Number.isInteger(value) || !Number.isFinite(value) || value < 1) return undefined;
+	return value;
+}
+
+export function resolveProactiveSkillSubagentsConfig(
+	config?: ProactiveSkillSubagentsConfig | false,
+): ResolvedProactiveSkillSubagentsConfig {
+	if (config === false) {
+		return {
+			enabled: false,
+			minReferences: DEFAULT_MIN_REFERENCES,
+			maxRecommendations: DEFAULT_MAX_RECOMMENDATIONS,
+			preferredAgent: DEFAULT_PREFERRED_AGENT,
+		};
+	}
+
+	const maxRecommendations = positiveInteger(config?.maxRecommendations) ?? DEFAULT_MAX_RECOMMENDATIONS;
+	return {
+		enabled: config?.enabled ?? true,
+		minReferences: positiveInteger(config?.minReferences) ?? DEFAULT_MIN_REFERENCES,
+		maxRecommendations: Math.min(maxRecommendations, MAX_RECOMMENDATION_CAP),
+		preferredAgent: typeof config?.preferredAgent === "string" && config.preferredAgent.trim()
+			? config.preferredAgent.trim()
+			: DEFAULT_PREFERRED_AGENT,
+	};
+}
+
+function normalizeSkillNames(value: unknown): string[] {
+	if (value === false || value === true || value === undefined || value === null) return [];
+	if (Array.isArray(value)) {
+		return [...new Set(value.filter((entry): entry is string => typeof entry === "string").map((entry) => entry.trim()).filter(Boolean))];
+	}
+	if (typeof value === "string") {
+		return [...new Set(value.split(",").map((entry) => entry.trim()).filter(Boolean))];
+	}
+	return [];
+}
+
+function collectStepSkills(step: ChainStepConfig, out: Set<string>): void {
+	for (const skill of normalizeSkillNames(step.skills ?? (step as { skill?: unknown }).skill)) {
+		out.add(skill);
+	}
+
+	const parallel = step.parallel;
+	if (!parallel) return;
+	if (Array.isArray(parallel)) {
+		for (const child of parallel) {
+			if (child && typeof child === "object" && !Array.isArray(child)) {
+				collectStepSkills(child as ChainStepConfig, out);
+			}
+		}
+		return;
+	}
+	if (typeof parallel === "object") {
+		collectStepSkills(parallel as ChainStepConfig, out);
+	}
+}
+
+function chooseRecommendationAgent(agents: AgentConfig[], preferredAgent: string): string | undefined {
+	const enabled = agents.filter((agent) => !agent.disabled);
+	if (enabled.some((agent) => agent.name === preferredAgent)) return preferredAgent;
+	for (const name of FALLBACK_AGENT_ORDER) {
+		if (enabled.some((agent) => agent.name === name)) return name;
+	}
+	return enabled[0]?.name;
+}
+
+function addSource(counts: Map<string, Set<string>>, skill: string, source: string): void {
+	if (skill === SUBAGENT_ORCHESTRATION_SKILL) return;
+	const sources = counts.get(skill) ?? new Set<string>();
+	sources.add(source);
+	counts.set(skill, sources);
+}
+
+export function recommendProactiveSkillSubagents(input: {
+	agents: AgentConfig[];
+	chains?: ChainConfig[];
+	availableSkills?: AvailableSkill[];
+	config?: ProactiveSkillSubagentsConfig | false;
+}): ProactiveSkillSubagentRecommendation[] {
+	const config = resolveProactiveSkillSubagentsConfig(input.config);
+	if (!config.enabled) return [];
+
+	const agent = chooseRecommendationAgent(input.agents, config.preferredAgent);
+	if (!agent) return [];
+
+	const availableByName = input.availableSkills
+		? new Map(input.availableSkills.map((skill) => [skill.name, skill]))
+		: undefined;
+	const counts = new Map<string, Set<string>>();
+
+	for (const candidate of input.agents) {
+		if (candidate.disabled) continue;
+		for (const skill of candidate.skills ?? []) {
+			addSource(counts, skill, `agent:${candidate.name}`);
+		}
+	}
+
+	for (const chain of input.chains ?? []) {
+		const chainSkills = new Set<string>();
+		for (const step of chain.steps) {
+			collectStepSkills(step, chainSkills);
+		}
+		for (const skill of chainSkills) {
+			addSource(counts, skill, `chain:${chain.name}`);
+		}
+	}
+
+	return [...counts.entries()]
+		.filter(([skill, sources]) => sources.size >= config.minReferences && (!availableByName || availableByName.has(skill)))
+		.map(([skill, sources]) => ({
+			skill,
+			agent,
+			references: sources.size,
+			sources: [...sources].sort((a, b) => a.localeCompare(b)),
+			description: availableByName?.get(skill)?.description,
+			reason: `referenced by ${sources.size} configured agents/chains`,
+		}))
+		.sort((a, b) => b.references - a.references || a.skill.localeCompare(b.skill))
+		.slice(0, config.maxRecommendations);
+}
+
+export function formatProactiveSkillSubagentRecommendations(
+	recommendations: ProactiveSkillSubagentRecommendation[],
+): string[] {
+	if (recommendations.length === 0) return [];
+	return [
+		"Proactive skill subagent suggestions:",
+		...recommendations.map((recommendation) => {
+			const sampleSources = recommendation.sources.slice(0, 3).join(", ");
+			const extra = recommendation.sources.length > 3 ? `, +${recommendation.sources.length - 3} more` : "";
+			const description = recommendation.description ? ` - ${recommendation.description}` : "";
+			return `- ${recommendation.skill} via ${recommendation.agent} (${recommendation.reason}; ${sampleSources}${extra})${description}`;
+		}),
+		"Guardrails: use these for broad tasks where a skill-specialist pass is useful; keep fanout small, use fresh context unless private/session context is explicitly needed, and skip when the user asks for a direct answer.",
+	];
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -393,6 +393,7 @@ EXECUTION (use exactly ONE mode):
 • CHAIN: { chain: [{agent:"agent-a"}, {parallel:[{agent:"agent-b",count:3}]}] } - sequential pipeline with optional parallel fan-out
 • PARALLEL: { tasks: [{agent,task,count?,output?,reads?,progress?}, ...], concurrency?: number, worktree?: true } - concurrent execution (worktree: isolate each task in a git worktree)
 • Optional context: { context: "fresh" | "fork" } (default: if any requested agent has defaultContext: "fork", the whole invocation uses fork; otherwise "fresh"; inspect agent defaults via { action: "list" })
+• If { action: "list" } shows proactive skill subagent suggestions, consider a small fresh-context fanout for broad tasks where one of those skills would materially help
 
 CHAIN TEMPLATE VARIABLES (use in task strings):
 • {task} - The original task/request from the user

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2319,7 +2319,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					details: { mode: "management" as const, results: [] },
 				};
 			}
-			return handleManagementAction(params.action, paramsWithResolvedCwd, { ...ctx, cwd: requestCwd });
+			return handleManagementAction(params.action, paramsWithResolvedCwd, { ...ctx, cwd: requestCwd, config: deps.config });
 		}
 
 		const { blocked, depth, maxDepth } = checkSubagentDepth(deps.config.maxSubagentDepth);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -815,6 +815,13 @@ interface ExtensionChainConfig {
 	};
 }
 
+export interface ProactiveSkillSubagentsConfig {
+	enabled?: boolean;
+	minReferences?: number;
+	maxRecommendations?: number;
+	preferredAgent?: string;
+}
+
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
 	forceTopLevelAsync?: boolean;
@@ -826,6 +833,7 @@ export interface ExtensionConfig {
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
 	intercomBridge?: IntercomBridgeConfig;
+	proactiveSkillSubagents?: ProactiveSkillSubagentsConfig | false;
 }
 
 // ============================================================================

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -4,8 +4,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { handleCreate, handleManagementAction, handleUpdate } from "../../src/agents/agent-management.ts";
+import { clearSkillCache } from "../../src/agents/skills.ts";
 
 let tempDir = "";
+let oldAgentDir: string | undefined;
 
 function readText(result: { content: Array<{ type: string; text?: string }> }): string {
 	const first = result.content[0];
@@ -18,9 +20,15 @@ function readText(result: { content: Array<{ type: string; text?: string }> }): 
 describe("agent management config parsing", () => {
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-management-"));
+		oldAgentDir = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = path.join(tempDir, "agent-home");
+		clearSkillCache();
 	});
 
 	afterEach(() => {
+		if (oldAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = oldAgentDir;
+		clearSkillCache();
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
 
@@ -249,4 +257,57 @@ Inspect
 		assert.match(content, /inheritProjectContext: true/);
 		assert.match(content, /inheritSkills: false/);
 	});
+
+	it("lists proactive skill subagent suggestions from repeated configured skill use", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+		fs.mkdirSync(path.join(tempDir, ".pi", "agents"), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, ".pi", "skills", "deslop"), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, ".pi", "skills", "deslop", "SKILL.md"), `---
+description: Cleanup review.
+---
+
+Review for cleanup.
+`, "utf-8");
+		for (const name of ["cleanup-a", "cleanup-b"]) {
+			fs.writeFileSync(path.join(tempDir, ".pi", "agents", `${name}.md`), `---
+name: ${name}
+description: Cleanup ${name}
+skills: deslop
+---
+
+Inspect cleanup.
+`, "utf-8");
+		}
+
+		const listed = handleManagementAction("list", {}, ctx);
+		const text = readText(listed);
+		assert.match(text, /Proactive skill subagent suggestions:/);
+		assert.match(text, /- deslop via reviewer/);
+		assert.match(text, /Cleanup review\./);
+	});
+
+	it("can disable proactive skill subagent suggestions in config", () => {
+		const ctx = {
+			cwd: tempDir,
+			modelRegistry: { getAvailable: () => [] },
+			config: { proactiveSkillSubagents: false },
+		};
+		fs.mkdirSync(path.join(tempDir, ".pi", "agents"), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, ".pi", "skills", "deslop"), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, ".pi", "skills", "deslop", "SKILL.md"), "Review for cleanup.\n", "utf-8");
+		for (const name of ["cleanup-a", "cleanup-b"]) {
+			fs.writeFileSync(path.join(tempDir, ".pi", "agents", `${name}.md`), `---
+name: ${name}
+description: Cleanup ${name}
+skills: deslop
+---
+
+Inspect cleanup.
+`, "utf-8");
+		}
+
+		const listed = handleManagementAction("list", {}, ctx);
+		assert.doesNotMatch(readText(listed), /Proactive skill subagent suggestions:/);
+	});
+
 });

--- a/test/unit/proactive-skills.test.ts
+++ b/test/unit/proactive-skills.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { AgentConfig, ChainConfig } from "../../src/agents/agents.ts";
 import {
+	buildProactiveSkillSubagentRecommendationLines,
 	formatProactiveSkillSubagentRecommendations,
 	recommendProactiveSkillSubagents,
 	resolveProactiveSkillSubagentsConfig,
@@ -89,5 +90,29 @@ describe("proactive skill subagent recommendations", () => {
 		]);
 		assert.match(lines.join("\n"), /Proactive skill subagent suggestions:/);
 		assert.match(lines.join("\n"), /fresh context/);
+	});
+
+	it("does not discover skills when disabled and treats discovery failures as no suggestions", () => {
+		let discoveryCalls = 0;
+		const disabledLines = buildProactiveSkillSubagentRecommendationLines({
+			agents: [agent("reviewer", ["deslop"]), agent("cleanup", ["deslop"])],
+			config: false,
+			discoverAvailableSkills: () => {
+				discoveryCalls++;
+				throw new Error("should not discover when disabled");
+			},
+		});
+		assert.deepEqual(disabledLines, []);
+		assert.equal(discoveryCalls, 0);
+
+		const failedDiscoveryLines = buildProactiveSkillSubagentRecommendationLines({
+			agents: [agent("reviewer", ["deslop"]), agent("cleanup", ["deslop"])],
+			discoverAvailableSkills: () => {
+				discoveryCalls++;
+				throw new Error("skill scan failed");
+			},
+		});
+		assert.deepEqual(failedDiscoveryLines, []);
+		assert.equal(discoveryCalls, 1);
 	});
 });

--- a/test/unit/proactive-skills.test.ts
+++ b/test/unit/proactive-skills.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AgentConfig, ChainConfig } from "../../src/agents/agents.ts";
+import {
+	formatProactiveSkillSubagentRecommendations,
+	recommendProactiveSkillSubagents,
+	resolveProactiveSkillSubagentsConfig,
+} from "../../src/agents/proactive-skills.ts";
+
+function agent(name: string, skills?: string[], disabled = false): AgentConfig {
+	return {
+		name,
+		description: `${name} agent`,
+		systemPrompt: "",
+		systemPromptMode: "replace",
+		inheritProjectContext: false,
+		inheritSkills: false,
+		source: "project",
+		filePath: `/tmp/${name}.md`,
+		...(skills ? { skills } : {}),
+		...(disabled ? { disabled } : {}),
+	};
+}
+
+function chain(name: string, skills: string[]): ChainConfig {
+	return {
+		name,
+		description: `${name} chain`,
+		source: "project",
+		filePath: `/tmp/${name}.chain.md`,
+		steps: [{ agent: "worker", skills }],
+	};
+}
+
+describe("proactive skill subagent recommendations", () => {
+	it("recommends available skills referenced by multiple enabled configs", () => {
+		const recommendations = recommendProactiveSkillSubagents({
+			agents: [
+				agent("reviewer"),
+				agent("ui-reviewer", ["accessibility"]),
+				agent("disabled-reviewer", ["accessibility"], true),
+			],
+			chains: [chain("ui-check", ["accessibility"]), chain("cleanup", ["deslop"])],
+			availableSkills: [
+				{ name: "accessibility", description: "Accessibility review." },
+				{ name: "deslop", description: "Cleanup review." },
+			],
+		});
+
+		assert.equal(recommendations.length, 1);
+		assert.equal(recommendations[0]?.skill, "accessibility");
+		assert.equal(recommendations[0]?.agent, "reviewer");
+		assert.equal(recommendations[0]?.references, 2);
+		assert.deepEqual(recommendations[0]?.sources, ["agent:ui-reviewer", "chain:ui-check"]);
+	});
+
+	it("filters unavailable orchestration skills and honors config bounds", () => {
+		const recommendations = recommendProactiveSkillSubagents({
+			agents: [
+				agent("delegate", ["pi-subagents", "alpha", "beta"]),
+				agent("one", ["alpha", "beta"]),
+				agent("two", ["gamma"]),
+				agent("three", ["gamma"]),
+			],
+			availableSkills: [{ name: "alpha" }, { name: "beta" }, { name: "gamma" }],
+			config: { preferredAgent: "delegate", maxRecommendations: 2 },
+		});
+
+		assert.deepEqual(recommendations.map((entry) => entry.skill), ["alpha", "beta"]);
+		assert.ok(recommendations.every((entry) => entry.agent === "delegate"));
+	});
+
+	it("can be disabled and formats guardrails for visible suggestions", () => {
+		assert.equal(resolveProactiveSkillSubagentsConfig(false).enabled, false);
+		assert.deepEqual(recommendProactiveSkillSubagents({
+			agents: [agent("reviewer", ["deslop"]), agent("cleanup", ["deslop"])],
+			availableSkills: [{ name: "deslop" }],
+			config: false,
+		}), []);
+
+		const lines = formatProactiveSkillSubagentRecommendations([
+			{
+				skill: "deslop",
+				agent: "reviewer",
+				references: 2,
+				sources: ["agent:a", "chain:b"],
+				reason: "referenced by 2 configured agents/chains",
+			},
+		]);
+		assert.match(lines.join("\n"), /Proactive skill subagent suggestions:/);
+		assert.match(lines.join("\n"), /fresh context/);
+	});
+});

--- a/test/unit/tool-description.test.ts
+++ b/test/unit/tool-description.test.ts
@@ -21,6 +21,7 @@ describe("registered subagent tool description", () => {
 		}
 		assert.match(description, /use \{ action: "list" \} to inspect configured agents\/chains/i);
 		assert.match(description, /executable\/non-disabled/i);
+		assert.match(description, /proactive skill subagent suggestions/i);
 		assert.doesNotMatch(description, /disabled builtins/i);
 		assert.match(description, /output\?,reads\?,progress\?/i);
 	});


### PR DESCRIPTION
## Summary

Adds a conservative recommendation layer for regularly used skills. `subagent({ action: "list" })` now surfaces proactive skill subagent suggestions when an available skill is referenced repeatedly by configured agents or saved chains.

The feature is advisory rather than hidden automation: the parent/orchestrator still launches any fanout explicitly, with guidance to keep it small, fresh-context by default, and easy to disable or tune through `proactiveSkillSubagents` config.

## Tests

- `node --experimental-strip-types --test test/unit/proactive-skills.test.ts`
- `node --experimental-strip-types --test test/unit/proactive-skills.test.ts test/unit/agent-management.test.ts test/unit/tool-description.test.ts`
- `npm run test:unit`