### PR TITLE
fix: recognize git publication mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-- Count clear `git add`, `git commit`, and `git push` bash calls as implementation mutation attempts so workers that finalize pre-applied changes do not fail the completion guard.
-
 ### Added
 - Added trusted inline `workflowScript` orchestration with stable-key child launches through the ordinary executor, timed worker isolation, captured console and emitted milestones, artifact references, status lookup, and a concise call trace. Chains remain supported for compatibility; durable replay and saved scripts are deferred.
 - Added opt-in async one-shot `external-cli` agent profiles with stdin prompt delivery, argv-only spawning, lifecycle/status artifacts, stdout/stderr logs, timeout, and stop support.
@@ -20,6 +17,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Count clear `git add`, `git commit`, and `git push` bash calls as implementation mutation attempts so workers that finalize pre-applied changes do not fail the completion guard.
 - Render structured-output-only children as useful JSON output instead of misleading `(no output)` summaries and empty output artifacts.
 - Journaled managed worktree ownership before child execution so abrupt exits retain a manifest-backed cleanup path.
 - Made automatic mission persistence best-effort without weakening explicit mission requests, bounded terminal mission retention and stale global pointers, exposed auto missions without modifying structured JSON output, added authority-consistent manifest-backed preserved-worktree discard, and clarified the Herdr inspector/schema surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Count clear `git add`, `git commit`, and `git push` bash calls as implementation mutation attempts so workers that finalize pre-applied changes do not fail the completion guard.
+
 ### Added
 - Added trusted inline `workflowScript` orchestration with stable-key child launches through the ordinary executor, timed worker isolation, captured console and emitted milestones, artifact references, status lookup, and a concise call trace. Chains remain supported for compatibility; durable replay and saved scripts are deferred.
 - Added opt-in async one-shot `external-cli` agent profiles with stdin prompt delivery, argv-only spawning, lifecycle/status artifacts, stdout/stderr logs, timeout, and stop support.

--- a/src/runs/shared/long-running-guard.ts
+++ b/src/runs/shared/long-running-guard.ts
@@ -103,26 +103,24 @@ function unquotedShellText(command: string): string {
 	let result = "";
 	for (const char of command) {
 		if (escaped) {
-			result += inSingle || inDouble ? " " : char;
+			result += inSingle || inDouble ? "_" : char;
 			escaped = false;
 			continue;
 		}
 		if (char === "\\" && !inSingle) {
 			escaped = true;
-			result += inDouble ? " " : char;
+			result += inDouble ? "_" : char;
 			continue;
 		}
 		if (char === "'" && !inDouble) {
 			inSingle = !inSingle;
-			result += " ";
 			continue;
 		}
 		if (char === '"' && !inSingle) {
 			inDouble = !inDouble;
-			result += " ";
 			continue;
 		}
-		result += inSingle || inDouble ? " " : char;
+		result += inSingle || inDouble ? "_" : char;
 	}
 	return result;
 }
@@ -132,7 +130,7 @@ function hasMutatingGitCommand(command: string): boolean {
 	for (const segment of unquoted.split(/(?:&&|\|\||[;|()\n])/)) {
 		const trimmed = segment.trim();
 		if (!trimmed || /^(?:echo|printf)\b/.test(trimmed)) continue;
-		if (/^git\s+(?:(?:(?:-C|--git-dir|--work-tree)\s+\S+|(?:--git-dir|--work-tree)=\S+|--[\w-]+)\s+)*(?:add|commit|push)\b/.test(trimmed)) return true;
+		if (/^git\s+(?:(?:(?:-C|--git-dir|--work-tree)\s+\S+|(?:--git-dir|--work-tree)=\S+)\s+)*(?:add|commit|push)\b/.test(trimmed)) return true;
 	}
 	return false;
 }

--- a/src/runs/shared/long-running-guard.ts
+++ b/src/runs/shared/long-running-guard.ts
@@ -96,8 +96,51 @@ function hasUnquotedFileRedirection(command: string): boolean {
 	return false;
 }
 
