### PR TITLE
fix: prune replayed nested event records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 - Required `@earendil-works/pi-ai` 0.80.0 or newer because watchdog reviews import its `./compat` entrypoint, preventing background runs from loading on older hosts. Thanks to @donwellsav for #599.
+- Removed evicted nested async status event files after the bounded cursor is written so old records are not rediscovered and replayed after the retention cap. Thanks to @mhbzhy-lost for #579.
 - Re-derived foreground delegation structured-output hardening on current main: schema-bound runs now require the runtime-owned `structured_output` tool call, report `structured_output_failed`, preserve strict versioned hard-turn boundaries, and clean temporary protocol files when artifacts are disabled. Thanks to @dimahike for #571.
 - Kept foreground slash execution commands responsive while their live result finalization continues asynchronously. Thanks to Eli Stark (@white-hat) for #594.
 - Re-armed remembered detached foreground children on every blocking `contact_supervisor` request so targeted `subagent_wait` calls wake for repeated supervisor decisions.

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -612,7 +612,9 @@ export function projectNestedEvents(route: NestedRoute): NestedRegistry {
 		} catch {
 			continue;
 		}
-		for (const event of parseNestedEventRecords(content, route)) {
+		const records = parseNestedEventRecords(content, route);
+		if (records.length === 0) continue;
+		for (const event of records) {
 			registry = applyNestedEvent(registry, event);
 			changed = true;
 		}
@@ -620,11 +622,34 @@ export function projectNestedEvents(route: NestedRoute): NestedRegistry {
 		changed = true;
 	}
 	if (changed) {
-		registry = { ...registry, processedEvents: [...seen].slice(-1000) };
+		const processedEvents = [...seen];
+		const retainedEvents = processedEvents.slice(-1000);
+		const evictedEvents = processedEvents.slice(0, -1000);
+		registry = { ...registry, processedEvents: retainedEvents };
 		// Parent projection is the only writer to this sidecar registry. Child and
 		// runner processes only create immutable event files, so parent status.json
 		// remains owned by the existing runner writer and is never rewritten here.
 		writeAtomicJson(registryPath(route), registry);
+
+		// The registry retains only a bounded filename cursor. Remove the old
+		// immutable status records after the cursor is durable; otherwise an evicted
+		// filename is rediscovered on the next projection and replayed forever.
+		for (const entry of evictedEvents) {
+			const eventPath = path.join(route.eventSink, entry);
+			if (!containedPath(route.eventSink, eventPath)) continue;
+			try {
+				const stat = fs.statSync(eventPath);
+				if (!stat.isFile() || stat.size > MAX_EVENT_BYTES) continue;
+				const content = fs.readFileSync(eventPath, "utf-8");
+				const hasStatusRecord = parseNestedEventRecords(content, route).length > 0;
+				const hasControlResult = content
+					.split("\n")
+					.some((line) => line.trim() && parseControlResult(line.trim(), route));
+				if (hasStatusRecord && !hasControlResult) fs.unlinkSync(eventPath);
+			} catch {
+				// A cleanup failure must not make a successfully projected status fail.
+			}
+		}
 	}
 	return registry;
 }

--- a/test/unit/nested-events.test.ts
+++ b/test/unit/nested-events.test.ts
@@ -326,4 +326,34 @@ describe("nested event parsing and projection", () => {
 		assert.equal(records.length, 1);
 		assert.equal(records[0]?.child.id, "jsonl-good");
 	});
+
+	it("removes evicted status files without replaying completed children", () => {
+		const route = trackRoute();
+		for (let index = 0; index < 1000; index++) {
+			writeNestedEvent(route, {
+				type: "subagent.nested.updated",
+				ts: index + 1,
+				parentRunId: "root-run",
+				parentStepIndex: 1,
+				child: child("nested-retained", "running", index + 1),
+			});
+		}
+		writeNestedEvent(route, {
+			type: "subagent.nested.completed",
+			ts: 1001,
+			parentRunId: "root-run",
+			parentStepIndex: 1,
+			child: child("nested-retained", "complete", 1001),
+		});
+
+		assert.equal(fs.readdirSync(route.eventSink).length, 1001);
+		const firstProjection = projectNestedEvents(route);
+		assert.equal(firstProjection.processedEvents.length, 1000);
+		assert.equal(fs.readdirSync(route.eventSink).length, 1000);
+		assert.equal(firstProjection.children[0]?.state, "complete");
+
+		const secondProjection = projectNestedEvents(route);
+		assert.deepEqual(secondProjection, firstProjection);
+		assert.equal(secondProjection.children[0]?.state, "complete");
+	});
 });


### PR DESCRIPTION
Closes #579.

This removes evicted nested async status-event files after the bounded cursor is durably written, so old completed-child records are not rediscovered and replayed after the `processedEvents` retention cap. Control-result files are preserved.

Validation:

- `node --experimental-strip-types --test test/unit/nested-events.test.ts test/unit/nested-control.test.ts`
- `git diff --check`

Thanks to @mhbzhy-lost for reporting #579.
