### PR TITLE
fix: per-child task descriptions in fleet status async rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Reduced repeated runtime filesystem work by caching stable Pi config-directory resolution, incrementally sanitizing run history, and limiting nested control-result polling to files created for the active request.
 
 ### Fixed
+- Show per-child async task descriptions in the persistent running-subagents status widget instead of repeating the run-level description for every parallel child.
 - Restored model and thinking-effort badges in the persistent running-subagents status widget.
 - Retained foreground controls until scheduling owners and active children settle, keeping queued foreground work steerable after early result handling. Thanks to @magoz for #708/#709/#710.
 - Render resolved model and thinking effort for active and recent foreground children in Fleet inspector summaries and details. Thanks to @saleemlala for #706.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -17,6 +17,7 @@ interface AsyncRunStepSummary {
 	agent: string;
 	context?: ContextMode;
 	label?: string;
+	description?: string;
 	phase?: string;
 	outputName?: string;
 	structured?: boolean;
@@ -232,6 +233,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 			agent: step.agent,
 			...(step.context ? { context: step.context } : {}),
 			...(step.label ? { label: step.label } : {}),
+			...(step.description ? { description: step.description } : {}),
 			...(step.phase ? { phase: step.phase } : {}),
 			...(step.outputName ? { outputName: step.outputName } : {}),
 			...(step.structured ? { structured: step.structured } : {}),

--- a/src/runs/background/chain-append.ts
+++ b/src/runs/background/chain-append.ts
@@ -130,9 +130,22 @@ export function consumeChainAppendRequests(asyncDir: string): ChainAppendRequest
 	return requests.sort((left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id));
 }
 
