### PR TITLE
feat(profiles): support thinking/fallbackModels and preserve unrelated subagents settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added automatic Herdr status metadata for active async runs, including reload recovery, needs-attention blocking, and a forward-compatible `herdr:busy` sibling event for semantic working state. Thanks to @magoz for #730.
 - Added optional Herdr 0.7.5+ drill-in inspector panes for async runs, with durable pane bindings, lifecycle/transcript/mission dashboards, FleetView opening, and steer/stop controls through the existing file control channel.
 - Added Herdr project panes so an orchestrator can open a project-rooted Pi session for substantial cross-codebase work.
+- Added optional `thinking` and `fallbackModels` fields to `/subagents` profile agent overrides, so a saved profile can pin reasoning effort and fallbacks (not just the model) — important for reasoning-sensitive models where the thinking level is load-bearing. Thanks to @dt-benedict for #741.
 
 ### Changed
 - Removed the public top-level `tasks[]`, `chain[]`, static parallel controls, and `/chain`, `/parallel`, and `/run-chain` commands; `workflowScript` is now the sole public multi-agent orchestration surface. `append-step` now accepts a control-only `step` object.
@@ -22,6 +23,7 @@
 ### Fixed
 - Count clear `git add`, `git commit`, and `git push` bash calls as implementation mutation attempts so workers that finalize pre-applied changes do not fail the completion guard.
 - Render structured-output-only children as useful JSON output instead of misleading `(no output)` summaries and empty output artifacts.
+- Preserved unrelated `subagents` settings (e.g. `disableBuiltins`, `modelScope`, `watchdog`) when applying a `/subagents` profile, instead of replacing the whole `subagents` object; a profile still owns the complete `agentOverrides` mapping. Also validate profile `thinking`, `fallbackModels`, and `disableBuiltins` fields. Thanks to @dt-benedict for #741.
 - Journaled managed worktree ownership before child execution so abrupt exits retain a manifest-backed cleanup path.
 - Made automatic mission persistence best-effort without weakening explicit mission requests, bounded terminal mission retention and stale global pointers, exposed auto missions without modifying structured JSON output, added authority-consistent manifest-backed preserved-worktree discard, and clarified the Herdr inspector/schema surface.
 - Recovered valid structured acceptance reports from unterminated explicit `acceptance-report` fences while retaining hard failures for malformed or invalid reports.

--- a/src/profiles/profiles.ts
+++ b/src/profiles/profiles.ts
@@ -18,11 +18,15 @@ export type RecommendedRoleTier = "cheap" | "medium" | "strong";
 
 interface ProfileAgentOverride {
 	model?: string;
+	thinking?: string | false;
+	fallbackModels?: string[] | false;
 }
 
 export interface SubagentProfileFile {
 	subagents: {
 		agentOverrides: Record<string, ProfileAgentOverride>;
+		disableBuiltins?: boolean;
+		[key: string]: unknown;
 	};
 }
 
@@ -130,10 +134,23 @@ function validateSubagentProfile(filePath: string, parsed: Record<string, unknow
 		if (!value || typeof value !== "object" || Array.isArray(value)) {
 			throw new Error(`Profile '${filePath}' has invalid override '${name}'; expected an object.`);
 		}
-		const model = (value as Record<string, unknown>).model;
+		const override = value as Record<string, unknown>;
+		const model = override.model;
 		if (model !== undefined && typeof model !== "string") {
 			throw new Error(`Profile '${filePath}' has invalid model for '${name}'; expected a string.`);
 		}
+		const thinking = override.thinking;
+		if (thinking !== undefined && thinking !== false && typeof thinking !== "string") {
+			throw new Error(`Profile '${filePath}' has invalid thinking for '${name}'; expected a string or false.`);
+		}
+		const fallbackModels = override.fallbackModels;
+		if (fallbackModels !== undefined && fallbackModels !== false && (!Array.isArray(fallbackModels) || fallbackModels.some((item) => typeof item !== "string"))) {
+			throw new Error(`Profile '${filePath}' has invalid fallbackModels for '${name}'; expected an array of strings or false.`);
+		}
+	}
+	const disableBuiltins = (subagents as Record<string, unknown>).disableBuiltins;
+	if (disableBuiltins !== undefined && typeof disableBuiltins !== "boolean") {
+		throw new Error(`Profile '${filePath}' has invalid subagents.disableBuiltins; expected a boolean.`);
 	}
 	return parsed as unknown as SubagentProfileFile;
 }
