### PR TITLE
feat: pi permission system integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,77 @@ For normal use, you do not need to configure anything. Advanced users can tune t
 
 At this point, you know enough to use the plugin. The rest of this README is reference material for exact command syntax, custom agents, saved chains, worktrees, and configuration.
 
+## Optional pi-permission-system integration
+
+[`@gotgenes/pi-permission-system`](https://github.com/gotgenes/pi-packages/tree/main/packages/pi-permission-system)
+adds a second policy layer — `allow` / `ask` / `deny` — on top of
+pi-subagents' visibility-based tool restrictions.
+
+The two compose independently:
+
+| Layer | What it controls | Who provides it |
+|-------|-----------------|-----------------|
+| Visibility | Which tools are registered before the session starts | pi-subagents (`tools:` frontmatter key) |
+| Policy  | Runtime allow/ask/deny decisions on every tool call, bash command, MCP operation | pi-permission-system (`permission:` frontmatter key) |
+
+### Installing
+
+```bash
+pi install npm:@gotgenes/pi-permission-system
+```
+
+No configuration is required for the integration — it is automatic when both
+extensions are installed. pi-subagents passes the parent session identity
+to child processes via the `PI_SUBAGENT_PARENT_SESSION` environment variable,
+which the permission system uses to forward `ask` prompts from headless
+subagent processes back to the parent session's UI.
+
+### Per-agent permission frontmatter
+
+Agent files can include a `permission:` block alongside the standard `tools:`
+key. The permission system reads it independently:
+
+```yaml
+---
+name: worker
+tools: bash,read,write,edit
+permission:
+  "*": ask
+  read: allow
+  bash:
+    "*": ask
+    "git *": allow
+    "npm test": allow
+---
+```
+
+In this example the subagent extension restricts visibility to four tools,
+and the permission system then applies `ask`/`allow` policy within that
+visible set. Both keys coexist without collision.
+
+### Checking the integration
+
+Run `/subagents-doctor` to check the permission system status.
+If `ask` prompts from children are not reaching the parent UI, verify both
+extensions are installed:
+
+```bash
+pi list
+```
+
+### How it works
+
+At session start, pi-subagents records the current session identity in
+`PI_SUBAGENT_PARENT_SESSION`. Every child subprocess inherits this variable
+from the process environment. When the permission system inside a child
+encounters an `ask` permission, it reads this variable to locate the parent
+session and forwards the confirmation request there. The parent session's
+UI prompts the user, and the decision flows back to the child.
+
+For nested subagents (depth > 1), the forwarding chain goes directly to the
+root UI session. The permission system includes agent-name metadata in every
+forwarded request so the parent knows which child triggered it.
+
 ## Direct commands
 
 Skip this section until you want exact syntax.

--- a/README.md
+++ b/README.md
@@ -297,16 +297,18 @@ pi list
 
 ### How it works
 
-At session start, pi-subagents records the current session identity in
-`PI_SUBAGENT_PARENT_SESSION`. Every child subprocess inherits this variable
-from the process environment. When the permission system inside a child
+At session start, the interactive (root) session records its own identity in
+`PI_SUBAGENT_PARENT_SESSION`. When pi-subagents launches a child, it passes the
+launching session's identity to that child explicitly, falling back to the
+inherited environment variable. When the permission system inside a child
 encounters an `ask` permission, it reads this variable to locate the parent
-session and forwards the confirmation request there. The parent session's
-UI prompts the user, and the decision flows back to the child.
+session and forwards the confirmation request there.
 
-For nested subagents (depth > 1), the forwarding chain goes directly to the
-root UI session. The permission system includes agent-name metadata in every
-forwarded request so the parent knows which child triggered it.
+This resolves an interactive prompt only when the parent it points at is the
+interactive session — i.e. for the direct children of the root session. A
+nested child's parent is itself a headless subagent process with no UI to
+surface the prompt, so `ask` policies are best placed on agents that run as
+direct children of the interactive session.
 
 ## Direct commands
 

--- a/src/agents/agent-serializer.ts
+++ b/src/agents/agent-serializer.ts
@@ -81,7 +81,15 @@ export function serializeAgent(config: AgentConfig): string {
 	if (config.extraFields) {
 		for (const [key, value] of Object.entries(config.extraFields)) {
 			if (KNOWN_FIELDS.has(key)) continue;
-			lines.push(`${key}: ${value}`);
+			if (typeof value === "string" && value.includes("\n")) {
+				// Multi-line block value (e.g. permission: nested YAML)
+				lines.push(`${key}:`);
+				for (const blockLine of value.split("\n")) {
+					lines.push(`  ${blockLine}`);
+				}
+			} else {
+				lines.push(`${key}: ${value}`);
+			}
 		}
 	}
 

--- a/src/agents/frontmatter.ts
+++ b/src/agents/frontmatter.ts
@@ -1,3 +1,16 @@
+/**
+ * Escape regex special characters for use in a RegExp constructor.
+ */
+function escapeRegex(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Parse YAML frontmatter from agent/chain files.
+ * Handles both flat (key: value) and nested block (key: \n  sub: val) values.
+ * Block values are stored as single strings with embedded newlines.
+ * The indentation of the block content is preserved relative to the key.
+ */
 export function parseFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
 	const frontmatter: Record<string, string> = {};
 	const normalized = content.replace(/\r\n/g, "\n");
@@ -14,15 +27,66 @@ export function parseFrontmatter(content: string): { frontmatter: Record<string,
 	const frontmatterBlock = normalized.slice(4, endIndex);
 	const body = normalized.slice(endIndex + 4).trim();
 
-	for (const line of frontmatterBlock.split("\n")) {
+	const lines = frontmatterBlock.split("\n");
+	let currentKey: string | null = null;
+	let currentBlockLines: string[] | null = null;
+	let currentIndent: number | null = null;
+
+	for (const line of lines) {
+		const indent = line.search(/\S|$/); // position of first non-whitespace char
+		const trimmed = line.trim();
+
+		if (currentKey !== null && currentBlockLines !== null && indent > (currentIndent ?? 0)) {
+			// This line is part of the current block value
+			currentBlockLines.push(line);
+			continue;
+		}
+
+		// Flush any pending block value
+		if (currentKey !== null && currentBlockLines !== null) {
+			// Strip the common leading whitespace from the block so the
+			// serializer can add its own indentation level.
+			const rawBlock = currentBlockLines.join("\n");
+			const leadingSpaces = rawBlock.match(/^([ \t]+)/m);
+			const prefix = leadingSpaces?.[1] ?? "";
+			const stripped = prefix
+				? rawBlock.replace(new RegExp(`^${escapeRegex(prefix)}`, "gm"), "").replace(/^\n/, "")
+				: rawBlock;
+			frontmatter[currentKey] = stripped;
+			currentKey = null;
+			currentBlockLines = null;
+			currentIndent = null;
+		}
+
 		const match = line.match(/^([\w-]+):\s*(.*)$/);
 		if (match) {
 			let value = match[2].trim();
 			if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
 				value = value.slice(1, -1);
 			}
-			frontmatter[match[1]] = value;
+
+			if (value === "") {
+				// Key with empty value — might start a block; defer storing until we see indent
+				currentKey = match[1];
+				currentBlockLines = [];
+				currentIndent = indent;
+			} else {
+				// Simple key: value
+				frontmatter[match[1]] = value;
+			}
 		}
+		// Lines that don't match a key pattern (e.g., comments, empty lines) are ignored
+	}
+
+	// Flush final block value
+	if (currentKey !== null && currentBlockLines !== null) {
+		const rawBlock = currentBlockLines.join("\n");
+		const leadingSpaces = rawBlock.match(/^([ \t]+)/m);
+		const prefix = leadingSpaces?.[1] ?? "";
+		const stripped = prefix
+			? rawBlock.replace(new RegExp(`^${escapeRegex(prefix)}`, "gm"), "").replace(/^\n/, "")
+			: rawBlock;
+		frontmatter[currentKey] = stripped;
 	}
 
 	return { frontmatter, body };

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { discoverAgentsAll, type AgentSource } from "../agents/agents.ts";
 import { isAsyncAvailable } from "../runs/background/async-execution.ts";
@@ -180,13 +179,9 @@ function formatPermissionSystemSection(): string[] {
 	}
 	const isChild = process.env["PI_SUBAGENT_CHILD"] === "1";
 	lines.push(`- subagent process: ${isChild ? "yes (PI_SUBAGENT_CHILD=1)" : "no"}`);
-	// Check for pi-permission-system extension config
-	const configPath = path.join(os.homedir(), ".pi", "agent", "extensions", "pi-permission-system", "config.json");
-	if (fs.existsSync(configPath)) {
-		lines.push(`- pi-permission-system config: found (${configPath})`);
-	} else {
-		lines.push("- pi-permission-system config: not found — extension may not be installed");
-	}
+	// Whether pi-permission-system is installed and where it stores config is
+	// outside pi-subagents' control, so we only report the forwarding signal we
+	// own. Run `pi list` to confirm the permission extension is installed.
 	return lines;
 }
 

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { discoverAgentsAll, type AgentSource } from "../agents/agents.ts";
 import { isAsyncAvailable } from "../runs/background/async-execution.ts";
@@ -168,6 +169,27 @@ function formatIntercomDiagnostic(diagnostic: IntercomBridgeDiagnostic, context:
 	return lines;
 }
 
+function formatPermissionSystemSection(): string[] {
+	const lines: string[] = [];
+	const parentSession = process.env["PI_SUBAGENT_PARENT_SESSION"] ?? "";
+	const trimmed = parentSession.trim();
+	if (trimmed) {
+		lines.push(`- parent session: set (${trimmed})`);
+	} else {
+		lines.push("- parent session: not set — ask forwarding from subprocess children will not reach a parent UI");
+	}
+	const isChild = process.env["PI_SUBAGENT_CHILD"] === "1";
+	lines.push(`- subagent process: ${isChild ? "yes (PI_SUBAGENT_CHILD=1)" : "no"}`);
+	// Check for pi-permission-system extension config
+	const configPath = path.join(os.homedir(), ".pi", "agent", "extensions", "pi-permission-system", "config.json");
+	if (fs.existsSync(configPath)) {
+		lines.push(`- pi-permission-system config: found (${configPath})`);
+	} else {
+		lines.push("- pi-permission-system config: not found — extension may not be installed");
+	}
+	return lines;
+}
+
 export function buildDoctorReport(input: DoctorReportInput): string {
 	const paths = input.paths ?? DEFAULT_PATHS;
 	const deps = { ...DEFAULT_DEPS, ...input.deps };
@@ -187,6 +209,9 @@ export function buildDoctorReport(input: DoctorReportInput): string {
 		"",
 		"Discovery",
 		...formatDiscovery(input, deps),
+		"",
+		"Permission system",
+		...formatPermissionSystemSection(),
 		"",
 		"Intercom bridge",
 		...lineFromCheck("intercom bridge", () => formatIntercomDiagnostic(deps.diagnoseIntercomBridge({

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -33,7 +33,7 @@ import { registerSlashSubagentBridge } from "../slash/slash-bridge.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
 import registerSubagentNotify, { type SubagentNotifyDetails } from "../runs/background/notify.ts";
-import { SUBAGENT_CHILD_ENV } from "../runs/shared/pi-args.ts";
+import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import { loadConfig } from "./config.ts";
 import {
@@ -522,6 +522,17 @@ DIAGNOSTICS:
 	const resetSessionState = (ctx: ExtensionContext) => {
 		state.baseCwd = ctx.cwd;
 		state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
+		// Set PI_SUBAGENT_PARENT_SESSION for permission-system forwarding.
+		// Only set in the root session (the interactive UI session), not in
+		// child subagent processes — children inherit the parent's value
+		// through the process environment at spawn time and must not overwrite
+		// it with their own session identity.
+		if (!process.env[SUBAGENT_CHILD_ENV]) {
+			const sessionId = ctx.sessionManager.getSessionId();
+			if (sessionId) {
+				process.env[SUBAGENT_PARENT_SESSION_ENV] = sessionId;
+			}
+		}
 		state.lastUiContext = ctx;
 		cleanupSessionArtifacts(ctx);
 		clearPendingForegroundControlNotices(state);
@@ -535,6 +546,7 @@ DIAGNOSTICS:
 	});
 
 	pi.on("session_shutdown", () => {
+		delete process.env[SUBAGENT_PARENT_SESSION_ENV];
 		for (const unsubscribe of eventUnsubscribes) {
 			try {
 				unsubscribe();

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -359,6 +359,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		const primaryModel = resolveSubagentModelOverride(requestedModel, ctx.currentModel, availableModels, ctx.currentModelProvider);
 		const model = applyThinkingSuffix(primaryModel, a.thinking);
 		return {
+			parentSessionId: ctx.currentSessionId,
 			agent: s.agent,
 			task,
 			phase: s.phase,

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -784,6 +784,7 @@ export function executeAsyncSingle(
 				id,
 				steps: [
 					{
+						parentSessionId: ctx.currentSessionId,
 						agent,
 						task: taskWithOutputInstruction,
 						cwd: runnerCwd,

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -95,6 +95,8 @@ interface AsyncExecutionContext {
 	pi: ExtensionAPI;
 	cwd: string;
 	currentSessionId: string;
+	/** Parent session id used by permission-system ask forwarding. */
+	parentSessionId?: string;
 	currentModelProvider?: string;
 	currentModel?: ParentModel;
 }
@@ -359,7 +361,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		const primaryModel = resolveSubagentModelOverride(requestedModel, ctx.currentModel, availableModels, ctx.currentModelProvider);
 		const model = applyThinkingSuffix(primaryModel, a.thinking);
 		return {
-			parentSessionId: ctx.currentSessionId,
+			parentSessionId: ctx.parentSessionId ?? ctx.currentSessionId,
 			agent: s.agent,
 			task,
 			phase: s.phase,
@@ -784,7 +786,7 @@ export function executeAsyncSingle(
 				id,
 				steps: [
 					{
-						parentSessionId: ctx.currentSessionId,
+						parentSessionId: ctx.parentSessionId ?? ctx.currentSessionId,
 						agent,
 						task: taskWithOutputInstruction,
 						cwd: runnerCwd,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -676,6 +676,7 @@ async function runSingleStep(
 			}
 		}
 		const { args, env, tempDir } = buildPiArgs({
+			parentSessionId: step.parentSessionId,
 			baseArgs: ["--mode", "json", "-p"],
 			task,
 			sessionEnabled,

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -266,6 +266,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				? createStructuredOutputRuntime(task.outputSchema, path.join(input.chainDir, "structured-output"))
 				: undefined;
 			const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
+				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 				cwd: taskCwd,
 				signal: input.signal,
 				interruptSignal: interruptController.signal,
@@ -1054,6 +1055,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
 				: undefined;
 			const r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
+				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				cwd: resolveChildCwd(cwd ?? ctx.cwd, seqStep.cwd),
 				signal,
 				interruptSignal: interruptController.signal,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -178,6 +178,7 @@ async function runSingleAttempt(
 		parentControlInbox: options.nestedRoute?.controlInbox,
 			parentRootRunId: options.nestedRoute?.rootRunId,
 			parentCapabilityToken: options.nestedRoute?.capabilityToken,
+			parentSessionId: options.parentSessionId,
 			structuredOutput: options.structuredOutput,
 		});
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1783,6 +1783,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		}
 		const agentConfig = input.agents.find((agent) => agent.name === task.agent);
 		return runSync(input.ctx.cwd, input.agents, task.agent, taskText, {
+			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 			cwd: taskCwd,
 			signal: input.signal,
 			interruptSignal: interruptController.signal,
@@ -2350,6 +2351,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		: undefined;
 
 	const r = await runSync(ctx.cwd, agents, params.agent!, task, {
+		parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 		cwd: effectiveCwd,
 		signal,
 		interruptSignal: interruptController.signal,
@@ -2498,7 +2500,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				let orchestratorTarget: string | undefined;
 				try {
 					orchestratorTarget = resolveIntercomSessionTarget(deps.pi.getSessionName(), ctx.sessionManager.getSessionId());
-				} catch {}
+				} catch (error) {
+					if (!sessionError) sessionError = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+				}
 				return {
 					content: [{
 						type: "text",

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -553,6 +553,7 @@ function appendStepToAsyncChain(input: {
 		pi: input.deps.pi,
 		cwd: input.ctx.cwd,
 		currentSessionId: resolveCurrentSessionId(input.ctx.sessionManager),
+		parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 		currentModelProvider: input.ctx.model?.provider,
 		currentModel: input.ctx.model,
 	};
@@ -879,6 +880,7 @@ async function resumeAsyncRun(input: {
 				pi: input.deps.pi,
 				cwd: input.requestCwd,
 				currentSessionId: input.deps.state.currentSessionId,
+				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 				currentModelProvider: input.ctx.model?.provider,
 				currentModel: input.ctx.model,
 			},
@@ -921,6 +923,7 @@ async function resumeAsyncRun(input: {
 			pi: input.deps.pi,
 			cwd: input.requestCwd,
 			currentSessionId: input.deps.state.currentSessionId,
+			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 			currentModelProvider: input.ctx.model?.provider,
 			currentModel: input.ctx.model,
 		},
@@ -1368,6 +1371,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		pi: deps.pi,
 		cwd: ctx.cwd,
 		currentSessionId: deps.state.currentSessionId!,
+		parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 		currentModelProvider: ctx.model?.provider,
 		currentModel: ctx.model,
 	};
@@ -1567,6 +1571,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			pi: deps.pi,
 			cwd: ctx.cwd,
 			currentSessionId: deps.state.currentSessionId!,
+			parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 			currentModelProvider: ctx.model?.provider,
 			currentModel: ctx.model,
 		};
@@ -1985,6 +1990,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				pi: deps.pi,
 				cwd: ctx.cwd,
 				currentSessionId: deps.state.currentSessionId!,
+				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				currentModelProvider: ctx.model?.provider,
 				currentModel: ctx.model,
 			};
@@ -2267,6 +2273,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				pi: deps.pi,
 				cwd: ctx.cwd,
 				currentSessionId: deps.state.currentSessionId!,
+				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				currentModelProvider: ctx.model?.provider,
 				currentModel: ctx.model,
 			};

--- a/src/runs/shared/dynamic-fanout.ts
+++ b/src/runs/shared/dynamic-fanout.ts
@@ -49,7 +49,7 @@ const RUNNER_DYNAMIC_PARALLEL_KEYS = new Set([
 	...DYNAMIC_PARALLEL_KEYS,
 	"outputName", "structured", "inheritProjectContext", "inheritSkills", "skills", "outputPath", "maxSubagentDepth",
 	"structuredOutput", "structuredOutputSchema", "tools", "extensions", "subagentOnlyExtensions", "mcpDirectTools", "completionGuard", "systemPrompt",
-	"systemPromptMode", "thinking", "modelCandidates", "sessionFile", "effectiveAcceptance",
+	"systemPromptMode", "thinking", "modelCandidates", "sessionFile", "effectiveAcceptance", "parentSessionId",
 ]);
 const DYNAMIC_COLLECT_KEYS = new Set(["as", "outputSchema"]);
 

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -1,4 +1,6 @@
 export interface RunnerSubagentStep {
+	/** Session id of the direct parent session for permission-system ask forwarding. */
+	parentSessionId?: string;
 	agent: string;
 	task: string;
 	importAsyncRoot?: {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -25,8 +25,10 @@ export const SUBAGENT_PARENT_CHILD_INDEX_ENV = "PI_SUBAGENT_PARENT_CHILD_INDEX";
 export const SUBAGENT_PARENT_DEPTH_ENV = "PI_SUBAGENT_PARENT_DEPTH";
 export const SUBAGENT_PARENT_PATH_ENV = "PI_SUBAGENT_PARENT_PATH";
 export const SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV = "PI_SUBAGENT_PARENT_CAPABILITY_TOKEN";
+export const SUBAGENT_PARENT_SESSION_ENV = "PI_SUBAGENT_PARENT_SESSION";
 
 interface BuildPiArgsInput {
+	parentSessionId?: string;
 	baseArgs: string[];
 	task: string;
 	sessionEnabled: boolean;
@@ -216,6 +218,8 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		env[STRUCTURED_OUTPUT_CAPTURE_ENV] = input.structuredOutput.outputPath;
 		env[STRUCTURED_OUTPUT_SCHEMA_ENV] = input.structuredOutput.schemaPath;
 	}
+
+	env[SUBAGENT_PARENT_SESSION_ENV] = input.parentSessionId ?? process.env[SUBAGENT_PARENT_SESSION_ENV] ?? "";
 
 	return { args, env, tempDir };
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -754,6 +754,8 @@ export const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom
 // ============================================================================
 
 export interface RunSyncOptions {
+	/** Session id of the direct parent session for permission-system ask forwarding. */
+	parentSessionId?: string;
 	cwd?: string;
 	signal?: AbortSignal;
 	interruptSignal?: AbortSignal;

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -53,6 +53,40 @@ afterEach(() => {
 	}
 });
 
+describe("agent permission frontmatter", () => {
+	it("preserves nested permission YAML blocks through discovery and serialization", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-permission-frontmatter-"));
+		tempDirs.push(dir);
+		const agentsDir = path.join(dir, ".pi", "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(path.join(agentsDir, "worker.md"), `---
+name: worker
+description: Worker
+tools: bash,read,write
+permission:
+  "*": ask
+  read: allow
+  bash:
+    "*": ask
+    "git *": allow
+---
+
+Do work
+`, "utf-8");
+
+		const result = discoverAgents(dir, "project");
+		const worker = result.agents.find((agent) => agent.name === "worker");
+		assert.equal(worker?.extraFields?.permission, `"*": ask
+read: allow
+bash:
+  "*": ask
+  "git *": allow`);
+
+		const serialized = serializeAgent(worker!);
+		assert.match(serialized, /^permission:\n  "\*": ask\n  read: allow\n  bash:\n    "\*": ask\n    "git \*": allow$/m);
+	});
+});
+
 describe("agent frontmatter defaultContext", () => {
 	it("serializes defaultContext into agent frontmatter", () => {
 		const agent: AgentConfig = {

--- a/test/unit/async-permission-session.test.ts
+++ b/test/unit/async-permission-session.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import type { AgentConfig } from "../../src/agents/agents.ts";
+import { buildAsyncRunnerSteps } from "../../src/runs/background/async-execution.ts";
+
+function makeAgent(name: string): AgentConfig {
+	return {
+		name,
+		description: `${name} agent`,
+		systemPrompt: "Do work",
+		systemPromptMode: "replace",
+		inheritProjectContext: false,
+		inheritSkills: false,
+		source: "project",
+		filePath: `/tmp/${name}.md`,
+	};
+}
+
+describe("async permission forwarding session identity", () => {
+	it("uses the parent session id for permission forwarding instead of the async status identity", () => {
+		const currentSessionId = path.join("/tmp", "parent-session.jsonl");
+		const built = buildAsyncRunnerSteps("run-abc", {
+			chain: [{ agent: "worker", task: "Do work" }],
+			agents: [makeAgent("worker")],
+			ctx: {
+				pi: {} as never,
+				cwd: "/tmp/project",
+				currentSessionId,
+				parentSessionId: "session-abc123",
+			},
+			maxSubagentDepth: 1,
+			asyncDir: "/tmp/async-run",
+		});
+
+		assert.ok(!("error" in built));
+		const step = built.steps[0];
+		assert.ok(step && !("parallel" in step));
+		assert.equal(step.parentSessionId, "session-abc123");
+	});
+});

--- a/test/unit/dynamic-fanout.test.ts
+++ b/test/unit/dynamic-fanout.test.ts
@@ -7,6 +7,7 @@ import {
 	materializeDynamicParallelStep,
 	resolveJsonPointer,
 	validateDynamicCollection,
+	validateDynamicStepShape,
 } from "../../src/runs/shared/dynamic-fanout.ts";
 import type { ChainStep } from "../../src/shared/settings.ts";
 import type { ChainOutputMap, SingleResult } from "../../src/shared/types.ts";
@@ -120,6 +121,22 @@ describe("dynamic fanout helpers", () => {
 				ChainOutputValidationError,
 			);
 		}
+	});
+
+	it("accepts a runner-injected parentSessionId on the parallel template but keeps it out of user-facing validation", () => {
+		// Regression: the async runner threads parentSessionId onto the dynamic parallel
+		// template for permission-system forwarding. It must pass runner-internal validation
+		// (allowRunnerFields) without leaking into the user-facing dynamic field whitelist.
+		const runnerStep = {
+			expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+			parallel: { agent: "reviewer", task: "Review {item.path}", parentSessionId: "session-parent" },
+			collect: { as: "reviews" },
+		} as unknown as Parameters<typeof validateDynamicStepShape>[0];
+		assert.doesNotThrow(() => validateDynamicStepShape(runnerStep, 1, { allowRunnerFields: true }));
+		assert.throws(
+			() => validateDynamicStepShape(runnerStep, 1),
+			(error: unknown) => error instanceof DynamicFanoutError && /parentSessionId/.test(error.message),
+		);
 	});
 
 	it("validates source ordering and collect name collisions", () => {

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -14,6 +14,7 @@ import {
 	SUBAGENT_PARENT_PATH_ENV,
 	SUBAGENT_PARENT_ROOT_RUN_ID_ENV,
 	SUBAGENT_PARENT_RUN_ID_ENV,
+	SUBAGENT_PARENT_SESSION_ENV,
 	SUBAGENT_RUN_ID_ENV,
 	applyThinkingSuffix,
 	buildPiArgs,
@@ -32,6 +33,7 @@ const originalEnv = {
 	PI_SUBAGENT_PARENT_DEPTH: process.env.PI_SUBAGENT_PARENT_DEPTH,
 	PI_SUBAGENT_PARENT_PATH: process.env.PI_SUBAGENT_PARENT_PATH,
 	PI_SUBAGENT_PARENT_CAPABILITY_TOKEN: process.env.PI_SUBAGENT_PARENT_CAPABILITY_TOKEN,
+	PI_SUBAGENT_PARENT_SESSION: process.env.PI_SUBAGENT_PARENT_SESSION,
 	PI_SUBAGENT_RUN_ID: process.env.PI_SUBAGENT_RUN_ID,
 };
 const originalCwd = process.cwd();
@@ -151,6 +153,33 @@ describe("buildPiArgs session wiring", () => {
 		assert.ok(args.includes("--session-dir"));
 		assert.ok(args.includes("/tmp/subagent-sessions"));
 		assert.ok(!args.includes("--session"));
+	});
+
+	it("emits explicit parent session env for permission forwarding", () => {
+		process.env.PI_SUBAGENT_PARENT_SESSION = "inherited-parent";
+		const { env } = buildPiArgs({
+			parentSessionId: "direct-parent",
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.equal(env[SUBAGENT_PARENT_SESSION_ENV], "direct-parent");
+	});
+
+	it("falls back to inherited parent session env for permission forwarding", () => {
+		process.env.PI_SUBAGENT_PARENT_SESSION = "inherited-parent";
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.equal(env[SUBAGENT_PARENT_SESSION_ENV], "inherited-parent");
 	});
 });
 


### PR DESCRIPTION

Add permission-system `ask` forwarding (for `@gotgenes/pi-permission-system`) from
subagent child processes back to the parent Pi session UI, preserve per-agent
`permission:` frontmatter blocks, and document the integration.

This is a fresh, current-main revision of the previously closed PR. See
"Changes since the previous review" below for what changed.

## Why

`pi-permission-system` supports subprocess subagent prompt forwarding through the
`PI_SUBAGENT_PARENT_SESSION` environment variable.

Before this PR, subprocess children launched by `pi-subagents` did not reliably
receive that parent session identity, so `ask` permissions in child processes
could be auto-denied instead of being forwarded to the parent UI.

This PR implements the documented integration contract and makes `permission:`
frontmatter safe to use in `pi-subagents` agent files.

## Changes

- Set `PI_SUBAGENT_PARENT_SESSION` at session start in the interactive (root)
  session; child subprocesses inherit it through the process environment.
- Explicitly propagate the launching session identity through:
  - foreground single runs
  - foreground parallel runs
  - foreground chain runs
  - async single runs
  - async dynamic-fanout children
- Keep inherited `process.env.PI_SUBAGENT_PARENT_SESSION` as a defensive fallback.
- Preserve nested `permission:` YAML frontmatter through agent discovery and
  serialization.
- Add a `/subagents-doctor` "Permission system" section reporting the signals
  pi-subagents actually owns: parent-session env status and subagent-process
  detection.
- Document the integration in `README.md`, scoped to behavior the permission
  system can actually resolve.
- Regression coverage for: explicit parent-session env precedence, inherited env
  fallback, `permission:` frontmatter round-trip, and the dynamic-fanout
  runner-vs-user validation split.

## Changes since the previous review

- **Rebased onto current main** (was conflicting). The `fanout-child` registration
  moved out of `index.ts` into a standalone extension upstream; the parent-session
  env wiring was re-applied on top of that structure.
- **Async dynamic fanout fixed.** `parentSessionId` is now allowed on the
  runner-internal dynamic parallel template only, so dynamic async children
  receive the parent session without the field leaking into user-facing dynamic
  validation (a `.chain.json` that sets `parentSessionId` is still rejected).
  Previously the injected field was rejected as an unsupported dynamic fanout
  field and the async dynamic path failed.
- **Async single now propagates explicitly** instead of relying only on the
  inherited env fallback.
- **Docs/diagnostics scoped down.** Dropped the inaccurate "nested forwarding goes
  directly to the root UI session" / agent-name-metadata claims (a nested child's
  direct parent is a headless subagent with no UI), and removed the doctor's
  guessed pi-permission-system config-path check that produced false
  "not installed" diagnostics. `pi list` is the install check.

## Example

```yaml
---
name: worker
tools: bash,read,write,edit
permission:
  "*": ask
  read: allow
  bash:
    "*": ask
    "git *": allow
    "npm test": allow
---

You are a worker agent.
```

`tools:` continues to control tool visibility via `pi-subagents`. `permission:` is
consumed independently by `@gotgenes/pi-permission-system` as the runtime policy
layer. The two layers compose without collision.

`ask` forwarding resolves an interactive prompt for direct children of the
interactive session; place `ask` policies on agents that run as direct children.

## Validation

```bash
node --experimental-strip-types --test \
  test/unit/pi-args.test.ts \
  test/unit/agent-frontmatter.test.ts \
  test/unit/dynamic-fanout.test.ts \
  test/unit/doctor.test.ts
```