### PR TITLE
fix: preserve terminal turn-budget completions

### DIFF
--- a/src/runs/shared/turn-budget.ts
+++ b/src/runs/shared/turn-budget.ts
@@ -91,8 +91,7 @@ export function turnBudgetDecision(
 	enforceHardLimit = false,
 ): "continue" | "defer" | "abort" {
 	const hardLimit = budget.maxTurns + budget.graceTurns;
-	if (turnCount < hardLimit) return "continue";
+	if (terminalAssistantStop || turnCount < hardLimit) return "continue";
 	if (toolWorkActiveOrStarting && !enforceHardLimit) return "defer";
-	if (turnCount === hardLimit && terminalAssistantStop) return "continue";
 	return "abort";
 }

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -1186,7 +1186,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(status.steps?.[0]?.turnBudget?.turnCount, 2);
 	});
 
-	it("async turn budget hard-aborts beyond the final grace turn at a safe assistant boundary", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+	it("async turn budget preserves a clean terminal response beyond the final grace turn", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			jsonl: [
 				mockAssistantMessage("working before wrap-up", "tool_use"),
@@ -1209,24 +1209,22 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const resultPath = await waitForAsyncResultFile(id, 10_000);
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
 		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
-		assert.equal(payload.success, false);
-		assert.equal(payload.state, "failed");
-		assert.equal(payload.exitCode, 1);
-		assert.equal(payload.turnBudgetExceeded, true);
+		assert.equal(payload.success, true);
+		assert.equal(payload.state, "complete");
+		assert.equal(payload.exitCode, 0);
+		assert.equal(payload.turnBudgetExceeded, undefined);
 		assert.equal(payload.wrapUpRequested, true);
-		assert.equal(payload.turnBudget?.outcome, "exceeded");
+		assert.equal(payload.turnBudget?.outcome, "wrap-up-requested");
 		assert.equal(payload.turnBudget?.turnCount, 3);
-		assert.equal(payload.turnBudget?.exceededAtTurn, 3);
-		assert.equal(payload.results[0]?.turnBudgetExceeded, true);
-		assert.match(payload.results[0]?.output ?? "", /Partial output before turn-budget abort:/);
+		assert.equal(payload.results[0]?.turnBudgetExceeded, undefined);
 		assert.match(payload.results[0]?.output ?? "", /safe assistant boundary after tool work/);
-		assert.equal(status.state, "failed");
-		assert.equal(status.turnBudgetExceeded, true);
-		assert.equal(status.steps?.[0]?.turnBudgetExceeded, true);
-		assert.equal(status.steps?.[0]?.turnBudget?.outcome, "exceeded");
+		assert.equal(status.state, "complete");
+		assert.equal(status.turnBudgetExceeded, undefined);
+		assert.equal(status.steps?.[0]?.turnBudgetExceeded, undefined);
+		assert.equal(status.steps?.[0]?.turnBudget?.outcome, "wrap-up-requested");
 	});
 
-	it("defers an async hard turn limit through active tool work and aborts at the next assistant boundary", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+	it("preserves an async clean completion after turn-budget work defers", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			steps: [
 				{
@@ -1267,15 +1265,15 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const resultPath = await waitForAsyncResultFile(id, 10_000);
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
 		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
-		assert.equal(payload.state, "failed");
-		assert.equal(payload.turnBudgetExceeded, true);
-		assert.equal(payload.turnBudget?.outcome, "exceeded");
+		assert.equal(payload.state, "complete");
+		assert.equal(payload.turnBudgetExceeded, undefined);
+		assert.equal(payload.turnBudget?.outcome, "wrap-up-requested");
 		assert.equal(payload.turnBudget?.turnCount, 2);
-		assert.equal(payload.results[0]?.turnBudgetExceeded, true);
+		assert.equal(payload.results[0]?.turnBudgetExceeded, undefined);
 		assert.match(payload.results[0]?.output ?? "", /safe assistant boundary reached/);
-		assert.equal(status.state, "failed");
-		assert.equal(status.turnBudgetExceeded, true);
-		assert.equal(status.steps?.[0]?.turnBudget?.outcome, "exceeded");
+		assert.equal(status.state, "complete");
+		assert.equal(status.turnBudgetExceeded, undefined);
+		assert.equal(status.steps?.[0]?.turnBudget?.outcome, "wrap-up-requested");
 	});
 
 	it("lets timeout delivery preempt deferred turn-budget termination", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -3207,7 +3207,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.finalOutput ?? "", /final wrapped output/);
 	});
 
-	it("defers a foreground hard turn limit through active tool work and aborts at the next assistant boundary", async () => {
+	it("preserves a clean foreground completion after turn-budget work defers", async () => {
 		mockPi.onCall({
 			steps: [
 				{
@@ -3257,8 +3257,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(duringTool.turnBudgetExceeded, undefined);
 		assert.equal(duringTool.error, undefined);
 		assert.equal(duringTool.status, "running");
-		assert.equal(result.turnBudgetExceeded, true);
-		assert.equal(result.turnBudget?.outcome, "exceeded");
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.turnBudgetExceeded, undefined);
+		assert.equal(result.turnBudget?.outcome, "wrap-up-requested");
 		assert.equal(result.turnBudget?.turnCount, 2);
 		assert.match(result.finalOutput ?? "", /safe assistant boundary reached/);
 		assert.ok(result.messages?.some((message) => message.role === "toolResult" && JSON.stringify(message.content).includes("build completed")));

--- a/test/unit/turn-budget.test.ts
+++ b/test/unit/turn-budget.test.ts
@@ -178,9 +178,10 @@ describe("turn-budget module", () => {
 	});
 
 	describe("turnBudgetDecision", () => {
-		it("continues below the hard limit and for a terminal response on the final grace turn", () => {
+		it("continues for a clean terminal response even after the hard limit", () => {
 			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 3, false, false), "continue");
 			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 4, true, false), "continue");
+			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 5, true, false), "continue");
 		});
 
 		it("defers termination when the hard-limit assistant response starts tool work", () => {
@@ -193,9 +194,9 @@ describe("turn-budget module", () => {
 			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 4, true, true, true), "continue");
 		});
 
-		it("aborts at the next safe assistant boundary", () => {
+		it("aborts non-terminal work at the next safe assistant boundary", () => {
 			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 4, false, false), "abort");
-			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 5, true, false), "abort");
+			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 5, false, false), "abort");
 		});
 
 		it("allows a terminal response at the soft limit when grace turns are zero", () => {

--- a/test/unit/turn-budget.test.ts
+++ b/test/unit/turn-budget.test.ts
@@ -189,9 +189,10 @@ describe("turn-budget module", () => {
 			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 5, false, true), "defer");
 		});
 
-		it("enforces the hard limit for strict foreground delegation but allows the exact terminal boundary", () => {
+		it("enforces the hard limit for strict foreground delegation but allows terminal completion", () => {
 			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 4, false, true, true), "abort");
 			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 4, true, true, true), "continue");
+			assert.equal(turnBudgetDecision(budget({ maxTurns: 3, graceTurns: 1 }), 5, true, true, true), "continue");
 		});
 
 		it("aborts non-terminal work at the next safe assistant boundary", () => {


### PR DESCRIPTION
A clean terminal assistant response could be marked turn-budget-exceeded when it arrived after the hard boundary. The budget decision now preserves a terminal response while retaining aborts for non-terminal work.

Tests cover foreground and async terminal completion after deferred work, plus the decision boundary.