### PR TITLE
Show every required criterion in acceptance report examples

### DIFF
--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -331,7 +331,7 @@ export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig): st
 		"Use empty arrays when no items apply; array fields contain strings unless object entries are shown.",
 		"```acceptance-report",
 		JSON.stringify({
-			criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "specific proof" }],
+			criteriaSatisfied: acceptance.criteria.map((criterion) => ({ id: criterion.id, status: "satisfied", evidence: `specific proof for ${criterion.id}` })),
 			changedFiles: ["src/file.ts"],
 			testsAddedOrUpdated: ["test/file.test.ts"],
 			commandsRun: [{ command: "command", result: "passed", summary: "short result" }],

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -78,6 +78,19 @@ describe("acceptance gates", () => {
 		assert.match(prompt, /"reviewFindings": \[\n    "blocker:/);
 	});
 
+	it("includes every required criterion in the acceptance report example", () => {
+		const resolved = resolveEffectiveAcceptance({
+			agentName: "worker",
+			task: "Implement a risky migration",
+			async: true,
+			explicit: "verified",
+		});
+		const prompt = formatAcceptancePrompt(resolved);
+
+		assert.match(prompt, /"id": "criterion-1"/);
+		assert.match(prompt, /"id": "criterion-2"/);
+	});
+
 	it("parses acceptance-report fences and ignores unrelated json fences", () => {
 		const parsed = parseAcceptanceReport(report());
 


### PR DESCRIPTION
## Summary
- generate `criteriaSatisfied` example entries from the resolved acceptance criteria
- add regression coverage for reviewed contracts requiring criterion-1 and criterion-2

## Why
A reviewed contract currently lists two required criteria but its generated JSON example contains only criterion-1. Agents following the example are rejected with `Required criterion 'criterion-2' was not reported.`

## Verification
- RED: focused regression failed because criterion-2 was absent
- GREEN: `test/unit/acceptance.test.ts` — 19 passed
- previously flaky unrelated run-status and watchdog tests pass independently