### PR TITLE
fix: finalize detached foreground completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Reduced repeated runtime filesystem work by caching stable Pi config-directory resolution, incrementally sanitizing run history, and limiting nested control-result polling to files created for the active request.
 
 ### Fixed
-- Retained foreground controls until scheduling owners and active children settle, keeping queued foreground work steerable after early result handling. Thanks to @magoz for #708/#709.
+- Retained foreground controls until scheduling owners and active children settle, keeping queued foreground work steerable after early result handling. Thanks to @magoz for #708/#709/#710.
 - Render resolved model and thinking effort for active and recent foreground children in Fleet inspector summaries and details. Thanks to @saleemlala for #706.
 - Resynchronized async job control-event scans that resume inside an oversized JSONL record, avoiding malformed-tail parse noise while preserving later control events. Thanks to @vicary for #700.
 - Report signal-terminated child processes with a canonical signal error instead of stderr-tail noise and classify those results separately from ordinary task failures. Thanks to @cking000bigdemon for #688.

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -122,6 +122,46 @@ function sumUsage(target: Usage, source: Usage): void {
 	target.turns += source.turns;
 }
 
+function persistSingleResultMetadata(input: {
+	metadataPath?: string;
+	enabled: boolean;
+	runId?: string;
+	agent: string;
+	task: string;
+	result: SingleResult;
+}): void {
+	if (!input.enabled || !input.metadataPath) return;
+	const target = input.result;
+	writeMetadata(input.metadataPath, {
+		runId: input.runId,
+		agent: input.agent,
+		task: input.task,
+		exitCode: target.exitCode,
+		processSignal: target.processSignal,
+		usage: target.usage,
+		model: target.model,
+		attemptedModels: target.attemptedModels,
+		modelAttempts: target.modelAttempts,
+		durationMs: target.progressSummary?.durationMs,
+		toolCount: target.progressSummary?.toolCount,
+		error: target.error,
+		agentContract: target.agentContract,
+		launchContractDigest: target.launchContractDigest,
+		launchResolvedExtensions: target.launchResolvedExtensions,
+		execution: target.execution,
+		acceptance: target.acceptance,
+		capabilityCeiling: target.capabilityCeiling,
+		capabilityAudit: target.capabilityAudit,
+		review: target.review,
+		effects: target.effects,
+		transcriptPath: target.transcriptPath,
+		transcriptError: target.transcriptError,
+		skills: target.skills,
+		skillsWarning: target.skillsWarning,
+		timestamp: Date.now(),
+	});
+}
+
 function formatTimeoutMessage(timeoutMs: number): string {
 	return `Subagent timed out after ${timeoutMs}ms.`;
 }
@@ -147,6 +187,21 @@ function buildPendingAcceptanceLedger(acceptance: ResolvedAcceptanceConfig): Acc
 		runtimeChecks: [],
 		verifyRuns: [],
 	};
+}
+
+function buildInterruptedAcceptanceLedger(acceptance: ResolvedAcceptanceConfig): AcceptanceLedger {
+	const pending = buildPendingAcceptanceLedger(acceptance);
+	if (acceptance.level === "none") {
+		pending.status = "not-required";
+		pending.evidenceStatus = "not-required";
+	} else {
+		pending.runtimeChecks = [{
+			id: "interrupted",
+			status: "not-applicable",
+			message: "Acceptance was not evaluated because the subagent was interrupted.",
+		}];
+	}
+	return pending;
 }
 
 function appendRecentOutput(progress: AgentProgress, lines: string[]): void {
@@ -204,7 +259,7 @@ function snapshotResult(result: SingleResult, progress: AgentProgress): SingleRe
  * unbounded `messages` transcript in favour of compact tool-call summaries so a
  * single `tool_execution_update` line stays well under the child-stdout protocol
  * cap (`MAX_CHILD_PENDING_LINE_BYTES`). Non-streaming consumers such as
- * detached-exit recovery call snapshotResult directly and keep the full transcript.
+ * foreground detach receipts and terminal consumers use snapshotResult directly.
  */
 function snapshotStreamResult(result: SingleResult, progress: AgentProgress): SingleResult {
 	const snapshot = snapshotResult(result, progress);
@@ -402,7 +457,7 @@ async function runSingleAttempt(
 		});
 		const jsonlWriter = createJsonlWriter(shared.jsonlPath, proc.stdout);
 		let processClosed = false;
-		let settled = false;
+		let lifecycleFinished = false;
 		let detached = false;
 		let intercomStarted = false;
 		let assistantError: string | undefined;
@@ -441,19 +496,43 @@ async function runSingleAttempt(
 			}
 		};
 
