### PR TITLE
feat: add subagent tool budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added optional `toolBudget` limits for child subagent tool calls. Runs, steps, and agents can set `{ soft?, hard, block? }`; the child runtime nudges at the soft limit and blocks configured tools after the hard limit so runaway browsing can still finish with final text.
 - Added a stable v1 in-process event-bus RPC for other Pi extensions, with `ping`, `status`, async-only `spawn`, `interrupt`, and async `stop` over versioned request/reply envelopes.
 - Added `toolDescriptionMode` with `full`, `compact`, and `custom` modes for the parent-facing `subagent` tool description. Compact mode reduces prompt bloat while keeping safety-critical orchestration guidance, and invalid custom descriptions fall back to full mode.
 - Added an optional read-only subagent fleet/status view with `/subagents-fleet` and `subagent({ action: "status", view: "fleet" })`, plus `view: "transcript"` to tail active async child output/session artifacts.

--- a/README.md
+++ b/README.md
@@ -1045,7 +1045,7 @@ Agent definitions are not loaded into context by default. Management actions let
 | `outputMode` | `"inline" \| "file-only"` | `inline` | Return saved output inline or as a concise saved-file reference. `file-only` requires an `output` path. |
 | `skill` | `string \| string[] \| false` | agent default | Override skills or disable all. |
 | `model` | string | agent default | Override model. |
-| `tasks` | array | - | Top-level parallel tasks. Supports `agent`, `task`, `cwd`, `count`, `output`, `outputMode`, `reads`, `progress`, `skill`, `model`, and `acceptance`. |
+| `tasks` | array | - | Top-level parallel tasks. Supports `agent`, `task`, `cwd`, `count`, `output`, `outputMode`, `reads`, `progress`, `skill`, `model`, `toolBudget`, and `acceptance`. |
 | `concurrency` | number | config or `4` | Top-level parallel concurrency. |
 | `worktree` | boolean | false | Create isolated git worktrees for parallel tasks. |
 | `chain` | array | - | Sequential, static parallel, and dynamic fanout chain steps. Steps and chain parallel tasks support `phase`, `label`, `as`, `outputSchema`, and `acceptance` in addition to the usual execution fields. Dynamic fanout uses `expand`, one child `parallel` template, and `collect`. With `action: "append-step"`, pass exactly one step to append to a running async chain. |
@@ -1058,6 +1058,7 @@ Agent definitions are not loaded into context by default. Management actions let
 | `async` | boolean | false | Background execution. For chains, `clarify: true` explicitly keeps the run foreground for the clarify UI. |
 | `timeoutMs` / `maxRuntimeMs` | number | none | Optional run-level max runtime in milliseconds for foreground and async/background runs. |
 | `turnBudget` | object | none | Optional assistant-turn budget `{ maxTurns, graceTurns }`. At `maxTurns` the child is warned to wrap up; after `graceTurns` (default 1) more assistant turns the run is aborted and partial output is returned. |
+| `toolBudget` | object | none | Optional child tool-call budget `{ soft?, hard, block? }`. At `soft` the child is nudged to finalize. After `hard`, configured tools are blocked; `block` defaults to `read`, `grep`, `find`, and `ls`, or use `"*"` to block every tool call. Final assistant text is never blocked. |
 | `cwd` | string | runtime cwd | Override working directory. |
 | `maxOutput` | object | 200KB, 5000 lines | Final output truncation limits. |
 | `artifacts` | boolean | true | Write debug artifacts. |
@@ -1070,7 +1071,7 @@ Agent definitions are not loaded into context by default. Management actions let
 
 Use `outputMode: "file-only"` when a saved output may be large and the parent only needs a pointer. The returned text is a compact reference like `Output saved to: /abs/report.md (48.2 KB, 2847 lines). Read this file if needed.` Failed runs and save errors still return normal inline output for debugging. In chains, later `{previous}` steps receive the same compact reference when the prior step used file-only mode.
 
-Sequential and parallel chain tasks accept `agent`, `task`, `phase`, `label`, `as`, `outputSchema`, `cwd`, `output`, `outputMode`, `reads`, `progress`, `skill`, and `model`. Parallel tasks also accept `count`. Parallel step groups accept `parallel`, `concurrency`, `failFast`, and `worktree`. If `outputSchema` is present, the child must call `structured_output` with schema-valid JSON; prose-only completion or invalid JSON fails the step. Validated structured values are preserved on the step result, and `as` also exposes a compact text representation through `{outputs.name}`.
+Sequential and parallel chain tasks accept `agent`, `task`, `phase`, `label`, `as`, `outputSchema`, `cwd`, `output`, `outputMode`, `reads`, `progress`, `skill`, `model`, and `toolBudget`. Parallel tasks also accept `count`. Parallel step groups accept `parallel`, `concurrency`, `failFast`, and `worktree`. If `outputSchema` is present, the child must call `structured_output` with schema-valid JSON; prose-only completion or invalid JSON fails the step. Validated structured values are preserved on the step result, and `as` also exposes a compact text representation through `{outputs.name}`.
 
 Status and control actions:
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -21,7 +21,7 @@ Use this skill when the parent orchestrator needs to launch a specialized subage
 - **Recon and planning**: use `scout` or `context-builder`, then `planner`
 - **Parallel exploration**: run multiple non-conflicting tasks concurrently
 - **Regular skill specialists**: when discovery shows proactive skill subagent suggestions and the current work is broad enough, launch a small fresh-context fanout that asks one subagent per relevant regularly used skill to apply that skill's perspective to the task
-- **Long-running work**: launch async/background runs and inspect them later; use `timeoutMs` or `maxRuntimeMs` when a foreground or async run needs a hard max runtime, or `turnBudget: { maxTurns, graceTurns }` for a soft assistant-turn budget that warns the child to wrap up before aborting
+- **Long-running work**: launch async/background runs and inspect them later; use `timeoutMs` or `maxRuntimeMs` when a foreground or async run needs a hard max runtime, `turnBudget: { maxTurns, graceTurns }` for a soft assistant-turn budget, or `toolBudget: { soft?, hard, block? }` to nudge after a tool-call threshold and then block read/search tools so the child can finalize
 - **Subagent control**: watch needs-attention signals and soft-interrupt only when a delegated run is genuinely blocked
 - **Agent authoring**: create, update, or override agents and chains for a project
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -29,7 +29,8 @@ import {
 import { parseFrontmatter } from "./frontmatter.ts";
 import { toModelInfo } from "../shared/model-info.ts";
 import { resolveSubagentModelOverride, type ParentModel } from "../runs/shared/model-fallback.ts";
-import type { Details, ExtensionConfig } from "../shared/types.ts";
+import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
+import type { Details, ExtensionConfig, ToolBudgetConfig } from "../shared/types.ts";
 import { getProjectConfigDir } from "../shared/utils.ts";
 
 type ManagementAction = "list" | "get" | "models" | "create" | "update" | "delete" | "eject" | "disable" | "enable" | "reset";
@@ -267,6 +268,7 @@ function preservedAgentFrontmatterFields(agent: AgentConfig, cfg: Record<string,
 		changed("completionGuard");
 		if (cfg.completionGuard === true) fields.add("completionGuard");
 	}
+	if (hasKey(cfg, "toolBudget")) changed("toolBudget");
 
 	return fields;
 }
@@ -323,6 +325,11 @@ function parseStepList(raw: unknown): { steps?: ChainStepConfig[]; error?: strin
 		if (hasKey(s, "progress")) {
 			if (typeof s.progress === "boolean") step.progress = s.progress;
 			else return { error: `config.steps[${i}].progress must be a boolean.` };
+		}
+		if (hasKey(s, "toolBudget")) {
+			const validation = validateToolBudgetConfig(s.toolBudget, `config.steps[${i}].toolBudget`);
+			if (validation.error) return { error: validation.error };
+			step.toolBudget = s.toolBudget as ChainStepConfig["toolBudget"];
 		}
 		steps.push(step);
 	}
@@ -435,6 +442,14 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 		if (typeof cfg.completionGuard !== "boolean") return "config.completionGuard must be a boolean when provided.";
 		target.completionGuard = cfg.completionGuard;
 	}
+	if (hasKey(cfg, "toolBudget")) {
+		if (cfg.toolBudget === false || cfg.toolBudget === "") target.toolBudget = undefined;
+		else {
+			const validation = validateToolBudgetConfig(cfg.toolBudget, "config.toolBudget");
+			if (validation.error) return validation.error;
+			target.toolBudget = cfg.toolBudget as ToolBudgetConfig;
+		}
+	}
 	return undefined;
 }
 