+const MAX_STATUS_STEP_DESCRIPTION_CHARS = 160;
+
+/** Bounded one-line per-step task description persisted into status.json for fleet display. */
+export function statusStepDescription(task: string | undefined): string | undefined {
+	const description = task?.replace(/\s+/g, " ").trim();
+	if (!description) return undefined;
+	return description.length > MAX_STATUS_STEP_DESCRIPTION_CHARS
+		? `${description.slice(0, MAX_STATUS_STEP_DESCRIPTION_CHARS - 1)}…`
+		: description;
+}
+
 function statusStepForTask(task: RunnerSubagentStep): StatusStep {
+	const description = statusStepDescription(task.task);
 	return {
 		agent: task.agent,
+		...(description ? { description } : {}),
 		...(task.context ? { context: task.context } : {}),
 		phase: task.phase,
 		label: task.label,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -113,7 +113,7 @@ import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts
 import { acceptanceFailureMessage, aggregateAcceptanceReport, buildSkippedAcceptanceLedger, evaluateAcceptance, formatAcceptancePrompt, resolveEffectiveAcceptance, stripAcceptanceReport } from "../shared/acceptance.ts";
 import { attachContractProjections, isAgentContractV1 } from "../shared/agent-contract.ts";
 import { waitForImportedAsyncRoot } from "./chain-root-attachment.ts";
-import { appendRunnerStepsToStatus, consumeChainAppendRequests, countPendingChainAppendRequests } from "./chain-append.ts";
+import { appendRunnerStepsToStatus, consumeChainAppendRequests, countPendingChainAppendRequests, statusStepDescription } from "./chain-append.ts";
 import { appendTurnBudgetSystemPrompt, formatTurnBudgetOutput, initialTurnBudgetState, turnBudgetDecision, turnBudgetDeferredNote, turnBudgetDeferredState, turnBudgetExceededMessage, turnBudgetSoftNote, turnBudgetState } from "../shared/turn-budget.ts";
 import { initialToolBudgetState, toolBudgetState } from "../shared/tool-budget.ts";
 import { usageBudgetExceededMessage, usageBudgetState } from "../shared/usage-budget.ts";
@@ -1625,6 +1625,7 @@ async function runSingleStep(
 
 type RunnerStatusStep = NonNullable<AsyncStatus["steps"]>[number] & {
 	exitCode?: number | null;
+	description?: string;
 };
 
 function appendCapabilityCeilingAppliedEvent(eventsPath: string, runId: string, stepIndex: number, agent: string, result: StepResult): void {
@@ -1860,6 +1861,7 @@ async function runSubagent(
 				const transcriptPath = resolveAsyncStepTranscriptPath({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: taskFlatIndex, flatStepCount: initialFlatStepCount });
 				initialStatusSteps.push({
 					agent: task.agent,
+					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
 					...(task.context ? { context: task.context } : {}),
 					phase: task.phase,
 					label: task.label,
@@ -1904,6 +1906,7 @@ async function runSubagent(
 			const transcriptPath = resolveAsyncStepTranscriptPath({ artifactsDir, artifactConfig, runId: id, agent: step.agent, flatIndex: stepFlatIndex, flatStepCount: initialFlatStepCount });
 			initialStatusSteps.push({
 				agent: step.agent,
+				...(statusStepDescription(step.task) ? { description: statusStepDescription(step.task) } : {}),
 				...(step.context ? { context: step.context } : {}),
 				phase: step.phase,
 				label: step.label,
@@ -3157,6 +3160,7 @@ async function runSubagent(
 				const transcriptPath = resolveAsyncStepTranscriptPath({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: groupStartFlatIndex + itemIndex, flatStepCount: dynamicFlatStepCount });
 				return {
 					agent: task.agent,
+					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
 					...(task.context ? { context: task.context } : {}),
 					phase: task.phase ?? step.phase,
 					label: task.label,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1173,6 +1173,8 @@ export interface AsyncStatus {
 		agent: string;
 		/** Resolved launch context for this child step. */
 		context?: "fresh" | "fork";
+		/** Short caller-facing task/goal shown in fleet surfaces when available. */
+		description?: string;
 		phase?: string;
 		label?: string;
 		outputName?: string;
@@ -1241,6 +1243,7 @@ export interface AsyncStatus {
 
 export type AsyncJobStep = NonNullable<AsyncStatus["steps"]>[number] & {
 	index?: number;
+	description?: string;
 };
 
 export interface AsyncJobState {

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -119,7 +119,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				key: `async:${job.asyncId}:${index}`,
 				agent: step.label ? `${step.label} (${step.agent})` : step.agent,
 				...(modelThinking ? { modelThinking } : {}),
-				description: job.description,
+				description: step.description ?? job.description,
 				startedAt: step.startedAt ?? startedAt,
 				tokens: step.tokens?.total ?? (steps.length === 1 ? job.totalTokens?.total ?? 0 : 0),
 			});

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -27,8 +27,8 @@ describe("async status helpers", () => {
 				currentStep: 1,
 				outputFile,
 				steps: [
-					{ agent: "scout", status: "complete", durationMs: 10 },
-					{ agent: "worker", status: "running", durationMs: 20 },
+					{ agent: "scout", status: "complete", durationMs: 10, description: "Inspect auth only" },
+					{ agent: "worker", status: "running", durationMs: 20, description: "Patch billing only" },
 				],
 			});
 			createAsyncDir(root, "run-b", {
@@ -47,6 +47,8 @@ describe("async status helpers", () => {
 			assert.equal(runs[0]?.steps.length, 2);
 			assert.equal(runs[0]?.steps[1]?.agent, "worker");
 			assert.equal(runs[0]?.steps[1]?.status, "running");
+			assert.equal(runs[0]?.steps[0]?.description, "Inspect auth only");
+			assert.equal(runs[0]?.steps[1]?.description, "Patch billing only");
 			assert.match(formatAsyncRunList(runs), /output: .*output-1\.log/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/chain-append.test.ts
+++ b/test/unit/chain-append.test.ts
@@ -198,6 +198,12 @@ describe("chain append requests", () => {
 			"reviewer:pending",
 			"auditor:pending",
 		]);
+		// Appended steps must carry their own bounded task description for fleet display.
+		assert.deepEqual(status.steps?.slice(1).map((step) => step.description), [
+			"Use {previous}",
+			"Use {previous}",
+			"Use {previous}",
+		]);
 		assert.deepEqual(status.parallelGroups, [{ start: 2, count: 2, stepIndex: 2 }]);
 		assert.equal(status.workflowGraph?.nodes[1]?.id, "step-1");
 		assert.equal(status.workflowGraph?.nodes[2]?.kind, "parallel-group");

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -414,8 +414,8 @@ describe("below-editor subagent FleetView", () => {
 			startedAt: 100,
 			updatedAt: 200,
 			steps: [
-				{ agent: "reviewer", index: 0, status: "running", startedAt: 120, model: "openai/gpt-5", thinking: "medium", tokens: { input: 4_000, output: 200, total: 4_200 } },
-				{ agent: "worker", index: 1, status: "complete", tokens: { input: 100, output: 20, total: 120 } },
+				{ agent: "reviewer", index: 0, status: "running", description: "Review only authentication", startedAt: 120, model: "openai/gpt-5", thinking: "medium", tokens: { input: 4_000, output: 200, total: 4_200 } },
+				{ agent: "worker", index: 1, status: "running", description: "Implement only billing", startedAt: 121, tokens: { input: 100, output: 20, total: 120 } },
 			],
 		});
 		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
@@ -434,9 +434,10 @@ describe("below-editor subagent FleetView", () => {
 		try {
 			fleet.setContext(ctx);
 			const lines = widgetFactory!({ requestRender() {} }, theme).render(100);
-			assert.ok(lines.some((line) => line.includes("reviewer (gpt-5 · thinking medium)") && line.includes("Review the authentication")));
+			assert.ok(lines.some((line) => line.includes("reviewer (gpt-5 · thinking medium)") && line.includes("Review only authentication")));
+			assert.ok(lines.some((line) => line.includes("worker") && line.includes("Implement only billing")));
+			assert.ok(lines.every((line) => !line.includes("Review the authentication changes")), "per-child descriptions should replace the run-level fallback when present");
 			assert.ok(lines.some((line) => line.includes("↓ 4.2k tokens")));
-			assert.ok(!lines.some((line) => line.includes("worker")), "completed async children should leave the status fleet");
 		} finally {
 			fleet.dispose();
 		}


### PR DESCRIPTION
## Summary

Owner-reproduced bug: with an async parallel run of two different tasks, the fleet status widget rendered both child rows with the first task's text, because every async step row used the run-level `job.description` and `status.json` never persisted per-step task text at all.

Fix plumbs a bounded one-line per-step description end to end: the runner derives it (whitespace-collapsed, 160-char cap) when building status steps for static parallel, static single/chain, materialized dynamic fanout, and appended chain steps; `AsyncStatus.steps`/`AsyncJobStep` gain an optional `description`; async status summaries preserve it; and the widget renders `step.description ?? job.description`. Old status files without the field keep the previous fallback, and foreground rows (which already had per-child descriptions) are untouched.

## Review

Fresh read-only review found one blocker — appended chain steps (`chain-append.ts`) still dropped the description — fixed by moving the bounded derivation helper into `chain-append.ts` (matching the existing runner→chain-append import direction) and applying it in `statusStepForTask`, with a regression assertion in `test/unit/chain-append.test.ts`. Reviewer verified bounds, optional-field parse tolerance, and scope hygiene.

## Validation

- Focused: chain-append, fleet-status, async-status suites — 39 pass
- `npm run test:unit` after rebase: 1521 pass, 0 fail
- `git diff --check` clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a rendering bug where every async parallel child row in the fleet status widget displayed the run-level `job.description` instead of its own task text. The fix plumbs a bounded, whitespace-normalised per-step description through `status.json` end-to-end and falls back to `job.description` for status files written before this change.

- `statusStepDescription` (160-char cap, single-line collapse) is introduced in `chain-append.ts` and re-exported to `subagent-runner.ts`, covering static parallel, static single/chain, materialised dynamic fanout, and appended chain steps.
- `AsyncStatus["steps"][number]` and `AsyncJobStep` gain an optional `description` field; `fleet-status.ts` renders `step.description ?? job.description`.
- Focused regression tests added in `chain-append.test.ts`, `fleet-status.test.ts`, and `async-status.test.ts`; however, CI on the exact head SHA (03c5f696) is not yet confirmed — this is a required merge gate per repository policy.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrowly scoped to status.json serialisation and fleet widget rendering; old status files without the new field fall back cleanly to the existing run-level description.

The logic is straightforward and the new optional field degrades gracefully. The only concrete finding is the double-call pattern in three sites of subagent-runner.ts, which is cosmetic. CI on the exact head SHA has not been confirmed, which is a required gate before merging.

**Files Needing Attention:** subagent-runner.ts — three sites call statusStepDescription twice; otherwise no files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/runs/background/subagent-runner.ts | Adds per-step description to status steps for static parallel, static single/chain, and materialized dynamic fanout; calls statusStepDescription twice per site (3×) rather than capturing to a variable first |
| src/runs/background/chain-append.ts | Adds statusStepDescription helper and wires it into statusStepForTask; helper correctly caps at 160 chars with ellipsis and collapses whitespace |
| src/tui/fleet-status.ts | One-line fix: renders step.description ?? job.description, correctly falling back to run-level description for pre-fix status files |
| src/shared/types.ts | Adds description?: string to AsyncStatus["steps"] array type and to AsyncJobStep intersection; the latter is now redundant since the base type already carries the field |
| src/runs/background/async-status.ts | Adds description to AsyncRunStepSummary and propagates it in statusToSummary; change is symmetric and correct |
| test/unit/chain-append.test.ts | Regression assertion verifies that appended steps carry their bounded task description; covers the specific regression path added in this PR |
| test/unit/fleet-status.test.ts | Updated to assert per-child descriptions render correctly in the widget and that the run-level fallback is suppressed when per-step descriptions are present |
| test/integration/async-status.test.ts | Adds description assertions on step summaries returned by the async status reader; covers round-trip preservation end-to-end |
| CHANGELOG.md | Adds a Fixed entry for per-child async task descriptions; owner-authored fix, no external contributor credit required |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Runner as subagent-runner.ts
    participant ChainAppend as chain-append.ts
    participant StatusJSON as status.json
    participant AsyncStatus as async-status.ts
    participant Fleet as fleet-status.ts

    Runner->>ChainAppend: statusStepDescription(task.task)
    ChainAppend-->>Runner: bounded description (≤160 chars)
    Runner->>StatusJSON: "write step { agent, description?, … }"
    ChainAppend->>StatusJSON: appendRunnerStepsToStatus() (chain-append steps)
    AsyncStatus->>StatusJSON: read steps[]
    AsyncStatus-->>Fleet: "AsyncJobStep { description?, … }"
    Fleet->>Fleet: step.description ?? job.description
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/runs/background/subagent-runner.ts:1864
`statusStepDescription` called twice per site — three instances in this file (lines 1864, 1909, 3163). `chain-append.ts` captures the result to a variable first (`const description = statusStepDescription(task.task)`) before spreading it, which avoids the redundant call. Applying the same pattern here keeps the three sites consistent with the helper's own usage.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: per-child task descriptions in flee..."](https://github.com/nicobailon/pi-subagents/commit/03c5f696f2ef10caf0681ab1f0b79f6cd6c17b3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49332017)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Do not state that a PR is safe to merge or merge-r... ([source](.greptile))
- Rule used - Report only concrete, reachable release risks, dir... ([source](.greptile))

<!-- /greptile_comment -->