### PR TITLE
fix: retain foreground controls until scheduling settles

### DIFF
--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -34,7 +34,13 @@ import {
 import { discoverAvailableSkills, normalizeSkillInput } from "../../agents/skills.ts";
 import { INTERCOM_BRIDGE_MARKER } from "../../intercom/intercom-bridge.ts";
 import { runSync } from "./execution.ts";
-import { beginForegroundChild, finishForegroundChild, updateForegroundChild } from "./foreground-control.ts";
+import {
+	beginForegroundChild,
+	finishForegroundChild,
+	retainForegroundSchedulingOwner,
+	settleForegroundSchedulingOwner,
+	updateForegroundChild,
+} from "./foreground-control.ts";
 import { buildChainSummary } from "../../shared/formatters.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
@@ -153,6 +159,8 @@ interface ParallelChainRunInput {
 	turnBudget?: ResolvedTurnBudget;
 	usageBudget?: UsageBudgetConfig;
 	onDetachedExit?: (index: number, result: SingleResult) => void;
+	/** Called after an attached child releases its foreground ownership. */
+	onForegroundChildSettled?: () => void;
 	toolBudget?: ResolvedToolBudget;
 	configToolBudget?: ToolBudgetConfig;
 	globalSemaphore?: Semaphore;
@@ -287,6 +295,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 	}
 
 	const completedResults: SingleResult[] = [];
+	if (input.foregroundControl) retainForegroundSchedulingOwner(input.foregroundControl);
 	const parallelResults = await mapConcurrent(
 		input.step.parallel,
 		concurrency,
@@ -364,7 +373,9 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				? createStructuredOutputRuntime(task.outputSchema, path.join(input.chainDir, "structured-output"))
 				: undefined;
 			const agentContract = task.agentContract ?? input.step.agentContract ?? input.agentContract;
-			const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
+			let result!: SingleResult;
+			try {
+				result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
 				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 				capabilityCeiling: input.capabilityCeiling,
 				context: input.contextForAgent?.(task.agent),
@@ -402,9 +413,13 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				timeoutMs: input.timeoutMs,
 				deadlineAt: input.deadlineAt,
 				turnBudget: input.turnBudget,
-				onDetachedExit: input.onDetachedExit
-					? (result) => input.onDetachedExit?.(childIndex, result)
-					: undefined,
+				onDetachedExit: (result) => {
+					try {
+						if (input.foregroundControl) finishForegroundChild(input.foregroundControl, childIndex);
+					} finally {
+						input.onDetachedExit?.(childIndex, result);
+					}
+				},
 				toolBudget: toolBudget.toolBudget,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
@@ -438,8 +453,15 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 						});
 					}
 					: undefined,
-			});
-			if (input.foregroundControl) finishForegroundChild(input.foregroundControl, childIndex);
+				});
+			} finally {
+				// Rejected attached attempts still release their parallel child control;
+				// detached receipts transfer ownership to onDetachedExit.
+				if (!result?.detached) {
+					if (input.foregroundControl) finishForegroundChild(input.foregroundControl, childIndex);
+					input.onForegroundChildSettled?.();
+				}
+			}
 
 			if (result.exitCode !== 0 && failFast) {
 				aborted = true;
@@ -449,6 +471,10 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 			return result;
 		},
 		input.globalSemaphore,
+		() => {
+			if (input.foregroundControl) settleForegroundSchedulingOwner(input.foregroundControl);
+			input.onForegroundChildSettled?.();
+		},
 	);
 
 	return parallelResults;
@@ -493,6 +519,8 @@ interface ChainExecutionParams {
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
 	onDetachedExit?: (index: number, result: SingleResult) => void;
+	/** Ownership callback used when parallel siblings outlive executeChain rejection. */
+	onForegroundChildSettled?: () => void;
 	toolBudget?: ResolvedToolBudget;
 	usageBudget?: UsageBudgetConfig;
 	configToolBudget?: ToolBudgetConfig;
@@ -817,6 +845,7 @@ ${step.message}` : ""}` }],
 					turnBudget: params.turnBudget,
 					usageBudget: params.usageBudget,
 					onDetachedExit,
+					onForegroundChildSettled: params.onForegroundChildSettled,
 					toolBudget: params.toolBudget,
 					configToolBudget: params.configToolBudget,
 					globalSemaphore,
@@ -1074,6 +1103,7 @@ ${step.message}` : ""}` }],
 				turnBudget: params.turnBudget,
 				usageBudget: params.usageBudget,
 				onDetachedExit,
