### PR TITLE
Recommend companion packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Added configurable companion package recommendations for `pi-intercom` and `pi-prompt-template-model`, surfaced in session-start transcript messages, `subagent({ action: "list" })`, and `/subagents-doctor`, with `/subagents-companions` hide/show/status controls.
+
 ## [0.31.1] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Add `autofix` to `/parallel-review` or `/parallel-cleanup` to apply only the syn
 pi install npm:pi-intercom
 ```
 
+When `pi-intercom` is not active, `pi-subagents` may recommend it at session start, in `subagent({ action: "list" })`, and in `/subagents-doctor`. The recommendation is visible to the assistant so it can offer to run the install command or hide the recommendation after you approve that action.
+
 Most users do not call `intercom` directly. After `pi-intercom` is installed, `pi-subagents` can automatically give child agents a private coordination channel back to the parent session. The bridge recognizes the normal `pi install npm:pi-intercom` package install as well as legacy local extension checkouts.
 
 Use it for work where the child might need a decision instead of guessing:
@@ -1113,6 +1115,28 @@ Bridge activation also requires `pi-intercom` to be installed and enabled throug
 
 The default injected guidance tells children to use `contact_supervisor` with `reason: "need_decision"` when blocked or needing a decision, `reason: "progress_update"` only for meaningful blocked/progress updates, generic `intercom` as fallback plumbing, and avoid routine completion handoffs.
 
+### `companionSuggestions`
+
+```json
+{
+  "companionSuggestions": {
+    "enabled": true,
+    "packages": {
+      "pi-intercom": {
+        "surfaces": ["session_start", "list", "doctor"]
+      },
+      "pi-prompt-template-model": {
+        "surfaces": ["session_start", "list", "doctor"]
+      }
+    }
+  }
+}
+```
+
+Controls recommendations for optional companion packages. `pi-intercom` enables live supervisor decisions, progress updates, and grouped result delivery. `pi-prompt-template-model` makes subagent workflows reusable as prompt templates with model/thinking/skill/subagent frontmatter.
+
+Use `/subagents-companions status` to inspect recommendation status. Use `/subagents-companions hide pi-intercom workspace` or `/subagents-companions hide pi-prompt-template-model user` to hide a recommendation. Use `/subagents-companions show <package>` to show a workspace recommendation again. Set `companionSuggestions` to `false` to disable all companion recommendations.
+
 ### `worktreeSetupHook`
 
 ```json
@@ -1268,6 +1292,8 @@ Use url in the prompt to take screenshot: $@
 Then `/take-screenshot https://example.com` switches to Sonnet, delegates to `browser-screenshoter` with `/tmp/screenshots` as cwd, and restores your model when done. Runtime overrides like `--cwd=<path>` and `--subagent=<name>` work too.
 
 For more reusable workflows on top of subagents, including `/chain-prompts` and compare-style prompts such as `/best-of-n`, install `pi-prompt-template-model` separately and copy the examples you want into `~/.pi/agent/prompts/`.
+
+When `pi-prompt-template-model` is not active, `pi-subagents` may recommend it at session start, in `subagent({ action: "list" })`, and in `/subagents-doctor`. The recommendation is only a prompt; package installation still requires an explicit user-approved command.
 
 ## Runtime files
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -632,6 +632,11 @@ If `pi-prompt-template-model` is installed, additional user prompt templates can
 `pi-subagents`. This is useful when a slash command should always run through a
 particular agent or with forked context.
 
+If `subagent({ action: "list" })`, `/subagents-doctor`, or a startup message recommends
+`pi-intercom` or `pi-prompt-template-model`, offer to run the shown `pi install npm:<package>`
+command only after user approval. To hide future recommendations, use
+`/subagents-companions hide <package> workspace` or `... user`.
+
 ## Important Constraints
 
 - **Forking requires a persisted parent session.** If the current session does not

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -31,7 +31,7 @@ import { getProjectConfigDir } from "../shared/utils.ts";
 
 type ManagementAction = "list" | "get" | "models" | "create" | "update" | "delete";
 type ManagementScope = "user" | "project";
-type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry"> & { model?: ExtensionContext["model"]; config?: ExtensionConfig };
+type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry"> & { model?: ExtensionContext["model"]; config?: ExtensionConfig; companionSuggestionLines?: () => string[] };
 
 interface ManagementParams {
 	action?: string;
@@ -549,6 +549,7 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 		config: ctx.config?.proactiveSkillSubagents,
 		discoverAvailableSkills: () => discoverAvailableSkills(ctx.cwd),
 	});
