### PR TITLE
fix: support YAML folded block scalars (> and >-) in agent frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Added YAML folded block scalar support for agent and chain frontmatter descriptions, preserving quoted indicators, more-indented content, and blank-line separators. Thanks to Luis Cinco (@tekniko24) for #488.
 - Distinguished interactive async yielding from headless auto-drain guidance, so interactive sessions return control by default while non-interactive sessions retain a completion path. Thanks to Luke Chen (@lukechen526) for #480.
 - Deferred hard turn-budget termination when an assistant starts tool work at the limit, exposing `termination-deferred` until the next safe assistant boundary while elapsed timeout and explicit stop retain precedence. Guidance now conservatively keeps hard turn and tool-call caps off mutation-capable workers. Thanks to JT (@juicetin) for #482 and #483.
 - Prevented watchdog idle notices while a child tool is actively running and made top-level live async `resume` a non-destructive error that directs callers to `steer`; paused, completed, or failed children retain current-session-scoped revival behavior, while stopped runs remain non-resumable. Thanks to Vlad Bereznyuk (@vrolok) for #496 and #497, and @wiansapu for confirming #496's user impact.

--- a/src/agents/frontmatter.ts
+++ b/src/agents/frontmatter.ts
@@ -6,6 +6,40 @@ function escapeRegex(s: string): string {
 }
 
 /**
+ * Fold a YAML folded block scalar while preserving more-indented lines and
+ * every blank-line separator. Trailing whitespace is trimmed.
+ */
+function foldBlock(block: string): string {
+	let folded = "";
+	let hasContent = false;
+	let previousIsMoreIndented = false;
+	let blankLines = 0;
+
+	for (const line of block.split("\n")) {
+		const current = line.trimEnd();
+		if (current.trim() === "") {
+			if (hasContent) blankLines++;
+			continue;
+		}
+
+		const currentIsMoreIndented = current.length > current.trimStart().length;
+		if (hasContent) {
+			if (blankLines > 0) {
+				folded += "\n".repeat(blankLines + (previousIsMoreIndented || currentIsMoreIndented ? 1 : 0));
+			} else {
+				folded += previousIsMoreIndented || currentIsMoreIndented ? "\n" : " ";
+			}
+		}
+		folded += current;
+		hasContent = true;
+		previousIsMoreIndented = currentIsMoreIndented;
+		blankLines = 0;
+	}
+
+	return folded.trim();
+}
+
+/**
  * Parse YAML frontmatter from agent/chain files.
  * Handles both flat (key: value) and nested block (key: \n  sub: val) values.
  * Block values are stored as single strings with embedded newlines.
@@ -31,12 +65,13 @@ export function parseFrontmatter(content: string): { frontmatter: Record<string,
 	let currentKey: string | null = null;
 	let currentBlockLines: string[] | null = null;
 	let currentIndent: number | null = null;
+	let currentFolded = false;
 
 	for (const line of lines) {
 		const indent = line.search(/\S|$/); // position of first non-whitespace char
 		const trimmed = line.trim();
 
-		if (currentKey !== null && currentBlockLines !== null && indent > (currentIndent ?? 0)) {
+		if (currentKey !== null && currentBlockLines !== null && (indent > (currentIndent ?? 0) || (currentFolded && trimmed === ""))) {
 			// This line is part of the current block value
 			currentBlockLines.push(line);
 			continue;
@@ -47,29 +82,31 @@ export function parseFrontmatter(content: string): { frontmatter: Record<string,
 			// Strip the common leading whitespace from the block so the
 			// serializer can add its own indentation level.
 			const rawBlock = currentBlockLines.join("\n");
-			const leadingSpaces = rawBlock.match(/^([ \t]+)/m);
-			const prefix = leadingSpaces?.[1] ?? "";
+			const leadingSpaces = rawBlock.match(/^[ \t]+(?=\S)/m);
+			const prefix = leadingSpaces?.[0] ?? "";
 			const stripped = prefix
 				? rawBlock.replace(new RegExp(`^${escapeRegex(prefix)}`, "gm"), "").replace(/^\n/, "")
 				: rawBlock;
-			frontmatter[currentKey] = stripped;
+			frontmatter[currentKey] = currentFolded ? foldBlock(stripped) : stripped;
 			currentKey = null;
 			currentBlockLines = null;
 			currentIndent = null;
+			currentFolded = false;
 		}
 
 		const match = line.match(/^([\w-]+):\s*(.*)$/);
 		if (match) {
-			let value = match[2].trim();
-			if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-				value = value.slice(1, -1);
-			}
+			const rawValue = match[2].trim();
+			const isQuoted = (rawValue.startsWith('"') && rawValue.endsWith('"')) || (rawValue.startsWith("'") && rawValue.endsWith("'"));
+			const value = isQuoted ? rawValue.slice(1, -1) : rawValue;
+			const isFolded = !isQuoted && (rawValue === ">" || rawValue === ">-");
 
-			if (value === "") {
-				// Key with empty value — might start a block; defer storing until we see indent
+			if (value === "" || isFolded) {
+				// Key with empty value or folded block indicator — defer storing until we see indent
 				currentKey = match[1];
 				currentBlockLines = [];
 				currentIndent = indent;
+				currentFolded = isFolded;
 			} else {
 				// Simple key: value
 				frontmatter[match[1]] = value;
@@ -81,12 +118,12 @@ export function parseFrontmatter(content: string): { frontmatter: Record<string,
 	// Flush final block value
 	if (currentKey !== null && currentBlockLines !== null) {
 		const rawBlock = currentBlockLines.join("\n");
-		const leadingSpaces = rawBlock.match(/^([ \t]+)/m);
-		const prefix = leadingSpaces?.[1] ?? "";
+		const leadingSpaces = rawBlock.match(/^[ \t]+(?=\S)/m);
+		const prefix = leadingSpaces?.[0] ?? "";
 		const stripped = prefix
 			? rawBlock.replace(new RegExp(`^${escapeRegex(prefix)}`, "gm"), "").replace(/^\n/, "")
 			: rawBlock;
-		frontmatter[currentKey] = stripped;
+		frontmatter[currentKey] = currentFolded ? foldBlock(stripped) : stripped;
 	}
 
 	return { frontmatter, body };

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -7,6 +7,7 @@ import { handleManagementAction } from "../../src/agents/agent-management.ts";
 import { serializeAgent } from "../../src/agents/agent-serializer.ts";
 import { parseChain, serializeChain } from "../../src/agents/chain-serializer.ts";
 import { discoverAgents, discoverAgentsAll, type AgentConfig } from "../../src/agents/agents.ts";
+import { parseFrontmatter } from "../../src/agents/frontmatter.ts";
 import { buildPiArgs } from "../../src/runs/shared/pi-args.ts";
 import { THINKING_LEVELS } from "../../src/shared/model-info.ts";
 
@@ -53,6 +54,86 @@ afterEach(() => {
 		if (!dir) continue;
 		fs.rmSync(dir, { recursive: true, force: true });
 	}
+});
+
+describe("folded frontmatter blocks", () => {
+	it("folds ordinary lines and paragraph breaks for > and >-", () => {
+		const expected = "first line second line\nthird line";
+		const folded = parseFrontmatter(`---
+name: worker
+description: >
+  first line
+  second line
+
+  third line
+---
+body`);
+		const stripped = parseFrontmatter(`---
+name: worker
+description: >-
+  first line
+  second line
+
+  third line
+---
+body`);
+
+		assert.equal(folded.frontmatter.description, expected);
+		assert.equal(stripped.frontmatter.description, expected);
+		assert.equal(folded.frontmatter.name, "worker");
+	});
+
+	it("keeps quoted indicators as literal values", () => {
+		const parsed = parseFrontmatter(`---
+description: ">"
+other: '>-'
+---
+body`);
+
+		assert.equal(parsed.frontmatter.description, ">");
+		assert.equal(parsed.frontmatter.other, ">-");
+	});
+
+	it("preserves more-indented lines and repeated whitespace-only separators", () => {
+		const parsed = parseFrontmatter(`---
+description: >
+  normal
+    code
+  next
+
+  first
+
+  ${" ".repeat(3)}
+  second
+name: worker
+---
+body`);
+
+		assert.equal(parsed.frontmatter.description, "normal\n  code\nnext\nfirst\n\nsecond");
+		assert.equal(parsed.frontmatter.name, "worker");
+	});
+
+	it("keeps paragraph breaks adjacent to more-indented lines", () => {
+		const afterIndented = parseFrontmatter(`---
+description: >
+  normal
+    code
+
+  next
+---
+body`);
+		const beforeIndented = parseFrontmatter(`---
+description: >
+  normal
+
+    code
+  next
+---
+body`);
+
+		assert.equal(afterIndented.frontmatter.description, "normal\n  code\n\nnext");
+		assert.equal(beforeIndented.frontmatter.description, "normal\n\n  code\nnext");
+	});
 });
 
 describe("agent skillPath frontmatter", () => {

--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -170,7 +170,7 @@ describe("acknowledged steering action", () => {
 		let recovered = false;
 		try {
 			const action = steerAsyncRun({
-				state: createState(), runId, message: "correct course", location: { asyncDir }, ackTimeoutMs: 25,
+				state: createState(), runId, message: "correct course", location: { asyncDir }, ackTimeoutMs: 500,
 				kill: (_pid, signal) => { if (signal !== 0) interrupted = true; return true; },
 				onRecoveryCommitted: (_requestId, committedAt) => {
 					assert.ok(request);


### PR DESCRIPTION
Agent and chain frontmatter could not parse YAML folded block scalars, so a `description: >` value was stored as the literal `>` and its indented content was dropped.

This revision keeps Luis Cinco’s focused parser change while tightening the folding behavior around the cases exposed during review. Unquoted `>` and `>-` start folded blocks; quoted indicators remain literal values. Ordinary lines fold to spaces, more-indented lines preserve structural line breaks and indentation, and blank or whitespace-only separator runs remain distinct even when they touch more-indented content. Existing plain nested blocks continue through the same parser path unchanged.

The regression suite exercises both indicators, quoted values, ordinary paragraphs, more-indented transitions in both directions, repeated separators, adjacent-key flushing, and existing nested frontmatter. A seven-case transition matrix also matches the installed YAML parser after normalizing only the trailing chomping behavior this narrow parser already trims.

Exact-head CI also exposed an unrelated 25 ms steering test race under Ubuntu load. A separate maintainer test-only commit aligns that fixture with the existing 500 ms acknowledgment window; the isolated case passed 10/10 stress runs and the full unit suite.

Validation on the reviewed head:

- Frontmatter tests: 54 passed, 0 failed
- Unit: 1,269 passed, 1 expected skip, 0 failed
- Integration: 581 passed, 0 failed
- E2E: 2 passed, 0 failed
- `git diff --check`: passed

Thanks to Luis Cinco (`@tekniko24`) for the implementation and #488.