### PR TITLE
feat: add launch contract preflight API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added a public `pi-subagents/preflight` API that resolves an ordinary single-agent launch contract without creating child sessions, temp prompt files, structured-output runtimes, or run artifacts. Thanks to @shaggitza for #634.
 - Added an out-of-band, session-scoped capability-ceiling API for monotonic child tool and extension restrictions, with inherited async/nested propagation and bounded audit metadata. Thanks to aoguai for #585.
 - Added durable v3 process-terminal proof for detached async runners, with exact close observation, conservative unknown states after observer loss, and status/RPC projections. Thanks to shaggitza for #626.
 - Added `subagents.defaultThinking` for project- or user-scoped default thinking levels on agents without explicit thinking settings. Thanks to corrius for #612.

--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,33 @@ If you are writing an agent that orchestrates subagents, the bundled skill helps
 Pi extensions can request configured foreground agents through the public event
 contract exported by `pi-subagents/delegation`.
 
+### Launch contract preflight
+
+Use `pi-subagents/preflight` when an extension needs to inspect the resolved child launch contract before deciding whether to run anything:
+
+```ts
+import { resolveSubagentLaunchContract } from "pi-subagents/preflight";
+
+const result = await resolveSubagentLaunchContract({
+  agent: "reviewer",
+  task: "Review the current diff.",
+  context: "fresh",
+  cwd: ctx.cwd,
+  sessionRoot: "/tmp/my-extension-preflight-session-root",
+  availableModels: ctx.modelRegistry.getAvailable(),
+});
+
+if (!result.ok) {
+  // missing_agent, ambiguous_agent, missing_skill, denied_required_tool,
+  // invalid_artifact_dir, invalid_cwd, or unsupported_mode
+  throw new Error(result.message);
+}
+
+console.log(result.contract.digest, result.contract.tools.effectiveAllowlist);
+```
+
+Preflight covers ordinary single-agent launch resolution: selected agent identity and shadowed candidates, fresh/fork context, effective model and thinking, skill and tool resolution, direct MCP selections, runtime/configured extensions, artifact and session paths, package/lifecycle versions, capability-ceiling audit data, and a stable digest. It is side-effect-free for launch state: it does not create child sessions, temp prompt files, structured-output runtimes, tool-diagnostic files, or run artifacts. Some host-owned facts, such as exact fork snapshots and live model registries, can only be proven by the Pi host; those appear as `host_required` diagnostics instead of silently pretending to be exact.
+
 ### Delegation v1
 
 The compatibility v1 contract runs one configured foreground agent per request:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     ".": "./index.ts",
     "./background-work": "./src/api/background-work.ts",
     "./delegation": "./src/api/delegation.ts",
