### PR TITLE
feat: add artifactDir config option (project | session | temp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added `artifactDir` config to store subagent artifacts in the project, Pi session, or temp artifact directory while keeping project-local artifacts as the default. Thanks to WeZZard (@WeZZard) for #582.
 - Added opt-in `agentContract: { version: 1 }` runs with explicit execution, acceptance, review, and effects projections, report-optional acceptance, observational file-mutation effects, generic `outputSchema` plumbing, and `gateOn` chain controls while keeping the current/default contract unchanged. Thanks to mapleluv (@mapleluvr) for #499.
 - Added `advisor` as an `oracle`-compatible bundled agent alias for users switching between Claude Code and Pi naming. Thanks to Serhii Chernenko (@serhii-chernenko) for #552.
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.

--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,18 @@ stdin is a JSON object with `repoRoot`, `worktreePath`, `agentCwd`, `branch`, `i
 
 `syntheticPaths` must be relative to the worktree root. They are removed before diff capture so helper files do not pollute patches. Tracked files are never excluded; marking a tracked path as synthetic fails setup. Default timeout is `30000` ms.
 
+### `artifactDir`
+
+```json
+{
+  "artifactDir": "session"
+}
+```
+
+Controls where subagent artifact files (inputs, outputs, transcripts, metadata) are stored. Defaults to `"project"`, which writes to `<cwd>/.pi-subagents/artifacts/`. Set to `"session"` to store artifacts under pi's session directory (`~/.pi/agent/sessions/<session>/subagent-artifacts/`), keeping the working directory clean. Set to `"temp"` to use the OS temp directory.
+
+The `"session"` option uses the same directory that `cleanupAllArtifactDirs` already scans for age-based cleanup, so artifacts are still cleaned up automatically.
+
 ### `completionBatch`
 
 ```json

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -1,7 +1,9 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExtensionConfig } from "../shared/types.ts";
+import type { ArtifactDirPreference, ExtensionConfig } from "../shared/types.ts";
 import { getAgentDir } from "../shared/utils.ts";
+
+const ARTIFACT_DIR_PREFERENCES = new Set<ArtifactDirPreference>(["project", "session", "temp"]);
 
 export function getConfigPath(): string {
 	return path.join(getAgentDir(), "extensions", "subagent", "config.json");
@@ -12,6 +14,10 @@ function readConfigForUpdate(configPath = getConfigPath()): ExtensionConfig {
 	const parsed = JSON.parse(fs.readFileSync(configPath, "utf-8")) as unknown;
 	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
 		throw new Error(`Subagent config at '${configPath}' must be a JSON object`);
+	}
+	const config = parsed as Record<string, unknown>;
+	if (config.artifactDir !== undefined && !ARTIFACT_DIR_PREFERENCES.has(config.artifactDir as ArtifactDirPreference)) {
+		throw new Error(`config.artifactDir must be "project", "session", or "temp"`);
 	}
 	return parsed as ExtensionConfig;
 }

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1224,7 +1224,7 @@ async function resumeAsyncRun(input: {
 			};
 		}
 		const runId = randomUUID().slice(0, 8);
-		const artifactConfig: ArtifactConfig = { ...DEFAULT_ARTIFACT_CONFIG, enabled: input.params.artifacts !== false };
+		const artifactConfig: ArtifactConfig = { ...DEFAULT_ARTIFACT_CONFIG, enabled: input.params.artifacts !== false, dir: input.deps.config.artifactDir ?? DEFAULT_ARTIFACT_CONFIG.dir };
 		const availableModels = input.ctx.modelRegistry.getAvailable().map(toModelInfo);
 		const contextPolicy = resolveExplicitContextPolicy(input.params);
 		const workflowTask = (input.params.task ?? followUp) || undefined;
