### PR TITLE
feat: report async status to Herdr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Added automatic Herdr status metadata for active async runs, including reload recovery, needs-attention blocking, and a forward-compatible `herdr:busy` sibling event for semantic working state. Thanks to @magoz for #730.
+
 ### Fixed
 - Routed foreground chain scratch files to user-scoped temp storage when `artifactDir` is `"session"` or `"temp"`, preventing `.pi-subagents/` clutter in the working directory. Thanks to @magoz for #729.
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,18 @@ Background runs keep working after control returns to you. Inspect active runs w
 
 FleetView replaces the legacy above-editor async widget by default, while completion notifications remain enabled. Parallel runs show every active child independently. Chains with parallel groups keep their grouped shape in progress and results, so failed or paused agents stay visible next to completed ones. When a child is explicitly allowed to fan out with `tools: subagent`, its nested runs appear under that parent child in the main status tree instead of being hidden inside the child process.
 
+When Pi runs inside [Herdr](https://herdr.dev), pi-subagents automatically reports active async-run counts through Herdr pane metadata. The bridge is enabled only when Herdr supplies `HERDR_ENV=1` and `HERDR_PANE_ID`; outside Herdr it registers no listeners or timers. It restores current-session active runs after `/reload` or `/resume`, refreshes metadata while work is active, and clears it on completion or shutdown. To show the reported label in the expanded Agent sidebar, include `state_text` or `$summary` in its row layout, for example:
+
+```toml
+[ui.sidebar.agents]
+rows = [
+  ["state_icon", "workspace", "tab"],
+  ["agent", "state_text"],
+]
+```
+
+The bridge uses Herdr's existing `herdr:blocked` sibling event when an async child needs attention. It also emits `herdr:busy` while async work remains. Herdr versions that support that sibling event keep the pane's semantic state `working`; older versions ignore it safely and still display the metadata label while the Pi integration remains the lifecycle authority.
+
 You can also ask naturally:
 
 ```text

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -38,6 +38,7 @@ import { registerPromptTemplateDelegationBridge } from "../slash/prompt-template
 import { registerMainWatchdog } from "../watchdog/register-main.ts";
 import { registerSlashSubagentBridge } from "../slash/slash-bridge.ts";
 import { createNativeSupervisorChannel } from "../intercom/native-supervisor-channel.ts";
+import { registerHerdrStatusBridge } from "../integrations/herdr-status.ts";
 import { registerSubagentRpcBridge } from "./rpc.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
@@ -482,6 +483,20 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const existingVisibleControlNotices = globalStore[controlNoticeSeenStoreKey];
 	const visibleControlNotices = existingVisibleControlNotices instanceof Set ? existingVisibleControlNotices as Set<string> : new Set<string>();
 	globalStore[controlNoticeSeenStoreKey] = visibleControlNotices;
+	const activeHerdrRuns = () => [...state.asyncJobs.values()]
+		.filter((job) => job.status === "queued" || job.status === "running")
+		.map((job) => ({
+			id: job.asyncId,
+			agents: job.agents,
+			needsAttention: job.activityState === "needs_attention",
+		}));
+	const herdrStatusBridge = registerHerdrStatusBridge({
+		events: pi.events,
+		getRuns: activeHerdrRuns,
+		async runHerdr(args) {
+			await pi.exec(process.env.HERDR_BIN || "herdr", [...args], { timeout: 5_000 });
+		},
+	});
 	const controlEventHandler = (payload: unknown) => {
 		handleSubagentControlNotice({
 			pi,
@@ -506,6 +521,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, asyncCompleteHandler),
 		pi.events.on(SUBAGENT_CONTROL_EVENT, controlEventHandler),
 		pi.events.on(SUBAGENT_STEERING_NOTICE_EVENT, steeringNoticeHandler),
+		herdrStatusBridge.dispose,
 		rpcBridge.dispose,
 	];
 	globalStore[eventUnsubscribeStoreKey] = eventUnsubscribes;
@@ -569,14 +585,22 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		fleetStatus?.setContext(ctx);
 	};
 
+	pi.on("agent_start", () => {
+		herdrStatusBridge.agentStarted();
+	});
+
 	pi.on("session_start", (event, ctx) => {
 		const recovering = event.reason === "startup" || event.reason === "reload" || event.reason === "resume";
 		resetSessionState(ctx, recovering);
+		herdrStatusBridge.sessionStarted({
+			hasUI: ctx.hasUI === true,
+			runs: activeHerdrRuns(),
+		});
 		rpcBridge.emitReady(ctx);
 		supervisorChannel.start();
 	});
 
-	pi.on("session_shutdown", () => {
+	pi.on("session_shutdown", async () => {
 		stopResultWatcher();
 		state.currentSessionId = null;
 		state.parentSessionFile = null;
@@ -618,5 +642,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		} catch (error) {
 			if (!isStaleExtensionContextError(error)) throw error;
 		}
+		await herdrStatusBridge.flush();
 	});
 }

--- a/src/integrations/herdr-status.ts
+++ b/src/integrations/herdr-status.ts
@@ -1,0 +1,330 @@
+import {
+	SUBAGENT_ASYNC_COMPLETE_EVENT,
+	SUBAGENT_ASYNC_STARTED_EVENT,
+	SUBAGENT_CONTROL_EVENT,
+} from "../shared/types.ts";
+
+const DEFAULT_SOURCE = "pi-subagents:herdr";
+const DEFAULT_TTL_MS = 120_000;
+const DEFAULT_REFRESH_MS = 45_000;
+
+let metadataReportSeq = Date.now() * 1000;
+
+function nextMetadataReportSeq(): number {
+	metadataReportSeq = Math.max(metadataReportSeq + 1, Date.now() * 1000);
+	return metadataReportSeq;
+}
+
+export interface HerdrStatusBridgeEvents {
+	on(event: string, handler: (data: unknown) => void): (() => void) | void;
+	emit(event: string, data: unknown): void;
+}
+
+export interface HerdrStatusRun {
+	id: string;
+	agent?: string;
+	agents?: string[];
+	needsAttention?: boolean;
+	attentionLabel?: string;
+}
+
+export interface HerdrStatusBridgeOptions {
+	events: HerdrStatusBridgeEvents;
+	env?: Record<string, string | undefined>;
+	/** Current authoritative active-run projection, used before TTL refresh. */
+	getRuns?: () => Iterable<HerdrStatusRun>;
+	runHerdr: (args: readonly string[]) => void | Promise<void>;
+	ttlMs?: number;
+	refreshMs?: number;
+	timers?: {
+		setInterval: typeof setInterval;
+		clearInterval: typeof clearInterval;
+	};
+}
+
+export interface HerdrStatusBridge {
+	/**
+	 * Binds the pane owner. Only the root interactive session may publish pane
+	 * metadata: headless parents (print/json), non-UI harnesses, and child
+	 * runtimes must never fight the pane's lifecycle authority over display
+	 * state. Also re-syncs runs that survived a reload/resume.
+	 */
+	sessionStarted(input: { hasUI: boolean; runs: Iterable<HerdrStatusRun> }): void;
+	agentStarted(): void;
+	flush(): Promise<void>;
+	dispose(): void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function startedRun(data: unknown): HerdrStatusRun | undefined {
+	if (!isRecord(data) || typeof data.id !== "string" || !data.id) return undefined;
+	return {
+		id: data.id,
+		...(typeof data.agent === "string" ? { agent: data.agent } : {}),
+		...(Array.isArray(data.agents) && data.agents.every((agent) => typeof agent === "string") ? { agents: data.agents as string[] } : {}),
+	};
+}
+
+function completedRunId(data: unknown): string | undefined {
+	if (!isRecord(data)) return undefined;
+	const id = typeof data.runId === "string" ? data.runId : data.id;
+	return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+function attentionNotice(data: unknown): { runId: string; label: string } | undefined {
+	if (!isRecord(data) || data.source !== "async" || !isRecord(data.event)) return undefined;
+	if (data.event.type !== "needs_attention" || typeof data.event.runId !== "string" || !data.event.runId) return undefined;
+	const label = typeof data.noticeText === "string" && data.noticeText
+		? data.noticeText
+		: typeof data.event.message === "string" && data.event.message
+			? data.event.message
+			: "subagent needs attention";
+	return { runId: data.event.runId, label };
+}
+
+export function registerHerdrStatusBridge(options: HerdrStatusBridgeOptions): HerdrStatusBridge {
+	const env = options.env ?? process.env;
+	const paneId = env.HERDR_PANE_ID;
+	const enabled = env.HERDR_ENV === "1" && typeof paneId === "string" && paneId.length > 0;
+	const runHerdr = options.runHerdr;
+	const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+	const refreshMs = options.refreshMs ?? DEFAULT_REFRESH_MS;
+	const timers = options.timers ?? { setInterval, clearInterval };
+	const runs = new Map<string, HerdrStatusRun>();
+	const attentionLabels = new Map<string, string>();
+	const acknowledgedAttention = new Set<string>();
+	const subscriptions: Array<() => void> = [];
+	let rootSession = false;
+	let published = false;
+	let busyRaised = false;
+	let busyLabel: string | undefined;
+	let blockedRaised = false;
+	let blockedLabel: string | undefined;
+	let disposed = false;
+	let pendingReport: readonly string[] | undefined;
+	let draining = false;
+	let drainPromise = Promise.resolve();
+	let refreshTimer: ReturnType<typeof setInterval> | undefined;
+
+	const label = (): string => {
+		const agents = [...new Set([...runs.values()].flatMap((run) => run.agents?.length ? run.agents : run.agent ? [run.agent] : []))];
+		const who = agents.length > 0
+			? ` (${agents.slice(0, 3).join(", ")}${agents.length > 3 ? ", …" : ""})`
+			: "";
+		return `⏳ ${runs.size} subagent${runs.size === 1 ? "" : "s"}${who}`;
+	};
+
+	const enqueue = (args: readonly string[]): void => {
+		pendingReport = args;
+		if (draining) return;
+		draining = true;
+		drainPromise = (async () => {
+			while (pendingReport) {
+				const next = pendingReport;
+				pendingReport = undefined;
+				try {
+					await runHerdr(next);
+				} catch {
+					// Herdr integration is best effort; a later state transition or TTL
+					// refresh retries with the newest desired snapshot.
+				}
+			}
+		})().finally(() => {
+			draining = false;
+		});
+	};
+
+	const publish = (): void => {
+		if (!enabled || !rootSession || disposed || !paneId) return;
+		if (runs.size === 0 && !published) return;
+		const seq = String(nextMetadataReportSeq());
+		if (runs.size === 0) {
+			published = false;
+			enqueue([
+				"pane", "report-metadata", paneId,
+				"--source", DEFAULT_SOURCE,
+				"--agent", "pi",
+				"--applies-to-source", "herdr:pi",
+				"--clear-state-labels",
+				"--clear-token", "summary",
+				"--seq", seq,
+			]);
+			return;
+		}
+		const text = label();
+		published = true;
+		enqueue([
+			"pane", "report-metadata", paneId,
+			"--source", DEFAULT_SOURCE,
+			"--agent", "pi",
+			"--applies-to-source", "herdr:pi",
+			"--state-label", `idle=${text}`,
+			"--state-label", `done=${text}`,
+			"--state-label", `working=${text}`,
+			"--token", `summary=${text}`,
+			"--ttl-ms", String(ttlMs),
+			"--seq", seq,
+		]);
+	};
+
+	const syncRefreshTimer = (): void => {
+		if (runs.size > 0 && refreshMs > 0 && !refreshTimer) {
+			refreshTimer = timers.setInterval(() => refresh(), refreshMs);
+			refreshTimer.unref?.();
+		} else if ((runs.size === 0 || refreshMs <= 0) && refreshTimer) {
+			timers.clearInterval(refreshTimer);
+			refreshTimer = undefined;
+		}
+	};
+
+	const syncBusy = (): void => {
+		if (!enabled || !rootSession || disposed) return;
+		if (runs.size > 0) {
+			const text = label();
+			if (busyRaised && busyLabel === text) return;
+			if (busyRaised) options.events.emit("herdr:busy", { active: false });
+			busyRaised = true;
+			busyLabel = text;
+			options.events.emit("herdr:busy", { active: true, label: text });
+			return;
+		}
+		if (busyRaised) {
+			busyRaised = false;
+			busyLabel = undefined;
+			options.events.emit("herdr:busy", { active: false });
+		}
+	};
+
+	const syncBlocked = (): void => {
+		if (!enabled || !rootSession || disposed) return;
+		const nextLabel = [...attentionLabels.values()].at(-1);
+		if (nextLabel !== undefined) {
+			if (blockedRaised && blockedLabel === nextLabel) return;
+			// Herdr's sibling overlay contract is counted. Lower before changing
+			// the active label so this bridge continues to own exactly one count.
+			if (blockedRaised) options.events.emit("herdr:blocked", { active: false });
+			blockedRaised = true;
+			blockedLabel = nextLabel;
+			options.events.emit("herdr:blocked", { active: true, label: nextLabel });
+			return;
+		}
+		if (blockedRaised) {
+			blockedRaised = false;
+			blockedLabel = undefined;
+			options.events.emit("herdr:blocked", { active: false });
+		}
+	};
+
+	const clearAttention = (): void => {
+		attentionLabels.clear();
+		syncBlocked();
+	};
+
+	const raiseAttention = (runId: string, labelText: string): void => {
+		if (!rootSession || attentionLabels.has(runId)) return;
+		acknowledgedAttention.delete(runId);
+		attentionLabels.set(runId, labelText);
+		syncBlocked();
+	};
+
+	const replaceRuns = (nextRuns: Iterable<HerdrStatusRun>): void => {
+		const nextAttention = new Map<string, string>();
+		const activeIds = new Set<string>();
+		runs.clear();
+		for (const run of nextRuns) {
+			if (!run || typeof run.id !== "string" || !run.id) continue;
+			activeIds.add(run.id);
+			runs.set(run.id, { ...run });
+			if (!run.needsAttention) {
+				acknowledgedAttention.delete(run.id);
+			} else if (!acknowledgedAttention.has(run.id)) {
+				nextAttention.set(run.id, run.attentionLabel || attentionLabels.get(run.id) || "subagent needs attention");
+			}
+		}
+		for (const id of acknowledgedAttention) {
+			if (!activeIds.has(id)) acknowledgedAttention.delete(id);
+		}
+		attentionLabels.clear();
+		for (const [id, labelText] of nextAttention) attentionLabels.set(id, labelText);
+		syncBusy();
+		syncRefreshTimer();
+		syncBlocked();
+		publish();
+	};
+
+	const refresh = (): void => {
+		if (!options.getRuns) {
+			publish();
+			return;
+		}
+		try {
+			replaceRuns(options.getRuns());
+		} catch {
+			// Keep the last known active projection and retry on the next refresh.
+			publish();
+		}
+	};
+
+	const subscribe = (event: string, handler: (data: unknown) => void): void => {
+		const unsubscribe = options.events.on(event, handler);
+		if (typeof unsubscribe === "function") subscriptions.push(unsubscribe);
+	};
+
+	if (enabled) {
+		subscribe(SUBAGENT_ASYNC_STARTED_EVENT, (data) => {
+			if (!rootSession) return;
+			const run = startedRun(data);
+			if (!run) return;
+			acknowledgedAttention.delete(run.id);
+			runs.set(run.id, run);
+			syncBusy();
+			syncRefreshTimer();
+			publish();
+		});
+		subscribe(SUBAGENT_ASYNC_COMPLETE_EVENT, (data) => {
+			if (!rootSession) return;
+			const id = completedRunId(data);
+			if (!id || !runs.delete(id)) return;
+			acknowledgedAttention.delete(id);
+			if (attentionLabels.delete(id)) syncBlocked();
+			syncBusy();
+			syncRefreshTimer();
+			publish();
+		});
+		subscribe(SUBAGENT_CONTROL_EVENT, (data) => {
+			if (!rootSession) return;
+			const notice = attentionNotice(data);
+			if (!notice || !runs.has(notice.runId)) return;
+			raiseAttention(notice.runId, notice.label);
+		});
+	}
+
+	return {
+		agentStarted() {
+			for (const id of attentionLabels.keys()) acknowledgedAttention.add(id);
+			clearAttention();
+		},
+		sessionStarted({ hasUI, runs: restoredRuns }) {
+			if (!enabled || disposed || hasUI !== true) return;
+			rootSession = true;
+			replaceRuns(restoredRuns);
+		},
+		async flush() {
+			while (draining || pendingReport) await drainPromise;
+		},
+		dispose() {
+			if (disposed) return;
+			clearAttention();
+			acknowledgedAttention.clear();
+			runs.clear();
+			syncBusy();
+			syncRefreshTimer();
+			publish();
+			for (const unsubscribe of subscriptions) unsubscribe();
+			disposed = true;
+		},
+	};
+}

--- a/test/unit/herdr-status-bridge.test.ts
+++ b/test/unit/herdr-status-bridge.test.ts
@@ -1,0 +1,494 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+	registerHerdrStatusBridge,
+	type HerdrStatusBridgeEvents,
+} from "../../src/integrations/herdr-status.ts";
+import {
+	SUBAGENT_ASYNC_COMPLETE_EVENT,
+	SUBAGENT_ASYNC_STARTED_EVENT,
+	SUBAGENT_CONTROL_EVENT,
+} from "../../src/shared/types.ts";
+
+class FakeIntervals {
+	private callbacks = new Map<object, () => void>();
+
+	readonly timers = {
+		setInterval: ((callback: () => void) => {
+			const handle = { unref() {} };
+			this.callbacks.set(handle, callback);
+			return handle;
+		}) as unknown as typeof setInterval,
+		clearInterval: ((handle: object) => {
+			this.callbacks.delete(handle);
+		}) as unknown as typeof clearInterval,
+	};
+
+	fireAll(): void {
+		for (const callback of [...this.callbacks.values()]) callback();
+	}
+
+	pendingCount(): number {
+		return this.callbacks.size;
+	}
+}
+
+class FakeEvents implements HerdrStatusBridgeEvents {
+	private handlers = new Map<string, Array<(data: unknown) => void>>();
+
+	on(event: string, handler: (data: unknown) => void): () => void {
+		const handlers = this.handlers.get(event) ?? [];
+		handlers.push(handler);
+		this.handlers.set(event, handlers);
+		return () => {
+			const current = this.handlers.get(event) ?? [];
+			this.handlers.set(event, current.filter((candidate) => candidate !== handler));
+		};
+	}
+
+	emit(event: string, data: unknown): void {
+		for (const handler of [...(this.handlers.get(event) ?? [])]) handler(data);
+	}
+}
+
+describe("Herdr status bridge", () => {
+	it("reports an async run as visible and semantically busy", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const busyEvents: unknown[] = [];
+		events.on("herdr:busy", (payload) => busyEvents.push(payload));
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: {
+				HERDR_ENV: "1",
+				HERDR_PANE_ID: "w1:p1",
+			},
+			runHerdr: (args) => {
+				commands.push([...args]);
+			},
+			refreshMs: 0,
+		});
+
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, {
+			id: "run-1",
+			agent: "worker",
+		});
+		await bridge.flush();
+
+		assert.deepEqual(busyEvents, [{
+			active: true,
+			label: "⏳ 1 subagent (worker)",
+		}]);
+		assert.equal(commands.length, 1);
+		assert.deepEqual(commands[0]?.slice(0, 8), [
+			"pane",
+			"report-metadata",
+			"w1:p1",
+			"--source",
+			"pi-subagents:herdr",
+			"--agent",
+			"pi",
+			"--applies-to-source",
+		]);
+		assert.ok(commands[0]?.includes("herdr:pi"));
+		assert.ok(commands[0]?.includes("--state-label"));
+		assert.ok(commands[0]?.includes("working=⏳ 1 subagent (worker)"));
+		assert.ok(commands[0]?.includes("idle=⏳ 1 subagent (worker)"));
+		assert.ok(commands[0]?.includes("done=⏳ 1 subagent (worker)"));
+		assert.ok(commands[0]?.includes("summary=⏳ 1 subagent (worker)"));
+		assert.ok(commands[0]?.includes("--ttl-ms"));
+		assert.ok(commands[0]?.includes("--seq"));
+
+		bridge.dispose();
+	});
+
+	it("updates the aggregate label and clears status after the final run completes", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const busyEvents: unknown[] = [];
+		events.on("herdr:busy", (payload) => busyEvents.push(payload));
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 0,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
+		await bridge.flush();
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-2", agent: "reviewer" });
+		await bridge.flush();
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { runId: "run-1" });
+		await bridge.flush();
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { id: "run-2" });
+		await bridge.flush();
+
+		assert.deepEqual(busyEvents, [
+			{ active: true, label: "⏳ 1 subagent (worker)" },
+			{ active: false },
+			{ active: true, label: "⏳ 2 subagents (worker, reviewer)" },
+			{ active: false },
+			{ active: true, label: "⏳ 1 subagent (reviewer)" },
+			{ active: false },
+		]);
+		assert.equal(commands.length, 4);
+		assert.ok(commands[1]?.includes("summary=⏳ 2 subagents (worker, reviewer)"));
+		assert.ok(commands[2]?.includes("summary=⏳ 1 subagent (reviewer)"));
+		assert.ok(commands[3]?.includes("--clear-state-labels"));
+		assert.ok(commands[3]?.includes("--clear-token"));
+
+		bridge.dispose();
+	});
+
+	it("marks an async run blocked until the parent agent wakes", () => {
+		const events = new FakeEvents();
+		const blockedEvents: unknown[] = [];
+		events.on("herdr:blocked", (payload) => blockedEvents.push(payload));
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: () => {},
+			refreshMs: 0,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
+		events.emit(SUBAGENT_CONTROL_EVENT, {
+			source: "async",
+			noticeText: "worker needs attention",
+			event: {
+				type: "needs_attention",
+				runId: "run-1",
+			},
+		});
+		events.emit(SUBAGENT_CONTROL_EVENT, {
+			source: "async",
+			event: { type: "active_long_running", runId: "run-1" },
+		});
+		events.emit(SUBAGENT_CONTROL_EVENT, {
+			source: "foreground",
+			event: { type: "needs_attention", runId: "run-1" },
+		});
+		bridge.agentStarted();
+
+		assert.deepEqual(blockedEvents, [
+			{ active: true, label: "worker needs attention" },
+			{ active: false },
+		]);
+
+		bridge.dispose();
+	});
+
+	it("does not resurrect acknowledged attention during TTL reconciliation", async () => {
+		const events = new FakeEvents();
+		const blockedEvents: unknown[] = [];
+		const intervals = new FakeIntervals();
+		let authoritativeRuns = [{ id: "run-1", agent: "worker", needsAttention: false }];
+		events.on("herdr:blocked", (payload) => blockedEvents.push(payload));
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			getRuns: () => authoritativeRuns,
+			runHerdr: () => {},
+			refreshMs: 45_000,
+			timers: intervals.timers,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: authoritativeRuns });
+		events.emit(SUBAGENT_CONTROL_EVENT, {
+			source: "async",
+			noticeText: "worker needs attention",
+			event: { type: "needs_attention", runId: "run-1" },
+		});
+		authoritativeRuns = [{ id: "run-1", agent: "worker", needsAttention: true }];
+		bridge.agentStarted();
+
+		intervals.fireAll();
+		await bridge.flush();
+		assert.deepEqual(blockedEvents, [
+			{ active: true, label: "worker needs attention" },
+			{ active: false },
+		]);
+
+		// A new explicit control event is a new attention transition and may
+		// raise the overlay again even if the tracker flag never dropped.
+		events.emit(SUBAGENT_CONTROL_EVENT, {
+			source: "async",
+			noticeText: "worker still needs attention",
+			event: { type: "needs_attention", runId: "run-1" },
+		});
+		assert.deepEqual(blockedEvents.at(-1), {
+			active: true,
+			label: "worker still needs attention",
+		});
+
+		bridge.dispose();
+	});
+
+	it("releases blocked state when the affected run completes", () => {
+		const events = new FakeEvents();
+		const blockedEvents: unknown[] = [];
+		events.on("herdr:blocked", (payload) => blockedEvents.push(payload));
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: () => {},
+			refreshMs: 0,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
+		events.emit(SUBAGENT_CONTROL_EVENT, {
+			source: "async",
+			event: { type: "needs_attention", runId: "run-1", message: "stuck" },
+		});
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { runId: "run-1" });
+
+		assert.deepEqual(blockedEvents, [
+			{ active: true, label: "stuck" },
+			{ active: false },
+		]);
+
+		bridge.dispose();
+	});
+
+	it("keeps one accurate blocked overlay while multiple runs need attention", () => {
+		const events = new FakeEvents();
+		const blockedEvents: unknown[] = [];
+		events.on("herdr:blocked", (payload) => blockedEvents.push(payload));
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: () => {},
+			refreshMs: 0,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-2", agent: "reviewer" });
+
+		events.emit(SUBAGENT_CONTROL_EVENT, {
+			source: "async",
+			noticeText: "worker needs attention",
+			event: { type: "needs_attention", runId: "run-1" },
+		});
+		events.emit(SUBAGENT_CONTROL_EVENT, {
+			source: "async",
+			noticeText: "reviewer needs attention",
+			event: { type: "needs_attention", runId: "run-2" },
+		});
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { runId: "run-2" });
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { runId: "run-1" });
+
+		assert.deepEqual(blockedEvents, [
+			{ active: true, label: "worker needs attention" },
+			{ active: false },
+			{ active: true, label: "reviewer needs attention" },
+			{ active: false },
+			{ active: true, label: "worker needs attention" },
+			{ active: false },
+		]);
+
+		bridge.dispose();
+	});
+
+	it("restores active runs and clears overlays on disposal", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const busyEvents: unknown[] = [];
+		const blockedEvents: unknown[] = [];
+		events.on("herdr:busy", (payload) => busyEvents.push(payload));
+		events.on("herdr:blocked", (payload) => blockedEvents.push(payload));
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 0,
+		});
+
+		bridge.sessionStarted({
+			hasUI: true,
+			runs: [{
+				id: "run-restored",
+				agents: ["worker", "reviewer"],
+				needsAttention: true,
+				attentionLabel: "reviewer needs attention",
+			}],
+		});
+		await bridge.flush();
+
+		assert.deepEqual(busyEvents, [{
+			active: true,
+			label: "⏳ 1 subagent (worker, reviewer)",
+		}]);
+		assert.deepEqual(blockedEvents, [{
+			active: true,
+			label: "reviewer needs attention",
+		}]);
+		assert.ok(commands[0]?.includes("summary=⏳ 1 subagent (worker, reviewer)"));
+
+		bridge.dispose();
+		await bridge.flush();
+
+		assert.deepEqual(busyEvents.at(-1), { active: false });
+		assert.deepEqual(blockedEvents.at(-1), { active: false });
+		assert.ok(commands.at(-1)?.includes("--clear-state-labels"));
+	});
+
+	it("refreshes metadata only while runs are active", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const intervals = new FakeIntervals();
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 45_000,
+			timers: intervals.timers,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+
+		assert.equal(intervals.pendingCount(), 0);
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
+		assert.equal(intervals.pendingCount(), 1);
+		await bridge.flush();
+		intervals.fireAll();
+		await bridge.flush();
+		assert.equal(commands.length, 2);
+
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { runId: "run-1" });
+		assert.equal(intervals.pendingCount(), 0);
+		await bridge.flush();
+		assert.ok(commands.at(-1)?.includes("--clear-state-labels"));
+
+		bridge.dispose();
+	});
+
+	it("reconciles missed completion events before refreshing metadata", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const busyEvents: unknown[] = [];
+		const intervals = new FakeIntervals();
+		let authoritativeRuns = [{ id: "run-1", agent: "worker" }];
+		events.on("herdr:busy", (payload) => busyEvents.push(payload));
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			getRuns: () => authoritativeRuns,
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 45_000,
+			timers: intervals.timers,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: authoritativeRuns });
+		await bridge.flush();
+		assert.equal(intervals.pendingCount(), 1);
+
+		// Simulate the tracker reaching terminal state while the bridge misses
+		// the completion event. The refresh must clear instead of extending TTL.
+		authoritativeRuns = [];
+		intervals.fireAll();
+		await bridge.flush();
+
+		assert.deepEqual(busyEvents, [
+			{ active: true, label: "⏳ 1 subagent (worker)" },
+			{ active: false },
+		]);
+		assert.equal(intervals.pendingCount(), 0);
+		assert.ok(commands.at(-1)?.includes("--clear-state-labels"));
+
+		bridge.dispose();
+	});
+
+	it("coalesces queued metadata reports to the latest desired state", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		let releaseFirst: (() => void) | undefined;
+		const firstPending = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: (args) => {
+				commands.push([...args]);
+				if (commands.length === 1) return firstPending;
+			},
+			refreshMs: 0,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
+		await Promise.resolve();
+		assert.equal(commands.length, 1);
+
+		// These snapshots all arrive while the first CLI call is blocked. Only
+		// the final clear matters once that call returns.
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-2", agent: "reviewer" });
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { runId: "run-1" });
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { runId: "run-2" });
+		releaseFirst?.();
+		await bridge.flush();
+
+		assert.equal(commands.length, 2);
+		assert.ok(commands[0]?.includes("summary=⏳ 1 subagent (worker)"));
+		assert.ok(commands[1]?.includes("--clear-state-labels"));
+
+		bridge.dispose();
+	});
+
+	it("stays inert until a root interactive session starts", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const busyEvents: unknown[] = [];
+		events.on("herdr:busy", (payload) => busyEvents.push(payload));
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 0,
+		});
+
+		// Before any session_start, the pane owner is unknown.
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-early", agent: "worker" });
+		await bridge.flush();
+		assert.deepEqual(commands, []);
+		assert.deepEqual(busyEvents, []);
+
+		// A headless parent (print/json mode, or a test harness) must never publish.
+		bridge.sessionStarted({ hasUI: false, runs: [{ id: "run-headless", agent: "worker" }] });
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
+		await bridge.flush();
+		assert.deepEqual(commands, []);
+		assert.deepEqual(busyEvents, []);
+
+		// Only the root interactive session owns the pane.
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-2", agent: "reviewer" });
+		await bridge.flush();
+		assert.equal(commands.length, 1);
+		assert.ok(commands[0]?.includes("summary=⏳ 1 subagent (reviewer)"));
+		assert.deepEqual(busyEvents, [{ active: true, label: "⏳ 1 subagent (reviewer)" }]);
+
+		bridge.dispose();
+	});
+
+	it("stays inert outside a Herdr pane", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: {},
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 0,
+		});
+
+		bridge.sessionStarted({ hasUI: true, runs: [{ id: "run-2", agent: "reviewer" }] });
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
+		bridge.agentStarted();
+		bridge.dispose();
+		await bridge.flush();
+
+		assert.deepEqual(commands, []);
+	});
+});


### PR DESCRIPTION
## Summary

- report active async-run counts to Herdr through pane metadata when Pi is running in a Herdr pane
- restore current-session runs after reload/resume and reconcile from the authoritative async-job tracker before TTL refresh
- bridge async `needs_attention` through Herdr's existing `herdr:blocked` sibling event
- emit a forward-compatible `herdr:busy` sibling event so supporting Herdr versions can keep semantic pane state `working`
- coalesce CLI reports to one in-flight call plus the latest pending state, and clear overlays on completion/shutdown

The bridge is inactive unless Herdr supplies `HERDR_ENV=1` and `HERDR_PANE_ID`, and it publishes only from a root UI session. Older Herdr versions safely ignore `herdr:busy` while still rendering the metadata label.

Related Herdr direction discussion: https://github.com/herdrdev/herdr/discussions/1274#discussioncomment-17868530

## Testing

- `node --experimental-strip-types --test test/unit/herdr-status-bridge.test.ts` — 12/12 pass
- `npm run test:e2e` — 3/3 pass
- isolated `test/integration/async-execution.test.ts` — 110/110 pass
- clean Pi package-load smoke with `-e ./index.ts --list-models` — pass
- isolated `test/integration/single-execution.test.ts` — 150/152 on this machine; the same two strict delegation tests fail on untouched `main` (150/152 baseline)
