### PR TITLE
fix: wait for detached foreground runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Made `subagent_wait({ id })` track remembered detached foreground runs, defer acceptance until the child exits, and wake the originating session with recovered output so parents do not launch duplicate replacements after supervisor coordination. Thanks to Ramin Hazegh (@rhazegh) for #456.
 - Renamed the parent blocking tool from `wait` to `subagent_wait` with no legacy alias, avoiding startup conflicts with unrelated extension wait tools. Thanks to DesZhang (@DesZhang) for #437 and Nate Rutman (@nrutman) for confirming the conflict and clarifying the incompatible semantics.
 - Reused the verified current or installed Pi CLI on POSIX instead of resolving a potentially missing or different `pi` from `PATH`. Thanks to Luke Parke (@LukasParke) for #443.
 - Preserved `{outputs.name}` as literal task text in async single runs while keeping named-output interpolation for real chains. Thanks to Tristan Storch (@tstorch) for #427.

--- a/README.md
+++ b/README.md
@@ -589,7 +589,9 @@ You can combine them in either order:
 /run reviewer "review this diff" --bg --fork
 ```
 
-Background runs are detached. If the parent agent has other independent work, it should keep working. When it has nothing useful to do until a background result arrives, it should call `subagent_wait` instead of running sleep or status-polling loops. `subagent_wait()` returns when the next active run finishes or needs attention and keeps the turn alive for normal notification delivery; use `subagent_wait({ all: true })` to drain every active run, `subagent_wait({ id })` for one run, and `subagent_wait({ timeoutMs })` to cap the block.
+Background runs are detached. If the parent agent has other independent work, it should keep working. When it has nothing useful to do until a background result arrives, it should call `subagent_wait` instead of running sleep or status-polling loops. `subagent_wait()` returns when the next active run finishes or needs attention and keeps the turn alive for normal notification delivery; use `subagent_wait({ all: true })` to drain every active async run, `subagent_wait({ id })` for one async run or remembered detached foreground run, and `subagent_wait({ timeoutMs })` to cap the block.
+
+A foreground child can detach while it waits for a supervisor reply. Reply first, then call `subagent_wait({ id: runId })`. The remembered run stays pending until the child exits, then emits a session-scoped completion notification with recovered output and remains inspectable through `subagent({ action: "status", id: runId })`. Do not call `resume` or launch a replacement while the child remains detached.
 
 `subagent_wait` is what lets a background-launching skill keep moving in a single turn, including non-interactive `pi -p` invocations where there is no subsequent turn to receive a completion notification. Ending the turn to wait for a completion only works in an interactive session where the user will prompt the agent again; in a run-to-completion skill or a non-interactive run, use `subagent_wait` so the still-running children are not abandoned.
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -350,7 +350,7 @@ Async does not mean parallel writes. Do not edit the same active worktree while 
 
 Do not end your turn immediately after launching an async child if you promised to keep working. Continue the local inspection, synthesis, or validation prep, then check the async run when its result is needed.
 
-When there is no independent work left and you just need the next async result, **call `subagent_wait()`** rather than `sleep`/status-polling loops. `subagent_wait()` returns when the next active run finishes or needs attention and keeps the turn alive for normal notification delivery. Use `subagent_wait({ all: true })` to drain every active run, `subagent_wait({ id: "..." })` to block on one run, and `subagent_wait({ timeoutMs })` to cap how long you block.
+When there is no independent work left and you just need the next async result, **call `subagent_wait()`** rather than `sleep`/status-polling loops. `subagent_wait()` returns when the next active run finishes or needs attention and keeps the turn alive for normal notification delivery. Use `subagent_wait({ all: true })` to drain every active async run, `subagent_wait({ id: "..." })` to block on one async run or remembered detached foreground run, and `subagent_wait({ timeoutMs })` to cap how long you block. If a foreground child detaches for supervisor coordination, reply first, then wait on its id; do not resume or launch a replacement while it remains detached.
 
 Prefer `subagent_wait()` over ending the turn whenever you must keep going to finish the job — inside a skill that has to run to completion, or in any non-interactive run (`pi -p ...`) where the whole task is a single turn. In those cases ending the turn abandons the still-running children, because there is no next turn to receive their completion. Only end the turn to wait when you are in an interactive session and are certain the user will prompt you again; then Pi will wake you when the run finishes.
 
@@ -728,7 +728,7 @@ When you have launched async runs and have no independent work left but must kee
 
 - `subagent_wait()` — return when the next active async run in this session finishes or needs attention.
 - `subagent_wait({ all: true })` — block until every active async run in this session finishes or one needs attention.
-- `subagent_wait({ id: "..." })` — block on one run (id or prefix).
+- `subagent_wait({ id: "..." })` — block on one async run or remembered detached foreground run (id or prefix). For a detached foreground child, reply to the supervisor request first; completion wakes the originating session with recovered output.
 - `subagent_wait({ timeoutMs })` — cap the block; the runs keep going if it elapses.
 
 `subagent_wait()` is the correct way to keep N workers in flight: launch N, call `subagent_wait()`, react to the result, launch a replacement if needed, then call `subagent_wait()` again. Use `subagent_wait({ all: true })` only when you intentionally want to drain the fleet to zero. Reserve ending-the-turn-to-wait for interactive sessions where the user will prompt you again; in a skill that must complete or a non-interactive `pi -p` run there is no next turn, so `subagent_wait()` is required to avoid abandoning live children.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -39,7 +39,7 @@ import { registerSubagentRpcBridge } from "./rpc.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
 import { resolveWaitToolConfig, waitForSubagents } from "../runs/background/subagent-wait.ts";
-import registerSubagentNotify, { type SubagentNotifyDetails } from "../runs/background/notify.ts";
+import registerSubagentNotify, { parseSubagentNotifyContent, type SubagentNotifyDetails } from "../runs/background/notify.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import { loadConfig } from "./config.ts";
@@ -177,38 +177,6 @@ function createSlashResultComponent(
 		return Container.prototype.render.call(container, width);
 	};
 	return container;
-}
-
-function parseSubagentNotifyContent(content: string): SubagentNotifyDetails | undefined {
-	const lines = content.split("\n");
-	const header = lines[0] ?? "";
-	const match = header.match(/^Background task (completed|failed|paused): \*\*(.+?)\*\*(?:\s+(\([^)]*\)))?$/);
-	if (!match) return undefined;
-	const body = lines.slice(2);
-	let sessionIndex = -1;
-	for (let i = body.length - 1; i >= 1; i--) {
-		if (body[i - 1]?.trim() === "" && /^(Session|Session file|Session share error):\s+/.test(body[i]!)) {
-			sessionIndex = i;
-			break;
-		}
-	}
-	const sessionLine = sessionIndex >= 0 ? body[sessionIndex] : undefined;
-	const resultLines = sessionIndex >= 0 ? body.slice(0, sessionIndex) : body;
-	const resultPreview = resultLines.join("\n").trim() || "(no output)";
-	let sessionLabel: string | undefined;
-	let sessionValue: string | undefined;
-	if (sessionLine) {
-		const separator = sessionLine.indexOf(":");
-		sessionLabel = sessionLine.slice(0, separator).toLowerCase();
-		sessionValue = sessionLine.slice(separator + 1).trim();
-	}
-	return {
-		agent: match[2]!,
-		status: match[1] as SubagentNotifyDetails["status"],
-		...(match[3] ? { taskInfo: match[3] } : {}),
-		resultPreview,
-		...(sessionLabel && sessionValue ? { sessionLabel, sessionValue } : {}),
-	};
 }
 
 class SubagentControlNoticeComponent implements Component {
@@ -528,7 +496,7 @@ Use this after launching async subagents when you have no independent work left 
 
 • { } — return as soon as the FIRST active run finishes (default). Ideal for a rolling fleet: launch N, wait, spawn a replacement for the one that finished, then call subagent_wait again — keeping N in flight.
 • { all: true } — block until EVERY active run in this session is finished.
-• { id: "..." } — wait for one specific run (id or prefix) to finish.
+• { id: "..." } — wait for one specific async run or remembered detached foreground run (id or prefix) to finish.
 • { timeoutMs: 600000 } — stop waiting after N ms (the runs keep going regardless; default 30 min)
 
 subagent_wait also returns when a run needs attention (a child that went idle or blocked for a decision), not only on completion — so a stuck child never stalls the loop; the summary names the run(s) to inspect/nudge/resume/interrupt. It wakes the instant a completion or control event arrives (subscribed to Pi's event bus, with a poll fallback that reconciles crashed runners), keeps the turn alive for normal notification delivery, and resolves early if the turn is aborted.${waitToolConfig.enabled ? "" : "\n\nConfigured behavior: subagent_wait is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED and returns immediately without blocking."}`,

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -298,7 +298,7 @@ export const SubagentParams = keepTopLevelParameterDescriptions(SubagentParamsSc
 
 const SubagentWaitParamsSchema = Type.Object({
 	id: Type.Optional(Type.String({
-		description: "Run id or prefix to wait for one specific run. Omit to wait across every active async run started in this session.",
+		description: "Async run or remembered detached foreground run id/prefix to wait for one specific run. Omit to wait across every active async run started in this session.",
 	})),
 	all: Type.Optional(Type.Boolean({
 		description: "Wait for ALL active runs to finish. Default false: return as soon as the first run finishes, so a fleet manager can spawn a replacement and wait again. Ignored when id targets a single run.",

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -264,7 +264,7 @@ function formatDetachedForegroundFleetLines(runs: ForegroundRun[]): string[] {
 		const childSummary = detachedChildren.map((child) => `${child.agent} #${child.index}`).join(", ");
 		lines.push(`- ${run.runId} | detached | ${run.mode}${childSummary ? ` | ${childSummary}` : ""}`);
 		lines.push(`  status: subagent({ action: "status", id: "${run.runId}" })`);
-		lines.push(`  recovery: reply to the supervisor request first; status will recover output after the child exits.`);
+		lines.push(`  recovery: reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); do not resume or launch a replacement while any child remains detached.`);
 	}
 	return lines;
 }
@@ -333,7 +333,7 @@ export function inspectSubagentFleet(_params: FleetViewParams, deps: FleetViewDe
 	const foregroundControls = deps.state ? [...deps.state.foregroundControls.values()] : [];
 	const activeForegroundIds = new Set(foregroundControls.map((control) => control.runId));
 	const detachedForegroundRuns = deps.state?.foregroundRuns
-		? [...deps.state.foregroundRuns.values()].filter((run) => !activeForegroundIds.has(run.runId) && run.children.some((child) => child.status === "detached"))
+		? [...deps.state.foregroundRuns.values()].filter((run) => run.sessionId === deps.state?.currentSessionId && !activeForegroundIds.has(run.runId) && run.children.some((child) => child.status === "detached"))
 		: [];
 	const total = foregroundControls.length + detachedForegroundRuns.length + asyncRuns.length;
 	if (total === 0) {

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -16,7 +16,7 @@ import {
 	createCompletionBatcher,
 	resolveCompletionBatchConfig,
 } from "./completion-batcher.ts";
-import { SUBAGENT_ASYNC_COMPLETE_EVENT, type SubagentState } from "../../shared/types.ts";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT, type SubagentState } from "../../shared/types.ts";
 
 interface ChainStepResult {
 	agent: string;
@@ -27,6 +27,7 @@ interface ChainStepResult {
 export interface SubagentNotifyDetails {
 	agent: string;
 	status: "completed" | "failed" | "paused";
+	source?: "async" | "foreground";
 	taskInfo?: string;
 	resultPreview: string;
 	durationMs?: number;
@@ -36,6 +37,7 @@ export interface SubagentNotifyDetails {
 
 interface SubagentResult {
 	id: string | null;
+	source?: "async" | "foreground";
 	agent: string | null;
 	success: boolean;
 	summary: string;
@@ -72,8 +74,9 @@ function formatSessionLine(details: SubagentNotifyDetails): string | undefined {
 
 export function formatSingleCompletion(details: SubagentNotifyDetails): string {
 	const sessionLine = formatSessionLine(details);
+	const taskKind = details.source === "foreground" ? "Detached foreground task" : "Background task";
 	return [
-		`Background task ${details.status}: **${details.agent}**${details.taskInfo ?? ""}`,
+		`${taskKind} ${details.status}: **${details.agent}**${details.taskInfo ?? ""}`,
 		"",
 		details.resultPreview.trim() ? details.resultPreview : "(no output)",
 		sessionLine ? "" : undefined,
@@ -81,6 +84,37 @@ export function formatSingleCompletion(details: SubagentNotifyDetails): string {
 	]
 		.filter((line) => line !== undefined)
 		.join("\n");
+}
+
+export function parseSubagentNotifyContent(content: string): SubagentNotifyDetails | undefined {
+	const lines = content.split("\n");
+	const match = (lines[0] ?? "").match(/^(Background task|Detached foreground task) (completed|failed|paused): \*\*(.+?)\*\*(?:\s+(\([^)]*\)))?$/);
+	if (!match) return undefined;
+	const body = lines.slice(2);
+	let sessionIndex = -1;
+	for (let i = body.length - 1; i >= 1; i--) {
+		if (body[i - 1]?.trim() === "" && /^(Session|Session file|Session share error):\s+/.test(body[i]!)) {
+			sessionIndex = i;
+			break;
+		}
+	}
+	const sessionLine = sessionIndex >= 0 ? body[sessionIndex] : undefined;
+	const resultPreview = (sessionIndex >= 0 ? body.slice(0, sessionIndex) : body).join("\n").trim() || "(no output)";
+	let sessionLabel: string | undefined;
+	let sessionValue: string | undefined;
+	if (sessionLine) {
+		const separator = sessionLine.indexOf(":");
+		sessionLabel = sessionLine.slice(0, separator).toLowerCase();
+		sessionValue = sessionLine.slice(separator + 1).trim();
+	}
+	return {
+		agent: match[3]!,
+		status: match[2] as SubagentNotifyDetails["status"],
+		...(match[1] === "Detached foreground task" ? { source: "foreground" as const } : {}),
+		...(match[4] ? { taskInfo: match[4] } : {}),
+		resultPreview,
+		...(sessionLabel && sessionValue ? { sessionLabel, sessionValue } : {}),
+	};
 }
 
 export function formatGroupedCompletion(details: SubagentNotifyDetails[]): string {
@@ -147,6 +181,7 @@ export function buildCompletionDetails(result: SubagentResult): SubagentNotifyDe
 	return {
 		agent,
 		status,
+		...(result.source ? { source: result.source } : {}),
 		...(taskInfo ? { taskInfo } : {}),
 		resultPreview: summary,
 		...(typeof result.durationMs === "number" ? { durationMs: result.durationMs } : {}),
@@ -199,6 +234,10 @@ export default function registerSubagentNotify(
 		if (markSeenWithTtl(seen, key, now, ttlMs)) return;
 
 		const details = buildCompletionDetails(result);
+		if (result.source === "foreground") {
+			sendCompletion(pi, [details]);
+			return;
+		}
 		const batchKey = completionBatchKey(result);
 		let batcher = batchers.get(batchKey);
 		if (!batcher) {
@@ -221,5 +260,11 @@ export default function registerSubagentNotify(
 		batcher.push(details);
 	};
 
-	globalStore[unsubscribeStoreKey] = pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, handleComplete);
+	const unsubscribers = [
+		pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, handleComplete),
+		pi.events.on(SUBAGENT_FOREGROUND_COMPLETE_EVENT, handleComplete),
+	].filter((unsubscribe): unsubscribe is () => void => typeof unsubscribe === "function");
+	globalStore[unsubscribeStoreKey] = () => {
+		for (const unsubscribe of unsubscribers) unsubscribe();
+	};
 }

--- a/src/runs/background/run-id-resolver.ts
+++ b/src/runs/background/run-id-resolver.ts
@@ -29,7 +29,19 @@ function exactAsyncLocation(id: string, asyncDirRoot: string, resultsDir: string
 
 function foregroundIds(state: SubagentState | undefined): string[] {
 	if (!state) return [];
-	return [...new Set([...state.foregroundControls.keys(), ...(state.foregroundRuns?.keys() ?? [])])];
+	const remembered = state.currentSessionId
+		? [...(state.foregroundRuns?.values() ?? [])]
+			.filter((run) => run.sessionId === state.currentSessionId)
+			.map((run) => run.runId)
+		: [];
+	return [...new Set([...state.foregroundControls.keys(), ...remembered])];
+}
+
+function hasExactForegroundId(state: SubagentState | undefined, id: string): boolean {
+	if (!state) return false;
+	if (state.foregroundControls.has(id)) return true;
+	const remembered = state.foregroundRuns?.get(id);
+	return Boolean(remembered && state.currentSessionId && remembered.sessionId === state.currentSessionId);
 }
 
 function nestedScopeFromState(state: SubagentState | undefined): NestedRunResolutionScope | undefined {
@@ -58,7 +70,7 @@ export function resolveSubagentRunId(id: string, deps: ResolveSubagentRunIdDeps 
 	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
 
 	const nestedScope = deps.nested ?? nestedScopeFromState(deps.state);
-	if (deps.state?.foregroundControls.has(id) || deps.state?.foregroundRuns?.has(id)) return { kind: "foreground", id };
+	if (hasExactForegroundId(deps.state, id)) return { kind: "foreground", id };
 	const exactAsync = exactAsyncLocation(id, asyncDirRoot, resultsDir);
 	if (exactAsync) return { kind: "async", id, location: exactAsync };
 	const exactNested = findNestedRunMatchesById(id, nestedScope ? { scope: nestedScope } : {});

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -108,6 +108,8 @@ function formatRememberedForegroundStatus(run: ForegroundResumeRun): string {
 			`${child.index + 1}. ${child.agent} ${child.status}`,
 			child.exitCode !== undefined ? `exit ${child.exitCode}` : undefined,
 			child.detachedReason ? `detached: ${child.detachedReason}` : undefined,
+			child.acceptance ? `acceptance: ${child.acceptance.status}` : undefined,
+			child.error ? `error: ${child.error}` : undefined,
 			output ? `output: ${output.slice(0, 160)}` : undefined,
 		].filter(Boolean);
 		lines.push(parts.join(", "));
@@ -121,13 +123,14 @@ function formatRememberedForegroundStatus(run: ForegroundResumeRun): string {
 	lines.push("", `Status: subagent({ action: "status", id: "${run.runId}" })`);
 	if (run.children.length === 1) lines.push(`Transcript: subagent({ action: "status", id: "${run.runId}", view: "transcript" })`);
 	else lines.push(`Transcript: subagent({ action: "status", id: "${run.runId}", index: 0, view: "transcript" })`);
-	const resumable = run.children.find((child) => child.status !== "detached" && hasExistingSessionFile(child.sessionFile));
-	if (resumable) {
+	const detached = run.children.some((child) => child.status === "detached");
+	const resumable = run.children.find((child) => hasExistingSessionFile(child.sessionFile));
+	if (detached) {
+		lines.push(`Recovery: reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); do not resume or launch a replacement while any child remains detached.`);
+	} else if (resumable) {
 		lines.push(run.children.length === 1
 			? `Revive: subagent({ action: "resume", id: "${run.runId}", message: "..." })`
 			: `Revive child: subagent({ action: "resume", id: "${run.runId}", index: ${resumable.index}, message: "..." })`);
-	} else if (run.children.some((child) => child.status === "detached")) {
-		lines.push("Recovery: child detached for intercom coordination; status will show recovered output after the child exits when Pi can observe it.");
 	} else {
 		lines.push("Resume: unavailable; no child session file was persisted.");
 	}

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -1,6 +1,6 @@
 /**
- * `subagent_wait` tool: block the current turn until outstanding async
- * subagent runs finish (or another completion notification arrives).
+ * `subagent_wait` tool: block the current turn until outstanding async runs
+ * or a named remembered detached foreground run finishes.
  *
  * Background subagent runs are detached. In an interactive session the parent
  * can end its turn and Pi will wake it with a completion notification. That
@@ -18,8 +18,8 @@
  * manager can use it in a rolling-replacement loop: launch N workers, wait for
  * the next one to finish, spawn its replacement, then call `subagent_wait`
  * again — keeping N in flight instead of draining to zero between batches.
- * Pass `all: true` to block until every tracked run is terminal, or `id` to
- * block on one specific run.
+ * Pass `all: true` to block until every tracked async run is terminal, or `id`
+ * to block on one specific async or remembered detached foreground run.
  *
  * `subagent_wait` also returns when a run needs attention — not just on
  * completion. A child that goes idle or blocks for a decision surfaces
@@ -44,10 +44,12 @@ import {
 	ASYNC_DIR,
 	RESULTS_DIR,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
+	SUBAGENT_FOREGROUND_COMPLETE_EVENT,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_RESULT_INTERCOM_EVENT,
 	type Details,
+	type ForegroundResumeRun,
 	type SubagentState,
 	type WaitToolConfig,
 } from "../../shared/types.ts";
@@ -137,6 +139,7 @@ export interface SubagentWaitDeps {
 /** Bus channels that indicate a run changed state or needs attention. */
 const WAKE_CHANNELS = [
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
+	SUBAGENT_FOREGROUND_COMPLETE_EVENT,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_RESULT_INTERCOM_EVENT,
@@ -201,6 +204,26 @@ function matchesId(run: AsyncRunSummary, id: string): boolean {
 	return run.id === id || run.id.startsWith(id);
 }
 
+function activeDetachedForegroundRuns(params: SubagentWaitParams, deps: SubagentWaitDeps): ForegroundResumeRun[] {
+	if (!params.id || !deps.state.foregroundRuns) return [];
+	const sessionId = deps.state.currentSessionId;
+	if (!sessionId) return [];
+	return [...deps.state.foregroundRuns.values()].filter((run) =>
+		(run.runId === params.id || run.runId.startsWith(params.id!))
+		&& run.sessionId === sessionId
+		&& run.children.some((child) => child.status === "detached")
+	);
+}
+
+function summarizeForegroundChildren(run: ForegroundResumeRun, indices: Set<number>): string {
+	const counts = new Map<string, number>();
+	for (const child of run.children) {
+		if (!indices.has(child.index) || child.status === "detached") continue;
+		counts.set(child.status, (counts.get(child.status) ?? 0) + 1);
+	}
+	return [...counts.entries()].map(([status, count]) => `${count} ${status}`).join(", ");
+}
+
 /** A running run that has flagged it needs the parent's attention. */
 function needsAttention(run: AsyncRunSummary): boolean {
 	return run.activityState === "needs_attention";
@@ -259,9 +282,48 @@ function result(text: string, isError = false): AgentToolResult<Details> {
 	};
 }
 
+async function waitForDetachedForegroundRun(
+	run: ForegroundResumeRun,
+	signal: AbortSignal | undefined,
+	deps: SubagentWaitDeps,
+	startedAt: number,
+	now: () => number,
+	pollIntervalMs: number,
+	timeoutMs: number,
+): Promise<AgentToolResult<Details>> {
+	const initialDetachedIndices = new Set(run.children.filter((child) => child.status === "detached").map((child) => child.index));
+	while (true) {
+		if (deps.state.currentSessionId !== run.sessionId) {
+			return result(`Wait stopped because the active session changed while remembered foreground run "${run.runId}" was still detached. Return to the originating session to inspect or wait for it.`, true);
+		}
+		const current = deps.state.foregroundRuns?.get(run.runId);
+		if (!current || current.sessionId !== run.sessionId) {
+			return result(`Remembered foreground run "${run.runId}" disappeared before a terminal child result was recorded. Completion cannot be confirmed; do not launch a replacement without checking the originating child session.`, true);
+		}
+		const pending = current.children.filter((child) => initialDetachedIndices.has(child.index) && child.status === "detached");
+		if (pending.length === 0) {
+			const outcome = summarizeForegroundChildren(current, initialDetachedIndices);
+			return result(
+				`Waited ${formatDuration(now() - startedAt)} for remembered detached foreground run "${run.runId}"; done. Outcome: ${outcome || "no recovered child status"}. Completion event observed; inspect with subagent({ action: "status", id: "${run.runId}" }) for recovered output.`,
+			);
+		}
+		if (signal?.aborted) {
+			return result(`Wait aborted after ${formatDuration(now() - startedAt)}. Remembered foreground run "${run.runId}" remains detached.`, true);
+		}
+		if (now() - startedAt >= timeoutMs) {
+			return result(
+				`Wait timed out after ${formatDuration(timeoutMs)} with remembered foreground run "${run.runId}" still detached. Reply to any pending supervisor request, then call subagent_wait({ id: "${run.runId}" }) again or inspect status; do not resume or launch a replacement while it remains detached.`,
+				true,
+			);
+		}
+		await waitForWake(pollIntervalMs, signal, deps);
+	}
+}
+
 /**
- * Block until the targeted async runs finish, the timeout elapses, or the turn
- * is aborted. Resolves with a short human-readable summary either way.
+ * Block until the targeted async or remembered detached foreground run finishes,
+ * the timeout elapses, or the turn is aborted. Resolves with a short
+ * human-readable summary either way.
  */
 export async function waitForSubagents(
 	params: SubagentWaitParams,
@@ -282,10 +344,29 @@ export async function waitForSubagents(
 	const waitForAll = params.id ? true : params.all === true;
 
 	let active: AsyncRunSummary[];
+	let foreground: ForegroundResumeRun[];
 	try {
 		active = activeRunsForSession(params, deps);
+		foreground = activeDetachedForegroundRuns(params, deps);
 	} catch (error) {
 		return result(error instanceof Error ? error.message : String(error), true);
+	}
+
+	if (params.id) {
+		const candidates = [
+			...active.map((run) => ({ kind: "async" as const, id: run.id, run })),
+			...foreground.map((run) => ({ kind: "foreground" as const, id: run.runId, run })),
+		];
+		const exact = candidates.filter((candidate) => candidate.id === params.id);
+		const matches = exact.length > 0 ? exact : candidates;
+		if (matches.length > 1) {
+			return result(`Ambiguous subagent run id prefix "${params.id}" matched ${matches.length} active runs: ${matches.map((candidate) => candidate.id).join(", ")}. Pass a longer id.`, true);
+		}
+		const selected = matches[0];
+		if (selected?.kind === "foreground") {
+			return waitForDetachedForegroundRun(selected.run, signal, deps, startedAt, now, pollIntervalMs, timeoutMs);
+		}
+		active = selected?.kind === "async" ? [selected.run] : [];
 	}
 
 	if (active.length === 0) {
@@ -293,13 +374,6 @@ export async function waitForSubagents(
 			? `No active run matched "${params.id}". Nothing to wait for.`
 			: "No active async runs in this session. Nothing to wait for.";
 		return result(finished);
-	}
-	if (params.id) {
-		const exact = active.filter((run) => run.id === params.id);
-		if (exact.length === 1) active = exact;
-		else if (active.length > 1) {
-			return result(`Ambiguous async run id prefix "${params.id}" matched ${active.length} active runs: ${active.map((run) => run.id).join(", ")}. Pass a longer id.`, true);
-		}
 	}
 	const waitParams = params.id ? { ...params, id: active[0]!.id } : params;
 

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -768,7 +768,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				const detached = detachedIndexInStep >= 0 ? parallelResults[detachedIndexInStep] : undefined;
 				if (detached) {
 					return {
-						content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${detached.agent}). Reply to the supervisor request first. Status: subagent({ action: "status", id: "${runId}" }). After the child exits, start a fresh follow-up if needed.` }],
+						content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${detached.agent}). Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.` }],
 						details: buildChainExecutionDetails(makeDetailsInput({
 							currentStepIndex: stepIndex,
 							currentFlatIndex: globalTaskIndex - step.parallel.length + detachedIndexInStep,
@@ -988,7 +988,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			const detached = detachedIndexInStep >= 0 ? parallelResults[detachedIndexInStep] : undefined;
 			if (detached) {
 				return {
-					content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${detached.agent}). Reply to the supervisor request first. Status: subagent({ action: "status", id: "${runId}" }). After the child exits, start a fresh follow-up if needed.` }],
+					content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${detached.agent}). Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.` }],
 					details: buildChainExecutionDetails(makeDetailsInput({
 						currentStepIndex: stepIndex,
 						currentFlatIndex: dynamicStartIndex + detachedIndexInStep,
@@ -1264,7 +1264,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			}
 			if (r.detached) {
 				return {
-					content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${r.agent}). Reply to the supervisor request first. Status: subagent({ action: "status", id: "${runId}" }). After the child exits, start a fresh follow-up if needed.` }],
+					content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${r.agent}). Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.` }],
 					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: childIndex })),
 				};
 			}

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -110,6 +110,18 @@ function resolveAttemptTimeout(options: RunSyncOptions): { timeoutMs: number; re
 	};
 }
 
+function buildPendingAcceptanceLedger(acceptance: ResolvedAcceptanceConfig): AcceptanceLedger {
+	return {
+		status: "pending",
+		explicit: acceptance.explicit,
+		effectiveAcceptance: acceptance,
+		inferredReason: acceptance.inferredReason,
+		criteria: acceptance.criteria,
+		runtimeChecks: [],
+		verifyRuns: [],
+	};
+}
+
 function buildSkippedAcceptanceLedger(acceptance: ResolvedAcceptanceConfig, input: { id: string; message: string }): AcceptanceLedger {
 	return {
 		status: acceptance.level === "none" ? "not-required" : "rejected",
@@ -851,7 +863,12 @@ async function runSingleAttempt(
 					tokens: recoveredProgress.tokens,
 					durationMs: recoveredProgress.durationMs,
 				};
-				let fullOutput = stripAcceptanceReport(getFinalOutput(recoveredResult.messages ?? []));
+				const acceptanceOutput = getFinalOutput(recoveredResult.messages ?? []).trim()
+					|| recoveredResult.error
+					|| recoveredResult.finalOutput
+					|| "Detached child exited without final output.";
+				acceptanceOutputByResult.set(recoveredResult, acceptanceOutput);
+				let fullOutput = stripAcceptanceReport(acceptanceOutput);
 				fullOutput = fullOutput.trim() || recoveredResult.error || recoveredResult.finalOutput || "Detached child exited without final output.";
 				recoveredResult.outputMode = options.outputMode ?? "inline";
 				if (options.outputPath && recoveredResult.exitCode === 0) {
@@ -1198,12 +1215,49 @@ export async function runSync(
 		}
 	}
 
+	const detachedAwareOptions: RunSyncOptions = options.onDetachedExit
+		? {
+			...options,
+			onDetachedExit: (recoveredResult) => {
+				void (async () => {
+					const childWrittenOutput = options.outputPath
+						? extractChildWrittenOutput(recoveredResult.messages, options.outputPath, options.cwd ?? runtimeCwd)
+						: undefined;
+					recoveredResult.acceptance = await evaluateAcceptance({
+						acceptance: effectiveAcceptance,
+						output: acceptanceOutputByResult.get(recoveredResult) ?? recoveredResult.finalOutput ?? "",
+						fileOutput: childWrittenOutput !== undefined && options.outputPath
+							? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
+							: undefined,
+						cwd: options.cwd ?? runtimeCwd,
+					});
+					const acceptanceFailure = acceptanceFailureMessage(recoveredResult.acceptance);
+					stripAcceptanceReportsFromMessages(recoveredResult.messages);
+					if (acceptanceFailure && recoveredResult.acceptance.explicit && recoveredResult.exitCode === 0) {
+						recoveredResult.exitCode = 1;
+						recoveredResult.error = recoveredResult.error ? `${recoveredResult.error}\n${acceptanceFailure}` : acceptanceFailure;
+						if (recoveredResult.progress) {
+							recoveredResult.progress.status = "failed";
+							recoveredResult.progress.error = recoveredResult.error;
+						}
+					}
+					options.onDetachedExit?.(recoveredResult);
+				})().catch((error) => {
+					const message = error instanceof Error ? error.message : String(error);
+					recoveredResult.exitCode = 1;
+					recoveredResult.error = recoveredResult.error ? `${recoveredResult.error}\nAcceptance evaluation failed: ${message}` : `Acceptance evaluation failed: ${message}`;
+					options.onDetachedExit?.(recoveredResult);
+				});
+			},
+		}
+		: options;
+
 	let lastResult: SingleResult | undefined;
 	const modelsToTry = candidates.length > 0 ? candidates : [undefined];
 	for (let i = 0; i < modelsToTry.length; i++) {
 		const candidate = modelsToTry[i];
 		const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
-		const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, options, {
+		const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, detachedAwareOptions, {
 			sessionEnabled,
 			systemPrompt,
 			resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
@@ -1317,7 +1371,7 @@ export async function runSync(
 		? extractChildWrittenOutput(result.messages, options.outputPath, options.cwd ?? runtimeCwd)
 		: undefined;
 	result.acceptance = result.detached
-		? buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "detached", message: "Acceptance was not evaluated because the subagent detached for intercom coordination before task completion." })
+		? buildPendingAcceptanceLedger(effectiveAcceptance)
 		: result.timedOut
 			? buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." })
 			: result.turnBudgetExceeded

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -102,6 +102,7 @@ import {
 	SUBAGENT_ACTIONS,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
+	SUBAGENT_FOREGROUND_COMPLETE_EVENT,
 	checkSubagentDepth,
 	resolveMaxSubagentSpawnsPerSession,
 	resolveTopLevelParallelConcurrency,
@@ -213,6 +214,7 @@ interface ExecutionContextData {
 	configToolBudget?: ResolvedToolBudget;
 	contextPolicy: AgentDefaultContextPolicy;
 	modelScope?: ModelScopeConfig;
+	parentSessionId: string | null;
 }
 
 function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefined): string {
@@ -320,13 +322,15 @@ function foregroundStatusResult(control: SubagentState["foregroundControls"] ext
 function trimRememberedForegroundRuns(state: SubagentState): void {
 	if (!state.foregroundRuns) return;
 	while (state.foregroundRuns.size > 50) {
-		const oldest = [...state.foregroundRuns.values()].sort((left, right) => left.updatedAt - right.updatedAt)[0];
-		if (!oldest) break;
-		state.foregroundRuns.delete(oldest.runId);
+		const oldestTerminal = [...state.foregroundRuns.values()]
+			.filter((run) => !run.children.some((child) => child.status === "detached"))
+			.sort((left, right) => left.updatedAt - right.updatedAt)[0];
+		if (!oldestTerminal) break;
+		state.foregroundRuns.delete(oldestTerminal.runId);
 	}
 }
 
-function rememberForegroundRun(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; results: SingleResult[] }): void {
+function rememberForegroundRun(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; results: SingleResult[] }): void {
 	state.foregroundRuns ??= new Map();
 	const previous = state.foregroundRuns.get(input.runId);
 	const updatedAt = Date.now();
@@ -334,6 +338,7 @@ function rememberForegroundRun(state: SubagentState, input: { runId: string; mod
 		runId: input.runId,
 		mode: input.mode,
 		cwd: input.cwd,
+		...(input.sessionId ? { sessionId: input.sessionId } : {}),
 		updatedAt,
 		children: input.results.map((result, index) => {
 			const child = {
@@ -342,6 +347,7 @@ function rememberForegroundRun(state: SubagentState, input: { runId: string; mod
 				status: resolveSubagentResultStatus({ exitCode: result.exitCode, interrupted: result.interrupted, detached: result.detached }),
 				updatedAt,
 				...(result.exitCode !== undefined ? { exitCode: result.exitCode } : {}),
+				...(result.error ? { error: result.error } : {}),
 				...(result.finalOutput ? { finalOutput: result.finalOutput } : {}),
 				...(result.outputMode ? { outputMode: result.outputMode } : {}),
 				...(result.savedOutputPath ? { savedOutputPath: result.savedOutputPath } : {}),
@@ -351,6 +357,7 @@ function rememberForegroundRun(state: SubagentState, input: { runId: string; mod
 				...(result.transcriptPath ? { transcriptPath: result.transcriptPath } : {}),
 				...(result.transcriptError ? { transcriptError: result.transcriptError } : {}),
 				...(result.detachedReason ? { detachedReason: result.detachedReason } : {}),
+				...(result.acceptance ? { acceptance: result.acceptance } : {}),
 			};
 			const recovered = previous?.children[index];
 			return child.status === "detached" && recovered && recovered.status !== "detached" ? recovered : child;
@@ -359,12 +366,12 @@ function rememberForegroundRun(state: SubagentState, input: { runId: string; mod
 	trimRememberedForegroundRuns(state);
 }
 
-function updateRememberedForegroundChild(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; index: number; result: SingleResult }): void {
+function updateRememberedForegroundChild(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; index: number; result: SingleResult; events: IntercomEventBus }): void {
 	state.foregroundRuns ??= new Map();
 	const updatedAt = Date.now();
 	let run = state.foregroundRuns.get(input.runId);
 	if (!run) {
-		run = { runId: input.runId, mode: input.mode, cwd: input.cwd, updatedAt, children: [] };
+		run = { runId: input.runId, mode: input.mode, cwd: input.cwd, ...(input.sessionId ? { sessionId: input.sessionId } : {}), updatedAt, children: [] };
 		state.foregroundRuns.set(input.runId, run);
 	}
 	run.updatedAt = updatedAt;
@@ -373,9 +380,12 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		...child,
 		agent: input.result.agent,
 		index: input.index,
-		status: resolveSubagentResultStatus({ exitCode: input.result.exitCode, interrupted: input.result.interrupted, detached: false }),
+		status: input.result.acceptance?.status === "rejected"
+			? "failed"
+			: resolveSubagentResultStatus({ exitCode: input.result.exitCode, interrupted: input.result.interrupted, detached: false }),
 		updatedAt,
 		...(input.result.exitCode !== undefined ? { exitCode: input.result.exitCode } : {}),
+		...(input.result.error ? { error: input.result.error } : {}),
 		...(input.result.finalOutput ? { finalOutput: input.result.finalOutput } : {}),
 		outputMode: input.result.outputMode,
 		savedOutputPath: input.result.savedOutputPath,
@@ -385,24 +395,47 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		...(input.result.transcriptPath ? { transcriptPath: input.result.transcriptPath } : {}),
 		...(input.result.transcriptError ? { transcriptError: input.result.transcriptError } : {}),
 		...(input.result.detachedReason ? { detachedReason: input.result.detachedReason } : {}),
+		...(input.result.acceptance ? { acceptance: input.result.acceptance } : {}),
 	};
 	trimRememberedForegroundRuns(state);
+	const output = getSingleResultOutput(input.result).trim();
+	const success = input.result.exitCode === 0 && input.result.acceptance?.status !== "rejected";
+	const summary = !success && input.result.error
+		? `${input.result.error}${output ? `\n\nOutput:\n${output}` : ""}`
+		: output || input.result.error || "Detached child exited without final output.";
+	input.events.emit(SUBAGENT_FOREGROUND_COMPLETE_EVENT, {
+		id: `${input.runId}:${input.index}`,
+		runId: input.runId,
+		source: "foreground",
+		mode: input.mode,
+		agent: input.result.agent,
+		success,
+		summary,
+		exitCode: input.result.exitCode,
+		state: success ? "complete" : "failed",
+		timestamp: updatedAt,
+		cwd: input.cwd,
+		sessionFile: input.result.sessionFile,
+		sessionId: input.sessionId,
+		taskIndex: input.index,
+	});
 }
 
 function resolveForegroundResumeTarget(params: SubagentParamsLike, state: SubagentState): { runId: string; mode: "single" | "parallel" | "chain"; state: "complete"; agent: string; index: number; intercomTarget: string; cwd: string; sessionFile: string } | undefined {
 	const requested = (params.id ?? params.runId)?.trim();
-	if (!requested || !state.foregroundRuns?.size) return undefined;
-	const direct = state.foregroundRuns.get(requested);
-	const matches = direct ? [direct] : [...state.foregroundRuns.values()].filter((run) => run.runId.startsWith(requested));
+	if (!requested || !state.foregroundRuns?.size || !state.currentSessionId) return undefined;
+	const sessionRuns = [...state.foregroundRuns.values()].filter((run) => run.sessionId === state.currentSessionId);
+	const direct = sessionRuns.find((run) => run.runId === requested);
+	const matches = direct ? [direct] : sessionRuns.filter((run) => run.runId.startsWith(requested));
 	if (matches.length === 0) return undefined;
 	if (matches.length > 1) throw new Error(`Ambiguous foreground run id prefix '${requested}' matched: ${matches.map((run) => run.runId).join(", ")}. Provide a longer id.`);
 	const run = matches[0]!;
+	if (run.children.some((child) => child.status === "detached")) throw new Error(`Foreground run '${run.runId}' is detached for intercom coordination and cannot be revived safely while any child may still be live. Reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); use status to recover the result and do not launch a replacement while it remains detached.`);
 	if (run.children.length > 1 && params.index === undefined) throw new Error(`Foreground run '${run.runId}' has ${run.children.length} children. Provide index to choose one.`);
 	const index = params.index ?? 0;
 	if (!Number.isInteger(index)) throw new Error(`Foreground run '${run.runId}' index must be an integer.`);
 	if (index < 0 || index >= run.children.length) throw new Error(`Foreground run '${run.runId}' has ${run.children.length} children. Index ${index} is out of range.`);
 	const child = run.children[index]!;
-	if (child.status === "detached") throw new Error(`Foreground run '${run.runId}' child ${index} is detached for intercom coordination and cannot be revived safely from the remembered foreground state. Reply to the supervisor request first; after the child exits, start a fresh follow-up if needed.`);
 	if (!child.sessionFile) throw new Error(`Foreground run '${run.runId}' child ${index} does not have a persisted session file to resume from.`);
 	if (path.extname(child.sessionFile) !== ".jsonl") throw new Error(`Foreground run '${run.runId}' child ${index} session file must be a .jsonl file: ${child.sessionFile}`);
 	const sessionFile = path.resolve(child.sessionFile);
@@ -1028,6 +1061,7 @@ async function resumeAsyncRun(input: {
 			details: { mode: "management", results: [] },
 		};
 	}
+	input.deps.state.currentSessionId = resolveCurrentSessionId(input.ctx.sessionManager);
 
 	let target: ResumeSourceTarget;
 	const parentSessionFile = input.ctx.sessionManager.getSessionFile() ?? null;
@@ -2089,7 +2123,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		timeoutMs: data.timeoutMs,
 		deadlineAt: data.deadlineAt,
 		turnBudget: data.turnBudget,
-		onDetachedExit: (index, result) => updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, index, result }),
+		onDetachedExit: (index, result) => updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, index, result, events: deps.pi.events }),
 		toolBudget: data.toolBudget,
 		configToolBudget: data.configToolBudget,
 		globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
@@ -2153,7 +2187,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		rawChainDetails.totalCost = sumResultsCost(rawChainDetails.results);
 	}
 	const chainDetails = rawChainDetails ? compactForegroundDetails(rawChainDetails) : undefined;
-	if (chainDetails) rememberForegroundRun(deps.state, { runId, mode: "chain", cwd: effectiveCwd, results: chainDetails.results });
+	if (chainDetails) rememberForegroundRun(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, results: chainDetails.results });
 	const intercomReceipt = chainDetails && !chainDetails.results.some((result) => result.interrupted || result.detached)
 		? await maybeBuildForegroundIntercomReceipt({
 			pi: deps.pi,
@@ -2182,6 +2216,7 @@ interface ForegroundParallelRunInput {
 	ctx: ExtensionContext;
 	state: SubagentState;
 	intercomEvents: IntercomEventBus;
+	parentSessionId: string | null;
 	signal: AbortSignal;
 	runId: string;
 	sessionDirForIndex: (idx?: number) => string | undefined;
@@ -2383,7 +2418,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			maxSubagentDepth: input.maxSubagentDepths[index],
 			controlConfig: input.controlConfig,
 			onControlEvent: input.onControlEvent,
-			onDetachedExit: (result) => updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, index, result }),
+			onDetachedExit: (result) => updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents }),
 			intercomSessionName: input.childIntercomTarget?.(task.agent, index),
 			orchestratorIntercomTarget: input.orchestratorIntercomTarget,
 			nestedRoute: input.foregroundControl?.nestedRoute,
@@ -2683,6 +2718,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			ctx,
 			state: deps.state,
 			intercomEvents: deps.pi.events,
+			parentSessionId: data.parentSessionId,
 			signal,
 			runId,
 			sessionDirForIndex,
@@ -2742,7 +2778,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			totalChildUsage: sumResultsUsage(results),
 			totalCost: sumResultsCost(results),
 		});
-		rememberForegroundRun(deps.state, { runId, mode: "parallel", cwd: effectiveCwd, results: details.results });
+		rememberForegroundRun(deps.state, { runId, mode: "parallel", cwd: effectiveCwd, sessionId: data.parentSessionId, results: details.results });
 		if (interrupted) {
 			return {
 				content: [{ type: "text", text: `Parallel run paused after interrupt (${interrupted.agent}). Waiting for explicit next action.` }],
@@ -2753,7 +2789,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		const detached = detachedIndex >= 0 ? results[detachedIndex] : undefined;
 		if (detached) {
 			return {
-				content: [{ type: "text", text: `Parallel run detached for intercom coordination (${detached.agent}). Reply to the supervisor request first. Status: subagent({ action: "status", id: "${runId}" }). After the child exits, start a fresh follow-up if needed.` }],
+				content: [{ type: "text", text: `Parallel run detached for intercom coordination (${detached.agent}). Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.` }],
 				details,
 			};
 		}
@@ -3022,7 +3058,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		skills: effectiveSkills,
 		acceptance: params.acceptance,
 		acceptanceContext: { mode: "single" },
-		onDetachedExit: (result) => updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, index: 0, result }),
+		onDetachedExit: (result) => updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events }),
 		timeoutMs: data.timeoutMs,
 		deadlineAt,
 		turnBudget: data.turnBudget,
@@ -3072,7 +3108,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		totalChildUsage: sumResultsUsage([r]),
 		totalCost: sumResultsCost([r]),
 	});
-	rememberForegroundRun(deps.state, { runId, mode: "single", cwd: effectiveCwd, results: details.results });
+	rememberForegroundRun(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, results: details.results });
 
 	if (!r.detached && !r.interrupted) {
 		if (foregroundControl) updateForegroundNestedProjection(foregroundControl);
@@ -3095,7 +3131,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 
 	if (r.detached) {
 		return {
-			content: [{ type: "text", text: `Detached for intercom coordination: ${params.agent}. Reply to the supervisor request first. Status: subagent({ action: "status", id: "${runId}" }). After the child exits, start a fresh follow-up if needed.` }],
+			content: [{ type: "text", text: `Detached for intercom coordination: ${params.agent}. Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.` }],
 			details,
 		};
 	}
@@ -3222,6 +3258,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				};
 			}
 			if (action === "status") {
+				deps.state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
 				const targetRunId = paramsWithResolvedCwd.id ?? paramsWithResolvedCwd.runId;
 				const nestedScope = nestedResolutionScopeForExecutor(deps);
 				const sessionRoots = trustedSessionRootsForStatus(ctx, deps);
@@ -3573,6 +3610,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			configToolBudget: configToolBudget.toolBudget,
 			contextPolicy,
 			modelScope,
+			parentSessionId: deps.state.currentSessionId,
 		};
 
 		const foregroundControl = effectiveAsync

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -442,6 +442,7 @@ export interface AcceptanceReviewResult {
 }
 
 export type AcceptanceLedgerStatus =
+	| "pending"
 	| "not-required"
 	| "claimed"
 	| "attested"
@@ -839,6 +840,7 @@ export interface ForegroundResumeChild {
 	sessionFile?: string;
 	status: SubagentResultStatus;
 	exitCode?: number;
+	error?: string;
 	finalOutput?: string;
 	outputMode?: OutputMode;
 	savedOutputPath?: string;
@@ -847,6 +849,7 @@ export interface ForegroundResumeChild {
 	transcriptPath?: string;
 	transcriptError?: string;
 	detachedReason?: string;
+	acceptance?: AcceptanceLedger;
 	updatedAt?: number;
 }
 
@@ -854,6 +857,8 @@ export interface ForegroundResumeRun {
 	runId: string;
 	mode: SubagentRunMode;
 	cwd: string;
+	/** Originating parent session. Detached exits can outlive the active session. */
+	sessionId?: string;
 	updatedAt: number;
 	children: ForegroundResumeChild[];
 }
@@ -926,6 +931,7 @@ export const INTERCOM_DETACH_REQUEST_EVENT = "pi-intercom:detach-request";
 export const INTERCOM_DETACH_RESPONSE_EVENT = "pi-intercom:detach-response";
 export const SUBAGENT_ASYNC_STARTED_EVENT = "subagent:async-started";
 export const SUBAGENT_ASYNC_COMPLETE_EVENT = "subagent:async-complete";
+export const SUBAGENT_FOREGROUND_COMPLETE_EVENT = "subagent:foreground-complete";
 export const SUBAGENT_CONTROL_EVENT = "subagent:control-event";
 export const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 export const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -1420,7 +1420,7 @@ describe("chain execution — parallel steps", { skip: !available ? "pi packages
 
 		assert.equal(result.isError, undefined);
 		assert.match(result.content[0]?.text ?? "", /Chain detached for intercom coordination/);
-		assert.doesNotMatch(result.content[0]?.text ?? "", /resume/);
+		assert.match(result.content[0]?.text ?? "", /do not resume or launch a replacement/);
 		assert.equal(detachEmitted, true);
 		assert.equal(result.details.results.some((entry) => entry.detached === true && entry.exitCode === -2), true);
 	});
@@ -1460,7 +1460,7 @@ describe("chain execution — parallel steps", { skip: !available ? "pi packages
 
 		assert.equal(result.isError, undefined);
 		assert.match(result.content[0]?.text ?? "", /Chain detached for intercom coordination/);
-		assert.doesNotMatch(result.content[0]?.text ?? "", /resume/);
+		assert.match(result.content[0]?.text ?? "", /do not resume or launch a replacement/);
 		assert.equal(detachEmitted, true);
 		assert.equal(mockPi.callCount(), 1);
 	});

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -3,7 +3,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { after, afterEach, before, beforeEach, describe, it } from "node:test";
-import { ASYNC_DIR, INTERCOM_DETACH_REQUEST_EVENT, RESULTS_DIR, SUBAGENT_ASYNC_STARTED_EVENT } from "../../src/shared/types.ts";
+import { ASYNC_DIR, INTERCOM_DETACH_REQUEST_EVENT, RESULTS_DIR, SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT } from "../../src/shared/types.ts";
+import { waitForSubagents } from "../../src/runs/background/subagent-wait.ts";
 import type { MockPi } from "../support/helpers.ts";
 import {
 	createMockPi,
@@ -21,7 +22,7 @@ interface ExecutorResult {
 	details?: {
 		mode?: string;
 		runId?: string;
-		results?: Array<{ agent?: string; finalOutput?: string }>;
+		results?: Array<{ agent?: string; finalOutput?: string; acceptance?: { status?: string } }>;
 		asyncId?: string;
 	};
 }
@@ -317,7 +318,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 		assert.equal(detachEmitted, true);
 		assert.match(result.content[0]?.text ?? "", /Chain detached for intercom coordination/);
-		assert.doesNotMatch(result.content[0]?.text ?? "", /resume/);
+		assert.match(result.content[0]?.text ?? "", /do not resume or launch a replacement/);
 		assert.equal(bus.emitted.some((entry) => entry.channel === "subagent:result-intercom"), false);
 		assert.equal(mockPi.callCount(), 1);
 	});
@@ -681,6 +682,144 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.match(transcriptText, /final recovered answer/);
 	});
 
+	it("keeps detached acceptance pending and emits recovered foreground completion to the originating session", async () => {
+		const acceptanceReport = [
+			"final recovered answer",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "review completed" }],
+				changedFiles: ["src/review.ts"],
+				testsAddedOrUpdated: ["test/review.test.ts"],
+				commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+				validationOutput: ["npm test passed"],
+				residualRisks: [],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n");
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need a decision" })] },
+				{ delay: 75, jsonl: [events.assistantMessage(acceptanceReport)] },
+			],
+		});
+		const { executor, events: bus, state } = makeExecutor({ agents: [makeAgent("a", { systemPrompt: "Intercom orchestration channel:" })] });
+		let detachEmitted = false;
+		const original = await executor.execute(
+			"foreground-detached-completion-original",
+			{ agent: "a", task: "ask supervisor", acceptance: { level: "checked", criteria: ["Review completed"] } },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ currentTool?: string }> } }) => {
+				if (detachEmitted || !update.details?.progress?.some((entry) => entry.currentTool === "contact_supervisor")) return;
+				detachEmitted = true;
+				bus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "single-detached-completion" });
+			},
+			makeMinimalCtx(tempDir),
+		);
+		const runId = original.details?.runId;
+		assert.ok(runId, "expected foreground run id");
+		assert.equal(original.details?.results?.[0]?.acceptance?.status, "pending");
+		assert.match(original.content[0]?.text ?? "", /subagent_wait\(\{ id:/);
+
+		const waited = await waitForSubagents({ id: runId, timeoutMs: 5000 }, undefined, {
+			state: state as never,
+			events: bus,
+			asyncDirRoot: path.join(tempDir, "async-runs"),
+			resultsDir: path.join(tempDir, "results"),
+		});
+		assert.equal(waited.isError, undefined);
+		assert.match(waited.content[0]?.text ?? "", /remembered detached foreground run/);
+
+		const completion = bus.emitted.find((event) => event.channel === SUBAGENT_FOREGROUND_COMPLETE_EVENT);
+		assert.ok(completion, "expected a foreground completion event");
+		const payload = completion.payload as {
+			runId?: string;
+			sessionId?: string;
+			source?: string;
+			summary?: string;
+			success?: boolean;
+		};
+		assert.equal(payload.runId, runId);
+		assert.equal(payload.sessionId, "session-123");
+		assert.equal(payload.source, "foreground");
+		assert.equal(payload.success, true);
+		assert.match(payload.summary ?? "", /final recovered answer/);
+
+		const status = await executor.execute(
+			"foreground-detached-completion-status",
+			{ action: "status", id: runId },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.match(status.content[0]?.text ?? "", /acceptance: checked/);
+	});
+
+	it("preserves deferred acceptance failure details in foreground completion and status", async () => {
+		const rejectedReport = [
+			"final answer with rejected acceptance evidence",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "not-satisfied", evidence: "review found a blocker" }],
+				changedFiles: ["src/review.ts"],
+				testsAddedOrUpdated: ["test/review.test.ts"],
+				commandsRun: [{ command: "npm test", result: "failed", summary: "blocker remains" }],
+				validationOutput: ["blocker remains"],
+				residualRisks: ["review blocker"],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n");
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need a decision" })] },
+				{ delay: 75, jsonl: [events.assistantMessage(rejectedReport)] },
+			],
+		});
+		const { executor, events: bus, state } = makeExecutor({ agents: [makeAgent("a", { systemPrompt: "Intercom orchestration channel:" })] });
+		let detachEmitted = false;
+		const original = await executor.execute(
+			"foreground-detached-failed-acceptance",
+			{ agent: "a", task: "ask supervisor", acceptance: { level: "checked", criteria: ["Review completed"] } },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ currentTool?: string }> } }) => {
+				if (detachEmitted || !update.details?.progress?.some((entry) => entry.currentTool === "contact_supervisor")) return;
+				detachEmitted = true;
+				bus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "single-detached-failed-acceptance" });
+			},
+			makeMinimalCtx(tempDir),
+		);
+		const runId = original.details?.runId;
+		assert.ok(runId);
+		assert.equal(original.details?.results?.[0]?.acceptance?.status, "pending");
+
+		const waited = await waitForSubagents({ id: runId, timeoutMs: 5000 }, undefined, {
+			state: state as never,
+			events: bus,
+			asyncDirRoot: path.join(tempDir, "async-runs"),
+			resultsDir: path.join(tempDir, "results"),
+		});
+		assert.equal(waited.isError, undefined);
+		assert.match(waited.content[0]?.text ?? "", /1 failed/);
+
+		const completion = bus.emitted.find((event) => event.channel === SUBAGENT_FOREGROUND_COMPLETE_EVENT);
+		assert.ok(completion);
+		const payload = completion.payload as { success?: boolean; summary?: string };
+		assert.equal(payload.success, false);
+		assert.match(payload.summary ?? "", /Acceptance rejected/);
+		assert.match(payload.summary ?? "", /final answer with rejected acceptance evidence/);
+
+		const status = await executor.execute(
+			"foreground-detached-failed-status",
+			{ action: "status", id: runId },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.match(status.content[0]?.text ?? "", /acceptance: rejected/);
+		assert.match(status.content[0]?.text ?? "", /error: Acceptance rejected/);
+	});
+
 	it("status recovers remembered detached chain output after child exit", async () => {
 		mockPi.onCall({
 			steps: [
@@ -797,6 +936,45 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.match(transcript.content[0]?.text ?? "", /second recovered answer/);
 	});
 
+	it("blocks sibling resume while any remembered foreground child remains detached", async () => {
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("a"), makeAgent("b")] });
+		const siblingSession = path.join(tempDir, "completed-sibling.jsonl");
+		fs.writeFileSync(siblingSession, "", "utf-8");
+		state.foregroundRuns.set("mixed-detached-run", {
+			runId: "mixed-detached-run",
+			mode: "parallel",
+			cwd: tempDir,
+			sessionId: "session-123",
+			updatedAt: Date.now(),
+			children: [
+				{ agent: "a", index: 0, status: "detached", updatedAt: Date.now() },
+				{ agent: "b", index: 1, status: "completed", sessionFile: siblingSession, updatedAt: Date.now() },
+			],
+		});
+
+		const status = await executor.execute(
+			"mixed-detached-status",
+			{ action: "status", id: "mixed-detached-run" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		const statusText = status.content[0]?.text ?? "";
+		assert.match(statusText, /do not resume or launch a replacement while any child remains detached/);
+		assert.doesNotMatch(statusText, /Revive child:/);
+
+		const resumed = await executor.execute(
+			"mixed-detached-resume",
+			{ action: "resume", id: "mixed-detached-run", index: 1, message: "replace sibling" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(resumed.isError, true);
+		assert.match(resumed.content[0]?.text ?? "", /cannot be revived safely while any child may still be live/);
+		assert.match(resumed.content[0]?.text ?? "", /do not launch a replacement/);
+	});
+
 	it("resume action rejects detached foreground children that may still be live", async () => {
 		mockPi.onCall({
 			steps: [
@@ -848,6 +1026,50 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.doesNotMatch(resumed.content[0]?.text ?? "", /revive only/);
 	});
 
+	it("does not inspect or resume remembered foreground runs from another parent session", async () => {
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("a")] });
+		const sessionFile = path.join(tempDir, "other-session-child.jsonl");
+		fs.writeFileSync(sessionFile, "", "utf-8");
+		state.foregroundRuns.set("other-session-run", {
+			runId: "other-session-run",
+			mode: "single",
+			cwd: tempDir,
+			sessionId: "session-other",
+			updatedAt: Date.now(),
+			children: [{ agent: "a", index: 0, status: "completed", sessionFile }],
+		});
+
+		const status = await executor.execute(
+			"other-session-status",
+			{ action: "status", id: "other-session-run" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(status.isError, true);
+		assert.doesNotMatch(status.content[0]?.text ?? "", /State: remembered foreground/);
+
+		const fleet = await executor.execute(
+			"other-session-fleet",
+			{ action: "status", view: "fleet" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.doesNotMatch(fleet.content[0]?.text ?? "", /other-session-run/);
+
+		const resumed = await executor.execute(
+			"other-session-resume",
+			{ action: "resume", id: "other-session-run", message: "Follow up" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(resumed.isError, true);
+		assert.doesNotMatch(resumed.content[0]?.text ?? "", /Revived foreground subagent/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
 	it("resume action keeps exact foreground validation errors over async prefix matches", async () => {
 		const base = `exact-invalid-${Date.now()}`;
 		const asyncSession = path.join(tempDir, "async-exact-prefix.jsonl");
@@ -869,6 +1091,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				runId: base,
 				mode: "single",
 				cwd: tempDir,
+				sessionId: "session-123",
 				updatedAt: Date.now(),
 				children: [{ agent: "a", index: 0, status: "completed" }],
 			});
@@ -910,6 +1133,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				runId: `${base}-foreground`,
 				mode: "single",
 				cwd: tempDir,
+				sessionId: "session-123",
 				updatedAt: Date.now(),
 				children: [{ agent: "a", index: 0, status: "completed", sessionFile: foregroundSession }],
 			});
@@ -958,6 +1182,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				runId: `${base}-foreground`,
 				mode: "single",
 				cwd: tempDir,
+				sessionId: "session-123",
 				updatedAt: Date.now(),
 				children: [{ agent: "a", index: 0, status: "completed", sessionFile: foregroundSession }],
 			});
@@ -1003,6 +1228,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				runId: foregroundId,
 				mode: "single",
 				cwd: tempDir,
+				sessionId: "session-123",
 				updatedAt: Date.now(),
 				children: [{ agent: "a", index: 0, status: "completed", sessionFile: foregroundSession }],
 			});

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -5,10 +5,11 @@ import registerSubagentNotify, {
 	buildCompletionDetails,
 	formatGroupedCompletion,
 	formatSingleCompletion,
+	parseSubagentNotifyContent,
 	type RegisterSubagentNotifyOptions,
 	type SubagentNotifyDetails,
 } from "../../src/runs/background/notify.ts";
-import { SUBAGENT_ASYNC_COMPLETE_EVENT } from "../../src/shared/types.ts";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT } from "../../src/shared/types.ts";
 
 function createPi(currentSessionId = "session-1", registerOptions: RegisterSubagentNotifyOptions = {}) {
 	const events = new EventEmitter();
@@ -115,6 +116,46 @@ describe("registerSubagentNotify", () => {
 			},
 			options: { triggerTurn: true },
 		});
+	});
+
+	it("wakes the originating session with recovered detached foreground output", () => {
+		const { events, sent } = createPi();
+
+		events.emit(SUBAGENT_FOREGROUND_COMPLETE_EVENT, {
+			id: "foreground-run:0",
+			runId: "foreground-run",
+			source: "foreground",
+			agent: "reviewer",
+			success: true,
+			summary: "Recovered final review",
+			exitCode: 0,
+			timestamp: 123,
+			sessionId: "session-1",
+		});
+
+		assert.equal(sent.length, 1);
+		assert.deepEqual(sent[0], {
+			message: {
+				customType: "subagent-notify",
+				content: "Detached foreground task completed: **reviewer**\n\nRecovered final review",
+				display: true,
+			},
+			options: { triggerTurn: true },
+		});
+	});
+
+	it("does not deliver detached foreground completion to another active session", () => {
+		const { events, sent } = createPi("session-2");
+		events.emit(SUBAGENT_FOREGROUND_COMPLETE_EVENT, {
+			id: "foreground-run:0",
+			source: "foreground",
+			agent: "reviewer",
+			success: true,
+			summary: "Recovered final review",
+			timestamp: 123,
+			sessionId: "session-1",
+		});
+		assert.equal(sent.length, 0);
 	});
 
 	it("preserves non-empty completion summaries", () => {
@@ -290,6 +331,25 @@ describe("completion formatting helpers", () => {
 			sessionValue: "/tmp/session.jsonl",
 		});
 		assert.equal(content, "Background task completed: **worker** (2/3)\n\nDone\n\nSession file: /tmp/session.jsonl");
+	});
+
+	it("parses detached foreground notification content for the custom renderer", () => {
+		const content = formatSingleCompletion({
+			agent: "reviewer",
+			status: "failed",
+			source: "foreground",
+			resultPreview: "Acceptance rejected",
+			sessionLabel: "Session file",
+			sessionValue: "/tmp/reviewer.jsonl",
+		});
+		assert.deepEqual(parseSubagentNotifyContent(content), {
+			agent: "reviewer",
+			status: "failed",
+			source: "foreground",
+			resultPreview: "Acceptance rejected",
+			sessionLabel: "session file",
+			sessionValue: "/tmp/reviewer.jsonl",
+		});
 	});
 
 	it("formatGroupedCompletion lists each agent with its summary and session", () => {

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -256,6 +256,107 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("waits for a remembered detached foreground run by id and ignores other sessions", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-foreground-"));
+		try {
+			const state = makeState("sess-1");
+			state.foregroundRuns = new Map([
+				["foreground-alpha", {
+					runId: "foreground-alpha",
+					mode: "single",
+					cwd: root,
+					sessionId: "sess-1",
+					updatedAt: 1,
+					children: [{ agent: "reviewer", index: 0, status: "detached", updatedAt: 1 }],
+				}],
+				["foreground-other", {
+					runId: "foreground-other",
+					mode: "single",
+					cwd: root,
+					sessionId: "sess-2",
+					updatedAt: 1,
+					children: [{ agent: "worker", index: 0, status: "detached", updatedAt: 1 }],
+				}],
+			]);
+			let polls = 0;
+			const result = await waitForSubagents({ id: "foreground-al" }, undefined, baseDeps(root, state, {
+				sleep: async () => {
+					polls += 1;
+					state.foregroundRuns!.get("foreground-alpha")!.children[0] = {
+						agent: "reviewer",
+						index: 0,
+						status: "completed",
+						finalOutput: "Recovered review",
+						updatedAt: 2,
+					};
+				},
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /remembered detached foreground run "foreground-alpha"/i);
+			assert.match(textOf(result), /1 completed/);
+			assert.equal(polls, 1);
+
+			const otherSession = await waitForSubagents({ id: "foreground-other" }, undefined, baseDeps(root, state));
+			assert.match(textOf(otherSession), /No active run matched/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not claim completion when a detached foreground run disappears or the active session changes", async () => {
+		for (const scenario of ["missing", "session-change"] as const) {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), `pi-wait-foreground-${scenario}-`));
+			try {
+				const state = makeState("sess-1");
+				state.foregroundRuns = new Map([["foreground-still-live", {
+					runId: "foreground-still-live",
+					mode: "single",
+					cwd: root,
+					sessionId: "sess-1",
+					updatedAt: 1,
+					children: [{ agent: "reviewer", index: 0, status: "detached", updatedAt: 1 }],
+				}]]);
+				const result = await waitForSubagents({ id: "foreground-still", timeoutMs: 5000 }, undefined, baseDeps(root, state, {
+					sleep: async () => {
+						if (scenario === "missing") state.foregroundRuns!.delete("foreground-still-live");
+						else state.currentSessionId = "sess-2";
+					},
+				}));
+
+				assert.equal(result.isError, true);
+				assert.doesNotMatch(textOf(result), /; done\./);
+				assert.match(textOf(result), scenario === "missing" ? /disappeared before a terminal child result/ : /active session changed/);
+			} finally {
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("rejects ambiguous prefixes across async and remembered foreground runs", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-cross-kind-"));
+		try {
+			const state = makeState("sess-1");
+			writeStatus(path.join(root, "runs"), "shared-async", "running", { sessionId: "sess-1", pid: 999999 });
+			state.foregroundRuns = new Map([["shared-foreground", {
+				runId: "shared-foreground",
+				mode: "single",
+				cwd: root,
+				sessionId: "sess-1",
+				updatedAt: 1,
+				children: [{ agent: "reviewer", index: 0, status: "detached", updatedAt: 1 }],
+			}]]);
+
+			const result = await waitForSubagents({ id: "shared" }, undefined, baseDeps(root, state));
+			assert.equal(result.isError, true);
+			assert.match(textOf(result), /Ambiguous subagent run id prefix "shared"/);
+			assert.match(textOf(result), /shared-async/);
+			assert.match(textOf(result), /shared-foreground/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("can target a single run by id prefix", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-id-"));
 		try {
@@ -289,7 +390,7 @@ describe("subagent_wait tool", () => {
 
 			const ambiguous = await waitForSubagents({ id: "ru" }, undefined, baseDeps(root, state));
 			assert.equal(ambiguous.isError, true);
-			assert.match(textOf(ambiguous), /Ambiguous async run id prefix "ru"/);
+			assert.match(textOf(ambiguous), /Ambiguous subagent run id prefix "ru"/);
 			assert.match(textOf(ambiguous), /run-alpha/);
 
 			let polls = 0;


### PR DESCRIPTION
Fixes #456

Detached foreground children now remain waitable through `subagent_wait({ id })` after supervisor coordination. Their acceptance stays pending until child exit, the recovered result and concrete failure reason are retained in remembered status, and a session-scoped completion notification wakes the originating parent with recovered output.

Remembered foreground status, fleet, resume, and id resolution are scoped to the originating session. Resume is blocked for the whole run while any sibling remains detached, and disappearance or session changes cannot be mistaken for successful completion. The notification renderer, tool schema, runtime guidance, README, and packaged skill use the same contract.

Thanks to Ramin Hazegh (@rhazegh) for reporting #456.

Validation: 1,119 unit tests passed (1 skipped), 513 integration tests passed, 1 E2E test passed, `git diff --check` passed. Fresh-context final review: no issues found.