### PR TITLE
feat: support agent aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added agent frontmatter aliases and built-in worker aliases for `developer`, `coder`, `implementer`, and `develop`, while keeping canonical names in execution state. Thanks to @selimerunkut for #695.
 - Added explicit chain approval checkpoints with `{ checkpoint, message? }`, `approve-checkpoint`/`reject-checkpoint` controls, persisted checkpoint status, and terminal `rejected` outcomes. Thanks to @saleemlala for #694.
 - Added optional root `usageBudget` limits for reported token and cost totals, with soft status reporting and hard gating for later child launches without stopping already-running children. Thanks to @saleemlala for #693.
 - Added optional `launchResolvedExtensions` status/result/RPC metadata with opaque launch-resolved child extension identifiers and ambient-extension state. Thanks to @saleemlala for #691.

--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ name: scout
 # Optional: registers this as code-analysis.scout while preserving name: scout
 package: code-analysis
 description: Fast codebase recon
+aliases: explorer, code-scout
 tools: read, grep, find, ls, bash, mcp:chrome-devtools
 extensions:
 subagentOnlyExtensions: ./tools/child-only-search.ts
@@ -787,6 +788,7 @@ Important fields:
 | Field | Notes |
 |-------|-------|
 | `package` | Optional package identifier. A file with `name: scout` and `package: code-analysis` registers as `code-analysis.scout`; serialization keeps `name` and `package` separate. |
+| `aliases` | Optional comma-separated or block-list names that resolve to this agent for selection and explicit `agent`/chain/task inputs. Runtime status, persistence, and config still use the canonical `name`; exact canonical names take precedence over aliases, and alias collisions between distinct canonical agents fail as ambiguous. |
 | `tools` | Strict child tool allowlist. Named extension tools must also have their provider loaded. `mcp:` entries select direct MCP tools when `pi-mcp-adapter` is installed. |
 | `extensions` | Omitted means normal extensions; empty means no extensions; list values allowlist specific extensions. |
 | `subagentOnlyExtensions` | Extension paths loaded only in spawned child sessions for this agent. Tools registered there are unavailable to the main agent unless also installed through normal Pi extension configuration. |
