### PR TITLE
feat: parallel groups, metadata, group options, completion via /chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Skip this section until you want exact syntax.
 |---------|-------------|
 | `/run <agent> [task]` | Run one agent; omit the task for self-contained agents |
 | `/chain agent1 "task1" -> agent2 "task2"` | Run agents in sequence |
+| `/chain scout "scan" -> (reviewer "A" \| reviewer "B") -> writer "fix"` | Run a chain with a static parallel group inline |
 | `/parallel agent1 "task1" -> agent2 "task2"` | Run agents in parallel |
 | `/run-chain <chainName> -- <task>` | Launch a saved `.chain.md` or `.chain.json` workflow |
 | `/subagents-doctor` | Show read-only setup diagnostics |
@@ -352,6 +353,21 @@ Both double and single quotes work. You can also use `--` as a delimiter:
 ```
 
 Steps without a task inherit behavior from the execution mode. Chain steps get `{previous}`, the prior step’s output. Parallel steps use the first available task as a fallback.
+
+### Inline parallel groups in `/chain`
+
+Wrap a group of agents in parentheses and separate them with `|` to fan them out within a single chain step. The group runs all of its tasks concurrently, then the next `->` step continues once they finish:
+
+```text
+/chain scout "scan" -> (reviewer "review A" | reviewer "review B") -> writer "fix"
+```
+
+Notes:
+
+- Groups must contain at least two tasks separated by ` | `.
+- Group syntax is only valid between ` -> ` separators, and the group must appear as a complete step.
+- A group is treated as the prior step’s output for the next sequential step.
+- Dynamic fanout (`expand` / `collect`) and chain metadata fields are not yet available inline; use the `subagent({ chain: [...] })` tool API or a saved `.chain.json` for those.
 
 ```text
 /chain scout "analyze auth" -> planner -> worker

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Notes:
 
 - Groups must contain at least two tasks separated by ` | `, each with its own task.
 - Group syntax is only valid between ` -> ` separators, and the group must appear as a complete step.
+- Only a step that *opens* with `(` is a group. Parentheses inside a shared `--` task (e.g. `/chain scout -- inspect auth (backend)`) stay literal text and keep the legacy single-agent behavior.
 - A group is treated as the prior step’s output for the next sequential step.
 - Tab completion suggests agents inside groups — after `(`, after `|`, and on each new `->` step.
 

--- a/README.md
+++ b/README.md
@@ -364,10 +364,25 @@ Wrap a group of agents in parentheses and separate them with `|` to fan them out
 
 Notes:
 
-- Groups must contain at least two tasks separated by ` | `.
+- Groups must contain at least two tasks separated by ` | `, each with its own task.
 - Group syntax is only valid between ` -> ` separators, and the group must appear as a complete step.
 - A group is treated as the prior step’s output for the next sequential step.
