### PR TITLE
fix: bound watchdog repo signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Bounded main-watchdog repository signatures so startup and agent-end checks no longer recurse through nested Git worktrees or generated dependency trees, reducing slow starts in large repos. Thanks to @pompanonb for #551 and @markg85 for #555.
 - Raised the child stdout line limit above Pi’s resized-image payload range so image OCR subagents no longer fail with `protocol_output_limit` on valid `read` tool image events. Thanks to @zmarty for #538.
 - Wrote an explanatory failure stub to output artifacts when a child run ends before producing output, so advertised `_output.md` breadcrumbs are no longer empty. Thanks to Mattias Petter Johansson (@mpj) for #547.
 - Routed main watchdog reviews through matching provider-scoped `streamSimple` handlers before falling back to the compat dispatcher, restoring custom-provider watchdog models on newer Pi runtimes. Thanks to @alexei-led for #527.

--- a/src/watchdog/change-signature.ts
+++ b/src/watchdog/change-signature.ts
@@ -5,15 +5,29 @@ import * as path from "node:path";
 
 const IGNORED_CHANGE_PREFIXES = [".pi-subagents/", "tmp/", "node_modules/"];
 const IGNORED_CHANGE_PATHS = new Set([".pi-subagents", "tmp", "node_modules"]);
+const IGNORED_CHANGE_SEGMENTS = new Set([".git", ".pi-subagents", "node_modules"]);
 
 const DEFAULT_MAX_HASH_FILE_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_HASH_TOTAL_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_HASH_ENTRIES = 2_000;
 
