### PR TITLE
fix: retry Windows EPERM on async runner startup-control rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Routed foreground chain scratch files to user-scoped temp storage when `artifactDir` is `"session"` or `"temp"`, preventing `.pi-subagents/` clutter in the working directory. Thanks to @magoz for #729.
+- Retry transient Windows `EPERM`/`EBUSY`/`EACCES` locks when atomically replacing the async runner startup-control handshake file, so a transient antivirus/indexer lock no longer makes the parent believe the runner never reached the ready state. Thanks to @franktheglock for #731.
 
 ## [0.40.0] - 2026-08-01
 

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -12,7 +12,6 @@ import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { writePrivateAtomicJson } from "../../shared/atomic-json.ts";
-import { runFileSystemOperationWithRetry } from "../../shared/file-system-retry.ts";
 import { applyThinkingSuffix, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/pi-args.ts";
 import { injectOutputPathSystemPrompt, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { buildChainInstructions, isCheckpointStep, isDynamicParallelStep, isParallelStep, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
@@ -374,25 +373,12 @@ function waitForRunnerStartup(startupPath: string, expectedState: RunnerStartupS
 }
 
 function writeRunnerStartupControl(filePath: string, payload: { action: "ack" | "proceed"; token: string }): void {
-	const tempPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
-	try {
-		fs.writeFileSync(tempPath, JSON.stringify(payload), { encoding: "utf-8", mode: 0o600 });
-		// On Windows, atomically replacing an existing startup-control file can
-		// transiently fail with EPERM/EBUSY/EACCES when the target is briefly held
-		// by an antivirus/indexer scan or a concurrently polling parent process.
-		// Retry the rename the same way atomic-json does, so a transient lock does
-		// not make the parent believe the runner never reached the ready state.
-		runFileSystemOperationWithRetry(() => {
-			fs.renameSync(tempPath, filePath);
-		});
-	} catch (error) {
-		try {
-			fs.rmSync(tempPath, { force: true });
-		} catch {
-			// Preserve the startup-control write error.
-		}
-		throw error;
-	}
+	// Delegate to the shared atomic JSON writer (temp file + rename, retrying
+	// transient Windows EPERM/EBUSY/EACCES locks and cleaning up the temp file
+	// on failure), so the startup handshake gets the same locking resilience as
+	// every other async control/result file. This is exercised by
+	// test/unit/atomic-json.test.ts.
+	writePrivateAtomicJson(filePath, payload);
 }
 
 function runnerIsAlive(pid: number): boolean {

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -12,6 +12,7 @@ import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { writePrivateAtomicJson } from "../../shared/atomic-json.ts";
+import { runFileSystemOperationWithRetry } from "../../shared/file-system-retry.ts";
 import { applyThinkingSuffix, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/pi-args.ts";
 import { injectOutputPathSystemPrompt, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { buildChainInstructions, isCheckpointStep, isDynamicParallelStep, isParallelStep, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
@@ -376,7 +377,14 @@ function writeRunnerStartupControl(filePath: string, payload: { action: "ack" | 
 	const tempPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
 	try {
 		fs.writeFileSync(tempPath, JSON.stringify(payload), { encoding: "utf-8", mode: 0o600 });
-		fs.renameSync(tempPath, filePath);
+		// On Windows, atomically replacing an existing startup-control file can
+		// transiently fail with EPERM/EBUSY/EACCES when the target is briefly held
+		// by an antivirus/indexer scan or a concurrently polling parent process.
+		// Retry the rename the same way atomic-json does, so a transient lock does
+		// not make the parent believe the runner never reached the ready state.
+		runFileSystemOperationWithRetry(() => {
+			fs.renameSync(tempPath, filePath);
+		});
 	} catch (error) {
 		try {
 			fs.rmSync(tempPath, { force: true });


### PR DESCRIPTION
## Summary

The async runner startup handshake file (ack/proceed control) is atomically replaced via a temp file + `renameSync`. Unlike the `atomic-json` writer, that rename was **not** wrapped in a retry, so on Windows a transient `EPERM`/`EBUSY`/`EACCES` lock on the target (antivirus/indexer scan, or a concurrently polling parent process) throws synchronously and makes the parent believe the runner never reached the `ready` state, failing the run.

This reuses the existing `runFileSystemOperationWithRetry` helper that `atomic-json.ts` already uses, closing the one gap left by the earlier Windows-lock fixes (#269, #292, #380, #566, #601).

## Change

`src/runs/background/async-execution.ts` — wrap the startup-control `renameSync` in `runFileSystemOperationWithRetry`.

## Verification

- `node --experimental-strip-types --check` passes on the edited file.
- Reuses the already-tested retry helper; no new deps or behavior.