### PR TITLE
fix: recover detached foreground run status

### DIFF
--- a/src/runs/background/run-id-resolver.ts
+++ b/src/runs/background/run-id-resolver.ts
@@ -28,7 +28,8 @@ function exactAsyncLocation(id: string, asyncDirRoot: string, resultsDir: string
 }
 
 function foregroundIds(state: SubagentState | undefined): string[] {
-	return state ? [...state.foregroundControls.keys()] : [];
+	if (!state) return [];
+	return [...new Set([...state.foregroundControls.keys(), ...(state.foregroundRuns?.keys() ?? [])])];
 }
 
 function nestedScopeFromState(state: SubagentState | undefined): NestedRunResolutionScope | undefined {
@@ -57,7 +58,7 @@ export function resolveSubagentRunId(id: string, deps: ResolveSubagentRunIdDeps 
 	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
 
 	const nestedScope = deps.nested ?? nestedScopeFromState(deps.state);
-	if (deps.state?.foregroundControls.has(id)) return { kind: "foreground", id };
+	if (deps.state?.foregroundControls.has(id) || deps.state?.foregroundRuns?.has(id)) return { kind: "foreground", id };
 	const exactAsync = exactAsyncLocation(id, asyncDirRoot, resultsDir);
 	if (exactAsync) return { kind: "async", id, location: exactAsync };
 	const exactNested = findNestedRunMatchesById(id, nestedScope ? { scope: nestedScope } : {});

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -6,7 +6,7 @@ import { formatAsyncResultTranscript, formatAsyncRunTranscript, formatNestedRunT
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { formatModelThinking } from "../../shared/formatters.ts";
 import { formatActivityLabel } from "../../shared/status-format.ts";
-import { ASYNC_DIR, RESULTS_DIR, type AsyncStatus, type Details, type NestedRunSummary, type SubagentState } from "../../shared/types.ts";
+import { ASYNC_DIR, RESULTS_DIR, type AsyncStatus, type Details, type ForegroundResumeRun, type NestedRunSummary, type SubagentState } from "../../shared/types.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { resolveAsyncRunLocation } from "./async-resume.ts";
 import { resolveSubagentRunId } from "./run-id-resolver.ts";
@@ -78,6 +78,80 @@ function formatSteeringSummary(input: { steerCount?: number; lastSteerAt?: numbe
 	if (input.steerCount !== undefined) parts.push(`${input.steerCount} steer${input.steerCount === 1 ? "" : "s"}`);
 	if (typeof input.lastSteerAt === "number" && Number.isFinite(input.lastSteerAt)) parts.push(`last ${new Date(input.lastSteerAt).toISOString()}`);
 	return parts.length ? parts.join(", ") : undefined;
+}
+
+function rememberedForegroundChildOutput(child: ForegroundResumeRun["children"][number]): string {
+	const outputPath = child.artifactPaths?.outputPath;
+	if (outputPath && fs.existsSync(outputPath)) {
+		try {
+			const artifactOutput = fs.readFileSync(outputPath, "utf-8").trim();
+			if (artifactOutput) return artifactOutput;
+		} catch {
+			// Fall back to the remembered snapshot below.
+		}
+	}
+	return child.finalOutput ?? "";
+}
+
+function formatRememberedForegroundStatus(run: ForegroundResumeRun): string {
+	const lines = [
+		`Run: ${run.runId}`,
+		"State: remembered foreground",
+		`Mode: ${run.mode}`,
+		`Updated: ${new Date(run.updatedAt).toISOString()}`,
+		`Cwd: ${run.cwd}`,
+	];
+	for (const child of run.children) {
+		const output = rememberedForegroundChildOutput(child).trim().split(/\r?\n/).find((line) => line.trim());
+		const parts = [
+			`${child.index + 1}. ${child.agent} ${child.status}`,
+			child.exitCode !== undefined ? `exit ${child.exitCode}` : undefined,
+			child.detachedReason ? `detached: ${child.detachedReason}` : undefined,
+			output ? `output: ${output.slice(0, 160)}` : undefined,
+		].filter(Boolean);
+		lines.push(parts.join(", "));
+		if (child.sessionFile) lines.push(`  Session: ${child.sessionFile}`);
+		if (child.transcriptPath) lines.push(`  Transcript: ${child.transcriptPath}`);
+		if (child.artifactPaths?.outputPath) lines.push(`  Output: ${child.artifactPaths.outputPath}`);
+		if (child.transcriptError) lines.push(`  Transcript warning: ${child.transcriptError}`);
+	}
+	lines.push("", `Status: subagent({ action: "status", id: "${run.runId}" })`);
+	if (run.children.length === 1) lines.push(`Transcript: subagent({ action: "status", id: "${run.runId}", view: "transcript" })`);
+	else lines.push(`Transcript: subagent({ action: "status", id: "${run.runId}", index: 0, view: "transcript" })`);
+	const resumable = run.children.find((child) => child.status !== "detached" && hasExistingSessionFile(child.sessionFile));
+	if (resumable) {
+		lines.push(run.children.length === 1
+			? `Revive: subagent({ action: "resume", id: "${run.runId}", message: "..." })`
+			: `Revive child: subagent({ action: "resume", id: "${run.runId}", index: ${resumable.index}, message: "..." })`);
+	} else if (run.children.some((child) => child.status === "detached")) {
+		lines.push("Recovery: child detached for intercom coordination; status will show recovered output after the child exits when Pi can observe it.");
+	} else {
+		lines.push("Resume: unavailable; no child session file was persisted.");
+	}
+	return lines.join("\n");
+}
+
+function formatRememberedForegroundTranscript(run: ForegroundResumeRun, options: { index?: number; lines?: number }): string {
+	let index = options.index;
+	if (index !== undefined && !Number.isInteger(index)) throw new Error("Transcript index must be an integer.");
+	if (index === undefined && run.children.length === 1) index = 0;
+	if (index === undefined) return `Transcript view requires index for foreground run '${run.runId}' with ${run.children.length} children.`;
+	if (index < 0 || index >= run.children.length) throw new Error(`Transcript index ${index} is out of range for ${run.children.length} foreground children.`);
+	const child = run.children[index]!;
+	const lineLimit = Math.max(1, Math.min(options.lines ?? 80, 1000));
+	const outputLines = rememberedForegroundChildOutput(child).split(/\r?\n/).filter((line) => line.trim()).slice(-lineLimit);
+	const lines = [
+		`Run: ${run.runId}`,
+		`State: ${child.status}`,
+		`Child: ${index} (${child.agent})`,
+		child.sessionFile ? `Session: ${child.sessionFile}` : undefined,
+		child.transcriptPath ? `Transcript: ${child.transcriptPath}` : undefined,
+		child.artifactPaths?.outputPath ? `Output: ${child.artifactPaths.outputPath}` : undefined,
+	].filter((line): line is string => Boolean(line));
+	lines.push("Result transcript tail:");
+	if (outputLines.length === 0) lines.push("  (no recovered final output available yet)");
+	else for (const line of outputLines) lines.push(`  ${line}`);
+	return lines.join("\n");
 }
 
 function formatNestedExactStatus(rootRunId: string, run: NestedRunSummary): string {
@@ -163,6 +237,20 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 		const requestedId = params.id ?? params.runId;
 		if (!params.dir && requestedId) {
 			const resolved = resolveSubagentRunId(requestedId, { asyncDirRoot, resultsDir, state: deps.state, nested: deps.nested });
+			if (resolved?.kind === "foreground") {
+				const run = deps.state?.foregroundRuns?.get(resolved.id);
+				if (run) {
+					try {
+						return {
+							content: [{ type: "text", text: params.view === "transcript" ? formatRememberedForegroundTranscript(run, { index: params.index, lines: params.lines }) : formatRememberedForegroundStatus(run) }],
+							details: { mode: "single", results: [] },
+						};
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error);
+						return { content: [{ type: "text", text: message }], isError: true, details: { mode: "single", results: [] } };
+					}
+				}
+			}
 			if (resolved?.kind === "nested") {
 				reconcileNestedAsyncDescendants(resolved.match.route, { resultsDir, kill: deps.kill, now: deps.now });
 				const refreshed = resolveSubagentRunId(requestedId, { asyncDirRoot, resultsDir, state: deps.state, nested: deps.nested });

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -145,6 +145,7 @@ interface ParallelChainRunInput {
 	timeoutMs?: number;
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
+	onDetachedExit?: (index: number, result: SingleResult) => void;
 	globalSemaphore?: Semaphore;
 }
 
@@ -313,6 +314,9 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				timeoutMs: input.timeoutMs,
 				deadlineAt: input.deadlineAt,
 				turnBudget: input.turnBudget,
+				onDetachedExit: input.onDetachedExit
+					? (result) => input.onDetachedExit?.(input.globalTaskIndex + taskIndex, result)
+					: undefined,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
 						const stepResults = progressUpdate.details?.results || [];
@@ -422,6 +426,7 @@ interface ChainExecutionParams {
 	timeoutMs?: number;
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
+	onDetachedExit?: (index: number, result: SingleResult) => void;
 	/** Global cap on simultaneously-running tasks within this chain. Defaults to DEFAULT_GLOBAL_CONCURRENCY_LIMIT. */
 	globalConcurrencyLimit?: number;
 }
@@ -460,6 +465,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 		onUpdate,
 		onControlEvent,
 		controlConfig,
+		onDetachedExit,
 		childIntercomTarget,
 		orchestratorIntercomTarget,
 		foregroundControl,
@@ -711,6 +717,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					timeoutMs: params.timeoutMs,
 					deadlineAt,
 					turnBudget: params.turnBudget,
+					onDetachedExit,
 					globalSemaphore,
 				});
 				globalTaskIndex += step.parallel.length;
@@ -927,6 +934,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				timeoutMs: params.timeoutMs,
 				deadlineAt,
 				turnBudget: params.turnBudget,
+				onDetachedExit,
 				globalSemaphore,
 			});
 			globalTaskIndex = dynamicStartIndex + reservedDynamicItems;
@@ -1090,10 +1098,11 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				return buildChainExecutionErrorResult(validationError, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }));
 			}
 			const maxSubagentDepth = resolveChildMaxSubagentDepth(params.maxSubagentDepth, agentConfig.maxSubagentDepth);
