### PR TITLE
feat: add searchable selector to subagents-admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Replaced the flat `/subagents` admin model, thinking, and agent pickers with a searchable, bounded-scroll selector docked in place of the editor, matching Pi's built-in `/model` picker so the current selection no longer scrolls off screen when the option list is long.
 - Added `advisor` as an `oracle`-compatible bundled agent alias for users switching between Claude Code and Pi naming. Thanks to Serhii Chernenko (@serhii-chernenko) for #552.
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 

--- a/src/slash/selector.ts
+++ b/src/slash/selector.ts
@@ -1,0 +1,147 @@
+import { DynamicBorder, keyHint, rawKeyHint, type Theme } from "@earendil-works/pi-coding-agent";
+import { Container, fuzzyFilter, Input, type KeybindingsManager, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
+
+/** A single selectable row. `value` is returned on confirm; `label` is the primary text. */
+export interface SelectorItem {
+	value: string;
+	label: string;
+	/** Optional dimmed badge shown after the label (e.g. a provider name). */
+	badge?: string;
+	/** Marks the current selection (rendered with a ✓ checkmark). */
+	current?: boolean;
+}
+
+export interface SelectorResult {
+	confirmed: boolean;
+	value?: string;
+}
+
+export interface SelectorOptions {
+	title: string;
+	/** Optional dimmed hint line under the title (e.g. the current value). */
+	subtitle?: string;
+	items: SelectorItem[];
+	done: (result: SelectorResult) => void;
+}
+
+const MAX_VISIBLE = 10;
+
+/**
+ * A single-select list with a search field and a bounded scroll window that keeps the
+ * highlighted row on screen with an `(n/total)` indicator, so the selection never scrolls
+ * out of view when the option list is long. Composed from pi's own TUI primitives so it
+ * matches the built-in `/model` picker.
+ *
+ * Colors come from the `theme` passed to the factory: the module-level `theme` singleton
+ * is undefined under the extension's jiti module cache.
+ */
+export class SelectorComponent extends Container {
+	private readonly tui: TUI;
+	private readonly theme: Theme;
+	private readonly keybindings: KeybindingsManager;
+	private readonly items: SelectorItem[];
+	private readonly done: (result: SelectorResult) => void;
+
+	private readonly searchInput: Input;
+	private readonly listContainer: Container;
+	private filtered: SelectorItem[];
+	private selectedIndex = 0;
+
+	constructor(tui: TUI, theme: Theme, keybindings: KeybindingsManager, options: SelectorOptions) {
+		super();
+		this.tui = tui;
+		this.theme = theme;
+		this.keybindings = keybindings;
+		this.items = options.items;
+		this.done = options.done;
+		this.filtered = [...this.items];
+
+		const border = () => new DynamicBorder((str) => theme.fg("border", str));
+		this.addChild(border());
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg("accent", theme.bold(options.title)), 0, 0));
+		if (options.subtitle) this.addChild(new Text(theme.fg("muted", options.subtitle), 0, 0));
+		this.addChild(new Spacer(1));
+
+		this.searchInput = new Input();
+		this.searchInput.focused = true;
+		this.searchInput.onSubmit = () => this.confirmSelection();
+		this.addChild(this.searchInput);
+		this.addChild(new Spacer(1));
+
+		this.listContainer = new Container();
+		this.addChild(this.listContainer);
+		this.addChild(new Spacer(1));
+
+		this.addChild(new Text(rawKeyHint("↑↓", "navigate") + "  " + keyHint("tui.select.confirm", "select") + "  " + keyHint("tui.select.cancel", "cancel"), 0, 0));
+		this.addChild(new Spacer(1));
+		this.addChild(border());
+
+		const currentIndex = this.filtered.findIndex((item) => item.current);
+		if (currentIndex >= 0) this.selectedIndex = currentIndex;
+		this.updateList();
+	}
+
+	private applyFilter(query: string): void {
+		const previous = this.filtered[this.selectedIndex]?.value;
+		this.filtered = query
+			? fuzzyFilter(this.items, query, (item) => `${item.label} ${item.value} ${item.badge ?? ""}`)
+			: [...this.items];
+		const keepIndex = this.filtered.findIndex((item) => item.value === previous);
+		this.selectedIndex = keepIndex >= 0 ? keepIndex : Math.min(this.selectedIndex, Math.max(0, this.filtered.length - 1));
+		this.updateList();
+	}
+
+	private updateList(): void {
+		const th = this.theme;
+		this.listContainer.clear();
+		const startIndex = Math.max(0, Math.min(this.selectedIndex - Math.floor(MAX_VISIBLE / 2), this.filtered.length - MAX_VISIBLE));
+		const endIndex = Math.min(startIndex + MAX_VISIBLE, this.filtered.length);
+
+		for (let i = startIndex; i < endIndex; i++) {
+			const item = this.filtered[i]!;
+			const isSelected = i === this.selectedIndex;
+			const badge = item.badge ? ` ${th.fg("muted", `[${item.badge}]`)}` : "";
+			const checkmark = item.current ? th.fg("success", " ✓") : "";
+			const line = isSelected
+				? `${th.fg("accent", "→ ")}${th.fg("accent", item.label)}${badge}${checkmark}`
+				: `  ${item.label}${badge}${checkmark}`;
+			this.listContainer.addChild(new Text(line, 0, 0));
+		}
+
+		if (startIndex > 0 || endIndex < this.filtered.length) {
+			this.listContainer.addChild(new Text(th.fg("muted", `  (${this.selectedIndex + 1}/${this.filtered.length})`), 0, 0));
+		}
+		if (this.filtered.length === 0) {
+			this.listContainer.addChild(new Text(th.fg("muted", "  No matching entries"), 0, 0));
+		}
+	}
+
+	private confirmSelection(): void {
+		const selected = this.filtered[this.selectedIndex];
+		this.done(selected ? { confirmed: true, value: selected.value } : { confirmed: false });
+	}
+
+	handleInput(keyData: string): void {
+		const kb = this.keybindings;
+		if (kb.matches(keyData, "tui.select.up")) {
+			if (this.filtered.length === 0) return;
+			this.selectedIndex = this.selectedIndex === 0 ? this.filtered.length - 1 : this.selectedIndex - 1;
+			this.updateList();
+			this.tui.requestRender();
+		} else if (kb.matches(keyData, "tui.select.down")) {
+			if (this.filtered.length === 0) return;
+			this.selectedIndex = this.selectedIndex === this.filtered.length - 1 ? 0 : this.selectedIndex + 1;
+			this.updateList();
+			this.tui.requestRender();
+		} else if (kb.matches(keyData, "tui.select.confirm")) {
+			this.confirmSelection();
+		} else if (kb.matches(keyData, "tui.select.cancel")) {
+			this.done({ confirmed: false });
+		} else {
+			this.searchInput.handleInput(keyData);
+			this.applyFilter(this.searchInput.getValue());
+			this.tui.requestRender();
+		}
+	}
+}

