### PR TITLE
feat: add owned delegation protocol v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added delegation v2 for extension-owned concurrent foreground leaves, with logical run/node ownership, exact per-attempt cancellation, explicit duplicate-node outcomes, literal or structured values, effective model/thinking metadata, and detailed usage while preserving delegation v1 and the model-facing single-dispatch guard.
 - Added a persistent below-editor FleetView with safe empty-editor navigation and a structured inspector for Markdown, code, tool calls, and compact or expanded tool results. Thanks to Rui Pu (@Zeppelinpp) for #587.
 - Added `artifactDir` config to store subagent artifacts in the project, Pi session, or temp artifact directory while keeping project-local artifacts as the default. Thanks to WeZZard (@WeZZard) for #582.
 - Added opt-in `agentContract: { version: 1 }` runs with explicit execution, acceptance, review, and effects projections, report-optional acceptance, observational file-mutation effects, generic `outputSchema` plumbing, and `gateOn` chain controls while keeping the current/default contract unchanged. Thanks to mapleluv (@mapleluvr) for #499.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Added delegation v2 for extension-owned concurrent foreground leaves, with logical run/node ownership, exact per-attempt cancellation, explicit duplicate-node outcomes, literal or structured values, effective model/thinking metadata, and detailed usage while preserving delegation v1 and the model-facing single-dispatch guard.
+- Added delegation v2 for extension-owned concurrent foreground leaves, with logical run/node ownership, exact per-attempt cancellation, explicit duplicate-node outcomes, literal or structured values, effective model/thinking metadata, detailed usage, and an exact zero-tool budget while preserving delegation v1 and the model-facing single-dispatch guard.
 - Added a persistent below-editor FleetView with safe empty-editor navigation and a structured inspector for Markdown, code, tool calls, and compact or expanded tool results. Thanks to Rui Pu (@Zeppelinpp) for #587.
 - Added `artifactDir` config to store subagent artifacts in the project, Pi session, or temp artifact directory while keeping project-local artifacts as the default. Thanks to WeZZard (@WeZZard) for #582.
 - Added opt-in `agentContract: { version: 1 }` runs with explicit execution, acceptance, review, and effects projections, report-optional acceptance, observational file-mutation effects, generic `outputSchema` plumbing, and `gateOn` chain controls while keeping the current/default contract unchanged. Thanks to mapleluv (@mapleluvr) for #499.

--- a/README.md
+++ b/README.md
@@ -1087,8 +1087,11 @@ Terminal usage reports input, output, cache-read, cache-write, cost, turns, tool
 calls, and duration alongside the effective model and thinking level when
 known. Schemas are capped at 64 KiB; tasks and returned text/structured values
 are capped at 1 MiB, with smaller bounds on identity/configuration strings and
-a maximum v2 `timeoutMs` of 2,147,483,647. The foreground bridge retains up to
-8,192 exact pending-cancellation and settled-attempt identities per extension
+a maximum v2 `timeoutMs` of 2,147,483,647. V2 alone accepts
+`toolBudget: { hard: 0, block: "*" }` to block the first tool call and run a
+zero-tool leaf; delegation v1 and ordinary model-facing/configured budgets keep
+their existing minimum of one. The foreground bridge retains up to 8,192 exact
+pending-cancellation and settled-attempt identities per extension
 context. If either history fills, it fails closed with `unavailable_context`
 for later v2 starts rather than evicting identity facts; lifecycle reset clears
 the bounded history.

--- a/README.md
+++ b/README.md
@@ -984,7 +984,12 @@ If you are writing an agent that orchestrates subagents, the bundled skill helps
 
 ## Extension delegation API
 
