### PR TITLE
Add /subagents-models command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ Use `~/.pi/agent/settings.json` for a user override or `.pi/settings.json` for a
 
 If your provider rejects model IDs with thinking suffixes, set `subagents.disableThinking: true` in user or project settings. That clears bundled builtin thinking defaults in one place; an explicit higher-precedence `agentOverrides.<name>.thinking` value can opt a role back in.
 
+To inspect what `pi-subagents` has actually loaded right now, use:
+
+```text
+/subagents-models
+/subagents-models reviewer
+```
+
+That reports the live runtime mapping, which can differ from settings on disk until you reload Pi.
+
 ## Where running subagents show up
 
 Foreground runs stream progress in the conversation while they run.
@@ -250,6 +259,7 @@ Skip this section until you want exact syntax.
 | `/parallel agent1 "task1" -> agent2 "task2"` | Run agents in parallel |
 | `/run-chain <chainName> -- <task>` | Launch a saved `.chain.md` or `.chain.json` workflow |
 | `/subagents-doctor` | Show read-only setup diagnostics |
+| `/subagents-models [agent]` | Show the runtime-loaded builtin model mapping, optionally filtered to one builtin |
 
 Commands validate agent names locally, support tab completion, and send results back into the conversation.
 
@@ -757,6 +767,8 @@ Agent definitions are not loaded into context by default. Management actions let
 { action: "list" }
 { action: "list", agentScope: "project" }
 { action: "get", agent: "scout" }
