### PR TITLE
fix(fleet): invalidate live overlay before refresh

### DIFF
--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -463,7 +463,7 @@ export class SubagentFleetComponent implements Component {
 		this.refresh();
 		this.timer = setInterval(() => {
 			if (this.disposed) return;
-			this.refresh();
+			this.invalidate();
 			this.tui.requestRender();
 		}, options.refreshMs ?? REFRESH_MS);
 		this.timer.unref?.();

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -552,6 +552,12 @@ describe("native subagent fleet", () => {
 				() => {},
 				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 10 },
 			);
+			let invalidations = 0;
+			const originalInvalidate = component.invalidate.bind(component);
+			component.invalidate = () => {
+				invalidations++;
+				originalInvalidate();
+			};
 			try {
 				assert.ok(component.render(90).some((line) => line.includes("No tracked children")));
 				const initialOutput = Array.from({ length: 40 }, (_, index) => `output line ${index}`).join("\n");
@@ -565,6 +571,7 @@ describe("native subagent fleet", () => {
 				lines = component.render(90);
 				assert.ok(lines.some((line) => line.includes("LATEST LIVE OUTPUT")), "live transcript should keep following new output");
 				assert.ok(renderRequests > 0);
+				assert.ok(invalidations > 0, "live refresh must invalidate cached TUI frames before rendering");
 			} finally {
 				component.dispose();
 			}


### PR DESCRIPTION
## Summary
- invalidate the live Fleet inspector component before each timer-driven render
- keep roster/transcript refresh behavior unchanged
- cover timer invalidation in the existing live-refresh unit test

## Why
Pi TUI components must invalidate cached frames before `requestRender()` after state changes. Fleet refreshed its snapshot directly, so a live overlay could leave repeated stale structured-header frames (task/stats lines) while a single child continued normally. Persisted child execution/transcripts were unaffected; this is a package UI fix.

## Validation
- `node --experimental-strip-types --test test/unit/fleet.test.ts`
- 11/11 passed
