### PR TITLE
fix: omit absent background runner fields

### DIFF
--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -383,23 +383,29 @@ function isTerminalAssistantStop(message: Message): boolean {
 	return (message as { stopReason?: string }).stopReason === "stop" && !assistantStartsToolCall(message);
 }
 
-type WithoutUndefined<T extends object> = {
+type UndefinedOmitted<T extends object> = {
 	[K in keyof T]: Exclude<T[K], undefined>;
 };
 
-function withoutUndefined<const T extends object>(value: T): WithoutUndefined<T> {
+function omitUndefinedProperties<const T extends object>(value: T): UndefinedOmitted<T> {
 	for (const key in value) {
 		if (value[key] === undefined) delete value[key];
 	}
-	return value as WithoutUndefined<T>;
+	return value as UndefinedOmitted<T>;
 }
 
 type WithUndefinedOptionals<T extends object> = {
 	[K in keyof T]: {} extends Pick<T, K> ? T[K] | undefined : T[K];
 };
 
-function compactOptional<T extends object>(value: WithUndefinedOptionals<T>): T {
-	for (const key in value) {
+type RequiredKeysAllowingUndefined<T extends object> = {
+	[K in keyof T]-?: {} extends Pick<T, K> ? never : undefined extends T[K] ? K : never;
+}[keyof T];
+
+function compactOptional<T extends object>(
+	value: WithUndefinedOptionals<T> & (RequiredKeysAllowingUndefined<T> extends never ? unknown : never),
+): T {
+	for (const key of Object.keys(value) as Array<keyof T>) {
 		if (value[key] === undefined) delete value[key];
 	}
 	return value as T;
@@ -407,7 +413,7 @@ function compactOptional<T extends object>(value: WithUndefinedOptionals<T>): T 
 
 function setOptionalProperty<T extends object, K extends keyof T>(target: T, key: K, value: T[K]): void {
 	if (value === undefined) delete target[key];
-	else Reflect.set(target, key, value);
+	else target[key] = value;
 }
 
 function resetStepLiveDetail(step: RunnerStatusStep): void {
@@ -872,7 +878,7 @@ function runPiStreaming(
 				turnBudgetExceeded,
 				forcedDrainAfterFinalSuccess,
 			}) ? formatProcessSignalError(signal!) : undefined;
-			resolve(withoutUndefined({
+			resolve(omitUndefinedProperties({
 				stderr,
 				exitCode: timedOut || stopped ? 1 : turnBudgetExceeded ? 1 : interrupted || forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (exitCode ?? 1) : exitCode,
 				messages,
@@ -917,7 +923,7 @@ function runPiStreaming(
 			const stderr = stderrTail.text();
 			const finalOutput = getFinalOutput(messages) || rawStdoutTail.text().trim();
 			const spawnErrorMessage = spawnError instanceof Error ? spawnError.message : String(spawnError);
-			resolve(withoutUndefined({ stderr, exitCode: 1, messages, usage, toolCount, durationMs: Date.now() - startedAt, model, error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? turnBudgetMessage : error ?? assistantError ?? spawnErrorMessage, protocolError, finalOutput: (timedOut || stopped) && !finalOutput.trim() ? (stopped ? stopMessage ?? "Subagent stopped by user." : timeoutMessage ?? "Subagent timed out.") : finalOutput, outputState: finalOutput.trim() ? "present" : "absent", timedOut, stopped, turnBudget, turnBudgetExceeded, wrapUpRequested: turnBudget?.outcome === "wrap-up-requested" || turnBudget?.outcome === "termination-deferred" || turnBudgetExceeded || undefined, observedMutationAttempt, watchdog: childWatchdogState, processInstanceId }));
+			resolve(omitUndefinedProperties({ stderr, exitCode: 1, messages, usage, toolCount, durationMs: Date.now() - startedAt, model, error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? turnBudgetMessage : error ?? assistantError ?? spawnErrorMessage, protocolError, finalOutput: (timedOut || stopped) && !finalOutput.trim() ? (stopped ? stopMessage ?? "Subagent stopped by user." : timeoutMessage ?? "Subagent timed out.") : finalOutput, outputState: finalOutput.trim() ? "present" : "absent", timedOut, stopped, turnBudget, turnBudgetExceeded, wrapUpRequested: turnBudget?.outcome === "wrap-up-requested" || turnBudget?.outcome === "termination-deferred" || turnBudgetExceeded || undefined, observedMutationAttempt, watchdog: childWatchdogState, processInstanceId }));
 		});
 	});
 }
@@ -1085,7 +1091,7 @@ async function runSingleStep(
 				pid = undefined;
 			}
 			try {
-				deliverTimeoutRequest(withoutUndefined({ asyncDir: step.importAsyncRoot!.asyncDir, pid, source: "ancestor-timeout" }));
+				deliverTimeoutRequest(omitUndefinedProperties({ asyncDir: step.importAsyncRoot!.asyncDir, pid, source: "ancestor-timeout" }));
 			} catch {
 				// The parent runner's own timeout result is authoritative for the attached step.
 			}
@@ -1099,13 +1105,13 @@ async function runSingleStep(
 				pid = undefined;
 			}
 			try {
-				deliverStopRequest(withoutUndefined({ asyncDir: step.importAsyncRoot!.asyncDir, pid, source: "ancestor-stop" }));
+				deliverStopRequest(omitUndefinedProperties({ asyncDir: step.importAsyncRoot!.asyncDir, pid, source: "ancestor-stop" }));
 			} catch {
 				// The parent runner's own stopped result is authoritative for the attached step.
 			}
 		});
 		try {
-			const imported = await waitForImportedAsyncRoot(step.importAsyncRoot, withoutUndefined({
+			const imported = await waitForImportedAsyncRoot(step.importAsyncRoot, omitUndefinedProperties({
 				shouldAbort: () => importTimedOut || importStopped || ctx.timeoutSignal?.aborted === true || ctx.stopSignal?.aborted === true || ctx.skipAcceptance?.() === true,
 				timeoutMessage: importStopped || ctx.stopSignal?.aborted === true ? ctx.stopMessage : ctx.timeoutMessage,
 			}));
@@ -1117,7 +1123,7 @@ async function runSingleStep(
 			const stopped = importStopped || imported.stopped === true || ctx.stopSignal?.aborted === true;
 			const timedOut = !stopped && (importTimedOut || imported.timedOut === true || ctx.timeoutSignal?.aborted === true || ctx.skipAcceptance?.() === true);
 			const message = stopped ? ctx.stopMessage ?? "Subagent stopped by user." : ctx.timeoutMessage ?? "Subagent timed out.";
-			return withoutUndefined({
+			return omitUndefinedProperties({
 				agent: imported.agent,
 				output: timedOut || stopped ? message : imported.output,
 				exitCode: timedOut || stopped ? 1 : imported.exitCode,
@@ -1186,7 +1192,7 @@ async function runSingleStep(
 			capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false },
 		};
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
-		const external = await runExternalCli(withoutUndefined({
+		const external = await runExternalCli(omitUndefinedProperties({
 			command: runner.command,
 			args: runner.args,
 			cwd: step.cwd ?? ctx.cwd,
@@ -1204,7 +1210,7 @@ async function runSingleStep(
 			? resolveSingleOutput(step.outputPath, external.output, outputSnapshot)
 			: { fullOutput: external.output };
 		const outputReference = resolvedOutput.savedPath ? formatSavedOutputReference(resolvedOutput.savedPath, resolvedOutput.fullOutput) : undefined;
-		const finalizedOutput = finalizeSingleOutput(withoutUndefined({
+		const finalizedOutput = finalizeSingleOutput(omitUndefinedProperties({
 			fullOutput: resolvedOutput.fullOutput,
 			outputPath: step.outputPath,
 			outputMode: step.outputMode,
@@ -1215,13 +1221,13 @@ async function runSingleStep(
 		}));
 		if (artifactPaths && ctx.artifactConfig?.enabled !== false) {
 			if (ctx.artifactConfig?.includeOutput !== false) {
-				fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent(withoutUndefined({ output: resolvedOutput.fullOutput, error: external.error, metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath })), "utf-8");
+				fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent(omitUndefinedProperties({ output: resolvedOutput.fullOutput, error: external.error, metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath })), "utf-8");
 			}
 			if (ctx.artifactConfig?.includeMetadata !== false) {
 				fs.writeFileSync(artifactPaths.metadataPath, JSON.stringify({ runId: ctx.id, agent: step.agent, task, runner, externalProcess: external.externalProcess, exitCode: external.exitCode, error: external.error, timestamp: Date.now() }, null, 2), "utf-8");
 			}
 		}
-		return withoutUndefined({
+		return omitUndefinedProperties({
 			agent: step.agent,
 			context: step.context,
 			output: finalizedOutput.displayOutput,
@@ -1263,7 +1269,7 @@ async function runSingleStep(
 	modelAttemptsLoop: while (modelIndex < candidates.length) {
 		if (ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break;
 		const candidate = candidates[modelIndex];
-		ctx.onAttemptStart?.(withoutUndefined({ model: candidate, thinking: resolveEffectiveThinking(candidate, step.thinking) }));
+		ctx.onAttemptStart?.(omitUndefinedProperties({ model: candidate, thinking: resolveEffectiveThinking(candidate, step.thinking) }));
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
 		if (effectiveStructuredOutput) {
 			try {
@@ -1281,7 +1287,7 @@ async function runSingleStep(
 				childIndex: ctx.flatIndex,
 			})
 			: undefined;
-		const { args, env, tempDir, toolDiagnosticPath, runtimeAcknowledgedExtensionsPath, capabilityAudit: attemptCapabilityAudit } = buildPiArgs(withoutUndefined({
+		const { args, env, tempDir, toolDiagnosticPath, runtimeAcknowledgedExtensionsPath, capabilityAudit: attemptCapabilityAudit } = buildPiArgs(omitUndefinedProperties({
 			parentSessionId: step.parentSessionId,
 			baseArgs: ["--mode", "json", "-p"],
 			task,
@@ -1323,7 +1329,7 @@ async function runSingleStep(
 			waitToolEnabled: step.waitToolEnabled,
 		}));
 		if (step.definitionDigest) {
-			const toolPlan = resolvePiLaunchToolPlan(withoutUndefined({
+			const toolPlan = resolvePiLaunchToolPlan(omitUndefinedProperties({
 				tools: step.tools,
 				extensions: step.extensions,
 				subagentOnlyExtensions: step.subagentOnlyExtensions,
@@ -1335,7 +1341,7 @@ async function runSingleStep(
 				inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
 			}));
 			launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
-			actualLaunchContractDigest = launchBindingDigest(withoutUndefined({
+			actualLaunchContractDigest = launchBindingDigest(omitUndefinedProperties({
 				definitionDigest: step.definitionDigest,
 				task: step.launchBindingTask ?? task,
 				...(candidate ? { model: candidate } : {}),
@@ -1435,7 +1441,7 @@ async function runSingleStep(
 		}
 		const completionGuardEnabled = isAgentContractV1(step.agentContract) ? step.completionGuard === true : step.completionGuard !== false;
 		const completionGuard = run.exitCode === 0 && !run.error && !toolAvailabilityError && !hiddenError?.hasError && !emptyOutputError && completionGuardEnabled
-			? evaluateCompletionMutationGuard(withoutUndefined({
+			? evaluateCompletionMutationGuard(omitUndefinedProperties({
 				agent: step.agent,
 				task: taskForCompletionGuard,
 				messages: run.messages,
@@ -1462,7 +1468,7 @@ async function runSingleStep(
 				: run.error && run.exitCode === 0
 					? 1
 					: run.exitCode;
-		const signalError = run.exitCode !== 0 && isUnexplainedProcessSignal(withoutUndefined({
+		const signalError = run.exitCode !== 0 && isUnexplainedProcessSignal(omitUndefinedProperties({
 			processSignal: run.processSignal,
 			interrupted: run.interrupted,
 			timedOut: run.timedOut,
@@ -1478,7 +1484,7 @@ async function runSingleStep(
 					? `${hiddenError.errorType} failed (exit ${effectiveExitCode}): ${hiddenError.details}`
 					: `${hiddenError.errorType} failed with exit code ${effectiveExitCode}`
 				: run.error || signalError || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined));
-		const attempt: ModelAttempt = withoutUndefined({
+		const attempt: ModelAttempt = omitUndefinedProperties({
 			model: candidate ?? run.model ?? step.model ?? "default",
 			success: effectiveExitCode === 0 && !error,
 			exitCode: effectiveExitCode,
@@ -1500,7 +1506,7 @@ async function runSingleStep(
 		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break modelAttemptsLoop;
 		if (attempt.success || completionGuardTriggered) break modelAttemptsLoop;
 
-		const startupFailure = isRetryableSubagentStartupFailure(withoutUndefined({
+		const startupFailure = isRetryableSubagentStartupFailure(omitUndefinedProperties({
 			exitCode: effectiveExitCode,
 			error,
 			finalOutput: run.finalOutput,
@@ -1580,7 +1586,7 @@ async function runSingleStep(
 		: resolvedOutput.savedPath
 			? "unknown"
 			: finalResult?.outputState ?? "unknown";
-	const finalizedOutput = finalizeSingleOutput(withoutUndefined({
+	const finalizedOutput = finalizeSingleOutput(omitUndefinedProperties({
 		fullOutput: outputForSummary,
 		outputPath: step.outputPath,
 		outputMode: step.outputMode,
@@ -1591,7 +1597,7 @@ async function runSingleStep(
 	}));
 	outputForSummary = finalizedOutput.displayOutput;
 	const acceptance = step.effectiveAcceptance && !finalResult?.stopped && !finalResult?.turnBudgetExceeded && !ctx.timeoutSignal?.aborted && !ctx.stopSignal?.aborted && !ctx.skipAcceptance?.()
-		? await evaluateAcceptance(withoutUndefined({
+		? await evaluateAcceptance(omitUndefinedProperties({
 			acceptance: step.effectiveAcceptance,
 			output: outputForAcceptance,
 			fileOutput: childWrittenOutput !== undefined && step.outputPath
@@ -1630,7 +1636,7 @@ async function runSingleStep(
 
 	if (artifactPaths && ctx.artifactConfig?.enabled !== false) {
 		if (ctx.artifactConfig?.includeOutput !== false) {
-			fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent(withoutUndefined({
+			fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent(omitUndefinedProperties({
 				output,
 				error: effectiveFinalError,
 				transcriptPath: transcriptWriter ? artifactPaths.transcriptPath : undefined,
@@ -1664,7 +1670,7 @@ async function runSingleStep(
 		}
 	}
 
-	const result: StepResult & { completionGuardTriggered?: boolean } = withoutUndefined({
+	const result: StepResult & { completionGuardTriggered?: boolean } = omitUndefinedProperties({
 		agent: step.agent,
 		context: step.context,
 		...(step.agentContract ? { agentContract: step.agentContract } : {}),
@@ -1781,7 +1787,7 @@ function markParallelGroupSetupFailure(input: {
 		statusStep.endedAt = input.failedAt;
 		statusStep.durationMs = 0;
 		statusStep.exitCode = 1;
-		input.results.push(withoutUndefined({ agent: task.agent, context: task.context, output: input.setupError, success: false, exitCode: 1, sessionFile: task.sessionFile }));
+		input.results.push(omitUndefinedProperties({ agent: task.agent, context: task.context, output: input.setupError, success: false, exitCode: 1, sessionFile: task.sessionFile }));
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.lastUpdate = input.failedAt;
@@ -1949,7 +1955,7 @@ async function runSubagent(
 	for (let stepIndex = 0; stepIndex < steps.length; stepIndex++) {
 		const step = steps[stepIndex]!;
 		if (isCheckpointRunnerStep(step)) {
-			initialStatusSteps.push(withoutUndefined({
+			initialStatusSteps.push(omitUndefinedProperties({
 				agent: `checkpoint:${step.checkpoint}`,
 				phase: step.phase,
 				label: step.label ?? step.checkpoint,
@@ -1965,8 +1971,8 @@ async function runSubagent(
 			parallelGroups.push({ start: flatStepCount, count: step.parallel.length, stepIndex });
 			for (const task of step.parallel) {
 				const taskFlatIndex = flatStepCount;
-				const transcriptPath = resolveAsyncStepTranscriptPath(withoutUndefined({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: taskFlatIndex, flatStepCount: initialFlatStepCount }));
-				initialStatusSteps.push(withoutUndefined({
+				const transcriptPath = resolveAsyncStepTranscriptPath(omitUndefinedProperties({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: taskFlatIndex, flatStepCount: initialFlatStepCount }));
+				initialStatusSteps.push(omitUndefinedProperties({
 					agent: task.agent,
 					...(externalRunnerStatus(task.runner) ? { runner: externalRunnerStatus(task.runner) } : {}),
 					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
@@ -1994,7 +2000,7 @@ async function runSubagent(
 			}
 		} else if (isDynamicRunnerGroup(step)) {
 			parallelGroups.push({ start: flatStepCount, count: 1, stepIndex });
-			initialStatusSteps.push(withoutUndefined({
+			initialStatusSteps.push(omitUndefinedProperties({
 				agent: `expand:${step.parallel.agent}`,
 				...(externalRunnerStatus(step.parallel.runner) ? { runner: externalRunnerStatus(step.parallel.runner) } : {}),
 				...(step.parallel.context ? { context: step.parallel.context } : {}),
@@ -2012,8 +2018,8 @@ async function runSubagent(
 			flatStepCount++;
 		} else {
 			const stepFlatIndex = flatStepCount;
-			const transcriptPath = resolveAsyncStepTranscriptPath(withoutUndefined({ artifactsDir, artifactConfig, runId: id, agent: step.agent, flatIndex: stepFlatIndex, flatStepCount: initialFlatStepCount }));
-			initialStatusSteps.push(withoutUndefined({
+			const transcriptPath = resolveAsyncStepTranscriptPath(omitUndefinedProperties({ artifactsDir, artifactConfig, runId: id, agent: step.agent, flatIndex: stepFlatIndex, flatStepCount: initialFlatStepCount }));
+			initialStatusSteps.push(omitUndefinedProperties({
 				agent: step.agent,
 				...(externalRunnerStatus(step.runner) ? { runner: externalRunnerStatus(step.runner) } : {}),
 				...(statusStepDescription(step.task) ? { description: statusStepDescription(step.task) } : {}),
@@ -2048,7 +2054,7 @@ async function runSubagent(
 			step.processTerminal = { version: 1, state: "pending", runId: id, runnerProcessInstanceId: config.runnerProcessInstanceId };
 		}
 	}
-	const statusPayload: RunnerStatusPayload = withoutUndefined({
+	const statusPayload: RunnerStatusPayload = omitUndefinedProperties({
 		lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
 		runId: id,
 		...(config.sessionId ? { sessionId: config.sessionId } : {}),
@@ -2104,12 +2110,12 @@ async function runSubagent(
 	const emitNestedSelfEvent = (type: "subagent.nested.updated" | "subagent.nested.completed"): void => {
 		if (!config.nestedRoute || !config.nestedSelf) return;
 		try {
-			writeNestedEvent(config.nestedRoute, withoutUndefined({
+			writeNestedEvent(config.nestedRoute, omitUndefinedProperties({
 				type,
 				ts: Date.now(),
 				parentRunId: config.nestedSelf.parentRunId,
 				parentStepIndex: config.nestedSelf.parentStepIndex,
-				child: nestedSummaryFromAsyncStatus(statusPayload, asyncDir, withoutUndefined({
+				child: nestedSummaryFromAsyncStatus(statusPayload, asyncDir, omitUndefinedProperties({
 					id,
 					parentRunId: config.nestedSelf.parentRunId,
 					parentStepIndex: config.nestedSelf.parentStepIndex,
@@ -2232,7 +2238,7 @@ async function runSubagent(
 			const nestedAsyncDir = run.asyncDir ?? resolveNestedAsyncDir(config.nestedRoute.rootRunId, run);
 			if (!nestedAsyncDir) continue;
 			try {
-				deliverInterruptRequest(withoutUndefined({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-interrupt" }));
+				deliverInterruptRequest(omitUndefinedProperties({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-interrupt" }));
 			} catch (error) {
 				appendJsonl(eventsPath, JSON.stringify({
 					type: "subagent.nested.interrupt_failed",
@@ -2263,7 +2269,7 @@ async function runSubagent(
 			const nestedAsyncDir = run.asyncDir ?? resolveNestedAsyncDir(config.nestedRoute.rootRunId, run);
 			if (!nestedAsyncDir) continue;
 			try {
-				deliverStopRequest(withoutUndefined({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-stop" }));
+				deliverStopRequest(omitUndefinedProperties({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-stop" }));
 			} catch (error) {
 				appendJsonl(eventsPath, JSON.stringify({
 					type: "subagent.nested.stop_failed",
@@ -2294,7 +2300,7 @@ async function runSubagent(
 			const nestedAsyncDir = run.asyncDir ?? resolveNestedAsyncDir(config.nestedRoute.rootRunId, run);
 			if (!nestedAsyncDir) continue;
 			try {
-				deliverTimeoutRequest(withoutUndefined({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-timeout" }));
+				deliverTimeoutRequest(omitUndefinedProperties({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-timeout" }));
 			} catch (error) {
 				appendJsonl(eventsPath, JSON.stringify({
 					type: "subagent.nested.timeout_failed",
@@ -2306,14 +2312,14 @@ async function runSubagent(
 			}
 		}
 	};
-	const pausedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => withoutUndefined({
+	const pausedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => omitUndefinedProperties({
 		agent,
 		context,
 		output: "Paused after interrupt. Waiting for explicit next action.",
 		exitCode: 0,
 		interrupted: true,
 	});
-	const timedOutStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => withoutUndefined({
+	const timedOutStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => omitUndefinedProperties({
 		agent,
 		context,
 		output: timeoutMessage ?? "Subagent timed out.",
@@ -2321,7 +2327,7 @@ async function runSubagent(
 		exitCode: 1,
 		timedOut: true,
 	});
-	const stoppedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => withoutUndefined({
+	const stoppedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => omitUndefinedProperties({
 		agent,
 		context,
 		output: stopMessage,
@@ -2448,7 +2454,7 @@ async function runSubagent(
 		const previous = step.activityState;
 		step.activityState = "active_long_running";
 		statusPayload.activityState = statusPayload.activityState === "needs_attention" ? "needs_attention" : "active_long_running";
-		const event = buildControlEvent(withoutUndefined({
+		const event = buildControlEvent(omitUndefinedProperties({
 			type: "active_long_running",
 			from: previous,
 			to: "active_long_running",
@@ -2483,12 +2489,12 @@ async function runSubagent(
 	};
 	const recordSteeringLifecycle = (request: SteerRequest, targets: Array<{ index: number; state: SteeringTargetState; reason?: string }>): void => {
 		const lifecycle = steeringStatus(statusPayload);
-		recordSteeringRequest(lifecycle, withoutUndefined({ id: request.id, requestedAt: request.ts, source: request.source, message: request.message, targets }));
+		recordSteeringRequest(lifecycle, omitUndefinedProperties({ id: request.id, requestedAt: request.ts, source: request.source, message: request.message, targets }));
 		for (const target of targets) {
 			const step = statusPayload.steps[target.index];
 			if (!step) continue;
 			step.steering ??= createSteeringStatus();
-			recordSteeringRequest(step.steering, withoutUndefined({ id: request.id, requestedAt: request.ts, source: request.source, message: request.message, targets: [target] }));
+			recordSteeringRequest(step.steering, omitUndefinedProperties({ id: request.id, requestedAt: request.ts, source: request.source, message: request.message, targets: [target] }));
 		}
 	};
 	const updateSteeringLifecycleTarget = (
@@ -2578,7 +2584,7 @@ async function runSubagent(
 		const late = fs.existsSync(steeringMarkerPath(ack.requestId));
 		const now = Date.now();
 		if (ack.state === "delivered") {
-			updateSteeringLifecycleTarget(ack.requestId, ack.index, late ? "late" : "delivered", now, withoutUndefined({ reason: late ? "acknowledged after recovery commit" : undefined }));
+			updateSteeringLifecycleTarget(ack.requestId, ack.index, late ? "late" : "delivered", now, omitUndefinedProperties({ reason: late ? "acknowledged after recovery commit" : undefined }));
 			emitSteeringEvent("subagent.steer.delivered", { type: "steer", id: ack.requestId, ts: now, message: ack.message }, ack.index, { late, message: ack.message });
 		} else {
 			markSteeringAttention(ack.index);
@@ -2700,7 +2706,7 @@ async function runSubagent(
 			step.currentToolArgs = extractToolArgsPreview(event.args ?? {});
 			step.currentToolStartedAt = now;
 			setOptionalProperty(step, "currentPath", currentPath);
-			pendingToolResults[flatIndex] = withoutUndefined({ tool: event.toolName, path: currentPath, mutates, startedAt: now });
+			pendingToolResults[flatIndex] = omitUndefinedProperties({ tool: event.toolName, path: currentPath, mutates, startedAt: now });
 			statusPayload.toolCount = (statusPayload.toolCount ?? 0) + 1;
 			syncTopLevelCurrentTool();
 			if (controlConfig.enabled && isBlockingSupervisorTool(event.toolName, event.args) && step.activityState !== "needs_attention") {
@@ -2709,7 +2715,7 @@ async function runSubagent(
 				supervisorAttentionSteps.set(flatIndex, previous);
 				currentActivityState = "needs_attention";
 				statusPayload.activityState = "needs_attention";
-				appendControlEvent(buildControlEvent(withoutUndefined({
+				appendControlEvent(buildControlEvent(omitUndefinedProperties({
 					type: "needs_attention",
 					from: previous,
 					to: "needs_attention",
@@ -2759,7 +2765,7 @@ async function runSubagent(
 			appendRecentStepOutput(step, resultText.split("\n").slice(-10));
 			if (toolSnapshot?.mutates && didMutatingToolFail(resultText)) {
 				const state = mutatingFailureStates[flatIndex]!;
-				recordMutatingFailure(state, withoutUndefined({
+				recordMutatingFailure(state, omitUndefinedProperties({
 					tool: toolSnapshot.tool,
 					path: toolSnapshot.path,
 					error: resultText.split("\n").find((line) => line.trim())?.trim().slice(0, 180) ?? "mutating tool failed",
@@ -2769,7 +2775,7 @@ async function runSubagent(
 					const previous = step.activityState;
 					step.activityState = "needs_attention";
 					statusPayload.activityState = "needs_attention";
-					appendControlEvent(buildControlEvent(withoutUndefined({
+					appendControlEvent(buildControlEvent(omitUndefinedProperties({
 						type: "needs_attention",
 						from: previous,
 						to: "needs_attention",
@@ -2835,7 +2841,7 @@ async function runSubagent(
 				step.lastActivityAt = lastActivityAt;
 				changed = true;
 			}
-			const idleState = deriveActivityState(withoutUndefined({
+			const idleState = deriveActivityState(omitUndefinedProperties({
 				config: controlConfig,
 				startedAt: step.startedAt ?? overallStartTime,
 				lastActivityAt,
@@ -2846,7 +2852,7 @@ async function runSubagent(
 				const previous = step.activityState;
 				step.activityState = "needs_attention";
 				if (previous !== "needs_attention") {
-					appendControlEvent(buildControlEvent(withoutUndefined({
+					appendControlEvent(buildControlEvent(omitUndefinedProperties({
 						from: previous,
 						to: "needs_attention",
 						runId: id,
@@ -3137,7 +3143,7 @@ async function runSubagent(
 			const groupStartFlatIndex = flatIndex;
 			let materialized: ReturnType<typeof materializeDynamicParallelStep>;
 			try {
-				materialized = materializeDynamicParallelStep(step as Parameters<typeof materializeDynamicParallelStep>[0], outputs, stepIndex, withoutUndefined({ maxItems: config.dynamicFanoutMaxItems, allowRunnerFields: true }));
+				materialized = materializeDynamicParallelStep(step as Parameters<typeof materializeDynamicParallelStep>[0], outputs, stepIndex, omitUndefinedProperties({ maxItems: config.dynamicFanoutMaxItems, allowRunnerFields: true }));
 				if (materialized.parallel.length > 1 && step.parallel.outputPath && !step.parallel.namespaceOutputPath) {
 					throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} materialized ${materialized.parallel.length} items that resolve output to the same path: ${step.parallel.outputPath}. Remove the explicit output path or use an inherited relative agent output so each item can be isolated.`);
 				}
@@ -3160,11 +3166,11 @@ async function runSubagent(
 				statusPayload.lastUpdate = now;
 				markDynamicGraphGroup(stepIndex, "failed", message);
 				writeStatusPayload();
-				results.push(withoutUndefined({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1 }));
+				results.push(omitUndefinedProperties({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1 }));
 				break;
 			}
 
-			const effectiveDynamicGroupAcceptance = resolveEffectiveAcceptance(withoutUndefined({
+			const effectiveDynamicGroupAcceptance = resolveEffectiveAcceptance(omitUndefinedProperties({
 				explicit: step.acceptanceInput,
 				agentName: step.parallel.agent,
 				acceptanceRole: step.acceptanceRole,
@@ -3194,7 +3200,7 @@ async function runSubagent(
 				}
 				previousOutput = "Dynamic fanout produced 0 results.";
 				const groupAcceptance = effectiveDynamicGroupAcceptance.explicit && !timedOut && !stopped
-					? await evaluateAcceptance(withoutUndefined({
+					? await evaluateAcceptance(omitUndefinedProperties({
 						acceptance: effectiveDynamicGroupAcceptance,
 						output: "",
 						report: aggregateAcceptanceReport({
@@ -3227,7 +3233,7 @@ async function runSubagent(
 					markDynamicGraphGroup(stepIndex, groupStopped ? "stopped" : "failed", errorMessage, effectiveGroupAcceptance);
 					statusPayload.lastUpdate = Date.now();
 					writeStatusPayload();
-					results.push(withoutUndefined({ agent: step.parallel.agent, context: step.parallel.context, output: errorMessage, error: errorMessage, success: false, exitCode: 1, timedOut: groupTimedOut ? true : undefined, stopped: groupStopped ? true : undefined, acceptance: effectiveGroupAcceptance }));
+					results.push(omitUndefinedProperties({ agent: step.parallel.agent, context: step.parallel.context, output: errorMessage, error: errorMessage, success: false, exitCode: 1, timedOut: groupTimedOut ? true : undefined, stopped: groupStopped ? true : undefined, acceptance: effectiveGroupAcceptance }));
 					break;
 				}
 				flatIndex++;
@@ -3246,10 +3252,10 @@ async function runSubagent(
 					: step.parallel.outputPath;
 				const taskText = task.task ?? step.parallel.task;
 				const materializedTask = step.parallel.namespaceOutputPath ? injectSingleOutputInstruction(taskText, outputPath, step.parallel) : taskText;
-				return withoutUndefined({
+				return omitUndefinedProperties({
 					...step.parallel,
 					task: materializedTask,
-					effectiveAcceptance: resolveEffectiveAcceptance(withoutUndefined({
+					effectiveAcceptance: resolveEffectiveAcceptance(omitUndefinedProperties({
 						explicit: step.parallel.acceptanceInput,
 						agentName: step.parallel.agent,
 						acceptanceRole: step.parallel.acceptanceRole,
@@ -3276,8 +3282,8 @@ async function runSubagent(
 			});
 			const dynamicFlatStepCount = Math.max(statusPayload.steps.length - 1 + dynamicSteps.length, 1);
 			const dynamicStatusSteps: RunnerStatusStep[] = dynamicSteps.map((task, itemIndex) => {
-				const transcriptPath = resolveAsyncStepTranscriptPath(withoutUndefined({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: groupStartFlatIndex + itemIndex, flatStepCount: dynamicFlatStepCount }));
-				return withoutUndefined({
+				const transcriptPath = resolveAsyncStepTranscriptPath(omitUndefinedProperties({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: groupStartFlatIndex + itemIndex, flatStepCount: dynamicFlatStepCount }));
+				return omitUndefinedProperties({
 					agent: task.agent,
 					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
 					...(task.context ? { context: task.context } : {}),
@@ -3325,7 +3331,7 @@ async function runSubagent(
 				shiftFlatIndexes(statusPayload.workflowGraph.nodes);
 				const groupNode = statusPayload.workflowGraph.nodes.find((node) => node.id === `step-${stepIndex}`);
 				if (groupNode) {
-					groupNode.children = materialized.items.map((item, itemIndex) => withoutUndefined({
+					groupNode.children = materialized.items.map((item, itemIndex) => omitUndefinedProperties({
 						id: `step-${stepIndex}-item-${item.idKey}`,
 						kind: "agent",
 						agent: step.parallel.agent,
@@ -3360,7 +3366,7 @@ async function runSubagent(
 					usageBudgetExceeded = true;
 					writeStatusPayload();
 					appendJsonl(eventsPath, JSON.stringify({ type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: 1, durationMs: 0 }));
-					return withoutUndefined({ agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
+					return omitUndefinedProperties({ agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
 				}
 				if (timedOut) return timedOutStepResult(task.agent, task.context);
 				if (stopped) return stoppedStepResult(task.agent, task.context);
@@ -3375,7 +3381,7 @@ async function runSubagent(
 					requiredStatusStep(statusPayload, fi).exitCode = -1;
 					statusPayload.lastUpdate = skippedAt;
 					writeStatusPayload();
-					return withoutUndefined({ agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
+					return omitUndefinedProperties({ agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
 				}
 				const taskStartTime = Date.now();
 				statusPayload.currentStep = fi;
@@ -3487,7 +3493,7 @@ async function runSubagent(
 
 			flatIndex += dynamicSteps.length;
 			for (const pr of parallelResults) {
-				results.push(withoutUndefined({
+				results.push(omitUndefinedProperties({
 					agent: pr.agent,
 					context: pr.context,
 					agentContract: pr.agentContract,
@@ -3541,7 +3547,7 @@ async function runSubagent(
 				const message = acceptanceFailures
 					.map(({ result, originalIndex }) => `Dynamic item ${originalIndex + 1} (${result.agent}, key ${materialized.items[originalIndex]?.key ?? originalIndex}) acceptance rejected: ${(result.acceptance ? acceptanceFailureMessage(result.acceptance) : undefined) ?? "acceptance rejected"}`)
 					.join("\n");
-				results.push(withoutUndefined({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection }));
+				results.push(omitUndefinedProperties({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection }));
 				statusPayload.error = message;
 				markDynamicGraphGroup(stepIndex, "failed", message);
 			}
@@ -3556,7 +3562,7 @@ async function runSubagent(
 					};
 					statusPayload.outputs = outputs;
 					const groupAcceptance = !timedOut && !stopped
-						? await evaluateAcceptance(withoutUndefined({
+						? await evaluateAcceptance(omitUndefinedProperties({
 							acceptance: effectiveDynamicGroupAcceptance,
 							output: "",
 							report: aggregateAcceptanceReport({
@@ -3576,7 +3582,7 @@ async function runSubagent(
 					const groupError = groupStopped ? stopMessage : groupTimedOut ? timeoutMessage ?? "Subagent timed out." : groupAcceptanceFailure;
 					markDynamicGraphGroup(stepIndex, groupError ? groupStopped ? "stopped" : "failed" : "completed", groupError, effectiveGroupAcceptance);
 					if (groupError) {
-						results.push(withoutUndefined({
+						results.push(omitUndefinedProperties({
 							agent: step.parallel.agent,
 							output: groupError,
 							error: groupError,
@@ -3592,13 +3598,13 @@ async function runSubagent(
 					}
 				} catch (error) {
 					const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
-					results.push(withoutUndefined({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection }));
+					results.push(omitUndefinedProperties({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection }));
 					statusPayload.error = message;
 					markDynamicGraphGroup(stepIndex, "failed", message);
 				}
 			}
 			previousOutput = aggregateParallelOutputs(
-				parallelResults.map((r, i) => withoutUndefined({
+				parallelResults.map((r, i) => omitUndefinedProperties({
 					agent: r.agent,
 					taskIndex: i,
 					output: r.output,
@@ -3650,10 +3656,10 @@ async function runSubagent(
 					break;
 				}
 				try {
-					worktreeSetup = createWorktrees(cwd, `${id}-s${stepIndex}`, group.parallel.length, withoutUndefined({
+					worktreeSetup = createWorktrees(cwd, `${id}-s${stepIndex}`, group.parallel.length, omitUndefinedProperties({
 						agents: group.parallel.map((task) => task.agent),
 						setupHook: config.worktreeSetupHook
-							? withoutUndefined({ hookPath: config.worktreeSetupHook, timeoutMs: config.worktreeSetupHookTimeoutMs })
+							? omitUndefinedProperties({ hookPath: config.worktreeSetupHook, timeoutMs: config.worktreeSetupHookTimeoutMs })
 							: undefined,
 						baseDir: config.worktreeBaseDir,
 					}));
@@ -3726,7 +3732,7 @@ async function runSubagent(
 							appendJsonl(eventsPath, JSON.stringify({
 								type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: 1, durationMs: 0,
 							}));
-							return withoutUndefined({ agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
+							return omitUndefinedProperties({ agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
 						}
 						if (timedOut) return timedOutStepResult(task.agent, task.context);
 						if (stopped) return stoppedStepResult(task.agent, task.context);
@@ -3745,7 +3751,7 @@ async function runSubagent(
 							appendJsonl(eventsPath, JSON.stringify({
 								type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: -1, durationMs: 0,
 							}));
-							return withoutUndefined({ agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
+							return omitUndefinedProperties({ agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
 						}
 
 						const taskStartTime = Date.now();
@@ -3870,7 +3876,7 @@ async function runSubagent(
 							exitCode: stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode, durationMs: taskDuration,
 						}));
 						if (singleResult.completionGuardTriggered) {
-							const event = buildControlEvent(withoutUndefined({
+							const event = buildControlEvent(omitUndefinedProperties({
 								from: requiredStatusStep(statusPayload, fi).activityState,
 								to: "needs_attention",
 								runId: id,
@@ -3910,7 +3916,7 @@ async function runSubagent(
 				writeStatusPayload();
 
 				for (const pr of parallelResults) {
-					results.push(withoutUndefined({
+					results.push(omitUndefinedProperties({
 						agent: pr.agent,
 						context: pr.context,
 						agentContract: pr.agentContract,
@@ -3963,7 +3969,7 @@ async function runSubagent(
 				statusPayload.outputs = outputs;
 
 				previousOutput = aggregateParallelOutputs(
-					parallelResults.map((r) => withoutUndefined({
+					parallelResults.map((r) => omitUndefinedProperties({
 						agent: r.agent,
 						output: r.output,
 						exitCode: r.exitCode,
@@ -3989,7 +3995,7 @@ async function runSubagent(
 						diffs: captured.diffs,
 						results: parallelResults.map((result) => ({
 							agent: result.agent,
-							status: result.stopped || (result.exitCode !== 0 && isUnexplainedProcessSignal(withoutUndefined({
+							status: result.stopped || (result.exitCode !== 0 && isUnexplainedProcessSignal(omitUndefinedProperties({
 								processSignal: result.processSignal,
 								interrupted: result.interrupted,
 								timedOut: result.timedOut,
@@ -4099,7 +4105,7 @@ async function runSubagent(
 
 			previousOutput = singleResult.output;
 			const childStopped = singleResult.stopped === true;
-			results.push(withoutUndefined({
+			results.push(omitUndefinedProperties({
 				agent: singleResult.agent,
 				context: singleResult.context,
 				agentContract: singleResult.agentContract,
@@ -4232,7 +4238,7 @@ async function runSubagent(
 				tokens: stepTokens,
 			}));
 			if (singleResult.completionGuardTriggered) {
-				const event = buildControlEvent(withoutUndefined({
+				const event = buildControlEvent(omitUndefinedProperties({
 					from: requiredStatusStep(statusPayload, flatIndex).activityState,
 					to: "needs_attention",
 					runId: id,
@@ -4322,7 +4328,7 @@ async function runSubagent(
 		clearTimeout(timeoutTimer);
 		timeoutTimer = undefined;
 	}
-	const signalTerminated = !stopped && !timedOut && !turnBudgetExceeded && !interrupted && results.some((result) => result.exitCode !== 0 && isUnexplainedProcessSignal(withoutUndefined({
+	const signalTerminated = !stopped && !timedOut && !turnBudgetExceeded && !interrupted && results.some((result) => result.exitCode !== 0 && isUnexplainedProcessSignal(omitUndefinedProperties({
 		processSignal: result.processSignal,
 		interrupted: result.interrupted,
 		timedOut: result.timedOut,
@@ -4395,13 +4401,13 @@ async function runSubagent(
 			usageBudget: statusPayload.usageBudget,
 		}),
 	);
-	writeRunLog(logPath, withoutUndefined({
+	writeRunLog(logPath, omitUndefinedProperties({
 		id,
 		mode: statusPayload.mode,
 		cwd,
 		startedAt: overallStartTime,
 		endedAt: runEndedAt,
-		steps: statusPayload.steps.map((step) => withoutUndefined({
+		steps: statusPayload.steps.map((step) => omitUndefinedProperties({
 			agent: step.agent,
 			status: step.status,
 			durationMs: step.durationMs,
@@ -4433,7 +4439,7 @@ async function runSubagent(
 			...(statusPayload.usageBudget ? { usageBudget: statusPayload.usageBudget } : {}),
 			...(statusPayload.checkpoint ? { checkpoint: statusPayload.checkpoint } : {}),
 			...(stopped ? { stopped: true, error: stopMessage } : timedOut ? { timedOut: true, error: timeoutMessage ?? "Subagent timed out." } : turnBudgetExceeded ? { error: statusPayload.error ?? "Subagent exceeded turn budget." } : usageBudgetExceeded ? { error: statusPayload.error ?? "Usage budget exhausted." } : {}),
-			results: results.map((r) => withoutUndefined({
+			results: results.map((r) => omitUndefinedProperties({
 				agent: r.agent,
 				context: r.context,
 				output: r.output,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -383,11 +383,38 @@ function isTerminalAssistantStop(message: Message): boolean {
 	return (message as { stopReason?: string }).stopReason === "stop" && !assistantStartsToolCall(message);
 }
 
+type WithoutUndefined<T extends object> = {
+	[K in keyof T]: Exclude<T[K], undefined>;
+};
+
+function withoutUndefined<const T extends object>(value: T): WithoutUndefined<T> {
+	for (const key in value) {
+		if (value[key] === undefined) delete value[key];
+	}
+	return value as WithoutUndefined<T>;
+}
+
+type WithUndefinedOptionals<T extends object> = {
+	[K in keyof T]: {} extends Pick<T, K> ? T[K] | undefined : T[K];
+};
+
+function compactOptional<T extends object>(value: WithUndefinedOptionals<T>): T {
+	for (const key in value) {
+		if (value[key] === undefined) delete value[key];
+	}
+	return value as T;
+}
+
+function setOptionalProperty<T extends object, K extends keyof T>(target: T, key: K, value: T[K]): void {
+	if (value === undefined) delete target[key];
+	else Reflect.set(target, key, value);
+}
+
 function resetStepLiveDetail(step: RunnerStatusStep): void {
-	step.currentTool = undefined;
-	step.currentToolArgs = undefined;
-	step.currentToolStartedAt = undefined;
-	step.currentPath = undefined;
+	delete step.currentTool;
+	delete step.currentToolArgs;
+	delete step.currentToolStartedAt;
+	delete step.currentPath;
 	step.recentTools = [];
 	step.recentOutput = [];
 }
@@ -569,9 +596,11 @@ function runPiStreaming(
 				const next = acceptChildWatchdogEvent({
 					current: childWatchdogState,
 					event,
-					runId: childEventContext?.runId,
-					agent: childEventContext?.agent,
-					childIndex: childEventContext?.stepIndex,
+					...(childEventContext ? {
+						runId: childEventContext.runId,
+						agent: childEventContext.agent,
+						childIndex: childEventContext.stepIndex,
+					} : {}),
 				});
 				if (!next) return;
 				updateChildWatchdogState(next);
@@ -843,7 +872,7 @@ function runPiStreaming(
 				turnBudgetExceeded,
 				forcedDrainAfterFinalSuccess,
 			}) ? formatProcessSignalError(signal!) : undefined;
-			resolve({
+			resolve(withoutUndefined({
 				stderr,
 				exitCode: timedOut || stopped ? 1 : turnBudgetExceeded ? 1 : interrupted || forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (exitCode ?? 1) : exitCode,
 				messages,
@@ -866,7 +895,7 @@ function runPiStreaming(
 				processInstanceId,
 				processCloseObservedAt,
 				processSignal: signal,
-			});
+			}));
 		});
 
 		child.on("error", (spawnError) => {
@@ -888,7 +917,7 @@ function runPiStreaming(
 			const stderr = stderrTail.text();
 			const finalOutput = getFinalOutput(messages) || rawStdoutTail.text().trim();
 			const spawnErrorMessage = spawnError instanceof Error ? spawnError.message : String(spawnError);
-			resolve({ stderr, exitCode: 1, messages, usage, toolCount, durationMs: Date.now() - startedAt, model, error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? turnBudgetMessage : error ?? assistantError ?? spawnErrorMessage, protocolError, finalOutput: (timedOut || stopped) && !finalOutput.trim() ? (stopped ? stopMessage ?? "Subagent stopped by user." : timeoutMessage ?? "Subagent timed out.") : finalOutput, outputState: finalOutput.trim() ? "present" : "absent", timedOut, stopped, turnBudget, turnBudgetExceeded, wrapUpRequested: turnBudget?.outcome === "wrap-up-requested" || turnBudget?.outcome === "termination-deferred" || turnBudgetExceeded || undefined, observedMutationAttempt, watchdog: childWatchdogState, processInstanceId });
+			resolve(withoutUndefined({ stderr, exitCode: 1, messages, usage, toolCount, durationMs: Date.now() - startedAt, model, error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? turnBudgetMessage : error ?? assistantError ?? spawnErrorMessage, protocolError, finalOutput: (timedOut || stopped) && !finalOutput.trim() ? (stopped ? stopMessage ?? "Subagent stopped by user." : timeoutMessage ?? "Subagent timed out.") : finalOutput, outputState: finalOutput.trim() ? "present" : "absent", timedOut, stopped, turnBudget, turnBudgetExceeded, wrapUpRequested: turnBudget?.outcome === "wrap-up-requested" || turnBudget?.outcome === "termination-deferred" || turnBudgetExceeded || undefined, observedMutationAttempt, watchdog: childWatchdogState, processInstanceId }));
 		});
 	});
 }
@@ -1056,7 +1085,7 @@ async function runSingleStep(
 				pid = undefined;
 			}
 			try {
-				deliverTimeoutRequest({ asyncDir: step.importAsyncRoot!.asyncDir, pid, source: "ancestor-timeout" });
+				deliverTimeoutRequest(withoutUndefined({ asyncDir: step.importAsyncRoot!.asyncDir, pid, source: "ancestor-timeout" }));
 			} catch {
 				// The parent runner's own timeout result is authoritative for the attached step.
 			}
@@ -1070,16 +1099,16 @@ async function runSingleStep(
 				pid = undefined;
 			}
 			try {
-				deliverStopRequest({ asyncDir: step.importAsyncRoot!.asyncDir, pid, source: "ancestor-stop" });
+				deliverStopRequest(withoutUndefined({ asyncDir: step.importAsyncRoot!.asyncDir, pid, source: "ancestor-stop" }));
 			} catch {
 				// The parent runner's own stopped result is authoritative for the attached step.
 			}
 		});
 		try {
-			const imported = await waitForImportedAsyncRoot(step.importAsyncRoot, {
+			const imported = await waitForImportedAsyncRoot(step.importAsyncRoot, withoutUndefined({
 				shouldAbort: () => importTimedOut || importStopped || ctx.timeoutSignal?.aborted === true || ctx.stopSignal?.aborted === true || ctx.skipAcceptance?.() === true,
 				timeoutMessage: importStopped || ctx.stopSignal?.aborted === true ? ctx.stopMessage : ctx.timeoutMessage,
-			});
+			}));
 			try {
 				fs.writeFileSync(ctx.outputFile, imported.output, "utf-8");
 			} catch {
@@ -1088,7 +1117,7 @@ async function runSingleStep(
 			const stopped = importStopped || imported.stopped === true || ctx.stopSignal?.aborted === true;
 			const timedOut = !stopped && (importTimedOut || imported.timedOut === true || ctx.timeoutSignal?.aborted === true || ctx.skipAcceptance?.() === true);
 			const message = stopped ? ctx.stopMessage ?? "Subagent stopped by user." : ctx.timeoutMessage ?? "Subagent timed out.";
-			return {
+			return withoutUndefined({
 				agent: imported.agent,
 				output: timedOut || stopped ? message : imported.output,
 				exitCode: timedOut || stopped ? 1 : imported.exitCode,
@@ -1105,7 +1134,7 @@ async function runSingleStep(
 				structuredOutputPath: timedOut || stopped ? undefined : imported.structuredOutputPath,
 				structuredOutputSchemaPath: timedOut || stopped ? undefined : imported.structuredOutputSchemaPath,
 				acceptance: timedOut || stopped ? undefined : imported.acceptance,
-			};
+			});
 		} finally {
 			ctx.registerTimeout?.(undefined);
 			ctx.registerStop?.(undefined);
@@ -1157,7 +1186,7 @@ async function runSingleStep(
 			capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false },
 		};
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
-		const external = await runExternalCli({
+		const external = await runExternalCli(withoutUndefined({
 			command: runner.command,
 			args: runner.args,
 			cwd: step.cwd ?? ctx.cwd,
@@ -1169,13 +1198,13 @@ async function runSingleStep(
 			timeoutMessage: ctx.timeoutMessage,
 			stopMessage: ctx.stopMessage,
 			onProcess: ctx.onExternalProcess,
-		});
+		}));
 		try { fs.writeFileSync(ctx.outputFile, external.output, "utf-8"); } catch { /* Observability output is best-effort. */ }
 		const resolvedOutput = step.outputPath && external.exitCode === 0
 			? resolveSingleOutput(step.outputPath, external.output, outputSnapshot)
 			: { fullOutput: external.output };
 		const outputReference = resolvedOutput.savedPath ? formatSavedOutputReference(resolvedOutput.savedPath, resolvedOutput.fullOutput) : undefined;
-		const finalizedOutput = finalizeSingleOutput({
+		const finalizedOutput = finalizeSingleOutput(withoutUndefined({
 			fullOutput: resolvedOutput.fullOutput,
 			outputPath: step.outputPath,
 			outputMode: step.outputMode,
@@ -1183,16 +1212,16 @@ async function runSingleStep(
 			savedPath: resolvedOutput.savedPath,
 			outputReference,
 			saveError: resolvedOutput.saveError,
-		});
+		}));
 		if (artifactPaths && ctx.artifactConfig?.enabled !== false) {
 			if (ctx.artifactConfig?.includeOutput !== false) {
-				fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent({ output: resolvedOutput.fullOutput, error: external.error, metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath }), "utf-8");
+				fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent(withoutUndefined({ output: resolvedOutput.fullOutput, error: external.error, metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath })), "utf-8");
 			}
 			if (ctx.artifactConfig?.includeMetadata !== false) {
 				fs.writeFileSync(artifactPaths.metadataPath, JSON.stringify({ runId: ctx.id, agent: step.agent, task, runner, externalProcess: external.externalProcess, exitCode: external.exitCode, error: external.error, timestamp: Date.now() }, null, 2), "utf-8");
 			}
 		}
-		return {
+		return withoutUndefined({
 			agent: step.agent,
 			context: step.context,
 			output: finalizedOutput.displayOutput,
@@ -1205,7 +1234,7 @@ async function runSingleStep(
 			artifactPaths,
 			runner,
 			externalProcess: external.externalProcess,
-		};
+		});
 	}
 
 	const candidates = step.modelCandidates && step.modelCandidates.length > 0
@@ -1234,7 +1263,7 @@ async function runSingleStep(
 	modelAttemptsLoop: while (modelIndex < candidates.length) {
 		if (ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break;
 		const candidate = candidates[modelIndex];
-		ctx.onAttemptStart?.({ model: candidate, thinking: resolveEffectiveThinking(candidate, step.thinking) });
+		ctx.onAttemptStart?.(withoutUndefined({ model: candidate, thinking: resolveEffectiveThinking(candidate, step.thinking) }));
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
 		if (effectiveStructuredOutput) {
 			try {
@@ -1252,7 +1281,7 @@ async function runSingleStep(
 				childIndex: ctx.flatIndex,
 			})
 			: undefined;
-		const { args, env, tempDir, toolDiagnosticPath, runtimeAcknowledgedExtensionsPath, capabilityAudit: attemptCapabilityAudit } = buildPiArgs({
+		const { args, env, tempDir, toolDiagnosticPath, runtimeAcknowledgedExtensionsPath, capabilityAudit: attemptCapabilityAudit } = buildPiArgs(withoutUndefined({
 			parentSessionId: step.parentSessionId,
 			baseArgs: ["--mode", "json", "-p"],
 			task,
@@ -1292,9 +1321,9 @@ async function runSingleStep(
 				: undefined,
 			childWatchdog,
 			waitToolEnabled: step.waitToolEnabled,
-		});
+		}));
 		if (step.definitionDigest) {
-			const toolPlan = resolvePiLaunchToolPlan({
+			const toolPlan = resolvePiLaunchToolPlan(withoutUndefined({
 				tools: step.tools,
 				extensions: step.extensions,
 				subagentOnlyExtensions: step.subagentOnlyExtensions,
@@ -1304,9 +1333,9 @@ async function runSingleStep(
 				structuredOutput: Boolean(effectiveStructuredOutput),
 				capabilityCeiling: step.capabilityCeiling ?? ctx.capabilityCeiling,
 				inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
-			});
+			}));
 			launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
-			actualLaunchContractDigest = launchBindingDigest({
+			actualLaunchContractDigest = launchBindingDigest(withoutUndefined({
 				definitionDigest: step.definitionDigest,
 				task: step.launchBindingTask ?? task,
 				...(candidate ? { model: candidate } : {}),
@@ -1323,7 +1352,7 @@ async function runSingleStep(
 				...(step.outputPath ? { outputPath: step.outputPath } : {}),
 				...(step.outputMode ? { outputMode: step.outputMode } : {}),
 				...(step.structuredOutputSchema ? { structuredOutputSchema: step.structuredOutputSchema } : {}),
-			});
+			}));
 		}
 		capabilityAudit = attemptCapabilityAudit;
 		writerAttemptCount += 1;
@@ -1406,13 +1435,13 @@ async function runSingleStep(
 		}
 		const completionGuardEnabled = isAgentContractV1(step.agentContract) ? step.completionGuard === true : step.completionGuard !== false;
 		const completionGuard = run.exitCode === 0 && !run.error && !toolAvailabilityError && !hiddenError?.hasError && !emptyOutputError && completionGuardEnabled
-			? evaluateCompletionMutationGuard({
+			? evaluateCompletionMutationGuard(withoutUndefined({
 				agent: step.agent,
 				task: taskForCompletionGuard,
 				messages: run.messages,
 				tools: step.tools,
 				mcpDirectTools: step.mcpDirectTools,
-			})
+			}))
 			: undefined;
 		const completionGuardTriggered = completionGuard?.triggered === true && !run.observedMutationAttempt;
 		const fileMutationEffect = completionGuard
@@ -1433,13 +1462,13 @@ async function runSingleStep(
 				: run.error && run.exitCode === 0
 					? 1
 					: run.exitCode;
-		const signalError = run.exitCode !== 0 && isUnexplainedProcessSignal({
+		const signalError = run.exitCode !== 0 && isUnexplainedProcessSignal(withoutUndefined({
 			processSignal: run.processSignal,
 			interrupted: run.interrupted,
 			timedOut: run.timedOut,
 			stopped: run.stopped,
 			turnBudgetExceeded: run.turnBudgetExceeded,
-		}) ? formatProcessSignalError(run.processSignal!) : undefined;
+		})) ? formatProcessSignalError(run.processSignal!) : undefined;
 		const error = toolAvailabilityError
 			?? completionGuardError
 			?? structuredError
@@ -1449,13 +1478,13 @@ async function runSingleStep(
 					? `${hiddenError.errorType} failed (exit ${effectiveExitCode}): ${hiddenError.details}`
 					: `${hiddenError.errorType} failed with exit code ${effectiveExitCode}`
 				: run.error || signalError || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined));
-		const attempt: ModelAttempt = {
+		const attempt: ModelAttempt = withoutUndefined({
 			model: candidate ?? run.model ?? step.model ?? "default",
 			success: effectiveExitCode === 0 && !error,
 			exitCode: effectiveExitCode,
 			error,
 			usage: run.usage,
-		};
+		});
 		modelAttempts.push(attempt);
 		if (candidate && startupAttemptIndex === 0) attemptedModels.push(candidate);
 		completionGuardTriggeredFinal = completionGuardTriggered;
@@ -1471,7 +1500,7 @@ async function runSingleStep(
 		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break modelAttemptsLoop;
 		if (attempt.success || completionGuardTriggered) break modelAttemptsLoop;
 
-		const startupFailure = isRetryableSubagentStartupFailure({
+		const startupFailure = isRetryableSubagentStartupFailure(withoutUndefined({
 			exitCode: effectiveExitCode,
 			error,
 			finalOutput: run.finalOutput,
@@ -1486,7 +1515,7 @@ async function runSingleStep(
 			timedOut: run.timedOut,
 			stopped: run.stopped,
 			turnBudgetExceeded: run.turnBudgetExceeded,
-		});
+		}));
 		const retryDelayMs = SUBAGENT_STARTUP_RETRY_DELAYS_MS[startupAttemptIndex];
 		if (startupFailure && retryDelayMs !== undefined) {
 			const retryNote = formatSubagentStartupRetryNote({
@@ -1551,7 +1580,7 @@ async function runSingleStep(
 		: resolvedOutput.savedPath
 			? "unknown"
 			: finalResult?.outputState ?? "unknown";
-	const finalizedOutput = finalizeSingleOutput({
+	const finalizedOutput = finalizeSingleOutput(withoutUndefined({
 		fullOutput: outputForSummary,
 		outputPath: step.outputPath,
 		outputMode: step.outputMode,
@@ -1559,10 +1588,10 @@ async function runSingleStep(
 		savedPath: resolvedOutput.savedPath,
 		outputReference,
 		saveError: resolvedOutput.saveError,
-	});
+	}));
 	outputForSummary = finalizedOutput.displayOutput;
 	const acceptance = step.effectiveAcceptance && !finalResult?.stopped && !finalResult?.turnBudgetExceeded && !ctx.timeoutSignal?.aborted && !ctx.stopSignal?.aborted && !ctx.skipAcceptance?.()
-		? await evaluateAcceptance({
+		? await evaluateAcceptance(withoutUndefined({
 			acceptance: step.effectiveAcceptance,
 			output: outputForAcceptance,
 			fileOutput: childWrittenOutput !== undefined && step.outputPath
@@ -1572,7 +1601,7 @@ async function runSingleStep(
 			signal: combinedAbortSignal([ctx.timeoutSignal, ctx.stopSignal]),
 			abortMessage: ctx.stopSignal?.aborted ? ctx.stopMessage ?? "Subagent stopped by user." : ctx.timeoutMessage ?? "Subagent timed out.",
 			reportOptional: isAgentContractV1(step.agentContract),
-		})
+		}))
 		: undefined;
 	const stoppedAfterAcceptance = finalResult?.stopped === true || ctx.stopSignal?.aborted === true;
 	const timedOutAfterAcceptance = !stoppedAfterAcceptance && (finalResult?.timedOut === true || ctx.timeoutSignal?.aborted === true);
@@ -1601,12 +1630,12 @@ async function runSingleStep(
 
 	if (artifactPaths && ctx.artifactConfig?.enabled !== false) {
 		if (ctx.artifactConfig?.includeOutput !== false) {
-			fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent({
+			fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent(withoutUndefined({
 				output,
 				error: effectiveFinalError,
 				transcriptPath: transcriptWriter ? artifactPaths.transcriptPath : undefined,
 				metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath,
-			}), "utf-8");
+			})), "utf-8");
 		}
 		if (ctx.artifactConfig?.includeMetadata !== false) {
 			fs.writeFileSync(
@@ -1635,7 +1664,7 @@ async function runSingleStep(
 		}
 	}
 
-	const result = {
+	const result: StepResult & { completionGuardTriggered?: boolean } = withoutUndefined({
 		agent: step.agent,
 		context: step.context,
 		...(step.agentContract ? { agentContract: step.agentContract } : {}),
@@ -1675,7 +1704,7 @@ async function runSingleStep(
 		...((finalResult as (RunPiStreamingResult & { runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1 }) | undefined)?.runtimeAcknowledgedExtensions ? { runtimeAcknowledgedExtensions: (finalResult as RunPiStreamingResult & { runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1 }).runtimeAcknowledgedExtensions } : {}),
 		writerProcesses,
 		writerAttemptCount,
-	};
+	});
 	return isAgentContractV1(step.agentContract) ? attachContractProjections(result as unknown as import("../../shared/types.ts").SingleResult) as unknown as typeof result : result;
 }
 
@@ -1752,7 +1781,7 @@ function markParallelGroupSetupFailure(input: {
 		statusStep.endedAt = input.failedAt;
 		statusStep.durationMs = 0;
 		statusStep.exitCode = 1;
-		input.results.push({ agent: task.agent, context: task.context, output: input.setupError, success: false, exitCode: 1, sessionFile: task.sessionFile });
+		input.results.push(withoutUndefined({ agent: task.agent, context: task.context, output: input.setupError, success: false, exitCode: 1, sessionFile: task.sessionFile }));
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.lastUpdate = input.failedAt;
@@ -1782,15 +1811,15 @@ function markParallelGroupRunning(input: {
 		const flatTaskIndex = input.groupStartFlatIndex + taskIndex;
 		const statusStep = requiredStatusStep(input.statusPayload, flatTaskIndex);
 		statusStep.status = "pending";
-		statusStep.startedAt = undefined;
-		statusStep.endedAt = undefined;
-		statusStep.durationMs = undefined;
-		statusStep.lastActivityAt = undefined;
-		statusStep.activityState = undefined;
-		statusStep.error = undefined;
+		delete statusStep.startedAt;
+		delete statusStep.endedAt;
+		delete statusStep.durationMs;
+		delete statusStep.lastActivityAt;
+		delete statusStep.activityState;
+		delete statusStep.error;
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
-	input.statusPayload.activityState = undefined;
+	delete input.statusPayload.activityState;
 	input.statusPayload.lastActivityAt = input.groupStartTime;
 	input.statusPayload.lastUpdate = input.groupStartTime;
 	input.statusPayload.outputFile = path.join(input.asyncDir, `output-${input.groupStartFlatIndex}.log`);
@@ -1812,8 +1841,9 @@ function prepareParallelTaskRun(
 	taskIndex: number,
 ): { taskForRun: SubagentStep; taskCwd: string } {
 	if (!worktreeSetup) return { taskForRun: task, taskCwd: cwd };
+	const { cwd: _taskCwd, ...taskForRun } = task;
 	return {
-		taskForRun: { ...task, cwd: undefined },
+		taskForRun,
 		taskCwd: worktreeSetup.worktrees[taskIndex]!.agentCwd,
 	};
 }
@@ -1919,7 +1949,7 @@ async function runSubagent(
 	for (let stepIndex = 0; stepIndex < steps.length; stepIndex++) {
 		const step = steps[stepIndex]!;
 		if (isCheckpointRunnerStep(step)) {
-			initialStatusSteps.push({
+			initialStatusSteps.push(withoutUndefined({
 				agent: `checkpoint:${step.checkpoint}`,
 				phase: step.phase,
 				label: step.label ?? step.checkpoint,
@@ -1927,7 +1957,7 @@ async function runSubagent(
 				checkpoint: { name: step.checkpoint, ...(step.message ? { message: step.message } : {}), status: "pending", stepIndex },
 				recentTools: [],
 				recentOutput: [],
-			});
+			}));
 			flatStepCount++;
 			continue;
 		}
@@ -1935,8 +1965,8 @@ async function runSubagent(
 			parallelGroups.push({ start: flatStepCount, count: step.parallel.length, stepIndex });
 			for (const task of step.parallel) {
 				const taskFlatIndex = flatStepCount;
-				const transcriptPath = resolveAsyncStepTranscriptPath({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: taskFlatIndex, flatStepCount: initialFlatStepCount });
-				initialStatusSteps.push({
+				const transcriptPath = resolveAsyncStepTranscriptPath(withoutUndefined({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: taskFlatIndex, flatStepCount: initialFlatStepCount }));
+				initialStatusSteps.push(withoutUndefined({
 					agent: task.agent,
 					...(externalRunnerStatus(task.runner) ? { runner: externalRunnerStatus(task.runner) } : {}),
 					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
@@ -1959,12 +1989,12 @@ async function runSubagent(
 					attemptedModels: task.modelCandidates && task.modelCandidates.length > 0 ? task.modelCandidates : task.model ? [task.model] : undefined,
 					recentTools: [],
 					recentOutput: [],
-				});
+				}));
 				flatStepCount++;
 			}
 		} else if (isDynamicRunnerGroup(step)) {
 			parallelGroups.push({ start: flatStepCount, count: 1, stepIndex });
-			initialStatusSteps.push({
+			initialStatusSteps.push(withoutUndefined({
 				agent: `expand:${step.parallel.agent}`,
 				...(externalRunnerStatus(step.parallel.runner) ? { runner: externalRunnerStatus(step.parallel.runner) } : {}),
 				...(step.parallel.context ? { context: step.parallel.context } : {}),
@@ -1978,12 +2008,12 @@ async function runSubagent(
 				...(step.parallel.toolBudget ? { toolBudget: initialToolBudgetState(step.parallel.toolBudget) } : {}),
 				recentTools: [],
 				recentOutput: [],
-			});
+			}));
 			flatStepCount++;
 		} else {
 			const stepFlatIndex = flatStepCount;
-			const transcriptPath = resolveAsyncStepTranscriptPath({ artifactsDir, artifactConfig, runId: id, agent: step.agent, flatIndex: stepFlatIndex, flatStepCount: initialFlatStepCount });
-			initialStatusSteps.push({
+			const transcriptPath = resolveAsyncStepTranscriptPath(withoutUndefined({ artifactsDir, artifactConfig, runId: id, agent: step.agent, flatIndex: stepFlatIndex, flatStepCount: initialFlatStepCount }));
+			initialStatusSteps.push(withoutUndefined({
 				agent: step.agent,
 				...(externalRunnerStatus(step.runner) ? { runner: externalRunnerStatus(step.runner) } : {}),
 				...(statusStepDescription(step.task) ? { description: statusStepDescription(step.task) } : {}),
@@ -2006,7 +2036,7 @@ async function runSubagent(
 				attemptedModels: step.modelCandidates && step.modelCandidates.length > 0 ? step.modelCandidates : step.model ? [step.model] : undefined,
 				recentTools: [],
 				recentOutput: [],
-			});
+			}));
 			flatStepCount++;
 		}
 	}
@@ -2018,7 +2048,7 @@ async function runSubagent(
 			step.processTerminal = { version: 1, state: "pending", runId: id, runnerProcessInstanceId: config.runnerProcessInstanceId };
 		}
 	}
-	const statusPayload: RunnerStatusPayload = {
+	const statusPayload: RunnerStatusPayload = withoutUndefined({
 		lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
 		runId: id,
 		...(config.sessionId ? { sessionId: config.sessionId } : {}),
@@ -2050,7 +2080,7 @@ async function runSubagent(
 		artifactsDir,
 		sessionDir: config.sessionDir,
 		outputFile: path.join(asyncDir, "output-0.log"),
-	};
+	});
 
 	fs.mkdirSync(asyncDir, { recursive: true });
 	writeAtomicJson(statusPath, statusPayload);
@@ -2068,18 +2098,18 @@ async function runSubagent(
 		};
 	};
 	const refreshUsageBudget = () => {
-		statusPayload.usageBudget = usageBudgetState(config.usageBudget, currentUsageTotals());
+		setOptionalProperty(statusPayload, "usageBudget", usageBudgetState(config.usageBudget, currentUsageTotals()));
 		return statusPayload.usageBudget;
 	};
 	const emitNestedSelfEvent = (type: "subagent.nested.updated" | "subagent.nested.completed"): void => {
 		if (!config.nestedRoute || !config.nestedSelf) return;
 		try {
-			writeNestedEvent(config.nestedRoute, {
+			writeNestedEvent(config.nestedRoute, withoutUndefined({
 				type,
 				ts: Date.now(),
 				parentRunId: config.nestedSelf.parentRunId,
 				parentStepIndex: config.nestedSelf.parentStepIndex,
-				child: nestedSummaryFromAsyncStatus(statusPayload, asyncDir, {
+				child: nestedSummaryFromAsyncStatus(statusPayload, asyncDir, withoutUndefined({
 					id,
 					parentRunId: config.nestedSelf.parentRunId,
 					parentStepIndex: config.nestedSelf.parentStepIndex,
@@ -2087,8 +2117,8 @@ async function runSubagent(
 					path: config.nestedSelf.path,
 					mode: statusPayload.mode,
 					ts: Date.now(),
-				}),
-			});
+				})),
+			}));
 		} catch (error) {
 			console.error("Failed to emit nested async status event:", error);
 		}
@@ -2106,9 +2136,9 @@ async function runSubagent(
 				const step = statusPayload.steps[node.flatIndex];
 				if (step) {
 					node.status = normalize(step.status);
-					node.error = step.error;
-					node.acceptanceStatus = step.acceptance?.status;
-					node.checkpoint = step.checkpoint;
+					setOptionalProperty(node, "error", step.error);
+					setOptionalProperty(node, "acceptanceStatus", step.acceptance?.status);
+					setOptionalProperty(node, "checkpoint", step.checkpoint);
 				}
 				if (statusPayload.currentStep === node.flatIndex) graph.currentNodeId = node.id;
 			}
@@ -2202,7 +2232,7 @@ async function runSubagent(
 			const nestedAsyncDir = run.asyncDir ?? resolveNestedAsyncDir(config.nestedRoute.rootRunId, run);
 			if (!nestedAsyncDir) continue;
 			try {
-				deliverInterruptRequest({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-interrupt" });
+				deliverInterruptRequest(withoutUndefined({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-interrupt" }));
 			} catch (error) {
 				appendJsonl(eventsPath, JSON.stringify({
 					type: "subagent.nested.interrupt_failed",
@@ -2233,7 +2263,7 @@ async function runSubagent(
 			const nestedAsyncDir = run.asyncDir ?? resolveNestedAsyncDir(config.nestedRoute.rootRunId, run);
 			if (!nestedAsyncDir) continue;
 			try {
-				deliverStopRequest({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-stop" });
+				deliverStopRequest(withoutUndefined({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-stop" }));
 			} catch (error) {
 				appendJsonl(eventsPath, JSON.stringify({
 					type: "subagent.nested.stop_failed",
@@ -2264,7 +2294,7 @@ async function runSubagent(
 			const nestedAsyncDir = run.asyncDir ?? resolveNestedAsyncDir(config.nestedRoute.rootRunId, run);
 			if (!nestedAsyncDir) continue;
 			try {
-				deliverTimeoutRequest({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-timeout" });
+				deliverTimeoutRequest(withoutUndefined({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-timeout" }));
 			} catch (error) {
 				appendJsonl(eventsPath, JSON.stringify({
 					type: "subagent.nested.timeout_failed",
@@ -2276,14 +2306,14 @@ async function runSubagent(
 			}
 		}
 	};
-	const pausedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => ({
+	const pausedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => withoutUndefined({
 		agent,
 		context,
 		output: "Paused after interrupt. Waiting for explicit next action.",
 		exitCode: 0,
 		interrupted: true,
 	});
-	const timedOutStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => ({
+	const timedOutStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => withoutUndefined({
 		agent,
 		context,
 		output: timeoutMessage ?? "Subagent timed out.",
@@ -2291,7 +2321,7 @@ async function runSubagent(
 		exitCode: 1,
 		timedOut: true,
 	});
-	const stoppedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => ({
+	const stoppedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => withoutUndefined({
 		agent,
 		context,
 		output: stopMessage,
@@ -2342,8 +2372,8 @@ async function runSubagent(
 		const groupNode = statusPayload.workflowGraph?.nodes.find((node) => node.id === `step-${stepIndex}`);
 		if (!groupNode) return;
 		groupNode.status = status;
-		groupNode.error = error;
-		groupNode.acceptanceStatus = acceptance?.status ?? groupNode.acceptanceStatus;
+		setOptionalProperty(groupNode, "error", error);
+		setOptionalProperty(groupNode, "acceptanceStatus", acceptance?.status ?? groupNode.acceptanceStatus);
 	};
 
 	const stepOutputActivityAt = (index: number): number => {
@@ -2390,9 +2420,9 @@ async function runSubagent(
 		const activeStep = statusPayload.steps
 			.filter((step) => step.status === "running" && typeof step.currentTool === "string" && step.currentTool.length > 0)
 			.sort((left, right) => (right.currentToolStartedAt ?? 0) - (left.currentToolStartedAt ?? 0))[0];
-		statusPayload.currentTool = activeStep?.currentTool;
-		statusPayload.currentToolStartedAt = activeStep?.currentToolStartedAt;
-		statusPayload.currentPath = activeStep?.currentPath;
+		setOptionalProperty(statusPayload, "currentTool", activeStep?.currentTool);
+		setOptionalProperty(statusPayload, "currentToolStartedAt", activeStep?.currentToolStartedAt);
+		setOptionalProperty(statusPayload, "currentPath", activeStep?.currentPath);
 	};
 	const syncAggregateActivityState = (): void => {
 		const nextRunState = statusPayload.steps.some((step) => step.activityState === "needs_attention")
@@ -2401,7 +2431,7 @@ async function runSubagent(
 				? "active_long_running"
 				: undefined;
 		currentActivityState = nextRunState;
-		statusPayload.activityState = nextRunState;
+		setOptionalProperty(statusPayload, "activityState", nextRunState);
 	};
 	const maybeEmitActiveLongRunning = (flatIndex: number, now: number): boolean => {
 		if (!controlConfig.enabled || activeLongRunningSteps.has(flatIndex)) return false;
@@ -2418,7 +2448,7 @@ async function runSubagent(
 		const previous = step.activityState;
 		step.activityState = "active_long_running";
 		statusPayload.activityState = statusPayload.activityState === "needs_attention" ? "needs_attention" : "active_long_running";
-		const event = buildControlEvent({
+		const event = buildControlEvent(withoutUndefined({
 			type: "active_long_running",
 			from: previous,
 			to: "active_long_running",
@@ -2435,7 +2465,7 @@ async function runSubagent(
 			currentToolDurationMs: step.currentToolStartedAt ? Math.max(0, now - step.currentToolStartedAt) : undefined,
 			currentPath: step.currentPath,
 			elapsedMs: now - (step.startedAt ?? overallStartTime),
-		});
+		}));
 		appendControlEvent(event);
 		return true;
 	};
@@ -2453,12 +2483,12 @@ async function runSubagent(
 	};
 	const recordSteeringLifecycle = (request: SteerRequest, targets: Array<{ index: number; state: SteeringTargetState; reason?: string }>): void => {
 		const lifecycle = steeringStatus(statusPayload);
-		recordSteeringRequest(lifecycle, { id: request.id, requestedAt: request.ts, source: request.source, message: request.message, targets });
+		recordSteeringRequest(lifecycle, withoutUndefined({ id: request.id, requestedAt: request.ts, source: request.source, message: request.message, targets }));
 		for (const target of targets) {
 			const step = statusPayload.steps[target.index];
 			if (!step) continue;
 			step.steering ??= createSteeringStatus();
-			recordSteeringRequest(step.steering, { id: request.id, requestedAt: request.ts, source: request.source, message: request.message, targets: [target] });
+			recordSteeringRequest(step.steering, withoutUndefined({ id: request.id, requestedAt: request.ts, source: request.source, message: request.message, targets: [target] }));
 		}
 	};
 	const updateSteeringLifecycleTarget = (
@@ -2548,7 +2578,7 @@ async function runSubagent(
 		const late = fs.existsSync(steeringMarkerPath(ack.requestId));
 		const now = Date.now();
 		if (ack.state === "delivered") {
-			updateSteeringLifecycleTarget(ack.requestId, ack.index, late ? "late" : "delivered", now, { reason: late ? "acknowledged after recovery commit" : undefined });
+			updateSteeringLifecycleTarget(ack.requestId, ack.index, late ? "late" : "delivered", now, withoutUndefined({ reason: late ? "acknowledged after recovery commit" : undefined }));
 			emitSteeringEvent("subagent.steer.delivered", { type: "steer", id: ack.requestId, ts: now, message: ack.message }, ack.index, { late, message: ack.message });
 		} else {
 			markSteeringAttention(ack.index);
@@ -2571,8 +2601,8 @@ async function runSubagent(
 	const updateStepModel = (flatIndex: number, model: string | undefined, thinking: string | undefined, now = Date.now()): void => {
 		const step = statusPayload.steps[flatIndex];
 		if (!step) return;
-		step.model = model;
-		step.thinking = thinking;
+		setOptionalProperty(step, "model", model);
+		setOptionalProperty(step, "thinking", thinking);
 		statusPayload.lastUpdate = now;
 		writeStatusPayload();
 	};
@@ -2669,8 +2699,8 @@ async function runSubagent(
 			step.currentTool = event.toolName;
 			step.currentToolArgs = extractToolArgsPreview(event.args ?? {});
 			step.currentToolStartedAt = now;
-			step.currentPath = currentPath;
-			pendingToolResults[flatIndex] = { tool: event.toolName, path: currentPath, mutates, startedAt: now };
+			setOptionalProperty(step, "currentPath", currentPath);
+			pendingToolResults[flatIndex] = withoutUndefined({ tool: event.toolName, path: currentPath, mutates, startedAt: now });
 			statusPayload.toolCount = (statusPayload.toolCount ?? 0) + 1;
 			syncTopLevelCurrentTool();
 			if (controlConfig.enabled && isBlockingSupervisorTool(event.toolName, event.args) && step.activityState !== "needs_attention") {
@@ -2679,7 +2709,7 @@ async function runSubagent(
 				supervisorAttentionSteps.set(flatIndex, previous);
 				currentActivityState = "needs_attention";
 				statusPayload.activityState = "needs_attention";
-				appendControlEvent(buildControlEvent({
+				appendControlEvent(buildControlEvent(withoutUndefined({
 					type: "needs_attention",
 					from: previous,
 					to: "needs_attention",
@@ -2695,7 +2725,7 @@ async function runSubagent(
 					currentTool: step.currentTool,
 					currentToolDurationMs: 0,
 					currentPath: step.currentPath,
-				}));
+				})));
 			}
 		} else if (event.type === "tool_execution_end") {
 			if (step.currentTool) {
@@ -2704,12 +2734,12 @@ async function runSubagent(
 			}
 			const supervisorPreviousActivity = supervisorAttentionSteps.get(flatIndex);
 			const clearedSupervisorAttention = supervisorAttentionSteps.delete(flatIndex);
-			step.currentTool = undefined;
-			step.currentToolArgs = undefined;
-			step.currentToolStartedAt = undefined;
-			step.currentPath = undefined;
+			delete step.currentTool;
+			delete step.currentToolArgs;
+			delete step.currentToolStartedAt;
+			delete step.currentPath;
 			if (clearedSupervisorAttention && step.activityState === "needs_attention") {
-				step.activityState = supervisorPreviousActivity;
+				setOptionalProperty(step, "activityState", supervisorPreviousActivity);
 				syncAggregateActivityState();
 			}
 			syncTopLevelCurrentTool();
@@ -2729,17 +2759,17 @@ async function runSubagent(
 			appendRecentStepOutput(step, resultText.split("\n").slice(-10));
 			if (toolSnapshot?.mutates && didMutatingToolFail(resultText)) {
 				const state = mutatingFailureStates[flatIndex]!;
-				recordMutatingFailure(state, {
+				recordMutatingFailure(state, withoutUndefined({
 					tool: toolSnapshot.tool,
 					path: toolSnapshot.path,
 					error: resultText.split("\n").find((line) => line.trim())?.trim().slice(0, 180) ?? "mutating tool failed",
 					ts: now,
-				}, mutatingFailureWindowMs);
+				}), mutatingFailureWindowMs);
 				if (controlConfig.enabled && shouldEscalateMutatingFailures(state, controlConfig.failedToolAttemptsBeforeAttention) && step.activityState !== "needs_attention") {
 					const previous = step.activityState;
 					step.activityState = "needs_attention";
 					statusPayload.activityState = "needs_attention";
-					appendControlEvent(buildControlEvent({
+					appendControlEvent(buildControlEvent(withoutUndefined({
 						type: "needs_attention",
 						from: previous,
 						to: "needs_attention",
@@ -2756,7 +2786,7 @@ async function runSubagent(
 						currentToolDurationMs: toolSnapshot.startedAt ? Math.max(0, now - toolSnapshot.startedAt) : undefined,
 						currentPath: toolSnapshot.path,
 						recentFailureSummary: summarizeRecentMutatingFailures(state),
-					}));
+					})));
 				}
 			} else if (toolSnapshot?.mutates) {
 				resetMutatingFailureState(mutatingFailureStates[flatIndex]!);
@@ -2805,18 +2835,18 @@ async function runSubagent(
 				step.lastActivityAt = lastActivityAt;
 				changed = true;
 			}
-			const idleState = deriveActivityState({
+			const idleState = deriveActivityState(withoutUndefined({
 				config: controlConfig,
 				startedAt: step.startedAt ?? overallStartTime,
 				lastActivityAt,
 				currentTool: step.currentTool,
 				now,
-			});
+			}));
 			if (idleState === "needs_attention") {
 				const previous = step.activityState;
 				step.activityState = "needs_attention";
 				if (previous !== "needs_attention") {
-					appendControlEvent(buildControlEvent({
+					appendControlEvent(buildControlEvent(withoutUndefined({
 						from: previous,
 						to: "needs_attention",
 						runId: id,
@@ -2824,7 +2854,7 @@ async function runSubagent(
 						index,
 						ts: now,
 						lastActivityAt,
-					}));
+					})));
 					changed = true;
 				}
 			} else if (maybeEmitActiveLongRunning(index, now)) {
@@ -2842,7 +2872,7 @@ async function runSubagent(
 				: undefined;
 		if (nextRunState !== currentActivityState) {
 			currentActivityState = nextRunState;
-			statusPayload.activityState = nextRunState;
+			setOptionalProperty(statusPayload, "activityState", nextRunState);
 			changed = true;
 		}
 		statusPayload.lastUpdate = now;
@@ -2865,14 +2895,14 @@ async function runSubagent(
 		const now = Date.now();
 		statusPayload.state = "paused";
 		currentActivityState = undefined;
-		statusPayload.activityState = undefined;
+		delete statusPayload.activityState;
 		statusPayload.lastUpdate = now;
 		for (const step of statusPayload.steps) {
 			if (step.status === "running") {
 				step.status = "paused";
-				step.activityState = undefined;
+				delete step.activityState;
 				step.endedAt = now;
-				step.durationMs = step.startedAt ? now - step.startedAt : undefined;
+				setOptionalProperty(step, "durationMs", step.startedAt ? now - step.startedAt : undefined);
 				step.lastActivityAt = now;
 			}
 		}
@@ -2893,7 +2923,7 @@ async function runSubagent(
 		statusPayload.stopped = true;
 		statusPayload.error = stopMessage;
 		currentActivityState = undefined;
-		statusPayload.activityState = undefined;
+		delete statusPayload.activityState;
 		statusPayload.lastUpdate = now;
 		for (const step of statusPayload.steps) {
 			if (step.status !== "running" && step.status !== "pending") continue;
@@ -2901,7 +2931,7 @@ async function runSubagent(
 			step.error = stopMessage;
 			step.exitCode = 1;
 			step.stopped = true;
-			step.activityState = undefined;
+			delete step.activityState;
 			step.endedAt = now;
 			step.durationMs = step.startedAt ? now - step.startedAt : 0;
 			step.lastActivityAt = now;
@@ -2926,7 +2956,7 @@ async function runSubagent(
 		statusPayload.timedOut = true;
 		statusPayload.error = message;
 		currentActivityState = undefined;
-		statusPayload.activityState = undefined;
+		delete statusPayload.activityState;
 		statusPayload.lastUpdate = now;
 		for (const step of statusPayload.steps) {
 			if (step.status !== "running" && step.status !== "pending") continue;
@@ -2934,7 +2964,7 @@ async function runSubagent(
 			step.error = message;
 			step.exitCode = 1;
 			step.timedOut = true;
-			step.activityState = undefined;
+			delete step.activityState;
 			step.endedAt = now;
 			step.durationMs = step.startedAt ? now - step.startedAt : 0;
 			step.lastActivityAt = now;
@@ -3052,7 +3082,7 @@ async function runSubagent(
 			statusPayload.state = "paused";
 			statusPayload.currentStep = flatIndex;
 			statusPayload.checkpoint = checkpoint;
-			statusPayload.activityState = undefined;
+			delete statusPayload.activityState;
 			statusPayload.lastUpdate = now;
 			if (statusStep) {
 				statusStep.status = "paused";
@@ -3107,7 +3137,7 @@ async function runSubagent(
 			const groupStartFlatIndex = flatIndex;
 			let materialized: ReturnType<typeof materializeDynamicParallelStep>;
 			try {
-				materialized = materializeDynamicParallelStep(step as Parameters<typeof materializeDynamicParallelStep>[0], outputs, stepIndex, { maxItems: config.dynamicFanoutMaxItems, allowRunnerFields: true });
+				materialized = materializeDynamicParallelStep(step as Parameters<typeof materializeDynamicParallelStep>[0], outputs, stepIndex, withoutUndefined({ maxItems: config.dynamicFanoutMaxItems, allowRunnerFields: true }));
 				if (materialized.parallel.length > 1 && step.parallel.outputPath && !step.parallel.namespaceOutputPath) {
 					throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} materialized ${materialized.parallel.length} items that resolve output to the same path: ${step.parallel.outputPath}. Remove the explicit output path or use an inherited relative agent output so each item can be isolated.`);
 				}
@@ -3130,11 +3160,11 @@ async function runSubagent(
 				statusPayload.lastUpdate = now;
 				markDynamicGraphGroup(stepIndex, "failed", message);
 				writeStatusPayload();
-				results.push({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1 });
+				results.push(withoutUndefined({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1 }));
 				break;
 			}
 
-			const effectiveDynamicGroupAcceptance = resolveEffectiveAcceptance({
+			const effectiveDynamicGroupAcceptance = resolveEffectiveAcceptance(withoutUndefined({
 				explicit: step.acceptanceInput,
 				agentName: step.parallel.agent,
 				acceptanceRole: step.acceptanceRole,
@@ -3143,7 +3173,7 @@ async function runSubagent(
 				async: true,
 				dynamicGroup: true,
 				agentContract: step.agentContract,
-			});
+			}));
 
 			if (materialized.parallel.length === 0) {
 				const now = Date.now();
@@ -3164,7 +3194,7 @@ async function runSubagent(
 				}
 				previousOutput = "Dynamic fanout produced 0 results.";
 				const groupAcceptance = effectiveDynamicGroupAcceptance.explicit && !timedOut && !stopped
-					? await evaluateAcceptance({
+					? await evaluateAcceptance(withoutUndefined({
 						acceptance: effectiveDynamicGroupAcceptance,
 						output: "",
 						report: aggregateAcceptanceReport({
@@ -3175,7 +3205,7 @@ async function runSubagent(
 						signal: combinedAbortSignal([timeoutAbortController.signal, stopAbortController.signal]),
 						abortMessage: stopAbortController.signal.aborted ? stopMessage : timeoutMessage ?? "Subagent timed out.",
 						reportOptional: isAgentContractV1(step.agentContract),
-					})
+					}))
 					: undefined;
 				const groupStopped = stopped || stopAbortController.signal.aborted;
 				const groupTimedOut = !groupStopped && (timedOut || timeoutAbortController.signal.aborted);
@@ -3186,18 +3216,18 @@ async function runSubagent(
 					const errorMessage = groupStopped ? stopMessage : groupTimedOut ? timeoutMessage ?? "Subagent timed out." : groupAcceptanceFailure!;
 					statusPayload.state = groupStopped ? "stopped" : "failed";
 					statusPayload.error = errorMessage;
-					statusPayload.stopped = groupStopped ? true : statusPayload.stopped;
+					setOptionalProperty(statusPayload, "stopped", groupStopped ? true : statusPayload.stopped);
 					if (placeholder) {
 						placeholder.status = groupStopped ? "stopped" : "failed";
 						placeholder.error = errorMessage;
 						placeholder.exitCode = 1;
-						placeholder.timedOut = groupTimedOut ? true : undefined;
-						placeholder.stopped = groupStopped ? true : undefined;
+						setOptionalProperty(placeholder, "timedOut", groupTimedOut ? true : undefined);
+						setOptionalProperty(placeholder, "stopped", groupStopped ? true : undefined);
 					}
 					markDynamicGraphGroup(stepIndex, groupStopped ? "stopped" : "failed", errorMessage, effectiveGroupAcceptance);
 					statusPayload.lastUpdate = Date.now();
 					writeStatusPayload();
-					results.push({ agent: step.parallel.agent, context: step.parallel.context, output: errorMessage, error: errorMessage, success: false, exitCode: 1, timedOut: groupTimedOut ? true : undefined, stopped: groupStopped ? true : undefined, acceptance: effectiveGroupAcceptance });
+					results.push(withoutUndefined({ agent: step.parallel.agent, context: step.parallel.context, output: errorMessage, error: errorMessage, success: false, exitCode: 1, timedOut: groupTimedOut ? true : undefined, stopped: groupStopped ? true : undefined, acceptance: effectiveGroupAcceptance }));
 					break;
 				}
 				flatIndex++;
@@ -3216,10 +3246,10 @@ async function runSubagent(
 					: step.parallel.outputPath;
 				const taskText = task.task ?? step.parallel.task;
 				const materializedTask = step.parallel.namespaceOutputPath ? injectSingleOutputInstruction(taskText, outputPath, step.parallel) : taskText;
-				return {
+				return withoutUndefined({
 					...step.parallel,
 					task: materializedTask,
-					effectiveAcceptance: resolveEffectiveAcceptance({
+					effectiveAcceptance: resolveEffectiveAcceptance(withoutUndefined({
 						explicit: step.parallel.acceptanceInput,
 						agentName: step.parallel.agent,
 						acceptanceRole: step.parallel.acceptanceRole,
@@ -3228,7 +3258,7 @@ async function runSubagent(
 						async: true,
 						dynamic: step.parallel.acceptanceInput === undefined,
 						agentContract: step.parallel.agentContract ?? step.agentContract,
-					}),
+					})),
 					systemPrompt: step.parallel.namespaceOutputPath ? injectOutputPathSystemPrompt(step.parallel.systemPrompt ?? "", outputPath, step.parallel) : step.parallel.systemPrompt,
 					outputPath,
 					label: task.label ?? step.parallel.label,
@@ -3242,12 +3272,12 @@ async function runSubagent(
 						}) } : {}),
 					} : {}),
 					structuredOutputSchema: step.parallel.structuredOutputSchema ?? step.parallel.structuredOutput?.schema,
-				};
+				});
 			});
 			const dynamicFlatStepCount = Math.max(statusPayload.steps.length - 1 + dynamicSteps.length, 1);
 			const dynamicStatusSteps: RunnerStatusStep[] = dynamicSteps.map((task, itemIndex) => {
-				const transcriptPath = resolveAsyncStepTranscriptPath({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: groupStartFlatIndex + itemIndex, flatStepCount: dynamicFlatStepCount });
-				return {
+				const transcriptPath = resolveAsyncStepTranscriptPath(withoutUndefined({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: groupStartFlatIndex + itemIndex, flatStepCount: dynamicFlatStepCount }));
+				return withoutUndefined({
 					agent: task.agent,
 					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
 					...(task.context ? { context: task.context } : {}),
@@ -3266,7 +3296,7 @@ async function runSubagent(
 					...(task.modelCandidates && task.modelCandidates.length > 0 ? { attemptedModels: task.modelCandidates } : task.model ? { attemptedModels: [task.model] } : {}),
 					recentTools: [],
 					recentOutput: [],
-				};
+				});
 			});
 			statusPayload.steps.splice(groupStartFlatIndex, 1, ...dynamicStatusSteps);
 			if (config.childIntercomTargets) {
@@ -3295,7 +3325,7 @@ async function runSubagent(
 				shiftFlatIndexes(statusPayload.workflowGraph.nodes);
 				const groupNode = statusPayload.workflowGraph.nodes.find((node) => node.id === `step-${stepIndex}`);
 				if (groupNode) {
-					groupNode.children = materialized.items.map((item, itemIndex) => ({
+					groupNode.children = materialized.items.map((item, itemIndex) => withoutUndefined({
 						id: `step-${stepIndex}-item-${item.idKey}`,
 						kind: "agent",
 						agent: step.parallel.agent,
@@ -3314,7 +3344,7 @@ async function runSubagent(
 			const concurrency = step.concurrency ?? MAX_PARALLEL_CONCURRENCY;
 			const failFast = step.failFast ?? false;
 			let aborted = false;
-			const parallelResults = await mapConcurrent(dynamicSteps, concurrency, async (task, taskIdx) => {
+			const parallelResults = await mapConcurrent(dynamicSteps, concurrency, async (task, taskIdx): Promise<StepResult> => {
 				const fi = groupStartFlatIndex + taskIdx;
 				refreshUsageBudget();
 				if (statusPayload.usageBudget?.exhausted) {
@@ -3330,7 +3360,7 @@ async function runSubagent(
 					usageBudgetExceeded = true;
 					writeStatusPayload();
 					appendJsonl(eventsPath, JSON.stringify({ type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: 1, durationMs: 0 }));
-					return { agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true };
+					return withoutUndefined({ agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
 				}
 				if (timedOut) return timedOutStepResult(task.agent, task.context);
 				if (stopped) return stoppedStepResult(task.agent, task.context);
@@ -3345,13 +3375,13 @@ async function runSubagent(
 					requiredStatusStep(statusPayload, fi).exitCode = -1;
 					statusPayload.lastUpdate = skippedAt;
 					writeStatusPayload();
-					return { agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true };
+					return withoutUndefined({ agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
 				}
 				const taskStartTime = Date.now();
 				statusPayload.currentStep = fi;
 				requiredStatusStep(statusPayload, fi).status = "running";
-				requiredStatusStep(statusPayload, fi).error = undefined;
-				requiredStatusStep(statusPayload, fi).activityState = undefined;
+				delete requiredStatusStep(statusPayload, fi).error;
+				delete requiredStatusStep(statusPayload, fi).activityState;
 				resetStepLiveDetail(requiredStatusStep(statusPayload, fi));
 				requiredStatusStep(statusPayload, fi).startedAt = taskStartTime;
 				requiredStatusStep(statusPayload, fi).lastActivityAt = taskStartTime;
@@ -3361,7 +3391,7 @@ async function runSubagent(
 				writeStatusPayload();
 				appendJsonl(eventsPath, JSON.stringify({ type: "subagent.step.started", ts: taskStartTime, runId: id, stepIndex: fi, agent: task.agent }));
 				flushPendingStepSteers(fi);
-				const singleResult = await runSingleStep(task, {
+				const singleResult = await runSingleStep(task, compactOptional<SingleStepContext>({
 					previousOutput, placeholder, cwd, sessionEnabled,
 					outputs,
 					sessionDir: config.sessionDir ? path.join(config.sessionDir, `dynamic-${stepIndex}-${taskIdx}`) : undefined,
@@ -3391,7 +3421,7 @@ async function runSubagent(
 					onWriterProcess,
 					onExternalProcess: (process) => updateExternalProcess(fi, process),
 					skipAcceptance: () => timedOut || stopped,
-				});
+				}));
 				const taskEndTime = Date.now();
 				const childInterrupted = singleResult.interrupted === true;
 				const childStopped = singleResult.stopped === true;
@@ -3399,23 +3429,23 @@ async function runSubagent(
 				requiredStatusStep(statusPayload, fi).endedAt = taskEndTime;
 				requiredStatusStep(statusPayload, fi).durationMs = taskEndTime - taskStartTime;
 				requiredStatusStep(statusPayload, fi).exitCode = stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode;
-				requiredStatusStep(statusPayload, fi).timedOut = timedOut || singleResult.timedOut ? true : undefined;
-				requiredStatusStep(statusPayload, fi).stopped = stopped || childStopped ? true : undefined;
-				requiredStatusStep(statusPayload, fi).turnBudget = singleResult.turnBudget;
-				requiredStatusStep(statusPayload, fi).turnBudgetExceeded = singleResult.turnBudgetExceeded;
-				requiredStatusStep(statusPayload, fi).wrapUpRequested = singleResult.wrapUpRequested;
-				requiredStatusStep(statusPayload, fi).toolBudget = singleResult.toolBudget;
-				requiredStatusStep(statusPayload, fi).toolBudgetBlocked = singleResult.toolBudgetBlocked;
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "timedOut", timedOut || singleResult.timedOut ? true : undefined);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "stopped", stopped || childStopped ? true : undefined);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "turnBudget", singleResult.turnBudget);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "turnBudgetExceeded", singleResult.turnBudgetExceeded);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "wrapUpRequested", singleResult.wrapUpRequested);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "toolBudget", singleResult.toolBudget);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "toolBudgetBlocked", singleResult.toolBudgetBlocked);
 				if (singleResult.toolBudget) statusPayload.toolBudget = singleResult.toolBudget;
 				if (singleResult.toolBudgetBlocked) statusPayload.toolBudgetBlocked = true;
 				if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 				if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 				if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
-				requiredStatusStep(statusPayload, fi).model = singleResult.model;
-				requiredStatusStep(statusPayload, fi).thinking = resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, fi).thinking);
-				requiredStatusStep(statusPayload, fi).attemptedModels = singleResult.attemptedModels;
-				requiredStatusStep(statusPayload, fi).modelAttempts = singleResult.modelAttempts;
-				requiredStatusStep(statusPayload, fi).totalCost = singleResult.totalCost;
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "model", singleResult.model);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "thinking", resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, fi).thinking));
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "attemptedModels", singleResult.attemptedModels);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "modelAttempts", singleResult.modelAttempts);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "totalCost", singleResult.totalCost);
 				if (singleResult.totalCost) {
 					pendingParallelUsageCost = {
 						inputTokens: pendingParallelUsageCost.inputTokens + singleResult.totalCost.inputTokens,
@@ -3424,23 +3454,23 @@ async function runSubagent(
 					};
 					refreshUsageBudget();
 				}
-				requiredStatusStep(statusPayload, fi).error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
-				requiredStatusStep(statusPayload, fi).transcriptPath = singleResult.transcriptPath ?? requiredStatusStep(statusPayload, fi).transcriptPath;
-				requiredStatusStep(statusPayload, fi).transcriptError = singleResult.transcriptError;
-				requiredStatusStep(statusPayload, fi).agentContract = singleResult.agentContract;
-				requiredStatusStep(statusPayload, fi).launchContractDigest = singleResult.launchContractDigest;
-				requiredStatusStep(statusPayload, fi).launchResolvedExtensions = singleResult.launchResolvedExtensions;
-				requiredStatusStep(statusPayload, fi).runtimeAcknowledgedExtensions = singleResult.runtimeAcknowledgedExtensions;
-				requiredStatusStep(statusPayload, fi).effects = singleResult.effects;
-				requiredStatusStep(statusPayload, fi).execution = singleResult.execution;
-				requiredStatusStep(statusPayload, fi).review = singleResult.review;
-				requiredStatusStep(statusPayload, fi).structuredOutput = singleResult.structuredOutput;
-				requiredStatusStep(statusPayload, fi).structuredOutputPath = singleResult.structuredOutputPath;
-				requiredStatusStep(statusPayload, fi).structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
-				requiredStatusStep(statusPayload, fi).acceptance = singleResult.acceptance;
-				requiredStatusStep(statusPayload, fi).watchdog = singleResult.watchdog;
-				requiredStatusStep(statusPayload, fi).capabilityCeiling = singleResult.capabilityCeiling;
-				requiredStatusStep(statusPayload, fi).capabilityAudit = singleResult.capabilityAudit;
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "error", stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "transcriptPath", singleResult.transcriptPath ?? requiredStatusStep(statusPayload, fi).transcriptPath);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "transcriptError", singleResult.transcriptError);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "agentContract", singleResult.agentContract);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "launchContractDigest", singleResult.launchContractDigest);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "launchResolvedExtensions", singleResult.launchResolvedExtensions);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "runtimeAcknowledgedExtensions", singleResult.runtimeAcknowledgedExtensions);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "effects", singleResult.effects);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "execution", singleResult.execution);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "review", singleResult.review);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutput", singleResult.structuredOutput);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutputPath", singleResult.structuredOutputPath);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutputSchemaPath", singleResult.structuredOutputSchemaPath);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "acceptance", singleResult.acceptance);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "watchdog", singleResult.watchdog);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "capabilityCeiling", singleResult.capabilityCeiling);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "capabilityAudit", singleResult.capabilityAudit);
 				if (singleResult.capabilityCeiling) statusPayload.capabilityCeiling = singleResult.capabilityCeiling;
 				if (singleResult.capabilityAudit) statusPayload.capabilityAudit = singleResult.capabilityAudit;
 				statusPayload.lastUpdate = taskEndTime;
@@ -3457,7 +3487,7 @@ async function runSubagent(
 
 			flatIndex += dynamicSteps.length;
 			for (const pr of parallelResults) {
-				results.push({
+				results.push(withoutUndefined({
 					agent: pr.agent,
 					context: pr.context,
 					agentContract: pr.agentContract,
@@ -3498,7 +3528,7 @@ async function runSubagent(
 					watchdog: pr.watchdog,
 					capabilityCeiling: pr.capabilityCeiling,
 					capabilityAudit: pr.capabilityAudit,
-				});
+				}));
 			}
 			pendingParallelUsageCost = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
 			refreshUsageBudget();
@@ -3511,7 +3541,7 @@ async function runSubagent(
 				const message = acceptanceFailures
 					.map(({ result, originalIndex }) => `Dynamic item ${originalIndex + 1} (${result.agent}, key ${materialized.items[originalIndex]?.key ?? originalIndex}) acceptance rejected: ${(result.acceptance ? acceptanceFailureMessage(result.acceptance) : undefined) ?? "acceptance rejected"}`)
 					.join("\n");
-				results.push({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection });
+				results.push(withoutUndefined({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection }));
 				statusPayload.error = message;
 				markDynamicGraphGroup(stepIndex, "failed", message);
 			}
@@ -3526,7 +3556,7 @@ async function runSubagent(
 					};
 					statusPayload.outputs = outputs;
 					const groupAcceptance = !timedOut && !stopped
-						? await evaluateAcceptance({
+						? await evaluateAcceptance(withoutUndefined({
 							acceptance: effectiveDynamicGroupAcceptance,
 							output: "",
 							report: aggregateAcceptanceReport({
@@ -3537,7 +3567,7 @@ async function runSubagent(
 							signal: combinedAbortSignal([timeoutAbortController.signal, stopAbortController.signal]),
 							abortMessage: stopAbortController.signal.aborted ? stopMessage : timeoutMessage ?? "Subagent timed out.",
 							reportOptional: isAgentContractV1(step.agentContract),
-						})
+						}))
 						: undefined;
 					const groupStopped = stopped || stopAbortController.signal.aborted;
 					const groupTimedOut = !groupStopped && (timedOut || timeoutAbortController.signal.aborted);
@@ -3546,7 +3576,7 @@ async function runSubagent(
 					const groupError = groupStopped ? stopMessage : groupTimedOut ? timeoutMessage ?? "Subagent timed out." : groupAcceptanceFailure;
 					markDynamicGraphGroup(stepIndex, groupError ? groupStopped ? "stopped" : "failed" : "completed", groupError, effectiveGroupAcceptance);
 					if (groupError) {
-						results.push({
+						results.push(withoutUndefined({
 							agent: step.parallel.agent,
 							output: groupError,
 							error: groupError,
@@ -3556,19 +3586,19 @@ async function runSubagent(
 							stopped: groupStopped ? true : undefined,
 							structuredOutput: collection,
 							acceptance: effectiveGroupAcceptance,
-						});
+						}));
 						statusPayload.error = groupError;
-						statusPayload.stopped = groupStopped ? true : statusPayload.stopped;
+						setOptionalProperty(statusPayload, "stopped", groupStopped ? true : statusPayload.stopped);
 					}
 				} catch (error) {
 					const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
-					results.push({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection });
+					results.push(withoutUndefined({ agent: step.parallel.agent, context: step.parallel.context, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection }));
 					statusPayload.error = message;
 					markDynamicGraphGroup(stepIndex, "failed", message);
 				}
 			}
 			previousOutput = aggregateParallelOutputs(
-				parallelResults.map((r, i) => ({
+				parallelResults.map((r, i) => withoutUndefined({
 					agent: r.agent,
 					taskIndex: i,
 					output: r.output,
@@ -3620,13 +3650,13 @@ async function runSubagent(
 					break;
 				}
 				try {
-					worktreeSetup = createWorktrees(cwd, `${id}-s${stepIndex}`, group.parallel.length, {
+					worktreeSetup = createWorktrees(cwd, `${id}-s${stepIndex}`, group.parallel.length, withoutUndefined({
 						agents: group.parallel.map((task) => task.agent),
 						setupHook: config.worktreeSetupHook
-							? { hookPath: config.worktreeSetupHook, timeoutMs: config.worktreeSetupHookTimeoutMs }
+							? withoutUndefined({ hookPath: config.worktreeSetupHook, timeoutMs: config.worktreeSetupHookTimeoutMs })
 							: undefined,
 						baseDir: config.worktreeBaseDir,
-					});
+					}));
 				} catch (error) {
 					const setupError = error instanceof Error ? error.message : String(error);
 					const failedAt = Date.now();
@@ -3677,7 +3707,7 @@ async function runSubagent(
 				const parallelResults = await mapConcurrent(
 					group.parallel,
 					concurrency,
-					async (task, taskIdx) => {
+					async (task, taskIdx): Promise<StepResult> => {
 						const fi = groupStartFlatIndex + taskIdx;
 						refreshUsageBudget();
 						if (statusPayload.usageBudget?.exhausted) {
@@ -3689,14 +3719,14 @@ async function runSubagent(
 							requiredStatusStep(statusPayload, fi).endedAt = skippedAt;
 							requiredStatusStep(statusPayload, fi).durationMs = 0;
 							requiredStatusStep(statusPayload, fi).exitCode = 1;
-							requiredStatusStep(statusPayload, fi).activityState = undefined;
+							delete requiredStatusStep(statusPayload, fi).activityState;
 							statusPayload.lastUpdate = skippedAt;
 							usageBudgetExceeded = true;
 							writeStatusPayload();
 							appendJsonl(eventsPath, JSON.stringify({
 								type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: 1, durationMs: 0,
 							}));
-							return { agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true };
+							return withoutUndefined({ agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
 						}
 						if (timedOut) return timedOutStepResult(task.agent, task.context);
 						if (stopped) return stoppedStepResult(task.agent, task.context);
@@ -3709,24 +3739,24 @@ async function runSubagent(
 							requiredStatusStep(statusPayload, fi).endedAt = skippedAt;
 							requiredStatusStep(statusPayload, fi).durationMs = 0;
 							requiredStatusStep(statusPayload, fi).exitCode = -1;
-							requiredStatusStep(statusPayload, fi).activityState = undefined;
+							delete requiredStatusStep(statusPayload, fi).activityState;
 							statusPayload.lastUpdate = skippedAt;
 							writeStatusPayload();
 							appendJsonl(eventsPath, JSON.stringify({
 								type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: -1, durationMs: 0,
 							}));
-							return { agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true };
+							return withoutUndefined({ agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
 						}
 
 						const taskStartTime = Date.now();
 						statusPayload.currentStep = fi;
 						requiredStatusStep(statusPayload, fi).status = "running";
-						requiredStatusStep(statusPayload, fi).error = undefined;
-						requiredStatusStep(statusPayload, fi).activityState = undefined;
+						delete requiredStatusStep(statusPayload, fi).error;
+						delete requiredStatusStep(statusPayload, fi).activityState;
 						resetStepLiveDetail(requiredStatusStep(statusPayload, fi));
 						requiredStatusStep(statusPayload, fi).startedAt = taskStartTime;
-						requiredStatusStep(statusPayload, fi).endedAt = undefined;
-						requiredStatusStep(statusPayload, fi).durationMs = undefined;
+						delete requiredStatusStep(statusPayload, fi).endedAt;
+						delete requiredStatusStep(statusPayload, fi).durationMs;
 						requiredStatusStep(statusPayload, fi).lastActivityAt = taskStartTime;
 						statusPayload.outputFile = path.join(asyncDir, `output-${fi}.log`);
 						statusPayload.lastActivityAt = taskStartTime;
@@ -3743,7 +3773,7 @@ async function runSubagent(
 						const { taskForRun, taskCwd } = prepareParallelTaskRun(task, cwd, worktreeSetup, taskIdx);
 						flushPendingStepSteers(fi);
 
-						const singleResult = await runSingleStep(taskForRun, {
+						const singleResult = await runSingleStep(taskForRun, compactOptional<SingleStepContext>({
 							previousOutput, placeholder, cwd: taskCwd, sessionEnabled,
 							outputs,
 							sessionDir: taskSessionDir,
@@ -3773,7 +3803,7 @@ async function runSubagent(
 							onWriterProcess,
 							onExternalProcess: (process) => updateExternalProcess(fi, process),
 							skipAcceptance: () => timedOut || stopped,
-						});
+						}));
 						if (task.sessionFile) {
 							latestSessionFile = task.sessionFile;
 						}
@@ -3787,23 +3817,23 @@ async function runSubagent(
 						requiredStatusStep(statusPayload, fi).endedAt = taskEndTime;
 						requiredStatusStep(statusPayload, fi).durationMs = taskDuration;
 						requiredStatusStep(statusPayload, fi).exitCode = stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode;
-						requiredStatusStep(statusPayload, fi).timedOut = timedOut || singleResult.timedOut ? true : undefined;
-						requiredStatusStep(statusPayload, fi).stopped = stopped || childStopped ? true : undefined;
-						requiredStatusStep(statusPayload, fi).turnBudget = singleResult.turnBudget;
-						requiredStatusStep(statusPayload, fi).turnBudgetExceeded = singleResult.turnBudgetExceeded;
-						requiredStatusStep(statusPayload, fi).wrapUpRequested = singleResult.wrapUpRequested;
-						requiredStatusStep(statusPayload, fi).toolBudget = singleResult.toolBudget;
-						requiredStatusStep(statusPayload, fi).toolBudgetBlocked = singleResult.toolBudgetBlocked;
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "timedOut", timedOut || singleResult.timedOut ? true : undefined);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "stopped", stopped || childStopped ? true : undefined);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "turnBudget", singleResult.turnBudget);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "turnBudgetExceeded", singleResult.turnBudgetExceeded);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "wrapUpRequested", singleResult.wrapUpRequested);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "toolBudget", singleResult.toolBudget);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "toolBudgetBlocked", singleResult.toolBudgetBlocked);
 						if (singleResult.toolBudget) statusPayload.toolBudget = singleResult.toolBudget;
 						if (singleResult.toolBudgetBlocked) statusPayload.toolBudgetBlocked = true;
 						if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 						if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 						if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
-						requiredStatusStep(statusPayload, fi).model = singleResult.model;
-						requiredStatusStep(statusPayload, fi).thinking = resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, fi).thinking);
-						requiredStatusStep(statusPayload, fi).attemptedModels = singleResult.attemptedModels;
-						requiredStatusStep(statusPayload, fi).modelAttempts = singleResult.modelAttempts;
-						requiredStatusStep(statusPayload, fi).totalCost = singleResult.totalCost;
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "model", singleResult.model);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "thinking", resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, fi).thinking));
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "attemptedModels", singleResult.attemptedModels);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "modelAttempts", singleResult.modelAttempts);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "totalCost", singleResult.totalCost);
 						if (singleResult.totalCost) {
 							pendingParallelUsageCost = {
 								inputTokens: pendingParallelUsageCost.inputTokens + singleResult.totalCost.inputTokens,
@@ -3812,22 +3842,22 @@ async function runSubagent(
 							};
 							refreshUsageBudget();
 						}
-						requiredStatusStep(statusPayload, fi).error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
-						requiredStatusStep(statusPayload, fi).transcriptPath = singleResult.transcriptPath ?? requiredStatusStep(statusPayload, fi).transcriptPath;
-						requiredStatusStep(statusPayload, fi).transcriptError = singleResult.transcriptError;
-						requiredStatusStep(statusPayload, fi).agentContract = singleResult.agentContract;
-						requiredStatusStep(statusPayload, fi).launchResolvedExtensions = singleResult.launchResolvedExtensions;
-						requiredStatusStep(statusPayload, fi).runtimeAcknowledgedExtensions = singleResult.runtimeAcknowledgedExtensions;
-						requiredStatusStep(statusPayload, fi).effects = singleResult.effects;
-						requiredStatusStep(statusPayload, fi).execution = singleResult.execution;
-						requiredStatusStep(statusPayload, fi).review = singleResult.review;
-						requiredStatusStep(statusPayload, fi).structuredOutput = singleResult.structuredOutput;
-						requiredStatusStep(statusPayload, fi).structuredOutputPath = singleResult.structuredOutputPath;
-						requiredStatusStep(statusPayload, fi).structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
-						requiredStatusStep(statusPayload, fi).acceptance = singleResult.acceptance;
-						requiredStatusStep(statusPayload, fi).watchdog = singleResult.watchdog;
-						requiredStatusStep(statusPayload, fi).capabilityCeiling = singleResult.capabilityCeiling;
-						requiredStatusStep(statusPayload, fi).capabilityAudit = singleResult.capabilityAudit;
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "error", stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "transcriptPath", singleResult.transcriptPath ?? requiredStatusStep(statusPayload, fi).transcriptPath);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "transcriptError", singleResult.transcriptError);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "agentContract", singleResult.agentContract);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "launchResolvedExtensions", singleResult.launchResolvedExtensions);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "runtimeAcknowledgedExtensions", singleResult.runtimeAcknowledgedExtensions);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "effects", singleResult.effects);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "execution", singleResult.execution);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "review", singleResult.review);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutput", singleResult.structuredOutput);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutputPath", singleResult.structuredOutputPath);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutputSchemaPath", singleResult.structuredOutputSchemaPath);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "acceptance", singleResult.acceptance);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "watchdog", singleResult.watchdog);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "capabilityCeiling", singleResult.capabilityCeiling);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "capabilityAudit", singleResult.capabilityAudit);
 						if (singleResult.capabilityCeiling) statusPayload.capabilityCeiling = singleResult.capabilityCeiling;
 						if (singleResult.capabilityAudit) statusPayload.capabilityAudit = singleResult.capabilityAudit;
 						statusPayload.lastUpdate = taskEndTime;
@@ -3840,7 +3870,7 @@ async function runSubagent(
 							exitCode: stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode, durationMs: taskDuration,
 						}));
 						if (singleResult.completionGuardTriggered) {
-							const event = buildControlEvent({
+							const event = buildControlEvent(withoutUndefined({
 								from: requiredStatusStep(statusPayload, fi).activityState,
 								to: "needs_attention",
 								runId: id,
@@ -3849,7 +3879,7 @@ async function runSubagent(
 								ts: taskEndTime,
 								message: `${task.agent} completed without making edits for an implementation task`,
 								reason: "completion_guard",
-							});
+							}));
 							appendControlEvent(event);
 						}
 
@@ -3880,7 +3910,7 @@ async function runSubagent(
 				writeStatusPayload();
 
 				for (const pr of parallelResults) {
-					results.push({
+					results.push(withoutUndefined({
 						agent: pr.agent,
 						context: pr.context,
 						agentContract: pr.agentContract,
@@ -3918,7 +3948,7 @@ async function runSubagent(
 						structuredOutputSchemaPath: pr.structuredOutputSchemaPath,
 						acceptance: pr.acceptance,
 						watchdog: pr.watchdog,
-					});
+					}));
 				}
 				pendingParallelUsageCost = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
 				refreshUsageBudget();
@@ -3933,7 +3963,7 @@ async function runSubagent(
 				statusPayload.outputs = outputs;
 
 				previousOutput = aggregateParallelOutputs(
-					parallelResults.map((r) => ({
+					parallelResults.map((r) => withoutUndefined({
 						agent: r.agent,
 						output: r.output,
 						exitCode: r.exitCode,
@@ -3959,13 +3989,13 @@ async function runSubagent(
 						diffs: captured.diffs,
 						results: parallelResults.map((result) => ({
 							agent: result.agent,
-							status: result.stopped || (result.exitCode !== 0 && isUnexplainedProcessSignal({
+							status: result.stopped || (result.exitCode !== 0 && isUnexplainedProcessSignal(withoutUndefined({
 								processSignal: result.processSignal,
 								interrupted: result.interrupted,
 								timedOut: result.timedOut,
 								stopped: result.stopped,
 								turnBudgetExceeded: result.turnBudgetExceeded,
-							})) ? "stopped" as const : result.interrupted ? "paused" as const : result.exitCode === 0 ? "completed" as const : "failed" as const,
+							}))) ? "stopped" as const : result.interrupted ? "paused" as const : result.exitCode === 0 ? "completed" as const : "failed" as const,
 							summary: result.output || result.error || "(no output)",
 							...(result.artifactPaths?.outputPath ? { outputPath: result.artifactPaths.outputPath } : {}),
 							...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
@@ -4012,10 +4042,10 @@ async function runSubagent(
 			const stepStartTime = Date.now();
 			statusPayload.currentStep = flatIndex;
 			requiredStatusStep(statusPayload, flatIndex).status = "running";
-			requiredStatusStep(statusPayload, flatIndex).activityState = undefined;
-			statusPayload.activityState = undefined;
+			delete requiredStatusStep(statusPayload, flatIndex).activityState;
+			delete statusPayload.activityState;
 			resetStepLiveDetail(requiredStatusStep(statusPayload, flatIndex));
-			requiredStatusStep(statusPayload, flatIndex).skills = seqStep.skills;
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "skills", seqStep.skills);
 			requiredStatusStep(statusPayload, flatIndex).startedAt = stepStartTime;
 			requiredStatusStep(statusPayload, flatIndex).lastActivityAt = stepStartTime;
 			statusPayload.lastActivityAt = stepStartTime;
@@ -4032,7 +4062,7 @@ async function runSubagent(
 			}));
 
 			flushPendingStepSteers(flatIndex);
-			const singleResult = await runSingleStep(seqStep, {
+			const singleResult = await runSingleStep(seqStep, compactOptional<SingleStepContext>({
 				previousOutput, placeholder, cwd, sessionEnabled,
 				outputs: statusPayload.mode === "single" ? undefined : outputs,
 				sessionDir: config.sessionDir,
@@ -4062,14 +4092,14 @@ async function runSubagent(
 				onWriterProcess,
 				onExternalProcess: (process) => updateExternalProcess(flatIndex, process),
 				skipAcceptance: () => timedOut || stopped,
-			});
+			}));
 			if (seqStep.sessionFile) {
 				latestSessionFile = seqStep.sessionFile;
 			}
 
 			previousOutput = singleResult.output;
 			const childStopped = singleResult.stopped === true;
-			results.push({
+			results.push(withoutUndefined({
 				agent: singleResult.agent,
 				context: singleResult.context,
 				agentContract: singleResult.agentContract,
@@ -4111,7 +4141,7 @@ async function runSubagent(
 				toolBudgetBlocked: singleResult.toolBudgetBlocked,
 				runner: singleResult.runner,
 				externalProcess: singleResult.externalProcess,
-			});
+			}));
 			if (seqStep.outputName) {
 				outputs[seqStep.outputName] = outputEntryFromAsyncResult({
 					agent: singleResult.agent,
@@ -4148,39 +4178,39 @@ async function runSubagent(
 			requiredStatusStep(statusPayload, flatIndex).endedAt = stepEndTime;
 			requiredStatusStep(statusPayload, flatIndex).durationMs = stepEndTime - stepStartTime;
 			requiredStatusStep(statusPayload, flatIndex).exitCode = stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode;
-			requiredStatusStep(statusPayload, flatIndex).timedOut = timedOut || singleResult.timedOut ? true : undefined;
-			requiredStatusStep(statusPayload, flatIndex).stopped = stopped || childStopped ? true : undefined;
-			requiredStatusStep(statusPayload, flatIndex).turnBudget = singleResult.turnBudget;
-			requiredStatusStep(statusPayload, flatIndex).turnBudgetExceeded = singleResult.turnBudgetExceeded;
-			requiredStatusStep(statusPayload, flatIndex).wrapUpRequested = singleResult.wrapUpRequested;
-			requiredStatusStep(statusPayload, flatIndex).toolBudget = singleResult.toolBudget;
-			requiredStatusStep(statusPayload, flatIndex).toolBudgetBlocked = singleResult.toolBudgetBlocked;
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "timedOut", timedOut || singleResult.timedOut ? true : undefined);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "stopped", stopped || childStopped ? true : undefined);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "turnBudget", singleResult.turnBudget);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "turnBudgetExceeded", singleResult.turnBudgetExceeded);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "wrapUpRequested", singleResult.wrapUpRequested);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "toolBudget", singleResult.toolBudget);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "toolBudgetBlocked", singleResult.toolBudgetBlocked);
 			if (singleResult.toolBudget) statusPayload.toolBudget = singleResult.toolBudget;
 			if (singleResult.toolBudgetBlocked) statusPayload.toolBudgetBlocked = true;
 			if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 			if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 			if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
-			requiredStatusStep(statusPayload, flatIndex).model = singleResult.model;
-			requiredStatusStep(statusPayload, flatIndex).thinking = resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, flatIndex).thinking);
-			requiredStatusStep(statusPayload, flatIndex).attemptedModels = singleResult.attemptedModels;
-			requiredStatusStep(statusPayload, flatIndex).modelAttempts = singleResult.modelAttempts;
-			requiredStatusStep(statusPayload, flatIndex).totalCost = singleResult.totalCost;
-			requiredStatusStep(statusPayload, flatIndex).error = stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error;
-			requiredStatusStep(statusPayload, flatIndex).transcriptPath = singleResult.transcriptPath ?? requiredStatusStep(statusPayload, flatIndex).transcriptPath;
-			requiredStatusStep(statusPayload, flatIndex).transcriptError = singleResult.transcriptError;
-			requiredStatusStep(statusPayload, flatIndex).agentContract = singleResult.agentContract;
-			requiredStatusStep(statusPayload, flatIndex).launchResolvedExtensions = singleResult.launchResolvedExtensions;
-			requiredStatusStep(statusPayload, flatIndex).runtimeAcknowledgedExtensions = singleResult.runtimeAcknowledgedExtensions;
-			requiredStatusStep(statusPayload, flatIndex).effects = singleResult.effects;
-			requiredStatusStep(statusPayload, flatIndex).execution = singleResult.execution;
-			requiredStatusStep(statusPayload, flatIndex).review = singleResult.review;
-			requiredStatusStep(statusPayload, flatIndex).structuredOutput = singleResult.structuredOutput;
-			requiredStatusStep(statusPayload, flatIndex).structuredOutputPath = singleResult.structuredOutputPath;
-			requiredStatusStep(statusPayload, flatIndex).structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
-			requiredStatusStep(statusPayload, flatIndex).acceptance = singleResult.acceptance;
-			requiredStatusStep(statusPayload, flatIndex).watchdog = singleResult.watchdog;
-			requiredStatusStep(statusPayload, flatIndex).capabilityCeiling = singleResult.capabilityCeiling;
-			requiredStatusStep(statusPayload, flatIndex).capabilityAudit = singleResult.capabilityAudit;
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "model", singleResult.model);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "thinking", resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, flatIndex).thinking));
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "attemptedModels", singleResult.attemptedModels);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "modelAttempts", singleResult.modelAttempts);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "totalCost", singleResult.totalCost);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "error", stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "transcriptPath", singleResult.transcriptPath ?? requiredStatusStep(statusPayload, flatIndex).transcriptPath);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "transcriptError", singleResult.transcriptError);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "agentContract", singleResult.agentContract);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "launchResolvedExtensions", singleResult.launchResolvedExtensions);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "runtimeAcknowledgedExtensions", singleResult.runtimeAcknowledgedExtensions);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "effects", singleResult.effects);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "execution", singleResult.execution);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "review", singleResult.review);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "structuredOutput", singleResult.structuredOutput);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "structuredOutputPath", singleResult.structuredOutputPath);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "structuredOutputSchemaPath", singleResult.structuredOutputSchemaPath);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "acceptance", singleResult.acceptance);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "watchdog", singleResult.watchdog);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "capabilityCeiling", singleResult.capabilityCeiling);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "capabilityAudit", singleResult.capabilityAudit);
 			if (singleResult.capabilityCeiling) statusPayload.capabilityCeiling = singleResult.capabilityCeiling;
 			if (singleResult.capabilityAudit) statusPayload.capabilityAudit = singleResult.capabilityAudit;
 			if (stepTokens) {
@@ -4202,7 +4232,7 @@ async function runSubagent(
 				tokens: stepTokens,
 			}));
 			if (singleResult.completionGuardTriggered) {
-				const event = buildControlEvent({
+				const event = buildControlEvent(withoutUndefined({
 					from: requiredStatusStep(statusPayload, flatIndex).activityState,
 					to: "needs_attention",
 					runId: id,
@@ -4211,7 +4241,7 @@ async function runSubagent(
 					ts: stepEndTime,
 					message: `${seqStep.agent} completed without making edits for an implementation task`,
 					reason: "completion_guard",
-				});
+				}));
 				appendControlEvent(event);
 			}
 
@@ -4292,13 +4322,13 @@ async function runSubagent(
 		clearTimeout(timeoutTimer);
 		timeoutTimer = undefined;
 	}
-	const signalTerminated = !stopped && !timedOut && !turnBudgetExceeded && !interrupted && results.some((result) => result.exitCode !== 0 && isUnexplainedProcessSignal({
+	const signalTerminated = !stopped && !timedOut && !turnBudgetExceeded && !interrupted && results.some((result) => result.exitCode !== 0 && isUnexplainedProcessSignal(withoutUndefined({
 		processSignal: result.processSignal,
 		interrupted: result.interrupted,
 		timedOut: result.timedOut,
 		stopped: result.stopped,
 		turnBudgetExceeded: result.turnBudgetExceeded,
-	}));
+	})));
 	statusPayload.state = checkpointRejected ? "rejected" : stopped || signalTerminated ? "stopped" : timedOut || turnBudgetExceeded || usageBudgetExceeded || statusPayload.error ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : "failed";
 	closeSteerInbox(asyncDir, statusPayload.state);
 	disposeControlInbox();
@@ -4317,12 +4347,12 @@ async function runSubagent(
 		if (changed) emitTerminalSteeringNotice(request.id, `Steering failed for run ${id}: child terminated before delivery.`);
 	}
 	const runEndedAt = Date.now();
-	statusPayload.activityState = undefined;
+	delete statusPayload.activityState;
 	if (stopped) {
 		statusPayload.stopped = true;
 		statusPayload.error = stopMessage;
 	} else if (signalTerminated && !statusPayload.error) {
-		statusPayload.error = results.find((result) => result.processSignal)?.error;
+		setOptionalProperty(statusPayload, "error", results.find((result) => result.processSignal)?.error);
 	}
 	if (timedOut) {
 		statusPayload.timedOut = true;
@@ -4337,13 +4367,13 @@ async function runSubagent(
 	}
 	statusPayload.endedAt = runEndedAt;
 	statusPayload.lastUpdate = runEndedAt;
-	statusPayload.sessionFile = effectiveSessionFile;
+	setOptionalProperty(statusPayload, "sessionFile", effectiveSessionFile);
 	if (singleRuntimeAcknowledgedExtensions) statusPayload.runtimeAcknowledgedExtensions = singleRuntimeAcknowledgedExtensions;
-	statusPayload.totalCost = finalTotalCost;
-	statusPayload.usageBudget = usageBudgetState(config.usageBudget, currentUsageTotals());
-	statusPayload.shareUrl = shareUrl;
-	statusPayload.gistUrl = gistUrl;
-	statusPayload.shareError = shareError;
+	setOptionalProperty(statusPayload, "totalCost", finalTotalCost);
+	setOptionalProperty(statusPayload, "usageBudget", usageBudgetState(config.usageBudget, currentUsageTotals()));
+	setOptionalProperty(statusPayload, "shareUrl", shareUrl);
+	setOptionalProperty(statusPayload, "gistUrl", gistUrl);
+	setOptionalProperty(statusPayload, "shareError", shareError);
 	if (statusPayload.state === "failed" && !statusPayload.error) {
 		const failedStep = statusPayload.steps.find((s) => s.status === "failed");
 		if (failedStep?.agent) {
@@ -4365,13 +4395,13 @@ async function runSubagent(
 			usageBudget: statusPayload.usageBudget,
 		}),
 	);
-	writeRunLog(logPath, {
+	writeRunLog(logPath, withoutUndefined({
 		id,
 		mode: statusPayload.mode,
 		cwd,
 		startedAt: overallStartTime,
 		endedAt: runEndedAt,
-		steps: statusPayload.steps.map((step) => ({
+		steps: statusPayload.steps.map((step) => withoutUndefined({
 			agent: step.agent,
 			status: step.status,
 			durationMs: step.durationMs,
@@ -4382,7 +4412,7 @@ async function runSubagent(
 		sessionFile: effectiveSessionFile,
 		shareUrl,
 		shareError,
-	});
+	}));
 
 	try {
 		writeAtomicJson(resultPath, {
@@ -4403,7 +4433,7 @@ async function runSubagent(
 			...(statusPayload.usageBudget ? { usageBudget: statusPayload.usageBudget } : {}),
 			...(statusPayload.checkpoint ? { checkpoint: statusPayload.checkpoint } : {}),
 			...(stopped ? { stopped: true, error: stopMessage } : timedOut ? { timedOut: true, error: timeoutMessage ?? "Subagent timed out." } : turnBudgetExceeded ? { error: statusPayload.error ?? "Subagent exceeded turn budget." } : usageBudgetExceeded ? { error: statusPayload.error ?? "Usage budget exhausted." } : {}),
-			results: results.map((r) => ({
+			results: results.map((r) => withoutUndefined({
 				agent: r.agent,
 				context: r.context,
 				output: r.output,


### PR DESCRIPTION
## Summary
- omit absent optional fields throughout the background runner status/result paths
- preserve async, imported, dynamic/parallel, worktree, steering, watchdog, budget, and terminal-result behavior
- keep exactOptionalPropertyTypes disabled globally; this is one partial #748 slice

Refs #748. This PR intentionally does not close the issue.

## Validation
- npm run typecheck
- node --experimental-strip-types --test test/unit/background-work.test.ts test/unit/async-execution.test.ts test/unit/chain-root-attachment.test.ts test/unit/parallel-utils.test.ts test/unit/parallel-handoff.test.ts
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts test/integration/top-level-async.test.ts test/integration/parallel-execution.test.ts
- npx tsc --noEmit --exactOptionalPropertyTypes true (expected residual diagnostics outside this slice; no diagnostics in src/runs/background/subagent-runner.ts)
- git diff --check