-// Read at call time (not module load) so PI_SUBAGENTS_MAX_HASH_FILE_BYTES can be
-// overridden by tests after this module is imported. Falls back to the 64 MiB
-// default when the env value is missing, non-numeric, non-finite, or <= 0.
+function positiveEnvNumber(name: string, fallback: number): number {
+	const parsed = Number(process.env[name]);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+// Read at call time (not module load) so tests can override env guards after
+// this module is imported.
 function maxHashFileBytes(): number {
-	const parsed = Number(process.env.PI_SUBAGENTS_MAX_HASH_FILE_BYTES);
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_HASH_FILE_BYTES;
+	return positiveEnvNumber("PI_SUBAGENTS_MAX_HASH_FILE_BYTES", DEFAULT_MAX_HASH_FILE_BYTES);
+}
+
+function maxHashTotalBytes(): number {
+	return positiveEnvNumber("PI_SUBAGENTS_MAX_HASH_TOTAL_BYTES", DEFAULT_MAX_HASH_TOTAL_BYTES);
+}
+
+function maxHashEntries(): number {
+	return positiveEnvNumber("PI_SUBAGENTS_MAX_HASH_ENTRIES", DEFAULT_MAX_HASH_ENTRIES);
 }
 
 export interface WatchdogRepoChangeSignature {
@@ -34,7 +48,22 @@ function normalizeRelPath(value: string): string {
 
 function ignoredRelPath(relPath: string): boolean {
 	const normalized = normalizeRelPath(relPath);
-	return IGNORED_CHANGE_PATHS.has(normalized) || IGNORED_CHANGE_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+	return IGNORED_CHANGE_PATHS.has(normalized)
+		|| IGNORED_CHANGE_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+		|| normalized.split("/").some((segment) => IGNORED_CHANGE_SEGMENTS.has(segment));
+}
+
+interface HashBudget {
+	entries: number;
+	bytes: number;
+	maxEntries: number;
+	maxBytes: number;
+}
+
+function useHashEntryBudget(budget: HashBudget): boolean {
+	if (budget.entries >= budget.maxEntries) return false;
+	budget.entries++;
+	return true;
 }
 
 function hashFile(filePath: string): string {
@@ -45,13 +74,14 @@ function largeFileHash(stat: fs.Stats): string {
 	return "large:" + stat.size + ":" + Math.floor(stat.mtimeMs);
 }
 
-function hashFileEntry(normalized: string, fullPath: string, stat: fs.Stats): unknown {
+function hashFileEntry(normalized: string, fullPath: string, stat: fs.Stats, budget: HashBudget): unknown {
 	let hash: string;
-	if (stat.size > maxHashFileBytes()) {
+	if (stat.size > maxHashFileBytes() || budget.bytes + stat.size > budget.maxBytes) {
 		hash = largeFileHash(stat);
 	} else {
 		try {
 			hash = hashFile(fullPath);
+			budget.bytes += stat.size;
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			// A file racing away between lstat and read: mirror the lstat ENOENT path.
@@ -67,8 +97,20 @@ function hashFileEntry(normalized: string, fullPath: string, stat: fs.Stats): un
 	return { path: normalized, state: "file", mode: stat.mode & 0o777, size: stat.size, hash };
 }
 
-function hashPath(root: string, relPath: string): unknown {
+function gitWorktreeEntry(normalized: string, fullPath: string): unknown {
+	const status = git(fullPath, ["status", "--porcelain=v1", "-z", "--untracked-files=no"]);
+	return {
+		path: normalized,
+		state: "git-worktree",
+		head: git(fullPath, ["rev-parse", "HEAD"])?.trim(),
+		dirty: Boolean(status),
+		statusKey: status ? createHash("sha256").update(status).digest("hex") : undefined,
+	};
+}
+
+function hashPath(root: string, relPath: string, budget: HashBudget): unknown {
 	const normalized = normalizeRelPath(relPath);
+	if (!useHashEntryBudget(budget)) return { path: normalized, state: "skipped", reason: "entry-limit" };
 	const fullPath = path.join(root, normalized);
 	let stat: fs.Stats;
 	try {
@@ -81,22 +123,20 @@ function hashPath(root: string, relPath: string): unknown {
 		return { path: normalized, state: "symlink", target: fs.readlinkSync(fullPath) };
 	}
 	if (stat.isDirectory()) {
-		if (fs.existsSync(path.join(fullPath, ".git"))) {
-			const changes = computeWatchdogRepoChangeSignature(fullPath);
-			return {
-				path: normalized,
-				state: "git-worktree",
-				head: git(fullPath, ["rev-parse", "HEAD"])?.trim(),
-				changes: changes ? { key: changes.key, changedPaths: changes.changedPaths } : undefined,
-			};
-		}
+		if (fs.existsSync(path.join(fullPath, ".git"))) return gitWorktreeEntry(normalized, fullPath);
 		const entries = fs.readdirSync(fullPath)
 			.map((entry) => normalizeRelPath(path.posix.join(normalized, entry)))
 			.filter((entry) => !ignoredRelPath(entry))
 			.sort();
-		return { path: normalized, state: "dir", entries: entries.map((entry) => hashPath(root, entry)) };
+		const remainingEntries = Math.max(0, budget.maxEntries - budget.entries);
+		const selectedEntries = entries.slice(0, remainingEntries);
+		const childEntries = selectedEntries.map((entry) => hashPath(root, entry, budget));
+		if (selectedEntries.length < entries.length) {
+			childEntries.push({ path: normalized, state: "skipped-children", reason: "entry-limit", count: entries.length - selectedEntries.length });
+		}
+		return { path: normalized, state: "dir", entries: childEntries };
 	}
-	if (stat.isFile()) return hashFileEntry(normalized, fullPath, stat);
+	if (stat.isFile()) return hashFileEntry(normalized, fullPath, stat, budget);
 	return { path: normalized, state: "other", mode: stat.mode };
 }
 
@@ -127,10 +167,11 @@ function buildRepoChangeSignature(root: string, statusOutput: string): WatchdogR
 		.filter((entry) => entry.paths.length > 0)
 		.sort((a, b) => `${a.status} ${a.paths.join("\0")}`.localeCompare(`${b.status} ${b.paths.join("\0")}`));
 	const changedPaths = [...new Set(entries.flatMap((entry) => entry.paths))].sort();
+	const budget: HashBudget = { entries: 0, bytes: 0, maxEntries: maxHashEntries(), maxBytes: maxHashTotalBytes() };
 	const payload = entries.map((entry) => ({
 		status: entry.status,
 		paths: entry.paths,
-		content: entry.paths.map((relPath) => hashPath(root, relPath)),
+		content: entry.paths.map((relPath) => hashPath(root, relPath, budget)),
 	}));
 	const key = createHash("sha256").update(JSON.stringify(payload)).digest("hex");
 	return { root, key, changedPaths };

--- a/test/unit/watchdog-change-signature.test.ts
+++ b/test/unit/watchdog-change-signature.test.ts
@@ -57,7 +57,7 @@ function createRepo(prefix: string): string {
 }
 
 describe("watchdog change signature", () => {
-	it("hashes modified submodules through Git without traversing ignored dependencies", (t) => {
+	it("summarizes modified submodules as opaque Git worktrees", (t) => {
 		const childSource = createRepo("watchdog-child-");
 		const parent = createRepo("watchdog-parent-");
 		const checkout = path.join(parent, "vendor", "child");
@@ -74,6 +74,8 @@ describe("watchdog change signature", () => {
 
 		git(parent, ["-c", "protocol.file.allow=always", "submodule", "add", childSource, "vendor/child"]);
 		git(parent, ["commit", "-am", "add submodule"]);
+		git(checkout, ["config", "user.email", "watchdog@example.com"]);
+		git(checkout, ["config", "user.name", "Watchdog Tests"]);
 
 		fs.mkdirSync(path.dirname(ignoredFile), { recursive: true });
 		fs.writeFileSync(ignoredFile, "ignored one\n", "utf-8");
@@ -87,8 +89,13 @@ describe("watchdog change signature", () => {
 		assert.equal(ignoredOnly?.key, first?.key);
 
 		fs.writeFileSync(path.join(checkout, "tracked.txt"), "three\n", "utf-8");
-		const trackedChange = computeWatchdogRepoChangeSignature(parent);
-		assert.notEqual(trackedChange?.key, first?.key);
+		const stillDirty = computeWatchdogRepoChangeSignature(parent);
+		assert.equal(stillDirty?.key, first?.key, "dirty submodule content is intentionally opaque");
+
+		git(checkout, ["add", "tracked.txt"]);
+		git(checkout, ["commit", "-m", "update tracked"]);
+		const headChange = computeWatchdogRepoChangeSignature(parent);
+		assert.notEqual(headChange?.key, first?.key, "submodule HEAD changes remain visible");
 	});
 
 	function setThreshold(bytes: number, t: { after: (fn: () => void) => void }): void {
@@ -97,6 +104,24 @@ describe("watchdog change signature", () => {
 		t.after(() => {
 			if (previous === undefined) delete process.env.PI_SUBAGENTS_MAX_HASH_FILE_BYTES;
 			else process.env.PI_SUBAGENTS_MAX_HASH_FILE_BYTES = previous;
+		});
+	}
+
+	function setTotalThreshold(bytes: number, t: { after: (fn: () => void) => void }): void {
+		const previous = process.env.PI_SUBAGENTS_MAX_HASH_TOTAL_BYTES;
+		process.env.PI_SUBAGENTS_MAX_HASH_TOTAL_BYTES = String(bytes);
+		t.after(() => {
+			if (previous === undefined) delete process.env.PI_SUBAGENTS_MAX_HASH_TOTAL_BYTES;
+			else process.env.PI_SUBAGENTS_MAX_HASH_TOTAL_BYTES = previous;
+		});
+	}
+
+	function setEntryThreshold(entries: number, t: { after: (fn: () => void) => void }): void {
+		const previous = process.env.PI_SUBAGENTS_MAX_HASH_ENTRIES;
+		process.env.PI_SUBAGENTS_MAX_HASH_ENTRIES = String(entries);
+		t.after(() => {
+			if (previous === undefined) delete process.env.PI_SUBAGENTS_MAX_HASH_ENTRIES;
+			else process.env.PI_SUBAGENTS_MAX_HASH_ENTRIES = previous;
 		});
 	}
 
@@ -123,6 +148,52 @@ describe("watchdog change signature", () => {
 		fs.utimesSync(filePath, laterMtime, laterMtime);
 		const afterMtime = computeWatchdogRepoChangeSignature(repo);
 		assert.notEqual(afterMtime?.key, sig?.key, "mtime-only change must alter the key for large files");
+	});
+
+	it("uses metadata markers after the total content hash budget", (t) => {
+		const repo = createRepo("watchdog-total-budget-");
+		t.after(() => fs.rmSync(repo, { recursive: true, force: true }));
+		setTotalThreshold(10, t);
+
+		const aPath = path.join(repo, "a.txt");
+		const bPath = path.join(repo, "b.txt");
+		const mtime = new Date(1_600_000_000_000);
+		fs.writeFileSync(aPath, "aaaaaaaa");
+		fs.writeFileSync(bPath, "bbbbbbbb");
+		fs.utimesSync(aPath, mtime, mtime);
+		fs.utimesSync(bPath, mtime, mtime);
+
+		const first = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(first, "expected a signature");
+
+		fs.writeFileSync(bPath, "cccccccc");
+		fs.utimesSync(bPath, mtime, mtime);
+		assert.equal(computeWatchdogRepoChangeSignature(repo)?.key, first?.key, "over-budget files use size+mtime metadata instead of content");
+
+		fs.writeFileSync(aPath, "dddddddd");
+		fs.utimesSync(aPath, mtime, mtime);
+		assert.notEqual(computeWatchdogRepoChangeSignature(repo)?.key, first?.key, "within-budget files are still content hashed");
+	});
+
+	it("uses skipped markers after the entry budget", (t) => {
+		const repo = createRepo("watchdog-entry-budget-");
+		t.after(() => fs.rmSync(repo, { recursive: true, force: true }));
+		setEntryThreshold(3, t);
+
+		const dir = path.join(repo, "files");
+		fs.mkdirSync(dir);
+		for (const name of ["a.txt", "b.txt", "c.txt", "d.txt"]) {
+			fs.writeFileSync(path.join(dir, name), `${name}\n`, "utf-8");
+		}
+
+		const first = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(first, "expected a signature");
+
+		fs.writeFileSync(path.join(dir, "d.txt"), "changed d\n", "utf-8");
+		assert.equal(computeWatchdogRepoChangeSignature(repo)?.key, first?.key, "over-budget entries are summarized instead of hashed individually");
+
+		fs.writeFileSync(path.join(dir, "a.txt"), "changed a\n", "utf-8");
+		assert.notEqual(computeWatchdogRepoChangeSignature(repo)?.key, first?.key, "within-budget entries are still content hashed");
 	});
 
 	it("produces deterministic keys keyed on size and mtime for large files", (t) => {
@@ -165,6 +236,26 @@ describe("watchdog change signature", () => {
 		const sig = computeWatchdogRepoChangeSignature(repo);
 		assert.ok(sig, "expected a signature");
 		assert.ok(sig?.changedPaths.includes("huge.bin"));
+	});
+
+	it("ignores node_modules below changed directories", (t) => {
+		const repo = createRepo("watchdog-nested-ignored-");
+		t.after(() => fs.rmSync(repo, { recursive: true, force: true }));
+
+		const subdir = path.join(repo, "nested");
+		fs.mkdirSync(path.join(subdir, "node_modules"), { recursive: true });
+		fs.writeFileSync(path.join(subdir, "keep.txt"), "one\n", "utf-8");
+		fs.writeFileSync(path.join(subdir, "node_modules", "cache.bin"), "ignored one\n", "utf-8");
+
+		const first = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(first?.changedPaths.includes("nested/keep.txt"));
+		assert.ok(!first?.changedPaths.some((relPath) => relPath.includes("node_modules")));
+
+		fs.writeFileSync(path.join(subdir, "node_modules", "cache.bin"), "ignored two\n", "utf-8");
+		assert.equal(computeWatchdogRepoChangeSignature(repo)?.key, first?.key);
+
+		fs.writeFileSync(path.join(subdir, "keep.txt"), "two\n", "utf-8");
+		assert.notEqual(computeWatchdogRepoChangeSignature(repo)?.key, first?.key);
 	});
 
 	it("applies the threshold guard recursively into untracked subdirectories", (t) => {


### PR DESCRIPTION
Fixes #551.
Fixes #555.

Bounds main-watchdog repository signatures so enabled watchdog checks no longer recursively hash nested Git worktrees, nested `node_modules`, or unbounded changed trees on the main thread. Nested Git worktrees are summarized by HEAD and cheap dirty status instead of recursively walking their contents; generated dependency directories are ignored at any depth; and total content bytes plus entry counts are capped with stable metadata/skipped markers.

Current main already avoids repository signature work while the watchdog is default-off. This change reduces the remaining enabled-watchdog startup/agent-end risk in large repos and keeps the default-off startup path covered by the existing runtime regression.

Validation:

- `node --experimental-strip-types --test test/unit/watchdog-change-signature.test.ts test/unit/watchdog-runtime.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`
- `git diff --check`
- `git diff --cached --check`
