### PR TITLE
Accept JSON-fenced acceptance reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Resolve the async result watcher directory with `fs.realpathSync.native()` before `fs.watch()` so Windows profiles with 8.3 temp paths do not crash Pi when async subagent results arrive. Thanks to kerushidao (@kerushidao) for #254.
+- Accept structured acceptance reports emitted in JSON-family fences when the fenced body has the acceptance-report shape. Thanks to Suleiman Tawil (@stawils) for #253.
 - Keep crowded async subagent widgets at a stable collapsed height in short terminals, reducing destructive full-screen TUI redraws and flicker. Thanks to ssyram (@ssyram) for #186.
 - Added `subagents.disableThinking` so bundled builtin agents can drop thinking suffix defaults for providers that do not accept them. Thanks to Joshua Harding (@jhstatewide) for #212.
 - List configured subagent skills by name, description, and file path instead of inlining full skill bodies, and ensure tool-restricted children can read those skill files on demand. Thanks to Ruben Paz (@Istar-Eldritch) for #183.

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -299,24 +299,74 @@ function extractBalancedJson(text: string, start: number): string | undefined {
 	return undefined;
 }
 
-export function parseAcceptanceReport(output: string): { report?: AcceptanceReport; error?: string } {
-	const fenced = [...output.matchAll(/```acceptance-report\s*\n([\s\S]*?)```/gi)]
+function unwrapAcceptanceReport(value: unknown): unknown {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+	const record = value as { acceptance?: unknown; "acceptance-report"?: unknown };
+	if ("acceptance" in record) return record.acceptance;
+	if ("acceptance-report" in record) return record["acceptance-report"];
+	return value;
+}
+
+function hasAcceptanceReportWrapper(value: unknown): boolean {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value) && ("acceptance" in value || "acceptance-report" in value));
+}
+
+function parseReportJson(body: string): unknown {
+	const trimmed = body.trim();
+	try {
+		return JSON.parse(trimmed) as unknown;
+	} catch (error) {
+		const jsonStart = trimmed.indexOf("{");
+		if (jsonStart > 0) {
+			const json = extractBalancedJson(trimmed, jsonStart);
+			if (json) return JSON.parse(json) as unknown;
+		}
+		throw error;
+	}
+}
+
+function fencedBlocks(output: string, tag: string): string[] {
+	return [...output.matchAll(new RegExp(`\`\`\`${tag}\\s*\\n([\\s\\S]*?)\`\`\``, "gi"))]
 		.map((match) => match[1]?.trim())
 		.filter((value): value is string => Boolean(value));
+}
+
+function parseAcceptanceReportBody(body: string): AcceptanceReport | undefined {
+	const parsed = parseReportJson(body);
+	const report = unwrapAcceptanceReport(parsed);
+	return isAcceptanceReport(report) ? report : undefined;
+}
+
+function parseGenericJsonAcceptanceReportBody(body: string): AcceptanceReport | undefined {
+	const parsed = parseReportJson(body);
+	const report = unwrapAcceptanceReport(parsed);
+	if (!isAcceptanceReport(report)) return undefined;
+	if (hasAcceptanceReportWrapper(parsed)) return report;
+	return report.criteriaSatisfied !== undefined ? report : undefined;
+}
+
+export function parseAcceptanceReport(output: string): { report?: AcceptanceReport; error?: string } {
+	const fenced = fencedBlocks(output, "acceptance-report");
 	const parseErrors: string[] = [];
 	for (const body of fenced) {
 		try {
-			const parsed = JSON.parse(body) as unknown;
-			const report = (parsed && typeof parsed === "object" && "acceptance" in parsed)
-				? (parsed as { acceptance?: unknown }).acceptance
-				: parsed;
-			if (isAcceptanceReport(report)) return { report };
+			const report = parseAcceptanceReportBody(body);
+			if (report) return { report };
 			parseErrors.push("acceptance-report block does not contain a valid acceptance report");
 		} catch (error) {
 			parseErrors.push(error instanceof Error ? error.message : String(error));
 		}
 	}
 	if (parseErrors.length > 0) return { error: `Failed to parse acceptance-report: ${parseErrors.join("; ")}` };
+	for (const body of fencedBlocks(output, "(?:json|jsonc|json5)")) {
+		try {
+			const report = parseGenericJsonAcceptanceReportBody(body);
+			if (report) return { report };
+		} catch {
+			// Ignore unrelated or malformed generic JSON fences; only explicit
+			// acceptance-report fences should turn parse failures into blockers.
+		}
+	}
 	const markerIndex = output.search(/ACCEPTANCE_REPORT\s*:/i);
 	if (markerIndex !== -1) {
 		const jsonStart = output.indexOf("{", markerIndex);
@@ -325,7 +375,8 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 			if (json) {
 				try {
 					const parsed = JSON.parse(json) as unknown;
-					if (isAcceptanceReport(parsed)) return { report: parsed };
+					const report = unwrapAcceptanceReport(parsed);
+					if (isAcceptanceReport(report)) return { report };
 				} catch (error) {
 					return { error: error instanceof Error ? error.message : String(error) };
 				}
@@ -336,6 +387,16 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 }
 
 export function stripAcceptanceReport(output: string): string {
+	const trailingFence = output.match(/\n?```(acceptance-report|json|jsonc|json5)\s*\n([\s\S]*?)```\s*$/i);
+	if (trailingFence?.index !== undefined) {
+		const tag = trailingFence[1]?.toLowerCase();
+		if (tag === "acceptance-report") return output.slice(0, trailingFence.index).trimEnd();
+		try {
+			if (trailingFence[2] && parseGenericJsonAcceptanceReportBody(trailingFence[2])) return output.slice(0, trailingFence.index).trimEnd();
+		} catch {
+			// Leave unrelated or malformed generic JSON fences visible.
+		}
+	}
 	return output
 		.replace(/\n?```acceptance-report\s*\n[\s\S]*?```\s*$/i, "")
 		.replace(/\n?ACCEPTANCE_REPORT\s*:\s*\{[\s\S]*\}\s*$/i, "")

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -307,8 +307,30 @@ function unwrapAcceptanceReport(value: unknown): unknown {
 	return value;
 }
 
-function hasAcceptanceReportWrapper(value: unknown): boolean {
-	return Boolean(value && typeof value === "object" && !Array.isArray(value) && ("acceptance" in value || "acceptance-report" in value));
+function isCommandsRunArray(value: unknown): value is NonNullable<AcceptanceReport["commandsRun"]> {
+	return Array.isArray(value) && value.every((item) => {
+		if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+		const command = item as { command?: unknown; result?: unknown; summary?: unknown };
+		return typeof command.command === "string"
+			&& (command.result === "passed" || command.result === "failed" || command.result === "not-run")
+			&& typeof command.summary === "string";
+	});
+}
+
+function hasGenericAcceptanceReportSignal(value: unknown): boolean {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	return "criteriaSatisfied" in record && (
+		isStringArray(record.changedFiles)
+		|| isStringArray(record.testsAddedOrUpdated)
+		|| isCommandsRunArray(record.commandsRun)
+		|| isStringArray(record.validationOutput)
+		|| isStringArray(record.residualRisks)
+		|| typeof record.noStagedFiles === "boolean"
+		|| typeof record.diffSummary === "string"
+		|| isStringArray(record.reviewFindings)
+		|| typeof record.manualNotes === "string"
+	);
 }
 
 function parseReportJson(body: string): unknown {
@@ -341,8 +363,7 @@ function parseGenericJsonAcceptanceReportBody(body: string): AcceptanceReport | 
 	const parsed = parseReportJson(body);
 	const report = unwrapAcceptanceReport(parsed);
 	if (!isAcceptanceReport(report)) return undefined;
-	if (hasAcceptanceReportWrapper(parsed)) return report;
-	return report.criteriaSatisfied !== undefined ? report : undefined;
+	return hasGenericAcceptanceReportSignal(report) ? report : undefined;
 }
 
 export function parseAcceptanceReport(output: string): { report?: AcceptanceReport; error?: string } {
@@ -387,12 +408,18 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 }
 
 export function stripAcceptanceReport(output: string): string {
-	const trailingFence = output.match(/\n?```(acceptance-report|json|jsonc|json5)\s*\n([\s\S]*?)```\s*$/i);
-	if (trailingFence?.index !== undefined) {
-		const tag = trailingFence[1]?.toLowerCase();
-		if (tag === "acceptance-report") return output.slice(0, trailingFence.index).trimEnd();
+	const trailingFencePattern = /\n?```(acceptance-report|json|jsonc|json5)\s*\n([\s\S]*?)```\s*/gi;
+	let trailingFence: { index: number; tag: string; body: string } | undefined;
+	for (const match of output.matchAll(trailingFencePattern)) {
+		const end = (match.index ?? 0) + match[0].length;
+		if (output.slice(end).trim().length === 0 && match[1] && match[2]) {
+			trailingFence = { index: match.index ?? 0, tag: match[1].toLowerCase(), body: match[2] };
+		}
+	}
+	if (trailingFence) {
+		if (trailingFence.tag === "acceptance-report") return output.slice(0, trailingFence.index).trimEnd();
 		try {
-			if (trailingFence[2] && parseGenericJsonAcceptanceReportBody(trailingFence[2])) return output.slice(0, trailingFence.index).trimEnd();
+			if (parseGenericJsonAcceptanceReportBody(trailingFence.body)) return output.slice(0, trailingFence.index).trimEnd();
 		} catch {
 			// Leave unrelated or malformed generic JSON fences visible.
 		}

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -10,24 +10,29 @@ import {
 	formatAcceptancePrompt,
 	parseAcceptanceReport,
 	resolveEffectiveAcceptance,
+	stripAcceptanceReport,
 	validateAcceptanceInput,
 } from "../../src/runs/shared/acceptance.ts";
 
-function report(overrides: Record<string, unknown> = {}): string {
+function reportData(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "verified in test" }],
+		changedFiles: ["src/file.ts"],
+		testsAddedOrUpdated: ["test/file.test.ts"],
+		commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+		validationOutput: ["tests passed"],
+		residualRisks: [],
+		noStagedFiles: true,
+		notes: "complete",
+		...overrides,
+	};
+}
+
+function report(overrides: Record<string, unknown> = {}, fence = "acceptance-report"): string {
 	return [
 		"done",
-		"```acceptance-report",
-		JSON.stringify({
-			criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "verified in test" }],
-			changedFiles: ["src/file.ts"],
-			testsAddedOrUpdated: ["test/file.test.ts"],
-			commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
-			validationOutput: ["tests passed"],
-			residualRisks: [],
-			noStagedFiles: true,
-			notes: "complete",
-			...overrides,
-		}),
+		`\`\`\`${fence}`,
+		JSON.stringify(reportData(overrides)),
 		"```",
 	].join("\n");
 }
@@ -71,7 +76,7 @@ describe("acceptance gates", () => {
 		assert.match(prompt, /```acceptance-report/);
 	});
 
-	it("parses only explicit acceptance-report fences", () => {
+	it("parses acceptance-report fences and ignores unrelated json fences", () => {
 		const parsed = parseAcceptanceReport(report());
 
 		assert.ok(parsed.report);
@@ -84,9 +89,43 @@ describe("acceptance gates", () => {
 		assert.equal(genericJson.report, undefined);
 		assert.match(genericJson.error ?? "", /Structured acceptance report not found/);
 
+		const reportShapedJson = `done\n\
+\
+\`\`\`json\n{\"changedFiles\":[\"src/file.ts\"]}\n\`\`\``;
+		const genericReportShapedJson = parseAcceptanceReport(reportShapedJson);
+		assert.equal(genericReportShapedJson.report, undefined);
+		assert.match(genericReportShapedJson.error ?? "", /Structured acceptance report not found/);
+		assert.equal(stripAcceptanceReport(reportShapedJson), reportShapedJson);
+
 		const malformed = parseAcceptanceReport("```acceptance-report\n{bad-json\n```");
 		assert.equal(malformed.report, undefined);
 		assert.match(malformed.error ?? "", /Failed to parse acceptance-report/);
+	});
+
+	it("parses acceptance reports from json-family fences", () => {
+		for (const fence of ["json", "jsonc", "json5"]) {
+			const output = report({}, fence);
+			const parsed = parseAcceptanceReport(output);
+
+			assert.ok(parsed.report);
+			assert.deepEqual(parsed.report.changedFiles, ["src/file.ts"]);
+			assert.equal(parsed.error, undefined);
+			assert.equal(stripAcceptanceReport(output), "done");
+		}
+	});
+
+	it("unwraps acceptance-report wrapper objects", () => {
+		const output = [
+			"done",
+			"```json",
+			JSON.stringify({ "acceptance-report": reportData() }),
+			"```",
+		].join("\n");
+		const parsed = parseAcceptanceReport(output);
+
+		assert.ok(parsed.report);
+		assert.deepEqual(parsed.report.testsAddedOrUpdated, ["test/file.test.ts"]);
+		assert.equal(stripAcceptanceReport(output), "done");
 	});
 
 	it("explicit none disables inferred gates when a reason is present", () => {

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -89,6 +89,28 @@ describe("acceptance gates", () => {
 		assert.equal(genericJson.report, undefined);
 		assert.match(genericJson.error ?? "", /Structured acceptance report not found/);
 
+		const criteriaOnlyJson = parseAcceptanceReport(`done\n\
+\
+\`\`\`json\n{\"criteriaSatisfied\":[{\"id\":\"criterion-1\",\"status\":\"satisfied\",\"evidence\":\"example\"}]}\n\`\`\``);
+		assert.equal(criteriaOnlyJson.report, undefined);
+		assert.match(criteriaOnlyJson.error ?? "", /Structured acceptance report not found/);
+
+		const invalidSignalJson = `done\n\
+\
+\`\`\`json\n{\"criteriaSatisfied\":[{\"id\":\"criterion-1\",\"status\":\"satisfied\",\"evidence\":\"example\"}],\"changedFiles\":false}\n\`\`\``;
+		const genericJsonWithInvalidSignal = parseAcceptanceReport(invalidSignalJson);
+		assert.equal(genericJsonWithInvalidSignal.report, undefined);
+		assert.match(genericJsonWithInvalidSignal.error ?? "", /Structured acceptance report not found/);
+		assert.equal(stripAcceptanceReport(invalidSignalJson), invalidSignalJson);
+
+		const partialWrapperJson = `done\n\
+\
+\`\`\`json\n{\"acceptance\":{\"changedFiles\":[\"src/file.ts\"]}}\n\`\`\``;
+		const genericJsonWithPartialWrapper = parseAcceptanceReport(partialWrapperJson);
+		assert.equal(genericJsonWithPartialWrapper.report, undefined);
+		assert.match(genericJsonWithPartialWrapper.error ?? "", /Structured acceptance report not found/);
+		assert.equal(stripAcceptanceReport(partialWrapperJson), partialWrapperJson);
+
 		const reportShapedJson = `done\n\
 \
 \`\`\`json\n{\"changedFiles\":[\"src/file.ts\"]}\n\`\`\``;
@@ -112,6 +134,29 @@ describe("acceptance gates", () => {
 			assert.equal(parsed.error, undefined);
 			assert.equal(stripAcceptanceReport(output), "done");
 		}
+	});
+
+	it("strips trailing json-family reports after earlier unrelated json fences", () => {
+		const output = [
+			"metadata",
+			"```json",
+			JSON.stringify({ notes: "not an acceptance report" }),
+			"```",
+			"done",
+			"```json",
+			JSON.stringify(reportData()),
+			"```",
+		].join("\n");
+		const parsed = parseAcceptanceReport(output);
+
+		assert.ok(parsed.report);
+		assert.equal(stripAcceptanceReport(output), [
+			"metadata",
+			"```json",
+			JSON.stringify({ notes: "not an acceptance report" }),
+			"```",
+			"done",
+		].join("\n"));
 	});
 
 	it("unwraps acceptance-report wrapper objects", () => {


### PR DESCRIPTION
Refs #253.

This accepts structured acceptance reports when models put the report in `json`, `jsonc`, or `json5` fences, while still ignoring unrelated generic JSON. Generic fences now need `criteriaSatisfied` plus another well-formed acceptance-report field; explicit `acceptance-report` fences keep the existing behavior. Accepted JSON-family reports are stripped from the visible output, including when earlier unrelated JSON fences appear.

I kept this scoped to parser and wrapper handling. PR #305 touches the same files and will need ordinary conflict resolution if it lands first, but it does not cover JSON-family fences.

Tests run:
- `node --experimental-strip-types --test test/unit/acceptance.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `git diff --check`

Review loop: fresh xhigh reviewers found and I fixed a criteria-only generic JSON false positive, a trailing-strip issue with earlier JSON fences, invalid signal-field acceptance, and a partial-wrapper bypass. A final fresh xhigh pass found no blockers or fixes worth doing now.