### PR TITLE
fix: show foreground models in fleet inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Reduced repeated runtime filesystem work by caching stable Pi config-directory resolution, incrementally sanitizing run history, and limiting nested control-result polling to files created for the active request.
 
 ### Fixed
+- Render resolved model and thinking effort for active and recent foreground children in Fleet inspector summaries and details.
 - Resynchronized async job control-event scans that resume inside an oversized JSONL record, avoiding malformed-tail parse noise while preserving later control events. Thanks to @vicary for #700.
 - Report signal-terminated child processes with a canonical signal error instead of stderr-tail noise and classify those results separately from ordinary task failures. Thanks to @cking000bigdemon for #688.
 

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -4,7 +4,7 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { getMarkdownTheme, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type MarkdownTheme } from "@earendil-works/pi-tui";
 import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
-import { formatDuration, formatTokens, shortenPath } from "../shared/formatters.ts";
+import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../shared/formatters.ts";
 import { RESULTS_DIR, type AsyncJobState, type Details, type ForegroundChildControl, type ForegroundResumeChild, type ForegroundResumeRun, type ForegroundRunControl, type SubagentState } from "../shared/types.ts";
 import { readStatus } from "../shared/utils.ts";
 import { formatAsyncRunTranscript } from "../runs/background/fleet-view.ts";
