### PR TITLE
Fix async runner peer import diagnostics

### DIFF
--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -215,6 +215,74 @@ function resolveAsyncRunnerNodeCommand(): string {
 	return process.platform === "win32" ? "node.exe" : "node";
 }
 
+interface RunnerStdioFiles {
+	stdio: "ignore" | ["ignore", number, number];
+	closeParentFds: () => void;
+	stderrPath?: string;
+}
+
+const CONFIG_DIR_NAME_ENV = "PI_SUBAGENTS_CONFIG_DIR_NAME";
+
+function cleanString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function getAsyncDirFromRunnerConfig(cfg: object): string | undefined {
+	return cleanString((cfg as { asyncDir?: unknown }).asyncDir);
+}
+
+function getPiPackageRootFromRunnerConfig(cfg: object): string | undefined {
+	return cleanString((cfg as { piPackageRoot?: unknown }).piPackageRoot);
+}
+
+function readPiPackageConfigDirName(piPackageRoot: string | undefined): string | undefined {
+	if (!piPackageRoot) return undefined;
+	try {
+		const pkg = JSON.parse(fs.readFileSync(path.join(piPackageRoot, "package.json"), "utf-8")) as { piConfig?: { configDir?: unknown } };
+		return cleanString(pkg.piConfig?.configDir);
+	} catch {
+		return undefined;
+	}
+}
+
+function buildRunnerEnv(cfg: object): NodeJS.ProcessEnv | undefined {
+	const configDirName = cleanString(process.env[CONFIG_DIR_NAME_ENV])
+		?? readPiPackageConfigDirName(getPiPackageRootFromRunnerConfig(cfg));
+	return configDirName ? { ...process.env, [CONFIG_DIR_NAME_ENV]: configDirName } : undefined;
+}
+
+function openRunnerStdioFiles(cfg: object): RunnerStdioFiles {
+	const asyncDir = getAsyncDirFromRunnerConfig(cfg);
+	if (!asyncDir) return { stdio: "ignore", closeParentFds: () => {} };
+
+	const stdoutPath = path.join(asyncDir, "runner-stdout.log");
+	const stderrPath = path.join(asyncDir, "runner-stderr.log");
+	let stdoutFd: number | undefined;
+	let stderrFd: number | undefined;
+	const closeParentFds = () => {
+		for (const fd of [stdoutFd, stderrFd]) {
+			if (fd === undefined) continue;
+			try {
+				fs.closeSync(fd);
+			} catch {
+				// Best-effort cleanup of parent-side log descriptors.
+			}
+		}
+		stdoutFd = undefined;
+		stderrFd = undefined;
+	};
+
+	try {
+		fs.mkdirSync(asyncDir, { recursive: true });
+		stdoutFd = fs.openSync(stdoutPath, "a");
+		stderrFd = fs.openSync(stderrPath, "a");
+		return { stdio: ["ignore", stdoutFd, stderrFd], closeParentFds, stderrPath };
+	} catch {
+		closeParentFds();
+		return { stdio: "ignore", closeParentFds: () => {} };
+	}
+}
+
 /**
  * Spawn the async runner process
  */
