### PR TITLE
fix(acceptance): read the report from child-written configured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Recovered acceptance reports from child-written configured outputs, honoring file-only source precedence and surfacing malformed primary reports. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #434.
 - Isolated inherited output files for async parallel siblings and rejected duplicate resolved output paths before launch, preventing silent report loss. Thanks to basher83 (@basher83) for #420.
 - Replaced raw chain-schema failures with actionable errors that name invalid properties, list allowed fields, and show valid examples. Thanks to Nicolas Marchildon (@elecnix) for #416 and #425.
 - Hide lower-priority agent definitions from `subagent({ action: "list" })` when a higher-priority project or user agent shadows them. Thanks to Kylegl (@kylegl) for #415.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -8,7 +8,7 @@ import { createChildTranscriptWriter, type ChildTranscriptWriter } from "../../s
 import { consumeInterruptRequest, deliverInterruptRequest, deliverStopRequest, deliverTimeoutRequest, enqueueStepSteer, stepSteerInboxDir, watchAsyncControlInbox, type SteerRequest } from "./control-channel.ts";
 import { appendJsonl as appendRawJsonl, getArtifactPaths } from "../../shared/artifacts.ts";
 import { PI_CODING_AGENT_PACKAGE, getPiSpawnCommand, resolveInstalledPiPackageRoot } from "../shared/pi-spawn.ts";
