### PR TITLE
fix: finalize detached foreground runs through the full completion pipeline

### DIFF
--- a/src/intercom/result-intercom.ts
+++ b/src/intercom/result-intercom.ts
@@ -30,8 +30,9 @@ export function resolveSubagentResultStatus(input: {
 	if (input.detached) return "detached";
 	if (input.stopped || input.state === "stopped") return "stopped";
 	if (input.interrupted || input.state === "paused") return "paused";
+	if (input.timedOut || input.turnBudgetExceeded) return "failed";
 	if (input.success === true) return "completed";
-	if (isUnexplainedProcessSignal(input) && input.exitCode !== 0) return "stopped";
+	if (isUnexplainedProcessSignal(input)) return "stopped";
 	if (input.success === false) return "failed";
 	if (input.state === "complete") return "completed";
 	if (input.state === "failed") return "failed";

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -197,12 +197,13 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 	const summary = typeof result.summary === "string" ? result.summary : "";
 	const stopped = result.stopped === true
 		|| result.state === "stopped"
-		|| (result.success !== true && result.exitCode !== 0 && isUnexplainedProcessSignal(result))
+		|| (result.success !== true && isUnexplainedProcessSignal(result))
 		|| result.results?.some((child) => child.stopped === true
 			|| child.status === "stopped"
-			|| (child.success !== true && child.exitCode !== 0 && isUnexplainedProcessSignal(child))) === true;
-	const paused = !stopped && !result.success && (
-		result.exitCode === 0
+			|| (child.success !== true && isUnexplainedProcessSignal(child))) === true;
+	const paused = !stopped && !result.success && !result.timedOut && !result.turnBudgetExceeded && (
+		result.interrupted === true
+		|| result.exitCode === 0
 		|| result.state === "paused"
 		|| summary.startsWith("Paused after interrupt.")
 	);

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -34,7 +34,13 @@ import {
 import { discoverAvailableSkills, normalizeSkillInput } from "../../agents/skills.ts";
 import { INTERCOM_BRIDGE_MARKER } from "../../intercom/intercom-bridge.ts";
 import { runSync } from "./execution.ts";
-import { beginForegroundChild, finishForegroundChild, updateForegroundChild } from "./foreground-control.ts";
+import {
+	beginForegroundChild,
+	finishForegroundChild,
+	retainForegroundSchedulingOwner,
+	settleForegroundSchedulingOwner,
+	updateForegroundChild,
+} from "./foreground-control.ts";
 import { buildChainSummary } from "../../shared/formatters.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
@@ -153,6 +159,8 @@ interface ParallelChainRunInput {
 	turnBudget?: ResolvedTurnBudget;
 	usageBudget?: UsageBudgetConfig;
 	onDetachedExit?: (index: number, result: SingleResult) => void;
+	/** Called after an attached child releases its foreground ownership. */
+	onForegroundChildSettled?: () => void;
 	toolBudget?: ResolvedToolBudget;
 	configToolBudget?: ToolBudgetConfig;
 	globalSemaphore?: Semaphore;
@@ -287,6 +295,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 	}
 
 	const completedResults: SingleResult[] = [];
+	if (input.foregroundControl) retainForegroundSchedulingOwner(input.foregroundControl);
 	const parallelResults = await mapConcurrent(
 		input.step.parallel,
 		concurrency,
@@ -364,7 +373,9 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				? createStructuredOutputRuntime(task.outputSchema, path.join(input.chainDir, "structured-output"))
 				: undefined;
 			const agentContract = task.agentContract ?? input.step.agentContract ?? input.agentContract;
-			const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
+			let result!: SingleResult;
+			try {
+				result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
 				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 				capabilityCeiling: input.capabilityCeiling,
 				context: input.contextForAgent?.(task.agent),
@@ -402,9 +413,13 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				timeoutMs: input.timeoutMs,
 				deadlineAt: input.deadlineAt,
 				turnBudget: input.turnBudget,
-				onDetachedExit: input.onDetachedExit
-					? (result) => input.onDetachedExit?.(childIndex, result)
-					: undefined,
+				onDetachedExit: (result) => {
+					try {
+						if (input.foregroundControl) finishForegroundChild(input.foregroundControl, childIndex);
+					} finally {
+						input.onDetachedExit?.(childIndex, result);
+					}
+				},
 				toolBudget: toolBudget.toolBudget,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
@@ -438,8 +453,15 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 						});
 					}
 					: undefined,
-			});
-			if (input.foregroundControl) finishForegroundChild(input.foregroundControl, childIndex);
+				});
+			} finally {
+				// Rejected attached attempts still release their parallel child control;
+				// detached receipts transfer ownership to onDetachedExit.
+				if (!result?.detached) {
+					if (input.foregroundControl) finishForegroundChild(input.foregroundControl, childIndex);
+					input.onForegroundChildSettled?.();
+				}
+			}
 
 			if (result.exitCode !== 0 && failFast) {
 				aborted = true;
@@ -449,6 +471,10 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 			return result;
 		},
 		input.globalSemaphore,
+		() => {
+			if (input.foregroundControl) settleForegroundSchedulingOwner(input.foregroundControl);
+			input.onForegroundChildSettled?.();
+		},
 	);
 
 	return parallelResults;
@@ -493,6 +519,8 @@ interface ChainExecutionParams {
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
 	onDetachedExit?: (index: number, result: SingleResult) => void;
+	/** Ownership callback used when parallel siblings outlive executeChain rejection. */
+	onForegroundChildSettled?: () => void;
 	toolBudget?: ResolvedToolBudget;
 	usageBudget?: UsageBudgetConfig;
 	configToolBudget?: ToolBudgetConfig;
@@ -817,6 +845,7 @@ ${step.message}` : ""}` }],
 					turnBudget: params.turnBudget,
 					usageBudget: params.usageBudget,
 					onDetachedExit,
+					onForegroundChildSettled: params.onForegroundChildSettled,
 					toolBudget: params.toolBudget,
 					configToolBudget: params.configToolBudget,
 					globalSemaphore,
@@ -1074,6 +1103,7 @@ ${step.message}` : ""}` }],
 				turnBudget: params.turnBudget,
 				usageBudget: params.usageBudget,
 				onDetachedExit,
+				onForegroundChildSettled: params.onForegroundChildSettled,
 				toolBudget: params.toolBudget,
 				configToolBudget: params.configToolBudget,
 				globalSemaphore,
@@ -1278,28 +1308,30 @@ ${step.message}` : ""}` }],
 				});
 			}
 
-			const structuredRuntime = seqStep.outputSchema
-				? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
-				: undefined;
 			const agentContract = seqStep.agentContract ?? params.agentContract;
-			const toolBudget = resolveChainToolBudget({ stepBudget: seqStep.toolBudget, runBudget: params.toolBudget, agentBudget: agentConfig?.toolBudget, configBudget: params.configToolBudget });
-			if (toolBudget.error) return buildChainExecutionErrorResult(toolBudget.error, {
-				results,
-				includeProgress,
-				allProgress,
-				allArtifactPaths,
-				artifactsDir: params.artifactsDir,
-				chainAgents,
-				chainSteps,
-				totalSteps,
-				currentStepIndex: stepIndex,
-				runId: params.runId,
-				outputs,
-				currentFlatIndex: globalTaskIndex,
-				dynamicChildren,
-				dynamicGroupStatuses,
-			});
-			const r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
+			let r!: SingleResult;
+			try {
+				const structuredRuntime = seqStep.outputSchema
+					? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
+					: undefined;
+				const toolBudget = resolveChainToolBudget({ stepBudget: seqStep.toolBudget, runBudget: params.toolBudget, agentBudget: agentConfig?.toolBudget, configBudget: params.configToolBudget });
+				if (toolBudget.error) return buildChainExecutionErrorResult(toolBudget.error, {
+					results,
+					includeProgress,
+					allProgress,
+					allArtifactPaths,
+					artifactsDir: params.artifactsDir,
+					chainAgents,
+					chainSteps,
+					totalSteps,
+					currentStepIndex: stepIndex,
+					runId: params.runId,
+					outputs,
+					currentFlatIndex: globalTaskIndex,
+					dynamicChildren,
+					dynamicGroupStatuses,
+				});
+				r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
 				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				capabilityCeiling: params.capabilityCeiling,
 				context: params.contextForAgent?.(seqStep.agent),
@@ -1337,9 +1369,13 @@ ${step.message}` : ""}` }],
 				timeoutMs: params.timeoutMs,
 				deadlineAt,
 				turnBudget: params.turnBudget,
-				onDetachedExit: onDetachedExit
-					? (result) => onDetachedExit(childIndex, result)
-					: undefined,
+				onDetachedExit: (result) => {
+					try {
+						if (foregroundControl) finishForegroundChild(foregroundControl, childIndex);
+					} finally {
+						onDetachedExit?.(childIndex, result);
+					}
+				},
 				toolBudget: toolBudget.toolBudget,
 				onUpdate: onUpdate
 					? (p) => {
@@ -1373,8 +1409,15 @@ ${step.message}` : ""}` }],
 						});
 					}
 					: undefined,
-			});
-			if (foregroundControl) finishForegroundChild(foregroundControl, childIndex);
+				});
+			} finally {
+				// Rejected attempts and early validation returns release the child here.
+				// A detached receipt transfers cleanup ownership to onDetachedExit.
+				if (!r?.detached) {
+					if (foregroundControl) finishForegroundChild(foregroundControl, childIndex);
+					params.onForegroundChildSettled?.();
+				}
+			}
 			recordRun(seqStep.agent, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
 
 			globalTaskIndex++;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -122,6 +122,46 @@ function sumUsage(target: Usage, source: Usage): void {
 	target.turns += source.turns;
 }
 
+function persistSingleResultMetadata(input: {
+	metadataPath?: string;
+	enabled: boolean;
+	runId?: string;
+	agent: string;
+	task: string;
+	result: SingleResult;
+}): void {
+	if (!input.enabled || !input.metadataPath) return;
+	const target = input.result;
+	writeMetadata(input.metadataPath, {
+		runId: input.runId,
+		agent: input.agent,
+		task: input.task,
+		exitCode: target.exitCode,
+		processSignal: target.processSignal,
+		usage: target.usage,
+		model: target.model,
+		attemptedModels: target.attemptedModels,
+		modelAttempts: target.modelAttempts,
+		durationMs: target.progressSummary?.durationMs,
+		toolCount: target.progressSummary?.toolCount,
+		error: target.error,
+		agentContract: target.agentContract,
+		launchContractDigest: target.launchContractDigest,
+		launchResolvedExtensions: target.launchResolvedExtensions,
+		execution: target.execution,
+		acceptance: target.acceptance,
+		capabilityCeiling: target.capabilityCeiling,
+		capabilityAudit: target.capabilityAudit,
+		review: target.review,
+		effects: target.effects,
+		transcriptPath: target.transcriptPath,
+		transcriptError: target.transcriptError,
+		skills: target.skills,
+		skillsWarning: target.skillsWarning,
+		timestamp: Date.now(),
+	});
+}
+
 function formatTimeoutMessage(timeoutMs: number): string {
 	return `Subagent timed out after ${timeoutMs}ms.`;
 }
@@ -147,6 +187,21 @@ function buildPendingAcceptanceLedger(acceptance: ResolvedAcceptanceConfig): Acc
 		runtimeChecks: [],
 		verifyRuns: [],
 	};
