### PR TITLE
fix: tolerate transient Windows atomic JSON rename locks

### DIFF
--- a/src/shared/atomic-json.ts
+++ b/src/shared/atomic-json.ts
@@ -13,13 +13,26 @@ type AtomicJsonWriterOptions = {
 	wait?: (delayMs: number) => void;
 };
 
-const DEFAULT_RENAME_RETRY_DELAYS_MS = [10, 25, 50, 100, 200] as const;
+const DEFAULT_RENAME_RETRY_DELAYS_MS = [10, 25, 50, 100, 200, 500, 1000, 2000, 4000] as const;
 const RETRYABLE_RENAME_ERROR_CODES = new Set(["EACCES", "EBUSY", "EPERM"]);
+const WAIT_BUFFER = typeof SharedArrayBuffer !== "undefined" ? new SharedArrayBuffer(4) : undefined;
+const WAIT_VIEW = WAIT_BUFFER ? new Int32Array(WAIT_BUFFER) : undefined;
 
 function waitSync(delayMs: number): void {
+	if (delayMs <= 0) return;
+	if (WAIT_VIEW) {
+		try {
+			// writeAtomicJson is synchronous because callers often update status from sync callbacks.
+			// Atomics.wait gives Windows rename locks time to clear without burning CPU.
+			Atomics.wait(WAIT_VIEW, 0, 0, delayMs);
+			return;
+		} catch {
+			// Fall through to the portable busy wait below.
+		}
+	}
 	const end = Date.now() + delayMs;
 	while (Date.now() < end) {
-		// writeAtomicJson is synchronous because callers often update status from sync callbacks.
+		// Portable fallback for runtimes where Atomics.wait is unavailable.
 	}
 }
 

--- a/test/unit/atomic-json.test.ts
+++ b/test/unit/atomic-json.test.ts
@@ -38,7 +38,7 @@ class FakeFs {
 
 function createWriter(fakeFs: FakeFs, waits: number[]) {
 	return createAtomicJsonWriter({
-		fs: fakeFs,
+		fs: fakeFs as any,
 		now: () => 12345,
 		pid: 678,
 		random: () => 0.5,
@@ -63,6 +63,25 @@ describe("writeAtomicJson", () => {
 		assert.deepEqual(fakeFs.madeDirs, [path.dirname(targetPath)]);
 		assert.equal(fakeFs.files.get(targetPath), JSON.stringify({ state: "running" }, null, 2));
 		assert.equal(fakeFs.files.size, 1);
+	});
+
+	it("uses longer default retries for transient Windows rename locks", () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failRenameCodes = ["EPERM", "EPERM", "EPERM", "EPERM", "EPERM", "EPERM"];
+		const waits: number[] = [];
+		const writeAtomicJson = createAtomicJsonWriter({
+			fs: fakeFs as any,
+			now: () => 12345,
+			pid: 678,
+			random: () => 0.5,
+			retryRenameErrors: true,
+			wait: (delayMs) => waits.push(delayMs),
+		});
+
+		writeAtomicJson(path.join("/tmp", "status.json"), { state: "running" });
+
+		assert.equal(fakeFs.renameCalls, 7);
+		assert.deepEqual(waits, [10, 25, 50, 100, 200, 500]);
 	});
 
 	it("throws non-retryable rename failures without retrying", () => {


### PR DESCRIPTION
## Summary

- extend Windows atomic JSON rename retries to tolerate longer transient `EPERM`/`EBUSY`/`EACCES` locks
- replace the synchronous busy-wait sleep with `Atomics.wait` when available to avoid spinning the CPU during retry backoff
- add unit coverage for the longer default retry sequence

## Context

On Windows, async subagent runners can crash while updating `status.json` when an antivirus/indexer/other process briefly holds the destination file:

```text
Error: EPERM: operation not permitted, rename '.status.json.<pid>...tmp' -> 'status.json'
    at renameWithRetry (.../src/shared/atomic-json.ts:40:14)
```

The existing retry budget topped out at 200ms, which was not long enough in this observed case and caused stale-run reconciliation to mark otherwise healthy async runs as failed.

## Tests

- `node --experimental-strip-types --test test/unit/atomic-json.test.ts` ✅
- `npm run test:unit` ⚠️ unrelated existing Windows failures in `test/unit/agent-management.test.ts` after many tests pass; atomic-json tests pass. The failing tests look path/location-related (`ENOENT ... .pi\agents\*.md`) and are not touched by this PR.