+	const companionSuggestions = ctx.companionSuggestionLines?.() ?? [];
 	const lines = [
 		"Executable agents:",
 		...(agents.length
@@ -558,6 +559,7 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 		"Chains:",
 		...(chains.length ? chains.map((c) => `- ${c.name} (${c.source}): ${c.description}`) : ["- (none)"]),
 		...(proactiveSuggestions.length ? ["", ...proactiveSuggestions] : []),
+		...(companionSuggestions.length ? ["", ...companionSuggestions] : []),
 		...(diagnostics.length ? ["", "Chain diagnostics:", ...diagnostics.map((entry) => `- ${entry.filePath}: ${entry.error}`)] : []),
 	];
 	return result(lines.join("\n"));

--- a/src/extension/companion-suggestions.ts
+++ b/src/extension/companion-suggestions.ts
@@ -1,0 +1,357 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { diagnoseIntercomBridge, type IntercomBridgeDiagnostic, resolveIntercomSessionTarget } from "../intercom/intercom-bridge.ts";
+import type { CompanionSuggestionPackage, CompanionSuggestionSurface, ExtensionConfig, SubagentState } from "../shared/types.ts";
+import { getAgentDir } from "../shared/utils.ts";
+import { updateConfig } from "./config.ts";
+
+const PROMPT_TEMPLATE_MODEL: CompanionSuggestionPackage = "pi-prompt-template-model";
+const PI_INTERCOM: CompanionSuggestionPackage = "pi-intercom";
+const COMPANION_PACKAGES = [PI_INTERCOM, PROMPT_TEMPLATE_MODEL] as const;
+const DEFAULT_SURFACES: CompanionSuggestionSurface[] = ["session_start", "list", "doctor"];
+
+interface SourceInfoLike {
+	path?: unknown;
+	source?: unknown;
+	baseDir?: unknown;
+}
+
+interface NamedRuntimeResource {
+	name?: unknown;
+	sourceInfo?: unknown;
+}
+
+interface IntercomConfigStatus {
+	enabled: boolean;
+	error?: string;
+}
+
+export interface CompanionPackageStatus {
+	packageName: CompanionSuggestionPackage;
+	active: boolean;
+	disabled: boolean;
+	dismissed: boolean;
+	surfaces: Set<CompanionSuggestionSurface>;
+	installCommand: string;
+	benefit: string;
+	statusSource: string;
+	reason: string;
+	details?: string[];
+	intercomBridge?: IntercomBridgeDiagnostic;
+}
+
+interface CollectCompanionStatusesInput {
+	pi: Pick<ExtensionAPI, "getAllTools" | "getCommands">;
+	config: ExtensionConfig;
+	cwd: string;
+	context?: "fresh" | "fork";
+	orchestratorTarget?: string;
+	workspaceKey?: string;
+	fast?: boolean;
+}
+
+interface CompanionMessageInput {
+	pi: Pick<ExtensionAPI, "sendMessage">;
+	ctx: ExtensionContext;
+	state: SubagentState;
+	statuses: CompanionPackageStatus[];
+}
+
+function commandBaseName(name: string): string {
+	return name.replace(/:\d+$/, "");
+}
+
+function sourceValueMatchesPackage(value: string, packageName: CompanionSuggestionPackage): boolean {
+	const normalized = value.replaceAll("\\", "/").toLowerCase();
+	const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return new RegExp(`(^|[/:@])${escaped}($|[/:@])`).test(normalized);
+}
+
+function sourceInfoMatchesPackage(sourceInfo: unknown, packageName: CompanionSuggestionPackage): boolean {
+	if (!sourceInfo || typeof sourceInfo !== "object" || Array.isArray(sourceInfo)) return false;
+	const info = sourceInfo as SourceInfoLike;
+	return [info.path, info.source, info.baseDir]
+		.some((value) => typeof value === "string" && sourceValueMatchesPackage(value, packageName));
+}
+
+function namedResourcesFrom(value: unknown): NamedRuntimeResource[] {
+	return Array.isArray(value) ? value.filter((entry): entry is NamedRuntimeResource => Boolean(entry) && typeof entry === "object" && !Array.isArray(entry)) : [];
+}
+
+function hasPackageCommand(pi: Pick<ExtensionAPI, "getCommands">, packageName: CompanionSuggestionPackage, commandName: string): boolean {
+	return namedResourcesFrom(pi.getCommands()).some((command) =>
+		typeof command.name === "string"
+		&& commandBaseName(command.name) === commandName
+		&& sourceInfoMatchesPackage(command.sourceInfo, packageName)
+	);
+}
+
+function hasPackageTool(pi: Pick<ExtensionAPI, "getAllTools">, packageName: CompanionSuggestionPackage, toolName: string): boolean {
+	return namedResourcesFrom(pi.getAllTools()).some((tool) =>
+		typeof tool.name === "string"
+		&& commandBaseName(tool.name) === toolName
+		&& sourceInfoMatchesPackage(tool.sourceInfo, packageName)
+	);
+}
+
+function nearestGitRoot(cwd: string): string | undefined {
+	let current = path.resolve(cwd);
+	while (true) {
+		if (fs.existsSync(path.join(current, ".git"))) return current;
+		const parent = path.dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+}
+
+export function companionWorkspaceKey(cwd: string): string {
+	return nearestGitRoot(cwd) ?? path.resolve(cwd);
+}
+
+function normalizeSurface(value: unknown): CompanionSuggestionSurface | undefined {
+	return value === "session_start" || value === "list" || value === "doctor" ? value : undefined;
+}
+
+function packageConfig(config: ExtensionConfig, packageName: CompanionSuggestionPackage) {
+	const companionConfig = config.companionSuggestions;
+	if (companionConfig === false) return { enabled: false, surfaces: new Set<CompanionSuggestionSurface>(), dismissed: false };
+	const packageSpecific = companionConfig?.packages?.[packageName];
+	const surfaces = Array.isArray(packageSpecific?.surfaces)
+		? packageSpecific.surfaces.map(normalizeSurface).filter((surface): surface is CompanionSuggestionSurface => Boolean(surface))
+		: DEFAULT_SURFACES;
+	return {
+		enabled: companionConfig?.enabled !== false && packageSpecific?.enabled !== false,
+		surfaces: new Set(surfaces.length > 0 ? surfaces : DEFAULT_SURFACES),
+		dismissedConfig: packageSpecific?.dismissed,
+	};
+}
+
+function isDismissed(config: ExtensionConfig, packageName: CompanionSuggestionPackage, workspaceKey: string): boolean {
+	const dismissed = packageConfig(config, packageName).dismissedConfig;
+	return dismissed?.user === true || dismissed?.workspaces?.includes(workspaceKey) === true;
+}
+
+function readPiIntercomConfigStatus(agentDir = getAgentDir()): IntercomConfigStatus {
+	const configPath = path.join(agentDir, "intercom", "config.json");
+	if (!fs.existsSync(configPath)) return { enabled: true };
+	try {
+		const parsed = JSON.parse(fs.readFileSync(configPath, "utf-8")) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { enabled: true };
+		return { enabled: (parsed as { enabled?: unknown }).enabled !== false };
+	} catch (error) {
+		return { enabled: true, error: error instanceof Error ? `${error.name}: ${error.message}` : String(error) };
+	}
+}
+
+function promptTemplateModelStatus(input: CollectCompanionStatusesInput, workspaceKey: string): CompanionPackageStatus {
+	const config = packageConfig(input.config, PROMPT_TEMPLATE_MODEL);
+	const active = hasPackageCommand(input.pi, PROMPT_TEMPLATE_MODEL, "prompt-tool");
+	return {
+		packageName: PROMPT_TEMPLATE_MODEL,
+		active,
+		disabled: !config.enabled,
+		dismissed: isDismissed(input.config, PROMPT_TEMPLATE_MODEL, workspaceKey),
+		surfaces: config.surfaces,
+		installCommand: "pi install npm:pi-prompt-template-model",
+		benefit: "reusable prompt-template workflows with model/thinking/skill/subagent frontmatter",
+		statusSource: "active runtime command: prompt-tool",
+		reason: active ? "active" : "prompt-tool command from pi-prompt-template-model is not active in this session",
+	};
+}
+
+function piIntercomStatus(input: CollectCompanionStatusesInput, workspaceKey: string): CompanionPackageStatus {
+	const config = packageConfig(input.config, PI_INTERCOM);
+	const parentToolActive = hasPackageTool(input.pi, PI_INTERCOM, "intercom");
+	const intercomConfig = readPiIntercomConfigStatus();
+	const bridge = diagnoseIntercomBridge({
+		config: input.config.intercomBridge,
+		context: input.context,
+		orchestratorTarget: input.orchestratorTarget,
+		cwd: input.cwd,
+		globalNpmRoot: input.fast ? null : undefined,
+	});
+	const active = parentToolActive && intercomConfig.enabled && (!bridge.wantsIntercom || bridge.piIntercomAvailable);
+	const details = [
+		`parent runtime tool: ${parentToolActive ? "active" : "inactive"}`,
+		`bridge: ${bridge.active ? "active" : "inactive"}${bridge.reason ? ` (${bridge.reason})` : ""}`,
+		...(intercomConfig.error ? [`intercom config warning: ${intercomConfig.error}; runtime assumes enabled`] : []),
+	];
+	return {
+		packageName: PI_INTERCOM,
+		active,
+		disabled: !config.enabled,
+		dismissed: isDismissed(input.config, PI_INTERCOM, workspaceKey),
+		surfaces: config.surfaces,
+		installCommand: "pi install npm:pi-intercom",
+		benefit: "live supervisor decisions, progress updates, and grouped result delivery",
+		statusSource: "active runtime intercom tool plus intercom bridge diagnostics",
+		reason: active
+			? "active"
+			: !intercomConfig.enabled
+				? "pi-intercom config is disabled"
+				: parentToolActive
+					? "pi-intercom is active in the parent runtime, but child bridge discovery is not ready"
+					: "intercom tool from pi-intercom is not active in this session",
+		details,
+		intercomBridge: bridge,
+	};
+}
+
+export function collectCompanionStatuses(input: CollectCompanionStatusesInput): CompanionPackageStatus[] {
+	const workspaceKey = input.workspaceKey ?? companionWorkspaceKey(input.cwd);
+	return [
+		piIntercomStatus(input, workspaceKey),
+		promptTemplateModelStatus(input, workspaceKey),
+	];
+}
+
+function shouldRecommend(status: CompanionPackageStatus, surface: CompanionSuggestionSurface): boolean {
+	if (status.disabled || status.dismissed || status.active || !status.surfaces.has(surface)) return false;
+	if (status.packageName === PI_INTERCOM && status.reason === "pi-intercom config is disabled" && surface !== "doctor") return false;
+	if (status.packageName === PI_INTERCOM && status.intercomBridge?.wantsIntercom === false && surface !== "doctor") return false;
+	return true;
+}
+
+export function buildCompanionListLines(statuses: CompanionPackageStatus[]): string[] {
+	const recommended = statuses.filter((status) => shouldRecommend(status, "list"));
+	if (recommended.length === 0) return [];
+	const lines = ["Recommended companions:"];
+	for (const status of recommended) {
+		lines.push(`- ${status.packageName} is not active in this session.`);
+		lines.push(`  Benefit: ${status.benefit}.`);
+		lines.push(`  Run: ${status.installCommand}, then restart Pi or /reload.`);
+		lines.push(`  Hide: /subagents-companions hide ${status.packageName} workspace`);
+	}
+	return lines;
+}
+
+export function buildCompanionDoctorLines(statuses: CompanionPackageStatus[]): string[] {
+	const lines = ["Companion packages"];
+	for (const status of statuses) {
+		const hidden = status.dismissed ? " recommendation hidden by config" : "";
+		const disabled = status.disabled ? " disabled by config" : "";
+		lines.push(`- ${status.packageName}: ${status.active ? "active" : "inactive"}${hidden}${disabled}`);
+		lines.push(`  install: ${status.installCommand}`);
+		lines.push(`  benefit: ${status.benefit}`);
+		lines.push(`  status source: ${status.statusSource}`);
+		lines.push(`  reason: ${status.reason}`);
+		for (const detail of status.details ?? []) lines.push(`  ${detail}`);
+	}
+	return lines;
+}
+
+export function buildCompanionStartupMessage(statuses: CompanionPackageStatus[]): string | null {
+	const recommended = statuses.filter((status) => shouldRecommend(status, "session_start"));
+	if (recommended.length === 0) return null;
+	const lines = [
+		recommended.length === 1
+			? `Recommended: install ${recommended[0]!.packageName} for pi-subagents.`
+			: "Recommended: install companion packages for pi-subagents.",
+		"",
+	];
+	for (const status of recommended) {
+		lines.push(`- ${status.packageName}: ${status.benefit}.`);
+		lines.push(`  Run: ${status.installCommand}`);
+	}
+	lines.push(
+		"",
+		recommended.length === 1 ? "I can help you run that install command." : "I can help you run those install commands.",
+		"",
+		"Or hide a recommendation:",
+	);
+	for (const status of recommended) {
+		lines.push(`  /subagents-companions hide ${status.packageName} workspace`);
+	}
+	return lines.join("\n");
+}
+
+export function maybeSendCompanionStartupMessage(input: CompanionMessageInput): void {
+	if (!input.ctx.hasUI || input.state.companionSuggestionStartupShown) return;
+	const message = buildCompanionStartupMessage(input.statuses);
+	if (!message) return;
+	input.state.companionSuggestionStartupShown = true;
+	input.pi.sendMessage({
+		customType: "subagent_companion_suggestions",
+		content: message,
+		display: true,
+		details: { packages: input.statuses.filter((status) => shouldRecommend(status, "session_start")).map((status) => status.packageName) },
+	});
+}
+
+function parseCompanionPackage(value: string | undefined): CompanionSuggestionPackage | undefined {
+	return COMPANION_PACKAGES.find((packageName) => packageName === value);
+}
+
+function packageDismissedWorkspaces(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+export function updateCompanionDismissal(packageName: CompanionSuggestionPackage, scope: "workspace" | "user" | "show", cwd: string): ExtensionConfig {
+	const workspaceKey = companionWorkspaceKey(cwd);
+	return updateConfig((current) => {
+		const companionSuggestions = current.companionSuggestions && current.companionSuggestions !== false ? current.companionSuggestions : {};
+		const packages = companionSuggestions.packages ?? {};
+		const packageConfig = packages[packageName] ?? {};
+		const dismissed = { ...(packageConfig.dismissed ?? {}) };
+		if (scope === "user") {
+			dismissed.user = true;
+		} else if (scope === "workspace") {
+			dismissed.workspaces = [...new Set([...packageDismissedWorkspaces(dismissed.workspaces), workspaceKey])];
+		} else {
+			delete dismissed.user;
+			dismissed.workspaces = packageDismissedWorkspaces(dismissed.workspaces).filter((entry) => entry !== workspaceKey);
+			if (dismissed.workspaces.length === 0) delete dismissed.workspaces;
+		}
+		return {
+			...current,
+			companionSuggestions: {
+				...companionSuggestions,
+				packages: {
+					...packages,
+					[packageName]: {
+						...packageConfig,
+						...(Object.keys(dismissed).length > 0 ? { dismissed } : { dismissed: undefined }),
+					},
+				},
+			},
+		};
+	});
+}
+
+export function buildCompanionCommandStatus(statuses: CompanionPackageStatus[]): string {
+	return buildCompanionDoctorLines(statuses).join("\n");
+}
+
+export function handleCompanionCommand(args: string, ctx: ExtensionContext, statuses: CompanionPackageStatus[]): { text: string; updatedConfig?: ExtensionConfig; error?: boolean } {
+	const parts = args.trim().split(/\s+/).filter(Boolean);
+	if (parts.length === 0 || parts[0] === "status") {
+		return { text: buildCompanionCommandStatus(statuses) };
+	}
+	if (parts[0] !== "hide" && parts[0] !== "show") {
+		return { text: "Usage: /subagents-companions status | hide <pi-intercom|pi-prompt-template-model> <workspace|user> | show <pi-intercom|pi-prompt-template-model>", error: true };
+	}
+	const packageName = parseCompanionPackage(parts[1]);
+	if (!packageName) {
+		return { text: "Unknown companion package. Use pi-intercom or pi-prompt-template-model.", error: true };
+	}
+	if (parts[0] === "show") {
+		return { text: `Showing ${packageName} recommendations for this workspace again.`, updatedConfig: updateCompanionDismissal(packageName, "show", ctx.cwd) };
+	}
+	const scope = parts[2];
+	if (scope !== "workspace" && scope !== "user") {
+		return { text: "Usage: /subagents-companions hide <pi-intercom|pi-prompt-template-model> <workspace|user>", error: true };
+	}
+	return {
+		text: scope === "user" ? `Hid ${packageName} recommendations for this user.` : `Hid ${packageName} recommendations for this workspace.`,
+		updatedConfig: updateCompanionDismissal(packageName, scope, ctx.cwd),
+	};
+}
+
+export function resolveCompanionOrchestratorTarget(pi: Pick<ExtensionAPI, "getSessionName">, ctx: ExtensionContext): string | undefined {
+	try {
+		return resolveIntercomSessionTarget(pi.getSessionName(), ctx.sessionManager.getSessionId());
+	} catch {
+		return undefined;
+	}
+}

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -3,12 +3,35 @@ import * as path from "node:path";
 import type { ExtensionConfig } from "../shared/types.ts";
 import { getAgentDir } from "../shared/utils.ts";
 
+export function getConfigPath(): string {
+	return path.join(getAgentDir(), "extensions", "subagent", "config.json");
+}
+
+function readConfigForUpdate(configPath = getConfigPath()): ExtensionConfig {
+	if (!fs.existsSync(configPath)) return {};
+	const parsed = JSON.parse(fs.readFileSync(configPath, "utf-8")) as unknown;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(`Subagent config at '${configPath}' must be a JSON object`);
+	}
+	return parsed as ExtensionConfig;
+}
+
+export function saveConfig(config: ExtensionConfig, configPath = getConfigPath()): void {
+	fs.mkdirSync(path.dirname(configPath), { recursive: true });
+	fs.writeFileSync(configPath, `${JSON.stringify(config, null, "\t")}\n`, "utf-8");
+}
+
+export function updateConfig(updater: (config: ExtensionConfig) => ExtensionConfig): ExtensionConfig {
+	const configPath = getConfigPath();
+	const next = updater(readConfigForUpdate(configPath));
+	saveConfig(next, configPath);
+	return next;
+}
+
 export function loadConfig(): ExtensionConfig {
-	const configPath = path.join(getAgentDir(), "extensions", "subagent", "config.json");
+	const configPath = getConfigPath();
 	try {
-		if (fs.existsSync(configPath)) {
-			return JSON.parse(fs.readFileSync(configPath, "utf-8")) as ExtensionConfig;
-		}
+		return readConfigForUpdate(configPath);
 	} catch (error) {
 		console.error(`Failed to load subagent config from '${configPath}':`, error);
 	}

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -39,6 +39,7 @@ interface DoctorReportInput {
 	sessionError?: string;
 	expandTilde?: (value: string) => string;
 	paths?: DoctorPaths;
+	companionPackageLines?: string[];
 	deps?: Partial<DoctorDeps>;
 }
 
@@ -215,6 +216,7 @@ export function buildDoctorReport(input: DoctorReportInput): string {
 			orchestratorTarget: input.orchestratorTarget,
 			cwd: input.cwd,
 		}), input.context).join("\n")).split("\n"),
