### PR TITLE
Fix stale supervisor intercom asks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Suppress stale native supervisor-channel asks after replies, expiry, or inactive child runs, and clean cancelled child requests so `subagent_supervisor` and visible intercom notices stay aligned.
+
 ## [0.33.1] - 2026-07-03
 
 ### Fixed

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -29,6 +29,7 @@ interface SupervisorRequest {
 	type: "subagent.supervisor.request";
 	id: string;
 	createdAt: number;
+	expiresAt?: number;
 	reason: SupervisorReason;
 	message: string;
 	expectsReply: boolean;
@@ -203,9 +204,8 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
 	});
 }
 
-async function waitForReply(channelDir: string, requestId: string, signal?: AbortSignal): Promise<SupervisorReply> {
+async function waitForReply(channelDir: string, requestId: string, deadline: number, signal?: AbortSignal): Promise<SupervisorReply> {
 	const file = replyPath(channelDir, requestId);
-	const deadline = Date.now() + askTimeoutMs();
 	while (Date.now() <= deadline) {
 		if (signal?.aborted) throw new Error("Supervisor request cancelled.");
 		if (fs.existsSync(file)) {
@@ -228,11 +228,15 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: A
 	ensureSupervisorChannelDir(metadata.channelDir);
 	const requestId = randomUUID();
 	const expectsReply = params.reason !== "progress_update";
+	const createdAt = Date.now();
+	const replyDeadline = createdAt + askTimeoutMs();
+	const expiresAt = expectsReply ? replyDeadline : undefined;
 	const message = formatChildMessage({ ...metadata, reason: params.reason, message: params.message, interview: params.interview });
 	const request: SupervisorRequest = {
 		type: "subagent.supervisor.request",
 		id: requestId,
-		createdAt: Date.now(),
+		createdAt,
+		...(expiresAt !== undefined ? { expiresAt } : {}),
 		reason: params.reason,
 		message,
 		expectsReply,
@@ -255,17 +259,22 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: A
 		};
 	}
 
-	const reply = await waitForReply(metadata.channelDir, requestId, signal);
-	const details: Record<string, unknown> = { requestId, reason: params.reason };
-	if (params.reason === "interview_request") {
-		const structured = parseStructuredReply(reply.message);
-		if (structured.error) details.structuredReplyParseError = structured.error;
-		else details.structuredReply = structured.value;
+	try {
+		const reply = await waitForReply(metadata.channelDir, requestId, replyDeadline, signal);
+		const details: Record<string, unknown> = { requestId, reason: params.reason };
+		if (params.reason === "interview_request") {
+			const structured = parseStructuredReply(reply.message);
+			if (structured.error) details.structuredReplyParseError = structured.error;
+			else details.structuredReply = structured.value;
+		}
+		return {
+			content: [{ type: "text", text: `**Reply from supervisor:**\n${reply.message}` }],
+			details,
+		};
+	} catch (error) {
+		removeRequestFile(requestPath(metadata.channelDir, requestId));
+		throw error;
 	}
-	return {
-		content: [{ type: "text", text: `**Reply from supervisor:**\n${reply.message}` }],
-		details,
-	};
 }
 
 function hasTool(pi: ExtensionAPI, name: string): boolean {
@@ -365,6 +374,59 @@ function requestMatchesContext(request: SupervisorRequest, state: Pick<SubagentS
 	return Boolean(currentSessionId && request.orchestratorSessionId === currentSessionId);
 }
 
+function removeRequestFile(file: string): void {
+	try {
+		fs.rmSync(file, { force: true });
+	} catch {
+		// Request cleanup is best-effort; reply files and timeout errors remain authoritative.
+	}
+}
+
+type SupervisorRequestLifecycle = "pending" | "resolved" | "expired" | "inactive" | "missing" | "wrong-session";
+
+function requestExpiresAt(request: SupervisorRequest, now: number): number {
+	const expiresAt = (request as { expiresAt?: unknown }).expiresAt;
+	if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) return expiresAt;
+	return Number.isFinite(request.createdAt) ? request.createdAt + askTimeoutMs() : now;
+}
+
+function requestRunInactive(request: SupervisorRequest, state: SubagentState): boolean {
+	if (state.foregroundControls.has(request.runId)) return false;
+	const foregroundRun = state.foregroundRuns?.get(request.runId);
+	const foregroundChild = foregroundRun?.children.find((child) => child.index === request.childIndex && child.agent === request.agent)
+		?? foregroundRun?.children[request.childIndex];
+	if (foregroundChild) return foregroundChild.status !== "detached";
+
+	const asyncJob = state.asyncJobs.get(request.runId);
+	if (!asyncJob) return false;
+	if (asyncJob.status === "complete" || asyncJob.status === "failed" || asyncJob.status === "paused") return true;
+	const stepStatus = asyncJob.steps?.[request.childIndex]?.status;
+	return stepStatus === "complete" || stepStatus === "completed" || stepStatus === "failed" || stepStatus === "paused";
+}
+
+function requestLifecycle(request: PendingSupervisorRequest, state: SubagentState, ctx: ExtensionContext | undefined, now: number): SupervisorRequestLifecycle {
+	if (ctx && !requestMatchesContext(request, state, ctx)) return "wrong-session";
+	if (!fs.existsSync(request.requestFile)) return "missing";
+	if (request.expectsReply && fs.existsSync(replyPath(request.channelDir, request.id))) return "resolved";
+	if (request.expectsReply && now > requestExpiresAt(request, now)) return "expired";
+	if (request.expectsReply && requestRunInactive(request, state)) return "inactive";
+	return "pending";
+}
+
+function cleanupRequestLifecycle(request: PendingSupervisorRequest, lifecycle: SupervisorRequestLifecycle): void {
+	if (lifecycle === "resolved" || lifecycle === "expired" || lifecycle === "inactive") removeRequestFile(request.requestFile);
+}
+
+function refreshPendingRequests(pending: Map<string, PendingSupervisorRequest>, state: SubagentState, ctx: ExtensionContext | undefined): void {
+	const now = Date.now();
+	for (const request of pending.values()) {
+		const lifecycle = requestLifecycle(request, state, ctx, now);
+		if (lifecycle === "pending") continue;
+		pending.delete(request.id);
+		cleanupRequestLifecycle(request, lifecycle);
+	}
+}
+
 function formatPendingLine(request: PendingSupervisorRequest): string {
 	const replyHint = request.expectsReply ? ` Reply: ${NATIVE_SUPERVISOR_TOOL_NAME}({ action: "reply", replyTo: "${request.id}", message: "..." })` : "";
 	return `- ${request.id}: ${request.agent} [${request.runId}#${request.childIndex}] ${request.reason}.${replyHint}`;
@@ -387,11 +449,7 @@ function writeReply(request: PendingSupervisorRequest, message: string): void {
 		message: message.trim(),
 	};
 	writeAtomicJson(replyPath(request.channelDir, request.id), reply);
-	try {
-		fs.rmSync(request.requestFile, { force: true });
-	} catch {
-		// Best effort: the reply file is authoritative for the child.
-	}
+	removeRequestFile(request.requestFile);
 }
 
 function resolvePendingRequest(pending: Map<string, PendingSupervisorRequest>, params: IntercomParams): PendingSupervisorRequest {
@@ -427,7 +485,7 @@ function publicPendingRequests(pending: Map<string, PendingSupervisorRequest>): 
 	}));
 }
 