-		const detachForIntercom = () => {
-			detached = true;
-			processClosed = true;
-			result.detached = true;
-			result.detachedReason = "intercom coordination";
-			progress.status = "detached";
-			progress.durationMs = Date.now() - startTime;
-			result.progressSummary = {
-				toolCount: progress.toolCount,
-				tokens: progress.tokens,
-				durationMs: progress.durationMs,
+		const detachForeground = (reason: string): boolean => {
+			if (detached || processClosed || lifecycleFinished || options.signal?.aborted) return false;
+			const receiptProgress = snapshotProgress(progress);
+			receiptProgress.status = "detached";
+			receiptProgress.durationMs = Date.now() - startTime;
+			const receipt = snapshotResult(result, receiptProgress);
+			receipt.exitCode = -2;
+			receipt.detached = true;
+			receipt.detachedReason = reason;
+			receipt.finalOutput = reason === "intercom coordination"
+				? "Detached for intercom coordination before task completion."
+				: reason === "user request"
+					? "Detached at user request before task completion."
+					: `Detached for ${reason} before task completion.`;
+			receipt.outputMode = options.outputMode ?? "inline";
+			if (options.outputPath) {
+				receipt.outputSaveError = reason === "user request"
+					? "Output file was not finalized because the subagent detached at user request."
+					: `Output file was not finalized because the subagent detached for ${reason}.`;
+			}
+			receipt.progressSummary = {
+				toolCount: receiptProgress.toolCount,
+				tokens: receiptProgress.tokens,
+				durationMs: receiptProgress.durationMs,
 			};
-			finish(-2);
+			// The attempt is not detached until the outer coordinator has accepted and
+			// synchronously published the receipt. A persistence/callback failure must
+			// leave this attempt attached and abortable rather than orphaning it.
+			let accepted = false;
+			try {
+				accepted = options.onDetachReceipt?.(receipt) === true;
+			} catch {
+				return false;
+			}
+			if (!accepted) return false;
+			detached = true;
+			return true;
 		};
 
 		// If the child emits a terminal assistant stop but never exits,
@@ -494,9 +573,9 @@ async function runSingleAttempt(
 				armWatchdogTail();
 				return;
 			}
-			if (childExited || finalDrainTimer || settled || processClosed || detached) return;
+			if (childExited || finalDrainTimer || lifecycleFinished || processClosed) return;
 			finalDrainTimer = setTimeout(() => {
-				if (settled || processClosed || detached) return;
+				if (lifecycleFinished || processClosed) return;
 				const termSent = trySignalChild(proc, "SIGTERM");
 				if (!termSent) return;
 				forcedTerminationSignal = true;
@@ -504,7 +583,7 @@ async function runSingleAttempt(
 					result.error = result.error ?? `Subagent process did not exit within ${FINAL_STOP_GRACE_MS}ms after its terminal event. Forcing termination.`;
 				}
 				finalHardKillTimer = setTimeout(() => {
-					if (settled || processClosed || detached) return;
+					if (lifecycleFinished || processClosed) return;
 					forcedTerminationSignal = trySignalChild(proc, "SIGKILL") || forcedTerminationSignal;
 				}, HARD_KILL_MS);
 				finalHardKillTimer.unref?.();
@@ -512,7 +591,7 @@ async function runSingleAttempt(
 			finalDrainTimer.unref?.();
 		};
 		function armWatchdogTail(): void {
-			if ((!cleanTerminalAssistantStopReceived && !agentSettledReceived) || watchdogTailTimer || settled || processClosed || detached) return;
+			if ((!cleanTerminalAssistantStopReceived && !agentSettledReceived) || watchdogTailTimer || lifecycleFinished || processClosed) return;
 			watchdogTailTimer = setTimeout(() => {
 				watchdogTailTimer = undefined;
 				updateChildWatchdogState({
@@ -538,7 +617,7 @@ async function runSingleAttempt(
 		};
 
 		const unsubscribeIntercomDetach = options.intercomEvents?.on?.(INTERCOM_DETACH_REQUEST_EVENT, (payload) => {
-			if (!options.allowIntercomDetach || detached || processClosed) return;
+			if (!options.allowIntercomDetach || processClosed) return;
 			if (!payload || typeof payload !== "object") return;
 			const event = payload as { requestId?: unknown; runId?: unknown; agent?: unknown; childIndex?: unknown };
 			const requestId = event.requestId;
@@ -549,13 +628,13 @@ async function runSingleAttempt(
 				if (typeof event.agent === "string" && event.agent !== agent.name) return;
 				if (typeof event.childIndex === "number" && event.childIndex !== (options.index ?? 0)) return;
 			} else if (!intercomStarted) return;
-			options.intercomEvents?.emit(INTERCOM_DETACH_RESPONSE_EVENT, { requestId, accepted: true, runId: options.runId, agent: agent.name, childIndex: options.index ?? 0 });
-			detachForIntercom();
+			const accepted = detachForeground("intercom coordination");
+			options.intercomEvents?.emit(INTERCOM_DETACH_RESPONSE_EVENT, { requestId, accepted, runId: options.runId, agent: agent.name, childIndex: options.index ?? 0 });
 		});
 
 		const finish = (code: number) => {
-			if (settled) return;
-			settled = true;
+			if (lifecycleFinished) return;
+			lifecycleFinished = true;
 			clearFinalDrainTimers();
 			clearWatchdogTailTimer();
 			clearStdioGuard();
@@ -640,7 +719,7 @@ async function runSingleAttempt(
 		};
 		const requestTurnBudgetAbort = (turnCount: number) => {
 			const budget = options.turnBudget;
-			if (!budget || result.timedOut || result.turnBudgetExceeded || interruptedByControl || processClosed || settled || detached) return;
+			if (!budget || result.timedOut || result.turnBudgetExceeded || interruptedByControl || processClosed || lifecycleFinished) return;
 			const message = turnBudgetExceededMessage(budget, turnCount);
 			result.turnBudgetExceeded = true;
 			result.wrapUpRequested = true;
@@ -653,12 +732,12 @@ async function runSingleAttempt(
 			fireUpdate();
 			trySignalChild(proc, "SIGINT");
 			turnBudgetTerminationTimer = setTimeout(() => {
-				if (processClosed || settled || detached || result.timedOut) return;
+				if (processClosed || lifecycleFinished || result.timedOut) return;
 				trySignalChild(proc, "SIGTERM");
 			}, 1000);
 			turnBudgetTerminationTimer.unref?.();
 			turnBudgetHardKillTimer = setTimeout(() => {
-				if (processClosed || settled || detached || result.timedOut) return;
+				if (processClosed || lifecycleFinished || result.timedOut) return;
 				trySignalChild(proc, "SIGKILL");
 			}, 4000);
 			turnBudgetHardKillTimer.unref?.();
@@ -895,7 +974,7 @@ async function runSingleAttempt(
 
 		if (controlConfig.enabled) {
 			activityTimer = setInterval(() => {
-				if (processClosed || settled || detached) return;
+				if (processClosed || lifecycleFinished) return;
 				const now = Date.now();
 				if (updateActivityState(now)) {
 					progress.durationMs = now - startTime;
@@ -907,7 +986,7 @@ async function runSingleAttempt(
 
 		if (attemptTimeout) {
 			timeoutTimer = setTimeout(() => {
-				if (processClosed || settled || detached || interruptedByControl) return;
+				if (processClosed || lifecycleFinished || interruptedByControl) return;
 				result.timedOut = true;
 				result.error = attemptTimeout.message;
 				result.finalOutput = attemptTimeout.message;
@@ -917,12 +996,12 @@ async function runSingleAttempt(
 				fireUpdate();
 				trySignalChild(proc, "SIGINT");
 				timeoutTerminationTimer = setTimeout(() => {
-					if (processClosed || settled || detached) return;
+					if (processClosed || lifecycleFinished) return;
 					trySignalChild(proc, "SIGTERM");
 				}, 1000);
 				timeoutTerminationTimer.unref?.();
 				timeoutHardKillTimer = setTimeout(() => {
-					if (processClosed || settled || detached) return;
+					if (processClosed || lifecycleFinished) return;
 					trySignalChild(proc, "SIGKILL");
 				}, 4000);
 				timeoutHardKillTimer.unref?.();
@@ -966,6 +1045,8 @@ async function runSingleAttempt(
 			clearFinalDrainTimers();
 		});
 		proc.on("close", (code, signal) => {
+			if (lifecycleFinished) return;
+			processClosed = true;
 			clearFinalDrainTimers();
 			clearStdioGuard();
 			void jsonlWriter.close().catch(() => {
@@ -997,60 +1078,12 @@ async function runSingleAttempt(
 				closeError = stderr.trim();
 			}
 			const finalCode = forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
-			if (detached) {
-				const recoveredProgress = snapshotProgress(progress);
-				const recoveredResult = snapshotResult(result, recoveredProgress);
-				if (!recoveredResult.error && closeError) recoveredResult.error = closeError;
-				recoveredResult.exitCode = recoveredResult.error && finalCode === 0 ? 1 : finalCode;
-				recoveredProgress.status = recoveredResult.exitCode === 0 ? "completed" : "failed";
-				recoveredProgress.durationMs = Date.now() - startTime;
-				if (recoveredResult.error) recoveredProgress.error = recoveredResult.error;
-				recoveredResult.progressSummary = {
-					toolCount: recoveredProgress.toolCount,
-					tokens: recoveredProgress.tokens,
-					durationMs: recoveredProgress.durationMs,
-				};
-				const acceptanceOutput = getFinalOutput(recoveredResult.messages ?? []).trim()
-					|| recoveredResult.error
-					|| recoveredResult.finalOutput
-					|| "Detached child exited without final output.";
-				acceptanceOutputByResult.set(recoveredResult, acceptanceOutput);
-				let fullOutput = stripAcceptanceReport(acceptanceOutput);
-				fullOutput = fullOutput.trim() || recoveredResult.error || recoveredResult.finalOutput || "Detached child exited without final output.";
-				recoveredResult.outputMode = options.outputMode ?? "inline";
-				if (options.outputPath && recoveredResult.exitCode === 0) {
-					const resolvedOutput = resolveSingleOutput(options.outputPath, fullOutput, shared.outputSnapshot);
-					fullOutput = stripAcceptanceReport(resolvedOutput.fullOutput);
-					recoveredResult.savedOutputPath = resolvedOutput.savedPath;
-					recoveredResult.outputSaveError = resolvedOutput.saveError;
-					if (resolvedOutput.savedPath) {
-						recoveredResult.outputReference = formatSavedOutputReference(resolvedOutput.savedPath, fullOutput);
-					} else {
-						recoveredResult.exitCode = 1;
-						recoveredResult.error = `Output file was not finalized after detached child exit: ${resolvedOutput.saveError ?? options.outputPath}`;
-						recoveredProgress.status = "failed";
-						recoveredProgress.error = recoveredResult.error;
-					}
-				}
-				recoveredResult.finalOutput = options.outputMode === "file-only" && recoveredResult.savedOutputPath && recoveredResult.outputReference
-					? recoveredResult.outputReference.message
-					: fullOutput;
-				if (recoveredResult.artifactPaths && options.artifactConfig?.enabled !== false && options.artifactConfig?.includeOutput !== false) {
-					try {
-						writeArtifact(recoveredResult.artifactPaths.outputPath, fullOutput);
-					} catch {
-						// Detached children may outlive test/temp cleanup; recovered status is best-effort.
-					}
-				}
-				options.onDetachedExit?.(recoveredResult);
-				finish(-2);
-				return;
-			}
 			if (!result.error && closeError) result.error = closeError;
-			processClosed = true;
 			finish(finalCode);
 		});
 		proc.on("error", (error) => {
+			if (lifecycleFinished) return;
+			processClosed = true;
 			clearFinalDrainTimers();
 			clearStdioGuard();
 			void jsonlWriter.close().catch(() => {
@@ -1067,7 +1100,7 @@ async function runSingleAttempt(
 
 		if (options.signal) {
 			const kill = () => {
-				if (processClosed || detached) return;
+				if (processClosed || lifecycleFinished) return;
 				proc.kill("SIGTERM");
 				setTimeout(() => !proc.killed && proc.kill("SIGKILL"), 3000);
 			};
@@ -1080,7 +1113,7 @@ async function runSingleAttempt(
 
 		if (options.interruptSignal) {
 			const interrupt = () => {
-				if (processClosed || detached || settled) return;
+				if (processClosed || lifecycleFinished) return;
 				if (result.timedOut) return;
 				interruptedByControl = true;
 				clearTimeoutTimers();
@@ -1092,7 +1125,7 @@ async function runSingleAttempt(
 				fireUpdate();
 				trySignalChild(proc, "SIGINT");
 				setTimeout(() => {
-					if (settled || processClosed || detached) return;
+					if (lifecycleFinished || processClosed) return;
 					trySignalChild(proc, "SIGTERM");
 				}, 1000).unref?.();
 			};
@@ -1101,6 +1134,16 @@ async function runSingleAttempt(
 				options.interruptSignal.addEventListener("abort", interrupt, { once: true });
 				removeInterruptListener = () => options.interruptSignal?.removeEventListener("abort", interrupt);
 			}
+		}
+
+		// Publish only after every callback and cleanup guard captured by detach or
+		// later lifecycle events has initialized. Consumers may invoke synchronously.
+		try {
+			options.onDetachReady?.((reason = "user request") => detachForeground(reason));
+		} catch (error) {
+			// A consumer callback is advisory. Keep the child attached and observable
+			// rather than rejecting this attempt and orphaning its live process.
+			appendRecentOutput(progress, [`Foreground detach callback failed: ${error instanceof Error ? error.message : String(error)}`]);
 		}
 	});
 	result.exitCode = exitCode;
@@ -1119,16 +1162,6 @@ async function runSingleAttempt(
 		};
 		return result;
 	}
-	if (result.detached) {
-		result.exitCode = -2;
-		result.finalOutput = "Detached for intercom coordination before task completion.";
-		result.outputMode = options.outputMode ?? "inline";
-		if (options.outputPath) {
-			result.outputSaveError = "Output file was not finalized because the subagent detached for intercom coordination.";
-		}
-		return result;
-	}
-
 	if (result.error && result.exitCode === 0) {
 		result.exitCode = 1;
 	}
@@ -1278,7 +1311,7 @@ async function runSingleAttempt(
 /**
  * Run a subagent synchronously (blocking until complete)
  */
-export async function runSync(
+async function runSyncCompletion(
 	runtimeCwd: string,
 	agents: AgentConfig[],
 	agentName: string,
@@ -1398,84 +1431,42 @@ export async function runSync(
 	}
 
 	const persistResultMetadata = (target: SingleResult): void => {
-		if (!artifactPathsResult || options.artifactConfig?.enabled === false || options.artifactConfig?.includeMetadata === false) return;
-		writeMetadata(artifactPathsResult.metadataPath, {
+		persistSingleResultMetadata({
+			metadataPath: artifactPathsResult?.metadataPath,
+			enabled: options.artifactConfig?.enabled !== false && options.artifactConfig?.includeMetadata !== false,
 			runId: options.runId,
 			agent: agentName,
 			task,
-			exitCode: target.exitCode,
-			processSignal: target.processSignal,
-			usage: target.usage,
-			model: target.model,
-			attemptedModels: target.attemptedModels,
-			modelAttempts: target.modelAttempts,
-			durationMs: target.progressSummary?.durationMs,
-			toolCount: target.progressSummary?.toolCount,
-			error: target.error,
-			agentContract: target.agentContract,
-			launchContractDigest: target.launchContractDigest,
-			launchResolvedExtensions: target.launchResolvedExtensions,
-			execution: target.execution,
-			acceptance: target.acceptance,
-			capabilityCeiling: target.capabilityCeiling,
-			capabilityAudit: target.capabilityAudit,
-			review: target.review,
-			effects: target.effects,
-			...(transcriptWriter ? { transcriptPath: artifactPathsResult.transcriptPath } : {}),
-			transcriptError: target.transcriptError,
-			skills: target.skills,
-			skillsWarning: target.skillsWarning,
-			timestamp: Date.now(),
+			result: target,
 		});
 	};
 
-	const detachedAwareOptions: RunSyncOptions = options.onDetachedExit
-		? {
-			...options,
-			onDetachedExit: (recoveredResult) => {
-				void (async () => {
-					const childWrittenOutput = options.outputPath
-						? extractChildWrittenOutput(recoveredResult.messages, options.outputPath, options.cwd ?? runtimeCwd)
-						: undefined;
-					recoveredResult.acceptance = await evaluateAcceptance({
-						acceptance: effectiveAcceptance,
-						output: acceptanceOutputByResult.get(recoveredResult) ?? recoveredResult.finalOutput ?? "",
-						fileOutput: childWrittenOutput !== undefined && options.outputPath
-							? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
-							: undefined,
-						cwd: options.cwd ?? runtimeCwd,
-						reportOptional: isAgentContractV1(options.agentContract),
-					});
-					const acceptanceFailure = acceptanceFailureMessage(recoveredResult.acceptance);
-					stripAcceptanceReportsFromMessages(recoveredResult.messages);
-					if (acceptanceFailure && recoveredResult.acceptance.explicit && recoveredResult.exitCode === 0 && !isAgentContractV1(options.agentContract)) {
-						recoveredResult.exitCode = 1;
-						recoveredResult.error = recoveredResult.error ? `${recoveredResult.error}\n${acceptanceFailure}` : acceptanceFailure;
-						if (recoveredResult.progress) {
-							recoveredResult.progress.status = "failed";
-							recoveredResult.progress.error = recoveredResult.error;
-						}
-					}
-					if (isAgentContractV1(options.agentContract)) attachContractProjections(recoveredResult);
-					persistResultMetadata(recoveredResult);
-					options.onDetachedExit?.(recoveredResult);
-				})().catch((error) => {
-					const message = error instanceof Error ? error.message : String(error);
-					recoveredResult.exitCode = 1;
-					recoveredResult.error = recoveredResult.error ? `${recoveredResult.error}\nAcceptance evaluation failed: ${message}` : `Acceptance evaluation failed: ${message}`;
-					options.onDetachedExit?.(recoveredResult);
-				});
-			},
-		}
-		: options;
-
+	let intercomDetached = false;
+	let detachedReason: string | undefined;
+	const attemptOptions: RunSyncOptions = {
+		...options,
+		onDetachReceipt: (receipt) => {
+			receipt.acceptance = buildPendingAcceptanceLedger(effectiveAcceptance);
+			try {
+				persistResultMetadata(receipt);
+			} catch (error) {
+				receipt.metadataSaveError = error instanceof Error ? error.message : String(error);
+			}
+			const accepted = options.onDetachReceipt?.(receipt) === true;
+			if (accepted) {
+				detachedReason = receipt.detachedReason;
+				if (receipt.detachedReason === "intercom coordination") intercomDetached = true;
+			}
+			return accepted;
+		},
+	};
 	let lastResult: SingleResult | undefined;
 	const modelsToTry = candidates.length > 0 ? candidates : [undefined];
 	modelAttemptsLoop: for (let modelIndex = 0; modelIndex < modelsToTry.length; modelIndex++) {
 		const candidate = modelsToTry[modelIndex];
 		for (let startupAttemptIndex = 0; ; startupAttemptIndex++) {
 			const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
-			const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, detachedAwareOptions, {
+			const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, attemptOptions, {
 				sessionEnabled,
 				systemPrompt,
 				resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
@@ -1507,7 +1498,10 @@ export async function runSync(
 				usage: { ...result.usage },
 			};
 			modelAttempts.push(attempt);
-			if (result.detached || result.timedOut || result.turnBudgetExceeded) break modelAttemptsLoop;
+			// Preserve the legacy intercom handoff contract: once this logical run has
+			// been handed to a supervisor, terminating that attempt must not launch a
+			// startup retry or model fallback. Explicit user detach retains fallback.
+			if (intercomDetached || result.timedOut || result.turnBudgetExceeded) break modelAttemptsLoop;
 			if (attemptSucceeded) break modelAttemptsLoop;
 
 			const startupFailure = isRetryableSubagentStartupFailure({
@@ -1598,25 +1592,30 @@ export async function runSync(
 	if (transcriptWriter) result.transcriptPath = artifactPathsResult?.transcriptPath;
 	if (transcriptWriter?.getError()) result.transcriptError = transcriptWriter.getError();
 
-	if (artifactPathsResult && options.artifactConfig?.enabled !== false) {
-		result.artifactPaths = artifactPathsResult;
-		if (options.artifactConfig?.includeOutput !== false) {
-			writeArtifact(artifactPathsResult.outputPath, formatOutputArtifactContent({
-				output: artifactOutputByResult.get(result) ?? result.finalOutput ?? "",
-				error: result.error,
-				transcriptPath: result.transcriptPath,
-				metadataPath: options.artifactConfig?.includeMetadata === false ? undefined : artifactPathsResult.metadataPath,
-			}));
-		}
-		if (options.maxOutput) {
+	try {
+		if (artifactPathsResult && options.artifactConfig?.enabled !== false) {
+			result.artifactPaths = artifactPathsResult;
+			if (options.artifactConfig?.includeOutput !== false) {
+				writeArtifact(artifactPathsResult.outputPath, formatOutputArtifactContent({
+					output: artifactOutputByResult.get(result) ?? result.finalOutput ?? "",
+					error: result.error,
+					transcriptPath: result.transcriptPath,
+					metadataPath: options.artifactConfig?.includeMetadata === false ? undefined : artifactPathsResult.metadataPath,
+				}));
+			}
+			if (options.maxOutput) {
+				const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
+				const truncationResult = truncateOutput(result.finalOutput ?? "", config, artifactPathsResult.outputPath);
+				if (truncationResult.truncated) result.truncation = truncationResult;
+			}
+		} else if (options.maxOutput) {
 			const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
-			const truncationResult = truncateOutput(result.finalOutput ?? "", config, artifactPathsResult.outputPath);
+			const truncationResult = truncateOutput(result.finalOutput ?? "", config);
 			if (truncationResult.truncated) result.truncation = truncationResult;
 		}
-	} else if (options.maxOutput) {
-		const config = { ...DEFAULT_MAX_OUTPUT, ...options.maxOutput };
-		const truncationResult = truncateOutput(result.finalOutput ?? "", config);
-		if (truncationResult.truncated) result.truncation = truncationResult;
+	} catch (error) {
+		const message = `Artifact output post-processing failed: ${error instanceof Error ? error.message : String(error)}`;
+		result.outputSaveError = result.outputSaveError ? `${result.outputSaveError}\n${message}` : message;
 	}
 
 	if (options.sessionFile && (existsSync(options.sessionFile) || result.messages?.length)) {
@@ -1629,28 +1628,36 @@ export async function runSync(
 	const childWrittenOutput = options.outputPath
 		? extractChildWrittenOutput(result.messages, options.outputPath, options.cwd ?? runtimeCwd)
 		: undefined;
-	if (result.detached) {
-		result.acceptance = buildPendingAcceptanceLedger(effectiveAcceptance);
-	} else if (result.stopped) {
-		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "stopped", message: "Acceptance was not evaluated because the subagent was stopped." });
-	} else if (result.timedOut) {
-		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." });
-	} else if (result.turnBudgetExceeded) {
-		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "turn-budget", message: "Acceptance was not evaluated because the subagent exceeded its turn budget." });
-	} else {
-		result.acceptance = await evaluateAcceptance({
-			acceptance: effectiveAcceptance,
-			output: acceptanceOutputByResult.get(result) ?? result.finalOutput ?? "",
-			fileOutput: childWrittenOutput !== undefined && options.outputPath
-				? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
-				: undefined,
-			cwd: options.cwd ?? runtimeCwd,
-			reportOptional: isAgentContractV1(options.agentContract),
-		});
+	try {
+		if (result.interrupted && detachedReason === "user request") {
+			// Only an accepted user-detach receipt needs a non-rejecting terminal
+			// ledger. Attached and background execution retain their baseline
+			// acceptance behavior.
+			result.acceptance = buildInterruptedAcceptanceLedger(effectiveAcceptance);
+		} else if (result.stopped) {
+			result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "stopped", message: "Acceptance was not evaluated because the subagent was stopped." });
+		} else if (result.timedOut) {
+			result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "timeout", message: "Acceptance was not evaluated because the subagent timed out." });
+		} else if (result.turnBudgetExceeded) {
+			result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "turn-budget", message: "Acceptance was not evaluated because the subagent exceeded its turn budget." });
+		} else {
+			result.acceptance = await evaluateAcceptance({
+				acceptance: effectiveAcceptance,
+				output: acceptanceOutputByResult.get(result) ?? result.finalOutput ?? "",
+				fileOutput: childWrittenOutput !== undefined && options.outputPath
+					? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
+					: undefined,
+				cwd: options.cwd ?? runtimeCwd,
+				reportOptional: isAgentContractV1(options.agentContract),
+			});
+		}
+	} catch (error) {
+		const message = `Acceptance evaluation failed: ${error instanceof Error ? error.message : String(error)}`;
+		result.acceptance = buildSkippedAcceptanceLedger(effectiveAcceptance, { id: "acceptance-evaluation", message });
 	}
 	const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
 	stripAcceptanceReportsFromMessages(result.messages);
-	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.detached && !result.interrupted && !result.timedOut && !isAgentContractV1(options.agentContract)) {
+	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.interrupted && !result.timedOut && !isAgentContractV1(options.agentContract)) {
 		result.exitCode = 1;
 		result.error = result.error ? `${result.error}\n${acceptanceFailure}` : acceptanceFailure;
 		if (result.progress) {
@@ -1659,7 +1666,143 @@ export async function runSync(
 		}
 	}
 	if (isAgentContractV1(options.agentContract)) attachContractProjections(result);
-	persistResultMetadata(result);
+	try {
+		persistResultMetadata(result);
+	} catch (error) {
+		result.metadataSaveError = error instanceof Error ? error.message : String(error);
+	}
 
 	return result;
+}
+
+/**
+ * Runs the authoritative completion pipeline independently from the foreground
+ * receipt. Detachment is same-runtime only: it does not adopt or daemonize work.
+ */
+export async function runSync(
+	runtimeCwd: string,
+	agents: AgentConfig[],
+	agentName: string,
+	task: string,
+	options: RunSyncOptions,
+): Promise<SingleResult> {
+	// Capture the strict contract before consumer-owned objects can be mutated
+	// after a detached receipt is published.
+	const strictContract = isAgentContractV1(options.agentContract);
+	let detachedReason: string | undefined;
+	let publishedReceipt: SingleResult | undefined;
+	let activeDetachAttempt: ((reason?: string) => boolean) | undefined;
+	let detachReadyPublished = false;
+	let resolveReceipt!: (result: SingleResult) => void;
+	const receipt = new Promise<SingleResult>((resolve) => { resolveReceipt = resolve; });
+	const originSignal = options.signal;
+	const originController = new AbortController();
+	const forwardOriginAbort = () => {
+		if (!detachedReason) originController.abort(originSignal?.reason);
+	};
+	if (originSignal?.aborted) forwardOriginAbort();
+	else originSignal?.addEventListener("abort", forwardOriginAbort, { once: true });
+
+	const completion = runSyncCompletion(runtimeCwd, agents, agentName, task, {
+		...options,
+		signal: originController.signal,
+		onDetachedExit: undefined,
+		onDetachReceipt: (detachedReceipt) => {
+			if (detachedReason || publishedReceipt) return false;
+			// Keep the authoritative result, fallback snapshot, and caller receipt
+			// separately owned while the completion pipeline remains live.
+			publishedReceipt = structuredClone(detachedReceipt);
+			const callerReceipt = structuredClone(detachedReceipt);
+			// A strict contract was already validated before detach; normalize private
+			// and caller snapshots to the only safely known version.
+			publishedReceipt.agentContract = strictContract ? { version: 1 } : undefined;
+			callerReceipt.agentContract = strictContract ? { version: 1 } : undefined;
+			detachedReason = detachedReceipt.detachedReason ?? "user request";
+			resolveReceipt(callerReceipt);
+			return true;
+		},
+		onDetachReady: (detachAttempt) => {
+			activeDetachAttempt = detachAttempt;
+			if (detachReadyPublished) return;
+			detachReadyPublished = true;
+			options.onDetachReady?.((reason = "user request") => {
+				if (detachedReason || originController.signal.aborted) return false;
+				return activeDetachAttempt?.(reason) ?? false;
+			});
+		},
+	});
+
+	const authoritativeCompletion = completion.catch((error: unknown) => {
+		if (!publishedReceipt || !detachedReason) throw error;
+		const message = error instanceof Error ? error.message : String(error);
+		const failureMessage = `Detached completion pipeline failed after receipt: ${message}`;
+		const failedProgress: AgentProgress = publishedReceipt.progress
+			? { ...publishedReceipt.progress, status: "failed", error: failureMessage }
+			: {
+				index: options.index ?? 0,
+				agent: publishedReceipt.agent,
+				status: "failed",
+				task: publishedReceipt.task,
+				recentTools: [],
+				recentOutput: [],
+				toolCount: publishedReceipt.progressSummary?.toolCount ?? 0,
+				tokens: publishedReceipt.progressSummary?.tokens ?? 0,
+				durationMs: publishedReceipt.progressSummary?.durationMs ?? 0,
+				error: failureMessage,
+			};
+		const failedResult: SingleResult = {
+			...publishedReceipt,
+			detached: undefined,
+			detachedReason,
+			exitCode: 1,
+			error: failureMessage,
+			finalOutput: failureMessage,
+			progress: failedProgress,
+			progressSummary: {
+				toolCount: failedProgress.toolCount,
+				tokens: failedProgress.tokens,
+				durationMs: failedProgress.durationMs,
+			},
+			acceptance: publishedReceipt.acceptance
+				? buildSkippedAcceptanceLedger(publishedReceipt.acceptance.effectiveAcceptance, { id: "completion-pipeline", message: failureMessage })
+				: undefined,
+		};
+		if (strictContract) attachContractProjections(failedResult);
+		try {
+			// Replace the provisional detach receipt metadata with the authoritative
+			// terminal failure. Persistence remains best-effort and cannot orphan work.
+			persistSingleResultMetadata({
+				metadataPath: failedResult.artifactPaths?.metadataPath,
+				enabled: options.artifactConfig?.enabled !== false && options.artifactConfig?.includeMetadata !== false,
+				runId: options.runId,
+				agent: failedResult.agent,
+				task: failedResult.task,
+				result: failedResult,
+			});
+		} catch (metadataError) {
+			failedResult.metadataSaveError = metadataError instanceof Error ? metadataError.message : String(metadataError);
+		}
+		return failedResult;
+	});
+
+	let terminalCallbackInvoked = false;
+	void authoritativeCompletion.then((terminalResult) => {
+		if (!detachedReason || terminalCallbackInvoked) return;
+		terminalCallbackInvoked = true;
+		terminalResult.detached = undefined;
+		terminalResult.detachedReason = detachedReason;
+		try {
+			options.onDetachedExit?.(terminalResult);
+		} catch {
+			// The authoritative result has settled. Consumer callback failures are
+			// contained here; each consumer owns cleanup through its own finally block.
+		}
+	}).catch(() => {
+		// Attached completion rejection remains observable through the returned
+		// promise without becoming an unhandled side-channel rejection.
+	}).finally(() => {
+		originSignal?.removeEventListener("abort", forwardOriginAbort);
+	});
+
+	return Promise.race([authoritativeCompletion, receipt]);
 }

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -489,14 +489,6 @@ function applyControlEventToRememberedForegroundRun(state: SubagentState, event:
 	};
 }
 
-function rememberDetachedForegroundChild(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; index: number; result: SingleResult; events: IntercomEventBus }): void {
-	try {
-		updateRememberedForegroundChild(state, input);
-	} catch (error) {
-		console.error(`Failed to update remembered detached foreground child '${input.runId}:${input.index}':`, error);
-	}
-}
-
 function updateRememberedForegroundChild(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; index: number; result: SingleResult; events: IntercomEventBus }): void {
 	state.foregroundRuns ??= new Map();
 	const updatedAt = Date.now();
@@ -506,23 +498,23 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		state.foregroundRuns.set(input.runId, run);
 	}
 	run.updatedAt = updatedAt;
+	const terminalStatus = resolveSubagentResultStatus({
+		exitCode: input.result.exitCode,
+		...(input.result.acceptance?.status === "rejected" ? { success: false } : {}),
+		interrupted: input.result.interrupted,
+		detached: false,
+		processSignal: input.result.processSignal,
+		timedOut: input.result.timedOut,
+		stopped: input.result.stopped,
+		turnBudgetExceeded: input.result.turnBudgetExceeded,
+	});
 	const child = run.children[input.index] ?? { agent: input.result.agent, index: input.index, status: "detached" as const };
 	run.children[input.index] = {
 		...child,
 		agent: input.result.agent,
 		index: input.index,
 		...(input.result.context ? { context: input.result.context } : {}),
-		status: input.result.acceptance?.status === "rejected"
-			? "failed"
-			: resolveSubagentResultStatus({
-				exitCode: input.result.exitCode,
-				interrupted: input.result.interrupted,
-				detached: false,
-				processSignal: input.result.processSignal,
-				timedOut: input.result.timedOut,
-				stopped: input.result.stopped,
-				turnBudgetExceeded: input.result.turnBudgetExceeded,
-			}),
+		status: terminalStatus,
 		...foregroundChildActivityFromProgress(input.result.progress),
 		updatedAt,
 		...(input.result.exitCode !== undefined ? { exitCode: input.result.exitCode } : {}),
@@ -546,7 +538,7 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 	};
 	trimRememberedForegroundRuns(state);
 	const output = getSingleResultOutput(input.result).trim();
-	const success = input.result.exitCode === 0 && input.result.acceptance?.status !== "rejected";
+	const success = terminalStatus === "completed";
 	const summary = !success && input.result.error
 		? `${input.result.error}${output ? `\n\nOutput:\n${output}` : ""}`
 		: output || input.result.error || "Detached child exited without final output.";
@@ -562,7 +554,12 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		success,
 		summary,
 		exitCode: input.result.exitCode,
-		state: success ? "complete" : "failed",
+		state: terminalStatus === "completed" ? "complete" : terminalStatus,
+		...(input.result.interrupted !== undefined ? { interrupted: input.result.interrupted } : {}),
+		...(input.result.stopped !== undefined ? { stopped: input.result.stopped } : {}),
+		...(input.result.processSignal !== undefined ? { processSignal: input.result.processSignal } : {}),
+		...(input.result.timedOut !== undefined ? { timedOut: input.result.timedOut } : {}),
+		...(input.result.turnBudgetExceeded !== undefined ? { turnBudgetExceeded: input.result.turnBudgetExceeded } : {}),
 		timestamp: updatedAt,
 		cwd: input.cwd,
 		sessionFile: input.result.sessionFile,
@@ -2403,7 +2400,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		turnBudget: data.turnBudget,
 		onDetachedExit: (index, result) => {
 			try {
-				rememberDetachedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, index, result, events: deps.pi.events });
+				updateRememberedForegroundChild(deps.state, { runId, mode: "chain", cwd: effectiveCwd, sessionId: data.parentSessionId, index, result, events: deps.pi.events });
 			} finally {
 				removeForegroundControlIfIdle(deps.state, runId);
 			}
@@ -2787,7 +2784,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			onControlEvent: input.onControlEvent,
 			onDetachedExit: (result) => {
 				try {
-					rememberDetachedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents });
+					updateRememberedForegroundChild(input.state, { runId: input.runId, mode: "parallel", cwd: taskCwd, sessionId: input.parentSessionId, index, result, events: input.intercomEvents });
 				} finally {
 					try {
 						if (input.foregroundControl) finishForegroundChild(input.foregroundControl, index);
@@ -3482,7 +3479,11 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			acceptanceContext: { mode: "single" },
 			onDetachedExit: (result) => {
 				try {
-					rememberDetachedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events });
+					try {
+						updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: effectiveCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events });
+					} catch {
+						// Remembered foreground state is best-effort; run history and cleanup must still complete.
+					}
 				} finally {
 					try {
 						if (!artifactConfig.enabled) cleanupStructuredOutputRuntime(structuredRuntime);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -851,6 +851,8 @@ export interface SingleResult {
 	savedOutputPath?: string;
 	outputReference?: SavedOutputReference;
 	outputSaveError?: string;
+	/** Best-effort metadata persistence failure; execution and receipt publication continue. */
+	metadataSaveError?: string;
 	structuredOutput?: unknown;
 	structuredOutputFailed?: boolean;
 	structuredOutputPath?: string;
@@ -1474,6 +1476,11 @@ export interface RunSyncOptions {
 	intercomEvents?: IntercomEventBus;
 	onUpdate?: (r: import("@earendil-works/pi-agent-core").AgentToolResult<Details>) => void;
 	onControlEvent?: (event: ControlEvent) => void;
+	/** Exposes a non-terminating detach callback while the child is active. */
+	onDetachReady?: (detach: (reason?: string) => boolean) => void;
+	/** Internal foreground receipt proposal; returns true only when the outer waiter accepted it. */
+	onDetachReceipt?: (result: SingleResult) => boolean;
+	/** Authoritative terminal result, emitted only after the full detached run finalizes. */
 	onDetachedExit?: (result: SingleResult) => void;
 	controlConfig?: ResolvedControlConfig;
 	intercomSessionName?: string;

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -3278,6 +3278,464 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.finalOutput ?? "", /Interrupted/);
 	});
 
+	it("supports synchronous user detach and rejects duplicate and late detach calls", async () => {
+		mockPi.onCall({ steps: [
+			{ delay: 500, jsonl: [events.assistantMessage("completed after user detach")] },
+		] });
+		let detachActive: ((reason?: string) => boolean) | undefined;
+		let detachAccepted = false;
+		let duplicateAccepted = true;
+		let recoveredResult: RunSyncResult | undefined;
+
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Keep working", {
+			runId: "user-foreground-detach",
+			acceptance: false,
+			onDetachReady: (detach: (reason?: string) => boolean) => {
+				detachActive = detach;
+				detachAccepted = detach("user request");
+				duplicateAccepted = detach("user request");
+			},
+			onDetachedExit: (postExit) => { recoveredResult = postExit as RunSyncResult; },
+		});
+
+		assert.equal(detachAccepted, true);
+		assert.equal(duplicateAccepted, false);
+		assert.equal(recoveredResult, undefined, "foreground result should return before the child completes");
+		assert.equal(result.exitCode, -2);
+		assert.equal(result.detached, true);
+		assert.equal(result.detachedReason, "user request");
+		assert.equal(result.finalOutput, "Detached at user request before task completion.");
+		assert.equal(result.processSignal, undefined);
+
+		for (let attempt = 0; attempt < 100 && !recoveredResult; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(recoveredResult);
+		assert.equal(recoveredResult.exitCode, 0);
+		assert.equal(recoveredResult.processSignal, undefined);
+		assert.equal(recoveredResult.finalOutput, "completed after user detach");
+		assert.equal(detachActive?.("user request"), false, "detach must reject calls after child exit");
+	});
+
+	it("produces the same authoritative terminal result attached and detached", async () => {
+		mockPi.onCall({ output: "authoritative answer" });
+		mockPi.onCall({ steps: [{ delay: 75, jsonl: [events.assistantMessage("authoritative answer")] }] });
+		const agents = makeAgentConfigs(["echo"]);
+		const attached = await runSync(tempDir, agents, "echo", "Equivalent task", {
+			runId: "attached-authoritative-result",
+			acceptance: false,
+		});
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, agents, "echo", "Equivalent task", {
+			runId: "detached-authoritative-result",
+			acceptance: false,
+			onDetachReady: (detach) => assert.equal(detach("user request"), true),
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.deepEqual(
+			{
+				exitCode: terminal.exitCode,
+				finalOutput: terminal.finalOutput,
+				usage: terminal.usage,
+				progressStatus: terminal.progress.status,
+				acceptanceStatus: terminal.acceptance?.status,
+			},
+			{
+				exitCode: attached.exitCode,
+				finalOutput: attached.finalOutput,
+				usage: attached.usage,
+				progressStatus: attached.progress.status,
+				acceptanceStatus: attached.acceptance?.status,
+			},
+		);
+		assert.equal(terminal.detached, undefined);
+		assert.equal(terminal.detachedReason, "user request");
+	});
+
+	it("isolates every nested detach receipt field from terminal completion and later sanitization", async () => {
+		const receiptReport = [
+			"receipt snapshot",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "receipt evidence" }],
+				changedFiles: ["src/receipt.ts"],
+				testsAddedOrUpdated: ["test/receipt.test.ts"],
+				commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+				residualRisks: [],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n");
+		const terminalReport = [
+			"terminal answer",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "terminal isolation verified" }],
+				changedFiles: ["src/receipt.ts"],
+				testsAddedOrUpdated: ["test/receipt.test.ts"],
+				commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+				residualRisks: [],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n");
+		mockPi.onCall({ steps: [
+			{ jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: receiptReport }],
+					model: "mock/test-model",
+					stopReason: "toolUse",
+					usage: { input: 7, output: 3, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+				},
+			}] },
+			{ delay: 300, jsonl: [events.assistantMessage(terminalReport)] },
+		] });
+		let detach: ((reason?: string) => boolean) | undefined;
+		let detached = false;
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Keep the receipt isolated", {
+			runId: "detached-deep-receipt-isolation",
+			agentContract: { version: 1 },
+			acceptance: {
+				level: "checked",
+				criteria: [{
+					id: "criterion-1",
+					must: "Keep detach receipt state isolated",
+					evidence: ["changed-files", "tests-added", "commands-run", "residual-risks", "no-staged-files"],
+				}],
+			},
+			onDetachReady: (detachAttempt) => { detach = detachAttempt; },
+			onUpdate: (update: { content?: Array<{ text?: string }> }) => {
+				if (detached || !update.content?.[0]?.text?.includes("receipt snapshot")) return;
+				detached = detach?.("user request") === true;
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+
+		assert.equal(receipt.detached, true);
+		const receiptMessages = receipt.messages as Array<{
+			role?: string;
+			model?: string;
+			content: Array<{ type?: string; text?: string; callerOwned?: boolean }>;
+		}>;
+		const callerOwnedReceiptText = `caller-owned mutation\n${receiptReport}`;
+		(receipt.agentContract as unknown as { version: number }).version = 999;
+		receiptMessages[0]!.model = "caller-owned/model";
+		receiptMessages[0]!.content[0]!.text = callerOwnedReceiptText;
+		receiptMessages[0]!.content[0]!.callerOwned = true;
+		receiptMessages[0]!.content.push({ type: "text", text: "caller-only content" });
+		receiptMessages.push({ role: "assistant", model: "caller-only/model", content: [{ type: "text", text: "caller-only message" }] });
+		const mutableAcceptance = receipt.acceptance as unknown as {
+			status: string;
+			effectiveAcceptance: { level: string; criteria: Array<{ must: string }> };
+			criteria: Array<{ must: string }>;
+		};
+		mutableAcceptance.status = "rejected";
+		mutableAcceptance.effectiveAcceptance.level = "none";
+		mutableAcceptance.effectiveAcceptance.criteria[0]!.must = "caller corrupted effective criterion";
+		mutableAcceptance.criteria[0]!.must = "caller corrupted ledger criterion";
+		receipt.progress.status = "failed";
+		(receipt.progress as unknown as { recentOutput: string[] }).recentOutput.push("caller-only progress");
+		receipt.usage.turns = 999;
+		receipt.usage.input = 999;
+		receipt.attemptedModels = ["caller-only/model"];
+		receipt.modelAttempts = [{ success: false, exitCode: 99, error: "caller-only attempt" }];
+		receipt.effects = { fileMutation: { status: "missing", expected: true, attempted: false, message: "caller-only effect" } };
+		receipt.execution = { status: "failed", success: false, exitCode: 99 };
+		receipt.review = { status: "blockers" };
+
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.exitCode, 0);
+		assert.equal(terminal.finalOutput, "terminal answer");
+		assert.deepEqual(terminal.agentContract, { version: 1 });
+		assert.equal(terminal.acceptance?.status, "checked");
+		assert.equal(terminal.acceptance?.runtimeChecks.every((check) => check.status === "passed"), true);
+		assert.equal(terminal.progress.status, "completed");
+		assert.deepEqual(terminal.usage, { turns: 2, input: 107, output: 53, cacheRead: 0, cacheWrite: 0, cost: 0.002 });
+		assert.deepEqual(terminal.attemptedModels, ["mock/test-model"]);
+		assert.deepEqual(terminal.modelAttempts?.map((attempt) => ({ success: attempt.success, exitCode: attempt.exitCode })), [{ success: true, exitCode: 0 }]);
+		assert.equal(terminal.execution?.status, "completed");
+		assert.equal(terminal.execution?.success, true);
+		assert.equal(terminal.review?.status, "not-requested");
+		assert.deepEqual(terminal.effects, {});
+		assert.doesNotMatch(JSON.stringify(terminal.messages), /acceptance-report/);
+		assert.equal(receiptMessages[0]!.content[0]!.text, callerOwnedReceiptText, "terminal report sanitization must not mutate the caller receipt");
+		assert.equal(receiptMessages[0]!.content[0]!.callerOwned, true);
+		assert.equal(receiptMessages.length, 2);
+	});
+
+	it("keeps the full fallback loop and authoritative aggregation alive after detach", async () => {
+		mockPi.onCall({
+			jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "temporary provider failure" }],
+					model: "openai/gpt-5-mini",
+					errorMessage: "rate limit exceeded",
+					usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } },
+				},
+			}],
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "Recovered on detached fallback" });
+		const agents = [makeAgent("echo", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+		let terminal: RunSyncResult | undefined;
+
+		const receipt = await runSync(tempDir, agents, "echo", "Task", {
+			runId: "detached-fallback-loop",
+			acceptance: false,
+			onDetachReady: (detach) => assert.equal(detach("user request"), true),
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 300 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.detached, undefined, "terminal status must not remain detached");
+		assert.equal(terminal.detachedReason, "user request");
+		assert.equal(terminal.exitCode, 0);
+		assert.equal(terminal.finalOutput, "Recovered on detached fallback");
+		assert.deepEqual(terminal.attemptedModels, ["openai/gpt-5-mini", "anthropic/claude-sonnet-4"]);
+		assert.deepEqual(terminal.modelAttempts?.map((attempt) => attempt.success), [false, true]);
+		assert.equal(terminal.usage.turns, 2);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
+	it("terminalizes a post-receipt completion pipeline throw exactly once with strict projections", async () => {
+		mockPi.onCall({ steps: [{ delay: 75, jsonl: [events.assistantMessage("answer before callback failure")] }] });
+		let terminal: RunSyncResult | undefined;
+		let callbackCount = 0;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "detached-completion-pipeline-throw",
+			acceptance: { level: "checked", criteria: ["result is checked"] },
+			agentContract: { version: 1 },
+			onDetachReady: (detach) => {
+				assert.equal(detach("user request"), true);
+			},
+			onUpdate: (update: { details?: { progress?: Array<{ status?: string }> } }) => {
+				if (update.details?.progress?.[0]?.status === "completed") throw new Error("terminal consumer update failed");
+			},
+			onDetachedExit: (result) => {
+				callbackCount++;
+				terminal = result as RunSyncResult;
+			},
+		});
+		assert.equal(receipt.detached, true);
+		(receipt.agentContract as unknown as { version: number }).version = 999;
+		receipt.messages.push({ role: "assistant", content: [{ type: "text", text: "caller-only fallback message" }] });
+		const mutableAcceptance = receipt.acceptance as unknown as {
+			status: string;
+			effectiveAcceptance: { level: string; criteria: Array<{ must: string }> };
+		};
+		mutableAcceptance.status = "accepted";
+		mutableAcceptance.effectiveAcceptance.level = "none";
+		mutableAcceptance.effectiveAcceptance.criteria[0]!.must = "caller-only fallback criterion";
+		receipt.progress.status = "completed";
+		receipt.usage.turns = 999;
+		receipt.usage.input = 999;
+		receipt.attemptedModels = ["caller-only/fallback"];
+		receipt.modelAttempts = [{ success: true, exitCode: 0 }];
+		receipt.effects = { fileMutation: { status: "observed", expected: false, attempted: true, message: "caller-only fallback effect" } };
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(callbackCount, 1);
+		assert.equal(terminal.exitCode, 1);
+		assert.equal(terminal.detached, undefined);
+		assert.equal(terminal.detachedReason, "user request");
+		assert.equal(terminal.progress?.status, "failed");
+		assert.equal(terminal.acceptance?.status, "rejected");
+		assert.equal(terminal.acceptance?.runtimeChecks?.[0]?.id, "completion-pipeline");
+		assert.equal(terminal.execution?.status, "failed");
+		assert.equal(terminal.execution?.success, false);
+		assert.equal(terminal.review?.status, "not-requested");
+		assert.deepEqual(terminal.agentContract, { version: 1 });
+		assert.deepEqual(terminal.effects, {});
+		assert.equal(terminal.usage.turns, 0);
+		assert.equal(terminal.attemptedModels, undefined);
+		assert.equal(terminal.modelAttempts, undefined);
+		assert.doesNotMatch(JSON.stringify(terminal.messages), /caller-only fallback message/);
+		assert.match(terminal.error ?? "", /Detached completion pipeline failed after receipt/);
+	});
+
+	it("contains a synchronous onDetachReady throw and completes attached", async () => {
+		mockPi.onCall({ output: "completed while attached" });
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "throwing-detach-ready-consumer",
+			acceptance: false,
+			onDetachReady: () => {
+				throw new Error("bad detach consumer");
+			},
+		});
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.detached, undefined);
+		assert.equal(result.finalOutput, "completed while attached");
+		assert.equal(result.progress.recentOutput.some((line) => /Foreground detach callback failed: bad detach consumer/.test(line)), true);
+	});
+
+	it("reports expected artifact post-processing I/O failures without rejecting", async () => {
+		mockPi.onCall({ steps: [
+			{ jsonl: [events.toolStart("read", { path: "README.md" })] },
+			{ delay: 50, jsonl: [events.assistantMessage("artifact answer")] },
+		] });
+		const artifactsDir = path.join(tempDir, "artifact-output-failure");
+		let sabotaged = false;
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "artifact-output-result-field",
+			acceptance: false,
+			artifactsDir,
+			artifactConfig: { enabled: true },
+			onUpdate: (update: { details?: { results?: Array<{ artifactPaths?: { outputPath?: string } }> } }) => {
+				const outputPath = update.details?.results?.[0]?.artifactPaths?.outputPath;
+				if (sabotaged || !outputPath) return;
+				sabotaged = true;
+				fs.mkdirSync(outputPath);
+			},
+		});
+		assert.equal(sabotaged, true);
+		assert.equal(result.exitCode, 0);
+		assert.match(result.outputSaveError ?? "", /Artifact output post-processing failed/);
+	});
+
+	it("publishes detach despite best-effort receipt metadata persistence failure", async () => {
+		mockPi.onCall({ steps: [{ delay: 100, jsonl: [events.assistantMessage("completed after metadata recovery")] }] });
+		const artifactsDir = path.join(tempDir, "receipt-metadata-failure");
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "detach-receipt-metadata-failure",
+			acceptance: false,
+			artifactsDir,
+			artifactConfig: { enabled: true },
+			onDetachReady: (detach) => {
+				fs.rmSync(artifactsDir, { recursive: true, force: true });
+				fs.writeFileSync(artifactsDir, "block metadata", "utf-8");
+				assert.equal(detach("user request"), true);
+				fs.rmSync(artifactsDir, { force: true });
+				fs.mkdirSync(artifactsDir, { recursive: true });
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+		assert.equal(receipt.detached, true);
+		assert.ok(receipt.metadataSaveError, "receipt should record best-effort metadata persistence failure");
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(terminal?.exitCode, 0);
+	});
+
+	it("contains a throwing detached-exit callback", async () => {
+		mockPi.onCall({ steps: [{ delay: 50, jsonl: [events.assistantMessage("done")] }] });
+		let callbackCount = 0;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "throwing-detached-exit-callback",
+			acceptance: false,
+			onDetachReady: (detach) => assert.equal(detach("user request"), true),
+			onDetachedExit: () => {
+				callbackCount++;
+				throw new Error("consumer callback failed");
+			},
+		});
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && callbackCount === 0; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.equal(callbackCount, 1);
+	});
+
+	it("skips acceptance evaluation when an explicitly interrupted detached result settles", async () => {
+		mockPi.onCall({ steps: [{ delay: 10_000, jsonl: [events.assistantMessage("too late")] }] });
+		const interrupt = new AbortController();
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Task", {
+			runId: "detached-interrupted-acceptance",
+			acceptance: { level: "checked", criteria: ["result is checked"] },
+			interruptSignal: interrupt.signal,
+			onDetachReady: (detach) => {
+				assert.equal(detach("user request"), true);
+				setTimeout(() => interrupt.abort(), 25);
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.interrupted, true);
+		assert.equal(terminal.exitCode, 0);
+		assert.equal(terminal.acceptance?.status, "pending");
+		assert.equal(terminal.acceptance?.runtimeChecks[0]?.status, "not-applicable");
+		assert.equal(terminal.error, undefined);
+	});
+
+	it("linearizes originating abort against detach and keeps explicit interrupt routable afterward", async () => {
+		mockPi.onCall({ steps: [{ delay: 10_000, jsonl: [events.assistantMessage("too late")] }] });
+		const origin = new AbortController();
+		const interrupt = new AbortController();
+		let terminal: RunSyncResult | undefined;
+		const receipt = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Keep working", {
+			runId: "detach-origin-abort-race",
+			acceptance: false,
+			signal: origin.signal,
+			interruptSignal: interrupt.signal,
+			onDetachReady: (detach) => {
+				assert.equal(detach("user request"), true);
+				origin.abort();
+				setTimeout(() => interrupt.abort(), 50);
+			},
+			onDetachedExit: (result) => { terminal = result as RunSyncResult; },
+		});
+
+		assert.equal(receipt.detached, true);
+		for (let attempt = 0; attempt < 100 && !terminal; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(terminal);
+		assert.equal(terminal.interrupted, true, "explicit control interrupt must remain active after detach");
+		assert.equal(terminal.processSignal, "SIGINT");
+		assert.equal(terminal.detached, undefined);
+	});
+
+	it("lets an already-observed originating abort win over detach", async () => {
+		mockPi.onCall({ delay: 10_000 });
+		const origin = new AbortController();
+		let detachAccepted = true;
+		const result = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Abort first", {
+			runId: "origin-abort-wins-detach",
+			signal: origin.signal,
+			onDetachReady: (detach) => {
+				origin.abort();
+				detachAccepted = detach("user request");
+			},
+		});
+		assert.equal(detachAccepted, false);
+		assert.equal(result.detached, undefined);
+	});
+
+	it("keeps the configured runtime timeout active after user detach", async () => {
+		mockPi.onCall({ delay: 10_000 });
+		let recoveredResult: RunSyncResult | undefined;
+		const startedAt = Date.now();
+
+		const result = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Do not run forever", {
+			runId: "user-detach-timeout",
+			timeoutMs: 150,
+			acceptance: false,
+			onDetachReady: (detach: (reason?: string) => boolean) => {
+				assert.equal(detach("user request"), true);
+			},
+			onDetachedExit: (postExit) => { recoveredResult = postExit as RunSyncResult; },
+		});
+
+		assert.equal(result.detached, true);
+		assert.ok(Date.now() - startedAt < 1_000, "detach should release the foreground waiter promptly");
+		for (let attempt = 0; attempt < 300 && !recoveredResult; attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.ok(recoveredResult, "configured timeout should terminate and recover the detached child");
+		assert.equal(recoveredResult.timedOut, true);
+		assert.equal(recoveredResult.error, "Subagent timed out after 150ms.");
+		assert.equal(recoveredResult.progress.status, "failed");
+		assert.ok(Date.now() - startedAt < 5_000, "detached child should remain bounded by runtime enforcement");
+	});
+
 	for (const toolName of ["intercom", "contact_supervisor"]) {
 		it(`detaches cleanly on ${toolName} handoff without aborting the child process`, async () => {
 			const eventBus = createEventBus();
@@ -3323,6 +3781,106 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			assert.equal(accepted, true);
 		});
 	}
+
+	it("reports intercom detach race losses and repeated requests as not accepted", async () => {
+		const abortBus = createEventBus();
+		const abortResponses: boolean[] = [];
+		abortBus.on(INTERCOM_DETACH_RESPONSE_EVENT, (payload) => abortResponses.push((payload as { accepted: boolean }).accepted));
+		mockPi.onCall({ steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need decision" })] }, { delay: 10_000 }] });
+		const origin = new AbortController();
+		let requested = false;
+		const abortedResult = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "intercom-abort-race-loss",
+			allowIntercomDetach: true,
+			intercomEvents: abortBus,
+			signal: origin.signal,
+			onUpdate: (update) => {
+				if (requested || !update.details?.progress?.some((item) => item.currentTool === "contact_supervisor")) return;
+				requested = true;
+				origin.abort();
+				abortBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "abort-race" });
+			},
+		});
+		assert.equal(abortedResult.detached, undefined);
+		assert.deepEqual(abortResponses, [false]);
+
+		const repeatedBus = createEventBus();
+		const repeatedResponses: boolean[] = [];
+		repeatedBus.on(INTERCOM_DETACH_RESPONSE_EVENT, (payload) => repeatedResponses.push((payload as { accepted: boolean }).accepted));
+		mockPi.onCall({ steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need decision" })] }, { delay: 50, jsonl: [events.assistantMessage("done")] }] });
+		let repeated = false;
+		const repeatedReceipt = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "intercom-repeated-detach",
+			allowIntercomDetach: true,
+			intercomEvents: repeatedBus,
+			onUpdate: (update) => {
+				if (repeated || !update.details?.progress?.some((item) => item.currentTool === "contact_supervisor")) return;
+				repeated = true;
+				repeatedBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "first" });
+				repeatedBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "second" });
+			},
+		});
+		assert.equal(repeatedReceipt.detached, true);
+		assert.deepEqual(repeatedResponses, [true, false]);
+	});
+
+	it("does not launch retries or fallbacks after intercom detach and keeps timeout enforcement", async () => {
+		const fallbackBus = createEventBus();
+		mockPi.onCall({
+			steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need decision" })] }],
+			stderr: "rate limit exceeded",
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "must not launch" });
+		let resolveFallbackTerminal!: (result: RunSyncResult) => void;
+		const fallbackTerminal = new Promise<RunSyncResult>((resolve) => { resolveFallbackTerminal = resolve; });
+		let fallbackRequested = false;
+		const receipt = await runSync(tempDir, [makeAgent("echo", { model: "openai/gpt-5-mini", fallbackModels: ["anthropic/claude-sonnet-4"] })], "echo", "Task", {
+			runId: "intercom-no-fallback",
+			acceptance: false,
+			allowIntercomDetach: true,
+			intercomEvents: fallbackBus,
+			onUpdate: (update) => {
+				if (fallbackRequested || !update.details?.progress?.some((item) => item.currentTool === "contact_supervisor")) return;
+				fallbackRequested = true;
+				fallbackBus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "no-fallback" });
+			},
+			onDetachedExit: (result) => { resolveFallbackTerminal(result as RunSyncResult); },
+		});
+		assert.equal(receipt.detached, true);
+		const fallbackResult = await fallbackTerminal;
+		assert.equal(mockPi.callCount(), 1);
+		assert.equal(fallbackResult.exitCode, 1);
+
+		const timeoutBus = createEventBus();
+		mockPi.reset();
+		mockPi.onCall({ delay: 10_000 });
+		let resolveTimeoutTerminal!: (result: RunSyncResult) => void;
+		const timeoutTerminal = new Promise<RunSyncResult>((resolve) => { resolveTimeoutTerminal = resolve; });
+		let timeoutRequested = false;
+		const timeoutReceipt = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Task", {
+			runId: "intercom-timeout-enforced",
+			acceptance: false,
+			timeoutMs: 125,
+			allowIntercomDetach: true,
+			intercomEvents: timeoutBus,
+			onDetachReady: () => {
+				if (timeoutRequested) return;
+				timeoutRequested = true;
+				timeoutBus.emit(INTERCOM_DETACH_REQUEST_EVENT, {
+					requestId: "timeout",
+					runId: "intercom-timeout-enforced",
+					agent: "slow",
+					childIndex: 0,
+				});
+			},
+			onDetachedExit: (result) => { resolveTimeoutTerminal(result as RunSyncResult); },
+		});
+		assert.equal(timeoutReceipt.detached, true);
+		const timeoutResult = await timeoutTerminal;
+		assert.equal(timeoutResult.timedOut, true);
+		assert.equal(timeoutResult.exitCode, 1);
+	});
 
 	it("enforces the stdout protocol limit after foreground detachment", async () => {
 		const eventBus = createEventBus();


### PR DESCRIPTION
Replacement for #710, preserving @magoz's lifecycle contribution and landing it cleanly after the #709 prerequisite from #713.

This separates the immediate foreground detach receipt from authoritative same-runtime terminal completion. Detached foreground children can return a receipt to the parent while the child process continues to finalization, including output/artifact handling, metadata, acceptance/status/result state, and remembered foreground terminal updates.

This intentionally does not add the public `/subagents-detach` command from #711. It only lands the detached completion lifecycle needed before that user-facing command can be safely added.

Credit:

- `CHANGELOG.md` credits `Thanks to @magoz for #708/#709/#710.`
- Commit author preserved as `magoz <apps@magoz.is>`.

Validation:

- `git diff --check`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern "detach|detached|metadata|artifact output" test/integration/single-execution.test.ts` — 25 passed
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern "detached foreground|remembered detached|foreground-detached|detached chain|resume action rejects detached|blocks sibling resume" test/integration/intercom-result-delivery.test.ts` — 5 passed
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern "queued foreground|current-session children are queued or running|hard reported usage" test/integration/single-execution.test.ts` — 2 passed
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/intercom-result-delivery.test.ts` — 36 passed
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern "routes registered strict v1 delegation through the concurrent executor|routes registered strict v2 text delegation through the concurrent executor" test/integration/single-execution.test.ts` — 2 passed
- Exact-head CI for `3e8a43fe`: https://github.com/nicobailon/pi-subagents/actions/runs/30676480638 — Ubuntu, Windows, and Greptile passed

Review:

- Fresh read-only candidate review found no blockers: `/tmp/pi-subagents-710-replacement-review.md`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR finalizes the detached foreground completion lifecycle by separating the immediate receipt returned to the parent from the authoritative terminal result produced when the child process fully completes. It also credits `@magoz` with `#710` in the changelog.

- **`runSync` / `runSyncCompletion` split** (`execution.ts`): The old `runSync` is renamed to `runSyncCompletion`; a new `runSync` wrapper races `authoritativeCompletion` against a `receipt` promise, publishing the receipt as soon as `onDetachReceipt` is accepted and delivering the authoritative terminal result (including acceptance, artifacts, and metadata) via `onDetachedExit` after the child fully exits.
- **`detachForeground` replaces `detachForIntercom`** (`execution.ts`): Builds a snapshot receipt, calls `onDetachReceipt`, and only marks the attempt as detached on coordinator acceptance; the intercom response is now emitted with the actual acceptance boolean rather than a hardcoded `true`.
- **`rememberDetachedForegroundChild` wrapper removed** (`subagent-executor.ts`): Chain and parallel paths call `updateRememberedForegroundChild` directly (cleanup remains in `finally` blocks); the single path adds an inner try/catch for best-effort semantics, and `terminalStatus` extraction now correctly propagates acceptance rejections.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The detach lifecycle redesign is internally consistent and covered by 11 new focused tests, but a CI run against the exact current head is not linked.

The `runSync`/`runSyncCompletion` split, `Promise.race` receipt delivery, and `detachForeground` guard logic are correct — receipt isolation, fallback-loop survival, abort-signal linearization, and timeout enforcement are all exercised by the new tests. The one open item is that the PR description supplies only manual `node --test` invocations rather than an automated CI run for head SHA `3e8a43fe`; the repository's merge-gate policy requires CI on the exact head before merging.

**Files Needing Attention:** No files have code-level concerns; `CHANGELOG.md` carries the open merge-gate process item.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Extends `@magoz` credit from `#708/#709` to `#708/#709/#710` — contributor attribution is correct; no CI link for current head. |
| src/runs/foreground/execution.ts | Core lifecycle split: `runSync` renamed to `runSyncCompletion`; new `runSync` wraps it with `Promise.race([authoritativeCompletion, receipt])`. `detachForeground` replaces `detachForIntercom`, builds a snapshot receipt, calls `onDetachReceipt`, and only marks `detached=true` on coordinator acceptance. `settled` → `lifecycleFinished` merges the old detached+settled guards. Structural logic is sound. |
| src/runs/foreground/subagent-executor.ts | Removes the `rememberDetachedForegroundChild` error-swallowing wrapper; chain/parallel paths call `updateRememberedForegroundChild` directly with cleanup in `finally` blocks; single path adds an inner try/catch for best-effort semantics. `terminalStatus` extraction consolidates the accepted-rejection logic. |
| src/shared/types.ts | Adds `metadataSaveError` to `SingleResult` and `onDetachReady`/`onDetachReceipt` to `RunSyncOptions` — clean additions, no existing fields mutated. |
| test/integration/single-execution.test.ts | Adds 11 focused integration tests covering user-detach receipt/terminal isolation, duplicate-detach rejection, fallback loop survival, pipeline-throw terminalization, abort-signal linearization, metadata-persistence failure tolerance, and timeout enforcement. Tests are portable and aligned with the changed behavior. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant runSync
    participant runSyncCompletion
    participant runSingleAttempt
    participant Child as Child Process

    Caller->>runSync: call(task, options)
    runSync->>runSyncCompletion: start(onDetachReceipt, onDetachReady)
    runSyncCompletion->>runSingleAttempt: spawn attempt
    runSingleAttempt->>Child: spawn process
    runSingleAttempt-->>Caller: onDetachReady(detachFn) [published once]

    alt User or intercom detach triggered
        Caller->>runSingleAttempt: detachFn("user request")
        runSingleAttempt->>runSyncCompletion: onDetachReceipt(snapshot)
        runSyncCompletion->>runSync: onDetachReceipt(snapshot)
        runSync-->>Caller: receipt (Promise.race resolves)
        Note over runSingleAttempt,Child: Child keeps running
        Child-->>runSingleAttempt: process close (real exit code)
        runSingleAttempt-->>runSyncCompletion: finish(exitCode)
        runSyncCompletion->>runSyncCompletion: evaluate acceptance, write artifacts, persist metadata
        runSync->>Caller: onDetachedExit(terminalResult)
    else No detach — normal completion
        Child-->>runSingleAttempt: process close
        runSingleAttempt-->>runSyncCompletion: finish(exitCode)
        runSyncCompletion-->>runSync: authoritativeCompletion resolves
        runSync-->>Caller: result (Promise.race resolves)
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/runs/foreground/subagent-executor.ts`, line 3480-3494 ([link](https://github.com/nicobailon/pi-subagents/blob/277a8b67a0613330e9866ad4100859c858224a2e/src/runs/foreground/subagent-executor.ts#L3480-L3494)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`recordRun` can be silently skipped on throws from `updateRememberedForegroundChild`**

   The old `rememberDetachedForegroundChild` wrapper caught and swallowed all exceptions, so the caller's `try {...} finally {...}` block never propagated a throw and `recordRun` was always reached. Now that `updateRememberedForegroundChild` is called directly inside the `try` block, any exception it raises (most reachably, an event-handler throw from `input.events.emit`) will propagate out before `recordRun` executes. The `parallel` and `chain` callsites are unaffected because they have no post-finally call, but the `single` path loses a `recordRun` invocation whenever `updateRememberedForegroundChild` throws — silently, since `runSync`'s outer catch block swallows the error.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/runs/foreground/subagent-executor.ts
   Line: 3480-3494

   Comment:
   **`recordRun` can be silently skipped on throws from `updateRememberedForegroundChild`**

   The old `rememberDetachedForegroundChild` wrapper caught and swallowed all exceptions, so the caller's `try {...} finally {...}` block never propagated a throw and `recordRun` was always reached. Now that `updateRememberedForegroundChild` is called directly inside the `try` block, any exception it raises (most reachably, an event-handler throw from `input.events.emit`) will propagate out before `recordRun` executes. The `parallel` and `chain` callsites are unaffected because they have no post-finally call, but the `single` path loses a `recordRun` invocation whenever `updateRememberedForegroundChild` throws — silently, since `runSync`'s outer catch block swallows the error.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

2. `CHANGELOG.md`, line 1 ([link](https://github.com/nicobailon/pi-subagents/blob/277a8b67a0613330e9866ad4100859c858224a2e/CHANGELOG.md#L1)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Merge gate: no CI evidence on the exact PR head**

   The PR description documents manual test command runs but does not include a link to automated CI results against head SHA `277a8b67`. Per the repository's merge-gate policy, required CI must have run on the exact PR head before merging. If a CI pipeline is configured (GitHub Actions, etc.), attaching a passing run link here satisfies this gate; if CI is intentionally manual-only for this repo, this note can be disregarded.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: CHANGELOG.md
   Line: 1

   Comment:
   **Merge gate: no CI evidence on the exact PR head**

   The PR description documents manual test command runs but does not include a link to automated CI results against head SHA `277a8b67`. Per the repository's merge-gate policy, required CI must have run on the exact PR head before merging. If a CI pipeline is configured (GitHub Actions, etc.), attaching a passing run link here satisfies this gate; if CI is intentionally manual-only for this repo, this note can be disregarded.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

3. `CHANGELOG.md`, line 1 ([link](https://github.com/nicobailon/pi-subagents/blob/3e8a43fe9dc9e74d0b89ff3213e82e5292a614d8/CHANGELOG.md#L1)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Merge gate: no CI evidence on exact PR head**

   The PR description provides manual `node --test` runs but no link to automated CI results for the current head SHA `3e8a43fe`. Per the repository's merge-gate policy, required CI must have passed on the exact head before merging. If a CI pipeline exists, attaching the passing run link here satisfies this gate.

   **Rule Used:** Do not state that a PR is safe to merge or merge-r... ([source](.greptile))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: CHANGELOG.md
   Line: 1
   
   Comment:
   **Merge gate: no CI evidence on exact PR head**
   
   The PR description provides manual `node --test` runs but no link to automated CI results for the current head SHA `3e8a43fe`. Per the repository's merge-gate policy, required CI must have passed on the exact head before merging. If a CI pipeline exists, attaching the passing run link here satisfies this gate.
   
   **Rule Used:** Do not state that a PR is safe to merge or merge-r... ([source](.greptile))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
CHANGELOG.md:1
**Merge gate: no CI evidence on exact PR head**

The PR description provides manual `node --test` runs but no link to automated CI results for the current head SHA `3e8a43fe`. Per the repository's merge-gate policy, required CI must have passed on the exact head before merging. If a CI pipeline exists, attaching the passing run link here satisfies this gate.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: finalize detached foreground comple..."](https://github.com/nicobailon/pi-subagents/commit/3e8a43fe9dc9e74d0b89ff3213e82e5292a614d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49258852)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - Do not state that a PR is safe to merge or merge-r... ([source](.greptile))
- Rule used - When a change includes a CHANGELOG.md entry for ma... ([source](.greptile))
- Rule used - Do not hide useful error signals by wrapping throw... ([source](.greptile))
- Rule used - Report only concrete, reachable release risks, dir... ([source](.greptile))
</details>


<!-- /greptile_comment -->
