### PR TITLE
fix: respect artifactDir for chain scratch files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- Routed foreground chain scratch files to user-scoped temp storage when `artifactDir` is `"session"` or `"temp"`, preventing `.pi-subagents/` clutter in the working directory.
+- Routed foreground chain scratch files to user-scoped temp storage when `artifactDir` is `"session"` or `"temp"`, preventing `.pi-subagents/` clutter in the working directory. Thanks to @magoz for #729.
 
 ## [0.40.0] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Routed foreground chain scratch files to user-scoped temp storage when `artifactDir` is `"session"` or `"temp"`, preventing `.pi-subagents/` clutter in the working directory.
+
 ## [0.40.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1453,7 +1453,7 @@ Agent definitions are not loaded into context by default. Management actions let
 | `worktree` | boolean | false | Create isolated git worktrees for parallel tasks. |
 | `chain` | array | - | Sequential, checkpoint, static parallel, and dynamic fanout chain steps. Steps and chain parallel tasks support `phase`, `label`, `as`, `outputSchema`, `acceptance`, `agentContract`, and v1-only `gateOn` in addition to the usual execution fields. Dynamic fanout uses `expand`, one child `parallel` template, and `collect`. With `action: "append-step"`, pass exactly one step to append to a running async chain. |
 | `context` | `fresh \| fork` | per-agent default or `fresh` | Explicit `fresh` or `fork` overrides every child. When omitted, each agent uses its own `defaultContext`; `fork` creates real branched sessions from the parent leaf. Packaged `planner`, `worker`, `oracle`, and `advisor` default to `fork`. |
-| `chainDir` | string | temp chain dir | Persistent directory for chain artifacts. Relative chain `output`, `reads`, and `progress` paths live under this directory. |
+| `chainDir` | string | follows `artifactDir` | Persistent directory for chain artifacts. Relative chain `output`, `reads`, and `progress` paths live under this directory. When omitted, `artifactDir: "project"` uses `<cwd>/.pi-subagents/chain-runs/`; `"session"` and `"temp"` use user-scoped temp storage. |
 | `view` | `fleet \| transcript` | - | Optional `status` view for the active fleet surface or transcript tail inspection. |
 | `lines` | number | `80` | Maximum transcript lines for `action: "status", view: "transcript"`; capped at 500. |
 | `clarify` | boolean | false | Show TUI preview/edit flow. Explicit `clarify: true` keeps the run foreground for the clarify UI. |
