### PR TITLE
fix: accept launch contract digest in async recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Refreshed the bundled `pi-subagents` skill for 0.35–0.37 control and config surface: `/subagents`, `/subagents-stop`, `/subagents-watchdog`, `stop`/`append-step`, parallel `count`, watchdog overview, frontmatter `async`/`timeoutMs`/`turnBudget` defaults, `artifactDir`/`asyncWidget`, fresh/fork badges, and builtin worker/delegate ambient-tool boundaries.
 
 ### Fixed
+- Accepted persisted async recovery descriptors that include the launch contract digest written by async execution. Thanks to @boadij for #654 and #652.
 - Classified verification-only tasks that prohibit product/source/config files as read-only. Thanks to @git-geeky for #648.
 - Matched pi-mcp-adapter metadata cache identity so valid direct MCP tools are not rejected as stale when tool filters, socket transport, URL interpolation, or command-backed secrets are configured. Thanks to @mattrobenolt for #649.
 

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -285,7 +285,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': expected an object.`);
 	const parsed = value as Record<string, unknown>;
 	const allowedFields = new Set([
-		"version", "sourceRunId", "agentContract", "agent", "sessionFile", "cwd", "model", "fallbackModels", "thinking", "tools", "extensions",
+		"version", "launchContractDigest", "sourceRunId", "agentContract", "agent", "sessionFile", "cwd", "model", "fallbackModels", "thinking", "tools", "extensions",
 		"subagentOnlyExtensions", "mcpDirectTools", "systemPrompt", "systemPromptMode", "inheritProjectContext", "inheritSkills", "skills",
 		"skillPath", "agentFilePath", "completionGuard", "memory", "outputPath", "outputMode", "structuredOutputSchema", "acceptance", "sessionDir", "artifactConfig",
 		"artifactsDir", "maxOutput", "controlConfig", "absoluteDeadlineAt", "initialTurnBudget", "initialToolBudget", "maxSubagentDepth", "share", "capabilityCeiling",

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -315,7 +315,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 		if (item !== undefined && (!Array.isArray(item) || item.some((entry) => typeof entry !== "string" || !entry.trim()))) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${field} must contain non-empty strings.`);
 	}
 	if (parsed.systemPrompt !== undefined && typeof parsed.systemPrompt !== "string") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': systemPrompt must be a string.`);
-	for (const field of ["sessionFile", "model", "thinking", "agentFilePath", "outputPath", "sessionDir", "artifactsDir"] as const) {
+	for (const field of ["launchContractDigest", "sessionFile", "model", "thinking", "agentFilePath", "outputPath", "sessionDir", "artifactsDir"] as const) {
 		if (parsed[field] !== undefined && (typeof parsed[field] !== "string" || !(parsed[field] as string).trim())) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${field} must be a non-empty string.`);
 	}
 	if (parsed.completionGuard !== undefined && typeof parsed.completionGuard !== "boolean") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': completionGuard must be a boolean.`);

--- a/test/unit/async-recovery-descriptor.test.ts
+++ b/test/unit/async-recovery-descriptor.test.ts
@@ -31,4 +31,30 @@ describe("async recovery descriptor", () => {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	it("rejects malformed launchContractDigest values", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-recovery-bad-digest-"));
+		try {
+			fs.writeFileSync(path.join(root, "recovery-descriptor.json"), JSON.stringify({
+				version: 1,
+				launchContractDigest: {},
+				sourceRunId: "run-digest",
+				agent: "worker",
+				cwd: root,
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+				outputMode: "inline",
+				maxSubagentDepth: 2,
+				share: false,
+			}), "utf-8");
+
+			assert.throws(
+				() => readAsyncRecoveryDescriptor(root),
+				/launchContractDigest must be a non-empty string/,
+			);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
 });

--- a/test/unit/async-recovery-descriptor.test.ts
+++ b/test/unit/async-recovery-descriptor.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { readAsyncRecoveryDescriptor } from "../../src/runs/background/async-resume.ts";
+
+describe("async recovery descriptor", () => {
+	it("accepts launchContractDigest written by async execution", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-recovery-digest-"));
+		try {
+			const digest = "launch-contract-digest";
+			fs.writeFileSync(path.join(root, "recovery-descriptor.json"), JSON.stringify({
+				version: 1,
+				launchContractDigest: digest,
+				sourceRunId: "run-digest",
+				agent: "worker",
+				cwd: root,
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+				outputMode: "inline",
+				maxSubagentDepth: 2,
+				share: false,
+			}), "utf-8");
+
+			const descriptor = readAsyncRecoveryDescriptor(root);
+
+			assert.equal(descriptor?.launchContractDigest, digest);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Allow async recovery descriptors to contain `launchContractDigest`, matching the existing `SteeringRecoveryDescriptor` type and the async execution writer.

## Root cause

Async execution persists `launchContractDigest` in `recovery-descriptor.json`, but `readAsyncRecoveryDescriptor()` uses a strict allowlist that omitted the same field. Resuming a completed async run therefore failed before revival with:

```text
Invalid async recovery descriptor '.../recovery-descriptor.json': unknown field 'launchContractDigest'.
```

## Changes

- add `launchContractDigest` to the recovery descriptor allowlist
- add a focused unit regression test that parses a descriptor containing the field

## Validation

A completed async worker that previously failed at descriptor parsing was successfully revived after applying this change. The revived worker reused its persisted session context and completed normally.

The targeted unit regression test is included. Automated CI results are pending.

Closes #654