### PR TITLE
fix: synchronize async lifecycle regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- Made the steering pre-recovery acknowledgment regression synchronize at the committed-request boundary instead of depending on CI scheduler timing.
+- Made steering pre-recovery acknowledgment and Windows async hard-kill regressions synchronize around their actual lifecycle boundaries instead of depending on CI scheduler or process-start timing.
 - Added YAML folded block scalar support for agent and chain frontmatter descriptions, preserving quoted indicators, more-indented content, and blank-line separators. Thanks to Luis Cinco (@tekniko24) for #488.
 - Distinguished interactive async yielding from headless auto-drain guidance, so interactive sessions return control by default while non-interactive sessions retain a completion path. Thanks to Luke Chen (@lukechen526) for #480.
 - Deferred hard turn-budget termination when an assistant starts tool work at the limit, exposing `termination-deferred` until the next safe assistant boundary while elapsed timeout and explicit stop retain precedence. Guidance now conservatively keeps hard turn and tool-call caps off mutation-capable workers. Thanks to JT (@juicetin) for #482 and #483.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Made the steering pre-recovery acknowledgment regression synchronize at the committed-request boundary instead of depending on CI scheduler timing.
 - Added YAML folded block scalar support for agent and chain frontmatter descriptions, preserving quoted indicators, more-indented content, and blank-line separators. Thanks to Luis Cinco (@tekniko24) for #488.
 - Distinguished interactive async yielding from headless auto-drain guidance, so interactive sessions return control by default while non-interactive sessions retain a completion path. Thanks to Luke Chen (@lukechen526) for #480.
 - Deferred hard turn-budget termination when an assistant starts tool work at the limit, exposing `termination-deferred` until the next safe assistant boundary while elapsed timeout and explicit stop retain precedence. Guidance now conservatively keeps hard turn and tool-call caps off mutation-capable workers. Thanks to JT (@juicetin) for #482 and #483.

