### PR TITLE
docs: add fanout prompt guardrail

### DIFF
--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -31,6 +31,7 @@ For broad or uncertain requests, read more than one reference. For complex work,
 
 - Keep the parent as orchestrator and final decision-maker.
 - Use one writer per cwd/worktree unless isolated worktrees are intentional.
+- For parallel fanout, compare child prompts before launch. Do not send clone prompts with only issue numbers, titles, or broad file globs swapped; each child needs a lane-specific task, source seam, prior evidence, and decision that remains distinct without the item number.
 - Prefer fresh-context review/validation fanout, then synthesize and apply fixes in the parent.
 - Use async/background only when work can proceed independently; do not poll just to wait.
 - Preserve capability ceilings and child tool restrictions; role selection is not enforcement.


### PR DESCRIPTION
## Summary

Add a repo-local pi-subagents skill guardrail requiring fanout prompts to be lane-specific instead of cloned prompts with only issue numbers, titles, or broad file globs swapped.

## Validation

- git diff --check origin/main...HEAD
