### PR TITLE
Prune broad subagent discovery walks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Pruned broad agent and chain discovery roots so package-declared `.` scans no longer descend into `node_modules`, `.git`, Git submodules, or nested project roots during startup. Thanks to tupe12334 (@tupe12334) for #570 and shoehn (@shoehn) for narrowing the startup trace.
 - Made `subagent_wait({ id })` wake when an async child is blocked in `contact_supervisor` for a supervisor decision, instead of waiting for completion or timeout. Thanks to @DrunkenDonkey80 for #581.
 - Scoped async result delivery to the active session lease so stale watchers and recovered result files cannot wake or redeliver completions after reload, while retaining unaccepted result files for retry. Thanks to KawaiiNahida (@KawaiiNahida) for #588.
 - Namespaced inherited relative agent output paths for foreground top-level parallel tasks so repeated builtin agents no longer collide before launch. Thanks to Artem Timofeev (@atimofeev) for #580.

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1160,7 +1160,19 @@ export function removeBuiltinAgentOverrideFields(
 	return { path: filePath, removed: true };
 }
 
-function listFilesRecursive(dir: string, predicate: (fileName: string) => boolean): string[] {
+const DISCOVERY_PRUNED_DIR_NAMES = new Set([".git", "node_modules"]);
+
+function isDiscoveryNestedProjectRoot(dir: string): boolean {
+	return isDirectory(getProjectConfigDir(dir)) || isDirectory(path.join(dir, ".agents"));
+}
+
+function shouldPruneDiscoveryDir(rootDir: string, dir: string, dirName: string): boolean {
+	if (DISCOVERY_PRUNED_DIR_NAMES.has(dirName)) return true;
+	if (fs.existsSync(path.join(dir, ".git"))) return true;
+	return path.resolve(dir) !== path.resolve(rootDir) && isDiscoveryNestedProjectRoot(dir);
+}
+
+function listFilesRecursive(dir: string, predicate: (fileName: string) => boolean, rootDir = dir): string[] {
 	const files: string[] = [];
 	if (!fs.existsSync(dir)) return files;
 
@@ -1174,7 +1186,9 @@ function listFilesRecursive(dir: string, predicate: (fileName: string) => boolea
 	for (const entry of entries) {
 		const filePath = path.join(dir, entry.name);
 		if (entry.isDirectory()) {
-			files.push(...listFilesRecursive(filePath, predicate));
+			if (!shouldPruneDiscoveryDir(rootDir, filePath, entry.name)) {
+				files.push(...listFilesRecursive(filePath, predicate, rootDir));
+			}
 			continue;
 		}
 		if (!entry.isFile() && !entry.isSymbolicLink()) continue;

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -624,6 +624,83 @@ Agent prompt
 		assert.equal(packageAgents.some((agent) => agent.name === "package-skill"), false);
 	}));
 
+	it("prunes repo internals and nested project roots from broad package discovery", () => withTempHome(() => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-broad-package-prune-"));
+		tempDirs.push(dir);
+		writeJson(path.join(dir, "package.json"), {
+			name: "repo-root-workflow",
+			pi: {
+				subagents: {
+					agents: ["."],
+					chains: ["."],
+				},
+			},
+		});
+		writeAgent(path.join(dir, "root-agent.md"), `---
+name: root-agent
+description: Root package agent
+---
+
+Root prompt
+`);
+		writeAgent(path.join(dir, "root.chain.md"), `---
+name: root-chain
+description: Root package chain
+---
+
+## root-agent
+
+Run root agent
+`);
+		writeAgent(path.join(dir, "node_modules", "bad-agent.md"), `---
+name: node-modules-agent
+description: Should not be discovered
+---
+
+Ignored
+`);
+		writeAgent(path.join(dir, ".git", "hooks", "bad-agent.md"), `---
+name: git-agent
+description: Should not be discovered
+---
+
+Ignored
+`);
+		writeAgent(path.join(dir, "vendor", "submodule", "submodule-agent.md"), `---
+name: submodule-agent
+description: Should not be discovered
+---
+
+Ignored
+`);
+		fs.writeFileSync(path.join(dir, "vendor", "submodule", ".git"), "gitdir: ../.git/modules/submodule\n", "utf-8");
+		writeAgent(path.join(dir, "packages", "app", "local-agent.md"), `---
+name: nested-project-agent
+description: Should not be discovered
+---
+
+Ignored
+`);
+		fs.mkdirSync(path.join(dir, "packages", "app", ".pi"), { recursive: true });
+		writeAgent(path.join(dir, "node_modules", "bad.chain.md"), `---
+name: node-modules-chain
+description: Should not be discovered
+---
+
+## root-agent
+
+Ignored
+`);
+
+		const all = discoverAgentsAll(dir);
+		assert.ok(all.package.find((agent) => agent.name === "root-agent" && agent.filePath === path.join(dir, "root-agent.md")));
+		for (const name of ["node-modules-agent", "git-agent", "submodule-agent", "nested-project-agent"]) {
+			assert.equal(all.package.some((agent) => agent.name === name), false, `${name} should be pruned`);
+		}
+		assert.ok(all.chains.find((chain) => chain.name === "root-chain" && chain.filePath === path.join(dir, "root.chain.md")));
+		assert.equal(all.chains.some((chain) => chain.name === "node-modules-chain"), false);
+	}));
+
 	it("keeps package definitions below user and project overrides", () => withTempHome((home) => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-package-precedence-"));
 		tempDirs.push(dir);


### PR DESCRIPTION
Addresses #570.

This bounds broad package-declared agent and chain discovery roots so `agents: ["."]` and `chains: ["."]` no longer recurse into `node_modules`, `.git`, Git submodules/worktrees, or nested project roots during startup. Normal explicit project/user agent and chain directories still recurse as before.

Validation:
- `node --experimental-strip-types --test test/unit/agent-frontmatter.test.ts`
- `git diff --check`

I also ran `npm run test:unit` twice locally; both runs timed out after extensive passing output with no visible failure, matching the current local broad-suite reliability caveat.