### PR TITLE
fix: omit absent agent discovery fields

### DIFF
--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1006,7 +1006,7 @@ function applyBuiltinOverride(
 	if (override.skills !== undefined) { if (override.skills === false) delete next.skills; else next.skills = [...override.skills]; }
 	if (override.tools !== undefined) {
 		const { tools, mcpDirectTools } = splitToolList(override.tools === false ? [] : override.tools);
-		next.tools = tools;
+		if (tools === undefined) delete next.tools; else next.tools = tools;
 		if (mcpDirectTools === undefined) delete next.mcpDirectTools; else next.mcpDirectTools = mcpDirectTools;
 	}
 	if (override.extensions !== undefined) { if (override.extensions === false) delete next.extensions; else next.extensions = [...override.extensions]; }
@@ -1149,7 +1149,7 @@ function applyCustomAgentOverride(
 	if (override.tools !== undefined && !agentHasFrontmatterField(agent, "tools")) {
 		const { tools, mcpDirectTools } = splitToolList(override.tools === false ? [] : override.tools);
 		const target = mutable();
-		target.tools = tools;
+		if (tools === undefined) delete target.tools; else target.tools = tools;
 		if (mcpDirectTools === undefined) delete target.mcpDirectTools; else target.mcpDirectTools = mcpDirectTools;
 		anyFilled = true;
 	}

--- a/src/agents/chain-serializer.ts
+++ b/src/agents/chain-serializer.ts
@@ -93,7 +93,8 @@ function parseStepBody(agent: string, sectionBody: string): ChainStepConfig {
 			}
 			const validation = validateToolBudgetConfig(parsed, `toolBudget for step '${agent}'`);
 			if (validation.error) throw new Error(validation.error);
-			step.toolBudget = parsed as ChainStepConfig["toolBudget"];
+			const toolBudget = parsed as ChainStepConfig["toolBudget"];
+			if (toolBudget !== undefined) step.toolBudget = toolBudget;
 		}
 	}
 
@@ -132,12 +133,12 @@ export function parseChain(content: string, source: AgentSource, filePath: strin
 	return {
 		name: buildRuntimeName(localName, packageName),
 		localName,
-		packageName,
+		...(packageName !== undefined ? { packageName } : {}),
 		description: frontmatter.description,
 		source,
 		filePath,
 		steps,
-		extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
+		...(Object.keys(extraFields).length > 0 ? { extraFields } : {}),
 	};
 }
 
@@ -215,12 +216,12 @@ export function parseJsonChain(content: string, source: AgentSource, filePath: s
 	return {
 		name: buildRuntimeName(input.name.trim(), parsedPackage.packageName),
 		localName: input.name.trim(),
-		packageName: parsedPackage.packageName,
+		...(parsedPackage.packageName !== undefined ? { packageName: parsedPackage.packageName } : {}),
 		description: input.description.trim(),
 		source,
 		filePath,
 		steps: input.chain as ChainStepConfig[],
-		extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
+		...(Object.keys(extraFields).length > 0 ? { extraFields } : {}),
 	};
 }
 

