### PR TITLE
Fix stale subagent completion delivery after reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Scoped async result delivery to the active session lease so stale watchers and recovered result files cannot wake or redeliver completions after reload, while retaining unaccepted result files for retry. Thanks to KawaiiNahida (@KawaiiNahida) for #588.
 - Namespaced inherited relative agent output paths for foreground top-level parallel tasks so repeated builtin agents no longer collide before launch. Thanks to Artem Timofeev (@atimofeev) for #580.
 - Use Pi's native editor for `/subagents` system-prompt editing so terminal editors receive terminal ownership and cannot leave a stale waiting status. Thanks to Prodipta Guha (@proguha) for #576.
 - Bundled TypeBox as a production dependency so detached runners can always load `typebox/compile`, including managed extension installs where Pi's host package is not visible from the child process. Thanks to Matteo Collina (@mcollina) for #583.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -244,20 +244,20 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	const supervisorChannel = createNativeSupervisorChannel(pi, state);
 	const mainWatchdog = registerMainWatchdog(pi);
-	let disposeSubagentNotify = () => {};
+	const completionNotifier = registerSubagentNotify(pi, state, { batchConfig: config.completionBatch });
 	const { startResultWatcher, primeExistingResults, stopResultWatcher } = createResultWatcher(
 		pi,
 		state,
 		RESULTS_DIR,
 		10 * 60 * 1000,
+		{ notifier: completionNotifier },
 	);
-	startResultWatcher();
-	primeExistingResults();
 
 	const runtimeCleanup = () => {
-		disposeSubagentNotify();
-		mainWatchdog.dispose();
 		stopResultWatcher();
+		state.currentSessionId = null;
+		completionNotifier.dispose();
+		mainWatchdog.dispose();
 		scheduledRunManager.stop();
 		supervisorChannel.dispose();
 		clearPendingForegroundControlNotices(state);
@@ -472,8 +472,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			}
 		}
 	}
-	disposeSubagentNotify = registerSubagentNotify(pi, state, { batchConfig: config.completionBatch });
-
 	const existingVisibleControlNotices = globalStore[controlNoticeSeenStoreKey];
 	const visibleControlNotices = existingVisibleControlNotices instanceof Set ? existingVisibleControlNotices as Set<string> : new Set<string>();
 	globalStore[controlNoticeSeenStoreKey] = visibleControlNotices;
@@ -518,7 +516,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}
 	};
 