@@ -506,6 +521,7 @@ function formatAgentDetail(agent: AgentConfig): string {
 	if (agent.defaultProgress) lines.push("Progress: true");
 	if (agent.maxSubagentDepth !== undefined) lines.push(`Max subagent depth: ${agent.maxSubagentDepth}`);
 	if (agent.completionGuard === false) lines.push("Completion guard: false");
+	if (agent.toolBudget) lines.push(`Tool budget: ${JSON.stringify(agent.toolBudget)}`);
 	if (agent.memory) lines.push(`Memory: ${agent.memory.scope} scope, path: ${agent.memory.path}`);
 	if (agent.systemPrompt.trim()) lines.push("", "System Prompt:", agent.systemPrompt);
 	return lines.join("\n");
@@ -527,6 +543,7 @@ function formatChainStepDetail(step: ChainStepConfig, index: number): string[] {
 		if (typeof parallel?.label === "string") lines.push(`   Label: ${parallel.label}`);
 		if (typeof parallel?.task === "string" && parallel.task.trim()) lines.push(`   Task: ${parallel.task}`);
 		if (parallel?.outputSchema) lines.push("   Structured output: true");
+		if (parallel && "toolBudget" in parallel) lines.push(`   Tool budget: ${JSON.stringify((parallel as { toolBudget?: unknown }).toolBudget)}`);
 		if (collect?.outputSchema) lines.push("   Collect schema: true");
 		if (step.concurrency !== undefined) lines.push(`   Concurrency: ${step.concurrency}`);
 		if (step.failFast !== undefined) lines.push(`   Fail fast: ${step.failFast ? "true" : "false"}`);
@@ -537,6 +554,7 @@ function formatChainStepDetail(step: ChainStepConfig, index: number): string[] {
 	if (step.output === false) lines.push("   Output: false");
 	else if (step.output) lines.push(`   Output: ${step.output}`);
 	if (step.outputMode) lines.push(`   Output mode: ${step.outputMode}`);
+	if (step.toolBudget) lines.push(`   Tool budget: ${JSON.stringify(step.toolBudget)}`);
 	if (step.reads === false) lines.push("   Reads: false");
 	else if (Array.isArray(step.reads) && step.reads.length > 0) lines.push(`   Reads: ${step.reads.join(", ")}`);
 	if (step.model) lines.push(`   Model: ${step.model}`);

--- a/src/agents/agent-serializer.ts
+++ b/src/agents/agent-serializer.ts
@@ -23,6 +23,7 @@ export const KNOWN_FIELDS = new Set([
 	"interactive",
 	"maxSubagentDepth",
 	"completionGuard",
+	"toolBudget",
 	"memory",
 ]);
 
@@ -87,6 +88,9 @@ export function serializeAgent(config: AgentConfig, options: SerializeAgentOptio
 	}
 	if (config.completionGuard === false || preserve("completionGuard")) {
 		lines.push(`completionGuard: ${config.completionGuard === undefined ? "" : config.completionGuard ? "true" : "false"}`);
+	}
+	if (config.toolBudget || preserve("toolBudget")) {
+		lines.push(`toolBudget: ${config.toolBudget ? JSON.stringify(config.toolBudget) : ""}`);
 	}
 
 	if (config.memory) {

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AcceptanceInput, OutputMode } from "../shared/types.ts";
+import type { AcceptanceInput, OutputMode, ToolBudgetConfig } from "../shared/types.ts";
 import { getAgentDir, getProjectConfigDir } from "../shared/utils.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain, parseJsonChain } from "./chain-serializer.ts";
@@ -69,6 +69,7 @@ export interface BuiltinAgentOverrideBase {
 	mcpDirectTools?: string[];
 	subagentOnlyExtensions?: string[];
 	completionGuard?: boolean;
+	toolBudget?: ToolBudgetConfig;
 }
 
 interface BuiltinAgentOverrideConfig {
@@ -85,6 +86,7 @@ interface BuiltinAgentOverrideConfig {
 	tools?: string[] | false;
 	subagentOnlyExtensions?: string[] | false;
 	completionGuard?: boolean;
+	toolBudget?: ToolBudgetConfig | false;
 }
 
 interface BuiltinAgentOverrideInfo {
@@ -126,6 +128,7 @@ export interface AgentConfig {
 	interactive?: boolean;
 	maxSubagentDepth?: number;
 	completionGuard?: boolean;
+	toolBudget?: ToolBudgetConfig;
 	memory?: AgentMemoryConfig;
 	disabled?: boolean;
 	extraFields?: Record<string, string>;
@@ -164,6 +167,7 @@ export interface ChainStepConfig {
 	failFast?: boolean;
 	worktree?: boolean;
 	acceptance?: AcceptanceInput;
+	toolBudget?: ToolBudgetConfig;
 }
 
 export interface ChainConfig {
@@ -497,6 +501,7 @@ function cloneOverrideBase(agent: AgentConfig): BuiltinAgentOverrideBase {
 		mcpDirectTools: agent.mcpDirectTools ? [...agent.mcpDirectTools] : undefined,
 		subagentOnlyExtensions: agent.subagentOnlyExtensions ? [...agent.subagentOnlyExtensions] : undefined,
 		completionGuard: agent.completionGuard,
+		toolBudget: agent.toolBudget,
 	};
 }
 
@@ -517,6 +522,7 @@ function cloneOverrideValue(override: BuiltinAgentOverrideConfig): BuiltinAgentO
 		...(override.tools !== undefined ? { tools: override.tools === false ? false : [...override.tools] } : {}),
 		...(override.subagentOnlyExtensions !== undefined ? { subagentOnlyExtensions: override.subagentOnlyExtensions === false ? false : [...override.subagentOnlyExtensions] } : {}),
 		...(override.completionGuard !== undefined ? { completionGuard: override.completionGuard } : {}),
+		...(override.toolBudget !== undefined ? { toolBudget: override.toolBudget === false ? false : { ...override.toolBudget, ...(Array.isArray(override.toolBudget.block) ? { block: [...override.toolBudget.block] } : {}) } } : {}),
 	};
 }
 
@@ -661,6 +667,16 @@ function parseBuiltinOverrideEntry(
 		}
 	}
 
+	if ("toolBudget" in input) {
+		if (input.toolBudget === false) {
+			override.toolBudget = false;
+		} else if (input.toolBudget && typeof input.toolBudget === "object" && !Array.isArray(input.toolBudget)) {
+			override.toolBudget = input.toolBudget as ToolBudgetConfig;
+		} else {
+			throw new Error(`Builtin override '${name}' in '${filePath}' has invalid 'toolBudget'; expected an object or false.`);
+		}
+	}
+
 	if ("systemPrompt" in input) {
 		if (typeof input.systemPrompt === "string") override.systemPrompt = input.systemPrompt;
 		else throw new Error(`Builtin override '${name}' in '${filePath}' has invalid 'systemPrompt'; expected a string.`);
@@ -782,6 +798,7 @@ function applyBuiltinOverride(
 		next.subagentOnlyExtensions = override.subagentOnlyExtensions === false ? undefined : [...override.subagentOnlyExtensions];
 	}
 	if (override.completionGuard !== undefined) next.completionGuard = override.completionGuard;
+	if (override.toolBudget !== undefined) next.toolBudget = override.toolBudget === false ? undefined : override.toolBudget;
 
 	return next;
 }
@@ -927,6 +944,9 @@ function applyCustomAgentOverride(
 	if (override.completionGuard !== undefined) {
 		fill("completionGuard", ["completionGuard"], override.completionGuard);
 	}
+	if (override.toolBudget !== undefined) {
+		fill("toolBudget", ["toolBudget"], override.toolBudget === false ? undefined : override.toolBudget);
+	}
 
 	if (!anyFilled || !next) return agent;
 	next.override = { ...meta, base: cloneOverrideBase(agent) };
@@ -957,7 +977,7 @@ function applyCustomAgentOverrides(
 
 export function buildBuiltinOverrideConfig(
 	base: BuiltinAgentOverrideBase,
-	draft: Pick<AgentConfig, "model" | "fallbackModels" | "thinking" | "systemPromptMode" | "inheritProjectContext" | "inheritSkills" | "defaultContext" | "disabled" | "systemPrompt" | "skills" | "tools" | "mcpDirectTools" | "subagentOnlyExtensions" | "completionGuard">,
+	draft: Pick<AgentConfig, "model" | "fallbackModels" | "thinking" | "systemPromptMode" | "inheritProjectContext" | "inheritSkills" | "defaultContext" | "disabled" | "systemPrompt" | "skills" | "tools" | "mcpDirectTools" | "subagentOnlyExtensions" | "completionGuard" | "toolBudget">,
 ): BuiltinAgentOverrideConfig | undefined {
 	const override: BuiltinAgentOverrideConfig = {};
 
@@ -981,6 +1001,7 @@ export function buildBuiltinOverrideConfig(
 	if ((draft.completionGuard !== false) !== (base.completionGuard !== false)) {
 		override.completionGuard = draft.completionGuard !== false;
 	}
+	if (JSON.stringify(draft.toolBudget) !== JSON.stringify(base.toolBudget)) override.toolBudget = draft.toolBudget ?? false;
 
 	return Object.keys(override).length > 0 ? override : undefined;
 }
@@ -1239,6 +1260,14 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 		}
 
 		const parsedMaxSubagentDepth = Number(frontmatter.maxSubagentDepth);
+		let toolBudget: ToolBudgetConfig | undefined;
+		if (frontmatter.toolBudget !== undefined && frontmatter.toolBudget.trim()) {
+			const parsed = JSON.parse(frontmatter.toolBudget) as unknown;
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+				throw new Error(`Agent '${localName}' has invalid toolBudget frontmatter; expected a JSON object.`);
+			}
+			toolBudget = parsed as ToolBudgetConfig;
+		}
 		const completionGuard = frontmatter.completionGuard === "false"
 			? false
 			: frontmatter.completionGuard === "true"
@@ -1274,6 +1303,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 					? parsedMaxSubagentDepth
 					: undefined,
 			completionGuard,
+			toolBudget,
 			memory: parseMemoryFrontmatter(frontmatter.memory),
 			extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
 		};

--- a/src/agents/chain-serializer.ts
+++ b/src/agents/chain-serializer.ts
@@ -3,6 +3,7 @@ import { buildRuntimeName, frontmatterNameForConfig, parsePackageName } from "./
 import { parseFrontmatter } from "./frontmatter.ts";
 import { ChainOutputValidationError, validateChainOutputBindings } from "../runs/shared/chain-outputs.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
+import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
 import type { ChainStep } from "../shared/settings.ts";
 import type { AgentSource } from "./agents.ts";
 
@@ -78,6 +79,19 @@ function parseStepBody(agent: string, sectionBody: string): ChainStepConfig {
 		if (key === "progress") {
 			if (rawValue === "true") step.progress = true;
 			else if (rawValue === "false") step.progress = false;
+			continue;
+		}
+		if (key === "toolbudget") {
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(rawValue);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				throw new Error(`Invalid toolBudget in .chain.md step '${agent}': ${message}`);
+			}
+			const validation = validateToolBudgetConfig(parsed, `toolBudget for step '${agent}'`);
+			if (validation.error) throw new Error(validation.error);
+			step.toolBudget = parsed as ChainStepConfig["toolBudget"];
 		}
 	}
 
@@ -125,6 +139,11 @@ export function parseChain(content: string, source: AgentSource, filePath: strin
 	};
 }
 
+function validateJsonChainToolBudget(value: unknown, label: string): void {
+	const validation = validateToolBudgetConfig(value, label);
+	if (validation.error) throw new Error(validation.error);
+}
+
 export function parseJsonChain(content: string, source: AgentSource, filePath: string): ChainConfig {
 	let parsed: unknown;
 	try {
@@ -152,6 +171,7 @@ export function parseJsonChain(content: string, source: AgentSource, filePath: s
 			throw new Error(`JSON chain '${filePath}' step ${i + 1} must be an object.`);
 		}
 		const stepRecord = step as Record<string, unknown>;
+		if (stepRecord.toolBudget !== undefined) validateJsonChainToolBudget(stepRecord.toolBudget, `step ${i + 1} toolBudget`);
 		const acceptanceErrors = validateAcceptanceInput(stepRecord.acceptance, `step ${i + 1} acceptance`);
 		if (acceptanceErrors.length > 0) {
 			throw new Error(`Invalid JSON chain '${filePath}': ${acceptanceErrors.join(" ")}`);
@@ -161,13 +181,17 @@ export function parseJsonChain(content: string, source: AgentSource, filePath: s
 			for (let taskIndex = 0; taskIndex < parallel.length; taskIndex++) {
 				const task = parallel[taskIndex];
 				if (!task || typeof task !== "object" || Array.isArray(task)) continue;
-				const taskErrors = validateAcceptanceInput((task as Record<string, unknown>).acceptance, `step ${i + 1} parallel task ${taskIndex + 1} acceptance`);
+				const taskRecord = task as Record<string, unknown>;
+				if (taskRecord.toolBudget !== undefined) validateJsonChainToolBudget(taskRecord.toolBudget, `step ${i + 1} parallel task ${taskIndex + 1} toolBudget`);
+				const taskErrors = validateAcceptanceInput(taskRecord.acceptance, `step ${i + 1} parallel task ${taskIndex + 1} acceptance`);
 				if (taskErrors.length > 0) {
 					throw new Error(`Invalid JSON chain '${filePath}': ${taskErrors.join(" ")}`);
 				}
 			}
 		} else if (parallel && typeof parallel === "object") {
-			const templateErrors = validateAcceptanceInput((parallel as Record<string, unknown>).acceptance, `step ${i + 1} dynamic template acceptance`);
+			const parallelRecord = parallel as Record<string, unknown>;
+			if (parallelRecord.toolBudget !== undefined) validateJsonChainToolBudget(parallelRecord.toolBudget, `step ${i + 1} dynamic template toolBudget`);
+			const templateErrors = validateAcceptanceInput(parallelRecord.acceptance, `step ${i + 1} dynamic template acceptance`);
 			if (templateErrors.length > 0) {
 				throw new Error(`Invalid JSON chain '${filePath}': ${templateErrors.join(" ")}`);
 			}
@@ -243,6 +267,7 @@ export function serializeChain(config: ChainConfig): string {
 		if (step.skills === false) lines.push("skills: false");
 		else if (Array.isArray(step.skills) && step.skills.length > 0) lines.push(`skills: ${step.skills.join(", ")}`);
 		if (step.progress !== undefined) lines.push(`progress: ${step.progress ? "true" : "false"}`);
+		if (step.toolBudget !== undefined) lines.push(`toolBudget: ${JSON.stringify(step.toolBudget)}`);
 		lines.push("");
 		lines.push(step.task ?? "");
 		if (i < config.steps.length - 1) lines.push("");

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -74,6 +74,24 @@ const AcceptanceOverride = Type.Unsafe({
 	description: "Optional acceptance policy. Omitted means auto-inferred; verified requires configured runtime commands.",
 });
 
+const TurnBudgetOverride = Type.Object({
+	maxTurns: Type.Integer({ minimum: 1 }),
+	graceTurns: Type.Optional(Type.Integer({ minimum: 0 })),
+}, { additionalProperties: false, description: "Optional assistant-turn budget. At maxTurns the child is asked to wrap up; after graceTurns additional assistant turns it is aborted and partial output is returned." });
+
+const ToolBudgetBlock = Type.Unsafe({
+	anyOf: [
+		{ type: "array", minItems: 1, items: { type: "string", minLength: 1 } },
+		{ type: "string", enum: ["*"] },
+	],
+});
+
+const ToolBudgetOverride = Type.Object({
+	soft: Type.Optional(Type.Integer({ minimum: 1 })),
+	hard: Type.Integer({ minimum: 1 }),
+	block: Type.Optional(ToolBudgetBlock),
+}, { additionalProperties: false, description: "Optional child tool-call budget. soft nudges the child; after hard, block tools (default read/grep/find/ls, or '*' for all tools) are blocked so the child can finalize." });
+
 const TaskItem = Type.Object({
 	agent: Type.String(), 
 	task: Type.String(), 
@@ -85,6 +103,7 @@ const TaskItem = Type.Object({
 	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking for this task" })),
 	model: Type.Optional(Type.String({ description: "Override model for this task (e.g. 'google/gemini-3-pro')" })),
 	skill: Type.Optional(SkillOverride),
+	toolBudget: Type.Optional(ToolBudgetOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
 });
 
@@ -104,6 +123,7 @@ const ParallelTaskSchema = Type.Object({
 	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking in {chain_dir}" })),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for this task" })),
+	toolBudget: Type.Optional(ToolBudgetOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
 });
 
@@ -131,6 +151,7 @@ const DynamicParallelTemplateSchema = Type.Object({
 	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking in {chain_dir}" })),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for this task" })),
+	toolBudget: Type.Optional(ToolBudgetOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
 }, { additionalProperties: false });
 
@@ -156,6 +177,7 @@ const ChainItem = Type.Object({
 	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking in {chain_dir}" })),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for this step" })),
+	toolBudget: Type.Optional(ToolBudgetOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
 	parallel: Type.Optional(Type.Unsafe({
 		anyOf: [
@@ -175,11 +197,6 @@ const ChainItem = Type.Object({
 	description: "Chain step: use {agent, task?, ...} for sequential, {parallel: [...]} for static concurrent execution, or {expand, parallel: {...}, collect} for dynamic fanout.",
 	additionalProperties: false,
 });
-
-const TurnBudgetOverride = Type.Object({
-	maxTurns: Type.Integer({ minimum: 1 }),
-	graceTurns: Type.Optional(Type.Integer({ minimum: 0 })),
-}, { additionalProperties: false, description: "Optional assistant-turn budget. At maxTurns the child is asked to wrap up; after graceTurns additional assistant turns it is aborted and partial output is returned." });
 
 const ControlOverrides = Type.Object({
 	enabled: Type.Optional(Type.Boolean({ description: "Enable/disable subagent control attention tracking for this run" })),
@@ -248,6 +265,7 @@ const SubagentParamsSchema = Type.Object({
 	timeoutMs: Type.Optional(Type.Integer({ minimum: 1, description: "Optional run-level timeout in ms for foreground and async/background runs. Alias of maxRuntimeMs." })),
 	maxRuntimeMs: Type.Optional(Type.Integer({ minimum: 1, description: "Alias of timeoutMs for optional run-level timeout in foreground and async/background runs." })),
 	turnBudget: Type.Optional(TurnBudgetOverride),
+	toolBudget: Type.Optional(ToolBudgetOverride),
 	agentScope: Type.Optional(Type.String({ description: "Agent discovery scope: 'user', 'project', or 'both' (default: 'both'; project wins on name collisions)" })),
 	cwd: Type.Optional(Type.String()),
 	artifacts: Type.Optional(Type.Boolean({ description: "Write debug artifacts (default: true)" })),

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -34,6 +34,7 @@ import {
 	type NestedRouteInfo,
 	type ResolvedControlConfig,
 	type ResolvedTurnBudget,
+	type ResolvedToolBudget,
 	type SubagentRunMode,
 	ASYNC_DIR,
 	RESULTS_DIR,
@@ -45,6 +46,7 @@ import {
 } from "../../shared/types.ts";
 import { nestedResultsPath, resolveInheritedNestedRouteFromEnv, resolveNestedParentAddressFromEnv, writeNestedEvent } from "../shared/nested-events.ts";
 import { initialTurnBudgetState } from "../shared/turn-budget.ts";
+import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import type { ImportedAsyncRoot } from "./chain-root-attachment.ts";
 
 const require = createRequire(import.meta.url);
@@ -138,6 +140,8 @@ interface AsyncChainParams {
 	acceptance?: AcceptanceInput;
 	timeoutMs?: number;
 	turnBudget?: ResolvedTurnBudget;
+	toolBudget?: ResolvedToolBudget;
+	configToolBudget?: ResolvedToolBudget;
 	/** Global cap on simultaneously-running subagent tasks within the async run. */
 	globalConcurrencyLimit?: number;
 }
@@ -172,6 +176,8 @@ interface AsyncSingleParams {
 	acceptance?: AcceptanceInput;
 	timeoutMs?: number;
 	turnBudget?: ResolvedTurnBudget;
+	toolBudget?: ResolvedToolBudget;
+	configToolBudget?: ResolvedToolBudget;
 }
 
 interface AsyncExecutionResult {
@@ -199,6 +205,8 @@ export interface AsyncRunnerStepBuildParams {
 	asyncDir: string;
 	outputBaseDir?: string;
 	validateOutputBindings?: boolean;
+	toolBudget?: ResolvedToolBudget;
+	configToolBudget?: ResolvedToolBudget;
 }
 
 export type AsyncRunnerStepBuildResult =
@@ -412,6 +420,9 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 	};
 	const buildSeqStep = (s: SequentialStep, sessionFile?: string, behaviorCwd?: string, progressPrecreated = false, resolvedBehavior?: ResolvedStepBehavior, flatIndex?: number) => {
 		const a = agents.find((x) => x.name === s.agent)!;
+		const toolBudgetInput = s.toolBudget ?? params.toolBudget ?? a.toolBudget ?? params.configToolBudget;
+		const resolvedToolBudget = validateToolBudgetConfig(toolBudgetInput, s.toolBudget ? "toolBudget" : a.toolBudget ? "agent.toolBudget" : "config.toolBudget");
+		if (resolvedToolBudget.error) throw new AsyncStartValidationError(resolvedToolBudget.error);
 		const stepCwd = resolveChildCwd(runnerCwd, s.cwd);
 		const instructionCwd = behaviorCwd ?? stepCwd;
 		const behavior = suppressProgressForReadOnlyTask(resolvedBehavior ?? resolveStepBehavior(a, buildStepOverrides(s), chainSkills), s.task, originalTask);
@@ -485,6 +496,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			}),
 			...(s.outputSchema ? { structuredOutputSchema: s.outputSchema } : {}),
 			...(s.outputSchema ? { structuredOutput: createStructuredOutputRuntime(s.outputSchema, path.join(asyncDir, "structured-output")) } : {}),
+			...(resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}),
 		};
 	};
 
@@ -650,6 +662,8 @@ export function executeAsyncChain(
 		maxSubagentDepth,
 		worktreeBaseDir,
 		asyncDir,
+		toolBudget: params.toolBudget,
+		configToolBudget: params.configToolBudget,
 	});
 	if ("error" in built) {
 		try {
@@ -701,6 +715,7 @@ export function executeAsyncChain(
 				worktreeBaseDir,
 				controlConfig,
 				turnBudget: params.turnBudget,
+				toolBudget: params.toolBudget,
 				controlIntercomTarget,
 				childIntercomTargets,
 				resultMode,
@@ -825,7 +840,7 @@ export function executeAsyncChain(
 
 	return {
 		content: [{ type: "text", text: formatAsyncStartedMessage(`Async ${resultMode}: ${chainDesc} [${id}]`) }],
-		details: { mode: resultMode, runId: id, results: [], asyncId: id, asyncDir, workflowGraph, ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}) },
+		details: { mode: resultMode, runId: id, results: [], asyncId: id, asyncDir, workflowGraph, ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}), ...(params.toolBudget ? { toolBudget: params.toolBudget } : {}) },
 	};
 }
 
@@ -903,6 +918,9 @@ export function executeAsyncSingle(
 	);
 	const effectiveThinking = params.thinkingOverride ?? agentConfig.thinking;
 	const model = applyThinkingSuffix(primaryModel, effectiveThinking, params.thinkingOverride !== undefined);
+	const toolBudgetInput = params.toolBudget ?? agentConfig.toolBudget ?? params.configToolBudget;
+	const resolvedToolBudget = validateToolBudgetConfig(toolBudgetInput, params.toolBudget ? "toolBudget" : agentConfig.toolBudget ? "agent.toolBudget" : "config.toolBudget");
+	if (resolvedToolBudget.error) return formatAsyncStartError("single", resolvedToolBudget.error);
 	const deadlineAt = params.timeoutMs !== undefined ? Date.now() + params.timeoutMs : undefined;
 	const initialTurnBudget = params.turnBudget ? initialTurnBudgetState(params.turnBudget) : undefined;
 	let spawnResult: { pid?: number; error?: string } = {};
@@ -942,6 +960,7 @@ export function executeAsyncSingle(
 							mode: "single",
 							async: true,
 						}),
+						...(resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}),
 					},
 				],
 				resultPath: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : path.join(RESULTS_DIR, `${id}.json`),
@@ -963,6 +982,7 @@ export function executeAsyncSingle(
 				timeoutMs: params.timeoutMs,
 				deadlineAt,
 				turnBudget: params.turnBudget,
+				toolBudget: params.toolBudget,
 				controlIntercomTarget,
 				childIntercomTargets: childIntercomTarget ? [childIntercomTarget(agent, 0)] : undefined,
 				resultMode: "single",
@@ -1040,6 +1060,6 @@ export function executeAsyncSingle(
 
 	return {
 		content: [{ type: "text", text: formatAsyncStartedMessage(`Async: ${agent} [${id}]`) }],
-		details: { mode: "single", runId: id, results: [], asyncId: id, asyncDir, ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}) },
+		details: { mode: "single", runId: id, results: [], asyncId: id, asyncDir, ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}), ...(params.toolBudget ? { toolBudget: params.toolBudget } : {}) },
 	};
 }

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -22,7 +22,9 @@ import {
 	type NestedRunSummary,
 	type ResolvedControlConfig,
 	type ResolvedTurnBudget,
+	type ResolvedToolBudget,
 	type SubagentRunMode,
+	type ToolBudgetState,
 	type TurnBudgetState,
 	type Usage,
 	type WorkflowGraphSnapshot,
@@ -90,6 +92,7 @@ import { acceptanceFailureMessage, aggregateAcceptanceReport, evaluateAcceptance
 import { waitForImportedAsyncRoot } from "./chain-root-attachment.ts";
 import { appendRunnerStepsToStatus, consumeChainAppendRequests, countPendingChainAppendRequests } from "./chain-append.ts";
 import { appendTurnBudgetSystemPrompt, formatTurnBudgetOutput, initialTurnBudgetState, shouldAbortForTurnBudget, turnBudgetExceededMessage, turnBudgetSoftNote, turnBudgetState } from "../shared/turn-budget.ts";
+import { initialToolBudgetState, toolBudgetState } from "../shared/tool-budget.ts";
 
 interface SubagentRunConfig {
 	id: string;
@@ -122,6 +125,7 @@ interface SubagentRunConfig {
 	timeoutMs?: number;
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
+	toolBudget?: ResolvedToolBudget;
 	/** Global cap on simultaneously-running subagent tasks within this run. */
 	globalConcurrencyLimit?: number;
 }
@@ -138,6 +142,8 @@ interface StepResult {
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
+	toolBudget?: ToolBudgetState;
+	toolBudgetBlocked?: boolean;
 	sessionFile?: string;
 	intercomTarget?: string;
 	model?: string;
@@ -344,6 +350,8 @@ interface RunPiStreamingResult {
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
+	toolBudget?: ToolBudgetState;
+	toolBudgetBlocked?: boolean;
 	observedMutationAttempt?: boolean;
 }
 
@@ -793,6 +801,8 @@ async function runSingleStep(
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
+	toolBudget?: ToolBudgetState;
+	toolBudgetBlocked?: boolean;
 	sessionFile?: string;
 	intercomTarget?: string;
 	completionGuardTriggered?: boolean;
@@ -899,6 +909,8 @@ async function runSingleStep(
 	let finalOutputSnapshot: SingleOutputSnapshot | undefined;
 	let completionGuardTriggeredFinal = false;
 	let turnBudget = ctx.turnBudget ? initialTurnBudgetState(ctx.turnBudget) : undefined;
+	let toolBudget = step.toolBudget ? initialToolBudgetState(step.toolBudget) : undefined;
+	let toolBudgetBlocked = false;
 
 	for (let index = 0; index < candidates.length; index++) {
 		if (ctx.timeoutSignal?.aborted || ctx.skipAcceptance?.()) break;
@@ -942,6 +954,7 @@ async function runSingleStep(
 			parentCapabilityToken: ctx.nestedRoute?.capabilityToken,
 			steerInboxDir: ctx.steerInboxDir,
 			structuredOutput: effectiveStructuredOutput,
+			toolBudget: step.toolBudget,
 		});
 		const run = await runPiStreaming(
 			args,
@@ -1036,6 +1049,12 @@ async function runSingleStep(
 		if (candidate) attemptedModels.push(candidate);
 		completionGuardTriggeredFinal = completionGuardTriggered;
 		finalOutputSnapshot = outputSnapshot;
+		if (step.toolBudget) {
+			const toolMessages = run.messages.filter((message) => message.role === "toolResult");
+			const blockedMessage = toolMessages.find((message) => extractTextFromContent(message.content).includes("Tool budget hard limit reached"));
+			toolBudgetBlocked = Boolean(blockedMessage);
+			toolBudget = toolBudgetState(step.toolBudget, toolMessages.length, blockedMessage ? (blockedMessage as { toolName?: string }).toolName : undefined);
+		}
 		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput } as RunPiStreamingResult & { structuredOutput?: unknown };
 		if (run.turnBudgetExceeded) break;
 		if (run.timedOut || ctx.timeoutSignal?.aborted || ctx.skipAcceptance?.()) break;
@@ -1139,6 +1158,8 @@ async function runSingleStep(
 		turnBudget,
 		turnBudgetExceeded: turnBudgetExceeded || undefined,
 		wrapUpRequested: finalResult?.wrapUpRequested || turnBudget?.outcome === "wrap-up-requested" || turnBudgetExceeded || undefined,
+		toolBudget,
+		toolBudgetBlocked: toolBudgetBlocked || undefined,
 		completionGuardTriggered: completionGuardTriggeredFinal,
 		structuredOutput: timedOutAfterAcceptance || turnBudgetExceeded ? undefined : (finalResult as (RunPiStreamingResult & { structuredOutput?: unknown }) | undefined)?.structuredOutput,
 		structuredOutputPath: timedOutAfterAcceptance || turnBudgetExceeded ? undefined : effectiveStructuredOutput?.outputPath,
@@ -1339,6 +1360,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 					outputName: task.outputName,
 					structured: task.structured,
 					status: "pending",
+					...(task.toolBudget ? { toolBudget: initialToolBudgetState(task.toolBudget) } : {}),
 					...(task.sessionFile ? { sessionFile: task.sessionFile } : {}),
 					...(transcriptPath ? { transcriptPath } : {}),
 					skills: task.skills,
@@ -1359,6 +1381,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				outputName: step.collect.as,
 				structured: Boolean(step.collect.outputSchema),
 				status: "pending",
+				...(step.parallel.toolBudget ? { toolBudget: initialToolBudgetState(step.parallel.toolBudget) } : {}),
 				recentTools: [],
 				recentOutput: [],
 			});
@@ -1373,6 +1396,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				outputName: step.outputName,
 				structured: step.structured,
 				status: "pending",
+				...(step.toolBudget ? { toolBudget: initialToolBudgetState(step.toolBudget) } : {}),
 				...(step.sessionFile ? { sessionFile: step.sessionFile } : {}),
 				...(transcriptPath ? { transcriptPath } : {}),
 				skills: step.skills,
@@ -1400,6 +1424,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
 		...(config.deadlineAt !== undefined ? { deadlineAt: config.deadlineAt } : {}),
 		...(config.turnBudget ? { turnBudget: initialTurnBudgetState(config.turnBudget) } : {}),
+		...(config.toolBudget ? { toolBudget: initialToolBudgetState(config.toolBudget) } : {}),
 		pid: process.pid,
 		cwd,
 		currentStep: 0,
@@ -1815,6 +1840,11 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			const mutates = isMutatingTool(event.toolName, event.args);
 			const currentPath = resolveCurrentPath(event.toolName, event.args);
 			step.toolCount = (step.toolCount ?? 0) + 1;
+			const configuredToolBudget = flatSteps[flatIndex]?.toolBudget;
+			if (configuredToolBudget) {
+				step.toolBudget = toolBudgetState(configuredToolBudget, step.toolCount);
+				statusPayload.toolBudget = step.toolBudget;
+			}
 			step.currentTool = event.toolName;
 			step.currentToolArgs = extractToolArgsPreview(event.args ?? {});
 			step.currentToolStartedAt = now;
@@ -1836,6 +1866,15 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			const toolSnapshot = pendingToolResults[flatIndex];
 			pendingToolResults[flatIndex] = undefined;
 			const resultText = extractTextFromContent(event.message.content);
+			if (toolSnapshot && resultText.includes("Tool budget hard limit reached")) {
+				const configuredToolBudget = flatSteps[flatIndex]?.toolBudget;
+				if (configuredToolBudget) {
+					step.toolBudget = toolBudgetState(configuredToolBudget, step.toolCount ?? 0, toolSnapshot.tool);
+					step.toolBudgetBlocked = true;
+					statusPayload.toolBudget = step.toolBudget;
+					statusPayload.toolBudgetBlocked = true;
+				}
+			}
 			appendRecentStepOutput(step, resultText.split("\n").slice(-10));
 			if (toolSnapshot?.mutates && didMutatingToolFail(resultText)) {
 				const state = mutatingFailureStates[flatIndex]!;
@@ -2297,6 +2336,10 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				statusPayload.steps[fi].turnBudget = singleResult.turnBudget;
 				statusPayload.steps[fi].turnBudgetExceeded = singleResult.turnBudgetExceeded;
 				statusPayload.steps[fi].wrapUpRequested = singleResult.wrapUpRequested;
+				statusPayload.steps[fi].toolBudget = singleResult.toolBudget;
+				statusPayload.steps[fi].toolBudgetBlocked = singleResult.toolBudgetBlocked;
+				if (singleResult.toolBudget) statusPayload.toolBudget = singleResult.toolBudget;
+				if (singleResult.toolBudgetBlocked) statusPayload.toolBudgetBlocked = true;
 				if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 				if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 				if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
@@ -2337,6 +2380,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 					turnBudget: pr.turnBudget,
 					turnBudgetExceeded: pr.turnBudgetExceeded,
 					wrapUpRequested: pr.wrapUpRequested,
+					toolBudget: pr.toolBudget,
+					toolBudgetBlocked: pr.toolBudgetBlocked,
 					sessionFile: pr.sessionFile,
 					intercomTarget: pr.intercomTarget,
 					model: pr.model,
@@ -2584,6 +2629,10 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 						statusPayload.steps[fi].turnBudget = singleResult.turnBudget;
 						statusPayload.steps[fi].turnBudgetExceeded = singleResult.turnBudgetExceeded;
 						statusPayload.steps[fi].wrapUpRequested = singleResult.wrapUpRequested;
+						statusPayload.steps[fi].toolBudget = singleResult.toolBudget;
+						statusPayload.steps[fi].toolBudgetBlocked = singleResult.toolBudgetBlocked;
+						if (singleResult.toolBudget) statusPayload.toolBudget = singleResult.toolBudget;
+						if (singleResult.toolBudgetBlocked) statusPayload.toolBudgetBlocked = true;
 						if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 						if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 						if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
@@ -2660,6 +2709,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 						turnBudget: pr.turnBudget,
 						turnBudgetExceeded: pr.turnBudgetExceeded,
 						wrapUpRequested: pr.wrapUpRequested,
+						toolBudget: pr.toolBudget,
+						toolBudgetBlocked: pr.toolBudgetBlocked,
 						sessionFile: pr.sessionFile,
 						intercomTarget: pr.intercomTarget,
 						model: pr.model,
@@ -2788,6 +2839,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				turnBudget: singleResult.turnBudget,
 				turnBudgetExceeded: singleResult.turnBudgetExceeded,
 				wrapUpRequested: singleResult.wrapUpRequested,
+				toolBudget: singleResult.toolBudget,
+				toolBudgetBlocked: singleResult.toolBudgetBlocked,
 			});
 			if (seqStep.outputName) {
 				outputs[seqStep.outputName] = outputEntryFromAsyncResult({
@@ -2829,6 +2882,10 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			statusPayload.steps[flatIndex].turnBudget = singleResult.turnBudget;
 			statusPayload.steps[flatIndex].turnBudgetExceeded = singleResult.turnBudgetExceeded;
 			statusPayload.steps[flatIndex].wrapUpRequested = singleResult.wrapUpRequested;
+			statusPayload.steps[flatIndex].toolBudget = singleResult.toolBudget;
+			statusPayload.steps[flatIndex].toolBudgetBlocked = singleResult.toolBudgetBlocked;
+			if (singleResult.toolBudget) statusPayload.toolBudget = singleResult.toolBudget;
+			if (singleResult.toolBudgetBlocked) statusPayload.toolBudgetBlocked = true;
 			if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 			if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 			if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
@@ -3019,6 +3076,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			...(statusPayload.turnBudget ? { turnBudget: statusPayload.turnBudget } : {}),
 			...(statusPayload.turnBudgetExceeded ? { turnBudgetExceeded: true } : {}),
 			...(statusPayload.wrapUpRequested ? { wrapUpRequested: true } : {}),
+			...(statusPayload.toolBudget ? { toolBudget: statusPayload.toolBudget } : {}),
+			...(statusPayload.toolBudgetBlocked ? { toolBudgetBlocked: true } : {}),
 			...(timedOut ? { timedOut: true, error: timeoutMessage ?? "Subagent timed out." } : turnBudgetExceeded ? { error: statusPayload.error ?? "Subagent exceeded turn budget." } : {}),
 			results: results.map((r) => ({
 				agent: r.agent,
@@ -3031,6 +3090,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				turnBudget: r.turnBudget,
 				turnBudgetExceeded: r.turnBudgetExceeded || undefined,
 				wrapUpRequested: r.wrapUpRequested || undefined,
+				toolBudget: r.toolBudget,
+				toolBudgetBlocked: r.toolBudgetBlocked || undefined,
 				sessionFile: r.sessionFile,
 				intercomTarget: r.intercomTarget,
 				model: r.model,

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -57,7 +57,9 @@ import {
 	type NestedRouteInfo,
 	type ResolvedControlConfig,
 	type ResolvedTurnBudget,
+	type ResolvedToolBudget,
 	type SingleResult,
+	type ToolBudgetConfig,
 	MAX_CONCURRENCY,
 	resolveChildMaxSubagentDepth,
 } from "../../shared/types.ts";
@@ -70,6 +72,7 @@ import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection, type DynamicCollectedResult } from "../shared/dynamic-fanout.ts";
 import { acceptanceFailureMessage, aggregateAcceptanceReport, evaluateAcceptance, resolveEffectiveAcceptance } from "../shared/acceptance.ts";
 import type { ChainOutputMap } from "../../shared/types.ts";
+import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 
 interface ChainExecutionDetailsInput {
 	results: SingleResult[];
@@ -146,6 +149,8 @@ interface ParallelChainRunInput {
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
 	onDetachedExit?: (index: number, result: SingleResult) => void;
+	toolBudget?: ResolvedToolBudget;
+	configToolBudget?: ToolBudgetConfig;
 	globalSemaphore?: Semaphore;
 }
 
@@ -207,6 +212,20 @@ function appendParallelWorktreeSummary(
 	return `${output}\n\n${diffSummary}`;
 }
 
+function resolveChainToolBudget(input: { stepBudget?: ToolBudgetConfig; runBudget?: ResolvedToolBudget; agentBudget?: ToolBudgetConfig; configBudget?: ToolBudgetConfig }): { toolBudget?: ResolvedToolBudget; error?: string } {
+	if (input.stepBudget !== undefined) {
+		const resolved = validateToolBudgetConfig(input.stepBudget, "toolBudget");
+		return { toolBudget: resolved.budget, error: resolved.error };
+	}
+	if (input.runBudget !== undefined) return { toolBudget: input.runBudget };
+	if (input.agentBudget !== undefined) {
+		const resolved = validateToolBudgetConfig(input.agentBudget, "agent.toolBudget");
+		return { toolBudget: resolved.budget, error: resolved.error };
+	}
+	const resolved = validateToolBudgetConfig(input.configBudget, "config.toolBudget");
+	return { toolBudget: resolved.budget, error: resolved.error };
+}
+
 async function runParallelChainTasks(input: ParallelChainRunInput): Promise<SingleResult[]> {
 	const concurrency = input.step.concurrency ?? MAX_CONCURRENCY;
 	const failFast = input.step.failFast ?? false;
@@ -253,6 +272,8 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				{ scope: input.modelScope, source: task.model ? "explicit" : "inherited" },
 			);
 			const maxSubagentDepth = resolveChildMaxSubagentDepth(input.maxSubagentDepth, taskAgentConfig?.maxSubagentDepth);
+			const toolBudget = resolveChainToolBudget({ stepBudget: task.toolBudget, runBudget: input.toolBudget, agentBudget: taskAgentConfig?.toolBudget, configBudget: input.configToolBudget });
+			if (toolBudget.error) throw new Error(toolBudget.error);
 
 			const taskCwd = input.worktreeSetup
 				? input.worktreeSetup.worktrees[taskIndex]!.agentCwd
@@ -317,6 +338,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				onDetachedExit: input.onDetachedExit
 					? (result) => input.onDetachedExit?.(input.globalTaskIndex + taskIndex, result)
 					: undefined,
+				toolBudget: toolBudget.toolBudget,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
 						const stepResults = progressUpdate.details?.results || [];
@@ -427,6 +449,8 @@ interface ChainExecutionParams {
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
 	onDetachedExit?: (index: number, result: SingleResult) => void;
+	toolBudget?: ResolvedToolBudget;
+	configToolBudget?: ToolBudgetConfig;
 	/** Global cap on simultaneously-running tasks within this chain. Defaults to DEFAULT_GLOBAL_CONCURRENCY_LIMIT. */
 	globalConcurrencyLimit?: number;
 }
@@ -718,6 +742,8 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					deadlineAt,
 					turnBudget: params.turnBudget,
 					onDetachedExit,
+					toolBudget: params.toolBudget,
+					configToolBudget: params.configToolBudget,
 					globalSemaphore,
 				});
 				globalTaskIndex += step.parallel.length;
@@ -935,6 +961,8 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				deadlineAt,
 				turnBudget: params.turnBudget,
 				onDetachedExit,
+				toolBudget: params.toolBudget,
+				configToolBudget: params.configToolBudget,
 				globalSemaphore,
 			});
 			globalTaskIndex = dynamicStartIndex + reservedDynamicItems;
@@ -1117,6 +1145,23 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			const structuredRuntime = seqStep.outputSchema
 				? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
 				: undefined;
+			const toolBudget = resolveChainToolBudget({ stepBudget: seqStep.toolBudget, runBudget: params.toolBudget, agentBudget: agentConfig?.toolBudget, configBudget: params.configToolBudget });
+			if (toolBudget.error) return buildChainExecutionErrorResult(toolBudget.error, {
+				results,
+				includeProgress,
+				allProgress,
+				allArtifactPaths,
+				artifactsDir: params.artifactsDir,
+				chainAgents,
+				chainSteps,
+				totalSteps,
+				currentStepIndex: stepIndex,
+				runId: params.runId,
+				outputs,
+				currentFlatIndex: globalTaskIndex,
+				dynamicChildren,
+				dynamicGroupStatuses,
+			});
 			const r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
 				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				cwd: resolveChildCwd(cwd ?? ctx.cwd, seqStep.cwd),
@@ -1155,6 +1200,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				onDetachedExit: onDetachedExit
 					? (result) => onDetachedExit(childIndex, result)
 					: undefined,
+				toolBudget: toolBudget.toolBudget,
 				onUpdate: onUpdate
 					? (p) => {
 						const stepResults = p.details?.results || [];

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -70,6 +70,7 @@ import {
 } from "../shared/long-running-guard.ts";
 import { acceptanceFailureMessage, evaluateAcceptance, formatAcceptancePrompt, resolveEffectiveAcceptance, stripAcceptanceReport } from "../shared/acceptance.ts";
 import { appendTurnBudgetSystemPrompt, formatTurnBudgetOutput, initialTurnBudgetState, shouldAbortForTurnBudget, turnBudgetExceededMessage, turnBudgetSoftNote, turnBudgetState } from "../shared/turn-budget.ts";
+import { initialToolBudgetState, toolBudgetState } from "../shared/tool-budget.ts";
 
 const artifactOutputByResult = new WeakMap<SingleResult, string>();
 const acceptanceOutputByResult = new WeakMap<SingleResult, string>();
@@ -216,6 +217,7 @@ async function runSingleAttempt(
 		parentCapabilityToken: options.nestedRoute?.capabilityToken,
 		parentSessionId: options.parentSessionId,
 		structuredOutput: options.structuredOutput,
+		toolBudget: options.toolBudget,
 	});
 
 	const result: SingleResult = {
@@ -230,6 +232,7 @@ async function runSingleAttempt(
 		skills: shared.resolvedSkillNames,
 		skillsWarning: shared.skillsWarning,
 		...(options.turnBudget ? { turnBudget: initialTurnBudgetState(options.turnBudget) } : {}),
+		...(options.toolBudget ? { toolBudget: initialToolBudgetState(options.toolBudget) } : {}),
 	};
 	const startTime = Date.now();
 	if (options.structuredOutput) {
@@ -592,6 +595,9 @@ async function runSingleAttempt(
 						|| (evt.toolName === "contact_supervisor" && (toolArgs.reason === "need_decision" || toolArgs.reason === "interview_request"));
 				}
 				progress.toolCount++;
+				if (options.toolBudget) {
+					result.toolBudget = toolBudgetState(options.toolBudget, progress.toolCount);
+				}
 				progress.currentTool = evt.toolName;
 				progress.currentToolArgs = extractToolArgsPreview(toolArgs);
 				progress.currentToolStartedAt = now;
@@ -657,6 +663,10 @@ async function runSingleAttempt(
 			if (evt.type === "tool_result_end" && evt.message) {
 				result.messages.push(evt.message);
 				const resultText = extractTextFromContent(evt.message.content);
+				if (options.toolBudget && pendingToolResult && resultText.includes("Tool budget hard limit reached")) {
+					result.toolBudgetBlocked = true;
+					result.toolBudget = toolBudgetState(options.toolBudget, progress.toolCount, pendingToolResult.tool);
+				}
 				appendRecentOutput(progress, resultText.split("\n").slice(-10));
 				const toolSnapshot = pendingToolResult;
 				pendingToolResult = undefined;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -42,6 +42,7 @@ import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBridge, resolveIntercomSessionTarget, resolveSubagentIntercomTarget, type IntercomBridgeState } from "../../intercom/intercom-bridge.ts";
 import { formatControlIntercomMessage, formatControlNoticeMessage, resolveControlConfig, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
 import { DEFAULT_TURN_BUDGET_GRACE_TURNS } from "../shared/turn-budget.ts";
+import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
@@ -87,7 +88,9 @@ import {
 	type NestedRunSummary,
 	type ResolvedControlConfig,
 	type ResolvedTurnBudget,
+	type ResolvedToolBudget,
 	type SingleResult,
+	type ToolBudgetConfig,
 	type TurnBudgetConfig,
 	type SubagentRunMode,
 	type SubagentState,
@@ -120,6 +123,7 @@ interface TaskParam {
 	model?: string;
 	skill?: string | string[] | boolean;
 	acceptance?: AcceptanceInput;
+	toolBudget?: ToolBudgetConfig;
 }
 
 export interface SubagentParamsLike {
@@ -142,6 +146,7 @@ export interface SubagentParamsLike {
 	timeoutMs?: number;
 	maxRuntimeMs?: number;
 	turnBudget?: TurnBudgetConfig;
+	toolBudget?: ToolBudgetConfig;
 	clarify?: boolean;
 	share?: boolean;
 	control?: ControlConfig;
@@ -199,6 +204,8 @@ interface ExecutionContextData {
 	timeoutMs?: number;
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
+	toolBudget?: ResolvedToolBudget;
+	configToolBudget?: ResolvedToolBudget;
 	contextPolicy: AgentDefaultContextPolicy;
 	modelScope?: ModelScopeConfig;
 }
@@ -1515,6 +1522,18 @@ function resolveTurnBudget(params: SubagentParamsLike, config: ExtensionConfig):
 	return { turnBudget: { maxTurns: raw.maxTurns, graceTurns } };
 }
 
+function resolveToolBudget(raw: unknown, label = "toolBudget"): { toolBudget?: ResolvedToolBudget; error?: string } {
+	const resolved = validateToolBudgetConfig(raw, label);
+	return { toolBudget: resolved.budget, error: resolved.error };
+}
+
+function resolveEffectiveToolBudget(input: { stepBudget?: ToolBudgetConfig; runBudget?: ResolvedToolBudget; agentBudget?: ToolBudgetConfig; configBudget?: ToolBudgetConfig }): { toolBudget?: ResolvedToolBudget; error?: string } {
+	if (input.stepBudget !== undefined) return resolveToolBudget(input.stepBudget, "toolBudget");
+	if (input.runBudget !== undefined) return { toolBudget: input.runBudget };
+	if (input.agentBudget !== undefined) return resolveToolBudget(input.agentBudget, "agent.toolBudget");
+	return resolveToolBudget(input.configBudget, "config.toolBudget");
+}
+
 function expandTopLevelTaskCounts(tasks: TaskParam[]): { tasks?: TaskParam[]; error?: string } {
 	const expanded: TaskParam[] = [];
 	for (let taskIndex = 0; taskIndex < tasks.length; taskIndex++) {
@@ -1818,6 +1837,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			...(task.outputMode !== undefined ? { outputMode: task.outputMode } : {}),
 			...(task.reads !== undefined && task.reads !== true ? { reads: task.reads } : {}),
 			...(task.progress !== undefined ? { progress: task.progress } : {}),
+			...(task.toolBudget !== undefined ? { toolBudget: task.toolBudget } : {}),
 			...(task.acceptance !== undefined ? { acceptance: task.acceptance } : {}),
 		}));
 		return executeAsyncChain(id, {
@@ -1849,6 +1869,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			nestedRoute,
 			timeoutMs: data.timeoutMs,
 			turnBudget: data.turnBudget,
+			toolBudget: data.toolBudget,
+			configToolBudget: data.configToolBudget,
 			globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 		});
 	}
@@ -1883,6 +1905,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			nestedRoute,
 			timeoutMs: data.timeoutMs,
 			turnBudget: data.turnBudget,
+			toolBudget: data.toolBudget,
+			configToolBudget: data.configToolBudget,
 			globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 		});
 	}
@@ -1933,6 +1957,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			acceptance: params.acceptance,
 			timeoutMs: data.timeoutMs,
 			turnBudget: data.turnBudget,
+			toolBudget: data.toolBudget,
+			configToolBudget: data.configToolBudget,
 		});
 	}
 
@@ -2003,6 +2029,8 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		deadlineAt: data.deadlineAt,
 		turnBudget: data.turnBudget,
 		onDetachedExit: (index, result) => updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, index, result }),
+		toolBudget: data.toolBudget,
+		configToolBudget: data.configToolBudget,
 		globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 	});
 
@@ -2051,6 +2079,8 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			nestedRoute: data.nestedRoute,
 			timeoutMs: data.timeoutMs,
 			turnBudget: data.turnBudget,
+			toolBudget: data.toolBudget,
+			configToolBudget: data.configToolBudget,
 			globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 		});
 	}
