### PR TITLE
refactor: omit undefined management config fields

### DIFF
--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -215,34 +215,54 @@ function skillsWarning(cwd: string, agent: Pick<AgentConfig, "skills" | "skillPa
 }
 
 export function editableAgentConfig(agent: AgentConfig): AgentConfig {
+	const { extensions: _extensions, ...withoutExtensions } = agent;
 	const base = agent.override?.base;
+	const {
+		override: _override,
+		model: _model,
+		fallbackModels: _fallbackModels,
+		thinking: _thinking,
+		systemPromptMode: _systemPromptMode,
+		inheritProjectContext: _inheritProjectContext,
+		inheritSkills: _inheritSkills,
+		defaultContext: _defaultContext,
+		acceptanceRole: _acceptanceRole,
+		disabled: _disabled,
+		systemPrompt: _systemPrompt,
+		skills: _skills,
+		skillPath: _skillPath,
+		tools: _tools,
+		mcpDirectTools: _mcpDirectTools,
+		subagentOnlyExtensions: _subagentOnlyExtensions,
+		completionGuard: _completionGuard,
+		...editable
+	} = withoutExtensions;
 	if (!base) {
 		return {
-			...agent,
-			extensions: agent.extensionsFromDefault ? undefined : agent.extensions ? [...agent.extensions] : undefined,
+			...withoutExtensions,
+			...(agent.extensionsFromDefault ? {} : agent.extensions !== undefined ? { extensions: [...agent.extensions] } : {}),
 		};
 	}
 
 	return {
-		...agent,
-		model: base.model,
-		fallbackModels: base.fallbackModels ? [...base.fallbackModels] : undefined,
-		thinking: base.thinking,
+		...editable,
+		...(base.model !== undefined ? { model: base.model } : {}),
+		...(base.fallbackModels !== undefined ? { fallbackModels: [...base.fallbackModels] } : {}),
+		...(base.thinking !== undefined ? { thinking: base.thinking } : {}),
 		systemPromptMode: base.systemPromptMode,
 		inheritProjectContext: base.inheritProjectContext,
 		inheritSkills: base.inheritSkills,
-		defaultContext: base.defaultContext,
-		acceptanceRole: base.acceptanceRole,
-		disabled: base.disabled,
+		...(base.defaultContext !== undefined ? { defaultContext: base.defaultContext } : {}),
+		...(base.acceptanceRole !== undefined ? { acceptanceRole: base.acceptanceRole } : {}),
+		...(base.disabled !== undefined ? { disabled: base.disabled } : {}),
 		systemPrompt: base.systemPrompt,
-		skills: base.skills ? [...base.skills] : undefined,
-		skillPath: base.skillPath ? [...base.skillPath] : undefined,
-		tools: base.tools ? [...base.tools] : undefined,
-		mcpDirectTools: base.mcpDirectTools ? [...base.mcpDirectTools] : undefined,
-		extensions: base.extensions ? [...base.extensions] : undefined,
-		subagentOnlyExtensions: base.subagentOnlyExtensions ? [...base.subagentOnlyExtensions] : undefined,
-		completionGuard: base.completionGuard,
-		override: undefined,
+		...(base.skills !== undefined ? { skills: [...base.skills] } : {}),
+		...(base.skillPath !== undefined ? { skillPath: [...base.skillPath] } : {}),
+		...(base.tools !== undefined ? { tools: [...base.tools] } : {}),
+		...(base.mcpDirectTools !== undefined ? { mcpDirectTools: [...base.mcpDirectTools] } : {}),
+		...(base.extensions !== undefined ? { extensions: [...base.extensions] } : {}),
+		...(base.subagentOnlyExtensions !== undefined ? { subagentOnlyExtensions: [...base.subagentOnlyExtensions] } : {}),
+		...(base.completionGuard !== undefined ? { completionGuard: base.completionGuard } : {}),
 	};
 }
 
@@ -381,7 +401,10 @@ function parseTools(raw: string): { tools?: string[]; mcpDirectTools?: string[] 
 			if (direct) mcpDirectTools.push(direct);
 		} else tools.push(item);
 	}
