### PR TITLE
fix: bound streamed subagent progress snapshots to avoid protocol_output_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Improved acceptance policy validation errors and tool-schema guidance for invalid evidence kinds. Thanks to @atimofeev for #672.
 - Tolerated temporary steering inbox scan failures so pending steer requests can be retried on the next poll. Thanks to @hughcars for #670.
 - Retried short, zero-activity child startup exits on the same model with bounded backoff, reducing concurrent subagent launch races without replaying model or tool work. Thanks to @felipeteodorocw for #671.
+- Bounded streamed subagent progress snapshots so a long or deeply nested fan-out no longer emits a `tool_execution_update` line above the child-stdout protocol cap and gets the child killed with `protocol_output_limit`. Streamed `onUpdate` snapshots now carry compact tool-call summaries instead of the full message transcript, cap `recentTools`, and truncate `recentOutput` line length; the returned result and detached-exit recovery keep the full transcript. Thanks to @shaharmor for #680/#681.
 
 ## [0.37.2] - 2026-07-28
 

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -45,6 +45,9 @@ import {
 	hasEmptyTerminalAssistantResponse,
 	extractToolArgsPreview,
 	extractTextFromContent,
+	boundStreamedRecentTools,
+	boundStreamedRecentOutput,
+	boundStreamedToolCalls,
 } from "../../shared/utils.ts";
 import { buildSkillInjection, resolveSkillsWithFallback } from "../../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../../agents/agent-memory.ts";
@@ -168,8 +171,8 @@ function snapshotProgress(progress: AgentProgress): AgentProgress {
 	return {
 		...progress,
 		skills: progress.skills ? [...progress.skills] : undefined,
-		recentTools: progress.recentTools.map((tool) => ({ ...tool })),
-		recentOutput: [...progress.recentOutput],
+		recentTools: boundStreamedRecentTools(progress.recentTools),
+		recentOutput: boundStreamedRecentOutput(progress.recentOutput),
 	};
 }
 
@@ -193,6 +196,20 @@ function snapshotResult(result: SingleResult, progress: AgentProgress): SingleRe
 		truncation: result.truncation ? { ...result.truncation } : undefined,
 		outputReference: result.outputReference ? { ...result.outputReference } : undefined,
 	};