@@ -1365,7 +1367,7 @@ Agent definitions are not loaded into context by default. Management actions let
 { action: "reset", agent: "reviewer" }
 ```
 
-`create` uses `config.scope`, not `agentScope`. `config.name` is the local frontmatter name; optional `config.package` registers the runtime name as `{package}.{name}` and is saved as separate `name` and `package` frontmatter. `update` and `delete` use the runtime name and `agentScope` only when the same runtime name exists in multiple scopes. To clear optional string fields, including `package`, set them to `false` or `""`.
+`create` uses `config.scope`, not `agentScope`. `config.name` is the local frontmatter name; optional `config.package` registers the runtime name as `{package}.{name}` and is saved as separate `name` and `package` frontmatter. `config.aliases` accepts a comma-separated string, string array, or `false` to clear aliases; aliases resolve to the canonical agent name for execution and are shown by `list`/`get`. `update` and `delete` use the runtime name and `agentScope` only when the same runtime name exists in multiple scopes. To clear optional string fields, including `package`, set them to `false` or `""`.
 
 `eject` copies a bundled builtin or package agent verbatim into the user or project agent dir (default `user`) as an editable custom file that shadows the original, so you can customize a builtin without hunting package files. `disable` writes a reversible `agentOverrides.<name>.disabled: true` entry to the user or project settings file (default `user`); the agent stays on disk but is hidden from runtime discovery and `list`. `enable` removes that `disabled` field while preserving any other override fields on the same entry. `reset` deletes the scope's custom agent file and/or settings override entry, restoring the bundled default; it refuses if no bundled default exists (use `delete` for purely custom agents). All four accept `agentScope: "user" | "project"` and operate in one scope at a time; project overrides still win over user ones, so a project-scope disable survives a user-scope `enable` until you target the project scope.
 
@@ -1373,7 +1375,7 @@ Agent definitions are not loaded into context by default. Management actions let
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
-| `agent` | string | - | Agent name for single mode, or target for management actions. |
+| `agent` | string | - | Agent name or alias for single mode, or target for management actions. Execution records use the canonical agent name. |
 | `task` | string | - | Task string for single mode. |
 | `action` | string | - | `list`, `get`, `create`, `update`, `delete`, `status`, `interrupt`, `stop`, `resume`, `steer`, `append-step`, `approve-checkpoint`, `reject-checkpoint`, or `doctor`. |
 | `chainName` | string | - | Chain name for management actions. |

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -1,6 +1,7 @@
 ---
 name: worker
 description: Implementation agent for normal tasks and approved oracle handoffs
+aliases: developer, coder, implementer, develop
 thinking: high
 systemPromptMode: replace
 inheritProjectContext: true

--- a/skills/pi-subagents/references/management-authoring-rpc.md
+++ b/skills/pi-subagents/references/management-authoring-rpc.md
@@ -78,6 +78,7 @@ A minimal agent file looks like this:
 name: my-agent
 package: code-analysis
 description: What this agent does
+aliases: developer, coder
 model: openai-codex/gpt-5.4
 thinking: high
 tools: read, grep, find, ls, bash
@@ -95,6 +96,7 @@ That is only a starting point. Omit `package` for the traditional unqualified ru
 - `defaultProgress`
 - `defaultReads`
 - `output`
+- `aliases`
 - `fallbackModels`
 - `subagentOnlyExtensions`
 - `skills`
@@ -106,6 +108,8 @@ That is only a starting point. Omit `package` for the traditional unqualified ru
 - `async` — single-agent default for background launch (`true`/`false`); explicit tool-call `async` wins
 - `timeoutMs` — single-agent default run-level max runtime in ms; foreground calls use a 30-minute package default only when neither the call nor agent provides one (tool alias `maxRuntimeMs` is also accepted)
 - `turnBudget` — single-agent default `{ maxTurns, graceTurns? }` JSON object
+
+`aliases` is an optional comma-separated or block-list set of alternate names for selecting an agent. Aliases resolve to the canonical `name` for execution, status, persistence, and config. Exact canonical names take precedence over aliases, and alias collisions between distinct canonical agents fail as ambiguous. Management create/update accepts a comma-separated string, string array, or `false`/empty string to clear aliases.
 
 `acceptance` is a single-agent launch default. Use a scalar level such as `checked` or an inline/block YAML map such as `{ level: "none", reason: "lightweight lookup" }`. An explicit tool-call value wins; chain and parallel acceptance remains configured on the task or step. Management create/update accepts the same policy object, and `acceptance: ""` clears the frontmatter default (`false` remains the deprecated disabled-policy shorthand).
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -19,6 +19,7 @@ import {
 	mergeBuiltinAgentOverride,
 	removeBuiltinAgentOverride,
 	removeBuiltinAgentOverrideFields,
+	resolveAgentName,
 } from "./agents.ts";
 import { serializeAgent } from "./agent-serializer.ts";
 import { mergeAgentsForScope } from "./agent-selection.ts";
@@ -113,8 +114,13 @@ function findAgents(name: string, cwd: string, scope: AgentScope = "both"): Agen
 	const d = discoverAgentsAll(cwd);
 	const raw = name.trim();
 	const sanitized = sanitizeName(raw);
-	return allAgents(d)
-		.filter((a) => (scope === "both" || a.source === scope) && (a.name === raw || a.name === sanitized))
+	const scoped = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package);
+	let resolved = resolveAgentName(raw, scoped);
+	if (!resolved.agent && !resolved.error && sanitized !== raw) resolved = resolveAgentName(sanitized, scoped);
+	if (resolved.agent) return scoped.filter((agent) => agent.name === resolved.agent!.name).sort((a, b) => a.source.localeCompare(b.source));
+	return scoped
+		.filter((agent) => Boolean(resolveAgentName(raw, [agent]).agent)
+			|| (sanitized !== raw && Boolean(resolveAgentName(sanitized, [agent]).agent)))
 		.sort((a, b) => a.source.localeCompare(b.source));
 }
 
@@ -128,15 +134,20 @@ function findChains(name: string, cwd: string, scope: AgentScope = "both"): Chai
 
 const AGENT_SOURCE_PRECEDENCE: Record<AgentSource, number> = { builtin: 0, package: 1, user: 2, project: 3 };
 
-// Returns the highest-precedence agent for a name (project > user > package > builtin,
-// matching mergeAgentsForScope for "both"), including disabled agents so disable/enable/reset
-// can locate agents that runtime discovery filters out.
-function pickEffectiveAgent(d: ReturnType<typeof discoverAgentsAll>, name: string): AgentConfig | undefined {
+// Returns the highest-precedence definition for a resolved canonical name (project > user > package > builtin),
+// matching mergeAgentsForScope for "both", including disabled agents so disable/enable can locate hidden targets.
+function resolveEffectiveAgent(d: ReturnType<typeof discoverAgentsAll>, name: string): { agent?: AgentConfig; error?: string } {
 	const raw = name.trim();
-	const sanitized = sanitizeName(raw);
-	const matches = allAgents(d).filter((a) => a.name === raw || a.name === sanitized);
-	if (matches.length === 0) return undefined;
-	return matches.reduce((best, agent) => (AGENT_SOURCE_PRECEDENCE[agent.source] > AGENT_SOURCE_PRECEDENCE[best.source] ? agent : best));
+	const candidates = allAgents(d);
+	let resolved = resolveAgentName(raw, candidates);
+	if (!resolved.agent && !resolved.error) {
+		const sanitized = sanitizeName(raw);
+		if (sanitized !== raw) resolved = resolveAgentName(sanitized, candidates);
+	}
+	if (resolved.error) return { error: resolved.error };
+	if (!resolved.agent) return {};
+	const matches = candidates.filter((agent) => agent.name === resolved.agent!.name);
+	return { agent: matches.reduce((best, agent) => (AGENT_SOURCE_PRECEDENCE[agent.source] > AGENT_SOURCE_PRECEDENCE[best.source] ? agent : best)) };
 }
 
 function nameExistsInScope(cwd: string, scope: ManagementScope, name: string, excludePath?: string): boolean {
@@ -156,8 +167,9 @@ function isMutableSource(source: AgentSource): source is ManagementScope {
 
 function unknownChainAgents(cwd: string, steps: ChainStepConfig[]): string[] {
 	const d = discoverAgentsAll(cwd);
-	const known = new Set(allAgents(d).map((a) => a.name));
-	return [...new Set(steps.map((s) => s.agent).filter((a) => !known.has(a)))].sort((a, b) => a.localeCompare(b));
+	const agents = allAgents(d);
+	return [...new Set(steps.map((s) => s.agent).filter((agentName): agentName is string => typeof agentName === "string" && !resolveAgentName(agentName, agents).agent))]
+		.sort((a, b) => a.localeCompare(b));
 }
 
 function chainStepWarnings(ctx: ManagementContext, steps: ChainStepConfig[]): string[] {
@@ -251,6 +263,7 @@ export function preservedAgentFrontmatterFields(agent: AgentConfig, cfg: Record<
 	if (hasKey(cfg, "name")) changed("name");
 	if (hasKey(cfg, "package")) changed("package");
 	if (hasKey(cfg, "description")) changed("description");
+	if (hasKey(cfg, "aliases")) changed("alias", "aliases");
 	if (hasKey(cfg, "systemPrompt")) changed("systemPrompt");
 	if (hasKey(cfg, "model")) changed("model");
 	if (hasKey(cfg, "fallbackModels")) changed("fallbackModels");
@@ -370,6 +383,16 @@ function parseTools(raw: string): { tools?: string[]; mcpDirectTools?: string[] 
 }
 
 function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): string | undefined {
+	if (hasKey(cfg, "aliases")) {
+		if (cfg.aliases === false || cfg.aliases === "") target.aliases = undefined;
+		else if (typeof cfg.aliases === "string") {
+			const aliases = parseCsv(cfg.aliases).filter((alias) => alias !== target.name);
+			target.aliases = aliases.length ? aliases : undefined;
+		} else if (Array.isArray(cfg.aliases) && cfg.aliases.every((entry) => typeof entry === "string")) {
+			const aliases = [...new Set(cfg.aliases.map((entry) => entry.trim()).filter(Boolean).filter((alias) => alias !== target.name))];
+			target.aliases = aliases.length ? aliases : undefined;
+		} else return "config.aliases must be a comma-separated string, string array, or false when provided.";
+	}
 	if (hasKey(cfg, "systemPrompt")) {
 		if (cfg.systemPrompt === false || cfg.systemPrompt === "") target.systemPrompt = "";
 		else if (typeof cfg.systemPrompt === "string") target.systemPrompt = cfg.systemPrompt;
@@ -513,13 +536,17 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 	return undefined;
 }
 
-function resolveTarget<T extends { source: AgentSource; filePath: string }>(
+function resolveTarget<T extends { name: string; source: AgentSource; filePath: string }>(
 	kind: "agent" | "chain",
 	name: string,
 	matches: T[],
 	cwd: string,
 	scopeHint?: string,
 ): T | AgentToolResult<Details> {
+	const distinctNames = [...new Set(matches.map((m) => m.name))];
+	if (distinctNames.length > 1) {
+		return result(`Ambiguous ${kind} alias or name '${name}': ${distinctNames.sort((a, b) => a.localeCompare(b)).join(", ")}`, true);
+	}
 	const mutable = matches.filter((m): m is T & { source: ManagementScope } => isMutableSource(m.source));
 	if (mutable.length === 0) {
 		if (matches.length > 0) {
@@ -564,6 +591,7 @@ function formatAgentDetail(agent: AgentConfig): string {
 		lines.push(`Local name: ${frontmatterNameForConfig(agent)}`);
 		lines.push(`Package: ${agent.packageName}`);
 	}
+	if (agent.aliases?.length) lines.push(`Aliases: ${agent.aliases.join(", ")}`);
 	if (agent.model) lines.push(`Model: ${agent.model}`);
 	if (agent.fallbackModels?.length) lines.push(`Fallback models: ${agent.fallbackModels.join(", ")}`);
 	if (tools.length) lines.push(`Tools: ${tools.join(", ")}`);
@@ -660,7 +688,7 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 	const lines = [
 		"Executable agents:",
 		...(agents.length
-			? agents.map((a) => `- ${a.name} (${a.source}${a.defaultContext ? `, context: ${a.defaultContext}` : ""}): ${a.description}`)
+			? agents.map((a) => `- ${a.name} (${a.source}${a.defaultContext ? `, context: ${a.defaultContext}` : ""}${a.aliases?.length ? `, aliases: ${a.aliases.join(", ")}` : ""}): ${a.description}`)
 			: ["- (none)"]),
 		"",
 		"Chains:",
@@ -760,12 +788,13 @@ function handleGet(params: ManagementParams, ctx: ManagementContext): AgentToolR
 	const blocks: string[] = [];
 	let anyFound = false;
 	if (params.agent) {
-		const raw = params.agent.trim();
-		const sanitized = sanitizeName(raw);
-		const d = discoverAgentsAll(ctx.cwd);
-		const matches = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package)
-			.filter((agent) => agent.name === raw || agent.name === sanitized);
-		if (!matches.length) {
+		const matches = findAgents(params.agent, ctx.cwd, scope);
+		const distinctNames = [...new Set(matches.map((agent) => agent.name))];
+		if (distinctNames.length > 1) {
+			const msg = `Ambiguous agent alias or name '${params.agent}': ${distinctNames.sort((a, b) => a.localeCompare(b)).join(", ")}`;
+			if (!hasBoth) return result(msg, true);
+			blocks.push(msg);
+		} else if (!matches.length) {
 			const msg = `Agent '${params.agent}' not found. Available: ${availableNames(ctx.cwd, "agent").join(", ") || "none"}.`;
 			if (!hasBoth) return result(msg, true);
 			blocks.push(msg);
@@ -1027,13 +1056,14 @@ function handleDisable(params: ManagementParams, ctx: ManagementContext): AgentT
 	if (scope === "project" && d.projectSettingsPath === null) {
 		return result("Project override is not available here: no project config root (.pi or .agents) was found above the cwd. Use agentScope: 'user' or run from inside a project.", true);
 	}
-	const effective = pickEffectiveAgent(d, raw);
-	if (!effective) {
+	const effective = resolveEffectiveAgent(d, raw);
+	if (effective.error) return result(effective.error, true);
+	if (!effective.agent) {
 		return result(`Agent '${raw}' not found. Available: ${availableNames(ctx.cwd, "agent").join(", ") || "none"}.`, true);
 	}
-	const runtimeName = effective.name;
+	const runtimeName = effective.agent.name;
 	const settingsPath = mergeBuiltinAgentOverride(ctx.cwd, runtimeName, scope, { disabled: true });
-	const after = pickEffectiveAgent(discoverAgentsAll(ctx.cwd), raw);
+	const after = resolveEffectiveAgent(discoverAgentsAll(ctx.cwd), raw).agent;
 	if (after?.disabled === true) {
 		return result(`Disabled agent '${runtimeName}' via ${scope} settings override at ${settingsPath}. It is now hidden from runtime discovery and { action: "list" }.`);
 	}
@@ -1050,13 +1080,14 @@ function handleEnable(params: ManagementParams, ctx: ManagementContext): AgentTo
 	if (scope === "project" && d.projectSettingsPath === null) {
 		return result("Project override is not available here: no project config root (.pi or .agents) was found above the cwd. Use agentScope: 'user' or run from inside a project.", true);
 	}
-	const effective = pickEffectiveAgent(d, raw);
-	if (!effective) {
+	const effective = resolveEffectiveAgent(d, raw);
+	if (effective.error) return result(effective.error, true);
+	if (!effective.agent) {
 		return result(`Agent '${raw}' not found. Available: ${availableNames(ctx.cwd, "agent").join(", ") || "none"}.`, true);
 	}
-	const runtimeName = effective.name;
+	const runtimeName = effective.agent.name;
 	const { path: settingsPath, removed } = removeBuiltinAgentOverrideFields(ctx.cwd, runtimeName, scope, ["disabled"]);
-	const after = pickEffectiveAgent(discoverAgentsAll(ctx.cwd), raw);
+	const after = resolveEffectiveAgent(discoverAgentsAll(ctx.cwd), raw).agent;
 	if (after && after.disabled !== true) {
 		if (removed) return result(`Enabled agent '${runtimeName}' (removed disabled override at ${settingsPath}).`);
 		return result(`Agent '${runtimeName}' is already enabled.`);

--- a/src/agents/agent-serializer.ts
+++ b/src/agents/agent-serializer.ts
@@ -5,6 +5,8 @@ export const KNOWN_FIELDS = new Set([
 	"name",
 	"package",
 	"description",
+	"alias",
+	"aliases",
 	"tools",
 	"model",
 	"fallbackModels",
@@ -50,6 +52,8 @@ export function serializeAgent(config: AgentConfig, options: SerializeAgentOptio
 	lines.push(`name: ${frontmatterNameForConfig(config)}`);
 	if (config.packageName) lines.push(`package: ${config.packageName}`);
 	lines.push(`description: ${config.description}`);
+	const aliasesValue = joinComma(config.aliases);
+	if (aliasesValue || preserve("alias", "aliases")) lines.push(`aliases: ${aliasesValue ?? ""}`);
 
 	const tools = [
 		...(config.tools ?? []),

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -116,6 +116,7 @@ export interface AgentConfig {
 	localName?: string;
 	packageName?: string;
 	description: string;
+	aliases?: string[];
 	tools?: string[];
 	mcpDirectTools?: string[];
 	model?: string;
@@ -471,6 +472,41 @@ function collectPackageSubagentPaths(cwd: string, options: { includeUser: boolea
 		}
 	}
 	return { agents, chains };
+}
+
+function normalizeAgentAliases(rawAliases: string[] | undefined, agentName: string): string[] | undefined {
+	const aliases = [...new Set((rawAliases ?? []).map((alias) => alias.trim()).filter(Boolean))]
+		.filter((alias) => alias !== agentName);
+	return aliases.length > 0 ? aliases : undefined;
+}
+
+function effectiveAgentMatch(matches: AgentConfig[]): { agent?: AgentConfig; error?: string } {
+	const distinctNames = [...new Set(matches.map((agent) => agent.name))];
+	if (distinctNames.length === 1) {
+		const sourceRank = new Map<AgentConfig["source"], number>([["builtin", 0], ["package", 1], ["user", 2], ["project", 3]]);
+		return { agent: [...matches].sort((a, b) => (sourceRank.get(b.source) ?? 0) - (sourceRank.get(a.source) ?? 0))[0] };
+	}
+	return {};
+}
+
+export function resolveAgentName(name: string, agents: AgentConfig[]): { agent?: AgentConfig; error?: string } {
+	const raw = name.trim();
+	const exact = agents.filter((agent) => agent.name === raw || agent.localName === raw);
+	if (exact.length === 1) return { agent: exact[0] };
+	if (exact.length > 1) {
+		const effective = effectiveAgentMatch(exact);
+		if (effective.agent) return effective;
+		return { error: `Ambiguous agent name '${name}': ${exact.map((agent) => agent.name).join(", ")}` };
+	}
+
+	const aliases = agents.filter((agent) => agent.aliases?.includes(raw));
+	if (aliases.length === 1) return { agent: aliases[0] };
+	if (aliases.length > 1) {
+		const effective = effectiveAgentMatch(aliases);
+		if (effective.agent) return effective;
+		return { error: `Ambiguous agent alias '${name}': ${aliases.map((agent) => agent.name).join(", ")}` };
+	}
+	return {};
 }
 
 function splitToolList(rawTools: string[] | undefined): { tools?: string[]; mcpDirectTools?: string[] } {
@@ -1385,6 +1421,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 		const tools = parsedTools.tools ?? [];
 		const mcpDirectTools = parsedTools.mcpDirectTools ?? [];
 		const defaultReads = parseFrontmatterList(frontmatter.defaultReads);
+		const aliases = normalizeAgentAliases(parseFrontmatterList(frontmatter.aliases ?? frontmatter.alias), runtimeName);
 		const skillStr = frontmatter.skill || frontmatter.skills;
 		const skills = parseFrontmatterList(skillStr);
 		const skillPath = parseFrontmatterList(frontmatter.skillPath);
@@ -1465,6 +1502,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 			localName,
 			packageName,
 			description: frontmatter.description,
+			aliases,
 			tools: rawTools !== undefined ? tools : undefined,
 			mcpDirectTools: mcpDirectTools.length > 0 ? mcpDirectTools : undefined,
 			model: frontmatter.model,

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { discoverAgents, discoverAgentsAll, type AgentConfig, type AgentScope, type AgentSource } from "../agents/agents.ts";
+import { discoverAgents, discoverAgentsAll, resolveAgentName, type AgentConfig, type AgentScope, type AgentSource } from "../agents/agents.ts";
 import { resolveExecutionAgentScope } from "../agents/agent-scope.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../agents/agent-memory.ts";
@@ -191,7 +191,7 @@ function normalizeAvailableModels(models: SubagentLaunchContractInput["available
 function candidateList(inputAgent: string, selected: AgentConfig | undefined, cwd: string): SubagentLaunchContractAgentCandidate[] {
 	const all = discoverAgentsAll(cwd);
 	return [...all.builtin, ...all.package, ...all.user, ...all.project]
-		.filter((agent) => agent.name === inputAgent || agent.localName === inputAgent)
+		.filter((agent) => Boolean(resolveAgentName(inputAgent, [agent]).agent))
 		.map((agent) => ({
 			name: agent.name,
 			...(agent.localName ? { localName: agent.localName } : {}),
@@ -225,14 +225,14 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 	}
 	const scope = resolveExecutionAgentScope(input.agentScope);
 	const discovered = discoverAgents(effectiveCwd, scope);
-	const matches = discovered.agents.filter((agent) => agent.name === input.agent || agent.localName === input.agent);
-	if (matches.length === 0) {
+	const resolvedAgent = resolveAgentName(input.agent, discovered.agents);
+	if (resolvedAgent.error) {
+		return { ok: false, code: "ambiguous_agent", message: resolvedAgent.error, diagnostics };
+	}
+	if (!resolvedAgent.agent) {
 		return { ok: false, code: "missing_agent", message: `Unknown agent: ${input.agent}`, diagnostics };
 	}
-	if (matches.length > 1) {
-		return { ok: false, code: "ambiguous_agent", message: `Ambiguous agent: ${input.agent}`, diagnostics };
-	}
-	const agent = matches[0]!;
+	const agent = resolvedAgent.agent;
 	const runId = input.runId ?? "preflight";
 	const skillInput = normalizeSkillInput(input.skill);
 	const outputOverride = normalizeSingleOutputOverride(input.output, agent.output);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { AgentConfig, AgentScope } from "../../agents/agents.ts";
+import { resolveAgentName, type AgentConfig, type AgentScope } from "../../agents/agents.ts";
 import { getArtifactsDir, getProjectChainRunsDir } from "../../shared/artifacts.ts";
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
 import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
@@ -1508,6 +1508,67 @@ async function maybeBuildForegroundIntercomReceipt(input: {
 		text: formatSubagentResultReceipt({ mode: input.mode, runId: input.runId, payload }),
 		details: stripDetailsOutputsForIntercomReceipt(input.details),
 	};
+}
+
+function canonicalizeAgentName(name: string, agents: AgentConfig[]): { name?: string; error?: string } {
+	const resolved = resolveAgentName(name, agents);
+	if (resolved.error) return { error: resolved.error };
+	if (!resolved.agent) return { error: `Unknown agent: ${name}` };
+	return { name: resolved.agent.name };
+}
+
+function canonicalizeExecutionParams(params: SubagentParamsLike, agents: AgentConfig[]): { params?: SubagentParamsLike; error?: string } {
+	const resolve = (name: string, location?: string): { name?: string; error?: string } => {
+		const result = canonicalizeAgentName(name, agents);
+		return result.error && location ? { error: `${result.error} (${location})` } : result;
+	};
+	if (params.agent) {
+		const result = resolve(params.agent);
+		if (result.error) return { error: result.error };
+		params = { ...params, agent: result.name };
+	}
+	if (params.tasks) {
+		const tasks: TaskParam[] = [];
+		for (let index = 0; index < params.tasks.length; index++) {
+			const task = params.tasks[index]!;
+			const result = resolve(task.agent, `task ${index + 1}`);
+			if (result.error) return { error: result.error };
+			tasks.push({ ...task, agent: result.name! });
+		}
+		params = { ...params, tasks };
+	}
+	if (params.chain) {
+		const chain: ChainStep[] = [];
+		for (let index = 0; index < params.chain.length; index++) {
+			const step = params.chain[index]!;
+			if (isParallelStep(step)) {
+				const parallel: typeof step.parallel = [];
+				for (let taskIndex = 0; taskIndex < step.parallel.length; taskIndex++) {
+					const task = step.parallel[taskIndex]!;
+					const result = resolve(task.agent, `step ${index + 1}, task ${taskIndex + 1}`);
+					if (result.error) return { error: result.error };
+					parallel.push({ ...task, agent: result.name! });
+				}
+				chain.push({ ...step, parallel });
+				continue;
+			}
+			if (isDynamicParallelStep(step)) {
+				const result = resolve(step.parallel.agent, `step ${index + 1}`);
+				if (result.error) return { error: result.error };
+				chain.push({ ...step, parallel: { ...step.parallel, agent: result.name! } });
+				continue;
+			}
+			if ("agent" in step && typeof step.agent === "string") {
+				const result = resolve(step.agent, `step ${index + 1}`);
+				if (result.error) return { error: result.error };
+				chain.push({ ...step, agent: result.name! });
+				continue;
+			}
+			chain.push(step);
+		}
+		params = { ...params, chain };
+	}
+	return { params };
 }
 
 function validateExecutionInput(
@@ -3965,6 +4026,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const parentSessionFile = ctx.sessionManager.getSessionFile() ?? null;
 		const discovered = deps.discoverAgents(effectiveCwd, scope);
 		const discoveredAgents = discovered.agents;
+		const canonicalParams = canonicalizeExecutionParams(effectiveParams, discoveredAgents);
+		if (canonicalParams.error) return buildRequestedModeError(effectiveParams, canonicalParams.error);
+		effectiveParams = canonicalParams.params!;
 		const modelScope = discovered.modelScope;
 		effectiveParams = applySingleAgentLaunchDefaults(effectiveParams, discoveredAgents);
 		const turnBudget = resolveTurnBudgetConfig(effectiveParams.turnBudget ?? deps.config.turnBudget);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1383,6 +1383,17 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.finalOutput, "Applied edit");
 	});
 
+	it("resolves explicit agent aliases to canonical execution names", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "Implemented" });
+		const executor = makeExecutor([makeAgent("worker", { aliases: ["developer"], completionGuard: false })]);
+
+		const result = await executor.execute("single", { agent: "developer", task: "Implement" }, new AbortController().signal, undefined, makeMinimalCtx(tempDir));
+
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details?.results[0]?.agent, "worker");
+		assert.match(result.content[0]?.text ?? "", /Implemented/);
+	});
+
 	it("returns error for unknown agent", async () => {
 		const agents = makeAgentConfigs(["echo"]);
 		const result = await runSync(tempDir, agents, "nonexistent", "Do something", {});

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -153,6 +153,47 @@ body`);
 	}));
 });
 