+}
+
+function buildInterruptedAcceptanceLedger(acceptance: ResolvedAcceptanceConfig): AcceptanceLedger {
+	const pending = buildPendingAcceptanceLedger(acceptance);
+	if (acceptance.level === "none") {
+		pending.status = "not-required";
+		pending.evidenceStatus = "not-required";
+	} else {
+		pending.runtimeChecks = [{
+			id: "interrupted",
+			status: "not-applicable",
+			message: "Acceptance was not evaluated because the subagent was interrupted.",
+		}];
+	}
+	return pending;
 }
 
 function appendRecentOutput(progress: AgentProgress, lines: string[]): void {
@@ -204,7 +259,7 @@ function snapshotResult(result: SingleResult, progress: AgentProgress): SingleRe
  * unbounded `messages` transcript in favour of compact tool-call summaries so a
  * single `tool_execution_update` line stays well under the child-stdout protocol
  * cap (`MAX_CHILD_PENDING_LINE_BYTES`). Non-streaming consumers such as
- * detached-exit recovery call snapshotResult directly and keep the full transcript.
+ * foreground detach receipts and terminal consumers use snapshotResult directly.
  */
 function snapshotStreamResult(result: SingleResult, progress: AgentProgress): SingleResult {
 	const snapshot = snapshotResult(result, progress);
@@ -402,7 +457,7 @@ async function runSingleAttempt(
 		});
 		const jsonlWriter = createJsonlWriter(shared.jsonlPath, proc.stdout);
 		let processClosed = false;
-		let settled = false;
+		let lifecycleFinished = false;
 		let detached = false;
 		let intercomStarted = false;
 		let assistantError: string | undefined;
@@ -441,19 +496,43 @@ async function runSingleAttempt(
 			}
 		};
 
