### PR TITLE
fix: show model and thinking level in persistent Fleet widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Reduced repeated runtime filesystem work by caching stable Pi config-directory resolution, incrementally sanitizing run history, and limiting nested control-result polling to files created for the active request.
 
 ### Fixed
+- Restored model and thinking-effort badges in the persistent running-subagents status widget.
 - Retained foreground controls until scheduling owners and active children settle, keeping queued foreground work steerable after early result handling. Thanks to @magoz for #708/#709/#710.
 - Render resolved model and thinking effort for active and recent foreground children in Fleet inspector summaries and details. Thanks to @saleemlala for #706.
 - Resynchronized async job control-event scans that resume inside an oversized JSONL record, avoiding malformed-tail parse noise while preserving later control events. Thanks to @vicary for #700.

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -8,7 +8,7 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { ChainClarifyComponent, type ChainClarifyResult, type BehaviorOverride } from "./chain-clarify.ts";
-import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
+import { resolveEffectiveThinking, toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import {
 	resolveChainTemplates,
 	createChainDir,
@@ -357,10 +357,13 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 			taskStr = injectSingleOutputInstruction(taskStr, outputPath, taskAgentConfig);
 			const interruptController = new AbortController();
 			if (input.foregroundControl) {
+				const thinking = resolveEffectiveThinking(effectiveModel, input.thinkingOverrideForTask?.(task.agent, childIndex, effectiveModel));
 				beginForegroundChild(input.foregroundControl, {
 					index: childIndex,
 					agent: task.agent,
 					description: cleanTask.trim(),
+					...(effectiveModel ? { model: effectiveModel } : {}),
+					...(thinking ? { thinking } : {}),
 					interrupt: () => {
 						if (interruptController.signal.aborted) return false;
 						interruptController.abort();
@@ -1296,10 +1299,13 @@ ${step.message}` : ""}` }],
 			const childIndex = globalTaskIndex;
 			const interruptController = new AbortController();
 			if (foregroundControl) {
+				const thinking = resolveEffectiveThinking(effectiveModel, params.thinkingOverrideForTask?.(seqStep.agent, childIndex, effectiveModel));
 				beginForegroundChild(foregroundControl, {
 					index: childIndex,
 					agent: seqStep.agent,
 					description: cleanTask.trim(),
+					...(effectiveModel ? { model: effectiveModel } : {}),
+					...(thinking ? { thinking } : {}),
 					interrupt: () => {
 						if (interruptController.signal.aborted) return false;
 						interruptController.abort();

--- a/src/runs/foreground/foreground-control.ts
+++ b/src/runs/foreground/foreground-control.ts
@@ -4,6 +4,8 @@ interface BeginForegroundChildInput {
 	index: number;
 	agent: string;
 	description?: string;
+	model?: string;
+	thinking?: string;
 	interrupt: () => boolean;
 	detach?: () => boolean;
 }
@@ -86,6 +88,8 @@ export function beginForegroundChild(control: ForegroundRunControl, input: Begin
 		...(input.description ? { description: input.description } : {}),
 		startedAt: now,
 		updatedAt: now,
+		...(input.model ? { model: input.model } : {}),
+		...(input.thinking ? { thinking: input.thinking } : {}),
 	};
 	child.interrupt = () => {
 		if (!input.interrupt()) return false;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -6,7 +6,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { resolveAgentName, type AgentConfig, type AgentScope } from "../../agents/agents.ts";
 import { getArtifactsDir, getProjectChainRunsDir } from "../../shared/artifacts.ts";
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
-import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
+import { resolveEffectiveThinking, toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import { executeChain } from "./chain-execution.ts";
 import {
 	beginForegroundChild,
@@ -2744,10 +2744,14 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		);
 		const interruptController = new AbortController();
 		if (input.foregroundControl) {
+			const model = input.modelOverrides[index];
+			const thinking = resolveEffectiveThinking(model, input.thinkingOverrideForTask(task.agent, index, model));
 			beginForegroundChild(input.foregroundControl, {
 				index,
 				agent: task.agent,
 				description: input.taskDescriptions[index],
+				...(model ? { model } : {}),
+				...(thinking ? { thinking } : {}),
 				interrupt: () => {
 					if (interruptController.signal.aborted) return false;
 					interruptController.abort();
@@ -3420,10 +3424,13 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	let detachForeground: ((reason?: string) => boolean) | undefined;
 	const foregroundControl = deps.state.foregroundControls.get(runId);
 	if (foregroundControl) {
+		const thinking = resolveEffectiveThinking(modelOverride, thinkingOverrideForTask(params.agent!, 0, modelOverride));
 		beginForegroundChild(foregroundControl, {
 			index: 0,
 			agent: params.agent!,
 			description: foregroundControl.description,
+			...(modelOverride ? { model: modelOverride } : {}),
+			...(thinking ? { thinking } : {}),
 			interrupt: () => {
 				if (interruptController.signal.aborted) return false;
 				interruptController.abort();

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { type EditorComponent, isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { formatModelThinking } from "../shared/formatters.ts";
 import type { AsyncJobStep, FleetViewPlacement, SubagentState } from "../shared/types.ts";
 
 export const FLEET_STATUS_WIDGET_KEY = "subagent-fleet-status";
@@ -14,6 +15,7 @@ type FleetStatusTui = {
 type FleetStatusEntry = {
 	key: string;
 	agent: string;
+	modelThinking?: string;
 	description?: string;
 	startedAt: number;
 	tokens: number;
@@ -65,9 +67,11 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 	for (const control of state.foregroundControls.values()) {
 		if (control.activeChildren) {
 			for (const child of [...control.activeChildren.values()].sort((left, right) => left.index - right.index)) {
+				const modelThinking = formatModelThinking(child.model, child.thinking) || undefined;
 				entries.push({
 					key: `foreground-active:${control.runId}:${child.index}`,
 					agent: child.agent,
+					...(modelThinking ? { modelThinking } : {}),
 					description: child.description,
 					startedAt: child.startedAt,
 					tokens: child.tokens ?? 0,
@@ -75,9 +79,11 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 			}
 			continue;
 		}
+		const modelThinking = formatModelThinking(control.model, control.thinking) || undefined;
 		entries.push({
 			key: `foreground-active:${control.runId}:${control.currentIndex ?? 0}`,
 			agent: control.currentAgent ?? control.mode,
+			...(modelThinking ? { modelThinking } : {}),
 			description: control.description,
 			startedAt: control.startedAt,
 			tokens: control.tokens ?? 0,
@@ -108,9 +114,11 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 			if (!isActiveState(step.status)) continue;
 			const index = step.index ?? offset;
 			if (step.status === "pending" && job.mode === "chain" && !job.activeParallelGroup && index !== (job.currentStep ?? 0)) continue;
+			const modelThinking = formatModelThinking(step.model, step.thinking) || undefined;
 			entries.push({
 				key: `async:${job.asyncId}:${index}`,
 				agent: step.label ? `${step.label} (${step.agent})` : step.agent,
+				...(modelThinking ? { modelThinking } : {}),
 				description: job.description,
 				startedAt: step.startedAt ?? startedAt,
 				tokens: step.tokens?.total ?? (steps.length === 1 ? job.totalTokens?.total ?? 0 : 0),
@@ -316,7 +324,8 @@ export class SubagentFleetStatus {
 
 	private renderEntry(rosterIndex: number, selectedIndex: number, entry: FleetStatusEntry, width: number, theme: Theme): string {
 		const description = entry.description?.replace(/\s+/g, " ").trim();
-		const left = `  ${this.bullet(rosterIndex, selectedIndex, theme)} ${theme.fg("muted", entry.agent)}${description ? `  ${description}` : ""}`;
+		const agent = entry.modelThinking ? `${entry.agent} (${entry.modelThinking})` : entry.agent;
+		const left = `  ${this.bullet(rosterIndex, selectedIndex, theme)} ${theme.fg("muted", agent)}${description ? `  ${description}` : ""}`;
 		const elapsed = Date.now() - entry.startedAt;
 		const right = theme.fg("dim", `${formatFleetElapsed(elapsed)} · ${formatFleetTokens(entry.tokens)}`);
 		return rightAlign(left, right, width);
@@ -362,6 +371,7 @@ export class SubagentFleetStatus {
 			entries: this.entries.map((entry) => [
 				entry.key,
 				entry.agent,
+				entry.modelThinking,
 				entry.description,
 				Math.round((now - entry.startedAt) / 1000),
 				entry.tokens,

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -64,6 +64,7 @@ describe("below-editor subagent FleetView", () => {
 				updatedAt: now,
 				currentAgent: `worker-${index}`,
 				description: index === 0 ? "Inspect\nmodule 0" : `Inspect module ${index}`,
+				...(index === 0 ? { model: "anthropic/fable-5", thinking: "low" } : {}),
 				tokens: index === 0 ? 13_100 : index,
 			});
 		}
@@ -93,7 +94,7 @@ describe("below-editor subagent FleetView", () => {
 			const component = widgetFactory!({ requestRender() {} }, theme);
 			const lines = component.render(80);
 			assert.ok(lines.some((line) => line.includes("⏺ main")));
-			assert.ok(lines.some((line) => line.includes("worker-0") && line.includes("Inspect module 0")));
+			assert.ok(lines.some((line) => line.includes("worker-0 (fable-5 · thinking low)") && line.includes("Inspect module 0")));
 			assert.ok(lines.some((line) => line.includes("11s · ↓ 13.1k tokens")));
 			assert.ok(lines.some((line) => line.includes("↓ 2 more")));
 			for (const line of lines) assert.ok(visibleWidth(line) <= 80, `line exceeded width: ${line}`);
@@ -413,7 +414,7 @@ describe("below-editor subagent FleetView", () => {
 			startedAt: 100,
 			updatedAt: 200,
 			steps: [
-				{ agent: "reviewer", index: 0, status: "running", startedAt: 120, tokens: { input: 4_000, output: 200, total: 4_200 } },
+				{ agent: "reviewer", index: 0, status: "running", startedAt: 120, model: "openai/gpt-5", thinking: "medium", tokens: { input: 4_000, output: 200, total: 4_200 } },
 				{ agent: "worker", index: 1, status: "complete", tokens: { input: 100, output: 20, total: 120 } },
 			],
 		});
@@ -433,7 +434,7 @@ describe("below-editor subagent FleetView", () => {
 		try {
 			fleet.setContext(ctx);
 			const lines = widgetFactory!({ requestRender() {} }, theme).render(100);
-			assert.ok(lines.some((line) => line.includes("reviewer") && line.includes("Review the authentication changes")));
+			assert.ok(lines.some((line) => line.includes("reviewer (gpt-5 · thinking medium)") && line.includes("Review the authentication")));
 			assert.ok(lines.some((line) => line.includes("↓ 4.2k tokens")));
 			assert.ok(!lines.some((line) => line.includes("worker")), "completed async children should leave the status fleet");
 		} finally {


### PR DESCRIPTION
## Summary

Restores model and thinking-effort badges for running subagents in the persistent FleetView status widget.

Regression: the persistent FleetView widget (introduced in 4b1df555) never carried forward the model/thinking display the older run status view had (e99bf5b8). `FleetStatusEntry` only projected agent/description/elapsed/tokens, so the user could not tell which model or effort level a running child was using. 57bfc83b restored this in the fleet overlay inspector but not the bottom widget.

## Changes

- Add `modelThinking` to persistent Fleet status entries; rows render as `agent (model · thinking level)` when known, unchanged otherwise.
- Project model/thinking from active foreground run controls, foreground parallel children, and async steps via the existing `formatModelThinking` helper (provider trim + thinking normalization, no raw paths).
- Include `modelThinking` in the widget render key so changes invalidate immediately.
- Seed foreground child controls with launch-resolved model/thinking for single, parallel, and chain children; progress updates remain authoritative.

## Validation

- `git diff --check` — clean
- `node --experimental-strip-types --test test/unit/fleet-status.test.ts` — 14 tests pass
- `npm run test:unit` — 1499 pass, 1 skipped, 0 failures
- Fresh read-only review: Pass, no findings (projection correctness, render invalidation, lifecycle safety vs #714/#715 detach paths, formatting, test adequacy).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores model and thinking-effort badges to the persistent Fleet status widget by propagating `model`/`thinking` through `beginForegroundChild` and projecting them as a formatted `modelThinking` string in every `FleetStatusEntry`. The render key now includes `modelThinking` so the widget invalidates immediately when that value changes.

- `foreground-control.ts` extends `BeginForegroundChildInput` with optional `model`/`thinking`, seeding the `ForegroundChildControl` at launch so badges appear before the first authoritative progress event.
- `subagent-executor.ts` and `chain-execution.ts` each call `resolveEffectiveThinking` to normalise suffix- and config-based levels before passing them to `beginForegroundChild` for single, parallel, and chain children.
- `fleet-status.ts` reads these fields via the existing `formatModelThinking` helper (provider trim + thinking normalisation) and renders them as `agent (model · thinking level)` inline; two focused tests assert the formatted output.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The code changes are focused and correct — model/thinking seeds flow cleanly from launch through the widget render. The only blocker is that the CI workflow (unit + integration + E2E on Linux and Windows) has not been confirmed to have run against the exact head commit.

The implementation is straightforward: three call-sites seed model/thinking into beginForegroundChild, the FleetStatusEntry type gains an optional field populated by the existing formatModelThinking helper, and the render key includes the new field. Two focused tests assert the formatted badge text and line-width bounds. Nothing in the changed logic introduces a new failure mode. The only unresolved gate is CI on the exact head SHA — the workflow runs integration and E2E suites on both Linux and Windows, and only a local unit-test run has been recorded.

**Files Needing Attention:** No individual file needs a second look; the unresolved item is the missing CI confirmation on head 8e4036bd.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tui/fleet-status.ts | Adds optional `modelThinking` field to `FleetStatusEntry`, projects it via `formatModelThinking` from foreground controls and async job steps, renders it inline in `renderEntry`, and includes it in the `getRenderKey` tuple for correct invalidation. |
| src/runs/foreground/foreground-control.ts | Extends `BeginForegroundChildInput` with optional `model` and `thinking`; seeds them onto the initial `ForegroundChildControl` object so the widget can show them before the first authoritative progress event arrives. |
| src/runs/foreground/subagent-executor.ts | Seeds `model` and `thinking` into `beginForegroundChild` for both the single-path and parallel-task entry points, using `resolveEffectiveThinking` to normalise suffix- and config-based thinking levels before seeding. |
| src/runs/foreground/chain-execution.ts | Seeds model/thinking in `beginForegroundChild` for parallel chain tasks and sequential chain steps; mirrors the pattern in `subagent-executor.ts`. |
| test/unit/fleet-status.test.ts | Updates two existing rendering tests to seed model/thinking and assert the formatted badge text (`fable-5 · thinking low`, `gpt-5 · thinking medium`) appears in widget output; width-bounding assertion retained. |
| CHANGELOG.md | Adds a Fixed entry for the widget regression. Entry is the author's own work so no external-contributor credit is required; however CI on the exact head SHA has not been confirmed. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Executor as subagent-executor / chain-execution
    participant FC as foreground-control
    participant State as SubagentState
    participant FleetStatus as fleet-status (collectFleetStatusEntries)
    participant Widget as FleetView Widget

    Executor->>FC: "beginForegroundChild({ model, thinking, ... })"
    FC->>State: "activeChildren.set(index, child{ model, thinking })"
    note over FC,State: Seeds model/thinking at launch time

    loop Agent running
        Executor->>FC: updateForegroundChild(index, progress)
        FC->>State: copyProgress → child.model, child.thinking (authoritative)
    end

    FleetStatus->>State: read foregroundControls / asyncJobs
    FleetStatus->>FleetStatus: formatModelThinking(model, thinking) → modelThinking string
    FleetStatus->>Widget: "FleetStatusEntry{ agent, modelThinking, ... }"
    Widget->>Widget: renderEntry → agent (model · thinking level)
    Widget->>Widget: getRenderKey includes modelThinking → invalidates on change
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
CHANGELOG.md:17
**Merge gate: CI not confirmed on exact head SHA**

The `.github/workflows/test.yml` workflow runs unit, integration, and E2E tests on both `ubuntu-latest` and `windows-latest` for every PR against `main`. The PR description cites only a local `npm run test:unit` run — no CI result is recorded against head `8e4036bd`. Integration and E2E passes (and a clean Windows unit run) are required gates before this reaches main.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: show model and thinking level in pe..."](https://github.com/nicobailon/pi-subagents/commit/8e4036bd400bedc605637dc418231d165a8087c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49280180)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Do not state that a PR is safe to merge or merge-r... ([source](.greptile))

<!-- /greptile_comment -->