### PR TITLE
fix: collapse management output by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Collapsed multiline management/status output behind a first-line preview and the configured expand-key hint. Thanks to Nikolay Panov (@niksite) for #523.
+
 ## [0.35.0] - 2026-07-17
 
 ### Fixed

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1471,6 +1471,14 @@ export function renderSubagentResult(
 		const contextPrefix = d?.context === "fork" ? `${theme.fg("warning", "[fork]")} ` : "";
 		const width = getTermWidth() - 4;
 		if (!text.includes("\n")) return new Text(truncLine(`${contextPrefix}${text}`, width), 0, 0);
+		if (d && !options.expanded && !result.isError) {
+			const lines = text.split(/\r?\n/);
+			const firstNonEmptyLine = lines.find((line) => line.trim())?.trim() || "(no output)";
+			const c = new Container();
+			c.addChild(new Text(truncLine(`${contextPrefix}${firstNonEmptyLine} · ${lines.length} lines`, width), 0, 0));
+			c.addChild(new Text(truncLine(theme.fg("accent", `  Press ${liveDetailKeyText()} for full output`), width), 0, 0));
+			return c;
+		}
 		const c = new Container();
 		const wrapped = wrapPlainText(`${contextPrefix}${text}`, width);
 		for (const line of wrapped) c.addChild(new Text(line, 0, 0));

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { keyText } from "@earendil-works/pi-coding-agent";
 
 type RenderSubagentResult = (
 	result: {
 		content: Array<{ type: "text"; text: string }>;
+		isError?: boolean;
 		details?: {
 			mode: "single" | "parallel" | "chain" | "management";
 			context?: "fresh" | "fork";
@@ -26,6 +28,8 @@ const theme = {
 	fg: (_name: string, text: string) => text,
 	bold: (text: string) => text,
 };
+const expandKey = keyText("app.tools.expand");
+const expandHint = `Press ${expandKey} for full output`;
 
 const emptyUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
 
@@ -134,6 +138,78 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(compact, /↳ \[\d{2}:\d{2}:\d{2}\] \+1 nested run \(1 complete\)/);
 		assert.doesNotMatch(compact, /compact-terminal-child · complete/);
 	});
+	it("collapses multiline structured management output to a first-line summary", () => {
+		const output = `\n${"Managed agents: ".padEnd(220, "x")}\n- reviewer\n- writer`;
+		const widget = renderSubagentResult!({
+			content: [{ type: "text", text: output }],
+			details: { mode: "management", context: "fork", results: [] },
+		}, { expanded: false }, theme);
+
+		const lines = widget.render(120).map((line) => line.trimEnd());
+		assert.match(lines[0]!, /^\[fork\] Managed agents:/);
+		assert.match(lines[0]!, /…$/);
+		const hintLineIndex = lines.findIndex((line) => line.includes(expandHint) || (expandKey === "" && line.includes("Press ") && line.includes(" for full output")));
+		assert.ok(hintLineIndex > 0);
+		assert.doesNotMatch(lines[0]!, /reviewer/);
+	});
+
+	it("keeps multiline structured zero-result errors visible", () => {
+		const widget = renderSubagentResult!({
+			content: [{ type: "text", text: "Error: management failed\nfirst diagnostic\nsecond diagnostic" }],
+			isError: true,
+			details: { mode: "management", results: [] },
+		}, { expanded: false }, theme);
+
+		const text = widget.render(120).join("\n");
+		assert.match(text, /Error: management failed/);
+		assert.match(text, /first diagnostic/);
+		assert.match(text, /second diagnostic/);
+		assert.ok(!text.includes(expandHint));
+	});
+
+	it("keeps full multiline structured output when expanded", () => {
+		const output = "Managed agents:\n- reviewer\n- writer";
+		const widget = renderSubagentResult!({
+			content: [{ type: "text", text: output }],
+			details: { mode: "management", results: [] },
+		}, { expanded: true }, theme);
+
+		const text = widget.render(120).join("\n");
+		assert.match(text, /Managed agents:/);
+		assert.match(text, /- reviewer/);
+		assert.match(text, /- writer/);
+		assert.ok(!text.includes(expandHint));
+	});
+
+	it("collapses multiline structured single output using the same contract", () => {
+		const widget = renderSubagentResult!({
+			content: [{ type: "text", text: "Run status:\nState: running\nTranscript: available" }],
+			details: { mode: "single", results: [] },
+		}, { expanded: false }, theme);
+
+		const text = widget.render(120).join("\n");
+		assert.match(text, /^Run status:/);
+		assert.match(text, /3 lines/);
+		assert.ok(text.includes(expandHint) || (expandKey === "" && text.includes("Press ") && text.includes(" for full output")));
+		assert.doesNotMatch(text, /State: running/);
+	});
+
+	it("preserves unstructured multiline and structured single-line output", () => {
+		const unstructured = renderSubagentResult!({
+			content: [{ type: "text", text: "Error:\nfirst detail\nsecond detail" }],
+		}, { expanded: false }, theme).render(120).join("\n");
+		assert.match(unstructured, /first detail/);
+		assert.match(unstructured, /second detail/);
+		assert.ok(!unstructured.includes(expandHint));
+
+		const singleLine = renderSubagentResult!({
+			content: [{ type: "text", text: "No active async run transcript is available." }],
+			details: { mode: "single", results: [] },
+		}, { expanded: false }, theme).render(120).map((line) => line.trimEnd()).join("\n");
+		assert.equal(singleLine, "No active async run transcript is available.");
+		assert.ok(!singleLine.includes(expandHint));
+	});
+
 	it("shows [fork] when details are empty but context is fork", () => {
 		const widget = renderSubagentResult!({
 			content: [{ type: "text", text: "Async: reviewer [abc123]" }],


### PR DESCRIPTION
Fixes #523.

Structured multiline management and status results now collapse to the first non-empty line, a line count, and Pi's configured expand-key hint. Expanding preserves the full existing body and wrapping. Multiline errors, unstructured output, and single-line results remain visible as before.

The renderer regression covers management and status paths, long previews, configured key labels, expanded output, fork context, error visibility, and unchanged unstructured/single-line behavior. The full local gate passed with 1,285 unit tests, 609 integration tests, and two E2E tests; `npm audit`, `npm pack --dry-run`, and `git diff --check` also passed.

Thanks to Nikolay Panov (@niksite) for the report and proposed direction.