+describe("agent aliases", () => {
+	it("parses and serializes agent aliases", () => withTempHome(() => {
+		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-alias-agent-"));
+		tempDirs.push(project);
+		writeAgent(path.join(project, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Worker
+aliases: developer, coder, worker
+---
+body`);
+
+		const worker = discoverAgents(project, "both").agents.find((agent) => agent.name === "worker")!;
+		assert.deepEqual(worker.aliases, ["developer", "coder"]);
+		assert.match(serializeAgent(worker), /^aliases: developer, coder$/m);
+
+		const ctx = { cwd: project, modelRegistry: { getAvailable: () => [] } };
+		assert.match(handleManagementAction("list", {}, ctx).content[0]?.text ?? "", /aliases: developer, coder/);
+		assert.match(handleManagementAction("get", { agent: "developer" }, ctx).content[0]?.text ?? "", /Agent: worker/);
+	}));
+
+	it("reports management alias collisions as ambiguous", () => withTempHome(() => {
+		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-alias-collision-"));
+		tempDirs.push(project);
+		writeAgent(path.join(project, ".pi", "agents", "review-agent.md"), `---
+name: review-agent
+description: Custom reviewer
+aliases: developer
+---
+body`);
+
+		const ctx = { cwd: project, modelRegistry: { getAvailable: () => [] } };
+		const getResult = handleManagementAction("get", { agent: "developer" }, ctx);
+		assert.equal(getResult.isError, true);
+		assert.match(getResult.content[0]?.text ?? "", /Ambiguous agent alias or name 'developer': review-agent, worker/);
+
+		const disableResult = handleManagementAction("disable", { agent: "developer" }, ctx);
+		assert.equal(disableResult.isError, true);
+		assert.match(disableResult.content[0]?.text ?? "", /Ambiguous agent alias 'developer': worker, review-agent|Ambiguous agent alias 'developer': review-agent, worker/);
+	}));
+});
+
 describe("agent simple-scalar list frontmatter", () => {
 	it("discovers newline block lists for all list fields and routes MCP tools", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-block-list-frontmatter-"));

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -153,6 +153,52 @@ Project prompt.
 		}
 	});
 
+	it("resolves agent aliases to the canonical launch contract agent", async () => {
+		const cwd = path.join(tempDir, "repo-alias");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Project worker
+aliases: developer, coder
+---
+Project prompt.
+`);
+
+		const result = await resolveSubagentLaunchContract({
+			agent: "developer",
+			cwd,
+			task: "Implement the change",
+		});
+
+		assert.equal(result.ok, true);
+		assert.equal(result.contract.agent.name, "worker");
+	});
+
+	it("reports alias collisions as ambiguous agents", async () => {
+		const cwd = path.join(tempDir, "repo-alias-collision");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Project worker
+aliases: coder
+---
+Project prompt.
+`);
+		writeAgent(path.join(cwd, ".pi", "agents", "reviewer.md"), `---
+name: reviewer
+description: Project reviewer
+aliases: coder
+---
+Review prompt.
+`);
+
+		const result = await resolveSubagentLaunchContract({ agent: "coder", cwd });
+
+		assert.equal(result.ok, false);
+		assert.equal(result.code, "ambiguous_agent");
+		assert.match(result.message, /Ambiguous agent alias 'coder': reviewer, worker|Ambiguous agent alias 'coder': worker, reviewer/);
+	});
+
 	it("changes definition and launch digests when selected agent content changes", async () => {
 		const cwd = path.join(tempDir, "repo");
 		fs.mkdirSync(cwd, { recursive: true });


### PR DESCRIPTION
Closes #695.

This adds first-class aliases for agents while keeping runtime state canonical:

- parses `alias`/`aliases` frontmatter and serializes `aliases`
- adds built-in `worker` aliases: `developer`, `coder`, `implementer`, `develop`
- resolves aliases before execution/preflight so persisted results, status, and config use the canonical agent name
- shows aliases in management `list`/`get` and supports `config.aliases` in create/update
- rejects ambiguous aliases across distinct canonical agents while preserving exact canonical-name precedence

Thanks to @selimerunkut for the proposal in #695.

Validation:

- `git diff --check`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds first-class alias support for agents: aliases are parsed from `alias`/`aliases` frontmatter, serialized canonically, and resolved to the canonical agent name before execution, preflight, and most management actions. The built-in `worker` agent gains `developer`, `coder`, `implementer`, and `develop` as built-in aliases.

- `resolveAgentName` (new export in `agents.ts`) centralizes alias lookup with source-precedence tie-breaking and ambiguous-alias detection; it is threaded into preflight, the executor's `canonicalizeExecutionParams`, and most management handlers.
- Management `list`/`get` surfaces aliases in output; `create`/`update` accept `config.aliases`; `disable`/`enable`/`delete` resolve aliases correctly — but `eject` and `reset` still use bare name comparison and silently reject alias inputs.
- `unknownChainAgents` (used for chain-creation warnings) conflates unresolvable ambiguous aliases with genuinely unknown agent names, producing a misleading warning message.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for execution and preflight paths, but two management actions (`eject` and `reset`) silently reject valid alias inputs with misleading 'not found' errors, making the alias feature incomplete for those operations.

The core alias resolution logic, executor canonicalization, and preflight integration are solid and well-tested. However, `handleEject` and `handleReset` were not updated to call `resolveAgentName`, so `{ action: 'eject', agent: 'developer' }` returns 'not found' for the `worker` alias. Every other management action was updated consistently, making this gap both surprising and likely to be hit by users who discover aliases work for `get`/`delete`/`disable` but not for `eject`/`reset`.

**Files Needing Attention:** src/agents/agent-management.ts — the `handleEject` and `handleReset` functions need alias resolution added to match the other management handlers
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/agents/agents.ts | Adds `aliases?: string[]` to `AgentConfig`, `normalizeAgentAliases` helper, and the central `resolveAgentName` export with source-precedence tie-breaking; logic is sound |
| src/agents/agent-management.ts | Most management handlers correctly routed through `resolveAgentName`/`findAgents`; `handleEject` and `handleReset` still use direct name comparison and silently ignore aliases |
| src/runs/foreground/subagent-executor.ts | New `canonicalizeExecutionParams` rewrites agent names to canonical form across single, parallel-task, and chain modes before any further validation |
| src/api/preflight.ts | Switches to `resolveAgentName` for both agent resolution and candidate-list filtering; ambiguous-alias error returns `ambiguous_agent` code |
| src/agents/agent-serializer.ts | Adds `alias`/`aliases` to `KNOWN_FIELDS` and serializes as comma-joined `aliases:` line; preserves both singular and plural frontmatter keys |
| agents/worker.md | Adds built-in `developer`, `coder`, `implementer`, `develop` aliases to the worker agent frontmatter |
| test/unit/agent-frontmatter.test.ts | Covers alias parsing/serialization, list/get display, and alias-collision detection |
| test/unit/preflight.test.ts | Adds tests for alias resolution to canonical name and ambiguous-alias collision returning `ambiguous_agent` code |
| test/integration/single-execution.test.ts | Integration test confirms alias `developer` resolves to canonical `worker` in execution results |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User input\n(agent name or alias)"] --> B{resolveAgentName}
    B -->|exact name/localName match| C[Return canonical agent]
    B -->|no exact match| D{alias match}
    D -->|single match| E[Return canonical agent]
    D -->|multiple distinct canonicals| F[Return ambiguous error]
    D -->|no match| G[Return empty - not found]
    C --> H{Caller}
    E --> H
    F --> H
    G --> H
    H -->|executor| I[canonicalizeExecutionParams\nrewrites all agent fields]
    H -->|preflight| J[resolveSubagentLaunchContract\nuses canonical name]
    H -->|management get/delete/disable/enable/update| K[findAgents / resolveEffectiveAgent\nvia resolveAgentName]
    H -->|management eject/reset| L["⚠ Direct name comparison\n(aliases not resolved)"]
    I --> M[Execution with canonical name\nin status & results]
    J --> N[Launch contract with\ncanonical agent.name]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/agents/agent-management.ts`, line 1011-1022 ([link](https://github.com/nicobailon/pi-subagents/blob/d73f98fc57d410a4b8bf52619a582fbe320e8ae5/src/agents/agent-management.ts#L1011-L1022)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`eject` and `reset` bypass alias resolution**

   `handleEject` (line 1019) and `handleReset` (line 1112) still use direct `a.name === raw || a.name === sanitized` comparisons — they do not call `resolveAgentName`. Every other mutating management action (`get`, `delete`, `disable`, `enable`, `update`) was updated to route through `findAgents`/`resolveEffectiveAgent`. As a result, `{ action: "eject", agent: "developer" }` returns "Agent 'developer' not found or is not a bundled/package agent." even though `developer` is a valid alias for the builtin `worker`, and `{ action: "reset", agent: "developer" }` similarly returns "not found".

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agents/agent-management.ts
   Line: 1011-1022

   Comment:
   **`eject` and `reset` bypass alias resolution**

   `handleEject` (line 1019) and `handleReset` (line 1112) still use direct `a.name === raw || a.name === sanitized` comparisons — they do not call `resolveAgentName`. Every other mutating management action (`get`, `delete`, `disable`, `enable`, `update`) was updated to route through `findAgents`/`resolveEffectiveAgent`. As a result, `{ action: "eject", agent: "developer" }` returns "Agent 'developer' not found or is not a bundled/package agent." even though `developer` is a valid alias for the builtin `worker`, and `{ action: "reset", agent: "developer" }` similarly returns "not found".

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/agents/agent-management.ts:1011-1022
**`eject` and `reset` bypass alias resolution**

`handleEject` (line 1019) and `handleReset` (line 1112) still use direct `a.name === raw || a.name === sanitized` comparisons — they do not call `resolveAgentName`. Every other mutating management action (`get`, `delete`, `disable`, `enable`, `update`) was updated to route through `findAgents`/`resolveEffectiveAgent`. As a result, `{ action: "eject", agent: "developer" }` returns "Agent 'developer' not found or is not a bundled/package agent." even though `developer` is a valid alias for the builtin `worker`, and `{ action: "reset", agent: "developer" }` similarly returns "not found".

### Issue 2
src/agents/agent-management.ts:168-175
**Ambiguous aliases mis-reported as unknown agents**

`unknownChainAgents` filters agent names where `!resolveAgentName(agentName, agents).agent`. When an alias is ambiguous, `resolveAgentName` returns `{ error, agent: undefined }`, so `!undefined` is `true` and the ambiguous alias name lands in the "unknown agents" warning list. A user who writes a chain step with `agent: "developer"` when two agents claim that alias would see `Warning: chain steps reference unknown agents: developer` rather than the more actionable `Ambiguous agent alias 'developer': worker, review-agent`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add agent aliases"](https://github.com/nicobailon/pi-subagents/commit/d73f98fc57d410a4b8bf52619a582fbe320e8ae5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49214625)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->