### PR TITLE
fix: classify empty child responses accurately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Documented that builtin worker and delegate agents use strict tool allowlists and do not inherit ambient parent extension tools; custom agents must explicitly name extension tools and load their providers. Thanks to buihongduc132 for #586.
 
 ### Fixed
+- Preferred direct empty terminal-response evidence over stale tool errors so fallback models can retry abandoned child turns, and stopped treating successful tool output as a hidden failure. Thanks to Dmitry S. (@nuzayets) for #645.
 - Separated evidence acceptance from independent review: evidence levels now end at `verified`, risky runs carry an orthogonal review requirement, `review-required` reports pending review while preserving `evidenceStatus`, and `reviewed` is reserved for achieved independent review. Explicit `reviewed` remains schema-recognized solely for actionable preflight recovery. Thanks to Theodor Hillmann (@t0dorakis) for #440.
 - Bound public preflight launch digests to resolved skill injection metadata, matching execution when skill descriptions change.
 - Classified missing resolved MCP direct tools as a host/pi-mcp-adapter child-registration problem while preserving strict fail-closed diagnostics. Thanks to peedrr for #638.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -68,7 +68,7 @@ import { formatModelAttemptNote, isRetryableModelFailure } from "../shared/model
 import { markProcessTerminalCandidateLeaseRelease, writeProcessTerminalCandidate, type ProcessTerminalCandidate } from "./process-terminal.ts";
 import { createSteeringStatus, recordSteeringRequest, steeringStatus, terminalSteeringNoticeState, updateSteeringTarget } from "./steering.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
