### PR TITLE
feat: add searchable subagents admin selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Added `artifactDir` config to store subagent artifacts in the project, Pi session, or temp artifact directory while keeping project-local artifacts as the default. Thanks to WeZZard (@WeZZard) for #582.
 - Added opt-in `agentContract: { version: 1 }` runs with explicit execution, acceptance, review, and effects projections, report-optional acceptance, observational file-mutation effects, generic `outputSchema` plumbing, and `gateOn` chain controls while keeping the current/default contract unchanged. Thanks to mapleluv (@mapleluvr) for #499.
-- Replaced the flat `/subagents` admin model, thinking, and agent pickers with a searchable, bounded-scroll selector docked in place of the editor, matching Pi's built-in `/model` picker so the current selection no longer scrolls off screen when the option list is long.
+- Replaced the flat `/subagents` admin model, thinking, and agent pickers with a searchable, bounded-scroll selector docked in place of the editor, matching Pi's built-in `/model` picker so the current selection no longer scrolls off screen when the option list is long. Thanks to Chanyeong Lim (@asp345) for #568.
 - Added `advisor` as an `oracle`-compatible bundled agent alias for users switching between Claude Code and Pi naming. Thanks to Serhii Chernenko (@serhii-chernenko) for #552.
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added `artifactDir` config to store subagent artifacts in the project, Pi session, or temp artifact directory while keeping project-local artifacts as the default. Thanks to WeZZard (@WeZZard) for #582.
 - Added opt-in `agentContract: { version: 1 }` runs with explicit execution, acceptance, review, and effects projections, report-optional acceptance, observational file-mutation effects, generic `outputSchema` plumbing, and `gateOn` chain controls while keeping the current/default contract unchanged. Thanks to mapleluv (@mapleluvr) for #499.
+- Replaced the flat `/subagents` admin model, thinking, and agent pickers with a searchable, bounded-scroll selector docked in place of the editor, matching Pi's built-in `/model` picker so the current selection no longer scrolls off screen when the option list is long.
 - Added `advisor` as an `oracle`-compatible bundled agent alias for users switching between Claude Code and Pi naming. Thanks to Serhii Chernenko (@serhii-chernenko) for #552.
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 

