### PR TITLE
fix: restrict empty child tool allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Show each subagent child’s resolved `[fresh]` or `[fork]` launch context in foreground results, async status, fleet, and widget surfaces, with `[mixed]` on aggregate headers when a run uses both modes.
 
 ### Fixed
+- Kept explicit empty and MCP-only child tool allowlists from falling back to Pi's default builtin tools. Thanks to @jstokke for #628.
 - Kept completed Fleet inspector durations stable when legacy terminal status lacks an explicit end timestamp, preventing time-sensitive redraws from changing rendered snapshots.
 - Deferred strict child tool availability diagnostics until after child extension startup hooks, so tools registered asynchronously by child-only extensions no longer falsely fail as unavailable. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #567.
 - Made parent-facing subagent tool descriptions lead with delegation and clarified that `action` is omitted for execution. Thanks to @donwellsav for #600.

--- a/README.md
+++ b/README.md
@@ -786,12 +786,12 @@ Project-scoped memory resolves under `<project>/.pi/agent-memory/<path>` and tra
 
 ### Tool and extension selection
 
-If `tools` is omitted, `pi-subagents` does not pass `--tools`, so the child gets Pi’s normal builtin tools. If `tools` is present, regular tool names become an explicit allowlist. An allowlisted name does not load the extension that registers it: load that provider through normal Pi extension discovery, `extensions`, `subagentOnlyExtensions`, or a path-like `tools` entry. `mcp:` entries are split out and forwarded as direct MCP selections. Path-like `tools` entries, such as extension paths or `.ts`/`.js` files, are treated as tool-extension paths rather than tool names. Internal runtime tools such as `structured_output` are added to an explicit allowlist only when their contract is active. Agents that declare only known read-only builtin tools skip the implementation completion guard, but `bash`, unknown tools, and MCP tools stay mutation-capable. Use `completionGuard: false` for bash-enabled validators or advisors that should never be judged as implementation agents.
+If `tools` is omitted, `pi-subagents` does not pass `--tools`, so the child gets Pi’s normal builtin tools. If `tools` is present, regular tool names become an explicit allowlist; an empty `tools:` field emits `--no-tools`. An allowlisted name does not load the extension that registers it: load that provider through normal Pi extension discovery, `extensions`, `subagentOnlyExtensions`, or a path-like `tools` entry. `mcp:` entries are split out and forwarded as direct MCP selections without granting normal builtins unless those builtins are also listed. Path-like `tools` entries, such as extension paths or `.ts`/`.js` files, are treated as tool-extension paths rather than tool names. Internal runtime tools such as `structured_output` are added to an explicit allowlist only when their contract is active. Agents that declare only known read-only builtin tools skip the implementation completion guard, but `bash`, unknown tools, and MCP tools stay mutation-capable. Use `completionGuard: false` for bash-enabled validators or advisors that should never be judged as implementation agents.
 
 Examples:
 
 - `tools` omitted and `extensions` omitted: normal builtins and normal extensions.
-- `tools: mcp:chrome-devtools`: normal builtins plus direct Chrome DevTools MCP tools.
+- `tools: mcp:chrome-devtools`: only the resolved direct Chrome DevTools MCP tools.
 - `tools: read, bash, mcp:chrome-devtools`: only `read` and `bash` as builtins, plus direct Chrome DevTools MCP tools.
 - `tools: subagent, read`: a child-safe `subagent` tool is available inside that child so it can run explicitly assigned nested fanout.
 - `tools: read, fixture_search` plus `subagentOnlyExtensions: ./tools/fixture-search.ts`: the provider loads only in this agent's child process, and the registered `fixture_search` name survives the strict allowlist.

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -477,7 +477,7 @@ function splitToolList(rawTools: string[] | undefined): { tools?: string[]; mcpD
 		}
 	}
 	return {
-		...(tools.length > 0 ? { tools } : {}),
+		...(rawTools !== undefined ? { tools } : {}),
 		...(mcpDirectTools.length > 0 ? { mcpDirectTools } : {}),
 	};
 }
@@ -1248,7 +1248,9 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 		const runtimeName = buildRuntimeName(localName, packageName);
 
 		const rawTools = parseFrontmatterList(frontmatter.tools);
-		const { tools = [], mcpDirectTools = [] } = splitToolList(rawTools);
+		const parsedTools = splitToolList(rawTools);
+		const tools = parsedTools.tools ?? [];
+		const mcpDirectTools = parsedTools.mcpDirectTools ?? [];
 		const defaultReads = parseFrontmatterList(frontmatter.defaultReads);
 		const skillStr = frontmatter.skill || frontmatter.skills;
 		const skills = parseFrontmatterList(skillStr);
@@ -1330,7 +1332,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			localName,
 			packageName,
 			description: frontmatter.description,
-			tools: tools.length > 0 ? tools : undefined,
+			tools: rawTools !== undefined ? tools : undefined,
 			mcpDirectTools: mcpDirectTools.length > 0 ? mcpDirectTools : undefined,
 			model: frontmatter.model,
 			fallbackModels: fallbackModels && fallbackModels.length > 0 ? fallbackModels : undefined,