+			const childIndex = globalTaskIndex;
 			const interruptController = new AbortController();
 			if (foregroundControl) {
 				foregroundControl.currentAgent = seqStep.agent;
-				foregroundControl.currentIndex = globalTaskIndex;
+				foregroundControl.currentIndex = childIndex;
 				foregroundControl.currentActivityState = undefined;
 				foregroundControl.updatedAt = Date.now();
 				foregroundControl.interrupt = () => {
@@ -1116,11 +1125,11 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				allowIntercomDetach: agentConfig.systemPrompt?.includes(INTERCOM_BRIDGE_MARKER) === true,
 				intercomEvents,
 				runId,
-				index: globalTaskIndex,
-				sessionDir: sessionDirForIndex(globalTaskIndex),
-				sessionFile: sessionFileForTask?.(seqStep.agent, globalTaskIndex)
-					?? sessionFileForIndex?.(globalTaskIndex),
-				thinkingOverride: thinkingOverrideForTask?.(seqStep.agent, globalTaskIndex),
+				index: childIndex,
+				sessionDir: sessionDirForIndex(childIndex),
+				sessionFile: sessionFileForTask?.(seqStep.agent, childIndex)
+					?? sessionFileForIndex?.(childIndex),
+				thinkingOverride: thinkingOverrideForTask?.(seqStep.agent, childIndex),
 				share: shareEnabled,
 				artifactsDir: artifactConfig.enabled ? artifactsDir : undefined,
 				artifactConfig,
@@ -1129,7 +1138,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				maxSubagentDepth,
 				controlConfig,
 				onControlEvent,
-				intercomSessionName: childIntercomTarget?.(seqStep.agent, globalTaskIndex),
+				intercomSessionName: childIntercomTarget?.(seqStep.agent, childIndex),
 				orchestratorIntercomTarget,
 				nestedRoute: params.nestedRoute,
 				modelOverride: effectiveModel,
@@ -1143,6 +1152,9 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				timeoutMs: params.timeoutMs,
 				deadlineAt,
 				turnBudget: params.turnBudget,
+				onDetachedExit: onDetachedExit
+					? (result) => onDetachedExit(childIndex, result)
+					: undefined,
 				onUpdate: onUpdate
 					? (p) => {
 						const stepResults = p.details?.results || [];
@@ -1150,7 +1162,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 						if (foregroundControl && stepProgress.length > 0) {
 							const current = stepProgress[0];
 							foregroundControl.currentAgent = seqStep.agent;
-							foregroundControl.currentIndex = globalTaskIndex;
+							foregroundControl.currentIndex = childIndex;
 							foregroundControl.currentActivityState = current?.activityState;
 							foregroundControl.lastActivityAt = current?.lastActivityAt;
 							foregroundControl.currentTool = current?.currentTool;
@@ -1178,7 +1190,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 									steps: chainSteps,
 									results: results.concat(stepResults),
 									currentStepIndex: stepIndex,
-									currentFlatIndex: globalTaskIndex,
+									currentFlatIndex: childIndex,
 									dynamicChildren,
 									dynamicGroupStatuses,
 								}),
@@ -1187,7 +1199,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					}
 					: undefined,
 			});