--- a/src/slash/selector.ts
+++ b/src/slash/selector.ts
@@ -1,0 +1,147 @@
+import { DynamicBorder, keyHint, rawKeyHint, type Theme } from "@earendil-works/pi-coding-agent";
+import { Container, fuzzyFilter, Input, type KeybindingsManager, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
+
+/** A single selectable row. `value` is returned on confirm; `label` is the primary text. */
+export interface SelectorItem {
+	value: string;
+	label: string;
+	/** Optional dimmed badge shown after the label (e.g. a provider name). */
+	badge?: string;
+	/** Marks the current selection (rendered with a ✓ checkmark). */
+	current?: boolean;
+}
+
+export interface SelectorResult {
+	confirmed: boolean;
+	value?: string;
+}
+
+export interface SelectorOptions {
+	title: string;
+	/** Optional dimmed hint line under the title (e.g. the current value). */
+	subtitle?: string;
+	items: SelectorItem[];
+	done: (result: SelectorResult) => void;
+}
+
+const MAX_VISIBLE = 10;
+
+/**
+ * A single-select list with a search field and a bounded scroll window that keeps the
+ * highlighted row on screen with an `(n/total)` indicator, so the selection never scrolls
+ * out of view when the option list is long. Composed from pi's own TUI primitives so it
+ * matches the built-in `/model` picker.
+ *
+ * Colors come from the `theme` passed to the factory: the module-level `theme` singleton
+ * is undefined under the extension's jiti module cache.
+ */
+export class SelectorComponent extends Container {
+	private readonly tui: TUI;
+	private readonly theme: Theme;
+	private readonly keybindings: KeybindingsManager;
+	private readonly items: SelectorItem[];
+	private readonly done: (result: SelectorResult) => void;
+
+	private readonly searchInput: Input;
+	private readonly listContainer: Container;
+	private filtered: SelectorItem[];
+	private selectedIndex = 0;
+
+	constructor(tui: TUI, theme: Theme, keybindings: KeybindingsManager, options: SelectorOptions) {
+		super();
+		this.tui = tui;
+		this.theme = theme;
+		this.keybindings = keybindings;
+		this.items = options.items;
+		this.done = options.done;
+		this.filtered = [...this.items];
+
+		const border = () => new DynamicBorder((str) => theme.fg("border", str));
+		this.addChild(border());
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg("accent", theme.bold(options.title)), 0, 0));
+		if (options.subtitle) this.addChild(new Text(theme.fg("muted", options.subtitle), 0, 0));
+		this.addChild(new Spacer(1));
+
+		this.searchInput = new Input();
+		this.searchInput.focused = true;
+		this.searchInput.onSubmit = () => this.confirmSelection();
+		this.addChild(this.searchInput);
+		this.addChild(new Spacer(1));
+
+		this.listContainer = new Container();
+		this.addChild(this.listContainer);
+		this.addChild(new Spacer(1));
+
+		this.addChild(new Text(rawKeyHint("↑↓", "navigate") + "  " + keyHint("tui.select.confirm", "select") + "  " + keyHint("tui.select.cancel", "cancel"), 0, 0));
+		this.addChild(new Spacer(1));
+		this.addChild(border());
+
+		const currentIndex = this.filtered.findIndex((item) => item.current);
+		if (currentIndex >= 0) this.selectedIndex = currentIndex;
+		this.updateList();
+	}
+
+	private applyFilter(query: string): void {
+		const previous = this.filtered[this.selectedIndex]?.value;
+		this.filtered = query
+			? fuzzyFilter(this.items, query, (item) => `${item.label} ${item.value} ${item.badge ?? ""}`)
+			: [...this.items];
+		const keepIndex = this.filtered.findIndex((item) => item.value === previous);
+		this.selectedIndex = keepIndex >= 0 ? keepIndex : Math.min(this.selectedIndex, Math.max(0, this.filtered.length - 1));
+		this.updateList();
+	}
+
+	private updateList(): void {
+		const th = this.theme;
+		this.listContainer.clear();
+		const startIndex = Math.max(0, Math.min(this.selectedIndex - Math.floor(MAX_VISIBLE / 2), this.filtered.length - MAX_VISIBLE));
+		const endIndex = Math.min(startIndex + MAX_VISIBLE, this.filtered.length);
+
+		for (let i = startIndex; i < endIndex; i++) {
+			const item = this.filtered[i]!;
+			const isSelected = i === this.selectedIndex;
+			const badge = item.badge ? ` ${th.fg("muted", `[${item.badge}]`)}` : "";
+			const checkmark = item.current ? th.fg("success", " ✓") : "";
+			const line = isSelected
+				? `${th.fg("accent", "→ ")}${th.fg("accent", item.label)}${badge}${checkmark}`
+				: `  ${item.label}${badge}${checkmark}`;
+			this.listContainer.addChild(new Text(line, 0, 0));
+		}
+
+		if (startIndex > 0 || endIndex < this.filtered.length) {
+			this.listContainer.addChild(new Text(th.fg("muted", `  (${this.selectedIndex + 1}/${this.filtered.length})`), 0, 0));
+		}
+		if (this.filtered.length === 0) {
+			this.listContainer.addChild(new Text(th.fg("muted", "  No matching entries"), 0, 0));
+		}
+	}
+
+	private confirmSelection(): void {
+		const selected = this.filtered[this.selectedIndex];
+		this.done(selected ? { confirmed: true, value: selected.value } : { confirmed: false });
+	}
+
+	handleInput(keyData: string): void {
+		const kb = this.keybindings;
+		if (kb.matches(keyData, "tui.select.up")) {
+			if (this.filtered.length === 0) return;
+			this.selectedIndex = this.selectedIndex === 0 ? this.filtered.length - 1 : this.selectedIndex - 1;
+			this.updateList();
+			this.tui.requestRender();
+		} else if (kb.matches(keyData, "tui.select.down")) {
+			if (this.filtered.length === 0) return;
+			this.selectedIndex = this.selectedIndex === this.filtered.length - 1 ? 0 : this.selectedIndex + 1;
+			this.updateList();
+			this.tui.requestRender();
+		} else if (kb.matches(keyData, "tui.select.confirm")) {
+			this.confirmSelection();
+		} else if (kb.matches(keyData, "tui.select.cancel")) {
+			this.done({ confirmed: false });
+		} else {
+			this.searchInput.handleInput(keyData);
+			this.applyFilter(this.searchInput.getValue());
+			this.tui.requestRender();
+		}
+	}
+}

