### PR TITLE
fix: bundle TypeBox as a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Bundled TypeBox as a production dependency so detached runners can always load `typebox/compile`, including managed extension installs where Pi's host package is not visible from the child process. Thanks to Matteo Collina (@mcollina) for #583.
 - Updated the Pi development SDK to 0.81.0 and passed the watchdog stream through the renamed `Agent.streamFunction` option, preventing watchdog reviews from terminating with `streamFunction is not a function`. Thanks to Wang Zixiong (@XWIlluDelu) for #574.
 - Documented that relative chain `output` paths are chain-artifact paths under `{chain_dir}`, with persistent `chainDir` and absolute `output` paths as the supported ways to keep artifacts outside the temp run directory. Thanks to @dougEfresh for #529.
 - Bounded main-watchdog repository signatures so startup and agent-end checks no longer recurse through nested Git worktrees or generated dependency trees, reducing slow starts in large repos. Thanks to @pompanonb for #551 and @markg85 for #555.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "jiti": "2.7.0",
+        "typebox": "1.1.38",
         "yaml": "2.8.3"
       },
       "bin": {
@@ -19,15 +20,13 @@
         "@earendil-works/pi-agent-core": "0.81.0",
         "@earendil-works/pi-ai": "0.81.0",
         "@earendil-works/pi-coding-agent": "0.81.0",
-        "@earendil-works/pi-tui": "0.81.0",
-        "typebox": "1.1.38"
+        "@earendil-works/pi-tui": "0.81.0"
       },
       "peerDependencies": {
         "@earendil-works/pi-agent-core": "*",
         "@earendil-works/pi-ai": "*",
         "@earendil-works/pi-coding-agent": "*",
-        "@earendil-works/pi-tui": "*",
-        "typebox": "*"
+        "@earendil-works/pi-tui": "*"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-agent-core": {
@@ -40,9 +39,6 @@
           "optional": true
         },
         "@earendil-works/pi-tui": {
-          "optional": true
-        },
-        "typebox": {
           "optional": true
         }
       }
@@ -3329,7 +3325,6 @@
       "version": "1.1.38",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
       "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
     "@earendil-works/pi-agent-core": "*",
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*",
-    "typebox": "*"
+    "@earendil-works/pi-tui": "*"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-agent-core": {
@@ -77,20 +76,17 @@
     },
     "@earendil-works/pi-tui": {
       "optional": true
-    },
-    "typebox": {
-      "optional": true
     }
   },
   "dependencies": {
     "jiti": "2.7.0",
+    "typebox": "1.1.38",
     "yaml": "2.8.3"
   },
   "devDependencies": {
     "@earendil-works/pi-agent-core": "0.81.0",
     "@earendil-works/pi-ai": "0.81.0",
     "@earendil-works/pi-coding-agent": "0.81.0",
-    "@earendil-works/pi-tui": "0.81.0",
-    "typebox": "1.1.38"
+    "@earendil-works/pi-tui": "0.81.0"
   }
 }

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -16,14 +16,12 @@ const hostPeerPackages = [
 	"@earendil-works/pi-ai",
 	"@earendil-works/pi-coding-agent",
 	"@earendil-works/pi-tui",
-	"typebox",
 ] as const;
 const expectedHostDevVersions = {
 	"@earendil-works/pi-agent-core": "0.81.0",
 	"@earendil-works/pi-ai": "0.81.0",
 	"@earendil-works/pi-coding-agent": "0.81.0",
 	"@earendil-works/pi-tui": "0.81.0",
-	typebox: "1.1.38",
 } satisfies Record<(typeof hostPeerPackages)[number], string>;
 
 function collectSourceFiles(dir: string): string[] {
@@ -101,6 +99,14 @@ test("host-owned packages are optional wildcard peers, not production dependenci
 		assert.equal(packageJson.dependencies?.[name], undefined, `${name} should not be a production dependency`);
 		assert.deepEqual(packageJson.peerDependenciesMeta?.[name], { optional: true }, `${name} should be an optional peer`);
 	}
+});
+test("typebox is a bundled runtime dependency", () => {
+	const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf-8"));
+
+	assert.equal(packageJson.dependencies?.typebox, "1.1.38");
+	assert.equal(packageJson.peerDependencies?.typebox, undefined);
+	assert.equal(packageJson.peerDependenciesMeta?.typebox, undefined);
+	assert.equal(packageJson.devDependencies?.typebox, undefined);
 });
 
 test("host-owned development packages use the supported SDK baseline", () => {


### PR DESCRIPTION
## Summary

- move `typebox@1.1.38` from optional peer/dev dependencies to production dependencies
- update the lockfile so published installs include TypeBox
- add a manifest regression test and changelog entry

## Why

#526 showed that detached runners can fail before producing a result when `typebox/compile` is not visible from the managed extension directory. #545 added host-peer fallback resolution, but TypeBox is imported directly by runtime code and every detached process still depends on host-specific module resolution.

Bundling the exact supported TypeBox version makes the published package self-contained and removes that process-boundary failure mode.

## Validation

- `npm run test:all` (unit: 1321 passed, 1 skipped; integration: 614 passed, 2 skipped; e2e: 2 passed)
- `npm pack --dry-run --json`
- `git diff --check`

Follow-up to #526 and #545.