-- Dynamic fanout (`expand` / `collect`) and chain metadata fields are not yet available inline; use the `subagent({ chain: [...] })` tool API or a saved `.chain.json` for those.
+- Tab completion suggests agents inside groups — after `(`, after `|`, and on each new `->` step.
+
+Add a `[...]` suffix right after the closing `)` to set step-level options on the group:
+
+```text
+/chain scout "scan" -> (reviewer "A" | reviewer "B")[concurrency=2,failFast,worktree] -> writer "fix"
+```
+
+| Group option | Description |
+|--------------|-------------|
+| `concurrency=N` | Max tasks running at once within the group. |
+| `failFast` | Stop the group as soon as one task fails. |
+| `worktree` | Run each group task in its own git worktree. |
+
+Dynamic fanout (`expand` / `collect`) is intentionally not available inline — use the
+`subagent({ chain: [...] })` tool API or a saved `.chain.json` for data-driven fan-out.
 
 ```text
 /chain scout "analyze auth" -> planner -> worker
@@ -399,8 +414,17 @@ Append `[key=value,...]` to an agent name to override defaults for that step:
 | `model` | `model=anthropic/claude-sonnet-4` | Override model for this step. |
 | `skills` | `skills=planning+review` | Override available skills. `+` separates multiple skills. |
 | `progress` | `progress` | Enable progress tracking. |
+| `as` | `as=context` | Name this step’s output so later steps can reference it. |
+| `label` | `label=Recon` | Human-readable label for the step. |
+| `phase` | `phase=analysis` | Group steps into a named phase. |
+| `cwd` | `cwd=packages/api` | Run the step in a subdirectory. |
+| `count` | `count=3` | Fan a group task into N copies (only inside a `( ... )` group). |
+| `outputSchema` | `outputSchema=schema.json` | Validate structured output against a JSON Schema file (path resolved against cwd). |
+| `acceptance` | `acceptance=verified` | Acceptance level: `none`, `attested`, `checked`, `verified`, or `reviewed`. |
 
 Set `output=false`, `reads=false`, or `skills=false` to disable that behavior explicitly. Do not use `output=false` for file-only returns; use `outputMode=file-only` with an `output` path.
+
+Inline `[...]` values must not contain spaces or commas — keep `label`/`phase` to single tokens.
 
 ### Background and forked runs
 

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -369,7 +369,148 @@ async function runSlashSubagent(
 }
 
 
-interface ParsedStep { name: string; config: InlineConfig; task?: string }
+export interface ParsedStep { kind: "step"; name: string; config: InlineConfig; task?: string }
+export interface ParsedGroup { kind: "group"; tasks: ParsedStep[] }
+export type ParsedGroupStep = ParsedStep | ParsedGroup;
+
+export const PARALLEL_GROUP_USAGE =
+	'Usage: /chain agent "task" -> (agent2 "task" | agent3 "task") -> agent4';
+
+export class SlashParseError extends Error {}
+
+// Walk `input` tracking quote/paren state; returns true if parens are unbalanced.
+function findUnmatchedCloseParen(input: string): boolean {
+	let depth = 0, inSingle = false, inDouble = false;
+	for (let i = 0; i < input.length; i++) {
+		const ch = input[i]!;
+		if (inSingle) { if (ch === "'") inSingle = false; continue; }
+		if (inDouble) { if (ch === '"') inDouble = false; continue; }
+		if (ch === "'") { inSingle = true; continue; }
+		if (ch === '"') { inDouble = true; continue; }
+		if (ch === "(") depth++;
+		else if (ch === ")") { depth--; if (depth < 0) return true; }
+	}
+	return depth !== 0;
+}
+
+// Split on top-level " -> ", ignoring arrows inside quotes or parentheses.
+function splitOnArrow(input: string): string[] {
+	const segments: string[] = [];
+	let depth = 0, inSingle = false, inDouble = false, start = 0;
+	for (let i = 0; i < input.length; i++) {
+		const ch = input[i]!;
+		if (inSingle) { if (ch === "'") inSingle = false; continue; }
+		if (inDouble) { if (ch === '"') inDouble = false; continue; }
+		if (ch === "'") { inSingle = true; continue; }
+		if (ch === '"') { inDouble = true; continue; }
+		if (ch === "(") depth++;
+		else if (ch === ")") depth--;
+		else if (depth === 0 && ch === "-" && input[i + 1] === ">" && input[i + 2] === " ") {
+			segments.push(input.slice(start, i));
+			i += 2;
+			start = i + 1;
+		}
+	}
+	segments.push(input.slice(start));
+	return segments;
+}
+
+// Split a group's inner text on top-level " | ", ignoring pipes inside quotes/parens.
+function splitGroupTasks(inner: string): string[] {
+	const parts: string[] = [];
+	let depth = 0, inSingle = false, inDouble = false, start = 0;
+	for (let i = 0; i < inner.length; i++) {
+		const ch = inner[i]!;
+		if (inSingle) { if (ch === "'") inSingle = false; continue; }
+		if (inDouble) { if (ch === '"') inDouble = false; continue; }
+		if (ch === "'") { inSingle = true; continue; }
+		if (ch === '"') { inDouble = true; continue; }
+		if (ch === "(") depth++;
+		else if (ch === ")") depth--;
+		else if (ch === "|" && depth === 0) {
+			parts.push(inner.slice(start, i));
+			start = i + 1;
+		}
+	}
+	parts.push(inner.slice(start));
+	return parts;
+}
+
+export function parseSingleTaskToken(token: string): ParsedStep {
+	let agentPart: string;
+	let task: string | undefined;
+	const qMatch = token.match(/^(\S+(?:\[[^\]]*\])?)\s+(?:"([^"]*)"|'([^']*)')$/);
+	if (qMatch) {
+		agentPart = qMatch[1]!;
+		task = (qMatch[2] ?? qMatch[3]) || undefined;
+	} else {
+		const dashIdx = token.indexOf(" -- ");
+		if (dashIdx !== -1) {
+			agentPart = token.slice(0, dashIdx).trim();
+			task = token.slice(dashIdx + 4).trim() || undefined;
+		} else {
+			agentPart = token;
+		}
+	}
+	return { kind: "step", ...parseAgentToken(agentPart), task };
+}
+
+export function parseGroupSegment(segment: string): ParsedGroup {
+	const trimmed = segment.trim();
+	if (!trimmed.startsWith("(") || !trimmed.endsWith(")")) {
+		throw new SlashParseError(`Parallel group must be wrapped in parentheses: '${trimmed}'`);
+	}
+	const inner = trimmed.slice(1, -1);
+	if (findUnmatchedCloseParen(inner)) {
+		throw new SlashParseError(`Unmatched parentheses in group: '${trimmed}'`);
+	}
+	const rawParts = splitGroupTasks(inner).map((p) => p.trim()).filter((p) => p.length > 0);
+	if (rawParts.length < 2) {
+		throw new SlashParseError("Parallel group must contain at least two tasks separated by ' | '");
+	}
+	return { kind: "group", tasks: rawParts.map((part) => parseSingleTaskToken(part)) };
+}
+
+// True if `input` uses inline parallel-group syntax (parens or pipe) outside quotes.
+export function hasGroupSyntax(input: string): boolean {
+	let inSingle = false, inDouble = false;
+	for (let i = 0; i < input.length; i++) {
+		const ch = input[i]!;
+		if (inSingle) { if (ch === "'") inSingle = false; continue; }
+		if (inDouble) { if (ch === '"') inDouble = false; continue; }
+		if (ch === "'") { inSingle = true; continue; }
+		if (ch === '"') { inDouble = true; continue; }
+		if (ch === "(" || ch === ")" || ch === "|") return true;
+	}
+	return false;
+}
+
+export function parseChainExpression(input: string): { steps: ParsedGroupStep[] } {
+	const trimmed = input.trim();
+	if (!trimmed.includes(" -> ")) {
+		throw new SlashParseError('Parallel groups in /chain require " -> " between steps');
+	}
+	if (findUnmatchedCloseParen(trimmed)) {
+		throw new SlashParseError("Unmatched parentheses in /chain expression");
+	}
+	const steps: ParsedGroupStep[] = [];
+	for (const seg of splitOnArrow(trimmed)) {
+		const t = seg.trim();
+		if (!t) continue;
+		if (t.startsWith("(")) {
+			steps.push(parseGroupSegment(t));
+			continue;
+		}
+		if (t.includes("(") || t.includes(")")) {
+			throw new SlashParseError(`Unmatched parentheses in chain segment: '${t}'`);
+		}
+		steps.push(parseSingleTaskToken(t));
+	}
+	if (steps.length === 0) {
+		throw new SlashParseError("/chain expression must include at least one step");
+	}
+	return { steps };
+}
 
 const parseAgentArgs = (
 	state: SubagentState,
@@ -390,23 +531,7 @@ const parseAgentArgs = (
 		for (const seg of segments) {
 			const trimmed = seg.trim();
 			if (!trimmed) continue;
-			let agentPart: string;
-			let task: string | undefined;
-			const qMatch = trimmed.match(/^(\S+(?:\[[^\]]*\])?)\s+(?:"([^"]*)"|'([^']*)')$/);
-			if (qMatch) {
-				agentPart = qMatch[1]!;
-				task = (qMatch[2] ?? qMatch[3]) || undefined;
-			} else {
-				const dashIdx = trimmed.indexOf(" -- ");
-				if (dashIdx !== -1) {
-					agentPart = trimmed.slice(0, dashIdx).trim();
-					task = trimmed.slice(dashIdx + 4).trim() || undefined;
-				} else {
-					agentPart = trimmed;
-				}
-			}
-			const parsed = parseAgentToken(agentPart);
-			steps.push({ ...parsed, task });
+			steps.push(parseSingleTaskToken(trimmed));
 		}
 		sharedTask = steps.find((s) => s.task)?.task ?? "";
 	} else {
@@ -421,7 +546,7 @@ const parseAgentArgs = (
 			ctx.ui.notify(usage, "error");
 			return null;
 		}
-		steps = agentsPart.split(/\s+/).filter(Boolean).map((t) => parseAgentToken(t));
+		steps = agentsPart.split(/\s+/).filter(Boolean).map((t) => parseSingleTaskToken(t));
 	}
 
 	if (steps.length === 0) {
@@ -449,6 +574,100 @@ const parseAgentArgs = (
 	}
 	return { steps, task: sharedTask };
 };
+
+type ChainStepObject = {
+	agent: string;
+	task?: string;
+	output?: string | false;
+	outputMode?: "inline" | "file-only";
+	reads?: string[] | false;
+	model?: string;
+	skill?: string[] | false;
+	progress?: boolean;
+};
+
+const mapParsedTaskToStepObject = (
+	step: ParsedStep,
+	fallbackTask: string | undefined,
+	isFirst: boolean,
+): ChainStepObject => {
+	const { name, config, task: stepTask } = step;
+	return {
+		agent: name,
+		...(stepTask ? { task: stepTask } : isFirst && fallbackTask ? { task: fallbackTask } : {}),
+		...(config.output !== undefined ? { output: config.output } : {}),
+		...(config.outputMode !== undefined ? { outputMode: config.outputMode } : {}),
+		...(config.reads !== undefined ? { reads: config.reads } : {}),
+		...(config.model ? { model: config.model } : {}),
+		...(config.skill !== undefined ? { skill: config.skill } : {}),
+		...(config.progress !== undefined ? { progress: config.progress } : {}),
+	};
+};
+
+export function buildChainExpressionSteps(
+	state: SubagentState,
+	input: string,
+	ctx: ExtensionContext,
+): { chain: ChainStep[]; task: string } | null {
+	const notify = (message: string) => ctx.ui.notify(message, "error");
+	if (!hasGroupSyntax(input)) {
+		const parsed = parseAgentArgs(state, input, "chain", ctx);
+		if (!parsed) return null;
+		const chain: ChainStep[] = parsed.steps.map((step, i) =>
+			mapParsedTaskToStepObject(step, parsed.task || undefined, i === 0),
+		);
+		return { chain, task: parsed.task };
+	}
+
+	let expression: { steps: ParsedGroupStep[] };
+	try {
+		expression = parseChainExpression(input);
+	} catch (error) {
+		notify(error instanceof Error ? error.message : String(error));
+		return null;
+	}
+	if (!state.baseCwd) {
+		notify("Subagent session cwd is not initialized yet");
+		return null;
+	}
+	const agents = discoverAgents(state.baseCwd, "both").agents;
+	const stepAgentNames = expression.steps.flatMap((step) =>
+		step.kind === "group" ? step.tasks.map((t) => t.name) : [step.name],
+	);
+	for (const name of stepAgentNames) {
+		if (!agents.find((a) => a.name === name)) {
+			notify(`Unknown agent: ${name}`);
+			return null;
+		}
+	}
+	// Every task inside a parallel group needs its own task; there is no shared-task fallback.
+	for (const step of expression.steps) {
+		if (step.kind === "group" && step.tasks.some((t) => !t.task)) {
+			notify('Each task in a parallel group needs a task: (agent "a" | agent "b")');
+			return null;
+		}
+	}
+	const firstStep = expression.steps[0]!;
+	const firstHasTask =
+		firstStep.kind === "group"
+			? firstStep.tasks.some((t) => Boolean(t.task))
+			: Boolean(firstStep.task);
+	if (!firstHasTask) {
+		notify('First step must have a task: /chain agent "task" -> agent2');
+		return null;
+	}
+	const sharedTask =
+		firstStep.kind === "group"
+			? (firstStep.tasks.find((t) => t.task)?.task ?? "")
+			: (firstStep.task ?? "");
+	const chain: ChainStep[] = expression.steps.map((step) => {
+		if (step.kind === "group") {
+			return { parallel: step.tasks.map((t) => mapParsedTaskToStepObject(t, undefined, false)) };
+		}
+		return mapParsedTaskToStepObject(step, sharedTask || undefined, false);
+	});
+	return { chain, task: sharedTask };
+}
 
 export function registerSlashCommands(
 	pi: ExtensionAPI,
@@ -489,19 +708,9 @@ export function registerSlashCommands(
 		getArgumentCompletions: makeAgentCompletions(state, true),
 		handler: async (args, ctx) => {
 			const { args: cleanedArgs, bg, fork } = extractExecutionFlags(args);
-			const parsed = parseAgentArgs(state, cleanedArgs, "chain", ctx);
-			if (!parsed) return;
-			const chain = parsed.steps.map(({ name, config, task: stepTask }, i) => ({
-				agent: name,
-				...(stepTask ? { task: stepTask } : i === 0 && parsed.task ? { task: parsed.task } : {}),
-				...(config.output !== undefined ? { output: config.output } : {}),
-				...(config.outputMode !== undefined ? { outputMode: config.outputMode } : {}),
-				...(config.reads !== undefined ? { reads: config.reads } : {}),
-				...(config.model ? { model: config.model } : {}),
-				...(config.skill !== undefined ? { skill: config.skill } : {}),
-				...(config.progress !== undefined ? { progress: config.progress } : {}),
-			}));
-			const params: SubagentParamsLike = { chain, task: parsed.task, clarify: false, agentScope: "both" };
+			const built = buildChainExpressionSteps(state, cleanedArgs, ctx);
+			if (!built) return;
+			const params: SubagentParamsLike = { chain: built.chain, task: built.task, clarify: false, agentScope: "both" };
 			if (bg) params.async = true;
 			if (fork) params.context = "fork";
 			await runSlashSubagent(pi, ctx, params);

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -471,7 +471,9 @@ export function parseGroupSegment(segment: string): ParsedGroup {
 	return { kind: "group", tasks: rawParts.map((part) => parseSingleTaskToken(part)) };
 }
 
-// True if `input` uses inline parallel-group syntax (parens or pipe) outside quotes.
+// True if `input` uses inline parallel-group syntax outside quotes. Only parentheses
+// mark a group — a bare `|` is meaningful only inside `( ... )`, so leaving it out keeps
+// legacy `-- task | with pipe` working as a plain single-agent chain.
 export function hasGroupSyntax(input: string): boolean {
 	let inSingle = false, inDouble = false;
 	for (let i = 0; i < input.length; i++) {
@@ -480,7 +482,7 @@ export function hasGroupSyntax(input: string): boolean {
 		if (inDouble) { if (ch === '"') inDouble = false; continue; }
 		if (ch === "'") { inSingle = true; continue; }
 		if (ch === '"') { inDouble = true; continue; }
-		if (ch === "(" || ch === ")" || ch === "|") return true;
+		if (ch === "(" || ch === ")") return true;
 	}
 	return false;
 }

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -111,17 +111,22 @@ const makeAgentCompletions = (state: SubagentState, multiAgent: boolean) => (pre
 		return agents.filter((a) => a.name.startsWith(prefix)).map((a) => ({ value: a.name, label: a.name }));
 	}
 
-	// Find the start of the current chain step: after the last top-level `->`, `(` or `|`
-	// (group boundaries), tracking quotes so separators inside a task are ignored.
-	let inSingle = false, inDouble = false, segStart = 0;
+	// Find the start of the current chain step: after the last top-level `->` arrow or `(`,
+	// or after a `|` *inside* a group. A `|` at depth 0 is plain task text (only `(` opens a
+	// group), so it must not restart agent completion — otherwise `scout -- do x | wr` would
+	// wrongly resume suggesting agents past the `--` task. Quotes are tracked so separators
+	// inside a task are ignored.
+	let inSingle = false, inDouble = false, depth = 0, segStart = 0;
 	for (let i = 0; i < prefix.length; i++) {
 		const ch = prefix[i]!;
 		if (inSingle) { if (ch === "'") inSingle = false; continue; }
 		if (inDouble) { if (ch === '"') inDouble = false; continue; }
 		if (ch === "'") { inSingle = true; continue; }
 		if (ch === '"') { inDouble = true; continue; }
-		if (ch === "(" || ch === "|") segStart = i + 1;
-		else if (ch === ">" && prefix[i - 1] === "-") segStart = i + 1;
+		if (ch === "(") { depth++; segStart = i + 1; }
+		else if (ch === ")") { if (depth > 0) depth--; segStart = i + 1; }
+		else if (ch === "|" && depth > 0) segStart = i + 1;
+		else if (ch === ">" && prefix[i - 1] === "-" && depth === 0) segStart = i + 1;
 	}
 	// Inside an open quote, or once the task has started (`--` / a quote), we are no
 	// longer typing an agent name.
@@ -537,20 +542,13 @@ export function parseGroupSegment(segment: string): ParsedGroup {
 	return { kind: "group", tasks: rawParts.map((part) => parseSingleTaskToken(part)), config };
 }
 
-// True if `input` uses inline parallel-group syntax outside quotes. Only parentheses
-// mark a group — a bare `|` is meaningful only inside `( ... )`, so leaving it out keeps
-// legacy `-- task | with pipe` working as a plain single-agent chain.
+// True if `input` uses inline parallel-group syntax. A group is a *step* that begins
+// with `(` at the top level, so we split on top-level ` -> ` arrows and look for a
+// segment that opens with `(`. Parentheses appearing inside a task (e.g.
+// `scout -- inspect auth (backend)`) do not count, which keeps legacy shared-task
+// `-- task` parsing — including a bare `|` inside the task — on the single-agent path.
 export function hasGroupSyntax(input: string): boolean {
-	let inSingle = false, inDouble = false;
-	for (let i = 0; i < input.length; i++) {
-		const ch = input[i]!;
-		if (inSingle) { if (ch === "'") inSingle = false; continue; }
-		if (inDouble) { if (ch === '"') inDouble = false; continue; }
-		if (ch === "'") { inSingle = true; continue; }
-		if (ch === '"') { inDouble = true; continue; }
-		if (ch === "(" || ch === ")") return true;
-	}
-	return false;
+	return splitOnArrow(input).some((seg) => seg.trim().startsWith("("));
 }
 
 export function parseChainExpression(input: string): { steps: ParsedGroupStep[] } {

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -567,7 +567,7 @@ export function parseChainExpression(input: string): { steps: ParsedGroupStep[] 
 			steps.push(parseGroupSegment(t));
 			continue;
 		}
-		if (t.includes("(") || t.includes(")")) {
+		if (findUnmatchedCloseParen(t)) {
 			throw new SlashParseError(`Unmatched parentheses in chain segment: '${t}'`);
 		}
 		steps.push(parseSingleTaskToken(t));

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -111,16 +111,29 @@ const makeAgentCompletions = (state: SubagentState, multiAgent: boolean) => (pre
 		return agents.filter((a) => a.name.startsWith(prefix)).map((a) => ({ value: a.name, label: a.name }));
 	}
 
-	const lastArrow = prefix.lastIndexOf(" -> ");
-	const segment = lastArrow !== -1 ? prefix.slice(lastArrow + 4) : prefix;
+	// Find the start of the current chain step: after the last top-level `->`, `(` or `|`
+	// (group boundaries), tracking quotes so separators inside a task are ignored.
+	let inSingle = false, inDouble = false, segStart = 0;
+	for (let i = 0; i < prefix.length; i++) {
+		const ch = prefix[i]!;
+		if (inSingle) { if (ch === "'") inSingle = false; continue; }
+		if (inDouble) { if (ch === '"') inDouble = false; continue; }
+		if (ch === "'") { inSingle = true; continue; }
+		if (ch === '"') { inDouble = true; continue; }
+		if (ch === "(" || ch === "|") segStart = i + 1;
+		else if (ch === ">" && prefix[i - 1] === "-") segStart = i + 1;
+	}
+	// Inside an open quote, or once the task has started (`--` / a quote), we are no
+	// longer typing an agent name.
+	if (inSingle || inDouble) return null;
+	const segment = prefix.slice(segStart);
 	if (segment.includes(" -- ") || segment.includes('"') || segment.includes("'")) return null;
 
-	const lastWord = (prefix.match(/(\S*)$/) || ["", ""])[1];
-	const beforeLastWord = prefix.slice(0, prefix.length - lastWord.length);
-
-	if (lastWord === "->") {
-		return agents.map((a) => ({ value: `${prefix} ${a.name}`, label: a.name }));
-	}
+	const lastWord = (segment.match(/(\S*)$/) || ["", ""])[1];
+	let beforeLastWord = prefix.slice(0, prefix.length - lastWord.length);
+	// A bare `->` or `|` just typed (no trailing space) needs a separating space;
+	// `(` glues naturally to the agent name.
+	if (lastWord === "" && /[>|]$/.test(beforeLastWord)) beforeLastWord = `${beforeLastWord} `;
 
 	return agents.filter((a) => a.name.startsWith(lastWord)).map((a) => ({ value: `${beforeLastWord}${a.name}`, label: a.name }));
 };

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -7,6 +7,7 @@ import { BUILTIN_AGENT_NAMES, discoverAgents, discoverAgentsAll, type ChainConfi
 import type { SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { isDynamicParallelStep, isParallelStep, type ChainStep } from "../shared/settings.ts";
 import { assertJsonSchemaObject } from "../runs/shared/structured-output.ts";
+import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.ts";
 import {
 	applySlashUpdate,
@@ -33,6 +34,13 @@ interface InlineConfig {
 	model?: string;
 	skill?: string[] | false;
 	progress?: boolean;
+	as?: string;
+	label?: string;
+	phase?: string;
+	cwd?: string;
+	count?: number;
+	outputSchema?: string;
+	acceptance?: string;
 }
 
 const parseInlineConfig = (raw: string): InlineConfig => {
@@ -54,6 +62,13 @@ const parseInlineConfig = (raw: string): InlineConfig => {
 			case "model": config.model = val || undefined; break;
 			case "skill": case "skills": config.skill = val === "false" ? false : val.split("+").filter(Boolean); break;
 			case "progress": config.progress = val !== "false"; break;
+			case "as": config.as = val || undefined; break;
+			case "label": config.label = val || undefined; break;
+			case "phase": config.phase = val || undefined; break;
+			case "cwd": config.cwd = val || undefined; break;
+			case "count": { const n = Number(val); if (Number.isInteger(n) && n > 0) config.count = n; break; }
+			case "outputSchema": config.outputSchema = val || undefined; break;
+			case "acceptance": config.acceptance = val || undefined; break;
 		}
 	}
 	return config;
@@ -586,14 +601,43 @@ type ChainStepObject = {
 	model?: string;
 	skill?: string[] | false;
 	progress?: boolean;
+	as?: string;
+	label?: string;
+	phase?: string;
+	cwd?: string;
+	count?: number;
+	outputSchema?: JsonSchemaObject;
+	acceptance?: string;
 };
 
+// Load an inline `outputSchema=<path>` JSON file, resolved against the session cwd.
+// Throws (SlashParseError / fs / JSON) on a missing or malformed schema.
+function loadInlineOutputSchema(baseCwd: string, agent: string, value: string): JsonSchemaObject {
+	const schemaPath = path.isAbsolute(value) ? value : path.join(baseCwd, value);
+	const label = `outputSchema for step '${agent}' (${schemaPath})`;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
+	} catch (error) {
+		throw new SlashParseError(`Cannot read ${label}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	assertJsonSchemaObject(parsed, label);
+	return parsed;
+}
+
+// Build a ChainStep object from a parsed token. `inGroup` enables `count` (parallel-only).
+// May throw SlashParseError for an invalid acceptance level or outputSchema path.
 const mapParsedTaskToStepObject = (
 	step: ParsedStep,
 	fallbackTask: string | undefined,
 	isFirst: boolean,
+	opts: { baseCwd: string; inGroup: boolean },
 ): ChainStepObject => {
 	const { name, config, task: stepTask } = step;
+	if (config.acceptance !== undefined) {
+		const errors = validateAcceptanceInput(config.acceptance, `acceptance for step '${name}'`);
+		if (errors.length > 0) throw new SlashParseError(errors[0]!);
+	}
 	return {
 		agent: name,
 		...(stepTask ? { task: stepTask } : isFirst && fallbackTask ? { task: fallbackTask } : {}),
@@ -603,6 +647,13 @@ const mapParsedTaskToStepObject = (
 		...(config.model ? { model: config.model } : {}),
 		...(config.skill !== undefined ? { skill: config.skill } : {}),
 		...(config.progress !== undefined ? { progress: config.progress } : {}),
+		...(config.as ? { as: config.as } : {}),
+		...(config.label ? { label: config.label } : {}),
+		...(config.phase ? { phase: config.phase } : {}),
+		...(config.cwd ? { cwd: config.cwd } : {}),
+		...(opts.inGroup && config.count !== undefined ? { count: config.count } : {}),
+		...(config.outputSchema ? { outputSchema: loadInlineOutputSchema(opts.baseCwd, name, config.outputSchema) } : {}),
+		...(config.acceptance ? { acceptance: config.acceptance } : {}),
 	};
 };
 
@@ -615,10 +666,16 @@ export function buildChainExpressionSteps(
 	if (!hasGroupSyntax(input)) {
 		const parsed = parseAgentArgs(state, input, "chain", ctx);
 		if (!parsed) return null;
-		const chain: ChainStep[] = parsed.steps.map((step, i) =>
-			mapParsedTaskToStepObject(step, parsed.task || undefined, i === 0),
-		);
-		return { chain, task: parsed.task };
+		const baseCwd = state.baseCwd!; // parseAgentArgs already verified baseCwd is set
+		try {
+			const chain: ChainStep[] = parsed.steps.map((step, i) =>
+				mapParsedTaskToStepObject(step, parsed.task || undefined, i === 0, { baseCwd, inGroup: false }),
+			);
+			return { chain, task: parsed.task };
+		} catch (error) {
+			notify(error instanceof Error ? error.message : String(error));
+			return null;
+		}
 	}
 
 	let expression: { steps: ParsedGroupStep[] };
@@ -662,12 +719,19 @@ export function buildChainExpressionSteps(
 		firstStep.kind === "group"
 			? (firstStep.tasks.find((t) => t.task)?.task ?? "")
 			: (firstStep.task ?? "");
-	const chain: ChainStep[] = expression.steps.map((step) => {
-		if (step.kind === "group") {
-			return { parallel: step.tasks.map((t) => mapParsedTaskToStepObject(t, undefined, false)) };
-		}
-		return mapParsedTaskToStepObject(step, sharedTask || undefined, false);
-	});
+	const baseCwd = state.baseCwd;
+	let chain: ChainStep[];
+	try {
+		chain = expression.steps.map((step) => {
+			if (step.kind === "group") {
+				return { parallel: step.tasks.map((t) => mapParsedTaskToStepObject(t, undefined, false, { baseCwd, inGroup: true })) };
+			}
+			return mapParsedTaskToStepObject(step, sharedTask || undefined, false, { baseCwd, inGroup: false });
+		});
+	} catch (error) {
+		notify(error instanceof Error ? error.message : String(error));
+		return null;
+	}
 	return { chain, task: sharedTask };
 }
 

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -384,8 +384,9 @@ async function runSlashSubagent(
 }
 
 
+export interface GroupConfig { concurrency?: number; failFast?: boolean; worktree?: boolean }
 export interface ParsedStep { kind: "step"; name: string; config: InlineConfig; task?: string }
-export interface ParsedGroup { kind: "group"; tasks: ParsedStep[] }
+export interface ParsedGroup { kind: "group"; tasks: ParsedStep[]; config: GroupConfig }
 export type ParsedGroupStep = ParsedStep | ParsedGroup;
 
 export const PARALLEL_GROUP_USAGE =
@@ -470,20 +471,57 @@ export function parseSingleTaskToken(token: string): ParsedStep {
 	return { kind: "step", ...parseAgentToken(agentPart), task };
 }
 
+const parseGroupConfig = (raw: string): GroupConfig => {
+	const config: GroupConfig = {};
+	for (const part of raw.split(",")) {
+		const trimmed = part.trim();
+		if (!trimmed) continue;
+		const eq = trimmed.indexOf("=");
+		const key = eq === -1 ? trimmed : trimmed.slice(0, eq).trim();
+		const val = eq === -1 ? "" : trimmed.slice(eq + 1).trim();
+		switch (key) {
+			case "concurrency": { const n = Number(val); if (Number.isInteger(n) && n > 0) config.concurrency = n; break; }
+			case "failFast": config.failFast = eq === -1 ? true : val !== "false"; break;
+			case "worktree": config.worktree = eq === -1 ? true : val !== "false"; break;
+		}
+	}
+	return config;
+};
+
+// Split `(...)` from an optional trailing `[...]` group-config suffix, respecting
+// quotes and nested parens. Returns the inner group text and the parsed config.
+const splitGroupBody = (trimmed: string): { inner: string; config: GroupConfig } => {
+	let depth = 0, inSingle = false, inDouble = false, closeIdx = -1;
+	for (let i = 0; i < trimmed.length; i++) {
+		const ch = trimmed[i]!;
+		if (inSingle) { if (ch === "'") inSingle = false; continue; }
+		if (inDouble) { if (ch === '"') inDouble = false; continue; }
+		if (ch === "'") { inSingle = true; continue; }
+		if (ch === '"') { inDouble = true; continue; }
+		if (ch === "(") depth++;
+		else if (ch === ")") { depth--; if (depth === 0) { closeIdx = i; break; } }
+	}
+	if (closeIdx === -1) throw new SlashParseError(`Unmatched parentheses in group: '${trimmed}'`);
+	const inner = trimmed.slice(1, closeIdx);
+	const suffix = trimmed.slice(closeIdx + 1).trim();
+	if (!suffix) return { inner, config: {} };
+	if (!suffix.startsWith("[") || !suffix.endsWith("]")) {
+		throw new SlashParseError(`Group options must be wrapped in [...]: '${suffix}'`);
+	}
+	return { inner, config: parseGroupConfig(suffix.slice(1, -1)) };
+};
+
 export function parseGroupSegment(segment: string): ParsedGroup {
 	const trimmed = segment.trim();
-	if (!trimmed.startsWith("(") || !trimmed.endsWith(")")) {
+	if (!trimmed.startsWith("(")) {
 		throw new SlashParseError(`Parallel group must be wrapped in parentheses: '${trimmed}'`);
 	}
-	const inner = trimmed.slice(1, -1);
-	if (findUnmatchedCloseParen(inner)) {
-		throw new SlashParseError(`Unmatched parentheses in group: '${trimmed}'`);
-	}
+	const { inner, config } = splitGroupBody(trimmed);
 	const rawParts = splitGroupTasks(inner).map((p) => p.trim()).filter((p) => p.length > 0);
 	if (rawParts.length < 2) {
 		throw new SlashParseError("Parallel group must contain at least two tasks separated by ' | '");
 	}
-	return { kind: "group", tasks: rawParts.map((part) => parseSingleTaskToken(part)) };
+	return { kind: "group", tasks: rawParts.map((part) => parseSingleTaskToken(part)), config };
 }
 
 // True if `input` uses inline parallel-group syntax outside quotes. Only parentheses
@@ -724,7 +762,13 @@ export function buildChainExpressionSteps(
 	try {
 		chain = expression.steps.map((step) => {
 			if (step.kind === "group") {
-				return { parallel: step.tasks.map((t) => mapParsedTaskToStepObject(t, undefined, false, { baseCwd, inGroup: true })) };
+				const parallel = step.tasks.map((t) => mapParsedTaskToStepObject(t, undefined, false, { baseCwd, inGroup: true }));
+				return {
+					parallel,
+					...(step.config.concurrency !== undefined ? { concurrency: step.config.concurrency } : {}),
+					...(step.config.failFast !== undefined ? { failFast: step.config.failFast } : {}),
+					...(step.config.worktree !== undefined ? { worktree: step.config.worktree } : {}),
+				};
 			}
 			return mapParsedTaskToStepObject(step, sharedTask || undefined, false, { baseCwd, inGroup: false });
 		});

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -820,6 +820,41 @@ Gather context
 			});
 		});
 	});
+
+	it("/chain parses a parenthesized parallel group into a { parallel: [...] } step", async () => {
+		await withTempProject("pi-chain-group-slash-", async (root) => {
+			for (const name of ["scout", "reviewer", "writer"]) {
+				fs.writeFileSync(path.join(root, ".pi", "agents", `${name}.md`), `---\nname: ${name}\ndescription: ${name}\n---\n\nBody\n`, "utf-8");
+			}
+
+			const { params, notifications } = await captureSlashCommandParams("chain", 'scout "scan" -> (reviewer "A" | reviewer "B") -> writer "fix"', root);
+			assert.deepEqual(notifications, []);
+			const built = params as { chain?: Array<Record<string, unknown>>; task?: string };
+			assert.equal(built.task, "scan");
+			assert.equal(built.chain?.length, 3);
+			assert.equal(built.chain?.[0]?.agent, "scout");
+			const parallel = built.chain?.[1]?.parallel as Array<{ agent: string; task: string }>;
+			assert.ok(Array.isArray(parallel), "second step should be a parallel group");
+			assert.deepEqual(parallel.map(({ agent, task }) => ({ agent, task })), [
+				{ agent: "reviewer", task: "A" },
+				{ agent: "reviewer", task: "B" },
+			]);
+			assert.equal(built.chain?.[2]?.agent, "writer");
+		});
+	});
+
+	it("/chain reports parallel-group errors as notifications and does not launch", async () => {
+		await withTempProject("pi-chain-group-error-", async (root) => {
+			for (const name of ["scout", "reviewer"]) {
+				fs.writeFileSync(path.join(root, ".pi", "agents", `${name}.md`), `---\nname: ${name}\ndescription: ${name}\n---\n\nBody\n`, "utf-8");
+			}
+
+			const { params, notifications } = await captureSlashCommandParams("chain", 'scout "scan" -> (reviewer "A")', root);
+			assert.equal(params, undefined);
+			assert.equal(notifications.length, 1);
+			assert.match(notifications[0] ?? "", /at least two/i);
+		});
+	});
 });
 
 

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -533,6 +533,13 @@ Write
 				assert.deepEqual(runCompletions.map((completion) => completion.value), ["code-analysis.scout"]);
 				const chainCompletions = commands.get("chain")!.getArgumentCompletions!("code-analysis.scout \"Scan\" -> doc") as Array<{ value: string; label: string }>;
 				assert.deepEqual(chainCompletions.map((completion) => completion.value), ["code-analysis.scout \"Scan\" -> documentation.writer"]);
+				// Regression: a bare `|` inside a `--` shared task is plain text, not a group
+				// separator, so it must not resume agent completion past the task.
+				const pipeInTask = commands.get("chain")!.getArgumentCompletions!("code-analysis.scout -- do x | doc");
+				assert.equal(pipeInTask, null);
+				// Inside an actual parallel group, `|` still separates tasks and completes agents.
+				const groupCompletions = commands.get("chain")!.getArgumentCompletions!("code-analysis.scout \"Scan\" -> (documentation.writer \"w\" | code") as Array<{ value: string; label: string }>;
+				assert.deepEqual(groupCompletions.map((completion) => completion.value), ["code-analysis.scout \"Scan\" -> (documentation.writer \"w\" | code-analysis.scout"]);
 			});
 		});
 	});

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -877,6 +877,38 @@ Gather context
 			assert.equal(group.failFast, true);
 		});
 	});
