### PR TITLE
feat: add watchdog-owned child permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added opt-in native Pi-child tool permissions with global and per-agent `allow`/`ask`/`deny` rules, supervisor-routed exact-call approval, and bounded redacted audit records. Unconfigured tools pass through, while bash policy remains with `pi-guard`.
 - Added a source-only, strict TypeScript typecheck command and CI gate.
 - Added trusted inline `workflowScript` orchestration with stable-key child launches through the ordinary executor, timed worker isolation, captured console and emitted milestones, artifact references, status lookup, and a concise call trace.
 - Added opt-in async one-shot `external-cli` agent profiles with stdin prompt delivery, argv-only spawning, lifecycle/status artifacts, stdout/stderr logs, timeout, and stop support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Added opt-in native Pi-child tool permissions with global and per-agent `allow`/`ask`/`deny` rules, supervisor-routed exact-call approval, and bounded redacted audit records. Unconfigured tools pass through, while bash policy remains with `pi-guard`.
+- Added opt-in native Pi-child tool permissions with global and per-agent `allow`/`ask`/`deny` rules, watchdog-owned exact-call decisions, and bounded redacted audit records. Unconfigured tools pass through, while bash policy remains with `pi-guard`.
 - Added a source-only, strict TypeScript typecheck command and CI gate.
 - Added trusted inline `workflowScript` orchestration with stable-key child launches through the ordinary executor, timed worker isolation, captured console and emitted milestones, artifact references, status lookup, and a concise call trace.
 - Added opt-in async one-shot `external-cli` agent profiles with stdin prompt delivery, argv-only spawning, lifecycle/status artifacts, stdout/stderr logs, timeout, and stop support.

--- a/README.md
+++ b/README.md
@@ -532,7 +532,9 @@ permission:
 
 Rules support `allow`, `ask`, and `deny`. Agent rules override matching global rules; omitted and unknown tools default to `allow`. Explicit `allow` removes an inherited restriction. The gate is not registered when the resolved policy has no `ask` or `deny` rules.
 
-An explicit `ask` pauses that exact tool call and routes a bounded, redacted preview through the native supervisor channel. The parent agent's exact `approve` or `deny` reply decides that call; malformed replies and transport failures deny it. Asked requests and decisions are written to a bounded audit JSONL file in the run artifacts. Ordinary direction and clarification through `contact_supervisor` or the optional `pi-intercom` extension remain separate and are never permission-gated.
+An explicit `ask` pauses that exact tool call and sends a bounded, redacted preview to a one-call permission arbiter owned by the built-in child watchdog. The arbiter uses the configured child-watchdog model and returns only `approve` or `deny`; it does not notify the parent agent. Enable and configure `subagents.watchdog.children` before using `ask` rules. A disabled watchdog, missing model/auth, timeout, malformed response, or runtime error denies the call with a clear error.
+
+Asked requests and decisions are written to bounded audit JSONL, including `decisionSource: "watchdog"` and bounded failure reasons. Ordinary direction and clarification through `contact_supervisor` or the optional `pi-intercom` extension remain separate and are never permission-gated.
 
 `bash` is always passed through by pi-subagents. Bash rules are rejected rather than parsed, gated, denied, or audited. Install and configure `pi-guard` when command-level bash policy is needed.
 

--- a/README.md
+++ b/README.md
@@ -503,78 +503,40 @@ For normal use, you do not need to configure anything. Advanced users can tune t
 
 At this point, you know enough to use the plugin. The rest of this README is reference material for exact command syntax, custom agents, scripted workflows, and configuration.
 
-## Optional pi-permission-system integration
+## Native child tool permissions
 
