### PR TITLE
feat(delegation): expose provider capability discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1022,6 +1022,30 @@ If you are writing an agent that orchestrates subagents, the bundled skill helps
 Pi extensions can request configured foreground agents through the public event
 contract exported by `pi-subagents/delegation`.
 
+### Provider capability discovery
+
+Consumers can synchronously inspect the provider currently registered for their
+exact Pi EventBus without emitting an event or reserving work:
+
+```ts
+import { getSubagentDelegationProvider } from "pi-subagents/delegation";
+
+const provider = getSubagentDelegationProvider(pi.events);
+if (!provider?.protocols.some(({ version }) => version === 2)) {
+  throw new Error("This pi-subagents generation does not support delegation v2");
+}
+```
+
+The immutable descriptor reports provider and package identity, package version,
+a monotonically unique bridge generation, exact terminal statuses, cancellation
+and concurrency behavior, and request-field support for every advertised protocol.
+It is registered and removed with the prompt-template delegation bridge. Reloading
+the bridge replaces the descriptor, and disposal of an older bridge cannot erase a
+newer generation. This process-local discovery seam is keyed by object identity;
+passing a different EventBus object returns `undefined`. Package/version and
+capability drift are therefore visible before a consumer chooses a protocol. It is
+not an acknowledgement that a request started and does not add a discovery event.
+
 ### Launch contract preflight
 
 Use `pi-subagents/preflight` when an extension needs to inspect the resolved child launch contract before deciding whether to run anything:

--- a/src/api/delegation.ts
+++ b/src/api/delegation.ts
@@ -1,3 +1,5 @@
+import { PACKAGE_METADATA } from "../shared/package-metadata.ts";
+
 export const SUBAGENT_DELEGATION_PROTOCOL_VERSION = 1 as const;
 export const SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION = 2 as const;
 
@@ -8,6 +10,141 @@ export const SUBAGENT_DELEGATION_STARTED_EVENT = "prompt-template:subagent:start
 export const SUBAGENT_DELEGATION_UPDATE_EVENT = "prompt-template:subagent:update";
 export const SUBAGENT_DELEGATION_RESPONSE_EVENT = "prompt-template:subagent:response";
 export const SUBAGENT_DELEGATION_CANCEL_EVENT = "prompt-template:subagent:cancel";
