### PR TITLE
fix: retain oversized event-line scan state

### DIFF
--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -150,7 +150,9 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		try {
 			const stat = fs.fstatSync(fd);
 			const savedCursor = job.controlEventCursor;
-			let cursor = stat.size < (savedCursor ?? 0) ? 0 : (savedCursor ?? 0);
+			const wasTruncated = stat.size < (savedCursor ?? 0);
+			if (wasTruncated) job.controlEventSkippingOversizedLine = false;
+			let cursor = wasTruncated ? 0 : (savedCursor ?? 0);
 			const startedFromTail = savedCursor === undefined && stat.size > CONTROL_EVENT_SCAN_WINDOW_BYTES;
 			if (startedFromTail) cursor = stat.size - CONTROL_EVENT_SCAN_WINDOW_BYTES;
 			if (stat.size <= cursor) return;
@@ -206,7 +208,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			let lastCompleteCursor = cursor;
 			let lineParts: Buffer[] = [];
 			let lineBytes = 0;
-			let skippingOversizedLine = startedFromTail;
+			let skippingOversizedLine = startedFromTail || job.controlEventSkippingOversizedLine === true;
 			const appendLineSegment = (segment: Buffer) => {
 				if (segment.length === 0 || skippingOversizedLine) return;
 				if (lineBytes + segment.length > MAX_CONTROL_EVENT_LINE_BYTES) {
@@ -234,6 +236,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 					lineParts = [];
 					lineBytes = 0;
 					skippingOversizedLine = false;
+					job.controlEventSkippingOversizedLine = false;
 					lastCompleteCursor = readCursor + index + 1;
 					lineStart = index + 1;
 				}
@@ -241,7 +244,10 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				readCursor += bytesRead;
 				if (skippingOversizedLine) job.controlEventCursor = readCursor;
 			}
-			if (lastCompleteCursor > cursor) job.controlEventCursor = lastCompleteCursor;
+			if (skippingOversizedLine) {
+				job.controlEventSkippingOversizedLine = true;
+				job.controlEventCursor = readCursor;
+			} else if (lastCompleteCursor > cursor) job.controlEventCursor = lastCompleteCursor;
 			else if (scanEnd < stat.size || startedFromTail) job.controlEventCursor = scanEnd;
 		} catch (error) {
 			console.error(`Failed to read async control events for '${job.asyncDir}':`, error);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1030,6 +1030,7 @@ export interface AsyncJobState {
 	totalTokens?: TokenUsage;
 	sessionFile?: string;
 	controlEventCursor?: number;
+	controlEventSkippingOversizedLine?: boolean;
 	nestedRoute?: NestedRouteInfo;
 	nestedChildren?: NestedRunSummary[];
 }

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -856,6 +856,112 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
+	it("skips oversized event lines across scan windows without malformed diagnostics", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-");
+		const originalError = console.error;
+		const errors: unknown[][] = [];
+		let tracker: { resetJobs(): void } | undefined;
+		console.error = (...args: unknown[]) => errors.push(args);
+		try {
+			const runDir = path.join(asyncRoot, "run-oversized-control");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-oversized-control",
+				mode: "single",
+				state: "running",
+				startedAt: Date.now() - 1000,
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "running" }],
+			}), "utf-8");
+			const oversizedEvent = JSON.stringify({ type: "entry_appended", entry: "x".repeat(2_200_000) });
+			const controlEvent = JSON.stringify({
+				type: "subagent.control",
+				channels: ["event"],
+				event: {
+					type: "needs_attention",
+					to: "needs_attention",
+					ts: 123,
+					runId: "run-oversized-control",
+					agent: "worker",
+					message: "worker needs attention",
+				},
+			});
+			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${oversizedEvent}\n${controlEvent}\n`, "utf-8");
+
+			const state = createState();
+			const recorder = createEventRecorder();
+			tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+			});
+			tracker.handleStarted({ id: "run-oversized-control", asyncDir: runDir, agent: "worker" });
+
+			await waitForCondition(
+				() => recorder.events.some((event) => event.channel === "subagent:control-event"),
+				"control event after oversized line",
+			);
+			assert.equal(errors.some((args) => String(args[0]).includes("Ignoring malformed async control event")), false);
+		} finally {
+			tracker?.resetJobs();
+			console.error = originalError;
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("resets oversized-line skip state when the event log is truncated", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-");
+		const originalError = console.error;
+		const errors: unknown[][] = [];
+		let tracker: { resetJobs(): void } | undefined;
+		console.error = (...args: unknown[]) => errors.push(args);
+		try {
+			const runDir = path.join(asyncRoot, "run-truncated-control");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-truncated-control",
+				mode: "single",
+				state: "running",
+				startedAt: Date.now() - 1000,
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "running" }],
+			}), "utf-8");
+			const eventsPath = path.join(runDir, "events.jsonl");
+			fs.writeFileSync(eventsPath, JSON.stringify({ type: "entry_appended", entry: "x".repeat(2_200_000) }), "utf-8");
+
+			const state = createState();
+			const recorder = createEventRecorder();
+			tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+			});
+			tracker.handleStarted({ id: "run-truncated-control", asyncDir: runDir, agent: "worker" });
+			await waitForCondition(
+				() => state.asyncJobs.get("run-truncated-control")?.controlEventSkippingOversizedLine === true,
+				"oversized-line skip state",
+			);
+
+			fs.writeFileSync(eventsPath, `${JSON.stringify({
+				type: "subagent.control",
+				channels: ["event"],
+				event: {
+					type: "needs_attention",
+					to: "needs_attention",
+					ts: 456,
+					runId: "run-truncated-control",
+					agent: "worker",
+					message: "replacement event",
+				},
+			})}\n`, "utf-8");
+			await waitForCondition(
+				() => recorder.events.some((event) => event.channel === "subagent:control-event"),
+				"control event after truncation",
+			);
+			assert.equal(errors.some((args) => String(args[0]).includes("Ignoring malformed async control event")), false);
+		} finally {
+			tracker?.resetJobs();
+			console.error = originalError;
+			removeTempDir(asyncRoot);
+		}
+	});
+
 	it("does not tail-skip control events for newly tracked large logs", async () => {
 		const asyncRoot = createTempDir("pi-async-job-tracker-");
 		try {


### PR DESCRIPTION
## Summary

Re-derived on current `main` (`7bf165240e48cd010263034dcfbeda41bc718fa5`) as a narrow slice of closed #611.

The async control-event scanner now retains `controlEventSkippingOversizedLine` across bounded scan windows and resets it only after the oversized line terminator or a real truncate/replacement reset. This prevents a >1 MiB diagnostic line from being reparsed as malformed fragments on every poll while preserving the following valid control event.

## Reproduction

Current main plus only the new regression test:

- `skips oversized event lines across scan windows without malformed diagnostics`: **fails** (`true !== false` for malformed diagnostic emission)

## Verification

Node `22.22.0`:

- oversized + truncation targeted tests: 25/25 iterations, 50/50 tests passed
- bounded 64 KiB chunks, 2 MiB scan window, and 1 MiB line cap remain unchanged
- `git diff --check`: clean

No UI, protocol, result-delivery, worktree, or artifact changes are included.
