### PR TITLE
fix: avoid watchdog startup scans when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added the missing `context: "fork"` field to the fork-context example in the bundled `pi-subagents` skill. Thanks to Kier (@kierr) for #540.
 - Resolved host-provided TypeBox compiler lookup for detached async runners and structured-output validation. Thanks to @nistaux for #526, 96tommykim (@96tommykim) for #545, and @git-geeky and @lukechen526 for reproduction and validation details.
 - Recognize Cursor edit/write thinking traces and replay tool calls as mutation evidence, so Cursor-provider workers that actually edit files no longer false-fail with `completed-without-making-edits`. Thanks to Mikhail Wijanarko (@mwijanarko1) for #539.
+- Skip repository change signatures while the watchdog is disabled and inspect modified nested Git worktrees through Git, preventing startup from recursively hashing ignored submodule dependencies. Thanks to 傅洋 (@4ier) for #531 and #532.
 
 ## [0.35.1] - 2026-07-17
 

--- a/src/watchdog/change-signature.ts
+++ b/src/watchdog/change-signature.ts
@@ -45,6 +45,15 @@ function hashPath(root: string, relPath: string): unknown {
 		return { path: normalized, state: "symlink", target: fs.readlinkSync(fullPath) };
 	}
 	if (stat.isDirectory()) {
+		if (fs.existsSync(path.join(fullPath, ".git"))) {
+			const changes = computeWatchdogRepoChangeSignature(fullPath);
+			return {
+				path: normalized,
+				state: "git-worktree",
+				head: git(fullPath, ["rev-parse", "HEAD"])?.trim(),
+				changes: changes ? { key: changes.key, changedPaths: changes.changedPaths } : undefined,
+			};
+		}
 		const entries = fs.readdirSync(fullPath)
 			.map((entry) => normalizeRelPath(path.posix.join(normalized, entry)))
 			.filter((entry) => !ignoredRelPath(entry))

--- a/src/watchdog/runtime.ts
+++ b/src/watchdog/runtime.ts
@@ -79,6 +79,7 @@ interface MainWatchdogRuntimeOptions {
 	displayWarning?: (warning: WatchdogWarningDetails) => void;
 	reviewChangesOnly?: boolean;
 	lspDiagnostics?: WatchdogLspDiagnosticsFunction;
+	repoChangeSignature?: typeof computeWatchdogRepoChangeSignature;
 }
 
 type ContextLike = Pick<ExtensionContext, "cwd">;
@@ -113,6 +114,7 @@ export class MainWatchdogRuntime {
 	private readonly displayWarning: ((warning: WatchdogWarningDetails) => void) | undefined;
 	private readonly reviewChangesOnly: boolean;
 	private readonly lspDiagnostics: WatchdogLspDiagnosticsFunction;
+	private readonly repoChangeSignature: typeof computeWatchdogRepoChangeSignature;
 	private readonly lspLedger = new WatchdogLspDiagnosticsLedger();
 	private configResult: WatchdogSettingsResult;
 	private sessionOverrideEnabled: boolean | undefined;
@@ -155,6 +157,7 @@ export class MainWatchdogRuntime {
 		this.displayWarning = options.displayWarning;
 		this.reviewChangesOnly = options.reviewChangesOnly === true;
 		this.lspDiagnostics = options.lspDiagnostics ?? collectWatchdogLspDiagnostics;
+		this.repoChangeSignature = options.repoChangeSignature ?? computeWatchdogRepoChangeSignature;
 		this.configResult = this.resolveConfig(this.cwd);
 		this.guardMaxWarnings = this.configResult.config.maxWarnings;
 		this.guard = new WatchdogEmissionGuard({ maxWarnings: this.guardMaxWarnings });
@@ -166,9 +169,8 @@ export class MainWatchdogRuntime {
 		this.cwd = ctx.cwd;
 		this.sessionOverrideEnabled = undefined;
 		this.sessionModelOverride = undefined;
-		this.reset("session_start", { clearReviewInputSignature: true, resetChangeSignature: true, clearLspLedger: true });
 		this.refreshConfig(ctx.cwd);
-		this.resetRepoChangeBaseline();
+		this.reset("session_start", { clearReviewInputSignature: true, resetChangeSignature: true, clearLspLedger: true });
 	}
 
 	refreshConfig(cwd = this.cwd): WatchdogSettingsResult {
@@ -532,7 +534,7 @@ export class MainWatchdogRuntime {
 	}
 
 	private currentRepoChangeSignature(cwd = this.cwd): WatchdogRepoChangeSignature | undefined {
-		return this.reviewChangesOnly ? computeWatchdogRepoChangeSignature(cwd) : undefined;
+		return this.reviewChangesOnly && this.isEnabled() ? this.repoChangeSignature(cwd) : undefined;
 	}
 
 	private resetRepoChangeBaseline(options: { cwd?: string; reviewed?: boolean } = {}): void {

--- a/test/unit/watchdog-change-signature.test.ts
+++ b/test/unit/watchdog-change-signature.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { computeWatchdogRepoChangeSignature } from "../../src/watchdog/change-signature.ts";
+
+function git(cwd: string, args: string[]): string {
+	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8" });
+	if (result.status !== 0) throw new Error(result.stderr.trim() || result.stdout.trim() || `git ${args.join(" ")} failed`);
+	return result.stdout.trim();
+}
+
+function createRepo(prefix: string): string {
+	const repo = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	git(repo, ["init"]);
+	git(repo, ["config", "user.email", "watchdog@example.com"]);
+	git(repo, ["config", "user.name", "Watchdog Tests"]);
+	return repo;
+}
+
+describe("watchdog change signature", () => {
+	it("hashes modified submodules through Git without traversing ignored dependencies", (t) => {
+		const childSource = createRepo("watchdog-child-");
+		const parent = createRepo("watchdog-parent-");
+		const checkout = path.join(parent, "vendor", "child");
+		const ignoredFile = path.join(checkout, "node_modules", "ignored.bin");
+		t.after(() => {
+			fs.rmSync(parent, { recursive: true, force: true });
+			fs.rmSync(childSource, { recursive: true, force: true });
+		});
+
+		fs.writeFileSync(path.join(childSource, ".gitignore"), "node_modules/\n", "utf-8");
+		fs.writeFileSync(path.join(childSource, "tracked.txt"), "one\n", "utf-8");
+		git(childSource, ["add", "-A"]);
+		git(childSource, ["commit", "-m", "initial"]);
+
+		git(parent, ["-c", "protocol.file.allow=always", "submodule", "add", childSource, "vendor/child"]);
+		git(parent, ["commit", "-am", "add submodule"]);
+
+		fs.mkdirSync(path.dirname(ignoredFile), { recursive: true });
+		fs.writeFileSync(ignoredFile, "ignored one\n", "utf-8");
+		fs.writeFileSync(path.join(checkout, "tracked.txt"), "two\n", "utf-8");
+
+		const first = computeWatchdogRepoChangeSignature(parent);
+		assert.deepEqual(first?.changedPaths, ["vendor/child"]);
+
+		fs.writeFileSync(ignoredFile, "ignored two\n", "utf-8");
+		const ignoredOnly = computeWatchdogRepoChangeSignature(parent);
+		assert.equal(ignoredOnly?.key, first?.key);
+
+		fs.writeFileSync(path.join(checkout, "tracked.txt"), "three\n", "utf-8");
+		const trackedChange = computeWatchdogRepoChangeSignature(parent);
+		assert.notEqual(trackedChange?.key, first?.key);
+	});
+});

--- a/test/unit/watchdog-runtime.test.ts
+++ b/test/unit/watchdog-runtime.test.ts
@@ -72,6 +72,46 @@ function createRepo(): string {
 }
 
 describe("main watchdog runtime", () => {
+	it("does not inspect the repository until the watchdog is enabled", () => {
+		let enabled = false;
+		let signatureCalls = 0;
+		const runtime = new MainWatchdogRuntime({
+			cwd: "/tmp/project",
+			resolveConfig: () => configResult(enabled ? enabledConfig() : cloneConfig()),
+			reviewChangesOnly: true,
+			repoChangeSignature: () => {
+				signatureCalls++;
+				return { root: "/tmp/project", key: "signature", changedPaths: [] };
+			},
+		});
+
+		assert.equal(signatureCalls, 0);
+		runtime.handleBeforeAgentStart({ prompt: "disabled" }, { cwd: "/tmp/project" });
+		assert.equal(signatureCalls, 0);
+
+		enabled = true;
+		runtime.handleBeforeAgentStart({ prompt: "enabled" }, { cwd: "/tmp/project" });
+		assert.equal(signatureCalls, 1);
+	});
+
+	it("does not use stale enabled config to inspect a newly bound default-off session", () => {
+		let signatureCalls = 0;
+		const runtime = new MainWatchdogRuntime({
+			cwd: "/tmp/enabled",
+			resolveConfig: (cwd) => configResult(cwd === "/tmp/enabled" ? enabledConfig() : cloneConfig()),
+			reviewChangesOnly: true,
+			repoChangeSignature: (cwd) => {
+				signatureCalls++;
+				return { root: cwd, key: cwd, changedPaths: [] };
+			},
+		});
+
+		assert.equal(signatureCalls, 1);
+		runtime.bindSession({ cwd: "/tmp/default-off" });
+		assert.equal(signatureCalls, 1);
+		assert.equal(runtime.getSnapshot().enabled, false);
+	});
+
 	it("stays default-off and contains invalid config at the watchdog boundary", () => {
 		let reviewCalls = 0;
 		const runtime = new MainWatchdogRuntime({


### PR DESCRIPTION
## Summary

- skip repository change-signature work while the default-off watchdog is disabled
- represent modified nested Git worktrees by their HEAD and Git-filtered change signature instead of recursively walking the directory
- add regressions for default-off startup and modified submodules with ignored dependencies

Fixes #531.

## Why

The watchdog captured a baseline during extension construction even when disabled. When the superproject reported a modified submodule, the generic directory hasher recursively read that submodule, including ignored dependency trees. On the reported dirty monorepo this blocked startup for 30–95+ seconds.

Nested Git worktrees now calculate their own Git-filtered signature, so ignored files stay ignored while tracked content changes still alter the parent signature.

## Validation

- dirty-monorepo Pi startup with the patched extension: `0.659s`, `0.546s`, `0.534s` (median `0.546s`)
- Node 24 unit suite: 1,287 passed, 0 failed, 1 skipped
- Node 24 integration suite: 609 passed, 0 failed, 2 skipped
- Node 24 E2E suite: 2 passed, 0 failed
- `git diff --check`
