### PR TITLE
feat: make subagent control notices compact and actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 
 ### Fixed
+- Revalidated debounced foreground and async attention notices against the exact active child before display, canceling stale delivery across recovery and lifecycle resets. In-flight tools now stay active instead of becoming ordinary idle attention, and activity epochs allow a later genuine stall to notify without replaying restored history.
 - Moved the published extension entrypoint to the package root so Pi displays the startup label as `pi-subagents` instead of an internal source path. Thanks to Ramin Hazegh (@rhazegh) for #475.
 - Accepted empty optional `manualNotes` and `notes` strings in acceptance reports while retaining the `manual-notes` evidence requirement when configured. Thanks to Nick Tripp (@nicholastripp) for #474.
 - Kept explicit child tool allowlists strict while surfacing actionable errors when named extension tools are requested without a loaded provider. Internal `structured_output` is now admitted automatically when an output schema is active, and direct and chained children share the same registry check. Thanks to DesertThief (@DesertThief) for #429 and Chris-Kode (@Chris-Kode) for confirming the structured-output case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Added a chain quick-reference (sequential, parallel fan-out, and mixed examples) to the `subagent` tool description in both full and compact modes so agents have the correct nested schema format up front. Thanks to Nicolas Marchildon (@elecnix) for #417 and #424.
 
 ### Changed
+- Made visible subagent control notices and native supervisor requests compact by default, with full human-readable diagnostics and structured request details available through Pi's expand key while preserving complete model-facing message content.
 - Updated the bundled `pi-subagents` skill so Fable mode is the default orchestration posture for complex work, and refreshed recent command/config guidance.
 - Documented `contact_supervisor` structured interview requests in the default child bridge instructions.
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ The child can use one dedicated coordination tool:
 
 The parent replies with `subagent_supervisor({ action: "reply", replyTo, message })` or checks pending requests with `subagent_supervisor({ action: "pending" })`. Supervisor messages are scoped to the exact Pi session id that spawned the child. A second Pi session in the same repository does not receive those requests.
 
