### PR TITLE
feat: integrate background work with subagent wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fork-context sanitization no longer disables thinking for every child. Forking over a transcript with signed Anthropic thinking blocks now classifies each child’s effective primary and fallback models through registry provider/API metadata, forces thinking off for Anthropic-backed or unresolved candidates, and reports every downgrade even when the run fails. Other resolved providers keep their requested thinking level. The tool description also documents thinking suffixes, including `max`, and the fork/thinking interaction. Thanks to Jeff (@jefftheai) for #476.
 
 ### Added
+- Added a versioned `pi-subagents/background-work` provider contract so `subagent_wait` can track exact current-session jobs from other extensions without count races. Child runtimes can expose the wait tool through their strict allowlist, effective wait config is propagated to every child launch path, and headless sessions drain active work before ending. Thanks to RoboBryce (@robobryce) for #472 and #473.
 - Added a typed v1 foreground delegation contract for extension consumers through the existing `prompt-template:subagent:*` transport, with strict bounded controls, structured terminal states, cancellation, and a supported `pi-subagents/delegation` package export. Thanks to JT (@juicetin) for #465 and #467.
 - Added `acceptanceRole: read-only | writer` to agent frontmatter, settings overrides, and agent management so custom agent names can declare automatic acceptance semantics. Explicit task mutation or no-edit intent wins, while omitted metadata preserves the existing name heuristics. Thanks to Taylor C Jensen (@taylorcjensen) for #466.
 - Added acknowledged async steering: action `steer` returns a correlated request id and waits up to three seconds for child-Pi input acceptance, supports scheduled pending children, records a bounded steering ledger, and fail-closed single-run recovery after confirmed pause within a further 15-second bound. Chain, parallel, and nested runs report per-child partial/failure states without automatic interruption.
@@ -54,7 +55,7 @@
 ## [0.34.0] - 2026-07-07
 
 ### Added
-- Added `waitTool` config and `PI_SUBAGENT_WAIT_TOOL_ENABLED` so interactive users can keep the `wait` tool registered while making it return immediately instead of blocking on background subagents. Thanks to Rebecca Dessonville (@TwistedTabby) for #394.
+- Added `waitTool` config and `PI_SUBAGENT_WAIT_TOOL_ENABLED` so interactive users can keep the `subagent_wait` tool registered while making it return immediately instead of blocking on background subagents. Thanks to Rebecca Dessonville (@TwistedTabby) for #394.
 
 ### Fixed
 - Coerce agent frontmatter `thinking: false` to disabled thinking so child model IDs do not gain invalid `:false` suffixes. Thanks to Alberto Vasquez (@albertovasquez) for #399.

--- a/README.md
+++ b/README.md
@@ -591,11 +591,11 @@ You can combine them in either order:
 /run reviewer "review this diff" --bg --fork
 ```
 
-Background runs are detached. If the parent agent has other independent work, it should keep working. When it has nothing useful to do until a background result arrives, it should call `subagent_wait` instead of running sleep or status-polling loops. `subagent_wait()` returns when the next active run finishes or needs attention and keeps the turn alive for normal notification delivery; use `subagent_wait({ all: true })` to drain every active async run, `subagent_wait({ id })` for one async run or remembered detached foreground run, and `subagent_wait({ timeoutMs })` to cap the block.
+Background runs are detached. If the parent agent has other independent work, it should keep working. In an interactive chat, it should normally return control when ready to yield and let Pi deliver the completion notification instead of blocking merely to wait. Use `subagent_wait` when the current request must run to completion in this turn, when a skill cannot return before its work finishes, or in a non-interactive run with no next turn. It returns when the next initially active run or registered provider item finishes or a subagent needs attention; use `subagent_wait({ all: true })` for all work active at call time, `subagent_wait({ id })` for one async or remembered detached foreground run, and `subagent_wait({ timeoutMs })` to cap the block.
 
 A foreground child can detach while it waits for a supervisor reply. Reply first, then call `subagent_wait({ id: runId })`. The remembered run stays pending until the child exits, then emits a session-scoped completion notification with recovered output and remains inspectable through `subagent({ action: "status", id: runId })`. Do not call `resume` or launch a replacement while the child remains detached.
 
-`subagent_wait` is what lets a background-launching skill keep moving in a single turn, including non-interactive `pi -p` invocations where there is no subsequent turn to receive a completion notification. Ending the turn to wait for a completion only works in an interactive session where the user will prompt the agent again; in a run-to-completion skill or a non-interactive run, use `subagent_wait` so the still-running children are not abandoned.
+Headless sessions also auto-drain current-session subagent and registered provider work at `agent_end`, using one absolute timeout and continuing through attention states. This is a final lifecycle safeguard rather than a replacement for explicit orchestration: `subagent_wait` still lets a model react to each result during the turn. Provider, reconciliation, timeout, and malformed-state failures remain visible errors instead of being treated as successful drains.
 
 The `oracle` and `worker` builtins are designed for an explicit decision loop. A typical pattern is to ask `oracle` for diagnosis and a recommended execution prompt, then only run `worker` after the main agent approves that direction.
 
@@ -1006,6 +1006,29 @@ Delegation requires an active extension context. Emit requests from a supported 
 
 Existing prompt-template payloads continue over the same event family, including their parallel-only adapter. `pi-subagents/delegation` is the canonical contract for new extension integrations.
 
+## Background-work provider API
+
+Other Pi extensions can make their current-session jobs visible to `subagent_wait` through the versioned process-local provider contract:
+
+```ts
+import { registerBackgroundWorkProvider } from "pi-subagents/background-work";
+
+const dispose = registerBackgroundWorkProvider({
+  name: "my-background-extension",
+  wakeChannels: ["my-extension:job-finished"],
+  listActiveWork: () => jobs
+    .filter((job) => job.status === "running")
+    .map((job) => ({ id: job.id, sessionId: job.ownerSessionId })),
+  reconcile: ({ sessionId, nowMs }) => reconcileJobs(sessionId, nowMs),
+});
+```
+
+Each item needs a stable provider-local ID and the exact Pi session ID that owns it. `subagent_wait` captures those identities rather than a count, so one job finishing while another starts still satisfies first-completion waits without losing the replacement. It filters snapshots to the active session, fails closed if a provider disappears while its work is tracked, and surfaces malformed snapshots or provider errors with provider context. Wake channels only shorten polling; validated snapshots remain authoritative.
+
+Providers share a registry through `Symbol.for("pi-subagents.background-work.v1")`, allowing independently loaded extension modules to meet in one Pi process. Registration is reload-safe: a new provider with the same name replaces the old callback, and the old disposer cannot remove the replacement. Call the disposer during extension shutdown when possible.
+
+Child processes do not gain provider tools or extensions automatically. Add `subagent_wait` to the child agent's `tools` allowlist and load each provider through `extensions` or `subagentOnlyExtensions`. The parent's effective `waitTool` setting is serialized through foreground, async, resume, chain, parallel, and fanout launch paths; `PI_SUBAGENT_WAIT_TOOL_ENABLED` keeps precedence.
+
 ## Programmatic tool usage
 
 These are the parameters the LLM passes when it calls the `subagent` tool. Most users ask naturally or use slash commands instead.
@@ -1292,7 +1315,7 @@ Controls the above-editor widget for background runs. The default is `true`. Set
 { "waitTool": { "enabled": false } }
 ```
 
