### PR TITLE
feat: add agent-local skill paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added agent-local `skillPath` discovery so custom agents can select private skills without publishing them to Pi's parent/global catalog. Relative paths resolve from the defining agent file, local matches take precedence, and missing or unreadable candidates fall back to normal discovery. Thanks to Kylegl (@kylegl) for #428.
 - Added strict `acceptance` defaults in agent frontmatter and agent management. The default applies only to single-agent launches, explicit call values win, and chain/parallel acceptance remains task or step configuration. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #453.
 - Added canonical-session leases for direct child revival so independent parent processes cannot write the same persisted session concurrently. Lease ownership includes the revived/source run, parent session, runner and writer process identities, and host; a two-phase startup handshake rejects contention before Pi starts, and stale recovery remains conservative. Thanks to Luke Parke (@LukasParke) for #446.
 - Added single-agent launch defaults for `async`, `timeoutMs`, and `turnBudget` in agent frontmatter, with explicit tool-call values taking precedence. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #410.

--- a/README.md
+++ b/README.md
@@ -704,7 +704,8 @@ thinking: high
 systemPromptMode: replace
 inheritProjectContext: false
 inheritSkills: false
-skills: safe-bash, chrome-devtools
+skills: safe-bash, review-checklist
+skillPath: ./skills, ../shared-skills
 output: context.md
 defaultReads: context.md
 defaultProgress: true
@@ -735,7 +736,8 @@ Important fields:
 | `inheritProjectContext` | Keeps or strips inherited project instruction blocks. |
 | `inheritSkills` | Keeps or strips Pi’s discovered skills catalog. |
 | `defaultContext` | Optional `fresh` or `fork` launch context default for this agent. |
-| `skills` | Adds specific skills to the child’s available skill list, regardless of `inheritSkills`. |
+| `skills` | Selects specific skills for the child, regardless of `inheritSkills`. |
+| `skillPath` | Comma-separated invocation-private skill files or discovery directories. Relative paths resolve from the agent definition file. Local matches take precedence, while unresolved or unreadable matches fall back to normal skill discovery. This field discovers candidates only; `skills` still selects what the child receives. |
 | `output` | Default single-agent output file. |
 | `defaultReads` | Files to read before running in chain/parallel behavior. |
 | `defaultProgress` | Maintain `progress.md`. |
@@ -747,6 +749,8 @@ Important fields:
 | `interactive` | Parsed for compatibility but not enforced in v1. |
 | `maxSubagentDepth` | Tightens nested delegation for this agent's children. |
 | `memory` | Opt-in role-specific persistent memory. `memory: { scope: "project" \| "user", path: "<name>" }` injects the first lines of a `MEMORY.md` from a dedicated `agent-memory/` directory into the child system prompt. Agents with write tools (`edit`/`write`/`bash`) get a read-write block; read-only agents get a read-only fallback. Project scope resolves under `<project>/.pi/agent-memory/`, user scope under `~/.pi/agent/agent-memory/`. Paths are validated against traversal and symlink escape. |
+
+Agent-local `skillPath` candidates never enter Pi's parent/global skills catalog. Pair `inheritSkills: false` with explicit `skills` and `skillPath` when a child should receive only its selected private skills.
 
 ### Per-agent persistent memory
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -659,6 +659,8 @@ tools: read, grep, find, ls, bash
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
+skills: safe-bash, review-checklist
+skillPath: ./skills, ../shared-skills
 ---
 
 Your system prompt here.
@@ -670,13 +672,15 @@ That is only a starting point. Omit `package` for the traditional unqualified ru
 - `output`
 - `fallbackModels`
 - `subagentOnlyExtensions`
+- `skills`
+- `skillPath`
 - `memory`
 - `maxSubagentDepth`
 - `acceptance`
 
 `acceptance` is a single-agent launch default. Use a scalar level such as `checked` or an inline/block YAML map such as `{ level: "none", reason: "lightweight lookup" }`. An explicit tool-call value wins; chain and parallel acceptance remains configured on the task or step. Management create/update accepts the same policy object, and `acceptance: ""` clears the frontmatter default (`false` remains the deprecated disabled-policy shorthand).
 
