### PR TITLE
Add wait tool opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Added `waitTool` config and `PI_SUBAGENT_WAIT_TOOL_ENABLED` so interactive users can keep the `wait` tool registered while making it return immediately instead of blocking on background subagents.
+
 ### Fixed
 - Suppress stale native supervisor-channel asks after replies, expiry, or inactive child runs, and clean cancelled child requests so `subagent_supervisor` and visible intercom notices stay aligned.
 

--- a/README.md
+++ b/README.md
@@ -1154,6 +1154,14 @@ Controls the parent-facing `subagent` tool description registered at startup. `f
 
 Makes top-level calls use background execution when the request does not explicitly set `async`. Callers can still force foreground with `async: false` unless `forceTopLevelAsync` is enabled.
 
+### `waitTool`
+
+```json
+{ "waitTool": { "enabled": false } }
+```
+
+Keeps the `wait` tool registered but makes it return immediately instead of blocking on active async runs. Use this in interactive sessions where background completions should arrive as notifications while the main conversation stays steerable. The default is enabled. You can also set `"waitTool": false`; set `PI_SUBAGENT_WAIT_TOOL_ENABLED=false` (or `0`, `off`, `disabled`) to override config for one process. Invalid `waitTool` config or env values fail instead of being coerced.
+
 ### `forceTopLevelAsync`
 
 ```json

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -36,7 +36,7 @@ import { createNativeSupervisorChannel } from "../intercom/native-supervisor-cha
 import { registerSubagentRpcBridge } from "./rpc.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
-import { waitForSubagents } from "../runs/background/wait.ts";
+import { resolveWaitToolConfig, waitForSubagents } from "../runs/background/wait.ts";
 import registerSubagentNotify, { type SubagentNotifyDetails } from "../runs/background/notify.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
@@ -257,6 +257,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	cleanupOldChainDirs();
 
 	const config = loadConfig();
+	const waitToolConfig = resolveWaitToolConfig(config.waitTool);
 	const asyncByDefault = config.asyncByDefault === true;
 	const tempArtifactsDir = getArtifactsDir(null);
 	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
@@ -517,10 +518,10 @@ Use this after launching async subagents when you have no independent work left 
 • { id: "..." } — wait for one specific run (id or prefix) to finish.
 • { timeoutMs: 600000 } — stop waiting after N ms (the runs keep going regardless; default 30 min)
 
