### PR TITLE
fix: support max thinking level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Recognized Pi's `max` thinking level in child model suffixes, Clarify selection, watchdog settings, and status formatting, while exposing it only when model metadata explicitly supports it. Thanks to mapleluv (@mapleluvr) for #423.
 - Labeled every chain-clarification shortcut with its action, made the background state explicit, and kept primary actions in a separate footer without widening the fixed 84-column overlay. Thanks to GonzaloRocca (@gonzalonicolasr) for #430.
 - Hardened acceptance reports so explicit empty changed-file and test arrays are treated as not applicable, required criteria are reflected in examples, known model-output variants normalize to one strict canonical shape, unknown or ambiguous values fail with exact diagnostics, and parsed reports plus ledgers persist in child metadata while normal output stays clean. Thanks to Nick Tripp (@nicholastripp) for #442, maxsturmb (@maxsturmb) for #452, and techmodv90 (@techmodv90) for #449 and #450.
 - Shared task-intent classification between acceptance inference and the completion guard so read-only tasks with explicit no-edit wording do not receive impossible write-evidence gates, while scoped prohibitions still preserve later implementation clauses. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #433.

--- a/src/runs/foreground/chain-clarify.ts
+++ b/src/runs/foreground/chain-clarify.ts
@@ -1004,6 +1004,7 @@ export class ChainClarifyComponent implements Component {
 			"medium": "Moderate reasoning",
 			"high": "Deep reasoning",
 			"xhigh": "Maximum reasoning (ultrathink)",
+			"max": "Maximum available reasoning",
 		};
 
 		const levels = this.getAvailableThinkingLevels(this.editingStep!);

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -6,10 +6,10 @@ import { encodeNestedPathEnv, parseNestedPathEnv, type NestedPathEntry } from ".
 import { resolveMcpDirectToolNames } from "./mcp-direct-tool-allowlist.ts";
 import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "./structured-output.ts";
 import { TEMP_ROOT_DIR, type JsonSchemaObject, type ResolvedToolBudget } from "../../shared/types.ts";
+import { THINKING_LEVELS } from "../../shared/model-info.ts";
 import { TOOL_BUDGET_ENV, encodeToolBudgetEnv } from "./tool-budget.ts";
 import { CHILD_WATCHDOG_CONFIG_ENV, encodeChildWatchdogConfig, type ChildWatchdogConfig } from "../../watchdog/child-status.ts";
 
-const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
 const TASK_ARG_LIMIT = 8000;
 const PROMPT_RUNTIME_EXTENSION_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-prompt-runtime.ts");
 const FANOUT_CHILD_EXTENSION_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "extension", "fanout-child.ts");
