### PR TITLE
refactor: nest project-local subagent artifacts under .pi/subagents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .pi/todos/
+.pi/subagents/
+# Legacy artifacts location; keep ignored until old worktrees are cleaned up.
 .pi-subagents/
 .DS_Store
 AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Moved project-local subagent artifacts from `.pi-subagents/` to the project config `subagents/` directory (`.pi/subagents/` in standard Pi), consistent with the existing project-scoped config directory used for agent memory. The watchdog change signature ignores the new location under custom Pi config directories too. Existing `.pi-subagents/` directories are left in place and are safe to delete manually. Projects that gitignored `.pi-subagents/` should add the new location (`.pi/subagents/` in standard Pi, or `{configDir}/subagents/` for custom Pi config directories) to their `.gitignore`.
+
 ### Added
 - Added single-agent launch defaults for `async`, `timeoutMs`, and `turnBudget` in agent frontmatter, with explicit tool-call values taking precedence. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #410.
 - Added `/subagents-stop` and `subagent({ action: "stop", id })` for current-session top-level async runs. The slash command opens a confirmation selector when no id is provided, falls back to exact commands without a TUI, routes scheduled jobs through `schedule-cancel`, and records manual stops as `stopped`/cancelled lifecycle events instead of timeouts. Thanks to Sean Seaman (@seans-leadsonline) for #407 and #408.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ You do not have to spell a model exactly. Model ids are matched fuzzily against 
 
 The subagent watchdog is not the `reviewer` subagent. `subagents.defaultModel` and `subagents.agentOverrides.reviewer` do not configure it. The watchdog is an opt-in adversarial change reviewer, so it should usually use a strong complementary model rather than a cheap/light model.
 
-The watchdog reviews repo edits, not ordinary conversation. It runs at the safe `agent_end` boundary only when the current agent or child writer changed the final repo state since the start of that turn. Multiple edits in one turn are coalesced into one review of the final changed state, unchanged/reverted diffs are skipped, and generated `.pi-subagents/` or `tmp/` artifacts do not trigger review. In orchestrated runs, each writing child can review its own edited worktree, and the parent can still review the aggregate repo diff after child changes are applied.
+The watchdog reviews repo edits, not ordinary conversation. It runs at the safe `agent_end` boundary only when the current agent or child writer changed the final repo state since the start of that turn. Multiple edits in one turn are coalesced into one review of the final changed state, unchanged/reverted diffs are skipped, and generated project-local subagent artifacts (`.pi/subagents/` in standard Pi) or `tmp/` artifacts do not trigger review. In orchestrated runs, each writing child can review its own edited worktree, and the parent can still review the aggregate repo diff after child changes are applied.
 
 When the watchdog is enabled, it also checks changed TypeScript and JavaScript files for fresh language-server diagnostics before the model review. It auto-detects `typescript-language-server` from the project `node_modules/.bin` or `PATH`; it never installs tools or scans the whole workspace. LSP errors surface as watchdog blockers, warnings as concerns, and info/hints stay in status details. Slow or missing servers are reported in `/subagents-watchdog status` without blocking the turn or emitting late mid-turn warnings. Configure the bounds with `subagents.watchdog.lsp.enabled`, `timeoutMs`, `maxFiles`, and `maxDiagnostics`.
 
@@ -1382,7 +1382,7 @@ Each chain run creates a user-scoped temp directory like:
 
 It may contain files such as `context.md`, `plan.md`, `progress.md`, and `parallel-{stepIndex}/.../output.md`. Directories older than 24 hours are cleaned up on extension startup.
 
-Debug artifacts live under `{sessionDir}/subagent-artifacts/`, `.pi-subagents/artifacts/` for project-scoped runs, or a user-scoped temp artifact directory. Single-run relative `output` files are saved under `{artifactsDir}/outputs/{runId}/` unless `singleRunOutputBaseDir` is configured. Per task you may see:
+Debug artifacts live under `{sessionDir}/subagent-artifacts/`, the project config `subagents/artifacts/` directory for project-scoped runs (`.pi/subagents/artifacts/` in standard Pi), or a user-scoped temp artifact directory. Single-run relative `output` files are saved under `{artifactsDir}/outputs/{runId}/` unless `singleRunOutputBaseDir` is configured. Per task you may see:
 
 - `{runId}_{agent}_input.md`
 - `{runId}_{agent}_output.md`
