### PR TITLE
fix: use provider streams for watchdog reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Routed main watchdog reviews through matching provider-scoped `streamSimple` handlers before falling back to the compat dispatcher, restoring custom-provider watchdog models on newer Pi runtimes. Thanks to @alexei-led for #527.
 - Kept async resume recovery descriptors from rejecting acceptance metadata written by earlier async runs, and now persist only the public acceptance input needed for safe revival. Thanks to Phil (@philliugithub) for #537.
 - Made `subagent_wait({ id })` wake when a remembered detached foreground child reaches `needs_attention`, so headless parents can answer pending supervisor requests instead of waiting until timeout. Thanks to Mattias Petter Johansson (@mpj) for #554.
 - Made `run-history.jsonl` and its agent directory owner-only where supported, redacted stored task prompts, and retained only a SHA-256 task hash for history correlation. Thanks to @avishkandi for #534.

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -252,7 +252,12 @@ export function createMainWatchdogReview(provider: WatchdogContextProvider, opti
 		});
 		if (ctx.signal?.aborted || request.signal?.aborted) return { stopReason: "aborted" };
 		const auth = selection.auth;
-		const baseStreamFn = options.streamFn ?? streamSimple;
+		const registeredProvider = (ctx.modelRegistry as {
+			getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
+		}).getRegisteredProviderConfig?.(selection.model.provider);
+		const baseStreamFn = options.streamFn ?? (registeredProvider?.streamSimple && registeredProvider.api === selection.model.api
+			? registeredProvider.streamSimple
+			: streamSimple);
 		const streamFn: StreamFn = (model, context, streamOptions) => baseStreamFn(model, context, {
 			...streamOptions,
 			...(auth.apiKey ? { apiKey: auth.apiKey } : {}),

--- a/test/unit/watchdog-review.test.ts
+++ b/test/unit/watchdog-review.test.ts
@@ -59,6 +59,7 @@ function createCtx(input: {
 	models?: Model<any>[];
 	authenticated?: string[];
 	thinkingLevel?: string;
+	providerConfig?: { provider: string; api: string; streamSimple: StreamFn };
 }) {
 	const allModels = input.models ?? (input.current ? [input.current] : []);
 	const authenticated = new Set(input.authenticated ?? allModels.map((entry) => `${entry.provider}/${entry.id}`));
@@ -75,6 +76,7 @@ function createCtx(input: {
 			getApiKeyAndHeaders: async (entry: Model<any>) => authenticated.has(`${entry.provider}/${entry.id}`)
 				? { ok: true as const, apiKey: `key-${entry.provider}-${entry.id}`, headers: { "x-model": entry.id }, env: { WATCHDOG_PROVIDER: entry.provider } }
 				: { ok: false as const, error: `No auth for ${entry.provider}/${entry.id}` },
+			getRegisteredProviderConfig: (provider: string) => input.providerConfig?.provider === provider ? input.providerConfig : undefined,
 		},
 	} as never;
 }
@@ -274,6 +276,22 @@ describe("main watchdog review adapter", () => {
 			() => resolveWatchdogReviewModel(ctx, enabledConfig({ model: "anthropic/missing-watchdog" })),
 			/was not found.*anthropic\/missing-watchdog/s,
 		);
+	});
+
+	it("uses the registered stream for matching custom providers", async () => {
+		const current = model("custom-provider", "watchdog", { api: "custom-api" });
+		const { streamFn, calls } = createStreamFn([fauxAssistantMessage("clean", { stopReason: "stop" })]);
+		const ctx = createCtx({ current, providerConfig: { provider: current.provider, api: "custom-api", streamSimple: streamFn } });
+		const warnings: WatchdogWarning[] = [];
+
+		const result = await createMainWatchdogReview(ctx)(request(enabledConfig(), warnings));
+
+		assert.equal(result?.stopReason, "stop");
+		assert.equal(calls.length, 1);
+		assert.equal(calls[0]?.model, current);
+		assert.equal(calls[0]?.options?.apiKey, "key-custom-provider-watchdog");
+		assert.equal(calls[0]?.options?.headers?.["x-model"], "watchdog");
+		assert.deepEqual(calls[0]?.options?.env, { WATCHDOG_PROVIDER: "custom-provider" });
 	});
 
 	it("falls back to the current session model and thinking when no watchdog model is configured", async () => {


### PR DESCRIPTION
Fixes #527.

This makes main watchdog review dispatch use the selected provider's registered `streamSimple` when the provider config API matches the selected model API. The existing compat dispatcher remains the fallback, and the existing test seam can still override the stream function directly.

Validation:

- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/watchdog-review.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`
- `git diff --check`