@@ -237,18 +305,37 @@ function spawnRunner(cfg: object, suffix: string, cwd: string): { pid?: number; 
 	fs.writeFileSync(cfgPath, JSON.stringify(cfg));
 	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
 	const nodeCommand = resolveAsyncRunnerNodeCommand();
+	const runnerStdio = openRunnerStdioFiles(cfg);
+	const runnerEnv = buildRunnerEnv(cfg);
 
-	const proc = spawn(nodeCommand, [jitiCliPath, runner, cfgPath], {
-		cwd,
-		detached: true,
-		stdio: "ignore",
-		windowsHide: true,
-	});
+	let proc: ReturnType<typeof spawn>;
+	try {
+		proc = spawn(nodeCommand, [jitiCliPath, runner, cfgPath], {
+			cwd,
+			detached: true,
+			stdio: runnerStdio.stdio,
+			...(runnerEnv ? { env: runnerEnv } : {}),
+			windowsHide: true,
+		});
+	} catch (error) {
+		runnerStdio.closeParentFds();
+		const message = error instanceof Error ? error.message : String(error);
+		return { error: `async runner spawn threw for cwd ${cwd}: ${message}` };
+	}
+	runnerStdio.closeParentFds();
 	proc.on("error", (error) => {
+		if (runnerStdio.stderrPath) {
+			try {
+				fs.appendFileSync(runnerStdio.stderrPath, `[pi-subagents] async spawn failed: ${error.message}\n`, "utf-8");
+			} catch {
+				// Diagnostics are best-effort; keep the original console fallback.
+			}
+		}
 		console.error(`[pi-subagents] async spawn failed: ${error.message}`);
 	});
 	if (typeof proc.pid !== "number") {
-		return { error: `async runner did not produce a pid for cwd: ${cwd}` };
+		const hint = runnerStdio.stderrPath ? `; stderr log: ${runnerStdio.stderrPath}` : "";
+		return { error: `async runner did not produce a pid for cwd: ${cwd}${hint}` };
 	}
 	proc.unref();
 	return { pid: proc.pid };

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -41,6 +41,31 @@ function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+function readRunnerStartupDiagnostics(asyncDir: string): string | undefined {
+	const stderrPath = path.join(asyncDir, "runner-stderr.log");
+	const maxBytes = 64 * 1024;
+	let content: string;
+	try {
+		const stat = fs.statSync(stderrPath);
+		if (stat.size <= 0) return undefined;
+		const fd = fs.openSync(stderrPath, "r");
+		try {
+			const bytesToRead = Math.min(stat.size, maxBytes);
+			const start = Math.max(0, stat.size - bytesToRead);
+			const buffer = Buffer.alloc(bytesToRead);
+			fs.readSync(fd, buffer, 0, bytesToRead, start);
+			content = buffer.toString("utf-8").trim();
+		} finally {
+			fs.closeSync(fd);
+		}
+	} catch {
+		return undefined;
+	}
+	if (!content) return undefined;
+	const lines = content.split(/\r?\n/).slice(-30).join("\n");
+	return lines.length > 4000 ? `${lines.slice(-4000)}\n[stderr tail truncated]` : lines;
+}
+
 function isNotFoundError(error: unknown): boolean {
 	return typeof error === "object"
 		&& error !== null
@@ -172,7 +197,9 @@ function buildStartedStatus(asyncDir: string, startedRun: StartedRunMetadata, no
 function buildFailedRepair(status: AsyncStatus, asyncDir: string, now: number, reason?: string): { status: AsyncStatus; result: object; message: string } {
 	const runId = status.runId || path.basename(asyncDir);
 	const pid = typeof status.pid === "number" ? status.pid : "unknown";
-	const message = reason ?? `Async runner process ${pid} exited or disappeared before writing a result. Marked run failed by stale-run reconciliation.`;
+	const baseMessage = reason ?? `Async runner process ${pid} exited or disappeared before writing a result. Marked run failed by stale-run reconciliation.`;
+	const diagnostics = readRunnerStartupDiagnostics(asyncDir);
+	const message = diagnostics ? `${baseMessage}\n\nRunner stderr tail:\n${diagnostics}` : baseMessage;
 	const steps = status.steps?.length ? status.steps : [{ agent: "subagent", status: "running" as const }];
 	const repairedSteps = steps.map((step) => step.status === "running" || step.status === "pending"
 		? {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -5,7 +5,6 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import * as piCodingAgent from "@earendil-works/pi-coding-agent";
 import type { Message } from "@earendil-works/pi-ai";
 import { formatToolCall } from "./formatters.ts";
 import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, SingleResult, ToolCallSummary } from "./types.ts";
@@ -15,12 +14,48 @@ import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, Singl
 // ============================================================================
 
 const DEFAULT_CONFIG_DIR_NAME = ".pi";
+const CONFIG_DIR_NAME_ENV = "PI_SUBAGENTS_CONFIG_DIR_NAME";
 
-export function resolveConfigDirName(codingAgentModule: unknown = piCodingAgent): string {
+function cleanConfigDirName(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function readConfigDirNameFromPackageJson(packageJsonPath: string): string | undefined {
+	try {
+		const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as { piConfig?: { configDir?: unknown } };
+		return cleanConfigDirName(pkg.piConfig?.configDir);
+	} catch {
+		return undefined;
+	}
+}
+
+function findConfigDirNameFromEntry(entryPoint: string | undefined = process.argv[1]): string | undefined {
+	if (!entryPoint) return undefined;
+	let dir: string;
+	try {
+		dir = path.dirname(fs.realpathSync(entryPoint));
+	} catch {
+		dir = path.dirname(entryPoint);
+	}
+	while (dir !== path.dirname(dir)) {
+		const packageJsonPath = path.join(dir, "package.json");
+		if (fs.existsSync(packageJsonPath)) {
+			const configDir = readConfigDirNameFromPackageJson(packageJsonPath);
+			if (configDir) return configDir;
+		}
+		dir = path.dirname(dir);
+	}
+	return undefined;
+}
+
+export function resolveConfigDirName(codingAgentModule?: unknown): string {
 	const value = codingAgentModule && typeof codingAgentModule === "object"
 		? (codingAgentModule as { CONFIG_DIR_NAME?: unknown }).CONFIG_DIR_NAME
 		: undefined;
-	return typeof value === "string" && value.trim() ? value : DEFAULT_CONFIG_DIR_NAME;
+	return cleanConfigDirName(value)
+		?? cleanConfigDirName(process.env[CONFIG_DIR_NAME_ENV])
+		?? findConfigDirNameFromEntry()
+		?? DEFAULT_CONFIG_DIR_NAME;
 }
 
 export function getConfigDirName(): string {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -265,6 +265,45 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		}
 	});
 
+	it("captures detached runner stdio and forwards config-dir env", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const originalConfigDirName = process.env.PI_SUBAGENTS_CONFIG_DIR_NAME;
+		process.env.PI_SUBAGENTS_CONFIG_DIR_NAME = ".custom-pi";
+		try {
+			mockPi.onCall({ echoEnv: ["PI_SUBAGENTS_CONFIG_DIR_NAME"] });
+			const id = `async-runner-stdio-${Date.now().toString(36)}`;
+			const result = executeAsyncSingle(id, {
+				agent: "worker",
+				task: "Echo config env. Do not edit files.",
+				agentConfig: makeAgent("worker"),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: {
+					enabled: false,
+					includeInput: false,
+					includeOutput: false,
+					includeJsonl: false,
+					includeMetadata: false,
+					cleanupDays: 7,
+				},
+				shareEnabled: false,
+				sessionRoot: path.join(tempDir, "sessions"),
+				maxSubagentDepth: 2,
+			});
+
+			assert.equal(result.isError, undefined);
+			const resultPath = await waitForAsyncResultFile(id, 10_000);
+			const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+			assert.equal(payload.success, true);
+			assert.deepEqual(JSON.parse(payload.results[0]?.output ?? "{}"), { PI_SUBAGENTS_CONFIG_DIR_NAME: ".custom-pi" });
+			assert.ok(ASYNC_DIR, "expected async dir constant");
+			const asyncDir = path.join(ASYNC_DIR, id);
+			assert.equal(fs.existsSync(path.join(asyncDir, "runner-stdout.log")), true);
+			assert.equal(fs.existsSync(path.join(asyncDir, "runner-stderr.log")), true);
+		} finally {
+			if (originalConfigDirName === undefined) delete process.env.PI_SUBAGENTS_CONFIG_DIR_NAME;
+			else process.env.PI_SUBAGENTS_CONFIG_DIR_NAME = originalConfigDirName;
+		}
+	});
+
 	it("readStatus returns null for missing directory", () => {
 		const status = readStatus("/nonexistent/path/abc123");
 		assert.equal(status, null);

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -19,6 +19,7 @@ let cwd = "";
 let oldAgentDir: string | undefined;
 let oldHome: string | undefined;
 let oldUserProfile: string | undefined;
+let oldSubagentsConfigDirName: string | undefined;
 
 function writeFile(filePath: string, content: string): void {
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -38,6 +39,7 @@ describe("PI_CODING_AGENT_DIR runtime paths", () => {
 		oldAgentDir = process.env.PI_CODING_AGENT_DIR;
 		oldHome = process.env.HOME;
 		oldUserProfile = process.env.USERPROFILE;
+		oldSubagentsConfigDirName = process.env.PI_SUBAGENTS_CONFIG_DIR_NAME;
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-coding-agent-dir-"));
 		tempHome = path.join(tempDir, "home");
 		agentDir = path.join(tempDir, "agent");
@@ -57,6 +59,8 @@ describe("PI_CODING_AGENT_DIR runtime paths", () => {
 		else process.env.HOME = oldHome;
 		if (oldUserProfile === undefined) delete process.env.USERPROFILE;
 		else process.env.USERPROFILE = oldUserProfile;
+		if (oldSubagentsConfigDirName === undefined) delete process.env.PI_SUBAGENTS_CONFIG_DIR_NAME;
+		else process.env.PI_SUBAGENTS_CONFIG_DIR_NAME = oldSubagentsConfigDirName;
 		clearSkillCache();
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
@@ -66,6 +70,10 @@ describe("PI_CODING_AGENT_DIR runtime paths", () => {
 		assert.equal(resolveConfigDirName({ CONFIG_DIR_NAME: "" }), ".pi");
 		assert.equal(getConfigDirName(), ".pi");
 		assert.equal(getProjectConfigDir(cwd), path.join(cwd, ".pi"));
+		process.env.PI_SUBAGENTS_CONFIG_DIR_NAME = ".custom-pi";
+		assert.equal(getConfigDirName(), ".custom-pi");
+		assert.equal(getProjectConfigDir(cwd), path.join(cwd, ".custom-pi"));
+		delete process.env.PI_SUBAGENTS_CONFIG_DIR_NAME;
 		assert.equal(getAgentDir(), agentDir);
 
 		process.env.PI_CODING_AGENT_DIR = "~";
@@ -84,6 +92,12 @@ describe("PI_CODING_AGENT_DIR runtime paths", () => {
 		const config = loadConfig();
 		assert.equal(config.asyncByDefault, true);
 		assert.equal(config.maxSubagentDepth, 3);
+	});
+
+	it("does not value-import the host pi package from runner-loaded shared utils", () => {
+		const utilsSource = fs.readFileSync(new URL("../../src/shared/utils.ts", import.meta.url), "utf-8");
+
+		assert.doesNotMatch(utilsSource, /from\s+["']@earendil-works\/pi-coding-agent["']/);
 	});
 
 	it("discovers user agents, chains, and settings under the configured agent dir", () => {

--- a/test/unit/stale-run-reconciler.test.ts
+++ b/test/unit/stale-run-reconciler.test.ts
@@ -71,6 +71,41 @@ describe("async stale-run reconciliation", () => {
 		}
 	});
 
+	it("includes runner stderr diagnostics when repairing a stale startup crash", () => {
+		const root = tempRoot("pi-stale-run-stderr-");
+		try {
+			const asyncDir = path.join(root, "run-dead-stderr");
+			const resultsDir = path.join(root, "results");
+			writeStatus(asyncDir, {
+				runId: "run-dead-stderr",
+				mode: "single",
+				state: "running",
+				pid: 12345,
+				startedAt: 1000,
+				lastUpdate: 1000,
+				currentStep: 0,
+				steps: [{ agent: "scout", status: "running", startedAt: 1000 }],
+			});
+			fs.writeFileSync(path.join(asyncDir, "runner-stderr.log"), "startup failed\nmissing peer package\n", "utf-8");
+
+			const result = reconcileAsyncRun(asyncDir, {
+				resultsDir,
+				kill: () => { throw errno("ESRCH"); },
+				now: () => 2000,
+			});
+
+			assert.equal(result.repaired, true);
+			assert.match(result.message ?? "", /Runner stderr tail:/);
+			assert.match(result.message ?? "", /missing peer package/);
+			const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+			assert.match(status.steps[0].error, /missing peer package/);
+			const resultJson = JSON.parse(fs.readFileSync(path.join(resultsDir, "run-dead-stderr.json"), "utf-8"));
+			assert.match(resultJson.summary, /missing peer package/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps stale repair successful when the event log cannot be appended", () => {
 		const root = tempRoot("pi-stale-event-log-collision-");
 		try {


### PR DESCRIPTION
## Summary

Fixes the async runner startup crash reported in #334 by removing the runner-loaded value import from `@earendil-works/pi-coding-agent` while preserving custom config-dir support.

This PR also makes future async runner startup failures diagnosable by capturing detached runner stdout/stderr and surfacing the stderr tail during stale-run reconciliation.

## What changed

- Avoid value-importing `@earendil-works/pi-coding-agent` from `src/shared/utils.ts`.
- Resolve the config directory name from, in order:
  1. explicit `codingAgentModule` argument,
  2. `PI_SUBAGENTS_CONFIG_DIR_NAME`,
  3. nearest entry-point `package.json` `piConfig.configDir`,
  4. default `.pi`.
- Pass `PI_SUBAGENTS_CONFIG_DIR_NAME` into detached async runners when the parent can derive it from the Pi package root.
- Capture detached runner stdout/stderr to `runner-stdout.log` and `runner-stderr.log` under the async run directory.
- Include a bounded stderr tail in stale-run failures so startup crashes are visible instead of only reporting that the process disappeared.
- Add regression coverage for the no-peer-import path, env propagation, stdio logs, and stale-run diagnostics.

## Validation

- `npm run test:all`
  - unit: 666 passed
  - integration: 420 passed

## Notes

This intentionally does not change completion-guard policy/inference behavior; it is scoped to the async runner peer-import crash and diagnostics path.
