### PR TITLE
fix(extension): friendly chain schema errors with allowed props and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Replaced raw chain-schema failures with actionable errors that name invalid properties, list allowed fields, and show valid examples. Thanks to Nicolas Marchildon (@elecnix) for #416 and #425.
 - Hide lower-priority agent definitions from `subagent({ action: "list" })` when a higher-priority project or user agent shadows them. Thanks to Kylegl (@kylegl) for #415.
 - Resolve the real Pi CLI on Windows when pi-subagents runs inside an embedded SDK host instead of relaunching the host application's entry point. Thanks to Marc Kassubeck (@CompN3rd) for #413.
 - Avoid rendering active subagent activity as `now ago`. Thanks to Viktor Chernodub (@chernodub) for #414.

--- a/src/extension/chain-validation.ts
+++ b/src/extension/chain-validation.ts
@@ -1,0 +1,160 @@
+/**
+ * Friendly chain parameter validation.
+ *
+ * The runtime (pi-ai) validates tool arguments against the TypeBox schema before
+ * the tool's `execute` runs. When a chain step has an extra property, the model
+ * receives a raw TypeBox message such as `chain.1: must not have additional
+ * properties` — which does not name the offending property, list the allowed
+ * ones, or show the expected shape. Agents then iteratively guess the format and
+ * waste several turns before getting it right.
+ *
+ * `validateChainInput` runs from the tool's `prepareArguments` shim (and the RPC
+ * bridge) *before* schema validation. It throws a rich, actionable error for the
+ * common chain-shape failures, so the model sees which property is disallowed,
+ * what is allowed, and a valid example — instead of a raw TypeBox diagnostic.
+ *
+ * Allowed property names are derived directly from the schema objects in
+ * `schemas.ts` so this never drifts from what the TypeBox validator enforces.
+ */
+
+import {
+	ChainItem,
+	ParallelTaskSchema,
+	DynamicParallelTemplateSchema,
+	DynamicExpandSchema,
+	DynamicCollectSchema,
+} from "./schemas.ts";
+
+type ObjectSchema = { properties?: Record<string, unknown> };
+
+function allowedKeysOf(schema: ObjectSchema | undefined): string[] {
+	return schema?.properties ? Object.keys(schema.properties) : [];
+}
+
+const ExpandFromSchema = (DynamicExpandSchema.properties?.from ?? {}) as ObjectSchema;
+
+export const CHAIN_STEP_KEYS = allowedKeysOf(ChainItem);
+export const PARALLEL_TASK_KEYS = allowedKeysOf(ParallelTaskSchema);
+export const DYNAMIC_TEMPLATE_KEYS = allowedKeysOf(DynamicParallelTemplateSchema);
+export const EXPAND_KEYS = allowedKeysOf(DynamicExpandSchema);
+export const EXPAND_FROM_KEYS = allowedKeysOf(ExpandFromSchema);
+export const COLLECT_KEYS = allowedKeysOf(DynamicCollectSchema);
+
+const CHAIN_STEP_EXAMPLE = '{"agent": "worker", "task": "do X"}';
+const PARALLEL_TASK_EXAMPLE = '{"agent": "worker", "task": "do X"}';
+const DYNAMIC_TEMPLATE_EXAMPLE = '{"agent": "worker", "task": "Review {item.path}"}';
+const EXPAND_EXAMPLE = '{"from": {"output": "targets", "path": "/items"}, "maxItems": 4}';
+const EXPAND_FROM_EXAMPLE = '{"output": "targets", "path": "/items"}';
+const COLLECT_EXAMPLE = '{"as": "reviews"}';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function disallowedKeys(value: Record<string, unknown>, allowed: readonly string[]): string[] {
+	return Object.keys(value).filter((key) => !allowed.includes(key));
+}
+
+function typeName(value: unknown): string {
+	if (Array.isArray(value)) return "array";
+	return typeof value;
+}
+
+function quoteList(keys: string[]): string {
+	return keys.map((key) => `"${key}"`).join(", ");
+}
+
+function disallowedMessage(
+	path: string,
+	keys: string[],
+	allowed: readonly string[],
+	example?: string,
+): string {
+	const subject = keys.length === 1
+		? `property "${keys[0]}" is not allowed`
+		: `properties ${quoteList(keys)} are not allowed`;
+	const examplePart = example ? `\n\nExample: ${example}` : "";
+	return `subagent ${path}: ${subject}.\nAllowed properties: ${allowed.join(", ")}.${examplePart}`;
+}
+
+function expectObject(value: unknown, path: string, allowed: readonly string[], example?: string): asserts value is Record<string, unknown> {
+	if (!isPlainObject(value)) {
+		const examplePart = example ? `\n\nExample: ${example}` : "";
+		throw new Error(
+			`subagent ${path}: expected an object, received ${typeName(value)}.\nAllowed properties: ${allowed.join(", ")}.${examplePart}`,
+		);
+	}
+}
+
+function checkNoExtraKeys(
+	value: Record<string, unknown>,
+	path: string,
+	allowed: readonly string[],
+	example?: string,
+): void {
+	const extra = disallowedKeys(value, allowed);
+	if (extra.length > 0) {
+		throw new Error(disallowedMessage(path, extra, allowed, example));
+	}
+}
+
+/**
+ * Validates the `chain` array on a raw subagent tool-call argument object and
+ * throws a friendly, actionable error when a chain step (or a nested
+ * `parallel`/`expand`/`collect` object) has a disallowed property or wrong shape.
+ *
+ * No-op when `chain` is absent or not an array, so management/control/single/
+ * parallel calls are unaffected.
+ */
+export function validateChainInput(args: unknown): void {
+	if (!isPlainObject(args)) return;
+	const chain = (args as Record<string, unknown>).chain;
+	if (!Array.isArray(chain)) return;
+
+	chain.forEach((step, index) => {
+		const stepPath = `chain step validation failed at chain[${index}]`;
+		expectObject(step, stepPath, CHAIN_STEP_KEYS, CHAIN_STEP_EXAMPLE);
+		checkNoExtraKeys(step, stepPath, CHAIN_STEP_KEYS, CHAIN_STEP_EXAMPLE);
+
+		if (step.expand !== undefined) {
+			const expandPath = `${stepPath}.expand`;
+			expectObject(step.expand, expandPath, EXPAND_KEYS, EXPAND_EXAMPLE);
+			checkNoExtraKeys(step.expand, expandPath, EXPAND_KEYS, EXPAND_EXAMPLE);
+
+			const from = (step.expand as Record<string, unknown>).from;
+			if (from !== undefined) {
+				const fromPath = `${expandPath}.from`;
+				expectObject(from, fromPath, EXPAND_FROM_KEYS, EXPAND_FROM_EXAMPLE);
+				checkNoExtraKeys(from, fromPath, EXPAND_FROM_KEYS, EXPAND_FROM_EXAMPLE);
+			}
+		}
+
+		if (step.collect !== undefined) {
+			const collectPath = `${stepPath}.collect`;
+			expectObject(step.collect, collectPath, COLLECT_KEYS, COLLECT_EXAMPLE);
+			checkNoExtraKeys(step.collect, collectPath, COLLECT_KEYS, COLLECT_EXAMPLE);
+		}
+
+		const parallel = step.parallel;
+		if (parallel === undefined) return;
+
+		if (Array.isArray(parallel)) {
+			parallel.forEach((task, pIndex) => {
+				const taskPath = `${stepPath}.parallel[${pIndex}]`;
+				expectObject(task, taskPath, PARALLEL_TASK_KEYS, PARALLEL_TASK_EXAMPLE);
+				checkNoExtraKeys(task, taskPath, PARALLEL_TASK_KEYS, PARALLEL_TASK_EXAMPLE);
+			});
+			return;
+		}
+
+		if (isPlainObject(parallel)) {
+			const templatePath = `${stepPath}.parallel (dynamic fanout template)`;
+			checkNoExtraKeys(parallel, templatePath, DYNAMIC_TEMPLATE_KEYS, DYNAMIC_TEMPLATE_EXAMPLE);
+			return;
+		}
+
+		throw new Error(
+			`subagent ${stepPath}.parallel: expected an array of task objects or a dynamic fanout template object, received ${typeName(parallel)}.\n\nExample static: [${PARALLEL_TASK_EXAMPLE}]\nExample dynamic: ${DYNAMIC_TEMPLATE_EXAMPLE}`,
+		);
+	});
+}