-[`@gotgenes/pi-permission-system`](https://github.com/gotgenes/pi-packages/tree/main/packages/pi-permission-system)
-adds a second policy layer — `allow` / `ask` / `deny` — on top of
-pi-subagents' visibility-based tool restrictions.
+Native permissions are opt-in and apply only to Pi child runtimes. With no rules configured, every tool call passes through unchanged. Configure explicit non-bash rules globally in `~/.pi/agent/extensions/subagent/config.json`:
 
-The two compose independently:
-
-| Layer | What it controls | Who provides it |
-|-------|-----------------|-----------------|
-| Visibility | Which tools are registered before the session starts | pi-subagents (`tools:` frontmatter key) |
-| Policy  | Runtime allow/ask/deny decisions on every tool call, bash command, MCP operation | pi-permission-system (`permission:` frontmatter key) |
-
-### Installing
-
-```bash
-pi install npm:@gotgenes/pi-permission-system
+```json
+{
+  "permissions": {
+    "rules": {
+      "read": "allow",
+      "write": "ask",
+      "edit": "deny"
+    }
+  }
+}
 ```
 
-No configuration is required for the integration — it is automatic when both
-extensions are installed. pi-subagents passes the parent session identity
-to child processes via the `PI_SUBAGENT_PARENT_SESSION` environment variable,
-which the permission system uses to forward `ask` prompts from headless
-subagent processes back to the parent session's UI.
-
-### Per-agent permission frontmatter
-
-Agent files can include a `permission:` block alongside the standard `tools:`
-key. The permission system reads it independently:
+Custom agents can override matching global rules with a `permission:` or `permissions:` frontmatter block:
 
 ```yaml
 ---
 name: worker
-tools: bash,read,write,edit
 permission:
-  "*": ask
-  read: allow
-  bash:
-    "*": ask
-    "git *": allow
-    "npm test": allow
+  write: allow
+  edit: ask
 ---
 ```
 
-In this example the subagent extension restricts visibility to four tools,
-and the permission system then applies `ask`/`allow` policy within that
-visible set. Both keys coexist without collision.
+Rules support `allow`, `ask`, and `deny`. Agent rules override matching global rules; omitted and unknown tools default to `allow`. Explicit `allow` removes an inherited restriction. The gate is not registered when the resolved policy has no `ask` or `deny` rules.
 
-### Checking the integration
+An explicit `ask` pauses that exact tool call and routes a bounded, redacted preview through the native supervisor channel. The parent agent's exact `approve` or `deny` reply decides that call; malformed replies and transport failures deny it. Asked requests and decisions are written to a bounded audit JSONL file in the run artifacts. Ordinary direction and clarification through `contact_supervisor` or the optional `pi-intercom` extension remain separate and are never permission-gated.
 
-Run `/subagents-doctor` to check the permission system status.
-If `ask` prompts from children are not reaching the parent UI, verify both
-extensions are installed:
+`bash` is always passed through by pi-subagents. Bash rules are rejected rather than parsed, gated, denied, or audited. Install and configure `pi-guard` when command-level bash policy is needed.
 
-```bash
-pi list
-```
-
-### How it works
-
-At session start, the interactive (root) session records its own identity in
-`PI_SUBAGENT_PARENT_SESSION`. When pi-subagents launches a child, it passes the
-launching session's identity to that child explicitly, falling back to the
-inherited environment variable. When the permission system inside a child
-encounters an `ask` permission, it reads this variable to locate the parent
-session and forwards the confirmation request there.
-
-This resolves an interactive prompt only when the parent it points at is the
-interactive session — i.e. for the direct children of the root session. A
-nested child's parent is itself a headless subagent process with no UI to
-surface the prompt, so `ask` policies are best placed on agents that run as
-direct children of the interactive session.
+External CLI profiles are opaque processes, so native permissions cannot intercept their tools. A launch with effective `ask` or `deny` rules is rejected for an external CLI agent instead of claiming enforcement.
 
 ## Direct commands
 

--- a/src/agents/agent-serializer.ts
+++ b/src/agents/agent-serializer.ts
@@ -33,6 +33,8 @@ export const KNOWN_FIELDS = new Set([
 	"maxSubagentDepth",
 	"completionGuard",
 	"toolBudget",
+	"permission",
+	"permissions",
 	"memory",
 	"runner",
 ]);
@@ -124,6 +126,13 @@ export function serializeAgent(config: AgentConfig, options: SerializeAgentOptio
 	}
 	if (config.toolBudget || preserve("toolBudget")) {
 		lines.push(`toolBudget: ${config.toolBudget ? JSON.stringify(config.toolBudget) : ""}`);
+	}
+	if (config.permissions || preserve("permission", "permissions")) {
+		const key = preserve("permission") && !preserve("permissions") ? "permission" : "permissions";
+		lines.push(`${key}:`);
+		if (config.permissions) {
+			for (const line of stringifyYaml(config.permissions).trimEnd().split("\n")) lines.push(`  ${line}`);
+		}
 	}
 
 	if (config.memory) {

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -20,6 +20,7 @@ export { buildRuntimeName, frontmatterNameForConfig, parsePackageName } from "./
 import { parseMemoryFrontmatter } from "./agent-memory.ts";
 import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
+import { validatePermissionRules, type PermissionRules } from "../runs/shared/permissions.ts";
 
 export type AgentScope = "user" | "project" | "both";
 
@@ -149,6 +150,7 @@ export interface AgentConfig {
 	maxSubagentDepth?: number;
 	completionGuard?: boolean;
 	toolBudget?: ToolBudgetConfig;
+	permissions?: PermissionRules;
 	memory?: AgentMemoryConfig;
 	disabled?: boolean;
 	extraFields?: Record<string, string>;
@@ -1440,7 +1442,7 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 
 function validateExternalRunnerProfile(frontmatter: Record<string, string>, agentName: string, runner: AgentRunnerConfig | undefined): void {
 	if (runner?.type !== "external-cli") return;
-	const unsupported = ["tools", "model", "fallbackModels", "thinking", "extensions", "subagentOnlyExtensions", "maxSubagentDepth", "completionGuard", "skills", "skill", "skillPath", "toolBudget"]
+	const unsupported = ["tools", "model", "fallbackModels", "thinking", "extensions", "subagentOnlyExtensions", "maxSubagentDepth", "completionGuard", "skills", "skill", "skillPath", "toolBudget", "permission", "permissions"]
 		.filter((field) => frontmatter[field] !== undefined);
 	if (unsupported.length > 0) {
 		throw new Error(`Agent '${agentName}' uses runner.type='external-cli' and declares unsupported Pi-only fields: ${unsupported.join(", ")}.`);
@@ -1556,6 +1558,13 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 		}
 
 		const parsedMaxSubagentDepth = Number(frontmatter.maxSubagentDepth);
+		if (frontmatter.permission !== undefined && frontmatter.permissions !== undefined) {
+			throw new Error(`Agent '${localName}' cannot declare both permission and permissions frontmatter.`);
+		}
+		const permissionSource = frontmatter.permissions ?? frontmatter.permission;
+		const permissions = permissionSource?.trim()
+			? validatePermissionRules(parseYaml(permissionSource), `Agent '${localName}' permissions`)
+			: undefined;
 		let toolBudget: ToolBudgetConfig | undefined;
 		if (frontmatter.toolBudget !== undefined && frontmatter.toolBudget.trim()) {
 			const parsed = JSON.parse(frontmatter.toolBudget) as unknown;
@@ -1608,6 +1617,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 					: undefined,
 			completionGuard,
 			toolBudget,
+			permissions,
 			memory: parseMemoryFrontmatter(frontmatter.memory),
 			extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
 		};

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -4,6 +4,7 @@ import type { ArtifactDirPreference, ExtensionConfig } from "../shared/types.ts"
 import { validateMissionStoreConfig } from "../missions/store.ts";
 import { validateAuthorityPolicy } from "../policy/authority.ts";
 import { getAgentDir } from "../shared/utils.ts";
+import { validatePermissionConfig } from "../runs/shared/permissions.ts";
 
 const ARTIFACT_DIR_PREFERENCES = new Set<ArtifactDirPreference>(["project", "session", "temp"]);
 
@@ -23,6 +24,7 @@ function readConfigForUpdate(configPath = getConfigPath()): ExtensionConfig {
 	}
 	validateMissionStoreConfig(config.missions);
 	validateAuthorityPolicy(config.authorityPolicy);
+	validatePermissionConfig(config.permissions);
 	return parsed as ExtensionConfig;
 }
 

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -12,7 +12,6 @@ import {
 	SUBAGENT_RUN_ID_ENV,
 	SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV,
 } from "../runs/shared/pi-args.ts";
-import { appendPermissionAudit, PERMISSION_AUDIT_PATH_ENV, permissionArgsPreview } from "../runs/shared/permissions.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
 import { writeAtomicJson } from "../shared/atomic-json.ts";
 
@@ -26,8 +25,7 @@ const CHANNEL_POLL_MS = Math.min(POLL_INTERVAL_MS, 500);
 const STALE_EMPTY_CHANNEL_AGE_MS = 60 * 1000;
 const STALE_EMPTY_CHANNEL_CLEANUP_INTERVAL_MS = 60 * 1000;
 
-type ContactSupervisorReason = "need_decision" | "interview_request" | "progress_update";
-type SupervisorReason = ContactSupervisorReason | "permission_request";
+type SupervisorReason = "need_decision" | "interview_request" | "progress_update";
 
 interface SupervisorRequest {
 	type: "subagent.supervisor.request";
@@ -44,7 +42,6 @@ interface SupervisorRequest {
 	childIndex: number;
 	childTarget?: string;
 	interview?: unknown;
-	permission?: { toolName: string; preview: string; matchedRule: "ask" };
 }
 
 interface PendingSupervisorRequest extends SupervisorRequest {
@@ -60,7 +57,7 @@ interface SupervisorReply {
 }
 
 interface ContactSupervisorParams {
-	reason: ContactSupervisorReason;
+	reason: SupervisorReason;
 	message?: string;
 	interview?: unknown;
 }
@@ -140,7 +137,6 @@ function readChildMetadata(): {
 function reasonHeading(reason: SupervisorReason): string {
 	if (reason === "interview_request") return "Subagent requests a structured supervisor interview.";
 	if (reason === "progress_update") return "Subagent progress update.";
-	if (reason === "permission_request") return "Subagent requests permission for a tool call.";
 	return "Subagent needs a supervisor decision.";
 }
 
@@ -162,7 +158,6 @@ function formatChildMessage(input: {
 	if (input.childTarget) lines.push(`Child intercom target: ${input.childTarget}`);
 	lines.push("");
 	if (input.message?.trim()) lines.push(input.message.trim());
-	if (input.reason === "permission_request") lines.push("", "Reply with exactly `approve` or `deny`. This authorizes only this exact tool call.");
 	if (input.reason === "interview_request") {
 		lines.push(
 			"",
@@ -226,20 +221,19 @@ async function waitForReply(channelDir: string, requestId: string, deadline: num
 	throw new Error("Timed out waiting for supervisor reply.");
 }
 
-async function sendSupervisorRequest(params: ContactSupervisorParams | { reason: "permission_request"; message: string; permission: { toolName: string; preview: string; matchedRule: "ask" }; requestId?: string }, signal?: AbortSignal): Promise<AgentToolResult<Record<string, unknown>>> {
+async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: AbortSignal): Promise<AgentToolResult<Record<string, unknown>>> {
 	const metadata = readChildMetadata();
 	if (!metadata) throw new Error("Native supervisor channel is not available for this subagent.");
 	if (params.reason !== "progress_update" && !params.message?.trim() && params.reason !== "interview_request") {
 		throw new Error("message is required for supervisor decisions.");
 	}
 	ensureSupervisorChannelDir(metadata.channelDir);
-	const requestId = "requestId" in params && params.requestId ? params.requestId : randomUUID();
+	const requestId = randomUUID();
 	const expectsReply = params.reason !== "progress_update";
 	const createdAt = Date.now();
 	const replyDeadline = createdAt + askTimeoutMs();
 	const expiresAt = expectsReply ? replyDeadline : undefined;
-	const interview = "interview" in params ? params.interview : undefined;
-	const message = formatChildMessage({ ...metadata, reason: params.reason, message: params.message, interview });
+	const message = formatChildMessage({ ...metadata, reason: params.reason, message: params.message, interview: params.interview });
 	const request: SupervisorRequest = {
 		type: "subagent.supervisor.request",
 		id: requestId,
@@ -254,8 +248,7 @@ async function sendSupervisorRequest(params: ContactSupervisorParams | { reason:
 		agent: metadata.agent,
 		childIndex: metadata.childIndex,
 		...(metadata.childTarget ? { childTarget: metadata.childTarget } : {}),
-		...(interview !== undefined ? { interview } : {}),
-		...("permission" in params ? { permission: params.permission } : {}),
+		...(params.interview !== undefined ? { interview: params.interview } : {}),
 	};
 	const serialized = JSON.stringify(request, null, "\t");
 	if (Buffer.byteLength(serialized, "utf-8") > MAX_MESSAGE_BYTES) throw new Error("Supervisor request is too large.");
@@ -270,7 +263,7 @@ async function sendSupervisorRequest(params: ContactSupervisorParams | { reason:
 
 	try {
 		const reply = await waitForReply(metadata.channelDir, requestId, replyDeadline, signal);
-		const details: Record<string, unknown> = { requestId, reason: params.reason, reply: reply.message };
+		const details: Record<string, unknown> = { requestId, reason: params.reason };
 		if (params.reason === "interview_request") {
 			const structured = parseStructuredReply(reply.message);
 			if (structured.error) details.structuredReplyParseError = structured.error;
@@ -283,43 +276,6 @@ async function sendSupervisorRequest(params: ContactSupervisorParams | { reason:
 	} catch (error) {
 		removeRequestFile(requestPath(metadata.channelDir, requestId));
 		throw error;
-	}
-}
-
-function parsePermissionDecision(message: string): "approve" | "deny" | undefined {
-	const normalized = message.trim().toLowerCase();
-	if (normalized === "approve" || normalized === "deny") return normalized;
-	try {
-		const parsed = JSON.parse(message) as { decision?: unknown };
-		return parsed.decision === "approve" || parsed.decision === "deny" ? parsed.decision : undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-export async function requestSupervisorPermission(input: { toolName: string; args: unknown; signal?: AbortSignal }): Promise<{ approved: boolean; reason: string; requestId?: string }> {
-	const preview = permissionArgsPreview(input.args);
-	const auditPath = readTextEnv(PERMISSION_AUDIT_PATH_ENV);
-	const createdAt = Date.now();
-	const requestId = randomUUID();
-	appendPermissionAudit(auditPath, { type: "permission.request", createdAt, toolName: input.toolName, preview, matchedRule: "ask", requestId });
-	try {
-		const result = await sendSupervisorRequest({
-			reason: "permission_request",
-			message: `Tool: ${input.toolName}\nArguments: ${preview}`,
-			permission: { toolName: input.toolName, preview, matchedRule: "ask" },
-			requestId,
-		}, input.signal);
-		const reply = typeof result.details?.reply === "string" ? result.details.reply : "";
-		const decision = parsePermissionDecision(reply);
-		const approved = decision === "approve";
-		const reason = decision ? `Supervisor ${decision}d this exact '${input.toolName}' call.` : "Supervisor reply was malformed; expected approve or deny.";
-		appendPermissionAudit(auditPath, { type: "permission.decision", createdAt: Date.now(), requestCreatedAt: createdAt, toolName: input.toolName, requestId, decision: decision ?? "malformed", approved });
-		return { approved, reason, requestId };
-	} catch (error) {
-		const reason = error instanceof Error ? error.message : String(error);
-		appendPermissionAudit(auditPath, { type: "permission.decision", createdAt: Date.now(), requestCreatedAt: createdAt, toolName: input.toolName, requestId, decision: "transport-error", approved: false, reason: reason.slice(0, 500) });
-		return { approved: false, reason: `Permission request failed closed: ${reason}` };
 	}
 }
 
@@ -370,7 +326,7 @@ function parseRequestFile(file: string, channelDir: string): PendingSupervisorRe
 		const parsed = JSON.parse(fs.readFileSync(file, "utf-8")) as Partial<SupervisorRequest>;
 		if (parsed.type !== "subagent.supervisor.request") return undefined;
 		if (typeof parsed.id !== "string" || !parsed.id) return undefined;
-		if (parsed.reason !== "need_decision" && parsed.reason !== "interview_request" && parsed.reason !== "progress_update" && parsed.reason !== "permission_request") return undefined;
+		if (parsed.reason !== "need_decision" && parsed.reason !== "interview_request" && parsed.reason !== "progress_update") return undefined;
 		if (typeof parsed.message !== "string" || !parsed.message) return undefined;
 		if (typeof parsed.runId !== "string" || typeof parsed.agent !== "string" || typeof parsed.childIndex !== "number") return undefined;
 		return { ...parsed as SupervisorRequest, channelDir, requestFile: file };
@@ -505,7 +461,7 @@ function markForegroundSupervisorAttention(request: SupervisorRequest, state: Su
 	remembered.run.updatedAt = updatedAt;
 	remembered.child.activityState = "needs_attention";
 	remembered.child.lastActivityAt = request.createdAt;
-	remembered.child.currentTool = request.permission ? `permission:${request.permission.toolName}` : "contact_supervisor";
+	remembered.child.currentTool = "contact_supervisor";
 	remembered.child.currentToolStartedAt = request.createdAt;
 	remembered.child.updatedAt = updatedAt;
 }
@@ -518,7 +474,7 @@ function clearForegroundSupervisorAttention(request: SupervisorRequest, pending:
 		&& candidate.childIndex === request.childIndex
 	)) return;
 	const remembered = rememberedForegroundChild(request, state);
-	if (!remembered || remembered.child.status !== "detached" || (remembered.child.currentTool !== "contact_supervisor" && !remembered.child.currentTool?.startsWith("permission:"))) return;
+	if (!remembered || remembered.child.status !== "detached" || remembered.child.currentTool !== "contact_supervisor") return;
 	const updatedAt = Date.now();
 	remembered.run.updatedAt = updatedAt;
 	remembered.child.activityState = undefined;

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -12,6 +12,7 @@ import {
 	SUBAGENT_RUN_ID_ENV,
 	SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV,
 } from "../runs/shared/pi-args.ts";
+import { appendPermissionAudit, PERMISSION_AUDIT_PATH_ENV, permissionArgsPreview } from "../runs/shared/permissions.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
 import { writeAtomicJson } from "../shared/atomic-json.ts";
 
@@ -25,7 +26,8 @@ const CHANNEL_POLL_MS = Math.min(POLL_INTERVAL_MS, 500);
 const STALE_EMPTY_CHANNEL_AGE_MS = 60 * 1000;
 const STALE_EMPTY_CHANNEL_CLEANUP_INTERVAL_MS = 60 * 1000;
 
-type SupervisorReason = "need_decision" | "interview_request" | "progress_update";
+type ContactSupervisorReason = "need_decision" | "interview_request" | "progress_update";
+type SupervisorReason = ContactSupervisorReason | "permission_request";
 
 interface SupervisorRequest {
 	type: "subagent.supervisor.request";
@@ -42,6 +44,7 @@ interface SupervisorRequest {
 	childIndex: number;
 	childTarget?: string;
 	interview?: unknown;
+	permission?: { toolName: string; preview: string; matchedRule: "ask" };
 }
 
 interface PendingSupervisorRequest extends SupervisorRequest {
@@ -57,7 +60,7 @@ interface SupervisorReply {
 }
 
 interface ContactSupervisorParams {
-	reason: SupervisorReason;
+	reason: ContactSupervisorReason;
 	message?: string;
 	interview?: unknown;
 }
@@ -137,6 +140,7 @@ function readChildMetadata(): {
 function reasonHeading(reason: SupervisorReason): string {
 	if (reason === "interview_request") return "Subagent requests a structured supervisor interview.";
 	if (reason === "progress_update") return "Subagent progress update.";
+	if (reason === "permission_request") return "Subagent requests permission for a tool call.";
 	return "Subagent needs a supervisor decision.";
 }
 
@@ -158,6 +162,7 @@ function formatChildMessage(input: {
 	if (input.childTarget) lines.push(`Child intercom target: ${input.childTarget}`);
 	lines.push("");
 	if (input.message?.trim()) lines.push(input.message.trim());
+	if (input.reason === "permission_request") lines.push("", "Reply with exactly `approve` or `deny`. This authorizes only this exact tool call.");
 	if (input.reason === "interview_request") {
 		lines.push(
 			"",
@@ -221,19 +226,20 @@ async function waitForReply(channelDir: string, requestId: string, deadline: num
 	throw new Error("Timed out waiting for supervisor reply.");
 }
 
-async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: AbortSignal): Promise<AgentToolResult<Record<string, unknown>>> {
+async function sendSupervisorRequest(params: ContactSupervisorParams | { reason: "permission_request"; message: string; permission: { toolName: string; preview: string; matchedRule: "ask" }; requestId?: string }, signal?: AbortSignal): Promise<AgentToolResult<Record<string, unknown>>> {
 	const metadata = readChildMetadata();
 	if (!metadata) throw new Error("Native supervisor channel is not available for this subagent.");
 	if (params.reason !== "progress_update" && !params.message?.trim() && params.reason !== "interview_request") {
 		throw new Error("message is required for supervisor decisions.");
 	}
 	ensureSupervisorChannelDir(metadata.channelDir);
-	const requestId = randomUUID();
+	const requestId = "requestId" in params && params.requestId ? params.requestId : randomUUID();
 	const expectsReply = params.reason !== "progress_update";
 	const createdAt = Date.now();
 	const replyDeadline = createdAt + askTimeoutMs();
 	const expiresAt = expectsReply ? replyDeadline : undefined;
-	const message = formatChildMessage({ ...metadata, reason: params.reason, message: params.message, interview: params.interview });
+	const interview = "interview" in params ? params.interview : undefined;
+	const message = formatChildMessage({ ...metadata, reason: params.reason, message: params.message, interview });
 	const request: SupervisorRequest = {
 		type: "subagent.supervisor.request",
 		id: requestId,
@@ -248,7 +254,8 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: A
 		agent: metadata.agent,
 		childIndex: metadata.childIndex,
 		...(metadata.childTarget ? { childTarget: metadata.childTarget } : {}),
-		...(params.interview !== undefined ? { interview: params.interview } : {}),
+		...(interview !== undefined ? { interview } : {}),
+		...("permission" in params ? { permission: params.permission } : {}),
 	};
 	const serialized = JSON.stringify(request, null, "\t");
 	if (Buffer.byteLength(serialized, "utf-8") > MAX_MESSAGE_BYTES) throw new Error("Supervisor request is too large.");
@@ -263,7 +270,7 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: A
 
 	try {
 		const reply = await waitForReply(metadata.channelDir, requestId, replyDeadline, signal);
-		const details: Record<string, unknown> = { requestId, reason: params.reason };
+		const details: Record<string, unknown> = { requestId, reason: params.reason, reply: reply.message };
 		if (params.reason === "interview_request") {
 			const structured = parseStructuredReply(reply.message);
 			if (structured.error) details.structuredReplyParseError = structured.error;
@@ -276,6 +283,43 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: A
 	} catch (error) {
 		removeRequestFile(requestPath(metadata.channelDir, requestId));
 		throw error;
+	}
+}
+
+function parsePermissionDecision(message: string): "approve" | "deny" | undefined {
+	const normalized = message.trim().toLowerCase();
+	if (normalized === "approve" || normalized === "deny") return normalized;
+	try {
+		const parsed = JSON.parse(message) as { decision?: unknown };
+		return parsed.decision === "approve" || parsed.decision === "deny" ? parsed.decision : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export async function requestSupervisorPermission(input: { toolName: string; args: unknown; signal?: AbortSignal }): Promise<{ approved: boolean; reason: string; requestId?: string }> {
+	const preview = permissionArgsPreview(input.args);
+	const auditPath = readTextEnv(PERMISSION_AUDIT_PATH_ENV);
+	const createdAt = Date.now();
+	const requestId = randomUUID();
+	appendPermissionAudit(auditPath, { type: "permission.request", createdAt, toolName: input.toolName, preview, matchedRule: "ask", requestId });
+	try {
+		const result = await sendSupervisorRequest({
+			reason: "permission_request",
+			message: `Tool: ${input.toolName}\nArguments: ${preview}`,
+			permission: { toolName: input.toolName, preview, matchedRule: "ask" },
+			requestId,
+		}, input.signal);
+		const reply = typeof result.details?.reply === "string" ? result.details.reply : "";
+		const decision = parsePermissionDecision(reply);
+		const approved = decision === "approve";
+		const reason = decision ? `Supervisor ${decision}d this exact '${input.toolName}' call.` : "Supervisor reply was malformed; expected approve or deny.";
+		appendPermissionAudit(auditPath, { type: "permission.decision", createdAt: Date.now(), requestCreatedAt: createdAt, toolName: input.toolName, requestId, decision: decision ?? "malformed", approved });
+		return { approved, reason, requestId };
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		appendPermissionAudit(auditPath, { type: "permission.decision", createdAt: Date.now(), requestCreatedAt: createdAt, toolName: input.toolName, requestId, decision: "transport-error", approved: false, reason: reason.slice(0, 500) });
+		return { approved: false, reason: `Permission request failed closed: ${reason}` };
 	}
 }
 
@@ -326,7 +370,7 @@ function parseRequestFile(file: string, channelDir: string): PendingSupervisorRe
 		const parsed = JSON.parse(fs.readFileSync(file, "utf-8")) as Partial<SupervisorRequest>;
 		if (parsed.type !== "subagent.supervisor.request") return undefined;
 		if (typeof parsed.id !== "string" || !parsed.id) return undefined;
-		if (parsed.reason !== "need_decision" && parsed.reason !== "interview_request" && parsed.reason !== "progress_update") return undefined;
+		if (parsed.reason !== "need_decision" && parsed.reason !== "interview_request" && parsed.reason !== "progress_update" && parsed.reason !== "permission_request") return undefined;
 		if (typeof parsed.message !== "string" || !parsed.message) return undefined;
 		if (typeof parsed.runId !== "string" || typeof parsed.agent !== "string" || typeof parsed.childIndex !== "number") return undefined;
 		return { ...parsed as SupervisorRequest, channelDir, requestFile: file };
@@ -461,7 +505,7 @@ function markForegroundSupervisorAttention(request: SupervisorRequest, state: Su
 	remembered.run.updatedAt = updatedAt;
 	remembered.child.activityState = "needs_attention";
 	remembered.child.lastActivityAt = request.createdAt;
-	remembered.child.currentTool = "contact_supervisor";
+	remembered.child.currentTool = request.permission ? `permission:${request.permission.toolName}` : "contact_supervisor";
 	remembered.child.currentToolStartedAt = request.createdAt;
 	remembered.child.updatedAt = updatedAt;
 }
@@ -474,7 +518,7 @@ function clearForegroundSupervisorAttention(request: SupervisorRequest, pending:
 		&& candidate.childIndex === request.childIndex
 	)) return;
 	const remembered = rememberedForegroundChild(request, state);
-	if (!remembered || remembered.child.status !== "detached" || remembered.child.currentTool !== "contact_supervisor") return;
+	if (!remembered || remembered.child.status !== "detached" || (remembered.child.currentTool !== "contact_supervisor" && !remembered.child.currentTool?.startsWith("permission:"))) return;
 	const updatedAt = Date.now();
 	remembered.run.updatedAt = updatedAt;
 	remembered.child.activityState = undefined;

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -61,6 +61,7 @@ import { finalizeProcessTerminal, readProcessTerminal } from "./process-terminal
 import { SUBAGENT_PROCESS_TERMINAL_EVENT } from "../../shared/types.ts";
 import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
 import { agentDefinitionDigest, launchBindingDigest } from "../../shared/launch-contract.ts";
+import { resolvePermissionRules, type PermissionConfig } from "../shared/permissions.ts";
 
 const require = createRequire(import.meta.url);
 const piPackageRoot = resolvePiPackageRoot();
@@ -117,6 +118,7 @@ interface AsyncExecutionContext {
 	currentSessionId: string;
 	/** Parent session id used by permission-system ask forwarding. */
 	parentSessionId?: string;
+	permissions?: PermissionConfig;
 	currentModelProvider?: string;
 	currentModel?: ParentModel;
 	/** Optional model-scope enforcement resolved from subagent settings. */
@@ -729,8 +731,13 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			agentName: a.name,
 		});
 		const launchResolvedExtensions = externalRunner ? undefined : projectLaunchResolvedChildExtensions(toolPlan);
+		const permissionRules = resolvePermissionRules(ctx.permissions, a.permissions);
+		if (externalRunner && permissionRules) {
+			throw new AsyncStartValidationError(`Agent '${a.name}' uses runner.type='external-cli', which cannot enforce native Pi child permission rules.`);
+		}
 		return {
 			parentSessionId: ctx.parentSessionId ?? ctx.currentSessionId,
+			permissionRules,
 			...(params.capabilityCeiling ? { capabilityCeiling: params.capabilityCeiling } : {}),
 			agent: s.agent,
 			task,
@@ -1194,6 +1201,7 @@ export function executeAsyncSingle(
 	} = params;
 	const task = params.task ?? "";
 	const externalRunner = agentConfig.runner?.type === "external-cli";
+	const permissionRules = resolvePermissionRules(ctx.permissions, agentConfig.permissions);
 	if (externalRunner) {
 		const unsupported: string[] = [];
 		if (params.modelOverride !== undefined) unsupported.push("model override");
@@ -1203,6 +1211,7 @@ export function executeAsyncSingle(
 		if (params.toolBudget !== undefined || agentConfig.toolBudget !== undefined || params.configToolBudget !== undefined) unsupported.push("tool budget");
 		if (params.context === "fork") unsupported.push("fork context");
 		if ((params.skills?.length ?? 0) > 0) unsupported.push("skills");
+		if (permissionRules) unsupported.push("native Pi child permissions");
 		if (unsupported.length > 0) return formatAsyncStartError("single", `Agent '${agentConfig.name}' uses runner.type='external-cli' and does not support: ${unsupported.join(", ")}.`);
 	}
 	const capabilityCeiling = intersectSubagentCapabilityCeilings(params.capabilityCeiling ?? resolveCurrentSubagentCapabilityCeiling(ctx.currentSessionId), decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]));
@@ -1379,6 +1388,7 @@ export function executeAsyncSingle(
 				steps: [
 					{
 						parentSessionId: ctx.parentSessionId ?? ctx.currentSessionId,
+						permissionRules,
 						...(capabilityCeiling ? { capabilityCeiling } : {}),
 						agent,
 						task: taskWithOutputInstruction,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1282,6 +1282,10 @@ async function runSingleStep(
 			steerAckDir: ctx.steerAckDir,
 			structuredOutput: effectiveStructuredOutput,
 			toolBudget: step.toolBudget,
+			permissionRules: step.permissionRules,
+			permissionAuditPath: step.permissionRules && ctx.artifactsDir
+				? path.join(ctx.artifactsDir, "permission-audit", `${ctx.id}-${ctx.flatIndex}.jsonl`)
+				: undefined,
 			childWatchdog,
 			waitToolEnabled: step.waitToolEnabled,
 		});

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -44,6 +44,7 @@ import {
 import { buildChainSummary } from "../../shared/formatters.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
+import type { PermissionConfig } from "../shared/permissions.ts";
 import { formatParallelHandoffError, formatParallelHandoffReference, parallelHandoffPath, writeParallelHandoffGroup, writePendingParallelHandoff } from "../shared/parallel-handoff.ts";
 import { recordRun } from "../shared/run-history.ts";
 import {
@@ -531,6 +532,7 @@ interface ChainExecutionParams {
 	toolBudget?: ResolvedToolBudget;
 	usageBudget?: UsageBudgetConfig;
 	configToolBudget?: ToolBudgetConfig;
+	permissions?: PermissionConfig;
 	/** Global cap on simultaneously-running tasks within this chain. Defaults to DEFAULT_GLOBAL_CONCURRENCY_LIMIT. */
 	globalConcurrencyLimit?: number;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
@@ -1355,6 +1357,7 @@ ${step.message}` : ""}` }],
 					dynamicGroupStatuses,
 				});
 				r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
+				permissions: params.permissions,
 				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 				capabilityCeiling: params.capabilityCeiling,
 				context: params.contextForAgent?.(seqStep.agent),

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -166,6 +166,7 @@ interface ParallelChainRunInput {
 	configToolBudget?: ToolBudgetConfig;
 	globalSemaphore?: Semaphore;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	permissions?: PermissionConfig;
 	dynamic?: boolean;
 }
 
@@ -384,6 +385,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 			let result!: SingleResult;
 			try {
 				result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
+				permissions: input.permissions,
 				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 				capabilityCeiling: input.capabilityCeiling,
 				context: input.contextForAgent?.(task.agent),
@@ -871,6 +873,7 @@ ${step.message}` : ""}` }],
 					toolBudget: params.toolBudget,
 					configToolBudget: params.configToolBudget,
 					globalSemaphore,
+					permissions: params.permissions,
 				});
 				globalTaskIndex += step.parallel.length;
 
@@ -1129,6 +1132,7 @@ ${step.message}` : ""}` }],
 				toolBudget: params.toolBudget,
 				configToolBudget: params.configToolBudget,
 				globalSemaphore,
+				permissions: params.permissions,
 				dynamic: true,
 			});
 			globalTaskIndex = dynamicStartIndex + reservedDynamicItems;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -55,6 +55,7 @@ import { evaluateCompletionMutationGuard } from "../shared/completion-guard.ts";
 import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
+import { resolvePermissionRules } from "../shared/permissions.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/pi-args.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV } from "../shared/capability-ceiling.ts";
@@ -302,6 +303,10 @@ async function runSingleAttempt(
 			childIndex: options.index ?? 0,
 		})
 		: undefined;
+	const permissionRules = resolvePermissionRules(options.permissions, agent.permissions);
+	const permissionAuditPath = permissionRules && options.artifactsDir
+		? path.join(options.artifactsDir, "permission-audit", `${options.runId}-${options.index ?? 0}.jsonl`)
+		: undefined;
 	const { args, env: sharedEnv, tempDir, toolDiagnosticPath, runtimeAcknowledgedExtensionsPath, capabilityAudit } = buildPiArgs({
 		baseArgs: ["--mode", "json", "-p"],
 		task,
@@ -334,6 +339,8 @@ async function runSingleAttempt(
 		structuredOutput: options.structuredOutput,
 		toolBudget: options.toolBudget,
 		allowZeroToolBudget: options.allowZeroToolBudget,
+		permissionRules,
+		permissionAuditPath,
 		childWatchdog,
 		waitToolEnabled: options.waitToolEnabled,
 		capabilityCeiling: options.capabilityCeiling,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -952,6 +952,7 @@ function appendStepToAsyncChain(input: {
 		currentModel: parentModel,
 		modelScope: discoveredForAppend.modelScope,
 		interactive: input.ctx.hasUI,
+		permissions: input.deps.config.permissions,
 	};
 	const built = buildAsyncRunnerSteps(resolved.id, {
 		chain: wrapChainTasksForFork(chain, contextPolicy),
@@ -1371,6 +1372,7 @@ async function resumeAsyncRun(input: {
 				currentModel: parentModel,
 				modelScope,
 				interactive: input.ctx.hasUI,
+		permissions: input.deps.config.permissions,
 			},
 			availableModels,
 			cwd: effectiveCwd,
@@ -1429,6 +1431,7 @@ async function resumeAsyncRun(input: {
 			currentModel: parentModel,
 			modelScope,
 			interactive: input.ctx.hasUI,
+		permissions: input.deps.config.permissions,
 		},
 		cwd: effectiveCwd,
 		maxOutput: input.params.maxOutput ?? recoveryDescriptor?.maxOutput,
@@ -2226,6 +2229,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		currentModel: parentModel,
 		modelScope: data.modelScope,
 		interactive: ctx.hasUI,
+		permissions: deps.config.permissions,
 	};
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const currentMaxSubagentDepth = resolveCurrentMaxSubagentDepth(deps.config.maxSubagentDepth);
@@ -2499,6 +2503,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			currentModel: parentModel,
 			modelScope: data.modelScope,
 			interactive: ctx.hasUI,
+		permissions: deps.config.permissions,
 		};
 		const rawAsyncChain = chainResult.requestedAsync.chain;
 		const asyncChain = wrapChainTasksForFork(rawAsyncChain, contextPolicy);
@@ -2620,6 +2625,7 @@ interface ForegroundParallelRunInput {
 	usageBudget?: UsageBudgetConfig;
 	toolBudgets: (ResolvedToolBudget | undefined)[];
 	agentContract?: AgentContract;
+	permissions?: ExtensionConfig["permissions"];
 }
 function buildParallelModeError(message: string): AgentToolResult<Details> {
 	return {
@@ -2832,6 +2838,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			: undefined;
 		let detachedReceipt = false;
 		const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskText, {
+			permissions: input.permissions,
 			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
 			context: input.contextPolicy.contextForAgent(task.agent),
 			cwd: taskCwd,
@@ -3071,6 +3078,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				currentModel: parentModel,
 				modelScope: data.modelScope,
 				interactive: ctx.hasUI,
+		permissions: deps.config.permissions,
 			};
 			const parallelTasks = tasks.map((t, i) => {
 				const taskText = shouldForkAgent(contextPolicy, t.agent) ? wrapForkTask(taskTexts[i]!) : taskTexts[i]!;
@@ -3193,6 +3201,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		const deadlineAt = data.deadlineAt ?? (data.timeoutMs !== undefined ? Date.now() + data.timeoutMs : undefined);
 		const results = await runForegroundParallelTasks({
 			tasks,
+			permissions: deps.config.permissions,
 			taskTexts,
 			taskDescriptions,
 			agents,
@@ -3437,6 +3446,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				currentModel: parentModel,
 				modelScope: data.modelScope,
 				interactive: ctx.hasUI,
+		permissions: deps.config.permissions,
 			};
 			return executeAsyncSingle(id, {
 				agent: params.agent!,
@@ -3531,6 +3541,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	let r: Awaited<ReturnType<typeof runSync>> | undefined;
 	try {
 		r = await runSync(ctx.cwd, agents, params.agent!, task, {
+			permissions: deps.config.permissions,
 			parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 			context: data.contextPolicy.contextForAgent(params.agent!),
 			cwd: effectiveCwd,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2480,6 +2480,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		toolBudget: data.toolBudget,
 		usageBudget: data.usageBudget,
 		configToolBudget: data.configToolBudget,
+		permissions: deps.config.permissions,
 		globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 		capabilityCeiling: data.capabilityCeiling,
 	});

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -3,6 +3,8 @@ export type ResolvedRunnerConfig = import("../../shared/types.ts").AgentRunnerCo
 export interface RunnerSubagentStep {
 	/** Session id of the direct parent session for permission-system ask forwarding. */
 	parentSessionId?: string;
+	/** Resolved opt-in rules for native Pi child tool calls. */
+	permissionRules?: import("./permissions.ts").PermissionRules;
 	agent: string;
 	task: string;
 	runner?: ResolvedRunnerConfig;

--- a/src/runs/shared/permissions.ts
+++ b/src/runs/shared/permissions.ts
@@ -1,0 +1,85 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export type PermissionDecision = "allow" | "ask" | "deny";
+export type PermissionRules = Record<string, PermissionDecision>;
+export interface PermissionConfig { rules?: PermissionRules }
+
+export const PERMISSION_POLICY_ENV = "PI_SUBAGENT_PERMISSION_POLICY";
+export const PERMISSION_AUDIT_PATH_ENV = "PI_SUBAGENT_PERMISSION_AUDIT_PATH";
+const INTERNAL_TOOLS = new Set(["contact_supervisor", "intercom", "subagent_wait", "structured_output"]);
+const DECISIONS = new Set<PermissionDecision>(["allow", "ask", "deny"]);
+const MAX_POLICY_BYTES = 16 * 1024;
+const MAX_PREVIEW_BYTES = 2048;
+const SECRET_KEY = /(?:authorization|cookie|credential|password|secret|token|api[-_]?key)/i;
+const SECRET_VALUE = /\b(?:Bearer\s+\S+|(?:sk|ghp|github_pat|xox[baprs])[-_A-Za-z0-9]{8,})\b/gi;
+
+export function validatePermissionRules(value: unknown, label: string): PermissionRules | undefined {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object mapping tool names to allow, ask, or deny.`);
+	const result: PermissionRules = {};
+	for (const [tool, decision] of Object.entries(value)) {
+		if (!tool.trim()) throw new Error(`${label} contains an empty tool name.`);
+		if (tool === "bash") throw new Error(`${label}.bash is unsupported; pi-subagents leaves bash policy to pi-guard.`);
+		if (INTERNAL_TOOLS.has(tool)) throw new Error(`${label}.${tool} is reserved for child coordination and cannot be gated.`);
+		if (!DECISIONS.has(decision as PermissionDecision)) throw new Error(`${label}.${tool} must be allow, ask, or deny.`);
+		result[tool] = decision as PermissionDecision;
+	}
+	return Object.keys(result).length ? result : undefined;
+}
+
+export function validatePermissionConfig(value: unknown, label = "config.permissions"): PermissionConfig | undefined {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object.`);
+	const object = value as Record<string, unknown>;
+	const unknown = Object.keys(object).filter((key) => key !== "rules");
+	if (unknown.length) throw new Error(`${label} has unsupported fields: ${unknown.join(", ")}.`);
+	return { rules: validatePermissionRules(object.rules, `${label}.rules`) };
+}
+
+export function resolvePermissionRules(globalConfig?: PermissionConfig, agentRules?: PermissionRules): PermissionRules | undefined {
+	const merged = { ...(globalConfig?.rules ?? {}), ...(agentRules ?? {}) };
+	for (const [tool, decision] of Object.entries(merged)) if (decision === "allow") delete merged[tool];
+	return Object.keys(merged).length ? merged : undefined;
+}
+
+export function permissionDecision(rules: PermissionRules | undefined, toolName: string): PermissionDecision {
+	if (toolName === "bash" || INTERNAL_TOOLS.has(toolName)) return "allow";
+	return rules?.[toolName] ?? "allow";
+}
+
+export function encodePermissionRules(rules: PermissionRules | undefined): string | undefined {
+	if (!rules || Object.keys(rules).length === 0) return undefined;
+	const encoded = JSON.stringify(rules);
+	if (Buffer.byteLength(encoded, "utf-8") > MAX_POLICY_BYTES) throw new Error("Resolved permission policy is too large.");
+	return encoded;
+}
+
+export function decodePermissionRules(encoded: string | undefined): PermissionRules | undefined {
+	if (!encoded?.trim()) return undefined;
+	return validatePermissionRules(JSON.parse(encoded), PERMISSION_POLICY_ENV);
+}
+
+function redact(value: unknown, key = "", depth = 0): unknown {
+	if (SECRET_KEY.test(key)) return "[redacted]";
+	if (depth >= 3) return "[truncated]";
+	if (Array.isArray(value)) return value.slice(0, 10).map((item) => redact(item, "", depth + 1));
+	if (value && typeof value === "object") return Object.fromEntries(Object.entries(value as Record<string, unknown>).slice(0, 20).map(([entryKey, entryValue]) => [entryKey, redact(entryValue, entryKey, depth + 1)]));
+	if (typeof value === "string") {
+		const redacted = value.replace(SECRET_VALUE, "[redacted]");
+		return redacted.length > 500 ? `${redacted.slice(0, 500)}…` : redacted;
+	}
+	return value;
+}
+
+export function permissionArgsPreview(input: unknown): string {
+	const serialized = JSON.stringify(redact(input));
+	if (!serialized) return "{}";
+	return Buffer.byteLength(serialized, "utf-8") <= MAX_PREVIEW_BYTES ? serialized : `${Buffer.from(serialized).subarray(0, MAX_PREVIEW_BYTES).toString("utf-8")}…`;
+}
+
+export function appendPermissionAudit(filePath: string | undefined, record: Record<string, unknown>): void {
+	if (!filePath) return;
+	fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+	fs.appendFileSync(filePath, `${JSON.stringify(record)}\n`, { encoding: "utf-8", mode: 0o600 });
+}

--- a/src/runs/shared/permissions.ts
+++ b/src/runs/shared/permissions.ts
@@ -75,7 +75,17 @@ function redact(value: unknown, key = "", depth = 0): unknown {
 export function permissionArgsPreview(input: unknown): string {
 	const serialized = JSON.stringify(redact(input));
 	if (!serialized) return "{}";
-	return Buffer.byteLength(serialized, "utf-8") <= MAX_PREVIEW_BYTES ? serialized : `${Buffer.from(serialized).subarray(0, MAX_PREVIEW_BYTES).toString("utf-8")}…`;
+	if (Buffer.byteLength(serialized, "utf-8") <= MAX_PREVIEW_BYTES) return serialized;
+	const maxContentBytes = MAX_PREVIEW_BYTES - Buffer.byteLength("…", "utf-8");
+	let preview = "";
+	let previewBytes = 0;
+	for (const character of serialized) {
+		const characterBytes = Buffer.byteLength(character, "utf-8");
+		if (previewBytes + characterBytes > maxContentBytes) break;
+		preview += character;
+		previewBytes += characterBytes;
+	}
+	return `${preview}…`;
 }
 
 export function appendPermissionAudit(filePath: string | undefined, record: Record<string, unknown>): void {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -394,14 +394,14 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV] = input.parentSessionId;
 	}
 	const encodedPermissionRules = encodePermissionRules(input.permissionRules);
-	if ((input.orchestratorIntercomTarget || encodedPermissionRules) && input.parentSessionId && input.runId && input.childAgentName) {
+	if (input.orchestratorIntercomTarget && input.parentSessionId && input.runId && input.childAgentName) {
 		const childIndex = input.childIndex ?? 0;
 		const channelDir = supervisorChannelDir(input.runId, input.childAgentName, childIndex);
 		fs.mkdirSync(path.join(channelDir, "requests"), { recursive: true });
 		fs.mkdirSync(path.join(channelDir, "replies"), { recursive: true });
 		env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] = channelDir;
-		if (encodedPermissionRules) env[PERMISSION_AUDIT_PATH_ENV] = input.permissionAuditPath ?? path.join(channelDir, "permission-audit.jsonl");
 	}
+	if (encodedPermissionRules) env[PERMISSION_AUDIT_PATH_ENV] = input.permissionAuditPath ?? path.join(tempDir, "permission-audit.jsonl");
 	if (input.runId) {
 		env[SUBAGENT_RUN_ID_ENV] = input.runId;
 	}

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -393,12 +393,14 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	if (input.parentSessionId) {
 		env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV] = input.parentSessionId;
 	}
-	if (input.orchestratorIntercomTarget && input.parentSessionId && input.runId && input.childAgentName) {
+	const encodedPermissionRules = encodePermissionRules(input.permissionRules);
+	if ((input.orchestratorIntercomTarget || encodedPermissionRules) && input.parentSessionId && input.runId && input.childAgentName) {
 		const childIndex = input.childIndex ?? 0;
 		const channelDir = supervisorChannelDir(input.runId, input.childAgentName, childIndex);
 		fs.mkdirSync(path.join(channelDir, "requests"), { recursive: true });
 		fs.mkdirSync(path.join(channelDir, "replies"), { recursive: true });
 		env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] = channelDir;
+		if (encodedPermissionRules) env[PERMISSION_AUDIT_PATH_ENV] = input.permissionAuditPath ?? path.join(channelDir, "permission-audit.jsonl");
 	}
 	if (input.runId) {
 		env[SUBAGENT_RUN_ID_ENV] = input.runId;
@@ -414,11 +416,7 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	else env.MCP_DIRECT_TOOLS = "__none__";
 	const encodedCapabilityCeiling = encodeSubagentCapabilityCeiling(toolPlan.capabilityCeiling);
 	if (encodedCapabilityCeiling) env[SUBAGENT_CAPABILITY_CEILING_ENV] = encodedCapabilityCeiling;
-	const encodedPermissionRules = encodePermissionRules(input.permissionRules);
-	if (encodedPermissionRules) {
-		env[PERMISSION_POLICY_ENV] = encodedPermissionRules;
-		env[PERMISSION_AUDIT_PATH_ENV] = input.permissionAuditPath;
-	}
+	if (encodedPermissionRules) env[PERMISSION_POLICY_ENV] = encodedPermissionRules;
 	if (input.structuredOutput) {
 		env[STRUCTURED_OUTPUT_CAPTURE_ENV] = input.structuredOutput.outputPath;
 		env[STRUCTURED_OUTPUT_SCHEMA_ENV] = input.structuredOutput.schemaPath;

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -15,6 +15,7 @@ import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, MCP_DIRECT_CHILD_TOOLS_ENV, REQUIRED_CH
 import { CHILD_WATCHDOG_CONFIG_ENV, encodeChildWatchdogConfig, type ChildWatchdogConfig } from "../../watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../background/wait-config.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../shared/utils.ts";
+import { encodePermissionRules, PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV, type PermissionRules } from "./permissions.ts";
 import { SUBAGENT_CAPABILITY_CEILING_ENV, capabilityCeilingAgentRestrictionSources, decodeSubagentCapabilityCeiling, encodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, isAgentAllowedByCapabilityCeiling, type ResolvedSubagentCapabilityCeiling, type SubagentCapabilityAudit } from "./capability-ceiling.ts";
 
 const TASK_ARG_LIMIT = 8000;
@@ -87,6 +88,8 @@ export interface BuildPiArgsInput {
 	};
 	toolBudget?: ResolvedToolBudget;
 	allowZeroToolBudget?: boolean;
+	permissionRules?: PermissionRules;
+	permissionAuditPath?: string;
 	childWatchdog?: ChildWatchdogConfig;
 	waitToolEnabled?: boolean;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
@@ -411,6 +414,11 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	else env.MCP_DIRECT_TOOLS = "__none__";
 	const encodedCapabilityCeiling = encodeSubagentCapabilityCeiling(toolPlan.capabilityCeiling);
 	if (encodedCapabilityCeiling) env[SUBAGENT_CAPABILITY_CEILING_ENV] = encodedCapabilityCeiling;
+	const encodedPermissionRules = encodePermissionRules(input.permissionRules);
+	if (encodedPermissionRules) {
+		env[PERMISSION_POLICY_ENV] = encodedPermissionRules;
+		env[PERMISSION_AUDIT_PATH_ENV] = input.permissionAuditPath;
+	}
 	if (input.structuredOutput) {
 		env[STRUCTURED_OUTPUT_CAPTURE_ENV] = input.structuredOutput.outputPath;
 		env[STRUCTURED_OUTPUT_SCHEMA_ENV] = input.structuredOutput.schemaPath;

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -1,7 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { registerNativeSupervisorClient } from "../../intercom/native-supervisor-channel.ts";
+import { registerNativeSupervisorClient, requestSupervisorPermission } from "../../intercom/native-supervisor-channel.ts";
+import { decodePermissionRules, permissionDecision, PERMISSION_POLICY_ENV } from "./permissions.ts";
 import { consumeSteerRequestsFromDir, steerAckPathFromDir, writeSteerAckAt, writeSteerCapabilityAt, writeSteerRequestToDir, type SteerRequest } from "../background/control-channel.ts";
 import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_INDEX_ENV, SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_STEER_ACK_DIR_ENV, SUBAGENT_STEER_CAPABILITY_ENV, SUBAGENT_STEER_INBOX_ENV } from "./pi-args.ts";
 import { RUNTIME_EXTENSION_ACK_EVENT, RUNTIME_EXTENSION_ACK_PATH_ENV, isRuntimeAcknowledgedExtensionId, writeRuntimeAcknowledgedExtensions } from "./runtime-acknowledged-extensions.ts";
@@ -241,6 +242,21 @@ export function formatSteerMessage(request: SteerRequest): string {
 	].join("\n");
 }
 
+export function registerPermissionGate(pi: ExtensionAPI): void {
+	const rules = decodePermissionRules(process.env[PERMISSION_POLICY_ENV]);
+	if (!rules) return;
+	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: { toolName?: string; input?: unknown }, ctx?: unknown) => unknown) => void;
+	onRuntimeEvent("tool_call", async (event) => {
+		const toolName = typeof event.toolName === "string" ? event.toolName : "tool";
+		const decision = permissionDecision(rules, toolName);
+		if (decision === "allow") return undefined;
+		if (decision === "deny") return { block: true, reason: `Blocked by pi-subagents permission rule: '${toolName}' is denied.` };
+		const result = await requestSupervisorPermission({ toolName, args: event.input ?? {}, });
+		if (result.approved) return undefined;
+		return { block: true, reason: `Blocked by pi-subagents permission rule: ${result.reason}` };
+	});
+}
+
 function registerToolBudget(pi: ExtensionAPI, budget: ResolvedToolBudget | undefined): void {
 	if (!budget) return;
 	let toolCount = 0;
@@ -377,6 +393,7 @@ export function registerSteeringInbox(
 export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 	registerRuntimeExtensionAcknowledgements(pi);
 	registerSteeringInbox(pi);
+	registerPermissionGate(pi);
 	registerToolBudget(pi, decodeToolBudgetEnv(process.env[TOOL_BUDGET_ENV], { allowZero: process.env[TOOL_BUDGET_ZERO_AUTH_ENV] === "1" }));
 	registerChildWatchdog(pi);
 	const waitToolEnabled = resolveWaitToolConfig().enabled;

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -1,8 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { registerNativeSupervisorClient, requestSupervisorPermission } from "../../intercom/native-supervisor-channel.ts";
-import { decodePermissionRules, permissionDecision, PERMISSION_POLICY_ENV } from "./permissions.ts";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { registerNativeSupervisorClient } from "../../intercom/native-supervisor-channel.ts";
+import { decodePermissionRules, permissionDecision, PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV } from "./permissions.ts";
 import { consumeSteerRequestsFromDir, steerAckPathFromDir, writeSteerAckAt, writeSteerCapabilityAt, writeSteerRequestToDir, type SteerRequest } from "../background/control-channel.ts";
 import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_INDEX_ENV, SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_STEER_ACK_DIR_ENV, SUBAGENT_STEER_CAPABILITY_ENV, SUBAGENT_STEER_INBOX_ENV } from "./pi-args.ts";
 import { RUNTIME_EXTENSION_ACK_EVENT, RUNTIME_EXTENSION_ACK_PATH_ENV, isRuntimeAcknowledgedExtensionId, writeRuntimeAcknowledgedExtensions } from "./runtime-acknowledged-extensions.ts";
@@ -19,6 +19,8 @@ import type { JsonSchemaObject, ResolvedToolBudget, SubagentState } from "../../
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { resolveWatchPath } from "../../shared/utils.ts";
 import { registerChildWatchdog } from "../../watchdog/register-child.ts";
+import { CHILD_WATCHDOG_CONFIG_ENV } from "../../watchdog/child-status.ts";
+import { requestWatchdogPermission, type WatchdogPermissionRequest, type WatchdogPermissionResult } from "../../watchdog/permission-arbiter.ts";
 import { SUBAGENT_WATCHDOG_WARNING_TYPE } from "../../watchdog/types.ts";
 import { resolveWaitToolConfig } from "../background/wait-config.ts";
 import { registerWaitTool } from "../background/wait-tool.ts";
@@ -242,16 +244,26 @@ export function formatSteerMessage(request: SteerRequest): string {
 	].join("\n");
 }
 
-export function registerPermissionGate(pi: ExtensionAPI): void {
+export function registerPermissionGate(
+	pi: ExtensionAPI,
+	requestPermission: (request: WatchdogPermissionRequest) => Promise<WatchdogPermissionResult> = requestWatchdogPermission,
+): void {
 	const rules = decodePermissionRules(process.env[PERMISSION_POLICY_ENV]);
 	if (!rules) return;
-	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: { toolName?: string; input?: unknown }, ctx?: unknown) => unknown) => void;
-	onRuntimeEvent("tool_call", async (event) => {
+	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: { toolName?: string; input?: unknown }, ctx: ExtensionContext) => unknown) => void;
+	onRuntimeEvent("tool_call", async (event, ctx) => {
 		const toolName = typeof event.toolName === "string" ? event.toolName : "tool";
 		const decision = permissionDecision(rules, toolName);
 		if (decision === "allow") return undefined;
 		if (decision === "deny") return { block: true, reason: `Blocked by pi-subagents permission rule: '${toolName}' is denied.` };
-		const result = await requestSupervisorPermission({ toolName, args: event.input ?? {}, });
+		const result = await requestPermission({
+			ctx,
+			toolName,
+			args: event.input ?? {},
+			rawWatchdogConfig: process.env[CHILD_WATCHDOG_CONFIG_ENV],
+			auditPath: process.env[PERMISSION_AUDIT_PATH_ENV],
+			...(ctx.signal ? { signal: ctx.signal } : {}),
+		});
 		if (result.approved) return undefined;
 		return { block: true, reason: `Blocked by pi-subagents permission rule: ${result.reason}` };
 	});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1587,6 +1587,8 @@ export const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom
 // ============================================================================
 
 export interface RunSyncOptions {
+	/** Opt-in global permission rules; missing tools remain allowed. */
+	permissions?: import("../runs/shared/permissions.ts").PermissionConfig;
 	/** Session id of the direct parent session for permission-system ask forwarding. */
 	parentSessionId?: string;
 	/** Resolved launch context for this child. */
@@ -1717,6 +1719,8 @@ export interface ExtensionConfig {
 	completionBatch?: CompletionBatchConfig;
 	turnBudget?: TurnBudgetConfig;
 	toolBudget?: ToolBudgetConfig;
+	/** Opt-in native tool permissions. Bash remains outside this policy. */
+	permissions?: import("../runs/shared/permissions.ts").PermissionConfig;
 	usageBudget?: UsageBudgetConfig;
 	parallel?: TopLevelParallelConfig;
 	chain?: ExtensionChainConfig;

--- a/src/watchdog/permission-arbiter.ts
+++ b/src/watchdog/permission-arbiter.ts
@@ -1,0 +1,145 @@
+import { Agent, type AgentTool, type StreamFn } from "@earendil-works/pi-agent-core";
+import { convertToLlm, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { streamSimple } from "@earendil-works/pi-ai/compat";
+import { Type, type Static } from "typebox";
+import { appendPermissionAudit, permissionArgsPreview } from "../runs/shared/permissions.ts";
+import { decodeChildWatchdogConfig } from "./child-status.ts";
+import { childResolvedConfig } from "./register-child.ts";
+import { resolveWatchdogReviewModel } from "./review.ts";
+
+const PermissionDecisionParams = Type.Object({
+	decision: Type.String({ enum: ["approve", "deny"] }),
+	reason: Type.String({ description: "One concise reason for this exact decision." }),
+}, { additionalProperties: false });
+
+type PermissionDecisionParams = Static<typeof PermissionDecisionParams>;
+
+export interface WatchdogPermissionResult {
+	approved: boolean;
+	reason: string;
+	source: "watchdog";
+}
+
+export interface WatchdogPermissionRequest {
+	ctx: ExtensionContext;
+	toolName: string;
+	args: unknown;
+	rawWatchdogConfig?: string;
+	auditPath?: string;
+	signal?: AbortSignal;
+}
+
+export interface WatchdogPermissionArbiterOptions {
+	streamFn?: StreamFn;
+}
+
+function conciseReason(value: string): string {
+	const trimmed = value.trim();
+	return trimmed ? trimmed.slice(0, 500) : "Watchdog returned an empty reason.";
+}
+
+export function createWatchdogPermissionArbiter(options: WatchdogPermissionArbiterOptions = {}) {
+	return async (request: WatchdogPermissionRequest): Promise<WatchdogPermissionResult> => {
+		const preview = permissionArgsPreview(request.args);
+		const createdAt = Date.now();
+		const auditBase = { type: "permission.request", createdAt, toolName: request.toolName, preview, matchedRule: "ask", decisionSource: "watchdog" };
+		appendPermissionAudit(request.auditPath, auditBase);
+		const finish = (approved: boolean, reason: string, decision: string): WatchdogPermissionResult => {
+			appendPermissionAudit(request.auditPath, {
+				type: "permission.decision",
+				createdAt: Date.now(),
+				requestCreatedAt: createdAt,
+				toolName: request.toolName,
+				decision,
+				approved,
+				decisionSource: "watchdog",
+				reason: conciseReason(reason),
+			});
+			return { approved, reason: conciseReason(reason), source: "watchdog" };
+		};
+
+		let childConfig;
+		try {
+			childConfig = decodeChildWatchdogConfig(request.rawWatchdogConfig);
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+			return finish(false, `Watchdog permission arbiter configuration is invalid: ${reason}`, "unavailable");
+		}
+		if (!childConfig) return finish(false, "Watchdog permission arbiter is unavailable because the child watchdog is disabled.", "unavailable");
+		if (request.signal?.aborted || request.ctx.signal?.aborted) return finish(false, "Watchdog permission decision was cancelled.", "cancelled");
+
+		let decision: PermissionDecisionParams | undefined;
+		const tool: AgentTool<typeof PermissionDecisionParams, { recorded: boolean }> = {
+			name: "watchdog_permission_decision",
+			label: "Watchdog permission decision",
+			description: "Approve or deny this exact child tool call. Call exactly once.",
+			parameters: PermissionDecisionParams,
+			executionMode: "sequential",
+			async execute(_toolCallId, params) {
+				if (!decision) decision = params;
+				return { content: [{ type: "text", text: "Permission decision recorded." }], details: { recorded: true } };
+			},
+		};
+
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		let agent: Agent | undefined;
+		try {
+			const config = childResolvedConfig(childConfig);
+			const selection = await resolveWatchdogReviewModel(request.ctx, config);
+			const auth = selection.auth;
+			const registeredProvider = (request.ctx.modelRegistry as {
+				getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
+			}).getRegisteredProviderConfig?.(selection.model.provider);
+			const baseStreamFn = options.streamFn ?? (registeredProvider?.streamSimple && registeredProvider.api === selection.model.api
+				? registeredProvider.streamSimple
+				: streamSimple);
+			const streamFn: StreamFn = (model, context, streamOptions) => baseStreamFn(model, context, {
+				...streamOptions,
+				...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
+				env: auth.env || streamOptions?.env ? { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } : undefined,
+				headers: { ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
+			});
+			agent = new Agent({
+				initialState: {
+					systemPrompt: [
+						"You are the pi-subagents watchdog permission arbiter.",
+						"Decide only whether this exact non-bash child tool call should proceed.",
+						"Call watchdog_permission_decision exactly once with approve or deny and a concise reason.",
+						"Deny when uncertain. Do not produce freeform advice or ask the parent orchestrator.",
+					].join("\n"),
+					model: selection.model,
+					thinkingLevel: selection.thinkingLevel,
+					tools: [tool],
+				},
+				convertToLlm,
+				streamFunction: streamFn,
+				getApiKey: (providerName) => providerName === selection.model.provider ? auth.apiKey : undefined,
+				beforeToolCall: async ({ toolCall }) => toolCall.name === tool.name ? undefined : { block: true, reason: `Permission arbiter tool '${toolCall.name}' is not allowed.` },
+				toolExecution: "sequential",
+			});
+			const abort = () => agent?.abort();
+			request.signal?.addEventListener("abort", abort, { once: true });
+			request.ctx.signal?.addEventListener("abort", abort, { once: true });
+			try {
+				const prompt = `Tool: ${request.toolName}\nRedacted arguments: ${preview}`;
+				await Promise.race([
+					agent.prompt(prompt),
+					new Promise<never>((_, reject) => { timeout = setTimeout(() => { agent?.abort(); reject(new Error("Watchdog permission decision timed out.")); }, childConfig.agentEndTimeoutMs); }),
+				]);
+			} finally {
+				request.signal?.removeEventListener("abort", abort);
+				request.ctx.signal?.removeEventListener("abort", abort);
+			}
+			if (!decision) return finish(false, "Watchdog permission arbiter returned no decision.", "malformed");
+			const approved = decision.decision === "approve";
+			return finish(approved, decision.reason, decision.decision);
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+			return finish(false, `Watchdog permission arbiter failed closed: ${reason}`, reason.includes("timed out") ? "timeout" : "error");
+		} finally {
+			if (timeout) clearTimeout(timeout);
+		}
+	};
+}
+
+export const requestWatchdogPermission = createWatchdogPermissionArbiter();

--- a/src/watchdog/register-child.ts
+++ b/src/watchdog/register-child.ts
@@ -12,7 +12,7 @@ import {
 } from "./child-status.ts";
 import type { ResolvedWatchdogConfig, WatchdogWarningDetails } from "./types.ts";
 
-function childResolvedConfig(config: ChildWatchdogConfig): ResolvedWatchdogConfig {
+export function childResolvedConfig(config: ChildWatchdogConfig): ResolvedWatchdogConfig {
 	return {
 		...DEFAULT_WATCHDOG_CONFIG,
 		enabled: true,

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -26,7 +26,6 @@ import {
 } from "../support/helpers.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT } from "../../src/shared/types.ts";
 import { PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV } from "../../src/runs/shared/permissions.ts";
-import { SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV } from "../../src/runs/shared/pi-args.ts";
 
 interface TestSequentialStep {
 	agent: string;
@@ -240,8 +239,8 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 		assert.equal(mockPi.callCount(), 1);
 	});
 
-	it("applies global permissions to foreground chain children without requiring intercom", async () => {
-		mockPi.onCall({ echoEnv: [PERMISSION_POLICY_ENV, SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV, PERMISSION_AUDIT_PATH_ENV] });
+	it("applies global permissions to foreground chain children", async () => {
+		mockPi.onCall({ echoEnv: [PERMISSION_POLICY_ENV, PERMISSION_AUDIT_PATH_ENV] });
 		const agents = [makeAgent("worker")];
 
 		const result = await executeChain!(makeChainParams(
@@ -253,7 +252,6 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 		assert.equal(result.isError, undefined);
 		const env = JSON.parse(result.details.results[0]?.finalOutput ?? "{}") as Record<string, string | null>;
 		assert.equal(env[PERMISSION_POLICY_ENV], JSON.stringify({ write: "ask" }));
-		assert.match(env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] ?? "", /supervisor-channels/);
 		assert.match(env[PERMISSION_AUDIT_PATH_ENV] ?? "", /permission-audit\.jsonl$/);
 	});
 
@@ -717,6 +715,39 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 		const dynamicNode = result.details.workflowGraph?.nodes[1];
 		assert.equal(dynamicNode?.kind, "dynamic-parallel-group");
 		assert.deepEqual(dynamicNode?.children?.map((child) => child.itemKey), ["src/a.ts", "src/b.ts"]);
+	});
+
+	it("applies global permissions to materialized dynamic parallel children", async () => {
+		mockPi.onCall({
+			output: "targets",
+			structuredOutput: { items: [{ path: "src/a.ts" }, { path: "src/b.ts" }] },
+		});
+		mockPi.onCall({ echoEnv: [PERMISSION_POLICY_ENV, PERMISSION_AUDIT_PATH_ENV], structuredOutput: { ok: "a" } });
+		mockPi.onCall({ echoEnv: [PERMISSION_POLICY_ENV, PERMISSION_AUDIT_PATH_ENV], structuredOutput: { ok: "b" } });
+		const agents = [makeAgent("scout"), makeAgent("reviewer")];
+
+		const result = await executeChain!(makeChainParams(
+			[
+				{ agent: "scout", task: "Return targets", as: "targets", outputSchema: { type: "object" } },
+				{
+					expand: { from: { output: "targets", path: "/items" }, key: "/path", maxItems: 4 },
+					parallel: { agent: "reviewer", task: "Review {item.path}", outputSchema: { type: "object" } },
+					collect: { as: "reviews" },
+					concurrency: 1,
+				},
+			],
+			agents,
+			{ permissions: { rules: { write: "ask" } } },
+		));
+
+		assert.equal(result.isError, undefined);
+		const reviewerResults = result.details.results.filter((entry) => entry.agent === "reviewer");
+		assert.equal(reviewerResults.length, 2);
+		for (const child of reviewerResults) {
+			const env = JSON.parse(child.finalOutput ?? "{}") as Record<string, string | null>;
+			assert.equal(env[PERMISSION_POLICY_ENV], JSON.stringify({ write: "ask" }));
+			assert.match(env[PERMISSION_AUDIT_PATH_ENV] ?? "", /permission-audit\.jsonl$/);
+		}
 	});
 
 	it("persists checked child evidence and pending aggregate review for dynamic fanout", async () => {
@@ -1404,6 +1435,31 @@ describe("chain execution — parallel steps", { skip: !available ? "pi packages
 		assert.ok(!result.isError, `should succeed: ${JSON.stringify(result.content)}`);
 		assert.equal(result.details.results.length, 2);
 		assert.deepEqual(result.details.results.map((row) => row.index), [0, 1]);
+	});
+
+	it("applies global permissions to foreground static parallel children", async () => {
+		mockPi.onCall({ echoEnv: [PERMISSION_POLICY_ENV, PERMISSION_AUDIT_PATH_ENV] });
+		mockPi.onCall({ echoEnv: [PERMISSION_POLICY_ENV, PERMISSION_AUDIT_PATH_ENV] });
+		const agents = [makeAgent("reviewer-a"), makeAgent("reviewer-b")];
+
+		const result = await executeChain!(makeChainParams(
+			[{
+				parallel: [
+					{ agent: "reviewer-a", task: "Review A" },
+					{ agent: "reviewer-b", task: "Review B" },
+				],
+			}],
+			agents,
+			{ permissions: { rules: { write: "ask" } } },
+		));
+
+		assert.equal(result.isError, undefined);
+		assert.equal(result.details.results.length, 2);
+		for (const child of result.details.results) {
+			const env = JSON.parse(child.finalOutput ?? "{}") as Record<string, string | null>;
+			assert.equal(env[PERMISSION_POLICY_ENV], JSON.stringify({ write: "ask" }));
+			assert.match(env[PERMISSION_AUDIT_PATH_ENV] ?? "", /permission-audit\.jsonl$/);
+		}
 	});
 
 	it("aggregates worktree handoffs across foreground chain groups", { skip: process.platform === "win32" ? "worktree paths differ on Windows" : undefined }, async () => {

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -25,6 +25,8 @@ import {
 	events,
 } from "../support/helpers.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT } from "../../src/shared/types.ts";
+import { PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV } from "../../src/runs/shared/permissions.ts";
+import { SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV } from "../../src/runs/shared/pi-args.ts";
 
 interface TestSequentialStep {
 	agent: string;
@@ -236,6 +238,23 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 		assert.equal(result.details.workflowGraph?.nodes[1]?.kind, "checkpoint");
 		assert.equal(result.details.workflowGraph?.nodes[1]?.status, "paused");
 		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("applies global permissions to foreground chain children without requiring intercom", async () => {
+		mockPi.onCall({ echoEnv: [PERMISSION_POLICY_ENV, SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV, PERMISSION_AUDIT_PATH_ENV] });
+		const agents = [makeAgent("worker")];
+
+		const result = await executeChain!(makeChainParams(
+			[{ agent: "worker", task: "Work" }],
+			agents,
+			{ permissions: { rules: { write: "ask" } } },
+		));
+
+		assert.equal(result.isError, undefined);
+		const env = JSON.parse(result.details.results[0]?.finalOutput ?? "{}") as Record<string, string | null>;
+		assert.equal(env[PERMISSION_POLICY_ENV], JSON.stringify({ write: "ask" }));
+		assert.match(env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] ?? "", /supervisor-channels/);
+		assert.match(env[PERMISSION_AUDIT_PATH_ENV] ?? "", /permission-audit\.jsonl$/);
 	});
 
 	it("runs a 2-step chain", async () => {

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -330,7 +330,7 @@ Do work
 });
 
 describe("agent permission frontmatter", () => {
-	it("preserves nested permission YAML blocks through discovery and serialization", () => {
+	it("parses and preserves explicit non-bash permission rules", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-permission-frontmatter-"));
 		tempDirs.push(dir);
 		const agentsDir = path.join(dir, ".pi", "agents");
@@ -340,26 +340,30 @@ name: worker
 description: Worker
 tools: bash,read,write
 permission:
-  "*": ask
   read: allow
-  bash:
-    "*": ask
-    "git *": allow
+  write: ask
+  edit: deny
 ---
 
 Do work
 `, "utf-8");
 
