### PR TITLE
feat: add agent launch defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added single-agent launch defaults for `async`, `timeoutMs`, and `turnBudget` in agent frontmatter, with explicit tool-call values taking precedence. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #410.
 - Added `/subagents-stop` and `subagent({ action: "stop", id })` for current-session top-level async runs. The slash command opens a confirmation selector when no id is provided, falls back to exact commands without a TUI, routes scheduled jobs through `schedule-cancel`, and records manual stops as `stopped`/cancelled lifecycle events instead of timeouts. Thanks to Sean Seaman (@seans-leadsonline) for #407 and #408.
 - Added an opt-in read-only subagent watchdog that reviews actual repo edits at safe agent-end boundaries, with visible warnings, main and child watchdog coordination, strong complementary model recommendations, changed-file TypeScript/JavaScript LSP diagnostics, `/subagents-watchdog` status/model commands, and agent-facing watchdog configuration actions. Thanks to can1357/oh-my-pi for the advisor/watchdog concept, and to apmantza/pi-lens, gjczone/pi-shazam, and can1357/oh-my-pi for LSP diagnostics patterns.
 

--- a/README.md
+++ b/README.md
@@ -704,6 +704,9 @@ skills: safe-bash, chrome-devtools
 output: context.md
 defaultReads: context.md
 defaultProgress: true
+async: true
+timeoutMs: 900000
+turnBudget: {"maxTurns":20,"graceTurns":2}
 completionGuard: false
 interactive: true
 maxSubagentDepth: 1
@@ -731,6 +734,9 @@ Important fields:
 | `output` | Default single-agent output file. |
 | `defaultReads` | Files to read before running in chain/parallel behavior. |
 | `defaultProgress` | Maintain `progress.md`. |
+| `async` | Default a single-agent launch to background (`true`) or foreground (`false`) when the call omits `async`. Explicit call values and `forceTopLevelAsync` win. |
+| `timeoutMs` | Positive integer default runtime deadline in milliseconds for single-agent launches. An explicit `timeoutMs` or `maxRuntimeMs` wins. |
+| `turnBudget` | JSON object default such as `{"maxTurns":20,"graceTurns":2}` for single-agent launches. An explicit call value wins, followed by this agent default, then global `turnBudget` config. |
 | `completionGuard` | Set `false` only for non-implementation agents that may mention implementation words while using mutation-capable tools such as `bash`. |
 | `interactive` | Parsed for compatibility but not enforced in v1. |
 | `maxSubagentDepth` | Tightens nested delegation for this agent's children. |

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -31,6 +31,7 @@ import { parseFrontmatter } from "./frontmatter.ts";
 import { toModelInfo } from "../shared/model-info.ts";
 import { resolveSubagentModelOverride, type ParentModel } from "../runs/shared/model-fallback.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
+import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
 import type { Details, ExtensionConfig, ToolBudgetConfig } from "../shared/types.ts";
 import { getProjectConfigDir } from "../shared/utils.ts";
 
@@ -261,6 +262,9 @@ function preservedAgentFrontmatterFields(agent: AgentConfig, cfg: Record<string,
 		fields.add("inheritSkills");
 	}
 	if (hasKey(cfg, "defaultContext")) changed("defaultContext");
+	if (hasKey(cfg, "async")) changed("async");
+	if (hasKey(cfg, "timeoutMs")) changed("timeoutMs");
+	if (hasKey(cfg, "turnBudget")) changed("turnBudget");
 	if (hasKey(cfg, "output")) changed("output");
 	if (hasKey(cfg, "reads")) changed("defaultReads");
 	if (hasKey(cfg, "progress")) changed("defaultProgress");
@@ -417,6 +421,24 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 		else if (cfg.defaultContext === "fresh" || cfg.defaultContext === "fork") target.defaultContext = cfg.defaultContext;
 		else return "config.defaultContext must be 'fresh', 'fork', or false when provided.";
 	}