@@ -2124,6 +2154,7 @@ interface ForegroundParallelRunInput {
 	timeoutMs?: number;
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
+	toolBudgets: (ResolvedToolBudget | undefined)[];
 }
 
 function buildParallelModeError(message: string): AgentToolResult<Details> {
@@ -2306,6 +2337,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			timeoutMs: input.timeoutMs,
 			deadlineAt: input.deadlineAt,
 			turnBudget: input.turnBudget,
+			toolBudget: input.toolBudgets[index],
 			onUpdate: input.onUpdate
 				? (progressUpdate) => {
 					const stepResults = progressUpdate.details?.results || [];
@@ -2402,6 +2434,12 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 	const maxSubagentDepths = agentConfigs.map((config) =>
 		resolveChildMaxSubagentDepth(currentMaxSubagentDepth, config.maxSubagentDepth),
 	);
+	const toolBudgets: (ResolvedToolBudget | undefined)[] = [];
+	for (let index = 0; index < tasks.length; index++) {
+		const resolved = resolveEffectiveToolBudget({ stepBudget: tasks[index]?.toolBudget, runBudget: data.toolBudget, agentBudget: agentConfigs[index]?.toolBudget, configBudget: data.configToolBudget });
+		if (resolved.error) return buildParallelModeError(resolved.error);
+		toolBudgets.push(resolved.toolBudget);
+	}
 
 	if (params.worktree) {
 		const worktreeTaskCwdError = buildParallelWorktreeTaskCwdError(tasks, effectiveCwd);
@@ -2501,6 +2539,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 					...(behaviorOverrides[i]?.outputMode !== undefined ? { outputMode: behaviorOverrides[i]!.outputMode } : {}),
 					...(behaviorOverrides[i]?.reads !== undefined ? { reads: behaviorOverrides[i]!.reads } : {}),
 					...(progress !== undefined ? { progress } : {}),
+					...(t.toolBudget !== undefined ? { toolBudget: t.toolBudget } : {}),
 					...(t.acceptance !== undefined ? { acceptance: t.acceptance } : {}),
 				};
 			});