@@ -1747,7 +1747,9 @@ stdin is a JSON object with `repoRoot`, `worktreePath`, `agentCwd`, `branch`, `i
 
 Controls where subagent artifact files (inputs, outputs, transcripts, metadata) are stored. Defaults to `"project"`, which writes to `<cwd>/.pi-subagents/artifacts/`. Set to `"session"` to store artifacts under pi's session directory (`~/.pi/agent/sessions/<session>/subagent-artifacts/`), keeping the working directory clean. Set to `"temp"` to use the OS temp directory.
 
-The `"session"` option uses the same directory that `cleanupAllArtifactDirs` already scans for age-based cleanup, so artifacts are still cleaned up automatically.
+This preference also controls the default chain scratch directory. `"project"` uses `<cwd>/.pi-subagents/chain-runs/`, while `"session"` and `"temp"` use the user-scoped temp chain directory. An explicit `chainDir` always takes precedence.
+
+The `"session"` option uses the same directory that `cleanupAllArtifactDirs` already scans for age-based cleanup, so artifacts are still cleaned up automatically. Temporary chain directories are cleaned up separately after 24 hours.
 
 ### `completionBatch`
 
@@ -1770,13 +1772,13 @@ Failed and paused completions bypass batching and fire immediately, flushing any
 
 ## Files, logs, and observability
 
-Each chain run creates a user-scoped temp directory like:
+Each chain run creates a scratch directory under its resolved chain root. With the default `artifactDir: "project"`, that root is `<cwd>/.pi-subagents/chain-runs/`. With `artifactDir: "session"` or `"temp"`, it is user-scoped temp storage:
 
 ```text
 <tmpdir>/pi-subagents-<scope>/chain-runs/{runId}/
 ```
 
-It may contain files such as `context.md`, `plan.md`, `progress.md`, and `parallel-{stepIndex}/.../output.md`. Directories older than 24 hours are cleaned up on extension startup.
+An explicit `chainDir` overrides both defaults. A run directory may contain files such as `context.md`, `plan.md`, `progress.md`, and `parallel-{stepIndex}/.../output.md`. User-scoped temp chain directories older than 24 hours are cleaned up on extension startup; project-local and explicit persistent roots are not age-scanned.
 
 Debug artifacts live under `{sessionDir}/subagent-artifacts/`, `.pi-subagents/artifacts/` for project-scoped runs, or a user-scoped temp artifact directory. Single-run relative `output` files are saved under `{artifactsDir}/outputs/{runId}/` unless `singleRunOutputBaseDir` is configured. Per task you may see:
 

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -312,7 +312,7 @@ const SubagentParamsSchema = Type.Object({
 		enum: ["fresh", "fork"],
 		description: "'fresh' or 'fork' to branch from parent session. Explicit context overrides every child in the invocation. If omitted, each requested agent uses its own defaultContext; agents without defaultContext: 'fork' run fresh.",
 	})),
-	chainDir: Type.Optional(Type.String({ description: "Persistent chain artifact directory; defaults to user-scoped temp storage." })),
+	chainDir: Type.Optional(Type.String({ description: "Persistent chain artifact directory; otherwise follows artifactDir (project-local for project, user-scoped temp for session/temp)." })),
 	async: Type.Optional(Type.Boolean({ description: "Run in background (default: false, or per config)" })),
 	timeoutMs: Type.Optional(Type.Integer({ minimum: 1, description: "Timeout for foreground and async/background runs; foreground defaults to 30m absent call/agent. Alias maxRuntimeMs." })),
 	maxRuntimeMs: Type.Optional(Type.Integer({ minimum: 1, description: "Alias timeoutMs for foreground and async/background runs; foreground defaults to 30m absent call/agent." })),

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resolveAgentName, type AgentConfig, type AgentScope } from "../../agents/agents.ts";
-import { getArtifactsDir, getProjectChainRunsDir } from "../../shared/artifacts.ts";
+import { getArtifactsDir, getChainRunsDir } from "../../shared/artifacts.ts";
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
 import { resolveEffectiveThinking, toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import { executeChain } from "./chain-execution.ts";
@@ -2394,7 +2394,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		foregroundControl,
 		nestedRoute: foregroundControl?.nestedRoute,
 		chainSkills,
-		chainDir: params.chainDir ?? getProjectChainRunsDir(effectiveCwd),
+		chainDir: params.chainDir ?? getChainRunsDir(effectiveCwd, artifactConfig.dir),
 		dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
 		maxSubagentDepth: currentMaxSubagentDepth,
 		worktreeSetupHook: deps.config.worktreeSetupHook,

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { TEMP_ARTIFACTS_DIR, type ArtifactPaths, type ArtifactDirPreference } from "./types.ts";
+import { CHAIN_RUNS_DIR, TEMP_ARTIFACTS_DIR, type ArtifactPaths, type ArtifactDirPreference } from "./types.ts";
 import { getAgentDir } from "./utils.ts";
 const CLEANUP_MARKER_FILE = ".last-cleanup";
 const PROJECT_ARTIFACT_ROOT = ".pi-subagents";
@@ -15,6 +15,21 @@ export function getProjectArtifactsDir(cwd: string): string {
 
 export function getProjectChainRunsDir(cwd: string): string {
 	return path.join(getProjectSubagentsDir(cwd), "chain-runs");
+}
+
+export function getChainRunsDir(
+	projectCwd: string,
+	dirPreference: ArtifactDirPreference = "project",
+): string {
+	switch (dirPreference) {
+		case "project":
+			return getProjectChainRunsDir(projectCwd);
+		case "session":
+		case "temp":
+			return CHAIN_RUNS_DIR;
+		default:
+			throw new Error(`Unsupported artifactDir ${JSON.stringify(dirPreference)}; expected "project", "session", or "temp".`);
+	}
 }
 
 export function getArtifactsDir(

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -39,7 +39,7 @@ import {
 	type SubagentDelegationV2Response,
 	type SubagentDelegationV2Started,
 } from "../../src/api/delegation.ts";
-import { INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, type SubagentState } from "../../src/shared/types.ts";
+import { CHAIN_RUNS_DIR, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, type SubagentState } from "../../src/shared/types.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
 import { TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV } from "../../src/runs/shared/tool-budget.ts";
@@ -2305,6 +2305,29 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(fs.readFileSync(result.details.artifacts.files[0].outputPath, "utf-8"), "session artifact result");
 		assert.equal(fs.existsSync(path.join(tempDir, ".pi-subagents", "artifacts")), false);
 	});
+
+	for (const artifactDir of ["session", "temp"] as const) {
+		it(`keeps foreground chain scratch files out of the project for artifactDir=${artifactDir}`, { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+			mockPi.onCall({ output: `${artifactDir} chain result` });
+			const sessionFile = path.join(tempDir, "sessions", "parent-session", "session.jsonl");
+			const ctx = makeMinimalCtx(tempDir);
+			ctx.sessionManager.getSessionFile = () => sessionFile;
+			const executor = makeExecutor([makeAgent("echo")], { artifactDir });
+
+			const result = await executor.execute(
+				`${artifactDir}-chain-artifact-dir`,
+				{ chain: [{ agent: "echo", task: "Run without project-local scratch files in {chain_dir}" }] },
+				new AbortController().signal,
+				undefined,
+				ctx,
+			);
+
+			const taskArg = readCallArgs().at(-1) ?? "";
+			assert.equal(result.isError, undefined);
+			assert.ok(taskArg.includes(`${CHAIN_RUNS_DIR}${path.sep}`), taskArg);
+			assert.equal(fs.existsSync(path.join(tempDir, ".pi-subagents")), false);
+		});
+	}
 
 	it("writes a failure stub to foreground output artifacts when no output was produced", async () => {
 		mockPi.onCall({ output: "", stderr: "model unavailable", exitCode: 1 });

--- a/test/unit/artifacts.test.ts
+++ b/test/unit/artifacts.test.ts
@@ -3,10 +3,12 @@ import * as path from "node:path";
 import { describe, it } from "node:test";
 import {
 	getArtifactsDir,
+	getChainRunsDir,
 	getProjectArtifactsDir,
 	getProjectChainRunsDir,
 	getProjectSubagentsDir,
 } from "../../src/shared/artifacts.ts";
+import { CHAIN_RUNS_DIR } from "../../src/shared/types.ts";
 
 describe("project-local artifact paths", () => {
 	it("places generated subagent files under .pi-subagents for a project cwd", () => {
@@ -15,6 +17,14 @@ describe("project-local artifact paths", () => {
 		assert.equal(getProjectArtifactsDir(cwd), path.join(cwd, ".pi-subagents", "artifacts"));
 		assert.equal(getProjectChainRunsDir(cwd), path.join(cwd, ".pi-subagents", "chain-runs"));
 		assert.equal(getArtifactsDir(null, cwd), path.join(cwd, ".pi-subagents", "artifacts"));
+	});
+
+	it("routes chain scratch files according to the artifact preference", () => {
+		const cwd = path.join("tmp", "repo");
+		assert.equal(getChainRunsDir(cwd), getProjectChainRunsDir(cwd));
+		assert.equal(getChainRunsDir(cwd, "project"), getProjectChainRunsDir(cwd));
+		assert.equal(getChainRunsDir(cwd, "session"), CHAIN_RUNS_DIR);
+		assert.equal(getChainRunsDir(cwd, "temp"), CHAIN_RUNS_DIR);
 	});
 
 	it("keeps the session artifact fallback when no project cwd is available", () => {


### PR DESCRIPTION
## Summary

- route foreground chain scratch directories through the effective `artifactDir` preference
- keep the existing project-local default for `artifactDir: "project"`, while using the user-scoped temp chain root for `"session"` and `"temp"`
- preserve explicit `chainDir` overrides and document the resolved behavior

## Problem

`artifactDir: "session"` and `"temp"` correctly moved normal run artifacts out of the working directory, but foreground chains still unconditionally used `<cwd>/.pi-subagents/chain-runs`. Even an empty completed chain therefore left project-local directory scaffolding behind.

The project-local chain root also falls outside `cleanupOldChainDirs()`, which scans only the user-scoped temp root.

## Testing

- `node --experimental-strip-types --test test/unit/artifacts.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='keeps foreground chain scratch files out of the project' test/integration/single-execution.test.ts`
- `npm run test:all` attempted: 1,521 passed; 4 unrelated local/environment-sensitive failures remained in capability-ceiling agent discovery and close-grace/watchdog timing tests
