### PR TITLE
fix: write failure stubs for empty output artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Wrote an explanatory failure stub to output artifacts when a child run ends before producing output, so advertised `_output.md` breadcrumbs are no longer empty. Thanks to Mattias Petter Johansson (@mpj) for #547.
 - Routed main watchdog reviews through matching provider-scoped `streamSimple` handlers before falling back to the compat dispatcher, restoring custom-provider watchdog models on newer Pi runtimes. Thanks to @alexei-led for #527.
 - Kept async resume recovery descriptors from rejecting acceptance metadata written by earlier async runs, and now persist only the public acceptance input needed for safe revival. Thanks to Phil (@philliugithub) for #537.
 - Made `subagent_wait({ id })` wake when a remembered detached foreground child reaches `needs_attention`, so headless parents can answer pending supervisor requests instead of waiting until timeout. Thanks to Mattias Petter Johansson (@mpj) for #554.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -6,7 +6,7 @@ import type { Message } from "@earendil-works/pi-ai";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { createChildTranscriptWriter, type ChildTranscriptWriter } from "../../shared/child-transcript.ts";
 import { closeSteerInbox, consumeInterruptRequest, consumeSteerRequests, deliverInterruptRequest, deliverStopRequest, deliverTimeoutRequest, enqueueStepSteer, steerAcksDir, steerCapabilityPath, stepSteerInboxDir, watchAsyncControlInbox, type SteerAck, type SteerCapability, type SteerRequest } from "./control-channel.ts";
