### PR TITLE
fix: tidy unreleased launch contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 - Added durable v3 process-terminal proof for detached async runners, with exact close observation, conservative unknown states after observer loss, and status/RPC projections. Thanks to shaggitza for #626.
 - Added `subagents.defaultThinking` for project- or user-scoped default thinking levels on agents without explicit thinking settings. Thanks to corrius for #612.
 - Documented that builtin worker and delegate agents use strict tool allowlists and do not inherit ambient parent extension tools; custom agents must explicitly name extension tools and load their providers. Thanks to buihongduc132 for #586.
+
+### Fixed
+- Bound public preflight launch digests to resolved skill injection metadata, matching execution when skill descriptions change.
+- Classified missing resolved MCP direct tools as a host/pi-mcp-adapter child-registration problem while preserving strict fail-closed diagnostics. Thanks to peedrr for #638.
+
+## [0.36.0] - 2026-07-24
+
+### Added
 - Added versioned aggregate handoff manifests for worktree-isolated parallel runs, including per-child status and output references, durable patch metadata, explicit cleanup outcomes, async status/result projection, and completion-delivery paths.
 - Added delegation v2 for extension-owned concurrent foreground leaves, with logical run/node ownership, exact per-attempt cancellation, explicit duplicate-node outcomes, literal or structured values, effective model/thinking metadata, detailed usage, and an exact zero-tool budget while preserving delegation v1 and the model-facing single-dispatch guard. Thanks to Jakub Neumann (@neumie) for #610.
 - Added acknowledged `steer` support to the extension RPC for exact-child async orchestration without recovery replacement. Thanks to Daan Bosch (@daanbosch) for #607.
@@ -21,7 +29,6 @@
 
 ### Fixed
 - Kept explicit empty and MCP-only child tool allowlists from falling back to Pi's default builtin tools. Thanks to @jstokke for #628.
-- Classified missing resolved MCP direct tools as a host/pi-mcp-adapter child-registration problem while preserving strict fail-closed diagnostics. Thanks to peedrr for #638.
 - Kept completed Fleet inspector durations stable when legacy terminal status lacks an explicit end timestamp, preventing time-sensitive redraws from changing rendered snapshots.
 - Deferred strict child tool availability diagnostics until after child extension startup hooks, so tools registered asynchronously by child-only extensions no longer falsely fail as unavailable. Thanks to ConjugativeIndicator (@CovetingEpiphany2152) for #567.
 - Made parent-facing subagent tool descriptions lead with delegation and clarified that `action` is omitted for execution. Thanks to @donwellsav for #600.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-subagents",
