### PR TITLE
fix: tolerate steering inbox scan failures

### DIFF
--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -380,8 +380,15 @@ function parseSteerRequest(raw: unknown): SteerRequest | undefined {
 
 export function consumeSteerRequestsFromDir(dir: string, fsImpl: Pick<typeof fs, "existsSync" | "rmSync" | "readdirSync" | "readFileSync"> = fs): SteerRequest[] {
 	if (!fsImpl.existsSync(dir)) return [];
+	let entries: string[];
+	try {
+		entries = fsImpl.readdirSync(dir).filter((name) => name.endsWith(".json")).sort();
+	} catch {
+		// Leave requests in place so the periodic poll can retry the scan.
+		return [];
+	}
 	const requests: SteerRequest[] = [];
-	for (const entry of fsImpl.readdirSync(dir).filter((name) => name.endsWith(".json")).sort()) {
+	for (const entry of entries) {
 		const requestPath = path.join(dir, entry);
 		let parsed: SteerRequest | undefined;
 		try {

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -148,6 +148,33 @@ describe("control channel: request file", () => {
 		}
 	});
 
+	it("keeps steer requests for retry when the inbox cannot be scanned", () => {
+		const asyncDir = tmpAsyncDir("pi-control-steer-scan-retry-");
+		try {
+			requestAsyncSteer(asyncDir, { message: "retry me", id: "retry", ts: 1 });
+			let failScan = true;
+			const fsImpl = {
+				existsSync: fs.existsSync,
+				readdirSync: ((target: fs.PathLike) => {
+					if (failScan) {
+						failScan = false;
+						throw Object.assign(new Error("file table overflow"), { code: "ENFILE" });
+					}
+					return fs.readdirSync(target);
+				}) as typeof fs.readdirSync,
+				readFileSync: fs.readFileSync,
+				rmSync: fs.rmSync,
+			};
+
+			assert.deepEqual(consumeSteerRequests(asyncDir, fsImpl), []);
+			assert.deepEqual(consumeSteerRequests(asyncDir, fsImpl), [
+				{ type: "steer", id: "retry", ts: 1, message: "retry me" },
+			]);
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
 	it("does not deliver a steer request if another consumer removed it first", () => {
 		const asyncDir = tmpAsyncDir("pi-control-steer-concurrent-");
 		try {


### PR DESCRIPTION
## Summary

`consumeSteerRequestsFromDir()` did not guard its initial `readdirSync()`. A scan error such as `ENFILE` could therefore escape the steering timer and terminate the child process.

Treat a failed scan as temporarily unavailable, leaving request files untouched for the next poll. This matches the existing acknowledgement consumer behavior.

## Validation

- confirmed the regression test fails before the production change with `ENFILE` from `readdirSync()`
- `node --experimental-strip-types --test test/unit/control-channel.test.ts` — 23/23 passing
- `npm run test:unit` — 1,464 passing, 1 skipped