-		const detachForIntercom = () => {
-			detached = true;
-			processClosed = true;
-			result.detached = true;
-			result.detachedReason = "intercom coordination";
-			progress.status = "detached";
-			progress.durationMs = Date.now() - startTime;
-			result.progressSummary = {
-				toolCount: progress.toolCount,
-				tokens: progress.tokens,
-				durationMs: progress.durationMs,
+		const detachForeground = (reason: string): boolean => {
+			if (detached || processClosed || lifecycleFinished || options.signal?.aborted) return false;
+			const receiptProgress = snapshotProgress(progress);
+			receiptProgress.status = "detached";
+			receiptProgress.durationMs = Date.now() - startTime;
+			const receipt = snapshotResult(result, receiptProgress);
+			receipt.exitCode = -2;
+			receipt.detached = true;
+			receipt.detachedReason = reason;
+			receipt.finalOutput = reason === "intercom coordination"
+				? "Detached for intercom coordination before task completion."
+				: reason === "user request"
+					? "Detached at user request before task completion."
+					: `Detached for ${reason} before task completion.`;
+			receipt.outputMode = options.outputMode ?? "inline";
+			if (options.outputPath) {
+				receipt.outputSaveError = reason === "user request"
+					? "Output file was not finalized because the subagent detached at user request."
+					: `Output file was not finalized because the subagent detached for ${reason}.`;
+			}
+			receipt.progressSummary = {
+				toolCount: receiptProgress.toolCount,
+				tokens: receiptProgress.tokens,
+				durationMs: receiptProgress.durationMs,
 			};
-			finish(-2);
+			// The attempt is not detached until the outer coordinator has accepted and
+			// synchronously published the receipt. A persistence/callback failure must
+			// leave this attempt attached and abortable rather than orphaning it.
+			let accepted = false;
+			try {
+				accepted = options.onDetachReceipt?.(receipt) === true;
+			} catch {
+				return false;
+			}
+			if (!accepted) return false;
+			detached = true;
+			return true;
 		};
 
 		// If the child emits a terminal assistant stop but never exits,
@@ -494,9 +573,9 @@ async function runSingleAttempt(
 				armWatchdogTail();
 				return;
 			}
-			if (childExited || finalDrainTimer || settled || processClosed || detached) return;
+			if (childExited || finalDrainTimer || lifecycleFinished || processClosed) return;
 			finalDrainTimer = setTimeout(() => {
-				if (settled || processClosed || detached) return;
+				if (lifecycleFinished || processClosed) return;
 				const termSent = trySignalChild(proc, "SIGTERM");
 				if (!termSent) return;
 				forcedTerminationSignal = true;
@@ -504,7 +583,7 @@ async function runSingleAttempt(
 					result.error = result.error ?? `Subagent process did not exit within ${FINAL_STOP_GRACE_MS}ms after its terminal event. Forcing termination.`;
 				}
 				finalHardKillTimer = setTimeout(() => {
-					if (settled || processClosed || detached) return;
+					if (lifecycleFinished || processClosed) return;
 					forcedTerminationSignal = trySignalChild(proc, "SIGKILL") || forcedTerminationSignal;
 				}, HARD_KILL_MS);
 				finalHardKillTimer.unref?.();
@@ -512,7 +591,7 @@ async function runSingleAttempt(
 			finalDrainTimer.unref?.();
 		};
 		function armWatchdogTail(): void {
-			if ((!cleanTerminalAssistantStopReceived && !agentSettledReceived) || watchdogTailTimer || settled || processClosed || detached) return;
+			if ((!cleanTerminalAssistantStopReceived && !agentSettledReceived) || watchdogTailTimer || lifecycleFinished || processClosed) return;
 			watchdogTailTimer = setTimeout(() => {
 				watchdogTailTimer = undefined;
 				updateChildWatchdogState({
@@ -538,7 +617,7 @@ async function runSingleAttempt(
 		};
 
 		const unsubscribeIntercomDetach = options.intercomEvents?.on?.(INTERCOM_DETACH_REQUEST_EVENT, (payload) => {
-			if (!options.allowIntercomDetach || detached || processClosed) return;
+			if (!options.allowIntercomDetach || processClosed) return;
 			if (!payload || typeof payload !== "object") return;
 			const event = payload as { requestId?: unknown; runId?: unknown; agent?: unknown; childIndex?: unknown };
 			const requestId = event.requestId;
@@ -549,13 +628,13 @@ async function runSingleAttempt(
 				if (typeof event.agent === "string" && event.agent !== agent.name) return;
 				if (typeof event.childIndex === "number" && event.childIndex !== (options.index ?? 0)) return;
 			} else if (!intercomStarted) return;
-			options.intercomEvents?.emit(INTERCOM_DETACH_RESPONSE_EVENT, { requestId, accepted: true, runId: options.runId, agent: agent.name, childIndex: options.index ?? 0 });
-			detachForIntercom();
+			const accepted = detachForeground("intercom coordination");
+			options.intercomEvents?.emit(INTERCOM_DETACH_RESPONSE_EVENT, { requestId, accepted, runId: options.runId, agent: agent.name, childIndex: options.index ?? 0 });
 		});
 
 		const finish = (code: number) => {
-			if (settled) return;
-			settled = true;
+			if (lifecycleFinished) return;
+			lifecycleFinished = true;
 			clearFinalDrainTimers();
 			clearWatchdogTailTimer();
 			clearStdioGuard();
@@ -640,7 +719,7 @@ async function runSingleAttempt(
 		};
 		const requestTurnBudgetAbort = (turnCount: number) => {
 			const budget = options.turnBudget;
-			if (!budget || result.timedOut || result.turnBudgetExceeded || interruptedByControl || processClosed || settled || detached) return;
+			if (!budget || result.timedOut || result.turnBudgetExceeded || interruptedByControl || processClosed || lifecycleFinished) return;
 			const message = turnBudgetExceededMessage(budget, turnCount);
 			result.turnBudgetExceeded = true;
 			result.wrapUpRequested = true;
@@ -653,12 +732,12 @@ async function runSingleAttempt(
 			fireUpdate();
 			trySignalChild(proc, "SIGINT");
 			turnBudgetTerminationTimer = setTimeout(() => {
-				if (processClosed || settled || detached || result.timedOut) return;
+				if (processClosed || lifecycleFinished || result.timedOut) return;
 				trySignalChild(proc, "SIGTERM");
 			}, 1000);
 			turnBudgetTerminationTimer.unref?.();
 			turnBudgetHardKillTimer = setTimeout(() => {
-				if (processClosed || settled || detached || result.timedOut) return;
+				if (processClosed || lifecycleFinished || result.timedOut) return;
 				trySignalChild(proc, "SIGKILL");
 			}, 4000);
 			turnBudgetHardKillTimer.unref?.();
@@ -895,7 +974,7 @@ async function runSingleAttempt(
 
 		if (controlConfig.enabled) {
 			activityTimer = setInterval(() => {
-				if (processClosed || settled || detached) return;
+				if (processClosed || lifecycleFinished) return;
 				const now = Date.now();
 				if (updateActivityState(now)) {
 					progress.durationMs = now - startTime;
@@ -907,7 +986,7 @@ async function runSingleAttempt(
 
 		if (attemptTimeout) {
 			timeoutTimer = setTimeout(() => {
-				if (processClosed || settled || detached || interruptedByControl) return;
+				if (processClosed || lifecycleFinished || interruptedByControl) return;
 				result.timedOut = true;
 				result.error = attemptTimeout.message;
 				result.finalOutput = attemptTimeout.message;
@@ -917,12 +996,12 @@ async function runSingleAttempt(
 				fireUpdate();
 				trySignalChild(proc, "SIGINT");
 				timeoutTerminationTimer = setTimeout(() => {
-					if (processClosed || settled || detached) return;
+					if (processClosed || lifecycleFinished) return;
 					trySignalChild(proc, "SIGTERM");
 				}, 1000);
 				timeoutTerminationTimer.unref?.();
 				timeoutHardKillTimer = setTimeout(() => {
-					if (processClosed || settled || detached) return;
+					if (processClosed || lifecycleFinished) return;
 					trySignalChild(proc, "SIGKILL");
 				}, 4000);
 				timeoutHardKillTimer.unref?.();
@@ -966,6 +1045,8 @@ async function runSingleAttempt(
 			clearFinalDrainTimers();
 		});
 		proc.on("close", (code, signal) => {
+			if (lifecycleFinished) return;
+			processClosed = true;
 			clearFinalDrainTimers();
 			clearStdioGuard();
 			void jsonlWriter.close().catch(() => {
@@ -997,60 +1078,12 @@ async function runSingleAttempt(
 				closeError = stderr.trim();
 			}
 			const finalCode = forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
-			if (detached) {
-				const recoveredProgress = snapshotProgress(progress);
-				const recoveredResult = snapshotResult(result, recoveredProgress);
-				if (!recoveredResult.error && closeError) recoveredResult.error = closeError;
-				recoveredResult.exitCode = recoveredResult.error && finalCode === 0 ? 1 : finalCode;
-				recoveredProgress.status = recoveredResult.exitCode === 0 ? "completed" : "failed";
-				recoveredProgress.durationMs = Date.now() - startTime;
-				if (recoveredResult.error) recoveredProgress.error = recoveredResult.error;
-				recoveredResult.progressSummary = {
-					toolCount: recoveredProgress.toolCount,
-					tokens: recoveredProgress.tokens,
-					durationMs: recoveredProgress.durationMs,
-				};
-				const acceptanceOutput = getFinalOutput(recoveredResult.messages ?? []).trim()
-					|| recoveredResult.error
-					|| recoveredResult.finalOutput
-					|| "Detached child exited without final output.";
-				acceptanceOutputByResult.set(recoveredResult, acceptanceOutput);
-				let fullOutput = stripAcceptanceReport(acceptanceOutput);
-				fullOutput = fullOutput.trim() || recoveredResult.error || recoveredResult.finalOutput || "Detached child exited without final output.";
-				recoveredResult.outputMode = options.outputMode ?? "inline";
-				if (options.outputPath && recoveredResult.exitCode === 0) {
-					const resolvedOutput = resolveSingleOutput(options.outputPath, fullOutput, shared.outputSnapshot);
-					fullOutput = stripAcceptanceReport(resolvedOutput.fullOutput);
-					recoveredResult.savedOutputPath = resolvedOutput.savedPath;
-					recoveredResult.outputSaveError = resolvedOutput.saveError;
-					if (resolvedOutput.savedPath) {
-						recoveredResult.outputReference = formatSavedOutputReference(resolvedOutput.savedPath, fullOutput);
-					} else {
-						recoveredResult.exitCode = 1;
-						recoveredResult.error = `Output file was not finalized after detached child exit: ${resolvedOutput.saveError ?? options.outputPath}`;
-						recoveredProgress.status = "failed";
-						recoveredProgress.error = recoveredResult.error;
-					}
-				}
-				recoveredResult.finalOutput = options.outputMode === "file-only" && recoveredResult.savedOutputPath && recoveredResult.outputReference
-					? recoveredResult.outputReference.message
-					: fullOutput;
-				if (recoveredResult.artifactPaths && options.artifactConfig?.enabled !== false && options.artifactConfig?.includeOutput !== false) {
-					try {
-						writeArtifact(recoveredResult.artifactPaths.outputPath, fullOutput);
-					} catch {
-						// Detached children may outlive test/temp cleanup; recovered status is best-effort.
-					}
-				}
-				options.onDetachedExit?.(recoveredResult);
-				finish(-2);
-				return;
-			}
 			if (!result.error && closeError) result.error = closeError;
-			processClosed = true;
 			finish(finalCode);
 		});
 		proc.on("error", (error) => {
+			if (lifecycleFinished) return;
+			processClosed = true;
 			clearFinalDrainTimers();
 			clearStdioGuard();
 			void jsonlWriter.close().catch(() => {
@@ -1067,7 +1100,7 @@ async function runSingleAttempt(
 
 		if (options.signal) {
 			const kill = () => {
-				if (processClosed || detached) return;
+				if (processClosed || lifecycleFinished) return;
 				proc.kill("SIGTERM");
 				setTimeout(() => !proc.killed && proc.kill("SIGKILL"), 3000);
 			};
@@ -1080,7 +1113,7 @@ async function runSingleAttempt(
 
 		if (options.interruptSignal) {
 			const interrupt = () => {
-				if (processClosed || detached || settled) return;
+				if (processClosed || lifecycleFinished) return;
 				if (result.timedOut) return;
 				interruptedByControl = true;
 				clearTimeoutTimers();
@@ -1092,7 +1125,7 @@ async function runSingleAttempt(
 				fireUpdate();
 				trySignalChild(proc, "SIGINT");
 				setTimeout(() => {
-					if (settled || processClosed || detached) return;
+					if (lifecycleFinished || processClosed) return;
 					trySignalChild(proc, "SIGTERM");
 				}, 1000).unref?.();
 			};
@@ -1101,6 +1134,16 @@ async function runSingleAttempt(
 				options.interruptSignal.addEventListener("abort", interrupt, { once: true });
 				removeInterruptListener = () => options.interruptSignal?.removeEventListener("abort", interrupt);
 			}
+		}
+
+		// Publish only after every callback and cleanup guard captured by detach or
+		// later lifecycle events has initialized. Consumers may invoke synchronously.
+		try {
+			options.onDetachReady?.((reason = "user request") => detachForeground(reason));
+		} catch (error) {
+			// A consumer callback is advisory. Keep the child attached and observable
+			// rather than rejecting this attempt and orphaning its live process.
+			appendRecentOutput(progress, [`Foreground detach callback failed: ${error instanceof Error ? error.message : String(error)}`]);
 		}
 	});
 	result.exitCode = exitCode;
@@ -1119,16 +1162,6 @@ async function runSingleAttempt(
 		};
 		return result;
 	}
-	if (result.detached) {
-		result.exitCode = -2;
-		result.finalOutput = "Detached for intercom coordination before task completion.";
-		result.outputMode = options.outputMode ?? "inline";
-		if (options.outputPath) {
-			result.outputSaveError = "Output file was not finalized because the subagent detached for intercom coordination.";
-		}
-		return result;
-	}
-
 	if (result.error && result.exitCode === 0) {
 		result.exitCode = 1;
 	}
@@ -1278,7 +1311,7 @@ async function runSingleAttempt(
 /**
  * Run a subagent synchronously (blocking until complete)
  */
-export async function runSync(
+async function runSyncCompletion(
 	runtimeCwd: string,
 	agents: AgentConfig[],
 	agentName: string,
@@ -1398,84 +1431,42 @@ export async function runSync(
 	}
 
 	const persistResultMetadata = (target: SingleResult): void => {
-		if (!artifactPathsResult || options.artifactConfig?.enabled === false || options.artifactConfig?.includeMetadata === false) return;
-		writeMetadata(artifactPathsResult.metadataPath, {
+		persistSingleResultMetadata({
+			metadataPath: artifactPathsResult?.metadataPath,
+			enabled: options.artifactConfig?.enabled !== false && options.artifactConfig?.includeMetadata !== false,
 			runId: options.runId,
 			agent: agentName,
 			task,
-			exitCode: target.exitCode,
-			processSignal: target.processSignal,
-			usage: target.usage,
-			model: target.model,
-			attemptedModels: target.attemptedModels,
-			modelAttempts: target.modelAttempts,
-			durationMs: target.progressSummary?.durationMs,
-			toolCount: target.progressSummary?.toolCount,
-			error: target.error,
-			agentContract: target.agentContract,
-			launchContractDigest: target.launchContractDigest,
-			launchResolvedExtensions: target.launchResolvedExtensions,
-			execution: target.execution,
-			acceptance: target.acceptance,
-			capabilityCeiling: target.capabilityCeiling,
-			capabilityAudit: target.capabilityAudit,
-			review: target.review,
-			effects: target.effects,
-			...(transcriptWriter ? { transcriptPath: artifactPathsResult.transcriptPath } : {}),
-			transcriptError: target.transcriptError,
-			skills: target.skills,
-			skillsWarning: target.skillsWarning,
-			timestamp: Date.now(),
+			result: target,
 		});
 	};
 
-	const detachedAwareOptions: RunSyncOptions = options.onDetachedExit
-		? {
-			...options,
-			onDetachedExit: (recoveredResult) => {
-				void (async () => {
-					const childWrittenOutput = options.outputPath
-						? extractChildWrittenOutput(recoveredResult.messages, options.outputPath, options.cwd ?? runtimeCwd)
-						: undefined;
-					recoveredResult.acceptance = await evaluateAcceptance({
-						acceptance: effectiveAcceptance,
-						output: acceptanceOutputByResult.get(recoveredResult) ?? recoveredResult.finalOutput ?? "",
-						fileOutput: childWrittenOutput !== undefined && options.outputPath
-							? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
-							: undefined,
-						cwd: options.cwd ?? runtimeCwd,
-						reportOptional: isAgentContractV1(options.agentContract),
-					});
-					const acceptanceFailure = acceptanceFailureMessage(recoveredResult.acceptance);
-					stripAcceptanceReportsFromMessages(recoveredResult.messages);
-					if (acceptanceFailure && recoveredResult.acceptance.explicit && recoveredResult.exitCode === 0 && !isAgentContractV1(options.agentContract)) {
-						recoveredResult.exitCode = 1;
-						recoveredResult.error = recoveredResult.error ? `${recoveredResult.error}\n${acceptanceFailure}` : acceptanceFailure;
-						if (recoveredResult.progress) {
-							recoveredResult.progress.status = "failed";
-							recoveredResult.progress.error = recoveredResult.error;
-						}
-					}
-					if (isAgentContractV1(options.agentContract)) attachContractProjections(recoveredResult);
-					persistResultMetadata(recoveredResult);
-					options.onDetachedExit?.(recoveredResult);
-				})().catch((error) => {
-					const message = error instanceof Error ? error.message : String(error);
-					recoveredResult.exitCode = 1;
-					recoveredResult.error = recoveredResult.error ? `${recoveredResult.error}\nAcceptance evaluation failed: ${message}` : `Acceptance evaluation failed: ${message}`;
-					options.onDetachedExit?.(recoveredResult);
-				});
-			},
-		}
-		: options;
-
+	let intercomDetached = false;
+	let detachedReason: string | undefined;
+	const attemptOptions: RunSyncOptions = {
+		...options,
+		onDetachReceipt: (receipt) => {
+			receipt.acceptance = buildPendingAcceptanceLedger(effectiveAcceptance);
+			try {
+				persistResultMetadata(receipt);
+			} catch (error) {
+				receipt.metadataSaveError = error instanceof Error ? error.message : String(error);
+			}
+			const accepted = options.onDetachReceipt?.(receipt) === true;
+			if (accepted) {
+				detachedReason = receipt.detachedReason;
+				if (receipt.detachedReason === "intercom coordination") intercomDetached = true;
+			}
+			return accepted;
+		},
+	};
 	let lastResult: SingleResult | undefined;
 	const modelsToTry = candidates.length > 0 ? candidates : [undefined];
 	modelAttemptsLoop: for (let modelIndex = 0; modelIndex < modelsToTry.length; modelIndex++) {
 		const candidate = modelsToTry[modelIndex];
 		for (let startupAttemptIndex = 0; ; startupAttemptIndex++) {
 			const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
-			const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, detachedAwareOptions, {
+			const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, attemptOptions, {
 				sessionEnabled,
 				systemPrompt,
 				resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
@@ -1507,7 +1498,10 @@ export async function runSync(
 				usage: { ...result.usage },
 			};
 			modelAttempts.push(attempt);
-			if (result.detached || result.timedOut || result.turnBudgetExceeded) break modelAttemptsLoop;
+			// Preserve the legacy intercom handoff contract: once this logical run has
+			// been handed to a supervisor, terminating that attempt must not launch a
+			// startup retry or model fallback. Explicit user detach retains fallback.
+			if (intercomDetached || result.timedOut || result.turnBudgetExceeded) break modelAttemptsLoop;
 			if (attemptSucceeded) break modelAttemptsLoop;
 
 			const startupFailure = isRetryableSubagentStartupFailure({
@@ -1598,25 +1592,30 @@ export async function runSync(
 	if (transcriptWriter) result.transcriptPath = artifactPathsResult?.transcriptPath;
 	if (transcriptWriter?.getError()) result.transcriptError = transcriptWriter.getError();
 
-	if (artifactPathsResult && options.artifactConfig?.enabled !== false) {
-		result.artifactPaths = artifactPathsResult;
-		if (options.artifactConfig?.includeOutput !== false) {
-			writeArtifact(artifactPathsResult.outputPath, formatOutputArtifactContent({
-				output: artifactOutputByResult.get(result) ?? result.finalOutput ?? "",
-				error: result.error,
-				transcriptPath: result.transcriptPath,
-				metadataPath: options.artifactConfig?.includeMetadata === false ? undefined : artifactPathsResult.metadataPath,
-			}));
-		}
-		if (options.maxOutput) {
+	try {
+		if (artifactPathsResult && options.artifactConfig?.enabled !== false) {
+			result.artifactPaths = artifactPathsResult;
+			if (options.artifactConfig?.includeOutput !== false) {
+				writeArtifact(artifactPathsResult.outputPath, formatOutputArtifactContent({
+					output: artifactOutputByResult.get(result) ?? result.finalOutput ?? "",
+					error: result.error,
+					transcriptPath: result.transcriptPath,
+					metadataPath: options.artifactConfig?.includeMetadata === false ? undefined : artifactPathsResult.metadataPath,
+				}));
+			}
+			if (options.maxOutput) {
+				const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
+				const truncationResult = truncateOutput(result.finalOutput ?? "", config, artifactPathsResult.outputPath);
+				if (truncationResult.truncated) result.truncation = truncationResult;
+			}
+		} else if (options.maxOutput) {
 			const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
-			const truncationResult = truncateOutput(result.finalOutput ?? "", config, artifactPathsResult.outputPath);
+			const truncationResult = truncateOutput(result.finalOutput ?? "", config);
 			if (truncationResult.truncated) result.truncation = truncationResult;
 		}
-	} else if (options.maxOutput) {
-		const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
-		const truncationResult = truncateOutput(result.finalOutput ?? "", config);
-		if (truncationResult.truncated) result.truncation = truncationResult;
+	} catch (error) {
+		const message = `Artifact output post-processing failed: ${error instanceof Error ? error.message : String(error)}`;
+		result.outputSaveError = result.outputSaveError ? `${result.outputSaveError}\n${message}` : message;
 	}
 
 	if (options.sessionFile && (existsSync(options.sessionFile) || result.messages?.length)) {
@@ -1629,28 +1628,36 @@ export async function runSync(
 	const childWrittenOutput = options.outputPath
 		? extractChildWrittenOutput(result.messages, options.outputPath, options.cwd ?? runtimeCwd)
 		: undefined;
-	if (result.detached) {
-		result.acceptance = buildPendingAcceptanceLedger(effectiveAcceptance);
-	} else if (result.stopped) {
-		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "stopped", message: "Acceptance was not evaluated because the subagent was stopped." });
-	} else if (result.timedOut) {
-		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." });
-	} else if (result.turnBudgetExceeded) {
-		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "turn-budget", message: "Acceptance was not evaluated because the subagent exceeded its turn budget." });
-	} else {
-		result.acceptance = await evaluateAcceptance({
-			acceptance: effectiveAcceptance,
-			output: acceptanceOutputByResult.get(result) ?? result.finalOutput ?? "",
-			fileOutput: childWrittenOutput !== undefined && options.outputPath
-				? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
-				: undefined,
-			cwd: options.cwd ?? runtimeCwd,
-			reportOptional: isAgentContractV1(options.agentContract),
-		});
+	try {
+		if (result.interrupted && detachedReason === "user request") {
+			// Only an accepted user-detach receipt needs a non-rejecting terminal
+			// ledger. Attached and background execution retain their baseline
+			// acceptance behavior.
+			result.acceptance = buildInterruptedAcceptanceLedger(effectiveAcceptance);
+		} else if (result.stopped) {
+			result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "stopped", message: "Acceptance was not evaluated because the subagent was stopped." });
+		} else if (result.timedOut) {
+			result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." });
+		} else if (result.turnBudgetExceeded) {
+			result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "turn-budget", message: "Acceptance was not evaluated because the subagent exceeded its turn budget." });
+		} else {
+			result.acceptance = await evaluateAcceptance({
+				acceptance: effectiveAcceptance,
+				output: acceptanceOutputByResult.get(result) ?? result.finalOutput ?? "",
+				fileOutput: childWrittenOutput !== undefined && options.outputPath
+					? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
+					: undefined,
+				cwd: options.cwd ?? runtimeCwd,
+				reportOptional: isAgentContractV1(options.agentContract),
+			});
+		}
+	} catch (error) {
+		const message = `Acceptance evaluation failed: ${error instanceof Error ? error.message : String(error)}`;
+		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "acceptance-evaluation", message });
 	}
 	const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
 	stripAcceptanceReportsFromMessages(result.messages);
-	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.detached && !result.interrupted && !result.timedOut && !isAgentContractV1(options.agentContract)) {
+	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.interrupted && !result.timedOut && !isAgentContractV1(options.agentContract)) {
 		result.exitCode = 1;
 		result.error = result.error ? `${result.error}\n${acceptanceFailure}` : acceptanceFailure;
 		if (result.progress) {
@@ -1659,7 +1666,143 @@ export async function runSync(
 		}
 	}
 	if (isAgentContractV1(options.agentContract)) attachContractProjections(result);
-	persistResultMetadata(result);
+	try {
+		persistResultMetadata(result);
+	} catch (error) {
+		result.metadataSaveError = error instanceof Error ? error.message : String(error);
+	}
 
 	return result;
+}
+
+/**
+ * Runs the authoritative completion pipeline independently from the foreground
+ * receipt. Detachment is same-runtime only: it does not adopt or daemonize work.
+ */
+export async function runSync(
+	runtimeCwd: string,
+	agents: AgentConfig[],
+	agentName: string,
+	task: string,
+	options: RunSyncOptions,
+): Promise<SingleResult> {
+	// Capture the strict contract before consumer-owned objects can be mutated
+	// after a detached receipt is published.
+	const strictContract = isAgentContractV1(options.agentContract);
+	let detachedReason: string | undefined;
+	let publishedReceipt: SingleResult | undefined;
+	let activeDetachAttempt: ((reason?: string) => boolean) | undefined;
+	let detachReadyPublished = false;
+	let resolveReceipt!: (result: SingleResult) => void;
+	const receipt = new Promise<SingleResult>((resolve) => { resolveReceipt = resolve; });
+	const originSignal = options.signal;
+	const originController = new AbortController();
+	const forwardOriginAbort = () => {
+		if (!detachedReason) originController.abort(originSignal?.reason);
+	};
+	if (originSignal?.aborted) forwardOriginAbort();
+	else originSignal?.addEventListener("abort", forwardOriginAbort, { once: true });
+
+	const completion = runSyncCompletion(runtimeCwd, agents, agentName, task, {
+		...options,
+		signal: originController.signal,
+		onDetachedExit: undefined,
+		onDetachReceipt: (detachedReceipt) => {
+			if (detachedReason || publishedReceipt) return false;
+			// Keep the authoritative result, fallback snapshot, and caller receipt
+			// separately owned while the completion pipeline remains live.
+			publishedReceipt = structuredClone(detachedReceipt);
+			const callerReceipt = structuredClone(detachedReceipt);
+			// A strict contract was already validated before detach; normalize private
+			// and caller snapshots to the only safely known version.
+			publishedReceipt.agentContract = strictContract ? { version: 1 } : undefined;
+			callerReceipt.agentContract = strictContract ? { version: 1 } : undefined;
+			detachedReason = detachedReceipt.detachedReason ?? "user request";
+			resolveReceipt(callerReceipt);
+			return true;
+		},
+		onDetachReady: (detachAttempt) => {
+			activeDetachAttempt = detachAttempt;
+			if (detachReadyPublished) return;
+			detachReadyPublished = true;
+			options.onDetachReady?.((reason = "user request") => {
+				if (detachedReason || originController.signal.aborted) return false;
+				return activeDetachAttempt?.(reason) ?? false;
+			});
+		},
+	});
+
+	const authoritativeCompletion = completion.catch((error: unknown) => {
+		if (!publishedReceipt || !detachedReason) throw error;
+		const message = error instanceof Error ? error.message : String(error);
+		const failureMessage = `Detached completion pipeline failed after receipt: ${message}`;
+		const failedProgress: AgentProgress = publishedReceipt.progress
+			? { ...publishedReceipt.progress, status: "failed", error: failureMessage }
+			: {
+				index: options.index ?? 0,
+				agent: publishedReceipt.agent,
+				status: "failed",
+				task: publishedReceipt.task,
+				recentTools: [],
+				recentOutput: [],
+				toolCount: publishedReceipt.progressSummary?.toolCount ?? 0,
+				tokens: publishedReceipt.progressSummary?.tokens ?? 0,
+				durationMs: publishedReceipt.progressSummary?.durationMs ?? 0,
+				error: failureMessage,
+			};
+		const failedResult: SingleResult = {
+			...publishedReceipt,
+			detached: undefined,
+			detachedReason,
+			exitCode: 1,
+			error: failureMessage,
+			finalOutput: failureMessage,
+			progress: failedProgress,
+			progressSummary: {
+				toolCount: failedProgress.toolCount,
+				tokens: failedProgress.tokens,
+				durationMs: failedProgress.durationMs,
+			},
+			acceptance: publishedReceipt.acceptance
+				? buildSkippedAcceptanceLedger(publishedReceipt.acceptance.effectiveAcceptance, { id: "completion-pipeline", message: failureMessage })
+				: undefined,
+		};
+		if (strictContract) attachContractProjections(failedResult);
+		try {
+			// Replace the provisional detach receipt metadata with the authoritative
+			// terminal failure. Persistence remains best-effort and cannot orphan work.
+			persistSingleResultMetadata({
+				metadataPath: failedResult.artifactPaths?.metadataPath,
+				enabled: options.artifactConfig?.enabled !== false && options.artifactConfig?.includeMetadata !== false,
+				runId: options.runId,
+				agent: failedResult.agent,
+				task: failedResult.task,
+				result: failedResult,
+			});
+		} catch (metadataError) {
+			failedResult.metadataSaveError = metadataError instanceof Error ? metadataError.message : String(metadataError);
+		}
+		return failedResult;
+	});
+
+	let terminalCallbackInvoked = false;
+	void authoritativeCompletion.then((terminalResult) => {
+		if (!detachedReason || terminalCallbackInvoked) return;
+		terminalCallbackInvoked = true;
+		terminalResult.detached = undefined;
+		terminalResult.detachedReason = detachedReason;
+		try {
+			options.onDetachedExit?.(terminalResult);
+		} catch {
+			// The authoritative result has settled. Consumer callback failures are
+			// contained here; each consumer owns cleanup through its own finally block.
+		}
+	}).catch(() => {
+		// Attached completion rejection remains observable through the returned
+		// promise without becoming an unhandled side-channel rejection.
+	}).finally(() => {
+		originSignal?.removeEventListener("abort", forwardOriginAbort);
+	});
+
+	return Promise.race([authoritativeCompletion, receipt]);
 }

--- a/src/runs/foreground/foreground-control.ts
+++ b/src/runs/foreground/foreground-control.ts
@@ -61,6 +61,20 @@ function clearCurrentChild(control: ForegroundRunControl): void {
 	control.interrupt = undefined;
 }
 
+export function retainForegroundSchedulingOwner(control: ForegroundRunControl): void {
+	control.schedulingOwners = (control.schedulingOwners ?? 0) + 1;
+	control.updatedAt = Date.now();
+}
+
+export function settleForegroundSchedulingOwner(control: ForegroundRunControl): void {
+	control.schedulingOwners = Math.max(0, (control.schedulingOwners ?? 0) - 1);
+	control.updatedAt = Date.now();
+}
+
+export function foregroundSchedulingSettled(control: ForegroundRunControl): boolean {
+	return (control.schedulingOwners ?? 0) === 0;
+}
+
 export function beginForegroundChild(control: ForegroundRunControl, input: BeginForegroundChildInput): void {
 	const now = Date.now();
 	const child: ForegroundChildControl = {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -498,23 +498,23 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		state.foregroundRuns.set(input.runId, run);
 	}
 	run.updatedAt = updatedAt;
+	const terminalStatus = resolveSubagentResultStatus({
+		exitCode: input.result.exitCode,
+		...(input.result.acceptance?.status === "rejected" ? { success: false } : {}),
+		interrupted: input.result.interrupted,
+		detached: false,
+		processSignal: input.result.processSignal,
+		timedOut: input.result.timedOut,
+		stopped: input.result.stopped,
+		turnBudgetExceeded: input.result.turnBudgetExceeded,
+	});
 	const child = run.children[input.index] ?? { agent: input.result.agent, index: input.index, status: "detached" as const };
 	run.children[input.index] = {
 		...child,
 		agent: input.result.agent,
 		index: input.index,
 		...(input.result.context ? { context: input.result.context } : {}),
-		status: input.result.acceptance?.status === "rejected"
-			? "failed"
-			: resolveSubagentResultStatus({
-				exitCode: input.result.exitCode,
-				interrupted: input.result.interrupted,
-				detached: false,
-				processSignal: input.result.processSignal,
-				timedOut: input.result.timedOut,
-				stopped: input.result.stopped,
-				turnBudgetExceeded: input.result.turnBudgetExceeded,
-			}),
+		status: terminalStatus,
 		...foregroundChildActivityFromProgress(input.result.progress),
 		updatedAt,
 		...(input.result.exitCode !== undefined ? { exitCode: input.result.exitCode } : {}),
@@ -538,7 +538,7 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 	};
 	trimRememberedForegroundRuns(state);
 	const output = getSingleResultOutput(input.result).trim();
-	const success = input.result.exitCode === 0 && input.result.acceptance?.status !== "rejected";
+	const success = terminalStatus === "completed";
 	const summary = !success && input.result.error
 		? `${input.result.error}${output ? `\n\nOutput:\n${output}` : ""}`
 		: output || input.result.error || "Detached child exited without final output.";
@@ -554,7 +554,12 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		success,
 		summary,
 		exitCode: input.result.exitCode,
-		state: success ? "complete" : "failed",
+		state: terminalStatus === "completed" ? "complete" : terminalStatus,
+		...(input.result.interrupted !== undefined ? { interrupted: input.result.interrupted } : {}),
+		...(input.result.stopped !== undefined ? { stopped: input.result.stopped } : {}),
+		...(input.result.processSignal !== undefined ? { processSignal: input.result.processSignal } : {}),
+		...(input.result.timedOut !== undefined ? { timedOut: input.result.timedOut } : {}),
+		...(input.result.turnBudgetExceeded !== undefined ? { turnBudgetExceeded: input.result.turnBudgetExceeded } : {}),
 		timestamp: updatedAt,
 		cwd: input.cwd,
 		sessionFile: input.result.sessionFile,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -8,7 +8,14 @@ import { getArtifactsDir, getProjectChainRunsDir } from "../../shared/artifacts.
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
 import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import { executeChain } from "./chain-execution.ts";
-import { beginForegroundChild, finishForegroundChild, updateForegroundChild } from "./foreground-control.ts";
+import {
+	beginForegroundChild,
+	finishForegroundChild,
+	foregroundSchedulingSettled,
+	retainForegroundSchedulingOwner,
+	settleForegroundSchedulingOwner,
+	updateForegroundChild,
+} from "./foreground-control.ts";
 import { resolveExecutionAgentScope } from "../../agents/agent-scope.ts";
 import { handleManagementAction } from "../../agents/agent-management.ts";
 import { buildDoctorReport } from "../../extension/doctor.ts";
@@ -261,6 +268,15 @@ interface ExecutionContextData {
 
 function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefined): string {
 	return requestedCwd ? path.resolve(runtimeCwd, requestedCwd) : runtimeCwd;
+}
+
+function removeForegroundControlIfIdle(state: SubagentState, runId: string): boolean {
+	const control = state.foregroundControls.get(runId);
+	if (control && (!foregroundSchedulingSettled(control) || (control.activeChildren?.size ?? 0) > 0)) return false;
+	clearPendingForegroundControlNotices(state, runId);
+	state.foregroundControls.delete(runId);
+	if (state.lastForegroundControlId === runId) state.lastForegroundControlId = null;
+	return true;
 }
 
 function getForegroundControl(state: SubagentState, runId: string | undefined) {
@@ -2377,7 +2393,16 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		timeoutMs: data.timeoutMs,
 		deadlineAt: data.deadlineAt,
 		turnBudget: data.turnBudget,
-		onDetachedExit: (index, result) => updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, index, result, events: deps.pi.events }),
+		onDetachedExit: (index, result) => {
+			try {
+				updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, index, result, events: deps.pi.events });
+			} finally {
+				removeForegroundControlIfIdle(deps.state, runId);
+			}
+		},
+		onForegroundChildSettled: () => {
+			removeForegroundControlIfIdle(deps.state, runId);
+		},
 		toolBudget: data.toolBudget,
 		usageBudget: data.usageBudget,
 		configToolBudget: data.configToolBudget,
@@ -2682,6 +2707,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		input.sessionFileForTask(input.tasks[i]!.agent, i, input.modelOverrides[i]);
 	}
 	const completedResults: SingleResult[] = [];
+	if (input.foregroundControl) retainForegroundSchedulingOwner(input.foregroundControl);
 	return mapConcurrent(input.tasks, input.concurrencyLimit, async (task, index) => {
 		const budgetState = usageBudgetState(input.usageBudget, sumResultsCost(completedResults));
 		if (budgetState?.exhausted) {
@@ -2727,6 +2753,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		const structuredRuntime = task.outputSchema
 			? createStructuredOutputRuntime(task.outputSchema, path.join(input.artifactsDir, "structured-output", input.runId))
 			: undefined;
+		let detachedReceipt = false;
 		const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskText, {
 			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 			context: input.contextPolicy.contextForAgent(task.agent),
@@ -2750,7 +2777,17 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			capabilityCeiling: input.capabilityCeiling,
 			controlConfig: input.controlConfig,
 			onControlEvent: input.onControlEvent,
-			onDetachedExit: (result) => updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents }),
+			onDetachedExit: (result) => {
+				try {
+					updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents });
+				} finally {
+					try {
+						if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
+					} finally {
+						removeForegroundControlIfIdle(input.state, input.runId);
+					}
+				}
+			},
 			intercomSessionName: input.childIntercomTarget?.(task.agent, index),
 			orchestratorIntercomTarget: input.orchestratorIntercomTarget,
 			nestedRoute: input.foregroundControl?.nestedRoute,
@@ -2791,12 +2828,24 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 					});
 				}
 				: undefined,
+		}).then((result) => {
+			detachedReceipt = result.detached === true;
+			return result;
 		}).finally(() => {
-			if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
+			// mapConcurrent rejects before siblings settle, so every attached child
+			// attempts idle removal after releasing its own control. Detached receipts
+			// transfer both responsibilities to the authoritative exit callback.
+			if (!detachedReceipt) {
+				if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
+				removeForegroundControlIfIdle(input.state, input.runId);
+			}
 		});
 		completedResults.push(result);
 		return result;
-	}, input.globalSemaphore);
+	}, input.globalSemaphore, () => {
+		if (input.foregroundControl) settleForegroundSchedulingOwner(input.foregroundControl);
+		removeForegroundControlIfIdle(input.state, input.runId);
+	});
 }
 
 async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): Promise<AgentToolResult<Details>> {
@@ -3423,7 +3472,22 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			agentContract: params.agentContract,
 			acceptance: params.acceptance,
 			acceptanceContext: { mode: "single" },
-			onDetachedExit: (result) => updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events }),
+			onDetachedExit: (result) => {
+				try {
+					updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events });
+				} finally {
+					try {
+						if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
+					} finally {
+						try {
+							if (foregroundControl) finishForegroundChild(foregroundControl, 0);
+						} finally {
+							removeForegroundControlIfIdle(deps.state, runId);
+						}
+					}
+				}
+				recordRun(params.agent!, cleanTask, result.exitCode, result.progressSummary?.durationMs ?? 0);
+			},
 			timeoutMs: data.timeoutMs,
 			deadlineAt,
 			turnBudget: data.turnBudget,
@@ -3433,10 +3497,17 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			allowZeroToolBudget: data.allowZeroToolBudget && effectiveToolBudget.toolBudget === data.toolBudget,
 		});
 	} finally {
-		if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
+		// An attached runSync rejection still owns its child and structured runtime.
+		// A successful detached receipt transfers both to onDetachedExit while the
+		// authoritative completion remains live.
+		if (!r?.detached) {
+			if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
+			if (foregroundControl) finishForegroundChild(foregroundControl, 0);
+		}
 	}
-	if (foregroundControl) finishForegroundChild(foregroundControl, 0);
-	recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
+	if (!r.detached) {
+		recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
+	}
 
 	if (r.progress) allProgress.push(r.progress);
 	if (r.artifactPaths) allArtifactPaths.push(r.artifactPaths);
@@ -4244,6 +4315,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				description: foregroundDescription,
 				currentActivityState: undefined,
 				activeChildren: new Map(),
+				// The outer executor owns scheduling until its finally block settles.
+				schedulingOwners: 1,
 				nestedRoute,
 				interrupt: undefined,
 			};
@@ -4341,11 +4414,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return errorResult;
 		} finally {
 			if (foregroundControl) {
-				clearPendingForegroundControlNotices(deps.state, runId);
-				deps.state.foregroundControls.delete(runId);
-				if (deps.state.lastForegroundControlId === runId) {
-					deps.state.lastForegroundControlId = null;
-				}
+				settleForegroundSchedulingOwner(foregroundControl);
+				removeForegroundControlIfIdle(deps.state, runId);
 			}
 		}
 

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -158,29 +158,45 @@ export async function mapConcurrent<T, R>(
 	limit: number,
 	fn: (item: T, i: number) => Promise<R>,
 	globalSemaphore?: Semaphore,
+	/** Invoked after every worker has stopped, including workers outliving an early rejection. */
+	onSchedulingSettled?: () => void,
 ): Promise<R[]> {
 	const safeLimit = Math.max(1, Math.floor(limit) || 1);
 	const results: R[] = new Array(items.length);
 	let next = 0;
+	let liveWorkers = Math.min(safeLimit, items.length);
+	const notifySchedulingSettled = () => {
+		try {
+			onSchedulingSettled?.();
+		} catch {
+			// Scheduling lifecycle cleanup must not replace the worker result.
+		}
+	};
 
 	async function worker(_workerIndex: number): Promise<void> {
-		while (next < items.length) {
-			const i = next++;
-			if (globalSemaphore) {
-				await globalSemaphore.acquire();
-				try {
+		try {
+			while (next < items.length) {
+				const i = next++;
+				if (globalSemaphore) {
+					await globalSemaphore.acquire();
+					try {
+						results[i] = await fn(items[i], i);
+					} finally {
+						globalSemaphore.release();
+					}
+				} else {
 					results[i] = await fn(items[i], i);
-				} finally {
-					globalSemaphore.release();
 				}
-			} else {
-				results[i] = await fn(items[i], i);
 			}
+		} finally {
+			liveWorkers--;
+			if (liveWorkers === 0) notifySchedulingSettled();
 		}
 	}
 
+	if (liveWorkers === 0) notifySchedulingSettled();
 	await Promise.all(
-		Array.from({ length: Math.min(safeLimit, items.length) }, (_, wi) => worker(wi)),
+		Array.from({ length: liveWorkers }, (_, wi) => worker(wi)),
 	);
 	return results;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -851,6 +851,8 @@ export interface SingleResult {
 	savedOutputPath?: string;
 	outputReference?: SavedOutputReference;
 	outputSaveError?: string;
+	/** Best-effort metadata persistence failure; execution and receipt publication continue. */
+	metadataSaveError?: string;
 	structuredOutput?: unknown;
 	structuredOutputFailed?: boolean;
 	structuredOutputPath?: string;
@@ -1474,6 +1476,11 @@ export interface RunSyncOptions {
 	intercomEvents?: IntercomEventBus;
 	onUpdate?: (r: import("@earendil-works/pi-agent-core").AgentToolResult<Details>) => void;
 	onControlEvent?: (event: ControlEvent) => void;
+	/** Exposes a non-terminating detach callback while the child is active. */
+	onDetachReady?: (detach: (reason?: string) => boolean) => void;
+	/** Internal foreground receipt proposal; returns true only when the outer waiter accepted it. */
+	onDetachReceipt?: (result: SingleResult) => boolean;
+	/** Authoritative terminal result, emitted only after the full detached run finalizes. */
 	onDetachedExit?: (result: SingleResult) => void;
 	controlConfig?: ResolvedControlConfig;
 	intercomSessionName?: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1370,6 +1370,8 @@ export interface ForegroundRunControl {
 	toolCount?: number;
 	/** Independently tracked children for foreground parallel work and fleet inspection. */
 	activeChildren?: Map<number, ForegroundChildControl>;
+	/** Scheduling owners that may still launch another child. Removal is safe only at zero. */
+	schedulingOwners?: number;
 	nestedRoute?: NestedRouteInfo;
 	nestedChildren?: NestedRunSummary[];
 	interrupt?: () => boolean;

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -304,6 +304,139 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.equal(result.details?.results?.every((entry) => entry.finalOutput === undefined), true);
 	});
 
+	it("keeps a queued top-level parallel child controlled after an early outer rejection", async () => {
+		mockPi.onCall({ matchArgIncludes: "task-a", output: "early child", delay: 100 });
+		mockPi.onCall({ matchArgIncludes: "task-b", output: "middle child", delay: 400 });
+		mockPi.onCall({ matchArgIncludes: "task-c", output: "too late", delay: 10_000 });
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });
+		let rejected = false;
+		const result = await executor.execute(
+			"parallel-rejection-cleanup",
+			{ concurrency: 2, tasks: [{ agent: "a", task: "task-a" }, { agent: "b", task: "task-b" }, { agent: "c", task: "task-c" }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ agent?: string; status?: string }> } }) => {
+				if (!rejected && update.details?.progress?.some((entry) => entry.agent === "a" && entry.status === "completed")) {
+					rejected = true;
+					throw new Error("reject early parallel completion");
+				}
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(rejected, true);
+		assert.equal(result.isError, true);
+		assert.equal(state.foregroundControls.size, 1, "remaining worker still owns queued scheduling");
+		await waitForCallCount(3);
+		const liveControl = [...state.foregroundControls.values()][0];
+		assert.equal(liveControl?.currentAgent, "c", "later queued child must remain discoverable after launch");
+		assert.ok(liveControl?.interrupt, "later queued child must remain interruptible");
+		assert.equal(liveControl.interrupt(), true);
+		for (let attempt = 0; attempt < 100 && state.foregroundControls.size > 0; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(state.foregroundControls.size, 0, "control must disappear after workers and children settle");
+	});
+
+	it("keeps a queued chain-parallel child controlled after an early outer rejection", async () => {
+		mockPi.onCall({ matchArgIncludes: "chain-task-a", output: "early chain child", delay: 100 });
+		mockPi.onCall({ matchArgIncludes: "chain-task-b", output: "middle chain child", delay: 400 });
+		mockPi.onCall({ matchArgIncludes: "chain-task-c", output: "too late", delay: 10_000 });
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });
+		let rejected = false;
+		const result = await executor.execute(
+			"chain-parallel-rejection-cleanup",
+			{ chain: [{ concurrency: 2, parallel: [{ agent: "a", task: "chain-task-a" }, { agent: "b", task: "chain-task-b" }, { agent: "c", task: "chain-task-c" }] }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ agent?: string; status?: string }> } }) => {
+				if (!rejected && update.details?.progress?.some((entry) => entry.agent === "a" && entry.status === "completed")) {
+					rejected = true;
+					throw new Error("reject early chain completion");
+				}
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(rejected, true);
+		assert.equal(result.isError, true);
+		assert.equal(state.foregroundControls.size, 1, "remaining chain worker still owns queued scheduling");
+		await waitForCallCount(3);
+		const liveControl = [...state.foregroundControls.values()][0];
+		assert.equal(liveControl?.currentAgent, "c", "later queued chain child must remain discoverable after launch");
+		assert.ok(liveControl?.interrupt, "later queued chain child must remain interruptible");
+		assert.equal(liveControl.interrupt(), true);
+		for (let attempt = 0; attempt < 100 && state.foregroundControls.size > 0; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(state.foregroundControls.size, 0, "chain control must disappear after workers and children settle");
+	});
+
+	it("cleans a rejected sequential chain child and releases foreground ownership", async () => {
+		mockPi.onCall({ output: "sequential child output" });
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		let rejected = false;
+		let ownedControl: { schedulingOwners?: number; activeChildren?: Map<number, unknown> } | undefined;
+		const result = await executor.execute(
+			"chain-sequential-rejection-cleanup",
+			{ chain: [{ agent: "worker", task: "sequential task" }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ status?: string }> } }) => {
+				if (rejected || !update.details?.progress?.some((entry) => entry.status === "completed")) return;
+				rejected = true;
+				ownedControl = [...state.foregroundControls.values()][0];
+				throw new Error("reject sequential chain completion");
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(rejected, true);
+		assert.equal(result.isError, true);
+		assert.ok(ownedControl);
+		assert.equal(ownedControl.schedulingOwners, 0);
+		assert.equal(ownedControl.activeChildren?.size, 0);
+		assert.equal(state.foregroundControls.size, 0);
+	});
+
+	it("cleans a sequential chain child after an early tool-budget validation return", async () => {
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		const execution = executor.execute(
+			"chain-sequential-budget-cleanup",
+			{ chain: [{ agent: "worker", task: "invalid budget task", toolBudget: { hard: 0 } }] },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		const ownedControl = [...state.foregroundControls.values()][0];
+		assert.ok(ownedControl, "outer scheduling owner should remain visible until execution settles");
+		const result = await execution;
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /toolBudget\.hard must be an integer >= 1/);
+		assert.equal(mockPi.callCount(), 0);
+		assert.equal(ownedControl.schedulingOwners, 0);
+		assert.equal(ownedControl.activeChildren?.size, 0);
+		assert.equal(state.foregroundControls.size, 0);
+	});
+
+	it("cleans an attached single rejection and its temporary structured runtime", async () => {
+		mockPi.onCall({
+			stdoutRaw: [
+				{ type: "tool_execution_start", toolName: "structured_output", args: { value: { ok: true } } },
+				{ type: "tool_result_end", message: { role: "toolResult", toolName: "structured_output", content: [{ type: "text", text: "Structured output captured." }] } },
+				{ type: "tool_execution_end", toolName: "structured_output" },
+			].map((entry) => JSON.stringify(entry)).join("\n") + "\n",
+			structuredOutputCapture: { ok: true },
+		});
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		let structuredDir: string | undefined;
+		const result = await executor.execute(
+			"single-rejection-cleanup",
+			{ agent: "worker", task: "structured task", artifacts: false, outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] } },
+			new AbortController().signal,
+			(update: { details?: { results?: Array<{ structuredOutputPath?: string }>; progress?: Array<{ status?: string }> } }) => {
+				const outputPath = update.details?.results?.[0]?.structuredOutputPath;
+				if (outputPath) structuredDir = path.dirname(outputPath);
+				if (update.details?.progress?.[0]?.status === "completed") throw new Error("reject attached single completion");
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(result.isError, true);
+		assert.equal(state.foregroundControls.size, 0);
+		assert.ok(structuredDir);
+		assert.equal(fs.existsSync(structuredDir), false, "temporary structured runtime must be removed on rejection");
+	});
+
 	it("chain runs emit one grouped event containing all executed children", async () => {
 		mockPi.onCall({ output: "Chain child output" });
 		const { executor, events } = makeExecutor({ agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -3278,6 +3278,464 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.finalOutput ?? "", /Interrupted/);
 	});
 
+	it("supports synchronous user detach and rejects duplicate and late detach calls", async () => {
+		mockPi.onCall({ steps: [
+			{ delay: 500, jsonl: [events.assistantMessage("completed after user detach")] },
+		] });
+		let detachActive: ((reason?: string) => boolean) | undefined;
+		let detachAccepted = false;
+		let duplicateAccepted = true;
+		let recoveredResult: RunSyncResult | undefined;
+
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Keep working", {
+			runId: "user-foreground-detach",
+			acceptance: false,
+			onDetachReady: (detach: (reason?: string) => boolean) => {
+				detachActive = detach;
+				detachAccepted = detach("user request");
+				duplicateAccepted = detach("user request");
+			},
+			onDetachedExit: (postExit) => { recoveredResult = postExit as RunSyncResult; },
+		});
+
+		assert.equal(detachAccepted, true);
+		assert.equal(duplicateAccepted, false);
+		assert.equal(recoveredResult, undefined, "foreground result should return before the child completes");
+		assert.equal(result.exitCode, -2);
+		assert.equal(result.detached, true);
+		assert.equal(result.detachedReason, "user request");
+		assert.equal(result.finalOutput, "Detached at user request before task completion.");
+		assert.equal(result.processSignal, undefined);
+
+		for (let attempt = 0; attempt < 100 && !recoveredResult; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(recoveredResult);
+		assert.equal(recoveredResult.exitCode, 0);
+		assert.equal(recoveredResult.processSignal, undefined);
+		assert.equal(recoveredResult.finalOutput, "completed after user detach");
+		assert.equal(detachActive?.("user request"), false, "detach must reject calls after child exit");
+	});
+
+	it("produces the same authoritative terminal result attached and detached", async () => {
+		mockPi.onCall({ output: "authoritative answer" });
+		mockPi.onCall({ steps: [{ delay: 75, jsonl: [events.assistantMessage("authoritative answer")] }] });
+		const agents = makeAgentConfigs(["echo"]);
+		const attached = await runSync(tempDir, agents, "echo", "Equivalent task", {
+			runId: "attached-authoritative-result",
+			acceptance: false,
+		});
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, agents, "echo", "Equivalent task", {
+			runId: "detached-authoritative-result",
+			acceptance: false,
+			onDetachReady: (detach) => assert.equal(detach("user request"), true),
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.deepEqual(
+			{
+				exitCode: terminal.exitCode,
+				finalOutput: terminal.finalOutput,
+				usage: terminal.usage,
+				progressStatus: terminal.progress.status,
+				acceptanceStatus: terminal.acceptance?.status,
+			},
+			{
+				exitCode: attached.exitCode,
+				finalOutput: attached.finalOutput,
+				usage: attached.usage,
+				progressStatus: attached.progress.status,
+				acceptanceStatus: attached.acceptance?.status,
+			},
+		);
+		assert.equal(terminal.detached, undefined);
+		assert.equal(terminal.detachedReason, "user request");
+	});
+
+	it("isolates every nested detach receipt field from terminal completion and later sanitization", async () => {
+		const receiptReport = [
+			"receipt snapshot",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "receipt evidence" }],
+				changedFiles: ["src/receipt.ts"],
+				testsAddedOrUpdated: ["test/receipt.test.ts"],
+				commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+				residualRisks: [],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n");
+		const terminalReport = [
+			"terminal answer",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "terminal isolation verified" }],
+				changedFiles: ["src/receipt.ts"],
+				testsAddedOrUpdated: ["test/receipt.test.ts"],
+				commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+				residualRisks: [],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n");
+		mockPi.onCall({ steps: [
+			{ jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: receiptReport }],
+					model: "mock/test-model",
+					stopReason: "toolUse",
+					usage: { input: 7, output: 3, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+				},
+			}] },
+			{ delay: 300, jsonl: [events.assistantMessage(terminalReport)] },
+		] });
+		let detach: ((reason?: string) => boolean) | undefined;
+		let detached = false;
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Keep the receipt isolated", {
+			runId: "detached-deep-receipt-isolation",
+			agentContract: { version: 1 },
+			acceptance: {
+				level: "checked",
+				criteria: [{
+					id: "criterion-1",
+					must: "Keep detach receipt state isolated",
+					evidence: ["changed-files", "tests-added", "commands-run", "residual-risks", "no-staged-files"],
+				}],
+			},
+			onDetachReady: (detachAttempt) => { detach = detachAttempt; },
+			onUpdate: (update: { content?: Array<{ text?: string }> }) => {
+				if (detached || !update.content?.[0]?.text?.includes("receipt snapshot")) return;
+				detached = detach?.("user request") === true;
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+
+		assert.equal(receipt.detached, true);
+		const receiptMessages = receipt.messages as Array<{
+			role?: string;
+			model?: string;
+			content: Array<{ type?: string; text?: string; callerOwned?: boolean }>;
+		}>;
+		const callerOwnedReceiptText = `caller-owned mutation\n${receiptReport}`;
+		(receipt.agentContract as unknown as { version: number }).version = 999;
+		receiptMessages[0]!.model = "caller-owned/model";
+		receiptMessages[0]!.content[0]!.text = callerOwnedReceiptText;
+		receiptMessages[0]!.content[0]!.callerOwned = true;
+		receiptMessages[0]!.content.push({ type: "text", text: "caller-only content" });
+		receiptMessages.push({ role: "assistant", model: "caller-only/model", content: [{ type: "text", text: "caller-only message" }] });
+		const mutableAcceptance = receipt.acceptance as unknown as {
+			status: string;
+			effectiveAcceptance: { level: string; criteria: Array<{ must: string }> };
+			criteria: Array<{ must: string }>;
+		};
+		mutableAcceptance.status = "rejected";
+		mutableAcceptance.effectiveAcceptance.level = "none";
+		mutableAcceptance.effectiveAcceptance.criteria[0]!.must = "caller corrupted effective criterion";
+		mutableAcceptance.criteria[0]!.must = "caller corrupted ledger criterion";
+		receipt.progress.status = "failed";
+		(receipt.progress as unknown as { recentOutput: string[] }).recentOutput.push("caller-only progress");
+		receipt.usage.turns = 999;
+		receipt.usage.input = 999;
+		receipt.attemptedModels = ["caller-only/model"];
+		receipt.modelAttempts = [{ success: false, exitCode: 99, error: "caller-only attempt" }];
+		receipt.effects = { fileMutation: { status: "missing", expected: true, attempted: false, message: "caller-only effect" } };
+		receipt.execution = { status: "failed", success: false, exitCode: 99 };
+		receipt.review = { status: "blockers" };
+
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.exitCode, 0);
+		assert.equal(terminal.finalOutput, "terminal answer");
+		assert.deepEqual(terminal.agentContract, { version: 1 });
+		assert.equal(terminal.acceptance?.status, "checked");
+		assert.equal(terminal.acceptance?.runtimeChecks.every((check) => check.status === "passed"), true);
+		assert.equal(terminal.progress.status, "completed");
+		assert.deepEqual(terminal.usage, { turns: 2, input: 107, output: 53, cacheRead: 0, cacheWrite: 0, cost: 0.002 });
+		assert.deepEqual(terminal.attemptedModels, ["mock/test-model"]);
+		assert.deepEqual(terminal.modelAttempts?.map((attempt) => ({ success: attempt.success, exitCode: attempt.exitCode })), [{ success: true, exitCode: 0 }]);
+		assert.equal(terminal.execution?.status, "completed");
+		assert.equal(terminal.execution?.success, true);
+		assert.equal(terminal.review?.status, "not-requested");
+		assert.deepEqual(terminal.effects, {});
+		assert.doesNotMatch(JSON.stringify(terminal.messages), /acceptance-report/);
+		assert.equal(receiptMessages[0]!.content[0]!.text, callerOwnedReceiptText, "terminal report sanitization must not mutate the caller receipt");
+		assert.equal(receiptMessages[0]!.content[0]!.callerOwned, true);
+		assert.equal(receiptMessages.length, 2);
+	});
+
+	it("keeps the full fallback loop and authoritative aggregation alive after detach", async () => {
+		mockPi.onCall({
+			jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "temporary provider failure" }],
+					model: "openai/gpt-5-mini",
+					errorMessage: "rate limit exceeded",
+					usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } },
+				},
+			}],
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "Recovered on detached fallback" });
+		const agents = [makeAgent("echo", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+		let terminal: RunSyncResult | undefined;
+
+		const receipt = await runSync(tempDir, agents, "echo", "Task", {
+			runId: "detached-fallback-loop",
+			acceptance: false,
+			onDetachReady: (detach) => assert.equal(detach("user request"), true),
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 300 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.detached, undefined, "terminal status must not remain detached");
+		assert.equal(terminal.detachedReason, "user request");
+		assert.equal(terminal.exitCode, 0);
+		assert.equal(terminal.finalOutput, "Recovered on detached fallback");
+		assert.deepEqual(terminal.attemptedModels, ["openai/gpt-5-mini", "anthropic/claude-sonnet-4"]);
+		assert.deepEqual(terminal.modelAttempts?.map((attempt) => attempt.success), [false, true]);
+		assert.equal(terminal.usage.turns, 2);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
+	it("terminalizes a post-receipt completion pipeline throw exactly once with strict projections", async () => {
+		mockPi.onCall({ steps: [{ delay: 75, jsonl: [events.assistantMessage("answer before callback failure")] }] });
+		let terminal: RunSyncResult | undefined;
+		let callbackCount = 0;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "detached-completion-pipeline-throw",
+			acceptance: { level: "checked", criteria: ["result is checked"] },
+			agentContract: { version: 1 },
+			onDetachReady: (detach) => {
+				assert.equal(detach("user request"), true);
+			},
+			onUpdate: (update: { details?: { progress?: Array<{ status?: string }> } }) => {
+				if (update.details?.progress?.[0]?.status === "completed") throw new Error("terminal consumer update failed");
+			},
+			onDetachedExit: (result) => {
+				callbackCount++;
+				terminal = result as RunSyncResult;
+			},
+		});
+		assert.equal(receipt.detached, true);
+		(receipt.agentContract as unknown as { version: number }).version = 999;
+		receipt.messages.push({ role: "assistant", content: [{ type: "text", text: "caller-only fallback message" }] });
+		const mutableAcceptance = receipt.acceptance as unknown as {
+			status: string;
+			effectiveAcceptance: { level: string; criteria: Array<{ must: string }> };
+		};
+		mutableAcceptance.status = "accepted";
+		mutableAcceptance.effectiveAcceptance.level = "none";
+		mutableAcceptance.effectiveAcceptance.criteria[0]!.must = "caller-only fallback criterion";
+		receipt.progress.status = "completed";
+		receipt.usage.turns = 999;
+		receipt.usage.input = 999;
+		receipt.attemptedModels = ["caller-only/fallback"];
+		receipt.modelAttempts = [{ success: true, exitCode: 0 }];
+		receipt.effects = { fileMutation: { status: "observed", expected: false, attempted: true, message: "caller-only fallback effect" } };
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(callbackCount, 1);
+		assert.equal(terminal.exitCode, 1);
+		assert.equal(terminal.detached, undefined);
+		assert.equal(terminal.detachedReason, "user request");
+		assert.equal(terminal.progress?.status, "failed");
+		assert.equal(terminal.acceptance?.status, "rejected");
+		assert.equal(terminal.acceptance?.runtimeChecks?.[0]?.id, "completion-pipeline");
+		assert.equal(terminal.execution?.status, "failed");
+		assert.equal(terminal.execution?.success, false);
+		assert.equal(terminal.review?.status, "not-requested");
+		assert.deepEqual(terminal.agentContract, { version: 1 });
+		assert.deepEqual(terminal.effects, {});
+		assert.equal(terminal.usage.turns, 0);
+		assert.equal(terminal.attemptedModels, undefined);
+		assert.equal(terminal.modelAttempts, undefined);
+		assert.doesNotMatch(JSON.stringify(terminal.messages), /caller-only fallback message/);
+		assert.match(terminal.error ?? "", /Detached completion pipeline failed after receipt/);
+	});
+
+	it("contains a synchronous onDetachReady throw and completes attached", async () => {
+		mockPi.onCall({ output: "completed while attached" });
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "throwing-detach-ready-consumer",
+			acceptance: false,
+			onDetachReady: () => {
+				throw new Error("bad detach consumer");
+			},
+		});
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.detached, undefined);
+		assert.equal(result.finalOutput, "completed while attached");
+		assert.equal(result.progress.recentOutput.some((line) => /Foreground detach callback failed: bad detach consumer/.test(line)), true);
+	});
+
+	it("reports expected artifact post-processing I/O failures without rejecting", async () => {
+		mockPi.onCall({ steps: [
+			{ jsonl: [events.toolStart("read", { path: "README.md" })] },
+			{ delay: 50, jsonl: [events.assistantMessage("artifact answer")] },
+		] });
+		const artifactsDir = path.join(tempDir, "artifact-output-failure");
+		let sabotaged = false;
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "artifact-output-result-field",
+			acceptance: false,
+			artifactsDir,
+			artifactConfig: { enabled: true },
+			onUpdate: (update: { details?: { results?: Array<{ artifactPaths?: { outputPath?: string } }> } }) => {
+				const outputPath = update.details?.results?.[0]?.artifactPaths?.outputPath;
+				if (sabotaged || !outputPath) return;
+				sabotaged = true;
+				fs.mkdirSync(outputPath);
+			},
+		});
+		assert.equal(sabotaged, true);
+		assert.equal(result.exitCode, 0);
+		assert.match(result.outputSaveError ?? "", /Artifact output post-processing failed/);
+	});
+
+	it("publishes detach despite best-effort receipt metadata persistence failure", async () => {
+		mockPi.onCall({ steps: [{ delay: 100, jsonl: [events.assistantMessage("completed after metadata recovery")] }] });
+		const artifactsDir = path.join(tempDir, "receipt-metadata-failure");
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "detach-receipt-metadata-failure",
+			acceptance: false,
+			artifactsDir,
+			artifactConfig: { enabled: true },
+			onDetachReady: (detach) => {
+				fs.rmSync(artifactsDir, { recursive: true, force: true });
+				fs.writeFileSync(artifactsDir, "block metadata", "utf-8");
+				assert.equal(detach("user request"), true);
+				fs.rmSync(artifactsDir, { force: true });
+				fs.mkdirSync(artifactsDir, { recursive: true });
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+		assert.equal(receipt.detached, true);
+		assert.match(receipt.metadataSaveError ?? "", /ENOTDIR|not a directory/);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(terminal?.exitCode, 0);
+	});
+
+	it("contains a throwing detached-exit callback", async () => {
+		mockPi.onCall({ steps: [{ delay: 50, jsonl: [events.assistantMessage("done")] }] });
+		let callbackCount = 0;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "throwing-detached-exit-callback",
+			acceptance: false,
+			onDetachReady: (detach) => assert.equal(detach("user request"), true),
+			onDetachedExit: () => {
+				callbackCount++;
+				throw new Error("consumer callback failed");
+			},
+		});
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && callbackCount === 0; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(callbackCount, 1);
+	});
+
+	it("skips acceptance evaluation when an explicitly interrupted detached result settles", async () => {
+		mockPi.onCall({ steps: [{ delay: 10_000, jsonl: [events.assistantMessage("too late")] }] });
+		const interrupt = new AbortController();
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Task", {
+			runId: "detached-interrupted-acceptance",
+			acceptance: { level: "checked", criteria: ["result is checked"] },
+			interruptSignal: interrupt.signal,
+			onDetachReady: (detach) => {
+				assert.equal(detach("user request"), true);
+				setTimeout(() => interrupt.abort(), 25);
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.interrupted, true);
+		assert.equal(terminal.exitCode, 0);
+		assert.equal(terminal.acceptance?.status, "pending");
+		assert.equal(terminal.acceptance?.runtimeChecks[0]?.status, "not-applicable");
+		assert.equal(terminal.error, undefined);
+	});
+
+	it("linearizes originating abort against detach and keeps explicit interrupt routable afterward", async () => {
+		mockPi.onCall({ steps: [{ delay: 10_000, jsonl: [events.assistantMessage("too late")] }] });
+		const origin = new AbortController();
+		const interrupt = new AbortController();
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Keep working", {
+			runId: "detach-origin-abort-race",
+			acceptance: false,
+			signal: origin.signal,
+			interruptSignal: interrupt.signal,
+			onDetachReady: (detach) => {
+				assert.equal(detach("user request"), true);
+				origin.abort();
+				setTimeout(() => interrupt.abort(), 50);
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.interrupted, true, "explicit control interrupt must remain active after detach");
+		assert.equal(terminal.processSignal, "SIGINT");
+		assert.equal(terminal.detached, undefined);
+	});
+
+	it("lets an already-observed originating abort win over detach", async () => {
+		mockPi.onCall({ delay: 10_000 });
+		const origin = new AbortController();
+		let detachAccepted = true;
+		const result = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Abort first", {
+			runId: "origin-abort-wins-detach",
+			signal: origin.signal,
+			onDetachReady: (detach) => {
+				origin.abort();
+				detachAccepted = detach("user request");
+			},
+		});
+		assert.equal(detachAccepted, false);
+		assert.equal(result.detached, undefined);
+	});
+
+	it("keeps the configured runtime timeout active after user detach", async () => {
+		mockPi.onCall({ delay: 10_000 });
+		let recoveredResult: RunSyncResult | undefined;
+		const startedAt = Date.now();
+
+		const result = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Do not run forever", {
+			runId: "user-detach-timeout",
+			timeoutMs: 150,
+			acceptance: false,
+			onDetachReady: (detach: (reason?: string) => boolean) => {
+				assert.equal(detach("user request"), true);
+			},
+			onDetachedExit: (postExit) => { recoveredResult = postExit as RunSyncResult; },
+		});
+
+		assert.equal(result.detached, true);
+		assert.ok(Date.now() - startedAt < 1_000, "detach should release the foreground waiter promptly");
+		for (let attempt = 0; attempt < 300 && !recoveredResult; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(recoveredResult, "configured timeout should terminate and recover the detached child");
+		assert.equal(recoveredResult.timedOut, true);
+		assert.equal(recoveredResult.error, "Subagent timed out after 150ms.");
+		assert.equal(recoveredResult.progress.status, "failed");
+		assert.ok(Date.now() - startedAt < 5_000, "detached child should remain bounded by runtime enforcement");
+	});
+
 	for (const toolName of ["intercom", "contact_supervisor"]) {
 		it(`detaches cleanly on ${toolName} handoff without aborting the child process`, async () => {
 			const eventBus = createEventBus();
@@ -3323,6 +3781,106 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			assert.equal(accepted, true);
 		});
 	}
