### PR TITLE
fix: retry zero-activity subagent startup exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Kept pi-intercom stable IDs from leaking into child sessions and used the current intercom runtime ID for unnamed supervisor targets.
 - Improved acceptance policy validation errors and tool-schema guidance for invalid evidence kinds. Thanks to @atimofeev for #672.
 - Tolerated temporary steering inbox scan failures so pending steer requests can be retried on the next poll. Thanks to @hughcars for #670.
+- Retried short, zero-activity child startup exits on the same model with bounded backoff, reducing concurrent subagent launch races without replaying model or tool work. Thanks to @felipeteodorocw for #671.
 
 ## [0.37.2] - 2026-07-28
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -65,6 +65,13 @@ import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection } from "../shared/dynamic-fanout.ts";
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent } from "../shared/nested-events.ts";
 import { formatModelAttemptNote, isRetryableModelFailure } from "../shared/model-fallback.ts";
+import {
+	SUBAGENT_STARTUP_RETRY_DELAYS_MS,
+	formatSubagentStartupRetryExhaustedError,
+	formatSubagentStartupRetryNote,
+	isRetryableSubagentStartupFailure,
+	waitForSubagentStartupRetry,
+} from "../shared/subagent-startup-retry.ts";
 import { markProcessTerminalCandidateLeaseRelease, writeProcessTerminalCandidate, type ProcessTerminalCandidate } from "./process-terminal.ts";
 import { createSteeringStatus, recordSteeringRequest, steeringStatus, terminalSteeringNoticeState, updateSteeringTarget } from "./steering.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