-import { captureSingleOutputSnapshot, finalizeSingleOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, injectSingleOutputInstruction, resolveSingleOutput, type SingleOutputSnapshot } from "../shared/single-output.ts";
+import { captureSingleOutputSnapshot, extractChildWrittenOutput, finalizeSingleOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, injectSingleOutputInstruction, resolveSingleOutput, type SingleOutputSnapshot } from "../shared/single-output.ts";
 import {
 	type ActivityState,
 	type ArtifactConfig,
@@ -1198,7 +1198,7 @@ async function runSingleStep(
 	const resolvedOutput = step.outputPath && finalResult?.exitCode === 0
 		? resolveSingleOutput(step.outputPath, outputForPersistence, finalOutputSnapshot)
 		: { fullOutput: outputForPersistence };
-	const output = resolvedOutput.fullOutput;
+	const output = stripAcceptanceReport(resolvedOutput.fullOutput);
 	const outputReference = resolvedOutput.savedPath ? formatSavedOutputReference(resolvedOutput.savedPath, output) : undefined;
 	let outputForSummary = output;
 	if (attemptNotes.length > 0) {
@@ -1213,6 +1213,9 @@ async function runSingleStep(
 		outputForSummary = outputForSummary.trim() ? `${note}\n\n${outputForSummary}` : note;
 	}
 	const outputForAcceptance = rawOutput;
+	const childWrittenOutput = step.outputPath
+		? extractChildWrittenOutput(finalResult?.messages, step.outputPath, step.cwd ?? ctx.cwd)
+		: undefined;
 	const finalizedOutput = finalizeSingleOutput({
 		fullOutput: outputForSummary,
 		outputPath: step.outputPath,
@@ -1227,6 +1230,9 @@ async function runSingleStep(
 		? await evaluateAcceptance({
 			acceptance: step.effectiveAcceptance,
 			output: outputForAcceptance,
+			fileOutput: childWrittenOutput !== undefined && step.outputPath
+				? { content: childWrittenOutput, path: step.outputPath, authoritative: step.outputMode === "file-only" }
+				: undefined,
 			cwd: step.cwd ?? ctx.cwd,
 			signal: combinedAbortSignal([ctx.timeoutSignal, ctx.stopSignal]),
 			abortMessage: ctx.stopSignal?.aborted ? ctx.stopMessage ?? "Subagent stopped by user." : ctx.timeoutMessage ?? "Subagent timed out.",

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -51,7 +51,7 @@ import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir } from "../shared/pi-args.ts";
 import { readStructuredOutput } from "../shared/structured-output.ts";
-import { captureSingleOutputSnapshot, formatSavedOutputReference, injectOutputPathSystemPrompt, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
+import { captureSingleOutputSnapshot, extractChildWrittenOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
 import {
 	buildModelCandidates,
 	formatModelAttemptNote,
@@ -1313,6 +1313,9 @@ export async function runSync(
 		if (sessionFile) result.sessionFile = sessionFile;
 	}
 
+	const childWrittenOutput = options.outputPath
+		? extractChildWrittenOutput(result.messages, options.outputPath, options.cwd ?? runtimeCwd)
+		: undefined;
 	result.acceptance = result.detached
 		? buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "detached", message: "Acceptance was not evaluated because the subagent detached for intercom coordination before task completion." })
 		: result.timedOut
@@ -1322,6 +1325,9 @@ export async function runSync(
 			: await evaluateAcceptance({
 			acceptance: effectiveAcceptance,
 			output: acceptanceOutputByResult.get(result) ?? result.finalOutput ?? "",
+			fileOutput: childWrittenOutput !== undefined && options.outputPath
+				? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
+				: undefined,
 			cwd: options.cwd ?? runtimeCwd,
 		});
 	const acceptanceFailure = acceptanceFailureMessage(result.acceptance);

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -448,7 +448,10 @@ function parseGenericJsonAcceptanceReportBody(body: string): AcceptanceReport | 
 	return hasGenericAcceptanceReportSignal(validation.report) ? validation.report : undefined;
 }
 
+export const ACCEPTANCE_REPORT_NOT_FOUND = "Structured acceptance report not found.";
+
 export function parseAcceptanceReport(output: string): { report?: AcceptanceReport; error?: string } {
+	const explicitFencePresent = /```acceptance-report\b/i.test(output);
 	const fenced = fencedBlocks(output, "acceptance-report");
 	const parseErrors: string[] = [];
 	for (const body of fenced) {
@@ -461,6 +464,9 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 		}
 	}
 	if (parseErrors.length > 0) return { error: `Failed to parse acceptance-report: ${parseErrors.join("; ")}` };
+	if (explicitFencePresent) {
+		return { error: "Failed to parse acceptance-report: Empty or unterminated acceptance-report fence." };
+	}
 	for (const body of fencedBlocks(output, "(?:json|jsonc|json5)")) {
 		try {
 			const report = parseGenericJsonAcceptanceReportBody(body);
@@ -473,22 +479,46 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 	const markerIndex = output.search(/ACCEPTANCE_REPORT\s*:/i);
 	if (markerIndex !== -1) {
 		const jsonStart = output.indexOf("{", markerIndex);
-			if (jsonStart !== -1) {
-				const json = extractBalancedJson(output, jsonStart);
-				if (json) {
-					try {
-						const parsed = JSON.parse(json) as unknown;
-						const report = unwrapAcceptanceReport(parsed);
-						const validation = validateAcceptanceReport(report, validationPathLabelForWrapper(parsed));
-						if (validation.report) return { report: validation.report };
-						return { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}` };
-					} catch (error) {
-						return { error: error instanceof Error ? error.message : String(error) };
-					}
-				}
-			}
+		if (jsonStart === -1) {
+			return { error: "Failed to parse acceptance-report: Expected a JSON object after ACCEPTANCE_REPORT:." };
 		}
-	return { error: "Structured acceptance report not found." };
+		const json = extractBalancedJson(output, jsonStart);
+		if (!json) {
+			return { error: "Failed to parse acceptance-report: Unterminated JSON object after ACCEPTANCE_REPORT:." };
+		}
+		try {
+			const parsed = JSON.parse(json) as unknown;
+			const report = unwrapAcceptanceReport(parsed);
+			const validation = validateAcceptanceReport(report, validationPathLabelForWrapper(parsed));
+			if (validation.report) return { report: validation.report };
+			return { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}` };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return { error: `Failed to parse acceptance-report: ${message}` };
+		}
+	}
+	return { error: ACCEPTANCE_REPORT_NOT_FOUND };
+}
+
+function parseAcceptanceReportSources(
+	output: string,
+	fileOutput: { content: string; path: string; authoritative?: boolean } | undefined,
+): { report?: AcceptanceReport; error?: string } {
+	const fromText = () => parseAcceptanceReport(output);
+	const fromFile = () => {
+		if (!fileOutput) return { error: ACCEPTANCE_REPORT_NOT_FOUND };
+		const parsed = parseAcceptanceReport(fileOutput.content);
+		return parsed.report || parsed.error === ACCEPTANCE_REPORT_NOT_FOUND
+			? parsed
+			: { error: `${parsed.error} (in configured output ${fileOutput.path})` };
+	};
+	const [primary, secondary] = fileOutput?.authoritative ? [fromFile, fromText] : [fromText, fromFile];
+	const first = primary();
+	// A malformed report in the primary source is a defect to surface, not a
+	// miss to paper over with the secondary source; only a genuinely absent
+	// report falls through.
+	if (first.report || first.error !== ACCEPTANCE_REPORT_NOT_FOUND) return first;
+	return secondary();
 }
 
 export function stripAcceptanceReport(output: string): string {
@@ -788,6 +818,13 @@ export async function evaluateAcceptance(input: {
 	acceptance: ResolvedAcceptanceConfig;
 	output: string;
 	cwd: string;
+	/**
+	 * Content the child sent to its configured output file (from its own write
+	 * tool calls, not from disk, so a concurrent writer to the same path cannot
+	 * be misattributed). Searched for the acceptance report; searched before
+	 * the assistant output when `authoritative` (outputMode "file-only").
+	 */
+	fileOutput?: { content: string; path: string; authoritative?: boolean };
 	report?: AcceptanceReport;
 	reviewResult?: AcceptanceReviewResult;
 	signal?: AbortSignal;
@@ -805,7 +842,7 @@ export async function evaluateAcceptance(input: {
 	};
 	if (acceptance.level === "none") return ledger;
 
-	const parsed = input.report ? { report: input.report } : parseAcceptanceReport(input.output);
+	const parsed = input.report ? { report: input.report } : parseAcceptanceReportSources(input.output, input.fileOutput);
 	if (parsed.report) {
 		ledger.childReport = parsed.report;
 		ledger.status = "attested";

--- a/src/runs/shared/single-output.ts
+++ b/src/runs/shared/single-output.ts
@@ -1,11 +1,53 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { Message } from "@earendil-works/pi-ai";
 import type { OutputMode, SavedOutputReference } from "../../shared/types.ts";
 
 export interface SingleOutputSnapshot {
 	exists: boolean;
 	mtimeMs?: number;
 	size?: number;
+}
+
+/**
+ * Content the child itself sent to the configured output path, taken from its
+ * last `write` tool call whose tool result reports success. Unlike reading the
+ * path from disk, this cannot be polluted by a sibling run writing the same
+ * path (#420); requiring the successful tool result keeps failed, cancelled,
+ * or unanswered write calls from counting as authored output. Returns
+ * undefined when no such write exists (e.g. bash or edit-based construction),
+ * in which case callers must not assume file authorship.
+ */
+export function extractChildWrittenOutput(
+	messages: Message[] | undefined,
+	outputPath: string | undefined,
+	cwd?: string,
+): string | undefined {
+	if (!messages?.length || !outputPath) return undefined;
+	const resolvedTarget = path.resolve(cwd ?? ".", outputPath);
+	const comparableTarget = process.platform === "win32" ? resolvedTarget.toLowerCase() : resolvedTarget;
+	const successfulCallIds = new Set<string>();
+	for (const message of messages) {
+		if (message.role === "toolResult" && message.isError === false && typeof message.toolCallId === "string") {
+			successfulCallIds.add(message.toolCallId);
+		}
+	}
+	let content: string | undefined;
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		for (const part of message.content) {
+			if (part.type !== "toolCall" || part.name !== "write" || !successfulCallIds.has(part.id)) continue;
+			const args = typeof part.arguments === "object" && part.arguments !== null && !Array.isArray(part.arguments)
+				? part.arguments as Record<string, unknown>
+				: {};
+			if (typeof args.path !== "string" || typeof args.content !== "string") continue;
+			const resolvedWritePath = path.resolve(cwd ?? ".", args.path);
+			const comparableWritePath = process.platform === "win32" ? resolvedWritePath.toLowerCase() : resolvedWritePath;
+			if (comparableWritePath !== comparableTarget) continue;
+			content = args.content;
+		}
+	}
+	return content;
 }
 
 export function normalizeSingleOutputOverride(

--- a/test/integration/acceptance-file-report.test.ts
+++ b/test/integration/acceptance-file-report.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Acceptance report sourcing through the real execution drivers: the report the
+ * child wrote to its configured output file (recovered from its write tool
+ * calls) versus the assistant text, ordered by outputMode, including parallel
+ * children with the distinct configured paths required after #420. Runs the
+ * full spawn → stream-parse → acceptance pipeline against the mock pi CLI.
+ */
+import { after, afterEach, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { MockPi } from "../support/helpers.ts";
+import { createEventBus, createMockPi, createTempDir, events, makeAgent, makeAgentConfigs, makeMinimalCtx, removeTempDir, tryImport } from "../support/helpers.ts";
+
+interface AcceptanceSummary {
+	status?: string;
+	childReport?: { criteriaSatisfied?: Array<{ id?: string; status?: string; evidence?: string }> };
+	runtimeChecks?: Array<{ id?: string; status?: string; message?: string }>;
+}
+
+interface ExecutionModule {
+	runSync(
+		runtimeCwd: string,
+		agents: ReturnType<typeof makeAgentConfigs>,
+		agentName: string,
+		task: string,
+		options: Record<string, unknown>,
+	): Promise<{
+		exitCode: number;
+		error?: string;
+		finalOutput?: string;
+		savedOutputPath?: string;
+		acceptance?: AcceptanceSummary;
+	}>;
+}
+
+interface AsyncExecutionModule {
+	isAsyncAvailable(): boolean;
+	executeAsyncSingle(id: string, params: Record<string, unknown>): unknown;
+}
+
+interface TypesModule {
+	ASYNC_DIR: string;
+	RESULTS_DIR: string;
+}
+
+interface ExecutorModule {
+	createSubagentExecutor?: (...args: unknown[]) => {
+		execute: (...args: unknown[]) => Promise<{ content: Array<{ text?: string }>; isError?: boolean; details?: { asyncId?: string } }>;
+	};
+}
+
+interface AsyncResultPayload {
+	success: boolean;
+	results: Array<{ output?: string; error?: string; acceptance?: AcceptanceSummary }>;
+}
+
+const execution = await tryImport<ExecutionModule>("./src/runs/foreground/execution.ts");
+const asyncMod = await tryImport<AsyncExecutionModule>("./src/runs/background/async-execution.ts");
+const typesMod = await tryImport<TypesModule>("./src/shared/types.ts");
+const executorMod = await tryImport<ExecutorModule>("./src/runs/foreground/subagent-executor.ts");
+
+const runSync = execution?.runSync;
+const isAsyncAvailable = asyncMod?.isAsyncAvailable;
+const executeAsyncSingle = asyncMod?.executeAsyncSingle;
+const ASYNC_DIR = typesMod?.ASYNC_DIR;
+const RESULTS_DIR = typesMod?.RESULTS_DIR;
+const createSubagentExecutor = executorMod?.createSubagentExecutor;
+
+const DISABLED_ARTIFACTS = {
+	enabled: false,
+	includeInput: false,
+	includeOutput: false,
+	includeJsonl: false,
+	includeMetadata: false,
+	cleanupDays: 7,
+};
+
+function acceptanceReport(criterionStatus: "satisfied" | "not-satisfied", evidence: string): string {
+	return [
+		"```acceptance-report",
+		JSON.stringify({
+			criteriaSatisfied: [{ id: "criterion-1", status: criterionStatus, evidence }],
+			changedFiles: ["src/module.ts"],
+			testsAddedOrUpdated: ["test/module.test.ts"],
+			commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+			validationOutput: ["passed"],
+			residualRisks: [],
+			noStagedFiles: true,
+			notes: evidence,
+		}),
+		"```",
+	].join("\n");
+}
+
+async function waitForAsyncResult(id: string, timeoutMs = 15_000): Promise<AsyncResultPayload> {
+	const resultPath = path.join(RESULTS_DIR!, `${id}.json`);
+	const deadline = Date.now() + timeoutMs;
+	while (!fs.existsSync(resultPath)) {
+		if (Date.now() > deadline) assert.fail(`Timed out waiting for async result file: ${resultPath}`);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	return JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+}
+
+describe("acceptance file reports", { skip: !runSync ? "pi packages not available" : undefined }, () => {
+	let tempDir: string;
+	let mockPi: MockPi;
+
+	before(() => {
+		mockPi = createMockPi();
+		mockPi.install();
+	});
+
+	after(() => {
+		mockPi.uninstall();
+	});
+
+	beforeEach(() => {
+		tempDir = createTempDir();
+		mockPi.reset();
+	});
+
+	afterEach(() => {
+		removeTempDir(tempDir);
+	});
+
+	function conflictingReportsCall(outputPath: string, fileStatus: "satisfied" | "not-satisfied", textStatus: "satisfied" | "not-satisfied") {
+		const fileReport = `# Findings\n${acceptanceReport(fileStatus, "from child-written file")}`;
+		mockPi.onCall({
+			jsonl: [
+				...events.completedWrite(outputPath, fileReport),
+				events.assistantMessage(`Report written to the output file.\n${acceptanceReport(textStatus, "from assistant text")}`),
+			],
+			writeFiles: [{ path: outputPath, content: fileReport }],
+		});
+	}
+
+	describe("foreground runSync", () => {
+		it("file-only mode accepts from the child-written file when the text report fails", async () => {
+			const outputPath = path.join(tempDir, "report.md");
+			conflictingReportsCall(outputPath, "satisfied", "not-satisfied");
+
+			const result = await runSync!(tempDir, makeAgentConfigs(["worker"]), "worker", "Write the findings report.", {
+				runId: "acceptance-file-only",
+				outputPath,
+				outputMode: "file-only",
+				acceptance: { level: "checked", criteria: ["Report the findings"] },
+			});
+
+			assert.equal(result.acceptance?.status, "checked");
+			assert.equal(result.exitCode, 0);
+			assert.equal(result.savedOutputPath, outputPath);
+		});
+
+		it("file-only mode accepts a saved report when final assistant text is only a receipt", async () => {
+			const outputPath = path.join(tempDir, "saved-review.md");
+			const fileReport = `# Review\n${acceptanceReport("satisfied", "foreground saved verdict")}`;
+			mockPi.onCall({
+				jsonl: [...events.completedWrite(outputPath, fileReport), events.assistantMessage("Output saved to the configured file.")],
+				writeFiles: [{ path: outputPath, content: fileReport }],
+			});
+
+			const result = await runSync!(tempDir, makeAgentConfigs(["worker"]), "worker", "Write the findings report.", {
+				runId: "acceptance-foreground-saved-receipt",
+				outputPath,
+				outputMode: "file-only",
+				acceptance: { level: "checked", criteria: ["Report the findings"] },
+			});
+
+			assert.equal(result.acceptance?.status, "checked");
+			assert.equal(result.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence, "foreground saved verdict");
+			assert.equal(result.exitCode, 0);
+		});
+
+		it("inline mode rejects on the text report even when the child-written file passes", async () => {
+			const outputPath = path.join(tempDir, "report.md");
+			conflictingReportsCall(outputPath, "satisfied", "not-satisfied");
+
+			const result = await runSync!(tempDir, makeAgentConfigs(["worker"]), "worker", "Write the findings report.", {
+				runId: "acceptance-inline-text-first",
+				outputPath,
+				acceptance: { level: "checked", criteria: ["Report the findings"] },
+			});
+
+			assert.equal(result.acceptance?.status, "rejected");
+			assert.equal(result.exitCode, 1);
+			assert.match(result.error ?? "", /Acceptance rejected: Required criterion 'criterion-1' was reported as not-satisfied\./);
+		});
+
+		it("inline mode accepts on the text report regardless of a failing file report", async () => {
+			const outputPath = path.join(tempDir, "report.md");
+			conflictingReportsCall(outputPath, "not-satisfied", "satisfied");
+
+			const result = await runSync!(tempDir, makeAgentConfigs(["worker"]), "worker", "Write the findings report.", {
+				runId: "acceptance-inline-file-fallback-only",
+				outputPath,
+				acceptance: { level: "checked", criteria: ["Report the findings"] },
+			});
+
+			assert.equal(result.acceptance?.status, "checked");
+			assert.equal(result.exitCode, 0);
+		});
+
+		it("does not credit a failed write as the file report", async () => {
+			const outputPath = path.join(tempDir, "report.md");
+			const fileReport = `# Findings\n${acceptanceReport("satisfied", "from a write that failed")}`;
+			mockPi.onCall({
+				jsonl: [
+					{
+						type: "message_end",
+						message: {
+							role: "assistant",
+							content: [{ type: "toolCall", id: "w-failed", name: "write", arguments: { path: outputPath, content: fileReport } }],
+							model: "mock/test-model",
+							stopReason: "toolUse",
+							usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+						},
+					},
+					{
+						type: "tool_result_end",
+						message: { role: "toolResult", toolCallId: "w-failed", toolName: "write", isError: true, content: [{ type: "text", text: "disk full" }] },
+					},
+					events.assistantMessage(`The write failed.\n${acceptanceReport("not-satisfied", "from assistant text")}`),
+				],
+			});
+
+			const result = await runSync!(tempDir, makeAgentConfigs(["worker"]), "worker", "Write the findings report.", {
+				runId: "acceptance-failed-write",
+				outputPath,
+				outputMode: "file-only",
+				acceptance: { level: "checked", criteria: ["Report the findings"] },
+			});
+
+			assert.equal(result.acceptance?.status, "rejected");
+			assert.equal(result.exitCode, 1);
+			assert.match(result.error ?? "", /reported as not-satisfied/);
+		});
+
+		it("rejects a malformed child-written file report instead of accepting the text report", async () => {
+			const outputPath = path.join(tempDir, "report.md");
+			const malformedReport = "```acceptance-report\n{ not json";
+			mockPi.onCall({
+				jsonl: [
+					...events.completedWrite(outputPath, malformedReport),
+					events.assistantMessage(acceptanceReport("satisfied", "from assistant text")),
+				],
+				writeFiles: [{ path: outputPath, content: malformedReport }],
+			});
+
+			const result = await runSync!(tempDir, makeAgentConfigs(["worker"]), "worker", "Write the findings report.", {
+				runId: "acceptance-malformed-file-report",
+				outputPath,
+				outputMode: "file-only",
+				acceptance: { level: "checked", criteria: ["Report the findings"] },
+			});
+
+			assert.equal(result.acceptance?.status, "rejected");
+			assert.equal(result.exitCode, 1);
+			assert.match(result.error ?? "", /Empty or unterminated acceptance-report fence.*configured output/);
+		});
+	});
+
+	describe("background runner", { skip: isAsyncAvailable && !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
+		function runAsyncSingle(id: string, outputPath: string, outputMode: "inline" | "file-only") {
+			executeAsyncSingle!(id, {
+				agent: "worker",
+				task: "Write the findings report.",
+				agentConfig: makeAgent("worker", { completionGuard: false }),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-file-report" },
+				artifactConfig: DISABLED_ARTIFACTS,
+				shareEnabled: false,
+				maxSubagentDepth: 2,
+				output: outputPath,
+				outputMode,
+				acceptance: { level: "checked", criteria: ["Report the findings"] },
+			});
+		}
+
+		it("file-only mode accepts from the child-written file when the text report fails", async () => {
+			const outputPath = path.join(tempDir, "async-report.md");
+			conflictingReportsCall(outputPath, "satisfied", "not-satisfied");
+			const id = `acceptance-file-report-${Date.now().toString(36)}`;
+			runAsyncSingle(id, outputPath, "file-only");
+
+			const payload = await waitForAsyncResult(id);
+			assert.equal(payload.success, true);
+			assert.equal(payload.results[0]?.acceptance?.status, "checked");
+			assert.match(payload.results[0]?.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence ?? "", /from child-written file/);
+			const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR!, id, "status.json"), "utf-8")) as { steps?: Array<{ acceptance?: { status?: string } }> };
+			assert.equal(status.steps?.[0]?.acceptance?.status, "checked");
+		});
+
+		it("file-only mode accepts a saved report when final assistant text is only a receipt", async () => {
+			const outputPath = path.join(tempDir, "saved-review.md");
+			const fileReport = `# Review\n${acceptanceReport("satisfied", "saved reviewer verdict")}`;
+			mockPi.onCall({
+				jsonl: [...events.completedWrite(outputPath, fileReport), events.assistantMessage("Output saved to the configured file.")],
+				writeFiles: [{ path: outputPath, content: fileReport }],
+			});
+			const id = `acceptance-saved-receipt-${Date.now().toString(36)}`;
+			runAsyncSingle(id, outputPath, "file-only");
+
+			const payload = await waitForAsyncResult(id);
+			assert.equal(payload.success, true);
+			assert.equal(payload.results[0]?.acceptance?.status, "checked");
+			assert.equal(payload.results[0]?.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence, "saved reviewer verdict");
+		});
+
+		it("inline mode accepts from the text report and strips fences from the resolved file output", async () => {
+			const outputPath = path.join(tempDir, "async-report.md");
+			conflictingReportsCall(outputPath, "not-satisfied", "satisfied");
+			const id = `acceptance-inline-strip-${Date.now().toString(36)}`;
+			runAsyncSingle(id, outputPath, "inline");
+
+			const payload = await waitForAsyncResult(id);
+			assert.equal(payload.success, true);
+			assert.equal(payload.results[0]?.acceptance?.status, "checked");
+			assert.match(payload.results[0]?.output ?? "", /# Findings/);
+			assert.doesNotMatch(payload.results[0]?.output ?? "", /```acceptance-report/);
+		});
+
+		it("parallel children keep acceptance tied to their distinct configured outputs", { skip: !createSubagentExecutor ? "executor not available" : undefined }, async () => {
+			const alphaPath = path.join(tempDir, "alpha-report.md");
+			const betaPath = path.join(tempDir, "beta-report.md");
+			const alphaReport = `# Alpha findings\n${acceptanceReport("satisfied", "alpha evidence")}`;
+			const betaReport = `# Beta findings\n${acceptanceReport("not-satisfied", "beta evidence")}`;
+			mockPi.onCall({
+				matchArgIncludes: "Alpha task",
+				jsonl: [...events.completedWrite(alphaPath, alphaReport), events.assistantMessage("Alpha wrote its report.")],
+				writeFiles: [{ path: alphaPath, content: alphaReport }],
+			});
+			mockPi.onCall({
+				matchArgIncludes: "Beta task",
+				jsonl: [...events.completedWrite(betaPath, betaReport), events.assistantMessage("Beta wrote its report.")],
+				writeFiles: [{ path: betaPath, content: betaReport }],
+			});
+			const executor = createSubagentExecutor!({
+				pi: { events: createEventBus(), getSessionName: () => undefined },
+				state: { baseCwd: tempDir, currentSessionId: null, asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null },
+				config: {},
+				asyncByDefault: false,
+				tempArtifactsDir: tempDir,
+				getSubagentSessionRoot: () => tempDir,
+				expandTilde: (p: string) => p,
+				discoverAgents: () => ({ agents: [makeAgent("worker", { completionGuard: false })] }),
+			});
+
+			const acceptance = { level: "checked", criteria: ["Report the findings"] };
+			const result = await executor.execute(
+				"acceptance-parallel-files",
+				{
+					tasks: [
+						{ agent: "worker", task: "Alpha task: write the report.", output: alphaPath, outputMode: "file-only", acceptance },
+						{ agent: "worker", task: "Beta task: write the report.", output: betaPath, outputMode: "file-only", acceptance },
+					],
+					async: true,
+					clarify: false,
+				},
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+
+			const asyncId = result.details?.asyncId;
+			assert.ok(asyncId, "expected asyncId");
+			const payload = await waitForAsyncResult(asyncId);
+			assert.equal(payload.results.length, 2);
+			const alpha = payload.results[0];
+			const beta = payload.results[1];
+			assert.equal(alpha?.acceptance?.status, "checked");
+			assert.equal(alpha?.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence, "alpha evidence");
+			assert.equal(beta?.acceptance?.status, "rejected");
+			assert.equal(beta?.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence, "beta evidence");
+		});
+	});
+});

--- a/test/support/helpers.ts
+++ b/test/support/helpers.ts
@@ -153,6 +153,8 @@ export async function tryImport<T>(specifier: string): Promise<T | null> {
 	}
 }
 
+let writeCallSeq = 0;
+
 export const events = {
 	assistantMessage(text: string, model = "mock/test-model"): object {
 		return {
@@ -165,6 +167,33 @@ export const events = {
 				usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
 			},
 		};
+	},
+
+	/** Assistant write tool call plus its successful tool result, as one completed write. */
+	completedWrite(filePath: string, content: string, model = "mock/test-model"): object[] {
+		const id = `write-${++writeCallSeq}`;
+		return [
+			{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id, name: "write", arguments: { path: filePath, content } }],
+					model,
+					stopReason: "toolUse",
+					usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+				},
+			},
+			{
+				type: "tool_result_end",
+				message: {
+					role: "toolResult",
+					toolCallId: id,
+					toolName: "write",
+					isError: false,
+					content: [{ type: "text", text: `Wrote ${filePath}` }],
+				},
+			},
+		];
 	},
 
 	toolStart(toolName: string, args: Record<string, unknown> = {}): object {

--- a/test/support/mock-pi-script.mjs
+++ b/test/support/mock-pi-script.mjs
@@ -167,6 +167,16 @@ function defaultResponse() {
 	return { output: "ok", exitCode: 0 };
 }
 
+function writeDeclaredFiles(response) {
+	if (!Array.isArray(response.writeFiles)) return;
+	for (const file of response.writeFiles) {
+		if (!file || typeof file.path !== "string" || typeof file.content !== "string") continue;
+		const target = path.resolve(process.cwd(), file.path);
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.writeFileSync(target, file.content, "utf-8");
+	}
+}
+
 function isJsonMode(args) {
 	for (let i = 0; i < args.length; i++) {
 		if (args[i] === "--mode") {
@@ -292,6 +302,8 @@ async function main() {
 	if (typeof response.delay === "number" && response.delay > 0) {
 		await new Promise((resolve) => setTimeout(resolve, response.delay));
 	}
+
+	writeDeclaredFiles(response);
 
 	if (Array.isArray(response.steps) && response.steps.length > 0) {
 		for (const step of response.steps) {

--- a/test/support/mock-pi.ts
+++ b/test/support/mock-pi.ts
@@ -18,6 +18,8 @@ interface MockPiResponse {
 	}>;
 	echoEnv?: string[];
 	matchArgIncludes?: string | string[];
+	/** Files the mock child writes to disk before emitting output, standing in for its write-tool side effects. */
+	writeFiles?: Array<{ path: string; content: string }>;
 }
 
 export interface MockPi {

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
+import type { Message } from "@earendil-works/pi-ai";
 import {
 	acceptanceFailureMessage,
 	aggregateAcceptanceReport,
@@ -13,6 +14,7 @@ import {
 	stripAcceptanceReport,
 	validateAcceptanceInput,
 } from "../../src/runs/shared/acceptance.ts";
+import { extractChildWrittenOutput } from "../../src/runs/shared/single-output.ts";
 
 function reportData(overrides: Record<string, unknown> = {}): Record<string, unknown> {
 	return {
@@ -121,9 +123,17 @@ describe("acceptance gates", () => {
 		assert.match(genericReportShapedJson.error ?? "", /Structured acceptance report not found/);
 		assert.equal(stripAcceptanceReport(reportShapedJson), reportShapedJson);
 
-		const malformed = parseAcceptanceReport("```acceptance-report\n{bad-json\n```");
-		assert.equal(malformed.report, undefined);
-		assert.match(malformed.error ?? "", /Failed to parse acceptance-report/);
+		for (const malformedOutput of [
+			"```acceptance-report\n{bad-json\n```",
+			"```acceptance-report\n```",
+			"```acceptance-report\n{\"criteriaSatisfied\": []}",
+			"ACCEPTANCE_REPORT: { not json",
+			"ACCEPTANCE_REPORT: no object",
+		]) {
+			const malformed = parseAcceptanceReport(malformedOutput);
+			assert.equal(malformed.report, undefined);
+			assert.match(malformed.error ?? "", /Failed to parse acceptance-report/, malformedOutput);
+		}
 	});
 
 	it("parses acceptance reports from json-family fences", () => {
@@ -398,6 +408,165 @@ describe("acceptance gates", () => {
 
 			assert.equal(ledger.status, "rejected");
 			assert.match(acceptanceFailureMessage(ledger) ?? "", /criterion|changed-files|tests-added|commands-run|validation-output|no-staged-files/);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("recovers the acceptance report from child-written configured output", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "checked" },
+			});
+			const receipt = "Report written to the configured output file.";
+
+			const withoutFile = await evaluateAcceptance({ acceptance, output: receipt, cwd });
+			assert.equal(withoutFile.status, "rejected");
+
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: receipt,
+				fileOutput: { content: report(), path: "/tmp/report.md", authoritative: true },
+				cwd,
+			});
+			assert.equal(ledger.status, "checked");
+			assert.ok(ledger.childReport);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("report source order follows output authority", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "checked" },
+			});
+			const inline = await evaluateAcceptance({
+				acceptance,
+				output: report({ notes: "from text" }),
+				fileOutput: { content: report({ notes: "from file" }), path: "/tmp/report.md" },
+				cwd,
+			});
+			assert.equal(inline.childReport?.notes, "from text");
+
+			const fileOnly = await evaluateAcceptance({
+				acceptance,
+				output: report({ notes: "from text" }),
+				fileOutput: { content: report({ notes: "from file" }), path: "/tmp/report.md", authoritative: true },
+				cwd,
+			});
+			assert.equal(fileOnly.childReport?.notes, "from file");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("sibling overwrites of a shared output path cannot pollute this child's acceptance", async () => {
+		const cwd = tempRepo();
+		const sharedPath = path.join(cwd, "context.md");
+		try {
+			// Sibling child B wrote the shared path last (issue #420); the disk
+			// content is B's. Child A's acceptance input comes from A's own
+			// successful write-tool call, so B's report must not be attributed to A.
+			fs.writeFileSync(sharedPath, report({ notes: "sibling B report" }), "utf-8");
+			const childAMessages: Message[] = [
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "w1", name: "write", arguments: { path: sharedPath, content: report({ notes: "child A report" }) } }],
+					api: "test",
+					provider: "test",
+					model: "mock/test-model",
+					usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+					stopReason: "toolUse",
+					timestamp: 0,
+				},
+				{ role: "toolResult", toolCallId: "w1", toolName: "write", content: [{ type: "text", text: "ok" }], isError: false, timestamp: 0 },
+			];
+			const childAContent = extractChildWrittenOutput(childAMessages, sharedPath, cwd);
+			assert.equal(typeof childAContent, "string");
+
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "checked" },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: "Report written to the configured output file.",
+				fileOutput: { content: childAContent!, path: sharedPath, authoritative: true },
+				cwd,
+			});
+			assert.equal(ledger.childReport?.notes, "child A report");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a malformed primary report instead of falling back to the secondary source", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "checked" },
+			});
+			const malformedReports = [
+				"```acceptance-report\n{ not json\n```",
+				"```acceptance-report\n```",
+				"```acceptance-report\n{\"criteriaSatisfied\": []}",
+				"ACCEPTANCE_REPORT: { not json",
+			];
+
+			for (const malformed of malformedReports) {
+				const fileOnly = await evaluateAcceptance({
+					acceptance,
+					output: report({ notes: "valid text report" }),
+					fileOutput: { content: malformed, path: "/tmp/report.md", authoritative: true },
+					cwd,
+				});
+				assert.equal(fileOnly.status, "rejected", malformed);
+				assert.match(fileOnly.childReportParseError ?? "", /configured output/, malformed);
+			}
+
+			const inline = await evaluateAcceptance({
+				acceptance,
+				output: malformedReports[0]!,
+				fileOutput: { content: report({ notes: "valid file report" }), path: "/tmp/report.md" },
+				cwd,
+			});
+			assert.equal(inline.status, "rejected");
+			assert.match(inline.childReportParseError ?? "", /Failed to parse acceptance-report/);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("surfaces field-level errors from an invalid configured-output report", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "checked" },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: "wrote the report to the file",
+				fileOutput: {
+					content: report({ criteriaSatisfied: [{ id: "criterion-1", status: "not_satisfied", evidence: "x" }] }),
+					path: "/tmp/report.md",
+				},
+				cwd,
+			});
+			assert.equal(ledger.status, "rejected");
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /not_satisfied/);
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /configured output/);
 		} finally {
 			fs.rmSync(cwd, { recursive: true, force: true });
 		}

