### PR TITLE
fix(tui): animate foreground subagent spinner between child events

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -106,6 +106,30 @@ function isSlashResultRunning(result: { details?: Details }): boolean {
 		|| false;
 }
 
+// Drives the inline running-indicator braille animation for foreground subagent
+// results. Foreground runs receive progress only on child events, so the glyph
+// (derived from progress fields) would freeze between events. While a result is
+// running we tick a frame counter + invalidate() every 80ms so renderSubagentResult
+// can blend the frame into runningGlyph and produce a smooth spinner.
+function subagentResultIsRunning(result: { details?: Details }): boolean {
+	return result.details?.progress?.some((entry) => entry.status === "running")
+		|| result.details?.results.some((entry) => entry.progress?.status === "running")
+		|| false;
+}
+
+function ensureSubagentResultAnimation(context: { state: Record<string, unknown>; invalidate?: () => void }): void {
+	const state = context.state as { subagentResultAnimationTimer?: ReturnType<typeof setInterval>; frame?: number };
+	if (state.subagentResultAnimationTimer) return;
+	if (typeof context.invalidate !== "function") return;
+	if (state.frame === undefined) state.frame = 0;
+	state.subagentResultAnimationTimer = setInterval(() => {
+		state.frame = ((state.frame ?? 0) + 1) % 10;
+		try {
+			context.invalidate();
+		} catch {}
+	}, 80);
+}
+
 function isSlashResultError(result: { details?: Details }): boolean {
 	return result.details?.results.some((entry) => entry.exitCode !== 0 && entry.progress?.status !== "running") || false;
 }
@@ -455,8 +479,13 @@ DIAGNOSTICS:
 		},
 
 		renderResult(result, options, theme, context) {
-			clearLegacyResultAnimationTimer(context);
-			return renderSubagentResult(result, options, theme);
+			if (subagentResultIsRunning(result)) {
+				ensureSubagentResultAnimation(context);
+			} else {
+				clearLegacyResultAnimationTimer(context);
+			}
+			const frame = (context.state as { frame?: number } | undefined)?.frame ?? 0;
+			return renderSubagentResult(result, options, theme, frame);
 		},
 
 	};

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -231,8 +231,11 @@ function resultStatusLine(result: Details["results"][number], output: string): s
 	return "Done";
 }
 
-function resultGlyph(result: Details["results"][number], output: string, theme: Theme, running = result.progress?.status === "running", seed = progressRunningSeed(result.progress ?? result.progressSummary)): string {
-	if (running) return theme.fg("accent", runningGlyph(seed));
+function resultGlyph(result: Details["results"][number], output: string, theme: Theme, running = result.progress?.status === "running", seed = progressRunningSeed(result.progress ?? result.progressSummary), frame?: number): string {
+	if (running) {
+		if (frame !== undefined) return theme.fg("accent", runningGlyph((seed ?? 0) + frame));
+		return theme.fg("accent", runningGlyph(seed));
+	}
 	if (result.detached) return theme.fg("warning", "■");
 	if (result.interrupted) return theme.fg("warning", "■");
 	if (result.exitCode !== 0) return theme.fg("error", "✗");
@@ -1009,7 +1012,7 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, ctx.ui.getToolsExpanded?.() ?? false));
 }
 
