### PR TITLE
Redact run history prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Made `run-history.jsonl` and its agent directory owner-only where supported, redacted stored task prompts, and retained only a SHA-256 task hash for history correlation. Thanks to @avishkandi for #534.
 - Registered the native child `intercom` fallback before strict tool-allowlist diagnostics run and stopped treating Pi core tools as missing extension tools, preventing read-only scouts and workers from failing before execution when strict child tool allowlists are active.
 - Kept async oracle review tasks with implementation vocabulary from triggering write-evidence acceptance contracts or the no-mutation implementation guard.
 - Added the missing `context: "fork"` field to the fork-context example in the bundled `pi-subagents` skill. Thanks to Kier (@kierr) for #540.

--- a/src/runs/shared/run-history.ts
+++ b/src/runs/shared/run-history.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAgentDir } from "../../shared/utils.ts";
@@ -5,6 +6,7 @@ import { getAgentDir } from "../../shared/utils.ts";
 export interface RunEntry {
 	agent: string;
 	task: string;
+	taskHash?: string;
 	ts: number;
 	status: "ok" | "error";
 	duration: number;
@@ -13,24 +15,103 @@ export interface RunEntry {
 
 const ROTATE_READ_THRESHOLD = 1200;
 const ROTATE_KEEP = 1000;
+const PRIVATE_DIR_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const REDACTED_TASK = "[redacted]";
 
 function getHistoryPath(): string {
 	return path.join(getAgentDir(), "run-history.jsonl");
+}
+
+function hashTask(task: string): string {
+	return createHash("sha256").update(task).digest("hex");
+}
+
+function hardenHistoryStorage(historyPath: string): void {
+	const historyDir = path.dirname(historyPath);
+	fs.mkdirSync(historyDir, { recursive: true, mode: PRIVATE_DIR_MODE });
+	try { fs.chmodSync(historyDir, PRIVATE_DIR_MODE); } catch {}
+	try { if (fs.existsSync(historyPath)) fs.chmodSync(historyPath, PRIVATE_FILE_MODE); } catch {}
+}
+
+function sanitizeHistoryLine(line: string): string | undefined {
+	let value: unknown;
+	try {
+		value = JSON.parse(line);
+	} catch {
+		return undefined;
+	}
+	if (!value || typeof value !== "object") return undefined;
+
+	const record = value as Record<string, unknown>;
+	const task = typeof record.task === "string" ? record.task : "";
+	const taskHash = typeof record.taskHash === "string" && record.taskHash
+		? record.taskHash
+		: task && task !== REDACTED_TASK
+			? hashTask(task)
+			: undefined;
+
+	return JSON.stringify({
+		...record,
+		task: REDACTED_TASK,
+		...(taskHash ? { taskHash } : {}),
+	});
+}
+
+function sanitizeHistoryLines(raw: string): { lines: string[]; changed: boolean } {
+	const lines: string[] = [];
+	let changed = false;
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		const sanitized = sanitizeHistoryLine(trimmed);
+		if (!sanitized) {
+			changed = true;
+			continue;
+		}
+		if (sanitized !== trimmed) changed = true;
+		lines.push(sanitized);
+	}
+	return { lines, changed };
+}
+
+function writePrivateHistory(historyPath: string, lines: string[]): void {
+	fs.writeFileSync(historyPath, lines.length ? `${lines.join("\n")}\n` : "", { encoding: "utf-8", mode: PRIVATE_FILE_MODE });
+	try { fs.chmodSync(historyPath, PRIVATE_FILE_MODE); } catch {}
+}
+
+function sanitizeHistoryFile(historyPath: string): void {
+	if (!fs.existsSync(historyPath)) return;
+	const raw = fs.readFileSync(historyPath, "utf-8");
+	const { lines, changed } = sanitizeHistoryLines(raw);
+	if (changed) writePrivateHistory(historyPath, lines);
+}
+
+function appendPrivateHistoryLine(historyPath: string, line: string): void {
+	const fd = fs.openSync(historyPath, fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY, PRIVATE_FILE_MODE);
+	try {
+		fs.writeSync(fd, `${line}\n`);
+	} finally {
+		fs.closeSync(fd);
+	}
+	try { fs.chmodSync(historyPath, PRIVATE_FILE_MODE); } catch {}
 }
 
 export function recordRun(agent: string, task: string, exitCode: number, durationMs: number): void {
 	try {
 		const entry: RunEntry = {
 			agent,
-			task: task.slice(0, 200),
+			task: REDACTED_TASK,
+			taskHash: hashTask(task),
 			ts: Math.floor(Date.now() / 1000),
 			status: exitCode === 0 ? "ok" : "error",
 			duration: durationMs,
 			...(exitCode !== 0 ? { exit: exitCode } : {}),
 		};
 		const historyPath = getHistoryPath();
-		fs.mkdirSync(path.dirname(historyPath), { recursive: true });
-		fs.appendFileSync(historyPath, `${JSON.stringify(entry)}\n`);
+		hardenHistoryStorage(historyPath);
+		try { sanitizeHistoryFile(historyPath); } catch {}
+		appendPrivateHistoryLine(historyPath, JSON.stringify(entry));
 	} catch {
 		// Best-effort — never crash the execution flow for history recording
 	}
@@ -38,6 +119,7 @@ export function recordRun(agent: string, task: string, exitCode: number, duratio
 
 export function loadRunsForAgent(agent: string): RunEntry[] {
 	const historyPath = getHistoryPath();
+	try { hardenHistoryStorage(historyPath); } catch {}
 	if (!fs.existsSync(historyPath)) return [];
 	let raw: string;
 	try {
@@ -46,11 +128,14 @@ export function loadRunsForAgent(agent: string): RunEntry[] {
 		return [];
 	}
 
-	let lines = raw.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
+	let { lines, changed } = sanitizeHistoryLines(raw);
 
 	if (lines.length > ROTATE_READ_THRESHOLD) {
 		lines = lines.slice(-ROTATE_KEEP);
-		try { fs.writeFileSync(historyPath, `${lines.join("\n")}\n`, "utf-8"); } catch {}
+		changed = true;
+	}
+	if (changed) {
+		try { writePrivateHistory(historyPath, lines); } catch {}
 	}
 
 	return lines

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -31,6 +32,16 @@ function readText(result: { content: Array<{ type: string; text?: string }> }): 
 	assert.equal(first.type, "text");
 	assert.equal(typeof first.text, "string");
 	return first.text;
+}
+
+function taskHash(task: string): string {
+	return createHash("sha256").update(task).digest("hex");
+}
+
+function assertPrivateHistoryModes(historyPath: string): void {
+	if (process.platform === "win32") return;
+	assert.equal(fs.statSync(path.dirname(historyPath)).mode & 0o777, 0o700);
+	assert.equal(fs.statSync(historyPath).mode & 0o777, 0o600);
 }
 
 describe("PI_CODING_AGENT_DIR runtime paths", () => {
@@ -167,13 +178,22 @@ Package skill content.
 		assert.ok(available.find((skill) => skill.name === "package-skill" && skill.source === "user-package"));
 	});
 
-	it("records run history and cleans session artifacts under the configured agent dir", () => {
-		recordRun("env-agent", "Inspect", 0, 42);
+	it("records private redacted run history and cleans session artifacts under the configured agent dir", () => {
+		const task = "Inspect customer ACME token=SECRET";
+		recordRun("env-agent", task, 0, 42);
 		const historyPath = path.join(agentDir, "run-history.jsonl");
 		assert.equal(fs.existsSync(historyPath), true);
+		assertPrivateHistoryModes(historyPath);
+
+		const rawHistory = fs.readFileSync(historyPath, "utf-8");
+		assert.doesNotMatch(rawHistory, /Inspect customer|ACME|SECRET/);
+		assert.match(rawHistory, /"task":"\[redacted\]"/);
+		assert.match(rawHistory, /"taskHash":"[a-f0-9]{64}"/);
+
 		const history = loadRunsForAgent("env-agent");
 		assert.equal(history.length, 1);
-		assert.equal(history[0]?.task, "Inspect");
+		assert.equal(history[0]?.task, "[redacted]");
+		assert.equal(history[0]?.taskHash, taskHash(task));
 		assert.equal(history[0]?.status, "ok");
 
 		const artifactPath = path.join(agentDir, "sessions", "session-1", "subagent-artifacts", "old_output.md");
@@ -183,6 +203,33 @@ Package skill content.
 
 		cleanupAllArtifactDirs(0);
 		assert.equal(fs.existsSync(artifactPath), false);
+	});
+
+	it("hardens and redacts existing run history while recording", () => {
+		const historyPath = path.join(agentDir, "run-history.jsonl");
+		fs.mkdirSync(agentDir, { recursive: true, mode: 0o755 });
+		fs.writeFileSync(historyPath, `${JSON.stringify({
+			agent: "env-agent",
+			task: "legacy customer secret",
+			ts: 1,
+			status: "ok",
+			duration: 2,
+		})}\nnot json with pasted secret\n`, { encoding: "utf-8", mode: 0o644 });
+
+		recordRun("env-agent", "new customer secret", 1, 9);
+
+		assertPrivateHistoryModes(historyPath);
+		const rawHistory = fs.readFileSync(historyPath, "utf-8");
+		assert.doesNotMatch(rawHistory, /legacy customer secret|new customer secret|not json with pasted secret/);
+
+		const history = loadRunsForAgent("env-agent");
+		assert.equal(history.length, 2);
+		assert.equal(history[0]?.task, "[redacted]");
+		assert.equal(history[0]?.taskHash, taskHash("new customer secret"));
+		assert.equal(history[0]?.status, "error");
+		assert.equal(history[0]?.exit, 1);
+		assert.equal(history[1]?.task, "[redacted]");
+		assert.equal(history[1]?.taskHash, taskHash("legacy customer secret"));
 	});
 
 	it("uses the configured agent dir for subagent bridge instruction files", () => {


### PR DESCRIPTION
Fixes #534.

This makes `run-history.jsonl` owner-only where supported, redacts stored task prompts, stores a SHA-256 task hash for correlation, and sanitizes legacy history entries best-effort before appending new records.

Validation run locally:
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/pi-coding-agent-dir.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`
- `git diff --check`