### PR TITLE
fix: remove timer-driven foreground redraws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Removed timer-driven foreground spinner redraws that repeatedly rendered the full Pi TUI and could survive session shutdown; running indicators now advance only with real progress updates.
 - Exposed cumulative spawn-budget usage in status and doctor output, preflighted declared static work before partial launch, and added bounded root-interactive additive grants without changing unlimited or compaction semantics. Thanks to Mati Gummá (@matigumma) for #495.
 - Skipped optional global npm package discovery while Pi is offline, avoiding `npm root -g` subprocesses during agent and skill discovery. Thanks to Rafiq Rashid (@rrvsh) for #506.
 - Invalidated cached async status reads when a replacement changes file identity but reuses the same modification time, preventing steering and recovery from observing stale lifecycle state.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -120,30 +120,6 @@ function isSlashResultRunning(result: { details?: Details }): boolean {
 		|| false;
 }
 
-// Drives the inline running-indicator braille animation for foreground subagent
-// results. Foreground runs receive progress only on child events, so the glyph
-// (derived from progress fields) would freeze between events. While a result is
-// running we tick a frame counter + invalidate() every 80ms so renderSubagentResult
-// can blend the frame into runningGlyph and produce a smooth spinner.
-function subagentResultIsRunning(result: { details?: Details }): boolean {
-	return result.details?.progress?.some((entry) => entry.status === "running")
-		|| result.details?.results.some((entry) => entry.progress?.status === "running")
-		|| false;
-}
-
-function ensureSubagentResultAnimation(context: { state: Record<string, unknown>; invalidate?: () => void }): void {
-	const state = context.state as { subagentResultAnimationTimer?: ReturnType<typeof setInterval>; frame?: number };
-	if (state.subagentResultAnimationTimer) return;
-	if (typeof context.invalidate !== "function") return;
-	if (state.frame === undefined) state.frame = 0;
-	state.subagentResultAnimationTimer = setInterval(() => {
-		state.frame = ((state.frame ?? 0) + 1) % 10;
-		try {
-			context.invalidate();
-		} catch {}
-	}, 80);
-}
-
 function isSlashResultError(result: { details?: Details }): boolean {
 	return result.details?.results.some((entry) => entry.exitCode !== 0 && entry.progress?.status !== "running") || false;
 }
@@ -466,13 +442,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		},
 
 		renderResult(result, options, theme, context) {
-			if (subagentResultIsRunning(result)) {
-				ensureSubagentResultAnimation(context);
-			} else {
-				clearLegacyResultAnimationTimer(context);
-			}
-			const frame = (context.state as { frame?: number } | undefined)?.frame ?? 0;
-			return renderSubagentResult(result, options, theme, frame);
+			clearLegacyResultAnimationTimer(context);
+			return renderSubagentResult(result, options, theme);
 		},
 
 	};

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -115,6 +115,57 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
+	it("does not animate foreground results on a timer", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./index.ts";
+			const events = { on() { return () => {}; }, emit() {} };
+			let registeredTool;
+			const fakePi = new Proxy({
+				events,
+				registerTool(tool) { if (tool.name === "subagent") registeredTool = tool; },
+				registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+				sendMessage() {}, getSessionName() { return undefined; },
+			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+			registerSubagentExtension(fakePi);
+			if (!registeredTool) throw new Error("tool not registered");
+			let invalidations = 0;
+			let legacyTicks = 0;
+			const context = {
+				state: { subagentResultAnimationTimer: setInterval(() => { legacyTicks += 1; }, 10) },
+				invalidate() { invalidations += 1; },
+			};
+			registeredTool.renderResult({
+				content: [{ type: "text", text: "running" }],
+				details: {
+					mode: "single",
+					results: [{
+						agent: "worker", task: "quiet", exitCode: 0, messages: [],
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+						progress: { status: "running", index: 0, agent: "worker", toolCount: 0, tokens: 0, durationMs: 0 },
+					}],
+				},
+			}, { expanded: false }, { fg(_name, text) { return text; }, bold(text) { return text; } }, context);
+			await new Promise((resolve) => setTimeout(resolve, 120));
+			if (context.state.subagentResultAnimationTimer) clearInterval(context.state.subagentResultAnimationTimer);
+			if (context.state.subagentResultAnimationTimer !== undefined) throw new Error("legacy timer was not cleared");
+			if (legacyTicks !== 0) throw new Error("legacy timer ticked " + legacyTicks + " times");
+			if (invalidations !== 0) throw new Error("foreground result invalidated " + invalidations + " times");
+		`;
+
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-transform-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" },
+		);
+	});
+
 	it("registers only subagent_wait and honors waitTool disabled config", () => {
 		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-wait-tool-config-"));
 		try {


### PR DESCRIPTION
Foreground subagent results currently call `context.invalidate()` every 80 ms to animate their running glyph. Pi handles each invalidation by rebuilding the tool renderer and requesting a global TUI render, producing 12.5 full render/diff cycles per second. The overhead grows with transcript length, continues for expanded results where the glyph is not displayed, and can survive session shutdown.

This removes the renderer-owned timer, keeps running glyphs event-driven from real progress updates, and clears any legacy timer when the result renders.

Validation:
- `npm run test:all` (1,283 unit passes/one skip; 604 integration passes/two skips; two E2E passes)
- focused foreground and renderer tests
- fresh read-only TUI review: no issues
- `git diff --check`