+		...(input.companionPackageLines?.length ? ["", ...input.companionPackageLines] : []),
 	];
 	return lines.join("\n");
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -37,6 +37,14 @@ import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import { loadConfig } from "./config.ts";
 import {
+	buildCompanionDoctorLines,
+	buildCompanionListLines,
+	collectCompanionStatuses,
+	handleCompanionCommand,
+	maybeSendCompanionStartupMessage,
+	resolveCompanionOrchestratorTarget,
+} from "./companion-suggestions.ts";
+import {
 	type Details,
 	type SubagentState,
 	ASYNC_DIR,
@@ -250,7 +258,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	ensureAccessibleDir(ASYNC_DIR);
 	cleanupOldChainDirs();
 
-	const config = loadConfig();
+	let config = loadConfig();
 	const asyncByDefault = config.asyncByDefault === true;
 	const tempArtifactsDir = getArtifactsDir(null);
 	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
@@ -270,6 +278,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		completionSeen: new Map(),
 		watcher: null,
 		watcherRestartTimer: null,
+		companionSuggestionStartupShown: false,
+		companionSuggestionListShown: false,
 		resultFileCoalescer: {
 			schedule: () => false,
 			clear: () => {},
@@ -301,6 +311,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		state,
 		config,
 		asyncByDefault,
+		companionSuggestionLines: ({ surface, cwd, context, orchestratorTarget }) => {
+			const statuses = collectCompanionStatuses({ pi, config, cwd, context, orchestratorTarget });
+			return surface === "doctor" ? buildCompanionDoctorLines(statuses) : buildCompanionListLines(statuses);
+		},
 		tempArtifactsDir,
 		getSubagentSessionRoot,
 		expandTilde,
@@ -417,6 +431,28 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			return total + count;
 		}, 0);
 	}
