### PR TITLE
perf: reduce runtime filesystem work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Reduced repeated runtime filesystem work by caching stable Pi config-directory resolution, incrementally sanitizing run history, and limiting nested control-result polling to files created for the active request.
+
 ## [0.38.0] - 2026-07-30
 
 ### Added

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -69,7 +69,7 @@ import { waitForSteeringAction } from "../background/steering.ts";
 import { steerAsyncRun } from "./async-steering-action.ts";
 import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
 import { resolveAsyncRootResultPath } from "../background/chain-root-attachment.ts";
-import { attachRootChildrenToSteps, createNestedRoute, readNestedControlResults, resolveInheritedNestedRouteFromEnv, resolveNestedAsyncDir, resolveNestedParentAddressFromEnv, updateForegroundNestedProjection, writeNestedControlRequest, writeNestedEvent, type NestedRunResolutionScope } from "../shared/nested-events.ts";
+import { attachRootChildrenToSteps, createNestedRoute, findNestedControlResult, resolveInheritedNestedRouteFromEnv, resolveNestedAsyncDir, resolveNestedParentAddressFromEnv, snapshotNestedEventFiles, updateForegroundNestedProjection, writeNestedControlRequest, writeNestedEvent, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 import { resolveSubagentRunId, type ResolvedSubagentRunId } from "../background/run-id-resolver.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { inspectSubagentStatus } from "../background/run-status.ts";
@@ -1032,10 +1032,10 @@ function resolveNestedResumeTarget(match: ResolvedSubagentRunId & { kind: "neste
 	};
 }
 
-async function waitForNestedControlResult(target: ResolvedSubagentRunId & { kind: "nested" }, requestId: string, timeoutMs = 1_000) {
+async function waitForNestedControlResult(target: ResolvedSubagentRunId & { kind: "nested" }, requestId: string, ignoredFiles: ReadonlySet<string>, timeoutMs = 1_000) {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
-		const result = readNestedControlResults(target.match.route).find((candidate) => candidate.requestId === requestId && candidate.targetRunId === target.match.run.id);
+		const result = findNestedControlResult(target.match.route, requestId, target.match.run.id, ignoredFiles);
 		if (result) return result;
 		await new Promise((resolve) => setTimeout(resolve, 50));
 	}
@@ -1044,14 +1044,16 @@ async function waitForNestedControlResult(target: ResolvedSubagentRunId & { kind
 
 async function sendNestedControlRequest(target: ResolvedSubagentRunId & { kind: "nested" }, action: "interrupt" | "resume", message?: string) {
 	const requestId = randomUUID();
+	const ignoredFiles = snapshotNestedEventFiles(target.match.route);
+	const requestedAt = Date.now();
 	writeNestedControlRequest(target.match.route, {
-		ts: Date.now(),
+		ts: requestedAt,
 		requestId,
 		targetRunId: target.match.run.id,
 		action,
 		...(message ? { message } : {}),
 	});
-	return waitForNestedControlResult(target, requestId);
+	return waitForNestedControlResult(target, requestId, ignoredFiles);
 }
 
 function directNestedAsyncInterrupt(target: ResolvedSubagentRunId & { kind: "nested" }): AgentToolResult<Details> | undefined {

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -788,32 +788,50 @@ export function writeNestedControlResult(route: NestedRoute, result: Omit<Nested
 	writeRouteRecord(route.eventSink, sanitized.ts, sanitized);
 }
 
-export function readNestedControlResults(route: NestedRoute): NestedControlResultRecord[] {
-	validateRouteShape(route);
-	let entries: string[] = [];
+function readControlResultsFromFile(route: NestedRoute, eventPath: string): NestedControlResultRecord[] {
+	if (!containedPath(route.eventSink, eventPath)) return [];
 	try {
-		entries = fs.readdirSync(route.eventSink).filter((entry) => entry.endsWith(".json") || entry.endsWith(".jsonl")).sort();
+		const stat = fs.statSync(eventPath);
+		if (!stat.isFile() || stat.size > MAX_EVENT_BYTES) return [];
+		const content = fs.readFileSync(eventPath, "utf-8");
+		const lines = content.includes("\n") ? content.split("\n").filter((line) => line.trim()) : [content];
+		return lines.map((line) => parseControlResult(line, route)).filter((result): result is NestedControlResultRecord => Boolean(result));
+	} catch {
+		return [];
+	}
+}
+
+function listNestedEventFiles(route: NestedRoute): string[] {
+	validateRouteShape(route);
+	try {
+		return fs.readdirSync(route.eventSink).filter((entry) => entry.endsWith(".json") || entry.endsWith(".jsonl"));
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
 	}
-	const results: NestedControlResultRecord[] = [];
+}
+
+export function snapshotNestedEventFiles(route: NestedRoute): Set<string> {
+	return new Set(listNestedEventFiles(route));
+}
+
+export function findNestedControlResult(route: NestedRoute, requestId: string, targetRunId: string, ignoredFiles: ReadonlySet<string>): NestedControlResultRecord | undefined {
+	const entries = listNestedEventFiles(route)
+		.filter((entry) => !ignoredFiles.has(entry))
+		.sort()
+		.reverse();
 	for (const entry of entries) {
-		const eventPath = path.join(route.eventSink, entry);
-		if (!containedPath(route.eventSink, eventPath)) continue;
-		try {
-			const stat = fs.statSync(eventPath);
-			if (!stat.isFile() || stat.size > MAX_EVENT_BYTES) continue;
-			const content = fs.readFileSync(eventPath, "utf-8");
-			const lines = content.includes("\n") ? content.split("\n").filter((line) => line.trim()) : [content];
-			for (const line of lines) {
-				const result = parseControlResult(line, route);
-				if (result) results.push(result);
-			}
-		} catch {
-			continue;
-		}
+		const result = readControlResultsFromFile(route, path.join(route.eventSink, entry))
+			.find((candidate) => candidate.requestId === requestId && candidate.targetRunId === targetRunId);
+		if (result) return result;
 	}
-	return results;
+	return undefined;
+}
+
+export function readNestedControlResults(route: NestedRoute): NestedControlResultRecord[] {
+	return listNestedEventFiles(route)
+		.sort()
+		.flatMap((entry) => readControlResultsFromFile(route, path.join(route.eventSink, entry)));
 }
 
 export function nestedRouteEnv(route: NestedRoute): Record<string, string> {

--- a/src/runs/shared/run-history.ts
+++ b/src/runs/shared/run-history.ts
@@ -18,6 +18,7 @@ const ROTATE_KEEP = 1000;
 const PRIVATE_DIR_MODE = 0o700;
 const PRIVATE_FILE_MODE = 0o600;
 const REDACTED_TASK = "[redacted]";
+const historyFileStates = new Map<string, { mtimeMs: number; ctimeMs: number; size: number; ino: number; lineCount: number }>();
 
 function getHistoryPath(): string {
 	return path.join(getAgentDir(), "run-history.jsonl");
@@ -30,8 +31,12 @@ function hashTask(task: string): string {
 function hardenHistoryStorage(historyPath: string): void {
 	const historyDir = path.dirname(historyPath);
 	fs.mkdirSync(historyDir, { recursive: true, mode: PRIVATE_DIR_MODE });
-	try { fs.chmodSync(historyDir, PRIVATE_DIR_MODE); } catch {}
-	try { if (fs.existsSync(historyPath)) fs.chmodSync(historyPath, PRIVATE_FILE_MODE); } catch {}
+	try {
+		if ((fs.statSync(historyDir).mode & 0o777) !== PRIVATE_DIR_MODE) fs.chmodSync(historyDir, PRIVATE_DIR_MODE);
+	} catch {}
+	try {
+		if ((fs.statSync(historyPath).mode & 0o777) !== PRIVATE_FILE_MODE) fs.chmodSync(historyPath, PRIVATE_FILE_MODE);
+	} catch {}
 }
 
 function sanitizeHistoryLine(line: string): string | undefined {
@@ -80,11 +85,39 @@ function writePrivateHistory(historyPath: string, lines: string[]): void {
 	try { fs.chmodSync(historyPath, PRIVATE_FILE_MODE); } catch {}
 }
 
-function sanitizeHistoryFile(historyPath: string): void {
-	if (!fs.existsSync(historyPath)) return;
+function rememberHistoryFile(historyPath: string, lineCount: number): void {
+	const stat = fs.statSync(historyPath);
+	historyFileStates.set(historyPath, {
+		mtimeMs: stat.mtimeMs,
+		ctimeMs: stat.ctimeMs,
+		size: stat.size,
+		ino: stat.ino,
+		lineCount,
+	});
+	if (historyFileStates.size > 8) historyFileStates.delete(historyFileStates.keys().next().value!);
+}
+
+function sanitizeHistoryFile(historyPath: string): number {
+	let stat: fs.Stats;
+	try {
+		stat = fs.statSync(historyPath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
+		throw error;
+	}
+	const cached = historyFileStates.get(historyPath);
+	if (cached
+		&& cached.mtimeMs === stat.mtimeMs
+		&& cached.ctimeMs === stat.ctimeMs
+		&& cached.size === stat.size
+		&& cached.ino === stat.ino) {
+		return cached.lineCount;
+	}
 	const raw = fs.readFileSync(historyPath, "utf-8");
 	const { lines, changed } = sanitizeHistoryLines(raw);
 	if (changed) writePrivateHistory(historyPath, lines);
+	rememberHistoryFile(historyPath, lines.length);
+	return lines.length;
 }
 
 function appendPrivateHistoryLine(historyPath: string, line: string): void {
@@ -94,7 +127,6 @@ function appendPrivateHistoryLine(historyPath: string, line: string): void {
 	} finally {
 		fs.closeSync(fd);
 	}
-	try { fs.chmodSync(historyPath, PRIVATE_FILE_MODE); } catch {}
 }
 
 export function recordRun(agent: string, task: string, exitCode: number, durationMs: number): void {
@@ -110,8 +142,11 @@ export function recordRun(agent: string, task: string, exitCode: number, duratio
 		};
 		const historyPath = getHistoryPath();
 		hardenHistoryStorage(historyPath);
-		try { sanitizeHistoryFile(historyPath); } catch {}
+		let lineCount: number | undefined;
+		try { lineCount = sanitizeHistoryFile(historyPath); } catch {}
 		appendPrivateHistoryLine(historyPath, JSON.stringify(entry));
+		if (lineCount === undefined) historyFileStates.delete(historyPath);
+		else rememberHistoryFile(historyPath, lineCount + 1);
 	} catch {
 		// Best-effort — never crash the execution flow for history recording
 	}
@@ -134,9 +169,10 @@ export function loadRunsForAgent(agent: string): RunEntry[] {
 		lines = lines.slice(-ROTATE_KEEP);
 		changed = true;
 	}
-	if (changed) {
-		try { writePrivateHistory(historyPath, lines); } catch {}
-	}
+	try {
+		if (changed) writePrivateHistory(historyPath, lines);
+		rememberHistoryFile(historyPath, lines.length);
+	} catch {}
 
 	return lines
 		.map((line) => { try { return JSON.parse(line) as RunEntry; } catch { return undefined; } })

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -73,8 +73,19 @@ export function resolveConfigDirName(codingAgentModule?: unknown, entryPoint?: s
 		?? DEFAULT_CONFIG_DIR_NAME;
 }
 
+let cachedConfigDirName: { entryPoint: string | undefined; packageRoot: string | undefined; value: string } | undefined;
+
 export function getConfigDirName(): string {
-	return resolveConfigDirName();
+	const entryPoint = process.argv[1];
+	const packageRoot = process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV];
+	if (cachedConfigDirName
+		&& cachedConfigDirName.entryPoint === entryPoint
+		&& cachedConfigDirName.packageRoot === packageRoot) {
+		return cachedConfigDirName.value;
+	}
+	const value = resolveConfigDirName(undefined, entryPoint, packageRoot);
+	cachedConfigDirName = { entryPoint, packageRoot, value };
+	return value;
 }
 
 export function getProjectConfigDir(projectRoot: string): string {

--- a/test/unit/config-dir-runtime.test.ts
+++ b/test/unit/config-dir-runtime.test.ts
@@ -65,6 +65,29 @@ describe("config directory resolution", () => {
 		}
 	});
 
+	it("invalidates cached runtime resolution when the package root changes", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-config-cache-"));
+		try {
+			const firstRoot = path.join(tempDir, "first");
+			const secondRoot = path.join(tempDir, "second");
+			for (const [root, configDir] of [[firstRoot, ".first-pi"], [secondRoot, ".second-pi"]] as const) {
+				fs.mkdirSync(root, { recursive: true });
+				fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({
+					name: "@earendil-works/pi-coding-agent",
+					piConfig: { configDir },
+				}), "utf-8");
+			}
+
+			process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] = firstRoot;
+			assert.equal(getConfigDirName(), ".first-pi");
+			assert.equal(getConfigDirName(), ".first-pi");
+			process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] = secondRoot;
+			assert.equal(getConfigDirName(), ".second-pi");
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("canonicalizes watcher paths and preserves the original path when native realpath fails", () => {
 		assert.equal(resolveWatchPath("C:\\SHORT~1\\watch", () => "C:\\Long Path\\watch"), "C:\\Long Path\\watch");
 		assert.equal(resolveWatchPath("C:\\SHORT~1\\watch", () => { throw new Error("missing"); }), "C:\\SHORT~1\\watch");

--- a/test/unit/nested-control.test.ts
+++ b/test/unit/nested-control.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import registerFanoutChildSubagentExtension from "../../src/extension/fanout-child.ts";
 import { createSubagentExecutor } from "../../src/runs/foreground/subagent-executor.ts";
-import { createNestedRoute, projectNestedEvents, readNestedControlRequests, readNestedControlResults, writeNestedControlRequest, writeNestedControlResult, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
+import { createNestedRoute, findNestedControlResult, projectNestedEvents, readNestedControlRequests, readNestedControlResults, snapshotNestedEventFiles, writeNestedControlRequest, writeNestedControlResult, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
 import {
 	SUBAGENT_CHILD_ENV,
 	SUBAGENT_FANOUT_CHILD_ENV,
@@ -129,6 +129,25 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<voi
 }
 
 describe("nested control routing", () => {
+	it("finds a control result without considering files present before its request", () => {
+		const route = createNestedRoute("root-targeted-result");
+		routeRoots.push(path.dirname(route.eventSink));
+		const requestedAt = Date.now();
+		writeNestedControlResult(route, { ts: requestedAt, requestId: "older", targetRunId: "child", ok: true, message: "older result" });
+		writeNestedEvent(route, {
+			type: "subagent.nested.updated",
+			ts: requestedAt + 1,
+			parentRunId: route.rootRunId,
+			child: { id: "child", parentRunId: route.rootRunId, depth: 1, path: [], state: "running" },
+		});
+		const ignoredFiles = snapshotNestedEventFiles(route);
+		writeNestedControlResult(route, { ts: requestedAt - 1, requestId: "target", targetRunId: "child", ok: true, message: "target result" });
+
+		assert.equal(findNestedControlResult(route, "target", "child", ignoredFiles)?.message, "target result");
+		assert.equal(findNestedControlResult(route, "older", "child", ignoredFiles), undefined);
+		assert.equal(readNestedControlResults(route).length, 2);
+	});
+
 	it("routes interrupt to an explicit nested id through the control inbox", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-nested-control-"));
 		try {

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -252,6 +252,24 @@ Package skill content.
 		assert.equal(history[1]?.taskHash, taskHash("legacy customer secret"));
 	});
 
+	it("re-sanitizes run history after an external write", () => {
+		recordRun("env-agent", "first secret", 0, 1);
+		const historyPath = path.join(agentDir, "run-history.jsonl");
+		fs.appendFileSync(historyPath, `${JSON.stringify({
+			agent: "env-agent",
+			task: "externally written secret",
+			ts: 2,
+			status: "ok",
+			duration: 2,
+		})}\n`);
+
+		recordRun("env-agent", "second secret", 0, 3);
+
+		const rawHistory = fs.readFileSync(historyPath, "utf-8");
+		assert.doesNotMatch(rawHistory, /first secret|externally written secret|second secret/);
+		assert.equal(loadRunsForAgent("env-agent").length, 3);
+	});
+
 	it("uses the configured agent dir for subagent bridge instruction files", () => {
 		const instructionPath = path.join(agentDir, "extensions", "subagent", "bridge.md");
 		writeFile(instructionPath, "Native bridge for {orchestratorTarget}");


### PR DESCRIPTION
## Summary

Reduce repeated synchronous filesystem work in three runtime paths:

- cache Pi config-directory resolution until its entrypoint or package-root input changes
- skip full run-history sanitization when the file identity and metadata are unchanged, while invalidating safely after external edits or failed rewrites
- limit nested control-result polling to immutable event files created after the request starts

The nested lookup uses a pre-request filename snapshot rather than wall-clock timestamps, so clock adjustments cannot hide a valid response.

## Performance

A local benchmark with 10,000 config lookups, 100 history appends against 1,000 existing entries, and 20 nested control lookups across 1,001 event files measured:

- config lookup: 28.2µs → 0.21µs per call
- history append: 0.64ms → 0.05ms per append
- nested control lookup: 16.55ms → 0.49ms per lookup

## Testing

- `npm run test:all`
- focused config-directory, run-history, nested-control, and cold-start extension registration tests