-Pi extensions can request one configured foreground agent through the typed v1 event contract:
+Pi extensions can request configured foreground agents through the public event
+contract exported by `pi-subagents/delegation`.
+
+### Delegation v1
+
+The compatibility v1 contract runs one configured foreground agent per request:
 
 ```ts
 import {
@@ -1016,11 +1021,85 @@ pi.events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, request);
 
 The contract uses the established `prompt-template:subagent:*` event transport and the same executor as the `subagent` tool; it does not add another launcher. New integrations must send `version: 1`. Requests are strict and single-agent only. They can set fresh or fork context, model, cwd, timeout, turn and tool-call budgets, skills, output behavior, acceptance, and artifact capture. Unknown or malformed fields return `invalid_request` before execution.
 
-Responses distinguish completion, failure, timeout, cancellation, interruption, turn or tool-budget exhaustion, explicit acceptance failure, invalid requests, and unavailable active context. Optional run, model, output, session, acceptance, usage, progress, and warning fields are omitted when unavailable. Request IDs must be unique while active; duplicate active IDs are ignored so the original request keeps ownership of its terminal response. Emit `SUBAGENT_DELEGATION_CANCEL_EVENT` with the same version and request ID to cancel queued or active work.
+Responses distinguish completion, failure, timeout, cancellation, interruption,
+turn or tool-budget exhaustion, explicit acceptance failure, invalid requests,
+and unavailable active context. Optional metadata is omitted when unavailable.
+Request IDs must be unique while active; duplicate active IDs are ignored so the
+original request keeps ownership of its terminal response. Emit
+`SUBAGENT_DELEGATION_CANCEL_EVENT` with the same version and request ID to cancel
+queued or active work.
+
+### Delegation v2
+
+V2 is the owned-leaf contract for workflow supervisors. Independent requests
+can overlap through the delegated executor without weakening the ordinary
+model-facing tool's one-foreground-call-per-turn guard.
+
+```ts
+import {
+  SUBAGENT_DELEGATION_REQUEST_EVENT,
+  SUBAGENT_DELEGATION_RESPONSE_EVENT,
+  type SubagentDelegationV2Request,
+  type SubagentDelegationV2Response,
+} from "pi-subagents/delegation";
+
+const request: SubagentDelegationV2Request = {
+  version: 2,
+  requestId: crypto.randomUUID(),
+  ownerRunId: workflowRunId,
+  nodeId: "review-accuracy",
+  agent: "reviewer",
+  task: "Review the supplied evidence.",
+  context: "fresh",
+  cwd: ctx.cwd,
+  thinking: "high",
+  result: {
+    kind: "structured",
+    schema: {
+      type: "object",
+      properties: { verdict: { type: "string" } },
+      required: ["verdict"],
+      additionalProperties: false,
+    },
+  },
+};
+
+const unsubscribe = pi.events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => {
+  const response = payload as SubagentDelegationV2Response;
+  if (response.version !== 2 || response.requestId !== request.requestId) return;
+  if (response.ownerRunId !== request.ownerRunId || response.nodeId !== request.nodeId) return;
+  unsubscribe();
+  // Inspect response.status, response.result, response.usage, model, and thinking.
+});
+pi.events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, request);
+```
+
+`ownerRunId` plus `nodeId` is the active logical identity; `requestId` identifies
+one attempt. A second active attempt for the same logical node receives
+`duplicate_node` without disturbing the original. Started, update, response,
+and cancellation payloads carry the full tuple. Cancellation affects only an
+exact tuple, including cancel-before-start races. Each attempt emits at most one
+terminal response.
+
+Result mode is explicit. Text remains literal even when it looks like JSON.
+Structured mode returns the separately captured, schema-validated JSON value.
+Terminal usage reports input, output, cache-read, cache-write, cost, turns, tool
+calls, and duration alongside the effective model and thinking level when
+known. Schemas are capped at 64 KiB; tasks and returned text/structured values
+are capped at 1 MiB, with smaller bounds on identity/configuration strings and
+a maximum v2 `timeoutMs` of 2,147,483,647. The foreground bridge retains up to
+8,192 exact pending-cancellation and settled-attempt identities per extension
+context. If either history fills, it fails closed with `unavailable_context`
+for later v2 starts rather than evicting identity facts; lifecycle reset clears
+the bounded history.
 
 Delegation requires an active extension context. Emit requests from a supported event callback or queued application step, not by recursively invoking the `subagent` tool inside another tool's `tool_call` hook. The caller selects a configured agent, but agent discovery and effective tools remain package-owned. A request cannot grant arbitrary tools, and tool restrictions are not an operating-system sandbox. The detached RPC remains async-only; this API is foreground-only.
 
-Existing prompt-template payloads continue over the same event family, including their parallel-only adapter. `pi-subagents/delegation` is the canonical contract for new extension integrations.
+Existing prompt-template payloads and delegation v1 continue over the same event
+family. V2 remains foreground-only and inherits the configured agent's current
+tools, skills, context, model policy, and workspace authority; it is not a
+sandbox or a durable task broker. `pi-subagents/delegation` is the canonical
+contract for extension integrations.
 
 ## Background-work provider API
 

--- a/src/api/delegation.ts
+++ b/src/api/delegation.ts
@@ -1,4 +1,5 @@
 export const SUBAGENT_DELEGATION_PROTOCOL_VERSION = 1 as const;
+export const SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION = 2 as const;
 
 // This is the established extension-to-extension transport. The public API
 // intentionally reuses it instead of adding a second event protocol.
@@ -192,3 +193,90 @@ export interface SubagentDelegationResponse extends SubagentDelegationStarted {
 }
 
 export interface SubagentDelegationCancel extends SubagentDelegationStarted {}
+
+export type SubagentDelegationV2Thinking = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
+export type SubagentDelegationV2ResultRequest =
+	| { kind: "text" }
+	| { kind: "structured"; schema: SubagentDelegationJsonSchemaObject };
+
+export interface SubagentDelegationV2Request {
+	version: typeof SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION;
+	requestId: string;
+	ownerRunId: string;
+	nodeId: string;
+	agent: string;
+	task: string;
+	context: "fresh" | "fork";
+	cwd: string;
+	model?: string;
+	thinking?: SubagentDelegationV2Thinking;
+	timeoutMs?: number;
+	turnBudget?: SubagentDelegationTurnBudget;
+	toolBudget?: SubagentDelegationToolBudget;
+	skill?: string | string[] | boolean;
+	artifacts?: boolean;
+	result: SubagentDelegationV2ResultRequest;
+}
+
+export interface SubagentDelegationV2Started {
+	version: typeof SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION;
+	requestId: string;
+	ownerRunId: string;
+	nodeId: string;
+}
+
+export interface SubagentDelegationV2Update extends SubagentDelegationV2Started {
+	currentTool?: string;
+	currentToolArgs?: string;
+	recentOutput?: string;
+	recentOutputLines?: string[];
+	recentTools?: Array<{ tool: string; args: string }>;
+	model?: string;
+	toolCount?: number;
+	durationMs?: number;
+	tokens?: number;
+}
+
+export type SubagentDelegationV2Status = SubagentDelegationStatus | "duplicate_node";
+
+export type SubagentDelegationV2Value =
+	| { kind: "text"; text: string }
+	| { kind: "structured"; value: unknown };
+
+export interface SubagentDelegationV2Usage {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	cost: number;
+	turns: number;
+	toolCalls: number;
+	durationMs: number;
+}
+
+export interface SubagentDelegationV2TerminalResponse extends SubagentDelegationV2Started {
+	status: Exclude<SubagentDelegationV2Status, "invalid_request">;
+	error?: string;
+	runId?: string;
+	agent?: string;
+	model?: string;
+	thinking?: string;
+	exitCode?: number;
+	result?: SubagentDelegationV2Value;
+	usage?: SubagentDelegationV2Usage;
+}
+
+/** A malformed V2 request can only be correlated by the valid identity fields it supplied. */
+export interface SubagentDelegationV2InvalidResponse {
+	version: typeof SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION;
+	requestId: string;
+	ownerRunId?: string;
+	nodeId?: string;
+	status: "invalid_request";
+	error?: string;
+}
+
+export type SubagentDelegationV2Response = SubagentDelegationV2TerminalResponse | SubagentDelegationV2InvalidResponse;
+
+export interface SubagentDelegationV2Cancel extends SubagentDelegationV2Started {}

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -52,6 +52,7 @@ import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir } from "../shared/pi-args.ts";
+import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { readStructuredOutput } from "../shared/structured-output.ts";
 import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
 import { captureSingleOutputSnapshot, extractChildWrittenOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
@@ -204,6 +205,7 @@ async function runSingleAttempt(
 ): Promise<SingleResult> {
 	const effectiveThinking = options.thinkingOverride ?? agent.thinking;
 	const modelArg = applyThinkingSuffix(model, effectiveThinking, options.thinkingOverride !== undefined);
+	const resolvedThinking = resolveEffectiveThinking(modelArg, effectiveThinking);
 	const watchdogConfig = resolveWatchdogConfig(options.cwd ?? runtimeCwd);
 	const childWatchdog = watchdogConfig.ok
 		? resolveChildWatchdogConfig({
@@ -256,6 +258,7 @@ async function runSingleAttempt(
 		messages: [],
 		usage: emptyUsage(),
 		model: modelArg,
+		...(resolvedThinking ? { thinking: resolvedThinking } : {}),
 		artifactPaths: shared.artifactPaths,
 		transcriptPath: shared.transcriptWriter ? shared.artifactPaths?.transcriptPath : undefined,
 		skills: shared.resolvedSkillNames,
@@ -655,7 +658,7 @@ async function runSingleAttempt(
 		const fireUpdate = () => {
 			if (!options.onUpdate || processClosed) return;
 			progress.durationMs = Date.now() - startTime;
-			const output = (result.timedOut || result.turnBudgetExceeded) && result.finalOutput ? result.finalOutput : getFinalOutput(result.messages);
+			const output = (result.timedOut || result.turnBudgetExceeded) && result.finalOutput ? result.finalOutput : getFinalOutput(result.messages ?? []);
 			emitUpdateSnapshot(output || "(running...)");
 		};
 
@@ -738,7 +741,7 @@ async function runSingleAttempt(
 			}
 
 			if (evt.type === "message_end" && evt.message) {
-				result.messages.push(evt.message);
+				result.messages!.push(evt.message);
 				if (evt.message.role === "assistant") {
 					result.usage.turns++;
 					progress.turnCount = result.usage.turns;
@@ -772,7 +775,7 @@ async function runSingleAttempt(
 			}
 
 			if (evt.type === "tool_result_end" && evt.message) {
-				result.messages.push(evt.message);
+				result.messages!.push(evt.message);
 				const resultText = extractTextFromContent(evt.message.content);
 				if (options.toolBudget && pendingToolResult && resultText.includes("Tool budget hard limit reached")) {
 					result.toolBudgetBlocked = true;
@@ -1030,7 +1033,7 @@ async function runSingleAttempt(
 		result.exitCode = 1;
 	}
 	if (result.exitCode === 0 && !result.error) {
-		const errInfo = detectSubagentError(result.messages);
+		const errInfo = detectSubagentError(result.messages ?? []);
 		if (errInfo.hasError) {
 			result.exitCode = errInfo.exitCode ?? 1;
 			result.error = errInfo.details
@@ -1039,7 +1042,7 @@ async function runSingleAttempt(
 		}
 	}
 	if (result.exitCode === 0 && !result.error) {
-		const finalText = getFinalOutput(result.messages);
+		const finalText = getFinalOutput(result.messages ?? []);
 		const missingStructuredOutput = options.structuredOutput
 			? !existsSync(options.structuredOutput.outputPath)
 			: false;
@@ -1079,7 +1082,7 @@ async function runSingleAttempt(
 		durationMs: progress.durationMs,
 	};
 
-	const acceptanceOutput = getFinalOutput(result.messages);
+	const acceptanceOutput = getFinalOutput(result.messages ?? []);
 	let fullOutput = stripAcceptanceReport(acceptanceOutput);
 	if (result.timedOut) {
 		const timeoutMessage = formatTimeoutMessage(options.timeoutMs ?? 0);
@@ -1100,7 +1103,7 @@ async function runSingleAttempt(
 		? evaluateCompletionMutationGuard({
 			agent: agent.name,
 			task: shared.originalTask ?? task,
-			messages: result.messages,
+			messages: result.messages ?? [],
 			tools: agent.tools,
 			mcpDirectTools: agent.mcpDirectTools,
 		})

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { type AgentConfig, type AgentScope } from "../../agents/agents.ts";
+import type { AgentConfig, AgentScope } from "../../agents/agents.ts";
 import { getArtifactsDir, getProjectChainRunsDir } from "../../shared/artifacts.ts";
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
 import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
@@ -3348,6 +3348,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		ctx: ExtensionContext,
 	) => Promise<AgentToolResult<Details>>;
 } {
+	const delegatedThinkingOverrides = new WeakMap<object, AgentConfig["thinking"]>();
 	const execute = async (
 		_id: string,
 		params: SubagentParamsLike,
@@ -3355,6 +3356,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		onUpdate: ((r: AgentToolResult<Details>) => void) | undefined,
 		ctx: ExtensionContext,
 	): Promise<AgentToolResult<Details>> => {
+		const delegatedThinkingOverride = delegatedThinkingOverrides.get(params);
 		deps.state.baseCwd = ctx.cwd;
 		deps.state.foregroundRuns ??= new Map();
 		deps.state.foregroundControls ??= new Map();
@@ -3822,11 +3824,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return forkSessionFileForIndex(idx);
 		};
 		const forkThinkingOverrideForTask: ForkThinkingOverrideForTask = (agentName, idx = 0, modelOverride) => {
-			if (!shouldForkAgent(contextPolicy, agentName)) return undefined;
+			if (!shouldForkAgent(contextPolicy, agentName)) return delegatedThinkingOverride;
 			prepareForkThinking(agentName, idx, modelOverride);
 			const override = forkThinkingOverrideForIndex(idx);
 			if (override === "off") forkThinkingDowngrades.set(idx, agentName);
-			return override;
+			return override ?? delegatedThinkingOverride;
 		};
 		const childSessionFileForTask: ForkSessionFileForTask = (agentName, idx, modelOverride) =>
 			forkSessionFileForTask(agentName, idx, modelOverride) ?? path.join(sessionDirForIndex(idx), "session.jsonl");
@@ -4034,5 +4036,20 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		}
 	};
 
-	return { execute: executeWithSingleDispatchGuard, executeDelegated: execute };
+	const executeDelegated = async (
+		id: string,
+		params: SubagentParamsLike,
+		signal: AbortSignal,
+		onUpdate: ((r: AgentToolResult<Details>) => void) | undefined,
+		ctx: ExtensionContext,
+	): Promise<AgentToolResult<Details>> => {
+		const delegatedParams = { ...params };
+		const privateParams = delegatedParams as SubagentParamsLike & { delegatedThinkingOverride?: AgentConfig["thinking"] };
+		const thinkingOverride = privateParams.delegatedThinkingOverride;
+		delete privateParams.delegatedThinkingOverride;
+		if (thinkingOverride !== undefined) delegatedThinkingOverrides.set(delegatedParams, thinkingOverride);
+		return execute(id, delegatedParams, signal, onUpdate, ctx);
+	};
+
+	return { execute: executeWithSingleDispatchGuard, executeDelegated };
 }

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1687,8 +1687,12 @@ function resolveForegroundTimeout(params: SubagentParamsLike): { timeoutMs?: num
 	return { timeoutMs: rawTimeout ?? rawMaxRuntime };
 }
 
-function resolveToolBudget(raw: unknown, label = "toolBudget"): { toolBudget?: ResolvedToolBudget; error?: string } {
-	const resolved = validateToolBudgetConfig(raw, label);
+function resolveToolBudget(
+	raw: unknown,
+	label = "toolBudget",
+	options?: { minimumHard?: 0 | 1 },
+): { toolBudget?: ResolvedToolBudget; error?: string } {
+	const resolved = validateToolBudgetConfig(raw, label, options);
 	return { toolBudget: resolved.budget, error: resolved.error };
 }
 
@@ -3349,6 +3353,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 	) => Promise<AgentToolResult<Details>>;
 } {
 	const delegatedThinkingOverrides = new WeakMap<object, AgentConfig["thinking"]>();
+	const delegatedZeroToolBudgets = new WeakSet<object>();
 	const execute = async (
 		_id: string,
 		params: SubagentParamsLike,
@@ -3357,6 +3362,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		ctx: ExtensionContext,
 	): Promise<AgentToolResult<Details>> => {
 		const delegatedThinkingOverride = delegatedThinkingOverrides.get(params);
+		const allowZeroToolBudget = delegatedZeroToolBudgets.has(params);
 		deps.state.baseCwd = ctx.cwd;
 		deps.state.foregroundRuns ??= new Map();
 		deps.state.foregroundControls ??= new Map();
@@ -3688,7 +3694,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			depth,
 			deps.config.forceTopLevelAsync === true,
 		);
-		const runToolBudget = resolveToolBudget(effectiveParams.toolBudget, "toolBudget");
+		const runToolBudget = resolveToolBudget(
+			effectiveParams.toolBudget,
+			"toolBudget",
+			allowZeroToolBudget ? { minimumHard: 0 } : undefined,
+		);
 		if (runToolBudget.error) return buildRequestedModeError(effectiveParams, runToolBudget.error);
 		const configToolBudget = resolveToolBudget(deps.config.toolBudget, "config.toolBudget");
 		if (configToolBudget.error) return buildRequestedModeError(effectiveParams, configToolBudget.error);
@@ -4044,10 +4054,16 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		ctx: ExtensionContext,
 	): Promise<AgentToolResult<Details>> => {
 		const delegatedParams = { ...params };
-		const privateParams = delegatedParams as SubagentParamsLike & { delegatedThinkingOverride?: AgentConfig["thinking"] };
+		const privateParams = delegatedParams as SubagentParamsLike & {
+			delegatedThinkingOverride?: AgentConfig["thinking"];
+			delegatedAllowZeroToolBudget?: true;
+		};
 		const thinkingOverride = privateParams.delegatedThinkingOverride;
+		const allowZeroToolBudget = privateParams.delegatedAllowZeroToolBudget === true;
 		delete privateParams.delegatedThinkingOverride;
+		delete privateParams.delegatedAllowZeroToolBudget;
 		if (thinkingOverride !== undefined) delegatedThinkingOverrides.set(delegatedParams, thinkingOverride);
+		if (allowZeroToolBudget) delegatedZeroToolBudgets.add(delegatedParams);
 		return execute(id, delegatedParams, signal, onUpdate, ctx);
 	};
 

--- a/src/runs/shared/tool-budget.ts
+++ b/src/runs/shared/tool-budget.ts
@@ -9,12 +9,17 @@ export function normalizeToolBudgetBlock(block: ToolBudgetConfig["block"] | unde
 	return [...new Set(block.map((tool) => tool.trim()).filter(Boolean))];
 }
 
-export function validateToolBudgetConfig(raw: unknown, label = "toolBudget"): { budget?: ResolvedToolBudget; error?: string } {
+export function validateToolBudgetConfig(
+	raw: unknown,
+	label = "toolBudget",
+	options: { minimumHard?: 0 | 1 } = {},
+): { budget?: ResolvedToolBudget; error?: string } {
 	if (raw === undefined) return {};
 	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return { error: `${label} must be an object with hard and optional soft/block.` };
 	const value = raw as ToolBudgetConfig;
-	if (typeof value.hard !== "number" || !Number.isInteger(value.hard) || value.hard < 1) {
-		return { error: `${label}.hard must be an integer >= 1.` };
+	const minimumHard = options.minimumHard ?? 1;
+	if (typeof value.hard !== "number" || !Number.isInteger(value.hard) || value.hard < minimumHard) {
+		return { error: `${label}.hard must be an integer >= ${minimumHard}.` };
 	}
 	if (value.soft !== undefined && (typeof value.soft !== "number" || !Number.isInteger(value.soft) || value.soft < 1)) {
 		return { error: `${label}.soft must be an integer >= 1 when provided.` };
@@ -68,7 +73,7 @@ export function encodeToolBudgetEnv(budget: ResolvedToolBudget | undefined): str
 export function decodeToolBudgetEnv(value: string | undefined): ResolvedToolBudget | undefined {
 	if (!value?.trim()) return undefined;
 	const parsed = JSON.parse(value) as unknown;
-	const normalized = validateToolBudgetConfig(parsed, TOOL_BUDGET_ENV);
+	const normalized = validateToolBudgetConfig(parsed, TOOL_BUDGET_ENV, { minimumHard: 0 });
 	if (normalized.error) throw new Error(normalized.error);
 	return normalized.budget;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,6 +5,7 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@earendil-works/pi-ai";
+import type { AgentConfig } from "../agents/agents.ts";
 import type { FSWatcher } from "node:fs";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ModelScopeConfig } from "../runs/shared/model-scope.ts";
@@ -639,6 +640,8 @@ export interface SingleResult {
 	messages?: Message[];
 	usage: Usage;
 	model?: string;
+	/** Effective thinking level used by this foreground child, when known. */
+	thinking?: string;
 	attemptedModels?: string[];
 	modelAttempts?: ModelAttempt[];
 	controlEvents?: ControlEvent[];

--- a/src/slash/delegation-adapters.ts
+++ b/src/slash/delegation-adapters.ts
@@ -152,6 +152,8 @@ export interface DelegatedSubagentExecutionParams {
 	artifacts?: boolean;
 	/** Internal-only thinking override accepted by executeDelegated. */
 	delegatedThinkingOverride?: SubagentDelegationV2Thinking;
+	/** Internal-only V2 capability accepted and stripped by executeDelegated. */
+	delegatedAllowZeroToolBudget?: true;
 	async: false;
 	foregroundOnly: true;
 	clarify: false;
@@ -394,6 +396,7 @@ export function toSubagentDelegationV2ExecutionParams(request: SubagentDelegatio
 		acceptance: false,
 		artifacts: request.artifacts,
 		delegatedThinkingOverride: request.thinking,
+		delegatedAllowZeroToolBudget: true,
 		async: false,
 		foregroundOnly: true,
 		clarify: false,

--- a/src/slash/delegation-adapters.ts
+++ b/src/slash/delegation-adapters.ts
@@ -1,5 +1,6 @@
 import {
 	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
+	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	type SubagentDelegationAcceptanceResult,
 	type SubagentDelegationEffectsResult,
 	type SubagentDelegationExecutionResult,
@@ -8,9 +9,15 @@ import {
 	type SubagentDelegationReviewResult,
 	type SubagentDelegationStatus,
 	type SubagentDelegationUpdate,
+	type SubagentDelegationV2Request,
+	type SubagentDelegationV2Response,
+	type SubagentDelegationV2Thinking,
+	type SubagentDelegationV2Value,
+	type SubagentDelegationV2Update,
 } from "../api/delegation.ts";
-import type { AcceptanceInput, AgentContract, EffectsProjection, ExecutionProjection, JsonSchemaObject, ReviewProjection, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
+import type { AcceptanceInput, AgentContract, EffectsProjection, ExecutionProjection, JsonSchemaObject, ReviewProjection, ToolBudgetConfig, TurnBudgetConfig, Usage } from "../shared/types.ts";
 import { isAgentContractV1 } from "../runs/shared/agent-contract.ts";
+import { cloneJsonWithinByteLimit } from "./delegation-json.ts";
 
 export interface PromptTemplateDelegationTask {
 	agent: string;
@@ -90,6 +97,8 @@ export interface PromptTemplateBridgeResult {
 			exitCode?: number;
 			error?: string;
 			model?: string;
+			thinking?: string;
+			structuredOutput?: unknown;
 			interrupted?: boolean;
 			timedOut?: boolean;
 			stopped?: boolean;
@@ -102,7 +111,7 @@ export interface PromptTemplateBridgeResult {
 			acceptance?: SubagentDelegationAcceptanceResult;
 			review?: ReviewProjection;
 			effects?: EffectsProjection;
-			usage?: { turns?: number };
+			usage?: Usage;
 			progressSummary?: { toolCount?: number; durationMs?: number; tokens?: number };
 			skillsWarning?: string;
 			outputSaveError?: string;
@@ -141,6 +150,8 @@ export interface DelegatedSubagentExecutionParams {
 	agentContract?: AgentContract;
 	acceptance?: AcceptanceInput;
 	artifacts?: boolean;
+	/** Internal-only thinking override accepted by executeDelegated. */
+	delegatedThinkingOverride?: SubagentDelegationV2Thinking;
 	async: false;
 	foregroundOnly: true;
 	clarify: false;
@@ -185,8 +196,8 @@ export function parsePromptTemplateRequest(data: unknown): PromptTemplateDelegat
 	const fallbackTask = tasks[0];
 	return {
 		requestId: value.requestId,
-		agent: hasSingle ? value.agent : fallbackTask!.agent,
-		task: hasSingle ? value.task : fallbackTask!.task,
+		agent: hasSingle ? value.agent! : fallbackTask!.agent,
+		task: hasSingle ? value.task! : fallbackTask!.task,
 		...(tasks.length > 0 ? { tasks } : {}),
 		context: value.context,
 		model: value.model,
@@ -367,12 +378,57 @@ export function toSubagentDelegationExecutionParams(request: SubagentDelegationR
 	};
 }
 
+export function toSubagentDelegationV2ExecutionParams(request: SubagentDelegationV2Request): DelegatedSubagentExecutionParams {
+	return {
+		agent: request.agent,
+		task: request.task,
+		context: request.context,
+		cwd: request.cwd,
+		model: request.model,
+		timeoutMs: request.timeoutMs,
+		turnBudget: request.turnBudget,
+		toolBudget: request.toolBudget,
+		skill: request.skill,
+		output: false,
+		...(request.result.kind === "structured" ? { outputSchema: request.result.schema } : {}),
+		acceptance: false,
+		artifacts: request.artifacts,
+		delegatedThinkingOverride: request.thinking,
+		async: false,
+		foregroundOnly: true,
+		clarify: false,
+	};
+}
+
 export function toSubagentDelegationUpdate(requestId: string, result: PromptTemplateBridgeResult): SubagentDelegationUpdate | undefined {
 	const legacy = toDelegationUpdate(requestId, result);
 	if (!legacy) return undefined;
 	return {
 		version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
 		requestId,
+		...(legacy.currentTool ? { currentTool: legacy.currentTool } : {}),
+		...(legacy.currentToolArgs ? { currentToolArgs: legacy.currentToolArgs } : {}),
+		...(legacy.recentOutput ? { recentOutput: legacy.recentOutput } : {}),
+		...(legacy.recentOutputLines ? { recentOutputLines: legacy.recentOutputLines } : {}),
+		...(legacy.recentTools ? { recentTools: legacy.recentTools } : {}),
+		...(legacy.model ? { model: legacy.model } : {}),
+		...(typeof legacy.toolCount === "number" ? { toolCount: legacy.toolCount } : {}),
+		...(typeof legacy.durationMs === "number" ? { durationMs: legacy.durationMs } : {}),
+		...(typeof legacy.tokens === "number" ? { tokens: legacy.tokens } : {}),
+	};
+}
+
+export function toSubagentDelegationV2Update(
+	request: SubagentDelegationV2Request,
+	result: PromptTemplateBridgeResult,
+): SubagentDelegationV2Update | undefined {
+	const legacy = toDelegationUpdate(request.requestId, result);
+	if (!legacy) return undefined;
+	return {
+		version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+		requestId: request.requestId,
+		ownerRunId: request.ownerRunId,
+		nodeId: request.nodeId,
 		...(legacy.currentTool ? { currentTool: legacy.currentTool } : {}),
 		...(legacy.currentToolArgs ? { currentToolArgs: legacy.currentToolArgs } : {}),
 		...(legacy.recentOutput ? { recentOutput: legacy.recentOutput } : {}),
@@ -434,6 +490,73 @@ export function toSubagentDelegationResponse(
 		...(typeof progress?.durationMs === "number" ? { durationMs: progress.durationMs } : {}),
 		...(typeof progress?.tokens === "number" ? { tokens: progress.tokens } : {}),
 		...(warnings.length > 0 ? { warnings } : {}),
+	};
+}
+
+const MAX_V2_RESULT_BYTES = 1024 * 1024;
+
+export function toSubagentDelegationV2Response(
+	request: SubagentDelegationV2Request,
+	result: PromptTemplateBridgeResult,
+	aborted: boolean,
+): SubagentDelegationV2Response {
+	const child = result.details?.results?.[0];
+	const progress = child?.progressSummary ?? result.details?.progress?.[0];
+	let status = resolveSubagentDelegationStatus(result, aborted);
+	let error = child?.error ?? (status === "failed" ? firstTextContent(result.content) : undefined);
+	let projectedResult: SubagentDelegationV2Value | undefined;
+	if (status === "completed") {
+		if (request.result.kind === "text") {
+			if (typeof child?.finalOutput !== "string") {
+				status = "failed";
+				error = "Delegated subagent did not capture a text result.";
+			} else if (Buffer.byteLength(child.finalOutput, "utf8") > MAX_V2_RESULT_BYTES) {
+				status = "failed";
+				error = "Delegated text result exceeds 1 MiB when UTF-8 encoded.";
+			} else {
+				projectedResult = { kind: "text", text: child.finalOutput };
+			}
+		} else if (child?.structuredOutput === undefined) {
+			status = "failed";
+			error = "Delegated subagent did not capture the requested structured result.";
+		} else {
+			const inspected = cloneJsonWithinByteLimit(child.structuredOutput, MAX_V2_RESULT_BYTES);
+			if (!inspected.ok) {
+				status = "failed";
+				error = inspected.reason === "too_large"
+					? "Delegated structured result exceeds 1 MiB when encoded."
+					: "Delegated structured result is not plain JSON data.";
+			} else {
+				projectedResult = { kind: "structured", value: inspected.value };
+			}
+		}
+	}
+	const usage = child?.usage;
+	return {
+		version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+		requestId: request.requestId,
+		ownerRunId: request.ownerRunId,
+		nodeId: request.nodeId,
+		status,
+		...(error ? { error } : {}),
+		...(result.details?.runId ? { runId: result.details.runId } : {}),
+		...(child?.agent ? { agent: child.agent } : {}),
+		...(child?.model ? { model: child.model } : {}),
+		...(child?.thinking ? { thinking: child.thinking } : {}),
+		...(typeof child?.exitCode === "number" ? { exitCode: child.exitCode } : {}),
+		...(projectedResult ? { result: projectedResult } : {}),
+		...(usage ? {
+			usage: {
+				input: usage.input,
+				output: usage.output,
+				cacheRead: usage.cacheRead,
+				cacheWrite: usage.cacheWrite,
+				cost: usage.cost,
+				turns: usage.turns,
+				toolCalls: progress?.toolCount ?? 0,
+				durationMs: progress?.durationMs ?? 0,
+			},
+		} : {}),
 	};
 }
 

--- a/src/slash/delegation-json.ts
+++ b/src/slash/delegation-json.ts
@@ -1,0 +1,108 @@
+const MAX_JSON_DEPTH = 64;
+const MAX_JSON_ENTRIES = 100_000;
+
+export type BoundedJsonClone =
+	| { ok: true; value: unknown; encodedBytes: number }
+	| { ok: false; reason: "invalid" | "too_large" };
+
+/** Clone plain JSON data without invoking getters or toJSON hooks. */
+export function cloneJsonWithinByteLimit(input: unknown, maxBytes: number): BoundedJsonClone {
+	let minimumBytes = 0;
+	let entries = 0;
+	const active = new WeakSet<object>();
+
+	const addMinimumBytes = (bytes: number): void => {
+		minimumBytes += bytes;
+		if (minimumBytes > maxBytes) throw new RangeError("too_large");
+	};
+
+	const visit = (value: unknown, depth: number): unknown => {
+		if (depth > MAX_JSON_DEPTH) throw new TypeError("invalid");
+		if (value === null) {
+			addMinimumBytes(4);
+			return null;
+		}
+		if (typeof value === "boolean") {
+			addMinimumBytes(value ? 4 : 5);
+			return value;
+		}
+		if (typeof value === "number") {
+			if (!Number.isFinite(value)) throw new TypeError("invalid");
+			const encoded = JSON.stringify(Object.is(value, -0) ? 0 : value);
+			addMinimumBytes(Buffer.byteLength(encoded, "utf8"));
+			return Object.is(value, -0) ? 0 : value;
+		}
+		if (typeof value === "string") {
+			// Quoting and escaping can only increase the encoded size.
+			addMinimumBytes(Buffer.byteLength(value, "utf8") + 2);
+			return value;
+		}
+		if (typeof value !== "object") throw new TypeError("invalid");
+
+		const object = value as object;
+		if (active.has(object)) throw new TypeError("invalid");
+		active.add(object);
+		try {
+			const prototype = Object.getPrototypeOf(object);
+			const keys = Reflect.ownKeys(object);
+			if (Array.isArray(object)) {
+				if (prototype !== Array.prototype) throw new TypeError("invalid");
+				const lengthDescriptor = Object.getOwnPropertyDescriptor(object, "length");
+				if (!lengthDescriptor || !("value" in lengthDescriptor) || !Number.isSafeInteger(lengthDescriptor.value) || lengthDescriptor.value < 0) {
+					throw new TypeError("invalid");
+				}
+				const length = lengthDescriptor.value as number;
+				addMinimumBytes(2 + Math.max(0, length - 1));
+				const output: unknown[] = [];
+				for (const key of keys) {
+					if (typeof key === "symbol") throw new TypeError("invalid");
+					if (key === "length") continue;
+					if (!/^(?:0|[1-9][0-9]*)$/.test(key) || Number(key) >= length) throw new TypeError("invalid");
+				}
+				for (let index = 0; index < length; index++) {
+					const descriptor = Object.getOwnPropertyDescriptor(object, String(index));
+					if (!descriptor || !("value" in descriptor) || !descriptor.enumerable) throw new TypeError("invalid");
+					entries++;
+					if (entries > MAX_JSON_ENTRIES) throw new TypeError("invalid");
+					output.push(visit(descriptor.value, depth + 1));
+				}
+				return output;
+			}
+
+			if (prototype !== Object.prototype && prototype !== null) throw new TypeError("invalid");
+			addMinimumBytes(2 + Math.max(0, keys.length - 1));
+			const output: Record<string, unknown> = {};
+			for (const key of keys) {
+				if (typeof key === "symbol") throw new TypeError("invalid");
+				const descriptor = Object.getOwnPropertyDescriptor(object, key);
+				if (!descriptor || !("value" in descriptor) || !descriptor.enumerable) throw new TypeError("invalid");
+				entries++;
+				if (entries > MAX_JSON_ENTRIES) throw new TypeError("invalid");
+				addMinimumBytes(Buffer.byteLength(JSON.stringify(key), "utf8") + 1);
+				Object.defineProperty(output, key, {
+					value: visit(descriptor.value, depth + 1),
+					enumerable: true,
+					configurable: true,
+					writable: true,
+				});
+			}
+			return output;
+		} finally {
+			active.delete(object);
+		}
+	};
+
+	try {
+		const value = visit(input, 0);
+		const encoded = JSON.stringify(value);
+		if (encoded === undefined) return { ok: false, reason: "invalid" };
+		const encodedBytes = Buffer.byteLength(encoded, "utf8");
+		if (encodedBytes > maxBytes) return { ok: false, reason: "too_large" };
+		return { ok: true, value, encodedBytes };
+	} catch (error) {
+		return {
+			ok: false,
+			reason: error instanceof RangeError && error.message === "too_large" ? "too_large" : "invalid",
+		};
+	}
+}

--- a/src/slash/delegation-request.ts
+++ b/src/slash/delegation-request.ts
@@ -1,16 +1,19 @@
 import {
 	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
+	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	type SubagentDelegationRequest,
+	type SubagentDelegationV2Request,
 } from "../api/delegation.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
 import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
+import { cloneJsonWithinByteLimit } from "./delegation-json.ts";
 
 export type SubagentDelegationParseResult =
-	| { ok: true; request: SubagentDelegationRequest }
-	| { ok: false; requestId?: string; error: string };
+	| { ok: true; request: SubagentDelegationRequest | SubagentDelegationV2Request }
+	| { ok: false; version?: 1 | 2; requestId?: string; ownerRunId?: string; nodeId?: string; error: string };
 
-const supportedFields = new Set([
+const v1SupportedFields = new Set([
 	"version",
 	"requestId",
 	"agent",
@@ -30,63 +33,168 @@ const supportedFields = new Set([
 	"artifacts",
 ]);
 
+const v2SupportedFields = new Set([
+	"version",
+	"requestId",
+	"ownerRunId",
+	"nodeId",
+	"agent",
+	"task",
+	"context",
+	"cwd",
+	"model",
+	"thinking",
+	"timeoutMs",
+	"turnBudget",
+	"toolBudget",
+	"skill",
+	"artifacts",
+	"result",
+]);
+
+const v2ThinkingLevels = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+const MAX_SCHEMA_BYTES = 64 * 1024;
+const MAX_V2_TASK_BYTES = 1024 * 1024;
+const MAX_V2_CWD_BYTES = 32 * 1024;
+const MAX_V2_SHORT_TEXT_BYTES = 1024;
+const MAX_V2_SKILL_ENTRIES = 256;
+const MAX_V2_SKILL_AGGREGATE_BYTES = 64 * 1024;
+
 function nonEmptyString(value: unknown): value is string {
 	return typeof value === "string" && value.trim().length > 0;
 }
 
-function validateRequestId(value: unknown): string | undefined {
+function validateId(value: unknown): string | undefined {
 	if (!nonEmptyString(value) || value.length > 256 || /[\r\n]/.test(value)) return undefined;
 	return value;
 }
 
-export function parseSubagentDelegationRequest(data: unknown): SubagentDelegationParseResult {
-	if (!data || typeof data !== "object" || Array.isArray(data)) {
-		return { ok: false, error: "Delegation request must be an object." };
-	}
-	const value = data as Record<string, unknown>;
-	const requestId = validateRequestId(value.requestId);
-	if (value.version !== SUBAGENT_DELEGATION_PROTOCOL_VERSION) {
-		return {
-			...(requestId ? { requestId } : {}),
-			ok: false,
-			error: `Unsupported delegation protocol version: ${String(value.version)}.`,
-		};
-	}
-	if (!requestId) {
-		return { ok: false, error: "Delegation requestId must be a non-empty string of at most 256 characters without newlines." };
-	}
-	const unsupportedField = Object.keys(value).find((key) => !supportedFields.has(key));
-	if (unsupportedField) return { ok: false, requestId, error: `Unsupported delegation field: ${unsupportedField}.` };
-	if (!nonEmptyString(value.agent)) return { ok: false, requestId, error: "Delegation agent must be a non-empty string." };
-	if (!nonEmptyString(value.task)) return { ok: false, requestId, error: "Delegation task must be a non-empty string." };
+function validateSharedFields(
+	value: Record<string, unknown>,
+	identity: { requestId: string; version?: 1 | 2; ownerRunId?: string; nodeId?: string },
+): SubagentDelegationParseResult | undefined {
+	if (!nonEmptyString(value.agent)) return { ok: false, ...identity, error: "Delegation agent must be a non-empty string." };
+	if (!nonEmptyString(value.task)) return { ok: false, ...identity, error: "Delegation task must be a non-empty string." };
 	if (value.context !== "fresh" && value.context !== "fork") {
-		return { ok: false, requestId, error: "Delegation context must be fresh or fork." };
+		return { ok: false, ...identity, error: "Delegation context must be fresh or fork." };
 	}
-	if (!nonEmptyString(value.cwd)) return { ok: false, requestId, error: "Delegation cwd must be a non-empty string." };
+	if (!nonEmptyString(value.cwd)) return { ok: false, ...identity, error: "Delegation cwd must be a non-empty string." };
 	if (value.model !== undefined && !nonEmptyString(value.model)) {
-		return { ok: false, requestId, error: "model must be a non-empty string when provided." };
+		return { ok: false, ...identity, error: "model must be a non-empty string when provided." };
 	}
 	if (value.timeoutMs !== undefined && (typeof value.timeoutMs !== "number" || !Number.isInteger(value.timeoutMs) || value.timeoutMs < 1)) {
-		return { ok: false, requestId, error: "timeoutMs must be an integer >= 1." };
+		return { ok: false, ...identity, error: "timeoutMs must be an integer >= 1." };
+	}
+	if (identity.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION && value.timeoutMs !== undefined && value.timeoutMs > 2_147_483_647) {
+		return { ok: false, ...identity, error: "timeoutMs must be <= 2147483647 for delegation v2." };
 	}
 	const turnBudget = resolveTurnBudgetConfig(value.turnBudget);
-	if (turnBudget.error) return { ok: false, requestId, error: turnBudget.error };
+	if (turnBudget.error) return { ok: false, ...identity, error: turnBudget.error };
 	if (value.toolBudget && typeof value.toolBudget === "object" && !Array.isArray(value.toolBudget)) {
 		const unsupportedToolBudgetField = Object.keys(value.toolBudget).find((key) => key !== "soft" && key !== "hard" && key !== "block");
 		if (unsupportedToolBudgetField) {
-			return { ok: false, requestId, error: `toolBudget.${unsupportedToolBudgetField} is not supported.` };
+			return { ok: false, ...identity, error: `toolBudget.${unsupportedToolBudgetField} is not supported.` };
 		}
 	}
 	const toolBudget = validateToolBudgetConfig(value.toolBudget);
-	if (toolBudget.error) return { ok: false, requestId, error: toolBudget.error };
+	if (toolBudget.error) return { ok: false, ...identity, error: toolBudget.error };
 	if (value.skill !== undefined) {
 		const validSkill = typeof value.skill === "boolean"
 			|| nonEmptyString(value.skill)
 			|| (Array.isArray(value.skill) && value.skill.length > 0 && value.skill.every(nonEmptyString));
 		if (!validSkill) {
-			return { ok: false, requestId, error: "skill must be a boolean, non-empty string, or non-empty string array." };
+			return { ok: false, ...identity, error: "skill must be a boolean, non-empty string, or non-empty string array." };
 		}
 	}
+	if (value.artifacts !== undefined && typeof value.artifacts !== "boolean") {
+		return { ok: false, ...identity, error: "artifacts must be a boolean." };
+	}
+	return undefined;
+}
+
+function parseV2(value: Record<string, unknown>, requestId: string): SubagentDelegationParseResult {
+	const ownerRunId = validateId(value.ownerRunId);
+	if (!ownerRunId) {
+		return { ok: false, version: 2, requestId, error: "Delegation ownerRunId must be a non-empty string of at most 256 characters without newlines." };
+	}
+	const nodeId = validateId(value.nodeId);
+	if (!nodeId) {
+		return { ok: false, version: 2, requestId, ownerRunId, error: "Delegation nodeId must be a non-empty string of at most 256 characters without newlines." };
+	}
+	const identity = { version: 2 as const, requestId, ownerRunId, nodeId };
+	const unsupportedField = Object.keys(value).find((key) => !v2SupportedFields.has(key));
+	if (unsupportedField) return { ok: false, ...identity, error: `Unsupported delegation field: ${unsupportedField}.` };
+	const sharedError = validateSharedFields(value, identity);
+	if (sharedError) return sharedError;
+	if (Buffer.byteLength(value.task as string, "utf8") > MAX_V2_TASK_BYTES) {
+		return { ok: false, ...identity, error: "Delegation task exceeds 1 MiB when UTF-8 encoded." };
+	}
+	if (Buffer.byteLength(value.cwd as string, "utf8") > MAX_V2_CWD_BYTES) {
+		return { ok: false, ...identity, error: "Delegation cwd exceeds 32 KiB when UTF-8 encoded." };
+	}
+	if (Buffer.byteLength(value.agent as string, "utf8") > MAX_V2_SHORT_TEXT_BYTES) {
+		return { ok: false, ...identity, error: "Delegation agent exceeds 1 KiB when UTF-8 encoded." };
+	}
+	if (typeof value.model === "string" && Buffer.byteLength(value.model, "utf8") > MAX_V2_SHORT_TEXT_BYTES) {
+		return { ok: false, ...identity, error: "Delegation model exceeds 1 KiB when UTF-8 encoded." };
+	}
+	const skillEntries = typeof value.skill === "string" ? [value.skill] : Array.isArray(value.skill) ? value.skill as string[] : [];
+	if (skillEntries.length > MAX_V2_SKILL_ENTRIES) {
+		return { ok: false, ...identity, error: "Delegation skill supports at most 256 entries." };
+	}
+	if (skillEntries.some((entry) => Buffer.byteLength(entry, "utf8") > MAX_V2_SHORT_TEXT_BYTES)) {
+		return { ok: false, ...identity, error: "Delegation skill entry exceeds 1 KiB when UTF-8 encoded." };
+	}
+	if (skillEntries.reduce((total, entry) => total + Buffer.byteLength(entry, "utf8"), 0) > MAX_V2_SKILL_AGGREGATE_BYTES) {
+		return { ok: false, ...identity, error: "Delegation skill entries exceed 64 KiB in aggregate when UTF-8 encoded." };
+	}
+	if (value.thinking !== undefined && (typeof value.thinking !== "string" || !v2ThinkingLevels.has(value.thinking))) {
+		return { ok: false, ...identity, error: "thinking must be one of off, minimal, low, medium, high, xhigh, or max." };
+	}
+	if (!value.result || typeof value.result !== "object" || Array.isArray(value.result)) {
+		return { ok: false, ...identity, error: "result must be { kind: \"text\" } or { kind: \"structured\", schema: object }." };
+	}
+	const result = value.result as Record<string, unknown>;
+	let structuredSchema: Record<string, unknown> | undefined;
+	if (result.kind === "text") {
+		const unsupportedResultField = Object.keys(result).find((key) => key !== "kind");
+		if (unsupportedResultField) return { ok: false, ...identity, error: `result.${unsupportedResultField} is not supported for text results.` };
+	} else if (result.kind === "structured") {
+		const unsupportedResultField = Object.keys(result).find((key) => key !== "kind" && key !== "schema");
+		if (unsupportedResultField) return { ok: false, ...identity, error: `result.${unsupportedResultField} is not supported for structured results.` };
+		if (!result.schema || typeof result.schema !== "object" || Array.isArray(result.schema)) {
+			return { ok: false, ...identity, error: "result.schema must be a JSON Schema object." };
+		}
+		const inspectedSchema = cloneJsonWithinByteLimit(result.schema, MAX_SCHEMA_BYTES);
+		if (!inspectedSchema.ok) {
+			return {
+				ok: false,
+				...identity,
+				error: inspectedSchema.reason === "too_large"
+					? "result.schema exceeds 64 KiB when encoded."
+					: "result.schema must be plain JSON data.",
+			};
+		}
+		structuredSchema = inspectedSchema.value as Record<string, unknown>;
+	} else {
+		return { ok: false, ...identity, error: "result.kind must be text or structured." };
+	}
+	return {
+		ok: true,
+		request: {
+			...value,
+			result: structuredSchema
+				? { kind: "structured", schema: structuredSchema }
+				: { kind: "text" },
+		} as unknown as SubagentDelegationV2Request,
+	};
+}
+
+function parseV1(value: Record<string, unknown>, requestId: string): SubagentDelegationParseResult {
+	const unsupportedField = Object.keys(value).find((key) => !v1SupportedFields.has(key));
+	if (unsupportedField) return { ok: false, requestId, error: `Unsupported delegation field: ${unsupportedField}.` };
+	const sharedError = validateSharedFields(value, { requestId });
+	if (sharedError) return sharedError;
 	if (value.output !== undefined && typeof value.output !== "boolean" && !nonEmptyString(value.output)) {
 		return { ok: false, requestId, error: "output must be a boolean or non-empty string." };
 	}
@@ -106,8 +214,32 @@ export function parseSubagentDelegationRequest(data: unknown): SubagentDelegatio
 	}
 	const acceptanceErrors = validateAcceptanceInput(value.acceptance);
 	if (acceptanceErrors.length > 0) return { ok: false, requestId, error: acceptanceErrors.join(" ") };
-	if (value.artifacts !== undefined && typeof value.artifacts !== "boolean") {
-		return { ok: false, requestId, error: "artifacts must be a boolean." };
-	}
 	return { ok: true, request: value as unknown as SubagentDelegationRequest };
+}
+
+export function parseSubagentDelegationRequest(data: unknown): SubagentDelegationParseResult {
+	if (!data || typeof data !== "object" || Array.isArray(data)) {
+		return { ok: false, error: "Delegation request must be an object." };
+	}
+	const value = data as Record<string, unknown>;
+	const requestId = validateId(value.requestId);
+	if (value.version !== SUBAGENT_DELEGATION_PROTOCOL_VERSION && value.version !== SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
+		return {
+			...(requestId ? { requestId } : {}),
+			ok: false,
+			error: `Unsupported delegation protocol version: ${String(value.version)}.`,
+		};
+	}
+	if (!requestId) {
+		return { ok: false, error: "Delegation requestId must be a non-empty string of at most 256 characters without newlines." };
+	}
+	if (value.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
+		// Preserve the v1 parser's historical diagnostic for a v1-shaped payload
+		// whose version alone was changed to 2.
+		if (!Object.hasOwn(value, "ownerRunId") && !Object.hasOwn(value, "nodeId") && !Object.hasOwn(value, "result")) {
+			return { ok: false, version: 2, requestId, error: "Unsupported delegation protocol version: 2." };
+		}
+		return parseV2(value, requestId);
+	}
+	return parseV1(value, requestId);
 }

--- a/src/slash/delegation-request.ts
+++ b/src/slash/delegation-request.ts
@@ -96,7 +96,11 @@ function validateSharedFields(
 			return { ok: false, ...identity, error: `toolBudget.${unsupportedToolBudgetField} is not supported.` };
 		}
 	}
-	const toolBudget = validateToolBudgetConfig(value.toolBudget);
+	const toolBudget = validateToolBudgetConfig(
+		value.toolBudget,
+		"toolBudget",
+		identity.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION ? { minimumHard: 0 } : undefined,
+	);
 	if (toolBudget.error) return { ok: false, ...identity, error: toolBudget.error };
 	if (value.skill !== undefined) {
 		const validSkill = typeof value.skill === "boolean"

--- a/src/slash/prompt-template-bridge.ts
+++ b/src/slash/prompt-template-bridge.ts
@@ -1,12 +1,16 @@
 import {
 	SUBAGENT_DELEGATION_CANCEL_EVENT,
 	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
+	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
 	SUBAGENT_DELEGATION_RESPONSE_EVENT,
 	SUBAGENT_DELEGATION_STARTED_EVENT,
 	SUBAGENT_DELEGATION_UPDATE_EVENT,
 	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
+	type SubagentDelegationV2InvalidResponse,
+	type SubagentDelegationV2Request,
+	type SubagentDelegationV2Response,
 } from "../api/delegation.ts";
 import { parseSubagentDelegationRequest } from "./delegation-request.ts";
 import {
@@ -17,6 +21,9 @@ import {
 	toSubagentDelegationExecutionParams,
 	toSubagentDelegationResponse,
 	toSubagentDelegationUpdate,
+	toSubagentDelegationV2ExecutionParams,
+	toSubagentDelegationV2Response,
+	toSubagentDelegationV2Update,
 	type DelegatedSubagentExecutionParams,
 	type PromptTemplateBridgeResult,
 	type PromptTemplateDelegationRequest,
@@ -63,10 +70,17 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 	cancelAll: () => void;
 	dispose: () => void;
 } {
+	// Legacy and V1 retain requestId-only correlation. V2 attempts are isolated by
+	// their complete wire identity, while logical-node ownership is tracked separately.
 	const controllers = new Map<string, AbortController>();
 	const pendingCancels = new Map<string, true>();
+	const v2Controllers = new Map<string, AbortController>();
+	const pendingV2Cancels = new Map<string, true>();
+	const activeV2Nodes = new Map<string, { attemptKey: string; controller: AbortController }>();
+	const settledV2Attempts = new Map<string, true>();
 	const subscriptions: Array<() => void> = [];
 	let disposed = false;
+	let v2IdentitySaturated = false;
 
 	const subscribe = (event: string, handler: (data: unknown) => void): void => {
 		const unsubscribe = options.events.on(event, handler);
@@ -74,25 +88,63 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 	};
 	const ownsRequest = (requestId: string, controller: AbortController): boolean =>
 		!disposed && controllers.get(requestId) === controller;
-	const rememberPendingCancel = (requestId: string): void => {
-		pendingCancels.delete(requestId);
-		pendingCancels.set(requestId, true);
-		while (pendingCancels.size > 256) {
-			const oldest = pendingCancels.keys().next().value;
+	const ownsV2Attempt = (attemptKey: string, controller: AbortController): boolean =>
+		!disposed && v2Controllers.get(attemptKey) === controller;
+	const boundedRemember = (map: Map<string, true>, key: string): void => {
+		map.delete(key);
+		map.set(key, true);
+		while (map.size > 256) {
+			const oldest = map.keys().next().value;
 			if (typeof oldest !== "string") break;
-			pendingCancels.delete(oldest);
+			map.delete(oldest);
 		}
+	};
+	const rememberV2Identity = (map: Map<string, true>, key: string): void => {
+		if (map.has(key) || v2IdentitySaturated) return;
+		if (map.size >= 8_192) {
+			v2IdentitySaturated = true;
+			return;
+		}
+		map.set(key, true);
+		if (map.size === 8_192) {
+			// V2 identity facts are security state, not an LRU cache. Saturate as
+			// soon as the bounded history fills so no later untracked attempt can
+			// start, rather than evicting a cancellation or settled-attempt fact.
+			v2IdentitySaturated = true;
+		}
+	};
+	const v2NodeKey = (ownerRunId: string, nodeId: string): string => JSON.stringify([ownerRunId, nodeId]);
+	const v2AttemptKey = (requestId: string, ownerRunId: string, nodeId: string): string => JSON.stringify([requestId, ownerRunId, nodeId]);
+	const rememberPendingCancel = (requestId: string): void => {
+		boundedRemember(pendingCancels, requestId);
+	};
+	const emitV2Terminal = (attemptKey: string, payload: SubagentDelegationV2Response): void => {
+		if (disposed || settledV2Attempts.has(attemptKey)) return;
+		rememberV2Identity(settledV2Attempts, attemptKey);
+		options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, payload);
 	};
 
 	subscribe(PROMPT_TEMPLATE_SUBAGENT_CANCEL_EVENT, (data) => {
 		if (!data || typeof data !== "object" || Array.isArray(data)) return;
-		if (Object.hasOwn(data, "version")) {
-			const value = data as Record<string, unknown>;
+		const value = data as Record<string, unknown>;
+		const requestId = value.requestId;
+		if (typeof requestId !== "string" || !requestId.trim() || requestId.length > 256 || /[\r\n]/.test(requestId)) return;
+		if (Object.hasOwn(value, "version")) {
+			if (value.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
+				if (Object.keys(value).some((key) => key !== "version" && key !== "requestId" && key !== "ownerRunId" && key !== "nodeId")) return;
+				const ownerRunId = value.ownerRunId;
+				const nodeId = value.nodeId;
+				if (typeof ownerRunId !== "string" || !ownerRunId.trim() || ownerRunId.length > 256 || /[\r\n]/.test(ownerRunId)) return;
+				if (typeof nodeId !== "string" || !nodeId.trim() || nodeId.length > 256 || /[\r\n]/.test(nodeId)) return;
+				const attemptKey = v2AttemptKey(requestId, ownerRunId, nodeId);
+				const controller = v2Controllers.get(attemptKey);
+				if (controller) controller.abort();
+				else rememberV2Identity(pendingV2Cancels, attemptKey);
+				return;
+			}
 			if (value.version !== SUBAGENT_DELEGATION_PROTOCOL_VERSION) return;
 			if (Object.keys(value).some((key) => key !== "version" && key !== "requestId")) return;
 		}
-		const requestId = (data as { requestId?: unknown }).requestId;
-		if (typeof requestId !== "string" || !requestId.trim() || requestId.length > 256 || /[\r\n]/.test(requestId)) return;
 		const controller = controllers.get(requestId);
 		if (controller) {
 			controller.abort();
@@ -105,25 +157,50 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 		const isVersioned = !!data && typeof data === "object" && Object.hasOwn(data, "version");
 		let requestId: string;
 		let params: DelegatedSubagentExecutionParams;
-		let versionedRequest: SubagentDelegationRequest | undefined;
+		let versionedRequest: SubagentDelegationRequest | SubagentDelegationV2Request | undefined;
+		let v2Request: SubagentDelegationV2Request | undefined;
+		let v2Key: string | undefined;
 		let legacyRequest: PromptTemplateDelegationRequest | undefined;
 
 		if (isVersioned) {
 			const parsed = parseSubagentDelegationRequest(data);
 			if (parsed.ok === false) {
-				if (!disposed && parsed.requestId && !controllers.has(parsed.requestId)) {
-					options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
-						version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-						requestId: parsed.requestId,
-						status: "invalid_request",
-						error: parsed.error,
-					} satisfies SubagentDelegationResponse);
+				if (!disposed && parsed.requestId) {
+					if (parsed.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
+						const payload = {
+							version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+							requestId: parsed.requestId,
+							...(parsed.ownerRunId ? { ownerRunId: parsed.ownerRunId } : {}),
+							...(parsed.nodeId ? { nodeId: parsed.nodeId } : {}),
+							status: "invalid_request",
+							error: parsed.error,
+						} satisfies SubagentDelegationV2InvalidResponse;
+						if (parsed.ownerRunId && parsed.nodeId) {
+							const attemptKey = v2AttemptKey(parsed.requestId, parsed.ownerRunId, parsed.nodeId);
+							if (!v2Controllers.has(attemptKey)) emitV2Terminal(attemptKey, payload);
+						} else {
+							options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, payload);
+						}
+					} else if (!controllers.has(parsed.requestId)) {
+						options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
+							version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
+							requestId: parsed.requestId,
+							status: "invalid_request",
+							error: parsed.error,
+						} satisfies SubagentDelegationResponse);
+					}
 				}
 				return;
 			}
 			versionedRequest = parsed.request;
 			requestId = parsed.request.requestId;
-			params = toSubagentDelegationExecutionParams(parsed.request);
+			if (parsed.request.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
+				v2Request = parsed.request;
+				v2Key = v2AttemptKey(requestId, parsed.request.ownerRunId, parsed.request.nodeId);
+				params = toSubagentDelegationV2ExecutionParams(parsed.request);
+			} else {
+				params = toSubagentDelegationExecutionParams(parsed.request);
+			}
 		} else {
 			legacyRequest = parsePromptTemplateRequest(data);
 			if (!legacyRequest) return;
@@ -131,12 +208,56 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 			params = toLegacyExecutionParams(legacyRequest);
 		}
 
-		// The first request owns its correlation ID until it settles. A duplicate
-		// cannot receive a terminal response without stealing the original caller's.
-		if (controllers.has(requestId)) return;
+		// Legacy and V1 keep requestId-only ownership. V2 retransmission and terminal
+		// suppression use the full tuple, independently from logical-node ownership.
+		if (!v2Request && controllers.has(requestId)) return;
+		if (v2Request && v2Key) {
+			if (v2Controllers.has(v2Key) || settledV2Attempts.has(v2Key)) return;
+			if (pendingV2Cancels.delete(v2Key)) {
+				emitV2Terminal(v2Key, {
+					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+					requestId,
+					ownerRunId: v2Request.ownerRunId,
+					nodeId: v2Request.nodeId,
+					status: "cancelled",
+				});
+				return;
+			}
+			if (v2IdentitySaturated) {
+				options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
+					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+					requestId,
+					ownerRunId: v2Request.ownerRunId,
+					nodeId: v2Request.nodeId,
+					status: "unavailable_context",
+					error: "Delegation v2 identity capacity is exhausted for this extension context.",
+				} satisfies SubagentDelegationV2Response);
+				return;
+			}
+			const active = activeV2Nodes.get(v2NodeKey(v2Request.ownerRunId, v2Request.nodeId));
+			if (active) {
+				emitV2Terminal(v2Key, {
+					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+					requestId,
+					ownerRunId: v2Request.ownerRunId,
+					nodeId: v2Request.nodeId,
+					status: "duplicate_node",
+				});
+				return;
+			}
+		}
 		const ctx = options.getContext();
 		if (!ctx) {
-			if (versionedRequest) {
+			if (v2Request && v2Key) {
+				emitV2Terminal(v2Key, {
+					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+					requestId,
+					ownerRunId: v2Request.ownerRunId,
+					nodeId: v2Request.nodeId,
+					status: "unavailable_context",
+					error: "No active extension context for delegated subagent execution.",
+				});
+			} else if (versionedRequest) {
 				options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
 					version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
 					requestId,
@@ -155,10 +276,24 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 		}
 
 		const controller = new AbortController();
-		controllers.set(requestId, controller);
-		if (pendingCancels.delete(requestId)) controller.abort();
+		if (v2Request && v2Key) {
+			v2Controllers.set(v2Key, controller);
+			activeV2Nodes.set(v2NodeKey(v2Request.ownerRunId, v2Request.nodeId), { attemptKey: v2Key, controller });
+		} else {
+			controllers.set(requestId, controller);
+			if (pendingCancels.delete(requestId)) controller.abort();
+		}
 		if (controller.signal.aborted) {
-			if (versionedRequest) {
+			if (v2Request && v2Key) {
+				emitV2Terminal(v2Key, {
+					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+					requestId,
+					ownerRunId: v2Request.ownerRunId,
+					nodeId: v2Request.nodeId,
+					status: "cancelled",
+				});
+				activeV2Nodes.delete(v2NodeKey(v2Request.ownerRunId, v2Request.nodeId));
+			} else if (versionedRequest) {
 				options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
 					version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
 					requestId,
@@ -172,15 +307,18 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 					errorText: "Delegated prompt cancelled.",
 				} satisfies PromptTemplateDelegationResponse);
 			}
-			controllers.delete(requestId);
+			if (v2Key) v2Controllers.delete(v2Key);
+			else controllers.delete(requestId);
 			return;
 		}
 
 		options.events.emit(
 			versionedRequest ? SUBAGENT_DELEGATION_STARTED_EVENT : PROMPT_TEMPLATE_SUBAGENT_STARTED_EVENT,
-			versionedRequest
-				? { version: SUBAGENT_DELEGATION_PROTOCOL_VERSION, requestId }
-				: { requestId },
+			v2Request
+				? { version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION, requestId, ownerRunId: v2Request.ownerRunId, nodeId: v2Request.nodeId }
+				: versionedRequest
+					? { version: SUBAGENT_DELEGATION_PROTOCOL_VERSION, requestId }
+					: { requestId },
 		);
 
 		try {
@@ -193,7 +331,12 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 				controller.signal,
 				ctx,
 				(update) => {
-					if (!ownsRequest(requestId, controller)) return;
+					if (v2Key ? !ownsV2Attempt(v2Key, controller) : !ownsRequest(requestId, controller)) return;
+					if (v2Request) {
+						const payload = toSubagentDelegationV2Update(v2Request, update);
+						if (payload) options.events.emit(SUBAGENT_DELEGATION_UPDATE_EVENT, payload);
+						return;
+					}
 					if (versionedRequest) {
 						const payload = toSubagentDelegationUpdate(requestId, update);
 						if (payload) options.events.emit(SUBAGENT_DELEGATION_UPDATE_EVENT, payload);
@@ -203,8 +346,10 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 					if (payload) options.events.emit(PROMPT_TEMPLATE_SUBAGENT_UPDATE_EVENT, payload);
 				},
 			);
-			if (!ownsRequest(requestId, controller)) return;
-			if (versionedRequest) {
+			if (v2Key ? !ownsV2Attempt(v2Key, controller) : !ownsRequest(requestId, controller)) return;
+			if (v2Request && v2Key) {
+				emitV2Terminal(v2Key, toSubagentDelegationV2Response(v2Request, result, controller.signal.aborted));
+			} else if (versionedRequest) {
 				options.events.emit(
 					SUBAGENT_DELEGATION_RESPONSE_EVENT,
 					toSubagentDelegationResponse(requestId, result, controller.signal.aborted),
@@ -218,8 +363,17 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 				);
 			}
 		} catch (error) {
-			if (!ownsRequest(requestId, controller)) return;
-			if (versionedRequest) {
+			if (v2Key ? !ownsV2Attempt(v2Key, controller) : !ownsRequest(requestId, controller)) return;
+			if (v2Request && v2Key) {
+				emitV2Terminal(v2Key, {
+					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+					requestId,
+					ownerRunId: v2Request.ownerRunId,
+					nodeId: v2Request.nodeId,
+					status: controller.signal.aborted ? "cancelled" : "failed",
+					...(controller.signal.aborted ? {} : { error: error instanceof Error ? error.message : String(error) }),
+				});
+			} else if (versionedRequest) {
 				options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
 					version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
 					requestId,
@@ -235,23 +389,40 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 				} satisfies PromptTemplateDelegationResponse);
 			}
 		} finally {
-			if (controllers.get(requestId) === controller) controllers.delete(requestId);
+			if (v2Key) {
+				if (v2Controllers.get(v2Key) === controller) v2Controllers.delete(v2Key);
+			} else if (controllers.get(requestId) === controller) controllers.delete(requestId);
+			if (v2Request) {
+				const key = v2NodeKey(v2Request.ownerRunId, v2Request.nodeId);
+				if (activeV2Nodes.get(key)?.controller === controller) activeV2Nodes.delete(key);
+			}
 		}
 	});
 
 	return {
 		cancelAll: () => {
 			for (const controller of controllers.values()) controller.abort();
+			for (const controller of v2Controllers.values()) controller.abort();
 			controllers.clear();
+			v2Controllers.clear();
 			pendingCancels.clear();
+			pendingV2Cancels.clear();
+			activeV2Nodes.clear();
+			settledV2Attempts.clear();
+			v2IdentitySaturated = false;
 		},
 		dispose: () => {
 			disposed = true;
 			for (const controller of controllers.values()) controller.abort();
+			for (const controller of v2Controllers.values()) controller.abort();
 			controllers.clear();
+			v2Controllers.clear();
 			for (const unsubscribe of subscriptions) unsubscribe();
 			subscriptions.length = 0;
 			pendingCancels.clear();
+			pendingV2Cancels.clear();
+			activeV2Nodes.clear();
+			settledV2Attempts.clear();
 		},
 	};
 }

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -42,6 +42,7 @@ import {
 import { INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, type SubagentState } from "../../src/shared/types.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
+import { TOOL_BUDGET_ENV } from "../../src/runs/shared/tool-budget.ts";
 import { MainWatchdogRuntime } from "../../src/watchdog/runtime.ts";
 import { MAX_CHILD_PENDING_LINE_BYTES, MAX_CHILD_STDERR_BYTES } from "../../src/runs/shared/child-protocol.ts";
 import {
@@ -354,6 +355,66 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.isError, undefined);
 		assert.match(result.content[0]?.text ?? "", /single alias finished/);
+	});
+
+	it("admits a zero run-level tool budget only for marked v2 delegated execution", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const zeroBudget = { hard: 0, block: "*" as const };
+		const params = { agent: "echo", task: "Answer without tools", toolBudget: zeroBudget };
+		const ctx = makeMinimalCtx(tempDir);
+		const executor = makeExecutor([makeAgent("echo")]);
+
+		const ordinary = await executor.execute(
+			"ordinary-zero-budget",
+			{ ...params, delegatedAllowZeroToolBudget: true },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.equal(ordinary.isError, true);
+		assert.match(ordinary.content[0]?.text ?? "", /toolBudget\.hard must be an integer >= 1/);
+
+		const v1Delegated = await executor.executeDelegated(
+			"v1-delegated-zero-budget",
+			params,
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.equal(v1Delegated.isError, true);
+		assert.match(v1Delegated.content[0]?.text ?? "", /toolBudget\.hard must be an integer >= 1/);
+
+		mockPi.onCall({ echoEnv: [TOOL_BUDGET_ENV] });
+		const v2Delegated = await executor.executeDelegated(
+			"v2-delegated-zero-budget",
+			{ ...params, delegatedAllowZeroToolBudget: true },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.equal(v2Delegated.isError, undefined);
+		const env = JSON.parse(v2Delegated.content[0]?.text ?? "{}") as Record<string, string>;
+		assert.deepEqual(JSON.parse(env[TOOL_BUDGET_ENV] ?? "null"), zeroBudget);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("keeps delegated agent and config tool budgets at a minimum of one", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const ctx = makeMinimalCtx(tempDir);
+		const cases = [
+			makeExecutor([makeAgent("echo", { toolBudget: { hard: 0 } })]),
+			makeExecutor([makeAgent("echo")], { toolBudget: { hard: 0 } }),
+		];
+		for (const [index, executor] of cases.entries()) {
+			const result = await executor.executeDelegated(
+				`delegated-default-zero-budget-${index}`,
+				{ agent: "echo", task: "Do work", delegatedAllowZeroToolBudget: true },
+				new AbortController().signal,
+				undefined,
+				ctx,
+			);
+			assert.equal(result.isError, true);
+			assert.match(result.content[0]?.text ?? "", /(?:agent\.|config\.)?toolBudget\.hard must be an integer >= 1/);
+		}
+		assert.equal(mockPi.callCount(), 0);
 	});
 
 	it("rejects string \"none\" acceptance before spawning", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -28,11 +28,16 @@ import {
 import registerSubagentExtension from "../../src/extension/index.ts";
 import {
 	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
+	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
 	SUBAGENT_DELEGATION_RESPONSE_EVENT,
+	SUBAGENT_DELEGATION_STARTED_EVENT,
 	SUBAGENT_DELEGATION_UPDATE_EVENT,
 	type SubagentDelegationResponse,
 	type SubagentDelegationUpdate,
+	type SubagentDelegationV2Request,
+	type SubagentDelegationV2Response,
+	type SubagentDelegationV2Started,
 } from "../../src/api/delegation.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, type SubagentState } from "../../src/shared/types.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
@@ -499,7 +504,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		try {
 			registerSubagentExtension(fakePi as never);
-			for (const handler of runtimeHandlers.get("session_start") ?? []) handler({ reason: "startup" }, ctx);
+			for (const handler of runtimeHandlers.get("session_start") ?? []) {
+				await handler({ reason: "startup" }, ctx);
+			}
 			extensionEvents.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
 				version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
 				requestId: "registered-a",
@@ -531,11 +538,179 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			}
 			assert.deepEqual(responses.map((response) => response.requestId).sort(), ["registered-a", "registered-b"]);
 			assert.ok(responses.every((response) => response.status === "completed"));
-			assert.equal(responses.find((response) => response.requestId === "registered-a")?.output, "registered first delegated call");
-			assert.equal(responses.find((response) => response.requestId === "registered-b")?.output, "registered second delegated call");
-			assert.equal(updates.some((update) => update.requestId === "registered-a" && update.currentTool === "read"), true);
+			assert.deepEqual(responses.map((response) => response.output).sort(), [
+				"registered first delegated call",
+				"registered second delegated call",
+			]);
+			const toolResponse = responses.find((response) => response.output === "registered first delegated call");
+			assert.ok(toolResponse);
+			assert.equal(updates.some((update) => update.requestId === toolResponse.requestId && update.currentTool === "read"), true);
 		} finally {
-			for (const handler of runtimeHandlers.get("session_shutdown") ?? []) handler({}, ctx);
+			for (const handler of runtimeHandlers.get("session_shutdown") ?? []) {
+				await handler({}, ctx);
+			}
+		}
+	});
+
+	it("routes registered strict v2 text delegation through the concurrent executor", async () => {
+		const literalJsonText = '{"looks":"json"}';
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("read", { path: "package.json" })], delay: 20 },
+				{ jsonl: [events.toolEnd("read"), events.toolResult("read", "{}")], delay: 20 },
+				{
+					jsonl: [{
+						type: "message_end",
+						message: {
+							role: "assistant",
+							content: [{ type: "text", text: literalJsonText }],
+							model: "mock/test-model",
+							stopReason: "stop",
+							usage: {
+								input: 11,
+								output: 7,
+								cacheRead: 3,
+								cacheWrite: 2,
+								cost: { total: 0.0125 },
+							},
+						},
+					}],
+					delay: 60,
+				},
+			],
+		});
+		mockPi.onCall({ output: "registered v2 second node", delay: 100 });
+		const extensionEvents = createEventBus();
+		const runtimeHandlers = new Map<string, Array<(event: unknown, ctx: ReturnType<typeof makeMinimalCtx>) => void>>();
+		const fakePi = new Proxy({
+			events: extensionEvents,
+			on(event: string, handler: (event: unknown, ctx: ReturnType<typeof makeMinimalCtx>) => void) {
+				const handlers = runtimeHandlers.get(event) ?? [];
+				handlers.push(handler);
+				runtimeHandlers.set(event, handlers);
+				return () => runtimeHandlers.set(event, (runtimeHandlers.get(event) ?? []).filter((entry) => entry !== handler));
+			},
+			registerTool() {},
+			registerCommand() {},
+			registerShortcut() {},
+			registerMessageRenderer() {},
+			sendMessage() {},
+			getSessionName() { return undefined; },
+		}, {
+			get(target, prop) {
+				if (prop in target) return target[prop as keyof typeof target];
+				return () => undefined;
+			},
+		});
+		const ctx = {
+			...makeMinimalCtx(tempDir),
+			modelRegistry: {
+				getAvailable: () => [{ provider: "mock", id: "test-model", reasoning: true }],
+			},
+			sessionManager: {
+				getSessionId: () => "registered-delegation-v2-session",
+				getSessionFile: () => path.join(tempDir, "registered-delegation-v2-session.jsonl"),
+				getEntries: () => [],
+			},
+		};
+		const started: SubagentDelegationV2Started[] = [];
+		const responses: SubagentDelegationV2Response[] = [];
+		extensionEvents.on(SUBAGENT_DELEGATION_STARTED_EVENT, (payload) => {
+			if ((payload as { version?: unknown }).version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
+				started.push(payload as SubagentDelegationV2Started);
+			}
+		});
+		extensionEvents.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => {
+			if ((payload as { version?: unknown }).version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
+				responses.push(payload as SubagentDelegationV2Response);
+			}
+		});
+
+		const firstRequest = {
+			version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+			requestId: "registered-v2-a",
+			ownerRunId: "owner-v2",
+			nodeId: "node-a",
+			agent: "worker",
+			task: "Return literal JSON-looking text",
+			context: "fresh",
+			cwd: tempDir,
+			model: "mock/test-model",
+			thinking: "high",
+			result: { kind: "text" },
+		} satisfies SubagentDelegationV2Request;
+		const secondRequest = {
+			version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+			requestId: "registered-v2-b",
+			ownerRunId: "owner-v2",
+			nodeId: "node-b",
+			agent: "reviewer",
+			task: "Run the second logical node",
+			context: "fresh",
+			cwd: tempDir,
+			model: "mock/test-model",
+			thinking: "high",
+			result: { kind: "text" },
+		} satisfies SubagentDelegationV2Request;
+
+		try {
+			registerSubagentExtension(fakePi as never);
+			for (const handler of runtimeHandlers.get("session_start") ?? []) {
+				await handler({ reason: "startup" }, ctx);
+			}
+			extensionEvents.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, firstRequest);
+			extensionEvents.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, secondRequest);
+
+			const callDeadlineAt = Date.now() + 30_000;
+			while (mockPi.callCount() < 2 && responses.length < 2 && Date.now() < callDeadlineAt) {
+				await new Promise((resolve) => setTimeout(resolve, 20));
+			}
+			assert.equal(mockPi.callCount(), 2, `different V2 logical nodes should use the concurrent delegated execution path: ${JSON.stringify(responses)}`);
+			assert.deepEqual(started.map(({ requestId, ownerRunId, nodeId }) => ({ requestId, ownerRunId, nodeId })).sort((a, b) => a.nodeId.localeCompare(b.nodeId)), [
+				{ requestId: "registered-v2-a", ownerRunId: "owner-v2", nodeId: "node-a" },
+				{ requestId: "registered-v2-b", ownerRunId: "owner-v2", nodeId: "node-b" },
+			]);
+
+			const responseDeadlineAt = Date.now() + 30_000;
+			while (responses.length < 2 && Date.now() < responseDeadlineAt) {
+				await new Promise((resolve) => setTimeout(resolve, 20));
+			}
+			assert.equal(responses.length, 2);
+			assert.ok(responses.every((response) => response.status === "completed"));
+			const terminalResponses = responses.filter((response) => response.status !== "invalid_request");
+			assert.equal(terminalResponses.length, 2);
+			for (const response of terminalResponses) {
+				assert.equal(response.ownerRunId, "owner-v2");
+				assert.equal(response.model, "mock/test-model:high");
+				assert.equal(response.thinking, "high");
+			}
+			const literalResponse = terminalResponses.find((response) => response.result?.kind === "text" && response.result.text === literalJsonText);
+			assert.ok(literalResponse);
+			assert.deepEqual(literalResponse.result, { kind: "text", text: literalJsonText });
+			assert.deepEqual(literalResponse.usage && {
+				input: literalResponse.usage.input,
+				output: literalResponse.usage.output,
+				cacheRead: literalResponse.usage.cacheRead,
+				cacheWrite: literalResponse.usage.cacheWrite,
+				cost: literalResponse.usage.cost,
+				turns: literalResponse.usage.turns,
+				toolCalls: literalResponse.usage.toolCalls,
+			}, {
+				input: 11,
+				output: 7,
+				cacheRead: 3,
+				cacheWrite: 2,
+				cost: 0.0125,
+				turns: 1,
+				toolCalls: 1,
+			});
+			assert.equal(typeof literalResponse.usage?.durationMs, "number");
+			const plainResponse = terminalResponses.find((response) => response.result?.kind === "text" && response.result.text === "registered v2 second node");
+			assert.ok(plainResponse);
+		} finally {
+			for (const handler of runtimeHandlers.get("session_shutdown") ?? []) {
+				await handler({}, ctx);
+			}
 		}
 	});
 

--- a/test/support/helpers.ts
+++ b/test/support/helpers.ts
@@ -61,6 +61,7 @@ interface AgentConfig {
 	output?: string | false;
 	reads?: string[] | false;
 	progress?: boolean;
+	toolBudget?: { soft?: number; hard: number; block?: string[] | "*" };
 	mcpDirectTools?: string[];
 	maxSubagentDepth?: number;
 	completionGuard?: boolean;

--- a/test/unit/delegation-api.test.ts
+++ b/test/unit/delegation-api.test.ts
@@ -139,6 +139,20 @@ describe("public subagent delegation contract", () => {
 		}
 	});
 
+	it("accepts an exact zero tool budget only for v2", () => {
+		const zeroBudget = { hard: 0, block: "*" as const };
+		const parsedV2 = parseSubagentDelegationRequest({ ...v2Request, toolBudget: zeroBudget });
+		assert.equal(parsedV2.ok, true);
+		if (parsedV2.ok) assert.deepEqual(parsedV2.request.toolBudget, zeroBudget);
+
+		const parsedV1 = parseSubagentDelegationRequest({ ...request, toolBudget: zeroBudget });
+		assert.equal(parsedV1.ok, false);
+		if (!parsedV1.ok) assert.equal(parsedV1.error, "toolBudget.hard must be an integer >= 1.");
+		for (const soft of [0, 1]) {
+			assert.equal(parseSubagentDelegationRequest({ ...v2Request, toolBudget: { ...zeroBudget, soft } }).ok, false);
+		}
+	});
+
 	it("rejects non-JSON v2 schemas without executing toJSON hooks", () => {
 		let calls = 0;
 		const parsed = parseSubagentDelegationRequest({
@@ -253,6 +267,7 @@ describe("public subagent delegation contract", () => {
 			acceptance: false,
 			artifacts: true,
 			delegatedThinkingOverride: "high",
+			delegatedAllowZeroToolBudget: true,
 			async: false,
 			foregroundOnly: true,
 			clarify: false,

--- a/test/unit/delegation-api.test.ts
+++ b/test/unit/delegation-api.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
 	SUBAGENT_DELEGATION_CANCEL_EVENT,
 	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
+	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
 	SUBAGENT_DELEGATION_RESPONSE_EVENT,
 	SUBAGENT_DELEGATION_STARTED_EVENT,
@@ -11,6 +12,9 @@ import {
 	type SubagentDelegationAcceptance,
 	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
+	type SubagentDelegationV2InvalidResponse,
+	type SubagentDelegationV2Request,
+	type SubagentDelegationV2Response,
 } from "../../src/api/delegation.ts";
 import { parseSubagentDelegationRequest } from "../../src/slash/delegation-request.ts";
 import {
@@ -56,6 +60,25 @@ const acceptance: SubagentDelegationAcceptance = {
 	reason: "Explicit verification contract",
 };
 
+const v2Request: SubagentDelegationV2Request = {
+	version: 2,
+	requestId: "attempt-1",
+	ownerRunId: "owner-1",
+	nodeId: "node-1",
+	agent: "reviewer",
+	task: "Review evidence",
+	context: "fresh",
+	cwd: "/repo",
+	model: "openai/gpt-5",
+	thinking: "high",
+	timeoutMs: 1_000,
+	turnBudget: { maxTurns: 4, graceTurns: 1 },
+	toolBudget: { soft: 3, hard: 5, block: "*" },
+	skill: ["review"],
+	artifacts: true,
+	result: { kind: "structured", schema: { type: "object", properties: { ok: { type: "boolean" } } } },
+};
+
 const request: SubagentDelegationRequest = {
 	version: 1,
 	requestId: "delegation-1",
@@ -84,6 +107,50 @@ describe("public subagent delegation contract", () => {
 		assert.equal(SUBAGENT_DELEGATION_UPDATE_EVENT, "prompt-template:subagent:update");
 		assert.equal(SUBAGENT_DELEGATION_RESPONSE_EVENT, "prompt-template:subagent:response");
 		assert.equal(SUBAGENT_DELEGATION_CANCEL_EVENT, "prompt-template:subagent:cancel");
+	});
+
+	it("strictly parses the complete v2 request and enforces its independent allowlists and bounds", () => {
+		assert.equal(SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION, 2);
+		assert.deepEqual(parseSubagentDelegationRequest(v2Request), { ok: true, request: v2Request });
+		const malformed = [
+			[{ ...v2Request, ownerRunId: "bad\nowner" }, /ownerRunId.*256 characters without newlines/],
+			[{ ...v2Request, nodeId: "x".repeat(257) }, /nodeId.*256 characters without newlines/],
+			[{ ...v2Request, thinking: "extreme" }, /thinking must be one of/],
+			[{ ...v2Request, output: false }, /Unsupported delegation field: output/],
+			[{ ...v2Request, outputMode: "inline" }, /Unsupported delegation field: outputMode/],
+			[{ ...v2Request, agentContract: { version: 1 } }, /Unsupported delegation field: agentContract/],
+			[{ ...v2Request, acceptance: false }, /Unsupported delegation field: acceptance/],
+			[{ ...v2Request, result: { kind: "text", schema: {} } }, /result.schema is not supported/],
+			[{ ...v2Request, result: { kind: "structured" } }, /result.schema must be a JSON Schema object/],
+			[{ ...v2Request, task: "é".repeat(524_289) }, /task exceeds 1 MiB/],
+			[{ ...v2Request, cwd: "é".repeat(16_385) }, /cwd exceeds 32 KiB/],
+			[{ ...v2Request, agent: "é".repeat(513) }, /agent exceeds 1 KiB/],
+			[{ ...v2Request, model: "é".repeat(513) }, /model exceeds 1 KiB/],
+			[{ ...v2Request, skill: "é".repeat(513) }, /skill entry exceeds 1 KiB/],
+			[{ ...v2Request, skill: Array.from({ length: 257 }, () => "x") }, /skill supports at most 256 entries/],
+			[{ ...v2Request, skill: Array.from({ length: 256 }, () => "x".repeat(257)) }, /skill entries exceed 64 KiB in aggregate/],
+			[{ ...v2Request, result: { kind: "structured", schema: { value: "x".repeat(65_536) } } }, /result.schema exceeds 64 KiB/],
+			[{ ...v2Request, timeoutMs: 2_147_483_648 }, /timeoutMs must be <= 2147483647 for delegation v2/],
+		] as const;
+		for (const [input, expected] of malformed) {
+			const parsed = parseSubagentDelegationRequest(input);
+			assert.equal(parsed.ok, false);
+			if (!parsed.ok) assert.match(parsed.error, expected);
+		}
+	});
+
+	it("rejects non-JSON v2 schemas without executing toJSON hooks", () => {
+		let calls = 0;
+		const parsed = parseSubagentDelegationRequest({
+			...v2Request,
+			result: {
+				kind: "structured",
+				schema: { toJSON: () => { calls++; return {}; } },
+			},
+		});
+		assert.equal(parsed.ok, false);
+		if (!parsed.ok) assert.match(parsed.error, /result.schema must be plain JSON data/);
+		assert.equal(calls, 0);
 	});
 
 	it("strictly parses the complete v1 request", () => {
@@ -117,6 +184,310 @@ describe("public subagent delegation contract", () => {
 			assert.equal(parsed.ok, false);
 			if (!parsed.ok) assert.match(parsed.error, expected);
 		}
+	});
+
+	it("runs v2 through the versioned executor and preserves literal text with full effective metadata", async () => {
+		const events = new FakeEvents();
+		let ordinaryCalls = 0;
+		let observedParams: Record<string, unknown> | undefined;
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => {
+				ordinaryCalls++;
+				return { details: { mode: "single", results: [] } };
+			},
+			executeVersioned: async (_id, params, _signal, _ctx, onUpdate) => {
+				observedParams = params as unknown as Record<string, unknown>;
+				onUpdate({ details: { mode: "single", results: [{ agent: "reviewer", model: "openai/gpt-5", thinking: "high" }], progress: [{ currentTool: "read" }] } });
+				return {
+					details: {
+						mode: "single",
+						runId: "run-v2",
+						results: [{
+							agent: "reviewer",
+							exitCode: 0,
+							model: "openai/gpt-5",
+							thinking: "high",
+							finalOutput: '{"looks":"json"}',
+							usage: { input: 2, output: 3, cacheRead: 4, cacheWrite: 5, cost: 0.01, turns: 2 },
+							progressSummary: { toolCount: 6, tokens: 5, durationMs: 7 },
+						}],
+					},
+				};
+			},
+		});
+		const textRequest = { ...v2Request, result: { kind: "text" as const } };
+		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
+		const updatePromise = once(events, SUBAGENT_DELEGATION_UPDATE_EVENT);
+		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, textRequest);
+		assert.deepEqual(await startedPromise, { version: 2, requestId: "attempt-1", ownerRunId: "owner-1", nodeId: "node-1" });
+		assert.deepEqual(await updatePromise, { version: 2, requestId: "attempt-1", ownerRunId: "owner-1", nodeId: "node-1", currentTool: "read", model: "openai/gpt-5" });
+		assert.deepEqual(await responsePromise, {
+			version: 2,
+			requestId: "attempt-1",
+			ownerRunId: "owner-1",
+			nodeId: "node-1",
+			status: "completed",
+			runId: "run-v2",
+			agent: "reviewer",
+			model: "openai/gpt-5",
+			thinking: "high",
+			exitCode: 0,
+			result: { kind: "text", text: '{"looks":"json"}' },
+			usage: { input: 2, output: 3, cacheRead: 4, cacheWrite: 5, cost: 0.01, turns: 2, toolCalls: 6, durationMs: 7 },
+		} satisfies SubagentDelegationV2Response);
+		assert.equal(ordinaryCalls, 0);
+		assert.deepEqual(observedParams, {
+			agent: "reviewer",
+			task: "Review evidence",
+			context: "fresh",
+			cwd: "/repo",
+			model: "openai/gpt-5",
+			timeoutMs: 1_000,
+			turnBudget: { maxTurns: 4, graceTurns: 1 },
+			toolBudget: { soft: 3, hard: 5, block: "*" },
+			skill: ["review"],
+			output: false,
+			acceptance: false,
+			artifacts: true,
+			delegatedThinkingOverride: "high",
+			async: false,
+			foregroundOnly: true,
+			clarify: false,
+		});
+		bridge.dispose();
+	});
+
+	it("projects structured v2 values and fails missing or oversized captures", async () => {
+		const cases = [
+			[{ ok: true }, "completed", { kind: "structured", value: { ok: true } }],
+			[undefined, "failed", undefined],
+			[{ value: "x".repeat(1024 * 1024) }, "failed", undefined],
+		] as const;
+		for (const [structuredOutput, expectedStatus, expectedResult] of cases) {
+			const events = new FakeEvents();
+			const bridge = registerPromptTemplateDelegationBridge({
+				events,
+				getContext: () => ({ cwd: "/repo" }),
+				execute: async () => { throw new Error("ordinary executor must remain separate"); },
+				executeVersioned: async () => ({
+					details: {
+						mode: "single",
+						results: [{
+							agent: "reviewer",
+							exitCode: 0,
+							...(structuredOutput === undefined ? {} : { structuredOutput }),
+							usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+						}],
+					},
+				}),
+			});
+			const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+			events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: `structured-${expectedStatus}-${Math.random()}` });
+			const response = await responsePromise as SubagentDelegationV2Response;
+			assert.equal(response.status, expectedStatus);
+			assert.deepEqual(response.result, expectedResult);
+			if (expectedStatus === "failed") assert.match(response.error ?? "", /structured result/);
+			bridge.dispose();
+		}
+	});
+
+	it("rejects non-JSON structured results without executing toJSON hooks", async () => {
+		let calls = 0;
+		const events = new FakeEvents();
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("ordinary executor must remain separate"); },
+			executeVersioned: async () => ({
+				details: {
+					mode: "single",
+					results: [{
+						agent: "reviewer",
+						exitCode: 0,
+						structuredOutput: { toJSON: () => { calls++; return {}; } },
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+					}],
+				},
+			}),
+		});
+		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "unsafe-structured" });
+		const response = await responsePromise as SubagentDelegationV2Response;
+		assert.equal(response.status, "failed");
+		assert.match(response.error ?? "", /structured result is not plain JSON data/);
+		assert.equal(calls, 0);
+		bridge.dispose();
+	});
+
+	it("rejects v2 text results exceeding 1 MiB when UTF-8 encoded", async () => {
+		const events = new FakeEvents();
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("ordinary executor must remain separate"); },
+			executeVersioned: async () => ({
+				details: { mode: "single", results: [{ agent: "reviewer", exitCode: 0, finalOutput: "é".repeat(524_289) }] },
+			}),
+		});
+		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "oversized-text", result: { kind: "text" } });
+		const response = await responsePromise as SubagentDelegationV2Response;
+		assert.equal(response.status, "failed");
+		assert.match(response.error ?? "", /text result exceeds 1 MiB/);
+		assert.equal("result" in response, false);
+		bridge.dispose();
+	});
+
+	it("isolates v2 logical-node ownership, exact cancellation, pre-cancellation, and reuse", async () => {
+		const events = new FakeEvents();
+		const releases = new Map<string, () => void>();
+		const responses: SubagentDelegationV2Response[] = [];
+		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationV2Response));
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("ordinary executor must remain separate"); },
+			executeVersioned: async (id, params, signal) => await new Promise((resolve, reject) => {
+				releases.set(id, () => resolve({ details: { mode: "single", results: [{ agent: params.agent, exitCode: 0, finalOutput: id, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 } }] } }));
+				signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+			}),
+		});
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "owner-a", result: { kind: "text" } });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "owner-b", result: { kind: "text" } });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "owner-b", result: { kind: "text" } });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "other-node", nodeId: "node-2", result: { kind: "text" } });
+		while (!releases.has("owner-a") || !releases.has("other-node")) await tick();
+		await tick();
+		assert.equal(responses.find((entry) => entry.requestId === "owner-b")?.status, "duplicate_node");
+		assert.equal(responses.filter((entry) => entry.requestId === "owner-b").length, 1);
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "owner-a", ownerRunId: "wrong", nodeId: "node-1" });
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "owner-a", ownerRunId: "owner-1", nodeId: "wrong" });
+		await tick();
+		assert.equal(responses.some((entry) => entry.requestId === "owner-a"), false);
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "owner-a", ownerRunId: "owner-1", nodeId: "node-1" });
+		while (!responses.some((entry) => entry.requestId === "owner-a")) await tick();
+		assert.equal(responses.find((entry) => entry.requestId === "owner-a")?.status, "cancelled");
+		releases.get("other-node")?.();
+		while (!responses.some((entry) => entry.requestId === "other-node")) await tick();
+
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "pre", ownerRunId: "owner-1", nodeId: "node-1" });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "pre", result: { kind: "text" } });
+		while (!responses.some((entry) => entry.requestId === "pre")) await tick();
+		assert.equal(responses.find((entry) => entry.requestId === "pre")?.status, "cancelled");
+
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "reuse", result: { kind: "text" } });
+		while (!releases.has("reuse")) await tick();
+		releases.get("reuse")?.();
+		while (!responses.some((entry) => entry.requestId === "reuse")) await tick();
+		assert.equal(responses.find((entry) => entry.requestId === "reuse")?.status, "completed");
+		bridge.dispose();
+	});
+
+	it("keys concurrent v2 attempts and retransmissions by the full identity tuple", async () => {
+		const events = new FakeEvents();
+		const releases = new Map<string, () => void>();
+		const responses: SubagentDelegationV2Response[] = [];
+		let executeCalls = 0;
+		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationV2Response));
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("ordinary executor must remain separate"); },
+			executeVersioned: async (_id, params) => {
+				executeCalls++;
+				if (typeof params.task !== "string") throw new Error("expected a single delegated task");
+				const task = params.task;
+				await new Promise<void>((resolve) => releases.set(task, resolve));
+				return { details: { mode: "single", results: [{ agent: params.agent, exitCode: 0, finalOutput: task }] } };
+			},
+		});
+		const first = { ...v2Request, requestId: "shared-attempt", task: "first", result: { kind: "text" as const } };
+		const second = { ...first, ownerRunId: "owner-2", nodeId: "node-2", task: "second" };
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, first);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, second);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, first);
+		for (let index = 0; index < 5 && releases.size < 2; index++) await tick();
+		assert.equal(releases.size, 2);
+		assert.equal(executeCalls, 2);
+		releases.get("first")?.();
+		releases.get("second")?.();
+		while (responses.length < 2) await tick();
+		assert.deepEqual(responses.map(({ ownerRunId, nodeId, status }) => ({ ownerRunId, nodeId, status })).sort((a, b) => (a.ownerRunId ?? "").localeCompare(b.ownerRunId ?? "")), [
+			{ ownerRunId: "owner-1", nodeId: "node-1", status: "completed" },
+			{ ownerRunId: "owner-2", nodeId: "node-2", status: "completed" },
+		]);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, first);
+		await tick();
+		assert.equal(executeCalls, 2);
+		assert.equal(responses.length, 2);
+		bridge.dispose();
+	});
+
+	it("applies exact v2 pre-cancellation despite logical-node and bare-id conflicts", async () => {
+		const events = new FakeEvents();
+		const releases = new Map<string, () => void>();
+		const activeSignals = new Map<string, AbortSignal>();
+		const responses: SubagentDelegationV2Response[] = [];
+		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationV2Response));
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("ordinary executor must remain separate"); },
+			executeVersioned: async (_id, params, signal) => {
+				if (typeof params.task !== "string") throw new Error("expected a single delegated task");
+				const task = params.task;
+				activeSignals.set(task, signal);
+				await new Promise<void>((resolve) => releases.set(task, resolve));
+				return { details: { mode: "single", results: [{ agent: params.agent, exitCode: 0, finalOutput: task }] } };
+			},
+		});
+
+		const logicalOwner = { ...v2Request, requestId: "logical-owner", task: "logical-owner", result: { kind: "text" as const } };
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, logicalOwner);
+		while (!releases.has("logical-owner")) await tick();
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "logical-pre", ownerRunId: "owner-1", nodeId: "node-1" });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...logicalOwner, requestId: "logical-pre", task: "must-not-run" });
+		await tick();
+		assert.equal(responses.find((entry) => entry.requestId === "logical-pre")?.status, "cancelled");
+		assert.equal(activeSignals.get("logical-owner")?.aborted, false);
+		assert.equal(releases.has("must-not-run"), false);
+
+		const bareOwner = { ...v2Request, requestId: "shared-bare", ownerRunId: "owner-2", nodeId: "node-2", task: "bare-owner", result: { kind: "text" as const } };
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, bareOwner);
+		while (!releases.has("bare-owner")) await tick();
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "shared-bare", ownerRunId: "owner-3", nodeId: "node-3" });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...bareOwner, ownerRunId: "owner-3", nodeId: "node-3", task: "also-must-not-run" });
+		await tick();
+		assert.equal(responses.find((entry) => entry.ownerRunId === "owner-3")?.status, "cancelled");
+		assert.equal(activeSignals.get("bare-owner")?.aborted, false);
+		assert.equal(releases.has("also-must-not-run"), false);
+
+		releases.get("logical-owner")?.();
+		releases.get("bare-owner")?.();
+		bridge.dispose();
+	});
+
+	it("suppresses v2 terminal events after disposal", async () => {
+		const events = new FakeEvents();
+		const responses: unknown[] = [];
+		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload));
+		let rejectExecution: ((error: Error) => void) | undefined;
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("ordinary executor must remain separate"); },
+			executeVersioned: async () => await new Promise((_resolve, reject) => { rejectExecution = reject; }),
+		});
+		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "dispose-v2", result: { kind: "text" } });
+		await startedPromise;
+		bridge.dispose();
+		rejectExecution?.(new Error("aborted"));
+		await tick();
+		assert.deepEqual(responses, []);
 	});
 
 	it("runs one v1 request through the existing executor and returns structured metadata", async () => {
@@ -279,11 +650,11 @@ describe("public subagent delegation contract", () => {
 		const invalidPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
 		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, version: 2, requestId: "invalid-1" });
 		assert.deepEqual(await invalidPromise, {
-			version: 1,
+			version: 2,
 			requestId: "invalid-1",
 			status: "invalid_request",
 			error: "Unsupported delegation protocol version: 2.",
-		});
+		} satisfies SubagentDelegationV2InvalidResponse);
 
 		const unavailablePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
 		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "unavailable-1" });
@@ -407,6 +778,99 @@ describe("public subagent delegation contract", () => {
 		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "cancel-299" });
 		assert.equal((await retainedPromise as SubagentDelegationResponse).status, "cancelled");
 		assert.equal(executeCalls, 1);
+		bridge.dispose();
+	});
+
+	it("fails closed instead of evicting exact v2 cancellation identity", async () => {
+		const events = new FakeEvents();
+		let executeCalls = 0;
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => {
+				executeCalls++;
+				return { details: { mode: "single", results: [{ agent: "reviewer", exitCode: 0, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } }] } };
+			},
+		});
+		for (let index = 0; index < 8_192; index++) {
+			events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, {
+				version: 2,
+				requestId: `attempt-${index}`,
+				ownerRunId: "saturated-owner",
+				nodeId: `node-${index}`,
+			});
+		}
+
+		const retainedPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+			...v2Request,
+			requestId: "attempt-0",
+			ownerRunId: "saturated-owner",
+			nodeId: "node-0",
+		});
+		assert.equal((await retainedPromise as SubagentDelegationV2Response).status, "cancelled");
+
+		const overflowPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+			...v2Request,
+			requestId: "overflow-attempt",
+			ownerRunId: "saturated-owner",
+			nodeId: "overflow-node",
+		});
+		const overflow = await overflowPromise as SubagentDelegationV2Response;
+		assert.equal(overflow.status, "unavailable_context");
+		assert.match(overflow.error ?? "", /identity capacity/i);
+		assert.equal(executeCalls, 0);
+		bridge.dispose();
+	});
+
+	it("fails closed when settled v2 identity history reaches capacity", async () => {
+		const events = new FakeEvents();
+		const responses: SubagentDelegationV2Response[] = [];
+		let executeCalls = 0;
+		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationV2Response));
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async (requestId) => {
+				executeCalls++;
+				return { details: { mode: "single", results: [{ agent: "reviewer", exitCode: 0, finalOutput: requestId }] } };
+			},
+		});
+		for (let index = 0; index < 8_192; index++) {
+			events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+				...v2Request,
+				requestId: `settled-${index}`,
+				ownerRunId: "settled-owner",
+				nodeId: `settled-node-${index}`,
+				result: { kind: "text" },
+			});
+		}
+		for (let attempt = 0; responses.length < 8_192 && attempt < 100; attempt++) await tick();
+		assert.equal(responses.length, 8_192);
+		assert.equal(executeCalls, 8_192);
+
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+			...v2Request,
+			requestId: "settled-overflow",
+			ownerRunId: "settled-owner",
+			nodeId: "settled-overflow-node",
+			result: { kind: "text" },
+		});
+		await tick();
+		assert.equal(responses.at(-1)?.status, "unavailable_context");
+		assert.equal(executeCalls, 8_192);
+
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+			...v2Request,
+			requestId: "settled-0",
+			ownerRunId: "settled-owner",
+			nodeId: "settled-node-0",
+			result: { kind: "text" },
+		});
+		await tick();
+		assert.equal(responses.length, 8_193);
+		assert.equal(executeCalls, 8_192);
 		bridge.dispose();
 	});
 

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -57,6 +57,7 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.equal(backgroundWork.BACKGROUND_WORK_REGISTRY_KEY, "pi-subagents.background-work.v1");
 	const delegation = await import("pi-subagents/delegation");
 	assert.equal(delegation.SUBAGENT_DELEGATION_PROTOCOL_VERSION, 1);
+	assert.equal(delegation.SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION, 2);
 	assert.equal(delegation.SUBAGENT_DELEGATION_REQUEST_EVENT, "prompt-template:subagent:request");
 });
 

--- a/test/unit/tool-budget.test.ts
+++ b/test/unit/tool-budget.test.ts
@@ -23,6 +23,17 @@ describe("tool-budget module", () => {
 		assert.deepEqual(resolved.budget, { soft: 2, hard: 4, block: "*" });
 	});
 
+	it("accepts a zero hard limit only when the internal minimum opts in", () => {
+		assert.deepEqual(
+			validateToolBudgetConfig({ hard: 0, block: "*" }, "toolBudget", { minimumHard: 0 }).budget,
+			{ hard: 0, block: "*" },
+		);
+		assert.equal(
+			validateToolBudgetConfig({ soft: 0, hard: 0, block: "*" }, "toolBudget", { minimumHard: 0 }).error,
+			"toolBudget.soft must be an integer >= 1 when provided.",
+		);
+	});
+
 	it("rejects unsafe configs", () => {
 		assert.equal(validateToolBudgetConfig({ hard: 0 }).error, "toolBudget.hard must be an integer >= 1.");
 		assert.equal(validateToolBudgetConfig({ soft: 5, hard: 4 }).error, "toolBudget.soft must be <= toolBudget.hard.");
@@ -33,6 +44,8 @@ describe("tool-budget module", () => {
 	it("serializes and decodes env config", () => {
 		const budget = { soft: 2, hard: 4, block: ["read"] };
 		assert.deepEqual(decodeToolBudgetEnv(encodeToolBudgetEnv(budget)), budget);
+		const zeroBudget = { hard: 0, block: "*" as const };
+		assert.deepEqual(decodeToolBudgetEnv(encodeToolBudgetEnv(zeroBudget)), zeroBudget);
 	});
 
 	it("tracks state and block decisions", () => {
@@ -42,6 +55,7 @@ describe("tool-budget module", () => {
 		assert.equal(toolBudgetState(budget, 4, "read").outcome, "hard-blocked");
 		assert.equal(shouldBlockToolForBudget(budget, "read", 4), true);
 		assert.equal(shouldBlockToolForBudget(budget, "write", 4), false);
+		assert.equal(shouldBlockToolForBudget({ hard: 0, block: "*" }, "read", 1), true);
 	});
 
 	it("formats user-facing budget messages", () => {


### PR DESCRIPTION
## Summary
- add a public delegation v2 contract for workflow supervisors over the existing prompt-template event family
- preserve delegation v1 and the model-facing one-foreground-call guard while routing owned leaves through the concurrent delegated executor
- make attempt identity, cancellation, result mode, accounting, and boundary failures explicit and fail-closed

## Changes
- exports protocol-v2 request, started, update, response, cancellation, usage, thinking, and typed-result contracts from `pi-subagents/delegation`
- keys attempts by `(requestId, ownerRunId, nodeId)` and active logical nodes by `(ownerRunId, nodeId)`
- supports exact cancellation and cancel-before-start, `duplicate_node`, literal text vs schema-validated structured output, effective model/thinking, and detailed usage
- applies strict field allowlists, safe plain-JSON cloning, UTF-8 payload bounds, a safe timer ceiling, and fail-closed bounded cancellation/settled identity history
- adds direct bridge tests plus registered-extension v1/v2 integration coverage and documents authority/security limits

## Test plan
- [x] `node --experimental-strip-types --test test/unit/delegation-api.test.ts test/unit/package-manifest.test.ts test/unit/prompt-template-bridge.test.ts` (40/40)
- [x] registered extension v1 and v2 delegation integration tests (2/2)
- [x] `npm run test:e2e` (2/2)
- [x] `npm pack --dry-run --ignore-scripts`
- [x] edited-file TypeScript diagnostics and `git diff --check`

## Baseline note
The broader upstream suite has existing timing-sensitive timeout/watchdog failures. The same chain/parallel timeout failures reproduced from an exact upstream-base worktree; the delegation-focused, registered-extension, package, and E2E gates above are green.