### PR TITLE
fix: clear settled workflow graph current node

### DIFF
--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1768,6 +1768,8 @@ async function runSubagent(
 	const refreshWorkflowGraph = (): void => {
 		if (!config.workflowGraph) return;
 		const graph = structuredClone(statusPayload.workflowGraph ?? config.workflowGraph);
+		delete graph.currentNodeId;
+		const hasCurrentNode = statusPayload.state === "queued" || statusPayload.state === "running" || statusPayload.state === "paused";
 		const normalize = (status: RunnerStatusStep["status"]): "pending" | "running" | "completed" | "failed" | "paused" | "stopped" | "detached" => {
 			if (status === "complete" || status === "completed") return "completed";
 			if (status === "running" || status === "failed" || status === "paused" || status === "stopped" || status === "pending") return status;
@@ -1781,7 +1783,7 @@ async function runSubagent(
 					node.error = step.error;
 					node.acceptanceStatus = step.acceptance?.status;
 				}
-				if (statusPayload.currentStep === node.flatIndex) graph.currentNodeId = node.id;
+				if (hasCurrentNode && statusPayload.currentStep === node.flatIndex) graph.currentNodeId = node.id;
 			}
 			for (const child of node.children ?? []) updateNode(child);
 			if (node.children?.length) {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -48,7 +48,7 @@ interface AsyncResultPayload {
 	totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
 	results: Array<{ agent?: string; output?: string; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string } }>;
 	outputs?: Record<string, { text?: string; structured?: unknown }>;
-	workflowGraph?: { nodes?: Array<{ kind?: string; label?: string; phase?: string; status?: string; acceptanceStatus?: string; error?: string; outputName?: string; structured?: boolean; children?: Array<{ label?: string; outputName?: string; itemKey?: string; status?: string; acceptanceStatus?: string; error?: string }> }> };
+	workflowGraph?: { currentNodeId?: string; nodes?: Array<{ kind?: string; label?: string; phase?: string; status?: string; acceptanceStatus?: string; error?: string; outputName?: string; structured?: boolean; children?: Array<{ label?: string; outputName?: string; itemKey?: string; status?: string; acceptanceStatus?: string; error?: string }> }> };
 }
 
 interface AsyncStatusPayload {
@@ -688,6 +688,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const status = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatusPayload;
 		assert.equal(payload.state, "paused");
 		assert.equal(payload.success, false);
+		assert.ok(payload.workflowGraph?.currentNodeId, "paused workflow should retain its resumable position");
 		assert.deepEqual(status.steps?.map((step) => step.status), ["paused", "paused", "paused"]);
 		assert.equal(mockPi.callCount(), 3);
 	});
@@ -988,6 +989,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")) as AsyncStatusPayload;
 		assert.equal(payload.state, "failed");
 		assert.equal(payload.timedOut, true);
+		assert.equal(payload.workflowGraph?.currentNodeId, undefined);
 		assert.equal(payload.turnBudgetExceeded, undefined);
 		assert.match(payload.error ?? payload.summary ?? "", /timed out after 30000ms/);
 		assert.equal(payload.results[0]?.timedOut, true);
@@ -1029,6 +1031,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")) as AsyncStatusPayload;
 		assert.equal(payload.state, "stopped");
 		assert.equal(payload.stopped, true);
+		assert.equal(payload.workflowGraph?.currentNodeId, undefined);
 		assert.equal(payload.turnBudgetExceeded, undefined);
 		assert.match(payload.error ?? payload.summary ?? "", /stopped by user/i);
 		assert.equal(payload.results[0]?.stopped, true);
@@ -1567,6 +1570,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.workflowGraph?.nodes?.[0]?.outputName, "data");
 		assert.equal(payload.workflowGraph?.nodes?.[0]?.status, "completed");
 		assert.equal(payload.workflowGraph?.nodes?.[1]?.status, "completed");
+		assert.equal(payload.workflowGraph?.currentNodeId, undefined);
 	});
 
 	it("async chains can start parallel, funnel into one step, then fan back out", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {


### PR DESCRIPTION
## Summary

Re-derived on current `main` (`7bf165240e48cd010263034dcfbeda41bc718fa5`) as a narrow lifecycle slice of closed #611.

`refreshWorkflowGraph()` now clears the previous `currentNodeId` before projecting current step state, then sets it only for pending/running/paused nodes. Completed, failed, stopped, and timed-out workflows no longer expose a stale active node while each node's terminal status remains intact.

## Reproduction

Current main plus only the new assertion:

- completed structured chain result still reports `workflowGraph.currentNodeId === "step-1"` instead of `undefined`

## Verification

Node `22.22.0`:

- completed structured-chain regression: 25/25 iterations passed
- existing paused workflow assertion still requires a resumable `currentNodeId`
- timeout/stopped assertions require no current node
- `git diff --check`: clean

No scheduler, RPC, delegation-v2, control, or artifact changes are included.
