### PR TITLE
fix: show model and thinking on running foreground result rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Collapsed running foreground subagent rows now show the model and thinking level: single-result cards include the effective thinking suffix and parallel/chain rows show the per-child model badge, matching the async widget.
+
 ### Added
 - Added `description` to `subagents.agentOverrides` so deployments can replace the discovered description for builtin and custom agents in list output. Thanks to @chronoAP for #724.
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1318,7 +1318,7 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 	]);
 	const c = new Container();
 	const width = getTermWidth() - 4;
-	const modelDisplay = modelThinkingBadge(theme, r.model);
+	const modelDisplay = modelThinkingBadge(theme, r.model ?? r.progress?.model, r.thinking ?? r.progress?.thinking);
 	c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
 
 	if (isRunning && r.progress) {
@@ -1428,7 +1428,9 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 		const glyph = rPending ? theme.fg("dim", "◦") : resultGlyph(r, output, theme, rRunning, progressRunningSeed(rProg), frame);
 		const pendingLabel = rPending ? ` ${theme.fg("dim", "· pending")}` : "";
 		const stepLabel = entry.rowLabel ?? resultRowLabel(multiLabel, i, stepNumber);
-		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${contextModeBadge(theme, r.context)}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
+		const rowProgressModel = rProg && "model" in rProg ? rProg : undefined;
+		const rowModelDisplay = modelThinkingBadge(theme, r.model ?? rowProgressModel?.model, r.thinking ?? rowProgressModel?.thinking);
+		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${contextModeBadge(theme, r.context)}${rowModelDisplay}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
 		c.addChild(new Text(truncLine(`  ${line}`, width), 0, 0));
 		if (rRunning && rProg && "status" in rProg) {
 			const activity = compactCurrentActivity(rProg);

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1428,7 +1428,7 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 		const glyph = rPending ? theme.fg("dim", "◦") : resultGlyph(r, output, theme, rRunning, progressRunningSeed(rProg), frame);
 		const pendingLabel = rPending ? ` ${theme.fg("dim", "· pending")}` : "";
 		const stepLabel = entry.rowLabel ?? resultRowLabel(multiLabel, i, stepNumber);
-		const rowProgressModel = rProg && "model" in rProg ? rProg : undefined;
+		const rowProgressModel = rProg && "status" in rProg ? rProg : undefined;
 		const rowModelDisplay = modelThinkingBadge(theme, r.model ?? rowProgressModel?.model, r.thinking ?? rowProgressModel?.thinking);
 		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${contextModeBadge(theme, r.context)}${rowModelDisplay}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
 		c.addChild(new Text(truncLine(`  ${line}`, width), 0, 0));

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -454,6 +454,50 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(text, /output: \/tmp\/reviewer_output\.md/);
 	});
 
