### PR TITLE
Discover nested skill directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Keep crowded async subagent widgets at a stable collapsed height in short terminals, reducing destructive full-screen TUI redraws and flicker. Thanks to ssyram (@ssyram) for #186.
 - Added `subagents.disableThinking` so bundled builtin agents can drop thinking suffix defaults for providers that do not accept them. Thanks to Joshua Harding (@jhstatewide) for #212.
 - List configured subagent skills by name, description, and file path instead of inlining full skill bodies, and ensure tool-restricted children can read those skill files on demand. Thanks to Ruben Paz (@Istar-Eldritch) for #183.
+- Discover nested grouped skills such as `.pi/skills/group/name/SKILL.md` so subagents match the host runtime's recursive skill lookup. Thanks to Weaxs (@Weaxs) for #262.
 - Actually wire the previously documented foreground-only `timeoutMs`/`maxRuntimeMs` aliases through single, parallel, chain, and dynamic fanout runs, including stable `timedOut: true` results, preserved partial output, manual-interrupt precedence, and skipped acceptance verification after timeout.
 - Apply `subagents.agentOverrides.<name>` to matching user-scope and project-scope custom agents, while keeping explicit agent frontmatter authoritative per field. Thanks to Jacek Juraszek (@jjuraszek) for #218.
 - Preserve compact foreground `write`/`edit` tool-call evidence in prompt-template delegation responses so convergence checks do not stop loops early. Thanks to Hans Schnedlitz (@hschne) for #207.

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -394,19 +394,32 @@ function maybeReadSkillDescription(filePath: string): string | undefined {
 
 function collectFilesystemSkills(cwd: string, agentDir: string, skillPaths: SkillSearchPath[]): CachedSkillEntry[] {
 	const entries: CachedSkillEntry[] = [];
-	const seen = new Set<string>();
-	const visitedDirectories = new Set<string>();
+	const seen = new Map<string, number>();
+	const visitedDirectories = new Map<string, number>();
 	let order = 0;
 
 	const pushEntry = (name: string, filePath: string, sourceHint?: SkillSource) => {
 		const resolvedFile = path.resolve(filePath);
-		if (seen.has(resolvedFile)) return;
 		if (!fs.existsSync(resolvedFile)) return;
-		seen.add(resolvedFile);
+		const source = inferSkillSource(resolvedFile, cwd, agentDir, sourceHint);
+		const existingIndex = seen.get(resolvedFile);
+		if (existingIndex !== undefined) {
+			const existing = entries[existingIndex];
+			if (existing && (SOURCE_PRIORITY[source] ?? 0) > (SOURCE_PRIORITY[existing.source] ?? 0)) {
+				entries[existingIndex] = {
+					...existing,
+					name,
+					source,
+					description: maybeReadSkillDescription(resolvedFile),
+				};
+			}
+			return;
+		}
+		seen.set(resolvedFile, entries.length);
 		entries.push({
 			name,
 			filePath: resolvedFile,
-			source: inferSkillSource(resolvedFile, cwd, agentDir, sourceHint),
+			source,
 			description: maybeReadSkillDescription(resolvedFile),
 			order: order++,
 		});
@@ -414,20 +427,22 @@ function collectFilesystemSkills(cwd: string, agentDir: string, skillPaths: Skil
 
 	const shouldSkipDirectory = (name: string) => name.startsWith(".") || name === "node_modules";
 
-	const markDirectoryVisited = (dirPath: string): boolean => {
+	const markDirectoryVisited = (dirPath: string, sourceHint?: SkillSource): boolean => {
 		let resolvedDir: string;
 		try {
 			resolvedDir = fs.realpathSync(dirPath);
 		} catch {
 			resolvedDir = path.resolve(dirPath);
 		}
-		if (visitedDirectories.has(resolvedDir)) return false;
-		visitedDirectories.add(resolvedDir);
+		const priority = sourceHint ? SOURCE_PRIORITY[sourceHint] ?? 0 : SOURCE_PRIORITY.unknown;
+		const previousPriority = visitedDirectories.get(resolvedDir);
+		if (previousPriority !== undefined && previousPriority >= priority) return false;
+		visitedDirectories.set(resolvedDir, priority);
 		return true;
 	};
 
 	const walkSkillDirectories = (dirPath: string, sourceHint?: SkillSource) => {
-		if (!markDirectoryVisited(dirPath)) return;
+		if (!markDirectoryVisited(dirPath, sourceHint)) return;
 
 		const skillFile = path.join(dirPath, "SKILL.md");
 		if (fs.existsSync(skillFile)) {
@@ -487,7 +502,7 @@ function collectFilesystemSkills(cwd: string, agentDir: string, skillPaths: Skil
 			continue;
 		}
 
-		markDirectoryVisited(skillPath.path);
+		markDirectoryVisited(skillPath.path, skillPath.source);
 
 		let childEntries: fs.Dirent[];
 		try {

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -331,7 +331,8 @@ function buildSkillPaths(cwd: string, agentDir: string): SkillSearchPath[] {
 	const deduped = new Map<string, SkillSearchPath>();
 	for (const entry of skillPaths) {
 		const resolvedPath = path.resolve(entry.path);
-		if (!deduped.has(resolvedPath)) {
+		const existing = deduped.get(resolvedPath);
+		if (!existing || (SOURCE_PRIORITY[entry.source] ?? 0) > (SOURCE_PRIORITY[existing.source] ?? 0)) {
 			deduped.set(resolvedPath, { path: resolvedPath, source: entry.source });
 		}
 	}

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -395,6 +395,7 @@ function maybeReadSkillDescription(filePath: string): string | undefined {
 function collectFilesystemSkills(cwd: string, agentDir: string, skillPaths: SkillSearchPath[]): CachedSkillEntry[] {
 	const entries: CachedSkillEntry[] = [];
 	const seen = new Set<string>();
+	const visitedDirectories = new Set<string>();
 	let order = 0;
 
 	const pushEntry = (name: string, filePath: string, sourceHint?: SkillSource) => {
@@ -409,6 +410,53 @@ function collectFilesystemSkills(cwd: string, agentDir: string, skillPaths: Skil
 			description: maybeReadSkillDescription(resolvedFile),
 			order: order++,
 		});
+	};
+
+	const shouldSkipDirectory = (name: string) => name.startsWith(".") || name === "node_modules";
+
+	const markDirectoryVisited = (dirPath: string): boolean => {
+		let resolvedDir: string;
+		try {
+			resolvedDir = fs.realpathSync(dirPath);
+		} catch {
+			resolvedDir = path.resolve(dirPath);
+		}
+		if (visitedDirectories.has(resolvedDir)) return false;
+		visitedDirectories.add(resolvedDir);
+		return true;
+	};
+
+	const walkSkillDirectories = (dirPath: string, sourceHint?: SkillSource) => {
+		if (!markDirectoryVisited(dirPath)) return;
+
+		const skillFile = path.join(dirPath, "SKILL.md");
+		if (fs.existsSync(skillFile)) {
+			pushEntry(path.basename(dirPath), skillFile, sourceHint);
+			return;
+		}
+
+		let entriesInDir: fs.Dirent[];
+		try {
+			entriesInDir = fs.readdirSync(dirPath, { withFileTypes: true });
+		} catch {
+			return;
+		}
+
+		for (const entry of entriesInDir) {
+			if (shouldSkipDirectory(entry.name)) continue;
+			if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+
+			const entryPath = path.join(dirPath, entry.name);
+			let stat: fs.Stats;
+			try {
+				stat = fs.statSync(entryPath);
+			} catch {
+				continue;
+			}
+			if (stat.isDirectory()) {
+				walkSkillDirectories(entryPath, sourceHint);
+			}
+		}
 	};
 
 	for (const skillPath of skillPaths) {
@@ -436,7 +484,10 @@ function collectFilesystemSkills(cwd: string, agentDir: string, skillPaths: Skil
 		const rootSkillFile = path.join(skillPath.path, "SKILL.md");
 		if (fs.existsSync(rootSkillFile)) {
 			pushEntry(path.basename(skillPath.path), rootSkillFile, skillPath.source);
+			continue;
 		}
+
+		markDirectoryVisited(skillPath.path);
 
 		let childEntries: fs.Dirent[];
 		try {
@@ -449,10 +500,14 @@ function collectFilesystemSkills(cwd: string, agentDir: string, skillPaths: Skil
 			if (child.name.startsWith(".")) continue;
 			const childPath = path.join(skillPath.path, child.name);
 			if (child.isDirectory() || child.isSymbolicLink()) {
-				const nestedSkillPath = path.join(childPath, "SKILL.md");
-				if (fs.existsSync(nestedSkillPath)) {
-					pushEntry(child.name, nestedSkillPath, skillPath.source);
+				if (shouldSkipDirectory(child.name)) continue;
+				let childStat: fs.Stats;
+				try {
+					childStat = fs.statSync(childPath);
+				} catch {
+					continue;
 				}
+				if (childStat.isDirectory()) walkSkillDirectories(childPath, skillPath.source);
 				continue;
 			}
 			if (child.isFile() && child.name.toLowerCase().endsWith(".md")) {

--- a/test/unit/skills-fallback.test.ts
+++ b/test/unit/skills-fallback.test.ts
@@ -132,6 +132,30 @@ describe("skills filesystem fallback", () => {
 		assert.match(resolved[0]?.content ?? "", /Use direct markdown skill\./);
 	});
 
+	it("keeps nested skills from higher-priority explicit settings roots after parent recursion", () => {
+		writeSkillFile(
+			path.join(tempDir, "skills", "group", "issue-262-settings-nested"),
+			"Use settings nested skill.",
+		);
+		fs.writeFileSync(
+			path.join(tempDir, "package.json"),
+			JSON.stringify({ name: "fixture", version: "1.0.0", pi: { skills: ["./skills"] } }, null, 2),
+			"utf-8",
+		);
+		fs.mkdirSync(path.join(tempDir, ".pi"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, ".pi", "settings.json"),
+			JSON.stringify({ skills: ["../skills/group"] }, null, 2),
+			"utf-8",
+		);
+
+		const { resolved, missing } = resolveSkills(["issue-262-settings-nested"], tempDir);
+		assert.deepEqual(missing, []);
+		assert.equal(resolved.length, 1);
+		assert.equal(resolved[0]?.source, "project-settings");
+		assert.match(resolved[0]?.content ?? "", /Use settings nested skill\./);
+	});
+
 	it("resolves and reads skill content via filesystem fallback", () => {
 		makeProjectSkill(tempDir, "resolve-skill", "Run local fallback checks.");
 

--- a/test/unit/skills-fallback.test.ts
+++ b/test/unit/skills-fallback.test.ts
@@ -156,6 +156,30 @@ describe("skills filesystem fallback", () => {
 		assert.match(resolved[0]?.content ?? "", /Use settings nested skill\./);
 	});
 
+	it("keeps nested skills from higher-priority explicit settings roots when the root path is duplicated", () => {
+		writeSkillFile(
+			path.join(tempDir, "skills", "group", "issue-262-settings-same-root"),
+			"Use settings same root skill.",
+		);
+		fs.writeFileSync(
+			path.join(tempDir, "package.json"),
+			JSON.stringify({ name: "fixture", version: "1.0.0", pi: { skills: ["./skills"] } }, null, 2),
+			"utf-8",
+		);
+		fs.mkdirSync(path.join(tempDir, ".pi"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, ".pi", "settings.json"),
+			JSON.stringify({ skills: ["../skills"] }, null, 2),
+			"utf-8",
+		);
+
+		const { resolved, missing } = resolveSkills(["issue-262-settings-same-root"], tempDir);
+		assert.deepEqual(missing, []);
+		assert.equal(resolved.length, 1);
+		assert.equal(resolved[0]?.source, "project-settings");
+		assert.match(resolved[0]?.content ?? "", /Use settings same root skill\./);
+	});
+
 	it("resolves and reads skill content via filesystem fallback", () => {
 		makeProjectSkill(tempDir, "resolve-skill", "Run local fallback checks.");
 

--- a/test/unit/skills-fallback.test.ts
+++ b/test/unit/skills-fallback.test.ts
@@ -14,14 +14,18 @@ import {
 
 let tempDir = "";
 
-function makeProjectSkill(cwd: string, name: string, body: string, description = "Test description"): void {
-	const skillDir = path.join(cwd, ".pi", "skills", name);
+function writeSkillFile(skillDir: string, body: string, description = "Test description"): void {
 	fs.mkdirSync(skillDir, { recursive: true });
 	fs.writeFileSync(
 		path.join(skillDir, "SKILL.md"),
 		`---\ndescription: ${description}\n---\n\n${body}\n`,
 		"utf-8",
 	);
+}
+
+function makeProjectSkill(cwd: string, name: string, body: string, description = "Test description"): void {
+	const skillDir = path.join(cwd, ".pi", "skills", name);
+	writeSkillFile(skillDir, body, description);
 }
 
 function makeProjectPackageSkill(cwd: string, packageName: string, name: string, body: string): void {
@@ -66,6 +70,66 @@ describe("skills filesystem fallback", () => {
 		assert.ok(discovered, "expected fallback-skill to be discovered");
 		assert.equal(discovered?.source, "project");
 		assert.equal(discovered?.description, "Test description");
+	});
+
+	it("discovers project skills nested below grouping directories", () => {
+		writeSkillFile(
+			path.join(tempDir, ".pi", "skills", "shell", "issue-262-nested-skill"),
+			"Use nested project skill.",
+			"Nested issue 262 skill",
+		);
+
+		const skills = discoverAvailableSkills(tempDir);
+		const discovered = skills.find((skill) => skill.name === "issue-262-nested-skill");
+		assert.ok(discovered, "expected grouped nested skill to be discovered");
+		assert.equal(discovered?.source, "project");
+		assert.equal(discovered?.description, "Nested issue 262 skill");
+
+		const { resolved, missing } = resolveSkills(["issue-262-nested-skill"], tempDir);
+		assert.deepEqual(missing, []);
+		assert.equal(resolved.length, 1);
+		assert.match(resolved[0]?.content ?? "", /Use nested project skill\./);
+	});
+
+	it("stops recursive project skill discovery at the first SKILL.md anchor", () => {
+		const groupedRoot = path.join(tempDir, ".pi", "skills", "group");
+		writeSkillFile(path.join(groupedRoot, "issue-262-anchor"), "Use anchor skill.");
+		writeSkillFile(path.join(groupedRoot, "issue-262-anchor", "nested", "issue-262-leaked-skill"), "Should not leak.");
+		writeSkillFile(path.join(groupedRoot, "issue-262-sibling"), "Use sibling skill.");
+
+		const names = discoverAvailableSkills(tempDir).map((skill) => skill.name);
+		assert.equal(names.includes("issue-262-anchor"), true);
+		assert.equal(names.includes("issue-262-sibling"), true);
+		assert.equal(names.includes("issue-262-leaked-skill"), false);
+	});
+
+	it("skips hidden directories and node_modules while recursing for project skills", () => {
+		const groupedRoot = path.join(tempDir, ".pi", "skills", "group");
+		writeSkillFile(path.join(groupedRoot, ".hidden", "issue-262-hidden-skill"), "Should stay hidden.");
+		writeSkillFile(path.join(groupedRoot, "node_modules", "issue-262-node-skill"), "Should stay ignored.");
+		writeSkillFile(path.join(groupedRoot, "visible", "issue-262-visible-skill"), "Use visible nested skill.");
+
+		const names = discoverAvailableSkills(tempDir).map((skill) => skill.name);
+		assert.equal(names.includes("issue-262-visible-skill"), true);
+		assert.equal(names.includes("issue-262-hidden-skill"), false);
+		assert.equal(names.includes("issue-262-node-skill"), false);
+	});
+
+	it("keeps direct markdown skills from explicit settings roots after parent recursion", () => {
+		const groupedRoot = path.join(tempDir, ".pi", "skills", "group");
+		fs.mkdirSync(groupedRoot, { recursive: true });
+		fs.writeFileSync(path.join(groupedRoot, "issue-262-direct.md"), "Use direct markdown skill.\n", "utf-8");
+		fs.writeFileSync(
+			path.join(tempDir, ".pi", "settings.json"),
+			JSON.stringify({ skills: ["./skills/group"] }, null, 2),
+			"utf-8",
+		);
+
+		const { resolved, missing } = resolveSkills(["issue-262-direct"], tempDir);
+		assert.deepEqual(missing, []);
+		assert.equal(resolved.length, 1);
+		assert.equal(resolved[0]?.source, "project-settings");
+		assert.match(resolved[0]?.content ?? "", /Use direct markdown skill\./);
 	});
 
 	it("resolves and reads skill content via filesystem fallback", () => {


### PR DESCRIPTION
Fixes #262.

Subagents now recurse through configured filesystem skill roots to find nested `SKILL.md` anchors, while still stopping at the first skill root and skipping hidden directories and `node_modules`. Direct markdown skills from explicit settings roots keep working when a parent scan has already walked that directory, and higher-priority explicit settings roots can still classify nested skills correctly when the same tree was first seen through a lower-priority package path.

Tests run:
- `node --experimental-strip-types --test test/unit/skills-fallback.test.ts`
- `npm run test:unit`
- `npm run test:integration`

Fresh review loop: the first reviewer found a real source-precedence issue around explicit settings roots after parent recursion. I fixed it with a focused regression test, reran the local suites, and pushed the update. A second fresh reviewer found no blockers. Hosted Ubuntu and Windows checks are green.
