### PR TITLE
feat: compact human-facing subagent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added a chain quick-reference (sequential, parallel fan-out, and mixed examples) to the `subagent` tool description in both full and compact modes so agents have the correct nested schema format up front. Thanks to Nicolas Marchildon (@elecnix) for #417 and #424.
 
 ### Changed
+- Made visible subagent control notices and native supervisor requests compact by default, with full human-readable diagnostics and structured request details available through Pi's expand key while preserving complete model-facing message content.
 - Updated the bundled `pi-subagents` skill so Fable mode is the default orchestration posture for complex work, and refreshed recent command/config guidance.
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ The child can use one dedicated coordination tool:
 
 The parent replies with `subagent_supervisor({ action: "reply", replyTo, message })` or checks pending requests with `subagent_supervisor({ action: "pending" })`. Supervisor messages are scoped to the exact Pi session id that spawned the child. A second Pi session in the same repository does not receive those requests.
 
+Visible supervisor requests and subagent control notices use a compact human summary by default. Press Pi's configured expand key (`Ctrl+O` by default) to show the full question, structured interview, or control diagnostics. This only changes terminal presentation: the complete control or coordination message remains in the conversation for the parent model.
+
 Child-side routine completion handoffs are still not expected. If a child appears stalled, needs-attention notices can show up in the parent session with useful next actions, such as checking `subagent({ action: "status" })`, interrupting the run, or nudging the child.
 
 If messages do not show up, run:

--- a/src/extension/control-notices.ts
+++ b/src/extension/control-notices.ts
@@ -1,10 +1,11 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { controlNotificationKey, formatControlNoticeMessage } from "../runs/shared/subagent-control.ts";
 import type { ControlEvent, SubagentState } from "../shared/types.ts";
+import { resolveChildPresentation, type ChildPresentationDetails } from "./human-messages.ts";
 
 export const SUBAGENT_CONTROL_MESSAGE_TYPE = "subagent_control_notice";
 
