### PR TITLE
Generalize the foreground delegation bridge for extension consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added a typed v1 foreground delegation event contract for extension consumers, with bounded execution fields, structured terminal status, progress/cancellation events, and compatibility with the existing prompt-template bridge.
 - Added single-agent launch defaults for `async`, `timeoutMs`, and `turnBudget` in agent frontmatter, with explicit tool-call values taking precedence. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #410.
 - Added `/subagents-stop` and `subagent({ action: "stop", id })` for current-session top-level async runs. The slash command opens a confirmation selector when no id is provided, falls back to exact commands without a TUI, routes scheduled jobs through `schedule-cancel`, and records manual stops as `stopped`/cancelled lifecycle events instead of timeouts. Thanks to Sean Seaman (@seans-leadsonline) for #407 and #408.
 - Added an opt-in read-only subagent watchdog that reviews actual repo edits at safe agent-end boundaries, with visible warnings, main and child watchdog coordination, strong complementary model recommendations, changed-file TypeScript/JavaScript LSP diagnostics, `/subagents-watchdog` status/model commands, and agent-facing watchdog configuration actions. Thanks to can1357/oh-my-pi for the advisor/watchdog concept, and to apmantza/pi-lens, gjczone/pi-shazam, and can1357/oh-my-pi for LSP diagnostics patterns.

--- a/README.md
+++ b/README.md
@@ -955,6 +955,40 @@ What the bundled skill covers:
 
 If you are writing an agent that orchestrates subagents, the bundled skill helps it behave correctly without guessing the patterns. If you are a human user, you do not need to read it directly; the README and prompt shortcuts encode the same workflows in user-facing form.
 
