### PR TITLE
Add PI_SUBAGENT_PI_BINARY override for child Pi launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added `/chain` inline parallel groups with per-step metadata, group options, and tab completion.
 - Added subagent profile commands and provider model catalog generation for quota and quality model profiles.
+- Added `PI_SUBAGENT_PI_BINARY` to let wrappers launch child agents through an explicit Pi binary instead of resolving `pi` from `PATH`.
 
 ### Fixed
 - Discover `pi-intercom` installations created by `--extension npm:pi-intercom` under Pi's temporary npm extension cache.

--- a/README.md
+++ b/README.md
@@ -1091,6 +1091,14 @@ Session directory precedence is: `params.sessionDir`, then `config.defaultSessio
 
 Controls nested delegation when no inherited `PI_SUBAGENT_MAX_DEPTH` is already in effect. Per-agent `maxSubagentDepth` can tighten the limit for that agent’s child runs, but cannot relax an inherited stricter limit. This applies even to children that explicitly declare `tools: subagent`; at the cap, execution fanout is blocked instead of silently hiding nested work.
 
+### `PI_SUBAGENT_PI_BINARY`
+
+```bash
+export PI_SUBAGENT_PI_BINARY=/path/to/pi-or-wrapper
+```
+
+Overrides the command used to launch child Pi processes. Package wrappers can set this to their own `pi`/agent binary so subagents inherit wrapper flags, environment setup, and bundled resources without relying on `PATH` ordering. Empty or whitespace-only values are ignored.
+
 ### `intercomBridge`
 
 ```json

--- a/src/runs/shared/pi-spawn.ts
+++ b/src/runs/shared/pi-spawn.ts
@@ -3,13 +3,18 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const PI_CODING_AGENT_PACKAGE = "@earendil-works/pi-coding-agent";
+export const PI_SUBAGENT_PI_BINARY_ENV = "PI_SUBAGENT_PI_BINARY";
 
