### PR TITLE
fix: skip global discovery while offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Skipped optional global npm package discovery while Pi is offline, avoiding `npm root -g` subprocesses during agent and skill discovery. Thanks to Rafiq Rashid (@rrvsh) for #506.
 - Invalidated cached async status reads when a replacement changes file identity but reuses the same modification time, preventing steering and recovery from observing stale lifecycle state.
 - Moved Pi-owned `@earendil-works/pi-tui` and `typebox` imports to optional wildcard peer dependencies while retaining exact dev versions for local and CI tests. Thanks to Alexei Ledenev (@alexei-led) for #510.
 - Made steering pre-recovery acknowledgment and Windows async hard-kill regressions synchronize around their actual lifecycle boundaries instead of depending on CI scheduler or process-start timing.

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -313,6 +313,8 @@ function resolveSettingsPackageRoot(source: string, baseDir: string): string | u
 }
 
 function getGlobalNpmRoot(): string | null {
+	const offline = process.env.PI_OFFLINE?.toLowerCase();
+	if (offline === "1" || offline === "true" || offline === "yes") return null;
 	if (cachedGlobalNpmRoot !== null) return cachedGlobalNpmRoot;
 	try {
 		cachedGlobalNpmRoot = fs.realpathSync(execSync("npm root -g", { encoding: "utf-8", timeout: 5000 }).trim());

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -122,6 +122,8 @@ function extractSkillPathsFromPackageRoot(packageRoot: string, source: SkillSour
 let cachedGlobalNpmRoot: string | null = null;
 
 function getGlobalNpmRoot(): string | null {
+	const offline = process.env.PI_OFFLINE?.toLowerCase();
+	if (offline === "1" || offline === "true" || offline === "yes") return null;
 	if (cachedGlobalNpmRoot !== null) return cachedGlobalNpmRoot;
 	try {
 		cachedGlobalNpmRoot = execSync("npm root -g", { encoding: "utf-8", timeout: 5000 }).trim();

--- a/test/unit/skills-fallback.test.ts
+++ b/test/unit/skills-fallback.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -301,6 +302,59 @@ describe("skills filesystem fallback", () => {
 		assert.deepEqual(missing, []);
 		assert.equal(resolved.length, 1);
 		assert.equal(resolved[0]?.source, "project-package");
+	});
+
+	it("skips optional global npm discovery in offline mode", () => {
+		const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+		const binDir = path.join(tempDir, "bin");
+		const fakeHome = path.join(tempDir, "home");
+		const marker = path.join(tempDir, "npm-calls.txt");
+		fs.mkdirSync(binDir, { recursive: true });
+		fs.mkdirSync(fakeHome, { recursive: true });
+		fs.writeFileSync(
+			path.join(binDir, "npm"),
+			"#!/bin/sh\nprintf 'npm-root-called\\n' >> \"$PI_DISCOVERY_MARKER\"\nexit 1\n",
+			{ encoding: "utf-8", mode: 0o755 },
+		);
+		fs.writeFileSync(
+			path.join(binDir, "npm.cmd"),
+			"@echo off\r\n>>\"%PI_DISCOVERY_MARKER%\" echo npm-root-called\r\nexit /b 1\r\n",
+			"utf-8",
+		);
+
+		const script = `
+			import fs from "node:fs";
+			const [{ clearSkillCache, discoverAvailableSkills }, { discoverAgents }] = await Promise.all([
+				import("./src/agents/skills.ts"),
+				import("./src/agents/agents.ts"),
+			]);
+			discoverAvailableSkills(process.cwd());
+			discoverAgents(process.cwd(), "both");
+			if (fs.existsSync(process.env.PI_DISCOVERY_MARKER)) {
+				throw new Error("npm was invoked while PI_OFFLINE was enabled");
+			}
+			delete process.env.PI_OFFLINE;
+			clearSkillCache();
+			discoverAvailableSkills(process.cwd());
+			discoverAgents(process.cwd(), "both");
+		`;
+		execFileSync(
+			process.execPath,
+			["--experimental-transform-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script],
+			{
+				cwd: projectRoot,
+				env: {
+					...process.env,
+					HOME: fakeHome,
+					USERPROFILE: fakeHome,
+					PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+					PI_DISCOVERY_MARKER: marker,
+					PI_OFFLINE: "1",
+				},
+				stdio: "pipe",
+			},
+		);
+		assert.deepEqual(fs.readFileSync(marker, "utf-8").trim().split(/\r?\n/), ["npm-root-called", "npm-root-called"]);
 	});
 
 	it("falls back to the runtime cwd when the execution cwd lacks the skill", () => {


### PR DESCRIPTION
`PI_OFFLINE` now bypasses both optional `npm root -g` discovery paths before their module-local caches. Project, user, settings, and local package scans are unchanged, and normal online global discovery still runs.

The regression uses fresh Node discovery in an isolated home with portable POSIX and Windows fake npm commands. It verifies zero calls offline and both agent/skill calls online.

Validation: focused agent/skill discovery tests, full unit/integration/E2E suite, `git diff --check`, and fresh read-only review (`No issues found`).

Thanks to Rafiq Rashid (@rrvsh) for reporting this.

Fixes #506