@@ -223,12 +223,14 @@ function statusGlyph(item: FleetItem, theme: Theme): string {
 function foregroundActiveDetail(item: Extract<FleetItem, { kind: "foreground-active" }>): string[] {
 	const { control } = item;
 	const live = item.activeChild ?? control;
+	const modelThinking = formatModelThinking(live.model, live.thinking);
 	const lines = [
 		`Run: ${item.runId}`,
 		"Source: foreground",
 		`State: running`,
 		`Mode: ${control.mode}`,
 		item.index !== undefined ? `Child: ${item.index} (${item.agent})` : `Agent: ${item.agent}`,
+		modelThinking ? `Model: ${modelThinking}` : undefined,
 		`Started: ${new Date(live.startedAt).toISOString()}`,
 		live.currentTool ? `Current tool: ${live.currentTool}${live.currentPath ? ` · ${shortenPath(live.currentPath)}` : ""}` : undefined,
 		live.turnCount !== undefined ? `Turns: ${live.turnCount}` : undefined,
@@ -244,12 +246,14 @@ function foregroundActiveDetail(item: Extract<FleetItem, { kind: "foreground-act
 function foregroundRecentDetail(item: Extract<FleetItem, { kind: "foreground-recent" }>): string[] {
 	const { child, run } = item;
 	const outputPath = child.artifactPaths?.outputPath ?? child.savedOutputPath;
+	const modelThinking = formatModelThinking(child.model, child.thinking);
 	const lines = [
 		`Run: ${item.runId}`,
 		"Source: foreground",
 		`State: ${child.status}`,
 		`Mode: ${run.mode}`,
 		`Child: ${child.index} (${child.agent})${contextModeLabel(child.context) ? ` ${contextModeLabel(child.context)}` : ""}`,
+		modelThinking ? `Model: ${modelThinking}` : undefined,
 		`Updated: ${new Date(child.updatedAt ?? run.updatedAt).toISOString()}`,
 		outputPath ? `Output: ${outputPath}` : undefined,
 		child.sessionFile ? `Session: ${child.sessionFile}` : undefined,
@@ -377,10 +381,12 @@ function itemStats(item: FleetItem): string[] {
 	let durationMs: number | undefined;
 	if (item.kind === "foreground-active") {
 		const live = item.activeChild ?? item.control;
+		model = formatModelThinking(live.model, live.thinking) || undefined;
 		tokens = live.tokens;
 		tools = live.toolCount;
 		durationMs = Math.max(0, Date.now() - live.startedAt);
 	} else if (item.kind === "foreground-recent") {
+		model = formatModelThinking(item.child.model, item.child.thinking) || undefined;
 		tokens = item.child.tokens;
 		tools = item.child.toolCount;
 	} else {
@@ -733,7 +739,7 @@ export class SubagentFleetComponent implements Component {
 		if (transcriptWarning) raw.unshift(`Transcript preview warning: ${transcriptWarning}`, "");
 		const lines: string[] = [];
 		for (const line of raw) {
-			const styled = /^(Run|State|Mode|Source|Child|Agent):/.test(line)
+			const styled = /^(Run|State|Mode|Source|Child|Agent|Model):/.test(line)
 				? this.theme.bold(line)
 				: /^(Transcript|Result transcript tail)/.test(line)
 					? this.theme.fg("accent", line)

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -368,7 +368,7 @@ describe("native subagent fleet", () => {
 				currentIndex: 1,
 				description: "Review the active task",
 				activeChildren: new Map([
-					[0, { index: 0, agent: "worker", description: "Implement the active task", startedAt: now - 900, updatedAt: now - 100, tokens: 120 }],
+					[0, { index: 0, agent: "worker", description: "Implement the active task", startedAt: now - 900, updatedAt: now - 100, tokens: 120, model: "provider/live-model", thinking: "high" }],
 					[1, { index: 1, agent: "reviewer", description: "Review the active task", startedAt: now - 800, updatedAt: now, tokens: 240 }],
 				]),
 			});
@@ -388,6 +388,7 @@ describe("native subagent fleet", () => {
 				assert.ok(lines.some((line) => line.includes("worker")));
 				assert.ok(lines.some((line) => line.includes("reviewer")));
 				assert.ok(lines.some((line) => line.includes("foreground · live")));
+				assert.ok(lines.some((line) => line.includes("live-model · thinking high")));
 				assert.ok(lines.some((line) => line.includes("Task") && line.includes("Implement the active task")));
 				assert.ok(lines.some((line) => line.includes("Conversation") && line.includes("assistant response")));
 				assert.ok(lines.some((line) => line.includes("Worker live result")));
@@ -442,7 +443,7 @@ describe("native subagent fleet", () => {
 					cwd: baseCwd,
 					sessionId: "session-current",
 					updatedAt: 200,
-					children: [{ agent: "reviewer", index: 0, status: "completed", transcriptPath: recentTranscript }],
+					children: [{ agent: "reviewer", index: 0, status: "completed", transcriptPath: recentTranscript, model: "provider/recent-model", thinking: "xhigh" }],
 				});
 				state.asyncJobs.set(asyncId, {
 					asyncId,
@@ -469,7 +470,11 @@ describe("native subagent fleet", () => {
 						{ initialKey, refreshMs: 60_000, markdownTheme },
 					);
 					try {
-						assert.ok(component.render(100).some((line) => line.includes(expected)), `missing ${expected}`);
+						const lines = component.render(100);
+						assert.ok(lines.some((line) => line.includes(expected)), `missing ${expected}`);
+						if (initialKey.startsWith("foreground-recent:")) {
+							assert.ok(lines.some((line) => line.includes("recent-model · thinking xhigh")));
+						}
 					} finally {
 						component.dispose();
 					}
@@ -506,7 +511,7 @@ describe("native subagent fleet", () => {
 		assert.equal(state.fleetInspectorOpen, false);
 	});
 
-	it("opens the inspector with the FleetView-selected child focused", () => {
+	it("focuses the selected child and renders raw foreground model details", () => {
 		const state = stateForTest();
 		state.foregroundControls.set("run-worker", {
 			runId: "run-worker",
@@ -515,6 +520,8 @@ describe("native subagent fleet", () => {
 			updatedAt: 20,
 			currentAgent: "worker",
 			currentIndex: 0,
+			model: "provider/raw-model",
+			thinking: "medium",
 		});
 		state.foregroundControls.set("run-reviewer", {
 			runId: "run-reviewer",
@@ -524,6 +531,14 @@ describe("native subagent fleet", () => {
 			currentAgent: "reviewer",
 			currentIndex: 0,
 		});
+		state.foregroundRuns!.set("run-recent", {
+			runId: "run-recent",
+			mode: "single",
+			cwd: process.cwd(),
+			sessionId: "session-current",
+			updatedAt: 19,
+			children: [{ agent: "reviewer", index: 0, status: "completed", model: "provider/recent-raw-model", thinking: "xhigh" }],
+		});
 		const component = new SubagentFleetComponent(
 			{ terminal: { rows: 28, columns: 90 }, requestRender() {} } as never,
 			theme as never,
@@ -532,10 +547,25 @@ describe("native subagent fleet", () => {
 			{ initialKey: "foreground-active:run-worker:0", refreshMs: 60_000 },
 		);
 		try {
-			const selectedLine = component.render(90).find((line) => line.includes("›"));
+			const lines = component.render(90);
+			const selectedLine = lines.find((line) => line.includes("›"));
 			assert.ok(selectedLine?.includes("run-work"), `unexpected selected row: ${selectedLine}`);
+			assert.ok(lines.some((line) => line.includes("Model: raw-model · thinking medium")));
 		} finally {
 			component.dispose();
+		}
+
+		const recentComponent = new SubagentFleetComponent(
+			{ terminal: { rows: 28, columns: 90 }, requestRender() {} } as never,
+			theme as never,
+			state,
+			() => {},
+			{ initialKey: "foreground-recent:run-recent:0", refreshMs: 60_000 },
+		);
+		try {
+			assert.ok(recentComponent.render(90).some((line) => line.includes("Model: recent-raw-model · thinking xhigh")));
+		} finally {
+			recentComponent.dispose();
 		}
 	});
 


### PR DESCRIPTION
## Summary

- render the already-retained model and thinking effort for active and recent foreground children in Fleet inspector structured headers
- show the same information in raw fallback details through the existing `formatModelThinking` helper
- cover active/recent children with and without structured transcripts

## Context

Foreground controls and remembered foreground runs already retain resolved `model` and `thinking` values, but the native Fleet inspector omitted them while rendering foreground summaries and details. Async rendering is unchanged.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/fleet.test.ts test/unit/status-format.test.ts` — 17 passed
- `PI_CODING_AGENT_DIR=<empty-temp-dir> npm run test:integration` — 679 passed
- `npm run test:e2e` — 3 passed
- manual interactive preview with the local extension confirmed model/thinking visibility for active and recent foreground children
- fresh read-only review found no blockers

## Local full-suite note

Eight `pi-args`/`preflight` unit failures involving direct MCP tool-name prefixes reproduce unchanged on a clean worktree at the upstream base in this environment. They are outside the Fleet inspector change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces the already-retained `model` and `thinking` values for active and recent foreground children in the Fleet Inspector, mirroring what async runs already showed. Both the structured header stats line (via `itemStats`) and the raw fallback detail view (via `foregroundActiveDetail` / `foregroundRecentDetail`) are updated, and the bold-label regex is extended to cover `Model:` in the raw view.

- `itemStats` now populates `model` for `foreground-active` (from `activeChild ?? control`) and `foreground-recent` (from `child`) using the shared `formatModelThinking` helper.
- `foregroundActiveDetail` and `foregroundRecentDetail` each compute `modelThinking` and conditionally insert a `Model:` line into the raw detail array; the bold-regex in the renderer is extended to match it.
- New test assertions cover model/thinking visibility in structured headers (with transcript) and raw details (without transcript) for both foreground-active and foreground-recent items.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are additive display-only additions that read already-retained fields and fall back gracefully when those fields are absent.

The change reads optional model and thinking fields already present on all three relevant interfaces; absent-field paths produce an empty string that is filtered out. Both rendering paths are exercised by new test assertions and the logic reuses the battle-tested formatModelThinking helper already used for async items.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tui/fleet.ts | Adds formatModelThinking import and uses it in itemStats, foregroundActiveDetail, and foregroundRecentDetail; extends bold-regex to include Model: — all changes are consistent with the existing async pattern and type-safe. |
| test/unit/fleet.test.ts | Test fixtures updated with model/thinking fields and new assertions cover structured header stats and raw detail paths for both active and recent foreground children. |
| CHANGELOG.md | Changelog entry added for the fix under the existing Fixed section. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Fleet Inspector renders selected item] --> B{Transcript with events?}
    B -- Yes --> C[structuredHeader]
    C --> D[itemStats]
    D --> E{item.kind}
    E -- foreground-active --> F["formatModelThinking(activeChild ?? control)"]
    E -- foreground-recent --> G["formatModelThinking(child.model, child.thinking)"]
    E -- async --> H["item.step?.model"]
    F --> I[Stats line: model · tokens · tools · duration]
    G --> I
    H --> I
    B -- No --> J[detailLines / raw fallback]
    J --> K{item.kind}
    K -- foreground-active --> L[foregroundActiveDetail]
    K -- foreground-recent --> M[foregroundRecentDetail]
    L --> N["formatModelThinking(live.model, live.thinking) → Model: line"]
    M --> O["formatModelThinking(child.model, child.thinking) → Model: line"]
    N --> P[Bold regex now matches Model:]
    O --> P
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: show foreground models in fleet ins..."](https://github.com/nicobailon/pi-subagents/commit/330a539095972d7f35f1c8bda331eb686d7b7634) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49227052)</sub>

<!-- /greptile_comment -->