### PR TITLE
List subagent skills lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Added `subagents.disableThinking` so bundled builtin agents can drop thinking suffix defaults for providers that do not accept them. Thanks to Joshua Harding (@jhstatewide) for #212.
+- List configured subagent skills by name, description, and file path instead of inlining full skill bodies, and ensure tool-restricted children can read those skill files on demand. Thanks to Ruben Paz (@Istar-Eldritch) for #183.
 - Actually wire the previously documented foreground-only `timeoutMs`/`maxRuntimeMs` aliases through single, parallel, chain, and dynamic fanout runs, including stable `timedOut: true` results, preserved partial output, manual-interrupt precedence, and skipped acceptance verification after timeout.
 - Apply `subagents.agentOverrides.<name>` to matching user-scope and project-scope custom agents, while keeping explicit agent frontmatter authoritative per field. Thanks to Jacek Juraszek (@jjuraszek) for #218.
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Append `[key=value,...]` to an agent name to override defaults for that step:
 | `outputMode` | `outputMode=file-only` | Return only a concise file reference for saved output instead of the full saved content. Requires `output`; default is `inline`. |
 | `reads` | `reads=a.md+b.md` | Read files before executing. `+` separates multiple paths. |
 | `model` | `model=anthropic/claude-sonnet-4` | Override model for this step. |
-| `skills` | `skills=planning+review` | Override injected skills. `+` separates multiple skills. |
+| `skills` | `skills=planning+review` | Override available skills. `+` separates multiple skills. |
 | `progress` | `progress` | Enable progress tracking. |
 
 Set `output=false`, `reads=false`, or `skills=false` to disable that behavior explicitly. Do not use `output=false` for file-only returns; use `outputMode=file-only` with an `output` path.
@@ -462,7 +462,7 @@ Important fields:
 | `inheritProjectContext` | Keeps or strips inherited project instruction blocks. |
 | `inheritSkills` | Keeps or strips Pi’s discovered skills catalog. |
 | `defaultContext` | Optional `fresh` or `fork` launch context default for this agent. |
-| `skills` | Injects specific skills directly, regardless of `inheritSkills`. |
+| `skills` | Adds specific skills to the child’s available skill list, regardless of `inheritSkills`. |
 | `output` | Default single-agent output file. |
 | `defaultReads` | Files to read before running in chain/parallel behavior. |
 | `defaultProgress` | Maintain `progress.md`. |
@@ -609,7 +609,7 @@ Parallel outputs are aggregated with clear separators before being passed to the
 
 ## Skills
 
-Skills are `SKILL.md` files injected into an agent’s system prompt.
+Skills are `SKILL.md` files made available to an agent. The prompt includes skill metadata and the file location; the agent reads the full skill file only when the task matches.
 
 Discovery uses project-first precedence:
 
@@ -631,13 +631,23 @@ Use agent defaults, override them at runtime, or disable them:
 
 For chains, `skill` at the top level is additive. A step-level `skill` overrides that step; `false` disables skills for that step.
 
-Injected skills use this shape:
+Available skills use this shape:
 
 ```xml
-<skill name="safe-bash">
-[skill content from SKILL.md, frontmatter stripped]
-</skill>
+The following configured skills are available to this subagent.
+Use the read tool to load a skill's file when the task matches its description.
+When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.
+
+<available_skills>
+  <skill>
+    <name>safe-bash</name>
+    <description>Run shell commands safely.</description>
+    <location>/absolute/path/to/safe-bash/SKILL.md</location>
+  </skill>
+</available_skills>
 ```
+
+If an agent has an explicit `tools` allowlist and resolved skills, `read` is added for that child run so the listed skill files can be loaded on demand.
 
 Missing skills do not fail execution. The result summary shows a warning.
 

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -23,6 +23,7 @@ interface ResolvedSkill {
 	name: string;
 	path: string;
 	content: string;
+	description?: string;
 	source: SkillSource;
 }
 