@@ -395,6 +402,8 @@ interface RunPiStreamingResult {
 	exitCode: number | null;
 	messages: Message[];
 	usage: Usage;
+	toolCount: number;
+	durationMs: number;
 	model?: string;
 	error?: string;
 	protocolError?: ProtocolOutputLimit;
@@ -434,6 +443,7 @@ function runPiStreaming(
 	onWriterProcess?: (writer: { state: "none" | "spawning" } | { state: "running"; pid: number }) => void,
 ): Promise<RunPiStreamingResult> {
 	return new Promise((resolve) => {
+		const startedAt = Date.now();
 		const processInstanceId = randomUUID();
 		onWriterProcess?.({ state: "spawning" });
 		const outputStream = fs.createWriteStream(outputFile, { flags: "w" });
@@ -471,6 +481,7 @@ function runPiStreaming(
 		let turnBudgetMessage: string | undefined;
 		let turnBudget: TurnBudgetState | undefined;
 		let observedMutationAttempt = false;
+		let toolCount = 0;
 		const childWatchdogConfig = decodeChildWatchdogConfig(env?.[CHILD_WATCHDOG_CONFIG_ENV]);
 		let childWatchdogState: ChildWatchdogStateSnapshot | undefined;
 		let applyChildLifecycle = (_action: ChildLifecycleAction): void => {};
@@ -557,6 +568,7 @@ function runPiStreaming(
 			onChildEvent?.(event);
 
 			if (event.type === "tool_execution_start" && event.toolName) {
+				toolCount += 1;
 				observedMutationAttempt = observedMutationAttempt || isMutatingTool(event.toolName, event.args);
 				const toolArgs = extractToolArgsPreview(event.args ?? {});
 				writeOutputLine(toolArgs ? `${event.toolName}: ${toolArgs}` : event.toolName);
@@ -796,6 +808,8 @@ function runPiStreaming(
 				exitCode: timedOut || stopped ? 1 : turnBudgetExceeded ? 1 : interrupted || forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (exitCode ?? 1) : exitCode,
 				messages,
 				usage,
+				toolCount,
+				durationMs: Date.now() - startedAt,
 				model,
 				error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? turnBudgetMessage : interrupted || forcedDrainAfterFinalSuccess ? undefined : finalError,
 				protocolError,
@@ -833,7 +847,7 @@ function runPiStreaming(
 			const stderr = stderrTail.text();
 			const finalOutput = getFinalOutput(messages) || rawStdoutTail.text().trim();
 			const spawnErrorMessage = spawnError instanceof Error ? spawnError.message : String(spawnError);
-			resolve({ stderr, exitCode: 1, messages, usage, model, error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? turnBudgetMessage : error ?? assistantError ?? spawnErrorMessage, protocolError, finalOutput: (timedOut || stopped) && !finalOutput.trim() ? (stopped ? stopMessage ?? "Subagent stopped by user." : timeoutMessage ?? "Subagent timed out.") : finalOutput, timedOut, stopped, turnBudget, turnBudgetExceeded, wrapUpRequested: turnBudget?.outcome === "wrap-up-requested" || turnBudget?.outcome === "termination-deferred" || turnBudgetExceeded || undefined, observedMutationAttempt, watchdog: childWatchdogState, processInstanceId });
+			resolve({ stderr, exitCode: 1, messages, usage, toolCount, durationMs: Date.now() - startedAt, model, error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? turnBudgetMessage : error ?? assistantError ?? spawnErrorMessage, protocolError, finalOutput: (timedOut || stopped) && !finalOutput.trim() ? (stopped ? stopMessage ?? "Subagent stopped by user." : timeoutMessage ?? "Subagent timed out.") : finalOutput, timedOut, stopped, turnBudget, turnBudgetExceeded, wrapUpRequested: turnBudget?.outcome === "wrap-up-requested" || turnBudget?.outcome === "termination-deferred" || turnBudgetExceeded || undefined, observedMutationAttempt, watchdog: childWatchdogState, processInstanceId });
 		});
 	});
 }
@@ -1145,9 +1159,11 @@ async function runSingleStep(
 	let toolBudgetBlocked = false;
 	let actualLaunchContractDigest = step.launchContractDigest;
 
-	for (let index = 0; index < candidates.length; index++) {
-		if (ctx.timeoutSignal?.aborted || ctx.skipAcceptance?.()) break;
-		const candidate = candidates[index];
+	let modelIndex = 0;
+	let startupAttemptIndex = 0;
+	modelAttemptsLoop: while (modelIndex < candidates.length) {
+		if (ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break;
+		const candidate = candidates[modelIndex];
 		ctx.onAttemptStart?.({ model: candidate, thinking: resolveEffectiveThinking(candidate, step.thinking) });
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
 		if (effectiveStructuredOutput) {
@@ -1259,7 +1275,7 @@ async function runSingleStep(
 			writerProcesses.push({
 				processInstanceId: run.processInstanceId,
 				kind: "pi-writer",
-				attempt: index,
+				attempt: writerAttemptCount - 1,
 				closeObservedAt: run.processCloseObservedAt,
 				exitCode: run.exitCode,
 				signal: run.processSignal ?? null,
@@ -1358,7 +1374,7 @@ async function runSingleStep(
 			usage: run.usage,
 		};
 		modelAttempts.push(attempt);
-		if (candidate) attemptedModels.push(candidate);
+		if (candidate && startupAttemptIndex === 0) attemptedModels.push(candidate);
 		completionGuardTriggeredFinal = completionGuardTriggered;
 		finalOutputSnapshot = outputSnapshot;
 		if (step.toolBudget) {
@@ -1368,11 +1384,55 @@ async function runSingleStep(
 			toolBudget = toolBudgetState(step.toolBudget, toolMessages.length, blockedMessage ? (blockedMessage as { toolName?: string }).toolName : undefined);
 		}
 		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(fileMutationEffect ? { effects: { fileMutation: fileMutationEffect } } : {}) } as RunPiStreamingResult & { structuredOutput?: unknown; agentContract?: import("../../shared/types.ts").AgentContract; effects?: import("../../shared/types.ts").EffectsProjection };
-		if (run.turnBudgetExceeded) break;
-		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break;
-		if (attempt.success || completionGuardTriggered) break;
-		if (!isRetryableModelFailure(error) || index === candidates.length - 1) break;
-		attemptNotes.push(formatModelAttemptNote(attempt, candidates[index + 1]));
+		if (run.turnBudgetExceeded) break modelAttemptsLoop;
+		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break modelAttemptsLoop;
+		if (attempt.success || completionGuardTriggered) break modelAttemptsLoop;
+
+		const startupFailure = isRetryableSubagentStartupFailure({
+			exitCode: effectiveExitCode,
+			error,
+			finalOutput: run.finalOutput,
+			messageCount: run.messages.length,
+			toolCount: run.toolCount,
+			usage: run.usage,
+			durationMs: run.durationMs,
+			protocolError: run.protocolError,
+			processSignal: run.processSignal,
+			observedMutationAttempt: run.observedMutationAttempt,
+			interrupted: run.interrupted,
+			timedOut: run.timedOut,
+			stopped: run.stopped,
+			turnBudgetExceeded: run.turnBudgetExceeded,
+		});
+		const retryDelayMs = SUBAGENT_STARTUP_RETRY_DELAYS_MS[startupAttemptIndex];
+		if (startupFailure && retryDelayMs !== undefined) {
+			const retryNote = formatSubagentStartupRetryNote({
+				model: attempt.model,
+				attempt: startupAttemptIndex + 1,
+				maxAttempts: SUBAGENT_STARTUP_RETRY_DELAYS_MS.length + 1,
+				delayMs: retryDelayMs,
+			});
+			const shouldRetry = await waitForSubagentStartupRetry(retryDelayMs, [ctx.timeoutSignal, ctx.stopSignal]);
+			if (!shouldRetry || ctx.skipAcceptance?.()) break modelAttemptsLoop;
+			attempt.error = retryNote;
+			attemptNotes.push(retryNote);
+			startupAttemptIndex += 1;
+			continue;
+		}
+		if (startupFailure) {
+			const startupError = formatSubagentStartupRetryExhaustedError({
+				model: attempt.model,
+				attempts: startupAttemptIndex + 1,
+			});
+			attempt.error = startupError;
+			finalResult.error = startupError;
+			finalResult.finalOutput = startupError;
+			break modelAttemptsLoop;
+		}
+		if (!isRetryableModelFailure(error) || modelIndex === candidates.length - 1) break modelAttemptsLoop;
+		attemptNotes.push(formatModelAttemptNote(attempt, candidates[modelIndex + 1]));
+		modelIndex += 1;
+		startupAttemptIndex = 0;
 	}
 
 	const rawOutput = finalResult?.finalOutput ?? "";

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -64,6 +64,13 @@ import {
 	isRetryableModelFailure,
 } from "../shared/model-fallback.ts";
 import {
+	SUBAGENT_STARTUP_RETRY_DELAYS_MS,
+	formatSubagentStartupRetryExhaustedError,
+	formatSubagentStartupRetryNote,
+	isRetryableSubagentStartupFailure,
+	waitForSubagentStartupRetry,
+} from "../shared/subagent-startup-retry.ts";
+import {
 	createMutatingFailureState,
 	didMutatingToolFail,
 	isMutatingTool,
@@ -703,6 +710,7 @@ async function runSingleAttempt(
 			emitUpdateSnapshot(output || "(running...)");
 		};
 
+		const rawStdoutTail = createBoundedByteTail();
 		const processLine = (line: string) => {
 			if (!line.trim()) return;
 			jsonlWriter.writeLine(line);
@@ -710,6 +718,7 @@ async function runSingleAttempt(
 			try {
 				evt = JSON.parse(line) as { type?: string; message?: Message; toolName?: string; args?: unknown; willRetry?: unknown };
 			} catch {
+				rawStdoutTail.push(`${line}\n`);
 				shared.transcriptWriter?.writeStdoutLine(line);
 				// Non-JSON stdout lines are expected; only structured events are parsed.
 				return;
@@ -938,12 +947,17 @@ async function runSingleAttempt(
 			stdoutReader.end();
 			stderrReader.end();
 			const stderr = stderrTail.text();
+			const rawStdout = rawStdoutTail.text();
 			let closeError = result.error ?? toolDiagnosticError ?? assistantError;
 			const forcedDrainAfterFinalSuccess = forcedTerminationSignal && (cleanTerminalAssistantStopReceived || agentSettledReceived) && !closeError;
+			if (code !== 0 && rawStdout.trim() && !closeError && !forcedDrainAfterFinalSuccess) {
+				closeError = rawStdout.trim();
+			}
 			if (code !== 0 && stderr.trim() && !closeError && !forcedDrainAfterFinalSuccess) {
 				closeError = stderr.trim();
 			}
 			const finalCode = forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
+			if (signal) result.processSignal = signal;
 			if (detached) {
 				const recoveredProgress = snapshotProgress(progress);
 				const recoveredResult = snapshotResult(result, recoveredProgress);
@@ -1351,6 +1365,7 @@ export async function runSync(
 			agent: agentName,
 			task,
 			exitCode: target.exitCode,
+			processSignal: target.processSignal,
 			usage: target.usage,
 			model: target.model,
 			attemptedModels: target.attemptedModels,
@@ -1416,47 +1431,109 @@ export async function runSync(
 
 	let lastResult: SingleResult | undefined;
 	const modelsToTry = candidates.length > 0 ? candidates : [undefined];
-	for (let i = 0; i < modelsToTry.length; i++) {
-		const candidate = modelsToTry[i];
-		const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
-		const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, detachedAwareOptions, {
-			sessionEnabled,
-			systemPrompt,
-			resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
-			skillsWarning: missingSkills.length > 0 ? `Skills not found: ${missingSkills.join(", ")}` : undefined,
-			jsonlPath,
-			artifactPaths: artifactPathsResult,
-			transcriptWriter,
-			attemptNotes,
-			modelCandidates: candidates.map((candidate) => applyThinkingSuffix(candidate, options.thinkingOverride ?? agent.thinking, options.thinkingOverride !== undefined)),
-			outputSnapshot,
-			originalTask: task,
-		});
-		lastResult = result;
-		if (result.model) attemptedModels.push(result.model);
-		else if (candidate) attemptedModels.push(candidate);
-		sumUsage(aggregateUsage, result.usage);
-		totalToolCount += result.progressSummary?.toolCount ?? 0;
-		totalDurationMs += result.progressSummary?.durationMs ?? 0;
-		const attemptSucceeded = result.exitCode === 0 && !result.error;
-		const attempt: ModelAttempt = {
-			model: result.model ?? candidate ?? agent.model ?? "default",
-			success: attemptSucceeded,
-			exitCode: result.exitCode,
-			error: result.error,
-			usage: { ...result.usage },
-		};
-		modelAttempts.push(attempt);
-		if (result.detached || result.timedOut || result.turnBudgetExceeded) {
+	modelAttemptsLoop: for (let modelIndex = 0; modelIndex < modelsToTry.length; modelIndex++) {
+		const candidate = modelsToTry[modelIndex];
+		for (let startupAttemptIndex = 0; ; startupAttemptIndex++) {
+			const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
+			const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, detachedAwareOptions, {
+				sessionEnabled,
+				systemPrompt,
+				resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
+				skillsWarning: missingSkills.length > 0 ? `Skills not found: ${missingSkills.join(", ")}` : undefined,
+				jsonlPath,
+				artifactPaths: artifactPathsResult,
+				transcriptWriter,
+				attemptNotes,
+				modelCandidates: candidates.map((modelCandidate) => applyThinkingSuffix(modelCandidate, options.thinkingOverride ?? agent.thinking, options.thinkingOverride !== undefined)),
+				outputSnapshot,
+				originalTask: task,
+			});
+			lastResult = result;
+			if (startupAttemptIndex === 0) {
+				if (result.model) attemptedModels.push(result.model);
+				else if (candidate) attemptedModels.push(candidate);
+			}
+			sumUsage(aggregateUsage, result.usage);
+			totalToolCount += result.progressSummary?.toolCount ?? 0;
+			totalDurationMs += result.progressSummary?.durationMs ?? 0;
+			const attemptSucceeded = result.exitCode === 0 && !result.error;
+			const attempt: ModelAttempt = {
+				model: result.model ?? candidate ?? agent.model ?? "default",
+				success: attemptSucceeded,
+				exitCode: result.exitCode,
+				error: result.error,
+				usage: { ...result.usage },
+			};
+			modelAttempts.push(attempt);
+			if (result.detached || result.timedOut || result.turnBudgetExceeded) break modelAttemptsLoop;
+			if (attemptSucceeded) break modelAttemptsLoop;
+
+			const startupFailure = isRetryableSubagentStartupFailure({
+				exitCode: result.exitCode,
+				error: result.error,
+				finalOutput: result.finalOutput,
+				messageCount: result.messages?.length ?? 0,
+				toolCount: result.progressSummary?.toolCount ?? 0,
+				usage: result.usage,
+				durationMs: result.progressSummary?.durationMs ?? Number.POSITIVE_INFINITY,
+				protocolError: result.protocolError,
+				processSignal: result.processSignal,
+				detached: result.detached,
+				interrupted: result.interrupted,
+				timedOut: result.timedOut,
+				stopped: result.stopped,
+				turnBudgetExceeded: result.turnBudgetExceeded,
+			});
+			const retryDelayMs = SUBAGENT_STARTUP_RETRY_DELAYS_MS[startupAttemptIndex];
+			if (startupFailure && retryDelayMs !== undefined) {
+				const retryNote = formatSubagentStartupRetryNote({
+					model: attempt.model,
+					attempt: startupAttemptIndex + 1,
+					maxAttempts: SUBAGENT_STARTUP_RETRY_DELAYS_MS.length + 1,
+					delayMs: retryDelayMs,
+				});
+				const shouldRetry = await waitForSubagentStartupRetry(retryDelayMs, [options.signal, options.interruptSignal]);
+				if (!shouldRetry) {
+					if (options.interruptSignal?.aborted) {
+						result.exitCode = 0;
+						result.interrupted = true;
+						result.error = undefined;
+						result.finalOutput = "Interrupted. Waiting for explicit next action.";
+						if (result.progress) {
+							result.progress.status = "running";
+							result.progress.error = undefined;
+						}
+					} else {
+						const cancellationError = "Subagent startup retry cancelled before relaunch.";
+						result.error = cancellationError;
+						result.finalOutput = cancellationError;
+						attempt.error = cancellationError;
+						if (result.progress) result.progress.error = cancellationError;
+					}
+					break modelAttemptsLoop;
+				}
+				attempt.error = retryNote;
+				attemptNotes.push(retryNote);
+				continue;
+			}
+			if (startupFailure) {
+				const startupError = formatSubagentStartupRetryExhaustedError({
+					model: attempt.model,
+					attempts: startupAttemptIndex + 1,
+				});
+				result.error = startupError;
+				result.finalOutput = startupError;
+				if (result.progress) {
+					result.progress.error = startupError;
+					result.progress.status = "failed";
+				}
+				attempt.error = startupError;
+				break modelAttemptsLoop;
+			}
+			if (!isRetryableModelFailure(result.error) || modelIndex === modelsToTry.length - 1) break modelAttemptsLoop;
+			attemptNotes.push(formatModelAttemptNote(attempt, modelsToTry[modelIndex + 1]));
 			break;
 		}
-		if (attemptSucceeded) {
-			break;
-		}
-		if (!isRetryableModelFailure(result.error) || i === modelsToTry.length - 1) {
-			break;
-		}
-		attemptNotes.push(formatModelAttemptNote(attempt, modelsToTry[i + 1]));
 	}
 
 	const result = withRunContext(lastResult ?? {
@@ -1476,13 +1553,6 @@ export async function runSync(
 		tokens: aggregateUsage.input + aggregateUsage.output,
 		durationMs: totalDurationMs,
 	};
-	if (attemptNotes.length > 0 && result.progress) {
-		result.progress.recentOutput = [...attemptNotes, ...result.progress.recentOutput];
-		if (result.progress.recentOutput.length > 50) {
-			result.progress.recentOutput.splice(50);
-		}
-	}
-
 	if (transcriptWriter) result.transcriptPath = artifactPathsResult?.transcriptPath;
 	if (transcriptWriter?.getError()) result.transcriptError = transcriptWriter.getError();
 

--- a/src/runs/shared/subagent-startup-retry.ts
+++ b/src/runs/shared/subagent-startup-retry.ts
@@ -1,0 +1,101 @@
+import type { Usage } from "../../shared/types.ts";
+
+/**
+ * Retry delays for child processes that exit before any model or tool activity.
+ * The schedule is intentionally short and bounded to avoid amplifying persistent
+ * launch failures while allowing concurrent Pi startup locks to clear.
+ */
+export const SUBAGENT_STARTUP_RETRY_DELAYS_MS = [250, 750, 1500] as const;
+
+/** A genuine startup race should fail well before a model request can complete. */
+export const MAX_SUBAGENT_STARTUP_FAILURE_DURATION_MS = 2000;
+
+export interface SubagentStartupFailureEvidence {
+	exitCode: number | null | undefined;
+	error?: string;
+	finalOutput?: string;
+	messageCount: number;
+	toolCount: number;
+	usage: Usage;
+	durationMs: number;
+	protocolError?: unknown;
+	processSignal?: string | null;
+	observedMutationAttempt?: boolean;
+	detached?: boolean;
+	interrupted?: boolean;
+	timedOut?: boolean;
+	stopped?: boolean;
+	turnBudgetExceeded?: boolean;
+}
+
+function hasUsage(usage: Usage): boolean {
+	return usage.input !== 0
+		|| usage.output !== 0
+		|| usage.cacheRead !== 0
+		|| usage.cacheWrite !== 0
+		|| usage.cost !== 0
+		|| usage.turns !== 0;
+}
+
+/**
+ * Classify only unexplained, zero-activity child exits as startup failures.
+ * This intentionally fails closed: any model output, tool activity, usage,
+ * mutation evidence, diagnostic, or lifecycle interruption prevents a retry.
+ */
+export function isRetryableSubagentStartupFailure(evidence: SubagentStartupFailureEvidence): boolean {
+	return evidence.exitCode !== undefined
+		&& evidence.exitCode !== null
+		&& evidence.exitCode !== 0
+		&& !evidence.error?.trim()
+		&& !evidence.finalOutput?.trim()
+		&& evidence.messageCount === 0
+		&& evidence.toolCount === 0
+		&& !hasUsage(evidence.usage)
+		&& evidence.durationMs >= 0
+		&& evidence.durationMs <= MAX_SUBAGENT_STARTUP_FAILURE_DURATION_MS
+		&& evidence.protocolError === undefined
+		&& (evidence.processSignal === undefined || evidence.processSignal === null)
+		&& evidence.observedMutationAttempt !== true
+		&& evidence.detached !== true
+		&& evidence.interrupted !== true
+		&& evidence.timedOut !== true
+		&& evidence.stopped !== true
+		&& evidence.turnBudgetExceeded !== true;
+}
+
+export function formatSubagentStartupRetryNote(input: {
+	model: string;
+	attempt: number;
+	maxAttempts: number;
+	delayMs: number;
+}): string {
+	return `[startup-retry] ${input.model} exited before model or tool activity (attempt ${input.attempt}/${input.maxAttempts}). Retrying the same model in ${input.delayMs}ms.`;
+}
+
+export function formatSubagentStartupRetryExhaustedError(input: {
+	model: string;
+	attempts: number;
+}): string {
+	return `Subagent failed to start after ${input.attempts} attempts on ${input.model}; no model, tool, output, usage, or diagnostic activity was observed. This may be a concurrent Pi startup race. Retry the run or temporarily lower subagent concurrency.`;
+}
+
+/** Wait for a retry delay, returning false when any lifecycle signal aborts it. */
+export async function waitForSubagentStartupRetry(delayMs: number, signals: Array<AbortSignal | undefined>): Promise<boolean> {
+	const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+	if (activeSignals.some((signal) => signal.aborted)) return false;
+	if (delayMs <= 0) return true;
+
+	return await new Promise<boolean>((resolve) => {
+		let settled = false;
+		const finish = (shouldRetry: boolean): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			for (const signal of activeSignals) signal.removeEventListener("abort", abort);
+			resolve(shouldRetry);
+		};
+		const abort = (): void => finish(false);
+		const timer = setTimeout(() => finish(true), delayMs);
+		for (const signal of activeSignals) signal.addEventListener("abort", abort, { once: true });
+	});
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -762,6 +762,7 @@ export interface SingleResult {
 	/** Resolved launch context for this child. */
 	context?: "fresh" | "fork";
 	exitCode: number;
+	processSignal?: string | null;
 	detached?: boolean;
 	detachedReason?: string;
 	interrupted?: boolean;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -2360,6 +2360,43 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(mockPi.callCount(), 2);
 	});
 
+	it("background runs retry a zero-activity startup exit on the same model", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ exitCode: 1 });
+		mockPi.onCall({ output: "Recovered asynchronously after startup race" });
+		const id = `async-startup-retry-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", {
+				model: "openai/gpt-5-mini:high",
+				fallbackModels: ["anthropic/claude-sonnet-4:low"],
+			}),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			availableModels: [
+				{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" },
+				{ provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
+			],
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf-8")) as AsyncResultPayload;
+		assert.equal(payload.success, true);
+		assert.equal(payload.results[0]?.model, "openai/gpt-5-mini:high");
+		assert.deepEqual(payload.results[0]?.attemptedModels, ["openai/gpt-5-mini:high"]);
+		assert.deepEqual(payload.results[0]?.modelAttempts?.map((attempt) => attempt.success), [false, true]);
+		assert.match(payload.results[0]?.output ?? "", /\[startup-retry\].*Recovered asynchronously after startup race/s);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
 	it("background runs retry the fallback model when the provider stream ends without finish_reason", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			jsonl: [{

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1418,6 +1418,98 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok(result.error?.includes("Something went wrong"));
 	});
 
+	it("retries a zero-activity startup exit on the same model", async () => {
+		mockPi.onCall({ exitCode: 1 });
+		mockPi.onCall({ output: "Recovered after startup race" });
+		const agents = [makeAgent("worker", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+
+		const result = await runSync(tempDir, agents, "worker", "Do work", {
+			runId: "startup-retry-sync",
+			acceptance: false,
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.model, "openai/gpt-5-mini");
+		assert.equal(result.finalOutput, "Recovered after startup race");
+		assert.deepEqual(result.attemptedModels, ["openai/gpt-5-mini"]);
+		assert.deepEqual(result.modelAttempts?.map((attempt) => attempt.success), [false, true]);
+		assert.match(result.progress.recentOutput.join("\n"), /\[startup-retry\].*same model/i);
+		assert.equal(result.progress.recentOutput.filter((line) => line.startsWith("[startup-retry]")).length, 1);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
+	it("does not retry a non-zero exit after tool activity", async () => {
+		mockPi.onCall({ jsonl: [events.toolStart("read", { path: "package.json" })], exitCode: 1 });
+		mockPi.onCall({ output: "must not run" });
+		const agents = [makeAgent("worker", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+
+		const result = await runSync(tempDir, agents, "worker", "Read a file", {
+			runId: "startup-no-retry-after-tool",
+			acceptance: false,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.modelAttempts?.length, 1);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("does not retry a signaled child exit", { skip: process.platform === "win32" ? "POSIX child signal reporting is unavailable on Windows" : false }, async () => {
+		mockPi.onCall({ signal: "SIGKILL" });
+		mockPi.onCall({ output: "must not run" });
+		const agents = [makeAgent("worker", { model: "openai/gpt-5-mini" })];
+
+		const result = await runSync(tempDir, agents, "worker", "Do work", {
+			runId: "startup-no-retry-after-signal",
+			acceptance: false,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.processSignal, "SIGKILL");
+		assert.equal(result.modelAttempts?.length, 1);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("does not retry a child exit with raw stdout diagnostics", async () => {
+		mockPi.onCall({ stdoutRaw: "configuration failed before protocol startup\n", exitCode: 1 });
+		mockPi.onCall({ output: "must not run" });
+		const agents = [makeAgent("worker", { model: "openai/gpt-5-mini" })];
+
+		const result = await runSync(tempDir, agents, "worker", "Do work", {
+			runId: "startup-no-retry-after-stdout-diagnostic",
+			acceptance: false,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /configuration failed before protocol startup/);
+		assert.equal(result.modelAttempts?.length, 1);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("reports an actionable error after startup retries are exhausted", async () => {
+		mockPi.onCall({ exitCode: 1 });
+		const agents = [makeAgent("worker", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+
+		const result = await runSync(tempDir, agents, "worker", "Do work", {
+			runId: "startup-retry-exhausted-sync",
+			acceptance: false,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.modelAttempts?.length, 4);
+		assert.deepEqual(result.attemptedModels, ["openai/gpt-5-mini"]);
+		assert.match(result.error ?? "", /failed to start after 4 attempts.*concurrent Pi startup race/i);
+		assert.equal(mockPi.callCount(), 4);
+	});
+
 	it("handles long tasks via temp file (ENAMETOOLONG prevention)", async () => {
 		mockPi.onCall({ output: "Got it" });
 		const longTask = "Analyze ".repeat(2000); // ~16KB
@@ -1534,6 +1626,42 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.usage.turns, 1);
 		assert.equal(result.usage.input, 100); // from mock
 		assert.equal(result.usage.output, 50); // from mock
+	});
+
+	it("advances to a fallback model after a recovered startup race and provider failure", async () => {
+		mockPi.onCall({ exitCode: 1 });
+		mockPi.onCall({
+			jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "temporary provider failure" }],
+					model: "openai/gpt-5-mini",
+					errorMessage: "rate limit exceeded",
+					usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } },
+				},
+			}],
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "Recovered on fallback" });
+		const agents = [makeAgent("echo", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+
+		const result = await runSync(tempDir, agents, "echo", "Task", {
+			runId: "startup-then-fallback-sync",
+			acceptance: false,
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.model, "anthropic/claude-sonnet-4");
+		assert.deepEqual(result.attemptedModels, [
+			"openai/gpt-5-mini",
+			"anthropic/claude-sonnet-4",
+		]);
+		assert.deepEqual(result.modelAttempts?.map((attempt) => attempt.success), [false, false, true]);
+		assert.equal(mockPi.callCount(), 3);
 	});
 
 	it("retries with fallback models on retryable provider failures", async () => {

--- a/test/support/mock-pi-script.mjs
+++ b/test/support/mock-pi-script.mjs
@@ -383,6 +383,10 @@ async function main() {
 		await new Promise((resolve) => setTimeout(resolve, response.keepAliveAfterFinalMessageMs));
 	}
 
+	if (typeof response.signal === "string") {
+		process.kill(process.pid, response.signal);
+		return;
+	}
 	exitAfterFlush(typeof response.exitCode === "number" ? response.exitCode : 0);
 }
 

--- a/test/support/mock-pi.ts
+++ b/test/support/mock-pi.ts
@@ -7,6 +7,7 @@ interface MockPiResponse {
 	output?: string;
 	stderr?: string;
 	exitCode?: number;
+	signal?: NodeJS.Signals;
 	delay?: number;
 	waitForPath?: string;
 	keepAliveAfterFinalMessageMs?: number;

--- a/test/unit/subagent-startup-retry.test.ts
+++ b/test/unit/subagent-startup-retry.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Usage } from "../../src/shared/types.ts";
+import {
+	MAX_SUBAGENT_STARTUP_FAILURE_DURATION_MS,
+	SUBAGENT_STARTUP_RETRY_DELAYS_MS,
+	formatSubagentStartupRetryExhaustedError,
+	formatSubagentStartupRetryNote,
+	isRetryableSubagentStartupFailure,
+	waitForSubagentStartupRetry,
+	type SubagentStartupFailureEvidence,
+} from "../../src/runs/shared/subagent-startup-retry.ts";
+
+function emptyUsage(): Usage {
+	return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
+}
+
+function startupFailure(overrides: Partial<SubagentStartupFailureEvidence> = {}): SubagentStartupFailureEvidence {
+	return {
+		exitCode: 1,
+		messageCount: 0,
+		toolCount: 0,
+		usage: emptyUsage(),
+		durationMs: 20,
+		...overrides,
+	};
+}
+
+describe("subagent startup retry", () => {
+	it("uses a bounded retry schedule", () => {
+		assert.deepEqual(SUBAGENT_STARTUP_RETRY_DELAYS_MS, [250, 750, 1500]);
+	});
+
+	it("classifies a short non-zero exit with no child activity", () => {
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure()), true);
+	});
+
+	it("rejects successful, long-running, and diagnosed exits", () => {
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ exitCode: 0 })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ durationMs: MAX_SUBAGENT_STARTUP_FAILURE_DURATION_MS + 1 })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ error: "authentication failed" })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ finalOutput: "partial response" })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ protocolError: { code: "protocol_output_limit" } })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ processSignal: "SIGKILL" })), false);
+	});
+
+	it("rejects any model, tool, usage, mutation, or lifecycle activity", () => {
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ messageCount: 1 })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ toolCount: 1 })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ usage: { ...emptyUsage(), input: 1 } })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ usage: { ...emptyUsage(), turns: 1 } })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ observedMutationAttempt: true })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ detached: true })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ interrupted: true })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ timedOut: true })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ stopped: true })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ turnBudgetExceeded: true })), false);
+	});
+
+	it("formats retry and exhaustion diagnostics without task content", () => {
+		assert.equal(
+			formatSubagentStartupRetryNote({ model: "openai/test", attempt: 1, maxAttempts: 4, delayMs: 250 }),
+			"[startup-retry] openai/test exited before model or tool activity (attempt 1/4). Retrying the same model in 250ms.",
+		);
+		assert.match(
+			formatSubagentStartupRetryExhaustedError({ model: "openai/test", attempts: 4 }),
+			/failed to start after 4 attempts.*concurrent Pi startup race.*lower subagent concurrency/i,
+		);
+	});
+
+	it("cancels a pending retry delay", async () => {
+		const controller = new AbortController();
+		const wait = waitForSubagentStartupRetry(5000, [controller.signal]);
+		controller.abort();
+		assert.equal(await wait, false);
+	});
+});


### PR DESCRIPTION
Maintainer replacement for #671 because the contributor branch conflicts with current main.\n\nThis preserves @felipeteodorocw's startup retry implementation and resolves the current CHANGELOG.md conflict with visible contributor credit.\n\nValidation:\n- `git diff --check main...HEAD`\n- `node --experimental-strip-types --test test/unit/subagent-startup-retry.test.ts` — 6/6 passed\n- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts --test-name-pattern 'startup retry|zero-activity'` — passed\n- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts --test-name-pattern 'startup retry|zero-activity'` — passed\n\nCredit: Thanks to @felipeteodorocw for #671.