+	if (hasKey(cfg, "async")) {
+		if (cfg.async === "") target.defaultAsync = undefined;
+		else if (typeof cfg.async === "boolean") target.defaultAsync = cfg.async;
+		else return "config.async must be a boolean or empty string when provided.";
+	}
+	if (hasKey(cfg, "timeoutMs")) {
+		if (cfg.timeoutMs === false || cfg.timeoutMs === "") target.defaultTimeoutMs = undefined;
+		else if (typeof cfg.timeoutMs === "number" && Number.isInteger(cfg.timeoutMs) && cfg.timeoutMs > 0) target.defaultTimeoutMs = cfg.timeoutMs;
+		else return "config.timeoutMs must be a positive integer or false when provided.";
+	}
+	if (hasKey(cfg, "turnBudget")) {
+		if (cfg.turnBudget === false || cfg.turnBudget === "") target.defaultTurnBudget = undefined;
+		else {
+			const resolved = resolveTurnBudgetConfig(cfg.turnBudget, "config.turnBudget");
+			if (resolved.error) return resolved.error;
+			target.defaultTurnBudget = resolved.turnBudget;
+		}
+	}
 	if (hasKey(cfg, "output")) {
 		if (cfg.output === false || cfg.output === "") target.output = undefined;
 		else if (typeof cfg.output === "string") target.output = cfg.output;
@@ -513,6 +535,9 @@ function formatAgentDetail(agent: AgentConfig): string {
 	lines.push(`Inherit project context: ${agent.inheritProjectContext ? "true" : "false"}`);
 	lines.push(`Inherit skills: ${agent.inheritSkills ? "true" : "false"}`);
 	if (agent.defaultContext) lines.push(`Default context: ${agent.defaultContext}`);
+	if (agent.defaultAsync !== undefined) lines.push(`Async: ${agent.defaultAsync ? "true" : "false"}`);
+	if (agent.defaultTimeoutMs !== undefined) lines.push(`Timeout: ${agent.defaultTimeoutMs}ms`);
+	if (agent.defaultTurnBudget) lines.push(`Turn budget: ${JSON.stringify(agent.defaultTurnBudget)}`);
 	if (agent.source === "builtin") lines.push(`Disabled: ${agent.disabled ? "true" : "false"}`);
 	if (agent.extensions !== undefined) lines.push(`Extensions: ${agent.extensions.length ? agent.extensions.join(", ") : "(none)"}`);
 	if (agent.subagentOnlyExtensions !== undefined) lines.push(`Subagent-only extensions: ${agent.subagentOnlyExtensions.length ? agent.subagentOnlyExtensions.join(", ") : "(none)"}`);

--- a/src/agents/agent-serializer.ts
+++ b/src/agents/agent-serializer.ts
@@ -13,6 +13,9 @@ export const KNOWN_FIELDS = new Set([
 	"inheritProjectContext",
 	"inheritSkills",
 	"defaultContext",
+	"async",
+	"timeoutMs",
+	"turnBudget",
 	"skill",
 	"skills",
 	"extensions",
@@ -62,6 +65,9 @@ export function serializeAgent(config: AgentConfig, options: SerializeAgentOptio
 	if (!preservingExistingFrontmatter || preserve("inheritProjectContext")) lines.push(`inheritProjectContext: ${config.inheritProjectContext ? "true" : "false"}`);
 	if (!preservingExistingFrontmatter || preserve("inheritSkills")) lines.push(`inheritSkills: ${config.inheritSkills ? "true" : "false"}`);
 	if (config.defaultContext || preserve("defaultContext")) lines.push(`defaultContext: ${config.defaultContext ?? ""}`);
+	if (config.defaultAsync !== undefined || preserve("async")) lines.push(`async: ${config.defaultAsync === undefined ? "" : config.defaultAsync ? "true" : "false"}`);
+	if (config.defaultTimeoutMs !== undefined || preserve("timeoutMs")) lines.push(`timeoutMs: ${config.defaultTimeoutMs ?? ""}`);
+	if (config.defaultTurnBudget || preserve("turnBudget")) lines.push(`turnBudget: ${config.defaultTurnBudget ? JSON.stringify(config.defaultTurnBudget) : ""}`);
 
 	const skillsValue = joinComma(config.skills);
 	if (skillsValue || preserve("skill", "skills")) lines.push(`skills: ${skillsValue ?? ""}`);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AcceptanceInput, OutputMode, ToolBudgetConfig } from "../shared/types.ts";
+import type { AcceptanceInput, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
 import { getAgentDir, getProjectConfigDir } from "../shared/utils.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain, parseJsonChain } from "./chain-serializer.ts";
@@ -17,6 +17,7 @@ import { buildRuntimeName, parsePackageName } from "./identity.ts";
 import { parseModelScopeConfig, type ModelScopeConfig } from "../runs/shared/model-scope.ts";
 export { buildRuntimeName, frontmatterNameForConfig, parsePackageName } from "./identity.ts";
 import { parseMemoryFrontmatter } from "./agent-memory.ts";
+import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
 
 export type AgentScope = "user" | "project" | "both";
 
@@ -116,6 +117,9 @@ export interface AgentConfig {
 	inheritProjectContext: boolean;
 	inheritSkills: boolean;
 	defaultContext?: AgentDefaultContext;
+	defaultAsync?: boolean;
+	defaultTimeoutMs?: number;
+	defaultTurnBudget?: TurnBudgetConfig;
 	systemPrompt: string;
 	source: AgentSource;
 	filePath: string;
@@ -1238,6 +1242,27 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			: frontmatter.defaultContext === "fresh"
 				? "fresh" as const
 				: undefined;
+		let defaultAsync: boolean | undefined;
+		if (frontmatter.async !== undefined) {
+			if (frontmatter.async === "true") defaultAsync = true;
+			else if (frontmatter.async === "false") defaultAsync = false;
+			else throw new Error(`Agent '${localName}' has invalid async frontmatter; expected true or false.`);
+		}
+		let defaultTimeoutMs: number | undefined;
+		if (frontmatter.timeoutMs !== undefined) {
+			const parsed = Number(frontmatter.timeoutMs);
+			if (!Number.isInteger(parsed) || parsed <= 0) {
+				throw new Error(`Agent '${localName}' has invalid timeoutMs frontmatter; expected a positive integer.`);
+			}
+			defaultTimeoutMs = parsed;
+		}
+		let defaultTurnBudget: TurnBudgetConfig | undefined;
+		if (frontmatter.turnBudget !== undefined && frontmatter.turnBudget.trim()) {
+			const parsed = JSON.parse(frontmatter.turnBudget) as unknown;
+			const resolved = resolveTurnBudgetConfig(parsed, `Agent '${localName}' turnBudget frontmatter`);
+			if (resolved.error) throw new Error(resolved.error);
+			defaultTurnBudget = resolved.turnBudget;
+		}
 
 		let extensions: string[] | undefined;
 		if (frontmatter.extensions !== undefined) {
@@ -1288,6 +1313,9 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			inheritProjectContext,
 			inheritSkills,
 			defaultContext,
+			defaultAsync,
+			defaultTimeoutMs,
+			defaultTurnBudget,
 			systemPrompt: body,
 			source,
 			filePath,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -43,7 +43,7 @@ import { createForkContextResolver } from "../../shared/fork-context.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBridge, resolveIntercomSessionTarget, resolveSubagentIntercomTarget, type IntercomBridgeState } from "../../intercom/intercom-bridge.ts";
 import { formatControlIntercomMessage, formatControlNoticeMessage, resolveControlConfig, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
-import { DEFAULT_TURN_BUDGET_GRACE_TURNS } from "../shared/turn-budget.ts";
+import { resolveTurnBudgetConfig } from "../shared/turn-budget.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
@@ -1551,6 +1551,22 @@ function buildRequestedModeError(params: SubagentParamsLike, message: string): A
 	);
 }
 
+function applySingleAgentLaunchDefaults(params: SubagentParamsLike, agents: AgentConfig[]): SubagentParamsLike {
+	if ((params.chain?.length ?? 0) > 0 || (params.tasks?.length ?? 0) > 0 || !params.agent) return params;
+	const agent = agents.find((candidate) => candidate.name === params.agent);
+	if (!agent) return params;
+	return {
+		...params,
+		...(params.async === undefined && agent.defaultAsync !== undefined ? { async: agent.defaultAsync } : {}),
+		...(params.timeoutMs === undefined && params.maxRuntimeMs === undefined && agent.defaultTimeoutMs !== undefined
+			? { timeoutMs: agent.defaultTimeoutMs }
+			: {}),
+		...(params.turnBudget === undefined && agent.defaultTurnBudget !== undefined
+			? { turnBudget: agent.defaultTurnBudget }
+			: {}),
+	};
+}
+
 function resolveForegroundTimeout(params: SubagentParamsLike): { timeoutMs?: number; error?: string } {
 	const rawTimeout = params.timeoutMs;
 	const rawMaxRuntime = params.maxRuntimeMs;
@@ -1565,20 +1581,6 @@ function resolveForegroundTimeout(params: SubagentParamsLike): { timeoutMs?: num
 		return { error: "timeoutMs and maxRuntimeMs are aliases; provide only one value or use the same value for both." };
 	}
 	return { timeoutMs: rawTimeout ?? rawMaxRuntime };
-}
-
-function resolveTurnBudget(params: SubagentParamsLike, config: ExtensionConfig): { turnBudget?: ResolvedTurnBudget; error?: string } {
-	const raw = params.turnBudget ?? config.turnBudget;
-	if (raw === undefined) return {};
-	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return { error: "turnBudget must be an object with maxTurns and optional graceTurns." };
-	if (typeof raw.maxTurns !== "number" || !Number.isInteger(raw.maxTurns) || raw.maxTurns < 1) {
-		return { error: "turnBudget.maxTurns must be an integer >= 1." };
-	}
-	const graceTurns = raw.graceTurns ?? DEFAULT_TURN_BUDGET_GRACE_TURNS;
-	if (typeof graceTurns !== "number" || !Number.isInteger(graceTurns) || graceTurns < 0) {
-		return { error: "turnBudget.graceTurns must be an integer >= 0." };
-	}
-	return { turnBudget: { maxTurns: raw.maxTurns, graceTurns } };
 }
 
 function resolveToolBudget(raw: unknown, label = "toolBudget"): { toolBudget?: ResolvedToolBudget; error?: string } {
@@ -3423,10 +3425,6 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			depth,
 			deps.config.forceTopLevelAsync === true,
 		);
-		const foregroundTimeout = resolveForegroundTimeout(effectiveParams);
-		if (foregroundTimeout.error) return buildRequestedModeError(effectiveParams, foregroundTimeout.error);
-		const turnBudget = resolveTurnBudget(effectiveParams, deps.config);
-		if (turnBudget.error) return buildRequestedModeError(effectiveParams, turnBudget.error);
 		const runToolBudget = resolveToolBudget(effectiveParams.toolBudget, "toolBudget");
 		if (runToolBudget.error) return buildRequestedModeError(effectiveParams, runToolBudget.error);
 		const configToolBudget = resolveToolBudget(deps.config.toolBudget, "config.toolBudget");
@@ -3439,6 +3437,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const discovered = deps.discoverAgents(effectiveCwd, scope);
 		const discoveredAgents = discovered.agents;
 		const modelScope = discovered.modelScope;
+		effectiveParams = applySingleAgentLaunchDefaults(effectiveParams, discoveredAgents);
+		const foregroundTimeout = resolveForegroundTimeout(effectiveParams);
+		if (foregroundTimeout.error) return buildRequestedModeError(effectiveParams, foregroundTimeout.error);
+		const turnBudget = resolveTurnBudgetConfig(effectiveParams.turnBudget ?? deps.config.turnBudget);
+		if (turnBudget.error) return buildRequestedModeError(effectiveParams, turnBudget.error);
 		const contextPolicy = resolveAgentDefaultContextPolicy(effectiveParams, discoveredAgents);
 		effectiveParams = contextPolicy.params;
 		const sessionName = resolveIntercomSessionTarget(deps.pi.getSessionName(), ctx.sessionManager.getSessionId());

--- a/src/runs/shared/turn-budget.ts
+++ b/src/runs/shared/turn-budget.ts
@@ -2,6 +2,27 @@ import type { ResolvedTurnBudget, TurnBudgetState } from "../../shared/types.ts"
 
 export const DEFAULT_TURN_BUDGET_GRACE_TURNS = 1;
 
+export function resolveTurnBudgetConfig(
+	raw: unknown,
+	label = "turnBudget",
+): { turnBudget?: ResolvedTurnBudget; error?: string } {
+	if (raw === undefined) return {};
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		return { error: `${label} must be an object with maxTurns and optional graceTurns.` };
+	}
+	const unknownField = Object.keys(raw).find((key) => key !== "maxTurns" && key !== "graceTurns");
+	if (unknownField) return { error: `${label}.${unknownField} is not supported.` };
+	const budget = raw as { maxTurns?: unknown; graceTurns?: unknown };
+	if (typeof budget.maxTurns !== "number" || !Number.isInteger(budget.maxTurns) || budget.maxTurns < 1) {
+		return { error: `${label}.maxTurns must be an integer >= 1.` };
+	}
+	const graceTurns = budget.graceTurns ?? DEFAULT_TURN_BUDGET_GRACE_TURNS;
+	if (typeof graceTurns !== "number" || !Number.isInteger(graceTurns) || graceTurns < 0) {
+		return { error: `${label}.graceTurns must be an integer >= 0.` };
+	}
+	return { turnBudget: { maxTurns: budget.maxTurns, graceTurns } };
+}
+
 export function appendTurnBudgetSystemPrompt(systemPrompt: string, budget: ResolvedTurnBudget | undefined): string {
 	if (!budget) return systemPrompt;
 	const grace = budget.graceTurns === 1 ? "1 additional assistant turn" : `${budget.graceTurns} additional assistant turns`;

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -195,7 +195,9 @@ interface ExecutorToolResult {
 	isError?: boolean;
 	details?: {
 		totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
+		asyncId?: string;
 		timeoutMs?: number;
+		turnBudget?: { maxTurns: number; graceTurns: number };
 	};
 }
 
@@ -270,12 +272,16 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		return readCall().args;
 	}
 
-	function makeExecutor(agents = [makeAgent("echo")], config: Record<string, unknown> = {}) {
+	function makeExecutor(
+		agents = [makeAgent("echo")],
+		config: Record<string, unknown> = {},
+		asyncByDefault = false,
+	) {
 		return createSubagentExecutor!({
 			pi: { events: createEventBus(), getSessionName: () => undefined },
 			state: { baseCwd: tempDir, currentSessionId: null, asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null },
 			config,
-			asyncByDefault: false,
+			asyncByDefault,
 			tempArtifactsDir: tempDir,
 			getSubagentSessionRoot: () => tempDir,
 			expandTilde: (value: string) => value,
@@ -1326,6 +1332,80 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.isError, true);
 		assert.match(result.content[0]?.text ?? "", /aliases/);
 		assert.equal(mockPi.callCount(), 0);
+	});
+
+	it("applies agent frontmatter defaults to single-agent launches", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([
+			makeAgent("echo", {
+				defaultAsync: true,
+				defaultTimeoutMs: 2_000,
+				defaultTurnBudget: { maxTurns: 4, graceTurns: 2 },
+			}),
+		]);
+
+		const result = await executor.execute(
+			"agent-launch-defaults",
+			{ agent: "echo", task: "Task" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.match(result.content[0]?.text ?? "", /Async:/);
+		assert.equal(typeof result.details?.asyncId, "string");
+		assert.equal(result.details?.timeoutMs, 2_000);
+		assert.deepEqual(result.details?.turnBudget, { maxTurns: 4, graceTurns: 2 });
+	});
+
+	it("lets agent frontmatter override the global async default", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "agent foreground default finished" });
+		const executor = makeExecutor(
+			[makeAgent("echo", { defaultAsync: false })],
+			{},
+			true,
+		);
+
+		const result = await executor.execute(
+			"agent-foreground-default",
+			{ agent: "echo", task: "Task" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.match(result.content[0]?.text ?? "", /agent foreground default finished/);
+		assert.equal(result.details?.asyncId, undefined);
+	});
+
+	it("lets explicit single-agent launch values override frontmatter defaults", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "explicit foreground finished" });
+		const executor = makeExecutor([
+			makeAgent("echo", {
+				defaultAsync: true,
+				defaultTimeoutMs: 1,
+				defaultTurnBudget: { maxTurns: 1, graceTurns: 0 },
+			}),
+		]);
+
+		const result = await executor.execute(
+			"explicit-launch-values",
+			{
+				agent: "echo",
+				task: "Task",
+				async: false,
+				timeoutMs: 2_000,
+				turnBudget: { maxTurns: 4, graceTurns: 2 },
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.match(result.content[0]?.text ?? "", /explicit foreground finished/);
+		assert.equal(result.details?.asyncId, undefined);
 	});
 
 	it("allows timeout settings for async runs before spawning", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -138,6 +138,56 @@ Do work
 	});
 });
 
+describe("agent frontmatter launch defaults", () => {
+	it("serializes and discovers single-agent launch defaults", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-launch-defaults-"));
+		tempDirs.push(dir);
+		const filePath = path.join(dir, ".pi", "agents", "worker.md");
+		const agent: AgentConfig = {
+			name: "worker",
+			description: "Worker",
+			systemPrompt: "Do work",
+			systemPromptMode: "replace",
+			inheritProjectContext: false,
+			inheritSkills: false,
+			source: "project",
+			filePath,
+			defaultAsync: false,
+			defaultTimeoutMs: 90_000,
+			defaultTurnBudget: { maxTurns: 12, graceTurns: 2 },
+		};
+
+		const serialized = serializeAgent(agent);
+		assert.match(serialized, /^async: false$/m);
+		assert.match(serialized, /^timeoutMs: 90000$/m);
+		assert.match(serialized, /^turnBudget: \{"maxTurns":12,"graceTurns":2\}$/m);
+		writeAgent(filePath, serialized);
+
+		const worker = discoverAgents(dir, "project").agents.find((candidate) => candidate.name === "worker");
+		assert.equal(worker?.defaultAsync, false);
+		assert.equal(worker?.defaultTimeoutMs, 90_000);
+		assert.deepEqual(worker?.defaultTurnBudget, { maxTurns: 12, graceTurns: 2 });
+	});
+
+	it("rejects invalid launch defaults instead of silently ignoring them", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-invalid-launch-defaults-"));
+		tempDirs.push(dir);
+		writeAgent(path.join(dir, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Worker
+async: sometimes
+---
+
+Do work
+`);
+
+		assert.throws(
+			() => discoverAgents(dir, "project"),
+			/Agent 'worker' has invalid async frontmatter; expected true or false/,
+		);
+	});
+});
+
 describe("chain discovery", () => {
 	it("prefers same-scope .chain.json over .chain.md for the same runtime name", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-chain-format-precedence-"));

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -153,6 +153,63 @@ Inspect
 		assert.doesNotMatch(content, /^package:/m);
 	});
 
+	it("creates and updates agents with single-agent launch defaults", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+		const result = handleCreate(
+			{
+				config: {
+					name: "background-reviewer",
+					description: "Review in the background",
+					scope: "project",
+					async: false,
+					timeoutMs: 120_000,
+					turnBudget: { maxTurns: 8, graceTurns: 2 },
+				},
+			},
+			ctx,
+		);
+
+		assert.equal(result.isError, false);
+		const filePath = path.join(tempDir, ".pi", "agents", "background-reviewer.md");
+		let content = fs.readFileSync(filePath, "utf-8");
+		assert.match(content, /^async: false$/m);
+		assert.match(content, /^timeoutMs: 120000$/m);
+		assert.match(content, /^turnBudget: \{"maxTurns":8,"graceTurns":2\}$/m);
+
+		const got = handleManagementAction("get", { agent: "background-reviewer" }, ctx);
+		assert.equal(got.isError, false);
+		assert.match(readText(got), /Async: false/);
+		assert.match(readText(got), /Timeout: 120000ms/);
+		assert.match(readText(got), /Turn budget: \{"maxTurns":8,"graceTurns":2\}/);
+
+		const updated = handleUpdate(
+			{ agent: "background-reviewer", config: { async: true, timeoutMs: false, turnBudget: false } },
+			ctx,
+		);
+		assert.equal(updated.isError, false);
+		content = fs.readFileSync(filePath, "utf-8");
+		assert.match(content, /^async: true$/m);
+		assert.doesNotMatch(content, /^timeoutMs:/m);
+		assert.doesNotMatch(content, /^turnBudget:/m);
+	});
+
+	it("rejects invalid single-agent launch defaults", () => {
+		const result = handleCreate(
+			{
+				config: {
+					name: "bad-launch-defaults",
+					description: "Bad defaults",
+					scope: "project",
+					timeoutMs: 0,
+				},
+			},
+			{ cwd: tempDir, modelRegistry: { getAvailable: () => [] } },
+		);
+
+		assert.equal(result.isError, true);
+		assert.match(readText(result), /config\.timeoutMs must be a positive integer/);
+	});
+
 	it("creates and updates agents with tool budgets", () => {
 		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
 		const result = handleCreate(

--- a/test/unit/turn-budget.test.ts
+++ b/test/unit/turn-budget.test.ts
@@ -6,6 +6,7 @@ import {
 	appendTurnBudgetSystemPrompt,
 	formatTurnBudgetOutput,
 	initialTurnBudgetState,
+	resolveTurnBudgetConfig,
 	shouldAbortForTurnBudget,
 	turnBudgetExceededMessage,
 	turnBudgetSoftNote,
@@ -20,6 +21,29 @@ describe("turn-budget module", () => {
 	describe("DEFAULT_TURN_BUDGET_GRACE_TURNS", () => {
 		it("defaults to one grace turn", () => {
 			assert.equal(DEFAULT_TURN_BUDGET_GRACE_TURNS, 1);
+		});
+	});
+
+	describe("resolveTurnBudgetConfig", () => {
+		it("resolves valid budgets and supplies the default grace turn", () => {
+			assert.deepEqual(resolveTurnBudgetConfig({ maxTurns: 5 }), {
+				turnBudget: { maxTurns: 5, graceTurns: 1 },
+			});
+			assert.deepEqual(resolveTurnBudgetConfig({ maxTurns: 5, graceTurns: 0 }), {
+				turnBudget: { maxTurns: 5, graceTurns: 0 },
+			});
+		});
+
+		it("rejects invalid values with the caller's boundary label", () => {
+			assert.deepEqual(resolveTurnBudgetConfig({ maxTurns: 0 }, "agent.turnBudget"), {
+				error: "agent.turnBudget.maxTurns must be an integer >= 1.",
+			});
+			assert.deepEqual(resolveTurnBudgetConfig({ maxTurns: 2, graceTurns: -1 }), {
+				error: "turnBudget.graceTurns must be an integer >= 0.",
+			});
+			assert.deepEqual(resolveTurnBudgetConfig({ maxTurns: 2, extra: true }), {
+				error: "turnBudget.extra is not supported.",
+			});
 		});
 	});
 


### PR DESCRIPTION
Closes #410.

Agent frontmatter can now set defaults for single-agent `async`, `timeoutMs`, and `turnBudget` launches. Explicit tool-call values remain authoritative, followed by agent frontmatter and then global config; `forceTopLevelAsync` still wins. Chain and parallel lifecycle settings remain top-level.

This includes parsing, serialization, management create/update/get support, documentation, and precedence regressions.

Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for the request.