-export interface SubagentControlMessageDetails {
+export interface SubagentControlMessageDetails extends Partial<ChildPresentationDetails> {
 	event: ControlEvent;
 	source?: "foreground" | "async";
 	asyncDir?: string;
@@ -37,6 +38,7 @@ export function clearPendingForegroundControlNotices(state: SubagentState, runId
 
 function deliverControlNotice(input: {
 	pi: Pick<ExtensionAPI, "sendMessage">;
+	state: SubagentState;
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;
 }): void {
@@ -45,12 +47,18 @@ function deliverControlNotice(input: {
 	if (input.visibleControlNotices.has(key)) return;
 	input.visibleControlNotices.add(key);
 	const noticeText = input.details.noticeText ?? formatControlNoticeMessage(input.details.event, childIntercomTarget);
+	const presentation = resolveChildPresentation(
+		input.state,
+		input.details.event.runId,
+		input.details.event.agent,
+		input.details.event.index,
+	);
 	input.pi.sendMessage(
 		{
 			customType: SUBAGENT_CONTROL_MESSAGE_TYPE,
 			content: noticeText,
 			display: true,
-			details: { ...input.details, childIntercomTarget, noticeText },
+			details: { ...input.details, ...presentation, childIntercomTarget, noticeText },
 		},
 		{ triggerTurn: input.details.source !== "foreground" },
 	);

--- a/src/extension/human-messages.ts
+++ b/src/extension/human-messages.ts
@@ -1,0 +1,193 @@
+import { flatToLogicalStepIndex } from "../runs/background/parallel-groups.ts";
+import type { ControlEvent, SubagentState } from "../shared/types.ts";
+
+export const SUBAGENT_SUPERVISOR_MESSAGE_TYPE = "subagent_supervisor_request";
+
+export interface ChildPresentationDetails {
+	label: string;
+	role: string;
+	logicalStep?: number;
+	totalSteps?: number;
+}
+
+export interface SupervisorRequestMessageDetails extends ChildPresentationDetails {
+	id: string;
+	reason: "need_decision" | "interview_request" | "progress_update";
+	expectsReply: boolean;
+	runId: string;
+	agent: string;
+	childIndex: number;
+	question?: string;
+	interview?: unknown;
+}
+
+export interface HumanControlMessageDetails extends ChildPresentationDetails {
+	event: ControlEvent;
+}
+
+export function shortRunId(runId: string): string {
+	return runId.length > 8 ? runId.slice(0, 8) : runId;
+}
+
+function logicalPosition(details: Pick<ChildPresentationDetails, "logicalStep" | "totalSteps">): string | undefined {
+	if (details.logicalStep === undefined) return undefined;
+	return details.totalSteps !== undefined
+		? `Step ${details.logicalStep}/${details.totalSteps}`
+		: `Step ${details.logicalStep}`;
+}
+
+export function resolveChildPresentation(
+	state: Pick<SubagentState, "asyncJobs" | "foregroundRuns">,
+	runId: string,
+	agent: string,
+	childIndex: number | undefined,
+): ChildPresentationDetails {
+	const fallback: ChildPresentationDetails = {
+		label: agent,
+		role: agent,
+		...(childIndex !== undefined ? { logicalStep: childIndex + 1 } : {}),
+	};
+	if (childIndex === undefined) return fallback;
+
+	const asyncJob = state.asyncJobs.get(runId);
+	if (asyncJob) {
+		const step = asyncJob.steps?.find((candidate) => candidate.index === childIndex) ?? asyncJob.steps?.[childIndex];
+		const totalSteps = asyncJob.chainStepCount ?? asyncJob.stepsTotal ?? asyncJob.steps?.length;
+		const logicalIndex = asyncJob.mode === "chain" && asyncJob.chainStepCount !== undefined
+			? flatToLogicalStepIndex(childIndex, asyncJob.chainStepCount, asyncJob.parallelGroups ?? [])
+			: childIndex;
+		return {
+			label: step?.label ?? step?.agent ?? agent,
+			role: step?.agent ?? agent,
+			logicalStep: logicalIndex + 1,
+			...(totalSteps !== undefined ? { totalSteps } : {}),
+		};
+	}
+
+	const foreground = state.foregroundRuns?.get(runId);
+	if (foreground) {
+		const child = foreground.children.find((candidate) => candidate.index === childIndex) ?? foreground.children[childIndex];
+		return {
+			label: child?.agent ?? agent,
+			role: child?.agent ?? agent,
+			logicalStep: childIndex + 1,
+			totalSteps: foreground.children.length,
+		};
+	}
+	return fallback;
+}
+
+function durationLabel(durationMs: number): string {
+	const seconds = Math.max(0, Math.floor(durationMs / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	return seconds % 60 === 0 ? `${minutes}m` : `${minutes}m ${seconds % 60}s`;
+}
+
+function roleLabel(details: ChildPresentationDetails): string {
+	return details.label === details.role ? details.label : `${details.label} [${details.role}]`;
+}
+
+function expandHint(expandKey: string): string {
+	return `${expandKey} for details`;
+}
+
+export function formatHumanControlNotice(
+	details: HumanControlMessageDetails,
+	expanded: boolean,
+	expandKey: string,
+): string {
+	const { event } = details;
+	const position = logicalPosition(details);
+	const run = `run ${shortRunId(event.runId)}`;
+	const subject = roleLabel(details);
+	const elapsed = event.elapsedMs !== undefined ? durationLabel(event.elapsedMs) : undefined;
+	const heading = event.reason === "completion_guard"
+		? `✗ ${subject} failed`
+		: event.type === "active_long_running"
+			? `⚠ ${subject} is still working`
+			: `⚠ ${subject} may be stuck${elapsed ? ` · no activity for ${elapsed}` : ""}`;
+	const location = [position, run].filter(Boolean).join(" · ");
+	if (!expanded) return `${heading}\n${location} · ${expandHint(expandKey)}`;
+
+	const lines = [heading, `${details.label} [${details.role}] · ${location}`];
+	if (event.message.trim()) lines.push(`Observed: ${event.message.trim()}`);
+	if (event.currentTool) {
+		const toolDuration = event.currentToolDurationMs !== undefined ? ` for ${durationLabel(event.currentToolDurationMs)}` : "";
+		lines.push(`Current activity: ${event.currentTool}${toolDuration}`);
+	}
+	if (event.currentPath) lines.push(`Working in: ${event.currentPath}`);
+	if (event.recentFailureSummary) lines.push(`Recent failures: ${event.recentFailureSummary}`);
+	const facts = [
+		event.turns !== undefined ? `${event.turns} turns` : undefined,
+		event.tokens !== undefined ? `${event.tokens} tokens` : undefined,
+		event.toolCount !== undefined ? `${event.toolCount} tools` : undefined,
+	].filter((value): value is string => Boolean(value));
+	if (facts.length > 0) lines.push(`Diagnostics: ${facts.join(" · ")}`);
+	if (event.reason !== "completion_guard") lines.push("Recommendation: inspect current status before nudging or interrupting the child.");
+	return lines.join("\n");
+}
+
+function compactSummary(value: string | undefined): string | undefined {
+	const firstLine = value?.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+	if (!firstLine) return undefined;
+	if (/\b(?:subagent|intercom)\s*\(|\{\s*"?(?:action|replyTo)"?\s*:/i.test(firstLine)) return undefined;
+	const sanitized = firstLine
+		.replace(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi, (id) => id.slice(0, 8))
+		.replace(/\b[A-Za-z]:\\[^\s]+|(?:^|\s)\/(?:[^\s/]+\/)*[^\s]+/g, " [path hidden]")
+		.replace(/\b(?:child\s+)?intercom\s+target\b[^·|]*/gi, "coordination details hidden")
+		.trim();
+	return sanitized.length > 100 ? `${sanitized.slice(0, 99)}…` : sanitized;
+}
+
+function humanizeKey(key: string): string {
+	return key.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replaceAll("_", " ").replace(/^./, (value) => value.toUpperCase());
+}
+
+function formatStructuredValue(value: unknown, indent = ""): string[] {
+	if (value === null || value === undefined) return [];
+	if (typeof value !== "object") return [`${indent}${String(value)}`];
+	if (Array.isArray(value)) {
+		return value.flatMap((entry) => {
+			const lines = formatStructuredValue(entry, `${indent}  `);
+			if (lines.length === 0) return [];
+			return [`${indent}- ${lines[0]!.trimStart()}`, ...lines.slice(1)];
+		});
+	}
+	return Object.entries(value as Record<string, unknown>).flatMap(([key, entry]) => {
+		if (entry === null || entry === undefined) return [];
+		if (typeof entry !== "object") return [`${indent}${humanizeKey(key)}: ${String(entry)}`];
+		return [`${indent}${humanizeKey(key)}:`, ...formatStructuredValue(entry, `${indent}  `)];
+	});
+}
+
+export function formatHumanSupervisorRequest(
+	details: SupervisorRequestMessageDetails,
+	expanded: boolean,
+	expandKey: string,
+): string {
+	const position = logicalPosition(details);
+	const run = `run ${shortRunId(details.runId)}`;
+	const subject = roleLabel(details);
+	const heading = details.reason === "progress_update"
+		? `↗ ${subject} · progress update`
+		: details.reason === "interview_request"
+			? `⚠ Supervisor interview needed · ${subject}`
+			: `⚠ Supervisor decision needed · ${subject}`;
+	const summary = compactSummary(details.question)
+		?? (details.reason === "interview_request" ? "Structured input requested" : undefined);
+	const location = [position, run].filter(Boolean).join(" · ");
+	if (!expanded) {
+		const secondLine = [summary, location, expandHint(expandKey)].filter(Boolean).join(" · ");
+		return secondLine ? `${heading}\n${secondLine}` : heading;
+	}
+
+	const lines = [
+		heading,
+		`${details.label} [${details.role}] · ${location} · ${details.expectsReply ? "Reply required" : "No reply required"}`,
+	];
+	if (details.question?.trim()) lines.push("", details.question.trim());
+	const interviewLines = formatStructuredValue(details.interview);
+	if (interviewLines.length > 0) lines.push("", "Structured interview:", ...interviewLines);
+	return lines.join("\n");
+}

--- a/src/extension/human-messages.ts
+++ b/src/extension/human-messages.ts
@@ -113,14 +113,14 @@ export function formatHumanControlNotice(
 
 	const legacy = extractLegacyControlContent(legacyContent);
 	const lines = [heading, `${details.label} [${details.role}] · ${location}`];
-	const observed = legacy.observed ?? substantiveText(event.message);
+	const observed = substantiveText(event.message) ?? legacy.observed;
 	if (observed) lines.push(`Observed: ${observed}`);
 	if (event.currentTool) {
 		const toolDuration = event.currentToolDurationMs !== undefined ? ` for ${durationLabel(event.currentToolDurationMs)}` : "";
 		lines.push(`Current activity: ${event.currentTool}${toolDuration}`);
 	}
 	if (event.currentPath) lines.push(`Working in: ${event.currentPath}`);
-	const recentFailures = legacy.recentFailures ?? substantiveText(event.recentFailureSummary);
+	const recentFailures = substantiveText(event.recentFailureSummary) ?? legacy.recentFailures;
 	if (recentFailures) lines.push(`Recent failures: ${recentFailures}`);
 	const facts = [
 		event.turns !== undefined ? `${event.turns} turns` : undefined,
@@ -270,7 +270,6 @@ function formatStructuredValue(value: unknown, indent = ""): string[] {
 		});
 	}
 	const record = value as Record<string, unknown>;
-	if (hasInternalCommand(record)) return [];
 	return Object.entries(record).flatMap(([key, entry]) => {
 		if (entry === null || entry === undefined || key === "childTarget") return [];
 		if (typeof entry !== "object") {

--- a/src/extension/human-messages.ts
+++ b/src/extension/human-messages.ts
@@ -96,6 +96,7 @@ export function formatHumanControlNotice(
 	details: HumanControlMessageDetails,
 	expanded: boolean,
 	expandKey: string,
+	legacyContent?: string,
 ): string {
 	const { event } = details;
 	const position = logicalPosition(details);
@@ -110,28 +111,82 @@ export function formatHumanControlNotice(
 	const location = [position, run].filter(Boolean).join(" · ");
 	if (!expanded) return `${heading}\n${location} · ${expandHint(expandKey)}`;
 
+	const legacy = extractLegacyControlContent(legacyContent);
 	const lines = [heading, `${details.label} [${details.role}] · ${location}`];
-	if (event.message.trim()) lines.push(`Observed: ${event.message.trim()}`);
+	const observed = legacy.observed ?? substantiveText(event.message);
+	if (observed) lines.push(`Observed: ${observed}`);
 	if (event.currentTool) {
 		const toolDuration = event.currentToolDurationMs !== undefined ? ` for ${durationLabel(event.currentToolDurationMs)}` : "";
 		lines.push(`Current activity: ${event.currentTool}${toolDuration}`);
 	}
 	if (event.currentPath) lines.push(`Working in: ${event.currentPath}`);
-	if (event.recentFailureSummary) lines.push(`Recent failures: ${event.recentFailureSummary}`);
+	const recentFailures = legacy.recentFailures ?? substantiveText(event.recentFailureSummary);
+	if (recentFailures) lines.push(`Recent failures: ${recentFailures}`);
 	const facts = [
 		event.turns !== undefined ? `${event.turns} turns` : undefined,
 		event.tokens !== undefined ? `${event.tokens} tokens` : undefined,
 		event.toolCount !== undefined ? `${event.toolCount} tools` : undefined,
 	].filter((value): value is string => Boolean(value));
 	if (facts.length > 0) lines.push(`Diagnostics: ${facts.join(" · ")}`);
-	if (event.reason !== "completion_guard") lines.push("Recommendation: inspect current status before nudging or interrupting the child.");
+	else if (legacy.diagnostics) lines.push(`Diagnostics: ${legacy.diagnostics}`);
+	const recommendation = legacy.recommendation
+		?? (event.reason !== "completion_guard" ? "inspect current status before nudging or interrupting the child." : undefined);
+	if (recommendation) lines.push(`Recommendation: ${recommendation}`);
 	return lines.join("\n");
 }
 
+function hasInternalCommand(value: unknown): boolean {
+	if (!value || typeof value !== "object") return false;
+	if (Array.isArray(value)) return value.some(hasInternalCommand);
+	const record = value as Record<string, unknown>;
+	if ("replyTo" in record || ("action" in record && typeof record.action === "string")) return true;
+	return Object.values(record).some(hasInternalCommand);
+}
+
+function isInternalLine(line: string): boolean {
+	return /\b(?:subagent(?:_supervisor)?|intercom)\s*\(\s*\{/i.test(line)
+		|| /"(?:action|replyTo)"\s*:/i.test(line)
+		|| /^\s*(?:Reply with|Nudge|Status|Interrupt):/i.test(line)
+		|| /^\s*(?:Child|Direct|Run) intercom target\s*:/i.test(line);
+}
+
+function withoutInternalJsonBlocks(lines: string[]): string[] {
+	const safe: string[] = [];
+	for (let index = 0; index < lines.length; index += 1) {
+		if (!/^[{[]/.test(lines[index]!.trim())) {
+			safe.push(lines[index]!);
+			continue;
+		}
+		for (let end = index; end < lines.length; end += 1) {
+			try {
+				const parsed = JSON.parse(lines.slice(index, end + 1).join("\n"));
+				if (hasInternalCommand(parsed)) {
+					index = end;
+					break;
+				}
+				safe.push(...lines.slice(index, end + 1));
+				index = end;
+				break;
+			} catch {
+				if (end === lines.length - 1) safe.push(lines[index]!);
+			}
+		}
+	}
+	return safe;
+}
+
+function substantiveText(value: string | undefined): string | undefined {
+	const lines = withoutInternalJsonBlocks(value?.split(/\r?\n/) ?? [])
+		.filter((line) => !isInternalLine(line))
+		.filter((line) => !/^\s*[{}[\],]+\s*$/.test(line))
+		.map((line) => line.trimEnd());
+	const text = lines?.join("\n").trim();
+	return text || undefined;
+}
+
 function compactSummary(value: string | undefined): string | undefined {
-	const firstLine = value?.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+	const firstLine = substantiveText(value)?.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
 	if (!firstLine) return undefined;
-	if (/\b(?:subagent|intercom)\s*\(|\{\s*"?(?:action|replyTo)"?\s*:/i.test(firstLine)) return undefined;
 	const sanitized = firstLine
 		.replace(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi, (id) => id.slice(0, 8))
 		.replace(/\b[A-Za-z]:\\[^\s]+|(?:^|\s)\/(?:[^\s/]+\/)*[^\s]+/g, " [path hidden]")
@@ -140,13 +195,73 @@ function compactSummary(value: string | undefined): string | undefined {
 	return sanitized.length > 100 ? `${sanitized.slice(0, 99)}…` : sanitized;
 }
 
+interface LegacySupervisorContent {
+	question?: string;
+	interview?: unknown;
+}
+
+function extractLegacySupervisorContent(content: string | undefined): LegacySupervisorContent {
+	if (!content?.trim()) return {};
+	const lines = content.split(/\r?\n/);
+	const structuredIndex = lines.findIndex((line) => /^Structured response requested\./i.test(line.trim()));
+	const replyIndex = lines.findIndex((line) => /^Reply with:/i.test(line.trim()));
+	const questionEnd = structuredIndex >= 0 ? structuredIndex : replyIndex >= 0 ? replyIndex : lines.length;
+	const question = substantiveText(lines.slice(0, questionEnd)
+		.filter((line) => !/^Subagent (?:requests|progress update|needs)/i.test(line.trim()))
+		.filter((line) => !/^(?:Run|Agent|Child index|Child intercom target):/i.test(line.trim()))
+		.join("\n"));
+
+	let interview: unknown;
+	if (structuredIndex >= 0) {
+		const serialized = lines.slice(structuredIndex + 1, replyIndex >= 0 ? replyIndex : lines.length).join("\n").trim();
+		if (serialized) {
+			try {
+				interview = JSON.parse(serialized);
+			} catch {
+				// Legacy content is untrusted display data. Never fall back to showing raw JSON.
+			}
+		}
+	}
+	return { ...(question ? { question } : {}), ...(interview !== undefined ? { interview } : {}) };
+}
+
+interface LegacyControlContent {
+	observed?: string;
+	recentFailures?: string;
+	diagnostics?: string;
+	recommendation?: string;
+}
+
+function extractLegacyControlContent(content: string | undefined): LegacyControlContent {
+	if (!content?.trim()) return {};
+	const result: LegacyControlContent = {};
+	for (const line of content.split(/\r?\n/)) {
+		if (isInternalLine(line)) continue;
+		const match = line.match(/^\s*(Signal|Recent failures|Facts|Hint|Next):\s*(.+?)\s*$/i);
+		if (!match) continue;
+		const value = substantiveText(match[2]);
+		if (!value) continue;
+		switch (match[1]?.toLowerCase()) {
+			case "signal": result.observed = value; break;
+			case "recent failures": result.recentFailures = value; break;
+			case "facts": result.diagnostics = value; break;
+			case "hint":
+			case "next": result.recommendation = value; break;
+		}
+	}
+	return result;
+}
+
 function humanizeKey(key: string): string {
 	return key.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replaceAll("_", " ").replace(/^./, (value) => value.toUpperCase());
 }
 
 function formatStructuredValue(value: unknown, indent = ""): string[] {
 	if (value === null || value === undefined) return [];
-	if (typeof value !== "object") return [`${indent}${String(value)}`];
+	if (typeof value !== "object") {
+		const text = substantiveText(String(value));
+		return text ? [`${indent}${text}`] : [];
+	}
 	if (Array.isArray(value)) {
 		return value.flatMap((entry) => {
 			const lines = formatStructuredValue(entry, `${indent}  `);
@@ -154,10 +269,16 @@ function formatStructuredValue(value: unknown, indent = ""): string[] {
 			return [`${indent}- ${lines[0]!.trimStart()}`, ...lines.slice(1)];
 		});
 	}
-	return Object.entries(value as Record<string, unknown>).flatMap(([key, entry]) => {
-		if (entry === null || entry === undefined) return [];
-		if (typeof entry !== "object") return [`${indent}${humanizeKey(key)}: ${String(entry)}`];
-		return [`${indent}${humanizeKey(key)}:`, ...formatStructuredValue(entry, `${indent}  `)];
+	const record = value as Record<string, unknown>;
+	if (hasInternalCommand(record)) return [];
+	return Object.entries(record).flatMap(([key, entry]) => {
+		if (entry === null || entry === undefined || key === "childTarget") return [];
+		if (typeof entry !== "object") {
+			const text = substantiveText(String(entry));
+			return text ? [`${indent}${humanizeKey(key)}: ${text}`] : [];
+		}
+		const lines = formatStructuredValue(entry, `${indent}  `);
+		return lines.length > 0 ? [`${indent}${humanizeKey(key)}:`, ...lines] : [];
 	});
 }
 
@@ -165,6 +286,7 @@ export function formatHumanSupervisorRequest(
 	details: SupervisorRequestMessageDetails,
 	expanded: boolean,
 	expandKey: string,
+	legacyContent?: string,
 ): string {
 	const position = logicalPosition(details);
 	const run = `run ${shortRunId(details.runId)}`;
@@ -174,7 +296,10 @@ export function formatHumanSupervisorRequest(
 		: details.reason === "interview_request"
 			? `⚠ Supervisor interview needed · ${subject}`
 			: `⚠ Supervisor decision needed · ${subject}`;
-	const summary = compactSummary(details.question)
+	const legacy = extractLegacySupervisorContent(legacyContent);
+	const question = substantiveText(details.question) ?? legacy.question;
+	const interview = details.interview ?? legacy.interview;
+	const summary = compactSummary(question)
 		?? (details.reason === "interview_request" ? "Structured input requested" : undefined);
 	const location = [position, run].filter(Boolean).join(" · ");
 	if (!expanded) {
@@ -186,8 +311,8 @@ export function formatHumanSupervisorRequest(
 		heading,
 		`${details.label} [${details.role}] · ${location} · ${details.expectsReply ? "Reply required" : "No reply required"}`,
 	];
-	if (details.question?.trim()) lines.push("", details.question.trim());
-	const interviewLines = formatStructuredValue(details.interview);
+	if (question) lines.push("", question);
+	const interviewLines = formatStructuredValue(interview);
 	if (interviewLines.length > 0) lines.push("", "Structured interview:", ...interviewLines);
 	return lines.join("\n");
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -355,7 +355,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			...(details.totalSteps !== undefined ? { totalSteps: details.totalSteps } : {}),
 			event: details.event,
 		};
-		return new Text(theme.fg("accent", formatHumanControlNotice(presentation, options.expanded, keyText("app.tools.expand"))), 0, 0);
+		const legacyContent = typeof message.content === "string" ? message.content : undefined;
+		return new Text(theme.fg("accent", formatHumanControlNotice(presentation, options.expanded, keyText("app.tools.expand"), legacyContent)), 0, 0);
 	});
 
 	pi.registerMessageRenderer<SupervisorRequestMessageDetails>(SUBAGENT_SUPERVISOR_MESSAGE_TYPE, (message, options, theme) => {
@@ -367,7 +368,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			role: details.role ?? details.agent,
 		};
 		const color = details.reason === "progress_update" ? "muted" : "accent";
-		return new Text(theme.fg(color, formatHumanSupervisorRequest(presentation, options.expanded, keyText("app.tools.expand"))), 0, 0);
+		const legacyContent = typeof message.content === "string" ? message.content : undefined;
+		return new Text(theme.fg(color, formatHumanSupervisorRequest(presentation, options.expanded, keyText("app.tools.expand"), legacyContent)), 0, 0);
 	});
 
 	const executeSubagentCollapsed = (id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((result: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -18,7 +18,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { keyText, type ExtensionAPI, type ExtensionContext, type ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { Box, Container, Spacer, Text, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
+import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import { discoverAgents } from "../agents/agents.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
@@ -63,11 +63,16 @@ import {
 } from "../shared/types.ts";
 import {
 	clearPendingForegroundControlNotices,
-	formatSubagentControlNotice,
 	handleSubagentControlNotice,
 	SUBAGENT_CONTROL_MESSAGE_TYPE,
 	type SubagentControlMessageDetails,
 } from "./control-notices.ts";
+import {
+	formatHumanControlNotice,
+	formatHumanSupervisorRequest,
+	SUBAGENT_SUPERVISOR_MESSAGE_TYPE,
+	type SupervisorRequestMessageDetails,
+} from "./human-messages.ts";
 
 export { loadConfig } from "./config.ts";
 
@@ -181,34 +186,6 @@ function createSlashResultComponent(
 		return Container.prototype.render.call(container, width);
 	};
 	return container;
-}
-
-class SubagentControlNoticeComponent implements Component {
-	constructor(
-		private readonly details: SubagentControlMessageDetails,
-		private readonly theme: ExtensionContext["ui"]["theme"],
-	) {}
-
-	invalidate(): void {}
-
-	render(width: number): string[] {
-		const eventLabel = this.details.event.type.replaceAll("_", " ");
-		if (width < 3) return [truncateToWidth(`Subagent ${eventLabel}`, width)];
-		const bodyWidth = Math.max(1, width - 2);
-		const borderChar = "─";
-		const header = ` ⚠ Subagent ${eventLabel}: ${this.details.event.agent} `;
-		const headerText = truncateToWidth(header, bodyWidth, "");
-		const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
-		const lines = [this.theme.fg("accent", `╭${headerText}${borderChar.repeat(headerPadding)}╮`)];
-
-		for (const line of wrapTextWithAnsi(formatSubagentControlNotice(this.details), bodyWidth)) {
-			const text = truncateToWidth(line, bodyWidth, "");
-			const padding = Math.max(0, bodyWidth - visibleWidth(text));
-			lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));
-		}
-		lines.push(this.theme.fg("accent", `╰${borderChar.repeat(bodyWidth)}╯`));
-		return lines;
-	}
 }
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
@@ -368,11 +345,29 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		return new Text(theme.fg(details.state === "recovered" ? "warning" : "error", formatSteeringNotice(details)), 0, 0);
 	});
 
-	pi.registerMessageRenderer<SubagentControlMessageDetails>(SUBAGENT_CONTROL_MESSAGE_TYPE, (message, _options, theme) => {
+	pi.registerMessageRenderer<SubagentControlMessageDetails>(SUBAGENT_CONTROL_MESSAGE_TYPE, (message, options, theme) => {
 		const details = message.details as SubagentControlMessageDetails | undefined;
 		if (!details?.event) return undefined;
-		const content = typeof message.content === "string" ? message.content : undefined;
-		return new SubagentControlNoticeComponent({ ...details, noticeText: formatSubagentControlNotice(details, content) }, theme);
+		const presentation = {
+			label: details.label ?? details.event.agent,
+			role: details.role ?? details.event.agent,
+			...(details.logicalStep !== undefined ? { logicalStep: details.logicalStep } : {}),
+			...(details.totalSteps !== undefined ? { totalSteps: details.totalSteps } : {}),
+			event: details.event,
+		};
+		return new Text(theme.fg("accent", formatHumanControlNotice(presentation, options.expanded, keyText("app.tools.expand"))), 0, 0);
+	});
+
+	pi.registerMessageRenderer<SupervisorRequestMessageDetails>(SUBAGENT_SUPERVISOR_MESSAGE_TYPE, (message, options, theme) => {
+		const details = message.details as SupervisorRequestMessageDetails | undefined;
+		if (!details?.id || !details.runId || !details.agent) return undefined;
+		const presentation = {
+			...details,
+			label: details.label ?? details.agent,
+			role: details.role ?? details.agent,
+		};
+		const color = details.reason === "progress_update" ? "muted" : "accent";
+		return new Text(theme.fg(color, formatHumanSupervisorRequest(presentation, options.expanded, keyText("app.tools.expand"))), 0, 0);
 	});
 
 	const executeSubagentCollapsed = (id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((result: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => {

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -14,6 +14,11 @@ import {
 } from "../runs/shared/pi-args.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
 import { writeAtomicJson } from "../shared/atomic-json.ts";
+import {
+	resolveChildPresentation,
+	SUBAGENT_SUPERVISOR_MESSAGE_TYPE,
+	type SupervisorRequestMessageDetails,
+} from "../extension/human-messages.ts";
 
 const SUPERVISOR_CHANNEL_ROOT = path.join(TEMP_ROOT_DIR, "supervisor-channels");
 const REQUESTS_DIR = "requests";
@@ -41,6 +46,7 @@ interface SupervisorRequest {
 	agent: string;
 	childIndex: number;
 	childTarget?: string;
+	question?: string;
 	interview?: unknown;
 }
 
@@ -248,6 +254,7 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: A
 		agent: metadata.agent,
 		childIndex: metadata.childIndex,
 		...(metadata.childTarget ? { childTarget: metadata.childTarget } : {}),
+		...(params.message?.trim() ? { question: params.message.trim() } : {}),
 		...(params.interview !== undefined ? { interview: params.interview } : {}),
 	};
 	const serialized = JSON.stringify(request, null, "\t");
@@ -633,18 +640,23 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 			else {
 				removeRequestFile(request.requestFile);
 			}
+			const presentation = resolveChildPresentation(state, request.runId, request.agent, request.childIndex);
+			const messageDetails: SupervisorRequestMessageDetails = {
+				id: request.id,
+				reason: request.reason,
+				expectsReply: request.expectsReply,
+				runId: request.runId,
+				agent: request.agent,
+				childIndex: request.childIndex,
+				...presentation,
+				...(request.question ? { question: request.question } : {}),
+				...(request.interview !== undefined ? { interview: request.interview } : {}),
+			};
 			pi.sendMessage({
-				customType: "subagent_supervisor_request",
+				customType: SUBAGENT_SUPERVISOR_MESSAGE_TYPE,
 				content: requestVisibleText(request),
 				display: true,
-				details: {
-					id: request.id,
-					reason: request.reason,
-					expectsReply: request.expectsReply,
-					runId: request.runId,
-					agent: request.agent,
-					childIndex: request.childIndex,
-				},
+				details: messageDetails,
 			});
 			if (request.expectsReply) {
 				(pi as { events?: IntercomEventBus }).events?.emit(INTERCOM_DETACH_REQUEST_EVENT, {

--- a/test/unit/control-notices.test.ts
+++ b/test/unit/control-notices.test.ts
@@ -4,7 +4,22 @@ import {
 	clearPendingForegroundControlNotices,
 	handleSubagentControlNotice,
 } from "../../src/extension/control-notices.ts";
+import { formatControlNoticeMessage } from "../../src/runs/shared/subagent-control.ts";
 import type { ControlEvent, SubagentState } from "../../src/shared/types.ts";
+
+interface SentControlNotice {
+	customType: string;
+	content: string;
+	display: boolean;
+	details: {
+		event: ControlEvent;
+		label?: string;
+		role?: string;
+		logicalStep?: number;
+		totalSteps?: number;
+		noticeText?: string;
+	};
+}
 
 function makeState(): SubagentState {
 	return {
@@ -55,20 +70,53 @@ function wait(ms: number): Promise<void> {
 }
 
 describe("subagent control notice delivery", () => {
-	it("delivers async needs-attention notices immediately", () => {
+	it("delivers async needs-attention notices immediately without changing model-facing content", () => {
 		const state = makeState();
+		state.asyncJobs.set("run-1", {
+			asyncId: "run-1",
+			asyncDir: "/tmp/run-1",
+			status: "running",
+			mode: "chain",
+			chainStepCount: 2,
+			steps: [
+				{ index: 0, agent: "worker", label: "Implement API", status: "running" },
+				{ index: 1, agent: "tester", label: "Validate", status: "pending" },
+			],
+		});
 		const recorder = makeRecorder();
+		const event = needsAttentionEvent({
+			message: "worker needs attention with complete diagnostics",
+			currentPath: "/tmp/project/src/index.ts",
+			toolCount: 7,
+		});
+		const expectedModelContent = formatControlNoticeMessage(event);
 
 		handleSubagentControlNotice({
 			pi: recorder.pi,
 			state,
 			visibleControlNotices: new Set(),
-			details: { source: "async", event: needsAttentionEvent() },
+			details: { source: "async", event },
 			foregroundDelayMs: 20,
 		});
 
 		assert.equal(recorder.sent.length, 1);
 		assert.deepEqual(recorder.sent[0]?.options, { triggerTurn: true });
+		const message = recorder.sent[0]?.message as SentControlNotice;
+		assert.equal(message.content, expectedModelContent);
+		assert.equal(message.details.noticeText, expectedModelContent);
+		assert.match(message.content, /worker needs attention with complete diagnostics/);
+		assert.match(message.content, /Status: subagent\(\{ action: "status"/);
+		assert.deepEqual({
+			label: message.details.label,
+			role: message.details.role,
+			logicalStep: message.details.logicalStep,
+			totalSteps: message.details.totalSteps,
+		}, {
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 1,
+			totalSteps: 2,
+		});
 	});
 
 	it("queues foreground needs-attention notices until the same step is still actionable", async () => {

--- a/test/unit/human-messages.test.ts
+++ b/test/unit/human-messages.test.ts
@@ -90,6 +90,46 @@ describe("compact human message formatting", () => {
 		assert.match(rendered, /Recommendation: inspect current status/);
 	});
 
+	it("uses safe legacy control content as an expanded structured fallback only", () => {
+		const legacyContent = [
+			"Subagent needs attention: worker",
+			"Run: 12345678-abcd-4abc-8abc-1234567890ab step 3",
+			"Signal: The compiler found a compatibility regression in the public API.",
+			"Recent failures: npm test failed in compatibility.test.ts",
+			"Facts: 9 turns | 17 tools",
+			"Hint: Inspect the failing assertion before changing the implementation.",
+			'Status: subagent({ action: "status", id: "12345678-abcd-4abc-8abc-1234567890ab" })',
+			'Interrupt: subagent({ action: "interrupt", id: "12345678-abcd-4abc-8abc-1234567890ab" })',
+			"Direct intercom target: internal-worker-channel",
+		].join("\n");
+		const details = {
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 4,
+			event: controlEvent({
+				message: "",
+				currentTool: undefined,
+				currentPath: undefined,
+				recentFailureSummary: undefined,
+				turns: undefined,
+				tokens: undefined,
+				toolCount: undefined,
+			}),
+		};
+
+		const collapsed = formatHumanControlNotice(details, false, "Alt+E", legacyContent);
+		const expanded = formatHumanControlNotice(details, true, "Alt+E", legacyContent);
+
+		assert.match(collapsed, /Alt\+E for details/);
+		assert.doesNotMatch(collapsed, /compatibility regression|subagent\s*\(|intercom target/i);
+		assert.match(expanded, /Observed: The compiler found a compatibility regression in the public API\./);
+		assert.match(expanded, /Recent failures: npm test failed in compatibility\.test\.ts/);
+		assert.match(expanded, /Diagnostics: 9 turns \| 17 tools/);
+		assert.match(expanded, /Recommendation: Inspect the failing assertion/);
+		assert.doesNotMatch(expanded, /subagent\s*\(|intercom target|internal-worker-channel|action: "(?:status|interrupt)"/i);
+	});
+
 	it("renders supervisor requests compactly and expands the complete question and interview", () => {
 		const details = supervisorDetails({
 			reason: "interview_request",
@@ -110,6 +150,41 @@ describe("compact human message formatting", () => {
 		assert.match(expanded, /Should the API return 404 or 410\?\nThe compatibility contract is ambiguous\./);
 		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice/);
 		assert.match(expanded, /Questions:\n  - Id: status\n    Choices:\n      - 404\n      - 410/);
+	});
+
+	it("extracts complete legacy questions and interviews without rendering commands or raw JSON", () => {
+		const legacyContent = [
+			"Subagent requests a structured supervisor interview.",
+			"Run: abcdef12-abcd-4abc-8abc-1234567890ab",
+			"Agent: worker",
+			"Child index: 1",
+			"Child intercom target: internal-worker-channel",
+			"",
+			"Which status preserves compatibility?",
+			"Include the migration impact in the decision.",
+			"",
+			"Structured response requested. Reply with JSON, optionally fenced in ```json, matching the requested interview shape.",
+			JSON.stringify({
+				title: "Compatibility choice",
+				questions: [{ id: "status", prompt: "Select the status", choices: [404, 410] }],
+			}, null, "\t"),
+			"",
+			'Reply with: subagent_supervisor({ action: "reply", replyTo: "request-123", message: "..." })',
+		].join("\n");
+		const details = supervisorDetails({ reason: "interview_request", question: undefined, interview: undefined });
+
+		const collapsed = formatHumanSupervisorRequest(details, false, "Alt+E", legacyContent);
+		const expanded = formatHumanSupervisorRequest(details, true, "Alt+E", legacyContent);
+
+		assert.equal(collapsed, [
+			"⚠ Supervisor interview needed · Implement API [worker]",
+			"Which status preserves compatibility? · Step 2/4 · run abcdef12 · Alt+E for details",
+		].join("\n"));
+		assert.match(expanded, /Which status preserves compatibility\?\nInclude the migration impact in the decision\./);
+		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice/);
+		assert.match(expanded, /Prompt: Select the status/);
+		assert.match(expanded, /Choices:\n      - 404\n      - 410/);
+		assert.doesNotMatch(expanded, /subagent_supervisor\s*\(|replyTo|internal-worker-channel|[{}]|"questions"/i);
 	});
 
 	it("keeps progress updates visually informational and marks them as no-reply", () => {

--- a/test/unit/human-messages.test.ts
+++ b/test/unit/human-messages.test.ts
@@ -130,11 +130,35 @@ describe("compact human message formatting", () => {
 		assert.doesNotMatch(expanded, /subagent\s*\(|intercom target|internal-worker-channel|action: "(?:status|interrupt)"/i);
 	});
 
+	it("prefers complete structured control fields over lossy legacy summaries", () => {
+		const details = {
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 4,
+			event: controlEvent({
+				message: "First observed line.\nSecond observed line.",
+				recentFailureSummary: "First failure line.\nSecond failure line.",
+			}),
+		};
+		const legacyContent = [
+			"Signal: Truncated legacy observation",
+			"Recent failures: Truncated legacy failure",
+		].join("\n");
+
+		const expanded = formatHumanControlNotice(details, true, "Ctrl+O", legacyContent);
+
+		assert.match(expanded, /Observed: First observed line\.\nSecond observed line\./);
+		assert.match(expanded, /Recent failures: First failure line\.\nSecond failure line\./);
+		assert.doesNotMatch(expanded, /Truncated legacy/);
+	});
+
 	it("renders supervisor requests compactly and expands the complete question and interview", () => {
 		const details = supervisorDetails({
 			reason: "interview_request",
 			interview: {
 				title: "Compatibility choice",
+				action: "choose release strategy",
 				questions: [{ id: "status", choices: [404, 410] }],
 			},
 		});
@@ -148,7 +172,7 @@ describe("compact human message formatting", () => {
 		assert.doesNotMatch(collapsed, /compatibility contract|Compatibility choice|Choices/);
 		assert.match(expanded, /Reply required/);
 		assert.match(expanded, /Should the API return 404 or 410\?\nThe compatibility contract is ambiguous\./);
-		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice/);
+		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice\nAction: choose release strategy/);
 		assert.match(expanded, /Questions:\n  - Id: status\n    Choices:\n      - 404\n      - 410/);
 	});
 

--- a/test/unit/human-messages.test.ts
+++ b/test/unit/human-messages.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	formatHumanControlNotice,
+	formatHumanSupervisorRequest,
+	resolveChildPresentation,
+	type SupervisorRequestMessageDetails,
+} from "../../src/extension/human-messages.ts";
+import type { ControlEvent, SubagentState } from "../../src/shared/types.ts";
+
+function controlEvent(overrides: Partial<ControlEvent> = {}): ControlEvent {
+	return {
+		type: "needs_attention",
+		to: "needs_attention",
+		ts: 1,
+		runId: "12345678-abcd-4abc-8abc-1234567890ab",
+		agent: "worker",
+		index: 2,
+		message: "No child activity was observed during the attention window.",
+		reason: "idle",
+		elapsedMs: 125_000,
+		currentTool: "bash",
+		currentToolDurationMs: 65_000,
+		currentPath: "/tmp/project/src/index.ts",
+		recentFailureSummary: "npm test exited 1",
+		turns: 8,
+		tokens: 4321,
+		toolCount: 12,
+		...overrides,
+	};
+}
+
+function supervisorDetails(overrides: Partial<SupervisorRequestMessageDetails> = {}): SupervisorRequestMessageDetails {
+	return {
+		id: "request-123",
+		reason: "need_decision",
+		expectsReply: true,
+		runId: "abcdef12-abcd-4abc-8abc-1234567890ab",
+		agent: "worker",
+		childIndex: 1,
+		label: "Implement API",
+		role: "worker",
+		logicalStep: 2,
+		totalSteps: 4,
+		question: "Should the API return 404 or 410?\nThe compatibility contract is ambiguous.",
+		...overrides,
+	};
+}
+
+function presentationState(): Pick<SubagentState, "asyncJobs" | "foregroundRuns"> {
+	return {
+		asyncJobs: new Map(),
+		foregroundRuns: new Map(),
+	};
+}
+
+describe("compact human message formatting", () => {
+	it("renders control notices compact by default without verbose diagnostics", () => {
+		const rendered = formatHumanControlNotice({
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 4,
+			event: controlEvent(),
+		}, false, "Ctrl+O");
+
+		assert.equal(rendered, [
+			"⚠ Implement API [worker] may be stuck · no activity for 2m 5s",
+			"Step 2/4 · run 12345678 · Ctrl+O for details",
+		].join("\n"));
+		assert.doesNotMatch(rendered, /No child activity|\/tmp\/project|npm test|4321/);
+	});
+
+	it("renders complete control diagnostics when expanded", () => {
+		const rendered = formatHumanControlNotice({
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 4,
+			event: controlEvent(),
+		}, true, "Ctrl+O");
+
+		assert.match(rendered, /^⚠ Implement API \[worker\] may be stuck/);
+		assert.match(rendered, /Implement API \[worker\] · Step 2\/4 · run 12345678/);
+		assert.match(rendered, /Observed: No child activity was observed during the attention window\./);
+		assert.match(rendered, /Current activity: bash for 1m 5s/);
+		assert.match(rendered, /Working in: \/tmp\/project\/src\/index\.ts/);
+		assert.match(rendered, /Recent failures: npm test exited 1/);
+		assert.match(rendered, /Diagnostics: 8 turns · 4321 tokens · 12 tools/);
+		assert.match(rendered, /Recommendation: inspect current status/);
+	});
+
+	it("renders supervisor requests compactly and expands the complete question and interview", () => {
+		const details = supervisorDetails({
+			reason: "interview_request",
+			interview: {
+				title: "Compatibility choice",
+				questions: [{ id: "status", choices: [404, 410] }],
+			},
+		});
+		const collapsed = formatHumanSupervisorRequest(details, false, "Ctrl+O");
+		const expanded = formatHumanSupervisorRequest(details, true, "Ctrl+O");
+
+		assert.equal(collapsed, [
+			"⚠ Supervisor interview needed · Implement API [worker]",
+			"Should the API return 404 or 410? · Step 2/4 · run abcdef12 · Ctrl+O for details",
+		].join("\n"));
+		assert.doesNotMatch(collapsed, /compatibility contract|Compatibility choice|Choices/);
+		assert.match(expanded, /Reply required/);
+		assert.match(expanded, /Should the API return 404 or 410\?\nThe compatibility contract is ambiguous\./);
+		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice/);
+		assert.match(expanded, /Questions:\n  - Id: status\n    Choices:\n      - 404\n      - 410/);
+	});
+
+	it("keeps progress updates visually informational and marks them as no-reply", () => {
+		const rendered = formatHumanSupervisorRequest(supervisorDetails({
+			reason: "progress_update",
+			expectsReply: false,
+			question: "Validation is now passing.",
+		}), true, "Ctrl+O");
+
+		assert.match(rendered, /^↗ Implement API \[worker\] · progress update/);
+		assert.match(rendered, /No reply required/);
+		assert.match(rendered, /Validation is now passing\./);
+	});
+});
+
+describe("child presentation details", () => {
+	it("uses async labels and logical chain positions for flattened parallel children", () => {
+		const state = presentationState();
+		state.asyncJobs.set("run-chain", {
+			asyncId: "run-chain",
+			asyncDir: "/tmp/run-chain",
+			status: "running",
+			mode: "chain",
+			chainStepCount: 3,
+			parallelGroups: [{ start: 1, count: 2, stepIndex: 1 }],
+			steps: [
+				{ index: 0, agent: "scout", label: "Discover", status: "complete" },
+				{ index: 1, agent: "reviewer", label: "API review", status: "running" },
+				{ index: 2, agent: "worker", label: "Implementation", status: "running" },
+				{ index: 3, agent: "tester", label: "Validate", status: "pending" },
+			],
+		});
+
+		assert.deepEqual(resolveChildPresentation(state, "run-chain", "worker", 2), {
+			label: "Implementation",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 3,
+		});
+	});
+
+	it("falls back to stable agent and child-index details when run metadata is unavailable", () => {
+		assert.deepEqual(resolveChildPresentation(presentationState(), "missing-run", "worker", 3), {
+			label: "worker",
+			role: "worker",
+			logicalStep: 4,
+		});
+	});
+});

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -48,7 +48,19 @@ function makeState(sessionId: string | null, ctx: unknown): SubagentState {
 	};
 }
 
-function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string; createdAt?: number; expiresAt?: number }): string {
+function writeRequest(input: {
+	sessionId: string;
+	runId: string;
+	agent?: string;
+	index?: number;
+	message?: string;
+	question?: string;
+	reason?: "need_decision" | "interview_request" | "progress_update";
+	expectsReply?: boolean;
+	interview?: unknown;
+	createdAt?: number;
+	expiresAt?: number;
+}): string {
 	const agent = input.agent ?? "worker";
 	const index = input.index ?? 0;
 	const channelDir = resolveSupervisorChannelDir(input.runId, agent, index);
@@ -60,14 +72,16 @@ function writeRequest(input: { sessionId: string; runId: string; agent?: string;
 		id: requestId,
 		createdAt: input.createdAt ?? Date.now(),
 		...(input.expiresAt !== undefined ? { expiresAt: input.expiresAt } : {}),
-		reason: "need_decision",
+		reason: input.reason ?? "need_decision",
 		message: input.message ?? "Need a decision",
-		expectsReply: true,
+		expectsReply: input.expectsReply ?? true,
 		orchestratorSessionId: input.sessionId,
 		orchestratorTarget: "shared-name",
 		runId: input.runId,
 		agent,
 		childIndex: index,
+		...(input.question ? { question: input.question } : {}),
+		...(input.interview !== undefined ? { interview: input.interview } : {}),
 	}, null, "\t"));
 	return requestId;
 }
@@ -140,6 +154,90 @@ describe("native supervisor channel", () => {
 		assert.deepEqual(sent.map((message) => message.details?.id), [matchingId]);
 		assert.equal(channel.pending.has(matchingId), false, "disposed channel clears pending requests");
 		assert.equal(sent.some((message) => message.details?.id === otherId), false);
+	});
+
+	it("adds complete structured presentation details without changing model-facing request content", () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const modelContent = [
+			"Subagent requests a structured supervisor interview.",
+			`Run: ${runId}`,
+			"Agent: worker",
+			"Child index: 1",
+			"",
+			"Choose the compatible status code. Full context remains model-visible.",
+			"",
+			"Structured response requested. Reply with JSON matching the requested interview shape.",
+			'{"choices":[404,410]}',
+		].join("\n");
+		const question = "Choose the compatible status code.\nFull context remains model-visible.";
+		const interview = { title: "Status code", questions: [{ id: "status", choices: [404, 410] }] };
+		const requestId = writeRequest({
+			sessionId: currentSessionId,
+			runId,
+			index: 1,
+			reason: "interview_request",
+			message: modelContent,
+			question,
+			interview,
+		});
+		const sent: Array<{
+			customType?: string;
+			content?: string;
+			display?: boolean;
+			details?: Record<string, unknown>;
+		}> = [];
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const state = makeState(currentSessionId, ctx);
+		state.asyncJobs.set(runId, {
+			asyncId: runId,
+			asyncDir: `/tmp/${runId}`,
+			status: "running",
+			mode: "chain",
+			chainStepCount: 3,
+			steps: [
+				{ index: 0, agent: "scout", label: "Discover", status: "complete" },
+				{ index: 1, agent: "worker", label: "Implement API", status: "running" },
+				{ index: 2, agent: "tester", label: "Validate", status: "pending" },
+			],
+		});
+		const pi = {
+			getAllTools: () => [],
+			registerTool: () => {},
+			sendMessage: (message: typeof sent[number]) => { sent.push(message); },
+			getSessionName: () => "shared-name",
+		};
+		const channel = createNativeSupervisorChannel(pi as never, state);
+
+		channel.start();
+		channel.dispose();
+
+		assert.equal(sent.length, 1);
+		assert.equal(sent[0]?.customType, "subagent_supervisor_request");
+		assert.equal(sent[0]?.display, true);
+		assert.equal(sent[0]?.content, `${modelContent}\n\nReply with: ${NATIVE_SUPERVISOR_TOOL_NAME}({ action: "reply", replyTo: "${requestId}", message: "..." })`);
+		assert.deepEqual(sent[0]?.details, {
+			id: requestId,
+			reason: "interview_request",
+			expectsReply: true,
+			runId,
+			agent: "worker",
+			childIndex: 1,
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 3,
+			question,
+			interview,
+		});
 	});
 
 	it("prunes stale empty supervisor channel directories before polling", () => {


### PR DESCRIPTION
## Summary
- add compact collapsed renderers for control notices and supervisor requests
- keep expanded human details substantive while hiding raw command JSON, full UUIDs, and intercom internals
- preserve complete model-facing content and support legacy persisted/in-flight messages
- respect the configured expand key and retain structured interviews, including arbitrary fields

## Validation
- focused control, human-message, and supervisor-channel tests passed
- final human-message suite: 9/9 passed
- `git diff --check` passed

## Compatibility
This changes presentation only. Model-facing instructions, reply commands, persisted content, and delivery semantics remain intact.