--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -14,6 +14,8 @@ import {
 import { serializeAgent } from "../agents/agent-serializer.ts";
 import { editableAgentConfig, preservedAgentFrontmatterFields } from "../agents/agent-management.ts";
 import { findModelInfo, getSupportedThinkingLevels, toModelInfo } from "../shared/model-info.ts";
+import { editorLabel, resolveEditorCommand, runEditorAndWait } from "./subagents-editor.ts";
+import { SelectorComponent, type SelectorItem, type SelectorResult } from "./selector.ts";
 
 const ADMIN_MESSAGE_TYPE = "subagents-admin";
 const INHERIT_MODEL_CHOICE = "Default / inherit session model";
@@ -48,6 +50,10 @@ function agentChoices(agents: AgentConfig[]): Map<string, AgentConfig> {
 		const label = labels[index]!;
 		return [counts.get(label) === 1 ? label : `${label} · ${agent.filePath}`, agent] as const;
 	}));
+}
+
+function agentSelectItems(byLabel: Map<string, AgentConfig>): SelectorItem[] {
+	return [...byLabel.keys()].map((label) => ({ value: label, label }));
 }
 
 function agentMatches(agent: AgentConfig, rawName: string): boolean {
@@ -154,7 +160,7 @@ async function selectAgent(ctx: ExtensionContext, args: string): Promise<AgentSe
 		if (matches.length > 1 && !ctx.hasUI) return { kind: "ambiguous", requestedName, matches };
 		if (matches.length > 1) {
 			const byLabel = agentChoices(matches);
-			const choice = await ctx.ui.select(`Multiple subagents named '${requestedName}'`, [...byLabel.keys()]);
+			const choice = await selectFromList(ctx, `Multiple subagents named '${requestedName}'`, undefined, agentSelectItems(byLabel));
 			return choice ? { kind: "selected", agent: byLabel.get(choice)! } : { kind: "cancelled" };
 		}
 		return { kind: "not-found", agents, requestedName };
@@ -162,7 +168,7 @@ async function selectAgent(ctx: ExtensionContext, args: string): Promise<AgentSe
 
 	if (!ctx.hasUI) return { kind: "not-found", agents };
 	const byLabel = agentChoices(agents);
-	const choice = await ctx.ui.select("Select subagent", [...byLabel.keys()]);
+	const choice = await selectFromList(ctx, "Select subagent", undefined, agentSelectItems(byLabel));
 	return choice ? { kind: "selected", agent: byLabel.get(choice)! } : { kind: "cancelled" };
 }
 
@@ -196,13 +202,33 @@ function metadataFor(agent: AgentConfig): string {
 	return lines.join("\n");
 }
 
