### PR TITLE
fix: wake async waits for supervisor requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Made `subagent_wait({ id })` wake when an async child is blocked in `contact_supervisor` for a supervisor decision, instead of waiting for completion or timeout. Thanks to @DrunkenDonkey80 for #581.
 - Scoped async result delivery to the active session lease so stale watchers and recovered result files cannot wake or redeliver completions after reload, while retaining unaccepted result files for retry. Thanks to KawaiiNahida (@KawaiiNahida) for #588.
 - Namespaced inherited relative agent output paths for foreground top-level parallel tasks so repeated builtin agents no longer collide before launch. Thanks to Artem Timofeev (@atimofeev) for #580.
 - Use Pi's native editor for `/subagents` system-prompt editing so terminal editors receive terminal ownership and cannot leave a stale waiting status. Thanks to Prodipta Guha (@proguha) for #576.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -262,6 +262,15 @@ function shouldPersistChildEvent(event: Record<string, unknown>): boolean {
 	return event.type !== "message_update";
 }
 
+function isBlockingSupervisorTool(toolName: string | undefined, args: unknown): boolean {
+	if (!args || typeof args !== "object" || Array.isArray(args)) return false;
+	if (toolName === "contact_supervisor") {
+		const reason = (args as Record<string, unknown>).reason;
+		return reason === "need_decision" || reason === "interview_request";
+	}
+	return toolName === "intercom" && (args as Record<string, unknown>).action === "ask";
+}
+
 function findLatestSessionFile(sessionDir: string): string | null {
 	try {
 		const files = fs
@@ -2019,6 +2028,7 @@ async function runSubagent(
 	const activeLongRunningSteps = new Set<number>();
 	const mutatingFailureStates = initialStatusSteps.map(() => createMutatingFailureState());
 	const pendingToolResults: Array<{ tool: string; path?: string; mutates: boolean; startedAt?: number } | undefined> = initialStatusSteps.map(() => undefined);
+	const supervisorAttentionSteps = new Map<number, ActivityState | undefined>();
 	const mutatingFailureWindowMs = 5 * 60_000;
 	const appendControlEvent = (event: ReturnType<typeof buildControlEvent>) => {
 		if (!controlConfig.enabled) return;
@@ -2048,6 +2058,15 @@ async function runSubagent(
 		statusPayload.currentTool = activeStep?.currentTool;
 		statusPayload.currentToolStartedAt = activeStep?.currentToolStartedAt;
 		statusPayload.currentPath = activeStep?.currentPath;
+	};
+	const syncAggregateActivityState = (): void => {
+		const nextRunState = statusPayload.steps.some((step) => step.activityState === "needs_attention")
+			? "needs_attention"
+			: statusPayload.steps.some((step) => step.activityState === "active_long_running")
+				? "active_long_running"
+				: undefined;
+		currentActivityState = nextRunState;
+		statusPayload.activityState = nextRunState;
 	};
 	const maybeEmitActiveLongRunning = (flatIndex: number, now: number): boolean => {
 		if (!controlConfig.enabled || activeLongRunningSteps.has(flatIndex)) return false;
@@ -2319,15 +2338,45 @@ async function runSubagent(
 			pendingToolResults[flatIndex] = { tool: event.toolName, path: currentPath, mutates, startedAt: now };
 			statusPayload.toolCount = (statusPayload.toolCount ?? 0) + 1;
 			syncTopLevelCurrentTool();
+			if (controlConfig.enabled && isBlockingSupervisorTool(event.toolName, event.args) && step.activityState !== "needs_attention") {
+				const previous = step.activityState;
+				step.activityState = "needs_attention";
+				supervisorAttentionSteps.set(flatIndex, previous);
+				currentActivityState = "needs_attention";
+				statusPayload.activityState = "needs_attention";
+				appendControlEvent(buildControlEvent({
+					type: "needs_attention",
+					from: previous,
+					to: "needs_attention",
+					runId: id,
+					agent: step.agent,
+					index: flatIndex,
+					ts: now,
+					message: `${step.agent} is waiting for a supervisor reply`,
+					reason: "supervisor_request",
+					turns: step.turnCount,
+					tokens: step.tokens?.total,
+					toolCount: step.toolCount,
+					currentTool: step.currentTool,
+					currentToolDurationMs: 0,
+					currentPath: step.currentPath,
+				}));
+			}
 		} else if (event.type === "tool_execution_end") {
 			if (step.currentTool) {
 				step.recentTools ??= [];
 				step.recentTools.push({ tool: step.currentTool, args: step.currentToolArgs || "", endMs: now });
 			}
+			const supervisorPreviousActivity = supervisorAttentionSteps.get(flatIndex);
+			const clearedSupervisorAttention = supervisorAttentionSteps.delete(flatIndex);
 			step.currentTool = undefined;
 			step.currentToolArgs = undefined;
 			step.currentToolStartedAt = undefined;
 			step.currentPath = undefined;
+			if (clearedSupervisorAttention && step.activityState === "needs_attention") {
+				step.activityState = supervisorPreviousActivity;
+				syncAggregateActivityState();
+			}
 			syncTopLevelCurrentTool();
 		} else if (event.type === "tool_result_end" && event.message) {
 			const toolSnapshot = pendingToolResults[flatIndex];

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -230,7 +230,13 @@ function formatForegroundAttention(run: ForegroundResumeRun, children: ReturnTyp
 
 /** A running run that has flagged it needs the parent's attention. */
 function needsAttention(run: AsyncRunSummary): boolean {
-	return run.activityState === "needs_attention";
+	return run.activityState === "needs_attention" || run.steps.some((step) => step.activityState === "needs_attention");
+}
+
+function hasSupervisorTool(run: AsyncRunSummary): boolean {
+	return run.currentTool === "contact_supervisor"
+		|| run.currentTool === "intercom"
+		|| run.steps.some((step) => step.currentTool === "contact_supervisor" || step.currentTool === "intercom");
 }
 
 function backgroundWorkIdentity(item: RegisteredBackgroundWorkItem): string {
@@ -559,8 +565,11 @@ export async function waitForSubagents(
 	}
 
 	const relevantAttention = attention.filter((run) => initialAsyncIds.has(run.id));
+	const supervisorAttentionHint = relevantAttention.some(hasSupervisorTool)
+		? " Reply to any pending supervisor request. If subagent_supervisor({ action: \"pending\" }) is empty, check intercom({ action: \"pending\" }) because an external intercom tool may own the request."
+		: "";
 	const attentionNote = relevantAttention.length > 0
-		? ` ${relevantAttention.length} run(s) need attention: ${relevantAttention.map((run) => run.id).join(", ")} — inspect with subagent({ action: "status" }) then steer a top-level live async child, resume a paused/completed/failed child, or interrupt explicitly.`
+		? ` ${relevantAttention.length} run(s) need attention: ${relevantAttention.map((run) => run.id).join(", ")} —${supervisorAttentionHint} inspect with subagent({ action: "status" }) then steer a top-level live async child, resume a paused/completed/failed child, or interrupt explicitly.`
 		: "";
 	const stillRunning = active.filter((run) => initialAsyncIds.has(run.id)).length
 		+ providerActive.filter((item) => initialProviderIds.has(backgroundWorkIdentity(item))).length;

--- a/src/runs/shared/subagent-control.ts
+++ b/src/runs/shared/subagent-control.ts
@@ -193,11 +193,15 @@ export function formatControlNoticeMessage(event: ControlEvent, childIntercomTar
 		].filter((line): line is string => Boolean(line)).join("\n");
 	}
 
+	const supervisorHint = event.reason === "supervisor_request"
+		? "Supervisor request: reply to the pending request. If subagent_supervisor pending is empty, check intercom pending because an external intercom tool may own the request."
+		: undefined;
 	return [
 		`Subagent needs attention: ${event.agent}`,
 		`Run: ${runTarget}${event.index !== undefined ? ` step ${event.index + 1}` : ""}`,
 		`Signal: ${event.message}`,
 		event.recentFailureSummary ? `Recent failures: ${event.recentFailureSummary}` : undefined,
+		supervisorHint,
 		"Hint: Inspect status first unless the run is clearly blocked. Use steer for a top-level live async child, routed resume for a live nested child, or resume to revive a paused/completed/failed child.",
 		`Top-level live async nudge: ${steerCommand}`,
 		`Routed live nested nudge: ${nestedResumeCommand}`,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -201,7 +201,7 @@ export interface ControlEvent {
 	nestedRunId?: string;
 	nestingPath?: NestedRunAddress["path"];
 	message: string;
-	reason?: "idle" | "completion_guard" | "active_long_running" | "tool_failures" | "time_threshold" | "turn_threshold" | "token_threshold";
+	reason?: "idle" | "completion_guard" | "active_long_running" | "tool_failures" | "supervisor_request" | "time_threshold" | "turn_threshold" | "token_threshold";
 	turns?: number;
 	tokens?: number;
 	toolCount?: number;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -16,6 +16,7 @@ import * as path from "node:path";
 import { createEventBus, createMockPi, createTempDir, events, makeAgent, makeMinimalCtx, removeTempDir, tryImport } from "../support/helpers.ts";
 import type { MockPi } from "../support/helpers.ts";
 import { deliverInterruptRequest, deliverStopRequest, deliverTimeoutRequest } from "../../src/runs/background/control-channel.ts";
+import { waitForSubagents } from "../../src/runs/background/subagent-wait.ts";
 import { writeAtomicJson } from "../../src/shared/atomic-json.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { MAX_CHILD_PENDING_LINE_BYTES, MAX_CHILD_STDERR_BYTES } from "../../src/runs/shared/child-protocol.ts";
@@ -3863,6 +3864,90 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		await waitForAsyncResultFile(id);
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
 		assert.equal(payload.success, true);
+	});
+
+	it("subagent_wait wakes when an async child is waiting on contact_supervisor", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need a decision" })] },
+				{ delay: 5_000, jsonl: [events.toolEnd("contact_supervisor"), events.toolResult("contact_supervisor", "**Reply from supervisor:**\nProceed")] },
+				{ delay: 2_500, jsonl: [events.assistantMessage("Done")] },
+			],
+		});
+
+		const id = `async-supervisor-attention-${Date.now().toString(36)}`;
+		const asyncDir = path.join(ASYNC_DIR, id);
+		const eventsPath = path.join(asyncDir, "events.jsonl");
+		const resultPath = path.join(RESULTS_DIR, `${id}.json`);
+		const statusPath = path.join(asyncDir, "status.json");
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Ask the supervisor for a blocking decision",
+			agentConfig: makeAgent("worker"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			maxSubagentDepth: 2,
+			controlConfig: {
+				enabled: true,
+				needsAttentionAfterMs: 999_999,
+				activeNoticeAfterMs: 999_999,
+				failedToolAttemptsBeforeAttention: 3,
+				notifyOn: ["active_long_running", "needs_attention"],
+				notifyChannels: ["event", "async", "intercom"],
+			},
+		});
+
+		const attentionDeadline = Date.now() + 10_000;
+		let statusDuringAttention: AsyncStatusPayload | undefined;
+		while (Date.now() < attentionDeadline && !fs.existsSync(resultPath)) {
+			if (fs.existsSync(statusPath)) {
+				const nextStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatusPayload;
+				if (nextStatus.currentTool === "contact_supervisor" && nextStatus.activityState === "needs_attention") {
+					statusDuringAttention = nextStatus;
+					break;
+				}
+			}
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		assert.ok(statusDuringAttention, "expected status.json to expose the blocking supervisor request");
+
+		const waitResult = await waitForSubagents({ id, timeoutMs: 3_500 }, undefined, {
+			state: { currentSessionId: "session-1", foregroundRuns: new Map(), asyncJobs: new Map(), cleanupTimers: new Map(), resultFileCoalescer: new Map() },
+			pollIntervalMs: 100,
+			events: createEventBus(),
+		});
+		const waitText = waitResult.content[0]?.text ?? "";
+		assert.equal(waitResult.isError, undefined);
+		assert.match(waitText, /attention required/i);
+		assert.match(waitText, new RegExp(id));
+		assert.match(waitText, /intercom\(\{ action: "pending" \}\)/);
+		assert.equal(fs.existsSync(resultPath), false, "wait should return before the child completes");
+
+		const eventText = fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf-8") : "";
+		assert.match(eventText, /"type":"needs_attention"/);
+		assert.match(eventText, /"reason":"supervisor_request"/);
+		assert.equal(statusDuringAttention.activityState, "needs_attention");
+		assert.equal(statusDuringAttention.steps?.[0]?.activityState, "needs_attention");
+		assert.equal(statusDuringAttention.currentTool, "contact_supervisor");
+		assert.equal(statusDuringAttention.steps?.[0]?.currentTool, "contact_supervisor");
+
+		const clearDeadline = Date.now() + 10_000;
+		let statusAfterReply: AsyncStatusPayload | undefined;
+		while (Date.now() < clearDeadline && !fs.existsSync(resultPath)) {
+			const nextStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatusPayload;
+			if (nextStatus.state === "running" && !nextStatus.currentTool && !nextStatus.steps?.[0]?.currentTool) {
+				statusAfterReply = nextStatus;
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		assert.ok(statusAfterReply, "expected the child to keep running after the supervisor reply");
+		assert.equal(statusAfterReply.activityState, undefined);
+		assert.equal(statusAfterReply.steps?.[0]?.activityState, undefined);
+
+		await waitForAsyncResultFile(id);
 	});
 
 	it("background runs escalate repeated mutating tool failures", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/unit/subagent-control.test.ts
+++ b/test/unit/subagent-control.test.ts
@@ -172,6 +172,22 @@ describe("subagent control attention state", () => {
 		assert.doesNotMatch(message, /Wait:/);
 	});
 
+	it("formats supervisor-request notices with pending-channel guidance", () => {
+		const event = buildControlEvent({
+			to: "needs_attention",
+			runId: "78f659a3",
+			agent: "worker",
+			reason: "supervisor_request",
+			currentTool: "contact_supervisor",
+		});
+
+		const message = formatControlNoticeMessage(event, "subagent-worker-78f659a3");
+
+		assert.match(message, /Supervisor request: reply to the pending request/);
+		assert.match(message, /subagent_supervisor pending/);
+		assert.match(message, /intercom pending/);
+	});
+
 	it("formats active-long-running notices as informational", () => {
 		const event = buildControlEvent({
 			type: "active_long_running",

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -208,6 +208,31 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("reports step-level attention even when the aggregate flag has not caught up", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-step-attn-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-step-blocked", "running", {
+				sessionId: "sess-1",
+				pid: 999999,
+				steps: [{ agent: "worker", status: "running", activityState: "needs_attention" }],
+			});
+
+			let polls = 0;
+			const result = await waitForSubagents({}, undefined, baseDeps(root, state, {
+				sleep: async () => { polls += 1; },
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /need attention/i);
+			assert.match(textOf(result), /run-step-blocked/);
+			assert.equal(polls, 0, "step-level attention should return without polling");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("by default returns as soon as the FIRST run finishes, leaving the rest in flight", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-first-"));
 		try {


### PR DESCRIPTION
Fixes #581.

This makes async runs mark blocking supervisor requests as `needs_attention` as soon as a child starts `contact_supervisor` for `need_decision` or `interview_request`, or starts `intercom` with `action: "ask"`. `subagent_wait` now wakes from run-level or step-level attention, and the runner clears only the supervisor-request attention state when the tool returns so a later wait does not trip over stale state.

The notice text also points users to `intercom({ action: "pending" })` when `subagent_supervisor({ action: "pending" })` is empty, matching the failure mode reported in the issue.

Validation:
- focused supervisor regression repeated 3x
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/subagent-wait.test.ts`
- `node --experimental-strip-types --test test/unit/subagent-control.test.ts`
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts`
- `npm run test:integration`
- `npm run test:e2e`
- `git diff --check`

Note: broad local `npm run test:unit` timed out earlier in this environment after many passing files and left no lingering test processes; the changed unit suites passed directly.