### PR TITLE
fix: avoid broad scans in targeted async waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - Suspended the persistent FleetView while its inspector overlay is open, preventing live status redraws from leaving repeated inspector frames in terminal scrollback.
 - Kept simultaneous foreground parallel children independently visible with stable descriptions, metrics, lifecycle state, and transcripts.
+- Avoided scanning and reconciling every historical async run when `subagent_wait({ id })` targets an exact run, preventing supervisor-attention waits from being delayed until the child completes.
 - Mapped sparse parallel slash progress updates by child index so one child’s live tool/output state no longer appears on another chain placeholder. Thanks to Eli Stark (@white-hat) for #595.
 - Retried transient Windows filesystem locks while creating async result directories and stopped destructively recreating shared async directories during startup access checks, so concurrent Pi instances are less likely to lose completed async results to `EPERM` directory handles. Thanks to AiraNadih (@AiraNadih) for #566.
 - Pruned broad agent and chain discovery roots so package-declared `.` scans no longer descend into `node_modules`, `.git`, Git submodules, or nested project roots during startup. Thanks to tupe12334 (@tupe12334) for #570 and shoehn (@shoehn) for narrowing the startup trace.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -102,6 +102,7 @@ interface AsyncRunListOptions {
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 	now?: () => number;
 	reconcile?: boolean;
