### PR TITLE
fix: canonicalize native watcher paths for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Canonicalized native `fs.watch` registration paths for async results, control inboxes, and child steering inboxes so Windows 8.3 short paths do not conflict with long-form libuv event paths. Thanks to NahidaChan (@KawaiiNahida) for #455.
 - Made configured output instructions capability-aware: read-only children now return the complete artifact for runtime persistence instead of treating an unavailable write tool as a supervisor blocker. Thanks to Alexander Gerdes (@Avg8888) for #426.
 - Bounded live child JSONL lines and stderr tails in foreground and async runners, preserving split UTF-8 and final unterminated events while returning structured `protocol_output_limit` failures for oversized lines. Completion now honors `agent_end.willRetry` and prefers `agent_settled` without removing the legacy terminal-message fallback. Thanks to Luke Parke (@LukasParke) for #444 and #445.
 - Made `subagent_wait({ id })` track remembered detached foreground runs, defer acceptance until the child exits, and wake the originating session with recovered output so parents do not launch duplicate replacements after supervisor coordination. Thanks to Ramin Hazegh (@rhazegh) for #456.

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -19,6 +19,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { POLL_INTERVAL_MS } from "../../shared/types.ts";
+import { resolveWatchPath } from "../../shared/utils.ts";
 
 /**
  * Opportunistic fast-path interrupt signal. On Unix `SIGUSR2` is trapped by the
@@ -27,7 +28,7 @@ import { POLL_INTERVAL_MS } from "../../shared/types.ts";
  */
 export const INTERRUPT_SIGNAL: NodeJS.Signals = process.platform === "win32" ? "SIGBREAK" : "SIGUSR2";
 
-export type ControlChannelFs = Pick<typeof fs, "mkdirSync" | "existsSync" | "rmSync" | "watch" | "readdirSync" | "readFileSync">;
+export type ControlChannelFs = Pick<typeof fs, "mkdirSync" | "existsSync" | "rmSync" | "watch" | "readdirSync" | "readFileSync" | "realpathSync">;
 export type ControlChannelTimers = { setInterval: typeof setInterval; clearInterval: typeof clearInterval };
 type KillFn = (pid: number, signal?: NodeJS.Signals | 0) => unknown;
 
