### PR TITLE
fix: expose package-root extension entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Moved the published extension entrypoint to the package root so Pi displays the startup label as `pi-subagents` instead of an internal source path. Thanks to Ramin Hazegh (@rhazegh) for #475.
 - Accepted empty optional `manualNotes` and `notes` strings in acceptance reports while retaining the `manual-notes` evidence requirement when configured. Thanks to Nick Tripp (@nicholastripp) for #474.
 - Kept explicit child tool allowlists strict while surfacing actionable errors when named extension tools are requested without a loaded provider. Internal `structured_output` is now admitted automatically when an output schema is active, and direct and chained children share the same registry check. Thanks to DesertThief (@DesertThief) for #429 and Chris-Kode (@Chris-Kode) for confirming the structured-output case.
 - Prevented model fallback retries for trailing child tool failures even when their details resemble provider outages, and retried provider streams that end without `finish_reason`. Thanks to 虚妄IlluDelu (@XWIlluDelu) for #436.

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./src/extension/index.ts";

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "pi-subagents": "install.mjs"
   },
   "files": [
+    "index.ts",
     "src/**/*.ts",
     "*.mjs",
     "agents/",
@@ -43,7 +44,7 @@
   },
   "pi": {
     "extensions": [
-      "./src/extension/index.ts"
+      "./index.ts"
     ],
     "skills": [
       "./skills"

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -21,7 +21,7 @@ function parentToolEnv(): NodeJS.ProcessEnv {
 describe("subagent extension child mode", () => {
 	it("collapses tool detail before direct subagent tool execution", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
+			import registerSubagentExtension from "./index.ts";
 			const events = { on() { return () => {}; }, emit() {} };
 			let registeredTool;
 			const fakePi = new Proxy({
@@ -73,7 +73,7 @@ describe("subagent extension child mode", () => {
 
 	it("does not show async badge for explicit foreground clarify chain calls", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
+			import registerSubagentExtension from "./index.ts";
 			const events = { on() { return () => {}; }, emit() {} };
 			let registeredTool;
 			const fakePi = new Proxy({
@@ -123,7 +123,7 @@ describe("subagent extension child mode", () => {
 			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ waitTool: { enabled: false } }), "utf-8");
 
 			const script = String.raw`
-				import registerSubagentExtension from "./src/extension/index.ts";
+				import registerSubagentExtension from "./index.ts";
 				const events = { on() { return () => {}; }, emit() {} };
 				let subagentWaitTool;
 				let legacyWaitRegistered = false;
@@ -178,7 +178,7 @@ describe("subagent extension child mode", () => {
 			fs.mkdirSync(configDir, { recursive: true });
 			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ asyncWidget: false }), "utf-8");
 			const script = String.raw`
-				import registerSubagentExtension from "./src/extension/index.ts";
+				import registerSubagentExtension from "./index.ts";
 				const eventHandlers = new Map();
 				const handlers = new Map();
 				const events = { on(channel, handler) { eventHandlers.set(channel, handler); return () => {}; }, emit() {} };
@@ -213,7 +213,7 @@ describe("subagent extension child mode", () => {
 
 	it("registers the main watchdog command and renderer in parent mode", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
+			import registerSubagentExtension from "./index.ts";
 			const events = { on() { return () => {}; }, emit() {} };
 			const commands = [];
 			const renderers = [];
@@ -252,7 +252,7 @@ describe("subagent extension child mode", () => {
 
 	it("returns before registering anything for non-fanout children", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
+			import registerSubagentExtension from "./index.ts";
 			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
 			process.env[SUBAGENT_CHILD_ENV] = "1";
 			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "0";
@@ -287,7 +287,7 @@ describe("subagent extension child mode", () => {
 
 	it("returns before registering anything for fanout children", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
+			import registerSubagentExtension from "./index.ts";
 			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
 			process.env[SUBAGENT_CHILD_ENV] = "1";
 			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
@@ -323,7 +323,7 @@ describe("subagent extension child mode", () => {
 
 	it("does not double-register the child-safe subagent tool when index and fanout-child both load", () => {
 		const script = String.raw`
-			import registerSubagentExtension from "./src/extension/index.ts";
+			import registerSubagentExtension from "./index.ts";
 			import registerFanoutChildSubagentExtension from "./src/extension/fanout-child.ts";
 			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
 			process.env[SUBAGENT_CHILD_ENV] = "1";

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -25,6 +25,17 @@ function collectTsFiles(dir: string): string[] {
 	return files;
 }
 
+test("published Pi extension uses the package-root entrypoint", () => {
+	const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf-8"));
+
+	assert.deepEqual(packageJson.pi?.extensions, ["./index.ts"]);
+	assert.equal(packageJson.files?.includes("index.ts"), true);
+	assert.equal(
+		fs.readFileSync(path.join(projectRoot, "index.ts"), "utf-8").trim(),
+		'export { default } from "./src/extension/index.ts";',
+	);
+});
+
 test("direct @earendil-works runtime imports are declared for CI installs", () => {
 	const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf-8"));
 	const declared = new Set([


### PR DESCRIPTION
Fixes #475.

This exposes the existing extension factory through a package-root `index.ts`, points Pi’s package manifest at that root entrypoint, and includes it in the npm tarball. Pi now derives the compact startup label as `pi-subagents` for both npm installs and filesystem package paths. Existing child-mode runtime coverage now loads through the public entrypoint, with a manifest regression covering the published contract.

Thanks to Ramin Hazegh (@rhazegh) for the report and proposed package-side fix.

Validated with the focused package/runtime tests, `npm pack --dry-run`, Pi’s public resource loader, the full unit/integration/E2E suite, and `git diff --check`.