-function buildParentIntercomTool(pending: Map<string, PendingSupervisorRequest>, name = "intercom"): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
+function buildParentIntercomTool(pending: Map<string, PendingSupervisorRequest>, state: SubagentState, name = "intercom"): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
 	return {
 		name,
 		label: name === "intercom" ? "Intercom" : "Subagent Supervisor",
@@ -436,6 +494,7 @@ function buildParentIntercomTool(pending: Map<string, PendingSupervisorRequest>,
 			: "Native pi-subagents supervisor channel. Use reply/pending/status to answer child subagent requests without overriding pi-intercom.",
 		parameters: IntercomParamsSchema,
 		async execute(_id, params) {
+			refreshPendingRequests(pending, state, state.lastUiContext ?? undefined);
 			const input = params as IntercomParams;
 			if (input.action === "status") {
 				return { content: [{ type: "text", text: `Native supervisor channel active. Pending replies: ${pending.size}.` }], details: { active: true, pending: pending.size, root: SUPERVISOR_CHANNEL_ROOT } };
@@ -464,25 +523,29 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	let poller: ReturnType<typeof setInterval> | undefined;
 
 	const registerParentTools = (): void => {
-		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentIntercomTool(pending, NATIVE_SUPERVISOR_TOOL_NAME));
-		if (!hasTool(pi, "intercom")) pi.registerTool(buildParentIntercomTool(pending));
+		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentIntercomTool(pending, state, NATIVE_SUPERVISOR_TOOL_NAME));
+		if (!hasTool(pi, "intercom")) pi.registerTool(buildParentIntercomTool(pending, state));
 	};
 
 	const poll = (): void => {
 		const ctx = state.lastUiContext;
 		if (!ctx) return;
+		refreshPendingRequests(pending, state, ctx);
+		const now = Date.now();
 		for (const { channelDir, file } of listRequestFiles()) {
 			if (seenFiles.has(file)) continue;
 			const request = parseRequestFile(file, channelDir);
 			if (!request || !requestMatchesContext(request, state, ctx)) continue;
+			const lifecycle = requestLifecycle(request, state, undefined, now);
+			if (lifecycle !== "pending") {
+				seenFiles.add(file);
+				cleanupRequestLifecycle(request, lifecycle);
+				continue;
+			}
 			seenFiles.add(file);
 			if (request.expectsReply) pending.set(request.id, request);
 			else {
-				try {
-					fs.rmSync(request.requestFile, { force: true });
-				} catch {
-					// Non-blocking progress updates are already delivered to this session.
-				}
+				removeRequestFile(request.requestFile);
 			}
 			pi.sendMessage({
 				customType: "subagent_supervisor_request",

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -8,11 +8,28 @@ import {
 	NATIVE_SUPERVISOR_TOOL_NAME,
 	createNativeSupervisorChannel,
 	ensureSupervisorChannelDir,
+	registerNativeSupervisorClient,
 	resolveSupervisorChannelDir,
 } from "../../src/intercom/native-supervisor-channel.ts";
+import {
+	SUBAGENT_CHILD_AGENT_ENV,
+	SUBAGENT_CHILD_INDEX_ENV,
+	SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV,
+	SUBAGENT_ORCHESTRATOR_TARGET_ENV,
+	SUBAGENT_RUN_ID_ENV,
+	SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV,
+} from "../../src/runs/shared/pi-args.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
 
 const createdChannels: string[] = [];
+const savedEnv = {
+	[SUBAGENT_CHILD_AGENT_ENV]: process.env[SUBAGENT_CHILD_AGENT_ENV],
+	[SUBAGENT_CHILD_INDEX_ENV]: process.env[SUBAGENT_CHILD_INDEX_ENV],
+	[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV]: process.env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV],
+	[SUBAGENT_ORCHESTRATOR_TARGET_ENV]: process.env[SUBAGENT_ORCHESTRATOR_TARGET_ENV],
+	[SUBAGENT_RUN_ID_ENV]: process.env[SUBAGENT_RUN_ID_ENV],
+	[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV]: process.env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV],
+};
 
 function makeState(sessionId: string | null, ctx: unknown): SubagentState {
 	return {
@@ -31,7 +48,7 @@ function makeState(sessionId: string | null, ctx: unknown): SubagentState {
 	};
 }
 
-function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string }): string {
+function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string; createdAt?: number; expiresAt?: number }): string {
 	const agent = input.agent ?? "worker";
 	const index = input.index ?? 0;
 	const channelDir = resolveSupervisorChannelDir(input.runId, agent, index);
@@ -41,7 +58,8 @@ function writeRequest(input: { sessionId: string; runId: string; agent?: string;
 	fs.writeFileSync(path.join(channelDir, "requests", `${requestId}.json`), JSON.stringify({
 		type: "subagent.supervisor.request",
 		id: requestId,
-		createdAt: Date.now(),
+		createdAt: input.createdAt ?? Date.now(),
+		...(input.expiresAt !== undefined ? { expiresAt: input.expiresAt } : {}),
 		reason: "need_decision",
 		message: input.message ?? "Need a decision",
 		expectsReply: true,
@@ -54,7 +72,24 @@ function writeRequest(input: { sessionId: string; runId: string; agent?: string;
 	return requestId;
 }
 
+function requestFile(runId: string, requestId: string, agent = "worker", index = 0): string {
+	return path.join(resolveSupervisorChannelDir(runId, agent, index), "requests", `${requestId}.json`);
+}
+
+function replyFile(runId: string, requestId: string, agent = "worker", index = 0): string {
+	return path.join(resolveSupervisorChannelDir(runId, agent, index), "replies", `${requestId}.json`);
+}
+
+function restoreEnv(): void {
+	for (const [key, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+}
+
 afterEach(() => {
+	restoreEnv();
+	delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
 	for (const channel of createdChannels.splice(0)) fs.rmSync(channel, { recursive: true, force: true });
 });
 
@@ -151,12 +186,135 @@ describe("native supervisor channel", () => {
 
 			assert.deepEqual([...registeredTools.keys()], [NATIVE_SUPERVISOR_TOOL_NAME]);
 			await registeredTools.get(NATIVE_SUPERVISOR_TOOL_NAME)?.execute("reply", { action: "reply", replyTo: requestId, message: "Approved" });
-			const replyFile = path.join(resolveSupervisorChannelDir(runId, "worker", 0), "replies", `${requestId}.json`);
-			const reply = JSON.parse(fs.readFileSync(replyFile, "utf-8")) as { message?: string; requestId?: string };
+			const reply = JSON.parse(fs.readFileSync(replyFile(runId, requestId), "utf-8")) as { message?: string; requestId?: string };
 			assert.equal(reply.requestId, requestId);
 			assert.equal(reply.message, "Approved");
+			assert.equal(fs.existsSync(requestFile(runId, requestId)), false);
 		} finally {
 			channel.dispose();
 		}
+	});
+
+	it("suppresses resolved, expired, and inactive requests before displaying them", () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const resolvedRunId = `run-${randomUUID()}`;
+		const expiredRunId = `run-${randomUUID()}`;
+		const inactiveRunId = `run-${randomUUID()}`;
+		const resolvedId = writeRequest({ sessionId: currentSessionId, runId: resolvedRunId });
+		const expiredId = writeRequest({ sessionId: currentSessionId, runId: expiredRunId, expiresAt: Date.now() - 1 });
+		const inactiveId = writeRequest({ sessionId: currentSessionId, runId: inactiveRunId });
+		fs.writeFileSync(replyFile(resolvedRunId, resolvedId), JSON.stringify({
+			type: "subagent.supervisor.reply",
+			requestId: resolvedId,
+			createdAt: Date.now(),
+			message: "Already handled",
+		}), "utf-8");
+		const sent: Array<{ details?: { id?: string } }> = [];
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const state = makeState(currentSessionId, ctx);
+		state.foregroundRuns = new Map([[inactiveRunId, {
+			runId: inactiveRunId,
+			mode: "single",
+			cwd: process.cwd(),
+			updatedAt: Date.now(),
+			children: [{ agent: "worker", index: 0, status: "completed", updatedAt: Date.now() }],
+		}]]);
+		const pi = {
+			getAllTools: () => [],
+			registerTool: () => {},
+			sendMessage: (message: { details?: { id?: string } }) => { sent.push(message); },
+			getSessionName: () => "shared-name",
+		};
+		const channel = createNativeSupervisorChannel(pi as never, state);
+
+		channel.start();
+		channel.dispose();
+
+		assert.deepEqual(sent, []);
+		assert.equal(fs.existsSync(requestFile(resolvedRunId, resolvedId)), false);
+		assert.equal(fs.existsSync(requestFile(expiredRunId, expiredId)), false);
+		assert.equal(fs.existsSync(requestFile(inactiveRunId, inactiveId)), false);
+	});
+
+	it("refreshes pending requests before listing or replying", async () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const requestId = writeRequest({ sessionId: currentSessionId, runId });
+		const registeredTools = new Map<string, { execute: (_id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<{ content: Array<{ text: string }>; details?: { pending?: unknown[] } }> }>();
+		const sent: Array<{ details?: { id?: string } }> = [];
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const pi = {
+			getAllTools: () => [...registeredTools.keys()].map((name) => ({ name })),
+			registerTool: (tool: { name: string; execute: (_id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<{ content: Array<{ text: string }>; details?: { pending?: unknown[] } }> }) => {
+				registeredTools.set(tool.name, tool);
+			},
+			sendMessage: (message: { details?: { id?: string } }) => { sent.push(message); },
+			getSessionName: () => "shared-name",
+		};
+		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx));
+
+		try {
+			channel.start();
+			assert.deepEqual(sent.map((message) => message.details?.id), [requestId]);
+			assert.equal(channel.pending.has(requestId), true);
+
+			fs.rmSync(requestFile(runId, requestId), { force: true });
+			const pendingResult = await registeredTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+
+			assert.match(pendingResult.content[0]!.text, /No pending supervisor requests/);
+			assert.deepEqual(pendingResult.details?.pending, []);
+			assert.equal(channel.pending.has(requestId), false);
+			await assert.rejects(
+				() => registeredTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("reply", { action: "reply", replyTo: requestId, message: "Too late" }),
+				new RegExp(`No pending supervisor request found for replyTo '${requestId}'`),
+			);
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("removes the request file when a child supervisor ask is cancelled", async () => {
+		const runId = `run-${randomUUID()}`;
+		const channelDir = resolveSupervisorChannelDir(runId, "worker", 0);
+		createdChannels.push(channelDir);
+		process.env[SUBAGENT_ORCHESTRATOR_TARGET_ENV] = "shared-name";
+		process.env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV] = "session-parent";
+		process.env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] = channelDir;
+		process.env[SUBAGENT_RUN_ID_ENV] = runId;
+		process.env[SUBAGENT_CHILD_AGENT_ENV] = "worker";
+		process.env[SUBAGENT_CHILD_INDEX_ENV] = "0";
+		const registeredTools = new Map<string, { execute: (_id: string, params: { reason: string; message?: string }, signal?: AbortSignal) => Promise<unknown> | unknown }>();
+		const pi = {
+			getAllTools: () => [...registeredTools.keys()].map((name) => ({ name })),
+			registerTool: (tool: { name: string; execute: (_id: string, params: { reason: string; message?: string }, signal?: AbortSignal) => Promise<unknown> | unknown }) => {
+				registeredTools.set(tool.name, tool);
+			},
+		};
+		registerNativeSupervisorClient(pi as never, { includeIntercomFallback: false });
+		const controller = new AbortController();
+		controller.abort();
+
+		await assert.rejects(
+			() => registeredTools.get("contact_supervisor")!.execute("contact", { reason: "need_decision", message: "Need a decision" }, controller.signal),
+			/Supervisor request cancelled/,
+		);
+
+		assert.deepEqual(fs.readdirSync(path.join(channelDir, "requests")), []);
 	});
 });


### PR DESCRIPTION
This fixes stale native supervisor-channel asks that could remain visible after they were already replied to, expired, or came from inactive child runs. It also cleans up cancelled child asks so the visible supervisor notice and `subagent_supervisor` pending state stay aligned. Fixes #393