### PR TITLE
fix: resolve Pi CLI inside embedded Windows hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Resolve the real Pi CLI on Windows when pi-subagents runs inside an embedded SDK host instead of relaunching the host application's entry point. Thanks to Marc Kassubeck (@CompN3rd) for #413.
 - Avoid rendering active subagent activity as `now ago`. Thanks to Viktor Chernodub (@chernodub) for #414.
 - Preserve async resume model/thinking metadata for live, completed, and result-only child runs, and repair stale status metadata from final results. Thanks to BoxChen (@nishuzumi) for #403.
 - Gate foreground `contact_supervisor`/intercom detaches on delivered supervisor handoff events, keep detached foreground runs visible through status/fleet, and mark detached placeholders as non-successful so missing explicit outputs are not mistaken for completed work.

--- a/src/runs/shared/pi-spawn.ts
+++ b/src/runs/shared/pi-spawn.ts
@@ -81,7 +81,11 @@ export function resolveWindowsPiCliScript(
 	if (argv1) {
 		const argvPath = normalizePath(argv1);
 		if (isRunnableNodeScript(argvPath, existsSync)) {
-			return argvPath;
+			try {
+				if (findPiPackageRootFromEntry(argvPath)) return argvPath;
+			} catch {
+				// Host package metadata is untrusted here; keep resolving the installed Pi CLI.
+			}
 		}
 	}
 

--- a/test/support/mock-pi.ts
+++ b/test/support/mock-pi.ts
@@ -58,13 +58,22 @@ export function createMockPi(): MockPi {
 	const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-mock-cli-"));
 	const queueDir = path.join(rootDir, "queue");
 	const binDir = path.join(rootDir, "bin");
+	const piPackageDir = path.join(rootDir, "pi-package");
+	const cliScriptPath = path.join(piPackageDir, "dist", "cli.mjs");
 	ensureDir(queueDir);
 	ensureDir(binDir);
+	ensureDir(path.dirname(cliScriptPath));
+	fs.copyFileSync(SCRIPT_PATH, cliScriptPath);
+	fs.writeFileSync(
+		path.join(piPackageDir, "package.json"),
+		JSON.stringify({ name: "@earendil-works/pi-coding-agent" }),
+		"utf-8",
+	);
 
 	const shellScriptPath = path.join(binDir, "pi");
 	const cmdScriptPath = path.join(binDir, "pi.cmd");
-	writeExecutable(shellScriptPath, `#!/bin/sh\nexec "${process.execPath}" "${SCRIPT_PATH}" "$@"\n`);
-	writeExecutable(cmdScriptPath, `@echo off\r\n"${process.execPath}" "${SCRIPT_PATH}" %*\r\n`);
+	writeExecutable(shellScriptPath, `#!/bin/sh\nexec "${process.execPath}" "${cliScriptPath}" "$@"\n`);
+	writeExecutable(cmdScriptPath, `@echo off\r\n"${process.execPath}" "${cliScriptPath}" %*\r\n`);
 
 	let installed = false;
 	let nextSequence = 0;
@@ -85,7 +94,7 @@ export function createMockPi(): MockPi {
 			process.env.MOCK_PI_QUEUE_DIR = queueDir;
 			if (process.platform === "win32") {
 				originalArgv1 = process.argv[1];
-				process.argv[1] = SCRIPT_PATH;
+				process.argv[1] = cliScriptPath;
 			}
 		},
 		uninstall() {

--- a/test/support/real-session-runner.ts
+++ b/test/support/real-session-runner.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
 	type AssistantMessage,
 	type Context,
@@ -114,25 +114,33 @@ function createModelRegistry(model: { provider: string; id: string }) {
 function installChildPiShim(childText: string): () => void {
 	const rootDir = mkdtempSync(path.join(os.tmpdir(), "pi-real-session-cli-"));
 	const binDir = path.join(rootDir, "bin");
+	const piPackageDir = path.join(rootDir, "pi-package");
+	const childCliPath = path.join(piPackageDir, "dist", "cli.mjs");
 	const previousPath = process.env.PATH;
 	const previousChildText = process.env.PI_SUBAGENTS_E2E_CHILD_TEXT;
 	const previousArgv1 = process.argv[1];
 
 	writeFileSync(path.join(rootDir, ".keep"), "");
 	mkdirSync(binDir, { recursive: true });
+	mkdirSync(path.dirname(childCliPath), { recursive: true });
+	writeFileSync(childCliPath, `import ${JSON.stringify(pathToFileURL(CHILD_CLI_PATH).href)};\n`);
+	writeFileSync(
+		path.join(piPackageDir, "package.json"),
+		JSON.stringify({ name: "@earendil-works/pi-coding-agent" }),
+	);
 	writeFileSync(
 		path.join(binDir, "pi"),
-		`#!/bin/sh\nexec "${process.execPath}" "${CHILD_CLI_PATH}" "$@"\n`,
+		`#!/bin/sh\nexec "${process.execPath}" "${childCliPath}" "$@"\n`,
 		{ mode: 0o755 },
 	);
 	writeFileSync(
 		path.join(binDir, "pi.cmd"),
-		`@echo off\r\n"${process.execPath}" "${CHILD_CLI_PATH}" %*\r\n`,
+		`@echo off\r\n"${process.execPath}" "${childCliPath}" %*\r\n`,
 	);
 
 	process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
 	process.env.PI_SUBAGENTS_E2E_CHILD_TEXT = childText;
-	if (process.platform === "win32") process.argv[1] = CHILD_CLI_PATH;
+	if (process.platform === "win32") process.argv[1] = childCliPath;
 
 	return () => {
 		if (previousPath === undefined) delete process.env.PATH;

--- a/test/unit/pi-spawn.test.ts
+++ b/test/unit/pi-spawn.test.ts
@@ -106,23 +106,91 @@ describe("getPiSpawnCommand", () => {
 		assert.deepEqual(result, { command: "pi", args });
 	});
 
-	it("uses node + argv1 script on Windows when argv1 is runnable JS", () => {
-		const argv1 = "/tmp/pi-entry.mjs";
-		const deps = makeDeps({
-			platform: "win32",
-			execPath: "/usr/local/bin/node",
-			argv1,
-			existing: [argv1],
-		});
-		const args = [
-			"--mode",
-			"json",
-			'Task: Read C:/dev/file.md and review "quotes" & pipes | too',
-		];
-		const result = getPiSpawnCommand(args, deps);
-		assert.equal(result.command, "/usr/local/bin/node");
-		assert.equal(result.args[0], argv1);
-		assert.equal(result.args[3], args[2]);
+	it("uses node + argv1 script on Windows when argv1 belongs to the Pi package", () => {
+		const tempDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-spawn-argv-entry-"),
+		);
+		try {
+			const argv1 = path.join(tempDir, "dist", "cli.js");
+			fs.mkdirSync(path.dirname(argv1), { recursive: true });
+			fs.writeFileSync(argv1, "#!/usr/bin/env node\n");
+			fs.writeFileSync(
+				path.join(tempDir, "package.json"),
+				JSON.stringify({ name: "@earendil-works/pi-coding-agent" }),
+			);
+			const args = [
+				"--mode",
+				"json",
+				'Task: Read C:/dev/file.md and review "quotes" & pipes | too',
+			];
+			const result = getPiSpawnCommand(args, {
+				platform: "win32",
+				execPath: "/usr/local/bin/node",
+				argv1,
+				env: {},
+			});
+			assert.equal(result.command, "/usr/local/bin/node");
+			assert.equal(result.args[0], argv1);
+			assert.equal(result.args[3], args[2]);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("ignores an embedded host entry point and resolves the Pi package bin on Windows", () => {
+		const tempDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-spawn-embedded-host-"),
+		);
+		try {
+			const hostRoot = path.join(tempDir, "pi-web");
+			const hostEntry = path.join(hostRoot, "dist", "server.js");
+			const hostPackageJson = path.join(hostRoot, "package.json");
+			const piRoot = path.join(
+				tempDir,
+				"node_modules",
+				"@earendil-works",
+				"pi-coding-agent",
+			);
+			const piCli = path.join(piRoot, "dist", "cli.js");
+			fs.mkdirSync(path.dirname(hostEntry), { recursive: true });
+			fs.mkdirSync(path.dirname(piCli), { recursive: true });
+			fs.writeFileSync(hostEntry, "export {};\n");
+			fs.writeFileSync(
+				hostPackageJson,
+				JSON.stringify({ name: "@jmfederico/pi-web" }),
+			);
+			fs.writeFileSync(piCli, "#!/usr/bin/env node\n");
+			fs.writeFileSync(
+				path.join(piRoot, "package.json"),
+				JSON.stringify({
+					name: "@earendil-works/pi-coding-agent",
+					bin: { pi: "dist/cli.js" },
+				}),
+			);
+
+			const result = getPiSpawnCommand(["-p", "Task: hello"], {
+				platform: "win32",
+				execPath: "/usr/local/bin/node",
+				argv1: hostEntry,
+				resolvePackageJson: () => path.join(piRoot, "package.json"),
+				env: {},
+			});
+			assert.equal(result.command, "/usr/local/bin/node");
+			assert.equal(result.args[0], piCli);
+
+			fs.writeFileSync(hostPackageJson, "{");
+			const malformedHostResult = getPiSpawnCommand(["-p", "Task: hello"], {
+				platform: "win32",
+				execPath: "/usr/local/bin/node",
+				argv1: hostEntry,
+				resolvePackageJson: () => path.join(piRoot, "package.json"),
+				env: {},
+			});
+			assert.equal(malformedHostResult.command, "/usr/local/bin/node");
+			assert.equal(malformedHostResult.args[0], piCli);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("resolves CLI script from package bin when argv1 is not runnable JS", () => {


### PR DESCRIPTION
When pi-subagents runs inside an SDK host on Windows, only accept the inherited Node entry point when it belongs to `@earendil-works/pi-coding-agent`. Embedded host entry points now fall through to the existing installed-package bin resolver.\n\nAdds regression coverage for direct Pi launches, embedded hosts, and malformed host package metadata.\n\nThanks to Marc Kassubeck (@CompN3rd) for the detailed diagnosis in #413.\n\nCloses #413.