@@ -92,7 +92,7 @@ function supervisorChannelDir(runId: string, agent: string, childIndex: number):
 export function applyThinkingSuffix(model: string | undefined, thinking: string | false | undefined, replaceExisting = false): string | undefined {
 	if (!model || !thinking) return model;
 	const colonIdx = model.lastIndexOf(":");
-	if (colonIdx !== -1 && THINKING_LEVELS.includes(model.substring(colonIdx + 1))) {
+	if (colonIdx !== -1 && THINKING_LEVELS.some((level) => level === model.substring(colonIdx + 1))) {
 		return replaceExisting ? `${model.slice(0, colonIdx)}:${thinking}` : model;
 	}
 	return `${model}:${thinking}`;

--- a/src/shared/model-info.ts
+++ b/src/shared/model-info.ts
@@ -1,4 +1,4 @@
-export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 export type ThinkingLevel = typeof THINKING_LEVELS[number];
 export type ThinkingLevelMap = Partial<Record<ThinkingLevel, string | null>>;
 
@@ -63,15 +63,15 @@ export function findModelInfo(model: string | undefined, availableModels: ModelI
 }
 
 export function getSupportedThinkingLevels(model: ModelInfo | undefined): ThinkingLevel[] {
-	if (!model) return [...THINKING_LEVELS];
+	if (!model) return THINKING_LEVELS.filter((level) => level !== "max");
 	if (model.reasoning === false) return ["off"];
 
-	if (!model.thinkingLevelMap) return [...THINKING_LEVELS];
+	if (!model.thinkingLevelMap) return THINKING_LEVELS.filter((level) => level !== "max");
 
 	const levels = THINKING_LEVELS.filter((level) => {
 		const mapped = model.thinkingLevelMap?.[level];
 		if (mapped === null) return false;
-		if (level === "xhigh") return mapped !== undefined;
+		if (level === "xhigh" || level === "max") return mapped !== undefined;
 		return true;
 	});
 	return levels;

--- a/test/integration/chain-clarify.test.ts
+++ b/test/integration/chain-clarify.test.ts
@@ -8,7 +8,7 @@ interface ClarifyTestModel {
 	id: string;
 	fullId: string;
 	reasoning?: boolean;
-	thinkingLevelMap?: Partial<Record<"off" | "minimal" | "low" | "medium" | "high" | "xhigh", string | null>>;
+	thinkingLevelMap?: Partial<Record<"off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max", string | null>>;
 }
 
 interface ClarifyTestComponent {
@@ -116,6 +116,38 @@ describe("chain clarify model display", { skip: !available ? "pi packages not av
 		assert.doesNotMatch(rendered, /minimal - Brief reasoning/);
 		assert.doesNotMatch(rendered, /low - Light reasoning/);
 		assert.doesNotMatch(rendered, /medium - Moderate reasoning/);
+		assert.doesNotMatch(rendered, /max - Maximum available reasoning/);
+	});
+
+	it("renders the max thinking option when the selected model exposes it", () => {
+		const component = new ChainClarifyComponent(
+			{ requestRender() {} },
+			{ fg(_key: string, text: string) { return text; } },
+			[{
+				name: "worker",
+				description: "",
+				systemPrompt: "",
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+				source: "user",
+				filePath: "worker.md",
+				model: "openai/gpt-5",
+			}],
+			["Task"],
+			"Task",
+			undefined,
+			[{ output: false, outputMode: "inline", reads: false, progress: false, skills: [], model: "openai/gpt-5" }],
+			[{ provider: "openai", id: "gpt-5", fullId: "openai/gpt-5", reasoning: true, thinkingLevelMap: { max: "max" } }],
+			"openai",
+			[],
+			() => {},
+			"single",
+		);
+		component.selectedStep = 0;
+		component.enterThinkingSelector();
+		const rendered = component.renderThinkingSelector().join("\n");
+		assert.match(rendered, /max - Maximum available reasoning/);
 	});
 
 	it("drops thinking when switching to a model that does not support it", () => {

--- a/test/unit/model-info.test.ts
+++ b/test/unit/model-info.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { findModelInfo, getSupportedThinkingLevels, type ModelInfo } from "../../src/shared/model-info.ts";
+import { findModelInfo, getSupportedThinkingLevels, splitKnownThinkingSuffix, type ModelInfo } from "../../src/shared/model-info.ts";
 
 describe("model info helpers", () => {
 	const ambiguousModels: ModelInfo[] = [
@@ -20,14 +20,15 @@ describe("model info helpers", () => {
 		assert.equal(findModelInfo("openai/gpt-5-mini:high", ambiguousModels, "github-copilot")?.fullId, "openai/gpt-5-mini");
 	});
 
-	it("keeps the legacy full thinking list for reasoning models without per-level metadata", () => {
+	it("keeps the legacy thinking list for models without per-level metadata", () => {
 		assert.deepEqual(
 			getSupportedThinkingLevels({ provider: "openai", id: "gpt-5", fullId: "openai/gpt-5", reasoning: true }),
 			["off", "minimal", "low", "medium", "high", "xhigh"],
 		);
+		assert.deepEqual(getSupportedThinkingLevels(undefined), ["off", "minimal", "low", "medium", "high", "xhigh"]);
 	});
 
-	it("keeps the legacy full thinking list when older model metadata omits reasoning", () => {
+	it("keeps the legacy thinking list when older model metadata omits reasoning", () => {
 		assert.deepEqual(
 			getSupportedThinkingLevels({ provider: "openai", id: "gpt-5", fullId: "openai/gpt-5" }),
 			["off", "minimal", "low", "medium", "high", "xhigh"],
@@ -57,6 +58,23 @@ describe("model info helpers", () => {
 				thinkingLevelMap: { off: null, minimal: null, low: null, medium: null, high: "high" },
 			}),
 			["high"],
+		);
+	});
+
+	it("honors an explicit max mapping and recognizes max suffixes", () => {
+		assert.deepEqual(
+			getSupportedThinkingLevels({
+				provider: "openai",
+				id: "gpt-5",
+				fullId: "openai/gpt-5",
+				reasoning: true,
+				thinkingLevelMap: { off: null, minimal: null, low: null, medium: null, high: null, xhigh: null, max: "max" },
+			}),
+			["max"],
+		);
+		assert.deepEqual(
+			splitKnownThinkingSuffix("openai/gpt-5:max"),
+			{ baseModel: "openai/gpt-5", thinkingSuffix: ":max" },
 		);
 	});
 });

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -282,6 +282,24 @@ describe("buildPiArgs model wiring", () => {
 		assert.ok(args.includes("openai-codex/gpt-5.4-mini:high"));
 	});
 
+	it("passes max thinking through to the model argument", () => {
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			model: "openai/gpt-5",
+			thinking: "max",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.equal(applyThinkingSuffix("openai/gpt-5", "max"), "openai/gpt-5:max");
+		assert.equal(applyThinkingSuffix("openai/gpt-5:max", "high"), "openai/gpt-5:max");
+		assert.equal(applyThinkingSuffix("openai/gpt-5:max", "high", true), "openai/gpt-5:high");
+		assert.ok(args.includes("--model"));
+		assert.ok(args.includes("openai/gpt-5:max"));
+	});
+
 	it("passes explicit thinking off through to the model arg", () => {
 		const { args } = buildPiArgs({
 			baseArgs: ["-p"],

--- a/test/unit/status-format.test.ts
+++ b/test/unit/status-format.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { formatModelThinking } from "../../src/shared/formatters.ts";
 import { aggregateStepStatus, formatActivityLabel, formatParallelOutcome } from "../../src/shared/status-format.ts";
 import type { AsyncJobStep } from "../../src/shared/types.ts";
 
@@ -9,6 +10,11 @@ describe("status format helpers", () => {
 		assert.equal(formatActivityLabel(1_000, "needs_attention", 4_000), "no activity for 3s");
 		assert.equal(formatActivityLabel(undefined, "active_long_running", 4_000), "active but long-running");
 		assert.equal(formatActivityLabel(4_000, "active_long_running", 4_000), "active but long-running · last activity now");
+	});
+
+	it("formats max thinking from model suffixes and explicit metadata", () => {
+		assert.equal(formatModelThinking("openai/gpt-5:max"), "gpt-5 · thinking max");
+		assert.equal(formatModelThinking("openai/gpt-5", "max"), "gpt-5 · thinking max");
 	});
 
 	it("aggregates step status and parallel outcomes", () => {

--- a/test/unit/watchdog-model-selection.test.ts
+++ b/test/unit/watchdog-model-selection.test.ts
@@ -2,11 +2,14 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { recommendStrongWatchdogModel, resolveWatchdogModelInput } from "../../src/watchdog/model-selection.ts";
 
-function createCtx(current: { provider: string; id: string }, authenticated: string[] = ["openai-codex/gpt-5.5", "anthropic/claude-opus-4-8"]) {
-	const models = [
+function createCtx(
+	current: { provider: string; id: string },
+	authenticated: string[] = ["openai-codex/gpt-5.5", "anthropic/claude-opus-4-8"],
+	models: Array<{ provider: string; id: string; reasoning: boolean; thinkingLevelMap?: Record<string, string | null> }> = [
 		{ provider: "openai-codex", id: "gpt-5.5", reasoning: true },
 		{ provider: "anthropic", id: "claude-opus-4-8", reasoning: true },
-	];
+	],
+) {
 	return {
 		cwd: "/tmp/watchdog-model-selection",
 		model: current,
@@ -105,5 +108,14 @@ describe("watchdog model selection", () => {
 
 		assert.equal(resolved.model, "openai-codex/gpt-5.5");
 		assert.equal(resolved.thinking, "high");
+	});
+
+	it("accepts a max suffix for an authenticated watchdog model", () => {
+		const ctx = createCtx(
+			{ provider: "openai", id: "gpt-5" },
+			["openai/gpt-5"],
+			[{ provider: "openai", id: "gpt-5", reasoning: true, thinkingLevelMap: { max: "max" } }],
+		);
+		assert.equal(resolveWatchdogModelInput(ctx, "openai/gpt-5:max").thinking, "max");
 	});
 });


### PR DESCRIPTION
## Summary
- Add `max` to the single shared thinking-level source.
- Recognize and forward `:max` model suffixes across Pi arguments and watchdog model selection.
- Expose `max` in Clarify only when a model has an explicit `thinkingLevelMap.max`, while preserving legacy behavior for models without metadata.
- Add the Clarify label and unreleased changelog entry.

## Validation
- Focused unit suites: 53 passed, 0 failed.
- Clarify integration suite: 7 passed, 0 failed.
- E2E suite: 1 passed, 0 failed.
- `git diff --check` passed.

## Known Environment Failures
The aggregate test commands retain unrelated upstream failures outside this diff: package-agent fixture/management assertions, Windows symlink creation (`EPERM`), and the async acceptance-timeout cancellation assertion. The focused affected suites above pass.