### PR TITLE
fix: count Cursor edit traces as completion-guard mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Kept async oracle review tasks with implementation vocabulary from triggering write-evidence acceptance contracts or the no-mutation implementation guard.
 - Added the missing `context: "fork"` field to the fork-context example in the bundled `pi-subagents` skill. Thanks to Kier (@kierr) for #540.
 - Resolved host-provided TypeBox compiler lookup for detached async runners and structured-output validation. Thanks to @nistaux for #526, 96tommykim (@96tommykim) for #545, and @git-geeky and @lukechen526 for reproduction and validation details.
+- Recognize Cursor edit/write thinking traces and replay tool calls as mutation evidence, so Cursor-provider workers that actually edit files no longer false-fail with `completed-without-making-edits`. Thanks to Mikhail Wijanarko (@mwijanarko1) for #539.
 
 ## [0.35.1] - 2026-07-17
 

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -1,5 +1,5 @@
 import type { Message } from "@earendil-works/pi-ai";
-import { isMutatingBashCommand } from "./long-running-guard.ts";
+import { isMutatingTool } from "./long-running-guard.ts";
 import { expectsImplementationMutation } from "./task-intent.ts";
 
 export { expectsImplementationMutation };
@@ -15,6 +15,12 @@ const READ_ONLY_BUILTIN_TOOLS = new Set([
 	"intercom",
 	"contact_supervisor",
 ]);