-import { detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput, readStatus } from "../../shared/utils.ts";
+import { detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput, hasEmptyTerminalAssistantResponse, readStatus } from "../../shared/utils.ts";
 import { evaluateCompletionMutationGuard } from "../shared/completion-guard.ts";
 import {
 	createMutatingFailureState,
@@ -1293,7 +1293,12 @@ async function runSingleStep(
 		const missingStructuredOutput = effectiveStructuredOutput
 			? !fs.existsSync(effectiveStructuredOutput.outputPath)
 			: false;
-		const emptyOutputError = run.exitCode === 0 && !run.error && !toolAvailabilityError && !hiddenError?.hasError && !run.finalOutput.trim() && (!effectiveStructuredOutput || missingStructuredOutput)
+		const emptyOutputError = run.exitCode === 0
+			&& !run.error
+			&& !toolAvailabilityError
+			&& !run.finalOutput.trim()
+			&& (!effectiveStructuredOutput || missingStructuredOutput)
+			&& (!hiddenError?.hasError || hasEmptyTerminalAssistantResponse(run.messages))
 			? "Subagent produced no output (possible model cold-start or empty response)."
 			: undefined;
 		let structuredOutput: unknown;
@@ -1329,23 +1334,22 @@ async function runSingleStep(
 		const completionGuardError = completionGuardTriggered && !isAgentContractV1(step.agentContract)
 			? "Subagent completed without making edits for an implementation task.\nIt appears to have returned planning or scratchpad output instead of applying changes."
 			: undefined;
-		const effectiveExitCode = toolAvailabilityError || (completionGuardTriggered && !isAgentContractV1(step.agentContract)) || structuredError
+		const effectiveExitCode = toolAvailabilityError || (completionGuardTriggered && !isAgentContractV1(step.agentContract)) || structuredError || emptyOutputError
 			? 1
 			: hiddenError?.hasError
 				? (hiddenError.exitCode ?? 1)
-				: emptyOutputError
+				: run.error && run.exitCode === 0
 					? 1
-					: run.error && run.exitCode === 0
-						? 1
-						: run.exitCode;
+					: run.exitCode;
 		const error = toolAvailabilityError
 			?? completionGuardError
 			?? structuredError
+			?? emptyOutputError
 			?? (hiddenError?.hasError
 				? hiddenError.details
 					? `${hiddenError.errorType} failed (exit ${effectiveExitCode}): ${hiddenError.details}`
 					: `${hiddenError.errorType} failed with exit code ${effectiveExitCode}`
-				: emptyOutputError ?? (run.error || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined)));
+				: run.error || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined));
 		const attempt: ModelAttempt = {
 			model: candidate ?? run.model ?? step.model ?? "default",
 			success: effectiveExitCode === 0 && !error,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -42,6 +42,7 @@ import {
 	getFinalOutput,
 	findLatestSessionFile,
 	detectSubagentError,
+	hasEmptyTerminalAssistantResponse,
 	extractToolArgsPreview,
 	extractTextFromContent,
 } from "../../shared/utils.ts";
@@ -1079,22 +1080,21 @@ async function runSingleAttempt(
 		result.exitCode = 1;
 	}
 	if (result.exitCode === 0 && !result.error) {
-		const errInfo = detectSubagentError(result.messages ?? []);
-		if (errInfo.hasError) {
+		const messages = result.messages ?? [];
+		const finalText = getFinalOutput(messages);
+		const missingStructuredOutput = options.structuredOutput
+			? !existsSync(options.structuredOutput.outputPath)
+			: false;
+		const errInfo = detectSubagentError(messages);
+		const missingOutput = !finalText?.trim() && (!options.structuredOutput || missingStructuredOutput);
+		if (missingOutput && (!errInfo.hasError || hasEmptyTerminalAssistantResponse(messages))) {
+			result.exitCode = 1;
+			result.error = "Subagent produced no output (possible model cold-start or empty response).";
+		} else if (errInfo.hasError) {
 			result.exitCode = errInfo.exitCode ?? 1;
 			result.error = errInfo.details
 				? `${errInfo.errorType} failed (exit ${errInfo.exitCode}): ${errInfo.details}`
 				: `${errInfo.errorType} failed with exit code ${errInfo.exitCode}`;
-		}
-	}
-	if (result.exitCode === 0 && !result.error) {
-		const finalText = getFinalOutput(result.messages ?? []);
-		const missingStructuredOutput = options.structuredOutput
-			? !existsSync(options.structuredOutput.outputPath)
-			: false;
-		if (!finalText?.trim() && (!options.structuredOutput || missingStructuredOutput)) {
-			result.exitCode = 1;
-			result.error = "Subagent produced no output (possible model cold-start or empty response).";
 		}
 	}
 	if (options.structuredOutput && result.exitCode === 0 && !result.error) {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -412,6 +412,14 @@ export function compactForegroundDetails(details: Details): Details {
 	};
 }
 
+export function hasEmptyTerminalAssistantResponse(messages: Message[]): boolean {
+	const lastAssistant = messages.findLast((message) => message.role === "assistant");
+	return lastAssistant?.role === "assistant"
+		&& Array.isArray(lastAssistant.content)
+		&& lastAssistant.content.length === 0
+		&& lastAssistant.usage.output === 0;
+}
+
 /**
  * Detect errors in subagent execution from messages (only errors with no subsequent success)
  */
@@ -438,50 +446,17 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 		const toolName = "toolName" in msg && typeof msg.toolName === "string" ? msg.toolName : undefined;
 		const isError = "isError" in msg && msg.isError === true;
 
-		if (isError) {
-			const text = msg.content.find((c) => c.type === "text");
-			const details = text && "text" in text ? text.text : undefined;
-			const exitMatch = details?.match(/exit(?:ed)?\s*(?:with\s*)?(?:code|status)?\s*[:\s]?\s*(\d+)/i);
-			return {
-				hasError: true,
-				exitCode: exitMatch ? parseInt(exitMatch[1], 10) : 1,
-				errorType: toolName || "tool",
-				details: details?.slice(0, 200),
-			};
-		}
-
-		if (toolName !== "bash") continue;
+		if (!isError) continue;
 
 		const text = msg.content.find((c) => c.type === "text");
-		if (!text || !("text" in text)) continue;
-		const output = text.text;
-
-		const exitMatch = output.match(/exit(?:ed)?\s*(?:with\s*)?(?:code|status)?\s*[:\s]?\s*(\d+)/i);
-		if (exitMatch) {
-			const code = parseInt(exitMatch[1], 10);
-			if (code !== 0) {
-				return { hasError: true, exitCode: code, errorType: "bash", details: output.slice(0, 200) };
-			}
-		}
-
-		// NOTE: These patterns can match legitimate output (grep results, logs,
-		// testing). With the assistant-message check above, most false positives
-		// are mitigated since the agent will have responded after routine errors.
-		const fatalPatterns = [
-			/command not found/i,
-			/permission denied/i,
-			/no such file or directory/i,
-			/segmentation fault/i,
-			/killed|terminated/i,
-			/out of memory/i,
-			/connection refused/i,
-			/timeout/i,
-		];
-		for (const pattern of fatalPatterns) {
-			if (pattern.test(output)) {
-				return { hasError: true, exitCode: 1, errorType: "bash", details: output.slice(0, 200) };
-			}
-		}
+		const details = text && "text" in text ? text.text : undefined;
+		const exitMatch = details?.match(/exit(?:ed)?\s*(?:with\s*)?(?:code|status)?\s*[:\s]?\s*(\d+)/i);
+		return {
+			hasError: true,
+			exitCode: exitMatch ? parseInt(exitMatch[1], 10) : 1,
+			errorType: toolName || "tool",
+			details: details?.slice(0, 200),
+		};
 	}
 
 	return { hasError: false };

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -2550,6 +2550,54 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(mockPi.callCount(), 2);
 	});
 