+## Extension delegation API
+
+Extensions can request one configured foreground agent through the versioned event contract in `pi-subagents/src/api/delegation.mjs`:
+
+```ts
+import {
+  SUBAGENT_DELEGATION_REQUEST_EVENT,
+  SUBAGENT_DELEGATION_RESPONSE_EVENT,
+  type SubagentDelegationRequest,
+} from "pi-subagents/src/api/delegation.mjs";
+
+const request: SubagentDelegationRequest = {
+  version: 1,
+  requestId: crypto.randomUUID(),
+  agent: "reviewer",
+  task: "Review the supplied evidence.",
+  context: "fresh",
+  cwd: ctx.cwd,
+  timeoutMs: 120_000,
+  toolBudget: { soft: 10, hard: 16, block: "*" },
+};
+
+pi.events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (response) => {
+  // Correlate by requestId and inspect the structured status.
+});
+pi.events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, request);
+```
+
+The bridge uses the same foreground executor as the `subagent` tool. It supports timeout, runtime, turn/tool budgets, skill selection, output settings, acceptance, progress, and cancellation. Agent discovery and effective tool restrictions remain package-owned; requests cannot grant arbitrary tools. Tool restrictions are not an operating-system sandbox.
+
+The request requires an active extension context. Emit it from a supported event callback or queued application step, not by recursively invoking the `subagent` tool inside another `tool_call` hook. Responses distinguish completion, failure, timeout, cancellation, interruption, budget exhaustion, acceptance rejection, invalid requests, and unavailable context. Optional session and artifact fields are omitted when the executor does not produce them.
+
+The existing `prompt-template:subagent:*` event family remains supported for prompt workflows and parallel templates. The v1 extension contract is single-agent only. The event-bus RPC remains async-only.
+
 ## Programmatic tool usage
 
 These are the parameters the LLM passes when it calls the `subagent` tool. Most users ask naturally or use slash commands instead.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   },
   "files": [
     "src/**/*.ts",
+    "src/**/*.mjs",
+    "src/**/*.d.mts",
     "*.mjs",
     "agents/",
     "skills/**/*",

--- a/src/api/delegation.d.mts
+++ b/src/api/delegation.d.mts
@@ -1,0 +1,99 @@
+export declare const SUBAGENT_DELEGATION_REQUEST_EVENT: "subagent:delegation:request";
+export declare const SUBAGENT_DELEGATION_STARTED_EVENT: "subagent:delegation:started";
+export declare const SUBAGENT_DELEGATION_UPDATE_EVENT: "subagent:delegation:update";
+export declare const SUBAGENT_DELEGATION_RESPONSE_EVENT: "subagent:delegation:response";
+export declare const SUBAGENT_DELEGATION_CANCEL_EVENT: "subagent:delegation:cancel";
+
+export interface SubagentDelegationTurnBudget {
+	maxTurns: number;
+	graceTurns?: number;
+}
+
+export interface SubagentDelegationToolBudget {
+	soft?: number;
+	hard: number;
+	block?: string[] | "*";
+}
+
+export type SubagentDelegationAcceptance =
+	| "auto"
+	| "attested"
+	| "checked"
+	| "verified"
+	| false
+	| Record<string, unknown>;
+
+export type SubagentDelegationStatus =
+	| "completed"
+	| "failed"
+	| "timed_out"
+	| "cancelled"
+	| "interrupted"
+	| "turn_budget_exhausted"
+	| "tool_budget_exhausted"
+	| "acceptance_failed"
+	| "invalid_request"
+	| "unavailable_context";
+
+export interface SubagentDelegationRequest {
+	version: 1;
+	requestId: string;
+	agent: string;
+	task: string;
+	context: "fresh" | "fork";
+	cwd: string;
+	model?: string;
+	timeoutMs?: number;
+	maxRuntimeMs?: number;
+	turnBudget?: SubagentDelegationTurnBudget;
+	toolBudget?: SubagentDelegationToolBudget;
+	skill?: string | string[] | boolean;
+	output?: string | boolean;
+	outputMode?: "inline" | "file-only";
+	acceptance?: SubagentDelegationAcceptance;
+	artifacts?: boolean;
+}
+
+export interface SubagentDelegationStarted {
+	version: 1;
+	requestId: string;
+}
+
+export interface SubagentDelegationUpdate extends SubagentDelegationStarted {
+	currentTool?: string;
+	currentToolArgs?: string;
+	recentOutput?: string;
+	recentOutputLines?: string[];
+	recentTools?: Array<{ tool: string; args: string }>;
+	model?: string;
+	toolCount?: number;
+	durationMs?: number;
+	tokens?: number;
+}
+
+export interface SubagentDelegationResponse extends SubagentDelegationStarted {
+	status: SubagentDelegationStatus;
+	error?: string;
+	runId?: string;
+	childIndex?: number;
+	agent?: string;
+	model?: string;
+	exitCode?: number;
+	output?: string;
+	outputPath?: string;
+	sessionFile?: string;
+	acceptance?: unknown;
+	turns?: number;
+	toolCount?: number;
+	durationMs?: number;
+	tokens?: number;
+	warnings?: string[];
+}
+
+export interface SubagentDelegationCancel extends SubagentDelegationStarted {}
+
+export type SubagentDelegationParseResult =
+	| { ok: true; request: SubagentDelegationRequest }
+	| { ok: false; requestId?: string; error: string };
+
+export function parseSubagentDelegationRequest(data: unknown): SubagentDelegationParseResult;

--- a/src/api/delegation.mjs
+++ b/src/api/delegation.mjs
@@ -1,0 +1,118 @@
+export const SUBAGENT_DELEGATION_REQUEST_EVENT = "subagent:delegation:request";
+export const SUBAGENT_DELEGATION_STARTED_EVENT = "subagent:delegation:started";
+export const SUBAGENT_DELEGATION_UPDATE_EVENT = "subagent:delegation:update";
+export const SUBAGENT_DELEGATION_RESPONSE_EVENT = "subagent:delegation:response";
+export const SUBAGENT_DELEGATION_CANCEL_EVENT = "subagent:delegation:cancel";
+
+const supportedFields = new Set([
+	"version",
+	"requestId",
+	"agent",
+	"task",
+	"context",
+	"cwd",
+	"model",
+	"timeoutMs",
+	"maxRuntimeMs",
+	"turnBudget",
+	"toolBudget",
+	"skill",
+	"output",
+	"outputMode",
+	"acceptance",
+	"artifacts",
+]);
+
+function nonEmptyString(value) {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function positiveInteger(value) {
+	return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function optionalString(value) {
+	return value === undefined || nonEmptyString(value);
+}
+
+function validateTurnBudget(value) {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) return "turnBudget must be an object.";
+	if (!positiveInteger(value.maxTurns)) return "turnBudget.maxTurns must be a positive integer.";
+	if (value.graceTurns !== undefined && (!Number.isInteger(value.graceTurns) || value.graceTurns < 0)) {
+		return "turnBudget.graceTurns must be a non-negative integer.";
+	}
+	return undefined;
+}
+
+function validateToolBudget(value) {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) return "toolBudget must be an object.";
+	if (!positiveInteger(value.hard)) return "toolBudget.hard must be a positive integer.";
+	if (value.soft !== undefined && (!positiveInteger(value.soft) || value.soft > value.hard)) {
+		return "toolBudget.soft must be a positive integer no greater than toolBudget.hard.";
+	}
+	if (value.block !== undefined && value.block !== "*" && (!Array.isArray(value.block) || !value.block.every(nonEmptyString))) {
+		return 'toolBudget.block must be "*" or an array of non-empty tool names.';
+	}
+	return undefined;
+}
+
+function validateOptionalFields(value) {
+	if (!optionalString(value.model)) return "model must be a non-empty string when provided.";
+	for (const name of ["timeoutMs", "maxRuntimeMs"]) {
+		if (value[name] !== undefined && !positiveInteger(value[name])) return `${name} must be a positive integer.`;
+	}
+	if (value.timeoutMs !== undefined && value.maxRuntimeMs !== undefined && value.timeoutMs !== value.maxRuntimeMs) {
+		return "timeoutMs and maxRuntimeMs are aliases; provide one or use the same value for both.";
+	}
+	const turnBudgetError = validateTurnBudget(value.turnBudget);
+	if (turnBudgetError) return turnBudgetError;
+	const toolBudgetError = validateToolBudget(value.toolBudget);
+	if (toolBudgetError) return toolBudgetError;
+	if (value.skill !== undefined) {
+		const validSkill = typeof value.skill === "boolean" || nonEmptyString(value.skill) ||
+			(Array.isArray(value.skill) && value.skill.length > 0 && value.skill.every(nonEmptyString));
+		if (!validSkill) return "skill must be a boolean, non-empty string, or non-empty string array.";
+	}
+	if (value.output !== undefined && typeof value.output !== "boolean" && !nonEmptyString(value.output)) {
+		return "output must be a boolean or non-empty string.";
+	}
+	if (value.outputMode !== undefined && value.outputMode !== "inline" && value.outputMode !== "file-only") {
+		return "outputMode must be inline or file-only.";
+	}
+	if (value.acceptance !== undefined) {
+		const levels = new Set(["auto", "attested", "checked", "verified"]);
+		const validAcceptance = value.acceptance === false || levels.has(value.acceptance) ||
+			(!!value.acceptance && typeof value.acceptance === "object" && !Array.isArray(value.acceptance));
+		if (!validAcceptance) return "acceptance must be a supported level, false, or an object.";
+	}
+	if (value.artifacts !== undefined && typeof value.artifacts !== "boolean") return "artifacts must be a boolean.";
+	return undefined;
+}
+
+export function parseSubagentDelegationRequest(data) {
+	if (!data || typeof data !== "object" || Array.isArray(data)) {
+		return { ok: false, error: "Delegation request must be an object." };
+	}
+	const requestId = nonEmptyString(data.requestId) ? data.requestId : undefined;
+	if (data.version !== 1) {
+		return {
+			ok: false,
+			...(requestId ? { requestId } : {}),
+			error: `Unsupported delegation protocol version: ${String(data.version)}.`,
+		};
+	}
+	if (!requestId) return { ok: false, error: "Delegation requestId must be a non-empty string." };
+	if (!nonEmptyString(data.agent)) return { ok: false, requestId, error: "Delegation agent must be a non-empty string." };
+	if (!nonEmptyString(data.task)) return { ok: false, requestId, error: "Delegation task must be a non-empty string." };
+	if (data.context !== "fresh" && data.context !== "fork") {
+		return { ok: false, requestId, error: "Delegation context must be fresh or fork." };
+	}
+	if (!nonEmptyString(data.cwd)) return { ok: false, requestId, error: "Delegation cwd must be a non-empty string." };
+	const unsupportedField = Object.keys(data).find((key) => !supportedFields.has(key));
+	if (unsupportedField) return { ok: false, requestId, error: `Unsupported delegation field: ${unsupportedField}.` };
+	const optionalFieldError = validateOptionalFields(data);
+	if (optionalFieldError) return { ok: false, requestId, error: optionalFieldError };
+	return { ok: true, request: data };
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -31,7 +31,10 @@ import { createAsyncJobTracker } from "../runs/background/async-job-tracker.ts";
 import { createResultWatcher } from "../runs/background/result-watcher.ts";
 import { createScheduledRunManager } from "../runs/background/scheduled-runs.ts";
 import { registerSlashCommands } from "../slash/slash-commands.ts";
-import { registerPromptTemplateDelegationBridge } from "../slash/prompt-template-bridge.ts";
+import {
+	registerPromptTemplateDelegationBridge,
+	toSubagentDelegationExecutionParams,
+} from "../slash/prompt-template-bridge.ts";
 import { registerMainWatchdog } from "../watchdog/register-main.ts";
 import { registerSlashSubagentBridge } from "../slash/slash-bridge.ts";
 import { createNativeSupervisorChannel } from "../intercom/native-supervisor-channel.ts";
@@ -377,6 +380,15 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		events: pi.events,
 		getContext: () => state.lastUiContext,
 		execute: async (requestId, request, signal, ctx, onUpdate) => {
+			if ("version" in request) {
+				return executeSubagentCollapsed(
+					requestId,
+					toSubagentDelegationExecutionParams(request),
+					signal,
+					onUpdate,
+					ctx,
+				);
+			}
 			if (request.tasks && request.tasks.length > 0) {
 				return executeSubagentCollapsed(
 					requestId,

--- a/src/slash/prompt-template-bridge.ts
+++ b/src/slash/prompt-template-bridge.ts
@@ -1,3 +1,15 @@
+import {
+	SUBAGENT_DELEGATION_CANCEL_EVENT,
+	SUBAGENT_DELEGATION_REQUEST_EVENT,
+	SUBAGENT_DELEGATION_RESPONSE_EVENT,
+	SUBAGENT_DELEGATION_STARTED_EVENT,
+	SUBAGENT_DELEGATION_UPDATE_EVENT,
+	parseSubagentDelegationRequest,
+	type SubagentDelegationRequest,
+	type SubagentDelegationResponse,
+	type SubagentDelegationStatus,
+} from "../api/delegation.mjs";
+
 export const PROMPT_TEMPLATE_SUBAGENT_REQUEST_EVENT = "prompt-template:subagent:request";
 export const PROMPT_TEMPLATE_SUBAGENT_STARTED_EVENT = "prompt-template:subagent:started";
 export const PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT = "prompt-template:subagent:response";
@@ -18,7 +30,7 @@ interface PromptTemplateDelegationParallelResult {
 	errorText?: string;
 }
 
-interface PromptTemplateDelegationRequest {
+export interface PromptTemplateDelegationRequest {
 	requestId: string;
 	agent: string;
 	task: string;
@@ -75,6 +87,9 @@ interface PromptTemplateBridgeResult {
 	isError?: boolean;
 	content?: unknown;
 	details?: {
+		runId?: string;
+		timedOut?: boolean;
+		stopped?: boolean;
 		results?: Array<{
 			agent?: string;
 			messages?: unknown[];
@@ -83,6 +98,19 @@ interface PromptTemplateBridgeResult {
 			exitCode?: number;
 			error?: string;
 			model?: string;
+			timedOut?: boolean;
+			interrupted?: boolean;
+			stopped?: boolean;
+			turnBudgetExceeded?: boolean;
+			toolBudgetBlocked?: boolean;
+			savedOutputPath?: string;
+			sessionFile?: string;
+			acceptance?: { status?: string } & Record<string, unknown>;
+			usage?: { turns?: number };
+			progress?: { toolCount?: number; durationMs?: number; tokens?: number };
+			skillsWarning?: string;
+			outputSaveError?: string;
+			transcriptError?: string;
 		}>;
 		progress?: Array<{
 			index?: number;
@@ -99,12 +127,14 @@ interface PromptTemplateBridgeResult {
 	};
 }
 
+export type DelegationBridgeRequest = PromptTemplateDelegationRequest | SubagentDelegationRequest;
+
 interface PromptTemplateBridgeOptions<Ctx extends { cwd?: string }> {
 	events: PromptTemplateBridgeEvents;
 	getContext: () => Ctx | null;
 	execute: (
 		requestId: string,
-		request: PromptTemplateDelegationRequest,
+		request: DelegationBridgeRequest,
 		signal: AbortSignal,
 		ctx: Ctx,
 		onUpdate: (result: PromptTemplateBridgeResult) => void,
@@ -285,14 +315,87 @@ function toDelegationUpdate(requestId: string, update: PromptTemplateBridgeResul
 	};
 }
 
+export function toSubagentDelegationExecutionParams(request: SubagentDelegationRequest) {
+	return {
+		agent: request.agent,
+		task: request.task,
+		context: request.context,
+		cwd: request.cwd,
+		model: request.model,
+		timeoutMs: request.timeoutMs,
+		maxRuntimeMs: request.maxRuntimeMs,
+		turnBudget: request.turnBudget,
+		toolBudget: request.toolBudget,
+		skill: request.skill,
+		output: request.output,
+		outputMode: request.outputMode,
+		acceptance: request.acceptance,
+		artifacts: request.artifacts,
+		async: false as const,
+		clarify: false as const,
+	};
+}
+
+function generalStatus(result: PromptTemplateBridgeResult, aborted = false): SubagentDelegationStatus {
+	if (aborted) return "cancelled";
+	const child = result.details?.results?.[0];
+	if (result.details?.timedOut || child?.timedOut) return "timed_out";
+	if (child?.turnBudgetExceeded) return "turn_budget_exhausted";
+	if (child?.toolBudgetBlocked) return "tool_budget_exhausted";
+	if (child?.acceptance?.status === "rejected") return "acceptance_failed";
+	if (child?.interrupted || child?.stopped || result.details?.stopped) return "interrupted";
+	if (result.isError || child?.error || (typeof child?.exitCode === "number" && child.exitCode !== 0)) return "failed";
+	return "completed";
+}
+
+function generalResponse(
+	requestId: string,
+	result: PromptTemplateBridgeResult,
+	aborted = false,
+): SubagentDelegationResponse {
+	const child = result.details?.results?.[0];
+	const progress = child?.progress ?? result.details?.progress?.[0];
+	const warnings = [child?.skillsWarning, child?.outputSaveError, child?.transcriptError]
+		.filter((warning): warning is string => typeof warning === "string" && warning.length > 0);
+	return {
+		version: 1,
+		requestId,
+		status: generalStatus(result, aborted),
+		...(child?.error ? { error: child.error } : {}),
+		...(result.details?.runId ? { runId: result.details.runId } : {}),
+		...(child ? { childIndex: 0 } : {}),
+		...(child?.agent ? { agent: child.agent } : {}),
+		...(child?.model ? { model: child.model } : {}),
+		...(typeof child?.exitCode === "number" ? { exitCode: child.exitCode } : {}),
+		...(child?.finalOutput ? { output: child.finalOutput } : {}),
+		...(child?.savedOutputPath ? { outputPath: child.savedOutputPath } : {}),
+		...(child?.sessionFile ? { sessionFile: child.sessionFile } : {}),
+		...(child?.acceptance ? { acceptance: child.acceptance } : {}),
+		...(typeof child?.usage?.turns === "number" ? { turns: child.usage.turns } : {}),
+		...(typeof progress?.toolCount === "number" ? { toolCount: progress.toolCount } : {}),
+		...(typeof progress?.durationMs === "number" ? { durationMs: progress.durationMs } : {}),
+		...(typeof progress?.tokens === "number" ? { tokens: progress.tokens } : {}),
+		...(warnings.length > 0 ? { warnings } : {}),
+	};
+}
+
+function generalUpdate(requestId: string, result: PromptTemplateBridgeResult): unknown {
+	const update = toDelegationUpdate(requestId, result);
+	if (!update) return undefined;
+	const { taskProgress: _taskProgress, requestId: _legacyRequestId, ...progress } = update;
+	return { version: 1, requestId, ...progress };
+}
+
 export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: string }>(
 	options: PromptTemplateBridgeOptions<Ctx>,
 ): {
 	cancelAll: () => void;
 	dispose: () => void;
 } {
-	const controllers = new Map<string, AbortController>();
-	const pendingCancels = new Set<string>();
+	const legacyControllers = new Map<string, AbortController>();
+	const legacyPendingCancels = new Set<string>();
+	const delegationControllers = new Map<string, AbortController>();
+	const delegationPendingCancels = new Set<string>();
 	const subscriptions: Array<() => void> = [];
 
 	const subscribe = (event: string, handler: (data: unknown) => void): void => {
@@ -300,7 +403,11 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 		if (typeof unsubscribe === "function") subscriptions.push(unsubscribe);
 	};
 
-	subscribe(PROMPT_TEMPLATE_SUBAGENT_CANCEL_EVENT, (data) => {
+	const handleCancel = (
+		data: unknown,
+		controllers: Map<string, AbortController>,
+		pendingCancels: Set<string>,
+	): void => {
 		if (!data || typeof data !== "object") return;
 		const requestId = (data as { requestId?: unknown }).requestId;
 		if (typeof requestId !== "string") return;
@@ -310,6 +417,84 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 			return;
 		}
 		pendingCancels.add(requestId);
+	};
+
+	subscribe(PROMPT_TEMPLATE_SUBAGENT_CANCEL_EVENT, (data) => {
+		handleCancel(data, legacyControllers, legacyPendingCancels);
+	});
+	subscribe(SUBAGENT_DELEGATION_CANCEL_EVENT, (data) => {
+		handleCancel(data, delegationControllers, delegationPendingCancels);
+	});
+
+	subscribe(SUBAGENT_DELEGATION_REQUEST_EVENT, async (data) => {
+		const parsed = parseSubagentDelegationRequest(data);
+		if (!parsed.ok) {
+			if (!parsed.requestId) return;
+			options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
+				version: 1,
+				requestId: parsed.requestId,
+				status: "invalid_request",
+				error: parsed.error,
+			} satisfies SubagentDelegationResponse);
+			return;
+		}
+		const request = parsed.request;
+		if (delegationControllers.has(request.requestId)) {
+			options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
+				version: 1,
+				requestId: request.requestId,
+				status: "invalid_request",
+				error: "A delegation request with this requestId is already running.",
+			} satisfies SubagentDelegationResponse);
+			return;
+		}
+		const ctx = options.getContext();
+		if (!ctx) {
+			options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
+				version: 1,
+				requestId: request.requestId,
+				status: "unavailable_context",
+				error: "No active extension context for delegated subagent execution.",
+			} satisfies SubagentDelegationResponse);
+			return;
+		}
+		const controller = new AbortController();
+		delegationControllers.set(request.requestId, controller);
+		if (delegationPendingCancels.delete(request.requestId)) controller.abort();
+		if (controller.signal.aborted) {
+			options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
+				version: 1,
+				requestId: request.requestId,
+				status: "cancelled",
+			} satisfies SubagentDelegationResponse);
+			delegationControllers.delete(request.requestId);
+			return;
+		}
+		options.events.emit(SUBAGENT_DELEGATION_STARTED_EVENT, { version: 1, requestId: request.requestId });
+		try {
+			const result = await options.execute(
+				request.requestId,
+				request,
+				controller.signal,
+				ctx,
+				(update) => {
+					const payload = generalUpdate(request.requestId, update);
+					if (payload) options.events.emit(SUBAGENT_DELEGATION_UPDATE_EVENT, payload);
+				},
+			);
+			options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, generalResponse(request.requestId, result, controller.signal.aborted));
+		} catch (error) {
+			options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
+				version: 1,
+				requestId: request.requestId,
+				status: controller.signal.aborted ? "cancelled" : "failed",
+				error: error instanceof Error ? error.message : String(error),
+			} satisfies SubagentDelegationResponse);
+		} finally {
+			if (delegationControllers.get(request.requestId) === controller) {
+				delegationControllers.delete(request.requestId);
+			}
+		}
 	});
 
 	subscribe(PROMPT_TEMPLATE_SUBAGENT_REQUEST_EVENT, async (data) => {
@@ -329,9 +514,9 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 		}
 
 		const controller = new AbortController();
-		controllers.set(request.requestId, controller);
+		legacyControllers.set(request.requestId, controller);
 
-		if (pendingCancels.delete(request.requestId)) {
+		if (legacyPendingCancels.delete(request.requestId)) {
 			controller.abort();
 			const response: PromptTemplateDelegationResponse = {
 				...request,
@@ -340,7 +525,7 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 				errorText: "Delegated prompt cancelled.",
 			};
 			options.events.emit(PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT, response);
-			controllers.delete(request.requestId);
+			legacyControllers.delete(request.requestId);
 			return;
 		}
 
@@ -399,22 +584,27 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 			};
 			options.events.emit(PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT, response);
 		} finally {
-			controllers.delete(request.requestId);
+			if (legacyControllers.get(request.requestId) === controller) {
+				legacyControllers.delete(request.requestId);
+			}
 		}
 	});
 
 	return {
 		cancelAll: () => {
-			for (const controller of controllers.values()) {
+			for (const controller of [...legacyControllers.values(), ...delegationControllers.values()]) {
 				controller.abort();
 			}
-			controllers.clear();
-			pendingCancels.clear();
+			legacyControllers.clear();
+			delegationControllers.clear();
+			legacyPendingCancels.clear();
+			delegationPendingCancels.clear();
 		},
 		dispose: () => {
 			for (const unsubscribe of subscriptions) unsubscribe();
 			subscriptions.length = 0;
-			pendingCancels.clear();
+			legacyPendingCancels.clear();
+			delegationPendingCancels.clear();
 		},
 	};
 }