+Visible supervisor requests and subagent control notices use a compact human summary by default. Press Pi's configured expand key (`Ctrl+O` by default) to show the full question, structured interview, or control diagnostics. This only changes terminal presentation: the complete control or coordination message remains in the conversation for the parent model.
+
 Child-side routine completion handoffs are still not expected. If a child appears stalled, needs-attention notices can show up in the parent session with useful next actions, such as checking `subagent({ action: "status" })`, interrupting the run, or nudging the child.
 
 If messages do not show up, run:

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ The parent replies with `subagent_supervisor({ action: "reply", replyTo, message
 
 Visible supervisor requests and subagent control notices use a compact human summary by default. Press Pi's configured expand key (`Ctrl+O` by default) to show the full question, structured interview, or control diagnostics. This only changes terminal presentation: the complete control or coordination message remains in the conversation for the parent model.
 
-Child-side routine completion handoffs are still not expected. If a child appears stalled, needs-attention notices can show up in the parent session with useful next actions, such as checking `subagent({ action: "status" })`, interrupting the run, or nudging the child.
+Child-side routine completion handoffs are still not expected. If a child appears stalled, needs-attention notices can show up in the parent session with useful next actions, such as checking `subagent({ action: "status" })`, interrupting the run, or nudging the child. Delivery is debounced and revalidated against the exact live run and child, so recovery, newer activity, completion, stop, reset, reload, or run ownership replacement suppresses stale notices. A later genuine stall can notify again after activity begins a new interval. Known in-flight tools remain active (and may become `active_long_running`) rather than being classified as ordinary idle time. Control thresholds remain configurable through `needsAttentionAfterMs` and `activeNoticeAfterMs`; their defaults remain 60 seconds and 4 minutes.
 
 If messages do not show up, run:
 

--- a/src/extension/control-notices.ts
+++ b/src/extension/control-notices.ts
@@ -1,10 +1,11 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { controlNotificationKey, formatControlNoticeMessage } from "../runs/shared/subagent-control.ts";
 import type { ControlEvent, SubagentState } from "../shared/types.ts";
+import { resolveChildPresentation, type ChildPresentationDetails } from "./human-messages.ts";
 
 export const SUBAGENT_CONTROL_MESSAGE_TYPE = "subagent_control_notice";
 
-export interface SubagentControlMessageDetails {
+export interface SubagentControlMessageDetails extends Partial<ChildPresentationDetails> {
 	event: ControlEvent;
 	source?: "foreground" | "async";
 	asyncDir?: string;
@@ -37,6 +38,7 @@ export function clearPendingForegroundControlNotices(state: SubagentState, runId
 
 function deliverControlNotice(input: {
 	pi: Pick<ExtensionAPI, "sendMessage">;
+	state: SubagentState;
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;
 }): void {
@@ -45,12 +47,18 @@ function deliverControlNotice(input: {
 	if (input.visibleControlNotices.has(key)) return;
 	input.visibleControlNotices.add(key);
 	const noticeText = input.details.noticeText ?? formatControlNoticeMessage(input.details.event, childIntercomTarget);
+	const presentation = resolveChildPresentation(
+		input.state,
+		input.details.event.runId,
+		input.details.event.agent,
+		input.details.event.index,
+	);
 	input.pi.sendMessage(
 		{
 			customType: SUBAGENT_CONTROL_MESSAGE_TYPE,
 			content: noticeText,
 			display: true,
-			details: { ...input.details, childIntercomTarget, noticeText },
+			details: { ...input.details, ...presentation, childIntercomTarget, noticeText },
 		},
 		{ triggerTurn: input.details.source !== "foreground" },
 	);

--- a/src/extension/control-notices.ts
+++ b/src/extension/control-notices.ts
@@ -4,7 +4,13 @@ import {
 	formatControlNoticeMessage,
 	isControlEventActionable,
 } from "../runs/shared/subagent-control.ts";
-import type { AsyncStatus, ControlEvent, SubagentState } from "../shared/types.ts";
+import {
+	SUBAGENT_CONTROL_EVENT,
+	SUBAGENT_CONTROL_INTERCOM_EVENT,
+	type AsyncStatus,
+	type ControlEvent,
+	type SubagentState,
+} from "../shared/types.ts";
 import { readStatus } from "../shared/utils.ts";
 import { resolveChildPresentation, type ChildPresentationDetails } from "./human-messages.ts";
 
@@ -16,6 +22,8 @@ export interface SubagentControlMessageDetails extends Partial<ChildPresentation
 	asyncDir?: string;
 	childIntercomTarget?: string;
 	noticeText?: string;
+	channels?: string[];
+	intercom?: { to?: string; message?: string };
 }
 
 export function controlNoticeTarget(details: SubagentControlMessageDetails): string | undefined {
@@ -42,7 +50,7 @@ export function clearPendingForegroundControlNotices(state: SubagentState, runId
 }
 
 function deliverControlNotice(input: {
-	pi: Pick<ExtensionAPI, "sendMessage">;
+	pi: Pick<ExtensionAPI, "events" | "sendMessage">;
 	state: SubagentState;
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;
@@ -50,23 +58,41 @@ function deliverControlNotice(input: {
 	const childIntercomTarget = controlNoticeTarget(input.details);
 	const key = controlNotificationKey(input.details.event, childIntercomTarget);
 	if (input.visibleControlNotices.has(key)) return;
+	const channels = input.details.channels ?? ["event"];
+	const deliverVisible = channels.includes("event");
+	const deliverIntercom = channels.includes("intercom")
+		&& input.details.event.type !== "active_long_running"
+		&& typeof input.details.intercom?.to === "string"
+		&& typeof input.details.intercom.message === "string";
+	if (!deliverVisible && !deliverIntercom) return;
 	input.visibleControlNotices.add(key);
 	const noticeText = input.details.noticeText ?? formatControlNoticeMessage(input.details.event, childIntercomTarget);
-	const presentation = resolveChildPresentation(
-		input.state,
-		input.details.event.runId,
-		input.details.event.agent,
-		input.details.event.index,
-	);
-	input.pi.sendMessage(
-		{
-			customType: SUBAGENT_CONTROL_MESSAGE_TYPE,
-			content: noticeText,
-			display: true,
-			details: { ...input.details, ...presentation, childIntercomTarget, noticeText },
-		},
-		{ triggerTurn: input.details.source !== "foreground" },
-	);
+	if (deliverVisible) {
+		const presentation = resolveChildPresentation(
+			input.state,
+			input.details.event.runId,
+			input.details.event.agent,
+			input.details.event.index,
+		);
+		const details = { ...input.details, ...presentation, childIntercomTarget, noticeText };
+		input.pi.events.emit(SUBAGENT_CONTROL_EVENT, details);
+		input.pi.sendMessage(
+			{
+				customType: SUBAGENT_CONTROL_MESSAGE_TYPE,
+				content: noticeText,
+				display: true,
+				details,
+			},
+			{ triggerTurn: input.details.source !== "foreground" },
+		);
+	}
+	if (deliverIntercom) {
+		input.pi.events.emit(SUBAGENT_CONTROL_INTERCOM_EVENT, {
+			...input.details,
+			to: input.details.intercom!.to,
+			message: input.details.intercom!.message,
+		});
+	}
 }
 
 function asyncStatusSnapshot(status: AsyncStatus, event: ControlEvent) {
@@ -79,6 +105,7 @@ function asyncStatusSnapshot(status: AsyncStatus, event: ControlEvent) {
 		state: status.state,
 		agent: step.agent,
 		index,
+		status: step.status,
 		activityState: step.activityState,
 		lastActivityAt: step.lastActivityAt,
 		currentTool: step.currentTool,
@@ -100,11 +127,22 @@ function isNoticeStillActionable(state: SubagentState, details: SubagentControlM
 
 	const control = state.foregroundControls.get(details.event.runId);
 	if (!control) return false;
-	return isControlEventActionable(details.event, {
+	const child = details.event.index !== undefined ? control.childSnapshots?.get(details.event.index) : undefined;
+	return isControlEventActionable(details.event, child ? {
+		runId: control.runId,
+		state: "running",
+		agent: child.agent,
+		index: details.event.index,
+		status: child.status,
+		activityState: child.activityState,
+		lastActivityAt: child.lastActivityAt,
+		currentTool: child.currentTool,
+	} : {
 		runId: control.runId,
 		state: "running",
 		agent: control.currentAgent,
 		index: control.currentIndex,
+		status: control.currentStatus,
 		activityState: control.currentActivityState,
 		lastActivityAt: control.lastActivityAt,
 		currentTool: control.currentTool,
@@ -112,7 +150,7 @@ function isNoticeStillActionable(state: SubagentState, details: SubagentControlM
 }
 
 export function handleSubagentControlNotice(input: {
-	pi: Pick<ExtensionAPI, "sendMessage">;
+	pi: Pick<ExtensionAPI, "events" | "sendMessage">;
 	state: SubagentState;
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;

--- a/src/extension/control-notices.ts
+++ b/src/extension/control-notices.ts
@@ -1,6 +1,11 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { controlNotificationKey, formatControlNoticeMessage } from "../runs/shared/subagent-control.ts";
-import type { ControlEvent, SubagentState } from "../shared/types.ts";
+import {
+	controlNotificationKey,
+	formatControlNoticeMessage,
+	isControlEventActionable,
+} from "../runs/shared/subagent-control.ts";
+import type { AsyncStatus, ControlEvent, SubagentState } from "../shared/types.ts";
+import { readStatus } from "../shared/utils.ts";
 import { resolveChildPresentation, type ChildPresentationDetails } from "./human-messages.ts";
 
 export const SUBAGENT_CONTROL_MESSAGE_TYPE = "subagent_control_notice";
@@ -64,12 +69,46 @@ function deliverControlNotice(input: {
 	);
 }
 
-function isForegroundNoticeStillActionable(state: SubagentState, details: SubagentControlMessageDetails): boolean {
+function asyncStatusSnapshot(status: AsyncStatus, event: ControlEvent) {
+	const index = event.index ?? status.currentStep ?? (status.steps?.length === 1 ? 0 : undefined);
+	if (index === undefined) return undefined;
+	const step = status.steps?.[index];
+	if (!step) return undefined;
+	return {
+		runId: status.runId,
+		state: status.state,
+		agent: step.agent,
+		index,
+		activityState: step.activityState,
+		lastActivityAt: step.lastActivityAt,
+		currentTool: step.currentTool,
+	};
+}
+
+function isNoticeStillActionable(state: SubagentState, details: SubagentControlMessageDetails): boolean {
+	if (details.source === "async") {
+		const job = state.asyncJobs.get(details.event.runId);
+		if (!job || job.status !== "running") return false;
+		let status: AsyncStatus | null;
+		try {
+			status = readStatus(details.asyncDir ?? job.asyncDir);
+		} catch {
+			return false;
+		}
+		return status !== null && isControlEventActionable(details.event, asyncStatusSnapshot(status, details.event));
+	}
+
 	const control = state.foregroundControls.get(details.event.runId);
 	if (!control) return false;
-	if (control.currentAgent && control.currentAgent !== details.event.agent) return false;
-	if (details.event.index !== undefined && control.currentIndex !== details.event.index) return false;
-	return control.currentActivityState === "needs_attention";
+	return isControlEventActionable(details.event, {
+		runId: control.runId,
+		state: "running",
+		agent: control.currentAgent,
+		index: control.currentIndex,
+		activityState: control.currentActivityState,
+		lastActivityAt: control.lastActivityAt,
+		currentTool: control.currentTool,
+	});
 }
 
 export function handleSubagentControlNotice(input: {
@@ -78,12 +117,9 @@ export function handleSubagentControlNotice(input: {
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;
 	foregroundDelayMs?: number;
+	asyncDelayMs?: number;
 }): void {
-	if (!input.details?.event || input.details.event.type === "active_long_running") return;
-	if (input.details.source !== "foreground") {
-		deliverControlNotice(input);
-		return;
-	}
+	if (!input.details?.event || input.details.event.type === "active_long_running" || input.details.event.reason === "completion_guard") return;
 
 	const pending = input.state.pendingForegroundControlNotices ?? new Map<string, ReturnType<typeof setTimeout>>();
 	input.state.pendingForegroundControlNotices = pending;
@@ -92,9 +128,9 @@ export function handleSubagentControlNotice(input: {
 	if (existing) clearTimeout(existing);
 	const timer = setTimeout(() => {
 		pending.delete(timerKey);
-		if (!isForegroundNoticeStillActionable(input.state, input.details)) return;
+		if (!isNoticeStillActionable(input.state, input.details)) return;
 		deliverControlNotice(input);
-	}, input.foregroundDelayMs ?? 1000);
+	}, input.details.source === "foreground" ? input.foregroundDelayMs ?? 1000 : input.asyncDelayMs ?? 1000);
 	timer.unref?.();
 	pending.set(timerKey, timer);
 }

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -12,7 +12,8 @@ import { deliverSubagentIntercomMessageEvent } from "../intercom/result-intercom
 import { resolveSubagentIntercomTarget } from "../intercom/intercom-bridge.ts";
 import { SubagentParams } from "./schemas.ts";
 import { loadConfig } from "./config.ts";
-import { type Details, type SubagentState } from "../shared/types.ts";
+import { handleSubagentControlNotice, type SubagentControlMessageDetails } from "./control-notices.ts";
+import { SUBAGENT_CONTROL_DELIVERY_EVENT, type Details, type SubagentState } from "../shared/types.ts";
 
 function getSubagentSessionRoot(parentSessionFile: string | null): string {
 	if (parentSessionFile) {
@@ -170,5 +171,9 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 	};
 
 	pi.registerTool(tool);
+	const visibleControlNotices = new Set<string>();
+	pi.events.on(SUBAGENT_CONTROL_DELIVERY_EVENT, (payload) => {
+		handleSubagentControlNotice({ pi, state, visibleControlNotices, details: payload as SubagentControlMessageDetails });
+	});
 	startNestedControlInboxListener(pi, state);
 }

--- a/src/extension/human-messages.ts
+++ b/src/extension/human-messages.ts
@@ -1,0 +1,193 @@
+import { flatToLogicalStepIndex } from "../runs/background/parallel-groups.ts";
+import type { ControlEvent, SubagentState } from "../shared/types.ts";
+
+export const SUBAGENT_SUPERVISOR_MESSAGE_TYPE = "subagent_supervisor_request";
+
+export interface ChildPresentationDetails {
+	label: string;
+	role: string;
+	logicalStep?: number;
+	totalSteps?: number;
+}
+
+export interface SupervisorRequestMessageDetails extends ChildPresentationDetails {
+	id: string;
+	reason: "need_decision" | "interview_request" | "progress_update";
+	expectsReply: boolean;
+	runId: string;
+	agent: string;
+	childIndex: number;
+	question?: string;
+	interview?: unknown;
+}
+
+export interface HumanControlMessageDetails extends ChildPresentationDetails {
+	event: ControlEvent;
+}
+
+export function shortRunId(runId: string): string {
+	return runId.length > 8 ? runId.slice(0, 8) : runId;
+}
+
+function logicalPosition(details: Pick<ChildPresentationDetails, "logicalStep" | "totalSteps">): string | undefined {
+	if (details.logicalStep === undefined) return undefined;
+	return details.totalSteps !== undefined
+		? `Step ${details.logicalStep}/${details.totalSteps}`
+		: `Step ${details.logicalStep}`;
+}
+
+export function resolveChildPresentation(
+	state: Pick<SubagentState, "asyncJobs" | "foregroundRuns">,
+	runId: string,
+	agent: string,
+	childIndex: number | undefined,
+): ChildPresentationDetails {
+	const fallback: ChildPresentationDetails = {
+		label: agent,
+		role: agent,
+		...(childIndex !== undefined ? { logicalStep: childIndex + 1 } : {}),
+	};
+	if (childIndex === undefined) return fallback;
+
+	const asyncJob = state.asyncJobs.get(runId);
+	if (asyncJob) {
+		const step = asyncJob.steps?.find((candidate) => candidate.index === childIndex) ?? asyncJob.steps?.[childIndex];
+		const totalSteps = asyncJob.chainStepCount ?? asyncJob.stepsTotal ?? asyncJob.steps?.length;
+		const logicalIndex = asyncJob.mode === "chain" && asyncJob.chainStepCount !== undefined
+			? flatToLogicalStepIndex(childIndex, asyncJob.chainStepCount, asyncJob.parallelGroups ?? [])
+			: childIndex;
+		return {
+			label: step?.label ?? step?.agent ?? agent,
+			role: step?.agent ?? agent,
+			logicalStep: logicalIndex + 1,
+			...(totalSteps !== undefined ? { totalSteps } : {}),
+		};
+	}
+
+	const foreground = state.foregroundRuns?.get(runId);
+	if (foreground) {
+		const child = foreground.children.find((candidate) => candidate.index === childIndex) ?? foreground.children[childIndex];
+		return {
+			label: child?.agent ?? agent,
+			role: child?.agent ?? agent,
+			logicalStep: childIndex + 1,
+			totalSteps: foreground.children.length,
+		};
+	}
+	return fallback;
+}
+
+function durationLabel(durationMs: number): string {
+	const seconds = Math.max(0, Math.floor(durationMs / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	return seconds % 60 === 0 ? `${minutes}m` : `${minutes}m ${seconds % 60}s`;
+}
+
+function roleLabel(details: ChildPresentationDetails): string {
+	return details.label === details.role ? details.label : `${details.label} [${details.role}]`;
+}
+
+function expandHint(expandKey: string): string {
+	return `${expandKey} for details`;
+}
+
+export function formatHumanControlNotice(
+	details: HumanControlMessageDetails,
+	expanded: boolean,
+	expandKey: string,
+): string {
+	const { event } = details;
+	const position = logicalPosition(details);
+	const run = `run ${shortRunId(event.runId)}`;
+	const subject = roleLabel(details);
+	const elapsed = event.elapsedMs !== undefined ? durationLabel(event.elapsedMs) : undefined;
+	const heading = event.reason === "completion_guard"
+		? `✗ ${subject} failed`
+		: event.type === "active_long_running"
+			? `⚠ ${subject} is still working`
+			: `⚠ ${subject} may be stuck${elapsed ? ` · no activity for ${elapsed}` : ""}`;
+	const location = [position, run].filter(Boolean).join(" · ");
+	if (!expanded) return `${heading}\n${location} · ${expandHint(expandKey)}`;
+
+	const lines = [heading, `${details.label} [${details.role}] · ${location}`];
+	if (event.message.trim()) lines.push(`Observed: ${event.message.trim()}`);
+	if (event.currentTool) {
+		const toolDuration = event.currentToolDurationMs !== undefined ? ` for ${durationLabel(event.currentToolDurationMs)}` : "";
+		lines.push(`Current activity: ${event.currentTool}${toolDuration}`);
+	}
+	if (event.currentPath) lines.push(`Working in: ${event.currentPath}`);
+	if (event.recentFailureSummary) lines.push(`Recent failures: ${event.recentFailureSummary}`);
+	const facts = [
+		event.turns !== undefined ? `${event.turns} turns` : undefined,
+		event.tokens !== undefined ? `${event.tokens} tokens` : undefined,
+		event.toolCount !== undefined ? `${event.toolCount} tools` : undefined,
+	].filter((value): value is string => Boolean(value));
+	if (facts.length > 0) lines.push(`Diagnostics: ${facts.join(" · ")}`);
+	if (event.reason !== "completion_guard") lines.push("Recommendation: inspect current status before nudging or interrupting the child.");
+	return lines.join("\n");
+}
+
+function compactSummary(value: string | undefined): string | undefined {
+	const firstLine = value?.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+	if (!firstLine) return undefined;
+	if (/\b(?:subagent|intercom)\s*\(|\{\s*"?(?:action|replyTo)"?\s*:/i.test(firstLine)) return undefined;
+	const sanitized = firstLine
+		.replace(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi, (id) => id.slice(0, 8))
+		.replace(/\b[A-Za-z]:\\[^\s]+|(?:^|\s)\/(?:[^\s/]+\/)*[^\s]+/g, " [path hidden]")
+		.replace(/\b(?:child\s+)?intercom\s+target\b[^·|]*/gi, "coordination details hidden")
+		.trim();
+	return sanitized.length > 100 ? `${sanitized.slice(0, 99)}…` : sanitized;
+}
+
+function humanizeKey(key: string): string {
+	return key.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replaceAll("_", " ").replace(/^./, (value) => value.toUpperCase());
+}
+
+function formatStructuredValue(value: unknown, indent = ""): string[] {
+	if (value === null || value === undefined) return [];
+	if (typeof value !== "object") return [`${indent}${String(value)}`];
+	if (Array.isArray(value)) {
+		return value.flatMap((entry) => {
+			const lines = formatStructuredValue(entry, `${indent}  `);
+			if (lines.length === 0) return [];
+			return [`${indent}- ${lines[0]!.trimStart()}`, ...lines.slice(1)];
+		});
+	}
+	return Object.entries(value as Record<string, unknown>).flatMap(([key, entry]) => {
+		if (entry === null || entry === undefined) return [];
+		if (typeof entry !== "object") return [`${indent}${humanizeKey(key)}: ${String(entry)}`];
+		return [`${indent}${humanizeKey(key)}:`, ...formatStructuredValue(entry, `${indent}  `)];
+	});
+}
+
+export function formatHumanSupervisorRequest(
+	details: SupervisorRequestMessageDetails,
+	expanded: boolean,
+	expandKey: string,
+): string {
+	const position = logicalPosition(details);
+	const run = `run ${shortRunId(details.runId)}`;
+	const subject = roleLabel(details);
+	const heading = details.reason === "progress_update"
+		? `↗ ${subject} · progress update`
+		: details.reason === "interview_request"
+			? `⚠ Supervisor interview needed · ${subject}`
+			: `⚠ Supervisor decision needed · ${subject}`;
+	const summary = compactSummary(details.question)
+		?? (details.reason === "interview_request" ? "Structured input requested" : undefined);
+	const location = [position, run].filter(Boolean).join(" · ");
+	if (!expanded) {
+		const secondLine = [summary, location, expandHint(expandKey)].filter(Boolean).join(" · ");
+		return secondLine ? `${heading}\n${secondLine}` : heading;
+	}
+
+	const lines = [
+		heading,
+		`${details.label} [${details.role}] · ${location} · ${details.expectsReply ? "Reply required" : "No reply required"}`,
+	];
+	if (details.question?.trim()) lines.push("", details.question.trim());
+	const interviewLines = formatStructuredValue(details.interview);
+	if (interviewLines.length > 0) lines.push("", "Structured interview:", ...interviewLines);
+	return lines.join("\n");
+}

--- a/src/extension/human-messages.ts
+++ b/src/extension/human-messages.ts
@@ -113,14 +113,14 @@ export function formatHumanControlNotice(
 
 	const legacy = extractLegacyControlContent(legacyContent);
 	const lines = [heading, `${details.label} [${details.role}] · ${location}`];
-	const observed = legacy.observed ?? substantiveText(event.message);
+	const observed = substantiveText(event.message) ?? legacy.observed;
 	if (observed) lines.push(`Observed: ${observed}`);
 	if (event.currentTool) {
 		const toolDuration = event.currentToolDurationMs !== undefined ? ` for ${durationLabel(event.currentToolDurationMs)}` : "";
 		lines.push(`Current activity: ${event.currentTool}${toolDuration}`);
 	}
 	if (event.currentPath) lines.push(`Working in: ${event.currentPath}`);
-	const recentFailures = legacy.recentFailures ?? substantiveText(event.recentFailureSummary);
+	const recentFailures = substantiveText(event.recentFailureSummary) ?? legacy.recentFailures;
 	if (recentFailures) lines.push(`Recent failures: ${recentFailures}`);
 	const facts = [
 		event.turns !== undefined ? `${event.turns} turns` : undefined,
@@ -270,7 +270,6 @@ function formatStructuredValue(value: unknown, indent = ""): string[] {
 		});
 	}
 	const record = value as Record<string, unknown>;
-	if (hasInternalCommand(record)) return [];
 	return Object.entries(record).flatMap(([key, entry]) => {
 		if (entry === null || entry === undefined || key === "childTarget") return [];
 		if (typeof entry !== "object") {

--- a/src/extension/human-messages.ts
+++ b/src/extension/human-messages.ts
@@ -96,6 +96,7 @@ export function formatHumanControlNotice(
 	details: HumanControlMessageDetails,
 	expanded: boolean,
 	expandKey: string,
+	legacyContent?: string,
 ): string {
 	const { event } = details;
 	const position = logicalPosition(details);
@@ -110,28 +111,82 @@ export function formatHumanControlNotice(
 	const location = [position, run].filter(Boolean).join(" · ");
 	if (!expanded) return `${heading}\n${location} · ${expandHint(expandKey)}`;
 
+	const legacy = extractLegacyControlContent(legacyContent);
 	const lines = [heading, `${details.label} [${details.role}] · ${location}`];
-	if (event.message.trim()) lines.push(`Observed: ${event.message.trim()}`);
+	const observed = legacy.observed ?? substantiveText(event.message);
+	if (observed) lines.push(`Observed: ${observed}`);
 	if (event.currentTool) {
 		const toolDuration = event.currentToolDurationMs !== undefined ? ` for ${durationLabel(event.currentToolDurationMs)}` : "";
 		lines.push(`Current activity: ${event.currentTool}${toolDuration}`);
 	}
 	if (event.currentPath) lines.push(`Working in: ${event.currentPath}`);
-	if (event.recentFailureSummary) lines.push(`Recent failures: ${event.recentFailureSummary}`);
+	const recentFailures = legacy.recentFailures ?? substantiveText(event.recentFailureSummary);
+	if (recentFailures) lines.push(`Recent failures: ${recentFailures}`);
 	const facts = [
 		event.turns !== undefined ? `${event.turns} turns` : undefined,
 		event.tokens !== undefined ? `${event.tokens} tokens` : undefined,
 		event.toolCount !== undefined ? `${event.toolCount} tools` : undefined,
 	].filter((value): value is string => Boolean(value));
 	if (facts.length > 0) lines.push(`Diagnostics: ${facts.join(" · ")}`);
-	if (event.reason !== "completion_guard") lines.push("Recommendation: inspect current status before nudging or interrupting the child.");
+	else if (legacy.diagnostics) lines.push(`Diagnostics: ${legacy.diagnostics}`);
+	const recommendation = legacy.recommendation
+		?? (event.reason !== "completion_guard" ? "inspect current status before nudging or interrupting the child." : undefined);
+	if (recommendation) lines.push(`Recommendation: ${recommendation}`);
 	return lines.join("\n");
 }
 
+function hasInternalCommand(value: unknown): boolean {
+	if (!value || typeof value !== "object") return false;
+	if (Array.isArray(value)) return value.some(hasInternalCommand);
+	const record = value as Record<string, unknown>;
+	if ("replyTo" in record || ("action" in record && typeof record.action === "string")) return true;
+	return Object.values(record).some(hasInternalCommand);
+}
+
+function isInternalLine(line: string): boolean {
+	return /\b(?:subagent(?:_supervisor)?|intercom)\s*\(\s*\{/i.test(line)
+		|| /"(?:action|replyTo)"\s*:/i.test(line)
+		|| /^\s*(?:Reply with|Nudge|Status|Interrupt):/i.test(line)
+		|| /^\s*(?:Child|Direct|Run) intercom target\s*:/i.test(line);
+}
+
+function withoutInternalJsonBlocks(lines: string[]): string[] {
+	const safe: string[] = [];
+	for (let index = 0; index < lines.length; index += 1) {
+		if (!/^[{[]/.test(lines[index]!.trim())) {
+			safe.push(lines[index]!);
+			continue;
+		}
+		for (let end = index; end < lines.length; end += 1) {
+			try {
+				const parsed = JSON.parse(lines.slice(index, end + 1).join("\n"));
+				if (hasInternalCommand(parsed)) {
+					index = end;
+					break;
+				}
+				safe.push(...lines.slice(index, end + 1));
+				index = end;
+				break;
+			} catch {
+				if (end === lines.length - 1) safe.push(lines[index]!);
+			}
+		}
+	}
+	return safe;
+}
+
+function substantiveText(value: string | undefined): string | undefined {
+	const lines = withoutInternalJsonBlocks(value?.split(/\r?\n/) ?? [])
+		.filter((line) => !isInternalLine(line))
+		.filter((line) => !/^\s*[{}[\],]+\s*$/.test(line))
+		.map((line) => line.trimEnd());
+	const text = lines?.join("\n").trim();
+	return text || undefined;
+}
+
 function compactSummary(value: string | undefined): string | undefined {
-	const firstLine = value?.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+	const firstLine = substantiveText(value)?.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
 	if (!firstLine) return undefined;
-	if (/\b(?:subagent|intercom)\s*\(|\{\s*"?(?:action|replyTo)"?\s*:/i.test(firstLine)) return undefined;
 	const sanitized = firstLine
 		.replace(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi, (id) => id.slice(0, 8))
 		.replace(/\b[A-Za-z]:\\[^\s]+|(?:^|\s)\/(?:[^\s/]+\/)*[^\s]+/g, " [path hidden]")
@@ -140,13 +195,73 @@ function compactSummary(value: string | undefined): string | undefined {
 	return sanitized.length > 100 ? `${sanitized.slice(0, 99)}…` : sanitized;
 }
 
+interface LegacySupervisorContent {
+	question?: string;
+	interview?: unknown;
+}
+
+function extractLegacySupervisorContent(content: string | undefined): LegacySupervisorContent {
+	if (!content?.trim()) return {};
+	const lines = content.split(/\r?\n/);
+	const structuredIndex = lines.findIndex((line) => /^Structured response requested\./i.test(line.trim()));
+	const replyIndex = lines.findIndex((line) => /^Reply with:/i.test(line.trim()));
+	const questionEnd = structuredIndex >= 0 ? structuredIndex : replyIndex >= 0 ? replyIndex : lines.length;
+	const question = substantiveText(lines.slice(0, questionEnd)
+		.filter((line) => !/^Subagent (?:requests|progress update|needs)/i.test(line.trim()))
+		.filter((line) => !/^(?:Run|Agent|Child index|Child intercom target):/i.test(line.trim()))
+		.join("\n"));
+
+	let interview: unknown;
+	if (structuredIndex >= 0) {
+		const serialized = lines.slice(structuredIndex + 1, replyIndex >= 0 ? replyIndex : lines.length).join("\n").trim();
+		if (serialized) {
+			try {
+				interview = JSON.parse(serialized);
+			} catch {
+				// Legacy content is untrusted display data. Never fall back to showing raw JSON.
+			}
+		}
+	}
+	return { ...(question ? { question } : {}), ...(interview !== undefined ? { interview } : {}) };
+}
+
+interface LegacyControlContent {
+	observed?: string;
+	recentFailures?: string;
+	diagnostics?: string;
+	recommendation?: string;
+}
+
+function extractLegacyControlContent(content: string | undefined): LegacyControlContent {
+	if (!content?.trim()) return {};
+	const result: LegacyControlContent = {};
+	for (const line of content.split(/\r?\n/)) {
+		if (isInternalLine(line)) continue;
+		const match = line.match(/^\s*(Signal|Recent failures|Facts|Hint|Next):\s*(.+?)\s*$/i);
+		if (!match) continue;
+		const value = substantiveText(match[2]);
+		if (!value) continue;
+		switch (match[1]?.toLowerCase()) {
+			case "signal": result.observed = value; break;
+			case "recent failures": result.recentFailures = value; break;
+			case "facts": result.diagnostics = value; break;
+			case "hint":
+			case "next": result.recommendation = value; break;
+		}
+	}
+	return result;
+}
+
 function humanizeKey(key: string): string {
 	return key.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replaceAll("_", " ").replace(/^./, (value) => value.toUpperCase());
 }
 
 function formatStructuredValue(value: unknown, indent = ""): string[] {
 	if (value === null || value === undefined) return [];
-	if (typeof value !== "object") return [`${indent}${String(value)}`];
+	if (typeof value !== "object") {
+		const text = substantiveText(String(value));
+		return text ? [`${indent}${text}`] : [];
+	}
 	if (Array.isArray(value)) {
 		return value.flatMap((entry) => {
 			const lines = formatStructuredValue(entry, `${indent}  `);
@@ -154,10 +269,16 @@ function formatStructuredValue(value: unknown, indent = ""): string[] {
 			return [`${indent}- ${lines[0]!.trimStart()}`, ...lines.slice(1)];
 		});
 	}
-	return Object.entries(value as Record<string, unknown>).flatMap(([key, entry]) => {
-		if (entry === null || entry === undefined) return [];
-		if (typeof entry !== "object") return [`${indent}${humanizeKey(key)}: ${String(entry)}`];
-		return [`${indent}${humanizeKey(key)}:`, ...formatStructuredValue(entry, `${indent}  `)];
+	const record = value as Record<string, unknown>;
+	if (hasInternalCommand(record)) return [];
+	return Object.entries(record).flatMap(([key, entry]) => {
+		if (entry === null || entry === undefined || key === "childTarget") return [];
+		if (typeof entry !== "object") {
+			const text = substantiveText(String(entry));
+			return text ? [`${indent}${humanizeKey(key)}: ${text}`] : [];
+		}
+		const lines = formatStructuredValue(entry, `${indent}  `);
+		return lines.length > 0 ? [`${indent}${humanizeKey(key)}:`, ...lines] : [];
 	});
 }
 
@@ -165,6 +286,7 @@ export function formatHumanSupervisorRequest(
 	details: SupervisorRequestMessageDetails,
 	expanded: boolean,
 	expandKey: string,
+	legacyContent?: string,
 ): string {
 	const position = logicalPosition(details);
 	const run = `run ${shortRunId(details.runId)}`;
@@ -174,7 +296,10 @@ export function formatHumanSupervisorRequest(
 		: details.reason === "interview_request"
 			? `⚠ Supervisor interview needed · ${subject}`
 			: `⚠ Supervisor decision needed · ${subject}`;
-	const summary = compactSummary(details.question)
+	const legacy = extractLegacySupervisorContent(legacyContent);
+	const question = substantiveText(details.question) ?? legacy.question;
+	const interview = details.interview ?? legacy.interview;
+	const summary = compactSummary(question)
 		?? (details.reason === "interview_request" ? "Structured input requested" : undefined);
 	const location = [position, run].filter(Boolean).join(" · ");
 	if (!expanded) {
@@ -186,8 +311,8 @@ export function formatHumanSupervisorRequest(
 		heading,
 		`${details.label} [${details.role}] · ${location} · ${details.expectsReply ? "Reply required" : "No reply required"}`,
 	];
-	if (details.question?.trim()) lines.push("", details.question.trim());
-	const interviewLines = formatStructuredValue(details.interview);
+	if (question) lines.push("", question);
+	const interviewLines = formatStructuredValue(interview);
 	if (interviewLines.length > 0) lines.push("", "Structured interview:", ...interviewLines);
 	return lines.join("\n");
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -57,7 +57,7 @@ import {
 	SLASH_TEXT_RESULT_TYPE,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_ASYNC_STARTED_EVENT,
-	SUBAGENT_CONTROL_EVENT,
+	SUBAGENT_CONTROL_DELIVERY_EVENT,
 	SUBAGENT_STEERING_NOTICE_EVENT,
 	WIDGET_KEY,
 } from "../shared/types.ts";
@@ -511,7 +511,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const eventUnsubscribes = [
 		pi.events.on(SUBAGENT_ASYNC_STARTED_EVENT, handleStarted),
 		pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, handleComplete),
-		pi.events.on(SUBAGENT_CONTROL_EVENT, controlEventHandler),
+		pi.events.on(SUBAGENT_CONTROL_DELIVERY_EVENT, controlEventHandler),
 		pi.events.on(SUBAGENT_STEERING_NOTICE_EVENT, steeringNoticeHandler),
 		rpcBridge.dispose,
 	];

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -264,6 +264,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	const { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs } = createAsyncJobTracker(pi, state, ASYNC_DIR, {
 		widgetEnabled: config.asyncWidget !== false,
+		onRunInactive: (runId) => clearPendingForegroundControlNotices(state, runId),
 	});
 	let executorExecute: ((id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((r: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>) | undefined;
 	const scheduledRunManager = createScheduledRunManager({

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -18,7 +18,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { keyText, type ExtensionAPI, type ExtensionContext, type ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { Box, Container, Spacer, Text, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
+import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import { discoverAgents } from "../agents/agents.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
@@ -63,11 +63,16 @@ import {
 } from "../shared/types.ts";
 import {
 	clearPendingForegroundControlNotices,
-	formatSubagentControlNotice,
 	handleSubagentControlNotice,
 	SUBAGENT_CONTROL_MESSAGE_TYPE,
 	type SubagentControlMessageDetails,
 } from "./control-notices.ts";
+import {
+	formatHumanControlNotice,
+	formatHumanSupervisorRequest,
+	SUBAGENT_SUPERVISOR_MESSAGE_TYPE,
+	type SupervisorRequestMessageDetails,
+} from "./human-messages.ts";
 
 export { loadConfig } from "./config.ts";
 
@@ -181,34 +186,6 @@ function createSlashResultComponent(
 		return Container.prototype.render.call(container, width);
 	};
 	return container;
-}
-
-class SubagentControlNoticeComponent implements Component {
-	constructor(
-		private readonly details: SubagentControlMessageDetails,
-		private readonly theme: ExtensionContext["ui"]["theme"],
-	) {}
-
-	invalidate(): void {}
-
-	render(width: number): string[] {
-		const eventLabel = this.details.event.type.replaceAll("_", " ");
-		if (width < 3) return [truncateToWidth(`Subagent ${eventLabel}`, width)];
-		const bodyWidth = Math.max(1, width - 2);
-		const borderChar = "─";
-		const header = ` ⚠ Subagent ${eventLabel}: ${this.details.event.agent} `;
-		const headerText = truncateToWidth(header, bodyWidth, "");
-		const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
-		const lines = [this.theme.fg("accent", `╭${headerText}${borderChar.repeat(headerPadding)}╮`)];
-
-		for (const line of wrapTextWithAnsi(formatSubagentControlNotice(this.details), bodyWidth)) {
-			const text = truncateToWidth(line, bodyWidth, "");
-			const padding = Math.max(0, bodyWidth - visibleWidth(text));
-			lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));
-		}
-		lines.push(this.theme.fg("accent", `╰${borderChar.repeat(bodyWidth)}╯`));
-		return lines;
-	}
 }
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
@@ -370,11 +347,29 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		return new Text(theme.fg(details.state === "recovered" ? "warning" : "error", formatSteeringNotice(details)), 0, 0);
 	});
 
-	pi.registerMessageRenderer<SubagentControlMessageDetails>(SUBAGENT_CONTROL_MESSAGE_TYPE, (message, _options, theme) => {
+	pi.registerMessageRenderer<SubagentControlMessageDetails>(SUBAGENT_CONTROL_MESSAGE_TYPE, (message, options, theme) => {
 		const details = message.details as SubagentControlMessageDetails | undefined;
 		if (!details?.event) return undefined;
-		const content = typeof message.content === "string" ? message.content : undefined;
-		return new SubagentControlNoticeComponent({ ...details, noticeText: formatSubagentControlNotice(details, content) }, theme);
+		const presentation = {
+			label: details.label ?? details.event.agent,
+			role: details.role ?? details.event.agent,
+			...(details.logicalStep !== undefined ? { logicalStep: details.logicalStep } : {}),
+			...(details.totalSteps !== undefined ? { totalSteps: details.totalSteps } : {}),
+			event: details.event,
+		};
+		return new Text(theme.fg("accent", formatHumanControlNotice(presentation, options.expanded, keyText("app.tools.expand"))), 0, 0);
+	});
+
+	pi.registerMessageRenderer<SupervisorRequestMessageDetails>(SUBAGENT_SUPERVISOR_MESSAGE_TYPE, (message, options, theme) => {
+		const details = message.details as SupervisorRequestMessageDetails | undefined;
+		if (!details?.id || !details.runId || !details.agent) return undefined;
+		const presentation = {
+			...details,
+			label: details.label ?? details.agent,
+			role: details.role ?? details.agent,
+		};
+		const color = details.reason === "progress_update" ? "muted" : "accent";
+		return new Text(theme.fg(color, formatHumanSupervisorRequest(presentation, options.expanded, keyText("app.tools.expand"))), 0, 0);
 	});
 
 	const executeSubagentCollapsed = (id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((result: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -357,7 +357,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			...(details.totalSteps !== undefined ? { totalSteps: details.totalSteps } : {}),
 			event: details.event,
 		};
-		return new Text(theme.fg("accent", formatHumanControlNotice(presentation, options.expanded, keyText("app.tools.expand"))), 0, 0);
+		const legacyContent = typeof message.content === "string" ? message.content : undefined;
+		return new Text(theme.fg("accent", formatHumanControlNotice(presentation, options.expanded, keyText("app.tools.expand"), legacyContent)), 0, 0);
 	});
 
 	pi.registerMessageRenderer<SupervisorRequestMessageDetails>(SUBAGENT_SUPERVISOR_MESSAGE_TYPE, (message, options, theme) => {
@@ -369,7 +370,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			role: details.role ?? details.agent,
 		};
 		const color = details.reason === "progress_update" ? "muted" : "accent";
-		return new Text(theme.fg(color, formatHumanSupervisorRequest(presentation, options.expanded, keyText("app.tools.expand"))), 0, 0);
+		const legacyContent = typeof message.content === "string" ? message.content : undefined;
+		return new Text(theme.fg(color, formatHumanSupervisorRequest(presentation, options.expanded, keyText("app.tools.expand"), legacyContent)), 0, 0);
 	});
 
 	const executeSubagentCollapsed = (id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((result: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => {

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -14,6 +14,11 @@ import {
 } from "../runs/shared/pi-args.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
 import { writeAtomicJson } from "../shared/atomic-json.ts";
+import {
+	resolveChildPresentation,
+	SUBAGENT_SUPERVISOR_MESSAGE_TYPE,
+	type SupervisorRequestMessageDetails,
+} from "../extension/human-messages.ts";
 
 const SUPERVISOR_CHANNEL_ROOT = path.join(TEMP_ROOT_DIR, "supervisor-channels");
 const REQUESTS_DIR = "requests";
@@ -41,6 +46,7 @@ interface SupervisorRequest {
 	agent: string;
 	childIndex: number;
 	childTarget?: string;
+	question?: string;
 	interview?: unknown;
 }
 
@@ -248,6 +254,7 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: A
 		agent: metadata.agent,
 		childIndex: metadata.childIndex,
 		...(metadata.childTarget ? { childTarget: metadata.childTarget } : {}),
+		...(params.message?.trim() ? { question: params.message.trim() } : {}),
 		...(params.interview !== undefined ? { interview: params.interview } : {}),
 	};
 	const serialized = JSON.stringify(request, null, "\t");
@@ -633,18 +640,23 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 			else {
 				removeRequestFile(request.requestFile);
 			}
+			const presentation = resolveChildPresentation(state, request.runId, request.agent, request.childIndex);
+			const messageDetails: SupervisorRequestMessageDetails = {
+				id: request.id,
+				reason: request.reason,
+				expectsReply: request.expectsReply,
+				runId: request.runId,
+				agent: request.agent,
+				childIndex: request.childIndex,
+				...presentation,
+				...(request.question ? { question: request.question } : {}),
+				...(request.interview !== undefined ? { interview: request.interview } : {}),
+			};
 			pi.sendMessage({
-				customType: "subagent_supervisor_request",
+				customType: SUBAGENT_SUPERVISOR_MESSAGE_TYPE,
 				content: requestVisibleText(request),
 				display: true,
-				details: {
-					id: request.id,
-					reason: request.reason,
-					expectsReply: request.expectsReply,
-					runId: request.runId,
-					agent: request.agent,
-					childIndex: request.childIndex,
-				},
+				details: messageDetails,
 			});
 			if (request.expectsReply) {
 				(pi as { events?: IntercomEventBus }).events?.emit(INTERCOM_DETACH_REQUEST_EVENT, {

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -11,8 +11,8 @@ import {
 	type SubagentState,
 	POLL_INTERVAL_MS,
 	RESULTS_DIR,
+	SUBAGENT_CONTROL_DELIVERY_EVENT,
 	SUBAGENT_CONTROL_EVENT,
-	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_STEERING_NOTICE_EVENT,
 } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
@@ -136,27 +136,36 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		}, completionRetentionMs);
 		state.cleanupTimers.set(asyncId, timer);
 	};
-	const controlEventIsCurrentlyActionable = (job: AsyncJobState, event: ControlEvent): boolean => {
+	const classifyControlEvent = (job: AsyncJobState, event: ControlEvent): "actionable" | "retry" | "stale" => {
 		let status;
 		try {
 			status = readStatus(job.asyncDir);
 		} catch {
-			return false;
+			return "retry";
 		}
-		if (!status) return false;
+		if (!status) return "retry";
+		if (status.runId !== event.runId || status.state !== "running" || event.reason === "completion_guard") return "stale";
 		const index = event.index ?? status.currentStep ?? (status.steps?.length === 1 ? 0 : undefined);
-		if (index === undefined) return false;
+		if (index === undefined) return "retry";
 		const step = status.steps?.[index];
-		if (!step) return false;
-		return isControlEventActionable(event, {
+		if (!step) return "retry";
+		if (step.agent !== event.agent) return "stale";
+		if (step.status !== "running") return step.status === "pending" ? "retry" : "stale";
+		if (isControlEventActionable(event, {
 			runId: status.runId,
 			state: status.state,
 			agent: step.agent,
 			index,
+			status: step.status,
 			activityState: step.activityState,
 			lastActivityAt: step.lastActivityAt,
 			currentTool: step.currentTool,
-		});
+		})) return "actionable";
+		const evidence = event.evidenceLastActivityAt ?? event.activityEpoch;
+		if (evidence !== undefined && step.lastActivityAt !== undefined && step.lastActivityAt <= evidence && step.activityState === undefined && !step.currentTool) {
+			return "retry";
+		}
+		return "stale";
 	};
 	const emitNewControlEvents = (job: AsyncJobState) => {
 		const eventsPath = path.join(job.asyncDir, "events.jsonl");
@@ -176,22 +185,22 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			if (startedFromTail) cursor = stat.size - CONTROL_EVENT_SCAN_WINDOW_BYTES;
 			if (stat.size <= cursor) return;
 			const scanEnd = Math.min(stat.size, cursor + CONTROL_EVENT_SCAN_WINDOW_BYTES);
-			const handleLine = (line: string) => {
-				if (!line.trim()) return;
+			const handleLine = (line: string): "consumed" | "retry" => {
+				if (!line.trim()) return "consumed";
 				let parsed: unknown;
 				try {
 					parsed = JSON.parse(line);
 				} catch (error) {
 					console.error(`Ignoring malformed async control event in '${eventsPath}':`, error);
-					return;
+					return "consumed";
 				}
-				if (!parsed || typeof parsed !== "object") return;
+				if (!parsed || typeof parsed !== "object") return "consumed";
 				if ((parsed as { type?: unknown }).type === "subagent.steering.notice") {
 					const notice = parsed as Partial<SteeringNotice>;
-					if (typeof notice.requestId !== "string" || typeof notice.runId !== "string" || (notice.state !== "failed" && notice.state !== "partial" && notice.state !== "recovered") || typeof notice.message !== "string") return;
-					if (typeof state.currentSessionId === "string" && notice.currentSessionId !== state.currentSessionId) return;
+					if (typeof notice.requestId !== "string" || typeof notice.runId !== "string" || (notice.state !== "failed" && notice.state !== "partial" && notice.state !== "recovered") || typeof notice.message !== "string") return "consumed";
+					if (typeof state.currentSessionId === "string" && notice.currentSessionId !== state.currentSessionId) return "consumed";
 					const key = `${notice.runId}:${notice.requestId}:${notice.state}`;
-					if (steeringNoticeSeen.has(key)) return;
+					if (steeringNoticeSeen.has(key)) return "consumed";
 					const now = Date.now();
 					steeringNoticeSeen.set(key, now);
 					if (steeringNoticeSeen.size > 200) {
@@ -200,35 +209,36 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 						}
 					}
 					pi.events.emit(SUBAGENT_STEERING_NOTICE_EVENT, { ...notice, source: "async", asyncDir: job.asyncDir, noticeText: notice.message });
-					return;
+					return "consumed";
 				}
-				if ((parsed as { type?: unknown }).type !== "subagent.control") return;
+				if ((parsed as { type?: unknown }).type !== "subagent.control") return "consumed";
 				const record = parsed as { event?: ControlEvent; channels?: string[]; childIntercomTarget?: string; noticeText?: string; intercom?: { to?: string; message?: string } };
-				if (!record.event || !Array.isArray(record.channels)) return;
-				if (!controlEventIsCurrentlyActionable(job, record.event)) return;
+				if (!record.event || !Array.isArray(record.channels)) return "consumed";
+				const classification = classifyControlEvent(job, record.event);
+				if (classification === "retry") return "retry";
+				if (classification === "stale") return "consumed";
 				const payload = {
 					event: record.event,
 					source: "async" as const,
 					asyncDir: job.asyncDir,
+					channels: record.channels,
+					intercom: record.intercom,
 					childIntercomTarget: record.childIntercomTarget,
 					noticeText: record.noticeText ?? formatControlNoticeMessage(record.event, record.childIntercomTarget),
 				};
-				if (record.channels.includes("event")) {
-					pi.events.emit(SUBAGENT_CONTROL_EVENT, payload);
+				if (record.event.type === "active_long_running") {
+					if (record.channels.includes("event")) pi.events.emit(SUBAGENT_CONTROL_EVENT, payload);
+				} else if (record.channels.includes("event") || (record.channels.includes("intercom") && record.intercom?.to && record.intercom.message)) {
+					pi.events.emit(SUBAGENT_CONTROL_DELIVERY_EVENT, payload);
 				}
-				if (record.event.type !== "active_long_running" && record.channels.includes("intercom") && record.intercom?.to && record.intercom.message) {
-					pi.events.emit(SUBAGENT_CONTROL_INTERCOM_EVENT, {
-						...payload,
-						to: record.intercom.to,
-						message: record.intercom.message,
-					});
-				}
+				return "consumed";
 			};
 			let readCursor = cursor;
 			let lastCompleteCursor = cursor;
 			let lineParts: Buffer[] = [];
 			let lineBytes = 0;
 			let skippingOversizedLine = startedFromTail;
+			let retryPending = false;
 			const appendLineSegment = (segment: Buffer) => {
 				if (segment.length === 0 || skippingOversizedLine) return;
 				if (lineBytes + segment.length > MAX_CONTROL_EVENT_LINE_BYTES) {
@@ -250,8 +260,9 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				for (let index = 0; index < chunk.length; index++) {
 					if (chunk[index] !== 0x0a) continue;
 					appendLineSegment(chunk.subarray(lineStart, index));
-					if (!skippingOversizedLine && lineBytes > 0) {
-						handleLine(Buffer.concat(lineParts, lineBytes).toString("utf-8"));
+					if (!skippingOversizedLine && lineBytes > 0 && handleLine(Buffer.concat(lineParts, lineBytes).toString("utf-8")) === "retry") {
+						retryPending = true;
+						break;
 					}
 					lineParts = [];
 					lineBytes = 0;
@@ -259,11 +270,13 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 					lastCompleteCursor = readCursor + index + 1;
 					lineStart = index + 1;
 				}
+				if (retryPending) break;
 				appendLineSegment(chunk.subarray(lineStart));
 				readCursor += bytesRead;
 				if (skippingOversizedLine) job.controlEventCursor = readCursor;
 			}
-			if (lastCompleteCursor > cursor) job.controlEventCursor = lastCompleteCursor;
+			if (retryPending) job.controlEventCursor = lastCompleteCursor;
+			else if (lastCompleteCursor > cursor) job.controlEventCursor = lastCompleteCursor;
 			else if (scanEnd < stat.size || startedFromTail) job.controlEventCursor = scanEnd;
 		} catch (error) {
 			console.error(`Failed to read async control events for '${job.asyncDir}':`, error);

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { renderWidget, widgetRenderKey } from "../../tui/render.ts";
-import { formatControlNoticeMessage } from "../shared/subagent-control.ts";
+import { formatControlNoticeMessage, isControlEventActionable } from "../shared/subagent-control.ts";
 import {
 	type AsyncJobState,
 	type AsyncStartedEvent,
@@ -28,6 +28,7 @@ interface AsyncJobTrackerOptions {
 	widgetEnabled?: boolean;
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 	now?: () => number;
+	onRunInactive?: (runId?: string) => void;
 }
 
 const CONTROL_EVENT_READ_CHUNK_BYTES = 64 * 1024;
@@ -135,6 +136,28 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		}, completionRetentionMs);
 		state.cleanupTimers.set(asyncId, timer);
 	};
+	const controlEventIsCurrentlyActionable = (job: AsyncJobState, event: ControlEvent): boolean => {
+		let status;
+		try {
+			status = readStatus(job.asyncDir);
+		} catch {
+			return false;
+		}
+		if (!status) return false;
+		const index = event.index ?? status.currentStep ?? (status.steps?.length === 1 ? 0 : undefined);
+		if (index === undefined) return false;
+		const step = status.steps?.[index];
+		if (!step) return false;
+		return isControlEventActionable(event, {
+			runId: status.runId,
+			state: status.state,
+			agent: step.agent,
+			index,
+			activityState: step.activityState,
+			lastActivityAt: step.lastActivityAt,
+			currentTool: step.currentTool,
+		});
+	};
 	const emitNewControlEvents = (job: AsyncJobState) => {
 		const eventsPath = path.join(job.asyncDir, "events.jsonl");
 		let fd: number;
@@ -182,6 +205,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				if ((parsed as { type?: unknown }).type !== "subagent.control") return;
 				const record = parsed as { event?: ControlEvent; channels?: string[]; childIntercomTarget?: string; noticeText?: string; intercom?: { to?: string; message?: string } };
 				if (!record.event || !Array.isArray(record.channels)) return;
+				if (!controlEventIsCurrentlyActionable(job, record.event)) return;
 				const payload = {
 					event: record.event,
 					source: "async" as const,
@@ -303,6 +327,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 					const status = reconciliation.status ?? readStatus(job.asyncDir);
 					if (status) {
 						const previousStatus = job.status;
+						const previousActivityState = job.activityState;
 						job.status = status.state;
 						if (job.status !== "complete" && job.status !== "failed" && job.status !== "paused" && job.status !== "stopped") cancelCleanup(job.asyncId);
 						job.sessionId = status.sessionId ?? job.sessionId;
@@ -349,6 +374,11 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 						job.turnBudgetExceeded = status.turnBudgetExceeded ?? job.turnBudgetExceeded;
 						job.wrapUpRequested = status.wrapUpRequested ?? job.wrapUpRequested;
 						job.sessionFile = status.sessionFile ?? job.sessionFile;
+						const becameTerminal = previousStatus !== job.status
+							&& (job.status === "complete" || job.status === "failed" || job.status === "paused" || job.status === "stopped");
+						if ((previousActivityState === "needs_attention" && job.activityState !== "needs_attention") || becameTerminal) {
+							options.onRunInactive?.(job.asyncId);
+						}
 						if (job.status === "complete" || job.status === "failed" || job.status === "paused" || job.status === "stopped") {
 							rememberFleetJob(state, job);
 							if (!nestedRefreshFailed && !hasLiveNestedDescendants(job.nestedChildren) && (previousStatus !== job.status || !state.cleanupTimers.has(job.asyncId))) {
@@ -385,6 +415,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		const info = data as AsyncStartedEvent;
 		if (!info.id) return;
 		if (typeof state.currentSessionId === "string" && info.sessionId !== state.currentSessionId) return;
+		if (state.asyncJobs.has(info.id)) options.onRunInactive?.(info.id);
 		const now = Date.now();
 		const asyncDir = info.asyncDir ?? path.join(asyncDirRoot, info.id);
 		const rawAgents = info.agents?.length ? info.agents : info.chain && info.chain.length > 0 ? info.chain : info.agent ? [info.agent] : undefined;
@@ -428,6 +459,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		const asyncId = result.id;
 		if (!asyncId) return;
 		const job = state.asyncJobs.get(asyncId);
+		options.onRunInactive?.(asyncId);
 		let nestedRefreshFailed = false;
 		if (job) {
 			job.status = result.state ?? (result.success ? "complete" : "failed");
@@ -449,6 +481,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	};
 
 	const resetJobs = (ctx?: ExtensionContext) => {
+		options.onRunInactive?.();
 		for (const timer of state.cleanupTimers.values()) {
 			clearTimeout(timer);
 		}

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -2040,6 +2040,7 @@ async function runSubagent(
 			toolCount: step.toolCount,
 			currentTool: step.currentTool,
 			currentToolDurationMs: step.currentToolStartedAt ? Math.max(0, now - step.currentToolStartedAt) : undefined,
+			lastActivityAt: step.lastActivityAt,
 			currentPath: step.currentPath,
 			elapsedMs: now - (step.startedAt ?? overallStartTime),
 		});
@@ -2248,6 +2249,7 @@ async function runSubagent(
 		if (!step) return;
 		const now = Date.now();
 		statusPayload.currentStep = flatIndex;
+		if (step.activityState === "needs_attention") step.activityState = undefined;
 		if (isChildWatchdogStatusEvent(event)) {
 			const next = acceptChildWatchdogEvent({
 				current: step.watchdog,
@@ -2333,6 +2335,8 @@ async function runSubagent(
 						currentToolDurationMs: toolSnapshot.startedAt ? Math.max(0, now - toolSnapshot.startedAt) : undefined,
 						currentPath: toolSnapshot.path,
 						recentFailureSummary: summarizeRecentMutatingFailures(state),
+						lastActivityAt: now,
+						activityEpoch: now,
 					}));
 				}
 			} else if (toolSnapshot?.mutates) {
@@ -2366,6 +2370,12 @@ async function runSubagent(
 		statusPayload.lastActivityAt = now;
 		statusPayload.lastUpdate = now;
 		maybeEmitActiveLongRunning(flatIndex, now);
+		currentActivityState = statusPayload.steps.some((candidate) => candidate.activityState === "needs_attention")
+			? "needs_attention"
+			: statusPayload.steps.some((candidate) => candidate.activityState === "active_long_running")
+				? "active_long_running"
+				: undefined;
+		statusPayload.activityState = currentActivityState;
 		writeStatusPayload();
 	};
 	const updateRunnerActivityState = (now: number): boolean => {
@@ -2386,6 +2396,7 @@ async function runSubagent(
 				startedAt: step.startedAt ?? overallStartTime,
 				lastActivityAt,
 				currentTool: step.currentTool,
+				currentToolStartedAt: step.currentToolStartedAt,
 				now,
 			});
 			if (idleState === "needs_attention") {
@@ -2403,8 +2414,12 @@ async function runSubagent(
 					}));
 					changed = true;
 				}
-			} else if (maybeEmitActiveLongRunning(index, now)) {
-				changed = true;
+			} else {
+				if (step.activityState === "needs_attention") {
+					step.activityState = undefined;
+					changed = true;
+				}
+				if (maybeEmitActiveLongRunning(index, now)) changed = true;
 			}
 		}
 		if (statusPayload.lastActivityAt !== runLastActivityAt) {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1988,6 +1988,9 @@ async function runSubagent(
 			? controlConfig.notifyChannels.filter((channel) => channel !== "intercom")
 			: controlConfig.notifyChannels;
 		if (channels.length === 0 || !claimControlNotification(controlConfig, event, emittedControlEventKeys, childIntercomTarget)) return;
+		// Publish the actionable status atomically before exposing its event record.
+		// Readers may then safely advance their JSONL cursor without losing the notice.
+		writeStatusPayload();
 		appendJsonl(eventsPath, JSON.stringify({
 			type: "subagent.control",
 			event,

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -295,9 +295,13 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 			taskStr = injectSingleOutputInstruction(taskStr, outputPath, taskAgentConfig);
 			const interruptController = new AbortController();
 			if (input.foregroundControl) {
+				const childIndex = input.globalTaskIndex + taskIndex;
 				input.foregroundControl.currentAgent = task.agent;
-				input.foregroundControl.currentIndex = input.globalTaskIndex + taskIndex;
+				input.foregroundControl.currentIndex = childIndex;
+				input.foregroundControl.currentStatus = "running";
 				input.foregroundControl.currentActivityState = undefined;
+				input.foregroundControl.childSnapshots ??= new Map();
+				input.foregroundControl.childSnapshots.set(childIndex, { agent: task.agent, status: "running" });
 				input.foregroundControl.updatedAt = Date.now();
 				input.foregroundControl.interrupt = () => {
 					if (interruptController.signal.aborted) return false;
@@ -350,17 +354,25 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 					? (result) => input.onDetachedExit?.(input.globalTaskIndex + taskIndex, result)
 					: undefined,
 				toolBudget: toolBudget.toolBudget,
-				onUpdate: input.onUpdate
-					? (progressUpdate) => {
+				onUpdate: (progressUpdate) => {
 						const stepResults = progressUpdate.details?.results || [];
 						const stepProgress = progressUpdate.details?.progress || [];
 						if (input.foregroundControl && stepProgress.length > 0) {
 							const current = stepProgress[0];
 							input.foregroundControl.currentAgent = task.agent;
 							input.foregroundControl.currentIndex = input.globalTaskIndex + taskIndex;
+							const childIndex = input.globalTaskIndex + taskIndex;
+							input.foregroundControl.currentStatus = "running";
 							input.foregroundControl.currentActivityState = current?.activityState;
 							input.foregroundControl.lastActivityAt = current?.lastActivityAt;
 							input.foregroundControl.currentTool = current?.currentTool;
+							input.foregroundControl.childSnapshots?.set(childIndex, {
+								agent: task.agent,
+								status: "running",
+								activityState: current?.activityState,
+								lastActivityAt: current?.lastActivityAt,
+								currentTool: current?.currentTool,
+							});
 							input.foregroundControl.currentToolStartedAt = current?.currentToolStartedAt;
 							input.foregroundControl.currentPath = current?.currentPath;
 							input.foregroundControl.turnCount = current?.turnCount;
@@ -391,10 +403,14 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 								}),
 							},
 						});
-					}
-					: undefined,
+					},
 			});
-			if (input.foregroundControl?.currentIndex === input.globalTaskIndex + taskIndex) {
+			const childIndex = input.globalTaskIndex + taskIndex;
+			const childStatus = result.interrupted || result.detached ? "paused" : result.exitCode === 0 ? "complete" : "failed";
+			const childSnapshot = input.foregroundControl?.childSnapshots?.get(childIndex);
+			if (childSnapshot) childSnapshot.status = childStatus;
+			if (input.foregroundControl?.currentIndex === childIndex) {
+				input.foregroundControl.currentStatus = childStatus;
 				input.foregroundControl.interrupt = undefined;
 				input.foregroundControl.updatedAt = Date.now();
 			}
@@ -1149,6 +1165,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			if (foregroundControl) {
 				foregroundControl.currentAgent = seqStep.agent;
 				foregroundControl.currentIndex = childIndex;
+				foregroundControl.currentStatus = "running";
 				foregroundControl.currentActivityState = undefined;
 				foregroundControl.updatedAt = Date.now();
 				foregroundControl.interrupt = () => {
@@ -1227,6 +1244,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 							const current = stepProgress[0];
 							foregroundControl.currentAgent = seqStep.agent;
 							foregroundControl.currentIndex = childIndex;
+							foregroundControl.currentStatus = "running";
 							foregroundControl.currentActivityState = current?.activityState;
 							foregroundControl.lastActivityAt = current?.lastActivityAt;
 							foregroundControl.currentTool = current?.currentTool;
@@ -1264,6 +1282,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					: undefined,
 			});
 			if (foregroundControl?.currentIndex === childIndex) {
+				foregroundControl.currentStatus = r.interrupted || r.detached ? "paused" : r.exitCode === 0 ? "complete" : "failed";
 				foregroundControl.interrupt = undefined;
 				foregroundControl.updatedAt = Date.now();
 			}

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -525,6 +525,7 @@ async function runSingleAttempt(
 				currentToolDurationMs: input.currentToolDurationMs ?? currentToolDurationMs(now),
 				currentPath: input.currentPath ?? progress.currentPath,
 				recentFailureSummary: input.recentFailureSummary,
+				activityEpoch: progress.lastActivityAt,
 			});
 			emitControlEvent(event);
 			return previous !== "needs_attention";
@@ -549,6 +550,7 @@ async function runSingleAttempt(
 				toolCount: progress.toolCount,
 				currentTool: progress.currentTool,
 				currentToolDurationMs: currentToolDurationMs(now),
+				lastActivityAt: progress.lastActivityAt,
 				currentPath: progress.currentPath,
 				elapsedMs: now - startTime,
 			}));
@@ -612,6 +614,7 @@ async function runSingleAttempt(
 				startedAt: startTime,
 				lastActivityAt: progress.lastActivityAt,
 				currentTool: progress.currentTool,
+				currentToolStartedAt: progress.currentToolStartedAt,
 				now,
 			});
 			if (idleState === "needs_attention") {
@@ -690,6 +693,7 @@ async function runSingleAttempt(
 			const now = Date.now();
 			progress.durationMs = now - startTime;
 			progress.lastActivityAt = now;
+			if (progress.activityState === "needs_attention") progress.activityState = undefined;
 			updateActivityState(now);
 
 			if (evt.type === "tool_execution_start") {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3712,6 +3712,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				interrupt: undefined,
 			};
 		if (foregroundControl) {
+			clearPendingForegroundControlNotices(deps.state, runId);
 			deps.state.foregroundControls.set(runId, foregroundControl);
 			deps.state.lastForegroundControlId = runId;
 		}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -103,8 +103,8 @@ import {
 	DEFAULT_FORK_PREAMBLE,
 	RESULTS_DIR,
 	SUBAGENT_ACTIONS,
+	SUBAGENT_CONTROL_DELIVERY_EVENT,
 	SUBAGENT_CONTROL_EVENT,
-	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_FOREGROUND_COMPLETE_EVENT,
 	checkSubagentDepth,
 	resolveMaxSubagentSpawnsPerSession,
@@ -572,21 +572,26 @@ function emitControlNotification(input: {
 	const childIntercomTarget = input.intercomBridge.active
 		? resolveSubagentIntercomTarget(input.event.runId, input.event.agent, input.event.index)
 		: undefined;
+	const channels = input.controlConfig.notifyChannels;
 	const payload = {
 		event: input.event,
 		source: "foreground" as const,
+		channels,
 		childIntercomTarget,
 		noticeText: formatControlNoticeMessage(input.event, childIntercomTarget),
+		...(channels.includes("intercom") && input.intercomBridge.active && input.intercomBridge.orchestratorTarget ? {
+			intercom: {
+				to: input.intercomBridge.orchestratorTarget,
+				message: formatControlIntercomMessage(input.event, childIntercomTarget),
+			},
+		} : {}),
 	};
-	if (input.controlConfig.notifyChannels.includes("event")) {
-		input.pi.events.emit(SUBAGENT_CONTROL_EVENT, payload);
+	if (input.event.type === "active_long_running" || input.event.reason === "completion_guard") {
+		if (channels.includes("event")) input.pi.events.emit(SUBAGENT_CONTROL_EVENT, payload);
+		return;
 	}
-	if (input.event.type !== "active_long_running" && input.controlConfig.notifyChannels.includes("intercom") && input.intercomBridge.active && input.intercomBridge.orchestratorTarget) {
-		input.pi.events.emit(SUBAGENT_CONTROL_INTERCOM_EVENT, {
-			...payload,
-			to: input.intercomBridge.orchestratorTarget,
-			message: formatControlIntercomMessage(input.event, childIntercomTarget),
-		});
+	if (channels.includes("event") || channels.includes("intercom")) {
+		input.pi.events.emit(SUBAGENT_CONTROL_DELIVERY_EVENT, payload);
 	}
 }
 
@@ -2425,7 +2430,10 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		if (input.foregroundControl) {
 			input.foregroundControl.currentAgent = task.agent;
 			input.foregroundControl.currentIndex = index;
+			input.foregroundControl.currentStatus = "running";
 			input.foregroundControl.currentActivityState = undefined;
+			input.foregroundControl.childSnapshots ??= new Map();
+			input.foregroundControl.childSnapshots.set(index, { agent: task.agent, status: "running" });
 			input.foregroundControl.updatedAt = Date.now();
 			input.foregroundControl.interrupt = () => {
 				if (interruptController.signal.aborted) return false;
@@ -2472,17 +2480,24 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			deadlineAt: input.deadlineAt,
 			turnBudget: input.turnBudget,
 			toolBudget: input.toolBudgets[index],
-			onUpdate: input.onUpdate
-				? (progressUpdate) => {
+			onUpdate: (progressUpdate) => {
 					const stepResults = progressUpdate.details?.results || [];
 					const stepProgress = progressUpdate.details?.progress || [];
 					if (input.foregroundControl && stepProgress.length > 0) {
 						const current = stepProgress[0];
 						input.foregroundControl.currentAgent = task.agent;
 						input.foregroundControl.currentIndex = index;
+						input.foregroundControl.currentStatus = "running";
 						input.foregroundControl.currentActivityState = current?.activityState;
 						input.foregroundControl.lastActivityAt = current?.lastActivityAt;
 						input.foregroundControl.currentTool = current?.currentTool;
+						input.foregroundControl.childSnapshots?.set(index, {
+							agent: task.agent,
+							status: "running",
+							activityState: current?.activityState,
+							lastActivityAt: current?.lastActivityAt,
+							currentTool: current?.currentTool,
+						});
 						input.foregroundControl.currentToolStartedAt = current?.currentToolStartedAt;
 						input.foregroundControl.currentPath = current?.currentPath;
 						input.foregroundControl.turnCount = current?.turnCount;
@@ -2504,13 +2519,22 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 							totalSteps: input.tasks.length,
 						},
 					});
-				}
-				: undefined,
-		}).finally(() => {
+				},
+		}).then((result) => {
+			const status = result.interrupted || result.detached ? "paused" : result.exitCode === 0 ? "complete" : "failed";
+			const snapshot = input.foregroundControl?.childSnapshots?.get(index);
+			if (snapshot) snapshot.status = status;
 			if (input.foregroundControl?.currentIndex === index) {
+				input.foregroundControl.currentStatus = status;
 				input.foregroundControl.interrupt = undefined;
 				input.foregroundControl.updatedAt = Date.now();
 			}
+			return result;
+		}, (error) => {
+			const snapshot = input.foregroundControl?.childSnapshots?.get(index);
+			if (snapshot) snapshot.status = "failed";
+			if (input.foregroundControl?.currentIndex === index) input.foregroundControl.currentStatus = "failed";
+			throw error;
 		});
 	}, input.globalSemaphore);
 }
@@ -3040,6 +3064,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	if (foregroundControl) {
 		foregroundControl.currentAgent = params.agent;
 		foregroundControl.currentIndex = 0;
+		foregroundControl.currentStatus = "running";
 		foregroundControl.currentActivityState = undefined;
 		foregroundControl.updatedAt = Date.now();
 		foregroundControl.interrupt = () => {
@@ -3057,6 +3082,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				const firstProgress = update.details?.progress?.[0];
 				foregroundControl.currentAgent = params.agent;
 				foregroundControl.currentIndex = firstProgress?.index ?? 0;
+				foregroundControl.currentStatus = "running";
 				foregroundControl.currentActivityState = firstProgress?.activityState;
 				foregroundControl.lastActivityAt = firstProgress?.lastActivityAt;
 				foregroundControl.currentTool = firstProgress?.currentTool;
@@ -3113,6 +3139,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	});
 	if (foregroundControl?.currentIndex === 0) {
 		foregroundControl.interrupt = undefined;
+		foregroundControl.currentStatus = r.interrupted || r.detached ? "paused" : r.exitCode === 0 ? "complete" : "failed";
 		foregroundControl.currentActivityState = r.progress?.activityState;
 		foregroundControl.lastActivityAt = r.progress?.lastActivityAt;
 		foregroundControl.currentTool = r.progress?.currentTool;
@@ -3707,7 +3734,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				updatedAt: Date.now(),
 				currentAgent: undefined,
 				currentIndex: undefined,
+				currentStatus: undefined,
 				currentActivityState: undefined,
+				childSnapshots: undefined,
 				nestedRoute,
 				interrupt: undefined,
 			};

--- a/src/runs/shared/subagent-control.ts
+++ b/src/runs/shared/subagent-control.ts
@@ -164,6 +164,7 @@ export interface ControlEventActionabilitySnapshot {
 	state: string;
 	agent?: string;
 	index?: number;
+	status?: string;
 	activityState?: ActivityState;
 	lastActivityAt?: number;
 	currentTool?: string;
@@ -171,7 +172,7 @@ export interface ControlEventActionabilitySnapshot {
 
 export function isControlEventActionable(event: ControlEvent, snapshot: ControlEventActionabilitySnapshot | undefined): boolean {
 	if (!snapshot || event.reason === "completion_guard") return false;
-	if (snapshot.runId !== event.runId || snapshot.state !== "running") return false;
+	if (snapshot.runId !== event.runId || snapshot.state !== "running" || snapshot.status !== "running") return false;
 	if (snapshot.agent !== event.agent) return false;
 	if (event.index !== undefined && snapshot.index !== event.index) return false;
 	if (snapshot.activityState !== event.to) return false;

--- a/src/runs/shared/subagent-control.ts
+++ b/src/runs/shared/subagent-control.ts
@@ -75,10 +75,15 @@ export function deriveActivityState(input: {
 	startedAt: number;
 	lastActivityAt?: number;
 	currentTool?: string;
+	currentToolStartedAt?: number;
 	now?: number;
 }): ActivityState | undefined {
-	if (!input.config.enabled || input.currentTool) return undefined;
+	if (!input.config.enabled) return undefined;
 	const now = input.now ?? Date.now();
+	if (input.currentTool) {
+		const toolStartedAt = input.currentToolStartedAt ?? input.lastActivityAt ?? input.startedAt;
+		return now - toolStartedAt >= input.config.activeNoticeAfterMs ? "active_long_running" : undefined;
+	}
 	const lastActivity = input.lastActivityAt ?? input.startedAt;
 	const ageMs = Math.max(0, now - lastActivity);
 	return ageMs > input.config.needsAttentionAfterMs ? "needs_attention" : undefined;
@@ -103,6 +108,7 @@ export function buildControlEvent(input: {
 	currentPath?: string;
 	elapsedMs?: number;
 	recentFailureSummary?: string;
+	activityEpoch?: number;
 }): ControlEvent {
 	const ts = input.ts ?? Date.now();
 	const type = input.type ?? (input.to === "active_long_running" ? "active_long_running" : "needs_attention");
@@ -131,6 +137,9 @@ export function buildControlEvent(input: {
 		...(input.currentPath ? { currentPath: input.currentPath } : {}),
 		...(elapsedMs !== undefined ? { elapsedMs } : {}),
 		...(input.recentFailureSummary ? { recentFailureSummary: input.recentFailureSummary } : {}),
+		...(input.activityEpoch !== undefined || input.lastActivityAt !== undefined
+			? { activityEpoch: input.activityEpoch ?? input.lastActivityAt, evidenceLastActivityAt: input.lastActivityAt ?? input.activityEpoch }
+			: {}),
 	};
 }
 
@@ -138,9 +147,38 @@ export function shouldNotifyControlEvent(config: ResolvedControlConfig, event: C
 	return config.enabled && config.notifyOn.includes(event.type);
 }
 
+export function controlEventEvidenceLastActivityAt(event: ControlEvent): number | undefined {
+	if (event.evidenceLastActivityAt !== undefined) return event.evidenceLastActivityAt;
+	if (event.elapsedMs !== undefined) return event.ts - event.elapsedMs;
+	return event.activityEpoch;
+}
+
 export function controlNotificationKey(event: ControlEvent, childIntercomTarget?: string): string {
 	const childKey = childIntercomTarget ?? (event.index !== undefined ? `${event.runId}:${event.index}` : event.runId);
-	return `${childKey}:${event.type}:${event.reason ?? "idle"}`;
+	const epoch = event.activityEpoch ?? controlEventEvidenceLastActivityAt(event);
+	return `${childKey}:${event.type}:${event.reason ?? "idle"}:${epoch ?? "legacy"}`;
+}
+
+export interface ControlEventActionabilitySnapshot {
+	runId: string;
+	state: string;
+	agent?: string;
+	index?: number;
+	activityState?: ActivityState;
+	lastActivityAt?: number;
+	currentTool?: string;
+}
+
+export function isControlEventActionable(event: ControlEvent, snapshot: ControlEventActionabilitySnapshot | undefined): boolean {
+	if (!snapshot || event.reason === "completion_guard") return false;
+	if (snapshot.runId !== event.runId || snapshot.state !== "running") return false;
+	if (snapshot.agent !== event.agent) return false;
+	if (event.index !== undefined && snapshot.index !== event.index) return false;
+	if (snapshot.activityState !== event.to) return false;
+	if (event.reason === "idle" && snapshot.currentTool) return false;
+	const evidence = controlEventEvidenceLastActivityAt(event);
+	if (evidence !== undefined && snapshot.lastActivityAt !== undefined && snapshot.lastActivityAt > evidence) return false;
+	return true;
 }
 
 export function claimControlNotification(config: ResolvedControlConfig, event: ControlEvent, seenKeys: Set<string>, childIntercomTarget?: string): boolean {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -999,7 +999,16 @@ export interface SubagentState {
 		updatedAt: number;
 		currentAgent?: string;
 		currentIndex?: number;
+		currentStatus?: "pending" | "running" | "complete" | "completed" | "failed" | "paused" | "stopped";
 		currentActivityState?: ActivityState;
+		/** Exact per-child live snapshots for concurrent foreground children. */
+		childSnapshots?: Map<number, {
+			agent: string;
+			status: "pending" | "running" | "complete" | "completed" | "failed" | "paused" | "stopped";
+			activityState?: ActivityState;
+			lastActivityAt?: number;
+			currentTool?: string;
+		}>;
 		lastActivityAt?: number;
 		currentTool?: string;
 		currentToolStartedAt?: number;
@@ -1055,6 +1064,8 @@ export const INTERCOM_DETACH_RESPONSE_EVENT = "pi-intercom:detach-response";
 export const SUBAGENT_ASYNC_STARTED_EVENT = "subagent:async-started";
 export const SUBAGENT_ASYNC_COMPLETE_EVENT = "subagent:async-complete";
 export const SUBAGENT_FOREGROUND_COMPLETE_EVENT = "subagent:foreground-complete";
+/** Internal route for control delivery that still requires debounce and final revalidation. */
+export const SUBAGENT_CONTROL_DELIVERY_EVENT = "subagent:control-delivery";
 export const SUBAGENT_CONTROL_EVENT = "subagent:control-event";
 export const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 export const SUBAGENT_STEERING_NOTICE_EVENT = "subagent:steering-notice";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -210,6 +210,10 @@ export interface ControlEvent {
 	currentPath?: string;
 	elapsedMs?: number;
 	recentFailureSummary?: string;
+	/** Meaningful-activity sequence for one notice per uninterrupted stale interval. */
+	activityEpoch?: number;
+	/** Last observed activity used as evidence when this event was classified. */
+	evidenceLastActivityAt?: number;
 }
 
 export type SubagentResultStatus = "completed" | "failed" | "paused" | "stopped" | "detached";
@@ -1008,6 +1012,7 @@ export interface SubagentState {
 		interrupt?: () => boolean;
 	}>;
 	lastForegroundControlId: string | null;
+	/** Debounced foreground and async control notices awaiting final actionability checks. */
 	pendingForegroundControlNotices?: Map<string, ReturnType<typeof setTimeout>>;
 	cleanupTimers: Map<string, ReturnType<typeof setTimeout>>;
 	lastUiContext: ExtensionContext | null;

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -16,6 +16,7 @@ interface AsyncJobTrackerModule {
 			widgetEnabled?: boolean;
 			kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 			now?: () => number;
+			onRunInactive?: (runId?: string) => void;
 		},
 	): {
 		ensurePoller(): void;
@@ -130,6 +131,24 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			assert.equal(state.fleetJobs.get("run-1")?.status, "complete", "fleet history should outlive widget cleanup");
 			assert.ok(ui.renderRequests > 0, "expected widget cleanup to request a rerender");
 			assert.equal(ui.widgets.at(-1), undefined);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("cancels pending notice ownership on replacement, completion, and reset", () => {
+		const asyncRoot = createTempDir("pi-async-job-cancel-notices-");
+		try {
+			const inactive: Array<string | undefined> = [];
+			const state = createState();
+			const tracker = trackerMod!.createAsyncJobTracker(createEventRecorder().pi, state as never, asyncRoot, {
+				onRunInactive: (runId) => inactive.push(runId),
+			});
+			tracker.handleStarted({ id: "run-1", asyncDir: path.join(asyncRoot, "run-1"), agent: "worker" });
+			tracker.handleStarted({ id: "run-1", asyncDir: path.join(asyncRoot, "run-1-replacement"), agent: "worker" });
+			tracker.handleComplete({ id: "run-1", success: true });
+			tracker.resetJobs();
+			assert.deepEqual(inactive, ["run-1", "run-1", undefined]);
 		} finally {
 			removeTempDir(asyncRoot);
 		}
@@ -411,7 +430,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				startedAt: 1000,
 				lastUpdate,
 				...(toolCount !== undefined ? { toolCount } : {}),
-				steps: [{ agent: "worker", status: "running", startedAt: 1000 }],
+				steps: [{ agent: "worker", status: "running", startedAt: 1000, activityState: "needs_attention" }],
 			}), "utf-8");
 			writeStatus(2000);
 
@@ -448,6 +467,36 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			writeStatus(3000, 1);
 			await new Promise((resolve) => setTimeout(resolve, 40));
 			assert.ok(ui.renderRequests > requestsAfterStatusLoaded, "changed non-terminal status should redraw the widget");
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("suppresses a queued control event when the exact child already completed", async () => {
+		const asyncRoot = createTempDir("pi-async-job-terminal-notice-");
+		try {
+			const runDir = path.join(asyncRoot, "run-terminal-notice");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-terminal-notice",
+				mode: "single",
+				state: "complete",
+				startedAt: 1,
+				endedAt: 3,
+				steps: [{ agent: "worker", status: "complete", activityState: "needs_attention", lastActivityAt: 1 }],
+			}));
+			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
+				type: "subagent.control",
+				channels: ["event", "intercom"],
+				event: { type: "needs_attention", to: "needs_attention", ts: 2, runId: "run-terminal-notice", agent: "worker", index: 0, message: "stale", activityEpoch: 1, evidenceLastActivityAt: 1 },
+				intercom: { to: "main", message: "stale" },
+			})}\n`);
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, { pollIntervalMs: 10, completionRetentionMs: 5 });
+			tracker.handleStarted({ id: "run-terminal-notice", asyncDir: runDir, agent: "worker" });
+			await new Promise((resolve) => setTimeout(resolve, 40));
+			assert.equal(recorder.events.length, 0);
 		} finally {
 			removeTempDir(asyncRoot);
 		}
