### PR TITLE
fix(acceptance): harden report contracts and persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Hardened acceptance reports so explicit empty changed-file and test arrays are treated as not applicable, required criteria are reflected in examples, known model-output variants normalize to one strict canonical shape, unknown or ambiguous values fail with exact diagnostics, and parsed reports plus ledgers persist in child metadata while normal output stays clean. Thanks to Nick Tripp (@nicholastripp) for #442, maxsturmb (@maxsturmb) for #452, and techmodv90 (@techmodv90) for #449 and #450.
 - Shared task-intent classification between acceptance inference and the completion guard so read-only tasks with explicit no-edit wording do not receive impossible write-evidence gates, while scoped prohibitions still preserve later implementation clauses. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #433.
 - Rejected explicit `acceptance: "reviewed"` and `{ level: "reviewed" }` before launch because the current run cannot supply the required independent reviewer result; inferred and `auto` review policies remain non-blocking. Thanks to Theodor Hillmann (@t0dorakis) for #440 and #441.
 - Rejected bare `acceptance: "none"` before spawning because disabling inferred gates requires the reason-bearing `{ level: "none", reason: "..." }` form; retained `false` only as a deprecated shorthand. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #435.

--- a/README.md
+++ b/README.md
@@ -1393,7 +1393,7 @@ Debug artifacts live under `{sessionDir}/subagent-artifacts/`, `.pi-subagents/ar
 - `{runId}_{agent}.jsonl`
 - `{runId}_{agent}_meta.json`
 
-Metadata records timing, usage, exit code, final model, attempted models, and fallback attempt outcomes.
+Metadata records timing, usage, exit code, final model, attempted models, fallback attempt outcomes, and the resolved acceptance ledger with its parsed child report.
 
 Session files are stored under a per-run session directory. With `context: "fork"`, each child starts with `--session <branched-session-file>` produced from the parent’s current leaf. That is a real session fork, not an injected summary.
 
@@ -1439,7 +1439,9 @@ Acceptance provenance is stored separately from child prose:
 - `reviewed`: an independent reviewer result is present.
 - `rejected`: attestation, structural checks, verification, or review failed.
 
-For `attested` or stricter levels, the child prompt includes a standardized acceptance section and asks for a fenced `acceptance-report` JSON block. Explicit failed gates fail the run. Inferred gates are persisted for observability without breaking older calls that omit `acceptance`.
+For `attested` or stricter levels, the child prompt includes a standardized acceptance section and asks for a fenced `acceptance-report` JSON block. The parser canonicalizes known enum synonyms, snake_case report keys and wrappers, underscore fence tags, unambiguous scalar arrays, string booleans, and criterion-id separators. Unknown or ambiguous keys and enum values fail with field-level diagnostics. Explicit empty `changedFiles` and `testsAddedOrUpdated` arrays are recorded as not applicable; missing fields and empty required command or validation evidence still fail.
+
+Acceptance fences are removed from normal output artifacts, while the raw child transcript remains intact and per-child metadata stores the complete acceptance ledger and parsed report. Explicit failed gates fail the run. Inferred gates remain observable without failing the run.
 
 ## Live progress
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -88,7 +88,7 @@ import {
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { writeInitialProgressFile } from "../../shared/settings.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
-import { acceptanceFailureMessage, aggregateAcceptanceReport, evaluateAcceptance, formatAcceptancePrompt, stripAcceptanceReport } from "../shared/acceptance.ts";
+import { acceptanceFailureMessage, aggregateAcceptanceReport, buildSkippedAcceptanceLedger, evaluateAcceptance, formatAcceptancePrompt, stripAcceptanceReport } from "../shared/acceptance.ts";
 import { waitForImportedAsyncRoot } from "./chain-root-attachment.ts";
 import { appendRunnerStepsToStatus, consumeChainAppendRequests, countPendingChainAppendRequests } from "./chain-append.ts";
 import { appendTurnBudgetSystemPrompt, formatTurnBudgetOutput, initialTurnBudgetState, shouldAbortForTurnBudget, turnBudgetExceededMessage, turnBudgetSoftNote, turnBudgetState } from "../shared/turn-budget.ts";
@@ -1274,7 +1274,15 @@ async function runSingleStep(
 	const stoppedAfterAcceptance = finalResult?.stopped === true || ctx.stopSignal?.aborted === true;
 	const timedOutAfterAcceptance = !stoppedAfterAcceptance && (finalResult?.timedOut === true || ctx.timeoutSignal?.aborted === true);
 	const turnBudgetExceeded = finalResult?.turnBudgetExceeded === true;
-	const effectiveAcceptance = timedOutAfterAcceptance || stoppedAfterAcceptance || turnBudgetExceeded ? undefined : acceptance;
+	const effectiveAcceptance = step.effectiveAcceptance
+		? stoppedAfterAcceptance
+			? buildSkippedAcceptanceLedger(step.effectiveAcceptance, { id: "stopped", message: "Acceptance was not evaluated because the subagent was stopped." })
+			: timedOutAfterAcceptance
+				? buildSkippedAcceptanceLedger(step.effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." })
+				: turnBudgetExceeded
+					? buildSkippedAcceptanceLedger(step.effectiveAcceptance, { id: "turn-budget", message: "Acceptance was not evaluated because the subagent exceeded its turn budget." })
+					: acceptance
+		: undefined;
 	const acceptanceFailure = effectiveAcceptance ? acceptanceFailureMessage(effectiveAcceptance) : undefined;
 	const acceptanceCanFailRun = acceptanceFailure && effectiveAcceptance?.explicit && (finalResult?.exitCode ?? 1) === 0 && !finalResult?.interrupted && !timedOutAfterAcceptance && !stoppedAfterAcceptance && !turnBudgetExceeded;
 	const effectiveFinalExitCode = timedOutAfterAcceptance || stoppedAfterAcceptance || turnBudgetExceeded ? 1 : acceptanceCanFailRun ? 1 : finalResult?.exitCode ?? 1;
@@ -1303,6 +1311,8 @@ async function runSingleStep(
 					model: finalResult?.model,
 					attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
 					modelAttempts,
+					error: effectiveFinalError,
+					acceptance: effectiveAcceptance,
 					...(transcriptWriter ? { transcriptPath: artifactPaths.transcriptPath } : {}),
 					transcriptError: transcriptWriter?.getError(),
 					skills: step.skills,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -68,7 +68,7 @@ import {
 	shouldEscalateMutatingFailures,
 	summarizeRecentMutatingFailures,
 } from "../shared/long-running-guard.ts";
-import { acceptanceFailureMessage, evaluateAcceptance, formatAcceptancePrompt, resolveEffectiveAcceptance, stripAcceptanceReport } from "../shared/acceptance.ts";
+import { acceptanceFailureMessage, buildSkippedAcceptanceLedger, evaluateAcceptance, formatAcceptancePrompt, resolveEffectiveAcceptance, stripAcceptanceReport } from "../shared/acceptance.ts";
 import { appendTurnBudgetSystemPrompt, formatTurnBudgetOutput, initialTurnBudgetState, shouldAbortForTurnBudget, turnBudgetExceededMessage, turnBudgetSoftNote, turnBudgetState } from "../shared/turn-budget.ts";
 import { initialToolBudgetState, toolBudgetState } from "../shared/tool-budget.ts";
 import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
@@ -119,20 +119,6 @@ function buildPendingAcceptanceLedger(acceptance: ResolvedAcceptanceConfig): Acc
 		inferredReason: acceptance.inferredReason,
 		criteria: acceptance.criteria,
 		runtimeChecks: [],
-		verifyRuns: [],
-	};
-}
-
-function buildSkippedAcceptanceLedger(acceptance: ResolvedAcceptanceConfig, input: { id: string; message: string }): AcceptanceLedger {
-	return {
-		status: acceptance.level === "none" ? "not-required" : "rejected",
-		explicit: acceptance.explicit,
-		effectiveAcceptance: acceptance,
-		inferredReason: acceptance.inferredReason,
-		criteria: acceptance.criteria,
-		runtimeChecks: acceptance.level === "none"
-			? []
-			: [{ id: input.id, status: "failed", message: input.message }],
 		verifyRuns: [],
 	};
 }
@@ -1252,6 +1238,29 @@ export async function runSync(
 		}
 	}
 
+	const persistResultMetadata = (target: SingleResult): void => {
+		if (!artifactPathsResult || options.artifactConfig?.enabled === false || options.artifactConfig?.includeMetadata === false) return;
+		writeMetadata(artifactPathsResult.metadataPath, {
+			runId: options.runId,
+			agent: agentName,
+			task,
+			exitCode: target.exitCode,
+			usage: target.usage,
+			model: target.model,
+			attemptedModels: target.attemptedModels,
+			modelAttempts: target.modelAttempts,
+			durationMs: target.progressSummary?.durationMs,
+			toolCount: target.progressSummary?.toolCount,
+			error: target.error,
+			acceptance: target.acceptance,
+			...(transcriptWriter ? { transcriptPath: artifactPathsResult.transcriptPath } : {}),
+			transcriptError: target.transcriptError,
+			skills: target.skills,
+			skillsWarning: target.skillsWarning,
+			timestamp: Date.now(),
+		});
+	};
+
 	const detachedAwareOptions: RunSyncOptions = options.onDetachedExit
 		? {
 			...options,
@@ -1278,6 +1287,7 @@ export async function runSync(
 							recoveredResult.progress.error = recoveredResult.error;
 						}
 					}
+					persistResultMetadata(recoveredResult);
 					options.onDetachedExit?.(recoveredResult);
 				})().catch((error) => {
 					const message = error instanceof Error ? error.message : String(error);
@@ -1365,27 +1375,6 @@ export async function runSync(
 		if (options.artifactConfig?.includeOutput !== false) {
 			writeArtifact(artifactPathsResult.outputPath, artifactOutputByResult.get(result) ?? result.finalOutput ?? "");
 		}
-		if (options.artifactConfig?.includeMetadata !== false) {
-			writeMetadata(artifactPathsResult.metadataPath, {
-				runId: options.runId,
-				agent: agentName,
-				task,
-				exitCode: result.exitCode,
-				usage: result.usage,
-				model: result.model,
-				attemptedModels: result.attemptedModels,
-				modelAttempts: result.modelAttempts,
-				durationMs: result.progressSummary?.durationMs,
-				toolCount: result.progressSummary?.toolCount,
-				error: result.error,
-				...(transcriptWriter ? { transcriptPath: artifactPathsResult.transcriptPath } : {}),
-				transcriptError: result.transcriptError,
-				skills: result.skills,
-				skillsWarning: result.skillsWarning,
-				timestamp: Date.now(),
-			});
-		}
-
 		if (options.maxOutput) {
 			const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
 			const truncationResult = truncateOutput(result.finalOutput ?? "", config, artifactPathsResult.outputPath);
@@ -1407,13 +1396,16 @@ export async function runSync(
 	const childWrittenOutput = options.outputPath
 		? extractChildWrittenOutput(result.messages, options.outputPath, options.cwd ?? runtimeCwd)
 		: undefined;
-	result.acceptance = result.detached
-		? buildPendingAcceptanceLedger(effectiveAcceptance)
-		: result.timedOut
-			? buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." })
-			: result.turnBudgetExceeded
-			? buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "turn-budget", message: "Acceptance was not evaluated because the subagent exceeded its turn budget." })
-			: await evaluateAcceptance({
+	if (result.detached) {
+		result.acceptance = buildPendingAcceptanceLedger(effectiveAcceptance);
+	} else if (result.stopped) {
+		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "stopped", message: "Acceptance was not evaluated because the subagent was stopped." });
+	} else if (result.timedOut) {
+		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." });
+	} else if (result.turnBudgetExceeded) {
+		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "turn-budget", message: "Acceptance was not evaluated because the subagent exceeded its turn budget." });
+	} else {
+		result.acceptance = await evaluateAcceptance({
 			acceptance: effectiveAcceptance,
 			output: acceptanceOutputByResult.get(result) ?? result.finalOutput ?? "",
 			fileOutput: childWrittenOutput !== undefined && options.outputPath
@@ -1421,6 +1413,7 @@ export async function runSync(
 				: undefined,
 			cwd: options.cwd ?? runtimeCwd,
 		});
+	}
 	const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
 	stripAcceptanceReportsFromMessages(result.messages);
 	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.detached && !result.interrupted && !result.timedOut) {
@@ -1431,6 +1424,7 @@ export async function runSync(
 			result.progress.error = result.error;
 		}
 	}
+	persistResultMetadata(result);
 
 	return result;
 }

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -10,6 +10,7 @@ import type {
 	AcceptanceLevel,
 	AcceptanceReport,
 	AcceptanceRuntimeCheck,
+	AcceptanceRuntimeCheckStatus,
 	AcceptanceReviewResult,
 	AcceptanceVerifyCommand,
 	AcceptanceVerifyResult,
@@ -168,6 +169,7 @@ export function validateAcceptanceInput(input: unknown, pathLabel = "acceptance"
 	if (value.reason !== undefined && typeof value.reason !== "string") errors.push(`${pathLabel}.reason must be a string.`);
 	if (value.criteria !== undefined && !Array.isArray(value.criteria)) errors.push(`${pathLabel}.criteria must be an array.`);
 	if (Array.isArray(value.criteria)) {
+		const criterionIds = new Set<string>();
 		for (const [index, criterion] of value.criteria.entries()) {
 			if (typeof criterion === "string") continue;
 			const criterionPath = `${pathLabel}.criteria[${index}]`;
@@ -179,7 +181,13 @@ export function validateAcceptanceInput(input: unknown, pathLabel = "acceptance"
 			for (const key of Object.keys(gate)) {
 				if (!ACCEPTANCE_GATE_KEYS.has(key)) errors.push(`${criterionPath}.${key} is not supported.`);
 			}
-			if (typeof gate.id !== "string" || !gate.id.trim()) errors.push(`${criterionPath}.id is required.`);
+			if (typeof gate.id !== "string" || !gate.id.trim()) {
+				errors.push(`${criterionPath}.id is required.`);
+			} else {
+				const normalizedId = normalizedToken(gate.id);
+				if (criterionIds.has(normalizedId)) errors.push(`${criterionPath}.id duplicates normalized criterion id '${normalizedId}'.`);
+				criterionIds.add(normalizedId);
+			}
 			if (typeof gate.must !== "string" || !gate.must.trim()) errors.push(`${criterionPath}.must is required.`);
 			if (gate.evidence !== undefined && !Array.isArray(gate.evidence)) errors.push(`${criterionPath}.evidence must be an array.`);
 			if (Array.isArray(gate.evidence)) {
@@ -362,9 +370,13 @@ export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig): st
 		"",
 		"Finish with a fenced JSON block tagged `acceptance-report` in this shape:",
 		"Use empty arrays when no items apply; array fields contain strings unless object entries are shown.",
+		"`criteriaSatisfied[].status` must be exactly one of: satisfied, not-satisfied, not-applicable.",
+		"`commandsRun[].result` must be exactly one of: passed, failed, not-run.",
 		"```acceptance-report",
 		JSON.stringify({
-			criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "specific proof" }],
+			criteriaSatisfied: acceptance.criteria
+				.filter((criterion) => criterion.severity !== "recommended")
+				.map((criterion) => ({ id: criterion.id, status: "satisfied", evidence: "specific proof" })),
 			changedFiles: ["src/file.ts"],
 			testsAddedOrUpdated: ["test/file.test.ts"],
 			commandsRun: [{ command: "command", result: "passed", summary: "short result" }],
