### PR TITLE
Update wait follow-ups on latest upstream

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -39,6 +39,7 @@ import { registerSubagentRpcBridge } from "./rpc.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
 import { registerWaitTool } from "../runs/background/wait-tool.ts";
+import { drainOutstandingWork } from "../runs/background/auto-drain.ts";
 import registerSubagentNotify, { parseSubagentNotifyContent, type SubagentNotifyDetails } from "../runs/background/notify.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
@@ -526,6 +527,17 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		rpcBridge.dispose,
 	];
 	globalStore[eventUnsubscribeStoreKey] = eventUnsubscribes;
+
+	// Non-interactive auto-drain: in a headless run (`pi -p ...`) there is no next
+	// turn to receive a detached run's completion, so a model that ends the turn
+	// without calling subagent_wait would orphan its async runs (and any registered
+	// background-work provider's jobs, e.g. pi-patty-bg-tasks). Block turn-end
+	// until that work drains, so the process can't exit mid-flight. No-op when a
+	// UI is present or nothing is outstanding.
+	pi.on("agent_end", async (_event, ctx) => {
+		if (ctx.hasUI) return;
+		await drainOutstandingWork({ state, events: pi.events });
+	});
 
 	pi.on("tool_result", (event, ctx) => {
 		if (event.toolName !== "subagent") return;

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -23,7 +23,7 @@ import { discoverAgents } from "../agents/agents.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
-import { clearLegacyResultAnimationTimer, renderSubagentResult } from "../tui/render.ts";
+import { clearLegacyResultAnimationTimer, renderWidget, renderSubagentResult } from "../tui/render.ts";
 import { SubagentParams, SubagentWaitParams } from "./schemas.ts";
 import { validateChainInput } from "./chain-validation.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
@@ -38,7 +38,7 @@ import { createNativeSupervisorChannel } from "../intercom/native-supervisor-cha
 import { registerSubagentRpcBridge } from "./rpc.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
-import { resolveWaitToolConfig, waitForSubagents } from "../runs/background/subagent-wait.ts";
+import { registerWaitTool } from "../runs/background/wait-tool.ts";
 import registerSubagentNotify, { parseSubagentNotifyContent, type SubagentNotifyDetails } from "../runs/background/notify.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
@@ -227,7 +227,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	cleanupOldChainDirs();
 
 	const config = loadConfig();
-	const waitToolConfig = resolveWaitToolConfig(config.waitTool);
 	const asyncByDefault = config.asyncByDefault === true;
 	const tempArtifactsDir = getArtifactsDir(null);
 	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
@@ -490,25 +489,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	pi.registerTool(tool);
 
-	const subagentWaitTool: ToolDefinition<typeof SubagentWaitParams, Details> = {
-		name: "subagent_wait",
-		label: "Subagent Wait",
-		description: `Block until background (async) subagent runs started in this session finish, then return.
-
-Use this after launching async subagents when you have no independent work left and must not end your turn — for example inside a skill that has to run to completion, or any non-interactive run (\`pi -p ...\`) where the whole task is a single turn and ending it would abandon the still-running children.
-
-• { } — return as soon as the FIRST active run finishes (default). Ideal for a rolling fleet: launch N, wait, spawn a replacement for the one that finished, then call subagent_wait again — keeping N in flight.
-• { all: true } — block until EVERY active run in this session is finished.
-• { id: "..." } — wait for one specific async run or remembered detached foreground run (id or prefix) to finish.
-• { timeoutMs: 600000 } — stop waiting after N ms (the runs keep going regardless; default 30 min)
-
-subagent_wait also returns when a run needs attention (a child that went idle or blocked for a decision), not only on completion — so a stuck child never stalls the loop; the summary names the run(s) to inspect/nudge/resume/interrupt. It wakes the instant a completion or control event arrives (subscribed to Pi's event bus, with a poll fallback that reconciles crashed runners), keeps the turn alive for normal notification delivery, and resolves early if the turn is aborted.${waitToolConfig.enabled ? "" : "\n\nConfigured behavior: subagent_wait is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED and returns immediately without blocking."}`,
-		parameters: SubagentWaitParams,
-		execute(_id, params, signal, _onUpdate, _ctx) {
-			return waitForSubagents(params, signal, { state, events: pi.events, enabled: waitToolConfig.enabled });
-		},
-	};
-	pi.registerTool(subagentWaitTool);
+	registerWaitTool(pi, state, { waitTool: config.waitTool });
 
 	registerSlashCommands(pi, state);
 

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -447,7 +447,18 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		if (!state.currentSessionId) return;
 		let runs: AsyncRunSummary[];
 		try {
-			runs = listAsyncRuns(asyncDirRoot, { states: ["queued", "running"], sessionId: state.currentSessionId, resultsDir, kill: options.kill, now: options.now });
+			// Scope restore to this session's runs. asyncDirRoot is shared across
+			// every Pi session on the machine, so without the sessionId filter a
+			// new session would adopt other sessions' active runs — surfacing their
+			// TUI widget and completion notifications here. Matches result-watcher
+			// delivery scoping and the subagent_wait tool.
+			runs = listAsyncRuns(asyncDirRoot, {
+				states: ["queued", "running"],
+				sessionId: state.currentSessionId,
+				resultsDir,
+				kill: options.kill,
+				now: options.now,
+			});
 		} catch (error) {
 			console.error(`Failed to restore active async jobs from '${asyncDirRoot}':`, error);
 			return;

--- a/src/runs/background/auto-drain.ts
+++ b/src/runs/background/auto-drain.ts
@@ -1,0 +1,80 @@
+/**
+ * Non-interactive auto-drain: block turn-end until outstanding background work
+ * finishes when there is no next turn to receive completions.
+ *
+ * In an interactive session, a detached async run (or a registered background-
+ * work provider's job, e.g. pi-patty-bg-tasks) finishing later wakes the parent
+ * with a completion notification. Non-interactively (`pi -p ...`) the whole task
+ * is a single turn: once the model stops, the process exits and any in-flight
+ * work is abandoned — the async runner is orphaned, its result never observed;
+ * a patty bash job is killed at shutdown. Either way the model "finished"
+ * without the work it started.
+ *
+ * `subagent_wait` already closes this gap when the model calls it. This closes
+ * it when the model DOESN'T: on `agent_end` in a non-interactive session we run
+ * the same wait-until-drained logic ourselves, so the turn cannot end while
+ * tracked work is still in flight. The model no longer has to remember to call
+ * `subagent_wait`.
+ *
+ * This is gated on non-interactive mode (no UI) and only blocks while there is
+ * actually outstanding work, so it is a no-op for ordinary interactive turns and
+ * for turns that started nothing.
+ */
+
+import { waitForSubagents } from "./subagent-wait.ts";
+import { totalLiveBackgroundWork } from "./bg-providers.ts";
+import { listAsyncRuns } from "./async-status.ts";
+import { ASYNC_DIR, RESULTS_DIR, type SubagentState } from "../../shared/types.ts";
+import type { WaitEventBus } from "./subagent-wait.ts";
+
+/** Are there any tracked async runs or provider jobs still in flight for this session? */
+function hasOutstandingWork(state: SubagentState): boolean {
+	if (totalLiveBackgroundWork() > 0) return true;
+	try {
+		const active = listAsyncRuns(ASYNC_DIR, {
+			states: ["queued", "running"],
+			sessionId: state.currentSessionId ?? undefined,
+			resultsDir: RESULTS_DIR,
+		});
+		return active.length > 0;
+	} catch {
+		return false;
+	}
+}
+
+export interface AutoDrainDeps {
+	state: SubagentState;
+	events?: WaitEventBus;
+	/** Overall cap so a stuck job can't hang process exit forever. Default 30 min. */
+	timeoutMs?: number;
+	/** Injectable for tests; defaults to the real wait. */
+	wait?: typeof waitForSubagents;
+	/** Injectable for tests; defaults to hasOutstandingWork. */
+	hasWork?: (state: SubagentState) => boolean;
+}
+
+/**
+ * Block until every tracked async run and registered background-work provider
+ * job for this session is terminal (or the timeout elapses). Safe to call when
+ * nothing is outstanding — returns immediately. Never throws.
+ *
+ * Returns a short human-readable note about what it waited on (or undefined when
+ * there was nothing to wait for), for optional logging by the caller.
+ */
+export async function drainOutstandingWork(deps: AutoDrainDeps): Promise<string | undefined> {
+	const hasWork = deps.hasWork ?? hasOutstandingWork;
+	if (!hasWork(deps.state)) return undefined;
+	const wait = deps.wait ?? waitForSubagents;
+	try {
+		const res = await wait(
+			{ all: true, timeoutMs: deps.timeoutMs },
+			undefined,
+			{ state: deps.state, events: deps.events },
+		);
+		const text = res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" ").trim();
+		return text || "drained outstanding background work";
+	} catch (error) {
+		// Draining is best-effort; never block process exit on our own failure.
+		return `auto-drain error: ${error instanceof Error ? error.message : String(error)}`;
+	}
+}

--- a/src/runs/background/bg-providers.ts
+++ b/src/runs/background/bg-providers.ts
@@ -42,6 +42,23 @@ export interface BackgroundWorkProvider {
 	 * with no push signal still works via the poll fallback.
 	 */
 	wakeChannels?: readonly string[];
+	/**
+	 * Optional health check, run by `subagent_wait` on every poll tick before it reads
+	 * `liveCount()`. This is the provider's chance to reconcile its own units the
+	 * way pi-subagents reconciles detached async runs: detect a unit whose
+	 * process has died or wedged (no progress / not alive) and resolve it —
+	 * typically by terminating it so it stops counting as live and its normal
+	 * completion path fires.
+	 *
+	 * Without this, `subagent_wait` can block forever on a unit the provider still reports
+	 * as "running" but which will never finish (e.g. a background child hung in
+	 * its event loop, producing no output and never exiting). Implementations
+	 * must be cheap, synchronous, and must never throw — a throwing reconcile is
+	 * ignored so it can't break subagent_wait's loop.
+	 *
+	 * `nowMs` is passed so staleness thresholds are testable with a fake clock.
+	 */
+	reconcile?(nowMs: number): void;
 }
 
 /**
@@ -105,4 +122,19 @@ export function backgroundWorkWakeChannels(): string[] {
 		for (const ch of p.wakeChannels ?? []) channels.add(ch);
 	}
 	return [...channels];
+}
+
+/**
+ * Run every registered provider's optional `reconcile()` health check. Called by
+ * `subagent_wait` on each poll tick so a wedged/dead unit gets resolved instead
+ * of blocking forever. Never throws; a provider that throws is skipped.
+ */
+export function reconcileBackgroundWork(nowMs: number = Date.now()): void {
+	for (const p of registry().values()) {
+		try {
+			p.reconcile?.(nowMs);
+		} catch {
+			// A misbehaving provider must not break subagent_wait's reconciliation loop.
+		}
+	}
 }

--- a/src/runs/background/bg-providers.ts
+++ b/src/runs/background/bg-providers.ts
@@ -1,0 +1,108 @@
+/**
+ * Generic background-work provider contract for `subagent_wait`.
+ *
+ * `subagent_wait` blocks the current turn until outstanding out-of-band work finishes.
+ * Async subagent runs are tracked natively; but other extensions also produce
+ * background work the agent may need to join on — e.g. pi-patty-bg-tasks'
+ * backgrounded shell/agent jobs, a job-queue extension, a remote-exec worker,
+ * a test-runner, etc.
+ *
+ * Rather than hardcoding one extension's identifiers, `subagent_wait` reads a process-
+ * global registry of providers. Any extension in the same Node process can
+ * register a provider that answers two questions:
+ *
+ *   - `liveCount()` — how many of my background units are still in flight?
+ *   - `wakeChannels` — which event-bus channels should end subagent_wait's poll-sleep
+ *      early because my state just changed?
+ *
+ * `subagent_wait` sums `liveCount()` across all providers and subscribes to the union of
+ * their `wakeChannels`. A provider that isn't installed simply isn't in the
+ * registry, so this is null-safe and dependency-free (no imports between the
+ * packages — just a shared global keyed by a stable, versioned symbol).
+ */
+
+/** A source of background work that `subagent_wait` can join on. */
+export interface BackgroundWorkProvider {
+	/**
+	 * Stable identifier for this provider (e.g. "pi-patty-bg-tasks"). Used to
+	 * de-duplicate registrations and for diagnostics. Registering the same name
+	 * twice replaces the earlier entry.
+	 */
+	name: string;
+	/**
+	 * Count of this provider's background units currently in flight. Must be
+	 * cheap and synchronous — `subagent_wait` calls it every poll tick. Return 0 when
+	 * nothing is running. Should never throw; throwing providers are ignored.
+	 */
+	liveCount(): number;
+	/**
+	 * Event-bus channel names this provider emits when its state changes (e.g. a
+	 * job finished). `subagent_wait` subscribes to these so it wakes the instant work
+	 * finishes instead of waiting out the poll interval. Optional; a provider
+	 * with no push signal still works via the poll fallback.
+	 */
+	wakeChannels?: readonly string[];
+}
+
+/**
+ * Versioned global key holding the provider registry. Bumping the suffix is a
+ * breaking change to the registry shape; `subagent_wait` and every provider must agree.
+ */
+const REGISTRY_KEY = "__pi_bg_work_providers_v1";
+
+type Registry = Map<string, BackgroundWorkProvider>;
+
+function registry(): Registry {
+	const g = globalThis as Record<string, unknown>;
+	let reg = g[REGISTRY_KEY] as Registry | undefined;
+	if (!(reg instanceof Map)) {
+		reg = new Map<string, BackgroundWorkProvider>();
+		g[REGISTRY_KEY] = reg;
+	}
+	return reg;
+}
+
+/**
+ * Register (or replace) a background-work provider. Returns an unregister
+ * function. Safe to call from any extension; the registry is shared process-
+ * wide. Idempotent by `name`.
+ */
+export function registerBackgroundWorkProvider(provider: BackgroundWorkProvider): () => void {
+	if (!provider || typeof provider.liveCount !== "function" || typeof provider.name !== "string") {
+		return () => {};
+	}
+	const reg = registry();
+	reg.set(provider.name, provider);
+	return () => {
+		const current = reg.get(provider.name);
+		if (current === provider) reg.delete(provider.name);
+	};
+}
+
+/** All registered providers (snapshot). */
+export function backgroundWorkProviders(): BackgroundWorkProvider[] {
+	return [...registry().values()];
+}
+
+/** Total in-flight background units across all registered providers. Never throws. */
+export function totalLiveBackgroundWork(): number {
+	let total = 0;
+	for (const p of registry().values()) {
+		try {
+			const n = p.liveCount();
+			if (Number.isFinite(n) && n > 0) total += n;
+		} catch {
+			// A misbehaving provider must not break subagent_wait's accounting.
+		}
+	}
+	return total;
+}
+
+/** Union of wake channels across all registered providers. */
+export function backgroundWorkWakeChannels(): string[] {
+	const channels = new Set<string>();
+	for (const p of registry().values()) {
+		for (const ch of p.wakeChannels ?? []) channels.add(ch);
+	}
+	return [...channels];
+}

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -54,6 +54,7 @@ import {
 	type WaitToolConfig,
 } from "../../shared/types.ts";
 import { formatDuration } from "../../shared/formatters.ts";
+import { totalLiveBackgroundWork, backgroundWorkWakeChannels } from "./bg-providers.ts";
 
 /** States that mean a run is still in flight (not yet resolved). */
 const ACTIVE_STATES: ReadonlyArray<AsyncRunSummary["state"]> = ["queued", "running"];
@@ -135,39 +136,39 @@ export interface SubagentWaitDeps {
 	 */
 	events?: WaitEventBus;
 	/**
-	 * Count of in-flight background bash/agent jobs (pi-patty-bg-tasks). Defaults
-	 * to reading that extension's process-global live set; injectable for tests.
+	 * Count of in-flight background work across all registered providers. Defaults
+	 * to summing every provider's liveCount() (see bg-providers.ts); injectable
+	 * for tests.
 	 */
 	bgTaskCount?: () => number;
 }
 
-/** Bus channel emitted by pi-patty-bg-tasks when a background job finishes. */
-const BG_TASK_FINISHED_EVENT = "patty:bg-task-finished";
-
-/** Bus channels that indicate a run changed state or needs attention. */
-const WAKE_CHANNELS = [
+/** Subagent-run bus channels that indicate a run changed state or needs attention. */
+const SUBAGENT_WAKE_CHANNELS = [
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_FOREGROUND_COMPLETE_EVENT,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_RESULT_INTERCOM_EVENT,
-	// pi-patty-bg-tasks emits this the instant a background bash/agent job
-	// finishes, so wait catches a backgrounded shell completing, not just
-	// subagent runs.
-	BG_TASK_FINISHED_EVENT,
 ];
 
 /**
- * Count of in-flight background jobs published by pi-patty-bg-tasks on a
- * process-global set (its shared-live.ts, keyed by this versioned symbol). Both
- * extensions share one Node process, so this is a dependency-free read of how
- * many backgrounded bash/agent jobs are running. Returns 0 when the extension
- * isn't installed (the global is absent).
+ * All channels wait wakes on: the subagent channels above plus whatever wake
+ * channels registered background-work providers contribute (e.g. a job-finished
+ * event from pi-patty-bg-tasks or any other provider). Computed per call so
+ * providers that register after module load are still honored.
  */
-const PATTY_LIVE_KEY = "__pi_patty_bg_live_jobs_v1";
+function wakeChannels(): string[] {
+	return [...SUBAGENT_WAKE_CHANNELS, ...backgroundWorkWakeChannels()];
+}
+
+/**
+ * Count of in-flight background work across every registered provider.
+ * Dependency-free: providers publish themselves on a shared process-global
+ * registry, so this returns 0 when nothing is registered. See bg-providers.ts.
+ */
 function liveBgTaskCount(): number {
-	const set = (globalThis as Record<string, unknown>)[PATTY_LIVE_KEY];
-	return set instanceof Set ? set.size : 0;
+	return totalLiveBackgroundWork();
 }
 
 function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
@@ -216,7 +217,7 @@ function waitForWake(ms: number, signal: AbortSignal | undefined, deps: Subagent
 			return;
 		}
 		signal?.addEventListener("abort", done, { once: true });
-		for (const channel of WAKE_CHANNELS) {
+		for (const channel of wakeChannels()) {
 			try { unsubs.push(events.on(channel, done)); } catch { /* ignore bad channel */ }
 		}
 		// Poll-interval fallback so we still reconcile even if no event arrives.
@@ -368,8 +369,8 @@ export async function waitForSubagents(
 	// first run to finish.
 	const waitForAll = params.id ? true : params.all === true;
 
-	// Background bash/agent jobs (pi-patty-bg-tasks) are tracked only for an
-	// unscoped wait — an `id` targets a specific async subagent run.
+	// Background work from registered providers (e.g. pi-patty-bg-tasks) is
+	// tracked only for an unscoped wait — an `id` targets a specific async run.
 	const bgCountFn = deps.bgTaskCount ?? liveBgTaskCount;
 	const trackBg = !params.id;
 	const initialBgCount = trackBg ? bgCountFn() : 0;
@@ -479,7 +480,7 @@ export async function waitForSubagents(
 	const elapsed = formatDuration(now() - startedAt);
 	const outcome = terminalSummary ? ` Outcome: ${terminalSummary}.` : "";
 
-	// Background-job accounting (pi-patty-bg-tasks).
+	// Background-job accounting (registered background-work providers).
 	const bgNow = trackBg ? bgCountFn() : 0;
 	const bgFinished = Math.max(0, initialBgCount - bgNow);
 	const bgNote = initialBgCount > 0

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -134,7 +134,15 @@ export interface SubagentWaitDeps {
 	 * events). Omit in tests that want pure poll behavior.
 	 */
 	events?: WaitEventBus;
+	/**
+	 * Count of in-flight background bash/agent jobs (pi-patty-bg-tasks). Defaults
+	 * to reading that extension's process-global live set; injectable for tests.
+	 */
+	bgTaskCount?: () => number;
 }
+
+/** Bus channel emitted by pi-patty-bg-tasks when a background job finishes. */
+const BG_TASK_FINISHED_EVENT = "patty:bg-task-finished";
 
 /** Bus channels that indicate a run changed state or needs attention. */
 const WAKE_CHANNELS = [
@@ -143,7 +151,24 @@ const WAKE_CHANNELS = [
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_RESULT_INTERCOM_EVENT,
+	// pi-patty-bg-tasks emits this the instant a background bash/agent job
+	// finishes, so wait catches a backgrounded shell completing, not just
+	// subagent runs.
+	BG_TASK_FINISHED_EVENT,
 ];
+
+/**
+ * Count of in-flight background jobs published by pi-patty-bg-tasks on a
+ * process-global set (its shared-live.ts, keyed by this versioned symbol). Both
+ * extensions share one Node process, so this is a dependency-free read of how
+ * many backgrounded bash/agent jobs are running. Returns 0 when the extension
+ * isn't installed (the global is absent).
+ */
+const PATTY_LIVE_KEY = "__pi_patty_bg_live_jobs_v1";
+function liveBgTaskCount(): number {
+	const set = (globalThis as Record<string, unknown>)[PATTY_LIVE_KEY];
+	return set instanceof Set ? set.size : 0;
+}
 
 function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
 	return new Promise((resolve) => {
@@ -343,6 +368,12 @@ export async function waitForSubagents(
 	// first run to finish.
 	const waitForAll = params.id ? true : params.all === true;
 
+	// Background bash/agent jobs (pi-patty-bg-tasks) are tracked only for an
+	// unscoped wait — an `id` targets a specific async subagent run.
+	const bgCountFn = deps.bgTaskCount ?? liveBgTaskCount;
+	const trackBg = !params.id;
+	const initialBgCount = trackBg ? bgCountFn() : 0;
+
 	let active: AsyncRunSummary[];
 	let foreground: ForegroundResumeRun[];
 	try {
@@ -369,10 +400,10 @@ export async function waitForSubagents(
 		active = selected?.kind === "async" ? [selected.run] : [];
 	}
 
-	if (active.length === 0) {
+	if (active.length === 0 && initialBgCount === 0) {
 		const finished = params.id
 			? `No active run matched "${params.id}". Nothing to wait for.`
-			: "No active async runs in this session. Nothing to wait for.";
+			: "No active async runs or background jobs in this session. Nothing to wait for.";
 		return result(finished);
 	}
 	const waitParams = params.id ? { ...params, id: active[0]!.id } : params;
@@ -389,10 +420,17 @@ export async function waitForSubagents(
 		// caller has to act on it (nudge/resume/interrupt) and blocking longer
 		// helps nothing.
 		if (attention.length > 0) return true;
-		if (waitForAll) return active.every((run) => !initialIds.has(run.id));
-		// First-completion: satisfied once any initially-pending run is gone.
+		const bgNow = trackBg ? bgCountFn() : 0;
+		if (waitForAll) {
+			// Everything must be terminal: no initial async runs still active AND
+			// no background jobs left running.
+			return active.every((run) => !initialIds.has(run.id)) && bgNow === 0;
+		}
+		// First-completion: satisfied once any initially-pending async run is gone,
+		// OR any background job has finished (bg count dropped).
 		const stillActiveInitial = active.filter((run) => initialIds.has(run.id));
-		return stillActiveInitial.length < initialCount;
+		if (stillActiveInitial.length < initialCount) return true;
+		return bgNow < initialBgCount;
 	};
 
 	let attention = active.filter((run) => needsAttention(run));
@@ -441,30 +479,42 @@ export async function waitForSubagents(
 	const elapsed = formatDuration(now() - startedAt);
 	const outcome = terminalSummary ? ` Outcome: ${terminalSummary}.` : "";
 
+	// Background-job accounting (pi-patty-bg-tasks).
+	const bgNow = trackBg ? bgCountFn() : 0;
+	const bgFinished = Math.max(0, initialBgCount - bgNow);
+	const bgNote = initialBgCount > 0
+		? ` ${bgFinished} of ${initialBgCount} background job(s) finished` + (bgNow > 0 ? `, ${bgNow} still running.` : ".")
+		: "";
+
 	if (waitForAll) {
-		const scope = params.id ? `run "${params.id}"` : `${initialCount} async run(s)`;
+		const parts: string[] = [];
+		if (initialCount > 0) parts.push(`${initialCount} async run(s)`);
+		if (initialBgCount > 0) parts.push(`${initialBgCount} background job(s)`);
+		const scope = params.id ? `run "${params.id}"` : (parts.join(" + ") || "0 runs");
 		const status = attention.length > 0 ? "attention required" : "done";
 		const notificationText = attention.length > 0
 			? "Relevant completion/control events have been observed; inspect status if the notification is not visible yet."
 			: "Completion events have been observed; inspect status if the notification is not visible yet.";
 		return result(
-			`Waited ${elapsed} for ${scope}; ${status}.${outcome}${attentionNote} ${notificationText}`,
+			`Waited ${elapsed} for ${scope}; ${status}.${outcome}${bgNote}${attentionNote} ${notificationText}`,
 		);
 	}
 
 	// First-completion mode.
-	const remainder = stillRunning > 0
-		? ` ${stillRunning} run(s) still in flight — call subagent_wait again to catch the next one.`
+	const remainder = (stillRunning > 0 || bgNow > 0)
+		? ` ${stillRunning} run(s) + ${bgNow} background job(s) still in flight — call subagent_wait again to catch the next one.`
 		: attention.length > 0
 			? " No other runs are waitable until attention is handled."
-			: " No runs remain in flight.";
+			: " Nothing remains in flight.";
 	const progress = attention.length > 0 && finishedCount === 0
 		? `${attention.length} of ${initialCount} run(s) need attention`
-		: `${finishedCount} of ${initialCount} run(s) finished`;
-	const notificationText = finishedCount > 0
-		? " Completion events for the finished run(s) have been observed; inspect status if the notification is not visible yet."
+		: initialCount > 0
+			? `${finishedCount} of ${initialCount} run(s) finished`
+			: "no async runs tracked";
+	const notificationText = (finishedCount > 0 || bgFinished > 0)
+		? " Completion events for the finished work have been observed; inspect status if the notification is not visible yet."
 		: " Relevant control events have been observed; inspect status if the notification is not visible yet.";
 	return result(
-		`Waited ${elapsed}; ${progress}.${outcome}${attentionNote}${remainder}${notificationText}`,
+		`Waited ${elapsed}; ${progress}.${outcome}${bgNote}${attentionNote}${remainder}${notificationText}`,
 	);
 }

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -54,7 +54,7 @@ import {
 	type WaitToolConfig,
 } from "../../shared/types.ts";
 import { formatDuration } from "../../shared/formatters.ts";
-import { totalLiveBackgroundWork, backgroundWorkWakeChannels } from "./bg-providers.ts";
+import { totalLiveBackgroundWork, backgroundWorkWakeChannels, reconcileBackgroundWork } from "./bg-providers.ts";
 
 /** States that mean a run is still in flight (not yet resolved). */
 const ACTIVE_STATES: ReadonlyArray<AsyncRunSummary["state"]> = ["queued", "running"];
@@ -129,7 +129,7 @@ export interface SubagentWaitDeps {
 	/** Injectable sleep for tests. */
 	sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
 	/**
-	 * Optional event bus (pi.events). When provided, wait wakes immediately on a
+	 * Optional event bus (pi.events). When provided, subagent_wait wakes immediately on a
 	 * subagent completion/control event instead of waiting out the poll interval;
 	 * the poll then remains as a reconciliation fallback (crashed runners, missed
 	 * events). Omit in tests that want pure poll behavior.
@@ -141,6 +141,12 @@ export interface SubagentWaitDeps {
 	 * for tests.
 	 */
 	bgTaskCount?: () => number;
+	/**
+	 * Run registered providers' health checks (reconcile) once per poll tick, so a
+	 * wedged/dead provider unit is resolved instead of blocking subagent_wait forever.
+	 * Defaults to reconcileBackgroundWork; injectable for tests.
+	 */
+	reconcileBg?: (nowMs: number) => void;
 }
 
 /** Subagent-run bus channels that indicate a run changed state or needs attention. */
@@ -153,7 +159,7 @@ const SUBAGENT_WAKE_CHANNELS = [
 ];
 
 /**
- * All channels wait wakes on: the subagent channels above plus whatever wake
+ * All channels subagent_wait wakes on: the subagent channels above plus whatever wake
  * channels registered background-work providers contribute (e.g. a job-finished
  * event from pi-patty-bg-tasks or any other provider). Computed per call so
  * providers that register after module load are still honored.
@@ -372,7 +378,11 @@ export async function waitForSubagents(
 	// Background work from registered providers (e.g. pi-patty-bg-tasks) is
 	// tracked only for an unscoped wait — an `id` targets a specific async run.
 	const bgCountFn = deps.bgTaskCount ?? liveBgTaskCount;
+	const reconcileBg = deps.reconcileBg ?? reconcileBackgroundWork;
 	const trackBg = !params.id;
+	// Health-check providers before the first count so a unit that is already
+	// dead/wedged at wait entry isn't counted as outstanding.
+	if (trackBg) reconcileBg(now());
 	const initialBgCount = trackBg ? bgCountFn() : 0;
 
 	let active: AsyncRunSummary[];
@@ -450,6 +460,10 @@ export async function waitForSubagents(
 			);
 		}
 		await waitForWake(pollIntervalMs, signal, deps);
+		// Reconcile provider health each tick: a background unit whose process died
+		// or wedged is resolved here (e.g. terminated) so its live count drops and
+		// subagent_wait can make progress instead of blocking on a unit that never finishes.
+		if (trackBg) reconcileBg(now());
 		try {
 			active = activeRunsForSession(waitParams, deps);
 			pending = active.filter((run) => !needsAttention(run));

--- a/src/runs/background/wait-tool.ts
+++ b/src/runs/background/wait-tool.ts
@@ -3,7 +3,8 @@
  *
  * Used by both the parent extension (src/extension/index.ts) and the child
  * subagent runtime (src/runs/shared/subagent-prompt-runtime.ts) so subagents
- * that background a bash/agent job (pi-patty-bg-tasks) or launch their own
+ * that background work via any registered background-work provider (e.g.
+ * pi-patty-bg-tasks' bash/agent jobs; see bg-providers.ts) or launch their own
  * async runs can block on completion the same way the parent can.
  */
 
@@ -27,8 +28,9 @@ subagent_wait also returns when a subagent run needs attention (a child that wen
 
 /**
  * Register the `subagent_wait` tool on `pi` backed by `state`. `state` supplies
- * the current session id (for scoping async runs); background-job tracking reads
- * the pi-patty-bg-tasks process-global live set and needs no state.
+ * the current session id (for scoping async runs); background-job tracking sums
+ * the live counts of registered background-work providers (bg-providers.ts) and
+ * needs no state.
  */
 export function registerWaitTool(pi: ExtensionAPI, state: SubagentState, options: { waitTool?: WaitToolConfig; enabled?: boolean } = {}): void {
 	const enabled = options.enabled ?? resolveWaitToolConfig(options.waitTool).enabled;

--- a/src/runs/background/wait-tool.ts
+++ b/src/runs/background/wait-tool.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared registration of the `subagent_wait` tool.
+ *
+ * Used by both the parent extension (src/extension/index.ts) and the child
+ * subagent runtime (src/runs/shared/subagent-prompt-runtime.ts) so subagents
+ * that background a bash/agent job (pi-patty-bg-tasks) or launch their own
+ * async runs can block on completion the same way the parent can.
+ */
+
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { SubagentWaitParams } from "../../extension/schemas.ts";
+import type { Details, SubagentState, WaitToolConfig } from "../../shared/types.ts";
+import { resolveWaitToolConfig, waitForSubagents } from "./subagent-wait.ts";
+
+function waitDescription(enabled: boolean): string {
+	return `Block until background work started in this session finishes, then return.
+
+Use this after launching async subagents or background bash/agent jobs when you have no independent work left and must not end your turn — for example inside a skill that must run to completion, or any non-interactive run (\`pi -p ...\`) where the whole task is a single turn and ending it would abandon the still-running work.
+
+• { } — return as soon as the FIRST piece of work finishes (default): an async subagent run OR a background job (pi-patty-bg-tasks bash_bg/agent_bg). Ideal for a rolling fleet: launch N, wait, spawn a replacement, then call subagent_wait again.
+• { all: true } — block until EVERY active subagent run AND background job in this session is finished.
+• { id: "..." } — wait for one specific async subagent run or remembered detached foreground run (id or prefix) to finish.
+• { timeoutMs: 600000 } — stop waiting after N ms (the work keeps going regardless; default 30 min)
+
+subagent_wait also returns when a subagent run needs attention (a child that went idle or blocked for a decision), not only on completion — so a stuck child never stalls the loop. It wakes the instant a completion/control event arrives (subscribed to Pi's event bus — subagent completions and background-job completions — with a poll fallback), and resolves early if the turn is aborted.${enabled ? "" : "\n\nConfigured behavior: subagent_wait is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED and returns immediately without blocking."}`;
+}
+
+/**
+ * Register the `subagent_wait` tool on `pi` backed by `state`. `state` supplies
+ * the current session id (for scoping async runs); background-job tracking reads
+ * the pi-patty-bg-tasks process-global live set and needs no state.
+ */
+export function registerWaitTool(pi: ExtensionAPI, state: SubagentState, options: { waitTool?: WaitToolConfig; enabled?: boolean } = {}): void {
+	const enabled = options.enabled ?? resolveWaitToolConfig(options.waitTool).enabled;
+	const waitTool: ToolDefinition<typeof SubagentWaitParams, Details> = {
+		name: "subagent_wait",
+		label: "Subagent Wait",
+		description: waitDescription(enabled),
+		parameters: SubagentWaitParams,
+		execute(_id, params, signal, _onUpdate, _ctx) {
+			return waitForSubagents(params, signal, { state, events: pi.events, enabled });
+		},
+	};
+	pi.registerTool(waitTool);
+}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3781,6 +3781,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 	): Promise<AgentToolResult<Details>> => {
 		const requestParams = omitExecutionModeActionAlias(params);
 		if (requestParams.action) return execute(id, requestParams, signal, onUpdate, ctx);
+		// The single-dispatch guard only serializes FOREGROUND (blocking) runs:
+		// they hold the turn and drive the interactive UI through a single
+		// foreground-control slot, so two concurrent ones would collide. Async
+		// runs are detached and return immediately, so any number can be launched
+		// in one turn — that is the intended fleet/fan-out pattern (launch N, then
+		// subagent_wait()). Only foreground runs engage the in-progress lock.
+		const runsForeground = !((requestParams.async ?? deps.asyncByDefault) && requestParams.clarify !== true);
+		if (!runsForeground) return execute(id, requestParams, signal, onUpdate, ctx);
 		if (deps.state.subagentInProgress === true) return duplicateSubagentCallResult(requestParams);
 		deps.state.subagentInProgress = true;
 		try {

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -302,7 +302,32 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		registerNativeSupervisorClient(pi);
 	};
 	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown) => unknown) => void;
-	onRuntimeEvent("session_start", () => {
+	// Make `subagent_wait` available inside subagents too. A subagent that backgrounds a
+	// bash/agent job (pi-patty-bg-tasks) or launches its own async runs can then
+	// block on their completion. Background-work tracking uses registered
+	// providers; async-run scoping uses this child's own session id.
+	const childWaitState = {
+		baseCwd: "",
+		currentSessionId: null,
+		asyncJobs: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	} as unknown as SubagentState;
+	try {
+		registerWaitTool(pi, childWaitState);
+	} catch {
+		// subagent_wait is a convenience in children; never block child startup on it.
+	}
+	onRuntimeEvent("session_start", (_event: unknown, ctx: unknown) => {
+		const sm = (ctx as { sessionManager?: { getSessionId?: () => string | undefined } } | undefined)?.sessionManager;
+		childWaitState.currentSessionId = sm?.getSessionId?.() ?? null;
 		registerNativeSupervisorClientOnce();
 		refreshChildToolDiagnostic(pi);
 	});
@@ -376,33 +401,4 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		return { systemPrompt: rewritten };
 	});
 
-	// Make `subagent_wait` available inside subagents too. A subagent that backgrounds a
-	// bash/agent job (pi-patty-bg-tasks) or launches its own async runs can then
-	// block on their completion — the same tool the parent has. Background-job
-	// tracking uses the process-global live set (no state needed); async-run
-	// scoping uses this child's own session id, resolved lazily at wait time.
-	try {
-		const childState = {
-			baseCwd: "",
-			currentSessionId: null,
-			asyncJobs: new Map(),
-			foregroundControls: new Map(),
-			lastForegroundControlId: null,
-			cleanupTimers: new Map(),
-			lastUiContext: null,
-			poller: null,
-			completionSeen: new Map(),
-			watcher: null,
-			watcherRestartTimer: null,
-			resultFileCoalescer: { schedule: () => false, clear: () => {} },
-		} as unknown as SubagentState;
-		const onChildSessionStart = pi.on as unknown as (event: string, handler: (event: unknown, ctx: unknown) => unknown) => void;
-		onChildSessionStart("session_start", (_event: unknown, ctx: unknown) => {
-			const sm = (ctx as { sessionManager?: { getSessionId?: () => string | undefined } }).sessionManager;
-			childState.currentSessionId = sm?.getSessionId?.() ?? null;
-		});
-		registerWaitTool(pi, childState);
-	} catch {
-		// subagent_wait is a convenience in children; never block child startup on it.
-	}
 }

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -13,10 +13,11 @@ import {
 	type ChildToolDiagnostic,
 } from "./tool-availability.ts";
 import { TOOL_BUDGET_ENV, decodeToolBudgetEnv, shouldBlockToolForBudget, toolBudgetBlockedMessage, toolBudgetSoftNudge } from "./tool-budget.ts";
-import type { JsonSchemaObject, ResolvedToolBudget } from "../../shared/types.ts";
+import type { JsonSchemaObject, ResolvedToolBudget, SubagentState } from "../../shared/types.ts";
 import { resolveWatchPath } from "../../shared/utils.ts";
 import { registerChildWatchdog } from "../../watchdog/register-child.ts";
 import { SUBAGENT_WATCHDOG_WARNING_TYPE } from "../../watchdog/types.ts";
+import { registerWaitTool } from "../background/wait-tool.ts";
 
 const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
 const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
@@ -374,4 +375,34 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		if (rewritten === event.systemPrompt) return;
 		return { systemPrompt: rewritten };
 	});
+
+	// Make `subagent_wait` available inside subagents too. A subagent that backgrounds a
+	// bash/agent job (pi-patty-bg-tasks) or launches its own async runs can then
+	// block on their completion — the same tool the parent has. Background-job
+	// tracking uses the process-global live set (no state needed); async-run
+	// scoping uses this child's own session id, resolved lazily at wait time.
+	try {
+		const childState = {
+			baseCwd: "",
+			currentSessionId: null,
+			asyncJobs: new Map(),
+			foregroundControls: new Map(),
+			lastForegroundControlId: null,
+			cleanupTimers: new Map(),
+			lastUiContext: null,
+			poller: null,
+			completionSeen: new Map(),
+			watcher: null,
+			watcherRestartTimer: null,
+			resultFileCoalescer: { schedule: () => false, clear: () => {} },
+		} as unknown as SubagentState;
+		const onChildSessionStart = pi.on as unknown as (event: string, handler: (event: unknown, ctx: unknown) => unknown) => void;
+		onChildSessionStart("session_start", (_event: unknown, ctx: unknown) => {
+			const sm = (ctx as { sessionManager?: { getSessionId?: () => string | undefined } }).sessionManager;
+			childState.currentSessionId = sm?.getSessionId?.() ?? null;
+		});
+		registerWaitTool(pi, childState);
+	} catch {
+		// subagent_wait is a convenience in children; never block child startup on it.
+	}
 }

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -223,39 +223,38 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
-	it("restores only active async runs for the current session", () => {
+	it("restores only the current session's runs, not other sessions'", async () => {
 		const asyncRoot = createTempDir("pi-async-job-restore-scope-");
 		try {
-			const ownerDir = path.join(asyncRoot, "run-owner");
-			const otherDir = path.join(asyncRoot, "run-other");
-			fs.mkdirSync(ownerDir, { recursive: true });
-			fs.mkdirSync(otherDir, { recursive: true });
-			fs.writeFileSync(path.join(ownerDir, "status.json"), JSON.stringify({
-				runId: "run-owner",
-				mode: "single",
-				state: "running",
-				sessionId: "session-owner",
-				startedAt: 1000,
-				steps: [{ agent: "worker", status: "running" }],
-			}), "utf-8");
-			fs.writeFileSync(path.join(otherDir, "status.json"), JSON.stringify({
-				runId: "run-other",
-				mode: "single",
-				state: "running",
-				sessionId: "session-other",
-				startedAt: 1000,
-				steps: [{ agent: "worker", status: "running" }],
-			}), "utf-8");
+			const writeRun = (id: string, sessionId: string) => {
+				const runDir = path.join(asyncRoot, id);
+				fs.mkdirSync(runDir, { recursive: true });
+				fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+					runId: id,
+					mode: "single",
+					state: "running",
+					sessionId,
+					startedAt: 1000,
+					lastUpdate: 2000,
+					steps: [{ agent: "worker", status: "running" }],
+				}), "utf-8");
+			};
+			writeRun("run-mine", "session-mine");
+			writeRun("run-theirs", "session-theirs");
 
 			const state = createState();
-			state.currentSessionId = "session-owner";
-			const tracker = trackerMod!.createAsyncJobTracker(createEventRecorder().pi, state as never, asyncRoot, {
+			state.currentSessionId = "session-mine";
+			const ui = createUiContext();
+			const recorder = createEventRecorder();
+			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
-			tracker.restoreActiveJobs();
+			tracker.resetJobs(ui.ctx as never);
+			tracker.restoreActiveJobs(ui.ctx as never);
 
-			assert.deepEqual([...state.asyncJobs.keys()], ["run-owner"]);
-			tracker.resetJobs();
+			assert.ok(state.asyncJobs.get("run-mine"), "expected this session's run to be restored");
+			assert.equal(state.asyncJobs.get("run-theirs"), undefined, "must not restore another session's run");
+			assert.equal(state.asyncJobs.size, 1);
 		} finally {
 			removeTempDir(asyncRoot);
 		}

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -409,6 +409,28 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(mockPi.callCount(), 1);
 	});
 
+	it("does not reject concurrent async subagent launches in one turn", async () => {
+		mockPi.onCall({ output: "async one" });
+		mockPi.onCall({ output: "async two" });
+		const executor = makeExecutor([makeAgent("echo"), makeAgent("second")]);
+		const ctx = makeMinimalCtx(tempDir);
+
+		// Two detached (async) launches fired CONCURRENTLY in the same turn — the
+		// fleet pattern. Fire without awaiting the first so both are in flight at
+		// once; the old single-dispatch guard rejected the second with "Issue
+		// exactly ONE subagent call per turn". Assert on the guard message only:
+		// async launch may or may not fully spawn in the sandbox, but neither call
+		// should ever be turned away by the dispatch guard.
+		const [first, second] = await Promise.all([
+			executor.execute("first", { agent: "echo", task: "First", async: true }, new AbortController().signal, undefined, ctx),
+			executor.execute("second", { agent: "second", task: "Second", async: true }, new AbortController().signal, undefined, ctx),
+		]);
+
+		const guardMsg = /Issue exactly ONE subagent call per turn/;
+		assert.doesNotMatch(first.content[0]?.text ?? "", guardMsg, "first async launch must not hit the dispatch guard");
+		assert.doesNotMatch(second.content[0]?.text ?? "", guardMsg, "second concurrent async launch must not hit the dispatch guard");
+	});
+
 	it("blocks total subagent spawns after the per-session quota", async () => {
 		mockPi.onCall({ output: "first call completed" });
 		const executor = makeExecutor([makeAgent("echo")], { maxSubagentSpawnsPerSession: 1 });

--- a/test/unit/auto-drain.test.ts
+++ b/test/unit/auto-drain.test.ts
@@ -1,0 +1,60 @@
+/**
+ * drainOutstandingWork: blocks turn-end until tracked work drains, no-op when
+ * nothing outstanding. Deterministic — injects hasWork + a fake wait.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { drainOutstandingWork } from "../../src/runs/background/auto-drain.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+function makeState(): SubagentState {
+	return { currentSessionId: "s1" } as SubagentState;
+}
+const okResult = {
+	content: [{ type: "text", text: "Waited; done." }],
+	details: { mode: "management", results: [] },
+} as never;
+
+describe("drainOutstandingWork", () => {
+	it("no-op when there is no outstanding work (wait never called)", async () => {
+		let called = false;
+		const note = await drainOutstandingWork({
+			state: makeState(),
+			hasWork: () => false,
+			wait: (async () => { called = true; return okResult; }) as never,
+		});
+		assert.equal(called, false, "wait must not be called when nothing is outstanding");
+		assert.equal(note, undefined);
+	});
+
+	it("calls wait({all:true}) when work is outstanding and returns its note", async () => {
+		let params: unknown;
+		const note = await drainOutstandingWork({
+			state: makeState(),
+			hasWork: () => true,
+			wait: (async (p: unknown) => { params = p; return okResult; }) as never,
+		});
+		assert.deepEqual((params as { all?: boolean }).all, true, "must wait for ALL work");
+		assert.match(note ?? "", /done/);
+	});
+
+	it("never throws if wait rejects (best-effort at exit)", async () => {
+		const note = await drainOutstandingWork({
+			state: makeState(),
+			hasWork: () => true,
+			wait: (async () => { throw new Error("boom"); }) as never,
+		});
+		assert.match(note ?? "", /auto-drain error: boom/);
+	});
+
+	it("forwards a timeout cap to wait", async () => {
+		let params: { timeoutMs?: number } | undefined;
+		await drainOutstandingWork({
+			state: makeState(),
+			hasWork: () => true,
+			timeoutMs: 12345,
+			wait: (async (p: { timeoutMs?: number }) => { params = p; return okResult; }) as never,
+		});
+		assert.equal(params?.timeoutMs, 12345);
+	});
+});

--- a/test/unit/bg-providers.test.ts
+++ b/test/unit/bg-providers.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Generic background-work provider contract (bg-providers.ts) + its integration
+ * with subagent_wait. Deterministic: no real subagents, no real bash. Providers are
+ * registered on the shared process-global registry and asserted through both the
+ * low-level helpers and an end-to-end subagent_wait() using the real (non-injected)
+ * liveBgTaskCount path plus the union of provider wake channels.
+ */
+
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+	registerBackgroundWorkProvider,
+	backgroundWorkProviders,
+	totalLiveBackgroundWork,
+	backgroundWorkWakeChannels,
+} from "../../src/runs/background/bg-providers.ts";
+import { waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+const REGISTRY_KEY = "__pi_bg_work_providers_v1";
+
+function resetRegistry() {
+	const g = globalThis as Record<string, unknown>;
+	delete g[REGISTRY_KEY];
+}
+
+function makeState(sessionId: string | null): SubagentState {
+	return {
+		baseCwd: "", currentSessionId: sessionId, asyncJobs: new Map(),
+		foregroundControls: new Map(), lastForegroundControlId: null,
+		cleanupTimers: new Map(), lastUiContext: null, poller: null,
+		completionSeen: new Map(), watcher: null, watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	} as SubagentState;
+}
+
+function textOf(r: { content: Array<{ type: string; text?: string }> }): string {
+	return r.content.map((c) => c.text ?? "").join("");
+}
+
+function fakeBus() {
+	const handlers = new Map<string, Array<(d: unknown) => void>>();
+	return {
+		on(ch: string, h: (d: unknown) => void) {
+			const l = handlers.get(ch) ?? []; l.push(h); handlers.set(ch, l);
+			return () => handlers.set(ch, (handlers.get(ch) ?? []).filter((x) => x !== h));
+		},
+		emit(ch: string, d: unknown) { for (const h of [...(handlers.get(ch) ?? [])]) h(d); },
+	};
+}
+
+function emptyRunsDeps(root: string, state: SubagentState, overrides: Partial<SubagentWaitDeps>): SubagentWaitDeps {
+	return {
+		state,
+		asyncDirRoot: path.join(root, "runs"),
+		resultsDir: path.join(root, "results"),
+		kill: () => true,
+		pollIntervalMs: 5,
+		...overrides,
+	};
+}
+
+describe("background-work provider registry", () => {
+	afterEach(resetRegistry);
+
+	it("sums liveCount across multiple registered providers", () => {
+		resetRegistry();
+		registerBackgroundWorkProvider({ name: "a", liveCount: () => 2 });
+		registerBackgroundWorkProvider({ name: "b", liveCount: () => 3 });
+		assert.equal(totalLiveBackgroundWork(), 5);
+	});
+
+	it("unregister removes a provider", () => {
+		resetRegistry();
+		const off = registerBackgroundWorkProvider({ name: "a", liveCount: () => 4 });
+		assert.equal(totalLiveBackgroundWork(), 4);
+		off();
+		assert.equal(totalLiveBackgroundWork(), 0);
+	});
+
+	it("registering the same name replaces the earlier provider", () => {
+		resetRegistry();
+		registerBackgroundWorkProvider({ name: "dup", liveCount: () => 1 });
+		registerBackgroundWorkProvider({ name: "dup", liveCount: () => 9 });
+		assert.equal(totalLiveBackgroundWork(), 9);
+		assert.equal(backgroundWorkProviders().filter((p) => p.name === "dup").length, 1);
+	});
+
+	it("a throwing provider is ignored, not fatal", () => {
+		resetRegistry();
+		registerBackgroundWorkProvider({ name: "boom", liveCount: () => { throw new Error("nope"); } });
+		registerBackgroundWorkProvider({ name: "ok", liveCount: () => 2 });
+		assert.equal(totalLiveBackgroundWork(), 2);
+	});
+
+	it("unions wake channels across providers (deduped)", () => {
+		resetRegistry();
+		registerBackgroundWorkProvider({ name: "a", liveCount: () => 0, wakeChannels: ["x", "shared"] });
+		registerBackgroundWorkProvider({ name: "b", liveCount: () => 0, wakeChannels: ["y", "shared"] });
+		const chans = backgroundWorkWakeChannels().sort();
+		assert.deepEqual(chans, ["shared", "x", "y"]);
+	});
+
+	it("no providers registered → zero work, no channels", () => {
+		resetRegistry();
+		assert.equal(totalLiveBackgroundWork(), 0);
+		assert.deepEqual(backgroundWorkWakeChannels(), []);
+	});
+});
+
+describe("subagent_wait × generic providers (no injected bgTaskCount)", () => {
+	afterEach(resetRegistry);
+
+	it("blocks on a registered provider's live work and returns when it drains", async () => {
+		resetRegistry();
+		let live = 2;
+		registerBackgroundWorkProvider({ name: "queue", liveCount: () => live });
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-bgp-drain-"));
+		try {
+			let polls = 0;
+			const sleep = async () => { polls += 1; if (polls === 1) live = 1; };
+			const r = await waitForSubagents({}, undefined, emptyRunsDeps(root, makeState("s1"), { sleep }));
+			assert.equal(r.isError, undefined);
+			assert.match(textOf(r), /1 of 2 background job\(s\) finished/);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+
+	it("wakes on a custom provider wake channel", async () => {
+		resetRegistry();
+		let live = 1;
+		registerBackgroundWorkProvider({ name: "queue", liveCount: () => live, wakeChannels: ["queue:job-done"] });
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-bgp-wake-"));
+		try {
+			const bus = fakeBus();
+			const realSleep = (ms: number, signal?: AbortSignal) => new Promise<void>((res) => {
+				const t = setTimeout(res, ms); signal?.addEventListener("abort", () => { clearTimeout(t); res(); }, { once: true });
+			});
+			const startedAt = Date.now();
+			const p = waitForSubagents({ all: true }, undefined,
+				emptyRunsDeps(root, makeState("s1"), { events: bus, pollIntervalMs: 10_000, sleep: realSleep }));
+			setTimeout(() => { live = 0; bus.emit("queue:job-done", { id: "q1" }); }, 15);
+			const r = await p;
+			const elapsed = Date.now() - startedAt;
+			assert.equal(r.isError, undefined);
+			assert.match(textOf(r), /1 of 1 background job\(s\) finished\./);
+			assert.ok(elapsed < 2000, `should wake via custom channel (~15ms), not the 10s poll; took ${elapsed}ms`);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+});

--- a/test/unit/bg-reconcile.test.ts
+++ b/test/unit/bg-reconcile.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Generic provider health checks: subagent_wait runs registered providers' reconcile()
+ * on every poll tick, and reconcileBackgroundWork drives them. A reconcile that
+ * resolves a wedged unit (drops liveCount) unblocks subagent_wait instead of hanging.
+ */
+
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+	registerBackgroundWorkProvider,
+	reconcileBackgroundWork,
+} from "../../src/runs/background/bg-providers.ts";
+import { waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+const REGISTRY_KEY = "__pi_bg_work_providers_v1";
+function resetRegistry() {
+	delete (globalThis as Record<string, unknown>)[REGISTRY_KEY];
+}
+
+function makeState(sessionId: string | null): SubagentState {
+	return {
+		baseCwd: "", currentSessionId: sessionId, asyncJobs: new Map(),
+		foregroundControls: new Map(), lastForegroundControlId: null,
+		cleanupTimers: new Map(), lastUiContext: null, poller: null,
+		completionSeen: new Map(), watcher: null, watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	} as SubagentState;
+}
+const textOf = (r: { content: Array<{ type: string; text?: string }> }) =>
+	r.content.map((c) => c.text ?? "").join("");
+
+function emptyRunsDeps(root: string, state: SubagentState, overrides: Partial<SubagentWaitDeps>): SubagentWaitDeps {
+	return {
+		state,
+		asyncDirRoot: path.join(root, "runs"),
+		resultsDir: path.join(root, "results"),
+		kill: () => true,
+		pollIntervalMs: 5,
+		...overrides,
+	};
+}
+
+describe("reconcileBackgroundWork", () => {
+	afterEach(resetRegistry);
+
+	it("calls each provider's reconcile with the given clock", () => {
+		resetRegistry();
+		let seen = -1;
+		registerBackgroundWorkProvider({ name: "p", liveCount: () => 0, reconcile: (n) => { seen = n; } });
+		reconcileBackgroundWork(12345);
+		assert.equal(seen, 12345);
+	});
+
+	it("ignores a throwing reconcile", () => {
+		resetRegistry();
+		registerBackgroundWorkProvider({ name: "bad", liveCount: () => 0, reconcile: () => { throw new Error("x"); } });
+		registerBackgroundWorkProvider({ name: "ok", liveCount: () => 0, reconcile: () => {} });
+		assert.doesNotThrow(() => reconcileBackgroundWork(1));
+	});
+});
+
+describe("subagent_wait × provider reconcile", () => {
+	afterEach(resetRegistry);
+
+	it("runs reconcile every poll tick and unblocks when it resolves a wedged unit", async () => {
+		resetRegistry();
+		// A wedged provider: 1 unit live, and it never finishes on its own — only
+		// its reconcile() can resolve it (mimicking terminating a hung job).
+		let live = 1;
+		let reconciles = 0;
+		registerBackgroundWorkProvider({
+			name: "wedged",
+			liveCount: () => live,
+			reconcile: () => { reconciles += 1; if (reconciles >= 2) live = 0; },
+		});
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-bg-recon-"));
+		try {
+			const r = await waitForSubagents({ all: true }, undefined, emptyRunsDeps(root, makeState("s1"), {}));
+			assert.equal(r.isError, undefined);
+			assert.match(textOf(r), /1 of 1 background job\(s\) finished\./);
+			assert.ok(reconciles >= 2, `reconcile ran each tick until resolved (ran ${reconciles})`);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+
+	it("would hang without reconcile — a live unit with no reconcile keeps wait waiting", async () => {
+		resetRegistry();
+		registerBackgroundWorkProvider({ name: "stuck", liveCount: () => 1 }); // no reconcile
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-bg-recon2-"));
+		try {
+			// Bounded timeout so the test itself doesn't hang; proves it does NOT
+			// finish (times out with the unit still in flight).
+			const r = await waitForSubagents({ all: true, timeoutMs: 40 }, undefined,
+				emptyRunsDeps(root, makeState("s1"), { pollIntervalMs: 5 }));
+			assert.equal(r.isError, true);
+			assert.match(textOf(r), /timed out/i);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+});

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -460,10 +460,11 @@ describe("subagent prompt runtime", () => {
 			},
 		} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(tool: { name: string }): void });
 
-		assert.deepEqual(registered, []);
+		const nativeTools = () => registered.filter((name) => name !== "subagent_wait");
+		assert.deepEqual(nativeTools(), []);
 		handlers.get("session_start")?.({});
 		await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT });
-		assert.deepEqual(registered, []);
+		assert.deepEqual(nativeTools(), []);
 	});
 
 	it("keeps installed pi-intercom while filling only a missing child contact_supervisor tool", async () => {
@@ -484,7 +485,7 @@ describe("subagent prompt runtime", () => {
 		handlers.get("session_start")?.({});
 		await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT });
 
-		assert.deepEqual(registered, ["contact_supervisor"]);
+		assert.deepEqual(registered.filter((name) => name !== "subagent_wait"), ["contact_supervisor"]);
 	});
 
 	it("registers native supervisor tools at runtime when pi-intercom is absent", async () => {
@@ -503,10 +504,11 @@ describe("subagent prompt runtime", () => {
 		} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(tool: { name: string }): void });
 
 		handlers.get("session_start")?.({});
-		assert.deepEqual(registered, ["contact_supervisor"]);
+		const nativeTools = () => registered.filter((name) => name !== "subagent_wait");
+		assert.deepEqual(nativeTools(), ["contact_supervisor"]);
 
 		await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT });
-		assert.deepEqual(registered, ["contact_supervisor", "intercom"]);
+		assert.deepEqual(nativeTools(), ["contact_supervisor", "intercom"]);
 	});
 
 	it("records and explains requested tools missing from the child registry", async () => {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -642,4 +642,14 @@ describe("subagent prompt runtime", () => {
 
 		assert.equal(contextHandler?.({ messages }), undefined);
 	});
+
+	it("registers subagent_wait so subagents can block on their own background work", () => {
+		const registered: string[] = [];
+		registerSubagentPromptRuntime({
+			registerTool(tool: { name: string }) { registered.push(tool.name); },
+			on() {},
+			events: { on() { return () => {}; }, emit() {} },
+		} as unknown as Parameters<typeof registerSubagentPromptRuntime>[0]);
+		assert.ok(registered.includes("subagent_wait"), `child runtime should register 'subagent_wait'; got ${registered.join(", ")}`);
+	});
 });

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -211,7 +211,7 @@ describe("subagent_wait tool", () => {
 			const text = textOf(result);
 			assert.match(text, /1 of 3 run\(s\) finished/);
 			assert.match(text, /1 complete/);
-			assert.match(text, /2 run\(s\) still in flight/);
+			assert.match(text, /2 run\(s\).*still in flight/);
 			// Must not have blocked on b and c: a bounded number of polls.
 			assert.ok(polls <= 2, `first-completion should return promptly, polled ${polls}`);
 		} finally {

--- a/test/unit/wait.bgtasks.test.ts
+++ b/test/unit/wait.bgtasks.test.ts
@@ -1,7 +1,7 @@
 /**
- * wait × pi-patty-bg-tasks integration. Deterministic: no real subagents, no
+ * subagent_wait × pi-patty-bg-tasks integration. Deterministic: no real subagents, no
  * real bash. A fake bgTaskCount() models pi-patty-bg-tasks' process-global live
- * set, and a fake event bus emits patty:bg-task-finished. Asserts wait blocks on
+ * set, and a fake event bus emits patty:bg-task-finished. Asserts subagent_wait blocks on
  * outstanding background jobs and returns when one (or all) finish.
  */
 
@@ -9,9 +9,14 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
+import { registerBackgroundWorkProvider } from "../../src/runs/background/bg-providers.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
+
+function resetRegistry() {
+	delete (globalThis as Record<string, unknown>)["__pi_bg_work_providers_v1"];
+}
 
 function makeState(sessionId: string | null): SubagentState {
 	return {
@@ -49,7 +54,9 @@ function emptyRunsDeps(root: string, state: SubagentState, overrides: Partial<Su
 	};
 }
 
-describe("wait × background tasks", () => {
+describe("subagent_wait × background tasks", () => {
+	afterEach(resetRegistry);
+
 	it("nothing to wait for when no runs and no bg jobs", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-bg-none-"));
 		try {
@@ -98,9 +105,12 @@ describe("wait × background tasks", () => {
 			const realSleep = (ms: number, signal?: AbortSignal) => new Promise<void>((res) => {
 				const t = setTimeout(res, ms); signal?.addEventListener("abort", () => { clearTimeout(t); res(); }, { once: true });
 			});
+			// A provider both supplies the live count and declares the wake channel
+			// that subagent_wait subscribes to (bgTaskCount dep is left to the real path here).
+			registerBackgroundWorkProvider({ name: "patty", liveCount: () => live, wakeChannels: ["patty:bg-task-finished"] });
 			const startedAt = Date.now();
 			const p = waitForSubagents({ all: true }, undefined, emptyRunsDeps(root, makeState("s1"), {
-				bgTaskCount: () => live, events: bus, pollIntervalMs: 10_000, sleep: realSleep,
+				events: bus, pollIntervalMs: 10_000, sleep: realSleep,
 			}));
 			setTimeout(() => { live = 0; bus.emit("patty:bg-task-finished", { jobId: "job-1", status: "completed" }); }, 15);
 			const r = await p;
@@ -132,7 +142,7 @@ describe("wait × background tasks", () => {
 			}));
 			assert.equal(r.isError, undefined);
 			assert.match(textOf(r), /1 of 1 background job\(s\) finished/);
-			// subagent run still in flight → invites another wait
+			// subagent run still in flight -> invites another subagent_wait
 			assert.match(textOf(r), /still in flight/i);
 			assert.ok(polls <= 2, `bg finishing first should return promptly, polled ${polls}`);
 		} finally { fs.rmSync(root, { recursive: true, force: true }); }

--- a/test/unit/wait.bgtasks.test.ts
+++ b/test/unit/wait.bgtasks.test.ts
@@ -1,0 +1,140 @@
+/**
+ * wait × pi-patty-bg-tasks integration. Deterministic: no real subagents, no
+ * real bash. A fake bgTaskCount() models pi-patty-bg-tasks' process-global live
+ * set, and a fake event bus emits patty:bg-task-finished. Asserts wait blocks on
+ * outstanding background jobs and returns when one (or all) finish.
+ */
+
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+function makeState(sessionId: string | null): SubagentState {
+	return {
+		baseCwd: "", currentSessionId: sessionId, asyncJobs: new Map(),
+		foregroundControls: new Map(), lastForegroundControlId: null,
+		cleanupTimers: new Map(), lastUiContext: null, poller: null,
+		completionSeen: new Map(), watcher: null, watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	} as SubagentState;
+}
+
+function textOf(r: { content: Array<{ type: string; text?: string }> }): string {
+	return r.content.map((c) => c.text ?? "").join("");
+}
+
+function fakeBus() {
+	const handlers = new Map<string, Array<(d: unknown) => void>>();
+	return {
+		on(ch: string, h: (d: unknown) => void) {
+			const l = handlers.get(ch) ?? []; l.push(h); handlers.set(ch, l);
+			return () => handlers.set(ch, (handlers.get(ch) ?? []).filter((x) => x !== h));
+		},
+		emit(ch: string, d: unknown) { for (const h of [...(handlers.get(ch) ?? [])]) h(d); },
+	};
+}
+
+function emptyRunsDeps(root: string, state: SubagentState, overrides: Partial<SubagentWaitDeps>): SubagentWaitDeps {
+	return {
+		state,
+		asyncDirRoot: path.join(root, "runs"),   // empty dir → no subagent runs
+		resultsDir: path.join(root, "results"),
+		kill: () => true,
+		pollIntervalMs: 5,
+		...overrides,
+	};
+}
+
+describe("wait × background tasks", () => {
+	it("nothing to wait for when no runs and no bg jobs", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-bg-none-"));
+		try {
+			const r = await waitForSubagents({}, undefined, emptyRunsDeps(root, makeState("s1"), { bgTaskCount: () => 0 }));
+			assert.equal(r.isError, undefined);
+			assert.match(textOf(r), /nothing to wait for/i);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+
+	it("blocks on an outstanding bg job and returns (first-completion) when it finishes", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-bg-first-"));
+		try {
+			let live = 2; // two bg jobs in flight at start
+			let polls = 0;
+			const sleep = async () => { polls += 1; if (polls === 1) live = 1; }; // one finishes
+			const r = await waitForSubagents({}, undefined, emptyRunsDeps(root, makeState("s1"), {
+				bgTaskCount: () => live, sleep,
+			}));
+			assert.equal(r.isError, undefined);
+			assert.match(textOf(r), /1 of 2 background job\(s\) finished/);
+			assert.match(textOf(r), /1 still running/);
+			assert.ok(polls <= 2, `first bg completion should return promptly, polled ${polls}`);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+
+	it("all:true blocks until every bg job finishes", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-bg-all-"));
+		try {
+			let live = 3;
+			let polls = 0;
+			const sleep = async () => { polls += 1; live = Math.max(0, 3 - polls); }; // drains 1/poll
+			const r = await waitForSubagents({ all: true }, undefined, emptyRunsDeps(root, makeState("s1"), {
+				bgTaskCount: () => live, sleep,
+			}));
+			assert.equal(r.isError, undefined);
+			assert.match(textOf(r), /3 of 3 background job\(s\) finished\./);
+			assert.ok(polls >= 3, `all:true should wait for all three, polled ${polls}`);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+
+	it("wakes instantly on patty:bg-task-finished instead of the poll interval", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-bg-event-"));
+		try {
+			let live = 1;
+			const bus = fakeBus();
+			const realSleep = (ms: number, signal?: AbortSignal) => new Promise<void>((res) => {
+				const t = setTimeout(res, ms); signal?.addEventListener("abort", () => { clearTimeout(t); res(); }, { once: true });
+			});
+			const startedAt = Date.now();
+			const p = waitForSubagents({ all: true }, undefined, emptyRunsDeps(root, makeState("s1"), {
+				bgTaskCount: () => live, events: bus, pollIntervalMs: 10_000, sleep: realSleep,
+			}));
+			setTimeout(() => { live = 0; bus.emit("patty:bg-task-finished", { jobId: "job-1", status: "completed" }); }, 15);
+			const r = await p;
+			const elapsed = Date.now() - startedAt;
+			assert.equal(r.isError, undefined);
+			assert.match(textOf(r), /1 of 1 background job\(s\) finished\./);
+			assert.ok(elapsed < 2000, `should wake via bg event (~15ms), not the 10s poll; took ${elapsed}ms`);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+
+	it("waits across BOTH a subagent run and a bg job (mixed), first-completion", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-bg-mixed-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			// one real subagent run fixture, still running
+			const dir = path.join(asyncRoot, "run-a");
+			fs.mkdirSync(dir, { recursive: true });
+			const nowMs = Date.now();
+			fs.writeFileSync(path.join(dir, "status.json"), JSON.stringify({
+				runId: "run-a", mode: "single", state: "running", startedAt: nowMs, lastUpdate: nowMs,
+				sessionId: "s1", pid: 999999, steps: [{ agent: "w", status: "running" }],
+			}));
+			let live = 1; // plus one bg job
+			let polls = 0;
+			// The bg job finishes first; the subagent run stays running.
+			const sleep = async () => { polls += 1; if (polls === 1) live = 0; };
+			const r = await waitForSubagents({}, undefined, emptyRunsDeps(root, makeState("s1"), {
+				bgTaskCount: () => live, sleep,
+			}));
+			assert.equal(r.isError, undefined);
+			assert.match(textOf(r), /1 of 1 background job\(s\) finished/);
+			// subagent run still in flight → invites another wait
+			assert.match(textOf(r), /still in flight/i);
+			assert.ok(polls <= 2, `bg finishing first should return promptly, polled ${polls}`);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+});

--- a/test/unit/wait.stress.test.ts
+++ b/test/unit/wait.stress.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Stress tests for the wait tool. Deterministic (no LLM): synthesize many async
+ * run status files and drive waitForSubagents through fixtures + a fake event
+ * bus, exercising high concurrency, rapid/staggered completions, churn, mixed
+ * terminal states, event storms, and the reconciliation fallback. Guards against
+ * hangs, missed completions, cross-session leakage, and O(n^2) blowups.
+ */
+
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+function makeState(sessionId: string | null): SubagentState {
+	return {
+		baseCwd: "",
+		currentSessionId: sessionId,
+		asyncJobs: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	} as SubagentState;
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.map((c) => c.text ?? "").join("");
+}
+
+function writeRun(asyncRoot: string, runId: string, state: string, extra: object = {}): void {
+	const dir = path.join(asyncRoot, runId);
+	fs.mkdirSync(dir, { recursive: true });
+	const nowMs = Date.now();
+	fs.writeFileSync(
+		path.join(dir, "status.json"),
+		JSON.stringify({ runId, mode: "single", state, startedAt: nowMs, lastUpdate: nowMs, steps: [{ agent: "w", status: state }], ...extra }),
+		"utf-8",
+	);
+}
+
+function baseDeps(root: string, state: SubagentState, overrides: Partial<SubagentWaitDeps> = {}): SubagentWaitDeps {
+	return {
+		state,
+		asyncDirRoot: path.join(root, "runs"),
+		resultsDir: path.join(root, "results"),
+		kill: () => true,
+		pollIntervalMs: 5,
+		...overrides,
+	};
+}
+
+function tmp(label: string): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), `pi-wait-stress-${label}-`));
+}
+
+describe("wait stress", () => {
+	it("all:true drains a large fleet (100 runs) completing in staggered waves", async () => {
+		const root = tmp("fleet100");
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			const N = 100;
+			for (let i = 0; i < N; i++) writeRun(asyncRoot, `run-${i}`, "running", { sessionId: "sess-1", pid: 900000 + i });
+
+			// Each poll completes the next 7 runs, so it takes ~15 polls to drain.
+			let completed = 0;
+			const sleep = async () => {
+				for (let k = 0; k < 7 && completed < N; k++, completed++) {
+					writeRun(asyncRoot, `run-${completed}`, completed % 5 === 0 ? "failed" : "complete", { sessionId: "sess-1" });
+				}
+			};
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, { sleep }));
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /done/i);
+			// 100 runs: 80 complete (non-mult-of-5) + 20 failed.
+			assert.match(textOf(result), /80 complete/);
+			assert.match(textOf(result), /20 failed/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("first-completion returns after exactly one of a large fleet finishes", async () => {
+		const root = tmp("first-of-many");
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			for (let i = 0; i < 50; i++) writeRun(asyncRoot, `run-${i}`, "running", { sessionId: "sess-1", pid: 900000 + i });
+			let polls = 0;
+			const sleep = async () => { polls += 1; if (polls === 1) writeRun(asyncRoot, "run-7", "complete", { sessionId: "sess-1" }); };
+			const result = await waitForSubagents({}, undefined, baseDeps(root, state, { sleep }));
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /1 of 50 run\(s\) finished/);
+			assert.match(textOf(result), /49 run\(s\).*still in flight/);
+			assert.ok(polls <= 2, `should return promptly on first completion, polled ${polls}`);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("survives rapid event storm on the bus without hanging or double-resolving", async () => {
+		const root = tmp("event-storm");
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			for (let i = 0; i < 10; i++) writeRun(asyncRoot, `run-${i}`, "running", { sessionId: "sess-1", pid: 900000 + i });
+			const handlers = new Map<string, Array<(d: unknown) => void>>();
+			const events = {
+				on(ch: string, h: (d: unknown) => void) {
+					const l = handlers.get(ch) ?? []; l.push(h); handlers.set(ch, l);
+					return () => handlers.set(ch, (handlers.get(ch) ?? []).filter((x) => x !== h));
+				},
+				emit(ch: string, d: unknown) { for (const h of [...(handlers.get(ch) ?? [])]) h(d); },
+			};
+			let resolves = 0;
+			const sleep = (ms: number, signal?: AbortSignal) => new Promise<void>((r) => {
+				const t = setTimeout(r, ms); signal?.addEventListener("abort", () => { clearTimeout(t); r(); }, { once: true });
+			});
+			// Fire a storm of events; on the 3rd poll, everything completes.
+			let polls = 0;
+			const sleepWrap = (ms: number, signal?: AbortSignal) => {
+				polls += 1;
+				if (polls === 3) for (let i = 0; i < 10; i++) writeRun(asyncRoot, `run-${i}`, "complete", { sessionId: "sess-1" });
+				return sleep(ms, signal);
+			};
+			const p = waitForSubagents({ all: true }, undefined, baseDeps(root, state, { events, sleep: sleepWrap, pollIntervalMs: 20 }))
+				.then((r) => { resolves += 1; return r; });
+			// Hammer the bus with events from many channels.
+			const storm = setInterval(() => {
+				events.emit("subagent:control-event", {});
+				events.emit("subagent:async-complete", {});
+				events.emit("subagent:result-intercom", {});
+			}, 1);
+			const result = await p;
+			clearInterval(storm);
+			await new Promise((r) => setTimeout(r, 30));
+			assert.equal(result.isError, undefined);
+			assert.equal(resolves, 1, "must resolve exactly once despite the event storm");
+			assert.match(textOf(result), /10 complete/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("100 sequential first-completion waits over a churning fleet never hang", async () => {
+		const root = tmp("churn");
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			// Keep ~5 in flight; each wait finishes one and we "replace" it.
+			let nextId = 0;
+			const inflight = new Set<string>();
+			const spawn = () => { const id = `run-${nextId++}`; writeRun(asyncRoot, id, "running", { sessionId: "sess-1", pid: 900000 + (nextId % 1000) }); inflight.add(id); };
+			for (let i = 0; i < 5; i++) spawn();
+			for (let round = 0; round < 100; round++) {
+				const victim = [...inflight][0];
+				let polls = 0;
+				const sleep = async () => { polls += 1; if (polls === 1) { writeRun(asyncRoot, victim, "complete", { sessionId: "sess-1" }); inflight.delete(victim); } };
+				const result = await waitForSubagents({}, undefined, baseDeps(root, state, { sleep }));
+				assert.equal(result.isError, undefined, `round ${round} errored: ${textOf(result)}`);
+				assert.ok(polls <= 3, `round ${round} polled ${polls}`);
+				spawn(); // rolling replacement
+			}
+			assert.equal(inflight.size, 5, "fleet stays at 5 in flight");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("ignores a flood of other-session runs (no cross-session leak at scale)", async () => {
+		const root = tmp("xsession");
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-mine");
+			// 200 runs from OTHER sessions, plus 1 of mine.
+			for (let i = 0; i < 200; i++) writeRun(asyncRoot, `other-${i}`, "running", { sessionId: `sess-${i % 7}`, pid: 800000 + i });
+			writeRun(asyncRoot, "mine", "running", { sessionId: "sess-mine", pid: 999999 });
+			let polls = 0;
+			const sleep = async () => { polls += 1; if (polls === 1) writeRun(asyncRoot, "mine", "complete", { sessionId: "sess-mine" }); };
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, { sleep }));
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /1 async run\(s\)|done/i);
+			assert.match(textOf(result), /1 complete/);
+			assert.ok(polls <= 2, `should only track my 1 run, polled ${polls}`);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("tolerates malformed / partially-written status files during polling", async () => {
+		const root = tmp("malformed");
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeRun(asyncRoot, "good", "running", { sessionId: "sess-1", pid: 999999 });
+			// A directory with a garbage status.json — must not crash the wait.
+			const bad = path.join(asyncRoot, "bad");
+			fs.mkdirSync(bad, { recursive: true });
+			fs.writeFileSync(path.join(bad, "status.json"), "{ this is not json ", "utf-8");
+			let polls = 0;
+			const sleep = async () => { polls += 1; if (polls === 1) writeRun(asyncRoot, "good", "complete", { sessionId: "sess-1" }); };
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, { sleep }));
+			// Either it resolves cleanly or reports an error — but it must not hang.
+			assert.ok(typeof textOf(result) === "string");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("timeout fires deterministically with a virtual clock under load", async () => {
+		const root = tmp("timeout");
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			for (let i = 0; i < 30; i++) writeRun(asyncRoot, `run-${i}`, "running", { sessionId: "sess-1", pid: 900000 + i });
+			let clock = 0;
+			const now = () => clock;
+			const sleep = async (ms: number) => { clock += ms; }; // nothing ever completes
+			const result = await waitForSubagents({ all: true, timeoutMs: 1000 }, undefined, baseDeps(root, state, { now, sleep, pollIntervalMs: 50 }));
+			assert.equal(result.isError, true);
+			assert.match(textOf(result), /timed out/i);
+			assert.match(textOf(result), /30 run\(s\) still active/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("treats paused runs as terminal (blocked-for-decision children)", async () => {
+		const root = tmp("paused");
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			for (let i = 0; i < 20; i++) writeRun(asyncRoot, `run-${i}`, "running", { sessionId: "sess-1", pid: 900000 + i });
+			let polls = 0;
+			const sleep = async () => {
+				polls += 1;
+				// On first poll, everything pauses (e.g. all blocked on contact_supervisor).
+				if (polls === 1) for (let i = 0; i < 20; i++) writeRun(asyncRoot, `run-${i}`, "paused", { sessionId: "sess-1" });
+			};
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, { sleep }));
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /20 paused/);
+			assert.ok(polls <= 2, `paused should end the wait promptly, polled ${polls}`);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("handles attention and completion arriving together in the same poll", async () => {
+		const root = tmp("mixed");
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			for (let i = 0; i < 10; i++) writeRun(asyncRoot, `run-${i}`, "running", { sessionId: "sess-1", pid: 900000 + i });
+			let polls = 0;
+			const sleep = async () => {
+				polls += 1;
+				if (polls === 1) {
+					writeRun(asyncRoot, "run-0", "complete", { sessionId: "sess-1" });
+					writeRun(asyncRoot, "run-1", "running", { sessionId: "sess-1", pid: 900001, activityState: "needs_attention" });
+				}
+			};
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, { sleep }));
+			assert.equal(result.isError, undefined);
+			// Reports both the completion outcome and the attention run.
+			assert.match(textOf(result), /1 complete/);
+			assert.match(textOf(result), /need attention/i);
+			assert.match(textOf(result), /run-1/);
+			assert.ok(polls <= 2, `mixed signals should end wait promptly, polled ${polls}`);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Rebase the wait follow-up stack onto upstream `main` (`8d2c05e`).
- Keep upstream's `subagent_wait` tool name and child-tool diagnostics while restoring fork fixes for child wait registration, async session scoping, and concurrent async fanout launches.
- Add the generic background-work provider registry, non-interactive auto-drain, and provider reconcile hook so `subagent_wait` can drain provider-backed work and avoid hanging on wedged units.

## Tests
- PASS: `node --experimental-strip-types --test test/unit/subagent-wait.test.ts test/unit/wait.bgtasks.test.ts test/unit/bg-providers.test.ts test/unit/bg-reconcile.test.ts test/unit/auto-drain.test.ts test/unit/subagent-prompt-runtime.test.ts test/unit/index-child-registration.test.ts` (76 tests)
- PASS: `node --experimental-strip-types --test --test-reporter=dot $(find test/unit -name '*.test.ts' ! -name 'worktree.test.ts' ! -name 'agent-disabled.test.ts' ! -name 'watchdog-runtime.test.ts' | sort)`
- PARTIAL: `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/async-job-tracker.test.ts test/integration/single-execution.test.ts test/integration/async-execution.test.ts` passed 205/206; the remaining async worktree fixture is blocked in this sandbox by `autonomous-agent-bootstrap` because the test commits as `Async Tests <tests@example.com>` instead of the configured global identity.

## Local sandbox blockers
- Full unit runs also hit the same bootstrap identity guard in git-fixture suites (`worktree.test.ts`, `watchdog-runtime.test.ts`) and a local installed-package-agent expectation mismatch in `agent-disabled.test.ts`.
