### PR TITLE
fix: stabilize completed Fleet inspector durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Kept completed Fleet inspector durations stable when legacy terminal status lacks an explicit end timestamp, preventing time-sensitive redraws from changing rendered snapshots.
 - Deferred strict child tool availability diagnostics until after child extension startup hooks, so tools registered asynchronously by child-only extensions no longer falsely fail as unavailable. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #567.
 - Required `@earendil-works/pi-ai` 0.80.0 or newer because watchdog reviews import its `./compat` entrypoint, preventing background runs from loading on older hosts. Thanks to @donwellsav for #599.
 - Removed evicted nested async status event files after the bounded cursor is written so old records are not rediscovered and replayed after the retention cap. Thanks to @mhbzhy-lost for #579.

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -363,8 +363,9 @@ function itemStats(item: FleetItem): string[] {
 		model = item.step?.model;
 		tokens = item.step?.tokens?.total ?? (item.index === undefined ? item.run.totalTokens?.total : undefined);
 		tools = item.step?.toolCount ?? (item.index === undefined ? item.run.toolCount : undefined);
-		durationMs = item.step?.durationMs
-			?? Math.max(0, (item.run.endedAt ?? Date.now()) - item.run.startedAt);
+		const terminalRun = item.state !== "queued" && item.state !== "running" && item.state !== "pending";
+		const endTime = item.run.endedAt ?? (terminalRun ? item.run.lastUpdate : undefined) ?? Date.now();
+		durationMs = item.step?.durationMs ?? Math.max(0, endTime - item.run.startedAt);
 	}
 	return [
 		model,

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -231,12 +231,19 @@ describe("native subagent fleet", () => {
 				assert.ok(!lines.some((line) => line.includes("very large tool payload")));
 				assert.ok(!lines.some((line) => line.includes("RAW FALLBACK SHOULD NOT RENDER")));
 				const bottomLines = lines;
-				component.handleInput("K");
-				lines = component.render(100);
-				assert.notDeepEqual(lines, bottomLines, "Shift+K should scroll the conversation up by one line");
-				component.handleInput("J");
-				lines = component.render(100);
-				assert.deepEqual(lines, bottomLines, "Shift+J should scroll the conversation back down by one line");
+				const realDateNow = Date.now;
+				const laterNow = realDateNow() + 2_000;
+				Date.now = () => laterNow;
+				try {
+					component.handleInput("K");
+					lines = component.render(100);
+					assert.notDeepEqual(lines, bottomLines, "Shift+K should scroll the conversation up by one line");
+					component.handleInput("J");
+					lines = component.render(100);
+					assert.deepEqual(lines, bottomLines, "Shift+J should scroll the conversation back down by one line");
+				} finally {
+					Date.now = realDateNow;
+				}
 				for (let page = 0; page < 4; page++) component.handleInput("\x1b[5~");
 				lines = component.render(100);
 				assert.ok(lines.some((line) => line.includes("Conversation") && line.includes("assistant response")), "the conversation header should remain pinned while scrolling");


### PR DESCRIPTION
Fixes the Windows failure from post-merge CI run 30130326998. Completed Fleet inspector items without an explicit end timestamp now use persisted `lastUpdate` instead of advancing `Date.now()` on every redraw. The focused regression advances the clock between Shift+K/Shift+J renders and verifies the snapshot remains stable.

Validation:
- `node --experimental-strip-types --test test/unit/fleet.test.ts`
- `git diff --check`
- pre-fix logic reproduces the elapsed-time assertion failure