### PR TITLE
fix: avoid runtime peer import in async runner

### DIFF
--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -16,7 +16,7 @@ import { buildChainInstructions, isDynamicParallelStep, isParallelStep, resolveS
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../../agents/skills.ts";
-import { resolveChildCwd } from "../../shared/utils.ts";
+import { PI_CODING_AGENT_PACKAGE_ROOT_ENV, resolveChildCwd } from "../../shared/utils.ts";
 import { buildModelCandidates, resolveModelCandidate, resolveSubagentModelOverride, type AvailableModelInfo, type ParentModel } from "../shared/model-fallback.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { resolveExpectedWorktreeAgentCwd } from "../shared/worktree.ts";
@@ -243,6 +243,10 @@ function spawnRunner(cfg: object, suffix: string, cwd: string): { pid?: number; 
 		detached: true,
 		stdio: "ignore",
 		windowsHide: true,
+		env: {
+			...process.env,
+			...(piPackageRoot ? { [PI_CODING_AGENT_PACKAGE_ROOT_ENV]: piPackageRoot } : {}),
+		},
 	});
 	proc.on("error", (error) => {
 		console.error(`[pi-subagents] async spawn failed: ${error.message}`);

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -5,7 +5,6 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import * as piCodingAgent from "@earendil-works/pi-coding-agent";
 import type { Message } from "@earendil-works/pi-ai";
 import { formatToolCall } from "./formatters.ts";
 import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, SingleResult, ToolCallSummary } from "./types.ts";
@@ -15,12 +14,51 @@ import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, Singl
 // ============================================================================
 
 const DEFAULT_CONFIG_DIR_NAME = ".pi";
+const PI_CODING_AGENT_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
+export const PI_CODING_AGENT_PACKAGE_ROOT_ENV = "PI_SUBAGENTS_PI_CODING_AGENT_PACKAGE_ROOT";
 
-export function resolveConfigDirName(codingAgentModule: unknown = piCodingAgent): string {
-	const value = codingAgentModule && typeof codingAgentModule === "object"
-		? (codingAgentModule as { CONFIG_DIR_NAME?: unknown }).CONFIG_DIR_NAME
+function validConfigDirName(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function readConfigDirNameFromPackageRoot(packageRoot: string | undefined): string | undefined {
+	if (!packageRoot) return undefined;
+	try {
+		const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf-8")) as {
+			name?: unknown;
+			piConfig?: { configDir?: unknown };
+		};
+		if (pkg.name !== PI_CODING_AGENT_PACKAGE_NAME) return undefined;
+		return validConfigDirName(pkg.piConfig?.configDir);
+	} catch {
+		return undefined;
+	}
+}
+
+function resolveConfigDirNameFromPackageJson(entryPoint = process.argv[1], packageRoot = process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV]): string | undefined {
+	const packageRootValue = readConfigDirNameFromPackageRoot(packageRoot);
+	if (packageRootValue) return packageRootValue;
+	if (!entryPoint) return undefined;
+	try {
+		let dir = path.dirname(fs.realpathSync(entryPoint));
+		while (dir !== path.dirname(dir)) {
+			const value = readConfigDirNameFromPackageRoot(dir);
+			if (value) return value;
+			dir = path.dirname(dir);
+		}
+	} catch {
+		// Package metadata lookup is best-effort; detached runners must not fail here.
+	}
+	return undefined;
+}
+
+export function resolveConfigDirName(codingAgentModule?: unknown, entryPoint?: string, packageRoot?: string): string {
+	const moduleValue = codingAgentModule && typeof codingAgentModule === "object"
+		? validConfigDirName((codingAgentModule as { CONFIG_DIR_NAME?: unknown }).CONFIG_DIR_NAME)
 		: undefined;
-	return typeof value === "string" && value.trim() ? value : DEFAULT_CONFIG_DIR_NAME;
+	return moduleValue
+		?? resolveConfigDirNameFromPackageJson(entryPoint, packageRoot)
+		?? DEFAULT_CONFIG_DIR_NAME;
 }
 
 export function getConfigDirName(): string {

--- a/test/unit/config-dir-runtime.test.ts
+++ b/test/unit/config-dir-runtime.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { getConfigDirName, resolveConfigDirName } from "../../src/shared/utils.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+describe("config directory resolution", () => {
+	it("falls back without importing the Pi peer package at runtime", () => {
+		assert.equal(resolveConfigDirName(), ".pi");
+		assert.equal(getConfigDirName(), ".pi");
+	});
+
+	it("honors an explicitly provided Pi module shape", () => {
+		assert.equal(resolveConfigDirName({ CONFIG_DIR_NAME: ".custom-pi" }), ".custom-pi");
+		assert.equal(resolveConfigDirName({ CONFIG_DIR_NAME: "" }), ".pi");
+	});
+
+	it("honors Pi package metadata without importing the peer package", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-config-dir-"));
+		try {
+			const packageRoot = path.join(tempDir, "coding-agent");
+			const distDir = path.join(packageRoot, "dist");
+			fs.mkdirSync(distDir, { recursive: true });
+			const cliPath = path.join(distDir, "cli.js");
+			fs.writeFileSync(cliPath, "", "utf-8");
+			fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({
+				name: "@earendil-works/pi-coding-agent",
+				piConfig: { configDir: ".custom-pi" },
+			}), "utf-8");
+
+			assert.equal(resolveConfigDirName(undefined, cliPath), ".custom-pi");
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("uses an explicit Pi package root before the process entrypoint walk", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-config-root-"));
+		try {
+			const packageRoot = path.join(tempDir, "coding-agent-root");
+			fs.mkdirSync(packageRoot, { recursive: true });
+			fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({
+				name: "@earendil-works/pi-coding-agent",
+				piConfig: { configDir: ".root-pi" },
+			}), "utf-8");
+
+			assert.equal(resolveConfigDirName(undefined, undefined, packageRoot), ".root-pi");
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not runtime-import the coding agent peer from shared utils", () => {
+		const source = fs.readFileSync(path.join(repoRoot, "src/shared/utils.ts"), "utf-8");
+		assert.doesNotMatch(source, /import\s+[^;]*from\s+["']@earendil-works\/pi-coding-agent["']/);
+	});
+});


### PR DESCRIPTION
## Summary

- Remove the runtime value import of `@earendil-works/pi-coding-agent` from shared utilities used by the detached async runner.
- Preserve configurable Pi config directory resolution by reading `piConfig.configDir` from Pi package metadata instead of importing the peer package.
- Pass the resolved Pi package root into detached async runner processes via env so hoisted `jiti` launches can still find package metadata.
- Add unit coverage for fallback, explicit module shape, package metadata, explicit package root, and no runtime peer import.

## Why

Detached async runner processes start outside Pi's extension-loader module context. If `pi-subagents` does not have the Pi package peer resolvable from its own install, a top-level runtime import of `@earendil-works/pi-coding-agent` can crash the runner before it writes status/result files. The parent then reports only a stale-run failure.

## Test plan

- [x] `node --experimental-strip-types --test test/unit/config-dir-runtime.test.ts test/unit/pi-args.test.ts test/unit/pi-coding-agent-dir.test.ts test/unit/package-manifest.test.ts`
- [x] Ran full `npm run test:unit`; unrelated baseline failures observed:
  - `test/unit/agent-frontmatter.test.ts` invalid package normalization expectation
  - two `test/unit/worktree.test.ts` failures due local 1Password git signing (`failed to write commit object`)

Fixes #353