+	runId?: string;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -283,7 +284,15 @@ function sortRuns(runs: AsyncRunSummary[]): AsyncRunSummary[] {
 export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions = {}): AsyncRunSummary[] {
 	let entries: string[];
 	try {
-		entries = fs.readdirSync(asyncDirRoot).filter((entry) => isAsyncRunDir(asyncDirRoot, entry));
+		if (options.runId !== undefined) {
+			entries = options.runId !== "." && options.runId !== ".."
+				&& path.basename(options.runId) === options.runId
+				&& isAsyncRunDir(asyncDirRoot, options.runId)
+				? [options.runId]
+				: [];
+		} else {
+			entries = fs.readdirSync(asyncDirRoot).filter((entry) => isAsyncRunDir(asyncDirRoot, entry));
+		}
 	} catch (error) {
 		if (isNotFoundError(error)) return [];
 		throw new Error(`Failed to list async runs in '${asyncDirRoot}': ${getErrorMessage(error)}`, {

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -328,7 +328,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 			entries = resolution.kind === "exact"
 				? [resolution.id]
 				: resolution.kind === "scan"
-					? fs.readdirSync(asyncDirRoot).filter((entry) => isAsyncRunDir(asyncDirRoot, entry))
+					? fs.readdirSync(asyncDirRoot).filter((entry) => resolveTargetedAsyncRun(asyncDirRoot, entry).kind === "exact")
 					: [];
 		} else {
 			entries = fs.readdirSync(asyncDirRoot).filter((entry) => isAsyncRunDir(asyncDirRoot, entry));

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -328,7 +328,10 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 			entries = resolution.kind === "exact"
 				? [resolution.id]
 				: resolution.kind === "scan"
-					? fs.readdirSync(asyncDirRoot).filter((entry) => resolveTargetedAsyncRun(asyncDirRoot, entry).kind === "exact")
+					? fs.readdirSync(asyncDirRoot).filter((entry) =>
+						(entry === options.runId || entry.startsWith(options.runId!))
+						&& resolveTargetedAsyncRun(asyncDirRoot, entry, options.sessionId).kind === "exact"
+					)
 					: [];
 		} else {
 			entries = fs.readdirSync(asyncDirRoot).filter((entry) => isAsyncRunDir(asyncDirRoot, entry));

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -128,6 +128,45 @@ function isAsyncRunDir(root: string, entry: string): boolean {
 	}
 }
 
+type TargetedAsyncRunResolution =
+	| { kind: "exact"; id: string }
+	| { kind: "scan" }
+	| { kind: "reject" };
+
+/**
+ * Resolve an exact targeted run without following a run-directory symlink or
+ * accepting a path whose canonical location escaped the async root.
+ */
+export function resolveTargetedAsyncRun(asyncDirRoot: string, id: string, sessionId?: string): TargetedAsyncRunResolution {
+	if (!id || id === "." || id === ".." || path.basename(id) !== id) return { kind: "reject" };
+	const asyncDir = path.join(asyncDirRoot, id);
+	let entryStat: fs.Stats;
+	try {
+		entryStat = fs.lstatSync(asyncDir);
+	} catch (error) {
+		if (isNotFoundError(error)) return { kind: "scan" };
+		throw new Error(`Failed to inspect async run path '${asyncDir}': ${getErrorMessage(error)}`, {
+			cause: error instanceof Error ? error : undefined,
+		});
+	}
+	if (!entryStat.isDirectory() || entryStat.isSymbolicLink()) return { kind: "reject" };
+	try {
+		const canonicalRoot = fs.realpathSync(asyncDirRoot);
+		const canonicalDir = fs.realpathSync(asyncDir);
+		if (canonicalDir !== canonicalRoot && !canonicalDir.startsWith(`${canonicalRoot}${path.sep}`)) return { kind: "reject" };
+	} catch (error) {
+		if (isNotFoundError(error)) return { kind: "reject" };
+		throw new Error(`Failed to resolve async run path '${asyncDir}': ${getErrorMessage(error)}`, {
+			cause: error instanceof Error ? error : undefined,
+		});
+	}
+	if (sessionId !== undefined) {
+		const status = readStatus(asyncDir);
+		if (status?.sessionId !== sessionId) return { kind: "scan" };
+	}
+	return { kind: "exact", id };
+}
+
 function outputFileMtime(outputFile: string | undefined): number | undefined {
 	if (!outputFile) return undefined;
 	try {
@@ -285,11 +324,12 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 	let entries: string[];
 	try {
 		if (options.runId !== undefined) {
-			entries = options.runId !== "." && options.runId !== ".."
-				&& path.basename(options.runId) === options.runId
-				&& isAsyncRunDir(asyncDirRoot, options.runId)
-				? [options.runId]
-				: [];
+			const resolution = resolveTargetedAsyncRun(asyncDirRoot, options.runId, options.sessionId);
+			entries = resolution.kind === "exact"
+				? [resolution.id]
+				: resolution.kind === "scan"
+					? fs.readdirSync(asyncDirRoot).filter((entry) => isAsyncRunDir(asyncDirRoot, entry))
+					: [];
 		} else {
 			entries = fs.readdirSync(asyncDirRoot).filter((entry) => isAsyncRunDir(asyncDirRoot, entry));
 		}

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -39,7 +39,6 @@
  */
 
 import * as fs from "node:fs";
-import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import {
 	listBackgroundWorkWakeChannels,
@@ -198,20 +197,6 @@ function matchesId(run: AsyncRunSummary, id: string): boolean {
 	return run.id === id || run.id.startsWith(id);
 }
 
-function exactAsyncRunId(params: SubagentWaitParams, deps: SubagentWaitDeps): string | undefined {
-	const id = params.id;
-	if (!id || path.basename(id) !== id) return undefined;
-	const asyncDir = path.join(deps.asyncDirRoot ?? ASYNC_DIR, id);
-	try {
-		return fs.statSync(asyncDir).isDirectory() ? id : undefined;
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-		throw new Error(`Failed to inspect async run path '${asyncDir}': ${error instanceof Error ? error.message : String(error)}`, {
-			cause: error instanceof Error ? error : undefined,
-		});
-	}
-}
-
 function activeDetachedForegroundRuns(params: SubagentWaitParams, deps: SubagentWaitDeps): ForegroundResumeRun[] {
 	if (!params.id || !deps.state.foregroundRuns) return [];
 	const sessionId = deps.state.currentSessionId;
@@ -274,7 +259,7 @@ function activeRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps
 		resultsDir,
 		kill: deps.kill,
 		now: deps.now,
-		runId: exactAsyncRunId(params, deps),
+		...(params.id ? { runId: params.id } : {}),
 	});
 	return params.id ? runs.filter((run) => matchesId(run, params.id!)) : runs;
 }
@@ -293,7 +278,7 @@ function allRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps): 
 		resultsDir,
 		kill: deps.kill,
 		now: deps.now,
-		runId: exactAsyncRunId(params, deps),
+		...(params.id ? { runId: params.id } : {}),
 	});
 	return params.id ? runs.filter((run) => matchesId(run, params.id!)) : runs;
 }

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -39,6 +39,7 @@
  */
 
 import * as fs from "node:fs";
+import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import {
 	listBackgroundWorkWakeChannels,
@@ -197,6 +198,20 @@ function matchesId(run: AsyncRunSummary, id: string): boolean {
 	return run.id === id || run.id.startsWith(id);
 }
 
+function exactAsyncRunId(params: SubagentWaitParams, deps: SubagentWaitDeps): string | undefined {
+	const id = params.id;
+	if (!id || path.basename(id) !== id) return undefined;
+	const asyncDir = path.join(deps.asyncDirRoot ?? ASYNC_DIR, id);
+	try {
+		return fs.statSync(asyncDir).isDirectory() ? id : undefined;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw new Error(`Failed to inspect async run path '${asyncDir}': ${error instanceof Error ? error.message : String(error)}`, {
+			cause: error instanceof Error ? error : undefined,
+		});
+	}
+}
+
 function activeDetachedForegroundRuns(params: SubagentWaitParams, deps: SubagentWaitDeps): ForegroundResumeRun[] {
 	if (!params.id || !deps.state.foregroundRuns) return [];
 	const sessionId = deps.state.currentSessionId;
@@ -259,6 +274,7 @@ function activeRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps
 		resultsDir,
 		kill: deps.kill,
 		now: deps.now,
+		runId: exactAsyncRunId(params, deps),
 	});
 	return params.id ? runs.filter((run) => matchesId(run, params.id!)) : runs;
 }