+}
+
+/**
+ * Streaming variant of snapshotResult for `onUpdate` progress events: it drops the
+ * unbounded `messages` transcript in favour of compact tool-call summaries so a
+ * single `tool_execution_update` line stays well under the child-stdout protocol
+ * cap (`MAX_CHILD_PENDING_LINE_BYTES`). Non-streaming consumers such as
+ * detached-exit recovery call snapshotResult directly and keep the full transcript.
+ */
+function snapshotStreamResult(result: SingleResult, progress: AgentProgress): SingleResult {
+	const snapshot = snapshotResult(result, progress);
+	snapshot.messages = undefined;
+	snapshot.toolCalls = boundStreamedToolCalls(result);
+	return snapshot;
 }
 
 async function runSingleAttempt(
@@ -694,7 +711,7 @@ async function runSingleAttempt(
 		const emitUpdateSnapshot = (text: string) => {
 			if (!options.onUpdate || processClosed) return;
 			const progressSnapshot = snapshotProgress(progress);
-			const resultSnapshot = snapshotResult(result, progressSnapshot);
+			const resultSnapshot = snapshotStreamResult(result, progressSnapshot);
 			const controlEvents = drainPendingControlEvents();
 			options.onUpdate({
 				content: [{ type: "text", text }],
@@ -1231,7 +1248,7 @@ async function runSingleAttempt(
 	if (options.onUpdate) {
 		const finalText = result.finalOutput || result.error || "(no output)";
 		const progressSnapshot = snapshotProgress(progress);
-		const resultSnapshot = snapshotResult(result, progressSnapshot);
+		const resultSnapshot = snapshotStreamResult(result, progressSnapshot);
 		options.onUpdate({
 			content: [{ type: "text", text: finalText }],
 			details: {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -412,6 +412,49 @@ export function compactForegroundDetails(details: Details): Details {
 	};
 }
 
+/**
+ * Streaming counterparts to compactForegroundResult / compactCompletedProgress.
+ *
+ * The completed-compaction helpers above bail out while a child is still
+ * `running`, so a long or deeply nested fan-out streams full, unbounded progress on
+ * every tick. Pi serializes each streamed `tool_execution_update` as a single
+ * child-stdout line, which the parent reads under `MAX_CHILD_PENDING_LINE_BYTES`;
+ * an unbounded running snapshot can cross that cap and kill the child with
+ * `protocol_output_limit`.
+ *
+ * These bound the STREAMED snapshot only. The final returned result keeps the full
+ * live progress and message transcript, and every live-display consumer already
+ * reads just the last few entries (`recentTools.slice(-3)`, `recentOutput.slice(-5)`).
+ */
+export const MAX_STREAMED_RECENT_TOOLS = 32;
+export const MAX_STREAMED_TOOL_CALLS = 64;
+export const MAX_STREAMED_OUTPUT_LINE_CHARS = 2000;
+
+/** Keep only the most recent tool-history entries in a streamed snapshot. */
+export function boundStreamedRecentTools(recentTools: AgentProgress["recentTools"]): AgentProgress["recentTools"] {
+	return recentTools.slice(-MAX_STREAMED_RECENT_TOOLS).map((tool) => ({ ...tool }));
+}
+
+/** Cap per-line length of recent output so one long line can't inflate a snapshot. */
+export function boundStreamedRecentOutput(recentOutput: string[]): string[] {
+	return recentOutput.map((line) =>
+		line.length > MAX_STREAMED_OUTPUT_LINE_CHARS
+			? `${line.slice(0, MAX_STREAMED_OUTPUT_LINE_CHARS)}… [truncated]`
+			: line,
+	);
+}
+
+/**
+ * Compact tool-call summaries for a streamed snapshot, standing in for the
+ * unbounded `messages` transcript. Prefers an existing `toolCalls` summary, else
+ * derives one from `messages`; bounded to the most recent calls.
+ */
+export function boundStreamedToolCalls(result: Pick<SingleResult, "toolCalls" | "messages">): ToolCallSummary[] | undefined {
+	const summaries = result.toolCalls?.length ? result.toolCalls : extractToolCallSummaries(result.messages);
+	if (!summaries.length) return undefined;
+	return summaries.slice(-MAX_STREAMED_TOOL_CALLS).map((summary) => ({ ...summary }));
+}
+
 export function hasEmptyTerminalAssistantResponse(messages: Message[]): boolean {
 	const lastAssistant = messages.findLast((message) => message.role === "assistant");
 	return lastAssistant?.role === "assistant"

--- a/test/unit/streamed-progress-bounds.test.ts
+++ b/test/unit/streamed-progress-bounds.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { describe, it } from "node:test";
+import {
+	boundStreamedRecentOutput,
+	boundStreamedRecentTools,
+	boundStreamedToolCalls,
+	MAX_STREAMED_OUTPUT_LINE_CHARS,
+	MAX_STREAMED_RECENT_TOOLS,
+	MAX_STREAMED_TOOL_CALLS,
+} from "../../src/shared/utils.ts";
+
+describe("streamed progress snapshot bounds", () => {
+	it("keeps only the most recent tool-history entries and clones them", () => {
+		const recentTools = Array.from({ length: MAX_STREAMED_RECENT_TOOLS + 40 }, (_, i) => ({
+			tool: "read",
+			args: `file-${i}.ts`,
+			endMs: i,
+		}));
+		const bounded = boundStreamedRecentTools(recentTools);
+		assert.equal(bounded.length, MAX_STREAMED_RECENT_TOOLS);
+		// most-recent retained (chronological)
+		assert.equal(bounded.at(-1)?.endMs, recentTools.at(-1)?.endMs);
+		assert.equal(bounded[0]?.endMs, recentTools.at(-MAX_STREAMED_RECENT_TOOLS)?.endMs);
+		// cloned, not aliased
+		bounded[0]!.args = "mutated";
+		assert.notEqual(recentTools.at(-MAX_STREAMED_RECENT_TOOLS)?.args, "mutated");
+	});
+
+	it("truncates long recent-output lines but leaves short lines intact", () => {
+		const shortLine = "ok";
+		const longLine = "x".repeat(MAX_STREAMED_OUTPUT_LINE_CHARS + 5000);
+		const bounded = boundStreamedRecentOutput([shortLine, longLine]);
+		assert.equal(bounded[0], shortLine);
+		assert.ok(bounded[1]!.length < longLine.length);
+		assert.ok(bounded[1]!.startsWith("x".repeat(MAX_STREAMED_OUTPUT_LINE_CHARS)));
+		assert.match(bounded[1]!, /\[truncated\]$/);
+	});
+
+	it("prefers an existing toolCalls summary and caps it", () => {
+		const toolCalls = Array.from({ length: MAX_STREAMED_TOOL_CALLS + 20 }, (_, i) => ({
+			text: `read(${i})`,
+			expandedText: `read(file-${i}.ts)`,
+		}));
+		const bounded = boundStreamedToolCalls({ toolCalls, messages: undefined });
+		assert.equal(bounded?.length, MAX_STREAMED_TOOL_CALLS);
+		assert.equal(bounded?.at(-1)?.text, toolCalls.at(-1)?.text);
+	});
+
+	it("derives tool-call summaries from messages when none are present", () => {
+		const messages = [
+			{ role: "assistant", content: [{ type: "toolCall", name: "read", arguments: { path: "a.ts" } }] },
+			{ role: "assistant", content: [{ type: "toolCall", name: "grep", arguments: { pattern: "foo" } }] },
+			{ role: "user", content: [{ type: "text", text: "ignored" }] },
+		] as never;
+		const bounded = boundStreamedToolCalls({ toolCalls: undefined, messages });
+		assert.equal(bounded?.length, 2);
+		assert.match(bounded![0]!.text, /read/);
+		assert.match(bounded![1]!.text, /grep/);
+	});
+
+	it("returns undefined when there are no tool calls", () => {
+		assert.equal(boundStreamedToolCalls({ toolCalls: [], messages: [] as never }), undefined);
+		assert.equal(boundStreamedToolCalls({ toolCalls: undefined, messages: undefined }), undefined);
+	});
+
+	it("bounds a pathological running snapshot well under the child-stdout protocol cap", () => {
+		// Simulates a long, deep nested fan-out: many tool calls + long output lines.
+		const recentTools = Array.from({ length: 5000 }, (_, i) => ({ tool: "read", args: `services/pkg/file-${i}.ts`, endMs: i }));
+		const recentOutput = Array.from({ length: 50 }, () => "y".repeat(60_000));
+		const snapshot = {
+			recentTools: boundStreamedRecentTools(recentTools),
+			recentOutput: boundStreamedRecentOutput(recentOutput),
+		};
+		const bytes = Buffer.byteLength(JSON.stringify(snapshot), "utf8");
+		assert.ok(bytes < 256 * 1024, `bounded snapshot should be small, was ${bytes} bytes`);
+	});
+});


### PR DESCRIPTION
Fixes #680.

## Problem

A long or deeply nested subagent fan-out (reproduced with `ce-code-review mode:agent depth:full`, which fans out ~5 persona reviewers in one parallel `subagent` call) can be killed mid-run with:

```
protocol_output_limit: child stdout line exceeded 4194304 bytes (observed at least 4203208 bytes without a newline).
```

The oversized line is a single **`tool_execution_update` progress event**. A running child streams a progress snapshot on every tick whose `details.results[]` carry:

- the full **`messages`** transcript (every tool result, each up to ~50 KB) — the dominant term,
- **`recentTools`** — uncapped, and
- **`recentOutput`** — capped at 50 entries but with no per-line length cap.

Summed across N concurrent children and re-serialized on every tick, one snapshot crosses the 4 MiB `MAX_CHILD_PENDING_LINE_BYTES` cap and the child is terminated. The existing `compactForegroundResult` / `compactCompletedProgress` helpers already strip this data, but they early-return while a child is still `running` — exactly the streaming window that overflows. See #680 for the captured diagnostic and full analysis.

## Fix

Bound the **streamed** snapshot only; leave the returned result and detached-exit recovery untouched.

- `src/shared/utils.ts`: add streaming counterparts next to the completed-compaction helpers — `boundStreamedRecentTools` (cap count), `boundStreamedRecentOutput` (truncate line length), `boundStreamedToolCalls` (compact summaries via the existing `extractToolCallSummaries`).
- `src/runs/foreground/execution.ts`:
  - `snapshotProgress` now caps `recentTools` and truncates `recentOutput` lines.
  - new `snapshotStreamResult` drops the `messages` transcript in favour of compact `toolCalls` summaries; it's used only at the two `onUpdate` emission sites.
  - the detached-exit **recovery** path keeps calling `snapshotResult` (full `messages`), because its saved output is derived from `result.messages`.

Every live-display consumer already reads just the last few entries (`recentTools.slice(-3)`, `recentOutput.slice(-5)`), and the parent doesn't consume `tool_execution_update` at all in headless mode, so nothing downstream regresses.

## Testing

- New unit test `test/unit/streamed-progress-bounds.test.ts` (6 cases) covering the bounds and a pathological-snapshot size assertion.
- `npm run test:unit` — **1478 pass, 0 fail**.
- Integration `single-execution` + `parallel-execution` + `foreground-result-size` — **green** (including the detached-exit recovery test, which is why the message-drop is streaming-only).

## Notes / follow-up

The same three unbounded fields also exist in the async status snapshot (`background/subagent-runner.ts`, `writeStatusPayload` / `step.recentTools`). That path serializes to `status.json` rather than the child-stdout protocol stream, so it's lower severity; happy to fold a matching bound into this PR or a follow-up. Cap values (32 tools / 64 tool-calls / 2000 chars) are conservative — glad to adjust to your preference.
