### PR TITLE
feat: watchdog scope monitoring, cadence reviews, and main auto-follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added watchdog current-scope context, optional every-N-tools scope-monitor cadence, and visible main-session blocker auto-follow, inspired by Scopey (github.com/ArchAstro/scopey) by Calvin Grunewald (@CalvinGrunewald).
 - Added optional `runtimeAcknowledgedExtensions` status/result/RPC metadata for cooperating child-runtime extensions that emit `subagent:acknowledge-extension`. Thanks to @saleemlala for #705.
 - Added `/subagents-detach` for detaching the active foreground single-subagent run without terminating the child. Thanks to @magoz for #708/#711.
 - Added agent frontmatter aliases and built-in worker aliases for `developer`, `coder`, `implementer`, and `develop`, while keeping canonical names in execution state. Thanks to @selimerunkut for #695.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ The subagent watchdog is not the `reviewer` subagent. `subagents.defaultModel` a
 
 The watchdog reviews repo edits, not ordinary conversation. It runs at the safe `agent_end` boundary only when the current agent or child writer changed the final repo state since the start of that turn. Multiple edits in one turn are coalesced into one review of the final changed state, unchanged/reverted diffs are skipped, and generated `.pi-subagents/` or `tmp/` artifacts do not trigger review. In orchestrated runs, each writing child can review its own edited worktree, and the parent can still review the aggregate repo diff after child changes are applied.
 
