### PR TITLE
Preserve attested acceptance for read-only agents

### DIFF
--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -86,6 +86,15 @@ function inferLevel(input: {
 		|| Boolean(input.dynamicGroup)
 		|| /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/.test(task);
 
+	if (readOnlyAgent) {
+		reasons.push("read-only/reviewer-style agent");
+		return {
+			level: "attested",
+			reasons,
+			criteria: ["Return concrete findings with file paths and severity when applicable"],
+			evidence: ["review-findings", "residual-risks"],
+		};
+	}
 	if (risky) {
 		reasons.push(input.async ? "async write-capable or risky run" : "risky write-capable run");
 		if (input.dynamic || input.dynamicGroup) reasons.push("dynamic fanout context");
@@ -106,8 +115,8 @@ function inferLevel(input: {
 			evidence: requiredEvidenceForLevel("checked"),
 		};
 	}
-	if (readOnlyAgent || readOnlyTask) {
-		reasons.push(readOnlyAgent ? "read-only/reviewer-style agent" : "read-only task wording");
+	if (readOnlyTask) {
+		reasons.push("read-only task wording");
 		return {
 			level: "attested",
 			reasons,

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -51,6 +51,19 @@ describe("acceptance gates", () => {
 		assert.equal(resolveEffectiveAcceptance({ agentName: "worker", task: "Fix each item", mode: "chain", dynamic: true }).level, "reviewed");
 	});
 
+	it("keeps async read-only agents attested when their task mentions risky code", () => {
+		const resolved = resolveEffectiveAcceptance({
+			agentName: "task-scout",
+			task: "Read-only migration and security scan. Inspect update and delete paths; do not edit project files.",
+			mode: "single",
+			async: true,
+			explicit: "attested",
+		});
+
+		assert.equal(resolved.level, "attested");
+		assert.deepEqual(resolved.evidence, ["review-findings", "residual-risks"]);
+	});
+
 	it("explicit acceptance can strengthen inferred policy", () => {
 		const resolved = resolveEffectiveAcceptance({
 			agentName: "reviewer",


### PR DESCRIPTION
## Summary
- classify recognized read-only agent roles before risky task-keyword inference
- keep async scouts/reviewers attested even when their inspection task mentions migration, security, update, or delete paths
- add a regression test for explicit attested async task-scout launches

## Why
The README documents that read-only reviewer/scout tasks infer lightweight attestation and only async/risky writer contexts infer reviewed acceptance. Currently the risk check runs before read-only-agent classification; even `Do not edit project files` matches the `edit` writer keyword, escalating an async scout to reviewed and requiring changed-file evidence.

## Verification
- `npm test` — 1083 passed
- regression observed RED (`reviewed`) before the fix and GREEN (`attested`) after it