### PR TITLE
build: add strict TypeScript CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: 24
       - name: Install devDependencies
         run: npm ci --ignore-scripts
+      - name: Typecheck
+        run: npm run typecheck
       - name: Unit tests
         run: npm test
       - name: Integration tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added a source-only, strict TypeScript typecheck command and CI gate.
 - Added trusted inline `workflowScript` orchestration with stable-key child launches through the ordinary executor, timed worker isolation, captured console and emitted milestones, artifact references, status lookup, and a concise call trace. Chains remain supported for compatibility; durable replay and saved scripts are deferred.
 - Added opt-in async one-shot `external-cli` agent profiles with stdin prompt delivery, argv-only spawning, lifecycle/status artifacts, stdout/stderr logs, timeout, and stop support.
 - Added default-on durable project missions with management actions, launch attachment, lifecycle/artifact links, explicit opt-out, a user-local cross-project pointer index, and typed delivery receipts for pull requests, CI, deployments, and releases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
         "@earendil-works/pi-agent-core": "0.81.0",
         "@earendil-works/pi-ai": "0.81.0",
         "@earendil-works/pi-coding-agent": "0.81.0",
-        "@earendil-works/pi-tui": "0.81.0"
+        "@earendil-works/pi-tui": "0.81.0",
+        "@types/node": "24.13.3",
+        "typescript": "5.9.3"
       },
       "peerDependencies": {
         "@earendil-works/pi-agent-core": "*",
@@ -1398,6 +1400,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2535,6 +2538,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2615,6 +2619,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2824,13 +2829,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/retry": {
@@ -3327,10 +3332,24 @@
       "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
       "license": "MIT"
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3387,6 +3406,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "npm run test:unit",
     "test:unit": "node --experimental-strip-types --test test/unit/*.test.ts",
     "test:integration": "node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/*.test.ts",
@@ -89,6 +90,8 @@
     "@earendil-works/pi-agent-core": "0.81.0",
     "@earendil-works/pi-ai": "0.81.0",
     "@earendil-works/pi-coding-agent": "0.81.0",
-    "@earendil-works/pi-tui": "0.81.0"
+    "@earendil-works/pi-tui": "0.81.0",
+    "@types/node": "24.13.3",
+    "typescript": "5.9.3"
   }
 }

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -46,7 +46,7 @@ interface ManagementParams {
 	action?: string;
 	agent?: string;
 	chainName?: string;
-	agentScope?: string;
+	agentScope?: unknown;
 	config?: unknown;
 }
 
