### PR TITLE
fix: constrain pi-ai peer compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Required `@earendil-works/pi-ai` 0.80.0 or newer because watchdog reviews import its `./compat` entrypoint, preventing background runs from loading on older hosts. Thanks to @donwellsav for #599.
 - Re-derived foreground delegation structured-output hardening on current main: schema-bound runs now require the runtime-owned `structured_output` tool call, report `structured_output_failed`, preserve strict versioned hard-turn boundaries, and clean temporary protocol files when artifacts are disabled. Thanks to @dimahike for #571.
 - Kept foreground slash execution commands responsive while their live result finalization continues asynchronously. Thanks to Eli Stark (@white-hat) for #594.
 - Re-armed remembered detached foreground children on every blocking `contact_supervisor` request so targeted `subagent_wait` calls wake for repeated supervisor decisions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       },
       "peerDependencies": {
         "@earendil-works/pi-agent-core": "*",
-        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-ai": ">=0.80.0",
         "@earendil-works/pi-coding-agent": "*",
         "@earendil-works/pi-tui": "*"
       },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-agent-core": "*",
-    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-ai": ">=0.80.0",
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*"
   },

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -17,6 +17,12 @@ const hostPeerPackages = [
 	"@earendil-works/pi-coding-agent",
 	"@earendil-works/pi-tui",
 ] as const;
+const expectedHostPeerRanges = {
+	"@earendil-works/pi-agent-core": "*",
+	"@earendil-works/pi-ai": ">=0.80.0",
+	"@earendil-works/pi-coding-agent": "*",
+	"@earendil-works/pi-tui": "*",
+} satisfies Record<(typeof hostPeerPackages)[number], string>;
 const expectedHostDevVersions = {
 	"@earendil-works/pi-agent-core": "0.81.0",
 	"@earendil-works/pi-ai": "0.81.0",
@@ -92,11 +98,11 @@ test("direct dependency declarations are exact version pins", () => {
 	}
 });
 
-test("host-owned packages are optional wildcard peers, not production dependencies", () => {
+test("host-owned packages are optional peers with supported ranges, not production dependencies", () => {
 	const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf-8"));
 
 	for (const name of hostPeerPackages) {
-		assert.equal(packageJson.peerDependencies?.[name], "*", `${name} should be a wildcard peer`);
+		assert.equal(packageJson.peerDependencies?.[name], expectedHostPeerRanges[name], `${name} should use its supported peer range`);
 		assert.equal(packageJson.dependencies?.[name], undefined, `${name} should not be a production dependency`);
 		assert.deepEqual(packageJson.peerDependenciesMeta?.[name], { optional: true }, `${name} should be an optional peer`);
 	}


### PR DESCRIPTION
Closes #599.

This constrains the optional `@earendil-works/pi-ai` peer to `>=0.80.0`, matching the `@earendil-works/pi-ai/compat` export required by `src/watchdog/review.ts`. The lockfile metadata and package-manifest regression are updated with the same range.

Validation:

- `node --experimental-strip-types --test test/unit/package-manifest.test.ts`
- `npm install --package-lock-only --ignore-scripts --offline --dry-run`
- `npm pack --dry-run`
- `git diff --check`

Thanks to @donwellsav for reporting #599.
