### PR TITLE
feat: add /subagents-detach for active single runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Skip this section until you want exact syntax.
 | `/subagent-cost` | Show parent plus child subagent token usage and cost for this session |
 | `/subagents [agent] [model\|thinking\|prompt\|details]` | Interactively inspect or edit an agent's model, thinking level, or system prompt |
 | `/subagents-doctor` | Show read-only setup diagnostics |
+| `/subagents-detach [run-id]` | Release the wait for an active foreground single-subagent run without terminating it |
 | `/subagents-models [agent]` | Show the runtime-loaded builtin model mapping, optionally filtered to one builtin |
 | `/subagents-watchdog [status|on|off|recommend-model|model ...|session model ...|check]` | Show or configure the opt-in watchdog; use a strong complementary model such as Opus 4.8 high or GPT 5.5 high |
 | `/subagents-profiles` | List saved subagent profiles from `~/.pi/agent/profiles/pi-subagents/` |
@@ -496,6 +497,8 @@ Skip this section until you want exact syntax.
 | `/subagents-check-profile <name>` | Check a saved profile against the current registry and live model probes |
 
 Commands validate agent names locally, support tab completion, and send results back into the conversation.
+
+`/subagents-detach` is limited to active foreground single-subagent runs. It releases the current foreground wait while the existing child stays observed through `status`/`subagent_wait` and can still emit completion; its configured runtime timeout, turn budget, watchdog, and lifecycle drain enforcement remain active until exit. This is same-runtime only: it does not migrate the child into the detached async runner, daemonize it, support process adoption, or guarantee survival across Pi reload/restart.
 
 `/subagents` opens a compact administration flow for builtin, package, user, and project agents. Model choices refresh Pi's model registry first, thinking choices are filtered to levels declared by the selected model, and prompt editing uses Pi's native multiline editor; press Ctrl+G to open the configured external editor. Full metadata is opt-in through `details`. Edits are persisted to the field-owning layer: explicit custom-agent frontmatter remains in the agent file, while settings/profile-managed fields remain in `settings.subagents.agentOverrides`. Package-owned fields and definitions loaded through `PI_SUBAGENT_EXTRA_AGENT_DIRS` stay read-only; settings can still supply model or thinking fields omitted by a package definition.
 

--- a/src/intercom/result-intercom.ts
+++ b/src/intercom/result-intercom.ts
@@ -30,8 +30,9 @@ export function resolveSubagentResultStatus(input: {
 	if (input.detached) return "detached";
 	if (input.stopped || input.state === "stopped") return "stopped";
 	if (input.interrupted || input.state === "paused") return "paused";
+	if (input.timedOut || input.turnBudgetExceeded) return "failed";
 	if (input.success === true) return "completed";
-	if (isUnexplainedProcessSignal(input) && input.exitCode !== 0) return "stopped";
+	if (isUnexplainedProcessSignal(input)) return "stopped";
 	if (input.success === false) return "failed";
 	if (input.state === "complete") return "completed";
 	if (input.state === "failed") return "failed";

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -17,6 +17,7 @@ import {
 import { readStatus } from "../../shared/utils.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { contextModeLabel, summarizeContextModes } from "../shared/context-mode.ts";
+import { detachedChildrenRequireSupervisor } from "../shared/foreground-detach.ts";
 import { formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 
 const DEFAULT_TRANSCRIPT_LINES = 80;
@@ -265,7 +266,9 @@ function formatDetachedForegroundFleetLines(runs: ForegroundRun[]): string[] {
 		const childSummary = detachedChildren.map((child) => `${child.agent} #${child.index}`).join(", ");
 		lines.push(`- ${run.runId} | detached | ${run.mode}${childSummary ? ` | ${childSummary}` : ""}`);
 		lines.push(`  status: subagent({ action: "status", id: "${run.runId}" })`);
-		lines.push(`  recovery: reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); do not resume or launch a replacement while any child remains detached.`);
+		lines.push(detachedChildrenRequireSupervisor(detachedChildren)
+			? `  recovery: reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); do not resume or launch a replacement while any child remains detached.`
+			: `  recovery: detached at user request; wait with subagent_wait({ id: "${run.runId}" }) or inspect status. Do not resume or launch a replacement while its child remains live.`);
 	}
 	return lines;
 }
@@ -333,11 +336,12 @@ export function inspectSubagentFleet(_params: FleetViewParams, deps: FleetViewDe
 		return { content: [{ type: "text", text: message }], isError: true, details: { mode: "management", results: [] } };
 	}
 
-	const foregroundControls = deps.state ? [...deps.state.foregroundControls.values()] : [];
-	const activeForegroundIds = new Set(foregroundControls.map((control) => control.runId));
+	const allForegroundControls = deps.state ? [...deps.state.foregroundControls.values()] : [];
 	const detachedForegroundRuns = deps.state?.foregroundRuns
-		? [...deps.state.foregroundRuns.values()].filter((run) => run.sessionId === deps.state?.currentSessionId && !activeForegroundIds.has(run.runId) && run.children.some((child) => child.status === "detached"))
+		? [...deps.state.foregroundRuns.values()].filter((run) => run.sessionId === deps.state?.currentSessionId && run.children.some((child) => child.status === "detached"))
 		: [];
+	const detachedForegroundIds = new Set(detachedForegroundRuns.map((run) => run.runId));
+	const foregroundControls = allForegroundControls.filter((control) => !detachedForegroundIds.has(control.runId));
 	const total = foregroundControls.length + detachedForegroundRuns.length + asyncRuns.length;
 	if (total === 0) {
 		return {

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -197,12 +197,13 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 	const summary = typeof result.summary === "string" ? result.summary : "";
 	const stopped = result.stopped === true
 		|| result.state === "stopped"
-		|| (result.success !== true && result.exitCode !== 0 && isUnexplainedProcessSignal(result))
+		|| (result.success !== true && isUnexplainedProcessSignal(result))
 		|| result.results?.some((child) => child.stopped === true
 			|| child.status === "stopped"
-			|| (child.success !== true && child.exitCode !== 0 && isUnexplainedProcessSignal(child))) === true;
-	const paused = !stopped && !result.success && (
-		result.exitCode === 0
+			|| (child.success !== true && isUnexplainedProcessSignal(child))) === true;
+	const paused = !stopped && !result.success && !result.timedOut && !result.turnBudgetExceeded && (
+		result.interrupted === true
+		|| result.exitCode === 0
 		|| result.state === "paused"
 		|| summary.startsWith("Paused after interrupt.")
 	);

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -15,6 +15,7 @@ import { resolveSubagentRunId } from "./run-id-resolver.ts";
 import { flatToLogicalStepIndex, normalizeParallelGroups } from "./parallel-groups.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
 import { attachRootChildrenToSteps, findNestedRouteForRootId, projectNestedRegistryForRoot, type NestedRunResolutionScope } from "../shared/nested-events.ts";
+import { detachedChildrenRequireSupervisor } from "../shared/foreground-detach.ts";
 
 interface RunStatusParams {
 	action?: "status";
@@ -139,7 +140,9 @@ function formatRememberedForegroundStatus(run: ForegroundResumeRun): string {
 		return lines.join("\n");
 	}
 	if (detached) {
-		lines.push(`Recovery: reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); do not resume or launch a replacement while any child remains detached.`);
+		lines.push(detachedChildrenRequireSupervisor(run.children)
+			? `Recovery: reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); do not resume or launch a replacement while any child remains detached.`
+			: `Recovery: this run was detached at user request. Wait with subagent_wait({ id: "${run.runId}" }) or inspect status; do not resume or launch a replacement while its child remains live.`);
 	} else if (resumable) {
 		lines.push(run.children.length === 1
 			? `Revive: subagent({ action: "resume", id: "${run.runId}", message: "..." })`

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -61,6 +61,7 @@ import {
 	type SubagentState,
 } from "../../shared/types.ts";
 import { formatDuration } from "../../shared/formatters.ts";
+import { detachedChildActivityLabel, detachedChildrenRequireSupervisor } from "../shared/foreground-detach.ts";
 export { WAIT_TOOL_ENABLED_ENV, resolveWaitToolConfig, type ResolvedWaitToolConfig } from "./wait-config.ts";
 
 /** States that mean a run is still in flight (not yet resolved). */
@@ -225,8 +226,11 @@ function foregroundChildrenNeedingAttention(run: ForegroundResumeRun, indices: S
 
 function formatForegroundAttention(run: ForegroundResumeRun, children: ReturnType<typeof foregroundChildrenNeedingAttention>, elapsedMs: number): AgentToolResult<Details> {
 	const childList = children.map((child) => `${child.agent}${child.index !== undefined ? `#${child.index}` : ""}`).join(", ");
+	const guidance = detachedChildrenRequireSupervisor(children)
+		? `Reply to any pending supervisor request, then call subagent_wait({ id: "${run.runId}" }) again or inspect status; do not resume or launch a replacement while it remains detached.`
+		: `Inspect status, then call subagent_wait({ id: "${run.runId}" }) again; this user-detached child is not waiting for a supervisor reply and must not be resumed or replaced while still live.`;
 	return result(
-		`Waited ${formatDuration(elapsedMs)} for remembered detached foreground run "${run.runId}"; attention required. ${children.length} child run(s) need attention: ${childList}. Reply to any pending supervisor request, then call subagent_wait({ id: "${run.runId}" }) again or inspect status; do not resume or launch a replacement while it remains detached.`,
+		`Waited ${formatDuration(elapsedMs)} for remembered detached foreground run "${run.runId}"; attention required. ${children.length} child run(s) need attention: ${childList}. ${guidance}`,
 	);
 }
 
@@ -391,7 +395,7 @@ function detachedForegroundWaitUpdate(run: ForegroundResumeRun, pendingIndices: 
 		if (!pendingIndices.has(child.index) || child.status !== "detached") continue;
 		const activity = readTranscriptActivity(child.transcriptPath);
 		const age = activity?.latestAt !== undefined ? ` · activity ${formatDuration(Math.max(0, nowMs - activity.latestAt))} ago` : "";
-		lines.push(`${child.agent} · working after supervisor handoff${age}`);
+		lines.push(`${child.agent} · ${detachedChildActivityLabel(child)}${age}`);
 		if (activity?.currentTool) {
 			lines.push(`  current: ${activity.currentTool}${activity.currentToolArgs ? `: ${activity.currentToolArgs}` : ""}`);
 		}
@@ -414,7 +418,10 @@ async function waitForDetachedForegroundRun(
 	const initialDetachedIndices = new Set(run.children.filter((child) => child.status === "detached").map((child) => child.index));
 	while (true) {
 		if (deps.state.currentSessionId !== run.sessionId) {
-			return result(`Wait stopped because the active session changed while remembered foreground run "${run.runId}" was still detached. Return to the originating session to inspect or wait for it. Reply to any pending supervisor request before resuming or launching a replacement.`, true);
+			const guidance = detachedChildrenRequireSupervisor(run.children)
+				? "Reply to any pending supervisor request before resuming or launching a replacement."
+				: "This user-detached run is not waiting for a supervisor reply; do not resume or launch a replacement while its child may still be live.";
+			return result(`Wait stopped because the active session changed while remembered foreground run "${run.runId}" was still detached. Return to the originating session to inspect or wait for it. ${guidance}`, true);
 		}
 		const current = deps.state.foregroundRuns?.get(run.runId);
 		if (!current || current.sessionId !== run.sessionId) {
@@ -432,11 +439,17 @@ async function waitForDetachedForegroundRun(
 		const updateNow = now();
 		deps.onUpdate?.(detachedForegroundWaitUpdate(current, initialDetachedIndices, updateNow, updateNow - startedAt));
 		if (signal?.aborted) {
-			return result(`Wait aborted after ${formatDuration(now() - startedAt)}. Remembered foreground run "${run.runId}" remains detached. Reply to any pending supervisor request before resuming or launching a replacement.`, true);
+			const guidance = detachedChildrenRequireSupervisor(pending)
+				? "Reply to any pending supervisor request before resuming or launching a replacement."
+				: "This user-detached run is not waiting for a supervisor reply; do not resume or launch a replacement while its child remains live.";
+			return result(`Wait aborted after ${formatDuration(now() - startedAt)}. Remembered foreground run "${run.runId}" remains detached. ${guidance}`, true);
 		}
 		if (now() - startedAt >= timeoutMs) {
+			const guidance = detachedChildrenRequireSupervisor(pending)
+				? `Reply to any pending supervisor request, then call subagent_wait({ id: "${run.runId}" }) again or inspect status; do not resume or launch a replacement while it remains detached.`
+				: `This user-detached run is not waiting for a supervisor reply. Call subagent_wait({ id: "${run.runId}" }) again or inspect status; do not resume or launch a replacement while its child remains live.`;
 			return result(
-				`Wait timed out after ${formatDuration(timeoutMs)} with remembered foreground run "${run.runId}" still detached. Reply to any pending supervisor request, then call subagent_wait({ id: "${run.runId}" }) again or inspect status; do not resume or launch a replacement while it remains detached.`,
+				`Wait timed out after ${formatDuration(timeoutMs)} with remembered foreground run "${run.runId}" still detached. ${guidance}`,
 				true,
 			);
 		}

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -34,7 +34,13 @@ import {
 import { discoverAvailableSkills, normalizeSkillInput } from "../../agents/skills.ts";
 import { INTERCOM_BRIDGE_MARKER } from "../../intercom/intercom-bridge.ts";
 import { runSync } from "./execution.ts";
-import { beginForegroundChild, finishForegroundChild, updateForegroundChild } from "./foreground-control.ts";
+import {
+	beginForegroundChild,
+	finishForegroundChild,
+	retainForegroundSchedulingOwner,
+	settleForegroundSchedulingOwner,
+	updateForegroundChild,
+} from "./foreground-control.ts";
 import { buildChainSummary } from "../../shared/formatters.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
@@ -153,6 +159,8 @@ interface ParallelChainRunInput {
 	turnBudget?: ResolvedTurnBudget;
 	usageBudget?: UsageBudgetConfig;
 	onDetachedExit?: (index: number, result: SingleResult) => void;
+	/** Called after an attached child releases its foreground ownership. */
+	onForegroundChildSettled?: () => void;
 	toolBudget?: ResolvedToolBudget;
 	configToolBudget?: ToolBudgetConfig;
 	globalSemaphore?: Semaphore;
@@ -287,6 +295,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 	}
 
 	const completedResults: SingleResult[] = [];
+	if (input.foregroundControl) retainForegroundSchedulingOwner(input.foregroundControl);
 	const parallelResults = await mapConcurrent(
 		input.step.parallel,
 		concurrency,
@@ -364,7 +373,9 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				? createStructuredOutputRuntime(task.outputSchema, path.join(input.chainDir, "structured-output"))
 				: undefined;
 			const agentContract = task.agentContract ?? input.step.agentContract ?? input.agentContract;
-			const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
+			let result!: SingleResult;
+			try {
+				result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
 				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 				capabilityCeiling: input.capabilityCeiling,
 				context: input.contextForAgent?.(task.agent),
@@ -402,9 +413,13 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				timeoutMs: input.timeoutMs,
 				deadlineAt: input.deadlineAt,
 				turnBudget: input.turnBudget,
-				onDetachedExit: input.onDetachedExit
-					? (result) => input.onDetachedExit?.(childIndex, result)
-					: undefined,
+				onDetachedExit: (result) => {
+					try {
+						if (input.foregroundControl) finishForegroundChild(input.foregroundControl, childIndex);
+					} finally {
+						input.onDetachedExit?.(childIndex, result);
+					}
+				},
 				toolBudget: toolBudget.toolBudget,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
@@ -438,8 +453,15 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 						});
 					}
 					: undefined,
-			});
-			if (input.foregroundControl) finishForegroundChild(input.foregroundControl, childIndex);
+				});
+			} finally {
+				// Rejected attached attempts still release their parallel child control;
+				// detached receipts transfer ownership to onDetachedExit.
+				if (!result?.detached) {
+					if (input.foregroundControl) finishForegroundChild(input.foregroundControl, childIndex);
+					input.onForegroundChildSettled?.();
+				}
+			}
 
 			if (result.exitCode !== 0 && failFast) {
 				aborted = true;
@@ -449,6 +471,10 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 			return result;
 		},
 		input.globalSemaphore,
+		() => {
+			if (input.foregroundControl) settleForegroundSchedulingOwner(input.foregroundControl);
+			input.onForegroundChildSettled?.();
+		},
 	);
 
 	return parallelResults;
@@ -493,6 +519,8 @@ interface ChainExecutionParams {
 	deadlineAt?: number;
 	turnBudget?: ResolvedTurnBudget;
 	onDetachedExit?: (index: number, result: SingleResult) => void;
+	/** Ownership callback used when parallel siblings outlive executeChain rejection. */
+	onForegroundChildSettled?: () => void;
 	toolBudget?: ResolvedToolBudget;
 	usageBudget?: UsageBudgetConfig;
 	configToolBudget?: ToolBudgetConfig;
@@ -817,6 +845,7 @@ ${step.message}` : ""}` }],
 					turnBudget: params.turnBudget,
 					usageBudget: params.usageBudget,
 					onDetachedExit,
+					onForegroundChildSettled: params.onForegroundChildSettled,
 					toolBudget: params.toolBudget,
 					configToolBudget: params.configToolBudget,
 					globalSemaphore,
@@ -1074,6 +1103,7 @@ ${step.message}` : ""}` }],
 				turnBudget: params.turnBudget,
 				usageBudget: params.usageBudget,
 				onDetachedExit,
+				onForegroundChildSettled: params.onForegroundChildSettled,
 				toolBudget: params.toolBudget,
 				configToolBudget: params.configToolBudget,
 				globalSemaphore,
@@ -1278,28 +1308,30 @@ ${step.message}` : ""}` }],
 				});
 			}
 
-			const structuredRuntime = seqStep.outputSchema
-				? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
-				: undefined;
 			const agentContract = seqStep.agentContract ?? params.agentContract;
-			const toolBudget = resolveChainToolBudget({ stepBudget: seqStep.toolBudget, runBudget: params.toolBudget, agentBudget: agentConfig?.toolBudget, configBudget: params.configToolBudget });
-			if (toolBudget.error) return buildChainExecutionErrorResult(toolBudget.error, {
-				results,
-				includeProgress,
-				allProgress,
-				allArtifactPaths,
-				artifactsDir: params.artifactsDir,
-				chainAgents,
-				chainSteps,
-				totalSteps,
-				currentStepIndex: stepIndex,
-				runId: params.runId,
-				outputs,
-				currentFlatIndex: globalTaskIndex,
-				dynamicChildren,
-				dynamicGroupStatuses,
-			});
-			const r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
+			let r!: SingleResult;
+			try {
+				const structuredRuntime = seqStep.outputSchema
+					? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
+					: undefined;
+				const toolBudget = resolveChainToolBudget({ stepBudget: seqStep.toolBudget, runBudget: params.toolBudget, agentBudget: agentConfig?.toolBudget, configBudget: params.configToolBudget });
+				if (toolBudget.error) return buildChainExecutionErrorResult(toolBudget.error, {
+					results,
+					includeProgress,
+					allProgress,
+					allArtifactPaths,
+					artifactsDir: params.artifactsDir,
+					chainAgents,
+					chainSteps,
+					totalSteps,
+					currentStepIndex: stepIndex,
+					runId: params.runId,
+					outputs,
+					currentFlatIndex: globalTaskIndex,
+					dynamicChildren,
+					dynamicGroupStatuses,
+				});
+				r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
 				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				capabilityCeiling: params.capabilityCeiling,
 				context: params.contextForAgent?.(seqStep.agent),
@@ -1337,9 +1369,13 @@ ${step.message}` : ""}` }],
 				timeoutMs: params.timeoutMs,
 				deadlineAt,
 				turnBudget: params.turnBudget,