--- a/src/extension/chain-validation.ts
+++ b/src/extension/chain-validation.ts
@@ -13,8 +13,8 @@
  * common chain-shape failures, so the model sees which property is disallowed,
  * what is allowed, and a valid example — instead of a raw TypeBox diagnostic.
  *
- * Allowed property names are derived directly from the schema objects in
- * `schemas.ts` so this never drifts from what the TypeBox validator enforces.
+ * Allowed property names and additional-property strictness are derived directly
+ * from the schema objects in `schemas.ts` so this stays aligned with TypeBox.
  */
 
 import {
@@ -25,7 +25,10 @@ import {
 	DynamicCollectSchema,
 } from "./schemas.ts";
 
-type ObjectSchema = { properties?: Record<string, unknown> };
+type ObjectSchema = {
+	properties?: Record<string, unknown>;
+	additionalProperties?: unknown;
+};
 
 function allowedKeysOf(schema: ObjectSchema | undefined): string[] {
 	return schema?.properties ? Object.keys(schema.properties) : [];
@@ -89,9 +92,11 @@ function expectObject(value: unknown, path: string, allowed: readonly string[], 
 function checkNoExtraKeys(
 	value: Record<string, unknown>,
 	path: string,
+	schema: ObjectSchema,
 	allowed: readonly string[],
 	example?: string,
 ): void {
+	if (schema.additionalProperties !== false) return;
 	const extra = disallowedKeys(value, allowed);
 	if (extra.length > 0) {
 		throw new Error(disallowedMessage(path, extra, allowed, example));
@@ -114,25 +119,25 @@ export function validateChainInput(args: unknown): void {
 	chain.forEach((step, index) => {
 		const stepPath = `chain step validation failed at chain[${index}]`;
 		expectObject(step, stepPath, CHAIN_STEP_KEYS, CHAIN_STEP_EXAMPLE);
-		checkNoExtraKeys(step, stepPath, CHAIN_STEP_KEYS, CHAIN_STEP_EXAMPLE);
+		checkNoExtraKeys(step, stepPath, ChainItem, CHAIN_STEP_KEYS, CHAIN_STEP_EXAMPLE);
 
 		if (step.expand !== undefined) {
 			const expandPath = `${stepPath}.expand`;
 			expectObject(step.expand, expandPath, EXPAND_KEYS, EXPAND_EXAMPLE);
-			checkNoExtraKeys(step.expand, expandPath, EXPAND_KEYS, EXPAND_EXAMPLE);
+			checkNoExtraKeys(step.expand, expandPath, DynamicExpandSchema, EXPAND_KEYS, EXPAND_EXAMPLE);
 
 			const from = (step.expand as Record<string, unknown>).from;
 			if (from !== undefined) {
 				const fromPath = `${expandPath}.from`;
 				expectObject(from, fromPath, EXPAND_FROM_KEYS, EXPAND_FROM_EXAMPLE);
-				checkNoExtraKeys(from, fromPath, EXPAND_FROM_KEYS, EXPAND_FROM_EXAMPLE);
+				checkNoExtraKeys(from, fromPath, ExpandFromSchema, EXPAND_FROM_KEYS, EXPAND_FROM_EXAMPLE);
 			}
 		}
 
 		if (step.collect !== undefined) {
 			const collectPath = `${stepPath}.collect`;
 			expectObject(step.collect, collectPath, COLLECT_KEYS, COLLECT_EXAMPLE);
-			checkNoExtraKeys(step.collect, collectPath, COLLECT_KEYS, COLLECT_EXAMPLE);
+			checkNoExtraKeys(step.collect, collectPath, DynamicCollectSchema, COLLECT_KEYS, COLLECT_EXAMPLE);
 		}
 
 		const parallel = step.parallel;
@@ -142,14 +147,14 @@ export function validateChainInput(args: unknown): void {
 			parallel.forEach((task, pIndex) => {
 				const taskPath = `${stepPath}.parallel[${pIndex}]`;
 				expectObject(task, taskPath, PARALLEL_TASK_KEYS, PARALLEL_TASK_EXAMPLE);
-				checkNoExtraKeys(task, taskPath, PARALLEL_TASK_KEYS, PARALLEL_TASK_EXAMPLE);
+				checkNoExtraKeys(task, taskPath, ParallelTaskSchema, PARALLEL_TASK_KEYS, PARALLEL_TASK_EXAMPLE);
 			});
 			return;
 		}
 
 		if (isPlainObject(parallel)) {
 			const templatePath = `${stepPath}.parallel (dynamic fanout template)`;
-			checkNoExtraKeys(parallel, templatePath, DYNAMIC_TEMPLATE_KEYS, DYNAMIC_TEMPLATE_EXAMPLE);
+			checkNoExtraKeys(parallel, templatePath, DynamicParallelTemplateSchema, DYNAMIC_TEMPLATE_KEYS, DYNAMIC_TEMPLATE_EXAMPLE);
 			return;
 		}
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -25,6 +25,7 @@ import { resolveCurrentSessionId } from "../shared/session-identity.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
 import { clearLegacyResultAnimationTimer, renderWidget, renderSubagentResult } from "../tui/render.ts";
 import { SubagentParams, WaitParams } from "./schemas.ts";
+import { validateChainInput } from "./chain-validation.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { createAsyncJobTracker } from "../runs/background/async-job-tracker.ts";
 import { createResultWatcher } from "../runs/background/result-watcher.ts";
@@ -461,6 +462,14 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		label: "Subagent",
 		description: buildSubagentToolDescription(config),
 		parameters: SubagentParams,
+
+		prepareArguments(args) {
+			// Run friendly chain validation before pi-ai's raw TypeBox schema check
+			// so the model sees which property is disallowed, what is allowed, and a
+			// valid example instead of `chain.N: must not have additional properties`.
+			validateChainInput(args);
+			return args as never;
+		},
 
 		execute(id, params, signal, onUpdate, ctx) {
 			return executeSubagentCollapsed(id, params, signal, onUpdate, ctx);

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -9,6 +9,7 @@ import type { SubagentParamsLike } from "../runs/foreground/subagent-executor.ts
 import { type Details, ASYNC_DIR, RESULTS_DIR } from "../shared/types.ts";
 import { readStatus } from "../shared/utils.ts";
 import { SubagentParams } from "./schemas.ts";
+import { validateChainInput } from "./chain-validation.ts";
 
 export const SUBAGENT_RPC_PROTOCOL_VERSION = 1;
 export const SUBAGENT_RPC_REQUEST_EVENT = "subagents:rpc:v1:request";
@@ -111,6 +112,13 @@ function assertRecordParams(params: unknown, method: SubagentRpcMethod): Record<
 }
 
 function assertSubagentParams(params: SubagentParamsLike, label: string): void {
+	// Friendly chain validation first: name the disallowed property, list allowed
+	// ones, and show a valid example instead of raw TypeBox diagnostics.
+	try {
+		validateChainInput(params);
+	} catch (error) {
+		throw new SubagentRpcError("invalid_params", `${label}: ${error instanceof Error ? error.message : String(error)}`);
+	}
 	if (subagentParamsValidator.Check(params)) return;
 	const messages = [...subagentParamsValidator.Errors(params)]
 		.slice(0, 4)

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -108,7 +108,7 @@ const TaskItem = Type.Object({
 });
 
 // Parallel task item (within a parallel step)
-const ParallelTaskSchema = Type.Object({
+export const ParallelTaskSchema = Type.Object({
 	agent: Type.String(),
 	task: Type.Optional(Type.String({ description: "Task template with {task}, {previous}, {chain_dir} variables. Defaults to {previous}." })),
 	phase: Type.Optional(Type.String({ description: "Optional phase/group label for status and graph rendering." })),
@@ -127,7 +127,7 @@ const ParallelTaskSchema = Type.Object({
 	acceptance: Type.Optional(AcceptanceOverride),
 });
 
-const DynamicExpandSchema = Type.Object({
+export const DynamicExpandSchema = Type.Object({
 	from: Type.Object({
 		output: Type.String({ description: "Prior named structured output to expand from." }),
 		path: Type.String({ description: "JSON Pointer into the structured output, e.g. /items." }),
@@ -138,7 +138,7 @@ const DynamicExpandSchema = Type.Object({
 	onEmpty: Type.Optional(Type.String({ enum: ["skip", "fail"], description: "Empty input behavior. Defaults to skip." })),
 }, { additionalProperties: false });
 
-const DynamicParallelTemplateSchema = Type.Object({
+export const DynamicParallelTemplateSchema = Type.Object({
 	agent: Type.String(),
 	task: Type.Optional(Type.String({ description: "Task template with {item}, {item.path}, {task}, {previous}, {chain_dir}, and {outputs.name} variables." })),
 	phase: Type.Optional(Type.String({ description: "Optional phase/group label for status and graph rendering." })),
@@ -155,13 +155,13 @@ const DynamicParallelTemplateSchema = Type.Object({
 	acceptance: Type.Optional(AcceptanceOverride),
 }, { additionalProperties: false });
 
-const DynamicCollectSchema = Type.Object({
+export const DynamicCollectSchema = Type.Object({
 	as: Type.String({ description: "Safe output name for the ordered collected result array." }),
 	outputSchema: Type.Optional(JsonSchemaObject),
 }, { additionalProperties: false });
 
 // Flattened so chain steps do not need an object-shape anyOf/oneOf union.
-const ChainItem = Type.Object({
+export const ChainItem = Type.Object({
 	agent: Type.Optional(Type.String({ description: "Sequential step agent name" })),
 	task: Type.Optional(Type.String({
 		description: "Task template with variables: {task}=original request, {previous}=prior step's text response, {chain_dir}=shared folder, {outputs.name}=prior named output. Required for first step, defaults to '{previous}' for subsequent steps."

--- a/test/unit/chain-validation.test.ts
+++ b/test/unit/chain-validation.test.ts
@@ -24,8 +24,8 @@ function missingPackageName(error: unknown): string | undefined {
 }
 
 let validateChainInput: (args: unknown) => void = () => {};
+let validateSubagentParams: (args: unknown) => boolean = () => true;
 let chainItemProperties: Record<string, unknown> | undefined;
-let parallelTaskProperties: Record<string, unknown> | undefined;
 let dynamicTemplateProperties: Record<string, unknown> | undefined;
 let schemasAvailable = true;
 try {
@@ -38,11 +38,15 @@ try {
 	validateChainInput = mod.validateChainInput;
 	const schemas = await import("../../src/extension/schemas.ts") as {
 		ChainItem: JsonSchemaNode;
-		ParallelTaskSchema: JsonSchemaNode;
 		DynamicParallelTemplateSchema: JsonSchemaNode;
+		SubagentParams: JsonSchemaNode;
 	};
+	const { Compile } = await import("typebox/compile") as unknown as {
+		Compile: (schema: JsonSchemaNode) => { Check(value: unknown): boolean };
+	};
+	const subagentParamsValidator = Compile(schemas.SubagentParams);
+	validateSubagentParams = (args) => subagentParamsValidator.Check(args);
 	chainItemProperties = schemas.ChainItem.properties as Record<string, unknown> | undefined;
-	parallelTaskProperties = schemas.ParallelTaskSchema.properties as Record<string, unknown> | undefined;
 	dynamicTemplateProperties = schemas.DynamicParallelTemplateSchema.properties as Record<string, unknown> | undefined;
 } catch (error) {
 	if (missingPackageName(error) !== "typebox") throw error;
@@ -142,29 +146,10 @@ describe("chain input validation", { skip: !schemasAvailable ? "typebox not avai
 		);
 	});
 
-	it("names disallowed properties on a static parallel task", () => {
-		expectInvalid(
-			{ chain: [{ parallel: [{ agent: "worker", oops: true }] }] },
-			/chain\[0\]\.parallel\[0\]/,
-			/"oops" is not allowed/,
-			/Allowed properties:/,
-			/Example:/,
-		);
-	});
-
-	it("lists every allowed static parallel task property from the schema", () => {
-		const allowed = Object.keys(parallelTaskProperties ?? {});
-		assert.ok(allowed.includes("agent"));
-		assert.ok(allowed.includes("count"));
-		try {
-			validateChainInput({ chain: [{ parallel: [{ notReal: 1 }] }] });
-			assert.fail("should have thrown");
-		} catch (error) {
-			assert.ok(error instanceof Error);
-			for (const key of allowed) {
-				assert.match(error.message, new RegExp(`\\b${key}\\b`), `allowed key ${key} should appear: ${error.message}`);
-			}
-		}
+	it("preserves static parallel extra properties accepted by the TypeBox schema", () => {
+		const args = { chain: [{ parallel: [{ agent: "worker", extensionField: true }] }] };
+		assert.equal(validateSubagentParams(args), true);
+		assert.doesNotThrow(() => validateChainInput(args));
 	});
 
 	it("names disallowed properties on a dynamic fanout template", () => {
@@ -325,6 +310,11 @@ describe("registered subagent tool prepareArguments", { skip: !schemasAvailable 
 
 	it("passes valid chain arguments through unchanged", () => {
 		const result = runPrepare({ chain: [{ agent: "worker", task: "do X" }] });
+		assert.equal(result.ok, true);
+	});
+
+	it("preserves static parallel extra properties accepted by the registered schema", () => {
+		const result = runPrepare({ chain: [{ parallel: [{ agent: "worker", extensionField: true }] }] });
 		assert.equal(result.ok, true);
 	});
 

--- a/test/unit/chain-validation.test.ts
+++ b/test/unit/chain-validation.test.ts
@@ -1,0 +1,336 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
+import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait.ts";
+
+type JsonSchemaNode = Record<string, unknown>;
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function parentToolEnv(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	delete env[SUBAGENT_CHILD_ENV];
+	delete env[SUBAGENT_FANOUT_CHILD_ENV];
+	delete env[WAIT_TOOL_ENABLED_ENV];
+	return env;
+}
+
+function missingPackageName(error: unknown): string | undefined {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.match(/Cannot find package ['"]([^'"]+)['"]/i)?.[1];
+}
+
+let validateChainInput: (args: unknown) => void = () => {};
+let chainItemProperties: Record<string, unknown> | undefined;
+let parallelTaskProperties: Record<string, unknown> | undefined;
+let dynamicTemplateProperties: Record<string, unknown> | undefined;
+let schemasAvailable = true;
+try {
+	const mod = await import("../../src/extension/chain-validation.ts") as {
+		validateChainInput: (args: unknown) => void;
+		CHAIN_STEP_KEYS: string[];
+		PARALLEL_TASK_KEYS: string[];
+		DYNAMIC_TEMPLATE_KEYS: string[];
+	};
+	validateChainInput = mod.validateChainInput;
+	const schemas = await import("../../src/extension/schemas.ts") as {
+		ChainItem: JsonSchemaNode;
+		ParallelTaskSchema: JsonSchemaNode;
+		DynamicParallelTemplateSchema: JsonSchemaNode;
+	};
+	chainItemProperties = schemas.ChainItem.properties as Record<string, unknown> | undefined;
+	parallelTaskProperties = schemas.ParallelTaskSchema.properties as Record<string, unknown> | undefined;
+	dynamicTemplateProperties = schemas.DynamicParallelTemplateSchema.properties as Record<string, unknown> | undefined;
+} catch (error) {
+	if (missingPackageName(error) !== "typebox") throw error;
+	schemasAvailable = false;
+}
+
+function expectInvalid(args: unknown, ...patterns: RegExp[]): void {
+	assert.throws(
+		() => validateChainInput(args),
+		(error) => {
+			assert.ok(error instanceof Error, "validation should throw an Error");
+			const message = error.message;
+			for (const pattern of patterns) {
+				assert.match(message, pattern, `expected message to match ${pattern}; got: ${message}`);
+			}
+			return true;
+		},
+		`expected validation to fail for ${JSON.stringify(args)}`,
+	);
+}
+
+describe("chain input validation", { skip: !schemasAvailable ? "typebox not available" : undefined }, () => {
+	it("is a no-op when chain is absent or not an array", () => {
+		assert.doesNotThrow(() => validateChainInput({}));
+		assert.doesNotThrow(() => validateChainInput({ agent: "worker", task: "do X" }));
+		assert.doesNotThrow(() => validateChainInput({ chain: "not-an-array" }));
+		assert.doesNotThrow(() => validateChainInput({ action: "status" }));
+		assert.doesNotThrow(() => validateChainInput(undefined));
+		assert.doesNotThrow(() => validateChainInput(null));
+	});
+
+	it("accepts valid chain steps without throwing", () => {
+		assert.doesNotThrow(() => validateChainInput({ chain: [{ agent: "worker", task: "do X" }] }));
+		assert.doesNotThrow(() =>
+			validateChainInput({ chain: [{ agent: "worker", task: "do X", parallel: [{ agent: "reviewer", task: "review" }] }] }),
+		);
+		assert.doesNotThrow(() =>
+			validateChainInput({
+				chain: [{
+					expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+					parallel: { agent: "reviewer", task: "Review {item.path}" },
+					collect: { as: "reviews" },
+				}],
+			}),
+		);
+	});
+
+	it("names the disallowed property and lists allowed properties for a chain step", () => {
+		expectInvalid(
+			{ chain: [{ agent: "worker", task: "do X", bogus: true }] },
+			/chain\[0\]/,
+			/"bogus" is not allowed/,
+			/Allowed properties:/,
+			/Example:/,
+		);
+	});
+
+	it("lists every allowed chain step property from the schema", () => {
+		const allowed = Object.keys(chainItemProperties ?? {});
+		assert.ok(allowed.includes("agent"));
+		assert.ok(allowed.includes("parallel"));
+		assert.ok(allowed.includes("expand"));
+		try {
+			validateChainInput({ chain: [{ notReal: 1 }] });
+			assert.fail("should have thrown");
+		} catch (error) {
+			assert.ok(error instanceof Error);
+			for (const key of allowed) {
+				assert.match(error.message, new RegExp(`\\b${key}\\b`), `allowed key ${key} should appear in message: ${error.message}`);
+			}
+		}
+	});
+
+	it("reports multiple disallowed properties at once", () => {
+		expectInvalid(
+			{ chain: [{ agent: "worker", foo: 1, bar: 2 }] },
+			/chain\[0\]/,
+			/"foo"/,
+			/"bar"/,
+		);
+	});
+
+	it("explains expected shape when a chain step is not an object", () => {
+		expectInvalid(
+			{ chain: ["not-an-object"] },
+			/chain\[0\]/,
+			/expected an object/,
+			/string/,
+			/Allowed properties:/,
+			/Example:/,
+		);
+		expectInvalid(
+			{ chain: [42] },
+			/chain\[0\]/,
+			/expected an object/,
+			/number/,
+		);
+	});
+
+	it("names disallowed properties on a static parallel task", () => {
+		expectInvalid(
+			{ chain: [{ parallel: [{ agent: "worker", oops: true }] }] },
+			/chain\[0\]\.parallel\[0\]/,
+			/"oops" is not allowed/,
+			/Allowed properties:/,
+			/Example:/,
+		);
+	});
+
+	it("lists every allowed static parallel task property from the schema", () => {
+		const allowed = Object.keys(parallelTaskProperties ?? {});
+		assert.ok(allowed.includes("agent"));
+		assert.ok(allowed.includes("count"));
+		try {
+			validateChainInput({ chain: [{ parallel: [{ notReal: 1 }] }] });
+			assert.fail("should have thrown");
+		} catch (error) {
+			assert.ok(error instanceof Error);
+			for (const key of allowed) {
+				assert.match(error.message, new RegExp(`\\b${key}\\b`), `allowed key ${key} should appear: ${error.message}`);
+			}
+		}
+	});
+
+	it("names disallowed properties on a dynamic fanout template", () => {
+		expectInvalid(
+			{
+				chain: [{
+					expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+					parallel: { agent: "worker", bogus: true },
+					collect: { as: "reviews" },
+				}],
+			},
+			/chain\[0\]\.parallel/,
+			/"bogus" is not allowed/,
+			/Allowed properties:/,
+		);
+	});
+
+	it("lists every allowed dynamic template property from the schema", () => {
+		const allowed = Object.keys(dynamicTemplateProperties ?? {});
+		assert.ok(allowed.includes("agent"));
+		assert.ok(allowed.includes("outputSchema"));
+		try {
+			validateChainInput({
+				chain: [{
+					expand: { from: { output: "x", path: "/items" }, maxItems: 4 },
+					parallel: { notReal: 1 },
+					collect: { as: "reviews" },
+				}],
+			});
+			assert.fail("should have thrown");
+		} catch (error) {
+			assert.ok(error instanceof Error);
+			for (const key of allowed) {
+				assert.match(error.message, new RegExp(`\\b${key}\\b`), `allowed key ${key} should appear: ${error.message}`);
+			}
+		}
+	});
+
+	it("guides the agent when parallel is neither an array nor an object", () => {
+		expectInvalid(
+			{ chain: [{ parallel: "nope" }] },
+			/chain\[0\]\.parallel/,
+			/expected an array of task objects or a dynamic fanout template object/,
+			/string/,
+		);
+	});
+
+	it("names disallowed properties on expand", () => {
+		expectInvalid(
+			{
+				chain: [{
+					expand: { from: { output: "x", path: "/items" }, maxItems: 4, bogus: true },
+					parallel: { agent: "worker" },
+					collect: { as: "reviews" },
+				}],
+			},
+			/chain\[0\]\.expand/,
+			/"bogus" is not allowed/,
+			/Allowed properties:/,
+		);
+	});
+
+	it("names disallowed properties on expand.from", () => {
+		expectInvalid(
+			{
+				chain: [{
+					expand: { from: { output: "x", path: "/items", bogus: true }, maxItems: 4 },
+					parallel: { agent: "worker" },
+					collect: { as: "reviews" },
+				}],
+			},
+			/chain\[0\]\.expand\.from/,
+			/"bogus" is not allowed/,
+			/Allowed properties:/,
+		);
+	});
+
+	it("names disallowed properties on collect", () => {
+		expectInvalid(
+			{
+				chain: [{
+					expand: { from: { output: "x", path: "/items" }, maxItems: 4 },
+					parallel: { agent: "worker" },
+					collect: { as: "reviews", bogus: true },
+				}],
+			},
+			/chain\[0\]\.collect/,
+			/"bogus" is not allowed/,
+			/Allowed properties:/,
+		);
+	});
+
+	it("reports the correct chain index for multi-step chains", () => {
+		expectInvalid(
+			{ chain: [{ agent: "worker", task: "ok" }, { agent: "worker", bogus: true }] },
+			/chain\[1\]/,
+			/"bogus" is not allowed/,
+		);
+	});
+});
+
+describe("registered subagent tool prepareArguments", { skip: !schemasAvailable ? "typebox not available" : undefined }, () => {
+	function runPrepare(args: unknown): { error?: string; ok: true } | { error: string; ok: false } {
+		const script = String.raw`
+			import registerSubagentExtension from "./src/extension/index.ts";
+			const events = { on() { return () => {}; }, emit() {} };
+			let registeredTool;
+			const fakePi = new Proxy({
+				events,
+				registerTool(tool) { if (tool.name === "subagent") registeredTool = tool; },
+				registerCommand() {},
+				registerShortcut() {},
+				registerMessageRenderer() {},
+				sendMessage() {},
+				getSessionName() { return undefined; },
+			}, {
+				get(target, prop) {
+					if (prop in target) return target[prop];
+					return () => undefined;
+				},
+			});
+			registerSubagentExtension(fakePi);
+			if (!registeredTool) throw new Error("tool not registered");
+			if (typeof registeredTool.prepareArguments !== "function") throw new Error("prepareArguments not attached");
+			const args = JSON.parse(process.argv[process.argv.length - 1] ?? "{}");
+			try {
+				registeredTool.prepareArguments(args);
+				process.stdout.write(JSON.stringify({ ok: true }));
+			} catch (error) {
+				process.stdout.write(JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) }));
+			}
+		`;
+		const output = execFileSync(
+			process.execPath,
+			[
+				"--experimental-transform-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+				"--",
+				JSON.stringify(args),
+			],
+			{ cwd: projectRoot, env: parentToolEnv(), encoding: "utf-8", stdio: "pipe" },
+		);
+		return JSON.parse(output) as { error?: string; ok: boolean };
+	}
+
+	it("throws a friendly chain error before schema validation when a step has a disallowed property", () => {
+		const result = runPrepare({ chain: [{ agent: "worker", task: "do X", bogus: true }] });
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? "", /chain\[0\]/);
+		assert.match(result.error ?? "", /"bogus" is not allowed/);
+		assert.match(result.error ?? "", /Allowed properties:/);
+		assert.match(result.error ?? "", /Example:/);
+	});
+
+	it("passes valid chain arguments through unchanged", () => {
+		const result = runPrepare({ chain: [{ agent: "worker", task: "do X" }] });
+		assert.equal(result.ok, true);
+	});
+
+	it("is a no-op for management actions and single/parallel calls", () => {
+		assert.equal(runPrepare({ action: "status" }).ok, true);
+		assert.equal(runPrepare({ agent: "worker", task: "do X" }).ok, true);
+		assert.equal(runPrepare({ tasks: [{ agent: "worker", task: "do X" }] }).ok, true);
+	});
+});

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -160,6 +160,31 @@ describe("subagent extension RPC bridge", () => {
 		bridge.dispose();
 	});
 
+	it("preserves schema-valid static parallel extension fields", async () => {
+		const events = new FakeEvents();
+		let executedParams: any;
+		const bridge = registerSubagentRpcBridge({
+			events,
+			getContext: () => ctx(),
+			execute: async (_id, params) => {
+				executedParams = params;
+				return {
+					content: [{ type: "text", text: "Async: worker [run-1]" }],
+					details: { mode: "chain", results: [], asyncId: "run-1", asyncDir: "/tmp/run-1" },
+				} as any;
+			},
+		});
+
+		const reply = await request(events, "spawn-chain-extra", "spawn", {
+			chain: [{ parallel: [{ agent: "worker", extensionField: true }] }],
+		});
+
+		assert.equal(reply.success, true);
+		assert.equal(executedParams.chain[0].parallel[0].extensionField, true);
+
+		bridge.dispose();
+	});
+
 	it("rejects foreground or management spawn requests before executor dispatch", async () => {
 		const events = new FakeEvents();
 		let executeCalls = 0;


### PR DESCRIPTION
## What

When an agent passes a disallowed property to the `subagent` tool's `chain` parameter, the runtime emits raw TypeBox diagnostics such as:

- `chain.1: must not have additional properties` — no hint which property is extra
- `chain.1: must match "then" schema` — does not say which condition failed
- `chain.0: must be object` — does not explain the expected format

Agents then iteratively guess the format and waste 3–6 turns per chain invocation before getting it right.

Closes #416.

## How

Run a focused, friendly validation from the tool's `prepareArguments` shim (and the RPC bridge's `assertSubagentParams`) **before** pi-ai's raw TypeBox schema check. On failure the model now receives:

1. The failing property name(s)
2. The expected/allowed properties for that position
3. A valid example showing the correct shape

```
subagent chain step validation failed at chain[0]: property "bogus" is not allowed.
Allowed properties: agent, task, phase, label, as, outputSchema, cwd, output, outputMode, reads, progress, skill, model, toolBudget, acceptance, parallel, expand, collect, concurrency, failFast, worktree.
Example: {"agent": "worker", "task": "do X"}
```

Allowed property names are derived directly from the schema objects in `schemas.ts` so the friendly checker never drifts from what the TypeBox validator enforces. Covers chain steps plus nested `parallel` tasks, dynamic fanout templates, and `expand` / `expand.from` / `collect` objects. It is a no-op for management, single, and parallel calls, so unrelated tool invocations are unaffected.

## Files

- `src/extension/chain-validation.ts` — new friendly chain validator (allowed keys read from the schemas)
- `src/extension/schemas.ts` — export `ChainItem`, `ParallelTaskSchema`, `DynamicParallelTemplateSchema`, `DynamicExpandSchema`, `DynamicCollectSchema` so the validator derives allowed keys from the source of truth
- `src/extension/index.ts` — wire `validateChainInput` into the `subagent` tool's `prepareArguments`
- `src/extension/rpc.ts` — run `validateChainInput` before the raw TypeBox check in `assertSubagentParams`
- `test/unit/chain-validation.test.ts` — unit tests for the validator and a wiring test that runs the registered tool's `prepareArguments`

## Tests

- `npm run test:unit` — 1100 pass (15 new)
- `npm run test:integration` — 490 pass

— solar-heron-7