-import { appendJsonl as appendRawJsonl, getArtifactPaths } from "../../shared/artifacts.ts";
+import { appendJsonl as appendRawJsonl, formatOutputArtifactContent, getArtifactPaths } from "../../shared/artifacts.ts";
 import { PI_CODING_AGENT_PACKAGE, getPiSpawnCommand, resolveInstalledPiPackageRoot } from "../shared/pi-spawn.ts";
 import { captureSingleOutputSnapshot, extractChildWrittenOutput, finalizeSingleOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, injectSingleOutputInstruction, resolveSingleOutput, type SingleOutputSnapshot } from "../shared/single-output.ts";
 import {
@@ -1345,7 +1345,12 @@ async function runSingleStep(
 
 	if (artifactPaths && ctx.artifactConfig?.enabled !== false) {
 		if (ctx.artifactConfig?.includeOutput !== false) {
-			fs.writeFileSync(artifactPaths.outputPath, output, "utf-8");
+			fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent({
+				output,
+				error: effectiveFinalError,
+				transcriptPath: transcriptWriter ? artifactPaths.transcriptPath : undefined,
+				metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath,
+			}), "utf-8");
 		}
 		if (ctx.artifactConfig?.includeMetadata !== false) {
 			fs.writeFileSync(

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -9,6 +9,7 @@ import type { Message } from "@earendil-works/pi-ai";
 import type { AgentConfig } from "../../agents/agents.ts";
 import {
 	ensureArtifactsDir,
+	formatOutputArtifactContent,
 	getArtifactPaths,
 	writeArtifact,
 	writeMetadata,
@@ -1402,7 +1403,12 @@ export async function runSync(
 	if (artifactPathsResult && options.artifactConfig?.enabled !== false) {
 		result.artifactPaths = artifactPathsResult;
 		if (options.artifactConfig?.includeOutput !== false) {
-			writeArtifact(artifactPathsResult.outputPath, artifactOutputByResult.get(result) ?? result.finalOutput ?? "");
+			writeArtifact(artifactPathsResult.outputPath, formatOutputArtifactContent({
+				output: artifactOutputByResult.get(result) ?? result.finalOutput ?? "",
+				error: result.error,
+				transcriptPath: result.transcriptPath,
+				metadataPath: options.artifactConfig?.includeMetadata === false ? undefined : artifactPathsResult.metadataPath,
+			}));
 		}
 		if (options.maxOutput) {
 			const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1364,7 +1364,7 @@ function formatFailedSingleRunOutput(result: SingleResult, displayOutput: string
 	if (output && output !== error.trim()) {
 		lines.push("", "Output:", output);
 	}
-	if (result.artifactPaths?.outputPath) {
+	if (result.artifactPaths?.outputPath && fs.existsSync(result.artifactPaths.outputPath)) {
 		lines.push("", `Output artifact: ${result.artifactPaths.outputPath}`);
 	}
 	return lines.join("\n");

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -47,6 +47,19 @@ export function writeArtifact(filePath: string, content: string): void {
 	fs.writeFileSync(filePath, content, "utf-8");
 }
 
+export function formatOutputArtifactContent(input: {
+	output: string;
+	error?: string;
+	transcriptPath?: string;
+	metadataPath?: string;
+}): string {
+	if (input.output.trim() || !input.error) return input.output;
+	const lines = ["Subagent run failed before producing output.", "", "Error:", input.error];
+	if (input.transcriptPath) lines.push("", `Transcript: ${input.transcriptPath}`);
+	if (input.metadataPath) lines.push(`Metadata: ${input.metadataPath}`);
+	return lines.join("\n");
+}
+
 export function writeMetadata(filePath: string, metadata: object): void {
 	fs.writeFileSync(filePath, JSON.stringify(metadata, null, 2), "utf-8");
 }

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -427,6 +427,32 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(payload.results[0]?.error ?? "", /protocol_output_limit/);
 	});
 
+	it("background writes a failure stub to output artifacts when no output was produced", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "", stderr: "model unavailable", exitCode: 1 });
+		const id = `async-empty-failure-artifact-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Fail before output",
+			agentConfig: makeAgent("worker", { completionGuard: false }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: true, includeInput: true, includeOutput: true, includeJsonl: false, includeMetadata: true, cleanupDays: 7 },
+			artifactsDir: path.join(tempDir, ".pi-subagents", "artifacts"),
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+
+		const payload = await readAsyncPayload(id);
+		assert.equal(payload.success, false);
+		const outputPath = payload.results[0]?.artifactPaths?.outputPath;
+		assert.ok(outputPath, "should expose an output artifact path");
+		const artifact = fs.readFileSync(outputPath, "utf-8");
+		assert.match(artifact, /Subagent run failed before producing output\./);
+		assert.match(artifact, /Error:\nmodel unavailable/);
+		assert.match(artifact, /Transcript:/);
+		assert.match(artifact, /Metadata:/);
+	});
+
 	it("background keeps only a bounded UTF-8 stderr tail", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ output: "failed", stderr: `${"x".repeat(MAX_CHILD_STDERR_BYTES + 1024)}终`, exitCode: 1 });
 		const id = `async-stderr-tail-${Date.now().toString(36)}`;

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1499,6 +1499,26 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok(fs.existsSync(artifactsDir), "artifacts dir should exist");
 	});
 
+	it("writes a failure stub to foreground output artifacts when no output was produced", async () => {
+		mockPi.onCall({ output: "", stderr: "model unavailable", exitCode: 1 });
+		const artifactsDir = path.join(tempDir, "artifacts-failed-output");
+
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "failed-no-output",
+			artifactsDir,
+			artifactConfig: { enabled: true, includeInput: true, includeOutput: true, includeMetadata: true },
+			acceptance: false,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.ok(result.artifactPaths?.outputPath, "should expose an output artifact path");
+		const artifact = fs.readFileSync(result.artifactPaths.outputPath, "utf-8");
+		assert.match(artifact, /Subagent run failed before producing output\./);
+		assert.match(artifact, /Error:\nmodel unavailable/);
+		assert.match(artifact, /Transcript:/);
+		assert.match(artifact, /Metadata:/);
+	});
+
 	it("does not surface transcript paths when transcript artifacts are disabled", async () => {
 		mockPi.onCall({ output: "Result text" });
 		const agents = makeAgentConfigs(["echo"]);


### PR DESCRIPTION
Fixes #547.

Failed child runs that produce no final output now write a short explanatory stub into the advertised `_output.md` artifact instead of leaving it empty. The stub includes the error and available transcript/metadata breadcrumbs. The result formatter also avoids printing an output artifact path when that artifact was not written.

Validation:

- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/acceptance-file-report.test.ts test/integration/single-execution.test.ts test/integration/async-execution.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`
- `git diff --check`
