### PR TITLE
Show subagent context badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
+
 ## [0.35.1] - 2026-07-17
 
 ### Fixed

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -15,6 +15,7 @@ import { applyThinkingSuffix } from "../shared/pi-args.ts";
 import { injectOutputPathSystemPrompt, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { buildChainInstructions, isDynamicParallelStep, isParallelStep, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
 import type { RunnerStep } from "../shared/parallel-utils.ts";
+import type { ContextMode } from "../shared/context-mode.ts";
 import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../../agents/agent-memory.ts";
@@ -134,6 +135,7 @@ interface AsyncChainParams {
 	chainSkills?: string[];
 	sessionFilesByFlatIndex?: (string | undefined)[];
 	thinkingOverridesByFlatIndex?: (AgentConfig["thinking"] | undefined)[];
+	contextForAgent?: (agentName: string) => ContextMode;
 	progressDir?: string;
 	dynamicFanoutMaxItems?: number;
 	maxSubagentDepth: number;
@@ -170,6 +172,7 @@ interface AsyncSingleParams {
 	sessionDir?: string;
 	sessionFile?: string;
 	revivalLease?: SessionLeaseRequest;
+	context?: ContextMode;
 	skills?: string[];
 	output?: string | boolean;
 	outputMode?: "inline" | "file-only";
@@ -212,6 +215,7 @@ export interface AsyncRunnerStepBuildParams {
 	chainSkills?: string[];
 	sessionFilesByFlatIndex?: (string | undefined)[];
 	thinkingOverridesByFlatIndex?: (AgentConfig["thinking"] | undefined)[];
+	contextForAgent?: (agentName: string) => ContextMode;
 	progressDir?: string;
 	dynamicFanoutMaxItems?: number;
 	maxSubagentDepth: number;
@@ -628,6 +632,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			parentSessionId: ctx.parentSessionId ?? ctx.currentSessionId,
 			agent: s.agent,
 			task,
+			...(params.contextForAgent ? { context: params.contextForAgent(s.agent) } : {}),
 			phase: s.phase,
 			label: s.label,
 			outputName: s.as,
@@ -844,6 +849,7 @@ export function executeAsyncChain(
 		chainSkills: params.chainSkills,
 		sessionFilesByFlatIndex,
 		thinkingOverridesByFlatIndex,
+		contextForAgent: params.contextForAgent,
 		progressDir: params.progressDir ?? (artifactsDir ? path.join(artifactsDir, "progress", id) : resultMode === "parallel" ? path.join(asyncDir, "progress") : undefined),
 		outputBaseDir: artifactsDir ? path.join(artifactsDir, "outputs", id) : undefined,
 		dynamicFanoutMaxItems: params.dynamicFanoutMaxItems,
@@ -1185,6 +1191,7 @@ export function executeAsyncSingle(
 						parentSessionId: ctx.parentSessionId ?? ctx.currentSessionId,
 						agent,
 						task: taskWithOutputInstruction,
+						...(params.context ? { context: params.context } : {}),
 						cwd: runnerCwd,
 						model,
 						thinking: resolveEffectiveThinking(model, effectiveThinking),
@@ -1309,6 +1316,6 @@ export function executeAsyncSingle(
 
 	return {
 		content: [{ type: "text", text: formatAsyncStartedMessage(`Async: ${agent} [${id}]`, ctx.interactive === true) }],
-		details: { mode: "single", runId: id, results: [], asyncId: id, asyncDir, ...(timeoutMs !== undefined ? { timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}), ...(params.toolBudget ? { toolBudget: params.toolBudget } : {}) },
+		details: { mode: "single", runId: id, results: [], asyncId: id, asyncDir, ...(params.context ? { context: params.context } : {}), ...(timeoutMs !== undefined ? { timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}), ...(params.toolBudget ? { toolBudget: params.toolBudget } : {}) },
 	};
 }

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -91,6 +91,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			toolCount: run.toolCount,
 			steering: run.steering,
 			mode: run.mode,
+			context: run.context,
 			agents: visibleSteps.map((step) => step.agent),
 			currentStep: run.currentStep,
 			chainStepCount: run.chainStepCount,

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -7,11 +7,13 @@ import { readStatus } from "../../shared/utils.ts";
 import { attachRootChildrenToSteps, buildNestedRouteIndex, type NestedRoute, projectNestedEvents } from "../shared/nested-events.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { flatToLogicalStepIndex, normalizeParallelGroups } from "./parallel-groups.ts";
+import { contextModeLabel, summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
 	agent: string;
+	context?: ContextMode;
 	label?: string;
 	phase?: string;
 	outputName?: string;
@@ -59,6 +61,7 @@ export interface AsyncRunSummary {
 	toolCount?: number;
 	steering?: SteeringStatus;
 	mode: SubagentRunMode;
+	context?: ContextSummary;
 	cwd?: string;
 	startedAt: number;
 	lastUpdate?: number;
@@ -163,6 +166,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		return {
 			index,
 			agent: step.agent,
+			...(step.context ? { context: step.context } : {}),
 			...(step.label ? { label: step.label } : {}),
 			...(step.phase ? { phase: step.phase } : {}),
 			...(step.outputName ? { outputName: step.outputName } : {}),
@@ -211,6 +215,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		toolCount: status.toolCount,
 		steering: status.steering,
 		mode: status.mode,
+		...(summarizeContextModes(summarizedSteps.map((step) => step.context)) ? { context: summarizeContextModes(summarizedSteps.map((step) => step.context)) } : {}),
 		cwd: status.cwd,
 		startedAt: status.startedAt,
 		lastUpdate: status.lastUpdate,
@@ -333,8 +338,9 @@ function formatActivityFacts(input: { activityState?: ActivityState; lastActivit
 
 function formatStepLine(step: AsyncRunStepSummary): string {
 	const display = step.label ? `${step.label} (${step.agent})` : step.agent;
+	const context = contextModeLabel(step.context);
 	const phase = step.phase ? `[${step.phase}] ` : "";
-	const parts = [`${step.index + 1}. ${phase}${display}`, step.status];
+	const parts = [`${step.index + 1}. ${phase}${display}${context ? ` ${context}` : ""}`, step.status];
 	const activity = formatActivityFacts(step);
 	if (activity) parts.push(activity);
 	const modelThinking = formatModelThinking(step.model, step.thinking);
@@ -375,7 +381,8 @@ function formatRunHeader(run: AsyncRunSummary): string {
 	const cwd = run.cwd ? shortenPath(run.cwd) : shortenPath(run.asyncDir);
 	const activity = formatActivityFacts(run);
 	const pending = run.pendingAppends ? ` | ${run.pendingAppends} pending append${run.pendingAppends === 1 ? "" : "s"}` : "";
-	return `${run.id} | ${run.state}${activity ? ` | ${activity}` : ""} | ${run.mode} | ${stepLabel}${pending} | ${cwd}`;
+	const context = contextModeLabel(run.context);
+	return `${run.id} | ${run.state}${activity ? ` | ${activity}` : ""} | ${run.mode}${context ? ` ${context}` : ""} | ${stepLabel}${pending} | ${cwd}`;
 }
 
 export function formatAsyncRunList(runs: AsyncRunSummary[], heading = "Active async runs"): string {

--- a/src/runs/background/chain-append.ts
+++ b/src/runs/background/chain-append.ts
@@ -131,6 +131,7 @@ export function consumeChainAppendRequests(asyncDir: string): ChainAppendRequest
 function statusStepForTask(task: RunnerSubagentStep): StatusStep {
 	return {
 		agent: task.agent,
+		...(task.context ? { context: task.context } : {}),
 		phase: task.phase,
 		label: task.label,
 		outputName: task.outputName,
@@ -151,6 +152,7 @@ function statusStepsForRunnerStep(step: RunnerStep): StatusStep[] {
 	if (isDynamicRunnerGroup(step)) {
 		return [{
 			agent: `expand:${step.parallel.agent}`,
+			...(step.parallel.context ? { context: step.parallel.context } : {}),
 			phase: step.phase ?? step.parallel.phase,
 			label: step.label ?? step.parallel.label ?? `Dynamic fanout (${step.collect.as})`,
 			outputName: step.collect.as,

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -16,6 +16,7 @@ import {
 } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
+import { contextModeLabel, summarizeContextModes } from "../shared/context-mode.ts";
 import { formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 
 const DEFAULT_TRANSCRIPT_LINES = 80;
@@ -277,15 +278,17 @@ function formatAsyncFleetLines(runs: AsyncRunSummary[]): string[] {
 		const activity = formatActivityFacts(run);
 		const cwd = run.cwd ? shortenPath(run.cwd) : shortenPath(run.asyncDir);
 		const pending = run.pendingAppends ? ` | ${run.pendingAppends} pending append${run.pendingAppends === 1 ? "" : "s"}` : "";
-		lines.push(`- ${run.id} | ${run.state}${activity ? ` | ${activity}` : ""} | ${run.mode} | ${progress}${pending} | ${cwd}`);
+		const runContext = contextModeLabel(run.context);
+		lines.push(`- ${run.id} | ${run.state}${activity ? ` | ${activity}` : ""} | ${run.mode}${runContext ? ` ${runContext}` : ""} | ${progress}${pending} | ${cwd}`);
 		lines.push(`  status: subagent({ action: "status", id: "${run.id}" })`);
 		lines.push(`  transcript: subagent({ action: "status", id: "${run.id}", view: "transcript" })`);
 		for (const step of run.steps) {
 			const display = step.label ? `${step.label} (${step.agent})` : step.agent;
+			const stepContext = contextModeLabel(step.context);
 			const phase = step.phase ? `[${step.phase}] ` : "";
 			const stepActivity = formatActivityFacts(step);
 			const modelThinking = formatModelThinking(step.model, step.thinking);
-			const parts = [`${step.index}. ${phase}${display}`, step.status, stepActivity, modelThinking].filter(Boolean);
+			const parts = [`${step.index}. ${phase}${display}${stepContext ? ` ${stepContext}` : ""}`, step.status, stepActivity, modelThinking].filter(Boolean);
 			lines.push(`  ${parts.join(" | ")}`);
 			const output = path.join(run.asyncDir, `output-${step.index}.log`);
 			if (fs.existsSync(output)) lines.push(`    output: ${shortenPath(output)}`);
@@ -385,8 +388,9 @@ function selectTranscriptStep(status: AsyncStatus, options: TranscriptOptions): 
 function stepStateLine(mode: SubagentRunMode, index: number | undefined, step: AsyncJobStep | undefined): string | undefined {
 	if (index === undefined || !step) return undefined;
 	const modelThinking = formatModelThinking(step.model, step.thinking);
+	const context = contextModeLabel(step.context);
 	const parts = [
-		`${mode === "parallel" ? "Agent" : "Step"}: ${index} (${step.agent})`,
+		`${mode === "parallel" ? "Agent" : "Step"}: ${index} (${step.agent})${context ? ` ${context}` : ""}`,
 		step.status,
 		formatActivityFacts(step),
 		modelThinking,
@@ -428,10 +432,11 @@ export function formatAsyncRunTranscript(status: AsyncStatus, asyncDir: string, 
 	const sessionFile = selected.index !== undefined ? selected.step?.sessionFile : status.sessionFile;
 	const eventsPath = path.join(asyncDir, "events.jsonl");
 
+	const context = contextModeLabel(status.context ?? summarizeContextModes((status.steps ?? []).map((step) => step.context)));
 	const lines = [
 		`Run: ${status.runId}`,
 		`State: ${status.state}`,
-		`Mode: ${status.mode}`,
+		`Mode: ${status.mode}${context ? ` ${context}` : ""}`,
 		stepStateLine(status.mode, selected.index, selected.step),
 		selected.hint,
 	].filter((line): line is string => Boolean(line));

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -150,6 +150,7 @@ interface SubagentRunConfig {
 
 interface StepResult {
 	agent: string;
+	context?: "fresh" | "fork";
 	output: string;
 	error?: string;
 	protocolError?: ProtocolOutputLimit;
@@ -1371,6 +1372,7 @@ async function runSingleStep(
 
 	return {
 		agent: step.agent,
+		context: step.context,
 		output: outputForSummary,
 		exitCode: effectiveFinalExitCode,
 		error: effectiveFinalError,
@@ -1440,7 +1442,7 @@ function markParallelGroupSetupFailure(input: {
 		input.statusPayload.steps[flatTaskIndex].endedAt = input.failedAt;
 		input.statusPayload.steps[flatTaskIndex].durationMs = 0;
 		input.statusPayload.steps[flatTaskIndex].exitCode = 1;
-		input.results.push({ agent: input.group.parallel[taskIndex].agent, output: input.setupError, success: false, exitCode: 1, sessionFile: input.group.parallel[taskIndex].sessionFile });
+		input.results.push({ agent: input.group.parallel[taskIndex].agent, context: input.group.parallel[taskIndex].context, output: input.setupError, success: false, exitCode: 1, sessionFile: input.group.parallel[taskIndex].sessionFile });
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.lastUpdate = input.failedAt;
@@ -1612,6 +1614,7 @@ async function runSubagent(
 				const transcriptPath = resolveAsyncStepTranscriptPath({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: taskFlatIndex, flatStepCount: initialFlatStepCount });
 				initialStatusSteps.push({
 					agent: task.agent,
+					...(task.context ? { context: task.context } : {}),
 					phase: task.phase,
 					label: task.label,
 					outputName: task.outputName,
@@ -1633,6 +1636,7 @@ async function runSubagent(
 			parallelGroups.push({ start: flatStepCount, count: 1, stepIndex });
 			initialStatusSteps.push({
 				agent: `expand:${step.parallel.agent}`,
+				...(step.parallel.context ? { context: step.parallel.context } : {}),
 				phase: step.phase ?? step.parallel.phase,
 				label: step.label ?? step.parallel.label ?? `Dynamic fanout (${step.collect.as})`,
 				outputName: step.collect.as,
@@ -1648,6 +1652,7 @@ async function runSubagent(
 			const transcriptPath = resolveAsyncStepTranscriptPath({ artifactsDir, artifactConfig, runId: id, agent: step.agent, flatIndex: stepFlatIndex, flatStepCount: initialFlatStepCount });
 			initialStatusSteps.push({
 				agent: step.agent,
+				...(step.context ? { context: step.context } : {}),
 				phase: step.phase,
 				label: step.label,
 				outputName: step.outputName,
@@ -1896,21 +1901,24 @@ async function runSubagent(
 			}
 		}
 	};
-	const pausedStepResult = (agent: string): SingleStepResult => ({
+	const pausedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => ({
 		agent,
+		context,
 		output: "Paused after interrupt. Waiting for explicit next action.",
 		exitCode: 0,
 		interrupted: true,
 	});
-	const timedOutStepResult = (agent: string): SingleStepResult => ({
+	const timedOutStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => ({
 		agent,
+		context,
 		output: timeoutMessage ?? "Subagent timed out.",
 		error: timeoutMessage ?? "Subagent timed out.",
 		exitCode: 1,
 		timedOut: true,
 	});
-	const stoppedStepResult = (agent: string): SingleStepResult => ({
+	const stoppedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => ({
 		agent,
+		context,
 		output: stopMessage,
 		error: stopMessage,
 		exitCode: 1,
@@ -2621,7 +2629,7 @@ async function runSubagent(
 				statusPayload.lastUpdate = now;
 				markDynamicGraphGroup(stepIndex, "failed", message);
 				writeStatusPayload();
-				results.push({ agent: step.parallel.agent, output: message, error: message, success: false, exitCode: 1 });
+				results.push({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1 });
 				break;
 			}
 
@@ -2686,7 +2694,7 @@ async function runSubagent(
 					markDynamicGraphGroup(stepIndex, groupStopped ? "stopped" : "failed", errorMessage, effectiveGroupAcceptance);
 					statusPayload.lastUpdate = Date.now();
 					writeStatusPayload();
-					results.push({ agent: step.parallel.agent, output: errorMessage, error: errorMessage, success: false, exitCode: 1, timedOut: groupTimedOut ? true : undefined, stopped: groupStopped ? true : undefined, acceptance: effectiveGroupAcceptance });
+					results.push({ agent: step.parallel.agent, context: step.parallel.context, output: errorMessage, error: errorMessage, success: false, exitCode: 1, timedOut: groupTimedOut ? true : undefined, stopped: groupStopped ? true : undefined, acceptance: effectiveGroupAcceptance });
 					break;
 				}
 				flatIndex++;
@@ -2735,6 +2743,7 @@ async function runSubagent(
 				const transcriptPath = resolveAsyncStepTranscriptPath({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: groupStartFlatIndex + itemIndex, flatStepCount: dynamicFlatStepCount });
 				return {
 					agent: task.agent,
+					...(task.context ? { context: task.context } : {}),
 					phase: task.phase ?? step.phase,
 					label: task.label,
 					outputName: undefined,
@@ -2798,9 +2807,9 @@ async function runSubagent(
 			let aborted = false;
 			const parallelResults = await mapConcurrent(dynamicSteps, concurrency, async (task, taskIdx) => {
 				const fi = groupStartFlatIndex + taskIdx;
-				if (timedOut) return timedOutStepResult(task.agent);
-				if (stopped) return stoppedStepResult(task.agent);
-				if (interrupted) return pausedStepResult(task.agent);
+				if (timedOut) return timedOutStepResult(task.agent, task.context);
+				if (stopped) return stoppedStepResult(task.agent, task.context);
+				if (interrupted) return pausedStepResult(task.agent, task.context);
 				if (aborted && failFast) {
 					const skippedAt = Date.now();
 					statusPayload.steps[fi].status = "failed";
@@ -2811,7 +2820,7 @@ async function runSubagent(
 					statusPayload.steps[fi].exitCode = -1;
 					statusPayload.lastUpdate = skippedAt;
 					writeStatusPayload();
-					return { agent: task.agent, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true };
+					return { agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true };
 				}
 				const taskStartTime = Date.now();
 				statusPayload.currentStep = fi;
@@ -2903,6 +2912,7 @@ async function runSubagent(
 			for (const pr of parallelResults) {
 				results.push({
 					agent: pr.agent,
+					context: pr.context,
 					output: pr.output,
 					error: pr.error,
 					protocolError: pr.protocolError,
@@ -2981,7 +2991,7 @@ async function runSubagent(
 					}
 				} catch (error) {
 					const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
-					results.push({ agent: step.parallel.agent, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection });
+					results.push({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection });
 					statusPayload.error = message;
 					markDynamicGraphGroup(stepIndex, "failed", message);
 				}
@@ -3085,9 +3095,9 @@ async function runSubagent(
 					concurrency,
 					async (task, taskIdx) => {
 						const fi = groupStartFlatIndex + taskIdx;
-						if (timedOut) return timedOutStepResult(task.agent);
-						if (stopped) return stoppedStepResult(task.agent);
-						if (interrupted) return pausedStepResult(task.agent);
+						if (timedOut) return timedOutStepResult(task.agent, task.context);
+						if (stopped) return stoppedStepResult(task.agent, task.context);
+						if (interrupted) return pausedStepResult(task.agent, task.context);
 						if (aborted && failFast) {
 							const skippedAt = Date.now();
 							statusPayload.steps[fi].status = "failed";
@@ -3102,7 +3112,7 @@ async function runSubagent(
 							appendJsonl(eventsPath, JSON.stringify({
 								type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: -1, durationMs: 0,
 							}));
-							return { agent: task.agent, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true };
+							return { agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true };
 						}
 
 						const taskStartTime = Date.now();
@@ -3248,6 +3258,7 @@ async function runSubagent(
 				for (const pr of parallelResults) {
 					results.push({
 						agent: pr.agent,
+						context: pr.context,
 						output: pr.output,
 						error: pr.error,
 						protocolError: pr.protocolError,
@@ -3376,6 +3387,7 @@ async function runSubagent(
 			const childStopped = singleResult.stopped === true;
 			results.push({
 				agent: singleResult.agent,
+				context: singleResult.context,
 				output: stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.output,
 				error: stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error,
 				protocolError: singleResult.protocolError,
@@ -3663,6 +3675,7 @@ async function runSubagent(
 			...(stopped ? { stopped: true, error: stopMessage } : timedOut ? { timedOut: true, error: timeoutMessage ?? "Subagent timed out." } : turnBudgetExceeded ? { error: statusPayload.error ?? "Subagent exceeded turn budget." } : {}),
 			results: results.map((r) => ({
 				agent: r.agent,
+				context: r.context,
 				output: r.output,
 				error: r.error,
 				protocolError: r.protocolError,

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -73,6 +73,7 @@ import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelSt
 import { acceptanceFailureMessage, aggregateAcceptanceReport, evaluateAcceptance, resolveEffectiveAcceptance } from "../shared/acceptance.ts";
 import type { ChainOutputMap } from "../../shared/types.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
+import type { ContextMode } from "../shared/context-mode.ts";
 
 interface ChainExecutionDetailsInput {
 	results: SingleResult[];
@@ -111,6 +112,7 @@ interface ParallelChainRunInput {
 	sessionFileForIndex?: (idx?: number) => string | undefined;
 	sessionFileForTask?: (agentName: string, idx?: number, modelOverride?: string) => string | undefined;
 	thinkingOverrideForTask?: (agentName: string, idx?: number, modelOverride?: string) => AgentConfig["thinking"] | undefined;
+	contextForAgent?: (agentName: string) => ContextMode;
 	shareEnabled: boolean;
 	artifactConfig: ArtifactConfig;
 	artifactsDir: string;
@@ -313,6 +315,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				: undefined;
 			const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
 				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
+				context: input.contextForAgent?.(task.agent),
 				cwd: taskCwd,
 				signal: input.signal,
 				interruptSignal: interruptController.signal,
@@ -425,6 +428,7 @@ interface ChainExecutionParams {
 	sessionFileForIndex?: (idx?: number) => string | undefined;
 	sessionFileForTask?: (agentName: string, idx?: number, modelOverride?: string) => string | undefined;
 	thinkingOverrideForTask?: (agentName: string, idx?: number, modelOverride?: string) => AgentConfig["thinking"] | undefined;
+	contextForAgent?: (agentName: string) => ContextMode;
 	artifactsDir: string;
 	artifactConfig: ArtifactConfig;
 	includeProgress?: boolean;
@@ -728,6 +732,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					sessionFileForIndex,
 					sessionFileForTask,
 					thinkingOverrideForTask,
+					contextForAgent: params.contextForAgent,
 					shareEnabled,
 					artifactConfig,
 					artifactsDir,
@@ -949,6 +954,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				sessionFileForIndex,
 				sessionFileForTask,
 				thinkingOverrideForTask,
+				contextForAgent: params.contextForAgent,
 				shareEnabled,
 				artifactConfig,
 				artifactsDir,
@@ -1182,6 +1188,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			});
 			const r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
 				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
+				context: params.contextForAgent?.(seqStep.agent),
 				cwd: resolveChildCwd(cwd ?? ctx.cwd, seqStep.cwd),
 				signal,
 				interruptSignal: interruptController.signal,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -90,6 +90,12 @@ function emptyUsage(): Usage {
 	return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
 }
 
+function withRunContext<T extends SingleResult>(result: T, context: RunSyncOptions["context"]): T {
+	if (!context) return result;
+	result.context = context;
+	return result;
+}
+
 function sumUsage(target: Usage, source: Usage): void {
 	target.input += source.input;
 	target.output += source.output;
@@ -240,7 +246,7 @@ async function runSingleAttempt(
 		waitToolEnabled: options.waitToolEnabled,
 	});
 
-	const result: SingleResult = {
+	const result: SingleResult = withRunContext({
 		agent: agent.name,
 		task: shared.originalTask ?? task,
 		exitCode: 0,
@@ -253,7 +259,7 @@ async function runSingleAttempt(
 		skillsWarning: shared.skillsWarning,
 		...(options.turnBudget ? { turnBudget: initialTurnBudgetState(options.turnBudget) } : {}),
 		...(options.toolBudget ? { toolBudget: initialToolBudgetState(options.toolBudget) } : {}),
-	};
+	}, options.context);
 	const startTime = Date.now();
 	if (options.structuredOutput) {
 		try {
@@ -1156,18 +1162,18 @@ export async function runSync(
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
-		return {
+		return withRunContext({
 			agent: agentName,
 			task,
 			exitCode: 1,
 			messages: [],
 			usage: emptyUsage(),
 			error: `Unknown agent: ${agentName}`,
-		};
+		}, options.context);
 	}
 	const outputModeValidationError = validateFileOnlyOutputMode(options.outputMode, options.outputPath, `Single run (${agentName})`);
 	if (outputModeValidationError) {
-		return {
+		return withRunContext({
 			agent: agentName,
 			task,
 			exitCode: 1,
@@ -1175,7 +1181,7 @@ export async function runSync(
 			usage: emptyUsage(),
 			outputMode: options.outputMode,
 			error: outputModeValidationError,
-		};
+		}, options.context);
 	}
 
 	const shareEnabled = options.share === true;
@@ -1202,14 +1208,14 @@ export async function runSync(
 		agent.filePath ? path.dirname(agent.filePath) : skillCwd,
 	);
 	if (skillNames.some((skill) => skill.trim() === "pi-subagents") && missingSkills.includes("pi-subagents")) {
-		return {
+		return withRunContext({
 			agent: agentName,
 			task,
 			exitCode: 1,
 			messages: [],
 			usage: emptyUsage(),
 			error: "Skills not found: pi-subagents",
-		};
+		}, options.context);
 	}
 	let systemPrompt = agent.systemPrompt?.trim() || "";
 	if (resolvedSkills.length > 0) {
@@ -1366,14 +1372,14 @@ export async function runSync(
 		attemptNotes.push(formatModelAttemptNote(attempt, modelsToTry[i + 1]));
 	}
 
-	const result = lastResult ?? {
+	const result = withRunContext(lastResult ?? {
 		agent: agentName,
 		task,
 		exitCode: 1,
 		messages: [],
 		usage: emptyUsage(),
 		error: "Subagent did not produce a result.",
-	} satisfies SingleResult;
+	} satisfies SingleResult, options.context);
 
 	result.usage = aggregateUsage;
 	result.attemptedModels = attemptedModels.length > 0 ? attemptedModels : undefined;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -49,6 +49,7 @@ import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
+import { summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
 import {
 	attachNestedChildrenToResultChildren,
 	buildSubagentResultIntercomPayload,
@@ -365,6 +366,7 @@ function rememberForegroundRun(state: SubagentState, input: { runId: string; mod
 			const child = {
 				agent: result.agent,
 				index,
+				...(result.context ? { context: result.context } : {}),
 				status: resolveSubagentResultStatus({ exitCode: result.exitCode, interrupted: result.interrupted, detached: result.detached }),
 				updatedAt,
 				...(result.exitCode !== undefined ? { exitCode: result.exitCode } : {}),
@@ -401,6 +403,7 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		...child,
 		agent: input.result.agent,
 		index: input.index,
+		...(input.result.context ? { context: input.result.context } : {}),
 		status: input.result.acceptance?.status === "rejected"
 			? "failed"
 			: resolveSubagentResultStatus({ exitCode: input.result.exitCode, interrupted: input.result.interrupted, detached: false }),
@@ -824,6 +827,7 @@ function appendStepToAsyncChain(input: {
 		dynamicFanoutMaxItems: input.deps.config.chain?.dynamicFanout?.maxItems,
 		maxSubagentDepth: resolveCurrentMaxSubagentDepth(input.deps.config.maxSubagentDepth),
 		waitToolEnabled: input.deps.waitToolEnabled,
+		contextForAgent: contextPolicy.contextForAgent,
 		asyncDir: resolved.location.asyncDir,
 		validateOutputBindings: false,
 	});
@@ -1531,7 +1535,8 @@ function getRequestedModeLabel(params: SubagentParamsLike): Details["mode"] {
 
 interface AgentDefaultContextPolicy {
 	params: SubagentParamsLike;
-	contextForAgent(agentName: string): "fresh" | "fork";
+	contextForAgent(agentName: string): ContextMode;
+	contextSummary?: ContextSummary;
 	usesFork: boolean;
 }
 
@@ -1540,12 +1545,15 @@ function resolveAgentDefaultContextPolicy(params: SubagentParamsLike, agents: Ag
 		return resolveExplicitContextPolicy(params);
 	}
 	const byName = new Map(agents.map((agent) => [agent.name, agent]));
-	const contextForAgent = (agentName: string): "fresh" | "fork" =>
+	const contextForAgent = (agentName: string): ContextMode =>
 		byName.get(agentName)?.defaultContext === "fork" ? "fork" : "fresh";
-	const usesFork = collectRequestedAgentNames(params).some((name) => contextForAgent(name) === "fork");
+	const requestedAgentNames = collectRequestedAgentNames(params);
+	const contextSummary = summarizeContextModes(requestedAgentNames.map((name) => contextForAgent(name)));
+	const usesFork = contextSummary === "fork" || contextSummary === "mixed";
 	return {
-		params: usesFork ? { ...params, context: "fork" } : params,
+		params,
 		contextForAgent,
+		contextSummary,
 		usesFork,
 	};
 }
@@ -1555,6 +1563,7 @@ function resolveExplicitContextPolicy(params: SubagentParamsLike): AgentDefaultC
 	return {
 		params,
 		contextForAgent: () => context,
+		contextSummary: context,
 		usesFork: context === "fork",
 	};
 }
@@ -1571,8 +1580,12 @@ function shouldForkAgent(contextPolicy: AgentDefaultContextPolicy, agentName: st
 	return contextPolicy.contextForAgent(agentName) === "fork";
 }
 
+function summarizeResultContext(details: Details, fallback: ContextSummary | undefined): ContextSummary | undefined {
+	return summarizeContextModes(details.results.map((result) => result.context)) ?? fallback;
+}
+
 function buildRequestedModeError(params: SubagentParamsLike, message: string): AgentToolResult<Details> {
-	return withForkContext(
+	return withResolvedContext(
 		{
 			content: [{ type: "text", text: message }],
 			isError: true,
@@ -1688,16 +1701,18 @@ function normalizeRepeatedParallelCounts(params: SubagentParamsLike): { params?:
 	return { params };
 }
 
-function withForkContext(
+function withResolvedContext(
 	result: AgentToolResult<Details>,
-	context: SubagentParamsLike["context"],
+	fallback: ContextSummary | undefined,
 ): AgentToolResult<Details> {
-	if (context !== "fork" || !result.details) return result;
+	if (!result.details) return result;
+	const context = summarizeResultContext(result.details, fallback);
+	if (!context) return result;
 	return {
 		...result,
 		details: {
 			...result.details,
-			context: "fork",
+			context,
 		},
 	};
 }
@@ -1715,15 +1730,15 @@ function withForkThinkingNotes(
 	return { ...result, content: [...result.content, { type: "text", text: note }] };
 }
 
-function toExecutionErrorResult(params: SubagentParamsLike, error: unknown): AgentToolResult<Details> {
+function toExecutionErrorResult(params: SubagentParamsLike, error: unknown, contextSummary?: ContextSummary): AgentToolResult<Details> {
 	const message = error instanceof Error ? error.message : String(error);
-	return withForkContext(
+	return withResolvedContext(
 		{
 			content: [{ type: "text", text: message }],
 			isError: true,
 			details: { mode: getRequestedModeLabel(params), results: [] },
 		},
-		params.context,
+		contextSummary,
 	);
 }
 
@@ -1991,6 +2006,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			chainSkills: [],
 			sessionFilesByFlatIndex: params.tasks.map((task, index) => sessionFileForTask(task.agent, index, task.model)),
 			thinkingOverridesByFlatIndex: params.tasks.map((task, index) => thinkingOverrideForTask(task.agent, index, task.model)),
+			contextForAgent: contextPolicy.contextForAgent,
 			maxSubagentDepth: currentMaxSubagentDepth,
 			waitToolEnabled: deps.waitToolEnabled,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
@@ -2029,6 +2045,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			chainSkills,
 			sessionFilesByFlatIndex: collectChainSessionFiles(chain, sessionFileForTask, deps.config.chain?.dynamicFanout?.maxItems),
 			thinkingOverridesByFlatIndex: collectChainThinkingOverrides(chain, thinkingOverrideForTask, deps.config.chain?.dynamicFanout?.maxItems),
+			contextForAgent: contextPolicy.contextForAgent,
 			dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
 			maxSubagentDepth: currentMaxSubagentDepth,
 			waitToolEnabled: deps.waitToolEnabled,
@@ -2077,6 +2094,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			shareEnabled,
 			sessionRoot,
 			sessionFile: sessionFileForTask(params.agent!, 0, modelOverride),
+			context: contextPolicy.contextForAgent(params.agent!),
 			skills,
 			output: effectiveOutput,
 			outputMode: effectiveOutputMode,
@@ -2145,6 +2163,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		sessionFileForIndex,
 		sessionFileForTask,
 		thinkingOverrideForTask,
+		contextForAgent: contextPolicy.contextForAgent,
 		artifactsDir,
 		artifactConfig,
 		includeProgress: params.includeProgress,
@@ -2210,6 +2229,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			chainSkills: chainResult.requestedAsync.chainSkills,
 			sessionFilesByFlatIndex: collectChainSessionFiles(asyncChain, sessionFileForTask, deps.config.chain?.dynamicFanout?.maxItems),
 			thinkingOverridesByFlatIndex: collectChainThinkingOverrides(asyncChain, thinkingOverrideForTask, deps.config.chain?.dynamicFanout?.maxItems),
+			contextForAgent: contextPolicy.contextForAgent,
 			dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
 			maxSubagentDepth: currentMaxSubagentDepth,
 			waitToolEnabled: deps.waitToolEnabled,
@@ -2286,6 +2306,7 @@ interface ForegroundParallelRunInput {
 	behaviors: Array<ReturnType<typeof resolveStepBehavior>>;
 	firstProgressIndex: number;
 	controlConfig: ResolvedControlConfig;
+	contextPolicy: AgentDefaultContextPolicy;
 	onControlEvent?: (event: ControlEvent) => void;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
 	orchestratorIntercomTarget?: string;
@@ -2449,6 +2470,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		}
 		return runSync(input.ctx.cwd, input.agents, task.agent, taskText, {
 			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
+			context: input.contextPolicy.contextForAgent(task.agent),
 			cwd: taskCwd,
 			signal: input.signal,
 			interruptSignal: interruptController.signal,
@@ -2706,6 +2728,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				chainSkills: [],
 				sessionFilesByFlatIndex: tasks.map((task, index) => sessionFileForTask(task.agent, index, modelOverrides[index])),
 				thinkingOverridesByFlatIndex: tasks.map((task, index) => thinkingOverrideForTask(task.agent, index, modelOverrides[index])),
+				contextForAgent: contextPolicy.contextForAgent,
 				maxSubagentDepth: currentMaxSubagentDepth,
 				waitToolEnabled: deps.waitToolEnabled,
 				worktreeSetupHook: deps.config.worktreeSetupHook,
@@ -2791,6 +2814,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			behaviors,
 			firstProgressIndex: parallelProgressPrecreated ? -1 : firstProgressIndex,
 			controlConfig,
+			contextPolicy,
 			onControlEvent,
 			childIntercomTarget: childIntercomTarget ? (agent, index) => childIntercomTarget(runId, agent, index) : undefined,
 			orchestratorIntercomTarget: data.intercomBridge.active ? data.intercomBridge.orchestratorTarget : undefined,
@@ -2924,7 +2948,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		};
 	}
 	const effectiveToolBudget = resolveEffectiveToolBudget({ runBudget: data.toolBudget, agentBudget: agentConfig.toolBudget, configBudget: data.configToolBudget });
-	if (effectiveToolBudget.error) return toExecutionErrorResult(params, new Error(effectiveToolBudget.error));
+	if (effectiveToolBudget.error) return toExecutionErrorResult(params, new Error(effectiveToolBudget.error), data.contextPolicy.contextSummary);
 
 	const currentProvider = ctx.model?.provider;
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
@@ -3009,6 +3033,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				shareEnabled,
 				sessionRoot,
 				sessionFile: sessionFileForTask(params.agent!, 0, modelOverride),
+				context: contextPolicy.contextForAgent(params.agent!),
 				skills: skillOverride === false ? [] : skillOverride,
 				output: effectiveOutput,
 				outputMode: effectiveOutputMode,
@@ -3086,6 +3111,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const deadlineAt = data.deadlineAt ?? (data.timeoutMs !== undefined ? Date.now() + data.timeoutMs : undefined);
 	const r = await runSync(ctx.cwd, agents, params.agent!, task, {
 		parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
+		context: data.contextPolicy.contextForAgent(params.agent!),
 		cwd: effectiveCwd,
 		signal,
 		interruptSignal: interruptController.signal,
@@ -3615,7 +3641,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const sessionName = resolveIntercomSessionTarget(deps.pi.getSessionName(), ctx.sessionManager.getSessionId());
 		const intercomBridge = resolveIntercomBridge({
 			config: deps.config.intercomBridge,
-			context: effectiveParams.context,
+			context: effectiveParams.context ?? (contextPolicy.usesFork ? "fork" : undefined),
 			orchestratorTarget: sessionName,
 		});
 		const agents = intercomBridge.active
@@ -3688,7 +3714,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			forkSessionFileForIndex = forkContextResolver.sessionFileForIndex;
 			forkThinkingOverrideForIndex = forkContextResolver.thinkingOverrideForIndex;
 		} catch (error) {
-			return toExecutionErrorResult(effectiveParams, error);
+			return toExecutionErrorResult(effectiveParams, error, contextPolicy.contextSummary);
 		}
 		const requestedAsync = effectiveParams.async ?? deps.asyncByDefault;
 		const backgroundRequestedWhileClarifying = (hasChain || hasTasks) && requestedAsync && effectiveParams.clarify === true;
@@ -3717,6 +3743,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return toExecutionErrorResult(
 				effectiveParams,
 				new Error(`Failed to create session directory '${sessionRoot}': ${message}`),
+				contextPolicy.contextSummary,
 			);
 		}
 		const sessionDirForIndex = (idx?: number) =>
@@ -3742,13 +3769,13 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				preflightForkSessionsForStaticTasks(effectiveParams, contextPolicy, forkSessionFileForTask, deps.config.chain?.dynamicFanout?.maxItems);
 			}
 		} catch (error) {
-			return toExecutionErrorResult(effectiveParams, error);
+			return toExecutionErrorResult(effectiveParams, error, contextPolicy.contextSummary);
 		}
 		const chainBindingsError = validateExecutionChainBindings(effectiveParams, deps.config.chain?.dynamicFanout?.maxItems);
-		if (chainBindingsError) return chainBindingsError;
+		if (chainBindingsError) return withResolvedContext(chainBindingsError, contextPolicy.contextSummary);
 
 		const onUpdateWithContext = onUpdate
-			? (r: AgentToolResult<Details>) => onUpdate(withForkContext(r, effectiveParams.context))
+			? (r: AgentToolResult<Details>) => onUpdate(withResolvedContext(r, contextPolicy.contextSummary))
 			: undefined;
 
 		const reservation = reserveSpawnBudget(
@@ -3870,7 +3897,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		let nestedForegroundStarted = false;
 		try {
 			const asyncResult = runAsyncPath(execData, deps);
-			if (asyncResult) return withForkContext(withForkThinkingNotes(asyncResult, forkThinkingDowngrades), effectiveParams.context);
+			if (asyncResult) return withResolvedContext(withForkThinkingNotes(asyncResult, forkThinkingDowngrades), contextPolicy.contextSummary);
 			if (foregroundControl) {
 				writeNestedForegroundEvent("subagent.nested.started");
 				nestedForegroundStarted = true;
@@ -3878,20 +3905,20 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			if (hasChain && effectiveParams.chain) {
 				const result = await runChainPath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return withForkContext(withForkThinkingNotes(result, forkThinkingDowngrades), effectiveParams.context);
+				return withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary);
 			}
 			if (hasTasks && effectiveParams.tasks) {
 				const result = await runParallelPath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return withForkContext(withForkThinkingNotes(result, forkThinkingDowngrades), effectiveParams.context);
+				return withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary);
 			}
 			if (hasSingle) {
 				const result = await runSinglePath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return withForkContext(withForkThinkingNotes(result, forkThinkingDowngrades), effectiveParams.context);
+				return withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary);
 			}
 		} catch (error) {
-			const errorResult = withForkThinkingNotes(toExecutionErrorResult(effectiveParams, error), forkThinkingDowngrades);
+			const errorResult = withForkThinkingNotes(toExecutionErrorResult(effectiveParams, error, contextPolicy.contextSummary), forkThinkingDowngrades);
 			if (nestedForegroundStarted) writeNestedForegroundEvent("subagent.nested.completed", errorResult);
 			return errorResult;
 		} finally {
@@ -3904,11 +3931,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			}
 		}
 
-		return withForkContext({
+		return withResolvedContext({
 			content: [{ type: "text", text: "Invalid params" }],
 			isError: true,
 			details: { mode: "single" as const, results: [] },
-		}, effectiveParams.context);
+		}, contextPolicy.contextSummary);
 	};
 
 	const executeWithSingleDispatchGuard = async (

--- a/src/runs/shared/context-mode.ts
+++ b/src/runs/shared/context-mode.ts
@@ -1,0 +1,44 @@
+export type ContextMode = "fresh" | "fork";
+export type ContextSummary = ContextMode | "mixed";
+
+export function isContextMode(value: unknown): value is ContextMode {
+	return value === "fresh" || value === "fork";
+}
+
+export function isContextSummary(value: unknown): value is ContextSummary {
+	return isContextMode(value) || value === "mixed";
+}
+
+export function summarizeContextModes(modes: Array<ContextMode | undefined>): ContextSummary | undefined {
+	const resolved = modes.filter(isContextMode);
+	if (resolved.length === 0) return undefined;
+	const first = resolved[0]!;
+	return resolved.every((mode) => mode === first) ? first : "mixed";
+}
+
+export function contextModeLabel(mode: ContextMode | ContextSummary | undefined): string {
+	if (mode === "fork") return "[fork]";
+	if (mode === "fresh") return "[fresh]";
+	if (mode === "mixed") return "[mixed]";
+	return "";
+}
+
+export function contextModeBadge(
+	theme: { fg(name: string, text: string): string },
+	mode: ContextMode | ContextSummary | undefined,
+): string {
+	const label = contextModeLabel(mode);
+	if (!label) return "";
+	if (mode === "fork") return theme.fg("warning", ` ${label}`);
+	return theme.fg("dim", ` ${label}`);
+}
+
+export function contextModePrefix(
+	theme: { fg(name: string, text: string): string },
+	mode: ContextMode | ContextSummary | undefined,
+): string {
+	const label = contextModeLabel(mode);
+	if (!label) return "";
+	if (mode === "fork") return `${theme.fg("warning", label)} `;
+	return `${theme.fg("dim", label)} `;
+}

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -3,6 +3,8 @@ export interface RunnerSubagentStep {
 	parentSessionId?: string;
 	agent: string;
 	task: string;
+	/** Resolved launch context for this child. */
+	context?: "fresh" | "fork";
 	importAsyncRoot?: {
 		runId: string;
 		asyncDir: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -585,6 +585,8 @@ export interface ProtocolOutputLimit {
 export interface SingleResult {
 	agent: string;
 	task: string;
+	/** Resolved launch context for this child. */
+	context?: "fresh" | "fork";
 	exitCode: number;
 	detached?: boolean;
 	detachedReason?: string;
@@ -648,7 +650,8 @@ export interface SpawnBudgetSnapshot {
 export interface Details {
 	mode: SubagentRunMode | "management";
 	runId?: string;
-	context?: "fresh" | "fork";
+	/** Run-level context summary. "mixed" when children resolved to different modes. */
+	context?: "fresh" | "fork" | "mixed";
 	results: SingleResult[];
 	controlEvents?: ControlEvent[];
 	steering?: SteerActionResult;
@@ -867,6 +870,8 @@ export interface AsyncStatus {
 	workflowGraph?: WorkflowGraphSnapshot;
 	steps?: Array<{
 		agent: string;
+		/** Resolved launch context for this child step. */
+		context?: "fresh" | "fork";
 		phase?: string;
 		label?: string;
 		outputName?: string;
@@ -939,6 +944,8 @@ export interface AsyncJobState {
 	toolCount?: number;
 	steering?: SteeringStatus;
 	mode?: SubagentRunMode;
+	/** Run-level context summary derived from step contexts. */
+	context?: "fresh" | "fork" | "mixed";
 	agents?: string[];
 	currentStep?: number;
 	chainStepCount?: number;
@@ -972,6 +979,7 @@ export interface AsyncJobState {
 export interface ForegroundResumeChild {
 	agent: string;
 	index: number;
+	context?: "fresh" | "fork";
 	sessionFile?: string;
 	status: SubagentResultStatus;
 	exitCode?: number;
@@ -1088,6 +1096,8 @@ export const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom
 export interface RunSyncOptions {
 	/** Session id of the direct parent session for permission-system ask forwarding. */
 	parentSessionId?: string;
+	/** Resolved launch context for this child. */
+	context?: "fresh" | "fork";
 	cwd?: string;
 	signal?: AbortSignal;
 	interruptSignal?: AbortSignal;

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -6,6 +6,7 @@ import { RESULTS_DIR, type AsyncJobState, type ForegroundResumeChild, type Foreg
 import { readStatus } from "../shared/utils.ts";
 import { formatAsyncRunTranscript } from "../runs/background/fleet-view.ts";
 import { listAsyncRuns, summarizeAsyncStatus, type AsyncRunSummary } from "../runs/background/async-status.ts";
+import { contextModeBadge, contextModeLabel } from "../runs/shared/context-mode.ts";
 
 const REFRESH_MS = 750;
 const MAX_RECENT_ASYNC_RUNS = 20;
@@ -39,6 +40,7 @@ function trackedJobSummary(job: AsyncJobState): AsyncRunSummary {
 		...(job.sessionId ? { sessionId: job.sessionId } : {}),
 		state: job.status,
 		mode: job.mode ?? "single",
+		...(job.context ? { context: job.context } : {}),
 		startedAt,
 		...(job.updatedAt !== undefined ? { lastUpdate: job.updatedAt } : {}),
 		...(job.currentStep !== undefined ? { currentStep: job.currentStep } : {}),
@@ -180,7 +182,7 @@ function foregroundRecentDetail(item: Extract<FleetItem, { kind: "foreground-rec
 		"Source: foreground",
 		`State: ${child.status}`,
 		`Mode: ${run.mode}`,
-		`Child: ${child.index} (${child.agent})`,
+		`Child: ${child.index} (${child.agent})${contextModeLabel(child.context) ? ` ${contextModeLabel(child.context)}` : ""}`,
 		`Updated: ${new Date(child.updatedAt ?? run.updatedAt).toISOString()}`,
 		outputPath ? `Output: ${outputPath}` : undefined,
 		child.sessionFile ? `Session: ${child.sessionFile}` : undefined,
@@ -206,8 +208,8 @@ function asyncDetail(item: Extract<FleetItem, { kind: "async" }>): string[] {
 		`Run: ${item.runId}`,
 		"Source: async",
 		`State: ${item.state}`,
-		`Mode: ${item.run.mode}`,
-		item.index !== undefined ? `Child: ${item.index} (${item.agent})` : `Agent: ${item.agent}`,
+		`Mode: ${item.run.mode}${contextModeLabel(item.run.context) ? ` ${contextModeLabel(item.run.context)}` : ""}`,
+		item.index !== undefined ? `Child: ${item.index} (${item.agent})${contextModeLabel(item.step?.context) ? ` ${contextModeLabel(item.step?.context)}` : ""}` : `Agent: ${item.agent}${contextModeLabel(item.run.context) ? ` ${contextModeLabel(item.run.context)}` : ""}`,
 		outputPath ? `Output: ${outputPath}` : undefined,
 		item.step?.sessionFile ? `Session: ${item.step.sessionFile}` : item.run.sessionFile ? `Session: ${item.run.sessionFile}` : undefined,
 		"",
@@ -327,7 +329,8 @@ export class SubagentFleetComponent implements Component {
 			const marker = index === this.selected ? this.theme.fg("accent", "›") : " ";
 			const child = item.index !== undefined ? `:${item.index + 1}` : "";
 			const source = item.kind === "async" ? "async" : item.kind === "foreground-active" ? "live" : "recent";
-			const left = `${marker} ${statusGlyph(item, this.theme)} ${source} ${item.runId.slice(0, 8)}${child} ${item.agent}`;
+			const context = item.kind === "async" ? contextModeBadge(this.theme, item.step?.context ?? item.run.context) : item.kind === "foreground-recent" ? contextModeBadge(this.theme, item.child.context) : "";
+			const left = `${marker} ${statusGlyph(item, this.theme)} ${source} ${item.runId.slice(0, 8)}${child} ${item.agent}${context}`;
 			return rightAligned(left, this.theme.fg("dim", item.state), width);
 		});
 	}

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -23,6 +23,7 @@ import { getDisplayItems, getSingleResultOutput } from "../shared/utils.ts";
 import { flatToLogicalStepIndex } from "../runs/background/parallel-groups.ts";
 import { formatNestedAggregate } from "../runs/shared/nested-render.ts";
 import { aggregateStepStatus, formatActivityLabel, formatAgentRunningLabel, formatParallelOutcome } from "../shared/status-format.ts";
+import { contextModeBadge, contextModePrefix } from "../runs/shared/context-mode.ts";
 
 type Theme = ExtensionContext["ui"]["theme"];
 
@@ -902,7 +903,7 @@ function foregroundStyleWidgetStepLines(
 	const status = widgetStepStatus(step.status, theme);
 	const stats = widgetStepStats(theme, step);
 	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
-	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1))} ${itemTitle} ${index}/${total}: ${themeBold(theme, step.agent)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
+	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1))} ${itemTitle} ${index}/${total}: ${themeBold(theme, step.agent)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
 	const activity = widgetStepActivityLine(step, width, expanded, job.updatedAt);
 	if (activity) lines.push(`    ${theme.fg("dim", `⎿  ${activity}`)}`);
 	for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt)) {
@@ -955,7 +956,7 @@ function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number,
 	const title = `async subagent ${mode}${count && count > 1 ? ` (${count})` : ""}`;
 	return [
 		`${theme.fg("toolTitle", themeBold(theme, title))} ${theme.fg("dim", "· background")}`,
-		`${widgetStatusGlyph(job, theme)} ${themeBold(theme, mode)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
+		`${widgetStatusGlyph(job, theme)} ${themeBold(theme, mode)}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 		...foregroundStyleWidgetDetails(job, theme, expanded, width),
 	].map((line) => truncLine(line, width));
 }
@@ -973,7 +974,7 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 		const stepStats = widgetStepStats(theme, step);
 		const activitySuffix = activity ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", activity)}` : "";
 		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
-		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index))} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, step.agent)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
+		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index))} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, step.agent)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt)) lines.push(`    ${nestedLine}`);
 	}
 	if (job.steps.some((step) => step.status === "running")) lines.push(theme.fg("accent", `  ${liveDetailHintText()}`));
@@ -1113,7 +1114,7 @@ function progressiveJobLine(job: AsyncJobState, theme: Theme, width: number): st
 	const activity = widgetActivity(job);
 	const status = job.status === "complete" ? "done" : job.status;
 	const parts = [
-		themeBold(theme, widgetJobName(job)),
+		`${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}`,
 		theme.fg("dim", status),
 		stats,
 		activity && activity.toLowerCase() !== status ? theme.fg("dim", activity) : "",
@@ -1248,7 +1249,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 		if (slots <= 0) { hiddenRunning++; continue; }
 		const stats = widgetStats(job, theme);
 		items.push([
-			`${widgetStatusGlyph(job, theme)} ${themeBold(theme, widgetJobName(job))}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
+			`${widgetStatusGlyph(job, theme)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
 			...widgetParallelAgentDetails(job, theme, expanded, width),
 		]);
@@ -1265,7 +1266,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 		if (slots <= 0) { hiddenFinished++; continue; }
 		const stats = widgetStats(job, theme);
 		items.push([
-			`${widgetStatusGlyph(job, theme)} ${themeBold(theme, widgetJobName(job))}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
+			`${widgetStatusGlyph(job, theme)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
 			...widgetParallelAgentDetails(job, theme, expanded, width),
 		]);
@@ -1313,7 +1314,7 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 	const output = r.truncation?.text || getSingleResultOutput(r);
 	const progress = r.progress || r.progressSummary;
 	const isRunning = r.progress?.status === "running";
-	const contextBadge = d.context === "fork" ? theme.fg("warning", " [fork]") : "";
+	const contextBadge = contextModeBadge(theme, r.context ?? d.context);
 	const stats = statJoin(theme, [
 		r.usage?.turns ? `⟳ ${r.usage.turns}` : "",
 		formatProgressStats(theme, progress),
@@ -1387,7 +1388,7 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 			: paused
 				? theme.fg("warning", "■")
 				: theme.fg("success", "✓");
-	const contextBadge = d.context === "fork" ? theme.fg("warning", " [fork]") : "";
+	const contextBadge = contextModeBadge(theme, d.context);
 	const c = new Container();
 	const width = getTermWidth() - 4;
 	c.addChild(new Text(truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold(d.mode))}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
@@ -1430,7 +1431,7 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 		const glyph = rPending ? theme.fg("dim", "◦") : resultGlyph(r, output, theme, rRunning, progressRunningSeed(rProg), frame);
 		const pendingLabel = rPending ? ` ${theme.fg("dim", "· pending")}` : "";
 		const stepLabel = resultRowLabel(d, multiLabel, i, stepNumber);
-		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
+		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${contextModeBadge(theme, r.context)}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
 		c.addChild(new Text(truncLine(`  ${line}`, width), 0, 0));
 		if (rRunning && rProg && "status" in rProg) {
 			const activity = compactCurrentActivity(rProg);
@@ -1468,7 +1469,7 @@ export function renderSubagentResult(
 	if (!d || !d.results.length) {
 		const t = result.content[0];
 		const text = t?.type === "text" ? t.text : "(no output)";
-		const contextPrefix = d?.context === "fork" ? `${theme.fg("warning", "[fork]")} ` : "";
+		const contextPrefix = contextModePrefix(theme, d?.context);
 		const width = getTermWidth() - 4;
 		if (!text.includes("\n")) return new Text(truncLine(`${contextPrefix}${text}`, width), 0, 0);
 		if (d && !options.expanded && !result.isError) {
@@ -1499,7 +1500,7 @@ export function renderSubagentResult(
 				: r.exitCode === 0
 					? theme.fg("success", "ok")
 					: theme.fg("error", "failed");
-		const contextBadge = d.context === "fork" ? theme.fg("warning", " [fork]") : "";
+		const contextBadge = contextModeBadge(theme, r.context ?? d.context);
 		const output = r.truncation?.text || getSingleResultOutput(r);
 
 		const progressInfo = isRunning && r.progress
@@ -1646,7 +1647,7 @@ export function renderSubagentResult(
 	const summaryStr = summaryParts.length ? ` | ${summaryParts.join(", ")}` : "";
 
 	const modeLabel = d.mode;
-	const contextBadge = d.context === "fork" ? theme.fg("warning", " [fork]") : "";
+	const contextBadge = contextModeBadge(theme, d.context);
 	const multiLabel = buildMultiProgressLabel(d, hasRunning);
 	const itemTitle = multiLabel.itemTitle;
 	
@@ -1669,7 +1670,7 @@ export function renderSubagentResult(
 								: isCurrent && hasRunning
 									? theme.fg("warning", "running")
 									: theme.fg("dim", "pending");
-					return `${stepIcon} ${agent}`;
+					return `${stepIcon} ${agent}${contextModeBadge(theme, result?.context)}`;
 				})
 				.join(theme.fg("dim", " → "))
 		: null;
@@ -1740,9 +1741,10 @@ export function renderSubagentResult(
 		const stats = rProg ? ` | ${rProg.toolCount} tools, ${formatDuration(rProg.durationMs)}` : "";
 		const modelDisplay = modelThinkingBadge(theme, r.model);
 		const stepLabel = resultRowLabel(d, multiLabel, i, stepNumber);
+		const contextBadge = contextModeBadge(theme, r.context);
 		const stepHeader = rRunning
-			? `${statusIcon} ${stepLabel}: ${theme.bold(theme.fg("warning", r.agent))}${modelDisplay}${stats}`
-			: `${statusIcon} ${stepLabel}: ${theme.bold(r.agent)}${modelDisplay}${stats}`;
+			? `${statusIcon} ${stepLabel}: ${theme.bold(theme.fg("warning", r.agent))}${contextBadge}${modelDisplay}${stats}`
+			: `${statusIcon} ${stepLabel}: ${theme.bold(r.agent)}${contextBadge}${modelDisplay}${stats}`;
 		const toolCallLines = getToolCallLines(r, expanded);
 		c.addChild(new Text(fit(stepHeader), 0, 0));
 

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -53,6 +53,33 @@ describe("async status helpers", () => {
 		}
 	});
 
+	it("formats async run and step context labels", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-context-"));
+		try {
+			createAsyncDir(root, "run-context", {
+				runId: "run-context",
+				mode: "parallel",
+				state: "running",
+				startedAt: 100,
+				lastUpdate: 200,
+				steps: [
+					{ agent: "scout", context: "fresh", status: "running" },
+					{ agent: "worker", context: "fork", status: "running" },
+				],
+			});
+
+			const runs = listAsyncRuns(root, { states: ["running"] });
+			assert.equal(runs[0]?.context, "mixed");
+			assert.deepEqual(runs[0]?.steps.map((step) => step.context), ["fresh", "fork"]);
+			const text = formatAsyncRunList(runs);
+			assert.match(text, /run-context \| running .* \| parallel \[mixed\]/);
+			assert.match(text, /1\. scout \[fresh\] \| running/);
+			assert.match(text, /2\. worker \[fork\] \| running/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("formats model thinking in step summaries", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-model-thinking-"));
 		try {

--- a/test/integration/fork-context-execution.test.ts
+++ b/test/integration/fork-context-execution.test.ts
@@ -19,10 +19,10 @@ interface ExecutorModule {
 			isError?: boolean;
 			content: Array<{ text?: string }>;
 			details?: {
-				context?: "fresh" | "fork";
+				context?: "fresh" | "fork" | "mixed";
 				mode?: "single" | "parallel" | "chain";
 				asyncId?: string;
-				results?: Array<{ detached?: boolean; exitCode?: number; skills?: string[] }>;
+				results?: Array<{ context?: "fresh" | "fork"; detached?: boolean; exitCode?: number; skills?: string[] }>;
 			};
 		}>;
 	};
@@ -854,7 +854,8 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		);
 
 		assert.equal(result.isError, undefined);
-		assert.equal(result.details?.context, undefined);
+		assert.equal(result.details?.context, "fresh");
+		assert.equal(result.details?.results?.[0]?.context, "fresh");
 		assert.deepEqual(openedPaths, []);
 		assert.deepEqual(branchedLeafIds, []);
 		assert.notEqual(readSessionArgsFromCalls()[0], path.join(tempDir, "fork-1.jsonl"));
@@ -880,7 +881,8 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		);
 
 		assert.equal(result.isError, undefined);
-		assert.equal(result.details?.context, "fork");
+		assert.equal(result.details?.context, "mixed");
+		assert.deepEqual(result.details?.results?.map((entry) => entry.context), ["fork", "fresh"]);
 		assert.deepEqual(openedPaths, [parentSessionFile]);
 		assert.deepEqual(branchedLeafIds, ["leaf-current"]);
 		const workerArgs = readCallArgsForTask("one");
@@ -911,7 +913,8 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		);
 
 		assert.equal(result.isError, undefined);
-		assert.equal(result.details?.context, undefined);
+		assert.equal(result.details?.context, "fresh");
+		assert.deepEqual(result.details?.results?.map((entry) => entry.context), ["fresh", "fresh"]);
 		assert.deepEqual(openedPaths, []);
 	});
 
@@ -935,7 +938,8 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		);
 
 		assert.equal(result.isError, undefined);
-		assert.equal(result.details?.context, "fork");
+		assert.equal(result.details?.context, "mixed");
+		assert.deepEqual(result.details?.results?.map((entry) => entry.context), ["fresh", "fork"]);
 		assert.deepEqual(openedPaths, [parentSessionFile]);
 		assert.deepEqual(branchedLeafIds, ["leaf-current"]);
 		const scanArgs = readCallArgsForTask("scan");

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -8,7 +8,7 @@ type RenderSubagentResult = (
 		isError?: boolean;
 		details?: {
 			mode: "single" | "parallel" | "chain" | "management";
-			context?: "fresh" | "fork";
+			context?: "fresh" | "fork" | "mixed";
 			results: unknown[];
 		};
 	},
@@ -251,24 +251,61 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(text, /↳ \[\d{2}:\d{2}:\d{2}\] \+1 nested run \(1 running\)/);
 	});
 
-	it("shows [fork] on single-result header", () => {
-		const widget = renderSubagentResult!({
+	it("shows [fresh] and [fork] on single-result headers", () => {
+		for (const context of ["fresh", "fork"] as const) {
+			const widget = renderSubagentResult!({
+				content: [{ type: "text", text: "done" }],
+				details: {
+					mode: "single",
+					context,
+					results: [{
+						agent: "reviewer",
+						task: "review",
+						context,
+						exitCode: 0,
+						messages: [],
+						usage: emptyUsage,
+					}],
+				},
+			}, { expanded: false }, theme);
+
+			const text = widget.render(120).join("\n");
+			assert.match(text, new RegExp(`\\[${context}\\]`));
+		}
+	});
+
+	it("shows [mixed] on mixed runs and per-child context badges", () => {
+		const compact = renderSubagentResult!({
 			content: [{ type: "text", text: "done" }],
 			details: {
-				mode: "single",
-				context: "fork",
-				results: [{
-					agent: "reviewer",
-					task: "review",
-					exitCode: 0,
-					messages: [],
-					usage: emptyUsage,
-				}],
+				mode: "parallel",
+				context: "mixed",
+				results: [
+					{ agent: "scout", task: "scan", context: "fresh", exitCode: 0, messages: [], usage: emptyUsage },
+					{ agent: "worker", task: "fix", context: "fork", exitCode: 0, messages: [], usage: emptyUsage },
+				],
 			},
-		}, { expanded: false }, theme);
+		}, { expanded: false }, theme).render(160).join("\n");
 
-		const text = widget.render(120).join("\n");
-		assert.match(text, /\[fork\]/);
+		assert.match(compact, /parallel \[mixed\]/);
+		assert.match(compact, /scout \[fresh\]/);
+		assert.match(compact, /worker \[fork\]/);
+
+		const expanded = renderSubagentResult!({
+			content: [{ type: "text", text: "done" }],
+			details: {
+				mode: "parallel",
+				context: "mixed",
+				results: [
+					{ agent: "scout", task: "scan", context: "fresh", exitCode: 0, messages: [], usage: emptyUsage },
+					{ agent: "worker", task: "fix", context: "fork", exitCode: 0, messages: [], usage: emptyUsage },
+				],
+			},
+		}, { expanded: true }, theme).render(160).join("\n");
+
+		assert.match(expanded, /parallel \[mixed\]/);
+		assert.match(expanded, /scout \[fresh\]/);
+		assert.match(expanded, /worker \[fork\]/);
 	});
 
 	it("uses compacted tool-call summaries when messages were stripped", () => {

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -333,6 +333,33 @@ describe("subagent async widget rendering", () => {
 		assert.match(text, /Agent 3\/3: reviewer · complete · 1\.5k token/);
 	});
 
+	it("shows async job and step context badges", () => {
+		const now = Date.now();
+		const text = buildWidgetLines([
+			{
+				asyncId: "run-1",
+				asyncDir: "/tmp/1",
+				status: "running",
+				mode: "parallel",
+				context: "mixed",
+				agents: ["scout", "worker"],
+				activeParallelGroup: true,
+				runningSteps: 2,
+				completedSteps: 0,
+				stepsTotal: 2,
+				updatedAt: now,
+				steps: [
+					{ agent: "scout", context: "fresh", status: "running", lastActivityAt: now },
+					{ agent: "worker", context: "fork", status: "running", currentTool: "bash", currentToolStartedAt: now - 1000 },
+				],
+			},
+		], theme, 160).join("\n");
+
+		assert.match(text, /parallel \[mixed\]/);
+		assert.match(text, /Agent 1\/2: scout \[fresh\] · running/);
+		assert.match(text, /Agent 2\/2: worker \[fork\] · running/);
+	});
+
 	it("shows model and thinking for active async widget rows", () => {
 		const lines = buildWidgetLines([
 			{

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -30,6 +30,7 @@ function writeAsyncRun(root: string, input: {
 	sessionId?: string;
 	state?: "running" | "complete";
 	agents?: string[];
+	contexts?: Array<"fresh" | "fork">;
 	output?: string;
 }): string {
 	const asyncDir = path.join(root, input.id);
@@ -46,6 +47,7 @@ function writeAsyncRun(root: string, input: {
 		currentStep: 0,
 		steps: agents.map((agent, index) => ({
 			agent,
+			...(input.contexts?.[index] ? { context: input.contexts[index] } : {}),
 			status: input.state === "complete" ? "complete" : index === 0 ? "running" : "pending",
 			startedAt: 100,
 			...(index === 0 ? { sessionFile: path.join(asyncDir, `${agent}.jsonl`) } : {}),
@@ -141,7 +143,7 @@ describe("native subagent fleet", () => {
 	it("renders selectable transcript detail and completed artifact paths within terminal width", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-render-"));
 		try {
-			const asyncDir = writeAsyncRun(root, { id: "async-finished", state: "complete", output: "FINAL ASYNC OUTPUT" });
+			const asyncDir = writeAsyncRun(root, { id: "async-finished", state: "complete", contexts: ["fork"], output: "FINAL ASYNC OUTPUT" });
 			const state = stateForTest();
 			let closed = false;
 			let renderRequests = 0;
@@ -157,6 +159,7 @@ describe("native subagent fleet", () => {
 				const lines = component.render(100);
 				assert.ok(lines.some((line) => line.includes("FINAL ASYNC OUTPUT")));
 				assert.ok(lines.some((line) => line.includes("output-0.log")));
+				assert.ok(lines.some((line) => line.includes("worker") && line.includes("[fork]")));
 				assert.ok(lines.some((line) => line.includes("worker.jsonl")));
 				for (const line of lines) assert.ok(visibleWidth(line) <= 100, `line exceeded width: ${line}`);
 				tui.terminal.rows = 10;


### PR DESCRIPTION
Shows each child subagent’s resolved `[fresh]` or `[fork]` context across foreground results, async status, fleet, transcripts, and widget rows. Mixed aggregate runs now show `[mixed]` while child rows keep exact context, so mixed defaultContext launches no longer look all-fork.

Validation passed: `npm run test:unit`, `npm run test:integration`, `npm run test:e2e`, and `git diff --check`.