+
+	it("/chain tab-completion works inside parallel groups", async () => {
+		await withTempProject("pi-chain-group-complete-", async (root) => {
+			for (const name of ["scout", "reviewer", "writer"]) {
+				fs.writeFileSync(path.join(root, ".pi", "agents", `${name}.md`), `---\nname: ${name}\ndescription: ${name}\n---\n\nBody\n`, "utf-8");
+			}
+			await withIsolatedHome(async () => {
+				const commands = new Map<string, RegisteredSlashCommand>();
+				const pi = {
+					events: createEventBus(),
+					registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+					registerShortcut() {},
+					sendMessage(_message: unknown) {},
+				};
+				registerSlashCommands!(pi, createState(root));
+				const complete = (prefix: string) =>
+					(commands.get("chain")!.getArgumentCompletions!(prefix) as Array<{ value: string }> | null)?.map((c) => c.value) ?? null;
+
+				// after `(`
+				assert.deepEqual(complete('scout "scan" -> (rev'), ['scout "scan" -> (reviewer']);
+				// after `|`
+				assert.deepEqual(complete('scout "scan" -> (reviewer "A" | wr'), ['scout "scan" -> (reviewer "A" | writer']);
+				// after a bare `|` a space is inserted before every suggested agent
+				const barePipe = complete('scout "scan" -> (reviewer "A" |');
+				assert.ok(barePipe && barePipe.length > 0);
+				assert.ok(barePipe.every((v) => v.startsWith('scout "scan" -> (reviewer "A" | ')));
+				assert.ok(barePipe.includes('scout "scan" -> (reviewer "A" | writer'));
+				// inside an open quote: no agent completion
+				assert.equal(complete('scout "scan'), null);
+			});
+		});
+	});
 });
 
 

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -855,6 +855,28 @@ Gather context
 			assert.match(notifications[0] ?? "", /at least two/i);
 		});
 	});
