### PR TITLE
fix: re-arm repeated foreground supervisor attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Re-armed remembered detached foreground children on every blocking `contact_supervisor` request so targeted `subagent_wait` calls wake for repeated supervisor decisions.
 - Suspended the persistent FleetView while its inspector overlay is open, preventing live status redraws from leaving repeated inspector frames in terminal scrollback.
 - Kept simultaneous foreground parallel children independently visible with stable descriptions, metrics, lifecycle state, and transcripts.
 - Avoided scanning and reconciling every historical async run when `subagent_wait({ id })` targets an exact run, preventing supervisor-attention waits from being delayed until the child completes.

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -447,6 +447,43 @@ function requestMatchesContext(request: SupervisorRequest, state: Pick<SubagentS
 	return Boolean(currentSessionId && request.orchestratorSessionId === currentSessionId);
 }
 
+function rememberedForegroundChild(request: SupervisorRequest, state: SubagentState) {
+	const run = state.foregroundRuns?.get(request.runId);
+	const child = run?.children.find((candidate) => candidate.index === request.childIndex && candidate.agent === request.agent)
+		?? run?.children[request.childIndex];
+	return run && child ? { run, child } : undefined;
+}
+
+function markForegroundSupervisorAttention(request: SupervisorRequest, state: SubagentState): void {
+	const remembered = rememberedForegroundChild(request, state);
+	if (!remembered || remembered.child.status !== "detached") return;
+	const updatedAt = Date.now();
+	remembered.run.updatedAt = updatedAt;
+	remembered.child.activityState = "needs_attention";
+	remembered.child.lastActivityAt = request.createdAt;
+	remembered.child.currentTool = "contact_supervisor";
+	remembered.child.currentToolStartedAt = request.createdAt;
+	remembered.child.updatedAt = updatedAt;
+}
+
+function clearForegroundSupervisorAttention(request: SupervisorRequest, pending: Map<string, PendingSupervisorRequest>, state: SubagentState): void {
+	if ([...pending.values()].some((candidate) =>
+		candidate.expectsReply
+		&& candidate.runId === request.runId
+		&& candidate.agent === request.agent
+		&& candidate.childIndex === request.childIndex
+	)) return;
+	const remembered = rememberedForegroundChild(request, state);
+	if (!remembered || remembered.child.status !== "detached" || remembered.child.currentTool !== "contact_supervisor") return;
+	const updatedAt = Date.now();
+	remembered.run.updatedAt = updatedAt;
+	remembered.child.activityState = undefined;
+	remembered.child.lastActivityAt = updatedAt;
+	remembered.child.currentTool = undefined;
+	remembered.child.currentToolStartedAt = undefined;
+	remembered.child.updatedAt = updatedAt;
+}
+
 function removeRequestFile(file: string): void {
 	try {
 		fs.rmSync(file, { force: true });
@@ -465,10 +502,8 @@ function requestExpiresAt(request: SupervisorRequest, now: number): number {
 
 function requestRunInactive(request: SupervisorRequest, state: SubagentState): boolean {
 	if (state.foregroundControls.has(request.runId)) return false;
-	const foregroundRun = state.foregroundRuns?.get(request.runId);
-	const foregroundChild = foregroundRun?.children.find((child) => child.index === request.childIndex && child.agent === request.agent)
-		?? foregroundRun?.children[request.childIndex];
-	if (foregroundChild) return foregroundChild.status !== "detached";
+	const foreground = rememberedForegroundChild(request, state);
+	if (foreground) return foreground.child.status !== "detached";
 
 	const asyncJob = state.asyncJobs.get(request.runId);
 	if (!asyncJob) return false;
@@ -580,6 +615,7 @@ function buildParentIntercomTool(pending: Map<string, PendingSupervisorRequest>,
 				const request = resolvePendingRequest(pending, input);
 				writeReply(request, input.message ?? "");
 				pending.delete(request.id);
+				clearForegroundSupervisorAttention(request, pending, state);
 				return { content: [{ type: "text", text: `Replied to supervisor request ${request.id}.` }], details: { replyTo: request.id, runId: request.runId, agent: request.agent } };
 			}
 			if (input.action === "send" || input.action === "ask") {
@@ -629,7 +665,10 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 				continue;
 			}
 			seenFiles.add(file);
-			if (request.expectsReply) pending.set(request.id, request);
+			if (request.expectsReply) {
+				pending.set(request.id, request);
+				markForegroundSupervisorAttention(request, state);
+			}
 			else {
 				removeRequestFile(request.requestFile);
 			}

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -49,6 +49,7 @@ import {
 import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 import {
 	ASYNC_DIR,
+	INTERCOM_DETACH_REQUEST_EVENT,
 	RESULTS_DIR,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_FOREGROUND_COMPLETE_EVENT,
@@ -121,6 +122,7 @@ export interface SubagentWaitDeps {
 
 /** Bus channels that indicate a run changed state or needs attention. */
 const WAKE_CHANNELS = [
+	INTERCOM_DETACH_REQUEST_EVENT,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_FOREGROUND_COMPLETE_EVENT,
 	SUBAGENT_CONTROL_EVENT,

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -250,6 +250,57 @@ describe("native supervisor channel", () => {
 		}
 	});
 
+	it("re-arms remembered foreground attention for each blocking supervisor request", async () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const requestId = writeRequest({ sessionId: currentSessionId, runId });
+		const registeredTools = new Map<string, { execute: (_id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<unknown> }>();
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const state = makeState(currentSessionId, ctx);
+		state.foregroundRuns = new Map([[runId, {
+			runId,
+			mode: "single",
+			cwd: process.cwd(),
+			sessionId: currentSessionId,
+			updatedAt: 1,
+			children: [{ agent: "worker", index: 0, status: "detached", updatedAt: 1 }],
+		}]]);
+		const pi = {
+			getAllTools: () => [...registeredTools.keys()].map((name) => ({ name })),
+			registerTool: (tool: { name: string; execute: (_id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<unknown> }) => {
+				registeredTools.set(tool.name, tool);
+			},
+			sendMessage: () => {},
+			getSessionName: () => "shared-name",
+		};
+		const channel = createNativeSupervisorChannel(pi as never, state);
+
+		try {
+			channel.start();
+			const child = state.foregroundRuns.get(runId)!.children[0]!;
+			assert.equal(child.activityState, "needs_attention");
+			assert.equal(child.currentTool, "contact_supervisor");
+
+			await registeredTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("reply", {
+				action: "reply",
+				replyTo: requestId,
+				message: "Approved",
+			});
+			assert.equal(child.activityState, undefined);
+			assert.equal(child.currentTool, undefined);
+		} finally {
+			channel.dispose();
+		}
+	});
+
 	it("matches supervisor requests against the runtime session id instead of persisted session file path", () => {
 		const currentSessionId = `session-${randomUUID()}`;
 		const persistedSessionFile = path.join(os.tmpdir(), `${currentSessionId}.jsonl`);

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -384,6 +384,50 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("wakes a remembered foreground wait on a repeated supervisor request event", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-foreground-supervisor-"));
+		try {
+			const state = makeState("sess-1");
+			state.foregroundRuns = new Map([["foreground-repeated", {
+				runId: "foreground-repeated",
+				mode: "single",
+				cwd: root,
+				sessionId: "sess-1",
+				updatedAt: 1,
+				children: [{ agent: "worker", index: 0, status: "detached", updatedAt: 1 }],
+			}]]);
+			const handlers = new Map<string, Array<(data: unknown) => void>>();
+			const events = {
+				on(channel: string, handler: (data: unknown) => void) {
+					const list = handlers.get(channel) ?? [];
+					list.push(handler);
+					handlers.set(channel, list);
+					return () => handlers.set(channel, (handlers.get(channel) ?? []).filter((candidate) => candidate !== handler));
+				},
+				emit(channel: string, data: unknown) {
+					for (const handler of handlers.get(channel) ?? []) handler(data);
+				},
+			};
+			const startedAt = Date.now();
+			const waiting = waitForSubagents({ id: "foreground-repeated", timeoutMs: 30_000 }, undefined, baseDeps(root, state, {
+				events,
+				pollIntervalMs: 10_000,
+			}));
+
+			setTimeout(() => {
+				const child = state.foregroundRuns!.get("foreground-repeated")!.children[0]!;
+				child.activityState = "needs_attention";
+				events.emit("pi-intercom:detach-request", { runId: "foreground-repeated", childIndex: 0 });
+			}, 15);
+
+			const result = await waiting;
+			assert.match(textOf(result), /attention required/i);
+			assert.ok(Date.now() - startedAt < 5_000, "supervisor request should wake wait before the poll interval");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("streams detached foreground transcript activity while waiting", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-foreground-progress-"));
 		try {


### PR DESCRIPTION
## Summary

- Mark a remembered detached foreground child as `needs_attention` for every blocking `contact_supervisor` request.
- Clear that attention after the reply when no other blocking request is pending.
- Wake targeted `subagent_wait({ id })` calls on foreground detach-request events.
- Add regression coverage and an `Unreleased` changelog entry.

## Root cause

After the first foreground detach, the original execution listener ignores later detach requests. The native supervisor channel still delivers those requests, but it did not update the remembered child's attention state, and `subagent_wait` did not subscribe to the detach-request event. A later wait could therefore block until timeout or child completion.

## Validation

- `npm run test:all`
  - unit: 1373 passed, 0 failed, 1 skipped
  - integration: 636 passed, 0 failed
  - e2e: 2 passed, 0 failed
- `npm pack` produced `pi-subagents-0.35.1.tgz`.
- Installed that tarball in an isolated directory and ran a real Pi ten-round foreground supervisor probe:
  - 10 unique blocking requests
  - all 9 intermediate waits returned `attention-required`
  - final wait completed
  - 1 fresh launch
  - 0 resume calls
  - 0 replacement children

Fixes #608
