### PR TITLE
fix: register child intercom before tool diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
-- Registered the native child `intercom` fallback before strict tool-allowlist diagnostics run, preventing read-only scouts from failing before execution when the bridge adds `intercom` to their tools.
+- Registered the native child `intercom` fallback before strict tool-allowlist diagnostics run and stopped treating Pi core tools as missing extension tools, preventing read-only scouts and workers from failing before execution when strict child tool allowlists are active.
 
 ## [0.35.1] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
+### Fixed
+- Registered the native child `intercom` fallback before strict tool-allowlist diagnostics run, preventing read-only scouts from failing before execution when the bridge adds `intercom` to their tools.
+
 ## [0.35.1] - 2026-07-17
 
 ### Fixed

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -69,14 +69,20 @@ function readBooleanEnv(name: string): boolean | undefined {
 	return value !== "0";
 }
 
-function refreshChildToolDiagnostic(pi: ExtensionAPI): ChildToolDiagnostic | undefined {
-	const filePath = process.env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV]?.trim();
+function readRequiredChildTools(): string[] | undefined {
 	const encoded = process.env[REQUIRED_CHILD_TOOLS_ENV]?.trim();
-	if (!filePath || !encoded) return undefined;
+	if (!encoded) return undefined;
 	const required = JSON.parse(encoded) as unknown;
 	if (!Array.isArray(required) || required.some((name) => typeof name !== "string" || !name)) {
 		throw new Error(`Invalid ${REQUIRED_CHILD_TOOLS_ENV} payload.`);
 	}
+	return required;
+}
+
+function refreshChildToolDiagnostic(pi: ExtensionAPI): ChildToolDiagnostic | undefined {
+	const filePath = process.env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV]?.trim();
+	const required = readRequiredChildTools();
+	if (!filePath || !required) return undefined;
 	const available = pi.getAllTools().map((tool) => tool.name);
 	return writeChildToolDiagnostic(filePath, required, available, process.env[SUBAGENT_CHILD_AGENT_ENV]?.trim());
 }
@@ -365,6 +371,7 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		const sessionManager = (ctx as { sessionManager?: Parameters<typeof resolveCurrentSessionId>[0] } | undefined)?.sessionManager;
 		waitState.currentSessionId = sessionManager ? resolveCurrentSessionId(sessionManager) : null;
 		registerNativeSupervisorClientOnce();
+		if (readRequiredChildTools()?.includes("intercom")) registerNativeSupervisorFallbackOnce();
 		refreshChildToolDiagnostic(pi);
 	});
 	onRuntimeEvent("agent_end", async (_event: unknown, ctx: unknown) => {

--- a/src/runs/shared/tool-availability.ts
+++ b/src/runs/shared/tool-availability.ts
@@ -11,13 +11,15 @@ export interface ChildToolDiagnostic {
 	missing: string[];
 }
 
+const PI_CORE_CHILD_TOOLS = new Set(["bash", "edit", "find", "grep", "ls", "read", "write"]);
+
 export function writeChildToolDiagnostic(
 	filePath: string,
 	required: string[],
 	available: string[],
 	agent?: string,
 ): ChildToolDiagnostic | undefined {
-	const availableNames = new Set(available);
+	const availableNames = new Set([...available, ...PI_CORE_CHILD_TOOLS]);
 	const missing = required.filter((name) => !availableNames.has(name));
 	if (missing.length === 0) {
 		fs.rmSync(filePath, { force: true });

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -552,6 +552,35 @@ describe("subagent prompt runtime", () => {
 		assert.deepEqual(registered, ["subagent_wait"]);
 	});
 
+	it("registers native intercom before checking a strict allowlist", () => {
+		setSupervisorEnv();
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-intercom-diagnostic-"));
+		try {
+			const diagnosticPath = path.join(dir, "tools.json");
+			const handlers = new Map<string, (payload?: unknown) => unknown>();
+			const registered: string[] = [];
+			process.env[REQUIRED_CHILD_TOOLS_ENV] = JSON.stringify(["read", "intercom"]);
+			process.env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV] = diagnosticPath;
+			process.env[SUBAGENT_CHILD_AGENT_ENV] = "scout";
+
+			registerSubagentPromptRuntime({
+				on(event: string, handler: (payload?: unknown) => unknown) {
+					handlers.set(event, handler);
+				},
+				getAllTools: () => [{ name: "read" }, ...registered.map((name) => ({ name }))],
+				registerTool(tool: { name: string }) {
+					registered.push(tool.name);
+				},
+			} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(tool: { name: string }): void });
+
+			handlers.get("session_start")?.({});
+			assert.deepEqual(registered, ["subagent_wait", "contact_supervisor", "intercom"]);
+			assert.equal(fs.existsSync(diagnosticPath), false);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps installed pi-intercom while filling only a missing child contact_supervisor tool", async () => {
 		setSupervisorEnv();
 		const handlers = new Map<string, (payload?: unknown) => unknown>();

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -559,7 +559,7 @@ describe("subagent prompt runtime", () => {
 			const diagnosticPath = path.join(dir, "tools.json");
 			const handlers = new Map<string, (payload?: unknown) => unknown>();
 			const registered: string[] = [];
-			process.env[REQUIRED_CHILD_TOOLS_ENV] = JSON.stringify(["read", "intercom"]);
+			process.env[REQUIRED_CHILD_TOOLS_ENV] = JSON.stringify(["read", "grep", "find", "ls", "bash", "edit", "write", "intercom"]);
 			process.env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV] = diagnosticPath;
 			process.env[SUBAGENT_CHILD_AGENT_ENV] = "scout";
 
@@ -567,7 +567,7 @@ describe("subagent prompt runtime", () => {
 				on(event: string, handler: (payload?: unknown) => unknown) {
 					handlers.set(event, handler);
 				},
-				getAllTools: () => [{ name: "read" }, ...registered.map((name) => ({ name }))],
+				getAllTools: () => registered.map((name) => ({ name })),
 				registerTool(tool: { name: string }) {
 					registered.push(tool.name);
 				},


### PR DESCRIPTION
## Summary
- register the native child `intercom` fallback before strict allowlist diagnostics when `intercom` is explicitly required
- preserve external intercom providers and existing diagnostics for other unavailable tools
- add a startup-order regression test and changelog entry

## Validation
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`