### PR TITLE
fix: tolerate steering inbox scan failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Kept pi-intercom stable IDs from leaking into child sessions and used the current intercom runtime ID for unnamed supervisor targets.
 - Improved acceptance policy validation errors and tool-schema guidance for invalid evidence kinds. Thanks to @atimofeev for #672.
+- Tolerated temporary steering inbox scan failures so pending steer requests can be retried on the next poll. Thanks to @hughcars for #670.
 
 ## [0.37.2] - 2026-07-28
 

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -380,8 +380,15 @@ function parseSteerRequest(raw: unknown): SteerRequest | undefined {
 
 export function consumeSteerRequestsFromDir(dir: string, fsImpl: Pick<typeof fs, "existsSync" | "rmSync" | "readdirSync" | "readFileSync"> = fs): SteerRequest[] {
 	if (!fsImpl.existsSync(dir)) return [];
+	let entries: string[];
+	try {
+		entries = fsImpl.readdirSync(dir).filter((name) => name.endsWith(".json")).sort();
+	} catch {
+		// Leave requests in place so the periodic poll can retry the scan.
+		return [];
+	}
 	const requests: SteerRequest[] = [];
-	for (const entry of fsImpl.readdirSync(dir).filter((name) => name.endsWith(".json")).sort()) {
+	for (const entry of entries) {
 		const requestPath = path.join(dir, entry);
 		let parsed: SteerRequest | undefined;
 		try {

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -148,6 +148,33 @@ describe("control channel: request file", () => {
 		}
 	});
 
+	it("keeps steer requests for retry when the inbox cannot be scanned", () => {
+		const asyncDir = tmpAsyncDir("pi-control-steer-scan-retry-");
+		try {
+			requestAsyncSteer(asyncDir, { message: "retry me", id: "retry", ts: 1 });
+			let failScan = true;
+			const fsImpl = {
+				existsSync: fs.existsSync,
+				readdirSync: ((target: fs.PathLike) => {
+					if (failScan) {
+						failScan = false;
+						throw Object.assign(new Error("file table overflow"), { code: "ENFILE" });
+					}
+					return fs.readdirSync(target);
+				}) as typeof fs.readdirSync,
+				readFileSync: fs.readFileSync,
+				rmSync: fs.rmSync,
+			};
+
+			assert.deepEqual(consumeSteerRequests(asyncDir, fsImpl), []);
+			assert.deepEqual(consumeSteerRequests(asyncDir, fsImpl), [
+				{ type: "steer", id: "retry", ts: 1, message: "retry me" },
+			]);
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
 	it("does not deliver a steer request if another consumer removed it first", () => {
 		const asyncDir = tmpAsyncDir("pi-control-steer-concurrent-");
 		try {


### PR DESCRIPTION
Maintainer replacement for #670 because the source branch is an external fork and the contribution needed visible changelog credit before landing.\n\nThis preserves @hughcars' production fix and test, and adds the Unreleased changelog credit required by this repo.\n\nValidation:\n- `git diff --check main...HEAD`\n- `node --experimental-strip-types --test test/unit/control-channel.test.ts` — 23/23 passed\n\nCredit: Thanks to @hughcars for #670.