### PR TITLE
fix: preserve temp dir contents on fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Routed foreground chain scratch files to user-scoped temp storage when `artifactDir` is `"session"` or `"temp"`, preventing `.pi-subagents/` clutter in the working directory. Thanks to @magoz for #729.
 - Retry transient Windows `EPERM`/`EBUSY`/`EACCES` locks when atomically replacing the async runner startup-control handshake file, so a transient antivirus/indexer lock no longer makes the parent believe the runner never reached the ready state. Thanks to @franktheglock for #731.
 - Kept successful background subagent completions quiet so inactive Pi tabs are not marked unread, while failed and paused completions still notify the originating session. Thanks to @killianMei for #728.
+- Avoid crashing the extension at load on Windows when shared temp async result/run directories are persistently blocked by `EPERM`/`EACCES`, falling back to pid-scoped sibling paths without deleting saved run state. Thanks to @franktheglock for #734.
 
 ## [0.40.0] - 2026-08-01
 

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -18,7 +18,7 @@ import type { ResolvedTurnBudget } from "../shared/types.ts";
 import type { ResolvedMcpDirectToolSelection } from "../runs/shared/mcp-direct-tool-allowlist.ts";
 import { resolveStepBehavior } from "../shared/settings.ts";
 import { agentDefinitionDigest, AGENT_DEFINITION_PROJECTION_VERSION, launchBindingDigest } from "../shared/launch-contract.ts";
-import { ASYNC_DIR, RESULTS_DIR, TEMP_ROOT_DIR } from "../shared/types.ts";
+import { DIRS, TEMP_ROOT_DIR } from "../shared/types.ts";
 import { processTerminalCandidatePath, processTerminalPath } from "../runs/background/process-terminal.ts";
 import { nestedResultsPath } from "../runs/shared/nested-events.ts";
 
@@ -292,10 +292,10 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 	const sessionDir = sessionRoot ? path.join(sessionRoot, "run-0") : undefined;
 	const lifecycleAsyncDir = input.nestedRootRunId
 		? path.join(TEMP_ROOT_DIR, "nested-subagent-runs", input.nestedRootRunId, runId)
-		: path.join(ASYNC_DIR, runId);
+		: path.join(DIRS.async, runId);
 	const lifecycleResultPath = input.nestedRootRunId
 		? nestedResultsPath(input.nestedRootRunId, runId)