+				onForegroundChildSettled: params.onForegroundChildSettled,
 				toolBudget: params.toolBudget,
 				configToolBudget: params.configToolBudget,
 				globalSemaphore,
@@ -1278,28 +1308,30 @@ ${step.message}` : ""}` }],
 				});
 			}
 
-			const structuredRuntime = seqStep.outputSchema
-				? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
-				: undefined;
 			const agentContract = seqStep.agentContract ?? params.agentContract;
-			const toolBudget = resolveChainToolBudget({ stepBudget: seqStep.toolBudget, runBudget: params.toolBudget, agentBudget: agentConfig?.toolBudget, configBudget: params.configToolBudget });
-			if (toolBudget.error) return buildChainExecutionErrorResult(toolBudget.error, {
-				results,
-				includeProgress,
-				allProgress,
-				allArtifactPaths,
-				artifactsDir: params.artifactsDir,
-				chainAgents,
-				chainSteps,
-				totalSteps,
-				currentStepIndex: stepIndex,
-				runId: params.runId,
-				outputs,
-				currentFlatIndex: globalTaskIndex,
-				dynamicChildren,
-				dynamicGroupStatuses,
-			});
-			const r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
+			let r!: SingleResult;
+			try {
+				const structuredRuntime = seqStep.outputSchema
+					? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
+					: undefined;
+				const toolBudget = resolveChainToolBudget({ stepBudget: seqStep.toolBudget, runBudget: params.toolBudget, agentBudget: agentConfig?.toolBudget, configBudget: params.configToolBudget });
+				if (toolBudget.error) return buildChainExecutionErrorResult(toolBudget.error, {
+					results,
+					includeProgress,
+					allProgress,
+					allArtifactPaths,
+					artifactsDir: params.artifactsDir,
+					chainAgents,
+					chainSteps,
+					totalSteps,
+					currentStepIndex: stepIndex,
+					runId: params.runId,
+					outputs,
+					currentFlatIndex: globalTaskIndex,
+					dynamicChildren,
+					dynamicGroupStatuses,
+				});
+				r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
 				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				capabilityCeiling: params.capabilityCeiling,
 				context: params.contextForAgent?.(seqStep.agent),
@@ -1337,9 +1369,13 @@ ${step.message}` : ""}` }],
 				timeoutMs: params.timeoutMs,
 				deadlineAt,
 				turnBudget: params.turnBudget,
-				onDetachedExit: onDetachedExit
-					? (result) => onDetachedExit(childIndex, result)
-					: undefined,
+				onDetachedExit: (result) => {
+					try {
+						if (foregroundControl) finishForegroundChild(foregroundControl, childIndex);
+					} finally {
+						onDetachedExit?.(childIndex, result);
+					}
+				},
 				toolBudget: toolBudget.toolBudget,
 				onUpdate: onUpdate
 					? (p) => {
@@ -1373,8 +1409,15 @@ ${step.message}` : ""}` }],
 						});
 					}
 					: undefined,
