### PR TITLE
fix: invalidate replaced async status cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Invalidated cached async status reads when a replacement changes file identity but reuses the same modification time, preventing steering and recovery from observing stale lifecycle state.
 - Moved Pi-owned `@earendil-works/pi-tui` and `typebox` imports to optional wildcard peer dependencies while retaining exact dev versions for local and CI tests. Thanks to Alexei Ledenev (@alexei-led) for #510.
 - Made steering pre-recovery acknowledgment and Windows async hard-kill regressions synchronize around their actual lifecycle boundaries instead of depending on CI scheduler or process-start timing.
 - Added YAML folded block scalar support for agent and chain frontmatter descriptions, preserving quoted indicators, more-indented content, and blank-line separators. Thanks to Luis Cinco (@tekniko24) for #488.

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -88,7 +88,7 @@ export function getAgentDir(): string {
 	return configured || path.join(os.homedir(), getConfigDirName(), "agent");
 }
 
-const statusCache = new Map<string, { mtime: number; status: AsyncStatus }>();
+const statusCache = new Map<string, { mtime: number; ctime: number; size: number; ino: number; status: AsyncStatus }>();
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -123,7 +123,13 @@ export function readStatus(asyncDir: string): AsyncStatus | null {
 	}
 
 	const cached = statusCache.get(statusPath);
-	if (cached && cached.mtime === stat.mtimeMs) {
+	if (
+		cached
+		&& cached.mtime === stat.mtimeMs
+		&& cached.ctime === stat.ctimeMs
+		&& cached.size === stat.size
+		&& cached.ino === stat.ino
+	) {
 		return cached.status;
 	}
 
@@ -146,7 +152,13 @@ export function readStatus(asyncDir: string): AsyncStatus | null {
 		});
 	}
 
-	statusCache.set(statusPath, { mtime: stat.mtimeMs, status });
+	statusCache.set(statusPath, {
+		mtime: stat.mtimeMs,
+		ctime: stat.ctimeMs,
+		size: stat.size,
+		ino: stat.ino,
+		status,
+	});
 	if (statusCache.size > 50) {
 		const firstKey = statusCache.keys().next().value;
 		if (firstKey) statusCache.delete(firstKey);

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -16,6 +16,7 @@ import * as path from "node:path";
 import { createEventBus, createMockPi, createTempDir, events, makeAgent, makeMinimalCtx, removeTempDir, tryImport } from "../support/helpers.ts";
 import type { MockPi } from "../support/helpers.ts";
 import { deliverInterruptRequest, deliverStopRequest } from "../../src/runs/background/control-channel.ts";
+import { writeAtomicJson } from "../../src/shared/atomic-json.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { MAX_CHILD_PENDING_LINE_BYTES, MAX_CHILD_STDERR_BYTES } from "../../src/runs/shared/child-protocol.ts";
 import { SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_LIFECYCLE_ARTIFACT_VERSION } from "../../src/shared/types.ts";
@@ -722,6 +723,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	it("cancels async acceptance verification when the run times out", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ output: "implementation complete" });
 		const id = `async-timeout-acceptance-${Date.now().toString(36)}`;
+		const timeoutMs = 1_000;
 		const startedAt = Date.now();
 		executeAsyncSingle(id, {
 			agent: "worker",
@@ -739,10 +741,10 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			artifactsDir: path.join(tempDir, ".pi-subagents", "artifacts"),
 			shareEnabled: false,
 			maxSubagentDepth: 2,
-			timeoutMs: 1_000,
+			timeoutMs,
 			acceptance: {
 				level: "verified",
-				verify: [{ id: "slow", command: `${process.execPath} -e "setTimeout(()=>process.exit(0), 5000)"`, timeoutMs: 10_000 }],
+				verify: [{ id: "slow", command: `${process.execPath} -e "setTimeout(()=>process.exit(0), 30000)"`, timeoutMs: 60_000 }],
 			},
 		});
 