@@ -1257,7 +1257,7 @@ async function resumeAsyncRun(input: {
 			availableModels,
 			cwd: effectiveCwd,
 			maxOutput: input.params.maxOutput,
-			artifactsDir: getArtifactsDir(parentSessionFile, effectiveCwd),
+			artifactsDir: getArtifactsDir(parentSessionFile, effectiveCwd, artifactConfig.dir),
 			artifactConfig,
 			shareEnabled: input.params.share === true,
 			sessionRoot: input.deps.getSubagentSessionRoot(parentSessionFile),
@@ -1288,8 +1288,8 @@ async function resumeAsyncRun(input: {
 
 	const runId = randomUUID().slice(0, 8);
 	const recoveryAgentConfig = recoveryDescriptor ? applySteeringRecoveryAgentConfig(agentConfig, recoveryDescriptor) : agentConfig;
-	const artifactConfig: ArtifactConfig = recoveryDescriptor?.artifactConfig ?? { ...DEFAULT_ARTIFACT_CONFIG, enabled: input.params.artifacts !== false };
-	const artifactsDir = recoveryDescriptor?.artifactsDir ?? getArtifactsDir(parentSessionFile, effectiveCwd);
+	const artifactConfig: ArtifactConfig = recoveryDescriptor?.artifactConfig ?? { ...DEFAULT_ARTIFACT_CONFIG, enabled: input.params.artifacts !== false, dir: input.deps.config.artifactDir ?? DEFAULT_ARTIFACT_CONFIG.dir };
+	const artifactsDir = recoveryDescriptor?.artifactsDir ?? getArtifactsDir(parentSessionFile, effectiveCwd, artifactConfig.dir);
 	const availableModels = input.ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const result = executeAsyncSingle(runId, {
 		agent: target.agent,
@@ -3805,8 +3805,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const artifactConfig: ArtifactConfig = {
 			...DEFAULT_ARTIFACT_CONFIG,
 			enabled: effectiveParams.artifacts !== false,
+			dir: deps.config.artifactDir ?? DEFAULT_ARTIFACT_CONFIG.dir,
 		};
-		const artifactsDir = getArtifactsDir(parentSessionFile, effectiveCwd);
+		const artifactsDir = getArtifactsDir(parentSessionFile, effectiveCwd, artifactConfig.dir);
 
 		let sessionRoot: string;
 		if (effectiveParams.sessionDir) {

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { TEMP_ARTIFACTS_DIR, type ArtifactPaths } from "./types.ts";
+import { TEMP_ARTIFACTS_DIR, type ArtifactPaths, type ArtifactDirPreference } from "./types.ts";
 import { getAgentDir } from "./utils.ts";
 const CLEANUP_MARKER_FILE = ".last-cleanup";
 const PROJECT_ARTIFACT_ROOT = ".pi-subagents";
@@ -17,13 +17,30 @@ export function getProjectChainRunsDir(cwd: string): string {
 	return path.join(getProjectSubagentsDir(cwd), "chain-runs");
 }
 
-export function getArtifactsDir(sessionFile: string | null, projectCwd?: string): string {
-	if (projectCwd) return getProjectArtifactsDir(projectCwd);
-	if (sessionFile) {
-		const sessionDir = path.dirname(sessionFile);
-		return path.join(sessionDir, "subagent-artifacts");
+export function getArtifactsDir(
+	sessionFile: string | null,
+	projectCwd?: string,
+	dirPreference: ArtifactDirPreference = "project",
+): string {
+	switch (dirPreference) {
+		case "session":
+			if (sessionFile) {
+				const sessionDir = path.dirname(sessionFile);
+				return path.join(sessionDir, "subagent-artifacts");
+			}
+			return TEMP_ARTIFACTS_DIR;
+		case "temp":
+			return TEMP_ARTIFACTS_DIR;
+		case "project":
+			if (projectCwd) return getProjectArtifactsDir(projectCwd);
+			if (sessionFile) {
+				const sessionDir = path.dirname(sessionFile);
+				return path.join(sessionDir, "subagent-artifacts");
+			}
+			return TEMP_ARTIFACTS_DIR;
+		default:
+			throw new Error(`Unsupported artifactDir ${JSON.stringify(dirPreference)}; expected "project", "session", or "temp".`);
 	}
-	return TEMP_ARTIFACTS_DIR;
 }
 
 export function getArtifactPaths(artifactsDir: string, runId: string, agent: string, index?: number): ArtifactPaths {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -742,8 +742,11 @@ export interface ArtifactPaths {
 	metadataPath: string;
 }
 
+export type ArtifactDirPreference = "project" | "session" | "temp";
+
 export interface ArtifactConfig {
 	enabled: boolean;
+	dir?: ArtifactDirPreference;
 	includeInput: boolean;
 	includeOutput: boolean;
 	includeJsonl: boolean;
@@ -1269,6 +1272,8 @@ export interface ExtensionConfig {
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
 	worktreeBaseDir?: string;
+	/** Where to store subagent artifact files. Defaults to "project" (cwd/.pi-subagents). Set to "session" for pi session dir, or "temp" for OS temp. */
+	artifactDir?: ArtifactDirPreference;
 	intercomBridge?: IntercomBridgeConfig;
 	proactiveSkillSubagents?: ProactiveSkillSubagentsConfig | false;
 	scheduledRuns?: ScheduledRunsConfig;
@@ -1285,6 +1290,7 @@ export const DEFAULT_MAX_OUTPUT: Required<MaxOutputConfig> = {
 
 export const DEFAULT_ARTIFACT_CONFIG: ArtifactConfig = {
 	enabled: true,
+	dir: "project",
 	includeInput: true,
 	includeOutput: true,
 	includeJsonl: false,

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -24,7 +24,7 @@ import { SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_LIFECYCLE_ARTIFACT_VERSION } fro
 interface AsyncExecutionResult {
 	content: Array<{ text?: string }>;
 	isError?: boolean;
-	details: { asyncId?: string };
+	details: { asyncId?: string; asyncDir?: string };
 }
 
 interface AsyncResultPayload {
@@ -371,11 +371,11 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		removeTempDir(tempDir);
 	});
 
-	function makeAsyncExecutor(agents: ReturnType<typeof makeAgent>[]) {
+	function makeAsyncExecutor(agents: ReturnType<typeof makeAgent>[], config: Record<string, unknown> = {}) {
 		return createSubagentExecutor!({
 			pi: { events: createEventBus(), getSessionName: () => undefined },
 			state: { baseCwd: tempDir, currentSessionId: null, asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null },
-			config: {},
+			config,
 			asyncByDefault: false,
 			tempArtifactsDir: tempDir,
 			getSubagentSessionRoot: () => tempDir,
@@ -428,6 +428,35 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.results[0]?.protocolError?.code, "protocol_output_limit");
 		assert.equal(payload.results[0]?.protocolError?.stream, "stdout");
 		assert.match(payload.results[0]?.error ?? "", /protocol_output_limit/);
+	});
+
+	it("routes async artifacts to the configured session directory", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		mockPi.onCall({ output: "async session artifact" });
+		const sessionFile = path.join(tempDir, "sessions", "parent-session", "session.jsonl");
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionFile = () => sessionFile;
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })], { artifactDir: "session" });
+
+		const launch = await executor.execute(
+			"async-session-artifact-dir",
+			{ agent: "worker", task: "Write async session artifacts", async: true, runId: "async-session-artifacts", acceptance: false },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		) as AsyncExecutionResult;
+
+		const expectedDir = path.join(path.dirname(sessionFile), "subagent-artifacts");
+		assert.equal(launch.isError, undefined);
+		assert.ok(launch.details.asyncId);
+		const descriptor = JSON.parse(fs.readFileSync(path.join(launch.details.asyncDir!, "recovery-descriptor.json"), "utf-8"));
+		assert.equal(descriptor.artifactsDir, expectedDir);
+		assert.equal(descriptor.artifactConfig.dir, "session");
+
+		const payload = await readAsyncPayload(launch.details.asyncId);
+		const outputPath = payload.results[0]?.artifactPaths?.outputPath;
+		assert.ok(outputPath?.startsWith(`${expectedDir}${path.sep}`));
+		assert.equal(fs.readFileSync(outputPath, "utf-8"), "async session artifact");
+		assert.equal(fs.existsSync(path.join(tempDir, ".pi-subagents", "artifacts")), false);
 	});
 
 	it("background writes a failure stub to output artifacts when no output was produced", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -206,6 +206,7 @@ interface ExecutorToolResult {
 		asyncId?: string;
 		timeoutMs?: number;
 		turnBudget?: { maxTurns: number; graceTurns: number };
+		artifacts?: { dir: string; files: ArtifactPaths[] };
 	};
 }
 
@@ -1571,6 +1572,29 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(transcript.at(-1)?.text ?? "", /^Result text/);
 		assert.equal(result.transcriptError, undefined);
 		assert.ok(fs.existsSync(artifactsDir), "artifacts dir should exist");
+	});
+
+	it("routes foreground artifacts to the configured session directory", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "session artifact result" });
+		const sessionFile = path.join(tempDir, "sessions", "parent-session", "session.jsonl");
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionFile = () => sessionFile;
+		const executor = makeExecutor([makeAgent("echo")], { artifactDir: "session" });
+
+		const result = await executor.execute(
+			"session-artifact-dir",
+			{ agent: "echo", task: "Write session-scoped artifacts", runId: "session-artifacts" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+
+		const expectedDir = path.join(path.dirname(sessionFile), "subagent-artifacts");
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details?.artifacts?.dir, expectedDir);
+		assert.ok(result.details?.artifacts?.files[0]?.outputPath.startsWith(`${expectedDir}${path.sep}`));
+		assert.equal(fs.readFileSync(result.details.artifacts.files[0].outputPath, "utf-8"), "session artifact result");
+		assert.equal(fs.existsSync(path.join(tempDir, ".pi-subagents", "artifacts")), false);
 	});
 
 	it("writes a failure stub to foreground output artifacts when no output was produced", async () => {

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -7,10 +7,11 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import { discoverAgentsAll } from "../../src/agents/agents.ts";
 import { handleCreate } from "../../src/agents/agent-management.ts";
 import { clearSkillCache, discoverAvailableSkills, resolveSkillPath } from "../../src/agents/skills.ts";
-import { loadConfig } from "../../src/extension/config.ts";
+import { loadConfig, updateConfig } from "../../src/extension/config.ts";
 import { diagnoseIntercomBridge, resolveIntercomBridge } from "../../src/intercom/intercom-bridge.ts";
 import { loadRunsForAgent, recordRun } from "../../src/runs/shared/run-history.ts";
-import { cleanupAllArtifactDirs } from "../../src/shared/artifacts.ts";
+import { cleanupAllArtifactDirs, getArtifactsDir, getProjectArtifactsDir } from "../../src/shared/artifacts.ts";
+import { TEMP_ARTIFACTS_DIR } from "../../src/shared/types.ts";
 import { getAgentDir, getConfigDirName, getProjectConfigDir, resolveConfigDirName } from "../../src/shared/utils.ts";
 
 let tempDir = "";
@@ -90,11 +91,12 @@ describe("PI_CODING_AGENT_DIR runtime paths", () => {
 
 		process.env.PI_CODING_AGENT_DIR = agentDir;
 		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
-		writeFile(configPath, JSON.stringify({ asyncByDefault: true, maxSubagentDepth: 3 }));
+		writeFile(configPath, JSON.stringify({ asyncByDefault: true, maxSubagentDepth: 3, artifactDir: "session" }));
 
 		const config = loadConfig();
 		assert.equal(config.asyncByDefault, true);
 		assert.equal(config.maxSubagentDepth, 3);
+		assert.equal(config.artifactDir, "session");
 	});
 
 	it("discovers user agents, chains, and settings under the configured agent dir", () => {
@@ -203,6 +205,24 @@ Package skill content.
 
 		cleanupAllArtifactDirs(0);
 		assert.equal(fs.existsSync(artifactPath), false);
+	});
+
+	it("resolves configured artifact directory preferences", () => {
+		const sessionFile = path.join(agentDir, "sessions", "session-1", "session.jsonl");
+
+		assert.equal(getArtifactsDir(sessionFile, cwd), getProjectArtifactsDir(cwd));
+		assert.equal(getArtifactsDir(sessionFile, cwd, "project"), getProjectArtifactsDir(cwd));
+		assert.equal(getArtifactsDir(sessionFile, cwd, "session"), path.join(path.dirname(sessionFile), "subagent-artifacts"));
+		assert.equal(getArtifactsDir(sessionFile, cwd, "temp"), TEMP_ARTIFACTS_DIR);
+		assert.equal(getArtifactsDir(null, cwd, "session"), TEMP_ARTIFACTS_DIR);
+		assert.throws(() => getArtifactsDir(sessionFile, cwd, "workspace" as never), /Unsupported artifactDir/);
+	});
+
+	it("rejects invalid artifactDir config values", () => {
+		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
+		writeFile(configPath, JSON.stringify({ artifactDir: "workspace" }));
+
+		assert.throws(() => updateConfig((config) => config), /config\.artifactDir must be "project", "session", or "temp"/);
 	});
 
 	it("hardens and redacts existing run history while recording", () => {


### PR DESCRIPTION
## Problem

`getArtifactsDir` has three branches (project → session → temp), but the call site in `subagent-executor.ts` always passes `effectiveCwd` as `projectCwd`, which is checked first. This makes the **session-dir branch unreachable dead code** — users cannot choose to store subagent artifacts in pi's session directory (`~/.pi/agent/sessions/<session>/subagent-artifacts/`) even though the code path exists.

The project-local default (`cwd/.pi-subagents/`) was added deliberately (#326), but no config option was added to let users opt back to the session dir.

## Fix

Add a configurable `dir` preference to `ArtifactConfig` and `artifactDir` to `ExtensionConfig`:

```json
// ~/.pi/agent/extensions/subagent/config.json
{ "artifactDir": "session" }
```

| Value | Location |
|-------|----------|
| `"project"` (default) | `cwd/.pi-subagents/artifacts/` (current behavior, unchanged) |
| `"session"` | `~/.pi/agent/sessions/<session>/subagent-artifacts/` (pi session dir, already scanned by cleanup) |
| `"temp"` | OS temp directory |

## Changes

- `src/shared/types.ts`: `ArtifactDirPreference` type, `dir` on `ArtifactConfig` + `DEFAULT_ARTIFACT_CONFIG`, `artifactDir` on `ExtensionConfig`
- `src/shared/artifacts.ts`: `getArtifactsDir` accepts `dirPreference` parameter with switch logic
- `src/runs/foreground/subagent-executor.ts`: all 3 call sites pass `artifactConfig.dir` and read `artifactDir` from the extension config
- `README.md`: documents the new option

## Backward compatibility

Default is `"project"` — identical to current behavior. No config change needed for existing users.