--- a/test/unit/delegation-api.test.ts
+++ b/test/unit/delegation-api.test.ts
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+	SUBAGENT_DELEGATION_CANCEL_EVENT,
+	SUBAGENT_DELEGATION_REQUEST_EVENT,
+	SUBAGENT_DELEGATION_RESPONSE_EVENT,
+	SUBAGENT_DELEGATION_STARTED_EVENT,
+	SUBAGENT_DELEGATION_UPDATE_EVENT,
+	type SubagentDelegationRequest,
+	type SubagentDelegationResponse,
+} from "../../src/api/delegation.mjs";
+import {
+	registerPromptTemplateDelegationBridge,
+	toSubagentDelegationExecutionParams,
+	type PromptTemplateBridgeEvents,
+} from "../../src/slash/prompt-template-bridge.ts";
+
+class FakeEvents implements PromptTemplateBridgeEvents {
+	private handlers = new Map<string, Array<(data: unknown) => void>>();
+
+	on(event: string, handler: (data: unknown) => void): () => void {
+		const list = this.handlers.get(event) ?? [];
+		list.push(handler);
+		this.handlers.set(event, list);
+		return () => this.handlers.set(event, (this.handlers.get(event) ?? []).filter((entry) => entry !== handler));
+	}
+
+	emit(event: string, data: unknown): void {
+		for (const handler of [...(this.handlers.get(event) ?? [])]) handler(data);
+	}
+}
+
+function once(events: FakeEvents, event: string): Promise<unknown> {
+	return new Promise((resolve) => {
+		const unsubscribe = events.on(event, (payload) => {
+			unsubscribe();
+			resolve(payload);
+		});
+	});
+}
+
+const request: SubagentDelegationRequest = {
+	version: 1,
+	requestId: "general-1",
+	agent: "reviewer",
+	task: "Review evidence",
+	context: "fresh",
+	cwd: "/repo",
+	timeoutMs: 1_000,
+	turnBudget: { maxTurns: 4, graceTurns: 1 },
+	toolBudget: { soft: 3, hard: 5, block: "*" },
+	skill: ["review"],
+	output: "result.md",
+	outputMode: "file-only",
+	acceptance: "checked",
+	artifacts: true,
+};
+
+describe("public subagent delegation contract", () => {
+	it("maps every bounded request field to the existing executor", () => {
+		assert.deepEqual(toSubagentDelegationExecutionParams(request), {
+			agent: "reviewer", task: "Review evidence", context: "fresh", cwd: "/repo", model: undefined,
+			timeoutMs: 1_000, maxRuntimeMs: undefined,
+			turnBudget: { maxTurns: 4, graceTurns: 1 },
+			toolBudget: { soft: 3, hard: 5, block: "*" },
+			skill: ["review"], output: "result.md", outputMode: "file-only",
+			acceptance: "checked", artifacts: true, async: false, clarify: false,
+		});
+	});
+
+	it("runs one versioned request through the existing bridge and returns structured metadata", async () => {
+		const events = new FakeEvents();
+		let observedRequest: SubagentDelegationRequest | undefined;
+		let executeCalls = 0;
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async (_requestId, delegatedRequest, _signal, _ctx, onUpdate) => {
+				executeCalls++;
+				observedRequest = delegatedRequest as SubagentDelegationRequest;
+				onUpdate({ details: { results: [{ agent: "reviewer", model: "openai/gpt-5" }], progress: [{ currentTool: "read", toolCount: 1 }] } });
+				return {
+					details: {
+						runId: "run-1",
+						results: [{
+							agent: "reviewer",
+							exitCode: 0,
+							model: "openai/gpt-5",
+							finalOutput: "done",
+							savedOutputPath: "/repo/result.md",
+							sessionFile: "/tmp/session.jsonl",
+							usage: { turns: 2 },
+						}],
+					},
+				};
+			},
+		});
+		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
+		const updatePromise = once(events, SUBAGENT_DELEGATION_UPDATE_EVENT);
+		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, request);
+
+		assert.deepEqual(await startedPromise, { version: 1, requestId: "general-1" });
+		const update = await updatePromise as { version: number; requestId: string; currentTool?: string; toolCount?: number; model?: string };
+		assert.equal(update.version, 1);
+		assert.equal(update.requestId, "general-1");
+		assert.equal(update.currentTool, "read");
+		assert.equal(update.toolCount, 1);
+		assert.equal(update.model, "openai/gpt-5");
+		const response = await responsePromise as SubagentDelegationResponse;
+		assert.equal(executeCalls, 1);
+		assert.deepEqual(observedRequest, request);
+		assert.equal(response.status, "completed");
+		assert.equal(response.runId, "run-1");
+		assert.equal(response.agent, "reviewer");
+		assert.equal(response.output, "done");
+		assert.equal(response.outputPath, "/repo/result.md");
+		assert.equal(response.sessionFile, "/tmp/session.jsonl");
+		assert.equal(response.turns, 2);
+		assert.equal("acceptance" in response, false);
+		assert.equal("warnings" in response, false);
+		bridge.dispose();
+	});
+
+	it("returns correlated typed failures before execution", async () => {
+		const events = new FakeEvents();
+		let executeCalls = 0;
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => null,
+			execute: async () => {
+				executeCalls++;
+				return {};
+			},
+		});
+		const invalidPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, version: 2, requestId: "invalid-1" });
+		assert.deepEqual(await invalidPromise, {
+			version: 1,
+			requestId: "invalid-1",
+			status: "invalid_request",
+			error: "Unsupported delegation protocol version: 2.",
+		});
+
+		const unsupportedFieldPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "tools-1", tools: ["write"] });
+		assert.equal((await unsupportedFieldPromise as SubagentDelegationResponse).status, "invalid_request");
+
+		const malformedRequests = [
+			{ timeoutMs: "slow" },
+			{ timeoutMs: -1 },
+			{ timeoutMs: 10, maxRuntimeMs: 20 },
+			{ turnBudget: { maxTurns: 0 } },
+			{ toolBudget: { hard: 1, soft: 2 } },
+			{ toolBudget: { hard: 1, block: [""] } },
+			{ skill: {} },
+			{ output: "" },
+			{ outputMode: "stream" },
+			{ acceptance: "none" },
+			{ artifacts: "yes" },
+		];
+		for (const [index, malformed] of malformedRequests.entries()) {
+			const malformedPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+			events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+				...request,
+				...malformed,
+				requestId: `malformed-${index}`,
+			});
+			assert.equal((await malformedPromise as SubagentDelegationResponse).status, "invalid_request");
+		}
+
+		const malformedRequiredPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "malformed-agent", agent: "" });
+		assert.equal((await malformedRequiredPromise as SubagentDelegationResponse).status, "invalid_request");
+
+		const unavailablePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "unavailable-1" });
+		const unavailable = await unavailablePromise as SubagentDelegationResponse;
+		assert.equal(unavailable.status, "unavailable_context");
+		assert.equal(executeCalls, 0);
+		bridge.dispose();
+	});
+
+	it("rejects a duplicate active requestId and keeps cancellation ownership", async () => {
+		const events = new FakeEvents();
+		let executeCalls = 0;
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async (_id, _request, signal) => {
+				executeCalls++;
+				return await new Promise((_resolve, reject) => {
+					signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+				});
+			},
+		});
+		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "duplicate-1" });
+		await startedPromise;
+
+		const duplicateResponse = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "duplicate-1" });
+		const duplicate = await duplicateResponse as SubagentDelegationResponse;
+		assert.equal(duplicate.status, "invalid_request");
+		assert.equal(executeCalls, 1);
+
+		const cancelledResponse = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 1, requestId: "duplicate-1" });
+		assert.equal((await cancelledResponse as SubagentDelegationResponse).status, "cancelled");
+		bridge.dispose();
+	});
+
+	it("keeps legacy and versioned cancellation namespaces separate", async () => {
+		const events = new FakeEvents();
+		let executeCalls = 0;
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => {
+				executeCalls++;
+				return { details: { results: [{ agent: "reviewer", exitCode: 0 }] } };
+			},
+		});
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 1, requestId: "shared-1" });
+		const legacyResponse = once(events, "prompt-template:subagent:response");
+		events.emit("prompt-template:subagent:request", {
+			requestId: "shared-1", agent: "reviewer", task: "legacy", context: "fresh", model: "test", cwd: "/repo",
+		});
+		assert.equal((await legacyResponse as { isError: boolean }).isError, false);
+
+		const versionedResponse = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "shared-1" });
+		assert.equal((await versionedResponse as SubagentDelegationResponse).status, "cancelled");
+		assert.equal(executeCalls, 1);
+		bridge.dispose();
+	});
+
+	it("maps cancellation and terminal executor outcomes", async () => {
+		const cases = [
+			[{ timedOut: true }, "timed_out"],
+			[{ interrupted: true }, "interrupted"],
+			[{ turnBudgetExceeded: true }, "turn_budget_exhausted"],
+			[{ toolBudgetBlocked: true }, "tool_budget_exhausted"],
+			[{ acceptance: { status: "rejected" } }, "acceptance_failed"],
+			[{ exitCode: 1, error: "failed" }, "failed"],
+		] as const;
+		for (const [result, expectedStatus] of cases) {
+			const events = new FakeEvents();
+			const bridge = registerPromptTemplateDelegationBridge({
+				events,
+				getContext: () => ({ cwd: "/repo" }),
+				execute: async () => ({ details: { results: [{ agent: "reviewer", exitCode: 0, ...result }] } }),
+			});
+			const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+			events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: `case-${expectedStatus}` });
+			assert.equal((await responsePromise as SubagentDelegationResponse).status, expectedStatus);
+			bridge.dispose();
+		}
+
+		const preEvents = new FakeEvents();
+		let preCalls = 0;
+		const preBridge = registerPromptTemplateDelegationBridge({
+			events: preEvents, getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { preCalls++; return {}; },
+		});
+		preEvents.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 1, requestId: "pre-cancel-1" });
+		const preResponse = once(preEvents, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		preEvents.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "pre-cancel-1" });
+		assert.equal((await preResponse as SubagentDelegationResponse).status, "cancelled");
+		assert.equal(preCalls, 0);
+		preBridge.dispose();
+
+		const events = new FakeEvents();
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async (_id, _request, signal) => await new Promise((_resolve, reject) => {
+				signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+			}),
+		});
+		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "cancel-1" });
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 1, requestId: "cancel-1" });
+		assert.equal((await responsePromise as SubagentDelegationResponse).status, "cancelled");
+		bridge.dispose();
+	});
+});

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+
+import {
+	SUBAGENT_DELEGATION_REQUEST_EVENT,
+	SUBAGENT_DELEGATION_RESPONSE_EVENT,
+} from "../../src/api/delegation.mjs";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -24,6 +30,27 @@ function collectTsFiles(dir: string): string[] {
 	}
 	return files;
 }
