### PR TITLE
fix: chain outputs now leave the building

### DIFF
--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -666,6 +666,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 	let prev = "";
 	let globalTaskIndex = 0;
 	let progressCreated = false;
+	const collectedOutputPaths: string[] = [];
 
 	for (let stepIndex = 0; stepIndex < chainSteps.length; stepIndex++) {
 		const step = chainSteps[stepIndex]!;
@@ -708,6 +709,11 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 						: undefined;
 					const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Parallel chain step ${stepIndex + 1} task ${taskIndex + 1} (${step.parallel[taskIndex]!.agent})`);
 					if (validationError) return buildChainExecutionErrorResult(validationError, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex + taskIndex }));
+				}
+				for (const pb of parallelBehaviors) {
+					if (typeof pb.output === "string" && !path.isAbsolute(pb.output)) {
+						collectedOutputPaths.push(pb.output);
+					}
 				}
 				progressCreated = ensureParallelProgressFile(chainDir, progressCreated, parallelBehaviors);
 				createParallelDirs(chainDir, stepIndex, step.parallel.length, agentNames);
@@ -931,6 +937,11 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					return buildChainExecutionErrorResult(validationError, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex + taskIndex }));
 				}
 			}
+			for (const pb of parallelBehaviors) {
+				if (typeof pb.output === "string" && !path.isAbsolute(pb.output)) {
+					collectedOutputPaths.push(pb.output);
+				}
+			}
 
 			progressCreated = ensureParallelProgressFile(chainDir, progressCreated, parallelBehaviors);
 			createParallelDirs(chainDir, stepIndex, dynamicParallelStep.parallel.length, dynamicParallelStep.parallel.map((task) => task.agent));
@@ -1144,6 +1155,9 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			const outputPath = typeof behavior.output === "string"
 				? (path.isAbsolute(behavior.output) ? behavior.output : path.join(chainDir, behavior.output))
 				: undefined;
+			if (typeof behavior.output === "string" && !path.isAbsolute(behavior.output)) {
+				collectedOutputPaths.push(behavior.output);
+			}
 			stepTask = injectSingleOutputInstruction(stepTask, outputPath, agentConfig);
 			const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Chain step ${stepIndex + 1} (${seqStep.agent})`);
 			if (validationError) {
@@ -1326,6 +1340,20 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 
 			if (seqStep.as) outputs[seqStep.as] = outputEntryFromResult(r, stepIndex);
 			prev = getSingleResultOutput(r);
+		}
+	}
+
+	// Persist chain outputs from chainDir back to CWD
+	const outputCwd = cwd ?? ctx.cwd;
+	for (const relPath of collectedOutputPaths) {
+		try {
+			const src = path.join(chainDir, relPath);
+			if (!fs.existsSync(src)) continue;
+			const dest = path.join(outputCwd, relPath);
+			fs.mkdirSync(path.dirname(dest), { recursive: true });
+			fs.copyFileSync(src, dest);
+		} catch {
+			// Best effort: don't fail the chain over a copy error
 		}
 	}
 

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -1217,6 +1217,61 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 			else process.env.PI_SUBAGENT_MAX_DEPTH = originalMaxDepth;
 		}
 	});
+
+	it("persists chain output files from chainDir to CWD after completion", async () => {
+		const outputContent = "Report content";
+		mockPi.onCall({ output: outputContent });
+		const chainCwd = path.join(tempDir, "project");
+		fs.mkdirSync(chainCwd, { recursive: true });
+		const agents = [makeAgent("analyst", { tools: ["read", "grep", "find", "ls"] })];
+
+		const result = await executeChain(
+			makeChainParams(
+				[{ agent: "analyst", task: "Write report", output: "reports/analysis.md" }],
+				agents,
+				{ cwd: chainCwd },
+			),
+		);
+
+		assert.ok(!result.isError, `chain should succeed: ${JSON.stringify(result.content)}`);
+		const expectedCwdFile = path.join(chainCwd, "reports", "analysis.md");
+		assert.ok(fs.existsSync(expectedCwdFile), `output should be persisted to CWD: ${expectedCwdFile}`);
+		assert.equal(fs.readFileSync(expectedCwdFile, "utf-8"), outputContent);
+	});
+
+	it("does not persist absolute output paths outside chainDir", async () => {
+		mockPi.onCall({ output: "Abs path content" });
+		const agents = [makeAgent("analyst", { tools: ["read", "grep", "find", "ls"] })];
+
+		const result = await executeChain(
+			makeChainParams(
+				[{ agent: "analyst", task: "Write report", output: "/tmp/absolute-output.md" }],
+				agents,
+			),
+		);
+
+		assert.ok(!result.isError, `chain should succeed: ${JSON.stringify(result.content)}`);
+		const cwdCopy = path.join(tempDir, "absolute-output.md");
+		assert.ok(!fs.existsSync(cwdCopy), "absolute output paths should not be copied to CWD");
+	});
+
+	it("survives missing output files without failing the chain", async () => {
+		mockPi.onCall({ output: "Content without file" });
+		const chainCwd = path.join(tempDir, "project");
+		fs.mkdirSync(chainCwd, { recursive: true });
+		const agents = [makeAgent("analyst")];
+
+		const result = await executeChain(
+			makeChainParams(
+				[{ agent: "analyst", task: "Write report", output: "reports/missing.md" }],
+				agents,
+				{ cwd: chainCwd },
+			),
+		);
+
+		// Chain should still succeed even if the output file wasn't created
+		assert.ok(!result.isError, `chain should succeed: ${JSON.stringify(result.content)}`);
+	});
 });
 
 describe("chain execution — parallel steps", { skip: !available ? "pi packages not available" : undefined }, () => {


### PR DESCRIPTION
# Fixes #529: chain outputs now actually leave the building

Turns out writing a file to `{chainDir}/reports/report.md` and calling it "done" doesn't mean the poor thing ever makes it to the CWD path you actually asked for. It just sits in a temp dir like a package left on the porch, while the destination file rots stale from three runs ago. Nobody copied it. Nobody was ever going to.

So now, once a chain finishes clean, we walk every relative `output` path collected along the way (sequential steps, parallel groups, dynamic fanout — didn't play favorites) and copy each one from `chainDir` back to CWD, making directories as needed. Absolute paths are left alone, because they already know where they live. If a source file never got written for whatever reason, we shrug and move on — a missing copy shouldn't take down a chain that otherwise did its job.

Added three tests to keep this honest: the happy path persist, the "don't touch absolute paths" guard, and the "a file went missing, don't panic" case. All green, plus the full existing suite.
