### PR TITLE
feat(tui): timestamp nested subagent activity

### DIFF
--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -804,6 +804,29 @@ function nestedRunSeed(run: NestedRunSummary): number | undefined {
 	return runningSeed(run.lastUpdate, run.lastActivityAt, run.currentStep, run.toolCount, run.turnCount, run.totalTokens?.total, run.currentToolStartedAt);
 }
 
+function formatClockTime(ms: number | undefined): string | undefined {
+	if (ms === undefined || !Number.isFinite(ms)) return undefined;
+	const date = new Date(ms);
+	const pad = (value: number) => value.toString().padStart(2, "0");
+	return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+function nestedRunTimestamp(run: NestedRunSummary): string | undefined {
+	return formatClockTime(run.state === "running"
+		? (run.lastActivityAt ?? run.currentToolStartedAt ?? run.lastUpdate ?? run.startedAt)
+		: (run.endedAt ?? run.lastUpdate ?? run.lastActivityAt ?? run.startedAt));
+}
+
+function nestedStepTimestamp(step: NestedStepSummary, fallback?: number): string | undefined {
+	return formatClockTime(step.status === "running"
+		? (step.lastActivityAt ?? step.currentToolStartedAt ?? fallback ?? step.startedAt)
+		: (step.endedAt ?? step.lastActivityAt ?? fallback ?? step.startedAt));
+}
+
+function nestedTimestampPrefix(timestamp: string | undefined): string {
+	return timestamp ? `[${timestamp}] ` : "";
+}
+
 function nestedActivity(input: Pick<NestedRunSummary | NestedStepSummary, "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount">, state: NestedRunSummary["state"] | NestedStepSummary["status"], snapshotNow?: number): string {
 	const facts: string[] = [];
 	if (input.currentTool && input.currentToolStartedAt !== undefined && snapshotNow !== undefined) facts.push(`${input.currentTool} ${formatDuration(Math.max(0, snapshotNow - input.currentToolStartedAt))}`);
@@ -823,11 +846,17 @@ function nestedActivity(input: Pick<NestedRunSummary | NestedStepSummary, "activ
 	return "Done";
 }
 
+function nestedChildrenForResult(details: Details, resultIndex: number): NestedRunSummary[] | undefined {
+	const children = details.nestedChildren?.filter((child) => child.parentStepIndex === resultIndex);
+	return children?.length ? children : undefined;
+}
+
 function formatNestedWidgetLines(children: NestedRunSummary[] | undefined, theme: Theme, width: number, expanded: boolean, snapshotNow?: number, lineBudget = expanded ? 12 : 1): string[] {
 	if (!children?.length || lineBudget <= 0) return [];
 	if (!expanded) {
 		const aggregate = formatNestedAggregate(children);
-		return aggregate ? [theme.fg("dim", `↳ ${aggregate}`)] : [];
+		const latest = children.reduce((acc, child) => Math.max(acc, child.lastUpdate ?? child.lastActivityAt ?? child.startedAt ?? 0), 0);
+		return aggregate ? [theme.fg("dim", `↳ ${nestedTimestampPrefix(formatClockTime(latest || undefined))}${aggregate}`)] : [];
 	}
 	const lines: string[] = [];
 	const maxDepth = 2;
@@ -847,7 +876,7 @@ function formatNestedWidgetLines(children: NestedRunSummary[] | undefined, theme
 			}
 			const activity = nestedActivity(child, child.state, snapshotNow ?? child.lastUpdate);
 			const error = child.error ? ` · ${child.error}` : "";
-			lines.push(theme.fg("dim", `${prefix}↳ ${nestedStatusGlyph(child.state, theme, nestedRunSeed(child))} ${nestedRunName(child)} · ${child.state} · ${activity}${error}`));
+			lines.push(theme.fg("dim", `${prefix}↳ ${nestedTimestampPrefix(nestedRunTimestamp(child))}${nestedStatusGlyph(child.state, theme, nestedRunSeed(child))} ${nestedRunName(child)} · ${child.state} · ${activity}${error}`));
 			if (depth === maxDepth) {
 				const aggregate = formatNestedAggregate([...(child.steps?.flatMap((step) => step.children ?? []) ?? []), ...(child.children ?? [])]);
 				if (aggregate && lines.length < lineBudget) lines.push(theme.fg("dim", `${prefix}  ↳ ${aggregate}`));
@@ -855,7 +884,7 @@ function formatNestedWidgetLines(children: NestedRunSummary[] | undefined, theme
 			}
 			for (const step of child.steps ?? []) {
 				if (lines.length >= lineBudget) return;
-				lines.push(theme.fg("dim", `${prefix}  ↳ ${nestedStatusGlyph(step.status, theme)} ${step.agent} · ${step.status} · ${nestedActivity(step, step.status, snapshotNow ?? child.lastUpdate)}`));
+				lines.push(theme.fg("dim", `${prefix}  ↳ ${nestedTimestampPrefix(nestedStepTimestamp(step, child.lastUpdate))}${nestedStatusGlyph(step.status, theme)} ${step.agent} · ${step.status} · ${nestedActivity(step, step.status, snapshotNow ?? child.lastUpdate)}`));
 				append(step.children, depth + 1, `${prefix}    `);
 			}
 			append(child.children, depth + 1, `${prefix}  `);
@@ -1305,11 +1334,17 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 		c.addChild(new Text(truncLine(theme.fg("dim", `  ⎿  ${activity}`), width), 0, 0));
 		const liveStatus = buildLiveStatusLine(r.progress, progressSnapshotNow);
 		if (liveStatus && liveStatus !== activity) c.addChild(new Text(truncLine(theme.fg("dim", `     ${liveStatus}`), width), 0, 0));
+		for (const nestedLine of formatNestedWidgetLines(d.nestedChildren, theme, width, false, progressSnapshotNow)) {
+			c.addChild(new Text(truncLine(`  ${nestedLine}`, width), 0, 0));
+		}
 		c.addChild(new Text(truncLine(theme.fg("accent", `  ${liveDetailHintText()}`), width), 0, 0));
 		if (r.artifactPaths) c.addChild(new Text(truncLine(theme.fg("dim", `  output: ${shortenPath(r.artifactPaths.outputPath)}`), width), 0, 0));
 		return c;
 	}
 
+	for (const nestedLine of formatNestedWidgetLines(d.nestedChildren, theme, width, true, undefined, 4)) {
+		c.addChild(new Text(truncLine(`  ${nestedLine}`, width), 0, 0));
+	}
 	c.addChild(new Text(truncLine(theme.fg("dim", `  ⎿  ${resultStatusLine(r, output)}`), width), 0, 0));
 	const preview = firstOutputLine(output);
 	if (preview && r.exitCode === 0 && !hasEmptyTextOutputWithoutOutputTarget(r.task, output)) {
@@ -1405,6 +1440,9 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 		if (rRunning && rProg && "status" in rProg) {
 			const activity = compactCurrentActivity(rProg);
 			c.addChild(new Text(truncLine(theme.fg("dim", `    ⎿  ${activity}`), width), 0, 0));
+			for (const nestedLine of formatNestedWidgetLines(nestedChildrenForResult(d, i), theme, width, false, snapshotNowForProgress(rProg))) {
+				c.addChild(new Text(truncLine(`    ${nestedLine}`, width), 0, 0));
+			}
 			c.addChild(new Text(truncLine(theme.fg("accent", `    ${liveDetailHintText()}`), width), 0, 0));
 		} else if (!rPending && (r.exitCode !== 0 || r.interrupted || r.detached || hasEmptyTextOutputWithoutOutputTarget(r.task, output))) {
 			c.addChild(new Text(truncLine(theme.fg(r.exitCode !== 0 ? "error" : "dim", `    ⎿  ${resultStatusLine(r, output)}`), width), 0, 0));
@@ -1479,6 +1517,9 @@ export function renderSubagentResult(
 
 		if (isRunning && r.progress) {
 			const progressSnapshotNow = snapshotNowForProgress(r.progress);
+			for (const nestedLine of formatNestedWidgetLines(d.nestedChildren, theme, w, expanded, progressSnapshotNow, expanded ? 12 : 1)) {
+				c.addChild(new Text(fit(`  ${nestedLine}`), 0, 0));
+			}
 			const toolLine = formatCurrentToolLine(r.progress, w, expanded, progressSnapshotNow);
 			if (toolLine) {
 				c.addChild(new Text(fit(theme.fg("warning", `> ${toolLine}`)), 0, 0));
@@ -1726,6 +1767,9 @@ export function renderSubagentResult(
 			const liveStatusLine = buildLiveStatusLine(rProg, progressSnapshotNow);
 			if (liveStatusLine) {
 				c.addChild(new Text(fit(theme.fg("accent", `    ${liveStatusLine}`)), 0, 0));
+			}
+			for (const nestedLine of formatNestedWidgetLines(nestedChildrenForResult(d, i), theme, w, expanded, progressSnapshotNow, expanded ? 8 : 1)) {
+				c.addChild(new Text(fit(`    ${nestedLine}`), 0, 0));
 			}
 			c.addChild(new Text(fit(theme.fg("accent", `    ${liveDetailHintText()}`)), 0, 0));
 			if (r.artifactPaths) {

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -8,6 +8,7 @@ type RenderSubagentResult = (
 			mode: "single" | "parallel" | "chain" | "management";
 			context?: "fresh" | "fork";
 			results: unknown[];
+			nestedChildren?: unknown[];
 		};
 	},
 	options: { expanded: boolean },
@@ -58,6 +59,37 @@ describe("renderSubagentResult fork indicator", () => {
 
 		const text = widget.render(120).join("\n");
 		assert.match(text, /\[fork\]/);
+	});
+
+	it("shows nested foreground children with timestamps on running single results", () => {
+		const widget = renderSubagentResult!({
+			content: [{ type: "text", text: "running" }],
+			details: {
+				mode: "single",
+				results: [{
+					agent: "execute",
+					task: "run plan",
+					exitCode: 0,
+					messages: [],
+					usage: emptyUsage,
+					progress: { status: "running", index: 0, agent: "execute", toolCount: 1, tokens: 10, durationMs: 1_000, lastActivityAt: 1_700_000_001_000 },
+				}],
+				nestedChildren: [{
+					id: "impl-1",
+					parentRunId: "root",
+					parentStepIndex: 0,
+					depth: 1,
+					path: [{ runId: "root", stepIndex: 0, agent: "execute" }],
+					state: "running",
+					agent: "implement",
+					lastUpdate: 1_700_000_002_000,
+					currentTool: "bash",
+				}],
+			},
+		}, { expanded: false }, theme);
+
+		const text = widget.render(120).join("\n");
+		assert.match(text, /↳ \[\d{2}:\d{2}:\d{2}\] \+1 nested run \(1 running\)/);
 	});
 
 	it("shows [fork] on single-result header", () => {

--- a/test/unit/widget-nested-render.test.ts
+++ b/test/unit/widget-nested-render.test.ts
@@ -41,11 +41,11 @@ describe("nested widget rendering", () => {
 	it("uses aggregate lines when collapsed and full child rows when expanded", () => {
 		const child = nested("nested-reviewer", "root-run", "running", { currentTool: "read" });
 		const collapsed = buildWidgetLines([job(child)], theme as any, 120, false).join("\n");
-		assert.match(collapsed, /↳ \+1 nested run \(1 running\)/);
+		assert.match(collapsed, /↳ \[\d{2}:\d{2}:\d{2}\] \+1 nested run \(1 running\)/);
 		assert.doesNotMatch(collapsed, /nested-reviewer · running/);
 
 		const expanded = buildWidgetLines([job(child)], theme as any, 120, true).join("\n");
-		assert.match(expanded, /↳ . nested-reviewer · running · read/);
+		assert.match(expanded, /↳ \[\d{2}:\d{2}:\d{2}\] . nested-reviewer · running · read/);
 	});
 
 	it("collapses descendants beyond the nested depth budget", () => {
@@ -71,13 +71,13 @@ describe("nested widget rendering", () => {
 		state.steps![0]!.status = "complete";
 		const expanded = buildWidgetLines([state], theme as any, 120, true).join("\n");
 		assert.match(expanded, /✓ Step 1\/1: owner · complete/);
-		assert.match(expanded, /↳ . still-running · running/);
+		assert.match(expanded, /↳ \[\d{2}:\d{2}:\d{2}\] . still-running · running/);
 	});
 
 	it("degrades stale child summaries to id and state", () => {
 		const child = nested("missing-metadata", "root-run", "failed", { agent: undefined, error: "owner gone" });
 		const expanded = buildWidgetLines([job(child)], theme as any, 120, true).join("\n");
-		assert.match(expanded, /missing-metadata · failed · Failed · owner gone/);
+		assert.match(expanded, /\[\d{2}:\d{2}:\d{2}\] . missing-metadata · failed · Failed · owner gone/);
 	});
 
 	it("rerenders when only nested state changes", () => {


### PR DESCRIPTION
## Summary

- prefix nested run and step activity with local clock timestamps
- show nested child activity in foreground single, parallel, and chain result rendering
- retain compact aggregate rendering while exposing detailed timestamped rows when expanded

This is the clean, current-main version of the timestamp UI previously bundled into #270. The separate fanout-history fix from that PR already landed through #291. The CVT fork carries this patch as `v0.34.0-cvt.2` while this PR is reviewed.

## Tests

- `env -u PI_CODING_AGENT_DIR npm test` (1240 passed; one unrelated watchdog timing test timed out)
- `env -u PI_CODING_AGENT_DIR node --experimental-strip-types --test test/unit/watchdog-lsp-diagnostics.test.ts` (the timing test passed immediately in isolation)
- `env -u PI_CODING_AGENT_DIR npm run test:integration` (572 passed)
- focused nested widget and foreground rendering tests passed after rebasing onto current `main`