-		: path.join(RESULTS_DIR, `${runId}.json`);
+		: path.join(DIRS.results, `${runId}.json`);
 	if (!sessionDir) diagnostics.push({ code: "host_required", severity: "host-required", message: "No sessionRoot/sessionDir was supplied; exact child session paths require the Pi host session-root policy." });
 	if (input.availableModels === undefined && (input.model || agent.model || input.parentModel)) {
 		diagnostics.push({ code: "host_required", severity: "host-required", message: "No availableModels snapshot was supplied; model resolution may differ from the active Pi host registry." });

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -6,9 +6,8 @@ import { formatSpawnBudgetSummary, getSpawnBudgetSnapshot } from "../runs/shared
 import { diagnoseIntercomBridge, type IntercomBridgeDiagnostic } from "../intercom/intercom-bridge.ts";
 import { discoverAvailableSkills, type SkillSource } from "../agents/skills.ts";
 import {
-	ASYNC_DIR,
+	DIRS,
 	CHAIN_RUNS_DIR,
-	RESULTS_DIR,
 	TEMP_ROOT_DIR,
 	type ExtensionConfig,
 	type SubagentState,
@@ -43,12 +42,14 @@ interface DoctorReportInput {
 	deps?: Partial<DoctorDeps>;
 }
 
-const DEFAULT_PATHS: DoctorPaths = {
-	tempRootDir: TEMP_ROOT_DIR,
-	asyncDir: ASYNC_DIR,
-	resultsDir: RESULTS_DIR,
-	chainRunsDir: CHAIN_RUNS_DIR,
-};
+function defaultPaths(): DoctorPaths {
+	return {
+		tempRootDir: TEMP_ROOT_DIR,
+		asyncDir: DIRS.async,
+		resultsDir: DIRS.results,
+		chainRunsDir: CHAIN_RUNS_DIR,
+	};
+}
 
 const DEFAULT_DEPS: DoctorDeps = {
 	isAsyncAvailable,
@@ -192,7 +193,7 @@ function formatPermissionSystemSection(): string[] {
 }
 
 export function buildDoctorReport(input: DoctorReportInput): string {
-	const paths = input.paths ?? DEFAULT_PATHS;
+	const paths = input.paths ?? defaultPaths();
 	const deps = { ...DEFAULT_DEPS, ...input.deps };
 	const lines = [
 		"Subagents doctor report",

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -56,9 +56,8 @@ import { syncMissionFromAsyncCompletion } from "../missions/lifecycle.ts";
 import {
 	type Details,
 	type SubagentState,
-	ASYNC_DIR,
+	DIRS,
 	DEFAULT_ARTIFACT_CONFIG,
-	RESULTS_DIR,
 	SLASH_RESULT_TYPE,
 	SLASH_TEXT_RESULT_TYPE,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
@@ -190,8 +189,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}
 	}
 
-	ensureAccessibleDir(RESULTS_DIR);
-	ensureAccessibleDir(ASYNC_DIR);
+	DIRS.results = ensureAccessibleDir(DIRS.results);
+	DIRS.async = ensureAccessibleDir(DIRS.async);
 	cleanupOldChainDirs();
 
 	const config = loadConfig();
@@ -249,7 +248,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const { startResultWatcher, primeExistingResults, stopResultWatcher } = createResultWatcher(
 		pi,
 		state,
-		RESULTS_DIR,
+		DIRS.results,
 		10 * 60 * 1000,
 		{
 			notifier: completionNotifier,
@@ -273,7 +272,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	};
 	globalStore[runtimeCleanupStoreKey] = runtimeCleanup;
 
-	const { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs } = createAsyncJobTracker(pi, state, ASYNC_DIR, {
+	const { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs } = createAsyncJobTracker(pi, state, DIRS.async, {
 		widgetEnabled: asyncWidgetEnabled,
 	});
 	let executorExecute: ((id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((r: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>) | undefined;

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -11,8 +11,7 @@ import {
 	type AsyncJobStep,
 	type Details,
 	type SubagentState,
-	ASYNC_DIR,
-	RESULTS_DIR,
+	DIRS,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_PROCESS_TERMINAL_EVENT,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
@@ -468,8 +467,8 @@ function stopAsyncRun(
 ): { runId: string; asyncDir: string; previousState: string; state: "stopping"; message: string } {
 	const target = normalizeTargetParams(params, "stop");
 	assertSubagentParams({ action: "status", ...target }, "RPC stop target params");
-	const asyncDirRoot = options.asyncDirRoot ?? ASYNC_DIR;
-	const resultsDir = options.resultsDir ?? RESULTS_DIR;
+	const asyncDirRoot = options.asyncDirRoot ?? DIRS.async;
+	const resultsDir = options.resultsDir ?? DIRS.results;
 	let location;
 	try {
 		location = resolveAsyncRunLocation(target, asyncDirRoot, resultsDir);

--- a/src/inspectors/herdr/actions.ts
+++ b/src/inspectors/herdr/actions.ts
@@ -7,7 +7,7 @@ import { listMissions, missionRecordPath, resolveMissionStoreLocation } from "..
 import type { MissionStoreConfig } from "../../missions/types.ts";
 import { resolveAuthorityDecision, type AuthorityPolicyConfig } from "../../policy/authority.ts";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
-import { ASYNC_DIR, RESULTS_DIR, type Details, type SubagentState } from "../../shared/types.ts";
+import { DIRS, type Details, type SubagentState } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { resolveSubagentRunId } from "../../runs/background/run-id-resolver.ts";
 import { createHerdrClient, detectHerdr, type HerdrClient, type HerdrErrorCode, type HerdrResult } from "./client.ts";
@@ -122,7 +122,7 @@ function isTrustedAsyncDir(asyncDir: string, deps: InspectorDeps): boolean {
 			try { return fs.realpathSync(job.asyncDir) === realDir; } catch { return false; }
 		});
 		if (registered) return true;
-		const root = deps.asyncDirRoot ?? ASYNC_DIR;
+		const root = deps.asyncDirRoot ?? DIRS.async;
 		if (!fs.existsSync(root) || !pathWithin(root, asyncDir)) return false;
 		return pathWithin(fs.realpathSync(root), realDir);
 	} catch {
@@ -142,7 +142,7 @@ function resolveAsyncTarget(params: InspectorParams, deps: InspectorDeps): { run
 	}
 	if (!requestedId) return { error: "Herdr inspector actions require id or dir." };
 	try {
-		const resolved = resolveSubagentRunId(requestedId, { state: deps.state, asyncDirRoot: deps.asyncDirRoot ?? ASYNC_DIR, resultsDir: deps.resultsDir ?? RESULTS_DIR });
+		const resolved = resolveSubagentRunId(requestedId, { state: deps.state, asyncDirRoot: deps.asyncDirRoot ?? DIRS.async, resultsDir: deps.resultsDir ?? DIRS.results });
 		if (!resolved) return { error: `No subagent run found for '${requestedId}'.` };
 		if (resolved.kind !== "async" || !resolved.location.asyncDir) return { error: `Run '${resolved.id}' is not an inspectable async run with lifecycle artifacts.` };
 		return { runId: resolved.id, asyncDir: resolved.location.asyncDir };

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -43,8 +43,7 @@ import {
 	type SubagentRunMode,
 	type SteeringRecoveryDescriptor,
 	type UsageBudgetConfig,
-	ASYNC_DIR,
-	RESULTS_DIR,
+	DIRS,
 	SUBAGENT_ASYNC_STARTED_EVENT,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
 	TEMP_ROOT_DIR,
@@ -924,7 +923,7 @@ export function executeAsyncChain(
 	const nestedAddress = inheritedNestedRoute ? resolveNestedParentAddressFromEnv() : undefined;
 	const asyncDir = inheritedNestedRoute
 		? path.join(TEMP_ROOT_DIR, "nested-subagent-runs", inheritedNestedRoute.rootRunId, id)
-		: path.join(ASYNC_DIR, id);
+		: path.join(DIRS.async, id);
 	try {
 		fs.mkdirSync(asyncDir, { recursive: true });
 	} catch (error) {
@@ -995,7 +994,7 @@ export function executeAsyncChain(
 			{
 				id,
 				steps,
-				resultPath: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : path.join(RESULTS_DIR, `${id}.json`),
+				resultPath: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : path.join(DIRS.results, `${id}.json`),
 				cwd: runnerCwd,
 				placeholder: "{previous}",
 				maxOutput,
@@ -1209,7 +1208,7 @@ export function executeAsyncSingle(
 	const nestedAddress = inheritedNestedRoute ? resolveNestedParentAddressFromEnv() : undefined;
 	const asyncDir = inheritedNestedRoute
 		? path.join(TEMP_ROOT_DIR, "nested-subagent-runs", inheritedNestedRoute.rootRunId, id)
-		: path.join(ASYNC_DIR, id);
+		: path.join(DIRS.async, id);
 	try {
 		fs.mkdirSync(asyncDir, { recursive: true });
 	} catch (error) {
@@ -1382,7 +1381,7 @@ export function executeAsyncSingle(
 						...(resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}),
 					},
 				],
-				resultPath: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : path.join(RESULTS_DIR, `${id}.json`),
+				resultPath: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : path.join(DIRS.results, `${id}.json`),
 				cwd: runnerCwd,
 				placeholder: "{previous}",
 				maxOutput,

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -10,7 +10,7 @@ import {
 	type SteeringNotice,
 	type SubagentState,
 	POLL_INTERVAL_MS,
-	RESULTS_DIR,
+	DIRS,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_STEERING_NOTICE_EVENT,
@@ -54,7 +54,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 } {
 	const completionRetentionMs = options.completionRetentionMs ?? 10000;
 	const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
-	const resultsDir = options.resultsDir ?? RESULTS_DIR;
+	const resultsDir = options.resultsDir ?? DIRS.results;
 	const steeringNoticeSeen = new Map<string, number>();
 	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
 		renderWidget(ctx, options.widgetEnabled === false ? [] : jobs);

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ASYNC_DIR, RESULTS_DIR, type AcceptanceInput, type AsyncStatus, type SteeringRecoveryDescriptor } from "../../shared/types.ts";
+import { DIRS, type AcceptanceInput, type AsyncStatus, type SteeringRecoveryDescriptor } from "../../shared/types.ts";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { validateAcceptanceInput } from "../shared/acceptance.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
@@ -381,8 +381,8 @@ function validateResumeSessionFile(runId: string, sessionFile: string): string {
 }
 
 export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncResumeDeps = {}, options: AsyncResumeOptions = {}): AsyncResumeTarget {
-	const asyncDirRoot = deps.asyncDirRoot ?? ASYNC_DIR;
-	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
+	const asyncDirRoot = deps.asyncDirRoot ?? DIRS.async;
+	const resultsDir = deps.resultsDir ?? DIRS.results;
 	const requireSessionFile = options.requireSessionFile ?? true;
 	const location = resolveAsyncRunLocation(params, asyncDirRoot, resultsDir);
 	if (!location.asyncDir && !location.resultPath) {

--- a/src/runs/background/auto-drain.ts
+++ b/src/runs/background/auto-drain.ts
@@ -1,6 +1,6 @@
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { snapshotBackgroundWork } from "../../api/background-work.ts";
-import { ASYNC_DIR, RESULTS_DIR, type Details, type SubagentState } from "../../shared/types.ts";
+import { DIRS, type Details, type SubagentState } from "../../shared/types.ts";
 import { listAsyncRuns } from "./async-status.ts";
 import { waitForSubagents, type SubagentWaitDeps, type SubagentWaitParams, type WaitEventBus } from "./subagent-wait.ts";
 
@@ -24,10 +24,10 @@ function resultText(value: AgentToolResult<Details>): string {
 }
 
 function hasOutstandingWork(sessionId: string, nowMs: number): boolean {
-	const asyncRuns = listAsyncRuns(ASYNC_DIR, {
+	const asyncRuns = listAsyncRuns(DIRS.async, {
 		states: ["queued", "running"],
 		sessionId,
-		resultsDir: RESULTS_DIR,
+		resultsDir: DIRS.results,
 		now: () => nowMs,
 	});
 	return asyncRuns.length > 0 || snapshotBackgroundWork(sessionId, nowMs).items.length > 0;

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -4,8 +4,7 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../../shared/formatters.ts";
 import { formatActivityLabel } from "../../shared/status-format.ts";
 import {
-	ASYNC_DIR,
-	RESULTS_DIR,
+	DIRS,
 	type ActivityState,
 	type AsyncJobStep,
 	type AsyncStatus,
@@ -321,10 +320,10 @@ export function inspectSubagentFleet(_params: FleetViewParams, deps: FleetViewDe
 
 	let asyncRuns: AsyncRunSummary[];
 	try {
-		asyncRuns = listAsyncRuns(deps.asyncDirRoot ?? ASYNC_DIR, {
+		asyncRuns = listAsyncRuns(deps.asyncDirRoot ?? DIRS.async, {
 			states: ["queued", "running"],
 			sessionId: deps.state?.currentSessionId ?? undefined,
-			resultsDir: deps.resultsDir ?? RESULTS_DIR,
+			resultsDir: deps.resultsDir ?? DIRS.results,
 			kill: deps.kill,
 			now: deps.now,
 		});

--- a/src/runs/background/run-id-resolver.ts
+++ b/src/runs/background/run-id-resolver.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ASYNC_DIR, RESULTS_DIR, type SubagentState } from "../../shared/types.ts";
+import { DIRS, type SubagentState } from "../../shared/types.ts";
 import { findAsyncRunPrefixMatches, type AsyncRunLocation } from "./async-resume.ts";
 import { assertSafeNestedId, findNestedRunMatchesById, type NestedRoute, type NestedRunMatch, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 
@@ -66,8 +66,8 @@ function asyncPrefixMatches(prefix: string, asyncDirRoot: string, resultsDir: st
 
 export function resolveSubagentRunId(id: string, deps: ResolveSubagentRunIdDeps = {}): ResolvedSubagentRunId | undefined {
 	assertSafeNestedId("id", id);
-	const asyncDirRoot = deps.asyncDirRoot ?? ASYNC_DIR;
-	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
+	const asyncDirRoot = deps.asyncDirRoot ?? DIRS.async;
+	const resultsDir = deps.resultsDir ?? DIRS.results;
 
 	const nestedScope = deps.nested ?? nestedScopeFromState(deps.state);
 	if (hasExactForegroundId(deps.state, id)) return { kind: "foreground", id };

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -6,7 +6,7 @@ import { formatAsyncResultTranscript, formatAsyncRunTranscript, formatNestedRunT
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { formatModelThinking } from "../../shared/formatters.ts";
 import { formatActivityLabel } from "../../shared/status-format.ts";
-import { ASYNC_DIR, RESULTS_DIR, type AsyncStatus, type Details, type ForegroundResumeRun, type NestedRunSummary, type SteeringStatus, type SubagentState } from "../../shared/types.ts";
+import { DIRS, type AsyncStatus, type Details, type ForegroundResumeRun, type NestedRunSummary, type SteeringStatus, type SubagentState } from "../../shared/types.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { resolveSubagentResultStatus } from "../../intercom/result-intercom.ts";
 import { readProcessTerminal, sanitizeProcessTerminal } from "./process-terminal.ts";
@@ -209,8 +209,8 @@ function formatNestedExactStatus(rootRunId: string, run: NestedRunSummary): stri
 }
 
 export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDeps = {}): AgentToolResult<Details> {
-	const asyncDirRoot = deps.asyncDirRoot ?? ASYNC_DIR;
-	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
+	const asyncDirRoot = deps.asyncDirRoot ?? DIRS.async;
+	const resultsDir = deps.resultsDir ?? DIRS.results;
 	const currentSessionId = deps.state?.currentSessionId ?? undefined;
 	if (params.view && params.view !== "fleet" && params.view !== "transcript") {
 		return {

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
-import { RESULTS_DIR, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSummary, type SubagentRunMode } from "../../shared/types.ts";
+import { DIRS, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSummary, type SubagentRunMode } from "../../shared/types.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { normalizeParallelGroups } from "./parallel-groups.ts";
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent, type NestedRoute } from "../shared/nested-events.ts";
@@ -308,7 +308,7 @@ export function reconcileNestedAsyncDescendants(route: NestedRoute, options: Rec
 		if (!asyncDir) continue;
 		const result = reconcileAsyncRun(asyncDir, {
 			...options,
-			resultsDir: path.join(options.resultsDir ?? RESULTS_DIR, "nested", route.rootRunId),
+			resultsDir: path.join(options.resultsDir ?? DIRS.results, "nested", route.rootRunId),
 		});
 		const status = result.status;
 		if (!status) continue;
@@ -360,7 +360,7 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 	}
 
 	const runId = effectiveStatus.runId || path.basename(asyncDir);
-	const resultPath = path.join(options.resultsDir ?? RESULTS_DIR, `${runId}.json`);
+	const resultPath = path.join(options.resultsDir ?? DIRS.results, `${runId}.json`);
 	if (fs.existsSync(resultPath)) {
 		const terminalStatus = effectiveStatus.state === "running" || effectiveStatus.state === "queued"
 			? terminalStatusFromResult(effectiveStatus, resultPath, now)

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -48,9 +48,8 @@ import {
 } from "../../api/background-work.ts";
 import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 import {
-	ASYNC_DIR,
+	DIRS,
 	INTERCOM_DETACH_REQUEST_EVENT,
-	RESULTS_DIR,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_FOREGROUND_COMPLETE_EVENT,
 	SUBAGENT_CONTROL_EVENT,
@@ -253,8 +252,8 @@ function backgroundWorkForSession(deps: SubagentWaitDeps, nowMs: number): Backgr
 
 /** Queued/running runs from this session, including runs that need attention. */
 function activeRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps): AsyncRunSummary[] {
-	const asyncDirRoot = deps.asyncDirRoot ?? ASYNC_DIR;
-	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
+	const asyncDirRoot = deps.asyncDirRoot ?? DIRS.async;
+	const resultsDir = deps.resultsDir ?? DIRS.results;
 	const runs = listAsyncRuns(asyncDirRoot, {
 		states: [...ACTIVE_STATES],
 		sessionId: deps.state.currentSessionId ?? undefined,
@@ -273,8 +272,8 @@ function attentionRunsForSession(params: SubagentWaitParams, deps: SubagentWaitD
 
 /** All runs (any state) for this session, for the final summary. */
 function allRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps): AsyncRunSummary[] {
-	const asyncDirRoot = deps.asyncDirRoot ?? ASYNC_DIR;
-	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
+	const asyncDirRoot = deps.asyncDirRoot ?? DIRS.async;
+	const resultsDir = deps.resultsDir ?? DIRS.results;
 	const runs = listAsyncRuns(asyncDirRoot, {
 		sessionId: deps.state.currentSessionId ?? undefined,
 		resultsDir,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -123,10 +123,9 @@ import {
 	type UsageBudgetConfig,
 	type SubagentRunMode,
 	type SubagentState,
-	ASYNC_DIR,
+	DIRS,
 	DEFAULT_ARTIFACT_CONFIG,
 	DEFAULT_FORK_PREAMBLE,
-	RESULTS_DIR,
 	SUBAGENT_ACTIONS,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
@@ -1080,7 +1079,7 @@ function directNestedAsyncInterrupt(target: ResolvedSubagentRunId & { kind: "nes
 	const run = target.match.run;
 	const asyncDir = resolveNestedAsyncDir(target.match.rootRunId, run);
 	if (!asyncDir) return undefined;
-	const status = reconcileAsyncRun(asyncDir, { resultsDir: path.join(RESULTS_DIR, "nested", target.match.rootRunId) }).status;
+	const status = reconcileAsyncRun(asyncDir, { resultsDir: path.join(DIRS.results, "nested", target.match.rootRunId) }).status;
 	const pid = typeof status?.pid === "number" && status.pid > 0 ? status.pid : run.pid;
 	if (!status || status.state !== "running" || typeof pid !== "number" || pid <= 0) return undefined;
 	try {
@@ -1096,7 +1095,7 @@ async function directNestedAsyncSteer(input: { target: ResolvedSubagentRunId & {
 	const run = input.target.match.run;
 	const asyncDir = resolveNestedAsyncDir(input.target.match.rootRunId, run);
 	if (!asyncDir) return undefined;
-	const status = reconcileAsyncRun(asyncDir, { resultsDir: path.join(RESULTS_DIR, "nested", input.target.match.rootRunId) }).status;
+	const status = reconcileAsyncRun(asyncDir, { resultsDir: path.join(DIRS.results, "nested", input.target.match.rootRunId) }).status;
 	if (!status || (status.state !== "running" && status.state !== "queued")) return undefined;
 	const steps = status.steps ?? [];
 	if (input.index !== undefined) {
@@ -1317,8 +1316,8 @@ async function resumeAsyncRun(input: {
 			goal,
 			attachRoot: {
 				runId: target.runId,
-				asyncDir: target.asyncDir ?? path.join(ASYNC_DIR, target.runId),
-				resultPath: resolveAsyncRootResultPath(RESULTS_DIR, target.runId),
+				asyncDir: target.asyncDir ?? path.join(DIRS.async, target.runId),
+				resultPath: resolveAsyncRootResultPath(DIRS.results, target.runId),
 				index: target.index,
 				agent: target.agent,
 				label: `Attached ${target.runId}`,
@@ -3989,7 +3988,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						};
 					}
 					const location = paramsWithResolvedCwd.dir
-						? resolveAsyncRunLocation(paramsWithResolvedCwd, ASYNC_DIR, RESULTS_DIR)
+						? resolveAsyncRunLocation(paramsWithResolvedCwd, DIRS.async, DIRS.results)
 						: resolved?.kind === "async"
 							? resolved.location
 							: undefined;
@@ -4024,7 +4023,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				const targetRunId = paramsWithResolvedCwd.runId ?? paramsWithResolvedCwd.id;
 				if (paramsWithResolvedCwd.dir) {
 					try {
-						const location = resolveAsyncRunLocation(paramsWithResolvedCwd, ASYNC_DIR, RESULTS_DIR);
+						const location = resolveAsyncRunLocation(paramsWithResolvedCwd, DIRS.async, DIRS.results);
 						const runId = location.resolvedId ?? targetRunId ?? path.basename(location.asyncDir ?? paramsWithResolvedCwd.dir);
 						return steerAsyncRun({
 							state: deps.state,
@@ -4100,7 +4099,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				let resolved: ResolvedSubagentRunId | undefined;
 				if (paramsWithResolvedCwd.dir) {
 					try {
-						const location = resolveAsyncRunLocation(paramsWithResolvedCwd, ASYNC_DIR, RESULTS_DIR);
+						const location = resolveAsyncRunLocation(paramsWithResolvedCwd, DIRS.async, DIRS.results);
 						return stopAsyncRun(deps.state, location.resolvedId ?? targetRunId ?? path.basename(location.asyncDir ?? paramsWithResolvedCwd.dir), deps.kill, location);
 					} catch (error) {
 						const text = error instanceof Error ? error.message : String(error);

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -2,8 +2,7 @@ import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import {
-	ASYNC_DIR,
-	RESULTS_DIR,
+	DIRS,
 	TEMP_ROOT_DIR,
 	type AsyncJobState,
 	type AsyncStatus,
@@ -1012,11 +1011,11 @@ export function nestedArtifactEnv(rootRunId: string, parentRunId: string): Recor
 
 export function isTopLevelAsyncDir(asyncDir: string): boolean {
 	const resolved = path.resolve(asyncDir);
-	return containedPath(ASYNC_DIR, resolved) && !containedPath(path.join(TEMP_ROOT_DIR, "nested-subagent-runs"), resolved);
+	return containedPath(DIRS.async, resolved) && !containedPath(path.join(TEMP_ROOT_DIR, "nested-subagent-runs"), resolved);
 }
 
 export function nestedResultsPath(rootRunId: string, id: string): string {
 	assertSafeId("rootRunId", rootRunId);
 	assertSafeId("id", id);
-	return path.join(RESULTS_DIR, "nested", rootRunId, `${id}.json`);
+	return path.join(DIRS.results, "nested", rootRunId, `${id}.json`);
 }

--- a/src/shared/accessible-dir.ts
+++ b/src/shared/accessible-dir.ts
@@ -8,18 +8,40 @@ type AccessibleDirOptions = {
 	retryDirectoryErrors?: boolean;
 	retryDelaysMs?: readonly number[];
 	wait?: (delayMs: number) => void;
+	pid?: number;
 };
 
-export function ensureAccessibleDir(dirPath: string, options: AccessibleDirOptions = {}): void {
+export function ensureAccessibleDir(dirPath: string, options: AccessibleDirOptions = {}): string {
 	const fsImpl = options.fs ?? fs;
+	const pid = options.pid ?? process.pid;
 	const retryDirectoryErrors = options.retryDirectoryErrors ?? process.platform === "win32";
 	const retryDelaysMs = retryDirectoryErrors ? options.retryDelaysMs ?? DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS : [];
 	const wait = options.wait ?? waitForFileSystemRetry;
 
-	runFileSystemOperationWithRetry(() => {
-		fsImpl.mkdirSync(dirPath, { recursive: true });
-	}, { retryDelaysMs, wait });
-	runFileSystemOperationWithRetry(() => {
-		fsImpl.accessSync(dirPath, fs.constants.R_OK | fs.constants.W_OK);
-	}, { retryDelaysMs, wait });
+	const mkdirWithRetry = (target: string): void => {
+		runFileSystemOperationWithRetry(() => {
+			fsImpl.mkdirSync(target, { recursive: true });
+		}, { retryDelaysMs, wait });
+	};
+	const accessWithRetry = (target: string): void => {
+		runFileSystemOperationWithRetry(() => {
+			fsImpl.accessSync(target, fs.constants.R_OK | fs.constants.W_OK);
+		}, { retryDelaysMs, wait });
+	};
+	const fallbackPath = (): string => {
+		const fallback = `${dirPath}-${pid}`;
+		mkdirWithRetry(fallback);
+		accessWithRetry(fallback);
+		return fallback;
+	};
+
+	try {
+		mkdirWithRetry(dirPath);
+		accessWithRetry(dirPath);
+		return dirPath;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException | undefined)?.code;
+		if (code !== "EPERM" && code !== "EACCES") throw error;
+		return fallbackPath();
+	}
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1738,6 +1738,13 @@ export const RESULTS_DIR = path.join(TEMP_ROOT_DIR, "async-subagent-results");
 export const ASYNC_DIR = path.join(TEMP_ROOT_DIR, "async-subagent-runs");
 export const CHAIN_RUNS_DIR = path.join(TEMP_ROOT_DIR, "chain-runs");
 export const TEMP_ARTIFACTS_DIR = path.join(TEMP_ROOT_DIR, "artifacts");
+
+export const DIRS = {
+	results: RESULTS_DIR,
+	async: ASYNC_DIR,
+	chain: CHAIN_RUNS_DIR,
+	artifacts: TEMP_ARTIFACTS_DIR,
+};
 export const WIDGET_KEY = "subagent-async";
 export const SLASH_RESULT_TYPE = "subagent-slash-result";
 export const SLASH_TEXT_RESULT_TYPE = "subagent-slash-text-result";

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -41,7 +41,7 @@ import {
 	SLASH_SUBAGENT_RESPONSE_EVENT,
 	SLASH_SUBAGENT_STARTED_EVENT,
 	SLASH_SUBAGENT_UPDATE_EVENT,
-	ASYNC_DIR,
+	DIRS,
 	type Details,
 	type JsonSchemaObject,
 	type SingleResult,
@@ -285,7 +285,7 @@ function scheduledStopTargets(ctx: ExtensionContext, state: SubagentState): Stop
 
 function discoverStopTargets(ctx: ExtensionContext, state: SubagentState): StopSelectorTarget[] {
 	const sessionId = state.currentSessionId ?? ctx.sessionManager.getSessionId() ?? undefined;
-	const asyncTargets = listAsyncRuns(ASYNC_DIR, {
+	const asyncTargets = listAsyncRuns(DIRS.async, {
 		states: ["queued", "running"],
 		...(sessionId ? { sessionId } : {}),
 	}).map(formatAsyncStopTarget);

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -5,7 +5,7 @@ import { getMarkdownTheme, type ExtensionContext } from "@earendil-works/pi-codi
 import { Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type MarkdownTheme } from "@earendil-works/pi-tui";
 import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../shared/formatters.ts";
-import { RESULTS_DIR, type AsyncJobState, type Details, type ForegroundChildControl, type ForegroundResumeChild, type ForegroundResumeRun, type ForegroundRunControl, type SubagentState } from "../shared/types.ts";
+import { DIRS, type AsyncJobState, type Details, type ForegroundChildControl, type ForegroundResumeChild, type ForegroundResumeRun, type ForegroundRunControl, type SubagentState } from "../shared/types.ts";
 import { readStatus } from "../shared/utils.ts";
 import { formatAsyncRunTranscript } from "../runs/background/fleet-view.ts";
 import { listAsyncRuns, type AsyncRunSummary } from "../runs/background/async-status.ts";
@@ -169,7 +169,7 @@ export function collectFleetSnapshot(
 			runs = listAsyncRuns(options.asyncDirRoot, {
 				...(state.currentSessionId ? { sessionId: state.currentSessionId } : {}),
 				limit: options.limit ?? MAX_RECENT_ASYNC_RUNS,
-				resultsDir: options.resultsDir ?? RESULTS_DIR,
+				resultsDir: options.resultsDir ?? DIRS.results,
 				reconcile: false,
 			});
 		} else {

--- a/test/unit/ensure-accessible-dir.test.ts
+++ b/test/unit/ensure-accessible-dir.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { ensureAccessibleDir } from "../../src/shared/accessible-dir.ts";
+import { DIRS } from "../../src/shared/types.ts";
+
+class FakeFs {
+	created: string[] = [];
+	blockedMkdir = new Set<string>();
+	blockedAccess = new Set<string>();
+
+	mkdirSync(dirPath: string): void {
+		if (this.blockedMkdir.has(dirPath)) {
+			const error = new Error("mkdir blocked") as NodeJS.ErrnoException;
+			error.code = "EPERM";
+			throw error;
+		}
+		this.created.push(dirPath);
+	}
+
+	accessSync(dirPath: string): void {
+		if (this.blockedAccess.has(dirPath)) {
+			const error = new Error("access blocked") as NodeJS.ErrnoException;
+			error.code = "EPERM";
+			throw error;
+		}
+	}
+}
+
+function fakeOptions(fakeFs: FakeFs) {
+	return {
+		fs: fakeFs,
+		pid: 12345,
+		retryDirectoryErrors: true,
+		retryDelaysMs: [] as readonly number[],
+		wait: () => {},
+	};
+}
+
+describe("ensureAccessibleDir", () => {
+	it("returns the requested path when it is usable", () => {
+		const fakeFs = new FakeFs();
+		const dirPath = "/tmp/pi-subagents-ok/results";
+
+		const result = ensureAccessibleDir(dirPath, fakeOptions(fakeFs));
+
+		assert.equal(result, dirPath);
+		assert.deepEqual(fakeFs.created, [dirPath]);
+	});
+
+	it("falls back to a pid-scoped sibling when mkdir is persistently blocked", () => {
+		const fakeFs = new FakeFs();
+		const dirPath = "/tmp/pi-subagents-mkdir-eperm/results";
+		fakeFs.blockedMkdir.add(dirPath);
+
+		const result = ensureAccessibleDir(dirPath, fakeOptions(fakeFs));
+
+		assert.equal(result, `${dirPath}-12345`);
+		assert.deepEqual(fakeFs.created, [`${dirPath}-12345`]);
+	});
+
+	it("falls back to a pid-scoped sibling when access is persistently blocked", () => {
+		const fakeFs = new FakeFs();
+		const dirPath = "/tmp/pi-subagents-access-eperm/results";
+		fakeFs.blockedAccess.add(dirPath);
+
+		const result = ensureAccessibleDir(dirPath, fakeOptions(fakeFs));
+
+		assert.equal(result, `${dirPath}-12345`);
+		assert.deepEqual(fakeFs.created, [dirPath, `${dirPath}-12345`]);
+	});
+
+	it("does not delete existing primary directory contents when falling back", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-accessible-dir-"));
+		try {
+			const dirPath = path.join(root, "async-subagent-runs");
+			const statusPath = path.join(dirPath, "run-1", "status.json");
+			fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+			fs.writeFileSync(statusPath, "{}", "utf-8");
+
+			const fsImpl = {
+				mkdirSync: fs.mkdirSync,
+				accessSync(target: string, mode?: number): void {
+					if (target === dirPath) {
+						const error = new Error("access blocked") as NodeJS.ErrnoException;
+						error.code = "EPERM";
+						throw error;
+					}
+					fs.accessSync(target, mode);
+				},
+			};
+
+			const result = ensureAccessibleDir(dirPath, {
+				fs: fsImpl,
+				pid: 12345,
+				retryDirectoryErrors: true,
+				retryDelaysMs: [] as readonly number[],
+				wait: () => {},
+			});
+
+			assert.equal(result, `${dirPath}-12345`);
+			assert.equal(fs.readFileSync(statusPath, "utf-8"), "{}");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("DIRS", () => {
+	it("allows runtime reassignment for live async and results paths", () => {
+		const originalResults = DIRS.results;
+		const originalAsync = DIRS.async;
+		try {
+			DIRS.results = "/tmp/fallback-results";
+			DIRS.async = "/tmp/fallback-async";
+			assert.equal(DIRS.results, "/tmp/fallback-results");
+			assert.equal(DIRS.async, "/tmp/fallback-async");
+		} finally {
+			DIRS.results = originalResults;
+			DIRS.async = originalAsync;
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Replacement for #734. This keeps the useful Windows `EPERM`/`EACCES` fallback approach, but avoids deleting the existing shared async result/run roots during extension load.

- make `ensureAccessibleDir` return the usable directory path
- fall back to pid-scoped sibling result/run directories without removing the blocked primary directory
- route live async/results consumers through mutable `DIRS` paths, including Herdr inspector paths on current `main`
- keep `doctor` filesystem checks pointed at the live fallback-adjusted paths
- preserve contributor credit to @franktheglock for #734 in the changelog

## Validation

- `git diff --check`
- `node --experimental-strip-types --test test/unit/ensure-accessible-dir.test.ts`
- `node --experimental-strip-types --check` on all modified TypeScript files
- `npm run test:unit` had one temp cleanup race in `test/unit/run-status.test.ts`; rerunning that exact file passed with 28/28 tests.
