### PR TITLE
Disable context file loading for isolated agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Reduced repeated scanning and file reads in live TUI rendering and skill loading.
 
+### Fixed
+- Passed `--no-context-files` to child Pi runs when an agent disables inherited project context, avoiding stale prompt-header parsing as Pi's context block format changes. Thanks to @KorenKrita for #667.
+
 ## [0.37.1] - 2026-07-27
 
 ### Added

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -253,6 +253,9 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	}
 	for (const extPath of toolPlan.extensionArgs) args.push("--extension", extPath);
 
+	if (!input.inheritProjectContext) {
+		args.push("--no-context-files");
+	}
 	if (!input.inheritSkills) {
 		args.push("--no-skills");
 	}

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -417,9 +417,22 @@ describe("buildPiArgs system prompt mode wiring", () => {
 
 		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
 		assert.ok(extensionArgs.some((arg) => arg.endsWith(path.join("src", "runs", "shared", "subagent-prompt-runtime.ts"))));
+		assert.ok(args.includes("--no-context-files"));
 		assert.equal(env.PI_SUBAGENT_CHILD, "1");
 		assert.equal(env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT, "0");
 		assert.equal(env.PI_SUBAGENT_INHERIT_SKILLS, "1");
+	});
+
+	it("keeps context file loading enabled when project context is inherited", () => {
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: true,
+			inheritSkills: true,
+		});
+
+		assert.equal(args.includes("--no-context-files"), false);
 	});
 
 	it("passes tool budget through env", () => {


### PR DESCRIPTION
## Summary

Pass `--no-context-files` to child Pi runs when `inheritProjectContext` is false so AGENTS.md/CLAUDE.md are disabled at launch time instead of relying on prompt-header rewriting.

Fixes #667. Thanks to @KorenKrita for the report and root-cause analysis.

## Validation

- `node --experimental-strip-types --test test/unit/pi-args.test.ts`
- `npm run test:all`