### PR TITLE
Preserve compact tool calls for prompt-template delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - List configured subagent skills by name, description, and file path instead of inlining full skill bodies, and ensure tool-restricted children can read those skill files on demand. Thanks to Ruben Paz (@Istar-Eldritch) for #183.
 - Actually wire the previously documented foreground-only `timeoutMs`/`maxRuntimeMs` aliases through single, parallel, chain, and dynamic fanout runs, including stable `timedOut: true` results, preserved partial output, manual-interrupt precedence, and skipped acceptance verification after timeout.
 - Apply `subagents.agentOverrides.<name>` to matching user-scope and project-scope custom agents, while keeping explicit agent frontmatter authoritative per field. Thanks to Jacek Juraszek (@jjuraszek) for #218.
+- Preserve compact foreground `write`/`edit` tool-call evidence in prompt-template delegation responses so convergence checks do not stop loops early. Thanks to Hans Schnedlitz (@hschne) for #207.
 
 ## [0.30.0] - 2026-06-20
 

--- a/src/slash/prompt-template-bridge.ts
+++ b/src/slash/prompt-template-bridge.ts
@@ -79,6 +79,7 @@ interface PromptTemplateBridgeResult {
 			agent?: string;
 			messages?: unknown[];
 			finalOutput?: string;
+			toolCalls?: Array<{ text?: string; expandedText?: string }>;
 			exitCode?: number;
 			error?: string;
 			model?: string;
@@ -209,13 +210,35 @@ function resolveProgressModel(
 	return firstWithModel?.model;
 }
 
-function buildDelegationMessages(result: { messages?: unknown[]; finalOutput?: string }, fallbackText?: string): unknown[] {
+function toolCallNameFromSummary(summary: { text?: string; expandedText?: string }): string | undefined {
+	const text = typeof summary.expandedText === "string" && summary.expandedText.trim().length > 0
+		? summary.expandedText.trim()
+		: typeof summary.text === "string"
+			? summary.text.trim()
+			: "";
+	if (!text) return undefined;
+	if (text.startsWith("$ ")) return "bash";
+	return text.match(/^[A-Za-z_][\w.-]*/)?.[0];
+}
+
+function buildDelegationMessages(
+	result: { messages?: unknown[]; finalOutput?: string; toolCalls?: Array<{ text?: string; expandedText?: string }> },
+	fallbackText?: string,
+): unknown[] {
 	if (Array.isArray(result.messages) && result.messages.length > 0) return result.messages;
+	const toolCallParts = (result.toolCalls ?? []).flatMap((summary) => {
+		const name = toolCallNameFromSummary(summary);
+		return name ? [{ type: "toolCall", name, arguments: { summary: summary.expandedText ?? summary.text ?? "" } }] : [];
+	});
 	const text = typeof result.finalOutput === "string" && result.finalOutput.trim().length > 0
 		? result.finalOutput.trim()
 		: fallbackText;
-	if (!text) return [];
-	return [{ role: "assistant", content: [{ type: "text", text }] }];
+	const content = [
+		...toolCallParts,
+		...(text ? [{ type: "text", text }] : []),
+	];
+	if (content.length === 0) return [];
+	return [{ role: "assistant", content }];
 }
 
 function toDelegationUpdate(requestId: string, update: PromptTemplateBridgeResult): PromptTemplateDelegationUpdate | undefined {

--- a/test/unit/prompt-template-bridge.test.ts
+++ b/test/unit/prompt-template-bridge.test.ts
@@ -114,6 +114,46 @@ describe("prompt-template delegation bridge", () => {
 		bridge.dispose();
 	});
 
+	it("rebuilds compact tool-call summaries into delegated response messages", async () => {
+		const events = new FakeEvents();
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => ({
+				details: {
+					results: [{
+						finalOutput: "finished",
+						toolCalls: [
+							{ text: "write src/output.md", expandedText: "write src/output.md" },
+							{ text: "edit src/output.md", expandedText: "edit src/output.md" },
+						],
+					}],
+				},
+			}),
+		});
+
+		const responsePromise = once(events, PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT);
+		events.emit(PROMPT_TEMPLATE_SUBAGENT_REQUEST_EVENT, {
+			requestId: "r-compact-tools",
+			agent: "worker",
+			task: "do work",
+			context: "fresh",
+			model: "openai/gpt-5",
+			cwd: "/repo",
+		});
+
+		const response = await responsePromise as { messages: Array<{ role?: string; content?: Array<{ type?: string; name?: string; text?: string }> }> };
+		assert.equal(response.messages.length, 1);
+		assert.equal(response.messages[0]?.role, "assistant");
+		assert.deepEqual(
+			response.messages[0]?.content?.filter((part) => part.type === "toolCall").map((part) => part.name),
+			["write", "edit"],
+		);
+		assert.equal(response.messages[0]?.content?.some((part) => part.type === "text" && part.text === "finished"), true);
+
+		bridge.dispose();
+	});
+
 	it("filters malformed recent output entries in updates", async () => {
 		const events = new FakeEvents();
 		const bridge = registerPromptTemplateDelegationBridge({


### PR DESCRIPTION
Fixes #207.

Foreground result compaction kept compact tool-call summaries, but the prompt-template bridge only rebuilt fallback text messages when raw messages were stripped. This rebuilds minimal assistant toolCall blocks from those summaries so convergence checks can still see write/edit calls without carrying full message histories.

Tests:
- node --experimental-strip-types --test test/unit/prompt-template-bridge.test.ts
- npm run test:unit
- npm run test:integration

Fresh xhigh review found no blockers.