### PR TITLE
fix(fleet): restore arrow navigation when using custom editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added the optional versioned `fleetStatus` RPC capability with bounded, current-session child roles, goals, model/effort, split token usage, elapsed timestamps, stable opaque reconciliation keys, and explicit overflow counts. Thanks to @neumie for #682.
 
 ### Fixed
+- Recognized structurally compatible custom editors in FleetView focus detection, restoring FleetView arrow-key activation and navigation when a custom editor has focus. Thanks to @magoz for #679.
 - Scoped foreground fleet records to their originating parent session and propagated resolved model, thinking effort, and split input/output usage through live foreground controls.
 - Matched fleet RPC filtering to the canonical session-file identity used by live async and foreground state.
 - Kept pi-intercom stable IDs from leaking into child sessions and used the current intercom runtime ID for unnamed supervisor targets.

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -1,5 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { Editor, isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { type EditorComponent, isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { AsyncJobStep, FleetViewPlacement, SubagentState } from "../shared/types.ts";
 
 export const FLEET_STATUS_WIDGET_KEY = "subagent-fleet-status";
@@ -341,9 +341,16 @@ export class SubagentFleetStatus {
 	}
 
 	private editorHasFocus(): boolean {
-		// pi-tui exposes focus mutation but no focus getter; fail closed if this compatibility seam disappears.
+		// pi-tui exposes focus mutation but no focus getter, so inspect the focused
+		// component structurally. instanceof is unreliable across jiti module boundaries.
 		const focused = (this.tui as unknown as { focusedComponent?: unknown } | undefined)?.focusedComponent;
-		return focused instanceof Editor;
+		if (!focused || typeof focused !== "object") return false;
+		const candidate = focused as Partial<EditorComponent>;
+		return typeof candidate.render === "function"
+			&& typeof candidate.invalidate === "function"
+			&& typeof candidate.handleInput === "function"
+			&& typeof candidate.getText === "function"
+			&& typeof candidate.setText === "function";
 	}
 
 	private getRenderKey(): string {

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { Editor, visibleWidth } from "@earendil-works/pi-tui";
+import { Editor, type EditorComponent, visibleWidth } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { SubagentState } from "../../src/shared/types.ts";
 import { collectFleetSnapshot } from "../../src/tui/fleet.ts";
@@ -476,10 +476,25 @@ describe("below-editor subagent FleetView", () => {
 
 			assert.equal(inputHandler!("\x1b[B"), undefined, "non-empty editor should retain Down");
 			editorText = "";
-			tui.focusedComponent = {} as Editor;
+			tui.focusedComponent = {
+				render() { return []; },
+				invalidate() {},
+				handleInput() {},
+			} as unknown as Editor;
 			assert.equal(inputHandler!("\x1b[B"), undefined, "non-editor focus should retain Down");
+
+			const crossModuleCustomEditor = {
+				render() { return []; },
+				invalidate() {},
+				handleInput() {},
+				getText() { return ""; },
+				setText() {},
+			} satisfies EditorComponent;
+			assert.equal(crossModuleCustomEditor instanceof Editor, false, "regression setup must cross the instanceof boundary");
+			tui.focusedComponent = crossModuleCustomEditor as unknown as Editor;
+			assert.deepEqual(inputHandler!("\x1b[B"), { consume: true }, "custom editors should activate FleetView across jiti boundaries");
+
 			tui.focusedComponent = Object.create(Editor.prototype) as Editor;
-			assert.deepEqual(inputHandler!("\x1b[B"), { consume: true });
 			assert.deepEqual(inputHandler!("\x1b[B"), { consume: true });
 			assert.ok(component.render(100).some((line) => line.includes("⏺ worker")));
 			assert.deepEqual(inputHandler!("\r"), { consume: true });


### PR DESCRIPTION
## Summary

- replace FleetView's nominal `focused instanceof Editor` check with structural `EditorComponent` detection
- preserve fail-closed behavior for non-editor focused components such as dialogs and selectors
- add regression coverage for a structurally valid custom editor across an `instanceof` boundary

## Problem

FleetView only captures arrow-key navigation when the focused component passes an `instanceof Editor` check. Custom editors installed through Pi's supported `setEditorComponent()` API can cross jiti module boundaries, where constructor identity is not reliable.

This prevents FleetView activation with `pi-vimmode` even when the prompt is empty. Disabling Vim mode restores the default editor and makes the same arrow key work.

Reproduced with:

- `pi-subagents` 0.37.2
- `pi-vimmode` 0.9.0

## Fix

Detect the required runtime shape of `EditorComponent` (`render`, `invalidate`, `handleInput`, `getText`, and `setText`) instead of relying on class identity. The focused component remains an internal compatibility seam because pi-tui does not expose a public focus getter.

## Test plan

- regression test fails before the implementation change and passes afterward
- component-like non-editor focus remains rejected
- built-in `Editor` focus remains accepted
- `npm run test:all` on Node 24.18.0:
  - unit: 1,472 passed, 1 skipped, 0 failed
  - integration: 667 passed, 0 failed
  - E2E: 3 passed, 0 failed
