### PR TITLE
fix: label clarify dialog shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Labeled every chain-clarification shortcut with its action, made the background state explicit, and kept primary actions in a separate footer without widening the fixed 84-column overlay. Thanks to GonzaloRocca (@gonzalonicolasr) for #430.
 - Hardened acceptance reports so explicit empty changed-file and test arrays are treated as not applicable, required criteria are reflected in examples, known model-output variants normalize to one strict canonical shape, unknown or ambiguous values fail with exact diagnostics, and parsed reports plus ledgers persist in child metadata while normal output stays clean. Thanks to Nick Tripp (@nicholastripp) for #442, maxsturmb (@maxsturmb) for #452, and techmodv90 (@techmodv90) for #449 and #450.
 - Shared task-intent classification between acceptance inference and the completion guard so read-only tasks with explicit no-edit wording do not receive impossible write-evidence gates, while scoped prohibitions still preserve later implementation clauses. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #433.
 - Rejected explicit `acceptance: "reviewed"` and `{ level: "reviewed" }` before launch because the current run cannot supply the required independent reviewer result; inferred and `auto` review policies remain non-blocking. Thanks to Theodor Hillmann (@t0dorakis) for #440 and #441.

--- a/src/runs/foreground/chain-clarify.ts
+++ b/src/runs/foreground/chain-clarify.ts
@@ -1102,16 +1102,27 @@ export class ChainClarifyComponent implements Component {
 		return lines;
 	}
 
