### PR TITLE
build: enable unchecked indexed access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Enabled TypeScript `noUncheckedIndexedAccess` for production source after narrowing indexed reads at their runtime invariant boundaries. Thanks to @nicobailon for #748.
 - Added managed per-child worktree isolation to scripted workflows through `worktree: true` on `runs.run` / `runs.all` items or as a workflow-level default, with child overrides and handoff paths preserved in child artifacts.
 - Added opt-in native Pi-child tool permissions with global and per-agent `allow`/`ask`/`deny` rules, watchdog-owned exact-call decisions, and bounded redacted audit records. Unconfigured tools pass through, while bash policy remains with `pi-guard`.
 - Added a source-only, strict TypeScript typecheck command and CI gate.

--- a/src/agents/chain-serializer.ts
+++ b/src/agents/chain-serializer.ts
@@ -17,8 +17,10 @@ function parseStepBody(agent: string, sectionBody: string): ChainStepConfig {
 	for (const line of configLines) {
 		const match = line.match(/^([\w-]+):\s*(.*)$/);
 		if (!match) continue;
-		const key = match[1].trim().toLowerCase();
-		const rawValue = match[2].trim();
+		const [keyValue, rawValueValue] = match.slice(1);
+		if (keyValue === undefined || rawValueValue === undefined) continue;
+		const key = keyValue.trim().toLowerCase();
+		const rawValue = rawValueValue.trim();
 
 		if (key === "output") {
 			if (rawValue === "false") step.output = false;

--- a/src/agents/frontmatter.ts
+++ b/src/agents/frontmatter.ts
@@ -113,20 +113,22 @@ export function parseFrontmatter(content: string): { frontmatter: Record<string,
 
 		const match = line.match(/^([\w-]+):\s*(.*)$/);
 		if (match) {
-			const rawValue = match[2].trim();
+			const [key, rawValueValue] = match.slice(1);
+			if (key === undefined || rawValueValue === undefined) continue;
+			const rawValue = rawValueValue.trim();
 			const isQuoted = (rawValue.startsWith('"') && rawValue.endsWith('"')) || (rawValue.startsWith("'") && rawValue.endsWith("'"));
 			const value = isQuoted ? rawValue.slice(1, -1) : rawValue;
 			const isFolded = !isQuoted && (rawValue === ">" || rawValue === ">-");
 
 			if (value === "" || isFolded) {
 				// Key with empty value or folded block indicator — defer storing until we see indent
-				currentKey = match[1];
+				currentKey = key;
 				currentBlockLines = [];
 				currentIndent = indent;
 				currentFolded = isFolded;
 			} else {
 				// Simple key: value
-				frontmatter[match[1]] = value;
+				frontmatter[key] = value;
 			}
 		}
 		// Lines that don't match a key pattern (e.g., comments, empty lines) are ignored

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -1072,6 +1072,9 @@ export function executeAsyncChain(
 
 	if (spawnResult.pid) {
 		const eventFirstStep = eventChain[0];
+		if (!eventFirstStep) {
+			return formatAsyncStartError(resultMode, `Failed to start async ${resultMode} '${id}': event chain has no steps`);
+		}
 		const firstAgents = isParallelStep(eventFirstStep)
 			? eventFirstStep.parallel.map((t) => t.agent)
 			: isDynamicParallelStep(eventFirstStep)

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1723,6 +1723,12 @@ type RunnerStatusPayload = Omit<AsyncStatus, "steps" | "parallelGroups" | "pid" 
 	error?: string;
 };
 
+function requiredStatusStep(statusPayload: RunnerStatusPayload, index: number): RunnerStatusStep {
+	const step = statusPayload.steps[index];
+	if (!step) throw new Error(`Missing status step at index ${index}`);
+	return step;
+}
+
 function markParallelGroupSetupFailure(input: {
 	statusPayload: RunnerStatusPayload;
 	results: StepResult[];
@@ -1738,12 +1744,15 @@ function markParallelGroupSetupFailure(input: {
 }): void {
 	for (let taskIndex = 0; taskIndex < input.group.parallel.length; taskIndex++) {
 		const flatTaskIndex = input.groupStartFlatIndex + taskIndex;
-		input.statusPayload.steps[flatTaskIndex].status = "failed";
-		input.statusPayload.steps[flatTaskIndex].startedAt = input.failedAt;
-		input.statusPayload.steps[flatTaskIndex].endedAt = input.failedAt;
-		input.statusPayload.steps[flatTaskIndex].durationMs = 0;
-		input.statusPayload.steps[flatTaskIndex].exitCode = 1;
-		input.results.push({ agent: input.group.parallel[taskIndex].agent, context: input.group.parallel[taskIndex].context, output: input.setupError, success: false, exitCode: 1, sessionFile: input.group.parallel[taskIndex].sessionFile });
+		const statusStep = requiredStatusStep(input.statusPayload, flatTaskIndex);
+		const task = input.group.parallel[taskIndex];
+		if (!task) throw new Error(`Missing parallel task at index ${taskIndex}`);
+		statusStep.status = "failed";
+		statusStep.startedAt = input.failedAt;
+		statusStep.endedAt = input.failedAt;
+		statusStep.durationMs = 0;
+		statusStep.exitCode = 1;
+		input.results.push({ agent: task.agent, context: task.context, output: input.setupError, success: false, exitCode: 1, sessionFile: task.sessionFile });
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.lastUpdate = input.failedAt;
@@ -1771,13 +1780,14 @@ function markParallelGroupRunning(input: {
 }): void {
 	for (let taskIndex = 0; taskIndex < input.group.parallel.length; taskIndex++) {
 		const flatTaskIndex = input.groupStartFlatIndex + taskIndex;
-		input.statusPayload.steps[flatTaskIndex].status = "pending";
-		input.statusPayload.steps[flatTaskIndex].startedAt = undefined;
-		input.statusPayload.steps[flatTaskIndex].endedAt = undefined;
-		input.statusPayload.steps[flatTaskIndex].durationMs = undefined;
-		input.statusPayload.steps[flatTaskIndex].lastActivityAt = undefined;
-		input.statusPayload.steps[flatTaskIndex].activityState = undefined;
-		input.statusPayload.steps[flatTaskIndex].error = undefined;
+		const statusStep = requiredStatusStep(input.statusPayload, flatTaskIndex);
+		statusStep.status = "pending";
+		statusStep.startedAt = undefined;
+		statusStep.endedAt = undefined;
+		statusStep.durationMs = undefined;
+		statusStep.lastActivityAt = undefined;
+		statusStep.activityState = undefined;
+		statusStep.error = undefined;
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.activityState = undefined;
@@ -2122,7 +2132,7 @@ async function runSubagent(
 		emitNestedSelfEvent(statusPayload.state === "running" || statusPayload.state === "queued" ? "subagent.nested.updated" : "subagent.nested.completed");
 	};
 	const updateExternalProcess = (index: number, process: ExternalProcessStatus): void => {
-		statusPayload.steps[index].externalProcess = process;
+		requiredStatusStep(statusPayload, index).externalProcess = process;
 		statusPayload.lastUpdate = Date.now();
 		writeStatusPayload();
 	};
@@ -3310,12 +3320,12 @@ async function runSubagent(
 				if (statusPayload.usageBudget?.exhausted) {
 					const skippedAt = Date.now();
 					const message = usageBudgetExceededMessage(statusPayload.usageBudget);
-					statusPayload.steps[fi].status = "failed";
-					statusPayload.steps[fi].error = message;
-					statusPayload.steps[fi].startedAt = skippedAt;
-					statusPayload.steps[fi].endedAt = skippedAt;
-					statusPayload.steps[fi].durationMs = 0;
-					statusPayload.steps[fi].exitCode = 1;
+					requiredStatusStep(statusPayload, fi).status = "failed";
+					requiredStatusStep(statusPayload, fi).error = message;
+					requiredStatusStep(statusPayload, fi).startedAt = skippedAt;
+					requiredStatusStep(statusPayload, fi).endedAt = skippedAt;
+					requiredStatusStep(statusPayload, fi).durationMs = 0;
+					requiredStatusStep(statusPayload, fi).exitCode = 1;
 					statusPayload.lastUpdate = skippedAt;
 					usageBudgetExceeded = true;
 					writeStatusPayload();
@@ -3327,24 +3337,24 @@ async function runSubagent(
 				if (interrupted) return pausedStepResult(task.agent, task.context);
 				if (aborted && failFast) {
 					const skippedAt = Date.now();
-					statusPayload.steps[fi].status = "failed";
-					statusPayload.steps[fi].error = "Skipped due to fail-fast";
-					statusPayload.steps[fi].startedAt = skippedAt;
-					statusPayload.steps[fi].endedAt = skippedAt;
-					statusPayload.steps[fi].durationMs = 0;
-					statusPayload.steps[fi].exitCode = -1;
+					requiredStatusStep(statusPayload, fi).status = "failed";
+					requiredStatusStep(statusPayload, fi).error = "Skipped due to fail-fast";
+					requiredStatusStep(statusPayload, fi).startedAt = skippedAt;
+					requiredStatusStep(statusPayload, fi).endedAt = skippedAt;
+					requiredStatusStep(statusPayload, fi).durationMs = 0;
+					requiredStatusStep(statusPayload, fi).exitCode = -1;
 					statusPayload.lastUpdate = skippedAt;
 					writeStatusPayload();
 					return { agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true };
 				}
 				const taskStartTime = Date.now();
 				statusPayload.currentStep = fi;
-				statusPayload.steps[fi].status = "running";
-				statusPayload.steps[fi].error = undefined;
-				statusPayload.steps[fi].activityState = undefined;
-				resetStepLiveDetail(statusPayload.steps[fi]);
-				statusPayload.steps[fi].startedAt = taskStartTime;
-				statusPayload.steps[fi].lastActivityAt = taskStartTime;
+				requiredStatusStep(statusPayload, fi).status = "running";
+				requiredStatusStep(statusPayload, fi).error = undefined;
+				requiredStatusStep(statusPayload, fi).activityState = undefined;
+				resetStepLiveDetail(requiredStatusStep(statusPayload, fi));
+				requiredStatusStep(statusPayload, fi).startedAt = taskStartTime;
+				requiredStatusStep(statusPayload, fi).lastActivityAt = taskStartTime;
 				statusPayload.outputFile = path.join(asyncDir, `output-${fi}.log`);
 				statusPayload.lastActivityAt = taskStartTime;
 				statusPayload.lastUpdate = taskStartTime;
@@ -3385,27 +3395,27 @@ async function runSubagent(
 				const taskEndTime = Date.now();
 				const childInterrupted = singleResult.interrupted === true;
 				const childStopped = singleResult.stopped === true;
-				statusPayload.steps[fi].status = stopped || childStopped ? "stopped" : timedOut ? "failed" : childInterrupted ? "paused" : singleResult.exitCode === 0 ? "complete" : "failed";
-				statusPayload.steps[fi].endedAt = taskEndTime;
-				statusPayload.steps[fi].durationMs = taskEndTime - taskStartTime;
-				statusPayload.steps[fi].exitCode = stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode;
-				statusPayload.steps[fi].timedOut = timedOut || singleResult.timedOut ? true : undefined;
-				statusPayload.steps[fi].stopped = stopped || childStopped ? true : undefined;
-				statusPayload.steps[fi].turnBudget = singleResult.turnBudget;
-				statusPayload.steps[fi].turnBudgetExceeded = singleResult.turnBudgetExceeded;
-				statusPayload.steps[fi].wrapUpRequested = singleResult.wrapUpRequested;
-				statusPayload.steps[fi].toolBudget = singleResult.toolBudget;
-				statusPayload.steps[fi].toolBudgetBlocked = singleResult.toolBudgetBlocked;
+				requiredStatusStep(statusPayload, fi).status = stopped || childStopped ? "stopped" : timedOut ? "failed" : childInterrupted ? "paused" : singleResult.exitCode === 0 ? "complete" : "failed";
+				requiredStatusStep(statusPayload, fi).endedAt = taskEndTime;
+				requiredStatusStep(statusPayload, fi).durationMs = taskEndTime - taskStartTime;
+				requiredStatusStep(statusPayload, fi).exitCode = stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode;
+				requiredStatusStep(statusPayload, fi).timedOut = timedOut || singleResult.timedOut ? true : undefined;
+				requiredStatusStep(statusPayload, fi).stopped = stopped || childStopped ? true : undefined;
+				requiredStatusStep(statusPayload, fi).turnBudget = singleResult.turnBudget;
+				requiredStatusStep(statusPayload, fi).turnBudgetExceeded = singleResult.turnBudgetExceeded;
+				requiredStatusStep(statusPayload, fi).wrapUpRequested = singleResult.wrapUpRequested;
+				requiredStatusStep(statusPayload, fi).toolBudget = singleResult.toolBudget;
+				requiredStatusStep(statusPayload, fi).toolBudgetBlocked = singleResult.toolBudgetBlocked;
 				if (singleResult.toolBudget) statusPayload.toolBudget = singleResult.toolBudget;
 				if (singleResult.toolBudgetBlocked) statusPayload.toolBudgetBlocked = true;
 				if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 				if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 				if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
-				statusPayload.steps[fi].model = singleResult.model;
-				statusPayload.steps[fi].thinking = resolveEffectiveThinking(singleResult.model, statusPayload.steps[fi].thinking);
-				statusPayload.steps[fi].attemptedModels = singleResult.attemptedModels;
-				statusPayload.steps[fi].modelAttempts = singleResult.modelAttempts;
-				statusPayload.steps[fi].totalCost = singleResult.totalCost;
+				requiredStatusStep(statusPayload, fi).model = singleResult.model;
+				requiredStatusStep(statusPayload, fi).thinking = resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, fi).thinking);
+				requiredStatusStep(statusPayload, fi).attemptedModels = singleResult.attemptedModels;
+				requiredStatusStep(statusPayload, fi).modelAttempts = singleResult.modelAttempts;
+				requiredStatusStep(statusPayload, fi).totalCost = singleResult.totalCost;
 				if (singleResult.totalCost) {
 					pendingParallelUsageCost = {
 						inputTokens: pendingParallelUsageCost.inputTokens + singleResult.totalCost.inputTokens,
@@ -3414,23 +3424,23 @@ async function runSubagent(
 					};
 					refreshUsageBudget();
 				}
-				statusPayload.steps[fi].error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
-				statusPayload.steps[fi].transcriptPath = singleResult.transcriptPath ?? statusPayload.steps[fi].transcriptPath;
-				statusPayload.steps[fi].transcriptError = singleResult.transcriptError;
-				statusPayload.steps[fi].agentContract = singleResult.agentContract;
-				statusPayload.steps[fi].launchContractDigest = singleResult.launchContractDigest;
-				statusPayload.steps[fi].launchResolvedExtensions = singleResult.launchResolvedExtensions;
-				statusPayload.steps[fi].runtimeAcknowledgedExtensions = singleResult.runtimeAcknowledgedExtensions;
-				statusPayload.steps[fi].effects = singleResult.effects;
-				statusPayload.steps[fi].execution = singleResult.execution;
-				statusPayload.steps[fi].review = singleResult.review;
-				statusPayload.steps[fi].structuredOutput = singleResult.structuredOutput;
-				statusPayload.steps[fi].structuredOutputPath = singleResult.structuredOutputPath;
-				statusPayload.steps[fi].structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
-				statusPayload.steps[fi].acceptance = singleResult.acceptance;
-				statusPayload.steps[fi].watchdog = singleResult.watchdog;
-				statusPayload.steps[fi].capabilityCeiling = singleResult.capabilityCeiling;
-				statusPayload.steps[fi].capabilityAudit = singleResult.capabilityAudit;
+				requiredStatusStep(statusPayload, fi).error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
+				requiredStatusStep(statusPayload, fi).transcriptPath = singleResult.transcriptPath ?? requiredStatusStep(statusPayload, fi).transcriptPath;
+				requiredStatusStep(statusPayload, fi).transcriptError = singleResult.transcriptError;
+				requiredStatusStep(statusPayload, fi).agentContract = singleResult.agentContract;
+				requiredStatusStep(statusPayload, fi).launchContractDigest = singleResult.launchContractDigest;
+				requiredStatusStep(statusPayload, fi).launchResolvedExtensions = singleResult.launchResolvedExtensions;
+				requiredStatusStep(statusPayload, fi).runtimeAcknowledgedExtensions = singleResult.runtimeAcknowledgedExtensions;
+				requiredStatusStep(statusPayload, fi).effects = singleResult.effects;
+				requiredStatusStep(statusPayload, fi).execution = singleResult.execution;
+				requiredStatusStep(statusPayload, fi).review = singleResult.review;
+				requiredStatusStep(statusPayload, fi).structuredOutput = singleResult.structuredOutput;
+				requiredStatusStep(statusPayload, fi).structuredOutputPath = singleResult.structuredOutputPath;
+				requiredStatusStep(statusPayload, fi).structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
+				requiredStatusStep(statusPayload, fi).acceptance = singleResult.acceptance;
+				requiredStatusStep(statusPayload, fi).watchdog = singleResult.watchdog;
+				requiredStatusStep(statusPayload, fi).capabilityCeiling = singleResult.capabilityCeiling;
+				requiredStatusStep(statusPayload, fi).capabilityAudit = singleResult.capabilityAudit;
 				if (singleResult.capabilityCeiling) statusPayload.capabilityCeiling = singleResult.capabilityCeiling;
 				if (singleResult.capabilityAudit) statusPayload.capabilityAudit = singleResult.capabilityAudit;
 				statusPayload.lastUpdate = taskEndTime;
@@ -3673,13 +3683,13 @@ async function runSubagent(
 						if (statusPayload.usageBudget?.exhausted) {
 							const skippedAt = Date.now();
 							const message = usageBudgetExceededMessage(statusPayload.usageBudget);
-							statusPayload.steps[fi].status = "failed";
-							statusPayload.steps[fi].error = message;
-							statusPayload.steps[fi].startedAt = skippedAt;
-							statusPayload.steps[fi].endedAt = skippedAt;
-							statusPayload.steps[fi].durationMs = 0;
-							statusPayload.steps[fi].exitCode = 1;
-							statusPayload.steps[fi].activityState = undefined;
+							requiredStatusStep(statusPayload, fi).status = "failed";
+							requiredStatusStep(statusPayload, fi).error = message;
+							requiredStatusStep(statusPayload, fi).startedAt = skippedAt;
+							requiredStatusStep(statusPayload, fi).endedAt = skippedAt;
+							requiredStatusStep(statusPayload, fi).durationMs = 0;
+							requiredStatusStep(statusPayload, fi).exitCode = 1;
+							requiredStatusStep(statusPayload, fi).activityState = undefined;
 							statusPayload.lastUpdate = skippedAt;
 							usageBudgetExceeded = true;
 							writeStatusPayload();
@@ -3693,13 +3703,13 @@ async function runSubagent(
 						if (interrupted) return pausedStepResult(task.agent, task.context);
 						if (aborted && failFast) {
 							const skippedAt = Date.now();
-							statusPayload.steps[fi].status = "failed";
-							statusPayload.steps[fi].error = "Skipped due to fail-fast";
-							statusPayload.steps[fi].startedAt = skippedAt;
-							statusPayload.steps[fi].endedAt = skippedAt;
-							statusPayload.steps[fi].durationMs = 0;
-							statusPayload.steps[fi].exitCode = -1;
-							statusPayload.steps[fi].activityState = undefined;
+							requiredStatusStep(statusPayload, fi).status = "failed";
+							requiredStatusStep(statusPayload, fi).error = "Skipped due to fail-fast";
+							requiredStatusStep(statusPayload, fi).startedAt = skippedAt;
+							requiredStatusStep(statusPayload, fi).endedAt = skippedAt;
+							requiredStatusStep(statusPayload, fi).durationMs = 0;
+							requiredStatusStep(statusPayload, fi).exitCode = -1;
+							requiredStatusStep(statusPayload, fi).activityState = undefined;
 							statusPayload.lastUpdate = skippedAt;
 							writeStatusPayload();
 							appendJsonl(eventsPath, JSON.stringify({
@@ -3710,14 +3720,14 @@ async function runSubagent(
 
 						const taskStartTime = Date.now();
 						statusPayload.currentStep = fi;
-						statusPayload.steps[fi].status = "running";
-						statusPayload.steps[fi].error = undefined;
-						statusPayload.steps[fi].activityState = undefined;
-						resetStepLiveDetail(statusPayload.steps[fi]);
-						statusPayload.steps[fi].startedAt = taskStartTime;
-						statusPayload.steps[fi].endedAt = undefined;
-						statusPayload.steps[fi].durationMs = undefined;
-						statusPayload.steps[fi].lastActivityAt = taskStartTime;
+						requiredStatusStep(statusPayload, fi).status = "running";
+						requiredStatusStep(statusPayload, fi).error = undefined;
+						requiredStatusStep(statusPayload, fi).activityState = undefined;
+						resetStepLiveDetail(requiredStatusStep(statusPayload, fi));
+						requiredStatusStep(statusPayload, fi).startedAt = taskStartTime;
+						requiredStatusStep(statusPayload, fi).endedAt = undefined;
+						requiredStatusStep(statusPayload, fi).durationMs = undefined;
+						requiredStatusStep(statusPayload, fi).lastActivityAt = taskStartTime;
 						statusPayload.outputFile = path.join(asyncDir, `output-${fi}.log`);
 						statusPayload.lastActivityAt = taskStartTime;
 						statusPayload.lastUpdate = taskStartTime;
@@ -3773,27 +3783,27 @@ async function runSubagent(
 						const childInterrupted = singleResult.interrupted === true;
 						const childStopped = singleResult.stopped === true;
 
-						statusPayload.steps[fi].status = stopped || childStopped ? "stopped" : timedOut ? "failed" : childInterrupted ? "paused" : singleResult.exitCode === 0 ? "complete" : "failed";
-						statusPayload.steps[fi].endedAt = taskEndTime;
-						statusPayload.steps[fi].durationMs = taskDuration;
-						statusPayload.steps[fi].exitCode = stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode;
-						statusPayload.steps[fi].timedOut = timedOut || singleResult.timedOut ? true : undefined;
-						statusPayload.steps[fi].stopped = stopped || childStopped ? true : undefined;
-						statusPayload.steps[fi].turnBudget = singleResult.turnBudget;
-						statusPayload.steps[fi].turnBudgetExceeded = singleResult.turnBudgetExceeded;
-						statusPayload.steps[fi].wrapUpRequested = singleResult.wrapUpRequested;
-						statusPayload.steps[fi].toolBudget = singleResult.toolBudget;
-						statusPayload.steps[fi].toolBudgetBlocked = singleResult.toolBudgetBlocked;
+						requiredStatusStep(statusPayload, fi).status = stopped || childStopped ? "stopped" : timedOut ? "failed" : childInterrupted ? "paused" : singleResult.exitCode === 0 ? "complete" : "failed";
+						requiredStatusStep(statusPayload, fi).endedAt = taskEndTime;
+						requiredStatusStep(statusPayload, fi).durationMs = taskDuration;
+						requiredStatusStep(statusPayload, fi).exitCode = stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode;
+						requiredStatusStep(statusPayload, fi).timedOut = timedOut || singleResult.timedOut ? true : undefined;
+						requiredStatusStep(statusPayload, fi).stopped = stopped || childStopped ? true : undefined;
+						requiredStatusStep(statusPayload, fi).turnBudget = singleResult.turnBudget;
+						requiredStatusStep(statusPayload, fi).turnBudgetExceeded = singleResult.turnBudgetExceeded;
+						requiredStatusStep(statusPayload, fi).wrapUpRequested = singleResult.wrapUpRequested;
+						requiredStatusStep(statusPayload, fi).toolBudget = singleResult.toolBudget;
+						requiredStatusStep(statusPayload, fi).toolBudgetBlocked = singleResult.toolBudgetBlocked;
 						if (singleResult.toolBudget) statusPayload.toolBudget = singleResult.toolBudget;
 						if (singleResult.toolBudgetBlocked) statusPayload.toolBudgetBlocked = true;
 						if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 						if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 						if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
-						statusPayload.steps[fi].model = singleResult.model;
-						statusPayload.steps[fi].thinking = resolveEffectiveThinking(singleResult.model, statusPayload.steps[fi].thinking);
-						statusPayload.steps[fi].attemptedModels = singleResult.attemptedModels;
-						statusPayload.steps[fi].modelAttempts = singleResult.modelAttempts;
-						statusPayload.steps[fi].totalCost = singleResult.totalCost;
+						requiredStatusStep(statusPayload, fi).model = singleResult.model;
+						requiredStatusStep(statusPayload, fi).thinking = resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, fi).thinking);
+						requiredStatusStep(statusPayload, fi).attemptedModels = singleResult.attemptedModels;
+						requiredStatusStep(statusPayload, fi).modelAttempts = singleResult.modelAttempts;
+						requiredStatusStep(statusPayload, fi).totalCost = singleResult.totalCost;
 						if (singleResult.totalCost) {
 							pendingParallelUsageCost = {
 								inputTokens: pendingParallelUsageCost.inputTokens + singleResult.totalCost.inputTokens,
@@ -3802,22 +3812,22 @@ async function runSubagent(
 							};
 							refreshUsageBudget();
 						}
-						statusPayload.steps[fi].error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
-						statusPayload.steps[fi].transcriptPath = singleResult.transcriptPath ?? statusPayload.steps[fi].transcriptPath;
-						statusPayload.steps[fi].transcriptError = singleResult.transcriptError;
-						statusPayload.steps[fi].agentContract = singleResult.agentContract;
-						statusPayload.steps[fi].launchResolvedExtensions = singleResult.launchResolvedExtensions;
-						statusPayload.steps[fi].runtimeAcknowledgedExtensions = singleResult.runtimeAcknowledgedExtensions;
-						statusPayload.steps[fi].effects = singleResult.effects;
-						statusPayload.steps[fi].execution = singleResult.execution;
-						statusPayload.steps[fi].review = singleResult.review;
-						statusPayload.steps[fi].structuredOutput = singleResult.structuredOutput;
-						statusPayload.steps[fi].structuredOutputPath = singleResult.structuredOutputPath;
-						statusPayload.steps[fi].structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
-						statusPayload.steps[fi].acceptance = singleResult.acceptance;
-						statusPayload.steps[fi].watchdog = singleResult.watchdog;
-						statusPayload.steps[fi].capabilityCeiling = singleResult.capabilityCeiling;
-						statusPayload.steps[fi].capabilityAudit = singleResult.capabilityAudit;
+						requiredStatusStep(statusPayload, fi).error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
+						requiredStatusStep(statusPayload, fi).transcriptPath = singleResult.transcriptPath ?? requiredStatusStep(statusPayload, fi).transcriptPath;
+						requiredStatusStep(statusPayload, fi).transcriptError = singleResult.transcriptError;
+						requiredStatusStep(statusPayload, fi).agentContract = singleResult.agentContract;
+						requiredStatusStep(statusPayload, fi).launchResolvedExtensions = singleResult.launchResolvedExtensions;
+						requiredStatusStep(statusPayload, fi).runtimeAcknowledgedExtensions = singleResult.runtimeAcknowledgedExtensions;
+						requiredStatusStep(statusPayload, fi).effects = singleResult.effects;
+						requiredStatusStep(statusPayload, fi).execution = singleResult.execution;
+						requiredStatusStep(statusPayload, fi).review = singleResult.review;
+						requiredStatusStep(statusPayload, fi).structuredOutput = singleResult.structuredOutput;
+						requiredStatusStep(statusPayload, fi).structuredOutputPath = singleResult.structuredOutputPath;
+						requiredStatusStep(statusPayload, fi).structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
+						requiredStatusStep(statusPayload, fi).acceptance = singleResult.acceptance;
+						requiredStatusStep(statusPayload, fi).watchdog = singleResult.watchdog;
+						requiredStatusStep(statusPayload, fi).capabilityCeiling = singleResult.capabilityCeiling;
+						requiredStatusStep(statusPayload, fi).capabilityAudit = singleResult.capabilityAudit;
 						if (singleResult.capabilityCeiling) statusPayload.capabilityCeiling = singleResult.capabilityCeiling;
 						if (singleResult.capabilityAudit) statusPayload.capabilityAudit = singleResult.capabilityAudit;
 						statusPayload.lastUpdate = taskEndTime;
@@ -3831,7 +3841,7 @@ async function runSubagent(
 						}));
 						if (singleResult.completionGuardTriggered) {
 							const event = buildControlEvent({
-								from: statusPayload.steps[fi].activityState,
+								from: requiredStatusStep(statusPayload, fi).activityState,
 								to: "needs_attention",
 								runId: id,
 								agent: task.agent,
@@ -3858,7 +3868,7 @@ async function runSubagent(
 						: null;
 					const taskTokens = sessionTokens ?? tokenUsageFromAttempts(parallelResults[t]?.modelAttempts);
 					if (!taskTokens) continue;
-					statusPayload.steps[fi].tokens = taskTokens;
+					requiredStatusStep(statusPayload, fi).tokens = taskTokens;
 					previousCumulativeTokens = {
 						input: previousCumulativeTokens.input + taskTokens.input,
 						output: previousCumulativeTokens.output + taskTokens.output,
@@ -4001,13 +4011,13 @@ async function runSubagent(
 			const seqStep = step as SubagentStep;
 			const stepStartTime = Date.now();
 			statusPayload.currentStep = flatIndex;
-			statusPayload.steps[flatIndex].status = "running";
-			statusPayload.steps[flatIndex].activityState = undefined;
+			requiredStatusStep(statusPayload, flatIndex).status = "running";
+			requiredStatusStep(statusPayload, flatIndex).activityState = undefined;
 			statusPayload.activityState = undefined;
-			resetStepLiveDetail(statusPayload.steps[flatIndex]);
-			statusPayload.steps[flatIndex].skills = seqStep.skills;
-			statusPayload.steps[flatIndex].startedAt = stepStartTime;
-			statusPayload.steps[flatIndex].lastActivityAt = stepStartTime;
+			resetStepLiveDetail(requiredStatusStep(statusPayload, flatIndex));
+			requiredStatusStep(statusPayload, flatIndex).skills = seqStep.skills;
+			requiredStatusStep(statusPayload, flatIndex).startedAt = stepStartTime;
+			requiredStatusStep(statusPayload, flatIndex).lastActivityAt = stepStartTime;
 			statusPayload.lastActivityAt = stepStartTime;
 			statusPayload.lastUpdate = stepStartTime;
 			statusPayload.outputFile = path.join(asyncDir, `output-${flatIndex}.log`);
@@ -4134,47 +4144,47 @@ async function runSubagent(
 
 			const stepEndTime = Date.now();
 			const childInterrupted = singleResult.interrupted === true;
-			statusPayload.steps[flatIndex].status = stopped || childStopped ? "stopped" : timedOut ? "failed" : childInterrupted ? "paused" : singleResult.exitCode === 0 ? "complete" : "failed";
-			statusPayload.steps[flatIndex].endedAt = stepEndTime;
-			statusPayload.steps[flatIndex].durationMs = stepEndTime - stepStartTime;
-			statusPayload.steps[flatIndex].exitCode = stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode;
-			statusPayload.steps[flatIndex].timedOut = timedOut || singleResult.timedOut ? true : undefined;
-			statusPayload.steps[flatIndex].stopped = stopped || childStopped ? true : undefined;
-			statusPayload.steps[flatIndex].turnBudget = singleResult.turnBudget;
-			statusPayload.steps[flatIndex].turnBudgetExceeded = singleResult.turnBudgetExceeded;
-			statusPayload.steps[flatIndex].wrapUpRequested = singleResult.wrapUpRequested;
-			statusPayload.steps[flatIndex].toolBudget = singleResult.toolBudget;
-			statusPayload.steps[flatIndex].toolBudgetBlocked = singleResult.toolBudgetBlocked;
+			requiredStatusStep(statusPayload, flatIndex).status = stopped || childStopped ? "stopped" : timedOut ? "failed" : childInterrupted ? "paused" : singleResult.exitCode === 0 ? "complete" : "failed";
+			requiredStatusStep(statusPayload, flatIndex).endedAt = stepEndTime;
+			requiredStatusStep(statusPayload, flatIndex).durationMs = stepEndTime - stepStartTime;
+			requiredStatusStep(statusPayload, flatIndex).exitCode = stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode;
+			requiredStatusStep(statusPayload, flatIndex).timedOut = timedOut || singleResult.timedOut ? true : undefined;
+			requiredStatusStep(statusPayload, flatIndex).stopped = stopped || childStopped ? true : undefined;
+			requiredStatusStep(statusPayload, flatIndex).turnBudget = singleResult.turnBudget;
+			requiredStatusStep(statusPayload, flatIndex).turnBudgetExceeded = singleResult.turnBudgetExceeded;
+			requiredStatusStep(statusPayload, flatIndex).wrapUpRequested = singleResult.wrapUpRequested;
+			requiredStatusStep(statusPayload, flatIndex).toolBudget = singleResult.toolBudget;
+			requiredStatusStep(statusPayload, flatIndex).toolBudgetBlocked = singleResult.toolBudgetBlocked;
 			if (singleResult.toolBudget) statusPayload.toolBudget = singleResult.toolBudget;
 			if (singleResult.toolBudgetBlocked) statusPayload.toolBudgetBlocked = true;
 			if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 			if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 			if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
-			statusPayload.steps[flatIndex].model = singleResult.model;
-			statusPayload.steps[flatIndex].thinking = resolveEffectiveThinking(singleResult.model, statusPayload.steps[flatIndex].thinking);
-			statusPayload.steps[flatIndex].attemptedModels = singleResult.attemptedModels;
-			statusPayload.steps[flatIndex].modelAttempts = singleResult.modelAttempts;
-			statusPayload.steps[flatIndex].totalCost = singleResult.totalCost;
-			statusPayload.steps[flatIndex].error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
-			statusPayload.steps[flatIndex].transcriptPath = singleResult.transcriptPath ?? statusPayload.steps[flatIndex].transcriptPath;
-			statusPayload.steps[flatIndex].transcriptError = singleResult.transcriptError;
-			statusPayload.steps[flatIndex].agentContract = singleResult.agentContract;
-			statusPayload.steps[flatIndex].launchResolvedExtensions = singleResult.launchResolvedExtensions;
-			statusPayload.steps[flatIndex].runtimeAcknowledgedExtensions = singleResult.runtimeAcknowledgedExtensions;
-			statusPayload.steps[flatIndex].effects = singleResult.effects;
-			statusPayload.steps[flatIndex].execution = singleResult.execution;
-			statusPayload.steps[flatIndex].review = singleResult.review;
-			statusPayload.steps[flatIndex].structuredOutput = singleResult.structuredOutput;
-			statusPayload.steps[flatIndex].structuredOutputPath = singleResult.structuredOutputPath;
-			statusPayload.steps[flatIndex].structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
-			statusPayload.steps[flatIndex].acceptance = singleResult.acceptance;
-			statusPayload.steps[flatIndex].watchdog = singleResult.watchdog;
-			statusPayload.steps[flatIndex].capabilityCeiling = singleResult.capabilityCeiling;
-			statusPayload.steps[flatIndex].capabilityAudit = singleResult.capabilityAudit;
+			requiredStatusStep(statusPayload, flatIndex).model = singleResult.model;
+			requiredStatusStep(statusPayload, flatIndex).thinking = resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, flatIndex).thinking);
+			requiredStatusStep(statusPayload, flatIndex).attemptedModels = singleResult.attemptedModels;
+			requiredStatusStep(statusPayload, flatIndex).modelAttempts = singleResult.modelAttempts;
+			requiredStatusStep(statusPayload, flatIndex).totalCost = singleResult.totalCost;
+			requiredStatusStep(statusPayload, flatIndex).error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
+			requiredStatusStep(statusPayload, flatIndex).transcriptPath = singleResult.transcriptPath ?? requiredStatusStep(statusPayload, flatIndex).transcriptPath;
+			requiredStatusStep(statusPayload, flatIndex).transcriptError = singleResult.transcriptError;
+			requiredStatusStep(statusPayload, flatIndex).agentContract = singleResult.agentContract;
+			requiredStatusStep(statusPayload, flatIndex).launchResolvedExtensions = singleResult.launchResolvedExtensions;
+			requiredStatusStep(statusPayload, flatIndex).runtimeAcknowledgedExtensions = singleResult.runtimeAcknowledgedExtensions;
+			requiredStatusStep(statusPayload, flatIndex).effects = singleResult.effects;
+			requiredStatusStep(statusPayload, flatIndex).execution = singleResult.execution;
+			requiredStatusStep(statusPayload, flatIndex).review = singleResult.review;
+			requiredStatusStep(statusPayload, flatIndex).structuredOutput = singleResult.structuredOutput;
+			requiredStatusStep(statusPayload, flatIndex).structuredOutputPath = singleResult.structuredOutputPath;
+			requiredStatusStep(statusPayload, flatIndex).structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
+			requiredStatusStep(statusPayload, flatIndex).acceptance = singleResult.acceptance;
+			requiredStatusStep(statusPayload, flatIndex).watchdog = singleResult.watchdog;
+			requiredStatusStep(statusPayload, flatIndex).capabilityCeiling = singleResult.capabilityCeiling;
+			requiredStatusStep(statusPayload, flatIndex).capabilityAudit = singleResult.capabilityAudit;
 			if (singleResult.capabilityCeiling) statusPayload.capabilityCeiling = singleResult.capabilityCeiling;
 			if (singleResult.capabilityAudit) statusPayload.capabilityAudit = singleResult.capabilityAudit;
 			if (stepTokens) {
-				statusPayload.steps[flatIndex].tokens = stepTokens;
+				requiredStatusStep(statusPayload, flatIndex).tokens = stepTokens;
 				statusPayload.totalTokens = { ...previousCumulativeTokens };
 			}
 			statusPayload.lastUpdate = stepEndTime;
@@ -4193,7 +4203,7 @@ async function runSubagent(
 			}));
 			if (singleResult.completionGuardTriggered) {
 				const event = buildControlEvent({
-					from: statusPayload.steps[flatIndex].activityState,
+					from: requiredStatusStep(statusPayload, flatIndex).activityState,
 					to: "needs_attention",
 					runId: id,
 					agent: seqStep.agent,

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -288,7 +288,8 @@ function summarizeTerminalRuns(runs: AsyncRunSummary[], providerFinishedCount = 
 	if (runs.length === 0 && providerFinishedCount === 0) return "";
 	const counts = { complete: 0, failed: 0, paused: 0 } as Record<string, number>;
 	for (const run of runs) {
-		if (run.state in counts) counts[run.state] += 1;
+		const count = counts[run.state];
+		if (count !== undefined) counts[run.state] = count + 1;
 	}
 	const parts: string[] = [];
 	if (counts.complete) parts.push(`${counts.complete} complete`);

--- a/src/runs/foreground/chain-clarify.ts
+++ b/src/runs/foreground/chain-clarify.ts
@@ -779,8 +779,10 @@ export class ChainClarifyComponent implements Component {
 			const { lines: wrapped, starts } = wrapText(this.editState.buffer, textWidth);
 			const cursorPos = getCursorDisplayPos(this.editState.cursor, starts);
 			const targetLine = Math.max(0, cursorPos.line - this.EDIT_VIEWPORT_HEIGHT);
+			const targetStart = starts[targetLine];
+			if (targetStart === undefined) return;
 			const targetCol = Math.min(cursorPos.col, wrapped[targetLine]?.length ?? 0);
-			this.editState = { ...this.editState, cursor: starts[targetLine] + targetCol };
+			this.editState = { ...this.editState, cursor: targetStart + targetCol };
 			this.tui.requestRender();
 			return;
 		}
@@ -789,8 +791,10 @@ export class ChainClarifyComponent implements Component {
 			const { lines: wrapped, starts } = wrapText(this.editState.buffer, textWidth);
 			const cursorPos = getCursorDisplayPos(this.editState.cursor, starts);
 			const targetLine = Math.min(wrapped.length - 1, cursorPos.line + this.EDIT_VIEWPORT_HEIGHT);
+			const targetStart = starts[targetLine];
+			if (targetStart === undefined) return;
 			const targetCol = Math.min(cursorPos.col, wrapped[targetLine]?.length ?? 0);
-			this.editState = { ...this.editState, cursor: starts[targetLine] + targetCol };
+			this.editState = { ...this.editState, cursor: targetStart + targetCol };
 			this.tui.requestRender();
 			return;
 		}

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -1044,7 +1044,9 @@ ${step.message}` : ""}` }],
 						cwd: cwd ?? ctx.cwd,
 						reportOptional: isAgentContractV1(step.agentContract ?? params.agentContract),
 					});
-					dynamicGroupStatuses[stepIndex].acceptance = groupAcceptance;
+					const dynamicGroupStatus = dynamicGroupStatuses[stepIndex];
+					if (!dynamicGroupStatus) throw new Error(`Missing dynamic group status at step ${stepIndex}`);
+					dynamicGroupStatus.acceptance = groupAcceptance;
 					const groupAcceptanceFailure = !isAgentContractV1(step.agentContract ?? params.agentContract) || step.gateOn === "acceptance" ? acceptanceFailureMessage(groupAcceptance) : undefined;
 					if (groupAcceptanceFailure) {
 						dynamicGroupStatuses[stepIndex] = { status: "failed", error: groupAcceptanceFailure, acceptance: groupAcceptance };
@@ -1238,7 +1240,9 @@ ${step.message}` : ""}` }],
 				cwd: cwd ?? ctx.cwd,
 				reportOptional: isAgentContractV1(step.agentContract ?? params.agentContract),
 			});
-			dynamicGroupStatuses[stepIndex].acceptance = groupAcceptance;
+			const dynamicGroupStatus = dynamicGroupStatuses[stepIndex];
+			if (!dynamicGroupStatus) throw new Error(`Missing dynamic group status at step ${stepIndex}`);
+			dynamicGroupStatus.acceptance = groupAcceptance;
 			const groupAcceptanceFailure = effectiveGroupAcceptance.explicit && (!isAgentContractV1(step.agentContract ?? params.agentContract) || step.gateOn === "acceptance") ? acceptanceFailureMessage(groupAcceptance) : undefined;
 			if (groupAcceptanceFailure) {
 				dynamicGroupStatuses[stepIndex] = { status: "failed", error: groupAcceptanceFailure, acceptance: groupAcceptance };

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -185,8 +185,8 @@ export async function mapConcurrent<T, R>(
 		try {
 			while (next < items.length) {
 				const i = next++;
-				const item = items[i];
-				if (item === undefined) throw new Error(`Missing parallel item at index ${i}`);
+				if (!(i in items)) throw new Error(`Missing parallel item at index ${i}`);
+				const item = items[i] as T;
 				if (globalSemaphore) {
 					await globalSemaphore.acquire();
 					try {

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -185,15 +185,17 @@ export async function mapConcurrent<T, R>(
 		try {
 			while (next < items.length) {
 				const i = next++;
+				const item = items[i];
+				if (item === undefined) throw new Error(`Missing parallel item at index ${i}`);
 				if (globalSemaphore) {
 					await globalSemaphore.acquire();
 					try {
-						results[i] = await fn(items[i], i);
+						results[i] = await fn(item, i);
 					} finally {
 						globalSemaphore.release();
 					}
 				} else {
-					results[i] = await fn(items[i], i);
+					results[i] = await fn(item, i);
 				}
 			}
 		} finally {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -256,7 +256,8 @@ export function findLatestSessionFile(sessionDir: string): string | null {
 			};
 		})
 		.sort((a, b) => b.mtime - a.mtime);
-	return files.length > 0 ? files[0].path : null;
+	const latest = files[0];
+	return latest ? latest.path : null;
 }
 
 /**
@@ -280,7 +281,7 @@ export function getFinalOutput(messages: Message[]): string {
 	const validTextParts: string[] = [];
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const msg = messages[i];
-		if (msg.role !== "assistant") continue;
+		if (!msg || msg.role !== "assistant") continue;
 		const hasAssistantError = ("errorMessage" in msg && typeof msg.errorMessage === "string" && msg.errorMessage.length > 0)
 			|| ("stopReason" in msg && msg.stopReason === "error");
 		if (hasAssistantError) continue;
@@ -290,7 +291,7 @@ export function getFinalOutput(messages: Message[]): string {
 			.join("\n");
 		for (let j = msg.content.length - 1; j >= 0; j--) {
 			const part = msg.content[j];
-			if (part.type !== "text" || part.text.trim().length === 0) continue;
+			if (!part || part.type !== "text" || part.text.trim().length === 0) continue;
 			validTextParts.push(part.text);
 			if (/```acceptance[-_]report\s*\n[\s\S]*?```/i.test(part.text)) return messageText;
 			for (const match of part.text.matchAll(/```(?:json|jsonc|json5)\s*\n([\s\S]*?)```/gi)) {
@@ -481,7 +482,7 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 	let lastAssistantTextIndex = -1;
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const msg = messages[i];
-		if (msg.role === "assistant") {
+		if (msg?.role === "assistant") {
 			const hasText = Array.isArray(msg.content) && msg.content.some(
 				(c) => c.type === "text" && "text" in c && typeof c.text === "string" && c.text.trim().length > 0,
 			);
@@ -496,7 +497,7 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 
 	for (let i = messages.length - 1; i >= scanStart; i--) {
 		const msg = messages[i];
-		if (msg.role !== "toolResult") continue;
+		if (!msg || msg.role !== "toolResult") continue;
 		const toolName = "toolName" in msg && typeof msg.toolName === "string" ? msg.toolName : undefined;
 		const isError = "isError" in msg && msg.isError === true;
 
@@ -505,9 +506,10 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 		const text = msg.content.find((c) => c.type === "text");
 		const details = text && "text" in text ? text.text : undefined;
 		const exitMatch = details?.match(/exit(?:ed)?\s*(?:with\s*)?(?:code|status)?\s*[:\s]?\s*(\d+)/i);
+		const exitCodeText = exitMatch?.[1];
 		return {
 			hasError: true,
-			exitCode: exitMatch ? parseInt(exitMatch[1], 10) : 1,
+			exitCode: exitCodeText ? parseInt(exitCodeText, 10) : 1,
 			errorType: toolName || "tool",
 			details: details?.slice(0, 200),
 		};

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1491,6 +1491,7 @@ export function renderSubagentResult(
 
 	if (d.mode === "single" && d.results.length === 1) {
 		const r = d.results[0];
+		if (!r) return renderMultiCompact(d, theme, frame);
 		if (!expanded) return renderSingleCompact(d, r, theme, frame);
 		const isRunning = r.progress?.status === "running";
 		const icon = isRunning
@@ -1657,9 +1658,9 @@ export function renderSubagentResult(
 					const result = d.results[i];
 					const isFailed = result && result.exitCode !== 0 && result.progress?.status !== "running";
 					const isComplete = result && result.exitCode === 0 && result.progress?.status !== "running";
-					const isEmptyWithoutTarget = Boolean(result)
-						&& Boolean(isComplete)
-						&& hasEmptyTextOutputWithoutOutputTarget(result.task, getSingleResultOutput(result));
+					const isEmptyWithoutTarget = result
+						? Boolean(isComplete) && hasEmptyTextOutputWithoutOutputTarget(result.task, getSingleResultOutput(result))
+						: false;
 					const isCurrent = i === (d.currentStepIndex ?? d.results.length);
 					const stepIcon = isFailed
 						? theme.fg("error", "failed")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["index.ts", "src/**/*.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary

This is the first implementation slice for #748. It enables `noUncheckedIndexedAccess` and narrows indexed reads at the relevant runtime invariant boundaries.

It intentionally does not enable `exactOptionalPropertyTypes`; that remains the larger follow-up slice for #748.

## Validation

- `npm run typecheck`
- `npx tsc --noEmit --exactOptionalPropertyTypes false --noUncheckedIndexedAccess true`
- `node --experimental-strip-types --test test/unit/render-helpers.test.ts test/unit/frontmatter.test.ts test/unit/chain-serializer.test.ts test/unit/parallel-utils.test.ts test/integration/async-execution.test.ts`
- `git diff --check`

## Credit

Thanks to @nicobailon for #748.