### PR TITLE
fix: preserve async resume acceptance metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Kept async resume recovery descriptors from rejecting acceptance metadata written by earlier async runs, and now persist only the public acceptance input needed for safe revival. Thanks to Phil (@philliugithub) for #537.
 - Made `subagent_wait({ id })` wake when a remembered detached foreground child reaches `needs_attention`, so headless parents can answer pending supervisor requests instead of waiting until timeout. Thanks to Mattias Petter Johansson (@mpj) for #554.
 - Made `run-history.jsonl` and its agent directory owner-only where supported, redacted stored task prompts, and retained only a SHA-256 task hash for history correlation. Thanks to @avishkandi for #534.
 - Registered the native child `intercom` fallback before strict tool-allowlist diagnostics run and stopped treating Pi core tools as missing extension tools, preventing read-only scouts and workers from failing before execution when strict child tool allowlists are active.

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -1164,7 +1164,7 @@ export function executeAsyncSingle(
 		...(agentConfig.memory ? { memory: { ...agentConfig.memory } } : {}),
 		...(outputPath ? { outputPath } : {}),
 		outputMode,
-		...(resolvedAcceptance ? { acceptance: resolvedAcceptance } : {}),
+		...(params.acceptance !== undefined ? { acceptance: params.acceptance } : {}),
 		...(controlConfig ? { controlConfig } : {}),
 		...(deadlineAt !== undefined ? { absoluteDeadlineAt: deadlineAt } : {}),
 		...(params.turnBudget ? { initialTurnBudget: params.turnBudget } : {}),

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ASYNC_DIR, RESULTS_DIR, type AsyncStatus, type SteeringRecoveryDescriptor } from "../../shared/types.ts";
+import { ASYNC_DIR, RESULTS_DIR, type AcceptanceInput, type AsyncStatus, type SteeringRecoveryDescriptor } from "../../shared/types.ts";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { validateAcceptanceInput } from "../shared/acceptance.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
@@ -250,6 +250,21 @@ function validateStatusForResume(status: AsyncStatus | null, source: string): vo
 	}
 }
 