+	it("shows model and thinking on running compact single and multi rows", () => {
+		const single = renderSubagentResult!({
+			content: [{ type: "text", text: "(running...)" }],
+			details: {
+				mode: "single",
+				results: [{
+					agent: "reviewer",
+					task: "review",
+					exitCode: 0,
+					messages: [],
+					usage: emptyUsage,
+					progress: {
+						index: 0,
+						agent: "reviewer",
+						status: "running",
+						task: "review",
+						model: "openai-codex/gpt-5.5",
+						thinking: "high",
+						recentTools: [],
+						recentOutput: [],
+						toolCount: 1,
+						tokens: 42,
+						durationMs: 3_000,
+					},
+				}],
+			},
+		}, { expanded: false }, theme).render(160).join("\n");
+		assert.match(single, /reviewer \(gpt-5\.5 · thinking high\)/);
+
+		const multi = renderSubagentResult!({
+			content: [{ type: "text", text: "(running...)" }],
+			details: {
+				mode: "parallel",
+				totalSteps: 2,
+				results: [
+					{ agent: "scout", task: "scan", exitCode: 0, messages: [], usage: emptyUsage, model: "anthropic/claude-haiku-4-5", thinking: "low", progress: { index: 0, agent: "scout", status: "running", task: "scan", recentTools: [], recentOutput: [], toolCount: 0, tokens: 0, durationMs: 0 } },
+					{ agent: "worker", task: "fix", exitCode: 0, messages: [], usage: emptyUsage, progress: { index: 1, agent: "worker", status: "running", task: "fix", model: "openai/gpt-5-mini", recentTools: [], recentOutput: [], toolCount: 0, tokens: 0, durationMs: 0 } },
+				],
+			},
+		}, { expanded: false }, theme).render(160).join("\n");
+		assert.match(multi, /Agent 1\/2: scout \(claude-haiku-4-5 · thinking low\)/);
+		assert.match(multi, /Agent 2\/2: worker \(gpt-5-mini\)/);
+	});
+
 	it("keeps running compact result output stable when progress is unchanged", async () => {
 		const result = {
 			content: [{ type: "text" as const, text: "(running...)" }],


### PR DESCRIPTION
Collapsed running foreground subagent cards were missing model detail: the single-result card showed the model without the effective thinking level (and only once the final model was recorded), and parallel/chain rows showed no model badge at all, unlike the async widget rows.

renderSingleCompact now falls back to the live progress model/thinking, and renderMultiCompact rows render the same model badge used elsewhere. Added a focused regression covering both collapsed paths.

Validation: render-fork-badge + render-widget integration files (54 pass), full unit suite (1523 pass), full integration suite (703 pass).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes two missing model/thinking badge omissions in the collapsed running foreground subagent view. `renderSingleCompact` now falls back to the live `progress.model`/`progress.thinking` fields when the final recorded values are not yet set, and `renderMultiCompact` rows now render the same `modelThinkingBadge` already used in the async widget.

- **`renderSingleCompact` (line 1321):** `r.model ?? r.progress?.model` and `r.thinking ?? r.progress?.thinking` are safe because `r.progress` is typed as `AgentProgress | undefined`, requiring no discriminant.
- **`renderMultiCompact` (lines 1431-1432):** Uses `"status" in rProg` to narrow the `AgentProgress | ProgressSummary | undefined` union — consistent with the existing `rRunning`/`rPending` guards two lines above.
- **Test coverage:** A single focused regression confirms both code paths (model on `r` vs. model only in `progress`) against the collapsed render output.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Two-line render fix with targeted test coverage and no structural changes; low risk of regression.

The changes are minimal and self-contained: both modified sites follow the same fallback pattern (final ?? live) and use the discriminant already present two lines above. The added test directly asserts the collapsed output for both the single and multi-row paths. No logic outside the display layer is touched.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tui/render.ts | Two targeted fixes: renderSingleCompact falls back to r.progress?.model/thinking for live data, and renderMultiCompact adds a rowModelDisplay via the same "status" in rProg discriminant already used by rRunning/rPending guards on lines 1424-1425. |
| test/integration/render-fork-badge.test.ts | Adds a focused regression covering both collapsed paths: single-result card falling back to progress.model/thinking, and multi-row using r.model/r.thinking vs progress.model. |
| CHANGELOG.md | Adds a concise Fixed entry for the model/thinking display regression; no external contributor credit required as the author is the repo owner. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[renderSubagentResult] --> B{details.mode}
    B -->|single| C[renderSingleCompact]
    B -->|parallel / chain| D[renderMultiCompact]

    C --> E{r.model set?}
    E -->|yes| F[modelThinkingBadge r.model, r.thinking]
    E -->|no| G[modelThinkingBadge r.progress.model, r.progress.thinking]
    F --> H[Render header row]
    G --> H

    D --> I{per-row rProg}
    I --> J{"'status' in rProg?"}
    J -->|yes - AgentProgress| K[r.model ?? rProg.model / r.thinking ?? rProg.thinking]
    J -->|no - ProgressSummary| L[r.model / r.thinking only]
    K --> M[modelThinkingBadge - rowModelDisplay]
    L --> M
    M --> N[Render row line]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: use status discriminant for pr..."](https://github.com/nicobailon/pi-subagents/commit/0c4c9927b91fd00be6e3ad022e6014e48cdc6ac6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49380822)</sub>

<!-- /greptile_comment -->