+
+	pi.registerCommand("subagents-companions", {
+		description: "Show or hide pi-subagents companion package recommendations",
+		handler: async (args, ctx) => {
+			try {
+				const statuses = collectCompanionStatuses({
+					pi,
+					config,
+					cwd: ctx.cwd,
+					orchestratorTarget: resolveCompanionOrchestratorTarget(pi, ctx),
+				});
+				const result = handleCompanionCommand(args, ctx, statuses);
+				if (result.updatedConfig) config = result.updatedConfig;
+				pi.sendMessage({ content: result.text, display: true });
+				if (result.error && ctx.hasUI) ctx.ui.notify(result.text, "error");
+			} catch (error) {
+				const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+				pi.sendMessage({ content: `Failed to update companion suggestions: ${message}`, display: true });
+				if (ctx.hasUI) ctx.ui.notify(`Failed to update companion suggestions: ${message}`, "error");
+			}
+		},
+	});
 
 	const tool: ToolDefinition<typeof SubagentParams, Details> = {
 		name: "subagent",
@@ -576,6 +612,8 @@ DIAGNOSTICS:
 			}
 		}
 		state.lastUiContext = ctx;
+		state.companionSuggestionStartupShown = false;
+		state.companionSuggestionListShown = false;
 		cleanupSessionArtifacts(ctx);
 		clearPendingForegroundControlNotices(state);
 		resetJobs(ctx);