@@ -761,7 +763,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { acceptance?: { status?: string; runtimeChecks?: Array<{ id?: string }> } };
 		assert.equal(metadata.acceptance?.status, "rejected");
 		assert.equal(metadata.acceptance?.runtimeChecks?.[0]?.id, "timeout");
-		assert.ok(elapsedMs < 3_000, `timeout should cancel acceptance verification promptly, elapsed ${elapsedMs}ms`);
+		assert.ok(elapsedMs < timeoutMs + 4_000, `timeout should cancel acceptance verification well before the verify command completes, elapsed ${elapsedMs}ms`);
 	});
 
 	it("async turn budget allows a terminal final grace turn", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
@@ -2026,22 +2028,31 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		}
 	});
 
-	it("readStatus caches by mtime (second call uses cache)", () => {
+	it("readStatus caches unchanged files and invalidates same-mtime replacements", () => {
 		const dir = createTempDir();
 		try {
+			const statusPath = path.join(dir, "status.json");
+			const fixedTimestamp = new Date(1_700_000_000_000);
 			const statusData = {
 				runId: "cache-test",
 				state: "running",
 				mode: "single",
-				startedAt: Date.now(),
+				startedAt: fixedTimestamp.getTime(),
 			};
-			fs.writeFileSync(path.join(dir, "status.json"), JSON.stringify(statusData));
+			fs.writeFileSync(statusPath, JSON.stringify(statusData));
+			fs.utimesSync(statusPath, fixedTimestamp, fixedTimestamp);
 
-			const s1 = readStatus(dir);
-			const s2 = readStatus(dir);
-			assert.ok(s1);
-			assert.ok(s2);
-			assert.equal(s1.runId, s2.runId);
+			const cached = readStatus(dir);
+			assert.ok(cached);
+			assert.strictEqual(readStatus(dir), cached);
+
+			writeAtomicJson(statusPath, { ...statusData, state: "stopped" });
+			fs.utimesSync(statusPath, fixedTimestamp, fixedTimestamp);
+			assert.equal(fs.statSync(statusPath).mtimeMs, fixedTimestamp.getTime());
+			const replaced = readStatus(dir);
+			assert.ok(replaced);
+			assert.equal(replaced.state, "stopped");
+			assert.notStrictEqual(replaced, cached);
 		} finally {
 			removeTempDir(dir);
 		}

--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { writePrivateAtomicJson } from "../../src/shared/atomic-json.ts";
+import { writeAtomicJson, writePrivateAtomicJson } from "../../src/shared/atomic-json.ts";
 import { closeSteerInbox, interruptRequestPath, steerRequestsDir, writeSteerAck, type SteerRequest } from "../../src/runs/background/control-channel.ts";
 import { steerAsyncRun } from "../../src/runs/foreground/async-steering-action.ts";
 import { createSteeringStatus, recordSteeringRequest, updateSteeringTarget } from "../../src/runs/background/steering.ts";
@@ -30,7 +30,7 @@ function createState(): SubagentState {
 
 function writeStatus(asyncDir: string, status: AsyncStatus): void {
 	fs.mkdirSync(asyncDir, { recursive: true });
-	fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status, null, 2), "utf-8");
+	writeAtomicJson(path.join(asyncDir, "status.json"), status);
 }
 
 function runningStatus(runId: string, mode: AsyncStatus["mode"] = "single", count = 1): AsyncStatus {


### PR DESCRIPTION
The exact-merge CI run after #513 exposed stale lifecycle reads in steering tests. A controlled same-mtime replacement reproduced the failure: `readStatus()` cached only by modification time, so an atomic replacement could be mistaken for the previous status file.

This invalidates cached statuses using modification time, change time, size, and inode. Steering tests now write status through the production atomic writer, and the acceptance-timeout regression measures cancellation against a 30-second verifier while allowing bounded runner startup and hard-kill time.

Validated with 30 focused steering stress runs, 1,272 unit tests, 596 integration tests, 2 E2E tests, and a fresh read-only review with no findings.
