### PR TITLE
feat: add generic agent contract v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added opt-in `agentContract: { version: 1 }` runs with explicit execution, acceptance, review, and effects projections, report-optional acceptance, observational file-mutation effects, generic `outputSchema` plumbing, and `gateOn` chain controls while keeping the current/default contract unchanged. Thanks to mapleluv (@mapleluvr) for #499.
 - Added `advisor` as an `oracle`-compatible bundled agent alias for users switching between Claude Code and Pi naming. Thanks to Serhii Chernenko (@serhii-chernenko) for #552.
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 

--- a/README.md
+++ b/README.md
@@ -1203,10 +1203,12 @@ Agent definitions are not loaded into context by default. Management actions let
 | `outputMode` | `"inline" \| "file-only"` | `inline` | Return saved output inline or as a concise saved-file reference. `file-only` requires an `output` path. |
 | `skill` | `string \| string[] \| false` | agent default | Override skills or disable all. |
 | `model` | string | agent default | Override model. |
-| `tasks` | array | - | Top-level parallel tasks. Supports `agent`, `task`, `cwd`, `count`, `output`, `outputMode`, `reads`, `progress`, `skill`, `model`, `toolBudget`, and `acceptance`. |
+| `outputSchema` | object | - | Require schema-valid structured output for a direct single-agent run. |
+| `agentContract` | `{ version: 1 }` | - | Opt into generic agent contract v1. Omit to keep the current/default contract. |
+| `tasks` | array | - | Top-level parallel tasks. Supports `agent`, `task`, `cwd`, `count`, `output`, `outputMode`, `outputSchema`, `reads`, `progress`, `skill`, `model`, `toolBudget`, `acceptance`, and `agentContract`. |
 | `concurrency` | number | config or `4` | Top-level parallel concurrency. |
 | `worktree` | boolean | false | Create isolated git worktrees for parallel tasks. |
-| `chain` | array | - | Sequential, static parallel, and dynamic fanout chain steps. Steps and chain parallel tasks support `phase`, `label`, `as`, `outputSchema`, and `acceptance` in addition to the usual execution fields. Dynamic fanout uses `expand`, one child `parallel` template, and `collect`. With `action: "append-step"`, pass exactly one step to append to a running async chain. |
+| `chain` | array | - | Sequential, static parallel, and dynamic fanout chain steps. Steps and chain parallel tasks support `phase`, `label`, `as`, `outputSchema`, `acceptance`, `agentContract`, and v1-only `gateOn` in addition to the usual execution fields. Dynamic fanout uses `expand`, one child `parallel` template, and `collect`. With `action: "append-step"`, pass exactly one step to append to a running async chain. |
 | `context` | `fresh \| fork` | per-agent default or `fresh` | Explicit `fresh` or `fork` overrides every child. When omitted, each agent uses its own `defaultContext`; `fork` creates real branched sessions from the parent leaf. Packaged `planner`, `worker`, `oracle`, and `advisor` default to `fork`. |
 | `chainDir` | string | temp chain dir | Persistent directory for chain artifacts. Relative chain `output`, `reads`, and `progress` paths live under this directory. |
 | `view` | `fleet \| transcript` | - | Optional `status` view for the active fleet surface or transcript tail inspection. |
@@ -1223,7 +1225,9 @@ Agent definitions are not loaded into context by default. Management actions let
 | `includeProgress` | boolean | false | Include full progress in result. |
 | `share` | boolean | false | Upload session export to GitHub Gist. |
 | `sessionDir` | string | derived | Override session log directory. |
-| `acceptance` | string/object/false | inferred | Override inferred gates with `"auto"`, `"attested"`, `"checked"`, `"verified"`, or `{ level: "none", reason: "..." }`. `reviewed` is inferred-only; explicit requests fail preflight. `false` is a deprecated shorthand for disabling gates. |
+| `acceptance` | string/object/false | inferred | Override inferred gates with `"auto"`, `"attested"`, `"checked"`, `"verified"`, or `{ level: "none", reason: "..." }`. `reviewed` is inferred-only; explicit requests fail preflight. `false` disables gates. With `agentContract: { version: 1 }`, omitted, `"auto"`, and `false` mean no acceptance request for that run; explicit acceptance is reported separately from execution. |
+
+`agentContract: { version: 1 }` keeps existing fields and artifacts but adds derived `execution`, `acceptance`, `review`, and `effects` projections. In v1, acceptance failures do not rewrite execution success, and an explicit completion guard reports `effects.fileMutation` instead of failing the run by itself. Chain steps default to advancing on execution under v1; set `gateOn: "acceptance"` on a v1 step or parallel task when rejected acceptance should stop the chain.
 
 As a conservative orchestration policy, do not set `turnBudget` or a hard `toolBudget` on implementation workers, fix workers, reviewers with edit authority, or other mutation-capable children. A default tool budget blocks read/search tools rather than mutation tools, but neither assistant turns nor tool-call counts measure whether a delivery slice is buildable or safe to hand off. Hard count caps remain appropriate for explicitly read-only scouts, reviewers, and validators.
 
@@ -1233,7 +1237,7 @@ Bound writer work with a narrow task and an outer `timeoutMs` or `maxRuntimeMs` 
 
 Use `outputMode: "file-only"` when a saved output may be large and the parent only needs a pointer. The returned text is a compact reference like `Output saved to: /abs/report.md (48.2 KB, 2847 lines). Read this file if needed.` Failed runs and save errors still return normal inline output for debugging. In chains, relative `output` paths are resolved inside the chain artifact directory, not the caller's CWD; later `{previous}` steps receive the same compact reference when the prior step used file-only mode. To persist chain outputs outside the temp artifact area, pass a persistent `chainDir` or use an absolute `output` path. A child with only read-only tools does not need direct filesystem access for `output`: it returns the complete artifact in its final response and the runtime persists it. Children with mutation-capable tools retain the direct-write instruction.
 
-Sequential and parallel chain tasks accept `agent`, `task`, `phase`, `label`, `as`, `outputSchema`, `cwd`, `output`, `outputMode`, `reads`, `progress`, `skill`, `model`, and `toolBudget`. Parallel tasks also accept `count`. Parallel step groups accept `parallel`, `concurrency`, `failFast`, and `worktree`. If `outputSchema` is present, the child must call `structured_output` with schema-valid JSON; prose-only completion or invalid JSON fails the step. Validated structured values are preserved on the step result, and `as` also exposes a compact text representation through `{outputs.name}`.
+Sequential and parallel chain tasks accept `agent`, `task`, `phase`, `label`, `as`, `outputSchema`, `cwd`, `output`, `outputMode`, `reads`, `progress`, `skill`, `model`, `toolBudget`, `acceptance`, `agentContract`, and v1-only `gateOn`. Parallel tasks also accept `count`. Parallel step groups accept `parallel`, `concurrency`, `failFast`, and `worktree`. If `outputSchema` is present, the child must call `structured_output` with schema-valid JSON; prose-only completion or invalid JSON fails the step. Validated structured values are preserved on the step result, and `as` also exposes a compact text representation through `{outputs.name}`.
 
 Status and control actions:
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -348,6 +348,13 @@ handoffs or full fan-in summaries. Use `phase` and `label` for status readabilit
 Use `outputSchema` when later steps need reliable structured data; the child must
 call `structured_output` with schema-valid JSON, or the step fails.
 
+Use `agentContract: { version: 1 }` when a caller needs generic result projections
+instead of acceptance or mutation effects rewriting execution success. V1 adds
+`execution`, `acceptance`, `review`, and `effects`; omitted acceptance means no
+acceptance request. Chain steps advance on execution by default under v1. Set
+`gateOn: "acceptance"` only when a rejected explicit acceptance report should stop
+the chain.
+
 ### Async/background
 
 Prefer async mode for every subagent launch. Set `async: true` no matter the task unless there is a specific reason to opt into a foreground/blocking run. This applies to scouts, researchers, workers, reviewers, validators, oracle checks, one-off delegates, chains, and parallel groups. Keep the write path single-threaded even when the run is async.

--- a/src/api/delegation.ts
+++ b/src/api/delegation.ts
@@ -19,6 +19,37 @@ export interface SubagentDelegationToolBudget {
 	block?: string[] | "*";
 }
 
+export interface SubagentDelegationAgentContract {
+	version: 1;
+}
+
+export type SubagentDelegationJsonSchemaObject = Record<string, unknown>;
+
+export interface SubagentDelegationExecutionResult {
+	status: "completed" | "failed" | "paused" | "stopped" | "detached";
+	success: boolean;
+	exitCode: number;
+	error?: string;
+	interrupted?: boolean;
+	timedOut?: boolean;
+	stopped?: boolean;
+	detached?: boolean;
+}
+
+export interface SubagentDelegationReviewResult {
+	status: "not-requested" | "no-blockers" | "blockers" | "needs-parent-decision";
+	findings?: Array<{ severity: "blocker" | "non-blocking"; file?: string; issue: string; rationale: string }>;
+}
+
+export interface SubagentDelegationEffectsResult {
+	fileMutation?: {
+		status: "not-requested" | "not-applicable" | "observed" | "missing";
+		expected: boolean;
+		attempted: boolean;
+		message?: string;
+	};
+}
+
 export type SubagentDelegationAcceptanceEvidence =
 	| "changed-files"
 	| "tests-added"
@@ -87,6 +118,8 @@ export interface SubagentDelegationRequest {
 	skill?: string | string[] | boolean;
 	output?: string | boolean;
 	outputMode?: "inline" | "file-only";
+	outputSchema?: SubagentDelegationJsonSchemaObject;
+	agentContract?: SubagentDelegationAgentContract;
 	acceptance?: SubagentDelegationAcceptance;
 	artifacts?: boolean;
 }
