### PR TITLE
docs: clarify worktree dependency setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1483,6 +1483,8 @@ Requirements:
 - task-level `cwd` overrides must be omitted or match the shared cwd
 - configured `worktreeSetupHook` must return valid JSON before timeout
 
+Git worktrees start from tracked files, so ignored dependency state may be absent. `pi-subagents` attempts the `node_modules` symlink above, but if module resolution fails in a fresh worktree, first confirm dependencies were linked, installed, or provisioned by `worktreeSetupHook` before treating it as a code failure.
+
 By default, worktrees are created under the system temp directory. Set `worktreeBaseDir` in config, or `PI_SUBAGENTS_WORKTREE_DIR` when config is unset, to put them under a stable trusted directory. Missing base directories are created automatically.
 
 After a worktree parallel step completes, per-agent diff stats are appended to the output and full patch files are written to artifacts. The runtime also writes a versioned aggregate handoff manifest: foreground runs use the artifact directory's `handoffs/<run-id>.json`, while async runs use `<async-dir>/handoff.json`. The manifest records each child's terminal status, summary, output/session/structured-output references, patch stats and path, and whether its worktree and temporary branch were actually removed. Foreground `details`, async `status.json` and result files, status output, intercom delivery, and completion notifications expose the manifest path. Worktrees and temp branches still receive best-effort fallback cleanup if handoff finalization cannot run.

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -333,6 +333,14 @@ patch paths and stats, and whether each temporary worktree and branch was
 removed. If you want one writer thread and several advisory agents, prefer a
 single-writer pattern instead.
 
+Git worktrees start from tracked files, so ignored or untracked build state
+such as `node_modules` may be absent. `pi-subagents` attempts to symlink the
+root checkout's `node_modules` into each managed worktree when it exists, but
+agents should still treat dependency setup as an explicit bootstrap step before
+running tests, typecheck, or builds. If module resolution fails in a fresh
+worktree, first confirm dependencies were linked, installed, or provisioned by
+`worktreeSetupHook` before treating it as a code failure.
+
 ## The Oracle Workflow
 
 The intended oracle loop is:


### PR DESCRIPTION
Clarifies worktree dependency setup for `worktree: true` subagent runs.

Git worktrees start from tracked files, so ignored dependency state can be absent. The docs now note that `pi-subagents` attempts to symlink root `node_modules` when present, but agents should still verify dependencies were linked, installed, or provisioned by `worktreeSetupHook` before treating module-resolution failures as code failures.

Validation:

- `git diff --check`

Docs-only change; no tests run.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This docs-only PR adds a clarifying paragraph in two places explaining that git worktrees begin from tracked files, so ignored state like `node_modules` may be absent, and that `pi-subagents` makes a best-effort symlink rather than a guaranteed one.

- **README.md**: Inserts the note directly after the worktree requirements bullet list, using a back-reference (\"the symlink above\") that is slightly less self-contained than ideal.
- **`execution-controls.md`**: Adds the same guidance before \"The Oracle Workflow\" with fuller phrasing that reads well in isolation, including explicit mention of tests, typecheck, and builds as scenarios affected by missing deps.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; no runtime behavior is modified.

Both files receive a prose-only addition that accurately describes existing behavior (best-effort node_modules symlinking) and gives agents actionable guidance when module resolution fails in a fresh worktree. The only gap is that the README paragraph leans on a back-reference that is slightly more fragile than the fully self-contained wording used in execution-controls.md, but this does not affect correctness.

**Files Needing Attention:** README.md — the new paragraph's back-reference phrasing is slightly less clear than the parallel passage in execution-controls.md.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds a prose paragraph after the worktree requirements list noting that git worktrees start from tracked files and that node_modules symlinking is best-effort, directing users to confirm deps before blaming code failures. |
| skills/pi-subagents/references/execution-controls.md | Adds a self-contained paragraph before 'The Oracle Workflow' section with the same dependency-setup guidance, phrased more explicitly and with additional context (typecheck, builds). |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[worktree: true parallel step starts] --> B[pi-subagents creates git worktree from HEAD tracked files]
    B --> C{root node_modules exists?}
    C -- Yes --> D[Attempt symlink: worktree/node_modules to root/node_modules]
    C -- No --> E[No symlink; deps absent]
    D --> F{Symlink succeeded?}
    F -- Yes --> G[Module resolution works]
    F -- No --> E
    E --> H[worktreeSetupHook runs if configured]
    H --> I{Hook provisioned deps?}
    I -- Yes --> G
    I -- No --> J[Module resolution fails - confirm dep setup before treating as code failure]
    G --> K[Agent runs tests / typecheck / build]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:1486
**Cross-reference phrasing is less clear than the parallel passage**

The phrase "attempts the `node_modules` symlink above" relies on the reader noticing the bullet point two lines earlier, and the shorthand makes the sentence read awkwardly. The equivalent passage in `execution-controls.md` is fully self-contained ("attempts to symlink the root checkout's `node_modules` into each managed worktree when it exists"), which is easier to read in isolation and mirrors how many readers hit this section (deep-link or search). Aligning the README wording to the same pattern would make both docs consistently informative on their own.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify worktree dependency setup"](https://github.com/nicobailon/pi-subagents/commit/4a755a2fdb58ca6d18c03a8185c39411c28d7f20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49226575)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->