-	private getFooterText(): string {
-		const bgLabel = this.runInBackground ? '[b]g:ON' : '[b]g';
+	private getShortcutHelpText(): string {
+		const th = this.theme;
+		const shortcut = (key: string, label: string) =>
+			th.fg("accent", `[${key}]`) + th.fg("dim", label);
+		const backgroundState = this.runInBackground ? "ON" : "OFF";
+		const background = shortcut("b", `Background:${backgroundState}`);
+
 		switch (this.mode) {
 			case 'single':
-				return ` [Enter] Run • [Esc] Cancel • e m t w s ${bgLabel} `;
+				return ` ${shortcut("e", "Task")} ${shortcut("m", "Model")} ${shortcut("t", "Think")} ${shortcut("w", "Output")} ${shortcut("s", "Skills")} ${background}`;
 			case 'parallel':
-				return ` [Enter] Run • [Esc] Cancel • e m t s ${bgLabel} • ↑↓ Nav `;
+				return ` ${shortcut("e", "Task")} ${shortcut("m", "Model")} ${shortcut("t", "Think")} ${shortcut("s", "Skills")} ${background}`;
 			case 'chain':
-				return ` [Enter] Run • [Esc] Cancel • e m t w r p s ${bgLabel} • ↑↓ Nav `;
+				return ` ${shortcut("e", "Task")} ${shortcut("m", "Model")} ${shortcut("t", "Think")} ${shortcut("w", "Output")} ${shortcut("r", "Reads")} ${shortcut("p", "Prog")} ${shortcut("s", "Skills")} ${background}`;
 		}
+	}
+
+	private getFooterText(): string {
+		return this.mode === 'single'
+			? " [Enter] Run • [Esc] Cancel "
+			: " [Enter] Run • [Esc] Cancel • [↑↓] Navigate ";
 	}
 
 	private appendNotice(lines: string[]): void {
@@ -1162,7 +1173,7 @@ export class ChainClarifyComponent implements Component {
 		const skillsLabel = th.fg("dim", "skills: ");
 		lines.push(this.row(`     ${skillsLabel}${truncateToWidth(skillsValue, innerW - 14)}`));
 
-		lines.push(this.row(""));
+		lines.push(this.row(this.getShortcutHelpText()));
 
 		this.appendNotice(lines);
 		lines.push(this.renderFooter(this.getFooterText()));
@@ -1216,6 +1227,8 @@ export class ChainClarifyComponent implements Component {
 			lines.push(this.row(""));
 		}
 
+		if (this.agentConfigs.length > 0) lines.pop();
+		lines.push(this.row(this.getShortcutHelpText()));
 		this.appendNotice(lines);
 		lines.push(this.renderFooter(this.getFooterText()));
 
@@ -1319,6 +1332,8 @@ export class ChainClarifyComponent implements Component {
 			lines.push(this.row(""));
 		}
 
+		if (this.agentConfigs.length > 0) lines.pop();
+		lines.push(this.row(this.getShortcutHelpText()));
 		this.appendNotice(lines);
 		lines.push(this.renderFooter(this.getFooterText()));
 

--- a/test/integration/chain-clarify.test.ts
+++ b/test/integration/chain-clarify.test.ts
@@ -271,4 +271,69 @@ describe("chain clarify model display", { skip: !available ? "pi packages not av
 
 		assert.equal(component.getEffectiveModel(0), "github-copilot/gpt-5:high");
 	});
+
+	it("labels every shortcut and keeps the clarify overlay within 84 columns", () => {
+		for (const mode of ["single", "parallel", "chain"] as const) {
+			const count = mode === "single" ? 1 : mode === "parallel" ? 2 : 4;
+			const component = new ChainClarifyComponent(
+				{ requestRender() {} },
+				{ fg(_key: string, text: string) { return `\u001b[31m${text}\u001b[0m`; } },
+				Array.from({ length: count }, (_, index) => ({
+					name: `agent-${index + 1}`,
+					description: "",
+					systemPrompt: "",
+					systemPromptMode: "replace",
+					inheritProjectContext: false,
+					inheritSkills: false,
+					source: "user",
+					filePath: `agent-${index + 1}.md`,
+				})),
+				Array.from({ length: count }, (_, index) => index === 0 ? "Task" : "Use {previous}"),
+				"Task",
+				undefined,
+				Array.from({ length: count }, () => ({
+					output: false,
+					outputMode: "inline",
+					reads: false,
+					progress: false,
+					skills: [],
+					model: undefined,
+				})),
+				[],
+				undefined,
+				[],
+				() => {},
+				mode,
+			);
+
+			const initialLines = component.render(84).map(stripAnsi);
+			const initial = initialLines.join("\n");
+			assert.match(initial, /\[e\]Task/);
+			assert.match(initial, /\[m\]Model/);
+			assert.match(initial, /\[t\]Think/);
+			assert.match(initial, /\[s\]Skills/);
+			assert.match(initial, /\[b\]Background:OFF/);
+			assert.doesNotMatch(initial, /• e m t/);
+			assert.match(initial, /\[Enter\] Run • \[Esc\] Cancel/);
+			if (mode === "single") {
+				assert.match(initial, /\[w\]Output/);
+				assert.doesNotMatch(initial, /\[↑↓\] Navigate/);
+			} else {
+				assert.match(initial, /\[↑↓\] Navigate/);
+			}
+			if (mode === "chain") {
+				assert.match(initial, /\[w\]Output/);
+				assert.match(initial, /\[r\]Reads/);
+				assert.match(initial, /\[p\]Prog/);
+			} else if (mode === "parallel") {
+				assert.doesNotMatch(initial, /\[w\]Output|\[r\]Reads|\[p\]Prog/);
+			}
+			for (const line of initialLines) {
+				assert.equal(visibleWidth(line), 84, `${mode} line did not match component width: ${line}`);
+			}
+
+			component.handleInput("b");
+			assert.match(component.render(84).map(stripAnsi).join("\n"), /\[b\]Background:ON/);
+		}
+	});
 });


### PR DESCRIPTION
## Summary

The chain clarification footer currently renders shortcut keys as an unlabeled sequence such as `e m t w r p s [b]g`, which makes the available actions difficult to discover.

This change:

- renders every shortcut as a key/action pair (`[e]Task`, `[m]Model`, `[t]Think`, etc.)
- shows the current background state as `[b]Background:ON|OFF`
- keeps primary actions in a separate footer (`Run`, `Cancel`, `Navigate`)
- reuses the trailing spacer row, so the dialog does not grow vertically
- preserves the fixed 84-column overlay width in single, parallel, and chain modes

## Validation

- `chain-clarify.test.ts`: **7/7 passed**
- full integration suite: **491/491 passed**
- added coverage for all three modes, the background toggle, and the 84-column width constraint
- `git diff --check`: passed

## Environment note

The unit suite reaches **1073/1082** on Node 26.3.1. The 9 failures are unrelated subprocess tests that invoke the removed `--experimental-transform-types` Node flag. The integration suite passes when run with Node 26's `--experimental-strip-types` equivalent.
