### PR TITLE
docs: add Greptile review guidelines

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,33 @@
+{
+  "instructions": "Follow the tracked review policy in .greptile/rules.md. Prefer concrete release-risk findings over speculative improvements. Do not describe a PR as safe to merge or merge-ready unless required changelog credit, focused validation, and exact-head CI gates are satisfied.",
+  "rules": [
+    {
+      "id": "release-risk-findings-only",
+      "rule": "Report only concrete, reachable release risks, direct contract contradictions, or clear local simplifications. Avoid speculative hardening, broad rewrites, and future-proofing suggestions.",
+      "severity": "high"
+    },
+    {
+      "id": "merge-ready-gates",
+      "rule": "Do not state that a PR is safe to merge or merge-ready unless required contributor credit, focused validation, and required CI on the exact PR head are present. If one is missing, call it out as a merge gate rather than a code defect.",
+      "severity": "high"
+    },
+    {
+      "id": "external-contributor-credit",
+      "rule": "When a change includes a CHANGELOG.md entry for material external contributor work, the entry must visibly credit the contributor with their GitHub login/name and PR or issue number, for example: Thanks to @login for #123.",
+      "scope": ["CHANGELOG.md"],
+      "severity": "high"
+    },
+    {
+      "id": "portable-tests",
+      "rule": "Tests must be portable across macOS, Linux, and Windows. Avoid machine-specific absolute Pi/TUI install paths, isolate both HOME and USERPROFILE when testing home-directory behavior, and prefer deterministic filesystem failures over POSIX chmod permission assumptions.",
+      "scope": ["test/**"],
+      "severity": "medium"
+    },
+    {
+      "id": "preserve-error-signals",
+      "rule": "Do not hide useful error signals by wrapping throwing/rejecting code into null, defaults, or less-informative results unless the surrounding code already uses a Result-style contract.",
+      "scope": ["src/**"],
+      "severity": "medium"
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,8 @@
+{
+  "files": [
+    {
+      "path": "CHANGELOG.md",
+      "description": "Unreleased changelog entries used to verify visible contributor credit for material changes."
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,16 @@
+# pi-subagents review rules
+
+Only report findings that identify a concrete, reachable release risk, direct contract contradiction, or clear local simplification. Avoid speculative hardening, broad rewrites, optional future-proofing, and unsupported edge-case warnings.
+
+Before describing a PR as safe to merge or merge-ready, verify the process gates that matter for this repository:
+
+- material external contributors are credited in `CHANGELOG.md` or release notes with login/name and PR or issue number;
+- focused validation is present for changed behavior;
+- required CI has run on the exact PR head;
+- docs and tests match the actual runtime behavior.
+
+If a process gate is missing, report it as a merge gate rather than a code defect.
+
+For tests, prefer narrow changed-file or focused regressions. Do not request broad integration or E2E coverage unless the change actually crosses that behavior boundary.
+
+For TypeScript changes, preserve existing error signals and local project patterns. Avoid wrappers that turn useful errors into `null`, defaults, or less-informative results.


### PR DESCRIPTION
Adds repo-level Greptile review guidance so automated PR summaries account for this repo's maintainer gates.

The new `.greptile/` config uses tracked `.greptile/rules.md` plus `CHANGELOG.md` context, and adds rules for release-risk-only findings, merge-ready gate language, external contributor changelog credit, portable tests, and preserving error signals.

This should help future Greptile summaries avoid marking PRs as safe to merge when process gates like exact-head CI or contributor credit are still missing.

Validation:

- `node -e 'JSON.parse(require("fs").readFileSync(".greptile/config.json","utf8")); JSON.parse(require("fs").readFileSync(".greptile/files.json","utf8")); console.log("greptile json ok")'`
- `git diff --cached --check`

Docs/config-only change; no tests run.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `.greptile/` configuration directory that encodes repo-specific review policy for Greptile's automated PR summaries. It adds three files: a machine-readable `config.json` with five scoped rules, a `files.json` that loads `CHANGELOG.md` as context, and a human-readable `rules.md` policy document.

- `config.json` defines rules covering release-risk-only findings, merge-ready gates, external contributor credit, test portability, and error-signal preservation — all consistent with the existing `.greptile-internal/` custom instructions already active in this repo.
- `files.json` references only `CHANGELOG.md`, which exists at the repo root, so context loading will succeed.
- `rules.md` mirrors the machine-readable rules for human reference; the content is internally consistent with `config.json`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Docs/config-only change with no runtime code modified; all referenced files resolve correctly.

All three new files are purely declarative configuration. CHANGELOG.md — the only external file referenced in files.json — exists at the repo root, so context loading will work. The rules in config.json are internally consistent with the human-readable policy in rules.md and with the existing custom instructions already active in the repo. No logic, tests, or runtime paths are affected.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .greptile/config.json | Adds Greptile config with five scoped rules and global instructions; JSON is structurally valid and self-consistent. |
| .greptile/files.json | Lists CHANGELOG.md as context file; the file exists in the repo root, so Greptile will load it correctly. |
| .greptile/rules.md | Human-readable policy document that mirrors the machine-readable rules in config.json; content is internally consistent. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Greptile PR Review Triggered] --> B[Load .greptile/config.json]
    B --> C[Apply global instructions]
    B --> D[Load scoped rules]
    D --> D1[release-risk-findings-only]
    D --> D2[merge-ready-gates]
    D --> D3[external-contributor-credit - scope: CHANGELOG.md]
    D --> D4[portable-tests - scope: test/**]
    D --> D5[preserve-error-signals - scope: src/**]
    A --> E[Load .greptile/files.json]
    E --> F{CHANGELOG.md exists?}
    F -- Yes --> G[Load CHANGELOG.md as context]
    F -- No --> H[Silent miss - no context]
    G --> I[Verify contributor credit in Unreleased section]
    C & G & D1 & D2 & D3 & D4 & D5 --> J[Generate review with merge-gate checks]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: add greptile review guidelines"](https://github.com/nicobailon/pi-subagents/commit/90ec01222cf82b954a53a8daff9e34f00a9acf81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49231382)</sub>

<!-- /greptile_comment -->