+
+	it("/chain carries inline metadata and group options through to params", async () => {
+		await withTempProject("pi-chain-group-meta-", async (root) => {
+			for (const name of ["scout", "reviewer", "writer"]) {
+				fs.writeFileSync(path.join(root, ".pi", "agents", `${name}.md`), `---\nname: ${name}\ndescription: ${name}\n---\n\nBody\n`, "utf-8");
+			}
+
+			const { params, notifications } = await captureSlashCommandParams(
+				"chain",
+				'scout[as=ctx,phase=recon] "scan" -> (reviewer "A" | writer "B")[concurrency=2,failFast]',
+				root,
+			);
+			assert.deepEqual(notifications, []);
+			const built = params as { chain?: Array<Record<string, unknown>> };
+			assert.equal(built.chain?.[0]?.as, "ctx");
+			assert.equal(built.chain?.[0]?.phase, "recon");
+			const group = built.chain?.[1] as Record<string, unknown>;
+			assert.equal((group.parallel as unknown[]).length, 2);
+			assert.equal(group.concurrency, 2);
+			assert.equal(group.failFast, true);
+		});
+	});
 });
 
 

--- a/test/unit/slash-chain-groups.test.ts
+++ b/test/unit/slash-chain-groups.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	buildChainExpressionSteps,
+	hasGroupSyntax,
+	PARALLEL_GROUP_USAGE,
+	parseChainExpression,
+	parseGroupSegment,
+	parseSingleTaskToken,
+	SlashParseError,
+} from "../../src/slash/slash-commands.ts";
+
+function makeCtx(notifications: string[]): {
+	ui: { notify: (message: string, level?: string) => void };
+} {
+	return {
+		ui: {
+			notify: (message: string) => {
+				notifications.push(message);
+			},
+		},
+	};
+}
+
+function makeState(cwd: string) {
+	return {
+		baseCwd: cwd,
+	};
+}
+
+let tempRoot: string;
+
+before(() => {
+	tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-slash-chain-test-"));
+	fs.mkdirSync(path.join(tempRoot, ".pi", "agents"), { recursive: true });
+	const agentsDir = path.join(tempRoot, ".pi", "agents");
+	const writeAgent = (name: string) => {
+		fs.writeFileSync(
+			path.join(agentsDir, `${name}.md`),
+			`---\nname: ${name}\ndescription: ${name}\n---\nBody\n`,
+			"utf-8",
+		);
+	};
+	for (const name of ["scout", "reviewer", "writer", "unknown"]) {
+		writeAgent(name);
+	}
+});
+
+after(() => {
+	fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("parseSingleTaskToken", () => {
+	it("parses a quoted task", () => {
+		const parsed = parseSingleTaskToken('reviewer "review auth module"');
+		assert.equal(parsed.kind, "step");
+		assert.equal(parsed.name, "reviewer");
+		assert.equal(parsed.task, "review auth module");
+	});
+
+	it("parses an agent with inline config and no task", () => {
+		const parsed = parseSingleTaskToken(
+			"scout[output=ctx.md,outputMode=file-only]",
+		);
+		assert.equal(parsed.kind, "step");
+		assert.equal(parsed.name, "scout");
+		assert.equal(parsed.config.output, "ctx.md");
+		assert.equal(parsed.config.outputMode, "file-only");
+		assert.equal(parsed.task, undefined);
+	});
+
+	it("parses a task via -- delimiter", () => {
+		const parsed = parseSingleTaskToken("reviewer -- Review {previous}");
+		assert.equal(parsed.kind, "step");
+		assert.equal(parsed.name, "reviewer");
+		assert.equal(parsed.task, "Review {previous}");
+	});
+});
+
+describe("parseGroupSegment", () => {
+	it("parses a static parallel group with two quoted tasks", () => {
+		const parsed = parseGroupSegment('(reviewer "A" | reviewer "B")');
+		assert.equal(parsed.kind, "group");
+		assert.equal(parsed.tasks.length, 2);
+		assert.equal(parsed.tasks[0]?.name, "reviewer");
+		assert.equal(parsed.tasks[0]?.task, "A");
+		assert.equal(parsed.tasks[1]?.task, "B");
+	});
+
+	it("rejects groups with a single task", () => {
+		assert.throws(
+			() => parseGroupSegment('(reviewer "A")'),
+			(error: unknown) => error instanceof SlashParseError,
+		);
+	});
+
+	it("rejects groups with unbalanced parentheses", () => {
+		assert.throws(
+			() => parseGroupSegment('(reviewer "A"'),
+			(error: unknown) => error instanceof SlashParseError,
+		);
+	});
+});
+
+describe("hasGroupSyntax", () => {
+	it("detects parentheses", () => {
+		assert.equal(hasGroupSyntax("a -> (b | c)"), true);
+	});
+
+	it("detects pipe", () => {
+		assert.equal(hasGroupSyntax("a -> b | c"), true);
+	});
+
+	it("ignores delimiters inside quotes", () => {
+		assert.equal(hasGroupSyntax('a -> b "with | inside"'), false);
+	});
+
+	it("returns false for plain chain input", () => {
+		assert.equal(hasGroupSyntax("scout -> reviewer"), false);
+	});
+});
+
+describe("parseChainExpression", () => {
+	it("parses sequential + group + sequential", () => {
+		const expression = parseChainExpression(
+			'scout "scan" -> (reviewer "A" | reviewer "B") -> writer "fix"',
+		);
+		assert.equal(expression.steps.length, 3);
+		const group = expression.steps[1];
+		assert.ok(group);
+		assert.equal(group.kind, "group");
+		if (group.kind === "group") {
+			assert.equal(group.tasks.length, 2);
+		}
+		assert.equal(expression.steps[0]?.kind, "step");
+		assert.equal((expression.steps[0] as { name: string }).name, "scout");
+		assert.equal((expression.steps[2] as { name: string }).name, "writer");
+	});
+
+	it("rejects expression without arrows", () => {
+		assert.throws(
+			() => parseChainExpression('(reviewer "A" | reviewer "B")'),
+			(error: unknown) =>
+				error instanceof SlashParseError && error.message.includes("->"),
+		);
+	});
+
+	it("rejects groups with one task", () => {
+		assert.throws(
+			() => parseChainExpression('scout "scan" -> (reviewer "A")'),
+			(error: unknown) => error instanceof SlashParseError,
+		);
+	});
+
+	it("respects quotes when splitting on arrows", () => {
+		const expression = parseChainExpression(
+			'scout "scan -> quick" -> reviewer "Review"',
+		);
+		assert.equal(expression.steps.length, 2);
+		assert.equal(
+			(expression.steps[0] as { task: string }).task,
+			"scan -> quick",
+		);
+	});
+});
+
+describe("buildChainExpressionSteps", () => {
+	it("emits a chain with a { parallel: [...] } step for groups", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout "scan" -> (reviewer "A" | reviewer "B") -> writer "fix"',
+			makeCtx(notifications) as never,
+		);
+		assert.ok(built, "should build a chain");
+		if (!built) return;
+		assert.deepEqual(notifications, []);
+		assert.equal(built.chain.length, 3);
+		assert.equal(
+			built.chain[0] && "agent" in built.chain[0]
+				? built.chain[0].agent
+				: undefined,
+			"scout",
+		);
+		assert.equal(
+			built.chain[1] && "parallel" in built.chain[1]
+				? built.chain[1].parallel.length
+				: undefined,
+			2,
+		);
+		assert.equal(
+			built.chain[2] && "agent" in built.chain[2]
+				? built.chain[2].agent
+				: undefined,
+			"writer",
+		);
+		assert.equal(built.task, "scan");
+	});
+
+	it("preserves backward-compatible linear chain behavior", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout "scan" -> reviewer "review"',
+			makeCtx(notifications) as never,
+		);
+		assert.ok(built);
+		if (!built) return;
+		assert.equal(built.chain.length, 2);
+		assert.equal(built.task, "scan");
+	});
+
+	it("falls back to shared task when first step has no task", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			"scout -> reviewer",
+			makeCtx(notifications) as never,
+		);
+		assert.equal(built, null);
+		assert.ok(
+			notifications.some((message) => /task/i.test(message)),
+			`notifications: ${notifications.join(" | ")}`,
+		);
+	});
+
+	it("reports parallel group errors as notifications", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout "scan" -> (reviewer "A")',
+			makeCtx(notifications) as never,
+		);
+		assert.equal(built, null);
+		assert.equal(notifications.length, 1);
+		assert.match(notifications[0] ?? "", /at least two/i);
+	});
+
+	it("exports a stable parallel group usage hint", () => {
+		assert.match(PARALLEL_GROUP_USAGE, /Usage: \/chain/);
+		assert.match(PARALLEL_GROUP_USAGE, /\(/);
+		assert.match(PARALLEL_GROUP_USAGE, /\|/);
+	});
+});