-			});
-			if (foregroundControl) finishForegroundChild(foregroundControl, childIndex);
+				});
+			} finally {
+				// Rejected attempts and early validation returns release the child here.
+				// A detached receipt transfers cleanup ownership to onDetachedExit.
+				if (!r?.detached) {
+					if (foregroundControl) finishForegroundChild(foregroundControl, childIndex);
+					params.onForegroundChildSettled?.();
+				}
+			}
 			recordRun(seqStep.agent, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
 
 			globalTaskIndex++;

--- a/src/runs/foreground/foreground-control.ts
+++ b/src/runs/foreground/foreground-control.ts
@@ -61,6 +61,20 @@ function clearCurrentChild(control: ForegroundRunControl): void {
 	control.interrupt = undefined;
 }
 
+export function retainForegroundSchedulingOwner(control: ForegroundRunControl): void {
+	control.schedulingOwners = (control.schedulingOwners ?? 0) + 1;
+	control.updatedAt = Date.now();
+}
+
+export function settleForegroundSchedulingOwner(control: ForegroundRunControl): void {
+	control.schedulingOwners = Math.max(0, (control.schedulingOwners ?? 0) - 1);
+	control.updatedAt = Date.now();
+}
+
+export function foregroundSchedulingSettled(control: ForegroundRunControl): boolean {
+	return (control.schedulingOwners ?? 0) === 0;
+}
+
 export function beginForegroundChild(control: ForegroundRunControl, input: BeginForegroundChildInput): void {
 	const now = Date.now();
 	const child: ForegroundChildControl = {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -8,7 +8,14 @@ import { getArtifactsDir, getProjectChainRunsDir } from "../../shared/artifacts.
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
 import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import { executeChain } from "./chain-execution.ts";
-import { beginForegroundChild, finishForegroundChild, updateForegroundChild } from "./foreground-control.ts";
+import {
+	beginForegroundChild,
+	finishForegroundChild,
+	foregroundSchedulingSettled,
+	retainForegroundSchedulingOwner,
+	settleForegroundSchedulingOwner,
+	updateForegroundChild,
+} from "./foreground-control.ts";
 import { resolveExecutionAgentScope } from "../../agents/agent-scope.ts";
 import { handleManagementAction } from "../../agents/agent-management.ts";
 import { buildDoctorReport } from "../../extension/doctor.ts";
@@ -261,6 +268,15 @@ interface ExecutionContextData {
 
 function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefined): string {
 	return requestedCwd ? path.resolve(runtimeCwd, requestedCwd) : runtimeCwd;
+}
+
+function removeForegroundControlIfIdle(state: SubagentState, runId: string): boolean {
+	const control = state.foregroundControls.get(runId);
+	if (control && (!foregroundSchedulingSettled(control) || (control.activeChildren?.size ?? 0) > 0)) return false;
+	clearPendingForegroundControlNotices(state, runId);
+	state.foregroundControls.delete(runId);
+	if (state.lastForegroundControlId === runId) state.lastForegroundControlId = null;
+	return true;
 }
 
 function getForegroundControl(state: SubagentState, runId: string | undefined) {
@@ -2377,7 +2393,16 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		timeoutMs: data.timeoutMs,
 		deadlineAt: data.deadlineAt,
 		turnBudget: data.turnBudget,
-		onDetachedExit: (index, result) => updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, index, result, events: deps.pi.events }),
+		onDetachedExit: (index, result) => {
+			try {
+				updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, index, result, events: deps.pi.events });
+			} finally {
+				removeForegroundControlIfIdle(deps.state, runId);
+			}
+		},
+		onForegroundChildSettled: () => {
+			removeForegroundControlIfIdle(deps.state, runId);
+		},
 		toolBudget: data.toolBudget,
 		usageBudget: data.usageBudget,
 		configToolBudget: data.configToolBudget,
@@ -2682,6 +2707,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		input.sessionFileForTask(input.tasks[i]!.agent, i, input.modelOverrides[i]);
 	}
 	const completedResults: SingleResult[] = [];
+	if (input.foregroundControl) retainForegroundSchedulingOwner(input.foregroundControl);
 	return mapConcurrent(input.tasks, input.concurrencyLimit, async (task, index) => {
 		const budgetState = usageBudgetState(input.usageBudget, sumResultsCost(completedResults));
 		if (budgetState?.exhausted) {
@@ -2727,6 +2753,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		const structuredRuntime = task.outputSchema
 			? createStructuredOutputRuntime(task.outputSchema, path.join(input.artifactsDir, "structured-output", input.runId))
 			: undefined;
+		let detachedReceipt = false;
 		const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskText, {
 			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 			context: input.contextPolicy.contextForAgent(task.agent),
@@ -2750,7 +2777,17 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			capabilityCeiling: input.capabilityCeiling,
 			controlConfig: input.controlConfig,
 			onControlEvent: input.onControlEvent,
-			onDetachedExit: (result) => updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents }),
+			onDetachedExit: (result) => {
+				try {
+					updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents });
+				} finally {
+					try {
+						if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
+					} finally {
+						removeForegroundControlIfIdle(input.state, input.runId);
+					}
+				}
+			},
 			intercomSessionName: input.childIntercomTarget?.(task.agent, index),
 			orchestratorIntercomTarget: input.orchestratorIntercomTarget,
 			nestedRoute: input.foregroundControl?.nestedRoute,
@@ -2791,12 +2828,24 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 					});
 				}
 				: undefined,
+		}).then((result) => {
+			detachedReceipt = result.detached === true;
+			return result;
 		}).finally(() => {
-			if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
+			// mapConcurrent rejects before siblings settle, so every attached child
+			// attempts idle removal after releasing its own control. Detached receipts
+			// transfer both responsibilities to the authoritative exit callback.
+			if (!detachedReceipt) {
+				if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
+				removeForegroundControlIfIdle(input.state, input.runId);
+			}
 		});
 		completedResults.push(result);
 		return result;
