### PR TITLE
fix: resolve typebox host peer in detached async runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Registered the native child `intercom` fallback before strict tool-allowlist diagnostics run and stopped treating Pi core tools as missing extension tools, preventing read-only scouts and workers from failing before execution when strict child tool allowlists are active.
 - Kept async oracle review tasks with implementation vocabulary from triggering write-evidence acceptance contracts or the no-mutation implementation guard.
 - Added the missing `context: "fork"` field to the fork-context example in the bundled `pi-subagents` skill. Thanks to Kier (@kierr) for #540.
+- Resolved host-provided TypeBox compiler lookup for detached async runners and structured-output validation. Thanks to @nistaux for #526, 96tommykim (@96tommykim) for #545, and @git-geeky and @lukechen526 for reproduction and validation details.
 
 ## [0.35.1] - 2026-07-17
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1207,7 +1207,7 @@ async function runSingleStep(
 		let structuredOutput: unknown;
 		let structuredError: string | undefined;
 		if (effectiveStructuredOutput && run.exitCode === 0 && !run.error && !toolAvailabilityError && !hiddenError?.hasError && !emptyOutputError) {
-			const structured = readStructuredOutput({
+			const structured = await readStructuredOutput({
 				schema: effectiveStructuredOutput.schema,
 				schemaPath: effectiveStructuredOutput.schemaPath,
 				outputPath: effectiveStructuredOutput.outputPath,
@@ -2610,7 +2610,7 @@ async function runSubagent(
 				if (materialized.parallel.length > 1 && step.parallel.outputPath && !step.parallel.namespaceOutputPath) {
 					throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} materialized ${materialized.parallel.length} items that resolve output to the same path: ${step.parallel.outputPath}. Remove the explicit output path or use an inherited relative agent output so each item can be isolated.`);
 				}
-				if (materialized.collectedOnEmpty) validateDynamicCollection(step.collect.outputSchema, materialized.collectedOnEmpty);
+				if (materialized.collectedOnEmpty) await validateDynamicCollection(step.collect.outputSchema, materialized.collectedOnEmpty);
 			} catch (error) {
 				const now = Date.now();
 				const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
@@ -2947,7 +2947,7 @@ async function runSubagent(
 			const failures = parallelResults.filter((result) => result.exitCode !== 0 && result.exitCode !== -1);
 			if (failures.length === 0) {
 				try {
-					validateDynamicCollection(step.collect.outputSchema, collection);
+					await validateDynamicCollection(step.collect.outputSchema, collection);
 					outputs[step.collect.as] = {
 						text: JSON.stringify(collection),
 						structured: collection,

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -868,7 +868,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			if (materialized.parallel.length === 0) {
 				const collection: DynamicCollectedResult[] = [];
 				try {
-					validateDynamicCollection(step.collect.outputSchema, collection);
+					await validateDynamicCollection(step.collect.outputSchema, collection);
 				} catch (error) {
 					const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
 					dynamicGroupStatuses[stepIndex] = { status: "failed", error: message };
@@ -1037,7 +1037,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				};
 			}
 			try {
-				validateDynamicCollection(step.collect.outputSchema, collected);
+				await validateDynamicCollection(step.collect.outputSchema, collected);
 			} catch (error) {
 				const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
 				dynamicGroupStatuses[stepIndex] = { status: "failed", error: message };

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -1046,7 +1046,7 @@ async function runSingleAttempt(
 		}
 	}
 	if (options.structuredOutput && result.exitCode === 0 && !result.error) {
-		const structured = readStructuredOutput({
+		const structured = await readStructuredOutput({
 			schema: options.structuredOutput.schema,
 			schemaPath: options.structuredOutput.schemaPath,
 			outputPath: options.structuredOutput.outputPath,

--- a/src/runs/shared/dynamic-fanout.ts
+++ b/src/runs/shared/dynamic-fanout.ts
@@ -288,9 +288,9 @@ export function collectDynamicResults(
 	});
 }
 
-export function validateDynamicCollection(schema: JsonSchemaObject | undefined, value: DynamicCollectedResult[]): void {
+export async function validateDynamicCollection(schema: JsonSchemaObject | undefined, value: DynamicCollectedResult[]): Promise<void> {
 	if (!schema) return;
-	const validation = validateStructuredOutputValue(schema, value);
+	const validation = await validateStructuredOutputValue(schema, value);
 	if (validation.status === "invalid") {
 		throw new DynamicFanoutError(`Collected output validation failed: ${validation.message}`);
 	}

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { encodeNestedPathEnv, parseNestedPathEnv, type NestedPathEntry } from "./nested-path.ts";
 import { resolveMcpDirectToolNames } from "./mcp-direct-tool-allowlist.ts";
+import { resolvePiPackageRoot } from "./pi-spawn.ts";
 import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "./structured-output.ts";
 import { TEMP_ROOT_DIR, type JsonSchemaObject, type ResolvedToolBudget } from "../../shared/types.ts";
 import { THINKING_LEVELS } from "../../shared/model-info.ts";
@@ -11,6 +12,7 @@ import { TOOL_BUDGET_ENV, encodeToolBudgetEnv } from "./tool-budget.ts";
 import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, REQUIRED_CHILD_TOOLS_ENV } from "./tool-availability.ts";
 import { CHILD_WATCHDOG_CONFIG_ENV, encodeChildWatchdogConfig, type ChildWatchdogConfig } from "../../watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../background/wait-config.ts";
+import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../shared/utils.ts";
 
 const TASK_ARG_LIMIT = 8000;
 const PROMPT_RUNTIME_EXTENSION_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-prompt-runtime.ts");
@@ -190,6 +192,8 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	}
 
 	const env: Record<string, string | undefined> = {};
+	const piPackageRoot = process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] ?? resolvePiPackageRoot();
+	if (piPackageRoot) env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] = piPackageRoot;
 	let toolDiagnosticPath: string | undefined;
 	if (requiredChildTools.length > 0) {
 		if (!tempDir) tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));

--- a/src/runs/shared/structured-output.ts
+++ b/src/runs/shared/structured-output.ts
@@ -1,7 +1,9 @@
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Compile } from "typebox/compile";
+import { pathToFileURL } from "node:url";
+import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../shared/utils.ts";
 import type { JsonSchemaObject } from "../../shared/types.ts";
 
 export const STRUCTURED_OUTPUT_SCHEMA_ENV = "PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA";
@@ -16,6 +18,51 @@ export interface StructuredOutputRuntime {
 interface CompiledJsonSchema {
 	Check(value: unknown): boolean;
 	Errors(value: unknown): Iterable<{ instancePath?: string; message?: string }>;
+}
+
+type CompileJsonSchema = (schema: unknown) => CompiledJsonSchema;
+
+let cachedCompile: Promise<CompileJsonSchema> | undefined;
+
+export async function resolveCompileFromPackageRoot(packageRoot: string): Promise<CompileJsonSchema | undefined> {
+	const requireFromRoot = createRequire(path.join(packageRoot, "package.json"));
+	const resolved = requireFromRoot.resolve("typebox/compile");
+	const mod = (await import(pathToFileURL(resolved).href)) as { Compile?: unknown };
+	return typeof mod.Compile === "function" ? (mod.Compile as CompileJsonSchema) : undefined;
+}
+
+async function importCompile(): Promise<CompileJsonSchema> {
+	const failures: string[] = [];
+	try {
+		const mod = (await import("typebox/compile")) as { Compile?: unknown };
+		if (typeof mod.Compile === "function") return mod.Compile as CompileJsonSchema;
+		failures.push("typebox/compile did not export a Compile function");
+	} catch (error) {
+		failures.push(`direct import failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	const packageRoot = process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV];
+	if (packageRoot) {
+		try {
+			const compile = await resolveCompileFromPackageRoot(packageRoot);
+			if (compile) return compile;
+			failures.push("Pi package root typebox/compile did not export a Compile function");
+		} catch (error) {
+			failures.push(`Pi package root import failed: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	} else {
+		failures.push(`${PI_CODING_AGENT_PACKAGE_ROOT_ENV} is not set`);
+	}
+	throw new Error(`Cannot load typebox/compile for structured output validation (${failures.join("; ")})`);
+}
+
+function loadCompile(): Promise<CompileJsonSchema> {
+	if (!cachedCompile) {
+		cachedCompile = importCompile().catch((error) => {
+			cachedCompile = undefined;
+			throw error;
+		});
+	}
+	return cachedCompile;
 }
 
 export function assertJsonSchemaObject(schema: unknown, label = "outputSchema"): asserts schema is JsonSchemaObject {
@@ -35,10 +82,11 @@ export function createStructuredOutputRuntime(schema: JsonSchemaObject, baseDir?
 	return { schema, schemaPath, outputPath };
 }
 
-export function validateStructuredOutputValue(schema: JsonSchemaObject, value: unknown): { status: "valid" } | { status: "invalid"; message: string } {
+export async function validateStructuredOutputValue(schema: JsonSchemaObject, value: unknown): Promise<{ status: "valid" } | { status: "invalid"; message: string }> {
+	const compile = await loadCompile();
 	let validator: CompiledJsonSchema;
 	try {
-		validator = (Compile as (schema: unknown) => CompiledJsonSchema)(schema);
+		validator = compile(schema);
 	} catch (error) {
 		return { status: "invalid", message: `invalid outputSchema: ${error instanceof Error ? error.message : String(error)}` };
 	}
@@ -52,7 +100,7 @@ export function validateStructuredOutputValue(schema: JsonSchemaObject, value: u
 	return { status: "invalid", message: errors.join("; ") || "schema validation failed" };
 }
 
-export function readStructuredOutput(runtime: StructuredOutputRuntime): { value?: unknown; error?: string } {
+export async function readStructuredOutput(runtime: StructuredOutputRuntime): Promise<{ value?: unknown; error?: string }> {
 	if (!fs.existsSync(runtime.outputPath)) {
 		return { error: "Missing structured_output call; this step has outputSchema and must finish by calling structured_output." };
 	}
@@ -62,8 +110,12 @@ export function readStructuredOutput(runtime: StructuredOutputRuntime): { value?
 	} catch (error) {
 		return { error: `Failed to read structured output: ${error instanceof Error ? error.message : String(error)}` };
 	}
-	const validation = validateStructuredOutputValue(runtime.schema, value);
-	if (validation.status === "invalid") return { error: `Structured output validation failed: ${validation.message}` };
+	try {
+		const validation = await validateStructuredOutputValue(runtime.schema, value);
+		if (validation.status === "invalid") return { error: `Structured output validation failed: ${validation.message}` };
+	} catch (error) {
+		return { error: `Failed to validate structured output: ${error instanceof Error ? error.message : String(error)}` };
+	}
 	return { value };
 }
 

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -401,7 +401,7 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 			description: "Submit the required final structured output for this subagent step. This terminates the step.",
 			parameters: parameters as never,
 			async execute(_id: string, params: { value: unknown }) {
-				const validation = validateStructuredOutputValue(schema, params.value);
+				const validation = await validateStructuredOutputValue(schema, params.value);
 				if (validation.status === "invalid") {
 					throw new Error(`Structured output validation failed: ${validation.message}`);
 				}

--- a/test/unit/dynamic-fanout.test.ts
+++ b/test/unit/dynamic-fanout.test.ts
@@ -190,7 +190,7 @@ describe("dynamic fanout helpers", () => {
 		], {}, { priorOutputNames: ["targets"], startStepIndex: 2 }));
 	});
 
-	it("collects ordered child result records and validates aggregate schema", () => {
+	it("collects ordered child result records and validates aggregate schema", async () => {
 		const step: ChainStep = {
 			expand: { from: { output: "targets", path: "/items" }, key: "/path", maxItems: 4 },
 			parallel: { agent: "reviewer", task: "Review {item.path}" },
@@ -211,7 +211,7 @@ describe("dynamic fanout helpers", () => {
 		assert.deepEqual(collected.map((item) => item.key), ["src/a.ts", "src/b.ts"]);
 		assert.deepEqual(collected.map((item) => item.structured), [{ ok: "a" }, { ok: "b" }]);
 		assert.equal(collected[1]?.timedOut, true);
-		assert.doesNotThrow(() => validateDynamicCollection({ type: "array", minItems: 2 }, collected));
-		assert.throws(() => validateDynamicCollection({ type: "object" }, collected), DynamicFanoutError);
+		await assert.doesNotReject(validateDynamicCollection({ type: "array", minItems: 2 }, collected));
+		await assert.rejects(validateDynamicCollection({ type: "object" }, collected), DynamicFanoutError);
 	});
 });

--- a/test/unit/host-peer-runtime-imports.test.ts
+++ b/test/unit/host-peer-runtime-imports.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { resolveCompileFromPackageRoot, validateStructuredOutputValue } from "../../src/runs/shared/structured-output.ts";
+import type { JsonSchemaObject } from "../../src/shared/types.ts";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const hostPeerPackages = [
+	"@earendil-works/pi-agent-core",
+	"@earendil-works/pi-ai",
+	"@earendil-works/pi-coding-agent",
+	"@earendil-works/pi-tui",
+	"typebox",
+] as const;
+
+function matchingHostPeerPackage(specifier: string): string | undefined {
+	return hostPeerPackages.find((pkg) => specifier === pkg || specifier.startsWith(`${pkg}/`));
+}
+
+/** Extract specifiers from top-level static import/export-from statements, skipping type-only lines. */
+function extractStaticImportSpecifiers(source: string): string[] {
+	const specifiers: string[] = [];
+	const lines = source.split("\n");
+	let i = 0;
+	while (i < lines.length) {
+		const line = lines[i]!.trim();
+		if (!/^(?:import|export)\b/.test(line)) {
+			i++;
+			continue;
+		}
+		// Multi-line statements (e.g. `import {\n\tFoo,\n} from "x";`) continue past this line: keep
+		// pulling lines into one logical statement until we see the `from "..."` clause or a `;`.
+		let statement = line;
+		while (!/from\s+["'][^"']+["']/.test(statement) && !statement.includes(";") && i + 1 < lines.length) {
+			i++;
+			statement += ` ${lines[i]!.trim()}`;
+		}
+		i++;
+
+		if (/^import\s+type\b/.test(statement) || /^export\s+type\b/.test(statement)) continue;
+		const fromMatch = statement.match(/from\s+["']([^"']+)["']/);
+		if (fromMatch) {
+			specifiers.push(fromMatch[1]!);
+			continue;
+		}
+		const sideEffectMatch = statement.match(/^import\s+["']([^"']+)["']/);
+		if (sideEffectMatch) specifiers.push(sideEffectMatch[1]!);
+	}
+	return specifiers;
+}
+
+function resolveRelativeImport(fromFile: string, specifier: string): string | undefined {
+	const base = path.dirname(fromFile);
+	const candidates = [path.resolve(base, specifier), path.resolve(base, `${specifier}.ts`), path.resolve(base, specifier, "index.ts")];
+	return candidates.find((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile());
+}
+
+test("detached async runner's runtime import graph never reaches a host peer package (issues #334, #526)", () => {
+	const entryPoint = path.join(projectRoot, "src", "runs", "background", "subagent-runner.ts");
+	const visited = new Set<string>([entryPoint]);
+	const queue: string[] = [entryPoint];
+	const violations: string[] = [];
+
+	while (queue.length > 0) {
+		const file = queue.shift()!;
+		const source = fs.readFileSync(file, "utf-8");
+		for (const specifier of extractStaticImportSpecifiers(source)) {
+			const hostPeerMatch = matchingHostPeerPackage(specifier);
+			if (hostPeerMatch) {
+				violations.push(`${path.relative(projectRoot, file)} has a runtime import of '${specifier}' (host peer package '${hostPeerMatch}')`);
+				continue;
+			}
+			if (!specifier.startsWith(".")) continue;
+			const resolved = resolveRelativeImport(file, specifier);
+			if (!resolved) {
+				throw new Error(`Could not resolve relative import '${specifier}' from ${path.relative(projectRoot, file)}`);
+			}
+			if (!visited.has(resolved)) {
+				visited.add(resolved);
+				queue.push(resolved);
+			}
+		}
+	}
+
+	assert.equal(violations.length, 0, `runtime import graph reached host peer package(s):\n${violations.join("\n")}`);
+	assert.ok(visited.size > 20, `expected a non-trivial reachable file set (a broken resolver could undercount it), got ${visited.size}`);
+});
+
+test("resolveCompileFromPackageRoot loads typebox/compile from a fake Pi host package root", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-host-root-"));
+	try {
+		fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "fake-pi-coding-agent", version: "0.0.0" }));
+		const typeboxDir = path.join(root, "node_modules", "typebox");
+		fs.mkdirSync(typeboxDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(typeboxDir, "package.json"),
+			JSON.stringify({ name: "typebox", version: "0.0.0-test", exports: { "./compile": "./compile.mjs" } }),
+		);
+		fs.writeFileSync(path.join(typeboxDir, "compile.mjs"), "export function Compile() {\n\treturn { Check: () => true, Errors: () => [] };\n}\n");
+
+		const compile = await resolveCompileFromPackageRoot(root);
+		assert.equal(typeof compile, "function");
+		const compiled = compile!({});
+		assert.equal(compiled.Check({}), true);
+		assert.deepEqual([...compiled.Errors({})], []);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+
+	const emptyRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-empty-root-"));
+	try {
+		await assert.rejects(resolveCompileFromPackageRoot(emptyRoot));
+	} finally {
+		fs.rmSync(emptyRoot, { recursive: true, force: true });
+	}
+});
+
+test("validateStructuredOutputValue validates values against a JSON Schema", async () => {
+	const valid = await validateStructuredOutputValue({ type: "object" }, {});
+	assert.deepEqual(valid, { status: "valid" });
+
+	const schema: JsonSchemaObject = {
+		type: "object",
+		properties: { a: { type: "number" } },
+		required: ["a"],
+		additionalProperties: false,
+	};
+	const invalid = await validateStructuredOutputValue(schema, {});
+	assert.equal(invalid.status, "invalid");
+	assert.ok(invalid.status === "invalid" && invalid.message.length > 0);
+});

--- a/test/unit/host-peer-runtime-imports.test.ts
+++ b/test/unit/host-peer-runtime-imports.test.ts
@@ -90,23 +90,27 @@ test("detached async runner's runtime import graph never reaches a host peer pac
 	assert.ok(visited.size > 20, `expected a non-trivial reachable file set (a broken resolver could undercount it), got ${visited.size}`);
 });
 
+function writeFakeTypeboxPackage(typeboxDir: string): void {
+	fs.mkdirSync(typeboxDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(typeboxDir, "package.json"),
+		JSON.stringify({ name: "typebox", version: "0.0.0-test", exports: { "./compile": "./compile.mjs" } }),
+	);
+	fs.writeFileSync(path.join(typeboxDir, "compile.mjs"), "export function Compile() {\n\treturn { Check: () => true, Errors: () => [], fakeTypebox: true };\n}\n");
+}
+
 test("resolveCompileFromPackageRoot loads typebox/compile from a fake Pi host package root", async () => {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-host-root-"));
 	try {
 		fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "fake-pi-coding-agent", version: "0.0.0" }));
-		const typeboxDir = path.join(root, "node_modules", "typebox");
-		fs.mkdirSync(typeboxDir, { recursive: true });
-		fs.writeFileSync(
-			path.join(typeboxDir, "package.json"),
-			JSON.stringify({ name: "typebox", version: "0.0.0-test", exports: { "./compile": "./compile.mjs" } }),
-		);
-		fs.writeFileSync(path.join(typeboxDir, "compile.mjs"), "export function Compile() {\n\treturn { Check: () => true, Errors: () => [] };\n}\n");
+		writeFakeTypeboxPackage(path.join(root, "node_modules", "typebox"));
 
 		const compile = await resolveCompileFromPackageRoot(root);
 		assert.equal(typeof compile, "function");
 		const compiled = compile!({});
 		assert.equal(compiled.Check({}), true);
 		assert.deepEqual([...compiled.Errors({})], []);
+		assert.equal((compiled as { fakeTypebox?: boolean }).fakeTypebox, true);
 	} finally {
 		fs.rmSync(root, { recursive: true, force: true });
 	}
@@ -116,6 +120,24 @@ test("resolveCompileFromPackageRoot loads typebox/compile from a fake Pi host pa
 		await assert.rejects(resolveCompileFromPackageRoot(emptyRoot));
 	} finally {
 		fs.rmSync(emptyRoot, { recursive: true, force: true });
+	}
+});
+
+test("resolveCompileFromPackageRoot resolves typebox hoisted to an ancestor node_modules", async () => {
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-hoisted-root-"));
+	try {
+		writeFakeTypeboxPackage(path.join(tmp, "node_modules", "typebox"));
+		const packageRoot = path.join(tmp, "apps", "pi", "node_modules", "@earendil-works", "pi-coding-agent");
+		fs.mkdirSync(packageRoot, { recursive: true });
+		fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent", version: "0.0.0" }));
+
+		const compile = await resolveCompileFromPackageRoot(packageRoot);
+		assert.equal(typeof compile, "function");
+		const compiled = compile!({});
+		assert.equal(compiled.Check({}), true);
+		assert.equal((compiled as { fakeTypebox?: boolean }).fakeTypebox, true);
+	} finally {
+		fs.rmSync(tmp, { recursive: true, force: true });
 	}
 });
 

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, it } from "node:test";
 import { computeMcpServerHash } from "../../src/runs/shared/mcp-direct-tool-allowlist.ts";
 import { TOOL_BUDGET_ENV } from "../../src/runs/shared/tool-budget.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
+import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
 import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, REQUIRED_CHILD_TOOLS_ENV } from "../../src/runs/shared/tool-availability.ts";
 import { CHILD_WATCHDOG_CONFIG_ENV } from "../../src/watchdog/child-status.ts";
 import {
@@ -41,6 +42,7 @@ const originalEnv = {
 	PI_SUBAGENT_PARENT_CAPABILITY_TOKEN: process.env.PI_SUBAGENT_PARENT_CAPABILITY_TOKEN,
 	PI_SUBAGENT_PARENT_SESSION: process.env.PI_SUBAGENT_PARENT_SESSION,
 	PI_SUBAGENT_RUN_ID: process.env.PI_SUBAGENT_RUN_ID,
+	[PI_CODING_AGENT_PACKAGE_ROOT_ENV]: process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV],
 };
 const originalCwd = process.cwd();
 const tempRoots: string[] = [];
@@ -504,6 +506,19 @@ describe("buildPiArgs system prompt mode wiring", () => {
 
 		assert.equal(args[args.indexOf("--tools") + 1], "read,fixture_search,structured_output");
 		assert.deepEqual(JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"), ["read", "fixture_search", "structured_output"]);
+	});
+
+	it("forwards the Pi package root to child processes for host peer resolution", () => {
+		process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] = "/opt/pi-coding-agent";
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.equal(env[PI_CODING_AGENT_PACKAGE_ROOT_ENV], "/opt/pi-coding-agent");
 	});
 
 	it("adds read to explicit tool allowlists when skills must be loaded lazily", () => {


### PR DESCRIPTION

Fixes #526.

After #513 moved TypeBox to a Pi-hosted peer, the detached async runner crashed at startup with `Cannot find module 'typebox/compile'` before it could write a result. `pi-args.ts` imports `structured-output.ts`, which eagerly loaded the compiler, even though `pi-args.ts` only needs two environment variable name constants. Foreground runs still worked because extensions load in the Pi host process.

This patch loads `typebox/compile` only when validation runs. It tries a direct import first, then falls back to `createRequire` from `PI_SUBAGENTS_PI_CODING_AGENT_PACKAGE_ROOT`, following `resolveJitiCliPath`. The fallback also handles detached dynamic fan-out `collect.outputSchema` validation.

`validateStructuredOutputValue`, `readStructuredOutput`, and `validateDynamicCollection` are now async, and all internal callers await them; none are exported package subpaths. `readStructuredOutput` still never throws: if the validator won't load, it records the failure as the step's structured output error instead of terminating the runner.

The static import graph test checks all five Pi-hosted peer packages for the eager-import problem fixed for #334 in 242d56a. Resolver tests cover nested and hoisted host installs.

## Verification

- Unit suite passes. The pre-existing intermittent `watchdog-lsp-diagnostics` 500 ms flake reproduces without this patch.
- In a clean packed install without TypeBox, `jiti subagent-runner.ts` gets through imports and fails on the empty stdin config. Before this patch, the first import failed with the #526 error.
- Under jiti, validation succeeds with TypeBox only in a fake host root supplied through the environment variable. Without it, validation returns an aggregated error with resolution details.

## Why not NODE_PATH?

@lukechen526 identified the detached child's host visibility as the issue and suggested a real-child test.

Node's ESM resolver ignores NODE_PATH. Locally, `require.resolve("typebox/compile")` succeeded with NODE_PATH, while `import("typebox/compile")` failed with `ERR_MODULE_NOT_FOUND`; the package resolves to an `.mjs` file.

A single prepended `node_modules` path also misses hoisted installs unless every ancestor is included. `createRequire` from the package root searches those locations and matches 242d56a's approach.

A packed-install test that launches a real detached child would cover this end to end, as @lukechen526 suggested. It would also catch the gap from @git-geeky's report, where `subagents doctor` stays green during the failure. That test can follow separately.

Thanks @nistaux for the report and workaround validation.