@@ -585,6 +623,18 @@ DIAGNOSTICS:
 
 	pi.on("session_start", (_event, ctx) => {
 		resetSessionState(ctx);
+		maybeSendCompanionStartupMessage({
+			pi,
+			ctx,
+			state,
+			statuses: collectCompanionStatuses({
+				pi,
+				config,
+				cwd: ctx.cwd,
+				orchestratorTarget: resolveCompanionOrchestratorTarget(pi, ctx),
+				fast: true,
+			}),
+		});
 	});
 
 	pi.on("session_shutdown", () => {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -154,6 +154,7 @@ interface ExecutorDeps {
 	state: SubagentState;
 	config: ExtensionConfig;
 	asyncByDefault: boolean;
+	companionSuggestionLines?: (input: { surface: "list" | "doctor"; cwd: string; context?: "fresh" | "fork"; orchestratorTarget?: string }) => string[];
 	tempArtifactsDir: string;
 	getSubagentSessionRoot: (parentSessionFile: string | null) => string;
 	expandTilde: (p: string) => string;
@@ -2741,6 +2742,12 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							orchestratorTarget,
 							sessionError,
 							expandTilde: deps.expandTilde,
+							companionPackageLines: deps.companionSuggestionLines?.({
+								surface: "doctor",
+								cwd: requestCwd,
+								context: paramsWithResolvedCwd.context,
+								orchestratorTarget,
+							}),
 						}),
 					}],
 					details: { mode: "management", results: [] },
