### PR TITLE
feat(tui): add j/k navigation to list-only views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Added `j`/`k` navigation aliases to the non-filterable `/subagents-stop` selector and clarify step list while preserving text input in editor and search modes.
+- Added `j`/`k` navigation aliases to the non-filterable `/subagents-stop` selector and clarify step list while preserving text input in editor and search modes. Thanks to @magoz for #686.
 - Added the optional versioned `fleetStatus` RPC capability with bounded, current-session child roles, goals, model/effort, split token usage, elapsed timestamps, stable opaque reconciliation keys, and explicit overflow counts. Thanks to @neumie for #682.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added `j`/`k` navigation aliases to the non-filterable `/subagents-stop` selector and clarify step list while preserving text input in editor and search modes.
 - Added the optional versioned `fleetStatus` RPC capability with bounded, current-session child roles, goals, model/effort, split token usage, elapsed timestamps, stable opaque reconciliation keys, and explicit overflow counts. Thanks to @neumie for #682.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ Common clarify keys:
 
 - `Enter` runs in the foreground, or in the background if background is toggled on
 - `Esc` cancels or backs out
-- `↑↓` moves between steps or tasks
+- `↑↓` or `j`/`k` moves between steps or tasks
 - `e` edits the task/template
 - `m` selects a model
 - `t` selects thinking level
@@ -1441,7 +1441,7 @@ subagent({ action: "doctor" })
 
 `resume` revives a paused, completed, or failed async/foreground child by starting a new child from its stored session file; stopped runs remain non-resumable, and it does not interrupt a live top-level async child. Use `steer` for acknowledged live async guidance. Multi-child async runs and remembered foreground single, parallel, or chain runs can be revived by passing `index` to choose the child. Nested runs can be resumed by nested id when their live route or persisted nested session metadata is available. Revive starts a new child process from the old session context; it does not restart the same OS process, and it requires the chosen child to have a persisted `.jsonl` session file. Direct revival takes an exclusive cross-process lease on the canonical session file until the new child finishes. A concurrent attempt fails before Pi is spawned and identifies the owning revived run; dead-owner leases are reclaimed only when staleness can be proved.
 
-`stop` ends a current-session top-level async run. It is deliberately stronger than `interrupt`: it is not a resumable pause, stopped runs should be restarted as new runs, foreground and nested targets are rejected, direct id calls execute immediately, and `/subagents-stop` without an id opens a selector with confirmation when a TUI is available. In non-TUI contexts the slash command prints exact `subagent({ action: "stop", id })` and `/subagents-stop <id>` commands. Scheduled jobs can appear in the selector, but they are labeled as scheduled cancellations and route through `schedule-cancel`, not `stop`.
+`stop` ends a current-session top-level async run. It is deliberately stronger than `interrupt`: it is not a resumable pause, stopped runs should be restarted as new runs, foreground and nested targets are rejected, direct id calls execute immediately, and `/subagents-stop` without an id opens a selector with confirmation when a TUI is available. Use `↑`/`↓` or `j`/`k` to move through that selector. In non-TUI contexts the slash command prints exact `subagent({ action: "stop", id })` and `/subagents-stop <id>` commands. Scheduled jobs can appear in the selector, but they are labeled as scheduled cancellations and route through `schedule-cancel`, not `stop`.
 
 `steer` waits up to three seconds for a correlated child-Pi input acceptance and returns a request id with `delivered`, `scheduled`, `pending`, `partial`, `recovered`, or `failed` plus per-child states. Delivery means Pi accepted the user message, not model compliance. A pending indexed child returns `scheduled`. Only a top-level single run may interrupt after the acknowledgment deadline and recover after a further 15-second pause/revival bound; chain, parallel, and nested runs never auto-interrupt. Recovery launches a replacement only after the source is confirmed paused, a valid persisted session exists, and deadline, turn, and tool budgets remain. It preserves the original child contract and remaining limits; otherwise the source stays paused with an explicit failure. Late acceptance is recorded but cannot cancel committed recovery. The persisted `steering` ledger retains 20 requests and replaces the old `steerCount`/`lastSteerAt` fields.
 

