### PR TITLE
fix: avoid now ago in activity status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Avoid rendering active subagent activity as `now ago`. Thanks to Viktor Chernodub (@chernodub) for #414.
 - Preserve async resume model/thinking metadata for live, completed, and result-only child runs, and repair stale status metadata from final results. Thanks to BoxChen (@nishuzumi) for #403.
 - Gate foreground `contact_supervisor`/intercom detaches on delivered supervisor handoff events, keep detached foreground runs visible through status/fleet, and mark detached placeholders as non-successful so missing explicit outputs are not mistaken for completed work.
 

--- a/src/shared/status-format.ts
+++ b/src/shared/status-format.ts
@@ -16,7 +16,10 @@ export function formatActivityLabel(lastActivityAt: number | undefined, activity
 	}
 	const age = formatActivityAge(Math.max(0, now - lastActivityAt));
 	if (activityState === "needs_attention") return `no activity for ${age}`;
-	if (activityState === "active_long_running") return `active but long-running · last activity ${age} ago`;
+	if (activityState === "active_long_running") {
+		const activityAge = age === "now" ? "now" : `${age} ago`;
+		return `active but long-running · last activity ${activityAge}`;
+	}
 	return age === "now" ? "active now" : `active ${age} ago`;
 }
 

--- a/test/unit/status-format.test.ts
+++ b/test/unit/status-format.test.ts
@@ -8,6 +8,7 @@ describe("status format helpers", () => {
 		assert.equal(formatActivityLabel(1_000, undefined, 1_500), "active now");
 		assert.equal(formatActivityLabel(1_000, "needs_attention", 4_000), "no activity for 3s");
 		assert.equal(formatActivityLabel(undefined, "active_long_running", 4_000), "active but long-running");
+		assert.equal(formatActivityLabel(4_000, "active_long_running", 4_000), "active but long-running · last activity now");
 	});
 
 	it("aggregates step status and parallel outcomes", () => {


### PR DESCRIPTION
   ## Summary

   Fixes a small wording bug in subagent activity status.

   When an active-long-running subagent had activity less than 1 second ago, the status could say:

   > last activity now ago

   It now says:

   > last activity now

   ## Changes

   - Added a regression test for the `"now"` activity case.
   - Updated the shared status formatter to avoid appending `"ago"` after `"now"`.