-  "version": "0.35.1",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-subagents",
-      "version": "0.35.1",
+      "version": "0.36.0",
       "license": "MIT",
       "dependencies": {
         "jiti": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-subagents",
-  "version": "0.35.1",
+  "version": "0.36.0",
   "description": "Pi extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification",
   "author": "Nico Bailon",
   "license": "MIT",

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -162,7 +162,10 @@ export type SubagentLaunchContractResult =
 function packageVersion(): string {
 	const packagePath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
 	const parsed = JSON.parse(fs.readFileSync(packagePath, "utf-8")) as { version?: unknown };
-	return typeof parsed.version === "string" ? parsed.version : "0.0.0";
+	if (typeof parsed.version !== "string" || !parsed.version.trim()) {
+		throw new Error(`Invalid package version in '${packagePath}'.`);
+	}
+	return parsed.version;
 }
 
 function stableJson(value: unknown): string {
@@ -297,8 +300,8 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		return { ok: false, code: "missing_skill", message: `Missing skills: ${resolvedSkills.missing.join(", ")}`, diagnostics };
 	}
 	let effectiveSystemPrompt = agent.systemPrompt?.trim() ?? "";
-	if (resolvedSkills.length > 0) {
-		const skillInjection = buildSkillInjection(resolvedSkills);
+	if (resolvedSkills.resolved.length > 0) {
+		const skillInjection = buildSkillInjection(resolvedSkills.resolved);
 		effectiveSystemPrompt = effectiveSystemPrompt ? `${effectiveSystemPrompt}\n\n${skillInjection}` : skillInjection;
 	}
 	const memoryInjection = buildAgentMemoryInjection(agent, effectiveCwd);

--- a/src/runs/background/process-terminal.ts
+++ b/src/runs/background/process-terminal.ts
@@ -35,13 +35,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function validProcessInstance(value: unknown, kind?: "runner" | "pi-writer"): value is ProcessInstanceExitV1 {
 	if (!isRecord(value)) return false;
-	return typeof value.processInstanceId === "string"
-		&& value.processInstanceId.length > 0
-		&& (kind ? value.kind === kind : (value.kind === "runner" || value.kind === "pi-writer"))
-		&& typeof value.closeObservedAt === "number"
-		&& Number.isFinite(value.closeObservedAt)
-		&& (typeof value.exitCode === "number" || value.exitCode === null)
-		&& (typeof value.signal === "string" || value.signal === null);
+	if (typeof value.processInstanceId !== "string" || value.processInstanceId.length === 0) return false;
+	if (kind ? value.kind !== kind : (value.kind !== "runner" && value.kind !== "pi-writer")) return false;
+	if (typeof value.closeObservedAt !== "number" || !Number.isFinite(value.closeObservedAt)) return false;
+	if (typeof value.exitCode !== "number" && value.exitCode !== null) return false;
+	if (typeof value.signal !== "string" && value.signal !== null) return false;
+	return value.kind === "runner"
+		? value.attempt === undefined
+		: typeof value.attempt === "number" && Number.isInteger(value.attempt) && value.attempt >= 0;
 }
 
 function validInstance(value: unknown): value is ProcessInstanceExitV1 {
@@ -170,6 +171,29 @@ export function readProcessTerminal(asyncDir: string, fallback?: { runId?: strin
 	}
 }
 
+function stepProcessTerminalProof(
+	proof: ProcessTerminalV1,
+	childIndex: number,
+	state: ProcessTerminalV1["state"],
+	records: ProcessInstanceExitV1[],
+	resumeDispositionValue: ProcessTerminalV1["resumeDisposition"],
+): ProcessTerminalV1 {
+	const base = {
+		version: 1 as const,
+		runId: proof.runId,
+		childIndex,
+		runnerProcessInstanceId: proof.runnerProcessInstanceId,
+		...(resumeDispositionValue ? { resumeDisposition: resumeDispositionValue } : {}),
+	};
+	if (state === "observed") {
+		return { ...base, state, observedAt: proof.state === "observed" ? proof.observedAt : Date.now(), instances: records };
+	}
+	if (state === "unknown") {
+		return { ...base, state, reason: proof.state === "unknown" ? proof.reason : "writer-close-unverified" };
+	}
+	return { ...base, state };
+}
+
 function overlayStatus(asyncDir: string, proof: ProcessTerminalV1, candidate?: ProcessTerminalCandidate): void {
 	const statusPath = path.join(asyncDir, "status.json");
 	try {
@@ -180,13 +204,7 @@ function overlayStatus(asyncDir: string, proof: ProcessTerminalV1, candidate?: P
 				const records = candidate?.writers[String(index)] ?? [];
 				const expected = candidate?.expectedWriters?.[String(index)] ?? (records.length > 0 ? records.length : 0);
 				const stepState = expected === 0 ? "not-started" : proof.state === "observed" && records.length === expected ? "observed" : proof.state === "pending" ? "pending" : "unknown";
-				step.processTerminal = {
-					...proof,
-					state: stepState,
-					childIndex: index,
-					...(records.length ? { instances: records } : {}),
-					resumeDisposition: resumeDisposition(step.status, step.sessionFile ?? candidate?.sessionFile),
-				};
+				step.processTerminal = stepProcessTerminalProof(proof, index, stepState, records, resumeDisposition(step.status, step.sessionFile ?? candidate?.sessionFile));
 			}
 		}
 		writeAtomicJson(statusPath, status);

--- a/src/runs/shared/capability-ceiling.ts
+++ b/src/runs/shared/capability-ceiling.ts
@@ -4,10 +4,9 @@ export const SUBAGENT_CAPABILITY_CEILING_VERSION = 1 as const;
 export const SUBAGENT_CAPABILITY_CEILING_REGISTRY_KEY = "pi-subagents.capability-ceiling.v1";
 export const SUBAGENT_CAPABILITY_CEILING_ENV = "PI_SUBAGENT_CAPABILITY_CEILING_V1";
 
-export interface SubagentCapabilityCeiling {
-	allowedTools?: readonly string[];
-	denyExtensions?: boolean;
-}
+export type SubagentCapabilityCeiling =
+	| { allowedTools: readonly string[]; denyExtensions?: boolean }
+	| { allowedTools?: readonly string[]; denyExtensions: boolean };
 
 export interface ResolvedSubagentCapabilityCeiling {
 	version: typeof SUBAGENT_CAPABILITY_CEILING_VERSION;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -333,14 +333,24 @@ export type ProcessTerminalReason =
 	| "proof-write-failed"
 	| "stale-repair";
 
-export interface ProcessInstanceExitV1 {
+export interface RunnerProcessInstanceExitV1 {
 	processInstanceId: string;
-	kind: "runner" | "pi-writer";
-	attempt?: number;
+	kind: "runner";
 	closeObservedAt: number;
 	exitCode: number | null;
 	signal: string | null;
 }
+
+export interface PiWriterProcessInstanceExitV1 {
+	processInstanceId: string;
+	kind: "pi-writer";
+	attempt: number;
+	closeObservedAt: number;
+	exitCode: number | null;
+	signal: string | null;
+}
+
+export type ProcessInstanceExitV1 = RunnerProcessInstanceExitV1 | PiWriterProcessInstanceExitV1;
 
 export interface CanonicalSessionTerminalV1 {
 	canonicalSessionId: string;
@@ -349,19 +359,27 @@ export interface CanonicalSessionTerminalV1 {
 	canonicalSessionLeaseReleased?: true;
 }
 
-export interface ProcessTerminalV1 {
+interface ProcessTerminalBaseV1 {
 	version: 1;
-	state: ProcessTerminalState;
 	runId: string;
 	childIndex?: number;
 	runnerProcessInstanceId: string;
-	observedAt?: number;
-	instances?: ProcessInstanceExitV1[];
-	canonicalSession?: CanonicalSessionTerminalV1;
 	resumeDisposition?: "resumable" | "non-resumable" | "unavailable";
-	reason?: ProcessTerminalReason;
-	diagnostic?: string;
 }
+
+export type ProcessTerminalV1 =
+	| (ProcessTerminalBaseV1 & { state: "pending" | "not-started" })
+	| (ProcessTerminalBaseV1 & {
+		state: "observed";
+		observedAt: number;
+		instances: ProcessInstanceExitV1[];
+		canonicalSession?: CanonicalSessionTerminalV1;
+	})
+	| (ProcessTerminalBaseV1 & {
+		state: "unknown";
+		reason: ProcessTerminalReason;
+		diagnostic?: string;
+	});
 
 export type SteeringActionState = "delivered" | "scheduled" | "pending" | "partial" | "recovered" | "failed";
 export type SteeringTargetState = "scheduled" | "routed" | "delivered" | "late" | "failed" | "recovered";

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -182,6 +182,32 @@ Changed prompt.
 		assert.notEqual(after.contract.digest, before.contract.digest);
 	});
 
+	it("binds resolved skill content into the launch digest", async () => {
+		const cwd = path.join(tempDir, "repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeSkill(cwd, "digest-skill");
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Project worker
+tools:
+  - read
+skills:
+  - digest-skill
+---
+Project prompt.
+`);
+		const before = await resolveSubagentLaunchContract({ agent: "worker", cwd, runId: "skill-digest-test" });
+		assert.equal(before.ok, true);
+		fs.writeFileSync(path.join(cwd, ".pi", "skills", "digest-skill", "SKILL.md"), "---\ndescription: updated digest-skill\n---\n\nUse digest-skill.\n", "utf-8");
+		clearSkillCache();
+
+		const after = await resolveSubagentLaunchContract({ agent: "worker", cwd, runId: "skill-digest-test" });
+		assert.equal(after.ok, true);
+		assert.equal(after.contract.agent.definitionDigest, before.contract.agent.definitionDigest);
+		assert.notEqual(after.contract.launchContractDigest, before.contract.launchContractDigest);
+		assert.notEqual(after.contract.digest, before.contract.digest);
+	});
+
 	it("returns closed failures for missing agents and missing skills", async () => {
 		const cwd = path.join(tempDir, "repo");
 		fs.mkdirSync(cwd, { recursive: true });

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -652,24 +652,31 @@ describe("subagent prompt runtime", () => {
 
 	it("registers native supervisor tools at runtime when pi-intercom is absent", async () => {
 		setSupervisorEnv();
+		const previousRequiredTools = process.env[REQUIRED_CHILD_TOOLS_ENV];
+		delete process.env[REQUIRED_CHILD_TOOLS_ENV];
 		const handlers = new Map<string, (payload?: unknown) => unknown>();
 		const registered: string[] = [];
 
-		registerSubagentPromptRuntime({
-			on(event: string, handler: (payload?: unknown) => unknown) {
-				handlers.set(event, handler);
-			},
-			getAllTools: () => registered.map((name) => ({ name })),
-			registerTool(tool: { name: string }) {
-				registered.push(tool.name);
-			},
-		} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(tool: { name: string }): void });
+		try {
+			registerSubagentPromptRuntime({
+				on(event: string, handler: (payload?: unknown) => unknown) {
+					handlers.set(event, handler);
+				},
+				getAllTools: () => registered.map((name) => ({ name })),
+				registerTool(tool: { name: string }) {
+					registered.push(tool.name);
+				},
+			} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(tool: { name: string }): void });
 
-		handlers.get("session_start")?.({});
-		assert.deepEqual(registered, ["subagent_wait", "contact_supervisor"]);
+			handlers.get("session_start")?.({});
+			assert.deepEqual(registered, ["subagent_wait", "contact_supervisor"]);
 
-		await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT });
-		assert.deepEqual(registered, ["subagent_wait", "contact_supervisor", "intercom"]);
+			await handlers.get("before_agent_start")?.({ systemPrompt: BASE_PROMPT });
+			assert.deepEqual(registered, ["subagent_wait", "contact_supervisor", "intercom"]);
+		} finally {
+			if (previousRequiredTools === undefined) delete process.env[REQUIRED_CHILD_TOOLS_ENV];
+			else process.env[REQUIRED_CHILD_TOOLS_ENV] = previousRequiredTools;
+		}
 	});
 
 	it("records requested tools missing from the child registry after startup hooks settle", async () => {


### PR DESCRIPTION
This cleans up a few issues in the unreleased changes since `v0.36.0`.

It restores the package metadata and changelog release boundary to `0.36.0`, tightens the new process-terminal and capability-ceiling public types so impossible states are not representable, and fixes preflight launch digest computation so resolved skill metadata is included the same way execution includes it. It also isolates a prompt-runtime unit test from inherited required-tool environment state.

Validation:

`node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/preflight.test.ts`

`node --experimental-strip-types --test test/unit/process-terminal.test.ts test/unit/capability-ceiling.test.ts test/unit/subagent-prompt-runtime.test.ts`

`node --experimental-strip-types --check src/api/preflight.ts src/runs/background/process-terminal.ts src/runs/shared/capability-ceiling.ts src/shared/types.ts test/unit/preflight.test.ts test/unit/subagent-prompt-runtime.test.ts`

`node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/unit/package-manifest.test.ts`

`node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts --test-name-pattern 'matches preflight launch digest|persists the actual launch digest'` (the runner executed the full file; 99 passed)

`npm pack --dry-run --json`

`git diff --check`
