### PR TITLE
Show field-level acceptance report parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Resolve the async result watcher directory with `fs.realpathSync.native()` before `fs.watch()` so Windows profiles with 8.3 temp paths do not crash Pi when async subagent results arrive. Thanks to kerushidao (@kerushidao) for #254.
 - Accept structured acceptance reports emitted in JSON-family fences when the fenced body has the acceptance-report shape. Thanks to Suleiman Tawil (@stawils) for #253.
+- Report field-level acceptance-report validation errors instead of a generic parse failure, and clarify array element types in the acceptance prompt. Thanks to Whisperfall (@Whisperfall) for #264 and josephkEA (@josephkEA) for the follow-up reproduction.
 - Keep crowded async subagent widgets at a stable collapsed height in short terminals, reducing destructive full-screen TUI redraws and flicker. Thanks to ssyram (@ssyram) for #186.
 - Added `subagents.disableThinking` so bundled builtin agents can drop thinking suffix defaults for providers that do not accept them. Thanks to Joshua Harding (@jhstatewide) for #212.
 - List configured subagent skills by name, description, and file path instead of inlining full skill bodies, and ensure tool-restricted children can read those skill files on demand. Thanks to Ruben Paz (@Istar-Eldritch) for #183.

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -258,16 +258,19 @@ export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig): st
 	lines.push(
 		"",
 		"Finish with a fenced JSON block tagged `acceptance-report` in this shape:",
+		"Use empty arrays when no items apply; array fields contain strings unless object entries are shown.",
 		"```acceptance-report",
 		JSON.stringify({
 			criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "specific proof" }],
-			changedFiles: [],
-			testsAddedOrUpdated: [],
+			changedFiles: ["src/file.ts"],
+			testsAddedOrUpdated: ["test/file.test.ts"],
 			commandsRun: [{ command: "command", result: "passed", summary: "short result" }],
-			validationOutput: [],
-			residualRisks: [],
+			validationOutput: ["validation output or concise summary"],
+			residualRisks: ["none"],
 			noStagedFiles: true,
-			notes: "anything else the parent should know",
+			diffSummary: "short description of the diff",
+			reviewFindings: ["blocker: file.ts:12 - issue found, or no blockers"],
+			manualNotes: "anything else the parent should know",
 		}, null, 2),
 		"```",
 	);
@@ -353,17 +356,26 @@ function fencedBlocks(output: string, tag: string): string[] {
 		.filter((value): value is string => Boolean(value));
 }
 