@@ -405,38 +417,166 @@ function extractBalancedJson(text: string, start: number): string | undefined {
 	return undefined;
 }
 
-function unwrapAcceptanceReport(value: unknown): unknown {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
-	const record = value as { acceptance?: unknown; "acceptance-report"?: unknown };
-	if ("acceptance" in record) return record.acceptance;
-	if ("acceptance-report" in record) return record["acceptance-report"];
+const ACCEPTANCE_REPORT_WRAPPERS = new Set(["acceptance", "acceptance-report", "acceptance_report", "acceptanceReport"]);
+
+const ACCEPTANCE_REPORT_FIELDS: Record<string, keyof AcceptanceReport> = {
+	criteriaSatisfied: "criteriaSatisfied",
+	criteria_satisfied: "criteriaSatisfied",
+	changedFiles: "changedFiles",
+	changed_files: "changedFiles",
+	testsAddedOrUpdated: "testsAddedOrUpdated",
+	tests_added_or_updated: "testsAddedOrUpdated",
+	commandsRun: "commandsRun",
+	commands_run: "commandsRun",
+	validationOutput: "validationOutput",
+	validation_output: "validationOutput",
+	residualRisks: "residualRisks",
+	residual_risks: "residualRisks",
+	noStagedFiles: "noStagedFiles",
+	no_staged_files: "noStagedFiles",
+	diffSummary: "diffSummary",
+	diff_summary: "diffSummary",
+	reviewFindings: "reviewFindings",
+	review_findings: "reviewFindings",
+	manualNotes: "manualNotes",
+	manual_notes: "manualNotes",
+	notes: "notes",
+};
+
+const CRITERION_REPORT_FIELDS = new Set(["id", "status", "evidence"]);
+const COMMAND_REPORT_FIELDS = new Set(["command", "result", "summary"]);
+
+function normalizedToken(value: string): string {
+	return value.trim().toLowerCase().replace(/[\s_]+/g, "-").replace(/-+/g, "-");
+}
+
+function normalizeCriterionStatus(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+	const token = normalizedToken(value);
+	if (["satisfied", "met", "complete", "completed", "done", "pass", "passed", "success", "succeeded"].includes(token)) return "satisfied";
+	if (["not-satisfied", "not-met", "unmet", "incomplete", "fail", "failed"].includes(token)) return "not-satisfied";
+	if (["not-applicable", "n-a", "na", "skip", "skipped"].includes(token)) return "not-applicable";
 	return value;
 }
 
-function isCommandsRunArray(value: unknown): value is NonNullable<AcceptanceReport["commandsRun"]> {
-	return Array.isArray(value) && value.every((item) => {
-		if (!item || typeof item !== "object" || Array.isArray(item)) return false;
-		const command = item as { command?: unknown; result?: unknown; summary?: unknown };
-		return typeof command.command === "string"
-			&& (command.result === "passed" || command.result === "failed" || command.result === "not-run")
-			&& typeof command.summary === "string";
-	});
+function normalizeCommandResult(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+	const token = normalizedToken(value);
+	if (["passed", "pass", "success", "successful", "succeeded", "ok"].includes(token)) return "passed";
+	if (["failed", "fail", "failure", "error"].includes(token)) return "failed";
+	if (["not-run", "not-executed", "skip", "skipped"].includes(token)) return "not-run";
+	return value;
+}
+
+function normalizeCriterionReport(value: unknown, pathLabel: string, errors: string[]): unknown {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+	const normalized: Record<string, unknown> = {};
+	for (const [key, fieldValue] of Object.entries(value as Record<string, unknown>)) {
+		if (!CRITERION_REPORT_FIELDS.has(key)) {
+			errors.push(`${pathLabel}.${key}: unsupported acceptance criterion field`);
+			continue;
+		}
+		normalized[key] = key === "id" && typeof fieldValue === "string"
+			? normalizedToken(fieldValue)
+			: key === "status"
+				? normalizeCriterionStatus(fieldValue)
+				: fieldValue;
+	}
+	return normalized;
+}
+
+function normalizeCommandReport(value: unknown, pathLabel: string, errors: string[]): unknown {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+	const normalized: Record<string, unknown> = {};
+	for (const [key, fieldValue] of Object.entries(value as Record<string, unknown>)) {
+		if (!COMMAND_REPORT_FIELDS.has(key)) {
+			errors.push(`${pathLabel}.${key}: unsupported acceptance command field`);
+			continue;
+		}
+		normalized[key] = key === "result" ? normalizeCommandResult(fieldValue) : fieldValue;
+	}
+	return normalized;
+}
+
+function normalizeAcceptanceReportValue(value: unknown, pathLabel = ""): { value: unknown; pathLabel: string; errors: string[] } {
+	const errors: string[] = [];
+	let reportValue = value;
+	let reportPath = pathLabel;
+	if (reportValue && typeof reportValue === "object" && !Array.isArray(reportValue)) {
+		const record = reportValue as Record<string, unknown>;
+		const wrapperKeys = Object.keys(record).filter((key) => ACCEPTANCE_REPORT_WRAPPERS.has(key));
+		if (wrapperKeys.length > 0) {
+			const wrapperKey = wrapperKeys[0]!;
+			if (wrapperKeys.length > 1) errors.push(`${pathLabel || "acceptance-report"}: multiple acceptance report wrappers are ambiguous`);
+			for (const key of Object.keys(record)) {
+				if (key !== wrapperKey) errors.push(`${pathFor(pathLabel, key)}: unsupported alongside acceptance report wrapper '${wrapperKey}'`);
+			}
+			reportValue = record[wrapperKey];
+			reportPath = pathFor(pathLabel, wrapperKey);
+		}
+	}
+	if (!reportValue || typeof reportValue !== "object" || Array.isArray(reportValue)) return { value: reportValue, pathLabel: reportPath, errors };
+
+	const normalized: Record<string, unknown> = {};
+	for (const [key, fieldValue] of Object.entries(reportValue as Record<string, unknown>)) {
+		const canonical = ACCEPTANCE_REPORT_FIELDS[key];
+		if (!canonical) {
+			errors.push(`${pathFor(reportPath, key)}: unsupported acceptance report field`);
+			continue;
+		}
+		if (Object.hasOwn(normalized, canonical)) {
+			errors.push(`${pathFor(reportPath, key)}: duplicates normalized field '${canonical}'`);
+			continue;
+		}
+		const fieldPath = pathFor(reportPath, canonical);
+		switch (canonical) {
+			case "criteriaSatisfied": {
+				const items = Array.isArray(fieldValue) ? fieldValue : fieldValue && typeof fieldValue === "object" ? [fieldValue] : fieldValue;
+				normalized[canonical] = Array.isArray(items)
+					? items.map((item, index) => normalizeCriterionReport(item, `${fieldPath}[${index}]`, errors))
+					: items;
+				break;
+			}
+			case "commandsRun": {
+				const items = Array.isArray(fieldValue) ? fieldValue : fieldValue && typeof fieldValue === "object" ? [fieldValue] : fieldValue;
+				normalized[canonical] = Array.isArray(items)
+					? items.map((item, index) => normalizeCommandReport(item, `${fieldPath}[${index}]`, errors))
+					: items;
+				break;
+			}
+			case "changedFiles":
+			case "testsAddedOrUpdated":
+			case "validationOutput":
+			case "residualRisks":
+			case "reviewFindings":
+				normalized[canonical] = typeof fieldValue === "string" ? [fieldValue] : fieldValue;
+				break;
+			case "noStagedFiles": {
+				const token = typeof fieldValue === "string" ? fieldValue.trim().toLowerCase() : undefined;
+				normalized[canonical] = token === "true" ? true : token === "false" ? false : fieldValue;
+				break;
+			}
+			default:
+				normalized[canonical] = fieldValue;
+		}
+	}
+	return { value: normalized, pathLabel: reportPath, errors };
 }
 
 function hasGenericAcceptanceReportSignal(value: unknown): boolean {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
 	const record = value as Record<string, unknown>;
-	return "criteriaSatisfied" in record && (
-		isStringArray(record.changedFiles)
-		|| isStringArray(record.testsAddedOrUpdated)
-		|| isCommandsRunArray(record.commandsRun)
-		|| isStringArray(record.validationOutput)
-		|| isStringArray(record.residualRisks)
-		|| typeof record.noStagedFiles === "boolean"
-		|| typeof record.diffSummary === "string"
-		|| isStringArray(record.reviewFindings)
-		|| typeof record.manualNotes === "string"
-	);
+	return "criteriaSatisfied" in record && [
+		"changedFiles",
+		"testsAddedOrUpdated",
+		"commandsRun",
+		"validationOutput",
+		"residualRisks",
+		"noStagedFiles",
+		"diffSummary",
+		"reviewFindings",
+		"manualNotes",
+	].some((key) => key in record);
 }
 
 function parseReportJson(body: string): unknown {
@@ -459,33 +599,29 @@ function fencedBlocks(output: string, tag: string): string[] {
 		.filter((value): value is string => Boolean(value));
 }
 
-function validationPathLabelForWrapper(value: unknown): string {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return "";
-	const record = value as Record<string, unknown>;
-	if ("acceptance" in record) return "acceptance";
-	if ("acceptance-report" in record) return "acceptance-report";
-	return "";
-}
-
 function parseAcceptanceReportBody(body: string): { report?: AcceptanceReport; errors: string[] } {
-	const parsed = parseReportJson(body);
-	const report = unwrapAcceptanceReport(parsed);
-	return validateAcceptanceReport(report, validationPathLabelForWrapper(parsed));
+	return validateAcceptanceReport(parseReportJson(body));
 }
 
-function parseGenericJsonAcceptanceReportBody(body: string): AcceptanceReport | undefined {
+function parseGenericJsonAcceptanceReportBody(body: string): { report?: AcceptanceReport; error?: string } {
 	const parsed = parseReportJson(body);
-	const report = unwrapAcceptanceReport(parsed);
-	const validation = validateAcceptanceReport(report);
-	if (!validation.report) return undefined;
-	return hasGenericAcceptanceReportSignal(validation.report) ? validation.report : undefined;
+	const normalized = normalizeAcceptanceReportValue(parsed);
+	const hasCriteriaMarker = normalized.value !== null
+		&& typeof normalized.value === "object"
+		&& !Array.isArray(normalized.value)
+		&& "criteriaSatisfied" in normalized.value;
+	if (!hasGenericAcceptanceReportSignal(normalized.value) && !(hasCriteriaMarker && normalized.errors.length > 0)) return {};
+	const validation = validateAcceptanceReport(parsed);
+	return validation.report
+		? { report: validation.report }
+		: { error: `Invalid acceptance-report: ${validation.errors.join("; ")}` };
 }
 
 export const ACCEPTANCE_REPORT_NOT_FOUND = "Structured acceptance report not found.";
 
 export function parseAcceptanceReport(output: string): { report?: AcceptanceReport; error?: string } {
-	const explicitFencePresent = /```acceptance-report\b/i.test(output);
-	const fenced = fencedBlocks(output, "acceptance-report");
+	const explicitFencePresent = /```acceptance[-_]report\b/i.test(output);
+	const fenced = fencedBlocks(output, "acceptance[-_]report");
 	const parseErrors: string[] = [];
 	for (const body of fenced) {
 		try {
@@ -502,11 +638,12 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 	}
 	for (const body of fencedBlocks(output, "(?:json|jsonc|json5)")) {
 		try {
-			const report = parseGenericJsonAcceptanceReportBody(body);
-			if (report) return { report };
+			const parsed = parseGenericJsonAcceptanceReportBody(body);
+			if (parsed.report) return { report: parsed.report };
+			if (parsed.error) return { error: `Failed to parse acceptance-report: ${parsed.error}` };
 		} catch {
-			// Ignore unrelated or malformed generic JSON fences; only explicit
-			// acceptance-report fences should turn parse failures into blockers.
+			// Ignore unrelated malformed generic JSON. A recognizable report shape
+			// returns exact validation errors above instead of being mistaken for prose.
 		}
 	}
 	const markerIndex = output.search(/ACCEPTANCE_REPORT\s*:/i);
@@ -521,8 +658,7 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 		}
 		try {
 			const parsed = JSON.parse(json) as unknown;
-			const report = unwrapAcceptanceReport(parsed);
-			const validation = validateAcceptanceReport(report, validationPathLabelForWrapper(parsed));
+			const validation = validateAcceptanceReport(parsed);
 			if (validation.report) return { report: validation.report };
 			return { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}` };
 		} catch (error) {
@@ -555,7 +691,7 @@ function parseAcceptanceReportSources(
 }
 
 export function stripAcceptanceReport(output: string): string {
-	const trailingFencePattern = /\n?```(acceptance-report|json|jsonc|json5)\s*\n([\s\S]*?)```\s*/gi;
+	const trailingFencePattern = /\n?```(acceptance[-_]report|json|jsonc|json5)\s*\n([\s\S]*?)```\s*/gi;
 	let trailingFence: { index: number; tag: string; body: string } | undefined;
 	for (const match of output.matchAll(trailingFencePattern)) {
 		const end = (match.index ?? 0) + match[0].length;
@@ -564,15 +700,15 @@ export function stripAcceptanceReport(output: string): string {
 		}
 	}
 	if (trailingFence) {
-		if (trailingFence.tag === "acceptance-report") return output.slice(0, trailingFence.index).trimEnd();
+		if (trailingFence.tag === "acceptance-report" || trailingFence.tag === "acceptance_report") return output.slice(0, trailingFence.index).trimEnd();
 		try {
-			if (parseGenericJsonAcceptanceReportBody(trailingFence.body)) return output.slice(0, trailingFence.index).trimEnd();
+			if (parseGenericJsonAcceptanceReportBody(trailingFence.body).report) return output.slice(0, trailingFence.index).trimEnd();
 		} catch {
 			// Leave unrelated or malformed generic JSON fences visible.
 		}
 	}
 	return output
-		.replace(/\n?```acceptance-report\s*\n[\s\S]*?```\s*$/i, "")
+		.replace(/\n?```acceptance[-_]report\s*\n[\s\S]*?```\s*$/i, "")
 		.replace(/\n?ACCEPTANCE_REPORT\s*:\s*\{[\s\S]*\}\s*$/i, "")
 		.trimEnd();
 }
@@ -607,12 +743,15 @@ function validateStringArrayField(errors: string[], value: unknown, pathLabel: s
 		return;
 	}
 	for (const [index, item] of value.entries()) {
-		if (typeof item !== "string") pushTypeError(errors, `${pathLabel}[${index}]`, "string", item);
+		if (typeof item !== "string" || !item.trim()) pushTypeError(errors, `${pathLabel}[${index}]`, "non-empty string", item);
 	}
 }
 
 function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: AcceptanceReport; errors: string[] } {
-	const errors: string[] = [];
+	const normalized = normalizeAcceptanceReportValue(value, pathLabel);
+	value = normalized.value;
+	pathLabel = normalized.pathLabel;
+	const errors = normalized.errors;
 	if (!value || typeof value !== "object" || Array.isArray(value)) {
 		pushTypeError(errors, pathLabel || "acceptance-report", "object", value);
 		return { errors };
@@ -622,6 +761,7 @@ function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: Ac
 		if (!Array.isArray(report.criteriaSatisfied)) {
 			pushTypeError(errors, pathFor(pathLabel, "criteriaSatisfied"), "array", report.criteriaSatisfied);
 		} else {
+			const criterionIds = new Set<string>();
 			for (const [index, item] of report.criteriaSatisfied.entries()) {
 				const itemPath = `${pathFor(pathLabel, "criteriaSatisfied")}[${index}]`;
 				if (!item || typeof item !== "object" || Array.isArray(item)) {
@@ -629,7 +769,12 @@ function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: Ac
 					continue;
 				}
 				const criterion = item as { id?: unknown; status?: unknown; evidence?: unknown };
-				if (criterion.id !== undefined && typeof criterion.id !== "string") pushTypeError(errors, `${itemPath}.id`, "string", criterion.id);
+				if (criterion.id !== undefined && typeof criterion.id !== "string") {
+					pushTypeError(errors, `${itemPath}.id`, "string", criterion.id);
+				} else if (typeof criterion.id === "string" && criterion.id) {
+					if (criterionIds.has(criterion.id)) errors.push(`${itemPath}.id: duplicate normalized criterion id '${criterion.id}'`);
+					criterionIds.add(criterion.id);
+				}
 				if (criterion.status !== "satisfied" && criterion.status !== "not-satisfied" && criterion.status !== "not-applicable") {
 					pushTypeError(errors, `${itemPath}.status`, "one of \"satisfied\", \"not-satisfied\", \"not-applicable\"", criterion.status);
 				}
@@ -654,17 +799,17 @@ function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: Ac
 				if (command.result !== "passed" && command.result !== "failed" && command.result !== "not-run") {
 					pushTypeError(errors, `${itemPath}.result`, "one of \"passed\", \"failed\", \"not-run\"", command.result);
 				}
-				if (typeof command.summary !== "string") pushTypeError(errors, `${itemPath}.summary`, "string", command.summary);
+				if (typeof command.summary !== "string" || !command.summary.trim()) pushTypeError(errors, `${itemPath}.summary`, "non-empty string", command.summary);
 			}
 		}
 	}
 	if (report.validationOutput !== undefined) validateStringArrayField(errors, report.validationOutput, pathFor(pathLabel, "validationOutput"));
 	if (report.residualRisks !== undefined) validateStringArrayField(errors, report.residualRisks, pathFor(pathLabel, "residualRisks"));
 	if (report.noStagedFiles !== undefined && typeof report.noStagedFiles !== "boolean") pushTypeError(errors, pathFor(pathLabel, "noStagedFiles"), "boolean", report.noStagedFiles);
-	if (report.diffSummary !== undefined && typeof report.diffSummary !== "string") pushTypeError(errors, pathFor(pathLabel, "diffSummary"), "string", report.diffSummary);
+	if (report.diffSummary !== undefined && (typeof report.diffSummary !== "string" || !report.diffSummary.trim())) pushTypeError(errors, pathFor(pathLabel, "diffSummary"), "non-empty string", report.diffSummary);
 	if (report.reviewFindings !== undefined) validateStringArrayField(errors, report.reviewFindings, pathFor(pathLabel, "reviewFindings"));
-	if (report.manualNotes !== undefined && typeof report.manualNotes !== "string") pushTypeError(errors, pathFor(pathLabel, "manualNotes"), "string", report.manualNotes);
-	if (report.notes !== undefined && typeof report.notes !== "string") pushTypeError(errors, pathFor(pathLabel, "notes"), "string", report.notes);
+	if (report.manualNotes !== undefined && (typeof report.manualNotes !== "string" || !report.manualNotes.trim())) pushTypeError(errors, pathFor(pathLabel, "manualNotes"), "non-empty string", report.manualNotes);
+	if (report.notes !== undefined && (typeof report.notes !== "string" || !report.notes.trim())) pushTypeError(errors, pathFor(pathLabel, "notes"), "non-empty string", report.notes);
 	if (errors.length > 0) return { errors };
 	const hasReportField = report.criteriaSatisfied !== undefined
 		|| report.changedFiles !== undefined
@@ -683,26 +828,30 @@ function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: Ac
 }
 
 function checkCriteriaSatisfied(criteria: ResolvedAcceptanceGate[], report: AcceptanceReport): AcceptanceRuntimeCheck[] {
-	const reports = new Map((report.criteriaSatisfied ?? []).filter((item) => item.id).map((item) => [item.id!, item]));
+	const reports = new Map((report.criteriaSatisfied ?? []).filter((item) => item.id).map((item) => [normalizedToken(item.id!), item]));
 	return criteria.filter((criterion) => criterion.severity !== "recommended").map((criterion) => {
-		const item = reports.get(criterion.id);
+		const item = reports.get(normalizedToken(criterion.id));
 		if (!item) return { id: `criterion:${criterion.id}`, status: "failed", message: `Required criterion '${criterion.id}' was not reported.` };
 		if (item.status !== "satisfied") return { id: `criterion:${criterion.id}`, status: "failed", message: `Required criterion '${criterion.id}' was reported as ${item.status}.` };
 		return { id: `criterion:${criterion.id}`, status: "passed", message: `Required criterion '${criterion.id}' satisfied.` };
 	});
 }
 
-function reportEvidencePresent(report: AcceptanceReport, kind: AcceptanceEvidenceKind): boolean {
+function reportEvidenceStatus(report: AcceptanceReport, kind: AcceptanceEvidenceKind): AcceptanceRuntimeCheckStatus {
 	switch (kind) {
-		case "changed-files": return isStringArray(report.changedFiles) && report.changedFiles.length > 0;
-		case "tests-added": return isStringArray(report.testsAddedOrUpdated) && report.testsAddedOrUpdated.length > 0;
-		case "commands-run": return Array.isArray(report.commandsRun) && report.commandsRun.length > 0;
-		case "validation-output": return isStringArray(report.validationOutput) && report.validationOutput.length > 0;
-		case "residual-risks": return isStringArray(report.residualRisks);
-		case "no-staged-files": return report.noStagedFiles === true;
-		case "diff-summary": return typeof report.diffSummary === "string" && report.diffSummary.trim().length > 0;
-		case "review-findings": return isStringArray(report.reviewFindings);
-		case "manual-notes": return Boolean((report.manualNotes ?? report.notes)?.trim());
+		case "changed-files":
+			if (!isStringArray(report.changedFiles)) return "failed";
+			return report.changedFiles.length === 0 ? "not-applicable" : "passed";
+		case "tests-added":
+			if (!isStringArray(report.testsAddedOrUpdated)) return "failed";
+			return report.testsAddedOrUpdated.length === 0 ? "not-applicable" : "passed";
+		case "commands-run": return Array.isArray(report.commandsRun) && report.commandsRun.length > 0 ? "passed" : "failed";
+		case "validation-output": return isStringArray(report.validationOutput) && report.validationOutput.length > 0 ? "passed" : "failed";
+		case "residual-risks": return isStringArray(report.residualRisks) ? "passed" : "failed";
+		case "no-staged-files": return report.noStagedFiles === true ? "passed" : "failed";
+		case "diff-summary": return typeof report.diffSummary === "string" && report.diffSummary.trim().length > 0 ? "passed" : "failed";
+		case "review-findings": return isStringArray(report.reviewFindings) ? "passed" : "failed";
+		case "manual-notes": return Boolean((report.manualNotes ?? report.notes)?.trim()) ? "passed" : "failed";
 	}
 }
 
@@ -720,11 +869,15 @@ function checkNoStagedFiles(cwd: string): AcceptanceRuntimeCheck {
 function runStructuralChecks(acceptance: ResolvedAcceptanceConfig, report: AcceptanceReport, cwd: string): AcceptanceRuntimeCheck[] {
 	const checks: AcceptanceRuntimeCheck[] = [];
 	for (const kind of acceptance.evidence) {
-		const present = reportEvidencePresent(report, kind);
+		const status = reportEvidenceStatus(report, kind);
 		checks.push({
 			id: `evidence:${kind}`,
-			status: present ? "passed" : "failed",
-			message: present ? `${kind} evidence present.` : `${kind} evidence missing from child report.`,
+			status,
+			message: status === "passed"
+				? `${kind} evidence present.`
+				: status === "not-applicable"
+					? `${kind} evidence explicitly reported as not applicable.`
+					: `${kind} evidence missing from child report.`,
 		});
 	}
 	if (acceptance.evidence.includes("no-staged-files")) checks.push(checkNoStagedFiles(cwd));
@@ -875,7 +1028,14 @@ export async function evaluateAcceptance(input: {
 	};
 	if (acceptance.level === "none") return ledger;
 
-	const parsed = input.report ? { report: input.report } : parseAcceptanceReportSources(input.output, input.fileOutput);
+	const parsed = input.report
+		? (() => {
+			const validation = validateAcceptanceReport(input.report);
+			return validation.report
+				? { report: validation.report }
+				: { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}` };
+		})()
+		: parseAcceptanceReportSources(input.output, input.fileOutput);
 	if (parsed.report) {
 		ledger.childReport = parsed.report;
 		ledger.status = "attested";
@@ -935,6 +1095,20 @@ export async function evaluateAcceptance(input: {
 	}
 
 	return ledger;
+}
+
+export function buildSkippedAcceptanceLedger(acceptance: ResolvedAcceptanceConfig, input: { id: string; message: string }): AcceptanceLedger {
+	return {
+		status: acceptance.level === "none" ? "not-required" : "rejected",
+		explicit: acceptance.explicit,
+		effectiveAcceptance: acceptance,
+		inferredReason: acceptance.inferredReason,
+		criteria: acceptance.criteria,
+		runtimeChecks: acceptance.level === "none"
+			? []
+			: [{ id: input.id, status: "failed", message: input.message }],
+		verifyRuns: [],
+	};
 }
 
 export function acceptanceFailureMessage(ledger: AcceptanceLedger): string | undefined {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -261,18 +261,22 @@ export function getFinalOutput(messages: Message[]): string {
 		const hasAssistantError = ("errorMessage" in msg && typeof msg.errorMessage === "string" && msg.errorMessage.length > 0)
 			|| ("stopReason" in msg && msg.stopReason === "error");
 		if (hasAssistantError) continue;
+		const messageText = msg.content
+			.filter((part) => part.type === "text" && part.text.trim().length > 0)
+			.map((part) => part.type === "text" ? part.text : "")
+			.join("\n");
 		for (let j = msg.content.length - 1; j >= 0; j--) {
 			const part = msg.content[j];
 			if (part.type !== "text" || part.text.trim().length === 0) continue;
 			validTextParts.push(part.text);
-			if (/```acceptance-report\s*\n[\s\S]*?```/i.test(part.text)) return part.text;
+			if (/```acceptance[-_]report\s*\n[\s\S]*?```/i.test(part.text)) return messageText;
 			for (const match of part.text.matchAll(/```(?:json|jsonc|json5)\s*\n([\s\S]*?)```/gi)) {
 				const body = match[1] ?? "";
-				if (/"criteriaSatisfied"/.test(body) && /"(?:changedFiles|testsAddedOrUpdated|commandsRun|validationOutput|residualRisks|noStagedFiles|diffSummary|reviewFindings|manualNotes)"/.test(body)) {
-					return part.text;
+				if (/"(?:criteriaSatisfied|criteria_satisfied)"/.test(body) && /"(?:changedFiles|changed_files|testsAddedOrUpdated|tests_added_or_updated|commandsRun|commands_run|validationOutput|validation_output|residualRisks|residual_risks|noStagedFiles|no_staged_files|diffSummary|diff_summary|reviewFindings|review_findings|manualNotes|manual_notes)"/.test(body)) {
+					return messageText;
 				}
 			}
-			if (/ACCEPTANCE_REPORT\s*:/i.test(part.text)) return part.text;
+			if (/ACCEPTANCE_REPORT\s*:/i.test(part.text)) return messageText;
 		}
 	}
 	return validTextParts[0] ?? "";

--- a/test/integration/acceptance-file-report.test.ts
+++ b/test/integration/acceptance-file-report.test.ts
@@ -18,6 +18,12 @@ interface AcceptanceSummary {
 	runtimeChecks?: Array<{ id?: string; status?: string; message?: string }>;
 }
 
+interface AcceptanceArtifactPaths {
+	outputPath: string;
+	metadataPath: string;
+	transcriptPath: string;
+}
+
 interface ExecutionModule {
 	runSync(
 		runtimeCwd: string,
@@ -31,6 +37,7 @@ interface ExecutionModule {
 		finalOutput?: string;
 		savedOutputPath?: string;
 		acceptance?: AcceptanceSummary;
+		artifactPaths?: AcceptanceArtifactPaths;
 	}>;
 }
 
@@ -52,7 +59,7 @@ interface ExecutorModule {
 
 interface AsyncResultPayload {
 	success: boolean;
-	results: Array<{ output?: string; error?: string; acceptance?: AcceptanceSummary }>;
+	results: Array<{ output?: string; error?: string; acceptance?: AcceptanceSummary; artifactPaths?: AcceptanceArtifactPaths }>;
 }
 
 const execution = await tryImport<ExecutionModule>("./src/runs/foreground/execution.ts");
@@ -73,6 +80,16 @@ const DISABLED_ARTIFACTS = {
 	includeOutput: false,
 	includeJsonl: false,
 	includeMetadata: false,
+	cleanupDays: 7,
+};
+
+const ACCEPTANCE_ARTIFACTS = {
+	enabled: true,
+	includeInput: false,
+	includeOutput: true,
+	includeJsonl: false,
+	includeTranscript: true,
+	includeMetadata: true,
 	cleanupDays: 7,
 };
 
@@ -153,8 +170,9 @@ describe("acceptance file reports", { skip: !runSync ? "pi packages not availabl
 			assert.equal(result.savedOutputPath, outputPath);
 		});
 
-		it("file-only mode accepts a saved report when final assistant text is only a receipt", async () => {
+		it("file-only mode persists acceptance metadata when final assistant text is only a receipt", async () => {
 			const outputPath = path.join(tempDir, "saved-review.md");
+			const artifactsDir = path.join(tempDir, "artifacts");
 			const fileReport = `# Review\n${acceptanceReport("satisfied", "foreground saved verdict")}`;
 			mockPi.onCall({
 				jsonl: [...events.completedWrite(outputPath, fileReport), events.assistantMessage("Output saved to the configured file.")],
@@ -166,26 +184,64 @@ describe("acceptance file reports", { skip: !runSync ? "pi packages not availabl
 				outputPath,
 				outputMode: "file-only",
 				acceptance: { level: "checked", criteria: ["Report the findings"] },
+				artifactsDir,
+				artifactConfig: ACCEPTANCE_ARTIFACTS,
 			});
 
 			assert.equal(result.acceptance?.status, "checked");
 			assert.equal(result.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence, "foreground saved verdict");
 			assert.equal(result.exitCode, 0);
+			assert.ok(result.artifactPaths);
+			const metadata = JSON.parse(fs.readFileSync(result.artifactPaths.metadataPath, "utf-8")) as { exitCode?: number; acceptance?: AcceptanceSummary };
+			assert.equal(metadata.exitCode, 0);
+			assert.equal(metadata.acceptance?.status, "checked");
+			assert.equal(metadata.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence, "foreground saved verdict");
+			assert.doesNotMatch(fs.readFileSync(result.artifactPaths.outputPath, "utf-8"), /```acceptance-report/);
 		});
 
-		it("inline mode rejects on the text report even when the child-written file passes", async () => {
+		it("persists a report-only child response in metadata while normal output stays clean", async () => {
+			const artifactsDir = path.join(tempDir, "report-only-artifacts");
+			mockPi.onCall({ output: acceptanceReport("satisfied", "report-only evidence") });
+
+			const result = await runSync!(tempDir, [makeAgent("worker", { completionGuard: false })], "worker", "Implement and report the fix.", {
+				runId: "acceptance-report-only",
+				acceptance: { level: "checked", criteria: ["Report the findings"] },
+				artifactsDir,
+				artifactConfig: ACCEPTANCE_ARTIFACTS,
+			});
+
+			assert.equal(result.exitCode, 0);
+			assert.equal(result.finalOutput, "");
+			assert.ok(result.artifactPaths);
+			assert.equal(fs.readFileSync(result.artifactPaths.outputPath, "utf-8"), "");
+			const metadata = JSON.parse(fs.readFileSync(result.artifactPaths.metadataPath, "utf-8")) as { acceptance?: AcceptanceSummary };
+			assert.equal(metadata.acceptance?.status, "checked");
+			assert.equal(metadata.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence, "report-only evidence");
+			assert.match(fs.readFileSync(result.artifactPaths.transcriptPath, "utf-8"), /```acceptance-report/);
+		});
+
+		it("inline mode persists final rejection metadata when the text report fails", async () => {
 			const outputPath = path.join(tempDir, "report.md");
+			const artifactsDir = path.join(tempDir, "rejected-artifacts");
 			conflictingReportsCall(outputPath, "satisfied", "not-satisfied");
 
 			const result = await runSync!(tempDir, makeAgentConfigs(["worker"]), "worker", "Write the findings report.", {
 				runId: "acceptance-inline-text-first",
 				outputPath,
 				acceptance: { level: "checked", criteria: ["Report the findings"] },
+				artifactsDir,
+				artifactConfig: ACCEPTANCE_ARTIFACTS,
 			});
 
 			assert.equal(result.acceptance?.status, "rejected");
 			assert.equal(result.exitCode, 1);
 			assert.match(result.error ?? "", /Acceptance rejected: Required criterion 'criterion-1' was reported as not-satisfied\./);
+			assert.ok(result.artifactPaths);
+			const metadata = JSON.parse(fs.readFileSync(result.artifactPaths.metadataPath, "utf-8")) as { exitCode?: number; error?: string; acceptance?: AcceptanceSummary };
+			assert.equal(metadata.exitCode, 1);
+			assert.match(metadata.error ?? "", /Acceptance rejected/);
+			assert.equal(metadata.acceptance?.status, "rejected");
+			assert.equal(metadata.acceptance?.runtimeChecks?.find((check) => check.id === "criterion:criterion-1")?.status, "failed");
 		});
 
 		it("inline mode accepts on the text report regardless of a failing file report", async () => {
@@ -262,13 +318,14 @@ describe("acceptance file reports", { skip: !runSync ? "pi packages not availabl
 	});
 
 	describe("background runner", { skip: isAsyncAvailable && !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
-		function runAsyncSingle(id: string, outputPath: string, outputMode: "inline" | "file-only") {
+		function runAsyncSingle(id: string, outputPath: string, outputMode: "inline" | "file-only", artifactConfig = DISABLED_ARTIFACTS) {
 			executeAsyncSingle!(id, {
 				agent: "worker",
 				task: "Write the findings report.",
 				agentConfig: makeAgent("worker", { completionGuard: false }),
 				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-file-report" },
-				artifactConfig: DISABLED_ARTIFACTS,
+				artifactConfig,
+				artifactsDir: path.join(tempDir, ".pi-subagents", "artifacts"),
 				shareEnabled: false,
 				maxSubagentDepth: 2,
 				output: outputPath,
@@ -291,7 +348,7 @@ describe("acceptance file reports", { skip: !runSync ? "pi packages not availabl
 			assert.equal(status.steps?.[0]?.acceptance?.status, "checked");
 		});
 
-		it("file-only mode accepts a saved report when final assistant text is only a receipt", async () => {
+		it("file-only mode persists async acceptance metadata when final assistant text is only a receipt", async () => {
 			const outputPath = path.join(tempDir, "saved-review.md");
 			const fileReport = `# Review\n${acceptanceReport("satisfied", "saved reviewer verdict")}`;
 			mockPi.onCall({
@@ -299,12 +356,17 @@ describe("acceptance file reports", { skip: !runSync ? "pi packages not availabl
 				writeFiles: [{ path: outputPath, content: fileReport }],
 			});
 			const id = `acceptance-saved-receipt-${Date.now().toString(36)}`;
-			runAsyncSingle(id, outputPath, "file-only");
+			runAsyncSingle(id, outputPath, "file-only", ACCEPTANCE_ARTIFACTS);
 
 			const payload = await waitForAsyncResult(id);
 			assert.equal(payload.success, true);
 			assert.equal(payload.results[0]?.acceptance?.status, "checked");
 			assert.equal(payload.results[0]?.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence, "saved reviewer verdict");
+			const metadataPath = payload.results[0]?.artifactPaths?.metadataPath;
+			assert.ok(metadataPath);
+			const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { acceptance?: AcceptanceSummary };
+			assert.equal(metadata.acceptance?.status, "checked");
+			assert.equal(metadata.acceptance?.childReport?.criteriaSatisfied?.[0]?.evidence, "saved reviewer verdict");
 		});
 
 		it("inline mode accepts from the text report and strips fences from the resolved file output", async () => {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -42,7 +42,7 @@ interface AsyncResultPayload {
 	wrapUpRequested?: boolean;
 	totalTokens?: { input: number; output: number; total: number };
 	totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
-	results: Array<{ output?: string; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; intercomTarget?: string; acceptance?: { status?: string; childReport?: unknown }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string } }>;
+	results: Array<{ output?: string; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; intercomTarget?: string; acceptance?: { status?: string; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string } }>;
 	outputs?: Record<string, { text?: string; structured?: unknown }>;
 	workflowGraph?: { nodes?: Array<{ kind?: string; label?: string; phase?: string; status?: string; error?: string; outputName?: string; structured?: boolean; children?: Array<{ label?: string; outputName?: string; itemKey?: string; status?: string; error?: string }> }> };
 }
@@ -707,13 +707,14 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			agentConfig: makeAgent("worker"),
 			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
 			artifactConfig: {
-				enabled: false,
+				enabled: true,
 				includeInput: false,
 				includeOutput: false,
 				includeJsonl: false,
-				includeMetadata: false,
+				includeMetadata: true,
 				cleanupDays: 7,
 			},
+			artifactsDir: path.join(tempDir, ".pi-subagents", "artifacts"),
 			shareEnabled: false,
 			maxSubagentDepth: 2,
 			timeoutMs: 1_000,
@@ -730,8 +731,14 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.state, "failed");
 		assert.equal(payload.timedOut, true);
 		assert.equal(payload.results[0]?.timedOut, true);
-		assert.equal(payload.results[0]?.acceptance, undefined);
+		assert.equal(payload.results[0]?.acceptance?.status, "rejected");
+		assert.equal(payload.results[0]?.acceptance?.runtimeChecks?.[0]?.id, "timeout");
 		assert.equal(status.steps?.[0]?.timedOut, true);
+		const metadataPath = payload.results[0]?.artifactPaths?.metadataPath;
+		assert.ok(metadataPath);
+		const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { acceptance?: { status?: string; runtimeChecks?: Array<{ id?: string }> } };
+		assert.equal(metadata.acceptance?.status, "rejected");
+		assert.equal(metadata.acceptance?.runtimeChecks?.[0]?.id, "timeout");
 		assert.ok(elapsedMs < 3_000, `timeout should cancel acceptance verification promptly, elapsed ${elapsedMs}ms`);
 	});
 

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -382,7 +382,6 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 				JSON.stringify({
 					criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "patched" }],
 					changedFiles: ["src/file.ts"],
-					testsAddedOrUpdated: [],
 					commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
 					residualRisks: [],
 					noStagedFiles: true,

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -22,7 +22,7 @@ interface ExecutorResult {
 	details?: {
 		mode?: string;
 		runId?: string;
-		results?: Array<{ agent?: string; finalOutput?: string; acceptance?: { status?: string } }>;
+		results?: Array<{ agent?: string; finalOutput?: string; acceptance?: { status?: string }; artifactPaths?: { metadataPath?: string } }>;
 		asyncId?: string;
 	};
 }
@@ -740,6 +740,10 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.ok(runId, "expected foreground run id");
 		assert.equal(original.details?.results?.[0]?.acceptance?.status, "pending");
 		assert.match(original.content[0]?.text ?? "", /subagent_wait\(\{ id:/);
+		const metadataPath = original.details?.results?.[0]?.artifactPaths?.metadataPath;
+		assert.ok(metadataPath);
+		const pendingMetadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { acceptance?: { status?: string } };
+		assert.equal(pendingMetadata.acceptance?.status, "pending");
 
 		const waited = await waitForSubagents({ id: runId, timeoutMs: 5000 }, undefined, {
 			state: state as never,
@@ -764,6 +768,10 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.equal(payload.source, "foreground");
 		assert.equal(payload.success, true);
 		assert.match(payload.summary ?? "", /final recovered answer/);
+		const recoveredMetadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { exitCode?: number; acceptance?: { status?: string; childReport?: unknown } };
+		assert.equal(recoveredMetadata.exitCode, 0);
+		assert.equal(recoveredMetadata.acceptance?.status, "checked");
+		assert.ok(recoveredMetadata.acceptance?.childReport);
 
 		const status = await executor.execute(
 			"foreground-detached-completion-status",

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -78,7 +78,34 @@ describe("acceptance gates", () => {
 		assert.match(prompt, /Patch the bug/);
 		assert.match(prompt, /```acceptance-report/);
 		assert.match(prompt, /array fields contain strings/);
+		assert.match(prompt, /criteriaSatisfied\[\]\.status.*satisfied, not-satisfied, not-applicable/);
+		assert.match(prompt, /commandsRun\[\]\.result.*passed, failed, not-run/);
 		assert.match(prompt, /"reviewFindings": \[\n    "blocker:/);
+	});
+
+	it("includes every required resolved criterion in report examples", () => {
+		const inferred = resolveEffectiveAcceptance({ agentName: "worker", task: "Implement the fix", mode: "single", async: true });
+		const inferredExample = formatAcceptancePrompt(inferred).match(/```acceptance-report\n([\s\S]*?)\n```/);
+		assert.ok(inferredExample?.[1]);
+		assert.deepEqual(
+			(JSON.parse(inferredExample[1]!) as { criteriaSatisfied: Array<{ id: string }> }).criteriaSatisfied.map((criterion) => criterion.id),
+			["criterion-1", "criterion-2"],
+		);
+
+		const custom = resolveEffectiveAcceptance({
+			agentName: "worker",
+			task: "Implement the fix",
+			explicit: { level: "checked", criteria: [
+				{ id: "required-check", must: "Required", severity: "required" },
+				{ id: "recommended-check", must: "Recommended", severity: "recommended" },
+			] },
+		});
+		const customExample = formatAcceptancePrompt(custom).match(/```acceptance-report\n([\s\S]*?)\n```/);
+		assert.ok(customExample?.[1]);
+		assert.deepEqual(
+			(JSON.parse(customExample[1]!) as { criteriaSatisfied: Array<{ id: string }> }).criteriaSatisfied.map((criterion) => criterion.id),
+			["required-check"],
+		);
 	});
 
 	it("parses acceptance-report fences and ignores unrelated json fences", () => {
@@ -100,12 +127,18 @@ describe("acceptance gates", () => {
 		assert.equal(criteriaOnlyJson.report, undefined);
 		assert.match(criteriaOnlyJson.error ?? "", /Structured acceptance report not found/);
 
+		const criteriaWithUnknownJson = parseAcceptanceReport(`done\n\
+\
+\`\`\`json\n{\"criteriaSatisfied\":[],\"unexpected\":true}\n\`\`\``);
+		assert.equal(criteriaWithUnknownJson.report, undefined);
+		assert.match(criteriaWithUnknownJson.error ?? "", /unexpected: unsupported acceptance report field/);
+
 		const invalidSignalJson = `done\n\
 \
 \`\`\`json\n{\"criteriaSatisfied\":[{\"id\":\"criterion-1\",\"status\":\"satisfied\",\"evidence\":\"example\"}],\"changedFiles\":false}\n\`\`\``;
 		const genericJsonWithInvalidSignal = parseAcceptanceReport(invalidSignalJson);
 		assert.equal(genericJsonWithInvalidSignal.report, undefined);
-		assert.match(genericJsonWithInvalidSignal.error ?? "", /Structured acceptance report not found/);
+		assert.match(genericJsonWithInvalidSignal.error ?? "", /changedFiles: expected string\[\]; got boolean false/);
 		assert.equal(stripAcceptanceReport(invalidSignalJson), invalidSignalJson);
 
 		const partialWrapperJson = `done\n\
@@ -172,18 +205,106 @@ describe("acceptance gates", () => {
 		].join("\n"));
 	});
 
-	it("unwraps acceptance-report wrapper objects", () => {
+	it("unwraps every accepted report wrapper", () => {
+		for (const wrapper of ["acceptance", "acceptance-report", "acceptance_report", "acceptanceReport"]) {
+			const output = [
+				"done",
+				"```json",
+				JSON.stringify({ [wrapper]: reportData() }),
+				"```",
+			].join("\n");
+			const parsed = parseAcceptanceReport(output);
+
+			assert.ok(parsed.report, wrapper);
+			assert.deepEqual(parsed.report.testsAddedOrUpdated, ["test/file.test.ts"]);
+			assert.equal(stripAcceptanceReport(output), "done");
+		}
+	});
+
+	it("normalizes known report wire variants to the canonical shape", () => {
 		const output = [
 			"done",
-			"```json",
-			JSON.stringify({ "acceptance-report": reportData() }),
+			"```acceptance_report",
+			JSON.stringify({ acceptance_report: {
+				criteria_satisfied: { id: "Criterion_1", status: "DONE", evidence: "verified" },
+				changed_files: "src/file.ts",
+				tests_added_or_updated: "test/file.test.ts",
+				commands_run: { command: "npm test", result: "success", summary: "passed" },
+				validation_output: "tests passed",
+				residual_risks: "none",
+				no_staged_files: " TRUE ",
+				diff_summary: "patched",
+				review_findings: "no blockers",
+				manual_notes: "complete",
+			} }),
 			"```",
 		].join("\n");
 		const parsed = parseAcceptanceReport(output);
 
-		assert.ok(parsed.report);
-		assert.deepEqual(parsed.report.testsAddedOrUpdated, ["test/file.test.ts"]);
+		assert.equal(parsed.error, undefined);
+		assert.deepEqual(parsed.report, {
+			criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "verified" }],
+			changedFiles: ["src/file.ts"],
+			testsAddedOrUpdated: ["test/file.test.ts"],
+			commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+			validationOutput: ["tests passed"],
+			residualRisks: ["none"],
+			noStagedFiles: true,
+			diffSummary: "patched",
+			reviewFindings: ["no blockers"],
+			manualNotes: "complete",
+		});
 		assert.equal(stripAcceptanceReport(output), "done");
+	});
+
+	it("normalizes only known enum synonyms and criterion id separators", () => {
+		for (const [value, expected] of [
+			["met", "satisfied"],
+			["not met", "not-satisfied"],
+			["not_applicable", "not-applicable"],
+		] as const) {
+			const parsed = parseAcceptanceReport(report({ criteriaSatisfied: [{ id: "Criterion 1", status: value, evidence: "proof" }] }));
+			assert.equal(parsed.report?.criteriaSatisfied?.[0]?.id, "criterion-1");
+			assert.equal(parsed.report?.criteriaSatisfied?.[0]?.status, expected);
+		}
+		for (const [value, expected] of [
+			["ok", "passed"],
+			["failure", "failed"],
+			["not run", "not-run"],
+		] as const) {
+			const parsed = parseAcceptanceReport(report({ commandsRun: [{ command: "check", result: value, summary: "complete" }] }));
+			assert.equal(parsed.report?.commandsRun?.[0]?.result, expected);
+		}
+	});
+
+	it("rejects unknown and ambiguous report fields with exact diagnostics", () => {
+		for (const [value, expected] of [
+			[{ ...reportData(), unexpected: true }, /unexpected: unsupported acceptance report field/],
+			[{ ...reportData(), changed_files: ["src/other.ts"] }, /changed_files: duplicates normalized field 'changedFiles'/],
+			[{ acceptance: reportData(), changedFiles: ["src/file.ts"] }, /changedFiles: unsupported alongside acceptance report wrapper 'acceptance'/],
+			[{ acceptance: reportData(), acceptance_report: reportData() }, /multiple acceptance report wrappers are ambiguous/],
+		] as const) {
+			const parsed = parseAcceptanceReport(`\`\`\`acceptance-report\n${JSON.stringify(value)}\n\`\`\``);
+			assert.equal(parsed.report, undefined);
+			assert.match(parsed.error ?? "", expected);
+		}
+	});
+
+	it("rejects unknown enums, duplicate criterion ids, and blank evidence", () => {
+		for (const [overrides, expected] of [
+			[{ commandsRun: [{ command: "npm test", result: "maybe", summary: "passed" }] }, /commandsRun\[0\]\.result.*got "maybe"/],
+			[{ commandsRun: [{ command: "npm test", result: "passed", summary: "", exitCode: 0 }] }, /commandsRun\[0\]\.exitCode: unsupported acceptance command field/],
+			[{ commandsRun: [{ command: "npm test", result: "passed", summary: "" }] }, /commandsRun\[0\]\.summary: expected non-empty string; got ""/],
+			[{ criteriaSatisfied: [{ id: "criterion-1", status: "maybe", evidence: "proof" }] }, /criteriaSatisfied\[0\]\.status.*got "maybe"/],
+			[{ criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "proof", confidence: 1 }] }, /criteriaSatisfied\[0\]\.confidence: unsupported acceptance criterion field/],
+			[{ criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "proof" }, { id: "Criterion_1", status: "satisfied", evidence: "proof" }] }, /duplicate normalized criterion id 'criterion-1'/],
+			[{ reviewFindings: [""] }, /reviewFindings\[0\]: expected non-empty string; got ""/],
+			[{ noStagedFiles: "yes" }, /noStagedFiles: expected boolean; got "yes"/],
+		] as const) {
+			const parsed = parseAcceptanceReport(report(overrides));
+			assert.equal(parsed.report, undefined);
+			assert.match(parsed.error ?? "", expected);
+		}
 	});
 
 	it("reports field-level validation errors for malformed acceptance-report fields", () => {
@@ -191,21 +312,21 @@ describe("acceptance gates", () => {
 			reviewFindings: [{ id: "B-1", severity: "blocker", finding: "Missing evidence" }],
 		}));
 		assert.equal(invalidReviewerReport.report, undefined);
-		assert.match(invalidReviewerReport.error ?? "", /reviewFindings\[0\]: expected string; got object/);
+		assert.match(invalidReviewerReport.error ?? "", /reviewFindings\[0\]: expected non-empty string; got object/);
 
 		const invalidCommandReport = parseAcceptanceReport(report({
 			commandsRun: [{ command: "npm test", exitCode: 0 }],
 		}));
 		assert.equal(invalidCommandReport.report, undefined);
 		assert.match(invalidCommandReport.error ?? "", /commandsRun\[0\]\.result: expected one of "passed", "failed", "not-run"; got missing/);
-		assert.match(invalidCommandReport.error ?? "", /commandsRun\[0\]\.summary: expected string; got missing/);
+		assert.match(invalidCommandReport.error ?? "", /commandsRun\[0\]\.summary: expected non-empty string; got missing/);
 
 		const invalidCriteriaReport = parseAcceptanceReport(report({
-			criteriaSatisfied: [{ id: 7, status: "done", evidence: "" }],
+			criteriaSatisfied: [{ id: 7, status: "maybe", evidence: "" }],
 		}));
 		assert.equal(invalidCriteriaReport.report, undefined);
 		assert.match(invalidCriteriaReport.error ?? "", /criteriaSatisfied\[0\]\.id: expected string; got number 7/);
-		assert.match(invalidCriteriaReport.error ?? "", /criteriaSatisfied\[0\]\.status: expected one of "satisfied", "not-satisfied", "not-applicable"; got "done"/);
+		assert.match(invalidCriteriaReport.error ?? "", /criteriaSatisfied\[0\]\.status: expected one of "satisfied", "not-satisfied", "not-applicable"; got "maybe"/);
 		assert.match(invalidCriteriaReport.error ?? "", /criteriaSatisfied\[0\]\.evidence: expected non-empty string; got ""/);
 	});
 
@@ -220,7 +341,7 @@ describe("acceptance gates", () => {
 		assert.deepEqual(acceptance.evidence, []);
 	});
 
-	it("checked mode rejects missing required evidence", async () => {
+	it("checked mode accepts explicit empty changed and test arrays as not applicable", async () => {
 		const cwd = tempRepo();
 		try {
 			const acceptance = resolveEffectiveAcceptance({
@@ -230,12 +351,43 @@ describe("acceptance gates", () => {
 			});
 			const ledger = await evaluateAcceptance({
 				acceptance,
-				output: report({ testsAddedOrUpdated: [] }),
+				output: report({ changedFiles: [], testsAddedOrUpdated: [] }),
 				cwd,
 			});
 
-			assert.equal(ledger.status, "rejected");
-			assert.match(acceptanceFailureMessage(ledger) ?? "", /tests-added evidence missing/);
+			assert.equal(ledger.status, "checked");
+			assert.equal(ledger.runtimeChecks.find((check) => check.id === "evidence:changed-files")?.status, "not-applicable");
+			assert.equal(ledger.runtimeChecks.find((check) => check.id === "evidence:tests-added")?.status, "not-applicable");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("still rejects missing changed and test evidence and empty required commands", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({ agentName: "worker", task: "Implement a fix", explicit: { level: "checked" } });
+			const missing = await evaluateAcceptance({ acceptance, output: report({
+				changedFiles: undefined,
+				testsAddedOrUpdated: undefined,
+			}), cwd });
+			assert.equal(missing.status, "rejected");
+			assert.match(acceptanceFailureMessage(missing) ?? "", /changed-files evidence missing/);
+
+			const missingTests = await evaluateAcceptance({ acceptance, output: report({
+				changedFiles: [],
+				testsAddedOrUpdated: undefined,
+			}), cwd });
+			assert.equal(missingTests.status, "rejected");
+			assert.match(acceptanceFailureMessage(missingTests) ?? "", /tests-added evidence missing/);
+
+			const emptyCommands = await evaluateAcceptance({
+				acceptance,
+				output: report({ changedFiles: [], testsAddedOrUpdated: [], commandsRun: [] }),
+				cwd,
+			});
+			assert.equal(emptyCommands.status, "rejected");
+			assert.match(acceptanceFailureMessage(emptyCommands) ?? "", /commands-run evidence missing/);
 		} finally {
 			fs.rmSync(cwd, { recursive: true, force: true });
 		}
@@ -257,7 +409,40 @@ describe("acceptance gates", () => {
 
 			assert.equal(ledger.status, "rejected");
 			assert.match(acceptanceFailureMessage(ledger) ?? "", /Failed to parse acceptance-report/);
-			assert.match(acceptanceFailureMessage(ledger) ?? "", /reviewFindings\[0\]: expected string; got object/);
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /reviewFindings\[0\]: expected non-empty string; got object/);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("normalizes configured criterion ids and validates direct report objects", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "checked", criteria: [{ id: "Release_Check", must: "Release check passes" }] },
+			});
+			const normalized = await evaluateAcceptance({
+				acceptance,
+				output: report({
+					criteriaSatisfied: [{ id: "release check", status: "met", evidence: "verified" }],
+					changedFiles: [],
+					testsAddedOrUpdated: [],
+				}),
+				cwd,
+			});
+			assert.equal(normalized.status, "checked");
+			assert.equal(normalized.childReport?.criteriaSatisfied?.[0]?.id, "release-check");
+
+			const malformedDirect = await evaluateAcceptance({
+				acceptance,
+				output: "",
+				report: { ...reportData(), unexpected: true } as never,
+				cwd,
+			});
+			assert.equal(malformedDirect.status, "rejected");
+			assert.match(malformedDirect.childReportParseError ?? "", /unexpected: unsupported acceptance report field/);
 		} finally {
 			fs.rmSync(cwd, { recursive: true, force: true });
 		}
@@ -585,13 +770,13 @@ describe("acceptance gates", () => {
 				acceptance,
 				output: "wrote the report to the file",
 				fileOutput: {
-					content: report({ criteriaSatisfied: [{ id: "criterion-1", status: "not_satisfied", evidence: "x" }] }),
+					content: report({ criteriaSatisfied: [{ id: "criterion-1", status: "partially_done", evidence: "x" }] }),
 					path: "/tmp/report.md",
 				},
 				cwd,
 			});
 			assert.equal(ledger.status, "rejected");
-			assert.match(acceptanceFailureMessage(ledger) ?? "", /not_satisfied/);
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /partially_done/);
 			assert.match(acceptanceFailureMessage(ledger) ?? "", /configured output/);
 		} finally {
 			fs.rmSync(cwd, { recursive: true, force: true });
@@ -683,6 +868,10 @@ describe("acceptance gates", () => {
 		assert.match(validateAcceptanceInput({ level: "reviewed" }).join("\n"), /cannot be requested explicitly.*independent reviewer result/i);
 		assert.deepEqual(validateAcceptanceInput({ criteria: ["ship the fix"], review: false, stopRules: ["stay scoped"] }), []);
 		assert.match(validateAcceptanceInput({ criteria: [{ id: "missing-must" }] }).join("\n"), /acceptance\.criteria\[0\]\.must is required/);
+		assert.match(validateAcceptanceInput({ criteria: [
+			{ id: "Release_Check", must: "first" },
+			{ id: "release check", must: "second" },
+		] }).join("\n"), /acceptance\.criteria\[1\]\.id duplicates normalized criterion id 'release-check'/);
 		assert.match(validateAcceptanceInput({ criteria: [123] }).join("\n"), /acceptance\.criteria\[0\] must be a string or an object/);
 		assert.match(validateAcceptanceInput({ evidence: ["bogus"] }).join("\n"), /acceptance\.evidence\[0\] is not a supported evidence kind/);
 		assert.match(validateAcceptanceInput({ review: true }).join("\n"), /acceptance\.review must be false or an object/);

--- a/test/unit/get-final-output.test.ts
+++ b/test/unit/get-final-output.test.ts
@@ -81,6 +81,29 @@ describe("getFinalOutput", () => {
 		assert.equal(getFinalOutput(messages), report);
 	});
 
+	it("preserves prose from a sibling text part when selecting an acceptance report", () => {
+		const report = "```acceptance-report\n{}\n```";
+		const messages = [assistantContent([
+			{ type: "text", text: "Human-readable answer." },
+			{ type: "text", text: report },
+		])];
+
+		assert.equal(getFinalOutput(messages), `Human-readable answer.\n${report}`);
+	});
+
+	it("recognizes underscore fences and snake_case generic report keys", () => {
+		for (const report of [
+			"```acceptance_report\n{}\n```",
+			`\`\`\`json\n${JSON.stringify({ criteria_satisfied: [], validation_output: ["passed"] })}\n\`\`\``,
+		]) {
+			const messages = [
+				assistantContent([{ type: "text", text: report }]),
+				assistantContent([{ type: "text", text: "Later summary." }]),
+			];
+			assert.equal(getFinalOutput(messages), report);
+		}
+	});
+
 	it("does not prefer provider-error acceptance reports", () => {
 		const messages = [
 			{


### PR DESCRIPTION
This finishes the acceptance-report contract from #442. Explicit empty `changedFiles` and `testsAddedOrUpdated` arrays are now not applicable rather than missing, required criteria drive the child example, known wire variants normalize to one canonical report, and unknown or ambiguous values fail with field-level diagnostics.

Normal output stays fence-free while the raw transcript remains intact. Foreground, detached foreground, and async child metadata now persist the full acceptance ledger and parsed report, including explicit skipped ledgers for stopped, timed-out, and turn-budget terminal states.

The original aggregate async-notification commit is intentionally excluded. Against current main it bypasses the custom notification renderer and labels stopped aggregates as failed, so that behavior needs a separately scoped rework.

Local validation passed 1,154 unit tests with one skip, 530 integration tests, and one E2E test. Thanks to Nick Tripp (@nicholastripp) for #442, maxsturmb (@maxsturmb) for this implementation, and techmodv90 (@techmodv90) for the overlapping #449 and #450 work.