@@ -2828,7 +2835,21 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					details: { mode: "management" as const, results: [] },
 				};
 			}
-			return handleManagementAction(params.action, paramsWithResolvedCwd, { ...ctx, cwd: requestCwd, config: deps.config });
+			return handleManagementAction(params.action, paramsWithResolvedCwd, {
+				...ctx,
+				cwd: requestCwd,
+				config: deps.config,
+				companionSuggestionLines: () => {
+					if (params.action !== "list" || deps.state.companionSuggestionListShown) return [];
+					const lines = deps.companionSuggestionLines?.({
+						surface: "list",
+						cwd: requestCwd,
+						context: paramsWithResolvedCwd.context,
+					}) ?? [];
+					if (lines.length > 0) deps.state.companionSuggestionListShown = true;
+					return lines;
+				},
+			});
 		}
 
 		const { blocked, depth, maxDepth } = checkSubagentDepth(deps.config.maxSubagentDepth);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -712,6 +712,8 @@ export interface SubagentState {
 	completionSeen: Map<string, number>;
 	watcher: FSWatcher | null;
 	watcherRestartTimer: ReturnType<typeof setTimeout> | null;
+	companionSuggestionStartupShown?: boolean;
+	companionSuggestionListShown?: boolean;
 	resultFileCoalescer: {
 		schedule(file: string, delayMs?: number): boolean;
 		clear(): void;
@@ -829,6 +831,23 @@ export interface ProactiveSkillSubagentsConfig {
 	preferredAgent?: string;
 }
 
+export type CompanionSuggestionPackage = "pi-prompt-template-model" | "pi-intercom";
+export type CompanionSuggestionSurface = "session_start" | "list" | "doctor";
+
+export interface CompanionSuggestionPackageConfig {
+	enabled?: boolean;
+	surfaces?: CompanionSuggestionSurface[];
+	dismissed?: {
+		user?: boolean;
+		workspaces?: string[];
+	};
+}
+
+export interface CompanionSuggestionsConfig {
+	enabled?: boolean;
+	packages?: Partial<Record<CompanionSuggestionPackage, CompanionSuggestionPackageConfig>>;
+}
+
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
 	forceTopLevelAsync?: boolean;
@@ -841,6 +860,7 @@ export interface ExtensionConfig {
 	worktreeSetupHookTimeoutMs?: number;
 	intercomBridge?: IntercomBridgeConfig;
 	proactiveSkillSubagents?: ProactiveSkillSubagentsConfig | false;
+	companionSuggestions?: CompanionSuggestionsConfig | false;
 }
 
 // ============================================================================

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -483,6 +483,17 @@ Inspect cleanup.
 		assert.match(text, /Cleanup review\./);
 	});
 