-function parseAcceptanceReportBody(body: string): AcceptanceReport | undefined {
+function validationPathLabelForWrapper(value: unknown): string {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return "";
+	const record = value as Record<string, unknown>;
+	if ("acceptance" in record) return "acceptance";
+	if ("acceptance-report" in record) return "acceptance-report";
+	return "";
+}
+
+function parseAcceptanceReportBody(body: string): { report?: AcceptanceReport; errors: string[] } {
 	const parsed = parseReportJson(body);
 	const report = unwrapAcceptanceReport(parsed);
-	return isAcceptanceReport(report) ? report : undefined;
+	return validateAcceptanceReport(report, validationPathLabelForWrapper(parsed));
 }
 
 function parseGenericJsonAcceptanceReportBody(body: string): AcceptanceReport | undefined {
 	const parsed = parseReportJson(body);
 	const report = unwrapAcceptanceReport(parsed);
-	if (!isAcceptanceReport(report)) return undefined;
-	return hasGenericAcceptanceReportSignal(report) ? report : undefined;
+	const validation = validateAcceptanceReport(report);
+	if (!validation.report) return undefined;
+	return hasGenericAcceptanceReportSignal(validation.report) ? validation.report : undefined;
 }
 
 export function parseAcceptanceReport(output: string): { report?: AcceptanceReport; error?: string } {
@@ -371,9 +383,9 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 	const parseErrors: string[] = [];
 	for (const body of fenced) {
 		try {
-			const report = parseAcceptanceReportBody(body);
-			if (report) return { report };
-			parseErrors.push("acceptance-report block does not contain a valid acceptance report");
+			const validation = parseAcceptanceReportBody(body);
+			if (validation.report) return { report: validation.report };
+			parseErrors.push(`Invalid acceptance-report: ${validation.errors.join("; ")}`);
 		} catch (error) {
 			parseErrors.push(error instanceof Error ? error.message : String(error));
 		}
@@ -391,19 +403,21 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 	const markerIndex = output.search(/ACCEPTANCE_REPORT\s*:/i);
 	if (markerIndex !== -1) {
 		const jsonStart = output.indexOf("{", markerIndex);
-		if (jsonStart !== -1) {
-			const json = extractBalancedJson(output, jsonStart);
-			if (json) {
-				try {
-					const parsed = JSON.parse(json) as unknown;
-					const report = unwrapAcceptanceReport(parsed);
-					if (isAcceptanceReport(report)) return { report };
-				} catch (error) {
-					return { error: error instanceof Error ? error.message : String(error) };
+			if (jsonStart !== -1) {
+				const json = extractBalancedJson(output, jsonStart);
+				if (json) {
+					try {
+						const parsed = JSON.parse(json) as unknown;
+						const report = unwrapAcceptanceReport(parsed);
+						const validation = validateAcceptanceReport(report, validationPathLabelForWrapper(parsed));
+						if (validation.report) return { report: validation.report };
+						return { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}` };
+					} catch (error) {
+						return { error: error instanceof Error ? error.message : String(error) };
+					}
 				}
 			}
 		}
-	}
 	return { error: "Structured acceptance report not found." };
 }
 
@@ -434,26 +448,105 @@ function isStringArray(value: unknown): value is string[] {
 	return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
-function isAcceptanceReport(value: unknown): value is AcceptanceReport {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+function pathFor(base: string, segment: string): string {
+	return base ? `${base}.${segment}` : segment;
+}
+
+function describeValidationValue(value: unknown): string {
+	if (value === undefined) return "missing";
+	if (value === null) return "null";
+	if (Array.isArray(value)) return "array";
+	if (typeof value === "object") return "object";
+	if (typeof value === "string") {
+		const short = value.length > 80 ? `${value.slice(0, 77)}...` : value;
+		return JSON.stringify(short);
+	}
+	return `${typeof value} ${String(value)}`;
+}
+
+function pushTypeError(errors: string[], pathLabel: string, expected: string, value: unknown): void {
+	errors.push(`${pathLabel}: expected ${expected}; got ${describeValidationValue(value)}`);
+}
+
+function validateStringArrayField(errors: string[], value: unknown, pathLabel: string): void {
+	if (!Array.isArray(value)) {
+		pushTypeError(errors, pathLabel, "string[]", value);
+		return;
+	}
+	for (const [index, item] of value.entries()) {
+		if (typeof item !== "string") pushTypeError(errors, `${pathLabel}[${index}]`, "string", item);
+	}
+}
+
+function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: AcceptanceReport; errors: string[] } {
+	const errors: string[] = [];
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		pushTypeError(errors, pathLabel || "acceptance-report", "object", value);
+		return { errors };
+	}
 	const report = value as AcceptanceReport;
 	if (report.criteriaSatisfied !== undefined) {
-		if (!Array.isArray(report.criteriaSatisfied)) return false;
-		for (const item of report.criteriaSatisfied) {
-			if (!item || typeof item !== "object" || Array.isArray(item)) return false;
-			const criterion = item as { id?: unknown; status?: unknown; evidence?: unknown };
-			if (criterion.id !== undefined && typeof criterion.id !== "string") return false;
-			if (criterion.status !== "satisfied" && criterion.status !== "not-satisfied" && criterion.status !== "not-applicable") return false;
-			if (typeof criterion.evidence !== "string" || !criterion.evidence.trim()) return false;
+		if (!Array.isArray(report.criteriaSatisfied)) {
+			pushTypeError(errors, pathFor(pathLabel, "criteriaSatisfied"), "array", report.criteriaSatisfied);
+		} else {
+			for (const [index, item] of report.criteriaSatisfied.entries()) {
+				const itemPath = `${pathFor(pathLabel, "criteriaSatisfied")}[${index}]`;
+				if (!item || typeof item !== "object" || Array.isArray(item)) {
+					pushTypeError(errors, itemPath, "object", item);
+					continue;
+				}
+				const criterion = item as { id?: unknown; status?: unknown; evidence?: unknown };
+				if (criterion.id !== undefined && typeof criterion.id !== "string") pushTypeError(errors, `${itemPath}.id`, "string", criterion.id);
+				if (criterion.status !== "satisfied" && criterion.status !== "not-satisfied" && criterion.status !== "not-applicable") {
+					pushTypeError(errors, `${itemPath}.status`, "one of \"satisfied\", \"not-satisfied\", \"not-applicable\"", criterion.status);
+				}
+				if (typeof criterion.evidence !== "string" || !criterion.evidence.trim()) pushTypeError(errors, `${itemPath}.evidence`, "non-empty string", criterion.evidence);
+			}
 		}
 	}
-	return report.criteriaSatisfied !== undefined
+	if (report.changedFiles !== undefined) validateStringArrayField(errors, report.changedFiles, pathFor(pathLabel, "changedFiles"));
+	if (report.testsAddedOrUpdated !== undefined) validateStringArrayField(errors, report.testsAddedOrUpdated, pathFor(pathLabel, "testsAddedOrUpdated"));
+	if (report.commandsRun !== undefined) {
+		if (!Array.isArray(report.commandsRun)) {
+			pushTypeError(errors, pathFor(pathLabel, "commandsRun"), "array", report.commandsRun);
+		} else {
+			for (const [index, item] of report.commandsRun.entries()) {
+				const itemPath = `${pathFor(pathLabel, "commandsRun")}[${index}]`;
+				if (!item || typeof item !== "object" || Array.isArray(item)) {
+					pushTypeError(errors, itemPath, "object", item);
+					continue;
+				}
+				const command = item as { command?: unknown; result?: unknown; summary?: unknown };
+				if (typeof command.command !== "string" || !command.command.trim()) pushTypeError(errors, `${itemPath}.command`, "non-empty string", command.command);
+				if (command.result !== "passed" && command.result !== "failed" && command.result !== "not-run") {
+					pushTypeError(errors, `${itemPath}.result`, "one of \"passed\", \"failed\", \"not-run\"", command.result);
+				}
+				if (typeof command.summary !== "string") pushTypeError(errors, `${itemPath}.summary`, "string", command.summary);
+			}
+		}
+	}
+	if (report.validationOutput !== undefined) validateStringArrayField(errors, report.validationOutput, pathFor(pathLabel, "validationOutput"));
+	if (report.residualRisks !== undefined) validateStringArrayField(errors, report.residualRisks, pathFor(pathLabel, "residualRisks"));
+	if (report.noStagedFiles !== undefined && typeof report.noStagedFiles !== "boolean") pushTypeError(errors, pathFor(pathLabel, "noStagedFiles"), "boolean", report.noStagedFiles);
+	if (report.diffSummary !== undefined && typeof report.diffSummary !== "string") pushTypeError(errors, pathFor(pathLabel, "diffSummary"), "string", report.diffSummary);
+	if (report.reviewFindings !== undefined) validateStringArrayField(errors, report.reviewFindings, pathFor(pathLabel, "reviewFindings"));
+	if (report.manualNotes !== undefined && typeof report.manualNotes !== "string") pushTypeError(errors, pathFor(pathLabel, "manualNotes"), "string", report.manualNotes);
+	if (report.notes !== undefined && typeof report.notes !== "string") pushTypeError(errors, pathFor(pathLabel, "notes"), "string", report.notes);
+	if (errors.length > 0) return { errors };
+	const hasReportField = report.criteriaSatisfied !== undefined
 		|| report.changedFiles !== undefined
 		|| report.testsAddedOrUpdated !== undefined
 		|| report.commandsRun !== undefined
+		|| report.validationOutput !== undefined
 		|| report.residualRisks !== undefined
+		|| report.noStagedFiles !== undefined
+		|| report.diffSummary !== undefined
 		|| report.manualNotes !== undefined
+		|| report.notes !== undefined
 		|| report.reviewFindings !== undefined;
+	return hasReportField
+		? { report, errors }
+		: { errors: [`${pathLabel || "acceptance-report"}: expected at least one acceptance report field`] };
 }
 
 function checkCriteriaSatisfied(criteria: ResolvedAcceptanceGate[], report: AcceptanceReport): AcceptanceRuntimeCheck[] {

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -74,6 +74,8 @@ describe("acceptance gates", () => {
 		assert.match(prompt, /Acceptance level: checked/);
 		assert.match(prompt, /Patch the bug/);
 		assert.match(prompt, /```acceptance-report/);
+		assert.match(prompt, /array fields contain strings/);
+		assert.match(prompt, /"reviewFindings": \[\n    "blocker:/);
 	});
 
 	it("parses acceptance-report fences and ignores unrelated json fences", () => {
@@ -173,6 +175,29 @@ describe("acceptance gates", () => {
 		assert.equal(stripAcceptanceReport(output), "done");
 	});
 
+	it("reports field-level validation errors for malformed acceptance-report fields", () => {
+		const invalidReviewerReport = parseAcceptanceReport(report({
+			reviewFindings: [{ id: "B-1", severity: "blocker", finding: "Missing evidence" }],
+		}));
+		assert.equal(invalidReviewerReport.report, undefined);
+		assert.match(invalidReviewerReport.error ?? "", /reviewFindings\[0\]: expected string; got object/);
+
+		const invalidCommandReport = parseAcceptanceReport(report({
+			commandsRun: [{ command: "npm test", exitCode: 0 }],
+		}));
+		assert.equal(invalidCommandReport.report, undefined);
+		assert.match(invalidCommandReport.error ?? "", /commandsRun\[0\]\.result: expected one of "passed", "failed", "not-run"; got missing/);
+		assert.match(invalidCommandReport.error ?? "", /commandsRun\[0\]\.summary: expected string; got missing/);
+
+		const invalidCriteriaReport = parseAcceptanceReport(report({
+			criteriaSatisfied: [{ id: 7, status: "done", evidence: "" }],
+		}));
+		assert.equal(invalidCriteriaReport.report, undefined);
+		assert.match(invalidCriteriaReport.error ?? "", /criteriaSatisfied\[0\]\.id: expected string; got number 7/);
+		assert.match(invalidCriteriaReport.error ?? "", /criteriaSatisfied\[0\]\.status: expected one of "satisfied", "not-satisfied", "not-applicable"; got "done"/);
+		assert.match(invalidCriteriaReport.error ?? "", /criteriaSatisfied\[0\]\.evidence: expected non-empty string; got ""/);
+	});
+
 	it("explicit none disables inferred gates when a reason is present", () => {
 		const acceptance = resolveEffectiveAcceptance({
 			agentName: "worker",
@@ -200,6 +225,28 @@ describe("acceptance gates", () => {
 
 			assert.equal(ledger.status, "rejected");
 			assert.match(acceptanceFailureMessage(ledger) ?? "", /tests-added evidence missing/);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("surfaces parse validation details in acceptance failure messages", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "reviewer",
+				task: "Review-only. Do not edit.",
+				explicit: { level: "attested", evidence: ["review-findings"] },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: report({ reviewFindings: [{ id: "B-1", finding: "Missing evidence" }] }),
+				cwd,
+			});
+
+			assert.equal(ledger.status, "rejected");
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /Failed to parse acceptance-report/);
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /reviewFindings\[0\]: expected string; got object/);
 		} finally {
 			fs.rmSync(cwd, { recursive: true, force: true });
 		}


### PR DESCRIPTION
Fixes #264.

This replaces the boolean acceptance-report shape check with validation that names the invalid field, expected shape, and actual value. It also updates the acceptance prompt example so string-array fields show their element type, including reviewer findings.

Tests run:
- node --experimental-strip-types --test test/unit/acceptance.test.ts
- npm run test:unit
- npm run test:integration

Review loop: one fresh reviewer pass flagged the changelog credit wording; I fixed it, reran the focused acceptance test, and a final fresh reviewer pass found no actionable issues.