### PR TITLE
fix: isolate foreground parallel inherited outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Namespaced inherited relative agent output paths for foreground top-level parallel tasks so repeated builtin agents no longer collide before launch. Thanks to Artem Timofeev (@atimofeev) for #580.
 - Use Pi's native editor for `/subagents` system-prompt editing so terminal editors receive terminal ownership and cannot leave a stale waiting status. Thanks to Prodipta Guha (@proguha) for #576.
 - Bundled TypeBox as a production dependency so detached runners can always load `typebox/compile`, including managed extension installs where Pi's host package is not visible from the child process. Thanks to Matteo Collina (@mcollina) for #583.
 - Updated the Pi development SDK to 0.81.0 and passed the watchdog stream through the renamed `Agent.streamFunction` option, preventing watchdog reviews from terminating with `streamFunction is not a function`. Thanks to Wang Zixiong (@XWIlluDelu) for #574.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2815,7 +2815,13 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		}
 	}
 
-	const behaviors = agentConfigs.map((config, index) => suppressProgressForReadOnlyTask(resolveStepBehavior(config, behaviorOverrides[index]!), taskTexts[index]));
+	const behaviors = tasks.map((task, index) => {
+		let behavior = suppressProgressForReadOnlyTask(resolveStepBehavior(agentConfigs[index]!, behaviorOverrides[index]!), taskTexts[index]);
+		if (behaviorOverrides[index]?.output === undefined && typeof behavior.output === "string" && !path.isAbsolute(behavior.output)) {
+			behavior = { ...behavior, output: path.join("parallel-0", `${index}-${task.agent}`, behavior.output) };
+		}
+		return behavior;
+	});
 	const firstProgressIndex = behaviors.findIndex((behavior) => behavior.progress);
 	const liveResults: (SingleResult | undefined)[] = new Array(tasks.length).fill(undefined);
 	const liveProgress: (AgentProgress | undefined)[] = new Array(tasks.length).fill(undefined);

--- a/test/integration/parallel-execution.test.ts
+++ b/test/integration/parallel-execution.test.ts
@@ -369,7 +369,9 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 	});
 
 	for (const outputOverride of [undefined, true] as const) {
-		it(`rejects foreground inherited output collisions (${outputOverride === true ? "output:true" : "omitted output"})`, { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		it(`isolates foreground inherited output (${outputOverride === true ? "output:true" : "omitted output"})`, { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+			mockPi.onCall({ matchArgIncludes: "Write A", output: "first foreground report" });
+			mockPi.onCall({ matchArgIncludes: "Write B", output: "second foreground report" });
 			const executor = makeExecutor([makeAgent("echo", { output: "context.md" })]);
 			const tasks = [
 				{ agent: "echo", task: "Write A", ...(outputOverride !== undefined ? { output: outputOverride } : {}) },
@@ -384,9 +386,17 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 				makeMinimalCtx(tempDir),
 			);
 
-			assert.equal(result.isError, true);
-			assert.match(result.content[0]?.text ?? "", /resolve output to the same path/);
-			assert.equal(mockPi.callCount(), 0);
+			const runId = result.details?.runId;
+			assert.ok(runId, "expected run id in details");
+			const outputDir = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", runId);
+			const firstOutputPath = path.join(outputDir, "parallel-0", "0-echo", "context.md");
+			const secondOutputPath = path.join(outputDir, "parallel-0", "1-echo", "context.md");
+			assert.equal(result.isError, undefined);
+			assert.equal(mockPi.callCount(), 2);
+			assert.equal(fs.readFileSync(firstOutputPath, "utf-8"), "first foreground report");
+			assert.equal(fs.readFileSync(secondOutputPath, "utf-8"), "second foreground report");
+			assert.equal(result.details?.results?.[0]?.savedOutputPath, firstOutputPath);
+			assert.equal(result.details?.results?.[1]?.savedOutputPath, secondOutputPath);
 		});
 	}
 


### PR DESCRIPTION
Addresses #580.

This keeps explicit top-level parallel output collisions rejected, but namespaces inherited relative agent output defaults for foreground parallel runs under `parallel-0/<index>-<agent>/...`, matching the async path.

Validation:
- focused `test/integration/parallel-execution.test.ts` passed
- `npm run test:integration` passed
- `npm run test:e2e` passed
- `git diff --check` passed

Note: `npm run test:unit` is currently blocked locally by `test/unit/watchdog-review.test.ts`, and I reproduced the same two assertions on pristine `origin/main` with this local dependency install, so I am treating that as unrelated to this fix.