@@ -1390,6 +1390,8 @@ Debug artifacts live under `{sessionDir}/subagent-artifacts/`, `.pi-subagents/ar
 - `{runId}_{agent}_meta.json`
 
 Metadata records timing, usage, exit code, final model, attempted models, and fallback attempt outcomes.
+
+Project-scoped artifacts are generated files, so add the project config `subagents/` directory to your project's `.gitignore` (`.pi/subagents/` in standard Pi; adjust the prefix if your Pi build uses a custom config directory).
 
 Session files are stored under a per-run session directory. With `context: "fork"`, each child starts with `--session <branched-session-file>` produced from the parent’s current leaf. That is a real session fork, not an injected summary.
 

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -1,12 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { TEMP_ARTIFACTS_DIR, type ArtifactPaths } from "./types.ts";
-import { getAgentDir } from "./utils.ts";
+import { getAgentDir, getProjectConfigDir } from "./utils.ts";
 const CLEANUP_MARKER_FILE = ".last-cleanup";
-const PROJECT_ARTIFACT_ROOT = ".pi-subagents";
+const PROJECT_ARTIFACT_DIR_NAME = "subagents";
 
 export function getProjectSubagentsDir(cwd: string): string {
-	return path.join(cwd, PROJECT_ARTIFACT_ROOT);
+	return path.join(getProjectConfigDir(cwd), PROJECT_ARTIFACT_DIR_NAME);
 }
 
 export function getProjectArtifactsDir(cwd: string): string {

--- a/src/watchdog/change-signature.ts
+++ b/src/watchdog/change-signature.ts
@@ -2,9 +2,25 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { getProjectSubagentsDir } from "../shared/artifacts.ts";
 
-const IGNORED_CHANGE_PREFIXES = [".pi-subagents/", "tmp/", "node_modules/"];
-const IGNORED_CHANGE_PATHS = new Set([".pi-subagents", "tmp", "node_modules"]);
+const STATIC_IGNORED_CHANGE_PATHS = ["tmp", "node_modules"];
+
+interface IgnoreRules {
+	prefixes: string[];
+	paths: Set<string>;
+}
+
+function buildIgnoreRules(root: string): IgnoreRules {
+	// Project-local subagent artifacts live under {project config dir}/subagents,
+	// which is configurable (".pi" by default), so resolve it per repo root.
+	const subagentsRelPath = normalizeRelPath(path.relative(root, getProjectSubagentsDir(root)));
+	const ignoredPaths = [...STATIC_IGNORED_CHANGE_PATHS, subagentsRelPath];
+	return {
+		prefixes: ignoredPaths.map((entry) => `${entry}/`),
+		paths: new Set(ignoredPaths),
+	};
+}
 
 export interface WatchdogRepoChangeSignature {
 	root: string;
@@ -22,16 +38,16 @@ function normalizeRelPath(value: string): string {
 	return value.replaceAll(path.sep, "/").replace(/^\.\//, "");
 }
 
-function ignoredRelPath(relPath: string): boolean {
+function ignoredRelPath(relPath: string, rules: IgnoreRules): boolean {
 	const normalized = normalizeRelPath(relPath);
-	return IGNORED_CHANGE_PATHS.has(normalized) || IGNORED_CHANGE_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+	return rules.paths.has(normalized) || rules.prefixes.some((prefix) => normalized.startsWith(prefix));
 }
 
 function hashFile(filePath: string): string {
 	return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
 
-function hashPath(root: string, relPath: string): unknown {
+function hashPath(root: string, relPath: string, rules: IgnoreRules): unknown {
 	const normalized = normalizeRelPath(relPath);
 	const fullPath = path.join(root, normalized);
 	let stat: fs.Stats;
@@ -47,9 +63,9 @@ function hashPath(root: string, relPath: string): unknown {
 	if (stat.isDirectory()) {
 		const entries = fs.readdirSync(fullPath)
 			.map((entry) => normalizeRelPath(path.posix.join(normalized, entry)))
-			.filter((entry) => !ignoredRelPath(entry))
+			.filter((entry) => !ignoredRelPath(entry, rules))
 			.sort();
-		return { path: normalized, state: "dir", entries: entries.map((entry) => hashPath(root, entry)) };
+		return { path: normalized, state: "dir", entries: entries.map((entry) => hashPath(root, entry, rules)) };
 	}
 	if (stat.isFile()) {
 		return { path: normalized, state: "file", mode: stat.mode & 0o777, size: stat.size, hash: hashFile(fullPath) };
@@ -80,10 +96,11 @@ export function computeWatchdogRepoChangeSignature(cwd: string): WatchdogRepoCha
 	if (!root) return undefined;
 	const statusOutput = git(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]);
 	if (statusOutput === undefined) return undefined;
+	const rules = buildIgnoreRules(root);
 	const entries = parsePorcelainZ(statusOutput)
 		.map((entry) => ({
 			status: entry.status,
-			paths: entry.paths.map(normalizeRelPath).filter((relPath) => !ignoredRelPath(relPath)),
+			paths: entry.paths.map(normalizeRelPath).filter((relPath) => !ignoredRelPath(relPath, rules)),
 		}))
 		.filter((entry) => entry.paths.length > 0)
 		.sort((a, b) => `${a.status} ${a.paths.join("\0")}`.localeCompare(`${b.status} ${b.paths.join("\0")}`));
@@ -91,7 +108,7 @@ export function computeWatchdogRepoChangeSignature(cwd: string): WatchdogRepoCha
 	const payload = entries.map((entry) => ({
 		status: entry.status,
 		paths: entry.paths,
-		content: entry.paths.map((relPath) => hashPath(root, relPath)),
+		content: entry.paths.map((relPath) => hashPath(root, relPath, rules)),
 	}));
 	const key = createHash("sha256").update(JSON.stringify(payload)).digest("hex");
 	return { root, key, changedPaths };

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -790,7 +790,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			assert.equal(payload.results[0]?.acceptance?.status, "checked");
 			assert.equal(status.sessionId, "session-123");
 			assert.equal(status.steps?.[0]?.acceptance?.status, "checked");
-		const outputPath = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", asyncId, "async-top-output.md");
+		const outputPath = path.join(tempDir, ".pi", "subagents", "artifacts", "outputs", asyncId, "async-top-output.md");
 		const outputDeadline = Date.now() + 5_000;
 		while (!fs.existsSync(outputPath)) {
 			if (Date.now() > outputDeadline) {
@@ -803,7 +803,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.ok(callFile, "expected a recorded mock pi call");
 		const args = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
 		const taskArg = args.at(-1) ?? "";
-		const progressPath = path.join(tempDir, ".pi-subagents", "artifacts", "progress", asyncId, "progress.md");
+		const progressPath = path.join(tempDir, ".pi", "subagents", "artifacts", "progress", asyncId, "progress.md");
 		assert.ok(taskArg.includes(`[Read from: ${path.join(tempDir, "input.md")}]`));
 		assert.ok(taskArg.includes(`Update progress at: ${progressPath}`));
 		assert.ok(taskArg.includes(`Write your findings to exactly this path: ${outputPath}`));
@@ -1339,7 +1339,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			const args = await waitForMockPiArgs(mockPi, 0);
 			const taskArg = args.at(-1) ?? "";
 			assert.ok(taskArg.includes(`[Read from: ${path.join(worktreeCwd, "input.md")}]`));
-			assert.ok(taskArg.includes(`Write your findings to exactly this path: ${path.join(repoDir, ".pi-subagents", "artifacts", "outputs", asyncId, "report.md")}`));
+			assert.ok(taskArg.includes(`Write your findings to exactly this path: ${path.join(repoDir, ".pi", "subagents", "artifacts", "outputs", asyncId, "report.md")}`));
 			await waitForAsyncResultFile(asyncId, 90_000);
 		} finally {
 			removeTempDir(repoDir);

--- a/test/integration/parallel-execution.test.ts
+++ b/test/integration/parallel-execution.test.ts
@@ -205,7 +205,7 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 
 		const runId = result.details?.runId;
 		assert.ok(runId, "expected run id in details");
-		const outputPath = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", runId, "parallel-output.md");
+		const outputPath = path.join(tempDir, ".pi", "subagents", "artifacts", "outputs", runId, "parallel-output.md");
 		assert.equal(result.isError, undefined);
 		assert.equal(fs.readFileSync(outputPath, "utf-8"), "Saved report");
 		assert.equal(result.details?.results?.[0]?.savedOutputPath, outputPath);
@@ -258,7 +258,7 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 
 		const runId = result.details?.runId;
 		assert.ok(runId, "expected run id in details");
-		const outputPath = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", runId, "parallel-file-only.md");
+		const outputPath = path.join(tempDir, ".pi", "subagents", "artifacts", "outputs", runId, "parallel-file-only.md");
 		const text = result.content[0]?.text ?? "";
 		assert.equal(result.isError, undefined);
 		assert.match(text, /Output saved to:/);
@@ -369,7 +369,7 @@ Inspect
 		);
 		const runId = result.details?.runId;
 		assert.ok(runId, "expected run id in details");
-		const expectedProgressPath = path.join(tempDir, ".pi-subagents", "artifacts", "progress", runId, "progress.md");
+		const expectedProgressPath = path.join(tempDir, ".pi", "subagents", "artifacts", "progress", runId, "progress.md");
 
 		const args = readLastCallArgs();
 		const taskArg = args.at(-1) ?? "";

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1241,7 +1241,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		const taskArg = readCallArgs().at(-1) ?? "";
 		assert.equal(result.isError, undefined);
-		assert.match(taskArg, new RegExp(`Write your findings to exactly this path: ${escapeRegExp(path.join(tempDir, ".pi-subagents", "artifacts", "outputs"))}.*context\\.md`));
+		assert.match(taskArg, new RegExp(`Write your findings to exactly this path: ${escapeRegExp(path.join(tempDir, ".pi", "subagents", "artifacts", "outputs"))}.*context\\.md`));
 		assert.equal(fs.existsSync(path.join(tempDir, "context.md")), false);
 	});
 

--- a/test/unit/artifacts.test.ts
+++ b/test/unit/artifacts.test.ts
@@ -9,12 +9,12 @@ import {
 } from "../../src/shared/artifacts.ts";
 
 describe("project-local artifact paths", () => {
-	it("places generated subagent files under .pi-subagents for a project cwd", () => {
+	it("places generated subagent files under .pi/subagents for a project cwd", () => {
 		const cwd = path.join("tmp", "repo");
-		assert.equal(getProjectSubagentsDir(cwd), path.join(cwd, ".pi-subagents"));
-		assert.equal(getProjectArtifactsDir(cwd), path.join(cwd, ".pi-subagents", "artifacts"));
-		assert.equal(getProjectChainRunsDir(cwd), path.join(cwd, ".pi-subagents", "chain-runs"));
-		assert.equal(getArtifactsDir(null, cwd), path.join(cwd, ".pi-subagents", "artifacts"));
+		assert.equal(getProjectSubagentsDir(cwd), path.join(cwd, ".pi", "subagents"));
+		assert.equal(getProjectArtifactsDir(cwd), path.join(cwd, ".pi", "subagents", "artifacts"));
+		assert.equal(getProjectChainRunsDir(cwd), path.join(cwd, ".pi", "subagents", "chain-runs"));
+		assert.equal(getArtifactsDir(null, cwd), path.join(cwd, ".pi", "subagents", "artifacts"));
 	});
 
 	it("keeps the session artifact fallback when no project cwd is available", () => {

--- a/test/unit/single-output.test.ts
+++ b/test/unit/single-output.test.ts
@@ -74,8 +74,8 @@ describe("resolveSingleOutputPath", () => {
 	});
 
 	it("resolves relative output paths against an explicit artifact base", () => {
-		const resolved = resolveSingleOutputPath("reviews/report.md", "/runtime", "/requested", "/repo/.pi-subagents/artifacts/outputs/run-1");
-		assert.equal(resolved, path.resolve("/repo/.pi-subagents/artifacts/outputs/run-1", "reviews/report.md"));
+		const resolved = resolveSingleOutputPath("reviews/report.md", "/runtime", "/requested", "/repo/.pi/subagents/artifacts/outputs/run-1");
+		assert.equal(resolved, path.resolve("/repo/.pi/subagents/artifacts/outputs/run-1", "reviews/report.md"));
 	});
 });
 

--- a/test/unit/watchdog-change-signature.test.ts
+++ b/test/unit/watchdog-change-signature.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
+import { computeWatchdogRepoChangeSignature } from "../../src/watchdog/change-signature.ts";
+
+function git(cwd: string, args: string[]): string {
+	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8" });
+	if (result.status !== 0) throw new Error(result.stderr.trim() || result.stdout.trim() || `git ${args.join(" ")} failed`);
+	return result.stdout.trim();
+}
+
+function createRepo(): string {
+	const repo = fs.mkdtempSync(path.join(os.tmpdir(), "watchdog-change-signature-"));
+	git(repo, ["init"]);
+	git(repo, ["config", "user.email", "watchdog@example.com"]);
+	git(repo, ["config", "user.name", "Watchdog Tests"]);
+	fs.mkdirSync(path.join(repo, "src"));
+	fs.writeFileSync(path.join(repo, "src", "file.ts"), "export const value = 1;\n", "utf-8");
+	git(repo, ["add", "-A"]);
+	git(repo, ["commit", "-m", "initial"]);
+	return repo;
+}
+
+function writeArtifact(repo: string, configDirName: string): void {
+	const artifactsDir = path.join(repo, configDirName, "subagents", "artifacts");
+	fs.mkdirSync(artifactsDir, { recursive: true });
+	fs.writeFileSync(path.join(artifactsDir, "run_output.md"), "artifact\n", "utf-8");
+}
+
+function createCustomConfigPackageRoot(configDirName: string): string {
+	const packageRoot = fs.mkdtempSync(path.join(os.tmpdir(), "watchdog-config-root-"));
+	fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({
+		name: "@earendil-works/pi-coding-agent",
+		piConfig: { configDir: configDirName },
+	}), "utf-8");
+	return packageRoot;
+}
+
+describe("watchdog repo change signature ignore rules", () => {
+	const tempDirs: string[] = [];
+	let previousPackageRootEnv: string | undefined;
+
+	beforeEach(() => {
+		previousPackageRootEnv = process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV];
+		delete process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV];
+	});
+
+	afterEach(() => {
+		if (previousPackageRootEnv === undefined) delete process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV];
+		else process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] = previousPackageRootEnv;
+		for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	function trackedRepo(): string {
+		const repo = createRepo();
+		tempDirs.push(repo);
+		return repo;
+	}
+
+	it("ignores default .pi/subagents artifacts and keeps real changes", () => {
+		const repo = trackedRepo();
+		const baseline = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(baseline);
+
+		writeArtifact(repo, ".pi");
+		const withArtifact = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(withArtifact);
+		assert.equal(withArtifact.key, baseline.key);
+		assert.deepEqual(withArtifact.changedPaths, []);
+
+		fs.writeFileSync(path.join(repo, "src", "file.ts"), "export const value = 2;\n", "utf-8");
+		const withEdit = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(withEdit);
+		assert.notEqual(withEdit.key, baseline.key);
+		assert.deepEqual(withEdit.changedPaths, ["src/file.ts"]);
+	});
+
+	it("ignores artifacts under a custom Pi config directory", () => {
+		const packageRoot = createCustomConfigPackageRoot(".custom-pi");
+		tempDirs.push(packageRoot);
+		process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] = packageRoot;
+
+		const repo = trackedRepo();
+		const baseline = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(baseline);
+
+		writeArtifact(repo, ".custom-pi");
+		const withArtifact = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(withArtifact);
+		assert.equal(withArtifact.key, baseline.key);
+		assert.deepEqual(withArtifact.changedPaths, []);
+	});
+
+	it("still ignores tmp/ and node_modules/ alongside dynamic artifact rules", () => {
+		const repo = trackedRepo();
+		const baseline = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(baseline);
+
+		fs.mkdirSync(path.join(repo, "tmp"), { recursive: true });
+		fs.writeFileSync(path.join(repo, "tmp", "scratch.txt"), "scratch\n", "utf-8");
+		fs.mkdirSync(path.join(repo, "node_modules", "dep"), { recursive: true });
+		fs.writeFileSync(path.join(repo, "node_modules", "dep", "index.js"), "module.exports = 1;\n", "utf-8");
+
+		const withIgnored = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(withIgnored);
+		assert.equal(withIgnored.key, baseline.key);
+		assert.deepEqual(withIgnored.changedPaths, []);
+	});
+});


### PR DESCRIPTION
Small follow-up to #326 / the `.pi-subagents/` default.

`.pi-subagents/` currently sits as its own top-level dot-folder in the project root. Every coding agent already claims its own project dot-folder these days — `.claude/`, `.cursor/`, `.codex/`, `.gemini/` — so repo roots fill up fast, and one consolidated folder per tool feels cleaner than two Pi-related ones. Pi's slot is `.pi/`, and this codebase already uses it for agent memory (`getProjectConfigDir()` → `<project>/.pi/`, used in `agent-memory.ts`). This PR reuses that same convention for artifacts.

## Changes

- `getProjectSubagentsDir()` now builds off `getProjectConfigDir()` instead of a hardcoded `.pi-subagents` constant. New default: `<project>/.pi/subagents/`. Since the config dir name is resolvable (custom Pi builds can override `.pi`), the artifact path follows it automatically.
- The watchdog ignore rules resolve the artifact directory per repo root instead of hardcoding the path, so custom config dir names stay ignored too. Added unit tests covering the default dir, a custom config dir, and the static `tmp/` / `node_modules/` rules.
- Updated README mentions, `.gitignore` (old `.pi-subagents/` entry kept for existing worktrees), and the tests that asserted the old path.
- Existing `.pi-subagents/` directories from prior runs are untouched (not migrated) — noted in the CHANGELOG, safe to delete manually.

If you'd rather keep the old path as default and gate this behind a config option / env var instead, I'm happy to go that route — wanted to start with the direct version since it's a pure rename with no behavior change, but no strong attachment to the approach if you see it differently.

## Testing

- `npm run test:unit` — 1085 passing
- Touched integration suites (`parallel-execution`, `async-execution`, `single-execution`) — 168 passing
