### PR TITLE
Fix async resume metadata preservation

### DIFF
--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -86,7 +86,9 @@ interface AsyncResultFile {
 	success?: boolean;
 	cwd?: string;
 	sessionFile?: string;
-	results?: Array<{ agent?: string; success?: boolean; sessionFile?: string; intercomTarget?: string }>;
+	model?: string;
+	thinking?: string;
+	results?: Array<{ agent?: string; success?: boolean; sessionFile?: string; intercomTarget?: string; model?: string; thinking?: string }>;
 }
 
 export interface AsyncRunLocation {
@@ -124,9 +126,11 @@ function validateResultFile(value: unknown, resultPath: string): AsyncResultFile
 			const agent = validateOptionalString(child, "agent", resultPath, `results[${index}].agent`);
 			const sessionFile = validateOptionalString(child, "sessionFile", resultPath, `results[${index}].sessionFile`);
 			const intercomTarget = validateOptionalString(child, "intercomTarget", resultPath, `results[${index}].intercomTarget`);
+			const model = validateOptionalString(child, "model", resultPath, `results[${index}].model`);
+			const thinking = validateOptionalString(child, "thinking", resultPath, `results[${index}].thinking`);
 			const success = child.success;
 			if (success !== undefined && typeof success !== "boolean") throw new Error(`Invalid async result file '${resultPath}': results[${index}].success must be a boolean.`);
-			return { agent, sessionFile, intercomTarget, ...(typeof success === "boolean" ? { success } : {}) };
+			return { agent, sessionFile, intercomTarget, model, thinking, ...(typeof success === "boolean" ? { success } : {}) };
 		});
 	}
 	const success = data.success;
@@ -139,6 +143,8 @@ function validateResultFile(value: unknown, resultPath: string): AsyncResultFile
 		state: validateOptionalString(data, "state", resultPath),
 		cwd: validateOptionalString(data, "cwd", resultPath),
 		sessionFile: validateOptionalString(data, "sessionFile", resultPath),
+		model: validateOptionalString(data, "model", resultPath),
+		thinking: validateOptionalString(data, "thinking", resultPath),
 		...(typeof success === "boolean" ? { success } : {}),
 		...(results ? { results } : {}),
 	};
@@ -270,8 +276,11 @@ function validateStatusForResume(status: AsyncStatus | null, source: string): vo
 		if (!Array.isArray(status.steps)) throw new Error(`Invalid async status '${source}': steps must be an array.`);
 		status.steps.forEach((step, index) => {
 			if (!step || typeof step !== "object" || Array.isArray(step)) throw new Error(`Invalid async status '${source}': steps[${index}] must be an object.`);
-			if (typeof step.agent !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].agent must be a string.`);
-			if (step.sessionFile !== undefined && typeof step.sessionFile !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].sessionFile must be a string.`);
+			const stepRecord = step as Record<string, unknown>;
+			if (typeof stepRecord.agent !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].agent must be a string.`);
+			if (stepRecord.sessionFile !== undefined && typeof stepRecord.sessionFile !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].sessionFile must be a string.`);
+			if (stepRecord.model !== undefined && typeof stepRecord.model !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].model must be a string.`);
+			if (stepRecord.thinking !== undefined && typeof stepRecord.thinking !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].thinking must be a string.`);
 		});
 	}
 }
@@ -367,8 +376,8 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 		?? (stepCount === 1 ? status?.sessionFile ?? result?.sessionFile : undefined);
 	if (!sessionFile && requireSessionFile) throw new Error(`Async run '${runId}' child ${index} does not have a persisted session file to resume from.`);
 	const resolvedSessionFile = sessionFile ? validateResumeSessionFile(runId, sessionFile) : undefined;