-wait also returns when a run needs attention (a child that went idle or blocked for a decision), not only on completion — so a stuck child never stalls the loop; the summary names the run(s) to inspect/nudge/resume/interrupt. It wakes the instant a completion or control event arrives (subscribed to Pi's event bus, with a poll fallback that reconciles crashed runners), keeps the turn alive for normal notification delivery, and resolves early if the turn is aborted.`,
+wait also returns when a run needs attention (a child that went idle or blocked for a decision), not only on completion — so a stuck child never stalls the loop; the summary names the run(s) to inspect/nudge/resume/interrupt. It wakes the instant a completion or control event arrives (subscribed to Pi's event bus, with a poll fallback that reconciles crashed runners), keeps the turn alive for normal notification delivery, and resolves early if the turn is aborted.${waitToolConfig.enabled ? "" : "\n\nConfigured behavior: wait is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED and returns immediately without blocking."}`,
 		parameters: WaitParams,
 		execute(_id, params, signal, _onUpdate, _ctx) {
-			return waitForSubagents(params, signal, { state, events: pi.events });
+			return waitForSubagents(params, signal, { state, events: pi.events, enabled: waitToolConfig.enabled });
 		},
 	};
 	pi.registerTool(waitTool);

--- a/src/runs/background/wait.ts
+++ b/src/runs/background/wait.ts
@@ -47,6 +47,7 @@ import {
 	SUBAGENT_RESULT_INTERCOM_EVENT,
 	type Details,
 	type SubagentState,
+	type WaitToolConfig,
 } from "../../shared/types.ts";
 import { formatDuration } from "../../shared/formatters.ts";
 
@@ -56,6 +57,41 @@ const ACTIVE_STATES: ReadonlyArray<AsyncRunSummary["state"]> = ["queued", "runni
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const MIN_POLL_INTERVAL_MS = 250;
 const DEFAULT_POLL_INTERVAL_MS = 1000;
+
+export const WAIT_TOOL_ENABLED_ENV = "PI_SUBAGENT_WAIT_TOOL_ENABLED";
+
+export interface ResolvedWaitToolConfig {
+	enabled: boolean;
+}
+
+const WAIT_TOOL_TRUE_VALUES = new Set(["1", "true", "yes", "on", "enabled"]);
+const WAIT_TOOL_FALSE_VALUES = new Set(["0", "false", "no", "off", "disabled"]);
+
+function parseWaitToolEnabledEnv(value: string | undefined): boolean | undefined {
+	if (value === undefined) return undefined;
+	const normalized = value.trim().toLowerCase();
+	if (WAIT_TOOL_TRUE_VALUES.has(normalized)) return true;
+	if (WAIT_TOOL_FALSE_VALUES.has(normalized)) return false;
+	throw new Error(`${WAIT_TOOL_ENABLED_ENV} must be one of true/false, 1/0, yes/no, on/off, or enabled/disabled.`);
+}
+
+function configWaitToolEnabled(config: unknown): boolean | undefined {
+	if (config === undefined) return undefined;
+	if (typeof config === "boolean") return config;
+	if (!config || typeof config !== "object" || Array.isArray(config)) {
+		throw new Error("config.waitTool must be a boolean or an object with optional enabled boolean.");
+	}
+	const enabled = (config as { enabled?: unknown }).enabled;
+	if (enabled === undefined) return undefined;
+	if (typeof enabled !== "boolean") throw new Error("config.waitTool.enabled must be a boolean.");
+	return enabled;
+}
+
+export function resolveWaitToolConfig(config?: WaitToolConfig, env: Record<string, string | undefined> = process.env): ResolvedWaitToolConfig {
+	return {
+		enabled: parseWaitToolEnabledEnv(env[WAIT_TOOL_ENABLED_ENV]) ?? configWaitToolEnabled(config) ?? true,
+	};
+}
 
 export interface WaitParams {
 	/** Optional run id/prefix to wait for. When omitted, waits across every active run in this session. */
@@ -83,6 +119,8 @@ export interface WaitDeps {
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 	now?: () => number;
 	pollIntervalMs?: number;
+	/** False makes the tool return immediately without blocking active async runs. */
+	enabled?: boolean;
 	/** Injectable sleep for tests. */
 	sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
 	/**
@@ -228,6 +266,9 @@ export async function waitForSubagents(
 	signal: AbortSignal | undefined,
 	deps: WaitDeps,
 ): Promise<AgentToolResult<Details>> {
+	if (deps.enabled === false) {
+		return result("Wait tool is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED; returning immediately without blocking background subagent runs. Active runs keep going, and you can inspect them with subagent({ action: \"status\" }) or wait for completion notifications.");
+	}
 	const now = deps.now ?? Date.now;
 	const pollIntervalMs = Math.max(MIN_POLL_INTERVAL_MS, deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
 	const timeoutMs = params.timeoutMs !== undefined && params.timeoutMs > 0 ? params.timeoutMs : DEFAULT_TIMEOUT_MS;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -181,6 +181,12 @@ export interface CompletionBatchConfig {
 	stragglerWindowMs?: number;
 }
 
+export interface WaitToolConfigObject {
+	enabled?: boolean;
+}
+
+export type WaitToolConfig = boolean | WaitToolConfigObject;
+
 export interface ControlEvent {
 	type: ControlEventType;
 	from?: ActivityState;
@@ -1000,6 +1006,7 @@ export interface ExtensionConfig {
 	/** Tool description variant registered for the parent-facing subagent tool. Defaults to full. */
 	toolDescriptionMode?: ToolDescriptionMode;
 	forceTopLevelAsync?: boolean;
+	waitTool?: WaitToolConfig;
 	defaultSessionDir?: string;
 	singleRunOutputBaseDir?: string;
 	maxSubagentDepth?: number;

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -11,6 +14,7 @@ function parentToolEnv(): NodeJS.ProcessEnv {
 	const env = { ...process.env };
 	delete env[SUBAGENT_CHILD_ENV];
 	delete env[SUBAGENT_FANOUT_CHILD_ENV];
+	delete env[WAIT_TOOL_ENABLED_ENV];
 	return env;
 }
 
@@ -109,6 +113,57 @@ describe("subagent extension child mode", () => {
 			],
 			{ cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" },
 		);
+	});
+
+	it("honors waitTool disabled config for the registered wait tool", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-wait-tool-config-"));
+		try {
+			const configDir = path.join(agentDir, "extensions", "subagent");
+			fs.mkdirSync(configDir, { recursive: true });
+			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ waitTool: { enabled: false } }), "utf-8");
+
+			const script = String.raw`
+				import registerSubagentExtension from "./src/extension/index.ts";
+				const events = { on() { return () => {}; }, emit() {} };
+				let waitTool;
+				const fakePi = new Proxy({
+					events,
+					registerTool(tool) { if (tool.name === "wait") waitTool = tool; },
+					registerCommand() {},
+					registerShortcut() {},
+					registerMessageRenderer() {},
+					sendMessage() {},
+					getSessionName() { return undefined; },
+				}, {
+					get(target, prop) {
+						if (prop in target) return target[prop];
+						return () => undefined;
+					},
+				});
+				registerSubagentExtension(fakePi);
+				if (!waitTool) throw new Error("wait tool not registered");
+				const result = await waitTool.execute("wait-disabled", {}, new AbortController().signal, undefined, {});
+				process.stdout.write(JSON.stringify(result.content[0].text));
+			`;
+
+			const env = parentToolEnv();
+			env.PI_CODING_AGENT_DIR = agentDir;
+			const output = execFileSync(
+				process.execPath,
+				[
+					"--experimental-transform-types",
+					"--import",
+					"./test/support/register-loader.mjs",
+					"--input-type=module",
+					"--eval",
+					script,
+				],
+				{ cwd: projectRoot, env, encoding: "utf-8" },
+			);
+			assert.match(JSON.parse(output) as string, /disabled/i);
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
 	});
 
 	it("returns before registering anything for non-fanout children", () => {

--- a/test/unit/wait.test.ts
+++ b/test/unit/wait.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { waitForSubagents, type WaitDeps } from "../../src/runs/background/wait.ts";
+import { WAIT_TOOL_ENABLED_ENV, resolveWaitToolConfig, waitForSubagents, type WaitDeps } from "../../src/runs/background/wait.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
 
 function writeStatus(asyncRoot: string, runId: string, state: string, extra: object = {}): void {
@@ -62,6 +62,41 @@ function baseDeps(root: string, state: SubagentState, overrides: Partial<WaitDep
 }
 
 describe("wait tool", () => {
+	it("resolves waitTool config and environment overrides strictly", () => {
+		assert.deepEqual(resolveWaitToolConfig(undefined, {}), { enabled: true });
+		assert.deepEqual(resolveWaitToolConfig(false, {}), { enabled: false });
+		assert.deepEqual(resolveWaitToolConfig({ enabled: false }, {}), { enabled: false });
+		assert.deepEqual(resolveWaitToolConfig({ enabled: false }, { [WAIT_TOOL_ENABLED_ENV]: "true" }), { enabled: true });
+		assert.deepEqual(resolveWaitToolConfig(true, { [WAIT_TOOL_ENABLED_ENV]: "off" }), { enabled: false });
+		assert.throws(() => resolveWaitToolConfig("false" as never, {}), /config\.waitTool/);
+		assert.throws(() => resolveWaitToolConfig({ enabled: "false" } as never, {}), /config\.waitTool\.enabled/);
+		assert.throws(() => resolveWaitToolConfig(undefined, { [WAIT_TOOL_ENABLED_ENV]: "maybe" }), /PI_SUBAGENT_WAIT_TOOL_ENABLED/);
+	});
+
+	it("returns immediately without polling when waitTool is disabled", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-disabled-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-a", "running", { sessionId: "sess-1", pid: 999999 });
+			let slept = false;
+			const result = await waitForSubagents({}, undefined, baseDeps(root, state, {
+				enabled: false,
+				sleep: async () => {
+					slept = true;
+					throw new Error("disabled wait should not sleep");
+				},
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /disabled/i);
+			assert.match(textOf(result), /without blocking/i);
+			assert.equal(slept, false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("returns immediately when there is nothing to wait for", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-empty-"));
 		try {


### PR DESCRIPTION
This keeps the wait tool registered but lets users make it return immediately with config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED. The default stays unchanged, invalid values fail loudly, and the focused tests cover config, environment precedence, and the registered tool path.

Fixes #394