### PR TITLE
fix: reuse verified Pi CLI on POSIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Reused the verified current or installed Pi CLI on POSIX instead of resolving a potentially missing or different `pi` from `PATH`. Thanks to Luke Parke (@LukasParke) for #443.
 - Preserved `{outputs.name}` as literal task text in async single runs while keeping named-output interpolation for real chains. Thanks to Tristan Storch (@tstorch) for #427.
 - Recovered acceptance reports from child-written configured outputs, honoring file-only source precedence and surfacing malformed primary reports. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #434.
 - Isolated inherited output files for async parallel siblings and rejected duplicate resolved output paths before launch, preventing silent report loss. Thanks to basher83 (@basher83) for #420.

--- a/src/runs/shared/pi-spawn.ts
+++ b/src/runs/shared/pi-spawn.ts
@@ -45,6 +45,7 @@ export interface PiSpawnDeps {
 	execPath?: string;
 	argv1?: string;
 	existsSync?: (filePath: string) => boolean;
+	realpathSync?: (filePath: string) => string;
 	readFileSync?: (filePath: string, encoding: "utf-8") => string;
 	resolvePackageJson?: () => string;
 	resolvePackageEntry?: () => string;
@@ -69,10 +70,11 @@ function normalizePath(filePath: string): string {
 	return path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
 }
 
-export function resolveWindowsPiCliScript(
+export function resolvePiCliScript(
 	deps: PiSpawnDeps = {},
 ): string | undefined {
 	const existsSync = deps.existsSync ?? fs.existsSync;
+	const realpathSync = deps.realpathSync ?? fs.realpathSync;
 	const readFileSync =
 		deps.readFileSync ??
 		((filePath, encoding) => fs.readFileSync(filePath, encoding));
@@ -82,7 +84,10 @@ export function resolveWindowsPiCliScript(
 		const argvPath = normalizePath(argv1);
 		if (isRunnableNodeScript(argvPath, existsSync)) {
 			try {
-				if (findPiPackageRootFromEntry(argvPath)) return argvPath;
+				const canonicalArgvPath = realpathSync(argvPath);
+				if (isRunnableNodeScript(canonicalArgvPath, existsSync) && findPiPackageRootFromEntry(canonicalArgvPath)) {
+					return canonicalArgvPath;
+				}
 			} catch {
 				// Host package metadata is untrusted here; keep resolving the installed Pi CLI.
 			}
@@ -119,7 +124,7 @@ export function resolveWindowsPiCliScript(
 			return candidate;
 		}
 	} catch {
-		// Windows CLI resolution is optional; falling back to `pi` lets PATH handle execution.
+		// Verified CLI resolution is optional; falling back to `pi` lets PATH handle execution.
 		return undefined;
 	}
 
@@ -136,15 +141,12 @@ export function getPiSpawnCommand(
 		return { command: piBinary, args };
 	}
 
-	const platform = deps.platform ?? process.platform;
-	if (platform === "win32") {
-		const piCliPath = resolveWindowsPiCliScript(deps);
-		if (piCliPath) {
-			return {
-				command: deps.execPath ?? process.execPath,
-				args: [piCliPath, ...args],
-			};
-		}
+	const piCliPath = resolvePiCliScript(deps);
+	if (piCliPath) {
+		return {
+			command: deps.execPath ?? process.execPath,
+			args: [piCliPath, ...args],
+		};
 	}
 
 	return { command: "pi", args };

--- a/test/support/mock-pi.ts
+++ b/test/support/mock-pi.ts
@@ -80,6 +80,7 @@ export function createMockPi(): MockPi {
 	let installed = false;
 	let nextSequence = 0;
 	let originalPath: string | undefined;
+	let originalPiBinary: string | undefined;
 	let originalArgv1: string | undefined;
 	let originalQueueEnv: string | undefined;
 
@@ -91,25 +92,31 @@ export function createMockPi(): MockPi {
 			if (installed) return;
 			installed = true;
 			originalPath = process.env.PATH;
+			originalPiBinary = process.env.PI_SUBAGENT_PI_BINARY;
 			originalQueueEnv = process.env.MOCK_PI_QUEUE_DIR;
 			process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
-			process.env.MOCK_PI_QUEUE_DIR = queueDir;
 			if (process.platform === "win32") {
+				delete process.env.PI_SUBAGENT_PI_BINARY;
 				originalArgv1 = process.argv[1];
 				process.argv[1] = cliScriptPath;
+			} else {
+				process.env.PI_SUBAGENT_PI_BINARY = shellScriptPath;
 			}
+			process.env.MOCK_PI_QUEUE_DIR = queueDir;
 		},
 		uninstall() {
 			if (!installed) return;
 			installed = false;
 			if (originalPath === undefined) delete process.env.PATH;
 			else process.env.PATH = originalPath;
-			if (originalQueueEnv === undefined) delete process.env.MOCK_PI_QUEUE_DIR;
-			else process.env.MOCK_PI_QUEUE_DIR = originalQueueEnv;
+			if (originalPiBinary === undefined) delete process.env.PI_SUBAGENT_PI_BINARY;
+			else process.env.PI_SUBAGENT_PI_BINARY = originalPiBinary;
 			if (process.platform === "win32") {
 				if (originalArgv1 === undefined) delete process.argv[1];
 				else process.argv[1] = originalArgv1;
 			}
+			if (originalQueueEnv === undefined) delete process.env.MOCK_PI_QUEUE_DIR;
+			else process.env.MOCK_PI_QUEUE_DIR = originalQueueEnv;
 			try {
 				fs.rmSync(rootDir, { recursive: true, force: true });
 			} catch {}

--- a/test/support/real-session-runner.ts
+++ b/test/support/real-session-runner.ts
@@ -117,6 +117,7 @@ function installChildPiShim(childText: string): () => void {
 	const piPackageDir = path.join(rootDir, "pi-package");
 	const childCliPath = path.join(piPackageDir, "dist", "cli.mjs");
 	const previousPath = process.env.PATH;
+	const previousPiBinary = process.env.PI_SUBAGENT_PI_BINARY;
 	const previousChildText = process.env.PI_SUBAGENTS_E2E_CHILD_TEXT;
 	const previousArgv1 = process.argv[1];
 
@@ -139,18 +140,25 @@ function installChildPiShim(childText: string): () => void {
 	);
 
 	process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
+	if (process.platform === "win32") {
+		delete process.env.PI_SUBAGENT_PI_BINARY;
+		process.argv[1] = childCliPath;
+	} else {
+		process.env.PI_SUBAGENT_PI_BINARY = path.join(binDir, "pi");
+	}
 	process.env.PI_SUBAGENTS_E2E_CHILD_TEXT = childText;
-	if (process.platform === "win32") process.argv[1] = childCliPath;
 
 	return () => {
 		if (previousPath === undefined) delete process.env.PATH;
 		else process.env.PATH = previousPath;
-		if (previousChildText === undefined) delete process.env.PI_SUBAGENTS_E2E_CHILD_TEXT;
-		else process.env.PI_SUBAGENTS_E2E_CHILD_TEXT = previousChildText;
+		if (previousPiBinary === undefined) delete process.env.PI_SUBAGENT_PI_BINARY;
+		else process.env.PI_SUBAGENT_PI_BINARY = previousPiBinary;
 		if (process.platform === "win32") {
 			if (previousArgv1 === undefined) delete process.argv[1];
 			else process.argv[1] = previousArgv1;
 		}
+		if (previousChildText === undefined) delete process.env.PI_SUBAGENTS_E2E_CHILD_TEXT;
+		else process.env.PI_SUBAGENTS_E2E_CHILD_TEXT = previousChildText;
 		rmSync(rootDir, { recursive: true, force: true });
 	};
 }
@@ -216,7 +224,6 @@ export async function runRealSubagentSession(options: RealSessionRunOptions): Pr
 		delete process.env.PI_SUBAGENT_DEPTH;
 		delete process.env.PI_SUBAGENT_MAX_DEPTH;
 		delete process.env.PI_SUBAGENT_PARENT_SESSION;
-		delete process.env.PI_SUBAGENT_PI_BINARY;
 		delete process.env.PI_SUBAGENTS_PI_CODING_AGENT_PACKAGE_ROOT;
 
 		faux = registerFauxProvider({

--- a/test/unit/pi-spawn.test.ts
+++ b/test/unit/pi-spawn.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { describe, it } from "node:test";
 import {
 	getPiSpawnCommand,
-	resolveWindowsPiCliScript,
+	resolvePiCliScript,
 	type PiSpawnDeps,
 } from "../../src/runs/shared/pi-spawn.ts";
 
@@ -63,25 +63,47 @@ describe("getPiSpawnCommand", () => {
 		const args = ["--mode", "json", "Task: check output"];
 		const result = getPiSpawnCommand(args, {
 			platform: "darwin",
+			argv1: "/missing/host.js",
+			existsSync: () => false,
+			resolvePackageJson: () => {
+				throw new Error("Pi package unavailable");
+			},
 			env: { PI_SUBAGENT_PI_BINARY: "   " },
 		});
 		assert.deepEqual(result, { command: "pi", args });
 	});
 
-	it("uses plain pi on non-Windows even when argv1 is a runnable JS file", () => {
-		const argv1 = "/tmp/pi-entry.mjs";
-		const deps = makeDeps({
-			platform: "darwin",
-			execPath: "/usr/local/bin/node",
-			argv1,
-			existing: [argv1],
+	for (const platform of ["darwin", "linux", "win32"] as const) {
+		it(`uses node + argv1 on ${platform} when argv1 belongs to the Pi package`, () => {
+			const tempDir = fs.mkdtempSync(
+				path.join(os.tmpdir(), "pi-spawn-argv-entry-"),
+			);
+			try {
+				const argv1 = path.join(tempDir, "dist", "cli.js");
+				fs.mkdirSync(path.dirname(argv1), { recursive: true });
+				fs.writeFileSync(argv1, "#!/usr/bin/env node\n");
+				fs.writeFileSync(
+					path.join(tempDir, "package.json"),
+					JSON.stringify({ name: "@earendil-works/pi-coding-agent" }),
+				);
+				const args = ["--mode", "json", 'Task: review "quotes" & pipes | too'];
+				const result = getPiSpawnCommand(args, {
+					platform,
+					execPath: "/usr/local/bin/node",
+					argv1,
+					env: {},
+				});
+				assert.deepEqual(result, {
+					command: "/usr/local/bin/node",
+					args: [fs.realpathSync(argv1), ...args],
+				});
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			}
 		});
-		const args = ["--mode", "json", "Task: check output"];
-		const result = getPiSpawnCommand(args, deps);
-		assert.deepEqual(result, { command: "pi", args });
-	});
+	}
 
-	it("uses plain pi on non-Windows even when the CLI script can be resolved from package bin", () => {
+	it("uses node + package bin on POSIX when argv1 is not a verified Pi entry", () => {
 		const packageJsonPath = "/opt/pi/package.json";
 		const cliPath = path.resolve(
 			path.dirname(packageJsonPath),
@@ -97,47 +119,27 @@ describe("getPiSpawnCommand", () => {
 		});
 		const args = ["-p", "Task: hello"];
 		const result = getPiSpawnCommand(args, deps);
-		assert.deepEqual(result, { command: "pi", args });
+		assert.deepEqual(result, {
+			command: "/usr/local/bin/node",
+			args: [cliPath, ...args],
+		});
 	});
 
-	it("falls back to plain pi command on non-Windows when CLI script cannot be resolved", () => {
+	it("falls back to plain pi command on POSIX when CLI script cannot be resolved", () => {
 		const args = ["--mode", "json", "Task: check output"];
-		const result = getPiSpawnCommand(args, { platform: "darwin", env: {} });
+		const result = getPiSpawnCommand(args, {
+			platform: "darwin",
+			argv1: "/missing/host.js",
+			existsSync: () => false,
+			resolvePackageJson: () => {
+				throw new Error("Pi package unavailable");
+			},
+			env: {},
+		});
 		assert.deepEqual(result, { command: "pi", args });
 	});
 
-	it("uses node + argv1 script on Windows when argv1 belongs to the Pi package", () => {
-		const tempDir = fs.mkdtempSync(
-			path.join(os.tmpdir(), "pi-spawn-argv-entry-"),
-		);
-		try {
-			const argv1 = path.join(tempDir, "dist", "cli.js");
-			fs.mkdirSync(path.dirname(argv1), { recursive: true });
-			fs.writeFileSync(argv1, "#!/usr/bin/env node\n");
-			fs.writeFileSync(
-				path.join(tempDir, "package.json"),
-				JSON.stringify({ name: "@earendil-works/pi-coding-agent" }),
-			);
-			const args = [
-				"--mode",
-				"json",
-				'Task: Read C:/dev/file.md and review "quotes" & pipes | too',
-			];
-			const result = getPiSpawnCommand(args, {
-				platform: "win32",
-				execPath: "/usr/local/bin/node",
-				argv1,
-				env: {},
-			});
-			assert.equal(result.command, "/usr/local/bin/node");
-			assert.equal(result.args[0], argv1);
-			assert.equal(result.args[3], args[2]);
-		} finally {
-			fs.rmSync(tempDir, { recursive: true, force: true });
-		}
-	});
-
-	it("ignores an embedded host entry point and resolves the Pi package bin on Windows", () => {
+	it("ignores embedded host entry points and resolves the Pi package bin on every platform", () => {
 		const tempDir = fs.mkdtempSync(
 			path.join(os.tmpdir(), "pi-spawn-embedded-host-"),
 		);
@@ -168,26 +170,71 @@ describe("getPiSpawnCommand", () => {
 				}),
 			);
 
-			const result = getPiSpawnCommand(["-p", "Task: hello"], {
-				platform: "win32",
-				execPath: "/usr/local/bin/node",
-				argv1: hostEntry,
-				resolvePackageJson: () => path.join(piRoot, "package.json"),
-				env: {},
-			});
-			assert.equal(result.command, "/usr/local/bin/node");
-			assert.equal(result.args[0], piCli);
+			for (const platform of ["darwin", "linux", "win32"] as const) {
+				const result = getPiSpawnCommand(["-p", "Task: hello"], {
+					platform,
+					execPath: "/usr/local/bin/node",
+					argv1: hostEntry,
+					resolvePackageJson: () => path.join(piRoot, "package.json"),
+					env: {},
+				});
+				assert.deepEqual(result, {
+					command: "/usr/local/bin/node",
+					args: [piCli, "-p", "Task: hello"],
+				});
+			}
 
 			fs.writeFileSync(hostPackageJson, "{");
-			const malformedHostResult = getPiSpawnCommand(["-p", "Task: hello"], {
-				platform: "win32",
+			for (const platform of ["darwin", "linux", "win32"] as const) {
+				const malformedHostResult = getPiSpawnCommand(["-p", "Task: hello"], {
+					platform,
+					execPath: "/usr/local/bin/node",
+					argv1: hostEntry,
+					resolvePackageJson: () => path.join(piRoot, "package.json"),
+					env: {},
+				});
+				assert.deepEqual(malformedHostResult, {
+					command: "/usr/local/bin/node",
+					args: [piCli, "-p", "Task: hello"],
+				});
+			}
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("validates argv1 ownership against its canonical target", () => {
+		const tempDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-spawn-canonical-entry-"),
+		);
+		try {
+			const hostRoot = path.join(tempDir, "embedded-host");
+			const hostEntry = path.join(hostRoot, "dist", "server.js");
+			const piRoot = path.join(tempDir, "node_modules", "@earendil-works", "pi-coding-agent");
+			const disguisedEntry = path.join(piRoot, "dist", "cli.js");
+			const piCli = path.join(piRoot, "dist", "real-cli.js");
+			fs.mkdirSync(path.dirname(hostEntry), { recursive: true });
+			fs.mkdirSync(path.dirname(piCli), { recursive: true });
+			fs.writeFileSync(hostEntry, "export {};\n");
+			fs.writeFileSync(path.join(hostRoot, "package.json"), JSON.stringify({ name: "embedded-host" }));
+			fs.writeFileSync(piCli, "#!/usr/bin/env node\n");
+			fs.writeFileSync(path.join(piRoot, "package.json"), JSON.stringify({
+				name: "@earendil-works/pi-coding-agent",
+				bin: { pi: "dist/real-cli.js" },
+			}));
+
+			const result = getPiSpawnCommand(["-p", "Task: hello"], {
 				execPath: "/usr/local/bin/node",
-				argv1: hostEntry,
+				argv1: disguisedEntry,
+				existsSync: (filePath) => filePath === disguisedEntry || fs.existsSync(filePath),
+				realpathSync: (filePath) => filePath === disguisedEntry ? hostEntry : fs.realpathSync(filePath),
 				resolvePackageJson: () => path.join(piRoot, "package.json"),
 				env: {},
 			});
-			assert.equal(malformedHostResult.command, "/usr/local/bin/node");
-			assert.equal(malformedHostResult.args[0], piCli);
+			assert.deepEqual(result, {
+				command: "/usr/local/bin/node",
+				args: [piCli, "-p", "Task: hello"],
+			});
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -287,7 +334,7 @@ describe("getPiSpawnCommand with piPackageRoot", () => {
 	});
 });
 
-describe("resolveWindowsPiCliScript", () => {
+describe("resolvePiCliScript", () => {
 	it("supports package bin as string", () => {
 		const packageJsonPath = "/opt/pi/package.json";
 		const cliPath = path.resolve(
@@ -301,6 +348,6 @@ describe("resolveWindowsPiCliScript", () => {
 			packageJsonContent: JSON.stringify({ bin: "dist/cli/index.mjs" }),
 			existing: [packageJsonPath, cliPath],
 		});
-		assert.equal(resolveWindowsPiCliScript(deps), cliPath);
+		assert.equal(resolvePiCliScript(deps), cliPath);
 	});
 });


### PR DESCRIPTION
Fixes #443.

Child Pi launches now use the same verified CLI resolution on every platform:

- `PI_SUBAGENT_PI_BINARY` remains authoritative.
- A runnable `argv[1]` is canonicalized and accepted only when its real target belongs to `@earendil-works/pi-coding-agent`.
- Otherwise the installed/current package `bin.pi` is launched through the current Node executable.
- Bare `pi` remains the final fallback when verified resolution is unavailable.

Canonical target validation prevents a symlink placed under the Pi package path from disguising an embedded host entry. The unit matrix covers Darwin, Linux, Windows, installed package fallback, malformed host metadata, canonical ownership, and bare fallback. Integration and E2E shims now use the explicit override on POSIX and a verified Pi-package `argv1` on Windows, avoiding direct `.cmd` spawning.

Validated with 1,113 passing unit tests (1 skipped), 509 integration tests, 1 E2E test, `git diff --check`, and three read-only review rounds.

Thanks to Luke Parke (@LukasParke) for the report and resolution contract in #443.