+function unquotedShellText(command: string): string {
+	let inSingle = false;
+	let inDouble = false;
+	let escaped = false;
+	let result = "";
+	for (const char of command) {
+		if (escaped) {
+			result += inSingle || inDouble ? " " : char;
+			escaped = false;
+			continue;
+		}
+		if (char === "\\" && !inSingle) {
+			escaped = true;
+			result += inDouble ? " " : char;
+			continue;
+		}
+		if (char === "'" && !inDouble) {
+			inSingle = !inSingle;
+			result += " ";
+			continue;
+		}
+		if (char === '"' && !inSingle) {
+			inDouble = !inDouble;
+			result += " ";
+			continue;
+		}
+		result += inSingle || inDouble ? " " : char;
+	}
+	return result;
+}
+
+function hasMutatingGitCommand(command: string): boolean {
+	const unquoted = unquotedShellText(command);
+	for (const segment of unquoted.split(/(?:&&|\|\||[;|()\n])/)) {
+		const trimmed = segment.trim();
+		if (!trimmed || /^(?:echo|printf)\b/.test(trimmed)) continue;
+		if (/^git\s+(?:(?:(?:-C|--git-dir|--work-tree)\s+\S+|(?:--git-dir|--work-tree)=\S+|--[\w-]+)\s+)*(?:add|commit|push)\b/.test(trimmed)) return true;
+	}
+	return false;
+}
+
 export function isMutatingBashCommand(command: string): boolean {
-	return hasUnquotedFileRedirection(command) || MUTATING_BASH_PATTERNS.some((pattern) => pattern.test(command));
+	return hasUnquotedFileRedirection(command)
+		|| hasMutatingGitCommand(command)
+		|| MUTATING_BASH_PATTERNS.some((pattern) => pattern.test(command));
 }
 
 export function isMutatingTool(toolName: string | undefined, args: Record<string, unknown> | undefined): boolean {

--- a/src/runs/shared/long-running-guard.ts
+++ b/src/runs/shared/long-running-guard.ts
@@ -130,7 +130,7 @@ function hasMutatingGitCommand(command: string): boolean {
 	for (const segment of unquoted.split(/(?:&&|\|\||[;|()\n])/)) {
 		const trimmed = segment.trim();
 		if (!trimmed || /^(?:echo|printf)\b/.test(trimmed)) continue;
-		if (/^git\s+(?:(?:(?:-C|--git-dir|--work-tree)\s+\S+|(?:--git-dir|--work-tree)=\S+)\s+)*(?:add|commit|push)\b/.test(trimmed)) return true;
+		if (/^git\s+(?:(?:(?:-C|--git-dir|--work-tree)\s+\S+|(?:--git-dir|--work-tree)=\S+|--paginate)\s+)*(?:add|commit|push)\b/.test(trimmed)) return true;
 	}
 	return false;
 }

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -193,6 +193,30 @@ test("obvious mutating bash commands count as mutation attempts", () => {
 	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "patch -p0 < fix.patch" })]), true);
 });
 
+test("git publication commands count as mutation attempts", () => {
+	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git add src/file.ts" })]), true);
+	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git commit -m 'fix: finish change'" })]), true);
+	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git push origin HEAD" })]), true);
+	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git -C /tmp/project add src/file.ts" })]), true);
+	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git diff --check && git add src/file.ts && git commit -m fix && git push" })]), true);
+});
+
+test("read-only and quoted git commands do not count as mutation attempts", () => {
+	for (const command of [
+		"git status --short",
+		"git diff --check",
+		"git log -1 --oneline",
+		"git show --stat HEAD",
+		"git ls-remote origin main",
+		"gh pr view 749",
+		"echo 'git add src/file.ts'",
+		'printf "git commit -m fix"',
+		"echo 'then git push origin HEAD'",
+	]) {
+		assert.equal(hasMutationToolCall([assistantToolCall("bash", { command })]), false, command);
+	}
+});
+
 test("implementation task with mutation attempts does not trigger", () => {
 	const result = evaluateCompletionMutationGuard({
 		agent: "worker",

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -200,6 +200,7 @@ test("git publication commands count as mutation attempts", () => {
 	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git -C /tmp/project add src/file.ts" })]), true);
 	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: 'git -C "/tmp/project with space" add src/file.ts' })]), true);
 	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: 'git -C "$WORKTREE" commit -m fix' })]), true);
+	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git --paginate push" })]), true);
 	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git diff --check && git add src/file.ts && git commit -m fix && git push" })]), true);
 });
 
@@ -213,7 +214,6 @@ test("read-only and quoted git commands do not count as mutation attempts", () =
 		"git --help add",
 		"git --version add",
 		"git -h commit",
-		"git --paginate push",
 		"gh pr view 749",
 		"echo 'git add src/file.ts'",
 		'printf "git commit -m fix"',

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -198,6 +198,8 @@ test("git publication commands count as mutation attempts", () => {
 	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git commit -m 'fix: finish change'" })]), true);
 	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git push origin HEAD" })]), true);
 	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git -C /tmp/project add src/file.ts" })]), true);
+	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: 'git -C "/tmp/project with space" add src/file.ts' })]), true);
+	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: 'git -C "$WORKTREE" commit -m fix' })]), true);
 	assert.equal(hasMutationToolCall([assistantToolCall("bash", { command: "git diff --check && git add src/file.ts && git commit -m fix && git push" })]), true);
 });
 
@@ -208,6 +210,10 @@ test("read-only and quoted git commands do not count as mutation attempts", () =
 		"git log -1 --oneline",
 		"git show --stat HEAD",
 		"git ls-remote origin main",
+		"git --help add",
+		"git --version add",
+		"git -h commit",
+		"git --paginate push",
 		"gh pr view 749",
 		"echo 'git add src/file.ts'",
 		'printf "git commit -m fix"',


### PR DESCRIPTION
## Summary
- Count direct `git add`, `git commit`, and `git push` bash calls as implementation mutation attempts.
- Preserve read-only git/gh commands and quoted examples as non-mutating.
- Add focused completion-guard coverage for quoted/variable `git -C` paths and read-only global options.

## Validation
- `node --experimental-strip-types --test test/unit/completion-guard.test.ts` — 21/21 passed
- full unit suite — 1595 passed, 1 skipped
- `git diff --check` — passed
- fresh follow-up review — no findings