@@ -2616,6 +2655,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			timeoutMs: data.timeoutMs,
 			deadlineAt,
 			turnBudget: data.turnBudget,
+			toolBudgets,
 		});
 		for (let i = 0; i < results.length; i++) {
 			const run = results[i]!;
@@ -2732,6 +2772,8 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			details: { mode: "single", results: [] },
 		};
 	}
+	const effectiveToolBudget = resolveEffectiveToolBudget({ runBudget: data.toolBudget, agentBudget: agentConfig.toolBudget, configBudget: data.configToolBudget });
+	if (effectiveToolBudget.error) return toExecutionErrorResult(params, new Error(effectiveToolBudget.error));
 
 	const currentProvider = ctx.model?.provider;
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
@@ -2828,6 +2870,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				childIntercomTarget: data.intercomBridge.active ? (agent, index) => resolveSubagentIntercomTarget(id, agent, index) : undefined,
 				timeoutMs: data.timeoutMs,
 				turnBudget: data.turnBudget,
+				toolBudget: effectiveToolBudget.toolBudget,
 			});
 		}
 	}
@@ -2922,6 +2965,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		timeoutMs: data.timeoutMs,
 		deadlineAt,
 		turnBudget: data.turnBudget,
+		toolBudget: effectiveToolBudget.toolBudget,
 	});
 	if (foregroundControl?.currentIndex === 0) {
 		foregroundControl.interrupt = undefined;
@@ -2960,6 +3004,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		runId,
 		results: [r],
 		...(data.turnBudget ? { turnBudget: data.turnBudget } : {}),
+		...(effectiveToolBudget.toolBudget ? { toolBudget: effectiveToolBudget.toolBudget } : {}),
 		progress: params.includeProgress ? allProgress : undefined,
 		artifacts: allArtifactPaths.length ? { dir: artifactsDir, files: allArtifactPaths } : undefined,
 		truncation: r.truncation,
@@ -3279,6 +3324,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		if (foregroundTimeout.error) return buildRequestedModeError(effectiveParams, foregroundTimeout.error);
 		const turnBudget = resolveTurnBudget(effectiveParams, deps.config);
 		if (turnBudget.error) return buildRequestedModeError(effectiveParams, turnBudget.error);
+		const runToolBudget = resolveToolBudget(effectiveParams.toolBudget, "toolBudget");
+		if (runToolBudget.error) return buildRequestedModeError(effectiveParams, runToolBudget.error);
+		const configToolBudget = resolveToolBudget(deps.config.toolBudget, "config.toolBudget");
+		if (configToolBudget.error) return buildRequestedModeError(effectiveParams, configToolBudget.error);
 
 		const scope: AgentScope = resolveExecutionAgentScope(effectiveParams.agentScope);
 		const effectiveCwd = effectiveParams.cwd ?? ctx.cwd;
@@ -3414,6 +3463,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			nestedRoute,
 			timeoutMs: foregroundTimeout.timeoutMs,
 			turnBudget: turnBudget.turnBudget,
+			toolBudget: runToolBudget.toolBudget,
+			configToolBudget: configToolBudget.toolBudget,
 			contextPolicy,
 			modelScope,
 		};