@@ -737,7 +786,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				state: "running",
 				startedAt: Date.now() - 1000,
 				lastUpdate: Date.now(),
-				steps: [{ agent: "worker", status: "running" }],
+				steps: [{ agent: "worker", status: "running", activityState: "needs_attention" }],
 			}), "utf-8");
 			const eventPath = path.join(runDir, "events.jsonl");
 			const partialRecord = JSON.stringify({
@@ -785,7 +834,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				state: "running",
 				startedAt: Date.now() - 1000,
 				lastUpdate: Date.now(),
-				steps: [{ agent: "worker", status: "running" }],
+				steps: [{ agent: "worker", status: "running", activityState: "needs_attention" }],
 			}), "utf-8");
 			const largeDiagnostic = JSON.stringify({
 				type: "message_update",
@@ -840,7 +889,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				state: "running",
 				startedAt: Date.now() - 1000,
 				lastUpdate: Date.now(),
-				steps: [{ agent: "worker", status: "running" }],
+				steps: [{ agent: "worker", status: "running", activityState: "needs_attention" }],
 			}), "utf-8");
 			const controlEvent = JSON.stringify({
 				type: "subagent.control",
@@ -893,7 +942,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				state: "running",
 				startedAt: Date.now() - 1000,
 				lastUpdate: Date.now(),
-				steps: [{ agent: "worker", status: "running" }],
+				steps: [{ agent: "worker", status: "running", activityState: "needs_attention" }],
 			}), "utf-8");
 			const diagnosticLine = JSON.stringify({
 				type: "message_update",
@@ -1011,7 +1060,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				state: "running",
 				startedAt: Date.now() - 1000,
 				lastUpdate: Date.now(),
-				steps: [{ agent: "worker", status: "running" }],
+				steps: [{ agent: "worker", status: "running", activityState: "needs_attention" }],
 			}), "utf-8");
 			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
 				type: "subagent.control",
