### PR TITLE
fix: allow larger child protocol lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Raised the child stdout line limit above Pi’s resized-image payload range so image OCR subagents no longer fail with `protocol_output_limit` on valid `read` tool image events. Thanks to @zmarty for #538.
 - Wrote an explanatory failure stub to output artifacts when a child run ends before producing output, so advertised `_output.md` breadcrumbs are no longer empty. Thanks to Mattias Petter Johansson (@mpj) for #547.
 - Routed main watchdog reviews through matching provider-scoped `streamSimple` handlers before falling back to the compat dispatcher, restoring custom-provider watchdog models on newer Pi runtimes. Thanks to @alexei-led for #527.
 - Kept async resume recovery descriptors from rejecting acceptance metadata written by earlier async runs, and now persist only the public acceptance input needed for safe revival. Thanks to Phil (@philliugithub) for #537.

--- a/src/runs/shared/child-protocol.ts
+++ b/src/runs/shared/child-protocol.ts
@@ -3,7 +3,7 @@ import type { ProtocolOutputLimit } from "../../shared/types.ts";
 
 export type { ProtocolOutputLimit } from "../../shared/types.ts";
 
-export const MAX_CHILD_PENDING_LINE_BYTES = 4 * 1024 * 1024;
+export const MAX_CHILD_PENDING_LINE_BYTES = 16 * 1024 * 1024;
 export const MAX_CHILD_STDERR_BYTES = 128 * 1024;
 const MAX_PROTOCOL_DIAGNOSTIC_BYTES = 4096;
 

--- a/test/unit/child-protocol.test.ts
+++ b/test/unit/child-protocol.test.ts
@@ -5,6 +5,7 @@ import {
 	createBoundedByteTail,
 	createBoundedLineReader,
 	formatProtocolOutputLimit,
+	MAX_CHILD_PENDING_LINE_BYTES,
 	projectChildLifecycle,
 	type ProtocolOutputLimit,
 } from "../../src/runs/shared/child-protocol.ts";
@@ -28,6 +29,18 @@ describe("bounded child protocol reader", () => {
 		reader.push(bytes.subarray(split));
 		reader.end();
 		assert.deepEqual(lines, ['{"text":"你好"}']);
+	});
+
+	it("accepts Pi-sized image payload lines by default", () => {
+		const lines: string[] = [];
+		const reader = createBoundedLineReader({ onLine: (line) => lines.push(line), onLimit: () => assert.fail("unexpected limit") });
+		const imageSizedLine = "x".repeat(5 * 1024 * 1024);
+		reader.push(imageSizedLine);
+		reader.push("\n");
+		reader.end();
+		assert.equal(MAX_CHILD_PENDING_LINE_BYTES, 16 * 1024 * 1024);
+		assert.equal(lines.length, 1);
+		assert.equal(lines[0]?.length, imageSizedLine.length);
 	});
 
 	it("stops buffering an oversized line and returns bounded diagnostics", () => {


### PR DESCRIPTION
Fixes #538.

Raises the child stdout pending-line guard from 4 MiB to 16 MiB so Pi-sized resized image payloads from `read` tool events can pass through the subagent protocol instead of tripping `protocol_output_limit`. The smaller explicit-limit path still fails with bounded diagnostics.

Validation:

- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/child-protocol.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`
- `git diff --check`
