### PR TITLE
fix: match pi-mcp-adapter cache identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Classified verification-only tasks that prohibit product/source/config files as read-only. Thanks to @git-geeky for #648.
+- Matched pi-mcp-adapter metadata cache identity so valid direct MCP tools are not rejected as stale when tool filters, socket transport, URL interpolation, or command-backed secrets are configured. Thanks to @mattrobenolt for #649.
 
 ## [0.37.0] - 2026-07-25
 

--- a/src/runs/shared/mcp-direct-tool-allowlist.ts
+++ b/src/runs/shared/mcp-direct-tool-allowlist.ts
@@ -27,6 +27,7 @@ type ImportKind = keyof typeof IMPORT_PATHS;
 interface ServerEntry {
 	command?: string;
 	args?: string[];
+	socket?: string;
 	env?: Record<string, string>;
 	cwd?: string;
 	url?: string;
@@ -35,6 +36,7 @@ interface ServerEntry {
 	bearerToken?: string;
 	bearerTokenEnv?: string;
 	exposeResources?: boolean;
+	includeTools?: string[];
 	excludeTools?: string[];
 	directTools?: boolean | string[];
 }
@@ -271,14 +273,16 @@ export function computeMcpServerHash(definition: ServerEntry): string {
 	const identity: Record<string, unknown> = {
 		command: definition.command,
 		args: definition.args,
+		socket: resolveConfigPath(definition.socket),
 		env: interpolateEnvRecord(definition.env),
 		cwd: resolveConfigPath(definition.cwd),
-		url: definition.url,
+		url: resolveServerUrl(definition),
 		headers: interpolateEnvRecord(definition.headers),
 		auth: definition.auth,
 		bearerToken: resolveBearerToken(definition),
 		bearerTokenEnv: definition.bearerTokenEnv,
 		exposeResources: definition.exposeResources,
+		includeTools: definition.includeTools,
 		excludeTools: definition.excludeTools,
 	};
 	return createHash("sha256").update(stableStringify(identity)).digest("hex");
@@ -333,22 +337,51 @@ function resourceNameToToolName(name: string): string {
 }
 
 function interpolateEnvRecord(values: Record<string, string> | undefined): Record<string, string> | undefined {
-	if (!values || typeof values !== "object" || Array.isArray(values)) return undefined;
-	const resolved: Record<string, string> = {};
-	for (const [key, value] of Object.entries(values)) {
-		if (typeof value === "string") resolved[key] = interpolateEnvVars(value);
-	}
-	return resolved;
+	if (!values) return undefined;
+	return Object.fromEntries(Object.entries(values).map(([key, value]) => [key, interpolateSecretExpression(value)]));
 }
 
 function interpolateEnvVars(value: string): string {
 	return value
 		.replace(/\$\{(\w+)\}/g, (_, name: string) => process.env[name] ?? "")
-		.replace(/\$env:(\w+)/g, (_, name: string) => process.env[name] ?? "");
+		.replace(/\$env:(\w+)/g, (_, name: string) => process.env[name] ?? "")
+		.replace(/\{env:(\w+)\}/g, (_, name: string) => process.env[name] ?? "");
+}
+
+function interpolateSecretExpression(value: string): string {
+	if (value.startsWith("!!")) return interpolateEnvVars(value.slice(1));
+	return value.startsWith("!") ? value : interpolateEnvVars(value);
+}
+
+function getMissingEnvVars(value: string): string[] {
+	const missing = new Set<string>();
+	for (const match of value.matchAll(/\$\{(\w+)\}|\$env:(\w+)|\{env:(\w+)\}/g)) {
+		const name = match[1] ?? match[2] ?? match[3];
+		if (name && process.env[name] === undefined) missing.add(name);
+	}
+	return [...missing];
+}
+
+function resolveServerUrl(definition: Pick<ServerEntry, "url">): string | undefined {
+	if (definition.url == null) return undefined;
+	if (typeof definition.url !== "string") throw new Error("MCP server URL must be a string");
+
+	const missing = getMissingEnvVars(definition.url);
+	if (missing.length > 0) {
+		throw new Error(`Missing environment variable${missing.length === 1 ? "" : "s"} in MCP server URL: ${missing.join(", ")}`);
+	}
+
+	const resolved = interpolateEnvVars(definition.url);
+	try {
+		new URL(resolved);
+	} catch (error) {
+		throw new Error(`Invalid MCP server URL after environment interpolation: ${resolved}`, { cause: error });
+	}
+	return resolved;
 }
 
 function resolveConfigPath(value: string | undefined): string | undefined {
-	if (typeof value !== "string") return undefined;
+	if (value === undefined) return undefined;
 	const resolved = interpolateEnvVars(value);
 	if (resolved === "~") return os.homedir();
 	if (resolved.startsWith("~/") || resolved.startsWith("~\\")) return path.join(os.homedir(), resolved.slice(2));
@@ -356,8 +389,8 @@ function resolveConfigPath(value: string | undefined): string | undefined {
 }
 
 function resolveBearerToken(definition: Pick<ServerEntry, "bearerToken" | "bearerTokenEnv">): string | undefined {
-	if (typeof definition.bearerToken === "string") return interpolateEnvVars(definition.bearerToken);
-	return typeof definition.bearerTokenEnv === "string" ? process.env[definition.bearerTokenEnv] : undefined;
+	if (definition.bearerToken !== undefined) return interpolateSecretExpression(definition.bearerToken);
+	return definition.bearerTokenEnv ? process.env[definition.bearerTokenEnv] : undefined;
 }
 
 function stableStringify(value: unknown): string {

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -45,6 +45,8 @@ const originalEnv = {
 	[MCP_DIRECT_CHILD_TOOLS_ENV]: process.env[MCP_DIRECT_CHILD_TOOLS_ENV],
 	[TOOL_BUDGET_ZERO_AUTH_ENV]: process.env[TOOL_BUDGET_ZERO_AUTH_ENV],
 	[PI_CODING_AGENT_PACKAGE_ROOT_ENV]: process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV],
+	MCP_HASH_ROOT: process.env.MCP_HASH_ROOT,
+	MCP_HASH_TOKEN: process.env.MCP_HASH_TOKEN,
 };
 const originalCwd = process.cwd();
 const tempRoots: string[] = [];
@@ -590,6 +592,46 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		});
 
 		assert.equal(args[args.indexOf("--tools") + 1], "read,bash");
+	});
+
+	it("includes adapter tool filters in MCP cache identity", () => {
+		const base = { command: "npx", args: ["browser-mcp"] };
+
+		assert.notEqual(
+			computeMcpServerHash(base),
+			computeMcpServerHash({ ...base, includeTools: ["browser_navigate"] }),
+		);
+	});
+
+	it("matches pi-mcp-adapter 2.15.0 metadata cache hashes", () => {
+		process.env.MCP_HASH_ROOT = "/tmp/mcp-root";
+		process.env.MCP_HASH_TOKEN = "token-value";
+
+		assert.deepEqual(
+			[
+				computeMcpServerHash({
+					command: "npx",
+					args: ["-y", "browser-mcp"],
+					env: { ROOT: "{env:MCP_HASH_ROOT}", SECRET_COMMAND: "!op read test" },
+					cwd: "${MCP_HASH_ROOT}/server",
+					exposeResources: false,
+					includeTools: ["browser_navigate"],
+					excludeTools: ["browser_close"],
+				}),
+				computeMcpServerHash({
+					url: "https://example.test/$env:MCP_HASH_TOKEN",
+					headers: { Authorization: "Bearer ${MCP_HASH_TOKEN}", Secret: "!op read test" },
+					auth: "bearer",
+					bearerTokenEnv: "MCP_HASH_TOKEN",
+				}),
+				computeMcpServerHash({ socket: "{env:MCP_HASH_ROOT}/rmcp.sock" }),
+			],
+			[
+				"8af47bd5a801f42bd252789826df883c6f4db6f1d425b82f8561d75063fbe3a8",
+				"77db141e556d24c3740a4b4f0cd50d8c23309a28062282cc1ca724207359ef5a",
+				"77f7f77a3e8df990d8c78e99ca81508fd8d1f954e814ee7cbfa46719f71eb46b",
+			],
+		);
 	});
 
 	it("augments explicit builtin allowlists with selected direct MCP tool names", () => {


### PR DESCRIPTION
pi-subagents validates pi-mcp-adapter's metadata cache with a local copy of the adapter's server hash contract. That copy omitted `includeTools`, so every current cache entry failed validation, even when `includeTools` was unset, because stable serialization retains undefined fields. Direct MCP selections then resolved to an empty allowlist.

This updates the mirror to pi-mcp-adapter 2.15.0's full identity contract, including socket transport, URL interpolation, secret expressions, and `includeTools`. The parity test uses adapter-generated hash vectors for stdio, HTTP, and socket definitions, so it covers the reported regression and the other drift found while checking the contract.

The remaining risk is future adapter contract drift because the projects do not share the hash implementation.

Fixes #649