### PR TITLE
fix: wake idle parents for supervisor requests

### DIFF
--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -645,7 +645,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 					agent: request.agent,
 					childIndex: request.childIndex,
 				},
-			});
+			}, { triggerTurn: true });
 			if (request.expectsReply) {
 				(pi as { events?: IntercomEventBus }).events?.emit(INTERCOM_DETACH_REQUEST_EVENT, {
 					requestId: request.id,

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -108,12 +108,15 @@ afterEach(() => {
 });
 
 describe("native supervisor channel", () => {
-	it("delivers requests only to the exact current session id", () => {
+	it("delivers requests only to the exact current session id and wakes the parent", () => {
 		const currentSessionId = `session-${randomUUID()}`;
 		const otherSessionId = `session-${randomUUID()}`;
 		const matchingId = writeRequest({ sessionId: currentSessionId, runId: `run-${randomUUID()}` });
 		const otherId = writeRequest({ sessionId: otherSessionId, runId: `run-${randomUUID()}` });
-		const sent: Array<{ content?: string; details?: { id?: string } }> = [];
+		const sent: Array<{
+			message: { content?: string; details?: { id?: string } };
+			options?: { triggerTurn?: boolean };
+		}> = [];
 		const registeredTools: string[] = [];
 		const ctx = {
 			cwd: process.cwd(),
@@ -127,7 +130,10 @@ describe("native supervisor channel", () => {
 		const pi = {
 			getAllTools: () => [],
 			registerTool: (tool: { name: string }) => { registeredTools.push(tool.name); },
-			sendMessage: (message: { content?: string; details?: { id?: string } }) => { sent.push(message); },
+			sendMessage: (
+				message: { content?: string; details?: { id?: string } },
+				options?: { triggerTurn?: boolean },
+			) => { sent.push({ message, options }); },
 			getSessionName: () => "shared-name",
 		};
 		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx));
@@ -137,9 +143,10 @@ describe("native supervisor channel", () => {
 		channel.dispose();
 
 		assert.deepEqual(registeredTools, [NATIVE_SUPERVISOR_TOOL_NAME, "intercom"]);
-		assert.deepEqual(sent.map((message) => message.details?.id), [matchingId]);
+		assert.deepEqual(sent.map(({ message }) => message.details?.id), [matchingId]);
+		assert.deepEqual(sent[0]?.options, { triggerTurn: true });
 		assert.equal(channel.pending.has(matchingId), false, "disposed channel clears pending requests");
-		assert.equal(sent.some((message) => message.details?.id === otherId), false);
+		assert.equal(sent.some(({ message }) => message.details?.id === otherId), false);
 	});
 
 	it("prunes stale empty supervisor channel directories before polling", () => {


### PR DESCRIPTION
Fixes #590.

Related to #581, which covers parents already blocked in `subagent_wait`; this PR fixes the idle interactive-parent delivery path.

## Summary

- trigger an assistant turn when the native supervisor channel delivers a child request
- retain the existing default `steer` behavior so requests queue safely during an active turn
- assert that matching supervisor messages are delivered with `triggerTurn: true`

## Why

The native channel appended and displayed `subagent_supervisor_request` messages without asking Pi to start a turn. An idle parent therefore left the child waiting until an unrelated user message woke the session.

## Validation

- `node --experimental-strip-types --test test/unit/native-supervisor-channel.test.ts` — 9 passed
- focused regression test observed `options === undefined` before the fix and passes with `{ triggerTurn: true }`
- TypeScript LSP — changed production file clean
- `git diff --check`
- independent read-only review — no blocking or major findings

## Local suite note

`npm run test:unit` was attempted but not used as passing evidence: unrelated watchdog tests fail or hang in this local Node 25.6.0 environment. The malformed-language-server case passed when rerun alone; the remaining failures are in unchanged watchdog code outside this patch.