### PR TITLE
fix: preserve named output refs in async single tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Preserved `{outputs.name}` as literal task text in async single runs while keeping named-output interpolation for real chains. Thanks to Tristan Storch (@tstorch) for #427.
 - Recovered acceptance reports from child-written configured outputs, honoring file-only source precedence and surfacing malformed primary reports. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #434.
 - Isolated inherited output files for async parallel siblings and rejected duplicate resolved output paths before launch, preventing silent report loss. Thanks to basher83 (@basher83) for #420.
 - Replaced raw chain-schema failures with actionable errors that name invalid properties, list allowed fields, and show valid examples. Thanks to Nicolas Marchildon (@elecnix) for #416 and #425.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -983,7 +983,7 @@ async function runSingleStep(
 		: undefined);
 	const placeholderRegex = new RegExp(ctx.placeholder.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
 	let task = step.task.replace(placeholderRegex, () => ctx.previousOutput);
-	task = resolveOutputReferences(task, ctx.outputs ?? {});
+	if (ctx.outputs) task = resolveOutputReferences(task, ctx.outputs);
 	const taskForCompletionGuard = task;
 	if (step.effectiveAcceptance) {
 		const acceptancePrompt = formatAcceptancePrompt(step.effectiveAcceptance);
@@ -3084,7 +3084,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			flushPendingStepSteers(flatIndex);
 			const singleResult = await runSingleStep(seqStep, {
 				previousOutput, placeholder, cwd, sessionEnabled,
-				outputs,
+				outputs: statusPayload.mode === "single" ? undefined : outputs,
 				sessionDir: config.sessionDir,
 				artifactsDir, artifactConfig, id,
 				flatIndex, flatStepCount: Math.max(statusPayload.steps.length, 1),

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -367,6 +367,36 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(typeof result, "boolean");
 	});
 
+	it("keeps named output references literal in async single tasks", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const task = "Reply with OK. You may reference {outputs.name} if it helps.";
+		mockPi.onCall({ output: "OK" });
+		const id = `async-single-literal-output-ref-${Date.now().toString(36)}`;
+		const result = executeAsyncSingle(id, {
+			agent: "worker",
+			task,
+			agentConfig: makeAgent("worker"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			maxSubagentDepth: 2,
+		});
+
+		assert.equal(result.isError, undefined);
+		const call = await waitForMockPiCall(mockPi, 0, 10_000);
+		assert.match(call.args.at(-1) ?? "", /\{outputs\.name\}/);
+		const payload = await readAsyncPayload(id);
+		assert.equal(payload.success, true);
+		assert.equal(payload.results[0]?.output, "OK");
+	});
+
 	it("spawns the async runner with node when process.execPath is not node", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		const originalExecPath = process.execPath;
 		process.execPath = path.join(tempDir, process.platform === "win32" ? "pi.exe" : "pi");


### PR DESCRIPTION
Fixes #427.

Async single runs were passing their task through the background chain-output resolver with an empty output map. A task that merely documented `{outputs.name}` therefore failed before the child started, while the same foreground task worked.

This skips named-output interpolation only for async single mode. Real async chains keep their existing validation and substitution behavior. The regression test drives the detached runner, confirms the exact token reaches the child, and verifies the run completes successfully.

Validated with the focused async runner reproduction, the full async integration file, 1,111 passing unit tests (1 skipped), 509 integration tests, 1 E2E test, and `git diff --check`.

Thanks to Tristan Storch (@tstorch) for the report and reproduction in #427.