-				onDetachedExit: onDetachedExit
-					? (result) => onDetachedExit(childIndex, result)
-					: undefined,
+				onDetachedExit: (result) => {
+					try {
+						if (foregroundControl) finishForegroundChild(foregroundControl, childIndex);
+					} finally {
+						onDetachedExit?.(childIndex, result);
+					}
+				},
 				toolBudget: toolBudget.toolBudget,
 				onUpdate: onUpdate
 					? (p) => {
@@ -1373,8 +1409,15 @@ ${step.message}` : ""}` }],
 						});
 					}
 					: undefined,
-			});
-			if (foregroundControl) finishForegroundChild(foregroundControl, childIndex);
+				});
+			} finally {
+				// Rejected attempts and early validation returns release the child here.
+				// A detached receipt transfers cleanup ownership to onDetachedExit.
+				if (!r?.detached) {
+					if (foregroundControl) finishForegroundChild(foregroundControl, childIndex);
+					params.onForegroundChildSettled?.();
+				}
+			}
 			recordRun(seqStep.agent, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
 
 			globalTaskIndex++;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -122,6 +122,46 @@ function sumUsage(target: Usage, source: Usage): void {
 	target.turns += source.turns;
 }
 
+function persistSingleResultMetadata(input: {
+	metadataPath?: string;
+	enabled: boolean;
+	runId?: string;
+	agent: string;
+	task: string;
+	result: SingleResult;
+}): void {
+	if (!input.enabled || !input.metadataPath) return;
+	const target = input.result;
+	writeMetadata(input.metadataPath, {
+		runId: input.runId,
+		agent: input.agent,
+		task: input.task,
+		exitCode: target.exitCode,
+		processSignal: target.processSignal,
+		usage: target.usage,
+		model: target.model,
+		attemptedModels: target.attemptedModels,
+		modelAttempts: target.modelAttempts,
+		durationMs: target.progressSummary?.durationMs,
+		toolCount: target.progressSummary?.toolCount,
+		error: target.error,
+		agentContract: target.agentContract,
+		launchContractDigest: target.launchContractDigest,
+		launchResolvedExtensions: target.launchResolvedExtensions,
+		execution: target.execution,
+		acceptance: target.acceptance,
+		capabilityCeiling: target.capabilityCeiling,
+		capabilityAudit: target.capabilityAudit,
+		review: target.review,
+		effects: target.effects,
+		transcriptPath: target.transcriptPath,
+		transcriptError: target.transcriptError,
+		skills: target.skills,
+		skillsWarning: target.skillsWarning,
+		timestamp: Date.now(),
+	});
+}
+
 function formatTimeoutMessage(timeoutMs: number): string {
 	return `Subagent timed out after ${timeoutMs}ms.`;
 }
@@ -147,6 +187,21 @@ function buildPendingAcceptanceLedger(acceptance: ResolvedAcceptanceConfig): Acc
 		runtimeChecks: [],
 		verifyRuns: [],
 	};
+}
+
+function buildInterruptedAcceptanceLedger(acceptance: ResolvedAcceptanceConfig): AcceptanceLedger {
+	const pending = buildPendingAcceptanceLedger(acceptance);
+	if (acceptance.level === "none") {
+		pending.status = "not-required";
+		pending.evidenceStatus = "not-required";
+	} else {
+		pending.runtimeChecks = [{
+			id: "interrupted",
+			status: "not-applicable",
+			message: "Acceptance was not evaluated because the subagent was interrupted.",
+		}];
+	}
+	return pending;
 }
 
 function appendRecentOutput(progress: AgentProgress, lines: string[]): void {
@@ -204,7 +259,7 @@ function snapshotResult(result: SingleResult, progress: AgentProgress): SingleRe
  * unbounded `messages` transcript in favour of compact tool-call summaries so a
  * single `tool_execution_update` line stays well under the child-stdout protocol
  * cap (`MAX_CHILD_PENDING_LINE_BYTES`). Non-streaming consumers such as
- * detached-exit recovery call snapshotResult directly and keep the full transcript.
+ * foreground detach receipts and terminal consumers use snapshotResult directly.
  */
 function snapshotStreamResult(result: SingleResult, progress: AgentProgress): SingleResult {
 	const snapshot = snapshotResult(result, progress);
@@ -402,7 +457,7 @@ async function runSingleAttempt(
 		});
 		const jsonlWriter = createJsonlWriter(shared.jsonlPath, proc.stdout);
 		let processClosed = false;
-		let settled = false;
+		let lifecycleFinished = false;
 		let detached = false;
 		let intercomStarted = false;
 		let assistantError: string | undefined;
@@ -441,19 +496,43 @@ async function runSingleAttempt(
 			}
 		};
 