-Keeps the `subagent_wait` tool registered but makes it return immediately instead of blocking on active async runs. Use this in interactive sessions where background completions should arrive as notifications while the main conversation stays steerable. The default is enabled. You can also set `"waitTool": false`; set `PI_SUBAGENT_WAIT_TOOL_ENABLED=false` (or `0`, `off`, `disabled`) to override config for one process. Invalid `waitTool` config or env values fail instead of being coerced.
+Keeps the `subagent_wait` tool registered but makes direct calls return immediately instead of blocking on active subagent or provider work. The default is enabled. You can also set `"waitTool": false`; set `PI_SUBAGENT_WAIT_TOOL_ENABLED=false` (or `0`, `off`, `disabled`) to override config for one process. The effective value is passed explicitly to child runtimes. Headless `agent_end` auto-drain remains a lifecycle safeguard even when direct wait calls are disabled. Invalid config or environment values fail instead of being coerced.
 
 ### `forceTopLevelAsync`
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "exports": {
     ".": "./index.ts",
+    "./background-work": "./src/api/background-work.ts",
     "./delegation": "./src/api/delegation.ts"
   },
   "repository": {

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -352,9 +352,9 @@ Async does not mean parallel writes. Do not edit the same active worktree while 
 
 Do not end your turn immediately after launching an async child if you promised to keep working. Continue the local inspection, synthesis, or validation prep, then check the async run when its result is needed.
 
-When there is no independent work left and you just need the next async result, **call `subagent_wait()`** rather than `sleep`/status-polling loops. `subagent_wait()` returns when the next active run finishes or needs attention and keeps the turn alive for normal notification delivery. Use `subagent_wait({ all: true })` to drain every active async run, `subagent_wait({ id: "..." })` to block on one async run or remembered detached foreground run, and `subagent_wait({ timeoutMs })` to cap how long you block. If a foreground child detaches for supervisor coordination, reply first, then wait on its id; do not resume or launch a replacement while it remains detached.
+In an interactive chat, normally return control when ready to yield and let Pi wake the session on completion; do not call `subagent_wait()` merely to wait. Call it when this request must run to completion in the current turn, when a skill cannot return before its background work finishes, or in a non-interactive run with no next turn. Never substitute sleep or status-polling loops.
 
-Prefer `subagent_wait()` over ending the turn whenever you must keep going to finish the job — inside a skill that has to run to completion, or in any non-interactive run (`pi -p ...`) where the whole task is a single turn. In those cases ending the turn abandons the still-running children, because there is no next turn to receive their completion. Only end the turn to wait when you are in an interactive session and are certain the user will prompt you again; then Pi will wake you when the run finishes.
+`subagent_wait()` returns when the next initially active async run or registered provider item finishes or a subagent needs attention. Use `subagent_wait({ all: true })` for all work active at call time, `subagent_wait({ id: "..." })` for one async or remembered detached foreground run, and `subagent_wait({ timeoutMs })` to cap the block. If a foreground child detaches for supervisor coordination, reply first, then wait on its id; do not resume or launch a replacement while it remains detached. Headless sessions also auto-drain exact current-session work at `agent_end` as a final safeguard.
 
 ```typescript
 subagent({
@@ -737,7 +737,7 @@ Methods: `ping`, `status`, `spawn`, `interrupt`, and `stop`. `spawn` is async-on
 - **Keep conversational authority clear.** Advisory subagents should not silently
   become second decision-makers.
 
-Runtime config can change orchestration behavior. `asyncByDefault` and `forceTopLevelAsync` affect whether launches detach; `waitTool` can make `subagent_wait()` return immediately; `globalConcurrencyLimit` bounds concurrent fanout, while a positive `maxSubagentSpawnsPerSession` optionally caps cumulative launches (`0` or unset is unlimited); `singleRunOutputBaseDir` and `worktreeBaseDir` route outputs and worktrees; `completionBatch` groups async notifications. Per-run `artifacts: false` disables artifact capture for that launch. Async status and result artifacts are versioned with fields such as `lifecycleArtifactVersion`, `workflowGraph`, `steps`, `results`, `totalTokens`, `totalCost`, `turnCount`, `toolCount`, and nested `children`. Child protocol failures expose a structured `protocolError`; `protocol_output_limit` means a child emitted a JSONL line above the 4 MiB live-parser cap. Prefer these artifacts and `status` views over scraping terminal output.
+Runtime config can change orchestration behavior. `asyncByDefault` and `forceTopLevelAsync` affect whether launches detach; `waitTool` can make direct `subagent_wait()` calls return immediately while headless auto-drain remains active, and its effective value is propagated to child runtimes; `globalConcurrencyLimit` bounds concurrent fanout, while a positive `maxSubagentSpawnsPerSession` optionally caps cumulative launches (`0` or unset is unlimited); `singleRunOutputBaseDir` and `worktreeBaseDir` route outputs and worktrees; `completionBatch` groups async notifications. Per-run `artifacts: false` disables artifact capture for that launch. Async status and result artifacts are versioned with fields such as `lifecycleArtifactVersion`, `workflowGraph`, `steps`, `results`, `totalTokens`, `totalCost`, `turnCount`, `toolCount`, and nested `children`. Child protocol failures expose a structured `protocolError`; `protocol_output_limit` means a child emitted a JSONL line above the 4 MiB live-parser cap. Prefer these artifacts and `status` views over scraping terminal output.
 
 ## Best Practices
 
@@ -747,16 +747,16 @@ Launch every subagent asynchronously by default. Use `async: true` for scouts, r
 
 ### Use subagent_wait() to block until async runs finish
 
-When you have launched async runs and have no independent work left but must keep going to finish the task, call `subagent_wait()`. It blocks the current turn until the next run completes or needs attention, keeps the turn alive for normal notification delivery, then returns.
+In an interactive chat, return control and let Pi wake the session unless the current request must run to completion in this turn. Use `subagent_wait()` for that run-to-completion case, inside a skill that cannot return yet, or in a non-interactive invocation. It blocks until tracked work changes and keeps the turn alive for completion delivery.
 
-- `subagent_wait()` — return when the next active async run in this session finishes or needs attention.
-- `subagent_wait({ all: true })` — block until every active async run in this session finishes or one needs attention.
-- `subagent_wait({ id: "..." })` — block on one async run or remembered detached foreground run (id or prefix). For a detached foreground child, reply to the supervisor request first; completion wakes the originating session with recovered output.
-- `subagent_wait({ timeoutMs })` — cap the block; the runs keep going if it elapses.
+- `subagent_wait()` — return when the next initially active async run or registered provider item finishes, or a subagent needs attention.
+- `subagent_wait({ all: true })` — block until every async run and provider item active at call time finishes, or a subagent needs attention.
+- `subagent_wait({ id: "..." })` — block on one async or remembered detached foreground run (id or prefix). Provider items are not selected through this parameter.
+- `subagent_wait({ timeoutMs })` — cap the block; active work keeps running if it elapses.
 
-`subagent_wait()` is the correct way to keep N workers in flight: launch N, call `subagent_wait()`, react to the result, launch a replacement if needed, then call `subagent_wait()` again. Use `subagent_wait({ all: true })` only when you intentionally want to drain the fleet to zero. Reserve ending-the-turn-to-wait for interactive sessions where the user will prompt you again; in a skill that must complete or a non-interactive `pi -p` run there is no next turn, so `subagent_wait()` is required to avoid abandoning live children.
+Providers are discovered through the versioned `pi-subagents/background-work` registry and must return stable item IDs with exact owning session IDs. Child agents receive no provider automatically: keep `subagent_wait` in the child `tools` allowlist and load provider extensions through `extensions` or `subagentOnlyExtensions`.
 
-If `config.waitTool` or `PI_SUBAGENT_WAIT_TOOL_ENABLED` disables blocking behavior, the `subagent_wait` tool stays registered but returns immediately. In that case, inspect status, continue independent work, or rely on normal completion notifications instead of building sleep/status polling loops.
+If config or `PI_SUBAGENT_WAIT_TOOL_ENABLED` disables blocking behavior, direct `subagent_wait` calls return immediately. Headless `agent_end` auto-drain remains active as a lifecycle safeguard and surfaces provider, reconciliation, or timeout failures.
 
 ### Keep writes single-threaded by default
 

--- a/src/api/background-work.ts
+++ b/src/api/background-work.ts
@@ -1,0 +1,197 @@
+export const BACKGROUND_WORK_PROTOCOL_VERSION = 1;
+export const BACKGROUND_WORK_REGISTRY_KEY = "pi-subagents.background-work.v1";
+
+const MAX_PROVIDER_NAME_LENGTH = 128;
+const MAX_PROVIDERS = 100;
+const MAX_ITEM_ID_LENGTH = 256;
+const MAX_SESSION_ID_LENGTH = 256;
+const MAX_WAKE_CHANNEL_LENGTH = 256;
+const MAX_ITEMS_PER_PROVIDER = 10_000;
+
+export interface BackgroundWorkItem {
+	id: string;
+	sessionId: string;
+}
+
+export interface BackgroundWorkReconcileContext {
+	sessionId: string;
+	nowMs: number;
+}
+
+export interface BackgroundWorkProvider {
+	name: string;
+	listActiveWork(): readonly BackgroundWorkItem[];
+	wakeChannels?: readonly string[];
+	reconcile?(context: BackgroundWorkReconcileContext): void;
+}
+
+export interface RegisteredBackgroundWorkItem extends BackgroundWorkItem {
+	provider: string;
+}
+
+export interface BackgroundWorkSnapshot {
+	providers: readonly string[];
+	items: readonly RegisteredBackgroundWorkItem[];
+}
+
+interface BackgroundWorkRegistry {
+	version: typeof BACKGROUND_WORK_PROTOCOL_VERSION;
+	providers: Map<string, BackgroundWorkProvider>;
+}
+
+function registry(): BackgroundWorkRegistry {
+	const key = Symbol.for(BACKGROUND_WORK_REGISTRY_KEY);
+	const globalObject = globalThis as Record<PropertyKey, unknown>;
+	const existing = globalObject[key];
+	if (existing === undefined) {
+		const created: BackgroundWorkRegistry = {
+			version: BACKGROUND_WORK_PROTOCOL_VERSION,
+			providers: new Map(),
+		};
+		globalObject[key] = created;
+		return created;
+	}
+	if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+		throw new Error(`Malformed background-work registry at Symbol.for("${BACKGROUND_WORK_REGISTRY_KEY}").`);
+	}
+	const candidate = existing as Partial<BackgroundWorkRegistry>;
+	if (candidate.version !== BACKGROUND_WORK_PROTOCOL_VERSION || !(candidate.providers instanceof Map)) {
+		throw new Error(`Unsupported background-work registry at Symbol.for("${BACKGROUND_WORK_REGISTRY_KEY}").`);
+	}
+	return candidate as BackgroundWorkRegistry;
+}
+
+function validateString(value: unknown, field: string, maxLength: number): string {
+	if (typeof value !== "string" || value.length === 0 || value.trim() !== value) {
+		throw new Error(`${field} must be a non-empty string without leading or trailing whitespace.`);
+	}
+	if (value.length > maxLength) throw new Error(`${field} must be at most ${maxLength} characters.`);
+	if (value.includes("\0")) throw new Error(`${field} must not contain NUL characters.`);
+	return value;
+}
+
+function validateProvider(value: unknown): BackgroundWorkProvider {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("Background-work provider must be an object.");
+	}
+	const provider = value as Record<string, unknown>;
+	const unknownFields = Object.keys(provider).filter((key) => !["name", "listActiveWork", "wakeChannels", "reconcile"].includes(key));
+	if (unknownFields.length > 0) throw new Error(`Background-work provider has unknown fields: ${unknownFields.join(", ")}.`);
+	const name = validateString(provider.name, "Background-work provider name", MAX_PROVIDER_NAME_LENGTH);
+	if (typeof provider.listActiveWork !== "function") {
+		throw new Error(`Background-work provider '${name}' must expose listActiveWork().`);
+	}
+	if (provider.reconcile !== undefined && typeof provider.reconcile !== "function") {
+		throw new Error(`Background-work provider '${name}' reconcile must be a function when provided.`);
+	}
+	if (provider.wakeChannels !== undefined) {
+		if (!Array.isArray(provider.wakeChannels)) {
+			throw new Error(`Background-work provider '${name}' wakeChannels must be an array when provided.`);
+		}
+		const channels = provider.wakeChannels.map((channel, index) =>
+			validateString(channel, `Background-work provider '${name}' wakeChannels[${index}]`, MAX_WAKE_CHANNEL_LENGTH));
+		if (new Set(channels).size !== channels.length) {
+			throw new Error(`Background-work provider '${name}' wakeChannels must not contain duplicates.`);
+		}
+	}
+	return value as BackgroundWorkProvider;
+}
+
+function validateItem(provider: string, value: unknown, index: number): BackgroundWorkItem {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`Background-work provider '${provider}' item ${index} must be an object.`);
+	}
+	const item = value as Record<string, unknown>;
+	const unknownFields = Object.keys(item).filter((key) => key !== "id" && key !== "sessionId");
+	if (unknownFields.length > 0) {
+		throw new Error(`Background-work provider '${provider}' item ${index} has unknown fields: ${unknownFields.join(", ")}.`);
+	}
+	return {
+		id: validateString(item.id, `Background-work provider '${provider}' item ${index} id`, MAX_ITEM_ID_LENGTH),
+		sessionId: validateString(item.sessionId, `Background-work provider '${provider}' item ${index} sessionId`, MAX_SESSION_ID_LENGTH),
+	};
+}
+
+/**
+ * Register or replace one process-local background-work provider. The returned
+ * disposer only removes this exact registration, so an old extension reload
+ * cannot unregister its replacement.
+ */
+export function registerBackgroundWorkProvider(provider: BackgroundWorkProvider): () => void {
+	const validated = validateProvider(provider);
+	const current = registry();
+	if (!current.providers.has(validated.name) && current.providers.size >= MAX_PROVIDERS) {
+		throw new Error(`Background-work registry supports at most ${MAX_PROVIDERS} providers.`);
+	}
+	current.providers.set(validated.name, validated);
+	return () => {
+		if (current.providers.get(validated.name) === validated) current.providers.delete(validated.name);
+	};
+}
+
+export function listBackgroundWorkProviders(): readonly BackgroundWorkProvider[] {
+	const current = registry();
+	if (current.providers.size > MAX_PROVIDERS) throw new Error(`Background-work registry contains more than ${MAX_PROVIDERS} providers.`);
+	const providers: BackgroundWorkProvider[] = [];
+	for (const [key, value] of current.providers) {
+		const provider = validateProvider(value);
+		if (key !== provider.name) throw new Error(`Background-work registry key '${key}' does not match provider name '${provider.name}'.`);
+		providers.push(provider);
+	}
+	return providers;
+}
+
+/** Read validated provider wake channels without reconciling or listing work. */
+export function listBackgroundWorkWakeChannels(): readonly string[] {
+	const channels = new Set<string>();
+	for (const provider of listBackgroundWorkProviders()) {
+		for (const channel of provider.wakeChannels ?? []) channels.add(channel);
+	}
+	return [...channels];
+}
+
+/** Reconcile and snapshot active provider work owned by one exact Pi session. */
+export function snapshotBackgroundWork(sessionId: string, nowMs = Date.now()): BackgroundWorkSnapshot {
+	validateString(sessionId, "Background-work snapshot sessionId", MAX_SESSION_ID_LENGTH);
+	const providers = listBackgroundWorkProviders();
+	const items: RegisteredBackgroundWorkItem[] = [];
+	const identities = new Set<string>();
+	for (const provider of providers) {
+		try {
+			provider.reconcile?.({ sessionId, nowMs });
+		} catch (error) {
+			throw new Error(
+				`Background-work provider '${provider.name}' reconcile failed: ${error instanceof Error ? error.message : String(error)}`,
+				{ cause: error },
+			);
+		}
+		let active: readonly BackgroundWorkItem[];
+		try {
+			active = provider.listActiveWork();
+		} catch (error) {
+			throw new Error(
+				`Background-work provider '${provider.name}' listActiveWork failed: ${error instanceof Error ? error.message : String(error)}`,
+				{ cause: error },
+			);
+		}
+		if (!Array.isArray(active)) {
+			throw new Error(`Background-work provider '${provider.name}' listActiveWork() must return an array.`);
+		}
+		if (active.length > MAX_ITEMS_PER_PROVIDER) {
+			throw new Error(`Background-work provider '${provider.name}' returned ${active.length} items; maximum is ${MAX_ITEMS_PER_PROVIDER}.`);
+		}
+		active.forEach((value, index) => {
+			const item = validateItem(provider.name, value, index);
+			const identity = `${provider.name}\0${item.sessionId}\0${item.id}`;
+			if (identities.has(identity)) {
+				throw new Error(`Background-work provider '${provider.name}' returned duplicate item '${item.id}' for session '${item.sessionId}'.`);
+			}
+			identities.add(identity);
+			if (item.sessionId === sessionId) items.push({ provider: provider.name, ...item });
+		});
+	}
+	return {
+		providers: providers.map((provider) => provider.name),
+		items,
+	};
+}

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -5,6 +5,7 @@ import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-age
 import { discoverAgents } from "../agents/agents.ts";
 import { getArtifactsDir } from "../shared/artifacts.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
+import { resolveWaitToolConfig } from "../runs/background/wait-config.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../runs/shared/pi-args.ts";
 import { readNestedControlRequests, resolveNestedRouteFromEnv, writeNestedControlResult } from "../runs/shared/nested-events.ts";
 import { deliverSubagentIntercomMessageEvent } from "../intercom/result-intercom.ts";
@@ -146,6 +147,7 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 		state,
 		config,
 		asyncByDefault: config.asyncByDefault === true,
+		waitToolEnabled: resolveWaitToolConfig(config.waitTool).enabled,
 		tempArtifactsDir: getArtifactsDir(null),
 		getSubagentSessionRoot,
 		expandTilde,

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -24,7 +24,7 @@ import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "..
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
 import { clearLegacyResultAnimationTimer, renderSubagentResult } from "../tui/render.ts";
-import { SubagentParams, SubagentWaitParams } from "./schemas.ts";
+import { SubagentParams } from "./schemas.ts";
 import { validateChainInput } from "./chain-validation.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { createAsyncJobTracker } from "../runs/background/async-job-tracker.ts";
@@ -38,7 +38,9 @@ import { createNativeSupervisorChannel } from "../intercom/native-supervisor-cha
 import { registerSubagentRpcBridge } from "./rpc.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
-import { resolveWaitToolConfig, waitForSubagents } from "../runs/background/subagent-wait.ts";
+import { resolveWaitToolConfig } from "../runs/background/subagent-wait.ts";
+import { registerWaitTool } from "../runs/background/wait-tool.ts";
+import { drainOutstandingWork } from "../runs/background/auto-drain.ts";
 import registerSubagentNotify, { parseSubagentNotifyContent, type SubagentNotifyDetails } from "../runs/background/notify.ts";
 import { formatSteeringNotice, handleSubagentSteeringNotice, SUBAGENT_STEERING_MESSAGE_TYPE, type SubagentSteeringMessageDetails } from "./steering-notices.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
@@ -303,6 +305,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		state,
 		config,
 		asyncByDefault,
+		waitToolEnabled: waitToolConfig.enabled,
 		handleScheduledRunAction: (params, ctx) => scheduledRunManager.handleToolCall(params, ctx),
 		watchdog: mainWatchdog,
 		tempArtifactsDir,
@@ -467,25 +470,12 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	pi.registerTool(tool);
 
-	const subagentWaitTool: ToolDefinition<typeof SubagentWaitParams, Details> = {
-		name: "subagent_wait",
-		label: "Subagent Wait",
-		description: `Block until background (async) subagent runs started in this session finish, then return.
+	registerWaitTool(pi, state, waitToolConfig.enabled);
 
-Use this after launching async subagents when you have no independent work left and must not end your turn — for example inside a skill that has to run to completion, or any non-interactive run (\`pi -p ...\`) where the whole task is a single turn and ending it would abandon the still-running children.
-
-• { } — return as soon as the FIRST active run finishes (default). Ideal for a rolling fleet: launch N, wait, spawn a replacement for the one that finished, then call subagent_wait again — keeping N in flight.
-• { all: true } — block until EVERY active run in this session is finished.
-• { id: "..." } — wait for one specific async run or remembered detached foreground run (id or prefix) to finish.
-• { timeoutMs: 600000 } — stop waiting after N ms (the runs keep going regardless; default 30 min)
-
-subagent_wait also returns when a run needs attention (a child that went idle or blocked for a decision), not only on completion — so a stuck child never stalls the loop; the summary names the run(s) to inspect/nudge/resume/interrupt. It wakes the instant a completion or control event arrives (subscribed to Pi's event bus, with a poll fallback that reconciles crashed runners), keeps the turn alive for normal notification delivery, and resolves early if the turn is aborted.${waitToolConfig.enabled ? "" : "\n\nConfigured behavior: subagent_wait is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED and returns immediately without blocking."}`,
-		parameters: SubagentWaitParams,
-		execute(_id, params, signal, _onUpdate, _ctx) {
-			return waitForSubagents(params, signal, { state, events: pi.events, enabled: waitToolConfig.enabled });
-		},
-	};
-	pi.registerTool(subagentWaitTool);
+	pi.on("agent_end", async (_event, ctx) => {
+		if (ctx.hasUI) return;
+		await drainOutstandingWork({ state, events: pi.events });
+	});
 
 	registerSlashCommands(pi, state);
 

--- a/src/extension/tool-description.ts
+++ b/src/extension/tool-description.ts
@@ -9,7 +9,7 @@ const CUSTOM_TOOL_DESCRIPTION_MAX_BYTES = 50 * 1024;
 export const SUBAGENT_SAFETY_GUIDANCE = `SAFETY-CRITICAL SUBAGENT GUIDANCE:
 • Use { action: "list" } before execution and only run executable/non-disabled agents or chains.
 • Keep execution and management separate: omit action for SINGLE/PARALLEL/CHAIN execution; use action only for list/get/models/create/update/delete/status/interrupt/stop/resume/append-step/doctor.
-• Async/background runs: launch with async:true only when work can proceed independently. Do not sleep or poll status just to wait; if this turn must block, use subagent_wait. Otherwise continue useful work or respond and let completion notifications arrive.
+• Async/background runs: launch with async:true only when work can proceed independently. Do not sleep or poll status just to wait. In an interactive session, normally return control and let Pi wake you; use subagent_wait when this request must run to completion in the current turn or skill. Headless sessions auto-drain current-session work.
 • Child-safety boundary: ordinary child subagents are not orchestrators and must not run subagents. Only explicitly configured fanout children may use the child-safe subagent tool, still bounded by depth/session limits.
 • Writing/review safety: keep one writer for the same cwd/worktree. Use fresh-context read-only reviewers/validators for independent review, then have the parent synthesize and apply fixes as the sole writer unless an isolated worktree was intentionally requested.
 • Artifacts/status essentials: chain outputs live under {chain_dir}; async runs expose asyncId/asyncDir with status.json, events.jsonl, output logs, and status via { action: "status", id }. Include output paths and residual risks when reporting results.`;
@@ -90,7 +90,7 @@ MANAGE / CONTROL:
 • Opt-in schedule actions: schedule, schedule-list, schedule-status, schedule-cancel. Schedule only explicit delayed runs the user asked for.
 
 ASYNC / WAIT:
-• async:true detaches background work. Do not sleep or poll just to wait; use subagent_wait only when this turn must block. Otherwise continue useful work or respond and let completion notifications arrive.
+• async:true detaches background work. Do not sleep or poll just to wait. Interactive sessions normally yield for completion notifications; use subagent_wait for run-to-completion turns or skills. Headless sessions auto-drain current-session work.
 • Status and artifacts live under asyncId/asyncDir with status.json, events.jsonl, output logs, session files, and { action:"status", id:"..." }.
 
 SAFETY:

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -135,6 +135,7 @@ interface AsyncChainParams {
 	progressDir?: string;
 	dynamicFanoutMaxItems?: number;
 	maxSubagentDepth: number;
+	waitToolEnabled?: boolean;
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
 	worktreeBaseDir?: string;
@@ -175,6 +176,7 @@ interface AsyncSingleParams {
 	thinkingOverride?: AgentConfig["thinking"];
 	availableModels?: AvailableModelInfo[];
 	maxSubagentDepth: number;
+	waitToolEnabled?: boolean;
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
 	worktreeBaseDir?: string;
@@ -211,6 +213,7 @@ export interface AsyncRunnerStepBuildParams {
 	progressDir?: string;
 	dynamicFanoutMaxItems?: number;
 	maxSubagentDepth: number;
+	waitToolEnabled?: boolean;
 	worktreeBaseDir?: string;
 	asyncDir: string;
 	outputBaseDir?: string;
@@ -642,6 +645,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			outputMode: behavior.outputMode,
 			sessionFile,
 			maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, a.maxSubagentDepth),
+			waitToolEnabled: params.waitToolEnabled,
 			effectiveAcceptance: resolveEffectiveAcceptance({
 				explicit: s.acceptance,
 				agentName: s.agent,
@@ -836,6 +840,7 @@ export function executeAsyncChain(
 		outputBaseDir: artifactsDir ? path.join(artifactsDir, "outputs", id) : undefined,
 		dynamicFanoutMaxItems: params.dynamicFanoutMaxItems,
 		maxSubagentDepth,
+		waitToolEnabled: params.waitToolEnabled,
 		worktreeBaseDir,
 		asyncDir,
 		toolBudget: params.toolBudget,
@@ -1192,6 +1197,7 @@ export function executeAsyncSingle(
 						outputMode,
 						sessionFile,
 						maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, agentConfig.maxSubagentDepth),
+						waitToolEnabled: params.waitToolEnabled,
 						effectiveAcceptance: resolvedAcceptance,
 						...(resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}),
 					},

--- a/src/runs/background/auto-drain.ts
+++ b/src/runs/background/auto-drain.ts
@@ -1,0 +1,67 @@
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { snapshotBackgroundWork } from "../../api/background-work.ts";
+import { ASYNC_DIR, RESULTS_DIR, type Details, type SubagentState } from "../../shared/types.ts";
+import { listAsyncRuns } from "./async-status.ts";
+import { waitForSubagents, type SubagentWaitDeps, type SubagentWaitParams, type WaitEventBus } from "./subagent-wait.ts";
+
+export const DEFAULT_AUTO_DRAIN_TIMEOUT_MS = 30 * 60 * 1000;
+
+export interface AutoDrainDeps {
+	state: SubagentState;
+	events?: WaitEventBus;
+	timeoutMs?: number;
+	now?: () => number;
+	wait?: (
+		params: SubagentWaitParams,
+		signal: AbortSignal | undefined,
+		deps: SubagentWaitDeps,
+	) => Promise<AgentToolResult<Details>>;
+	hasWork?: (sessionId: string, nowMs: number) => boolean;
+}
+
+function resultText(value: AgentToolResult<Details>): string {
+	return value.content.map((part) => part.type === "text" ? part.text : "").join(" ").trim();
+}
+
+function hasOutstandingWork(sessionId: string, nowMs: number): boolean {
+	const asyncRuns = listAsyncRuns(ASYNC_DIR, {
+		states: ["queued", "running"],
+		sessionId,
+		resultsDir: RESULTS_DIR,
+		now: () => nowMs,
+	});
+	return asyncRuns.length > 0 || snapshotBackgroundWork(sessionId, nowMs).items.length > 0;
+}
+
+/** Drain all work owned by the current headless session, including work added while draining. */
+export async function drainOutstandingWork(deps: AutoDrainDeps): Promise<void> {
+	const sessionId = deps.state.currentSessionId;
+	if (!sessionId) throw new Error("Cannot auto-drain background work without an active session identity.");
+	const now = deps.now ?? Date.now;
+	const timeoutMs = deps.timeoutMs ?? DEFAULT_AUTO_DRAIN_TIMEOUT_MS;
+	if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error("Auto-drain timeoutMs must be a positive finite number.");
+	const deadlineAt = now() + timeoutMs;
+	const hasWork = deps.hasWork ?? hasOutstandingWork;
+	const wait = deps.wait ?? waitForSubagents;
+
+	while (hasWork(sessionId, now())) {
+		const remainingMs = deadlineAt - now();
+		if (remainingMs <= 0) {
+			throw new Error(`Auto-drain timed out after ${timeoutMs}ms with background work still active in session '${sessionId}'.`);
+		}
+		const waitResult = await wait(
+			{ all: true, timeoutMs: remainingMs },
+			undefined,
+			{
+				state: deps.state,
+				events: deps.events,
+				now,
+				stopOnAttention: false,
+				failOnFailedRuns: true,
+			},
+		);
+		if (waitResult.isError) {
+			throw new Error(`Auto-drain failed for session '${sessionId}': ${resultText(waitResult) || "subagent_wait returned an error without details"}.`);
+		}
+	}
+}

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1149,6 +1149,7 @@ async function runSingleStep(
 			structuredOutput: effectiveStructuredOutput,
 			toolBudget: step.toolBudget,
 			childWatchdog,
+			waitToolEnabled: step.waitToolEnabled,
 		});
 		const run = await runPiStreaming(
 			args,

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -39,6 +39,12 @@
  */
 
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import {
+	listBackgroundWorkWakeChannels,
+	snapshotBackgroundWork,
+	type BackgroundWorkSnapshot,
+	type RegisteredBackgroundWorkItem,
+} from "../../api/background-work.ts";
 import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 import {
 	ASYNC_DIR,
@@ -51,9 +57,9 @@ import {
 	type Details,
 	type ForegroundResumeRun,
 	type SubagentState,
-	type WaitToolConfig,
 } from "../../shared/types.ts";
 import { formatDuration } from "../../shared/formatters.ts";
+export { WAIT_TOOL_ENABLED_ENV, resolveWaitToolConfig, type ResolvedWaitToolConfig } from "./wait-config.ts";
 
 /** States that mean a run is still in flight (not yet resolved). */
 const ACTIVE_STATES: ReadonlyArray<AsyncRunSummary["state"]> = ["queued", "running"];
@@ -61,41 +67,6 @@ const ACTIVE_STATES: ReadonlyArray<AsyncRunSummary["state"]> = ["queued", "runni
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const MIN_POLL_INTERVAL_MS = 250;
 const DEFAULT_POLL_INTERVAL_MS = 1000;
-
-export const WAIT_TOOL_ENABLED_ENV = "PI_SUBAGENT_WAIT_TOOL_ENABLED";
-
-export interface ResolvedWaitToolConfig {
-	enabled: boolean;
-}
-
-const WAIT_TOOL_TRUE_VALUES = new Set(["1", "true", "yes", "on", "enabled"]);
-const WAIT_TOOL_FALSE_VALUES = new Set(["0", "false", "no", "off", "disabled"]);
-
-function parseWaitToolEnabledEnv(value: string | undefined): boolean | undefined {
-	if (value === undefined) return undefined;
-	const normalized = value.trim().toLowerCase();
-	if (WAIT_TOOL_TRUE_VALUES.has(normalized)) return true;
-	if (WAIT_TOOL_FALSE_VALUES.has(normalized)) return false;
-	throw new Error(`${WAIT_TOOL_ENABLED_ENV} must be one of true/false, 1/0, yes/no, on/off, or enabled/disabled.`);
-}
-
-function configWaitToolEnabled(config: unknown): boolean | undefined {
-	if (config === undefined) return undefined;
-	if (typeof config === "boolean") return config;
-	if (!config || typeof config !== "object" || Array.isArray(config)) {
-		throw new Error("config.waitTool must be a boolean or an object with optional enabled boolean.");
-	}
-	const enabled = (config as { enabled?: unknown }).enabled;
-	if (enabled === undefined) return undefined;
-	if (typeof enabled !== "boolean") throw new Error("config.waitTool.enabled must be a boolean.");
-	return enabled;
-}
-
-export function resolveWaitToolConfig(config?: WaitToolConfig, env: Record<string, string | undefined> = process.env): ResolvedWaitToolConfig {
-	return {
-		enabled: parseWaitToolEnabledEnv(env[WAIT_TOOL_ENABLED_ENV]) ?? configWaitToolEnabled(config) ?? true,
-	};
-}
 
 export interface SubagentWaitParams {
 	/** Optional run id/prefix to wait for. When omitted, waits across every active run in this session. */
@@ -127,6 +98,15 @@ export interface SubagentWaitDeps {
 	enabled?: boolean;
 	/** Injectable sleep for tests. */
 	sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+	/** Internal auto-drain mode waits through needs-attention states. */
+	stopOnAttention?: boolean;
+	/** Internal auto-drain mode surfaces failed terminal subagent runs as errors. */
+	failOnFailedRuns?: boolean;
+	/** Injectable provider protocol surfaces for deterministic tests. */
+	backgroundWork?: {
+		snapshot(sessionId: string, nowMs: number): BackgroundWorkSnapshot;
+		wakeChannels(): readonly string[];
+	};
 	/**
 	 * Optional event bus (pi.events). When provided, wait wakes immediately on a
 	 * subagent completion/control event instead of waiting out the poll interval;
@@ -172,7 +152,8 @@ function waitForWake(ms: number, signal: AbortSignal | undefined, deps: Subagent
 	const sleep = deps.sleep ?? defaultSleep;
 	const events = deps.events;
 	if (!events) return sleep(ms, signal);
-	return new Promise((resolve) => {
+	const providerChannels = deps.backgroundWork?.wakeChannels() ?? listBackgroundWorkWakeChannels();
+	return new Promise((resolve, reject) => {
 		let settled = false;
 		const unsubs: Array<() => void> = [];
 		const wakeController = new AbortController();
@@ -191,8 +172,17 @@ function waitForWake(ms: number, signal: AbortSignal | undefined, deps: Subagent
 			return;
 		}
 		signal?.addEventListener("abort", done, { once: true });
-		for (const channel of WAKE_CHANNELS) {
-			try { unsubs.push(events.on(channel, done)); } catch { /* ignore bad channel */ }
+		try {
+			for (const channel of [...new Set([...WAKE_CHANNELS, ...providerChannels])]) {
+				unsubs.push(events.on(channel, done));
+			}
+		} catch (error) {
+			signal?.removeEventListener("abort", done);
+			for (const unsubscribe of unsubs) {
+				try { unsubscribe(); } catch { /* best effort cleanup */ }
+			}
+			reject(error);
+			return;
 		}
 		// Poll-interval fallback so we still reconcile even if no event arrives.
 		// The local signal cancels that fallback timer when an event wakes us first.
@@ -229,6 +219,16 @@ function needsAttention(run: AsyncRunSummary): boolean {
 	return run.activityState === "needs_attention";
 }
 
+function backgroundWorkIdentity(item: RegisteredBackgroundWorkItem): string {
+	return `${item.provider}\0${item.sessionId}\0${item.id}`;
+}
+
+function backgroundWorkForSession(deps: SubagentWaitDeps, nowMs: number): BackgroundWorkSnapshot {
+	const sessionId = deps.state.currentSessionId;
+	if (!sessionId) throw new Error("subagent_wait requires an active session identity to scope background work safely.");
+	return deps.backgroundWork?.snapshot(sessionId, nowMs) ?? snapshotBackgroundWork(sessionId, nowMs);
+}
+
 /** Queued/running runs from this session, including runs that need attention. */
 function activeRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps): AsyncRunSummary[] {
 	const asyncDirRoot = deps.asyncDirRoot ?? ASYNC_DIR;
@@ -261,8 +261,8 @@ function allRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps): 
 	return params.id ? runs.filter((run) => matchesId(run, params.id!)) : runs;
 }
 
-function summarizeTerminalRuns(runs: AsyncRunSummary[]): string {
-	if (runs.length === 0) return "";
+function summarizeTerminalRuns(runs: AsyncRunSummary[], providerFinishedCount = 0): string {
+	if (runs.length === 0 && providerFinishedCount === 0) return "";
 	const counts = { complete: 0, failed: 0, paused: 0 } as Record<string, number>;
 	for (const run of runs) {
 		if (run.state in counts) counts[run.state] += 1;
@@ -271,6 +271,7 @@ function summarizeTerminalRuns(runs: AsyncRunSummary[]): string {
 	if (counts.complete) parts.push(`${counts.complete} complete`);
 	if (counts.failed) parts.push(`${counts.failed} failed`);
 	if (counts.paused) parts.push(`${counts.paused} paused`);
+	if (providerFinishedCount > 0) parts.push(`${providerFinishedCount} provider item(s) finished`);
 	return parts.join(", ");
 }
 
@@ -331,23 +332,25 @@ export async function waitForSubagents(
 	deps: SubagentWaitDeps,
 ): Promise<AgentToolResult<Details>> {
 	if (deps.enabled === false) {
-		return result("subagent_wait is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED; returning immediately without blocking background subagent runs. Active runs keep going, and you can inspect them with subagent({ action: \"status\" }) or wait for completion notifications.");
+		return result("subagent_wait is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED; returning immediately without blocking background work. Active work keeps going, and you can inspect subagents with subagent({ action: \"status\" }) or rely on completion notifications.");
 	}
+	if (!deps.state.currentSessionId) {
+		return result("subagent_wait requires an active session identity to scope background work safely.", true);
+	}
+
 	const now = deps.now ?? Date.now;
 	const pollIntervalMs = Math.max(MIN_POLL_INTERVAL_MS, deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
 	const timeoutMs = params.timeoutMs !== undefined && params.timeoutMs > 0 ? params.timeoutMs : DEFAULT_TIMEOUT_MS;
 	const startedAt = now();
-
-	// A single named run always means "wait until that one is done", regardless
-	// of `all`. Otherwise `all` decides: true → every run terminal; false → the
-	// first run to finish.
 	const waitForAll = params.id ? true : params.all === true;
 
 	let active: AsyncRunSummary[];
 	let foreground: ForegroundResumeRun[];
+	let providerSnapshot: BackgroundWorkSnapshot;
 	try {
 		active = activeRunsForSession(params, deps);
 		foreground = activeDetachedForegroundRuns(params, deps);
+		providerSnapshot = params.id ? { providers: [], items: [] } : backgroundWorkForSession(deps, startedAt);
 	} catch (error) {
 		return result(error instanceof Error ? error.message : String(error), true);
 	}
@@ -369,102 +372,113 @@ export async function waitForSubagents(
 		active = selected?.kind === "async" ? [selected.run] : [];
 	}
 
-	if (active.length === 0) {
-		const finished = params.id
+	let providerActive = providerSnapshot.items;
+	if (active.length === 0 && providerActive.length === 0) {
+		return result(params.id
 			? `No active run matched "${params.id}". Nothing to wait for.`
-			: "No active async runs in this session. Nothing to wait for.";
-		return result(finished);
+			: "No active async runs or registered provider work in this session. Nothing to wait for.");
 	}
 	const waitParams = params.id ? { ...params, id: active[0]!.id } : params;
-
-	// The set of runs in flight when the wait began. In first-completion mode we
-	// return as soon as any of THESE leaves the active set — a run spawned by a
-	// concurrent turn shouldn't satisfy this wait.
-	const initialIds = new Set(active.map((run) => run.id));
-	const initialCount = initialIds.size;
-	let pending = active.filter((run) => !needsAttention(run));
-
-	const done = (active: AsyncRunSummary[], attention: AsyncRunSummary[]): boolean => {
-		// A run needing attention always breaks the wait, in either mode: the
-		// caller has to act on it (nudge/resume/interrupt) and blocking longer
-		// helps nothing.
-		if (attention.length > 0) return true;
-		if (waitForAll) return active.every((run) => !initialIds.has(run.id));
-		// First-completion: satisfied once any initially-pending run is gone.
-		const stillActiveInitial = active.filter((run) => initialIds.has(run.id));
-		return stillActiveInitial.length < initialCount;
-	};
-
+	const initialAsyncIds = new Set(active.map((run) => run.id));
+	const initialProviderIds = new Set(providerActive.map(backgroundWorkIdentity));
+	const initialProviderNames = new Set(providerActive.map((item) => item.provider));
+	const initialCount = initialAsyncIds.size + initialProviderIds.size;
+	const stopOnAttention = deps.stopOnAttention !== false;
 	let attention = active.filter((run) => needsAttention(run));
 
-	while (!done(pending, attention)) {
+	const isDone = (): boolean => {
+		if (stopOnAttention && attention.some((run) => initialAsyncIds.has(run.id))) return true;
+		const activeAsyncIds = new Set(active.map((run) => run.id));
+		const activeProviderIds = new Set(providerActive.map(backgroundWorkIdentity));
+		if (waitForAll) {
+			return [...initialAsyncIds].every((id) => !activeAsyncIds.has(id))
+				&& [...initialProviderIds].every((id) => !activeProviderIds.has(id));
+		}
+		return [...initialAsyncIds].some((id) => !activeAsyncIds.has(id))
+			|| [...initialProviderIds].some((id) => !activeProviderIds.has(id));
+	};
+
+	while (!isDone()) {
+		const activeInitialRuns = active.filter((run) => initialAsyncIds.has(run.id));
+		const activeInitialProviderItems = providerActive.filter((item) => initialProviderIds.has(backgroundWorkIdentity(item)));
+		const stillActive = [
+			...activeInitialRuns.map((run) => `${run.id} (${run.state})`),
+			...activeInitialProviderItems.map((item) => `${item.provider}/${item.id}`),
+		].join(", ");
 		if (signal?.aborted) {
-			const stillActive = pending.map((run) => `${run.id} (${run.state})`).join(", ");
 			return result(`Wait aborted after ${formatDuration(now() - startedAt)}. Still active: ${stillActive}.`, true);
 		}
 		if (now() - startedAt >= timeoutMs) {
-			const stillActive = pending.map((run) => `${run.id} (${run.state})`).join(", ");
 			return result(
-				`Wait timed out after ${formatDuration(timeoutMs)} with ${pending.length} run(s) still active: ${stillActive}. `
-					+ `The runs are detached and keep going; call subagent_wait again or inspect with subagent({ action: "status" }).`,
+				`Wait timed out after ${formatDuration(timeoutMs)} with ${activeInitialRuns.length} async run(s) and ${activeInitialProviderItems.length} provider item(s) still active: ${stillActive}. The work keeps going; call subagent_wait again or inspect subagent status.`,
 				true,
 			);
 		}
-		await waitForWake(pollIntervalMs, signal, deps);
 		try {
+			await waitForWake(pollIntervalMs, signal, deps);
 			active = activeRunsForSession(waitParams, deps);
-			pending = active.filter((run) => !needsAttention(run));
-			attention = attentionRunsForSession(waitParams, deps, initialIds);
+			attention = attentionRunsForSession(waitParams, deps, initialAsyncIds);
+			providerSnapshot = params.id ? providerSnapshot : backgroundWorkForSession(deps, now());
+			for (const provider of initialProviderNames) {
+				if (!providerSnapshot.providers.includes(provider)) {
+					return result(`Background-work provider '${provider}' disappeared while subagent_wait was tracking its active work; completion cannot be confirmed.`, true);
+				}
+			}
+			providerActive = providerSnapshot.items;
 		} catch (error) {
 			return result(error instanceof Error ? error.message : String(error), true);
 		}
 	}
 
-	// Report how the finished run(s) came out. In first-completion mode, name the
-	// runs from the initial set that are now terminal.
-	let terminalSummary = "";
-	let finishedCount = 0;
+	let terminalSummary: string;
+	let finishedAsyncCount: number;
+	let failedAsyncCount: number;
+	const activeProviderIds = new Set(providerActive.map(backgroundWorkIdentity));
+	const providerFinishedCount = [...initialProviderIds].filter((id) => !activeProviderIds.has(id)).length;
 	try {
 		const allNow = allRunsForSession(waitParams, deps);
-		const terminal = allNow.filter((run) => !ACTIVE_STATES.includes(run.state) && initialIds.has(run.id));
-		finishedCount = terminal.length;
-		terminalSummary = summarizeTerminalRuns(terminal);
-	} catch {
-		// Summary is best-effort; the important part is that the wait resolved.
+		const terminal = allNow.filter((run) => !ACTIVE_STATES.includes(run.state) && initialAsyncIds.has(run.id));
+		finishedAsyncCount = terminal.length;
+		failedAsyncCount = terminal.filter((run) => run.state === "failed").length;
+		terminalSummary = summarizeTerminalRuns(terminal, providerFinishedCount);
+	} catch (error) {
+		return result(error instanceof Error ? error.message : String(error), true);
 	}
 
-	const attentionNote = attention.length > 0
-		? ` ${attention.length} run(s) need attention: ${attention.map((r) => r.id).join(", ")} — inspect with subagent({ action: "status" }) then nudge/resume/interrupt.`
+	const relevantAttention = attention.filter((run) => initialAsyncIds.has(run.id));
+	const attentionNote = relevantAttention.length > 0
+		? ` ${relevantAttention.length} run(s) need attention: ${relevantAttention.map((run) => run.id).join(", ")} — inspect with subagent({ action: "status" }) then nudge/resume/interrupt.`
 		: "";
-
-	const stillRunning = pending.filter((run) => initialIds.has(run.id)).length;
+	const stillRunning = active.filter((run) => initialAsyncIds.has(run.id)).length
+		+ providerActive.filter((item) => initialProviderIds.has(backgroundWorkIdentity(item))).length;
 	const elapsed = formatDuration(now() - startedAt);
 	const outcome = terminalSummary ? ` Outcome: ${terminalSummary}.` : "";
 
 	if (waitForAll) {
-		const scope = params.id ? `run "${params.id}"` : `${initialCount} async run(s)`;
-		const status = attention.length > 0 ? "attention required" : "done";
-		const notificationText = attention.length > 0
-			? "Relevant completion/control events have been observed; inspect status if the notification is not visible yet."
-			: "Completion events have been observed; inspect status if the notification is not visible yet.";
+		const scope = params.id
+			? `run "${params.id}"`
+			: initialProviderIds.size === 0
+				? `${initialAsyncIds.size} async run(s)`
+				: `${initialAsyncIds.size} async run(s) and ${initialProviderIds.size} provider item(s)`;
+		const status = relevantAttention.length > 0 ? "attention required" : "done";
 		return result(
-			`Waited ${elapsed} for ${scope}; ${status}.${outcome}${attentionNote} ${notificationText}`,
+			`Waited ${elapsed} for ${scope}; ${status}.${outcome}${attentionNote} Completion/control events have been observed; inspect status if a notification is not visible yet.`,
+			deps.failOnFailedRuns === true && failedAsyncCount > 0,
 		);
 	}
 
-	// First-completion mode.
+	const finishedCount = finishedAsyncCount + providerFinishedCount;
+	const subject = initialProviderIds.size === 0 ? "run(s)" : "item(s)";
 	const remainder = stillRunning > 0
-		? ` ${stillRunning} run(s) still in flight — call subagent_wait again to catch the next one.`
-		: attention.length > 0
-			? " No other runs are waitable until attention is handled."
-			: " No runs remain in flight.";
-	const progress = attention.length > 0 && finishedCount === 0
-		? `${attention.length} of ${initialCount} run(s) need attention`
-		: `${finishedCount} of ${initialCount} run(s) finished`;
-	const notificationText = finishedCount > 0
-		? " Completion events for the finished run(s) have been observed; inspect status if the notification is not visible yet."
-		: " Relevant control events have been observed; inspect status if the notification is not visible yet.";
+		? ` ${stillRunning} ${subject} still in flight — call subagent_wait again to catch the next one.`
+		: relevantAttention.length > 0
+			? " No other work is waitable until attention is handled."
+			: initialProviderIds.size === 0 ? " No runs remain in flight." : " No work remains in flight.";
+	const progress = relevantAttention.length > 0 && finishedCount === 0
+		? `${relevantAttention.length} of ${initialCount} ${subject} need attention`
+		: `${finishedCount} of ${initialCount} ${subject} finished`;
 	return result(
-		`Waited ${elapsed}; ${progress}.${outcome}${attentionNote}${remainder}${notificationText}`,
+		`Waited ${elapsed}; ${progress}.${outcome}${attentionNote}${remainder} Relevant completion/control events have been observed; inspect status if a notification is not visible yet.`,
+		deps.failOnFailedRuns === true && failedAsyncCount > 0,
 	);
 }

--- a/src/runs/background/wait-config.ts
+++ b/src/runs/background/wait-config.ts
@@ -1,0 +1,36 @@
+import type { WaitToolConfig } from "../../shared/types.ts";
+
+export const WAIT_TOOL_ENABLED_ENV = "PI_SUBAGENT_WAIT_TOOL_ENABLED";
+
+export interface ResolvedWaitToolConfig {
+	enabled: boolean;
+}
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on", "enabled"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off", "disabled"]);
+
+function environmentValue(value: string | undefined): boolean | undefined {
+	if (value === undefined) return undefined;
+	const normalized = value.trim().toLowerCase();
+	if (TRUE_VALUES.has(normalized)) return true;
+	if (FALSE_VALUES.has(normalized)) return false;
+	throw new Error(`${WAIT_TOOL_ENABLED_ENV} must be one of true/false, 1/0, yes/no, on/off, or enabled/disabled.`);
+}
+
+function configuredValue(config: unknown): boolean | undefined {
+	if (config === undefined) return undefined;
+	if (typeof config === "boolean") return config;
+	if (!config || typeof config !== "object" || Array.isArray(config)) {
+		throw new Error("config.waitTool must be a boolean or an object with optional enabled boolean.");
+	}
+	const enabled = (config as { enabled?: unknown }).enabled;
+	if (enabled === undefined) return undefined;
+	if (typeof enabled !== "boolean") throw new Error("config.waitTool.enabled must be a boolean.");
+	return enabled;
+}
+
+export function resolveWaitToolConfig(config?: WaitToolConfig, env: Record<string, string | undefined> = process.env): ResolvedWaitToolConfig {
+	return {
+		enabled: environmentValue(env[WAIT_TOOL_ENABLED_ENV]) ?? configuredValue(config) ?? true,
+	};
+}

--- a/src/runs/background/wait-tool.ts
+++ b/src/runs/background/wait-tool.ts
@@ -1,0 +1,26 @@
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { SubagentWaitParams } from "../../extension/schemas.ts";
+import type { Details, SubagentState } from "../../shared/types.ts";
+import { resolveWaitToolConfig, waitForSubagents } from "./subagent-wait.ts";
+
+export function registerWaitTool(pi: ExtensionAPI, state: SubagentState, enabled = resolveWaitToolConfig().enabled): void {
+	const tool: ToolDefinition<typeof SubagentWaitParams, Details> = {
+		name: "subagent_wait",
+		label: "Subagent Wait",
+		description: `Block until background work owned by this session changes, then return.
+
+In an interactive chat, do not call this merely to wait: return control to the user and let Pi wake the session on completion. Call it when the current request must run to completion in this turn, when a skill cannot return before its work finishes, or in a non-interactive run where there is no next turn.
+
+• { } — return when the first initially active async run or registered provider item finishes, or when a subagent needs attention.
+• { all: true } — wait for every async run and provider item that was active when the call began.
+• { id: "..." } — wait for one async or remembered detached foreground subagent run (id or prefix).
+• { timeoutMs: 600000 } — stop waiting after N ms; active work keeps running.
+
+Provider jobs are session-scoped and identified exactly, so replacing one job with another cannot hide a completion. Provider extensions must be explicitly loaded in this process. In a child agent, keep \`subagent_wait\` in the child tool allowlist and load each provider through the agent's extensions or subagentOnlyExtensions; this tool never loads providers or grants tools itself.${enabled ? "" : "\n\nConfigured behavior: subagent_wait is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED and returns immediately without blocking."}`,
+		parameters: SubagentWaitParams,
+		execute(_id, params, signal) {
+			return waitForSubagents(params, signal, { state, events: pi.events, enabled });
+		},
+	};
+	pi.registerTool(tool);
+}

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -237,6 +237,7 @@ async function runSingleAttempt(
 		structuredOutput: options.structuredOutput,
 		toolBudget: options.toolBudget,
 		childWatchdog,
+		waitToolEnabled: options.waitToolEnabled,
 	});
 
 	const result: SingleResult = {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -181,6 +181,7 @@ interface ExecutorDeps {
 	state: SubagentState;
 	config: ExtensionConfig;
 	asyncByDefault: boolean;
+	waitToolEnabled?: boolean;
 	handleScheduledRunAction?: (params: SubagentParamsLike, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>;
 	watchdog?: MainWatchdogRuntime;
 	tempArtifactsDir: string;
@@ -805,6 +806,7 @@ function appendStepToAsyncChain(input: {
 		chainSkills,
 		dynamicFanoutMaxItems: input.deps.config.chain?.dynamicFanout?.maxItems,
 		maxSubagentDepth: resolveCurrentMaxSubagentDepth(input.deps.config.maxSubagentDepth),
+		waitToolEnabled: input.deps.waitToolEnabled,
 		asyncDir: resolved.location.asyncDir,
 		validateOutputBindings: false,
 	});
@@ -1214,6 +1216,7 @@ async function resumeAsyncRun(input: {
 			chainSkills: normalized === false ? [] : (normalized ?? []),
 			dynamicFanoutMaxItems: input.deps.config.chain?.dynamicFanout?.maxItems,
 			maxSubagentDepth: resolveCurrentMaxSubagentDepth(input.deps.config.maxSubagentDepth),
+			waitToolEnabled: input.deps.waitToolEnabled,
 			worktreeSetupHook: input.deps.config.worktreeSetupHook,
 			worktreeSetupHookTimeoutMs: input.deps.config.worktreeSetupHookTimeoutMs,
 			worktreeBaseDir: input.deps.config.worktreeBaseDir,
@@ -1271,6 +1274,7 @@ async function resumeAsyncRun(input: {
 		thinkingOverride: input.params.model ? undefined : recoveryDescriptor?.thinking ?? target.thinking,
 		outputBaseDir: resolveSingleRunOutputBaseDir(input.deps, artifactsDir, runId),
 		maxSubagentDepth: recoveryDescriptor?.maxSubagentDepth ?? resolveCurrentMaxSubagentDepth(input.deps.config.maxSubagentDepth),
+		waitToolEnabled: input.deps.waitToolEnabled,
 		worktreeSetupHook: input.deps.config.worktreeSetupHook,
 		worktreeSetupHookTimeoutMs: input.deps.config.worktreeSetupHookTimeoutMs,
 		worktreeBaseDir: input.deps.config.worktreeBaseDir,
@@ -1988,6 +1992,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			sessionFilesByFlatIndex: params.tasks.map((task, index) => sessionFileForTask(task.agent, index, task.model)),
 			thinkingOverridesByFlatIndex: params.tasks.map((task, index) => thinkingOverrideForTask(task.agent, index, task.model)),
 			maxSubagentDepth: currentMaxSubagentDepth,
+			waitToolEnabled: deps.waitToolEnabled,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 			worktreeBaseDir: deps.config.worktreeBaseDir,
@@ -2026,6 +2031,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			thinkingOverridesByFlatIndex: collectChainThinkingOverrides(chain, thinkingOverrideForTask, deps.config.chain?.dynamicFanout?.maxItems),
 			dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
 			maxSubagentDepth: currentMaxSubagentDepth,
+			waitToolEnabled: deps.waitToolEnabled,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 			worktreeBaseDir: deps.config.worktreeBaseDir,
@@ -2078,6 +2084,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			modelOverride,
 			thinkingOverride: thinkingOverrideForTask(params.agent!, 0, modelOverride),
 			maxSubagentDepth,
+			waitToolEnabled: deps.waitToolEnabled,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 			worktreeBaseDir: deps.config.worktreeBaseDir,
@@ -2204,6 +2211,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			thinkingOverridesByFlatIndex: collectChainThinkingOverrides(asyncChain, thinkingOverrideForTask, deps.config.chain?.dynamicFanout?.maxItems),
 			dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
 			maxSubagentDepth: currentMaxSubagentDepth,
+			waitToolEnabled: deps.waitToolEnabled,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 			worktreeBaseDir: deps.config.worktreeBaseDir,
@@ -2270,6 +2278,7 @@ interface ForegroundParallelRunInput {
 	paramsCwd: string;
 	progressDir: string;
 	maxSubagentDepths: number[];
+	waitToolEnabled?: boolean;
 	availableModels: ModelInfo[];
 	modelScope?: ModelScopeConfig;
 	modelOverrides: (string | undefined)[];
@@ -2455,6 +2464,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			outputPath,
 			outputMode: behavior?.outputMode,
 			maxSubagentDepth: input.maxSubagentDepths[index],
+			waitToolEnabled: input.waitToolEnabled,
 			controlConfig: input.controlConfig,
 			onControlEvent: input.onControlEvent,
 			onDetachedExit: (result) => updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents }),
@@ -2695,6 +2705,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				sessionFilesByFlatIndex: tasks.map((task, index) => sessionFileForTask(task.agent, index, modelOverrides[index])),
 				thinkingOverridesByFlatIndex: tasks.map((task, index) => thinkingOverrideForTask(task.agent, index, modelOverrides[index])),
 				maxSubagentDepth: currentMaxSubagentDepth,
+				waitToolEnabled: deps.waitToolEnabled,
 				worktreeSetupHook: deps.config.worktreeSetupHook,
 				worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 				worktreeBaseDir: deps.config.worktreeBaseDir,
@@ -2785,6 +2796,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			concurrencyLimit: parallelConcurrency,
 			globalSemaphore: new Semaphore(deps.config.globalConcurrencyLimit ?? DEFAULT_GLOBAL_CONCURRENCY_LIMIT),
 			maxSubagentDepths,
+			waitToolEnabled: deps.waitToolEnabled,
 			liveResults,
 			liveProgress,
 			onUpdate,
@@ -3001,6 +3013,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				modelOverride,
 				thinkingOverride: thinkingOverrideForTask(params.agent!, 0, modelOverride),
 				maxSubagentDepth,
+				waitToolEnabled: deps.waitToolEnabled,
 				worktreeSetupHook: deps.config.worktreeSetupHook,
 				worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 				worktreeBaseDir: deps.config.worktreeBaseDir,
@@ -3085,6 +3098,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		outputPath,
 		outputMode: effectiveOutputMode,
 		maxSubagentDepth,
+		waitToolEnabled: deps.waitToolEnabled,
 		onUpdate: forwardSingleUpdate,
 		controlConfig,
 		onControlEvent,
@@ -3824,6 +3838,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 	): Promise<AgentToolResult<Details>> => {
 		const requestParams = omitExecutionModeActionAlias(params);
 		if (requestParams.action) return execute(id, requestParams, signal, onUpdate, ctx);
+		const { depth } = checkSubagentDepth(deps.config.maxSubagentDepth);
+		const dispatchParams = applyForceTopLevelAsyncOverride(requestParams, depth, deps.config.forceTopLevelAsync === true);
+		const runsForeground = dispatchParams.clarify === true || (dispatchParams.async ?? deps.asyncByDefault) !== true;
+		if (!runsForeground) return execute(id, requestParams, signal, onUpdate, ctx);
 		if (deps.state.subagentInProgress === true) return duplicateSubagentCallResult(requestParams);
 		deps.state.subagentInProgress = true;
 		try {

--- a/src/runs/shared/dynamic-fanout.ts
+++ b/src/runs/shared/dynamic-fanout.ts
@@ -49,7 +49,7 @@ const DYNAMIC_EXPAND_FROM_KEYS = new Set(["output", "path"]);
 const DYNAMIC_PARALLEL_KEYS = new Set(["agent", "task", "phase", "label", "outputSchema", "cwd", "output", "outputMode", "reads", "progress", "skill", "model", "toolBudget", "acceptance"]);
 const RUNNER_DYNAMIC_PARALLEL_KEYS = new Set([
 	...DYNAMIC_PARALLEL_KEYS,
-	"outputName", "structured", "inheritProjectContext", "inheritSkills", "skills", "outputPath", "namespaceOutputPath", "maxSubagentDepth",
+	"outputName", "structured", "inheritProjectContext", "inheritSkills", "skills", "outputPath", "namespaceOutputPath", "maxSubagentDepth", "waitToolEnabled",
 	"structuredOutput", "structuredOutputSchema", "tools", "extensions", "subagentOnlyExtensions", "mcpDirectTools", "completionGuard", "systemPrompt",
 	"systemPromptMode", "thinking", "modelCandidates", "sessionFile", "effectiveAcceptance", "acceptanceInput", "acceptanceRole", "parentSessionId",
 ]);

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -33,6 +33,7 @@ export interface RunnerSubagentStep {
 	outputMode?: "inline" | "file-only";
 	sessionFile?: string;
 	maxSubagentDepth?: number;
+	waitToolEnabled?: boolean;
 	structuredOutput?: {
 		schema: import("../../shared/types.ts").JsonSchemaObject;
 		schemaPath: string;

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -10,6 +10,7 @@ import { THINKING_LEVELS } from "../../shared/model-info.ts";
 import { TOOL_BUDGET_ENV, encodeToolBudgetEnv } from "./tool-budget.ts";
 import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, REQUIRED_CHILD_TOOLS_ENV } from "./tool-availability.ts";
 import { CHILD_WATCHDOG_CONFIG_ENV, encodeChildWatchdogConfig, type ChildWatchdogConfig } from "../../watchdog/child-status.ts";
+import { WAIT_TOOL_ENABLED_ENV } from "../background/wait-config.ts";
 
 const TASK_ARG_LIMIT = 8000;
 const PROMPT_RUNTIME_EXTENSION_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-prompt-runtime.ts");
@@ -78,6 +79,7 @@ interface BuildPiArgsInput {
 	};
 	toolBudget?: ResolvedToolBudget;
 	childWatchdog?: ChildWatchdogConfig;
+	waitToolEnabled?: boolean;
 }
 
 interface BuildPiArgsResult {
@@ -197,6 +199,9 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	}
 	env[SUBAGENT_CHILD_ENV] = "1";
 	env[SUBAGENT_FANOUT_CHILD_ENV] = fanoutAuthorized ? "1" : "0";
+	if (input.waitToolEnabled !== undefined) {
+		env[WAIT_TOOL_ENABLED_ENV] = input.waitToolEnabled ? "true" : "false";
+	}
 	const inheritedNestedRoute = Boolean(process.env[SUBAGENT_PARENT_EVENT_SINK_ENV] && process.env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] && process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV]);
 	const parentRunId = input.parentRunId ?? input.runId ?? (inheritedNestedRoute ? process.env[SUBAGENT_RUN_ID_ENV] : undefined) ?? process.env[SUBAGENT_PARENT_RUN_ID_ENV] ?? "";
 	const parentChildIndex = input.parentChildIndex !== undefined

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -13,10 +13,14 @@ import {
 	type ChildToolDiagnostic,
 } from "./tool-availability.ts";
 import { TOOL_BUDGET_ENV, decodeToolBudgetEnv, shouldBlockToolForBudget, toolBudgetBlockedMessage, toolBudgetSoftNudge } from "./tool-budget.ts";
-import type { JsonSchemaObject, ResolvedToolBudget } from "../../shared/types.ts";
+import type { JsonSchemaObject, ResolvedToolBudget, SubagentState } from "../../shared/types.ts";
+import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { resolveWatchPath } from "../../shared/utils.ts";
 import { registerChildWatchdog } from "../../watchdog/register-child.ts";
 import { SUBAGENT_WATCHDOG_WARNING_TYPE } from "../../watchdog/types.ts";
+import { resolveWaitToolConfig } from "../background/wait-config.ts";
+import { registerWaitTool } from "../background/wait-tool.ts";
+import { drainOutstandingWork } from "../background/auto-drain.ts";
 
 const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
 const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
@@ -327,6 +331,22 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 	registerSteeringInbox(pi);
 	registerToolBudget(pi, decodeToolBudgetEnv(process.env[TOOL_BUDGET_ENV]));
 	registerChildWatchdog(pi);
+	const waitToolEnabled = resolveWaitToolConfig().enabled;
+	const waitState = {
+		baseCwd: "",
+		currentSessionId: null,
+		asyncJobs: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	} as unknown as SubagentState;
+	if (typeof pi.registerTool === "function") registerWaitTool(pi, waitState, waitToolEnabled);
 	let nativeSupervisorClientRegistered = false;
 	let nativeSupervisorFallbackRegistered = false;
 	const registerNativeSupervisorClientOnce = (): void => {
@@ -341,9 +361,15 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		registerNativeSupervisorClient(pi);
 	};
 	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown) => unknown) => void;
-	onRuntimeEvent("session_start", () => {
+	onRuntimeEvent("session_start", (_event: unknown, ctx: unknown) => {
+		const sessionManager = (ctx as { sessionManager?: Parameters<typeof resolveCurrentSessionId>[0] } | undefined)?.sessionManager;
+		waitState.currentSessionId = sessionManager ? resolveCurrentSessionId(sessionManager) : null;
 		registerNativeSupervisorClientOnce();
 		refreshChildToolDiagnostic(pi);
+	});
+	onRuntimeEvent("agent_end", async (_event: unknown, ctx: unknown) => {
+		if ((ctx as { hasUI?: boolean } | undefined)?.hasUI === true) return;
+		await drainOutstandingWork({ state: waitState, events: pi.events });
 	});
 	const structuredOutputPath = process.env[STRUCTURED_OUTPUT_CAPTURE_ENV];
 	const structuredSchemaPath = process.env[STRUCTURED_OUTPUT_SCHEMA_ENV];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1088,6 +1088,8 @@ export interface RunSyncOptions {
 	outputPath?: string;
 	outputMode?: OutputMode;
 	maxSubagentDepth?: number;
+	/** Effective parent wait-tool setting propagated to the child runtime. */
+	waitToolEnabled?: boolean;
 	nestedRoute?: NestedRouteInfo;
 	/** Override the agent's default model (format: "provider/id" or just "id") */
 	modelOverride?: string;

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../support/helpers.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT } from "../../src/shared/types.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
+import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
 import { MainWatchdogRuntime } from "../../src/watchdog/runtime.ts";
 import { MAX_CHILD_PENDING_LINE_BYTES, MAX_CHILD_STDERR_BYTES } from "../../src/runs/shared/child-protocol.ts";
 import {
@@ -415,6 +416,24 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(second.isError, true);
 		assert.match(second.content[0]?.text ?? "", /Issue exactly ONE subagent call per turn/);
 		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("allows concurrent async launches in one turn", async () => {
+		mockPi.onCall({ output: "async one" });
+		mockPi.onCall({ output: "async two" });
+		const executor = makeExecutor([makeAgent("echo"), makeAgent("second")]);
+		const ctx = makeMinimalCtx(tempDir);
+		const [first, second] = await Promise.all([
+			executor.execute("first", { agent: "echo", task: "First", async: true }, new AbortController().signal, undefined, ctx),
+			executor.execute("second", { agent: "second", task: "Second", async: true }, new AbortController().signal, undefined, ctx),
+		]);
+		assert.doesNotMatch(first.content[0]?.text ?? "", /Issue exactly ONE subagent call per turn/);
+		assert.doesNotMatch(second.content[0]?.text ?? "", /Issue exactly ONE subagent call per turn/);
+		const deadlineAt = Date.now() + 30_000;
+		while (mockPi.callCount() < 2 && Date.now() < deadlineAt) {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		assert.equal(mockPi.callCount(), 2, "both detached mock children should start before test cleanup");
 	});
 
 	it("does not impose a cumulative spawn cap by default", async () => {
@@ -1699,6 +1718,18 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			if (prevMaxDepth === undefined) delete process.env.PI_SUBAGENT_MAX_DEPTH;
 			else process.env.PI_SUBAGENT_MAX_DEPTH = prevMaxDepth;
 		}
+	});
+
+	it("passes the effective wait-tool setting through to child execution", async () => {
+		mockPi.onCall({ echoEnv: [WAIT_TOOL_ENABLED_ENV] });
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "wait-tool-env",
+			waitToolEnabled: false,
+		});
+		assert.equal(result.exitCode, 0);
+		assert.deepEqual(JSON.parse(result.finalOutput ?? "{}"), {
+			[WAIT_TOOL_ENABLED_ENV]: "false",
+		});
 	});
 
 	it("passes prompt inheritance env flags through to child execution", async () => {

--- a/test/unit/async-execution.test.ts
+++ b/test/unit/async-execution.test.ts
@@ -47,12 +47,14 @@ describe("async runner execution", () => {
 			ctx,
 			asyncDir: path.join(process.cwd(), ".tmp-async-test"),
 			maxSubagentDepth: 2,
+			waitToolEnabled: false,
 			toolBudget: { hard: 3, block: ["find"] },
 			configToolBudget: { hard: 5, block: ["ls"] },
 		});
 
 		assert.ok("steps" in result, "expected successful step build");
 		assert.deepEqual(result.steps[0]?.toolBudget, { hard: 3, block: ["find"] });
+		assert.equal(result.steps[0]?.waitToolEnabled, false);
 		assert.deepEqual(result.steps[1]?.toolBudget, { hard: 2, block: ["grep"] });
 	});
 

--- a/test/unit/auto-drain.test.ts
+++ b/test/unit/auto-drain.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { drainOutstandingWork } from "../../src/runs/background/auto-drain.ts";
+import type { Details, SubagentState } from "../../src/shared/types.ts";
+
+function state(sessionId: string | null = "session-a"): SubagentState {
+	return { currentSessionId: sessionId } as SubagentState;
+}
+
+function waitResult(text: string, isError = false) {
+	return {
+		content: [{ type: "text" as const, text }],
+		...(isError ? { isError: true } : {}),
+		details: { mode: "management" as const, results: [] } satisfies Details,
+	};
+}
+
+describe("headless background-work auto-drain", () => {
+	it("is a no-op when the exact session has no work", async () => {
+		let waited = false;
+		await drainOutstandingWork({
+			state: state(),
+			hasWork: () => false,
+			wait: async () => { waited = true; return waitResult("unexpected"); },
+		});
+		assert.equal(waited, false);
+	});
+
+	it("loops until work added while draining is also gone", async () => {
+		let checks = 0;
+		const waits: Array<{ all?: boolean; timeoutMs?: number; stopOnAttention?: boolean; failOnFailedRuns?: boolean }> = [];
+		await drainOutstandingWork({
+			state: state(),
+			timeoutMs: 1000,
+			now: () => checks * 10,
+			hasWork: () => checks++ < 2,
+			wait: async (params, _signal, deps) => {
+				waits.push({ ...params, stopOnAttention: deps.stopOnAttention, failOnFailedRuns: deps.failOnFailedRuns });
+				return waitResult("done");
+			},
+		});
+		assert.equal(waits.length, 2);
+		assert.ok(waits.every((entry) => entry.all === true && entry.stopOnAttention === false && entry.failOnFailedRuns === true));
+		assert.ok((waits[1]!.timeoutMs ?? 0) < (waits[0]!.timeoutMs ?? 0), "each wait must share one absolute deadline");
+	});
+
+	it("preserves wait errors instead of treating them as a successful drain", async () => {
+		await assert.rejects(() => drainOutstandingWork({
+			state: state(),
+			hasWork: () => true,
+			wait: async () => waitResult("provider 'patty' snapshot failed", true),
+		}), /Auto-drain failed.*provider 'patty' snapshot failed/);
+	});
+
+	it("propagates work-discovery errors", async () => {
+		await assert.rejects(() => drainOutstandingWork({
+			state: state(),
+			hasWork: () => { throw new Error("provider reconcile failed"); },
+		}), /provider reconcile failed/);
+	});
+
+	it("enforces one absolute timeout across repeated drains", async () => {
+		let clock = 0;
+		await assert.rejects(() => drainOutstandingWork({
+			state: state(),
+			timeoutMs: 100,
+			now: () => clock,
+			hasWork: () => true,
+			wait: async () => {
+				clock = 101;
+				return waitResult("first batch done");
+			},
+		}), /timed out after 100ms.*session 'session-a'/);
+	});
+
+	it("fails without a session identity", async () => {
+		await assert.rejects(() => drainOutstandingWork({ state: state(null) }), /without an active session identity/);
+	});
+});

--- a/test/unit/background-work.test.ts
+++ b/test/unit/background-work.test.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+	BACKGROUND_WORK_REGISTRY_KEY,
+	listBackgroundWorkProviders,
+	listBackgroundWorkWakeChannels,
+	registerBackgroundWorkProvider,
+	snapshotBackgroundWork,
+	type BackgroundWorkSnapshot,
+} from "../../src/api/background-work.ts";
+import { waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+function clearRegistry(): void {
+	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(BACKGROUND_WORK_REGISTRY_KEY)];
+}
+
+afterEach(clearRegistry);
+
+function makeState(sessionId = "session-a"): SubagentState {
+	return {
+		baseCwd: "",
+		currentSessionId: sessionId,
+		asyncJobs: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	} as SubagentState;
+}
+
+function writeStatus(root: string, id: string, state: string, sessionId = "session-a"): void {
+	const dir = path.join(root, id);
+	fs.mkdirSync(dir, { recursive: true });
+	const now = Date.now();
+	fs.writeFileSync(path.join(dir, "status.json"), JSON.stringify({
+		runId: id,
+		mode: "single",
+		state,
+		sessionId,
+		startedAt: now,
+		lastUpdate: now,
+		pid: 999999,
+		steps: [{ agent: "worker", status: state }],
+	}));
+}
+
+function waitDeps(root: string, state: SubagentState, backgroundWork: SubagentWaitDeps["backgroundWork"], sleep: () => Promise<void>): SubagentWaitDeps {
+	return {
+		state,
+		backgroundWork,
+		sleep,
+		pollIntervalMs: 250,
+		asyncDirRoot: path.join(root, "runs"),
+		resultsDir: path.join(root, "results"),
+		kill: () => true,
+	};
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.map((part) => part.text ?? "").join("");
+}
+
+function snapshot(providers: string[], items: BackgroundWorkSnapshot["items"]): BackgroundWorkSnapshot {
+	return { providers, items };
+}
+
+describe("background-work provider protocol", () => {
+	it("replaces registrations safely across reloads and scopes snapshots to one session", () => {
+		let context: { sessionId: string; nowMs: number } | undefined;
+		const disposeOld = registerBackgroundWorkProvider({
+			name: "patty",
+			listActiveWork: () => [{ id: "old", sessionId: "session-a" }],
+		});
+		const replacement = {
+			name: "patty",
+			wakeChannels: ["patty:finished"],
+			reconcile: (value: { sessionId: string; nowMs: number }) => { context = value; },
+			listActiveWork: () => [
+				{ id: "mine", sessionId: "session-a" },
+				{ id: "theirs", sessionId: "session-b" },
+			],
+		};
+		const disposeReplacement = registerBackgroundWorkProvider(replacement);
+		disposeOld();
+
+		assert.deepEqual(listBackgroundWorkProviders(), [replacement]);
+		assert.deepEqual(listBackgroundWorkWakeChannels(), ["patty:finished"]);
+		assert.deepEqual(snapshotBackgroundWork("session-a", 42), {
+			providers: ["patty"],
+			items: [{ provider: "patty", id: "mine", sessionId: "session-a" }],
+		});
+		assert.deepEqual(context, { sessionId: "session-a", nowMs: 42 });
+
+		disposeReplacement();
+		assert.deepEqual(listBackgroundWorkProviders(), []);
+	});
+
+	it("validates provider metadata and work items strictly", () => {
+		assert.throws(() => registerBackgroundWorkProvider({ name: " patty", listActiveWork: () => [] }), /leading or trailing/);
+		assert.throws(() => registerBackgroundWorkProvider({ name: "patty", listActiveWork: () => [], wakeChannels: ["done", "done"] }), /duplicates/);
+
+		registerBackgroundWorkProvider({
+			name: "patty",
+			listActiveWork: () => [{ id: "job", sessionId: "session-a", extra: true } as never],
+		});
+		assert.throws(() => snapshotBackgroundWork("session-a"), /unknown fields: extra/);
+		clearRegistry();
+
+		registerBackgroundWorkProvider({
+			name: "patty",
+			listActiveWork: () => [
+				{ id: "job", sessionId: "session-a" },
+				{ id: "job", sessionId: "session-a" },
+			],
+		});
+		assert.throws(() => snapshotBackgroundWork("session-a"), /duplicate item 'job'/);
+	});
+
+	it("preserves list and reconcile errors with provider context", () => {
+		registerBackgroundWorkProvider({
+			name: "broken-reconcile",
+			reconcile: () => { throw new Error("pid probe failed"); },
+			listActiveWork: () => [],
+		});
+		assert.throws(() => snapshotBackgroundWork("session-a"), /broken-reconcile.*pid probe failed/);
+		clearRegistry();
+
+		registerBackgroundWorkProvider({
+			name: "broken-list",
+			listActiveWork: () => { throw new Error("registry unavailable"); },
+		});
+		assert.throws(() => snapshotBackgroundWork("session-a"), /broken-list.*registry unavailable/);
+	});
+
+	it("discovers wake channels without reconciling or listing work", () => {
+		let called = false;
+		registerBackgroundWorkProvider({
+			name: "patty",
+			wakeChannels: ["patty:finished"],
+			reconcile: () => { called = true; },
+			listActiveWork: () => { called = true; return []; },
+		});
+		assert.deepEqual(listBackgroundWorkWakeChannels(), ["patty:finished"]);
+		assert.equal(called, false);
+	});
+});
+
+describe("subagent_wait with background-work providers", () => {
+	it("detects completion when another item replaces it at the same count", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-provider-replace-"));
+		try {
+			let stage = 0;
+			const backgroundWork = {
+				wakeChannels: () => [],
+				snapshot: () => stage === 0
+					? snapshot(["patty"], [{ provider: "patty", id: "job-a", sessionId: "session-a" }])
+					: snapshot(["patty"], [{ provider: "patty", id: "job-b", sessionId: "session-a" }]),
+			};
+			const result = await waitForSubagents({}, undefined, waitDeps(root, makeState(), backgroundWork, async () => { stage = 1; }));
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /1 of 1 item\(s\) finished/);
+			assert.match(textOf(result), /provider item\(s\) finished/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("waits for both initial async and provider identities in all mode", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-provider-mixed-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			writeStatus(asyncRoot, "run-a", "running");
+			let stage = 0;
+			const backgroundWork = {
+				wakeChannels: () => [],
+				snapshot: () => snapshot(["patty"], stage < 2 ? [{ provider: "patty", id: "job-a", sessionId: "session-a" }] : []),
+			};
+			const result = await waitForSubagents({ all: true }, undefined, waitDeps(root, makeState(), backgroundWork, async () => {
+				stage += 1;
+				if (stage === 1) writeStatus(asyncRoot, "run-a", "complete");
+			}));
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /1 async run\(s\) and 1 provider item\(s\).*done/s);
+			assert.equal(stage, 2);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed when a provider disappears or its snapshot throws", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-provider-missing-"));
+		try {
+			let calls = 0;
+			const disappeared = await waitForSubagents({}, undefined, waitDeps(root, makeState(), {
+				wakeChannels: () => [],
+				snapshot: () => calls++ === 0
+					? snapshot(["patty"], [{ provider: "patty", id: "job-a", sessionId: "session-a" }])
+					: snapshot([], []),
+			}, async () => {}));
+			assert.equal(disappeared.isError, true);
+			assert.match(textOf(disappeared), /provider 'patty' disappeared/);
+
+			const failed = await waitForSubagents({}, undefined, waitDeps(root, makeState(), {
+				wakeChannels: () => [],
+				snapshot: () => { throw new Error("provider registry failed"); },
+			}, async () => {}));
+			assert.equal(failed.isError, true);
+			assert.match(textOf(failed), /provider registry failed/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("can continue through needs-attention while draining", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-provider-attention-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			writeStatus(asyncRoot, "run-a", "running");
+			const statusPath = path.join(asyncRoot, "run-a", "status.json");
+			const status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+			fs.writeFileSync(statusPath, JSON.stringify({ ...status, activityState: "needs_attention" }));
+			let polls = 0;
+			const result = await waitForSubagents({ all: true }, undefined, {
+				...waitDeps(root, makeState(), { wakeChannels: () => [], snapshot: () => snapshot([], []) }, async () => {
+					polls += 1;
+					writeStatus(asyncRoot, "run-a", "complete");
+				}),
+				stopOnAttention: false,
+			});
+			assert.equal(result.isError, undefined);
+			assert.equal(polls, 1);
+			assert.match(textOf(result), /done/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("wakes on a provider channel instead of the poll interval", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-provider-event-"));
+		try {
+			let active = true;
+			const handlers = new Map<string, Array<(data: unknown) => void>>();
+			const events = {
+				on(channel: string, handler: (data: unknown) => void) {
+					const channelHandlers = handlers.get(channel) ?? [];
+					channelHandlers.push(handler);
+					handlers.set(channel, channelHandlers);
+					return () => handlers.set(channel, (handlers.get(channel) ?? []).filter((candidate) => candidate !== handler));
+				},
+				emit(channel: string) {
+					for (const handler of handlers.get(channel) ?? []) handler(undefined);
+				},
+			};
+			const backgroundWork = {
+				wakeChannels: () => ["patty:finished"],
+				snapshot: () => snapshot(["patty"], active ? [{ provider: "patty", id: "job-a", sessionId: "session-a" }] : []),
+			};
+			const promise = waitForSubagents({}, undefined, {
+				...waitDeps(root, makeState(), backgroundWork, async (ms?: number, signal?: AbortSignal) => {
+					await new Promise<void>((resolve) => {
+						const timer = setTimeout(resolve, ms ?? 10_000);
+						signal?.addEventListener("abort", () => { clearTimeout(timer); resolve(); }, { once: true });
+					});
+				}),
+				events,
+				pollIntervalMs: 10_000,
+			});
+			setTimeout(() => { active = false; events.emit("patty:finished"); }, 15);
+			const result = await promise;
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /provider item\(s\) finished/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -25,7 +25,7 @@ function collectTsFiles(dir: string): string[] {
 	return files;
 }
 
-test("published Pi extension and delegation API use supported package entrypoints", async () => {
+test("published extension APIs use supported package entrypoints", async () => {
 	const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf-8"));
 
 	assert.deepEqual(packageJson.pi?.extensions, ["./index.ts"]);
@@ -37,8 +37,12 @@ test("published Pi extension and delegation API use supported package entrypoint
 	assert.equal(fs.existsSync(path.join(projectRoot, "src", "api", "delegation.ts")), true);
 	assert.deepEqual(packageJson.exports, {
 		".": "./index.ts",
+		"./background-work": "./src/api/background-work.ts",
 		"./delegation": "./src/api/delegation.ts",
 	});
+	const backgroundWork = await import("pi-subagents/background-work");
+	assert.equal(backgroundWork.BACKGROUND_WORK_PROTOCOL_VERSION, 1);
+	assert.equal(backgroundWork.BACKGROUND_WORK_REGISTRY_KEY, "pi-subagents.background-work.v1");
 	const delegation = await import("pi-subagents/delegation");
 	assert.equal(delegation.SUBAGENT_DELEGATION_PROTOCOL_VERSION, 1);
 	assert.equal(delegation.SUBAGENT_DELEGATION_REQUEST_EVENT, "prompt-template:subagent:request");

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { computeMcpServerHash } from "../../src/runs/shared/mcp-direct-tool-allowlist.ts";
 import { TOOL_BUDGET_ENV } from "../../src/runs/shared/tool-budget.ts";
+import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
 import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, REQUIRED_CHILD_TOOLS_ENV } from "../../src/runs/shared/tool-availability.ts";
 import { CHILD_WATCHDOG_CONFIG_ENV } from "../../src/watchdog/child-status.ts";
 import {
@@ -185,6 +186,19 @@ describe("buildPiArgs session wiring", () => {
 		});
 
 		assert.equal(env[SUBAGENT_PARENT_SESSION_ENV], "inherited-parent");
+	});
+
+	it("passes the effective wait-tool setting explicitly to children", () => {
+		assert.equal(buildPiArgs({
+			baseArgs: [], task: "test", sessionEnabled: false,
+			inheritProjectContext: true, inheritSkills: true,
+			waitToolEnabled: false,
+		}).env[WAIT_TOOL_ENABLED_ENV], "false");
+		assert.equal(buildPiArgs({
+			baseArgs: [], task: "test", sessionEnabled: false,
+			inheritProjectContext: true, inheritSkills: true,
+			waitToolEnabled: true,
+		}).env[WAIT_TOOL_ENABLED_ENV], "true");
 	});
 
 	it("passes child watchdog config only when explicitly provided", () => {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -302,7 +302,7 @@ describe("subagent prompt runtime", () => {
 				handlersWithout.set(event, [...(handlersWithout.get(event) ?? []), handler]);
 			},
 		} as { on(event: string, handler: unknown): void });
-		assert.equal(handlersWithout.get("agent_end")?.length ?? 0, 0);
+		assert.equal(handlersWithout.get("agent_end")?.length ?? 0, 1, "headless auto-drain is always registered");
 
 		process.env[CHILD_WATCHDOG_CONFIG_ENV] = JSON.stringify({
 			enabled: true,
@@ -330,7 +330,7 @@ describe("subagent prompt runtime", () => {
 
 		assert.ok((handlersWith.get("before_agent_start")?.length ?? 0) >= 2);
 		assert.ok((handlersWith.get("turn_end")?.length ?? 0) >= 1);
-		assert.ok((handlersWith.get("agent_end")?.length ?? 0) >= 1);
+		assert.ok((handlersWith.get("agent_end")?.length ?? 0) >= 2, "watchdog and auto-drain both observe agent_end");
 	});
 
 	it("registered structured_output tool accepts valid schema output and writes the capture file", async () => {
@@ -546,10 +546,10 @@ describe("subagent prompt runtime", () => {
 			},
 		} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(tool: { name: string }): void });
 
-		assert.deepEqual(registered, []);
+		assert.deepEqual(registered, ["subagent_wait"]);
 		handlers.get("session_start")?.({});
 		await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT });
-		assert.deepEqual(registered, []);
+		assert.deepEqual(registered, ["subagent_wait"]);
 	});
 
 	it("keeps installed pi-intercom while filling only a missing child contact_supervisor tool", async () => {
@@ -570,7 +570,7 @@ describe("subagent prompt runtime", () => {
 		handlers.get("session_start")?.({});
 		await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT });
 
-		assert.deepEqual(registered, ["contact_supervisor"]);
+		assert.deepEqual(registered, ["subagent_wait", "contact_supervisor"]);
 	});
 
 	it("registers native supervisor tools at runtime when pi-intercom is absent", async () => {
@@ -589,10 +589,10 @@ describe("subagent prompt runtime", () => {
 		} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(tool: { name: string }): void });
 
 		handlers.get("session_start")?.({});
-		assert.deepEqual(registered, ["contact_supervisor"]);
+		assert.deepEqual(registered, ["subagent_wait", "contact_supervisor"]);
 
 		await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT });
-		assert.deepEqual(registered, ["contact_supervisor", "intercom"]);
+		assert.deepEqual(registered, ["subagent_wait", "contact_supervisor", "intercom"]);
 	});
 
 	it("records and explains requested tools missing from the child registry", async () => {

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -138,6 +138,23 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("surfaces failed terminal runs as errors only for internal auto-drain", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-drain-failure-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-failed", "running", { sessionId: "sess-1", pid: 999999 });
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
+				failOnFailedRuns: true,
+				sleep: async () => writeStatus(asyncRoot, "run-failed", "failed", { sessionId: "sess-1" }),
+			}));
+			assert.equal(result.isError, true);
+			assert.match(textOf(result), /1 failed/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("wakes when a run needs attention, not only on completion", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-attn-"));
 		try {


### PR DESCRIPTION
This replaces the count-based approach in #472 and #473 with a stable, versioned `pi-subagents/background-work` contract.

Providers publish exact `{ provider, id, sessionId }` identities. `subagent_wait` captures the work active when a wait begins, so replacement jobs cannot satisfy `all:true` accidentally and same-count churn cannot hide a first completion. Provider registration, snapshots, wake channels, reconciliation, and disappearance are validated and fail with provider context instead of becoming zero work.

Headless parent and child sessions now drain current-session work at `agent_end` with one absolute deadline. The drain loops to include work started while draining, continues through ordinary attention states, and preserves terminal subagent failures as errors. Interactive sessions remain notification-driven unless a caller explicitly needs the current turn to run to completion.

The effective `waitTool` setting is propagated through foreground, async, resume, chain, parallel, and dynamic fanout paths. Child runtimes register `subagent_wait`, while Pi's `--tools` allowlist remains authoritative and provider extensions still require explicit loading through `extensions` or `subagentOnlyExtensions`.

The package export, README, packaged skill, tool guidance, and changelog are updated. The companion `pi-patty-bg-tasks` integration should migrate its PR #2 provider to stable job IDs with captured session ownership and a session-scoped, error-preserving drain.

Local validation passed with 1,258 unit tests plus one expected skip, 573 integration tests, 2 E2E tests, `git diff --check`, and a packed external TypeScript/Jiti consumer.

Thanks to RoboBryce (@robobryce) for the original work and follow-up in #472 and #473.