@@ -1053,7 +1102,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				state: "running",
 				startedAt: Date.now() - 1000,
 				lastUpdate: Date.now(),
-				steps: [{ agent: "worker", status: "running" }],
+				steps: [{ agent: "worker", status: "running", activityState: "active_long_running" }],
 			}), "utf-8");
 			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
 				type: "subagent.control",
@@ -1095,7 +1144,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				state: "running",
 				startedAt: Date.now() - 1000,
 				lastUpdate: Date.now(),
-				steps: [{ agent: "worker", status: "running" }],
+				steps: [{ agent: "worker", status: "running", activityState: "needs_attention" }],
 			}), "utf-8");
 			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
 				type: "subagent.control",

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -461,7 +461,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				},
 			})}\n`, "utf-8");
 			await new Promise((resolve) => setTimeout(resolve, 40));
-			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-event"), true);
+			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-delivery"), true);
 			assert.equal(ui.renderRequests, requestsAfterStatusLoaded, "unchanged status and control cursors should not request widget redraws");
 
 			writeStatus(3000, 1);
@@ -472,18 +472,20 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
-	it("suppresses a queued control event when the exact child already completed", async () => {
+	it("suppresses a terminal child control event while another child keeps the run live", async () => {
 		const asyncRoot = createTempDir("pi-async-job-terminal-notice-");
 		try {
 			const runDir = path.join(asyncRoot, "run-terminal-notice");
 			fs.mkdirSync(runDir, { recursive: true });
 			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
 				runId: "run-terminal-notice",
-				mode: "single",
-				state: "complete",
+				mode: "parallel",
+				state: "running",
 				startedAt: 1,
-				endedAt: 3,
-				steps: [{ agent: "worker", status: "complete", activityState: "needs_attention", lastActivityAt: 1 }],
+				steps: [
+					{ agent: "worker", status: "complete", activityState: "needs_attention", lastActivityAt: 1 },
+					{ agent: "reviewer", status: "running", lastActivityAt: 2 },
+				],
 			}));
 			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
 				type: "subagent.control",
@@ -815,7 +817,59 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			fs.appendFileSync(eventPath, "\n", "utf-8");
 			await new Promise((resolve) => setTimeout(resolve, 30));
-			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-event"), true);
+			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-delivery"), true);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("retries a complete control record until status exposes the matching attention state", async () => {
+		const asyncRoot = createTempDir("pi-async-job-ordering-");
+		try {
+			const runDir = path.join(asyncRoot, "run-event-before-status");
+			fs.mkdirSync(runDir, { recursive: true });
+			const writeStatus = (activityState?: "needs_attention") => fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-event-before-status",
+				mode: "single",
+				state: "running",
+				startedAt: 1,
+				lastUpdate: 100,
+				steps: [{ agent: "worker", status: "running", activityState, lastActivityAt: 100 }],
+			}), "utf-8");
+			writeStatus();
+			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
+				type: "subagent.control",
+				channels: ["event", "intercom"],
+				event: {
+					type: "needs_attention",
+					to: "needs_attention",
+					ts: 200,
+					runId: "run-event-before-status",
+					agent: "worker",
+					index: 0,
+					message: "worker needs attention",
+					activityEpoch: 100,
+					evidenceLastActivityAt: 100,
+				},
+				intercom: { to: "main", message: "UNCHANGED INTERCOM CONTENT" },
+			})}\n`, "utf-8");
+
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, { pollIntervalMs: 10 });
+			tracker.handleStarted({ id: "run-event-before-status", asyncDir: runDir, agent: "worker" });
+
+			await new Promise((resolve) => setTimeout(resolve, 30));
+			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-delivery"), false);
+			assert.equal(state.asyncJobs.get("run-event-before-status")?.controlEventCursor, 0, "retry must retain the record cursor");
+
+			writeStatus("needs_attention");
+			await waitForCondition(
+				() => recorder.events.some((event) => event.channel === "subagent:control-delivery"),
+				"ordered control delivery",
+			);
+			const delivery = recorder.events.find((event) => event.channel === "subagent:control-delivery");
+			assert.deepEqual((delivery?.data as { intercom?: unknown }).intercom, { to: "main", message: "UNCHANGED INTERCOM CONTENT" });
 		} finally {
 			removeTempDir(asyncRoot);
 		}
