### PR TITLE
fix: scope active-run restore to the starting session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 - Scope async subagent completion notifications to the exact owning Pi session so another session in the same repo no longer receives result notices.
+- Restore only the async runs spawned by the session that is starting, instead of every active run in the shared async directory, so unrelated Pi sessions (and their footers) no longer pick up someone else's background subagents on launch. `listAsyncRuns` now takes a composable `filters` list instead of an ad hoc `sessionId` option, so future restore-scoping filters (e.g. by cwd) can be added without changing its call sites. Thanks to @EtienneChollet, @TwistedTabby, and @vicary for confirming the regression. Fixes #383.
 - Harden scheduled-run timestamp parsing and persisted store validation so ambiguous absolute times and corrupted job records fail clearly instead of being normalized or dropped.
 - Derive live-detail and full-notification hints from Pi's configured expand key instead of hard-coding `Ctrl+O`. Thanks to Kylegl (@kylegl) for #364.
 - Tolerate transient Windows `EPERM`/`EBUSY`/`EACCES` locks when atomically replacing async JSON files. Thanks to ThanhNT29Jacky (@ThanhNT29Jacky) for #380.

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -17,7 +17,7 @@ import { readStatus } from "../../shared/utils.ts";
 import { normalizeParallelGroups } from "./parallel-groups.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
 import { hasLiveNestedDescendants, updateAsyncJobNestedProjection } from "../shared/nested-events.ts";
