### PR TITLE
Route async completions to their launch branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Route detached async result artifacts by their launch branch, retaining them while a sibling branch is selected and retrying after session-tree navigation, including stale-run recovery.
 - Removed the hidden default limit of 40 cumulative subagent launches per session. Sessions are unlimited unless a positive `maxSubagentSpawnsPerSession` or `PI_SUBAGENT_MAX_SPAWNS_PER_SESSION` cap is configured; `0` explicitly means unlimited. Thanks to @Maverobot, @KawaiiNahida, and @markng for the follow-up reports on #239.
 - Fork-context sanitization no longer disables thinking for every child. Forking over a transcript with signed Anthropic thinking blocks now classifies each child’s effective primary and fallback models through registry provider/API metadata, forces thinking off for Anthropic-backed or unresolved candidates, and reports every downgrade even when the run fails. Other resolved providers keep their requested thinking level. The tool description also documents thinking suffixes, including `max`, and the fork/thinking interaction. Thanks to Jeff (@jefftheai) for #476.
 

--- a/README.md
+++ b/README.md
@@ -1460,7 +1460,7 @@ stdin is a JSON object with `repoRoot`, `worktreePath`, `agentCwd`, `branch`, `i
 
 Controls smart batching of async-completion notifications. When several background subagents finish within a short window, their successful completions are held briefly and delivered as a single grouped message instead of separate notifications. A hard `maxWaitMs` cap (measured from the first completion in a group) guarantees nothing is held indefinitely, and late-finishing siblings that arrive within `stragglerWindowMs` of a group emit join a shorter straggler group governed by `stragglerDebounceMs` and `stragglerMaxWaitMs`.
 
-Failed and paused completions bypass batching and fire immediately, flushing any held successes first, so failure and needs-attention signals are never delayed. Set `enabled` to `false` to restore the original one-notification-per-completion behavior. Changes apply on the next session start.
+Failed and paused completions bypass batching and fire immediately, flushing any held successes first, so failure and needs-attention signals are never delayed. Results tied to a session-tree launch branch also bypass batching to minimize the gap between branch matching and notification. Set `enabled` to `false` to restore the original one-notification-per-completion behavior. Changes apply on the next session start.
 
 ## Files, logs, and observability
 
@@ -1483,7 +1483,7 @@ Metadata records timing, usage, exit code, final model, attempted models, fallba
 
 Session files are stored under a per-run session directory. With `context: "fork"`, each child starts with `--session <branched-session-file>` produced from the parent’s current leaf. That is a real session fork, not an injected summary.
 
-Async completions notify only the originating session. The result watcher emits `subagent:async-complete`, and the extension consumes that event to render completion notifications. Successful sibling completions are held briefly and delivered as a single grouped message when they finish within a short window (see `completionBatch`); failed and paused completions always fire immediately.
+Async completions notify only the originating session. Detached results also retain the session-tree leaf where they launched: a result remains available while a sibling branch is selected and is retried after returning to the launch branch. The result watcher emits `subagent:async-complete`, and the extension consumes that event to render completion notifications. Successful unanchored sibling completions are held briefly and delivered as a single grouped message when they finish within a short window (see `completionBatch`); branch-scoped, failed, and paused completions fire immediately. Pi's current notification API has no branch target, so the final delivery remains best-effort if Pi queues it while a user changes branches.
 
 Async runs write:
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -266,6 +266,15 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		state,
 		RESULTS_DIR,
 		10 * 60 * 1000,
+		{
+			isLaunchLeafOnCurrentBranch(launchLeafId) {
+				try {
+					return state.lastUiContext?.sessionManager.getBranch().some((entry) => entry.id === launchLeafId) ?? false;
+				} catch {
+					return false;
+				}
+			},
+		},
 	);
 	startResultWatcher();
 	primeExistingResults();
@@ -567,6 +576,11 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		resetSessionState(ctx);
 		rpcBridge.emitReady(ctx);
 		supervisorChannel.start();
+	});
+
+	pi.on("session_tree", (_event, ctx) => {
+		state.lastUiContext = ctx;
+		primeExistingResults();
 	});
 
 	pi.on("session_shutdown", () => {

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -105,6 +105,8 @@ interface AsyncExecutionContext {
 	pi: ExtensionAPI;
 	cwd: string;
 	currentSessionId: string;
+	/** Session-tree leaf current when this detached run was launched. */
+	launchLeafId?: string;
 	/** Parent session id used by permission-system ask forwarding. */
 	parentSessionId?: string;
 	currentModelProvider?: string;
@@ -889,6 +891,7 @@ export function executeAsyncChain(
 				sessionDir: sessionRoot ? path.join(sessionRoot, `async-${id}`) : undefined,
 				asyncDir,
 				sessionId: ctx.currentSessionId,
+				...(ctx.launchLeafId !== undefined ? { launchLeafId: ctx.launchLeafId } : {}),
 				piPackageRoot,
 				piArgv1: process.argv[1],
 				worktreeSetupHook,
@@ -997,6 +1000,7 @@ export function executeAsyncChain(
 			id,
 			pid: spawnResult.pid,
 			sessionId: ctx.currentSessionId,
+			...(ctx.launchLeafId !== undefined ? { launchLeafId: ctx.launchLeafId } : {}),
 			mode: resultMode,
 			agent: firstAgents[0],
 			agents: flatAgents,
@@ -1212,6 +1216,7 @@ export function executeAsyncSingle(
 				sessionDir: resolvedSessionDir,
 				asyncDir,
 				sessionId: ctx.currentSessionId,
+				...(ctx.launchLeafId !== undefined ? { launchLeafId: ctx.launchLeafId } : {}),
 				piPackageRoot,
 				piArgv1: process.argv[1],
 				worktreeSetupHook,
@@ -1287,6 +1292,7 @@ export function executeAsyncSingle(
 			id,
 			pid: spawnResult.pid,
 			sessionId: ctx.currentSessionId,
+			...(ctx.launchLeafId !== undefined ? { launchLeafId: ctx.launchLeafId } : {}),
 			mode: "single",
 			agent,
 			task: task?.slice(0, 50),

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -82,6 +82,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			asyncDir: run.asyncDir,
 			status: run.state,
 			sessionId: run.sessionId,
+			...(run.launchLeafId !== undefined ? { launchLeafId: run.launchLeafId } : {}),
 			activityState: run.activityState,
 			lastActivityAt: run.lastActivityAt,
 			currentTool: run.currentTool,
@@ -292,6 +293,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 							runId: job.asyncId,
 							pid: job.pid,
 							sessionId: job.sessionId,
+							...(job.launchLeafId !== undefined ? { launchLeafId: job.launchLeafId } : {}),
 							mode: job.mode,
 							agents: job.agents,
 							chainStepCount: job.chainStepCount,
@@ -306,6 +308,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 						job.status = status.state;
 						if (job.status !== "complete" && job.status !== "failed" && job.status !== "paused" && job.status !== "stopped") cancelCleanup(job.asyncId);
 						job.sessionId = status.sessionId ?? job.sessionId;
+						if (status.launchLeafId !== undefined) job.launchLeafId = status.launchLeafId;
 						job.activityState = status.activityState;
 						job.lastActivityAt = status.lastActivityAt ?? job.lastActivityAt;
 						job.currentTool = status.currentTool;
@@ -400,6 +403,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			status: "queued",
 			pid: typeof info.pid === "number" ? info.pid : undefined,
 			...(typeof info.sessionId === "string" ? { sessionId: info.sessionId } : {}),
+			...(info.launchLeafId !== undefined ? { launchLeafId: info.launchLeafId } : {}),
 			mode: info.mode ?? (info.chain ? "chain" : "single"),
 			agents,
 			chainStepCount: info.chainStepCount,

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -48,6 +48,7 @@ export interface AsyncRunSummary {
 	id: string;
 	asyncDir: string;
 	sessionId?: string;
+	launchLeafId?: string;
 	state: "queued" | "running" | "complete" | "failed" | "paused" | "stopped";
 	error?: string;
 	activityState?: ActivityState;
@@ -200,6 +201,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		id: status.runId || path.basename(asyncDir),
 		asyncDir,
 		...(status.sessionId ? { sessionId: status.sessionId } : {}),
+		...(status.launchLeafId !== undefined ? { launchLeafId: status.launchLeafId } : {}),
 		state: status.state,
 		...(status.error ? { error: status.error } : {}),
 		activityState,

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -54,6 +54,8 @@ interface SubagentResult {
 	taskIndex?: number;
 	totalTasks?: number;
 	sessionId?: string | null;
+	/** Session-tree leaf current when this detached result was launched. */
+	launchLeafId?: string;
 }
 
 interface NotifyTimerApi {
@@ -149,7 +151,8 @@ function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage">, details: Subagent
 
 function completionBatchKey(result: SubagentResult): string {
 	const sessionId = typeof result.sessionId === "string" ? result.sessionId.trim() : "";
-	if (sessionId) return `session:${sessionId}`;
+	const launchLeafId = typeof result.launchLeafId === "string" ? result.launchLeafId.trim() : "";
+	if (sessionId) return launchLeafId ? `session:${sessionId}:branch:${launchLeafId}` : `session:${sessionId}`;
 	const cwd = typeof result.cwd === "string" ? result.cwd.trim() : "";
 	return cwd ? `cwd:${cwd}` : "unknown";
 }
@@ -235,6 +238,14 @@ export default function registerSubagentNotify(
 
 		const details = buildCompletionDetails(result);
 		if (result.source === "foreground") {
+			sendCompletion(pi, [details]);
+			return;
+		}
+		if (result.launchLeafId !== undefined) {
+			// Do not add an avoidable batch delay after the watcher has matched this
+			// result to its launch branch. Pi's public sendMessage API cannot bind a
+			// queued notification to that branch, so a branch switch while Pi is busy
+			// remains a documented best-effort edge case.
 			sendCompletion(pi, [details]);
 			return;
 		}

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -34,6 +34,7 @@ type ResultWatcherTimers = {
 type ResultWatcherDeps = {
 	fs?: ResultWatcherFs;
 	timers?: ResultWatcherTimers;
+	isLaunchLeafOnCurrentBranch?: (launchLeafId: string) => boolean;
 };
 
 type ResultFileChild = {
@@ -60,6 +61,7 @@ type ResultFileData = {
 	results?: ResultFileChild[];
 	nestedChildren?: unknown;
 	sessionId?: string;
+	launchLeafId?: string;
 	cwd?: string;
 	sessionFile?: string;
 	asyncDir?: string;
@@ -108,14 +110,33 @@ export function createResultWatcher(
 } {
 	const fsApi = deps.fs ?? fs;
 	const timers = deps.timers ?? { setTimeout, clearTimeout, setInterval, clearInterval };
+	const inFlightFiles = new Set<string>();
+	const acknowledgedIntercomCompletions = new Set<string>();
+
+	const isEligibleForCurrentSessionAndBranch = (data: ResultFileData): boolean => {
+		if (typeof data.sessionId !== "string" || data.sessionId !== state.currentSessionId) return false;
+		if (data.launchLeafId === undefined) return true;
+		if (typeof data.launchLeafId !== "string" || !data.launchLeafId || data.launchLeafId.trim() !== data.launchLeafId) return false;
+		return deps.isLaunchLeafOnCurrentBranch?.(data.launchLeafId) ?? false;
+	};
 
 	const handleResult = async (file: string) => {
+		if (inFlightFiles.has(file)) return;
+		inFlightFiles.add(file);
 		const resultPath = path.join(resultsDir, file);
-		if (!fsApi.existsSync(resultPath)) return;
+		if (!fsApi.existsSync(resultPath)) {
+			inFlightFiles.delete(file);
+			return;
+		}
 		try {
 			const data = JSON.parse(fsApi.readFileSync(resultPath, "utf-8")) as ResultFileData;
-			if (typeof data.sessionId !== "string" || data.sessionId !== state.currentSessionId) return;
+			// This gate keeps shared-tree sibling panes from consuming each other's
+			// detached results. Pi's public sendMessage API has no branch target, so
+			// a queued notification can still follow a later branch change after this
+			// handoff; that narrow active-turn case is intentionally best-effort.
+			if (!isEligibleForCurrentSessionAndBranch(data)) return;
 
+			const completionKey = buildCompletionKey(data, `result:${file}`);
 			const runId = data.runId ?? data.id ?? file.replace(/\.json$/i, "");
 			const hasExplicitNestedChildren = data.nestedChildren !== undefined;
 			let nestedChildren = compactNestedResultChildren(sanitizeNestedResultChildren(data.nestedChildren, resultPath, "nestedChildren"));
@@ -127,13 +148,6 @@ export function createResultWatcher(
 					return;
 				}
 			}
-			const now = Date.now();
-			const completionKey = buildCompletionKey(data, `result:${file}`);
-			if (markSeenWithTtl(state.completionSeen, completionKey, now, completionTtlMs)) {
-				fsApi.unlinkSync(resultPath);
-				return;
-			}
-
 			const hasResultChildren = Array.isArray(data.results) && data.results.length > 0;
 			const resultChildren = hasResultChildren
 				? data.results!
@@ -174,7 +188,7 @@ export function createResultWatcher(
 			}), nestedChildren);
 
 			const intercomTarget = data.intercomTarget?.trim();
-			if (intercomTarget) {
+			if (intercomTarget && !acknowledgedIntercomCompletions.has(completionKey)) {
 				const mode = data.mode === "single" || data.mode === "parallel" || data.mode === "chain"
 					? data.mode
 					: resultChildren.length > 1 ? "chain" : "single";
@@ -188,9 +202,22 @@ export function createResultWatcher(
 					asyncDir: data.asyncDir,
 				});
 				const delivered = await deliverSubagentResultIntercomEvent(pi.events, payload);
-				if (!delivered) {
+				if (delivered) {
+					// A branch change can retain the artifact after an acknowledged
+					// handoff. Do not send that same intercom result again on retry.
+					acknowledgedIntercomCompletions.add(completionKey);
+				} else {
 					console.error(`Subagent async grouped result intercom delivery was not acknowledged for '${resultPath}'.`);
 				}
+			}
+
+			// Intercom delivery may await. Re-check before consuming the artifact so
+			// navigation during that handoff leaves it available for a later retry.
+			if (!isEligibleForCurrentSessionAndBranch(data)) return;
+			const now = Date.now();
+			if (markSeenWithTtl(state.completionSeen, completionKey, now, completionTtlMs)) {
+				fsApi.unlinkSync(resultPath);
+				return;
 			}
 
 			pi.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
@@ -216,6 +243,8 @@ export function createResultWatcher(
 		} catch (error) {
 			if (isNotFoundError(error)) return;
 			console.error(`Failed to process subagent result file '${resultPath}':`, error);
+		} finally {
+			inFlightFiles.delete(file);
 		}
 	};
 
@@ -312,6 +341,8 @@ export function createResultWatcher(
 		}
 		state.watcherRestartTimer = null;
 		state.resultFileCoalescer.clear();
+		inFlightFiles.clear();
+		acknowledgedIntercomCompletions.clear();
 	};
 
 	return { startResultWatcher, primeExistingResults, stopResultWatcher };

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -14,6 +14,7 @@ interface StartedRunMetadata {
 	runId: string;
 	pid?: number;
 	sessionId?: string;
+	launchLeafId?: string;
 	mode?: SubagentRunMode;
 	agents?: string[];
 	chainStepCount?: number;
@@ -193,6 +194,7 @@ function buildStartedStatus(asyncDir: string, startedRun: StartedRunMetadata, no
 	return {
 		runId: startedRun.runId || path.basename(asyncDir),
 		...(startedRun.sessionId ? { sessionId: startedRun.sessionId } : {}),
+		...(startedRun.launchLeafId !== undefined ? { launchLeafId: startedRun.launchLeafId } : {}),
 		mode: startedRun.mode ?? "single",
 		state: "running",
 		pid: startedRun.pid,
@@ -262,6 +264,7 @@ function buildFailedRepair(status: AsyncStatus, asyncDir: string, now: number, r
 			durationMs: Math.max(0, now - status.startedAt),
 			asyncDir,
 			sessionId: status.sessionId,
+			...(status.launchLeafId !== undefined ? { launchLeafId: status.launchLeafId } : {}),
 			sessionFile: status.sessionFile,
 		},
 	};

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -126,6 +126,7 @@ interface SubagentRunConfig {
 	sessionDir?: string;
 	asyncDir: string;
 	sessionId?: string | null;
+	launchLeafId?: string;
 	piPackageRoot?: string;
 	piArgv1?: string;
 	worktreeSetupHook?: string;
@@ -1664,6 +1665,7 @@ async function runSubagent(
 		lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
 		runId: id,
 		...(config.sessionId ? { sessionId: config.sessionId } : {}),
+		...(config.launchLeafId !== undefined ? { launchLeafId: config.launchLeafId } : {}),
 		mode: config.resultMode ?? (flatSteps.length > 1 ? "chain" : "single"),
 		...(config.nestedRoute ? { isNested: true } : {}),
 		state: "running",
@@ -3662,6 +3664,7 @@ async function runSubagent(
 			cwd,
 			asyncDir,
 			sessionId: config.sessionId,
+			...(config.launchLeafId !== undefined ? { launchLeafId: config.launchLeafId } : {}),
 			sessionFile: effectiveSessionFile,
 			intercomTarget: config.controlIntercomTarget,
 			shareUrl,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -226,6 +226,15 @@ interface ExecutionContextData {
 	parentSessionId: string | null;
 }
 
+function captureLaunchLeafId(sessionManager: ExtensionContext["sessionManager"]): string | undefined {
+	try {
+		const leafId = sessionManager.getBranch().at(-1)?.id;
+		return typeof leafId === "string" && leafId.trim() === leafId && leafId ? leafId : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefined): string {
 	return requestedCwd ? path.resolve(runtimeCwd, requestedCwd) : runtimeCwd;
 }
@@ -1201,6 +1210,7 @@ async function resumeAsyncRun(input: {
 				pi: input.deps.pi,
 				cwd: input.requestCwd,
 				currentSessionId: input.deps.state.currentSessionId,
+				launchLeafId: captureLaunchLeafId(input.ctx.sessionManager),
 				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 				currentModelProvider: input.ctx.model?.provider,
 				currentModel: input.ctx.model,
@@ -1251,6 +1261,7 @@ async function resumeAsyncRun(input: {
 			pi: input.deps.pi,
 			cwd: input.requestCwd,
 			currentSessionId: input.deps.state.currentSessionId,
+			launchLeafId: captureLaunchLeafId(input.ctx.sessionManager),
 			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 			currentModelProvider: input.ctx.model?.provider,
 			currentModel: input.ctx.model,
@@ -1945,6 +1956,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		pi: deps.pi,
 		cwd: ctx.cwd,
 		currentSessionId: deps.state.currentSessionId!,
+		launchLeafId: captureLaunchLeafId(ctx.sessionManager),
 		parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 		currentModelProvider: ctx.model?.provider,
 		currentModel: ctx.model,
@@ -2185,6 +2197,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			pi: deps.pi,
 			cwd: ctx.cwd,
 			currentSessionId: deps.state.currentSessionId!,
+			launchLeafId: captureLaunchLeafId(ctx.sessionManager),
 			parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 			currentModelProvider: ctx.model?.provider,
 			currentModel: ctx.model,
@@ -2666,6 +2679,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				pi: deps.pi,
 				cwd: ctx.cwd,
 				currentSessionId: deps.state.currentSessionId!,
+				launchLeafId: captureLaunchLeafId(ctx.sessionManager),
 				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				currentModelProvider: ctx.model?.provider,
 				currentModel: ctx.model,
@@ -2987,6 +3001,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				pi: deps.pi,
 				cwd: ctx.cwd,
 				currentSessionId: deps.state.currentSessionId!,
+				launchLeafId: captureLaunchLeafId(ctx.sessionManager),
 				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				currentModelProvider: ctx.model?.provider,
 				currentModel: ctx.model,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -793,6 +793,7 @@ export interface AsyncStartedEvent {
 	asyncDir?: string;
 	pid?: number;
 	sessionId?: string;
+	launchLeafId?: string;
 	mode?: SubagentRunMode;
 	agent?: string;
 	agents?: string[];
@@ -814,6 +815,7 @@ export interface AsyncStatus {
 	lifecycleArtifactVersion?: SubagentLifecycleArtifactVersion;
 	runId: string;
 	sessionId?: string;
+	launchLeafId?: string;
 	mode: SubagentRunMode;
 	isNested?: boolean;
 	state: "queued" | "running" | "complete" | "failed" | "paused" | "stopped";
@@ -910,6 +912,7 @@ export interface AsyncJobState {
 	status: "queued" | "running" | "complete" | "failed" | "paused" | "stopped";
 	pid?: number;
 	sessionId?: string;
+	launchLeafId?: string;
 	activityState?: ActivityState;
 	lastActivityAt?: number;
 	currentTool?: string;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -32,6 +32,7 @@ interface AsyncResultPayload {
 	state?: string;
 	exitCode?: number;
 	sessionId?: string;
+	launchLeafId?: string;
 	mode?: string;
 	summary?: string;
 	error?: string;
@@ -51,6 +52,7 @@ interface AsyncResultPayload {
 interface AsyncStatusPayload {
 	lifecycleArtifactVersion?: number;
 	sessionId?: string;
+	launchLeafId?: string;
 	activityState?: string;
 	currentTool?: string;
 	currentPath?: string;
@@ -369,7 +371,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			agent: "worker",
 			task: "Exercise child protocol",
 			agentConfig: makeAgent("worker", { completionGuard: false }),
-			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1", launchLeafId: "launch-leaf" },
 			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
 			shareEnabled: false,
 			sessionRoot: path.join(tempDir, "sessions"),
@@ -390,8 +392,11 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const id = `async-protocol-utf8-${Date.now().toString(36)}`;
 		launchProtocolTest(id);
 		const payload = await readAsyncPayload(id);
+		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
 		assert.equal(payload.success, true);
 		assert.equal(payload.results[0]?.output, "你好 from fragmented async JSON");
+		assert.equal(status.launchLeafId, "launch-leaf");
+		assert.equal(payload.launchLeafId, "launch-leaf");
 	});
 
 	it("background fails with protocol_output_limit for an oversized stdout line", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -167,6 +167,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				mode: "chain",
 				state: "running",
 				sessionId: "session-restored",
+				launchLeafId: "branch-anchor",
 				startedAt: 1000,
 				lastUpdate: 2000,
 				currentStep: 1,
@@ -206,6 +207,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			assert.ok(job);
 			assert.equal(job.status, "running");
 			assert.equal(job.sessionId, "session-restored");
+			assert.equal(job.launchLeafId, "branch-anchor");
 			assert.deepEqual(job.agents, ["reviewer", "worker"]);
 			assert.deepEqual(job.steps?.map((step: { index?: number }) => step.index), [1, 2]);
 			assert.equal(job.stepsTotal, 2);
@@ -527,7 +529,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
-	it("repairs started jobs whose runner dies before writing status", async () => {
+	it("retains launch metadata when repairing started jobs whose runner dies before writing status", async () => {
 		const asyncRoot = createTempDir("pi-async-job-no-status-");
 		try {
 			const resultsDir = path.join(asyncRoot, "results");
@@ -548,11 +550,13 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				asyncDir: runDir,
 				pid: 12345,
 				sessionId: "session-current",
+				launchLeafId: "branch-anchor",
 				mode: "parallel",
 				agents: ["scout", "reviewer", "worker"],
 				chainStepCount: 1,
 				parallelGroups: [{ start: 0, count: 3, stepIndex: 0 }],
 			});
+			assert.equal(state.asyncJobs.get("run-no-status")?.launchLeafId, "branch-anchor");
 
 			await new Promise((resolve) => setTimeout(resolve, 80));
 
@@ -561,6 +565,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const result = JSON.parse(fs.readFileSync(path.join(resultsDir, "run-no-status.json"), "utf-8"));
 			assert.equal(status.state, "failed");
 			assert.equal(status.sessionId, "session-current");
+			assert.equal(status.launchLeafId, "branch-anchor");
 			assert.equal(status.mode, "parallel");
 			assert.equal(status.currentStep, 0);
 			assert.equal(status.chainStepCount, 1);
@@ -572,6 +577,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			]);
 			assert.equal(result.success, false);
 			assert.equal(result.sessionId, "session-current");
+			assert.equal(result.launchLeafId, "branch-anchor");
 			assert.ok(ui.renderRequests > 0, "expected startup-crash repair cleanup to request a rerender");
 		} finally {
 			removeTempDir(asyncRoot);

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -70,6 +70,127 @@ describe("result watcher", () => {
 		}
 	});
 
+	it("routes matching-session results by their launch branch and retries after a branch switch", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-branch-"));
+		try {
+			const emitted: Array<{ event: string; data: unknown }> = [];
+			const pi = {
+				events: {
+					on: () => () => {},
+					emit(event: string, data: unknown) {
+						emitted.push({ event, data });
+					},
+				},
+			};
+			const state = createState();
+			state.currentSessionId = "session-current";
+			let liveBranch = ["root", "sibling-b"];
+			const watcher = createResultWatcher(pi, state, resultsDir, 60_000, {
+				isLaunchLeafOnCurrentBranch: (launchLeafId) => liveBranch.includes(launchLeafId),
+			});
+			const writeResult = (name: string, launchLeafId?: unknown) => {
+				const resultPath = path.join(resultsDir, `${name}.json`);
+				fs.writeFileSync(resultPath, JSON.stringify({ id: name, sessionId: "session-current", ...(launchLeafId !== undefined ? { launchLeafId } : {}) }), "utf-8");
+				return resultPath;
+			};
+			const deliver = async () => {
+				watcher.primeExistingResults();
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			};
+			try {
+				const siblingResult = writeResult("sibling", "sibling-a");
+				await deliver();
+				assert.equal(emitted.length, 0, "a same-session post-divergence sibling must not receive the result");
+				assert.equal(fs.existsSync(siblingResult), true, "ineligible sibling result must be retained");
+
+				liveBranch = ["root", "sibling-a"];
+				await deliver();
+				assert.equal(fs.existsSync(siblingResult), false, "the live branch switch should retry and consume the result");
+
+				liveBranch = ["root", "sibling-b"];
+				const ancestorResult = writeResult("ancestor", "root");
+				await deliver();
+				assert.equal(fs.existsSync(ancestorResult), false, "an anchor in common ancestry is visible from either descendant");
+
+				const legacyResult = writeResult("legacy");
+				await deliver();
+				assert.equal(fs.existsSync(legacyResult), false, "legacy matching-session results retain exact-session behavior");
+
+				const malformedResult = writeResult("malformed", " ");
+				await deliver();
+				assert.equal(fs.existsSync(malformedResult), true, "a malformed launch leaf fails closed without consuming the artifact");
+			} finally {
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal(emitted.filter((entry) => entry.event === "subagent:async-complete").length, 3);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("retains a branch-scoped result when navigation happens during intercom delivery", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-branch-race-"));
+		try {
+			const emitted: Array<{ event: string; data: unknown }> = [];
+			const listeners = new Map<string, Set<(data: unknown) => void>>();
+			let liveBranch = ["root", "anchor"];
+			let switchBranchOnce = true;
+			const pi = {
+				events: {
+					on(event: string, handler: (data: unknown) => void) {
+						const handlers = listeners.get(event) ?? new Set();
+						handlers.add(handler);
+						listeners.set(event, handlers);
+						return () => handlers.delete(handler);
+					},
+					emit(event: string, data: unknown) {
+						emitted.push({ event, data });
+						for (const handler of listeners.get(event) ?? []) handler(data);
+						if (event !== "subagent:result-intercom") return;
+						if (switchBranchOnce) {
+							liveBranch = ["root", "sibling"];
+							switchBranchOnce = false;
+						}
+						const requestId = data && typeof data === "object" ? (data as { requestId?: unknown }).requestId : undefined;
+						if (typeof requestId === "string") {
+							setImmediate(() => pi.events.emit("subagent:result-intercom-delivery", { requestId, delivered: true }));
+						}
+					},
+				},
+			};
+			const state = createState();
+			state.currentSessionId = "session-current";
+			const watcher = createResultWatcher(pi, state, resultsDir, 60_000, {
+				isLaunchLeafOnCurrentBranch: (launchLeafId) => liveBranch.includes(launchLeafId),
+			});
+			const resultPath = path.join(resultsDir, "branch-race.json");
+			fs.writeFileSync(resultPath, JSON.stringify({
+				id: "branch-race",
+				sessionId: "session-current",
+				launchLeafId: "anchor",
+				intercomTarget: "owner",
+			}), "utf-8");
+			try {
+				watcher.primeExistingResults();
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				assert.equal(fs.existsSync(resultPath), true, "navigation during the awaited handoff must retain the result");
+				assert.equal(emitted.some((entry) => entry.event === "subagent:async-complete"), false);
+
+				liveBranch = ["root", "anchor"];
+				watcher.primeExistingResults();
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				assert.equal(fs.existsSync(resultPath), false, "returning to the launch branch should retry the retained result");
+				assert.equal(emitted.filter((entry) => entry.event === "subagent:async-complete").length, 1);
+				assert.equal(emitted.filter((entry) => entry.event === "subagent:result-intercom").length, 1, "an acknowledged intercom result must not be sent again on retry");
+			} finally {
+				watcher.stopResultWatcher();
+			}
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("delivers result files only to the exact owning session when another watcher shares the same repo", async () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-scope-"));
 		const createPi = () => {

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -211,6 +211,79 @@ describe("subagent extension child mode", () => {
 		}
 	});
 
+	it("retries retained branch-scoped results after session-tree navigation", () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-session-tree-"));
+		try {
+			const script = String.raw`
+				import * as fs from "node:fs";
+				import * as path from "node:path";
+				import registerSubagentExtension from "./index.ts";
+				import { RESULTS_DIR } from "./src/shared/types.ts";
+				const eventHandlers = new Map();
+				const lifecycleHandlers = new Map();
+				const emitted = [];
+				const events = {
+					on(channel, handler) {
+						const handlers = eventHandlers.get(channel) ?? [];
+						handlers.push(handler);
+						eventHandlers.set(channel, handlers);
+						return () => eventHandlers.set(channel, (eventHandlers.get(channel) ?? []).filter((candidate) => candidate !== handler));
+					},
+					emit(channel, data) {
+						emitted.push({ channel, data });
+						for (const handler of eventHandlers.get(channel) ?? []) handler(data);
+					},
+				};
+				const fakePi = new Proxy({
+					events,
+					on(channel, handler) {
+						const handlers = lifecycleHandlers.get(channel) ?? [];
+						handlers.push(handler);
+						lifecycleHandlers.set(channel, handlers);
+					},
+					registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+					sendMessage() {}, getSessionName() { return undefined; },
+				}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+				const fire = async (channel, event, ctx) => {
+					for (const handler of lifecycleHandlers.get(channel) ?? []) await handler(event, ctx);
+				};
+				const makeCtx = (branch) => ({
+					cwd: process.cwd(), hasUI: true,
+					ui: { setWidget() {}, requestRender() {}, theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } } },
+					sessionManager: {
+						getSessionId() { return "session-tree"; }, getSessionFile() { return null; }, getEntries() { return []; },
+						getBranch() { return branch.map((id) => ({ id })); },
+					},
+					modelRegistry: { getAvailable() { return []; } },
+				});
+				const startCtx = makeCtx(["root", "sibling"]);
+				const treeCtx = makeCtx(["root", "anchor"]);
+				registerSubagentExtension(fakePi);
+				const resultPath = path.join(RESULTS_DIR, "branch-result.json");
+				fs.writeFileSync(resultPath, JSON.stringify({ id: "branch-result", sessionId: "session-tree", launchLeafId: "anchor", agent: "worker", success: true, summary: "done" }), "utf-8");
+				await fire("session_start", {}, startCtx);
+				await new Promise((resolve) => setTimeout(resolve, 120));
+				if (emitted.some((entry) => entry.channel === "subagent:async-complete")) throw new Error("sibling branch received retained result");
+				if (!fs.existsSync(resultPath)) throw new Error("ineligible result was consumed");
+				await fire("session_tree", {}, treeCtx);
+				const deadline = Date.now() + 1000;
+				while (!emitted.some((entry) => entry.channel === "subagent:async-complete")) {
+					if (Date.now() > deadline) throw new Error("session_tree did not retry retained result");
+					await new Promise((resolve) => setTimeout(resolve, 10));
+				}
+				if (fs.existsSync(resultPath)) throw new Error("eligible result was not consumed");
+				await fire("session_shutdown", {}, treeCtx);
+			`;
+			const env = parentToolEnv();
+			env.TMPDIR = tmpDir;
+			env.TMP = tmpDir;
+			env.TEMP = tmpDir;
+			execFileSync(process.execPath, ["--experimental-transform-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
 	it("registers the main watchdog command and renderer in parent mode", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./index.ts";

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -292,6 +292,23 @@ describe("registerSubagentNotify", () => {
 		assert.deepEqual(sent[0]!.options, { triggerTurn: true });
 	});
 
+	it("sends launch-branch completions immediately instead of holding them in a batch", () => {
+		const clock = createFakeClock();
+		const { events, sent } = createBatchingPi(clock);
+
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, completionResult({
+			id: "anchored-1",
+			agent: "alpha",
+			summary: "alpha done",
+			launchLeafId: "branch-anchor",
+		}));
+
+		assert.equal(sent.length, 1);
+		assert.match((sent[0]!.message as { content: string }).content, /^Background task completed: \*\*alpha\*\*/);
+		clock.advance(1000);
+		assert.equal(sent.length, 1, "the branch-scoped completion must not be emitted again by a pending batch");
+	});
+
 	it("ignores successes from other sessions instead of grouping them", () => {
 		const clock = createFakeClock();
 		const { events, sent } = createBatchingPi(clock, "session-a");

--- a/test/unit/stale-run-reconciler.test.ts
+++ b/test/unit/stale-run-reconciler.test.ts
@@ -71,6 +71,39 @@ describe("async stale-run reconciliation", () => {
 		}
 	});
 
+	it("retains launch leaf metadata when repairing a stale status", () => {
+		const root = tempRoot("pi-stale-run-launch-leaf-");
+		try {
+			const asyncDir = path.join(root, "run-launch-leaf");
+			const resultsDir = path.join(root, "results");
+			writeStatus(asyncDir, {
+				runId: "run-launch-leaf",
+				sessionId: "session-current",
+				launchLeafId: "branch-anchor",
+				mode: "single",
+				state: "running",
+				pid: 12345,
+				startedAt: 1000,
+				lastUpdate: 1000,
+				steps: [{ agent: "worker", status: "running", startedAt: 1000 }],
+			});
+
+			const repaired = reconcileAsyncRun(asyncDir, {
+				resultsDir,
+				kill: () => { throw errno("ESRCH"); },
+				now: () => 2000,
+			});
+
+			assert.equal(repaired.status?.launchLeafId, "branch-anchor");
+			const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+			const result = JSON.parse(fs.readFileSync(path.join(resultsDir, "run-launch-leaf.json"), "utf-8"));
+			assert.equal(status.launchLeafId, "branch-anchor");
+			assert.equal(result.launchLeafId, "branch-anchor");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("includes runner stderr diagnostics when repairing a stale startup crash", () => {
 		const root = tempRoot("pi-stale-run-stderr-");
 		try {


### PR DESCRIPTION
## Summary
- persist the session-tree leaf where detached async runs launch
- retain result artifacts while a sibling branch is active and retry after tree navigation
- bypass completion batching for branch-scoped results and preserve launch metadata through status/recovery paths
- document the remaining best-effort edge case: Pi may place a queued notification on a later-selected branch

## Validation
- `npm run test:all`

## Scope
No Pi-core, cmux, terminal, or per-window identity changes. Same-branch panes retain shared semantics.