+async function selectFromList(ctx: ExtensionContext, title: string, subtitle: string | undefined, items: SelectorItem[]): Promise<string | undefined> {
+	if (typeof ctx.ui.custom === "function") {
+		const result = await ctx.ui.custom<SelectorResult>(
+			(tui, theme, kb, done) => new SelectorComponent(tui, theme, kb, { title, subtitle, items, done }),
+			{ overlay: false },
+		);
+		return result?.confirmed ? result.value : undefined;
+	}
+	const flatTitle = subtitle ? `${title}\nCurrent: ${subtitle}` : title;
+	const labelToValue = new Map(items.map((item) => [item.label, item.value] as const));
+	const choice = await ctx.ui.select(flatTitle, items.map((item) => item.label));
+	return choice ? labelToValue.get(choice) : undefined;
+}
+
 async function chooseModel(ctx: ExtensionContext, agent: AgentConfig): Promise<string | undefined | null> {
-	const models = liveAvailableModels(ctx).map((model) => modelFullId(model));
+	const models = liveAvailableModels(ctx);
 	const current = agent.model ?? INHERIT_MODEL_CHOICE;
-	const choices = [INHERIT_MODEL_CHOICE, ...models.filter((model) => model !== agent.model)];
-	if (agent.model && !choices.includes(agent.model)) choices.splice(1, 0, agent.model);
-	const choice = await ctx.ui.select(`Select model for ${agent.name}\nCurrent: ${current}`, choices);
-	if (!choice) return null;
+	const items: SelectorItem[] = [{ value: INHERIT_MODEL_CHOICE, label: INHERIT_MODEL_CHOICE, current: !agent.model }];
+	if (agent.model && !models.some((model) => modelFullId(model) === agent.model)) {
+		items.push({ value: agent.model, label: agent.model, current: true });
+	}
+	for (const model of models) {
+		const fullId = modelFullId(model);
+		items.push({ value: fullId, label: model.id, badge: model.provider, current: fullId === agent.model });
+	}
+	const choice = await selectFromList(ctx, `Select model for ${agent.name}`, current, items);
+	if (choice === undefined) return null;
 	return choice === INHERIT_MODEL_CHOICE ? undefined : choice;
 }
 
@@ -212,18 +238,16 @@ async function chooseThinking(ctx: ExtensionContext, agent: AgentConfig): Promis
 	const modelInfo = findModelInfo(effectiveModel, availableModels, ctx.model?.provider);
 	const levels = getSupportedThinkingLevels(modelInfo);
 	const current = agent.thinking === false ? "off" : agent.thinking ?? INHERIT_THINKING_CHOICE;
-	const choices: string[] = [INHERIT_THINKING_CHOICE, ...levels];
-	if (current !== INHERIT_THINKING_CHOICE && !choices.includes(current)) choices.splice(1, 0, current);
+	const values: string[] = [INHERIT_THINKING_CHOICE, ...levels];
+	if (current !== INHERIT_THINKING_CHOICE && !values.includes(current)) values.splice(1, 0, current);
 	const modelNote = agent.model
 		? `Model: ${agent.model}`
 		: effectiveModel
 			? `Session model: ${effectiveModel}`
 			: "Model: default / inherit";
-	const choice = await ctx.ui.select(
-		`Select thinking level for ${agent.name}\n${modelNote} · Current: ${current}`,
-		choices,
-	);
-	if (!choice) return null;
+	const items: SelectorItem[] = values.map((value) => ({ value, label: value, current: value === current }));
+	const choice = await selectFromList(ctx, `Select thinking level for ${agent.name}`, `${modelNote} · ${current}`, items);
+	if (choice === undefined) return null;
 	return choice === INHERIT_THINKING_CHOICE ? undefined : choice;
 }
 