--- a/src/runs/foreground/chain-clarify.ts
+++ b/src/runs/foreground/chain-clarify.ts
@@ -451,13 +451,13 @@ export class ChainClarifyComponent implements Component {
 			return;
 		}
 
-		if (matchesKey(data, "up")) {
+		if (matchesKey(data, "up") || matchesKey(data, "k")) {
 			this.selectedStep = Math.max(0, this.selectedStep - 1);
 			this.tui.requestRender();
 			return;
 		}
 
-		if (matchesKey(data, "down")) {
+		if (matchesKey(data, "down") || matchesKey(data, "j")) {
 			const maxStep = Math.max(0, this.agentConfigs.length - 1);
 			this.selectedStep = Math.min(maxStep, this.selectedStep + 1);
 			this.tui.requestRender();
@@ -1123,7 +1123,7 @@ export class ChainClarifyComponent implements Component {
 	private getFooterText(): string {
 		return this.mode === 'single'
 			? " [Enter] Run • [Esc] Cancel "
-			: " [Enter] Run • [Esc] Cancel • [↑↓] Navigate ";
+			: " [Enter] Run • [Esc] Cancel • [↑↓/jk] Navigate ";
 	}
 
 	private appendNotice(lines: string[]): void {

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -336,12 +336,12 @@ class SubagentsStopSelector implements Component {
 			}
 			return;
 		}
-		if (matchesKey(data, "up")) {
+		if (matchesKey(data, "up") || matchesKey(data, "k")) {
 			this.selected = Math.max(0, this.selected - 1);
 			this.tui.requestRender();
 			return;
 		}
-		if (matchesKey(data, "down")) {
+		if (matchesKey(data, "down") || matchesKey(data, "j")) {
 			this.selected = Math.min(this.targets.length - 1, this.selected + 1);
 			this.tui.requestRender();
 			return;
@@ -375,7 +375,7 @@ class SubagentsStopSelector implements Component {
 			if (target.kind === "async") lines.push(this.theme.fg("dim", "Stop ends this run; use interrupt for a resumable pause."));
 			lines.push(this.theme.fg("dim", "Enter/Y confirms · N returns · Esc cancels"));
 		} else {
-			lines.push(this.theme.fg("dim", "↑/↓ select · Enter confirm · Esc cancel"));
+			lines.push(this.theme.fg("dim", "↑↓/jk select · Enter confirm · Esc cancel"));
 		}
 		return lines;
 	}

--- a/test/integration/chain-clarify.test.ts
+++ b/test/integration/chain-clarify.test.ts
@@ -349,9 +349,9 @@ describe("chain clarify model display", { skip: !available ? "pi packages not av
 			assert.match(initial, /\[Enter\] Run • \[Esc\] Cancel/);
 			if (mode === "single") {
 				assert.match(initial, /\[w\]Output/);
-				assert.doesNotMatch(initial, /\[↑↓\] Navigate/);
+				assert.doesNotMatch(initial, /\[↑↓\/jk\] Navigate/);
 			} else {
-				assert.match(initial, /\[↑↓\] Navigate/);
+				assert.match(initial, /\[↑↓\/jk\] Navigate/);
 			}
 			if (mode === "chain") {
 				assert.match(initial, /\[w\]Output/);
@@ -367,5 +367,54 @@ describe("chain clarify model display", { skip: !available ? "pi packages not av
 			component.handleInput("b");
 			assert.match(component.render(84).map(stripAnsi).join("\n"), /\[b\]Background:ON/);
 		}
+	});
+
+	it("navigates non-editing chain steps with j and k", () => {
+		const agents = ["scout", "worker"].map((name) => ({
+			name,
+			description: "",
+			systemPrompt: "",
+			systemPromptMode: "replace",
+			inheritProjectContext: false,
+			inheritSkills: false,
+			source: "user",
+			filePath: `${name}.md`,
+		}));
+		const component = new ChainClarifyComponent(
+			{ requestRender() {} },
+			{ fg(_key: string, text: string) { return text; } },
+			agents,
+			["Scout", "Implement"],
+			"Task",
+			undefined,
+			agents.map(() => ({ output: false, outputMode: "inline", reads: false, progress: false, skills: [], model: undefined })),
+			[],
+			undefined,
+			[{ name: "jk-skill", source: "user" }],
+			() => {},
+			"chain",
+		);
+
+		component.handleInput("j");
+		assert.equal(component.selectedStep, 1);
+		component.handleInput("k");
+		assert.equal(component.selectedStep, 0);
+
+		component.handleInput("e");
+		component.handleInput("j");
+		component.handleInput("k");
+		assert.match(component.render(84).map(stripAnsi).join("\n"), /jkScout/);
+		component.handleInput("\x1b");
+
+		component.handleInput("m");
+		component.handleInput("j");
+		component.handleInput("k");
+		assert.match(component.render(84).map(stripAnsi).join("\n"), /Search: jk/);
+		component.handleInput("\x1b");
+
+		component.handleInput("s");
+		component.handleInput("j");
+		component.handleInput("k");
+		assert.match(component.render(84).map(stripAnsi).join("\n"), /Search: jk/);
 	});
 });

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -2162,6 +2162,17 @@ describe("subagents-doctor slash command", { skip: !available ? "slash-commands.
 					cwd: root,
 					sessionId: "session-test",
 					jobs: [{
+						id: "job-1",
+						name: "early scout",
+						schedule: "+5m",
+						runAt: Date.now() + 300_000,
+						state: "scheduled",
+						createdAt: Date.now(),
+						updatedAt: Date.now(),
+						cwd: root,
+						sessionId: "session-test",
+						params: { agent: "scout", task: "soon", async: true },
+					}, {
 						id: "job-2",
 						name: "delayed worker",
 						schedule: "+10m",
@@ -2200,9 +2211,27 @@ describe("subagents-doctor slash command", { skip: !available ? "slash-commands.
 				await commands.get("subagents-stop")!.handler("", createCommandContext({
 					cwd: root,
 					hasUI: true,
-					custom: async () => ({
-						confirmed: true,
-						target: { kind: "scheduled", id: "job-2", label: "job-2", detail: "scheduled", actionLabel: "cancel scheduled run" },
+					custom: async (...args: unknown[]) => new Promise((resolve) => {
+						const factory = args[0] as (
+							tui: { requestRender(): void },
+							theme: { fg(key: string, text: string): string; bold(text: string): string },
+							keybindings: unknown,
+							done: (result: unknown) => void,
+						) => { handleInput(data: string): void; render(width: number): string[] };
+						const component = factory(
+							{ requestRender() {} },
+							{ fg(_key, text) { return text; }, bold(text) { return text; } },
+							{},
+							resolve,
+						);
+						assert.match(component.render(84).join("\n"), /↑↓\/jk select/);
+						component.handleInput("j");
+						assert.ok(component.render(84).some((line) => line.startsWith("›") && line.includes("job-2")));
+						component.handleInput("k");
+						assert.ok(component.render(84).some((line) => line.startsWith("›") && line.includes("job-1")));
+						component.handleInput("j");
+						component.handleInput("\r");
+						component.handleInput("y");
 					}),
 				}));
 


### PR DESCRIPTION
## Summary

This is a maintainer replacement for #686 after the contributor branch became unavailable for restoration. It preserves @magoz's original implementation and adds visible changelog credit.

Changes:

- add `j`/`k` aliases for chain/parallel clarification step navigation and `/subagents-stop` target selection
- keep printable `j`/`k` available in task editors and type-to-filter model/skill pickers
- update hints, README, and changelog

Supersedes #686. Thanks to @magoz for the contribution.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/chain-clarify.test.ts test/integration/slash-commands.test.ts`