-	const stepModel = statusSteps[index]?.model;
-	const stepThinking = statusSteps[index]?.thinking;
+	const stepModel = statusSteps[index]?.model ?? resultSteps[index]?.model ?? (stepCount === 1 ? result?.model : undefined);
+	const stepThinking = statusSteps[index]?.thinking ?? resultSteps[index]?.thinking ?? (stepCount === 1 ? result?.thinking : undefined);
 
 	return {
 		kind: "revive",

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -35,6 +35,8 @@ export type AsyncResumeTarget = {
 	intercomTarget: string;
 	cwd?: string;
 	sessionFile?: string;
+	model?: string;
+	thinking?: string;
 };
 
 type KillFn = (pid: number, signal?: NodeJS.Signals | 0) => boolean;
@@ -322,6 +324,8 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 					intercomTarget: resolveSubagentIntercomTarget(runId, selectedStep.agent, requestedIndex),
 					cwd: status?.cwd ?? result?.cwd,
 					sessionFile: selectedStep.sessionFile ?? status?.sessionFile ?? result?.sessionFile,
+					model: selectedStep.model,
+					thinking: selectedStep.thinking,
 				};
 			}
 			if (selectedStep?.status === "pending") throw new Error(`Async run '${runId}' child ${requestedIndex} is pending and has not started yet. Wait for it to run or complete before resuming.`);
@@ -344,6 +348,8 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 				intercomTarget: resolveSubagentIntercomTarget(runId, selected.step.agent, selected.index),
 				cwd: status?.cwd ?? result?.cwd,
 				sessionFile: selected.step.sessionFile ?? status?.sessionFile ?? result?.sessionFile,
+				model: selected.step.model,
+				thinking: selected.step.thinking,
 			};
 		}
 	}
@@ -361,6 +367,8 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 		?? (stepCount === 1 ? status?.sessionFile ?? result?.sessionFile : undefined);
 	if (!sessionFile && requireSessionFile) throw new Error(`Async run '${runId}' child ${index} does not have a persisted session file to resume from.`);
 	const resolvedSessionFile = sessionFile ? validateResumeSessionFile(runId, sessionFile) : undefined;
+	const stepModel = statusSteps[index]?.model;
+	const stepThinking = statusSteps[index]?.thinking;
 
 	return {
 		kind: "revive",
@@ -372,6 +380,8 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 		intercomTarget: resolveSubagentIntercomTarget(runId, agent, index),
 		cwd: status?.cwd ?? result?.cwd,
 		...(resolvedSessionFile ? { sessionFile: resolvedSessionFile } : {}),
+		...(stepModel ? { model: stepModel } : {}),
+		...(stepThinking ? { thinking: stepThinking } : {}),
 	};
 }
 

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { RESULTS_DIR, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSummary, type SubagentRunMode } from "../../shared/types.ts";
+import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { normalizeParallelGroups } from "./parallel-groups.ts";
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent, type NestedRoute } from "../shared/nested-events.ts";
 
@@ -109,6 +110,7 @@ interface ResultChildOutcome {
 	error?: string;
 	sessionFile?: string;
 	model?: string;
+	thinking?: string;
 	attemptedModels?: string[];
 	modelAttempts?: NonNullable<AsyncStatus["steps"]>[number]["modelAttempts"];
 }
