### PR TITLE
feat: support agent description overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Added `description` to `subagents.agentOverrides` so deployments can replace the discovered description for builtin and custom agents in list output. Thanks to @chronoAP for #724.
+
 ## [0.39.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ Example:
   "subagents": {
     "agentOverrides": {
       "reviewer": {
+        "description": "Independent review tier",
         "inheritProjectContext": false
       }
     }
@@ -743,7 +744,7 @@ Example:
 }
 ```
 
-Supported override fields are `model`, `fallbackModels`, `thinking`, `systemPromptMode`, `inheritProjectContext`, `inheritSkills`, `defaultContext`, `acceptanceRole`, `disabled`, `skills`, `tools`, and `systemPrompt`. Use `defaultContext: false` or `acceptanceRole: false` to clear an inherited override. Project overrides beat user overrides.
+Supported override fields are `description`, `model`, `fallbackModels`, `thinking`, `systemPromptMode`, `inheritProjectContext`, `inheritSkills`, `defaultContext`, `acceptanceRole`, `disabled`, `skills`, `tools`, and `systemPrompt`. `description` replaces the discovered description for builtin and custom agents, which lets list output show deployment-specific routing or model metadata. Use `defaultContext: false` or `acceptanceRole: false` to clear an inherited override. Project overrides beat user overrides.
 
 Set `subagents.defaultModel` to give all subagents without an explicit model their own default model, separate from the parent session model. Per-agent model overrides and agent frontmatter still win.
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1198,7 +1198,10 @@ export function buildBuiltinOverrideConfig(
 ): BuiltinAgentOverrideConfig | undefined {
 	const override: BuiltinAgentOverrideConfig = {};
 
-	if (draft.description !== undefined && draft.description !== base.description) override.description = draft.description;
+	if (draft.description !== undefined) {
+		const description = draft.description.trim();
+		if (description && description !== base.description) override.description = description;
+	}
 	if (draft.model !== base.model) override.model = draft.model ?? false;
 	if (!arraysEqual(draft.fallbackModels, base.fallbackModels)) override.fallbackModels = draft.fallbackModels ? [...draft.fallbackModels] : false;
 	if (draft.thinking !== base.thinking) override.thinking = draft.thinking ?? false;

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -59,6 +59,7 @@ export function defaultInheritSkills(): boolean {
 }
 
 export interface BuiltinAgentOverrideBase {
+	description?: string;
 	model?: string;
 	fallbackModels?: string[];
 	thinking?: string | false;
@@ -80,6 +81,7 @@ export interface BuiltinAgentOverrideBase {
 }
 
 interface BuiltinAgentOverrideConfig {
+	description?: string;
 	model?: string | false;
 	fallbackModels?: string[] | false;
 	thinking?: string | false;
@@ -545,6 +547,7 @@ function arraysEqual(a: string[] | undefined, b: string[] | undefined): boolean 
 
 function cloneOverrideBase(agent: AgentConfig): BuiltinAgentOverrideBase {
 	return {
+		description: agent.description,
 		model: agent.model,
 		fallbackModels: agent.fallbackModels ? [...agent.fallbackModels] : undefined,
 		thinking: agent.thinking,
@@ -568,6 +571,7 @@ function cloneOverrideBase(agent: AgentConfig): BuiltinAgentOverrideBase {
 
 function cloneOverrideValue(override: BuiltinAgentOverrideConfig): BuiltinAgentOverrideConfig {
 	return {
+		...(override.description !== undefined ? { description: override.description } : {}),
 		...(override.model !== undefined ? { model: override.model } : {}),
 		...(override.fallbackModels !== undefined
 			? { fallbackModels: override.fallbackModels === false ? false : [...override.fallbackModels] }
@@ -719,6 +723,14 @@ function parseBuiltinOverrideEntry(
 
 	const input = value as Record<string, unknown>;
 	const override: BuiltinAgentOverrideConfig = {};
+
+	if ("description" in input) {
+		if (typeof input.description === "string" && input.description.trim()) {
+			override.description = input.description.trim();
+		} else {
+			throw new Error(`Builtin override '${name}' in '${filePath}' has invalid 'description'; expected a non-empty string.`);
+		}
+	}
 
 	if ("model" in input) {
 		if (typeof input.model === "string" || input.model === false) override.model = input.model;
@@ -967,6 +979,7 @@ function applyBuiltinOverride(
 		override: { ...meta, base: cloneOverrideBase(agent) },
 	};
 
+	if (override.description !== undefined) next.description = override.description;
 	if (override.model !== undefined) next.model = override.model === false ? undefined : override.model;
 	if (override.fallbackModels !== undefined) {
 		next.fallbackModels = override.fallbackModels === false ? undefined : [...override.fallbackModels];
@@ -1087,6 +1100,10 @@ function applyCustomAgentOverride(
 		anyFilled = true;
 	};
 
+	if (override.description !== undefined) {
+		mutable().description = override.description;
+		anyFilled = true;
+	}
 	if (override.model !== undefined) {
 		fill("model", ["model"], override.model === false ? undefined : override.model);
 	}
@@ -1177,10 +1194,11 @@ function applyCustomAgentOverrides(
 
 export function buildBuiltinOverrideConfig(
 	base: BuiltinAgentOverrideBase,
-	draft: Pick<AgentConfig, "model" | "fallbackModels" | "thinking" | "systemPromptMode" | "inheritProjectContext" | "inheritSkills" | "defaultContext" | "acceptanceRole" | "disabled" | "systemPrompt" | "skills" | "tools" | "mcpDirectTools" | "extensions" | "subagentOnlyExtensions" | "completionGuard" | "toolBudget">,
+	draft: Pick<AgentConfig, "model" | "fallbackModels" | "thinking" | "systemPromptMode" | "inheritProjectContext" | "inheritSkills" | "defaultContext" | "acceptanceRole" | "disabled" | "systemPrompt" | "skills" | "tools" | "mcpDirectTools" | "extensions" | "subagentOnlyExtensions" | "completionGuard" | "toolBudget"> & Partial<Pick<AgentConfig, "description">>,
 ): BuiltinAgentOverrideConfig | undefined {
 	const override: BuiltinAgentOverrideConfig = {};
 
+	if (draft.description !== undefined && draft.description !== base.description) override.description = draft.description;
 	if (draft.model !== base.model) override.model = draft.model ?? false;
 	if (!arraysEqual(draft.fallbackModels, base.fallbackModels)) override.fallbackModels = draft.fallbackModels ? [...draft.fallbackModels] : false;
 	if (draft.thinking !== base.thinking) override.thinking = draft.thinking ?? false;

--- a/test/unit/agent-overrides.test.ts
+++ b/test/unit/agent-overrides.test.ts
@@ -734,5 +734,11 @@ describe("builtin agent overrides", () => {
 		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
 		saveBuiltinAgentOverride(tempProject, "reviewer", "project", override);
 		assert.equal(discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "reviewer")?.description, "Override description");
+
+		const whitespaceDescription = buildBuiltinOverrideConfig(
+			{ description: "Base description" },
+			{ description: "   " } as Parameters<typeof buildBuiltinOverrideConfig>[1],
+		);
+		assert.equal(whitespaceDescription, undefined);
 	});
 });

--- a/test/unit/agent-overrides.test.ts
+++ b/test/unit/agent-overrides.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { buildBuiltinOverrideConfig, discoverAgents, discoverAgentsAll, removeBuiltinAgentOverride } from "../../src/agents/agents.ts";
+import { buildBuiltinOverrideConfig, discoverAgents, discoverAgentsAll, removeBuiltinAgentOverride, saveBuiltinAgentOverride } from "../../src/agents/agents.ts";
 
 let tempHome = "";
 let tempProject = "";
@@ -176,6 +176,22 @@ describe("builtin agent overrides", () => {
 		assert.equal(agents.find((agent) => agent.name === "implementer")?.model, "deepseek-v4-pro");
 		assert.equal(agents.find((agent) => agent.name === "auditor")?.model, "google/gemini-3-pro");
 		assert.equal(agents.find((agent) => agent.name === "scout-copy")?.model, "deepseek-v4-flash");
+	});
+
+	it("overrides builtin and custom agent descriptions from settings", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: {
+				agentOverrides: {
+					reviewer: { description: " Priced reviewer " },
+					implementer: { description: "Priced implementer" },
+				},
+			},
+		});
+		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: Original implementer\n---\n\nImplement it.\n`);
+
+		const agents = discoverAgents(tempProject, "both").agents;
+		assert.equal(agents.find((agent) => agent.name === "reviewer")?.description, "Priced reviewer");
+		assert.equal(agents.find((agent) => agent.name === "implementer")?.description, "Priced implementer");
 	});
 
 	it("applies user settings overrides to builtin agents", () => {
@@ -625,6 +641,22 @@ describe("builtin agent overrides", () => {
 		);
 	});
 
+	it("surfaces malformed description override values", () => {
+		const settingsPath = path.join(tempHome, ".pi", "agent", "settings.json");
+		for (const description of ["", 42]) {
+			writeJson(settingsPath, {
+				subagents: { agentOverrides: { reviewer: { description } } },
+			});
+			assert.throws(
+				() => discoverAgents(tempProject, "both"),
+				(error: unknown) => error instanceof Error
+					&& error.message.includes(settingsPath)
+					&& error.message.includes("reviewer")
+					&& error.message.includes("description"),
+			);
+		}
+	});
+
 	it("surfaces malformed completion guard override values", () => {
 		const settingsPath = path.join(tempHome, ".pi", "agent", "settings.json");
 		writeJson(settingsPath, {
@@ -646,9 +678,10 @@ describe("builtin agent overrides", () => {
 		);
 	});
 
-	it("builds false sentinels when an override clears builtin fields", () => {
+	it("builds description changes and false sentinels when an override clears builtin fields", () => {
 		const override = buildBuiltinOverrideConfig(
 			{
+				description: "Base description",
 				model: "openai-codex/gpt-5.4-mini",
 				fallbackModels: ["openai/gpt-5-mini"],
 				thinking: "high",
@@ -665,6 +698,7 @@ describe("builtin agent overrides", () => {
 				completionGuard: false,
 			},
 			{
+				description: "Override description",
 				model: undefined,
 				fallbackModels: undefined,
 				thinking: undefined,
@@ -683,6 +717,7 @@ describe("builtin agent overrides", () => {
 		);
 
 		assert.deepEqual(override, {
+			description: "Override description",
 			model: false,
 			fallbackModels: false,
 			thinking: false,
@@ -695,5 +730,9 @@ describe("builtin agent overrides", () => {
 			subagentOnlyExtensions: false,
 			completionGuard: true,
 		});
+		assert.ok(override);
+		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
+		saveBuiltinAgentOverride(tempProject, "reviewer", "project", override);
+		assert.equal(discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "reviewer")?.description, "Override description");
 	});
 });


### PR DESCRIPTION
## Summary
- add `description` support to `subagents.agentOverrides`
- apply descriptions to builtin and custom agents, including overriding custom frontmatter for deployment-specific list metadata
- preserve description changes through override cloning, building, and persistence paths
- document the setting and validate non-empty values

## Tests
- `node --experimental-strip-types --test test/unit/agent-overrides.test.ts test/unit/agent-disabled.test.ts test/unit/default-extensions.test.ts` (52 passed)
- `npm test` with a clean isolated home/temp and exact `npm ci` dependencies (1509 passed, 14 skipped, 1 pre-existing Windows failure in `acceptance.test.ts`; reproduced against `origin/main`)
- LSP and pi-lens diagnostics: no errors

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `description` as a supported field in `subagents.agentOverrides`, letting deployments replace the discovered description for both builtin and custom agents in list output without touching agent files.

- `parseBuiltinOverrideEntry` validates and trims the incoming string (throwing on empty or non-string values); `buildBuiltinOverrideConfig` mirrors the trim guard and silently drops whitespace-only or unchanged descriptions, so neither path can write an invalid value to `settings.json`.
- The custom-agent apply path (`applyCustomAgentOverride`) uses `mutable()` directly rather than `fill()`, intentionally overriding any `description` in the agent's frontmatter — consistent with the stated goal of deployment-specific list metadata.
- Contributor credit and a focused test suite covering valid overrides, invalid-value rejection, and the build/save round-trip are all present.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The description override touches parse, build, clone, and apply paths consistently; trim guards prevent bad values from reaching settings.json; tests cover the key contracts.

All four changed paths (parse, build, builtin apply, custom apply) handle the new field symmetrically. The only gap is a missing whitespace-only test case in parseBuiltinOverrideEntry, which does not affect correctness since the logic is sound and the empty-string case already exercises the same branch.

**Files Needing Attention:** test/unit/agent-overrides.test.ts — whitespace-only string is untested through the parse path
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/agents/agents.ts | Adds `description` to override interfaces, parse/build/apply paths; trim guard in both parse and build paths is consistent; custom agent path uses `mutable()` unconditionally by design to override frontmatter. |
| test/unit/agent-overrides.test.ts | Adds focused coverage for description overrides on both builtin and custom agents, invalid-value rejection, build/save round-trip, and whitespace-only build guard; missing a whitespace-only case for `parseBuiltinOverrideEntry`. |
| README.md | Documents `description` in the override field list and adds an inline example; prose accurately reflects the runtime behavior (replacement, not append). |
| CHANGELOG.md | Adds an Unreleased entry for the description override feature with visible contributor credit (`@chronoAP`, `#724`). |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[settings.json agentOverrides] -->|parseBuiltinOverrideEntry| B{description present?}
    B -->|yes| C{string and trimmed non-empty?}
    C -->|yes| D[store trimmed description]
    C -->|no| E[throw invalid description error]
    B -->|no| F[skip field]

    G[buildBuiltinOverrideConfig] -->|draft.description defined| H{trimmed non-empty and differs from base?}
    H -->|yes| I[store trimmed description]
    H -->|no| J[omit from config]

    D --> K[applyBuiltinOverride: next.description = value]
    I --> K
    D --> L[applyCustomAgentOverride: mutable.description = value unconditional]
    I --> L
    K --> M[discoverAgents result with replaced description]
    L --> M
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: validate built agent description ov..."](https://github.com/nicobailon/pi-subagents/commit/83041c985e919a5451b936b70518b941933e6940) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49337706)</sub>

<!-- /greptile_comment -->