+	it("background runs prefer empty-output fallback over an earlier tool error", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [
+				events.toolResult("read", "ENOENT: no such file or directory", true),
+				events.toolResult("read", "recovered file contents"),
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "openai/gpt-5-mini",
+						stopReason: "stop",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+			],
+			exitCode: 0,
+		});
+		mockPi.onCall({ output: "Recovered asynchronously on fallback" });
+		const id = `async-empty-output-after-tool-error-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", {
+				model: "openai/gpt-5-mini",
+				fallbackModels: ["anthropic/claude-sonnet-4"],
+			}),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		assert.equal(payload.success, true);
+		assert.equal(payload.results[0]?.model, "anthropic/claude-sonnet-4");
+		assert.match(payload.results[0]?.modelAttempts?.[0]?.error ?? "", /no output/i);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
 	it("background runs fail zero-exit provider errors when no fallback succeeds", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			jsonl: [{

--- a/test/integration/detect-error.test.ts
+++ b/test/integration/detect-error.test.ts
@@ -69,6 +69,13 @@ describe("detectSubagentError", { skip: !available ? "utils not importable" : un
 		assert.equal(detectSubagentError(messages).hasError, false);
 	});
 
+	it("does not infer failure from successful bash output", () => {
+		const messages = [
+			toolResult("bash", "diff --git a/src/queue.ts b/src/queue.ts\n+ await new Promise((resolve) => setTimeout(resolve, 0))"),
+		];
+		assert.equal(detectSubagentError(messages).hasError, false);
+	});
+
 	it("detects isError tool result as failure (no assistant response)", () => {
 		const messages = [
 			toolResult("read", "file contents"),
@@ -80,18 +87,18 @@ describe("detectSubagentError", { skip: !available ? "utils not importable" : un
 		assert.match(result.details!, /EISDIR/);
 	});
 
-	it("detects bash fatal pattern (permission denied, no assistant response)", () => {
+	it("detects bash error (permission denied, no assistant response)", () => {
 		const messages = [
-			toolResult("bash", "ls: permission denied: /root/secret"),
+			toolResult("bash", "ls: permission denied: /root/secret", true),
 		];
 		const result = detectSubagentError(messages);
 		assert.equal(result.hasError, true);
 		assert.equal(result.errorType, "bash");
 	});
 
-	it("detects bash exit code in output", () => {
+	it("extracts a bash exit code from error output", () => {
 		const messages = [
-			toolResult("bash", "error: process exited with code 127"),
+			toolResult("bash", "error: process exited with code 127", true),
 		];
 		const result = detectSubagentError(messages);
 		assert.equal(result.hasError, true);
@@ -129,9 +136,9 @@ describe("detectSubagentError", { skip: !available ? "utils not importable" : un
 			"agent produced substantive output after error — not a failure");
 	});
 
-	it("ignores bash fatal pattern when agent responded after", () => {
+	it("ignores bash error when agent responded after", () => {
 		const messages = [
-			toolResult("bash", "ls: permission denied: /root/secret"),
+			toolResult("bash", "ls: permission denied: /root/secret", true),
 			assistantMsg("I couldn't access /root/secret, but I found the data elsewhere."),
 		];
 		const result = detectSubagentError(messages);
@@ -145,7 +152,7 @@ describe("detectSubagentError", { skip: !available ? "utils not importable" : un
 		const messages = [
 			assistantMsg("Here is my analysis..."),
 			toolResult("bash", "rm -rf /important", false),
-			toolResult("bash", "error: process exited with code 1", false),
+			toolResult("bash", "error: process exited with code 1", true),
 		];
 		const result = detectSubagentError(messages);
 		assert.equal(result.hasError, true);
@@ -168,7 +175,7 @@ describe("detectSubagentError", { skip: !available ? "utils not importable" : un
 	it("flags error when no assistant messages at all", () => {
 		const messages = [
 			toolResult("read", "ok"),
-			toolResult("bash", "segmentation fault"),
+			toolResult("bash", "segmentation fault", true),
 		];
 		const result = detectSubagentError(messages);
 		assert.equal(result.hasError, true,
@@ -181,7 +188,7 @@ describe("detectSubagentError", { skip: !available ? "utils not importable" : un
 		// assistant message doesn't count as recovery. The final tool result is
 		// successful to ensure this test actually distinguishes correct behavior.
 		const messages = [
-			toolResult("bash", "permission denied: /etc/shadow"),
+			toolResult("bash", "permission denied: /etc/shadow", true),
 			assistantToolCall("bash"),
 			toolResult("bash", "command succeeded"),
 		];

--- a/test/integration/error-handling.test.ts
+++ b/test/integration/error-handling.test.ts
@@ -49,13 +49,13 @@ describe("detectSubagentError", { skip: !detectSubagentError ? "utils not import
 		assert.equal(result.hasError, false);
 	});
 
-	it("detects fatal bash error in last tool result", () => {
+	it("detects bash error in last tool result", () => {
 		const messages = [
 			{ role: "assistant", content: [{ type: "text", text: "Running..." }] },
 			{
 				role: "toolResult",
 				toolName: "bash",
-				isError: false,
+				isError: true,
 				content: [{ type: "text", text: "command not found" }],
 			},
 		];
@@ -64,13 +64,13 @@ describe("detectSubagentError", { skip: !detectSubagentError ? "utils not import
 		assert.equal(result.errorType, "bash");
 	});
 
-	it("detects non-zero exit code in bash output", () => {
+	it("extracts a non-zero exit code from bash error output", () => {
 		const messages = [
 			{ role: "assistant", content: [{ type: "text", text: "Running..." }] },
 			{
 				role: "toolResult",
 				toolName: "bash",
-				isError: false,
+				isError: true,
 				content: [{ type: "text", text: "Error: process exited with code 127" }],
 			},
 		];
@@ -146,9 +146,10 @@ describe("runSync error handling", { skip: !piAvailable ? "pi packages not avail
 	it("detectSubagentError overrides exit 0 on hidden failure", async () => {
 		mockPi.onCall({
 			jsonl: [
+				events.assistantMessage("Starting deployment"),
 				events.toolStart("bash", { command: "deploy" }),
 				events.toolEnd("bash"),
-				events.toolResult("bash", "connection refused"),
+				events.toolResult("bash", "connection refused", true),
 			],
 		});
 		const agents = makeAgentConfigs(["deployer"]);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1629,6 +1629,40 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(mockPi.callCount(), 2);
 	});
 
+	it("prefers empty-output fallback over an earlier tool error", async () => {
+		mockPi.onCall({
+			jsonl: [
+				events.toolResult("read", "ENOENT: no such file or directory", true),
+				events.toolResult("read", "recovered file contents"),
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "openai/gpt-5-mini",
+						stopReason: "stop",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+			],
+			exitCode: 0,
+		});
+		mockPi.onCall({ output: "Recovered on fallback" });
+		const agents = [makeAgent("echo", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+
+		const result = await runSync(tempDir, agents, "echo", "Task", {
+			runId: "fallback-empty-output-after-tool-error",
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.model, "anthropic/claude-sonnet-4");
+		assert.match(result.modelAttempts?.[0]?.error ?? "", /no output/i);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
 	it("fails zero-exit provider errors when no fallback succeeds", async () => {
 		mockPi.onCall({
 			jsonl: [{
@@ -1801,7 +1835,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 	it("does not retry on ordinary task/tool failures", async () => {
 		mockPi.onCall({
-			jsonl: [events.toolResult("bash", "process exited with code 127")],
+			jsonl: [events.toolResult("bash", "process exited with code 127", true)],
 			exitCode: 0,
 		});
 		const agents = [makeAgent("echo", {


### PR DESCRIPTION
## Summary

- trust `toolResult.isError` instead of scanning successful bash stdout for fatal-looking words
- prefer a zero-usage empty terminal assistant response over stale historical tool errors, restoring retryable model fallback
- preserve non-retryable classification and parsed exit codes for genuine unrecovered tool failures

Thanks to Dmitry S. (@nuzayets) for the detailed report, transcript analysis, and minimized reproductions in #645.

Closes #645.

## Validation

- `node --experimental-transform-types --import ./test/support/register-loader.mjs --test test/integration/detect-error.test.ts test/integration/error-handling.test.ts`
- focused foreground/background fallback, empty-terminal-response, and genuine-tool-failure tests
- `node --experimental-strip-types --check` on the three changed source files
- `git diff --check`
- fresh read-only review: no issues found