+	it("can append companion package suggestions to list output", () => {
+		const listed = handleManagementAction("list", {}, {
+			cwd: tempDir,
+			modelRegistry: { getAvailable: () => [] },
+			companionSuggestionLines: () => ["Recommended companions:", "- pi-intercom is not active in this session."],
+		});
+		const text = readText(listed);
+		assert.match(text, /Recommended companions:/);
+		assert.match(text, /pi-intercom is not active/);
+	});
+
 	it("can disable proactive skill subagent suggestions in config", () => {
 		const ctx = {
 			cwd: tempDir,

--- a/test/unit/companion-suggestions.test.ts
+++ b/test/unit/companion-suggestions.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+	buildCompanionListLines,
+	buildCompanionStartupMessage,
+	collectCompanionStatuses,
+	handleCompanionCommand,
+	maybeSendCompanionStartupMessage,
+} from "../../src/extension/companion-suggestions.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+function makeState(cwd: string): SubagentState {
+	return {
+		baseCwd: cwd,
+		currentSessionId: "session-current",
+		asyncJobs: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	};
+}
+
+function makeRuntime(options: { intercom?: boolean; promptTemplateModel?: boolean } = {}) {
+	return {
+		getAllTools: () => options.intercom ? [{ name: "intercom", sourceInfo: { path: "/tmp/pi-intercom/index.ts" } }] : [],
+		getCommands: () => options.promptTemplateModel ? [{ name: "prompt-tool", sourceInfo: { path: "/tmp/pi-prompt-template-model/index.ts" } }] : [],
+	};
+}
+
+describe("companion suggestions", () => {
+	let tempDir = "";
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-companion-suggestions-"));
+		process.env.PI_CODING_AGENT_DIR = path.join(tempDir, "agent");
+	});
+
+	afterEach(() => {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("builds grouped list recommendations when companions are inactive", () => {
+		const statuses = collectCompanionStatuses({
+			pi: makeRuntime(),
+			config: {},
+			cwd: tempDir,
+			orchestratorTarget: "subagent-chat-session",
+			workspaceKey: tempDir,
+		});
+		const lines = buildCompanionListLines(statuses).join("\n");
+
+		assert.match(lines, /Recommended companions:/);
+		assert.match(lines, /pi-intercom is not active/);
+		assert.match(lines, /pi install npm:pi-intercom/);
+		assert.match(lines, /pi-prompt-template-model is not active/);
+		assert.match(lines, /pi install npm:pi-prompt-template-model/);
+	});
+
+	it("does not recommend pi-intercom from list when its bridge is explicitly off", () => {
+		const statuses = collectCompanionStatuses({
+			pi: makeRuntime(),
+			config: { intercomBridge: { mode: "off" } },
+			cwd: tempDir,
+			workspaceKey: tempDir,
+		});
+		const lines = buildCompanionListLines(statuses).join("\n");
+
+		assert.doesNotMatch(lines, /pi-intercom is not active/);
+		assert.match(lines, /pi-prompt-template-model is not active/);
+	});
+
+	it("does not recommend installing pi-intercom from list when intercom config is disabled", () => {
+		fs.mkdirSync(path.join(process.env.PI_CODING_AGENT_DIR!, "intercom"), { recursive: true });
+		fs.writeFileSync(path.join(process.env.PI_CODING_AGENT_DIR!, "intercom", "config.json"), JSON.stringify({ enabled: false }), "utf-8");
+		const statuses = collectCompanionStatuses({
+			pi: makeRuntime(),
+			config: {},
+			cwd: tempDir,
+			orchestratorTarget: "subagent-chat-session",
+			workspaceKey: tempDir,
+		});
+		const lines = buildCompanionListLines(statuses).join("\n");
+
+		assert.equal(statuses.find((status) => status.packageName === "pi-intercom")?.reason, "pi-intercom config is disabled");
+		assert.doesNotMatch(lines, /pi-intercom is not active/);
+		assert.match(lines, /pi-prompt-template-model is not active/);
+	});
+
+	it("does not treat similarly named source paths as active", () => {
+		const statuses = collectCompanionStatuses({
+			pi: {
+				getAllTools: () => [{ name: "intercom", sourceInfo: { path: "/tmp/not-pi-intercom/index.ts" } }],
+				getCommands: () => [{ name: "prompt-tool", sourceInfo: { path: "/tmp/not-pi-prompt-template-model/index.ts" } }],
+			},
+			config: {},
+			cwd: tempDir,
+			orchestratorTarget: "subagent-chat-session",
+			workspaceKey: tempDir,
+		});
+
+		assert.equal(statuses.find((status) => status.packageName === "pi-intercom")?.active, false);
+		assert.equal(statuses.find((status) => status.packageName === "pi-prompt-template-model")?.active, false);
+	});
+
+	it("treats runtime package resources as active", () => {
+		fs.mkdirSync(path.join(process.env.PI_CODING_AGENT_DIR!, "extensions", "pi-intercom"), { recursive: true });
+		const statuses = collectCompanionStatuses({
+			pi: makeRuntime({ intercom: true, promptTemplateModel: true }),
+			config: {},
+			cwd: tempDir,
+			orchestratorTarget: "subagent-chat-session",
+			workspaceKey: tempDir,
+		});
+		const lines = buildCompanionListLines(statuses).join("\n");
+
+		assert.equal(statuses.find((status) => status.packageName === "pi-intercom")?.active, true);
+		assert.equal(statuses.find((status) => status.packageName === "pi-prompt-template-model")?.active, true);
+		assert.equal(lines, "");
+	});
+
+	it("honors package-specific dismissal", () => {
+		const statuses = collectCompanionStatuses({
+			pi: makeRuntime(),
+			config: {
+				companionSuggestions: {
+					packages: {
+						"pi-intercom": { dismissed: { user: true } },
+					},
+				},
+			},
+			cwd: tempDir,
+			orchestratorTarget: "subagent-chat-session",
+			workspaceKey: tempDir,
+		});
+		const lines = buildCompanionListLines(statuses).join("\n");
+
+		assert.doesNotMatch(lines, /pi-intercom is not active/);
+		assert.match(lines, /pi-prompt-template-model is not active/);
+	});
+
+	it("sends one LLM-visible startup message without triggering a turn", () => {
+		const statuses = collectCompanionStatuses({
+			pi: makeRuntime(),
+			config: {},
+			cwd: tempDir,
+			orchestratorTarget: "subagent-chat-session",
+			workspaceKey: tempDir,
+		});
+		const sent: unknown[] = [];
+		const state = makeState(tempDir);
+		const ctx = {
+			cwd: tempDir,
+			hasUI: true,
+			ui: {},
+			sessionManager: { getSessionId: () => "session", getSessionFile: () => null },
+			modelRegistry: { getAvailable: () => [] },
+		};
+
+		maybeSendCompanionStartupMessage({
+			pi: { sendMessage: (message: unknown, options?: unknown) => sent.push({ message, options }) },
+			ctx: ctx as never,
+			state,
+			statuses,
+		});
+		maybeSendCompanionStartupMessage({
+			pi: { sendMessage: (message: unknown, options?: unknown) => sent.push({ message, options }) },
+			ctx: ctx as never,
+			state,
+			statuses,
+		});
+
+		assert.equal(sent.length, 1);
+		assert.match(JSON.stringify(sent[0]), /pi install npm:pi-intercom/);
+		assert.match(JSON.stringify(sent[0]), /pi install npm:pi-prompt-template-model/);
+		assert.doesNotMatch(JSON.stringify(sent[0]), /triggerTurn/);
+	});
+
+	it("writes workspace dismissal through the companion command", () => {
+		const ctx = { cwd: tempDir };
+		const statuses = collectCompanionStatuses({
+			pi: makeRuntime(),
+			config: {},
+			cwd: tempDir,
+			orchestratorTarget: "subagent-chat-session",
+			workspaceKey: tempDir,
+		});
+		const result = handleCompanionCommand("hide pi-intercom workspace", ctx as never, statuses);
+		const configPath = path.join(process.env.PI_CODING_AGENT_DIR!, "extensions", "subagent", "config.json");
+		const saved = JSON.parse(fs.readFileSync(configPath, "utf-8")) as { companionSuggestions?: { packages?: Record<string, { dismissed?: { workspaces?: string[] } }> } };
+
+		assert.equal(result.error, undefined);
+		assert.match(result.text, /Hid pi-intercom recommendations for this workspace/);
+		assert.deepEqual(saved.companionSuggestions?.packages?.["pi-intercom"]?.dismissed?.workspaces, [tempDir]);
+	});
+});

--- a/test/unit/doctor.test.ts
+++ b/test/unit/doctor.test.ts
@@ -68,6 +68,7 @@ describe("buildDoctorReport", () => {
 				orchestratorTarget: "subagent-chat-abc123",
 				expandTilde: (value) => value.replace(/^~\//, `${root}/home/`),
 				paths,
+				companionPackageLines: ["Companion packages", "- pi-intercom: inactive"],
 				deps: {
 					isAsyncAvailable: () => true,
 					discoverAgentsAll: () => ({
@@ -111,6 +112,8 @@ describe("buildDoctorReport", () => {
 			assert.match(report, /- skills: total 2 \(project 1, user-package 1\)/);
 			assert.match(report, /- bridge: inactive \(pi-intercom extension was not found\)/);
 			assert.match(report, /- pi-intercom: unavailable /);
+			assert.match(report, /Companion packages/);
+			assert.match(report, /- pi-intercom: inactive/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
This adds a gentle companion-package hint when pi-subagents can work better with pi-intercom or pi-prompt-template-model. It only suggests install commands, keeps the note visible to the agent, and lets people hide it per workspace or globally.

I also wired the status into doctor and covered the detection and dismissal paths in tests.
