### PR TITLE
fix: defer child tool diagnostics until startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Deferred strict child tool availability diagnostics until after child extension startup hooks, so tools registered asynchronously by child-only extensions no longer falsely fail as unavailable. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #567.
 - Required `@earendil-works/pi-ai` 0.80.0 or newer because watchdog reviews import its `./compat` entrypoint, preventing background runs from loading on older hosts. Thanks to @donwellsav for #599.
 - Removed evicted nested async status event files after the bounded cursor is written so old records are not rediscovered and replayed after the retention cap. Thanks to @mhbzhy-lost for #579.
 - Counted provider-native `pi-checkpoint` commit changes as mutation evidence so CompletionGuard does not falsely fail Cursor SDK writer runs that already edited files. Thanks to Matias Gigena (@MatiasGigena) for #615.

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -7,7 +7,6 @@ import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_INDEX_ENV, SUBAGENT_FANOUT_CHI
 import { createStructuredOutputToolParameters, STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV, validateStructuredOutputValue } from "./structured-output.ts";
 import {
 	CHILD_TOOL_DIAGNOSTIC_PATH_ENV,
-	formatChildToolDiagnostic,
 	REQUIRED_CHILD_TOOLS_ENV,
 	writeChildToolDiagnostic,
 	type ChildToolDiagnostic,
@@ -372,6 +371,8 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		waitState.currentSessionId = sessionManager ? resolveCurrentSessionId(sessionManager) : null;
 		registerNativeSupervisorClientOnce();
 		if (readRequiredChildTools()?.includes("intercom")) registerNativeSupervisorFallbackOnce();
+	});
+	onRuntimeEvent("agent_start", () => {
 		refreshChildToolDiagnostic(pi);
 	});
 	onRuntimeEvent("agent_end", async (_event: unknown, ctx: unknown) => {
@@ -419,7 +420,6 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 
 	onRuntimeEvent("before_agent_start", async (event: { systemPrompt: string }) => {
 		registerNativeSupervisorFallbackOnce();
-		const toolDiagnostic = refreshChildToolDiagnostic(pi);
 		const intercomSessionName = process.env[SUBAGENT_INTERCOM_SESSION_NAME_ENV]?.trim();
 		if (intercomSessionName && typeof pi.setSessionName === "function") {
 			pi.setSessionName(intercomSessionName);
@@ -435,9 +435,6 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 				inheritSkills: inheritSkills ?? true,
 				fanoutChild: fanoutChild === true,
 			});
-		}
-		if (toolDiagnostic) {
-			rewritten = `${formatChildToolDiagnostic(toolDiagnostic)}\nDo not claim tool-dependent work succeeded; report this configuration error to the parent.\n\n${rewritten}`;
 		}
 		if (rewritten === event.systemPrompt) return;
 		return { systemPrompt: rewritten };

--- a/test/e2e/real-session-subagent.test.ts
+++ b/test/e2e/real-session-subagent.test.ts
@@ -131,6 +131,51 @@ Use the available tools.`;
 		assert.match(results[3] ?? "", /subagentOnlyExtensions/);
 	});
 
+	it("accepts child tools registered by async before_agent_start hooks", async () => {
+		const { runRealSubagentSession, subagentCall, subagentToolResults } = await import("../support/real-session-runner.ts");
+		const asyncExtensionAgent = `---
+name: async-extension-worker
+description: Uses a child-only tool registered from before_agent_start
+tools: read, fixture_async_search
+subagentOnlyExtensions: ./fixture-async-extension.ts
+completionGuard: false
+---
+Report active tools.`;
+		const fixtureAsyncExtension = `export default function (pi) {
+	pi.on("before_agent_start", async () => {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		pi.registerTool({
+			name: "fixture_async_search",
+			label: "Fixture Async Search",
+			description: "Search the async E2E fixture.",
+			parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"], additionalProperties: false },
+			async execute() { return { content: [{ type: "text", text: "async fixture result" }] }; },
+		});
+	});
+}`;
+
+		run = await runRealSubagentSession({
+			prompt: "Run the async child tool check.",
+			childText: CHILD_MARKER,
+			reportChildTools: true,
+			projectFiles: {
+				".pi/agents/async-extension-worker.md": asyncExtensionAgent,
+				"fixture-async-extension.ts": fixtureAsyncExtension,
+			},
+			respond(context) {
+				const resultCount = (context.messages as Array<{ role?: string; toolName?: string }>).filter((message) => message.role === "toolResult" && message.toolName === "subagent").length;
+				if (resultCount > 0) return "Async child tool check complete.";
+				return subagentCall({ agent: "async-extension-worker", task: "Report active tools.", context: "fresh", agentScope: "project" }, "call-async-extension");
+			},
+			timeoutMs: 60_000,
+		});
+
+		const results = subagentToolResults(run.parentSession);
+		assert.equal(results.length, 1);
+		assert.match(results[0] ?? "", /ACTIVE_TOOLS:[^\n]*fixture_async_search/);
+		assert.doesNotMatch(results[0] ?? "", /requested unavailable child tools/);
+	});
+
 	it("boots the extension in a real parent session and delivers a faux child result", async () => {
 		const { routeParentThroughSubagent, runRealSubagentSession, subagentToolResults } = await import("../support/real-session-runner.ts");
 

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -596,7 +596,7 @@ describe("subagent prompt runtime", () => {
 		assert.deepEqual(registered, ["subagent_wait"]);
 	});
 
-	it("registers native intercom before checking a strict allowlist", () => {
+	it("registers native intercom before the final strict allowlist check", () => {
 		setSupervisorEnv();
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-intercom-diagnostic-"));
 		try {
@@ -619,6 +619,7 @@ describe("subagent prompt runtime", () => {
 
 			handlers.get("session_start")?.({});
 			assert.deepEqual(registered, ["subagent_wait", "contact_supervisor", "intercom"]);
+			handlers.get("agent_start")?.({});
 			assert.equal(fs.existsSync(diagnosticPath), false);
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });
@@ -668,7 +669,7 @@ describe("subagent prompt runtime", () => {
 		assert.deepEqual(registered, ["subagent_wait", "contact_supervisor", "intercom"]);
 	});
 
-	it("records and explains requested tools missing from the child registry", async () => {
+	it("records requested tools missing from the child registry after startup hooks settle", async () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-tool-diagnostic-"));
 		try {
 			const diagnosticPath = path.join(dir, "tools.json");
@@ -683,22 +684,24 @@ describe("subagent prompt runtime", () => {
 					handlers.set(event, handler);
 				},
 				getAllTools: () => available.map((name) => ({ name })),
-			} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }> });
+				registerTool() {},
+			} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(): void });
 
-			const missing = await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT }) as { systemPrompt?: string } | undefined;
+			const promptRewrite = await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT }) as { systemPrompt?: string } | undefined;
+			assert.equal(fs.existsSync(diagnosticPath), false);
+			assert.doesNotMatch(promptRewrite?.systemPrompt ?? "", /requested unavailable child tools/);
+
+			handlers.get("agent_start")?.({});
 			assert.deepEqual(readChildToolDiagnostic(diagnosticPath), {
 				agent: "extension-worker",
 				required: ["read", "fixture_search"],
 				available: ["read"],
 				missing: ["fixture_search"],
 			});
-			assert.match(missing?.systemPrompt ?? "", /requested unavailable child tools: fixture_search/);
-			assert.match(missing?.systemPrompt ?? "", /subagentOnlyExtensions/);
 
 			available.push("fixture_search");
-			const resolved = await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT });
+			handlers.get("agent_start")?.({});
 			assert.equal(fs.existsSync(diagnosticPath), false);
-			assert.equal(resolved, undefined);
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
Fixes #567.

This moves strict child tool availability diagnostics to `agent_start`, after async child extension startup hooks have had a chance to register their tools. It preserves the native supervisor/intercom fallback before the final strict allowlist check, and removes the prompt-time unavailable-tool diagnostic injection that could fire before child-only extensions were ready.

Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for reporting #567.

Validation:
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/subagent-prompt-runtime.test.ts test/e2e/real-session-subagent.test.ts`
- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'fails with actionable diagnostics when a requested extension tool is not loaded|fails background chains when requested extension tools are unavailable' test/integration/single-execution.test.ts test/integration/async-execution.test.ts`
- `npm run test:integration`
- `npm run test:e2e`
- `npm run test:unit` rerun reached the known unrelated watchdog LSP ordering failure once; isolated `test/unit/watchdog-lsp-diagnostics.test.ts` rerun passed, and a second full unit rerun showed the watchdog LSP test passing before the command was interrupted.