### PR TITLE
fix(fallback): stop model retry on child tool failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Prevented model fallback retries for trailing child tool failures even when their details resemble provider outages, and retried provider streams that end without `finish_reason`. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #436.
 - Recognized Pi's `max` thinking level in child model suffixes, Clarify selection, watchdog settings, and status formatting, while exposing it only when model metadata explicitly supports it. Thanks to mapleluv (@mapleluvr) for #423.
 - Labeled every chain-clarification shortcut with its action, made the background state explicit, and kept primary actions in a separate footer without widening the fixed 84-column overlay. Thanks to GonzaloRocca (@gonzalonicolasr) for #430.
 - Hardened acceptance reports so explicit empty changed-file and test arrays are treated as not applicable, required criteria are reflected in examples, known model-output variants normalize to one strict canonical shape, unknown or ambiguous values fail with exact diagnostics, and parsed reports plus ledgers persist in child metadata while normal output stays clean. Thanks to Nick Tripp (@nicholastripp) for #442, maxsturmb (@maxsturmb) for #452, and techmodv90 (@techmodv90) for #449 and #450.

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -267,6 +267,7 @@ const RETRYABLE_MODEL_FAILURE_PATTERNS = [
 	/fetch failed/i,
 	/network error/i,
 	/socket hang up/i,
+	/stream ended without finish_reason/i,
 	/upstream/i,
 	/timed? out/i,
 	/timeout/i,
@@ -279,8 +280,18 @@ const RETRYABLE_MODEL_FAILURE_PATTERNS = [
 	/model.*(?:load|fail|error)/i,
 ];
 
+/**
+ * Failures reported as `<tool> failed (exit N): ...` or `<tool> failed with
+ * exit code N` come from a tool call inside the child's task, not from the
+ * provider/model, however network-flavored their details read. Retrying a
+ * different model cannot fix them and would rerun the whole task. Tool names
+ * include namespaced forms like `mcp.server/write`.
+ */
+const TOOL_FAILURE_PREFIX = /^[\w.:@/-]+ failed (?:(?:\(exit \d+\):)|(?:with exit code \d+))(?:\s|$)/i;
+
 export function isRetryableModelFailure(error: string | undefined): boolean {
 	if (!error) return false;
+	if (TOOL_FAILURE_PREFIX.test(error.trim())) return false;
 	return RETRYABLE_MODEL_FAILURE_PATTERNS.some((pattern) => pattern.test(error));
 }
 

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -1763,6 +1763,95 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(mockPi.callCount(), 2);
 	});
 
+	it("background runs retry the fallback model when the provider stream ends without finish_reason", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "stream broke mid-response" }],
+					model: "openai/gpt-5-mini",
+					errorMessage: "Stream ended without finish_reason",
+					usage: { input: 10, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+				},
+			}],
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "Recovered after stream failure" });
+		const id = `async-fallback-stream-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", {
+				model: "openai/gpt-5-mini:high",
+				fallbackModels: ["anthropic/claude-sonnet-4:low"],
+			}),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			availableModels: [
+				{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" },
+				{ provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
+			],
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf-8"));
+		assert.equal(payload.success, true);
+		assert.deepEqual(payload.results[0].attemptedModels, ["openai/gpt-5-mini:high", "anthropic/claude-sonnet-4:low"]);
+		assert.match(payload.results[0].output ?? "", /Recovered after stream failure/);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
+	it("background runs do not retry the fallback model for a trailing tool failure", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [
+				mockAssistantMessage("checking connectivity", "tool_use"),
+				events.toolResult("bash", "curl: (28) Connection timed out after 5000 ms\nCommand exited with code 1", true),
+			],
+			exitCode: 0,
+		});
+		mockPi.onCall({ output: "fallback must not run" });
+		const id = `async-fallback-toolfail-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", {
+				model: "openai/gpt-5-mini:high",
+				fallbackModels: ["anthropic/claude-sonnet-4:low"],
+			}),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			availableModels: [
+				{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" },
+				{ provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
+			],
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf-8"));
+		assert.equal(payload.success, false);
+		assert.equal(payload.results[0].modelAttempts.length, 1);
+		assert.match(payload.results[0].error ?? "", /^bash failed \(exit 1\)/);
+		assert.match(payload.results[0].error ?? "", /timed out/i);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
 	it("background single thinking override replaces primary and fallback suffixes", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			jsonl: [{

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -71,12 +71,24 @@ describe("model fallback helpers", () => {
 		assert.equal(isRetryableModelFailure("authentication failed"), true);
 		assert.equal(isRetryableModelFailure("Subagent produced no output (possible model cold-start or empty response)."), true);
 		assert.equal(isRetryableModelFailure("model load failed"), true);
+		assert.equal(isRetryableModelFailure("Stream ended without finish_reason"), true);
+		assert.equal(isRetryableModelFailure("Request timed out."), true);
 	});
 
 	it("does not treat ordinary task/tool failures as retryable model failures", () => {
 		assert.equal(isRetryableModelFailure("bash failed (exit 1): command not found"), false);
 		assert.equal(isRetryableModelFailure("read failed (exit 1): no such file or directory"), false);
 		assert.equal(isRetryableModelFailure(undefined), false);
+	});
+
+	it("does not treat network-flavored tool failures as retryable model failures", () => {
+		assert.equal(isRetryableModelFailure("bash failed (exit 1): requests.exceptions.ConnectionError: Connection error."), false);
+		assert.equal(isRetryableModelFailure("bash failed (exit 1): urllib.error.URLError: request timed out"), false);
+		assert.equal(isRetryableModelFailure("fetch_content failed with exit code 1"), false);
+		assert.equal(isRetryableModelFailure("mcp.server/write failed (exit 1): request timed out"), false);
+		assert.equal(isRetryableModelFailure("mcp:tools.search failed with exit code 1"), false);
+		assert.equal(isRetryableModelFailure("Provider error: bash failed (exit 1): request timed out"), true);
+		assert.equal(isRetryableModelFailure("bash failed (exit unknown): request timed out"), true);
 	});
 });
 


### PR DESCRIPTION
## Problem

`isRetryableModelFailure` matches substrings like `timed out` anywhere in the error string. Two consequences:

- A child **tool** failure such as `bash failed (exit 1): curl: (28) Connection timed out after 5000 ms` is misread as a provider failure, so the whole task is rerun on the fallback model — the tool's failure had nothing to do with the model, and the rerun repeats any side effects the child already performed.
- `Stream ended without finish_reason` — a genuine provider stream failure — is **not** in the retryable set, so runs that hit it end `failed` without trying the configured fallback model.

## Fix

- Errors prefixed `<tool> failed (exit N): ...` or `<tool> failed with exit code N` never trigger model fallback. The tool-name match accepts namespaced forms such as `mcp.server/write`.
- `stream ended without finish_reason` joins the retryable patterns.

## Risk note

Retrying a finish_reason-less stream keeps this extension's existing retry policy: the child may already have executed side effects before the stream broke. Side-effect-aware retry needs a structured failure origin on results rather than string matching; that is follow-up work and should coordinate with #422's dynamic model fallbacks rather than land here.

## Testing

- `npm run test:unit` — 1083/1083
- `npm run test:integration` — 492/492; two new background-runner tests pin both directions (stream failure retries the fallback model; a trailing tool failure does not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
