### PR TITLE
feat: add agent acceptance defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added strict `acceptance` defaults in agent frontmatter and agent management. The default applies only to single-agent launches, explicit call values win, and chain/parallel acceptance remains task or step configuration. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #453.
 - Added canonical-session leases for direct child revival so independent parent processes cannot write the same persisted session concurrently. Lease ownership includes the revived/source run, parent session, runner and writer process identities, and host; a two-phase startup handshake rejects contention before Pi starts, and stale recovery remains conservative. Thanks to Luke Parke (@LukasParke) for #446.
 - Added single-agent launch defaults for `async`, `timeoutMs`, and `turnBudget` in agent frontmatter, with explicit tool-call values taking precedence. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #410.
 - Added `/subagents-stop` and `subagent({ action: "stop", id })` for current-session top-level async runs. The slash command opens a confirmation selector when no id is provided, falls back to exact commands without a TUI, routes scheduled jobs through `schedule-cancel`, and records manual stops as `stopped`/cancelled lifecycle events instead of timeouts. Thanks to Sean Seaman (@seans-leadsonline) for #407 and #408.

--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ defaultProgress: true
 async: true
 timeoutMs: 900000
 turnBudget: {"maxTurns":20,"graceTurns":2}
+acceptance: {"level":"none","reason":"lightweight lookup"}
 completionGuard: false
 interactive: true
 maxSubagentDepth: 1
@@ -741,6 +742,7 @@ Important fields:
 | `async` | Default a single-agent launch to background (`true`) or foreground (`false`) when the call omits `async`. Explicit call values and `forceTopLevelAsync` win. |
 | `timeoutMs` | Positive integer default runtime deadline in milliseconds for single-agent launches. An explicit `timeoutMs` or `maxRuntimeMs` wins. |
 | `turnBudget` | JSON object default such as `{"maxTurns":20,"graceTurns":2}` for single-agent launches. An explicit call value wins, followed by this agent default, then global `turnBudget` config. |
+| `acceptance` | Acceptance default for single-agent launches. Use a scalar level such as `checked` or an inline/block YAML map such as `{ level: "none", reason: "lightweight lookup" }`. Explicit call values win; chain and parallel acceptance remains task/step configuration. |
 | `completionGuard` | Set `false` only for non-implementation agents that may mention implementation words while using mutation-capable tools such as `bash`. |
 | `interactive` | Parsed for compatibility but not enforced in v1. |
 | `maxSubagentDepth` | Tightens nested delegation for this agent's children. |
@@ -1067,6 +1069,7 @@ Agent definitions are not loaded into context by default. Management actions let
   extensions: "",
   skills: "parallel-scout",
   thinking: "high",
+  acceptance: { level: "none", reason: "lightweight lookup" },
   output: "context.md",
   reads: "shared-context.md",
   progress: true
@@ -1083,6 +1086,7 @@ Agent definitions are not loaded into context by default. Management actions let
 }}
 
 { action: "update", agent: "code-analysis.scout", config: { model: "openai/gpt-4o" } }