+
+export const SUBAGENT_DELEGATION_PROVIDER_ID = "pi-subagents/prompt-template-bridge" as const;
+export const SUBAGENT_DELEGATION_PROVIDER_PACKAGE = PACKAGE_METADATA.name;
+export const SUBAGENT_DELEGATION_PROVIDER_PACKAGE_VERSION = PACKAGE_METADATA.version;
+
+export interface SubagentDelegationRequestFieldCapabilities {
+	readonly model: boolean;
+	readonly thinking: boolean;
+	readonly timeout: boolean;
+	readonly turnBudget: boolean;
+	readonly toolBudget: boolean;
+	readonly skills: boolean;
+	readonly artifacts: boolean;
+	readonly textResult: boolean;
+	readonly structuredResult: boolean;
+	readonly ownershipIdentity: boolean;
+}
+
+export interface SubagentDelegationProtocolCapability {
+	readonly version: 1 | 2;
+	readonly terminalStatuses: readonly string[];
+	readonly requestFields: SubagentDelegationRequestFieldCapabilities;
+}
+
+export interface SubagentDelegationProviderDescriptor {
+	readonly providerId: string;
+	readonly packageName: string;
+	readonly packageVersion: string;
+	/** Monotonically unique within this process-global provider registry. */
+	readonly generation: number;
+	readonly protocols: readonly SubagentDelegationProtocolCapability[];
+	readonly cancellation: Readonly<{
+		supported: boolean;
+		preCancellation: boolean;
+		identity: "requestId" | "requestId+ownerRunId+nodeId" | "protocol-specific";
+	}>;
+	readonly concurrency: Readonly<{
+		semantics: "v1-request-id-v2-owner-node";
+		maximumConcurrentRequests: number | null;
+		v2IdentityHistoryLimit: number;
+		v1DuplicateIdentity: "ignored";
+		v2DuplicateIdentity: "ignored";
+		v2ConcurrentLogicalNode: "duplicate_node";
+	}>;
+}
+
+export type SubagentDelegationProviderRegistration = Omit<SubagentDelegationProviderDescriptor, "generation">;
+
+interface SubagentDelegationProviderRegistry {
+	readonly providers: WeakMap<object, SubagentDelegationProviderDescriptor>;
+	nextGeneration: number;
+}
+
+// Symbol.for intentionally lets duplicate installed copies observe and replace the
+// provider owning the same concrete EventBus instead of maintaining split registries.
+const DELEGATION_PROVIDER_REGISTRY = Symbol.for("pi-subagents.delegation-provider-registry.v1");
+const globalRegistry = globalThis as typeof globalThis & {
+	[DELEGATION_PROVIDER_REGISTRY]?: SubagentDelegationProviderRegistry;
+};
+const delegationProviderRegistry = globalRegistry[DELEGATION_PROVIDER_REGISTRY] ??= {
+	providers: new WeakMap<object, SubagentDelegationProviderDescriptor>(),
+	nextGeneration: 0,
+};
+
+function freezeDelegationProviderDescriptor(
+	descriptor: SubagentDelegationProviderRegistration,
+	generation: number,
+): SubagentDelegationProviderDescriptor {
+	const protocols = descriptor.protocols.map((protocol) => Object.freeze({
+		...protocol,
+		terminalStatuses: Object.freeze([...protocol.terminalStatuses]),
+		requestFields: Object.freeze({ ...protocol.requestFields }),
+	}));
+	return Object.freeze({
+		...descriptor,
+		generation,
+		protocols: Object.freeze(protocols),
+		cancellation: Object.freeze({ ...descriptor.cancellation }),
+		concurrency: Object.freeze({ ...descriptor.concurrency }),
+	});
+}
+
+/**
+ * Registers the provider currently owning a concrete Pi EventBus/extension context.
+ * Registration is synchronous and does not dispatch or reserve delegation work.
+ * Disposing an older generation never invalidates a newer replacement.
+ */
+export function registerSubagentDelegationProvider(
+	context: object,
+	descriptor: SubagentDelegationProviderRegistration,
+): { readonly descriptor: SubagentDelegationProviderDescriptor; dispose(): void } {
+	const generation = ++delegationProviderRegistry.nextGeneration;
+	const immutableDescriptor = freezeDelegationProviderDescriptor(descriptor, generation);
+	delegationProviderRegistry.providers.set(context, immutableDescriptor);
+	return Object.freeze({
+		descriptor: immutableDescriptor,
+		dispose: () => {
+			if (delegationProviderRegistry.providers.get(context)?.generation === generation) delegationProviderRegistry.providers.delete(context);
+		},
+	});
+}
+
+/** Returns the current provider generation for this exact context without emitting events. */
+export function getSubagentDelegationProvider(
+	context: object,
+): SubagentDelegationProviderDescriptor | undefined {
+	return delegationProviderRegistry.providers.get(context);
+}
+
+export const DEFAULT_SUBAGENT_DELEGATION_PROVIDER: SubagentDelegationProviderRegistration = Object.freeze({
+	providerId: SUBAGENT_DELEGATION_PROVIDER_ID,
+	packageName: SUBAGENT_DELEGATION_PROVIDER_PACKAGE,
+	packageVersion: SUBAGENT_DELEGATION_PROVIDER_PACKAGE_VERSION,
+	protocols: Object.freeze([
+		Object.freeze({
+			version: 1 as const,
+			terminalStatuses: Object.freeze(["completed", "failed", "timed_out", "cancelled", "interrupted", "turn_budget_exhausted", "tool_budget_exhausted", "structured_output_failed", "acceptance_failed", "invalid_request", "unavailable_context"]),
+			requestFields: Object.freeze({ model: true, thinking: false, timeout: true, turnBudget: true, toolBudget: true, skills: true, artifacts: true, textResult: true, structuredResult: true, ownershipIdentity: false }),
+		}),
+		Object.freeze({
+			version: 2 as const,
+			terminalStatuses: Object.freeze(["completed", "failed", "timed_out", "cancelled", "interrupted", "turn_budget_exhausted", "tool_budget_exhausted", "structured_output_failed", "acceptance_failed", "invalid_request", "unavailable_context", "duplicate_node"]),
+			requestFields: Object.freeze({ model: true, thinking: true, timeout: true, turnBudget: true, toolBudget: true, skills: true, artifacts: true, textResult: true, structuredResult: true, ownershipIdentity: true }),
+		}),
+	]),
+	cancellation: Object.freeze({ supported: true, preCancellation: true, identity: "protocol-specific" as const }),
+	concurrency: Object.freeze({
+		semantics: "v1-request-id-v2-owner-node" as const,
+		maximumConcurrentRequests: null,
+		v2IdentityHistoryLimit: 8_192,
+		v1DuplicateIdentity: "ignored" as const,
+		v2DuplicateIdentity: "ignored" as const,
+		v2ConcurrentLogicalNode: "duplicate_node" as const,
+	}),
+});
 
 export interface SubagentDelegationTurnBudget {
 	maxTurns: number;

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { discoverAgents, discoverAgentsAll, type AgentConfig, type AgentScope, type AgentSource } from "../agents/agents.ts";
 import { resolveExecutionAgentScope } from "../agents/agent-scope.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../agents/skills.ts";
@@ -21,6 +20,7 @@ import { agentDefinitionDigest, AGENT_DEFINITION_PROJECTION_VERSION, launchBindi
 import { ASYNC_DIR, RESULTS_DIR, TEMP_ROOT_DIR } from "../shared/types.ts";
 import { processTerminalCandidatePath, processTerminalPath } from "../runs/background/process-terminal.ts";
 import { nestedResultsPath } from "../runs/shared/nested-events.ts";
+import { PACKAGE_METADATA } from "../shared/package-metadata.ts";
 
 export const SUBAGENT_LAUNCH_CONTRACT_VERSION = 2 as const;
 
@@ -158,15 +158,6 @@ export interface SubagentLaunchContract {
 export type SubagentLaunchContractResult =
 	| { ok: true; contract: SubagentLaunchContract }
 	| { ok: false; code: SubagentLaunchContractReasonCode; message: string; diagnostics: SubagentLaunchContractDiagnostic[] };
-
-function packageVersion(): string {
-	const packagePath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
-	const parsed = JSON.parse(fs.readFileSync(packagePath, "utf-8")) as { version?: unknown };
-	if (typeof parsed.version !== "string" || !parsed.version.trim()) {
-		throw new Error(`Invalid package version in '${packagePath}'.`);
-	}
-	return parsed.version;
-}
 
 function stableJson(value: unknown): string {
 	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
@@ -373,7 +364,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		},
 		protocol: {
 			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
-			packageVersion: packageVersion(),
+			packageVersion: PACKAGE_METADATA.version,
 		},
 		diagnostics,
 		launchContractDigest: launchBindingDigest({

--- a/src/shared/package-metadata.ts
+++ b/src/shared/package-metadata.ts
@@ -1,0 +1,21 @@
+import * as fs from "node:fs";
+
+interface PackageMetadata {
+	readonly name: string;
+	readonly version: string;
+}
+
+function loadPackageMetadata(): PackageMetadata {
+	const packagePath = new URL("../../package.json", import.meta.url);
+	const parsed = JSON.parse(fs.readFileSync(packagePath, "utf-8")) as { name?: unknown; version?: unknown };
+	if (typeof parsed.name !== "string" || !parsed.name.trim()) {
+		throw new Error(`Invalid package name in '${packagePath.pathname}'.`);
+	}
+	if (typeof parsed.version !== "string" || !parsed.version.trim()) {
+		throw new Error(`Invalid package version in '${packagePath.pathname}'.`);
+	}
+	return Object.freeze({ name: parsed.name, version: parsed.version });
+}
+
+/** Canonical runtime identity derived from the package manifest shipped with this module. */
+export const PACKAGE_METADATA = loadPackageMetadata();

--- a/src/slash/prompt-template-bridge.ts
+++ b/src/slash/prompt-template-bridge.ts
@@ -6,6 +6,8 @@ import {
 	SUBAGENT_DELEGATION_RESPONSE_EVENT,
 	SUBAGENT_DELEGATION_STARTED_EVENT,
 	SUBAGENT_DELEGATION_UPDATE_EVENT,
+	DEFAULT_SUBAGENT_DELEGATION_PROVIDER,
+	registerSubagentDelegationProvider,
 	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
 	type SubagentDelegationV2InvalidResponse,
@@ -79,6 +81,7 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 	const activeV2Nodes = new Map<string, { attemptKey: string; controller: AbortController }>();
 	const settledV2Attempts = new Map<string, true>();
 	const subscriptions: Array<() => void> = [];
+	const providerRegistration = registerSubagentDelegationProvider(options.events, DEFAULT_SUBAGENT_DELEGATION_PROVIDER);
 	let disposed = false;
 	let v2IdentitySaturated = false;
 
@@ -412,6 +415,7 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 			v2IdentitySaturated = false;
 		},
 		dispose: () => {
+			providerRegistration.dispose();
 			disposed = true;
 			for (const controller of controllers.values()) controller.abort();
 			for (const controller of v2Controllers.values()) controller.abort();

--- a/test/unit/delegation-api.test.ts
+++ b/test/unit/delegation-api.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
 import { describe, it } from "node:test";
 
 import {
+	DEFAULT_SUBAGENT_DELEGATION_PROVIDER,
+	getSubagentDelegationProvider,
+	registerSubagentDelegationProvider,
 	SUBAGENT_DELEGATION_CANCEL_EVENT,
+	SUBAGENT_DELEGATION_PROVIDER_PACKAGE_VERSION,
 	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
 	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
@@ -100,6 +105,72 @@ const request: SubagentDelegationRequest = {
 };
 
 describe("public subagent delegation contract", () => {
+	it("discovers the exact immutable v1/v2 provider descriptor registered for one context", () => {
+		const context = {};
+		assert.equal(getSubagentDelegationProvider(context), undefined);
+		const registration = registerSubagentDelegationProvider(context, DEFAULT_SUBAGENT_DELEGATION_PROVIDER);
+		assert.equal(getSubagentDelegationProvider(context), registration.descriptor);
+		assert.notEqual(getSubagentDelegationProvider({}), registration.descriptor);
+		assert.deepEqual(registration.descriptor.protocols, [
+			{
+				version: 1,
+				terminalStatuses: ["completed", "failed", "timed_out", "cancelled", "interrupted", "turn_budget_exhausted", "tool_budget_exhausted", "structured_output_failed", "acceptance_failed", "invalid_request", "unavailable_context"],
+				requestFields: { model: true, thinking: false, timeout: true, turnBudget: true, toolBudget: true, skills: true, artifacts: true, textResult: true, structuredResult: true, ownershipIdentity: false },
+			},
+			{
+				version: 2,
+				terminalStatuses: ["completed", "failed", "timed_out", "cancelled", "interrupted", "turn_budget_exhausted", "tool_budget_exhausted", "structured_output_failed", "acceptance_failed", "invalid_request", "unavailable_context", "duplicate_node"],
+				requestFields: { model: true, thinking: true, timeout: true, turnBudget: true, toolBudget: true, skills: true, artifacts: true, textResult: true, structuredResult: true, ownershipIdentity: true },
+			},
+		]);
+		assert.ok(Object.isFrozen(registration));
+		assert.ok(Object.isFrozen(registration.descriptor));
+		assert.ok(Object.isFrozen(registration.descriptor.protocols));
+		assert.ok(registration.descriptor.protocols.every((protocol) => Object.isFrozen(protocol) && Object.isFrozen(protocol.terminalStatuses) && Object.isFrozen(protocol.requestFields)));
+		assert.ok(Object.isFrozen(registration.descriptor.cancellation));
+		assert.ok(Object.isFrozen(registration.descriptor.concurrency));
+		assert.throws(() => { (registration.descriptor.protocols[0].requestFields as { thinking: boolean }).thinking = true; }, TypeError);
+		registration.dispose();
+		assert.equal(getSubagentDelegationProvider(context), undefined);
+	});
+
+	it("keeps newer bridge generations registered when an older generation disposes", () => {
+		const events = new FakeEvents();
+		const options = {
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => ({ details: { mode: "single" as const, results: [] } }),
+		};
+		const older = registerPromptTemplateDelegationBridge(options);
+		const olderDescriptor = getSubagentDelegationProvider(events);
+		const newer = registerPromptTemplateDelegationBridge(options);
+		const newerDescriptor = getSubagentDelegationProvider(events);
+		assert.ok(olderDescriptor);
+		assert.ok(newerDescriptor);
+		assert.ok(newerDescriptor.generation > olderDescriptor.generation);
+		older.dispose();
+		assert.equal(getSubagentDelegationProvider(events), newerDescriptor);
+		newer.dispose();
+		assert.equal(getSubagentDelegationProvider(events), undefined);
+	});
+
+	it("shares registration across duplicate module instances through the process-global Symbol registry", async () => {
+		const duplicate = await import(`../../src/api/delegation.ts?duplicate=${Date.now()}`);
+		const context = {};
+		const registration = duplicate.registerSubagentDelegationProvider(context, duplicate.DEFAULT_SUBAGENT_DELEGATION_PROVIDER);
+		assert.equal(getSubagentDelegationProvider(context), registration.descriptor);
+		const replacement = registerSubagentDelegationProvider(context, DEFAULT_SUBAGENT_DELEGATION_PROVIDER);
+		registration.dispose();
+		assert.equal(duplicate.getSubagentDelegationProvider(context), replacement.descriptor);
+		replacement.dispose();
+	});
+
+	it("derives the advertised package version from the canonical package manifest", () => {
+		const manifest = JSON.parse(fs.readFileSync(new URL("../../package.json", import.meta.url), "utf-8")) as { version: string };
+		assert.equal(SUBAGENT_DELEGATION_PROVIDER_PACKAGE_VERSION, manifest.version);
+		assert.equal(DEFAULT_SUBAGENT_DELEGATION_PROVIDER.packageVersion, manifest.version);
+	});
+
 	it("uses the existing prompt-template event family as the only transport", () => {
 		assert.equal(SUBAGENT_DELEGATION_PROTOCOL_VERSION, 1);
 		assert.equal(SUBAGENT_DELEGATION_REQUEST_EVENT, "prompt-template:subagent:request");


### PR DESCRIPTION
## Summary

- expose synchronous provider capability discovery from `pi-subagents/delegation`
- bind registrations to the concrete extension context with generation-safe disposal and reload behavior
- publish immutable v1/v2 capability descriptors, including package-version drift visibility
- document the public discovery contract and cover registration, duplicate package copies, disposal, reload, and immutability

## Verification

- `node --experimental-strip-types --test test/unit/delegation-api.test.ts` (28 passed)
- `node --experimental-strip-types --test test/unit/preflight.test.ts` (7 passed)
- Node 26-compatible unit subset (1387 passed, 1 skipped)
- `npm pack --dry-run --json`
- `git diff --check`