@@ -358,7 +359,7 @@ export function watchAsyncControlInbox(
 
 	let watcher: fs.FSWatcher | undefined;
 	try {
-		watcher = fsImpl.watch(dir, () => check());
+		watcher = fsImpl.watch(resolveWatchPath(dir, fsImpl.realpathSync.native), () => check());
 		watcher.on?.("error", () => {
 			// fs.watch can emit on transient FS errors; the interval poll keeps us live.
 		});

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -17,6 +17,7 @@ import {
 	resolveSubagentResultStatus,
 } from "../../intercom/result-intercom.ts";
 import { projectNestedRegistryForRoot, sanitizeSummary } from "../shared/nested-events.ts";
+import { resolveWatchPath } from "../../shared/utils.ts";
 
 const WATCHER_RESTART_DELAY_MS = 3000;
 const POLL_INTERVAL_MS = 3000;
@@ -93,13 +94,6 @@ function shouldFallBackToPolling(error: unknown): boolean {
 	return code === "EMFILE" || code === "ENOSPC";
 }
 
-function resolveNativeWatchDir(fsApi: ResultWatcherFs, resultsDir: string): string {
-	try {
-		return fsApi.realpathSync.native(resultsDir);
-	} catch {
-		return resultsDir;
-	}
-}
 
 export function createResultWatcher(
 	pi: { events: IntercomEventBus },
@@ -280,7 +274,7 @@ export function createResultWatcher(
 			state.watcherRestartTimer = null;
 		}
 		try {
-			const watchDir = resolveNativeWatchDir(fsApi, resultsDir);
+			const watchDir = resolveWatchPath(resultsDir, fsApi.realpathSync.native);
 			state.watcher = fsApi.watch(watchDir, (ev, file) => {
 				if (ev !== "rename" || !file) return;
 				const fileName = file.toString();

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -7,6 +7,7 @@ import { SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_STEER_INBOX_ENV } from "./pi-args.t
 import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV, validateStructuredOutputValue } from "./structured-output.ts";
 import { TOOL_BUDGET_ENV, decodeToolBudgetEnv, shouldBlockToolForBudget, toolBudgetBlockedMessage, toolBudgetSoftNudge } from "./tool-budget.ts";
 import type { JsonSchemaObject, ResolvedToolBudget } from "../../shared/types.ts";
+import { resolveWatchPath } from "../../shared/utils.ts";
 import { registerChildWatchdog } from "../../watchdog/register-child.ts";
 import { SUBAGENT_WATCHDOG_WARNING_TYPE } from "../../watchdog/types.ts";
 
@@ -192,7 +193,10 @@ function registerToolBudget(pi: ExtensionAPI, budget: ResolvedToolBudget | undef
 	});
 }
 
-function registerSteeringInbox(pi: ExtensionAPI): void {
+export function registerSteeringInbox(
+	pi: ExtensionAPI,
+	deps: { watch?: typeof fs.watch; nativeRealpath?: (filePath: string) => string } = {},
+): void {
 	const steerInbox = process.env[SUBAGENT_STEER_INBOX_ENV]?.trim();
 	if (!steerInbox) return;
 	const sendUserMessage = (pi as { sendUserMessage?: (content: string, options: { deliverAs: "steer" }) => unknown }).sendUserMessage;
@@ -231,7 +235,7 @@ function registerSteeringInbox(pi: ExtensionAPI): void {
 		}
 		started = true;
 		try {
-			watcher = fs.watch(steerInbox, () => flush());
+			watcher = (deps.watch ?? fs.watch)(resolveWatchPath(steerInbox, deps.nativeRealpath), () => flush());
 			watcher.on("error", () => {});
 		} catch {
 			watcher = undefined;

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -17,6 +17,18 @@ const DEFAULT_CONFIG_DIR_NAME = ".pi";
 const PI_CODING_AGENT_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
 export const PI_CODING_AGENT_PACKAGE_ROOT_ENV = "PI_SUBAGENTS_PI_CODING_AGENT_PACKAGE_ROOT";
 
+export function resolveWatchPath(
+	watchPath: string,
+	nativeRealpath: (filePath: string) => string = fs.realpathSync.native,
+): string {
+	// libuv's Windows watcher cannot mix 8.3 registration paths with long event paths.
+	try {
+		return nativeRealpath(watchPath);
+	} catch {
+		return watchPath;
+	}
+}
+
 function validConfigDirName(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim() ? value : undefined;
 }

--- a/test/unit/config-dir-runtime.test.ts
+++ b/test/unit/config-dir-runtime.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
-import { getConfigDirName, PI_CODING_AGENT_PACKAGE_ROOT_ENV, resolveConfigDirName } from "../../src/shared/utils.ts";
+import { getConfigDirName, PI_CODING_AGENT_PACKAGE_ROOT_ENV, resolveConfigDirName, resolveWatchPath } from "../../src/shared/utils.ts";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 let previousPackageRootEnv: string | undefined;
@@ -63,6 +63,11 @@ describe("config directory resolution", () => {
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
+	});
+
+	it("canonicalizes watcher paths and preserves the original path when native realpath fails", () => {
+		assert.equal(resolveWatchPath("C:\\SHORT~1\\watch", () => "C:\\Long Path\\watch"), "C:\\Long Path\\watch");
+		assert.equal(resolveWatchPath("C:\\SHORT~1\\watch", () => { throw new Error("missing"); }), "C:\\SHORT~1\\watch");
 	});
 
 	it("does not runtime-import the coding agent peer from shared utils", () => {

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -254,18 +254,24 @@ describe("control channel: watchAsyncControlInbox", () => {
 		timers: import("../../src/runs/background/control-channel.ts").ControlChannelTimers;
 		trigger: () => void;
 		closed: () => boolean;
+		watchedDir: () => string | undefined;
 	};
 
-	function harness(): WatchHarness {
+	function harness(nativeDir?: string): WatchHarness {
 		let listener: (() => void) | undefined;
 		let closed = false;
+		let watchedDir: string | undefined;
+		const realpathSync = ((target: fs.PathLike, options?: unknown) => fs.realpathSync(target, options as BufferEncoding)) as typeof fs.realpathSync;
+		realpathSync.native = ((target: fs.PathLike) => nativeDir ?? fs.realpathSync.native(target)) as typeof fs.realpathSync.native;
 		const fsImpl = {
 			mkdirSync: fs.mkdirSync,
 			existsSync: fs.existsSync,
 			rmSync: fs.rmSync,
 			readdirSync: fs.readdirSync,
 			readFileSync: fs.readFileSync,
-			watch: ((_dir: string, cb: () => void) => {
+			realpathSync,
+			watch: ((dir: string, cb: () => void) => {
+				watchedDir = dir;
 				listener = cb;
 				return { close: () => { closed = true; }, on: () => {} };
 			}),
@@ -274,8 +280,21 @@ describe("control channel: watchAsyncControlInbox", () => {
 			setInterval: (() => ({ unref() {} })) as unknown as typeof setInterval,
 			clearInterval: (() => {}) as unknown as typeof clearInterval,
 		};
-		return { fsImpl, timers, trigger: () => listener?.(), closed: () => closed };
+		return { fsImpl, timers, trigger: () => listener?.(), closed: () => closed, watchedDir: () => watchedDir };
 	}
+
+	it("registers the native canonical control inbox path", () => {
+		const asyncDir = tmpAsyncDir("pi-control-watch-native-");
+		try {
+			const nativeDir = path.join(path.dirname(asyncDir), "native-control-path");
+			const h = harness(nativeDir);
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers });
+			assert.equal(h.watchedDir(), nativeDir);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
 
 	it("fires on a request that arrived before the watcher started", () => {
 		const asyncDir = tmpAsyncDir("pi-control-watch-early-");

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -22,6 +22,7 @@ import registerSubagentPromptRuntime, {
 	CHILD_FANOUT_BOUNDARY_INSTRUCTIONS,
 	CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS,
 	SUBAGENT_INTERCOM_SESSION_NAME_ENV,
+	registerSteeringInbox,
 	rewriteSubagentPrompt,
 	stripInheritedSkills,
 	stripParentOnlySubagentMessages,
@@ -134,6 +135,40 @@ describe("subagent prompt runtime", () => {
 			reason: "Tool budget hard limit reached after 3 tool calls (hard 2). The 'read' tool is blocked so you can finalize from the context you already have.",
 		});
 		assert.equal(toolCall({ toolName: "write" }), undefined);
+	});
+
+	it("registers the native canonical steering inbox path", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-steering-watch-runtime-"));
+		try {
+			const inbox = path.join(dir, "steer");
+			const nativeInbox = path.join(dir, "native-steer");
+			process.env[SUBAGENT_STEER_INBOX_ENV] = inbox;
+			const handlers = new Map<string, (payload?: unknown) => unknown>();
+			let watchedDir: fs.PathLike | undefined;
+			const fakeWatcher = { on() { return fakeWatcher; }, close() {} } as fs.FSWatcher;
+
+			registerSteeringInbox({
+				on(event: string, handler: (payload?: unknown) => unknown) {
+					handlers.set(event, handler);
+				},
+				sendUserMessage() {},
+			} as { on(event: string, handler: (payload?: unknown) => unknown): void; sendUserMessage(): void }, {
+				nativeRealpath(target) {
+					assert.equal(target, inbox);
+					return nativeInbox;
+				},
+				watch: ((target: fs.PathLike) => {
+					watchedDir = target;
+					return fakeWatcher;
+				}) as typeof fs.watch,
+			});
+
+			handlers.get("session_start")?.({});
+			assert.equal(watchedDir, nativeInbox);
+			handlers.get("session_shutdown")?.({});
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("delivers steering inbox requests as mid-run user messages", () => {


### PR DESCRIPTION
 Fix Windows async subagent crashes caused by fs.watch() receiving 8.3 short paths while libuv reports long-form event paths.