-export function findPiPackageRootFromEntry(entryPoint: string): string | undefined {
+export function findPiPackageRootFromEntry(
+	entryPoint: string,
+): string | undefined {
 	let dir = path.dirname(entryPoint);
 	while (dir !== path.dirname(dir)) {
 		const packageJsonPath = path.join(dir, "package.json");
 		if (fs.existsSync(packageJsonPath)) {
-			const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as { name?: unknown };
+			const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+				name?: unknown;
+			};
 			if (pkg.name === PI_CODING_AGENT_PACKAGE) return dir;
 		}
 		dir = path.dirname(dir);
@@ -18,13 +23,17 @@ export function findPiPackageRootFromEntry(entryPoint: string): string | undefin
 }
 
 export function resolveInstalledPiPackageRoot(): string | undefined {
-	return findPiPackageRootFromEntry(fileURLToPath(import.meta.resolve(PI_CODING_AGENT_PACKAGE)));
+	return findPiPackageRootFromEntry(
+		fileURLToPath(import.meta.resolve(PI_CODING_AGENT_PACKAGE)),
+	);
 }
 
 export function resolvePiPackageRoot(): string | undefined {
 	try {
 		const entry = process.argv[1];
-		return entry ? findPiPackageRootFromEntry(fs.realpathSync(entry)) : undefined;
+		return entry
+			? findPiPackageRootFromEntry(fs.realpathSync(entry))
+			: undefined;
 	} catch {
 		// process.argv[1] probing is best-effort; callers can fall back to PATH/package resolution.
 		return undefined;
@@ -40,6 +49,7 @@ export interface PiSpawnDeps {
 	resolvePackageJson?: () => string;
 	resolvePackageEntry?: () => string;
 	piPackageRoot?: string;
+	env?: NodeJS.ProcessEnv;
 }
 
 interface PiSpawnCommand {
@@ -47,7 +57,10 @@ interface PiSpawnCommand {
 	args: string[];
 }
 
-function isRunnableNodeScript(filePath: string, existsSync: (filePath: string) => boolean): boolean {
+function isRunnableNodeScript(
+	filePath: string,
+	existsSync: (filePath: string) => boolean,
+): boolean {
 	if (!existsSync(filePath)) return false;
 	return /\.(?:mjs|cjs|js)$/i.test(filePath);
 }
@@ -56,9 +69,13 @@ function normalizePath(filePath: string): string {
 	return path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
 }
 
-export function resolveWindowsPiCliScript(deps: PiSpawnDeps = {}): string | undefined {
+export function resolveWindowsPiCliScript(
+	deps: PiSpawnDeps = {},
+): string | undefined {
 	const existsSync = deps.existsSync ?? fs.existsSync;
-	const readFileSync = deps.readFileSync ?? ((filePath, encoding) => fs.readFileSync(filePath, encoding));
+	const readFileSync =
+		deps.readFileSync ??
+		((filePath, encoding) => fs.readFileSync(filePath, encoding));
 	const argv1 = deps.argv1 ?? process.argv[1];
 
 	if (argv1) {
@@ -69,23 +86,29 @@ export function resolveWindowsPiCliScript(deps: PiSpawnDeps = {}): string | unde
 	}
 
 	try {
-		const resolvePackageJson = deps.resolvePackageJson ?? (() => {
-			const root = deps.piPackageRoot ?? resolvePiPackageRoot();
-			if (root) return path.join(root, "package.json");
-			const packageRoot = deps.resolvePackageEntry
-				? findPiPackageRootFromEntry(deps.resolvePackageEntry())
-				: resolveInstalledPiPackageRoot();
-			if (!packageRoot) throw new Error(`Could not resolve ${PI_CODING_AGENT_PACKAGE} package root`);
-			return path.join(packageRoot, "package.json");
-		});
+		const resolvePackageJson =
+			deps.resolvePackageJson ??
+			(() => {
+				const root = deps.piPackageRoot ?? resolvePiPackageRoot();
+				if (root) return path.join(root, "package.json");
+				const packageRoot = deps.resolvePackageEntry
+					? findPiPackageRootFromEntry(deps.resolvePackageEntry())
+					: resolveInstalledPiPackageRoot();
+				if (!packageRoot)
+					throw new Error(
+						`Could not resolve ${PI_CODING_AGENT_PACKAGE} package root`,
+					);
+				return path.join(packageRoot, "package.json");
+			});
 		const packageJsonPath = resolvePackageJson();
 		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as {
 			bin?: string | Record<string, string>;
 		};
 		const binField = packageJson.bin;
-		const binPath = typeof binField === "string"
-			? binField
-			: binField?.pi ?? Object.values(binField ?? {})[0];
+		const binPath =
+			typeof binField === "string"
+				? binField
+				: (binField?.pi ?? Object.values(binField ?? {})[0]);
 		if (!binPath) return undefined;
 		const candidate = path.resolve(path.dirname(packageJsonPath), binPath);
 		if (isRunnableNodeScript(candidate, existsSync)) {
@@ -99,7 +122,16 @@ export function resolveWindowsPiCliScript(deps: PiSpawnDeps = {}): string | unde
 	return undefined;
 }
 
-export function getPiSpawnCommand(args: string[], deps: PiSpawnDeps = {}): PiSpawnCommand {
+export function getPiSpawnCommand(
+	args: string[],
+	deps: PiSpawnDeps = {},
+): PiSpawnCommand {
+	const env = deps.env ?? process.env;
+	const piBinary = env[PI_SUBAGENT_PI_BINARY_ENV]?.trim();
+	if (piBinary) {
+		return { command: piBinary, args };
+	}
+
 	const platform = deps.platform ?? process.platform;
 	if (platform === "win32") {
 		const piCliPath = resolveWindowsPiCliScript(deps);

--- a/test/unit/pi-spawn.test.ts
+++ b/test/unit/pi-spawn.test.ts
@@ -3,7 +3,11 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { getPiSpawnCommand, resolveWindowsPiCliScript, type PiSpawnDeps } from "../../src/runs/shared/pi-spawn.ts";
+import {
+	getPiSpawnCommand,
+	resolveWindowsPiCliScript,
+	type PiSpawnDeps,
+} from "../../src/runs/shared/pi-spawn.ts";
 
 function makeDeps(input: {
 	platform?: NodeJS.Platform;
@@ -13,6 +17,7 @@ function makeDeps(input: {
 	packageJsonPath?: string;
 	packageJsonContent?: string;
 	packageEntry?: string;
+	env?: NodeJS.ProcessEnv;
 }): PiSpawnDeps {
 	const existing = new Set(input.existing ?? []);
 	const packageJsonPath = input.packageJsonPath;
@@ -29,11 +34,40 @@ function makeDeps(input: {
 			return packageJsonContent;
 		},
 		resolvePackageJson: packageJsonPath ? () => packageJsonPath : undefined,
-		resolvePackageEntry: input.packageEntry ? () => input.packageEntry! : undefined,
+		resolvePackageEntry: input.packageEntry
+			? () => input.packageEntry!
+			: undefined,
+		env: input.env ?? {},
 	};
 }
 
 describe("getPiSpawnCommand", () => {
+	it("honors explicit PI_SUBAGENT_PI_BINARY override on any platform", () => {
+		const args = ["--mode", "json", "Task: check output"];
+		const result = getPiSpawnCommand(args, {
+			platform: "win32",
+			execPath: "/usr/local/bin/node",
+			argv1: "/tmp/pi-entry.mjs",
+			env: {
+				PI_SUBAGENT_PI_BINARY: "/nix/store/pi-wrapper/bin/nhost-code-agent",
+			},
+			existsSync: () => true,
+		});
+		assert.deepEqual(result, {
+			command: "/nix/store/pi-wrapper/bin/nhost-code-agent",
+			args,
+		});
+	});
+
+	it("ignores a blank PI_SUBAGENT_PI_BINARY override", () => {
+		const args = ["--mode", "json", "Task: check output"];
+		const result = getPiSpawnCommand(args, {
+			platform: "darwin",
+			env: { PI_SUBAGENT_PI_BINARY: "   " },
+		});
+		assert.deepEqual(result, { command: "pi", args });
+	});
+
 	it("uses plain pi on non-Windows even when argv1 is a runnable JS file", () => {
 		const argv1 = "/tmp/pi-entry.mjs";
 		const deps = makeDeps({
@@ -49,7 +83,10 @@ describe("getPiSpawnCommand", () => {
 
 	it("uses plain pi on non-Windows even when the CLI script can be resolved from package bin", () => {
 		const packageJsonPath = "/opt/pi/package.json";
-		const cliPath = path.resolve(path.dirname(packageJsonPath), "dist/cli/index.js");
+		const cliPath = path.resolve(
+			path.dirname(packageJsonPath),
+			"dist/cli/index.js",
+		);
 		const deps = makeDeps({
 			platform: "darwin",
 			execPath: "/usr/local/bin/node",
@@ -65,7 +102,7 @@ describe("getPiSpawnCommand", () => {
 
 	it("falls back to plain pi command on non-Windows when CLI script cannot be resolved", () => {
 		const args = ["--mode", "json", "Task: check output"];
-		const result = getPiSpawnCommand(args, { platform: "darwin" });
+		const result = getPiSpawnCommand(args, { platform: "darwin", env: {} });
 		assert.deepEqual(result, { command: "pi", args });
 	});
 
@@ -77,7 +114,11 @@ describe("getPiSpawnCommand", () => {
 			argv1,
 			existing: [argv1],
 		});
-		const args = ["--mode", "json", 'Task: Read C:/dev/file.md and review "quotes" & pipes | too'];
+		const args = [
+			"--mode",
+			"json",
+			'Task: Read C:/dev/file.md and review "quotes" & pipes | too',
+		];
 		const result = getPiSpawnCommand(args, deps);
 		assert.equal(result.command, "/usr/local/bin/node");
 		assert.equal(result.args[0], argv1);
@@ -89,7 +130,10 @@ describe("getPiSpawnCommand", () => {
 		// Compute expected path the same way the production code does:
 		// path.resolve(path.dirname(packageJsonPath), binPath) — which on Windows
 		// prepends the current drive letter to POSIX absolute paths.
-		const cliPath = path.resolve(path.dirname(packageJsonPath), "dist/cli/index.js");
+		const cliPath = path.resolve(
+			path.dirname(packageJsonPath),
+			"dist/cli/index.js",
+		);
 		const deps = makeDeps({
 			platform: "win32",
 			execPath: "/usr/local/bin/node",
@@ -115,21 +159,35 @@ describe("getPiSpawnCommand", () => {
 	});
 
 	it("walks from package main entry to resolve package bin", () => {
-		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-spawn-package-root-"));
+		const tempDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-spawn-package-root-"),
+		);
 		try {
-			const packageRoot = path.join(tempDir, "node_modules", "@earendil-works", "pi-coding-agent");
+			const packageRoot = path.join(
+				tempDir,
+				"node_modules",
+				"@earendil-works",
+				"pi-coding-agent",
+			);
 			const entry = path.join(packageRoot, "dist", "index.js");
 			const cliPath = path.join(packageRoot, "dist", "cli", "index.js");
 			fs.mkdirSync(path.dirname(entry), { recursive: true });
 			fs.mkdirSync(path.dirname(cliPath), { recursive: true });
 			fs.writeFileSync(entry, "export {};\n");
 			fs.writeFileSync(cliPath, "#!/usr/bin/env node\n");
-			fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: { pi: "dist/cli/index.js" } }));
+			fs.writeFileSync(
+				path.join(packageRoot, "package.json"),
+				JSON.stringify({
+					name: "@earendil-works/pi-coding-agent",
+					bin: { pi: "dist/cli/index.js" },
+				}),
+			);
 			const result = getPiSpawnCommand(["-p", "Task: hello"], {
 				platform: "win32",
 				execPath: "/usr/local/bin/node",
 				argv1: "/opt/pi/subagent-runner.ts",
 				resolvePackageEntry: () => entry,
+				env: {},
 			});
 			assert.equal(result.command, "/usr/local/bin/node");
 			assert.equal(result.args[0], cliPath);
@@ -137,13 +195,15 @@ describe("getPiSpawnCommand", () => {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
-
 });
 
 describe("getPiSpawnCommand with piPackageRoot", () => {
 	it("resolves CLI script via piPackageRoot when argv1 is not runnable", () => {
 		const packageJsonPath = "/opt/pi/package.json";
-		const cliPath = path.resolve(path.dirname(packageJsonPath), "dist/cli/index.js");
+		const cliPath = path.resolve(
+			path.dirname(packageJsonPath),
+			"dist/cli/index.js",
+		);
 		const deps = makeDeps({
 			platform: "win32",
 			execPath: "/usr/local/bin/node",
@@ -162,7 +222,10 @@ describe("getPiSpawnCommand with piPackageRoot", () => {
 describe("resolveWindowsPiCliScript", () => {
 	it("supports package bin as string", () => {
 		const packageJsonPath = "/opt/pi/package.json";
-		const cliPath = path.resolve(path.dirname(packageJsonPath), "dist/cli/index.mjs");
+		const cliPath = path.resolve(
+			path.dirname(packageJsonPath),
+			"dist/cli/index.mjs",
+		);
 		const deps = makeDeps({
 			platform: "win32",
 			argv1: "/opt/pi/subagent-runner.ts",


### PR DESCRIPTION
## Summary

- Add `PI_SUBAGENT_PI_BINARY` support to `getPiSpawnCommand`
- Use the override to launch child Pi processes through an explicit wrapper/binary
- Document the new env var and add changelog entry
- Add regression coverage for override and blank-value fallback behavior

## Why

Packaged wrappers like need child subagents to launch through the same wrapper so they inherit bundled resources, flags, and environment setup without relying on fragile `PATH` ordering.

## Testing

- `node --experimental-strip-types --test test/unit/pi-spawn.test.ts`
- `env -u PI_SUBAGENT_PI_BINARY -u PI_CODING_AGENT_DIR -u PI_INTERCOM_EXTENSION_DIR npm run test:unit`