-	}, input.globalSemaphore);
+	}, input.globalSemaphore, () => {
+		if (input.foregroundControl) settleForegroundSchedulingOwner(input.foregroundControl);
+		removeForegroundControlIfIdle(input.state, input.runId);
+	});
 }
 
 async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): Promise<AgentToolResult<Details>> {
@@ -3423,7 +3472,22 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			agentContract: params.agentContract,
 			acceptance: params.acceptance,
 			acceptanceContext: { mode: "single" },
-			onDetachedExit: (result) => updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events }),
+			onDetachedExit: (result) => {
+				try {
+					updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events });
+				} finally {
+					try {
+						if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
+					} finally {
+						try {
+							if (foregroundControl) finishForegroundChild(foregroundControl, 0);
+						} finally {
+							removeForegroundControlIfIdle(deps.state, runId);
+						}
+					}
+				}
+				recordRun(params.agent!, cleanTask, result.exitCode, result.progressSummary?.durationMs ?? 0);
+			},
 			timeoutMs: data.timeoutMs,
 			deadlineAt,
 			turnBudget: data.turnBudget,
@@ -3433,10 +3497,17 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			allowZeroToolBudget: data.allowZeroToolBudget && effectiveToolBudget.toolBudget === data.toolBudget,
 		});
 	} finally {
-		if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
+		// An attached runSync rejection still owns its child and structured runtime.
+		// A successful detached receipt transfers both to onDetachedExit while the
+		// authoritative completion remains live.
+		if (!r?.detached) {
+			if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
+			if (foregroundControl) finishForegroundChild(foregroundControl, 0);
+		}
 	}
-	if (foregroundControl) finishForegroundChild(foregroundControl, 0);
-	recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
+	if (!r.detached) {
+		recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
+	}
 
 	if (r.progress) allProgress.push(r.progress);
 	if (r.artifactPaths) allArtifactPaths.push(r.artifactPaths);
@@ -4244,6 +4315,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				description: foregroundDescription,
 				currentActivityState: undefined,
 				activeChildren: new Map(),
+				// The outer executor owns scheduling until its finally block settles.
+				schedulingOwners: 1,
 				nestedRoute,
 				interrupt: undefined,
 			};
