### PR TITLE
Classify oracle review tasks as read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Registered the native child `intercom` fallback before strict tool-allowlist diagnostics run and stopped treating Pi core tools as missing extension tools, preventing read-only scouts and workers from failing before execution when strict child tool allowlists are active.
+- Kept async oracle review tasks with implementation vocabulary from triggering write-evidence acceptance contracts or the no-mutation implementation guard.
 
 ## [0.35.1] - 2026-07-17
 

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -90,9 +90,9 @@ function inferLevel(input: {
 		&& intent.kind !== "read-only"
 		&& !/\b(?:do not|don't|must not)\s+patch\b/.test(task)
 		&& /\bpatch\s+(?:(?:\.{0,2}[\\/])?(?:[\w.-]+[\\/])+[\w.-]+|[\w.-]+\.[a-z0-9]+\b|(?:the\s+)?parser\b)/.test(task);
-	const taskMayWrite = taskMayMutate(input.task ?? "") || intent.kind === "implementation" || rolePatchTask;
+	const taskMayWrite = readOnlyTask ? false : taskMayMutate(input.task ?? "") || intent.kind === "implementation" || rolePatchTask;
 	const readOnlyAgent = input.acceptanceRole === "read-only"
-		|| (input.acceptanceRole === undefined && /\b(?:reviewer|scout|context-builder|researcher|analyst)\b/.test(agent));
+		|| (input.acceptanceRole === undefined && /\b(?:reviewer|oracle|scout|context-builder|researcher|analyst)\b/.test(agent));
 	const writeTask = taskMayWrite
 		|| (input.acceptanceRole === "writer" && !readOnlyTask)
 		|| (input.acceptanceRole === undefined && /\bworker\b/.test(agent) && !readOnlyTask);

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -25,10 +25,11 @@ const REVIEW_ONLY_PATTERNS = [
 ];
 
 const REVIEWER_REQUIRED_EDIT_PATTERNS = [
-	/\bmust\s+(?:edit|modify|change|fix|patch|apply)\b/i,
-	/\brequired\s+to\s+(?:edit|modify|change|fix|patch|apply)\b/i,
+	/\bmust\s+(?:edit|modify|change|fix|patch|apply|implement)\b/i,
+	/\brequired\s+to\s+(?:edit|modify|change|fix|patch|apply|implement)\b/i,
+	/(?:^|[.!?\n]\s*)implement\s+(?:the\s+)?(?:approved|requested|specified|file|code|source|fix(?:es)?|changes?)\b/i,
 	/\bregardless\s+of\s+findings\b/i,
-	/\balways\s+(?:edit|modify|change|fix|patch|apply)\b/i,
+	/\balways\s+(?:edit|modify|change|fix|patch|apply|implement)\b/i,
 	/\bapply\s+(?:the\s+)?fix(?:es)?\s+directly\b/i,
 	/\bmake\s+(?:the\s+)?code\s+changes\b/i,
 ];
@@ -134,8 +135,12 @@ function taskHasReadOnlyDeliverable(taskText: string): boolean {
 	return READ_ONLY_DELIVERABLE_PATTERNS.some((pattern) => pattern.test(taskText));
 }
 
+function isReviewerStyleAgent(agent: string): boolean {
+	return /\b(?:reviewer|oracle)\b/i.test(agent);
+}
+
 function hasImplementationIntent(agent: string, taskText: string): boolean {
-	if (/\breviewer\b/i.test(agent)) return REVIEWER_REQUIRED_EDIT_PATTERNS.some((pattern) => pattern.test(taskText));
+	if (isReviewerStyleAgent(agent)) return REVIEWER_REQUIRED_EDIT_PATTERNS.some((pattern) => pattern.test(taskText));
 	if (agent === "worker") return WORKER_IMPLEMENTATION_PATTERNS.some((pattern) => pattern.test(taskText));
 	return GENERAL_IMPLEMENTATION_PATTERNS.some((pattern) => pattern.test(taskText));
 }
@@ -151,7 +156,7 @@ export function classifyTaskMutationIntent(agent: string, task: string): TaskMut
 
 	if (RESEARCH_AGENT_PATTERNS.some((pattern) => pattern.test(agent))) return { kind: "read-only" };
 	if (hasImplementationIntent(agent, taskText)) return { kind: "implementation" };
-	if (/\breviewer\b/i.test(agent)) return { kind: "read-only" };
+	if (isReviewerStyleAgent(agent)) return { kind: "read-only" };
 	return taskHasReadOnlyDeliverable(taskTextWithoutScopedConstraints) ? { kind: "read-only" } : { kind: "unknown" };
 }
 

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -54,6 +54,19 @@ describe("acceptance gates", () => {
 		assert.equal(resolveEffectiveAcceptance({ agentName: "worker", task: "Fix each item", mode: "chain", dynamic: true }).level, "reviewed");
 	});
 
+	it("keeps async oracle review tasks on read-only acceptance despite implementation vocabulary", () => {
+		const resolved = resolveEffectiveAcceptance({
+			agentName: "oracle",
+			task: "Review prep findings and determine what to implement with playbooks instead of before.",
+			mode: "single",
+			async: true,
+		});
+
+		assert.equal(resolved.level, "attested");
+		assert.deepEqual(resolved.inferredReason, ["read-only/reviewer-style agent"]);
+		assert.deepEqual(resolved.criteria.map((criterion) => criterion.must), ["Return concrete findings with file paths and severity when applicable"]);
+	});
+
 	it("uses explicit agent roles for ambiguous tasks while preserving task-intent precedence", () => {
 		assert.equal(resolveEffectiveAcceptance({
 			agentName: "explorer",

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -103,6 +103,22 @@ test("worker with mutating-capable tools still triggers when no mutation is obse
 	});
 });
 
+test("oracle review tasks with bash available do not require mutation", () => {
+	const task = "Review prep findings and determine what to implement with playbooks instead of before.";
+	const result = evaluateCompletionMutationGuard({
+		agent: "oracle",
+		task,
+		messages: [assistantText("Review complete with file-backed findings.")],
+		tools: ["read", "grep", "find", "ls", "bash", "intercom"],
+	});
+
+	assert.deepEqual(result, {
+		expectedMutation: false,
+		attemptedMutation: false,
+		triggered: false,
+	});
+});
+
 test("review-only, research, and framework output instructions do not expect mutation", () => {
 	assert.equal(expectsImplementationMutation("worker", "Review only: return findings, do not edit"), false);
 	assert.equal(expectsImplementationMutation("worker", "Do not edit files. Tell me how to fix the bug."), false);

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -45,10 +45,12 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Do not modify vendor/. Do not modify generated/. Implement the fix in src/.").kind, "implementation");
 	});
 
-	it("classifies research agents and plain reviewer tasks as read-only", () => {
+	it("classifies research agents and reviewer-style tasks as read-only", () => {
 		assert.equal(classifyTaskMutationIntent("researcher", "Research this and patch the bug").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("reviewer", "Review this and fix any real issues").kind, "read-only");
+		assert.equal(classifyTaskMutationIntent("oracle", "Review findings and determine what to implement with playbooks instead of before").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("reviewer", "Review this; regardless of findings, apply changes directly").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("oracle", "Implement the approved file changes").kind, "implementation");
 	});
 
 	it("keeps report-writing deliverables read-only", () => {


### PR DESCRIPTION
Treats `oracle` as a reviewer-style agent for task-intent and acceptance inference. This prevents async oracle review runs with implementation vocabulary like “what to implement” from receiving write-evidence acceptance contracts or tripping the no-mutation implementation guard, while explicit oracle implementation prompts still require edits.

Validation passed: targeted task-intent/completion-guard/acceptance unit tests, `single-execution` and `async-execution` integration tests, `npm run test:unit`, `npm run test:integration`, `npm run test:e2e`, and `git diff --check`.