-			if (foregroundControl?.currentIndex === globalTaskIndex) {
+			if (foregroundControl?.currentIndex === childIndex) {
 				foregroundControl.interrupt = undefined;
 				foregroundControl.updatedAt = Date.now();
 			}
@@ -1201,13 +1213,13 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			if (r.interrupted) {
 				return {
 					content: [{ type: "text", text: `Chain paused after interrupt at step ${stepIndex + 1} (${r.agent}). Waiting for explicit next action.` }],
-					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex - 1 })),
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: childIndex })),
 				};
 			}
 			if (r.detached) {
 				return {
 					content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${r.agent}). Reply to the supervisor request first. After the child exits, start a fresh follow-up if needed.` }],
-					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex - 1 })),
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: childIndex })),
 				};
 			}
 
@@ -1218,7 +1230,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				});
 				return {
 					content: [{ type: "text", text: summary }],
-					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex - 1 })),
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: childIndex })),
 					isError: true,
 				};
 			}

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -744,11 +744,6 @@ async function runSingleAttempt(
 				// JSONL artifact flush is best effort.
 			});
 			cleanupTempDir(tempDir);
-			if (detached) {
-				finish(-2);
-				return;
-			}
-			processClosed = true;
 			if (buf.trim()) processLine(buf);
 			if (stderrBuf.trim()) shared.transcriptWriter?.writeStderrText(stderrBuf);
 			if (!result.error && assistantError) result.error = assistantError;
@@ -757,6 +752,30 @@ async function runSingleAttempt(
 				result.error = stderrBuf.trim();
 			}
 			const finalCode = forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
+			if (detached) {
+				result.exitCode = result.error && finalCode === 0 ? 1 : finalCode;
+				progress.status = result.exitCode === 0 ? "completed" : "failed";
+				progress.durationMs = Date.now() - startTime;
+				if (result.error) progress.error = result.error;
+				result.progressSummary = {
+					toolCount: progress.toolCount,
+					tokens: progress.tokens,
+					durationMs: progress.durationMs,
+				};
+				const finalOutput = getFinalOutput(result.messages);
+				result.finalOutput = finalOutput.trim() || result.error || result.finalOutput || "Detached child exited without final output.";
+				if (result.artifactPaths && options.artifactConfig?.enabled !== false && options.artifactConfig?.includeOutput !== false) {
+					try {
+						writeArtifact(result.artifactPaths.outputPath, result.finalOutput);
+					} catch {
+						// Detached children may outlive test/temp cleanup; recovered status is best-effort.
+					}
+				}
+				options.onDetachedExit?.(snapshotResult(result, snapshotProgress(progress)));
+				finish(-2);
+				return;
+			}
+			processClosed = true;
 			finish(finalCode);
 		});
 		proc.on("error", (error) => {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -305,25 +305,70 @@ function foregroundStatusResult(control: SubagentState["foregroundControls"] ext
 	return { content: [{ type: "text", text: lines.join("\n") }], details: { mode: "management", results: [] } };
 }
 
-function rememberForegroundRun(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; results: SingleResult[] }): void {
-	state.foregroundRuns ??= new Map();
-	state.foregroundRuns.set(input.runId, {
-		runId: input.runId,
-		mode: input.mode,
-		cwd: input.cwd,
-		updatedAt: Date.now(),
-		children: input.results.map((result, index) => ({
-			agent: result.agent,
-			index,
-			status: resolveSubagentResultStatus({ exitCode: result.exitCode, interrupted: result.interrupted, detached: result.detached }),
-			...(result.sessionFile ? { sessionFile: result.sessionFile } : {}),
-		})),
-	});
+function trimRememberedForegroundRuns(state: SubagentState): void {
+	if (!state.foregroundRuns) return;
 	while (state.foregroundRuns.size > 50) {
 		const oldest = [...state.foregroundRuns.values()].sort((left, right) => left.updatedAt - right.updatedAt)[0];
 		if (!oldest) break;
 		state.foregroundRuns.delete(oldest.runId);
 	}
+}
+
+function rememberForegroundRun(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; results: SingleResult[] }): void {
+	state.foregroundRuns ??= new Map();
+	const previous = state.foregroundRuns.get(input.runId);
+	const updatedAt = Date.now();
+	state.foregroundRuns.set(input.runId, {
+		runId: input.runId,
+		mode: input.mode,
+		cwd: input.cwd,
+		updatedAt,
+		children: input.results.map((result, index) => {
+			const child = {
+				agent: result.agent,
+				index,
+				status: resolveSubagentResultStatus({ exitCode: result.exitCode, interrupted: result.interrupted, detached: result.detached }),
+				updatedAt,
+				...(result.exitCode !== undefined ? { exitCode: result.exitCode } : {}),
+				...(result.finalOutput ? { finalOutput: result.finalOutput } : {}),
+				...(result.sessionFile ? { sessionFile: result.sessionFile } : {}),
+				...(result.artifactPaths ? { artifactPaths: result.artifactPaths } : {}),
+				...(result.transcriptPath ? { transcriptPath: result.transcriptPath } : {}),
+				...(result.transcriptError ? { transcriptError: result.transcriptError } : {}),
+				...(result.detachedReason ? { detachedReason: result.detachedReason } : {}),
+			};
+			const recovered = previous?.children[index];
+			return child.status === "detached" && recovered && recovered.status !== "detached" ? recovered : child;
+		}),
+	});
+	trimRememberedForegroundRuns(state);
+}
+
+function updateRememberedForegroundChild(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; index: number; result: SingleResult }): void {
+	state.foregroundRuns ??= new Map();
+	const updatedAt = Date.now();
+	let run = state.foregroundRuns.get(input.runId);
+	if (!run) {
+		run = { runId: input.runId, mode: input.mode, cwd: input.cwd, updatedAt, children: [] };
+		state.foregroundRuns.set(input.runId, run);
+	}
+	run.updatedAt = updatedAt;
+	const child = run.children[input.index] ?? { agent: input.result.agent, index: input.index, status: "detached" as const };
+	run.children[input.index] = {
+		...child,
+		agent: input.result.agent,
+		index: input.index,
+		status: resolveSubagentResultStatus({ exitCode: input.result.exitCode, interrupted: input.result.interrupted, detached: false }),
+		updatedAt,
+		...(input.result.exitCode !== undefined ? { exitCode: input.result.exitCode } : {}),
+		...(input.result.finalOutput ? { finalOutput: input.result.finalOutput } : {}),
+		...(input.result.sessionFile ? { sessionFile: input.result.sessionFile } : {}),
+		...(input.result.artifactPaths ? { artifactPaths: input.result.artifactPaths } : {}),
+		...(input.result.transcriptPath ? { transcriptPath: input.result.transcriptPath } : {}),
+		...(input.result.transcriptError ? { transcriptError: input.result.transcriptError } : {}),
+		...(input.result.detachedReason ? { detachedReason: input.result.detachedReason } : {}),
+	};
+	trimRememberedForegroundRuns(state);
 }
 
 function resolveForegroundResumeTarget(params: SubagentParamsLike, state: SubagentState): { runId: string; mode: "single" | "parallel" | "chain"; state: "complete"; agent: string; index: number; intercomTarget: string; cwd: string; sessionFile: string } | undefined {
@@ -924,7 +969,14 @@ async function resumeAsyncRun(input: {
 	const parentSessionFile = input.ctx.sessionManager.getSessionFile() ?? null;
 	try {
 		const requestedId = input.params.id ?? input.params.runId;
-		const resolved = requestedId ? resolveSubagentRunId(requestedId, { state: input.deps.state, nested: nestedResolutionScopeForExecutor(input.deps) }) : undefined;
+		let resolved: ResolvedSubagentRunId | undefined;
+		try {
+			resolved = requestedId ? resolveSubagentRunId(requestedId, { state: input.deps.state, nested: nestedResolutionScopeForExecutor(input.deps) }) : undefined;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "";
+			const asyncMatches = message.match(/async:/g)?.length ?? 0;
+			if (!isResumeAmbiguity(error) || !message.includes("foreground:") || asyncMatches !== 1) throw error;
+		}
 		if (resolved?.kind === "nested") {
 			if (attachChain) {
 				return {
@@ -1950,6 +2002,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		timeoutMs: data.timeoutMs,
 		deadlineAt: data.deadlineAt,
 		turnBudget: data.turnBudget,
+		onDetachedExit: (index, result) => updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, index, result }),
 		globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 	});
 
@@ -2036,6 +2089,7 @@ interface ForegroundParallelRunInput {
 	taskTexts: string[];
 	agents: AgentConfig[];
 	ctx: ExtensionContext;
+	state: SubagentState;
 	intercomEvents: IntercomEventBus;
 	signal: AbortSignal;
 	runId: string;
@@ -2237,6 +2291,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			maxSubagentDepth: input.maxSubagentDepths[index],
 			controlConfig: input.controlConfig,
 			onControlEvent: input.onControlEvent,
+			onDetachedExit: (result) => updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, index, result }),
 			intercomSessionName: input.childIntercomTarget?.(task.agent, index),
 			orchestratorIntercomTarget: input.orchestratorIntercomTarget,
 			nestedRoute: input.foregroundControl?.nestedRoute,
@@ -2526,6 +2581,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			taskTexts,
 			agents,
 			ctx,
+			state: deps.state,
 			intercomEvents: deps.pi.events,
 			signal,
 			runId,
@@ -2862,6 +2918,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		skills: effectiveSkills,
 		acceptance: params.acceptance,
 		acceptanceContext: { mode: "single" },
+		onDetachedExit: (result) => updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, index: 0, result }),
 		timeoutMs: data.timeoutMs,
 		deadlineAt,
 		turnBudget: data.turnBudget,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -777,6 +777,13 @@ export interface ForegroundResumeChild {
 	index: number;
 	sessionFile?: string;
 	status: SubagentResultStatus;
+	exitCode?: number;
+	finalOutput?: string;
+	artifactPaths?: ArtifactPaths;
+	transcriptPath?: string;
+	transcriptError?: string;
+	detachedReason?: string;
+	updatedAt?: number;
 }
 
 export interface ForegroundResumeRun {
@@ -877,6 +884,7 @@ export interface RunSyncOptions {
 	intercomEvents?: IntercomEventBus;
 	onUpdate?: (r: import("@earendil-works/pi-agent-core").AgentToolResult<Details>) => void;
 	onControlEvent?: (event: ControlEvent) => void;
+	onDetachedExit?: (result: SingleResult) => void;
 	controlConfig?: ResolvedControlConfig;
 	intercomSessionName?: string;
 	orchestratorIntercomTarget?: string;

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -622,6 +622,180 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		}
 	});
 
+	it("status recovers remembered detached foreground output after child exit", async () => {
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need a decision" })] },
+				{ delay: 50, jsonl: [events.assistantMessage("final recovered answer")] },
+			],
+		});
+		const { executor, events: bus } = makeExecutor({ agents: [makeAgent("a", { systemPrompt: "Intercom orchestration channel:" })] });
+		let detachEmitted = false;
+		const original = await executor.execute(
+			"foreground-detached-status-original",
+			{ agent: "a", task: "ask supervisor" },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ currentTool?: string }> } }) => {
+				if (detachEmitted) return;
+				if (!update.details?.progress?.some((entry) => entry.currentTool === "contact_supervisor")) return;
+				detachEmitted = true;
+				bus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "single-detached-status" });
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(detachEmitted, true);
+		const runId = original.details?.runId;
+		assert.ok(runId, "expected foreground run id");
+		assert.match(original.content[0]?.text ?? "", /Detached for intercom coordination/);
+
+		const deadline = Date.now() + 5000;
+		let statusText = "";
+		while (Date.now() < deadline) {
+			const status = await executor.execute(
+				"foreground-detached-status",
+				{ action: "status", id: runId },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+			statusText = status.content[0]?.text ?? "";
+			if (/final recovered answer/.test(statusText)) break;
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+
+		assert.doesNotMatch(statusText, /Async run not found/);
+		assert.match(statusText, /State: remembered foreground/);
+		assert.match(statusText, /a completed/);
+		assert.match(statusText, /final recovered answer/);
+
+		const transcript = await executor.execute(
+			"foreground-detached-transcript",
+			{ action: "status", id: runId, view: "transcript" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		const transcriptText = transcript.content[0]?.text ?? "";
+		assert.doesNotMatch(transcriptText, /Async run not found/);
+		assert.match(transcriptText, /final recovered answer/);
+	});
+
+	it("status recovers remembered detached chain output after child exit", async () => {
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need a decision" })] },
+				{ delay: 50, jsonl: [events.assistantMessage("chain recovered answer")] },
+			],
+		});
+		const { executor, events: bus } = makeExecutor({ agents: [makeAgent("a", { systemPrompt: "Intercom orchestration channel:" }), makeAgent("b")] });
+		let detachEmitted = false;
+		const original = await executor.execute(
+			"foreground-detached-chain-status-original",
+			{ chain: [{ agent: "a", task: "ask supervisor" }, { agent: "b", task: "must not run" }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ currentTool?: string }> } }) => {
+				if (detachEmitted) return;
+				if (!update.details?.progress?.some((entry) => entry.currentTool === "contact_supervisor")) return;
+				detachEmitted = true;
+				bus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "chain-detached-status" });
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(detachEmitted, true);
+		const runId = original.details?.runId;
+		assert.ok(runId, "expected foreground run id");
+		assert.match(original.content[0]?.text ?? "", /Chain detached for intercom coordination/);
+		assert.equal(mockPi.callCount(), 1);
+
+		const deadline = Date.now() + 5000;
+		let statusText = "";
+		while (Date.now() < deadline) {
+			const status = await executor.execute(
+				"foreground-detached-chain-status",
+				{ action: "status", id: runId },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+			statusText = status.content[0]?.text ?? "";
+			if (/chain recovered answer/.test(statusText)) break;
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+
+		assert.doesNotMatch(statusText, /Async run not found/);
+		assert.match(statusText, /State: remembered foreground/);
+		assert.match(statusText, /a completed/);
+		assert.match(statusText, /chain recovered answer/);
+
+		const transcript = await executor.execute(
+			"foreground-detached-chain-transcript",
+			{ action: "status", id: runId, index: 0, view: "transcript" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.match(transcript.content[0]?.text ?? "", /chain recovered answer/);
+	});
+
+	it("status recovers a later detached serial chain child under its original index", async () => {
+		mockPi.onCall({ output: "first step done" });
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need a decision" })] },
+				{ delay: 200, jsonl: [events.assistantMessage("second recovered answer")] },
+			],
+		});
+		const { executor, events: bus } = makeExecutor({ agents: [makeAgent("a"), makeAgent("b", { systemPrompt: "Intercom orchestration channel:" }), makeAgent("c")] });
+		let detachEmitted = false;
+		const original = await executor.execute(
+			"foreground-later-detached-chain-status-original",
+			{ chain: [{ agent: "a", task: "first" }, { agent: "b", task: "ask supervisor" }, { agent: "c", task: "must not run" }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ currentTool?: string }> } }) => {
+				if (detachEmitted) return;
+				if (!update.details?.progress?.some((entry) => entry.currentTool === "contact_supervisor")) return;
+				detachEmitted = true;
+				bus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "later-chain-detached-status" });
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(detachEmitted, true);
+		const runId = original.details?.runId;
+		assert.ok(runId, "expected foreground run id");
+		assert.match(original.content[0]?.text ?? "", /Chain detached for intercom coordination/);
+		assert.equal(mockPi.callCount(), 2);
+
+		const deadline = Date.now() + 5000;
+		let statusText = "";
+		while (Date.now() < deadline) {
+			const status = await executor.execute(
+				"foreground-later-detached-chain-status",
+				{ action: "status", id: runId },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+			statusText = status.content[0]?.text ?? "";
+			if (/second recovered answer/.test(statusText)) break;
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+
+		assert.doesNotMatch(statusText, /Async run not found/);
+		assert.match(statusText, /State: remembered foreground/);
+		assert.match(statusText, /a completed/);
+		assert.match(statusText, /b completed/);
+		assert.match(statusText, /second recovered answer/);
+
+		const transcript = await executor.execute(
+			"foreground-later-detached-chain-transcript",
+			{ action: "status", id: runId, index: 1, view: "transcript" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.match(transcript.content[0]?.text ?? "", /second recovered answer/);
+	});
+
 	it("resume action rejects detached foreground children that may still be live", async () => {
 		mockPi.onCall({
 			steps: [


### PR DESCRIPTION
Closes #384.

This remembers detached foreground runs, recovers their final child output after process exit, keeps remembered foreground state capped, and handles serial, parallel, and chain detached children with stable indexes.

Validation:
- `node --experimental-strip-types --test test/integration/intercom-result-delivery.test.ts test/integration/chain-execution.test.ts`
- `git diff --check`
- Fresh reviewer: No issues found