### PR TITLE
fix: capture async runner stdio logs

### DIFF
--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -215,6 +215,26 @@ function resolveAsyncRunnerNodeCommand(): string {
 	return process.platform === "win32" ? "node.exe" : "node";
 }
 
+export function resolveAsyncRunnerLogPaths(cfg: object): { stdoutPath: string; stderrPath: string } | undefined {
+	const asyncDir = typeof (cfg as { asyncDir?: unknown }).asyncDir === "string"
+		? (cfg as { asyncDir: string }).asyncDir
+		: undefined;
+	if (!asyncDir) return undefined;
+	return {
+		stdoutPath: path.join(asyncDir, "runner.stdout.log"),
+		stderrPath: path.join(asyncDir, "runner.stderr.log"),
+	};
+}
+
+function closeFd(fd: number | undefined): void {
+	if (fd === undefined) return;
+	try {
+		fs.closeSync(fd);
+	} catch {
+		// Best-effort cleanup; child process already owns its duplicated stdio fd.
+	}
+}
+
 /**
  * Spawn the async runner process
  */
@@ -238,20 +258,36 @@ function spawnRunner(cfg: object, suffix: string, cwd: string): { pid?: number; 
 	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
 	const nodeCommand = resolveAsyncRunnerNodeCommand();
 
-	const proc = spawn(nodeCommand, [jitiCliPath, runner, cfgPath], {
-		cwd,
-		detached: true,
-		stdio: "ignore",
-		windowsHide: true,
-	});
-	proc.on("error", (error) => {
-		console.error(`[pi-subagents] async spawn failed: ${error.message}`);
-	});
-	if (typeof proc.pid !== "number") {
-		return { error: `async runner did not produce a pid for cwd: ${cwd}` };
+	const logPaths = resolveAsyncRunnerLogPaths(cfg);
+	let stdoutFd: number | undefined;
+	let stderrFd: number | undefined;
+	try {
+		if (logPaths) {
+			fs.mkdirSync(path.dirname(logPaths.stdoutPath), { recursive: true });
+			stdoutFd = fs.openSync(logPaths.stdoutPath, "a");
+			stderrFd = fs.openSync(logPaths.stderrPath, "a");
+		}
+		const proc = spawn(nodeCommand, [jitiCliPath, runner, cfgPath], {
+			cwd,
+			detached: true,
+			stdio: ["ignore", stdoutFd ?? "ignore", stderrFd ?? "ignore"],
+			windowsHide: true,
+		});
+		closeFd(stdoutFd);
+		closeFd(stderrFd);
+		proc.on("error", (error) => {
+			console.error(`[pi-subagents] async spawn failed: ${error.message}`);
+		});
+		if (typeof proc.pid !== "number") {
+			return { error: `async runner did not produce a pid for cwd: ${cwd}` };
+		}
+		proc.unref();
+		return { pid: proc.pid };
+	} catch (error) {
+		closeFd(stdoutFd);
+		closeFd(stderrFd);
+		return { error: error instanceof Error ? error.message : String(error) };
 	}
-	proc.unref();
-	return { pid: proc.pid };
 }
 
 function formatAsyncStartError(mode: SubagentRunMode, message: string): AsyncExecutionResult {

--- a/test/unit/async-execution.test.ts
+++ b/test/unit/async-execution.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { resolveAsyncRunnerLogPaths } from "../../src/runs/background/async-execution.ts";
+
+describe("async runner execution", () => {
+	it("places detached runner stdio logs in the async run directory", () => {
+		const asyncDir = path.join("tmp", "async-run");
+		assert.deepEqual(resolveAsyncRunnerLogPaths({ asyncDir }), {
+			stdoutPath: path.join(asyncDir, "runner.stdout.log"),
+			stderrPath: path.join(asyncDir, "runner.stderr.log"),
+		});
+	});
+
+	it("omits runner log paths when asyncDir is unavailable", () => {
+		assert.equal(resolveAsyncRunnerLogPaths({}), undefined);
+	});
+});


### PR DESCRIPTION
## Summary

- Capture detached async runner stdout/stderr into each async run directory.
- Add `runner.stdout.log` and `runner.stderr.log` path resolution coverage.
- Preserve detached/unref behavior while closing parent-side log fds after spawn.

## Why

When the async runner crashes before writing a result, stale-run reconciliation currently reports only that the process disappeared. Capturing runner stdio makes startup failures diagnosable from the run directory instead of losing the underlying error.

This complements #352 / #334 / #353: even after the peer-import root cause is fixed, future runner bootstrap failures should leave logs.

Fixes #357.

## Test plan

- [x] `node --experimental-strip-types --test test/unit/async-execution.test.ts test/unit/stale-run-reconciler.test.ts`
- [x] `git diff --check`
- [x] Attempted full unit suite with `node --experimental-strip-types --test test/unit/*.test.ts`; it still has unrelated baseline failures in `test/unit/slash-chain-groups.test.ts` reporting `Unknown agent: scout`.
