### PR TITLE
fix: stop FleetView refresh on stale context

### DIFF
--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -48,6 +48,13 @@ function isActiveState(value: string): boolean {
 	return value === "running" || value === "queued" || value === "pending";
 }
 
+function isStaleExtensionContextError(error: unknown): boolean {
+	// Pi currently exposes stale contexts as plain Errors without a stable code or subtype.
+	return error instanceof Error
+		&& (error.message.includes("This extension ctx is stale")
+			|| error.message.includes("Extension context no longer active"));
+}
+
 export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntry[] {
 	const entries: FleetStatusEntry[] = [];
 	for (const control of state.foregroundControls.values()) {
@@ -111,6 +118,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 
 export class SubagentFleetStatus {
 	private ctx: ExtensionContext | undefined;
+	private ui: ExtensionContext["ui"] | undefined;
 	private tui: FleetStatusTui | undefined;
 	private inputUnsubscribe: (() => void) | undefined;
 	private timer: ReturnType<typeof setInterval> | undefined;
@@ -138,15 +146,17 @@ export class SubagentFleetStatus {
 
 	setContext(ctx: ExtensionContext): void {
 		if (!ctx.hasUI) return;
-		if (this.ctx?.ui === ctx.ui) {
+		const ui = ctx.ui;
+		if (this.ui === ui) {
 			this.ctx = ctx;
 			this.refresh();
 			return;
 		}
 		this.clearUiRegistration();
 		this.ctx = ctx;
-		if (typeof ctx.ui.onTerminalInput === "function") {
-			this.inputUnsubscribe = ctx.ui.onTerminalInput((data) => this.handleKey(data));
+		this.ui = ui;
+		if (typeof ui.onTerminalInput === "function") {
+			this.inputUnsubscribe = ui.onTerminalInput((data) => this.handleKey(data));
 		}
 		this.timer = setInterval(() => this.refresh(), this.refreshMs);
 		this.timer.unref?.();
@@ -156,6 +166,7 @@ export class SubagentFleetStatus {
 	dispose(): void {
 		this.clearUiRegistration();
 		this.ctx = undefined;
+		this.ui = undefined;
 		this.entries = [];
 		this.active = false;
 		this.selectedKey = "main";
@@ -164,8 +175,8 @@ export class SubagentFleetStatus {
 	}
 
 	refresh(): void {
-		const ctx = this.ctx;
-		if (!ctx?.hasUI) return;
+		const ctx = this.getActiveUiContext();
+		if (!ctx) return;
 		this.entries = collectFleetStatusEntries(this.state);
 		this.clampSelection();
 		if (this.inspectorOpen || this.state.fleetInspectorOpen) {
@@ -215,8 +226,8 @@ export class SubagentFleetStatus {
 	}
 
 	handleKey(data: string): { consume?: boolean; data?: string } | undefined {
-		const ctx = this.ctx;
-		if (!ctx?.hasUI || this.entries.length === 0 || isKeyRelease(data)) return undefined;
+		const ctx = this.getActiveUiContext();
+		if (!ctx || this.entries.length === 0 || isKeyRelease(data)) return undefined;
 		if (this.inspectorOpen) return undefined;
 		if (!this.editorHasFocus()) {
 			if (this.active) this.deactivate();
@@ -344,19 +355,47 @@ export class SubagentFleetStatus {
 		});
 	}
 
+	private getActiveUiContext(): ExtensionContext | undefined {
+		const ctx = this.ctx;
+		if (!ctx) return undefined;
+		try {
+			return ctx.hasUI ? ctx : undefined;
+		} catch (error) {
+			if (!isStaleExtensionContextError(error)) throw error;
+			this.clearUiRegistration();
+			return undefined;
+		}
+	}
+
 	private clearUiRegistration(): void {
 		if (this.timer) clearInterval(this.timer);
 		this.timer = undefined;
-		this.inputUnsubscribe?.();
+
+		const inputUnsubscribe = this.inputUnsubscribe;
+		const ui = this.ui;
+		const widgetRegistered = this.widgetRegistered;
 		this.inputUnsubscribe = undefined;
-		if (this.ctx?.hasUI && this.widgetRegistered) {
-			try {
-				this.ctx.ui.setWidget(FLEET_STATUS_WIDGET_KEY, undefined);
-			} catch {
-				// The previous extension context may already be stale during reload/session replacement.
-			}
-		}
+		this.ctx = undefined;
+		this.ui = undefined;
 		this.widgetRegistered = false;
 		this.tui = undefined;
+
+		const cleanupErrors: unknown[] = [];
+		try {
+			inputUnsubscribe?.();
+		} catch (error) {
+			if (!isStaleExtensionContextError(error)) cleanupErrors.push(error);
+		}
+		if (ui && widgetRegistered) {
+			try {
+				ui.setWidget(FLEET_STATUS_WIDGET_KEY, undefined);
+			} catch (error) {
+				if (!isStaleExtensionContextError(error)) cleanupErrors.push(error);
+			}
+		}
+		if (cleanupErrors.length === 1) throw cleanupErrors[0];
+		if (cleanupErrors.length > 1) {
+			throw new AggregateError(cleanupErrors, "Failed to clean up FleetView UI registration");
+		}
 	}
 }

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -94,6 +94,112 @@ describe("below-editor subagent FleetView", () => {
 		}
 	});
 
+	it("stops refreshing when the captured extension context becomes stale", () => {
+		const state = stateForTest();
+		state.foregroundControls.set("run-worker", {
+			runId: "run-worker",
+			mode: "single",
+			startedAt: 10,
+			updatedAt: 20,
+			currentAgent: "worker",
+		});
+		let stale = false;
+		let contextReads = 0;
+		let inputUnsubscribes = 0;
+		let widgetRemovals = 0;
+		const ctx = {
+			get hasUI() {
+				contextReads++;
+				if (stale) {
+					throw new Error("This extension ctx is stale after session replacement or reload.");
+				}
+				return true;
+			},
+			ui: {
+				setWidget(_key: string, content: unknown) {
+					if (content === undefined) widgetRemovals++;
+				},
+				onTerminalInput() { return () => { inputUnsubscribes++; }; },
+				getEditorText() { return ""; },
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+		try {
+			fleet.setContext(ctx);
+			stale = true;
+			assert.doesNotThrow(() => fleet.refresh());
+			assert.equal(inputUnsubscribes, 1);
+			assert.equal(widgetRemovals, 1);
+			assert.equal((fleet as unknown as { timer?: unknown }).timer, undefined);
+			const readsAfterStaleRefresh = contextReads;
+			fleet.refresh();
+			assert.equal(contextReads, readsAfterStaleRefresh, "later refreshes must not reuse the stale context");
+		} finally {
+			fleet.dispose();
+		}
+	});
+
+	it("does not swallow unrelated widget cleanup errors", () => {
+		const state = stateForTest();
+		state.foregroundControls.set("run-worker", {
+			runId: "run-worker",
+			mode: "single",
+			startedAt: 10,
+			updatedAt: 20,
+			currentAgent: "worker",
+		});
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: unknown) {
+					if (content === undefined) throw new Error("widget cleanup failed");
+				},
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+		fleet.setContext(ctx);
+		assert.throws(() => fleet.dispose(), /widget cleanup failed/);
+	});
+
+	it("preserves multiple unrelated UI cleanup errors", () => {
+		const state = stateForTest();
+		state.foregroundControls.set("run-worker", {
+			runId: "run-worker",
+			mode: "single",
+			startedAt: 10,
+			updatedAt: 20,
+			currentAgent: "worker",
+		});
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: unknown) {
+					if (content === undefined) throw new Error("widget cleanup failed");
+				},
+				onTerminalInput() {
+					return () => { throw new Error("input cleanup failed"); };
+				},
+				getEditorText() { return ""; },
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+		fleet.setContext(ctx);
+		assert.throws(
+			() => fleet.dispose(),
+			(error: unknown) => error instanceof AggregateError
+				&& error.errors.map(String).join("\n").includes("input cleanup failed")
+				&& error.errors.map(String).join("\n").includes("widget cleanup failed"),
+		);
+	});
+
 	it("keeps widget ownership through invalidation so an empty refresh removes it", () => {
 		const state = stateForTest();
 		state.foregroundControls.set("run-worker", {


### PR DESCRIPTION
## Problem

FleetView keeps a refresh interval while subagents are active. After a session replacement or reload, Pi invalidates the previous extension context, but an already queued refresh can still access `ctx.hasUI` and crash Pi with an uncaught stale-context error.

This is the same lifecycle failure previously addressed in #122 for legacy animation timers, reintroduced by the persistent FleetView.

## Fix

Stop FleetView activity when Pi reports that its captured extension context is stale:

- retain the UI reference separately so cleanup does not dereference the stale context
- stop the refresh timer and release terminal-input registration
- discard stale context and widget references
- continue throwing unrelated context errors, aggregating them when multiple cleanup operations fail

Regression coverage verifies the current Pi stale-context error from `SubagentFleetStatus.refresh`, confirms stale registrations are released, and ensures unrelated cleanup errors remain visible.