@@ -867,7 +921,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			tracker.handleStarted({ id: "run-chunked-control", asyncDir: runDir, agent: "worker" });
 
 			await waitForCondition(
-				() => recorder.events.some((event) => event.channel === "subagent:control-event"),
+				() => recorder.events.some((event) => event.channel === "subagent:control-delivery"),
 				"chunked control event",
 			);
 			assert.ok(allocationSizes.length > 0, "expected the tracker to allocate read buffers");
@@ -919,7 +973,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			tracker.handleStarted({ id: "run-new-large-control", asyncDir: runDir, agent: "worker" });
 
 			await waitForCondition(
-				() => recorder.events.some((event) => event.channel === "subagent:control-event"),
+				() => recorder.events.some((event) => event.channel === "subagent:control-delivery"),
 				"new large log control event",
 			);
 		} finally {
@@ -986,7 +1040,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			tracker.ensurePoller();
 
 			await waitForCondition(
-				() => recorder.events.some((event) => event.channel === "subagent:control-event"),
+				() => recorder.events.some((event) => event.channel === "subagent:control-delivery"),
 				"tail-window control event",
 			);
 			assert.ok(allocationSizes.length > 0, "expected the tracker to allocate read buffers");
@@ -1084,8 +1138,10 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			tracker.handleStarted({ id: "run-channels", asyncDir: runDir, agent: "worker" });
 
 			await new Promise((resolve) => setTimeout(resolve, 30));
-			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-event"), false);
-			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-intercom"), true);
+			const delivery = recorder.events.find((event) => event.channel === "subagent:control-delivery");
+			assert.ok(delivery);
+			assert.deepEqual((delivery.data as { channels?: string[] }).channels, ["intercom"]);
+			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-intercom"), false);
 		} finally {
 			removeTempDir(asyncRoot);
 		}
