### PR TITLE
fix(intercom): discover pi-intercom installed via `--extension npm:pi-intercom`

### DIFF
--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -200,6 +200,23 @@ function getGlobalNpmRoot(): string | null {
 	}
 }
 
+function tmpNpmIntercomPackageDir(agentDir: string): string | undefined {
+	const tmpNpmDir = path.join(agentDir, "tmp", "extensions", "npm");
+	try {
+		const entries = fs.readdirSync(tmpNpmDir, { withFileTypes: true });
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			const pkgDir = path.join(tmpNpmDir, entry.name, "node_modules", PI_INTERCOM_PACKAGE_NAME);
+			if (fs.existsSync(pkgDir) && packageHasPiExtension(pkgDir)) {
+				return path.resolve(pkgDir);
+			}
+		}
+	} catch {
+		// ignore ENOTDIR, ENOENT, permission errors
+	}
+	return undefined;
+}
+
 function configuredPiIntercomPackageDir(input: ResolveIntercomBridgeInput, agentDir: string): string | undefined {
 	const projectConfigDir = input.cwd ? findNearestProjectConfigDir(path.resolve(input.cwd)) : undefined;
 	const settingsFiles = [
@@ -236,7 +253,14 @@ function configuredPiIntercomPackageDir(input: ResolveIntercomBridgeInput, agent
 function resolveIntercomExtensionDir(input: ResolveIntercomBridgeInput, agentDir: string): string {
 	const legacyDir = path.resolve(input.extensionDir ?? envIntercomExtensionDir() ?? defaultIntercomExtensionDir(agentDir));
 	if (fs.existsSync(legacyDir)) return legacyDir;
-	return configuredPiIntercomPackageDir(input, agentDir) ?? legacyDir;
+
+	const configured = configuredPiIntercomPackageDir(input, agentDir);
+	if (configured) return configured;
+
+	const tmpDir = tmpNpmIntercomPackageDir(agentDir);
+	if (tmpDir) return tmpDir;
+
+	return legacyDir;
 }
 
 function extensionSandboxAllowsIntercom(extensions: string[] | undefined, extensionDir: string): boolean {

--- a/test/unit/intercom-bridge.test.ts
+++ b/test/unit/intercom-bridge.test.ts
@@ -96,12 +96,15 @@ describe("diagnoseIntercomBridge", () => {
 	it("reports inactive and unavailable when pi-intercom is missing", () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-intercom-diagnostic-test-"));
 		try {
+			// Point agentDir at the temp dir so the new tmp/extensions/npm fallback
+			// does not accidentally discover a real pi-intercom from the user's system.
 			const diagnostic = diagnoseIntercomBridge({
 				config: { mode: "always" },
 				context: "fresh",
 				orchestratorTarget: "main",
 				extensionDir: path.join(tempDir, "missing-pi-intercom"),
 				configPath: path.join(tempDir, "config.json"),
+				agentDir: tempDir,
 			});
 			assert.equal(diagnostic.active, false);
 			assert.equal(diagnostic.wantsIntercom, true);

--- a/test/unit/intercom-extension-dir.test.ts
+++ b/test/unit/intercom-extension-dir.test.ts
@@ -70,4 +70,25 @@ describe("PI_INTERCOM_EXTENSION_DIR override", () => {
 		});
 		assert.equal(diagnostic.extensionDir, path.resolve(explicitDir));
 	});
+
+	it("finds pi-intercom in the tmp/extensions/npm fallback directory", () => {
+		// Simulate the structure pi uses when loading --extension npm:pi-intercom:
+		// <agentDir>/tmp/extensions/npm/<hash>/node_modules/pi-intercom/
+		const tmpHashDir = path.join(agentDir, "tmp", "extensions", "npm", "abc123");
+		const pkgDir = path.join(tmpHashDir, "node_modules", "pi-intercom");
+		fs.mkdirSync(pkgDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(pkgDir, "package.json"),
+			JSON.stringify({ name: "pi-intercom", pi: { extensions: ["./index.ts"] } }),
+		);
+		// Also create a distractor hash dir without pi-intercom
+		fs.mkdirSync(path.join(agentDir, "tmp", "extensions", "npm", "other", "node_modules"), { recursive: true });
+
+		const diagnostic = diagnoseIntercomBridge({
+			config: { mode: "always" },
+			context: "fresh",
+			orchestratorTarget: "main",
+		});
+		assert.equal(diagnostic.extensionDir, path.resolve(pkgDir));
+	});
 });


### PR DESCRIPTION
## Description

The intercom bridge resolver (`resolveIntercomExtensionDir`) discovered pi-intercom through two paths:

1. `~/.pi/agent/extensions/pi-intercom/` — legacy extension directory
2. Via `settings.json` → `packages` → `npm:pi-intercom` → npm `node_modules` (e.g. `~/.pi/agent/npm/node_modules/pi-intercom/`)

When pi-intercom is loaded via the `--extension npm:pi-intercom` CLI flag — for example from a Nix wrapper or a custom launcher — pi resolves the package into:

```
~/.pi/agent/tmp/extensions/npm/<hash>/node_modules/pi-intercom/
```

This location was not checked, so the bridge stayed inactive and child agents did not receive the `intercom` / `contact_supervisor` tools.

### Changes

- Added `tmpNpmIntercomPackageDir()` — a new fallback in `resolveIntercomExtensionDir()` that scans all hash directories under `tmp/extensions/npm/` and returns the first pi-intercom package with a valid pi extension manifest.
- Updated `resolveIntercomExtensionDir()` to try this fallback after the legacy dir and the settings.json-based lookup.
- Added a test case in `intercom-extension-dir.test.ts` for the new tmp/extensions/npm fallback.
- Fixed an isolation issue in the "reports inactive and unavailable when pi-intercom is missing" test — it now passes `agentDir` explicitly so the new fallback doesn't accidentally discover a real pi-intercom on the developer's machine.

### Testing

```bash
bun test test/unit/intercom-extension-dir.test.ts test/unit/intercom-bridge.test.ts
# 25 pass, 0 fail
```

### Notes

The `PI_INTERCOM_EXTENSION_DIR` env var (introduced earlier) is another way to solve this from the launcher side, but scanning the npm tmp directory makes the bridge robust without requiring every launcher to set the env var.