### PR TITLE
fix: map parallel live progress by child index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Mapped sparse parallel slash progress updates by child index so one child’s live tool/output state no longer appears on another chain placeholder. Thanks to Eli Stark (@white-hat) for #595.
 - Retried transient Windows filesystem locks while creating async result directories and stopped destructively recreating shared async directories during startup access checks, so concurrent Pi instances are less likely to lose completed async results to `EPERM` directory handles. Thanks to AiraNadih (@AiraNadih) for #566.
 - Pruned broad agent and chain discovery roots so package-declared `.` scans no longer descend into `node_modules`, `.git`, Git submodules, or nested project roots during startup. Thanks to tupe12334 (@tupe12334) for #570 and shoehn (@shoehn) for narrowing the startup trace.
 - Made `subagent_wait({ id })` wake when an async child is blocked in `contact_supervisor` for a supervisor decision, instead of waiting for completion or timeout. Thanks to @DrunkenDonkey80 for #581.

--- a/src/slash/slash-live-state.ts
+++ b/src/slash/slash-live-state.ts
@@ -193,8 +193,8 @@ function cloneResultsWithProgress(
 	progress: NonNullable<Details["progress"]> | undefined,
 ): SingleResult[] {
 	return results.map((result, index) => {
-		const nextProgress = progress?.find((entry) => entry.index === index)
-			?? progress?.[index]
+		const nextProgress = progress?.find((entry) => entry.index === index
+			|| (entry.index === undefined && entry.agent === result.agent))
 			?? result.progress;
 		return nextProgress ? { ...result, progress: nextProgress } : result;
 	});

--- a/test/integration/slash-live-state.test.ts
+++ b/test/integration/slash-live-state.test.ts
@@ -63,6 +63,33 @@ describe("slash live state", { skip: !available ? "slash-live-state.ts not impor
 		assert.equal(snapshot.version > 0, true);
 	});
 
+	it("does not assign a parallel child update to another chain placeholder", () => {
+		clearSlashSnapshots!();
+		const details = buildSlashInitialResult!("req-parallel", {
+			chain: [{ parallel: [{ agent: "scout", task: "map" }, { agent: "context-builder", task: "analyze" }] }],
+		});
+
+		applySlashUpdate!("req-parallel", {
+			requestId: "req-parallel",
+			progress: [{
+				index: 1,
+				agent: "context-builder",
+				status: "running",
+				task: "analyze",
+				currentTool: "find",
+				recentTools: [],
+				recentOutput: [],
+				toolCount: 38,
+				tokens: 1_000,
+				durationMs: 1_000,
+			}],
+		});
+
+		const results = getSlashRenderableSnapshot!(details).result.details.results;
+		assert.equal(results[0]?.progress?.currentTool, undefined);
+		assert.equal(results[1]?.progress?.currentTool, "find");
+	});
+
 	it("creates stable placeholders for a 40-step worker/reviewer chain", () => {
 		clearSlashSnapshots!();
 		const chain = Array.from({ length: 40 }, (_, index) => ({


### PR DESCRIPTION
## Problem 
UI shows duplicate output for parallel `/chain` agents

<img width="1140" height="451" alt="duplicate output" src="https://github.com/user-attachments/assets/9d061ad4-c354-4332-8caf-16837611f33c" />

## Fix
- match indexed parallel progress only to its matching child placeholder
- preserve agent-name matching for unindexed updates
- add regression coverage for sparse parallel progress updates
<img width="754" height="382" alt="fixed output" src="https://github.com/user-attachments/assets/fff13843-b56e-42e8-9afd-2cf6be5dbd08" />


## Test plan
- `node --experimental-strip-types --test test/integration/slash-live-state.test.ts`