+
+test("the packed source surface includes the public delegation contract", () => {
+	const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf-8"));
+	assert.equal(packageJson.files.includes("src/**/*.ts"), true);
+	assert.equal(packageJson.files.includes("src/**/*.mjs"), true);
+	assert.equal(packageJson.files.includes("src/**/*.d.mts"), true);
+	assert.equal(fs.existsSync(path.join(projectRoot, "src", "api", "delegation.mjs")), true);
+	assert.equal(fs.existsSync(path.join(projectRoot, "src", "api", "delegation.d.mts")), true);
+	assert.equal(SUBAGENT_DELEGATION_REQUEST_EVENT, "subagent:delegation:request");
+	assert.equal(SUBAGENT_DELEGATION_RESPONSE_EVENT, "subagent:delegation:response");
+
+	const packed = spawnSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+		cwd: projectRoot,
+		encoding: "utf-8",
+	});
+	assert.equal(packed.status, 0, packed.stderr);
+	const packReport = JSON.parse(packed.stdout) as Array<{ files: Array<{ path: string }> }>;
+	const packedPaths = new Set(packReport[0]?.files.map((file) => file.path));
+	assert.equal(packedPaths.has("src/api/delegation.mjs"), true);
+	assert.equal(packedPaths.has("src/api/delegation.d.mts"), true);
+});
 
 test("direct @earendil-works runtime imports are declared for CI installs", () => {
 	const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf-8"));


### PR DESCRIPTION
## Proposal

This PR is a tested reference implementation for #465.

The proposal and behavioral contract are the primary artifacts. The code demonstrates one possible implementation, but the public names, module location, and DTO shape remain maintainer decisions. I am happy to revise or replace the implementation if a different boundary fits the project better.

## Context

Current `main` already supports foreground extension-to-extension execution through `prompt-template:subagent:request`. The bridge validates a request, obtains the active extension context, invokes the existing foreground executor, publishes progress, handles cancellation, and publishes a response.

That made a new launcher or foreground RPC mode the wrong change. This PR instead adds a general typed event contract over the existing path.

The current prompt-template payload has two limitations for non-template extension consumers:

1. Its request, response, update, and result interfaces are private, so producers copy an undocumented payload shape.
2. It does not expose bounded execution controls or stable terminal states even though the foreground executor already supports them.

## Change

The reference implementation adds `src/api/delegation.mjs` with adjacent TypeScript declarations in `src/api/delegation.d.mts`.

A version 1 request supports one configured foreground agent and these existing executor controls:

- fresh or fork context;
- model and cwd;
- timeout or max runtime;
- turn budget;
- tool-call budget;
- skill selection;
- output path and output mode;
- acceptance;
- artifact capture.

The parser validates every field at the event boundary. Unknown fields, malformed optional controls, conflicting timeout aliases, and unsupported versions return a correlated `invalid_request` response before the executor starts. The request cannot grant arbitrary tools. Agent discovery and effective tool restrictions remain package-owned.

Responses distinguish:

- `completed`;
- `failed`;
- `timed_out`;
- `cancelled`;
- `interrupted`;
- `turn_budget_exhausted`;
- `tool_budget_exhausted`;
- `acceptance_failed`;
- `invalid_request`;
- `unavailable_context`.

Run, agent, model, exit, output, session, acceptance, usage, progress, and warning metadata are included only when the executor produces them.

## Compatibility

The existing prompt-template event family is unchanged. It retains its single and parallel request forms and its legacy response payload.

The new event family has separate controller and pending-cancel state, so identical request IDs in the two protocols cannot cross-cancel. Duplicate active versioned request IDs are rejected and cannot replace another request's cancellation controller.

Both protocols call the same injected foreground executor. This PR does not:

- add a second runner;
- change detached RPC;
- expose chain, parallel, scheduling, management, or TUI APIs;
- allow arbitrary tool grants;
- claim operating-system sandboxing;
- add workflow-specific concepts.

## Packaging

The package already publishes TypeScript source and root `.mjs` files. This PR adds `src/**/*.mjs` and `src/**/*.d.mts` to the packed file list.

The public runtime import is:

```ts
import {
  SUBAGENT_DELEGATION_REQUEST_EVENT,
  type SubagentDelegationRequest,
} from "pi-subagents/src/api/delegation.mjs";
```

A packed tarball was installed into a clean consumer. Plain Node imported the runtime module, and TypeScript 5.8 with `moduleResolution: NodeNext` type-checked a representative request and response.

## Test evidence

### Red

Before implementation:

```text
node --experimental-strip-types --test test/unit/delegation-api.test.ts
ERR_MODULE_NOT_FOUND: src/api/delegation.ts
```

### Green

```text
node --experimental-strip-types --test \
  test/unit/delegation-api.test.ts \
  test/unit/prompt-template-bridge.test.ts \
  test/unit/package-manifest.test.ts

20 tests passed, 0 failed
```

The focused tests cover:

- complete field mapping into the existing executor;
- started, update, response, and cancellation events;
- required and optional runtime validation;
- unknown tool-grant rejection;
- duplicate request IDs;
- separate legacy and versioned cancellation namespaces;
- timeout, interruption, turn/tool budget, acceptance, and generic failure mapping;
- omission of unavailable optional metadata;
- packed runtime and declaration files.

Additional checks:

- packed tarball install and plain Node runtime import: passed;
- packed consumer TypeScript 5.8 `tsc --noEmit`: passed;
- `git diff --check`: passed;
- Semgrep 1.168.0 on changed source/tests: 0 findings;
- TruffleHog 3.95.9 filesystem scan: 0 verified or unverified secrets;
- OSV-Scanner 2.4.0 with `--include-git-root`: no issues.

### Full-suite local limitation

`npm run test:all` completed with 12 environment-sensitive failures in agent settings, profile, and skill discovery tests. A pristine clone at the exact base commit produced the same 12 failures under the same isolated `PI_CODING_AGENT_DIR`. No changed or bridge/delegation test failed. CI remains the authoritative full-suite result.

## Review findings fixed

Fresh reviewers found two high-severity defects in the first draft:

1. Optional execution controls were not validated at the public boundary.
2. Duplicate request IDs could replace another request's cancellation controller.

Both were fixed with table-driven malformed-control tests, active-ID rejection, controller ownership checks, and protocol-scoped cancellation state. A packed declaration-resolution gap was also found and fixed by using the `.mjs` plus `.d.mts` pair.

## Maintainer questions

1. Is a separate general event family preferable to aliases over the prompt-template names?
2. Is `src/api/delegation.mjs` an acceptable supported path for this source-distributed package?
3. Should acceptance remain opaque in the response, or should a smaller stable acceptance DTO be defined?
4. Should the general contract remain single-agent only while prompt templates retain parallel requests?
5. Would you prefer a smaller first PR that exports only contracts and a subset of bounded controls?

Closes #465.