+
+	it("reports intercom detach race losses and repeated requests as not accepted", async () => {
+		const abortBus = createEventBus();
+		const abortResponses: boolean[] = [];
+		abortBus.on(INTERCOM_DETACH_RESPONSE_EVENT, (payload) => abortResponses.push((payload as { accepted: boolean }).accepted));
+		mockPi.onCall({ steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need decision" })] }, { delay: 10_000 }] });
+		const origin = new AbortController();
+		let requested = false;
+		const abortedResult = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "intercom-abort-race-loss",
+			allowIntercomDetach: true,
+			intercomEvents: abortBus,
+			signal: origin.signal,
+			onUpdate: (update) => {
+				if (requested || !update.details?.progress?.some((item) => item.currentTool === "contact_supervisor")) return;
+				requested = true;
+				origin.abort();
+				abortBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "abort-race" });
+			},
+		});
+		assert.equal(abortedResult.detached, undefined);
+		assert.deepEqual(abortResponses, [false]);
+
+		const repeatedBus = createEventBus();
+		const repeatedResponses: boolean[] = [];
+		repeatedBus.on(INTERCOM_DETACH_RESPONSE_EVENT, (payload) => repeatedResponses.push((payload as { accepted: boolean }).accepted));
+		mockPi.onCall({ steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need decision" })] }, { delay: 50, jsonl: [events.assistantMessage("done")] }] });
+		let repeated = false;
+		const repeatedReceipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "intercom-repeated-detach",
+			allowIntercomDetach: true,
+			intercomEvents: repeatedBus,
+			onUpdate: (update) => {
+				if (repeated || !update.details?.progress?.some((item) => item.currentTool === "contact_supervisor")) return;
+				repeated = true;
+				repeatedBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "first" });
+				repeatedBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "second" });
+			},
+		});
+		assert.equal(repeatedReceipt.detached, true);
+		assert.deepEqual(repeatedResponses, [true, false]);
+	});
+
+	it("does not launch retries or fallbacks after intercom detach and keeps timeout enforcement", async () => {
+		const fallbackBus = createEventBus();
+		mockPi.onCall({
+			steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need decision" })] }],
+			stderr: "rate limit exceeded",
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "must not launch" });
+		let resolveFallbackTerminal!: (result: RunSyncResult) => void;
+		const fallbackTerminal = new Promise<RunSyncResult>((resolve) => { resolveFallbackTerminal = resolve; });
+		let fallbackRequested = false;
+		const receipt = await runSync(tempDir, [makeAgent("echo", { model: "openai/gpt-5-mini", fallbackModels: ["anthropic/claude-sonnet-4"] })], "echo", "Task", {
+			runId: "intercom-no-fallback",
+			acceptance: false,
+			allowIntercomDetach: true,
+			intercomEvents: fallbackBus,
+			onUpdate: (update) => {
+				if (fallbackRequested || !update.details?.progress?.some((item) => item.currentTool === "contact_supervisor")) return;
+				fallbackRequested = true;
+				fallbackBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "no-fallback" });
+			},
+			onDetachedExit: (result) => { resolveFallbackTerminal(result as RunSyncResult); },
+		});
+		assert.equal(receipt.detached, true);
+		const fallbackResult = await fallbackTerminal;
+		assert.equal(mockPi.callCount(), 1);
+		assert.equal(fallbackResult.exitCode, 1);
+
+		const timeoutBus = createEventBus();
+		mockPi.reset();
+		mockPi.onCall({ delay: 10_000 });
+		let resolveTimeoutTerminal!: (result: RunSyncResult) => void;
+		const timeoutTerminal = new Promise<RunSyncResult>((resolve) => { resolveTimeoutTerminal = resolve; });
+		let timeoutRequested = false;
+		const timeoutReceipt = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Task", {
+			runId: "intercom-timeout-enforced",
+			acceptance: false,
+			timeoutMs: 125,
+			allowIntercomDetach: true,
+			intercomEvents: timeoutBus,
+			onDetachReady: () => {
+				if (timeoutRequested) return;
+				timeoutRequested = true;
+				timeoutBus.emit(INTERCOM_DETACH_REQUEST_EVENT, {
+					requestId: "timeout",
+					runId: "intercom-timeout-enforced",
+					agent: "slow",
+					childIndex: 0,
+				});
+			},
+			onDetachedExit: (result) => { resolveTimeoutTerminal(result as RunSyncResult); },
+		});
+		assert.equal(timeoutReceipt.detached, true);
+		const timeoutResult = await timeoutTerminal;
+		assert.equal(timeoutResult.timedOut, true);
+		assert.equal(timeoutResult.exitCode, 1);
+	});
 
 	it("enforces the stdout protocol limit after foreground detachment", async () => {
 		const eventBus = createEventBus();

--- a/test/unit/foreground-control.test.ts
+++ b/test/unit/foreground-control.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { AgentProgress, ForegroundRunControl } from "../../src/shared/types.ts";
-import { beginForegroundChild, finishForegroundChild, updateForegroundChild } from "../../src/runs/foreground/foreground-control.ts";
+import {
+	beginForegroundChild,
+	finishForegroundChild,
+	foregroundSchedulingSettled,
+	retainForegroundSchedulingOwner,
+	settleForegroundSchedulingOwner,
+	updateForegroundChild,
+} from "../../src/runs/foreground/foreground-control.ts";
 
 function progress(index: number, agent: string, tokens: number): AgentProgress {
 	return {
@@ -72,5 +79,22 @@ describe("foreground child control", () => {
 		assert.equal(control.inputTokens, undefined);
 		assert.equal(control.outputTokens, undefined);
 		assert.equal(control.interrupt, undefined);
+	});
+
+	it("settles scheduling only after every owner releases", () => {
+		const control: ForegroundRunControl = {
+			runId: "owned-run",
+			mode: "parallel",
+			startedAt: 1,
+			updatedAt: 1,
+			schedulingOwners: 1,
+		};
+
+		retainForegroundSchedulingOwner(control);
+		settleForegroundSchedulingOwner(control);
+		assert.equal(foregroundSchedulingSettled(control), false);
+		settleForegroundSchedulingOwner(control);
+		assert.equal(foregroundSchedulingSettled(control), true);
+		assert.equal(control.schedulingOwners, 0);
 	});
 });

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -472,11 +472,13 @@ describe("completion formatting helpers", () => {
 		notifier.dispose();
 	});
 
-	it("buildCompletionDetails derives paused and stopped statuses", () => {
-		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, state: "paused", summary: "Paused after interrupt.", timestamp: 1 }).status, "paused");
+	it("buildCompletionDetails derives lifecycle statuses before using exit code", () => {
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, state: "paused", interrupted: true, summary: "Paused after interrupt.", timestamp: 1 }).status, "paused");
 		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "boom", exitCode: 1, timestamp: 1 }).status, "failed");