-		const detachForIntercom = () => {
-			detached = true;
-			processClosed = true;
-			result.detached = true;
-			result.detachedReason = "intercom coordination";
-			progress.status = "detached";
-			progress.durationMs = Date.now() - startTime;
-			result.progressSummary = {
-				toolCount: progress.toolCount,
-				tokens: progress.tokens,
-				durationMs: progress.durationMs,
+		const detachForeground = (reason: string): boolean => {
+			if (detached || processClosed || lifecycleFinished || options.signal?.aborted) return false;
+			const receiptProgress = snapshotProgress(progress);
+			receiptProgress.status = "detached";
+			receiptProgress.durationMs = Date.now() - startTime;
+			const receipt = snapshotResult(result, receiptProgress);
+			receipt.exitCode = -2;
+			receipt.detached = true;
+			receipt.detachedReason = reason;
+			receipt.finalOutput = reason === "intercom coordination"
+				? "Detached for intercom coordination before task completion."
+				: reason === "user request"
+					? "Detached at user request before task completion."
+					: `Detached for ${reason} before task completion.`;
+			receipt.outputMode = options.outputMode ?? "inline";
+			if (options.outputPath) {
+				receipt.outputSaveError = reason === "user request"
+					? "Output file was not finalized because the subagent detached at user request."
+					: `Output file was not finalized because the subagent detached for ${reason}.`;
+			}
+			receipt.progressSummary = {
+				toolCount: receiptProgress.toolCount,
+				tokens: receiptProgress.tokens,
+				durationMs: receiptProgress.durationMs,
 			};
-			finish(-2);
+			// The attempt is not detached until the outer coordinator has accepted and
+			// synchronously published the receipt. A persistence/callback failure must
+			// leave this attempt attached and abortable rather than orphaning it.
+			let accepted = false;
+			try {
+				accepted = options.onDetachReceipt?.(receipt) === true;
+			} catch {
+				return false;
+			}
+			if (!accepted) return false;
+			detached = true;
+			return true;
 		};
 
 		// If the child emits a terminal assistant stop but never exits,
@@ -494,9 +573,9 @@ async function runSingleAttempt(
 				armWatchdogTail();
 				return;
 			}
-			if (childExited || finalDrainTimer || settled || processClosed || detached) return;
+			if (childExited || finalDrainTimer || lifecycleFinished || processClosed) return;
 			finalDrainTimer = setTimeout(() => {
-				if (settled || processClosed || detached) return;
+				if (lifecycleFinished || processClosed) return;
 				const termSent = trySignalChild(proc, "SIGTERM");
 				if (!termSent) return;
 				forcedTerminationSignal = true;
@@ -504,7 +583,7 @@ async function runSingleAttempt(
 					result.error = result.error ?? `Subagent process did not exit within ${FINAL_STOP_GRACE_MS}ms after its terminal event. Forcing termination.`;
 				}
 				finalHardKillTimer = setTimeout(() => {
-					if (settled || processClosed || detached) return;
+					if (lifecycleFinished || processClosed) return;
 					forcedTerminationSignal = trySignalChild(proc, "SIGKILL") || forcedTerminationSignal;
 				}, HARD_KILL_MS);
 				finalHardKillTimer.unref?.();
@@ -512,7 +591,7 @@ async function runSingleAttempt(
 			finalDrainTimer.unref?.();
 		};
 		function armWatchdogTail(): void {
-			if ((!cleanTerminalAssistantStopReceived && !agentSettledReceived) || watchdogTailTimer || settled || processClosed || detached) return;
+			if ((!cleanTerminalAssistantStopReceived && !agentSettledReceived) || watchdogTailTimer || lifecycleFinished || processClosed) return;
 			watchdogTailTimer = setTimeout(() => {
 				watchdogTailTimer = undefined;
 				updateChildWatchdogState({
@@ -538,7 +617,7 @@ async function runSingleAttempt(
 		};
 
 		const unsubscribeIntercomDetach = options.intercomEvents?.on?.(INTERCOM_DETACH_REQUEST_EVENT, (payload) => {
-			if (!options.allowIntercomDetach || detached || processClosed) return;
+			if (!options.allowIntercomDetach || processClosed) return;
 			if (!payload || typeof payload !== "object") return;
 			const event = payload as { requestId?: unknown; runId?: unknown; agent?: unknown; childIndex?: unknown };
 			const requestId = event.requestId;
@@ -549,13 +628,13 @@ async function runSingleAttempt(
 				if (typeof event.agent === "string" && event.agent !== agent.name) return;
 				if (typeof event.childIndex === "number" && event.childIndex !== (options.index ?? 0)) return;
 			} else if (!intercomStarted) return;
-			options.intercomEvents?.emit(INTERCOM_DETACH_RESPONSE_EVENT, { requestId, accepted: true, runId: options.runId, agent: agent.name, childIndex: options.index ?? 0 });
-			detachForIntercom();
+			const accepted = detachForeground("intercom coordination");
+			options.intercomEvents?.emit(INTERCOM_DETACH_RESPONSE_EVENT, { requestId, accepted, runId: options.runId, agent: agent.name, childIndex: options.index ?? 0 });
 		});
 
 		const finish = (code: number) => {
-			if (settled) return;
-			settled = true;
+			if (lifecycleFinished) return;
+			lifecycleFinished = true;
 			clearFinalDrainTimers();
 			clearWatchdogTailTimer();
 			clearStdioGuard();
@@ -640,7 +719,7 @@ async function runSingleAttempt(
 		};
 		const requestTurnBudgetAbort = (turnCount: number) => {
 			const budget = options.turnBudget;
-			if (!budget || result.timedOut || result.turnBudgetExceeded || interruptedByControl || processClosed || settled || detached) return;
+			if (!budget || result.timedOut || result.turnBudgetExceeded || interruptedByControl || processClosed || lifecycleFinished) return;
 			const message = turnBudgetExceededMessage(budget, turnCount);
 			result.turnBudgetExceeded = true;
 			result.wrapUpRequested = true;
@@ -653,12 +732,12 @@ async function runSingleAttempt(
 			fireUpdate();
 			trySignalChild(proc, "SIGINT");
 			turnBudgetTerminationTimer = setTimeout(() => {
-				if (processClosed || settled || detached || result.timedOut) return;
+				if (processClosed || lifecycleFinished || result.timedOut) return;
 				trySignalChild(proc, "SIGTERM");
 			}, 1000);
 			turnBudgetTerminationTimer.unref?.();
 			turnBudgetHardKillTimer = setTimeout(() => {
-				if (processClosed || settled || detached || result.timedOut) return;
+				if (processClosed || lifecycleFinished || result.timedOut) return;
 				trySignalChild(proc, "SIGKILL");
 			}, 4000);
 			turnBudgetHardKillTimer.unref?.();
@@ -895,7 +974,7 @@ async function runSingleAttempt(
 
 		if (controlConfig.enabled) {
 			activityTimer = setInterval(() => {
-				if (processClosed || settled || detached) return;
+				if (processClosed || lifecycleFinished) return;
 				const now = Date.now();
 				if (updateActivityState(now)) {
 					progress.durationMs = now - startTime;
@@ -907,7 +986,7 @@ async function runSingleAttempt(
 
 		if (attemptTimeout) {
 			timeoutTimer = setTimeout(() => {
-				if (processClosed || settled || detached || interruptedByControl) return;
+				if (processClosed || lifecycleFinished || interruptedByControl) return;
 				result.timedOut = true;
 				result.error = attemptTimeout.message;
 				result.finalOutput = attemptTimeout.message;
@@ -917,12 +996,12 @@ async function runSingleAttempt(
 				fireUpdate();
 				trySignalChild(proc, "SIGINT");
 				timeoutTerminationTimer = setTimeout(() => {
-					if (processClosed || settled || detached) return;
+					if (processClosed || lifecycleFinished) return;
 					trySignalChild(proc, "SIGTERM");
 				}, 1000);
 				timeoutTerminationTimer.unref?.();
 				timeoutHardKillTimer = setTimeout(() => {
-					if (processClosed || settled || detached) return;
+					if (processClosed || lifecycleFinished) return;
 					trySignalChild(proc, "SIGKILL");
 				}, 4000);
 				timeoutHardKillTimer.unref?.();
@@ -966,6 +1045,8 @@ async function runSingleAttempt(
 			clearFinalDrainTimers();
 		});
 		proc.on("close", (code, signal) => {
+			if (lifecycleFinished) return;
+			processClosed = true;
 			clearFinalDrainTimers();
 			clearStdioGuard();
 			void jsonlWriter.close().catch(() => {
@@ -997,60 +1078,12 @@ async function runSingleAttempt(
 				closeError = stderr.trim();
 			}
 			const finalCode = forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
-			if (detached) {
-				const recoveredProgress = snapshotProgress(progress);
-				const recoveredResult = snapshotResult(result, recoveredProgress);
-				if (!recoveredResult.error && closeError) recoveredResult.error = closeError;
-				recoveredResult.exitCode = recoveredResult.error && finalCode === 0 ? 1 : finalCode;
-				recoveredProgress.status = recoveredResult.exitCode === 0 ? "completed" : "failed";
-				recoveredProgress.durationMs = Date.now() - startTime;
-				if (recoveredResult.error) recoveredProgress.error = recoveredResult.error;
-				recoveredResult.progressSummary = {
-					toolCount: recoveredProgress.toolCount,
-					tokens: recoveredProgress.tokens,
-					durationMs: recoveredProgress.durationMs,
-				};
-				const acceptanceOutput = getFinalOutput(recoveredResult.messages ?? []).trim()
-					|| recoveredResult.error
-					|| recoveredResult.finalOutput
-					|| "Detached child exited without final output.";
-				acceptanceOutputByResult.set(recoveredResult, acceptanceOutput);
-				let fullOutput = stripAcceptanceReport(acceptanceOutput);
-				fullOutput = fullOutput.trim() || recoveredResult.error || recoveredResult.finalOutput || "Detached child exited without final output.";
-				recoveredResult.outputMode = options.outputMode ?? "inline";
-				if (options.outputPath && recoveredResult.exitCode === 0) {
-					const resolvedOutput = resolveSingleOutput(options.outputPath, fullOutput, shared.outputSnapshot);
-					fullOutput = stripAcceptanceReport(resolvedOutput.fullOutput);
-					recoveredResult.savedOutputPath = resolvedOutput.savedPath;
-					recoveredResult.outputSaveError = resolvedOutput.saveError;
-					if (resolvedOutput.savedPath) {
-						recoveredResult.outputReference = formatSavedOutputReference(resolvedOutput.savedPath, fullOutput);
-					} else {
-						recoveredResult.exitCode = 1;
-						recoveredResult.error = `Output file was not finalized after detached child exit: ${resolvedOutput.saveError ?? options.outputPath}`;
-						recoveredProgress.status = "failed";
-						recoveredProgress.error = recoveredResult.error;
-					}
-				}
-				recoveredResult.finalOutput = options.outputMode === "file-only" && recoveredResult.savedOutputPath && recoveredResult.outputReference
-					? recoveredResult.outputReference.message
-					: fullOutput;
-				if (recoveredResult.artifactPaths && options.artifactConfig?.enabled !== false && options.artifactConfig?.includeOutput !== false) {
-					try {
-						writeArtifact(recoveredResult.artifactPaths.outputPath, fullOutput);
-					} catch {
-						// Detached children may outlive test/temp cleanup; recovered status is best-effort.
-					}
-				}
-				options.onDetachedExit?.(recoveredResult);
-				finish(-2);
-				return;
-			}
 			if (!result.error && closeError) result.error = closeError;
-			processClosed = true;
 			finish(finalCode);
 		});
 		proc.on("error", (error) => {
+			if (lifecycleFinished) return;
+			processClosed = true;
 			clearFinalDrainTimers();
 			clearStdioGuard();
 			void jsonlWriter.close().catch(() => {
@@ -1067,7 +1100,7 @@ async function runSingleAttempt(
 
 		if (options.signal) {
 			const kill = () => {
-				if (processClosed || detached) return;
+				if (processClosed || lifecycleFinished) return;
 				proc.kill("SIGTERM");
 				setTimeout(() => !proc.killed && proc.kill("SIGKILL"), 3000);
 			};
@@ -1080,7 +1113,7 @@ async function runSingleAttempt(
 
 		if (options.interruptSignal) {
 			const interrupt = () => {
-				if (processClosed || detached || settled) return;
+				if (processClosed || lifecycleFinished) return;
 				if (result.timedOut) return;
 				interruptedByControl = true;
 				clearTimeoutTimers();
@@ -1092,7 +1125,7 @@ async function runSingleAttempt(
 				fireUpdate();
 				trySignalChild(proc, "SIGINT");
 				setTimeout(() => {
-					if (settled || processClosed || detached) return;
+					if (lifecycleFinished || processClosed) return;
 					trySignalChild(proc, "SIGTERM");
 				}, 1000).unref?.();
 			};
@@ -1101,6 +1134,16 @@ async function runSingleAttempt(
 				options.interruptSignal.addEventListener("abort", interrupt, { once: true });
 				removeInterruptListener = () => options.interruptSignal?.removeEventListener("abort", interrupt);
 			}
+		}
+
+		// Publish only after every callback and cleanup guard captured by detach or
+		// later lifecycle events has initialized. Consumers may invoke synchronously.
+		try {
+			options.onDetachReady?.((reason = "user request") => detachForeground(reason));
+		} catch (error) {
+			// A consumer callback is advisory. Keep the child attached and observable
+			// rather than rejecting this attempt and orphaning its live process.
+			appendRecentOutput(progress, [`Foreground detach callback failed: ${error instanceof Error ? error.message : String(error)}`]);
 		}
 	});
 	result.exitCode = exitCode;
@@ -1119,16 +1162,6 @@ async function runSingleAttempt(
 		};
 		return result;
 	}
-	if (result.detached) {
-		result.exitCode = -2;
-		result.finalOutput = "Detached for intercom coordination before task completion.";
-		result.outputMode = options.outputMode ?? "inline";
-		if (options.outputPath) {
-			result.outputSaveError = "Output file was not finalized because the subagent detached for intercom coordination.";
-		}
-		return result;
-	}
-
 	if (result.error && result.exitCode === 0) {
 		result.exitCode = 1;
 	}
@@ -1278,7 +1311,7 @@ async function runSingleAttempt(
 /**
  * Run a subagent synchronously (blocking until complete)
  */
-export async function runSync(
+async function runSyncCompletion(
 	runtimeCwd: string,
 	agents: AgentConfig[],
 	agentName: string,
@@ -1398,84 +1431,42 @@ export async function runSync(
 	}
 
 	const persistResultMetadata = (target: SingleResult): void => {
-		if (!artifactPathsResult || options.artifactConfig?.enabled === false || options.artifactConfig?.includeMetadata === false) return;
-		writeMetadata(artifactPathsResult.metadataPath, {
+		persistSingleResultMetadata({
+			metadataPath: artifactPathsResult?.metadataPath,
+			enabled: options.artifactConfig?.enabled !== false && options.artifactConfig?.includeMetadata !== false,
 			runId: options.runId,
 			agent: agentName,
 			task,
-			exitCode: target.exitCode,
-			processSignal: target.processSignal,
-			usage: target.usage,
-			model: target.model,
-			attemptedModels: target.attemptedModels,
-			modelAttempts: target.modelAttempts,
-			durationMs: target.progressSummary?.durationMs,
-			toolCount: target.progressSummary?.toolCount,
-			error: target.error,
-			agentContract: target.agentContract,
-			launchContractDigest: target.launchContractDigest,
-			launchResolvedExtensions: target.launchResolvedExtensions,
-			execution: target.execution,
-			acceptance: target.acceptance,
-			capabilityCeiling: target.capabilityCeiling,
-			capabilityAudit: target.capabilityAudit,
-			review: target.review,
-			effects: target.effects,
-			...(transcriptWriter ? { transcriptPath: artifactPathsResult.transcriptPath } : {}),
-			transcriptError: target.transcriptError,
-			skills: target.skills,
-			skillsWarning: target.skillsWarning,
-			timestamp: Date.now(),
+			result: target,
 		});
 	};
 
-	const detachedAwareOptions: RunSyncOptions = options.onDetachedExit
-		? {
-			...options,
-			onDetachedExit: (recoveredResult) => {
-				void (async () => {
-					const childWrittenOutput = options.outputPath
-						? extractChildWrittenOutput(recoveredResult.messages, options.outputPath, options.cwd ?? runtimeCwd)
-						: undefined;
-					recoveredResult.acceptance = await evaluateAcceptance({
-						acceptance: effectiveAcceptance,
-						output: acceptanceOutputByResult.get(recoveredResult) ?? recoveredResult.finalOutput ?? "",
-						fileOutput: childWrittenOutput !== undefined && options.outputPath
-							? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
-							: undefined,
-						cwd: options.cwd ?? runtimeCwd,
-						reportOptional: isAgentContractV1(options.agentContract),
-					});
-					const acceptanceFailure = acceptanceFailureMessage(recoveredResult.acceptance);
-					stripAcceptanceReportsFromMessages(recoveredResult.messages);
-					if (acceptanceFailure && recoveredResult.acceptance.explicit && recoveredResult.exitCode === 0 && !isAgentContractV1(options.agentContract)) {
-						recoveredResult.exitCode = 1;
-						recoveredResult.error = recoveredResult.error ? `${recoveredResult.error}\n${acceptanceFailure}` : acceptanceFailure;
-						if (recoveredResult.progress) {
-							recoveredResult.progress.status = "failed";
-							recoveredResult.progress.error = recoveredResult.error;
-						}
-					}
-					if (isAgentContractV1(options.agentContract)) attachContractProjections(recoveredResult);
-					persistResultMetadata(recoveredResult);
-					options.onDetachedExit?.(recoveredResult);
-				})().catch((error) => {
-					const message = error instanceof Error ? error.message : String(error);
-					recoveredResult.exitCode = 1;
-					recoveredResult.error = recoveredResult.error ? `${recoveredResult.error}\nAcceptance evaluation failed: ${message}` : `Acceptance evaluation failed: ${message}`;
-					options.onDetachedExit?.(recoveredResult);
-				});
-			},
-		}
-		: options;
-
+	let intercomDetached = false;
+	let detachedReason: string | undefined;
+	const attemptOptions: RunSyncOptions = {
+		...options,
+		onDetachReceipt: (receipt) => {
+			receipt.acceptance = buildPendingAcceptanceLedger(effectiveAcceptance);
+			try {
+				persistResultMetadata(receipt);
+			} catch (error) {
+				receipt.metadataSaveError = error instanceof Error ? error.message : String(error);
+			}
+			const accepted = options.onDetachReceipt?.(receipt) === true;
+			if (accepted) {
+				detachedReason = receipt.detachedReason;
+				if (receipt.detachedReason === "intercom coordination") intercomDetached = true;
+			}
+			return accepted;
+		},
+	};
 	let lastResult: SingleResult | undefined;
 	const modelsToTry = candidates.length > 0 ? candidates : [undefined];
 	modelAttemptsLoop: for (let modelIndex = 0; modelIndex < modelsToTry.length; modelIndex++) {
 		const candidate = modelsToTry[modelIndex];
 		for (let startupAttemptIndex = 0; ; startupAttemptIndex++) {
 			const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
-			const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, detachedAwareOptions, {
+			const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, attemptOptions, {
 				sessionEnabled,
 				systemPrompt,
 				resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
@@ -1507,7 +1498,10 @@ export async function runSync(
 				usage: { ...result.usage },
 			};
 			modelAttempts.push(attempt);
-			if (result.detached || result.timedOut || result.turnBudgetExceeded) break modelAttemptsLoop;
+			// Preserve the legacy intercom handoff contract: once this logical run has
+			// been handed to a supervisor, terminating that attempt must not launch a
+			// startup retry or model fallback. Explicit user detach retains fallback.
+			if (intercomDetached || result.timedOut || result.turnBudgetExceeded) break modelAttemptsLoop;
 			if (attemptSucceeded) break modelAttemptsLoop;
 
 			const startupFailure = isRetryableSubagentStartupFailure({
@@ -1598,25 +1592,30 @@ export async function runSync(
 	if (transcriptWriter) result.transcriptPath = artifactPathsResult?.transcriptPath;
 	if (transcriptWriter?.getError()) result.transcriptError = transcriptWriter.getError();
 
-	if (artifactPathsResult && options.artifactConfig?.enabled !== false) {
-		result.artifactPaths = artifactPathsResult;
-		if (options.artifactConfig?.includeOutput !== false) {
-			writeArtifact(artifactPathsResult.outputPath, formatOutputArtifactContent({
-				output: artifactOutputByResult.get(result) ?? result.finalOutput ?? "",
-				error: result.error,
-				transcriptPath: result.transcriptPath,
-				metadataPath: options.artifactConfig?.includeMetadata === false ? undefined : artifactPathsResult.metadataPath,
-			}));
-		}
-		if (options.maxOutput) {
+	try {
+		if (artifactPathsResult && options.artifactConfig?.enabled !== false) {
+			result.artifactPaths = artifactPathsResult;
+			if (options.artifactConfig?.includeOutput !== false) {
+				writeArtifact(artifactPathsResult.outputPath, formatOutputArtifactContent({
+					output: artifactOutputByResult.get(result) ?? result.finalOutput ?? "",
+					error: result.error,
+					transcriptPath: result.transcriptPath,
+					metadataPath: options.artifactConfig?.includeMetadata === false ? undefined : artifactPathsResult.metadataPath,
+				}));
+			}
+			if (options.maxOutput) {
+				const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
+				const truncationResult = truncateOutput(result.finalOutput ?? "", config, artifactPathsResult.outputPath);
+				if (truncationResult.truncated) result.truncation = truncationResult;
+			}
+		} else if (options.maxOutput) {
 			const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
-			const truncationResult = truncateOutput(result.finalOutput ?? "", config, artifactPathsResult.outputPath);
+			const truncationResult = truncateOutput(result.finalOutput ?? "", config);
 			if (truncationResult.truncated) result.truncation = truncationResult;
 		}
-	} else if (options.maxOutput) {
-		const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
-		const truncationResult = truncateOutput(result.finalOutput ?? "", config);
-		if (truncationResult.truncated) result.truncation = truncationResult;
+	} catch (error) {
+		const message = `Artifact output post-processing failed: ${error instanceof Error ? error.message : String(error)}`;
+		result.outputSaveError = result.outputSaveError ? `${result.outputSaveError}\n${message}` : message;
 	}
 
 	if (options.sessionFile && (existsSync(options.sessionFile) || result.messages?.length)) {
@@ -1629,28 +1628,36 @@ export async function runSync(
 	const childWrittenOutput = options.outputPath
 		? extractChildWrittenOutput(result.messages, options.outputPath, options.cwd ?? runtimeCwd)
 		: undefined;
-	if (result.detached) {
-		result.acceptance = buildPendingAcceptanceLedger(effectiveAcceptance);
-	} else if (result.stopped) {
-		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "stopped", message: "Acceptance was not evaluated because the subagent was stopped." });
-	} else if (result.timedOut) {
-		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." });
-	} else if (result.turnBudgetExceeded) {
-		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "turn-budget", message: "Acceptance was not evaluated because the subagent exceeded its turn budget." });
-	} else {
-		result.acceptance = await evaluateAcceptance({
-			acceptance: effectiveAcceptance,
-			output: acceptanceOutputByResult.get(result) ?? result.finalOutput ?? "",
-			fileOutput: childWrittenOutput !== undefined && options.outputPath
-				? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
-				: undefined,
-			cwd: options.cwd ?? runtimeCwd,
-			reportOptional: isAgentContractV1(options.agentContract),
-		});
+	try {
+		if (result.interrupted && detachedReason === "user request") {
+			// Only an accepted user-detach receipt needs a non-rejecting terminal
+			// ledger. Attached and background execution retain their baseline
+			// acceptance behavior.
+			result.acceptance = buildInterruptedAcceptanceLedger(effectiveAcceptance);
+		} else if (result.stopped) {
+			result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "stopped", message: "Acceptance was not evaluated because the subagent was stopped." });
+		} else if (result.timedOut) {
+			result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." });
+		} else if (result.turnBudgetExceeded) {
+			result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "turn-budget", message: "Acceptance was not evaluated because the subagent exceeded its turn budget." });
+		} else {
+			result.acceptance = await evaluateAcceptance({
+				acceptance: effectiveAcceptance,
+				output: acceptanceOutputByResult.get(result) ?? result.finalOutput ?? "",
+				fileOutput: childWrittenOutput !== undefined && options.outputPath
+					? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
+					: undefined,
+				cwd: options.cwd ?? runtimeCwd,
+				reportOptional: isAgentContractV1(options.agentContract),
+			});
+		}
+	} catch (error) {
+		const message = `Acceptance evaluation failed: ${error instanceof Error ? error.message : String(error)}`;
+		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "acceptance-evaluation", message });
 	}
 	const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
 	stripAcceptanceReportsFromMessages(result.messages);
-	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.detached && !result.interrupted && !result.timedOut && !isAgentContractV1(options.agentContract)) {
+	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.interrupted && !result.timedOut && !isAgentContractV1(options.agentContract)) {
 		result.exitCode = 1;
 		result.error = result.error ? `${result.error}\n${acceptanceFailure}` : acceptanceFailure;
 		if (result.progress) {
@@ -1659,7 +1666,143 @@ export async function runSync(
 		}
 	}
 	if (isAgentContractV1(options.agentContract)) attachContractProjections(result);
-	persistResultMetadata(result);
+	try {
+		persistResultMetadata(result);
+	} catch (error) {
+		result.metadataSaveError = error instanceof Error ? error.message : String(error);
+	}
 
 	return result;
+}
+
+/**
+ * Runs the authoritative completion pipeline independently from the foreground
+ * receipt. Detachment is same-runtime only: it does not adopt or daemonize work.
+ */
+export async function runSync(
+	runtimeCwd: string,
+	agents: AgentConfig[],
+	agentName: string,
+	task: string,
+	options: RunSyncOptions,
+): Promise<SingleResult> {
+	// Capture the strict contract before consumer-owned objects can be mutated
+	// after a detached receipt is published.
+	const strictContract = isAgentContractV1(options.agentContract);
+	let detachedReason: string | undefined;
+	let publishedReceipt: SingleResult | undefined;
+	let activeDetachAttempt: ((reason?: string) => boolean) | undefined;
+	let detachReadyPublished = false;
+	let resolveReceipt!: (result: SingleResult) => void;
+	const receipt = new Promise<SingleResult>((resolve) => { resolveReceipt = resolve; });
+	const originSignal = options.signal;
+	const originController = new AbortController();
+	const forwardOriginAbort = () => {
+		if (!detachedReason) originController.abort(originSignal?.reason);
+	};
+	if (originSignal?.aborted) forwardOriginAbort();
+	else originSignal?.addEventListener("abort", forwardOriginAbort, { once: true });
+
+	const completion = runSyncCompletion(runtimeCwd, agents, agentName, task, {
+		...options,
+		signal: originController.signal,
+		onDetachedExit: undefined,
+		onDetachReceipt: (detachedReceipt) => {
+			if (detachedReason || publishedReceipt) return false;
+			// Keep the authoritative result, fallback snapshot, and caller receipt
+			// separately owned while the completion pipeline remains live.
+			publishedReceipt = structuredClone(detachedReceipt);
+			const callerReceipt = structuredClone(detachedReceipt);
+			// A strict contract was already validated before detach; normalize private
+			// and caller snapshots to the only safely known version.
+			publishedReceipt.agentContract = strictContract ? { version: 1 } : undefined;
+			callerReceipt.agentContract = strictContract ? { version: 1 } : undefined;
+			detachedReason = detachedReceipt.detachedReason ?? "user request";
+			resolveReceipt(callerReceipt);
+			return true;
+		},
+		onDetachReady: (detachAttempt) => {
+			activeDetachAttempt = detachAttempt;
+			if (detachReadyPublished) return;
+			detachReadyPublished = true;
+			options.onDetachReady?.((reason = "user request") => {
+				if (detachedReason || originController.signal.aborted) return false;
+				return activeDetachAttempt?.(reason) ?? false;
+			});
+		},
+	});
+
+	const authoritativeCompletion = completion.catch((error: unknown) => {
+		if (!publishedReceipt || !detachedReason) throw error;
+		const message = error instanceof Error ? error.message : String(error);
+		const failureMessage = `Detached completion pipeline failed after receipt: ${message}`;
+		const failedProgress: AgentProgress = publishedReceipt.progress
+			? { ...publishedReceipt.progress, status: "failed", error: failureMessage }
+			: {
+				index: options.index ?? 0,
+				agent: publishedReceipt.agent,
+				status: "failed",
+				task: publishedReceipt.task,
+				recentTools: [],
+				recentOutput: [],
+				toolCount: publishedReceipt.progressSummary?.toolCount ?? 0,
+				tokens: publishedReceipt.progressSummary?.tokens ?? 0,
+				durationMs: publishedReceipt.progressSummary?.durationMs ?? 0,
+				error: failureMessage,
+			};
+		const failedResult: SingleResult = {
+			...publishedReceipt,
+			detached: undefined,
+			detachedReason,
+			exitCode: 1,
+			error: failureMessage,
+			finalOutput: failureMessage,
+			progress: failedProgress,
+			progressSummary: {
+				toolCount: failedProgress.toolCount,
+				tokens: failedProgress.tokens,
+				durationMs: failedProgress.durationMs,
+			},
+			acceptance: publishedReceipt.acceptance
+				? buildSkippedAcceptanceLedger(publishedReceipt.acceptance.effectiveAcceptance, { id: "completion-pipeline", message: failureMessage })
+				: undefined,
+		};
+		if (strictContract) attachContractProjections(failedResult);
+		try {
+			// Replace the provisional detach receipt metadata with the authoritative
+			// terminal failure. Persistence remains best-effort and cannot orphan work.
+			persistSingleResultMetadata({
+				metadataPath: failedResult.artifactPaths?.metadataPath,
+				enabled: options.artifactConfig?.enabled !== false && options.artifactConfig?.includeMetadata !== false,
+				runId: options.runId,
+				agent: failedResult.agent,
+				task: failedResult.task,
+				result: failedResult,
+			});
+		} catch (metadataError) {
+			failedResult.metadataSaveError = metadataError instanceof Error ? metadataError.message : String(metadataError);
+		}
+		return failedResult;
+	});
+
+	let terminalCallbackInvoked = false;
+	void authoritativeCompletion.then((terminalResult) => {
+		if (!detachedReason || terminalCallbackInvoked) return;
+		terminalCallbackInvoked = true;
+		terminalResult.detached = undefined;
+		terminalResult.detachedReason = detachedReason;
+		try {
+			options.onDetachedExit?.(terminalResult);
+		} catch {
+			// The authoritative result has settled. Consumer callback failures are
+			// contained here; each consumer owns cleanup through its own finally block.
+		}
+	}).catch(() => {
+		// Attached completion rejection remains observable through the returned
+		// promise without becoming an unhandled side-channel rejection.
+	}).finally(() => {
+		originSignal?.removeEventListener("abort", forwardOriginAbort);
+	});
+
+	return Promise.race([authoritativeCompletion, receipt]);
 }

--- a/src/runs/foreground/foreground-control.ts
+++ b/src/runs/foreground/foreground-control.ts
@@ -5,6 +5,7 @@ interface BeginForegroundChildInput {
 	agent: string;
 	description?: string;
 	interrupt: () => boolean;
+	detach?: () => boolean;
 }
 
 function copyProgress(target: ForegroundChildControl, progress: AgentProgress | undefined): void {
@@ -40,6 +41,7 @@ function syncCurrentChild(control: ForegroundRunControl, child: ForegroundChildC
 	control.thinking = child.thinking;
 	control.toolCount = child.toolCount;
 	control.interrupt = child.interrupt;
+	control.detach = child.detach;
 	control.updatedAt = child.updatedAt;
 }
 
@@ -59,6 +61,7 @@ function clearCurrentChild(control: ForegroundRunControl): void {
 	control.thinking = undefined;
 	control.toolCount = undefined;
 	control.interrupt = undefined;
+	control.detach = undefined;
 }
 
 export function retainForegroundSchedulingOwner(control: ForegroundRunControl): void {
@@ -91,6 +94,15 @@ export function beginForegroundChild(control: ForegroundRunControl, input: Begin
 		syncCurrentChild(control, child);
 		return true;
 	};
+	if (input.detach) {
+		child.detach = () => {
+			if (!input.detach?.()) return false;
+			child.currentActivityState = undefined;
+			child.updatedAt = Date.now();
+			syncCurrentChild(control, child);
+			return true;
+		};
+	}
 	control.activeChildren ??= new Map();
 	control.activeChildren.set(input.index, child);
 	syncCurrentChild(control, child);

--- a/src/runs/foreground/foreground-control.ts
+++ b/src/runs/foreground/foreground-control.ts
@@ -61,6 +61,20 @@ function clearCurrentChild(control: ForegroundRunControl): void {
 	control.interrupt = undefined;
 }
 
+export function retainForegroundSchedulingOwner(control: ForegroundRunControl): void {
+	control.schedulingOwners = (control.schedulingOwners ?? 0) + 1;
+	control.updatedAt = Date.now();
+}
+
+export function settleForegroundSchedulingOwner(control: ForegroundRunControl): void {
+	control.schedulingOwners = Math.max(0, (control.schedulingOwners ?? 0) - 1);
+	control.updatedAt = Date.now();
+}
+
+export function foregroundSchedulingSettled(control: ForegroundRunControl): boolean {
+	return (control.schedulingOwners ?? 0) === 0;
+}
+
 export function beginForegroundChild(control: ForegroundRunControl, input: BeginForegroundChildInput): void {
 	const now = Date.now();
 	const child: ForegroundChildControl = {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -498,23 +498,23 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		state.foregroundRuns.set(input.runId, run);
 	}
 	run.updatedAt = updatedAt;
+	const terminalStatus = resolveSubagentResultStatus({
+		exitCode: input.result.exitCode,
+		...(input.result.acceptance?.status === "rejected" ? { success: false } : {}),
+		interrupted: input.result.interrupted,
+		detached: false,
+		processSignal: input.result.processSignal,
+		timedOut: input.result.timedOut,
+		stopped: input.result.stopped,
+		turnBudgetExceeded: input.result.turnBudgetExceeded,
+	});
 	const child = run.children[input.index] ?? { agent: input.result.agent, index: input.index, status: "detached" as const };
 	run.children[input.index] = {
 		...child,
 		agent: input.result.agent,
 		index: input.index,
 		...(input.result.context ? { context: input.result.context } : {}),
-		status: input.result.acceptance?.status === "rejected"
-			? "failed"
-			: resolveSubagentResultStatus({
-				exitCode: input.result.exitCode,
-				interrupted: input.result.interrupted,
-				detached: false,
-				processSignal: input.result.processSignal,
-				timedOut: input.result.timedOut,
-				stopped: input.result.stopped,
-				turnBudgetExceeded: input.result.turnBudgetExceeded,
-			}),
+		status: terminalStatus,
 		...foregroundChildActivityFromProgress(input.result.progress),
 		updatedAt,
 		...(input.result.exitCode !== undefined ? { exitCode: input.result.exitCode } : {}),
@@ -538,7 +538,7 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 	};
 	trimRememberedForegroundRuns(state);
 	const output = getSingleResultOutput(input.result).trim();
-	const success = input.result.exitCode === 0 && input.result.acceptance?.status !== "rejected";
+	const success = terminalStatus === "completed";
 	const summary = !success && input.result.error
 		? `${input.result.error}${output ? `\n\nOutput:\n${output}` : ""}`
 		: output || input.result.error || "Detached child exited without final output.";
@@ -554,7 +554,12 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		success,
 		summary,
 		exitCode: input.result.exitCode,
-		state: success ? "complete" : "failed",
+		state: terminalStatus === "completed" ? "complete" : terminalStatus,
+		...(input.result.interrupted !== undefined ? { interrupted: input.result.interrupted } : {}),
+		...(input.result.stopped !== undefined ? { stopped: input.result.stopped } : {}),
+		...(input.result.processSignal !== undefined ? { processSignal: input.result.processSignal } : {}),
+		...(input.result.timedOut !== undefined ? { timedOut: input.result.timedOut } : {}),
+		...(input.result.turnBudgetExceeded !== undefined ? { turnBudgetExceeded: input.result.turnBudgetExceeded } : {}),
 		timestamp: updatedAt,
 		cwd: input.cwd,
 		sessionFile: input.result.sessionFile,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -79,6 +79,7 @@ import { stopAsyncRun } from "./async-stop-action.ts";
 import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
 import { resolveAsyncRootResultPath } from "../background/chain-root-attachment.ts";
 import { attachRootChildrenToSteps, createNestedRoute, findNestedControlResult, resolveInheritedNestedRouteFromEnv, resolveNestedAsyncDir, resolveNestedParentAddressFromEnv, snapshotNestedEventFiles, updateForegroundNestedProjection, writeNestedControlRequest, writeNestedEvent, type NestedRunResolutionScope } from "../shared/nested-events.ts";
+import { detachedChildrenRequireSupervisor } from "../shared/foreground-detach.ts";
 import { resolveSubagentRunId, type ResolvedSubagentRunId } from "../background/run-id-resolver.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { inspectSubagentStatus } from "../background/run-status.ts";
@@ -577,7 +578,11 @@ function resolveForegroundResumeTarget(params: SubagentParamsLike, state: Subage
 	if (matches.length === 0) return undefined;
 	if (matches.length > 1) throw new Error(`Ambiguous foreground run id prefix '${requested}' matched: ${matches.map((run) => run.runId).join(", ")}. Provide a longer id.`);
 	const run = matches[0]!;
-	if (run.children.some((child) => child.status === "detached")) throw new Error(`Foreground run '${run.runId}' is detached for intercom coordination and cannot be revived safely while any child may still be live. Reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); use status to recover the result and do not launch a replacement while it remains detached.`);
+	if (run.children.some((child) => child.status === "detached")) {
+		throw new Error(detachedChildrenRequireSupervisor(run.children)
+			? `Foreground run '${run.runId}' is detached for intercom coordination and cannot be revived safely while any child may still be live. Reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); use status to recover the result and do not launch a replacement while it remains detached.`
+			: `Foreground run '${run.runId}' was detached at user request and cannot be revived safely while its child may still be live. Wait with subagent_wait({ id: "${run.runId}" }) or use status to recover the result; do not launch a replacement while it remains detached.`);
+	}
 	if (run.children.length > 1 && params.index === undefined) throw new Error(`Foreground run '${run.runId}' has ${run.children.length} children. Provide index to choose one.`);
 	const index = params.index ?? 0;
 	if (!Number.isInteger(index)) throw new Error(`Foreground run '${run.runId}' index must be an integer.`);
@@ -3417,6 +3422,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		effectiveSkills = skillOverride;
 	}
 	const interruptController = new AbortController();
+	let detachActiveChild: ((reason?: string) => boolean) | undefined;
 	const foregroundControl = deps.state.foregroundControls.get(runId);
 	if (foregroundControl) {
 		beginForegroundChild(foregroundControl, {
@@ -3428,15 +3434,15 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				interruptController.abort();
 				return true;
 			},
+			detach: () => detachActiveChild?.("user request") ?? false,
 		});
 	}
 
-	const forwardSingleUpdate = onUpdate
-		? (update: AgentToolResult<Details>) => {
-			if (foregroundControl) updateForegroundChild(foregroundControl, 0, update.details?.progress?.[0]);
-			onUpdate(update);
-		}
-		: undefined;
+	let foregroundDetached = false;
+	const forwardSingleUpdate = (update: AgentToolResult<Details>) => {
+		if (foregroundControl) updateForegroundChild(foregroundControl, 0, update.details?.progress?.[0]);
+		if (!foregroundDetached) onUpdate?.(update);
+	};
 
 	const deadlineAt = data.deadlineAt ?? (data.timeoutMs !== undefined ? Date.now() + data.timeoutMs : undefined);
 	let r: Awaited<ReturnType<typeof runSync>>;
@@ -3463,6 +3469,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			onUpdate: forwardSingleUpdate,
 			controlConfig,
 			onControlEvent,
+			onDetachReady: (detach) => { detachActiveChild = detach; },
 			intercomSessionName: childIntercomTarget,
 			orchestratorIntercomTarget: data.intercomBridge.active ? data.intercomBridge.orchestratorTarget : undefined,
 			nestedRoute: foregroundControl?.nestedRoute,
@@ -3510,6 +3517,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			if (foregroundControl) finishForegroundChild(foregroundControl, 0);
 		}
 	}
+	foregroundDetached = r.detached === true;
 	if (!r.detached) {
 		recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
 	}
@@ -3569,8 +3577,11 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	}
 
 	if (r.detached) {
+		const text = r.detachedReason === "intercom coordination"
+			? `Detached for intercom coordination: ${params.agent}. Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.`
+			: `Detached at user request: ${params.agent}. The current foreground wait was released without terminating the child. Wait with subagent_wait({ id: "${runId}" }) or use subagent({ action: "status", id: "${runId}" }) to recover its eventual result. This does not migrate the run into the detached async runner or guarantee survival across Pi reload/restart.`;
 		return {
-			content: [{ type: "text", text: `Detached for intercom coordination: ${params.agent}. Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.` }],
+			content: [{ type: "text", text }],
 			details,
 		};
 	}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -8,7 +8,14 @@ import { getArtifactsDir, getProjectChainRunsDir } from "../../shared/artifacts.
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
 import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import { executeChain } from "./chain-execution.ts";
-import { beginForegroundChild, finishForegroundChild, updateForegroundChild } from "./foreground-control.ts";
+import {
+	beginForegroundChild,
+	finishForegroundChild,
+	foregroundSchedulingSettled,
+	retainForegroundSchedulingOwner,
+	settleForegroundSchedulingOwner,
+	updateForegroundChild,
+} from "./foreground-control.ts";
 import { resolveExecutionAgentScope } from "../../agents/agent-scope.ts";
 import { handleManagementAction } from "../../agents/agent-management.ts";
 import { buildDoctorReport } from "../../extension/doctor.ts";
@@ -261,6 +268,15 @@ interface ExecutionContextData {
 
 function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefined): string {
 	return requestedCwd ? path.resolve(runtimeCwd, requestedCwd) : runtimeCwd;
+}
+
+function removeForegroundControlIfIdle(state: SubagentState, runId: string): boolean {
+	const control = state.foregroundControls.get(runId);
+	if (control && (!foregroundSchedulingSettled(control) || (control.activeChildren?.size ?? 0) > 0)) return false;
+	clearPendingForegroundControlNotices(state, runId);
+	state.foregroundControls.delete(runId);
+	if (state.lastForegroundControlId === runId) state.lastForegroundControlId = null;
+	return true;
 }
 
 function getForegroundControl(state: SubagentState, runId: string | undefined) {
@@ -2377,7 +2393,16 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		timeoutMs: data.timeoutMs,
 		deadlineAt: data.deadlineAt,
 		turnBudget: data.turnBudget,
-		onDetachedExit: (index, result) => updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, index, result, events: deps.pi.events }),
+		onDetachedExit: (index, result) => {
+			try {
+				updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, index, result, events: deps.pi.events });
+			} finally {
+				removeForegroundControlIfIdle(deps.state, runId);
+			}
+		},
+		onForegroundChildSettled: () => {
+			removeForegroundControlIfIdle(deps.state, runId);
+		},
 		toolBudget: data.toolBudget,
 		usageBudget: data.usageBudget,
 		configToolBudget: data.configToolBudget,
@@ -2682,6 +2707,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		input.sessionFileForTask(input.tasks[i]!.agent, i, input.modelOverrides[i]);
 	}
 	const completedResults: SingleResult[] = [];
+	if (input.foregroundControl) retainForegroundSchedulingOwner(input.foregroundControl);
 	return mapConcurrent(input.tasks, input.concurrencyLimit, async (task, index) => {
 		const budgetState = usageBudgetState(input.usageBudget, sumResultsCost(completedResults));
 		if (budgetState?.exhausted) {
@@ -2727,6 +2753,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		const structuredRuntime = task.outputSchema
 			? createStructuredOutputRuntime(task.outputSchema, path.join(input.artifactsDir, "structured-output", input.runId))
 			: undefined;
+		let detachedReceipt = false;
 		const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskText, {
 			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 			context: input.contextPolicy.contextForAgent(task.agent),
@@ -2750,7 +2777,17 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			capabilityCeiling: input.capabilityCeiling,
 			controlConfig: input.controlConfig,
 			onControlEvent: input.onControlEvent,
-			onDetachedExit: (result) => updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents }),
+			onDetachedExit: (result) => {
+				try {
+					updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents });
+				} finally {
+					try {
+						if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
+					} finally {
+						removeForegroundControlIfIdle(input.state, input.runId);
+					}
+				}
+			},
 			intercomSessionName: input.childIntercomTarget?.(task.agent, index),
 			orchestratorIntercomTarget: input.orchestratorIntercomTarget,
 			nestedRoute: input.foregroundControl?.nestedRoute,
@@ -2791,12 +2828,24 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 					});
 				}
 				: undefined,
+		}).then((result) => {
+			detachedReceipt = result.detached === true;
+			return result;
 		}).finally(() => {
-			if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
+			// mapConcurrent rejects before siblings settle, so every attached child
+			// attempts idle removal after releasing its own control. Detached receipts
+			// transfer both responsibilities to the authoritative exit callback.
+			if (!detachedReceipt) {
+				if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
+				removeForegroundControlIfIdle(input.state, input.runId);
+			}
 		});
 		completedResults.push(result);
 		return result;
-	}, input.globalSemaphore);
+	}, input.globalSemaphore, () => {
+		if (input.foregroundControl) settleForegroundSchedulingOwner(input.foregroundControl);
+		removeForegroundControlIfIdle(input.state, input.runId);
+	});
 }
 
 async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): Promise<AgentToolResult<Details>> {
@@ -3423,7 +3472,22 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			agentContract: params.agentContract,
 			acceptance: params.acceptance,
 			acceptanceContext: { mode: "single" },
-			onDetachedExit: (result) => updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events }),
+			onDetachedExit: (result) => {
+				try {
+					updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events });
+				} finally {
+					try {
+						if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
+					} finally {
+						try {
+							if (foregroundControl) finishForegroundChild(foregroundControl, 0);
+						} finally {
+							removeForegroundControlIfIdle(deps.state, runId);
+						}
+					}
+				}
+				recordRun(params.agent!, cleanTask, result.exitCode, result.progressSummary?.durationMs ?? 0);
+			},
 			timeoutMs: data.timeoutMs,
 			deadlineAt,
 			turnBudget: data.turnBudget,
@@ -3433,10 +3497,17 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			allowZeroToolBudget: data.allowZeroToolBudget && effectiveToolBudget.toolBudget === data.toolBudget,
 		});
 	} finally {
-		if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
+		// An attached runSync rejection still owns its child and structured runtime.
+		// A successful detached receipt transfers both to onDetachedExit while the
+		// authoritative completion remains live.
+		if (!r?.detached) {
+			if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);
+			if (foregroundControl) finishForegroundChild(foregroundControl, 0);
+		}
 	}
-	if (foregroundControl) finishForegroundChild(foregroundControl, 0);
-	recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
+	if (!r.detached) {
+		recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
+	}
 
 	if (r.progress) allProgress.push(r.progress);
 	if (r.artifactPaths) allArtifactPaths.push(r.artifactPaths);
@@ -4244,6 +4315,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				description: foregroundDescription,
 				currentActivityState: undefined,
 				activeChildren: new Map(),
+				// The outer executor owns scheduling until its finally block settles.
+				schedulingOwners: 1,
 				nestedRoute,
 				interrupt: undefined,
 			};
@@ -4341,11 +4414,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return errorResult;
 		} finally {
 			if (foregroundControl) {
-				clearPendingForegroundControlNotices(deps.state, runId);
-				deps.state.foregroundControls.delete(runId);
-				if (deps.state.lastForegroundControlId === runId) {
-					deps.state.lastForegroundControlId = null;
-				}
+				settleForegroundSchedulingOwner(foregroundControl);
+				removeForegroundControlIfIdle(deps.state, runId);
 			}
 		}
 

--- a/src/runs/shared/foreground-detach.ts
+++ b/src/runs/shared/foreground-detach.ts
@@ -1,0 +1,14 @@
+import type { ForegroundResumeChild } from "../../shared/types.ts";
+
+type DetachedChild = Pick<ForegroundResumeChild, "status" | "detachedReason">;
+
+/** Legacy remembered detach records have no reason and originated from intercom. */
+export function detachedChildrenRequireSupervisor(children: readonly DetachedChild[]): boolean {
+	return children.some((child) => child.status === "detached" && child.detachedReason !== "user request");
+}
+
+export function detachedChildActivityLabel(child: DetachedChild): string {
+	return child.detachedReason === "user request"
+		? "working after user-requested detach"
+		: "working after supervisor handoff";
+}

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -158,29 +158,45 @@ export async function mapConcurrent<T, R>(
 	limit: number,
 	fn: (item: T, i: number) => Promise<R>,
 	globalSemaphore?: Semaphore,
+	/** Invoked after every worker has stopped, including workers outliving an early rejection. */
+	onSchedulingSettled?: () => void,
 ): Promise<R[]> {
 	const safeLimit = Math.max(1, Math.floor(limit) || 1);
 	const results: R[] = new Array(items.length);
 	let next = 0;
+	let liveWorkers = Math.min(safeLimit, items.length);
+	const notifySchedulingSettled = () => {
+		try {
+			onSchedulingSettled?.();
+		} catch {
+			// Scheduling lifecycle cleanup must not replace the worker result.
+		}
+	};
 
 	async function worker(_workerIndex: number): Promise<void> {
-		while (next < items.length) {
-			const i = next++;
-			if (globalSemaphore) {
-				await globalSemaphore.acquire();
-				try {
+		try {
+			while (next < items.length) {
+				const i = next++;
+				if (globalSemaphore) {
+					await globalSemaphore.acquire();
+					try {
+						results[i] = await fn(items[i], i);
+					} finally {
+						globalSemaphore.release();
+					}
+				} else {
 					results[i] = await fn(items[i], i);
-				} finally {
-					globalSemaphore.release();
 				}
-			} else {
-				results[i] = await fn(items[i], i);
 			}
+		} finally {
+			liveWorkers--;
+			if (liveWorkers === 0) notifySchedulingSettled();
 		}
 	}
 
+	if (liveWorkers === 0) notifySchedulingSettled();
 	await Promise.all(
-		Array.from({ length: Math.min(safeLimit, items.length) }, (_, wi) => worker(wi)),
+		Array.from({ length: liveWorkers }, (_, wi) => worker(wi)),
 	);
 	return results;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -851,6 +851,8 @@ export interface SingleResult {
 	savedOutputPath?: string;
 	outputReference?: SavedOutputReference;
 	outputSaveError?: string;
+	/** Best-effort metadata persistence failure; execution and receipt publication continue. */
+	metadataSaveError?: string;
 	structuredOutput?: unknown;
 	structuredOutputFailed?: boolean;
 	structuredOutputPath?: string;
@@ -1474,6 +1476,11 @@ export interface RunSyncOptions {
 	intercomEvents?: IntercomEventBus;
 	onUpdate?: (r: import("@earendil-works/pi-agent-core").AgentToolResult<Details>) => void;
 	onControlEvent?: (event: ControlEvent) => void;
+	/** Exposes a non-terminating detach callback while the child is active. */
+	onDetachReady?: (detach: (reason?: string) => boolean) => void;
+	/** Internal foreground receipt proposal; returns true only when the outer waiter accepted it. */
+	onDetachReceipt?: (result: SingleResult) => boolean;
+	/** Authoritative terminal result, emitted only after the full detached run finalizes. */
 	onDetachedExit?: (result: SingleResult) => void;
 	controlConfig?: ResolvedControlConfig;
 	intercomSessionName?: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1370,6 +1370,8 @@ export interface ForegroundRunControl {
 	toolCount?: number;
 	/** Independently tracked children for foreground parallel work and fleet inspection. */
 	activeChildren?: Map<number, ForegroundChildControl>;
+	/** Scheduling owners that may still launch another child. Removal is safe only at zero. */
+	schedulingOwners?: number;
 	nestedRoute?: NestedRouteInfo;
 	nestedChildren?: NestedRunSummary[];
 	interrupt?: () => boolean;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1343,6 +1343,7 @@ export interface ForegroundChildControl {
 	thinking?: string;
 	toolCount?: number;
 	interrupt?: () => boolean;
+	detach?: () => boolean;
 }
 
 export interface ForegroundRunControl {
@@ -1377,6 +1378,8 @@ export interface ForegroundRunControl {
 	nestedRoute?: NestedRouteInfo;
 	nestedChildren?: NestedRunSummary[];
 	interrupt?: () => boolean;
+	/** Release the foreground wait without terminating the active child. */
+	detach?: () => boolean;
 }
 
 export interface SubagentState {

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -1140,6 +1140,22 @@ export function buildChainExpressionSteps(
 	return { chain, task: sharedTask };
 }
 
+function resolveForegroundDetachControl(state: SubagentState, requested: string | undefined) {
+	const controls = [...state.foregroundControls.values()];
+	if (requested) {
+		const exact = state.foregroundControls.get(requested);
+		if (exact) return exact;
+		const matches = controls.filter((control) => control.runId.startsWith(requested));
+		if (matches.length > 1) throw new Error(`Ambiguous foreground run id prefix '${requested}' matched: ${matches.map((control) => control.runId).join(", ")}. Provide a longer id.`);
+		return matches[0];
+	}
+	// No-arg detach selects the newest run that can actually satisfy the command;
+	// a newer parallel/chain control must not hide an older detachable single run.
+	return controls
+		.filter((control) => control.mode === "single" && typeof control.detach === "function")
+		.sort((left, right) => right.updatedAt - left.updatedAt)[0];
+}
+
 export function registerSlashCommands(
 	pi: ExtensionAPI,
 	state: SubagentState,
@@ -1290,6 +1306,37 @@ export function registerSlashCommands(
 	pi.registerShortcut(Key.ctrlAlt("f"), {
 		description: "Open subagent fleet inspector",
 		handler: async (ctx) => showFleet(ctx),
+	});
+
+	pi.registerCommand("subagents-detach", {
+		description: "Release the wait for an active foreground single-subagent run without terminating it",
+		handler: async (args, ctx) => {
+			const parts = args.trim().split(/\s+/).filter(Boolean);
+			if (parts.length > 1) {
+				ctx.ui.notify("Usage: /subagents-detach [run-id]", "error");
+				return;
+			}
+			let control: ReturnType<typeof resolveForegroundDetachControl>;
+			try {
+				control = resolveForegroundDetachControl(state, parts[0]);
+			} catch (error) {
+				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+				return;
+			}
+			if (!control) {
+				ctx.ui.notify(parts[0] ? `No active foreground run found for '${parts[0]}'.` : "No active foreground run to detach.", "info");
+				return;
+			}
+			if (control.mode !== "single") {
+				ctx.ui.notify(`Foreground ${control.mode} run '${control.runId}' cannot be detached. /subagents-detach currently supports single-subagent runs only.`, "error");
+				return;
+			}
+			if (!control.detach?.()) {
+				ctx.ui.notify(`Foreground run '${control.runId}' has no active child available to detach.`, "error");
+				return;
+			}
+			sendSlashText(pi, `Detached foreground run ${control.runId} without terminating its child. The current wait is released; recover the eventual result with subagent_wait or status. This is not async-runner migration and does not guarantee survival across Pi reload/restart.`);
+		},
 	});
 
 	pi.registerCommand("subagents-stop", {

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -304,6 +304,139 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.equal(result.details?.results?.every((entry) => entry.finalOutput === undefined), true);
 	});
 
+	it("keeps a queued top-level parallel child controlled after an early outer rejection", async () => {
+		mockPi.onCall({ matchArgIncludes: "task-a", output: "early child", delay: 100 });
+		mockPi.onCall({ matchArgIncludes: "task-b", output: "middle child", delay: 400 });
+		mockPi.onCall({ matchArgIncludes: "task-c", output: "too late", delay: 10_000 });
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });
+		let rejected = false;
+		const result = await executor.execute(
+			"parallel-rejection-cleanup",
+			{ concurrency: 2, tasks: [{ agent: "a", task: "task-a" }, { agent: "b", task: "task-b" }, { agent: "c", task: "task-c" }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ agent?: string; status?: string }> } }) => {
+				if (!rejected && update.details?.progress?.some((entry) => entry.agent === "a" && entry.status === "completed")) {
+					rejected = true;
+					throw new Error("reject early parallel completion");
+				}
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(rejected, true);
+		assert.equal(result.isError, true);
+		assert.equal(state.foregroundControls.size, 1, "remaining worker still owns queued scheduling");
+		await waitForCallCount(3);
+		const liveControl = [...state.foregroundControls.values()][0];
+		assert.equal(liveControl?.currentAgent, "c", "later queued child must remain discoverable after launch");
+		assert.ok(liveControl?.interrupt, "later queued child must remain interruptible");
+		assert.equal(liveControl.interrupt(), true);
+		for (let attempt = 0; attempt < 100 && state.foregroundControls.size > 0; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(state.foregroundControls.size, 0, "control must disappear after workers and children settle");
+	});
+
+	it("keeps a queued chain-parallel child controlled after an early outer rejection", async () => {
+		mockPi.onCall({ matchArgIncludes: "chain-task-a", output: "early chain child", delay: 100 });
+		mockPi.onCall({ matchArgIncludes: "chain-task-b", output: "middle chain child", delay: 400 });
+		mockPi.onCall({ matchArgIncludes: "chain-task-c", output: "too late", delay: 10_000 });
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });
+		let rejected = false;
+		const result = await executor.execute(
+			"chain-parallel-rejection-cleanup",
+			{ chain: [{ concurrency: 2, parallel: [{ agent: "a", task: "chain-task-a" }, { agent: "b", task: "chain-task-b" }, { agent: "c", task: "chain-task-c" }] }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ agent?: string; status?: string }> } }) => {
+				if (!rejected && update.details?.progress?.some((entry) => entry.agent === "a" && entry.status === "completed")) {
+					rejected = true;
+					throw new Error("reject early chain completion");
+				}
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(rejected, true);
+		assert.equal(result.isError, true);
+		assert.equal(state.foregroundControls.size, 1, "remaining chain worker still owns queued scheduling");
+		await waitForCallCount(3);
+		const liveControl = [...state.foregroundControls.values()][0];
+		assert.equal(liveControl?.currentAgent, "c", "later queued chain child must remain discoverable after launch");
+		assert.ok(liveControl?.interrupt, "later queued chain child must remain interruptible");
+		assert.equal(liveControl.interrupt(), true);
+		for (let attempt = 0; attempt < 100 && state.foregroundControls.size > 0; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(state.foregroundControls.size, 0, "chain control must disappear after workers and children settle");
+	});
+
+	it("cleans a rejected sequential chain child and releases foreground ownership", async () => {
+		mockPi.onCall({ output: "sequential child output" });
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		let rejected = false;
+		let ownedControl: { schedulingOwners?: number; activeChildren?: Map<number, unknown> } | undefined;
+		const result = await executor.execute(
+			"chain-sequential-rejection-cleanup",
+			{ chain: [{ agent: "worker", task: "sequential task" }] },
+			new AbortController().signal,
+			(update: { details?: { progress?: Array<{ status?: string }> } }) => {
+				if (rejected || !update.details?.progress?.some((entry) => entry.status === "completed")) return;
+				rejected = true;
+				ownedControl = [...state.foregroundControls.values()][0];
+				throw new Error("reject sequential chain completion");
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(rejected, true);
+		assert.equal(result.isError, true);
+		assert.ok(ownedControl);
+		assert.equal(ownedControl.schedulingOwners, 0);
+		assert.equal(ownedControl.activeChildren?.size, 0);
+		assert.equal(state.foregroundControls.size, 0);
+	});
+
+	it("cleans a sequential chain child after an early tool-budget validation return", async () => {
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		const execution = executor.execute(
+			"chain-sequential-budget-cleanup",
+			{ chain: [{ agent: "worker", task: "invalid budget task", toolBudget: { hard: 0 } }] },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		const ownedControl = [...state.foregroundControls.values()][0];
+		assert.ok(ownedControl, "outer scheduling owner should remain visible until execution settles");
+		const result = await execution;
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /toolBudget\.hard must be an integer >= 1/);
+		assert.equal(mockPi.callCount(), 0);
+		assert.equal(ownedControl.schedulingOwners, 0);
+		assert.equal(ownedControl.activeChildren?.size, 0);
+		assert.equal(state.foregroundControls.size, 0);
+	});
+
+	it("cleans an attached single rejection and its temporary structured runtime", async () => {
+		mockPi.onCall({
+			stdoutRaw: [
+				{ type: "tool_execution_start", toolName: "structured_output", args: { value: { ok: true } } },
+				{ type: "tool_result_end", message: { role: "toolResult", toolName: "structured_output", content: [{ type: "text", text: "Structured output captured." }] } },
+				{ type: "tool_execution_end", toolName: "structured_output" },
+			].map((entry) => JSON.stringify(entry)).join("\n") + "\n",
+			structuredOutputCapture: { ok: true },
+		});
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		let structuredDir: string | undefined;
+		const result = await executor.execute(
+			"single-rejection-cleanup",
+			{ agent: "worker", task: "structured task", artifacts: false, outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] } },
+			new AbortController().signal,
+			(update: { details?: { results?: Array<{ structuredOutputPath?: string }>; progress?: Array<{ status?: string }> } }) => {
+				const outputPath = update.details?.results?.[0]?.structuredOutputPath;
+				if (outputPath) structuredDir = path.dirname(outputPath);
+				if (update.details?.progress?.[0]?.status === "completed") throw new Error("reject attached single completion");
+			},
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(result.isError, true);
+		assert.equal(state.foregroundControls.size, 0);
+		assert.ok(structuredDir);
+		assert.equal(fs.existsSync(structuredDir), false, "temporary structured runtime must be removed on rejection");
+	});
+
 	it("chain runs emit one grouped event containing all executed children", async () => {
 		mockPi.onCall({ output: "Chain child output" });
 		const { executor, events } = makeExecutor({ agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { after, afterEach, before, beforeEach, describe, it } from "node:test";
 import { ASYNC_DIR, INTERCOM_DETACH_REQUEST_EVENT, RESULTS_DIR, SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT } from "../../src/shared/types.ts";
 import { waitForSubagents } from "../../src/runs/background/subagent-wait.ts";
+import { buildCompletionDetails, type CompletionNotification } from "../../src/runs/background/notify.ts";
 import { sessionLeaseDir } from "../../src/runs/shared/session-lease.ts";
 import type { MockPi } from "../support/helpers.ts";
 import {
@@ -245,6 +246,202 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.equal(events.emitted.some((entry) => entry.channel === "subagent:result-intercom"), false);
 		assert.match(result.content[0]?.text ?? "", /Legacy foreground output/);
 	});
+
+	it("wires explicit foreground detachment through the live single-run control and remembers later completion", async () => {
+		mockPi.onCall({ steps: [{ delay: 500, jsonl: [events.assistantMessage("recovered after explicit detach")] }] });
+		const { executor, events: bus, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		const runPromise = executor.execute(
+			"single-user-detach",
+			{ agent: "worker", task: "Keep working" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		let control: { runId: string; detach?: () => boolean } | undefined;
+		for (let attempt = 0; attempt < 100 && !control?.detach; attempt++) {
+			control = [...state.foregroundControls.values()][0] as typeof control;
+			if (!control?.detach) await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+		assert.ok(control?.detach, "expected a live foreground detach callback");
+		assert.equal(control.detach(), true);
+
+		const original = await runPromise;
+		assert.match(original.content[0]?.text ?? "", /Detached at user request/);
+		assert.match(original.content[0]?.text ?? "", /does not migrate the run into the detached async runner/);
+		const runId = original.details?.runId;
+		assert.ok(runId);
+
+		for (let attempt = 0; attempt < 100; attempt++) {
+			const remembered = state.foregroundRuns.get(runId) as { children?: Array<{ status?: string }> } | undefined;
+			if (remembered?.children?.[0]?.status === "completed") break;
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		const status = await executor.execute(
+			"single-user-detach-status",
+			{ action: "status", id: runId },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.match(status.content[0]?.text ?? "", /worker completed/);
+		assert.match(status.content[0]?.text ?? "", /recovered after explicit detach/);
+		assert.equal(bus.emitted.some((entry) => entry.channel === SUBAGENT_FOREGROUND_COMPLETE_EVENT), true);
+	});
+
+	it("keeps an explicitly interrupted user-detached run paused with one terminal event", async () => {
+		mockPi.onCall({ steps: [{ delay: 10_000, jsonl: [events.assistantMessage("too late")] }] });
+		const { executor, events: bus, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+		const runPromise = executor.execute(
+			"single-user-detach-interrupt",
+			{ agent: "worker", task: "Keep working", acceptance: { level: "checked", criteria: ["result is checked"] } },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		let control: { runId: string; detach?: () => boolean; interrupt?: () => boolean } | undefined;
+		for (let attempt = 0; attempt < 100 && !control?.detach; attempt++) {
+			control = [...state.foregroundControls.values()][0] as typeof control;
+			if (!control?.detach) await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+		assert.equal(control?.detach?.(), true);
+		const receipt = await runPromise;
+		const runId = receipt.details?.runId;
+		assert.ok(runId);
+		const detachedControl = state.foregroundControls.get(runId);
+		assert.ok(detachedControl?.interrupt, "live control must remain registered after foreground receipt");
+		assert.equal(detachedControl.interrupt(), true);
+		for (let attempt = 0; attempt < 100 && state.foregroundControls.has(runId); attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		assert.equal(state.foregroundControls.has(runId), false, "control must be removed after terminal completion");
+		const remembered = state.foregroundRuns.get(runId)?.children[0];
+		assert.equal(remembered?.status, "paused");
+		assert.equal(remembered?.acceptance?.status, "pending");
+		const completions = bus.emitted.filter((entry) => entry.channel === SUBAGENT_FOREGROUND_COMPLETE_EVENT
+			&& (entry.payload as { runId?: string }).runId === runId);
+		assert.equal(completions.length, 1);
+		const payload = completions[0]!.payload as CompletionNotification & { runId?: string; mode?: string };
+		assert.deepEqual(payload, {
+			id: `${runId}:0`,
+			runId,
+			source: "foreground",
+			mode: "single",
+			agent: "worker",
+			success: false,
+			summary: "Interrupted. Waiting for explicit next action.",
+			exitCode: 0,
+			state: "paused",
+			interrupted: true,
+			processSignal: "SIGINT",
+			timestamp: remembered.updatedAt,
+			cwd: tempDir,
+			sessionFile: remembered.sessionFile,
+			sessionId: "session-123",
+			taskIndex: 0,
+		});
+		assert.equal(buildCompletionDetails(payload).status, "paused");
+	});
+
+	for (const scenario of ["success", "error", "interrupt", "timeout", "pipeline-failure"] as const) {
+		it(`emits exactly one foreground completion event after detached ${scenario}`, async () => {
+			if (scenario === "success") mockPi.onCall({ output: "detached success", delay: 400 });
+			else if (scenario === "error") mockPi.onCall({ output: "detached error", exitCode: 1, delay: 400 });
+			else if (scenario === "interrupt" || scenario === "timeout") mockPi.onCall({ output: "too late", delay: 10_000 });
+			else mockPi.onCall({ output: "completed before pipeline failure", delay: 400 });
+			const { executor, events: bus, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("worker")] });
+			const agentContract = { version: 1 };
+			const runPromise = executor.execute(
+				`detached-event-${scenario}`,
+				{
+					agent: "worker",
+					task: `detached ${scenario}`,
+					acceptance: scenario === "pipeline-failure" ? { level: "checked", criteria: ["checked"] } : false,
+					...(scenario === "timeout" ? { timeoutMs: 100 } : {}),
+					...(scenario === "pipeline-failure" ? { agentContract } : {}),
+				},
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+			let control: { detach?: () => boolean; interrupt?: () => boolean } | undefined;
+			for (let attempt = 0; attempt < 100; attempt++) {
+				control = [...state.foregroundControls.values()][0] as typeof control;
+				if (control?.detach) break;
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+			assert.equal(control?.detach?.(), true);
+			const receipt = await runPromise;
+			const runId = receipt.details?.runId;
+			assert.ok(runId);
+			const metadataPath = receipt.details?.results?.[0]?.artifactPaths?.metadataPath;
+			if (scenario === "interrupt") assert.equal(control?.interrupt?.(), true);
+			if (scenario === "pipeline-failure") {
+				// Force an unexpected strict-projection boundary failure after receipt;
+				// expected artifact/provider I/O failures are handled as result fields.
+				Object.defineProperty(agentContract, "version", {
+					get: () => { throw new Error("strict projection failed"); },
+				});
+			}
+			for (let attempt = 0; attempt < 200; attempt++) {
+				const completions = bus.emitted.filter((entry) => entry.channel === SUBAGENT_FOREGROUND_COMPLETE_EVENT
+					&& (entry.payload as { runId?: string }).runId === runId);
+				if (completions.length > 0 && !state.foregroundControls.has(runId)) break;
+				await new Promise((resolve) => setTimeout(resolve, 20));
+			}
+			const completions = bus.emitted.filter((entry) => entry.channel === SUBAGENT_FOREGROUND_COMPLETE_EVENT
+				&& (entry.payload as { runId?: string }).runId === runId);
+			assert.equal(completions.length, 1);
+			assert.equal(state.foregroundControls.has(runId), false);
+			const payload = completions[0]!.payload as CompletionNotification;
+			if (scenario === "success") {
+				assert.deepEqual({ success: payload.success, state: payload.state, notifierStatus: buildCompletionDetails(payload).status }, {
+					success: true,
+					state: "complete",
+					notifierStatus: "completed",
+				});
+			} else if (scenario === "error") {
+				assert.deepEqual({ success: payload.success, state: payload.state, notifierStatus: buildCompletionDetails(payload).status }, {
+					success: false,
+					state: "failed",
+					notifierStatus: "failed",
+				});
+			} else if (scenario === "timeout") {
+				assert.deepEqual({ success: payload.success, state: payload.state, timedOut: payload.timedOut, notifierStatus: buildCompletionDetails(payload).status }, {
+					success: false,
+					state: "failed",
+					timedOut: true,
+					notifierStatus: "failed",
+				});
+			}
+			if (scenario === "pipeline-failure") {
+				const remembered = state.foregroundRuns.get(runId)?.children[0];
+				assert.equal(remembered?.status, "failed");
+				assert.match(remembered?.error ?? "", /Detached completion pipeline failed after receipt/);
+				assert.equal(remembered?.acceptance?.status, "rejected");
+				assert.ok(metadataPath);
+				const terminalMetadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as {
+					exitCode?: number;
+					error?: string;
+					acceptance?: { status?: string };
+					execution?: { status?: string; success?: boolean; exitCode?: number; error?: string };
+					review?: { status?: string };
+					effects?: Record<string, unknown>;
+				};
+				assert.equal(terminalMetadata.exitCode, 1);
+				assert.match(terminalMetadata.error ?? "", /Detached completion pipeline failed after receipt/);
+				assert.equal(terminalMetadata.acceptance?.status, "rejected");
+				assert.deepEqual(terminalMetadata.execution, {
+					status: "failed",
+					success: false,
+					exitCode: 1,
+					error: terminalMetadata.error,
+				});
+				assert.equal(terminalMetadata.review?.status, "not-requested");
+				assert.deepEqual(terminalMetadata.effects, {});
+			}
+		});
+	}
 
 	it("keeps native foreground output without attempting external grouped delivery when disabled", async () => {
 		mockPi.onCall({ output: "Native foreground output" });
@@ -1416,6 +1613,51 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.equal(resumed.isError, true);
 		assert.match(resumed.content[0]?.text ?? "", /cannot be revived safely while any child may still be live/);
 		assert.match(resumed.content[0]?.text ?? "", /do not launch a replacement/);
+	});
+
+	it("uses user-detach wording in remembered status, fleet, and resume recovery", async () => {
+		const { executor, state } = makeExecutor({ bridgeMode: "off", agents: [makeAgent("a")] });
+		state.foregroundRuns.set("user-detached-run", {
+			runId: "user-detached-run",
+			mode: "single",
+			cwd: tempDir,
+			sessionId: "session-123",
+			updatedAt: Date.now(),
+			children: [{ agent: "a", index: 0, status: "detached", detachedReason: "user request", updatedAt: Date.now() }],
+		});
+
+		const status = await executor.execute(
+			"user-detached-status",
+			{ action: "status", id: "user-detached-run" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		const statusText = status.content[0]?.text ?? "";
+		assert.match(statusText, /detached at user request/);
+		assert.doesNotMatch(statusText, /reply to the supervisor request/i);
+
+		const fleet = await executor.execute(
+			"user-detached-fleet",
+			{ action: "status", view: "fleet" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		const fleetText = fleet.content[0]?.text ?? "";
+		assert.match(fleetText, /recovery: detached at user request/);
+		assert.doesNotMatch(fleetText, /reply to the supervisor request/i);
+
+		const resumed = await executor.execute(
+			"user-detached-resume",
+			{ action: "resume", id: "user-detached-run", message: "replace" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(resumed.isError, true);
+		assert.match(resumed.content[0]?.text ?? "", /detached at user request/);
+		assert.doesNotMatch(resumed.content[0]?.text ?? "", /Reply to the supervisor request/);
 	});
 
 	it("resume action rejects detached foreground children that may still be live", async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -3278,6 +3278,464 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.finalOutput ?? "", /Interrupted/);
 	});
 
+	it("supports synchronous user detach and rejects duplicate and late detach calls", async () => {
+		mockPi.onCall({ steps: [
+			{ delay: 500, jsonl: [events.assistantMessage("completed after user detach")] },
+		] });
+		let detachActive: ((reason?: string) => boolean) | undefined;
+		let detachAccepted = false;
+		let duplicateAccepted = true;
+		let recoveredResult: RunSyncResult | undefined;
+
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Keep working", {
+			runId: "user-foreground-detach",
+			acceptance: false,
+			onDetachReady: (detach: (reason?: string) => boolean) => {
+				detachActive = detach;
+				detachAccepted = detach("user request");
+				duplicateAccepted = detach("user request");
+			},
+			onDetachedExit: (postExit) => { recoveredResult = postExit as RunSyncResult; },
+		});
+
+		assert.equal(detachAccepted, true);
+		assert.equal(duplicateAccepted, false);
+		assert.equal(recoveredResult, undefined, "foreground result should return before the child completes");
+		assert.equal(result.exitCode, -2);
+		assert.equal(result.detached, true);
+		assert.equal(result.detachedReason, "user request");
+		assert.equal(result.finalOutput, "Detached at user request before task completion.");
+		assert.equal(result.processSignal, undefined);
+
+		for (let attempt = 0; attempt < 100 && !recoveredResult; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(recoveredResult);
+		assert.equal(recoveredResult.exitCode, 0);
+		assert.equal(recoveredResult.processSignal, undefined);
+		assert.equal(recoveredResult.finalOutput, "completed after user detach");
+		assert.equal(detachActive?.("user request"), false, "detach must reject calls after child exit");
+	});
+
+	it("produces the same authoritative terminal result attached and detached", async () => {
+		mockPi.onCall({ output: "authoritative answer" });
+		mockPi.onCall({ steps: [{ delay: 75, jsonl: [events.assistantMessage("authoritative answer")] }] });
+		const agents = makeAgentConfigs(["echo"]);
+		const attached = await runSync(tempDir, agents, "echo", "Equivalent task", {
+			runId: "attached-authoritative-result",
+			acceptance: false,
+		});
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, agents, "echo", "Equivalent task", {
+			runId: "detached-authoritative-result",
+			acceptance: false,
+			onDetachReady: (detach) => assert.equal(detach("user request"), true),
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.deepEqual(
+			{
+				exitCode: terminal.exitCode,
+				finalOutput: terminal.finalOutput,
+				usage: terminal.usage,
+				progressStatus: terminal.progress.status,
+				acceptanceStatus: terminal.acceptance?.status,
+			},
+			{
+				exitCode: attached.exitCode,
+				finalOutput: attached.finalOutput,
+				usage: attached.usage,
+				progressStatus: attached.progress.status,
+				acceptanceStatus: attached.acceptance?.status,
+			},
+		);
+		assert.equal(terminal.detached, undefined);
+		assert.equal(terminal.detachedReason, "user request");
+	});
+
+	it("isolates every nested detach receipt field from terminal completion and later sanitization", async () => {
+		const receiptReport = [
+			"receipt snapshot",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "receipt evidence" }],
+				changedFiles: ["src/receipt.ts"],
+				testsAddedOrUpdated: ["test/receipt.test.ts"],
+				commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+				residualRisks: [],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n");
+		const terminalReport = [
+			"terminal answer",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "terminal isolation verified" }],
+				changedFiles: ["src/receipt.ts"],
+				testsAddedOrUpdated: ["test/receipt.test.ts"],
+				commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+				residualRisks: [],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n");
+		mockPi.onCall({ steps: [
+			{ jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: receiptReport }],
+					model: "mock/test-model",
+					stopReason: "toolUse",
+					usage: { input: 7, output: 3, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+				},
+			}] },
+			{ delay: 300, jsonl: [events.assistantMessage(terminalReport)] },
+		] });
+		let detach: ((reason?: string) => boolean) | undefined;
+		let detached = false;
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Keep the receipt isolated", {
+			runId: "detached-deep-receipt-isolation",
+			agentContract: { version: 1 },
+			acceptance: {
+				level: "checked",
+				criteria: [{
+					id: "criterion-1",
+					must: "Keep detach receipt state isolated",
+					evidence: ["changed-files", "tests-added", "commands-run", "residual-risks", "no-staged-files"],
+				}],
+			},
+			onDetachReady: (detachAttempt) => { detach = detachAttempt; },
+			onUpdate: (update: { content?: Array<{ text?: string }> }) => {
+				if (detached || !update.content?.[0]?.text?.includes("receipt snapshot")) return;
+				detached = detach?.("user request") === true;
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+
+		assert.equal(receipt.detached, true);
+		const receiptMessages = receipt.messages as Array<{
+			role?: string;
+			model?: string;
+			content: Array<{ type?: string; text?: string; callerOwned?: boolean }>;
+		}>;
+		const callerOwnedReceiptText = `caller-owned mutation\n${receiptReport}`;
+		(receipt.agentContract as unknown as { version: number }).version = 999;
+		receiptMessages[0]!.model = "caller-owned/model";
+		receiptMessages[0]!.content[0]!.text = callerOwnedReceiptText;
+		receiptMessages[0]!.content[0]!.callerOwned = true;
+		receiptMessages[0]!.content.push({ type: "text", text: "caller-only content" });
+		receiptMessages.push({ role: "assistant", model: "caller-only/model", content: [{ type: "text", text: "caller-only message" }] });
+		const mutableAcceptance = receipt.acceptance as unknown as {
+			status: string;
+			effectiveAcceptance: { level: string; criteria: Array<{ must: string }> };
+			criteria: Array<{ must: string }>;
+		};
+		mutableAcceptance.status = "rejected";
+		mutableAcceptance.effectiveAcceptance.level = "none";
+		mutableAcceptance.effectiveAcceptance.criteria[0]!.must = "caller corrupted effective criterion";
+		mutableAcceptance.criteria[0]!.must = "caller corrupted ledger criterion";
+		receipt.progress.status = "failed";
+		(receipt.progress as unknown as { recentOutput: string[] }).recentOutput.push("caller-only progress");
+		receipt.usage.turns = 999;
+		receipt.usage.input = 999;
+		receipt.attemptedModels = ["caller-only/model"];
+		receipt.modelAttempts = [{ success: false, exitCode: 99, error: "caller-only attempt" }];
+		receipt.effects = { fileMutation: { status: "missing", expected: true, attempted: false, message: "caller-only effect" } };
+		receipt.execution = { status: "failed", success: false, exitCode: 99 };
+		receipt.review = { status: "blockers" };
+
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.exitCode, 0);
+		assert.equal(terminal.finalOutput, "terminal answer");
+		assert.deepEqual(terminal.agentContract, { version: 1 });
+		assert.equal(terminal.acceptance?.status, "checked");
+		assert.equal(terminal.acceptance?.runtimeChecks.every((check) => check.status === "passed"), true);
+		assert.equal(terminal.progress.status, "completed");
+		assert.deepEqual(terminal.usage, { turns: 2, input: 107, output: 53, cacheRead: 0, cacheWrite: 0, cost: 0.002 });
+		assert.deepEqual(terminal.attemptedModels, ["mock/test-model"]);
+		assert.deepEqual(terminal.modelAttempts?.map((attempt) => ({ success: attempt.success, exitCode: attempt.exitCode })), [{ success: true, exitCode: 0 }]);
+		assert.equal(terminal.execution?.status, "completed");
+		assert.equal(terminal.execution?.success, true);
+		assert.equal(terminal.review?.status, "not-requested");
+		assert.deepEqual(terminal.effects, {});
+		assert.doesNotMatch(JSON.stringify(terminal.messages), /acceptance-report/);
+		assert.equal(receiptMessages[0]!.content[0]!.text, callerOwnedReceiptText, "terminal report sanitization must not mutate the caller receipt");
+		assert.equal(receiptMessages[0]!.content[0]!.callerOwned, true);
+		assert.equal(receiptMessages.length, 2);
+	});
+
+	it("keeps the full fallback loop and authoritative aggregation alive after detach", async () => {
+		mockPi.onCall({
+			jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "temporary provider failure" }],
+					model: "openai/gpt-5-mini",
+					errorMessage: "rate limit exceeded",
+					usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } },
+				},
+			}],
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "Recovered on detached fallback" });
+		const agents = [makeAgent("echo", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+		let terminal: RunSyncResult | undefined;
+
+		const receipt = await runSync(tempDir, agents, "echo", "Task", {
+			runId: "detached-fallback-loop",
+			acceptance: false,
+			onDetachReady: (detach) => assert.equal(detach("user request"), true),
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 300 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.detached, undefined, "terminal status must not remain detached");
+		assert.equal(terminal.detachedReason, "user request");
+		assert.equal(terminal.exitCode, 0);
+		assert.equal(terminal.finalOutput, "Recovered on detached fallback");
+		assert.deepEqual(terminal.attemptedModels, ["openai/gpt-5-mini", "anthropic/claude-sonnet-4"]);
+		assert.deepEqual(terminal.modelAttempts?.map((attempt) => attempt.success), [false, true]);
+		assert.equal(terminal.usage.turns, 2);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
+	it("terminalizes a post-receipt completion pipeline throw exactly once with strict projections", async () => {
+		mockPi.onCall({ steps: [{ delay: 75, jsonl: [events.assistantMessage("answer before callback failure")] }] });
+		let terminal: RunSyncResult | undefined;
+		let callbackCount = 0;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "detached-completion-pipeline-throw",
+			acceptance: { level: "checked", criteria: ["result is checked"] },
+			agentContract: { version: 1 },
+			onDetachReady: (detach) => {
+				assert.equal(detach("user request"), true);
+			},
+			onUpdate: (update: { details?: { progress?: Array<{ status?: string }> } }) => {
+				if (update.details?.progress?.[0]?.status === "completed") throw new Error("terminal consumer update failed");
+			},
+			onDetachedExit: (result) => {
+				callbackCount++;
+				terminal = result as RunSyncResult;
+			},
+		});
+		assert.equal(receipt.detached, true);
+		(receipt.agentContract as unknown as { version: number }).version = 999;
+		receipt.messages.push({ role: "assistant", content: [{ type: "text", text: "caller-only fallback message" }] });
+		const mutableAcceptance = receipt.acceptance as unknown as {
+			status: string;
+			effectiveAcceptance: { level: string; criteria: Array<{ must: string }> };
+		};
+		mutableAcceptance.status = "accepted";
+		mutableAcceptance.effectiveAcceptance.level = "none";
+		mutableAcceptance.effectiveAcceptance.criteria[0]!.must = "caller-only fallback criterion";
+		receipt.progress.status = "completed";
+		receipt.usage.turns = 999;
+		receipt.usage.input = 999;
+		receipt.attemptedModels = ["caller-only/fallback"];
+		receipt.modelAttempts = [{ success: true, exitCode: 0 }];
+		receipt.effects = { fileMutation: { status: "observed", expected: false, attempted: true, message: "caller-only fallback effect" } };
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(callbackCount, 1);
+		assert.equal(terminal.exitCode, 1);
+		assert.equal(terminal.detached, undefined);
+		assert.equal(terminal.detachedReason, "user request");
+		assert.equal(terminal.progress?.status, "failed");
+		assert.equal(terminal.acceptance?.status, "rejected");
+		assert.equal(terminal.acceptance?.runtimeChecks?.[0]?.id, "completion-pipeline");
+		assert.equal(terminal.execution?.status, "failed");
+		assert.equal(terminal.execution?.success, false);
+		assert.equal(terminal.review?.status, "not-requested");
+		assert.deepEqual(terminal.agentContract, { version: 1 });
+		assert.deepEqual(terminal.effects, {});
+		assert.equal(terminal.usage.turns, 0);
+		assert.equal(terminal.attemptedModels, undefined);
+		assert.equal(terminal.modelAttempts, undefined);
+		assert.doesNotMatch(JSON.stringify(terminal.messages), /caller-only fallback message/);
+		assert.match(terminal.error ?? "", /Detached completion pipeline failed after receipt/);
+	});
+
+	it("contains a synchronous onDetachReady throw and completes attached", async () => {
+		mockPi.onCall({ output: "completed while attached" });
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "throwing-detach-ready-consumer",
+			acceptance: false,
+			onDetachReady: () => {
+				throw new Error("bad detach consumer");
+			},
+		});
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.detached, undefined);
+		assert.equal(result.finalOutput, "completed while attached");
+		assert.equal(result.progress.recentOutput.some((line) => /Foreground detach callback failed: bad detach consumer/.test(line)), true);
+	});
+
+	it("reports expected artifact post-processing I/O failures without rejecting", async () => {
+		mockPi.onCall({ steps: [
+			{ jsonl: [events.toolStart("read", { path: "README.md" })] },
+			{ delay: 50, jsonl: [events.assistantMessage("artifact answer")] },
+		] });
+		const artifactsDir = path.join(tempDir, "artifact-output-failure");
+		let sabotaged = false;
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "artifact-output-result-field",
+			acceptance: false,
+			artifactsDir,
+			artifactConfig: { enabled: true },
+			onUpdate: (update: { details?: { results?: Array<{ artifactPaths?: { outputPath?: string } }> } }) => {
+				const outputPath = update.details?.results?.[0]?.artifactPaths?.outputPath;
+				if (sabotaged || !outputPath) return;
+				sabotaged = true;
+				fs.mkdirSync(outputPath);
+			},
+		});
+		assert.equal(sabotaged, true);
+		assert.equal(result.exitCode, 0);
+		assert.match(result.outputSaveError ?? "", /Artifact output post-processing failed/);
+	});
+
+	it("publishes detach despite best-effort receipt metadata persistence failure", async () => {
+		mockPi.onCall({ steps: [{ delay: 100, jsonl: [events.assistantMessage("completed after metadata recovery")] }] });
+		const artifactsDir = path.join(tempDir, "receipt-metadata-failure");
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "detach-receipt-metadata-failure",
+			acceptance: false,
+			artifactsDir,
+			artifactConfig: { enabled: true },
+			onDetachReady: (detach) => {
+				fs.rmSync(artifactsDir, { recursive: true, force: true });
+				fs.writeFileSync(artifactsDir, "block metadata", "utf-8");
+				assert.equal(detach("user request"), true);
+				fs.rmSync(artifactsDir, { force: true });
+				fs.mkdirSync(artifactsDir, { recursive: true });
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+		assert.equal(receipt.detached, true);
+		assert.match(receipt.metadataSaveError ?? "", /ENOTDIR|not a directory/);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(terminal?.exitCode, 0);
+	});
+
+	it("contains a throwing detached-exit callback", async () => {
+		mockPi.onCall({ steps: [{ delay: 50, jsonl: [events.assistantMessage("done")] }] });
+		let callbackCount = 0;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "throwing-detached-exit-callback",
+			acceptance: false,
+			onDetachReady: (detach) => assert.equal(detach("user request"), true),
+			onDetachedExit: () => {
+				callbackCount++;
+				throw new Error("consumer callback failed");
+			},
+		});
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && callbackCount === 0; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(callbackCount, 1);
+	});
+
+	it("skips acceptance evaluation when an explicitly interrupted detached result settles", async () => {
+		mockPi.onCall({ steps: [{ delay: 10_000, jsonl: [events.assistantMessage("too late")] }] });
+		const interrupt = new AbortController();
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Task", {
+			runId: "detached-interrupted-acceptance",
+			acceptance: { level: "checked", criteria: ["result is checked"] },
+			interruptSignal: interrupt.signal,
+			onDetachReady: (detach) => {
+				assert.equal(detach("user request"), true);
+				setTimeout(() => interrupt.abort(), 25);
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.interrupted, true);
+		assert.equal(terminal.exitCode, 0);
+		assert.equal(terminal.acceptance?.status, "pending");
+		assert.equal(terminal.acceptance?.runtimeChecks[0]?.status, "not-applicable");
+		assert.equal(terminal.error, undefined);
+	});
+
+	it("linearizes originating abort against detach and keeps explicit interrupt routable afterward", async () => {
+		mockPi.onCall({ steps: [{ delay: 10_000, jsonl: [events.assistantMessage("too late")] }] });
+		const origin = new AbortController();
+		const interrupt = new AbortController();
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Keep working", {
+			runId: "detach-origin-abort-race",
+			acceptance: false,
+			signal: origin.signal,
+			interruptSignal: interrupt.signal,
+			onDetachReady: (detach) => {
+				assert.equal(detach("user request"), true);
+				origin.abort();
+				setTimeout(() => interrupt.abort(), 50);
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.interrupted, true, "explicit control interrupt must remain active after detach");
+		assert.equal(terminal.processSignal, "SIGINT");
+		assert.equal(terminal.detached, undefined);
+	});
+
+	it("lets an already-observed originating abort win over detach", async () => {
+		mockPi.onCall({ delay: 10_000 });
+		const origin = new AbortController();
+		let detachAccepted = true;
+		const result = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Abort first", {
+			runId: "origin-abort-wins-detach",
+			signal: origin.signal,
+			onDetachReady: (detach) => {
+				origin.abort();
+				detachAccepted = detach("user request");
+			},
+		});
+		assert.equal(detachAccepted, false);
+		assert.equal(result.detached, undefined);
+	});
+
+	it("keeps the configured runtime timeout active after user detach", async () => {
+		mockPi.onCall({ delay: 10_000 });
+		let recoveredResult: RunSyncResult | undefined;
+		const startedAt = Date.now();
+
+		const result = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Do not run forever", {
+			runId: "user-detach-timeout",
+			timeoutMs: 150,
+			acceptance: false,
+			onDetachReady: (detach: (reason?: string) => boolean) => {
+				assert.equal(detach("user request"), true);
+			},
+			onDetachedExit: (postExit) => { recoveredResult = postExit as RunSyncResult; },
+		});
+
+		assert.equal(result.detached, true);
+		assert.ok(Date.now() - startedAt < 1_000, "detach should release the foreground waiter promptly");
+		for (let attempt = 0; attempt < 300 && !recoveredResult; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(recoveredResult, "configured timeout should terminate and recover the detached child");
+		assert.equal(recoveredResult.timedOut, true);
+		assert.equal(recoveredResult.error, "Subagent timed out after 150ms.");
+		assert.equal(recoveredResult.progress.status, "failed");
+		assert.ok(Date.now() - startedAt < 5_000, "detached child should remain bounded by runtime enforcement");
+	});
+
 	for (const toolName of ["intercom", "contact_supervisor"]) {
 		it(`detaches cleanly on ${toolName} handoff without aborting the child process`, async () => {
 			const eventBus = createEventBus();
@@ -3323,6 +3781,106 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			assert.equal(accepted, true);
 		});
 	}
+
+	it("reports intercom detach race losses and repeated requests as not accepted", async () => {
+		const abortBus = createEventBus();
+		const abortResponses: boolean[] = [];
+		abortBus.on(INTERCOM_DETACH_RESPONSE_EVENT, (payload) => abortResponses.push((payload as { accepted: boolean }).accepted));
+		mockPi.onCall({ steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need decision" })] }, { delay: 10_000 }] });
+		const origin = new AbortController();
+		let requested = false;
+		const abortedResult = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "intercom-abort-race-loss",
+			allowIntercomDetach: true,
+			intercomEvents: abortBus,
+			signal: origin.signal,
+			onUpdate: (update) => {
+				if (requested || !update.details?.progress?.some((item) => item.currentTool === "contact_supervisor")) return;
+				requested = true;
+				origin.abort();
+				abortBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "abort-race" });
+			},
+		});
+		assert.equal(abortedResult.detached, undefined);
+		assert.deepEqual(abortResponses, [false]);
+
+		const repeatedBus = createEventBus();
+		const repeatedResponses: boolean[] = [];
+		repeatedBus.on(INTERCOM_DETACH_RESPONSE_EVENT, (payload) => repeatedResponses.push((payload as { accepted: boolean }).accepted));
+		mockPi.onCall({ steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need decision" })] }, { delay: 50, jsonl: [events.assistantMessage("done")] }] });
+		let repeated = false;
+		const repeatedReceipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "intercom-repeated-detach",
+			allowIntercomDetach: true,
+			intercomEvents: repeatedBus,
+			onUpdate: (update) => {
+				if (repeated || !update.details?.progress?.some((item) => item.currentTool === "contact_supervisor")) return;
+				repeated = true;
+				repeatedBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "first" });
+				repeatedBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "second" });
+			},
+		});
+		assert.equal(repeatedReceipt.detached, true);
+		assert.deepEqual(repeatedResponses, [true, false]);
+	});
+
+	it("does not launch retries or fallbacks after intercom detach and keeps timeout enforcement", async () => {
+		const fallbackBus = createEventBus();
+		mockPi.onCall({
+			steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need decision" })] }],
+			stderr: "rate limit exceeded",
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "must not launch" });
+		let resolveFallbackTerminal!: (result: RunSyncResult) => void;
+		const fallbackTerminal = new Promise<RunSyncResult>((resolve) => { resolveFallbackTerminal = resolve; });
+		let fallbackRequested = false;
+		const receipt = await runSync(tempDir, [makeAgent("echo", { model: "openai/gpt-5-mini", fallbackModels: ["anthropic/claude-sonnet-4"] })], "echo", "Task", {
+			runId: "intercom-no-fallback",
+			acceptance: false,
+			allowIntercomDetach: true,
+			intercomEvents: fallbackBus,
+			onUpdate: (update) => {
+				if (fallbackRequested || !update.details?.progress?.some((item) => item.currentTool === "contact_supervisor")) return;
+				fallbackRequested = true;
+				fallbackBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "no-fallback" });
+			},
+			onDetachedExit: (result) => { resolveFallbackTerminal(result as RunSyncResult); },
+		});
+		assert.equal(receipt.detached, true);
+		const fallbackResult = await fallbackTerminal;
+		assert.equal(mockPi.callCount(), 1);
+		assert.equal(fallbackResult.exitCode, 1);
+
+		const timeoutBus = createEventBus();
+		mockPi.reset();
+		mockPi.onCall({ delay: 10_000 });
+		let resolveTimeoutTerminal!: (result: RunSyncResult) => void;
+		const timeoutTerminal = new Promise<RunSyncResult>((resolve) => { resolveTimeoutTerminal = resolve; });
+		let timeoutRequested = false;
+		const timeoutReceipt = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Task", {
+			runId: "intercom-timeout-enforced",
+			acceptance: false,
+			timeoutMs: 125,
+			allowIntercomDetach: true,
+			intercomEvents: timeoutBus,
+			onDetachReady: () => {
+				if (timeoutRequested) return;
+				timeoutRequested = true;
+				timeoutBus.emit(INTERCOM_DETACH_REQUEST_EVENT, {
+					requestId: "timeout",
+					runId: "intercom-timeout-enforced",
+					agent: "slow",
+					childIndex: 0,
+				});
+			},
+			onDetachedExit: (result) => { resolveTimeoutTerminal(result as RunSyncResult); },
+		});
+		assert.equal(timeoutReceipt.detached, true);
+		const timeoutResult = await timeoutTerminal;
+		assert.equal(timeoutResult.timedOut, true);
+		assert.equal(timeoutResult.exitCode, 1);
+	});
 
 	it("enforces the stdout protocol limit after foreground detachment", async () => {
 		const eventBus = createEventBus();

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -2066,6 +2066,66 @@ describe("subagents-doctor slash command", { skip: !available ? "slash-commands.
 		assert.match(rendered, /live controls/);
 	});
 
+	it("detaches the latest active foreground single run without terminating it", async () => {
+		const commands = new Map<string, RegisteredSlashCommand>();
+		const sent: unknown[] = [];
+		const state = createState(process.cwd());
+		let detached = 0;
+		state.foregroundControls.set("foreground-single", {
+			runId: "foreground-single",
+			mode: "single",
+			startedAt: 1,
+			updatedAt: 2,
+			detach: () => { detached++; return true; },
+		});
+		state.foregroundControls.set("newer-parallel", {
+			runId: "newer-parallel",
+			mode: "parallel",
+			startedAt: 2,
+			updatedAt: 3,
+		});
+		state.lastForegroundControlId = "newer-parallel";
+		registerSlashCommands!({
+			events: createEventBus(),
+			registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+			registerShortcut() {},
+			sendMessage(message: unknown) { sent.push(message); },
+		}, state);
+
+		await commands.get("subagents-detach")!.handler("", createCommandContext());
+
+		assert.equal(detached, 1);
+		const content = String((sent[0] as { content?: unknown }).content ?? "");
+		assert.match(content, /Detached foreground run foreground-single without terminating its child/);
+		assert.match(content, /does not guarantee survival across Pi reload\/restart/);
+	});
+
+	it("reports missing and unsupported foreground detach targets", async () => {
+		const commands = new Map<string, RegisteredSlashCommand>();
+		const notifications: string[] = [];
+		const state = createState(process.cwd());
+		state.foregroundControls.set("parallel-run", {
+			runId: "parallel-run",
+			mode: "parallel",
+			startedAt: 1,
+			updatedAt: 1,
+			detach: () => true,
+		});
+		registerSlashCommands!({
+			events: createEventBus(),
+			registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+			registerShortcut() {},
+			sendMessage() {},
+		}, state);
+		const ctx = createCommandContext({ notify: (message) => notifications.push(message) });
+
+		await commands.get("subagents-detach")!.handler("missing", ctx);
+		await commands.get("subagents-detach")!.handler("parallel", ctx);
+
+		assert.match(notifications[0] ?? "", /No active foreground run found for 'missing'/);
+		assert.match(notifications[1] ?? "", /currently supports single-subagent runs only/);
+	});
+
 	it("routes subagents-stop with an id directly to the stop action", async () => {
 		const { params } = await captureSlashCommandParams("subagents-stop", "run-123", process.cwd());
 		assert.deepEqual(params, { action: "stop", id: "run-123" });

--- a/test/unit/foreground-control.test.ts
+++ b/test/unit/foreground-control.test.ts
@@ -39,11 +39,13 @@ describe("foreground child control", () => {
 		};
 		let firstInterrupts = 0;
 		let secondInterrupts = 0;
+		let firstDetaches = 0;
 		beginForegroundChild(control, {
 			index: 0,
 			agent: "reviewer",
 			description: "Review correctness",
 			interrupt: () => { firstInterrupts++; return true; },
+			detach: () => { firstDetaches++; return true; },
 		});
 		beginForegroundChild(control, {
 			index: 1,
@@ -65,6 +67,8 @@ describe("foreground child control", () => {
 		assert.equal(control.interrupt?.(), true);
 		assert.equal(firstInterrupts, 1);
 		assert.equal(secondInterrupts, 0);
+		assert.equal(control.detach?.(), true);
+		assert.equal(firstDetaches, 1);
 
 		updateForegroundChild(control, 1, progress(1, "reviewer", 240));
 		finishForegroundChild(control, 1);
@@ -79,6 +83,7 @@ describe("foreground child control", () => {
 		assert.equal(control.inputTokens, undefined);
 		assert.equal(control.outputTokens, undefined);
 		assert.equal(control.interrupt, undefined);
+		assert.equal(control.detach, undefined);
 	});
 
 	it("settles scheduling only after every owner releases", () => {

--- a/test/unit/foreground-control.test.ts
+++ b/test/unit/foreground-control.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { AgentProgress, ForegroundRunControl } from "../../src/shared/types.ts";
-import { beginForegroundChild, finishForegroundChild, updateForegroundChild } from "../../src/runs/foreground/foreground-control.ts";
+import {
+	beginForegroundChild,
+	finishForegroundChild,
+	foregroundSchedulingSettled,
+	retainForegroundSchedulingOwner,
+	settleForegroundSchedulingOwner,
+	updateForegroundChild,
+} from "../../src/runs/foreground/foreground-control.ts";
 
 function progress(index: number, agent: string, tokens: number): AgentProgress {
 	return {
@@ -72,5 +79,22 @@ describe("foreground child control", () => {
 		assert.equal(control.inputTokens, undefined);
 		assert.equal(control.outputTokens, undefined);
 		assert.equal(control.interrupt, undefined);
+	});
+
+	it("settles scheduling only after every owner releases", () => {
+		const control: ForegroundRunControl = {
+			runId: "owned-run",
+			mode: "parallel",
+			startedAt: 1,
+			updatedAt: 1,
+			schedulingOwners: 1,
+		};
+
+		retainForegroundSchedulingOwner(control);
+		settleForegroundSchedulingOwner(control);
+		assert.equal(foregroundSchedulingSettled(control), false);
+		settleForegroundSchedulingOwner(control);
+		assert.equal(foregroundSchedulingSettled(control), true);
+		assert.equal(control.schedulingOwners, 0);
 	});
 });

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -472,11 +472,13 @@ describe("completion formatting helpers", () => {
 		notifier.dispose();
 	});
 
-	it("buildCompletionDetails derives paused and stopped statuses", () => {
-		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, state: "paused", summary: "Paused after interrupt.", timestamp: 1 }).status, "paused");
+	it("buildCompletionDetails derives lifecycle statuses before using exit code", () => {
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, state: "paused", interrupted: true, summary: "Paused after interrupt.", timestamp: 1 }).status, "paused");
 		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "boom", exitCode: 1, timestamp: 1 }).status, "failed");
-		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "terminated", exitCode: 1, processSignal: "SIGTERM", timestamp: 1 }).status, "stopped");
-		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "terminated", results: [{ success: false, exitCode: 1, processSignal: "SIGTERM" }], timestamp: 1 }).status, "stopped");
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "terminated", exitCode: 0, processSignal: "SIGTERM", timestamp: 1 }).status, "stopped");
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "timed out", exitCode: 0, timedOut: true, timestamp: 1 }).status, "failed");
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "budget exceeded", exitCode: 0, turnBudgetExceeded: true, timestamp: 1 }).status, "failed");
+		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: false, summary: "terminated", results: [{ success: false, exitCode: 0, processSignal: "SIGTERM" }], timestamp: 1 }).status, "stopped");
 		assert.equal(buildCompletionDetails({ id: "x", agent: "w", success: true, summary: "ok", exitCode: 0, processSignal: "SIGTERM", timestamp: 1 }).status, "completed");
 	});
 