--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -161,7 +161,7 @@ export function applyIntercomBridgeToAgent(agent: AgentConfig, bridge: IntercomB
 	if (!bridge.active || !bridge.orchestratorTarget) return agent;
 
 	const bridgeTools = ["intercom", "contact_supervisor"];
-	const tools = agent.tools
+	const tools = agent.tools && agent.tools.length > 0
 		? [...agent.tools, ...bridgeTools.filter((tool) => !agent.tools?.includes(tool))]
 		: agent.tools;
 	const instruction = bridge.instruction;

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -37,7 +37,8 @@ interface CompletionMutationGuardResult {
 }
 
 export function hasMutationToolCapability(tools: string[] | undefined, mcpDirectTools: string[] | undefined): boolean {
-	if (tools === undefined || tools.length === 0 || (mcpDirectTools?.length ?? 0) > 0) return true;
+	if ((mcpDirectTools?.length ?? 0) > 0) return true;
+	if (tools === undefined) return true;
 	return !tools.every((tool) => READ_ONLY_BUILTIN_TOOLS.has(tool));
 }
 

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -130,27 +130,30 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		args.push("--model", modelArg);
 	}
 
+	const explicitToolAllowlist = input.tools !== undefined || (input.mcpDirectTools?.length ?? 0) > 0;
 	const declaredBuiltinToolsBase = input.tools?.filter((tool) => !(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js"))) ?? [];
-	const declaredBuiltinTools = input.requireReadTool && input.tools?.length && !declaredBuiltinToolsBase.includes("read")
+	const declaredBuiltinTools = input.requireReadTool && declaredBuiltinToolsBase.length > 0 && !declaredBuiltinToolsBase.includes("read")
 		? ["read", ...declaredBuiltinToolsBase]
 		: declaredBuiltinToolsBase;
 	const fanoutAuthorized = declaredBuiltinTools.includes("subagent");
 	const toolExtensionPaths: string[] = [];
 	let requiredChildTools: string[] = [];
-	if (input.tools?.length) {
-		const allowedTools = [...declaredBuiltinTools];
-		for (const tool of input.tools) {
-			if (!declaredBuiltinTools.includes(tool) && (tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js"))) {
-				toolExtensionPaths.push(tool);
-			}
+	for (const tool of input.tools ?? []) {
+		if (!declaredBuiltinTools.includes(tool) && (tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js"))) {
+			toolExtensionPaths.push(tool);
 		}
-		if (allowedTools.length > 0) {
-			if (input.mcpDirectTools?.length) {
-				allowedTools.push(...resolveMcpDirectToolNames(input.mcpDirectTools, input.cwd));
-			}
-			if (input.structuredOutput) allowedTools.push("structured_output");
-			requiredChildTools = [...new Set(allowedTools)];
+	}
+	if (explicitToolAllowlist) {
+		const allowedTools = [
+			...declaredBuiltinTools,
+			...resolveMcpDirectToolNames(input.mcpDirectTools, input.cwd),
+			...(input.structuredOutput ? ["structured_output"] : []),
+		];
+		requiredChildTools = [...new Set(allowedTools)];
+		if (requiredChildTools.length > 0) {
 			args.push("--tools", requiredChildTools.join(","));
+		} else {
+			args.push("--no-tools");
 		}
 	}
 

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -197,6 +197,24 @@ Do work
 		assert.deepEqual(worker?.subagentOnlyExtensions, ["./child-only.ts", "./child-helper.ts"]);
 	});
 
+	it("preserves MCP-only tools as an explicit empty builtin allowlist", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-mcp-only-frontmatter-"));
+		tempDirs.push(dir);
+		writeAgent(path.join(dir, ".pi", "agents", "mcp-only.md"), `---
+name: mcp-only
+description: MCP only
+tools: mcp:github/search_repositories
+---
+
+Do MCP work
+`);
+
+		const agent = discoverAgents(dir, "project").agents.find((candidate) => candidate.name === "mcp-only");
+		assert.deepEqual(agent?.tools, []);
+		assert.deepEqual(agent?.mcpDirectTools, ["github/search_repositories"]);
+		assert.match(serializeAgent(agent!), /^tools: mcp:github\/search_repositories$/m);
+	});
+
 	it("preserves comma-separated syntax across all list fields", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-comma-list-frontmatter-"));
 		tempDirs.push(dir);

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -74,7 +74,7 @@ test("read-only issue drafting tasks do not trigger on suggested fix wording", (
 	);
 });
 
-test("omitted, empty, bash, unknown, write, and MCP tool capabilities stay conservative", () => {
+test("omitted, bash, unknown, write, and MCP tool capabilities stay conservative while empty tools are toolless", () => {
 	const base = {
 		agent: "architect",
 		task: "Implement the approved source fix",
@@ -82,7 +82,7 @@ test("omitted, empty, bash, unknown, write, and MCP tool capabilities stay conse
 	};
 
 	assert.equal(evaluateCompletionMutationGuard(base).triggered, true);
-	assert.equal(evaluateCompletionMutationGuard({ ...base, tools: [] }).triggered, true);
+	assert.equal(evaluateCompletionMutationGuard({ ...base, tools: [] }).triggered, false);
 	assert.equal(evaluateCompletionMutationGuard({ ...base, tools: ["read", "bash", "ls"] }).triggered, true);
 	assert.equal(evaluateCompletionMutationGuard({ ...base, tools: ["read", "custom_lookup"] }).triggered, true);
 	assert.equal(evaluateCompletionMutationGuard({ ...base, tools: ["read", "write"] }).triggered, true);

--- a/test/unit/intercom-bridge.test.ts
+++ b/test/unit/intercom-bridge.test.ts
@@ -170,4 +170,15 @@ describe("applyIntercomBridgeToAgent", () => {
 		assert.deepEqual(updated.tools, ["read", "intercom", "contact_supervisor"]);
 		assert.match(updated.systemPrompt, /contact_supervisor/);
 	});
+
+	it("does not widen explicit empty or MCP-only builtin allowlists", () => {
+		const emptyTools = applyIntercomBridgeToAgent(makeAgent({ tools: [] }), activeBridge);
+		assert.deepEqual(emptyTools.tools, []);
+		assert.match(emptyTools.systemPrompt, /contact_supervisor/);
+
+		const mcpOnly = applyIntercomBridgeToAgent(makeAgent({ tools: [], mcpDirectTools: ["github/search_repositories"] }), activeBridge);
+		assert.deepEqual(mcpOnly.tools, []);
+		assert.deepEqual(mcpOnly.mcpDirectTools, ["github/search_repositories"]);
+		assert.match(mcpOnly.systemPrompt, /contact_supervisor/);
+	});
 });

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -593,21 +593,65 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
 	});
 
-	it("preserves no --tools for MCP-only agents", () => {
-		const fixture = createMcpFixture();
-		writeMcpFixture(fixture);
+	it("emits --no-tools for explicit empty tool allowlists", () => {
+		for (const requireReadTool of [false, true]) {
+			const { args, env } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				requireReadTool,
+				tools: [],
+			});
 
-		const { args, env } = buildPiArgs({
-			baseArgs: ["-p"],
-			task: "hello",
-			sessionEnabled: false,
-			inheritProjectContext: false,
-			inheritSkills: false,
-			mcpDirectTools: ["chrome-devtools"],
-		});
+			assert.ok(args.includes("--no-tools"));
+			assert.equal(args.includes("--tools"), false);
+			assert.equal(env.MCP_DIRECT_TOOLS, "__none__");
+		}
+	});
 
-		assert.equal(args.includes("--tools"), false);
-		assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
+	it("restricts MCP-only agents to selected direct MCP tool names", () => {
+		for (const requireReadTool of [false, true]) {
+			const fixture = createMcpFixture();
+			writeMcpFixture(fixture);
+
+			const { args, env } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				requireReadTool,
+				mcpDirectTools: ["chrome-devtools"],
+			});
+
+			assert.equal(args[args.indexOf("--tools") + 1], "chrome_devtools_take_screenshot,chrome_devtools_click");
+			assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
+		}
+	});
+
+	it("fails closed with --no-tools when MCP-only names cannot be resolved", () => {
+		for (const requireReadTool of [false, true]) {
+			const fixture = createMcpFixture();
+			writeJson(path.join(fixture.agentDir, "mcp.json"), {
+				mcpServers: { "chrome-devtools": { command: "npx", args: ["chrome-devtools-mcp"] } },
+			});
+
+			const { args, env } = buildPiArgs({
+				baseArgs: ["-p"],
+				task: "hello",
+				sessionEnabled: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				requireReadTool,
+				mcpDirectTools: ["chrome-devtools"],
+			});
+
+			assert.ok(args.includes("--no-tools"));
+			assert.equal(args.includes("--tools"), false);
+			assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
+		}
 	});
 
 	it("supports direct MCP server/tool filters", () => {


### PR DESCRIPTION
This fixes #628 by keeping explicit empty and MCP-only child tool allowlists restrictive instead of falling back to Pi's default builtin tools.

The launch args now emit `--no-tools` for an explicit empty allowlist, pass resolved direct MCP tool names through `--tools` for MCP-only agents, and fail closed with `--no-tools` when those direct MCP names cannot be resolved. Agent discovery also preserves an explicit MCP-only `tools:` field as an empty builtin allowlist plus direct MCP selections.

Validation run locally:

`node --experimental-strip-types --test test/unit/pi-args.test.ts test/unit/agent-frontmatter.test.ts test/unit/completion-guard.test.ts test/unit/agent-overrides.test.ts test/unit/agent-management.test.ts`

`git diff --check`