+{ action: "models" }
+{ action: "models", agent: "reviewer" }
 { action: "get", agent: "code-analysis.scout" }
 { action: "get", chainName: "review-pipeline" }
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -8,6 +8,7 @@ import {
 	type AgentSource,
 	type ChainConfig,
 	type ChainStepConfig,
+	BUILTIN_AGENT_NAMES,
 	defaultInheritProjectContext,
 	defaultInheritSkills,
 	defaultSystemPromptMode,
@@ -23,11 +24,13 @@ import {
 	buildProactiveSkillSubagentRecommendationLines,
 } from "./proactive-skills.ts";
 import { parseFrontmatter } from "./frontmatter.ts";
+import { toModelInfo } from "../shared/model-info.ts";
+import { resolveSubagentModelOverride, type ParentModel } from "../runs/shared/model-fallback.ts";
 import type { Details, ExtensionConfig } from "../shared/types.ts";
 
-type ManagementAction = "list" | "get" | "create" | "update" | "delete";
+type ManagementAction = "list" | "get" | "models" | "create" | "update" | "delete";
 type ManagementScope = "user" | "project";
-type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry"> & { config?: ExtensionConfig };
+type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry"> & { model?: ExtensionContext["model"]; config?: ExtensionConfig };
 
 interface ManagementParams {
 	action?: string;
@@ -559,6 +562,84 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 	return result(lines.join("\n"));
 }
 
+function formatModelSource(agent: AgentConfig, currentModel: ParentModel | undefined): string {
+	if (agent.override && agent.model !== agent.override.base.model) {
+		return `${agent.override.scope} override`;
+	}
+	if (agent.model) return "builtin agent config";
+	if (currentModel) return "inherits current session model";
+	return "inherit requested, but no current session model is available";
+}
+
+function handleModels(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
+	const requestedAgent = params.agent?.trim();
+	if (requestedAgent && !(BUILTIN_AGENT_NAMES as readonly string[]).includes(requestedAgent)) {
+		return result(`Builtin agent '${requestedAgent}' not found. Available: ${BUILTIN_AGENT_NAMES.join(", ")}.`, true);
+	}
+
+	const discovered = discoverAgentsAll(ctx.cwd);
+	const builtinByName = new Map(discovered.builtin.map((agent) => [agent.name, agent]));
+	const availableModels = ctx.modelRegistry.getAvailable().map(toModelInfo);
+	const currentModel = ctx.model ? { provider: ctx.model.provider, id: ctx.model.id } : undefined;
+	const preferredProvider = ctx.model?.provider;
+	const names = requestedAgent ? [requestedAgent] : [...BUILTIN_AGENT_NAMES];
+
+	if (requestedAgent) {
+		const agent = builtinByName.get(requestedAgent);
+		if (!agent) return result(`Builtin agent '${requestedAgent}' not found.`, true);
+		const resolvedModel = resolveSubagentModelOverride(agent.model, currentModel, availableModels, preferredProvider);
+		const lines = [
+			"Builtin subagent model",
+			"",
+			`Agent: ${requestedAgent}`,
+			"Effective model:",
+			`  ${resolvedModel ?? "(unresolved)"}`,
+			`Source: ${formatModelSource(agent, currentModel)}`,
+		];
+		if (agent.override) {
+			lines.push("Override file:");
+			lines.push(`  ${agent.override.path}`);
+		}
+		if (agent.model && resolvedModel && agent.model !== resolvedModel) {
+			lines.push("Requested model setting:");
+			lines.push(`  ${agent.model}`);
+		}
+		if (agent.disabled) lines.push("Disabled: true");
+		lines.push("Current session model:");
+		lines.push(`  ${currentModel ? `${currentModel.provider}/${currentModel.id}` : "(unavailable)"}`);
+		return result(lines.join("\n"));
+	}
+
+	const lines = [
+		"Builtin subagent models",
+		"",
+		"Current session model:",
+		`  ${currentModel ? `${currentModel.provider}/${currentModel.id}` : "(unavailable)"}`,
+		"",
+	];
+
+	for (const name of names) {
+		const agent = builtinByName.get(name);
+		if (!agent) {
+			lines.push(name);
+			lines.push("  model:");
+			lines.push("    (builtin definition not found)");
+			lines.push("  source: missing");
+			lines.push("");
+			continue;
+		}
+		const resolvedModel = resolveSubagentModelOverride(agent.model, currentModel, availableModels, preferredProvider);
+		const source = `${formatModelSource(agent, currentModel)}${agent.disabled ? "; disabled" : ""}`;
+		lines.push(name);
+		lines.push("  model:");
+		lines.push(`    ${resolvedModel ?? "(unresolved)"}`);
+		lines.push(`  source: ${source}`);
+		lines.push("");
+	}
+
+	return result(lines.join("\n"));
+}
+
 function handleGet(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
 	if (!params.agent && !params.chainName) return result("Specify 'agent' or 'chainName' for get.", true);
 	const hasBoth = Boolean(params.agent && params.chainName);
@@ -783,6 +864,7 @@ export function handleManagementAction(action: string, params: ManagementParams,
 	switch (action as ManagementAction) {
 		case "list": return handleList(params, ctx);
 		case "get": return handleGet(params, ctx);
+		case "models": return handleModels(params, ctx);
 		case "create": return handleCreate(params, ctx);
 		case "update": return handleUpdate(params, ctx);
 		case "delete": return handleDelete(params, ctx);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -22,6 +22,17 @@ export type AgentSource = "builtin" | "package" | "user" | "project";
 type SystemPromptMode = "append" | "replace";
 export type AgentDefaultContext = "fresh" | "fork";
 
+export const BUILTIN_AGENT_NAMES = [
+	"context-builder",
+	"delegate",
+	"oracle",
+	"planner",
+	"researcher",
+	"reviewer",
+	"scout",
+	"worker",
+] as const;
+
 export function defaultSystemPromptMode(name: string): SystemPromptMode {
 	return name === "delegate" ? "append" : "replace";
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -429,6 +429,7 @@ Example: { chain: [{agent:"agent-a", task:"Analyze {task}"}, {agent:"agent-b", t
 MANAGEMENT (use action field, omit agent/task/chain/tasks):
 • { action: "list" } - discover executable agents/chains
 • { action: "get", agent: "name" } - full detail; packaged agents use dotted runtime names like "package.agent"
+• { action: "models", agent?: "name" } - show the runtime-loaded builtin subagent model mapping, optionally filtered to one builtin
 • { action: "create", config: { name: "custom-agent", package: "code-analysis", systemPrompt, systemPromptMode, inheritProjectContext, inheritSkills, defaultContext, ... } }
 • { action: "update", agent: "code-analysis.custom-agent", config: { package: "analysis", ... } } - merge
 • { action: "delete", agent: "code-analysis.custom-agent" }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -928,7 +928,7 @@ export const SLASH_SUBAGENT_CANCEL_EVENT = "subagent:slash:cancel";
 export const POLL_INTERVAL_MS = 250;
 export const MAX_WIDGET_JOBS = 4;
 export const DEFAULT_SUBAGENT_MAX_DEPTH = 2;
-export const SUBAGENT_ACTIONS = ["list", "get", "create", "update", "delete", "status", "interrupt", "resume", "append-step", "doctor"] as const;
+export const SUBAGENT_ACTIONS = ["list", "get", "models", "create", "update", "delete", "status", "interrupt", "resume", "append-step", "doctor"] as const;
 
 export const DEFAULT_FORK_PREAMBLE =
 	"You are a delegated subagent running from a fork of the parent session. " +

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Key, matchesKey } from "@earendil-works/pi-tui";
-import { discoverAgents, discoverAgentsAll, type ChainConfig } from "../agents/agents.ts";
+import { BUILTIN_AGENT_NAMES, discoverAgents, discoverAgentsAll, type ChainConfig } from "../agents/agents.ts";
 import type { SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { isDynamicParallelStep, isParallelStep, type ChainStep } from "../shared/settings.ts";
 import { assertJsonSchemaObject } from "../runs/shared/structured-output.ts";
@@ -123,6 +123,13 @@ const makeChainCompletions = (state: SubagentState) => (prefix: string) => {
 	return discoverSavedChains(state.baseCwd)
 		.filter((chain) => chain.name.startsWith(prefix))
 		.map((chain) => ({ value: chain.name, label: chain.name }));
+};
+
+const makeBuiltinAgentNameCompletions = () => (prefix: string) => {
+	if (prefix.includes(" ")) return null;
+	return BUILTIN_AGENT_NAMES
+		.filter((name) => name.startsWith(prefix))
+		.map((name) => ({ value: name, label: name }));
 };
 
 function loadSavedOutputSchema(chain: ChainConfig, stepAgent: string, outputSchema: unknown): JsonSchemaObject | undefined {
@@ -330,7 +337,7 @@ async function runSlashSubagent(
 		pi.sendMessage({
 			customType: SLASH_RESULT_TYPE,
 			content: buildSlashExportText(response),
-			display: true,
+			display: !ctx.hasUI,
 			details: finalDetails,
 		});
 		persistSlashSessionSnapshot(ctx);
@@ -346,7 +353,7 @@ async function runSlashSubagent(
 		pi.sendMessage({
 			customType: SLASH_RESULT_TYPE,
 			content: `## Subagent result\n\n${message}`,
-			display: true,
+			display: !ctx.hasUI,
 			details: failedDetails,
 		});
 		persistSlashSessionSnapshot(ctx);
@@ -560,6 +567,29 @@ export function registerSlashCommands(
 		description: "Show subagent diagnostics",
 		handler: async (_args, ctx) => {
 			await runSlashSubagent(pi, ctx, { action: "doctor" });
+		},
+	});
+
+	pi.registerCommand("subagents-models", {
+		description: "Show runtime-loaded builtin subagent models",
+		getArgumentCompletions: makeBuiltinAgentNameCompletions(),
+		handler: async (args, ctx) => {
+			const trimmed = args.trim();
+			if (!trimmed) {
+				await runSlashSubagent(pi, ctx, { action: "models" });
+				return;
+			}
+			const parts = trimmed.split(/\s+/).filter(Boolean);
+			if (parts.length !== 1) {
+				ctx.ui.notify("Usage: /subagents-models [builtin-agent-name]", "error");
+				return;
+			}
+			const agent = parts[0]!;
+			if (!(BUILTIN_AGENT_NAMES as readonly string[]).includes(agent)) {
+				ctx.ui.notify(`Unknown builtin agent: ${agent}`, "error");
+				return;
+			}
+			await runSlashSubagent(pi, ctx, { action: "models", agent });
 		},
 	});
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -88,6 +88,33 @@ function truncLine(text: string, maxWidth: number): string {
 	return result + activeStyles.join("") + "…";
 }
 
+function wrapPlainText(text: string, maxWidth: number): string[] {
+	if (maxWidth <= 0) return [""];
+	const lines: string[] = [];
+	for (const rawLine of text.split("\n")) {
+		if (rawLine.length === 0) {
+			lines.push("");
+			continue;
+		}
+		let current = "";
+		let currentWidth = 0;
+		for (const seg of segmenter.segment(rawLine)) {
+			const grapheme = seg.segment;
+			const graphemeWidth = visibleWidth(grapheme);
+			if (currentWidth > 0 && currentWidth + graphemeWidth > maxWidth) {
+				lines.push(current);
+				current = grapheme;
+				currentWidth = graphemeWidth;
+				continue;
+			}
+			current += grapheme;
+			currentWidth += graphemeWidth;
+		}
+		lines.push(current);
+	}
+	return lines;
+}
+
 const RUNNING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const STATIC_RUNNING_GLYPH = "●";
 
@@ -1370,7 +1397,12 @@ export function renderSubagentResult(
 		const t = result.content[0];
 		const text = t?.type === "text" ? t.text : "(no output)";
 		const contextPrefix = d?.context === "fork" ? `${theme.fg("warning", "[fork]")} ` : "";
-		return new Text(truncLine(`${contextPrefix}${text}`, getTermWidth() - 4), 0, 0);
+		const width = getTermWidth() - 4;
+		if (!text.includes("\n")) return new Text(truncLine(`${contextPrefix}${text}`, width), 0, 0);
+		const c = new Container();
+		const wrapped = wrapPlainText(`${contextPrefix}${text}`, width);
+		for (const line of wrapped) c.addChild(new Text(line, 0, 0));
+		return c;
 	}
 
 	const expanded = options.expanded;

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -311,10 +311,10 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		assert.equal((sent[0] as { display?: boolean }).display, true);
 		assert.equal((sent[0] as { content?: string }).content, "inspect this");
 		assert.equal((sent[1] as { customType?: string; display?: boolean }).customType, SLASH_RESULT_TYPE);
-		assert.equal((sent[1] as { display?: boolean }).display, true);
+		assert.equal((sent[1] as { display?: boolean }).display, false);
 		assert.match((sent[1] as { content?: string }).content ?? "", /Scout finished/);
 		assert.match((sent[1] as { content?: string }).content ?? "", /Child session exports\n\n- `\/tmp\/child-session\.jsonl`/);
-		assert.deepEqual(log, ["send:visible", "status:running...", "send:visible", "status:clear"]);
+		assert.deepEqual(log, ["send:visible", "status:running...", "send:hidden", "status:clear"]);
 
 		const visibleDetails = resolveSlashMessageDetails!((sent[0] as { details?: unknown }).details);
 		assert.ok(visibleDetails);
@@ -400,9 +400,9 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		assert.equal((sent[0] as { display?: boolean }).display, true);
 		assert.equal((sent[0] as { content?: string }).content, "inspect this");
 		assert.equal((sent[1] as { customType?: string; display?: boolean }).customType, SLASH_RESULT_TYPE);
-		assert.equal((sent[1] as { display?: boolean }).display, true);
+		assert.equal((sent[1] as { display?: boolean }).display, false);
 		assert.match((sent[1] as { content?: string }).content ?? "", /Subagent failed/);
-		assert.deepEqual(log, ["send:visible", "status:running...", "send:visible", "status:clear"]);
+		assert.deepEqual(log, ["send:visible", "status:running...", "send:hidden", "status:clear"]);
 
 		const visibleDetails = resolveSlashMessageDetails!((sent[0] as { details?: unknown }).details);
 		assert.ok(visibleDetails);
@@ -822,6 +822,46 @@ Gather context
 	});
 });
 
+
+describe("subagents-models slash command", { skip: !available ? "slash-commands.ts not importable" : undefined }, () => {
+	beforeEach(() => {
+		clearSlashSnapshots?.();
+	});
+
+	it("routes to the models tool action", async () => {
+		const { params } = await captureSlashCommandParams("subagents-models", "", process.cwd());
+		assert.deepEqual(params, { action: "models" });
+	});
+
+	it("passes an optional builtin filter", async () => {
+		const { params } = await captureSlashCommandParams("subagents-models", "scout", process.cwd());
+		assert.deepEqual(params, { action: "models", agent: "scout" });
+	});
+
+	it("rejects invalid builtin filters without launching", async () => {
+		const { params, notifications } = await captureSlashCommandParams("subagents-models", "not-a-builtin", process.cwd());
+		assert.equal(params, undefined);
+		assert.deepEqual(notifications, ["Unknown builtin agent: not-a-builtin"]);
+	});
+
+	it("suggests builtin agent names", async () => {
+		await withIsolatedHome(async () => {
+			const commands = new Map<string, RegisteredSlashCommand>();
+			const pi = {
+				events: createEventBus(),
+				registerCommand(name: string, spec: RegisteredSlashCommand) {
+					commands.set(name, spec);
+				},
+				registerShortcut() {},
+				sendMessage(_message: unknown) {},
+			};
+
+			registerSlashCommands!(pi, createState(process.cwd()));
+			const completions = commands.get("subagents-models")!.getArgumentCompletions!("sc") as Array<{ value: string; label: string }>;
+			assert.deepEqual(completions.map((completion) => completion.value), ["scout"]);
+		});
+	});
+});
 
 describe("subagents-doctor slash command", { skip: !available ? "slash-commands.ts not importable" : undefined }, () => {
 	beforeEach(() => {

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -377,6 +377,70 @@ Drive the failing test first.
 		assert.match(readText(listed), /Invalid JSON chain/);
 	});
 
+	it("reports builtin runtime-loaded model mappings from current session state", () => {
+		const ctx = {
+			cwd: tempDir,
+			modelRegistry: {
+				getAvailable: () => [
+					{ provider: "openai", id: "gpt-5-mini" },
+					{ provider: "anthropic", id: "claude-sonnet-4" },
+				],
+			},
+			model: { provider: "openai", id: "gpt-5-mini" },
+		};
+
+		const result = handleManagementAction("models", {}, ctx);
+		const text = readText(result);
+		assert.equal(result.isError, false);
+		assert.match(text, /^Builtin subagent models/m);
+		assert.match(text, /Current session model:\n  openai\/gpt-5-mini/);
+		assert.match(text, /(?:^|\n)scout\n  model:\n    openai\/gpt-5-mini\n  source: inherits current session model(?:\n|$)/);
+	});
+
+	it("reports override source and disabled builtin state in runtime model mappings", () => {
+		const projectSettingsPath = path.join(tempDir, ".pi", "settings.json");
+		fs.mkdirSync(path.dirname(projectSettingsPath), { recursive: true });
+		fs.writeFileSync(projectSettingsPath, JSON.stringify({
+			subagents: {
+				agentOverrides: {
+					reviewer: { model: "claude-sonnet-4", disabled: true },
+				},
+			},
+		}, null, 2), "utf-8");
+
+		const ctx = {
+			cwd: tempDir,
+			modelRegistry: {
+				getAvailable: () => [
+					{ provider: "openai", id: "gpt-5-mini" },
+					{ provider: "anthropic", id: "claude-sonnet-4" },
+				],
+			},
+			model: { provider: "openai", id: "gpt-5-mini" },
+		};
+
+		const result = handleManagementAction("models", { agent: "reviewer" }, ctx);
+		const text = readText(result);
+		assert.equal(result.isError, false);
+		assert.match(text, /^Builtin subagent model/m);
+		assert.match(text, /Agent: reviewer/);
+		assert.match(text, /Effective model:\n  anthropic\/claude-sonnet-4/);
+		assert.match(text, /Source: project override/);
+		assert.match(text, /Requested model setting:\n  claude-sonnet-4/);
+		assert.match(text, /Disabled: true/);
+		assert.match(text, /Override file:\n  .*\.pi\/settings\.json/);
+	});
+
+	it("rejects unknown builtin filters for runtime model mappings", () => {
+		const result = handleManagementAction("models", { agent: "not-a-builtin" }, {
+			cwd: tempDir,
+			modelRegistry: { getAvailable: () => [] },
+		});
+
+		assert.equal(result.isError, true);
+		assert.match(readText(result), /Builtin agent 'not-a-builtin' not found/);
+	});
+
 	it("creates delegate with its builtin prompt defaults", () => {
 		const result = handleCreate(
 			{ config: { name: "delegate", description: "Delegate helper", scope: "project" } },

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -162,7 +162,7 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		const actionSchema = SubagentParams?.properties?.action;
 		assert.ok(actionSchema, "action schema should exist");
 		assert.equal(actionSchema.type, "string");
-		assert.deepEqual(actionSchema.enum, ["list", "get", "create", "update", "delete", "status", "interrupt", "resume", "append-step", "doctor"]);
+		assert.deepEqual(actionSchema.enum, ["list", "get", "models", "create", "update", "delete", "status", "interrupt", "resume", "append-step", "doctor"]);
 		const description = String(actionSchema.description ?? "");
 		assert.match(description, /Management\/control action/);
 		assert.match(description, /Omit for execution mode/);


### PR DESCRIPTION
Hi, 

 I forked the project because I wanted a quick way to see the actual runtime-loaded model mapping for builtin
 subagents in the current session, without digging through settings files manually.

 This PR adds a new slash command:

 - /subagents-models
 - /subagents-models <builtin-agent>

Which produces output like the following:
```
 Builtin subagent models
 Current session model: openai-codex/gpt-5.4
 context-builder → openai-codex/gpt-5.4-mini — user override
 delegate → openai-codex/gpt-5.3-codex-spark — user override
 oracle → openai-codex/gpt-5.4 — user override
 planner → openai-codex/gpt-5.4-mini — user override
 researcher → openai-codex/gpt-5.4-mini — user override
 reviewer → openai-codex/gpt-5.4 — user override
 scout → openai-codex/gpt-5.3-codex-spark — user override
 worker → openai-codex/gpt-5.4 — user override
 ```

 What it does:
 - shows the effective model for each builtin subagent
 - uses the live runtime resolution path, not raw settings-file parsing
 - indicates the source of each mapping (inherit / override / builtin config)
 - works well in the TUI with compact one-line output per agent

 I also added tests for:
 - command routing/completions
 - runtime model resolution
 - output formatting