@@ -508,10 +509,12 @@ function readSkill(
 
 		const raw = fs.readFileSync(skillPath, "utf-8");
 		const content = stripSkillFrontmatter(raw);
+		const description = maybeReadSkillDescription(skillPath);
 		const skill: ResolvedSkill = {
 			name: skillName,
 			path: skillPath,
 			content,
+			description,
 			source,
 		};
 
@@ -579,9 +582,29 @@ export function resolveSkillsWithFallback(
 export function buildSkillInjection(skills: ResolvedSkill[]): string {
 	if (skills.length === 0) return "";
 
-	return skills
-		.map((s) => `<skill name="${s.name}">\n${s.content}\n</skill>`)
-		.join("\n\n");
+	const lines = [
+		"The following configured skills are available to this subagent.",
+		"Use the read tool to load a skill's file when the task matches its description.",
+		"When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
+		"",
+		"<available_skills>",
+	];
+	for (const skill of skills) {
+		lines.push("  <skill>");
+		lines.push(`    <name>${escapeXmlText(skill.name)}</name>`);
+		lines.push(`    <description>${escapeXmlText(skill.description ?? "")}</description>`);
+		lines.push(`    <location>${escapeXmlText(skill.path)}</location>`);
+		lines.push("  </skill>");
+	}
+	lines.push("</available_skills>");
+	return lines.join("\n");
+}
+
+function escapeXmlText(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
 }
 
 export function normalizeSkillInput(

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -36,7 +36,7 @@ const SkillOverride = Type.Unsafe({
 		{ type: "boolean" },
 		{ type: "string" },
 	],
-	description: "Skill name(s) to inject (comma-separated), array of strings, or boolean (false disables, true uses default)",
+	description: "Skill name(s) to make available (comma-separated), array of strings, or boolean (false disables, true uses default)",
 });
 
 const OutputOverride = Type.Unsafe({

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -684,6 +684,7 @@ async function runSingleStep(
 			model: candidate,
 			inheritProjectContext: step.inheritProjectContext,
 			inheritSkills: step.inheritSkills,
+			requireReadTool: Boolean(step.skills?.length),
 			tools: step.tools,
 			extensions: step.extensions,
 			subagentOnlyExtensions: step.subagentOnlyExtensions,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -192,6 +192,7 @@ async function runSingleAttempt(
 		systemPromptMode: agent.systemPromptMode,
 		inheritProjectContext: agent.inheritProjectContext,
 		inheritSkills: agent.inheritSkills,
+		requireReadTool: Boolean(shared.resolvedSkillNames?.length),
 		tools: agent.tools,
 		extensions: agent.extensions,
 		subagentOnlyExtensions: agent.subagentOnlyExtensions,

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -37,6 +37,7 @@ interface BuildPiArgsInput {
 	systemPromptMode?: "append" | "replace";
 	inheritProjectContext: boolean;
 	inheritSkills: boolean;
+	requireReadTool?: boolean;
 	tools?: string[];
 	extensions?: string[];
 	subagentOnlyExtensions?: string[];
@@ -98,7 +99,10 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		args.push("--model", modelArg);
 	}
 
-	const declaredBuiltinTools = input.tools?.filter((tool) => !(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js"))) ?? [];
+	const declaredBuiltinToolsBase = input.tools?.filter((tool) => !(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js"))) ?? [];
+	const declaredBuiltinTools = input.requireReadTool && input.tools?.length && !declaredBuiltinToolsBase.includes("read")
+		? ["read", ...declaredBuiltinToolsBase]
+		: declaredBuiltinToolsBase;
 	const fanoutAuthorized = declaredBuiltinTools.includes("subagent");
 	const toolExtensionPaths: string[] = [];
 	if (input.tools?.length) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -785,7 +785,7 @@ export interface RunSyncOptions {
 	availableModels?: Array<{ provider: string; id: string; fullId: string }>;
 	/** Current parent-session provider to prefer for ambiguous bare model ids */
 	preferredModelProvider?: string;
-	/** Skills to inject (overrides agent default if provided) */
+	/** Skills to make available (overrides agent default if provided) */
 	skills?: string[];
 	structuredOutput?: {
 		schema: JsonSchemaObject;

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -300,6 +300,34 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(toolsArg, "read,grep,find,ls,bash,edit,write,contact_supervisor");
 	});
 
+	it("adds read to explicit tool allowlists when skills must be loaded lazily", () => {
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			requireReadTool: true,
+			tools: ["bash"],
+		});
+
+		assert.equal(args[args.indexOf("--tools") + 1], "read,bash");
+	});
+
+	it("does not duplicate read in explicit tool allowlists for lazy skills", () => {
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			requireReadTool: true,
+			tools: ["read", "bash"],
+		});
+
+		assert.equal(args[args.indexOf("--tools") + 1], "read,bash");
+	});
+
 	it("augments explicit builtin allowlists with selected direct MCP tool names", () => {
 		const fixture = createMcpFixture();
 		writeMcpFixture(fixture);

--- a/test/unit/skills-fallback.test.ts
+++ b/test/unit/skills-fallback.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import {
+	buildSkillInjection,
 	clearSkillCache,
 	discoverAvailableSkills,
 	resolveSkills,
@@ -13,12 +14,12 @@ import {
 
 let tempDir = "";
 
-function makeProjectSkill(cwd: string, name: string, body: string): void {
+function makeProjectSkill(cwd: string, name: string, body: string, description = "Test description"): void {
 	const skillDir = path.join(cwd, ".pi", "skills", name);
 	fs.mkdirSync(skillDir, { recursive: true });
 	fs.writeFileSync(
 		path.join(skillDir, "SKILL.md"),
-		`---\ndescription: Test description\n---\n\n${body}\n`,
+		`---\ndescription: ${description}\n---\n\n${body}\n`,
 		"utf-8",
 	);
 }
@@ -76,6 +77,33 @@ describe("skills filesystem fallback", () => {
 		assert.equal(resolved[0]?.name, "resolve-skill");
 		assert.equal(resolved[0]?.source, "project");
 		assert.match(resolved[0]?.content ?? "", /Run local fallback checks\./);
+	});
+
+	it("builds lazy skill references instead of inlining full skill bodies", () => {
+		makeProjectSkill(tempDir, "lazy-skill", "This body should stay out of the system prompt.");
+
+		const { resolved, missing } = resolveSkills(["lazy-skill"], tempDir);
+		assert.deepEqual(missing, []);
+
+		const injection = buildSkillInjection(resolved);
+		assert.match(injection, /The following configured skills are available to this subagent/);
+		assert.match(injection, /Use the read tool to load a skill's file/);
+		assert.match(injection, /<available_skills>/);
+		assert.match(injection, /<name>lazy-skill<\/name>/);
+		assert.match(injection, /<description>Test description<\/description>/);
+		assert.match(injection, /<location>.*lazy-skill.*SKILL\.md<\/location>/);
+		assert.doesNotMatch(injection, /This body should stay out/);
+		assert.doesNotMatch(injection, /<skill name=/);
+	});
+
+	it("escapes XML-sensitive skill metadata in lazy references", () => {
+		makeProjectSkill(tempDir, "amp&skill", "Body", "Use A & B <carefully>");
+
+		const { resolved } = resolveSkills(["amp&skill"], tempDir);
+		const injection = buildSkillInjection(resolved);
+		assert.match(injection, /<name>amp&amp;skill<\/name>/);
+		assert.match(injection, /<description>Use A &amp; B &lt;carefully&gt;<\/description>/);
+		assert.match(injection, /amp&amp;skill[\\/]SKILL\.md/);
 	});
 
 	it("does not expose pi-subagents as a child-injectable skill", () => {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -42,6 +42,8 @@ const PROMPT_WITH_EXPLICIT_SKILL = [
 	"\nCurrent date: 2026-04-16",
 ].join("");
 
+const CONFIGURED_SKILLS_SECTION = "\n\nThe following configured skills are available to this subagent.\nUse the read tool to load a skill's file when the task matches its description.\nWhen a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.\n\n<available_skills>\n  <skill>\n    <name>configured-skill</name>\n    <description>explicit agent skill</description>\n    <location>/tmp/configured-skill/SKILL.md</location>\n  </skill>\n</available_skills>";
+
 afterEach(() => {
 	if (envSnapshot.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT === undefined) delete process.env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT;
 	else process.env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = envSnapshot.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT;
@@ -155,6 +157,25 @@ describe("subagent prompt runtime", () => {
 		});
 		assert.ok(rewritten.includes("<skill name=\"explicit\">"));
 		assert.ok(!rewritten.includes("<available_skills>"));
+		assert.ok(!rewritten.includes("# Project Context"));
+	});
+
+	it("keeps configured lazy skill references when inherited skills are stripped", () => {
+		const prompt = [
+			"You are a subagent.",
+			CONFIGURED_SKILLS_SECTION,
+			"\n\n# Project Context\n\nProject-specific instructions and guidelines:\n\n## /repo/AGENTS.md\n\nProject rules\n\n",
+			SKILLS_SECTION,
+			"\nCurrent date: 2026-04-16",
+		].join("");
+		const rewritten = rewriteSubagentPrompt(prompt, {
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.ok(rewritten.includes("<name>configured-skill</name>"));
+		assert.ok(rewritten.includes("/tmp/configured-skill/SKILL.md"));
+		assert.ok(!rewritten.includes("<name>safe-bash</name>"));
 		assert.ok(!rewritten.includes("# Project Context"));
 	});
 


### PR DESCRIPTION
Fixes #183.

This changes configured subagent skills from full SKILL.md body injection to a compact list of name, description, and file path, with instructions for the child to read the matching skill on demand. Tool-restricted children that have resolved skills now get `read` added so those paths are usable.

I also kept configured skill references separate from Pi's inherited skill catalog so `inheritSkills: false` still strips the inherited catalog without removing explicit `skills:` entries.

Tests run:
- `node --experimental-strip-types --test test/unit/subagent-prompt-runtime.test.ts`
- `node --experimental-strip-types --test test/unit/skills-fallback.test.ts`
- `node --experimental-strip-types --test test/unit/pi-args.test.ts`
- `npm run test:unit`
- `npm run test:integration`

Fresh review loop: the first reviewer found that configured lazy skill references were being stripped with inherited skills. I fixed that and added regression coverage. A second fresh reviewer found no blockers.