+{ action: "update", agent: "code-analysis.scout", config: { acceptance: "" } } // clear the frontmatter default
 { action: "update", chainName: "review-pipeline", config: { steps: [...] } }
 { action: "delete", agent: "scout" }
 { action: "delete", chainName: "review-pipeline" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@earendil-works/pi-tui": "0.74.0",
         "jiti": "2.7.0",
-        "typebox": "1.1.24"
+        "typebox": "1.1.24",
+        "yaml": "2.8.3"
       },
       "bin": {
         "pi-subagents": "install.mjs"
@@ -3683,7 +3684,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   "dependencies": {
     "@earendil-works/pi-tui": "0.74.0",
     "jiti": "2.7.0",
-    "typebox": "1.1.24"
+    "typebox": "1.1.24",
+    "yaml": "2.8.3"
   },
   "devDependencies": {
     "@earendil-works/pi-agent-core": "0.74.0",

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -672,6 +672,9 @@ That is only a starting point. Omit `package` for the traditional unqualified ru
 - `subagentOnlyExtensions`
 - `memory`
 - `maxSubagentDepth`
+- `acceptance`
+
+`acceptance` is a single-agent launch default. Use a scalar level such as `checked` or an inline/block YAML map such as `{ level: "none", reason: "lightweight lookup" }`. An explicit tool-call value wins; chain and parallel acceptance remains configured on the task or step. Management create/update accepts the same policy object, and `acceptance: ""` clears the frontmatter default (`false` remains the deprecated disabled-policy shorthand).
 
 Use `subagentOnlyExtensions` when a custom tool should exist only inside child sessions for that agent. Use `memory: { scope: "project" | "user", path: "<name>" }` for opt-in role-specific durable memory under the dedicated `agent-memory/` namespace; it is separate from parent/session project memory.
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -32,7 +32,8 @@ import { toModelInfo } from "../shared/model-info.ts";
 import { resolveSubagentModelOverride, type ParentModel } from "../runs/shared/model-fallback.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
 import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
-import type { Details, ExtensionConfig, ToolBudgetConfig } from "../shared/types.ts";
+import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
+import type { AcceptanceInput, Details, ExtensionConfig, ToolBudgetConfig } from "../shared/types.ts";
 import { getProjectConfigDir } from "../shared/utils.ts";
 
 type ManagementAction = "list" | "get" | "models" | "create" | "update" | "delete" | "eject" | "disable" | "enable" | "reset";
@@ -265,6 +266,7 @@ function preservedAgentFrontmatterFields(agent: AgentConfig, cfg: Record<string,
 	if (hasKey(cfg, "async")) changed("async");
 	if (hasKey(cfg, "timeoutMs")) changed("timeoutMs");
 	if (hasKey(cfg, "turnBudget")) changed("turnBudget");
+	if (hasKey(cfg, "acceptance")) changed("acceptance");
 	if (hasKey(cfg, "output")) changed("output");
 	if (hasKey(cfg, "reads")) changed("defaultReads");
 	if (hasKey(cfg, "progress")) changed("defaultProgress");
@@ -439,6 +441,14 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 			target.defaultTurnBudget = resolved.turnBudget;
 		}
 	}
+	if (hasKey(cfg, "acceptance")) {
+		if (cfg.acceptance === "") target.defaultAcceptance = undefined;
+		else {
+			const errors = validateAcceptanceInput(cfg.acceptance, "config.acceptance");
+			if (errors.length > 0) return errors.join(" ");
+			target.defaultAcceptance = cfg.acceptance as AcceptanceInput;
+		}
+	}
 	if (hasKey(cfg, "output")) {
 		if (cfg.output === false || cfg.output === "") target.output = undefined;
 		else if (typeof cfg.output === "string") target.output = cfg.output;
@@ -538,6 +548,7 @@ function formatAgentDetail(agent: AgentConfig): string {
 	if (agent.defaultAsync !== undefined) lines.push(`Async: ${agent.defaultAsync ? "true" : "false"}`);
 	if (agent.defaultTimeoutMs !== undefined) lines.push(`Timeout: ${agent.defaultTimeoutMs}ms`);
 	if (agent.defaultTurnBudget) lines.push(`Turn budget: ${JSON.stringify(agent.defaultTurnBudget)}`);
+	if (agent.defaultAcceptance !== undefined) lines.push(`Acceptance: ${typeof agent.defaultAcceptance === "object" ? JSON.stringify(agent.defaultAcceptance) : String(agent.defaultAcceptance)}`);
 	if (agent.source === "builtin") lines.push(`Disabled: ${agent.disabled ? "true" : "false"}`);
 	if (agent.extensions !== undefined) lines.push(`Extensions: ${agent.extensions.length ? agent.extensions.join(", ") : "(none)"}`);
 	if (agent.subagentOnlyExtensions !== undefined) lines.push(`Subagent-only extensions: ${agent.subagentOnlyExtensions.length ? agent.subagentOnlyExtensions.join(", ") : "(none)"}`);

--- a/src/agents/agent-serializer.ts
+++ b/src/agents/agent-serializer.ts
@@ -16,6 +16,7 @@ export const KNOWN_FIELDS = new Set([
 	"async",
 	"timeoutMs",
 	"turnBudget",
+	"acceptance",
 	"skill",
 	"skills",
 	"extensions",
@@ -68,6 +69,13 @@ export function serializeAgent(config: AgentConfig, options: SerializeAgentOptio
 	if (config.defaultAsync !== undefined || preserve("async")) lines.push(`async: ${config.defaultAsync === undefined ? "" : config.defaultAsync ? "true" : "false"}`);
 	if (config.defaultTimeoutMs !== undefined || preserve("timeoutMs")) lines.push(`timeoutMs: ${config.defaultTimeoutMs ?? ""}`);
 	if (config.defaultTurnBudget || preserve("turnBudget")) lines.push(`turnBudget: ${config.defaultTurnBudget ? JSON.stringify(config.defaultTurnBudget) : ""}`);
+	if (config.defaultAcceptance !== undefined || preserve("acceptance")) {
+		lines.push(`acceptance: ${config.defaultAcceptance === undefined
+			? ""
+			: typeof config.defaultAcceptance === "object"
+				? JSON.stringify(config.defaultAcceptance)
+				: String(config.defaultAcceptance)}`);
+	}
 
 	const skillsValue = joinComma(config.skills);
 	if (skillsValue || preserve("skill", "skills")) lines.push(`skills: ${skillsValue ?? ""}`);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -4,6 +4,7 @@
 
 import { execSync } from "node:child_process";
 import * as fs from "node:fs";
+import { parse as parseYaml } from "yaml";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,6 +19,7 @@ import { parseModelScopeConfig, type ModelScopeConfig } from "../runs/shared/mod
 export { buildRuntimeName, frontmatterNameForConfig, parsePackageName } from "./identity.ts";
 import { parseMemoryFrontmatter } from "./agent-memory.ts";
 import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
+import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 
 export type AgentScope = "user" | "project" | "both";
 
@@ -120,6 +122,7 @@ export interface AgentConfig {
 	defaultAsync?: boolean;
 	defaultTimeoutMs?: number;
 	defaultTurnBudget?: TurnBudgetConfig;
+	defaultAcceptance?: AcceptanceInput;
 	systemPrompt: string;
 	source: AgentSource;
 	filePath: string;
@@ -1164,6 +1167,19 @@ function isLegacyAgentSkillPath(rootDir: string, filePath: string): boolean {
 	return parts.some((part, index) => part === ".agents" && parts[index + 1] === "skills");
 }
 
+function parseAgentAcceptanceFrontmatter(raw: string | undefined, agentName: string): AcceptanceInput | undefined {
+	if (raw === undefined || !raw.trim()) return undefined;
+	let parsed: unknown;
+	try {
+		parsed = parseYaml(raw);
+	} catch (error) {
+		throw new Error(`Agent '${agentName}' has invalid acceptance frontmatter: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+	}
+	const errors = validateAcceptanceInput(parsed, `Agent '${agentName}' acceptance frontmatter`);
+	if (errors.length > 0) throw new Error(errors.join(" "));
+	return parsed as AcceptanceInput;
+}
+
 function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
@@ -1263,6 +1279,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			if (resolved.error) throw new Error(resolved.error);
 			defaultTurnBudget = resolved.turnBudget;
 		}
+		const defaultAcceptance = parseAgentAcceptanceFrontmatter(frontmatter.acceptance, localName);
 
 		let extensions: string[] | undefined;
 		if (frontmatter.extensions !== undefined) {
@@ -1316,6 +1333,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			defaultAsync,
 			defaultTimeoutMs,
 			defaultTurnBudget,
+			defaultAcceptance,
 			systemPrompt: body,
 			source,
 			filePath,

--- a/src/extension/tool-description.ts
+++ b/src/extension/tool-description.ts
@@ -41,7 +41,7 @@ MANAGEMENT (use action field, omit agent/task/chain/tasks):
 • { action: "models", agent?: "name" } - show the runtime-loaded builtin subagent model mapping, optionally filtered to one builtin
 • { action: "watchdog.status" | "watchdog.check" | "watchdog.recommend-model" } - inspect the opt-in subagent watchdog and its strong complementary model recommendation
 • { action: "watchdog.configure", model: "recommended" | "inherit" | "provider/model[:thinking]", scope?: "session" | "user" | "project", target?: "main" | "children" | "child", agent?: "name", thinking?: "inherit" | "off" | "minimal" | "low" | "medium" | "high" | "xhigh" } - configure watchdog model selection; default scope is session, use persistent scopes only when the user asks
-• { action: "create", config: { name: "custom-agent", package: "code-analysis", systemPrompt, systemPromptMode, inheritProjectContext, inheritSkills, defaultContext, ... } }
+• { action: "create", config: { name: "custom-agent", package: "code-analysis", systemPrompt, systemPromptMode, inheritProjectContext, inheritSkills, defaultContext, acceptance, ... } }
 • { action: "update", agent: "code-analysis.custom-agent", config: { package: "analysis", ... } } - merge
 • { action: "delete", agent: "code-analysis.custom-agent" }
 • { action: "eject", agent: "reviewer", agentScope?: "user" | "project" } - copy a bundled/package agent to user/project scope as an editable custom file that shadows the original (default scope: user)

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1593,6 +1593,9 @@ function applySingleAgentLaunchDefaults(params: SubagentParamsLike, agents: Agen
 		...(params.turnBudget === undefined && agent.defaultTurnBudget !== undefined
 			? { turnBudget: agent.defaultTurnBudget }
 			: {}),
+		...(params.acceptance === undefined && agent.defaultAcceptance !== undefined
+			? { acceptance: agent.defaultAcceptance }
+			: {}),
 	};
 }
 

--- a/test/integration/parallel-execution.test.ts
+++ b/test/integration/parallel-execution.test.ts
@@ -191,6 +191,25 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 		}
 	});
 
+	it("does not apply agent acceptance defaults to top-level parallel tasks", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "parallel response without explicit acceptance" });
+		const executor = makeExecutor([
+			makeAgent("echo", { defaultAcceptance: { level: "none", reason: "single launches only" } }),
+		]);
+
+		const result = await executor.execute(
+			"parallel-agent-acceptance-default",
+			{ tasks: [{ agent: "echo", task: "Return a concise answer" }] },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details?.results?.[0]?.acceptance?.explicit, false);
+		assert.equal(result.details?.results?.[0]?.acceptance?.effectiveAcceptance.level, "attested");
+	});
+
 	it("top-level parallel output saves use per-task output paths", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "Saved report" });
 		const executor = makeExecutor();

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1503,6 +1503,35 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(result.details?.turnBudget, { maxTurns: 4, graceTurns: 2 });
 	});
 
+	it("applies agent acceptance defaults and lets explicit calls override them", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "default acceptance disabled" });
+		mockPi.onCall({ stdoutRaw: `${JSON.stringify(events.assistantMessage("explicit checked response without a report"))}\n` });
+		const executor = makeExecutor([
+			makeAgent("echo", { defaultAcceptance: { level: "none", reason: "lightweight response" } }),
+		]);
+
+		const defaulted = await executor.execute(
+			"agent-acceptance-default",
+			{ agent: "echo", task: "Return a concise answer" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(defaulted.isError, undefined);
+		assert.equal(defaulted.details?.results?.[0]?.acceptance?.status, "not-required");
+		assert.equal(defaulted.details?.results?.[0]?.acceptance?.effectiveAcceptance.reason, "lightweight response");
+
+		const explicit = await executor.execute(
+			"agent-acceptance-explicit",
+			{ agent: "echo", task: "Return a concise answer", acceptance: "checked" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(explicit.isError, true);
+		assert.equal(explicit.details?.results?.[0]?.acceptance?.status, "rejected");
+	});
+
 	it("lets agent frontmatter override the global async default", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "agent foreground default finished" });
 		const executor = makeExecutor(

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -155,18 +155,62 @@ describe("agent frontmatter launch defaults", () => {
 			defaultAsync: false,
 			defaultTimeoutMs: 90_000,
 			defaultTurnBudget: { maxTurns: 12, graceTurns: 2 },
+			defaultAcceptance: { level: "none", reason: "lightweight lookup" },
 		};
 
 		const serialized = serializeAgent(agent);
 		assert.match(serialized, /^async: false$/m);
 		assert.match(serialized, /^timeoutMs: 90000$/m);
 		assert.match(serialized, /^turnBudget: \{"maxTurns":12,"graceTurns":2\}$/m);
+		assert.match(serialized, /^acceptance: \{"level":"none","reason":"lightweight lookup"\}$/m);
 		writeAgent(filePath, serialized);
 
 		const worker = discoverAgents(dir, "project").agents.find((candidate) => candidate.name === "worker");
 		assert.equal(worker?.defaultAsync, false);
 		assert.equal(worker?.defaultTimeoutMs, 90_000);
 		assert.deepEqual(worker?.defaultTurnBudget, { maxTurns: 12, graceTurns: 2 });
+		assert.deepEqual(worker?.defaultAcceptance, { level: "none", reason: "lightweight lookup" });
+	});
+
+	it("parses scalar acceptance defaults and rejects invalid policies", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-acceptance-defaults-"));
+		tempDirs.push(dir);
+		const filePath = path.join(dir, ".pi", "agents", "worker.md");
+		writeAgent(filePath, `---
+name: worker
+description: Worker
+acceptance: checked
+---
+
+Do work
+`);
+		assert.equal(discoverAgents(dir, "project").agents.find((agent) => agent.name === "worker")?.defaultAcceptance, "checked");
+
+		writeAgent(filePath, `---
+name: worker
+description: Worker
+acceptance: { level: "none", reason: "NA" }
+---
+
+Do work
+`);
+		assert.deepEqual(
+			discoverAgents(dir, "project").agents.find((agent) => agent.name === "worker")?.defaultAcceptance,
+			{ level: "none", reason: "NA" },
+		);
+
+		writeAgent(filePath, `---
+name: worker
+description: Worker
+acceptance: none
+---
+
+Do work
+`);
+		assert.throws(
+			() => discoverAgents(dir, "project"),
+			/Agent 'worker' acceptance frontmatter level "none" requires a reason/,
+		);
 	});
 
 	it("rejects invalid launch defaults instead of silently ignoring them", () => {

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -164,6 +164,7 @@ Inspect
 					async: false,
 					timeoutMs: 120_000,
 					turnBudget: { maxTurns: 8, graceTurns: 2 },
+					acceptance: { level: "none", reason: "lightweight reviewer" },
 				},
 			},
 			ctx,
@@ -175,15 +176,17 @@ Inspect
 		assert.match(content, /^async: false$/m);
 		assert.match(content, /^timeoutMs: 120000$/m);
 		assert.match(content, /^turnBudget: \{"maxTurns":8,"graceTurns":2\}$/m);
+		assert.match(content, /^acceptance: \{"level":"none","reason":"lightweight reviewer"\}$/m);
 
 		const got = handleManagementAction("get", { agent: "background-reviewer" }, ctx);
 		assert.equal(got.isError, false);
 		assert.match(readText(got), /Async: false/);
 		assert.match(readText(got), /Timeout: 120000ms/);
 		assert.match(readText(got), /Turn budget: \{"maxTurns":8,"graceTurns":2\}/);
+		assert.match(readText(got), /Acceptance: \{"level":"none","reason":"lightweight reviewer"\}/);
 
 		const updated = handleUpdate(
-			{ agent: "background-reviewer", config: { async: true, timeoutMs: false, turnBudget: false } },
+			{ agent: "background-reviewer", config: { async: true, timeoutMs: false, turnBudget: false, acceptance: "" } },
 			ctx,
 		);
 		assert.equal(updated.isError, false);
@@ -191,6 +194,15 @@ Inspect
 		assert.match(content, /^async: true$/m);
 		assert.doesNotMatch(content, /^timeoutMs:/m);
 		assert.doesNotMatch(content, /^turnBudget:/m);
+		assert.doesNotMatch(content, /^acceptance:/m);
+
+		const deprecatedFalse = handleUpdate(
+			{ agent: "background-reviewer", config: { acceptance: false } },
+			ctx,
+		);
+		assert.equal(deprecatedFalse.isError, false);
+		content = fs.readFileSync(filePath, "utf-8");
+		assert.match(content, /^acceptance: false$/m);
 	});
 
 	it("rejects invalid single-agent launch defaults", () => {
@@ -208,6 +220,20 @@ Inspect
 
 		assert.equal(result.isError, true);
 		assert.match(readText(result), /config\.timeoutMs must be a positive integer/);
+
+		const invalidAcceptance = handleCreate(
+			{
+				config: {
+					name: "bad-acceptance-default",
+					description: "Bad acceptance",
+					scope: "project",
+					acceptance: "none",
+				},
+			},
+			{ cwd: tempDir, modelRegistry: { getAvailable: () => [] } },
+		);
+		assert.equal(invalidAcceptance.isError, true);
+		assert.match(readText(invalidAcceptance), /config\.acceptance level "none" requires a reason/);
 	});
 
 	it("creates and updates agents with tool budgets", () => {


### PR DESCRIPTION
Adds `acceptance` as an agent frontmatter default for single-agent launches. Explicit tool-call acceptance always wins, while top-level parallel tasks and chain steps continue to use their own task/step acceptance configuration.

Frontmatter accepts scalar levels and inline or block YAML maps, including the reported `{ level: "none", reason: "NA" }` form. Policies go through the existing strict shared validator, so bare `none`, explicit `reviewed`, unknown fields, and malformed contracts fail during discovery. Serialization and agent management now round-trip the field; management uses an empty string to clear it because `false` remains the deprecated disabled-policy shorthand.

The YAML parser is declared as a direct runtime dependency rather than relying on the existing transitive development copy. Coverage exercises YAML parsing, object serialization, strict rejection, management create/update/get/clear, deprecated `false` persistence, explicit-call precedence, and the single-agent-only boundary.

`npm run test:all` passes with 1,164 unit tests, 534 integration tests, and one E2E test; one existing unit test remains skipped. `git diff --check` passes.

Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #453.

Fixes #453