--- a/test/unit/single-output.test.ts
+++ b/test/unit/single-output.test.ts
@@ -3,8 +3,10 @@ import { afterEach, describe, it } from "node:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { Message, Usage } from "@earendil-works/pi-ai";
 import {
 	captureSingleOutputSnapshot,
+	extractChildWrittenOutput,
 	finalizeSingleOutput,
 	formatSavedOutputReference,
 	injectOutputPathSystemPrompt,
@@ -143,6 +145,88 @@ describe("resolveSingleOutput", () => {
 		assert.equal(result.fullOutput, "fallback output");
 		assert.equal(result.savedPath, undefined);
 		assert.match(result.saveError ?? "", /Failed to read changed output file/);
+	});
+});
+
+describe("extractChildWrittenOutput", () => {
+	const usage: Usage = { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } };
+	const toolCall = (id: string, name: string, args: Record<string, unknown>): Message => ({
+		role: "assistant",
+		content: [{ type: "toolCall", id, name, arguments: args }],
+		api: "test",
+		provider: "test",
+		model: "mock/test-model",
+		usage,
+		stopReason: "toolUse",
+		timestamp: 0,
+	});
+	const toolResult = (id: string, isError = false): Message => ({
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "write",
+		content: [{ type: "text", text: isError ? "write failed" : "ok" }],
+		isError,
+		timestamp: 0,
+	});
+	const completedWrite = (id: string, writePath: string, content: string): Message[] => [
+		toolCall(id, "write", { path: writePath, content }),
+		toolResult(id),
+	];
+
+	it("returns the last successfully written content for the configured path", () => {
+		const messages = [
+			...completedWrite("w1", "/tmp/out.md", "draft"),
+			...completedWrite("w2", "/tmp/other.md", "unrelated"),
+			...completedWrite("w3", "/tmp/out.md", "final report"),
+		];
+		assert.equal(extractChildWrittenOutput(messages, "/tmp/out.md", "/repo"), "final report");
+	});
+
+	it("ignores write calls whose tool result failed", () => {
+		const failedOnly = [toolCall("w1", "write", { path: "/tmp/out.md", content: "never landed" }), toolResult("w1", true)];
+		assert.equal(extractChildWrittenOutput(failedOnly, "/tmp/out.md", "/repo"), undefined);
+
+		const failedAfterSuccess = [
+			...completedWrite("w1", "/tmp/out.md", "landed"),
+			toolCall("w2", "write", { path: "/tmp/out.md", content: "never landed" }),
+			toolResult("w2", true),
+		];
+		assert.equal(extractChildWrittenOutput(failedAfterSuccess, "/tmp/out.md", "/repo"), "landed");
+	});
+
+	it("ignores write calls with no confirmed successful tool result", () => {
+		const missingResult = [toolCall("w1", "write", { path: "/tmp/out.md", content: "unconfirmed" })];
+		assert.equal(extractChildWrittenOutput(missingResult, "/tmp/out.md", "/repo"), undefined);
+
+		const missingStatus = [
+			toolCall("w1", "write", { path: "/tmp/out.md", content: "unconfirmed" }),
+			{ role: "toolResult", toolCallId: "w1", toolName: "write", content: [{ type: "text", text: "unknown" }], timestamp: 0 } as Message,
+		];
+		assert.equal(extractChildWrittenOutput(missingStatus, "/tmp/out.md", "/repo"), undefined);
+	});
+
+	it("resolves relative write paths against the child cwd", () => {
+		const messages = completedWrite("w1", "reports/out.md", "relative content");
+		assert.equal(extractChildWrittenOutput(messages, "/repo/reports/out.md", "/repo"), "relative content");
+		assert.equal(extractChildWrittenOutput(messages, "/elsewhere/reports/out.md", "/repo"), undefined);
+	});
+
+	it("matches configured output paths case-insensitively on Windows", { skip: process.platform !== "win32" ? "Windows path comparison" : undefined }, () => {
+		const writePath = path.join("C:\\Repo", "Reports", "Output.md");
+		const configuredPath = writePath.toLowerCase();
+		assert.equal(extractChildWrittenOutput(completedWrite("w1", writePath, "Windows report"), configuredPath, "C:\\Repo"), "Windows report");
+	});
+
+	it("ignores non-write tools and missing arguments", () => {
+		const messages = [
+			toolCall("e1", "edit", { path: "/tmp/out.md", oldText: "a", newText: "b" }),
+			toolResult("e1"),
+			toolCall("w1", "write", { path: "/tmp/out.md" }),
+			toolResult("w1"),
+		];
+		assert.equal(extractChildWrittenOutput(messages, "/tmp/out.md", "/repo"), undefined);
+		assert.equal(extractChildWrittenOutput(undefined, "/tmp/out.md", "/repo"), undefined);
+		assert.equal(extractChildWrittenOutput(messages, undefined, "/repo"), undefined);
 	});
 });
 


