### PR TITLE
fix: honor checkpoint mutation evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 - Required `@earendil-works/pi-ai` 0.80.0 or newer because watchdog reviews import its `./compat` entrypoint, preventing background runs from loading on older hosts. Thanks to @donwellsav for #599.
 - Removed evicted nested async status event files after the bounded cursor is written so old records are not rediscovered and replayed after the retention cap. Thanks to @mhbzhy-lost for #579.
+- Counted provider-native `pi-checkpoint` commit changes as mutation evidence so CompletionGuard does not falsely fail Cursor SDK writer runs that already edited files. Thanks to Matias Gigena (@MatiasGigena) for #615.
 - Re-derived foreground delegation structured-output hardening on current main: schema-bound runs now require the runtime-owned `structured_output` tool call, report `structured_output_failed`, preserve strict versioned hard-turn boundaries, and clean temporary protocol files when artifacts are disabled. Thanks to @dimahike for #571.
 - Kept foreground slash execution commands responsive while their live result finalization continues asynchronously. Thanks to Eli Stark (@white-hat) for #594.
 - Re-armed remembered detached foreground children on every blocking `contact_supervisor` request so targeted `subagent_wait` calls wake for repeated supervisor decisions.

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -41,8 +41,33 @@ export function hasMutationToolCapability(tools: string[] | undefined, mcpDirect
 	return !tools.every((tool) => READ_ONLY_BUILTIN_TOOLS.has(tool));
 }
 
+function hasCheckpointMutationEvidence(message: Message): boolean {
+	const record = message as unknown as {
+		role?: string;
+		type?: string;
+		customType?: unknown;
+		data?: unknown;
+		details?: unknown;
+	};
+	if ((record.role !== "custom" && record.type !== "custom") || record.customType !== "pi-checkpoint") return false;
+	const details = typeof record.details === "object" && record.details !== null && !Array.isArray(record.details)
+		? record.details as Record<string, unknown>
+		: undefined;
+	const data = typeof record.data === "object" && record.data !== null && !Array.isArray(record.data)
+		? record.data as Record<string, unknown>
+		: typeof details?.beforeCommit === "string" || typeof details?.afterCommit === "string"
+			? details
+			: details?.data && typeof details.data === "object" && !Array.isArray(details.data)
+				? details.data as Record<string, unknown>
+				: undefined;
+	return typeof data?.beforeCommit === "string"
+		&& typeof data.afterCommit === "string"
+		&& data.beforeCommit !== data.afterCommit;
+}
+
 export function hasMutationToolCall(messages: Message[]): boolean {
 	for (const message of messages) {
+		if (hasCheckpointMutationEvidence(message)) return true;
 		if (message.role !== "assistant") continue;
 		for (const part of message.content) {
 			if (part.type === "thinking" && CURSOR_FILE_MUTATION_THINKING.test(part.thinking)) return true;

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -244,6 +244,68 @@ test("claimed changedFiles without mutation evidence does not bypass the guard",
 	assert.equal(hasMutationToolCall([report]), false);
 });
 
+function checkpointDataEntry(beforeCommit: string, afterCommit: string): Message {
+	return {
+		type: "custom",
+		customType: "pi-checkpoint",
+		data: { beforeCommit, afterCommit },
+	} as unknown as Message;
+}
+
+function checkpointDetailsMessage(beforeCommit: string, afterCommit: string): Message {
+	return {
+		role: "custom",
+		customType: "pi-checkpoint",
+		content: [],
+		details: { beforeCommit, afterCommit },
+	} as unknown as Message;
+}
+
+function checkpointNestedDetailsMessage(beforeCommit: string, afterCommit: string): Message {
+	return {
+		role: "custom",
+		customType: "pi-checkpoint",
+		content: [],
+		details: { data: { beforeCommit, afterCommit } },
+	} as unknown as Message;
+}
+
+test("provider checkpoint with a changed commit counts as mutation evidence", () => {
+	for (const message of [
+		checkpointDataEntry("before", "after"),
+		checkpointDetailsMessage("before", "after"),
+		checkpointNestedDetailsMessage("before", "after"),
+	]) {
+		assert.equal(hasMutationToolCall([message]), true);
+		assert.equal(
+			evaluateCompletionMutationGuard({
+				agent: "worker",
+				task: "Edit the target source file",
+				messages: [message],
+			}).triggered,
+			false,
+		);
+	}
+});
+
+test("unchanged provider checkpoint does not bypass the completion guard", () => {
+	for (const message of [
+		checkpointDataEntry("same", "same"),
+		checkpointDetailsMessage("same", "same"),
+		checkpointNestedDetailsMessage("same", "same"),
+	]) {
+		assert.equal(hasMutationToolCall([message]), false);
+		assert.equal(
+			evaluateCompletionMutationGuard({
+				agent: "worker",
+				task: "Edit the target source file",
+				messages: [message],
+			}).triggered,
+			true,
+		);
+	}
+});
+
 test("implementation task with Cursor edit thinking does not trigger", () => {
 	const result = evaluateCompletionMutationGuard({
 		agent: "worker",


### PR DESCRIPTION
Closes #615.

This counts provider-native `pi-checkpoint` commit changes as mutation evidence for CompletionGuard. It recognizes the direct Pi SDK custom-message shape and the persisted custom-entry shapes, but only when both commits are strings and differ, so unchanged checkpoints still trigger the guard.

Validation:

- `node --experimental-strip-types --test test/unit/completion-guard.test.ts`
- `git diff --check`

Thanks to Matias Gigena (@MatiasGigena) for reporting #615.