@@ -120,9 +122,18 @@ interface ResultRepairData {
 
 function readResultRepairData(resultPath: string): ResultRepairData | undefined {
 	try {
-		const data = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { success?: boolean; state?: string; exitCode?: number; results?: ResultChildOutcome[] };
+		const data = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { success?: boolean; state?: string; exitCode?: number; results?: unknown };
 		const state = data.success ? "complete" : data.state === "paused" || data.exitCode === 0 ? "paused" : "failed";
-		return { state, ...(Array.isArray(data.results) ? { results: data.results } : {}) };
+		const results = Array.isArray(data.results)
+			? data.results.map((entry, index) => {
+				if (!entry || typeof entry !== "object" || Array.isArray(entry)) return {};
+				const child = entry as ResultChildOutcome;
+				if (child.model !== undefined && typeof child.model !== "string") throw new Error(`Invalid async result file '${resultPath}': results[${index}].model must be a string.`);
+				if (child.thinking !== undefined && typeof child.thinking !== "string") throw new Error(`Invalid async result file '${resultPath}': results[${index}].thinking must be a string.`);
+				return child;
+			})
+			: undefined;
+		return { state, ...(results ? { results } : {}) };
 	} catch (error) {
 		if (isNotFoundError(error)) return undefined;
 		throw new Error(`Failed to read async result file '${resultPath}': ${getErrorMessage(error)}`, {
@@ -144,6 +155,8 @@ function terminalStatusFromResult(status: AsyncStatus, resultPath: string, now: 
 		if (step.status !== "running" && step.status !== "pending") return step;
 		const child = repair.results?.[index];
 		const state = childState(repair.state, child);
+		const model = child?.model ?? step.model;
+		const thinking = resolveEffectiveThinking(model, child?.thinking ?? step.thinking);
 		return {
 			...step,
 			status: state === "complete" ? "complete" as const : state,
@@ -152,9 +165,10 @@ function terminalStatusFromResult(status: AsyncStatus, resultPath: string, now: 
 			exitCode: step.exitCode ?? (state === "complete" || state === "paused" ? 0 : 1),
 			error: state === "failed" ? step.error ?? child?.error : step.error,
 			sessionFile: step.sessionFile ?? child?.sessionFile,
-			model: step.model ?? child?.model,
-			attemptedModels: step.attemptedModels ?? child?.attemptedModels,
-			modelAttempts: step.modelAttempts ?? child?.modelAttempts,
+			model,
+			thinking,
+			attemptedModels: child?.attemptedModels ?? step.attemptedModels,
+			modelAttempts: child?.modelAttempts ?? step.modelAttempts,
 		};
 	});
 	return {
@@ -330,6 +344,12 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 	const startedStatus = !status && options.startedRun ? buildStartedStatus(asyncDir, options.startedRun, now) : undefined;
 	const effectiveStatus = status ?? startedStatus;
 	if (!effectiveStatus) return { status: null, repaired: false };
+	const statusPath = path.join(asyncDir, "status.json");
+	for (const [index, step] of (effectiveStatus.steps ?? []).entries()) {
+		const stepRecord = step as Record<string, unknown>;
+		if (stepRecord.model !== undefined && typeof stepRecord.model !== "string") throw new Error(`Invalid async status file '${statusPath}': steps[${index}].model must be a string.`);
+		if (stepRecord.thinking !== undefined && typeof stepRecord.thinking !== "string") throw new Error(`Invalid async status file '${statusPath}': steps[${index}].thinking must be a string.`);
+	}
 
 	const runId = effectiveStatus.runId || path.basename(asyncDir);
 	const resultPath = path.join(options.resultsDir ?? RESULTS_DIR, `${runId}.json`);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1171,6 +1171,8 @@ async function resumeAsyncRun(input: {
 		shareEnabled: input.params.share === true,
 		sessionRoot: input.deps.getSubagentSessionRoot(parentSessionFile),
 		sessionFile: target.sessionFile,
+		modelOverride: input.params.model ?? target.model,
+		thinkingOverride: input.params.model ? undefined : target.thinking,
 		outputBaseDir: resolveSingleRunOutputBaseDir(input.deps, artifactsDir, runId),
 		maxSubagentDepth: resolveCurrentMaxSubagentDepth(input.deps.config.maxSubagentDepth),
 		worktreeSetupHook: input.deps.config.worktreeSetupHook,

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -510,7 +510,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				cwd: tempDir,
 				steps: [
 					{ agent: "a", status: "complete", sessionFile: firstSession },
-					{ agent: "b", status: "complete", sessionFile: secondSession },
+					{ agent: "b", status: "complete", sessionFile: secondSession, model: "anthropic/claude-sonnet-4", thinking: "high" },
 				],
 			}, null, 2), "utf-8");
 			const { executor } = makeExecutor({ agents: [makeAgent("a"), makeAgent("b")] });
@@ -529,6 +529,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			assert.match(result.content[0]?.text ?? "", new RegExp(secondSession.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 			const args = await readMockCallArgs(0);
 			assert.equal(args[args.indexOf("--session") + 1], secondSession);
+			assert.equal(args[args.indexOf("--model") + 1], "anthropic/claude-sonnet-4:high");
 		} finally {
 			fs.rmSync(asyncDir, { recursive: true, force: true });
 		}

--- a/test/unit/async-resume.test.ts
+++ b/test/unit/async-resume.test.ts
@@ -133,6 +133,40 @@ describe("async resume lookup", () => {
 		}
 	});
 
+	it("rejects malformed result model metadata", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-malformed-result-model-"));
+		try {
+			const resultsDir = path.join(root, "results");
+			writeJson(path.join(resultsDir, "run-result-model.json"), {
+				id: "run-result-model",
+				agent: "worker",
+				success: true,
+				state: "complete",
+				results: [{ agent: "worker", model: { id: "bad" } }],
+			});
+
+			assert.throws(
+				() => resolveAsyncResumeTarget({ id: "run-result-model" }, { asyncDirRoot: path.join(root, "runs"), resultsDir }, { requireSessionFile: false }),
+				/results\[0\].model must be a string/,
+			);
+
+			writeJson(path.join(resultsDir, "run-result-model.json"), {
+				id: "run-result-model",
+				agent: "worker",
+				success: true,
+				state: "complete",
+				results: [{ agent: "worker", thinking: { level: "high" } }],
+			});
+
+			assert.throws(
+				() => resolveAsyncResumeTarget({ id: "run-result-model" }, { asyncDirRoot: path.join(root, "runs"), resultsDir }, { requireSessionFile: false }),
+				/results\[0\].thinking must be a string/,
+			);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects malformed status session ids", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-malformed-session-id-"));
 		try {
@@ -149,6 +183,40 @@ describe("async resume lookup", () => {
 			assert.throws(
 				() => resolveAsyncResumeTarget({ id: "run-session-id" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results") }),
 				/sessionId must be a string/,
+			);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects malformed status model metadata", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-malformed-status-model-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			writeJson(path.join(asyncRoot, "run-status-model", "status.json"), {
+				runId: "run-status-model",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running", model: { id: "bad" } }],
+			});
+
+			assert.throws(
+				() => resolveAsyncResumeTarget({ id: "run-status-model" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results") }),
+				/steps\[0\].model must be a string/,
+			);
+
+			writeJson(path.join(asyncRoot, "run-status-model", "status.json"), {
+				runId: "run-status-model",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running", thinking: { level: "high" } }],
+			});
+
+			assert.throws(
+				() => resolveAsyncResumeTarget({ id: "run-status-model" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results") }),
+				/steps\[0\].thinking must be a string/,
 			);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
@@ -261,6 +329,44 @@ describe("async resume lookup", () => {
 			assert.equal(target.kind, "revive");
 			assert.equal(target.agent, "b");
 			assert.equal(target.index, 1);
+			assert.equal(target.sessionFile, secondSession);
+			assert.equal(target.model, "anthropic/claude-sonnet-4");
+			assert.equal(target.thinking, "high");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves a completed result-only child with per-child model metadata", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-result-only-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const resultsDir = path.join(root, "results");
+			const firstSession = path.join(root, "a.jsonl");
+			const secondSession = path.join(root, "b.jsonl");
+			fs.writeFileSync(firstSession, "", "utf-8");
+			fs.writeFileSync(secondSession, "", "utf-8");
+			writeJson(path.join(resultsDir, "run-result-only.json"), {
+				id: "run-result-only",
+				mode: "parallel",
+				success: true,
+				state: "complete",
+				cwd: root,
+				results: [
+					{ agent: "a", success: true, sessionFile: firstSession, model: "openai/gpt-4.1" },
+					{ agent: "b", success: true, sessionFile: secondSession, model: "anthropic/claude-sonnet-4", thinking: "high" },
+				],
+			});
+
+			assert.throws(
+				() => resolveAsyncResumeTarget({ id: "run-result-only" }, { asyncDirRoot: asyncRoot, resultsDir }),
+				/Provide index to choose one/,
+			);
+			const target = resolveAsyncResumeTarget({ id: "run-result-only", index: 1 }, { asyncDirRoot: asyncRoot, resultsDir });
+			assert.equal(target.kind, "revive");
+			assert.equal(target.agent, "b");
+			assert.equal(target.index, 1);
+			assert.equal(target.cwd, root);
 			assert.equal(target.sessionFile, secondSession);
 			assert.equal(target.model, "anthropic/claude-sonnet-4");
 			assert.equal(target.thinking, "high");

--- a/test/unit/async-resume.test.ts
+++ b/test/unit/async-resume.test.ts
@@ -165,13 +165,15 @@ describe("async resume lookup", () => {
 				state: "running",
 				startedAt: 100,
 				lastUpdate: 100,
-				steps: [{ agent: "scout", status: "running" }],
+				steps: [{ agent: "scout", status: "running", model: "openai/gpt-4.1", thinking: "off" }],
 			});
 
 			const target = resolveAsyncResumeTarget({ id: "run-live" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results") });
 
 			assert.equal(target.kind, "live");
 			assert.equal(target.intercomTarget, "subagent-scout-run-live-1");
+			assert.equal(target.model, "openai/gpt-4.1");
+			assert.equal(target.thinking, "off");
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
@@ -247,7 +249,7 @@ describe("async resume lookup", () => {
 				lastUpdate: 200,
 				steps: [
 					{ agent: "a", status: "complete", sessionFile: firstSession },
-					{ agent: "b", status: "complete", sessionFile: secondSession },
+					{ agent: "b", status: "complete", sessionFile: secondSession, model: "anthropic/claude-sonnet-4", thinking: "high" },
 				],
 			});
 
@@ -260,6 +262,8 @@ describe("async resume lookup", () => {
 			assert.equal(target.agent, "b");
 			assert.equal(target.index, 1);
 			assert.equal(target.sessionFile, secondSession);
+			assert.equal(target.model, "anthropic/claude-sonnet-4");
+			assert.equal(target.thinking, "high");
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/stale-run-reconciler.test.ts
+++ b/test/unit/stale-run-reconciler.test.ts
@@ -153,8 +153,8 @@ describe("async stale-run reconciliation", () => {
 				startedAt: 1000,
 				lastUpdate: 1000,
 				steps: [
-					{ agent: "scout", status: "running", startedAt: 1000 },
-					{ agent: "worker", status: "running", startedAt: 1100 },
+					{ agent: "scout", status: "running", startedAt: 1000, model: "planned-scout", attemptedModels: ["planned-scout"] },
+					{ agent: "worker", status: "running", startedAt: 1100, model: "planned-worker", attemptedModels: ["planned-worker"] },
 				],
 			});
 			const scoutSession = path.join(root, "scout.jsonl");
@@ -164,8 +164,8 @@ describe("async stale-run reconciliation", () => {
 				success: false,
 				state: "failed",
 				results: [
-					{ agent: "scout", success: true, sessionFile: scoutSession, model: "fast" },
-					{ agent: "worker", success: false, error: "boom", sessionFile: workerSession, model: "careful" },
+					{ agent: "scout", success: true, sessionFile: scoutSession, model: "fast", attemptedModels: ["planned-scout", "fast"] },
+					{ agent: "worker", success: false, error: "boom", sessionFile: workerSession, model: "careful", attemptedModels: ["planned-worker", "careful"] },
 				],
 			}, null, 2), "utf-8");
 
@@ -180,11 +180,13 @@ describe("async stale-run reconciliation", () => {
 			assert.equal(result.status?.steps?.[0]?.status, "complete");
 			assert.equal(result.status?.steps?.[0]?.exitCode, 0);
 			assert.equal(result.status?.steps?.[0]?.model, "fast");
+			assert.deepEqual(result.status?.steps?.[0]?.attemptedModels, ["planned-scout", "fast"]);
 			assert.equal(result.status?.steps?.[0]?.sessionFile, scoutSession);
 			assert.equal(result.status?.steps?.[1]?.status, "failed");
 			assert.equal(result.status?.steps?.[1]?.exitCode, 1);
 			assert.equal(result.status?.steps?.[1]?.error, "boom");
 			assert.equal(result.status?.steps?.[1]?.model, "careful");
+			assert.deepEqual(result.status?.steps?.[1]?.attemptedModels, ["planned-worker", "careful"]);
 			assert.equal(result.status?.steps?.[1]?.sessionFile, workerSession);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
This builds on #403 after review found two resume paths that still lost the original child model. Result-only async resumes now keep the child model and thinking metadata from the result file, and stale running-status repair now prefers the final result metadata over the planned model so revived children use what actually ran.

I kept this as a separate branch because it includes the contributor's original PR plus the follow-up fixes, rather than pushing directly to their fork. It can replace #403, or the top commit can be cherry-picked onto that branch if that is cleaner.

Validated with the async-resume unit tests, stale-run-reconciler unit tests, intercom result delivery integration test, and `git diff --check`.