--- a/test/unit/parallel-utils.test.ts
+++ b/test/unit/parallel-utils.test.ts
@@ -153,6 +153,28 @@ describe("mapConcurrent", () => {
 		assert.ok(d2 < 20, `worker 2 should start immediately, got ${d2}ms delay`);
 	});
 
+	it("notifies scheduling settlement only after workers outliving an early rejection stop", async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => { release = resolve; });
+		const started: number[] = [];
+		let schedulingSettled = false;
+		const run = mapConcurrent([0, 1, 2], 2, async (item) => {
+			started.push(item);
+			if (item === 0) throw new Error("early rejection");
+			await gate;
+			return item;
+		}, undefined, () => { schedulingSettled = true; });
+
+		await assert.rejects(run, /early rejection/);
+		assert.equal(schedulingSettled, false);
+		release();
+		for (let attempt = 0; attempt < 20 && !schedulingSettled; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		assert.equal(schedulingSettled, true);
+		assert.deepEqual(started, [0, 1, 2]);
+	});
+
 	it("respects a shared global semaphore across simultaneous calls", async () => {
 		const globalSemaphore = new Semaphore(2);
 		let running = 0;

--- a/test/unit/result-intercom.test.ts
+++ b/test/unit/result-intercom.test.ts
@@ -217,10 +217,13 @@ describe("result intercom formatter", () => {
 		assert.equal(stripped.results[0]?.truncation, undefined);
 	});
 
-	it("resolves paused, detached, and signal-terminated statuses", () => {
-		assert.equal(resolveSubagentResultStatus({ interrupted: true }), "paused");
+	it("resolves lifecycle terminal statuses before inferring success from exit code", () => {
+		assert.equal(resolveSubagentResultStatus({ interrupted: true, exitCode: 0 }), "paused");
+		assert.equal(resolveSubagentResultStatus({ stopped: true, exitCode: 0 }), "stopped");
+		assert.equal(resolveSubagentResultStatus({ timedOut: true, exitCode: 0 }), "failed");
+		assert.equal(resolveSubagentResultStatus({ turnBudgetExceeded: true, exitCode: 0 }), "failed");
 		assert.equal(resolveSubagentResultStatus({ detached: true }), "detached");
-		assert.equal(resolveSubagentResultStatus({ processSignal: "SIGTERM", exitCode: 1 }), "stopped");
+		assert.equal(resolveSubagentResultStatus({ processSignal: "SIGTERM", exitCode: 0 }), "stopped");
 		assert.equal(resolveSubagentResultStatus({ processSignal: "SIGTERM", exitCode: 1, timedOut: true }), "failed");
 		assert.equal(resolveSubagentResultStatus({ processSignal: "SIGTERM", exitCode: 0, success: true }), "completed");
 		assert.equal(resolveSubagentResultStatus({ success: true }), "completed");

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -384,6 +384,35 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("uses user-detach wording without inventing a supervisor request", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-foreground-user-detach-"));
+		try {
+			const state = makeState("sess-1");
+			state.foregroundRuns = new Map([["foreground-user-detached", {
+				runId: "foreground-user-detached",
+				mode: "single",
+				cwd: root,
+				sessionId: "sess-1",
+				updatedAt: 1,
+				children: [{ agent: "worker", index: 0, status: "detached", detachedReason: "user request", updatedAt: 1 }],
+			}]]);
+			const controller = new AbortController();
+			controller.abort();
+			let updateText = "";
+			const result = await waitForSubagents({ id: "foreground-user-detached" }, controller.signal, baseDeps(root, state, {
+				onUpdate: (update) => { updateText = textOf(update); },
+			}));
+
+			assert.equal(result.isError, true);
+			assert.match(textOf(result), /user-detached run is not waiting for a supervisor reply/i);
+			assert.doesNotMatch(textOf(result), /Reply to any pending supervisor request/);
+			assert.match(updateText, /working after user-requested detach/);
+			assert.doesNotMatch(updateText, /supervisor handoff/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("wakes a remembered foreground wait on a repeated supervisor request event", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-foreground-supervisor-"));
 		try {


### PR DESCRIPTION
## Summary

- add `/subagents-detach [run-id]` for active foreground single-subagent runs
- release the current foreground wait without terminating the child
- expose eventual completion through status, fleet inspection, notifications, and `subagent_wait`

## Behavior

With an explicit run id, the command targets that active foreground run. Without an id, it selects the newest eligible active single run.

Parallel and chain targets are rejected initially rather than partially detaching an ambiguous aggregate workflow.

After a successful detach:

- the child remains observed and explicitly interruptible
- timeout, turn-budget, watchdog, protocol, and lifecycle-drain enforcement remain active
- normal output, structured-output, acceptance, contract, artifact, and metadata finalization continues
- `status`, fleet, resume errors, and `subagent_wait` distinguish user-requested detach from supervisor/intercom handoff
- resume/replacement remains blocked while the original child may still be live

## Important limitation

This is **not** async-runner migration:

- it does not daemonize or re-parent the process
- it does not adopt the run into async lifecycle artifacts
- it does not guarantee survival across Pi reload/restart

Reload-safe promotion would require a durable runner from launch or a separate process-adoption architecture.

## Test plan

- command selection, explicit target, missing target, ambiguous target, and unsupported mode coverage
- end-to-end detach of a live single run and eventual completion recovery
- success, error, paused, timeout, and pipeline-failure completion events
- user-specific status, fleet, wait, and resume guidance
- control lifetime through terminal completion
- focused user-detach and recovery suites passed
- changed-area post-rebase integration coverage passed
- E2E on the complete stack: 3 passed
- independent post-rebase review: clean

## Stack

Depends on #709 and #710. GitHub will show the prerequisite commits in this draft until they merge; the feature commit itself is `8ea211de`.

Part 3 of the implementation proposed in #708.