--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -9,7 +9,7 @@ function normalizePackageName(value: string | undefined): string | undefined {
 }
 
 export function parsePackageName(value: unknown, label = "package"): { packageName?: string; error?: string } {
-	if (value === undefined || value === false || value === "") return { packageName: undefined };
+	if (value === undefined || value === false || value === "") return {};
 	if (typeof value !== "string") return { error: `${label} must be a string or false when provided.` };
 	const packageName = normalizePackageName(value);
 	if (!packageName || !IDENTIFIER_PATTERN.test(packageName)) return { error: `${label} is invalid after sanitization.` };

--- a/src/agents/proactive-skills.ts
+++ b/src/agents/proactive-skills.ts
@@ -141,14 +141,17 @@ export function recommendProactiveSkillSubagents(input: {
 
 	return [...counts.entries()]
 		.filter(([skill, sources]) => sources.size >= config.minReferences && (!availableByName || availableByName.has(skill)))
-		.map(([skill, sources]) => ({
-			skill,
-			agent,
-			references: sources.size,
-			sources: [...sources].sort((a, b) => a.localeCompare(b)),
-			description: availableByName?.get(skill)?.description,
-			reason: `referenced by ${sources.size} configured agents/chains`,
-		}))
+		.map(([skill, sources]) => {
+			const description = availableByName?.get(skill)?.description;
+			return {
+				skill,
+				agent,
+				references: sources.size,
+				sources: [...sources].sort((a, b) => a.localeCompare(b)),
+				...(description !== undefined ? { description } : {}),
+				reason: `referenced by ${sources.size} configured agents/chains`,
+			};
+		})
 		.sort((a, b) => b.references - a.references || a.skill.localeCompare(b.skill))
 		.slice(0, config.maxRecommendations);
 }
@@ -184,8 +187,8 @@ export function buildProactiveSkillSubagentRecommendationLines(input: {
 	}
 	return formatProactiveSkillSubagentRecommendations(recommendProactiveSkillSubagents({
 		agents: input.agents,
-		chains: input.chains,
+		...(input.chains !== undefined ? { chains: input.chains } : {}),
 		availableSkills,
-		config: input.config,
+		...(input.config !== undefined ? { config: input.config } : {}),
 	}));
 }

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -410,15 +410,17 @@ function collectFilesystemSkills(cwd: string, agentDir: string, skillPaths: Skil
 		const resolvedFile = path.resolve(filePath);
 		if (!fs.existsSync(resolvedFile)) return;
 		const source = inferSkillSource(resolvedFile, cwd, agentDir, sourceHint);
+		const description = maybeReadSkillDescription(resolvedFile);
 		const existingIndex = seen.get(resolvedFile);
 		if (existingIndex !== undefined) {
 			const existing = entries[existingIndex];
 			if (existing && (SOURCE_PRIORITY[source] ?? 0) > (SOURCE_PRIORITY[existing.source] ?? 0)) {
+				const { description: _description, ...existingWithoutDescription } = existing;
 				entries[existingIndex] = {
-					...existing,
+					...existingWithoutDescription,
 					name,
 					source,
-					description: maybeReadSkillDescription(resolvedFile),
+					...(description !== undefined ? { description } : {}),
 				};
 			}
 			return;
@@ -428,7 +430,7 @@ function collectFilesystemSkills(cwd: string, agentDir: string, skillPaths: Skil
 			name,
 			filePath: resolvedFile,
 			source,
-			description: maybeReadSkillDescription(resolvedFile),
+			...(description !== undefined ? { description } : {}),
 			order: order++,
 		});
 	};
@@ -592,7 +594,7 @@ function readSkill(
 			name: skillName,
 			path: skillPath,
 			content,
-			description,
+			...(description !== undefined ? { description } : {}),
 			source,
 		};
 
@@ -733,7 +735,7 @@ export function discoverAvailableSkills(cwd: string): Array<{
 		.map((s) => ({
 			name: s.name,
 			source: s.source,
-			description: s.description,
+			...(s.description !== undefined ? { description: s.description } : {}),
 		}))
 		.sort((a, b) => a.name.localeCompare(b.name));
 }


### PR DESCRIPTION
## Summary
- omit absent optional fields in agent discovery and chain serialization paths
- preserve package names, frontmatter output, skill defaults, and override tool splitting behavior
- keep exactOptionalPropertyTypes disabled globally; this is one partial #748 slice

Refs #748. This PR intentionally does not close the issue.

## Validation
- npm run typecheck
- node --experimental-strip-types --test test/unit/agent-management.test.ts test/unit/agent-frontmatter.test.ts test/unit/proactive-skills.test.ts test/unit/skills-fallback.test.ts
- npx tsc --noEmit --exactOptionalPropertyTypes true (expected residual diagnostics outside this slice; no diagnostics in changed files)
- git diff --check