### PR TITLE
fix: retry Windows async result directory locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Retried transient Windows filesystem locks while creating async result directories and stopped destructively recreating shared async directories during startup access checks, so concurrent Pi instances are less likely to lose completed async results to `EPERM` directory handles. Thanks to AiraNadih (@AiraNadih) for #566.
 - Pruned broad agent and chain discovery roots so package-declared `.` scans no longer descend into `node_modules`, `.git`, Git submodules, or nested project roots during startup. Thanks to tupe12334 (@tupe12334) for #570 and shoehn (@shoehn) for narrowing the startup trace.
 - Made `subagent_wait({ id })` wake when an async child is blocked in `contact_supervisor` for a supervisor decision, instead of waiting for completion or timeout. Thanks to @DrunkenDonkey80 for #581.
 - Scoped async result delivery to the active session lease so stale watchers and recovered result files cannot wake or redeliver completions after reload, while retaining unaccepted result files for retry. Thanks to KawaiiNahida (@KawaiiNahida) for #588.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -20,6 +20,7 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { keyText, type ExtensionAPI, type ExtensionContext, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Box, Container, Spacer, Text, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
 import { discoverAgents } from "../agents/agents.ts";
+import { ensureAccessibleDir } from "../shared/accessible-dir.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
@@ -90,28 +91,6 @@ function getSubagentSessionRoot(parentSessionFile: string | null): string {
 
 function expandTilde(p: string): string {
 	return p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
-}
-
-/**
- * Create a directory and verify it is actually accessible.
- * On Windows with Azure AD/Entra ID, directories created shortly after
- * wake-from-sleep can end up with broken NTFS ACLs (null DACL) when the
- * cloud SID cannot be resolved without network connectivity. This leaves
- * the directory completely inaccessible to the creating user.
- */
-function ensureAccessibleDir(dirPath: string): void {
-	fs.mkdirSync(dirPath, { recursive: true });
-	try {
-		fs.accessSync(dirPath, fs.constants.R_OK | fs.constants.W_OK);
-	} catch {
-		try {
-			fs.rmSync(dirPath, { recursive: true, force: true });
-		} catch {
-			// Best effort: retry mkdir/access even if cleanup fails.
-		}
-		fs.mkdirSync(dirPath, { recursive: true });
-		fs.accessSync(dirPath, fs.constants.R_OK | fs.constants.W_OK);
-	}
 }
 
 function isSlashResultRunning(result: { details?: Details }): boolean {

--- a/src/shared/accessible-dir.ts
+++ b/src/shared/accessible-dir.ts
@@ -1,0 +1,25 @@
+import * as fs from "node:fs";
+import { DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS, runFileSystemOperationWithRetry, waitForFileSystemRetry } from "./file-system-retry.ts";
+
+type AccessibleDirFs = Pick<typeof fs, "accessSync" | "mkdirSync">;
+
+type AccessibleDirOptions = {
+	fs?: AccessibleDirFs;
+	retryDirectoryErrors?: boolean;
+	retryDelaysMs?: readonly number[];
+	wait?: (delayMs: number) => void;
+};
+
+export function ensureAccessibleDir(dirPath: string, options: AccessibleDirOptions = {}): void {
+	const fsImpl = options.fs ?? fs;
+	const retryDirectoryErrors = options.retryDirectoryErrors ?? process.platform === "win32";
+	const retryDelaysMs = retryDirectoryErrors ? options.retryDelaysMs ?? DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS : [];
+	const wait = options.wait ?? waitForFileSystemRetry;
+
+	runFileSystemOperationWithRetry(() => {
+		fsImpl.mkdirSync(dirPath, { recursive: true });
+	}, { retryDelaysMs, wait });
+	runFileSystemOperationWithRetry(() => {
+		fsImpl.accessSync(dirPath, fs.constants.R_OK | fs.constants.W_OK);
+	}, { retryDelaysMs, wait });
+}

--- a/src/shared/atomic-json.ts
+++ b/src/shared/atomic-json.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS, runFileSystemOperationWithRetry, waitForFileSystemRetry } from "./file-system-retry.ts";
 
 type AtomicJsonFs = Pick<typeof fs, "mkdirSync" | "writeFileSync" | "renameSync" | "rmSync">;
 
@@ -10,37 +11,10 @@ type AtomicJsonWriterOptions = {
 	random?: () => number;
 	mode?: number;
 	retryRenameErrors?: boolean;
+	retryDirectoryErrors?: boolean;
 	retryDelaysMs?: readonly number[];
 	wait?: (delayMs: number) => void;
 };
-
-const DEFAULT_RENAME_RETRY_DELAYS_MS = [10, 25, 50, 100, 200, 500, 1000, 2000, 4000] as const;
-const RETRYABLE_RENAME_ERROR_CODES = new Set(["EACCES", "EBUSY", "EPERM"]);
-const WAIT_BUFFER = typeof SharedArrayBuffer !== "undefined" ? new SharedArrayBuffer(4) : undefined;
-const WAIT_VIEW = WAIT_BUFFER ? new Int32Array(WAIT_BUFFER) : undefined;
-
-function waitSync(delayMs: number): void {
-	if (delayMs <= 0) return;
-	if (WAIT_VIEW) {
-		try {
-			// writeAtomicJson is synchronous because callers often update status from sync callbacks.
-			// Atomics.wait gives Windows rename locks time to clear without burning CPU.
-			Atomics.wait(WAIT_VIEW, 0, 0, delayMs);
-			return;
-		} catch {
-			// Fall through to the portable busy wait below.
-		}
-	}
-	const end = Date.now() + delayMs;
-	while (Date.now() < end) {
-		// Portable fallback for runtimes where Atomics.wait is unavailable.
-	}
-}
-
-function isRetryableRenameError(error: unknown): boolean {
-	const code = (error as NodeJS.ErrnoException | undefined)?.code;
-	return typeof code === "string" && RETRYABLE_RENAME_ERROR_CODES.has(code);
-}
 
 function renameWithRetry(
 	fsImpl: AtomicJsonFs,
@@ -49,16 +23,9 @@ function renameWithRetry(
 	retryDelaysMs: readonly number[],
 	wait: (delayMs: number) => void,
 ): void {
-	for (let attempt = 0; ; attempt++) {
-		try {
-			fsImpl.renameSync(sourcePath, targetPath);
-			return;
-		} catch (error) {
-			const delayMs = retryDelaysMs[attempt];
-			if (delayMs === undefined || !isRetryableRenameError(error)) throw error;
-			wait(delayMs);
-		}
-	}
+	runFileSystemOperationWithRetry(() => {
+		fsImpl.renameSync(sourcePath, targetPath);
+	}, { retryDelaysMs, wait });
 }
 
 export function createAtomicJsonWriter(options: AtomicJsonWriterOptions = {}): (filePath: string, payload: object) => void {
@@ -68,17 +35,22 @@ export function createAtomicJsonWriter(options: AtomicJsonWriterOptions = {}): (
 	const random = options.random ?? Math.random;
 	const mode = options.mode;
 	const retryRenameErrors = options.retryRenameErrors ?? process.platform === "win32";
-	const retryDelaysMs = retryRenameErrors ? options.retryDelaysMs ?? DEFAULT_RENAME_RETRY_DELAYS_MS : [];
-	const wait = options.wait ?? waitSync;
+	const retryDirectoryErrors = options.retryDirectoryErrors ?? retryRenameErrors;
+	const retryDelaysMs = options.retryDelaysMs ?? DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS;
+	const renameRetryDelaysMs = retryRenameErrors ? retryDelaysMs : [];
+	const directoryRetryDelaysMs = retryDirectoryErrors ? retryDelaysMs : [];
+	const wait = options.wait ?? waitForFileSystemRetry;
 	return (filePath: string, payload: object): void => {
-		fsImpl.mkdirSync(path.dirname(filePath), { recursive: true });
+		runFileSystemOperationWithRetry(() => {
+			fsImpl.mkdirSync(path.dirname(filePath), { recursive: true });
+		}, { retryDelaysMs: directoryRetryDelaysMs, wait });
 		const tempPath = path.join(
 			path.dirname(filePath),
 			`.${path.basename(filePath)}.${pid}.${now()}.${random().toString(36).slice(2)}.tmp`,
 		);
 		try {
 			fsImpl.writeFileSync(tempPath, JSON.stringify(payload, null, 2), mode === undefined ? "utf-8" : { encoding: "utf-8", mode });
-			renameWithRetry(fsImpl, tempPath, filePath, retryDelaysMs, wait);
+			renameWithRetry(fsImpl, tempPath, filePath, renameRetryDelaysMs, wait);
 		} finally {
 			fsImpl.rmSync(tempPath, { force: true });
 		}

--- a/src/shared/file-system-retry.ts
+++ b/src/shared/file-system-retry.ts
@@ -1,0 +1,47 @@
+const WAIT_BUFFER = typeof SharedArrayBuffer !== "undefined" ? new SharedArrayBuffer(4) : undefined;
+const WAIT_VIEW = WAIT_BUFFER ? new Int32Array(WAIT_BUFFER) : undefined;
+const RETRYABLE_FILE_SYSTEM_ERROR_CODES = new Set(["EACCES", "EBUSY", "EPERM"]);
+
+export const DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS = [10, 25, 50, 100, 200, 500, 1000, 2000, 4000] as const;
+
+export type FileSystemRetryOptions = {
+	retryDelaysMs?: readonly number[];
+	wait?: (delayMs: number) => void;
+};
+
+export function waitForFileSystemRetry(delayMs: number): void {
+	if (delayMs <= 0) return;
+	if (WAIT_VIEW) {
+		try {
+			// Callers are synchronous status/result writers; Atomics.wait gives
+			// Windows directory and rename locks time to clear without burning CPU.
+			Atomics.wait(WAIT_VIEW, 0, 0, delayMs);
+			return;
+		} catch {
+			// Fall through to the portable busy wait below.
+		}
+	}
+	const end = Date.now() + delayMs;
+	while (Date.now() < end) {
+		// Portable fallback for runtimes where Atomics.wait is unavailable.
+	}
+}
+
+export function isRetryableFileSystemError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_FILE_SYSTEM_ERROR_CODES.has(code);
+}
+
+export function runFileSystemOperationWithRetry<T>(operation: () => T, options: FileSystemRetryOptions = {}): T {
+	const retryDelaysMs = options.retryDelaysMs ?? DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS;
+	const wait = options.wait ?? waitForFileSystemRetry;
+	for (let attempt = 0; ; attempt++) {
+		try {
+			return operation();
+		} catch (error) {
+			const delayMs = retryDelaysMs[attempt];
+			if (delayMs === undefined || !isRetryableFileSystemError(error)) throw error;
+			wait(delayMs);
+		}
+	}
+}

--- a/test/unit/accessible-dir.test.ts
+++ b/test/unit/accessible-dir.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ensureAccessibleDir } from "../../src/shared/accessible-dir.ts";
+
+class FakeFs {
+	mkdirCalls = 0;
+	accessCalls = 0;
+	failMkdirCodes: string[] = [];
+	failAccessCodes: string[] = [];
+
+	mkdirSync(): void {
+		this.mkdirCalls++;
+		const failureCode = this.failMkdirCodes.shift();
+		if (failureCode) {
+			const error = new Error(`mkdir failed with ${failureCode}`) as NodeJS.ErrnoException;
+			error.code = failureCode;
+			throw error;
+		}
+	}
+
+	accessSync(): void {
+		this.accessCalls++;
+		const failureCode = this.failAccessCodes.shift();
+		if (failureCode) {
+			const error = new Error(`access failed with ${failureCode}`) as NodeJS.ErrnoException;
+			error.code = failureCode;
+			throw error;
+		}
+	}
+}
+
+describe("ensureAccessibleDir", () => {
+	it("retries transient shared-directory mkdir failures before validating access", () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failMkdirCodes = ["EPERM", "EBUSY"];
+		const waits: number[] = [];
+
+		ensureAccessibleDir("/tmp/pi-subagents-user/async-subagent-results", {
+			fs: fakeFs as any,
+			retryDirectoryErrors: true,
+			retryDelaysMs: [1, 2, 3],
+			wait: (delayMs) => waits.push(delayMs),
+		});
+
+		assert.equal(fakeFs.mkdirCalls, 3);
+		assert.equal(fakeFs.accessCalls, 1);
+		assert.deepEqual(waits, [1, 2]);
+	});
+
+	it("retries transient shared-directory access failures without recreating the directory", () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failAccessCodes = ["EPERM", "EACCES"];
+		const waits: number[] = [];
+
+		ensureAccessibleDir("/tmp/pi-subagents-user/async-subagent-results", {
+			fs: fakeFs as any,
+			retryDirectoryErrors: true,
+			retryDelaysMs: [1, 2, 3],
+			wait: (delayMs) => waits.push(delayMs),
+		});
+
+		assert.equal(fakeFs.mkdirCalls, 1);
+		assert.equal(fakeFs.accessCalls, 3);
+		assert.deepEqual(waits, [1, 2]);
+	});
+
+	it("throws non-retryable access failures without retrying", () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failAccessCodes = ["ENOENT"];
+		const waits: number[] = [];
+
+		assert.throws(() => ensureAccessibleDir("/tmp/pi-subagents-user/async-subagent-results", {
+			fs: fakeFs as any,
+			retryDirectoryErrors: true,
+			retryDelaysMs: [1, 2, 3],
+			wait: (delayMs) => waits.push(delayMs),
+		}), /ENOENT/);
+		assert.equal(fakeFs.mkdirCalls, 1);
+		assert.equal(fakeFs.accessCalls, 1);
+		assert.deepEqual(waits, []);
+	});
+});