+When enabled, the watchdog also keeps a bounded in-memory current-scope artifact from real user prompts and prepends it to review input by default (`subagents.watchdog.scope.enabled`). Newer prompts supersede and mutate older prompts, so the reviewer can flag work that no longer serves the current scope as `scope-drift`. Watchdog auto-follow prompts are not recorded as scope.
+
+You can opt into Scopey-style scope monitoring, inspired by [Scopey](https://github.com/ArchAstro/scopey), by setting `subagents.watchdog.cadence.everyNTools` to run additional non-blocking reviews every N tool results. Cadence warnings are transcript-visible and delivered with Pi's `steer` mode after the current tool boundary; they are never hidden. The same configured watchdog model is used for all checks, so choose a cheap model for frequent monitoring or a strong model for rarer adversarial review.
+
+When the watchdog displays a blocker at `agent_end`, the existing `subagents.watchdog.autoFollow` policy can queue a visible follow-up user message asking the agent to address it. Auto-follow only runs while the watchdog is enabled, respects `maxAttempts`, and stops on repeated identical blockers using `stalemateRepeats`.
+
 When the watchdog is enabled, it also checks changed TypeScript and JavaScript files for fresh language-server diagnostics before the model review. It auto-detects `typescript-language-server` from the project `node_modules/.bin` or `PATH`; it never installs tools or scans the whole workspace. LSP errors surface as watchdog blockers, warnings as concerns, and info/hints stay in status details. Slow or missing servers are reported in `/subagents-watchdog status` without blocking the turn or emitting late mid-turn warnings. Configure the bounds with `subagents.watchdog.lsp.enabled`, `timeoutMs`, `maxFiles`, and `maxDiagnostics`.
 
 Use `/subagents-watchdog recommend-model` to ask pi-subagents for the current strong pairing. The current recommendation policy is Opus 4.8 with thinking high or GPT 5.5 with thinking high. If your main session is using one, the watchdog should use the other when that model is authenticated.
@@ -241,6 +247,8 @@ You can also set the model explicitly:
 
 For settings files, use `subagents.watchdog.main.model` and `subagents.watchdog.main.thinking` for the main watchdog. If `main.model` is omitted, the main watchdog uses the current session model and thinking level. If `main.model` is set without a thinking suffix or `main.thinking`, it runs with thinking off, so prefer `:high` or `"thinking": "high"` for the strong-watchdog pairing.
 
+Default strong-reviewer profile:
+
 ```json
 {
   "subagents": {
@@ -249,6 +257,29 @@ For settings files, use `subagents.watchdog.main.model` and `subagents.watchdog.
       "main": {
         "model": "anthropic/claude-opus-4-8",
         "thinking": "high"
+      }
+    }
+  }
+}
+```
+
+Scopey-style scope monitoring profile:
+
+```json
+{
+  "subagents": {
+    "watchdog": {
+      "enabled": true,
+      "main": {
+        "model": "anthropic/claude-haiku-4-5",
+        "thinking": "medium"
+      },
+      "scope": { "enabled": true },
+      "cadence": { "everyNTools": 10 },
+      "autoFollow": {
+        "blockers": true,
+        "maxAttempts": 3,
+        "stalemateRepeats": 3
       }
     }
   }

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -270,6 +270,11 @@ generated `.pi-subagents/` / temp artifacts do not trigger review. Writing child
 can review their own worktree; the parent can still review the aggregate diff after
 child changes land. Enabled watchdogs also run changed-file TypeScript/JavaScript
 LSP diagnostics before the model pass when `typescript-language-server` is available.
+They keep bounded current-scope context from real user prompts (`watchdog.scope.enabled`)
+and can optionally run non-blocking Scopey-style cadence reviews every N tool results
+(`watchdog.cadence.everyNTools`). Cadence corrections and blocker auto-follow prompts
+are always transcript-visible; choose the watchdog model that matches the desired
+cheap-monitor vs strong-reviewer policy.
 
 Prefer a strong complementary model (for example Opus 4.8 high paired against a
 GPT 5.5 main session, or the reverse). Recommendation and configuration:

--- a/src/watchdog/register-main.ts
+++ b/src/watchdog/register-main.ts
@@ -111,6 +111,8 @@ export function buildWatchdogStatus(snapshot: ReturnType<MainWatchdogRuntime["ge
 		`Main: ${boolLabel(snapshot.enabled)}${!snapshot.config.enabled && snapshot.sessionOverride === undefined ? " (default off)" : ""}`,
 		`Runtime: ${statusLabel(snapshot.status)}${snapshot.bufferedDeltas > 0 ? ` · buffered deltas ${snapshot.bufferedDeltas}` : ""}`,
 		`Review trigger: ${snapshot.reviewTrigger === "repo-edits" ? "repo edits only" : "every non-empty turn delta"}`,
+		`Scope context: ${snapshot.config.scope.enabled ? "on" : "off"}`,
+		`Cadence: ${snapshot.config.cadence.everyNTools === null ? "boundary only" : `every ${snapshot.config.cadence.everyNTools} tools + boundary`}`,
 		lspLine(snapshot),
 		`Session override: ${snapshot.sessionOverride === undefined ? "none" : boolLabel(snapshot.sessionOverride)}`,
 		mainModelLine(snapshot, ctx),
@@ -118,7 +120,7 @@ export function buildWatchdogStatus(snapshot: ReturnType<MainWatchdogRuntime["ge
 		childrenLine(snapshot),
 		recommendationLine(ctx),
 		`Agent-end timeout: ${snapshot.config.agentEndTimeoutMs}ms`,
-		`Auto-follow: not implemented${snapshot.autoFollowQueued ? " (queued)" : ""}`,
+		`Auto-follow: ${snapshot.enabled && snapshot.config.autoFollow.blockers ? "on for blockers" : "off"} · attempts ${snapshot.autoFollowAttempts}${snapshot.config.autoFollow.maxAttempts === null ? "" : `/${snapshot.config.autoFollow.maxAttempts}`}${snapshot.autoFollowQueued ? " · queued" : ""}${snapshot.autoFollowStalemate ? " · stalemate" : ""}`,
 		`Review model call: ${snapshot.reviewDescription}`,
 	];
 	if (snapshot.failedReviews > 0) lines.push(`Failed reviews: ${snapshot.failedReviews}`);
@@ -236,7 +238,7 @@ function createTestWarning(severity: "concern" | "blocker", text: string): Watch
 		summary: text,
 		evidence: `Manual /subagents-watchdog test ${severity} message from the main session.`,
 		recommendedAction: severity === "blocker"
-			? "Verify the renderer and transcript delivery; no automatic follow-up is queued in Gate 1B."
+			? "Verify the renderer, transcript delivery, and auto-follow policy."
 			: "Verify the renderer and transcript delivery; decide manually whether any action is needed.",
 	};
 }
@@ -381,9 +383,10 @@ export function registerMainWatchdog(pi: ExtensionAPI, options: RegisterMainWatc
 		review: options.review ?? createMainWatchdogReview(() => currentContext, { getThinkingLevel: () => pi.getThinkingLevel() }),
 		reviewDescription: options.review ? "injected seam" : "real model review",
 		reviewChangesOnly: true,
-		displayWarning: (details) => {
-			pi.sendMessage(createWatchdogWarningMessage(details, { display: true, details }));
+		displayWarning: (details, delivery) => {
+			pi.sendMessage(createWatchdogWarningMessage(details, { display: true, details }), delivery?.deliverAs === "steer" ? { deliverAs: "steer" } : undefined);
 		},
+		sendUserMessage: (message) => pi.sendUserMessage(message),
 	});
 
 	pi.registerMessageRenderer<WatchdogWarningDetails>(SUBAGENT_WATCHDOG_WARNING_TYPE, (message, renderOptions, theme) => {
@@ -417,13 +420,17 @@ export function registerMainWatchdog(pi: ExtensionAPI, options: RegisterMainWatc
 		rememberContext(ctx);
 		runtime.handleTurnEnd(event, ctx);
 	});
+	pi.on("tool_result", (_event, ctx) => {
+		rememberContext(ctx);
+		runtime.handleToolResult(ctx);
+	});
 	pi.on("agent_end", (event, ctx) => {
 		rememberContext(ctx);
 		return runtime.handleAgentEnd(event, ctx);
 	});
-	pi.on("session_before_switch", () => runtime.reset("session switch", { clearReviewInputSignature: true, clearLspLedger: true }));
-	pi.on("session_before_fork", () => runtime.reset("session fork", { clearReviewInputSignature: true, clearLspLedger: true }));
-	pi.on("session_compact", () => runtime.reset("session compact"));
+	pi.on("session_before_switch", () => runtime.reset("session switch", { clearReviewInputSignature: true, clearLspLedger: true, clearScope: true, resetAutoFollow: true }));
+	pi.on("session_before_fork", () => runtime.reset("session fork", { clearReviewInputSignature: true, clearLspLedger: true, clearScope: true, resetAutoFollow: true }));
+	pi.on("session_compact", () => runtime.reset("session compact", { clearScope: true }));
 	pi.on("session_shutdown", () => {
 		currentContext = undefined;
 		runtime.dispose();

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -201,18 +201,19 @@ function createWatchdogWarnTool(request: WatchdogReviewRequest): AgentTool<typeo
 	};
 }
 
-function buildWatchdogSystemPrompt(ctx: ExtensionContext): string {
+function buildWatchdogSystemPrompt(ctx: ExtensionContext, options: { hasScope?: boolean } = {}): string {
 	return [
 		"You are the main-session subagent watchdog for Pi.",
 		`Working directory: ${ctx.cwd}`,
 		"Review only the supplied parent turn delta. Inspect repository files only when needed to verify a concrete concern.",
+		options.hasScope ? "When the review input includes a Current scope block, treat newer scope prompts as superseding/mutating older prompts and use category='scope-drift' for work that serves no current scope item." : undefined,
 		"You are read-only. You may use read, grep, find, and ls. Do not edit files, run shell commands, spawn agents, or mutate state.",
 		"Emit warnings only by calling watchdog_warn. Freeform assistant text is ignored and must not be used to report warnings.",
 		"Emit only medium/high confidence actionable concerns or blockers: missed user constraints, correctness risks, test gaps that matter, unsafe changes, stale facts, loop risks, or scope drift.",
 		"Do not emit nits, style preferences, low-confidence guesses, informational notes, praise, or summaries.",
 		"If the turn is clean, call no tools and end normally.",
 		"Use severity='blocker' only when the issue should stop acceptance until addressed; otherwise use severity='concern'.",
-	].join("\n");
+	].filter((line): line is string => Boolean(line)).join("\n");
 }
 
 function buildReviewPrompt(request: WatchdogReviewRequest, selection: WatchdogReviewModelSelection): string {
@@ -270,7 +271,7 @@ export function createMainWatchdogReview(provider: WatchdogContextProvider, opti
 		];
 		const agent = new Agent({
 			initialState: {
-				systemPrompt: buildWatchdogSystemPrompt(ctx),
+				systemPrompt: buildWatchdogSystemPrompt(ctx, { hasScope: request.hasScope }),
 				model: selection.model,
 				thinkingLevel: selection.thinkingLevel,
 				tools,

--- a/src/watchdog/runtime.ts
+++ b/src/watchdog/runtime.ts
@@ -9,6 +9,7 @@ import {
 	watchdogWarningFromLspDiagnostics,
 	type WatchdogLspDiagnosticsFunction,
 } from "./lsp-diagnostics.ts";
+import { WatchdogScopeArtifact, isWatchdogAutoFollowPromptEvent } from "./scope.ts";
 import { resolveWatchdogConfig } from "./settings.ts";
 import { formatWatchdogTurnDelta } from "./turn-delta.ts";
 import {
@@ -34,6 +35,7 @@ export interface WatchdogReviewResult {
 export interface WatchdogReviewRequest {
 	delta: string;
 	epoch: number;
+	hasScope: boolean;
 	reviewId: number;
 	config: ResolvedWatchdogConfig;
 	emitWarning(warning: WatchdogWarning): boolean;
@@ -60,7 +62,9 @@ export interface WatchdogRuntimeSnapshot {
 	staleReviews: number;
 	reviewConnected: boolean;
 	reviewDescription: string;
-	autoFollowQueued: false;
+	autoFollowQueued: boolean;
+	autoFollowAttempts: number;
+	autoFollowStalemate: boolean;
 	reviewTrigger: "turn-delta" | "repo-edits";
 	changedPaths?: string[];
 	lsp: WatchdogLspRuntimeSnapshot;
@@ -76,7 +80,8 @@ interface MainWatchdogRuntimeOptions {
 	resolveConfig?: (cwd: string, options?: { session?: Record<string, unknown> }) => WatchdogSettingsResult;
 	review?: WatchdogReviewFunction;
 	reviewDescription?: string;
-	displayWarning?: (warning: WatchdogWarningDetails) => void;
+	displayWarning?: (warning: WatchdogWarningDetails, options?: { deliverAs?: "steer" }) => void;
+	sendUserMessage?: (message: string) => void | Promise<void>;
 	reviewChangesOnly?: boolean;
 	lspDiagnostics?: WatchdogLspDiagnosticsFunction;
 	repoChangeSignature?: typeof computeWatchdogRepoChangeSignature;
@@ -111,11 +116,13 @@ export class MainWatchdogRuntime {
 	private readonly review: WatchdogReviewFunction;
 	private readonly reviewConnected: boolean;
 	private readonly reviewDescription: string;
-	private readonly displayWarning: ((warning: WatchdogWarningDetails) => void) | undefined;
+	private readonly displayWarning: ((warning: WatchdogWarningDetails, options?: { deliverAs?: "steer" }) => void) | undefined;
+	private readonly sendUserMessage: ((message: string) => void | Promise<void>) | undefined;
 	private readonly reviewChangesOnly: boolean;
 	private readonly lspDiagnostics: WatchdogLspDiagnosticsFunction;
 	private readonly repoChangeSignature: typeof computeWatchdogRepoChangeSignature;
 	private readonly lspLedger = new WatchdogLspDiagnosticsLedger();
+	private readonly scope = new WatchdogScopeArtifact();
 	private configResult: WatchdogSettingsResult;
 	private sessionOverrideEnabled: boolean | undefined;
 	private sessionModelOverride: Partial<Pick<WatchdogEndpointConfig, "model" | "thinking">> | undefined;
@@ -138,6 +145,7 @@ export class MainWatchdogRuntime {
 	private userPrompt: string | undefined;
 	private waiters: Waiter[] = [];
 	private lastWarning: WatchdogWarningDetails | undefined;
+	private displayedWarningSequence = 0;
 	private lastError: string | undefined;
 	private lastReviewInputSignature: string | undefined;
 	private turnStartChangeSignature: WatchdogRepoChangeSignature | undefined;
@@ -145,6 +153,16 @@ export class MainWatchdogRuntime {
 	private currentChangedPaths: string[] | undefined;
 	private lastLspSnapshot: WatchdogLspRuntimeSnapshot | undefined;
 	private observedRepoEditThisTurn = false;
+	private toolResultsThisRun = 0;
+	private midRunReviewing = false;
+	private autoFollowQueued = false;
+	private autoFollowAttempts = 0;
+	private consecutiveAutoFollowIdentity: string | undefined;
+	private consecutiveAutoFollowRepeats = 0;
+	private autoFollowStalemate = false;
+	private pendingAutoFollowPrompts: string[] = [];
+	private midRunGeneration = 0;
+	private activeReviewAbortController: AbortController | undefined;
 	private failedReviews = 0;
 	private staleReviews = 0;
 
@@ -155,6 +173,7 @@ export class MainWatchdogRuntime {
 		this.reviewConnected = Boolean(options.review);
 		this.reviewDescription = options.reviewDescription ?? (options.review ? "injected seam" : "not wired");
 		this.displayWarning = options.displayWarning;
+		this.sendUserMessage = options.sendUserMessage;
 		this.reviewChangesOnly = options.reviewChangesOnly === true;
 		this.lspDiagnostics = options.lspDiagnostics ?? collectWatchdogLspDiagnostics;
 		this.repoChangeSignature = options.repoChangeSignature ?? computeWatchdogRepoChangeSignature;
@@ -170,7 +189,7 @@ export class MainWatchdogRuntime {
 		this.sessionOverrideEnabled = undefined;
 		this.sessionModelOverride = undefined;
 		this.refreshConfig(ctx.cwd);
-		this.reset("session_start", { clearReviewInputSignature: true, resetChangeSignature: true, clearLspLedger: true });
+		this.reset("session_start", { clearReviewInputSignature: true, resetChangeSignature: true, clearLspLedger: true, clearScope: true, resetAutoFollow: true });
 	}
 
 	refreshConfig(cwd = this.cwd): WatchdogSettingsResult {
@@ -228,7 +247,7 @@ export class MainWatchdogRuntime {
 		return this.getSnapshot();
 	}
 
-	reset(_reason = "reset", options: { clearReviewInputSignature?: boolean; resetChangeSignature?: boolean; clearLspLedger?: boolean } = {}): void {
+	reset(_reason = "reset", options: { clearReviewInputSignature?: boolean; resetChangeSignature?: boolean; clearLspLedger?: boolean; clearScope?: boolean; resetAutoFollow?: boolean } = {}): void {
 		this.abortActiveAgentEnd();
 		this.epoch++;
 		this.status = "idle";
@@ -242,10 +261,18 @@ export class MainWatchdogRuntime {
 		this.lastError = undefined;
 		this.currentChangedPaths = undefined;
 		this.observedRepoEditThisTurn = false;
+		this.toolResultsThisRun = 0;
+		this.midRunReviewing = false;
+		this.autoFollowQueued = false;
 		if (options.clearLspLedger) {
 			this.lspLedger.reset();
 			this.lastLspSnapshot = undefined;
 		}
+		if (options.clearScope) {
+			this.scope.reset();
+			this.pendingAutoFollowPrompts = [];
+		}
+		if (options.resetAutoFollow) this.resetAutoFollowState();
 		if (options.clearReviewInputSignature) this.lastReviewInputSignature = undefined;
 		if (options.resetChangeSignature) this.resetRepoChangeBaseline({ reviewed: true });
 		this.guard.reset();
@@ -266,16 +293,31 @@ export class MainWatchdogRuntime {
 		this.currentChangedPaths = undefined;
 		this.lastLspSnapshot = undefined;
 		this.lspLedger.reset();
+		this.scope.reset();
 		this.observedRepoEditThisTurn = false;
+		this.toolResultsThisRun = 0;
+		this.midRunReviewing = false;
+		this.autoFollowQueued = false;
 		this.resolveWaiters(false);
 	}
 
 	handleBeforeAgentStart(event: unknown, ctx: ContextLike): void {
 		if (this.disposed) return;
-		this.reset("before_agent_start");
+		const incomingPrompt = promptFromBeforeAgentStart(event);
+		// Only exact queued auto-follow text is treated as an auto-follow turn; a real user
+		// prompt racing in ahead of one stays real and the pending matches survive for later.
+		const pendingIndex = incomingPrompt === undefined ? -1 : this.pendingAutoFollowPrompts.indexOf(incomingPrompt);
+		const autoFollowPrompt = pendingIndex >= 0 || isWatchdogAutoFollowPromptEvent(event);
+		if (pendingIndex >= 0) this.pendingAutoFollowPrompts.splice(pendingIndex, 1);
+		this.reset("before_agent_start", { resetAutoFollow: !autoFollowPrompt });
 		this.refreshConfig(ctx.cwd);
-		this.userPrompt = promptFromBeforeAgentStart(event);
-		this.includeUserPromptInNextDelta = Boolean(this.userPrompt?.trim());
+		this.userPrompt = incomingPrompt;
+		if (!autoFollowPrompt && this.userPrompt?.trim()) {
+			this.includeUserPromptInNextDelta = true;
+			this.scope.addPrompt(this.userPrompt);
+		} else {
+			this.includeUserPromptInNextDelta = false;
+		}
 		this.resetRepoChangeBaseline();
 	}
 
@@ -300,7 +342,21 @@ export class MainWatchdogRuntime {
 	enqueueDelta(delta: string): void {
 		if (this.disposed || !delta.trim() || !this.isEnabled()) return;
 		this.appendBoundedDelta(delta);
-		if (!this.reviewing && !this.waitingAtAgentEnd) this.status = "queued";
+		if (!this.reviewing && !this.waitingAtAgentEnd && !this.midRunReviewing) this.status = "queued";
+	}
+
+	handleToolResult(ctx: ContextLike): void {
+		if (this.disposed) return;
+		this.refreshConfig(ctx.cwd);
+		if (!this.isEnabled()) return;
+		const everyNTools = this.configResult.config.cadence.everyNTools;
+		if (everyNTools === null) return;
+		this.toolResultsThisRun++;
+		if (this.toolResultsThisRun % everyNTools !== 0) return;
+		if (this.reviewing || this.waitingAtAgentEnd || this.midRunReviewing) return;
+		const delta = this.buildReviewInput(undefined, "");
+		if (!delta.trim()) return;
+		void this.reviewMidRunDelta(delta);
 	}
 
 	async handleAgentEnd(_event: unknown, ctx: ContextLike): Promise<void> {
@@ -320,12 +376,15 @@ export class MainWatchdogRuntime {
 			this.resolveWaiters(true);
 			return;
 		}
+		this.cancelMidRunReview();
 		this.waitingAtAgentEnd = true;
 		const agentEndEpoch = this.epoch;
 		const agentEndId = ++this.agentEndIdCounter;
 		const lspAbortController = new AbortController();
 		this.activeAgentEndId = agentEndId;
 		this.activeAgentEndAbortController = lspAbortController;
+		let displayedDuringAgentEnd: WatchdogWarningDetails | undefined;
+		const previousDisplayedSequence = this.displayedWarningSequence;
 		try {
 			this.guard.startModelUpdate();
 			const lspBlock = await this.collectLspDiagnostics(changeSignature, {
@@ -366,6 +425,8 @@ export class MainWatchdogRuntime {
 				this.currentChangedPaths = changeSignature?.changedPaths;
 				this.status = "idle";
 			}
+			displayedDuringAgentEnd = this.displayedWarningSequence !== previousDisplayedSequence ? this.lastWarning : undefined;
+			this.queueAutoFollowIfNeeded(displayedDuringAgentEnd);
 			this.resolveWaiters(true);
 		} finally {
 			if (this.activeAgentEndAbortController === lspAbortController) this.activeAgentEndAbortController = undefined;
@@ -399,7 +460,9 @@ export class MainWatchdogRuntime {
 			staleReviews: this.staleReviews,
 			reviewConnected: this.reviewConnected,
 			reviewDescription: this.reviewDescription,
-			autoFollowQueued: false,
+			autoFollowQueued: this.autoFollowQueued,
+			autoFollowAttempts: this.autoFollowAttempts,
+			autoFollowStalemate: this.autoFollowStalemate,
 			reviewTrigger: this.reviewChangesOnly ? "repo-edits" : "turn-delta",
 			...(this.currentChangedPaths?.length ? { changedPaths: [...this.currentChangedPaths] } : {}),
 			lsp: this.lspSnapshot(),
@@ -428,8 +491,12 @@ export class MainWatchdogRuntime {
 		return !this.disposed && this.epoch === epoch && this.activeReviewId === reviewId;
 	}
 
+	private warningMeetsThreshold(warning: WatchdogWarning): boolean {
+		return this.configResult.config.severityThreshold === "concern" || warning.severity === "blocker";
+	}
+
 	private acceptWarning(epoch: number, reviewId: number, warning: WatchdogWarning): boolean {
-		if (!this.isCurrent(epoch, reviewId) || !this.isEnabled()) return false;
+		if (!this.isCurrent(epoch, reviewId) || !this.isEnabled() || !this.warningMeetsThreshold(warning)) return false;
 		const decision = this.guard.evaluate(warning);
 		if (!decision.accepted) return false;
 		const details = normalizeWatchdogWarningDetails(warning, {
@@ -443,7 +510,7 @@ export class MainWatchdogRuntime {
 	}
 
 	private displayBoundaryWarning(warning: WatchdogWarning): boolean {
-		if (!this.isEnabled()) return false;
+		if (!this.isEnabled() || !this.warningMeetsThreshold(warning)) return false;
 		const decision = this.guard.evaluate(warning);
 		if (!decision.accepted) return false;
 		const details = normalizeWatchdogWarningDetails(warning, {
@@ -453,6 +520,7 @@ export class MainWatchdogRuntime {
 			displayedAt: new Date().toISOString(),
 		});
 		this.lastWarning = details;
+		this.displayedWarningSequence++;
 		this.displayWarning?.(details);
 		return true;
 	}
@@ -468,7 +536,41 @@ export class MainWatchdogRuntime {
 		this.activeReviewWarning = undefined;
 	}
 
-	private async reviewDelta(delta: string, timeoutMs: number): Promise<ReviewDeltaOutcome> {
+	private async reviewMidRunDelta(delta: string): Promise<void> {
+		if (this.midRunReviewing || this.reviewing || this.waitingAtAgentEnd || this.disposed) return;
+		this.midRunReviewing = true;
+		const generation = this.midRunGeneration;
+		try {
+			const outcome = await this.reviewDelta(delta, this.configResult.config.agentEndTimeoutMs, { correction: true });
+			if (generation !== this.midRunGeneration) return;
+			if (outcome === "timeout") {
+				this.staleReviews++;
+				this.status = "stale";
+				this.markLastWarningStale();
+			}
+		} finally {
+			if (generation === this.midRunGeneration) {
+				this.midRunReviewing = false;
+				if (this.status === "reviewing") this.status = this.pendingDeltas.length ? "queued" : "idle";
+				this.resolveWaiters(this.isSettled());
+			}
+		}
+	}
+
+	// The agent-end boundary review is authoritative; an in-flight cadence review is superseded.
+	private cancelMidRunReview(): void {
+		if (!this.midRunReviewing) return;
+		this.midRunGeneration++;
+		this.activeReviewAbortController?.abort();
+		this.activeReviewAbortController = undefined;
+		this.staleReviews++;
+		this.reviewing = false;
+		this.midRunReviewing = false;
+		this.activeReviewId = undefined;
+		this.activeReviewWarning = undefined;
+	}
+
+	private async reviewDelta(delta: string, timeoutMs: number, options: { correction?: boolean } = {}): Promise<ReviewDeltaOutcome> {
 		if (this.reviewing || this.disposed) return "stale";
 		this.reviewing = true;
 		const reviewEpoch = this.epoch;
@@ -478,11 +580,13 @@ export class MainWatchdogRuntime {
 		this.status = "reviewing";
 		let timeout: ReturnType<typeof setTimeout> | undefined;
 		const abortController = new AbortController();
+		this.activeReviewAbortController = abortController;
 		const reviewPromise = Promise.resolve().then(() => this.review({
 			delta,
 			epoch: reviewEpoch,
 			reviewId,
 			config: this.configResult.config,
+			hasScope: this.scopeBlock().trim().length > 0,
 			signal: abortController.signal,
 			emitWarning: (warning) => this.acceptWarning(reviewEpoch, reviewId, warning),
 		}));
@@ -503,7 +607,7 @@ export class MainWatchdogRuntime {
 				this.fail(`Watchdog review ended with stop reason '${result.stopReason}'.`);
 				return "completed";
 			}
-			this.displayAcceptedReviewWarning();
+			this.displayAcceptedReviewWarning(options.correction);
 			return "completed";
 		} catch (error) {
 			if (this.isCurrent(reviewEpoch, reviewId)) {
@@ -513,6 +617,7 @@ export class MainWatchdogRuntime {
 			return "stale";
 		} finally {
 			if (timeout) clearTimeout(timeout);
+			if (this.activeReviewAbortController === abortController) this.activeReviewAbortController = undefined;
 			if (this.epoch === reviewEpoch && this.activeReviewId === reviewId) {
 				this.reviewing = false;
 				this.activeReviewId = undefined;
@@ -522,7 +627,7 @@ export class MainWatchdogRuntime {
 		}
 	}
 
-	private displayAcceptedReviewWarning(): void {
+	private displayAcceptedReviewWarning(correction = false): void {
 		if (!this.activeReviewWarning) return;
 		const details: WatchdogWarningDetails = {
 			...this.activeReviewWarning,
@@ -530,7 +635,50 @@ export class MainWatchdogRuntime {
 			displayedAt: new Date().toISOString(),
 		};
 		this.lastWarning = details;
-		this.displayWarning?.(details);
+		this.displayedWarningSequence++;
+		this.displayWarning?.(details, correction ? { deliverAs: "steer" } : undefined);
+	}
+
+	private resetAutoFollowState(): void {
+		this.autoFollowQueued = false;
+		this.autoFollowAttempts = 0;
+		this.consecutiveAutoFollowIdentity = undefined;
+		this.consecutiveAutoFollowRepeats = 0;
+		this.autoFollowStalemate = false;
+	}
+
+	private queueAutoFollowIfNeeded(warning: WatchdogWarningDetails | undefined): void {
+		if (!warning || warning.severity !== "blocker" || warning.stale || !this.configResult.config.autoFollow.blockers || !this.isEnabled()) return;
+		const identity = warning.identity ?? reviewInputSignature([warning.severity, warning.summary, warning.evidence].join("\n"));
+		if (this.consecutiveAutoFollowIdentity === identity) this.consecutiveAutoFollowRepeats++;
+		else {
+			this.consecutiveAutoFollowIdentity = identity;
+			this.consecutiveAutoFollowRepeats = 1;
+		}
+		if (this.consecutiveAutoFollowRepeats >= this.configResult.config.autoFollow.stalemateRepeats) {
+			this.autoFollowStalemate = true;
+			this.lastWarning = { ...warning, state: "stalemate", stalemateRepeats: this.consecutiveAutoFollowRepeats };
+			return;
+		}
+		const maxAttempts = this.configResult.config.autoFollow.maxAttempts;
+		if (maxAttempts !== null && this.autoFollowAttempts >= maxAttempts) return;
+		if (!this.sendUserMessage) return;
+		this.autoFollowAttempts++;
+		this.autoFollowQueued = true;
+		const prompt = [
+			"Watchdog auto-follow: address this blocker before continuing.",
+			`Summary: ${warning.summary}`,
+			`Evidence: ${warning.evidence}`,
+			`Recommended action: ${warning.recommendedAction}`,
+		].join("\n");
+		this.pendingAutoFollowPrompts.push(prompt);
+		if (this.pendingAutoFollowPrompts.length > 8) this.pendingAutoFollowPrompts.shift();
+		void Promise.resolve(this.sendUserMessage(prompt)).catch((error) => {
+			this.autoFollowQueued = false;
+			const index = this.pendingAutoFollowPrompts.indexOf(prompt);
+			if (index >= 0) this.pendingAutoFollowPrompts.splice(index, 1);
+			this.lastError = `Watchdog auto-follow failed: ${errorMessage(error)}`;
+		});
 	}
 
 	private currentRepoChangeSignature(cwd = this.cwd): WatchdogRepoChangeSignature | undefined {
@@ -645,10 +793,11 @@ export class MainWatchdogRuntime {
 
 	private buildReviewInput(changeSignature?: WatchdogRepoChangeSignature, lspBlock = ""): string {
 		const input = this.pendingDeltas.join(REVIEW_DELTA_SEPARATOR);
+		const scopeBlock = this.scopeBlock();
 		const changes = changeSignature?.changedPaths.length
 			? ["Changed repo paths:", ...changeSignature.changedPaths.slice(0, 200).map((file) => `- ${file}`)].join("\n")
 			: "";
-		const contextPieces = [changes, lspBlock].filter(Boolean);
+		const contextPieces = [scopeBlock, changes, lspBlock].filter(Boolean);
 		if (!contextPieces.length) return input.length > MAX_REVIEW_INPUT_CHARS ? input.slice(-MAX_REVIEW_INPUT_CHARS) : input;
 
 		const maxContextLength = Math.floor(MAX_REVIEW_INPUT_CHARS / 2);
@@ -664,6 +813,10 @@ export class MainWatchdogRuntime {
 				? input.slice(-inputBudget)
 				: input;
 		return [boundedContext, boundedInput].filter(Boolean).join(REVIEW_DELTA_SEPARATOR);
+	}
+
+	private scopeBlock(): string {
+		return this.configResult.config.scope.enabled ? this.scope.render() : "";
 	}
 
 	private clearPendingDeltas(): void {

--- a/src/watchdog/scope.ts
+++ b/src/watchdog/scope.ts
@@ -1,0 +1,62 @@
+export const WATCHDOG_AUTO_FOLLOW_PROMPT_MARKER = Symbol("subagent-watchdog-auto-follow-prompt");
+
+const MAX_SCOPE_ENTRIES = 8;
+const MAX_SCOPE_ENTRY_CHARS = 2_000;
+const MAX_SCOPE_TOTAL_CHARS = 16_000;
+
+export interface WatchdogScopeEntry {
+	prompt: string;
+	createdAt: string;
+}
+
+export class WatchdogScopeArtifact {
+	private entries: WatchdogScopeEntry[] = [];
+
+	addPrompt(prompt: string, options: { createdAt?: string } = {}): void {
+		const normalized = prompt.trim();
+		if (!normalized) return;
+		this.entries.push({
+			prompt: normalized.length > MAX_SCOPE_ENTRY_CHARS ? normalized.slice(0, MAX_SCOPE_ENTRY_CHARS) : normalized,
+			createdAt: options.createdAt ?? new Date().toISOString(),
+		});
+		this.trim();
+	}
+
+	reset(): void {
+		this.entries = [];
+	}
+
+	snapshot(): WatchdogScopeEntry[] {
+		return this.entries.map((entry) => ({ ...entry }));
+	}
+
+	render(): string {
+		if (!this.entries.length) return "";
+		return [
+			"Current scope:",
+			"The following real user prompts are the current scope record, newest last. Newer prompts supersede and mutate older prompts: they may add, modify, or remove requirements. Flag work that serves no current scope item as category 'scope-drift'.",
+			...this.entries.map((entry, index) => [
+				`Scope prompt ${index + 1} (${entry.createdAt}):`,
+				entry.prompt,
+			].join("\n")),
+		].join("\n\n");
+	}
+
+	private trim(): void {
+		while (this.entries.length > MAX_SCOPE_ENTRIES) this.entries.shift();
+		let total = this.entries.reduce((sum, entry) => sum + entry.prompt.length, 0);
+		while (this.entries.length > 1 && total > MAX_SCOPE_TOTAL_CHARS) {
+			const removed = this.entries.shift();
+			if (removed) total -= removed.prompt.length;
+		}
+	}
+}
+
+export function isWatchdogAutoFollowPromptEvent(event: unknown): boolean {
+	return Boolean(event && typeof event === "object" && (event as { [WATCHDOG_AUTO_FOLLOW_PROMPT_MARKER]?: unknown })[WATCHDOG_AUTO_FOLLOW_PROMPT_MARKER]);
+}
+
+export function markWatchdogAutoFollowPromptEvent<T extends object>(event: T): T {
+	Object.defineProperty(event, WATCHDOG_AUTO_FOLLOW_PROMPT_MARKER, { value: true });
+	return event;
+}

--- a/src/watchdog/settings.ts
+++ b/src/watchdog/settings.ts
@@ -13,8 +13,10 @@ import {
 	type WatchdogChildrenConfig,
 	type WatchdogDeliveryMode,
 	type WatchdogEndpointConfig,
+	type WatchdogCadenceConfig,
 	type WatchdogGuidanceConfig,
 	type WatchdogLateWarningPolicy,
+	type WatchdogScopeConfig,
 	type WatchdogLspConfig,
 	type WatchdogSettingsError,
 	type WatchdogSettingsResult,
@@ -25,6 +27,8 @@ import {
 
 type WatchdogAutoFollowPatch = Partial<WatchdogAutoFollowConfig>;
 type WatchdogGuidancePatch = Partial<WatchdogGuidanceConfig>;
+type WatchdogScopePatch = Partial<WatchdogScopeConfig>;
+type WatchdogCadencePatch = Partial<WatchdogCadenceConfig>;
 type WatchdogEndpointPatch = Partial<WatchdogEndpointConfig>;
 type WatchdogChildOverridePatch = Partial<WatchdogChildOverrideConfig>;
 type WatchdogChildrenPatch = Partial<Omit<WatchdogChildrenConfig, "autoFollow" | "overrides">> & {
@@ -48,9 +52,11 @@ export interface WatchdogModelSettingsWrite {
 	thinking?: ThinkingLevel | false | null;
 }
 
-type WatchdogConfigPatch = Partial<Omit<ResolvedWatchdogConfig, "guidance" | "autoFollow" | "main" | "children" | "asyncCompletion" | "lsp">> & {
+type WatchdogConfigPatch = Partial<Omit<ResolvedWatchdogConfig, "guidance" | "autoFollow" | "scope" | "cadence" | "main" | "children" | "asyncCompletion" | "lsp">> & {
 	guidance?: WatchdogGuidancePatch;
 	autoFollow?: WatchdogAutoFollowPatch;
+	scope?: WatchdogScopePatch;
+	cadence?: WatchdogCadencePatch;
 	main?: WatchdogEndpointPatch;
 	children?: WatchdogChildrenPatch;
 	asyncCompletion?: WatchdogAsyncCompletionPatch;
@@ -79,6 +85,12 @@ export const DEFAULT_WATCHDOG_CONFIG: ResolvedWatchdogConfig = {
 		blockers: true,
 		maxAttempts: 3,
 		stalemateRepeats: 3,
+	},
+	scope: {
+		enabled: true,
+	},
+	cadence: {
+		everyNTools: null,
 	},
 	main: {
 		enabled: false,
@@ -119,6 +131,8 @@ const WATCHDOG_FIELDS = new Set([
 	"maxWarnings",
 	"guidance",
 	"autoFollow",
+	"scope",
+	"cadence",
 	"main",
 	"children",
 	"asyncCompletion",
@@ -129,6 +143,8 @@ const WATCHDOG_FIELDS = new Set([
 ]);
 const GUIDANCE_FIELDS = new Set(["watchdogMd", "systemPromptPath"]);
 const AUTO_FOLLOW_FIELDS = new Set(["blockers", "maxAttempts", "stalemateRepeats"]);
+const SCOPE_FIELDS = new Set(["enabled"]);
+const CADENCE_FIELDS = new Set(["everyNTools"]);
 const ENDPOINT_FIELDS = new Set(["enabled", "model", "thinking"]);
 const CHILDREN_FIELDS = new Set(["enabled", "model", "thinking", "watchdogTailTimeoutMs", "autoFollow", "overrides"]);
 const CHILD_OVERRIDE_FIELDS = new Set(["enabled", "model", "thinking"]);
@@ -140,6 +156,8 @@ function cloneDefaultConfig(): ResolvedWatchdogConfig {
 		...DEFAULT_WATCHDOG_CONFIG,
 		guidance: { ...DEFAULT_WATCHDOG_CONFIG.guidance },
 		autoFollow: { ...DEFAULT_WATCHDOG_CONFIG.autoFollow },
+		scope: { ...DEFAULT_WATCHDOG_CONFIG.scope },
+		cadence: { ...DEFAULT_WATCHDOG_CONFIG.cadence },
 		main: { ...DEFAULT_WATCHDOG_CONFIG.main },
 		children: {
 			...DEFAULT_WATCHDOG_CONFIG.children,
@@ -241,6 +259,26 @@ function parseAutoFollowPatch(value: unknown, field: string, meta: ParseMeta): W
 	return patch;
 }
 
+function parseScopePatch(value: unknown, field: string, meta: ParseMeta): WatchdogScopePatch {
+	const input = parseObject(value, field, meta);
+	assertKnownFields(input, SCOPE_FIELDS, field, meta);
+	const patch: WatchdogScopePatch = {};
+	if ("enabled" in input) patch.enabled = parseBoolean(input.enabled, `${field}.enabled`, meta);
+	return patch;
+}
+
+function parseCadencePatch(value: unknown, field: string, meta: ParseMeta): WatchdogCadencePatch {
+	const input = parseObject(value, field, meta);
+	assertKnownFields(input, CADENCE_FIELDS, field, meta);
+	const patch: WatchdogCadencePatch = {};
+	if ("everyNTools" in input) {
+		patch.everyNTools = input.everyNTools === null
+			? null
+			: parseInteger(input.everyNTools, `${field}.everyNTools`, meta, "null or an integer >= 5", (candidate) => candidate >= 5);
+	}
+	return patch;
+}
+
 function parseEndpointPatch(value: unknown, field: string, meta: ParseMeta): WatchdogEndpointPatch {
 	const input = parseObject(value, field, meta);
 	assertKnownFields(input, ENDPOINT_FIELDS, field, meta);
@@ -325,6 +363,8 @@ function parseWatchdogPatch(value: unknown, field: string, meta: ParseMeta): Wat
 	}
 	if ("guidance" in input) patch.guidance = parseGuidancePatch(input.guidance, `${field}.guidance`, meta);
 	if ("autoFollow" in input) patch.autoFollow = parseAutoFollowPatch(input.autoFollow, `${field}.autoFollow`, meta);
+	if ("scope" in input) patch.scope = parseScopePatch(input.scope, `${field}.scope`, meta);
+	if ("cadence" in input) patch.cadence = parseCadencePatch(input.cadence, `${field}.cadence`, meta);
 	if ("main" in input) patch.main = parseEndpointPatch(input.main, `${field}.main`, meta);
 	if ("children" in input) patch.children = parseChildrenPatch(input.children, `${field}.children`, meta);
 	if ("asyncCompletion" in input) patch.asyncCompletion = parseAsyncCompletionPatch(input.asyncCompletion, `${field}.asyncCompletion`, meta);

--- a/src/watchdog/types.ts
+++ b/src/watchdog/types.ts
@@ -92,6 +92,14 @@ export interface WatchdogGuidanceConfig {
 	systemPromptPath: string | null;
 }
 
+export interface WatchdogScopeConfig {
+	enabled: boolean;
+}
+
+export interface WatchdogCadenceConfig {
+	everyNTools: number | null;
+}
+
 export interface WatchdogEndpointConfig {
 	enabled: boolean;
 	model?: string;
@@ -159,6 +167,8 @@ export interface ResolvedWatchdogConfig {
 	maxWarnings: number | null;
 	guidance: WatchdogGuidanceConfig;
 	autoFollow: WatchdogAutoFollowConfig;
+	scope: WatchdogScopeConfig;
+	cadence: WatchdogCadenceConfig;
 	main: WatchdogEndpointConfig;
 	children: WatchdogChildrenConfig;
 	asyncCompletion: WatchdogAsyncCompletionConfig;

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -339,6 +339,10 @@ describe("subagent prompt runtime", () => {
 	});
 
 	it("registers child watchdog lifecycle handlers only when enabled by env", () => {
+		delete process.env[CHILD_WATCHDOG_CONFIG_ENV];
+		// Clear the ack capture env explicitly: when this test suite itself runs inside a
+		// pi-subagents child, the runner sets it and an extra agent_end handler registers.
+		delete process.env[RUNTIME_EXTENSION_ACK_PATH_ENV];
 		const handlersWithout = new Map<string, unknown[]>();
 		registerSubagentPromptRuntime({
 			on(event: string, handler: unknown) {

--- a/test/unit/watchdog-runtime.test.ts
+++ b/test/unit/watchdog-runtime.test.ts
@@ -13,6 +13,8 @@ function cloneConfig(): ResolvedWatchdogConfig {
 		...DEFAULT_WATCHDOG_CONFIG,
 		guidance: { ...DEFAULT_WATCHDOG_CONFIG.guidance },
 		autoFollow: { ...DEFAULT_WATCHDOG_CONFIG.autoFollow },
+		scope: { ...DEFAULT_WATCHDOG_CONFIG.scope },
+		cadence: { ...DEFAULT_WATCHDOG_CONFIG.cadence },
 		main: { ...DEFAULT_WATCHDOG_CONFIG.main },
 		children: {
 			...DEFAULT_WATCHDOG_CONFIG.children,
@@ -36,6 +38,9 @@ function enabledConfig(overrides: Partial<ResolvedWatchdogConfig> = {}): Resolve
 	Object.assign(config, overrides);
 	if (overrides.main) config.main = { ...config.main, ...overrides.main };
 	if (overrides.lsp) config.lsp = { ...config.lsp, ...overrides.lsp };
+	if (overrides.scope) config.scope = { ...config.scope, ...overrides.scope };
+	if (overrides.cadence) config.cadence = { ...config.cadence, ...overrides.cadence };
+	if (overrides.autoFollow) config.autoFollow = { ...config.autoFollow, ...overrides.autoFollow };
 	return config;
 }
 
@@ -500,7 +505,8 @@ describe("main watchdog runtime", () => {
 		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: repo });
 
 		assert.equal(reviewedDelta.length, 24_000);
-		assert.match(reviewedDelta, /^Changed repo paths:/);
+		assert.match(reviewedDelta, /^Current scope:/);
+		assert.match(reviewedDelta, /Changed repo paths:/);
 		assert.match(reviewedDelta, /src\/file\.ts/);
 		assert.match(reviewedDelta, /x+$/);
 	});
@@ -820,6 +826,209 @@ describe("main watchdog runtime", () => {
 		assert.equal(displayed.length, 1);
 		assert.equal(runtime.getSnapshot().lastWarning?.summary, "Runtime concern");
 		assert.equal(runtime.getSnapshot().lastWarning?.state, "displayed");
+	});
+
+	it("prepends current scope to boundary reviews", async () => {
+		let reviewedDelta = "";
+		const runtime = new MainWatchdogRuntime({
+			resolveConfig: () => configResult(enabledConfig()),
+			review: (request) => {
+				reviewedDelta = request.delta;
+				assert.equal(request.hasScope, true);
+				return { stopReason: "stop" };
+			},
+		});
+
+		runtime.handleBeforeAgentStart({ prompt: "Only update docs." }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nEdited docs.");
+		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+
+		assert.match(reviewedDelta, /^Current scope:/);
+		assert.match(reviewedDelta, /Only update docs\./);
+		assert.match(reviewedDelta, /category 'scope-drift'/);
+	});
+
+	it("runs visible steer corrections at cadence multiples and skips overlapping mid-run reviews", async () => {
+		let releaseReview!: () => void;
+		let reviewCalls = 0;
+		const delivered: unknown[] = [];
+		const firstStarted = new Promise<void>((resolve) => {
+			const runtime = new MainWatchdogRuntime({
+				resolveConfig: () => configResult(enabledConfig({ cadence: { everyNTools: 5 } })),
+				displayWarning: (details, options) => delivered.push({ details, options }),
+				review: async (request) => {
+					reviewCalls++;
+					assert.match(request.delta, /Current scope:/);
+					assert.equal(request.emitWarning({ ...warning(), severity: "blocker", summary: `Cadence blocker ${reviewCalls}` }), true);
+					resolve();
+					await new Promise<void>((done) => { releaseReview = done; });
+					return { stopReason: "stop" };
+				},
+			});
+			runtime.handleBeforeAgentStart({ prompt: "Stay in scope." }, { cwd: "/tmp/project" });
+			runtime.enqueueDelta("Assistant:\nUsing tools.");
+			for (let index = 0; index < 5; index++) runtime.handleToolResult({ cwd: "/tmp/project" });
+			for (let index = 0; index < 5; index++) runtime.handleToolResult({ cwd: "/tmp/project" });
+		});
+
+		await firstStarted;
+		assert.equal(reviewCalls, 1);
+		releaseReview();
+		await tick();
+		assert.equal(delivered.length, 1);
+		assert.deepEqual((delivered[0] as { options?: unknown }).options, { deliverAs: "steer" });
+	});
+
+	it("auto-follows agent-end blockers, respects max attempts, and real prompts reset attempts", async () => {
+		const sent: string[] = [];
+		const runtime = new MainWatchdogRuntime({
+			resolveConfig: () => configResult(enabledConfig({ autoFollow: { blockers: true, maxAttempts: 1, stalemateRepeats: 3 } })),
+			sendUserMessage: (message) => sent.push(message),
+			review: (request) => {
+				assert.equal(request.emitWarning({ ...warning(), severity: "blocker", summary: "Needs fixing" }), true);
+				return { stopReason: "stop" };
+			},
+		});
+
+		runtime.handleBeforeAgentStart({ prompt: "Patch carefully." }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nBad patch.");
+		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+		assert.equal(sent.length, 1);
+		assert.match(sent[0] ?? "", /Watchdog auto-follow/);
+		assert.equal(runtime.getSnapshot().autoFollowAttempts, 1);
+
+		runtime.handleBeforeAgentStart({ prompt: sent[0] }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nStill bad.");
+		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+		assert.equal(sent.length, 1);
+
+		runtime.handleBeforeAgentStart({ prompt: "Human says try again with a different edit." }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nBad again in a different way.");
+		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+		assert.equal(sent.length, 2);
+		assert.equal(runtime.getSnapshot().autoFollowAttempts, 1);
+	});
+
+	it("keeps a racing real prompt authoritative while a queued auto-follow is pending", async () => {
+		const sent: string[] = [];
+		let reviewedDelta = "";
+		let blockerSummary = "First blocker";
+		const runtime = new MainWatchdogRuntime({
+			resolveConfig: () => configResult(enabledConfig({ autoFollow: { blockers: true, maxAttempts: 1, stalemateRepeats: 5 } })),
+			sendUserMessage: (message) => sent.push(message),
+			review: (request) => {
+				reviewedDelta = request.delta;
+				assert.equal(request.emitWarning({ ...warning(), severity: "blocker", summary: blockerSummary }), true);
+				return { stopReason: "stop" };
+			},
+		});
+
+		runtime.handleBeforeAgentStart({ prompt: "Patch carefully." }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nBad patch.");
+		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+		assert.equal(sent.length, 1);
+		assert.equal(runtime.getSnapshot().autoFollowAttempts, 1);
+
+		// A real user prompt arrives before the queued auto-follow turn starts.
+		blockerSummary = "Second blocker";
+		runtime.handleBeforeAgentStart({ prompt: "Human: also update the docs." }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nStill bad.");
+		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+		assert.match(reviewedDelta, /also update the docs\./);
+		assert.equal(sent.length, 2, "real prompt resets attempts so a new blocker auto-follows again");
+
+		// The originally queued auto-follow prompt then arrives and stays excluded from scope.
+		blockerSummary = "Third blocker";
+		runtime.handleBeforeAgentStart({ prompt: sent[0] }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nStill bad again.");
+		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+		assert.doesNotMatch(reviewedDelta, /Watchdog auto-follow: address this blocker/);
+		assert.equal(sent.length, 2, "auto-follow turn must not reset the attempt counter");
+	});
+
+	it("cancels an in-flight cadence review so the agent-end boundary review still runs", async () => {
+		let releaseFirstReview!: () => void;
+		let reviewCalls = 0;
+		let markFirstStarted!: () => void;
+		const firstReviewStarted = new Promise<void>((resolve) => { markFirstStarted = resolve; });
+		const runtime = new MainWatchdogRuntime({
+			resolveConfig: () => configResult(enabledConfig({ cadence: { everyNTools: 5 } })),
+			review: async (request) => {
+				reviewCalls++;
+				if (reviewCalls === 1) {
+					markFirstStarted();
+					await new Promise<void>((done) => { releaseFirstReview = done; });
+				}
+				return { stopReason: "stop" };
+			},
+		});
+
+		runtime.handleBeforeAgentStart({ prompt: "Stay in scope." }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nUsing tools.");
+		for (let index = 0; index < 5; index++) runtime.handleToolResult({ cwd: "/tmp/project" });
+		await firstReviewStarted;
+
+		runtime.enqueueDelta("Assistant:\nFinal edits.");
+		const agentEnd = runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+		releaseFirstReview();
+		await agentEnd;
+
+		const snapshot = runtime.getSnapshot();
+		assert.equal(reviewCalls, 2, "boundary review must run even when a cadence review was in flight");
+		assert.equal(snapshot.staleReviews, 1, "superseded cadence review is counted as stale");
+		assert.equal(snapshot.status, "idle");
+	});
+
+	it("stops auto-following repeated blocker identities at stalemate threshold", async () => {
+		const sent: string[] = [];
+		const runtime = new MainWatchdogRuntime({
+			resolveConfig: () => configResult(enabledConfig({ autoFollow: { blockers: true, maxAttempts: 5, stalemateRepeats: 2 } })),
+			sendUserMessage: (message) => sent.push(message),
+			review: (request) => {
+				assert.equal(request.emitWarning({ ...warning(), severity: "blocker", summary: "Same blocker" }), true);
+				return { stopReason: "stop" };
+			},
+		});
+
+		runtime.handleBeforeAgentStart({ prompt: "Patch carefully." }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nBad patch.");
+		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+		assert.equal(sent.length, 1);
+
+		runtime.handleBeforeAgentStart({ prompt: sent[0] }, { cwd: "/tmp/project" });
+		runtime.enqueueDelta("Assistant:\nStill bad but not identical input.");
+		await runtime.handleAgentEnd({ type: "agent_end" }, { cwd: "/tmp/project" });
+
+		const snapshot = runtime.getSnapshot();
+		assert.equal(sent.length, 1);
+		assert.equal(snapshot.autoFollowStalemate, true);
+		assert.equal(snapshot.lastWarning?.state, "stalemate");
+	});
+
+	it("does not auto-follow stale blocker warnings", async () => {
+		let emitWarning!: (candidate: WatchdogWarning) => boolean;
+		let finishReview!: () => void;
+		let started!: () => void;
+		const reviewStarted = new Promise<void>((resolve) => { started = resolve; });
+		const sent: string[] = [];
+		const runtime = new MainWatchdogRuntime({
+			resolveConfig: () => configResult(enabledConfig({ agentEndTimeoutMs: 5 })),
+			sendUserMessage: (message) => sent.push(message),
+			review: async (request) => {
+				emitWarning = request.emitWarning;
+				started();
+				await new Promise<void>((resolve) => { finishReview = resolve; });
+			},
+		});
+
+		runtime.enqueueDelta("Assistant:\nStill working");
+		const end = runtime.handleAgentEnd({ type: "agent_end", messages: [] }, { cwd: "/tmp/project" });
+		await reviewStarted;
+		await end;
+		assert.equal(emitWarning({ ...warning(), severity: "blocker" }), false);
+		finishReview();
+		await tick();
+		assert.equal(sent.length, 0);
 	});
 
 	it("session on/off overrides explicit main enabled settings", () => {

--- a/test/unit/watchdog-scope.test.ts
+++ b/test/unit/watchdog-scope.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { WatchdogScopeArtifact, isWatchdogAutoFollowPromptEvent, markWatchdogAutoFollowPromptEvent } from "../../src/watchdog/scope.ts";
+
+describe("watchdog scope artifact", () => {
+	it("keeps bounded prompts in newest-last order", () => {
+		const scope = new WatchdogScopeArtifact();
+		for (let index = 0; index < 10; index++) scope.addPrompt(`prompt-${index}`, { createdAt: `t${index}` });
+
+		const entries = scope.snapshot();
+		assert.equal(entries.length, 8);
+		assert.deepEqual(entries.map((entry) => entry.prompt), ["prompt-2", "prompt-3", "prompt-4", "prompt-5", "prompt-6", "prompt-7", "prompt-8", "prompt-9"]);
+		assert.match(scope.render(), /newest last/);
+		assert.match(scope.render(), /prompt-9/);
+	});
+
+	it("bounds each prompt and resets", () => {
+		const scope = new WatchdogScopeArtifact();
+		scope.addPrompt("x".repeat(3_000));
+		assert.equal(scope.snapshot()[0]?.prompt.length, 2_000);
+
+		scope.reset();
+		assert.deepEqual(scope.snapshot(), []);
+		assert.equal(scope.render(), "");
+	});
+
+	it("marks auto-follow prompt events without string sniffing", () => {
+		const event = markWatchdogAutoFollowPromptEvent({ prompt: "Watchdog auto-follow: address this blocker" });
+
+		assert.equal(isWatchdogAutoFollowPromptEvent(event), true);
+		assert.equal(isWatchdogAutoFollowPromptEvent({ prompt: "Watchdog auto-follow: address this blocker" }), false);
+	});
+});

--- a/test/unit/watchdog-settings.test.ts
+++ b/test/unit/watchdog-settings.test.ts
@@ -57,6 +57,8 @@ describe("watchdog settings", () => {
 		assert.equal(result.config.agentEndTimeoutMs, 30_000);
 		assert.equal(result.config.children.watchdogTailTimeoutMs, 120_000);
 		assert.equal(result.config.autoFollow.maxAttempts, 3);
+		assert.deepEqual(result.config.scope, { enabled: true });
+		assert.deepEqual(result.config.cadence, { everyNTools: null });
 		assert.deepEqual(result.config.lsp, { enabled: true, timeoutMs: 3000, maxFiles: 20, maxDiagnostics: 50 });
 	});
 
@@ -89,6 +91,8 @@ describe("watchdog settings", () => {
 						},
 					},
 					guidance: { systemPromptPath: "/tmp/user-watchdog.md" },
+					scope: { enabled: false },
+					cadence: { everyNTools: 10 },
 				},
 			},
 		});
@@ -125,6 +129,8 @@ describe("watchdog settings", () => {
 		assert.equal(result.config.main.model, "openai/gpt-test");
 		assert.deepEqual(result.config.autoFollow, { blockers: true, maxAttempts: null, stalemateRepeats: 2 });
 		assert.equal(result.config.guidance.systemPromptPath, "/tmp/user-watchdog.md");
+		assert.deepEqual(result.config.scope, { enabled: false });
+		assert.deepEqual(result.config.cadence, { everyNTools: 10 });
 		assert.deepEqual(result.config.lsp, { enabled: false, timeoutMs: 1500, maxFiles: 4, maxDiagnostics: 7 });
 		assert.deepEqual(result.config.children.autoFollow, { blockers: false, maxAttempts: 4, stalemateRepeats: 3 });
 		assert.deepEqual(result.config.children.overrides.worker, {
@@ -170,6 +176,32 @@ describe("watchdog settings", () => {
 			(error: unknown) => error instanceof Error
 				&& error.message === `Watchdog settings in '${userSettingsPath()}' have unknown field 'subagents.watchdog.children.overrides.worker.mode'.`,
 		);
+	});
+
+	it("rejects invalid scope and cadence config at settings load", () => {
+		writeJson(userSettingsPath(), {
+			subagents: {
+				watchdog: {
+					scope: { mode: "hidden" },
+				},
+			},
+		});
+
+		let result = resolveWatchdogConfig(tempProject);
+		assert.equal(result.ok, false);
+		assert.match(result.errors[0]?.message ?? "", /unknown field 'subagents\.watchdog\.scope\.mode'/);
+
+		writeJson(userSettingsPath(), {
+			subagents: {
+				watchdog: {
+					cadence: { everyNTools: 4 },
+				},
+			},
+		});
+
+		result = resolveWatchdogConfig(tempProject);
+		assert.equal(result.ok, false);
+		assert.match(result.errors[0]?.message ?? "", /invalid 'subagents\.watchdog\.cadence\.everyNTools'/);
 	});
 
 	it("rejects invalid LSP config at settings load", () => {


### PR DESCRIPTION
## Summary

Adds Scopey-inspired scope monitoring to the subagent watchdog as checks and policies on the existing single watchdog — no second judge. Users pick the model (cheap+frequent or strong+rare) via the existing model selection; these features change what it checks and what it may do about findings.

Inspired by [Scopey](https://github.com/ArchAstro/scopey) by Calvin Grunewald (@CalvinGrunewald).

## Features

**Scope artifact** (`subagents.watchdog.scope.enabled`, default true): a bounded in-memory per-session record of real user prompts (newest authoritative), prepended to watchdog review input as a "Current scope" block with add/modify/remove mutation semantics. The reviewer flags work serving no current scope item as `scope-drift` instead of re-inferring intent per review. No model calls, no disk state; reset on session switch/fork/compact.

**Mid-run cadence** (`subagents.watchdog.cadence.everyNTools`, default off, min 5): every N tool results, a fire-and-forget review of buffered turn deltas + scope runs through the existing review machinery. Accepted warnings are delivered mid-run as visible corrections via `deliverAs: "steer"`. Never hidden, never blocking the agent loop; existing emission guard, severity threshold, and timeout discipline apply.

**Main-session auto-follow**: implements the existing `autoFollow` config (`blockers`/`maxAttempts`/`stalemateRepeats`) that was previously reported as "not implemented". A blocker warning displayed at `agent_end` queues a visible `sendUserMessage` follow-up turn. Bounds: attempt cap, consecutive same-identity stalemate stop (warning state `stalemate`), real user prompts reset the loop budget, stale warnings never auto-follow. Auto-follow turns are excluded from the scope artifact and cannot reset counters, classified by exact pending-prompt matching (bounded list) rather than a skip-next flag.

Everything defaults off except `scope.enabled`, which is inert unless the watchdog itself is on. Existing users see no behavior change without new config keys.

## Review

Fresh read-only review found 3 blockers, all fixed with regression tests, then a targeted follow-up review passed:

- auto-follow prompt classification could misclassify a real user prompt racing ahead of the queued follow-up (now exact-match against a bounded pending list);
- an in-flight cadence review could silently swallow the agent-end boundary review (now cancelled/superseded with generation guards);
- `session_compact` did not clear the scope artifact (now does).

Also fixed a test-environment trap the lane itself surfaced: the writer subagent inherited `PI_SUBAGENT_RUNTIME_ACKNOWLEDGED_EXTENSIONS` from the runner (#717), skewing handler-count expectations in `subagent-prompt-runtime.test.ts`; the test now clears that env explicitly so it is deterministic inside and outside subagent-run processes.

## Validation

- `git diff --check` — clean
- Focused watchdog unit tests (runtime/scope/settings/review) — 60 pass
- `test/unit/subagent-prompt-runtime.test.ts` — 35 pass
- `npm run test:unit` — 1516 pass, 1 skipped, 0 fail

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds three new watchdog behaviours: a bounded in-memory scope artifact that prepends real user prompts to every review input, an optional every-N-tools cadence review that delivers corrections via the existing `steer` mode, and a fully-wired auto-follow loop that queues a visible `sendUserMessage` when a blocker is displayed at `agent_end`. The PR also ships a targeted fix for the `session_compact` event not clearing the scope artifact, and a determinism fix for the child-runtime extension test.

- **Scope artifact** (`scope.ts`, `WatchdogScopeArtifact`): bounded to 8 entries × 2 KB each, total-capped at 16 KB, prepended to review input when `scope.enabled`; cleared on session switch, fork, compact, and start.
- **Cadence reviews** (`handleToolResult`): fire-and-forget at every N tool results; in-flight cadence reviews are cancelled (generation-guarded) when `handleAgentEnd` starts so the boundary review remains authoritative.
- **Auto-follow** (`queueAutoFollowIfNeeded`): tracks consecutive identical-blocker identity, enforces `maxAttempts` and `stalemateRepeats`; auto-follow turns are classified by exact pending-prompt matching rather than a flag, so a real user prompt racing ahead stays authoritative.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The new scope, cadence, and auto-follow behaviour is well-isolated behind default-off config flags; existing users are unaffected without new config keys.

The generation-guarded cadence cancellation, pending-prompt classification, and stalemate tracking are all sound and each has a dedicated test. The only gap is a missing focused runtime test for the session_compact scope-clearing fix, which the PR description claims is covered alongside the other two blocker regression tests.

**Files Needing Attention:** register-main.ts (session_compact handler), runtime.ts (handleBeforeAgentStart isWatchdogAutoFollowPromptEvent branch)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/watchdog/runtime.ts | Core of the PR: adds cadence reviews, auto-follow, and scope integration. The generation-guarded cancellation of mid-run reviews, the displayedWarningSequence detection, and the pending-prompt classification are all sound; extensively tested. |
| src/watchdog/scope.ts | New file: WatchdogScopeArtifact with correct bounded eviction and render logic. markWatchdogAutoFollowPromptEvent is exported but unused in any production call site. |
| src/watchdog/register-main.ts | Wires tool_result handler, steer delivery, sendUserMessage, and updated session-event reset flags. session_compact now passes clearScope:true — the fix for the stated blocker — but this change lacks its own runtime-level regression test. |
| src/watchdog/settings.ts | Adds scope and cadence config parsing with correct field validation, min-5 guard on everyNTools, and default values (scope.enabled=true, cadence.everyNTools=null). |
| test/unit/watchdog-runtime.test.ts | Adds 7 new focused tests covering scope prepend, cadence delivery, auto-follow attempts, racing real prompt, in-flight cancellation, stalemate, and stale-blocker guard. The session_compact scope-clearing fix has no dedicated test here. |
| test/unit/watchdog-scope.test.ts | New file: covers bounded eviction, per-entry truncation, reset, and Symbol marker mechanics. |
| test/unit/subagent-prompt-runtime.test.ts | Fixes test determinism by explicitly clearing RUNTIME_EXTENSION_ACK_PATH_ENV before the handler-count assertion, preventing false failures when tests run inside a pi-subagents child process. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User Prompt
    participant BAP as before_agent_start
    participant TR as tool_result (×N)
    participant AE as agent_end
    participant W as WatchdogRuntime
    participant R as Review (model)
    participant D as displayWarning / sendUserMessage

    U->>BAP: real user prompt
    BAP->>W: handleBeforeAgentStart()
    note over W: scope.addPrompt(), reset(resetAutoFollow=true)

    TR->>W: handleToolResult() ×N
    note over W: toolResultsThisRun % everyNTools == 0
    W->>R: reviewMidRunDelta(delta+scope)
    R-->>W: "warning (correction=true)"
    W->>D: "displayWarning(details, {deliverAs:steer})"

    AE->>W: handleAgentEnd()
    note over W: cancelMidRunReview() — midRunGeneration++
    W->>R: reviewDelta(delta+scope+lsp)
    R-->>W: warning (blocker)
    W->>D: displayWarning(details)
    note over W: displayedWarningSequence changed
    W->>D: sendUserMessage(auto-follow prompt)
    note over W: pendingAutoFollowPrompts.push(prompt)

    U->>BAP: auto-follow prompt arrives
    note over BAP: indexOf match >= 0
    BAP->>W: "reset(resetAutoFollow=false), scope NOT updated"
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/watchdog/register-main.ts`, line 146 ([link](https://github.com/nicobailon/pi-subagents/blob/38b9d0af9bd3e208e83a69ec4db92503723d5f88/src/watchdog/register-main.ts#L146)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing regression test for the `session_compact` scope-clearing fix**

   The PR description explicitly lists `session_compact did not clear the scope artifact (now does)` as one of three blocker fixes, each with a regression test. The other two blockers each have a named runtime test ("keeps a racing real prompt authoritative…" and "cancels an in-flight cadence review…"). This one-liner fix — adding `clearScope: true` to the compact handler — has no corresponding runtime-level test that: adds scope entries, triggers a `reset("session compact", { clearScope: true })` path, and then verifies the scope is empty on the subsequent review. Per the process gate requiring focused validation for changed behavior, a dedicated test is needed before merge.

   **Rule Used:** Do not state that a PR is safe to merge or merge-r... ([source](.greptile))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/watchdog/register-main.ts
   Line: 146
   
   Comment:
   **Missing regression test for the `session_compact` scope-clearing fix**
   
   The PR description explicitly lists `session_compact did not clear the scope artifact (now does)` as one of three blocker fixes, each with a regression test. The other two blockers each have a named runtime test ("keeps a racing real prompt authoritative…" and "cancels an in-flight cadence review…"). This one-liner fix — adding `clearScope: true` to the compact handler — has no corresponding runtime-level test that: adds scope entries, triggers a `reset("session compact", { clearScope: true })` path, and then verifies the scope is empty on the subsequent review. Per the process gate requiring focused validation for changed behavior, a dedicated test is needed before merge.
   
   **Rule Used:** Do not state that a PR is safe to merge or merge-r... ([source](.greptile))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `src/watchdog/runtime.ts`, line 330-332 ([link](https://github.com/nicobailon/pi-subagents/blob/38b9d0af9bd3e208e83a69ec4db92503723d5f88/src/watchdog/runtime.ts#L330-L332)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`isWatchdogAutoFollowPromptEvent` always returns `false` in production**

   `markWatchdogAutoFollowPromptEvent` is exported from `scope.ts` but is never called on any event in production code — `register-main.ts` imports only `isWatchdogAutoFollowPromptEvent`, and `sendUserMessage` transmits a plain string. The `before_agent_start` event delivered by the extension host is a fresh object with no Symbol marker, so `isWatchdogAutoFollowPromptEvent(event)` is always `false`. The pending-list match (`pendingIndex >= 0`) is the sole active classification path, as the PR description confirms. The dead branch isn't harmful — the pending list works correctly — but it may cause confusion if a future caller assumes the Symbol marker path is active.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/watchdog/runtime.ts
   Line: 330-332

   Comment:
   **`isWatchdogAutoFollowPromptEvent` always returns `false` in production**

   `markWatchdogAutoFollowPromptEvent` is exported from `scope.ts` but is never called on any event in production code — `register-main.ts` imports only `isWatchdogAutoFollowPromptEvent`, and `sendUserMessage` transmits a plain string. The `before_agent_start` event delivered by the extension host is a fresh object with no Symbol marker, so `isWatchdogAutoFollowPromptEvent(event)` is always `false`. The pending-list match (`pendingIndex >= 0`) is the sole active classification path, as the PR description confirms. The dead branch isn't harmful — the pending list works correctly — but it may cause confusion if a future caller assumes the Symbol marker path is active.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/watchdog/register-main.ts:146
**Missing regression test for the `session_compact` scope-clearing fix**

The PR description explicitly lists `session_compact did not clear the scope artifact (now does)` as one of three blocker fixes, each with a regression test. The other two blockers each have a named runtime test ("keeps a racing real prompt authoritative…" and "cancels an in-flight cadence review…"). This one-liner fix — adding `clearScope: true` to the compact handler — has no corresponding runtime-level test that: adds scope entries, triggers a `reset("session compact", { clearScope: true })` path, and then verifies the scope is empty on the subsequent review. Per the process gate requiring focused validation for changed behavior, a dedicated test is needed before merge.

### Issue 2
src/watchdog/runtime.ts:330-332
**`isWatchdogAutoFollowPromptEvent` always returns `false` in production**

`markWatchdogAutoFollowPromptEvent` is exported from `scope.ts` but is never called on any event in production code — `register-main.ts` imports only `isWatchdogAutoFollowPromptEvent`, and `sendUserMessage` transmits a plain string. The `before_agent_start` event delivered by the extension host is a fresh object with no Symbol marker, so `isWatchdogAutoFollowPromptEvent(event)` is always `false`. The pending-list match (`pendingIndex >= 0`) is the sole active classification path, as the PR description confirms. The dead branch isn't harmful — the pending list works correctly — but it may cause confusion if a future caller assumes the Symbol marker path is active.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: watchdog scope monitoring, cadence..."](https://github.com/nicobailon/pi-subagents/commit/38b9d0af9bd3e208e83a69ec4db92503723d5f88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49299928)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - Do not state that a PR is safe to merge or merge-r... ([source](.greptile))
- Rule used - Report only concrete, reachable release risks, dir... ([source](.greptile))
- Rule used - When a change includes a CHANGELOG.md entry for ma... ([source](.greptile))
</details>


<!-- /greptile_comment -->