--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -14,7 +14,6 @@ import {
 import { serializeAgent } from "../agents/agent-serializer.ts";
 import { editableAgentConfig, preservedAgentFrontmatterFields } from "../agents/agent-management.ts";
 import { findModelInfo, getSupportedThinkingLevels, toModelInfo } from "../shared/model-info.ts";
-import { editorLabel, resolveEditorCommand, runEditorAndWait } from "./subagents-editor.ts";
 import { SelectorComponent, type SelectorItem, type SelectorResult } from "./selector.ts";
 
 const ADMIN_MESSAGE_TYPE = "subagents-admin";
@@ -212,8 +211,8 @@ async function selectFromList(ctx: ExtensionContext, title: string, subtitle: st
 	}
 	const flatTitle = subtitle ? `${title}\nCurrent: ${subtitle}` : title;
 	const labelToValue = new Map(items.map((item) => [item.label, item.value] as const));
-	const choice = await ctx.ui.select(flatTitle, items.map((item) => item.label));
-	return choice ? labelToValue.get(choice) : undefined;
+	const choice = await ctx.ui.select(flatTitle, items.map((item) => item.value));
+	return choice ? (items.find((item) => item.value === choice)?.value ?? labelToValue.get(choice)) : undefined;
 }
 
 async function chooseModel(ctx: ExtensionContext, agent: AgentConfig): Promise<string | undefined | null> {

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -168,7 +168,7 @@ function createCommandContext(
 			setStatus: overrides.setStatus ?? ((_key: string, _text: string | undefined) => {}),
 			setToolsExpanded: overrides.setToolsExpanded ?? ((_expanded: boolean) => {}),
 			onTerminalInput: () => () => {},
-			custom: overrides.custom ?? (async () => undefined),
+			...(overrides.custom ? { custom: overrides.custom } : {}),
 		},
 		model: overrides.model,
 		thinkingLevel: overrides.thinkingLevel,

--- a/test/unit/selector.test.ts
+++ b/test/unit/selector.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { SelectorComponent } from "../../src/slash/selector.ts";
+
+initTheme("dark");
+
+function createHarness(items: Array<{ value: string; label: string; current?: boolean }>) {
+	const results: Array<{ confirmed: boolean; value?: string }> = [];
+	const component = new SelectorComponent(
+		{ requestRender() {} } as never,
+		{
+			fg(_color: string, text: string) { return text; },
+			bold(text: string) { return text; },
+		} as never,
+		{
+			matches(key: string, binding: string) { return key === binding; },
+		} as never,
+		{ title: "Select item", items, done: (result) => results.push(result) },
+	);
+	return { component, results };
+}
+
+describe("SelectorComponent", () => {
+	it("keeps the current selection visible in a bounded list and confirms it", () => {
+		const items = Array.from({ length: 12 }, (_, index) => ({
+			value: `value-${index}`,
+			label: `Item ${index}`,
+			current: index === 10,
+		}));
+		const { component, results } = createHarness(items);
+
+		const rendered = component.render(80).join("\n");
+		assert.match(rendered, /Item 10/);
+		assert.match(rendered, /\(11\/12\)/);
+
+		component.handleInput("tui.select.confirm");
+		assert.deepEqual(results, [{ confirmed: true, value: "value-10" }]);
+	});
+
+	it("filters searchable values and reports cancellation", () => {
+		const { component, results } = createHarness([
+			{ value: "anthropic/opus", label: "opus" },
+			{ value: "openai/gpt", label: "gpt" },
+		]);
+
+		component.handleInput("gpt");
+		component.handleInput("tui.select.confirm");
+		component.handleInput("tui.select.cancel");
+
+		assert.deepEqual(results, [
+			{ confirmed: true, value: "openai/gpt" },
+			{ confirmed: false },
+		]);
+	});
+});


### PR DESCRIPTION
Clean maintainer-owned replacement for #568, rebased onto current `main` and limited to the searchable /subagents admin selector work.\n\nThis preserves Chanyeong Lim's picker improvement, fixes the current-main conflicts and fallback value handling, and adds the required changelog credit.\n\nLocal validation passed:\n- `node --experimental-strip-types --test test/unit/selector.test.ts`\n- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/slash-commands.test.ts`\n- `git diff --check origin/main...HEAD`\n\nThanks to Chanyeong Lim (@asp345) for #568.