--- a/test/unit/slash-chain-groups.test.ts
+++ b/test/unit/slash-chain-groups.test.ts
@@ -110,12 +110,12 @@ describe("hasGroupSyntax", () => {
 		assert.equal(hasGroupSyntax("a -> (b | c)"), true);
 	});
 
-	it("detects pipe", () => {
-		assert.equal(hasGroupSyntax("a -> b | c"), true);
+	it("does not treat a bare pipe as group syntax", () => {
+		assert.equal(hasGroupSyntax("a -> b | c"), false);
 	});
 
-	it("ignores delimiters inside quotes", () => {
-		assert.equal(hasGroupSyntax('a -> b "with | inside"'), false);
+	it("ignores parens inside quotes", () => {
+		assert.equal(hasGroupSyntax('a -> b "with (paren) inside"'), false);
 	});
 
 	it("returns false for plain chain input", () => {
@@ -237,6 +237,24 @@ describe("buildChainExpressionSteps", () => {
 		assert.equal(built, null);
 		assert.equal(notifications.length, 1);
 		assert.match(notifications[0] ?? "", /at least two/i);
+	});
+
+	it("keeps a bare pipe in a -- task on the legacy single-agent path", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			"scout -- do x | y",
+			makeCtx(notifications) as never,
+		);
+		assert.ok(built);
+		if (!built) return;
+		assert.deepEqual(notifications, []);
+		assert.equal(built.chain.length, 1);
+		assert.equal(built.task, "do x | y");
+		assert.equal(
+			built.chain[0] && "task" in built.chain[0] ? built.chain[0].task : undefined,
+			"do x | y",
+		);
 	});
 
 	it("exports a stable parallel group usage hint", () => {

--- a/test/unit/slash-chain-groups.test.ts
+++ b/test/unit/slash-chain-groups.test.ts
@@ -158,6 +158,18 @@ describe("hasGroupSyntax", () => {
 	it("returns false for plain chain input", () => {
 		assert.equal(hasGroupSyntax("scout -> reviewer"), false);
 	});
+
+	it("does not treat unquoted parens inside a -- task as group syntax", () => {
+		// Regression: a shared-task command must stay on the legacy path even when the
+		// task text contains bare parentheses. A group is a *step* that opens with `(`.
+		assert.equal(hasGroupSyntax("scout -- inspect auth (backend)"), false);
+		assert.equal(hasGroupSyntax("scout -- inspect (auth) -> writer"), false);
+	});
+
+	it("still detects a group that opens a step", () => {
+		assert.equal(hasGroupSyntax('scout "x" -> (a "y" | b "z")'), true);
+		assert.equal(hasGroupSyntax('(a "y" | b "z") -> writer'), true);
+	});
 });
 
 describe("parseChainExpression", () => {
@@ -380,6 +392,26 @@ describe("buildChainExpressionSteps", () => {
 		assert.equal(
 			built.chain[0] && "task" in built.chain[0] ? built.chain[0].task : undefined,
 			"do x | y",
+		);
+	});
+
+	it("keeps unquoted parens in a -- task on the legacy single-agent path", () => {
+		// Regression: `/chain scout -- inspect auth (backend)` was wrongly rejected as a
+		// malformed group. Bare parens in the shared task must parse as plain task text.
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			"scout -- inspect auth (backend)",
+			makeCtx(notifications) as never,
+		);
+		assert.ok(built);
+		if (!built) return;
+		assert.deepEqual(notifications, []);
+		assert.equal(built.chain.length, 1);
+		assert.equal(built.task, "inspect auth (backend)");
+		assert.equal(
+			built.chain[0] && "task" in built.chain[0] ? built.chain[0].task : undefined,
+			"inspect auth (backend)",
 		);
 	});
 

--- a/test/unit/slash-chain-groups.test.ts
+++ b/test/unit/slash-chain-groups.test.ts
@@ -121,6 +121,25 @@ describe("parseGroupSegment", () => {
 			(error: unknown) => error instanceof SlashParseError,
 		);
 	});
+
+	it("parses a trailing group-options suffix", () => {
+		const parsed = parseGroupSegment('(reviewer "A" | reviewer "B")[concurrency=2,failFast,worktree]');
+		assert.equal(parsed.tasks.length, 2);
+		assert.equal(parsed.config.concurrency, 2);
+		assert.equal(parsed.config.failFast, true);
+		assert.equal(parsed.config.worktree, true);
+	});
+
+	it("defaults to an empty group config without a suffix", () => {
+		assert.deepEqual(parseGroupSegment('(a "x" | b "y")').config, {});
+	});
+
+	it("rejects a non-bracketed group suffix", () => {
+		assert.throws(
+			() => parseGroupSegment('(a "x" | b "y") concurrency=2'),
+			(error: unknown) => error instanceof SlashParseError,
+		);
+	});
 });
 
 describe("hasGroupSyntax", () => {
@@ -288,6 +307,22 @@ describe("buildChainExpressionSteps", () => {
 		const parallel = (built.chain[1] as { parallel: Array<Record<string, unknown>> }).parallel;
 		assert.equal(parallel[0]?.count, 3);
 		assert.equal(parallel[1]?.count, undefined);
+	});
+
+	it("propagates group-level options onto the parallel step", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout "scan" -> (reviewer "A" | writer "B")[concurrency=2,failFast]',
+			makeCtx(notifications) as never,
+		);
+		assert.ok(built);
+		if (!built) return;
+		assert.deepEqual(notifications, []);
+		const group = built.chain[1] as Record<string, unknown>;
+		assert.equal(group.concurrency, 2);
+		assert.equal(group.failFast, true);
+		assert.equal(group.worktree, undefined);
 	});
 
 	it("rejects an invalid acceptance level", () => {

--- a/test/unit/slash-chain-groups.test.ts
+++ b/test/unit/slash-chain-groups.test.ts
@@ -214,6 +214,21 @@ describe("parseChainExpression", () => {
 			"scan -> quick",
 		);
 	});
+
+	it("allows balanced parens in a -- task after a group", () => {
+		const expression = parseChainExpression(
+			'scout "scan" -> (reviewer "A" | reviewer "B") -> writer -- fix (backend)',
+		);
+		assert.equal(expression.steps.length, 3);
+	});
+
+	it("still rejects truly unmatched parens in a non-group segment", () => {
+		assert.throws(
+			() => parseChainExpression('scout "scan" -> (reviewer "A" | reviewer "B") -> writer -- fix (backend'),
+			(error: unknown) =>
+				error instanceof SlashParseError && error.message.includes("Unmatched parentheses"),
+		);
+	});
 });
 
 describe("buildChainExpressionSteps", () => {
@@ -413,6 +428,20 @@ describe("buildChainExpressionSteps", () => {
 			built.chain[0] && "task" in built.chain[0] ? built.chain[0].task : undefined,
 			"inspect auth (backend)",
 		);
+	});
+
+	it("allows balanced parens in a -- task after a group step", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout "scan" -> (reviewer "A" | reviewer "B") -> writer -- fix (backend)',
+			makeCtx(notifications) as never,
+		);
+		assert.ok(built);
+		if (!built) return;
+		assert.deepEqual(notifications, []);
+		assert.equal(built.chain.length, 3);
+		assert.equal(built.task, "scan");
 	});
 
 	it("exports a stable parallel group usage hint", () => {

--- a/test/unit/slash-chain-groups.test.ts
+++ b/test/unit/slash-chain-groups.test.ts
@@ -78,6 +78,24 @@ describe("parseSingleTaskToken", () => {
 		assert.equal(parsed.name, "reviewer");
 		assert.equal(parsed.task, "Review {previous}");
 	});
+
+	it("parses extended metadata in inline config", () => {
+		const parsed = parseSingleTaskToken(
+			'reviewer[as=rev,label=Review,phase=p1,cwd=sub,count=3,acceptance=verified] "task"',
+		);
+		assert.equal(parsed.config.as, "rev");
+		assert.equal(parsed.config.label, "Review");
+		assert.equal(parsed.config.phase, "p1");
+		assert.equal(parsed.config.cwd, "sub");
+		assert.equal(parsed.config.count, 3);
+		assert.equal(parsed.config.acceptance, "verified");
+		assert.equal(parsed.task, "task");
+	});
+
+	it("ignores a non-positive count", () => {
+		assert.equal(parseSingleTaskToken("scout[count=0]").config.count, undefined);
+		assert.equal(parseSingleTaskToken("scout[count=x]").config.count, undefined);
+	});
 });
 
 describe("parseGroupSegment", () => {
@@ -237,6 +255,79 @@ describe("buildChainExpressionSteps", () => {
 		assert.equal(built, null);
 		assert.equal(notifications.length, 1);
 		assert.match(notifications[0] ?? "", /at least two/i);
+	});
+
+	it("propagates inline metadata onto chain steps", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout[as=ctx,label=Scan,phase=recon] "scan" -> reviewer "review"',
+			makeCtx(notifications) as never,
+		);
+		assert.ok(built);
+		if (!built) return;
+		assert.deepEqual(notifications, []);
+		const first = built.chain[0] as Record<string, unknown>;
+		assert.equal(first.as, "ctx");
+		assert.equal(first.label, "Scan");
+		assert.equal(first.phase, "recon");
+	});
+
+	it("applies count only inside a parallel group", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout[count=2] "scan" -> (reviewer[count=3] "A" | writer "B")',
+			makeCtx(notifications) as never,
+		);
+		assert.ok(built);
+		if (!built) return;
+		assert.deepEqual(notifications, []);
+		// sequential first step: count ignored
+		assert.equal((built.chain[0] as Record<string, unknown>).count, undefined);
+		const parallel = (built.chain[1] as { parallel: Array<Record<string, unknown>> }).parallel;
+		assert.equal(parallel[0]?.count, 3);
+		assert.equal(parallel[1]?.count, undefined);
+	});
+
+	it("rejects an invalid acceptance level", () => {
+		const notifications: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout[acceptance=bogus] "scan" -> reviewer "review"',
+			makeCtx(notifications) as never,
+		);
+		assert.equal(built, null);
+		assert.equal(notifications.length, 1);
+		assert.match(notifications[0] ?? "", /acceptance/i);
+	});
+
+	it("loads an inline outputSchema path and rejects a missing one", () => {
+		fs.writeFileSync(
+			path.join(tempRoot, "schema.json"),
+			JSON.stringify({ type: "object" }),
+			"utf-8",
+		);
+		const ok: string[] = [];
+		const built = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout[outputSchema=schema.json] "scan" -> reviewer "review"',
+			makeCtx(ok) as never,
+		);
+		assert.ok(built);
+		if (built) {
+			assert.deepEqual((built.chain[0] as Record<string, unknown>).outputSchema, { type: "object" });
+		}
+
+		const missing: string[] = [];
+		const bad = buildChainExpressionSteps(
+			makeState(tempRoot) as never,
+			'scout[outputSchema=nope.json] "scan" -> reviewer "review"',
+			makeCtx(missing) as never,
+		);
+		assert.equal(bad, null);
+		assert.equal(missing.length, 1);
+		assert.match(missing[0] ?? "", /outputSchema/i);
 	});
 
 	it("keeps a bare pipe in a -- task on the legacy single-agent path", () => {


### PR DESCRIPTION
Brings the inline `/chain` slash command to parity with the `ChainStep` model for
everything that fits on a single line: static parallel groups, per-step/per-task
metadata, group-level options, and group-aware tab completion. Dynamic fan-out
(`expand`/`collect`) is intentionally left out — it stays available through the
`subagent({ chain: [...] })` tool API and saved `.chain.json` files.

This is a fresh, current-main revision of the previously closed PR. See
"Changes since the previous review" below for what changed.

```text
/chain scout[as=ctx,phase=recon] "scan" -> (reviewer "review A" | reviewer[count=2] "review B")[concurrency=2,failFast] -> writer[outputSchema=schema.json,acceptance=verified] "fix"
```

## What's included

### Parallel groups (base)
Wrap agents in `( ... )` separated by `|` to fan them out as a single
`{ parallel: [...] }` chain step; the next `->` step continues once they finish.
A group must *open* a step — only a step that begins with `(` is parsed as a group,
so parentheses inside a shared `--` task (e.g. `/chain scout -- inspect auth (backend)`)
stay literal and keep the legacy single-agent behavior. Linear `/chain` behavior is
unchanged.

### Inline step/task metadata
Extended the `[key=value,...]` config with:

| Key            | Description                                                           |
| -------------- | --------------------------------------------------------------------- |
| `as`           | Name this step's output for later reference.                          |
| `label`        | Human-readable step label.                                            |
| `phase`        | Group steps into a named phase.                                       |
| `cwd`          | Run the step in a subdirectory.                                       |
| `count`        | Fan a group task into N copies (only inside a `( ... )` group).       |
| `outputSchema` | Path to a JSON Schema file, read relative to cwd and validated.       |
| `acceptance`   | Acceptance level (`none`/`attested`/`checked`/`verified`/`reviewed`). |

`outputSchema` is validated via `assertJsonSchemaObject`, `acceptance` via
`validateAcceptanceInput`; parse/load errors surface through `ctx.ui.notify`
instead of throwing. Inline values must not contain spaces or commas (unchanged
constraint).

### Group-level options
A trailing `[...]` suffix after the closing `)` sets step-level options on the group:

```text
/chain a "x" -> (b "y" | c "z")[concurrency=2,failFast,worktree]
```

`concurrency`, `failFast`, and `worktree` map onto the emitted parallel step.

### Group-aware tab completion
The multi-agent completion finds the current step after the last top-level `->` or
`(`, or after a `|` *inside* a group — tracking quotes and paren depth so separators
inside a task are ignored. Agents are suggested after an opening paren, after a `|`
inside a group, and on each new arrow step. A bare `->`/`|` gets a separating space.
Completion is suppressed inside an open quote and once a top-level `--` task has
begun. Linear-chain completion is unchanged.

## Changes since the previous review

- **Rebased onto current main** (was conflicting). Applied cleanly with no behavioral
  changes to the group work.
- **Unquoted parens in a `--` task no longer rejected.** `hasGroupSyntax` now treats
  `(` as group syntax only when it opens a top-level step, so a normal shared-task
  command like `/chain scout -- inspect auth (backend)` parses as plain task text
  instead of failing as a malformed group.
- **Completion no longer resumes after a `--` task.** A `|` only restarts agent
  suggestions inside a `( ... )` group; outside a group it is task text, so
  `scout -- do x | wr` no longer wrongly suggests `writer` past the `--`.
- Added focused regressions for both cases (parser + completion) and documented the
  "a group opens with `(`" rule in `README.md`.

## Non-goals
- Dynamic fan-out (`expand`/`collect`) inline — data-driven fan-out relies on JSON
  pointer paths and schemas that don't fit a single slash line.
- Full `acceptance` config objects inline — only the level shorthand is supported;
  use a saved chain for the full structure.

## Validation

```bash
node --experimental-strip-types --test test/unit/slash-chain-groups.test.ts
node --experimental-transform-types --import ./test/support/register-loader.mjs \
  --test test/integration/slash-commands.test.ts
```