### PR DESCRIPTION
## Problem

With `outputMode: "file-only"` the child is instructed to write its acceptance report to the configured output file — but `evaluateAcceptance` only ever parses assistant text. A child that follows its instructions exactly gets its report rejected as missing and the run ends `failed`. This was the largest source of false `failed` subagent runs we hit in real use.

## Fix

- `extractChildWrittenOutput` (new, `src/runs/shared/single-output.ts`) recovers the content of the child's last `write` tool call to the output path **whose tool result reports success**. Because it reads the transcript rather than the disk, a sibling run writing the same path (#420) cannot be misattributed to this child, and failed, cancelled, or unanswered writes never count.
- `evaluateAcceptance` gains `fileOutput`; both runners wire it in. It is the **primary** report source when authoritative (file-only mode), secondary otherwise.
- A malformed or incomplete primary report — bad JSON, an empty or unterminated ```acceptance-report fence, a dangling `ACCEPTANCE_REPORT:` marker — rejects with the parse error instead of being papered over by the secondary source. Only a genuinely absent report falls through.
- Background run summaries now strip acceptance-report fences the way foreground already did.

This does not change output-file collision behavior itself (#420 is about artifact identity and stays open); it makes acceptance evaluation immune to the collision.

## Testing

- `npm run test:unit` — 1092/1092
- `npm run test:integration` — 498/498; new `test/integration/acceptance-file-report.test.ts` drives both runners end-to-end through the mock pi CLI, including the #420 shared-path collision, a failed write that must not be credited, and a malformed child-written report that must reject rather than fall back to assistant text
- `npm run test:e2e` — 1/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