-import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
+import { listAsyncRuns, sessionFilters, type AsyncRunSummary } from "./async-status.ts";
 
 interface AsyncJobTrackerOptions {
 	completionRetentionMs?: number;
@@ -424,7 +424,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		if (!state.currentSessionId) return;
 		let runs: AsyncRunSummary[];
 		try {
-			runs = listAsyncRuns(asyncDirRoot, { states: ["queued", "running"], sessionId: state.currentSessionId, resultsDir, kill: options.kill, now: options.now });
+			runs = listAsyncRuns(asyncDirRoot, { states: ["queued", "running"], filters: sessionFilters(state.currentSessionId), resultsDir, kill: options.kill, now: options.now });
 		} catch (error) {
 			console.error(`Failed to restore active async jobs from '${asyncDirRoot}':`, error);
 			return;

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -84,9 +84,27 @@ export interface AsyncRunSummary {
 	nestedWarnings?: string[];
 }
 
+export interface AsyncRunFilterContext {
+	status: AsyncStatus & { cwd?: string };
+	asyncDir: string;
+}
+
+/** ANDed together, so a new filter kind (e.g. by cwd) can be added without touching existing ones. */
+export type AsyncRunFilter = (context: AsyncRunFilterContext) => boolean;
+
+/** The session that spawned the run, i.e. the parent/owning session, not any child run session. */
+export function filterBySessionId(sessionId: string): AsyncRunFilter {
+	return ({ status }) => status.sessionId === sessionId;
+}
+
+/** Convenience for the common "scope to the current session" case; empty (no filtering) when unset. */
+export function sessionFilters(sessionId?: string | null): AsyncRunFilter[] {
+	return sessionId ? [filterBySessionId(sessionId)] : [];
+}
+
 interface AsyncRunListOptions {
 	states?: Array<AsyncRunSummary["state"]>;
-	sessionId?: string;
+	filters?: AsyncRunFilter[];
 	limit?: number;
 	resultsDir?: string;
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
@@ -291,7 +309,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 		// restoration at load from scanning that directory when no active runs
 		// match.
 		if (allowedStates && !allowedStates.has(status.state)) continue;
-		if (options.sessionId && status.sessionId !== options.sessionId) continue;
+		if (options.filters?.some((filter) => !filter({ status, asyncDir })) ?? false) continue;
 		const nestedWarnings: string[] = [];
 		let nestedRoute: NestedRoute | undefined;
 		try {

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -16,7 +16,7 @@ import {
 } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
-import { formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
+import { formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns, sessionFilters, type AsyncRunSummary } from "./async-status.ts";
 
 const DEFAULT_TRANSCRIPT_LINES = 80;
 const MAX_TRANSCRIPT_LINES = 500;
@@ -305,7 +305,7 @@ export function inspectSubagentFleet(_params: FleetViewParams, deps: FleetViewDe
 	try {
 		asyncRuns = listAsyncRuns(deps.asyncDirRoot ?? ASYNC_DIR, {
 			states: ["queued", "running"],
-			sessionId: deps.state?.currentSessionId ?? undefined,
+			filters: sessionFilters(deps.state?.currentSessionId),
 			resultsDir: deps.resultsDir ?? RESULTS_DIR,
 			kill: deps.kill,
 			now: deps.now,

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { formatAsyncRunList, formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns } from "./async-status.ts";
+import { formatAsyncRunList, formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns, sessionFilters } from "./async-status.ts";
 import { formatAsyncResultTranscript, formatAsyncRunTranscript, formatNestedRunTranscript, inspectSubagentFleet } from "./fleet-view.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { formatModelThinking } from "../../shared/formatters.ts";
@@ -135,7 +135,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			};
 		}
 		try {
-			const runs = listAsyncRuns(asyncDirRoot, { states: ["queued", "running"], sessionId: currentSessionId, resultsDir, kill: deps.kill, now: deps.now });
+			const runs = listAsyncRuns(asyncDirRoot, { states: ["queued", "running"], filters: sessionFilters(currentSessionId), resultsDir, kill: deps.kill, now: deps.now });
 			if (params.view === "transcript") {
 				if (runs.length === 1) return inspectSubagentStatus({ ...params, id: runs[0]!.id }, deps);
 				return {

--- a/src/runs/background/wait.ts
+++ b/src/runs/background/wait.ts
@@ -37,7 +37,7 @@
  */
 
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
+import { listAsyncRuns, sessionFilters, type AsyncRunSummary } from "./async-status.ts";
 import {
 	ASYNC_DIR,
 	RESULTS_DIR,
@@ -172,7 +172,7 @@ function activeRunsForSession(params: WaitParams, deps: WaitDeps): AsyncRunSumma
 	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
 	const runs = listAsyncRuns(asyncDirRoot, {
 		states: [...ACTIVE_STATES],
-		sessionId: deps.state.currentSessionId ?? undefined,
+		filters: sessionFilters(deps.state.currentSessionId),
 		resultsDir,
 		kill: deps.kill,
 		now: deps.now,
@@ -190,7 +190,7 @@ function allRunsForSession(params: WaitParams, deps: WaitDeps): AsyncRunSummary[
 	const asyncDirRoot = deps.asyncDirRoot ?? ASYNC_DIR;
 	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
 	const runs = listAsyncRuns(asyncDirRoot, {
-		sessionId: deps.state.currentSessionId ?? undefined,
+		filters: sessionFilters(deps.state.currentSessionId),
 		resultsDir,
 		kill: deps.kill,
 		now: deps.now,

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { formatAsyncRunList, listAsyncRuns } from "../../src/runs/background/async-status.ts";
+import { filterBySessionId, formatAsyncRunList, listAsyncRuns, sessionFilters } from "../../src/runs/background/async-status.ts";
 
 function createAsyncDir(root: string, id: string, status: Record<string, unknown>): string {
 	const dir = path.join(root, id);
@@ -456,6 +456,70 @@ describe("async status helpers", () => {
 			// 200 terminal dirs filtered to active states should resolve in well
 			// under a second. The old per-run nested-route scan blew past this.
 			assert.ok(elapsed < 1000, `listAsyncRuns took ${elapsed}ms for 200 terminal runs`);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("scopes results to the owning session via filterBySessionId", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-filter-session-"));
+		try {
+			createAsyncDir(root, "run-owner", {
+				runId: "run-owner",
+				mode: "single",
+				state: "running",
+				sessionId: "session-owner",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			createAsyncDir(root, "run-other", {
+				runId: "run-other",
+				mode: "single",
+				state: "running",
+				sessionId: "session-other",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+
+			const owned = listAsyncRuns(root, { filters: [filterBySessionId("session-owner")] });
+			assert.deepEqual(owned.map((run) => run.id), ["run-owner"]);
+
+			// sessionFilters is the no-filtering-when-unset convenience used by call sites.
+			assert.deepEqual(sessionFilters(undefined), []);
+			const all = listAsyncRuns(root, { filters: sessionFilters(undefined) });
+			assert.deepEqual(new Set(all.map((run) => run.id)), new Set(["run-owner", "run-other"]));
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("combines multiple filters with AND semantics", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-filter-combo-"));
+		try {
+			createAsyncDir(root, "run-match", {
+				runId: "run-match",
+				mode: "single",
+				state: "running",
+				sessionId: "session-owner",
+				cwd: "/repo-a",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			createAsyncDir(root, "run-wrong-cwd", {
+				runId: "run-wrong-cwd",
+				mode: "single",
+				state: "running",
+				sessionId: "session-owner",
+				cwd: "/repo-b",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+
+			// A hypothetical future cwd filter, written the same way filterBySessionId is,
+			// composes with it without any changes to listAsyncRuns itself.
+			const byCwd = (cwd: string) => (({ status }: { status: { cwd?: string } }) => status.cwd === cwd);
+			const runs = listAsyncRuns(root, { filters: [filterBySessionId("session-owner"), byCwd("/repo-a")] });
+			assert.deepEqual(runs.map((run) => run.id), ["run-match"]);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
`listAsyncRuns` already had a `sessionId` option, and restoreActiveJobs
was passing state.currentSessionId through it, but the option was a
single ad hoc field bolted onto the loop. Generalize it into a small
composable filters mechanism (`AsyncRunFilter`, `filterBySessionId`,
`sessionFilters`) so restoreActiveJobs, wait, run-status, and the fleet
view all scope to the owning session the same way, and so a future
scope (e.g. by cwd, per #383's original config proposal) is a new
filter function instead of another option field threaded everywhere.

Verified with a script that seeds the shared async dir with runs from
several unrelated sessions and confirms restoreActiveJobs only revives
the one matching the resuming session, matching the reported behavior
in #383.

Fixes: #383