-function renderSingleCompact(d: Details, r: Details["results"][number], theme: Theme): Component {
+function renderSingleCompact(d: Details, r: Details["results"][number], theme: Theme, frame?: number): Component {
 	const output = r.truncation?.text || getSingleResultOutput(r);
 	const progress = r.progress || r.progressSummary;
 	const isRunning = r.progress?.status === "running";
@@ -1021,7 +1024,7 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 	const c = new Container();
 	const width = getTermWidth() - 4;
 	const modelDisplay = modelThinkingBadge(theme, r.model);
-	c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
+	c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
 
 	if (isRunning && r.progress) {
 		const progressSnapshotNow = snapshotNowForProgress(r.progress);
@@ -1045,7 +1048,7 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 	return c;
 }
 
-function renderMultiCompact(d: Details, theme: Theme): Component {
+function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component {
 	const hasRunning = d.progress?.some((p) => p.status === "running")
 		|| d.results.some((r) => r.progress?.status === "running")
 		|| workflowGraphHasStatus(d, ["running"]);
@@ -1071,7 +1074,7 @@ function renderMultiCompact(d: Details, theme: Theme): Component {
 	const itemTitle = multiLabel.itemTitle;
 	const stats = statJoin(theme, [multiLabel.headerLabel, formatProgressStats(theme, totalSummary)]);
 	const glyph = hasRunning
-		? theme.fg("accent", runningGlyph(runningSeed(progressRunningSeed(totalSummary), d.currentStepIndex)))
+		? theme.fg("accent", runningGlyph(frame !== undefined ? (runningSeed(progressRunningSeed(totalSummary), d.currentStepIndex) ?? 0) + frame : runningSeed(progressRunningSeed(totalSummary), d.currentStepIndex)))
 		: failed
 			? theme.fg("error", "✗")
 			: paused
@@ -1117,7 +1120,7 @@ function renderMultiCompact(d: Details, theme: Theme): Component {
 		const rPending = rProg && "status" in rProg && rProg.status === "pending";
 		const stepNumber = r.progress?.index !== undefined ? r.progress.index + 1 : progressFromArray?.index !== undefined ? progressFromArray.index + 1 : i + 1;
 		const stepStats = formatProgressStats(theme, rProg);
-		const glyph = rPending ? theme.fg("dim", "◦") : resultGlyph(r, output, theme, rRunning, progressRunningSeed(rProg));
+		const glyph = rPending ? theme.fg("dim", "◦") : resultGlyph(r, output, theme, rRunning, progressRunningSeed(rProg), frame);
 		const pendingLabel = rPending ? ` ${theme.fg("dim", "· pending")}` : "";
 		const stepLabel = resultRowLabel(d, multiLabel, i, stepNumber);
 		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
@@ -1144,6 +1147,7 @@ export function renderSubagentResult(
 	result: AgentToolResult<Details>,
 	options: { expanded: boolean },
 	theme: Theme,
+	frame?: number,
 ): Component {
 	const d = result.details;
 	if (!d || !d.results.length) {
@@ -1158,7 +1162,7 @@ export function renderSubagentResult(
 
 	if (d.mode === "single" && d.results.length === 1) {
 		const r = d.results[0];
-		if (!expanded) return renderSingleCompact(d, r, theme);
+		if (!expanded) return renderSingleCompact(d, r, theme, frame);
 		const isRunning = r.progress?.status === "running";
 		const icon = isRunning
 			? theme.fg("warning", "running")
@@ -1252,7 +1256,7 @@ export function renderSubagentResult(
 		return c;
 	}
 
-	if (!expanded) return renderMultiCompact(d, theme);
+	if (!expanded) return renderMultiCompact(d, theme, frame);
 
 	const hasRunning = d.progress?.some((p) => p.status === "running") 
 		|| d.results.some((r) => r.progress?.status === "running")


### PR DESCRIPTION
# Foreground subagent spinner freezes between child progress events

The inline braille spinner (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏) next to a foreground subagent result freezes on one frame and only jumps when the child emits a progress event. It should keep animating like the `Working` loader does.

The async/background path already animates, choppily, because `createAsyncJobTracker` polls `status.json` every 250ms (`POLL_INTERVAL_MS`), which advances `durationMs` and re-renders the widget. The foreground path has nothing equivalent, and its running glyph is computed from progress numeric fields. So between child events, neither the seed nor the render changes.

## Root cause

- `runningGlyph(seed)` in `src/tui/render.ts` maps a seed to a braille frame.
- `progressRunningSeed` sums progress fields (`durationMs`, `tokens`, `lastActivityAt`, `currentToolStartedAt`, `turnCount`). None of them is wall-clock, and none changes between child progress events for a foreground run.
- `renderSubagentResult` is a pure render function. It only runs again when the tool row re-renders, which for a foreground run only happens on child `onUpdate` events.
- Net effect: between events the glyph is identical on every render, so the spinner looks static.

## Fix

Drive a steady render tick while a foreground result is running, and blend a frame counter into the running glyph seed so each tick produces a new frame.

The infrastructure for this is already there but unused. pi passes `context.invalidate()` (triggers re-render) and a persistent `context.state` into `renderResult`. `clearLegacyResultAnimationTimer(context)` and the `subagentResultAnimationTimer` slot in `context.state` are already wired, just never set.

Two changes:

1. `src/tui/render.ts`: add an optional `frame?: number` to `renderSubagentResult`, `renderSingleCompact`, `renderMultiCompact`, and `resultGlyph`. When `frame` is provided, `runningGlyph` gets `(seed ?? 0) + frame`. When omitted, behavior is unchanged, including the static `●` fallback for seed-less progress.

2. `src/extension/index.ts`: in the tool's `renderResult`, while any result is running, start an 80ms interval (stored in `context.state` next to `frame`) that bumps `frame` and calls `context.invalidate()`. When nothing is running, the existing `clearLegacyResultAnimationTimer` clears it.

80ms matches pi's default `Loader` interval, so the foreground subagent spinner animates at the same cadence as the `Working` loader.

## Behavior preserved

- Expanded result rows use the text label `running`, not the braille glyph, so they are unaffected.
- Async/background runs keep their own 250ms widget poller, so they are unaffected.
- The no-`frame` call sites (for example the slash live-state preview around `src/extension/index.ts` L127) keep the original glyph behavior exactly.

## Patch

`spinnerfix.diff`, 136 lines across two files. Applied and syntax-checked with `node --experimental-strip-types --check` against pi-subagents 0.30.0.

## Repro

1. Run any foreground subagent (single, chain, or parallel) that takes longer than about a second.
2. Watch the collapsed tool row. The braille glyph is stuck on one frame and only advances when the child reports a tool event.

With the patch, the glyph animates smoothly for the whole run.
