### PR TITLE
feat: session-scoped agent allowlist on the capability ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added session-scoped `allowedAgents` capability ceilings for restricting launchable agent roles without global agent disabling. Thanks to @aoguai for #719.
 - Added stable foreground result row indexes for correlating child progress and final results. Thanks to @rochecompaan (Patchmill) for #720.
 - Added watchdog current-scope context, optional every-N-tools scope-monitor cadence, and visible main-session blocker auto-follow, inspired by Scopey (github.com/ArchAstro/scopey) by Calvin Grunewald (@CalvinGrunewald).
 - Added optional `runtimeAcknowledgedExtensions` status/result/RPC metadata for cooperating child-runtime extensions that emit `subagent:acknowledge-extension`. Thanks to @saleemlala for #705.

--- a/README.md
+++ b/README.md
@@ -1222,13 +1222,17 @@ import { registerSubagentCapabilityCeiling } from "pi-subagents/capability-ceili
 const restriction = registerSubagentCapabilityCeiling({
   sessionId: ctx.sessionManager.getSessionId(),
   source: "plan-mode",
-  ceiling: { allowedTools: ["read", "grep", "find", "ls"], denyExtensions: true },
+  ceiling: {
+    allowedAgents: ["plan-scout", "plan-researcher", "plan-reviewer"],
+    allowedTools: ["read", "grep", "find", "ls"],
+    denyExtensions: true,
+  },
 });
 // restriction.update(...) replaces this provider's policy atomically.
 // restriction.dispose() removes only this provider's registration.
 ```
 
-Active registrations intersect their `allowedTools` sets and OR `denyExtensions`; an explicit empty list means no caller-facing tools, while an omitted list does not restrict names. The resolved snapshot is propagated monotonically to nested and async children and is retained for recovery. `structured_output` may remain as a package-owned internal protocol tool when an output schema requires it; it is not a caller capability. A denied lazy-skill `read` requirement fails before spawn rather than widening the ceiling.
+Active registrations intersect their `allowedTools` and `allowedAgents` sets and OR `denyExtensions`; an explicit empty list means no caller-facing tools or launchable agents for that field, while an omitted list does not restrict names. `allowedAgents` entries are canonical agent names and are case-sensitive. Launching a non-allowlisted agent fails before spawn, and `{ action: "list" }` keeps restricted agents visible in a separate non-executable section instead of silently hiding them. The resolved snapshot is propagated monotonically to nested and async children and is retained for recovery. `structured_output` may remain as a package-owned internal protocol tool when an output schema requires it; it is not a caller capability. A denied lazy-skill `read` requirement fails before spawn rather than widening the ceiling.
 
 `denyExtensions` suppresses ambient, configured, and MCP provider extensions while retaining the package runtime needed for child protocol enforcement. This is a same-process policy boundary, not a sandbox against malicious code already running in the parent process. Schedules created while a ceiling is active are rejected until durable schedule persistence is available; unrestricted schedules remain subject to any policy active when they fire. Public status exposes bounded audit counts and sources, never full extension paths.
 

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -34,6 +34,6 @@ For broad or uncertain requests, read more than one reference. For complex work,
 - For parallel fanout, compare child prompts before launch. Do not send clone prompts with only issue numbers, titles, or broad file globs swapped; each child needs a lane-specific task, source seam, prior evidence, and decision that remains distinct without the item number.
 - Prefer fresh-context review/validation fanout, then synthesize and apply fixes in the parent.
 - Use async/background only when work can proceed independently; do not poll just to wait. For planned human gates in chains, use `{ checkpoint: "name", message?: "..." }` and approve or reject paused async checkpoints with `approve-checkpoint` / `reject-checkpoint`.
-- Preserve capability ceilings and child tool restrictions; role selection is not enforcement.
+- Preserve capability ceilings, including child tool restrictions and session-scoped allowed-agent restrictions.
 - Escalate unresolved product, architecture, or safety decisions upward instead of letting a child decide silently.
 - As a conservative orchestration policy, do not pass `turnBudget`, a hard `toolBudget`, or a tight `usageBudget` to mutation-capable workers. The default tool budget blocks read/search tools rather than mutation tools, and reported usage has no reservation model. If a worker is interrupted after a tool call starts, checkpoint after the current tool returns with changed files, build/test state, and commit or PR state.

--- a/skills/pi-subagents/references/prompting-and-roles.md
+++ b/skills/pi-subagents/references/prompting-and-roles.md
@@ -4,7 +4,7 @@ This file is a detailed reference loaded from `skills/pi-subagents/SKILL.md`.
 
 ## Capability ceilings
 
-Parent extensions may register a session-scoped, out-of-band ceiling through `pi-subagents/capability-ceiling`. Child tools are intersected with every active registration and inherited snapshot; `denyExtensions` removes ambient/provider extension loading while retaining package protocol runtime. Do not add a model-visible ceiling field or rely on role selection for enforcement. Restricted schedules are rejected until their ceiling can be persisted safely.
+Parent extensions may register a session-scoped, out-of-band ceiling through `pi-subagents/capability-ceiling`. Child tools and eligible canonical agent names are intersected with every active registration and inherited snapshot; `denyExtensions` removes ambient/provider extension loading while retaining package protocol runtime. `{ action: "list" }` marks non-allowlisted agents as restricted, and launch rejects them before spawn. Do not add a model-visible ceiling field or rely on unrestricted role selection for enforcement. Restricted schedules are rejected until their ceiling can be persisted safely.
 
 ## When to Use
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -36,10 +36,11 @@ import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import type { AcceptanceInput, Details, ExtensionConfig, ToolBudgetConfig } from "../shared/types.ts";
 import { getProjectConfigDir } from "../shared/utils.ts";
+import { capabilityCeilingAgentRestrictionSources, isAgentAllowedByCapabilityCeiling, resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
 
 type ManagementAction = "list" | "get" | "models" | "create" | "update" | "delete" | "eject" | "disable" | "enable" | "reset";
 type ManagementScope = "user" | "project";
-type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry"> & { model?: ExtensionContext["model"]; config?: ExtensionConfig };
+type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry"> & { model?: ExtensionContext["model"]; config?: ExtensionConfig; currentSessionId?: string };
 
 interface ManagementParams {
 	action?: string;
@@ -676,7 +677,11 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 	const d = discoverAgentsAll(ctx.cwd);
 	const scopedAgents = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package)
 		.sort((a, b) => a.name.localeCompare(b.name));
-	const agents = scopedAgents.filter((a) => !a.disabled);
+	const capabilityCeiling = resolveCurrentSubagentCapabilityCeiling(ctx.currentSessionId);
+	const visibleAgents = scopedAgents.filter((a) => !a.disabled);
+	const agents = visibleAgents.filter((a) => isAgentAllowedByCapabilityCeiling(a.name, capabilityCeiling));
+	const restrictedAgents = visibleAgents.filter((a) => !isAgentAllowedByCapabilityCeiling(a.name, capabilityCeiling));
+	const restrictedSources = capabilityCeilingAgentRestrictionSources(capabilityCeiling);
 	const chains = d.chains.filter((c) => scope === "both" || c.source === "package" || c.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const diagnostics = d.chainDiagnostics.filter((entry) => scope === "both" || entry.source === scope);
 	const proactiveSuggestions = buildProactiveSkillSubagentRecommendationLines({
@@ -690,6 +695,11 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 		...(agents.length
 			? agents.map((a) => `- ${a.name} (${a.source}${a.defaultContext ? `, context: ${a.defaultContext}` : ""}${a.aliases?.length ? `, aliases: ${a.aliases.join(", ")}` : ""}): ${a.description}`)
 			: ["- (none)"]),
+		...(restrictedAgents.length ? [
+			"",
+			`Restricted agents (not executable in this session${restrictedSources?.length ? `; capability ceiling: ${restrictedSources.join(", ")}` : ""}):`,
+			...restrictedAgents.map((a) => `- ${a.name} (${a.source}${a.aliases?.length ? `, aliases: ${a.aliases.join(", ")}` : ""}): ${a.description}`),
+		] : []),
 		"",
 		"Chains:",
 		...(chains.length ? chains.map((c) => `- ${c.name} (${c.source}): ${c.description}`) : ["- (none)"]),

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -12,7 +12,7 @@ import { injectOutputPathSystemPrompt, normalizeSingleOutputOverride, resolveSin
 import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveEffectiveThinking } from "../shared/model-info.ts";
 import { SUBAGENT_LIFECYCLE_ARTIFACT_VERSION, type ArtifactDirPreference, type ArtifactPaths, type JsonSchemaObject, type OutputMode } from "../shared/types.ts";
-import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../runs/shared/capability-ceiling.ts";
+import { capabilityCeilingAgentRestrictionMessage, intersectSubagentCapabilityCeilings, type ResolvedSubagentCapabilityCeiling, type SubagentCapabilityAudit } from "../runs/shared/capability-ceiling.ts";
 import { appendTurnBudgetSystemPrompt } from "../runs/shared/turn-budget.ts";
 import type { ResolvedTurnBudget } from "../shared/types.ts";
 import type { ResolvedMcpDirectToolSelection } from "../runs/shared/mcp-direct-tool-allowlist.ts";
@@ -31,7 +31,8 @@ export type SubagentLaunchContractReasonCode =
 	| "denied_required_tool"
 	| "invalid_artifact_dir"
 	| "invalid_cwd"
-	| "unsupported_mode";
+	| "unsupported_mode"
+	| "restricted_agent";
 
 export interface SubagentLaunchContractDiagnostic {
 	code: SubagentLaunchContractReasonCode | "host_required" | "snapshot_warning";
@@ -233,6 +234,9 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		return { ok: false, code: "missing_agent", message: `Unknown agent: ${input.agent}`, diagnostics };
 	}
 	const agent = resolvedAgent.agent;
+	const effectiveCapabilityCeiling = intersectSubagentCapabilityCeilings(input.capabilityCeiling, input.inheritedCapabilityCeiling);
+	const restrictionMessage = capabilityCeilingAgentRestrictionMessage(agent.name, effectiveCapabilityCeiling);
+	if (restrictionMessage) return { ok: false, code: "restricted_agent", message: restrictionMessage, diagnostics };
 	const runId = input.runId ?? "preflight";
 	const skillInput = normalizeSkillInput(input.skill);
 	const outputOverride = normalizeSingleOutputOverride(input.output, agent.output);
@@ -272,8 +276,8 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 			cwd: effectiveCwd,
 			requireReadTool: resolvedSkills.resolved.length > 0,
 			structuredOutput: Boolean(input.outputSchema),
-			capabilityCeiling: input.capabilityCeiling,
-			inheritedCapabilityCeiling: input.inheritedCapabilityCeiling,
+			capabilityCeiling: effectiveCapabilityCeiling,
+			agentName: agent.name,
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -59,7 +59,7 @@ import type { ImportedAsyncRoot } from "./chain-root-attachment.ts";
 import type { SessionLeaseRequest } from "../shared/session-lease.ts";
 import { finalizeProcessTerminal, readProcessTerminal } from "./process-terminal.ts";
 import { SUBAGENT_PROCESS_TERMINAL_EVENT } from "../../shared/types.ts";
-import { decodeSubagentCapabilityCeiling, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
+import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
 import { agentDefinitionDigest, launchBindingDigest } from "../../shared/launch-contract.ts";
 
 const require = createRequire(import.meta.url);
@@ -643,6 +643,11 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 	};
 	const buildSeqStep = (s: SequentialStep, sessionFile?: string, behaviorCwd?: string, progressPrecreated = false, resolvedBehavior?: ResolvedStepBehavior, flatIndex?: number, parallelOutputNamespace?: { stepIndex: number; taskIndex?: number }) => {
 		const a = agents.find((x) => x.name === s.agent)!;
+		try {
+			assertAgentAllowedByCapabilityCeiling(a.name, intersectSubagentCapabilityCeilings(params.capabilityCeiling, decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV])));
+		} catch (error) {
+			throw new AsyncStartValidationError(error instanceof Error ? error.message : String(error));
+		}
 		const toolBudgetInput = s.toolBudget ?? params.toolBudget ?? a.toolBudget ?? params.configToolBudget;
 		const resolvedToolBudget = validateToolBudgetConfig(toolBudgetInput, s.toolBudget ? "toolBudget" : a.toolBudget ? "agent.toolBudget" : "config.toolBudget");
 		if (resolvedToolBudget.error) throw new AsyncStartValidationError(resolvedToolBudget.error);
@@ -713,6 +718,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			structuredOutput: Boolean(s.outputSchema),
 			capabilityCeiling: params.capabilityCeiling,
 			inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
+			agentName: a.name,
 		});
 		const launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
 		return {
@@ -1178,7 +1184,12 @@ export function executeAsyncSingle(
 		nestedRoute,
 	} = params;
 	const task = params.task ?? "";
-	const capabilityCeiling = params.capabilityCeiling ?? resolveCurrentSubagentCapabilityCeiling(ctx.currentSessionId);
+	const capabilityCeiling = intersectSubagentCapabilityCeilings(params.capabilityCeiling ?? resolveCurrentSubagentCapabilityCeiling(ctx.currentSessionId), decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]));
+	try {
+		assertAgentAllowedByCapabilityCeiling(agentConfig.name, capabilityCeiling);
+	} catch (error) {
+		return formatAsyncStartError("single", error instanceof Error ? error.message : String(error));
+	}
 	const runnerCwd = resolveChildCwd(ctx.cwd, cwd);
 	const skillNames = params.skills ?? agentConfig.skills ?? [];
 	const availableModels = params.availableModels;
@@ -1259,6 +1270,7 @@ export function executeAsyncSingle(
 		structuredOutput: Boolean(params.structuredOutputSchema),
 		capabilityCeiling,
 		inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
+		agentName: agentConfig.name,
 	});
 	const launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
 	const launchContractDigest = launchBindingDigest({

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -57,7 +57,7 @@ import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/pi-args.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
-import { decodeSubagentCapabilityCeiling, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV } from "../shared/capability-ceiling.ts";
+import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV } from "../shared/capability-ceiling.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput } from "../shared/structured-output.ts";
 import { formatProcessSignalError, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
@@ -350,6 +350,7 @@ async function runSingleAttempt(
 		structuredOutput: Boolean(options.structuredOutput),
 		capabilityCeiling: options.capabilityCeiling,
 		inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
+		agentName: agent.name,
 	});
 	const launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
 	const launchContractDigest = launchBindingDigest({
@@ -1324,7 +1325,7 @@ async function runSyncCompletion(
 ): Promise<SingleResult> {
 	options = {
 		...options,
-		capabilityCeiling: options.capabilityCeiling ?? resolveCurrentSubagentCapabilityCeiling(options.parentSessionId),
+		capabilityCeiling: intersectSubagentCapabilityCeilings(options.capabilityCeiling ?? resolveCurrentSubagentCapabilityCeiling(options.parentSessionId), decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV])),
 	};
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
@@ -1336,6 +1337,19 @@ async function runSyncCompletion(
 			messages: [],
 			usage: emptyUsage(),
 			error: `Unknown agent: ${agentName}`,
+		}, options.context);
+	}
+	try {
+		assertAgentAllowedByCapabilityCeiling(agent.name, options.capabilityCeiling);
+	} catch (error) {
+		return withRunContext({
+			agent: agent.name,
+			task,
+			exitCode: 1,
+			messages: [],
+			usage: emptyUsage(),
+			error: error instanceof Error ? error.message : String(error),
+			...(options.capabilityCeiling ? { capabilityCeiling: options.capabilityCeiling } : {}),
 		}, options.context);
 	}
 	const outputModeValidationError = validateFileOnlyOutputMode(options.outputMode, options.outputPath, `Single run (${agentName})`);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4076,6 +4076,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				...ctx,
 				cwd: requestCwd,
 				config: deps.config,
+				currentSessionId: deps.state.currentSessionId ?? ctx.sessionManager.getSessionId() ?? undefined,
 			});
 		}
 

--- a/src/runs/shared/capability-ceiling.ts
+++ b/src/runs/shared/capability-ceiling.ts
@@ -5,12 +5,14 @@ export const SUBAGENT_CAPABILITY_CEILING_REGISTRY_KEY = "pi-subagents.capability
 export const SUBAGENT_CAPABILITY_CEILING_ENV = "PI_SUBAGENT_CAPABILITY_CEILING_V1";
 
 export type SubagentCapabilityCeiling =
-	| { allowedTools: readonly string[]; denyExtensions?: boolean }
-	| { allowedTools?: readonly string[]; denyExtensions: boolean };
+	| { allowedTools: readonly string[]; allowedAgents?: readonly string[]; denyExtensions?: boolean }
+	| { allowedTools?: readonly string[]; allowedAgents?: readonly string[]; denyExtensions: boolean }
+	| { allowedTools?: readonly string[]; allowedAgents: readonly string[]; denyExtensions?: boolean };
 
 export interface ResolvedSubagentCapabilityCeiling {
 	version: typeof SUBAGENT_CAPABILITY_CEILING_VERSION;
 	allowedTools?: string[];
+	allowedAgents?: string[];
 	denyExtensions: boolean;
 	sources: string[];
 }
@@ -25,6 +27,8 @@ export interface SubagentCapabilityAudit {
 	removedExtensionCount: number;
 	requestedMcpToolCount: number;
 	effectiveMcpTools: string[];
+	agentAllowed: boolean;
+	agentRestrictionSources?: string[];
 }
 
 export interface RegisterSubagentCapabilityCeilingOptions {
@@ -61,23 +65,28 @@ function validateText(value: unknown, field: string): string {
 function normalizeCeiling(ceiling: SubagentCapabilityCeiling): ResolvedSubagentCapabilityCeiling {
 	if (!ceiling || typeof ceiling !== "object" || Array.isArray(ceiling)) throw new Error("Invalid capability ceiling; expected an object.");
 	const hasAllowedTools = Object.hasOwn(ceiling, "allowedTools");
+	const hasAllowedAgents = Object.hasOwn(ceiling, "allowedAgents");
 	const hasDenyExtensions = Object.hasOwn(ceiling, "denyExtensions");
-	if (!hasAllowedTools && !hasDenyExtensions) throw new Error("Invalid capability ceiling; expected allowedTools or denyExtensions.");
+	if (!hasAllowedTools && !hasAllowedAgents && !hasDenyExtensions) throw new Error("Invalid capability ceiling; expected allowedTools, allowedAgents, or denyExtensions.");
 	if (hasDenyExtensions && typeof ceiling.denyExtensions !== "boolean") throw new Error("Invalid capability ceiling denyExtensions; expected a boolean.");
-	let allowedTools: string[] | undefined;
-	if (hasAllowedTools) {
-		if (!Array.isArray(ceiling.allowedTools)) throw new Error("Invalid capability ceiling allowedTools; expected an array.");
-		if (ceiling.allowedTools.length > 256) throw new Error("Invalid capability ceiling allowedTools; expected at most 256 names.");
-		allowedTools = [...new Set(ceiling.allowedTools.map((tool) => {
-			const name = validateText(tool, "allowedTools entry");
-			if (!/^[A-Za-z0-9_.:-]+$/u.test(name)) throw new Error(`Invalid capability ceiling allowedTools entry '${name}'.`);
-			if (Buffer.byteLength(name, "utf8") > 128) throw new Error(`Invalid capability ceiling allowedTools entry '${name}'; max 128 UTF-8 bytes.`);
+	const normalizeList = (field: "allowedTools" | "allowedAgents", pattern: RegExp): string[] | undefined => {
+		if (!Object.hasOwn(ceiling, field)) return undefined;
+		const values = ceiling[field];
+		if (!Array.isArray(values)) throw new Error(`Invalid capability ceiling ${field}; expected an array.`);
+		if (values.length > 256) throw new Error(`Invalid capability ceiling ${field}; expected at most 256 names.`);
+		return [...new Set(values.map((entry) => {
+			const name = validateText(entry, `${field} entry`);
+			if (!pattern.test(name)) throw new Error(`Invalid capability ceiling ${field} entry '${name}'.`);
+			if (Buffer.byteLength(name, "utf8") > 128) throw new Error(`Invalid capability ceiling ${field} entry '${name}'; max 128 UTF-8 bytes.`);
 			return name;
 		}))].sort();
-	}
+	};
+	const allowedTools = normalizeList("allowedTools", /^[A-Za-z0-9_.:-]+$/u);
+	const allowedAgents = normalizeList("allowedAgents", /^[A-Za-z0-9_.:-]+$/u);
 	return {
 		version: SUBAGENT_CAPABILITY_CEILING_VERSION,
-		...(allowedTools ? { allowedTools } : {}),
+		...(allowedTools !== undefined ? { allowedTools } : {}),
+		...(allowedAgents !== undefined ? { allowedAgents } : {}),
 		denyExtensions: ceiling.denyExtensions === true,
 		sources: [],
 	};
@@ -131,14 +140,17 @@ export function registerSubagentCapabilityCeiling(options: RegisterSubagentCapab
 export function intersectSubagentCapabilityCeilings(...ceilings: Array<ResolvedSubagentCapabilityCeiling | undefined>): ResolvedSubagentCapabilityCeiling | undefined {
 	const active = ceilings.filter((ceiling): ceiling is ResolvedSubagentCapabilityCeiling => ceiling !== undefined);
 	if (active.length === 0) return undefined;
-	const definedLists = active.filter((ceiling) => ceiling.allowedTools !== undefined).map((ceiling) => new Set(ceiling.allowedTools));
-	let allowedTools: string[] | undefined;
-	if (definedLists.length > 0) {
-		allowedTools = [...definedLists[0]!].filter((tool) => definedLists.every((list) => list.has(tool))).sort();
-	}
+	const intersectLists = (field: "allowedTools" | "allowedAgents"): string[] | undefined => {
+		const definedLists = active.filter((ceiling) => ceiling[field] !== undefined).map((ceiling) => new Set(ceiling[field]));
+		if (definedLists.length === 0) return undefined;
+		return [...definedLists[0]!].filter((entry) => definedLists.every((list) => list.has(entry))).sort();
+	};
+	const allowedTools = intersectLists("allowedTools");
+	const allowedAgents = intersectLists("allowedAgents");
 	return {
 		version: SUBAGENT_CAPABILITY_CEILING_VERSION,
-		...(allowedTools ? { allowedTools } : {}),
+		...(allowedTools !== undefined ? { allowedTools } : {}),
+		...(allowedAgents !== undefined ? { allowedAgents } : {}),
 		denyExtensions: active.some((ceiling) => ceiling.denyExtensions),
 		sources: [...new Set(active.flatMap((ceiling) => ceiling.sources))].sort(),
 	};
@@ -155,6 +167,26 @@ export function resolveSubagentCapabilityCeiling(sessionId: string | undefined, 
 
 export function resolveCurrentSubagentCapabilityCeiling(sessionId: string | undefined): ResolvedSubagentCapabilityCeiling | undefined {
 	return resolveSubagentCapabilityCeiling(sessionId, decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]));
+}
+
+export function isAgentAllowedByCapabilityCeiling(agentName: string, ceiling: ResolvedSubagentCapabilityCeiling | undefined): boolean {
+	return ceiling?.allowedAgents === undefined || ceiling.allowedAgents.includes(agentName);
+}
+
+export function capabilityCeilingAgentRestrictionMessage(agentName: string, ceiling: ResolvedSubagentCapabilityCeiling | undefined): string | undefined {
+	if (isAgentAllowedByCapabilityCeiling(agentName, ceiling)) return undefined;
+	const sources = ceiling?.sources.length ? ceiling.sources.join(", ") : "unknown source";
+	const allowed = ceiling?.allowedAgents?.length ? ceiling.allowedAgents.join(", ") : "(none)";
+	return `Capability ceiling from ${sources} does not allow agent '${agentName}'. Allowed agents: ${allowed}.`;
+}
+
+export function assertAgentAllowedByCapabilityCeiling(agentName: string, ceiling: ResolvedSubagentCapabilityCeiling | undefined): void {
+	const message = capabilityCeilingAgentRestrictionMessage(agentName, ceiling);
+	if (message) throw new Error(message);
+}
+
+export function capabilityCeilingAgentRestrictionSources(ceiling: ResolvedSubagentCapabilityCeiling | undefined): string[] | undefined {
+	return ceiling?.allowedAgents === undefined ? undefined : [...ceiling.sources];
 }
 
 export function encodeSubagentCapabilityCeiling(ceiling: ResolvedSubagentCapabilityCeiling | undefined): string | undefined {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -15,7 +15,7 @@ import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, MCP_DIRECT_CHILD_TOOLS_ENV, REQUIRED_CH
 import { CHILD_WATCHDOG_CONFIG_ENV, encodeChildWatchdogConfig, type ChildWatchdogConfig } from "../../watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../background/wait-config.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../shared/utils.ts";
-import { SUBAGENT_CAPABILITY_CEILING_ENV, decodeSubagentCapabilityCeiling, encodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, type ResolvedSubagentCapabilityCeiling, type SubagentCapabilityAudit } from "./capability-ceiling.ts";
+import { SUBAGENT_CAPABILITY_CEILING_ENV, capabilityCeilingAgentRestrictionSources, decodeSubagentCapabilityCeiling, encodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, isAgentAllowedByCapabilityCeiling, type ResolvedSubagentCapabilityCeiling, type SubagentCapabilityAudit } from "./capability-ceiling.ts";
 
 const TASK_ARG_LIMIT = 8000;
 const MAX_LAUNCH_RESOLVED_EXTENSION_IDS = 32;
@@ -128,6 +128,7 @@ export interface ResolvePiLaunchToolPlanInput {
 	structuredOutput?: boolean;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	inheritedCapabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	agentName?: string;
 }
 
 export interface PiLaunchToolPlan {
@@ -227,6 +228,8 @@ export function resolvePiLaunchToolPlan(input: ResolvePiLaunchToolPlanInput): Pi
 		removedExtensionCount: capabilityCeiling.denyExtensions ? (input.extensions?.length ?? 0) + (input.subagentOnlyExtensions?.length ?? 0) + ((input.tools ?? []).filter((tool) => tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")).length) : 0,
 		requestedMcpToolCount: input.mcpDirectTools?.length ?? 0,
 		effectiveMcpTools,
+		agentAllowed: input.agentName === undefined ? true : isAgentAllowedByCapabilityCeiling(input.agentName, capabilityCeiling),
+		...(capabilityCeilingAgentRestrictionSources(capabilityCeiling) ? { agentRestrictionSources: capabilityCeilingAgentRestrictionSources(capabilityCeiling) } : {}),
 	} satisfies SubagentCapabilityAudit : undefined;
 	return {
 		...(capabilityCeiling ? { capabilityCeiling } : {}),
@@ -280,6 +283,7 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		structuredOutput: input.structuredOutput,
 		capabilityCeiling: input.capabilityCeiling,
 		inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
+		agentName: input.childAgentName,
 	});
 	if (toolPlan.explicitToolAllowlist) {
 		args.push(toolPlan.effectiveToolAllowlist.length > 0 ? "--tools" : "--no-tools");

--- a/test/unit/capability-ceiling-agent-allowlist.test.ts
+++ b/test/unit/capability-ceiling-agent-allowlist.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { handleList } from "../../src/agents/agent-management.ts";
+import type { AgentConfig } from "../../src/agents/agents.ts";
+import { resolveSubagentLaunchContract } from "../../src/api/preflight.ts";
+import {
+	decodeSubagentCapabilityCeiling,
+	encodeSubagentCapabilityCeiling,
+	intersectSubagentCapabilityCeilings,
+	parseSubagentCapabilityCeiling,
+	registerSubagentCapabilityCeiling,
+} from "../../src/api/capability-ceiling.ts";
+import { runSync } from "../../src/runs/foreground/execution.ts";
+import { buildPiArgs } from "../../src/runs/shared/pi-args.ts";
+
+function agent(name: string): AgentConfig {
+	return {
+		name,
+		description: `${name} agent`,
+		systemPrompt: `${name} prompt`,
+		systemPromptMode: "replace",
+		inheritProjectContext: false,
+		inheritSkills: false,
+		source: "project",
+		filePath: `/tmp/${name}.md`,
+	};
+}
+
+describe("capability ceiling agent allowlist", () => {
+	it("parses, round-trips, and intersects allowedAgents", () => {
+		const parsed = parseSubagentCapabilityCeiling({ version: 1, allowedAgents: ["worker", "reviewer", "worker"], denyExtensions: false, sources: ["plan"] });
+		assert.deepEqual(parsed.allowedAgents, ["reviewer", "worker"]);
+		assert.deepEqual(decodeSubagentCapabilityCeiling(encodeSubagentCapabilityCeiling(parsed)), parsed);
+
+		assert.deepEqual(intersectSubagentCapabilityCeilings(
+			{ version: 1, allowedAgents: ["worker", "reviewer"], denyExtensions: false, sources: ["outer"] },
+			{ version: 1, allowedAgents: ["reviewer", "scout"], denyExtensions: true, sources: ["inner"] },
+		), {
+			version: 1,
+			allowedAgents: ["reviewer"],
+			denyExtensions: true,
+			sources: ["inner", "outer"],
+		});
+
+		assert.deepEqual(intersectSubagentCapabilityCeilings(
+			{ version: 1, allowedTools: ["read"], denyExtensions: false, sources: ["tools-only"] },
+			{ version: 1, allowedAgents: [], denyExtensions: false, sources: ["none"] },
+		)?.allowedAgents, []);
+	});
+
+	it("marks non-allowlisted agents as restricted in list output", () => {
+		const sessionId = `allowlist-list-${Date.now()}-${Math.random()}`;
+		const handle = registerSubagentCapabilityCeiling({ sessionId, source: "plan-mode", ceiling: { allowedAgents: ["reviewer"] } });
+		try {
+			const result = handleList({}, { cwd: process.cwd(), currentSessionId: sessionId, modelRegistry: { getAvailable: () => [] } });
+			const text = result.content[0]?.text ?? "";
+			assert.match(text, /Executable agents:/);
+			assert.match(text, /- reviewer /);
+			assert.match(text, /Restricted agents \(not executable in this session; capability ceiling: plan-mode\):/);
+			assert.match(text, /- worker /);
+		} finally {
+			handle.dispose();
+		}
+	});
+
+	it("rejects a non-allowlisted agent in preflight launch resolution", async () => {
+		const result = await resolveSubagentLaunchContract({
+			agent: "worker",
+			cwd: process.cwd(),
+			capabilityCeiling: { version: 1, allowedAgents: ["reviewer"], denyExtensions: false, sources: ["plan-mode"] },
+		});
+		assert.equal(result.ok, false);
+		assert.equal(result.code, "restricted_agent");
+		assert.match(result.message, /does not allow agent 'worker'/);
+		assert.match(result.message, /Allowed agents: reviewer/);
+	});
+
+	it("rejects a non-allowlisted foreground launch before spawning", async () => {
+		const result = await runSync(process.cwd(), [agent("worker"), agent("reviewer")], "worker", "Do work", {
+			capabilityCeiling: { version: 1, allowedAgents: ["reviewer"], denyExtensions: false, sources: ["plan-mode"] },
+		});
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /does not allow agent 'worker'/);
+		assert.deepEqual(result.capabilityCeiling?.allowedAgents, ["reviewer"]);
+	});
+
+	it("includes allowedAgents in propagated launch env and audit metadata", () => {
+		const { env, capabilityAudit } = buildPiArgs({
+			baseArgs: [],
+			task: "Review",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			childAgentName: "reviewer",
+			capabilityCeiling: { version: 1, allowedAgents: ["reviewer"], allowedTools: ["read"], denyExtensions: true, sources: ["plan-mode"] },
+		});
+		assert.equal(capabilityAudit?.agentAllowed, true);
+		assert.deepEqual(capabilityAudit?.agentRestrictionSources, ["plan-mode"]);
+		assert.ok(env.PI_SUBAGENT_CAPABILITY_CEILING_V1);
+		assert.deepEqual(decodeSubagentCapabilityCeiling(env.PI_SUBAGENT_CAPABILITY_CEILING_V1)?.allowedAgents, ["reviewer"]);
+	});
+});

--- a/test/unit/capability-ceiling.test.ts
+++ b/test/unit/capability-ceiling.test.ts
@@ -33,7 +33,7 @@ describe("subagent capability ceiling", () => {
 	});
 
 	it("rejects malformed policy and disposed updates", () => {
-		assert.throws(() => registerSubagentCapabilityCeiling({ sessionId: "x", source: "x", ceiling: {} }), /allowedTools or denyExtensions/);
+		assert.throws(() => registerSubagentCapabilityCeiling({ sessionId: "x", source: "x", ceiling: {} }), /allowedTools, allowedAgents, or denyExtensions/);
 		const handle = registerSubagentCapabilityCeiling({ sessionId: "disposed", source: "test", ceiling: { denyExtensions: true } });
 		handle.dispose();
 		assert.throws(() => handle.update({ allowedTools: ["read"] }), /disposed/);


### PR DESCRIPTION
## Summary

Implements #719: a session-scoped, out-of-band way to restrict which agent roles are eligible to launch, without globally disabling builtins like `worker` for ordinary sessions.

Extends the existing v1 capability-ceiling registry (#585 pattern) with optional `allowedAgents: string[]` (canonical agent names, case-sensitive):

- **Intersection** mirrors `allowedTools`: both sides defined ⇒ sorted set intersection; omitted side ⇒ no agent restriction; explicit empty list ⇒ nothing launchable. Nested runs cannot widen the restriction; malformed inherited env fails closed (decode throws rather than dropping the ceiling).
- **Enforcement on the resolved canonical name** (aliases and dotted package names resolve first): preflight rejects with `restricted_agent`, foreground `runSync` rejects pre-spawn, async single and chain/parallel step construction reject before the runner spawns. Append-step, attach-as-chain, and revive paths intersect target/current ceilings; scheduled-run creation is rejected under an active ceiling.
- **Discovery stays honest**: `action: "list"` keeps restricted agents visible under a dedicated "Restricted agents" section instead of silently hiding them, so executable state is accurate for restricted parents (e.g. Plan Mode) while ordinary sessions are untouched.
- Allowlist state propagates in the inherited ceiling env and surfaces in audit metadata (`agentAllowed`, `agentRestrictionSources`).

This also covers audit-only and review-only delegation workflows, not just Plan Mode.

Thanks to @aoguai for the report, the use case, and the earlier #585 groundwork.

## Review

Fresh read-only review: **Pass, no blockers** — verified enforcement is upstream of every spawn path (including resume/revive/append/scheduled), intersection/empty-list semantics, fail-closed decode, and alias-resolution ordering.

## Validation

- Focused: capability-ceiling suites, 16 pass
- `npm run test:unit` after rebase onto #721: 1521 pass, 0 fail
- `git diff --check` clean

Closes #719

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the v1 capability-ceiling registry with an optional `allowedAgents: string[]` field, giving session-scoped callers (e.g. Plan Mode) a way to restrict which canonical agent names are launchable without globally disabling builtins. Enforcement is inserted upstream of every spawn path — preflight, foreground `runSync`, and both async single and chain/parallel step construction — and the `{ action: "list" }` handler surfaces restricted agents in a dedicated non-executable section rather than hiding them.

- **Core logic** (`capability-ceiling.ts`): `normalizeList` is refactored to handle both `allowedTools` and `allowedAgents` with the same character-set validation and 256-entry cap; `intersectSubagentCapabilityCeilings` gains a symmetric `intersectLists` helper; four new helpers cover allow-checking, restriction messaging, throwing assertion, and source attribution.
- **Enforcement sites** (`preflight.ts`, `execution.ts`, `async-execution.ts`): each computes the effective ceiling via `intersectSubagentCapabilityCeilings` of the local and inherited (env-based) ceilings before any spawn attempt, and returns a typed `restricted_agent` error code on failure.
- **Audit propagation** (`pi-args.ts`): `agentAllowed` and `agentRestrictionSources` are added to `SubagentCapabilityAudit` and populated in `resolvePiLaunchToolPlan`; the ceiling is encoded into the child env so nested runs cannot widen the restriction.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The enforcement logic is correctly placed upstream of every spawn path and the intersection/fail-closed semantics are sound; the only gaps are a non-portable test path and a redundant function call in the audit block.

The enforcement sites (preflight, foreground runSync, async single, async chain steps) each independently compute the effective ceiling and reject restricted agents before any spawn. The core ceiling logic — intersection, empty-list semantics, and fail-closed decode — is covered by focused tests that match the changed behavior. The two findings are style-level: a POSIX /tmp/ path in the test helper (never accessed at runtime in these tests, but still non-portable per project convention) and a double call to capabilityCeilingAgentRestrictionSources in the audit block.

**Files Needing Attention:** test/unit/capability-ceiling-agent-allowlist.test.ts for the portable-path fix; src/runs/shared/pi-args.ts for the double-call cleanup.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/runs/shared/capability-ceiling.ts | Core implementation: adds allowedAgents to SubagentCapabilityCeiling type, normalizeList refactor shared with allowedTools, and four new helpers. Intersection, fail-closed decode, and empty-list semantics are correctly handled. |
| src/api/preflight.ts | Adds restricted_agent reason code and early agent-restriction check before resolvePiLaunchToolPlan; correctly pre-computes effectiveCapabilityCeiling so tool intersection inside resolvePiLaunchToolPlan remains correct. |
| src/runs/foreground/execution.ts | runSyncCompletion now intersects registry and env ceilings then calls assertAgentAllowedByCapabilityCeiling before spawn; returns properly shaped SingleResult with capabilityCeiling on rejection. |
| src/runs/background/async-execution.ts | Both buildAsyncRunnerSteps and executeAsyncSingle guard against restricted agents before spawn, consistent with the foreground path. |
| src/agents/agent-management.ts | handleList splits discovered agents into executable and restricted sections based on the session ceiling; currentSessionId is optional so callers without it continue to show all agents unrestricted. |
| src/runs/shared/pi-args.ts | Adds agentName to ResolvePiLaunchToolPlanInput and computes agentAllowed/agentRestrictionSources in the audit; capabilityCeilingAgentRestrictionSources is called twice on the same value in line 232. |
| test/unit/capability-ceiling-agent-allowlist.test.ts | New focused test suite covering parse/round-trip, list output, preflight rejection, foreground rejection, and env propagation. agent() helper uses /tmp/${name}.md, a POSIX-only path that violates the portable-tests rule. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/unit/capability-ceiling-agent-allowlist.test.ts:25
The `agent()` helper hardcodes `/tmp/${name}.md` as the `filePath`, which is a POSIX-only path and fails the portable-tests rule. Although `filePath` is never accessed in these tests (enforcement fires before any file I/O), the path is still non-portable on Windows. `os.tmpdir()` gives the platform-correct temp directory.

```suggestion
		filePath: `${os.tmpdir()}/${name}.md`,
```

### Issue 2
src/runs/shared/pi-args.ts:232
`capabilityCeilingAgentRestrictionSources` is called twice — once to check truthiness and again to produce the value. Both calls copy `ceiling.sources` into a new array, so the result is always identical. Storing it in a local variable avoids the redundant allocation.

```suggestion
		...((restrictionSources = capabilityCeilingAgentRestrictionSources(capabilityCeiling)) !== undefined ? { agentRestrictionSources: restrictionSources } : {}),
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: session-scoped agent allowlist on ..."](https://github.com/nicobailon/pi-subagents/commit/748b24837950bd72ce623108b55f640d63527513) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49331347)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Tests must be portable across macOS, Linux, and Wi... ([source](.greptile))

<!-- /greptile_comment -->