### PR TITLE
fix: use Pi host package peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Moved Pi-owned `@earendil-works/pi-tui` and `typebox` imports to optional wildcard peer dependencies while retaining exact dev versions for local and CI tests. Thanks to Alexei Ledenev (@alexei-led) for #510.
 - Made steering pre-recovery acknowledgment and Windows async hard-kill regressions synchronize around their actual lifecycle boundaries instead of depending on CI scheduler or process-start timing.
 - Added YAML folded block scalar support for agent and chain frontmatter descriptions, preserving quoted indicators, more-indented content, and blank-line separators. Thanks to Luis Cinco (@tekniko24) for #488.
 - Accepted simple-scalar newline block lists in agent frontmatter for tools, reads, skills, skill paths, fallback models, and extensions while preserving comma-separated syntax. Thanks to klopket (@klopket) for #507.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "0.34.0",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-tui": "0.74.0",
         "jiti": "2.7.0",
-        "typebox": "1.1.24",
         "yaml": "2.8.3"
       },
       "bin": {
@@ -20,12 +18,16 @@
       "devDependencies": {
         "@earendil-works/pi-agent-core": "0.74.0",
         "@earendil-works/pi-ai": "0.74.0",
-        "@earendil-works/pi-coding-agent": "0.74.0"
+        "@earendil-works/pi-coding-agent": "0.74.0",
+        "@earendil-works/pi-tui": "0.74.0",
+        "typebox": "1.1.24"
       },
       "peerDependencies": {
         "@earendil-works/pi-agent-core": "*",
         "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*"
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
+        "typebox": "*"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-agent-core": {
@@ -35,6 +37,12 @@
           "optional": true
         },
         "@earendil-works/pi-coding-agent": {
+          "optional": true
+        },
+        "@earendil-works/pi-tui": {
+          "optional": true
+        },
+        "typebox": {
           "optional": true
         }
       }
@@ -969,6 +977,7 @@
       "version": "0.74.0",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
       "integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -1997,6 +2006,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2178,6 +2188,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -2601,6 +2612,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2875,6 +2887,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
       "integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2903,6 +2916,7 @@
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -2915,6 +2929,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2924,6 +2939,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -3544,6 +3560,7 @@
       "version": "1.1.24",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.24.tgz",
       "integrity": "sha512-IGWOHx9UfqkEl7lNmA5417b80VY1NHNGdD5OgwEojHCKdsX1oj0lmgc6N6qEb0tUYzQBveIoccNwBen3IDIHwg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uint8array-extras": {
@@ -3741,7 +3758,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
   "peerDependencies": {
     "@earendil-works/pi-agent-core": "*",
     "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-agent-core": {
@@ -72,17 +74,23 @@
     },
     "@earendil-works/pi-coding-agent": {
       "optional": true
+    },
+    "@earendil-works/pi-tui": {
+      "optional": true
+    },
+    "typebox": {
+      "optional": true
     }
   },
   "dependencies": {
-    "@earendil-works/pi-tui": "0.74.0",
     "jiti": "2.7.0",
-    "typebox": "1.1.24",
     "yaml": "2.8.3"
   },
   "devDependencies": {
     "@earendil-works/pi-agent-core": "0.74.0",
     "@earendil-works/pi-ai": "0.74.0",
-    "@earendil-works/pi-coding-agent": "0.74.0"
+    "@earendil-works/pi-coding-agent": "0.74.0",
+    "@earendil-works/pi-tui": "0.74.0",
+    "typebox": "1.1.24"
   }
 }

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -11,6 +11,13 @@ const oldPiScopePattern = /@mariozechner\/pi-/;
 const piPackageJsonSubpathPattern = /@earendil-works\/pi-[^"']+\/package\.json/;
 const cjsPiPackageResolutionPattern = /require(?:\.resolve)?\(\s*["']@earendil-works\/pi-/;
 const exactVersionPattern = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+const hostPeerPackages = [
+	"@earendil-works/pi-agent-core",
+	"@earendil-works/pi-ai",
+	"@earendil-works/pi-coding-agent",
+	"@earendil-works/pi-tui",
+	"typebox",
+] as const;
 
 function collectTsFiles(dir: string): string[] {
 	const files: string[] = [];
@@ -53,6 +60,7 @@ test("direct @earendil-works runtime imports are declared for CI installs", () =
 	const declared = new Set([
 		...Object.keys(packageJson.dependencies ?? {}),
 		...Object.keys(packageJson.devDependencies ?? {}),
+		...Object.keys(packageJson.peerDependencies ?? {}),
 	]);
 	const imported = new Set<string>();
 
@@ -74,6 +82,16 @@ test("direct dependency declarations are exact version pins", () => {
 		for (const [name, version] of Object.entries<string>(packageJson[section] ?? {})) {
 			assert.match(version, exactVersionPattern, `${section}.${name} should use an exact version`);
 		}
+	}
+});
+
+test("host-owned packages are optional wildcard peers, not production dependencies", () => {
+	const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf-8"));
+
+	for (const name of hostPeerPackages) {
+		assert.equal(packageJson.peerDependencies?.[name], "*", `${name} should be a wildcard peer`);
+		assert.equal(packageJson.dependencies?.[name], undefined, `${name} should not be a production dependency`);
+		assert.deepEqual(packageJson.peerDependenciesMeta?.[name], { optional: true }, `${name} should be an optional peer`);
 	}
 });
 


### PR DESCRIPTION
Fixes #510.

`@earendil-works/pi-tui` and `typebox` now follow Pi's host-package contract: wildcard optional peers for runtime resolution, exact dev dependencies for deterministic local and CI tests, and no production dependency copies in the published package.

The lockfile root metadata and affected package entries reflect the peer/dev split. Manifest tests cover all five Pi-hosted packages, and a packed host-consumer check confirms the extension no longer installs nested Pi TUI or TypeBox copies.

This is an intentional hard cutover for Pi-hosted extensions; standalone consumers must provide compatible peers.

Thanks to Alexei Ledenev (@alexei-led) for reporting #510 and identifying the stale duplicate dependency tree.