-	return { tools: tools.length ? tools : undefined, mcpDirectTools: mcpDirectTools.length ? mcpDirectTools : undefined };
+	return {
+		...(tools.length ? { tools } : {}),
+		...(mcpDirectTools.length ? { mcpDirectTools } : {}),
+	};
 }
 
 function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): string | undefined {

--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -84,22 +84,22 @@ function liveAvailableModels(ctx: ExtensionContext) {
 
 function buildBuiltinBase(agent: AgentConfig): BuiltinAgentOverrideBase {
 	return {
-		model: agent.model,
-		fallbackModels: agent.fallbackModels ? [...agent.fallbackModels] : undefined,
-		thinking: agent.thinking,
+		...(agent.model !== undefined ? { model: agent.model } : {}),
+		...(agent.fallbackModels !== undefined ? { fallbackModels: [...agent.fallbackModels] } : {}),
+		...(agent.thinking !== undefined ? { thinking: agent.thinking } : {}),
 		systemPromptMode: agent.systemPromptMode,
 		inheritProjectContext: agent.inheritProjectContext,
 		inheritSkills: agent.inheritSkills,
-		defaultContext: agent.defaultContext,
-		acceptanceRole: agent.acceptanceRole,
-		disabled: agent.disabled,
+		...(agent.defaultContext !== undefined ? { defaultContext: agent.defaultContext } : {}),
+		...(agent.acceptanceRole !== undefined ? { acceptanceRole: agent.acceptanceRole } : {}),
+		...(agent.disabled !== undefined ? { disabled: agent.disabled } : {}),
 		systemPrompt: agent.systemPrompt,
-		skills: agent.skills ? [...agent.skills] : undefined,
-		tools: agent.tools ? [...agent.tools] : undefined,
-		mcpDirectTools: agent.mcpDirectTools ? [...agent.mcpDirectTools] : undefined,
-		subagentOnlyExtensions: agent.subagentOnlyExtensions ? [...agent.subagentOnlyExtensions] : undefined,
-		completionGuard: agent.completionGuard,
-		toolBudget: agent.toolBudget,
+		...(agent.skills !== undefined ? { skills: [...agent.skills] } : {}),
+		...(agent.tools !== undefined ? { tools: [...agent.tools] } : {}),
+		...(agent.mcpDirectTools !== undefined ? { mcpDirectTools: [...agent.mcpDirectTools] } : {}),
+		...(agent.subagentOnlyExtensions !== undefined ? { subagentOnlyExtensions: [...agent.subagentOnlyExtensions] } : {}),
+		...(agent.completionGuard !== undefined ? { completionGuard: agent.completionGuard } : {}),
+		...(agent.toolBudget !== undefined ? { toolBudget: agent.toolBudget } : {}),
 	};
 }
 
@@ -290,7 +290,9 @@ async function saveAgentModel(ctx: ExtensionContext, agent: AgentConfig, selecte
 
 	const readOnlyMessage = readOnlyAgentMessage(agent, "model");
 	if (readOnlyMessage) return readOnlyMessage;
-	const updated: AgentConfig = { ...editableAgentConfig(agent), model: selectedModel };
+	const updated = editableAgentConfig(agent);
+	if (selectedModel === undefined) delete updated.model;
+	else updated.model = selectedModel;
 	fs.writeFileSync(updated.filePath, serializeAgent(updated, {
 		preserveFrontmatterFields: preservedAgentFrontmatterFields(agent, { model: selectedModel }),
 	}), "utf-8");
@@ -311,7 +313,9 @@ async function saveAgentThinking(ctx: ExtensionContext, agent: AgentConfig, sele
 
 	const readOnlyMessage = readOnlyAgentMessage(agent, "thinking");
 	if (readOnlyMessage) return readOnlyMessage;
-	const updated: AgentConfig = { ...editableAgentConfig(agent), thinking: selectedThinking };
+	const updated = editableAgentConfig(agent);
+	if (selectedThinking === undefined) delete updated.thinking;
+	else updated.thinking = selectedThinking;
 	fs.writeFileSync(updated.filePath, serializeAgent(updated, {
 		preserveFrontmatterFields: preservedAgentFrontmatterFields(agent, { thinking: selectedThinking }),
 	}), "utf-8");


### PR DESCRIPTION
## Summary
- omit absent optional fields when constructing editable agent configs and builtin override bases
- preserve explicit values like false, empty arrays, and empty strings while clearing model/thinking by omission
- keep exactOptionalPropertyTypes disabled globally; this is one partial #748 slice

Refs #748. This PR intentionally does not close the issue.

## Validation
- npm run typecheck
- npx tsc --noEmit --exactOptionalPropertyTypes true (expected residual diagnostics outside this slice)
- node --experimental-strip-types --test test/unit/agent-management.test.ts
- git diff --check