### PR TITLE
test: allow Windows settings paths in model output

### DIFF
--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -428,7 +428,7 @@ Drive the failing test first.
 		assert.match(text, /Source: project override/);
 		assert.match(text, /Requested model setting:\n  claude-sonnet-4/);
 		assert.match(text, /Disabled: true/);
-		assert.match(text, /Override file:\n  .*\.pi\/settings\.json/);
+		assert.match(text.replaceAll("\\", "/"), /Override file:\n  .*\.pi\/settings\.json/);
 	});
 
 	it("rejects unknown builtin filters for runtime model mappings", () => {


### PR DESCRIPTION
Fixes the Windows-only unit assertion exposed after #304: model output can contain backslash-separated .pi/settings.json paths.\n\nValidation:\n- node --experimental-strip-types --test test/unit/agent-management.test.ts\n- npm run test:all