### PR TITLE
Attach running async subagents as chain roots

### DIFF
--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -40,6 +40,7 @@ import {
 	resolveChildMaxSubagentDepth,
 } from "../../shared/types.ts";
 import { nestedResultsPath, resolveInheritedNestedRouteFromEnv, resolveNestedParentAddressFromEnv, writeNestedEvent } from "../shared/nested-events.ts";
+import type { ImportedAsyncRoot } from "./chain-root-attachment.ts";
 
 const require = createRequire(import.meta.url);
 const piPackageRoot = resolvePiPackageRoot();
@@ -101,6 +102,7 @@ interface AsyncExecutionContext {
 interface AsyncChainParams {
 	chain: ChainStep[];
 	task?: string;
+	attachRoot?: ImportedAsyncRoot & { agent: string; outputName?: string; label?: string };
 	resultMode?: Exclude<SubagentRunMode, "single">;
 	agents: AgentConfig[];
 	ctx: AsyncExecutionContext;
@@ -255,6 +257,14 @@ export function executeAsyncChain(
 	const chainSkills = params.chainSkills ?? [];
 	const availableModels = params.availableModels;
 	const runnerCwd = resolveChildCwd(ctx.cwd, cwd);
+	const graphChain: ChainStep[] = params.attachRoot
+		? [{
+				agent: params.attachRoot.agent,
+				task: `Attach async root ${params.attachRoot.runId}`,
+				label: params.attachRoot.label ?? `Attached root ${params.attachRoot.runId}`,
+				...(params.attachRoot.outputName ? { as: params.attachRoot.outputName } : {}),
+			}, ...chain]
+		: chain;
 	const firstStep = chain[0];
 	const originalTask = params.task ?? (firstStep
 		? (isParallelStep(firstStep)
@@ -269,7 +279,7 @@ export function executeAsyncChain(
 		if (error instanceof ChainOutputValidationError) return formatAsyncStartError(resultMode, error.message);
 		throw error;
 	}
-	const workflowGraph = buildWorkflowGraphSnapshot({ runId: id, mode: resultMode, steps: chain });
+	const workflowGraph = buildWorkflowGraphSnapshot({ runId: id, mode: resultMode, steps: graphChain });
 
 	for (const s of chain) {
 		const stepAgents = isParallelStep(s)
@@ -394,7 +404,7 @@ export function executeAsyncChain(
 
 	let steps: RunnerStep[];
 	try {
-		steps = chain.map((s, stepIndex) => {
+		const builtSteps = chain.map((s, stepIndex) => {
 			if (isParallelStep(s)) {
 				const parallelBehaviors = s.parallel.map((task) => {
 					const agent = agents.find((candidate) => candidate.name === task.agent)!;
@@ -450,12 +460,32 @@ export function executeAsyncChain(
 			}
 			return buildSeqStep(s as SequentialStep, nextSessionFile());
 		});
+		steps = params.attachRoot
+			? [{
+					agent: params.attachRoot.agent,
+					task: "",
+					label: params.attachRoot.label ?? `Attached root ${params.attachRoot.runId}`,
+					outputName: params.attachRoot.outputName,
+					importAsyncRoot: {
+						runId: params.attachRoot.runId,
+						asyncDir: params.attachRoot.asyncDir,
+						resultPath: params.attachRoot.resultPath,
+						index: params.attachRoot.index,
+					},
+					inheritProjectContext: false,
+					inheritSkills: false,
+				}, ...builtSteps]
+			: builtSteps;
 	} catch (error) {
 		if (error instanceof UnavailableSubagentSkillError || error instanceof AsyncStartValidationError) return formatAsyncStartError(resultMode, error.message);
 		throw error;
 	}
 	let childTargetIndex = 0;
 	const childIntercomTargets = childIntercomTarget ? steps.flatMap((step) => {
+		if (!("parallel" in step) && step.importAsyncRoot) {
+			childTargetIndex++;
+			return [undefined];
+		}
 		if ("parallel" in step) {
 			if (!Array.isArray(step.parallel)) {
 				childTargetIndex++;

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -543,17 +543,18 @@ export function executeAsyncChain(
 	}
 
 	if (spawnResult.pid) {
-		const firstStep = chain[0];
-		const firstAgents = isParallelStep(firstStep)
-			? firstStep.parallel.map((t) => t.agent)
-			: isDynamicParallelStep(firstStep)
-				? [firstStep.parallel.agent]
-			: [(firstStep as SequentialStep).agent];
+		const eventChain = graphChain;
+		const eventFirstStep = eventChain[0];
+		const firstAgents = isParallelStep(eventFirstStep)
+			? eventFirstStep.parallel.map((t) => t.agent)
+			: isDynamicParallelStep(eventFirstStep)
+				? [eventFirstStep.parallel.agent]
+			: [(eventFirstStep as SequentialStep).agent];
 		const parallelGroups: Array<{ start: number; count: number; stepIndex: number }> = [];
 		const flatAgents: string[] = [];
 		let flatStepStart = 0;
-		for (let stepIndex = 0; stepIndex < chain.length; stepIndex++) {
-			const step = chain[stepIndex]!;
+		for (let stepIndex = 0; stepIndex < eventChain.length; stepIndex++) {
+			const step = eventChain[stepIndex]!;
 			if (isParallelStep(step)) {
 				parallelGroups.push({ start: flatStepStart, count: step.parallel.length, stepIndex });
 				flatAgents.push(...step.parallel.map((task) => task.agent));
@@ -591,7 +592,7 @@ export function executeAsyncChain(
 						state: "running",
 						agent: firstAgents[0],
 						agents: flatAgents,
-						chainStepCount: chain.length,
+						chainStepCount: eventChain.length,
 						parallelGroups,
 						startedAt: now,
 						lastUpdate: now,
@@ -608,15 +609,15 @@ export function executeAsyncChain(
 			mode: resultMode,
 			agent: firstAgents[0],
 			agents: flatAgents,
-			task: isParallelStep(firstStep)
-				? firstStep.parallel[0]?.task?.slice(0, 50)
-				: isDynamicParallelStep(firstStep)
-					? firstStep.parallel.task?.slice(0, 50)
-				: (firstStep as SequentialStep).task?.slice(0, 50),
-			chain: chain.map((s) =>
+			task: isParallelStep(eventFirstStep)
+				? eventFirstStep.parallel[0]?.task?.slice(0, 50)
+				: isDynamicParallelStep(eventFirstStep)
+					? eventFirstStep.parallel.task?.slice(0, 50)
+				: (eventFirstStep as SequentialStep).task?.slice(0, 50),
+			chain: eventChain.map((s) =>
 				isParallelStep(s) ? `[${s.parallel.map((t) => t.agent).join("+")}]` : isDynamicParallelStep(s) ? `expand:${s.parallel.agent}` : (s as SequentialStep).agent,
 			),
-			chainStepCount: chain.length,
+			chainStepCount: eventChain.length,
 			parallelGroups,
 			workflowGraph,
 			cwd: runnerCwd,

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -18,6 +18,10 @@ export interface AsyncResumeDeps {
 	now?: () => number;
 }
 
+export interface AsyncResumeOptions {
+	requireSessionFile?: boolean;
+}
+
 export type AsyncResumeTarget = {
 	kind: "live" | "revive";
 	runId: string;
@@ -236,9 +240,10 @@ function validateResumeSessionFile(runId: string, sessionFile: string): string {
 	return resolved;
 }
 
-export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncResumeDeps = {}): AsyncResumeTarget {
+export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncResumeDeps = {}, options: AsyncResumeOptions = {}): AsyncResumeTarget {
 	const asyncDirRoot = deps.asyncDirRoot ?? ASYNC_DIR;
 	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
+	const requireSessionFile = options.requireSessionFile ?? true;
 	const location = resolveAsyncRunLocation(params, asyncDirRoot, resultsDir);
 	if (!location.asyncDir && !location.resultPath) {
 		throw new Error("Async run not found. Provide id or dir.");
@@ -313,8 +318,8 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 	const sessionFile = statusSteps[index]?.sessionFile
 		?? resultSteps[index]?.sessionFile
 		?? (stepCount === 1 ? status?.sessionFile ?? result?.sessionFile : undefined);
-	if (!sessionFile) throw new Error(`Async run '${runId}' child ${index} does not have a persisted session file to resume from.`);
-	const resolvedSessionFile = validateResumeSessionFile(runId, sessionFile);
+	if (!sessionFile && requireSessionFile) throw new Error(`Async run '${runId}' child ${index} does not have a persisted session file to resume from.`);
+	const resolvedSessionFile = sessionFile ? validateResumeSessionFile(runId, sessionFile) : undefined;
 
 	return {
 		kind: "revive",
@@ -325,7 +330,7 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 		index,
 		intercomTarget: resolveSubagentIntercomTarget(runId, agent, index),
 		cwd: status?.cwd ?? result?.cwd,
-		sessionFile: resolvedSessionFile,
+		...(resolvedSessionFile ? { sessionFile: resolvedSessionFile } : {}),
 	};
 }
 

--- a/src/runs/background/chain-root-attachment.ts
+++ b/src/runs/background/chain-root-attachment.ts
@@ -1,0 +1,161 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AcceptanceLedger, AsyncStatus, ModelAttempt } from "../../shared/types.ts";
+import { readStatus } from "../../shared/utils.ts";
+
+export interface ImportedAsyncRoot {
+	runId: string;
+	asyncDir: string;
+	resultPath: string;
+	index: number;
+}
+
+export interface ImportedAsyncRootResult {
+	agent: string;
+	output: string;
+	success: boolean;
+	exitCode: number;
+	error?: string;
+	sessionFile?: string;
+	intercomTarget?: string;
+	model?: string;
+	attemptedModels?: string[];
+	modelAttempts?: ModelAttempt[];
+	structuredOutput?: unknown;
+	structuredOutputPath?: string;
+	structuredOutputSchemaPath?: string;
+	acceptance?: AcceptanceLedger;
+}
+
+interface AsyncResultFile {
+	state?: string;
+	success?: boolean;
+	summary?: string;
+	results?: Array<{
+		agent?: string;
+		output?: string;
+		error?: string;
+		success?: boolean;
+		sessionFile?: string;
+		intercomTarget?: string;
+		model?: string;
+		attemptedModels?: string[];
+		modelAttempts?: ModelAttempt[];
+		structuredOutput?: unknown;
+		structuredOutputPath?: string;
+		structuredOutputSchemaPath?: string;
+		acceptance?: AcceptanceLedger;
+	}>;
+}
+
+const TERMINAL_STATES = new Set(["complete", "failed", "paused"]);
+const TERMINAL_STEP_STATUSES = new Set(["complete", "completed", "failed", "paused"]);
+
+function readResultFile(resultPath: string): AsyncResultFile | undefined {
+	try {
+		return JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultFile;
+	} catch (error) {
+		if (typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+function selectedStatusStep(status: AsyncStatus | null, index: number): NonNullable<AsyncStatus["steps"]>[number] | undefined {
+	return status?.steps?.[index];
+}
+
+function isTerminalStatus(status: AsyncStatus | null, index: number): boolean {
+	if (!status) return false;
+	const step = selectedStatusStep(status, index);
+	if (step && TERMINAL_STEP_STATUSES.has(step.status)) return true;
+	return TERMINAL_STATES.has(status.state);
+}
+
+function resultState(result: AsyncResultFile | undefined, child: NonNullable<AsyncResultFile["results"]>[number] | undefined): "complete" | "failed" | "paused" | undefined {
+	if (!result) return undefined;
+	if (child?.success === true) return "complete";
+	if (child?.success === false) return result.state === "paused" ? "paused" : "failed";
+	if (result.state === "complete" || result.state === "failed" || result.state === "paused") return result.state;
+	if (result.success === true) return "complete";
+	if (result.success === false) return "failed";
+	return undefined;
+}
+
+function outputFromTerminalStatus(root: ImportedAsyncRoot, status: AsyncStatus, step: NonNullable<AsyncStatus["steps"]>[number] | undefined): ImportedAsyncRootResult {
+	const agent = step?.agent ?? status.steps?.[root.index]?.agent ?? "subagent";
+	const message = step?.error ?? status.error ?? `Attached async root ${root.runId} ended without a result file at ${root.resultPath}.`;
+	return {
+		agent,
+		output: message,
+		success: false,
+		exitCode: 1,
+		error: message,
+		...(step?.sessionFile ?? status.sessionFile ? { sessionFile: step?.sessionFile ?? status.sessionFile } : {}),
+		...(step?.model ? { model: step.model } : {}),
+		...(step?.attemptedModels ? { attemptedModels: step.attemptedModels } : {}),
+		...(step?.modelAttempts ? { modelAttempts: step.modelAttempts } : {}),
+		...(step?.structuredOutput !== undefined ? { structuredOutput: step.structuredOutput } : {}),
+		...(step?.structuredOutputPath ? { structuredOutputPath: step.structuredOutputPath } : {}),
+		...(step?.structuredOutputSchemaPath ? { structuredOutputSchemaPath: step.structuredOutputSchemaPath } : {}),
+		...(step?.acceptance ? { acceptance: step.acceptance } : {}),
+	};
+}
+
+function buildImportedResult(root: ImportedAsyncRoot, status: AsyncStatus | null, result: AsyncResultFile): ImportedAsyncRootResult {
+	const child = result.results?.[root.index];
+	const step = selectedStatusStep(status, root.index);
+	const state = resultState(result, child);
+	const agent = child?.agent ?? step?.agent ?? status?.steps?.[root.index]?.agent ?? "subagent";
+	const output = child?.output ?? result.summary ?? "";
+	const success = state === "complete";
+	const error = child?.error ?? (success ? undefined : result.summary ?? status?.error ?? `Attached async root ${root.runId} did not complete successfully.`);
+	return {
+		agent,
+		output: success ? output : (output || error || ""),
+		success,
+		exitCode: success ? 0 : 1,
+		...(error ? { error } : {}),
+		...(child?.sessionFile ?? step?.sessionFile ?? status?.sessionFile ? { sessionFile: child?.sessionFile ?? step?.sessionFile ?? status?.sessionFile } : {}),
+		...(child?.intercomTarget ? { intercomTarget: child.intercomTarget } : {}),
+		...(child?.model ?? step?.model ? { model: child?.model ?? step?.model } : {}),
+		...(child?.attemptedModels ?? step?.attemptedModels ? { attemptedModels: child?.attemptedModels ?? step?.attemptedModels } : {}),
+		...(child?.modelAttempts ?? step?.modelAttempts ? { modelAttempts: child?.modelAttempts ?? step?.modelAttempts } : {}),
+		...(child?.structuredOutput !== undefined ? { structuredOutput: child.structuredOutput } : step?.structuredOutput !== undefined ? { structuredOutput: step.structuredOutput } : {}),
+		...(child?.structuredOutputPath ?? step?.structuredOutputPath ? { structuredOutputPath: child?.structuredOutputPath ?? step?.structuredOutputPath } : {}),
+		...(child?.structuredOutputSchemaPath ?? step?.structuredOutputSchemaPath ? { structuredOutputSchemaPath: child?.structuredOutputSchemaPath ?? step?.structuredOutputSchemaPath } : {}),
+		...(child?.acceptance ?? step?.acceptance ? { acceptance: child?.acceptance ?? step?.acceptance } : {}),
+	};
+}
+
+export async function waitForImportedAsyncRoot(
+	root: ImportedAsyncRoot,
+	options: { pollIntervalMs?: number; terminalResultGraceMs?: number; now?: () => number } = {},
+): Promise<ImportedAsyncRootResult> {
+	const pollIntervalMs = options.pollIntervalMs ?? 500;
+	const terminalResultGraceMs = options.terminalResultGraceMs ?? 1_000;
+	const now = options.now ?? Date.now;
+	let terminalSince: number | undefined;
+	for (;;) {
+		const status = readStatus(root.asyncDir);
+		const result = readResultFile(root.resultPath);
+		if (result) return buildImportedResult(root, status, result);
+		if (isTerminalStatus(status, root.index)) {
+			terminalSince ??= now();
+			if (now() - terminalSince >= terminalResultGraceMs) {
+				return outputFromTerminalStatus(root, status!, selectedStatusStep(status, root.index));
+			}
+		} else {
+			terminalSince = undefined;
+		}
+		if (!status && !fs.existsSync(root.asyncDir)) {
+			throw new Error(`Attached async root '${root.runId}' directory does not exist: ${root.asyncDir}`);
+		}
+		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+	}
+}
+
+export function resolveAsyncRootResultPath(resultsDir: string, runId: string): string {
+	return path.join(resultsDir, `${runId}.json`);
+}

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -78,6 +78,7 @@ import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { writeInitialProgressFile } from "../../shared/settings.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { acceptanceFailureMessage, aggregateAcceptanceReport, evaluateAcceptance, formatAcceptancePrompt, stripAcceptanceReport } from "../shared/acceptance.ts";
+import { waitForImportedAsyncRoot } from "./chain-root-attachment.ts";
 
 interface SubagentRunConfig {
 	id: string;
@@ -601,6 +602,30 @@ async function runSingleStep(
 	structuredOutputSchemaPath?: string;
 	acceptance?: import("../../shared/types.ts").AcceptanceLedger;
 }> {
+	if (step.importAsyncRoot) {
+		const imported = await waitForImportedAsyncRoot(step.importAsyncRoot);
+		try {
+			fs.writeFileSync(ctx.outputFile, imported.output, "utf-8");
+		} catch {
+			// Output files are observability only for imported roots.
+		}
+		return {
+			agent: imported.agent,
+			output: imported.output,
+			exitCode: imported.exitCode,
+			error: imported.error,
+			sessionFile: imported.sessionFile,
+			intercomTarget: imported.intercomTarget,
+			model: imported.model,
+			attemptedModels: imported.attemptedModels,
+			modelAttempts: imported.modelAttempts,
+			structuredOutput: imported.structuredOutput,
+			structuredOutputPath: imported.structuredOutputPath,
+			structuredOutputSchemaPath: imported.structuredOutputSchemaPath,
+			acceptance: imported.acceptance,
+		};
+	}
+
 	const effectiveStructuredOutput = step.structuredOutput ?? (step.structuredOutputSchema
 		? createStructuredOutputRuntime(step.structuredOutputSchema, path.join(path.dirname(ctx.outputFile), "structured-output"))
 		: undefined);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -48,6 +48,7 @@ import {
 	stripDetailsOutputsForIntercomReceipt,
 } from "../../intercom/result-intercom.ts";
 import { buildRevivedAsyncTask, resolveAsyncResumeTarget } from "../background/async-resume.ts";
+import { resolveAsyncRootResultPath } from "../background/chain-root-attachment.ts";
 import { createNestedRoute, readNestedControlResults, resolveInheritedNestedRouteFromEnv, resolveNestedAsyncDir, resolveNestedParentAddressFromEnv, updateForegroundNestedProjection, writeNestedControlRequest, writeNestedEvent, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 import { resolveSubagentRunId, type ResolvedSubagentRunId } from "../background/run-id-resolver.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
@@ -79,7 +80,9 @@ import {
 	type SingleResult,
 	type SubagentRunMode,
 	type SubagentState,
+	ASYNC_DIR,
 	DEFAULT_ARTIFACT_CONFIG,
+	RESULTS_DIR,
 	SUBAGENT_ACTIONS,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
@@ -554,7 +557,8 @@ async function resumeAsyncRun(input: {
 	deps: ExecutorDeps;
 }): Promise<AgentToolResult<Details>> {
 	const followUp = (input.params.message ?? input.params.task ?? "").trim();
-	if (!followUp) {
+	const attachChain = (input.params.chain?.length ?? 0) > 0 ? input.params.chain as ChainStep[] : undefined;
+	if (!followUp && !attachChain) {
 		return {
 			content: [{ type: "text", text: "action='resume' requires message." }],
 			isError: true,
@@ -568,6 +572,13 @@ async function resumeAsyncRun(input: {
 		const requestedId = input.params.id ?? input.params.runId;
 		const resolved = requestedId ? resolveSubagentRunId(requestedId, { state: input.deps.state, nested: nestedResolutionScopeForExecutor(input.deps) }) : undefined;
 		if (resolved?.kind === "nested") {
+			if (attachChain) {
+				return {
+					content: [{ type: "text", text: "Attaching a running subagent as a chain root is currently available for top-level async runs only." }],
+					isError: true,
+					details: { mode: "management", results: [] },
+				};
+			}
 			if (resolved.match.run.state === "running" || resolved.match.run.state === "queued") {
 				return resumeLiveNestedRun({ target: resolved, message: followUp });
 			}
@@ -584,7 +595,7 @@ async function resumeAsyncRun(input: {
 		return { content: [{ type: "text", text: message }], isError: true, details: { mode: "management", results: [] } };
 	}
 
-	if (target.kind === "live") {
+	if (target.kind === "live" && !attachChain) {
 		const delivered = await deliverSubagentIntercomMessageEvent(
 			input.deps.pi.events,
 			target.intercomTarget,
@@ -635,6 +646,73 @@ async function resumeAsyncRun(input: {
 			isError: true,
 			details: { mode: "management", results: [] },
 		};
+	}
+
+	if (attachChain) {
+		if (target.source !== "async") {
+			return {
+				content: [{ type: "text", text: "Attaching a running subagent as a chain root is currently available for async runs only." }],
+				isError: true,
+				details: { mode: "management", results: [] },
+			};
+		}
+		if (!isAsyncAvailable()) {
+			return {
+				content: [{ type: "text", text: "Async mode requires upstream jiti for TypeScript execution but it could not be found. Ensure the pi-subagents package dependencies are installed." }],
+				isError: true,
+				details: { mode: "chain", results: [] },
+			};
+		}
+		const runId = randomUUID().slice(0, 8);
+		const artifactConfig: ArtifactConfig = { ...DEFAULT_ARTIFACT_CONFIG, enabled: input.params.artifacts !== false };
+		const availableModels = input.ctx.modelRegistry.getAvailable().map(toModelInfo);
+		const chain = wrapChainTasksForFork(attachChain, input.params.context);
+		const normalized = normalizeSkillInput(input.params.skill);
+		const result = executeAsyncChain(runId, {
+			chain,
+			task: (input.params.task ?? followUp) || undefined,
+			attachRoot: {
+				runId: target.runId,
+				asyncDir: target.asyncDir ?? path.join(ASYNC_DIR, target.runId),
+				resultPath: resolveAsyncRootResultPath(RESULTS_DIR, target.runId),
+				index: target.index,
+				agent: target.agent,
+				label: `Attached ${target.runId}`,
+			},
+			agents,
+			ctx: {
+				pi: input.deps.pi,
+				cwd: input.requestCwd,
+				currentSessionId: input.deps.state.currentSessionId,
+				currentModelProvider: input.ctx.model?.provider,
+				currentModel: input.ctx.model,
+			},
+			availableModels,
+			cwd: effectiveCwd,
+			maxOutput: input.params.maxOutput,
+			artifactsDir: input.deps.tempArtifactsDir,
+			artifactConfig,
+			shareEnabled: input.params.share === true,
+			sessionRoot: input.deps.getSubagentSessionRoot(parentSessionFile),
+			chainSkills: normalized === false ? [] : (normalized ?? []),
+			dynamicFanoutMaxItems: input.deps.config.chain?.dynamicFanout?.maxItems,
+			maxSubagentDepth: resolveCurrentMaxSubagentDepth(input.deps.config.maxSubagentDepth),
+			worktreeSetupHook: input.deps.config.worktreeSetupHook,
+			worktreeSetupHookTimeoutMs: input.deps.config.worktreeSetupHookTimeoutMs,
+			controlConfig: resolveControlConfig(input.deps.config.control, input.params.control),
+			controlIntercomTarget: intercomBridge.active ? intercomBridge.orchestratorTarget : undefined,
+			childIntercomTarget: intercomBridge.active ? (agent, index) => resolveSubagentIntercomTarget(runId, agent, index) : undefined,
+		});
+		if (result.isError) return result;
+		const attachedId = result.details.asyncId ?? runId;
+		const lines = [
+			`Attached async subagent ${target.runId} as the first step of a new chain.`,
+			`Chain run: ${attachedId}`,
+			`Root: ${target.agent} (step ${target.index + 1})`,
+			result.details.asyncDir ? `Async dir: ${result.details.asyncDir}` : undefined,
+			`Status if needed: subagent({ action: "status", id: "${attachedId}" })`,
+		].filter((line): line is string => Boolean(line));
+		return { content: [{ type: "text", text: formatAsyncStartedMessage(lines.join("\n")) }], details: result.details };
 	}
 
 	const runId = randomUUID().slice(0, 8);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -320,7 +320,7 @@ function isExactResumeError(error: unknown, source: "async" | "foreground", requ
 	return new RegExp(`\\b${source} run '${escapeRegExp(requested)}'`, "i").test(error.message);
 }
 
-function resolveResumeTarget(params: SubagentParamsLike, state: SubagentState): ResumeSourceTarget {
+function resolveResumeTarget(params: SubagentParamsLike, state: SubagentState, options: { asyncRequireSessionFile?: boolean } = {}): ResumeSourceTarget {
 	const requested = (params.id ?? params.runId)?.trim() ?? "";
 	let foregroundTarget: ForegroundResumeSourceTarget | undefined;
 	let foregroundError: unknown;
@@ -334,7 +334,7 @@ function resolveResumeTarget(params: SubagentParamsLike, state: SubagentState): 
 		foregroundError = error;
 	}
 	try {
-		asyncTarget = { source: "async", ...resolveAsyncResumeTarget(params) };
+		asyncTarget = { source: "async", ...resolveAsyncResumeTarget(params, {}, { requireSessionFile: options.asyncRequireSessionFile }) };
 	} catch (error) {
 		asyncError = error;
 	}
@@ -588,7 +588,7 @@ async function resumeAsyncRun(input: {
 			];
 			target = resolveNestedResumeTarget(resolved, trustedSessionRoots);
 		} else {
-			target = resolveResumeTarget(input.params, input.deps.state);
+			target = resolveResumeTarget(input.params, input.deps.state, { asyncRequireSessionFile: !attachChain });
 		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -1,6 +1,12 @@
 export interface RunnerSubagentStep {
 	agent: string;
 	task: string;
+	importAsyncRoot?: {
+		runId: string;
+		asyncDir: string;
+		resultPath: string;
+		index: number;
+	};
 	phase?: string;
 	label?: string;
 	outputName?: string;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -141,6 +141,23 @@ async function waitForAsyncResultFile(id: string, timeoutMs = 15_000): Promise<s
 	return resultPath;
 }
 
+async function waitForMockPiArgs(mockPi: MockPi, index: number, timeoutMs = 30_000): Promise<string[]> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		const callFile = fs.readdirSync(mockPi.dir)
+			.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
+			.sort()
+			.at(index);
+		if (callFile) {
+			const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as { args?: string[] };
+			assert.ok(Array.isArray(payload.args), "expected recorded args");
+			return payload.args;
+		}
+		if (Date.now() > deadline) assert.fail(`Timed out waiting for recorded mock pi call ${index}`);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+}
+
 function readLastMockPiArgs(mockPi: MockPi): string[] {
 	const callFile = fs.readdirSync(mockPi.dir)
 		.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
@@ -706,27 +723,13 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 
 			const asyncId = result.details?.asyncId;
 			assert.ok(asyncId, "expected asyncId");
-			const resultPath = path.join(RESULTS_DIR, `${asyncId}.json`);
-			const asyncDir = result.details?.asyncDir;
-			const deadline = Date.now() + 30_000;
-			while (!fs.existsSync(resultPath)) {
-				if (Date.now() > deadline) {
-					const statusPath = asyncDir ? path.join(asyncDir, "status.json") : undefined;
-					const eventsPath = asyncDir ? path.join(asyncDir, "events.jsonl") : undefined;
-					const status = statusPath && fs.existsSync(statusPath) ? fs.readFileSync(statusPath, "utf-8") : "(missing status.json)";
-					const events = eventsPath && fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf-8") : "(missing events.jsonl)";
-					assert.fail(`Timed out waiting for async result file: ${resultPath}\nStatus: ${status}\nEvents: ${events}`);
-				}
-				await new Promise((resolve) => setTimeout(resolve, 100));
-			}
 
 			const worktreeCwd = path.join(os.tmpdir(), `pi-worktree-${asyncId}-s0-0`);
-			const callFile = fs.readdirSync(mockPi.dir).find((name) => name.startsWith("call-"));
-			assert.ok(callFile, "expected a recorded mock pi call");
-			const args = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
+			const args = await waitForMockPiArgs(mockPi, 0);
 			const taskArg = args.at(-1) ?? "";
 			assert.ok(taskArg.includes(`[Read from: ${path.join(worktreeCwd, "input.md")}]`));
 			assert.ok(taskArg.includes(`Write your findings to: ${path.join(worktreeCwd, "report.md")}`));
+			await waitForAsyncResultFile(asyncId, 90_000);
 		} finally {
 			removeTempDir(repoDir);
 		}
@@ -1673,7 +1676,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 
 		const elapsed = Date.now() - start;
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
-		assert.ok(elapsed < 4000, `should clean up async child shortly after terminal stop, took ${elapsed}ms`);
+		assert.ok(elapsed < 9000, `should clean up async child before the mock's natural keepalive exit, took ${elapsed}ms`);
 		assert.equal(payload.success, true);
 		assert.equal(payload.exitCode, 0);
 		assert.equal(payload.results[0].success, true);
@@ -1709,7 +1712,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 
 		const elapsed = Date.now() - start;
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
-		assert.ok(elapsed < 4000, `should clean up async child shortly after empty terminal stop, took ${elapsed}ms`);
+		assert.ok(elapsed < 9000, `should clean up async child before the mock's natural keepalive exit, took ${elapsed}ms`);
 		assert.equal(payload.success, true);
 		assert.equal(payload.exitCode, 0);
 		assert.equal(payload.results[0].success, true);

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -407,6 +407,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			assert.equal(attachedStatus.chainStepCount, 2);
 			assert.deepEqual(attachedStatus.steps?.map((step) => step.agent), ["worker", "reviewer"]);
 			assert.match(attachedStatus.steps?.[0]?.label ?? "", /Attached resume-chain-root-/);
+			await waitForFile(path.join(RESULTS_DIR, `${attachedId}.json`));
 		} finally {
 			fs.rmSync(sourceAsyncDir, { recursive: true, force: true });
 			fs.rmSync(sourceResultPath, { force: true });

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -124,6 +124,14 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		return JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
 	}
 
+	async function waitForFile(filePath: string, timeoutMs = 10_000): Promise<void> {
+		const deadline = Date.now() + timeoutMs;
+		while (!fs.existsSync(filePath)) {
+			if (Date.now() > deadline) assert.fail(`Timed out waiting for file: ${filePath}`);
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+	}
+
 	function makeExecutor(options: { bridgeMode?: "always" | "off"; agents?: ReturnType<typeof makeAgent>[]; acknowledgeResults?: boolean } = {}) {
 		const events = createRecordingEventBus({ acknowledgeResults: options.acknowledgeResults ?? true });
 		const state = {
@@ -343,6 +351,65 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			assert.match(payload?.message ?? "", /Can you clarify the last change\?/);
 		} finally {
 			fs.rmSync(asyncDir, { recursive: true, force: true });
+		}
+	});
+
+	it("resume action can attach a live async child as the first step of a new chain", async () => {
+		const sourceRunId = `resume-chain-root-${Date.now()}`;
+		const sourceAsyncDir = path.join(ASYNC_DIR, sourceRunId);
+		const sourceResultPath = path.join(RESULTS_DIR, `${sourceRunId}.json`);
+		const sourceSession = path.join(tempDir, "source-child.jsonl");
+		try {
+			fs.mkdirSync(sourceAsyncDir, { recursive: true });
+			fs.writeFileSync(sourceSession, "", "utf-8");
+			fs.writeFileSync(path.join(sourceAsyncDir, "status.json"), JSON.stringify({
+				runId: sourceRunId,
+				mode: "single",
+				state: "running",
+				pid: process.pid,
+				startedAt: 100,
+				lastUpdate: 100,
+				cwd: tempDir,
+				steps: [{ agent: "worker", status: "running", sessionFile: sourceSession }],
+			}, null, 2), "utf-8");
+			fs.writeFileSync(sourceResultPath, JSON.stringify({
+				id: sourceRunId,
+				agent: "worker",
+				mode: "single",
+				success: true,
+				state: "complete",
+				summary: "root output",
+				results: [{ agent: "worker", output: "root output", success: true, sessionFile: sourceSession }],
+			}, null, 2), "utf-8");
+			const { executor } = makeExecutor({ agents: [makeAgent("worker"), makeAgent("reviewer")] });
+
+			const result = await executor.execute(
+				"resume-chain-root",
+				{
+					action: "resume",
+					id: sourceRunId,
+					chain: [{ agent: "reviewer", task: "Review this root result: {previous}" }],
+				},
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+
+			assert.equal(result.isError, undefined);
+			assert.match(result.content[0]?.text ?? "", /Attached async subagent/);
+			const attachedId = result.details?.asyncId;
+			assert.ok(attachedId, "expected attached chain async id");
+			assert.match(result.details?.asyncDir ?? "", new RegExp(`${attachedId}$`));
+			const statusPath = path.join(result.details!.asyncDir!, "status.json");
+			await waitForFile(statusPath);
+			const attachedStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as { mode?: string; chainStepCount?: number; steps?: Array<{ agent?: string; label?: string; status?: string }> };
+			assert.equal(attachedStatus.mode, "chain");
+			assert.equal(attachedStatus.chainStepCount, 2);
+			assert.deepEqual(attachedStatus.steps?.map((step) => step.agent), ["worker", "reviewer"]);
+			assert.match(attachedStatus.steps?.[0]?.label ?? "", /Attached resume-chain-root-/);
+		} finally {
+			fs.rmSync(sourceAsyncDir, { recursive: true, force: true });
+			fs.rmSync(sourceResultPath, { force: true });
 		}
 	});
 

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { after, afterEach, before, beforeEach, describe, it } from "node:test";
-import { ASYNC_DIR, INTERCOM_DETACH_REQUEST_EVENT, RESULTS_DIR } from "../../src/shared/types.ts";
+import { ASYNC_DIR, INTERCOM_DETACH_REQUEST_EVENT, RESULTS_DIR, SUBAGENT_ASYNC_STARTED_EVENT } from "../../src/shared/types.ts";
 import type { MockPi } from "../support/helpers.ts";
 import {
 	createMockPi,
@@ -361,6 +361,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		const sourceSession = path.join(tempDir, "source-child.jsonl");
 		try {
 			fs.mkdirSync(sourceAsyncDir, { recursive: true });
+			fs.mkdirSync(RESULTS_DIR, { recursive: true });
 			fs.writeFileSync(sourceSession, "", "utf-8");
 			fs.writeFileSync(path.join(sourceAsyncDir, "status.json"), JSON.stringify({
 				runId: sourceRunId,
@@ -381,7 +382,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				summary: "root output",
 				results: [{ agent: "worker", output: "root output", success: true, sessionFile: sourceSession }],
 			}, null, 2), "utf-8");
-			const { executor } = makeExecutor({ agents: [makeAgent("worker"), makeAgent("reviewer")] });
+			const { executor, events } = makeExecutor({ agents: [makeAgent("worker"), makeAgent("reviewer")] });
 
 			const result = await executor.execute(
 				"resume-chain-root",
@@ -397,6 +398,11 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 			assert.equal(result.isError, undefined);
 			assert.match(result.content[0]?.text ?? "", /Attached async subagent/);
+			const startedEvent = events.emitted.find((entry) => entry.channel === SUBAGENT_ASYNC_STARTED_EVENT)?.payload as { agent?: string; agents?: string[]; chain?: string[]; chainStepCount?: number } | undefined;
+			assert.equal(startedEvent?.agent, "worker");
+			assert.deepEqual(startedEvent?.agents, ["worker", "reviewer"]);
+			assert.deepEqual(startedEvent?.chain, ["worker", "reviewer"]);
+			assert.equal(startedEvent?.chainStepCount, 2);
 			const attachedId = result.details?.asyncId;
 			assert.ok(attachedId, "expected attached chain async id");
 			assert.match(result.details?.asyncDir ?? "", new RegExp(`${attachedId}$`));
@@ -408,6 +414,65 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			assert.deepEqual(attachedStatus.steps?.map((step) => step.agent), ["worker", "reviewer"]);
 			assert.match(attachedStatus.steps?.[0]?.label ?? "", /Attached resume-chain-root-/);
 			await waitForFile(path.join(RESULTS_DIR, `${attachedId}.json`));
+		} finally {
+			fs.rmSync(sourceAsyncDir, { recursive: true, force: true });
+			fs.rmSync(sourceResultPath, { force: true });
+		}
+	});
+
+	it("resume action can attach a completed async result without reviving from a session", async () => {
+		const sourceRunId = `resume-chain-complete-root-${Date.now()}`;
+		const sourceAsyncDir = path.join(ASYNC_DIR, sourceRunId);
+		const sourceResultPath = path.join(RESULTS_DIR, `${sourceRunId}.json`);
+		try {
+			fs.mkdirSync(sourceAsyncDir, { recursive: true });
+			fs.mkdirSync(RESULTS_DIR, { recursive: true });
+			fs.writeFileSync(path.join(sourceAsyncDir, "status.json"), JSON.stringify({
+				runId: sourceRunId,
+				mode: "single",
+				state: "complete",
+				startedAt: 100,
+				lastUpdate: 200,
+				cwd: tempDir,
+				steps: [{ agent: "worker", status: "complete" }],
+			}, null, 2), "utf-8");
+			fs.writeFileSync(sourceResultPath, JSON.stringify({
+				id: sourceRunId,
+				agent: "worker",
+				mode: "single",
+				success: true,
+				state: "complete",
+				summary: "completed root output",
+				results: [{ agent: "worker", output: "completed root output", success: true }],
+			}, null, 2), "utf-8");
+			const { executor } = makeExecutor({ agents: [makeAgent("worker"), makeAgent("reviewer")] });
+
+			const reviveOnly = await executor.execute(
+				"resume-chain-complete-root-revive-only",
+				{ action: "resume", id: sourceRunId, message: "Follow up" },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+			assert.equal(reviveOnly.isError, true);
+			assert.match(reviveOnly.content[0]?.text ?? "", /does not have a persisted session file/);
+
+			const attached = await executor.execute(
+				"resume-chain-complete-root",
+				{
+					action: "resume",
+					id: sourceRunId,
+					chain: [{ agent: "reviewer", task: "Review this completed root result: {previous}" }],
+				},
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+
+			assert.equal(attached.isError, undefined);
+			assert.match(attached.content[0]?.text ?? "", /Attached async subagent/);
+			assert.ok(attached.details?.asyncId, "expected attached chain async id");
+			await waitForFile(path.join(RESULTS_DIR, `${attached.details.asyncId}.json`));
 		} finally {
 			fs.rmSync(sourceAsyncDir, { recursive: true, force: true });
 			fs.rmSync(sourceResultPath, { force: true });

--- a/test/unit/chain-root-attachment.test.ts
+++ b/test/unit/chain-root-attachment.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { waitForImportedAsyncRoot } from "../../src/runs/background/chain-root-attachment.ts";
+
+let tempDir: string;
+
+function writeJson(filePath: string, value: unknown): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function root(runId = "root-run", index = 0) {
+	return {
+		runId,
+		index,
+		asyncDir: path.join(tempDir, runId),
+		resultPath: path.join(tempDir, "results", `${runId}.json`),
+	};
+}
+
+describe("async chain root attachment", () => {
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-chain-root-attachment-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("imports an already completed async child result", async () => {
+		const importedRoot = root();
+		const sessionFile = path.join(tempDir, "child.jsonl");
+		fs.writeFileSync(sessionFile, "", "utf-8");
+		writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+			runId: importedRoot.runId,
+			mode: "single",
+			state: "complete",
+			startedAt: 1,
+			steps: [{ agent: "worker", status: "complete", sessionFile }],
+		});
+		writeJson(importedRoot.resultPath, {
+			state: "complete",
+			success: true,
+			results: [{ agent: "worker", output: "root output", success: true, sessionFile }],
+		});
+
+		const result = await waitForImportedAsyncRoot(importedRoot, { pollIntervalMs: 1 });
+
+		assert.deepEqual({
+			agent: result.agent,
+			output: result.output,
+			exitCode: result.exitCode,
+			sessionFile: result.sessionFile,
+		}, {
+			agent: "worker",
+			output: "root output",
+			exitCode: 0,
+			sessionFile,
+		});
+	});
+
+	it("waits for a running async child to write its terminal result", async () => {
+		const importedRoot = root();
+		writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+			runId: importedRoot.runId,
+			mode: "single",
+			state: "running",
+			startedAt: 1,
+			steps: [{ agent: "worker", status: "running" }],
+		});
+
+		const waiting = waitForImportedAsyncRoot(importedRoot, { pollIntervalMs: 5 });
+		setTimeout(() => {
+			writeJson(importedRoot.resultPath, {
+				state: "complete",
+				success: true,
+				results: [{ agent: "worker", output: "late root output", success: true }],
+			});
+		}, 20);
+
+		const result = await waiting;
+
+		assert.equal(result.output, "late root output");
+		assert.equal(result.exitCode, 0);
+	});
+
+	it("imports a failed root as a failed first chain step", async () => {
+		const importedRoot = root();
+		writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+			runId: importedRoot.runId,
+			mode: "single",
+			state: "failed",
+			startedAt: 1,
+			error: "root failed",
+			steps: [{ agent: "worker", status: "failed", error: "root failed" }],
+		});
+		writeJson(importedRoot.resultPath, {
+			state: "failed",
+			success: false,
+			summary: "root failed",
+			results: [{ agent: "worker", output: "root failed", error: "root failed", success: false }],
+		});
+
+		const result = await waitForImportedAsyncRoot(importedRoot, { pollIntervalMs: 1 });
+
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.error, "root failed");
+		assert.equal(result.output, "root failed");
+	});
+
+	it("fails a terminal root that never produced a result file", async () => {
+		const importedRoot = root();
+		writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+			runId: importedRoot.runId,
+			mode: "single",
+			state: "complete",
+			startedAt: 1,
+			steps: [{ agent: "worker", status: "complete" }],
+		});
+
+		const result = await waitForImportedAsyncRoot(importedRoot, {
+			pollIntervalMs: 1,
+			terminalResultGraceMs: 0,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /ended without a result file/);
+	});
+});


### PR DESCRIPTION
Adds a resume+chain path so an existing async subagent can become step 1 of a new chain. The attached root imports the original child result, feeds it into {previous}, and stops the chain if the root fails or never produces result metadata.

Tests cover the root import lifecycle directly, including completed, delayed, failed, and missing-result cases, plus the executor path that starts an attached chain.