@@ -144,10 +177,13 @@ export interface SubagentDelegationResponse extends SubagentDelegationStarted {
 	agent?: string;
 	model?: string;
 	exitCode?: number;
+	execution?: SubagentDelegationExecutionResult;
 	output?: string;
 	outputPath?: string;
 	sessionFile?: string;
 	acceptance?: SubagentDelegationAcceptanceResult;
+	review?: SubagentDelegationReviewResult;
+	effects?: SubagentDelegationEffectsResult;
 	turns?: number;
 	toolCount?: number;
 	durationMs?: number;

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -71,7 +71,16 @@ const AcceptanceOverride = Type.Unsafe({
 		{ type: "boolean", enum: [false] },
 		{ type: "object", additionalProperties: true },
 	],
-	description: "Optional acceptance policy. Omitted means auto-inferred; verified requires configured runtime commands. Reviewed is inferred-only because explicit runs cannot supply an independent reviewer result. Bare \"none\" requires { level: \"none\", reason: \"...\" }, while false is deprecated.",
+	description: "Optional acceptance policy. In the current/default contract, omitted means auto-inferred; verified requires configured runtime commands. With agentContract.version=1, omitted means not requested and acceptance failures are reported separately from execution.",
+});
+
+const AgentContractOverride = Type.Object({
+	version: Type.Integer({ enum: [1], description: "Opt into generic agent contract v1 for this run/child." }),
+}, { additionalProperties: false, description: "Opt-in compatibility contract. Omit to use current default behavior." });
+
+const ChainGateOverride = Type.String({
+	enum: ["execution", "acceptance"],
+	description: "For agentContract.version=1 chain steps, choose whether the chain advances on execution success or acceptance success. Defaults to execution.",
 });
 
 const TurnBudgetOverride = Type.Object({
@@ -104,7 +113,9 @@ const TaskItem = Type.Object({
 	model: Type.Optional(Type.String({ description: "Override model for this task (e.g. 'google/gemini-3-pro')" })),
 	skill: Type.Optional(SkillOverride),
 	toolBudget: Type.Optional(ToolBudgetOverride),
+	outputSchema: Type.Optional(JsonSchemaObject),
 	acceptance: Type.Optional(AcceptanceOverride),
+	agentContract: Type.Optional(AgentContractOverride),
 });
 
 // Parallel task item (within a parallel step)
@@ -125,6 +136,8 @@ export const ParallelTaskSchema = Type.Object({
 	model: Type.Optional(Type.String({ description: "Override model for this task" })),
 	toolBudget: Type.Optional(ToolBudgetOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
+	agentContract: Type.Optional(AgentContractOverride),
+	gateOn: Type.Optional(ChainGateOverride),
 });
 
 export const DynamicExpandSchema = Type.Object({
@@ -153,6 +166,8 @@ export const DynamicParallelTemplateSchema = Type.Object({
 	model: Type.Optional(Type.String({ description: "Override model for this task" })),
 	toolBudget: Type.Optional(ToolBudgetOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
+	agentContract: Type.Optional(AgentContractOverride),
+	gateOn: Type.Optional(ChainGateOverride),
 }, { additionalProperties: false });
 
 export const DynamicCollectSchema = Type.Object({
@@ -179,6 +194,8 @@ export const ChainItem = Type.Object({
 	model: Type.Optional(Type.String({ description: "Override model for this step" })),
 	toolBudget: Type.Optional(ToolBudgetOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
+	agentContract: Type.Optional(AgentContractOverride),
+	gateOn: Type.Optional(ChainGateOverride),
 	parallel: Type.Optional(Type.Unsafe({
 		anyOf: [
 			Type.Array(ParallelTaskSchema, { minItems: 1, description: "Tasks to run in parallel" }),
@@ -292,6 +309,8 @@ const SubagentParamsSchema = Type.Object({
 	outputMode: Type.Optional(OutputModeOverride),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for single agent (e.g. 'anthropic/claude-sonnet-4')" })),
+	outputSchema: Type.Optional(JsonSchemaObject),
+	agentContract: Type.Optional(AgentContractOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
 });
 

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -30,8 +30,10 @@ import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { resolveEffectiveAcceptance } from "../shared/acceptance.ts";
 import {
 	type AcceptanceInput,
+	type AgentContract,
 	type ArtifactConfig,
 	type Details,
+	type JsonSchemaObject,
 	type MaxOutputConfig,
 	type NestedRouteInfo,
 	type ResolvedControlConfig,
@@ -132,6 +134,7 @@ interface AsyncChainParams {
 	artifactConfig: ArtifactConfig;
 	shareEnabled: boolean;
 	sessionRoot?: string;
+	agentContract?: AgentContract;
 	chainSkills?: string[];
 	sessionFilesByFlatIndex?: (string | undefined)[];
 	thinkingOverridesByFlatIndex?: (AgentConfig["thinking"] | undefined)[];
@@ -177,6 +180,8 @@ interface AsyncSingleParams {
 	output?: string | boolean;
 	outputMode?: "inline" | "file-only";
 	outputBaseDir?: string;
+	agentContract?: AgentContract;
+	structuredOutputSchema?: JsonSchemaObject;
 	modelOverride?: string;
 	thinkingOverride?: AgentConfig["thinking"];
 	availableModels?: AvailableModelInfo[];
@@ -217,6 +222,7 @@ export interface AsyncRunnerStepBuildParams {
 	thinkingOverridesByFlatIndex?: (AgentConfig["thinking"] | undefined)[];
 	contextForAgent?: (agentName: string) => ContextMode;
 	progressDir?: string;
+	agentContract?: AgentContract;
 	dynamicFanoutMaxItems?: number;
 	maxSubagentDepth: number;
 	waitToolEnabled?: boolean;
@@ -628,11 +634,13 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		const thinkingOverride = flatIndex === undefined ? undefined : thinkingOverridesByFlatIndex?.[flatIndex];
 		const effectiveThinking = thinkingOverride ?? a.thinking;
 		const model = applyThinkingSuffix(primaryModel, effectiveThinking, thinkingOverride !== undefined);
+		const agentContract = s.agentContract ?? params.agentContract;
 		return {
 			parentSessionId: ctx.parentSessionId ?? ctx.currentSessionId,
 			agent: s.agent,
 			task,
 			...(params.contextForAgent ? { context: params.contextForAgent(s.agent) } : {}),
+			...(agentContract ? { agentContract } : {}),
 			phase: s.phase,
 			label: s.label,
 			outputName: s.as,
@@ -667,9 +675,11 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 				mode: resultMode,
 				async: true,
 				dynamic: false,
+				agentContract,
 			}),
 			acceptanceInput: s.acceptance,
 			acceptanceRole: a.acceptanceRole,
+			...(s.gateOn ? { gateOn: s.gateOn } : {}),
 			...(s.outputSchema ? { structuredOutputSchema: s.outputSchema } : {}),
 			...(s.outputSchema ? { structuredOutput: createStructuredOutputRuntime(s.outputSchema, path.join(asyncDir, "structured-output")) } : {}),
 			...(resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}),
@@ -712,7 +722,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 							}
 						}
 						const staticStep = nextFlatStep();
-						return buildSeqStep(t, staticStep.sessionFile, behaviorCwd, progressPrecreated, parallelBehaviors[taskIndex], staticStep.index, { stepIndex, taskIndex });
+						return buildSeqStep({ ...t, agentContract: t.agentContract ?? s.agentContract, gateOn: t.gateOn ?? s.gateOn }, staticStep.sessionFile, behaviorCwd, progressPrecreated, parallelBehaviors[taskIndex], staticStep.index, { stepIndex, taskIndex });
 					}),
 					concurrency: s.concurrency,
 					failFast: s.failFast,
@@ -729,7 +739,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 				}
 				const maxItems = s.expand.maxItems ?? params.dynamicFanoutMaxItems ?? 0;
 				const dynamicFlatSteps = Array.from({ length: maxItems }, () => nextFlatStep());
-				const parallel = buildSeqStep(s.parallel as SequentialStep, undefined, undefined, progressPrecreated, behavior, undefined, { stepIndex });
+				const parallel = buildSeqStep({ ...(s.parallel as SequentialStep), agentContract: s.parallel.agentContract ?? s.agentContract, gateOn: s.parallel.gateOn ?? s.gateOn }, undefined, undefined, progressPrecreated, behavior, undefined, { stepIndex });
 				return {
 					expand: s.expand,
 					parallel,
@@ -748,9 +758,12 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 						mode: resultMode,
 						async: true,
 						dynamicGroup: true,
+						agentContract: s.agentContract ?? params.agentContract,
 					}),
 					acceptanceInput: s.acceptance,
 					acceptanceRole: agent.acceptanceRole,
+					...(s.agentContract ?? params.agentContract ? { agentContract: s.agentContract ?? params.agentContract } : {}),
+					...(s.gateOn ? { gateOn: s.gateOn } : {}),
 				};
 			}
 			const staticStep = nextFlatStep();
@@ -851,6 +864,7 @@ export function executeAsyncChain(
 		thinkingOverridesByFlatIndex,
 		contextForAgent: params.contextForAgent,
 		progressDir: params.progressDir ?? (artifactsDir ? path.join(artifactsDir, "progress", id) : resultMode === "parallel" ? path.join(asyncDir, "progress") : undefined),
+		agentContract: params.agentContract,
 		outputBaseDir: artifactsDir ? path.join(artifactsDir, "outputs", id) : undefined,
 		dynamicFanoutMaxItems: params.dynamicFanoutMaxItems,
 		maxSubagentDepth,
@@ -1132,6 +1146,9 @@ export function executeAsyncSingle(
 	if (timeoutMs !== undefined && timeoutMs <= 0) return formatAsyncStartError("single", "The source run's absolute deadline expired before recovery could launch.");
 	const initialTurnBudget = params.turnBudget ? initialTurnBudgetState(params.turnBudget) : undefined;
 	const resolvedSessionDir = params.sessionDir ?? (sessionRoot ? path.join(sessionRoot, `async-${id}`) : undefined);
+	const structuredOutput = params.structuredOutputSchema
+		? createStructuredOutputRuntime(params.structuredOutputSchema, path.join(asyncDir, "structured-output"))
+		: undefined;
 	const resolvedAcceptance = resolveEffectiveAcceptance({
 		explicit: params.acceptance,
 		agentName: agent,
@@ -1139,10 +1156,12 @@ export function executeAsyncSingle(
 		task,
 		mode: "single",
 		async: true,
+		agentContract: params.agentContract,
 	});
 	const recoveryDescriptor: SteeringRecoveryDescriptor = {
 		version: 1,
 		sourceRunId: id,
+		...(params.agentContract ? { agentContract: params.agentContract } : {}),
 		agent,
 		...(sessionFile ? { sessionFile } : {}),
 		cwd: runnerCwd,
@@ -1164,6 +1183,7 @@ export function executeAsyncSingle(
 		...(agentConfig.memory ? { memory: { ...agentConfig.memory } } : {}),
 		...(outputPath ? { outputPath } : {}),
 		outputMode,
+		...(params.structuredOutputSchema ? { structuredOutputSchema: params.structuredOutputSchema } : {}),
 		...(params.acceptance !== undefined ? { acceptance: params.acceptance } : {}),
 		...(controlConfig ? { controlConfig } : {}),
 		...(deadlineAt !== undefined ? { absoluteDeadlineAt: deadlineAt } : {}),
@@ -1213,7 +1233,10 @@ export function executeAsyncSingle(
 						sessionFile,
 						maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, agentConfig.maxSubagentDepth),
 						waitToolEnabled: params.waitToolEnabled,
+						...(params.agentContract ? { agentContract: params.agentContract } : {}),
 						effectiveAcceptance: resolvedAcceptance,
+						...(structuredOutput ? { structuredOutput } : {}),
+						...(params.structuredOutputSchema ? { structuredOutputSchema: params.structuredOutputSchema } : {}),
 						...(resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}),
 					},
 				],

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -278,9 +278,9 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': expected an object.`);
 	const parsed = value as Record<string, unknown>;
 	const allowedFields = new Set([
-		"version", "sourceRunId", "agent", "sessionFile", "cwd", "model", "fallbackModels", "thinking", "tools", "extensions",
+		"version", "sourceRunId", "agentContract", "agent", "sessionFile", "cwd", "model", "fallbackModels", "thinking", "tools", "extensions",
 		"subagentOnlyExtensions", "mcpDirectTools", "systemPrompt", "systemPromptMode", "inheritProjectContext", "inheritSkills", "skills",
-		"skillPath", "agentFilePath", "completionGuard", "memory", "outputPath", "outputMode", "acceptance", "sessionDir", "artifactConfig",
+		"skillPath", "agentFilePath", "completionGuard", "memory", "outputPath", "outputMode", "structuredOutputSchema", "acceptance", "sessionDir", "artifactConfig",
 		"artifactsDir", "maxOutput", "controlConfig", "absoluteDeadlineAt", "initialTurnBudget", "initialToolBudget", "maxSubagentDepth", "share",
 	]);
 	for (const field of Object.keys(parsed)) {
@@ -291,6 +291,11 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 		if (typeof parsed[field] !== "string" || !(parsed[field] as string).trim()) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${field} must be a non-empty string.`);
 	}
 	if (parsed.version !== 1) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': version must be 1.`);
+	if (parsed.agentContract !== undefined) {
+		if (!parsed.agentContract || typeof parsed.agentContract !== "object" || Array.isArray(parsed.agentContract)) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': agentContract must be an object.`);
+		const contract = parsed.agentContract as Record<string, unknown>;
+		if (contract.version !== 1 || Object.keys(contract).some((key) => key !== "version")) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': agentContract must be { version: 1 }.`);
+	}
 	if (parsed.systemPromptMode !== "append" && parsed.systemPromptMode !== "replace") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': systemPromptMode is invalid.`);
 	if (parsed.outputMode !== "inline" && parsed.outputMode !== "file-only") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': outputMode is invalid.`);
 	for (const field of ["inheritProjectContext", "inheritSkills", "share"] as const) {
@@ -306,6 +311,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 		if (parsed[field] !== undefined && (typeof parsed[field] !== "string" || !(parsed[field] as string).trim())) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${field} must be a non-empty string.`);
 	}
 	if (parsed.completionGuard !== undefined && typeof parsed.completionGuard !== "boolean") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': completionGuard must be a boolean.`);
+	if (parsed.structuredOutputSchema !== undefined && (!parsed.structuredOutputSchema || typeof parsed.structuredOutputSchema !== "object" || Array.isArray(parsed.structuredOutputSchema))) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': structuredOutputSchema must be an object.`);
 	if (parsed.memory !== undefined) {
 		if (!parsed.memory || typeof parsed.memory !== "object" || Array.isArray(parsed.memory)) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': memory must be an object.`);
 		const memory = parsed.memory as Record<string, unknown>;

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -43,6 +43,11 @@ interface AsyncRunStepSummary {
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
+	acceptance?: AsyncJobStep["acceptance"];
+	agentContract?: AsyncJobStep["agentContract"];
+	execution?: AsyncJobStep["execution"];
+	review?: AsyncJobStep["review"];
+	effects?: AsyncJobStep["effects"];
 	children?: NestedRunSummary[];
 }
 
@@ -196,6 +201,11 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 			...(step.turnBudget ? { turnBudget: step.turnBudget } : {}),
 			...(step.turnBudgetExceeded !== undefined ? { turnBudgetExceeded: step.turnBudgetExceeded } : {}),
 			...(step.wrapUpRequested !== undefined ? { wrapUpRequested: step.wrapUpRequested } : {}),
+			...(step.acceptance ? { acceptance: step.acceptance } : {}),
+			...(step.agentContract ? { agentContract: step.agentContract } : {}),
+			...(step.execution ? { execution: step.execution } : {}),
+			...(step.review ? { review: step.review } : {}),
+			...(step.effects ? { effects: step.effects } : {}),
 			...(step.children?.length ? { children: step.children } : {}),
 		};
 	});

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -94,6 +94,7 @@ import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { writeInitialProgressFile } from "../../shared/settings.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { acceptanceFailureMessage, aggregateAcceptanceReport, buildSkippedAcceptanceLedger, evaluateAcceptance, formatAcceptancePrompt, resolveEffectiveAcceptance, stripAcceptanceReport } from "../shared/acceptance.ts";
+import { attachContractProjections, isAgentContractV1 } from "../shared/agent-contract.ts";
 import { waitForImportedAsyncRoot } from "./chain-root-attachment.ts";
 import { appendRunnerStepsToStatus, consumeChainAppendRequests, countPendingChainAppendRequests } from "./chain-append.ts";
 import { appendTurnBudgetSystemPrompt, formatTurnBudgetOutput, initialTurnBudgetState, turnBudgetDecision, turnBudgetDeferredNote, turnBudgetDeferredState, turnBudgetExceededMessage, turnBudgetSoftNote, turnBudgetState } from "../shared/turn-budget.ts";
@@ -175,6 +176,10 @@ interface StepResult {
 	truncated?: boolean;
 	transcriptPath?: string;
 	transcriptError?: string;
+	agentContract?: import("../../shared/types.ts").AgentContract;
+	execution?: import("../../shared/types.ts").ExecutionProjection;
+	review?: import("../../shared/types.ts").ReviewProjection;
+	effects?: import("../../shared/types.ts").EffectsProjection;
 	structuredOutput?: unknown;
 	structuredOutputPath?: string;
 	structuredOutputSchemaPath?: string;
@@ -952,6 +957,8 @@ async function runSingleStep(
 	ctx: SingleStepContext,
 ): Promise<{
 	agent: string;
+	context?: "fresh" | "fork";
+	agentContract?: import("../../shared/types.ts").AgentContract;
 	output: string;
 	exitCode: number | null;
 	error?: string;
@@ -972,6 +979,9 @@ async function runSingleStep(
 	sessionFile?: string;
 	intercomTarget?: string;
 	completionGuardTriggered?: boolean;
+	effects?: import("../../shared/types.ts").EffectsProjection;
+	execution?: import("../../shared/types.ts").ExecutionProjection;
+	review?: import("../../shared/types.ts").ReviewProjection;
 	structuredOutput?: unknown;
 	structuredOutputPath?: string;
 	structuredOutputSchemaPath?: string;
@@ -1053,7 +1063,7 @@ async function runSingleStep(
 	if (ctx.outputs) task = resolveOutputReferences(task, ctx.outputs);
 	const taskForCompletionGuard = task;
 	if (step.effectiveAcceptance) {
-		const acceptancePrompt = formatAcceptancePrompt(step.effectiveAcceptance);
+		const acceptancePrompt = formatAcceptancePrompt(step.effectiveAcceptance, { reportOptional: isAgentContractV1(step.agentContract) });
 		if (acceptancePrompt) task = `${task}\n${acceptancePrompt}`;
 	}
 	const sessionEnabled = Boolean(step.sessionFile) || ctx.sessionEnabled;
@@ -1215,7 +1225,8 @@ async function runSingleStep(
 			if (structured.error) structuredError = structured.error;
 			else structuredOutput = structured.value;
 		}
-		const completionGuard = run.exitCode === 0 && !run.error && !toolAvailabilityError && !hiddenError?.hasError && !emptyOutputError && step.completionGuard !== false
+		const completionGuardEnabled = isAgentContractV1(step.agentContract) ? step.completionGuard === true : step.completionGuard !== false;
+		const completionGuard = run.exitCode === 0 && !run.error && !toolAvailabilityError && !hiddenError?.hasError && !emptyOutputError && completionGuardEnabled
 			? evaluateCompletionMutationGuard({
 				agent: step.agent,
 				task: taskForCompletionGuard,
@@ -1225,10 +1236,18 @@ async function runSingleStep(
 			})
 			: undefined;
 		const completionGuardTriggered = completionGuard?.triggered === true && !run.observedMutationAttempt;
-		const completionGuardError = completionGuardTriggered
+		const fileMutationEffect = completionGuard
+			? {
+				status: completionGuard.expectedMutation ? completionGuardTriggered ? "missing" as const : "observed" as const : "not-applicable" as const,
+				expected: completionGuard.expectedMutation,
+				attempted: completionGuard.attemptedMutation || run.observedMutationAttempt === true,
+				...(completionGuardTriggered ? { message: "Subagent completed without making edits for an implementation task." } : {}),
+			}
+			: undefined;
+		const completionGuardError = completionGuardTriggered && !isAgentContractV1(step.agentContract)
 			? "Subagent completed without making edits for an implementation task.\nIt appears to have returned planning or scratchpad output instead of applying changes."
 			: undefined;
-		const effectiveExitCode = toolAvailabilityError || completionGuardTriggered || structuredError
+		const effectiveExitCode = toolAvailabilityError || (completionGuardTriggered && !isAgentContractV1(step.agentContract)) || structuredError
 			? 1
 			: hiddenError?.hasError
 				? (hiddenError.exitCode ?? 1)
@@ -1262,7 +1281,7 @@ async function runSingleStep(
 			toolBudgetBlocked = Boolean(blockedMessage);
 			toolBudget = toolBudgetState(step.toolBudget, toolMessages.length, blockedMessage ? (blockedMessage as { toolName?: string }).toolName : undefined);
 		}
-		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput } as RunPiStreamingResult & { structuredOutput?: unknown };
+		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(fileMutationEffect ? { effects: { fileMutation: fileMutationEffect } } : {}) } as RunPiStreamingResult & { structuredOutput?: unknown; agentContract?: import("../../shared/types.ts").AgentContract; effects?: import("../../shared/types.ts").EffectsProjection };
 		if (run.turnBudgetExceeded) break;
 		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break;
 		if (attempt.success || completionGuardTriggered) break;
@@ -1316,6 +1335,7 @@ async function runSingleStep(
 			cwd: step.cwd ?? ctx.cwd,
 			signal: combinedAbortSignal([ctx.timeoutSignal, ctx.stopSignal]),
 			abortMessage: ctx.stopSignal?.aborted ? ctx.stopMessage ?? "Subagent stopped by user." : ctx.timeoutMessage ?? "Subagent timed out.",
+			reportOptional: isAgentContractV1(step.agentContract),
 		})
 		: undefined;
 	const stoppedAfterAcceptance = finalResult?.stopped === true || ctx.stopSignal?.aborted === true;
@@ -1331,7 +1351,7 @@ async function runSingleStep(
 					: acceptance
 		: undefined;
 	const acceptanceFailure = effectiveAcceptance ? acceptanceFailureMessage(effectiveAcceptance) : undefined;
-	const acceptanceCanFailRun = acceptanceFailure && effectiveAcceptance?.explicit && (finalResult?.exitCode ?? 1) === 0 && !finalResult?.interrupted && !timedOutAfterAcceptance && !stoppedAfterAcceptance && !turnBudgetExceeded;
+	const acceptanceCanFailRun = acceptanceFailure && effectiveAcceptance?.explicit && (finalResult?.exitCode ?? 1) === 0 && !finalResult?.interrupted && !timedOutAfterAcceptance && !stoppedAfterAcceptance && !turnBudgetExceeded && !isAgentContractV1(step.agentContract);
 	const effectiveFinalExitCode = timedOutAfterAcceptance || stoppedAfterAcceptance || turnBudgetExceeded ? 1 : acceptanceCanFailRun ? 1 : finalResult?.exitCode ?? 1;
 	const effectiveFinalError = stoppedAfterAcceptance
 		? ctx.stopMessage ?? "Subagent stopped by user."
@@ -1375,9 +1395,10 @@ async function runSingleStep(
 		}
 	}
 
-	return {
+	const result = {
 		agent: step.agent,
 		context: step.context,
+		...(step.agentContract ? { agentContract: step.agentContract } : {}),
 		output: outputForSummary,
 		exitCode: effectiveFinalExitCode,
 		error: effectiveFinalError,
@@ -1400,12 +1421,14 @@ async function runSingleStep(
 		toolBudget,
 		toolBudgetBlocked: toolBudgetBlocked || undefined,
 		completionGuardTriggered: completionGuardTriggeredFinal,
+		...((finalResult as (RunPiStreamingResult & { effects?: import("../../shared/types.ts").EffectsProjection }) | undefined)?.effects ? { effects: (finalResult as RunPiStreamingResult & { effects?: import("../../shared/types.ts").EffectsProjection }).effects } : {}),
 		structuredOutput: timedOutAfterAcceptance || stoppedAfterAcceptance || turnBudgetExceeded ? undefined : (finalResult as (RunPiStreamingResult & { structuredOutput?: unknown }) | undefined)?.structuredOutput,
 		structuredOutputPath: timedOutAfterAcceptance || stoppedAfterAcceptance || turnBudgetExceeded ? undefined : effectiveStructuredOutput?.outputPath,
 		structuredOutputSchemaPath: timedOutAfterAcceptance || stoppedAfterAcceptance || turnBudgetExceeded ? undefined : effectiveStructuredOutput?.schemaPath,
 		acceptance: effectiveAcceptance,
 		watchdog: finalResult?.watchdog,
 	};
+	return isAgentContractV1(step.agentContract) ? attachContractProjections(result as unknown as import("../../shared/types.ts").SingleResult) as unknown as typeof result : result;
 }
 
 type RunnerStatusStep = NonNullable<AsyncStatus["steps"]>[number] & {
@@ -1624,6 +1647,7 @@ async function runSubagent(
 					label: task.label,
 					outputName: task.outputName,
 					structured: task.structured,
+					...(task.agentContract ? { agentContract: task.agentContract } : {}),
 					status: "pending",
 					...(task.toolBudget ? { toolBudget: initialToolBudgetState(task.toolBudget) } : {}),
 					...(task.sessionFile ? { sessionFile: task.sessionFile } : {}),
@@ -1646,6 +1670,7 @@ async function runSubagent(
 				label: step.label ?? step.parallel.label ?? `Dynamic fanout (${step.collect.as})`,
 				outputName: step.collect.as,
 				structured: Boolean(step.collect.outputSchema),
+				...(step.agentContract ? { agentContract: step.agentContract } : {}),
 				status: "pending",
 				...(step.parallel.toolBudget ? { toolBudget: initialToolBudgetState(step.parallel.toolBudget) } : {}),
 				recentTools: [],
@@ -1662,6 +1687,7 @@ async function runSubagent(
 				label: step.label,
 				outputName: step.outputName,
 				structured: step.structured,
+				...(step.agentContract ? { agentContract: step.agentContract } : {}),
 				status: "pending",
 				...(step.toolBudget ? { toolBudget: initialToolBudgetState(step.toolBudget) } : {}),
 				...(step.sessionFile ? { sessionFile: step.sessionFile } : {}),
@@ -2646,6 +2672,7 @@ async function runSubagent(
 				mode: config.mode,
 				async: true,
 				dynamicGroup: true,
+				agentContract: step.agentContract,
 			});
 
 			if (materialized.parallel.length === 0) {
@@ -2677,13 +2704,14 @@ async function runSubagent(
 						cwd,
 						signal: combinedAbortSignal([timeoutAbortController.signal, stopAbortController.signal]),
 						abortMessage: stopAbortController.signal.aborted ? stopMessage : timeoutMessage ?? "Subagent timed out.",
+						reportOptional: isAgentContractV1(step.agentContract),
 					})
 					: undefined;
 				const groupStopped = stopped || stopAbortController.signal.aborted;
 				const groupTimedOut = !groupStopped && (timedOut || timeoutAbortController.signal.aborted);
 				const effectiveGroupAcceptance = groupTimedOut || groupStopped ? undefined : groupAcceptance;
 				if (placeholder && effectiveGroupAcceptance) placeholder.acceptance = effectiveGroupAcceptance;
-				const groupAcceptanceFailure = effectiveGroupAcceptance ? acceptanceFailureMessage(effectiveGroupAcceptance) : undefined;
+				const groupAcceptanceFailure = effectiveGroupAcceptance && (!isAgentContractV1(step.agentContract) || step.gateOn === "acceptance") ? acceptanceFailureMessage(effectiveGroupAcceptance) : undefined;
 				if (groupTimedOut || groupStopped || groupAcceptanceFailure) {
 					const errorMessage = groupStopped ? stopMessage : groupTimedOut ? timeoutMessage ?? "Subagent timed out." : groupAcceptanceFailure!;
 					statusPayload.state = groupStopped ? "stopped" : "failed";
@@ -2729,6 +2757,7 @@ async function runSubagent(
 						mode: config.mode,
 						async: true,
 						dynamic: step.parallel.acceptanceInput === undefined,
+						agentContract: step.parallel.agentContract ?? step.agentContract,
 					}),
 					systemPrompt: step.parallel.namespaceOutputPath ? injectOutputPathSystemPrompt(step.parallel.systemPrompt ?? "", outputPath, step.parallel) : step.parallel.systemPrompt,
 					outputPath,
@@ -2753,6 +2782,7 @@ async function runSubagent(
 					label: task.label,
 					outputName: undefined,
 					structured: Boolean(task.structuredOutputSchema),
+					...(task.agentContract ? { agentContract: task.agentContract } : {}),
 					status: "pending",
 					...(task.sessionFile ? { sessionFile: task.sessionFile } : {}),
 					...(transcriptPath ? { transcriptPath } : {}),
@@ -2897,6 +2927,10 @@ async function runSubagent(
 				statusPayload.steps[fi].error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
 				statusPayload.steps[fi].transcriptPath = singleResult.transcriptPath ?? statusPayload.steps[fi].transcriptPath;
 				statusPayload.steps[fi].transcriptError = singleResult.transcriptError;
+				statusPayload.steps[fi].agentContract = singleResult.agentContract;
+				statusPayload.steps[fi].effects = singleResult.effects;
+				statusPayload.steps[fi].execution = singleResult.execution;
+				statusPayload.steps[fi].review = singleResult.review;
 				statusPayload.steps[fi].structuredOutput = singleResult.structuredOutput;
 				statusPayload.steps[fi].structuredOutputPath = singleResult.structuredOutputPath;
 				statusPayload.steps[fi].structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
@@ -2918,6 +2952,7 @@ async function runSubagent(
 				results.push({
 					agent: pr.agent,
 					context: pr.context,
+					agentContract: pr.agentContract,
 					output: pr.output,
 					error: pr.error,
 					protocolError: pr.protocolError,
@@ -2941,6 +2976,9 @@ async function runSubagent(
 					artifactPaths: pr.artifactPaths,
 					transcriptPath: pr.transcriptPath,
 					transcriptError: pr.transcriptError,
+					effects: pr.effects,
+					execution: pr.execution,
+					review: pr.review,
 					structuredOutput: pr.structuredOutput,
 					structuredOutputPath: pr.structuredOutputPath,
 					structuredOutputSchemaPath: pr.structuredOutputSchemaPath,
@@ -2950,7 +2988,18 @@ async function runSubagent(
 			}
 			const collection = collectDynamicResults(step as Parameters<typeof collectDynamicResults>[0], materialized.items, parallelResults);
 			const failures = parallelResults.filter((result) => result.exitCode !== 0 && result.exitCode !== -1);
-			if (failures.length === 0) {
+			const acceptanceFailures = parallelResults
+				.map((result, originalIndex) => ({ result, originalIndex, task: dynamicSteps[originalIndex] }))
+				.filter(({ result, task }) => isAgentContractV1(task?.agentContract ?? step.agentContract) && task?.gateOn === "acceptance" && result.acceptance?.status === "rejected");
+			if (acceptanceFailures.length > 0) {
+				const message = acceptanceFailures
+					.map(({ result, originalIndex }) => `Dynamic item ${originalIndex + 1} (${result.agent}, key ${materialized.items[originalIndex]?.key ?? originalIndex}) acceptance rejected: ${acceptanceFailureMessage(result.acceptance) ?? "acceptance rejected"}`)
+					.join("\n");
+				results.push({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection });
+				statusPayload.error = message;
+				markDynamicGraphGroup(stepIndex, "failed", message);
+			}
+			if (failures.length === 0 && acceptanceFailures.length === 0) {
 				try {
 					await validateDynamicCollection(step.collect.outputSchema, collection);
 					outputs[step.collect.as] = {
@@ -2971,12 +3020,13 @@ async function runSubagent(
 							cwd,
 							signal: combinedAbortSignal([timeoutAbortController.signal, stopAbortController.signal]),
 							abortMessage: stopAbortController.signal.aborted ? stopMessage : timeoutMessage ?? "Subagent timed out.",
+							reportOptional: isAgentContractV1(step.agentContract),
 						})
 						: undefined;
 					const groupStopped = stopped || stopAbortController.signal.aborted;
 					const groupTimedOut = !groupStopped && (timedOut || timeoutAbortController.signal.aborted);
 					const effectiveGroupAcceptance = groupTimedOut || groupStopped ? undefined : groupAcceptance;
-					const groupAcceptanceFailure = effectiveDynamicGroupAcceptance.explicit && effectiveGroupAcceptance ? acceptanceFailureMessage(effectiveGroupAcceptance) : undefined;
+					const groupAcceptanceFailure = effectiveDynamicGroupAcceptance.explicit && effectiveGroupAcceptance && (!isAgentContractV1(step.agentContract) || step.gateOn === "acceptance") ? acceptanceFailureMessage(effectiveGroupAcceptance) : undefined;
 					const groupError = groupStopped ? stopMessage : groupTimedOut ? timeoutMessage ?? "Subagent timed out." : groupAcceptanceFailure;
 					markDynamicGraphGroup(stepIndex, groupError ? groupStopped ? "stopped" : "failed" : "completed", groupError, effectiveGroupAcceptance);
 					if (groupError) {
@@ -3016,7 +3066,7 @@ async function runSubagent(
 				ts: Date.now(),
 				runId: id,
 				stepIndex,
-				success: failures.length === 0,
+				success: failures.length === 0 && acceptanceFailures.length === 0,
 			}));
 			if (failures.length > 0) markDynamicGraphGroup(stepIndex, "failed", failures[0]?.error ?? "Dynamic fanout child failed.");
 			statusPayload.lastUpdate = Date.now();
@@ -3207,6 +3257,10 @@ async function runSubagent(
 						statusPayload.steps[fi].error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
 						statusPayload.steps[fi].transcriptPath = singleResult.transcriptPath ?? statusPayload.steps[fi].transcriptPath;
 						statusPayload.steps[fi].transcriptError = singleResult.transcriptError;
+						statusPayload.steps[fi].agentContract = singleResult.agentContract;
+						statusPayload.steps[fi].effects = singleResult.effects;
+						statusPayload.steps[fi].execution = singleResult.execution;
+						statusPayload.steps[fi].review = singleResult.review;
 						statusPayload.steps[fi].structuredOutput = singleResult.structuredOutput;
 						statusPayload.steps[fi].structuredOutputPath = singleResult.structuredOutputPath;
 						statusPayload.steps[fi].structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
@@ -3264,6 +3318,7 @@ async function runSubagent(
 					results.push({
 						agent: pr.agent,
 						context: pr.context,
+						agentContract: pr.agentContract,
 						output: pr.output,
 						error: pr.error,
 						protocolError: pr.protocolError,
@@ -3287,6 +3342,9 @@ async function runSubagent(
 						artifactPaths: pr.artifactPaths,
 						transcriptPath: pr.transcriptPath,
 						transcriptError: pr.transcriptError,
+						effects: pr.effects,
+						execution: pr.execution,
+						review: pr.review,
 						structuredOutput: pr.structuredOutput,
 						structuredOutputPath: pr.structuredOutputPath,
 						structuredOutputSchemaPath: pr.structuredOutputSchemaPath,
@@ -3321,9 +3379,18 @@ async function runSubagent(
 					ts: Date.now(),
 					runId: id,
 					stepIndex,
-					success: parallelResults.every((r) => r.exitCode === 0 || r.exitCode === -1),
+					success: parallelResults.every((r) => r.exitCode === 0 || r.exitCode === -1)
+						&& parallelResults.every((result, index) => !(isAgentContractV1(group.parallel[index]?.agentContract) && group.parallel[index]?.gateOn === "acceptance" && result.acceptance?.status === "rejected")),
 				}));
 
+				const acceptanceGateFailure = parallelResults
+					.map((result, index) => ({ result, index, task: group.parallel[index] }))
+					.find(({ result, task }) => isAgentContractV1(task?.agentContract) && task?.gateOn === "acceptance" && result.acceptance?.status === "rejected");
+				if (acceptanceGateFailure) {
+					statusPayload.error = acceptanceFailureMessage(acceptanceGateFailure.result.acceptance) ?? "Parallel acceptance gate rejected the step.";
+					writeStatusPayload();
+					break;
+				}
 				if (parallelResults.some((r) => r.exitCode !== 0 && r.exitCode !== -1)) {
 					break;
 				}
@@ -3393,6 +3460,7 @@ async function runSubagent(
 			results.push({
 				agent: singleResult.agent,
 				context: singleResult.context,
+				agentContract: singleResult.agentContract,
 				output: stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.output,
 				error: stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error,
 				protocolError: singleResult.protocolError,
@@ -3407,6 +3475,9 @@ async function runSubagent(
 				artifactPaths: singleResult.artifactPaths,
 				transcriptPath: singleResult.transcriptPath,
 				transcriptError: singleResult.transcriptError,
+				effects: singleResult.effects,
+				execution: singleResult.execution,
+				review: singleResult.review,
 				structuredOutput: singleResult.structuredOutput,
 				structuredOutputPath: singleResult.structuredOutputPath,
 				structuredOutputSchemaPath: singleResult.structuredOutputSchemaPath,
@@ -3477,6 +3548,10 @@ async function runSubagent(
 			statusPayload.steps[flatIndex].error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
 			statusPayload.steps[flatIndex].transcriptPath = singleResult.transcriptPath ?? statusPayload.steps[flatIndex].transcriptPath;
 			statusPayload.steps[flatIndex].transcriptError = singleResult.transcriptError;
+			statusPayload.steps[flatIndex].agentContract = singleResult.agentContract;
+			statusPayload.steps[flatIndex].effects = singleResult.effects;
+			statusPayload.steps[flatIndex].execution = singleResult.execution;
+			statusPayload.steps[flatIndex].review = singleResult.review;
 			statusPayload.steps[flatIndex].structuredOutput = singleResult.structuredOutput;
 			statusPayload.steps[flatIndex].structuredOutputPath = singleResult.structuredOutputPath;
 			statusPayload.steps[flatIndex].structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
@@ -3514,6 +3589,11 @@ async function runSubagent(
 			}
 
 			flatIndex++;
+			if (isAgentContractV1(seqStep.agentContract) && seqStep.gateOn === "acceptance" && singleResult.acceptance?.status === "rejected") {
+				statusPayload.error = acceptanceFailureMessage(singleResult.acceptance) ?? "Chain acceptance gate rejected the step.";
+				writeStatusPayload();
+				break;
+			}
 			if (singleResult.exitCode !== 0) {
 				break;
 			}
@@ -3584,7 +3664,7 @@ async function runSubagent(
 		clearTimeout(timeoutTimer);
 		timeoutTimer = undefined;
 	}
-	statusPayload.state = stopped ? "stopped" : timedOut || turnBudgetExceeded ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : "failed";
+	statusPayload.state = stopped ? "stopped" : timedOut || turnBudgetExceeded || statusPayload.error ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : "failed";
 	closeSteerInbox(asyncDir, statusPayload.state);
 	disposeControlInbox();
 	for (const request of consumeSteerRequests(asyncDir)) deliverSteerRequest(request);
@@ -3704,6 +3784,10 @@ async function runSubagent(
 				truncated: r.truncated,
 				transcriptPath: r.transcriptPath,
 				transcriptError: r.transcriptError,
+				agentContract: r.agentContract,
+				execution: r.execution,
+				review: r.review,
+				effects: r.effects,
 				structuredOutput: r.structuredOutput,
 				structuredOutputPath: r.structuredOutputPath,
 				structuredOutputSchemaPath: r.structuredOutputSchemaPath,

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -48,6 +48,7 @@ import {
 } from "../shared/worktree.ts";
 import {
 	type ActivityState,
+	type AgentContract,
 	type AgentProgress,
 	type ArtifactConfig,
 	type ArtifactPaths,
@@ -71,6 +72,7 @@ import { ChainOutputValidationError, outputEntryFromResult, resolveOutputReferen
 import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection, type DynamicCollectedResult } from "../shared/dynamic-fanout.ts";
 import { acceptanceFailureMessage, aggregateAcceptanceReport, evaluateAcceptance, resolveEffectiveAcceptance } from "../shared/acceptance.ts";
+import { isAgentContractV1 } from "../shared/agent-contract.ts";
 import type { ChainOutputMap } from "../../shared/types.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import type { ContextMode } from "../shared/context-mode.ts";
@@ -120,6 +122,7 @@ interface ParallelChainRunInput {
 	onUpdate?: (r: AgentToolResult<Details>) => void;
 	onControlEvent?: (event: ControlEvent) => void;
 	controlConfig: ResolvedControlConfig;
+	agentContract?: AgentContract;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
 	orchestratorIntercomTarget?: string;
 	foregroundControl?: {
@@ -313,6 +316,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 			const structuredRuntime = task.outputSchema
 				? createStructuredOutputRuntime(task.outputSchema, path.join(input.chainDir, "structured-output"))
 				: undefined;
+			const agentContract = task.agentContract ?? input.step.agentContract ?? input.agentContract;
 			const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
 				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 				context: input.contextForAgent?.(task.agent),
@@ -344,6 +348,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				modelScope: input.modelScope,
 				skills: behavior.skills === false ? [] : behavior.skills,
 				structuredOutput: structuredRuntime,
+				agentContract,
 				acceptance: task.acceptance,
 				acceptanceContext: { mode: "chain", dynamic: input.dynamic && task.acceptance === undefined },
 				timeoutMs: input.timeoutMs,
@@ -429,6 +434,7 @@ interface ChainExecutionParams {
 	sessionFileForTask?: (agentName: string, idx?: number, modelOverride?: string) => string | undefined;
 	thinkingOverrideForTask?: (agentName: string, idx?: number, modelOverride?: string) => AgentConfig["thinking"] | undefined;
 	contextForAgent?: (agentName: string) => ContextMode;
+	modelScope?: ModelScopeConfig;
 	artifactsDir: string;
 	artifactConfig: ArtifactConfig;
 	includeProgress?: boolean;
@@ -436,6 +442,7 @@ interface ChainExecutionParams {
 	onUpdate?: (r: AgentToolResult<Details>) => void;
 	onControlEvent?: (event: ControlEvent) => void;
 	controlConfig: ResolvedControlConfig;
+	agentContract?: AgentContract;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
 	orchestratorIntercomTarget?: string;
 	foregroundControl?: {
@@ -747,6 +754,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					dynamicChildren,
 					dynamicGroupStatuses,
 					controlConfig,
+					agentContract: params.agentContract,
 					onControlEvent,
 					childIntercomTarget,
 					orchestratorIntercomTarget,
@@ -810,6 +818,24 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 						details: buildChainExecutionDetails(makeDetailsInput({
 							currentStepIndex: stepIndex,
 							currentFlatIndex: globalTaskIndex - step.parallel.length + failures[0]!.originalIndex,
+						})),
+					};
+				}
+				const acceptanceFailures = parallelResults
+					.map((result, originalIndex) => ({ result, originalIndex, task: step.parallel[originalIndex] }))
+					.filter(({ result, task }) => isAgentContractV1(task?.agentContract ?? step.agentContract ?? params.agentContract) && (task?.gateOn ?? step.gateOn) === "acceptance" && result.acceptance?.status === "rejected");
+				if (acceptanceFailures.length > 0) {
+					const acceptanceSummary = acceptanceFailures
+						.map(({ result, originalIndex }) => `- Task ${originalIndex + 1} (${result.agent}): ${acceptanceFailureMessage(result.acceptance) ?? "acceptance rejected"}`)
+						.join("\n");
+					const errorMsg = `Parallel step ${stepIndex + 1} acceptance gate failed:\n${acceptanceSummary}`;
+					const summary = buildChainSummary(chainSteps, results, chainDir, "failed", { index: stepIndex, error: errorMsg });
+					return {
+						content: [{ type: "text", text: summary }],
+						isError: true,
+						details: buildChainExecutionDetails(makeDetailsInput({
+							currentStepIndex: stepIndex,
+							currentFlatIndex: globalTaskIndex - step.parallel.length + acceptanceFailures[0]!.originalIndex,
 						})),
 					};
 				}
@@ -889,6 +915,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 						task: (step.parallel.task ?? originalTask ?? "").replace(/\{task\}/g, originalTask ?? ""),
 						mode: "chain",
 						dynamicGroup: true,
+						agentContract: step.agentContract ?? params.agentContract,
 					});
 					const groupAcceptance = await evaluateAcceptance({
 						acceptance: effectiveGroupAcceptance,
@@ -898,9 +925,10 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 							notes: "Dynamic fanout produced 0 results.",
 						}),
 						cwd: cwd ?? ctx.cwd,
+						reportOptional: isAgentContractV1(step.agentContract ?? params.agentContract),
 					});
 					dynamicGroupStatuses[stepIndex].acceptance = groupAcceptance;
-					const groupAcceptanceFailure = acceptanceFailureMessage(groupAcceptance);
+					const groupAcceptanceFailure = !isAgentContractV1(step.agentContract ?? params.agentContract) || step.gateOn === "acceptance" ? acceptanceFailureMessage(groupAcceptance) : undefined;
 					if (groupAcceptanceFailure) {
 						dynamicGroupStatuses[stepIndex] = { status: "failed", error: groupAcceptanceFailure, acceptance: groupAcceptance };
 						return buildChainExecutionErrorResult(groupAcceptanceFailure, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }));
@@ -915,6 +943,8 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				parallel: materialized.parallel,
 				concurrency: step.concurrency,
 				failFast: step.failFast,
+				agentContract: step.agentContract,
+				gateOn: step.gateOn,
 			};
 			const parallelTemplates = materialized.parallel.map((task) => task.task ?? "{previous}");
 			const parallelBehaviors = resolveParallelBehaviors(dynamicParallelStep.parallel, agents, stepIndex, chainSkills)
@@ -969,6 +999,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				dynamicChildren,
 				dynamicGroupStatuses,
 				controlConfig,
+				agentContract: params.agentContract,
 				onControlEvent,
 				childIntercomTarget,
 				orchestratorIntercomTarget,
@@ -1036,6 +1067,22 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					})),
 				};
 			}
+			const acceptanceFailures = parallelResults
+				.map((result, originalIndex) => ({ result, originalIndex, task: dynamicParallelStep.parallel[originalIndex] }))
+				.filter(({ result, task }) => isAgentContractV1(task?.agentContract ?? dynamicParallelStep.agentContract ?? params.agentContract) && (task?.gateOn ?? dynamicParallelStep.gateOn) === "acceptance" && result.acceptance?.status === "rejected");
+			if (acceptanceFailures.length > 0) {
+				const acceptanceSummary = acceptanceFailures
+					.map(({ result, originalIndex }) => `- Item ${originalIndex + 1} (${result.agent}, key ${materialized.items[originalIndex]?.key ?? originalIndex}): ${acceptanceFailureMessage(result.acceptance) ?? "acceptance rejected"}`)
+					.join("\n");
+				const errorMsg = `Dynamic step ${stepIndex + 1} acceptance gate failed:\n${acceptanceSummary}`;
+				dynamicGroupStatuses[stepIndex] = { status: "failed", error: errorMsg };
+				const summary = buildChainSummary(chainSteps, results, chainDir, "failed", { index: stepIndex, error: errorMsg });
+				return {
+					content: [{ type: "text", text: summary }],
+					isError: true,
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: dynamicStartIndex + acceptanceFailures[0]!.originalIndex })),
+				};
+			}
 			try {
 				await validateDynamicCollection(step.collect.outputSchema, collected);
 			} catch (error) {
@@ -1059,6 +1106,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					.join("\n"),
 				mode: "chain",
 				dynamicGroup: true,
+				agentContract: step.agentContract ?? params.agentContract,
 			});
 			const groupAcceptance = await evaluateAcceptance({
 				acceptance: effectiveGroupAcceptance,
@@ -1068,9 +1116,10 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					notes: `Dynamic fanout collected ${collected.length} result(s) into ${step.collect.as}.`,
 				}),
 				cwd: cwd ?? ctx.cwd,
+				reportOptional: isAgentContractV1(step.agentContract ?? params.agentContract),
 			});
 			dynamicGroupStatuses[stepIndex].acceptance = groupAcceptance;
-			const groupAcceptanceFailure = effectiveGroupAcceptance.explicit ? acceptanceFailureMessage(groupAcceptance) : undefined;
+			const groupAcceptanceFailure = effectiveGroupAcceptance.explicit && (!isAgentContractV1(step.agentContract ?? params.agentContract) || step.gateOn === "acceptance") ? acceptanceFailureMessage(groupAcceptance) : undefined;
 			if (groupAcceptanceFailure) {
 				dynamicGroupStatuses[stepIndex] = { status: "failed", error: groupAcceptanceFailure, acceptance: groupAcceptance };
 				return buildChainExecutionErrorResult(groupAcceptanceFailure, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex - dynamicParallelStep.parallel.length }));
@@ -1169,6 +1218,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			const structuredRuntime = seqStep.outputSchema
 				? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
 				: undefined;
+			const agentContract = seqStep.agentContract ?? params.agentContract;
 			const toolBudget = resolveChainToolBudget({ stepBudget: seqStep.toolBudget, runBudget: params.toolBudget, agentBudget: agentConfig?.toolBudget, configBudget: params.configToolBudget });
 			if (toolBudget.error) return buildChainExecutionErrorResult(toolBudget.error, {
 				results,
@@ -1217,6 +1267,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				modelScope,
 				skills: behavior.skills === false ? [] : behavior.skills,
 				structuredOutput: structuredRuntime,
+				agentContract,
 				acceptance: seqStep.acceptance,
 				acceptanceContext: { mode: "chain" },
 				timeoutMs: params.timeoutMs,
@@ -1298,6 +1349,17 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				const summary = buildChainSummary(chainSteps, results, chainDir, "failed", {
 					index: stepIndex,
 					error: r.error || "Chain failed",
+				});
+				return {
+					content: [{ type: "text", text: summary }],
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: childIndex })),
+					isError: true,
+				};
+			}
+			if (isAgentContractV1(agentContract) && seqStep.gateOn === "acceptance" && r.acceptance?.status === "rejected") {
+				const summary = buildChainSummary(chainSteps, results, chainDir, "failed", {
+					index: stepIndex,
+					error: acceptanceFailureMessage(r.acceptance) ?? "Chain acceptance gate rejected the step.",
 				});
 				return {
 					content: [{ type: "text", text: summary }],

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -72,6 +72,7 @@ import {
 	summarizeRecentMutatingFailures,
 } from "../shared/long-running-guard.ts";
 import { acceptanceFailureMessage, buildSkippedAcceptanceLedger, evaluateAcceptance, formatAcceptancePrompt, resolveEffectiveAcceptance, stripAcceptanceReport } from "../shared/acceptance.ts";
+import { attachContractProjections, isAgentContractV1 } from "../shared/agent-contract.ts";
 import { appendTurnBudgetSystemPrompt, formatTurnBudgetOutput, initialTurnBudgetState, turnBudgetDecision, turnBudgetDeferredNote, turnBudgetDeferredState, turnBudgetExceededMessage, turnBudgetSoftNote, turnBudgetState } from "../shared/turn-budget.ts";
 import { initialToolBudgetState, toolBudgetState } from "../shared/tool-budget.ts";
 import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
@@ -250,6 +251,7 @@ async function runSingleAttempt(
 	const result: SingleResult = withRunContext({
 		agent: agent.name,
 		task: shared.originalTask ?? task,
+		...(options.agentContract ? { agentContract: options.agentContract } : {}),
 		exitCode: 0,
 		messages: [],
 		usage: emptyUsage(),
@@ -1093,7 +1095,8 @@ async function runSingleAttempt(
 		const note = turnBudgetSoftNote(result.turnBudget, result.turnBudget.wrapUpRequestedAtTurn ?? result.turnBudget.turnCount);
 		fullOutput = fullOutput.trim() ? `${note}\n\n${fullOutput}` : note;
 	}
-	const completionGuard = result.exitCode === 0 && !result.error && agent.completionGuard !== false
+	const completionGuardEnabled = isAgentContractV1(options.agentContract) ? agent.completionGuard === true : agent.completionGuard !== false;
+	const completionGuard = result.exitCode === 0 && !result.error && completionGuardEnabled
 		? evaluateCompletionMutationGuard({
 			agent: agent.name,
 			task: shared.originalTask ?? task,
@@ -1102,7 +1105,19 @@ async function runSingleAttempt(
 			mcpDirectTools: agent.mcpDirectTools,
 		})
 		: undefined;
-	if (completionGuard?.triggered && !observedMutationAttempt) {
+	const completionGuardTriggered = completionGuard?.triggered === true && !observedMutationAttempt;
+	if (completionGuard) {
+		result.effects = {
+			...(result.effects ?? {}),
+			fileMutation: {
+				status: completionGuard.expectedMutation ? completionGuardTriggered ? "missing" : "observed" : "not-applicable",
+				expected: completionGuard.expectedMutation,
+				attempted: completionGuard.attemptedMutation || observedMutationAttempt,
+				...(completionGuardTriggered ? { message: "Subagent completed without making edits for an implementation task." } : {}),
+			},
+		};
+	}
+	if (completionGuardTriggered && !isAgentContractV1(options.agentContract)) {
 		result.exitCode = 1;
 		result.error = "Subagent completed without making edits for an implementation task.\nIt appears to have returned planning or scratchpad output instead of applying changes.";
 		progress.status = "failed";
@@ -1195,8 +1210,9 @@ export async function runSync(
 		async: options.acceptanceContext?.async,
 		dynamic: options.acceptanceContext?.dynamic,
 		dynamicGroup: options.acceptanceContext?.dynamicGroup,
+		agentContract: options.agentContract,
 	});
-	const acceptancePrompt = formatAcceptancePrompt(effectiveAcceptance);
+	const acceptancePrompt = formatAcceptancePrompt(effectiveAcceptance, { reportOptional: isAgentContractV1(options.agentContract) });
 	const taskWithAcceptance = acceptancePrompt ? `${task}\n${acceptancePrompt}` : task;
 	const sessionEnabled = Boolean(options.sessionFile || options.sessionDir) || shareEnabled;
 	const skillNames = options.skills ?? agent.skills ?? [];
@@ -1282,7 +1298,11 @@ export async function runSync(
 			durationMs: target.progressSummary?.durationMs,
 			toolCount: target.progressSummary?.toolCount,
 			error: target.error,
+			agentContract: target.agentContract,
+			execution: target.execution,
 			acceptance: target.acceptance,
+			review: target.review,
+			effects: target.effects,
 			...(transcriptWriter ? { transcriptPath: artifactPathsResult.transcriptPath } : {}),
 			transcriptError: target.transcriptError,
 			skills: target.skills,
@@ -1306,10 +1326,11 @@ export async function runSync(
 							? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
 							: undefined,
 						cwd: options.cwd ?? runtimeCwd,
+						reportOptional: isAgentContractV1(options.agentContract),
 					});
 					const acceptanceFailure = acceptanceFailureMessage(recoveredResult.acceptance);
 					stripAcceptanceReportsFromMessages(recoveredResult.messages);
-					if (acceptanceFailure && recoveredResult.acceptance.explicit && recoveredResult.exitCode === 0) {
+					if (acceptanceFailure && recoveredResult.acceptance.explicit && recoveredResult.exitCode === 0 && !isAgentContractV1(options.agentContract)) {
 						recoveredResult.exitCode = 1;
 						recoveredResult.error = recoveredResult.error ? `${recoveredResult.error}\n${acceptanceFailure}` : acceptanceFailure;
 						if (recoveredResult.progress) {
@@ -1317,6 +1338,7 @@ export async function runSync(
 							recoveredResult.progress.error = recoveredResult.error;
 						}
 					}
+					if (isAgentContractV1(options.agentContract)) attachContractProjections(recoveredResult);
 					persistResultMetadata(recoveredResult);
 					options.onDetachedExit?.(recoveredResult);
 				})().catch((error) => {
@@ -1447,11 +1469,12 @@ export async function runSync(
 				? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
 				: undefined,
 			cwd: options.cwd ?? runtimeCwd,
+			reportOptional: isAgentContractV1(options.agentContract),
 		});
 	}
 	const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
 	stripAcceptanceReportsFromMessages(result.messages);
-	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.detached && !result.interrupted && !result.timedOut) {
+	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.detached && !result.interrupted && !result.timedOut && !isAgentContractV1(options.agentContract)) {
 		result.exitCode = 1;
 		result.error = result.error ? `${result.error}\n${acceptanceFailure}` : acceptanceFailure;
 		if (result.progress) {
@@ -1459,6 +1482,7 @@ export async function runSync(
 			result.progress.error = result.error;
 		}
 	}
+	if (isAgentContractV1(options.agentContract)) attachContractProjections(result);
 	persistResultMetadata(result);
 
 	return result;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -46,7 +46,9 @@ import { formatControlIntercomMessage, formatControlNoticeMessage, resolveContro
 import { resolveTurnBudgetConfig } from "../shared/turn-budget.ts";
 import { formatSpawnBudget, getSpawnBudgetSnapshot, grantSpawnBudget, preflightSpawnBudget, preflightSpawnBudgetGrant, reserveSpawnBudget } from "../shared/spawn-budget.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
+import { isAgentContractV1 } from "../shared/agent-contract.ts";
 import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
+import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
 import { summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
@@ -82,6 +84,7 @@ import {
 	type AgentProgress,
 	type AsyncStatus,
 	type AcceptanceInput,
+	type AgentContract,
 	type ArtifactConfig,
 	type ArtifactPaths,
 	type ControlConfig,
@@ -89,6 +92,7 @@ import {
 	type Details,
 	type ExtensionConfig,
 	type IntercomEventBus,
+	type JsonSchemaObject,
 	type MaxOutputConfig,
 	type NestedRouteInfo,
 	type NestedRunSummary,
@@ -128,7 +132,9 @@ interface TaskParam {
 	progress?: boolean;
 	model?: string;
 	skill?: string | string[] | boolean;
+	outputSchema?: JsonSchemaObject;
 	acceptance?: AcceptanceInput;
+	agentContract?: AgentContract;
 	toolBudget?: ToolBudgetConfig;
 }
 
@@ -169,9 +175,11 @@ export interface SubagentParamsLike {
 	skill?: string | string[] | boolean;
 	output?: string | boolean;
 	outputMode?: "inline" | "file-only";
+	outputSchema?: JsonSchemaObject;
 	agentScope?: unknown;
 	chainDir?: string;
 	acceptance?: AcceptanceInput;
+	agentContract?: AgentContract;
 	schedule?: string;
 	scheduleName?: string;
 	additional?: number;
@@ -1254,6 +1262,7 @@ async function resumeAsyncRun(input: {
 			shareEnabled: input.params.share === true,
 			sessionRoot: input.deps.getSubagentSessionRoot(parentSessionFile),
 			chainSkills: normalized === false ? [] : (normalized ?? []),
+			agentContract: input.params.agentContract,
 			dynamicFanoutMaxItems: input.deps.config.chain?.dynamicFanout?.maxItems,
 			maxSubagentDepth: resolveCurrentMaxSubagentDepth(input.deps.config.maxSubagentDepth),
 			waitToolEnabled: input.deps.waitToolEnabled,
@@ -1325,6 +1334,8 @@ async function resumeAsyncRun(input: {
 		availableModels,
 		output: recoveryDescriptor?.outputPath,
 		outputMode: recoveryDescriptor?.outputMode,
+		...(recoveryDescriptor?.agentContract ? { agentContract: recoveryDescriptor.agentContract } : {}),
+		...(recoveryDescriptor?.structuredOutputSchema ? { structuredOutputSchema: recoveryDescriptor.structuredOutputSchema } : {}),
 		...(recoveryDescriptor?.skills ? { skills: [...recoveryDescriptor.skills] } : {}),
 		...(recoveryDescriptor?.acceptance !== undefined && input.params.acceptance === undefined ? { acceptance: recoveryDescriptor.acceptance } : {}),
 		...(input.params.timeoutMs !== undefined ? { timeoutMs: input.params.timeoutMs } : {}),
@@ -2025,6 +2036,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			...(task.reads !== undefined && task.reads !== true ? { reads: task.reads } : {}),
 			...(task.progress !== undefined ? { progress: task.progress } : {}),
 			...(task.toolBudget !== undefined ? { toolBudget: task.toolBudget } : {}),
+			...(task.outputSchema !== undefined ? { outputSchema: task.outputSchema } : {}),
+			...(task.agentContract !== undefined ? { agentContract: task.agentContract } : {}),
 			...(task.acceptance !== undefined ? { acceptance: task.acceptance } : {}),
 		}));
 		return executeAsyncChain(id, {
@@ -2054,6 +2067,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 			worktreeBaseDir: deps.config.worktreeBaseDir,
 			controlConfig,
+			agentContract: params.agentContract,
 			controlIntercomTarget,
 			childIntercomTarget,
 			nestedRoute,
@@ -2094,6 +2108,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 			worktreeBaseDir: deps.config.worktreeBaseDir,
 			controlConfig,
+			agentContract: params.agentContract,
 			controlIntercomTarget,
 			childIntercomTarget,
 			nestedRoute,
@@ -2151,6 +2166,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			controlIntercomTarget,
 			childIntercomTarget: childIntercomTarget ? (agent, index) => childIntercomTarget(agent, index) : undefined,
 			nestedRoute,
+			agentContract: params.agentContract,
+			structuredOutputSchema: params.outputSchema,
 			acceptance: params.acceptance,
 			timeoutMs: data.timeoutMs,
 			turnBudget: data.turnBudget,
@@ -2212,6 +2229,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		onUpdate,
 		onControlEvent,
 		controlConfig,
+		agentContract: params.agentContract,
 		childIntercomTarget: childIntercomTarget ? (agent, index) => childIntercomTarget(runId, agent, index) : undefined,
 		orchestratorIntercomTarget: data.intercomBridge.active ? data.intercomBridge.orchestratorTarget : undefined,
 		foregroundControl,
@@ -2278,6 +2296,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 			worktreeBaseDir: deps.config.worktreeBaseDir,
 			controlConfig,
+			agentContract: params.agentContract,
 			controlIntercomTarget: data.intercomBridge.active ? data.intercomBridge.orchestratorTarget : undefined,
 			childIntercomTarget: data.intercomBridge.active ? (agent, index) => resolveSubagentIntercomTarget(id, agent, index) : undefined,
 			nestedRoute: data.nestedRoute,
@@ -2362,8 +2381,8 @@ interface ForegroundParallelRunInput {
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
 	toolBudgets: (ResolvedToolBudget | undefined)[];
+	agentContract?: AgentContract;
 }
-
 function buildParallelModeError(message: string): AgentToolResult<Details> {
 	return {
 		content: [{ type: "text", text: message }],
@@ -2509,6 +2528,9 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 				return true;
 			};
 		}
+		const structuredRuntime = task.outputSchema
+			? createStructuredOutputRuntime(task.outputSchema, path.join(input.artifactsDir, "structured-output", input.runId))
+			: undefined;
 		return runSync(input.ctx.cwd, input.agents, task.agent, taskText, {
 			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 			context: input.contextPolicy.contextForAgent(task.agent),
@@ -2541,6 +2563,8 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			preferredModelProvider: input.ctx.model?.provider,
 			modelScope: input.modelScope,
 			skills: effectiveSkills === false ? [] : effectiveSkills,
+			structuredOutput: structuredRuntime,
+			agentContract: task.agentContract ?? input.agentContract,
 			acceptance: task.acceptance,
 			acceptanceContext: { mode: "parallel" },
 			timeoutMs: input.timeoutMs,
@@ -2750,7 +2774,9 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 					...(behaviorOverrides[i]?.reads !== undefined ? { reads: behaviorOverrides[i]!.reads } : {}),
 					...(progress !== undefined ? { progress } : {}),
 					...(t.toolBudget !== undefined ? { toolBudget: t.toolBudget } : {}),
+					...(t.outputSchema !== undefined ? { outputSchema: t.outputSchema } : {}),
 					...(t.acceptance !== undefined ? { acceptance: t.acceptance } : {}),
+					...(t.agentContract !== undefined ? { agentContract: t.agentContract } : {}),
 				};
 			});
 			return executeAsyncChain(id, {
@@ -2776,10 +2802,14 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 				worktreeBaseDir: deps.config.worktreeBaseDir,
 				controlConfig,
+				agentContract: params.agentContract,
 				controlIntercomTarget: data.intercomBridge.active ? data.intercomBridge.orchestratorTarget : undefined,
 				childIntercomTarget: data.intercomBridge.active ? (agent, index) => resolveSubagentIntercomTarget(id, agent, index) : undefined,
+				nestedRoute: data.nestedRoute,
 				timeoutMs: data.timeoutMs,
 				turnBudget: data.turnBudget,
+				toolBudget: data.toolBudget,
+				configToolBudget: data.configToolBudget,
 				globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 			});
 		}
@@ -2872,6 +2902,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			deadlineAt,
 			turnBudget: data.turnBudget,
 			toolBudgets,
+			agentContract: params.agentContract,
 		});
 		for (let i = 0; i < results.length; i++) {
 			const run = results[i]!;
@@ -3089,6 +3120,10 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				controlConfig,
 				controlIntercomTarget: data.intercomBridge.active ? data.intercomBridge.orchestratorTarget : undefined,
 				childIntercomTarget: data.intercomBridge.active ? (agent, index) => resolveSubagentIntercomTarget(id, agent, index) : undefined,
+				nestedRoute: data.nestedRoute,
+				agentContract: params.agentContract,
+				structuredOutputSchema: params.outputSchema,
+				acceptance: params.acceptance,
 				timeoutMs: data.timeoutMs,
 				turnBudget: data.turnBudget,
 				toolBudget: effectiveToolBudget.toolBudget,
@@ -3101,6 +3136,9 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	}
 	const cleanTask = task;
 	const outputPath = resolveSingleOutputPath(effectiveOutput, ctx.cwd, effectiveCwd, resolveSingleRunOutputBaseDir(deps, artifactsDir, runId));
+	const structuredRuntime = params.outputSchema
+		? createStructuredOutputRuntime(params.outputSchema, path.join(artifactsDir, "structured-output", runId))
+		: undefined;
 	const validationError = validateFileOnlyOutputMode(effectiveOutputMode, outputPath, `Single run (${params.agent})`);
 	if (validationError) {
 		return { content: [{ type: "text", text: validationError }], isError: true, details: { mode: "single", results: [] } };
@@ -3182,6 +3220,8 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		preferredModelProvider: currentProvider,
 		modelScope: data.modelScope,
 		skills: effectiveSkills,
+		structuredOutput: structuredRuntime,
+		agentContract: params.agentContract,
 		acceptance: params.acceptance,
 		acceptanceContext: { mode: "single" },
 		onDetachedExit: (result) => updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events }),

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -6,6 +6,7 @@ import type {
 	AcceptanceConfig,
 	AcceptanceEvidenceKind,
 	AcceptanceInput,
+	AgentContract,
 	AcceptanceLedger,
 	AcceptanceLevel,
 	AcceptanceReport,
@@ -20,6 +21,7 @@ import type {
 	SingleResult,
 	SubagentRunMode,
 } from "../../shared/types.ts";
+import { isAgentContractV1 } from "./agent-contract.ts";
 import { classifyTaskMutationIntent, taskMayMutate } from "./task-intent.ts";
 
 const LEVEL_RANK: Record<Exclude<AcceptanceLevel, "auto">, number> = {
@@ -324,10 +326,32 @@ export function resolveEffectiveAcceptance(input: {
 	async?: boolean;
 	dynamic?: boolean;
 	dynamicGroup?: boolean;
+	agentContract?: AgentContract;
 }): ResolvedAcceptanceConfig {
 	const explicit = normalizeAcceptanceInput(input.explicit);
-	const inferred = inferLevel(input);
 	const explicitLevel = normalizeLevel(explicit.level);
+	if (isAgentContractV1(input.agentContract)) {
+		const level = explicitAcceptanceCanDisable(explicit) || explicitLevel === "auto"
+			? "none"
+			: explicitLevel;
+		const evidence = unique(explicit.evidence ?? []);
+		const criteria = normalizeCriteria(
+			explicit.criteria as Array<string | { id?: string; must?: string; evidence?: AcceptanceEvidenceKind[]; severity?: "required" | "recommended" }> | undefined,
+			evidence,
+		);
+		return {
+			level,
+			explicit: input.explicit !== undefined,
+			inferredReason: [],
+			criteria,
+			evidence,
+			verify: explicit.verify ?? [],
+			review: explicit.review,
+			stopRules: explicit.stopRules ?? [],
+			reason: explicit.reason,
+		};
+	}
+	const inferred = inferLevel(input);
 	const level = explicitAcceptanceCanDisable(explicit)
 		? "none"
 		: explicitLevel === "auto"
@@ -355,8 +379,13 @@ export function resolveEffectiveAcceptance(input: {
 	};
 }
 
-export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig): string {
+function acceptanceRequiresChildReport(acceptance: ResolvedAcceptanceConfig): boolean {
+	return acceptance.criteria.length > 0 || acceptance.evidence.length > 0;
+}
+
+export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig, options: { reportOptional?: boolean } = {}): string {
 	if (acceptance.level === "none") return "";
+	if (options.reportOptional && !acceptanceRequiresChildReport(acceptance)) return "";
 	const lines = [
 		"",
 		"## Acceptance Contract",
@@ -1029,6 +1058,7 @@ export async function evaluateAcceptance(input: {
 	reviewResult?: AcceptanceReviewResult;
 	signal?: AbortSignal;
 	abortMessage?: string;
+	reportOptional?: boolean;
 }): Promise<AcceptanceLedger> {
 	const acceptance = input.acceptance;
 	const ledger: AcceptanceLedger = {
@@ -1050,26 +1080,30 @@ export async function evaluateAcceptance(input: {
 				: { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}` };
 		})()
 		: parseAcceptanceReportSources(input.output, input.fileOutput);
+	const needsReport = acceptanceRequiresChildReport(acceptance);
 	if (parsed.report) {
 		ledger.childReport = parsed.report;
 		ledger.status = "attested";
-	} else {
+	} else if (!input.reportOptional || needsReport || parsed.error !== ACCEPTANCE_REPORT_NOT_FOUND) {
 		ledger.childReportParseError = parsed.error;
 		ledger.runtimeChecks.push({ id: "attestation", status: "failed", message: parsed.error ?? "Structured acceptance report missing." });
-		ledger.status = "rejected";
-		return ledger;
-	}
-
-	if (LEVEL_RANK[acceptance.level] >= LEVEL_RANK.checked) {
-		ledger.runtimeChecks = [
-			...checkCriteriaSatisfied(acceptance.criteria, parsed.report),
-			...runStructuralChecks(acceptance, parsed.report, input.cwd),
-		];
-		if (ledger.runtimeChecks.some((check) => check.status === "failed")) {
+		if (!input.reportOptional) {
 			ledger.status = "rejected";
 			return ledger;
 		}
-		ledger.status = "checked";
+	} else {
+		ledger.childReportParseError = parsed.error;
+	}
+
+	if (parsed.report && LEVEL_RANK[acceptance.level] >= LEVEL_RANK.checked) {
+		ledger.runtimeChecks = [
+			...ledger.runtimeChecks,
+			...checkCriteriaSatisfied(acceptance.criteria, parsed.report),
+			...runStructuralChecks(acceptance, parsed.report, input.cwd),
+		];
+		if (!ledger.runtimeChecks.some((check) => check.status === "failed")) {
+			ledger.status = "checked";
+		}
 	}
 
 	if (LEVEL_RANK[acceptance.level] >= LEVEL_RANK.verified && (acceptance.level === "verified" || acceptance.verify.length > 0)) {
@@ -1087,7 +1121,15 @@ export async function evaluateAcceptance(input: {
 			ledger.status = "rejected";
 			return ledger;
 		}
-		ledger.status = "verified";
+		if (!ledger.runtimeChecks.some((check) => check.status === "failed")) ledger.status = "verified";
+	}
+
+	if (ledger.runtimeChecks.some((check) => check.status === "failed")) {
+		ledger.status = "rejected";
+		return ledger;
+	}
+	if (ledger.status === "claimed" && acceptance.level !== "reviewed") {
+		ledger.status = acceptance.level === "verified" ? "verified" : acceptance.level;
 	}
 
 	if (acceptance.level === "reviewed") {

--- a/src/runs/shared/agent-contract.ts
+++ b/src/runs/shared/agent-contract.ts
@@ -1,0 +1,38 @@
+import type { AgentContract, EffectsProjection, ExecutionProjection, ReviewProjection, SingleResult } from "../../shared/types.ts";
+
+export function isAgentContractV1(contract: AgentContract | undefined): boolean {
+	return contract?.version === 1;
+}
+
+export function buildExecutionProjection(result: Pick<SingleResult, "exitCode" | "error" | "interrupted" | "timedOut" | "stopped" | "detached">): ExecutionProjection {
+	if (result.detached) {
+		return { status: "detached", success: false, exitCode: result.exitCode, detached: true, ...(result.error ? { error: result.error } : {}) };
+	}
+	if (result.stopped) {
+		return { status: "stopped", success: false, exitCode: result.exitCode, stopped: true, ...(result.error ? { error: result.error } : {}) };
+	}
+	if (result.interrupted) {
+		return { status: "paused", success: true, exitCode: result.exitCode, interrupted: true, ...(result.error ? { error: result.error } : {}) };
+	}
+	const success = result.exitCode === 0 && !result.error && !result.timedOut;
+	return {
+		status: success ? "completed" : "failed",
+		success,
+		exitCode: result.exitCode,
+		...(result.error ? { error: result.error } : {}),
+		...(result.timedOut ? { timedOut: true } : {}),
+	};
+}
+
+export function buildReviewProjection(result: Pick<SingleResult, "acceptance">): ReviewProjection {
+	const review = result.acceptance?.reviewResult;
+	if (!review) return { status: "not-requested" };
+	return { status: review.status, findings: review.findings };
+}
+
+export function attachContractProjections<T extends SingleResult>(result: T): T {
+	result.execution = buildExecutionProjection(result);
+	result.review = buildReviewProjection(result);
+	if (!result.effects) result.effects = {} satisfies EffectsProjection;
+	return result;
+}

--- a/src/runs/shared/dynamic-fanout.ts
+++ b/src/runs/shared/dynamic-fanout.ts
@@ -42,11 +42,11 @@ const SAFE_OUTPUT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const ITEM_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const ITEM_REF_PATTERN = /\{([A-Za-z_][A-Za-z0-9_]*)(?:\.([^{}]+))?\}/g;
 const RESERVED_TEMPLATE_NAMES = new Set(["task", "previous", "chain_dir", "outputs"]);
-const DYNAMIC_STEP_KEYS = new Set(["expand", "parallel", "collect", "concurrency", "failFast", "phase", "label", "acceptance"]);
+const DYNAMIC_STEP_KEYS = new Set(["expand", "parallel", "collect", "concurrency", "failFast", "phase", "label", "acceptance", "agentContract", "gateOn"]);
 const RUNNER_DYNAMIC_STEP_KEYS = new Set([...DYNAMIC_STEP_KEYS, "effectiveAcceptance", "acceptanceInput", "acceptanceRole", "sessionFiles", "thinkingOverrides"]);
 const DYNAMIC_EXPAND_KEYS = new Set(["from", "item", "key", "maxItems", "onEmpty"]);
 const DYNAMIC_EXPAND_FROM_KEYS = new Set(["output", "path"]);
-const DYNAMIC_PARALLEL_KEYS = new Set(["agent", "task", "phase", "label", "outputSchema", "cwd", "output", "outputMode", "reads", "progress", "skill", "model", "toolBudget", "acceptance"]);
+const DYNAMIC_PARALLEL_KEYS = new Set(["agent", "task", "phase", "label", "outputSchema", "cwd", "output", "outputMode", "reads", "progress", "skill", "model", "toolBudget", "acceptance", "agentContract", "gateOn"]);
 const RUNNER_DYNAMIC_PARALLEL_KEYS = new Set([
 	...DYNAMIC_PARALLEL_KEYS,
 	"outputName", "structured", "inheritProjectContext", "inheritSkills", "skills", "outputPath", "namespaceOutputPath", "maxSubagentDepth", "waitToolEnabled",

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -42,9 +42,11 @@ export interface RunnerSubagentStep {
 		outputPath: string;
 	};
 	structuredOutputSchema?: import("../../shared/types.ts").JsonSchemaObject;
+	agentContract?: import("../../shared/types.ts").AgentContract;
 	effectiveAcceptance?: import("../../shared/types.ts").ResolvedAcceptanceConfig;
 	acceptanceInput?: import("../../shared/types.ts").AcceptanceInput;
 	acceptanceRole?: import("../../shared/types.ts").AcceptanceRole;
+	gateOn?: import("../../shared/types.ts").ChainGateLayer;
 	toolBudget?: import("../../shared/types.ts").ResolvedToolBudget;
 }
 
@@ -68,6 +70,8 @@ export interface DynamicRunnerGroup {
 	effectiveAcceptance?: import("../../shared/types.ts").ResolvedAcceptanceConfig;
 	acceptanceInput?: import("../../shared/types.ts").AcceptanceInput;
 	acceptanceRole?: import("../../shared/types.ts").AcceptanceRole;
+	agentContract?: import("../../shared/types.ts").AgentContract;
+	gateOn?: import("../../shared/types.ts").ChainGateLayer;
 }
 
 export type RunnerStep = RunnerSubagentStep | ParallelStepGroup | DynamicRunnerGroup;

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentConfig } from "../agents/agents.ts";
 import { normalizeSkillInput } from "../agents/skills.ts";
-import { CHAIN_RUNS_DIR, type AcceptanceInput, type JsonSchemaObject, type OutputMode, type ToolBudgetConfig } from "./types.ts";
+import { CHAIN_RUNS_DIR, type AcceptanceInput, type AgentContract, type ChainGateLayer, type JsonSchemaObject, type OutputMode, type ToolBudgetConfig } from "./types.ts";
 const CHAIN_DIR_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const INITIAL_PROGRESS_CONTENT = "# Progress\n\n## Status\nIn Progress\n\n## Tasks\n\n## Files Changed\n\n## Notes\n";
 
@@ -57,6 +57,8 @@ export interface SequentialStep {
 	model?: string;
 	toolBudget?: ToolBudgetConfig;
 	acceptance?: AcceptanceInput;
+	agentContract?: AgentContract;
+	gateOn?: ChainGateLayer;
 }
 
 /** Parallel task item within a parallel step */
@@ -77,6 +79,8 @@ export interface ParallelTaskItem {
 	model?: string;
 	toolBudget?: ToolBudgetConfig;
 	acceptance?: AcceptanceInput;
+	agentContract?: AgentContract;
+	gateOn?: ChainGateLayer;
 }
 
 export interface DynamicExpandSpec {
@@ -106,6 +110,8 @@ export interface DynamicParallelStep {
 	phase?: string;
 	label?: string;
 	acceptance?: AcceptanceInput;
+	agentContract?: AgentContract;
+	gateOn?: ChainGateLayer;
 }
 
 /** Parallel step: multiple agents running concurrently */
@@ -115,6 +121,8 @@ export interface ParallelStep {
 	failFast?: boolean;
 	worktree?: boolean;
 	cwd?: string;
+	agentContract?: AgentContract;
+	gateOn?: ChainGateLayer;
 }
 
 /** Union type for chain steps */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -214,6 +214,42 @@ export interface ControlEvent {
 
 export type SubagentResultStatus = "completed" | "failed" | "paused" | "stopped" | "detached";
 export type SubagentRunMode = "single" | "parallel" | "chain";
+
+export interface AgentContract {
+	version: 1;
+}
+
+export type ChainGateLayer = "execution" | "acceptance";
+
+export type ExecutionProjectionStatus = "completed" | "failed" | "paused" | "stopped" | "detached";
+
+export interface ExecutionProjection {
+	status: ExecutionProjectionStatus;
+	success: boolean;
+	exitCode: number;
+	error?: string;
+	interrupted?: boolean;
+	timedOut?: boolean;
+	stopped?: boolean;
+	detached?: boolean;
+}
+
+export interface ReviewProjection {
+	status: "not-requested" | "no-blockers" | "blockers" | "needs-parent-decision";
+	findings?: AcceptanceReviewResult["findings"];
+}
+
+export interface FileMutationEffect {
+	status: "not-requested" | "not-applicable" | "observed" | "missing";
+	expected: boolean;
+	attempted: boolean;
+	message?: string;
+}
+
+export interface EffectsProjection {
+	fileMutation?: FileMutationEffect;
+}
+
 export const SUBAGENT_LIFECYCLE_ARTIFACT_VERSION = 2;
 export type SubagentLifecycleArtifactVersion = typeof SUBAGENT_LIFECYCLE_ARTIFACT_VERSION;
 
@@ -282,6 +318,7 @@ export interface SteeringNotice {
 export interface SteeringRecoveryDescriptor {
 	version: 1;
 	sourceRunId: string;
+	agentContract?: AgentContract;
 	agent: string;
 	sessionFile?: string;
 	cwd: string;
@@ -303,6 +340,7 @@ export interface SteeringRecoveryDescriptor {
 	memory?: { scope: "project" | "user"; path: string };
 	outputPath?: string;
 	outputMode: "inline" | "file-only";
+	structuredOutputSchema?: JsonSchemaObject;
 	acceptance?: AcceptanceInput;
 	controlConfig?: ResolvedControlConfig;
 	absoluteDeadlineAt?: number;
@@ -623,6 +661,10 @@ export interface SingleResult {
 	structuredOutputPath?: string;
 	structuredOutputSchemaPath?: string;
 	acceptance?: AcceptanceLedger;
+	agentContract?: AgentContract;
+	execution?: ExecutionProjection;
+	review?: ReviewProjection;
+	effects?: EffectsProjection;
 	transcriptPath?: string;
 	transcriptError?: string;
 	children?: NestedRunSummary[];
@@ -915,6 +957,10 @@ export interface AsyncStatus {
 		structuredOutputPath?: string;
 		structuredOutputSchemaPath?: string;
 		acceptance?: AcceptanceLedger;
+		agentContract?: AgentContract;
+		execution?: ExecutionProjection;
+		review?: ReviewProjection;
+		effects?: EffectsProjection;
 		watchdog?: ChildWatchdogProgress;
 	}>;
 	sessionDir?: string;
@@ -1001,6 +1047,10 @@ export interface ForegroundResumeChild {
 	transcriptError?: string;
 	detachedReason?: string;
 	acceptance?: AcceptanceLedger;
+	agentContract?: AgentContract;
+	execution?: ExecutionProjection;
+	review?: ReviewProjection;
+	effects?: EffectsProjection;
 	updatedAt?: number;
 }
 
@@ -1152,6 +1202,7 @@ export interface RunSyncOptions {
 		schemaPath: string;
 		outputPath: string;
 	};
+	agentContract?: AgentContract;
 	acceptance?: AcceptanceInput;
 	acceptanceContext?: {
 		mode?: SubagentRunMode;

--- a/src/slash/delegation-adapters.ts
+++ b/src/slash/delegation-adapters.ts
@@ -1,12 +1,16 @@
 import {
 	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
 	type SubagentDelegationAcceptanceResult,
+	type SubagentDelegationEffectsResult,
+	type SubagentDelegationExecutionResult,
 	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
+	type SubagentDelegationReviewResult,
 	type SubagentDelegationStatus,
 	type SubagentDelegationUpdate,
 } from "../api/delegation.ts";
-import type { AcceptanceInput, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
+import type { AcceptanceInput, AgentContract, EffectsProjection, ExecutionProjection, JsonSchemaObject, ReviewProjection, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
+import { isAgentContractV1 } from "../runs/shared/agent-contract.ts";
 
 export interface PromptTemplateDelegationTask {
 	agent: string;
@@ -93,7 +97,11 @@ export interface PromptTemplateBridgeResult {
 			toolBudgetBlocked?: boolean;
 			savedOutputPath?: string;
 			sessionFile?: string;
+			agentContract?: AgentContract;
+			execution?: ExecutionProjection;
 			acceptance?: SubagentDelegationAcceptanceResult;
+			review?: ReviewProjection;
+			effects?: EffectsProjection;
 			usage?: { turns?: number };
 			progressSummary?: { toolCount?: number; durationMs?: number; tokens?: number };
 			skillsWarning?: string;
@@ -129,6 +137,8 @@ export interface DelegatedSubagentExecutionParams {
 	skill?: string | string[] | boolean;
 	output?: string | boolean;
 	outputMode?: "inline" | "file-only";
+	outputSchema?: JsonSchemaObject;
+	agentContract?: AgentContract;
 	acceptance?: AcceptanceInput;
 	artifacts?: boolean;
 	async: false;
@@ -347,6 +357,8 @@ export function toSubagentDelegationExecutionParams(request: SubagentDelegationR
 		skill: request.skill,
 		output: request.output,
 		outputMode: request.outputMode,
+		outputSchema: request.outputSchema,
+		agentContract: request.agentContract,
 		acceptance: request.acceptance,
 		artifacts: request.artifacts,
 		async: false,
@@ -383,7 +395,7 @@ function resolveSubagentDelegationStatus(
 	if (result.details?.timedOut || child.timedOut) return "timed_out";
 	if (child?.turnBudgetExceeded) return "turn_budget_exhausted";
 	if (child?.toolBudgetBlocked) return "tool_budget_exhausted";
-	if (child?.acceptance?.status === "rejected" && child.acceptance.explicit) return "acceptance_failed";
+	if (!isAgentContractV1(child.agentContract) && child?.acceptance?.status === "rejected" && child.acceptance.explicit) return "acceptance_failed";
 	if (result.details?.stopped || child?.stopped || child?.interrupted) return "interrupted";
 	if (result.isError || child?.error || (typeof child?.exitCode === "number" && child.exitCode !== 0)) return "failed";
 	return "completed";
@@ -410,10 +422,13 @@ export function toSubagentDelegationResponse(
 		...(child?.agent ? { agent: child.agent } : {}),
 		...(child?.model ? { model: child.model } : {}),
 		...(typeof child?.exitCode === "number" ? { exitCode: child.exitCode } : {}),
+		...(child?.execution ? { execution: child.execution as SubagentDelegationExecutionResult } : {}),
 		...(child?.finalOutput ? { output: child.finalOutput } : {}),
 		...(child?.savedOutputPath ? { outputPath: child.savedOutputPath } : {}),
 		...(child?.sessionFile ? { sessionFile: child.sessionFile } : {}),
 		...(child?.acceptance ? { acceptance: { status: child.acceptance.status, explicit: child.acceptance.explicit } } : {}),
+		...(child?.review ? { review: child.review as SubagentDelegationReviewResult } : {}),
+		...(child?.effects ? { effects: child.effects as SubagentDelegationEffectsResult } : {}),
 		...(typeof child?.usage?.turns === "number" ? { turns: child.usage.turns } : {}),
 		...(typeof progress?.toolCount === "number" ? { toolCount: progress.toolCount } : {}),
 		...(typeof progress?.durationMs === "number" ? { durationMs: progress.durationMs } : {}),

--- a/src/slash/delegation-request.ts
+++ b/src/slash/delegation-request.ts
@@ -24,6 +24,8 @@ const supportedFields = new Set([
 	"skill",
 	"output",
 	"outputMode",
+	"outputSchema",
+	"agentContract",
 	"acceptance",
 	"artifacts",
 ]);
@@ -93,6 +95,14 @@ export function parseSubagentDelegationRequest(data: unknown): SubagentDelegatio
 	}
 	if (value.outputMode === "file-only" && !nonEmptyString(value.output)) {
 		return { ok: false, requestId, error: 'outputMode "file-only" requires output to be a non-empty path.' };
+	}
+	if (value.outputSchema !== undefined && (!value.outputSchema || typeof value.outputSchema !== "object" || Array.isArray(value.outputSchema))) {
+		return { ok: false, requestId, error: "outputSchema must be a JSON Schema object." };
+	}
+	if (value.agentContract !== undefined) {
+		if (!value.agentContract || typeof value.agentContract !== "object" || Array.isArray(value.agentContract)) return { ok: false, requestId, error: "agentContract must be an object." };
+		const contract = value.agentContract as Record<string, unknown>;
+		if (contract.version !== 1 || Object.keys(contract).some((key) => key !== "version")) return { ok: false, requestId, error: "agentContract must be { version: 1 }." };
 	}
 	const acceptanceErrors = validateAcceptanceInput(value.acceptance);
 	if (acceptanceErrors.length > 0) return { ok: false, requestId, error: acceptanceErrors.join(" ") };

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -45,7 +45,7 @@ interface AsyncResultPayload {
 	wrapUpRequested?: boolean;
 	totalTokens?: { input: number; output: number; total: number };
 	totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
-	results: Array<{ agent?: string; output?: string; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string } }>;
+	results: Array<{ agent?: string; output?: string; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string } }>;
 	outputs?: Record<string, { text?: string; structured?: unknown }>;
 	workflowGraph?: { nodes?: Array<{ kind?: string; label?: string; phase?: string; status?: string; acceptanceStatus?: string; error?: string; outputName?: string; structured?: boolean; children?: Array<{ label?: string; outputName?: string; itemKey?: string; status?: string; acceptanceStatus?: string; error?: string }> }> };
 }
@@ -85,6 +85,9 @@ interface AsyncStatusPayload {
 		thinking?: string;
 		tokens?: { total: number };
 		totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
+		agentContract?: { version: 1 };
+		execution?: { status?: string; success?: boolean; exitCode?: number };
+		effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean } };
 		acceptance?: { status?: string };
 		turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number };
 		turnBudgetExceeded?: boolean;
@@ -2768,6 +2771,77 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(eventsText, /Subagent failed: worker/);
 		assert.doesNotMatch(eventsText, /Status:/);
 		assert.doesNotMatch(eventsText, /Interrupt:/);
+	});
+
+	it("agent contract v1 keeps async acceptance and file-mutation effects separate from execution", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "I’ll do that now and report back after implementing.\n```acceptance-report\n{\"criteriaSatisfied\":[{\"id\":\"criterion-1\",\"status\":\"not-satisfied\",\"evidence\":\"no proof\"}]}\n```" });
+		const id = `async-v1-separate-${Date.now().toString(36)}`;
+
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Implement the approved fixes",
+			agentConfig: makeAgent("worker", { completionGuard: true }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			maxSubagentDepth: 2,
+			agentContract: { version: 1 },
+			acceptance: { level: "checked", criteria: ["Return required proof"] },
+		});
+
+		const resultPath = await waitForAsyncResultFile(id, 10_000);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		const statusPayload = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
+
+		assert.equal(payload.success, true);
+		assert.equal(payload.state, "complete");
+		assert.equal(payload.exitCode, 0);
+		assert.equal(payload.results[0]?.agentContract?.version, 1);
+		assert.equal(payload.results[0]?.execution?.status, "completed");
+		assert.equal(payload.results[0]?.execution?.success, true);
+		assert.equal(payload.results[0]?.acceptance?.status, "rejected");
+		assert.equal(payload.results[0]?.effects?.fileMutation?.status, "missing");
+		assert.equal(statusPayload.state, "complete");
+		assert.equal(statusPayload.steps?.[0]?.agentContract?.version, 1);
+		assert.equal(statusPayload.steps?.[0]?.execution?.status, "completed");
+		assert.equal(statusPayload.steps?.[0]?.effects?.fileMutation?.status, "missing");
+	});
+
+	it("background single runs support outputSchema", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "structured", structuredOutput: { ok: true, note: "async" } });
+		const id = `async-single-schema-${Date.now().toString(36)}`;
+
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Return structured data",
+			agentConfig: makeAgent("worker", { completionGuard: false }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			maxSubagentDepth: 2,
+			acceptance: false,
+			structuredOutputSchema: { type: "object", required: ["ok"], properties: { ok: { type: "boolean" }, note: { type: "string" } } },
+		});
+
+		const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id, 10_000), "utf-8")) as AsyncResultPayload;
+		assert.equal(payload.success, true);
+		assert.deepEqual(payload.results[0]?.structuredOutput, { ok: true, note: "async" });
 	});
 
 	it("background bash-enabled non-implementation agents can opt out of the completion guard", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -53,6 +53,38 @@ describe("async status helpers", () => {
 		}
 	});
 
+	it("preserves agent contract projections on step summaries", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-contract-"));
+		try {
+			createAsyncDir(root, "run-contract", {
+				runId: "run-contract",
+				mode: "single",
+				state: "complete",
+				startedAt: 100,
+				lastUpdate: 200,
+				steps: [{
+					agent: "worker",
+					status: "complete",
+					agentContract: { version: 1 },
+					execution: { status: "completed", success: true, exitCode: 0 },
+					acceptance: { status: "rejected", effectiveAcceptance: { level: "checked", explicit: true } },
+					review: { status: "not-requested" },
+					effects: { fileMutation: { status: "missing", expected: true, attempted: false } },
+				}],
+			});
+
+			const runs = listAsyncRuns(root, { states: ["complete"] });
+			const step = runs[0]?.steps[0];
+			assert.equal(step?.agentContract?.version, 1);
+			assert.deepEqual(step?.execution, { status: "completed", success: true, exitCode: 0 });
+			assert.equal(step?.acceptance?.status, "rejected");
+			assert.equal(step?.review?.status, "not-requested");
+			assert.equal(step?.effects?.fileMutation?.status, "missing");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("formats async run and step context labels", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-context-"));
 		try {

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -40,6 +40,8 @@ interface TestSequentialStep {
 	progress?: boolean;
 	cwd?: string;
 	acceptance?: unknown;
+	agentContract?: { version: 1 };
+	gateOn?: "execution" | "acceptance";
 }
 
 interface TestParallelTask {
@@ -57,6 +59,8 @@ interface TestParallelTask {
 	progress?: boolean;
 	cwd?: string;
 	acceptance?: unknown;
+	agentContract?: { version: 1 };
+	gateOn?: "execution" | "acceptance";
 }
 
 type TestChainStep = TestSequentialStep | {
@@ -65,6 +69,8 @@ type TestChainStep = TestSequentialStep | {
 	failFast?: boolean;
 	worktree?: boolean;
 	cwd?: string;
+	agentContract?: { version: 1 };
+	gateOn?: "execution" | "acceptance";
 } | {
 	expand: {
 		from: { output: string; path: string };
@@ -79,6 +85,8 @@ type TestChainStep = TestSequentialStep | {
 	failFast?: boolean;
 	label?: string;
 	acceptance?: unknown;
+	agentContract?: { version: 1 };
+	gateOn?: "execution" | "acceptance";
 };
 
 interface ChainResultItem {
@@ -1067,6 +1075,50 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 		assert.ok(result.isError, "chain should fail");
 		assert.equal(result.details.results.length, 1, "only step1 should have run");
 		assert.equal(result.details.results[0].exitCode, 1);
+	});
+
+	it("agent contract v1 chain defaults to execution gating after acceptance rejection", async () => {
+		mockPi.onCall({ output: "Step 1 done\n```acceptance-report\n{\"criteriaSatisfied\":[{\"id\":\"criterion-1\",\"status\":\"not-satisfied\",\"evidence\":\"no proof\"}]}\n```" });
+		mockPi.onCall({ output: "Step 2 ran" });
+		const agents = [makeAgent("step1", { completionGuard: false }), makeAgent("step2", { completionGuard: false })];
+
+		const result = await executeChain(
+			makeChainParams(
+				[
+					{ agent: "step1", task: "First", acceptance: { level: "checked", criteria: ["Return required proof"] } },
+					{ agent: "step2", task: "Second receives {previous}" },
+				],
+				agents,
+				{ task: "Original", agentContract: { version: 1 } },
+			),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details.results.length, 2);
+		assert.equal(result.details.results[0]?.acceptance?.status, "rejected");
+		assert.equal(result.details.results[0]?.exitCode, 0);
+		assert.match(result.details.results[1]?.finalOutput ?? "", /Step 2 ran/);
+	});
+
+	it("agent contract v1 chain can gate progression on acceptance", async () => {
+		mockPi.onCall({ output: "Step 1 done\n```acceptance-report\n{\"criteriaSatisfied\":[{\"id\":\"criterion-1\",\"status\":\"not-satisfied\",\"evidence\":\"no proof\"}]}\n```" });
+		const agents = [makeAgent("step1", { completionGuard: false }), makeAgent("step2", { completionGuard: false })];
+
+		const result = await executeChain(
+			makeChainParams(
+				[
+					{ agent: "step1", task: "First", acceptance: { level: "checked", criteria: ["Return required proof"] }, gateOn: "acceptance" },
+					{ agent: "step2", task: "Should not run" },
+				],
+				agents,
+				{ task: "Original", agentContract: { version: 1 } },
+			),
+		);
+
+		assert.equal(result.isError, true);
+		assert.equal(result.details.results.length, 1);
+		assert.equal(result.details.results[0]?.acceptance?.status, "rejected");
+		assert.equal(mockPi.callCount(), 1);
 	});
 
 	it("runs a 3-step chain end-to-end", async () => {

--- a/test/integration/parallel-execution.test.ts
+++ b/test/integration/parallel-execution.test.ts
@@ -247,6 +247,32 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 		assert.equal(result.details?.results?.[0]?.savedOutputPath, outputPath);
 	});
 
+	it("top-level parallel tasks support outputSchema", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ matchArgIncludes: "First structured", output: "first", structuredOutput: { ok: true, item: "first" } });
+		mockPi.onCall({ matchArgIncludes: "Second structured", output: "second", structuredOutput: { ok: true, item: "second" } });
+		const executor = makeExecutor();
+
+		const result = await executor.execute(
+			"parallel-schema",
+			{
+				tasks: [
+					{ agent: "echo", task: "First structured", outputSchema: { type: "object", required: ["ok", "item"], properties: { ok: { type: "boolean" }, item: { type: "string" } } } },
+					{ agent: "echo", task: "Second structured", outputSchema: { type: "object", required: ["ok", "item"], properties: { ok: { type: "boolean" }, item: { type: "string" } } } },
+				],
+				acceptance: false,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.deepEqual(result.details?.results?.map((item: { structuredOutput?: unknown }) => item.structuredOutput), [
+			{ ok: true, item: "first" },
+			{ ok: true, item: "second" },
+		]);
+	});
+
 	it("top-level parallel preserves completed siblings and marks timed-out children", { skip: !createSubagentExecutor ? "executor not importable" : process.platform === "win32" ? "timeout signal delivery intermittent on Windows CI" : undefined }, async () => {
 		mockPi.onCall({ matchArgIncludes: "Slow review", delay: 10000 });
 		mockPi.onCall({ matchArgIncludes: "Fast review", output: "fast done" });

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -96,6 +96,11 @@ interface RunSyncResult {
 	outputReference?: { path: string; bytes: number; lines: number; message: string };
 	outputSaveError?: string;
 	sessionFile?: string;
+	structuredOutput?: unknown;
+	agentContract?: { version: 1 };
+	execution?: { status?: string; success?: boolean; exitCode?: number; error?: string };
+	review?: { status?: string };
+	effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean; message?: string } };
 	acceptance?: {
 		status?: string;
 		verifyRuns?: Array<{ status?: string }>;
@@ -714,6 +719,75 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(result.controlEvents?.map((event) => event.message), [
 			"worker completed without making edits for an implementation task",
 		]);
+	});
+
+	it("agent contract v1 reports omitted acceptance separately without injecting a prompt", async () => {
+		mockPi.onCall({ output: "Plan only" });
+		const agents = [makeAgent("worker", { tools: ["read", "write"] })];
+
+		const result = await runSync(tempDir, agents, "worker", "Implement the approved file changes", {
+			runId: "v1-no-acceptance",
+			agentContract: { version: 1 },
+		});
+		const call = readCall();
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.agentContract?.version, 1);
+		assert.deepEqual(result.execution, { status: "completed", success: true, exitCode: 0 });
+		assert.equal(result.acceptance?.status, "not-required");
+		assert.equal(result.review?.status, "not-requested");
+		assert.deepEqual(result.effects, {});
+		assert.doesNotMatch(call.args.join("\n"), /## Acceptance Contract/);
+	});
+
+	it("agent contract v1 keeps acceptance rejection out of execution status", async () => {
+		mockPi.onCall({ output: "Done\n```acceptance-report\n{\"criteriaSatisfied\":[{\"id\":\"criterion-1\",\"status\":\"not-satisfied\",\"evidence\":\"no proof\"}]}\n```" });
+		const agents = [makeAgent("worker", { tools: ["read"], completionGuard: false })];
+
+		const result = await runSync(tempDir, agents, "worker", "Summarize the fix", {
+			runId: "v1-acceptance-reject",
+			agentContract: { version: 1 },
+			acceptance: { level: "checked", criteria: ["Return required proof"] },
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.error, undefined);
+		assert.equal(result.execution?.status, "completed");
+		assert.equal(result.execution?.success, true);
+		assert.equal(result.acceptance?.status, "rejected");
+		assert.match(result.acceptance.runtimeChecks?.[0]?.message ?? "", /not-satisfied/);
+	});
+
+	it("agent contract v1 records explicit completion guard as an effect", async () => {
+		mockPi.onCall({ output: "Plan only" });
+		const agents = [makeAgent("worker", { tools: ["read", "write"], completionGuard: true })];
+
+		const result = await runSync(tempDir, agents, "worker", "Implement the approved file changes", {
+			runId: "v1-completion-effect",
+			agentContract: { version: 1 },
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.execution?.status, "completed");
+		assert.equal(result.effects?.fileMutation?.status, "missing");
+		assert.equal(result.effects?.fileMutation?.expected, true);
+		assert.equal(result.effects?.fileMutation?.attempted, false);
+	});
+
+	it("direct single tool calls support outputSchema", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "structured", structuredOutput: { ok: true, note: "captured" } });
+		const executor = makeExecutor([makeAgent("echo")]);
+
+		const result = await executor.execute(
+			"single-schema",
+			{ agent: "echo", task: "Return structured data", outputSchema: { type: "object", required: ["ok"], properties: { ok: { type: "boolean" }, note: { type: "string" } } }, acceptance: false },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.deepEqual(result.details?.results?.[0]?.structuredOutput, { ok: true, note: "captured" });
 	});
 
 	it("returns captured output when the foreground executor fails an implementation run", async () => {

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -165,6 +165,51 @@ describe("acceptance gates", () => {
 		assert.equal(resolved.verify[0]?.id, "ok");
 	});
 
+	it("agent contract v1 disables inferred acceptance without changing current defaults", () => {
+		const current = resolveEffectiveAcceptance({ agentName: "worker", acceptanceRole: "writer", task: "Implement the fix", mode: "single", async: true });
+		assert.equal(current.level, "reviewed");
+		assert.deepEqual(current.inferredReason, ["async write-capable or risky run"]);
+
+		for (const explicit of [undefined, "auto" as const, false] as const) {
+			const resolved = resolveEffectiveAcceptance({ agentName: "worker", acceptanceRole: "writer", task: "Implement the fix", mode: "single", async: true, explicit, agentContract: { version: 1 } });
+			assert.equal(resolved.level, "none");
+			assert.deepEqual(resolved.inferredReason, []);
+			assert.equal(resolved.explicit, explicit !== undefined);
+		}
+	});
+
+	it("agent contract v1 keeps explicit acceptance report-optional and verify-only", async () => {
+		const checked = resolveEffectiveAcceptance({
+			agentName: "worker",
+			task: "Implement the fix",
+			explicit: "checked",
+			agentContract: { version: 1 },
+		});
+		assert.equal(formatAcceptancePrompt(checked, { reportOptional: true }), "");
+		const checkedLedger = await evaluateAcceptance({ acceptance: checked, output: "done", cwd: process.cwd(), reportOptional: true });
+		assert.equal(checkedLedger.status, "checked");
+		assert.equal(acceptanceFailureMessage(checkedLedger), undefined);
+
+		const verified = resolveEffectiveAcceptance({
+			agentName: "worker",
+			task: "Implement the fix",
+			explicit: { level: "verified", verify: [{ id: "ok", command: `${process.execPath} -e "process.exit(0)"` }] },
+			agentContract: { version: 1 },
+		});
+		assert.equal(formatAcceptancePrompt(verified, { reportOptional: true }), "");
+		const verifiedLedger = await evaluateAcceptance({ acceptance: verified, output: "done", cwd: process.cwd(), reportOptional: true });
+		assert.equal(verifiedLedger.status, "verified");
+		assert.equal(verifiedLedger.verifyRuns[0]?.status, "passed");
+	});
+
+	it("current/default acceptance still rejects missing required reports", async () => {
+		const current = resolveEffectiveAcceptance({ agentName: "worker", task: "Implement the fix", explicit: "checked" });
+		const ledger = await evaluateAcceptance({ acceptance: current, output: "done", cwd: process.cwd() });
+
+		assert.equal(ledger.status, "rejected");
+		assert.match(acceptanceFailureMessage(ledger) ?? "", /Structured acceptance report not found/);
+	});
+
 	it("formats a standardized child prompt section", () => {
 		const resolved = resolveEffectiveAcceptance({
 			agentName: "worker",

--- a/test/unit/delegation-api.test.ts
+++ b/test/unit/delegation-api.test.ts
@@ -70,6 +70,8 @@ const request: SubagentDelegationRequest = {
 	skill: ["review"],
 	output: "result.md",
 	outputMode: "file-only",
+	outputSchema: { type: "object", properties: { ok: { type: "boolean" } } },
+	agentContract: { version: 1 },
 	acceptance: "checked",
 	artifacts: true,
 };
@@ -103,6 +105,9 @@ describe("public subagent delegation contract", () => {
 			[{ ...request, skill: [] }, /skill must/],
 			[{ ...request, output: "" }, /output must/],
 			[{ ...request, output: false, outputMode: "file-only" }, /outputMode.*output.*path/],
+			[{ ...request, outputSchema: [] }, /outputSchema must be a JSON Schema object/],
+			[{ ...request, agentContract: { version: 2 } }, /agentContract must be \{ version: 1 \}/],
+			[{ ...request, agentContract: { version: 1, extra: true } }, /agentContract must be \{ version: 1 \}/],
 			[{ ...request, acceptance: "none" }, /level "none" requires a reason/],
 			[{ ...request, acceptance: { level: "none" } }, /reason is required/],
 			[{ ...request, artifacts: "yes" }, /artifacts must be a boolean/],
@@ -144,7 +149,11 @@ describe("public subagent delegation contract", () => {
 							sessionFile: "/tmp/session.jsonl",
 							usage: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0, cost: 0.01, turns: 2 },
 							progressSummary: { toolCount: 4, tokens: 5, durationMs: 6 },
+							agentContract: { version: 1 },
+							execution: { status: "completed", success: true, exitCode: 0 },
 							acceptance: { status: "checked", explicit: true },
+							review: { status: "not-requested" },
+							effects: { fileMutation: { status: "missing", expected: true, attempted: false } },
 							skillsWarning: "Skills not found: review",
 						}],
 					},
@@ -183,6 +192,8 @@ describe("public subagent delegation contract", () => {
 			skill: ["review"],
 			output: "result.md",
 			outputMode: "file-only",
+			outputSchema: { type: "object", properties: { ok: { type: "boolean" } } },
+			agentContract: { version: 1 },
 			acceptance: "checked",
 			artifacts: true,
 			async: false,
@@ -195,6 +206,9 @@ describe("public subagent delegation contract", () => {
 		assert.equal(response.output, "done");
 		assert.equal(response.outputPath, "/repo/result.md");
 		assert.equal(response.sessionFile, "/tmp/session.jsonl");
+		assert.deepEqual(response.execution, { status: "completed", success: true, exitCode: 0 });
+		assert.deepEqual(response.review, { status: "not-requested" });
+		assert.deepEqual(response.effects, { fileMutation: { status: "missing", expected: true, attempted: false } });
 		assert.equal(response.turns, 2);
 		assert.equal(response.toolCount, 4);
 		assert.equal(response.tokens, 5);
@@ -239,6 +253,7 @@ describe("public subagent delegation contract", () => {
 			[{ turnBudgetExceeded: true }, "turn_budget_exhausted"],
 			[{ toolBudgetBlocked: true }, "tool_budget_exhausted"],
 			[{ acceptance: { status: "rejected", explicit: true } }, "acceptance_failed"],
+			[{ agentContract: { version: 1 }, acceptance: { status: "rejected", explicit: true } }, "completed"],
 			[{ acceptance: { status: "rejected", explicit: false } }, "completed"],
 			[{ exitCode: 1, error: "failed" }, "failed"],
 		] as const;


### PR DESCRIPTION
Adds opt-in `agentContract: { version: 1 }` support for generic agent results while keeping the current/default contract unchanged when it is omitted.

The v1 path separates execution, acceptance, review, and effects projections; makes acceptance report-optional and non-fatal to execution; records explicit completion-guard file-mutation observations under effects; plumbs `outputSchema` through single, parallel, chain, async, and delegation paths; and adds per-step `gateOn` for v1 chain progression.

Validation passed locally: `npm run test:unit`, `npm run test:integration`, `npm run test:e2e`, and `git diff --check`.

Closes #499.