--- a/test/unit/atomic-json.test.ts
+++ b/test/unit/atomic-json.test.ts
@@ -7,11 +7,18 @@ class FakeFs {
 	files = new Map<string, string>();
 	madeDirs: string[] = [];
 	renameCalls = 0;
+	failMkdirCodes: string[] = [];
 	failRenameCodes: string[] = [];
 	writeOptions = new Map<string, unknown>();
 
 	mkdirSync(dirPath: string): void {
 		this.madeDirs.push(dirPath);
+		const failureCode = this.failMkdirCodes.shift();
+		if (failureCode) {
+			const error = new Error(`mkdir failed with ${failureCode}`) as NodeJS.ErrnoException;
+			error.code = failureCode;
+			throw error;
+		}
 	}
 
 	writeFileSync(filePath: string, contents: string, options?: unknown): void {
@@ -65,6 +72,21 @@ describe("writeAtomicJson", () => {
 		assert.deepEqual(fakeFs.madeDirs, [path.dirname(targetPath)]);
 		assert.equal(fakeFs.files.get(targetPath), JSON.stringify({ state: "running" }, null, 2));
 		assert.equal(fakeFs.files.size, 1);
+	});
+
+	it("retries transient directory creation failures before writing", () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failMkdirCodes = ["EPERM", "EACCES"];
+		const waits: number[] = [];
+		const writeAtomicJson = createWriter(fakeFs, waits);
+		const targetPath = path.join("/tmp", "status.json");
+
+		writeAtomicJson(targetPath, { state: "running" });
+
+		assert.equal(fakeFs.renameCalls, 1);
+		assert.deepEqual(waits, [1, 2]);
+		assert.deepEqual(fakeFs.madeDirs, [path.dirname(targetPath), path.dirname(targetPath), path.dirname(targetPath)]);
+		assert.equal(fakeFs.files.get(targetPath), JSON.stringify({ state: "running" }, null, 2));
 	});
 
 	it("writes the temporary descriptor with the requested private mode", () => {


### PR DESCRIPTION
Addresses #566.

This keeps the existing shared result-directory design, but hardens the Windows lock path reported in the issue:

- retries transient `EPERM`/`EACCES`/`EBUSY` while creating the atomic JSON target directory
- retries startup mkdir/access validation for shared async/result directories
- stops recursively deleting and recreating those shared directories on a generic access failure
- adds focused unit coverage for the result-writer and startup directory validation seams
- credits AiraNadih in `CHANGELOG.md`

Validation:

- `node --experimental-strip-types --test test/unit/atomic-json.test.ts test/unit/accessible-dir.test.ts`
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/index-child-registration.test.ts`
- `npm run test:integration`
- `npm run test:e2e`
- `git diff --check`

`npm run test:unit` was also retried with a longer timeout. It reached the end of visible test output without visible failures but did not exit before the local timeout; the one transient visible watchdog LSP failure from the earlier attempt passed when rerun directly.

No release or tag.