+
+// Cursor native edit/write often land as thinking traces (inactive_trace /
+// transcript_trace) rather than toolCall parts when native tool replay is off
+// or the tool is inactive in context. Match pi-cursor-sdk display labels.
+const CURSOR_FILE_MUTATION_THINKING =
+	/(?:^|\n)\s*Cursor (?:edit|write)\s*:/i;
 
 interface CompletionMutationGuardInput {
 	agent: string;
@@ -39,13 +45,12 @@ export function hasMutationToolCall(messages: Message[]): boolean {
 	for (const message of messages) {
 		if (message.role !== "assistant") continue;
 		for (const part of message.content) {
+			if (part.type === "thinking" && CURSOR_FILE_MUTATION_THINKING.test(part.thinking)) return true;
 			if (part.type !== "toolCall") continue;
-			if (part.name === "edit" || part.name === "write") return true;
-			if (part.name !== "bash") continue;
 			const args = typeof part.arguments === "object" && part.arguments !== null && !Array.isArray(part.arguments)
 				? part.arguments as Record<string, unknown>
 				: {};
-			if (typeof args.command === "string" && isMutatingBashCommand(args.command)) return true;
+			if (isMutatingTool(part.name, args)) return true;
 		}
 	}
 	return false;

--- a/src/runs/shared/long-running-guard.ts
+++ b/src/runs/shared/long-running-guard.ts
@@ -103,6 +103,10 @@ export function isMutatingBashCommand(command: string): boolean {
 export function isMutatingTool(toolName: string | undefined, args: Record<string, unknown> | undefined): boolean {
 	if (!toolName) return false;
 	if (toolName === "edit" || toolName === "write") return true;
+	if (toolName === "cursor") {
+		const activityTitle = typeof args?.activityTitle === "string" ? args.activityTitle : "";
+		return /^Cursor (?:edit|write)\b/i.test(activityTitle);
+	}
 	if (toolName !== "bash") return false;
 	const command = typeof args?.command === "string" ? args.command : "";
 	if (!command.trim()) return false;

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -8,6 +8,7 @@ import {
 	expectsImplementationMutation,
 	hasMutationToolCall,
 } from "../../src/runs/shared/completion-guard.ts";
+import { isMutatingTool } from "../../src/runs/shared/long-running-guard.ts";
 
 function assistantToolCall(name: string, args: Record<string, unknown> = {}): Message {
 	return {
@@ -200,4 +201,62 @@ test("implementation task with mutation attempts does not trigger", () => {
 	});
 
 	assert.equal(result.triggered, false);
+});
+
+function assistantThinking(thinking: string): Message {
+	return {
+		role: "assistant",
+		content: [{ type: "thinking", thinking }],
+	} as unknown as Message;
+}
+
+test("Cursor edit/write thinking traces count as mutation attempts", () => {
+	assert.equal(
+		hasMutationToolCall([assistantThinking("Cursor edit: docs/BACKEND_ARCHITECTURE.md added 10 lines, removed 3 lines\n")]),
+		true,
+	);
+	assert.equal(
+		hasMutationToolCall([assistantThinking("Cursor write: src/file.ts created\n")]),
+		true,
+	);
+	assert.equal(
+		hasMutationToolCall([assistantThinking("I plan to edit the file next\n")]),
+		false,
+	);
+	assert.equal(
+		hasMutationToolCall([assistantThinking("Cursor read: docs/BACKEND_ARCHITECTURE.md\n")]),
+		false,
+	);
+});
+
+test("Cursor replay tool calls count only edit/write activity as mutation", () => {
+	const cursorEdit = { activityTitle: "Cursor edit", path: "docs/BACKEND_ARCHITECTURE.md" };
+	const cursorWrite = { activityTitle: "Cursor write", path: "src/file.ts" };
+	assert.equal(hasMutationToolCall([assistantToolCall("cursor", cursorEdit)]), true);
+	assert.equal(hasMutationToolCall([assistantToolCall("cursor", cursorWrite)]), true);
+	assert.equal(hasMutationToolCall([assistantToolCall("cursor", { activityTitle: "Cursor read" })]), false);
+	assert.equal(isMutatingTool("cursor", cursorEdit), true);
+	assert.equal(isMutatingTool("cursor", { activityTitle: "Cursor read" }), false);
+});
+
+test("claimed changedFiles without mutation evidence does not bypass the guard", () => {
+	const report = assistantText(`Done.\n\`\`\`acceptance-report\n{\n  "changedFiles": ["docs/BACKEND_ARCHITECTURE.md"]\n}\n\`\`\``);
+	assert.equal(hasMutationToolCall([report]), false);
+});
+
+test("implementation task with Cursor edit thinking does not trigger", () => {
+	const result = evaluateCompletionMutationGuard({
+		agent: "worker",
+		task: "Edit docs/BACKEND_ARCHITECTURE.md",
+		messages: [
+			assistantThinking("Cursor edit: docs/BACKEND_ARCHITECTURE.md added 1 line\n"),
+			assistantText("Implemented the six simplifications."),
+		],
+		tools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+	});
+	assert.deepEqual(result, {
+		expectedMutation: true,
+		attemptedMutation: true,
+		triggered: false,
+	});
 });


### PR DESCRIPTION
## Description

A Cursor-powered subagent could successfully edit files and report completion, but `pi-subagents` still marked the run as failed with:

> Subagent completed without making edits for an implementation task.

Cursor may represent native file mutations in two provider-specific forms instead of ordinary `edit`/`write` tool calls:

- a thinking trace such as `Cursor edit: path ...`
- a replay `toolCall` named `cursor` with `activityTitle: "Cursor edit"` or `"Cursor write"`

The completion guard did not recognize either form, so it incorrectly treated successful implementation runs as no-op runs.

This change:

- recognizes Cursor edit/write thinking traces during end-of-run transcript evaluation
- recognizes Cursor replay edit/write tool calls
- reuses `isMutatingTool` so live foreground/background tracking and transcript evaluation agree
- does not trust a claimed acceptance-report `changedFiles` list without actual mutation evidence

## Steps to Reproduce Bug and Validate Solution

### Reproduce

1. Launch the `worker` subagent with a Cursor model such as `cursor/grok-4.5:high`.
2. Ask it to edit a file.
3. Let Cursor apply the edit through its native edit path.
4. Observe that the transcript contains `Cursor edit: ...` or a `cursor` replay tool call rather than a standard `edit`/`write` tool call.
5. Before this change, the completion guard marks the successful run as failed with “completed without making edits.”

### Validate

1. Run:
   ```bash
   node --experimental-strip-types --test test/unit/completion-guard.test.ts
   ```
2. Confirm all 16 tests pass.
3. Confirm Cursor edit/write traces and replay calls count as mutations.
4. Confirm Cursor read activity, planning prose, and claimed `changedFiles` without mutation evidence do not count as mutations.

## PR Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All relevant new and existing tests passed.
- [x] My code follows the code style of this project.
- [ ] I ran the full lint checks with no new errors or warnings.
- [x] I checked for other open pull requests for the same change.

## Does This Introduce a Breaking Change?

- [ ] Yes
- [x] No

## Testing

- **OS:** macOS
- **Runtime:** Node.js 26
- **Test command:** `node --experimental-strip-types --test test/unit/completion-guard.test.ts`
- **Result:** 16/16 tests passed
- **Scenarios covered:**
  - standard `edit`, `write`, and mutating `bash` calls
  - Cursor edit/write thinking traces
  - Cursor edit/write replay tool calls
  - non-mutating Cursor read activity
  - prose that only claims an edit will happen
  - acceptance-report `changedFiles` without actual mutation evidence

The full unit suite was not used as evidence because this local Node.js version rejects the repository's `--experimental-transform-types` subprocess flag. The directly affected unit test passes independently.

## Any Relevant Logs or Outputs

Original false failure:

```text
Subagent completed without making edits for an implementation task.
It appears to have returned planning or scratchpad output instead of applying changes.
```

Narrow test result:

```text
tests 16
pass 16
fail 0
```

## Other Information or Known Dependencies

- The fix intentionally supports both Cursor representations because the emitted shape depends on native replay state.
- No production dependency changes are included.
- The local installed `pi-subagents` package was patched for verification; this PR contains the durable upstream change.