-		const result = discoverAgents(dir, "project");
-		const worker = result.agents.find((agent) => agent.name === "worker");
-		assert.equal(worker?.extraFields?.permission, `"*": ask
-read: allow
-bash:
-  "*": ask
-  "git *": allow`);
+		const worker = discoverAgents(dir, "project").agents.find((agent) => agent.name === "worker");
+		assert.deepEqual(worker?.permissions, { read: "allow", write: "ask", edit: "deny" });
+		assert.equal(worker?.extraFields?.permission, undefined);
+		assert.match(serializeAgent(worker!), /^permissions:\n  read: allow\n  write: ask\n  edit: deny$/m);
+	});
 
-		const serialized = serializeAgent(worker!);
-		assert.match(serialized, /^permission:\n  "\*": ask\n  read: allow\n  bash:\n    "\*": ask\n    "git \*": allow$/m);
+	it("rejects bash permission rules and conflicting aliases", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-permission-invalid-"));
+		tempDirs.push(dir);
+		const agentsDir = path.join(dir, ".pi", "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(path.join(agentsDir, "worker.md"), `---\nname: worker\ndescription: Worker\npermission:\n  bash: deny\n---\n`, "utf-8");
+		assert.throws(() => discoverAgents(dir, "project"), /pi-guard/);
+
+		fs.writeFileSync(path.join(agentsDir, "worker.md"), `---\nname: worker\ndescription: Worker\npermission:\n  write: ask\npermissions:\n  edit: deny\n---\n`, "utf-8");
+		assert.throws(() => discoverAgents(dir, "project"), /cannot declare both permission and permissions/);
 	});
 });
 