@@ -1171,10 +1227,12 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			await new Promise((resolve) => setTimeout(resolve, 40));
 
-			const controlEvent = recorder.events.find((event) => event.channel === "subagent:control-event");
-			assert.ok(controlEvent);
-			assert.match((controlEvent.data as { noticeText?: string }).noticeText ?? "", /subagent-worker-run-3-1/);
-			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-intercom"), true);
+			const controlDelivery = recorder.events.find((event) => event.channel === "subagent:control-delivery");
+			assert.ok(controlDelivery);
+			assert.match((controlDelivery.data as { noticeText?: string }).noticeText ?? "", /subagent-worker-run-3-1/);
+			assert.deepEqual((controlDelivery.data as { channels?: string[] }).channels, ["event", "intercom"]);
+			assert.deepEqual((controlDelivery.data as { intercom?: unknown }).intercom, { to: "main", message: "SUBAGENT NEEDS ATTENTION: worker in run run-3." });
+			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-intercom"), false);
 		} finally {
 			removeTempDir(asyncRoot);
 		}

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -689,7 +689,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(failureEvent?.type, "needs_attention");
 		assert.equal(failureEvent?.currentPath, "src/runs/background/async-status.ts");
 		assert.match(failureEvent?.recentFailureSummary ?? "", /No exact match/);