@@ -468,7 +485,16 @@ export function applySubagentProfile(name: string): { filePath: string; settings
 	const { filePath, profile } = readSubagentProfile(name);
 	const settingsPath = getUserSettingsPath();
 	const settings = readSettingsFile(settingsPath);
-	settings.subagents = profile.subagents;
+	const existing = settings.subagents && typeof settings.subagents === "object" && !Array.isArray(settings.subagents)
+		? settings.subagents as Record<string, unknown>
+		: {};
+	// A profile owns the complete agent mapping, but unrelated subagent settings
+	// (notably disableBuiltins, modelScope, watchdog, etc.) survive profile switches.
+	settings.subagents = {
+		...existing,
+		...profile.subagents,
+		agentOverrides: profile.subagents.agentOverrides,
+	};
 	writeJsonFile(settingsPath, settings);
 	return { filePath, settingsPath };
 }

--- a/test/unit/profiles.test.ts
+++ b/test/unit/profiles.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
+import { discoverAgents } from "../../src/agents/agents.ts";
 import {
 	applySubagentProfile,
 	checkSubagentProfile,
@@ -49,26 +50,91 @@ describe("profiles helpers", () => {
 		assert.equal(fs.existsSync(getSubagentProfilesDir()), true);
 	});
 
-	it("applies a saved profile by replacing only settings.subagents", () => {
+	it("applies a saved profile while preserving unrelated subagent settings", () => {
 		const profilesDir = getSubagentProfilesDir();
 		fs.mkdirSync(profilesDir, { recursive: true });
 		fs.writeFileSync(path.join(profilesDir, "openai-codex.quota.json"), JSON.stringify({
 			subagents: {
 				agentOverrides: {
-					scout: { model: "openai-codex/gpt-5.3-codex-spark" },
+					scout: {
+						model: "openai-codex/gpt-5.3-codex-spark",
+						thinking: "medium",
+						fallbackModels: ["openai-codex/gpt-5.4-mini"],
+					},
+					reviewer: { thinking: false, fallbackModels: false },
 				},
 			},
 		}, null, 2));
 		const settingsPath = path.join(homeDir, ".pi", "agent", "settings.json");
 		fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-		fs.writeFileSync(settingsPath, JSON.stringify({ defaultModel: "openai/gpt-5", subagents: { agentOverrides: { scout: { model: "old" } } } }, null, 2));
+		fs.writeFileSync(settingsPath, JSON.stringify({
+			defaultModel: "openai/gpt-5",
+			subagents: {
+				disableBuiltins: true,
+				modelScope: { enforce: true, allow: ["openai-codex/*"] },
+				agentOverrides: { scout: { model: "old" }, stale: { model: "remove-me" } },
+			},
+		}, null, 2));
 
 		const result = applySubagentProfile("openai-codex.quota");
 		const written = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
 		assert.equal(result.settingsPath, settingsPath);
 		assert.equal(result.filePath.endsWith("openai-codex.quota.json"), true);
 		assert.equal(written.defaultModel, "openai/gpt-5");
-		assert.equal(written.subagents.agentOverrides.scout.model, "openai-codex/gpt-5.3-codex-spark");
+		assert.equal(written.subagents.disableBuiltins, true);
+		assert.deepEqual(written.subagents.modelScope, { enforce: true, allow: ["openai-codex/*"] });
+		assert.deepEqual(written.subagents.agentOverrides, {
+			scout: {
+				model: "openai-codex/gpt-5.3-codex-spark",
+				thinking: "medium",
+				fallbackModels: ["openai-codex/gpt-5.4-mini"],
+			},
+			reviewer: { thinking: false, fallbackModels: false },
+		});
+	});
+
+	it("applies profile models and thinking to user agents without frontmatter pins", () => {
+		const profilesDir = getSubagentProfilesDir();
+		fs.mkdirSync(profilesDir, { recursive: true });
+		fs.writeFileSync(path.join(profilesDir, "azure-fallback.json"), JSON.stringify({
+			subagents: {
+				disableBuiltins: true,
+				agentOverrides: {
+					worker: {
+						model: "bluebox-azure-openai/gpt-5_6-luna",
+						thinking: "high",
+						fallbackModels: ["bluebox-azure-openai/gpt-5_6-terra"],
+					},
+				},
+			},
+		}, null, 2));
+		const agentDir = path.join(homeDir, ".pi", "agent", "agents");
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(path.join(agentDir, "worker.md"), `---\nname: worker\ndescription: Profile-managed worker\n---\n\nDo work.\n`);
+
+		applySubagentProfile("azure-fallback");
+		const agents = discoverAgents(process.cwd(), "both").agents;
+		const worker = agents.find((agent) => agent.name === "worker");
+		assert.equal(worker?.source, "user");
+		assert.equal(worker?.model, "bluebox-azure-openai/gpt-5_6-luna");
+		assert.equal(worker?.thinking, "high");
+		assert.deepEqual(worker?.fallbackModels, ["bluebox-azure-openai/gpt-5_6-terra"]);
+		assert.equal(worker?.override?.scope, "user");
+		assert.equal(agents.some((agent) => agent.source === "builtin"), false);
+	});
+
+	it("rejects invalid profile fallback models", () => {
+		const profilesDir = getSubagentProfilesDir();
+		fs.mkdirSync(profilesDir, { recursive: true });
+		fs.writeFileSync(path.join(profilesDir, "invalid.json"), JSON.stringify({
+			subagents: {
+				agentOverrides: {
+					worker: { fallbackModels: ["openai/gpt-5", 42] },
+				},
+			},
+		}, null, 2));
+
+		assert.throws(() => applySubagentProfile("invalid"), /invalid fallbackModels.*array of strings or false/);
 	});
 
 	it("rejects profile and provider path traversal names", async () => {


### PR DESCRIPTION
## Problem

A `/subagents` profile agent override can only pin `model`:

```ts
interface ProfileAgentOverride { model?: string; }
```

and applying a profile replaces the whole `subagents` block:

```ts
settings.subagents = profile.subagents;
```

This has two consequences:

1. **Thinking level and fallbacks can't be saved in a profile.** For
   reasoning-sensitive models (e.g. Azure GPT-5.6 on the responses API, where
   the effort level is load-bearing) switching profiles silently drops the
   configured `thinking` level.
2. **Unrelated `subagents` settings are clobbered.** Applying a profile wipes
   keys the profile never meant to own — `disableBuiltins`, `modelScope`,
   `watchdog`, etc.

## Change

- Allow `thinking` and `fallbackModels` in profile agent overrides, with
  validation (`string | false`, `string[] | false`).
- Merge a profile into the existing `settings.subagents` so the profile owns
  only the complete `agentOverrides` mapping; unrelated settings survive.
- Validate `subagents.disableBuiltins` in profile files.
- Unit tests for preservation of unrelated settings and for applying
  profile `model` + `thinking` to a user agent without frontmatter pins.

## Notes

No behavior change for profiles that only set `model`. `agentOverrides` is
still fully owned/replaced by the applied profile.

`test/unit/profiles.test.ts`: 11/11 pass.
