### PR TITLE
feat: add aggregate parallel handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added versioned aggregate handoff manifests for worktree-isolated parallel runs, including per-child status and output references, durable patch metadata, explicit cleanup outcomes, async status/result projection, and completion-delivery paths.
 - Added delegation v2 for extension-owned concurrent foreground leaves, with logical run/node ownership, exact per-attempt cancellation, explicit duplicate-node outcomes, literal or structured values, effective model/thinking metadata, detailed usage, and an exact zero-tool budget while preserving delegation v1 and the model-facing single-dispatch guard. Thanks to Jakub Neumann (@neumie) for #610.
 - Added acknowledged `steer` support to the extension RPC for exact-child async orchestration without recovery replacement. Thanks to Daan Bosch (@daanbosch) for #607.
 - Added a persistent below-editor FleetView with safe empty-editor navigation and a structured inspector for Markdown, code, tool calls, and compact or expanded tool results. Thanks to Rui Pu (@Zeppelinpp) for #587.

--- a/README.md
+++ b/README.md
@@ -1383,7 +1383,7 @@ Requirements:
 
 By default, worktrees are created under the system temp directory. Set `worktreeBaseDir` in config, or `PI_SUBAGENTS_WORKTREE_DIR` when config is unset, to put them under a stable trusted directory. Missing base directories are created automatically.
 