-		assert.equal(result.progress.activityState, "needs_attention");
+		assert.equal(result.progress.activityState, undefined, "later activity should recover the live attention state while preserving the event history");
 	});
 
 	it("does not surface control state or events when control is disabled", async () => {

--- a/test/unit/control-notices.test.ts
+++ b/test/unit/control-notices.test.ts
@@ -4,7 +4,22 @@ import {
 	clearPendingForegroundControlNotices,
 	handleSubagentControlNotice,
 } from "../../src/extension/control-notices.ts";
+import { formatControlNoticeMessage } from "../../src/runs/shared/subagent-control.ts";
 import type { ControlEvent, SubagentState } from "../../src/shared/types.ts";
+
+interface SentControlNotice {
+	customType: string;
+	content: string;
+	display: boolean;
+	details: {
+		event: ControlEvent;
+		label?: string;
+		role?: string;
+		logicalStep?: number;
+		totalSteps?: number;
+		noticeText?: string;
+	};
+}
 
 function makeState(): SubagentState {
 	return {
@@ -55,20 +70,53 @@ function wait(ms: number): Promise<void> {
 }
 
 describe("subagent control notice delivery", () => {
-	it("delivers async needs-attention notices immediately", () => {
+	it("delivers async needs-attention notices immediately without changing model-facing content", () => {
 		const state = makeState();
+		state.asyncJobs.set("run-1", {
+			asyncId: "run-1",
+			asyncDir: "/tmp/run-1",
+			status: "running",
+			mode: "chain",
+			chainStepCount: 2,
+			steps: [
+				{ index: 0, agent: "worker", label: "Implement API", status: "running" },
+				{ index: 1, agent: "tester", label: "Validate", status: "pending" },
+			],
+		});
 		const recorder = makeRecorder();
+		const event = needsAttentionEvent({
+			message: "worker needs attention with complete diagnostics",
+			currentPath: "/tmp/project/src/index.ts",
+			toolCount: 7,
+		});
+		const expectedModelContent = formatControlNoticeMessage(event);
 
 		handleSubagentControlNotice({
 			pi: recorder.pi,
 			state,
 			visibleControlNotices: new Set(),
-			details: { source: "async", event: needsAttentionEvent() },
+			details: { source: "async", event },
 			foregroundDelayMs: 20,
 		});
 
 		assert.equal(recorder.sent.length, 1);
 		assert.deepEqual(recorder.sent[0]?.options, { triggerTurn: true });
+		const message = recorder.sent[0]?.message as SentControlNotice;
+		assert.equal(message.content, expectedModelContent);
+		assert.equal(message.details.noticeText, expectedModelContent);
+		assert.match(message.content, /worker needs attention with complete diagnostics/);
+		assert.match(message.content, /Status: subagent\(\{ action: "status"/);
+		assert.deepEqual({
+			label: message.details.label,
+			role: message.details.role,
+			logicalStep: message.details.logicalStep,
+			totalSteps: message.details.totalSteps,
+		}, {
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 1,
+			totalSteps: 2,
+		});
 	});
 
 	it("queues foreground needs-attention notices until the same step is still actionable", async () => {

--- a/test/unit/control-notices.test.ts
+++ b/test/unit/control-notices.test.ts
@@ -60,9 +60,16 @@ function needsAttentionEvent(overrides: Partial<ControlEvent> = {}): ControlEven
 
 function makeRecorder() {
 	const sent: Array<{ message: unknown; options: unknown }> = [];
+	const events: Array<{ channel: string; data: unknown }> = [];
 	return {
 		sent,
+		events,
 		pi: {
+			events: {
+				emit(channel: string, data: unknown) {
+					events.push({ channel, data });
+				},
+			},
 			sendMessage(message: unknown, options: unknown) {
 				sent.push({ message, options });
 			},
@@ -151,6 +158,7 @@ describe("subagent control notice delivery", () => {
 			updatedAt: 0,
 			currentAgent: "worker",
 			currentIndex: 0,
+			currentStatus: "running",
 			currentActivityState: "needs_attention",
 		});
 		const recorder = makeRecorder();
@@ -178,6 +186,7 @@ describe("subagent control notice delivery", () => {
 			updatedAt: 0,
 			currentAgent: "worker",
 			currentIndex: 0,
+			currentStatus: "running",
 			currentActivityState: "needs_attention",
 		});
 		const recorder = makeRecorder();
@@ -205,6 +214,7 @@ describe("subagent control notice delivery", () => {
 			updatedAt: 0,
 			currentAgent: "worker",
 			currentIndex: 0,
+			currentStatus: "running",
 			currentActivityState: "needs_attention",
 		});
 		const recorder = makeRecorder();
@@ -223,6 +233,7 @@ describe("subagent control notice delivery", () => {
 			updatedAt: 0,
 			currentAgent: "writer",
 			currentIndex: 1,
+			currentStatus: "running",
 			currentActivityState: undefined,
 		});
 
@@ -268,6 +279,7 @@ describe("subagent control notice delivery", () => {
 			updatedAt: 0,
 			currentAgent: "worker",
 			currentIndex: 0,
+			currentStatus: "running",
 			currentActivityState: "needs_attention",
 			lastActivityAt: 1,
 		});
@@ -285,5 +297,114 @@ describe("subagent control notice delivery", () => {
 		});
 		await wait(15);
 		assert.equal(recorder.sent.length, 2);
+	});
+
+	it("suppresses a terminal foreground child while another parallel child remains live", async () => {
+		const state = makeState();
+		state.foregroundControls.set("run-1", {
+			runId: "run-1",
+			mode: "parallel",
+			startedAt: 0,
+			updatedAt: 2,
+			currentAgent: "reviewer",
+			currentIndex: 1,
+			currentStatus: "running",
+			currentActivityState: undefined,
+			childSnapshots: new Map([
+				[0, { agent: "worker", status: "complete", activityState: "needs_attention" }],
+				[1, { agent: "reviewer", status: "running" }],
+			]),
+		});
+		const recorder = makeRecorder();
+		handleSubagentControlNotice({
+			pi: recorder.pi,
+			state,
+			visibleControlNotices: new Set(),
+			details: { source: "foreground", event: needsAttentionEvent() },
+			foregroundDelayMs: 5,
+		});
+
+		await wait(15);
+		assert.equal(recorder.sent.length, 0);
+		assert.equal(recorder.events.length, 0);
+	});
+
+	it("delivers configured intercom content only after the actionable gate", async () => {
+		const state = makeState();
+		state.foregroundControls.set("run-1", {
+			runId: "run-1",
+			mode: "single",
+			startedAt: 0,
+			updatedAt: 1,
+			currentAgent: "worker",
+			currentIndex: 0,
+			currentStatus: "running",
+			currentActivityState: "needs_attention",
+			lastActivityAt: 1,
+		});
+		const recorder = makeRecorder();
+		handleSubagentControlNotice({
+			pi: recorder.pi,
+			state,
+			visibleControlNotices: new Set(),
+			details: {
+				source: "foreground",
+				event: needsAttentionEvent(),
+				channels: ["intercom"],
+				intercom: { to: "main", message: "UNCHANGED INTERCOM CONTENT" },
+			},
+			foregroundDelayMs: 5,
+		});
+
+		assert.equal(recorder.events.length, 0);
+		await wait(15);
+		assert.equal(recorder.sent.length, 0);
+		assert.deepEqual(recorder.events, [{
+			channel: "subagent:control-intercom",
+			data: {
+				source: "foreground",
+				event: needsAttentionEvent(),
+				channels: ["intercom"],
+				intercom: { to: "main", message: "UNCHANGED INTERCOM CONTENT" },
+				to: "main",
+				message: "UNCHANGED INTERCOM CONTENT",
+			},
+		}]);
+	});
+
+	it("suppresses intercom delivery when the exact child recovers during debounce", async () => {
+		const state = makeState();
+		const childSnapshots = new Map([
+			[0, { agent: "worker", status: "running" as const, activityState: "needs_attention" as const, lastActivityAt: 1 }],
+		]);
+		state.foregroundControls.set("run-1", {
+			runId: "run-1",
+			mode: "parallel",
+			startedAt: 0,
+			updatedAt: 1,
+			currentAgent: "worker",
+			currentIndex: 0,
+			currentStatus: "running",
+			currentActivityState: "needs_attention",
+			childSnapshots,
+		});
+		const recorder = makeRecorder();
+		handleSubagentControlNotice({
+			pi: recorder.pi,
+			state,
+			visibleControlNotices: new Set(),
+			details: {
+				source: "foreground",
+				event: needsAttentionEvent(),
+				channels: ["intercom"],
+				intercom: { to: "main", message: "UNCHANGED INTERCOM CONTENT" },
+			},
+			foregroundDelayMs: 10,
+		});
+		childSnapshots.set(0, { agent: "worker", status: "running", lastActivityAt: 2 });
+
+		await wait(25);
+		assert.equal(recorder.sent.length, 0);
+		assert.equal(recorder.events.some((event) => event.channel === "subagent:control-intercom"), false);
 	});
 });

--- a/test/unit/control-notices.test.ts
+++ b/test/unit/control-notices.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, it } from "node:test";
 import {
 	clearPendingForegroundControlNotices,
@@ -49,6 +52,8 @@ function needsAttentionEvent(overrides: Partial<ControlEvent> = {}): ControlEven
 		index: 0,
 		message: "worker needs attention",
 		reason: "idle",
+		activityEpoch: 1,
+		evidenceLastActivityAt: 1,
 		...overrides,
 	};
 }
@@ -70,53 +75,71 @@ function wait(ms: number): Promise<void> {
 }
 
 describe("subagent control notice delivery", () => {
-	it("delivers async needs-attention notices immediately without changing model-facing content", () => {
-		const state = makeState();
-		state.asyncJobs.set("run-1", {
-			asyncId: "run-1",
-			asyncDir: "/tmp/run-1",
-			status: "running",
-			mode: "chain",
-			chainStepCount: 2,
-			steps: [
-				{ index: 0, agent: "worker", label: "Implement API", status: "running" },
-				{ index: 1, agent: "tester", label: "Validate", status: "pending" },
-			],
-		});
-		const recorder = makeRecorder();
-		const event = needsAttentionEvent({
-			message: "worker needs attention with complete diagnostics",
-			currentPath: "/tmp/project/src/index.ts",
-			toolCount: 7,
-		});
-		const expectedModelContent = formatControlNoticeMessage(event);
+	it("debounces and revalidates async needs-attention notices without changing model-facing content", async () => {
+		const asyncDir = fs.mkdtempSync(path.join(os.tmpdir(), "control-notice-"));
+		try {
+			const state = makeState();
+			state.asyncJobs.set("run-1", {
+				asyncId: "run-1",
+				asyncDir,
+				status: "running",
+				mode: "chain",
+				chainStepCount: 2,
+				steps: [
+					{ index: 0, agent: "worker", label: "Implement API", status: "running" },
+					{ index: 1, agent: "tester", label: "Validate", status: "pending" },
+				],
+			});
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "run-1",
+				mode: "chain",
+				state: "running",
+				startedAt: 0,
+				currentStep: 0,
+				steps: [
+					{ agent: "worker", label: "Implement API", status: "running", activityState: "needs_attention", lastActivityAt: 1 },
+					{ agent: "tester", label: "Validate", status: "pending" },
+				],
+			}));
+			const recorder = makeRecorder();
+			const event = needsAttentionEvent({
+				message: "worker needs attention with complete diagnostics",
+				currentPath: "/tmp/project/src/index.ts",
+				toolCount: 7,
+			});
+			const expectedModelContent = formatControlNoticeMessage(event);
 
-		handleSubagentControlNotice({
-			pi: recorder.pi,
-			state,
-			visibleControlNotices: new Set(),
-			details: { source: "async", event },
-			foregroundDelayMs: 20,
-		});
+			handleSubagentControlNotice({
+				pi: recorder.pi,
+				state,
+				visibleControlNotices: new Set(),
+				details: { source: "async", asyncDir, event },
+				asyncDelayMs: 5,
+			});
 
-		assert.equal(recorder.sent.length, 1);
-		assert.deepEqual(recorder.sent[0]?.options, { triggerTurn: true });
-		const message = recorder.sent[0]?.message as SentControlNotice;
-		assert.equal(message.content, expectedModelContent);
-		assert.equal(message.details.noticeText, expectedModelContent);
-		assert.match(message.content, /worker needs attention with complete diagnostics/);
-		assert.match(message.content, /Status: subagent\(\{ action: "status"/);
-		assert.deepEqual({
-			label: message.details.label,
-			role: message.details.role,
-			logicalStep: message.details.logicalStep,
-			totalSteps: message.details.totalSteps,
-		}, {
-			label: "Implement API",
-			role: "worker",
-			logicalStep: 1,
-			totalSteps: 2,
-		});
+			assert.equal(recorder.sent.length, 0);
+			await wait(20);
+			assert.equal(recorder.sent.length, 1);
+			assert.deepEqual(recorder.sent[0]?.options, { triggerTurn: true });
+			const message = recorder.sent[0]?.message as SentControlNotice;
+			assert.equal(message.content, expectedModelContent);
+			assert.equal(message.details.noticeText, expectedModelContent);
+			assert.match(message.content, /worker needs attention with complete diagnostics/);
+			assert.match(message.content, /Status: subagent\(\{ action: "status"/);
+			assert.deepEqual({
+				label: message.details.label,
+				role: message.details.role,
+				logicalStep: message.details.logicalStep,
+				totalSteps: message.details.totalSteps,
+			}, {
+				label: "Implement API",
+				role: "worker",
+				logicalStep: 1,
+				totalSteps: 2,
+			});
+		} finally {
+			fs.rmSync(asyncDir, { recursive: true, force: true });
+		}
 	});
 
 	it("queues foreground needs-attention notices until the same step is still actionable", async () => {
@@ -205,5 +228,62 @@ describe("subagent control notice delivery", () => {
 
 		await wait(25);
 		assert.equal(recorder.sent.length, 0);
+	});
+
+	it("suppresses async notices when activity resumes before delivery", async () => {
+		const asyncDir = fs.mkdtempSync(path.join(os.tmpdir(), "control-notice-recovery-"));
+		try {
+			const state = makeState();
+			state.asyncJobs.set("run-1", { asyncId: "run-1", asyncDir, status: "running" });
+			const writeStatus = (lastActivityAt: number, activityState?: "needs_attention") => fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "run-1",
+				mode: "single",
+				state: "running",
+				startedAt: 0,
+				steps: [{ agent: "worker", status: "running", activityState, lastActivityAt }],
+			}));
+			writeStatus(1, "needs_attention");
+			const recorder = makeRecorder();
+			handleSubagentControlNotice({
+				pi: recorder.pi,
+				state,
+				visibleControlNotices: new Set(),
+				details: { source: "async", asyncDir, event: needsAttentionEvent() },
+				asyncDelayMs: 15,
+			});
+			writeStatus(2);
+			await wait(30);
+			assert.equal(recorder.sent.length, 0);
+		} finally {
+			fs.rmSync(asyncDir, { recursive: true, force: true });
+		}
+	});
+
+	it("allows a new notice after activity starts a later stale interval", async () => {
+		const state = makeState();
+		state.foregroundControls.set("run-1", {
+			runId: "run-1",
+			mode: "single",
+			startedAt: 0,
+			updatedAt: 0,
+			currentAgent: "worker",
+			currentIndex: 0,
+			currentActivityState: "needs_attention",
+			lastActivityAt: 1,
+		});
+		const recorder = makeRecorder();
+		const visible = new Set<string>();
+		handleSubagentControlNotice({ pi: recorder.pi, state, visibleControlNotices: visible, details: { source: "foreground", event: needsAttentionEvent() }, foregroundDelayMs: 5 });
+		await wait(15);
+		state.foregroundControls.get("run-1")!.lastActivityAt = 2;
+		handleSubagentControlNotice({
+			pi: recorder.pi,
+			state,
+			visibleControlNotices: visible,
+			details: { source: "foreground", event: needsAttentionEvent({ activityEpoch: 2, evidenceLastActivityAt: 2 }) },
+			foregroundDelayMs: 5,
+		});
+		await wait(15);
+		assert.equal(recorder.sent.length, 2);
 	});
 });

--- a/test/unit/human-messages.test.ts
+++ b/test/unit/human-messages.test.ts
@@ -90,6 +90,46 @@ describe("compact human message formatting", () => {
 		assert.match(rendered, /Recommendation: inspect current status/);
 	});
 
+	it("uses safe legacy control content as an expanded structured fallback only", () => {
+		const legacyContent = [
+			"Subagent needs attention: worker",
+			"Run: 12345678-abcd-4abc-8abc-1234567890ab step 3",
+			"Signal: The compiler found a compatibility regression in the public API.",
+			"Recent failures: npm test failed in compatibility.test.ts",
+			"Facts: 9 turns | 17 tools",
+			"Hint: Inspect the failing assertion before changing the implementation.",
+			'Status: subagent({ action: "status", id: "12345678-abcd-4abc-8abc-1234567890ab" })',
+			'Interrupt: subagent({ action: "interrupt", id: "12345678-abcd-4abc-8abc-1234567890ab" })',
+			"Direct intercom target: internal-worker-channel",
+		].join("\n");
+		const details = {
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 4,
+			event: controlEvent({
+				message: "",
+				currentTool: undefined,
+				currentPath: undefined,
+				recentFailureSummary: undefined,
+				turns: undefined,
+				tokens: undefined,
+				toolCount: undefined,
+			}),
+		};
+
+		const collapsed = formatHumanControlNotice(details, false, "Alt+E", legacyContent);
+		const expanded = formatHumanControlNotice(details, true, "Alt+E", legacyContent);
+
+		assert.match(collapsed, /Alt\+E for details/);
+		assert.doesNotMatch(collapsed, /compatibility regression|subagent\s*\(|intercom target/i);
+		assert.match(expanded, /Observed: The compiler found a compatibility regression in the public API\./);
+		assert.match(expanded, /Recent failures: npm test failed in compatibility\.test\.ts/);
+		assert.match(expanded, /Diagnostics: 9 turns \| 17 tools/);
+		assert.match(expanded, /Recommendation: Inspect the failing assertion/);
+		assert.doesNotMatch(expanded, /subagent\s*\(|intercom target|internal-worker-channel|action: "(?:status|interrupt)"/i);
+	});
+
 	it("renders supervisor requests compactly and expands the complete question and interview", () => {
 		const details = supervisorDetails({
 			reason: "interview_request",
@@ -110,6 +150,41 @@ describe("compact human message formatting", () => {
 		assert.match(expanded, /Should the API return 404 or 410\?\nThe compatibility contract is ambiguous\./);
 		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice/);
 		assert.match(expanded, /Questions:\n  - Id: status\n    Choices:\n      - 404\n      - 410/);
+	});
+
+	it("extracts complete legacy questions and interviews without rendering commands or raw JSON", () => {
+		const legacyContent = [
+			"Subagent requests a structured supervisor interview.",
+			"Run: abcdef12-abcd-4abc-8abc-1234567890ab",
+			"Agent: worker",
+			"Child index: 1",
+			"Child intercom target: internal-worker-channel",
+			"",
+			"Which status preserves compatibility?",
+			"Include the migration impact in the decision.",
+			"",
+			"Structured response requested. Reply with JSON, optionally fenced in ```json, matching the requested interview shape.",
+			JSON.stringify({
+				title: "Compatibility choice",
+				questions: [{ id: "status", prompt: "Select the status", choices: [404, 410] }],
+			}, null, "\t"),
+			"",
+			'Reply with: subagent_supervisor({ action: "reply", replyTo: "request-123", message: "..." })',
+		].join("\n");
+		const details = supervisorDetails({ reason: "interview_request", question: undefined, interview: undefined });
+
+		const collapsed = formatHumanSupervisorRequest(details, false, "Alt+E", legacyContent);
+		const expanded = formatHumanSupervisorRequest(details, true, "Alt+E", legacyContent);
+
+		assert.equal(collapsed, [
+			"⚠ Supervisor interview needed · Implement API [worker]",
+			"Which status preserves compatibility? · Step 2/4 · run abcdef12 · Alt+E for details",
+		].join("\n"));
+		assert.match(expanded, /Which status preserves compatibility\?\nInclude the migration impact in the decision\./);
+		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice/);
+		assert.match(expanded, /Prompt: Select the status/);
+		assert.match(expanded, /Choices:\n      - 404\n      - 410/);
+		assert.doesNotMatch(expanded, /subagent_supervisor\s*\(|replyTo|internal-worker-channel|[{}]|"questions"/i);
 	});
 
 	it("keeps progress updates visually informational and marks them as no-reply", () => {

--- a/test/unit/human-messages.test.ts
+++ b/test/unit/human-messages.test.ts
@@ -130,11 +130,35 @@ describe("compact human message formatting", () => {
 		assert.doesNotMatch(expanded, /subagent\s*\(|intercom target|internal-worker-channel|action: "(?:status|interrupt)"/i);
 	});
 
+	it("prefers complete structured control fields over lossy legacy summaries", () => {
+		const details = {
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 4,
+			event: controlEvent({
+				message: "First observed line.\nSecond observed line.",
+				recentFailureSummary: "First failure line.\nSecond failure line.",
+			}),
+		};
+		const legacyContent = [
+			"Signal: Truncated legacy observation",
+			"Recent failures: Truncated legacy failure",
+		].join("\n");
+
+		const expanded = formatHumanControlNotice(details, true, "Ctrl+O", legacyContent);
+
+		assert.match(expanded, /Observed: First observed line\.\nSecond observed line\./);
+		assert.match(expanded, /Recent failures: First failure line\.\nSecond failure line\./);
+		assert.doesNotMatch(expanded, /Truncated legacy/);
+	});
+
 	it("renders supervisor requests compactly and expands the complete question and interview", () => {
 		const details = supervisorDetails({
 			reason: "interview_request",
 			interview: {
 				title: "Compatibility choice",
+				action: "choose release strategy",
 				questions: [{ id: "status", choices: [404, 410] }],
 			},
 		});
@@ -148,7 +172,7 @@ describe("compact human message formatting", () => {
 		assert.doesNotMatch(collapsed, /compatibility contract|Compatibility choice|Choices/);
 		assert.match(expanded, /Reply required/);
 		assert.match(expanded, /Should the API return 404 or 410\?\nThe compatibility contract is ambiguous\./);
-		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice/);
+		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice\nAction: choose release strategy/);
 		assert.match(expanded, /Questions:\n  - Id: status\n    Choices:\n      - 404\n      - 410/);
 	});
 

--- a/test/unit/human-messages.test.ts
+++ b/test/unit/human-messages.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	formatHumanControlNotice,
+	formatHumanSupervisorRequest,
+	resolveChildPresentation,
+	type SupervisorRequestMessageDetails,
+} from "../../src/extension/human-messages.ts";
+import type { ControlEvent, SubagentState } from "../../src/shared/types.ts";
+
+function controlEvent(overrides: Partial<ControlEvent> = {}): ControlEvent {
+	return {
+		type: "needs_attention",
+		to: "needs_attention",
+		ts: 1,
+		runId: "12345678-abcd-4abc-8abc-1234567890ab",
+		agent: "worker",
+		index: 2,
+		message: "No child activity was observed during the attention window.",
+		reason: "idle",
+		elapsedMs: 125_000,
+		currentTool: "bash",
+		currentToolDurationMs: 65_000,
+		currentPath: "/tmp/project/src/index.ts",
+		recentFailureSummary: "npm test exited 1",
+		turns: 8,
+		tokens: 4321,
+		toolCount: 12,
+		...overrides,
+	};
+}
+
+function supervisorDetails(overrides: Partial<SupervisorRequestMessageDetails> = {}): SupervisorRequestMessageDetails {
+	return {
+		id: "request-123",
+		reason: "need_decision",
+		expectsReply: true,
+		runId: "abcdef12-abcd-4abc-8abc-1234567890ab",
+		agent: "worker",
+		childIndex: 1,
+		label: "Implement API",
+		role: "worker",
+		logicalStep: 2,
+		totalSteps: 4,
+		question: "Should the API return 404 or 410?\nThe compatibility contract is ambiguous.",
+		...overrides,
+	};
+}
+
+function presentationState(): Pick<SubagentState, "asyncJobs" | "foregroundRuns"> {
+	return {
+		asyncJobs: new Map(),
+		foregroundRuns: new Map(),
+	};
+}
+
+describe("compact human message formatting", () => {
+	it("renders control notices compact by default without verbose diagnostics", () => {
+		const rendered = formatHumanControlNotice({
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 4,
+			event: controlEvent(),
+		}, false, "Ctrl+O");
+
+		assert.equal(rendered, [
+			"⚠ Implement API [worker] may be stuck · no activity for 2m 5s",
+			"Step 2/4 · run 12345678 · Ctrl+O for details",
+		].join("\n"));
+		assert.doesNotMatch(rendered, /No child activity|\/tmp\/project|npm test|4321/);
+	});
+
+	it("renders complete control diagnostics when expanded", () => {
+		const rendered = formatHumanControlNotice({
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 4,
+			event: controlEvent(),
+		}, true, "Ctrl+O");
+
+		assert.match(rendered, /^⚠ Implement API \[worker\] may be stuck/);
+		assert.match(rendered, /Implement API \[worker\] · Step 2\/4 · run 12345678/);
+		assert.match(rendered, /Observed: No child activity was observed during the attention window\./);
+		assert.match(rendered, /Current activity: bash for 1m 5s/);
+		assert.match(rendered, /Working in: \/tmp\/project\/src\/index\.ts/);
+		assert.match(rendered, /Recent failures: npm test exited 1/);
+		assert.match(rendered, /Diagnostics: 8 turns · 4321 tokens · 12 tools/);
+		assert.match(rendered, /Recommendation: inspect current status/);
+	});
+
+	it("renders supervisor requests compactly and expands the complete question and interview", () => {
+		const details = supervisorDetails({
+			reason: "interview_request",
+			interview: {
+				title: "Compatibility choice",
+				questions: [{ id: "status", choices: [404, 410] }],
+			},
+		});
+		const collapsed = formatHumanSupervisorRequest(details, false, "Ctrl+O");
+		const expanded = formatHumanSupervisorRequest(details, true, "Ctrl+O");
+
+		assert.equal(collapsed, [
+			"⚠ Supervisor interview needed · Implement API [worker]",
+			"Should the API return 404 or 410? · Step 2/4 · run abcdef12 · Ctrl+O for details",
+		].join("\n"));
+		assert.doesNotMatch(collapsed, /compatibility contract|Compatibility choice|Choices/);
+		assert.match(expanded, /Reply required/);
+		assert.match(expanded, /Should the API return 404 or 410\?\nThe compatibility contract is ambiguous\./);
+		assert.match(expanded, /Structured interview:\nTitle: Compatibility choice/);
+		assert.match(expanded, /Questions:\n  - Id: status\n    Choices:\n      - 404\n      - 410/);
+	});
+
+	it("keeps progress updates visually informational and marks them as no-reply", () => {
+		const rendered = formatHumanSupervisorRequest(supervisorDetails({
+			reason: "progress_update",
+			expectsReply: false,
+			question: "Validation is now passing.",
+		}), true, "Ctrl+O");
+
+		assert.match(rendered, /^↗ Implement API \[worker\] · progress update/);
+		assert.match(rendered, /No reply required/);
+		assert.match(rendered, /Validation is now passing\./);
+	});
+});
+
+describe("child presentation details", () => {
+	it("uses async labels and logical chain positions for flattened parallel children", () => {
+		const state = presentationState();
+		state.asyncJobs.set("run-chain", {
+			asyncId: "run-chain",
+			asyncDir: "/tmp/run-chain",
+			status: "running",
+			mode: "chain",
+			chainStepCount: 3,
+			parallelGroups: [{ start: 1, count: 2, stepIndex: 1 }],
+			steps: [
+				{ index: 0, agent: "scout", label: "Discover", status: "complete" },
+				{ index: 1, agent: "reviewer", label: "API review", status: "running" },
+				{ index: 2, agent: "worker", label: "Implementation", status: "running" },
+				{ index: 3, agent: "tester", label: "Validate", status: "pending" },
+			],
+		});
+
+		assert.deepEqual(resolveChildPresentation(state, "run-chain", "worker", 2), {
+			label: "Implementation",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 3,
+		});
+	});
+
+	it("falls back to stable agent and child-index details when run metadata is unavailable", () => {
+		assert.deepEqual(resolveChildPresentation(presentationState(), "missing-run", "worker", 3), {
+			label: "worker",
+			role: "worker",
+			logicalStep: 4,
+		});
+	});
+});

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -48,7 +48,19 @@ function makeState(sessionId: string | null, ctx: unknown): SubagentState {
 	};
 }
 
-function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string; createdAt?: number; expiresAt?: number }): string {
+function writeRequest(input: {
+	sessionId: string;
+	runId: string;
+	agent?: string;
+	index?: number;
+	message?: string;
+	question?: string;
+	reason?: "need_decision" | "interview_request" | "progress_update";
+	expectsReply?: boolean;
+	interview?: unknown;
+	createdAt?: number;
+	expiresAt?: number;
+}): string {
 	const agent = input.agent ?? "worker";
 	const index = input.index ?? 0;
 	const channelDir = resolveSupervisorChannelDir(input.runId, agent, index);
@@ -60,14 +72,16 @@ function writeRequest(input: { sessionId: string; runId: string; agent?: string;
 		id: requestId,
 		createdAt: input.createdAt ?? Date.now(),
 		...(input.expiresAt !== undefined ? { expiresAt: input.expiresAt } : {}),
-		reason: "need_decision",
+		reason: input.reason ?? "need_decision",
 		message: input.message ?? "Need a decision",
-		expectsReply: true,
+		expectsReply: input.expectsReply ?? true,
 		orchestratorSessionId: input.sessionId,
 		orchestratorTarget: "shared-name",
 		runId: input.runId,
 		agent,
 		childIndex: index,
+		...(input.question ? { question: input.question } : {}),
+		...(input.interview !== undefined ? { interview: input.interview } : {}),
 	}, null, "\t"));
 	return requestId;
 }
@@ -140,6 +154,90 @@ describe("native supervisor channel", () => {
 		assert.deepEqual(sent.map((message) => message.details?.id), [matchingId]);
 		assert.equal(channel.pending.has(matchingId), false, "disposed channel clears pending requests");
 		assert.equal(sent.some((message) => message.details?.id === otherId), false);
+	});
+
+	it("adds complete structured presentation details without changing model-facing request content", () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const modelContent = [
+			"Subagent requests a structured supervisor interview.",
+			`Run: ${runId}`,
+			"Agent: worker",
+			"Child index: 1",
+			"",
+			"Choose the compatible status code. Full context remains model-visible.",
+			"",
+			"Structured response requested. Reply with JSON matching the requested interview shape.",
+			'{"choices":[404,410]}',
+		].join("\n");
+		const question = "Choose the compatible status code.\nFull context remains model-visible.";
+		const interview = { title: "Status code", questions: [{ id: "status", choices: [404, 410] }] };
+		const requestId = writeRequest({
+			sessionId: currentSessionId,
+			runId,
+			index: 1,
+			reason: "interview_request",
+			message: modelContent,
+			question,
+			interview,
+		});
+		const sent: Array<{
+			customType?: string;
+			content?: string;
+			display?: boolean;
+			details?: Record<string, unknown>;
+		}> = [];
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const state = makeState(currentSessionId, ctx);
+		state.asyncJobs.set(runId, {
+			asyncId: runId,
+			asyncDir: `/tmp/${runId}`,
+			status: "running",
+			mode: "chain",
+			chainStepCount: 3,
+			steps: [
+				{ index: 0, agent: "scout", label: "Discover", status: "complete" },
+				{ index: 1, agent: "worker", label: "Implement API", status: "running" },
+				{ index: 2, agent: "tester", label: "Validate", status: "pending" },
+			],
+		});
+		const pi = {
+			getAllTools: () => [],
+			registerTool: () => {},
+			sendMessage: (message: typeof sent[number]) => { sent.push(message); },
+			getSessionName: () => "shared-name",
+		};
+		const channel = createNativeSupervisorChannel(pi as never, state);
+
+		channel.start();
+		channel.dispose();
+
+		assert.equal(sent.length, 1);
+		assert.equal(sent[0]?.customType, "subagent_supervisor_request");
+		assert.equal(sent[0]?.display, true);
+		assert.equal(sent[0]?.content, `${modelContent}\n\nReply with: ${NATIVE_SUPERVISOR_TOOL_NAME}({ action: "reply", replyTo: "${requestId}", message: "..." })`);
+		assert.deepEqual(sent[0]?.details, {
+			id: requestId,
+			reason: "interview_request",
+			expectsReply: true,
+			runId,
+			agent: "worker",
+			childIndex: 1,
+			label: "Implement API",
+			role: "worker",
+			logicalStep: 2,
+			totalSteps: 3,
+			question,
+			interview,
+		});
 	});
 
 	it("prunes stale empty supervisor channel directories before polling", () => {

--- a/test/unit/subagent-control.test.ts
+++ b/test/unit/subagent-control.test.ts
@@ -7,6 +7,7 @@ import {
 	deriveActivityState,
 	formatControlIntercomMessage,
 	formatControlNoticeMessage,
+	isControlEventActionable,
 	resolveControlConfig,
 	shouldNotifyControlEvent,
 } from "../../src/runs/shared/subagent-control.ts";
@@ -24,6 +25,10 @@ describe("subagent control attention state", () => {
 		assert.equal(deriveActivityState({ config, startedAt: 0, now: 400 }), "needs_attention");
 	});
 
+	it("keeps a known in-flight tool active until the long-running threshold", () => {
+		assert.equal(deriveActivityState({ config, startedAt: 0, lastActivityAt: 0, currentTool: "bash", currentToolStartedAt: 100, now: 400 }), undefined);
+		assert.equal(deriveActivityState({ config, startedAt: 0, lastActivityAt: 0, currentTool: "bash", currentToolStartedAt: 100, now: 240_100 }), "active_long_running");
+	});
 
 	it("builds compact needs-attention control events", () => {
 		const event = buildControlEvent({
@@ -44,6 +49,8 @@ describe("subagent control attention state", () => {
 			message: "worker needs attention (no observed activity for 0s)",
 			reason: "idle",
 			elapsedMs: 900,
+			activityEpoch: 100,
+			evidenceLastActivityAt: 100,
 		});
 	});
 
@@ -229,13 +236,15 @@ describe("subagent control attention state", () => {
 		assert.match(message, /Routed live nested nudge: subagent\(\{ action: "resume", id: "78f659a3", message: "What are you blocked on\?/);
 	});
 
-	it("dedupes notifications once per child target and attention state", () => {
-		const event = buildControlEvent({ to: "needs_attention", runId: "run-1", agent: "worker", index: 0 });
+	it("dedupes once per activity epoch and permits a later genuine stall", () => {
+		const event = buildControlEvent({ to: "needs_attention", runId: "run-1", agent: "worker", index: 0, lastActivityAt: 100 });
+		const laterStall = buildControlEvent({ to: "needs_attention", runId: "run-1", agent: "worker", index: 0, lastActivityAt: 200 });
 		const seen = new Set<string>();
 
-		assert.equal(controlNotificationKey(event, "subagent-worker-run-1-1"), "subagent-worker-run-1-1:needs_attention:idle");
+		assert.equal(controlNotificationKey(event, "subagent-worker-run-1-1"), "subagent-worker-run-1-1:needs_attention:idle:100");
 		assert.equal(claimControlNotification(resolveControlConfig(), event, seen, "subagent-worker-run-1-1"), true);
 		assert.equal(claimControlNotification(resolveControlConfig(), event, seen, "subagent-worker-run-1-1"), false);
+		assert.equal(claimControlNotification(resolveControlConfig(), laterStall, seen, "subagent-worker-run-1-1"), true);
 
 		const terminalEvent = buildControlEvent({
 			to: "needs_attention",
@@ -246,5 +255,15 @@ describe("subagent control attention state", () => {
 			reason: "completion_guard",
 		});
 		assert.equal(claimControlNotification(resolveControlConfig(), terminalEvent, seen, "subagent-worker-run-1-1"), true);
+	});
+
+	it("requires exact active state and unchanged activity evidence", () => {
+		const event = buildControlEvent({ to: "needs_attention", runId: "run-1", agent: "worker", index: 2, lastActivityAt: 100 });
+		const active = { runId: "run-1", state: "running", agent: "worker", index: 2, activityState: "needs_attention" as const, lastActivityAt: 100 };
+		assert.equal(isControlEventActionable(event, active), true);
+		assert.equal(isControlEventActionable(event, { ...active, lastActivityAt: 101 }), false);
+		assert.equal(isControlEventActionable(event, { ...active, state: "complete" }), false);
+		assert.equal(isControlEventActionable(event, { ...active, index: 3 }), false);
+		assert.equal(isControlEventActionable(event, { ...active, currentTool: "bash" }), false);
 	});
 });

--- a/test/unit/subagent-control.test.ts
+++ b/test/unit/subagent-control.test.ts
@@ -259,10 +259,11 @@ describe("subagent control attention state", () => {
 
 	it("requires exact active state and unchanged activity evidence", () => {
 		const event = buildControlEvent({ to: "needs_attention", runId: "run-1", agent: "worker", index: 2, lastActivityAt: 100 });
-		const active = { runId: "run-1", state: "running", agent: "worker", index: 2, activityState: "needs_attention" as const, lastActivityAt: 100 };
+		const active = { runId: "run-1", state: "running", agent: "worker", index: 2, status: "running", activityState: "needs_attention" as const, lastActivityAt: 100 };
 		assert.equal(isControlEventActionable(event, active), true);
 		assert.equal(isControlEventActionable(event, { ...active, lastActivityAt: 101 }), false);
 		assert.equal(isControlEventActionable(event, { ...active, state: "complete" }), false);
+		assert.equal(isControlEventActionable(event, { ...active, status: "complete" }), false);
 		assert.equal(isControlEventActionable(event, { ...active, index: 3 }), false);
 		assert.equal(isControlEventActionable(event, { ...active, currentTool: "bash" }), false);
 	});


### PR DESCRIPTION
## Summary

- Uses compact collapsed control and supervisor messages while keeping substantive detail in the expanded view.
- Preserves complete model-facing commands, identifiers, structured interviews, and persisted content.
- Debounces delivery and revalidates the exact child before showing a message to the user.
- Suppresses notices after recovery, completion, chain advancement, or activity-epoch changes.
- Routes visible and intercom delivery through the same final actionability gate.
- Classifies in-flight tool execution separately from inactivity.

## Compatibility

Only human presentation and stale-notice delivery change. Model-facing operational content, execution semantics, child ordering, output, artifacts, and transcripts remain intact.

## Validation

Rebased the five PR commits onto `dd24e35` (current `main`, including #509 deterministic steering fixes). New head: `b27c67b`.

- Human-message, control-notice, supervisor-channel, and subagent-control unit suites: 45 passed.
- Full steering-action unit file: 10 passed.
- Async job tracker integration file: 27 passed.
- Selected foreground control lifecycle integrations: 3 passed.
- Selected background control lifecycle and Windows hard-kill regressions: passed.
- `git diff --check`: passed.
- Fresh CI: Ubuntu passed; Windows hit an unrelated concurrent-revival timing failure, while that exact test passed on focused local rerun.

## Consolidation

Supersedes draft #501.

