### PR TITLE
fix: show only effective agent in get output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- `subagent({ action: "get" })` now honors `agentScope` for agent and chain details. Thanks to Kyle (@kylegl) for #519.
 - Removed timer-driven foreground spinner redraws that repeatedly rendered the full Pi TUI and could survive session shutdown; running indicators now advance only with real progress updates.
 - Exposed cumulative spawn-budget usage in status and doctor output, preflighted declared static work before partial launch, and added bounded root-interactive additive grants without changing unlimited or compaction semantics. Thanks to Mati Gummá (@matigumma) for #495.
 - Skipped optional global npm package discovery while Pi is offline, avoiding `npm root -g` subprocesses during agent and skill discovery. Thanks to Rafiq Rashid (@rrvsh) for #506.

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -122,7 +122,7 @@ function findChains(name: string, cwd: string, scope: AgentScope = "both"): Chai
 	const raw = name.trim();
 	const sanitized = sanitizeName(raw);
 	return discoverAgentsAll(cwd).chains
-		.filter((c) => (scope === "both" || c.source === scope) && (c.name === raw || c.name === sanitized))
+		.filter((c) => (scope === "both" || c.source === "package" || c.source === scope) && (c.name === raw || c.name === sanitized))
 		.sort((a, b) => a.source.localeCompare(b.source));
 }
 
