### PR TITLE
fix: accept empty acceptance note strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Accepted empty optional `manualNotes` and `notes` strings in acceptance reports while retaining the `manual-notes` evidence requirement when configured. Thanks to Nick Tripp (@nicholastripp) for #474.
 - Kept explicit child tool allowlists strict while surfacing actionable errors when named extension tools are requested without a loaded provider. Internal `structured_output` is now admitted automatically when an output schema is active, and direct and chained children share the same registry check. Thanks to DesertThief (@DesertThief) for #429 and Chris-Kode (@Chris-Kode) for confirming the structured-output case.
 - Prevented model fallback retries for trailing child tool failures even when their details resemble provider outages, and retried provider streams that end without `finish_reason`. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #436.
 - Recognized Pi's `max` thinking level in child model suffixes, Clarify selection, watchdog settings, and status formatting, while exposing it only when model metadata explicitly supports it. Thanks to mapleluv (@mapleluvr) for #423.

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -372,6 +372,7 @@ export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig): st
 		"Use empty arrays when no items apply; array fields contain strings unless object entries are shown.",
 		"`criteriaSatisfied[].status` must be exactly one of: satisfied, not-satisfied, not-applicable.",
 		"`commandsRun[].result` must be exactly one of: passed, failed, not-run.",
+		"`manualNotes` and `notes` are optional strings; an empty string means no note and does not satisfy `manual-notes` evidence.",
 		"```acceptance-report",
 		JSON.stringify({
 			criteriaSatisfied: acceptance.criteria
@@ -808,8 +809,8 @@ function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: Ac
 	if (report.noStagedFiles !== undefined && typeof report.noStagedFiles !== "boolean") pushTypeError(errors, pathFor(pathLabel, "noStagedFiles"), "boolean", report.noStagedFiles);
 	if (report.diffSummary !== undefined && (typeof report.diffSummary !== "string" || !report.diffSummary.trim())) pushTypeError(errors, pathFor(pathLabel, "diffSummary"), "non-empty string", report.diffSummary);
 	if (report.reviewFindings !== undefined) validateStringArrayField(errors, report.reviewFindings, pathFor(pathLabel, "reviewFindings"));
-	if (report.manualNotes !== undefined && (typeof report.manualNotes !== "string" || !report.manualNotes.trim())) pushTypeError(errors, pathFor(pathLabel, "manualNotes"), "non-empty string", report.manualNotes);
-	if (report.notes !== undefined && (typeof report.notes !== "string" || !report.notes.trim())) pushTypeError(errors, pathFor(pathLabel, "notes"), "non-empty string", report.notes);
+	if (report.manualNotes !== undefined && typeof report.manualNotes !== "string") pushTypeError(errors, pathFor(pathLabel, "manualNotes"), "string", report.manualNotes);
+	if (report.notes !== undefined && typeof report.notes !== "string") pushTypeError(errors, pathFor(pathLabel, "notes"), "string", report.notes);
 	if (errors.length > 0) return { errors };
 	const hasReportField = report.criteriaSatisfied !== undefined
 		|| report.changedFiles !== undefined

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -80,6 +80,7 @@ describe("acceptance gates", () => {
 		assert.match(prompt, /array fields contain strings/);
 		assert.match(prompt, /criteriaSatisfied\[\]\.status.*satisfied, not-satisfied, not-applicable/);
 		assert.match(prompt, /commandsRun\[\]\.result.*passed, failed, not-run/);
+		assert.match(prompt, /manualNotes.*optional strings.*empty string.*does not satisfy.*manual-notes/);
 		assert.match(prompt, /"reviewFindings": \[\n    "blocker:/);
 	});
 
@@ -304,6 +305,34 @@ describe("acceptance gates", () => {
 			const parsed = parseAcceptanceReport(report(overrides));
 			assert.equal(parsed.report, undefined);
 			assert.match(parsed.error ?? "", expected);
+		}
+	});
+
+	it("accepts empty optional note strings without treating them as evidence", async () => {
+		for (const field of ["manualNotes", "notes"] as const) {
+			const parsed = parseAcceptanceReport(report({ notes: undefined, [field]: "" }));
+			assert.equal(parsed.error, undefined);
+			assert.equal(parsed.report?.[field], "");
+		}
+
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Return a concise result",
+				explicit: { level: "attested", evidence: ["manual-notes"] },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: report({ notes: undefined, manualNotes: "" }),
+				cwd,
+			});
+			assert.equal(ledger.childReportParseError, undefined);
+			assert.equal(ledger.childReport?.manualNotes, "");
+			assert.equal(ledger.status, "rejected");
+			assert.equal(ledger.runtimeChecks.find((check) => check.id === "evidence:manual-notes")?.status, "failed");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
Acceptance reports now treat present `manualNotes` and `notes` values as plain optional strings, so `""` no longer rejects the entire report during parsing. Empty strings are preserved rather than coerced, and the existing `manual-notes` evidence check still fails when non-empty manual evidence is required.

The child contract now states that an empty note does not satisfy `manual-notes` evidence. Regression coverage exercises both note fields and verifies the parse/evidence boundary. Nick Tripp (@nicholastripp) is credited in the changelog.

Validation passed with `npm run test:all`: 1,214 unit tests passed with one Windows-only skip, 548 integration tests passed, and two E2E tests passed. `git diff --check` also passed.

Fixes #474.