### PR TITLE
fix: make async subagent interrupt/steer/stop work cross-OS

### DIFF
--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { ASYNC_DIR, RESULTS_DIR, type AsyncStatus, type SubagentState } from "../../shared/types.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
+import { deliverInterruptRequest } from "./control-channel.ts";
 import { reconcileAsyncRun } from "./stale-run-reconciler.ts";
 
 export const ASYNC_RESUME_INTERRUPT_SIGNAL: NodeJS.Signals = process.platform === "win32" ? "SIGBREAK" : "SIGUSR2";
@@ -64,7 +65,14 @@ export function interruptLiveAsyncResumeTarget(input: {
 		return { ok: false, message: `Async run ${asyncId} is live but no interrupt-capable runner pid was found.` };
 	}
 	try {
-		(input.kill ?? process.kill)(status.pid, ASYNC_RESUME_INTERRUPT_SIGNAL);
+		deliverInterruptRequest({
+			asyncDir: input.target.asyncDir,
+			pid: status.pid,
+			kill: input.kill,
+			signal: ASYNC_RESUME_INTERRUPT_SIGNAL,
+			now: input.now,
+			source: "async-resume",
+		});
 		const tracked = input.state?.asyncJobs.get(asyncId);
 		if (tracked) {
 			tracked.activityState = undefined;

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -39,28 +39,18 @@ export type AsyncResumeTarget = {
 
 type KillFn = (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 
-function readAsyncStatus(asyncDir: string): AsyncStatus | null {
-	const statusPath = path.join(asyncDir, "status.json");
-	try {
-		return JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatus;
-	} catch (error) {
-		const code = error && typeof error === "object" && "code" in error ? (error as NodeJS.ErrnoException).code : undefined;
-		if (code === "ENOENT") return null;
-		throw error;
-	}
-}
-
 export function interruptLiveAsyncResumeTarget(input: {
 	target: AsyncResumeTarget & { kind: "live" };
 	state?: Pick<SubagentState, "asyncJobs">;
 	kill?: KillFn;
 	now?: () => number;
+	resultsDir?: string;
 }): { ok: true; asyncId: string } | { ok: false; message: string } {
 	const asyncId = input.target.runId;
 	if (!input.target.asyncDir) {
 		return { ok: false, message: `Async run ${asyncId} is live but does not have an async directory to interrupt.` };
 	}
-	const status = readAsyncStatus(input.target.asyncDir);
+	const status = reconcileAsyncRun(input.target.asyncDir, { resultsDir: input.resultsDir, kill: input.kill, now: input.now }).status;
 	if (!status || status.state !== "running" || typeof status.pid !== "number") {
 		return { ok: false, message: `Async run ${asyncId} is live but no interrupt-capable runner pid was found.` };
 	}

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -1,0 +1,177 @@
+/**
+ * Cross-OS control channel for async subagent runs.
+ *
+ * Background runs are detached OS processes. The original control path delivered
+ * an interrupt with `process.kill(pid, SIGUSR2|SIGBREAK)`, but Windows cannot
+ * deliver those signals cross-process via `process.kill` and throws `ENOSYS`,
+ * which left async runs uninterruptible (no stop, no live steer) on Windows.
+ *
+ * This module adds a portable, file-based control inbox inside the run directory.
+ * The parent drops an interrupt request file; the runner watches the inbox and
+ * routes the request into its existing graceful `interruptRunner()` (pause +
+ * resumable), identically on every platform. The OS signal is kept only as an
+ * opportunistic fast-path; its failure is non-fatal because the file inbox is
+ * authoritative.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { POLL_INTERVAL_MS } from "../../shared/types.ts";
+
+/**
+ * Opportunistic fast-path interrupt signal. On Unix `SIGUSR2` is trapped by the
+ * runner; on Windows `process.kill(pid, "SIGBREAK")` is not deliverable
+ * cross-process and throws `ENOSYS`, so the file inbox below is the real channel.
+ */
+export const INTERRUPT_SIGNAL: NodeJS.Signals = process.platform === "win32" ? "SIGBREAK" : "SIGUSR2";
+
+export type ControlChannelFs = Pick<typeof fs, "mkdirSync" | "existsSync" | "rmSync" | "watch">;
+export type ControlChannelTimers = { setInterval: typeof setInterval; clearInterval: typeof clearInterval };
+type KillFn = (pid: number, signal?: NodeJS.Signals | 0) => unknown;
+
+export interface InterruptRequest {
+	type: "interrupt";
+	ts?: number;
+	source?: string;
+	reason?: string;
+}
+
+/** Control inbox directory inside an async run dir. */
+export function controlInboxDir(asyncDir: string): string {
+	return path.join(asyncDir, "control");
+}
+
+/** Path of the portable interrupt request file. */
+export function interruptRequestPath(asyncDir: string): string {
+	return path.join(controlInboxDir(asyncDir), "interrupt.json");
+}
+
+/**
+ * Parent side: drop a portable interrupt request the runner's inbox watcher will
+ * pick up regardless of OS. Written atomically (temp + rename), dir auto-created.
+ */
+export function requestAsyncInterrupt(
+	asyncDir: string,
+	payload: Omit<InterruptRequest, "type"> = {},
+	deps: { now?: () => number } = {},
+): string {
+	const requestPath = interruptRequestPath(asyncDir);
+	const request: InterruptRequest = { type: "interrupt", ts: deps.now?.() ?? Date.now(), ...payload };
+	writeAtomicJson(requestPath, request);
+	return requestPath;
+}
+
+/**
+ * Runner side: consume a pending interrupt request. Idempotent — removes the file
+ * so each distinct request fires exactly once. Returns whether one was pending.
+ */
+export function consumeInterruptRequest(
+	asyncDir: string,
+	fsImpl: Pick<typeof fs, "existsSync" | "rmSync"> = fs,
+): boolean {
+	const requestPath = interruptRequestPath(asyncDir);
+	if (!fsImpl.existsSync(requestPath)) return false;
+	try {
+		fsImpl.rmSync(requestPath, { force: true });
+	} catch {
+		// Already removed by a concurrent check — still counts as consumed.
+	}
+	return true;
+}
+
+/**
+ * Parent side: portable interrupt = authoritative file request + best-effort OS
+ * signal. The signal is only a latency optimization on Unix; ENOSYS on Windows
+ * is swallowed because the file inbox is authoritative there. Other signal
+ * failures are surfaced because they usually mean the runner is not alive to
+ * consume the request.
+ */
+export function deliverInterruptRequest(input: {
+	asyncDir: string;
+	pid?: number;
+	kill?: KillFn;
+	signal?: NodeJS.Signals;
+	now?: () => number;
+	source?: string;
+}): void {
+	const requestPath = requestAsyncInterrupt(input.asyncDir, input.source ? { source: input.source } : {}, { now: input.now });
+	if (typeof input.pid === "number" && input.pid > 0) {
+		try {
+			(input.kill ?? process.kill)(input.pid, input.signal ?? INTERRUPT_SIGNAL);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOSYS") {
+				// File inbox is authoritative when custom cross-process signals are unavailable.
+				return;
+			}
+			try {
+				fs.rmSync(requestPath, { force: true });
+			} catch {
+				// Best effort cleanup; the caller still gets the signal failure.
+			}
+			throw error;
+		}
+	}
+}
+
+/**
+ * Runner side: watch the control inbox and route interrupt requests into
+ * `onInterrupt`. Uses `fs.watch` when available plus an interval poll as a
+ * portable safety net (covers filesystems/platforms where `fs.watch` is
+ * unreliable). Fires once per distinct request. Returns a disposer.
+ */
+export function watchAsyncControlInbox(
+	asyncDir: string,
+	opts: {
+		onInterrupt: () => void;
+		pollIntervalMs?: number;
+		fs?: ControlChannelFs;
+		timers?: ControlChannelTimers;
+	},
+): () => void {
+	const fsImpl = opts.fs ?? fs;
+	const timers = opts.timers ?? { setInterval, clearInterval };
+	const dir = controlInboxDir(asyncDir);
+	try {
+		fsImpl.mkdirSync(dir, { recursive: true });
+	} catch {
+		// Best effort — the poll/watch below tolerates a missing dir.
+	}
+
+	let disposed = false;
+	const check = (): void => {
+		if (disposed) return;
+		try {
+			if (consumeInterruptRequest(asyncDir, fsImpl)) opts.onInterrupt();
+		} catch {
+			// Never let inbox errors crash the runner.
+		}
+	};
+
+	// Handle a request that may have arrived before the watcher started.
+	check();
+
+	let watcher: fs.FSWatcher | undefined;
+	try {
+		watcher = fsImpl.watch(dir, () => check());
+		watcher.on?.("error", () => {
+			// fs.watch can emit on transient FS errors; the interval poll keeps us live.
+		});
+	} catch {
+		watcher = undefined;
+	}
+
+	const interval = timers.setInterval(check, opts.pollIntervalMs ?? POLL_INTERVAL_MS);
+	interval.unref?.();
+
+	return () => {
+		if (disposed) return;
+		disposed = true;
+		try {
+			watcher?.close();
+		} catch {
+			// ignore
+		}
+		timers.clearInterval(interval);
+	};
+}

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -57,7 +57,7 @@ export function requestAsyncInterrupt(
 	deps: { now?: () => number } = {},
 ): string {
 	const requestPath = interruptRequestPath(asyncDir);
-	const request: InterruptRequest = { type: "interrupt", ts: deps.now?.() ?? Date.now(), ...payload };
+	const request: InterruptRequest = { ...payload, ts: payload.ts ?? deps.now?.() ?? Date.now(), type: "interrupt" };
 	writeAtomicJson(requestPath, request);
 	return requestPath;
 }
@@ -73,7 +73,7 @@ export function consumeInterruptRequest(
 	const requestPath = interruptRequestPath(asyncDir);
 	if (!fsImpl.existsSync(requestPath)) return false;
 	try {
-		fsImpl.rmSync(requestPath, { force: true });
+		fsImpl.rmSync(requestPath, { force: true, recursive: true });
 	} catch {
 		// Already removed by a concurrent check — still counts as consumed.
 	}

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { consumeInterruptRequest, watchAsyncControlInbox } from "./control-channel.ts";
 import { appendJsonl, getArtifactPaths } from "../../shared/artifacts.ts";
 import { PI_CODING_AGENT_PACKAGE, getPiSpawnCommand, resolveInstalledPiPackageRoot } from "../shared/pi-spawn.ts";
 import { captureSingleOutputSnapshot, finalizeSingleOutput, formatSavedOutputReference, resolveSingleOutput, type SingleOutputSnapshot } from "../shared/single-output.ts";
@@ -1431,6 +1432,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 	}
 
 	const interruptRunner = () => {
+		consumeInterruptRequest(asyncDir);
 		if (interrupted || statusPayload.state !== "running") return;
 		interrupted = true;
 		const now = Date.now();
@@ -1456,6 +1458,10 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		activeChildInterrupt?.();
 	};
 	process.on(ASYNC_INTERRUPT_SIGNAL, interruptRunner);
+	// Portable control inbox: the parent drops an interrupt request file here when
+	// it cannot deliver the OS signal (e.g. ENOSYS on Windows). Routes into the
+	// same graceful interruptRunner() so stop/steer work on every platform.
+	const disposeControlInbox = watchAsyncControlInbox(asyncDir, { onInterrupt: interruptRunner });
 	appendJsonl(
 		eventsPath,
 		JSON.stringify({
@@ -2241,6 +2247,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		clearInterval(activityTimer);
 		activityTimer = undefined;
 	}
+	disposeControlInbox();
 	const effectiveSessionFile = sessionFile ?? latestSessionFile;
 	const runEndedAt = Date.now();
 	statusPayload.state = interrupted ? "paused" : results.every((r) => r.success) ? "complete" : "failed";

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -50,6 +50,8 @@ import {
 	stripDetailsOutputsForIntercomReceipt,
 } from "../../intercom/result-intercom.ts";
 import { buildRevivedAsyncTask, interruptLiveAsyncResumeTarget, resolveAsyncResumeTarget } from "../background/async-resume.ts";
+import { deliverInterruptRequest } from "../background/control-channel.ts";
+import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
 import { resolveAsyncRootResultPath } from "../background/chain-root-attachment.ts";
 import { createNestedRoute, readNestedControlResults, resolveInheritedNestedRouteFromEnv, resolveNestedAsyncDir, resolveNestedParentAddressFromEnv, updateForegroundNestedProjection, writeNestedControlRequest, writeNestedEvent, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 import { resolveSubagentRunId, type ResolvedSubagentRunId } from "../background/run-id-resolver.ts";
@@ -96,7 +98,6 @@ import {
 	wrapForkTask,
 } from "../../shared/types.ts";
 
-const ASYNC_INTERRUPT_SIGNAL: NodeJS.Signals = process.platform === "win32" ? "SIGBREAK" : "SIGUSR2";
 const MUTATING_MANAGEMENT_ACTIONS = new Set(["create", "update", "delete"]);
 
 interface TaskParam {
@@ -411,7 +412,7 @@ function emitControlNotification(input: {
 function interruptAsyncRun(state: SubagentState, runId: string | undefined, kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean): AgentToolResult<Details> | null {
 	const target = getAsyncInterruptTarget(state, runId);
 	if (!target) return null;
-	const status = readStatus(target.asyncDir);
+	const status = reconcileAsyncRun(target.asyncDir, { kill }).status;
 	if (!status || status.state !== "running" || typeof status.pid !== "number") {
 		return {
 			content: [{ type: "text", text: `No running async run with an interrupt-capable pid was found for '${runId ?? "current"}'.` }],
@@ -420,7 +421,7 @@ function interruptAsyncRun(state: SubagentState, runId: string | undefined, kill
 		};
 	}
 	try {
-		(kill ?? process.kill)(status.pid, ASYNC_INTERRUPT_SIGNAL);
+		deliverInterruptRequest({ asyncDir: target.asyncDir, pid: status.pid, kill, source: "interrupt-action" });
 		const tracked = state.asyncJobs.get(target.asyncId);
 		if (tracked) {
 			tracked.activityState = undefined;
@@ -706,7 +707,7 @@ function directNestedAsyncInterrupt(target: ResolvedSubagentRunId & { kind: "nes
 	const pid = typeof status?.pid === "number" && status.pid > 0 ? status.pid : run.pid;
 	if (!status || status.state !== "running" || typeof pid !== "number" || pid <= 0) return undefined;
 	try {
-		process.kill(pid, ASYNC_INTERRUPT_SIGNAL);
+		deliverInterruptRequest({ asyncDir, pid, source: "nested-interrupt" });
 		return { content: [{ type: "text", text: `Interrupt requested for nested async run ${run.id}.` }], details: { mode: "management", results: [] } };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -720,7 +720,7 @@ function directNestedAsyncInterrupt(target: ResolvedSubagentRunId & { kind: "nes
 	const run = target.match.run;
 	const asyncDir = resolveNestedAsyncDir(target.match.rootRunId, run);
 	if (!asyncDir) return undefined;
-	const status = readStatus(asyncDir);
+	const status = reconcileAsyncRun(asyncDir, { resultsDir: path.join(RESULTS_DIR, "nested", target.match.rootRunId) }).status;
 	const pid = typeof status?.pid === "number" && status.pid > 0 ? status.pid : run.pid;
 	if (!status || status.state !== "running" || typeof pid !== "number" || pid <= 0) return undefined;
 	try {
@@ -801,6 +801,7 @@ async function resumeAsyncRun(input: {
 			target,
 			state: input.deps.state,
 			kill: input.deps.kill,
+			resultsDir: RESULTS_DIR,
 		});
 		if (!interrupt.ok) {
 			return {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -373,7 +373,17 @@ function resolveResumeTarget(params: SubagentParamsLike, state: SubagentState, o
 	throw new Error("Run not found. Provide id or runId.");
 }
 
-function getAsyncInterruptTarget(state: SubagentState, runId: string | undefined): { asyncId: string; asyncDir: string } | undefined {
+function getAsyncInterruptTarget(
+	state: SubagentState,
+	runId: string | undefined,
+	location?: { asyncDir: string | null; resolvedId?: string },
+): { asyncId: string; asyncDir: string } | undefined {
+	if (location?.asyncDir) {
+		return {
+			asyncId: location.resolvedId ?? runId ?? path.basename(location.asyncDir),
+			asyncDir: location.asyncDir,
+		};
+	}
 	if (runId) {
 		const direct = state.asyncJobs.get(runId);
 		if (direct) return { asyncId: direct.asyncId, asyncDir: direct.asyncDir };
@@ -416,8 +426,13 @@ function emitControlNotification(input: {
 	}
 }
 
-function interruptAsyncRun(state: SubagentState, runId: string | undefined, kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean): AgentToolResult<Details> | null {
-	const target = getAsyncInterruptTarget(state, runId);
+function interruptAsyncRun(
+	state: SubagentState,
+	runId: string | undefined,
+	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean,
+	location?: { asyncDir: string | null; resolvedId?: string },
+): AgentToolResult<Details> | null {
+	const target = getAsyncInterruptTarget(state, runId, location);
 	if (!target) return null;
 	const status = reconcileAsyncRun(target.asyncDir, { kill }).status;
 	if (!status || status.state !== "running" || typeof status.pid !== "number") {
@@ -2786,7 +2801,12 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						details: { mode: "management", results: [] },
 					};
 				}
-				const asyncInterruptResult = interruptAsyncRun(deps.state, resolved?.kind === "async" ? resolved.id : targetRunId, deps.kill);
+				const asyncInterruptResult = interruptAsyncRun(
+					deps.state,
+					resolved?.kind === "async" ? resolved.id : targetRunId,
+					deps.kill,
+					resolved?.kind === "async" ? resolved.location : undefined,
+				);
 				if (asyncInterruptResult) return asyncInterruptResult;
 				return {
 					content: [{ type: "text", text: "No interrupt-capable run found in this session." }],

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { createSubagentExecutor } from "../../src/runs/foreground/subagent-executor.ts";
+import { ASYNC_DIR, RESULTS_DIR, type SubagentState } from "../../src/shared/types.ts";
+
+function createState(): SubagentState {
+	return {
+		baseCwd: "",
+		currentSessionId: null,
+		asyncJobs: new Map(),
+		foregroundRuns: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		pendingForegroundControlNotices: new Map(),
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	};
+}
+
+function writeJson(filePath: string, value: object): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function createRunningAsync(state: SubagentState, runId: string): string {
+	const asyncDir = path.join(ASYNC_DIR, runId);
+	writeJson(path.join(asyncDir, "status.json"), {
+		runId,
+		mode: "single",
+		state: "running",
+		pid: 12345,
+		cwd: os.tmpdir(),
+		startedAt: 100,
+		lastUpdate: Date.now(),
+		steps: [{ agent: "worker", status: "running", startedAt: 100 }],
+	});
+	state.asyncJobs.set(runId, {
+		asyncId: runId,
+		asyncDir,
+		status: "running",
+		pid: 12345,
+		agents: ["worker"],
+		updatedAt: 100,
+	});
+	return asyncDir;
+}
+
+function cleanup(runId: string, asyncDir: string): void {
+	fs.rmSync(asyncDir, { recursive: true, force: true });
+	fs.rmSync(path.join(RESULTS_DIR, `${runId}.json`), { force: true });
+}
+
+function executorWithKill(state: SubagentState, kill: (pid: number, signal?: NodeJS.Signals | 0) => boolean) {
+	return createSubagentExecutor({
+		pi: { events: { emit() {}, on() { return () => {}; } }, getSessionName() { return "parent"; } } as any,
+		state,
+		config: { maxSubagentDepth: 2, control: {}, intercomBridge: {} } as any,
+		asyncByDefault: false,
+		tempArtifactsDir: os.tmpdir(),
+		getSubagentSessionRoot: (parentSessionFile) => parentSessionFile ? path.join(path.dirname(parentSessionFile), path.basename(parentSessionFile, ".jsonl")) : os.tmpdir(),
+		expandTilde: (value) => value,
+		discoverAgents: () => ({ agents: [] }),
+		kill,
+	});
+}
+
+function ctx() {
+	return {
+		cwd: os.tmpdir(),
+		hasUI: false,
+		sessionManager: { getSessionId() { return "session"; }, getSessionFile() { return null; } },
+		modelRegistry: { getAvailable() { return []; } },
+	} as any;
+}
+
+function text(result: Awaited<ReturnType<ReturnType<typeof executorWithKill>["execute"]>>): string {
+	return result.content[0]?.type === "text" ? result.content[0].text : "";
+}
+
+describe("async interrupt action", () => {
+	it("reports success and writes the portable request when the signal is unavailable", async () => {
+		const state = createState();
+		const runId = `interrupt-enosys-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId);
+		try {
+			const result = await executorWithKill(state, (_pid, signal) => {
+				if (signal === 0) return true;
+				const error = new Error("kill ENOSYS") as NodeJS.ErrnoException;
+				error.code = "ENOSYS";
+				throw error;
+			}).execute("interrupt", { action: "interrupt", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, undefined);
+			assert.match(text(result), new RegExp(`Interrupt requested for async run ${runId}`));
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), true);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("does not report success for stale running status with a dead pid", async () => {
+		const state = createState();
+		const runId = `interrupt-esrch-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId);
+		try {
+			const result = await executorWithKill(state, () => {
+				const error = new Error("missing process") as NodeJS.ErrnoException;
+				error.code = "ESRCH";
+				throw error;
+			}).execute("interrupt", { action: "interrupt", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, true);
+			assert.match(text(result), /No running async run with an interrupt-capable pid/);
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), false);
+			const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+			assert.equal(status.state, "failed");
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+});

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -30,7 +30,7 @@ function writeJson(filePath: string, value: object): void {
 	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
 }
 
-function createRunningAsync(state: SubagentState, runId: string): string {
+function createRunningAsync(state: SubagentState, runId: string, options: { track?: boolean } = {}): string {
 	const asyncDir = path.join(ASYNC_DIR, runId);
 	writeJson(path.join(asyncDir, "status.json"), {
 		runId,
@@ -42,14 +42,16 @@ function createRunningAsync(state: SubagentState, runId: string): string {
 		lastUpdate: Date.now(),
 		steps: [{ agent: "worker", status: "running", startedAt: 100 }],
 	});
-	state.asyncJobs.set(runId, {
-		asyncId: runId,
-		asyncDir,
-		status: "running",
-		pid: 12345,
-		agents: ["worker"],
-		updatedAt: 100,
-	});
+	if (options.track !== false) {
+		state.asyncJobs.set(runId, {
+			asyncId: runId,
+			asyncDir,
+			status: "running",
+			pid: 12345,
+			agents: ["worker"],
+			updatedAt: 100,
+		});
+	}
 	return asyncDir;
 }
 
@@ -86,6 +88,26 @@ function text(result: Awaited<ReturnType<ReturnType<typeof executorWithKill>["ex
 }
 
 describe("async interrupt action", () => {
+	it("interrupts a running async run resolved from disk after in-memory tracking is gone", async () => {
+		const state = createState();
+		const runId = `interrupt-disk-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false });
+		try {
+			const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+			const result = await executorWithKill(state, (pid, signal) => {
+				kills.push({ pid, signal });
+				return true;
+			}).execute("interrupt", { action: "interrupt", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, undefined);
+			assert.match(text(result), new RegExp(`Interrupt requested for async run ${runId}`));
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), true);
+			assert.deepEqual(kills, [{ pid: 12345, signal: 0 }, { pid: 12345, signal: process.platform === "win32" ? "SIGBREAK" : "SIGUSR2" }]);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
 	it("reports success and writes the portable request when the signal is unavailable", async () => {
 		const state = createState();
 		const runId = `interrupt-enosys-${Date.now().toString(36)}`;

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import {
+	consumeInterruptRequest,
+	deliverInterruptRequest,
+	interruptRequestPath,
+	requestAsyncInterrupt,
+	watchAsyncControlInbox,
+} from "../../src/runs/background/control-channel.ts";
+
+function tmpAsyncDir(label: string): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), label));
+	return path.join(root, "run");
+}
+
+function cleanup(asyncDir: string): void {
+	fs.rmSync(path.dirname(asyncDir), { recursive: true, force: true });
+}
+
+describe("control channel: request file", () => {
+	it("writes a parseable interrupt request, creating the inbox dir", () => {
+		const asyncDir = tmpAsyncDir("pi-control-write-");
+		try {
+			const requestPath = requestAsyncInterrupt(asyncDir, { source: "test" }, { now: () => 999 });
+			assert.equal(requestPath, interruptRequestPath(asyncDir));
+			const data = JSON.parse(fs.readFileSync(requestPath, "utf-8"));
+			assert.equal(data.type, "interrupt");
+			assert.equal(data.ts, 999);
+			assert.equal(data.source, "test");
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("consumes a pending request exactly once and removes the file", () => {
+		const asyncDir = tmpAsyncDir("pi-control-consume-");
+		try {
+			requestAsyncInterrupt(asyncDir);
+			assert.equal(consumeInterruptRequest(asyncDir), true);
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
+			assert.equal(consumeInterruptRequest(asyncDir), false);
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+});
+
+describe("control channel: deliverInterruptRequest", () => {
+	it("writes the portable request and signals best-effort when kill succeeds", () => {
+		const asyncDir = tmpAsyncDir("pi-control-deliver-ok-");
+		try {
+			const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+			deliverInterruptRequest({
+				asyncDir,
+				pid: 4242,
+				signal: "SIGUSR2",
+				kill: (pid, signal) => {
+					kills.push({ pid, signal });
+					return true;
+				},
+			});
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
+			assert.deepEqual(kills, [{ pid: 4242, signal: "SIGUSR2" }]);
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("still writes the request when the OS signal throws ENOSYS (Windows)", () => {
+		const asyncDir = tmpAsyncDir("pi-control-deliver-enosys-");
+		try {
+			assert.doesNotThrow(() =>
+				deliverInterruptRequest({
+					asyncDir,
+					pid: 4242,
+					kill: () => {
+						const error = new Error("kill ENOSYS") as NodeJS.ErrnoException;
+						error.code = "ENOSYS";
+						throw error;
+					},
+				}),
+			);
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("surfaces non-portability signal failures and removes the stale request", () => {
+		const asyncDir = tmpAsyncDir("pi-control-deliver-esrch-");
+		try {
+			assert.throws(
+				() =>
+					deliverInterruptRequest({
+						asyncDir,
+						pid: 4242,
+						kill: () => {
+							const error = new Error("missing process") as NodeJS.ErrnoException;
+							error.code = "ESRCH";
+							throw error;
+						},
+					}),
+				/missing process/,
+			);
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("skips signalling when no live pid is provided", () => {
+		const asyncDir = tmpAsyncDir("pi-control-deliver-nopid-");
+		try {
+			let killed = false;
+			deliverInterruptRequest({ asyncDir, kill: () => { killed = true; return true; } });
+			assert.equal(killed, false);
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+});
+
+describe("control channel: watchAsyncControlInbox", () => {
+	type WatchHarness = {
+		fsImpl: import("../../src/runs/background/control-channel.ts").ControlChannelFs;
+		timers: import("../../src/runs/background/control-channel.ts").ControlChannelTimers;
+		trigger: () => void;
+		closed: () => boolean;
+	};
+
+	function harness(): WatchHarness {
+		let listener: (() => void) | undefined;
+		let closed = false;
+		const fsImpl = {
+			mkdirSync: fs.mkdirSync,
+			existsSync: fs.existsSync,
+			rmSync: fs.rmSync,
+			watch: ((_dir: string, cb: () => void) => {
+				listener = cb;
+				return { close: () => { closed = true; }, on: () => {} };
+			}),
+		} as unknown as WatchHarness["fsImpl"];
+		const timers = {
+			setInterval: (() => ({ unref() {} })) as unknown as typeof setInterval,
+			clearInterval: (() => {}) as unknown as typeof clearInterval,
+		};
+		return { fsImpl, timers, trigger: () => listener?.(), closed: () => closed };
+	}
+
+	it("fires on a request that arrived before the watcher started", () => {
+		const asyncDir = tmpAsyncDir("pi-control-watch-early-");
+		try {
+			requestAsyncInterrupt(asyncDir);
+			let fired = 0;
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt: () => fired++, fs: h.fsImpl, timers: h.timers });
+			assert.equal(fired, 1);
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("fires once per request via the watch event and stops after dispose", () => {
+		const asyncDir = tmpAsyncDir("pi-control-watch-event-");
+		try {
+			let fired = 0;
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt: () => fired++, fs: h.fsImpl, timers: h.timers });
+			assert.equal(fired, 0);
+
+			requestAsyncInterrupt(asyncDir);
+			h.trigger();
+			assert.equal(fired, 1);
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
+
+			// No pending request → spurious event is a no-op.
+			h.trigger();
+			assert.equal(fired, 1);
+
+			dispose();
+			assert.equal(h.closed(), true);
+
+			// After dispose, even a fresh request is ignored.
+			requestAsyncInterrupt(asyncDir);
+			h.trigger();
+			assert.equal(fired, 1);
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+});

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -35,10 +35,34 @@ describe("control channel: request file", () => {
 		}
 	});
 
+	it("keeps the request type authoritative even for untyped callers", () => {
+		const asyncDir = tmpAsyncDir("pi-control-write-type-");
+		try {
+			const requestPath = requestAsyncInterrupt(asyncDir, { type: "not-interrupt", source: "test" } as any, { now: () => 999 });
+			const data = JSON.parse(fs.readFileSync(requestPath, "utf-8"));
+			assert.equal(data.type, "interrupt");
+			assert.equal(data.source, "test");
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
 	it("consumes a pending request exactly once and removes the file", () => {
 		const asyncDir = tmpAsyncDir("pi-control-consume-");
 		try {
 			requestAsyncInterrupt(asyncDir);
+			assert.equal(consumeInterruptRequest(asyncDir), true);
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
+			assert.equal(consumeInterruptRequest(asyncDir), false);
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("removes a malformed request directory instead of firing forever", () => {
+		const asyncDir = tmpAsyncDir("pi-control-consume-dir-");
+		try {
+			fs.mkdirSync(interruptRequestPath(asyncDir), { recursive: true });
 			assert.equal(consumeInterruptRequest(asyncDir), true);
 			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
 			assert.equal(consumeInterruptRequest(asyncDir), false);

--- a/test/unit/live-async-resume.test.ts
+++ b/test/unit/live-async-resume.test.ts
@@ -60,6 +60,103 @@ describe("live async resume interrupt", () => {
 			assert.deepEqual(kills, [{ pid: process.pid, signal: ASYNC_RESUME_INTERRUPT_SIGNAL }]);
 			assert.equal(state.asyncJobs.get("run-live")?.activityState, undefined);
 			assert.equal(state.asyncJobs.get("run-live")?.updatedAt, 1234);
+			// The portable control request is dropped regardless of the signal path.
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), true);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("still interrupts a live async child when the OS signal is unavailable (ENOSYS on Windows)", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-live-async-resume-enosys-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const resultsDir = path.join(root, "results");
+			const asyncDir = path.join(asyncRoot, "run-live");
+			writeJson(path.join(asyncDir, "status.json"), {
+				runId: "run-live",
+				mode: "single",
+				state: "running",
+				pid: process.pid,
+				cwd: root,
+				startedAt: 100,
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "running", startedAt: 100 }],
+			});
+			const target = resolveAsyncResumeTarget({ id: "run-live" }, { asyncDirRoot: asyncRoot, resultsDir });
+			assert.equal(target.kind, "live");
+
+			const state = {
+				asyncJobs: new Map([["run-live", {
+					asyncId: "run-live",
+					asyncDir,
+					status: "running" as const,
+					pid: process.pid,
+					activityState: "needs_attention" as const,
+					updatedAt: 100,
+				}]]),
+			};
+
+			const result = interruptLiveAsyncResumeTarget({
+				target,
+				state,
+				now: () => 7,
+				kill: () => {
+					const error = new Error("kill ENOSYS") as NodeJS.ErrnoException;
+					error.code = "ENOSYS";
+					throw error;
+				},
+			});
+
+			// The signal failed, but the file-based control inbox makes the interrupt succeed.
+			assert.deepEqual(result, { ok: true, asyncId: "run-live" });
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), true);
+			assert.equal(state.asyncJobs.get("run-live")?.activityState, undefined);
+			assert.equal(state.asyncJobs.get("run-live")?.updatedAt, 7);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not report success or leave a stale request when the runner pid is gone", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-live-async-resume-esrch-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const resultsDir = path.join(root, "results");
+			const asyncDir = path.join(asyncRoot, "run-live");
+			writeJson(path.join(asyncDir, "status.json"), {
+				runId: "run-live",
+				mode: "single",
+				state: "running",
+				pid: 12345,
+				cwd: root,
+				startedAt: 100,
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "running", startedAt: 100 }],
+			});
+			const target = resolveAsyncResumeTarget({ id: "run-live" }, {
+				asyncDirRoot: asyncRoot,
+				resultsDir,
+				kill: (_pid, signal) => {
+					if (signal === 0) return true;
+					const error = new Error("missing process") as NodeJS.ErrnoException;
+					error.code = "ESRCH";
+					throw error;
+				},
+			});
+			assert.equal(target.kind, "live");
+
+			const result = interruptLiveAsyncResumeTarget({
+				target,
+				kill: () => {
+					const error = new Error("missing process") as NodeJS.ErrnoException;
+					error.code = "ESRCH";
+					throw error;
+				},
+			});
+
+			assert.deepEqual(result, { ok: false, message: "Failed to interrupt async run run-live: missing process" });
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), false);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/live-async-resume.test.ts
+++ b/test/unit/live-async-resume.test.ts
@@ -50,6 +50,7 @@ describe("live async resume interrupt", () => {
 				target,
 				state,
 				now: () => 1234,
+				resultsDir,
 				kill: (pid, signal) => {
 					kills.push({ pid, signal });
 					return true;
@@ -57,7 +58,7 @@ describe("live async resume interrupt", () => {
 			});
 
 			assert.deepEqual(result, { ok: true, asyncId: "run-live" });
-			assert.deepEqual(kills, [{ pid: process.pid, signal: ASYNC_RESUME_INTERRUPT_SIGNAL }]);
+			assert.deepEqual(kills, [{ pid: process.pid, signal: 0 }, { pid: process.pid, signal: ASYNC_RESUME_INTERRUPT_SIGNAL }]);
 			assert.equal(state.asyncJobs.get("run-live")?.activityState, undefined);
 			assert.equal(state.asyncJobs.get("run-live")?.updatedAt, 1234);
 			// The portable control request is dropped regardless of the signal path.
@@ -101,6 +102,7 @@ describe("live async resume interrupt", () => {
 				target,
 				state,
 				now: () => 7,
+				resultsDir,
 				kill: () => {
 					const error = new Error("kill ENOSYS") as NodeJS.ErrnoException;
 					error.code = "ENOSYS";
@@ -148,6 +150,7 @@ describe("live async resume interrupt", () => {
 
 			const result = interruptLiveAsyncResumeTarget({
 				target,
+				resultsDir,
 				kill: () => {
 					const error = new Error("missing process") as NodeJS.ErrnoException;
 					error.code = "ESRCH";
@@ -155,8 +158,11 @@ describe("live async resume interrupt", () => {
 				},
 			});
 
-			assert.deepEqual(result, { ok: false, message: "Failed to interrupt async run run-live: missing process" });
+			assert.deepEqual(result, { ok: false, message: "Async run run-live is live but no interrupt-capable runner pid was found." });
 			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), false);
+			const repairedStatus = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+			assert.equal(repairedStatus.state, "failed");
+			assert.equal(fs.existsSync(path.join(resultsDir, "run-live.json")), true);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
Closes #331

## Problem

Async subagent control delivered an interrupt by sending an OS signal to the detached runner process:

```ts
process.kill(pid, process.platform === "win32" ? "SIGBREAK" : "SIGUSR2")
```

On Unix `SIGUSR2` is trapped by the runner and works. On Windows `process.kill(pid, "SIGBREAK")` throws `ENOSYS`, so async runs cannot be gracefully interrupted/paused. This breaks `action: "interrupt"` and any live steering/nudge through `action: "resume"` for a still-running async child (live resume interrupts the child before sending the follow-up). Read-only `status`/`peek` is unaffected — it only inspects persisted run state.

Reproduced on Windows with a real detached child process (`process.kill` against the live pid):

```
0        ok:true
SIGBREAK err:ENOSYS
SIGUSR2  err:ERR_UNKNOWN_SIGNAL
SIGTERM  ok:true
```

`SIGTERM` "works" only as unconditional termination — it would kill the runner instead of routing through the graceful path that marks the run paused, updates status/result, and preserves resume/live-steer. This matches Node's documented behavior: Windows has no real POSIX signals, and the few `process.kill` emulates (`SIGINT`/`SIGTERM`/`SIGKILL`) terminate unconditionally rather than acting as a catchable graceful interrupt (see [nodejs/node#12378](https://github.com/nodejs/node/issues/12378), [nodejs/node#35172](https://github.com/nodejs/node/issues/35172)).

## Fix

Add a portable, file-backed control inbox inside the async run directory (`<asyncDir>/control/interrupt.json`), consistent with the run state that is already file-backed (status/result/events). New module: `src/runs/background/control-channel.ts`.

**Parent side (`deliverInterruptRequest`):**
1. Write `control/interrupt.json` atomically (temp + rename).
2. Try the OS signal as a best-effort fast path.
3. Swallow `ENOSYS` (unsupported Windows signal delivery) — the file request is authoritative.
4. Remove the request file on real signal failures (e.g. stale pid / `ESRCH`) so we don't leave dangling requests.

**Runner side (`watchAsyncControlInbox`):**
1. Watch `<asyncDir>/control` with `fs.watch` plus an interval poll as a portable safety net (covers filesystems where `fs.watch` is unreliable).
2. Consume `interrupt.json` exactly once (idempotent).
3. Route it into the same graceful `interruptRunner()` already used by the signal path.

This keeps Unix on the fast signal path while making Windows reliable, without changing the detached spawn model (`detached: true, stdio: "ignore"`), so there is no parent↔child IPC channel to rely on and the inbox keeps working across a parent reload.

The interrupt entry points (`interrupt` action, live `resume`, nested interrupt) now reconcile stale async runs from disk before delivering, so runs resolved from disk after a reload — and stale PIDs — are handled instead of leaving an unconsumed request behind.

## Tests

- `test/unit/control-channel.test.ts` — request/consume idempotency, `ENOSYS` swallowed, stale-pid cleanup, watcher routing.
- `test/unit/async-interrupt-action.test.ts` — `interrupt` action delivered through the file inbox.
- `test/unit/live-async-resume.test.ts` — live-resume interrupt path over the portable channel.

All new tests pass. No new failures versus `main` (the pre-existing failures in the suite are unrelated, environment-specific, and present on `main` as well).