@@ -409,7 +409,8 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 				&& (runner.args === undefined || (Array.isArray(runner.args) && runner.args.every((arg) => typeof arg === "string")))
 				&& (runner.promptDelivery === undefined || runner.promptDelivery === "stdin")
 				&& Object.keys(runner).every((key) => ["type", "command", "args", "promptDelivery"].includes(key))) {
-				target.runner = { type: "external-cli", command: runner.command.trim(), ...(runner.args ? { args: [...runner.args] as string[] } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
+				const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
+				target.runner = { type: "external-cli", command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
 			} else return "config.runner must be { type: 'pi' } or { type: 'external-cli', command: string, args?: string[], promptDelivery?: 'stdin' }.";
 		} else return "config.runner must be an object, false, or empty string when provided.";
 	}
@@ -928,9 +929,10 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 	const warnings: string[] = [];
 	if (params.agent) {
 		const scopeHint = asDisambiguationScope(params.agentScope);
-		const targetOrError = resolveTarget("agent", params.agent, findAgents(params.agent, ctx.cwd, scopeHint ?? "both"), ctx.cwd, params.agentScope);
+		const targetOrError = resolveTarget("agent", params.agent, findAgents(params.agent, ctx.cwd, scopeHint ?? "both"), ctx.cwd, scopeHint);
 		if ("content" in targetOrError) return targetOrError;
 		const target = targetOrError;
+		if (target.source !== "user" && target.source !== "project") return result(`Cannot update ${target.source} agent '${target.name}'. Eject it to user or project scope first.`, true);
 		const updated = editableAgentConfig(target);
 		const oldName = target.name;
 		if (hasKey(cfg, "name") && (typeof cfg.name !== "string" || !cfg.name.trim())) return result("config.name must be a non-empty string when provided.", true);
@@ -981,9 +983,10 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 		return result([headline, ...warnings].join("\n"));
 	}
 	const scopeHint = asDisambiguationScope(params.agentScope);
-	const targetOrError = resolveTarget("chain", params.chainName!, findChains(params.chainName!, ctx.cwd, scopeHint ?? "both"), ctx.cwd, params.agentScope);
+	const targetOrError = resolveTarget("chain", params.chainName!, findChains(params.chainName!, ctx.cwd, scopeHint ?? "both"), ctx.cwd, scopeHint);
 	if ("content" in targetOrError) return targetOrError;
 	const target = targetOrError;
+	if (target.source !== "user" && target.source !== "project") return result(`Cannot update ${target.source} chain '${target.name}'. Eject it to user or project scope first.`, true);
 	const updated: ChainConfig = { ...target, steps: [...target.steps] };
 	const oldName = target.name;
 	if (hasKey(cfg, "name") && (typeof cfg.name !== "string" || !cfg.name.trim())) return result("config.name must be a non-empty string when provided.", true);
@@ -1032,7 +1035,7 @@ function handleDelete(params: ManagementParams, ctx: ManagementContext): AgentTo
 	if (params.agent && params.chainName) return result("Specify either 'agent' or 'chainName', not both.", true);
 	const scopeHint = asDisambiguationScope(params.agentScope);
 	if (params.agent) {
-		const targetOrError = resolveTarget("agent", params.agent, findAgents(params.agent, ctx.cwd, scopeHint ?? "both"), ctx.cwd, params.agentScope);
+		const targetOrError = resolveTarget("agent", params.agent, findAgents(params.agent, ctx.cwd, scopeHint ?? "both"), ctx.cwd, scopeHint);
 		if ("content" in targetOrError) return targetOrError;
 		const target = targetOrError;
 		fs.unlinkSync(target.filePath);
@@ -1041,7 +1044,7 @@ function handleDelete(params: ManagementParams, ctx: ManagementContext): AgentTo
 		if (refs.length) lines.push(`Warning: chains reference deleted agent '${target.name}': ${refs.join(", ")}.`);
 		return result(lines.join("\n"));
 	}
-	const targetOrError = resolveTarget("chain", params.chainName!, findChains(params.chainName!, ctx.cwd, scopeHint ?? "both"), ctx.cwd, params.agentScope);
+	const targetOrError = resolveTarget("chain", params.chainName!, findChains(params.chainName!, ctx.cwd, scopeHint ?? "both"), ctx.cwd, scopeHint);
 	if ("content" in targetOrError) return targetOrError;
 	const target = targetOrError;
 	fs.unlinkSync(target.filePath);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1429,10 +1429,11 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 	const supported = new Set(["type", "command", "args", "promptDelivery"]);
 	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
 	if (unknown.length > 0) throw new Error(`Agent '${agentName}' external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
+	const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
 	return {
 		type: "external-cli",
 		command: runner.command.trim(),
-		...(runner.args ? { args: [...runner.args] as string[] } : {}),
+		...(runnerArgs?.length ? { args: runnerArgs } : {}),
 		...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}),
 	};
 }

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -165,7 +165,7 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 		].join("\n"),
 		parameters: SubagentParams,
 		execute(id, params, signal, onUpdate, ctx) {
-			return executor.execute(id, params as SubagentParamsLike, signal, onUpdate, ctx);
+			return executor.execute(id, params as SubagentParamsLike, signal ?? new AbortController().signal, onUpdate, ctx);
 		},
 	};
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -418,7 +418,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		},
 
 		execute(id, params, signal, onUpdate, ctx) {
-			return executeSubagentCollapsed(id, params, signal, onUpdate, ctx);
+			return executeSubagentCollapsed(id, params as SubagentParamsLike, signal ?? new AbortController().signal, onUpdate, ctx);
 		},
 
 		renderCall(args, theme) {

--- a/src/inspectors/herdr/actions.ts
+++ b/src/inspectors/herdr/actions.ts
@@ -169,7 +169,7 @@ export async function handleHerdrInspectorAction(action: HerdrInspectorAction, p
 	if (action === "inspector.status") {
 		if (!existing) return result(`No Herdr inspector binding exists for async run ${target.runId}${params.index === undefined ? "" : ` child ${params.index}`}.`);
 		const live = await paneExists(client, existing.paneId, deps.signal);
-		if (!live.ok) return result(`${formatHerdrError(live.error)}\nBinding: ${bindingPath(target.asyncDir, params.index)}\nRun state remains authoritative: ${status.state}.`, true);
+		if (live.ok === false) return result(`${formatHerdrError(live.error)}\nBinding: ${bindingPath(target.asyncDir, params.index)}\nRun state remains authoritative: ${status.state}.`, true);
 		return result(`Herdr inspector ${existing.paneId} is open for async run ${target.runId}.\nRun state: ${status.state}\nBinding: ${bindingPath(target.asyncDir, params.index)}`);
 	}
 
@@ -177,13 +177,13 @@ export async function handleHerdrInspectorAction(action: HerdrInspectorAction, p
 	if (action === "inspector.close") {
 		if (!existing) return result(`No Herdr inspector binding exists for async run ${target.runId}.`);
 		const closed = await client.run(["pane", "close", existing.paneId], { timeoutMs: 10_000, signal: deps.signal });
-		if (!closed.ok && closed.error.code !== "NOT_FOUND" && closed.error.code !== "PANE_GONE") return result(formatHerdrError(closed.error), true);
+		if (closed.ok === false && closed.error.code !== "NOT_FOUND" && closed.error.code !== "PANE_GONE") return result(formatHerdrError(closed.error), true);
 		fs.rmSync(bindingPath(target.asyncDir, params.index), { force: true });
 		return result(`Closed Herdr inspector pane ${existing.paneId} for async run ${target.runId}. The subagent run was not stopped.`);
 	}
 
 	const detected = await detectHerdr(client, deps.signal);
-	if (!detected.ok) return result(formatHerdrError(detected.error), true);
+	if (detected.ok === false) return result(formatHerdrError(detected.error), true);
 	if (existing) {
 		const live = await paneExists(client, existing.paneId, deps.signal);
 		if (live.ok) return result(`Herdr inspector pane ${existing.paneId} is already open for async run ${target.runId}.${params.focus ? " Herdr cannot refocus an arbitrary raw pane id; select it in the Herdr UI." : ""}`);
@@ -191,7 +191,7 @@ export async function handleHerdrInspectorAction(action: HerdrInspectorAction, p
 	const splitArgs = ["pane", "split", "--current", "--direction", "right", "--cwd", status.cwd ?? deps.cwd];
 	if (params.focus !== false) splitArgs.push("--focus");
 	const split = await client.run(splitArgs, { timeoutMs: 15_000, signal: deps.signal });
-	if (!split.ok) return result(formatHerdrError(split.error), true);
+	if (split.ok === false) return result(formatHerdrError(split.error), true);
 	const paneId = extractPaneId(split.data);
 	if (!paneId) return result("Herdr inspector error (PANE_GONE): pane split returned no pane id.", true);
 	const mission = missionForRun(target.asyncDir, deps.cwd, deps.missions, target.runId);
@@ -206,7 +206,7 @@ export async function handleHerdrInspectorAction(action: HerdrInspectorAction, p
 		allowStop: resolveAuthorityDecision({ action: "stopRun", policy: deps.authorityPolicy }) === "auto",
 	});
 	const started = await client.run(["pane", "run", paneId, command], { timeoutMs: 15_000, signal: deps.signal });
-	if (!started.ok) {
+	if (started.ok === false) {
 		await client.run(["pane", "close", paneId], { timeoutMs: 5_000 });
 		return result(formatHerdrError(started.error), true);
 	}

--- a/src/inspectors/herdr/client.ts
+++ b/src/inspectors/herdr/client.ts
@@ -121,7 +121,7 @@ export function supportsRawPanes(version: HerdrVersion): boolean {
 
 export async function detectHerdr(client: HerdrClient, signal?: AbortSignal): Promise<HerdrResult<{ version: HerdrVersion; versionText: string }>> {
 	const result = await client.run<string>(["--version"], { timeoutMs: 3_000, signal, textOk: true });
-	if (!result.ok) return result;
+	if (result.ok === false) return result;
 	const versionText = typeof result.data === "string" ? result.data : JSON.stringify(result.data);
 	const version = parseHerdrVersion(versionText);
 	if (!version) return error("VALIDATION_ERROR", `Could not parse the Herdr version from '${versionText}'.`);

--- a/src/inspectors/herdr/project-panes.ts
+++ b/src/inspectors/herdr/project-panes.ts
@@ -106,20 +106,20 @@ export async function handleHerdrProjectPaneAction(action: HerdrProjectPaneActio
 	if (action === "project.status") {
 		if (!existing) return result(`No Herdr project pane binding exists for ${projectRoot}.`);
 		const live = await paneExists(client, existing.paneId, deps.signal);
-		if (!live.ok) return result(`${formatHerdrError(live.error)}\nBinding: ${bindingPath(projectRoot)}`, true);
+		if (live.ok === false) return result(`${formatHerdrError(live.error)}\nBinding: ${bindingPath(projectRoot)}`, true);
 		return result(`Herdr project pane ${existing.paneId} is open for ${projectRoot}.\nBinding: ${bindingPath(projectRoot)}`);
 	}
 
 	if (action === "project.close") {
 		if (!existing) return result(`No Herdr project pane binding exists for ${projectRoot}.`);
 		const closed = await client.run(["pane", "close", existing.paneId], { timeoutMs: 10_000, signal: deps.signal });
-		if (!closed.ok && closed.error.code !== "NOT_FOUND" && closed.error.code !== "PANE_GONE") return result(formatHerdrError(closed.error), true);
+		if (closed.ok === false && closed.error.code !== "NOT_FOUND" && closed.error.code !== "PANE_GONE") return result(formatHerdrError(closed.error), true);
 		fs.rmSync(bindingPath(projectRoot), { force: true });
 		return result(`Closed Herdr project pane ${existing.paneId} for ${projectRoot}.`);
 	}
 
 	const detected = await detectHerdr(client, deps.signal);
-	if (!detected.ok) return result(formatHerdrError(detected.error), true);
+	if (detected.ok === false) return result(formatHerdrError(detected.error), true);
 	if (existing) {
 		const live = await paneExists(client, existing.paneId, deps.signal);
 		if (live.ok) return result(`Herdr project pane ${existing.paneId} is already open for ${projectRoot}.${params.focus ? " Herdr cannot refocus an arbitrary raw pane id; select it in the Herdr UI." : ""}`);
@@ -127,13 +127,13 @@ export async function handleHerdrProjectPaneAction(action: HerdrProjectPaneActio
 	const splitArgs = ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot];
 	if (params.focus !== false) splitArgs.push("--focus");
 	const split = await client.run(splitArgs, { timeoutMs: 15_000, signal: deps.signal });
-	if (!split.ok) return result(formatHerdrError(split.error), true);
+	if (split.ok === false) return result(formatHerdrError(split.error), true);
 	const paneId = extractPaneId(split.data);
 	if (!paneId) return result("Herdr project pane error (PANE_GONE): pane split returned no pane id.", true);
 	const startupMessage = params.message?.trim();
 	const command = projectPaneCommand(startupMessage);
 	const started = await client.run(["pane", "run", paneId, command], { timeoutMs: 15_000, signal: deps.signal });
-	if (!started.ok) {
+	if (started.ok === false) {
 		await client.run(["pane", "close", paneId], { timeoutMs: 5_000 });
 		return result(formatHerdrError(started.error), true);
 	}

--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -53,6 +53,7 @@ interface ResolveIntercomBridgeInput {
 	config: ExtensionConfig["intercomBridge"];
 	context: "fresh" | "fork" | undefined;
 	orchestratorTarget?: string;
+	cwd?: string;
 	settingsDir?: string;
 	agentDir?: string;
 }

--- a/src/intercom/result-intercom.ts
+++ b/src/intercom/result-intercom.ts
@@ -315,7 +315,7 @@ export async function deliverSubagentResultIntercomEvent(
 	payload: SubagentResultIntercomPayload,
 	timeoutMs = 500,
 ): Promise<boolean> {
-	return deliverSubagentIntercomMessageEvent(events, payload.to, payload.message, timeoutMs, payload);
+	return deliverSubagentIntercomMessageEvent(events, payload.to, payload.message, timeoutMs, payload as unknown as Record<string, unknown>);
 }
 
 export async function deliverSubagentIntercomMessageEvent(

--- a/src/missions/lifecycle.ts
+++ b/src/missions/lifecycle.ts
@@ -13,8 +13,8 @@ export interface MissionLaunchParams {
 	missionId?: string;
 	mission?: unknown;
 	task?: string;
-	tasks?: Array<{ task: string }>;
-	chain?: Array<{ task?: string }>;
+	tasks?: Array<{ task?: string }>;
+	chain?: Array<{ task?: string; parallel?: Array<{ task?: string }> | { task?: string } }>;
 }
 
 export interface MissionLaunchBinding {
@@ -36,7 +36,7 @@ interface PersistedMissionBinding {
 
 function workflowGoal(params: MissionLaunchParams): string | undefined {
 	return params.task?.trim()
-		|| params.tasks?.find((task) => task.task.trim())?.task.trim()
+		|| params.tasks?.find((task) => task.task?.trim())?.task?.trim()
 		|| params.chain?.find((step) => step.task?.trim())?.task?.trim();
 }
 

--- a/src/missions/store.ts
+++ b/src/missions/store.ts
@@ -154,6 +154,10 @@ export function parseMissionRecord(value: unknown, source = "mission record"): M
 	if (!Array.isArray(input.decisions)) throw new Error(`${source}.decisions must be an array`);
 	if (!Array.isArray(input.artifacts)) throw new Error(`${source}.artifacts must be an array`);
 	if (input.receipts !== undefined && !Array.isArray(input.receipts)) throw new Error(`${source}.receipts must be an array`);
+	const runs = input.runs as unknown[];
+	const decisions = input.decisions as unknown[];
+	const artifacts = input.artifacts as unknown[];
+	const receipts = (input.receipts ?? []) as unknown[];
 	return {
 		schemaVersion: 1,
 		id: validateMissionId(input.id, `${source}.id`),
@@ -162,10 +166,10 @@ export function parseMissionRecord(value: unknown, source = "mission record"): M
 		status: missionStatus(input.status, `${source}.status`),
 		createdAt: timestamp(input.createdAt, `${source}.createdAt`),
 		updatedAt: timestamp(input.updatedAt, `${source}.updatedAt`),
-		runs: input.runs.map((item, index) => parseRunLink(item, `${source}.runs[${index}]`)),
-		decisions: input.decisions.map((item, index) => parseDecision(item, `${source}.decisions[${index}]`)),
-		artifacts: input.artifacts.map((item, index) => parseArtifact(item, `${source}.artifacts[${index}]`)),
-		receipts: (input.receipts ?? []).map((item, index) => parseReceipt(item, `${source}.receipts[${index}]`)),
+		runs: runs.map((item, index) => parseRunLink(item, `${source}.runs[${index}]`)),
+		decisions: decisions.map((item, index) => parseDecision(item, `${source}.decisions[${index}]`)),
+		artifacts: artifacts.map((item, index) => parseArtifact(item, `${source}.artifacts[${index}]`)),
+		receipts: receipts.map((item, index) => parseReceipt(item, `${source}.receipts[${index}]`)),
 		...(optionalString(input.cwd, `${source}.cwd`) ? { cwd: input.cwd as string } : {}),
 		...(optionalString(input.ownerSessionId, `${source}.ownerSessionId`) ? { ownerSessionId: input.ownerSessionId as string } : {}),
 		...(optionalString(input.summary, `${source}.summary`) ? { summary: input.summary as string } : {}),
@@ -195,9 +199,9 @@ export function validateMissionStoreConfig(value: unknown, label = "config.missi
 	const directory = optionalString(input.directory, `${label}.directory`);
 	const globalIndexDir = optionalString(input.globalIndexDir, `${label}.globalIndexDir`);
 	return {
-		...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+		...(typeof input.enabled === "boolean" ? { enabled: input.enabled } : {}),
 		...(directory ? { directory } : {}),
-		...(input.globalIndex !== undefined ? { globalIndex: input.globalIndex } : {}),
+		...(typeof input.globalIndex === "boolean" ? { globalIndex: input.globalIndex } : {}),
 		...(globalIndexDir ? { globalIndexDir } : {}),
 		...(input.retainTerminal !== undefined ? { retainTerminal: input.retainTerminal as number } : {}),
 	};

--- a/src/profiles/profiles.ts
+++ b/src/profiles/profiles.ts
@@ -514,7 +514,7 @@ export async function refreshProviderModelCatalog(
 		probe: { status: ProbeStatus; message?: string };
 	}>;
 	for (const rawModel of availableModels) {
-		const modelRecord = rawModel as Record<string, unknown> & { provider: string; id: string; name?: string };
+		const modelRecord = rawModel as unknown as Record<string, unknown> & { provider: string; id: string; name?: string };
 		const fullId = `${modelRecord.provider}/${modelRecord.id}`;
 		const probe = options.probe === false
 			? { status: "skipped" as const, message: "Live probing disabled." }

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -1527,6 +1527,6 @@ export function executeAsyncSingle(
 
 	return {
 		content: [{ type: "text", text: formatAsyncStartedMessage(`Async: ${agent} [${id}]`, ctx.interactive === true) }],
-		details: { mode: "single", runId: id, results: [], asyncId: id, asyncDir, launchContractDigest, launchResolvedExtensions, ...(capabilityCeiling ? { capabilityCeiling } : {}), ...(params.context ? { context: params.context } : {}), ...(timeoutMs !== undefined ? { timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}), ...(params.toolBudget && resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}), ...(initialUsageBudget ? { usageBudget: initialUsageBudget } : {}) } as Details,
+		details: { mode: "single", runId: id, results: [], asyncId: id, asyncDir, launchContractDigest, launchResolvedExtensions, ...(capabilityCeiling ? { capabilityCeiling } : {}), ...(params.context ? { context: params.context } : {}), ...(timeoutMs !== undefined ? { timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}), ...(params.toolBudget ? { toolBudget: resolvedToolBudget.budget ?? params.toolBudget } : {}), ...(initialUsageBudget ? { usageBudget: initialUsageBudget } : {}) } as Details,
 	};
 }

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -40,6 +40,7 @@ import {
 	type ResolvedControlConfig,
 	type ResolvedTurnBudget,
 	type ResolvedToolBudget,
+	type ToolBudgetConfig,
 	type SubagentRunMode,
 	type SteeringRecoveryDescriptor,
 	type UsageBudgetConfig,
@@ -205,10 +206,11 @@ interface AsyncSingleParams {
 	acceptance?: AcceptanceInput;
 	timeoutMs?: number;
 	absoluteDeadlineAt?: number;
-	turnBudget?: ResolvedTurnBudget;
-	toolBudget?: ResolvedToolBudget;
+	turnBudget?: { maxTurns: number; graceTurns?: number };
+	toolBudget?: ResolvedToolBudget | ToolBudgetConfig;
 	usageBudget?: UsageBudgetConfig;
 	configToolBudget?: ResolvedToolBudget;
+	allowZeroToolBudget?: boolean;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
@@ -425,9 +427,10 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, onProcessTerminal
 	fs.writeFileSync(cfgPath, JSON.stringify(launchConfig));
 	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
 	const nodeCommand = resolveAsyncRunnerNodeCommand();
-	const startupPath = typeof (launchConfig as { revivalLease?: unknown; asyncDir?: unknown }).revivalLease === "object"
-		&& typeof (launchConfig as { asyncDir?: unknown }).asyncDir === "string"
-		? path.join((launchConfig as { asyncDir: string }).asyncDir, "runner-startup.json")
+	const launchForStartup = launchConfig as typeof launchConfig & { asyncDir?: unknown; revivalLease?: unknown };
+	const launchAsyncDir = typeof launchForStartup.asyncDir === "string" ? launchForStartup.asyncDir : undefined;
+	const startupPath = typeof launchForStartup.revivalLease === "object" && launchAsyncDir
+		? path.join(launchAsyncDir, "runner-startup.json")
 		: undefined;
 	const startupAckPath = startupPath ? path.join(path.dirname(startupPath), "runner-startup-ack.json") : undefined;
 	const startupProceedPath = startupPath ? path.join(path.dirname(startupPath), "runner-startup-proceed.json") : undefined;
@@ -515,7 +518,7 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, onProcessTerminal
 		proc.unref();
 		if (startupPath && startupAckPath && startupProceedPath) {
 			const ready = waitForRunnerStartup(startupPath, "ready", RUNNER_STARTUP_TIMEOUT_MS);
-			if (!ready.ok) {
+			if (ready.ok === false) {
 				terminateRunnerBeforeProceed(proc.pid);
 				return { error: ready.error };
 			}
@@ -526,7 +529,7 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, onProcessTerminal
 				return { error: `Failed to acknowledge async runner startup: ${error instanceof Error ? error.message : String(error)}` };
 			}
 			const acknowledged = waitForRunnerStartup(startupPath, "acknowledged", RUNNER_STARTUP_TIMEOUT_MS, ready.token);
-			if (!acknowledged.ok) {
+			if (acknowledged.ok === false) {
 				terminateRunnerBeforeProceed(proc.pid);
 				return { error: acknowledged.error };
 			}
@@ -663,7 +666,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		if (inheritedRelativeParallelOutput && parallelOutputNamespace.taskIndex !== undefined) {
 			behavior = {
 				...behavior,
-				output: path.join(`parallel-${parallelOutputNamespace.stepIndex}`, `${parallelOutputNamespace.taskIndex}-${s.agent}`, behavior.output),
+				output: path.join(`parallel-${parallelOutputNamespace.stepIndex}`, `${parallelOutputNamespace.taskIndex}-${s.agent}`, behavior.output as string),
 			};
 		}
 		const namespaceOutputPath = Boolean(inheritedRelativeParallelOutput && parallelOutputNamespace.taskIndex === undefined);
@@ -895,7 +898,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 				seen.set(task.outputPath, { index, agent: task.agent });
 			}
 		}
-		return { steps, runnerCwd, workflowGraph, eventChain: graphChain, ...(originalTask !== undefined ? { originalTask } : {}) };
+		return { steps: steps as RunnerStep[], runnerCwd, workflowGraph, eventChain: graphChain, ...(originalTask !== undefined ? { originalTask } : {}) };
 	} catch (error) {
 		if (error instanceof UnavailableSubagentSkillError || error instanceof AsyncStartValidationError) return { error: error.message };
 		throw error;
@@ -987,7 +990,7 @@ export function executeAsyncChain(
 	const initialUsageBudget = usageBudgetState(params.usageBudget, undefined);
 	let childTargetIndex = 0;
 	const childIntercomTargets = childIntercomTarget ? steps.flatMap((step) => {
-		if (!("parallel" in step) && step.importAsyncRoot) {
+		if (!("parallel" in step) && "importAsyncRoot" in step && step.importAsyncRoot) {
 			childTargetIndex++;
 			return [undefined];
 		}
@@ -998,7 +1001,7 @@ export function executeAsyncChain(
 			}
 			return step.parallel.map((task) => childIntercomTarget(task.agent, childTargetIndex++));
 		}
-		return [childIntercomTarget(step.agent, childTargetIndex++)];
+		return "agent" in step ? [childIntercomTarget(step.agent, childTargetIndex++)] : [undefined];
 	}) : undefined;
 
 	let spawnResult: { pid?: number; error?: string } = {};
@@ -1274,9 +1277,11 @@ export function executeAsyncSingle(
 	const structuredOutput = params.structuredOutputSchema
 		? createStructuredOutputRuntime(params.structuredOutputSchema, path.join(asyncDir, "structured-output"))
 		: undefined;
-	const modelCandidates = buildModelCandidates(primaryModel, agentConfig.fallbackModels, availableModels, ctx.currentModelProvider, { scope: ctx.modelScope }).map((candidate) =>
-		applyThinkingSuffix(candidate, effectiveThinking, params.thinkingOverride !== undefined),
-	);
+	const modelCandidates = buildModelCandidates(primaryModel, agentConfig.fallbackModels, availableModels, ctx.currentModelProvider, { scope: ctx.modelScope })
+		.flatMap((candidate) => {
+			const resolved = applyThinkingSuffix(candidate, effectiveThinking, params.thinkingOverride !== undefined);
+			return resolved ? [resolved] : [];
+		});
 	const effectiveSystemPrompt = appendTurnBudgetSystemPrompt(systemPrompt, params.turnBudget);
 	const toolPlan = resolvePiLaunchToolPlan({
 		tools: agentConfig.tools,
@@ -1349,7 +1354,7 @@ export function executeAsyncSingle(
 		...(params.acceptance !== undefined ? { acceptance: params.acceptance } : {}),
 		...(controlConfig ? { controlConfig } : {}),
 		...(deadlineAt !== undefined ? { absoluteDeadlineAt: deadlineAt } : {}),
-		...(params.turnBudget ? { initialTurnBudget: params.turnBudget } : {}),
+		...(initialTurnBudget ? { initialTurnBudget } : {}),
 		...(resolvedToolBudget.budget ? { initialToolBudget: resolvedToolBudget.budget } : {}),
 		maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, agentConfig.maxSubagentDepth),
 		...(maxOutput ? { maxOutput } : {}),
@@ -1522,6 +1527,6 @@ export function executeAsyncSingle(
 
 	return {
 		content: [{ type: "text", text: formatAsyncStartedMessage(`Async: ${agent} [${id}]`, ctx.interactive === true) }],
-		details: { mode: "single", runId: id, results: [], asyncId: id, asyncDir, launchContractDigest, launchResolvedExtensions, ...(capabilityCeiling ? { capabilityCeiling } : {}), ...(params.context ? { context: params.context } : {}), ...(timeoutMs !== undefined ? { timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}), ...(params.toolBudget ? { toolBudget: params.toolBudget } : {}), ...(initialUsageBudget ? { usageBudget: initialUsageBudget } : {}) },
+		details: { mode: "single", runId: id, results: [], asyncId: id, asyncDir, launchContractDigest, launchResolvedExtensions, ...(capabilityCeiling ? { capabilityCeiling } : {}), ...(params.context ? { context: params.context } : {}), ...(timeoutMs !== undefined ? { timeoutMs, deadlineAt } : {}), ...(params.turnBudget ? { turnBudget: params.turnBudget } : {}), ...(params.toolBudget && resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}), ...(initialUsageBudget ? { usageBudget: initialUsageBudget } : {}) } as Details,
 	};
 }

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -394,7 +394,7 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 		: undefined;
 	const status = reconciliation?.status ?? null;
 	validateStatusForResume(status, location.asyncDir ? path.join(location.asyncDir, "status.json") : "status.json");
-	const recoveryDescriptor = readAsyncRecoveryDescriptor(location.asyncDir);
+	const recoveryDescriptor = readAsyncRecoveryDescriptor(location.asyncDir ?? undefined);
 	const result = location.resultPath ? readResultFile(location.resultPath) : undefined;
 	const runId = status?.runId ?? result?.runId ?? result?.id ?? location.resolvedId ?? (location.asyncDir ? path.basename(location.asyncDir) : "unknown");
 	if (options.sessionId && ((status && status.sessionId !== options.sessionId) || (result && result.sessionId !== options.sessionId))) {
@@ -508,13 +508,13 @@ export function applySteeringRecoveryAgentConfig(agentConfig: AgentConfig, descr
 		extensions: descriptor.extensions ? [...descriptor.extensions] : undefined,
 		subagentOnlyExtensions: descriptor.subagentOnlyExtensions ? [...descriptor.subagentOnlyExtensions] : undefined,
 		mcpDirectTools: descriptor.mcpDirectTools ? [...descriptor.mcpDirectTools] : undefined,
-		systemPrompt: descriptor.systemPrompt,
+		systemPrompt: descriptor.systemPrompt ?? agentConfig.systemPrompt,
 		systemPromptMode: descriptor.systemPromptMode,
 		inheritProjectContext: descriptor.inheritProjectContext,
 		inheritSkills: descriptor.inheritSkills,
 		skills: descriptor.skills ? [...descriptor.skills] : undefined,
 		skillPath: descriptor.skillPath ? [...descriptor.skillPath] : undefined,
-		filePath: descriptor.agentFilePath,
+		filePath: descriptor.agentFilePath as string,
 		completionGuard: descriptor.completionGuard,
 		memory: descriptor.memory ? { ...descriptor.memory } : undefined,
 		output: descriptor.outputPath,

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -349,6 +349,7 @@ function sortRuns(runs: AsyncRunSummary[]): AsyncRunSummary[] {
 			case "stopped": return 2;
 			case "paused": return 2;
 			case "complete": return 3;
+			default: return 4;
 		}
 	};
 	return [...runs].sort((a, b) => {

--- a/src/runs/background/chain-append.ts
+++ b/src/runs/background/chain-append.ts
@@ -104,9 +104,10 @@ export function enqueueChainAppendRequest(input: {
 function readAppendRequest(filePath: string): ChainAppendRequest | undefined {
 	const raw = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Partial<ChainAppendRequest>;
 	if (!raw.id || typeof raw.id !== "string") return undefined;
-	if (!Number.isFinite(raw.createdAt)) return undefined;
+	const createdAt = raw.createdAt;
+	if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) return undefined;
 	if (!Array.isArray(raw.steps) || raw.steps.length === 0) return undefined;
-	return { id: raw.id, createdAt: raw.createdAt, steps: raw.steps as RunnerStep[] };
+	return { id: raw.id, createdAt, steps: raw.steps as RunnerStep[] };
 }
 
 export function readPendingChainAppendRequests(asyncDir: string): ChainAppendRequest[] {

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -331,19 +331,21 @@ function parseSteerCapability(raw: unknown): SteerCapability | undefined {
 	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
 	const input = raw as Partial<SteerCapability>;
 	if (input.type !== "steer-capability" || input.protocolVersion !== 1) return undefined;
-	if (!Number.isInteger(input.index) || input.index < 0 || input.index > 1_000_000) return undefined;
-	if (!Number.isInteger(input.pid) || input.pid <= 0 || !Number.isFinite(input.readyAt) || input.readyAt <= 0 || typeof input.supported !== "boolean") return undefined;
-	return { type: "steer-capability", protocolVersion: 1, index: input.index, pid: input.pid, readyAt: input.readyAt, supported: input.supported };
+	const { index, pid, readyAt, supported } = input;
+	if (typeof index !== "number" || !Number.isInteger(index) || index < 0 || index > 1_000_000) return undefined;
+	if (typeof pid !== "number" || typeof readyAt !== "number" || !Number.isInteger(pid) || pid <= 0 || !Number.isFinite(readyAt) || readyAt <= 0 || typeof supported !== "boolean") return undefined;
+	return { type: "steer-capability", protocolVersion: 1, index, pid, readyAt, supported };
 }
 
 function parseSteerAck(raw: unknown): SteerAck | undefined {
 	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
 	const input = raw as Partial<SteerAck>;
 	if (input.type !== "steer-ack" || input.protocolVersion !== 1 || typeof input.requestId !== "string" || !/^[^\s]+$/.test(input.requestId) || input.requestId.length > 256) return undefined;
-	if (!Number.isInteger(input.index) || input.index < 0 || input.index > 1_000_000 || !Number.isFinite(input.ts) || input.ts <= 0) return undefined;
-	if (input.state !== "delivered" && input.state !== "failed") return undefined;
-	if (typeof input.message !== "string" || !input.message.trim() || input.message.length > 1000) return undefined;
-	return { type: "steer-ack", protocolVersion: 1, requestId: input.requestId, index: input.index, ts: input.ts, state: input.state, message: input.message.trim() };
+	const { index, ts, state, message } = input;
+	if (typeof index !== "number" || typeof ts !== "number" || !Number.isInteger(index) || index < 0 || index > 1_000_000 || !Number.isFinite(ts) || ts <= 0) return undefined;
+	if (state !== "delivered" && state !== "failed") return undefined;
+	if (typeof message !== "string" || !message.trim() || message.length > 1000) return undefined;
+	return { type: "steer-ack", protocolVersion: 1, requestId: input.requestId, index, ts, state, message: message.trim() };
 }
 
 export function readSteerCapability(asyncDir: string, index: number): SteerCapability | undefined {

--- a/src/runs/background/process-terminal.ts
+++ b/src/runs/background/process-terminal.ts
@@ -90,9 +90,9 @@ export function readProcessTerminalCandidate(asyncDir: string): ProcessTerminalC
 			runnerProcessInstanceId: raw.runnerProcessInstanceId,
 			writers,
 			...(expectedWriters ? { expectedWriters } : {}),
-			...(raw.sessionFile ? { sessionFile: raw.sessionFile } : {}),
-			...(raw.revivalLeaseToken ? { revivalLeaseToken: raw.revivalLeaseToken } : {}),
-			...(raw.revivalLeaseReleaseAcknowledged !== undefined ? { revivalLeaseReleaseAcknowledged: raw.revivalLeaseReleaseAcknowledged } : {}),
+			...(typeof raw.sessionFile === "string" && raw.sessionFile ? { sessionFile: raw.sessionFile } : {}),
+			...(typeof raw.revivalLeaseToken === "string" && raw.revivalLeaseToken ? { revivalLeaseToken: raw.revivalLeaseToken } : {}),
+			...(typeof raw.revivalLeaseReleaseAcknowledged === "boolean" ? { revivalLeaseReleaseAcknowledged: raw.revivalLeaseReleaseAcknowledged } : {}),
 		};
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
@@ -154,7 +154,7 @@ export function sanitizeProcessTerminal(value: unknown, fallback: { runId?: stri
 	if (value === undefined) return undefined;
 	try {
 		validateProof(value, label, fallback);
-		return value;
+		return value as ProcessTerminalV1;
 	} catch (error) {
 		return unknownProof(fallback.runId ?? label, fallback.runnerProcessInstanceId ?? "unknown", "proof-write-failed", errorMessage(error));
 	}
@@ -164,7 +164,7 @@ export function readProcessTerminal(asyncDir: string, fallback?: { runId?: strin
 	try {
 		const raw = JSON.parse(fs.readFileSync(processTerminalPath(asyncDir), "utf-8")) as unknown;
 		validateProof(raw, asyncDir, fallback);
-		return raw;
+		return raw as ProcessTerminalV1;
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 		return unknownProof(fallback?.runId ?? path.basename(asyncDir), fallback?.runnerProcessInstanceId ?? "unknown", "proof-write-failed", errorMessage(error));

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -234,7 +234,7 @@ export function createResultWatcher(
 					mode,
 					source: "async",
 					children: normalizedChildren,
-					asyncId: data.id,
+					asyncId: data.id ?? undefined,
 					asyncDir: data.asyncDir,
 					...(data.parallelHandoff ? { parallelHandoff: data.parallelHandoff } : {}),
 				}));

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -19,7 +19,7 @@ import { readMissionBinding } from "../../missions/lifecycle.ts";
 import { formatWorkflowJsonPreview } from "../../workflows/scripted-workflow.ts";
 
 interface RunStatusParams {
-	action?: "status";
+	action?: string;
 	id?: string;
 	runId?: string;
 	dir?: string;

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -179,12 +179,12 @@ class ScheduledRunStore {
 
 function resolveMaxLatenessMs(config: ExtensionConfig): number {
 	const value = config.scheduledRuns?.maxLatenessMs;
-	return Number.isInteger(value) && value >= 0 ? value : DEFAULT_MAX_LATENESS_MS;
+	return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : DEFAULT_MAX_LATENESS_MS;
 }
 
 function resolveMaxPending(config: ExtensionConfig): number {
 	const value = config.scheduledRuns?.maxPending;
-	return Number.isInteger(value) && value >= 1 ? value : DEFAULT_MAX_PENDING;
+	return typeof value === "number" && Number.isInteger(value) && value >= 1 ? value : DEFAULT_MAX_PENDING;
 }
 
 function terminalState(state: ScheduledRunState): boolean {
@@ -231,7 +231,7 @@ function sanitizeScheduledParams(params: SubagentParamsLike): { params?: Subagen
 	if (params.context === "fork") return { error: "Scheduled subagent runs require fresh context. Forked parent-session context is not safe at fire time." };
 	if (params.async === false) return { error: "Scheduled subagent runs are always async; omit async or set async: true." };
 	if (params.clarify === true) return { error: "Scheduled subagent runs cannot open clarify UI; omit clarify or set clarify: false." };
-	const acceptanceErrors = validateExecutionAcceptance(params);
+	const acceptanceErrors = validateExecutionAcceptance(params as Parameters<typeof validateExecutionAcceptance>[0]);
 	if (acceptanceErrors.length > 0) return { error: acceptanceErrors.join(" ") };
 
 	const {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -160,6 +160,7 @@ interface SubagentRunConfig {
 	controlIntercomTarget?: string;
 	childIntercomTargets?: Array<string | undefined>;
 	resultMode?: SubagentRunMode;
+	mode?: SubagentRunMode;
 	dynamicFanoutMaxItems?: number;
 	workflowGraph?: WorkflowGraphSnapshot;
 	nestedRoute?: NestedRouteInfo;
@@ -193,8 +194,10 @@ interface StepResult {
 	outputState?: SubagentOutputState;
 	error?: string;
 	protocolError?: ProtocolOutputLimit;
-	success: boolean;
-	exitCode?: number | null;
+	success?: boolean;
+	exitCode: number | null;
+	usage?: Usage;
+	savedOutputPath?: string;
 	skipped?: boolean;
 	interrupted?: boolean;
 	timedOut?: boolean;
@@ -556,7 +559,7 @@ function runPiStreaming(
 				return;
 			}
 
-			appendChildEvent(event);
+			appendChildEvent(event as unknown as Record<string, unknown>);
 			transcriptWriter?.writeChildEvent(event);
 			if (event.type === "agent_settled") agentSettledReceived = true;
 			applyChildLifecycle(projectChildLifecycle(event));
@@ -1036,44 +1039,7 @@ interface SingleStepContext {
 async function runSingleStep(
 	step: SubagentStep,
 	ctx: SingleStepContext,
-): Promise<{
-	agent: string;
-	context?: "fresh" | "fork";
-	agentContract?: import("../../shared/types.ts").AgentContract;
-	launchContractDigest?: string;
-	launchResolvedExtensions?: LaunchResolvedChildExtensionsV1;
-	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1;
-	output: string;
-	exitCode: number | null;
-	error?: string;
-	model?: string;
-	attemptedModels?: string[];
-	modelAttempts?: ModelAttempt[];
-	artifactPaths?: ArtifactPaths;
-	transcriptPath?: string;
-	transcriptError?: string;
-	interrupted?: boolean;
-	timedOut?: boolean;
-	stopped?: boolean;
-	turnBudget?: TurnBudgetState;
-	turnBudgetExceeded?: boolean;
-	wrapUpRequested?: boolean;
-	toolBudget?: ToolBudgetState;
-	toolBudgetBlocked?: boolean;
-	sessionFile?: string;
-	intercomTarget?: string;
-	completionGuardTriggered?: boolean;
-	effects?: import("../../shared/types.ts").EffectsProjection;
-	execution?: import("../../shared/types.ts").ExecutionProjection;
-	review?: import("../../shared/types.ts").ReviewProjection;
-	structuredOutput?: unknown;
-	structuredOutputPath?: string;
-	structuredOutputSchemaPath?: string;
-	acceptance?: import("../../shared/types.ts").AcceptanceLedger;
-	writerAttemptCount?: number;
-	runner?: ExternalCliRunnerStatus;
-	externalProcess?: ExternalProcessStatus;
-}> {
+): Promise<StepResult & { completionGuardTriggered?: boolean }> {
 	if (step.importAsyncRoot) {
 		let importTimedOut = false;
 		let importStopped = false;
@@ -1336,7 +1302,7 @@ async function runSingleStep(
 				definitionDigest: step.definitionDigest,
 				task: step.launchBindingTask ?? task,
 				...(candidate ? { model: candidate } : {}),
-				modelCandidates: candidates,
+				modelCandidates: candidates as string[],
 				...(resolveEffectiveThinking(candidate, step.thinking) ? { thinking: resolveEffectiveThinking(candidate, step.thinking) } : {}),
 				systemPrompt: appendTurnBudgetSystemPrompt(step.systemPrompt ?? "", ctx.turnBudget),
 				systemPromptMode: step.systemPromptMode,
@@ -3252,9 +3218,11 @@ async function runSubagent(
 					...(thinkingOverride ? {
 						...(model ? { model } : {}),
 						...(thinking ? { thinking } : {}),
-						...(step.parallel.modelCandidates ? { modelCandidates: step.parallel.modelCandidates.map((candidate) => applyThinkingSuffix(candidate, thinkingOverride, true)) } : {}),
+						...(step.parallel.modelCandidates ? { modelCandidates: step.parallel.modelCandidates.flatMap((candidate) => {
+							const resolved = applyThinkingSuffix(candidate, thinkingOverride, true);
+							return resolved ? [resolved] : [];
+						}) } : {}),
 					} : {}),
-					structuredOutput: undefined,
 					structuredOutputSchema: step.parallel.structuredOutputSchema ?? step.parallel.structuredOutput?.schema,
 				};
 			});
@@ -3265,9 +3233,8 @@ async function runSubagent(
 					agent: task.agent,
 					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
 					...(task.context ? { context: task.context } : {}),
-					phase: task.phase ?? step.phase,
-					label: task.label,
-					outputName: undefined,
+					...(task.phase ?? step.phase ? { phase: task.phase ?? step.phase } : {}),
+					...(task.label ? { label: task.label } : {}),
 					structured: Boolean(task.structuredOutputSchema),
 					...(task.agentContract ? { agentContract: task.agentContract } : {}),
 					...(task.launchResolvedExtensions ? { launchResolvedExtensions: task.launchResolvedExtensions } : {}),
@@ -3275,10 +3242,10 @@ async function runSubagent(
 					status: "pending",
 					...(task.sessionFile ? { sessionFile: task.sessionFile } : {}),
 					...(transcriptPath ? { transcriptPath } : {}),
-					skills: task.skills,
-					model: task.model,
-					thinking: task.thinking,
-					attemptedModels: task.modelCandidates && task.modelCandidates.length > 0 ? task.modelCandidates : task.model ? [task.model] : undefined,
+					...(task.skills ? { skills: task.skills } : {}),
+					...(task.model ? { model: task.model } : {}),
+					...(task.thinking ? { thinking: task.thinking } : {}),
+					...(task.modelCandidates && task.modelCandidates.length > 0 ? { attemptedModels: task.modelCandidates } : task.model ? { attemptedModels: [task.model] } : {}),
 					recentTools: [],
 					recentOutput: [],
 				};
@@ -3524,7 +3491,7 @@ async function runSubagent(
 				.filter(({ result, task }) => isAgentContractV1(task?.agentContract ?? step.agentContract) && task?.gateOn === "acceptance" && result.acceptance?.status === "rejected");
 			if (acceptanceFailures.length > 0) {
 				const message = acceptanceFailures
-					.map(({ result, originalIndex }) => `Dynamic item ${originalIndex + 1} (${result.agent}, key ${materialized.items[originalIndex]?.key ?? originalIndex}) acceptance rejected: ${acceptanceFailureMessage(result.acceptance) ?? "acceptance rejected"}`)
+					.map(({ result, originalIndex }) => `Dynamic item ${originalIndex + 1} (${result.agent}, key ${materialized.items[originalIndex]?.key ?? originalIndex}) acceptance rejected: ${(result.acceptance ? acceptanceFailureMessage(result.acceptance) : undefined) ?? "acceptance rejected"}`)
 					.join("\n");
 				results.push({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection });
 				statusPayload.error = message;
@@ -4012,7 +3979,7 @@ async function runSubagent(
 					.map((result, index) => ({ result, index, task: group.parallel[index] }))
 					.find(({ result, task }) => isAgentContractV1(task?.agentContract) && task?.gateOn === "acceptance" && result.acceptance?.status === "rejected");
 				if (acceptanceGateFailure) {
-					statusPayload.error = acceptanceFailureMessage(acceptanceGateFailure.result.acceptance) ?? "Parallel acceptance gate rejected the step.";
+					statusPayload.error = (acceptanceGateFailure.result.acceptance ? acceptanceFailureMessage(acceptanceGateFailure.result.acceptance) : undefined) ?? "Parallel acceptance gate rejected the step.";
 					writeStatusPayload();
 					break;
 				}

--- a/src/runs/foreground/async-steering-action.ts
+++ b/src/runs/foreground/async-steering-action.ts
@@ -121,7 +121,7 @@ export async function steerAsyncRun(input: {
 	if (finalResult?.state === "delivered") {
 		return { content: [{ type: "text", text: `Steering delivered for async run ${status.runId} (request ${requestId}).` }], details: { mode: "management", results: [], steering: finalResult } };
 	}
-	const running = (finalStatus?.steps ?? status.steps).filter((step) => step.status === "running");
+	const running = (finalStatus?.steps ?? status.steps ?? []).filter((step) => step.status === "running");
 	const recoveryAllowed = status.mode === "single" && status.isNested !== true && running.length === 1 && Boolean(finalStatus?.steering) && (input.index === undefined || input.index === 0);
 	if (recoveryAllowed && finalResult?.state !== "scheduled" && input.recover) {
 		const appendSteeringNotice = (state: "failed" | "recovered", message: string): void => {
@@ -194,7 +194,7 @@ export async function steerAsyncRun(input: {
 			const revived = await input.recover(limits);
 			if (revived.isError || !revived.details.asyncId) throw new Error(revived.content[0]?.type === "text" ? revived.content[0].text : "Replacement launch failed; source run remains paused.");
 			const sourceStatus = readStatus(asyncDir);
-			const targetIndex = input.index ?? status.steps.findIndex((step) => step.status === "running");
+			const targetIndex = input.index ?? status.steps?.findIndex((step) => step.status === "running") ?? -1;
 			if (sourceStatus?.state === "paused" && sourceStatus.steering && targetIndex >= 0) {
 				updateSteeringTarget(sourceStatus.steering, requestId, targetIndex, "recovered", Date.now(), { replacementRunId: revived.details.asyncId });
 				const stepSteering = sourceStatus.steps?.[targetIndex]?.steering;
@@ -207,7 +207,7 @@ export async function steerAsyncRun(input: {
 		} catch (error) {
 			const reason = error instanceof Error ? error.message : String(error);
 			const failedStatus = readStatus(asyncDir);
-			const targetIndex = input.index ?? status.steps.findIndex((step) => step.status === "running");
+			const targetIndex = input.index ?? status.steps?.findIndex((step) => step.status === "running") ?? -1;
 			if (failedStatus && failedStatus.state !== "running" && failedStatus.state !== "queued" && failedStatus.steering && targetIndex >= 0) {
 				updateSteeringTarget(failedStatus.steering, requestId, targetIndex, "failed", Date.now(), { reason });
 				const stepSteering = failedStatus.steps?.[targetIndex]?.steering;

--- a/src/runs/foreground/chain-clarify.ts
+++ b/src/runs/foreground/chain-clarify.ts
@@ -775,7 +775,7 @@ export class ChainClarifyComponent implements Component {
 
 	private handleEditInput(data: string): void {
 		const textWidth = this.width - 4; // Must match render: innerW - 2 = (width - 2) - 2
-		if (matchesKey(data, "shift+up") || matchesKey(data, "pageup")) {
+		if (matchesKey(data, "shift+up") || matchesKey(data, "pageUp")) {
 			const { lines: wrapped, starts } = wrapText(this.editState.buffer, textWidth);
 			const cursorPos = getCursorDisplayPos(this.editState.cursor, starts);
 			const targetLine = Math.max(0, cursorPos.line - this.EDIT_VIEWPORT_HEIGHT);
@@ -785,7 +785,7 @@ export class ChainClarifyComponent implements Component {
 			return;
 		}
 
-		if (matchesKey(data, "shift+down") || matchesKey(data, "pagedown")) {
+		if (matchesKey(data, "shift+down") || matchesKey(data, "pageDown")) {
 			const { lines: wrapped, starts } = wrapText(this.editState.buffer, textWidth);
 			const cursorPos = getCursorDisplayPos(this.editState.cursor, starts);
 			const targetLine = Math.min(wrapped.length - 1, cursorPos.line + this.EDIT_VIEWPORT_HEIGHT);

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -629,10 +629,11 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 		?? (isCheckpointStep(firstStep)
 			? undefined
 			: isParallelStep(firstStep)
-				? firstStep.parallel[0]!.task!
+				? firstStep.parallel[0]!.task
 				: isDynamicParallelStep(firstStep)
-					? firstStep.parallel.task!
-					: (firstStep as SequentialStep).task!);
+					? firstStep.parallel.task
+					: (firstStep as SequentialStep).task)
+		?? "";
 	try {
 		validateChainOutputBindings(chainSteps, { maxItems: params.dynamicFanoutMaxItems });
 	} catch (error) {
@@ -942,7 +943,7 @@ ${step.message}` : ""}` }],
 					.filter(({ result, task }) => isAgentContractV1(task?.agentContract ?? step.agentContract ?? params.agentContract) && (task?.gateOn ?? step.gateOn) === "acceptance" && result.acceptance?.status === "rejected");
 				if (acceptanceFailures.length > 0) {
 					const acceptanceSummary = acceptanceFailures
-						.map(({ result, originalIndex }) => `- Task ${originalIndex + 1} (${result.agent}): ${acceptanceFailureMessage(result.acceptance) ?? "acceptance rejected"}`)
+						.map(({ result, originalIndex }) => `- Task ${originalIndex + 1} (${result.agent}): ${(result.acceptance ? acceptanceFailureMessage(result.acceptance) : undefined) ?? "acceptance rejected"}`)
 						.join("\n");
 					const errorMsg = `Parallel step ${stepIndex + 1} acceptance gate failed:\n${acceptanceSummary}`;
 					const summary = buildChainSummary(chainSteps, results, chainDir, "failed", { index: stepIndex, error: errorMsg });
@@ -1185,7 +1186,7 @@ ${step.message}` : ""}` }],
 				.filter(({ result, task }) => isAgentContractV1(task?.agentContract ?? dynamicParallelStep.agentContract ?? params.agentContract) && (task?.gateOn ?? dynamicParallelStep.gateOn) === "acceptance" && result.acceptance?.status === "rejected");
 			if (acceptanceFailures.length > 0) {
 				const acceptanceSummary = acceptanceFailures
-					.map(({ result, originalIndex }) => `- Item ${originalIndex + 1} (${result.agent}, key ${materialized.items[originalIndex]?.key ?? originalIndex}): ${acceptanceFailureMessage(result.acceptance) ?? "acceptance rejected"}`)
+					.map(({ result, originalIndex }) => `- Item ${originalIndex + 1} (${result.agent}, key ${materialized.items[originalIndex]?.key ?? originalIndex}): ${(result.acceptance ? acceptanceFailureMessage(result.acceptance) : undefined) ?? "acceptance rejected"}`)
 					.join("\n");
 				const errorMsg = `Dynamic step ${stepIndex + 1} acceptance gate failed:\n${acceptanceSummary}`;
 				dynamicGroupStatuses[stepIndex] = { status: "failed", error: errorMsg };

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -1347,6 +1347,7 @@ async function runSyncCompletion(
 		assertAgentAllowedByCapabilityCeiling(agent.name, options.capabilityCeiling);
 	} catch (error) {
 		return withRunContext({
+			index: options.index ?? 0,
 			agent: agent.name,
 			task,
 			exitCode: 1,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -38,6 +38,7 @@ import {
 	suppressProgressForReadOnlyTask,
 	taskDisallowsFileUpdates,
 	type ChainStep,
+	type ParallelTaskItem,
 	type ResolvedStepBehavior,
 	type SequentialStep,
 	type StepOverrides,
@@ -168,6 +169,10 @@ export interface SubagentParamsLike {
 	index?: number;
 	view?: "fleet" | "transcript";
 	lines?: number;
+	chainName?: string;
+	config?: unknown;
+	name?: string;
+	type?: string;
 	agent?: string;
 	task?: string;
 	message?: string;
@@ -593,7 +598,7 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 	});
 }
 
-function resolveForegroundResumeTarget(params: SubagentParamsLike, state: SubagentState): { runId: string; mode: "single" | "parallel" | "chain"; state: "complete"; agent: string; index: number; cwd: string; sessionFile: string; model?: string; thinking?: string; launchContractDigest?: string; capabilityCeiling?: ResolvedSubagentCapabilityCeiling } | undefined {
+function resolveForegroundResumeTarget(params: SubagentParamsLike, state: SubagentState): { runId: string; mode: SubagentRunMode; state: "complete"; agent: string; index: number; cwd: string; sessionFile: string; model?: string; thinking?: string; launchContractDigest?: string; capabilityCeiling?: ResolvedSubagentCapabilityCeiling } | undefined {
 	const requested = (params.id ?? params.runId)?.trim();
 	if (!requested || !state.foregroundRuns?.size || !state.currentSessionId) return undefined;
 	const sessionRuns = [...state.foregroundRuns.values()].filter((run) => run.sessionId === state.currentSessionId);
@@ -638,6 +643,9 @@ type NestedResumeSourceTarget = {
 	index: number;
 	cwd?: string;
 	sessionFile: string;
+	model?: string;
+	thinking?: AgentConfig["thinking"];
+	launchContractDigest?: string;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 };
 type ResumeSourceTarget = AsyncResumeSourceTarget | ForegroundResumeSourceTarget | NestedResumeSourceTarget;
@@ -843,7 +851,7 @@ function appendStepToAsyncChain(input: {
 			details: { mode: "management", results: [] },
 		};
 	}
-	const acceptanceErrors = validateExecutionAcceptance(input.params);
+	const acceptanceErrors = validateExecutionAcceptance(input.params as Parameters<typeof validateExecutionAcceptance>[0]);
 	if (acceptanceErrors.length > 0) {
 		return {
 			content: [{ type: "text", text: `Cannot append step: ${acceptanceErrors.join(" ")}` }],
@@ -1206,7 +1214,7 @@ async function resumeAsyncRun(input: {
 			details: { mode: "management", results: [] },
 		};
 	}
-	const acceptanceErrors = validateExecutionAcceptance(input.params);
+	const acceptanceErrors = validateExecutionAcceptance(input.params as Parameters<typeof validateExecutionAcceptance>[0]);
 	if (acceptanceErrors.length > 0) {
 		return {
 			content: [{ type: "text", text: `Cannot resume: ${acceptanceErrors.join(" ")}` }],
@@ -1245,7 +1253,7 @@ async function resumeAsyncRun(input: {
 			];
 			target = resolveNestedResumeTarget(resolved, trustedSessionRoots);
 		} else {
-			if (resolved?.kind === "async") {
+			if (resolved?.kind === "async" && resolved.location.asyncDir) {
 				const unsupported = externalRunnerControlError(resolved.location.asyncDir, "resume");
 				if (unsupported) return unsupported;
 			}
@@ -1394,6 +1402,10 @@ async function resumeAsyncRun(input: {
 		return { content: [{ type: "text", text: formatAsyncStartedMessage(lines.join("\n"), input.ctx.hasUI) }], details: result.details };
 	}
 
+	const revivalSessionFile = target.sessionFile;
+	if (!revivalSessionFile) {
+		return { content: [{ type: "text", text: `Async child '${target.runId}' has no persisted session file to resume.` }], isError: true, details: { mode: "management", results: [] } };
+	}
 	const runId = randomUUID().slice(0, 8);
 	const recoveryAgentConfig = recoveryDescriptor ? applySteeringRecoveryAgentConfig(agentConfig, recoveryDescriptor) : agentConfig;
 	const artifactConfig: ArtifactConfig = recoveryDescriptor?.artifactConfig ?? { ...DEFAULT_ARTIFACT_CONFIG, enabled: input.params.artifacts !== false, dir: input.deps.config.artifactDir ?? DEFAULT_ARTIFACT_CONFIG.dir };
@@ -1402,7 +1414,7 @@ async function resumeAsyncRun(input: {
 	const parentModel = input.parentModel;
 	const result = executeAsyncSingle(runId, {
 		agent: target.agent,
-		task: buildRevivedAsyncTask(target, followUp),
+		task: buildRevivedAsyncTask(target as Parameters<typeof buildRevivedAsyncTask>[0], followUp),
 		goal: followUp,
 		agentConfig: recoveryAgentConfig,
 		ctx: {
@@ -1420,11 +1432,11 @@ async function resumeAsyncRun(input: {
 		artifactsDir,
 		artifactConfig,
 		shareEnabled: recoveryDescriptor?.share ?? input.params.share === true,
-		sessionRoot: input.deps.getSubagentSessionRoot(parentSessionFile),
+		sessionRoot: input.deps.getSubagentSessionRoot(parentSessionFile ?? revivalSessionFile),
 		...(recoveryDescriptor?.sessionDir ? { sessionDir: recoveryDescriptor.sessionDir } : {}),
-		sessionFile: target.sessionFile,
+		sessionFile: revivalSessionFile,
 		revivalLease: {
-			sessionFile: target.sessionFile,
+			sessionFile: revivalSessionFile,
 			runId,
 			sourceRunId: target.runId,
 			...(input.deps.state.currentSessionId ? { parentSessionId: input.deps.state.currentSessionId } : {}),
@@ -1610,7 +1622,7 @@ function canonicalizeExecutionParams(params: SubagentParamsLike, agents: AgentCo
 		for (let index = 0; index < params.chain.length; index++) {
 			const step = params.chain[index]!;
 			if (isParallelStep(step)) {
-				const parallel: typeof step.parallel = [];
+				const parallel: ParallelTaskItem[] = [];
 				for (let taskIndex = 0; taskIndex < step.parallel.length; taskIndex++) {
 					const task = step.parallel[taskIndex]!;
 					const result = resolve(task.agent, `step ${index + 1}, task ${taskIndex + 1}`);
@@ -1660,7 +1672,7 @@ function validateExecutionInput(
 		};
 	}
 
-	const acceptanceErrors = validateExecutionAcceptance(params);
+	const acceptanceErrors = validateExecutionAcceptance(params as Parameters<typeof validateExecutionAcceptance>[0]);
 	if (acceptanceErrors.length > 0) {
 		return {
 			content: [{ type: "text", text: acceptanceErrors.join(" ") }],
@@ -1912,7 +1924,7 @@ function expandChainParallelCounts(chain: ChainStep[]): { chain?: ChainStep[]; e
 			expandedChain.push(step);
 			continue;
 		}
-		const expandedParallel = [];
+		const expandedParallel: ParallelTaskItem[] = [];
 		for (let taskIndex = 0; taskIndex < step.parallel.length; taskIndex++) {
 			const task = step.parallel[taskIndex]!;
 			const rawCount = (task as typeof task & { count?: unknown }).count;
@@ -2409,7 +2421,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 	const chainSkills = normalized === false ? [] : (normalized ?? []);
 	const chain = wrapChainTasksForFork(params.chain as ChainStep[], contextPolicy);
 	const currentMaxSubagentDepth = resolveCurrentMaxSubagentDepth(deps.config.maxSubagentDepth);
-	const chainCtx = normalizeParentModel(ctx.model) || !data.parentModel ? ctx : { ...ctx, model: data.parentModel };
+	const chainCtx = normalizeParentModel(ctx.model) || !data.parentModel ? ctx : ({ ...ctx, model: data.parentModel } as ExtensionContext);
 	const chainResult = await executeChain({
 		chain,
 		task: params.task,
@@ -3513,7 +3525,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		: undefined;
 
 	const deadlineAt = data.deadlineAt ?? (data.timeoutMs !== undefined ? Date.now() + data.timeoutMs : undefined);
-	let r: Awaited<ReturnType<typeof runSync>>;
+	let r: Awaited<ReturnType<typeof runSync>> | undefined;
 	try {
 		r = await runSync(ctx.cwd, agents, params.agent!, task, {
 			parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
@@ -4212,7 +4224,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							return { content: [{ type: "text", text: `Run '${resolved.id}' was not found in the active session.` }], isError: true, details: { mode: "management", results: [] } };
 						}
 						const decidedAt = Date.now();
-						const checkpoint = { ...run.checkpoint, status: decision, ...(decision === "approved" ? { approvedAt: decidedAt } : { rejectedAt: decidedAt }) };
+						const checkpoint: NonNullable<Details["checkpoint"]> = decision === "approved"
+							? { ...run.checkpoint, status: "approved", approvedAt: decidedAt }
+							: { ...run.checkpoint, status: "rejected", rejectedAt: decidedAt };
 						run.checkpoint = checkpoint;
 						run.updatedAt = decidedAt;
 						return {
@@ -4294,8 +4308,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (resolved?.kind === "nested") return steerNestedRun({ target: resolved, message, index: paramsWithResolvedCwd.index, signal });
 				if (resolved?.kind === "foreground") return { content: [{ type: "text", text: "action='steer' currently supports live async Pi child sessions only; use action='interrupt' or action='resume' for foreground runs." }], isError: true, details: { mode: "management", results: [] } };
 				if (resolved?.kind !== "async") return { content: [{ type: "text", text: `No async run found for '${targetRunId}'.` }], isError: true, details: { mode: "management", results: [] } };
-				const unsupported = externalRunnerControlError(resolved.location.asyncDir, "steer");
-				if (unsupported) return unsupported;
+				if (resolved.location.asyncDir) {
+					const unsupported = externalRunnerControlError(resolved.location.asyncDir, "steer");
+					if (unsupported) return unsupported;
+				}
 				return steerAsyncRun({
 					state: deps.state,
 					runId: resolved.id,
@@ -4344,7 +4360,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (paramsWithResolvedCwd.dir) {
 					try {
 						const location = resolveAsyncRunLocation(paramsWithResolvedCwd, DIRS.async, DIRS.results);
-						return stopAsyncRun(deps.state, location.resolvedId ?? targetRunId ?? path.basename(location.asyncDir ?? paramsWithResolvedCwd.dir), deps.kill, location);
+						const stopResult = stopAsyncRun(deps.state, location.resolvedId ?? targetRunId ?? path.basename(location.asyncDir ?? paramsWithResolvedCwd.dir), deps.kill, location);
+						return stopResult ?? { content: [{ type: "text", text: `No running or queued async run was found for '${targetRunId ?? paramsWithResolvedCwd.dir}'.` }], isError: true, details: { mode: "management", results: [] } };
 					} catch (error) {
 						const text = error instanceof Error ? error.message : String(error);
 						return { content: [{ type: "text", text }], isError: true, details: { mode: "management", results: [] } };

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -311,7 +311,7 @@ export function validateExecutionAcceptance(input: {
 }
 
 function normalizeCriteria(criteria: Array<string | { id?: string; must?: string; evidence?: AcceptanceEvidenceKind[]; severity?: "required" | "recommended" }> | undefined, evidence: AcceptanceEvidenceKind[]): ResolvedAcceptanceGate[] {
-	return (criteria ?? []).map((criterion, index) => {
+	return (criteria ?? []).map((criterion, index): ResolvedAcceptanceGate => {
 		if (typeof criterion === "string") {
 			return { id: `criterion-${index + 1}`, must: criterion, evidence, severity: "required" };
 		}
@@ -405,7 +405,7 @@ export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig, opt
 		lines.push("", "Runtime verification commands configured by parent:");
 		for (const command of acceptance.verify) lines.push(`- ${command.id}: ${command.command}`);
 	}
-	if (acceptance.review && acceptance.review !== false) {
+	if (acceptance.review) {
 		lines.push("", `Review gate: ${acceptance.review.required === false ? "optional" : "required"}${acceptance.review.agent ? ` by ${acceptance.review.agent}` : ""}.`);
 		if (acceptance.review.focus) lines.push(`Review focus: ${acceptance.review.focus}`);
 	}
@@ -959,7 +959,7 @@ function uniqueStrings(items: Array<string | undefined>): string[] {
 }
 
 export function aggregateAcceptanceReport(input: {
-	results: Array<Pick<SingleResult, "agent" | "acceptance" | "error" | "exitCode">>;
+	results: Array<Pick<SingleResult, "agent" | "acceptance" | "error"> & { exitCode: number | null }>;
 	notes?: string;
 }): AcceptanceReport {
 	const childReports = input.results.map((result) => result.acceptance?.childReport).filter((report): report is AcceptanceReport => Boolean(report));
@@ -969,7 +969,7 @@ export function aggregateAcceptanceReport(input: {
 		criteriaSatisfied: [
 			{ id: "criterion-1", status: successfulChildren ? "satisfied" : "not-satisfied", evidence: successfulChildren ? `All ${input.results.length} dynamic child run(s) completed without child or acceptance blockers.` : "Dynamic fanout produced no accepted child evidence." },
 			{ id: "criterion-2", status: successfulChildren ? "satisfied" : "not-satisfied", evidence: successfulChildren ? "Collected child acceptance evidence for aggregate review." : "Dynamic fanout produced no aggregate review evidence." },
-			...input.results.map((result, index) => ({
+			...input.results.map((result, index): { id?: string; status: "satisfied" | "not-satisfied" | "not-applicable"; evidence: string } => ({
 				id: `child-${index + 1}`,
 				status: result.exitCode === 0 && result.acceptance?.status !== "rejected" ? "satisfied" : "not-satisfied",
 				evidence: `${result.agent}: acceptance ${result.acceptance?.status ?? "unreported"}${result.error ? ` (${result.error})` : ""}`,
@@ -1165,7 +1165,7 @@ export async function evaluateAcceptance(input: {
 		ledger.evidenceStatus = ledger.status;
 	}
 
-	if (acceptance.review && acceptance.review !== false) {
+	if (acceptance.review) {
 		if (input.reviewResult?.status === "reviewed") {
 			ledger.reviewResult = input.reviewResult;
 			ledger.status = "reviewed";

--- a/src/runs/shared/child-protocol.ts
+++ b/src/runs/shared/child-protocol.ts
@@ -100,7 +100,7 @@ export function createBoundedByteTail(maxBytes = MAX_CHILD_STDERR_BYTES): {
 	byteLength(): number;
 } {
 	if (!Number.isInteger(maxBytes) || maxBytes < 1) throw new Error("maxBytes must be a positive integer.");
-	let tail = Buffer.alloc(0);
+	let tail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
 	return {
 		push(chunk) {
 			const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;

--- a/src/runs/shared/dynamic-fanout.ts
+++ b/src/runs/shared/dynamic-fanout.ts
@@ -264,7 +264,7 @@ export function materializeDynamicParallelStep(step: DynamicParallelStep, output
 export function collectDynamicResults(
 	step: DynamicParallelStep,
 	items: DynamicMaterializedItem[],
-	results: Array<Pick<SingleResult, "agent" | "exitCode" | "error" | "timedOut" | "stopped" | "structuredOutput" | "artifactPaths" | "savedOutputPath"> & { output?: string; finalOutput?: string }>,
+	results: Array<Pick<SingleResult, "agent" | "error" | "timedOut" | "stopped" | "structuredOutput" | "artifactPaths" | "savedOutputPath"> & { exitCode: number | null; output?: string; finalOutput?: string }>,
 ): DynamicCollectedResult[] {
 	return items.map((entry, index) => {
 		const result = results[index];

--- a/src/runs/shared/nested-render.ts
+++ b/src/runs/shared/nested-render.ts
@@ -8,12 +8,13 @@ export interface NestedRunCounts {
 	paused: number;
 	complete: number;
 	failed: number;
+	rejected: number;
 	stopped: number;
 	queued: number;
 }
 
 export function countNestedRuns(children: NestedRunSummary[] | undefined): NestedRunCounts {
-	const counts: NestedRunCounts = { total: 0, running: 0, paused: 0, complete: 0, failed: 0, stopped: 0, queued: 0 };
+	const counts: NestedRunCounts = { total: 0, running: 0, paused: 0, complete: 0, failed: 0, rejected: 0, stopped: 0, queued: 0 };
 	for (const child of children ?? []) {
 		counts.total++;
 		counts[child.state]++;
@@ -23,6 +24,7 @@ export function countNestedRuns(children: NestedRunSummary[] | undefined): Neste
 		counts.paused += nested.paused;
 		counts.complete += nested.complete;
 		counts.failed += nested.failed;
+		counts.rejected += nested.rejected;
 		counts.stopped += nested.stopped;
 		counts.queued += nested.queued;
 	}
@@ -36,6 +38,7 @@ export function formatNestedAggregate(children: NestedRunSummary[] | undefined):
 		counts.running > 0 ? `${counts.running} running` : "",
 		counts.paused > 0 ? `${counts.paused} paused` : "",
 		counts.failed > 0 ? `${counts.failed} failed` : "",
+		counts.rejected > 0 ? `${counts.rejected} rejected` : "",
 		counts.stopped > 0 ? `${counts.stopped} stopped` : "",
 		counts.complete > 0 ? `${counts.complete} complete` : "",
 		counts.queued > 0 ? `${counts.queued} queued` : "",

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -89,6 +89,8 @@ export interface DynamicRunnerGroup {
 	acceptanceRole?: import("../../shared/types.ts").AcceptanceRole;
 	agentContract?: import("../../shared/types.ts").AgentContract;
 	gateOn?: import("../../shared/types.ts").ChainGateLayer;
+	capabilityCeiling?: import("./capability-ceiling.ts").ResolvedSubagentCapabilityCeiling;
+	capabilityAudit?: import("./capability-ceiling.ts").SubagentCapabilityAudit;
 }
 
 export type RunnerStep = RunnerSubagentStep | ParallelStepGroup | DynamicRunnerGroup | RunnerCheckpointStep;

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -125,7 +125,11 @@ export interface ResolvePiLaunchToolPlanInput {
 	mcpDirectTools?: string[];
 	cwd?: string;
 	requireReadTool?: boolean;
-	structuredOutput?: boolean;
+	structuredOutput?: boolean | {
+		schema: JsonSchemaObject;
+		schemaPath: string;
+		outputPath: string;
+	};
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	inheritedCapabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	agentName?: string;

--- a/src/runs/shared/run-history.ts
+++ b/src/runs/shared/run-history.ts
@@ -176,6 +176,6 @@ export function loadRunsForAgent(agent: string): RunEntry[] {
 
 	return lines
 		.map((line) => { try { return JSON.parse(line) as RunEntry; } catch { return undefined; } })
-		.filter((entry): entry is RunEntry => Boolean(entry) && entry.agent === agent)
+		.filter((entry): entry is RunEntry => entry !== undefined && entry.agent === agent)
 		.reverse();
 }

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -360,7 +360,7 @@ export function registerSteeringInbox(
 		return undefined;
 	};
 
-	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown) => unknown) => void;
+	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown, ctx?: unknown) => unknown) => void;
 	// Register input before the watcher so an accepted extension input cannot race request dispatch.
 	onRuntimeEvent("input", onInput);
 	onRuntimeEvent("session_start", () => start());
@@ -408,7 +408,7 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		nativeSupervisorFallbackRegistered = true;
 		registerNativeSupervisorClient(pi);
 	};
-	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown) => unknown) => void;
+	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown, ctx?: unknown) => unknown) => void;
 	onRuntimeEvent("session_start", (_event: unknown, ctx: unknown) => {
 		const sessionManager = (ctx as { sessionManager?: Parameters<typeof resolveCurrentSessionId>[0] } | undefined)?.sessionManager;
 		waitState.currentSessionId = sessionManager ? resolveCurrentSessionId(sessionManager) : null;
@@ -455,13 +455,15 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		});
 	}
 
-	onRuntimeEvent("context", (event: { messages: unknown[] }) => {
+	onRuntimeEvent("context", (event: unknown) => {
+		if (!event || typeof event !== "object" || !("messages" in event) || !Array.isArray(event.messages)) return undefined;
 		const messages = stripParentOnlySubagentMessages(event.messages);
 		if (messages === event.messages) return undefined;
 		return { messages };
 	});
 
-	onRuntimeEvent("before_agent_start", async (event: { systemPrompt: string }) => {
+	onRuntimeEvent("before_agent_start", async (event: unknown) => {
+		if (!event || typeof event !== "object" || !("systemPrompt" in event) || typeof event.systemPrompt !== "string") return undefined;
 		registerNativeSupervisorFallbackOnce();
 		const intercomSessionName = process.env[SUBAGENT_INTERCOM_SESSION_NAME_ENV]?.trim();
 		if (intercomSessionName && typeof pi.setSessionName === "function") {

--- a/src/runs/shared/turn-budget.ts
+++ b/src/runs/shared/turn-budget.ts
@@ -23,9 +23,10 @@ export function resolveTurnBudgetConfig(
 	return { turnBudget: { maxTurns: budget.maxTurns, graceTurns } };
 }
 
-export function appendTurnBudgetSystemPrompt(systemPrompt: string, budget: ResolvedTurnBudget | undefined): string {
+export function appendTurnBudgetSystemPrompt(systemPrompt: string, budget: { maxTurns: number; graceTurns?: number } | undefined): string {
 	if (!budget) return systemPrompt;
-	const grace = budget.graceTurns === 1 ? "1 additional assistant turn" : `${budget.graceTurns} additional assistant turns`;
+	const graceTurns = budget.graceTurns ?? DEFAULT_TURN_BUDGET_GRACE_TURNS;
+	const grace = graceTurns === 1 ? "1 additional assistant turn" : `${graceTurns} additional assistant turns`;
 	const block = [
 		"## Turn budget",
 		`This child run has a soft budget of ${budget.maxTurns} assistant turn${budget.maxTurns === 1 ? "" : "s"}.`,
@@ -55,8 +56,8 @@ export function formatTurnBudgetOutput(message: string, output: string): string 
 		: message;
 }
 
-export function initialTurnBudgetState(budget: ResolvedTurnBudget): TurnBudgetState {
-	return { ...budget, outcome: "within-budget", turnCount: 0 };
+export function initialTurnBudgetState(budget: { maxTurns: number; graceTurns?: number }): TurnBudgetState {
+	return { maxTurns: budget.maxTurns, graceTurns: budget.graceTurns ?? DEFAULT_TURN_BUDGET_GRACE_TURNS, outcome: "within-budget", turnCount: 0 };
 }
 
 export function turnBudgetState(budget: ResolvedTurnBudget, turnCount: number, exceeded: boolean): TurnBudgetState {

--- a/src/shared/fork-context.ts
+++ b/src/shared/fork-context.ts
@@ -77,8 +77,9 @@ function isUnsafeAnthropicThinkingBlock(message: BranchSessionEntry["message"], 
 	const isAnthropic = provider === "anthropic" || api === "anthropic-messages" || model.startsWith("anthropic/");
 	if (block.type === "redacted_thinking") return true;
 	if (block.type !== "thinking" || !isAnthropic) return false;
-	const signature = "thinkingSignature" in block ? block.thinkingSignature : "signature" in block ? block.signature : undefined;
-	return block.redacted === true || (typeof signature === "string" && signature.length > 0);
+	const record = block as Record<string, unknown>;
+	const signature = "thinkingSignature" in record ? record.thinkingSignature : "signature" in record ? record.signature : undefined;
+	return record.redacted === true || (typeof signature === "string" && signature.length > 0);
 }
 
 function createEntryId(entries: BranchSessionEntry[]): string {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -120,6 +120,16 @@ export interface CheckpointStep {
 	message?: string;
 	phase?: string;
 	label?: string;
+	agent?: string;
+	task?: string;
+	as?: string;
+	output?: string | false;
+	outputMode?: OutputMode;
+	reads?: string[] | false;
+	progress?: boolean;
+	skill?: string | string[] | false;
+	skills?: string[] | false;
+	model?: string;
 }
 
 /** Parallel step: multiple agents running concurrently */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,7 +75,7 @@ export interface ChainCheckpointState {
 
 export interface WorkflowGraphSnapshot {
 	runId: string;
-	mode: "chain" | "parallel" | "single";
+	mode: SubagentRunMode;
 	phases: Array<{ title: string; nodeIds: string[] }>;
 	nodes: WorkflowGraphNode[];
 	currentNodeId?: string;
@@ -380,6 +380,8 @@ interface ProcessTerminalBaseV1 {
 	runId: string;
 	childIndex?: number;
 	runnerProcessInstanceId: string;
+	observedAt?: number;
+	reason?: ProcessTerminalReason;
 	resumeDisposition?: "resumable" | "non-resumable" | "unavailable";
 }
 
@@ -398,7 +400,7 @@ export type ProcessTerminalV1 =
 	});
 
 export type SteeringActionState = "delivered" | "scheduled" | "pending" | "partial" | "recovered" | "failed";
-export type SteeringTargetState = "scheduled" | "routed" | "delivered" | "late" | "failed" | "recovered";
+export type SteeringTargetState = "scheduled" | "pending" | "routed" | "delivered" | "late" | "failed" | "recovered";
 
 export interface SteeringTargetStatus {
 	index: number;
@@ -494,6 +496,7 @@ export interface SteeringRecoveryDescriptor {
 	maxSubagentDepth: number;
 	maxOutput?: MaxOutputConfig;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	launchResolvedExtensions?: LaunchResolvedChildExtensionsV1;
 	share: boolean;
 	sessionDir?: string;
 	artifactsDir?: string;
@@ -602,8 +605,21 @@ export interface ToolCallSummary {
 }
 
 interface ProgressSummary {
+	index?: number;
+	agent?: string;
+	status?: AgentProgress["status"];
+	activityState?: ActivityState;
+	skills?: string[];
+	lastActivityAt?: number;
+	currentTool?: string;
+	currentToolArgs?: string;
+	currentToolStartedAt?: number;
+	recentTools?: Array<{ tool: string; args: string; endMs: number }>;
+	recentOutput?: string[];
 	toolCount: number;
 	tokens: number;
+	model?: string;
+	thinking?: string;
 	durationMs: number;
 }
 
@@ -1200,6 +1216,7 @@ export interface AsyncStatus {
 	runId: string;
 	sessionId?: string;
 	mode: SubagentRunMode;
+	context?: "fresh" | "fork" | "mixed";
 	isNested?: boolean;
 	state: "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
 	error?: string;
@@ -1298,7 +1315,7 @@ export interface AsyncStatus {
 		agentContract?: AgentContract;
 		launchContractDigest?: string;
 		launchResolvedExtensions?: LaunchResolvedChildExtensionsV1;
-	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1;
+		runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1;
 		execution?: ExecutionProjection;
 		review?: ReviewProjection;
 		effects?: EffectsProjection;
@@ -1310,7 +1327,6 @@ export interface AsyncStatus {
 	sessionDir?: string;
 	outputFile?: string;
 	totalTokens?: TokenUsage;
-	usageBudget?: UsageBudgetState;
 	totalCost?: CostSummary;
 	sessionFile?: string;
 	outputs?: ChainOutputMap;

--- a/src/slash/delegation-adapters.ts
+++ b/src/slash/delegation-adapters.ts
@@ -534,7 +534,7 @@ export function toSubagentDelegationV2Response(
 			error = "Delegated subagent did not capture the requested structured result.";
 		} else {
 			const inspected = cloneJsonWithinByteLimit(child.structuredOutput, MAX_V2_RESULT_BYTES);
-			if (!inspected.ok) {
+			if (inspected.ok === false) {
 				status = "failed";
 				error = inspected.reason === "too_large"
 					? "Delegated structured result exceeds 1 MiB when encoded."
@@ -545,6 +545,7 @@ export function toSubagentDelegationV2Response(
 		}
 	}
 	const usage = child?.usage;
+	const childLaunchContractDigest = (child as { launchContractDigest?: string } | undefined)?.launchContractDigest;
 	return {
 		version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 		requestId: request.requestId,
@@ -557,7 +558,7 @@ export function toSubagentDelegationV2Response(
 		...(child?.model ? { model: child.model } : {}),
 		...(child?.thinking ? { thinking: child.thinking } : {}),
 		...(typeof child?.exitCode === "number" ? { exitCode: child.exitCode } : {}),
-		...(child?.launchContractDigest ? { launchContractDigest: child.launchContractDigest } : {}),
+		...(childLaunchContractDigest ? { launchContractDigest: childLaunchContractDigest } : {}),
 		...(projectedResult ? { result: projectedResult } : {}),
 		...(usage ? {
 			usage: {

--- a/src/slash/delegation-request.ts
+++ b/src/slash/delegation-request.ts
@@ -85,7 +85,8 @@ function validateSharedFields(
 	if (value.timeoutMs !== undefined && (typeof value.timeoutMs !== "number" || !Number.isInteger(value.timeoutMs) || value.timeoutMs < 1)) {
 		return { ok: false, ...identity, error: "timeoutMs must be an integer >= 1." };
 	}
-	if (identity.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION && value.timeoutMs !== undefined && value.timeoutMs > 2_147_483_647) {
+	const timeoutMs = typeof value.timeoutMs === "number" ? value.timeoutMs : undefined;
+	if (identity.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION && timeoutMs !== undefined && timeoutMs > 2_147_483_647) {
 		return { ok: false, ...identity, error: "timeoutMs must be <= 2147483647 for delegation v2." };
 	}
 	const turnBudget = resolveTurnBudgetConfig(value.turnBudget);
@@ -170,7 +171,7 @@ function parseV2(value: Record<string, unknown>, requestId: string): SubagentDel
 			return { ok: false, ...identity, error: "result.schema must be a JSON Schema object." };
 		}
 		const inspectedSchema = cloneJsonWithinByteLimit(result.schema, MAX_SCHEMA_BYTES);
-		if (!inspectedSchema.ok) {
+		if (inspectedSchema.ok === false) {
 			return {
 				ok: false,
 				...identity,

--- a/src/slash/prompt-workflows.ts
+++ b/src/slash/prompt-workflows.ts
@@ -245,7 +245,7 @@ function workflowChainStep(workflow: PromptWorkflow, args: string[], runtime: Re
 		...(params.model ? { model: params.model } : {}),
 		...(params.skill !== undefined ? { skill: params.skill } : {}),
 		...(params.cwd ? { cwd: params.cwd } : {}),
-	};
+	} as ChainStep;
 }
 
 function findWorkflow(workflows: PromptWorkflow[], name: string): PromptWorkflow | undefined {
@@ -273,7 +273,7 @@ export function registerPromptWorkflowCommands(input: {
 			const name = words.shift();
 			const workflows = discoverPromptWorkflows(ctx.cwd);
 			if (!name || name === "list") {
-				pi.sendMessage({ content: formatWorkflowList(workflows), display: true });
+				pi.sendMessage({ content: formatWorkflowList(workflows), display: true } as Parameters<typeof pi.sendMessage>[0]);
 				return;
 			}
 			const workflow = findWorkflow(workflows, name);
@@ -306,7 +306,7 @@ export function registerPromptWorkflowCommands(input: {
 			const { declaration, argsText } = splitChainDeclaration(rawArgs);
 			const workflows = discoverPromptWorkflows(ctx.cwd);
 			if (!declaration || declaration === "list") {
-				pi.sendMessage({ content: formatWorkflowList(workflows), display: true });
+				pi.sendMessage({ content: formatWorkflowList(workflows), display: true } as Parameters<typeof pi.sendMessage>[0]);
 				return;
 			}
 			const runtime = parseRuntimeOptions(shellWords(argsText));

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -367,6 +367,8 @@ class SubagentsStopSelector implements Component {
 		}
 	}
 
+	invalidate(): void {}
+
 	render(width: number): string[] {
 		const contentWidth = Math.max(40, Math.min(this.width, width || this.width));
 		const lines = [this.theme.bold("Stop subagent run"), this.theme.fg("dim", "Select a current-session async run to stop, or a scheduled run to cancel."), ""];
@@ -548,21 +550,22 @@ const mapSavedChainSteps = (chain: ChainConfig, worktree = false): ChainStep[] =
 				collect: { ...step.collect, ...(collectSchema ? { outputSchema: collectSchema } : {}) },
 			};
 		}
+		if ("checkpoint" in step || !("agent" in step) || typeof step.agent !== "string") return step;
 		const outputSchema = loadSavedOutputSchema(chain, step.agent, (step as { outputSchema?: unknown }).outputSchema);
 		return {
 			agent: step.agent,
-			task: step.task || undefined,
+			...(step.task ? { task: step.task } : {}),
 			...(step.phase ? { phase: step.phase } : {}),
 			...(step.label ? { label: step.label } : {}),
 			...(step.as ? { as: step.as } : {}),
 			...(outputSchema ? { outputSchema } : {}),
-			...((step as { acceptance?: unknown }).acceptance !== undefined ? { acceptance: (step as { acceptance?: unknown }).acceptance } : {}),
-			output: step.output,
-			outputMode: step.outputMode,
-			reads: step.reads,
-			progress: step.progress,
-			skill: step.skill ?? step.skills,
-			model: step.model,
+			...(step.acceptance !== undefined ? { acceptance: step.acceptance } : {}),
+			...(step.output !== undefined ? { output: step.output } : {}),
+			...(step.outputMode ? { outputMode: step.outputMode } : {}),
+			...(step.reads !== undefined ? { reads: step.reads } : {}),
+			...(step.progress !== undefined ? { progress: step.progress } : {}),
+			...((step.skill ?? step.skills) !== undefined ? { skill: step.skill ?? step.skills } : {}),
+			...(step.model ? { model: step.model } : {}),
 		};
 	});
 };
@@ -1083,7 +1086,7 @@ export function buildChainExpressionSteps(
 		const baseCwd = state.baseCwd!; // parseAgentArgs already verified baseCwd is set
 		try {
 			const chain: ChainStep[] = parsed.steps.map((step, i) =>
-				mapParsedTaskToStepObject(step, parsed.task || undefined, i === 0, { baseCwd, inGroup: false }),
+				mapParsedTaskToStepObject(step, parsed.task || undefined, i === 0, { baseCwd, inGroup: false }) as ChainStep,
 			);
 			return { chain, task: parsed.task };
 		} catch (error) {
@@ -1136,7 +1139,7 @@ export function buildChainExpressionSteps(
 	const baseCwd = state.baseCwd;
 	let chain: ChainStep[];
 	try {
-		chain = expression.steps.map((step) => {
+		chain = expression.steps.map((step): ChainStep => {
 			if (step.kind === "group") {
 				const parallel = step.tasks.map((t) => mapParsedTaskToStepObject(t, undefined, false, { baseCwd, inGroup: true }));
 				return {
@@ -1144,9 +1147,9 @@ export function buildChainExpressionSteps(
 					...(step.config.concurrency !== undefined ? { concurrency: step.config.concurrency } : {}),
 					...(step.config.failFast !== undefined ? { failFast: step.config.failFast } : {}),
 					...(step.config.worktree !== undefined ? { worktree: step.config.worktree } : {}),
-				};
+				} as ChainStep;
 			}
-			return mapParsedTaskToStepObject(step, sharedTask || undefined, false, { baseCwd, inGroup: false });
+			return mapParsedTaskToStepObject(step, sharedTask || undefined, false, { baseCwd, inGroup: false }) as ChainStep;
 		});
 	} catch (error) {
 		notify(error instanceof Error ? error.message : String(error));
@@ -1430,7 +1433,7 @@ export function registerSlashCommands(
 		},
 		handler: async (args, ctx) => {
 			const parsed = parseSingleRequiredArg(args, "Usage: /subagents-load-profile <name>");
-			if (!parsed.ok) {
+			if (parsed.ok === false) {
 				ctx.ui.notify(parsed.message, "error");
 				return;
 			}
@@ -1481,7 +1484,7 @@ export function registerSlashCommands(
 			const force = /(?:^|\s)--force$/.test(trimmed) || /(?:^|\s)force$/.test(trimmed);
 			const withoutForce = trimmed.replace(/(?:^|\s)(?:--force|force)$/, "").trim();
 			const parsed = parseSingleRequiredArg(withoutForce, "Usage: /subagents-refresh-provider-models <provider> [--force]");
-			if (!parsed.ok) {
+			if (parsed.ok === false) {
 				ctx.ui.notify(parsed.message, "error");
 				return;
 			}
@@ -1512,7 +1515,7 @@ export function registerSlashCommands(
 		getArgumentCompletions: makeProviderCompletions(state),
 		handler: async (args, ctx) => {
 			const parsed = parseSingleRequiredArg(args, "Usage: /subagents-generate-profiles <provider>");
-			if (!parsed.ok) {
+			if (parsed.ok === false) {
 				ctx.ui.notify(parsed.message, "error");
 				return;
 			}
@@ -1555,7 +1558,7 @@ export function registerSlashCommands(
 		},
 		handler: async (args, ctx) => {
 			const parsed = parseSingleRequiredArg(args, "Usage: /subagents-check-profile <name>");
-			if (!parsed.ok) {
+			if (parsed.ok === false) {
 				ctx.ui.notify(parsed.message, "error");
 				return;
 			}

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -827,7 +827,7 @@ export async function openSubagentFleet(ctx: ExtensionContext, state: SubagentSt
 			runId: input.runId,
 			...(input.index !== undefined ? { index: input.index } : {}),
 			message: input.message,
-			location: { asyncDir: input.asyncDir, resolvedId: input.runId },
+			location: { asyncDir: input.asyncDir, resolvedId: input.runId } as Parameters<typeof steerAsyncRun>[0]["location"],
 		}), `Failed to steer async run ${input.runId}.`),
 		stop: (input: { runId: string; asyncDir: string; index?: number }) => firstToolResultText(stopAsyncRun(state, input.runId, undefined, { asyncDir: input.asyncDir, resolvedId: input.runId }), `Failed to stop async run ${input.runId}.`),
 		inspect: async (input: { runId: string; asyncDir: string; index?: number }) => firstToolResultText(await handleHerdrInspectorAction("inspector.open", {

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1433,9 +1433,10 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${contextModeBadge(theme, r.context)}${rowModelDisplay}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
 		c.addChild(new Text(truncLine(`  ${line}`, width), 0, 0));
 		if (rRunning && rProg && "status" in rProg) {
-			const activity = compactCurrentActivity(rProg);
+			const liveProgress = rProg as AgentProgress;
+			const activity = compactCurrentActivity(liveProgress);
 			c.addChild(new Text(truncLine(theme.fg("dim", `    ⎿  ${activity}`), width), 0, 0));
-			for (const nestedLine of formatNestedWidgetLines(r.children, theme, width, false, snapshotNowForProgress(rProg))) {
+			for (const nestedLine of formatNestedWidgetLines(r.children, theme, width, false, snapshotNowForProgress(liveProgress))) {
 				c.addChild(new Text(truncLine(`    ${nestedLine}`, width), 0, 0));
 			}
 			c.addChild(new Text(truncLine(theme.fg("accent", `    ${liveDetailHintText()}`), width), 0, 0));

--- a/src/types/pi-runtime-compat.d.ts
+++ b/src/types/pi-runtime-compat.d.ts
@@ -1,0 +1,14 @@
+declare module "@earendil-works/pi-agent-core" {
+	interface AgentToolResult<T> {
+		/** Runtime error flag emitted and rendered by pi tool execution. */
+		isError?: boolean;
+	}
+}
+
+declare module "@earendil-works/pi-coding-agent" {
+	interface ExtensionUIContext {
+		requestRender?: () => void;
+	}
+}
+
+export {};

--- a/src/watchdog/lsp-diagnostics.ts
+++ b/src/watchdog/lsp-diagnostics.ts
@@ -260,6 +260,7 @@ class JsonRpcLspClient {
 	private readonly child: ChildProcessWithoutNullStreams;
 	private stderr = "";
 	private exited = false;
+	private terminating = false;
 	private readonly exitWaiters: Array<() => void> = [];
 
 	constructor(child: ChildProcessWithoutNullStreams) {
@@ -295,17 +296,21 @@ class JsonRpcLspClient {
 
 	async shutdown(): Promise<void> {
 		if (this.exited) return;
-		try {
-			await this.request("shutdown", null, SHUTDOWN_TIMEOUT_MS);
-			this.notify("exit", null);
-		} catch {
-			this.child.kill("SIGTERM");
+		if (!this.terminating) {
+			try {
+				await this.request("shutdown", null, SHUTDOWN_TIMEOUT_MS);
+				this.notify("exit", null);
+			} catch {
+				this.kill();
+			}
 		}
 		await this.waitForExit(SHUTDOWN_TIMEOUT_MS);
 	}
 
 	kill(): void {
-		if (!this.exited) this.child.kill("SIGTERM");
+		if (this.exited || this.terminating) return;
+		this.terminating = true;
+		this.child.kill("SIGTERM");
 	}
 
 	stderrTail(): string {
@@ -367,7 +372,7 @@ class JsonRpcLspClient {
 	private failProtocol(error: Error): void {
 		if (this.exited) return;
 		this.rejectPending(error);
-		this.child.kill("SIGTERM");
+		this.kill();
 	}
 
 	private waitForExit(timeoutMs: number): Promise<void> {

--- a/src/watchdog/model-selection.ts
+++ b/src/watchdog/model-selection.ts
@@ -132,13 +132,13 @@ function findFamilyMatch(family: StrongWatchdogFamily, availableModels: ModelInf
 function resolveStrongCandidate(ctx: ExtensionContext, family: StrongWatchdogFamily): WatchdogModelRecommendation | undefined {
 	const availableModels = modelRegistryEntries(ctx);
 	const preference = STRONG_WATCHDOG_MODELS[family];
-	const queries = [...preference.queries];
+	const queries: string[] = [...preference.queries];
 	const familyMatch = findFamilyMatch(family, availableModels);
 	if (familyMatch) queries.push(familyMatch);
 	for (const query of queries) {
 		let resolved: ResolvedWatchdogModelInput;
 		try {
-			resolved = resolveWatchdogModelInput(ctx, query);
+			resolved = resolveWatchdogModelInput(ctx, query as Parameters<typeof resolveWatchdogModelInput>[1]);
 		} catch {
 			continue;
 		}

--- a/src/watchdog/register-main.ts
+++ b/src/watchdog/register-main.ts
@@ -184,7 +184,7 @@ function resolveModelCommandValue(ctx: ExtensionCommandContext, raw: string): { 
 	const resolved = resolveWatchdogModelInput(ctx as ExtensionContext, value);
 	return {
 		model: resolved.model,
-		thinking: resolved.thinking,
+		thinking: resolved.thinking ?? null,
 		description: `${resolved.model}${resolved.thinking ? `:${resolved.thinking}` : ""}`,
 	};
 }

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -93,6 +93,9 @@ function resolveConfiguredModel(ctx: ExtensionContext, rawModel: string): { mode
 	const availableModels = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const preferredProvider = typeof ctx.model?.provider === "string" ? ctx.model.provider : undefined;
 	const resolved = resolveModelCandidate(rawModel, availableModels, preferredProvider);
+	if (!resolved) {
+		throw new Error(`Configured watchdog model '${rawModel}' did not match exactly one authenticated available model. Use provider/model or configure credentials for the intended provider.`);
+	}
 	const { baseModel } = splitKnownThinkingSuffix(resolved);
 	const named = splitProviderModel(baseModel);
 	if (!named) {
@@ -109,7 +112,7 @@ function resolveConfiguredModel(ctx: ExtensionContext, rawModel: string): { mode
 
 async function resolveReviewAuth(ctx: ExtensionContext, model: RegistryModel): Promise<WatchdogReviewAuth> {
 	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-	if (!auth.ok) throw new Error(`Watchdog model auth failed for ${fullModelId(model)}: ${auth.error}`);
+	if (auth.ok === false) throw new Error(`Watchdog model auth failed for ${fullModelId(model)}: ${auth.error}`);
 	return {
 		...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
 		...(auth.headers ? { headers: auth.headers } : {}),

--- a/src/watchdog/runtime.ts
+++ b/src/watchdog/runtime.ts
@@ -602,8 +602,9 @@ export class MainWatchdogRuntime {
 				return "timeout";
 			}
 			if (!this.isCurrent(reviewEpoch, reviewId)) return "stale";
-			for (const warning of result?.warnings ?? []) this.acceptWarning(reviewEpoch, reviewId, warning);
-			if (result?.stopReason && result.stopReason !== "stop") {
+			if (!result) return "stale";
+			for (const warning of result.warnings ?? []) this.acceptWarning(reviewEpoch, reviewId, warning);
+			if (result.stopReason && result.stopReason !== "stop") {
 				this.fail(`Watchdog review ended with stop reason '${result.stopReason}'.`);
 				return "completed";
 			}

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -657,6 +657,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			ctx,
 		);
 		assert.equal(v2Delegated.isError, undefined);
+		assert.deepEqual(v2Delegated.details.toolBudget, zeroBudget);
 		const env = JSON.parse(v2Delegated.content[0]?.text ?? "{}") as Record<string, string>;
 		assert.deepEqual(JSON.parse(env[TOOL_BUDGET_ENV] ?? "null"), zeroBudget);
 		assert.equal(env[TOOL_BUDGET_ZERO_AUTH_ENV], "1");

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -500,7 +500,11 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		}
 		assert.equal(childStatus.parentWorkflowRunId, workflowRunId);
 		assert.equal(childStatus.workflowKey, "background");
-		const childResult = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${childRunId}.json`), "utf-8")) as { parentWorkflowRunId?: string; workflowKey?: string };
+		const childResultPath = path.join(DIRS.results, `${childRunId}.json`);
+		for (let attempt = 0; attempt < 200 && !fs.existsSync(childResultPath); attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		const childResult = JSON.parse(fs.readFileSync(childResultPath, "utf-8")) as { parentWorkflowRunId?: string; workflowKey?: string };
 		assert.equal(childResult.parentWorkflowRunId, workflowRunId);
 		assert.equal(childResult.workflowKey, "background");
 		fs.rmSync(started.details.asyncDir!, { recursive: true, force: true });

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -1148,7 +1148,7 @@ output: context.md
 outputMode: file-only
 reads: input.md, notes.md
 model: openai/gpt-5.5
-skills: research, audit
+skills: false
 progress: true
 
 Gather context
@@ -1163,7 +1163,7 @@ Gather context
 				outputMode: "file-only",
 				reads: ["input.md", "notes.md"],
 				progress: true,
-				skill: ["research", "audit"],
+				skill: false,
 				model: "openai/gpt-5.5",
 			});
 		});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["index.ts", "src/**/*.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary

- add a source-only `tsc --noEmit` gate with full `strict` mode
- run typechecking on Ubuntu and Windows before the existing test suites
- pin TypeScript and Node 24 types as dev dependencies while keeping all Pi SDK packages at `0.81.0`
- fix production-source type errors without broad suppressions and preserve existing runtime/result behavior

## Validation

- `npm run typecheck`
- `npm test` — 1593 passed, 1 skipped
- `npm run test:integration` — 721 passed
- `npm run test:e2e` — 3 passed
- focused saved-chain regression test — 70 passed
- `git diff --check`

## Follow-ups

- #747 removes legacy chain/parallel orchestration surfaces in favor of `workflowScript` as a separate hard-cutover product change.
- #748 tracks the larger opt-in `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess` migrations, which are not included in TypeScript `strict`.