--- a/test/unit/async-permission-session.test.ts
+++ b/test/unit/async-permission-session.test.ts
@@ -28,6 +28,7 @@ describe("async permission forwarding session identity", () => {
 				cwd: "/tmp/project",
 				currentSessionId,
 				parentSessionId: "session-abc123",
+				permissions: { rules: { write: "ask" } },
 			},
 			maxSubagentDepth: 1,
 			asyncDir: "/tmp/async-run",
@@ -37,6 +38,7 @@ describe("async permission forwarding session identity", () => {
 		const step = built.steps[0];
 		assert.ok(step && !("parallel" in step));
 		assert.equal(step.parentSessionId, "session-abc123");
+		assert.deepEqual(step.permissionRules, { write: "ask" });
 	});
 
 	it("consumes bounded dynamic fanout indexes before later static forked steps", () => {

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -9,7 +9,6 @@ import {
 	createNativeSupervisorChannel,
 	ensureSupervisorChannelDir,
 	registerNativeSupervisorClient,
-	requestSupervisorPermission,
 	resolveSupervisorChannelDir,
 } from "../../src/intercom/native-supervisor-channel.ts";
 import {
@@ -21,7 +20,6 @@ import {
 	SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV,
 } from "../../src/runs/shared/pi-args.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, type SubagentState } from "../../src/shared/types.ts";
-import { PERMISSION_AUDIT_PATH_ENV } from "../../src/runs/shared/permissions.ts";
 
 const createdChannels: string[] = [];
 const savedEnv = {
@@ -106,7 +104,6 @@ function restoreEnv(): void {
 afterEach(() => {
 	restoreEnv();
 	delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
-	delete process.env[PERMISSION_AUDIT_PATH_ENV];
 	for (const channel of createdChannels.splice(0)) fs.rmSync(channel, { recursive: true, force: true });
 });
 
@@ -463,37 +460,6 @@ describe("native supervisor channel", () => {
 		} finally {
 			channel.dispose();
 		}
-	});
-
-	it("approves an explicit permission ask and writes paired redacted audit records", async () => {
-		const runId = `run-${randomUUID()}`;
-		const channelDir = resolveSupervisorChannelDir(runId, "worker", 0);
-		createdChannels.push(channelDir);
-		process.env[SUBAGENT_ORCHESTRATOR_TARGET_ENV] = "shared-name";
-		process.env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV] = "session-parent";
-		process.env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] = channelDir;
-		process.env[SUBAGENT_RUN_ID_ENV] = runId;
-		process.env[SUBAGENT_CHILD_AGENT_ENV] = "worker";
-		process.env[SUBAGENT_CHILD_INDEX_ENV] = "0";
-		process.env[PERMISSION_AUDIT_PATH_ENV] = path.join(channelDir, "audit.jsonl");
-
-		const pending = requestSupervisorPermission({ toolName: "write", args: { token: "secret-value", path: "out.txt" } });
-		let requestName: string | undefined;
-		for (let attempt = 0; attempt < 20 && !requestName; attempt++) {
-			await new Promise((resolve) => setTimeout(resolve, 10));
-			requestName = fs.readdirSync(path.join(channelDir, "requests"))[0];
-		}
-		assert.ok(requestName);
-		const request = JSON.parse(fs.readFileSync(path.join(channelDir, "requests", requestName), "utf-8")) as { id: string; permission?: { preview?: string } };
-		assert.doesNotMatch(request.permission?.preview ?? "", /secret-value/);
-		fs.writeFileSync(path.join(channelDir, "replies", requestName), JSON.stringify({ type: "subagent.supervisor.reply", requestId: request.id, createdAt: Date.now(), message: "approve" }));
-
-		assert.deepEqual(await pending, { approved: true, reason: "Supervisor approved this exact 'write' call.", requestId: request.id });
-		const audit = fs.readFileSync(process.env[PERMISSION_AUDIT_PATH_ENV]!, "utf-8").trim().split("\n").map((line) => JSON.parse(line) as { requestId?: string; preview?: string });
-		assert.equal(audit.length, 2);
-		assert.equal(audit[0]?.requestId, request.id);
-		assert.equal(audit[1]?.requestId, request.id);
-		assert.doesNotMatch(audit[0]?.preview ?? "", /secret-value/);
 	});
 
 	it("removes the request file when a child supervisor ask is cancelled", async () => {

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -9,6 +9,7 @@ import {
 	createNativeSupervisorChannel,
 	ensureSupervisorChannelDir,
 	registerNativeSupervisorClient,
+	requestSupervisorPermission,
 	resolveSupervisorChannelDir,
 } from "../../src/intercom/native-supervisor-channel.ts";
 import {
@@ -20,6 +21,7 @@ import {
 	SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV,
 } from "../../src/runs/shared/pi-args.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, type SubagentState } from "../../src/shared/types.ts";
+import { PERMISSION_AUDIT_PATH_ENV } from "../../src/runs/shared/permissions.ts";
 
 const createdChannels: string[] = [];
 const savedEnv = {
@@ -104,6 +106,7 @@ function restoreEnv(): void {
 afterEach(() => {
 	restoreEnv();
 	delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+	delete process.env[PERMISSION_AUDIT_PATH_ENV];
 	for (const channel of createdChannels.splice(0)) fs.rmSync(channel, { recursive: true, force: true });
 });
 
@@ -460,6 +463,37 @@ describe("native supervisor channel", () => {
 		} finally {
 			channel.dispose();
 		}
+	});
+
+	it("approves an explicit permission ask and writes paired redacted audit records", async () => {
+		const runId = `run-${randomUUID()}`;
+		const channelDir = resolveSupervisorChannelDir(runId, "worker", 0);
+		createdChannels.push(channelDir);
+		process.env[SUBAGENT_ORCHESTRATOR_TARGET_ENV] = "shared-name";
+		process.env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV] = "session-parent";
+		process.env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] = channelDir;
+		process.env[SUBAGENT_RUN_ID_ENV] = runId;
+		process.env[SUBAGENT_CHILD_AGENT_ENV] = "worker";
+		process.env[SUBAGENT_CHILD_INDEX_ENV] = "0";
+		process.env[PERMISSION_AUDIT_PATH_ENV] = path.join(channelDir, "audit.jsonl");
+
+		const pending = requestSupervisorPermission({ toolName: "write", args: { token: "secret-value", path: "out.txt" } });
+		let requestName: string | undefined;
+		for (let attempt = 0; attempt < 20 && !requestName; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			requestName = fs.readdirSync(path.join(channelDir, "requests"))[0];
+		}
+		assert.ok(requestName);
+		const request = JSON.parse(fs.readFileSync(path.join(channelDir, "requests", requestName), "utf-8")) as { id: string; permission?: { preview?: string } };
+		assert.doesNotMatch(request.permission?.preview ?? "", /secret-value/);
+		fs.writeFileSync(path.join(channelDir, "replies", requestName), JSON.stringify({ type: "subagent.supervisor.reply", requestId: request.id, createdAt: Date.now(), message: "approve" }));
+
+		assert.deepEqual(await pending, { approved: true, reason: "Supervisor approved this exact 'write' call.", requestId: request.id });
+		const audit = fs.readFileSync(process.env[PERMISSION_AUDIT_PATH_ENV]!, "utf-8").trim().split("\n").map((line) => JSON.parse(line) as { requestId?: string; preview?: string });
+		assert.equal(audit.length, 2);
+		assert.equal(audit[0]?.requestId, request.id);
+		assert.equal(audit[1]?.requestId, request.id);
+		assert.doesNotMatch(audit[0]?.preview ?? "", /secret-value/);
 	});
 
 	it("removes the request file when a child supervisor ask is cancelled", async () => {

--- a/test/unit/permissions.test.ts
+++ b/test/unit/permissions.test.ts
@@ -36,6 +36,11 @@ describe("native child permissions", () => {
 		assert.deepEqual(decodePermissionRules(encoded), { write: "ask" });
 		const preview = permissionArgsPreview({ token: "secret-value", content: `Bearer abcdefghijklmnop ${"x".repeat(3000)}` });
 		assert.doesNotMatch(preview, /secret-value|abcdefghijklmnop/);
-		assert.ok(Buffer.byteLength(preview) <= 2051);
+		assert.ok(Buffer.byteLength(preview) <= 2048);
+
+		const multibytePreview = permissionArgsPreview({ content: Array.from({ length: 10 }, () => "😀".repeat(300)) });
+		assert.ok(Buffer.byteLength(multibytePreview, "utf-8") <= 2048);
+		assert.doesNotMatch(multibytePreview, /�/);
+		assert.match(multibytePreview, /…$/);
 	});
 });

--- a/test/unit/permissions.test.ts
+++ b/test/unit/permissions.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	decodePermissionRules,
+	encodePermissionRules,
+	permissionArgsPreview,
+	permissionDecision,
+	resolvePermissionRules,
+	validatePermissionConfig,
+	validatePermissionRules,
+} from "../../src/runs/shared/permissions.ts";
+
+describe("native child permissions", () => {
+	it("defaults every unconfigured tool and bash to pass-through", () => {
+		assert.equal(permissionDecision(undefined, "write"), "allow");
+		assert.equal(permissionDecision({ write: "deny" }, "unknown_tool"), "allow");
+		assert.equal(permissionDecision({ write: "deny" }, "bash"), "allow");
+		assert.equal(resolvePermissionRules(), undefined);
+	});
+
+	it("merges explicit global and agent rules while removing explicit allow rules", () => {
+		assert.deepEqual(resolvePermissionRules(
+			{ rules: { write: "ask", edit: "deny" } },
+			{ write: "allow", read: "deny" },
+		), { edit: "deny", read: "deny" });
+	});
+
+	it("rejects bash and coordination-tool rules", () => {
+		assert.throws(() => validatePermissionRules({ bash: "ask" }, "permissions"), /pi-guard/);
+		assert.throws(() => validatePermissionRules({ contact_supervisor: "deny" }, "permissions"), /reserved for child coordination/);
+		assert.throws(() => validatePermissionConfig({ rules: { write: "sometimes" } }), /allow, ask, or deny/);
+	});
+
+	it("round-trips only explicit non-allow rules and redacts bounded previews", () => {
+		const encoded = encodePermissionRules({ write: "ask" });
+		assert.deepEqual(decodePermissionRules(encoded), { write: "ask" });
+		const preview = permissionArgsPreview({ token: "secret-value", content: `Bearer abcdefghijklmnop ${"x".repeat(3000)}` });
+		assert.doesNotMatch(preview, /secret-value|abcdefghijklmnop/);
+		assert.ok(Buffer.byteLength(preview) <= 2051);
+	});
+});

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -563,8 +563,8 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env[PI_INTERCOM_SESSION_ID_ENV], undefined);
 	});
 
-	it("creates a permission supervisor channel and audit path without enabling intercom", () => {
-		const { env } = buildPiArgs({
+	it("creates a private permission audit path without enabling the supervisor channel", () => {
+		const { env, tempDir } = buildPiArgs({
 			baseArgs: ["-p"],
 			task: "hello",
 			sessionEnabled: false,
@@ -579,8 +579,8 @@ describe("buildPiArgs system prompt mode wiring", () => {
 
 		assert.equal(env.PI_SUBAGENT_ORCHESTRATOR_TARGET, undefined);
 		assert.equal(env[PERMISSION_POLICY_ENV], JSON.stringify({ write: "ask" }));
-		assert.match(env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] ?? "", /supervisor-channels/);
-		assert.equal(env[PERMISSION_AUDIT_PATH_ENV], path.join(env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV]!, "permission-audit.jsonl"));
+		assert.equal(env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV], undefined);
+		assert.equal(env[PERMISSION_AUDIT_PATH_ENV], path.join(tempDir!, "permission-audit.jsonl"));
 	});
 
 	it("does not create a supervisor channel without an exact parent session id", () => {

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -9,6 +9,7 @@ import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts"
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
 import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, MCP_DIRECT_CHILD_TOOLS_ENV, REQUIRED_CHILD_TOOLS_ENV } from "../../src/runs/shared/tool-availability.ts";
 import { CHILD_WATCHDOG_CONFIG_ENV } from "../../src/watchdog/child-status.ts";
+import { PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV } from "../../src/runs/shared/permissions.ts";
 import {
 	SUBAGENT_FANOUT_CHILD_ENV,
 	SUBAGENT_PARENT_CHILD_INDEX_ENV,
@@ -560,6 +561,26 @@ describe("buildPiArgs system prompt mode wiring", () => {
 
 		assert.equal(env[PI_INTERCOM_STABLE_ID_ENV], undefined);
 		assert.equal(env[PI_INTERCOM_SESSION_ID_ENV], undefined);
+	});
+
+	it("creates a permission supervisor channel and audit path without enabling intercom", () => {
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: true,
+			inheritSkills: true,
+			parentSessionId: "session-parent-123",
+			runId: "permission-run",
+			childAgentName: "worker",
+			childIndex: 3,
+			permissionRules: { write: "ask" },
+		});
+
+		assert.equal(env.PI_SUBAGENT_ORCHESTRATOR_TARGET, undefined);
+		assert.equal(env[PERMISSION_POLICY_ENV], JSON.stringify({ write: "ask" }));
+		assert.match(env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] ?? "", /supervisor-channels/);
+		assert.equal(env[PERMISSION_AUDIT_PATH_ENV], path.join(env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV]!, "permission-audit.jsonl"));
 	});
 
 	it("does not create a supervisor channel without an exact parent session id", () => {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -19,6 +19,7 @@ import {
 import { RUNTIME_EXTENSION_ACK_EVENT, RUNTIME_EXTENSION_ACK_PATH_ENV } from "../../src/runs/shared/runtime-acknowledged-extensions.ts";
 import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "../../src/runs/shared/structured-output.ts";
 import { TOOL_BUDGET_ENV } from "../../src/runs/shared/tool-budget.ts";
+import { PERMISSION_POLICY_ENV } from "../../src/runs/shared/permissions.ts";
 import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, formatChildToolDiagnostic, MCP_DIRECT_CHILD_TOOLS_ENV, readChildToolDiagnostic, REQUIRED_CHILD_TOOLS_ENV } from "../../src/runs/shared/tool-availability.ts";
 import { CHILD_WATCHDOG_CONFIG_ENV } from "../../src/watchdog/child-status.ts";
 import { SUBAGENT_WATCHDOG_WARNING_TYPE } from "../../src/watchdog/types.ts";
@@ -26,6 +27,7 @@ import registerSubagentPromptRuntime, {
 	CHILD_FANOUT_BOUNDARY_INSTRUCTIONS,
 	CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS,
 	SUBAGENT_INTERCOM_SESSION_NAME_ENV,
+	registerPermissionGate,
 	registerSteeringInbox,
 	rewriteSubagentPrompt,
 	stripInheritedSkills,
@@ -46,6 +48,7 @@ const envSnapshot = {
 	PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA: process.env.PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA,
 	PI_SUBAGENT_RUNTIME_ACKNOWLEDGED_EXTENSIONS: process.env.PI_SUBAGENT_RUNTIME_ACKNOWLEDGED_EXTENSIONS,
 	PI_SUBAGENT_TOOL_BUDGET: process.env.PI_SUBAGENT_TOOL_BUDGET,
+	PI_SUBAGENT_PERMISSION_POLICY: process.env.PI_SUBAGENT_PERMISSION_POLICY,
 	PI_SUBAGENT_REQUIRED_TOOLS: process.env.PI_SUBAGENT_REQUIRED_TOOLS,
 	PI_SUBAGENT_MCP_DIRECT_TOOLS: process.env.PI_SUBAGENT_MCP_DIRECT_TOOLS,
 	PI_SUBAGENT_TOOL_DIAGNOSTIC_PATH: process.env.PI_SUBAGENT_TOOL_DIAGNOSTIC_PATH,
@@ -100,6 +103,8 @@ afterEach(() => {
 	else process.env[RUNTIME_EXTENSION_ACK_PATH_ENV] = envSnapshot.PI_SUBAGENT_RUNTIME_ACKNOWLEDGED_EXTENSIONS;
 	if (envSnapshot.PI_SUBAGENT_TOOL_BUDGET === undefined) delete process.env[TOOL_BUDGET_ENV];
 	else process.env[TOOL_BUDGET_ENV] = envSnapshot.PI_SUBAGENT_TOOL_BUDGET;
+	if (envSnapshot.PI_SUBAGENT_PERMISSION_POLICY === undefined) delete process.env[PERMISSION_POLICY_ENV];
+	else process.env[PERMISSION_POLICY_ENV] = envSnapshot.PI_SUBAGENT_PERMISSION_POLICY;
 	if (envSnapshot.PI_SUBAGENT_REQUIRED_TOOLS === undefined) delete process.env[REQUIRED_CHILD_TOOLS_ENV];
 	else process.env[REQUIRED_CHILD_TOOLS_ENV] = envSnapshot.PI_SUBAGENT_REQUIRED_TOOLS;
 	if (envSnapshot.PI_SUBAGENT_MCP_DIRECT_TOOLS === undefined) delete process.env[MCP_DIRECT_CHILD_TOOLS_ENV];
@@ -132,6 +137,23 @@ function setSupervisorEnv(): void {
 }
 
 describe("subagent prompt runtime", () => {
+	it("registers no permission hook by default and never gates bash or coordination tools", async () => {
+		const handlers: Array<(event: { toolName?: string; input?: unknown }) => unknown> = [];
+		const pi = { on(event: string, handler: (event: { toolName?: string; input?: unknown }) => unknown) { if (event === "tool_call") handlers.push(handler); } };
+		delete process.env[PERMISSION_POLICY_ENV];
+		registerPermissionGate(pi as never);
+		assert.equal(handlers.length, 0);
+
+		process.env[PERMISSION_POLICY_ENV] = JSON.stringify({ write: "deny" });
+		registerPermissionGate(pi as never);
+		assert.equal(handlers.length, 1);
+		assert.equal(await handlers[0]!({ toolName: "bash", input: { command: "rm -rf /" } }), undefined);
+		assert.equal(await handlers[0]!({ toolName: "contact_supervisor", input: {} }), undefined);
+		assert.deepEqual(await handlers[0]!({ toolName: "write", input: {} }), {
+			block: true,
+			reason: "Blocked by pi-subagents permission rule: 'write' is denied.",
+		});
+	});
 	it("collects runtime extension acknowledgements until terminal serialization", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-runtime-ack-"));
 		try {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -137,9 +137,9 @@ function setSupervisorEnv(): void {
 }
 
 describe("subagent prompt runtime", () => {
-	it("registers no permission hook by default and never gates bash or coordination tools", async () => {
-		const handlers: Array<(event: { toolName?: string; input?: unknown }) => unknown> = [];
-		const pi = { on(event: string, handler: (event: { toolName?: string; input?: unknown }) => unknown) { if (event === "tool_call") handlers.push(handler); } };
+	it("registers no permission hook by default and routes ask only to the watchdog arbiter", async () => {
+		const handlers: Array<(event: { toolName?: string; input?: unknown }, ctx?: unknown) => unknown> = [];
+		const pi = { on(event: string, handler: (event: { toolName?: string; input?: unknown }, ctx?: unknown) => unknown) { if (event === "tool_call") handlers.push(handler); } };
 		delete process.env[PERMISSION_POLICY_ENV];
 		registerPermissionGate(pi as never);
 		assert.equal(handlers.length, 0);
@@ -153,6 +153,16 @@ describe("subagent prompt runtime", () => {
 			block: true,
 			reason: "Blocked by pi-subagents permission rule: 'write' is denied.",
 		});
+
+		process.env[PERMISSION_POLICY_ENV] = JSON.stringify({ write: "ask" });
+		const askHandlers: Array<(event: { toolName?: string; input?: unknown }, ctx: unknown) => unknown> = [];
+		const requests: Array<{ toolName: string; args: unknown }> = [];
+		registerPermissionGate({ on(event: string, handler: (event: { toolName?: string; input?: unknown }, ctx: unknown) => unknown) { if (event === "tool_call") askHandlers.push(handler); } } as never, async (request) => {
+			requests.push({ toolName: request.toolName, args: request.args });
+			return { approved: true, reason: "approved by watchdog", source: "watchdog" };
+		});
+		assert.equal(await askHandlers[0]!({ toolName: "write", input: { path: "out.txt" } }, { signal: undefined }), undefined);
+		assert.deepEqual(requests, [{ toolName: "write", args: { path: "out.txt" } }]);
 	});
 	it("collects runtime extension acknowledgements until terminal serialization", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-runtime-ack-"));

--- a/test/unit/watchdog-permission-arbiter.test.ts
+++ b/test/unit/watchdog-permission-arbiter.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { createAssistantMessageEventStream, fauxAssistantMessage, fauxToolCall, type AssistantMessage, type Model } from "@earendil-works/pi-ai";
+import { createWatchdogPermissionArbiter } from "../../src/watchdog/permission-arbiter.ts";
+
+function model(): Model<any> {
+	return { id: "watchdog", name: "watchdog", api: "faux", provider: "test", baseUrl: "https://example.invalid", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 100_000, maxTokens: 4_096 };
+}
+
+function ctx(current = model()) {
+	return {
+		cwd: "/tmp/watchdog-permission",
+		model: current,
+		signal: undefined,
+		modelRegistry: {
+			getAvailable: () => [current],
+			find: (provider: string, id: string) => provider === current.provider && id === current.id ? current : undefined,
+			hasConfiguredAuth: () => true,
+			getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "test-key" }),
+			getRegisteredProviderConfig: () => undefined,
+		},
+	} as never;
+}
+
+function responseStream(message: AssistantMessage) {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => stream.push({ type: "done", reason: message.stopReason, message }));
+	return stream;
+}
+
+function stream(decision: "approve" | "deny", reason: string): StreamFn {
+	const responses = [
+		fauxAssistantMessage(fauxToolCall("watchdog_permission_decision", { decision, reason }), { stopReason: "toolUse" }),
+		fauxAssistantMessage("done", { stopReason: "stop" }),
+	];
+	return () => responseStream(responses.shift()!);
+}
+
+const childConfig = JSON.stringify({
+	enabled: true,
+	watchdogTailTimeoutMs: 1_000,
+	agentEndTimeoutMs: 1_000,
+	maxWarnings: null,
+	lsp: { enabled: false, timeoutMs: 100, maxFiles: 1, maxDiagnostics: 1 },
+	autoFollowBlockers: false,
+	autoFollowMaxAttempts: null,
+	stalemateRepeats: 2,
+});
+
+describe("watchdog permission arbiter", () => {
+	it("approves and denies exact calls through the watchdog model decision tool", async () => {
+		const approved = await createWatchdogPermissionArbiter({ streamFn: stream("approve", "safe output path") })({ ctx: ctx(), toolName: "write", args: { path: "out.txt" }, rawWatchdogConfig: childConfig });
+		assert.deepEqual(approved, { approved: true, reason: "safe output path", source: "watchdog" });
+
+		const denied = await createWatchdogPermissionArbiter({ streamFn: stream("deny", "path is outside scope") })({ ctx: ctx(), toolName: "write", args: { path: "/etc/hosts" }, rawWatchdogConfig: childConfig });
+		assert.deepEqual(denied, { approved: false, reason: "path is outside scope", source: "watchdog" });
+	});
+
+	it("fails closed when the child watchdog is unavailable and audits redacted decisions", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "watchdog-permission-"));
+		try {
+			const auditPath = path.join(dir, "audit.jsonl");
+			const result = await createWatchdogPermissionArbiter()({ ctx: ctx(), toolName: "write", args: { token: "secret-value", path: "out.txt" }, auditPath });
+			assert.equal(result.approved, false);
+			assert.match(result.reason, /disabled/);
+			const records = fs.readFileSync(auditPath, "utf-8").trim().split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
+			assert.equal(records.length, 2);
+			assert.equal(records[0]?.decisionSource, "watchdog");
+			assert.equal(records[1]?.decision, "unavailable");
+			assert.doesNotMatch(String(records[0]?.preview), /secret-value/);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Implements #746 with opt-in native permissions for Pi child runtimes.

Unconfigured and unknown tools pass through. Explicit global or per-agent `allow`, `ask`, and `deny` rules apply only to non-bash, non-coordination tools. `allow` and `deny` resolve deterministically in the child runtime before the tool call executes. `ask` pauses the exact tool call and delegates the decision to a one-call child-watchdog permission arbiter, so ordinary permission decisions do not interrupt the main orchestrator agent. If the watchdog decision path is disabled, unauthenticated, malformed, timed out, or otherwise unavailable, the call fails closed with a clear error.

`bash` remains outside the native permission gate; bash governance stays with `pi-guard`. Ordinary direction and clarification via `contact_supervisor` or optional `pi-intercom` remain separate and are never permission-gated. External CLI launches reject effective native restrictions rather than claiming enforcement.

Audit records for explicit permission asks and decisions are bounded and redacted, include `decisionSource: "watchdog"`, and avoid raw tool arguments or secrets.

Validation:
- `npm run typecheck`
- focused permission, frontmatter, prompt-runtime, watchdog permission arbiter, chain, and async session tests
- `npm run test:unit` (1,550 passed, 1 skipped)
- `git diff --check`
- GitHub Ubuntu and Windows checks passed on `328830e8ef2e6979fb89c244b7d278f56daa19d1`
- Greptile passed on `328830e8ef2e6979fb89c244b7d278f56daa19d1` with no current-head defects
