### PR TITLE
fix: remove @earendil-works/pi-coding-agent import from utils.ts (async runner crash)

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -5,7 +5,6 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import * as piCodingAgent from "@earendil-works/pi-coding-agent";
 import type { Message } from "@earendil-works/pi-ai";
 import { formatToolCall } from "./formatters.ts";
 import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, SingleResult, ToolCallSummary } from "./types.ts";
@@ -16,7 +15,7 @@ import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, Singl
 
 const DEFAULT_CONFIG_DIR_NAME = ".pi";
 
-export function resolveConfigDirName(codingAgentModule: unknown = piCodingAgent): string {
+export function resolveConfigDirName(codingAgentModule?: unknown): string {
 	const value = codingAgentModule && typeof codingAgentModule === "object"
 		? (codingAgentModule as { CONFIG_DIR_NAME?: unknown }).CONFIG_DIR_NAME
 		: undefined;


### PR DESCRIPTION
## Problem

Every async subagent crashes immediately at module load time. The spawned runner process exits in ~1 second, and the stale-run reconciler eventually marks the run as failed:

```
subagent.run.repaired_stale: Async runner process {pid} exited or disappeared
before writing a result. Marked run failed by stale-run reconciliation.
```

## Root Cause

The async runner (`subagent-runner.ts`) spawns as a bare `node jiti subagent-runner.ts` process. `utils.ts` imports `@earendil-works/pi-coding-agent` at the module level via:

```typescript
import * as piCodingAgent from "@earendil-works/pi-coding-agent";
```

This package is installed globally alongside the `pi` CLI binary, outside the spawned process's module resolution path. jiti cannot resolve it, so the runner crashes before executing any code.

The runner never calls `resolveConfigDirName()` — the only function that uses this import — so the dependency is dead weight on the runner path.

## Fix

Remove the import and make the `codingAgentModule` parameter optional. The function already falls back to `DEFAULT_CONFIG_DIR_NAME = ".pi"` — the same value as `piCodingAgent.CONFIG_DIR_NAME`.

**Change:** 2 lines removed, 1 line modified. No behavioral change for any caller.

## Testing

- Verified the runner starts cleanly with exit 0 (no pi-coding-agent available in resolution path)
- Verified live async subagent completes successfully after the fix