@@ -748,11 +748,17 @@ function handleModels(params: ManagementParams, ctx: ManagementContext): AgentTo
 
 function handleGet(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
 	if (!params.agent && !params.chainName) return result("Specify 'agent' or 'chainName' for get.", true);
+	const scope = normalizeListScope(params.agentScope);
+	if (!scope) return result("agentScope must be 'user', 'project', or 'both' for get.", true);
 	const hasBoth = Boolean(params.agent && params.chainName);
 	const blocks: string[] = [];
 	let anyFound = false;
 	if (params.agent) {
-		const matches = findAgents(params.agent, ctx.cwd, "both");
+		const raw = params.agent.trim();
+		const sanitized = sanitizeName(raw);
+		const d = discoverAgentsAll(ctx.cwd);
+		const matches = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package)
+			.filter((agent) => agent.name === raw || agent.name === sanitized);
 		if (!matches.length) {
 			const msg = `Agent '${params.agent}' not found. Available: ${availableNames(ctx.cwd, "agent").join(", ") || "none"}.`;
 			if (!hasBoth) return result(msg, true);
@@ -763,7 +769,7 @@ function handleGet(params: ManagementParams, ctx: ManagementContext): AgentToolR
 		}
 	}
 	if (params.chainName) {
-		const matches = findChains(params.chainName, ctx.cwd, "both");
+		const matches = findChains(params.chainName, ctx.cwd, scope);
 		if (!matches.length) {
 			const msg = `Chain '${params.chainName}' not found. Available: ${availableNames(ctx.cwd, "chain").join(", ") || "none"}.`;
 			if (!hasBoth) return result(msg, true);

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -57,6 +57,67 @@ describe("agent management config parsing", () => {
 		assert.doesNotMatch(readText(result), /- scout \(builtin/);
 	});
 
+	it("gets only the effective agent detail and respects explicit scope", () => {
+		const projectAgentsDir = path.join(tempDir, ".pi", "agents");
+		const userAgentsDir = path.join(tempDir, "agent-home", "agents");
+		const packageDir = path.join(tempDir, ".pi", "npm", "node_modules", "test-agents");
+		fs.mkdirSync(projectAgentsDir, { recursive: true });
+		fs.mkdirSync(userAgentsDir, { recursive: true });
+		fs.mkdirSync(path.join(packageDir, "agents"), { recursive: true });
+		fs.mkdirSync(path.join(packageDir, "chains"), { recursive: true });
+		fs.writeFileSync(path.join(projectAgentsDir, "worker.md"), "---\nname: worker\ndescription: Project worker override\n---\n\nProject worker.\n");
+		fs.writeFileSync(path.join(userAgentsDir, "worker.md"), "---\nname: worker\ndescription: User worker override\n---\n\nUser worker.\n");
+		fs.writeFileSync(path.join(packageDir, "package.json"), JSON.stringify({ "pi-subagents": { agents: ["agents"], chains: ["chains"] } }));
+		fs.writeFileSync(path.join(packageDir, "agents", "worker.md"), "---\nname: worker\ndescription: Package worker override\n---\n\nPackage worker.\n");
+		fs.writeFileSync(path.join(packageDir, "chains", "package-flow.chain.json"), JSON.stringify({
+			name: "package-flow",
+			description: "Package flow",
+			chain: [{ agent: "worker", task: "Package task" }],
+		}), "utf-8");
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+
+		const effective = readText(handleManagementAction("get", { agent: "worker" }, ctx));
+		assert.match(effective, /Agent: worker \(project\)/);
+		assert.match(effective, /Description: Project worker override/);
+		assert.doesNotMatch(effective, /User worker override|Package worker override|Implementation agent for normal tasks/);
+
+		const userScoped = readText(handleManagementAction("get", { agent: "worker", agentScope: "user" }, ctx));
+		assert.match(userScoped, /Agent: worker \(user\)/);
+		assert.match(userScoped, /Description: User worker override/);
+		assert.doesNotMatch(userScoped, /Project worker override|Implementation agent for normal tasks/);
+
+		const userChainsDir = path.join(tempDir, "agent-home", "chains");
+		const projectChainsDir = path.join(tempDir, ".pi", "chains");
+		fs.mkdirSync(userChainsDir, { recursive: true });
+		fs.mkdirSync(projectChainsDir, { recursive: true });
+		fs.writeFileSync(path.join(userChainsDir, "shared-flow.chain.json"), JSON.stringify({
+			name: "shared-flow",
+			description: "User shared flow",
+			chain: [{ agent: "worker", task: "User flow" }],
+		}), "utf-8");
+		fs.writeFileSync(path.join(projectChainsDir, "shared-flow.chain.json"), JSON.stringify({
+			name: "shared-flow",
+			description: "Project shared flow",
+			chain: [{ agent: "worker", task: "Project flow" }],
+		}), "utf-8");
+
+		const userChain = readText(handleManagementAction("get", { chainName: "shared-flow", agentScope: "user" }, ctx));
+		assert.match(userChain, /Chain: shared-flow \(user\)/);
+		assert.match(userChain, /Description: User shared flow/);
+		assert.doesNotMatch(userChain, /Project shared flow|Project flow/);
+
+		const projectChain = readText(handleManagementAction("get", { chainName: "shared-flow", agentScope: "project" }, ctx));
+		assert.match(projectChain, /Chain: shared-flow \(project\)/);
+		assert.match(projectChain, /Description: Project shared flow/);
+		assert.doesNotMatch(projectChain, /User shared flow|User flow/);
+
+		for (const agentScope of ["user", "project"] as const) {
+			const packageChain = readText(handleManagementAction("get", { chainName: "package-flow", agentScope }, ctx));
+			assert.match(packageChain, /Chain: package-flow \(package\)/);
+			assert.match(packageChain, /Description: Package flow/);
+		}
+	});
+
 	it("surfaces JSON parse errors for update config strings", () => {
 		const result = handleUpdate(
 			{ agent: "reviewer", config: '{"description":' },


### PR DESCRIPTION
## Problem

When a user or project agent overrides a built-in or package agent with the same name, `get` displayed every matching definition instead of the effective runtime definition. `get` also ignored `agentScope`.

## Fix

Make `get` use the same effective agent precedence as list and runtime discovery:

```text
project > user > package > builtin
```

The reworked implementation also applies the normalized scope to chain lookup. User and project chain definitions remain isolated, while package chains stay available under either explicit scope to match existing list and runtime behavior.

## Validation

- Focused agent-management suite: 27 passed
- Full unit suite: 1,284 passed, 1 skipped
- Fresh correctness review and targeted follow-up review: no remaining issues

This rework preserves Kyle's original authorship and credits @kylegl in the changelog.
