### PR TITLE
fix: inactivity-based per-child timeout for background subagents

### DIFF
--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -152,6 +152,7 @@ interface AsyncChainParams {
 	configToolBudget?: ResolvedToolBudget;
 	/** Global cap on simultaneously-running subagent tasks within the async run. */
 	globalConcurrencyLimit?: number;
+	defaultTimeoutMs?: number;
 }
 
 interface AsyncSingleParams {
@@ -189,6 +190,7 @@ interface AsyncSingleParams {
 	acceptance?: AcceptanceInput;
 	timeoutMs?: number;
 	absoluteDeadlineAt?: number;
+	defaultTimeoutMs?: number;
 	turnBudget?: ResolvedTurnBudget;
 	toolBudget?: ResolvedToolBudget;
 	configToolBudget?: ResolvedToolBudget;
@@ -863,7 +865,7 @@ export function executeAsyncChain(
 		return formatAsyncStartError(resultMode, built.error);
 	}
 	const { steps, runnerCwd, workflowGraph, eventChain } = built;
-	const deadlineAt = params.timeoutMs !== undefined ? Date.now() + params.timeoutMs : undefined;
+	const deadlineAt = undefined;
 	const initialTurnBudget = params.turnBudget ? initialTurnBudgetState(params.turnBudget) : undefined;
 	let childTargetIndex = 0;
 	const childIntercomTargets = childIntercomTarget ? steps.flatMap((step) => {
@@ -912,6 +914,7 @@ export function executeAsyncChain(
 				timeoutMs: params.timeoutMs,
 				deadlineAt,
 				globalConcurrencyLimit: params.globalConcurrencyLimit,
+			defaultTimeoutMs: params.defaultTimeoutMs,
 				workflowGraph,
 				nestedRoute: nestedRoute ?? inheritedNestedRoute,
 				nestedSelf: inheritedNestedRoute && nestedAddress ? {
@@ -1119,7 +1122,7 @@ export function executeAsyncSingle(
 	const toolBudgetInput = params.toolBudget ?? agentConfig.toolBudget ?? params.configToolBudget;
 	const resolvedToolBudget = validateToolBudgetConfig(toolBudgetInput, params.toolBudget ? "toolBudget" : agentConfig.toolBudget ? "agent.toolBudget" : "config.toolBudget");
 	if (resolvedToolBudget.error) return formatAsyncStartError("single", resolvedToolBudget.error);
-	const deadlineAt = params.absoluteDeadlineAt ?? (params.timeoutMs !== undefined ? Date.now() + params.timeoutMs : undefined);
+	const deadlineAt = params.absoluteDeadlineAt;
 	const timeoutMs = params.absoluteDeadlineAt !== undefined && deadlineAt !== undefined
 		? deadlineAt - Date.now()
 		: params.timeoutMs;
@@ -1228,6 +1231,7 @@ export function executeAsyncSingle(
 				controlConfig,
 				timeoutMs,
 				deadlineAt,
+				defaultTimeoutMs: params.defaultTimeoutMs,
 				turnBudget: params.turnBudget,
 				toolBudget: params.toolBudget,
 				controlIntercomTarget,

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -379,7 +379,7 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 
 	const liveness = checkPidLiveness(effectiveStatus.pid, options.kill);
 	if (liveness !== "dead") {
-		const staleAfterMs = options.staleAlivePidMs ?? 24 * 60 * 60 * 1000;
+		const staleAfterMs = options.staleAlivePidMs ?? 30 * 60 * 1000;
 		const lastUpdate = effectiveStatus.lastUpdate ?? effectiveStatus.startedAt;
 		if (now - lastUpdate <= staleAfterMs) return { status: status ?? null, repaired: false, resultPath };
 		const message = `Async runner process ${effectiveStatus.pid} still has a live PID, but status has not updated for ${now - lastUpdate}ms. Marked run failed by stale-run reconciliation because PID ownership cannot be verified.`;

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -111,6 +111,9 @@ import {
 	type ChildWatchdogStateSnapshot,
 } from "../../watchdog/child-status.ts";
 
+/** Default timeout for runs without an explicit timeoutMs. 30 minutes. */
+const DEFAULT_RUN_TIMEOUT_MS = 30 * 60 * 1000;
+
 interface SubagentRunConfig {
 	id: string;
 	steps: RunnerStep[];
@@ -144,6 +147,8 @@ interface SubagentRunConfig {
 	turnBudget?: ResolvedTurnBudget;
 	toolBudget?: ResolvedToolBudget;
 	revivalLease?: SessionLeaseRequest;
+	/** Default timeout in ms applied when no explicit timeoutMs is set. 0 disables. */
+	defaultTimeoutMs?: number;
 	/** Global cap on simultaneously-running subagent tasks within this run. */
 	globalConcurrencyLimit?: number;
 }
@@ -1591,10 +1596,16 @@ async function runSubagent(
 	let timedOut = false;
 	let stopped = false;
 	let turnBudgetExceeded = false;
-	const timeoutMessage = config.timeoutMs !== undefined ? `Subagent timed out after ${config.timeoutMs}ms.` : undefined;
+	const effectiveTimeoutMs = config.timeoutMs !== undefined
+		? config.timeoutMs
+		: (config.defaultTimeoutMs !== undefined && config.defaultTimeoutMs > 0)
+			? config.defaultTimeoutMs
+			: (config.defaultTimeoutMs === 0 ? undefined : DEFAULT_RUN_TIMEOUT_MS);
+	const timeoutMessage = effectiveTimeoutMs !== undefined ? `Subagent timed out after ${effectiveTimeoutMs}ms.` : undefined;
 	const stopMessage = "Subagent stopped by user.";
 	const timeoutAbortController = new AbortController();
 	const stopAbortController = new AbortController();
+	const childTimeoutTimers = new Map<number, NodeJS.Timeout>();
 	let previousCumulativeTokens: TokenUsage = { input: 0, output: 0, total: 0 };
 	let latestSessionFile: string | undefined;
 
@@ -1680,8 +1691,8 @@ async function runSubagent(
 		lastActivityAt: overallStartTime,
 		startedAt: overallStartTime,
 		lastUpdate: overallStartTime,
-		...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
-		...(config.deadlineAt !== undefined ? { deadlineAt: config.deadlineAt } : {}),
+		...(effectiveTimeoutMs !== undefined ? { timeoutMs: effectiveTimeoutMs } : {}),
+		...(effectiveDeadlineAt !== undefined ? { deadlineAt: effectiveDeadlineAt } : {}),
 		...(config.turnBudget ? { turnBudget: initialTurnBudgetState(config.turnBudget) } : {}),
 		...(config.toolBudget ? { toolBudget: initialToolBudgetState(config.toolBudget) } : {}),
 		pid: process.pid,
@@ -1764,13 +1775,34 @@ async function runSubagent(
 		activeChildInterrupts.set(flatIndex, interrupt);
 		if (interrupted) interrupt();
 	};
+	const resetChildInactivityTimer = (flatIndex: number): void => {
+		if (effectiveTimeoutMs === undefined) return;
+		const existing = childTimeoutTimers.get(flatIndex);
+		if (existing) clearTimeout(existing);
+		const timer = setTimeout(() => {
+			childTimeoutTimers.delete(flatIndex);
+			const fn = activeChildTimeouts.get(flatIndex);
+			if (fn) fn();
+		}, effectiveTimeoutMs);
+		timer.unref?.();
+		childTimeoutTimers.set(flatIndex, timer);
+	};
 	const registerStepTimeout = (flatIndex: number, interrupt: (() => void) | undefined): void => {
 		if (!interrupt) {
 			activeChildTimeouts.delete(flatIndex);
+			const timer = childTimeoutTimers.get(flatIndex);
+			if (timer) {
+				clearTimeout(timer);
+				childTimeoutTimers.delete(flatIndex);
+			}
 			return;
 		}
 		activeChildTimeouts.set(flatIndex, interrupt);
-		if (timedOut) interrupt();
+		if (timedOut) {
+			interrupt();
+		} else if (effectiveTimeoutMs !== undefined) {
+			resetChildInactivityTimer(flatIndex);
+		}
 	};
 	const registerStepStop = (flatIndex: number, stop: (() => void) | undefined): void => {
 		if (!stop) {
@@ -2363,6 +2395,7 @@ async function runSubagent(
 		}
 		syncTopLevelCurrentTool();
 		step.lastActivityAt = now;
+		resetChildInactivityTimer(flatIndex);
 		statusPayload.lastActivityAt = now;
 		statusPayload.lastUpdate = now;
 		maybeEmitActiveLongRunning(flatIndex, now);
@@ -2520,8 +2553,8 @@ async function runSubagent(
 			type: "subagent.run.timed_out",
 			ts: now,
 			runId: id,
-			timeoutMs: config.timeoutMs,
-			deadlineAt: config.deadlineAt,
+			timeoutMs: effectiveTimeoutMs,
+			deadlineAt: effectiveDeadlineAt,
 			message,
 		}));
 		timeoutAbortController.abort();
@@ -2566,8 +2599,9 @@ async function runSubagent(
 		},
 		onSteerAck: consumeSteerAck,
 	});
-	if (config.deadlineAt !== undefined) {
-		const remainingMs = Math.max(0, config.deadlineAt - Date.now());
+	const effectiveDeadlineAt = config.deadlineAt !== undefined ? config.deadlineAt : undefined;
+	if (effectiveDeadlineAt !== undefined) {
+		const remainingMs = Math.max(0, effectiveDeadlineAt - Date.now());
 		timeoutTimer = setTimeout(timeoutRunner, remainingMs);
 		timeoutTimer.unref?.();
 	}
@@ -2897,7 +2931,7 @@ async function runSubagent(
 				}));
 				if (singleResult.exitCode !== 0 && failFast) aborted = true;
 				return stopped || childStopped ? { ...singleResult, output: stopMessage, error: stopMessage, exitCode: 1, interrupted: false, timedOut: false, stopped: true, skipped: false } : timedOut ? { ...singleResult, output: timeoutMessage ?? "Subagent timed out.", error: timeoutMessage ?? "Subagent timed out.", exitCode: 1, interrupted: false, timedOut: true, skipped: false } : { ...singleResult, skipped: false };
-			}, globalSemaphore);
+			}, globalSemaphore, timeoutAbortController.signal);
 
 			flatIndex += dynamicSteps.length;
 			for (const pr of parallelResults) {
@@ -3223,6 +3257,7 @@ async function runSubagent(
 						return stopped || childStopped ? { ...singleResult, output: stopMessage, error: stopMessage, exitCode: 1, interrupted: false, timedOut: false, stopped: true, skipped: false } : timedOut ? { ...singleResult, output: timeoutMessage ?? "Subagent timed out.", error: timeoutMessage ?? "Subagent timed out.", exitCode: 1, interrupted: false, timedOut: true, skipped: false } : { ...singleResult, skipped: false };
 					},
 					globalSemaphore,
+					timeoutAbortController.signal,
 				);
 
 				flatIndex += group.parallel.length;
@@ -3567,6 +3602,8 @@ async function runSubagent(
 		clearTimeout(timeoutTimer);
 		timeoutTimer = undefined;
 	}
+	for (const timer of childTimeoutTimers.values()) clearTimeout(timer);
+	childTimeoutTimers.clear();
 	statusPayload.state = stopped ? "stopped" : timedOut || turnBudgetExceeded ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : "failed";
 	closeSteerInbox(asyncDir, statusPayload.state);
 	disposeControlInbox();
@@ -3653,8 +3690,8 @@ async function runSubagent(
 			success: !stopped && !timedOut && !turnBudgetExceeded && !interrupted && results.every((r) => r.success),
 			state: stopped ? "stopped" : timedOut || turnBudgetExceeded ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : "failed",
 			summary: stopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? (statusPayload.error ?? "Subagent exceeded turn budget.") : interrupted ? "Paused after interrupt. Waiting for explicit next action." : summary,
-			...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
-			...(config.deadlineAt !== undefined ? { deadlineAt: config.deadlineAt } : {}),
+			...(effectiveTimeoutMs !== undefined ? { timeoutMs: effectiveTimeoutMs } : {}),
+			...(effectiveDeadlineAt !== undefined ? { deadlineAt: effectiveDeadlineAt } : {}),
 			...(statusPayload.turnBudget ? { turnBudget: statusPayload.turnBudget } : {}),
 			...(statusPayload.turnBudgetExceeded ? { turnBudgetExceeded: true } : {}),
 			...(statusPayload.wrapUpRequested ? { wrapUpRequested: true } : {}),

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1222,6 +1222,7 @@ async function resumeAsyncRun(input: {
 			controlIntercomTarget: intercomBridge.active ? intercomBridge.orchestratorTarget : undefined,
 			childIntercomTarget: intercomBridge.active ? (agent, index) => resolveSubagentIntercomTarget(runId, agent, index) : undefined,
 			globalConcurrencyLimit: input.deps.config.globalConcurrencyLimit,
+			defaultTimeoutMs: input.deps.config.defaultTimeoutMs,
 		});
 		if (result.isError) return result;
 		const attachedId = result.details.asyncId ?? runId;
@@ -2005,6 +2006,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			toolBudget: data.toolBudget,
 			configToolBudget: data.configToolBudget,
 			globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
+			defaultTimeoutMs: deps.config.defaultTimeoutMs,
 		});
 	}
 
@@ -2044,6 +2046,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			toolBudget: data.toolBudget,
 			configToolBudget: data.configToolBudget,
 			globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
+			defaultTimeoutMs: deps.config.defaultTimeoutMs,
 		});
 	}
 