--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -16,6 +16,7 @@ import { serializeAgent } from "../agents/agent-serializer.ts";
 import { editableAgentConfig, preservedAgentFrontmatterFields } from "../agents/agent-management.ts";
 import { findModelInfo, getSupportedThinkingLevels, toModelInfo } from "../shared/model-info.ts";
 import { editorLabel, resolveEditorCommand, runEditorAndWait } from "./subagents-editor.ts";
+import { SelectorComponent, type SelectorItem, type SelectorResult } from "./selector.ts";
 
 const ADMIN_MESSAGE_TYPE = "subagents-admin";
 const INHERIT_MODEL_CHOICE = "Default / inherit session model";
@@ -50,6 +51,10 @@ function agentChoices(agents: AgentConfig[]): Map<string, AgentConfig> {
 		const label = labels[index]!;
 		return [counts.get(label) === 1 ? label : `${label} · ${agent.filePath}`, agent] as const;
 	}));
+}
+
+function agentSelectItems(byLabel: Map<string, AgentConfig>): SelectorItem[] {
+	return [...byLabel.keys()].map((label) => ({ value: label, label }));
 }
 
 function agentMatches(agent: AgentConfig, rawName: string): boolean {
@@ -156,7 +161,7 @@ async function selectAgent(ctx: ExtensionContext, args: string): Promise<AgentSe
 		if (matches.length > 1 && !ctx.hasUI) return { kind: "ambiguous", requestedName, matches };
 		if (matches.length > 1) {
 			const byLabel = agentChoices(matches);
-			const choice = await ctx.ui.select(`Multiple subagents named '${requestedName}'`, [...byLabel.keys()]);
+			const choice = await selectFromList(ctx, `Multiple subagents named '${requestedName}'`, undefined, agentSelectItems(byLabel));
 			return choice ? { kind: "selected", agent: byLabel.get(choice)! } : { kind: "cancelled" };
 		}
 		return { kind: "not-found", agents, requestedName };
@@ -164,7 +169,7 @@ async function selectAgent(ctx: ExtensionContext, args: string): Promise<AgentSe
 
 	if (!ctx.hasUI) return { kind: "not-found", agents };
 	const byLabel = agentChoices(agents);
-	const choice = await ctx.ui.select("Select subagent", [...byLabel.keys()]);
+	const choice = await selectFromList(ctx, "Select subagent", undefined, agentSelectItems(byLabel));
 	return choice ? { kind: "selected", agent: byLabel.get(choice)! } : { kind: "cancelled" };
 }
 
@@ -198,13 +203,33 @@ function metadataFor(agent: AgentConfig): string {
 	return lines.join("\n");
 }
 