-After a worktree parallel step completes, per-agent diff stats are appended to the output and full patch files are written to artifacts. Worktrees and temp branches are cleaned up in `finally` blocks.
+After a worktree parallel step completes, per-agent diff stats are appended to the output and full patch files are written to artifacts. The runtime also writes a versioned aggregate handoff manifest: foreground runs use the artifact directory's `handoffs/<run-id>.json`, while async runs use `<async-dir>/handoff.json`. The manifest records each child's terminal status, summary, output/session/structured-output references, patch stats and path, and whether its worktree and temporary branch were actually removed. Foreground `details`, async `status.json` and result files, status output, intercom delivery, and completion notifications expose the manifest path. Worktrees and temp branches still receive best-effort fallback cleanup if handoff finalization cannot run.
 
 ## Configuration
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -519,8 +519,12 @@ subagent({
 
 `worktree: true` gives each parallel task its own git worktree branched from
 HEAD. This requires a clean git state and is mainly for intentionally parallel
-write workflows. If you want one writer thread and several advisory agents,
-prefer a single-writer pattern instead.
+write workflows. On completion, use the `parallelHandoff.path` returned in
+foreground details or async status/results instead of scraping the combined
+text. Its versioned manifest records child status and output references, full
+patch paths and stats, and whether each temporary worktree and branch was
+removed. If you want one writer thread and several advisory agents, prefer a
+single-writer pattern instead.
 
 ## The Oracle Workflow
 

--- a/src/intercom/result-intercom.ts
+++ b/src/intercom/result-intercom.ts
@@ -5,6 +5,7 @@ import {
 	type IntercomEventBus,
 	type NestedRunSummary,
 	type PublicNestedRunSummary,
+	type ParallelHandoffReference,
 	type SingleResult,
 	type SubagentResultIntercomChild,
 	type SubagentResultIntercomPayload,
@@ -179,6 +180,7 @@ interface GroupedResultIntercomMessageInput {
 	asyncId?: string;
 	asyncDir?: string;
 	chainSteps?: number;
+	parallelHandoff?: ParallelHandoffReference;
 }
 
 function asyncResumeGuidance(input: {
@@ -207,6 +209,7 @@ function formatSubagentResultIntercomMessage(input: {
 	asyncId?: string;
 	asyncDir?: string;
 	chainSteps?: number;
+	parallelHandoff?: ParallelHandoffReference;
 }): string {
 	const counts = countStatuses(input.children);
 	const lines: string[] = [
@@ -222,6 +225,7 @@ function formatSubagentResultIntercomMessage(input: {
 	}
 	if (input.asyncId) lines.push(`Async id: ${input.asyncId}`);
 	if (input.asyncDir) lines.push(`Async dir: ${input.asyncDir}`);
+	if (input.parallelHandoff) lines.push(`Parallel handoff: ${input.parallelHandoff.path}`);
 	const resumeGuidance = asyncResumeGuidance(input);
 	if (resumeGuidance) lines.push(resumeGuidance);
 	if (input.children.some((child) => child.intercomTarget)) {
@@ -266,6 +270,7 @@ export function buildSubagentResultIntercomPayload(input: GroupedResultIntercomM
 		...(input.asyncId ? { asyncId: input.asyncId } : {}),
 		...(input.asyncDir ? { asyncDir: input.asyncDir } : {}),
 		...(typeof input.chainSteps === "number" ? { chainSteps: input.chainSteps } : {}),
+		...(input.parallelHandoff ? { parallelHandoff: input.parallelHandoff } : {}),
 		...(firstChild?.agent ? { agent: firstChild.agent } : {}),
 		...(firstChild?.index !== undefined ? { index: firstChild.index } : {}),
 		...(firstChild?.artifactPath ? { artifactPath: firstChild.artifactPath } : {}),
@@ -351,6 +356,8 @@ export function formatSubagentResultReceipt(input: {
 		`Run: ${input.runId}`,
 		`Children: ${formatStatusCounts(counts)}`,
 	];
+
+	if (input.payload.parallelHandoff) lines.push(`Parallel handoff: ${input.payload.parallelHandoff.path}`);
 
 	const artifacts = input.payload.children.filter((child) => typeof child.artifactPath === "string");
 	if (artifacts.length > 0) {

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -14,7 +14,7 @@ import {
 	createCompletionBatcher,
 	resolveCompletionBatchConfig,
 } from "./completion-batcher.ts";
-import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT, type SubagentState } from "../../shared/types.ts";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT, type ParallelHandoffReference, type SubagentState } from "../../shared/types.ts";
 
 export interface SubagentNotifyDetails {
 	agent: string;
@@ -25,6 +25,7 @@ export interface SubagentNotifyDetails {
 	durationMs?: number;
 	sessionLabel?: string;
 	sessionValue?: string;
+	handoffPath?: string;
 }
 
 export interface CompletionNotification {
@@ -47,6 +48,7 @@ export interface CompletionNotification {
 	totalTasks?: number;
 	sessionId?: string | null;
 	triggerTurn?: boolean;
+	parallelHandoff?: ParallelHandoffReference;
 }
 
 interface NotifyTimerApi {
@@ -77,6 +79,8 @@ export function formatSingleCompletion(details: SubagentNotifyDetails): string {
 		`${taskKind} ${details.status}: **${details.agent}**${details.taskInfo ?? ""}`,
 		"",
 		details.resultPreview.trim() ? details.resultPreview : "(no output)",
+		details.handoffPath ? "" : undefined,
+		details.handoffPath ? `Parallel handoff: ${details.handoffPath}` : undefined,
 		sessionLine ? "" : undefined,
 		sessionLine,
 	]
@@ -97,7 +101,12 @@ export function parseSubagentNotifyContent(content: string): SubagentNotifyDetai
 		}
 	}
 	const sessionLine = sessionIndex >= 0 ? body[sessionIndex] : undefined;
-	const resultPreview = (sessionIndex >= 0 ? body.slice(0, sessionIndex) : body).join("\n").trim() || "(no output)";
+	const handoffIndex = body.findIndex((line) => line.startsWith("Parallel handoff: "));
+	const metadataIndexes = [sessionIndex, handoffIndex].filter((index) => index >= 0);
+	const firstMetadataIndex = metadataIndexes.length ? Math.min(...metadataIndexes) : body.length;
+	const resultEnd = firstMetadataIndex > 0 && body[firstMetadataIndex - 1]?.trim() === "" ? firstMetadataIndex - 1 : firstMetadataIndex;
+	const resultPreview = body.slice(0, resultEnd).join("\n").trim() || "(no output)";
+	const handoffPath = handoffIndex >= 0 ? body[handoffIndex]!.slice("Parallel handoff: ".length).trim() : undefined;
 	let sessionLabel: string | undefined;
 	let sessionValue: string | undefined;
 	if (sessionLine) {
@@ -111,6 +120,7 @@ export function parseSubagentNotifyContent(content: string): SubagentNotifyDetai
 		...(match[1] === "Detached foreground task" ? { source: "foreground" as const } : {}),
 		...(match[4] ? { taskInfo: match[4] } : {}),
 		resultPreview,
+		...(handoffPath ? { handoffPath } : {}),
 		...(sessionLabel && sessionValue ? { sessionLabel, sessionValue } : {}),
 	};
 }
@@ -124,6 +134,7 @@ export function formatGroupedCompletion(details: SubagentNotifyDetails[]): strin
 		const sessionLine = formatSessionLine(detail);
 		blocks.push(`${index + 1}. ${detail.agent}${detail.taskInfo ?? ""}`);
 		blocks.push(detail.resultPreview.trim() ? detail.resultPreview : "(no output)");
+		if (detail.handoffPath) blocks.push(`Parallel handoff: ${detail.handoffPath}`);
 		if (sessionLine) blocks.push(sessionLine);
 		blocks.push("");
 	}
@@ -177,6 +188,10 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 			? ` (${result.taskIndex + 1}/${result.totalTasks})`
 			: undefined;
 
+	const parallelHandoff = result.parallelHandoff && typeof result.parallelHandoff === "object"
+		? result.parallelHandoff as { path?: unknown }
+		: undefined;
+	const handoffPath = typeof parallelHandoff?.path === "string" ? parallelHandoff.path : undefined;
 	const session =
 		result.shareUrl
 			? { label: "Session", value: result.shareUrl }
@@ -192,6 +207,7 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 		...(taskInfo ? { taskInfo } : {}),
 		resultPreview: summary,
 		...(typeof result.durationMs === "number" ? { durationMs: result.durationMs } : {}),
+		...(handoffPath ? { handoffPath } : {}),
 		...(session ? { sessionLabel: session.label, sessionValue: session.value } : {}),
 	};
 }

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -6,6 +6,7 @@ import {
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	type IntercomEventBus,
 	type NestedRunSummary,
+	type ParallelHandoffReference,
 	type SubagentResultIntercomChild,
 	type SubagentState,
 } from "../../shared/types.ts";
@@ -59,6 +60,7 @@ type ResultFileData = CompletionNotification & {
 	nestedChildren?: unknown;
 	asyncDir?: string;
 	intercomTarget?: string;
+	parallelHandoff?: ParallelHandoffReference;
 };
 
 function sanitizeNestedResultChildren(value: unknown, resultPath: string, label: string): NestedRunSummary[] | undefined {
@@ -211,6 +213,7 @@ export function createResultWatcher(
 					children: normalizedChildren,
 					asyncId: data.id,
 					asyncDir: data.asyncDir,
+					...(data.parallelHandoff ? { parallelHandoff: data.parallelHandoff } : {}),
 				}));
 				if (!ownsSession(data.sessionId, epoch)) return;
 				if (!delivered) console.error(`Subagent async grouped result intercom delivery was not acknowledged for '${resultPath}'.`);

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -366,6 +366,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				status.turnBudget ? `Turn budget: ${status.turnBudget.turnCount}/${status.turnBudget.maxTurns}+${status.turnBudget.graceTurns} (${status.turnBudget.outcome})` : undefined,
 				`Dir: ${asyncDir}`,
 				outputPath ? `Output: ${outputPath}` : undefined,
+				status.parallelHandoff ? `Parallel handoff: ${status.parallelHandoff.path}` : undefined,
 				reconciliation.message ? `Diagnosis: ${reconciliation.message}` : undefined,
 				reconciliation.resultPath && fs.existsSync(reconciliation.resultPath) ? `Result: ${reconciliation.resultPath}` : undefined,
 			].filter((line): line is string => Boolean(line));
@@ -408,7 +409,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 	if (resultPath) {
 		try {
 			const raw = fs.readFileSync(resultPath, "utf-8");
-			const data = JSON.parse(raw) as { id?: string; runId?: string; agent?: string; success?: boolean; summary?: string; output?: string; exitCode?: number; state?: string; sessionFile?: string; results?: Array<{ agent?: string; output?: string; summary?: string; sessionFile?: string; state?: string; success?: boolean; exitCode?: number | null }> };
+			const data = JSON.parse(raw) as { id?: string; runId?: string; agent?: string; success?: boolean; summary?: string; output?: string; exitCode?: number; state?: string; sessionFile?: string; parallelHandoff?: { path?: string }; results?: Array<{ agent?: string; output?: string; summary?: string; sessionFile?: string; state?: string; success?: boolean; exitCode?: number | null }> };
 			if (params.view === "transcript") {
 				try {
 					return { content: [{ type: "text", text: formatAsyncResultTranscript(data, resultPath, { index: params.index, lines: params.lines }) }], details: { mode: "single", results: [] } };
@@ -420,6 +421,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			const status = data.state === "stopped" ? "stopped" : data.success ? "complete" : data.state === "paused" || data.exitCode === 0 ? "paused" : "failed";
 			const runId = data.runId ?? data.id ?? resolvedId;
 			const lines = [`Run: ${runId}`, `State: ${status}`, `Result: ${resultPath}`];
+			if (data.parallelHandoff?.path) lines.push(`Parallel handoff: ${data.parallelHandoff.path}`);
 			const children = Array.isArray(data.results) ? data.results : data.agent ? [{ agent: data.agent, sessionFile: data.sessionFile }] : [];
 			lines.push(formatResumeGuidance(runId, children, data.sessionFile, { stopped: status === "stopped" }));
 			if (data.summary) lines.push("", data.summary);

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -99,6 +99,7 @@ import { waitForImportedAsyncRoot } from "./chain-root-attachment.ts";
 import { appendRunnerStepsToStatus, consumeChainAppendRequests, countPendingChainAppendRequests } from "./chain-append.ts";
 import { appendTurnBudgetSystemPrompt, formatTurnBudgetOutput, initialTurnBudgetState, turnBudgetDecision, turnBudgetDeferredNote, turnBudgetDeferredState, turnBudgetExceededMessage, turnBudgetSoftNote, turnBudgetState } from "../shared/turn-budget.ts";
 import { initialToolBudgetState, toolBudgetState } from "../shared/tool-budget.ts";
+import { formatParallelHandoffError, formatParallelHandoffReference, parallelHandoffPath, writeParallelHandoffGroup } from "../shared/parallel-handoff.ts";
 import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
 import { createBoundedByteTail, createBoundedLineReader, formatProtocolOutputLimit, MAX_CHILD_STDERR_BYTES, projectChildLifecycle, type ChildLifecycleAction, type ProtocolOutputLimit } from "../shared/child-protocol.ts";
 import { acquireSessionLease, type SessionLeaseRequest } from "../shared/session-lease.ts";
@@ -1544,19 +1545,15 @@ function prepareParallelTaskRun(
 	};
 }
 
-function appendParallelWorktreeSummary(
-	previousOutput: string,
-	worktreeSetup: WorktreeSetup | undefined,
+function captureParallelWorktreeDiffs(
+	worktreeSetup: WorktreeSetup,
 	asyncDir: string,
 	stepIndex: number,
 	group: Extract<RunnerStep, { parallel: SubagentStep[] }>,
-): string {
-	if (!worktreeSetup) return previousOutput;
+): { diffs: ReturnType<typeof diffWorktrees>; summary: string } {
 	const diffsDir = path.join(asyncDir, "worktree-diffs", `step-${stepIndex}`);
 	const diffs = diffWorktrees(worktreeSetup, group.parallel.map((task) => task.agent), diffsDir);
-	const diffSummary = formatWorktreeDiffSummary(diffs);
-	if (!diffSummary) return previousOutput;
-	return `${previousOutput}\n\n${diffSummary}`;
+	return { diffs, summary: formatWorktreeDiffSummary(diffs) };
 }
 
 function ensureParallelProgressFile(cwd: string, group: Extract<RunnerStep, { parallel: SubagentStep[] }>): void {
@@ -3131,6 +3128,7 @@ async function runSubagent(
 			const groupStartFlatIndex = flatIndex;
 			let aborted = false;
 			let worktreeSetup: WorktreeSetup | undefined;
+			let worktreeFinalized = false;
 			if (group.worktree) {
 				const worktreeTaskCwdConflict = findWorktreeTaskCwdConflict(group.parallel, cwd);
 				if (worktreeTaskCwdConflict) {
@@ -3421,7 +3419,39 @@ async function runSubagent(
 						attemptedModels: r.attemptedModels,
 					})),
 				);
-				previousOutput = appendParallelWorktreeSummary(previousOutput, worktreeSetup, asyncDir, stepIndex, group);
+				if (worktreeSetup) {
+					const captured = captureParallelWorktreeDiffs(worktreeSetup, asyncDir, stepIndex, group);
+					if (captured.summary) previousOutput = `${previousOutput}\n\n${captured.summary}`;
+					worktreeFinalized = true;
+					const cleanup = cleanupWorktrees(worktreeSetup);
+					try {
+						statusPayload.parallelHandoff = writeParallelHandoffGroup({
+							manifestPath: parallelHandoffPath(asyncDir),
+							runId: id,
+							mode: (config.resultMode ?? statusPayload.mode) === "parallel" ? "parallel" : "chain",
+							source: "async",
+							cwd,
+							stepIndex,
+							flatStartIndex: groupStartFlatIndex,
+							setup: worktreeSetup,
+							diffs: captured.diffs,
+							cleanup,
+							results: parallelResults.map((result) => ({
+								agent: result.agent,
+								status: result.stopped ? "stopped" : result.interrupted ? "paused" : result.exitCode === 0 ? "completed" : "failed",
+								summary: result.output || result.error || "(no output)",
+								...(result.artifactPaths?.outputPath ? { outputPath: result.artifactPaths.outputPath } : {}),
+								...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
+								...(result.structuredOutputPath ? { structuredOutputPath: result.structuredOutputPath } : {}),
+								...(result.sessionFile ? { sessionPath: result.sessionFile } : {}),
+							})),
+						});
+						previousOutput = `${previousOutput}\n\n${formatParallelHandoffReference(statusPayload.parallelHandoff)}`;
+					} catch (error) {
+						previousOutput = `${previousOutput}\n\n${formatParallelHandoffError(error)}`;
+					}
+					writeStatusPayload();
+				}
 
 				appendJsonl(eventsPath, JSON.stringify({
 					type: "subagent.parallel.completed",
@@ -3444,7 +3474,7 @@ async function runSubagent(
 					break;
 				}
 			} finally {
-				if (worktreeSetup) cleanupWorktrees(worktreeSetup);
+				if (worktreeSetup && !worktreeFinalized) cleanupWorktrees(worktreeSetup);
 			}
 		} else {
 			const seqStep = step as SubagentStep;
@@ -3845,6 +3875,7 @@ async function runSubagent(
 			})),
 			outputs,
 			workflowGraph: statusPayload.workflowGraph,
+			parallelHandoff: statusPayload.parallelHandoff,
 			exitCode: stopped || timedOut || turnBudgetExceeded ? 1 : interrupted || results.every((r) => r.success) ? 0 : 1,
 			timestamp: runEndedAt,
 			durationMs: runEndedAt - overallStartTime,

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -37,6 +37,7 @@ import { beginForegroundChild, finishForegroundChild, updateForegroundChild } fr
 import { buildChainSummary } from "../../shared/formatters.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
+import { formatParallelHandoffError, formatParallelHandoffReference, parallelHandoffPath, writeParallelHandoffGroup } from "../shared/parallel-handoff.ts";
 import { recordRun } from "../shared/run-history.ts";
 import {
 	cleanupWorktrees,
@@ -94,6 +95,7 @@ interface ChainExecutionDetailsInput {
 	currentFlatIndex?: number;
 	dynamicChildren?: Record<number, Array<{ agent: string; label?: string; flatIndex: number; itemKey: string; outputName?: string; structured?: boolean; error?: string }>>;
 	dynamicGroupStatuses?: Record<number, { status: "pending" | "running" | "completed" | "failed" | "paused" | "stopped" | "detached"; error?: string; acceptance?: SingleResult["acceptance"] }>;
+	parallelHandoff?: Details["parallelHandoff"];
 }
 
 interface ParallelChainRunInput {
@@ -161,6 +163,7 @@ function buildChainExecutionDetails(input: ChainExecutionDetailsInput): Details 
 		outputs: input.outputs,
 		totalChildUsage: sumResultsUsage(input.results),
 		totalCost: sumResultsCost(input.results),
+		...(input.parallelHandoff ? { parallelHandoff: input.parallelHandoff } : {}),
 		workflowGraph: buildWorkflowGraphSnapshot({
 			runId: input.runId,
 			mode: "chain",
@@ -194,17 +197,48 @@ function ensureParallelProgressFile(
 	return true;
 }
 
-function appendParallelWorktreeSummary(
-	output: string,
-	worktreeSetup: WorktreeSetup | undefined,
-	diffsDir: string,
-	agents: string[],
-): string {
-	if (!worktreeSetup) return output;
-	const diffs = diffWorktrees(worktreeSetup, agents, diffsDir);
+function finalizeParallelWorktreeHandoff(input: {
+	output: string;
+	worktreeSetup: WorktreeSetup;
+	artifactsDir: string;
+	runId: string;
+	cwd: string;
+	stepIndex: number;
+	flatStartIndex: number;
+	agents: string[];
+	results: SingleResult[];
+}): { output: string; reference?: NonNullable<Details["parallelHandoff"]> } {
+	const diffs = diffWorktrees(input.worktreeSetup, input.agents, path.join(input.artifactsDir, "worktree-diffs", input.runId, `step-${input.stepIndex}`));
+	const cleanup = cleanupWorktrees(input.worktreeSetup);
 	const diffSummary = formatWorktreeDiffSummary(diffs);
-	if (!diffSummary) return output;
-	return `${output}\n\n${diffSummary}`;
+	try {
+		const reference = writeParallelHandoffGroup({
+			manifestPath: parallelHandoffPath(input.artifactsDir, input.runId),
+			runId: input.runId,
+			mode: "chain",
+			source: "foreground",
+			cwd: input.cwd,
+			stepIndex: input.stepIndex,
+			flatStartIndex: input.flatStartIndex,
+			setup: input.worktreeSetup,
+			diffs,
+			cleanup,
+			results: input.results.map((result) => ({
+				agent: result.agent,
+				status: result.stopped ? "stopped" : result.detached ? "detached" : result.interrupted ? "paused" : result.exitCode === 0 ? "completed" : "failed",
+				summary: getSingleResultOutput(result) || result.error || "(no output)",
+				...(result.artifactPaths?.outputPath ? { outputPath: result.artifactPaths.outputPath } : {}),
+				...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
+				...(result.structuredOutputPath ? { structuredOutputPath: result.structuredOutputPath } : {}),
+				...(result.sessionFile ? { sessionPath: result.sessionFile } : {}),
+			})),
+		});
+		const suffix = [diffSummary, formatParallelHandoffReference(reference)].filter(Boolean).join("\n\n");
+		return { output: suffix ? `${input.output}\n\n${suffix}` : input.output, reference };
+	} catch (error) {
+		const suffix = [diffSummary, formatParallelHandoffError(error)].filter(Boolean).join("\n\n");
+		return { output: suffix ? `${input.output}\n\n${suffix}` : input.output };
+	}
 }
 
 function resolveChainToolBudget(input: { stepBudget?: ToolBudgetConfig; runBudget?: ResolvedToolBudget; agentBudget?: ToolBudgetConfig; configBudget?: ToolBudgetConfig }): { toolBudget?: ResolvedToolBudget; error?: string } {
@@ -490,6 +524,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 	const dynamicGroupStatuses: ChainExecutionDetailsInput["dynamicGroupStatuses"] = {};
 	const allProgress: AgentProgress[] = [];
 	const allArtifactPaths: ArtifactPaths[] = [];
+	let parallelHandoff: Details["parallelHandoff"];
 
 	const chainAgents: string[] = chainSteps.map((step) =>
 		isParallelStep(step)
@@ -513,6 +548,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 		outputs,
 		dynamicChildren,
 		dynamicGroupStatuses,
+		...(parallelHandoff ? { parallelHandoff } : {}),
 		...overrides,
 	});
 
@@ -644,6 +680,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			const parallelTemplates = stepTemplates as string[];
 			const parallelCwd = resolveChildCwd(cwd ?? ctx.cwd, step.cwd);
 			let worktreeSetup: WorktreeSetup | undefined;
+			let worktreeFinalized = false;
 			if (step.worktree) {
 				const worktreeTaskCwdConflict = findWorktreeTaskCwdConflict(step.parallel, parallelCwd);
 				if (worktreeTaskCwdConflict) {
@@ -739,6 +776,23 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					if (result.progress) allProgress.push(result.progress);
 					if (result.artifactPaths) allArtifactPaths.push(result.artifactPaths);
 				}
+				let worktreeSuffix = "";
+				if (worktreeSetup) {
+					worktreeFinalized = true;
+					const finalized = finalizeParallelWorktreeHandoff({
+						output: "",
+						worktreeSetup,
+						artifactsDir,
+						runId,
+						cwd: parallelCwd,
+						stepIndex,
+						flatStartIndex: globalTaskIndex - step.parallel.length,
+						agents: agentNames,
+						results: parallelResults,
+					});
+					if (finalized.reference) parallelHandoff = finalized.reference;
+					worktreeSuffix = finalized.output.trim();
+				}
 				const interruptedIndexInStep = parallelResults.findIndex((result) => result.interrupted);
 				const interrupted = interruptedIndexInStep >= 0 ? parallelResults[interruptedIndexInStep] : undefined;
 				if (interrupted) {
@@ -824,14 +878,9 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					};
 				});
 				prev = aggregateParallelOutputs(taskResults);
-				prev = appendParallelWorktreeSummary(
-					prev,
-					worktreeSetup,
-					path.join(chainDir, "worktree-diffs", `step-${stepIndex}`),
-					agentNames,
-				);
+				if (worktreeSuffix) prev = `${prev}\n\n${worktreeSuffix}`;
 			} finally {
-				if (worktreeSetup) cleanupWorktrees(worktreeSetup);
+				if (worktreeSetup && !worktreeFinalized) cleanupWorktrees(worktreeSetup);
 			}
 		} else if (isDynamicParallelStep(step)) {
 			const dynamicStartIndex = globalTaskIndex;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -52,6 +52,7 @@ import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOut
 import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
+import { formatParallelHandoffError, formatParallelHandoffReference, parallelHandoffPath, writeParallelHandoffGroup } from "../shared/parallel-handoff.ts";
 import { summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
 import {
 	attachNestedChildrenToResultChildren,
@@ -1408,6 +1409,7 @@ async function emitForegroundResultIntercom(input: {
 	results: SingleResult[];
 	chainSteps?: number;
 	nestedChildren?: NestedRunSummary[];
+	parallelHandoff?: Details["parallelHandoff"];
 }): Promise<ReturnType<typeof buildSubagentResultIntercomPayload> | null> {
 	if (!input.intercomBridge.active || !input.intercomBridge.orchestratorTarget) return null;
 	const children = input.results.flatMap((result, index) => result.detached ? [] : [{
@@ -1431,6 +1433,7 @@ async function emitForegroundResultIntercom(input: {
 		source: "foreground",
 		children: attachNestedChildrenToResultChildren(input.runId, children, input.nestedChildren),
 		...(typeof input.chainSteps === "number" ? { chainSteps: input.chainSteps } : {}),
+		...(input.parallelHandoff ? { parallelHandoff: input.parallelHandoff } : {}),
 	});
 	const delivered = await deliverSubagentResultIntercomEvent(input.pi.events, payload);
 	if (!delivered) return null;
@@ -1453,6 +1456,7 @@ async function maybeBuildForegroundIntercomReceipt(input: {
 		results: input.details.results,
 		...(typeof input.details.totalSteps === "number" ? { chainSteps: input.details.totalSteps } : {}),
 		...(input.nestedChildren?.length ? { nestedChildren: input.nestedChildren } : {}),
+		...(input.details.parallelHandoff ? { parallelHandoff: input.details.parallelHandoff } : {}),
 	});
 	if (!payload) return null;
 	return {
@@ -2467,15 +2471,52 @@ function resolveParallelTaskCwd(
 	return resolveChildCwd(paramsCwd, task.cwd);
 }
 
-function buildParallelWorktreeSuffix(
-	worktreeSetup: WorktreeSetup | undefined,
-	artifactsDir: string,
-	tasks: TaskParam[],
-): string {
-	if (!worktreeSetup) return "";
-	const diffsDir = path.join(artifactsDir, "worktree-diffs");
-	const diffs = diffWorktrees(worktreeSetup, tasks.map((task) => task.agent), diffsDir);
-	return formatWorktreeDiffSummary(diffs);
+function finalizeParallelWorktreeHandoff(input: {
+	worktreeSetup: WorktreeSetup;
+	artifactsDir: string;
+	runId: string;
+	cwd: string;
+	tasks: TaskParam[];
+	results: SingleResult[];
+}): { suffix: string; reference?: NonNullable<Details["parallelHandoff"]> } {
+	const diffsDir = path.join(input.artifactsDir, "worktree-diffs", input.runId);
+	const diffs = diffWorktrees(input.worktreeSetup, input.tasks.map((task) => task.agent), diffsDir);
+	const cleanup = cleanupWorktrees(input.worktreeSetup);
+	const diffSummary = formatWorktreeDiffSummary(diffs);
+	try {
+		const reference = writeParallelHandoffGroup({
+			manifestPath: parallelHandoffPath(input.artifactsDir, input.runId),
+			runId: input.runId,
+			mode: "parallel",
+			source: "foreground",
+			cwd: input.cwd,
+			stepIndex: 0,
+			flatStartIndex: 0,
+			setup: input.worktreeSetup,
+			diffs,
+			cleanup,
+			results: input.results.map((result) => ({
+				agent: result.agent,
+				status: resolveSubagentResultStatus({
+					exitCode: result.exitCode,
+					interrupted: result.interrupted,
+					detached: result.detached,
+					state: result.stopped ? "stopped" : undefined,
+				}),
+				summary: resultSummaryForIntercom(result),
+				...(result.artifactPaths?.outputPath ? { outputPath: result.artifactPaths.outputPath } : {}),
+				...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
+				...(result.structuredOutputPath ? { structuredOutputPath: result.structuredOutputPath } : {}),
+				...(result.sessionFile ? { sessionPath: result.sessionFile } : {}),
+			})),
+		});
+		return {
+			suffix: [diffSummary, formatParallelHandoffReference(reference)].filter(Boolean).join("\n\n"),
+			reference,
+		};
+	} catch (error) {
+		return { suffix: [diffSummary, formatParallelHandoffError(error)].filter(Boolean).join("\n\n") };
+	}
 }
 
 function findDuplicateParallelOutputPath(input: {
@@ -2834,6 +2875,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 	);
 	if (errorResult) return errorResult;
 
+	let worktreeFinalized = false;
 	try {
 		const outputBaseDir = path.join(artifactsDir, "outputs", runId);
 		const duplicateOutputError = findDuplicateParallelOutputPath({
@@ -2923,6 +2965,11 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			updateForegroundNestedProjection(foregroundControl);
 			attachRootChildrenToSteps(runId, results, foregroundControl.nestedChildren);
 		}
+		let handoff: ReturnType<typeof finalizeParallelWorktreeHandoff> | undefined;
+		if (worktreeSetup) {
+			worktreeFinalized = true;
+			handoff = finalizeParallelWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: effectiveCwd, tasks, results });
+		}
 		const interrupted = results.find((result) => result.interrupted);
 		const details = compactForegroundDetails({
 			mode: "parallel",
@@ -2932,6 +2979,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			artifacts: allArtifactPaths.length ? { dir: artifactsDir, files: allArtifactPaths } : undefined,
 			totalChildUsage: sumResultsUsage(results),
 			totalCost: sumResultsCost(results),
+			...(handoff?.reference ? { parallelHandoff: handoff.reference } : {}),
 		});
 		rememberForegroundRun(deps.state, { runId, mode: "parallel", cwd: effectiveCwd, sessionId: data.parentSessionId, results: details.results });
 		if (interrupted) {
@@ -2965,7 +3013,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			};
 		}
 
-		const worktreeSuffix = buildParallelWorktreeSuffix(worktreeSetup, artifactsDir, tasks);
+		const worktreeSuffix = handoff?.suffix ?? "";
 		const ok = results.filter((result) => result.exitCode === 0).length;
 		const downgradeNote = backgroundRequestedWhileClarifying ? " (background requested, but clarify kept this run foreground)" : "";
 		const aggregatedOutput = aggregateParallelOutputs(
@@ -2989,7 +3037,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			details,
 		};
 	} finally {
-		if (worktreeSetup) cleanupWorktrees(worktreeSetup);
+		if (worktreeSetup && !worktreeFinalized) cleanupWorktrees(worktreeSetup);
 	}
 }
 

--- a/src/runs/shared/parallel-handoff.ts
+++ b/src/runs/shared/parallel-handoff.ts
@@ -1,0 +1,154 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import type {
+	ParallelHandoffGroup,
+	ParallelHandoffManifest,
+	ParallelHandoffReference,
+	SubagentResultStatus,
+} from "../../shared/types.ts";
+import type {
+	WorktreeCleanupReport,
+	WorktreeDiff,
+	WorktreeSetup,
+} from "./worktree.ts";
+
+export interface ParallelHandoffResult {
+	agent: string;
+	status: SubagentResultStatus;
+	summary: string;
+	outputPath?: string;
+	structuredOutput?: unknown;
+	structuredOutputPath?: string;
+	sessionPath?: string;
+}
+
+function readManifest(manifestPath: string): ParallelHandoffManifest | undefined {
+	if (!fs.existsSync(manifestPath)) return undefined;
+	const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as ParallelHandoffManifest;
+	if (parsed.version !== 1 || !Array.isArray(parsed.groups)) {
+		throw new Error(`Invalid parallel handoff manifest: ${manifestPath}`);
+	}
+	return parsed;
+}
+
+function referenceFor(manifestPath: string, manifest: ParallelHandoffManifest): ParallelHandoffReference {
+	const children = manifest.groups.flatMap((group) => group.children);
+	return {
+		version: 1,
+		path: manifestPath,
+		groupCount: manifest.groups.length,
+		childCount: children.length,
+		changedPatches: children.filter((child) => child.patch.changed).length,
+		cleanupState: manifest.groups.every((group) => group.cleanup.state === "complete") ? "complete" : "partial",
+	};
+}
+
+function safeHandoffAgentName(agent: string): string {
+	return agent.replace(/[^\w.-]/g, "_");
+}
+
+function missingDiff(input: { manifestPath: string; stepIndex: number; taskIndex: number; agent: string; branch?: string }): WorktreeDiff {
+	const patchPath = path.join(path.dirname(input.manifestPath), `missing-diff-step-${input.stepIndex}-task-${input.taskIndex}-${safeHandoffAgentName(input.agent)}.patch`);
+	try {
+		fs.mkdirSync(path.dirname(patchPath), { recursive: true });
+		fs.writeFileSync(patchPath, "", "utf-8");
+	} catch {
+		// Handoff records the artifact failure below; patch creation remains best-effort.
+	}
+	return {
+		index: input.taskIndex,
+		agent: input.agent,
+		branch: input.branch ?? "",
+		diffStat: "",
+		filesChanged: 0,
+		insertions: 0,
+		deletions: 0,
+		patchPath,
+		error: "diff artifact unavailable; no patch was captured",
+	};
+}
+
+export function writeParallelHandoffGroup(input: {
+	manifestPath: string;
+	runId: string;
+	mode: "parallel" | "chain";
+	source: "foreground" | "async";
+	cwd: string;
+	stepIndex: number;
+	flatStartIndex: number;
+	setup: WorktreeSetup;
+	diffs: WorktreeDiff[];
+	cleanup: WorktreeCleanupReport;
+	results: ParallelHandoffResult[];
+	now?: number;
+}): ParallelHandoffReference {
+	const now = input.now ?? Date.now();
+	const existing = readManifest(input.manifestPath);
+	if (existing && (existing.runId !== input.runId || existing.mode !== input.mode || existing.source !== input.source)) {
+		throw new Error(`Parallel handoff manifest belongs to a different run: ${input.manifestPath}`);
+	}
+	const group: ParallelHandoffGroup = {
+		stepIndex: input.stepIndex,
+		baseCommit: input.setup.baseCommit,
+		repoRoot: input.setup.cwd,
+		children: input.results.map((result, taskIndex) => {
+			const diff = input.diffs[taskIndex] ?? missingDiff({
+				manifestPath: input.manifestPath,
+				stepIndex: input.stepIndex,
+				taskIndex,
+				agent: result.agent,
+				branch: input.setup.worktrees[taskIndex]?.branch,
+			});
+			return {
+				index: input.flatStartIndex + taskIndex,
+				taskIndex,
+				agent: result.agent,
+				status: result.status,
+				summary: result.summary,
+				...(result.outputPath ? { outputPath: result.outputPath } : {}),
+				...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
+				...(result.structuredOutputPath ? { structuredOutputPath: result.structuredOutputPath } : {}),
+				...(result.sessionPath ? { sessionPath: result.sessionPath } : {}),
+				patch: {
+					path: diff.patchPath,
+					branch: diff.branch,
+					changed: diff.filesChanged > 0 || diff.insertions > 0 || diff.deletions > 0 || diff.diffStat.trim().length > 0,
+					diffStat: diff.diffStat,
+					filesChanged: diff.filesChanged,
+					insertions: diff.insertions,
+					deletions: diff.deletions,
+					...(diff.error ? { error: diff.error } : {}),
+				},
+			};
+		}),
+		cleanup: input.cleanup,
+	};
+	const groups = existing?.groups.filter((candidate) => candidate.stepIndex !== input.stepIndex) ?? [];
+	groups.push(group);
+	groups.sort((left, right) => left.stepIndex - right.stepIndex);
+	const manifest: ParallelHandoffManifest = {
+		version: 1,
+		runId: input.runId,
+		mode: input.mode,
+		source: input.source,
+		cwd: input.cwd,
+		createdAt: existing?.createdAt ?? now,
+		updatedAt: now,
+		groups,
+	};
+	writeAtomicJson(input.manifestPath, manifest);
+	return referenceFor(input.manifestPath, manifest);
+}
+
+export function parallelHandoffPath(baseDir: string, runId?: string): string {
+	return runId ? path.join(baseDir, "handoffs", `${runId}.json`) : path.join(baseDir, "handoff.json");
+}
+
+export function formatParallelHandoffReference(reference: ParallelHandoffReference): string {
+	return `Parallel handoff: ${reference.path} (${reference.childCount} children, ${reference.changedPatches} changed patches, cleanup ${reference.cleanupState})`;
+}
+
+export function formatParallelHandoffError(error: unknown): string {
+	return `Parallel handoff unavailable: ${error instanceof Error ? error.message : String(error)}`;
+}

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -18,7 +18,7 @@ interface WorktreeInfo {
 	syntheticPaths: string[];
 }
 
-interface WorktreeDiff {
+export interface WorktreeDiff {
 	index: number;
 	agent: string;
 	branch: string;
@@ -27,6 +27,23 @@ interface WorktreeDiff {
 	insertions: number;
 	deletions: number;
 	patchPath: string;
+	error?: string;
+}
+
+export interface WorktreeCleanupTask {
+	index: number;
+	path: string;
+	branch: string;
+	worktreeRemoved: boolean;
+	branchRemoved: boolean;
+	errors?: string[];
+}
+
+export interface WorktreeCleanupReport {
+	state: "complete" | "partial";
+	tasks: WorktreeCleanupTask[];
+	pruned: boolean;
+	errors?: string[];
 }
 
 interface WorktreeTaskCwdConflict {
@@ -426,7 +443,7 @@ function removeSyntheticPathsBeforeDiff(worktree: WorktreeInfo): void {
 	}
 }
 
-function emptyDiff(index: number, agent: string, branch: string, patchPath: string): WorktreeDiff {
+function emptyDiff(index: number, agent: string, branch: string, patchPath: string, error?: string): WorktreeDiff {
 	return {
 		index,
 		agent,
@@ -436,6 +453,7 @@ function emptyDiff(index: number, agent: string, branch: string, patchPath: stri
 		insertions: 0,
 		deletions: 0,
 		patchPath,
+		...(error ? { error } : {}),
 	};
 }
 
@@ -497,13 +515,30 @@ function writeEmptyPatch(patchPath: string): void {
 	}
 }
 
-function cleanupSingleWorktree(repoCwd: string, worktree: WorktreeInfo): void {
-	try { runGitChecked(repoCwd, ["worktree", "remove", "--force", worktree.path]); } catch {
-		// Cleanup is best-effort to avoid masking caller errors.
+function cleanupSingleWorktree(repoCwd: string, worktree: WorktreeInfo): WorktreeCleanupTask {
+	const errors: string[] = [];
+	let worktreeRemoved = false;
+	let branchRemoved = false;
+	try {
+		runGitChecked(repoCwd, ["worktree", "remove", "--force", worktree.path]);
+		worktreeRemoved = true;
+	} catch (error) {
+		errors.push(`worktree removal failed: ${error instanceof Error ? error.message : String(error)}`);
 	}
-	try { runGitChecked(repoCwd, ["branch", "-D", worktree.branch]); } catch {
-		// Cleanup is best-effort to avoid masking caller errors.
+	try {
+		runGitChecked(repoCwd, ["branch", "-D", worktree.branch]);
+		branchRemoved = true;
+	} catch (error) {
+		errors.push(`branch removal failed: ${error instanceof Error ? error.message : String(error)}`);
 	}
+	return {
+		index: worktree.index,
+		path: worktree.path,
+		branch: worktree.branch,
+		worktreeRemoved,
+		branchRemoved,
+		...(errors.length ? { errors } : {}),
+	};
 }
 
 function hasWorktreeChanges(diff: WorktreeDiff): boolean {
@@ -560,23 +595,37 @@ export function diffWorktrees(setup: WorktreeSetup, agents: string[], diffsDir: 
 		const patchPath = path.join(diffsDir, `task-${index}-${safePatchAgentName(agent)}.patch`);
 		try {
 			diffs.push(captureWorktreeDiff(setup, worktree, agent, patchPath));
-		} catch {
-			// Preserve execution flow; failed diff capture maps to an empty per-task patch.
+		} catch (error) {
+			// Preserve execution flow while retaining the failed capture as handoff evidence.
 			writeEmptyPatch(patchPath);
-			diffs.push(emptyDiff(index, agent, worktree.branch, patchPath));
+			diffs.push(emptyDiff(index, agent, worktree.branch, patchPath, error instanceof Error ? error.message : String(error)));
 		}
 	}
 
 	return diffs;
 }
 
-export function cleanupWorktrees(setup: WorktreeSetup): void {
+export function cleanupWorktrees(setup: WorktreeSetup): WorktreeCleanupReport {
+	const tasks: WorktreeCleanupTask[] = [];
 	for (let index = setup.worktrees.length - 1; index >= 0; index--) {
-		cleanupSingleWorktree(setup.cwd, setup.worktrees[index]!);
+		tasks.push(cleanupSingleWorktree(setup.cwd, setup.worktrees[index]!));
 	}
-	try { runGitChecked(setup.cwd, ["worktree", "prune"]); } catch {
-		// Pruning is best-effort cleanup.
+	tasks.sort((left, right) => left.index - right.index);
+	const errors: string[] = [];
+	let pruned = false;
+	try {
+		runGitChecked(setup.cwd, ["worktree", "prune"]);
+		pruned = true;
+	} catch (error) {
+		errors.push(`worktree prune failed: ${error instanceof Error ? error.message : String(error)}`);
 	}
+	const state = tasks.every((task) => task.worktreeRemoved && task.branchRemoved) && pruned ? "complete" : "partial";
+	return {
+		state,
+		tasks,
+		pruned,
+		...(errors.length ? { errors } : {}),
+	};
 }
 
 export function formatWorktreeDiffSummary(diffs: WorktreeDiff[]): string {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -216,6 +216,72 @@ export interface ControlEvent {
 export type SubagentResultStatus = "completed" | "failed" | "paused" | "stopped" | "detached";
 export type SubagentRunMode = "single" | "parallel" | "chain";
 
+export interface ParallelHandoffPatch {
+	path: string;
+	branch: string;
+	changed: boolean;
+	diffStat: string;
+	filesChanged: number;
+	insertions: number;
+	deletions: number;
+	error?: string;
+}
+
+export interface ParallelHandoffChild {
+	index: number;
+	taskIndex: number;
+	agent: string;
+	status: SubagentResultStatus;
+	summary: string;
+	outputPath?: string;
+	structuredOutput?: unknown;
+	structuredOutputPath?: string;
+	sessionPath?: string;
+	patch: ParallelHandoffPatch;
+}
+
+export interface ParallelHandoffCleanupTask {
+	index: number;
+	path: string;
+	branch: string;
+	worktreeRemoved: boolean;
+	branchRemoved: boolean;
+	errors?: string[];
+}
+
+export interface ParallelHandoffGroup {
+	stepIndex: number;
+	baseCommit: string;
+	repoRoot: string;
+	children: ParallelHandoffChild[];
+	cleanup: {
+		state: "complete" | "partial";
+		tasks: ParallelHandoffCleanupTask[];
+		pruned: boolean;
+		errors?: string[];
+	};
+}
+
+export interface ParallelHandoffManifest {
+	version: 1;
+	runId: string;
+	mode: "parallel" | "chain";
+	source: "foreground" | "async";
+	cwd: string;
+	createdAt: number;
+	updatedAt: number;
+	groups: ParallelHandoffGroup[];
+}
+
+export interface ParallelHandoffReference {
+	version: 1;
+	path: string;
+	groupCount: number;
+	childCount: number;
+	changedPatches: number;
+	cleanupState: "complete" | "partial";
+}
+
 export interface AgentContract {
 	version: 1;
 }
@@ -404,6 +470,7 @@ export interface SubagentResultIntercomPayload {
 	index?: number;
 	artifactPath?: string;
 	sessionPath?: string;
+	parallelHandoff?: ParallelHandoffReference;
 }
 
 // ============================================================================
@@ -731,6 +798,7 @@ export interface Details {
 	// Aggregated cost across all agents in the run
 	totalCost?: CostSummary;
 	spawnBudget?: SpawnBudgetSnapshot;
+	parallelHandoff?: ParallelHandoffReference;
 }
 
 // ============================================================================
@@ -977,6 +1045,7 @@ export interface AsyncStatus {
 	totalCost?: CostSummary;
 	sessionFile?: string;
 	outputs?: ChainOutputMap;
+	parallelHandoff?: ParallelHandoffReference;
 }
 
 export type AsyncJobStep = NonNullable<AsyncStatus["steps"]>[number] & {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -49,6 +49,7 @@ interface AsyncResultPayload {
 	results: Array<{ agent?: string; output?: string; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string } }>;
 	outputs?: Record<string, { text?: string; structured?: unknown }>;
 	workflowGraph?: { nodes?: Array<{ kind?: string; label?: string; phase?: string; status?: string; acceptanceStatus?: string; error?: string; outputName?: string; structured?: boolean; children?: Array<{ label?: string; outputName?: string; itemKey?: string; status?: string; acceptanceStatus?: string; error?: string }> }> };
+	parallelHandoff?: { version?: number; path?: string; groupCount?: number; childCount?: number; changedPatches?: number; cleanupState?: string };
 }
 
 interface AsyncStatusPayload {
@@ -70,6 +71,7 @@ interface AsyncStatusPayload {
 	totalTokens?: { total: number };
 	totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
 	parallelGroups?: Array<{ start: number; count: number; stepIndex: number }>;
+	parallelHandoff?: { version?: number; path?: string; groupCount?: number; childCount?: number; changedPatches?: number; cleanupState?: string };
 	steps?: Array<{
 		label?: string;
 		phase?: string;
@@ -2083,7 +2085,24 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			const taskArg = args.at(-1) ?? "";
 			assert.ok(taskArg.includes(`[Read from: ${path.join(worktreeCwd, "input.md")}]`));
 			assert.ok(taskArg.includes(`Write your findings to exactly this path: ${path.join(repoDir, ".pi-subagents", "artifacts", "outputs", asyncId, "report.md")}`));
-			await waitForAsyncResultFile(asyncId, 90_000);
+			const resultPath = await waitForAsyncResultFile(asyncId, 90_000);
+			const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+			const status = JSON.parse(fs.readFileSync(path.join(result.details!.asyncDir!, "status.json"), "utf-8")) as AsyncStatusPayload;
+			assert.equal(payload.parallelHandoff?.version, 1);
+			assert.equal(payload.parallelHandoff?.path, path.join(result.details!.asyncDir!, "handoff.json"));
+			assert.deepEqual(status.parallelHandoff, payload.parallelHandoff);
+			assert.equal(payload.parallelHandoff?.childCount, 1);
+			assert.equal(payload.parallelHandoff?.cleanupState, "complete");
+			assert.equal(fs.existsSync(worktreeCwd), false, "temporary worktree should be removed before handoff publication");
+			const handoff = JSON.parse(fs.readFileSync(payload.parallelHandoff!.path!, "utf-8")) as {
+				version: number;
+				groups: Array<{ children: Array<{ agent: string; status: string; patch: { path: string } }>; cleanup: { state: string } }>;
+			};
+			assert.equal(handoff.version, 1);
+			assert.equal(handoff.groups[0]!.children[0]!.agent, "worker");
+			assert.equal(handoff.groups[0]!.children[0]!.status, "completed");
+			assert.equal(handoff.groups[0]!.cleanup.state, "complete");
+			assert.equal(fs.existsSync(handoff.groups[0]!.children[0]!.patch.path), true, "patch artifact should outlive cleanup");
 		} finally {
 			removeTempDir(repoDir);
 		}

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { MockPi } from "../support/helpers.ts";
@@ -116,6 +117,7 @@ interface ChainExecutionResult {
 		};
 		currentStepIndex?: number;
 		outputs?: Record<string, { text: string; structured?: unknown }>;
+		parallelHandoff?: { version: number; path: string; groupCount: number; childCount: number; cleanupState: string };
 	};
 }
 
@@ -1312,6 +1314,12 @@ describe("chain execution — parallel steps", { skip: !available ? "pi packages
 		};
 	}
 
+	function git(args: string[]): string {
+		const result = spawnSync("git", args, { cwd: tempDir, encoding: "utf-8" });
+		assert.equal(result.status, 0, result.stderr || result.stdout);
+		return result.stdout.trim();
+	}
+
 	function readCallArgs(index: number): string[] {
 		const callFiles = fs.readdirSync(mockPi.dir)
 			.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
@@ -1352,6 +1360,38 @@ describe("chain execution — parallel steps", { skip: !available ? "pi packages
 
 		assert.ok(!result.isError, `should succeed: ${JSON.stringify(result.content)}`);
 		assert.equal(result.details.results.length, 2);
+	});
+
+	it("aggregates worktree handoffs across foreground chain groups", { skip: process.platform === "win32" ? "worktree paths differ on Windows" : undefined }, async () => {
+		git(["init"]);
+		git(["config", "user.email", "test@example.com"]);
+		git(["config", "user.name", "Test User"]);
+		fs.writeFileSync(path.join(tempDir, "tracked.txt"), "base\n", "utf-8");
+		git(["add", "tracked.txt"]);
+		git(["commit", "-m", "initial"]);
+		mockPi.onCall({ output: "Parallel task done" });
+		const runId = "foreground-chain-handoff";
+		const artifactsDir = path.join(tempDir, "artifacts");
+		const result = await executeChain(
+			makeChainParams(
+				[{ parallel: [{ agent: "reviewer-a", task: "Review in isolation" }], worktree: true }],
+				[makeAgent("reviewer-a")],
+				{ runId, artifactsDir },
+			),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details.parallelHandoff?.version, 1);
+		assert.equal(result.details.parallelHandoff?.childCount, 1);
+		assert.equal(result.details.parallelHandoff?.cleanupState, "complete");
+		const handoff = JSON.parse(fs.readFileSync(result.details.parallelHandoff!.path, "utf-8")) as {
+			groups: Array<{ stepIndex: number; children: Array<{ agent: string; patch: { path: string } }>; cleanup: { state: string } }>;
+		};
+		assert.equal(handoff.groups[0]!.stepIndex, 0);
+		assert.equal(handoff.groups[0]!.children[0]!.agent, "reviewer-a");
+		assert.equal(handoff.groups[0]!.cleanup.state, "complete");
+		assert.equal(fs.existsSync(handoff.groups[0]!.children[0]!.patch.path), true);
+		assert.match(handoff.groups[0]!.children[0]!.patch.path, /worktree-diffs\/foreground-chain-handoff\/step-0\//);
 	});
 
 	it("aggregates parallel outputs for next sequential step", async () => {

--- a/test/integration/parallel-execution.test.ts
+++ b/test/integration/parallel-execution.test.ts
@@ -10,7 +10,9 @@
 
 import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { MockPi } from "../support/helpers.ts";
 import {
@@ -115,17 +117,24 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 	function makeExecutor(
 		agents = [makeAgent("echo")],
 		state = { baseCwd: tempDir, currentSessionId: null, asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null },
+		config: Record<string, unknown> = {},
 	) {
 		return createSubagentExecutor({
 			pi: { events: createEventBus(), getSessionName: () => undefined },
 			state,
-			config: {},
+			config,
 			asyncByDefault: false,
 			tempArtifactsDir: tempDir,
 			getSubagentSessionRoot: () => tempDir,
 			expandTilde: (value: string) => value,
 			discoverAgents: () => ({ agents }),
 		});
+	}
+
+	function git(args: string[]): string {
+		const result = spawnSync("git", args, { cwd: tempDir, encoding: "utf-8" });
+		assert.equal(result.status, 0, result.stderr || result.stdout);
+		return result.stdout.trim();
 	}
 
 	function readLastCallArgs(): string[] {
@@ -216,6 +225,80 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 		const result = await executionPromise;
 		assert.equal(result.isError, undefined);
 		assert.equal(state.foregroundControls.size, 0);
+	});
+
+	it("publishes a durable handoff before cleaning foreground parallel worktrees", { skip: !createSubagentExecutor || process.platform === "win32" ? "executor unavailable or worktree paths differ on Windows" : undefined }, async () => {
+		git(["init"]);
+		git(["config", "user.email", "test@example.com"]);
+		git(["config", "user.name", "Test User"]);
+		fs.writeFileSync(path.join(tempDir, "tracked.txt"), "base\n", "utf-8");
+		git(["add", "tracked.txt"]);
+		git(["commit", "-m", "initial"]);
+		mockPi.onCall({ output: "Worktree task complete" });
+		const executor = makeExecutor();
+		const result = await executor.execute(
+			"foreground-worktree-handoff",
+			{ tasks: [{ agent: "echo", task: "Work in isolation" }], worktree: true },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details?.parallelHandoff?.version, 1);
+		assert.equal(result.details?.parallelHandoff?.cleanupState, "complete");
+		assert.match(result.content[0]?.text ?? "", /Parallel handoff:/);
+		const handoffPath = result.details!.parallelHandoff!.path;
+		const handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as {
+			groups: Array<{ children: Array<{ agent: string; summary: string; patch: { path: string } }>; cleanup: { state: string; tasks: Array<{ path: string; worktreeRemoved: boolean; branchRemoved: boolean }> } }>;
+		};
+		assert.equal(handoff.groups[0]!.children[0]!.agent, "echo");
+		assert.equal(handoff.groups[0]!.children[0]!.summary, "Worktree task complete");
+		assert.equal(fs.existsSync(handoff.groups[0]!.children[0]!.patch.path), true);
+		assert.ok(result.details?.runId);
+		assert.ok(handoff.groups[0]!.children[0]!.patch.path.includes(`${path.sep}worktree-diffs${path.sep}${result.details.runId}${path.sep}`));
+		assert.equal(handoff.groups[0]!.cleanup.state, "complete");
+		assert.equal(handoff.groups[0]!.cleanup.tasks[0]!.worktreeRemoved, true);
+		assert.equal(handoff.groups[0]!.cleanup.tasks[0]!.branchRemoved, true);
+		assert.equal(fs.existsSync(handoff.groups[0]!.cleanup.tasks[0]!.path), false);
+	});
+
+	it("keeps worktree parallel runs successful when handoff manifest writing fails", { skip: !createSubagentExecutor || process.platform === "win32" ? "executor unavailable or worktree paths differ on Windows" : undefined }, async () => {
+		git(["init"]);
+		git(["config", "user.email", "test@example.com"]);
+		git(["config", "user.name", "Test User"]);
+		fs.writeFileSync(path.join(tempDir, "tracked.txt"), "base\n", "utf-8");
+		git(["add", "tracked.txt"]);
+		git(["commit", "-m", "initial"]);
+		const sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-session-"));
+		try {
+			const artifactsDir = path.join(sessionDir, "subagent-artifacts");
+			fs.mkdirSync(artifactsDir, { recursive: true });
+			fs.writeFileSync(path.join(artifactsDir, "handoffs"), "not a directory", "utf-8");
+			mockPi.onCall({ output: "Worktree task complete" });
+			const executor = makeExecutor([makeAgent("echo")], undefined, { artifactDir: "session" });
+			const ctx = {
+				...makeMinimalCtx(tempDir),
+				sessionManager: {
+					getSessionId: () => "session-123",
+					getSessionFile: () => path.join(sessionDir, "session.jsonl"),
+				},
+			};
+			const result = await executor.execute(
+				"foreground-worktree-handoff-collision",
+				{ tasks: [{ agent: "echo", task: "Work in isolation" }], worktree: true },
+				new AbortController().signal,
+				undefined,
+				ctx,
+			);
+
+			assert.equal(result.isError, undefined);
+			assert.equal(result.details?.parallelHandoff, undefined);
+			assert.match(result.content[0]?.text ?? "", /Parallel handoff unavailable:/);
+			assert.doesNotMatch(git(["worktree", "list", "--porcelain"]), /pi-parallel-/);
+		} finally {
+			fs.rmSync(sessionDir, { recursive: true, force: true });
+		}
 	});
 
 	it("treats parallel action aliases with tasks as top-level parallel execution", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -453,6 +453,7 @@ describe("result watcher", () => {
 					sessionId: "session-1",
 					sessionFile: "/tmp/session.jsonl",
 					asyncDir: "/tmp/async-1",
+					parallelHandoff: { version: 1, path: "/tmp/async-1/handoff.json", groupCount: 1, childCount: 2, changedPatches: 1, cleanupState: "complete" },
 					intercomTarget: "subagent-chat-main",
 				}), "utf-8");
 				watcher.primeExistingResults();
@@ -463,14 +464,17 @@ describe("result watcher", () => {
 
 			const intercomEvents = emitted.filter((entry) => entry.event === "subagent:result-intercom");
 			assert.equal(intercomEvents.length, 1);
-			const eventData = intercomEvents[0]?.data as { message?: string; mode?: string; status?: string };
+			const eventData = intercomEvents[0]?.data as { message?: string; mode?: string; status?: string; parallelHandoff?: { path?: string } };
 			assert.equal(eventData.mode, "parallel");
 			assert.equal(eventData.status, "failed");
+			assert.equal(eventData.parallelHandoff?.path, "/tmp/async-1/handoff.json");
 			const message = String(eventData.message ?? "");
 			assert.match(message, /Revive child: subagent\(\{ action: "resume", id: "async-1", index: 0, message: "\.\.\." \}\)/);
 			assert.ok(message.includes(`Session: ${firstSession}`));
+			assert.match(message, /Parallel handoff: \/tmp\/async-1\/handoff\.json/);
 			assert.equal(message.includes(missingSession), false);
-			assert.equal(emitted.some((entry) => entry.event === "subagent:async-complete"), true);
+			const completion = emitted.find((entry) => entry.event === "subagent:async-complete")?.data as { parallelHandoff?: { path?: string } } | undefined;
+			assert.equal(completion?.parallelHandoff?.path, "/tmp/async-1/handoff.json");
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -388,6 +388,33 @@ describe("registerSubagentNotify", () => {
 });
 
 describe("completion formatting helpers", () => {
+	it("formats and parses a parallel handoff without folding it into the result preview", () => {
+		const content = formatSingleCompletion({
+			agent: "worker",
+			status: "completed",
+			resultPreview: "Done",
+			handoffPath: "/tmp/run/handoff.json",
+			sessionLabel: "Session file",
+			sessionValue: "/tmp/session.jsonl",
+		});
+		assert.equal(content, "Background task completed: **worker**\n\nDone\n\nParallel handoff: /tmp/run/handoff.json\n\nSession file: /tmp/session.jsonl");
+		assert.deepEqual(parseSubagentNotifyContent(content), {
+			agent: "worker",
+			status: "completed",
+			resultPreview: "Done",
+			handoffPath: "/tmp/run/handoff.json",
+			sessionLabel: "session file",
+			sessionValue: "/tmp/session.jsonl",
+		});
+		assert.equal(buildCompletionDetails({
+			id: "run",
+			agent: "worker",
+			success: true,
+			summary: "Done",
+			parallelHandoff: { path: "/tmp/run/handoff.json" },
+		}).handoffPath, "/tmp/run/handoff.json");
+	});
+
 	it("formatSingleCompletion mirrors the in-handler single message shape", () => {
 		const content = formatSingleCompletion({
 			agent: "worker",

--- a/test/unit/parallel-handoff.test.ts
+++ b/test/unit/parallel-handoff.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import {
+	formatParallelHandoffReference,
+	writeParallelHandoffGroup,
+} from "../../src/runs/shared/parallel-handoff.ts";
+import type { ParallelHandoffManifest } from "../../src/shared/types.ts";
+import type { WorktreeCleanupReport, WorktreeDiff, WorktreeSetup } from "../../src/runs/shared/worktree.ts";
+
+function setup(repoRoot: string, baseCommit: string): WorktreeSetup {
+	return { cwd: repoRoot, baseCommit, worktrees: [] };
+}
+
+function diff(dir: string, index: number, agent: string, changed: boolean): WorktreeDiff {
+	const patchPath = path.join(dir, `task-${index}-${agent}.patch`);
+	fs.mkdirSync(path.dirname(patchPath), { recursive: true });
+	fs.writeFileSync(patchPath, changed ? "diff --git a/a b/a\n" : "", "utf-8");
+	return {
+		index,
+		agent,
+		branch: `branch-${index}`,
+		diffStat: changed ? " a | 1 +" : "",
+		filesChanged: changed ? 1 : 0,
+		insertions: changed ? 1 : 0,
+		deletions: 0,
+		patchPath,
+	};
+}
+
+function cleanup(state: "complete" | "partial" = "complete"): WorktreeCleanupReport {
+	return {
+		state,
+		pruned: state === "complete",
+		tasks: [{
+			index: 0,
+			path: "/tmp/worktree-0",
+			branch: "branch-0",
+			worktreeRemoved: true,
+			branchRemoved: state === "complete",
+			...(state === "partial" ? { errors: ["branch removal failed"] } : {}),
+		}],
+	};
+}
+
+describe("parallel handoff", () => {
+	it("writes and aggregates versioned worktree handoff groups", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-parallel-handoff-"));
+		try {
+			const manifestPath = path.join(dir, "handoff.json");
+			const first = writeParallelHandoffGroup({
+				manifestPath,
+				runId: "run-1",
+				mode: "chain",
+				source: "async",
+				cwd: "/repo",
+				stepIndex: 2,
+				flatStartIndex: 3,
+				setup: setup("/repo", "base-1"),
+				diffs: [diff(dir, 0, "worker", true)],
+				cleanup: cleanup(),
+				results: [{
+					agent: "worker",
+					status: "completed",
+					summary: "implemented",
+					outputPath: "/artifacts/output.md",
+					structuredOutput: { ok: true },
+					structuredOutputPath: "/artifacts/structured.json",
+					sessionPath: "/sessions/worker.jsonl",
+				}],
+				now: 100,
+			});
+			assert.deepEqual(first, {
+				version: 1,
+				path: manifestPath,
+				groupCount: 1,
+				childCount: 1,
+				changedPatches: 1,
+				cleanupState: "complete",
+			});
+
+			const second = writeParallelHandoffGroup({
+				manifestPath,
+				runId: "run-1",
+				mode: "chain",
+				source: "async",
+				cwd: "/repo",
+				stepIndex: 1,
+				flatStartIndex: 1,
+				setup: setup("/repo", "base-1"),
+				diffs: [diff(dir, 1, "reviewer", false)],
+				cleanup: cleanup("partial"),
+				results: [{ agent: "reviewer", status: "failed", summary: "blocked" }],
+				now: 200,
+			});
+			assert.equal(second.groupCount, 2);
+			assert.equal(second.childCount, 2);
+			assert.equal(second.changedPatches, 1);
+			assert.equal(second.cleanupState, "partial");
+			assert.match(formatParallelHandoffReference(second), /2 children, 1 changed patches, cleanup partial/);
+
+			const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as ParallelHandoffManifest;
+			assert.equal(manifest.createdAt, 100);
+			assert.equal(manifest.updatedAt, 200);
+			assert.deepEqual(manifest.groups.map((group) => group.stepIndex), [1, 2]);
+			assert.equal(manifest.groups[0]!.children[0]!.index, 1);
+			assert.equal(manifest.groups[1]!.children[0]!.index, 3);
+			assert.deepEqual(manifest.groups[1]!.children[0]!.structuredOutput, { ok: true });
+			assert.equal(manifest.groups[1]!.children[0]!.patch.changed, true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("records missing diff artifacts instead of throwing", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-parallel-handoff-missing-diff-"));
+		try {
+			const manifestPath = path.join(dir, "handoff.json");
+			const reference = writeParallelHandoffGroup({
+				manifestPath,
+				runId: "run-missing-diff",
+				mode: "parallel",
+				source: "foreground",
+				cwd: "/repo",
+				stepIndex: 0,
+				flatStartIndex: 0,
+				setup: {
+					...setup("/repo", "base-1"),
+					worktrees: [{ path: "/tmp/worktree-0", agentCwd: "/tmp/worktree-0", branch: "branch-0", index: 0, nodeModulesLinked: false, syntheticPaths: [] }],
+				},
+				diffs: [],
+				cleanup: cleanup(),
+				results: [{ agent: "bad/name agent", status: "completed", summary: "done" }],
+			});
+			assert.equal(reference.childCount, 1);
+			assert.equal(reference.changedPatches, 0);
+			const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as ParallelHandoffManifest;
+			const patch = manifest.groups[0]!.children[0]!.patch;
+			assert.equal(patch.changed, false);
+			assert.match(patch.error ?? "", /diff artifact unavailable/);
+			assert.equal(path.basename(patch.path), "missing-diff-step-0-task-0-bad_name_agent.patch");
+			assert.equal(fs.existsSync(patch.path), true);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects reusing a manifest path for another run", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-parallel-handoff-owner-"));
+		try {
+			const manifestPath = path.join(dir, "handoff.json");
+			const common = {
+				manifestPath,
+				mode: "parallel" as const,
+				source: "foreground" as const,
+				cwd: "/repo",
+				stepIndex: 0,
+				flatStartIndex: 0,
+				setup: setup("/repo", "base-1"),
+				diffs: [diff(dir, 0, "worker", false)],
+				cleanup: cleanup(),
+				results: [{ agent: "worker", status: "completed" as const, summary: "done" }],
+			};
+			writeParallelHandoffGroup({ ...common, runId: "run-1" });
+			assert.throws(
+				() => writeParallelHandoffGroup({ ...common, runId: "run-2" }),
+				/belongs to a different run/,
+			);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -246,8 +246,12 @@ describe("worktree", () => {
 			setup = createWorktrees(repoDir, "cleanup", 2);
 			const worktreePaths = setup.worktrees.map((worktree) => worktree.path);
 			const branches = setup.worktrees.map((worktree) => worktree.branch);
-			cleanupWorktrees(setup);
+			const cleanup = cleanupWorktrees(setup);
 			setup = undefined;
+			assert.equal(cleanup.state, "complete");
+			assert.equal(cleanup.pruned, true);
+			assert.equal(cleanup.tasks.length, 2);
+			assert.ok(cleanup.tasks.every((task) => task.worktreeRemoved && task.branchRemoved));
 
 			for (const worktreePath of worktreePaths) {
 				assert.equal(fs.existsSync(worktreePath), false, `worktree path still exists: ${worktreePath}`);


### PR DESCRIPTION
## Summary
- add versioned aggregate handoff manifests for worktree-isolated parallel runs
- include per-child result, patch, and cleanup metadata in foreground, chain, async, status, notify, and intercom surfaces
- keep handoff artifact failures best-effort so child execution and worktree cleanup still complete

## Validation
- node --experimental-strip-types --test test/unit/parallel-handoff.test.ts test/unit/notify.test.ts test/unit/worktree.test.ts
- node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/parallel-execution.test.ts test/integration/chain-execution.test.ts test/integration/async-execution.test.ts test/integration/result-watcher.test.ts
- npm run test:e2e
- npm pack --dry-run
- git diff --cached --check