-    "./capability-ceiling": "./src/api/capability-ceiling.ts"
+    "./capability-ceiling": "./src/api/capability-ceiling.ts",
+    "./preflight": "./src/api/preflight.ts"
   },
   "repository": {
     "type": "git",

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -1,0 +1,329 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { discoverAgents, discoverAgentsAll, type AgentConfig, type AgentScope, type AgentSource } from "../agents/agents.ts";
+import { resolveExecutionAgentScope } from "../agents/agent-scope.ts";
+import { normalizeSkillInput, resolveSkillsWithFallback } from "../agents/skills.ts";
+import { buildModelCandidates, resolveEffectiveSubagentModel, type AvailableModelInfo, type ParentModel } from "../runs/shared/model-fallback.ts";
+import { applyThinkingSuffix, resolvePiLaunchToolPlan, type PiLaunchToolPlan } from "../runs/shared/pi-args.ts";
+import { normalizeSingleOutputOverride, resolveSingleOutputPath } from "../runs/shared/single-output.ts";
+import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
+import { resolveEffectiveThinking } from "../shared/model-info.ts";
+import { SUBAGENT_LIFECYCLE_ARTIFACT_VERSION, type ArtifactDirPreference, type ArtifactPaths, type JsonSchemaObject, type OutputMode } from "../shared/types.ts";
+import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../runs/shared/capability-ceiling.ts";
+import type { ResolvedMcpDirectToolSelection } from "../runs/shared/mcp-direct-tool-allowlist.ts";
+import { resolveStepBehavior } from "../shared/settings.ts";
+
+export const SUBAGENT_LAUNCH_CONTRACT_VERSION = 1 as const;
+
+export type SubagentLaunchContractReasonCode =
+	| "missing_agent"
+	| "ambiguous_agent"
+	| "missing_skill"
+	| "denied_required_tool"
+	| "invalid_artifact_dir"
+	| "invalid_cwd"
+	| "unsupported_mode";
+
+export interface SubagentLaunchContractDiagnostic {
+	code: SubagentLaunchContractReasonCode | "host_required" | "snapshot_warning";
+	severity: "error" | "warning" | "host-required";
+	message: string;
+}
+
+export interface SubagentLaunchContractInput {
+	agent: string;
+	cwd: string;
+	task?: string;
+	agentScope?: AgentScope;
+	context?: "fresh" | "fork";
+	model?: string;
+	thinking?: string | false;
+	parentModel?: ParentModel;
+	availableModels?: ReadonlyArray<AvailableModelInfo | { provider: string; id: string; fullId?: string; reasoning?: boolean }>;
+	preferredProvider?: string;
+	skill?: string | string[] | boolean;
+	output?: string | boolean;
+	outputMode?: OutputMode;
+	outputSchema?: JsonSchemaObject;
+	artifacts?: boolean;
+	artifactDir?: ArtifactDirPreference;
+	parentSessionFile?: string | null;
+	sessionRoot?: string;
+	sessionDir?: string;
+	runId?: string;
+	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	inheritedCapabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+}
+
+export interface SubagentLaunchContractAgentCandidate {
+	name: string;
+	localName?: string;
+	packageName?: string;
+	source: AgentSource;
+	filePath: string;
+	disabled?: boolean;
+	selected: boolean;
+}
+
+export interface SubagentLaunchContractAgent {
+	name: string;
+	localName?: string;
+	packageName?: string;
+	source: AgentSource;
+	filePath: string;
+	shadowedCandidates: SubagentLaunchContractAgentCandidate[];
+}
+
+export interface SubagentLaunchContractSkills {
+	requested: string[];
+	resolved: Array<{ name: string; path: string; source: string }>;
+	missing: string[];
+}
+
+export interface SubagentLaunchContractTools {
+	requestedBuiltin: string[];
+	declaredBuiltin: string[];
+	effectiveAllowlist: string[];
+	explicitAllowlist: boolean;
+	requiredChildTools: string[];
+	internalTools: string[];
+	mcp: ResolvedMcpDirectToolSelection[];
+	effectiveMcpTools: string[];
+	toolExtensionPaths: string[];
+	runtimeExtensions: string[];
+	configuredExtensions: string[];
+	extensionArgs: string[];
+	disableAmbientExtensions: boolean;
+	fanoutAuthorized: boolean;
+	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	capabilityAudit?: SubagentCapabilityAudit;
+}
+
+export interface SubagentLaunchContractRoots {
+	cwd: string;
+	sessionRoot?: string;
+	sessionDir?: string;
+	sessionFile?: string;
+	artifactsDir?: string;
+	artifactPaths?: ArtifactPaths;
+	outputPath?: string;
+}
+
+export interface SubagentLaunchContract {
+	version: typeof SUBAGENT_LAUNCH_CONTRACT_VERSION;
+	runId: string;
+	agent: SubagentLaunchContractAgent;
+	context: "fresh" | "fork";
+	model?: string;
+	modelCandidates: string[];
+	thinking?: string;
+	systemPromptMode: AgentConfig["systemPromptMode"];
+	inheritProjectContext: boolean;
+	inheritSkills: boolean;
+	skills: SubagentLaunchContractSkills;
+	tools: SubagentLaunchContractTools;
+	roots: SubagentLaunchContractRoots;
+	protocol: {
+		lifecycleArtifactVersion: number;
+		packageVersion: string;
+	};
+	diagnostics: SubagentLaunchContractDiagnostic[];
+	digest: string;
+}
+
+export type SubagentLaunchContractResult =
+	| { ok: true; contract: SubagentLaunchContract }
+	| { ok: false; code: SubagentLaunchContractReasonCode; message: string; diagnostics: SubagentLaunchContractDiagnostic[] };
+
+function packageVersion(): string {
+	const packagePath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
+	const parsed = JSON.parse(fs.readFileSync(packagePath, "utf-8")) as { version?: unknown };
+	return typeof parsed.version === "string" ? parsed.version : "0.0.0";
+}
+
+function stableJson(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+	if (value && typeof value === "object") {
+		return `{${Object.entries(value as Record<string, unknown>)
+			.filter(([, entry]) => entry !== undefined)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+			.join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+function digestContract(contract: Omit<SubagentLaunchContract, "digest">): string {
+	return createHash("sha256").update(stableJson(contract)).digest("hex");
+}
+
+function normalizeAvailableModels(models: SubagentLaunchContractInput["availableModels"]): AvailableModelInfo[] {
+	return (models ?? []).map((model) => ({ ...model, fullId: model.fullId ?? `${model.provider}/${model.id}` }));
+}
+
+function candidateList(inputAgent: string, selected: AgentConfig | undefined, cwd: string): SubagentLaunchContractAgentCandidate[] {
+	const all = discoverAgentsAll(cwd);
+	return [...all.builtin, ...all.package, ...all.user, ...all.project]
+		.filter((agent) => agent.name === inputAgent || agent.localName === inputAgent)
+		.map((agent) => ({
+			name: agent.name,
+			...(agent.localName ? { localName: agent.localName } : {}),
+			...(agent.packageName ? { packageName: agent.packageName } : {}),
+			source: agent.source,
+			filePath: agent.filePath,
+			...(agent.disabled === true ? { disabled: true } : {}),
+			selected: Boolean(selected && agent.filePath === selected.filePath && agent.name === selected.name),
+		}));
+}
+
+export async function resolveSubagentLaunchContract(input: SubagentLaunchContractInput): Promise<SubagentLaunchContractResult> {
+	const diagnostics: SubagentLaunchContractDiagnostic[] = [];
+	const effectiveCwd = path.resolve(input.cwd);
+	try {
+		if (!fs.statSync(effectiveCwd).isDirectory()) {
+			return { ok: false, code: "invalid_cwd", message: `cwd '${effectiveCwd}' is not a directory.`, diagnostics };
+		}
+	} catch (error) {
+		const detail = error instanceof Error ? ` ${error.message}` : "";
+		return { ok: false, code: "invalid_cwd", message: `cwd '${effectiveCwd}' is not a directory.${detail}`, diagnostics };
+	}
+	if (input.context !== undefined && input.context !== "fresh" && input.context !== "fork") {
+		return { ok: false, code: "unsupported_mode", message: `Unsupported context '${String(input.context)}'; expected 'fresh' or 'fork'.`, diagnostics };
+	}
+	if (input.artifactDir !== undefined && input.artifactDir !== "project" && input.artifactDir !== "session" && input.artifactDir !== "temp") {
+		return { ok: false, code: "invalid_artifact_dir", message: `Unsupported artifactDir '${String(input.artifactDir)}'; expected 'project', 'session', or 'temp'.`, diagnostics };
+	}
+	if (input.context === "fork") {
+		diagnostics.push({ code: "host_required", severity: "host-required", message: "Exact fork session branching and fork-thinking downgrade checks require Pi host session and model-registry snapshots." });
+	}
+	const scope = resolveExecutionAgentScope(input.agentScope);
+	const discovered = discoverAgents(effectiveCwd, scope);
+	const matches = discovered.agents.filter((agent) => agent.name === input.agent || agent.localName === input.agent);
+	if (matches.length === 0) {
+		return { ok: false, code: "missing_agent", message: `Unknown agent: ${input.agent}`, diagnostics };
+	}
+	if (matches.length > 1) {
+		return { ok: false, code: "ambiguous_agent", message: `Ambiguous agent: ${input.agent}`, diagnostics };
+	}
+	const agent = matches[0]!;
+	const runId = input.runId ?? "preflight";
+	const skillInput = normalizeSkillInput(input.skill);
+	const outputOverride = normalizeSingleOutputOverride(input.output, agent.output);
+	const behavior = resolveStepBehavior(agent, {
+		...(outputOverride !== undefined ? { output: outputOverride } : {}),
+		...(input.outputMode !== undefined ? { outputMode: input.outputMode } : {}),
+		...(skillInput !== undefined ? { skills: skillInput } : {}),
+		...(input.model !== undefined ? { model: input.model } : {}),
+	});
+	const requestedSkills = behavior.skills === false ? [] : behavior.skills;
+	const resolvedSkills = resolveSkillsWithFallback(
+		requestedSkills,
+		effectiveCwd,
+		effectiveCwd,
+		agent.skillPath,
+		agent.filePath ? path.dirname(agent.filePath) : effectiveCwd,
+	);
+	if (resolvedSkills.missing.includes("pi-subagents")) {
+		return { ok: false, code: "missing_skill", message: "The pi-subagents orchestration skill is not child-injectable.", diagnostics };
+	}
+	if (resolvedSkills.missing.length > 0) diagnostics.push({ code: "missing_skill", severity: "error", message: `Missing skills: ${resolvedSkills.missing.join(", ")}` });
+
+	const availableModels = normalizeAvailableModels(input.availableModels);
+	const preferredProvider = input.preferredProvider ?? input.parentModel?.provider;
+	const primaryModel = resolveEffectiveSubagentModel(input.model, agent.model, input.parentModel, availableModels, preferredProvider, { scope: discovered.modelScope });
+	const effectiveThinkingConfig = input.thinking !== undefined ? input.thinking : agent.thinking;
+	const model = applyThinkingSuffix(primaryModel, effectiveThinkingConfig, input.thinking !== undefined);
+	const modelCandidates = buildModelCandidates(primaryModel, agent.fallbackModels, availableModels, preferredProvider, { scope: discovered.modelScope })
+		.map((candidate) => applyThinkingSuffix(candidate, effectiveThinkingConfig, input.thinking !== undefined) ?? candidate);
+	let toolPlan: PiLaunchToolPlan;
+	try {
+		toolPlan = resolvePiLaunchToolPlan({
+			tools: agent.tools,
+			extensions: agent.extensions,
+			subagentOnlyExtensions: agent.subagentOnlyExtensions,
+			mcpDirectTools: agent.mcpDirectTools,
+			cwd: effectiveCwd,
+			requireReadTool: resolvedSkills.resolved.length > 0,
+			structuredOutput: Boolean(input.outputSchema),
+			capabilityCeiling: input.capabilityCeiling,
+			inheritedCapabilityCeiling: input.inheritedCapabilityCeiling,
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		diagnostics.push({ code: "denied_required_tool", severity: "error", message });
+		return { ok: false, code: "denied_required_tool", message, diagnostics };
+	}
+	const artifactsEnabled = input.artifacts !== false;
+	const artifactsDir = artifactsEnabled ? getArtifactsDir(input.parentSessionFile ?? null, effectiveCwd, input.artifactDir ?? "project") : undefined;
+	const artifactPaths = artifactsDir ? getArtifactPaths(artifactsDir, runId, agent.name, 0) : undefined;
+	const outputPath = resolveSingleOutputPath(behavior.output, effectiveCwd, effectiveCwd, artifactsDir ? path.join(artifactsDir, "outputs", runId) : undefined);
+	const sessionRoot = input.sessionDir ? path.resolve(input.sessionDir) : input.sessionRoot ? path.join(path.resolve(input.sessionRoot), runId) : undefined;
+	const sessionDir = sessionRoot ? path.join(sessionRoot, "run-0") : undefined;
+	if (!sessionDir) diagnostics.push({ code: "host_required", severity: "host-required", message: "No sessionRoot/sessionDir was supplied; exact child session paths require the Pi host session-root policy." });
+	if (input.availableModels === undefined && (input.model || agent.model || input.parentModel)) {
+		diagnostics.push({ code: "host_required", severity: "host-required", message: "No availableModels snapshot was supplied; model resolution may differ from the active Pi host registry." });
+	}
+	if (resolvedSkills.missing.length > 0) {
+		return { ok: false, code: "missing_skill", message: `Missing skills: ${resolvedSkills.missing.join(", ")}`, diagnostics };
+	}
+	const candidates = candidateList(input.agent, agent, effectiveCwd);
+	const shadowedCandidates = candidates.filter((candidate) => !candidate.selected);
+	const contractBase: Omit<SubagentLaunchContract, "digest"> = {
+		version: SUBAGENT_LAUNCH_CONTRACT_VERSION,
+		runId,
+		agent: {
+			name: agent.name,
+			...(agent.localName ? { localName: agent.localName } : {}),
+			...(agent.packageName ? { packageName: agent.packageName } : {}),
+			source: agent.source,
+			filePath: agent.filePath,
+			shadowedCandidates,
+		},
+		context: input.context ?? agent.defaultContext ?? "fresh",
+		...(model ? { model } : {}),
+		modelCandidates,
+		...(resolveEffectiveThinking(model, effectiveThinkingConfig) ? { thinking: resolveEffectiveThinking(model, effectiveThinkingConfig) } : {}),
+		systemPromptMode: agent.systemPromptMode,
+		inheritProjectContext: agent.inheritProjectContext,
+		inheritSkills: agent.inheritSkills,
+		skills: {
+			requested: requestedSkills,
+			resolved: resolvedSkills.resolved.map((skill) => ({ name: skill.name, path: skill.path, source: skill.source })),
+			missing: resolvedSkills.missing,
+		},
+		tools: {
+			requestedBuiltin: toolPlan.requestedBuiltinTools,
+			declaredBuiltin: toolPlan.declaredBuiltinTools,
+			effectiveAllowlist: toolPlan.effectiveToolAllowlist,
+			explicitAllowlist: toolPlan.explicitToolAllowlist,
+			requiredChildTools: toolPlan.requiredChildTools,
+			internalTools: toolPlan.internalTools,
+			mcp: toolPlan.effectiveMcpSelections,
+			effectiveMcpTools: toolPlan.effectiveMcpTools,
+			toolExtensionPaths: toolPlan.toolExtensionPaths,
+			runtimeExtensions: toolPlan.runtimeExtensions,
+			configuredExtensions: toolPlan.configuredExtensions,
+			extensionArgs: toolPlan.extensionArgs,
+			disableAmbientExtensions: toolPlan.disableAmbientExtensions,
+			fanoutAuthorized: toolPlan.fanoutAuthorized,
+			...(toolPlan.capabilityCeiling ? { capabilityCeiling: toolPlan.capabilityCeiling } : {}),
+			...(toolPlan.capabilityAudit ? { capabilityAudit: toolPlan.capabilityAudit } : {}),
+		},
+		roots: {
+			cwd: effectiveCwd,
+			...(sessionRoot ? { sessionRoot } : {}),
+			...(sessionDir ? { sessionDir, sessionFile: path.join(sessionDir, "session.jsonl") } : {}),
+			...(artifactsDir ? { artifactsDir } : {}),
+			...(artifactPaths ? { artifactPaths } : {}),
+			...(outputPath ? { outputPath } : {}),
+		},
+		protocol: {
+			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
+			packageVersion: packageVersion(),
+		},
+		diagnostics,
+	};
+	return { ok: true, contract: { ...contractBase, digest: digestContract(contractBase) } };
+}

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { encodeNestedPathEnv, parseNestedPathEnv, type NestedPathEntry } from "./nested-path.ts";
-import { resolveMcpDirectToolSelections } from "./mcp-direct-tool-allowlist.ts";
+import { resolveMcpDirectToolSelections, type ResolvedMcpDirectToolSelection } from "./mcp-direct-tool-allowlist.ts";
 import { resolvePiPackageRoot } from "./pi-spawn.ts";
 import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "./structured-output.ts";
 import { TEMP_ROOT_DIR, type JsonSchemaObject, type ResolvedToolBudget } from "../../shared/types.ts";
@@ -39,7 +39,7 @@ export const SUBAGENT_STEER_INBOX_ENV = "PI_SUBAGENT_STEER_INBOX";
 export const SUBAGENT_STEER_CAPABILITY_ENV = "PI_SUBAGENT_STEER_CAPABILITY";
 export const SUBAGENT_STEER_ACK_DIR_ENV = "PI_SUBAGENT_STEER_ACK_DIR";
 
-interface BuildPiArgsInput {
+export interface BuildPiArgsInput {
 	parentSessionId?: string;
 	baseArgs: string[];
 	task: string;
@@ -87,7 +87,7 @@ interface BuildPiArgsInput {
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 }
 
-interface BuildPiArgsResult {
+export interface BuildPiArgsResult {
 	args: string[];
 	env: Record<string, string | undefined>;
 	tempDir?: string;
@@ -112,6 +112,106 @@ export function applyThinkingSuffix(model: string | undefined, thinking: string 
 	return `${model}:${thinking}`;
 }
 
+export interface ResolvePiLaunchToolPlanInput {
+	tools?: string[];
+	extensions?: string[];
+	subagentOnlyExtensions?: string[];
+	mcpDirectTools?: string[];
+	cwd?: string;
+	requireReadTool?: boolean;
+	structuredOutput?: boolean;
+	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	inheritedCapabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+}
+
+export interface PiLaunchToolPlan {
+	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	requestedBuiltinTools: string[];
+	declaredBuiltinTools: string[];
+	toolExtensionPaths: string[];
+	resolvedMcpSelections: ResolvedMcpDirectToolSelection[];
+	effectiveMcpSelections: ResolvedMcpDirectToolSelection[];
+	effectiveMcpTools: string[];
+	explicitToolAllowlist: boolean;
+	internalTools: string[];
+	effectiveToolAllowlist: string[];
+	requiredChildTools: string[];
+	fanoutAuthorized: boolean;
+	runtimeExtensions: string[];
+	configuredExtensions: string[];
+	extensionArgs: string[];
+	disableAmbientExtensions: boolean;
+	capabilityAudit?: SubagentCapabilityAudit;
+}
+
+export function resolvePiLaunchToolPlan(input: ResolvePiLaunchToolPlanInput): PiLaunchToolPlan {
+	const capabilityCeiling = intersectSubagentCapabilityCeilings(input.capabilityCeiling, input.inheritedCapabilityCeiling);
+	const allowedToolSet = capabilityCeiling?.allowedTools === undefined ? undefined : new Set(capabilityCeiling.allowedTools);
+	const requestedBuiltinTools = input.tools?.filter((tool) => !(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js"))) ?? [];
+	if (input.requireReadTool && allowedToolSet && !allowedToolSet.has("read")) {
+		throw new Error(`Capability ceiling from ${capabilityCeiling?.sources.join(", ") || "unknown source"} excludes required tool 'read' for lazy skill loading.`);
+	}
+	const declaredBuiltinTools = input.tools === undefined
+		? (allowedToolSet ? [...allowedToolSet] : [])
+		: (input.requireReadTool && requestedBuiltinTools.length > 0 && !requestedBuiltinTools.includes("read") && !allowedToolSet
+			? ["read", ...requestedBuiltinTools]
+			: requestedBuiltinTools).filter((tool) => !allowedToolSet || allowedToolSet.has(tool));
+	const fanoutAuthorized = declaredBuiltinTools.includes("subagent");
+	const toolExtensionPaths: string[] = capabilityCeiling?.denyExtensions ? [] : (input.tools ?? []).filter((tool) => !requestedBuiltinTools.includes(tool) && (tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")));
+	const resolvedMcpSelections = capabilityCeiling?.denyExtensions ? [] : resolveMcpDirectToolSelections(input.mcpDirectTools, input.cwd);
+	const effectiveMcpSelections = resolvedMcpSelections.filter((selection) => !allowedToolSet || allowedToolSet.has(selection.name));
+	const effectiveMcpTools = effectiveMcpSelections.map((selection) => selection.name);
+	const explicitToolAllowlist = input.tools !== undefined || (input.mcpDirectTools?.length ?? 0) > 0 || allowedToolSet !== undefined;
+	const internalTools = input.structuredOutput ? ["structured_output"] : [];
+	const effectiveToolAllowlist = [...new Set([...declaredBuiltinTools, ...effectiveMcpTools, ...internalTools])];
+	const requiredChildTools = explicitToolAllowlist ? [...new Set([
+		...(input.tools !== undefined ? declaredBuiltinTools : []),
+		...(input.mcpDirectTools?.length ? effectiveMcpTools : []),
+		...internalTools,
+	])] : [];
+	const runtimeExtensions = fanoutAuthorized
+		? [PROMPT_RUNTIME_EXTENSION_PATH, FANOUT_CHILD_EXTENSION_PATH]
+		: [PROMPT_RUNTIME_EXTENSION_PATH];
+	const disableAmbientExtensions = capabilityCeiling?.denyExtensions === true || input.extensions !== undefined;
+	const configuredExtensions = capabilityCeiling?.denyExtensions ? [] : [...toolExtensionPaths, ...(input.extensions ?? []), ...(input.subagentOnlyExtensions ?? [])];
+	const extensionArgs = disableAmbientExtensions
+		? [...new Set([...runtimeExtensions, ...configuredExtensions])]
+		: [...new Set([...runtimeExtensions, ...toolExtensionPaths, ...(input.subagentOnlyExtensions ?? [])])];
+	const requestedToolNames = input.tools !== undefined
+		? [...new Set([...requestedBuiltinTools, ...resolvedMcpSelections.map((selection) => selection.name)])]
+		: undefined;
+	const capabilityAudit = capabilityCeiling ? {
+		ceiling: capabilityCeiling,
+		...(requestedToolNames ? { requestedTools: requestedToolNames } : {}),
+		effectiveTools: effectiveToolAllowlist,
+		removedTools: requestedToolNames?.filter((tool) => !effectiveToolAllowlist.includes(tool)) ?? [],
+		internalTools,
+		extensionsDenied: capabilityCeiling.denyExtensions,
+		removedExtensionCount: capabilityCeiling.denyExtensions ? (input.extensions?.length ?? 0) + (input.subagentOnlyExtensions?.length ?? 0) + ((input.tools ?? []).filter((tool) => tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")).length) : 0,
+		requestedMcpToolCount: input.mcpDirectTools?.length ?? 0,
+		effectiveMcpTools,
+	} satisfies SubagentCapabilityAudit : undefined;
+	return {
+		...(capabilityCeiling ? { capabilityCeiling } : {}),
+		requestedBuiltinTools,
+		declaredBuiltinTools,
+		toolExtensionPaths,
+		resolvedMcpSelections,
+		effectiveMcpSelections,
+		effectiveMcpTools,
+		explicitToolAllowlist,
+		internalTools,
+		effectiveToolAllowlist,
+		requiredChildTools,
+		fanoutAuthorized,
+		runtimeExtensions,
+		configuredExtensions,
+		extensionArgs,
+		disableAmbientExtensions,
+		...(capabilityAudit ? { capabilityAudit } : {}),
+	};
+}
+
 export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	const args = [...input.baseArgs];
 
@@ -133,50 +233,25 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		args.push("--model", modelArg);
 	}
 
-	const inheritedCeiling = decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]);
-	const capabilityCeiling = intersectSubagentCapabilityCeilings(input.capabilityCeiling, inheritedCeiling);
-	const allowedToolSet = capabilityCeiling?.allowedTools === undefined ? undefined : new Set(capabilityCeiling.allowedTools);
-	const requestedBuiltinTools = input.tools?.filter((tool) => !(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js"))) ?? [];
-	if (input.requireReadTool && allowedToolSet && !allowedToolSet.has("read")) {
-		throw new Error(`Capability ceiling from ${capabilityCeiling?.sources.join(", ") || "unknown source"} excludes required tool 'read' for lazy skill loading.`);
+	const toolPlan = resolvePiLaunchToolPlan({
+		tools: input.tools,
+		extensions: input.extensions,
+		subagentOnlyExtensions: input.subagentOnlyExtensions,
+		mcpDirectTools: input.mcpDirectTools,
+		cwd: input.cwd,
+		requireReadTool: input.requireReadTool,
+		structuredOutput: input.structuredOutput,
+		capabilityCeiling: input.capabilityCeiling,
+		inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
+	});
+	if (toolPlan.explicitToolAllowlist) {
+		args.push(toolPlan.effectiveToolAllowlist.length > 0 ? "--tools" : "--no-tools");
+		if (toolPlan.effectiveToolAllowlist.length > 0) args.push(toolPlan.effectiveToolAllowlist.join(","));
 	}
-	const declaredBuiltinTools = input.tools === undefined
-		? (allowedToolSet ? [...allowedToolSet] : [])
-		: (input.requireReadTool && requestedBuiltinTools.length > 0 && !requestedBuiltinTools.includes("read") && !allowedToolSet
-			? ["read", ...requestedBuiltinTools]
-			: requestedBuiltinTools).filter((tool) => !allowedToolSet || allowedToolSet.has(tool));
-	const fanoutAuthorized = declaredBuiltinTools.includes("subagent");
-	const toolExtensionPaths: string[] = capabilityCeiling?.denyExtensions ? [] : (input.tools ?? []).filter((tool) => !requestedBuiltinTools.includes(tool) && (tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")));
-	const resolvedMcpSelections = capabilityCeiling?.denyExtensions ? [] : resolveMcpDirectToolSelections(input.mcpDirectTools, input.cwd);
-	const effectiveMcpSelections = resolvedMcpSelections.filter((selection) => !allowedToolSet || allowedToolSet.has(selection.name));
-	const effectiveMcpTools = effectiveMcpSelections.map((selection) => selection.name);
-	const explicitToolAllowlist = input.tools !== undefined || (input.mcpDirectTools?.length ?? 0) > 0 || allowedToolSet !== undefined;
-	const internalTools = input.structuredOutput ? ["structured_output"] : [];
-	const effectiveToolAllowlist = [...new Set([...declaredBuiltinTools, ...effectiveMcpTools, ...internalTools])];
-	const requestedToolNames = input.tools !== undefined
-		? [...new Set([...requestedBuiltinTools, ...resolvedMcpSelections.map((selection) => selection.name)])]
-		: undefined;
-	let requiredChildTools: string[] = [];
-	if (explicitToolAllowlist) {
-		requiredChildTools = [...new Set([
-			...(input.tools !== undefined ? declaredBuiltinTools : []),
-			...(input.mcpDirectTools?.length ? effectiveMcpTools : []),
-			...internalTools,
-		])];
-		args.push(effectiveToolAllowlist.length > 0 ? "--tools" : "--no-tools");
-		if (effectiveToolAllowlist.length > 0) args.push(effectiveToolAllowlist.join(","));
-	}
-
-	const runtimeExtensions = fanoutAuthorized
-		? [PROMPT_RUNTIME_EXTENSION_PATH, FANOUT_CHILD_EXTENSION_PATH]
-		: [PROMPT_RUNTIME_EXTENSION_PATH];
-	if (capabilityCeiling?.denyExtensions || input.extensions !== undefined) {
+	if (toolPlan.disableAmbientExtensions) {
 		args.push("--no-extensions");
-		const configuredExtensions = capabilityCeiling?.denyExtensions ? [] : [...toolExtensionPaths, ...(input.extensions ?? []), ...(input.subagentOnlyExtensions ?? [])];
-		for (const extPath of [...new Set([...runtimeExtensions, ...configuredExtensions])]) args.push("--extension", extPath);
-	} else {
-		for (const extPath of [...new Set([...runtimeExtensions, ...toolExtensionPaths, ...(input.subagentOnlyExtensions ?? [])])]) args.push("--extension", extPath);
 	}
+	for (const extPath of toolPlan.extensionArgs) args.push("--extension", extPath);
 
 	if (!input.inheritSkills) {
 		args.push("--no-skills");
@@ -206,14 +281,14 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	const piPackageRoot = process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] ?? resolvePiPackageRoot();
 	if (piPackageRoot) env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] = piPackageRoot;
 	let toolDiagnosticPath: string | undefined;
-	if (requiredChildTools.length > 0) {
+	if (toolPlan.requiredChildTools.length > 0) {
 		if (!tempDir) tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));
 		toolDiagnosticPath = path.join(tempDir, "tool-diagnostic.json");
-		env[REQUIRED_CHILD_TOOLS_ENV] = JSON.stringify(requiredChildTools);
+		env[REQUIRED_CHILD_TOOLS_ENV] = JSON.stringify(toolPlan.requiredChildTools);
 		env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV] = toolDiagnosticPath;
 	}
 	env[SUBAGENT_CHILD_ENV] = "1";
-	env[SUBAGENT_FANOUT_CHILD_ENV] = fanoutAuthorized ? "1" : "0";
+	env[SUBAGENT_FANOUT_CHILD_ENV] = toolPlan.fanoutAuthorized ? "1" : "0";
 	if (input.waitToolEnabled !== undefined) {
 		env[WAIT_TOOL_ENABLED_ENV] = input.waitToolEnabled ? "true" : "false";
 	}
@@ -234,20 +309,20 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 			...(input.childAgentName ? { agent: input.childAgentName } : {}),
 		}] : []),
 	];
-	env[SUBAGENT_PARENT_EVENT_SINK_ENV] = fanoutAuthorized
+	env[SUBAGENT_PARENT_EVENT_SINK_ENV] = toolPlan.fanoutAuthorized
 		? input.parentEventSink ?? process.env[SUBAGENT_PARENT_EVENT_SINK_ENV] ?? ""
 		: "";
-	env[SUBAGENT_PARENT_CONTROL_INBOX_ENV] = fanoutAuthorized
+	env[SUBAGENT_PARENT_CONTROL_INBOX_ENV] = toolPlan.fanoutAuthorized
 		? input.parentControlInbox ?? process.env[SUBAGENT_PARENT_CONTROL_INBOX_ENV] ?? ""
 		: "";
-	env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] = fanoutAuthorized
+	env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] = toolPlan.fanoutAuthorized
 		? input.parentRootRunId ?? process.env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] ?? input.runId ?? ""
 		: "";
-	env[SUBAGENT_PARENT_RUN_ID_ENV] = fanoutAuthorized ? parentRunId : "";
-	env[SUBAGENT_PARENT_CHILD_INDEX_ENV] = fanoutAuthorized ? parentChildIndex : "";
-	env[SUBAGENT_PARENT_DEPTH_ENV] = fanoutAuthorized ? String(parentDepth) : "";
-	env[SUBAGENT_PARENT_PATH_ENV] = fanoutAuthorized ? encodeNestedPathEnv(parentPath) : "";
-	env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] = fanoutAuthorized
+	env[SUBAGENT_PARENT_RUN_ID_ENV] = toolPlan.fanoutAuthorized ? parentRunId : "";
+	env[SUBAGENT_PARENT_CHILD_INDEX_ENV] = toolPlan.fanoutAuthorized ? parentChildIndex : "";
+	env[SUBAGENT_PARENT_DEPTH_ENV] = toolPlan.fanoutAuthorized ? String(parentDepth) : "";
+	env[SUBAGENT_PARENT_PATH_ENV] = toolPlan.fanoutAuthorized ? encodeNestedPathEnv(parentPath) : "";
+	env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] = toolPlan.fanoutAuthorized
 		? input.parentCapabilityToken ?? process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] ?? ""
 		: "";
 	env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = input.inheritProjectContext ? "1" : "0";
@@ -277,10 +352,10 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	if (input.childIndex !== undefined) {
 		env[SUBAGENT_CHILD_INDEX_ENV] = String(input.childIndex);
 	}
-	if (!capabilityCeiling && input.mcpDirectTools?.length) env.MCP_DIRECT_TOOLS = input.mcpDirectTools.join(",");
-	else if (capabilityCeiling && effectiveMcpSelections.length && !capabilityCeiling.denyExtensions) env.MCP_DIRECT_TOOLS = effectiveMcpSelections.map((selection) => selection.selector).join(",");
+	if (!toolPlan.capabilityCeiling && input.mcpDirectTools?.length) env.MCP_DIRECT_TOOLS = input.mcpDirectTools.join(",");
+	else if (toolPlan.capabilityCeiling && toolPlan.effectiveMcpSelections.length && !toolPlan.capabilityCeiling.denyExtensions) env.MCP_DIRECT_TOOLS = toolPlan.effectiveMcpSelections.map((selection) => selection.selector).join(",");
 	else env.MCP_DIRECT_TOOLS = "__none__";
-	const encodedCapabilityCeiling = encodeSubagentCapabilityCeiling(capabilityCeiling);
+	const encodedCapabilityCeiling = encodeSubagentCapabilityCeiling(toolPlan.capabilityCeiling);
 	if (encodedCapabilityCeiling) env[SUBAGENT_CAPABILITY_CEILING_ENV] = encodedCapabilityCeiling;
 	if (input.structuredOutput) {
 		env[STRUCTURED_OUTPUT_CAPTURE_ENV] = input.structuredOutput.outputPath;
@@ -299,18 +374,7 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 
 	env[SUBAGENT_PARENT_SESSION_ENV] = input.parentSessionId ?? process.env[SUBAGENT_PARENT_SESSION_ENV] ?? "";
 
-	const capabilityAudit = capabilityCeiling ? {
-		ceiling: capabilityCeiling,
-		...(requestedToolNames ? { requestedTools: requestedToolNames } : {}),
-		effectiveTools: effectiveToolAllowlist,
-		removedTools: requestedToolNames?.filter((tool) => !effectiveToolAllowlist.includes(tool)) ?? [],
-		internalTools,
-		extensionsDenied: capabilityCeiling.denyExtensions,
-		removedExtensionCount: capabilityCeiling.denyExtensions ? (input.extensions?.length ?? 0) + (input.subagentOnlyExtensions?.length ?? 0) + ((input.tools ?? []).filter((tool) => tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")).length) : 0,
-		requestedMcpToolCount: input.mcpDirectTools?.length ?? 0,
-		effectiveMcpTools,
-	} satisfies SubagentCapabilityAudit : undefined;
-	return { args, env, tempDir, toolDiagnosticPath, capabilityAudit };
+	return { args, env, tempDir, toolDiagnosticPath, capabilityAudit: toolPlan.capabilityAudit };
 }
 
 export const parseParentPathEnv = parseNestedPathEnv;

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -58,6 +58,7 @@ test("published extension APIs use supported package entrypoints", async () => {
 		"./background-work": "./src/api/background-work.ts",
 		"./capability-ceiling": "./src/api/capability-ceiling.ts",
 		"./delegation": "./src/api/delegation.ts",
+		"./preflight": "./src/api/preflight.ts",
 	});
 	const backgroundWork = await import("pi-subagents/background-work");
 	assert.equal(backgroundWork.BACKGROUND_WORK_PROTOCOL_VERSION, 1);
@@ -69,6 +70,9 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.equal(delegation.SUBAGENT_DELEGATION_PROTOCOL_VERSION, 1);
 	assert.equal(delegation.SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION, 2);
 	assert.equal(delegation.SUBAGENT_DELEGATION_REQUEST_EVENT, "prompt-template:subagent:request");
+	const preflight = await import("pi-subagents/preflight");
+	assert.equal(preflight.SUBAGENT_LAUNCH_CONTRACT_VERSION, 1);
+	assert.equal(typeof preflight.resolveSubagentLaunchContract, "function");
 });
 
 test("direct @earendil-works runtime imports are declared for CI installs", () => {

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { registerSubagentCapabilityCeiling, resolveSubagentCapabilityCeiling } from "../../src/api/capability-ceiling.ts";
+import { resolveSubagentLaunchContract, SUBAGENT_LAUNCH_CONTRACT_VERSION } from "../../src/api/preflight.ts";
+import { clearSkillCache } from "../../src/agents/skills.ts";
+import { computeMcpServerHash } from "../../src/runs/shared/mcp-direct-tool-allowlist.ts";
+
+let tempDir = "";
+let previousHome: string | undefined;
+let previousUserProfile: string | undefined;
+let previousAgentDir: string | undefined;
+
+function writeAgent(filePath: string, body: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, body, "utf-8");
+}
+
+function writeSkill(cwd: string, name: string): void {
+	const skillDir = path.join(cwd, ".pi", "skills", name);
+	fs.mkdirSync(skillDir, { recursive: true });
+	fs.writeFileSync(path.join(skillDir, "SKILL.md"), `---\ndescription: ${name}\n---\n\nUse ${name}.\n`, "utf-8");
+}
+
+function writeJson(filePath: string, value: unknown): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function writeMcpFixture(): void {
+	const agentDir = process.env.PI_CODING_AGENT_DIR;
+	assert.equal(typeof agentDir, "string");
+	const definition = { command: "github-mcp" };
+	writeJson(path.join(agentDir, "mcp.json"), { mcpServers: { github: definition } });
+	writeJson(path.join(agentDir, "mcp-cache.json"), {
+		version: 1,
+		servers: {
+			github: {
+				configHash: computeMcpServerHash(definition),
+				cachedAt: Date.now(),
+				tools: [{ name: "search_repositories" }, { name: "create_issue" }],
+				resources: [],
+			},
+		},
+	});
+}
+
+describe("public launch contract preflight", () => {
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-preflight-"));
+		previousHome = process.env.HOME;
+		previousUserProfile = process.env.USERPROFILE;
+		previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const home = path.join(tempDir, "home");
+		process.env.HOME = home;
+		process.env.USERPROFILE = home;
+		process.env.PI_CODING_AGENT_DIR = path.join(home, ".pi", "agent");
+		clearSkillCache();
+	});
+
+	afterEach(() => {
+		clearSkillCache();
+		if (previousHome === undefined) delete process.env.HOME;
+		else process.env.HOME = previousHome;
+		if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = previousUserProfile;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("resolves an ordinary single-agent contract without creating launch directories", async () => {
+		const cwd = path.join(tempDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeSkill(cwd, "project-skill");
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Project worker
+tools:
+  - read
+  - write
+  - /tmp/private-tool.ts
+model: test/primary
+fallbackModels:
+  - test/fallback
+thinking: high
+skills:
+  - project-skill
+output: report.md
+---
+Project prompt.
+`);
+		const sessionRoot = path.join(tempDir, "sessions");
+		const handle = registerSubagentCapabilityCeiling({ sessionId: "preflight-session", ceiling: { allowedTools: ["read"], denyExtensions: true }, source: "test" });
+		try {
+			const ceiling = resolveSubagentCapabilityCeiling("preflight-session");
+			const result = await resolveSubagentLaunchContract({
+				agent: "worker",
+				cwd,
+				task: "Inspect the repo",
+				runId: "run-123",
+				sessionRoot,
+				availableModels: [
+					{ provider: "test", id: "primary", fullId: "test/primary" },
+					{ provider: "test", id: "fallback", fullId: "test/fallback" },
+				],
+				capabilityCeiling: ceiling,
+			});
+
+			assert.equal(result.ok, true);
+			assert.equal(result.contract.version, SUBAGENT_LAUNCH_CONTRACT_VERSION);
+			assert.equal(result.contract.agent.source, "project");
+			assert.ok(result.contract.agent.shadowedCandidates.some((candidate) => candidate.name === "worker" && candidate.source === "builtin"));
+			assert.equal(result.contract.model, "test/primary:high");
+			assert.deepEqual(result.contract.modelCandidates, ["test/primary:high", "test/fallback:high"]);
+			assert.equal(result.contract.thinking, "high");
+			assert.deepEqual(result.contract.skills.requested, ["project-skill"]);
+			assert.equal(result.contract.skills.resolved[0]?.name, "project-skill");
+			assert.deepEqual(result.contract.tools.effectiveAllowlist, ["read"]);
+			assert.deepEqual(result.contract.tools.capabilityAudit?.removedTools, ["write"]);
+			assert.equal(result.contract.tools.capabilityAudit?.removedExtensionCount, 1);
+			assert.equal(result.contract.tools.disableAmbientExtensions, true);
+			assert.equal(result.contract.roots.sessionFile, path.join(sessionRoot, "run-123", "run-0", "session.jsonl"));
+			assert.equal(result.contract.roots.outputPath, path.join(cwd, ".pi-subagents", "artifacts", "outputs", "run-123", "report.md"));
+			assert.match(result.contract.digest, /^[a-f0-9]{64}$/);
+			const repeated = await resolveSubagentLaunchContract({
+				agent: "worker",
+				cwd,
+				task: "Inspect the repo",
+				runId: "run-123",
+				sessionRoot,
+				availableModels: [
+					{ provider: "test", id: "primary", fullId: "test/primary" },
+					{ provider: "test", id: "fallback", fullId: "test/fallback" },
+				],
+				capabilityCeiling: ceiling,
+			});
+			assert.equal(repeated.ok, true);
+			assert.equal(repeated.contract.digest, result.contract.digest);
+			assert.equal(fs.existsSync(sessionRoot), false);
+			assert.equal(fs.existsSync(path.join(cwd, ".pi-subagents")), false);
+		} finally {
+			handle.dispose();
+		}
+	});
+
+	it("returns closed failures for missing agents and missing skills", async () => {
+		const cwd = path.join(tempDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Project worker
+skills:
+  - missing-skill
+---
+Project prompt.
+`);
+
+		const missingAgent = await resolveSubagentLaunchContract({ agent: "missing", cwd });
+		assert.deepEqual(missingAgent, { ok: false, code: "missing_agent", message: "Unknown agent: missing", diagnostics: [] });
+
+		const missingSkill = await resolveSubagentLaunchContract({ agent: "worker", cwd });
+		assert.equal(missingSkill.ok, false);
+		assert.equal(missingSkill.code, "missing_skill");
+		assert.match(missingSkill.message, /missing-skill/);
+	});
+
+	it("fails closed for invalid runtime inputs", async () => {
+		const cwd = path.join(tempDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Project worker
+---
+Project prompt.
+`);
+
+		const invalidCwd = await resolveSubagentLaunchContract({ agent: "worker", cwd: path.join(tempDir, "missing") });
+		assert.equal(invalidCwd.ok, false);
+		assert.equal(invalidCwd.code, "invalid_cwd");
+
+		const unsupportedMode = await resolveSubagentLaunchContract({ agent: "worker", cwd, context: "bogus" as never });
+		assert.equal(unsupportedMode.ok, false);
+		assert.equal(unsupportedMode.code, "unsupported_mode");
+
+		const invalidArtifactDir = await resolveSubagentLaunchContract({ agent: "worker", cwd, artifactDir: "bogus" as never });
+		assert.equal(invalidArtifactDir.ok, false);
+		assert.equal(invalidArtifactDir.code, "invalid_artifact_dir");
+	});
+
+	it("projects MCP, extension, fanout, structured-output, and fork diagnostics", async () => {
+		const cwd = path.join(tempDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeMcpFixture();
+		writeAgent(path.join(cwd, ".pi", "agents", "fanout.md"), `---
+name: fanout
+description: Project fanout
+tools:
+  - read
+  - subagent
+  - /tmp/tool-ext.ts
+  - mcp:github/search_repositories
+extensions:
+  - /tmp/config-ext.ts
+subagentOnlyExtensions:
+  - /tmp/subagent-only.ts
+defaultContext: fork
+---
+Project prompt.
+`);
+
+		const result = await resolveSubagentLaunchContract({
+			agent: "fanout",
+			cwd,
+			outputSchema: { type: "object", additionalProperties: false },
+		});
+		assert.equal(result.ok, true);
+		assert.equal(result.contract.context, "fork");
+		assert.ok(result.contract.diagnostics.some((diagnostic) => diagnostic.code === "host_required"));
+		assert.deepEqual(result.contract.tools.declaredBuiltin, ["read", "subagent"]);
+		assert.equal(result.contract.tools.explicitAllowlist, true);
+		assert.equal(result.contract.tools.fanoutAuthorized, true);
+		assert.deepEqual(result.contract.tools.internalTools, ["structured_output"]);
+		assert.deepEqual(result.contract.tools.effectiveMcpTools, ["github_search_repositories"]);
+		assert.deepEqual(result.contract.tools.requiredChildTools, ["read", "subagent", "github_search_repositories", "structured_output"]);
+		assert.deepEqual(result.contract.tools.toolExtensionPaths, ["/tmp/tool-ext.ts"]);
+		assert.equal(result.contract.tools.disableAmbientExtensions, true);
+		assert.ok(result.contract.tools.runtimeExtensions.some((extensionPath) => extensionPath.endsWith("subagent-prompt-runtime.ts")));
+		assert.ok(result.contract.tools.runtimeExtensions.some((extensionPath) => extensionPath.endsWith("fanout-child.ts")));
+		assert.ok(result.contract.tools.extensionArgs.includes("/tmp/config-ext.ts"));
+		assert.ok(result.contract.tools.extensionArgs.includes("/tmp/subagent-only.ts"));
+	});
+
+	it("fails closed when a capability ceiling denies read required for child skills", async () => {
+		const cwd = path.join(tempDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeSkill(cwd, "project-skill");
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Project worker
+tools:
+  - read
+skills:
+  - project-skill
+---
+Project prompt.
+`);
+
+		const result = await resolveSubagentLaunchContract({
+			agent: "worker",
+			cwd,
+			capabilityCeiling: { version: 1, allowedTools: [], denyExtensions: false, sources: ["test"] },
+		});
+		assert.equal(result.ok, false);
+		assert.equal(result.code, "denied_required_tool");
+		assert.match(result.message, /excludes required tool 'read'/);
+	});
+});


### PR DESCRIPTION
Closes #634.

Adds a public `pi-subagents/preflight` export for resolving an ordinary single-agent launch contract without creating child sessions, temp prompt files, structured-output runtimes, tool diagnostics, or run artifacts. The contract reports agent identity/shadowing, context, model/thinking candidates, skills, tools/MCP/extensions, capability-ceiling audit data, artifact/session roots, protocol versions, diagnostics, and a stable digest.

The implementation extracts the shared pure tool planner used by `buildPiArgs` so preflight and launch tool semantics stay aligned. Closed preflight failures cover missing/ambiguous agents, missing skills, denied required tools, invalid cwd, invalid artifactDir, and unsupported context values; host-only fork/model facts are surfaced as `host_required` diagnostics.

Validation:
- `node --experimental-strip-types --test test/unit/preflight.test.ts test/unit/package-manifest.test.ts test/unit/pi-args.test.ts test/unit/capability-ceiling-pi-args.test.ts` — 62 passed
- `git diff --check` — passed
- `npm pack --dry-run` — passed and includes `src/api/preflight.ts`
- Fresh review: /tmp/pi-subagents-remaining-backlog-20260724/issue-634-preflight-review.md found two blockers; both fixed
- Targeted follow-up review: /tmp/pi-subagents-remaining-backlog-20260724/issue-634-preflight-followup-review.md — PASS

Head commit: d7393edaf27cddd7dc7c52da9df996195c66f0c9