--- a/src/runs/shared/dynamic-fanout.ts
+++ b/src/runs/shared/dynamic-fanout.ts
@@ -45,7 +45,7 @@ const DYNAMIC_STEP_KEYS = new Set(["expand", "parallel", "collect", "concurrency
 const RUNNER_DYNAMIC_STEP_KEYS = new Set([...DYNAMIC_STEP_KEYS, "effectiveAcceptance", "sessionFiles", "thinkingOverrides"]);
 const DYNAMIC_EXPAND_KEYS = new Set(["from", "item", "key", "maxItems", "onEmpty"]);
 const DYNAMIC_EXPAND_FROM_KEYS = new Set(["output", "path"]);
-const DYNAMIC_PARALLEL_KEYS = new Set(["agent", "task", "phase", "label", "outputSchema", "cwd", "output", "outputMode", "reads", "progress", "skill", "model", "acceptance"]);
+const DYNAMIC_PARALLEL_KEYS = new Set(["agent", "task", "phase", "label", "outputSchema", "cwd", "output", "outputMode", "reads", "progress", "skill", "model", "toolBudget", "acceptance"]);
 const RUNNER_DYNAMIC_PARALLEL_KEYS = new Set([
 	...DYNAMIC_PARALLEL_KEYS,
 	"outputName", "structured", "inheritProjectContext", "inheritSkills", "skills", "outputPath", "maxSubagentDepth",

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -38,6 +38,7 @@ export interface RunnerSubagentStep {
 	};
 	structuredOutputSchema?: import("../../shared/types.ts").JsonSchemaObject;
 	effectiveAcceptance?: import("../../shared/types.ts").ResolvedAcceptanceConfig;
+	toolBudget?: import("../../shared/types.ts").ResolvedToolBudget;
 }
 
 export interface ParallelStepGroup {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -5,7 +5,8 @@ import { fileURLToPath } from "node:url";
 import { encodeNestedPathEnv, parseNestedPathEnv, type NestedPathEntry } from "./nested-path.ts";
 import { resolveMcpDirectToolNames } from "./mcp-direct-tool-allowlist.ts";
 import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "./structured-output.ts";
-import { TEMP_ROOT_DIR, type JsonSchemaObject } from "../../shared/types.ts";
+import { TEMP_ROOT_DIR, type JsonSchemaObject, type ResolvedToolBudget } from "../../shared/types.ts";
+import { TOOL_BUDGET_ENV, encodeToolBudgetEnv } from "./tool-budget.ts";
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
 const TASK_ARG_LIMIT = 8000;
@@ -69,6 +70,7 @@ interface BuildPiArgsInput {
 		schemaPath: string;
 		outputPath: string;
 	};
+	toolBudget?: ResolvedToolBudget;
 }
 
 interface BuildPiArgsResult {
@@ -249,6 +251,8 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	if (input.steerInboxDir) {
 		env[SUBAGENT_STEER_INBOX_ENV] = input.steerInboxDir;
 	}
+	const encodedToolBudget = encodeToolBudgetEnv(input.toolBudget);
+	if (encodedToolBudget) env[TOOL_BUDGET_ENV] = encodedToolBudget;
 
 	env[SUBAGENT_PARENT_SESSION_ENV] = input.parentSessionId ?? process.env[SUBAGENT_PARENT_SESSION_ENV] ?? "";
 

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -5,7 +5,8 @@ import { registerNativeSupervisorClient } from "../../intercom/native-supervisor
 import { consumeSteerRequestsFromDir, writeSteerRequestToDir, type SteerRequest } from "../background/control-channel.ts";
 import { SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_STEER_INBOX_ENV } from "./pi-args.ts";
 import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV, validateStructuredOutputValue } from "./structured-output.ts";
-import type { JsonSchemaObject } from "../../shared/types.ts";
+import { TOOL_BUDGET_ENV, decodeToolBudgetEnv, shouldBlockToolForBudget, toolBudgetBlockedMessage, toolBudgetSoftNudge } from "./tool-budget.ts";
+import type { JsonSchemaObject, ResolvedToolBudget } from "../../shared/types.ts";
 
 const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
 const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
@@ -167,6 +168,28 @@ export function formatSteerMessage(request: SteerRequest): string {
 	].join("\n");
 }
 
+function registerToolBudget(pi: ExtensionAPI, budget: ResolvedToolBudget | undefined): void {
+	if (!budget) return;
+	let toolCount = 0;
+	let softNudged = false;
+	const sendUserMessage = (pi as { sendUserMessage?: (content: string, options: { deliverAs: "steer" }) => unknown }).sendUserMessage;
+	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: { toolName?: string }) => unknown) => void;
+	onRuntimeEvent("tool_call", (event) => {
+		const toolName = typeof event.toolName === "string" ? event.toolName : "tool";
+		toolCount++;
+		if (budget.soft !== undefined && toolCount >= budget.soft && !softNudged) {
+			softNudged = true;
+			try {
+				sendUserMessage?.(toolBudgetSoftNudge(budget, toolCount), { deliverAs: "steer" });
+			} catch {
+				// Budget nudges are advisory; blocking below remains authoritative.
+			}
+		}
+		if (!shouldBlockToolForBudget(budget, toolName, toolCount)) return undefined;
+		return { block: true, reason: toolBudgetBlockedMessage(budget, toolName, toolCount) };
+	});
+}
+
 function registerSteeringInbox(pi: ExtensionAPI): void {
 	const steerInbox = process.env[SUBAGENT_STEER_INBOX_ENV]?.trim();
 	if (!steerInbox) return;
@@ -237,6 +260,7 @@ function registerSteeringInbox(pi: ExtensionAPI): void {
 
 export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 	registerSteeringInbox(pi);
+	registerToolBudget(pi, decodeToolBudgetEnv(process.env[TOOL_BUDGET_ENV]));
 	registerNativeSupervisorClient(pi);
 	const structuredOutputPath = process.env[STRUCTURED_OUTPUT_CAPTURE_ENV];
 	const structuredSchemaPath = process.env[STRUCTURED_OUTPUT_SCHEMA_ENV];

--- a/src/runs/shared/tool-budget.ts
+++ b/src/runs/shared/tool-budget.ts
@@ -1,0 +1,74 @@
+import type { ResolvedToolBudget, ToolBudgetConfig, ToolBudgetState } from "../../shared/types.ts";
+
+export const DEFAULT_TOOL_BUDGET_BLOCK = ["read", "grep", "find", "ls"] as const;
+export const TOOL_BUDGET_ENV = "PI_SUBAGENT_TOOL_BUDGET";
+
+export function normalizeToolBudgetBlock(block: ToolBudgetConfig["block"] | undefined): "*" | string[] {
+	if (block === "*") return "*";
+	if (block === undefined) return [...DEFAULT_TOOL_BUDGET_BLOCK];
+	return [...new Set(block.map((tool) => tool.trim()).filter(Boolean))];
+}
+
+export function validateToolBudgetConfig(raw: unknown, label = "toolBudget"): { budget?: ResolvedToolBudget; error?: string } {
+	if (raw === undefined) return {};
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return { error: `${label} must be an object with hard and optional soft/block.` };
+	const value = raw as ToolBudgetConfig;
+	if (typeof value.hard !== "number" || !Number.isInteger(value.hard) || value.hard < 1) {
+		return { error: `${label}.hard must be an integer >= 1.` };
+	}
+	if (value.soft !== undefined && (typeof value.soft !== "number" || !Number.isInteger(value.soft) || value.soft < 1)) {
+		return { error: `${label}.soft must be an integer >= 1 when provided.` };
+	}
+	if (value.soft !== undefined && value.soft > value.hard) {
+		return { error: `${label}.soft must be <= ${label}.hard.` };
+	}
+	if (value.block !== undefined && value.block !== "*") {
+		if (!Array.isArray(value.block)) return { error: `${label}.block must be "*" or an array of tool names.` };
+		if (value.block.length === 0) return { error: `${label}.block must contain at least one tool name.` };
+		for (const item of value.block) {
+			if (typeof item !== "string" || !item.trim()) return { error: `${label}.block must contain non-empty tool names.` };
+		}
+	}
+	return { budget: { hard: value.hard, ...(value.soft !== undefined ? { soft: value.soft } : {}), block: normalizeToolBudgetBlock(value.block) } };
+}
+
+export function initialToolBudgetState(budget: ResolvedToolBudget): ToolBudgetState {
+	return { ...budget, toolCount: 0, outcome: "within-budget" };
+}
+
+export function toolBudgetState(budget: ResolvedToolBudget, toolCount: number, blockedTool?: string): ToolBudgetState {
+	const overHard = toolCount > budget.hard;
+	const overSoft = budget.soft !== undefined && toolCount >= budget.soft;
+	return {
+		...budget,
+		toolCount,
+		outcome: overHard ? "hard-blocked" : overSoft ? "soft-reached" : "within-budget",
+		...(overSoft ? { softReachedAt: budget.soft } : {}),
+		...(overHard ? { hardReachedAt: budget.hard, blockedTool } : {}),
+	};
+}
+
+export function shouldBlockToolForBudget(budget: ResolvedToolBudget, toolName: string, nextToolCount: number): boolean {
+	if (nextToolCount <= budget.hard) return false;
+	return budget.block === "*" || budget.block.includes(toolName);
+}
+
+export function toolBudgetSoftNudge(budget: ResolvedToolBudget, toolCount: number): string {
+	return `Tool budget soft limit reached after ${toolCount} tool call${toolCount === 1 ? "" : "s"} (soft ${budget.soft}, hard ${budget.hard}). Stop starting new browsing/search work and finalize from the context you already have.`;
+}
+
+export function toolBudgetBlockedMessage(budget: ResolvedToolBudget, toolName: string, toolCount: number): string {
+	return `Tool budget hard limit reached after ${toolCount} tool call${toolCount === 1 ? "" : "s"} (hard ${budget.hard}). The '${toolName}' tool is blocked so you can finalize from the context you already have.`;
+}
+
+export function encodeToolBudgetEnv(budget: ResolvedToolBudget | undefined): string | undefined {
+	return budget ? JSON.stringify(budget) : undefined;
+}
+
+export function decodeToolBudgetEnv(value: string | undefined): ResolvedToolBudget | undefined {
+	if (!value?.trim()) return undefined;
+	const parsed = JSON.parse(value) as unknown;
+	const normalized = validateToolBudgetConfig(parsed, TOOL_BUDGET_ENV);
+	if (normalized.error) throw new Error(normalized.error);
+	return normalized.budget;
+}

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentConfig } from "../agents/agents.ts";
 import { normalizeSkillInput } from "../agents/skills.ts";
-import { CHAIN_RUNS_DIR, type AcceptanceInput, type JsonSchemaObject, type OutputMode } from "./types.ts";
+import { CHAIN_RUNS_DIR, type AcceptanceInput, type JsonSchemaObject, type OutputMode, type ToolBudgetConfig } from "./types.ts";
 const CHAIN_DIR_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const INITIAL_PROGRESS_CONTENT = "# Progress\n\n## Status\nIn Progress\n\n## Tasks\n\n## Files Changed\n\n## Notes\n";
 
@@ -55,6 +55,7 @@ export interface SequentialStep {
 	progress?: boolean;
 	skill?: string | string[] | false;
 	model?: string;
+	toolBudget?: ToolBudgetConfig;
 	acceptance?: AcceptanceInput;
 }
 
@@ -74,6 +75,7 @@ export interface ParallelTaskItem {
 	progress?: boolean;
 	skill?: string | string[] | false;
 	model?: string;
+	toolBudget?: ToolBudgetConfig;
 	acceptance?: AcceptanceInput;
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -99,6 +99,28 @@ export interface ResolvedTurnBudget {
 	graceTurns: number;
 }
 
+export interface ToolBudgetConfig {
+	soft?: number;
+	hard: number;
+	block?: string[] | "*";
+}
+
+export interface ResolvedToolBudget {
+	soft?: number;
+	hard: number;
+	block: string[] | "*";
+}
+
+export type ToolBudgetOutcome = "within-budget" | "soft-reached" | "hard-blocked";
+
+export interface ToolBudgetState extends ResolvedToolBudget {
+	outcome: ToolBudgetOutcome;
+	toolCount: number;
+	softReachedAt?: number;
+	hardReachedAt?: number;
+	blockedTool?: string;
+}
+
 export type TurnBudgetOutcome = "within-budget" | "wrap-up-requested" | "exceeded";
 
 export interface TurnBudgetState extends ResolvedTurnBudget {
@@ -188,7 +210,7 @@ export type SubagentLifecycleArtifactVersion = typeof SUBAGENT_LIFECYCLE_ARTIFAC
 
 export type PublicNestedStepSummary = Pick<
 	NestedStepSummary,
-	"agent" | "status" | "sessionFile" | "transcriptPath" | "transcriptError" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "startedAt" | "endedAt" | "error" | "timedOut"
+	"agent" | "status" | "sessionFile" | "transcriptPath" | "transcriptError" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "toolBudget" | "toolBudgetBlocked" | "startedAt" | "endedAt" | "error" | "timedOut"
 > & {
 	children?: PublicNestedRunSummary[];
 };
@@ -201,7 +223,7 @@ export type CostSummary = {
 
 export type PublicNestedRunSummary = Pick<
 	NestedRunSummary,
-	"id" | "parentRunId" | "parentStepIndex" | "parentAgent" | "depth" | "path" | "asyncDir" | "sessionId" | "sessionFile" | "intercomTarget" | "ownerIntercomTarget" | "leafIntercomTarget" | "ownerState" | "mode" | "state" | "agent" | "agents" | "currentStep" | "chainStepCount" | "parallelGroups" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "totalTokens" | "totalCost" | "startedAt" | "endedAt" | "lastUpdate" | "error" | "timeoutMs" | "deadlineAt" | "timedOut" | "turnBudget" | "turnBudgetExceeded" | "wrapUpRequested"
+	"id" | "parentRunId" | "parentStepIndex" | "parentAgent" | "depth" | "path" | "asyncDir" | "sessionId" | "sessionFile" | "intercomTarget" | "ownerIntercomTarget" | "leafIntercomTarget" | "ownerState" | "mode" | "state" | "agent" | "agents" | "currentStep" | "chainStepCount" | "parallelGroups" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "toolBudget" | "toolBudgetBlocked" | "totalTokens" | "totalCost" | "startedAt" | "endedAt" | "lastUpdate" | "error" | "timeoutMs" | "deadlineAt" | "timedOut" | "turnBudget" | "turnBudgetExceeded" | "wrapUpRequested"
 > & {
 	steps?: PublicNestedStepSummary[];
 	children?: PublicNestedRunSummary[];
@@ -442,6 +464,8 @@ export interface SingleResult {
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
+	toolBudget?: ToolBudgetState;
+	toolBudgetBlocked?: boolean;
 	messages?: Message[];
 	usage: Usage;
 	model?: string;
@@ -483,6 +507,7 @@ export interface Details {
 	deadlineAt?: number;
 	timedOut?: boolean;
 	turnBudget?: ResolvedTurnBudget;
+	toolBudget?: ResolvedToolBudget;
 	progress?: AgentProgress[];
 	progressSummary?: ProgressSummary;
 	artifacts?: {
@@ -571,6 +596,8 @@ export interface NestedStepSummary {
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
+	toolBudget?: ToolBudgetState;
+	toolBudgetBlocked?: boolean;
 	children?: NestedRunSummary[];
 }
 
@@ -612,6 +639,8 @@ export interface NestedRunSummary extends NestedRunAddress {
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
+	toolBudget?: ToolBudgetState;
+	toolBudgetBlocked?: boolean;
 	error?: string;
 }
 
@@ -666,6 +695,8 @@ export interface AsyncStatus {
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
+	toolBudget?: ToolBudgetState;
+	toolBudgetBlocked?: boolean;
 	pid?: number;
 	cwd?: string;
 	currentStep?: number;
@@ -702,6 +733,8 @@ export interface AsyncStatus {
 		turnBudget?: TurnBudgetState;
 		turnBudgetExceeded?: boolean;
 		wrapUpRequested?: boolean;
+		toolBudget?: ToolBudgetState;
+		toolBudgetBlocked?: boolean;
 		tokens?: TokenUsage;
 		skills?: string[];
 		model?: string;
@@ -763,6 +796,8 @@ export interface AsyncJobState {
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
+	toolBudget?: ToolBudgetState;
+	toolBudgetBlocked?: boolean;
 	sessionDir?: string;
 	outputFile?: string;
 	totalTokens?: TokenUsage;
@@ -880,6 +915,7 @@ export interface RunSyncOptions {
 	timeoutMs?: number;
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
+	toolBudget?: ResolvedToolBudget;
 	allowIntercomDetach?: boolean;
 	intercomEvents?: IntercomEventBus;
 	onUpdate?: (r: import("@earendil-works/pi-agent-core").AgentToolResult<Details>) => void;
@@ -973,6 +1009,7 @@ export interface ExtensionConfig {
 	control?: ControlConfig;
 	completionBatch?: CompletionBatchConfig;
 	turnBudget?: TurnBudgetConfig;
+	toolBudget?: ToolBudgetConfig;
 	parallel?: TopLevelParallelConfig;
 	chain?: ExtensionChainConfig;
 	worktreeSetupHook?: string;

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -114,7 +114,7 @@ Inspect
 `, "utf-8");
 
 		const created = handleCreate(
-			{ config: { name: "Review Flow", package: "Code Analysis", description: "Review flow", scope: "project", steps: [{ agent: "code-analysis.scout", task: "Inspect" }] } },
+			{ config: { name: "Review Flow", package: "Code Analysis", description: "Review flow", scope: "project", steps: [{ agent: "code-analysis.scout", task: "Inspect", toolBudget: { soft: 3, hard: 5, block: ["read"] } }] } },
 			ctx,
 		);
 		assert.equal(created.isError, false);
@@ -124,6 +124,7 @@ Inspect
 		assert.match(content, /^name: review-flow$/m);
 		assert.match(content, /^package: code-analysis$/m);
 		assert.match(content, /^## code-analysis\.scout$/m);
+		assert.match(content, /^toolBudget: \{"soft":3,"hard":5,"block":\["read"\]\}$/m);
 
 		const updated = handleUpdate(
 			{ chainName: "code-analysis.review-flow", config: { package: false } },
@@ -135,6 +136,48 @@ Inspect
 		content = fs.readFileSync(updatedPath, "utf-8");
 		assert.match(content, /^name: review-flow$/m);
 		assert.doesNotMatch(content, /^package:/m);
+	});
+
+	it("creates and updates agents with tool budgets", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+		const result = handleCreate(
+			{ config: { name: "budgeted-reviewer", description: "Review with a budget", scope: "project", toolBudget: { soft: 4, hard: 7, block: ["read", "grep"] } } },
+			ctx,
+		);
+
+		assert.equal(result.isError, false);
+		const filePath = path.join(tempDir, ".pi", "agents", "budgeted-reviewer.md");
+		let content = fs.readFileSync(filePath, "utf-8");
+		assert.match(content, /^toolBudget: \{"soft":4,"hard":7,"block":\["read","grep"\]\}$/m);
+
+		const got = handleManagementAction("get", { agent: "budgeted-reviewer" }, ctx);
+		assert.equal(got.isError, false);
+		assert.match(readText(got), /Tool budget: \{"soft":4,"hard":7,"block":\["read","grep"\]\}/);
+
+		const updated = handleUpdate(
+			{ agent: "budgeted-reviewer", config: { toolBudget: { hard: 3, block: "*" } } },
+			ctx,
+		);
+		assert.equal(updated.isError, false);
+		content = fs.readFileSync(filePath, "utf-8");
+		assert.match(content, /^toolBudget: \{"hard":3,"block":"\*"\}$/m);
+	});
+
+	it("rejects invalid tool budget management config", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+		const agentResult = handleCreate(
+			{ config: { name: "bad-budget", description: "Bad budget", scope: "project", toolBudget: { soft: 5, hard: 4 } } },
+			ctx,
+		);
+		assert.equal(agentResult.isError, true);
+		assert.match(readText(agentResult), /config\.toolBudget\.soft must be <= config\.toolBudget\.hard/);
+
+		const chainResult = handleCreate(
+			{ config: { name: "bad-chain-budget", description: "Bad budget", scope: "project", steps: [{ agent: "reviewer", toolBudget: { hard: 2, block: [] } }] } },
+			ctx,
+		);
+		assert.equal(chainResult.isError, true);
+		assert.match(readText(chainResult), /config\.steps\[0\]\.toolBudget\.block must contain at least one tool name/);
 	});
 
 	it("creates agents with completion guard disabled", () => {
@@ -251,6 +294,7 @@ Drive the failing test first.
 						skills: ["override-skill"],
 						defaultContext: "fork",
 						completionGuard: false,
+						toolBudget: { hard: 3 },
 					},
 				},
 			},
@@ -264,6 +308,7 @@ tools:
 skills:
 defaultContext:
 completionGuard: true
+toolBudget:
 ---
 
 Drive the failing test first.
@@ -289,6 +334,7 @@ Drive the failing test first.
 		assert.match(content, /^skills: ?$/m);
 		assert.match(content, /^defaultContext: ?$/m);
 		assert.match(content, /^completionGuard: true$/m);
+		assert.match(content, /^toolBudget: ?$/m);
 
 		const gotAfter = handleManagementAction("get", { agent: "implementer" }, ctx);
 		assert.equal(gotAfter.isError, false);

--- a/test/unit/async-execution.test.ts
+++ b/test/unit/async-execution.test.ts
@@ -1,7 +1,28 @@
 import assert from "node:assert/strict";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { resolveAsyncRunnerLogPaths } from "../../src/runs/background/async-execution.ts";
+import { buildAsyncRunnerSteps, resolveAsyncRunnerLogPaths } from "../../src/runs/background/async-execution.ts";
+import type { AgentConfig } from "../../src/agents/agents.ts";
+
+const agent = (name: string, toolBudget?: AgentConfig["toolBudget"]): AgentConfig => ({
+	name,
+	description: `${name} agent`,
+	systemPromptMode: "replace",
+	inheritProjectContext: false,
+	inheritSkills: false,
+	systemPrompt: "You are a test agent.",
+	source: "project",
+	filePath: `${name}.md`,
+	...(toolBudget ? { toolBudget } : {}),
+});
+
+const ctx = {
+	cwd: process.cwd(),
+	currentSessionId: "session-1",
+	currentModel: undefined,
+	currentModelProvider: undefined,
+	modelScope: undefined,
+};
 
 describe("async runner execution", () => {
 	it("places detached runner stdio logs in the async run directory", () => {
@@ -14,5 +35,52 @@ describe("async runner execution", () => {
 
 	it("omits runner log paths when asyncDir is unavailable", () => {
 		assert.equal(resolveAsyncRunnerLogPaths({}), undefined);
+	});
+
+	it("resolves async step tool budgets with step over run over agent over config precedence", () => {
+		const result = buildAsyncRunnerSteps("run-1", {
+			chain: [
+				{ agent: "worker", task: "agent beats config" },
+				{ agent: "worker", task: "step beats run", toolBudget: { hard: 2, block: ["grep"] } },
+			],
+			agents: [agent("worker", { hard: 4, block: ["read"] })],
+			ctx,
+			asyncDir: path.join(process.cwd(), ".tmp-async-test"),
+			maxSubagentDepth: 2,
+			toolBudget: { hard: 3, block: ["find"] },
+			configToolBudget: { hard: 5, block: ["ls"] },
+		});
+
+		assert.ok("steps" in result, "expected successful step build");
+		assert.deepEqual(result.steps[0]?.toolBudget, { hard: 3, block: ["find"] });
+		assert.deepEqual(result.steps[1]?.toolBudget, { hard: 2, block: ["grep"] });
+	});
+
+	it("uses agent tool budget before config default when no run override exists", () => {
+		const result = buildAsyncRunnerSteps("run-2", {
+			chain: [{ agent: "worker", task: "agent beats config" }],
+			agents: [agent("worker", { hard: 4, block: ["read"] })],
+			ctx,
+			asyncDir: path.join(process.cwd(), ".tmp-async-test"),
+			maxSubagentDepth: 2,
+			configToolBudget: { hard: 5, block: ["ls"] },
+		});
+
+		assert.ok("steps" in result, "expected successful step build");
+		assert.deepEqual(result.steps[0]?.toolBudget, { hard: 4, block: ["read"] });
+	});
+
+	it("uses config default when no step, run, or agent budget exists", () => {
+		const result = buildAsyncRunnerSteps("run-3", {
+			chain: [{ agent: "worker", task: "config default" }],
+			agents: [agent("worker")],
+			ctx,
+			asyncDir: path.join(process.cwd(), ".tmp-async-test"),
+			maxSubagentDepth: 2,
+			configToolBudget: { hard: 5, block: ["ls"] },
+		});
+
+		assert.ok("steps" in result, "expected successful step build");
+		assert.deepEqual(result.steps[0]?.toolBudget, { hard: 5, block: ["ls"] });
 	});
 });

--- a/test/unit/chain-serializer.test.ts
+++ b/test/unit/chain-serializer.test.ts
@@ -48,6 +48,38 @@ Review the diff
 		assert.match(serialized, /outputSchema: \.\/schemas\/finding\.schema\.json/);
 	});
 
+	it("round-trips markdown chain toolBudget", () => {
+		const parsed = parseChain(`---
+name: review-chain
+description: Review chain
+---
+
+## reviewer
+toolBudget: {"soft":3,"hard":5,"block":["read","grep"]}
+
+Review the diff
+`, "project", "/tmp/review-chain.md");
+
+		assert.deepEqual(parsed.steps[0]?.toolBudget, { soft: 3, hard: 5, block: ["read", "grep"] });
+		assert.match(serializeChain(parsed), /toolBudget: \{"soft":3,"hard":5,"block":\["read","grep"\]\}/);
+	});
+
+	it("rejects invalid markdown chain toolBudget", () => {
+		assert.throws(
+			() => parseChain(`---
+name: review-chain
+description: Review chain
+---
+
+## reviewer
+toolBudget: {"soft":6,"hard":5}
+
+Review the diff
+`, "project", "/tmp/review-chain.md"),
+			/toolBudget for step 'reviewer'\.soft must be <= toolBudget for step 'reviewer'\.hard/,
+		);
+	});
+
 	it("rejects inline outputSchema values in markdown chains", () => {
 		assert.throws(
 			() => parseChain(`---
@@ -107,6 +139,46 @@ Review the diff
 		assert.equal(reparsed.name, "dynamic-review");
 		assert.equal(reparsed.package, "code-analysis");
 		assert.equal(reparsed.chain?.[1]?.collect?.as, "reviews");
+	});
+
+	it("parses declarative JSON chains with dynamic fanout toolBudget", () => {
+		const parsed = parseJsonChain(JSON.stringify({
+			name: "dynamic-review",
+			description: "Review dynamic targets",
+			chain: [
+				{ agent: "scout", task: "Return targets", as: "targets", outputSchema: { type: "object" }, toolBudget: { hard: 4 } },
+				{
+					expand: { from: { output: "targets", path: "/items" }, item: "target", key: "/path", maxItems: 4 },
+					parallel: { agent: "reviewer", task: "Review {target.path}", outputSchema: { type: "object" }, toolBudget: { soft: 3, hard: 5 } },
+					collect: { as: "reviews" },
+				},
+			],
+		}), "project", "/tmp/dynamic-review.chain.json");
+
+		assert.deepEqual((parsed.steps[0] as { toolBudget?: unknown }).toolBudget, { hard: 4 });
+		assert.deepEqual((parsed.steps[1] as { parallel?: { toolBudget?: unknown } }).parallel?.toolBudget, { soft: 3, hard: 5 });
+	});
+
+	it("rejects invalid JSON chain toolBudget", () => {
+		assert.throws(
+			() => parseJsonChain(JSON.stringify({
+				name: "bad-tool-budget",
+				description: "Bad tool budget",
+				chain: [{ agent: "worker", toolBudget: { hard: 0 } }],
+			}), "project", "/tmp/bad-tool-budget.chain.json"),
+			/step 1 toolBudget\.hard must be an integer >= 1/,
+		);
+		assert.throws(
+			() => parseJsonChain(JSON.stringify({
+				name: "bad-dynamic-tool-budget",
+				description: "Bad dynamic tool budget",
+				chain: [
+					{ agent: "scout", task: "Return targets", as: "targets", outputSchema: { type: "object" } },
+					{ expand: { from: { output: "targets", path: "/items" }, maxItems: 4 }, parallel: { agent: "worker", toolBudget: { hard: 3, block: [] } }, collect: { as: "reviews" } },
+				],
+			}), "project", "/tmp/bad-dynamic-tool-budget.chain.json"),
+			/step 2 dynamic template toolBudget\.block must contain at least one tool name/,
+		);
 	});
 
 	it("parses declarative JSON chains with dynamic fanout", () => {

--- a/test/unit/dynamic-fanout.test.ts
+++ b/test/unit/dynamic-fanout.test.ts
@@ -139,6 +139,16 @@ describe("dynamic fanout helpers", () => {
 		);
 	});
 
+	it("accepts toolBudget on dynamic parallel templates", () => {
+		const step = {
+			expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+			parallel: { agent: "reviewer", task: "Review {item.path}", toolBudget: { hard: 3 } },
+			collect: { as: "reviews" },
+		} as unknown as Parameters<typeof validateDynamicStepShape>[0];
+
+		assert.doesNotThrow(() => validateDynamicStepShape(step, 1));
+	});
+
 	it("validates source ordering and collect name collisions", () => {
 		const chain: ChainStep[] = [
 			{ agent: "scout", task: "Return targets", as: "targets", outputSchema: { type: "object" } },

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { computeMcpServerHash } from "../../src/runs/shared/mcp-direct-tool-allowlist.ts";
+import { TOOL_BUDGET_ENV } from "../../src/runs/shared/tool-budget.ts";
 import {
 	SUBAGENT_FANOUT_CHILD_ENV,
 	SUBAGENT_PARENT_CHILD_INDEX_ENV,
@@ -311,6 +312,19 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env.PI_SUBAGENT_CHILD, "1");
 		assert.equal(env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT, "0");
 		assert.equal(env.PI_SUBAGENT_INHERIT_SKILLS, "1");
+	});
+
+	it("passes tool budget through env", () => {
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			toolBudget: { soft: 2, hard: 3, block: ["read"] },
+		});
+
+		assert.deepEqual(JSON.parse(env[TOOL_BUDGET_ENV] ?? "{}"), { soft: 2, hard: 3, block: ["read"] });
 	});
 
 	it("passes child intercom and orchestrator metadata through env", () => {

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -190,6 +190,7 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		const timeoutSchema = SubagentParams?.properties?.timeoutMs;
 		const maxRuntimeSchema = SubagentParams?.properties?.maxRuntimeMs;
 		const turnBudgetSchema = SubagentParams?.properties?.turnBudget;
+		const toolBudgetSchema = SubagentParams?.properties?.toolBudget;
 		assert.ok(timeoutSchema, "timeoutMs schema should exist");
 		assert.ok(maxRuntimeSchema, "maxRuntimeMs schema should exist");
 		assert.equal(timeoutSchema.minimum, 1);
@@ -200,6 +201,8 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		assert.match(String(maxRuntimeSchema.description ?? ""), /foreground and async\/background/i);
 		assert.equal(turnBudgetSchema?.properties?.maxTurns?.minimum, 1);
 		assert.equal(turnBudgetSchema?.properties?.graceTurns?.minimum, 0);
+		assert.equal(toolBudgetSchema?.properties?.soft?.minimum, 1);
+		assert.equal(toolBudgetSchema?.properties?.hard?.minimum, 1);
 	});
 
 	it("includes subagent control fields", () => {
@@ -506,6 +509,11 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 			{ agent: "worker", task: "Fix", turnBudget: { maxTurns: 5, graceTurns: 1 } },
 			{ agent: "worker", task: "Fix", turnBudget: { maxTurns: 1 } },
 			{ agent: "worker", task: "Fix", turnBudget: { maxTurns: 3, graceTurns: 0 } },
+			{ agent: "worker", task: "Fix", toolBudget: { soft: 5, hard: 8, block: ["read", "grep"] } },
+			{ agent: "worker", task: "Fix", toolBudget: { hard: 8, block: "*" } },
+			{ tasks: [{ agent: "worker", task: "Fix", toolBudget: { hard: 3 } }] },
+			{ chain: [{ agent: "worker", toolBudget: { hard: 3 } }] },
+			{ chain: [{ parallel: [{ agent: "worker", toolBudget: { hard: 3 } }] }] },
 		];
 		const invalidValues = [
 			{ skill: 123 },
@@ -532,6 +540,11 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 			{ agent: "worker", task: "Fix", turnBudget: { maxTurns: 1.5 } },
 			{ agent: "worker", task: "Fix", turnBudget: { graceTurns: 1 } },
 			{ agent: "worker", task: "Fix", turnBudget: { maxTurns: 5, graceTurns: 1, extra: true } },
+			{ agent: "worker", task: "Fix", toolBudget: { hard: 0 } },
+			{ agent: "worker", task: "Fix", toolBudget: { hard: 3, soft: 0 } },
+			{ agent: "worker", task: "Fix", toolBudget: { hard: 3, block: [123] } },
+			{ agent: "worker", task: "Fix", toolBudget: { hard: 3, block: [] } },
+			{ agent: "worker", task: "Fix", toolBudget: { hard: 3, block: "read" } },
 		];
 
 		for (const value of validValues) {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, it } from "node:test";
 import { writeSteerRequestToDir } from "../../src/runs/background/control-channel.ts";
 import { SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_STEER_INBOX_ENV } from "../../src/runs/shared/pi-args.ts";
 import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "../../src/runs/shared/structured-output.ts";
+import { TOOL_BUDGET_ENV } from "../../src/runs/shared/tool-budget.ts";
 import registerSubagentPromptRuntime, {
 	CHILD_FANOUT_BOUNDARY_INSTRUCTIONS,
 	CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS,
@@ -25,6 +26,7 @@ const envSnapshot = {
 	PI_SUBAGENT_STEER_INBOX: process.env.PI_SUBAGENT_STEER_INBOX,
 	PI_SUBAGENT_STRUCTURED_OUTPUT_CAPTURE: process.env.PI_SUBAGENT_STRUCTURED_OUTPUT_CAPTURE,
 	PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA: process.env.PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA,
+	PI_SUBAGENT_TOOL_BUDGET: process.env.PI_SUBAGENT_TOOL_BUDGET,
 };
 
 const SKILLS_SECTION = "\n\nThe following skills provide specialized instructions for specific tasks.\nUse the read tool to load a skill's file when the task matches its description.\nWhen a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.\n\n<available_skills>\n  <skill>\n    <name>safe-bash</name>\n    <description>desc</description>\n    <location>/tmp/SKILL.md</location>\n  </skill>\n  <skill>\n    <name>pi-subagents</name>\n    <description>delegate to subagents</description>\n    <location>/tmp/pi-subagents/SKILL.md</location>\n  </skill>\n</available_skills>";
@@ -61,9 +63,38 @@ afterEach(() => {
 	else process.env[STRUCTURED_OUTPUT_CAPTURE_ENV] = envSnapshot.PI_SUBAGENT_STRUCTURED_OUTPUT_CAPTURE;
 	if (envSnapshot.PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA === undefined) delete process.env[STRUCTURED_OUTPUT_SCHEMA_ENV];
 	else process.env[STRUCTURED_OUTPUT_SCHEMA_ENV] = envSnapshot.PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA;
+	if (envSnapshot.PI_SUBAGENT_TOOL_BUDGET === undefined) delete process.env[TOOL_BUDGET_ENV];
+	else process.env[TOOL_BUDGET_ENV] = envSnapshot.PI_SUBAGENT_TOOL_BUDGET;
 });
 
 describe("subagent prompt runtime", () => {
+	it("nudges after the tool budget soft limit and blocks configured tools after hard", () => {
+		const handlers = new Map<string, (payload: { toolName?: string }) => unknown>();
+		const sent: string[] = [];
+		process.env[TOOL_BUDGET_ENV] = JSON.stringify({ soft: 2, hard: 2, block: ["read"] });
+
+		registerSubagentPromptRuntime({
+			on(event: string, handler: (payload: { toolName?: string }) => unknown) {
+				handlers.set(event, handler);
+			},
+			sendUserMessage(content: string) {
+				sent.push(content);
+			},
+		} as { on(event: string, handler: (payload: { toolName?: string }) => unknown): void; sendUserMessage(content: string): void });
+
+		const toolCall = handlers.get("tool_call");
+		assert.ok(toolCall, "tool_call handler should be registered");
+		assert.equal(toolCall({ toolName: "grep" }), undefined);
+		assert.equal(toolCall({ toolName: "grep" }), undefined);
+		assert.equal(sent.length, 1);
+		assert.match(sent[0] ?? "", /soft limit reached/);
+		assert.deepEqual(toolCall({ toolName: "read" }), {
+			block: true,
+			reason: "Tool budget hard limit reached after 3 tool calls (hard 2). The 'read' tool is blocked so you can finalize from the context you already have.",
+		});
+		assert.equal(toolCall({ toolName: "write" }), undefined);
+	});
+
 	it("delivers steering inbox requests as mid-run user messages", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-steering-runtime-"));
 		try {

--- a/test/unit/tool-budget.test.ts
+++ b/test/unit/tool-budget.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	DEFAULT_TOOL_BUDGET_BLOCK,
+	decodeToolBudgetEnv,
+	encodeToolBudgetEnv,
+	initialToolBudgetState,
+	shouldBlockToolForBudget,
+	toolBudgetBlockedMessage,
+	toolBudgetSoftNudge,
+	toolBudgetState,
+	validateToolBudgetConfig,
+} from "../../src/runs/shared/tool-budget.ts";
+
+describe("tool-budget module", () => {
+	it("defaults block tools to read/search tools", () => {
+		const resolved = validateToolBudgetConfig({ hard: 5 });
+		assert.deepEqual(resolved.budget, { hard: 5, block: [...DEFAULT_TOOL_BUDGET_BLOCK] });
+	});
+
+	it("accepts soft and wildcard block", () => {
+		const resolved = validateToolBudgetConfig({ soft: 2, hard: 4, block: "*" });
+		assert.deepEqual(resolved.budget, { soft: 2, hard: 4, block: "*" });
+	});
+
+	it("rejects unsafe configs", () => {
+		assert.equal(validateToolBudgetConfig({ hard: 0 }).error, "toolBudget.hard must be an integer >= 1.");
+		assert.equal(validateToolBudgetConfig({ soft: 5, hard: 4 }).error, "toolBudget.soft must be <= toolBudget.hard.");
+		assert.equal(validateToolBudgetConfig({ hard: 4, block: [] }).error, "toolBudget.block must contain at least one tool name.");
+		assert.equal(validateToolBudgetConfig({ hard: 4, block: [""] }).error, "toolBudget.block must contain non-empty tool names.");
+	});
+
+	it("serializes and decodes env config", () => {
+		const budget = { soft: 2, hard: 4, block: ["read"] };
+		assert.deepEqual(decodeToolBudgetEnv(encodeToolBudgetEnv(budget)), budget);
+	});
+
+	it("tracks state and block decisions", () => {
+		const budget = { soft: 2, hard: 3, block: ["read"] };
+		assert.deepEqual(initialToolBudgetState(budget), { soft: 2, hard: 3, block: ["read"], toolCount: 0, outcome: "within-budget" });
+		assert.equal(toolBudgetState(budget, 2).outcome, "soft-reached");
+		assert.equal(toolBudgetState(budget, 4, "read").outcome, "hard-blocked");
+		assert.equal(shouldBlockToolForBudget(budget, "read", 4), true);
+		assert.equal(shouldBlockToolForBudget(budget, "write", 4), false);
+	});
+
+	it("formats user-facing budget messages", () => {
+		const budget = { soft: 2, hard: 3, block: ["read"] };
+		assert.match(toolBudgetSoftNudge(budget, 2), /soft limit reached after 2 tool calls/);
+		assert.match(toolBudgetBlockedMessage(budget, "read", 4), /'read' tool is blocked/);
+	});
+});


### PR DESCRIPTION
Closes #379.

This adds optional core `toolBudget` support with precedence from step/task override to run override to agent/default config. Child runtime nudges at the soft threshold and blocks configured tools after the hard threshold while allowing final assistant text. The budget is supported in schemas, settings, agent frontmatter, chain JSON/markdown, dynamic fanout templates, and management create/update flows.

Validation:
- `npm run test:unit`
- `node --experimental-strip-types --test test/unit/agent-management.test.ts test/unit/chain-serializer.test.ts test/unit/dynamic-fanout.test.ts test/unit/tool-budget.test.ts`
- `git diff --check`
- Fresh reviewer: No issues found