### PR TITLE
fix: ignore legacy skill files during agent discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - Interrupt live async children before delivering `resume` follow-up messages so intercom nudges reach workers that are stuck mid-turn more reliably.
 - Reject appended chain steps with duplicate reserved output names or unknown named-output references before they are queued.
+- Ignore legacy `.agents/skills` files during agent discovery so skill definitions are not registered as subagents. Thanks to chyax98 (@chyax98) for #257.
 
 ## [0.29.0] - 2026-06-19
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -844,10 +844,23 @@ function listFilesRecursive(dir: string, predicate: (fileName: string) => boolea
 	return files;
 }
 
+function isLegacyAgentSkillPath(rootDir: string, filePath: string): boolean {
+	const relative = path.relative(rootDir, filePath);
+	const parts = relative.split(path.sep).map((part) => part.toLowerCase());
+	if (path.basename(rootDir).toLowerCase() === ".agents") {
+		parts.unshift(".agents");
+	}
+	return parts.some((part, index) => part === ".agents" && parts[index + 1] === "skills");
+}
+
 function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
 	for (const filePath of listFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"))) {
+		if (isLegacyAgentSkillPath(dir, filePath)) {
+			continue;
+		}
+
 		let content: string;
 		try {
 			content = fs.readFileSync(filePath, "utf-8");

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -1140,8 +1140,8 @@ describe("chain execution — parallel steps", { skip: !available ? "pi packages
 	});
 
 	it("passes completed parallel task outputs to later {outputs.name} references", async () => {
-		mockPi.onCall({ output: "Alpha named output" });
-		mockPi.onCall({ output: "Beta named output" });
+		mockPi.onCall({ matchArgIncludes: "Alpha", output: "Alpha named output" });
+		mockPi.onCall({ matchArgIncludes: "Beta", output: "Beta named output" });
 		mockPi.onCall({ output: "Final" });
 		const agents = [makeAgent("alpha"), makeAgent("beta"), makeAgent("writer")];
 

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -25,8 +25,12 @@ function withTempHome<T>(fn: (home: string) => T): T {
 	tempDirs.push(home);
 	const oldHome = process.env.HOME;
 	const oldUserProfile = process.env.USERPROFILE;
+	const oldPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const oldExtraAgentDirs = process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
 	process.env.HOME = home;
 	process.env.USERPROFILE = home;
+	delete process.env.PI_CODING_AGENT_DIR;
+	delete process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
 	try {
 		return fn(home);
 	} finally {
@@ -34,6 +38,10 @@ function withTempHome<T>(fn: (home: string) => T): T {
 		else process.env.HOME = oldHome;
 		if (oldUserProfile === undefined) delete process.env.USERPROFILE;
 		else process.env.USERPROFILE = oldUserProfile;
+		if (oldPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = oldPiCodingAgentDir;
+		if (oldExtraAgentDirs === undefined) delete process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
+		else process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS = oldExtraAgentDirs;
 	}
 }
 
@@ -241,6 +249,45 @@ Review nested project work.
 		assert.ok(agent);
 		assert.equal(agent.source, "package");
 		assert.equal(agent.filePath, path.join(packageRoot, "agents", "reviewer.md"));
+	}));
+
+	it("does not register legacy skill files from broad package agent roots", () => withTempHome(() => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-broad-package-skills-"));
+		tempDirs.push(dir);
+		const packageRoot = path.join(dir, ".pi", "npm", "node_modules", "broad-workflow");
+		writeJson(path.join(packageRoot, "package.json"), {
+			name: "broad-workflow",
+			"pi-subagents": {
+				agents: ["."],
+			},
+		});
+		writeAgent(path.join(packageRoot, "agent.md"), `---
+name: package-agent
+description: Package agent
+---
+
+Package prompt
+`);
+		writeAgent(path.join(packageRoot, ".agents", "skills", "package-skill", "SKILL.md"), `---
+name: package-skill
+description: Package skill
+---
+
+Skill prompt
+`);
+		writeAgent(path.join(packageRoot, "agents", "SKILL.md"), `---
+name: skill-named-package-agent
+description: Skill-named package agent
+---
+
+Agent prompt
+`);
+
+		const packageAgents = discoverAgentsAll(dir).package;
+		assert.ok(packageAgents.find((agent) => agent.name === "package-agent" && agent.filePath === path.join(packageRoot, "agent.md")));
+		assert.ok(packageAgents.find((agent) => agent.name === "skill-named-package-agent" && agent.filePath === path.join(packageRoot, "agents", "SKILL.md")));
+		assert.equal(packageAgents.some((agent) => agent.filePath.includes(`${path.sep}.agents${path.sep}skills${path.sep}`)), false);
+		assert.equal(packageAgents.some((agent) => agent.name === "package-skill"), false);
 	}));
 
 	it("keeps package definitions below user and project overrides", () => withTempHome((home) => {
@@ -927,12 +974,76 @@ description: Canonical
 
 Canonical prompt
 `, "utf-8");
+		fs.writeFileSync(path.join(dir, ".pi", "agents", "SKILL.md"), `---
+name: skill-named-agent
+description: Skill-named agent
+---
+
+Skill-named agent prompt
+`, "utf-8");
 
 		const result = discoverAgents(dir, "project");
 		assert.ok(result.agents.find((agent) => agent.name === "legacy" && agent.filePath === path.join(dir, ".agents", "legacy.md")));
 		assert.ok(result.agents.find((agent) => agent.name === "canonical" && agent.filePath === path.join(dir, ".pi", "agents", "canonical.md")));
+		assert.ok(result.agents.find((agent) => agent.name === "skill-named-agent" && agent.filePath === path.join(dir, ".pi", "agents", "SKILL.md")));
 		assert.equal(result.projectAgentsDir, path.join(dir, ".pi", "agents"));
 	});
+
+	it("does not register legacy project skill files as agents", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-project-skills-not-agents-"));
+		tempDirs.push(dir);
+		writeAgent(path.join(dir, ".agents", "legacy.md"), `---
+name: legacy
+description: Legacy
+---
+
+Legacy prompt
+`);
+		writeAgent(path.join(dir, ".agents", "skills", "directory-skill", "SKILL.md"), `---
+name: directory-skill
+description: Directory skill
+---
+
+Skill prompt
+`);
+		writeAgent(path.join(dir, ".agents", "skills", "file-skill.md"), `---
+name: file-skill
+description: File skill
+---
+
+Skill prompt
+`);
+
+		const agents = discoverAgents(dir, "project").agents;
+		assert.ok(agents.find((agent) => agent.name === "legacy"));
+		assert.equal(agents.some((agent) => agent.filePath.includes(`${path.sep}.agents${path.sep}skills${path.sep}`)), false);
+		assert.equal(agents.some((agent) => agent.name === "directory-skill"), false);
+		assert.equal(agents.some((agent) => agent.name === "file-skill"), false);
+	});
+
+	it("does not register user SKILL.md files as agents", () => withTempHome((home) => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-user-skills-not-agents-"));
+		tempDirs.push(dir);
+		writeAgent(path.join(home, ".agents", "user-agent.md"), `---
+name: user-agent
+description: User agent
+---
+
+User prompt
+`);
+		writeAgent(path.join(home, ".agents", "skills", "user-skill", "SKILL.md"), `---
+name: user-skill
+description: User skill
+---
+
+Skill prompt
+`);
+
+		const agents = discoverAgents(dir, "user").agents;
+		assert.ok(agents.find((agent) => agent.name === "user-agent"));
+		assert.equal(agents.some((agent) => agent.filePath.includes(`${path.sep}.agents${path.sep}skills${path.sep}`)), false);
+		assert.equal(agents.some((agent) => agent.name === "user-skill"), false);
+	}));
 
 	it("prefers .pi/agents over .agents on project agent name collisions", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-project-agent-collision-"));


### PR DESCRIPTION
## Summary
- skip legacy `.agents/skills` paths during agent discovery, including when a package exposes a broad agent root
- keep legitimate `SKILL.md` agent files loadable from actual agent directories
- isolate discovery tests from env-driven user agent dirs

## Review
Ran a parallel fresh-context adversarial review loop before opening this. Reviewers caught an over-broad initial `SKILL.md` filename skip, so this now targets only legacy `.agents/skills` paths and adds guard coverage for real `SKILL.md` agents.

## Tests
- `node --experimental-strip-types --test test/unit/agent-frontmatter.test.ts`
- `npm run test:unit`
- `npm run test:integration`

Fixes #257