### PR TITLE
Honor disabled agent thinking frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `waitTool` config and `PI_SUBAGENT_WAIT_TOOL_ENABLED` so interactive users can keep the `wait` tool registered while making it return immediately instead of blocking on background subagents.
 
 ### Fixed
+- Coerce agent frontmatter `thinking: false` to disabled thinking so child model IDs do not gain invalid `:false` suffixes.
 - Suppress stale native supervisor-channel asks after replies, expiry, or inactive child runs, and clean cancelled child requests so `subagent_supervisor` and visible intercom notices stay aligned.
 - Avoid completion-guard failures for read-only issue-drafting tasks that mention suggested fixes while preserving mutation expectations for real implementation tasks.
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -57,7 +57,7 @@ export function defaultInheritSkills(): boolean {
 export interface BuiltinAgentOverrideBase {
 	model?: string;
 	fallbackModels?: string[];
-	thinking?: string;
+	thinking?: string | false;
 	systemPromptMode: SystemPromptMode;
 	inheritProjectContext: boolean;
 	inheritSkills: boolean;
@@ -111,7 +111,7 @@ export interface AgentConfig {
 	mcpDirectTools?: string[];
 	model?: string;
 	fallbackModels?: string[];
-	thinking?: string;
+	thinking?: string | false;
 	systemPromptMode: SystemPromptMode;
 	inheritProjectContext: boolean;
 	inheritSkills: boolean;
@@ -1283,7 +1283,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			mcpDirectTools: mcpDirectTools.length > 0 ? mcpDirectTools : undefined,
 			model: frontmatter.model,
 			fallbackModels: fallbackModels && fallbackModels.length > 0 ? fallbackModels : undefined,
-			thinking: frontmatter.thinking,
+			thinking: frontmatter.thinking === "false" ? false : frontmatter.thinking,
 			systemPromptMode,
 			inheritProjectContext,
 			inheritSkills,

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -39,7 +39,7 @@ interface BuildPiArgsInput {
 	sessionDir?: string;
 	sessionFile?: string;
 	model?: string;
-	thinking?: string;
+	thinking?: string | false;
 	systemPromptMode?: "append" | "replace";
 	inheritProjectContext: boolean;
 	inheritSkills: boolean;
@@ -87,7 +87,7 @@ function supervisorChannelDir(runId: string, agent: string, childIndex: number):
 	return path.join(TEMP_ROOT_DIR, "supervisor-channels", `${sanitizeSupervisorChannelSegment(runId)}-${sanitizeSupervisorChannelSegment(agent)}-${childIndex}`);
 }
 
-export function applyThinkingSuffix(model: string | undefined, thinking: string | undefined, replaceExisting = false): string | undefined {
+export function applyThinkingSuffix(model: string | undefined, thinking: string | false | undefined, replaceExisting = false): string | undefined {
 	if (!model || !thinking) return model;
 	const colonIdx = model.lastIndexOf(":");
 	if (colonIdx !== -1 && THINKING_LEVELS.includes(model.substring(colonIdx + 1))) {

--- a/src/shared/model-info.ts
+++ b/src/shared/model-info.ts
@@ -30,7 +30,7 @@ export function toModelInfo(model: RegistryModelLike): ModelInfo {
 /** Resolve the effective thinking level from a model string (which may contain a known suffix like `:high`)
  * and an explicit thinking config value. Returns `undefined` when no thinking is applicable
  * (e.g. no model was specified, or the model has no suffix and no config was provided). */
-export function resolveEffectiveThinking(model: string | undefined, configThinking: string | undefined): string | undefined {
+export function resolveEffectiveThinking(model: string | undefined, configThinking: string | false | undefined): string | undefined {
 	if (!model) return undefined;
 	const { thinkingSuffix } = splitKnownThinkingSuffix(model);
 	if (thinkingSuffix) return thinkingSuffix.slice(1);

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -7,6 +7,8 @@ import { handleManagementAction } from "../../src/agents/agent-management.ts";
 import { serializeAgent } from "../../src/agents/agent-serializer.ts";
 import { parseChain, serializeChain } from "../../src/agents/chain-serializer.ts";
 import { discoverAgents, discoverAgentsAll, type AgentConfig } from "../../src/agents/agents.ts";
+import { buildPiArgs } from "../../src/runs/shared/pi-args.ts";
+import { THINKING_LEVELS } from "../../src/shared/model-info.ts";
 
 const tempDirs: string[] = [];
 
@@ -513,6 +515,73 @@ Inspect code
 		const result = discoverAgents(dir, "project");
 		const scout = result.agents.find((agent) => agent.name === "scout");
 		assert.equal(scout?.maxSubagentDepth, 1);
+	});
+});
+
+describe("agent frontmatter thinking", () => {
+	it("coerces frontmatter false strings to disabled thinking", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-thinking-false-"));
+		tempDirs.push(dir);
+		const agentsDir = path.join(dir, ".pi", "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+
+		for (const [name, value] of [["unquoted", "false"], ["quoted", "\"false\""]] as const) {
+			fs.writeFileSync(path.join(agentsDir, `${name}.md`), `---
+name: ${name}
+description: ${name}
+model: glm-5.2-short-fast
+thinking: ${value}
+---
+
+Do work
+`, "utf-8");
+		}
+
+		const agents = discoverAgents(dir, "project").agents;
+		for (const name of ["unquoted", "quoted"]) {
+			const agent = agents.find((candidate) => candidate.name === name);
+			assert.ok(agent);
+			assert.equal(agent.thinking, false);
+
+			const { args } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				model: agent.model,
+				thinking: agent.thinking,
+				inheritProjectContext: agent.inheritProjectContext,
+				inheritSkills: agent.inheritSkills,
+			});
+
+			assert.ok(args.includes("--model"));
+			assert.ok(args.includes("glm-5.2-short-fast"));
+			assert.ok(!args.some((arg) => arg.includes(":false")));
+		}
+	});
+
+	it("preserves supported frontmatter thinking strings", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-thinking-levels-"));
+		tempDirs.push(dir);
+		const agentsDir = path.join(dir, ".pi", "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+
+		for (const level of THINKING_LEVELS) {
+			fs.writeFileSync(path.join(agentsDir, `${level}.md`), `---
+name: thinker-${level}
+description: Thinking ${level}
+thinking: ${level}
+---
+
+Do work
+`, "utf-8");
+		}
+
+		const agents = discoverAgents(dir, "project").agents;
+		for (const level of THINKING_LEVELS) {
+			const agent = agents.find((candidate) => candidate.name === `thinker-${level}`);
+			assert.ok(agent);
+			assert.equal(agent.thinking, level);
+		}
 	});
 });
 

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -251,6 +251,27 @@ describe("buildPiArgs model wiring", () => {
 		assert.ok(args.includes("anthropic/claude-haiku-4-5:off"));
 	});
 
+	it("does not append a thinking suffix for boolean false", () => {
+		const model = "glm-5.2-short-fast";
+		const once = applyThinkingSuffix(model, false);
+		assert.equal(once, model);
+		assert.equal(applyThinkingSuffix(once, false), model);
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			model,
+			thinking: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.ok(args.includes("--model"));
+		assert.ok(args.includes(model));
+		assert.ok(!args.some((arg) => arg.includes(":false")));
+	});
+
 	it("leaves provider-specific model suffixes untouched when thinking is disabled", () => {
 		const model = "openai-compatible/qwen2.5-coder:7b";
 		const { args } = buildPiArgs({


### PR DESCRIPTION
This fixes agent frontmatter with `thinking: false` so it disables thinking instead of appending `:false` to child model IDs. It also adds regression coverage for disabled frontmatter thinking and boolean false suffix handling, plus a changelog note. Fixes #399.