+async function selectFromList(ctx: ExtensionContext, title: string, subtitle: string | undefined, items: SelectorItem[]): Promise<string | undefined> {
+	if (typeof ctx.ui.custom === "function") {
+		const result = await ctx.ui.custom<SelectorResult>(
+			(tui, theme, kb, done) => new SelectorComponent(tui, theme, kb, { title, subtitle, items, done }),
+			{ overlay: false },
+		);
+		return result?.confirmed ? result.value : undefined;
+	}
+	const flatTitle = subtitle ? `${title}\nCurrent: ${subtitle}` : title;
+	const labelToValue = new Map(items.map((item) => [item.label, item.value] as const));
+	const choice = await ctx.ui.select(flatTitle, items.map((item) => item.label));
+	return choice ? labelToValue.get(choice) : undefined;
+}
+
 async function chooseModel(ctx: ExtensionContext, agent: AgentConfig): Promise<string | undefined | null> {
-	const models = liveAvailableModels(ctx).map((model) => modelFullId(model));
+	const models = liveAvailableModels(ctx);
 	const current = agent.model ?? INHERIT_MODEL_CHOICE;
-	const choices = [INHERIT_MODEL_CHOICE, ...models.filter((model) => model !== agent.model)];
-	if (agent.model && !choices.includes(agent.model)) choices.splice(1, 0, agent.model);
-	const choice = await ctx.ui.select(`Select model for ${agent.name}\nCurrent: ${current}`, choices);
-	if (!choice) return null;
+	const items: SelectorItem[] = [{ value: INHERIT_MODEL_CHOICE, label: INHERIT_MODEL_CHOICE, current: !agent.model }];
+	if (agent.model && !models.some((model) => modelFullId(model) === agent.model)) {
+		items.push({ value: agent.model, label: agent.model, current: true });
+	}
+	for (const model of models) {
+		const fullId = modelFullId(model);
+		items.push({ value: fullId, label: model.id, badge: model.provider, current: fullId === agent.model });
+	}
+	const choice = await selectFromList(ctx, `Select model for ${agent.name}`, current, items);
+	if (choice === undefined) return null;
 	return choice === INHERIT_MODEL_CHOICE ? undefined : choice;
 }
 
@@ -214,18 +239,16 @@ async function chooseThinking(ctx: ExtensionContext, agent: AgentConfig): Promis
 	const modelInfo = findModelInfo(effectiveModel, availableModels, ctx.model?.provider);
 	const levels = getSupportedThinkingLevels(modelInfo);
 	const current = agent.thinking === false ? "off" : agent.thinking ?? INHERIT_THINKING_CHOICE;
-	const choices: string[] = [INHERIT_THINKING_CHOICE, ...levels];
-	if (current !== INHERIT_THINKING_CHOICE && !choices.includes(current)) choices.splice(1, 0, current);
+	const values: string[] = [INHERIT_THINKING_CHOICE, ...levels];
+	if (current !== INHERIT_THINKING_CHOICE && !values.includes(current)) values.splice(1, 0, current);
 	const modelNote = agent.model
 		? `Model: ${agent.model}`
 		: effectiveModel
 			? `Session model: ${effectiveModel}`
 			: "Model: default / inherit";
-	const choice = await ctx.ui.select(
-		`Select thinking level for ${agent.name}\n${modelNote} · Current: ${current}`,
-		choices,
-	);
-	if (!choice) return null;
+	const items: SelectorItem[] = values.map((value) => ({ value, label: value, current: value === current }));
+	const choice = await selectFromList(ctx, `Select thinking level for ${agent.name}`, `${modelNote} · ${current}`, items);
+	if (choice === undefined) return null;
 	return choice === INHERIT_THINKING_CHOICE ? undefined : choice;
 }
 


### PR DESCRIPTION
## Summary

The `/subagents` admin flow presented its model, thinking, and agent choices through the flat `ctx.ui.select` list, which renders every option without a scroll window or search. With many models or agents the list grows past the viewport and the current selection scrolls off the top, so you cannot see what is selected.

This replaces those pickers with a searchable, bounded-scroll selector that mirrors Pi's built-in `/model` picker: a fixed header, a live search field, and a scroll window that keeps the highlighted row on screen with an `(n/total)` indicator and a `✓` on the current value.

## Changes

- Add `src/slash/selector.ts`: a reusable `SelectorComponent` built from Pi's own TUI primitives (`Container`/`Input`/`Text`/`Spacer`/`DynamicBorder` + `fuzzyFilter`), so it inherits the look and search behavior of the built-in selector.
- Route `chooseModel`, `chooseThinking`, and `selectAgent` (both the "Select subagent" list and the ambiguous-name disambiguation) through a `selectFromList` helper.
- The selector docks in place of the editor (`overlay: false`), matching the native `/model` picker rather than floating a centered overlay.
- Fall back to `ctx.ui.select` when a custom overlay is unavailable (RPC/print modes without a TUI).

## Notes

- Colors come from the `theme` passed to the `ctx.ui.custom` factory, since the module-level `theme` singleton is undefined under the extension's jiti module cache.
- Test suite result is unchanged from `main` (same 1310 pass / 10 pre-existing fail on this environment); no new failures are introduced, and no test imports the changed selector paths beyond the existing slash-command integration coverage.