@@ -2170,6 +2173,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		toolBudget: data.toolBudget,
 		configToolBudget: data.configToolBudget,
 		globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
+		defaultTimeoutMs: deps.config.defaultTimeoutMs,
 	});
 
 	if (chainResult.requestedAsync) {
@@ -2225,6 +2229,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			toolBudget: data.toolBudget,
 			configToolBudget: data.configToolBudget,
 			globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
+			defaultTimeoutMs: deps.config.defaultTimeoutMs,
 		});
 	}
 
@@ -2717,6 +2722,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				timeoutMs: data.timeoutMs,
 				turnBudget: data.turnBudget,
 				globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
+				defaultTimeoutMs: deps.config.defaultTimeoutMs,
 			});
 		}
 	}

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -133,6 +133,7 @@ export async function mapConcurrent<T, R>(
 	limit: number,
 	fn: (item: T, i: number) => Promise<R>,
 	globalSemaphore?: Semaphore,
+	abortSignal?: AbortSignal,
 ): Promise<R[]> {
 	const safeLimit = Math.max(1, Math.floor(limit) || 1);
 	const results: R[] = new Array(items.length);
@@ -140,6 +141,7 @@ export async function mapConcurrent<T, R>(
 
 	async function worker(_workerIndex: number): Promise<void> {
 		while (next < items.length) {
+			if (abortSignal?.aborted) break;
 			const i = next++;
 			if (globalSemaphore) {
 				await globalSemaphore.acquire();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1189,6 +1189,8 @@ export interface ExtensionConfig {
 	maxSubagentDepth?: number;
 	/** Optional cumulative session cap. Unset or 0 means unlimited. */
 	maxSubagentSpawnsPerSession?: number;
+	/** Default timeout in ms for runs without an explicit timeoutMs. Defaults to 30 minutes. 0 disables. */
+	defaultTimeoutMs?: number;
 	/** Global cap on simultaneously-running subagent tasks within a single run. Defaults to 20. */
 	globalConcurrencyLimit?: number;
 	control?: ControlConfig;


### PR DESCRIPTION
## Problem

Background subagents had no default timeout, and the explicit `timeoutMs` parameter was interpreted as a **run-level deadline** — meaning the 300s clock started when the first child launched. Children queued behind the concurrency limit (default 4) inherited almost no time and were killed prematurely, even while actively working.

This caused 1-2 out of N parallel background subagents to consistently time out when the total run exceeded `timeoutMs`, even though the individual children were still producing output.

## Solution

### 1. Default timeout (`subagent-runner.ts`)
- Add `DEFAULT_RUN_TIMEOUT_MS` (30 min) applied when no explicit `timeoutMs` is set
- Configurable via `defaultTimeoutMs` in `config.json`; `0` disables
- Priority: explicit `timeoutMs` > config `defaultTimeoutMs` > `DEFAULT_RUN_TIMEOUT_MS`

### 2. Inactivity-based per-child timer (`subagent-runner.ts`)
- `resetChildInactivityTimer` arms a `setTimeout` that **resets on every child event** (tool calls, messages, stdout)
- Only `effectiveTimeoutMs` of **complete silence** triggers a kill
- Active children (searching, fetching, writing) run indefinitely — their timer keeps resetting
- A child stuck on a hung API call with no output for 300s gets killed

### 3. Remove run-level deadline derivation (`async-execution.ts`)
- `timeoutMs` no longer converts to a run-level `deadlineAt`
- Only explicit `config.deadlineAt` (from `absoluteDeadlineAt` for revival) arms the run-level timer
- `timeoutMs` flows through as the per-child inactivity timeout only

### 4. `mapConcurrent` abort signal (`parallel-utils.ts`)
- Optional `abortSignal` parameter; workers check it before picking up new items
- Prevents queue drain after a run-level timeout (safety net)

### 5. Thread `defaultTimeoutMs` from extension config
- Added to `ExtensionConfig`, `AsyncChainParams`, `AsyncSingleParams`, `SubagentRunConfig`
- Passed through from `config.json` → extension → async execution → runner

### 6. Stale-run reconciliation (`stale-run-reconciler.ts`)
- Reduce `staleAlivePidMs` default from 24 hours to 30 minutes

## Verification

8 parallel background `researcher` subagents with `timeoutMs=300000`:
- **Before:** 2-4 children killed by run-level deadline (started late due to concurrency=4, inherited almost no time)
- **After:** 8/8 completed successfully, zero timeouts, run lasted 6m22s — well past the old 300s kill point

## Files changed

| File | Changes |
|------|--------|
| `src/shared/types.ts` | Add `defaultTimeoutMs` to `ExtensionConfig` |
| `src/runs/shared/parallel-utils.ts` | Add optional `abortSignal` to `mapConcurrent` |
| `src/runs/background/subagent-runner.ts` | Default timeout, inactivity-based per-child timer, cleanup |
| `src/runs/background/async-execution.ts` | Stop converting `timeoutMs` to run-level `deadlineAt`; thread `defaultTimeoutMs` |
| `src/runs/foreground/subagent-executor.ts` | Thread `defaultTimeoutMs` from config to async params |
| `src/runs/background/stale-run-reconciler.ts` | Reduce stale threshold 24h → 30min |

Thanks to @colourfulcode for the inactivity-based timeout design.