### PR TITLE
fix: hide shadowed agents from list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Hide lower-priority agent definitions from `subagent({ action: "list" })` when a higher-priority project or user agent shadows them. Thanks to Kylegl (@kylegl) for #415.
 - Resolve the real Pi CLI on Windows when pi-subagents runs inside an embedded SDK host instead of relaunching the host application's entry point. Thanks to Marc Kassubeck (@CompN3rd) for #413.
 - Avoid rendering active subagent activity as `now ago`. Thanks to Viktor Chernodub (@chernodub) for #414.
 - Preserve async resume model/thinking metadata for live, completed, and result-only child runs, and repair stale status metadata from final results. Thanks to BoxChen (@nishuzumi) for #403.

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -21,6 +21,7 @@ import {
 	removeBuiltinAgentOverrideFields,
 } from "./agents.ts";
 import { serializeAgent } from "./agent-serializer.ts";
+import { mergeAgentsForScope } from "./agent-selection.ts";
 import { serializeChain, serializeJsonChain } from "./chain-serializer.ts";
 import { discoverAvailableSkills } from "./skills.ts";
 import {
@@ -98,25 +99,6 @@ function parsePackageConfig(value: unknown): { packageName?: string; error?: str
 
 function allAgents(d: { builtin: AgentConfig[]; package: AgentConfig[]; user: AgentConfig[]; project: AgentConfig[] }): AgentConfig[] {
 	return [...d.builtin, ...d.package, ...d.user, ...d.project];
-}
-
-const agentSourcePriority: Record<AgentSource, number> = {
-	builtin: 0,
-	package: 1,
-	user: 2,
-	project: 3,
-};
-
-function hideShadowedAgentsForList(agents: AgentConfig[]): AgentConfig[] {
-	const highestPriorityByName = new Map<string, number>();
-	for (const agent of agents) {
-		const priority = agentSourcePriority[agent.source];
-		const current = highestPriorityByName.get(agent.name);
-		if (current === undefined || priority > current) {
-			highestPriorityByName.set(agent.name, priority);
-		}
-	}
-	return agents.filter((agent) => agentSourcePriority[agent.source] === highestPriorityByName.get(agent.name));
 }
 
 function availableNames(cwd: string, kind: "agent" | "chain"): string[] {
@@ -599,7 +581,8 @@ function formatChainDetail(chain: ChainConfig): string {
 export function handleList(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
 	const scope = normalizeListScope(params.agentScope) ?? "both";
 	const d = discoverAgentsAll(ctx.cwd);
-	const scopedAgents = hideShadowedAgentsForList(allAgents(d).filter((a) => scope === "both" || a.source === "builtin" || a.source === "package" || a.source === scope)).sort((a, b) => a.name.localeCompare(b.name));
+	const scopedAgents = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package)
+		.sort((a, b) => a.name.localeCompare(b.name));
 	const agents = scopedAgents.filter((a) => !a.disabled);
 	const chains = d.chains.filter((c) => scope === "both" || c.source === "package" || c.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const diagnostics = d.chainDiagnostics.filter((entry) => scope === "both" || entry.source === scope);

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -100,6 +100,25 @@ function allAgents(d: { builtin: AgentConfig[]; package: AgentConfig[]; user: Ag
 	return [...d.builtin, ...d.package, ...d.user, ...d.project];
 }
 
+const agentSourcePriority: Record<AgentSource, number> = {
+	builtin: 0,
+	package: 1,
+	user: 2,
+	project: 3,
+};
+
+function hideShadowedAgentsForList(agents: AgentConfig[]): AgentConfig[] {
+	const highestPriorityByName = new Map<string, number>();
+	for (const agent of agents) {
+		const priority = agentSourcePriority[agent.source];
+		const current = highestPriorityByName.get(agent.name);
+		if (current === undefined || priority > current) {
+			highestPriorityByName.set(agent.name, priority);
+		}
+	}
+	return agents.filter((agent) => agentSourcePriority[agent.source] === highestPriorityByName.get(agent.name));
+}
+
 function availableNames(cwd: string, kind: "agent" | "chain"): string[] {
 	const d = discoverAgentsAll(cwd);
 	const items = kind === "agent" ? allAgents(d) : d.chains;
@@ -580,7 +599,7 @@ function formatChainDetail(chain: ChainConfig): string {
 export function handleList(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
 	const scope = normalizeListScope(params.agentScope) ?? "both";
 	const d = discoverAgentsAll(ctx.cwd);
-	const scopedAgents = allAgents(d).filter((a) => scope === "both" || a.source === "builtin" || a.source === "package" || a.source === scope).sort((a, b) => a.name.localeCompare(b.name));
+	const scopedAgents = hideShadowedAgentsForList(allAgents(d).filter((a) => scope === "both" || a.source === "builtin" || a.source === "package" || a.source === scope)).sort((a, b) => a.name.localeCompare(b.name));
 	const agents = scopedAgents.filter((a) => !a.disabled);
 	const chains = d.chains.filter((c) => scope === "both" || c.source === "package" || c.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const diagnostics = d.chainDiagnostics.filter((entry) => scope === "both" || entry.source === scope);

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { handleCreate, handleManagementAction, handleUpdate } from "../../src/agents/agent-management.ts";
+import { handleCreate, handleList, handleManagementAction, handleUpdate } from "../../src/agents/agent-management.ts";
 import { clearSkillCache } from "../../src/agents/skills.ts";
 
 let tempDir = "";
@@ -40,6 +40,21 @@ describe("agent management config parsing", () => {
 
 		assert.equal(result.isError, true);
 		assert.match(readText(result), /config must be valid JSON:/);
+	});
+
+	it("hides lower-priority agents shadowed by project agents in list output", () => {
+		const agentsDir = path.join(tempDir, ".pi", "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(path.join(agentsDir, "scout.md"), "---\nname: scout\ndescription: Project scout override\n---\n\nProject scout agent.\n");
+
+		const result = handleList(
+			{ agentScope: "project" },
+			{ cwd: tempDir, modelRegistry: { getAvailable: () => [] } },
+		);
+
+		assert.equal(result.isError, false);
+		assert.match(readText(result), /- scout \(project\): Project scout override/);
+		assert.doesNotMatch(readText(result), /- scout \(builtin/);
 	});
 
 	it("surfaces JSON parse errors for update config strings", () => {


### PR DESCRIPTION
## Problem

`subagent({ action: "list" })` can show both a lower-priority builtin agent and the user/project agent that shadows it. That makes the agent-facing list noisier and suggests there are multiple selectable agents even though the higher-priority agent wins for normal resolution.

## Solution

Filter list output to keep only the highest-priority agent for each name, using the existing precedence order: builtin < package < user < project. This only changes the management list presentation; discovery and resolution behavior stay the same.

## Testing

- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test --test-name-pattern "hides lower-priority agents" test/unit/agent-management.test.ts`
