### PR TITLE
Apply agent overrides to custom agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Added `subagents.disableThinking` so bundled builtin agents can drop thinking suffix defaults for providers that do not accept them. Thanks to Joshua Harding (@jhstatewide) for #212.
 - Actually wire the previously documented foreground-only `timeoutMs`/`maxRuntimeMs` aliases through single, parallel, chain, and dynamic fanout runs, including stable `timedOut: true` results, preserved partial output, manual-interrupt precedence, and skipped acceptance verification after timeout.
+- Apply `subagents.agentOverrides.<name>` to matching user-scope and project-scope custom agents, while keeping explicit agent frontmatter authoritative per field. Thanks to Jacek Juraszek (@jjuraszek) for #218.
 
 ## [0.30.0] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The extension ships with builtin agents you can use immediately.
 
 A simple rule of thumb: use `scout` before you understand the code, `researcher` before you trust external facts, `planner` before a bigger change, `worker` to implement, `reviewer` to check, and `oracle` when the decision itself feels risky.
 
-## Changing a builtin agent's model
+## Changing an agent's model
 
 Builtin agents inherit your current Pi default model by default. This keeps new installs from depending on a provider you may not have configured. If you want a role to use a specific model, set an override instead of copying the bundled agent file.
 
@@ -141,7 +141,7 @@ For a persistent override, edit settings. This example pins the reviewer everywh
 }
 ```
 
-Use `~/.pi/agent/settings.json` for a user override or `.pi/settings.json` for a project override. The same `agentOverrides` block can change `tools`, `skills`, inherited context, prompt text, or disable a builtin. If you want a totally different agent, create a user or project agent with the same name; for normal tweaks, prefer overrides.
+Use `~/.pi/agent/settings.json` for a user override or `.pi/settings.json` for a project override. The same `agentOverrides` block can change `tools`, `skills`, inherited context, prompt text, or disable a builtin. Matching user and project agents also receive override fields that their frontmatter leaves unset, so a shared `.pi/agents/<name>.md` can keep the persona while local settings choose the model. Explicit frontmatter still wins.
 
 If your provider rejects model IDs with thinking suffixes, set `subagents.disableThinking: true` in user or project settings. That clears bundled builtin thinking defaults in one place; an explicit higher-precedence `agentOverrides.<name>.thinking` value can opt a role back in.
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -22,6 +22,7 @@ import { discoverAvailableSkills } from "./skills.ts";
 import {
 	buildProactiveSkillSubagentRecommendationLines,
 } from "./proactive-skills.ts";
+import { parseFrontmatter } from "./frontmatter.ts";
 import type { Details, ExtensionConfig } from "../shared/types.ts";
 
 type ManagementAction = "list" | "get" | "create" | "update" | "delete";
@@ -164,6 +165,84 @@ function skillsWarning(cwd: string, skills: string[] | undefined): string | unde
 	const available = new Set(discoverAvailableSkills(cwd).map((s) => s.name));
 	const missing = skills.filter((s) => !available.has(s));
 	return missing.length ? `Warning: skills not found: ${missing.join(", ")}.` : undefined;
+}
+
+function editableAgentConfig(agent: AgentConfig): AgentConfig {
+	const base = agent.override?.base;
+	if (!base) return { ...agent };
+
+	return {
+		...agent,
+		model: base.model,
+		fallbackModels: base.fallbackModels ? [...base.fallbackModels] : undefined,
+		thinking: base.thinking,
+		systemPromptMode: base.systemPromptMode,
+		inheritProjectContext: base.inheritProjectContext,
+		inheritSkills: base.inheritSkills,
+		defaultContext: base.defaultContext,
+		disabled: base.disabled,
+		systemPrompt: base.systemPrompt,
+		skills: base.skills ? [...base.skills] : undefined,
+		tools: base.tools ? [...base.tools] : undefined,
+		mcpDirectTools: base.mcpDirectTools ? [...base.mcpDirectTools] : undefined,
+		subagentOnlyExtensions: base.subagentOnlyExtensions ? [...base.subagentOnlyExtensions] : undefined,
+		completionGuard: base.completionGuard,
+		override: undefined,
+	};
+}
+
+function readAgentFrontmatterFields(filePath: string): Set<string> {
+	try {
+		const { frontmatter } = parseFrontmatter(fs.readFileSync(filePath, "utf-8"));
+		return new Set(Object.keys(frontmatter));
+	} catch {
+		return new Set();
+	}
+}
+
+function preservedAgentFrontmatterFields(agent: AgentConfig, cfg: Record<string, unknown>): Set<string> {
+	const fields = readAgentFrontmatterFields(agent.filePath);
+	const changed = (...names: string[]) => {
+		for (const name of names) fields.delete(name);
+	};
+
+	if (hasKey(cfg, "name")) changed("name");
+	if (hasKey(cfg, "package")) changed("package");
+	if (hasKey(cfg, "description")) changed("description");
+	if (hasKey(cfg, "systemPrompt")) changed("systemPrompt");
+	if (hasKey(cfg, "model")) changed("model");
+	if (hasKey(cfg, "fallbackModels")) changed("fallbackModels");
+	if (hasKey(cfg, "tools")) changed("tools");
+	if (hasKey(cfg, "skills")) changed("skill", "skills");
+	if (hasKey(cfg, "extensions")) changed("extensions");
+	if (hasKey(cfg, "subagentOnlyExtensions")) changed("subagentOnlyExtensions");
+	if (hasKey(cfg, "thinking")) {
+		changed("thinking");
+		if (cfg.thinking === "off") fields.add("thinking");
+	}
+	if (hasKey(cfg, "systemPromptMode")) {
+		changed("systemPromptMode");
+		fields.add("systemPromptMode");
+	}
+	if (hasKey(cfg, "inheritProjectContext")) {
+		changed("inheritProjectContext");
+		fields.add("inheritProjectContext");
+	}
+	if (hasKey(cfg, "inheritSkills")) {
+		changed("inheritSkills");
+		fields.add("inheritSkills");
+	}
+	if (hasKey(cfg, "defaultContext")) changed("defaultContext");
+	if (hasKey(cfg, "output")) changed("output");
+	if (hasKey(cfg, "reads")) changed("defaultReads");
+	if (hasKey(cfg, "progress")) changed("defaultProgress");
+	if (hasKey(cfg, "maxSubagentDepth")) changed("maxSubagentDepth");
+	if (hasKey(cfg, "completionGuard")) {
+		changed("completionGuard");
+		if (cfg.completionGuard === true) fields.add("completionGuard");
+	}
+
+	return fields;
 }
 
 function parseStepList(raw: unknown): { steps?: ChainStepConfig[]; error?: string } {
@@ -583,7 +662,7 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 		const targetOrError = resolveTarget("agent", params.agent, findAgents(params.agent, ctx.cwd, scopeHint ?? "both"), ctx.cwd, params.agentScope);
 		if ("content" in targetOrError) return targetOrError;
 		const target = targetOrError;
-		const updated: AgentConfig = { ...target };
+		const updated = editableAgentConfig(target);
 		const oldName = target.name;
 		if (hasKey(cfg, "name") && (typeof cfg.name !== "string" || !cfg.name.trim())) return result("config.name must be a non-empty string when provided.", true);
 		if (hasKey(cfg, "description") && (typeof cfg.description !== "string" || !cfg.description.trim())) return result("config.description must be a non-empty string when provided.", true);
@@ -600,6 +679,7 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 		}
 		const applyError = applyAgentConfig(updated, cfg);
 		if (applyError) return result(applyError, true);
+		const preserveFrontmatterFields = preservedAgentFrontmatterFields(target, cfg);
 		updated.localName = newLocalName;
 		updated.packageName = newPackageName;
 		updated.name = buildRuntimeName(newLocalName, newPackageName);
@@ -621,7 +701,7 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 			if (renamed.error) return result(renamed.error, true);
 			updated.filePath = renamed.filePath!;
 		}
-		fs.writeFileSync(updated.filePath, serializeAgent(updated), "utf-8");
+		fs.writeFileSync(updated.filePath, serializeAgent(updated, { preserveFrontmatterFields }), "utf-8");
 		if (updated.name !== oldName) {
 			const refs = discoverAgentsAll(ctx.cwd).chains.filter((c) => c.steps.some((s) => s.agent === oldName)).map((c) => `${c.name} (${c.source})`);
 			if (refs.length) warnings.push(`Warning: chains still reference '${oldName}': ${refs.join(", ")}.`);

--- a/src/agents/agent-serializer.ts
+++ b/src/agents/agent-serializer.ts
@@ -30,8 +30,14 @@ function joinComma(values: string[] | undefined): string | undefined {
 	return values.join(", ");
 }
 
-export function serializeAgent(config: AgentConfig): string {
+interface SerializeAgentOptions {
+	preserveFrontmatterFields?: ReadonlySet<string>;
+}
+
+export function serializeAgent(config: AgentConfig, options: SerializeAgentOptions = {}): string {
 	const lines: string[] = [];
+	const preserve = (...fields: string[]) => fields.some((field) => options.preserveFrontmatterFields?.has(field));
+	const preservingExistingFrontmatter = options.preserveFrontmatterFields !== undefined;
 	lines.push("---");
 	lines.push(`name: ${frontmatterNameForConfig(config)}`);
 	if (config.packageName) lines.push(`package: ${config.packageName}`);
@@ -42,25 +48,27 @@ export function serializeAgent(config: AgentConfig): string {
 		...(config.mcpDirectTools ?? []).map((tool) => `mcp:${tool}`),
 	];
 	const toolsValue = joinComma(tools);
-	if (toolsValue) lines.push(`tools: ${toolsValue}`);
+	if (toolsValue || preserve("tools")) lines.push(`tools: ${toolsValue ?? ""}`);
 
-	if (config.model) lines.push(`model: ${config.model}`);
+	if (config.model || preserve("model")) lines.push(`model: ${config.model ?? ""}`);
 	const fallbackModelsValue = joinComma(config.fallbackModels);
-	if (fallbackModelsValue) lines.push(`fallbackModels: ${fallbackModelsValue}`);
-	if (config.thinking && config.thinking !== "off") lines.push(`thinking: ${config.thinking}`);
-	lines.push(`systemPromptMode: ${config.systemPromptMode}`);
-	lines.push(`inheritProjectContext: ${config.inheritProjectContext ? "true" : "false"}`);
-	lines.push(`inheritSkills: ${config.inheritSkills ? "true" : "false"}`);
-	if (config.defaultContext) lines.push(`defaultContext: ${config.defaultContext}`);
+	if (fallbackModelsValue || preserve("fallbackModels")) lines.push(`fallbackModels: ${fallbackModelsValue ?? ""}`);
+	if ((config.thinking && (config.thinking !== "off" || preserve("thinking"))) || (!config.thinking && preserve("thinking"))) {
+		lines.push(`thinking: ${config.thinking ?? ""}`);
+	}
+	if (!preservingExistingFrontmatter || preserve("systemPromptMode")) lines.push(`systemPromptMode: ${config.systemPromptMode}`);
+	if (!preservingExistingFrontmatter || preserve("inheritProjectContext")) lines.push(`inheritProjectContext: ${config.inheritProjectContext ? "true" : "false"}`);
+	if (!preservingExistingFrontmatter || preserve("inheritSkills")) lines.push(`inheritSkills: ${config.inheritSkills ? "true" : "false"}`);
+	if (config.defaultContext || preserve("defaultContext")) lines.push(`defaultContext: ${config.defaultContext ?? ""}`);
 
 	const skillsValue = joinComma(config.skills);
-	if (skillsValue) lines.push(`skills: ${skillsValue}`);
+	if (skillsValue || preserve("skill", "skills")) lines.push(`skills: ${skillsValue ?? ""}`);
 
 	if (config.extensions !== undefined) {
 		const extensionsValue = joinComma(config.extensions);
 		lines.push(`extensions: ${extensionsValue ?? ""}`);
 	}
-	if (config.subagentOnlyExtensions !== undefined) {
+	if (config.subagentOnlyExtensions !== undefined || preserve("subagentOnlyExtensions")) {
 		const subagentOnlyExtensionsValue = joinComma(config.subagentOnlyExtensions);
 		lines.push(`subagentOnlyExtensions: ${subagentOnlyExtensionsValue ?? ""}`);
 	}
@@ -76,7 +84,9 @@ export function serializeAgent(config: AgentConfig): string {
 	if (typeof maxSubagentDepth === "number" && Number.isInteger(maxSubagentDepth) && maxSubagentDepth >= 0) {
 		lines.push(`maxSubagentDepth: ${maxSubagentDepth}`);
 	}
-	if (config.completionGuard === false) lines.push("completionGuard: false");
+	if (config.completionGuard === false || preserve("completionGuard")) {
+		lines.push(`completionGuard: ${config.completionGuard === undefined ? "" : config.completionGuard ? "true" : "false"}`);
+	}
 
 	if (config.extraFields) {
 		for (const [key, value] of Object.entries(config.extraFields)) {

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -111,6 +111,7 @@ interface SubagentSettings {
 }
 
 const EMPTY_SUBAGENT_SETTINGS: SubagentSettings = { overrides: {} };
+const agentFrontmatterFields = new WeakMap<AgentConfig, Set<string>>();
 
 export interface ChainStepConfig {
 	agent?: string;
@@ -782,6 +783,111 @@ function applyBuiltinOverrides(
 	});
 }
 
+function customAgentHasFrontmatterField(agent: AgentConfig, ...fields: string[]): boolean {
+	const frontmatterFields = agentFrontmatterFields.get(agent);
+	return frontmatterFields ? fields.some((field) => frontmatterFields.has(field)) : false;
+}
+
+function applyCustomAgentOverride(
+	agent: AgentConfig,
+	override: BuiltinAgentOverrideConfig,
+	meta: { scope: "user" | "project"; path: string },
+): AgentConfig {
+	let next: AgentConfig | undefined;
+	let anyFilled = false;
+
+	const mutable = (): AgentConfig => {
+		next ??= { ...agent };
+		return next;
+	};
+
+	const fill = <K extends keyof AgentConfig>(
+		field: K,
+		frontmatterFields: string[],
+		value: AgentConfig[K],
+	): void => {
+		if (customAgentHasFrontmatterField(agent, ...frontmatterFields)) return;
+		mutable()[field] = value;
+		anyFilled = true;
+	};
+
+	if (override.model !== undefined) {
+		fill("model", ["model"], override.model === false ? undefined : override.model);
+	}
+	if (override.fallbackModels !== undefined) {
+		fill(
+			"fallbackModels",
+			["fallbackModels"],
+			override.fallbackModels === false ? undefined : [...override.fallbackModels],
+		);
+	}
+	if (override.thinking !== undefined) {
+		fill("thinking", ["thinking"], override.thinking === false ? undefined : override.thinking);
+	}
+	if (override.systemPromptMode !== undefined) {
+		fill("systemPromptMode", ["systemPromptMode"], override.systemPromptMode);
+	}
+	if (override.inheritProjectContext !== undefined) {
+		fill("inheritProjectContext", ["inheritProjectContext"], override.inheritProjectContext);
+	}
+	if (override.inheritSkills !== undefined) {
+		fill("inheritSkills", ["inheritSkills"], override.inheritSkills);
+	}
+	if (override.defaultContext !== undefined) {
+		fill("defaultContext", ["defaultContext"], override.defaultContext === false ? undefined : override.defaultContext);
+	}
+	if (override.disabled !== undefined && agent.disabled === undefined) {
+		mutable().disabled = override.disabled;
+		anyFilled = true;
+	}
+	if (override.skills !== undefined) {
+		fill("skills", ["skill", "skills"], override.skills === false ? undefined : [...override.skills]);
+	}
+	if (override.tools !== undefined && !customAgentHasFrontmatterField(agent, "tools")) {
+		const { tools, mcpDirectTools } = splitToolList(override.tools === false ? [] : override.tools);
+		const target = mutable();
+		target.tools = tools;
+		target.mcpDirectTools = mcpDirectTools;
+		anyFilled = true;
+	}
+	if (override.subagentOnlyExtensions !== undefined) {
+		fill(
+			"subagentOnlyExtensions",
+			["subagentOnlyExtensions"],
+			override.subagentOnlyExtensions === false ? undefined : [...override.subagentOnlyExtensions],
+		);
+	}
+	if (override.completionGuard !== undefined) {
+		fill("completionGuard", ["completionGuard"], override.completionGuard);
+	}
+
+	if (!anyFilled || !next) return agent;
+	next.override = { ...meta, base: cloneOverrideBase(agent) };
+	return next;
+}
+
+function applyCustomAgentOverrides(
+	agents: AgentConfig[],
+	userSettings: SubagentSettings,
+	projectSettings: SubagentSettings,
+	userSettingsPath: string,
+	projectSettingsPath: string | null,
+): AgentConfig[] {
+	return agents.map((agent) => {
+		const projectOverride = projectSettings.overrides[agent.name];
+		if (projectOverride && projectSettingsPath) {
+			return applyCustomAgentOverride(agent, projectOverride, { scope: "project", path: projectSettingsPath });
+		}
+
+		const userOverride = userSettings.overrides[agent.name];
+		if (userOverride) {
+			return applyCustomAgentOverride(agent, userOverride, { scope: "user", path: userSettingsPath });
+		}
+
+		return agent;
+	});
+}
+
 export function buildBuiltinOverrideConfig(
 	base: BuiltinAgentOverrideBase,
 	draft: Pick<AgentConfig, "model" | "fallbackModels" | "thinking" | "systemPromptMode" | "inheritProjectContext" | "inheritSkills" | "defaultContext" | "disabled" | "systemPrompt" | "skills" | "tools" | "mcpDirectTools" | "subagentOnlyExtensions" | "completionGuard">,
@@ -999,7 +1105,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 				? true
 				: undefined;
 
-		agents.push({
+		const agent: AgentConfig = {
 			name: runtimeName,
 			localName,
 			packageName,
@@ -1029,7 +1135,9 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 					: undefined,
 			completionGuard,
 			extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
-		});
+		};
+		agentFrontmatterFields.set(agent, new Set(Object.keys(frontmatter)));
+		agents.push(agent);
 	}
 
 	return agents;
@@ -1137,9 +1245,21 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const userAgentsExtra = scope === "project" ? [] : extraUserAgentDirs().flatMap((dir) => loadAgentsFromDir(dir, "user"));
 	const userAgentsOld = scope === "project" ? [] : loadAgentsFromDir(userDirOld, "user");
 	const userAgentsNew = scope === "project" ? [] : loadAgentsFromDir(userDirNew, "user");
-	const userAgents = [...userAgentsExtra, ...userAgentsOld, ...userAgentsNew];
+	const userAgents = applyCustomAgentOverrides(
+		[...userAgentsExtra, ...userAgentsOld, ...userAgentsNew],
+		userSettings,
+		projectSettings,
+		userSettingsPath,
+		projectSettingsPath,
+	);
 
-	const projectAgents = scope === "user" ? [] : projectAgentDirs.flatMap((dir) => loadAgentsFromDir(dir, "project"));
+	const projectAgents = applyCustomAgentOverrides(
+		scope === "user" ? [] : projectAgentDirs.flatMap((dir) => loadAgentsFromDir(dir, "project")),
+		userSettings,
+		projectSettings,
+		userSettingsPath,
+		projectSettingsPath,
+	);
 	const packageAgents = packageSubagentPaths.agents.flatMap((dir) => loadAgentsFromDir(dir, "package"));
 	const agents = mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents, packageAgents)
 		.filter((agent) => agent.disabled !== true);
@@ -1179,11 +1299,17 @@ export function discoverAgentsAll(cwd: string): {
 		userSettingsPath,
 		projectSettingsPath,
 	);
-	const user = [
-		...extraUserAgentDirs().flatMap((dir) => loadAgentsFromDir(dir, "user")),
-		...loadAgentsFromDir(userDirOld, "user"),
-		...loadAgentsFromDir(userDirNew, "user"),
-	];
+	const user = applyCustomAgentOverrides(
+		[
+			...extraUserAgentDirs().flatMap((dir) => loadAgentsFromDir(dir, "user")),
+			...loadAgentsFromDir(userDirOld, "user"),
+			...loadAgentsFromDir(userDirNew, "user"),
+		],
+		userSettings,
+		projectSettings,
+		userSettingsPath,
+		projectSettingsPath,
+	);
 	const packageMap = new Map<string, AgentConfig>();
 	for (const dir of packageSubagentPaths.agents) {
 		for (const agent of loadAgentsFromDir(dir, "package")) {
@@ -1197,7 +1323,13 @@ export function discoverAgentsAll(cwd: string): {
 			projectMap.set(agent.name, agent);
 		}
 	}
-	const project = Array.from(projectMap.values());
+	const project = applyCustomAgentOverrides(
+		Array.from(projectMap.values()),
+		userSettings,
+		projectSettings,
+		userSettingsPath,
+		projectSettingsPath,
+	);
 
 	const chainMap = new Map<string, ChainConfig>();
 	const packageChainDiagnostics: ChainDiscoveryDiagnostic[] = [];

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -181,6 +181,122 @@ Inspect
 		assert.match(readText(got), /Subagent-only extensions: \.\/tools\/child-only\.ts, \/opt\/pi\/child\.ts/);
 	});
 
+	it("does not serialize settings overrides into custom agent frontmatter during updates", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-sonnet-4-6" }] } };
+		const settingsPath = path.join(tempDir, ".pi", "settings.json");
+		const agentPath = path.join(tempDir, ".pi", "agents", "implementer.md");
+		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+		fs.writeFileSync(settingsPath, JSON.stringify({
+			subagents: {
+				agentOverrides: {
+					implementer: {
+						model: "anthropic/claude-sonnet-4-6",
+						systemPromptMode: "append",
+						inheritProjectContext: true,
+						inheritSkills: true,
+					},
+				},
+			},
+		}, null, 2), "utf-8");
+		fs.writeFileSync(agentPath, `---
+name: implementer
+description: TDD implementer
+---
+
+Drive the failing test first.
+`, "utf-8");
+
+		const got = handleManagementAction("get", { agent: "implementer" }, ctx);
+		assert.equal(got.isError, false);
+		const beforeText = readText(got);
+		assert.match(beforeText, /Model: anthropic\/claude-sonnet-4-6/);
+		assert.match(beforeText, /System prompt mode: append/);
+		assert.match(beforeText, /Inherit project context: true/);
+		assert.match(beforeText, /Inherit skills: true/);
+
+		const updated = handleUpdate(
+			{ agent: "implementer", config: { description: "Updated implementer" } },
+			ctx,
+		);
+		assert.equal(updated.isError, false);
+
+		const content = fs.readFileSync(agentPath, "utf-8");
+		assert.match(content, /^description: Updated implementer$/m);
+		assert.doesNotMatch(content, /^model:/m);
+		assert.doesNotMatch(content, /^systemPromptMode:/m);
+		assert.doesNotMatch(content, /^inheritProjectContext:/m);
+		assert.doesNotMatch(content, /^inheritSkills:/m);
+
+		const gotAfter = handleManagementAction("get", { agent: "implementer" }, ctx);
+		assert.equal(gotAfter.isError, false);
+		const afterText = readText(gotAfter);
+		assert.match(afterText, /Model: anthropic\/claude-sonnet-4-6/);
+		assert.match(afterText, /System prompt mode: append/);
+		assert.match(afterText, /Inherit project context: true/);
+		assert.match(afterText, /Inherit skills: true/);
+	});
+
+	it("preserves explicit default-like frontmatter that blocks settings overrides during updates", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+		const settingsPath = path.join(tempDir, ".pi", "settings.json");
+		const agentPath = path.join(tempDir, ".pi", "agents", "implementer.md");
+		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+		fs.writeFileSync(settingsPath, JSON.stringify({
+			subagents: {
+				agentOverrides: {
+					implementer: {
+						thinking: "high",
+						fallbackModels: ["openai/gpt-5-mini"],
+						tools: ["bash"],
+						skills: ["override-skill"],
+						defaultContext: "fork",
+						completionGuard: false,
+					},
+				},
+			},
+		}, null, 2), "utf-8");
+		fs.writeFileSync(agentPath, `---
+name: implementer
+description: TDD implementer
+fallbackModels:
+thinking: off
+tools:
+skills:
+defaultContext:
+completionGuard: true
+---
+
+Drive the failing test first.
+`, "utf-8");
+
+		const got = handleManagementAction("get", { agent: "implementer" }, ctx);
+		assert.equal(got.isError, false);
+		const beforeText = readText(got);
+		assert.match(beforeText, /Thinking: off/);
+		assert.doesNotMatch(beforeText, /Thinking: high/);
+
+		const updated = handleUpdate(
+			{ agent: "implementer", config: { description: "Updated implementer" } },
+			ctx,
+		);
+		assert.equal(updated.isError, false);
+
+		const content = fs.readFileSync(agentPath, "utf-8");
+		assert.match(content, /^description: Updated implementer$/m);
+		assert.match(content, /^fallbackModels: ?$/m);
+		assert.match(content, /^thinking: off$/m);
+		assert.match(content, /^tools: ?$/m);
+		assert.match(content, /^skills: ?$/m);
+		assert.match(content, /^defaultContext: ?$/m);
+		assert.match(content, /^completionGuard: true$/m);
+
+		const gotAfter = handleManagementAction("get", { agent: "implementer" }, ctx);
+		assert.equal(gotAfter.isError, false);
+		const afterText = readText(gotAfter);
+		assert.match(afterText, /Thinking: off/);
+		assert.doesNotMatch(afterText, /Thinking: high/);
+	});
+
 	it("updates JSON chain descriptions without rewriting them as markdown", () => {
 		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
 		const chainPath = path.join(tempDir, ".pi", "chains", "dynamic-review.chain.json");

--- a/test/unit/agent-overrides.test.ts
+++ b/test/unit/agent-overrides.test.ts
@@ -9,6 +9,8 @@ let tempHome = "";
 let tempProject = "";
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
+const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+const originalExtraAgentDirs = process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
 
 function writeJson(filePath: string, value: unknown): void {
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -21,12 +23,20 @@ function writeProjectAgent(cwd: string, name: string, body: string): void {
 	fs.writeFileSync(filePath, body, "utf-8");
 }
 
+function writeUserAgent(home: string, name: string, body: string): void {
+	const filePath = path.join(home, ".pi", "agent", "agents", `${name}.md`);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, body, "utf-8");
+}
+
 describe("builtin agent overrides", () => {
 	beforeEach(() => {
 		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-home-"));
 		tempProject = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-project-"));
 		process.env.HOME = tempHome;
 		process.env.USERPROFILE = tempHome;
+		delete process.env.PI_CODING_AGENT_DIR;
+		delete process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
 	});
 
 	afterEach(() => {
@@ -34,6 +44,10 @@ describe("builtin agent overrides", () => {
 		else process.env.HOME = originalHome;
 		if (originalUserProfile === undefined) delete process.env.USERPROFILE;
 		else process.env.USERPROFILE = originalUserProfile;
+		if (originalPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+		if (originalExtraAgentDirs === undefined) delete process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
+		else process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS = originalExtraAgentDirs;
 		fs.rmSync(tempHome, { recursive: true, force: true });
 		fs.rmSync(tempProject, { recursive: true, force: true });
 	});
@@ -218,7 +232,7 @@ describe("builtin agent overrides", () => {
 		assert.equal(reviewer.override?.scope, "project");
 	});
 
-	it("does not apply builtin settings overrides when a full project agent overrides the builtin", () => {
+	it("frontmatter wins per-field over agentOverrides for a shadowing project agent", () => {
 		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
 		writeJson(path.join(tempProject, ".pi", "settings.json"), {
 			subagents: { agentOverrides: { reviewer: { model: "openai/gpt-5.4" } } },
@@ -230,6 +244,145 @@ describe("builtin agent overrides", () => {
 		assert.equal(reviewer.source, "project");
 		assert.equal(reviewer.model, "google/gemini-3-pro");
 		assert.equal(reviewer.override, undefined);
+	});
+
+	it("fills in unset fields on a custom project agent from project agentOverrides", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: {
+				agentOverrides: {
+					implementer: {
+						model: "anthropic/claude-sonnet-4-6",
+						fallbackModels: ["openai/gpt-5-mini"],
+						thinking: "high",
+						systemPromptMode: "append",
+						inheritProjectContext: true,
+						inheritSkills: true,
+						defaultContext: "fork",
+						tools: ["bash", "mcp:xcodebuild_list_sims"],
+						skills: ["tdd"],
+						subagentOnlyExtensions: ["./tools/child-review.ts"],
+						completionGuard: false,
+					},
+				},
+			},
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.source, "project");
+		assert.equal(implementer.model, "anthropic/claude-sonnet-4-6");
+		assert.deepEqual(implementer.fallbackModels, ["openai/gpt-5-mini"]);
+		assert.equal(implementer.thinking, "high");
+		assert.equal(implementer.systemPromptMode, "append");
+		assert.equal(implementer.inheritProjectContext, true);
+		assert.equal(implementer.inheritSkills, true);
+		assert.equal(implementer.defaultContext, "fork");
+		assert.deepEqual(implementer.tools, ["bash"]);
+		assert.deepEqual(implementer.mcpDirectTools, ["xcodebuild_list_sims"]);
+		assert.deepEqual(implementer.skills, ["tdd"]);
+		assert.deepEqual(implementer.subagentOnlyExtensions, ["./tools/child-review.ts"]);
+		assert.equal(implementer.completionGuard, false);
+		assert.equal(implementer.override?.scope, "project");
+		assert.equal(implementer.override?.path, path.join(tempProject, ".pi", "settings.json"));
+	});
+
+	it("fills in unset fields on a custom user agent from user agentOverrides", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { implementer: { model: "anthropic/claude-sonnet-4-6" } } },
+		});
+		writeUserAgent(tempHome, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.source, "user");
+		assert.equal(implementer.model, "anthropic/claude-sonnet-4-6");
+		assert.equal(implementer.override?.scope, "user");
+	});
+
+	it("applies user agentOverrides to a custom project agent when project settings have no entry", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { implementer: { model: "anthropic/claude-sonnet-4-6" } } },
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.source, "project");
+		assert.equal(implementer.model, "anthropic/claude-sonnet-4-6");
+		assert.equal(implementer.override?.scope, "user");
+	});
+
+	it("prefers project agentOverrides over user agentOverrides on a custom project agent", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { implementer: { model: "anthropic/claude-sonnet-4-6" } } },
+		});
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { agentOverrides: { implementer: { model: "openai/gpt-5.4" } } },
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.model, "openai/gpt-5.4");
+		assert.equal(implementer.override?.scope, "project");
+	});
+
+	it("keeps explicit custom frontmatter fields over matching agentOverrides", () => {
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: {
+				agentOverrides: {
+					implementer: {
+						model: "anthropic/claude-sonnet-4-6",
+						thinking: "high",
+						tools: ["bash"],
+						skills: ["override-skill"],
+						inheritProjectContext: true,
+						defaultContext: "fork",
+						completionGuard: true,
+					},
+				},
+			},
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\nmodel: google/gemini-3-pro\nthinking: medium\ntools: read, mcp:local_tool\nskills: agent-skill\ninheritProjectContext: false\ndefaultContext: fresh\ncompletionGuard: false\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.model, "google/gemini-3-pro");
+		assert.equal(implementer.thinking, "medium");
+		assert.deepEqual(implementer.tools, ["read"]);
+		assert.deepEqual(implementer.mcpDirectTools, ["local_tool"]);
+		assert.deepEqual(implementer.skills, ["agent-skill"]);
+		assert.equal(implementer.inheritProjectContext, false);
+		assert.equal(implementer.defaultContext, "fresh");
+		assert.equal(implementer.completionGuard, false);
+		assert.equal(implementer.override, undefined);
+	});
+
+	it("leaves a custom agent untouched when no agentOverrides entry matches its name", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { reviewer: { model: "openai/gpt-5.4" } } },
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.equal(implementer.model, undefined);
+		assert.equal(implementer.override, undefined);
+	});
+
+	it("disableBuiltins does not disable custom agents", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { disableBuiltins: true },
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\n---\n\nDrive the failing test first.\n`);
+
+		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
+		assert.ok(implementer);
+		assert.notEqual(implementer.disabled, true);
 	});
 
 	it("does not create a settings file when removing a non-existent override", () => {


### PR DESCRIPTION
Fixes #218.

This applies `subagents.agentOverrides.<name>` to matching user and project custom agents, while keeping explicit frontmatter authoritative per field. That lets shared `.pi/agents/<name>.md` persona files stay provider-neutral while local user/project settings supply model, thinking, tools, skills, context, and related defaults.

I also tightened management updates so editing a custom agent does not write settings-derived override values, or newly-added default frontmatter, back into the shared agent file.

Tests:
- `node --experimental-strip-types --test test/unit/agent-overrides.test.ts`
- `node --experimental-strip-types --test test/unit/agent-management.test.ts`
- `npm run test:unit`
- `npm run test:integration`