-	const resetSessionState = (ctx: ExtensionContext) => {
+	const resetSessionState = (ctx: ExtensionContext, recovering: boolean) => {
 		state.baseCwd = ctx.cwd;
 		state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
 		state.subagentSpawns = {
@@ -546,17 +544,21 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		restoreActiveJobs(ctx);
 		scheduledRunManager.bindSession(ctx);
 		restoreSlashFinalSnapshots(ctx.sessionManager.getEntries());
-		primeExistingResults();
+		startResultWatcher();
+		primeExistingResults({ triggerTurn: !recovering });
 	};
 
-	pi.on("session_start", (_event, ctx) => {
-		resetSessionState(ctx);
+	pi.on("session_start", (event, ctx) => {
+		const recovering = event.reason === "startup" || event.reason === "reload" || event.reason === "resume";
+		resetSessionState(ctx, recovering);
 		rpcBridge.emitReady(ctx);
 		supervisorChannel.start();
 	});
 
 	pi.on("session_shutdown", () => {
-		disposeSubagentNotify();
+		stopResultWatcher();
+		state.currentSessionId = null;
+		completionNotifier.dispose();
 		delete process.env[SUBAGENT_PARENT_SESSION_ENV];
 		for (const unsubscribe of eventUnsubscribes) {
 			try {
@@ -568,7 +570,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		if (globalStore[eventUnsubscribeStoreKey] === eventUnsubscribes) {
 			delete globalStore[eventUnsubscribeStoreKey];
 		}
-		stopResultWatcher();
 		scheduledRunManager.stop();
 		if (state.poller) clearInterval(state.poller);
 		state.poller = null;

--- a/src/runs/background/completion-batcher.ts
+++ b/src/runs/background/completion-batcher.ts
@@ -89,8 +89,8 @@ export interface CompletionBatcher<T> {
 	push(item: T): void;
 	/** Emit any held items immediately as a single group. */
 	flush(): void;
-	/** Clear timers without emitting. */
-	dispose(): void;
+	/** Clear timers and return items that were never emitted. */
+	dispose(): T[];
 }
 
 /**
@@ -109,7 +109,7 @@ export function createCompletionBatcher<T>(options: CompletionBatcherOptions<T>)
 				options.emit([item]);
 			},
 			flush() {},
-			dispose() {},
+			dispose() { return []; },
 		};
 	}
 
@@ -160,7 +160,9 @@ export function createCompletionBatcher<T>(options: CompletionBatcherOptions<T>)
 		flush: emitGroup,
 		dispose() {
 			clearTimers();
+			const abandoned = pending;
 			pending = [];
-		},
+			return abandoned;
+		}
 	};
 }

--- a/src/runs/background/completion-dedupe.ts
+++ b/src/runs/background/completion-dedupe.ts
@@ -20,9 +20,9 @@ function asFiniteNumber(value: unknown): number | undefined {
 }
 
 export function buildCompletionKey(data: CompletionDataLike, fallback: string): string {
-	const id = asNonEmptyString(data.id);
-	if (id) return `id:${id}`;
 	const sessionId = asNonEmptyString(data.sessionId) ?? "no-session";
+	const id = asNonEmptyString(data.id);
+	if (id) return `session:${sessionId}:id:${id}`;
 	const agent = asNonEmptyString(data.agent) ?? "unknown";
 	const timestamp = asFiniteNumber(data.timestamp);
 	const taskIndex = asFiniteNumber(data.taskIndex);
@@ -51,13 +51,4 @@ export function markSeenWithTtl(seen: Map<string, number>, key: string, now: num
 	if (seen.has(key)) return true;
 	seen.set(key, now);
 	return false;
-}
-
-export function getGlobalSeenMap(storeKey: string): Map<string, number> {
-	const globalStore = globalThis as Record<string, unknown>;
-	const existing = globalStore[storeKey];
-	if (existing instanceof Map) return existing as Map<string, number>;
-	const map = new Map<string, number>();
-	globalStore[storeKey] = map;
-	return map;
 }

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -1,15 +1,13 @@
 /**
- * Subagent completion notifications.
+ * Completion notification delivery.
  *
- * Successful (completed) async results are held briefly and emitted as a
- * single grouped message when sibling jobs finish within a short window (see
- * `completion-batcher.ts`). Failed and paused results bypass grouping and fire
- * immediately, flushing any held successes first, so failure and attention
- * signals are never delayed.
+ * Async result files call this notifier directly and are deleted only after
+ * `sendMessage()` accepts the notification. The event bus remains an
+ * observation channel, not a delivery acknowledgement.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { buildCompletionKey, getGlobalSeenMap, markSeenWithTtl } from "./completion-dedupe.ts";
+import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.ts";
 import {
 	type CompletionBatchConfig,
 	type CompletionBatcher,
@@ -17,12 +15,6 @@ import {
 	resolveCompletionBatchConfig,
 } from "./completion-batcher.ts";
 import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT, type SubagentState } from "../../shared/types.ts";
-
-interface ChainStepResult {
-	agent: string;
-	output: string;
-	success: boolean;
-}
 
 export interface SubagentNotifyDetails {
 	agent: string;
@@ -35,25 +27,26 @@ export interface SubagentNotifyDetails {
 	sessionValue?: string;
 }
 
-interface SubagentResult {
-	id: string | null;
+export interface CompletionNotification {
+	[key: string]: unknown;
+	id?: string | null;
 	source?: "async" | "foreground";
-	agent: string | null;
-	success: boolean;
-	summary: string;
+	agent?: string | null;
+	success?: boolean;
+	summary?: string;
 	exitCode?: number;
 	state?: string;
-	timestamp: number;
+	timestamp?: number;
 	durationMs?: number;
 	cwd?: string;
 	sessionFile?: string;
 	shareUrl?: string;
 	gistUrl?: string;
 	shareError?: string;
-	results?: ChainStepResult[];
 	taskIndex?: number;
 	totalTasks?: number;
 	sessionId?: string | null;
+	triggerTurn?: boolean;
 }
 
 interface NotifyTimerApi {
@@ -65,6 +58,11 @@ export interface RegisterSubagentNotifyOptions {
 	batchConfig?: CompletionBatchConfig;
 	timers?: NotifyTimerApi;
 	now?: () => number;
+}
+
+export interface CompletionNotifier {
+	deliver(result: CompletionNotification): Promise<boolean>;
+	dispose(): void;
 }
 
 function formatSessionLine(details: SubagentNotifyDetails): string | undefined {
@@ -132,29 +130,40 @@ export function formatGroupedCompletion(details: SubagentNotifyDetails[]): strin
 	return blocks.join("\n").trimEnd();
 }
 
-function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage">, details: SubagentNotifyDetails[]): void {
-	if (details.length === 0) return;
-	const content = details.length === 1
-		? formatSingleCompletion(details[0]!)
-		: formatGroupedCompletion(details);
-	pi.sendMessage(
-		{
-			customType: "subagent-notify",
-			content,
-			display: true,
-		},
-		{ triggerTurn: true },
-	);
+interface PendingCompletion {
+	key: string;
+	details: SubagentNotifyDetails;
+	triggerTurn: boolean;
+	resolve(accepted: boolean): void;
 }
 
-function completionBatchKey(result: SubagentResult): string {
+function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage">, items: PendingCompletion[]): boolean {
+	if (items.length === 0) return true;
+	const details = items.map((item) => item.details);
+	const content = details.length === 1 ? formatSingleCompletion(details[0]!) : formatGroupedCompletion(details);
+	try {
+		pi.sendMessage(
+			{
+				customType: "subagent-notify",
+				content,
+				display: true,
+			},
+			{ triggerTurn: items.some((item) => item.triggerTurn) },
+		);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function completionBatchKey(result: CompletionNotification): string {
 	const sessionId = typeof result.sessionId === "string" ? result.sessionId.trim() : "";
 	if (sessionId) return `session:${sessionId}`;
 	const cwd = typeof result.cwd === "string" ? result.cwd.trim() : "";
 	return cwd ? `cwd:${cwd}` : "unknown";
 }
 
-export function buildCompletionDetails(result: SubagentResult): SubagentNotifyDetails {
+export function buildCompletionDetails(result: CompletionNotification): SubagentNotifyDetails {
 	const agent = result.agent ?? "unknown";
 	const summary = typeof result.summary === "string" ? result.summary : "";
 	const paused = !result.success && (
@@ -163,7 +172,6 @@ export function buildCompletionDetails(result: SubagentResult): SubagentNotifyDe
 		|| summary.startsWith("Paused after interrupt.")
 	);
 	const status = paused ? "paused" : result.success ? "completed" : "failed";
-
 	const taskInfo =
 		result.taskIndex !== undefined && result.totalTasks !== undefined
 			? ` (${result.taskIndex + 1}/${result.totalTasks})`
@@ -177,7 +185,6 @@ export function buildCompletionDetails(result: SubagentResult): SubagentNotifyDe
 				: result.sessionFile
 					? { label: "Session file", value: result.sessionFile }
 					: undefined;
-
 	return {
 		agent,
 		status,
@@ -193,102 +200,91 @@ export default function registerSubagentNotify(
 	pi: ExtensionAPI,
 	state: Pick<SubagentState, "currentSessionId">,
 	options: RegisterSubagentNotifyOptions = {},
-): () => void {
-	const unsubscribeStoreKey = "__pi_subagents_notify_unsubscribe__";
-	const batcherStoreKey = "__pi_subagents_notify_batcher__";
-	const globalStore = globalThis as Record<string, unknown>;
-	const previousUnsubscribe = globalStore[unsubscribeStoreKey];
-	if (typeof previousUnsubscribe === "function") {
-		try {
-			previousUnsubscribe();
-		} catch {
-			// Best effort cleanup for stale handlers from an older reload.
-		}
-	}
-	const previousBatcher = globalStore[batcherStoreKey];
-	if (previousBatcher && typeof (previousBatcher as { dispose?: () => void }).dispose === "function") {
-		try {
-			(previousBatcher as { dispose: () => void }).dispose();
-		} catch {
-			// Best effort cleanup for a stale batcher from an older reload.
-		}
-	}
-
-	const seen = getGlobalSeenMap("__pi_subagents_notify_seen__");
+): CompletionNotifier {
+	const seen = new Map<string, number>();
+	const pending = new Map<string, Promise<boolean>>();
 	const ttlMs = 10 * 60 * 1000;
-	const nowFn = options.now ?? Date.now;
+	const now = options.now ?? Date.now;
 	const batchConfig = resolveCompletionBatchConfig(options.batchConfig);
-	const batchers = new Map<string, CompletionBatcher<SubagentNotifyDetails>>();
+	const batchers = new Map<string, CompletionBatcher<PendingCompletion>>();
 	let disposed = false;
 
-	const handleComplete = (data: unknown) => {
-		if (disposed) return;
-		const result = data as SubagentResult;
-		if (typeof result.sessionId !== "string" || result.sessionId !== state.currentSessionId) return;
-		const now = nowFn();
-		const key = buildCompletionKey(result, "notify");
-		if (markSeenWithTtl(seen, key, now, ttlMs)) return;
-
-		const details = buildCompletionDetails(result);
-		if (result.source === "foreground") {
-			sendCompletion(pi, [details]);
-			return;
+	const settle = (items: PendingCompletion[], accepted: boolean) => {
+		for (const item of items) {
+			pending.delete(item.key);
+			if (accepted) markSeenWithTtl(seen, item.key, now(), ttlMs);
+			item.resolve(accepted);
 		}
-		const batchKey = completionBatchKey(result);
-		let batcher = batchers.get(batchKey);
+	};
+	const emit = (items: PendingCompletion[]) => settle(items, sendCompletion(pi, items));
+	const getBatcher = (result: CompletionNotification) => {
+		const key = completionBatchKey(result);
+		let batcher = batchers.get(key);
 		if (!batcher) {
-			batcher = createCompletionBatcher<SubagentNotifyDetails>({
+			batcher = createCompletionBatcher<PendingCompletion>({
 				config: batchConfig,
-				emit: (items) => sendCompletion(pi, items),
+				emit,
 				...(options.timers ? { timers: options.timers } : {}),
-				now: nowFn,
+				now,
 			});
-			batchers.set(batchKey, batcher);
+			batchers.set(key, batcher);
 		}
-		if (details.status !== "completed") {
-			// Failures and paused runs bypass grouping. Flush any held
-			// successes for the same owner first so they are not stranded
-			// behind this signal, then emit the non-completion result immediately.
-			batcher.flush();
-			sendCompletion(pi, [details]);
-			return;
-		}
-		batcher.push(details);
+		return batcher;
 	};
 
-	const unsubscribers = [
-		pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, handleComplete),
-		pi.events.on(SUBAGENT_FOREGROUND_COMPLETE_EVENT, handleComplete),
-	].filter((unsubscribe): unsubscribe is () => void => typeof unsubscribe === "function");
-	const batcherRegistration = { dispose };
+	const deliver = (result: CompletionNotification): Promise<boolean> => {
+		if (disposed || typeof result.sessionId !== "string" || result.sessionId !== state.currentSessionId) return Promise.resolve(false);
+		const key = buildCompletionKey(result, "notify");
+		const seenAt = seen.get(key);
+		if (seenAt !== undefined && now() - seenAt <= ttlMs) return Promise.resolve(true);
+		if (seenAt !== undefined) seen.delete(key);
+		const inFlight = pending.get(key);
+		if (inFlight) return inFlight;
+		const details = buildCompletionDetails(result);
+		let resolve!: (accepted: boolean) => void;
+		const completion = new Promise<boolean>((settleCompletion) => { resolve = settleCompletion; });
+		pending.set(key, completion);
+		const item: PendingCompletion = {
+			key,
+			details,
+			triggerTurn: result.triggerTurn !== false,
+			resolve,
+		};
+		if (details.source === "foreground") {
+			emit([item]);
+			return completion;
+		}
+		const batcher = getBatcher(result);
+		if (details.status !== "completed") {
+			batcher.flush();
+			emit([item]);
+			return completion;
+		}
+		batcher.push(item);
+		return completion;
+	};
 
-	function dispose(): void {
-		if (disposed) return;
-		disposed = true;
-		for (const batcher of batchers.values()) {
-			try {
-				batcher.dispose();
-			} catch {
-				// Best effort cleanup must continue through every owned batcher.
-			}
-		}
-		batchers.clear();
-		for (const unsubscribe of unsubscribers) {
-			try {
-				unsubscribe();
-			} catch {
-				// Best effort cleanup must continue through every owned handler.
-			}
-		}
-		if (globalStore[unsubscribeStoreKey] === dispose) {
-			delete globalStore[unsubscribeStoreKey];
-		}
-		if (globalStore[batcherStoreKey] === batcherRegistration) {
-			delete globalStore[batcherStoreKey];
-		}
-	}
+	const unsubscribeAsync = pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, (data) => {
+		void deliver(data as CompletionNotification);
+	});
+	const unsubscribeForeground = pi.events.on(SUBAGENT_FOREGROUND_COMPLETE_EVENT, (data) => {
+		void deliver(data as CompletionNotification);
+	});
 
-	globalStore[unsubscribeStoreKey] = dispose;
-	globalStore[batcherStoreKey] = batcherRegistration;
-	return dispose;
+	return {
+		deliver,
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			for (const batcher of batchers.values()) settle(batcher.dispose(), false);
+			batchers.clear();
+			for (const unsubscribe of [unsubscribeAsync, unsubscribeForeground]) {
+				try {
+					unsubscribe?.();
+				} catch {
+					// The runtime is already shutting down; pending records stay on disk.
+				}
+			}
+		},
+	};
 }

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -18,9 +18,11 @@ import {
 } from "../../intercom/result-intercom.ts";
 import { projectNestedRegistryForRoot, sanitizeSummary } from "../shared/nested-events.ts";
 import { resolveWatchPath } from "../../shared/utils.ts";
+import type { CompletionNotifier, CompletionNotification } from "./notify.ts";
 
 const WATCHER_RESTART_DELAY_MS = 3000;
 const POLL_INTERVAL_MS = 3000;
+const RETRY_DELAY_MS = 100;
 
 type ResultWatcherFs = Pick<typeof fs, "existsSync" | "readFileSync" | "unlinkSync" | "readdirSync" | "mkdirSync" | "realpathSync" | "watch">;
 
@@ -34,6 +36,7 @@ type ResultWatcherTimers = {
 type ResultWatcherDeps = {
 	fs?: ResultWatcherFs;
 	timers?: ResultWatcherTimers;
+	notifier?: Pick<CompletionNotifier, "deliver">;
 };
 
 type ResultFileChild = {
@@ -49,19 +52,11 @@ type ResultFileChild = {
 	children?: unknown;
 };
 
-type ResultFileData = {
-	id?: string;
+type ResultFileData = CompletionNotification & {
 	runId?: string;
-	agent?: string;
-	success?: boolean;
-	state?: string;
 	mode?: string;
-	summary?: string;
 	results?: ResultFileChild[];
 	nestedChildren?: unknown;
-	sessionId?: string;
-	cwd?: string;
-	sessionFile?: string;
 	asyncDir?: string;
 	intercomTarget?: string;
 };
@@ -79,22 +74,24 @@ function sanitizeNestedResultChildren(value: unknown, resultPath: string, label:
 	return children.length ? children : undefined;
 }
 
-function getErrorCode(error: unknown): string | undefined {
-	return typeof error === "object" && error !== null && "code" in error
-		? (error as NodeJS.ErrnoException).code
-		: undefined;
+function errorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error ? (error as NodeJS.ErrnoException).code : undefined;
 }
 
-function isNotFoundError(error: unknown): boolean {
-	return getErrorCode(error) === "ENOENT";
+function isNotFound(error: unknown): boolean {
+	return errorCode(error) === "ENOENT";
 }
 
-function shouldFallBackToPolling(error: unknown): boolean {
-	const code = getErrorCode(error);
+function shouldPoll(error: unknown): boolean {
+	const code = errorCode(error);
 	return code === "EMFILE" || code === "ENOSPC";
 }
 
-
+/**
+ * Watches persisted async results for the session currently owned by this
+ * runtime. `stopResultWatcher()` revokes ownership before closing resources,
+ * so old callbacks can never emit or delete after reload/session replacement.
+ */
 export function createResultWatcher(
 	pi: { events: IntercomEventBus },
 	state: SubagentState,
@@ -103,18 +100,41 @@ export function createResultWatcher(
 	deps: ResultWatcherDeps = {},
 ): {
 	startResultWatcher: () => void;
-	primeExistingResults: () => void;
+	primeExistingResults: (options?: { triggerTurn?: boolean }) => void;
 	stopResultWatcher: () => void;
 } {
 	const fsApi = deps.fs ?? fs;
 	const timers = deps.timers ?? { setTimeout, clearTimeout, setInterval, clearInterval };
+	const notifier = deps.notifier ?? { deliver: async () => true };
+	const pendingTriggerTurn = new Map<string, boolean>();
+	const processing = new Set<string>();
+	let deliveryActive = true;
+	let deliveryEpoch = 0;
+	// The sole in-memory ownership lease. It is acquired for one active session
+	// and revoked before the watcher, queues, or callbacks are torn down.
+	let activeSessionId: string | null = null;
 
-	const handleResult = async (file: string) => {
+	const ownsSession = (sessionId: string, epoch: number) => {
+		if (!deliveryActive || epoch !== deliveryEpoch) return false;
+		if (!activeSessionId && state.currentSessionId) activeSessionId = state.currentSessionId;
+		return activeSessionId === sessionId && state.currentSessionId === sessionId;
+	};
+
+	const scheduleResult = (file: string, triggerTurn: boolean, delayMs = 0) => {
+		const pendingMode = pendingTriggerTurn.get(file);
+		pendingTriggerTurn.set(file, pendingMode === false || !triggerTurn ? false : true);
+		state.resultFileCoalescer.schedule(file, delayMs);
+	};
+
+	const handleResult = async (file: string, triggerTurn: boolean) => {
 		const resultPath = path.join(resultsDir, file);
-		if (!fsApi.existsSync(resultPath)) return;
+		if (processing.has(file) || !fsApi.existsSync(resultPath)) return;
+		processing.add(file);
 		try {
 			const data = JSON.parse(fsApi.readFileSync(resultPath, "utf-8")) as ResultFileData;
-			if (typeof data.sessionId !== "string" || data.sessionId !== state.currentSessionId) return;
+			if (typeof data.sessionId !== "string" || !data.sessionId) return;
+			const epoch = deliveryEpoch;
+			if (!ownsSession(data.sessionId, epoch)) return;
 
 			const runId = data.runId ?? data.id ?? file.replace(/\.json$/i, "");
 			const hasExplicitNestedChildren = data.nestedChildren !== undefined;
@@ -124,24 +144,29 @@ export function createResultWatcher(
 					nestedChildren = compactNestedResultChildren(projectNestedRegistryForRoot(runId)?.children);
 				} catch (error) {
 					console.error(`Failed to enrich subagent result file '${resultPath}' with nested registry children; will retry later:`, error);
+					scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 					return;
 				}
 			}
-			const now = Date.now();
+
 			const completionKey = buildCompletionKey(data, `result:${file}`);
-			if (markSeenWithTtl(state.completionSeen, completionKey, now, completionTtlMs)) {
-				fsApi.unlinkSync(resultPath);
+			if (state.completionSeen.has(completionKey)) {
+				if (!ownsSession(data.sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
+				try {
+					fsApi.unlinkSync(resultPath);
+				} catch (error) {
+					if (!isNotFound(error)) {
+						console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
+						scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+					}
+				}
 				return;
 			}
 
 			const hasResultChildren = Array.isArray(data.results) && data.results.length > 0;
-			const resultChildren = hasResultChildren
+			const resultChildren: ResultFileChild[] = hasResultChildren
 				? data.results!
-				: [{
-					agent: data.agent,
-					output: data.summary,
-					success: data.success,
-				}];
+				: [{ agent: data.agent ?? undefined, output: data.summary, success: data.success }];
 			const normalizedChildren = attachNestedChildrenToResultChildren(runId, resultChildren.map((result = {}, index): SubagentResultIntercomChild => {
 				const baseOutput = result.output ?? data.summary;
 				const hasRealOutput = typeof baseOutput === "string" && baseOutput.trim().length > 0;
@@ -160,10 +185,7 @@ export function createResultWatcher(
 							: undefined;
 				return {
 					agent: result.agent ?? data.agent ?? `step-${index + 1}`,
-					status: resolveSubagentResultStatus({
-						success: result.success,
-						state: childState,
-					}),
+					status: resolveSubagentResultStatus({ success: result.success, state: childState }),
 					summary,
 					index,
 					artifactPath: result.artifactPaths?.outputPath,
@@ -174,11 +196,11 @@ export function createResultWatcher(
 			}), nestedChildren);
 
 			const intercomTarget = data.intercomTarget?.trim();
-			if (intercomTarget) {
+			if (intercomTarget && triggerTurn) {
 				const mode = data.mode === "single" || data.mode === "parallel" || data.mode === "chain"
 					? data.mode
 					: resultChildren.length > 1 ? "chain" : "single";
-				const payload = buildSubagentResultIntercomPayload({
+				const delivered = await deliverSubagentResultIntercomEvent(pi.events, buildSubagentResultIntercomPayload({
 					to: intercomTarget,
 					runId,
 					mode,
@@ -186,20 +208,44 @@ export function createResultWatcher(
 					children: normalizedChildren,
 					asyncId: data.id,
 					asyncDir: data.asyncDir,
-				});
-				const delivered = await deliverSubagentResultIntercomEvent(pi.events, payload);
-				if (!delivered) {
-					console.error(`Subagent async grouped result intercom delivery was not acknowledged for '${resultPath}'.`);
-				}
+				}));
+				if (!ownsSession(data.sessionId, epoch)) return;
+				if (!delivered) console.error(`Subagent async grouped result intercom delivery was not acknowledged for '${resultPath}'.`);
 			}
 
-			pi.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
+			const accepted = await notifier.deliver({
 				...data,
+				id: data.id ?? runId,
 				runId,
+				triggerTurn,
 				...(nestedChildren?.length ? { nestedChildren } : {}),
 				...(Array.isArray(data.results) ? {
-					results: hasResultChildren
-						? normalizedChildren.map((child, index) => ({
+					results: hasResultChildren ? normalizedChildren.map((child, index) => ({
+						...data.results![index],
+						agent: child.agent,
+						status: child.status,
+						summary: child.summary,
+						index: child.index,
+						artifactPath: child.artifactPath,
+						sessionPath: child.sessionPath,
+						children: child.children,
+					})) : [],
+				} : {}),
+			});
+			if (!ownsSession(data.sessionId, epoch)) return;
+			if (!accepted) {
+				scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+				return;
+			}
+			markSeenWithTtl(state.completionSeen, completionKey, Date.now(), completionTtlMs);
+			try {
+				pi.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
+					...data,
+					runId,
+					triggerTurn,
+					...(nestedChildren?.length ? { nestedChildren } : {}),
+					...(Array.isArray(data.results) ? {
+						results: hasResultChildren ? normalizedChildren.map((child, index) => ({
 							...data.results![index],
 							agent: child.agent,
 							status: child.status,
@@ -208,40 +254,50 @@ export function createResultWatcher(
 							artifactPath: child.artifactPath,
 							sessionPath: child.sessionPath,
 							children: child.children,
-						}))
-						: [],
-				} : {}),
-			});
-			fsApi.unlinkSync(resultPath);
+						})) : [],
+					} : {}),
+				});
+			} catch (error) {
+				console.error(`Completion observer failed for '${resultPath}':`, error);
+			}
+			if (!ownsSession(data.sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
+			try {
+				fsApi.unlinkSync(resultPath);
+			} catch (error) {
+				if (!isNotFound(error)) {
+					console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
+					scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+				}
+			}
 		} catch (error) {
-			if (isNotFoundError(error)) return;
-			console.error(`Failed to process subagent result file '${resultPath}':`, error);
+			if (!isNotFound(error)) console.error(`Failed to process subagent result file '${resultPath}':`, error);
+		} finally {
+			processing.delete(file);
 		}
 	};
 
 	state.resultFileCoalescer = createFileCoalescer((file) => {
-		void handleResult(file);
+		const triggerTurn = pendingTriggerTurn.get(file) !== false;
+		pendingTriggerTurn.delete(file);
+		void handleResult(file, triggerTurn);
 	}, 50);
 
-	const primeExistingResults = () => {
+	const primeExistingResults = (options: { triggerTurn?: boolean } = {}) => {
 		try {
+			const triggerTurn = options.triggerTurn !== false;
 			fsApi.readdirSync(resultsDir)
 				.filter((f) => f.endsWith(".json"))
-				.forEach((file) => state.resultFileCoalescer.schedule(file, 0));
+				.forEach((file) => scheduleResult(file, triggerTurn));
 		} catch (error) {
-			if (isNotFoundError(error)) return;
-			console.error(`Failed to scan subagent result directory '${resultsDir}':`, error);
+			if (!isNotFound(error)) console.error(`Failed to scan subagent result directory '${resultsDir}':`, error);
 		}
 	};
 
-	const startPollingFallback = (reason: unknown) => {
+	const startPolling = (reason: unknown) => {
 		state.watcher?.close();
 		state.watcher = null;
 		if (state.watcherRestartTimer) return;
-
-		console.error(
-			`Subagent result watcher for '${resultsDir}' fell back to polling because native fs.watch is unavailable (${getErrorCode(reason) ?? "unknown error"}).`,
-		);
+		console.error(`Subagent result watcher for '${resultsDir}' fell back to polling because native fs.watch is unavailable (${errorCode(reason) ?? "unknown error"}).`);
 		primeExistingResults();
 		state.watcherRestartTimer = timers.setInterval(primeExistingResults, POLL_INTERVAL_MS);
 		state.watcherRestartTimer.unref?.();
@@ -255,10 +311,7 @@ export function createResultWatcher(
 				fsApi.mkdirSync(resultsDir, { recursive: true });
 				startResultWatcher();
 			} catch (error) {
-				if (shouldFallBackToPolling(error)) {
-					startPollingFallback(error);
-					return;
-				}
+				if (shouldPoll(error)) return startPolling(error);
 				console.error(`Failed to restart subagent result watcher for '${resultsDir}':`, error);
 				scheduleRestart();
 			}
@@ -268,6 +321,9 @@ export function createResultWatcher(
 
 	const startResultWatcher = () => {
 		if (state.watcher) return;
+		activeSessionId = state.currentSessionId;
+		deliveryActive = true;
+		deliveryEpoch += 1;
 		if (state.watcherRestartTimer) {
 			timers.clearTimeout(state.watcherRestartTimer);
 			timers.clearInterval(state.watcherRestartTimer);
@@ -275,17 +331,13 @@ export function createResultWatcher(
 		}
 		try {
 			const watchDir = resolveWatchPath(resultsDir, fsApi.realpathSync.native);
-			state.watcher = fsApi.watch(watchDir, (ev, file) => {
-				if (ev !== "rename" || !file) return;
+			state.watcher = fsApi.watch(watchDir, (event, file) => {
+				if (event !== "rename" || !file) return;
 				const fileName = file.toString();
-				if (!fileName.endsWith(".json")) return;
-				state.resultFileCoalescer.schedule(fileName);
+				if (fileName.endsWith(".json")) scheduleResult(fileName, true);
 			});
 			state.watcher.on("error", (error) => {
-				if (shouldFallBackToPolling(error)) {
-					startPollingFallback(error);
-					return;
-				}
+				if (shouldPoll(error)) return startPolling(error);
 				console.error(`Subagent result watcher failed for '${resultsDir}':`, error);
 				state.watcher?.close();
 				state.watcher = null;
@@ -293,10 +345,7 @@ export function createResultWatcher(
 			});
 			state.watcher.unref?.();
 		} catch (error) {
-			if (shouldFallBackToPolling(error)) {
-				startPollingFallback(error);
-				return;
-			}
+			if (shouldPoll(error)) return startPolling(error);
 			console.error(`Failed to start subagent result watcher for '${resultsDir}':`, error);
 			state.watcher = null;
 			scheduleRestart();
@@ -304,6 +353,9 @@ export function createResultWatcher(
 	};
 
 	const stopResultWatcher = () => {
+		deliveryActive = false;
+		activeSessionId = null;
+		deliveryEpoch += 1;
 		state.watcher?.close();
 		state.watcher = null;
 		if (state.watcherRestartTimer) {
@@ -312,6 +364,8 @@ export function createResultWatcher(
 		}
 		state.watcherRestartTimer = null;
 		state.resultFileCoalescer.clear();
+		pendingTriggerTurn.clear();
+		processing.clear();
 	};
 
 	return { startResultWatcher, primeExistingResults, stopResultWatcher };

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -150,7 +150,10 @@ export function createResultWatcher(
 			}
 
 			const completionKey = buildCompletionKey(data, `result:${file}`);
-			if (state.completionSeen.has(completionKey)) {
+			const lastSeenAt = state.completionSeen.get(completionKey);
+			if (lastSeenAt !== undefined && Date.now() - lastSeenAt > completionTtlMs) {
+				state.completionSeen.delete(completionKey);
+			} else if (lastSeenAt !== undefined) {
 				if (!ownsSession(data.sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
 				try {
 					fsApi.unlinkSync(resultPath);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -473,6 +473,9 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 	const summary = !success && input.result.error
 		? `${input.result.error}${output ? `\n\nOutput:\n${output}` : ""}`
 		: output || input.result.error || "Detached child exited without final output.";
+	// A detached callback may outlive its extension runtime. Stale sessions are
+	// intentionally dropped rather than routed through a replacement runtime.
+	if (!input.sessionId || input.sessionId !== state.currentSessionId) return;
 	input.events.emit(SUBAGENT_FOREGROUND_COMPLETE_EVENT, {
 		id: `${input.runId}:${input.index}`,
 		runId: input.runId,

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -951,4 +951,81 @@ describe("result watcher", () => {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});
+
+	it("keeps an unaccepted result for retry and deletes it only after notifier acceptance", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-notifier-retry-"));
+		try {
+			const state = createState();
+			state.currentSessionId = "session-1";
+			const emitted: string[] = [];
+			let attempts = 0;
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit(event) { emitted.push(event); } } }, state, resultsDir, 60_000, {
+				notifier: { async deliver() { attempts += 1; return attempts > 1; } },
+			});
+			const resultPath = path.join(resultsDir, "retry.json");
+			fs.writeFileSync(resultPath, JSON.stringify({ id: "retry", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1 }), "utf-8");
+			try {
+				watcher.primeExistingResults();
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				assert.equal(fs.existsSync(resultPath), true);
+				await new Promise((resolve) => setTimeout(resolve, 180));
+			} finally {
+				watcher.stopResultWatcher();
+			}
+			assert.equal(attempts, 2);
+			assert.equal(fs.existsSync(resultPath), false);
+			assert.deepEqual(emitted, ["subagent:async-complete"]);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("drops stale watcher authority without emitting or deleting", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-stale-"));
+		try {
+			const state = createState();
+			state.currentSessionId = "session-1";
+			const emitted: string[] = [];
+			let accept!: (value: boolean) => void;
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit(event) { emitted.push(event); } } }, state, resultsDir, 60_000, {
+				notifier: { deliver: () => new Promise<boolean>((resolve) => { accept = resolve; }) },
+			});
+			const resultPath = path.join(resultsDir, "stale.json");
+			fs.writeFileSync(resultPath, JSON.stringify({ id: "stale", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1 }), "utf-8");
+			watcher.primeExistingResults();
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			watcher.stopResultWatcher();
+			accept(true);
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			assert.equal(fs.existsSync(resultPath), true);
+			assert.deepEqual(emitted, []);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("marks reload backlog display-only", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-quiet-"));
+		try {
+			const state = createState();
+			state.currentSessionId = "session-1";
+			const delivered: Array<{ triggerTurn?: boolean }> = [];
+			const emitted: string[] = [];
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit(event) { emitted.push(event); } } }, state, resultsDir, 60_000, {
+				notifier: { async deliver(result) { delivered.push({ triggerTurn: result.triggerTurn }); return true; } },
+			});
+			fs.writeFileSync(path.join(resultsDir, "quiet.json"), JSON.stringify({ id: "quiet", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1, intercomTarget: "host" }), "utf-8");
+			try {
+				watcher.primeExistingResults({ triggerTurn: false });
+				await new Promise((resolve) => setTimeout(resolve, 75));
+			} finally {
+				watcher.stopResultWatcher();
+			}
+			assert.deepEqual(delivered, [{ triggerTurn: false }]);
+			assert.equal(emitted.includes("subagent:result-intercom"), false);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 });

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
+import { buildCompletionKey } from "../../src/runs/background/completion-dedupe.ts";
 import { createResultWatcher } from "../../src/runs/background/result-watcher.ts";
 import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
@@ -947,6 +948,32 @@ describe("result watcher", () => {
 			assert.equal(emitted.filter((entry) => entry.event === "subagent:result-intercom").length, 1);
 			assert.equal(emitted.some((entry) => entry.event === "subagent:async-complete"), true);
 			assert.equal(logged.some((entry) => /Subagent async grouped result intercom delivery was not acknowledged/.test(String(entry[0] ?? ""))), true);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("delivers a result when a previous duplicate key has expired", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-expired-"));
+		try {
+			const state = createState();
+			state.currentSessionId = "session-1";
+			const emitted: string[] = [];
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit(event) { emitted.push(event); } } }, state, resultsDir, 60_000);
+			const resultFile = "expired.json";
+			const result = { sessionId: "session-1", agent: "worker", success: true, summary: "new result", timestamp: 123 };
+			const resultPath = path.join(resultsDir, resultFile);
+			fs.writeFileSync(resultPath, JSON.stringify(result), "utf-8");
+			state.completionSeen.set(buildCompletionKey(result, `result:${resultFile}`), Date.now() - 61_000);
+			try {
+				watcher.primeExistingResults();
+				await new Promise((resolve) => setTimeout(resolve, 75));
+			} finally {
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal(fs.existsSync(resultPath), false);
+			assert.deepEqual(emitted, ["subagent:async-complete"]);
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}

--- a/test/unit/completion-batcher.test.ts
+++ b/test/unit/completion-batcher.test.ts
@@ -170,7 +170,9 @@ describe("createCompletionBatcher", () => {
 		});
 
 		batcher.push(item("a"));
-		batcher.dispose();
+		const abandoned = batcher.dispose();
+		assert.deepEqual(abandoned.map((entry) => entry.label), ["a"]);
+		assert.deepEqual(batcher.dispose(), []);
 		assert.deepEqual(emitted, []);
 		assert.equal(clock.pendingCount(), 0);
 		clock.advance(1000);

--- a/test/unit/completion-dedupe.test.ts
+++ b/test/unit/completion-dedupe.test.ts
@@ -1,17 +1,19 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { buildCompletionKey, getGlobalSeenMap, markSeenWithTtl } from "../../src/runs/background/completion-dedupe.ts";
+import { buildCompletionKey, markSeenWithTtl } from "../../src/runs/background/completion-dedupe.ts";
 
 describe("buildCompletionKey", () => {
-	it("uses id as canonical key when present", () => {
-		const key = buildCompletionKey({ id: "run-123", agent: "reviewer", timestamp: 123 }, "fallback");
-		assert.equal(key, "id:run-123");
+	it("scopes ids to their owning session", () => {
+		const first = buildCompletionKey({ id: "run-123", sessionId: "session-a" }, "fallback");
+		const second = buildCompletionKey({ id: "run-123", sessionId: "session-b" }, "fallback");
+		assert.equal(first, "session:session-a:id:run-123");
+		assert.notEqual(first, second);
 	});
 
 	it("builds deterministic fallback key when id is missing", () => {
-		const a = buildCompletionKey({ agent: "reviewer", timestamp: 123, taskIndex: 1, totalTasks: 2, success: true }, "x");
-		const b = buildCompletionKey({ agent: "reviewer", timestamp: 123, taskIndex: 1, totalTasks: 2, success: true }, "x");
-		assert.equal(a, b);
+		const first = buildCompletionKey({ agent: "reviewer", timestamp: 123, taskIndex: 1, totalTasks: 2, success: true }, "x");
+		const second = buildCompletionKey({ agent: "reviewer", timestamp: 123, taskIndex: 1, totalTasks: 2, success: true }, "x");
+		assert.equal(first, second);
 	});
 });
 
@@ -22,15 +24,5 @@ describe("markSeenWithTtl", () => {
 		assert.equal(markSeenWithTtl(seen, "k", 100, ttlMs), false);
 		assert.equal(markSeenWithTtl(seen, "k", 200, ttlMs), true);
 		assert.equal(markSeenWithTtl(seen, "k", 1201, ttlMs), false);
-	});
-});
-
-describe("getGlobalSeenMap", () => {
-	it("returns the same map for the same global store key", () => {
-		const a = getGlobalSeenMap("__test_seen_key__");
-		a.set("x", 1);
-		const b = getGlobalSeenMap("__test_seen_key__");
-		assert.equal(b.get("x"), 1);
-		assert.equal(a, b);
 	});
 });

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -392,10 +392,6 @@ describe("subagent extension child mode", () => {
 			if (oldRuntime.sent.length !== 0) throw new Error("old completion was not queued before reload");
 			const oldCompletionTimers = [...pendingTimers.entries()].filter(([token]) => !timersBeforeOldCompletion.has(token));
 			if (oldCompletionTimers.length === 0) throw new Error("old completion did not schedule a timer");
-			// Remove the notifier's registration-time fallback hooks so this test
-			// proves previousRuntimeCleanup owns and cancels the old timer.
-			delete globalThis.__pi_subagents_notify_unsubscribe__;
-			delete globalThis.__pi_subagents_notify_batcher__;
 
 			const newRuntime = createRuntime("notify-reload-new");
 			registerSubagentExtension(newRuntime.pi);

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -39,9 +39,9 @@ function createPi(currentSessionId = "session-1", registerOptions: RegisterSubag
 
 	// Formatting-focused tests run with batching disabled so single completions
 	// emit synchronously. Batching behavior is covered by the dedicated suite below.
-	const dispose = registerSubagentNotify(pi as never, { currentSessionId }, { batchConfig: { enabled: false }, ...registerOptions });
+	const notifier = registerSubagentNotify(pi as never, { currentSessionId }, { batchConfig: { enabled: false }, ...registerOptions });
 
-	return { events, sent, dispose };
+	return { events, sent, notifier, dispose: () => notifier.dispose() };
 }
 
 function createBatchingPi(clock: ReturnType<typeof createFakeClock>, currentSessionId = "session-a") {
@@ -53,12 +53,12 @@ function createBatchingPi(clock: ReturnType<typeof createFakeClock>, currentSess
 			sent.push({ message, options });
 		},
 	};
-	const dispose = registerSubagentNotify(pi as never, { currentSessionId }, {
+	const notifier = registerSubagentNotify(pi as never, { currentSessionId }, {
 		batchConfig: { enabled: true, debounceMs: 150, maxWaitMs: 1000, stragglerDebounceMs: 75, stragglerMaxWaitMs: 400, stragglerWindowMs: 2000 },
 		timers: clock.api,
 		now: clock.now,
 	});
-	return { events, sent, dispose };
+	return { events, sent, notifier, dispose: () => notifier.dispose() };
 }
 
 interface FakeJob {
@@ -132,6 +132,22 @@ describe("registerSubagentNotify", () => {
 			},
 			options: { triggerTurn: true },
 		});
+	});
+
+	it("acknowledges direct delivery only after sendMessage accepts it", async () => {
+		const { notifier, sent } = createPi("session-a");
+		assert.equal(await notifier.deliver(completionResult({ id: "direct-accepted" })), true);
+		assert.equal(sent.length, 1);
+	});
+
+	it("rejects a pending batch when the notifier is disposed", async () => {
+		const clock = createFakeClock();
+		const { notifier, sent } = createBatchingPi(clock);
+		const pending = notifier.deliver(completionResult({ id: "dispose-pending" }));
+		notifier.dispose();
+		assert.equal(await pending, false);
+		clock.advance(1000);
+		assert.equal(sent.length, 0);
 	});
 
 	it("wakes the originating session with recovered detached foreground output", () => {
@@ -353,25 +369,16 @@ describe("registerSubagentNotify", () => {
 		assert.equal(sent.length, 0);
 	});
 
-	it("does not let an older disposer clear a newer registration", () => {
-		const globalStore = globalThis as Record<string, unknown>;
+	it("does not let a disposed notifier affect another runtime", () => {
 		const oldClock = createFakeClock();
 		const oldRegistration = createBatchingPi(oldClock);
 		oldRegistration.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, completionResult({ id: "old-owner-held-1" }));
 
-		// Simulate a runtime ownership handoff without invoking the old disposer,
-		// so its later call exercises the identity guards rather than idempotency.
-		delete globalStore.__pi_subagents_notify_unsubscribe__;
-		delete globalStore.__pi_subagents_notify_batcher__;
 		const newClock = createFakeClock();
 		const newRegistration = createBatchingPi(newClock);
-		const newerBatcherRegistration = globalStore.__pi_subagents_notify_batcher__;
-
 		oldRegistration.dispose();
 		oldClock.advance(1000);
 		assert.equal(oldRegistration.sent.length, 0);
-		assert.equal(globalStore.__pi_subagents_notify_unsubscribe__, newRegistration.dispose);
-		assert.equal(globalStore.__pi_subagents_notify_batcher__, newerBatcherRegistration);
 
 		newRegistration.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, completionResult({ id: "new-owner-1" }));
 		newClock.advance(150);
@@ -423,6 +430,13 @@ describe("completion formatting helpers", () => {
 			+ "1. alpha\nalpha done\n\n"
 			+ "2. beta (1/2)\n(no output)\nSession: https://share/abc",
 		);
+	});
+
+	it("reports false when Pi rejects sendMessage synchronously", async () => {
+		const pi = { events: createEventBus(), sendMessage() { throw new Error("runtime inactive"); } };
+		const notifier = registerSubagentNotify(pi as never, { currentSessionId: "session-a" }, { batchConfig: { enabled: false } });
+		assert.equal(await notifier.deliver(completionResult({ id: "direct-rejected" })), false);
+		notifier.dispose();
 	});
 
 	it("buildCompletionDetails derives paused status from state and summary", () => {


### PR DESCRIPTION
an old watcher or recovered result file could resend a completed subagent result to the host after reload or restart, sometimes triggering a new turn. This change scopes completion delivery to the active session lease, keeps recovered completions display-only, and retains result files until the notification is accepted.