### PR TITLE
Stabilize crowded async widget height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Keep crowded async subagent widgets at a stable collapsed height in short terminals, reducing destructive full-screen TUI redraws and flicker. Thanks to ssyram (@ssyram) for #186.
+
 ## [0.30.0] - 2026-06-20
 
 ### Added

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -899,11 +899,189 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 	return lines.map((line) => truncLine(line, width));
 }
 
+type WidgetRenderTier = "full" | "single-line" | "progressive";
+
+interface WidgetLayoutSession {
+	expanded: boolean;
+	rows: number;
+	columns: number;
+	tier: WidgetRenderTier;
+	lockedRows?: number;
+	visibleJobKeys: string[];
+}
+
+const RESERVED_NON_WIDGET_ROWS = 19;
+
+let widgetLayoutSession: WidgetLayoutSession | undefined;
+
+function resetWidgetLayoutSession(): void {
+	widgetLayoutSession = undefined;
+}
+
+function estimateAvailableWidgetRows(): number {
+	const rows = process.stdout.rows || 30;
+	return Math.max(1, rows - RESERVED_NON_WIDGET_ROWS);
+}
+
+function currentTerminalRows(): number {
+	return process.stdout.rows || 30;
+}
+
+function currentTerminalColumns(): number {
+	return process.stdout.columns || 120;
+}
+
+function widgetSessionMatches(expanded: boolean): boolean {
+	return widgetLayoutSession?.expanded === expanded
+		&& widgetLayoutSession.rows === currentTerminalRows()
+		&& widgetLayoutSession.columns === currentTerminalColumns();
+}
+
+function widgetHeaderCounts(jobs: AsyncJobState[]): { running: AsyncJobState[]; queued: AsyncJobState[]; complete: AsyncJobState[]; failed: AsyncJobState[]; paused: AsyncJobState[] } {
+	return {
+		running: jobs.filter((job) => job.status === "running"),
+		queued: jobs.filter((job) => job.status === "queued"),
+		complete: jobs.filter((job) => job.status === "complete"),
+		failed: jobs.filter((job) => job.status === "failed"),
+		paused: jobs.filter((job) => job.status === "paused"),
+	};
+}
+
+function buildSingleLineWidgetLines(jobs: AsyncJobState[], theme: Theme, width: number): string[] {
+	const counts = widgetHeaderCounts(jobs);
+	const hasActive = counts.running.length > 0 || counts.queued.length > 0;
+	const glyph = counts.running.length > 0 ? runningGlyph(widgetJobsRunningSeed(counts.running)) : hasActive ? "●" : "○";
+	const parts: string[] = [];
+	if (counts.running.length > 0) parts.push(`${counts.running.length}/${jobs.length} running`);
+	if (counts.queued.length > 0) parts.push(`${counts.queued.length} queued`);
+	if (counts.failed.length > 0) parts.push(`${counts.failed.length} failed`);
+	if (counts.paused.length > 0) parts.push(`${counts.paused.length} paused`);
+	if (!hasActive && counts.complete.length > 0) parts.push(`${counts.complete.length}/${jobs.length} done`);
+	return [truncLine(`${theme.fg(hasActive ? "accent" : "dim", glyph)} ${theme.fg(hasActive ? "accent" : "dim", "subagents")} (${parts.join(", ") || `${jobs.length} total`})`, width)];
+}
+
+function orderedWidgetJobs(jobs: AsyncJobState[]): AsyncJobState[] {
+	return [
+		...jobs.filter((job) => job.status === "running"),
+		...jobs.filter((job) => job.status === "queued"),
+		...jobs.filter((job) => job.status !== "running" && job.status !== "queued"),
+	];
+}
+
+function progressiveJobKey(job: AsyncJobState): string {
+	return job.asyncId;
+}
+
+function isProgressiveActiveJob(job: AsyncJobState | undefined): boolean {
+	return job?.status === "running" || job?.status === "queued";
+}
+
+function selectProgressiveJobKeys(jobs: AsyncJobState[], previousKeys: string[], bodyRows: number): string[] {
+	if (bodyRows <= 0) return [];
+	const jobsByKey = new Map(jobs.map((job) => [progressiveJobKey(job), job]));
+	const selected: string[] = [];
+	const append = (key: string): void => {
+		if (selected.includes(key) || !jobsByKey.has(key)) return;
+		selected.push(key);
+	};
+	for (const key of previousKeys) {
+		if (!isProgressiveActiveJob(jobsByKey.get(key))) continue;
+		append(key);
+		if (selected.length >= bodyRows) return selected;
+	}
+	for (const job of orderedWidgetJobs(jobs)) {
+		if (!isProgressiveActiveJob(job)) continue;
+		const key = progressiveJobKey(job);
+		append(key);
+		if (selected.length >= bodyRows) break;
+	}
+	if (selected.length >= bodyRows) return selected;
+	for (const key of previousKeys) {
+		if (isProgressiveActiveJob(jobsByKey.get(key))) continue;
+		append(key);
+		if (selected.length >= bodyRows) return selected;
+	}
+	for (const job of orderedWidgetJobs(jobs)) {
+		const key = progressiveJobKey(job);
+		append(key);
+		if (selected.length >= bodyRows) break;
+	}
+	return selected;
+}
+
+function progressiveHeaderLine(jobs: AsyncJobState[], theme: Theme, width: number): string {
+	const counts = widgetHeaderCounts(jobs);
+	const hasActive = counts.running.length > 0 || counts.queued.length > 0;
+	const glyph = counts.running.length > 0 ? runningGlyph(widgetJobsRunningSeed(counts.running)) : hasActive ? "●" : "○";
+	const parts: string[] = [];
+	if (counts.running.length > 0) parts.push(formatAgentRunningLabel(counts.running.length));
+	if (counts.queued.length > 0) parts.push(`${counts.queued.length} queued`);
+	if (!hasActive) {
+		if (counts.failed.length > 0) parts.push(`${counts.failed.length} failed`);
+		if (counts.paused.length > 0) parts.push(`${counts.paused.length} paused`);
+		if (counts.complete.length > 0) parts.push(`${counts.complete.length}/${jobs.length} done`);
+	}
+	return truncLine(`${theme.fg(hasActive ? "accent" : "dim", glyph)} ${theme.fg(hasActive ? "accent" : "dim", "Async agents")} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(", ") || `${jobs.length} total`)}`, width);
+}
+
+function progressiveJobLine(job: AsyncJobState, theme: Theme, width: number): string {
+	const stats = widgetStats(job, theme);
+	const activity = widgetActivity(job);
+	const status = job.status === "complete" ? "done" : job.status;
+	const parts = [
+		themeBold(theme, widgetJobName(job)),
+		theme.fg("dim", status),
+		stats,
+		activity && activity.toLowerCase() !== status ? theme.fg("dim", activity) : "",
+	].filter(Boolean);
+	return truncLine(`  ${widgetStatusGlyph(job, theme)} ${parts.join(` ${theme.fg("dim", "·")} `)}`, width);
+}
+
+function progressiveHiddenLine(hiddenJobs: AsyncJobState[], theme: Theme, width: number): string {
+	const counts = widgetHeaderCounts(hiddenJobs);
+	const parts: string[] = [];
+	if (counts.running.length > 0) parts.push(`${counts.running.length} running`);
+	if (counts.queued.length > 0) parts.push(`${counts.queued.length} queued`);
+	const finished = counts.complete.length + counts.failed.length + counts.paused.length;
+	if (finished > 0) parts.push(`${finished} finished`);
+	return truncLine(theme.fg("dim", `  +${hiddenJobs.length} more${parts.length ? ` (${parts.join(", ")})` : ""}`), width);
+}
+
+function buildProgressiveWidgetLines(jobs: AsyncJobState[], theme: Theme, width: number, lockedRows: number, previousKeys: string[]): { lines: string[]; visibleJobKeys: string[] } {
+	const rowCount = Math.max(1, lockedRows);
+	if (rowCount === 1) return { lines: buildSingleLineWidgetLines(jobs, theme, width), visibleJobKeys: [] };
+
+	const bodyRows = rowCount - 1;
+	let visibleJobKeys = selectProgressiveJobKeys(jobs, previousKeys, bodyRows);
+	const jobsByKey = new Map(jobs.map((job) => [progressiveJobKey(job), job]));
+	let visibleJobs = visibleJobKeys.map((key) => jobsByKey.get(key)).filter((job): job is AsyncJobState => Boolean(job));
+	let hiddenJobs = jobs.filter((job) => !visibleJobKeys.includes(progressiveJobKey(job)));
+	const needsHiddenLine = hiddenJobs.length > 0;
+
+	if (needsHiddenLine && visibleJobs.length >= bodyRows && bodyRows > 0) {
+		visibleJobs = visibleJobs.slice(0, bodyRows - 1);
+		visibleJobKeys = visibleJobs.map(progressiveJobKey);
+		hiddenJobs = jobs.filter((job) => !visibleJobKeys.includes(progressiveJobKey(job)));
+	}
+
+	const lines = [
+		progressiveHeaderLine(jobs, theme, width),
+		...visibleJobs.map((job) => progressiveJobLine(job, theme, width)),
+	];
+	if (hiddenJobs.length > 0 && lines.length < rowCount) lines.push(progressiveHiddenLine(hiddenJobs, theme, width));
+	while (lines.length < rowCount) lines.push(" ");
+	return { lines: lines.slice(0, rowCount), visibleJobKeys };
+}
+
+function collapsedWidgetLineBudget(rows: number): number {
+	return Math.max(10, Math.min(14, Math.floor(rows * 0.35)));
+}
+
 function fitWidgetLineBudget(lines: string[], theme: Theme, width: number, expanded: boolean): string[] {
 	const rows = process.stdout.rows || 30;
 	const budget = expanded
 		? Math.max(12, Math.min(24, Math.floor(rows * 0.55)))
-		: Math.max(10, Math.min(14, Math.floor(rows * 0.35)));
+		: collapsedWidgetLineBudget(rows);
 	if (lines.length <= budget) return lines;
 	const visibleLines = Math.max(1, budget - 1);
 	const hiddenCount = lines.length - visibleLines;
@@ -911,6 +1089,43 @@ function fitWidgetLineBudget(lines: string[], theme: Theme, width: number, expan
 		? `… ${hiddenCount} live-detail lines hidden`
 		: `… ${hiddenCount} lines hidden · Ctrl+O expands`;
 	return [...lines.slice(0, visibleLines), truncLine(theme.fg("dim", hint), width)];
+}
+
+function fitAdaptiveWidgetLines(jobs: AsyncJobState[], lines: string[], theme: Theme, width: number, expanded: boolean): string[] {
+	if (expanded) {
+		resetWidgetLayoutSession();
+		return fitWidgetLineBudget(lines, theme, width, true);
+	}
+
+	const hasMatchingSession = widgetSessionMatches(expanded);
+	const rows = currentTerminalRows();
+	const columns = currentTerminalColumns();
+	const availableRows = estimateAvailableWidgetRows();
+
+	if (hasMatchingSession && widgetLayoutSession?.tier === "single-line") {
+		return buildSingleLineWidgetLines(jobs, theme, width);
+	}
+
+	if (hasMatchingSession && widgetLayoutSession?.tier === "progressive" && widgetLayoutSession.lockedRows !== undefined) {
+		const rendered = buildProgressiveWidgetLines(jobs, theme, width, widgetLayoutSession.lockedRows, widgetLayoutSession.visibleJobKeys);
+		widgetLayoutSession.visibleJobKeys = rendered.visibleJobKeys;
+		return rendered.lines;
+	}
+
+	if (lines.length <= availableRows) {
+		widgetLayoutSession = { expanded, rows, columns, tier: "full", visibleJobKeys: [] };
+		return fitWidgetLineBudget(lines, theme, width, false);
+	}
+
+	if (availableRows <= 2) {
+		widgetLayoutSession = { expanded, rows, columns, tier: "single-line", visibleJobKeys: [] };
+		return buildSingleLineWidgetLines(jobs, theme, width);
+	}
+
+	const lockedRows = Math.min(availableRows, collapsedWidgetLineBudget(rows));
+	const rendered = buildProgressiveWidgetLines(jobs, theme, width, lockedRows, []);
+	widgetLayoutSession = { expanded, rows, columns, tier: "progressive", lockedRows, visibleJobKeys: rendered.visibleJobKeys };
+	return rendered.lines;
 }
 
 function buildWidgetComponent(jobs: AsyncJobState[], expanded: boolean): (_tui: unknown, theme: Theme) => Component {
@@ -922,7 +1137,7 @@ function buildWidgetComponent(jobs: AsyncJobState[], expanded: boolean): (_tui: 
 				? compactSingleWidgetLines(jobs[0]!, theme, width)
 				: buildWidgetLines(jobs, theme, width, false);
 		const container = new Container();
-		for (const line of fitWidgetLineBudget(lines, theme, width, expanded)) container.addChild(new Text(line, 1, 0));
+		for (const line of fitAdaptiveWidgetLines(jobs, lines, theme, width, expanded)) container.addChild(new Text(line, 1, 0));
 		return container;
 	};
 }
@@ -1002,6 +1217,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
  */
 export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void {
 	if (jobs.length === 0) {
+		resetWidgetLayoutSession();
 		if (ctx.hasUI) ctx.ui.setWidget(WIDGET_KEY, undefined);
 		return;
 	}

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -54,6 +54,36 @@ function createUiContext() {
 	};
 }
 
+function renderWidgetLines(widget: unknown, width = 180): string[] {
+	return (widget as (_tui: unknown, widgetTheme: typeof theme) => { render(width: number): string[] })(undefined, theme).render(width);
+}
+
+function restoreDescriptor(target: object, key: string, descriptor: PropertyDescriptor | undefined): void {
+	if (descriptor) {
+		Object.defineProperty(target, key, descriptor);
+		return;
+	}
+	Reflect.deleteProperty(target, key);
+}
+
+function withStdoutSize<T>(rows: number, columns: number, fn: () => T): T {
+	const stdout = process.stdout as NodeJS.WriteStream & { rows?: number; columns?: number };
+	const rowsDescriptor = Object.getOwnPropertyDescriptor(stdout, "rows");
+	const columnsDescriptor = Object.getOwnPropertyDescriptor(stdout, "columns");
+	Object.defineProperty(stdout, "rows", { configurable: true, value: rows });
+	Object.defineProperty(stdout, "columns", { configurable: true, value: columns });
+	try {
+		return fn();
+	} finally {
+		restoreDescriptor(stdout, "rows", rowsDescriptor);
+		restoreDescriptor(stdout, "columns", columnsDescriptor);
+	}
+}
+
+function resetWidgetLayout(): void {
+	renderWidget(createUiContext().ctx as never, []);
+}
+
 describe("subagent async widget rendering", () => {
 	it("orders running jobs before queued summaries and completions", () => {
 		const lines = buildWidgetLines([
@@ -123,6 +153,152 @@ describe("subagent async widget rendering", () => {
 		assert.match(text, /Press Ctrl\+O for live detail/);
 		assert.doesNotMatch(text, /widget truncated/);
 		assert.ok(lines.length <= 10, "collapsed component should stay under Pi's string-widget cap even though it bypasses it");
+	});
+
+	it("locks crowded collapsed widget height for the current terminal session", () => {
+		resetWidgetLayout();
+		withStdoutSize(30, 120, () => {
+			const now = 20_000;
+			const crowdedJobs = Array.from({ length: 3 }, (_, jobIndex) => ({
+				asyncId: `run-${jobIndex + 1}`,
+				asyncDir: `/tmp/run-${jobIndex + 1}`,
+				status: "running",
+				mode: "parallel",
+				agents: ["scout", "reviewer"],
+				activeParallelGroup: true,
+				runningSteps: 2,
+				completedSteps: 0,
+				stepsTotal: 2,
+				updatedAt: now + jobIndex,
+				steps: [
+					{ index: 0, agent: "scout", status: "running", currentTool: "read", currentToolStartedAt: now - 1000 },
+					{ index: 1, agent: "reviewer", status: "running", currentTool: "grep", currentToolStartedAt: now - 2000 },
+				],
+			}));
+			const ui = createUiContext();
+
+			renderWidget(ui.ctx as never, crowdedJobs);
+			const crowdedLines = renderWidgetLines(ui.widgets.at(-1));
+			assert.equal(crowdedLines.length, 10, "30 terminal rows should keep the compact widget cap while locking height");
+			assert.match(crowdedLines.join("\n"), /Async agents · 3 agents running/);
+
+			renderWidget(ui.ctx as never, [{
+				...crowdedJobs[0]!,
+				status: "complete",
+				runningSteps: 0,
+				completedSteps: 2,
+				steps: [
+					{ index: 0, agent: "scout", status: "complete" },
+					{ index: 1, agent: "reviewer", status: "complete" },
+				],
+			}]);
+			const settledLines = renderWidgetLines(ui.widgets.at(-1));
+			assert.equal(settledLines.length, 10, "collapsed widget keeps its locked row count until cleared or resized");
+			assert.match(settledLines.join("\n"), /parallel · done/);
+
+			renderWidget(ui.ctx as never, []);
+			renderWidget(ui.ctx as never, [{ asyncId: "small", asyncDir: "/tmp/small", status: "running", agents: ["worker"], currentTool: "read" }]);
+			const resetLines = renderWidgetLines(ui.widgets.at(-1));
+			assert.ok(resetLines.length < 10, "clearing the widget starts a fresh layout session");
+		});
+		resetWidgetLayout();
+	});
+
+	it("keeps medium terminal progressive fallback within the compact cap", () => {
+		resetWidgetLayout();
+		withStdoutSize(50, 120, () => {
+			const ui = createUiContext();
+			const jobs = [{
+				asyncId: "run-wide",
+				asyncDir: "/tmp/run-wide",
+				status: "running",
+				mode: "parallel",
+				agents: Array.from({ length: 40 }, (_, index) => `agent-${index}`),
+				activeParallelGroup: true,
+				runningSteps: 40,
+				completedSteps: 0,
+				stepsTotal: 40,
+				steps: Array.from({ length: 40 }, (_, index) => ({ index, agent: `agent-${index}`, status: "running", currentTool: "read" })),
+			}];
+
+			renderWidget(ui.ctx as never, jobs);
+			const lines = renderWidgetLines(ui.widgets.at(-1));
+			assert.equal(lines.length, 14);
+			assert.match(lines.join("\n"), /parallel · running/);
+		});
+		resetWidgetLayout();
+	});
+
+	it("keeps constrained progressive slots focused on active jobs", () => {
+		resetWidgetLayout();
+		withStdoutSize(22, 120, () => {
+			const ui = createUiContext();
+			const jobs = [
+				{ asyncId: "run-1", asyncDir: "/tmp/run-1", status: "running", mode: "single", agents: ["first"], currentTool: "read" },
+				{ asyncId: "run-2", asyncDir: "/tmp/run-2", status: "running", mode: "single", agents: ["second"], currentTool: "grep" },
+				{ asyncId: "run-3", asyncDir: "/tmp/run-3", status: "running", mode: "single", agents: ["third"], currentTool: "edit" },
+			];
+			renderWidget(ui.ctx as never, jobs);
+			const firstText = renderWidgetLines(ui.widgets.at(-1)).join("\n");
+			assert.match(firstText, /first/);
+			assert.match(firstText, /\+2 more/);
+
+			renderWidget(ui.ctx as never, [
+				{ ...jobs[0]!, status: "complete", currentTool: undefined },
+				jobs[1]!,
+				jobs[2]!,
+			]);
+			const updatedText = renderWidgetLines(ui.widgets.at(-1)).join("\n");
+			assert.match(updatedText, /second/);
+			assert.doesNotMatch(updatedText, /first · done/);
+			assert.match(updatedText, /\+2 more/);
+		});
+		resetWidgetLayout();
+	});
+
+	it("uses a single collapsed widget line when the terminal has almost no spare rows", () => {
+		resetWidgetLayout();
+		withStdoutSize(20, 120, () => {
+			const ui = createUiContext();
+			renderWidget(ui.ctx as never, [{
+				asyncId: "run-tiny",
+				asyncDir: "/tmp/run-tiny",
+				status: "running",
+				agents: ["worker"],
+				currentTool: "read",
+			}]);
+
+			const lines = renderWidgetLines(ui.widgets.at(-1));
+			assert.equal(lines.length, 1);
+			assert.match(lines[0] ?? "", /subagents \(1\/1 running\)/);
+		});
+		resetWidgetLayout();
+	});
+
+	it("keeps expanded async widgets on the full-detail path", () => {
+		resetWidgetLayout();
+		withStdoutSize(20, 120, () => {
+			const ui = createUiContext();
+			ui.ctx.ui.getToolsExpanded = () => true;
+			renderWidget(ui.ctx as never, [{
+				asyncId: "run-expanded",
+				asyncDir: "/tmp/run-expanded",
+				status: "running",
+				mode: "parallel",
+				agents: ["reviewer"],
+				activeParallelGroup: true,
+				runningSteps: 1,
+				completedSteps: 0,
+				stepsTotal: 1,
+				steps: [{ index: 0, agent: "reviewer", status: "running", currentTool: "read" }],
+			}]);
+
+			const text = renderWidgetLines(ui.widgets.at(-1)).join("\n");
+			assert.match(text, /async subagent parallel · background/);
+			assert.match(text, /Agent 1\/1: reviewer · running/);
+			assert.doesNotMatch(text, /subagents \(1\/1 running\)/);
+		});
+		resetWidgetLayout();
 	});
 
 	it("shows per-agent detail for active async parallel widget rows", () => {


### PR DESCRIPTION
Fixes #186.

This keeps collapsed async widgets from changing height once they hit constrained rendering. The widget still uses the existing full compact path when it fits; when it does not, it uses a single-line or progressive layout locked to the estimated available height, capped by the existing compact budget. Expanded view remains full-detail.

Tests:
- node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts
- npm run test:integration
- npm run test:unit