@@ -277,6 +293,7 @@ function allRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps): 
 		resultsDir,
 		kill: deps.kill,
 		now: deps.now,
+		runId: exactAsyncRunId(params, deps),
 	});
 	return params.id ? runs.filter((run) => matchesId(run, params.id!)) : runs;
 }

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -504,6 +504,39 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("rejects symlinked prefix entries during foreign exact-id fallback", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-session-prefix-symlink-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const outsideRoot = path.join(root, "outside");
+			const outsideRun = path.join(outsideRoot, "run-alpha");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run", "running", { sessionId: "sess-2", pid: 999998 });
+			writeStatus(outsideRoot, "run-alpha", "running", { sessionId: "sess-1", pid: 999999 });
+			fs.symlinkSync(outsideRun, path.join(asyncRoot, "run-alpha"), "dir");
+			const reconciledPids: number[] = [];
+			let sleeps = 0;
+
+			const result = await waitForSubagents({ id: "run" }, undefined, baseDeps(root, state, {
+				kill: (pid) => {
+					reconciledPids.push(pid);
+					return true;
+				},
+				sleep: async () => {
+					sleeps += 1;
+					writeStatus(outsideRoot, "run-alpha", "complete", { sessionId: "sess-1" });
+				},
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /No active run matched "run"/);
+			assert.equal(reconciledPids.includes(999999), false, "outside symlink target must not be reconciled");
+			assert.equal(sleeps, 0, "outside symlink target must not be returned as active");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects symlinked targeted run directories before reconciliation", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-symlink-id-"));
 		try {

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -537,6 +537,57 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("does not reconcile unrelated runs when waiting for an exact id", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-exact-id-scan-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "target-run", "running", { sessionId: "sess-1", pid: 999999 });
+			writeStatus(asyncRoot, "other-run-a", "running", { sessionId: "sess-1", pid: 999998 });
+			writeStatus(asyncRoot, "other-run-b", "running", { sessionId: "sess-1", pid: 999997 });
+
+			let probes = 0;
+			const result = await waitForSubagents({ id: "target-run" }, undefined, baseDeps(root, state, {
+				kill: () => {
+					probes++;
+					return true;
+				},
+				sleep: async () => writeStatus(asyncRoot, "target-run", "complete", { sessionId: "sess-1" }),
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /run "target-run".*done/is);
+			assert.equal(probes, 1, "exact-id waits should reconcile only the selected run");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not resolve dot-segment ids outside the async root", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-dot-id-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			fs.writeFileSync(path.join(root, "status.json"), JSON.stringify({
+				runId: "..",
+				mode: "single",
+				state: "running",
+				startedAt: Date.now(),
+				lastUpdate: Date.now(),
+				sessionId: "sess-1",
+				steps: [{ agent: "outside", status: "running" }],
+			}), "utf-8");
+
+			const result = await waitForSubagents({ id: ".." }, undefined, baseDeps(root, state));
+
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /No active run matched "\.\."/);
+			assert.equal(fs.existsSync(path.join(asyncRoot, "status.json")), false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("times out while runs are still active and reports them", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-timeout-"));
 		try {

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -530,7 +530,7 @@ describe("subagent_wait tool", () => {
 
 			assert.equal(result.isError, undefined);
 			assert.match(textOf(result), /No active run matched "run"/);
-			assert.equal(reconciledPids.includes(999999), false, "outside symlink target must not be reconciled");
+			assert.deepEqual(reconciledPids, [], "foreign and outside runs must not be reconciled");
 			assert.equal(sleeps, 0, "outside symlink target must not be returned as active");
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -485,6 +485,51 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("preserves current-session prefix matches when a foreign exact id collides", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-session-prefix-collision-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-al", "running", { sessionId: "sess-2", pid: 999999 });
+			writeStatus(asyncRoot, "run-alpha", "running", { sessionId: "sess-1", pid: 999998 });
+
+			const result = await waitForSubagents({ id: "run-al" }, undefined, baseDeps(root, state, {
+				sleep: async () => writeStatus(asyncRoot, "run-alpha", "complete", { sessionId: "sess-1" }),
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /run "run-al".*done/is);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects symlinked targeted run directories before reconciliation", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-symlink-id-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const outsideRun = path.join(root, "outside-run");
+			const state = makeState("sess-1");
+			writeStatus(path.dirname(outsideRun), path.basename(outsideRun), "running", { sessionId: "sess-1", pid: 999999 });
+			fs.mkdirSync(asyncRoot, { recursive: true });
+			fs.symlinkSync(outsideRun, path.join(asyncRoot, "link"), "dir");
+			let reconciled = false;
+
+			const result = await waitForSubagents({ id: "link" }, undefined, baseDeps(root, state, {
+				kill: () => {
+					reconciled = true;
+					throw new Error("symlink target should not be reconciled");
+				},
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /No active run matched "link"/);
+			assert.equal(reconciled, false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("can target a single run by id prefix", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-id-"));
 		try {
@@ -563,28 +608,30 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
-	it("does not resolve dot-segment ids outside the async root", async () => {
-		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-dot-id-"));
-		try {
-			const asyncRoot = path.join(root, "runs");
-			const state = makeState("sess-1");
-			fs.writeFileSync(path.join(root, "status.json"), JSON.stringify({
-				runId: "..",
-				mode: "single",
-				state: "running",
-				startedAt: Date.now(),
-				lastUpdate: Date.now(),
-				sessionId: "sess-1",
-				steps: [{ agent: "outside", status: "running" }],
-			}), "utf-8");
+	it("rejects dot-segment ids before probing outside the async root", async () => {
+		for (const id of [".", ".."]) {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-dot-id-"));
+			try {
+				const asyncRoot = path.join(root, "runs");
+				const state = makeState("sess-1");
+				fs.writeFileSync(path.join(root, "status.json"), JSON.stringify({
+					runId: id,
+					mode: "single",
+					state: "running",
+					startedAt: Date.now(),
+					lastUpdate: Date.now(),
+					sessionId: "sess-1",
+					steps: [{ agent: "outside", status: "running" }],
+				}), "utf-8");
 
-			const result = await waitForSubagents({ id: ".." }, undefined, baseDeps(root, state));
+				const result = await waitForSubagents({ id }, undefined, baseDeps(root, state));
 
-			assert.equal(result.isError, undefined);
-			assert.match(textOf(result), /No active run matched "\.\."/);
-			assert.equal(fs.existsSync(path.join(asyncRoot, "status.json")), false);
-		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+				assert.equal(result.isError, undefined);
+				assert.ok(textOf(result).includes(`No active run matched "${id}"`));
+				assert.equal(fs.existsSync(path.join(asyncRoot, "status.json")), false);
+			} finally {
+				fs.rmSync(root, { recursive: true, force: true });
+			}
 		}
 	});
 


### PR DESCRIPTION
`subagent_wait({ id })` was reconciling every historical async run before filtering to the requested run. With a large async-run directory, that scan could outlast the child's attention window and let the child finish before the wait returned, making the supervisor-attention regression flaky.

This adds an exact-ID fast path while retaining full scans for prefixes so ambiguity behavior is unchanged. A focused regression verifies unrelated runs are not reconciled.

Validation: focused wait/integration tests, full integration suite (633 passed), and `git diff --check` passed. The full unit command timed out at 180s and independently reproduced two unrelated existing prompt-runtime failures.