### PR TITLE
Make live async intercom nudges interrupt first

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -412,7 +412,7 @@ MANAGEMENT (use action field, omit agent/task/chain/tasks):
 CONTROL:
 • { action: "status", id: "..." } - inspect an async/background run by id or prefix
 • { action: "interrupt", id?: "..." } - soft-interrupt the current child turn and leave the run paused
-• { action: "resume", id: "...", message: "...", index?: 0 } - follow up with a live async child or revive a completed async/foreground child from its session
+• { action: "resume", id: "...", message: "...", index?: 0 } - interrupt then follow up with a live async child, or revive a completed async/foreground child from its session
 
 DIAGNOSTICS:
 • { action: "doctor" } - read-only report for runtime paths, discovery, sessions, and intercom`,

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -1,8 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ASYNC_DIR, RESULTS_DIR, type AsyncStatus } from "../../shared/types.ts";
+import { ASYNC_DIR, RESULTS_DIR, type AsyncStatus, type SubagentState } from "../../shared/types.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { reconcileAsyncRun } from "./stale-run-reconciler.ts";
+
+export const ASYNC_RESUME_INTERRUPT_SIGNAL: NodeJS.Signals = process.platform === "win32" ? "SIGBREAK" : "SIGUSR2";
 
 export interface AsyncResumeParams {
 	id?: string;
@@ -29,6 +31,47 @@ export type AsyncResumeTarget = {
 	cwd?: string;
 	sessionFile?: string;
 };
+
+type KillFn = (pid: number, signal?: NodeJS.Signals | 0) => boolean;
+
+function readAsyncStatus(asyncDir: string): AsyncStatus | null {
+	const statusPath = path.join(asyncDir, "status.json");
+	try {
+		return JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatus;
+	} catch (error) {
+		const code = error && typeof error === "object" && "code" in error ? (error as NodeJS.ErrnoException).code : undefined;
+		if (code === "ENOENT") return null;
+		throw error;
+	}
+}
+
+export function interruptLiveAsyncResumeTarget(input: {
+	target: AsyncResumeTarget & { kind: "live" };
+	state?: Pick<SubagentState, "asyncJobs">;
+	kill?: KillFn;
+	now?: () => number;
+}): { ok: true; asyncId: string } | { ok: false; message: string } {
+	const asyncId = input.target.runId;
+	if (!input.target.asyncDir) {
+		return { ok: false, message: `Async run ${asyncId} is live but does not have an async directory to interrupt.` };
+	}
+	const status = readAsyncStatus(input.target.asyncDir);
+	if (!status || status.state !== "running" || typeof status.pid !== "number") {
+		return { ok: false, message: `Async run ${asyncId} is live but no interrupt-capable runner pid was found.` };
+	}
+	try {
+		(input.kill ?? process.kill)(status.pid, ASYNC_RESUME_INTERRUPT_SIGNAL);
+		const tracked = input.state?.asyncJobs.get(asyncId);
+		if (tracked) {
+			tracked.activityState = undefined;
+			tracked.updatedAt = input.now?.() ?? Date.now();
+		}
+		return { ok: true, asyncId };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return { ok: false, message: `Failed to interrupt async run ${asyncId}: ${message}` };
+	}
+}
 
 interface AsyncResultFile {
 	id?: string;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -47,7 +47,7 @@ import {
 	resolveSubagentResultStatus,
 	stripDetailsOutputsForIntercomReceipt,
 } from "../../intercom/result-intercom.ts";
-import { buildRevivedAsyncTask, resolveAsyncResumeTarget } from "../background/async-resume.ts";
+import { buildRevivedAsyncTask, interruptLiveAsyncResumeTarget, resolveAsyncResumeTarget } from "../background/async-resume.ts";
 import { createNestedRoute, readNestedControlResults, resolveInheritedNestedRouteFromEnv, resolveNestedAsyncDir, resolveNestedParentAddressFromEnv, updateForegroundNestedProjection, writeNestedControlRequest, writeNestedEvent, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 import { resolveSubagentRunId, type ResolvedSubagentRunId } from "../background/run-id-resolver.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
@@ -150,6 +150,7 @@ interface ExecutorDeps {
 	expandTilde: (p: string) => string;
 	discoverAgents: (cwd: string, scope: AgentScope) => { agents: AgentConfig[] };
 	allowMutatingManagementActions?: boolean;
+	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 }
 
 interface ExecutionContextData {
@@ -402,7 +403,7 @@ function emitControlNotification(input: {
 	}
 }
 
-function interruptAsyncRun(state: SubagentState, runId: string | undefined): AgentToolResult<Details> | null {
+function interruptAsyncRun(state: SubagentState, runId: string | undefined, kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean): AgentToolResult<Details> | null {
 	const target = getAsyncInterruptTarget(state, runId);
 	if (!target) return null;
 	const status = readStatus(target.asyncDir);
@@ -414,7 +415,7 @@ function interruptAsyncRun(state: SubagentState, runId: string | undefined): Age
 		};
 	}
 	try {
-		process.kill(status.pid, ASYNC_INTERRUPT_SIGNAL);
+		(kill ?? process.kill)(status.pid, ASYNC_INTERRUPT_SIGNAL);
 		const tracked = state.asyncJobs.get(target.asyncId);
 		if (tracked) {
 			tracked.activityState = undefined;
@@ -585,6 +586,18 @@ async function resumeAsyncRun(input: {
 	}
 
 	if (target.kind === "live") {
+		const interrupt = interruptLiveAsyncResumeTarget({
+			target,
+			state: input.deps.state,
+			kill: input.deps.kill,
+		});
+		if (!interrupt.ok) {
+			return {
+				content: [{ type: "text", text: interrupt.message }],
+				isError: true,
+				details: { mode: "management", results: [] },
+			};
+		}
 		const delivered = await deliverSubagentIntercomMessageEvent(
 			input.deps.pi.events,
 			target.intercomTarget,
@@ -594,7 +607,7 @@ async function resumeAsyncRun(input: {
 		);
 		if (delivered) {
 			return {
-				content: [{ type: "text", text: [`Delivered follow-up to live async child.`, `Run: ${target.runId}`, `Intercom target: ${target.intercomTarget}`].join("\n") }],
+				content: [{ type: "text", text: [`Interrupted live async child, then delivered follow-up.`, `Run: ${target.runId}`, `Intercom target: ${target.intercomTarget}`].join("\n") }],
 				details: { mode: "management", results: [] },
 			};
 		}
@@ -2297,7 +2310,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						details: { mode: "management", results: [] },
 					};
 				}
-				const asyncInterruptResult = interruptAsyncRun(deps.state, resolved?.kind === "async" ? resolved.id : targetRunId);
+				const asyncInterruptResult = interruptAsyncRun(deps.state, resolved?.kind === "async" ? resolved.id : targetRunId, deps.kill);
 				if (asyncInterruptResult) return asyncInterruptResult;
 				return {
 					content: [{ type: "text", text: "No interrupt-capable run found in this session." }],

--- a/src/runs/shared/subagent-control.ts
+++ b/src/runs/shared/subagent-control.ts
@@ -173,9 +173,8 @@ export function formatControlNoticeMessage(event: ControlEvent, childIntercomTar
 		].filter((line): line is string => Boolean(line)).join("\n");
 	}
 
-	const nudgeCommand = childIntercomTarget
-		? `intercom({ action: "send", to: "${childIntercomTarget}", message: "What are you blocked on? Reply with the smallest next step or ask for a decision." })`
-		: undefined;
+	const nudgeMessage = "What are you blocked on? Reply with the smallest next step or ask for a decision.";
+	const nudgeCommand = `subagent({ action: "resume", id: "${runTarget}", ${event.index !== undefined ? `index: ${event.index}, ` : ""}message: "${nudgeMessage}" })`;
 	if (event.type === "active_long_running") {
 		const facts = formatLongRunningFacts(event);
 		return [
@@ -183,10 +182,9 @@ export function formatControlNoticeMessage(event: ControlEvent, childIntercomTar
 			`Run: ${runTarget}${event.index !== undefined ? ` step ${event.index + 1}` : ""}`,
 			`Signal: ${event.message}`,
 			facts ? `Facts: ${facts}` : undefined,
-			"Hint: Inspect status, then nudge if the work seems stuck.",
-			childIntercomTarget
-				? `Nudge: ${nudgeCommand}`
-				: "Nudge: no child message route registered",
+			"Hint: Inspect status, then nudge if the work seems stuck. Live async nudges interrupt the child before sending the follow-up.",
+			`Nudge: ${nudgeCommand}`,
+			childIntercomTarget ? `Direct intercom target: ${childIntercomTarget}` : undefined,
 			`Status: subagent({ action: "status", id: "${runTarget}" })`,
 			`Interrupt: subagent({ action: "interrupt", id: "${runTarget}" })`,
 		].filter((line): line is string => Boolean(line)).join("\n");
@@ -197,10 +195,9 @@ export function formatControlNoticeMessage(event: ControlEvent, childIntercomTar
 		`Run: ${runTarget}${event.index !== undefined ? ` step ${event.index + 1}` : ""}`,
 		`Signal: ${event.message}`,
 		event.recentFailureSummary ? `Recent failures: ${event.recentFailureSummary}` : undefined,
-		"Hint: Inspect status first unless the run is clearly blocked.",
-		childIntercomTarget
-			? `Nudge: ${nudgeCommand}`
-			: "Nudge: no child message route registered",
+		"Hint: Inspect status first unless the run is clearly blocked. Live async nudges interrupt the child before sending the follow-up.",
+		`Nudge: ${nudgeCommand}`,
+		childIntercomTarget ? `Direct intercom target: ${childIntercomTarget}` : undefined,
 		`Status: subagent({ action: "status", id: "${runTarget}" })`,
 		`Interrupt: subagent({ action: "interrupt", id: "${runTarget}" })`,
 	].filter((line): line is string => Boolean(line)).join("\n");

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -124,7 +124,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		return JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
 	}
 
-	function makeExecutor(options: { bridgeMode?: "always" | "off"; agents?: ReturnType<typeof makeAgent>[]; acknowledgeResults?: boolean } = {}) {
+	function makeExecutor(options: { bridgeMode?: "always" | "off"; agents?: ReturnType<typeof makeAgent>[]; acknowledgeResults?: boolean; kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean } = {}) {
 		const events = createRecordingEventBus({ acknowledgeResults: options.acknowledgeResults ?? true });
 		const state = {
 			baseCwd: tempDir,
@@ -159,6 +159,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			getSubagentSessionRoot: () => tempDir,
 			expandTilde: (value: string) => value,
 			discoverAgents: () => ({ agents: options.agents ?? [makeAgent("worker")] }),
+			kill: options.kill,
 		});
 		return { executor, events, state };
 	}
@@ -316,17 +317,24 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 	it("resume action sends a follow-up to a live async child when the target is registered", async () => {
 		const runId = `resume-live-${Date.now()}`;
 		const asyncDir = path.join(ASYNC_DIR, runId);
+		const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
 		try {
 			fs.mkdirSync(asyncDir, { recursive: true });
 			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
 				runId,
 				mode: "single",
 				state: "running",
+				pid: process.pid,
 				startedAt: 100,
-				lastUpdate: 100,
+				lastUpdate: Date.now(),
 				steps: [{ agent: "worker", status: "running" }],
 			}, null, 2), "utf-8");
-			const { executor, events } = makeExecutor();
+			const { executor, events } = makeExecutor({
+				kill: (pid, signal) => {
+					kills.push({ pid, signal });
+					return true;
+				},
+			});
 
 			const result = await executor.execute(
 				"resume-live",
@@ -337,7 +345,8 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			);
 
 			assert.equal(result.isError, undefined);
-			assert.match(result.content[0]?.text ?? "", /Delivered follow-up to live async child/);
+			assert.match(result.content[0]?.text ?? "", /Interrupted live async child, then delivered follow-up/);
+			assert.deepEqual(kills, [{ pid: process.pid, signal: process.platform === "win32" ? "SIGBREAK" : "SIGUSR2" }]);
 			const payload = events.emitted.find((entry) => entry.channel === "subagent:result-intercom")?.payload as { to?: string; message?: string } | undefined;
 			assert.equal(payload?.to, `subagent-worker-${runId}-1`);
 			assert.match(payload?.message ?? "", /Can you clarify the last change\?/);

--- a/test/unit/live-async-resume.test.ts
+++ b/test/unit/live-async-resume.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import {
+	ASYNC_RESUME_INTERRUPT_SIGNAL,
+	interruptLiveAsyncResumeTarget,
+	resolveAsyncResumeTarget,
+} from "../../src/runs/background/async-resume.ts";
+
+function writeJson(filePath: string, value: object): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+describe("live async resume interrupt", () => {
+	it("interrupts a resolved live async child before the caller sends a follow-up", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-live-async-resume-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const resultsDir = path.join(root, "results");
+			const asyncDir = path.join(asyncRoot, "run-live");
+			writeJson(path.join(asyncDir, "status.json"), {
+				runId: "run-live",
+				mode: "single",
+				state: "running",
+				pid: process.pid,
+				cwd: root,
+				startedAt: 100,
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "running", startedAt: 100 }],
+			});
+			const target = resolveAsyncResumeTarget({ id: "run-live" }, { asyncDirRoot: asyncRoot, resultsDir });
+			assert.equal(target.kind, "live");
+
+			const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+			const state = {
+				asyncJobs: new Map([["run-live", {
+					asyncId: "run-live",
+					asyncDir,
+					status: "running" as const,
+					pid: process.pid,
+					activityState: "needs_attention" as const,
+					updatedAt: 100,
+				}]]),
+			};
+
+			const result = interruptLiveAsyncResumeTarget({
+				target,
+				state,
+				now: () => 1234,
+				kill: (pid, signal) => {
+					kills.push({ pid, signal });
+					return true;
+				},
+			});
+
+			assert.deepEqual(result, { ok: true, asyncId: "run-live" });
+			assert.deepEqual(kills, [{ pid: process.pid, signal: ASYNC_RESUME_INTERRUPT_SIGNAL }]);
+			assert.equal(state.asyncJobs.get("run-live")?.activityState, undefined);
+			assert.equal(state.asyncJobs.get("run-live")?.updatedAt, 1234);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/subagent-control.test.ts
+++ b/test/unit/subagent-control.test.ts
@@ -162,7 +162,9 @@ describe("subagent control attention state", () => {
 
 		assert.match(message, /Subagent needs attention: worker/);
 		assert.match(message, /Hint: Inspect status first unless the run is clearly blocked/);
-		assert.match(message, /Nudge: intercom\(\{ action: "send", to: "subagent-worker-78f659a3"/);
+		assert.match(message, /Live async nudges interrupt the child before sending the follow-up/);
+		assert.match(message, /Nudge: subagent\(\{ action: "resume", id: "78f659a3", message: "What are you blocked on\?/);
+		assert.match(message, /Direct intercom target: subagent-worker-78f659a3/);
 		assert.match(message, /Status: subagent\(\{ action: "status", id: "78f659a3" \}\)/);
 		assert.match(message, /Interrupt: subagent\(\{ action: "interrupt", id: "78f659a3" \}\)/);
 		assert.doesNotMatch(message, /Wait:/);
@@ -186,6 +188,7 @@ describe("subagent control attention state", () => {
 
 		assert.match(message, /Subagent active but long-running: worker/);
 		assert.match(message, /Inspect status/);
+		assert.match(message, /Nudge: subagent\(\{ action: "resume", id: "78f659a3", message: "What are you blocked on\?/);
 		assert.match(message, /15 turns/);
 		assert.match(message, /160000 tokens/);
 		assert.match(message, /path src\/runs\/background\/async-status\.ts/);
@@ -218,7 +221,7 @@ describe("subagent control attention state", () => {
 		const message = formatControlIntercomMessage(event, "subagent-worker-78f659a3");
 
 		assert.match(message, /worker needs attention in run 78f659a3/);
-		assert.match(message, /Nudge: intercom\(\{ action: "send", to: "subagent-worker-78f659a3"/);
+		assert.match(message, /Nudge: subagent\(\{ action: "resume", id: "78f659a3", message: "What are you blocked on\?/);
 	});
 
 	it("dedupes notifications once per child target and attention state", () => {


### PR DESCRIPTION
When a live async subagent is stuck mid-turn, sending a raw intercom follow-up can land but still not get handled until the child is interrupted. This changes the managed resume path so live async follow-ups request the existing async interrupt first, then send the intercom message to the child target.

Control notices now point orchestrators at `subagent({ action: "resume", ... })` for nudges, so the reliable path is the obvious one. Completed or paused async/foreground sessions still use the existing revive-from-session behavior.

Tests cover the new live interrupt helper, updated control notice guidance, and the integration resume flow.