@@ -4341,11 +4414,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return errorResult;
 		} finally {
 			if (foregroundControl) {
-				clearPendingForegroundControlNotices(deps.state, runId);
-				deps.state.foregroundControls.delete(runId);
-				if (deps.state.lastForegroundControlId === runId) {
-					deps.state.lastForegroundControlId = null;
-				}
+				settleForegroundSchedulingOwner(foregroundControl);
+				removeForegroundControlIfIdle(deps.state, runId);
 			}
 		}
 

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -158,29 +158,45 @@ export async function mapConcurrent<T, R>(
 	limit: number,
 	fn: (item: T, i: number) => Promise<R>,
 	globalSemaphore?: Semaphore,
+	/** Invoked after every worker has stopped, including workers outliving an early rejection. */
+	onSchedulingSettled?: () => void,
 ): Promise<R[]> {
 	const safeLimit = Math.max(1, Math.floor(limit) || 1);
 	const results: R[] = new Array(items.length);
 	let next = 0;
+	let liveWorkers = Math.min(safeLimit, items.length);
+	const notifySchedulingSettled = () => {
+		try {
+			onSchedulingSettled?.();
+		} catch {
+			// Scheduling lifecycle cleanup must not replace the worker result.
+		}
+	};
 
 	async function worker(_workerIndex: number): Promise<void> {
-		while (next < items.length) {
-			const i = next++;
-			if (globalSemaphore) {
-				await globalSemaphore.acquire();
-				try {
+		try {
+			while (next < items.length) {
+				const i = next++;
+				if (globalSemaphore) {
+					await globalSemaphore.acquire();
+					try {
+						results[i] = await fn(items[i], i);
+					} finally {
+						globalSemaphore.release();
+					}
+				} else {
 					results[i] = await fn(items[i], i);
-				} finally {
-					globalSemaphore.release();
 				}
-			} else {
-				results[i] = await fn(items[i], i);
 			}
+		} finally {
+			liveWorkers--;
+			if (liveWorkers === 0) notifySchedulingSettled();
 		}
 	}
 
+	if (liveWorkers === 0) notifySchedulingSettled();
 	await Promise.all(
-		Array.from({ length: Math.min(safeLimit, items.length) }, (_, wi) => worker(wi)),
+		Array.from({ length: liveWorkers }, (_, wi) => worker(wi)),
 	);
 	return results;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1370,6 +1370,8 @@ export interface ForegroundRunControl {
 	toolCount?: number;
 	/** Independently tracked children for foreground parallel work and fleet inspection. */
 	activeChildren?: Map<number, ForegroundChildControl>;
+	/** Scheduling owners that may still launch another child. Removal is safe only at zero. */
+	schedulingOwners?: number;
 	nestedRoute?: NestedRouteInfo;
 	nestedChildren?: NestedRunSummary[];
 	interrupt?: () => boolean;

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -304,6 +304,139 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.equal(result.details?.results?.every((entry) => entry.finalOutput === undefined), true);
 	});
 
+	it("keeps a queued top-level parallel child controlled after an early outer rejection", async () => {
+		mockPi.onCall({ matchArgIncludes: "task-a", output: "early child", delay: 100 });
+		mockPi.onCall({ matchArgIncludes: "task-b", output: "middle child", delay: 400 });
+		mockPi.onCall({ matchArgIncludes: "task-c", output: "too late", delay: 10_000 });
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });
+		let rejected = false;
+		const result = await executor.execute(
+			"parallel-rejection-cleanup",
+			{ concurrency: 2, tasks: [{ agent: "a", task: "task-a" }, { agent: "b", task: "task-b" }, { agent: "c", task: "task-c" }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ agent?: string; status?: string }> } }) => {
+				if (!rejected && update.details?.progress?.some((entry) => entry.agent === "a" && entry.status === "completed")) {
+					rejected = true;
+					throw new Error("reject early parallel completion");
+				}
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(rejected, true);
+		assert.equal(result.isError, true);
+		assert.equal(state.foregroundControls.size, 1, "remaining worker still owns queued scheduling");
+		await waitForCallCount(3);
+		const liveControl = [...state.foregroundControls.values()][0];
+		assert.equal(liveControl?.currentAgent, "c", "later queued child must remain discoverable after launch");
+		assert.ok(liveControl?.interrupt, "later queued child must remain interruptible");
+		assert.equal(liveControl.interrupt(), true);
+		for (let attempt = 0; attempt < 100 && state.foregroundControls.size > 0; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(state.foregroundControls.size, 0, "control must disappear after workers and children settle");
+	});
+
+	it("keeps a queued chain-parallel child controlled after an early outer rejection", async () => {
+		mockPi.onCall({ matchArgIncludes: "chain-task-a", output: "early chain child", delay: 100 });
+		mockPi.onCall({ matchArgIncludes: "chain-task-b", output: "middle chain child", delay: 400 });
+		mockPi.onCall({ matchArgIncludes: "chain-task-c", output: "too late", delay: 10_000 });
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });
+		let rejected = false;
+		const result = await executor.execute(
+			"chain-parallel-rejection-cleanup",
+			{ chain: [{ concurrency: 2, parallel: [{ agent: "a", task: "chain-task-a" }, { agent: "b", task: "chain-task-b" }, { agent: "c", task: "chain-task-c" }] }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ agent?: string; status?: string }> } }) => {
+				if (!rejected && update.details?.progress?.some((entry) => entry.agent === "a" && entry.status === "completed")) {
+					rejected = true;
+					throw new Error("reject early chain completion");
+				}
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(rejected, true);
+		assert.equal(result.isError, true);
+		assert.equal(state.foregroundControls.size, 1, "remaining chain worker still owns queued scheduling");
+		await waitForCallCount(3);
+		const liveControl = [...state.foregroundControls.values()][0];
+		assert.equal(liveControl?.currentAgent, "c", "later queued chain child must remain discoverable after launch");
+		assert.ok(liveControl?.interrupt, "later queued chain child must remain interruptible");
+		assert.equal(liveControl.interrupt(), true);
+		for (let attempt = 0; attempt < 100 && state.foregroundControls.size > 0; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(state.foregroundControls.size, 0, "chain control must disappear after workers and children settle");
+	});
+
+	it("cleans a rejected sequential chain child and releases foreground ownership", async () => {
+		mockPi.onCall({ output: "sequential child output" });
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		let rejected = false;
+		let ownedControl: { schedulingOwners?: number; activeChildren?: Map<number, unknown> } | undefined;
+		const result = await executor.execute(
+			"chain-sequential-rejection-cleanup",
+			{ chain: [{ agent: "worker", task: "sequential task" }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ status?: string }> } }) => {
+				if (rejected || !update.details?.progress?.some((entry) => entry.status === "completed")) return;
+				rejected = true;
+				ownedControl = [...state.foregroundControls.values()][0];
+				throw new Error("reject sequential chain completion");
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(rejected, true);
+		assert.equal(result.isError, true);
+		assert.ok(ownedControl);
+		assert.equal(ownedControl.schedulingOwners, 0);
+		assert.equal(ownedControl.activeChildren?.size, 0);
+		assert.equal(state.foregroundControls.size, 0);
+	});
+
+	it("cleans a sequential chain child after an early tool-budget validation return", async () => {
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		const execution = executor.execute(
+			"chain-sequential-budget-cleanup",
+			{ chain: [{ agent: "worker", task: "invalid budget task", toolBudget: { hard: 0 } }] },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		const ownedControl = [...state.foregroundControls.values()][0];
+		assert.ok(ownedControl, "outer scheduling owner should remain visible until execution settles");
+		const result = await execution;
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /toolBudget\.hard must be an integer >= 1/);
+		assert.equal(mockPi.callCount(), 0);
+		assert.equal(ownedControl.schedulingOwners, 0);
+		assert.equal(ownedControl.activeChildren?.size, 0);
+		assert.equal(state.foregroundControls.size, 0);
+	});
+
+	it("cleans an attached single rejection and its temporary structured runtime", async () => {
+		mockPi.onCall({
+			stdoutRaw: [
+				{ type: "tool_execution_start", toolName: "structured_output", args: { value: { ok: true } } },
+				{ type: "tool_result_end", message: { role: "toolResult", toolName: "structured_output", content: [{ type: "text", text: "Structured output captured." }] } },
+				{ type: "tool_execution_end", toolName: "structured_output" },
+			].map((entry) => JSON.stringify(entry)).join("\n") + "\n",
+			structuredOutputCapture: { ok: true },
+		});
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		let structuredDir: string | undefined;
+		const result = await executor.execute(
+			"single-rejection-cleanup",
+			{ agent: "worker", task: "structured task", artifacts: false, outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] } },
+			new AbortController().signal,
+			(update: { details?: { results?: Array<{ structuredOutputPath?: string }>; progress?: Array<{ status?: string }> } }) => {
+				const outputPath = update.details?.results?.[0]?.structuredOutputPath;
+				if (outputPath) structuredDir = path.dirname(outputPath);
+				if (update.details?.progress?.[0]?.status === "completed") throw new Error("reject attached single completion");
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(result.isError, true);
+		assert.equal(state.foregroundControls.size, 0);
+		assert.ok(structuredDir);
+		assert.equal(fs.existsSync(structuredDir), false, "temporary structured runtime must be removed on rejection");
+	});
+
 	it("chain runs emit one grouped event containing all executed children", async () => {
 		mockPi.onCall({ output: "Chain child output" });
 		const { executor, events } = makeExecutor({ agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });

--- a/test/unit/foreground-control.test.ts
+++ b/test/unit/foreground-control.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { AgentProgress, ForegroundRunControl } from "../../src/shared/types.ts";
-import { beginForegroundChild, finishForegroundChild, updateForegroundChild } from "../../src/runs/foreground/foreground-control.ts";
+import {
+	beginForegroundChild,
+	finishForegroundChild,
+	foregroundSchedulingSettled,
+	retainForegroundSchedulingOwner,
+	settleForegroundSchedulingOwner,
+	updateForegroundChild,
+} from "../../src/runs/foreground/foreground-control.ts";
 
 function progress(index: number, agent: string, tokens: number): AgentProgress {
 	return {
@@ -72,5 +79,22 @@ describe("foreground child control", () => {
 		assert.equal(control.inputTokens, undefined);
 		assert.equal(control.outputTokens, undefined);
 		assert.equal(control.interrupt, undefined);
+	});
+
+	it("settles scheduling only after every owner releases", () => {
+		const control: ForegroundRunControl = {
+			runId: "owned-run",
+			mode: "parallel",
+			startedAt: 1,
+			updatedAt: 1,
+			schedulingOwners: 1,
+		};
+
+		retainForegroundSchedulingOwner(control);
+		settleForegroundSchedulingOwner(control);
+		assert.equal(foregroundSchedulingSettled(control), false);
+		settleForegroundSchedulingOwner(control);
+		assert.equal(foregroundSchedulingSettled(control), true);
+		assert.equal(control.schedulingOwners, 0);
 	});
 });

--- a/test/unit/parallel-utils.test.ts
+++ b/test/unit/parallel-utils.test.ts
@@ -153,6 +153,28 @@ describe("mapConcurrent", () => {
 		assert.ok(d2 < 20, `worker 2 should start immediately, got ${d2}ms delay`);
 	});
 
+	it("notifies scheduling settlement only after workers outliving an early rejection stop", async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => { release = resolve; });
+		const started: number[] = [];
+		let schedulingSettled = false;
+		const run = mapConcurrent([0, 1, 2], 2, async (item) => {
+			started.push(item);
+			if (item === 0) throw new Error("early rejection");
+			await gate;
+			return item;
+		}, undefined, () => { schedulingSettled = true; });
+
+		await assert.rejects(run, /early rejection/);
+		assert.equal(schedulingSettled, false);
+		release();
+		for (let attempt = 0; attempt < 20 && !schedulingSettled; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		assert.equal(schedulingSettled, true);
+		assert.deepEqual(started, [0, 1, 2]);
+	});
+
 	it("respects a shared global semaphore across simultaneous calls", async () => {
 		const globalSemaphore = new Semaphore(2);
 		let running = 0;


### PR DESCRIPTION
## Summary

- retain foreground run controls while queued parallel or chain workers may still launch children
- release controls only after every scheduling owner and active child settles
- clean up attached single/sequential failures and validation exits without racing detached terminal ownership

## Problem

Foreground control cleanup was tied too closely to the outer executor promise. `mapConcurrent` can reject as soon as one worker fails while siblings continue or queued tasks are still eligible to start. The outer cleanup could then either remove a control too early or retain it forever, leaving live work invisible/uninterruptible or leaving a stale control behind.

This is also a prerequisite for safely releasing a foreground wait while its child continues.

## Approach

- add explicit scheduling-owner accounting to foreground controls
- let `mapConcurrent` report settlement only after every worker has actually stopped
- require both zero scheduling owners and zero active children before removing a control
- use child-level `finally` cleanup across top-level parallel, chain-parallel, sequential-chain, and attached single failure paths
- preserve detached completion ownership so a receipt does not release the live child early

## Safety

Controls may intentionally outlive the original executor call while surviving workers settle. Scheduling-settlement callback errors are contained and cannot replace worker results.

This PR does not add a user-facing detach command.

## Test plan

- unit coverage for multi-owner settlement and workers outliving early rejection
- integration coverage for queued top-level and chain-parallel children
- sequential rejection and validation-return cleanup
- attached single rejection and temporary structured-output cleanup
- post-rebase focused unit matrix: 368 passed
- E2E on the complete stack: 3 passed
- independent post-rebase review: clean

Broader-suite baseline notes on current `upstream/main`:

- two strict-delegation registration tests intermittently time out before spawning and reproduce on a clean upstream worktree
- the existing watchdog malformed-JSON and short parallel-timeout tests are load-sensitive and also reproduce upstream

Part 1 of the implementation proposed in #708.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a foreground control lifecycle bug where `mapConcurrent` could reject as soon as one worker failed while sibling or queued workers continued, causing the outer cleanup to remove the control too early or leave it stale. The fix adds explicit "scheduling owner" accounting so a control is removed only when both all scheduling owners have released and all active children have settled.

- Adds `retainForegroundSchedulingOwner`/`settleForegroundSchedulingOwner` to gate control removal on a reference count, with the outer executor and each parallel task group each contributing an owner.
- Extends `mapConcurrent` with an `onSchedulingSettled` callback that fires after every worker has stopped (including workers that outlive an early rejection), enabling deferred control teardown without changing the caller-visible rejection semantics.
- Moves `finishForegroundChild` and structured-runtime cleanup into `finally` and `onDetachedExit` blocks for attached-single, sequential-chain, and chain-parallel paths so rejections and early validation returns always release their resources.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; the scheduling-owner accounting is logically correct across all three execution paths and is backed by unit and integration tests that cover the key edge cases.

The scheduling-owner accounting is logically correct across all three execution paths and is backed by unit and integration tests covering the key edge cases. The one gap is in runSinglePath's onDetachedExit, where recordRun is placed after the nested try/finally chain — a throw from updateRememberedForegroundChild silently skips recording the detached run. It is isolated to a low-probability code path but is the only place that records a detached single run.

**Files Needing Attention:** src/runs/foreground/subagent-executor.ts — specifically the onDetachedExit callback in runSinglePath around the recordRun placement.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/runs/shared/parallel-utils.ts | Extends mapConcurrent with an onSchedulingSettled callback that fires after all workers stop, even when mapConcurrent's own Promise rejects early. The liveWorkers counter is correctly initialized once and decremented in each worker's finally block; the empty-array edge case is handled with an early synchronous notification. |
| src/runs/foreground/foreground-control.ts | Adds retainForegroundSchedulingOwner / settleForegroundSchedulingOwner / foregroundSchedulingSettled to track scheduling owners that may still launch children. Implementation is straightforward and saturates at 0 correctly. |
| src/runs/foreground/subagent-executor.ts | Core wiring of scheduling owners into the three execution paths (parallel, chain, single). removeForegroundControlIfIdle guards on both schedulingOwners === 0 and activeChildren.size === 0. The detached-single path places recordRun after the nested try/finally, so a throw from the cleanup chain silently skips run recording. |
| src/runs/foreground/chain-execution.ts | Adds retainForegroundSchedulingOwner before each parallel group in runParallelChainTasks and wires onForegroundChildSettled through to the executor. Wraps runSync calls in try/finally to ensure finishForegroundChild is called on rejection and early validation return. |
| src/shared/types.ts | Adds optional schedulingOwners field to ForegroundRunControl. Minimal, additive change with a clear doc-comment. |
| test/unit/parallel-utils.test.ts | Adds a unit test confirming onSchedulingSettled fires only after all workers stop following an early rejection. Test covers the key timing guarantee of the new callback. |
| test/unit/foreground-control.test.ts | Adds a unit test for the multi-owner retain/settle cycle. Correctly verifies the counter does not reach zero until all owners release. |
| test/integration/intercom-result-delivery.test.ts | Adds five integration tests covering queued top-level and chain-parallel children after early rejection, sequential rejection cleanup, tool-budget validation return, and attached-single rejection with structured-output teardown. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Executor as Outer Executor
    participant FC as ForegroundControl
    participant MC as mapConcurrent
    participant WA as Worker A (fails early)
    participant WB as Worker B (continues)

    Executor->>FC: "schedulingOwners = 1"
    Executor->>FC: "retainForegroundSchedulingOwner (owners = 2)"
    Executor->>MC: mapConcurrent(tasks, onSchedulingSettled)

    MC->>WA: start worker A
    MC->>WB: start worker B (queued worker C waits)

    WA-->>MC: throw (early rejection)
    WA->>FC: finishForegroundChild(A)
    WA->>FC: "removeForegroundControlIfIdle - owners=2, skip"

    MC-->>Executor: Promise.all rejects
    Executor->>FC: "settleForegroundSchedulingOwner (owners = 1)"
    Executor->>FC: "removeForegroundControlIfIdle - owners=1, CONTROL RETAINED"
    Executor-->>Executor: returns error result

    Note over WB: Worker B still alive, picks up Worker C
    WB->>FC: finishForegroundChild(C)
    WB-->>MC: "done (liveWorkers = 0)"

    MC->>FC: "onSchedulingSettled - settleForegroundSchedulingOwner (owners = 0)"
    MC->>FC: "removeForegroundControlIfIdle - owners=0, children=0, REMOVED"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/runs/foreground/subagent-executor.ts:3475-3490
`recordRun` is placed after the nested try/finally block, so if `updateRememberedForegroundChild` throws an exception (the exception escapes the outer `try`, the `finally` chain still runs cleanup, then propagates), `recordRun` is silently skipped and the detached run is never recorded in telemetry. This is the only call site responsible for recording detached single runs. Wrapping the cleanup chain in an outer try/finally ensures `recordRun` fires regardless.

```suggestion
			onDetachedExit: (result) => {
				try {
					try {
						updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events });
					} finally {
						try {
							if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
						} finally {
							try {
								if (foregroundControl) finishForegroundChild(foregroundControl, 0);
							} finally {
								removeForegroundControlIfIdle(deps.state, runId);
							}
						}
					}
				} finally {
					recordRun(params.agent!, cleanTask, result.exitCode, result.progressSummary?.durationMs ?? 0);
				}
			},
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: retain foreground controls through ..."](https://github.com/nicobailon/pi-subagents/commit/e682127bf88dca786aad1737538156a6cdd2965f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49234075)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->