+function normalizeRecoveryAcceptance(value: unknown, descriptorPath: string): AcceptanceInput | undefined {
+	if (value && typeof value === "object" && !Array.isArray(value) && ("explicit" in value || "inferredReason" in value)) {
+		const { explicit, inferredReason: _inferredReason, ...publicAcceptance } = value as Record<string, unknown>;
+		if (explicit === false) return undefined;
+		if (publicAcceptance.level === "reviewed") {
+			publicAcceptance.level = "verified";
+			delete publicAcceptance.review;
+		}
+		value = publicAcceptance;
+	}
+	const errors = validateAcceptanceInput(value, "recoveryDescriptor.acceptance");
+	if (errors.length) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${errors.join(" ")}`);
+	return value as AcceptanceInput;
+}
+
 export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): SteeringRecoveryDescriptor | undefined {
 	if (!asyncDir) return undefined;
 	const descriptorPath = path.join(asyncDir, "recovery-descriptor.json");
@@ -335,8 +350,9 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 		if (!Array.isArray(control.notifyChannels) || control.notifyChannels.some((item) => item !== "event" && item !== "async" && item !== "intercom")) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': controlConfig.notifyChannels is invalid.`);
 	}
 	if (parsed.acceptance !== undefined) {
-		const errors = validateAcceptanceInput(parsed.acceptance, "recoveryDescriptor.acceptance");
-		if (errors.length) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${errors.join(" ")}`);
+		const acceptance = normalizeRecoveryAcceptance(parsed.acceptance, descriptorPath);
+		if (acceptance === undefined) delete parsed.acceptance;
+		else parsed.acceptance = acceptance;
 	}
 	return parsed as unknown as SteeringRecoveryDescriptor;
 }

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -2092,6 +2092,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const run = executeAsyncSingle(id, {
 			agent: "worker",
 			task: "Do work",
+			acceptance: { level: "none", reason: "descriptor persistence coverage" },
 			agentConfig: makeAgent("worker", {
 				model: "openai/gpt-5-mini:high",
 				fallbackModels: ["anthropic/claude-sonnet-4:low"],
@@ -2132,6 +2133,9 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.deepEqual(descriptor.fallbackModels, ["anthropic/claude-sonnet-4:low"]);
 		assert.equal(descriptor.cwd, tempDir);
 		assert.equal(descriptor.sessionDir, path.join(sessionRoot, `async-${id}`));
+		assert.deepEqual(descriptor.acceptance, { level: "none", reason: "descriptor persistence coverage" });
+		assert.equal(Object.hasOwn(descriptor.acceptance, "explicit"), false);
+		assert.equal(Object.hasOwn(descriptor.acceptance, "inferredReason"), false);
 		assert.equal(Object.hasOwn(descriptor, "task"), false);
 		if (process.platform !== "win32") assert.equal(fs.statSync(descriptorPath).mode & 0o777, 0o600);
 

--- a/test/unit/async-resume.test.ts
+++ b/test/unit/async-resume.test.ts
@@ -70,6 +70,149 @@ describe("async resume lookup", () => {
 		}
 	});
 
+	it("accepts legacy resolved acceptance metadata in recovery descriptors", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-acceptance-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const asyncDir = path.join(asyncRoot, "run-acceptance");
+			const resultsDir = path.join(root, "results");
+			const sessionFile = path.join(root, "session.jsonl");
+			fs.writeFileSync(sessionFile, "", "utf-8");
+			writeJson(path.join(asyncDir, "status.json"), {
+				runId: "run-acceptance", mode: "single", state: "paused", startedAt: 100, lastUpdate: 200, cwd: root,
+				steps: [{ agent: "worker", status: "paused", sessionFile }],
+			});
+			writeJson(path.join(asyncDir, "recovery-descriptor.json"), {
+				version: 1,
+				sourceRunId: "run-acceptance",
+				agent: "worker",
+				cwd: root,
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+				outputMode: "inline",
+				maxSubagentDepth: 2,
+				share: false,
+				acceptance: {
+					level: "attested",
+					explicit: true,
+					inferredReason: ["async write-capable or risky run"],
+					criteria: [{ id: "criterion-1", must: "Return evidence", evidence: ["manual-notes"], severity: "required" }],
+					evidence: ["manual-notes", "residual-risks"],
+					verify: [],
+					stopRules: [],
+				},
+			});
+
+			const target = resolveAsyncResumeTarget({ id: "run-acceptance" }, { asyncDirRoot: asyncRoot, resultsDir });
+
+			assert.equal(target.kind, "revive");
+			assert.deepEqual(target.recoveryDescriptor?.acceptance, {
+				level: "attested",
+				criteria: [{ id: "criterion-1", must: "Return evidence", evidence: ["manual-notes"], severity: "required" }],
+				evidence: ["manual-notes", "residual-risks"],
+				verify: [],
+				stopRules: [],
+			});
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("downgrades explicit legacy reviewed acceptance metadata in recovery descriptors", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-reviewed-acceptance-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const asyncDir = path.join(asyncRoot, "run-reviewed-acceptance");
+			const resultsDir = path.join(root, "results");
+			const sessionFile = path.join(root, "session.jsonl");
+			fs.writeFileSync(sessionFile, "", "utf-8");
+			writeJson(path.join(asyncDir, "status.json"), {
+				runId: "run-reviewed-acceptance", mode: "single", state: "paused", startedAt: 100, lastUpdate: 200, cwd: root,
+				steps: [{ agent: "worker", status: "paused", sessionFile }],
+			});
+			writeJson(path.join(asyncDir, "recovery-descriptor.json"), {
+				version: 1,
+				sourceRunId: "run-reviewed-acceptance",
+				agent: "worker",
+				cwd: root,
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+				outputMode: "inline",
+				maxSubagentDepth: 2,
+				share: false,
+				acceptance: {
+					level: "reviewed",
+					explicit: true,
+					inferredReason: ["async write-capable or risky run"],
+					criteria: ["Return evidence"],
+					evidence: ["validation-output"],
+					verify: [],
+					review: { agent: "reviewer", required: true },
+					stopRules: [],
+				},
+			});
+
+			const target = resolveAsyncResumeTarget({ id: "run-reviewed-acceptance" }, { asyncDirRoot: asyncRoot, resultsDir });
+
+			assert.equal(target.kind, "revive");
+			assert.deepEqual(target.recoveryDescriptor?.acceptance, {
+				level: "verified",
+				criteria: ["Return evidence"],
+				evidence: ["validation-output"],
+				verify: [],
+				stopRules: [],
+			});
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("drops inferred legacy acceptance metadata from recovery descriptors", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-inferred-acceptance-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const asyncDir = path.join(asyncRoot, "run-inferred-acceptance");
+			const resultsDir = path.join(root, "results");
+			const sessionFile = path.join(root, "session.jsonl");
+			fs.writeFileSync(sessionFile, "", "utf-8");
+			writeJson(path.join(asyncDir, "status.json"), {
+				runId: "run-inferred-acceptance", mode: "single", state: "paused", startedAt: 100, lastUpdate: 200, cwd: root,
+				steps: [{ agent: "worker", status: "paused", sessionFile }],
+			});
+			writeJson(path.join(asyncDir, "recovery-descriptor.json"), {
+				version: 1,
+				sourceRunId: "run-inferred-acceptance",
+				agent: "worker",
+				cwd: root,
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+				outputMode: "inline",
+				maxSubagentDepth: 2,
+				share: false,
+				acceptance: {
+					level: "reviewed",
+					explicit: false,
+					inferredReason: ["async write-capable or risky run"],
+					criteria: [],
+					evidence: [],
+					verify: [],
+					review: { agent: "reviewer", required: true },
+					stopRules: [],
+				},
+			});
+
+			const target = resolveAsyncResumeTarget({ id: "run-inferred-acceptance" }, { asyncDirRoot: asyncRoot, resultsDir });
+
+			assert.equal(target.kind, "revive");
+			assert.equal(target.recoveryDescriptor?.acceptance, undefined);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects stopped runs instead of reviving them", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-stopped-"));
 		try {


### PR DESCRIPTION
Fixes #537.

This keeps recovery descriptors on the public `AcceptanceInput` contract going forward, instead of persisting the resolved internal acceptance metadata. Resume also tolerates descriptors written by older builds by stripping the internal `explicit` and `inferredReason` fields, dropping purely inferred legacy metadata, and mapping legacy resolved `reviewed` metadata to a public `verified` contract so revive does not hit the explicit-reviewed validation path.

Validation:

- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/async-resume.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`
- `git diff --check`