-Use `subagentOnlyExtensions` when a custom tool should exist only inside child sessions for that agent. Use `memory: { scope: "project" | "user", path: "<name>" }` for opt-in role-specific durable memory under the dedicated `agent-memory/` namespace; it is separate from parent/session project memory.
+Use `subagentOnlyExtensions` when a custom tool should exist only inside child sessions for that agent. `skillPath` adds invocation-private skill files or discovery directories relative to the agent file; it does not select them, so list the desired names under `skills`. Local matches win, unresolved or unreadable matches use normal discovery, and local candidates never enter the parent/global catalog. Use `memory: { scope: "project" | "user", path: "<name>" }` for opt-in role-specific durable memory under the dedicated `agent-memory/` namespace; it is separate from parent/session project memory.
 
 For many customizations, builtin overrides in settings are lower-friction than
 copying a full builtin file.

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -23,7 +23,7 @@ import {
 import { serializeAgent } from "./agent-serializer.ts";
 import { mergeAgentsForScope } from "./agent-selection.ts";
 import { serializeChain, serializeJsonChain } from "./chain-serializer.ts";
-import { discoverAvailableSkills } from "./skills.ts";
+import { discoverAvailableSkills, resolveSkills } from "./skills.ts";
 import {
 	buildProactiveSkillSubagentRecommendationLines,
 } from "./proactive-skills.ts";
@@ -190,10 +190,14 @@ function fallbackModelsWarning(ctx: ManagementContext, fallbackModels: string[] 
 	return missing.length ? `Warning: fallback models not in the current model registry: ${missing.join(", ")}.` : undefined;
 }
 
-function skillsWarning(cwd: string, skills: string[] | undefined): string | undefined {
-	if (!skills || skills.length === 0) return undefined;
-	const available = new Set(discoverAvailableSkills(cwd).map((s) => s.name));
-	const missing = skills.filter((s) => !available.has(s));
+function skillsWarning(cwd: string, agent: Pick<AgentConfig, "skills" | "skillPath" | "filePath">): string | undefined {
+	if (!agent.skills?.length) return undefined;
+	const { missing } = resolveSkills(
+		agent.skills,
+		cwd,
+		agent.skillPath,
+		agent.filePath ? path.dirname(agent.filePath) : cwd,
+	);
 	return missing.length ? `Warning: skills not found: ${missing.join(", ")}.` : undefined;
 }
 
@@ -213,6 +217,7 @@ function editableAgentConfig(agent: AgentConfig): AgentConfig {
 		disabled: base.disabled,
 		systemPrompt: base.systemPrompt,
 		skills: base.skills ? [...base.skills] : undefined,
+		skillPath: base.skillPath ? [...base.skillPath] : undefined,
 		tools: base.tools ? [...base.tools] : undefined,
 		mcpDirectTools: base.mcpDirectTools ? [...base.mcpDirectTools] : undefined,
 		subagentOnlyExtensions: base.subagentOnlyExtensions ? [...base.subagentOnlyExtensions] : undefined,
@@ -244,6 +249,7 @@ function preservedAgentFrontmatterFields(agent: AgentConfig, cfg: Record<string,
 	if (hasKey(cfg, "fallbackModels")) changed("fallbackModels");
 	if (hasKey(cfg, "tools")) changed("tools");
 	if (hasKey(cfg, "skills")) changed("skill", "skills");
+	if (hasKey(cfg, "skillPath")) changed("skillPath");
 	if (hasKey(cfg, "extensions")) changed("extensions");
 	if (hasKey(cfg, "subagentOnlyExtensions")) changed("subagentOnlyExtensions");
 	if (hasKey(cfg, "thinking")) {
@@ -388,6 +394,14 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 		if (cfg.skills === false || cfg.skills === "") target.skills = undefined;
 		else if (typeof cfg.skills === "string") { const skills = parseCsv(cfg.skills); target.skills = skills.length ? skills : undefined; }
 		else return "config.skills must be a comma-separated string or false when provided.";
+	}
+	if (hasKey(cfg, "skillPath")) {
+		if (cfg.skillPath === false || cfg.skillPath === "") target.skillPath = undefined;
+		else if (typeof cfg.skillPath === "string") { const skillPath = parseCsv(cfg.skillPath); target.skillPath = skillPath.length ? skillPath : undefined; }
+		else if (Array.isArray(cfg.skillPath) && cfg.skillPath.every((entry) => typeof entry === "string")) {
+			const skillPath = [...new Set(cfg.skillPath.map((entry) => entry.trim()).filter(Boolean))];
+			target.skillPath = skillPath.length ? skillPath : undefined;
+		} else return "config.skillPath must be a comma-separated string, string array, or false when provided.";
 	}
 	if (hasKey(cfg, "extensions")) {
 		if (cfg.extensions === false) target.extensions = undefined;
@@ -541,6 +555,7 @@ function formatAgentDetail(agent: AgentConfig): string {
 	if (agent.fallbackModels?.length) lines.push(`Fallback models: ${agent.fallbackModels.join(", ")}`);
 	if (tools.length) lines.push(`Tools: ${tools.join(", ")}`);
 	if (agent.skills?.length) lines.push(`Skills: ${agent.skills.join(", ")}`);
+	if (agent.skillPath?.length) lines.push(`Skill paths: ${agent.skillPath.join(", ")}`);
 	lines.push(`System prompt mode: ${agent.systemPromptMode}`);
 	lines.push(`Inherit project context: ${agent.inheritProjectContext ? "true" : "false"}`);
 	lines.push(`Inherit skills: ${agent.inheritSkills ? "true" : "false"}`);
@@ -808,7 +823,7 @@ export function handleCreate(params: ManagementParams, ctx: ManagementContext): 
 	if (mw) warnings.push(mw);
 	const fmw = fallbackModelsWarning(ctx, agent.fallbackModels);
 	if (fmw) warnings.push(fmw);
-	const sw = skillsWarning(ctx.cwd, agent.skills);
+	const sw = skillsWarning(ctx.cwd, agent);
 	if (sw) warnings.push(sw);
 	fs.writeFileSync(targetPath, serializeAgent(agent), "utf-8");
 	return result([`Created agent '${runtimeName}' at ${targetPath}.`, ...warnings].join("\n"));
@@ -857,8 +872,8 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 			const fmw = fallbackModelsWarning(ctx, updated.fallbackModels);
 			if (fmw) warnings.push(fmw);
 		}
-		if (hasKey(cfg, "skills")) {
-			const sw = skillsWarning(ctx.cwd, updated.skills);
+		if (hasKey(cfg, "skills") || hasKey(cfg, "skillPath")) {
+			const sw = skillsWarning(ctx.cwd, updated);
 			if (sw) warnings.push(sw);
 		}
 		if (updated.name !== oldName) {

--- a/src/agents/agent-serializer.ts
+++ b/src/agents/agent-serializer.ts
@@ -19,6 +19,7 @@ export const KNOWN_FIELDS = new Set([
 	"acceptance",
 	"skill",
 	"skills",
+	"skillPath",
 	"extensions",
 	"subagentOnlyExtensions",
 	"output",
@@ -79,6 +80,8 @@ export function serializeAgent(config: AgentConfig, options: SerializeAgentOptio
 
 	const skillsValue = joinComma(config.skills);
 	if (skillsValue || preserve("skill", "skills")) lines.push(`skills: ${skillsValue ?? ""}`);
+	const skillPathValue = joinComma(config.skillPath);
+	if (skillPathValue || preserve("skillPath")) lines.push(`skillPath: ${skillPathValue ?? ""}`);
 
 	if (config.extensions !== undefined) {
 		const extensionsValue = joinComma(config.extensions);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -68,6 +68,7 @@ export interface BuiltinAgentOverrideBase {
 	disabled?: boolean;
 	systemPrompt: string;
 	skills?: string[];
+	skillPath?: string[];
 	tools?: string[];
 	mcpDirectTools?: string[];
 	subagentOnlyExtensions?: string[];
@@ -127,6 +128,7 @@ export interface AgentConfig {
 	source: AgentSource;
 	filePath: string;
 	skills?: string[];
+	skillPath?: string[];
 	extensions?: string[];
 	subagentOnlyExtensions?: string[];
 	output?: string;
@@ -504,6 +506,7 @@ function cloneOverrideBase(agent: AgentConfig): BuiltinAgentOverrideBase {
 		disabled: agent.disabled,
 		systemPrompt: agent.systemPrompt,
 		skills: agent.skills ? [...agent.skills] : undefined,
+		skillPath: agent.skillPath ? [...agent.skillPath] : undefined,
 		tools: agent.tools ? [...agent.tools] : undefined,
 		mcpDirectTools: agent.mcpDirectTools ? [...agent.mcpDirectTools] : undefined,
 		subagentOnlyExtensions: agent.subagentOnlyExtensions ? [...agent.subagentOnlyExtensions] : undefined,
@@ -1234,6 +1237,10 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			?.split(",")
 			.map((s) => s.trim())
 			.filter(Boolean);
+		const skillPath = frontmatter.skillPath
+			?.split(",")
+			.map((entry) => entry.trim())
+			.filter(Boolean);
 		const fallbackModels = frontmatter.fallbackModels
 			?.split(",")
 			.map((model) => model.trim())
@@ -1338,6 +1345,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			source,
 			filePath,
 			skills: skills && skills.length > 0 ? skills : undefined,
+			skillPath: skillPath && skillPath.length > 0 ? skillPath : undefined,
 			extensions,
 			subagentOnlyExtensions,
 			output: frontmatter.output,

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -608,9 +608,22 @@ function readSkill(
 export function resolveSkills(
 	skillNames: string[],
 	cwd: string,
+	localSkillPaths?: string[],
+	localBaseDir?: string,
 ): { resolved: ResolvedSkill[]; missing: string[] } {
 	const resolved: ResolvedSkill[] = [];
 	const missing: string[] = [];
+	const localByName = new Map<string, CachedSkillEntry>();
+	if (localSkillPaths?.length) {
+		const agentDir = getAgentDir();
+		const localEntries = collectFilesystemSkills(cwd, agentDir, localSkillPaths.map((entry) => ({
+			path: path.resolve(localBaseDir ?? cwd, entry),
+			source: "unknown" as const,
+		})));
+		for (const entry of localEntries) {
+			if (!localByName.has(entry.name)) localByName.set(entry.name, entry);
+		}
+	}
 
 	for (const name of skillNames) {
 		const trimmed = name.trim();
@@ -620,18 +633,14 @@ export function resolveSkills(
 			continue;
 		}
 
-		const location = resolveSkillPath(trimmed, cwd);
-		if (!location) {
-			missing.push(trimmed);
-			continue;
+		const local = localByName.get(trimmed);
+		let skill = local ? readSkill(trimmed, local.filePath, local.source) : undefined;
+		if (!skill) {
+			const location = resolveSkillPath(trimmed, cwd);
+			if (location) skill = readSkill(trimmed, location.path, location.source);
 		}
-
-		const skill = readSkill(trimmed, location.path, location.source);
-		if (skill) {
-			resolved.push(skill);
-		} else {
-			missing.push(trimmed);
-		}
+		if (skill) resolved.push(skill);
+		else missing.push(trimmed);
 	}
 
 	return { resolved, missing };
@@ -641,8 +650,10 @@ export function resolveSkillsWithFallback(
 	skillNames: string[],
 	primaryCwd: string,
 	fallbackCwd?: string,
+	localSkillPaths?: string[],
+	localBaseDir?: string,
 ): { resolved: ResolvedSkill[]; missing: string[] } {
-	const primary = resolveSkills(skillNames, primaryCwd);
+	const primary = resolveSkills(skillNames, primaryCwd, localSkillPaths, localBaseDir);
 	if (!fallbackCwd || primary.missing.length === 0) return primary;
 	if (path.resolve(primaryCwd) === path.resolve(fallbackCwd)) return primary;
 

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -561,7 +561,13 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		}
 		const namespaceOutputPath = Boolean(inheritedRelativeParallelOutput && parallelOutputNamespace.taskIndex === undefined);
 		const skillNames = behavior.skills === false ? [] : behavior.skills;
-		const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(skillNames, stepCwd, ctx.cwd);
+		const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
+			skillNames,
+			stepCwd,
+			ctx.cwd,
+			a.skillPath,
+			a.filePath ? path.dirname(a.filePath) : stepCwd,
+		);
 		if (missingSkills.includes("pi-subagents")) throw new UnavailableSubagentSkillError(UNAVAILABLE_SUBAGENT_SKILL_ERROR);
 
 		let systemPrompt = a.systemPrompt?.trim() ?? "";
@@ -1024,7 +1030,13 @@ export function executeAsyncSingle(
 	const runnerCwd = resolveChildCwd(ctx.cwd, cwd);
 	const skillNames = params.skills ?? agentConfig.skills ?? [];
 	const availableModels = params.availableModels;
-	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(skillNames, runnerCwd, ctx.cwd);
+	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
+		skillNames,
+		runnerCwd,
+		ctx.cwd,
+		agentConfig.skillPath,
+		agentConfig.filePath ? path.dirname(agentConfig.filePath) : runnerCwd,
+	);
 	if (missingSkills.includes("pi-subagents")) return formatAsyncStartError("single", UNAVAILABLE_SUBAGENT_SKILL_ERROR);
 	let systemPrompt = agentConfig.systemPrompt?.trim() ?? "";
 	if (resolvedSkills.length > 0) {

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -4,6 +4,7 @@
 
 import { spawn } from "node:child_process";
 import { existsSync, unlinkSync } from "node:fs";
+import * as path from "node:path";
 import type { Message } from "@earendil-works/pi-ai";
 import type { AgentConfig } from "../../agents/agents.ts";
 import {
@@ -1177,7 +1178,13 @@ export async function runSync(
 	const sessionEnabled = Boolean(options.sessionFile || options.sessionDir) || shareEnabled;
 	const skillNames = options.skills ?? agent.skills ?? [];
 	const skillCwd = options.cwd ?? runtimeCwd;
-	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(skillNames, skillCwd, runtimeCwd);
+	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
+		skillNames,
+		skillCwd,
+		runtimeCwd,
+		agent.skillPath,
+		agent.filePath ? path.dirname(agent.filePath) : skillCwd,
+	);
 	if (skillNames.some((skill) => skill.trim() === "pi-subagents") && missingSkills.includes("pi-subagents")) {
 		return {
 			agent: agentName,

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -2546,6 +2546,60 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		}
 	});
 
+	it("injects agent-file-relative local skills into background single child prompts", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "Done asynchronously" });
+		const id = `async-local-skill-${Date.now().toString(36)}`;
+		const agentFile = path.join(tempDir, "agents", "worker", "worker.md");
+		const skillFile = path.join(path.dirname(agentFile), "skills", "local", "SKILL.md");
+		fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+		fs.writeFileSync(skillFile, "---\ndescription: async local skill\n---\nLocal skill body\n", "utf-8");
+
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", { filePath: agentFile, skills: ["local"], skillPath: ["./skills"] }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		await waitForAsyncResultFile(id);
+		const call = await waitForMockPiCall(mockPi, 0);
+		assert.match(call.systemPrompts.map((record) => record.text ?? "").join("\n"), /async local skill/);
+	});
+
+	it("isolates agent-local skills between background parallel chain children", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "one" });
+		mockPi.onCall({ output: "two" });
+		const id = `async-parallel-local-skills-${Date.now().toString(36)}`;
+		const agents = ["one", "two"].map((name) => {
+			const agentFile = path.join(tempDir, "agents", name, `${name}.md`);
+			const skillFile = path.join(path.dirname(agentFile), "skills", "local", "SKILL.md");
+			fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+			fs.writeFileSync(skillFile, `---\ndescription: ${name} async local skill\n---\nbody\n`, "utf-8");
+			return makeAgent(name, { filePath: agentFile, skills: ["local"], skillPath: ["./skills"] });
+		});
+
+		executeAsyncChain(id, {
+			chain: [{ parallel: [{ agent: "one", task: "One" }, { agent: "two", task: "Two" }], concurrency: 2 }],
+			resultMode: "parallel",
+			agents,
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		await waitForAsyncResultFile(id);
+		const prompts = await Promise.all([0, 1].map(async (index) => {
+			const call = await waitForMockPiCall(mockPi, index);
+			return call.systemPrompts.map((record) => record.text ?? "").join("\n");
+		}));
+		assert.equal(prompts.filter((prompt) => /one async local skill/.test(prompt) && !/two async local skill/.test(prompt)).length, 1);
+		assert.equal(prompts.filter((prompt) => /two async local skill/.test(prompt) && !/one async local skill/.test(prompt)).length, 1);
+	});
+
 	it("background single runs report unavailable pi-subagents skill requests", () => {
 		const id = `async-pi-subagents-skill-${Date.now().toString(36)}`;
 		const result = executeAsyncSingle(id, {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1178,6 +1178,23 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		}
 	});
 
+	it("injects an agent-file-relative local skill into the foreground child prompt", async () => {
+		mockPi.onCall({ output: "Done" });
+		const agentFile = path.join(tempDir, "agents", "nested", "worker.md");
+		const skillFile = path.join(path.dirname(agentFile), "skills", "local", "SKILL.md");
+		fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+		fs.writeFileSync(skillFile, "---\ndescription: local skill description\n---\nLocal skill body\n", "utf-8");
+		const agents = [makeAgent("worker", { filePath: agentFile, skills: ["local"], skillPath: ["./skills"] })];
+
+		const result = await runSync(tempDir, agents, "worker", "Task", {});
+
+		assert.equal(result.exitCode, 0);
+		assert.deepEqual(result.skills, ["local"]);
+		const prompt = readCall().systemPrompts.map((record) => record.text ?? "").join("\n");
+		assert.match(prompt, /local skill description/);
+		assert.match(prompt, new RegExp(escapeRegExp(skillFile)));
+	});
+
 	it("falls back to the runtime cwd when the task cwd lacks a skill", async () => {
 		const taskCwd = path.join(tempDir, "nested");
 		fs.mkdirSync(taskCwd, { recursive: true });

--- a/test/support/helpers.ts
+++ b/test/support/helpers.ts
@@ -51,6 +51,8 @@ interface AgentConfig {
 	extensions?: string[];
 	subagentOnlyExtensions?: string[];
 	skills?: string[];
+	skillPath?: string[];
+	filePath?: string;
 	thinking?: string;
 	systemPromptMode?: string;
 	inheritProjectContext?: boolean;

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -55,6 +55,23 @@ afterEach(() => {
 	}
 });
 
+describe("agent skillPath frontmatter", () => {
+	it("parses and serializes comma-separated paths", () => withTempHome(() => {
+		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-skill-path-agent-"));
+		tempDirs.push(project);
+		writeAgent(path.join(project, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Worker
+skillPath: ./skills, ../shared-skills
+---
+body`);
+
+		const worker = discoverAgents(project, "both").agents.find((agent) => agent.name === "worker")!;
+		assert.deepEqual(worker.skillPath, ["./skills", "../shared-skills"]);
+		assert.match(serializeAgent(worker), /^skillPath: \.\/skills, \.\.\/shared-skills$/m);
+	}));
+});
+
 describe("agent permission frontmatter", () => {
 	it("preserves nested permission YAML blocks through discovery and serialization", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-permission-frontmatter-"));

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -105,6 +105,39 @@ describe("agent management config parsing", () => {
 		assert.equal(fs.existsSync(updatedPath), false);
 	});
 
+	it("creates, reports, and clears agent-local skill paths", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+		const skillFile = path.join(tempDir, ".pi", "agents", "skills", "private", "SKILL.md");
+		fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+		fs.writeFileSync(skillFile, "---\ndescription: Private skill\n---\nbody\n", "utf-8");
+
+		const created = handleCreate({ config: {
+			name: "Local",
+			description: "Local skills",
+			scope: "project",
+			skills: "private",
+			skillPath: ["./skills", "./skills"],
+		} }, ctx);
+		assert.equal(created.isError, false);
+		assert.doesNotMatch(readText(created), /skills not found/);
+		const filePath = path.join(tempDir, ".pi", "agents", "local.md");
+		let content = fs.readFileSync(filePath, "utf-8");
+		assert.match(content, /^skillPath: \.\/skills$/m);
+
+		const got = handleManagementAction("get", { agent: "local" }, ctx);
+		assert.match(readText(got), /^Skill paths: \.\/skills$/m);
+
+		const updated = handleUpdate({ agent: "local", config: { skills: false, skillPath: false } }, ctx);
+		assert.equal(updated.isError, false);
+		content = fs.readFileSync(filePath, "utf-8");
+		assert.doesNotMatch(content, /^skills?:/m);
+		assert.doesNotMatch(content, /^skillPath:/m);
+
+		const invalid = handleUpdate({ agent: "local", config: { skillPath: ["./skills", 1] } }, ctx);
+		assert.equal(invalid.isError, true);
+		assert.match(readText(invalid), /config\.skillPath must be/);
+	});
+
 	it("rejects package values that cannot be normalized", () => {
 		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
 		const created = handleCreate(

--- a/test/unit/skills-fallback.test.ts
+++ b/test/unit/skills-fallback.test.ts
@@ -229,6 +229,12 @@ describe("skills filesystem fallback", () => {
 		const { resolved, missing } = resolveSkills(["pi-subagents", "safe-bash"], tempDir);
 		assert.deepEqual(missing, ["pi-subagents"]);
 		assert.deepEqual(resolved.map((skill) => skill.name), ["safe-bash"]);
+
+		const agentDir = path.join(tempDir, "agent");
+		writeSkillFile(path.join(agentDir, "skills", "pi-subagents"), "Still parent-only.");
+		const local = resolveSkills(["pi-subagents"], tempDir, ["./skills"], agentDir);
+		assert.deepEqual(local.resolved, []);
+		assert.deepEqual(local.missing, ["pi-subagents"]);
 	});
 
 	it("classifies package-provided skills as project-package", () => {
@@ -407,6 +413,56 @@ describe("skills filesystem fallback", () => {
 			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
 			else process.env.USERPROFILE = previousUserProfile;
 		}
+	});
+
+	it("resolves agent-local files and directories before global skills without publishing them", () => {
+		makeProjectSkill(tempDir, "shared", "global body");
+		const agentDir = path.join(tempDir, "agents", "nested");
+		writeSkillFile(path.join(agentDir, "skills", "shared"), "local shared body");
+		writeSkillFile(path.join(agentDir, "direct"), "local direct body");
+
+		const local = resolveSkills(["shared", "direct", "missing"], tempDir, ["./skills", "./direct/SKILL.md"], agentDir);
+		assert.deepEqual(local.resolved.map((skill) => [skill.name, skill.content]), [
+			["shared", "local shared body"],
+			["direct", "local direct body"],
+		]);
+		assert.deepEqual(local.missing, ["missing"]);
+		assert.equal(resolveSkills(["shared"], tempDir).resolved[0]?.content, "global body");
+		assert.equal(discoverAvailableSkills(tempDir).some((skill) => skill.name === "direct"), false);
+	});
+
+	it("does not read malformed global settings when every selected local skill resolves", () => {
+		const agentDir = path.join(tempDir, "agents", "nested");
+		writeSkillFile(path.join(agentDir, "skills", "local"), "local body");
+		fs.mkdirSync(path.join(tempDir, ".pi"), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, ".pi", "settings.json"), "{bad-json", "utf-8");
+
+		const result = resolveSkills(["local"], tempDir, ["./skills"], agentDir);
+		assert.deepEqual(result.missing, []);
+		assert.equal(result.resolved[0]?.content, "local body");
+	});
+
+	it("falls back globally when an agent-local skill candidate cannot be read", () => {
+		makeProjectSkill(tempDir, "shared", "global body");
+		const agentDir = path.join(tempDir, "agents", "nested");
+		const invalidLocalFile = path.join(agentDir, "skills", "shared", "SKILL.md");
+		fs.mkdirSync(invalidLocalFile, { recursive: true });
+
+		const result = resolveSkills(["shared"], tempDir, ["./skills"], agentDir);
+		assert.deepEqual(result.missing, []);
+		assert.equal(result.resolved[0]?.content, "global body");
+	});
+
+	it("keeps same-named agent-local skills isolated between invocations", () => {
+		makeProjectSkill(tempDir, "global-only", "global fallback");
+		const one = path.join(tempDir, "one");
+		const two = path.join(tempDir, "two");
+		writeSkillFile(path.join(one, "skills", "private"), "one private");
+		writeSkillFile(path.join(two, "skills", "private"), "two private");
+
+		assert.equal(resolveSkills(["private", "global-only"], tempDir, ["./skills"], one).resolved[0]?.content, "one private");
+		assert.equal(resolveSkills(["private", "global-only"], tempDir, ["./skills"], two).resolved[0]?.content, "two private");
+		assert.equal(resolveSkills(["global-only"], tempDir, ["./skills"], one).resolved[0]?.content, "global fallback");
 	});
 
 	it("surfaces malformed project settings files instead of silently ignoring them", () => {


### PR DESCRIPTION
Agent definitions can now declare invocation-private `skillPath` files or discovery directories while continuing to select skills by name through `skills`. Relative paths resolve from the defining agent file, local matches win, and unresolved or unreadable candidates fall back to normal discovery without entering the parent/global skills catalog.

The field is preserved through frontmatter, management create/update/get/clear, foreground runs, async single runs, and chain/parallel children. Tests cover lazy fallback, local precedence, cross-agent isolation, and the parent-only `pi-subagents` safety boundary.

This is the focused replacement for closed #428 and intentionally excludes that branch’s unrelated telemetry, widget, architecture, watchdog, and repository-guidance changes. Thanks to Kylegl (@kylegl) for the original feature and tests in #428.

Validation: `npm run test:all` and `git diff --check`.