--- a/src/runs/foreground/async-steering-action.ts
+++ b/src/runs/foreground/async-steering-action.ts
@@ -20,6 +20,8 @@ export async function steerAsyncRun(input: {
 	signal?: AbortSignal;
 	ackTimeoutMs?: number;
 	recoveryTimeoutMs?: number;
+	onRequestQueued?: (requestPath: string) => void;
+	onBeforeRecoveryClaim?: (requestId: string, committedAt: number) => void;
 	onRecoveryCommitted?: (requestId: string, committedAt: number) => void;
 	recover?: (limits: { timeoutMs?: number; absoluteDeadlineAt?: number; turnBudget?: TurnBudgetConfig; toolBudget?: ToolBudgetConfig }) => Promise<AgentToolResult<Details>>;
 }): Promise<AgentToolResult<Details>> {
@@ -86,8 +88,9 @@ export async function steerAsyncRun(input: {
 		};
 	}
 	const requestId = randomUUID();
+	let requestPath: string;
 	try {
-		requestAsyncSteer(asyncDir, {
+		requestPath = requestAsyncSteer(asyncDir, {
 			message: input.message,
 			...(effectiveTargetIndex !== undefined ? { targetIndex: effectiveTargetIndex } : { targetIndexes }),
 			source: "steer-action",
@@ -100,6 +103,7 @@ export async function steerAsyncRun(input: {
 			details: { mode: "management", results: [] },
 		};
 	}
+	input.onRequestQueued?.(requestPath);
 	const tracked = input.state.asyncJobs.get(status.runId);
 	if (tracked) tracked.updatedAt = Date.now();
 	const targets = targetIndexes.map((index) => ({ index, state: status.steps?.[index]?.status === "pending" ? "scheduled" as const : "pending" as const }));
@@ -132,6 +136,7 @@ export async function steerAsyncRun(input: {
 			const latestResult = latest?.steering ? actionResultFromSteeringStatus(latest.steering, status.runId, requestId) : undefined;
 			if (latestResult?.state === "delivered") return { content: [{ type: "text", text: `Steering delivered for async run ${status.runId} (request ${requestId}).` }], details: { mode: "management", results: [], steering: latestResult } };
 			const committedAt = Date.now();
+			input.onBeforeRecoveryClaim?.(requestId, committedAt);
 			const { claimPath, markerPath } = claimSteeringRecovery(asyncDir, { requestId, sourceRunId: status.runId, committedAt });
 			input.onRecoveryCommitted?.(requestId, committedAt);
 			const preCommitStatus = readStatus(asyncDir);

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -684,7 +684,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	it("hard-kills async children that ignore timeout SIGTERM", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ delay: 60_000, ignoreSigterm: true, output: "too late" });
 		const id = `async-timeout-hard-kill-${Date.now().toString(36)}`;
-		const timeoutMs = 1_500;
+		const timeoutMs = process.platform === "win32" ? 5_000 : 1_500;
 		const startedAt = Date.now();
 		executeAsyncSingle(id, {
 			agent: "stubborn",
@@ -705,7 +705,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		});
 
 		await waitForMockPiCall(mockPi, 0, 10_000);
-		const resultPath = await waitForAsyncResultFile(id, 8_000);
+		const resultPath = await waitForAsyncResultFile(id, 10_000);
 		const elapsedMs = Date.now() - startedAt;
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
 		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
@@ -715,7 +715,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.results[0]?.error, `Subagent timed out after ${timeoutMs}ms.`);
 		assert.equal(status.timedOut, true);
 		assert.equal(status.steps?.[0]?.timedOut, true);
-		assert.ok(elapsedMs < 7_000, `timeout result should settle after hard kill, elapsed ${elapsedMs}ms`);
+		assert.ok(elapsedMs < timeoutMs + 4_000, `timeout result should settle after hard kill, elapsed ${elapsedMs}ms`);
 		assert.equal(mockPi.callCount(), 1);
 	});
 

--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -169,27 +169,32 @@ describe("acknowledged steering action", () => {
 		let interrupted = false;
 		let recovered = false;
 		try {
-			const action = steerAsyncRun({
-				state: createState(), runId, message: "correct course", location: { asyncDir }, ackTimeoutMs: 500,
+			const result = await steerAsyncRun({
+				state: createState(), runId, message: "correct course", location: { asyncDir }, ackTimeoutMs: 25,
 				kill: (_pid, signal) => { if (signal !== 0) interrupted = true; return true; },
-				onRecoveryCommitted: (_requestId, committedAt) => {
+				onRequestQueued: (requestPath) => {
+					request = JSON.parse(fs.readFileSync(requestPath, "utf-8")) as SteerRequest;
+					const routed = runningStatus(runId);
+					projectRequest(routed, request, ["routed"]);
+					writeStatus(asyncDir, routed);
+				},
+				onBeforeRecoveryClaim: (_requestId, committedAt) => {
 					assert.ok(request);
+					const recoveryDir = path.join(asyncDir, "control", "steer-recovery");
+					assert.equal(fs.existsSync(path.join(recoveryDir, "claim.json")), false);
+					assert.equal(fs.existsSync(path.join(recoveryDir, `${Buffer.from(request.id).toString("base64url")}.json`)), false);
 					const acknowledged = runningStatus(runId);
-					projectRequest(acknowledged, request!, ["routed"]);
-					updateSteeringTarget(acknowledged.steering!, request!.id, 0, "delivered", committedAt);
-					updateSteeringTarget(acknowledged.steps![0]!.steering!, request!.id, 0, "delivered", committedAt);
+					projectRequest(acknowledged, request, ["routed"]);
+					updateSteeringTarget(acknowledged.steering!, request.id, 0, "delivered", committedAt);
+					updateSteeringTarget(acknowledged.steps![0]!.steering!, request.id, 0, "delivered", committedAt);
 					writeStatus(asyncDir, acknowledged);
 				},
 				recover: async () => { recovered = true; return successResult("replacement"); },
 			});
-			request = await readRequest(asyncDir);
-			const routed = runningStatus(runId);
-			projectRequest(routed, request, ["routed"]);
-			writeStatus(asyncDir, routed);
-			const result = await action;
 			assert.equal(result.details.steering?.state, "delivered");
 			assert.equal(interrupted, false);
 			assert.equal(recovered, false);
+			assert.ok(request);
 			assert.equal(fs.existsSync(path.join(asyncDir, "control", "steer-recovery", `${Buffer.from(request.id).toString("base64url")}.json`)), false);
 		} finally {
 			fs.rmSync(asyncDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Make the steering pre-recovery acknowledgment regression deterministic under the full concurrent unit suite.

The test previously started a 500 ms acknowledgment clock, then polled the queued request from a separate task before projecting it as routed. Under loaded Ubuntu CI this repeatedly exhausted the clock first and returned `pending`, even though the production contract was unchanged.

The follow-up adds two internal test seams around existing durable boundaries. `onRequestQueued` runs after the steering request is atomically committed and before acknowledgment waiting begins. `onBeforeRecoveryClaim` runs immediately before `claimSteeringRecovery`. The regression now projects routing synchronously, persists the delivered acknowledgment at the pre-claim boundary, and asserts that neither the recovery claim nor request marker exists yet.

Normal production callers omit both seams and retain the existing behavior.

Windows CI also exposed an unrelated startup race in the async hard-kill integration test: its 1.5-second production timeout could expire before the detached mock child had entered and installed its `SIGTERM` handler. The test now retains the 1.5-second Unix deadline, allows 5 seconds for Windows process startup, proves the stubborn child entered, and still requires the timed-out result to settle within the production four-second hard-kill grace. No production timeout behavior changed.

## Validation

- Steering action suite passed in 10 consecutive process runs
- Full unit suite: 1,269 passed, 1 expected skip
- Full integration suite: 596 passed, 2 non-Windows skips
- Real Pi-session E2E: 2/2 passed
- Async integration file: 91/91 passed
- Focused hard-kill test passed in three consecutive runs
- `git diff --check` passed