-		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "terminated", exitCode: 1, processSignal: "SIGTERM", timestamp: 1 }).status, "stopped");
-		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "terminated", results: [{ success: false, exitCode: 1, processSignal: "SIGTERM" }], timestamp: 1 }).status, "stopped");
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "terminated", exitCode: 0, processSignal: "SIGTERM", timestamp: 1 }).status, "stopped");
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "timed out", exitCode: 0, timedOut: true, timestamp: 1 }).status, "failed");
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "budget exceeded", exitCode: 0, turnBudgetExceeded: true, timestamp: 1 }).status, "failed");
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "terminated", results: [{ success: false, exitCode: 0, processSignal: "SIGTERM" }], timestamp: 1 }).status, "stopped");
 		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: true, summary: "ok", exitCode: 0, processSignal: "SIGTERM", timestamp: 1 }).status, "completed");
 	});
 

--- a/test/unit/parallel-utils.test.ts
+++ b/test/unit/parallel-utils.test.ts
@@ -153,6 +153,28 @@ describe("mapConcurrent", () => {
 		assert.ok(d2 < 20, `worker 2 should start immediately, got ${d2}ms delay`);
 	});
 
+	it("notifies scheduling settlement only after workers outliving an early rejection stop", async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => { release = resolve; });
+		const started: number[] = [];
+		let schedulingSettled = false;
+		const run = mapConcurrent([0, 1, 2], 2, async (item) => {
+			started.push(item);
+			if (item === 0) throw new Error("early rejection");
+			await gate;
+			return item;
+		}, undefined, () => { schedulingSettled = true; });
+
+		await assert.rejects(run, /early rejection/);
+		assert.equal(schedulingSettled, false);
+		release();
+		for (let attempt = 0; attempt < 20 && !schedulingSettled; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		assert.equal(schedulingSettled, true);
+		assert.deepEqual(started, [0, 1, 2]);
+	});
+
 	it("respects a shared global semaphore across simultaneous calls", async () => {
 		const globalSemaphore = new Semaphore(2);
 		let running = 0;

--- a/test/unit/result-intercom.test.ts
+++ b/test/unit/result-intercom.test.ts
@@ -217,10 +217,13 @@ describe("result intercom formatter", () => {
 		assert.equal(stripped.results[0]?.truncation, undefined);
 	});
 
-	it("resolves paused, detached, and signal-terminated statuses", () => {
-		assert.equal(resolveSubagentResultStatus({ interrupted: true }), "paused");
+	it("resolves lifecycle terminal statuses before inferring success from exit code", () => {
+		assert.equal(resolveSubagentResultStatus({ interrupted: true, exitCode: 0 }), "paused");
+		assert.equal(resolveSubagentResultStatus({ stopped: true, exitCode: 0 }), "stopped");
+		assert.equal(resolveSubagentResultStatus({ timedOut: true, exitCode: 0 }), "failed");
+		assert.equal(resolveSubagentResultStatus({ turnBudgetExceeded: true, exitCode: 0 }), "failed");
 		assert.equal(resolveSubagentResultStatus({ detached: true }), "detached");
-		assert.equal(resolveSubagentResultStatus({ processSignal: "SIGTERM", exitCode: 1 }), "stopped");
+		assert.equal(resolveSubagentResultStatus({ processSignal: "SIGTERM", exitCode: 0 }), "stopped");
 		assert.equal(resolveSubagentResultStatus({ processSignal: "SIGTERM", exitCode: 1, timedOut: true }), "failed");
 		assert.equal(resolveSubagentResultStatus({ processSignal: "SIGTERM", exitCode: 0, success: true }), "completed");
 		assert.equal(resolveSubagentResultStatus({ success: true }), "completed");


### PR DESCRIPTION
## Summary

- separate the immediate foreground-detach receipt from authoritative terminal completion
- keep timeout, explicit interrupt, fallback, structured output, acceptance, contracts, artifacts, and metadata active after detach
- harden existing intercom/supervisor detach recovery and terminal notification classification

## Problem

The existing intercom detach path resolved `runSingleAttempt()` / `runSync()` at the detach boundary. The child process could continue, but the normal finalization pipeline had already returned. This allowed detached runs to bypass structured-output validation, completion guards, fallback aggregation, output persistence, contract projections, and authoritative terminal metadata.

It also made generic user-triggered detach unsafe to expose.

## Approach

- race an isolated receipt against a separate authoritative completion promise
- keep the entire attempt/fallback/finalization pipeline alive after receipt delivery
- deep-clone published receipts so caller mutation cannot affect terminal state
- make receipt publication transactional and contain callback/persistence failures
- retain explicit interrupt and configured runtime enforcement after detach
- keep supervisor/intercom handoffs from launching replacement fallback attempts
- terminalize process errors and post-receipt pipeline failures exactly once
- derive paused/stopped/timed-out/success/error status from lifecycle flags before exit code

## Semantic changes and safety

This hardens existing foreground/intercom behavior beyond the new command proposed in #708:

- originating request abort is no longer forwarded after an accepted detach, while explicit interrupt and configured timeout remain active
- user-requested detach may continue normal model retries/fallbacks; supervisor handoff keeps its no-fallback behavior
- expected artifact, acceptance, and metadata failures become result fields/ledgers instead of orphaning a detached run or rejecting some attached paths
- lifecycle flags take precedence over exit code for terminal classification
- completion remains same-runtime only; this does not daemonize or migrate work into the async runner

## Test plan

- receipt isolation and duplicate/late/racing detach
- attached versus detached terminal-result parity
- startup retry and model fallback after user detach
- supervisor handoff no-fallback compatibility
- timeout, protocol, turn-budget, drain, and explicit-interrupt enforcement
- structured output, output files/file-only mode, mutation guards, acceptance, and contract projections
- artifact/metadata errors and synthetic terminal fallback
- process close/error and exactly-once completion events
- notification/intercom lifecycle classification
- focused post-rebase unit and integration coverage passed
- E2E on the complete stack: 3 passed
- independent post-rebase review: clean

## Stack

Depends on #709. GitHub will show the prerequisite commit in this draft until #709 merges; the lifecycle commit itself is `003c9def`.

Part 2 of the implementation proposed in #708.
