### PR TITLE
fix: treat product and config prohibitions as blanket no-edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Classified verification-only tasks that prohibit product/source/config files as read-only. Thanks to @git-geeky for #648.
+
 ## [0.37.0] - 2026-07-25
 
 ### Added

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -40,7 +40,7 @@ const REVIEWER_REQUIRED_EDIT_PATTERNS = [
 const NO_EDIT_PROHIBITION_PATTERN = /\b(?:do not|don't|must not)\s+(?:edit|modify|write(?:\s+to)?|touch|change)\b((?:(?!\b(?:but|and|then)\b)[^.;,:!?\n–—-])*)/gi;
 
 /** Objects of a no-edit prohibition that mean "the codebase in general" rather than a named scope. */
-const GENERIC_PROHIBITION_OBJECT = /^\s*(?:(?:any|all|the|these|those|your|our|existing|project|source|sources|repo|repository)[\s/,-]*)*(?:files?|code|codebase|sources?|anything|repo(?:sitory)?)?\s*$/i;
+const GENERIC_PROHIBITION_OBJECT = /^\s*(?:(?:any|all|the|these|those|your|our|existing|project|product|source|sources|config|configs|repo|repository)[\s/,-]*)*(?:files?|code|codebase|sources?|anything|repo(?:sitory)?)?\s*$/i;
 
 const SCOPED_NO_EDIT_CONSTRAINT_PATTERNS = [
 	/\bdo not edit files?\s+outside\b/i,

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -38,6 +38,7 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Do not edit files. Tell me how to fix the bug.").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("worker", "Report on the extraction pipeline. Do not modify project/source files.").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("reviewer", "Final correctness review after prior fixes. Inspect all changed files and tests. Do not modify project/source files. Report findings.").kind, "read-only");
+		assert.equal(classifyTaskMutationIntent("worker", "Verification-only task. Do not edit product/source/config files.\n   Run a disposable check, delete its temporary harness, and retain only\n   a sanitized report at an explicitly named artifact path.").kind, "read-only");
 	});
 
 	it("strips repeated prohibition phrases before testing write intent", () => {


### PR DESCRIPTION
`classifyTaskMutationIntent` treated `Do not edit product/source/config files.` as a scoped prohibition rather than a blanket one, because the generic scope vocabulary knew `project`, `source`, and `repo` but not `product` or `config`. After the prohibition was stripped, ordinary cleanup wording like `delete its temporary harness` matched the worker implementation verbs, so a verification-only run was classified as an implementation task. A successful child that correctly left the product tree untouched then got rewritten as `worker completed without making edits for an implementation task`.

This adds `product`, `config`, and `configs` to the generic no-edit objects so that established slash-separated blanket form is recognized. `test`/`tests` are deliberately not added, since `Do not modify tests; implement the fix` must stay scoped so the implementation clause still counts.

No new launch configuration. The reporter also asked for a per-run `completionGuard` override, but the public launch schemas intentionally omit it and that is separate scope, so it is not part of this fix.

Verified with `node --experimental-strip-types --test test/unit/task-intent.test.ts test/unit/completion-guard.test.ts` (31 passed) and `test/unit/acceptance.test.ts` (41 passed). The reporter's exact task now classifies `read-only` instead of `implementation`.

Fixes #648
