### PR TITLE
fix(async): fall back from stale node exec path

### DIFF
--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -207,9 +207,22 @@ export function isAsyncAvailable(): boolean {
 	return jitiCliPath !== undefined;
 }
 
+function isNodeExecutableName(execPath: string): boolean {
+	const basename = path.basename(execPath).toLowerCase();
+	return basename === "node" || basename === "node.exe" || basename === "nodejs" || basename === "nodejs.exe";
+}
+
+function canUseCurrentNodeExecutable(execPath: string): boolean {
+	try {
+		fs.accessSync(execPath, process.platform === "win32" ? fs.constants.F_OK : fs.constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function resolveAsyncRunnerNodeCommand(): string {
-	const basename = path.basename(process.execPath).toLowerCase();
-	if (basename === "node" || basename === "node.exe" || basename === "nodejs" || basename === "nodejs.exe") {
+	if (isNodeExecutableName(process.execPath) && canUseCurrentNodeExecutable(process.execPath)) {
 		return process.execPath;
 	}
 	return process.platform === "win32" ? "node.exe" : "node";

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -265,6 +265,40 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		}
 	});
 
+	it("falls back to PATH node when node-like process.execPath is stale", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const originalExecPath = process.execPath;
+		process.execPath = path.join(tempDir, "deleted-node-install", "bin", process.platform === "win32" ? "node.exe" : "node");
+		try {
+			mockPi.onCall({ output: "stale node exec async done" });
+			const id = `async-stale-node-exec-${Date.now().toString(36)}`;
+			const result = executeAsyncSingle(id, {
+				agent: "worker",
+				task: "Say stale node exec async done. Do not edit files.",
+				agentConfig: makeAgent("worker"),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: {
+					enabled: false,
+					includeInput: false,
+					includeOutput: false,
+					includeJsonl: false,
+					includeMetadata: false,
+					cleanupDays: 7,
+				},
+				shareEnabled: false,
+				sessionRoot: path.join(tempDir, "sessions"),
+				maxSubagentDepth: 2,
+			});
+
+			assert.equal(result.isError, undefined);
+			const resultPath = await waitForAsyncResultFile(id, 10_000);
+			const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+			assert.equal(payload.success, true);
+			assert.equal(payload.results[0]?.output, "stale node exec async done");
+		} finally {
+			process.execPath = originalExecPath;
+		}
+	});
+
 	it("readStatus returns null for missing directory", () => {
 		const status = readStatus("/nonexistent/path/abc123");
 		assert.equal(status, null);
@@ -1742,7 +1776,10 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 
 	it("returns a tool error when the async runner process cannot spawn", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
 		const originalExecPath = process.execPath;
-		process.execPath = path.join(tempDir, process.platform === "win32" ? "node.exe" : "node");
+		const pathKey = process.platform === "win32" ? "Path" : "PATH";
+		const originalPath = process.env[pathKey];
+		process.execPath = path.join(tempDir, process.platform === "win32" ? "pi.exe" : "pi");
+		process.env[pathKey] = tempDir;
 		try {
 			const id = `async-spawn-fail-${Date.now().toString(36)}`;
 			const result = executeAsyncSingle(id, {
@@ -1768,6 +1805,11 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			assert.match(result.content[0]?.text ?? "", /async runner did not produce a pid/);
 		} finally {
 			process.execPath = originalExecPath;
+			if (originalPath === undefined) {
+				delete process.env[pathKey];
+			} else {
+				process.env[pathKey] = originalPath;
+			}
 		}
 	});
 


### PR DESCRIPTION
## Summary

- Reuse `process.execPath` for the async runner only when it is node-like and accessible.
- Fall back to `node` / `node.exe` from PATH when the current Node executable is stale or deleted.
- Add regression coverage for a node-like `process.execPath` that no longer exists.

## Why

Long-running Pi sessions can survive a mise/Node upgrade where the original Node binary is deleted. In that state, `process.execPath` still looks like Node by basename, but spawning it fails before the async runner gets a PID.

This happened locally and was fixed by falling back to PATH `node` when the node-like `process.execPath` is no longer usable.

## Validation

- Tested locally in the failing Pi environment; async subagent startup works after this patch.
- `npm run test:integration -- --test-name-pattern='process.execPath|stale|cannot spawn' test/integration/async-execution.test.ts`
- `npm run test:unit`
- Reviewer subagent also ran `npm run test:integration -- test/integration/async-execution.test.ts` successfully: 420 passed, 0 failed.

## Notes

This intentionally preserves the existing behavior from #273:
- Node-like and accessible `process.execPath` is reused.
- Non-Node or stale/deleted `process.execPath` falls back to PATH `node` / `node.exe`.