### PR TITLE
perf: reuse workflow git identity

### DIFF
--- a/src/workflows/chat-progress.ts
+++ b/src/workflows/chat-progress.ts
@@ -76,7 +76,11 @@ export function resolveWorkflowChatProgress(input: ResolveWorkflowChatProgressIn
 	if (requested.error) return { error: requested.error };
 	const parentIdentity = resolveGitRepositoryIdentity(input.parentCwd);
 	const workflowIdentity = resolveGitRepositoryIdentity(input.workflowCwd);
-	const sameRepo = isSameGitRepositoryIdentity(parentIdentity, workflowIdentity);
+	const sameRepo = !!(
+		parentIdentity
+		&& workflowIdentity
+		&& (parentIdentity.commonDir === workflowIdentity.commonDir || parentIdentity.root === workflowIdentity.root)
+	);
 	const repoLabel = workflowIdentity ? path.basename(workflowIdentity.root) : undefined;
 	const repoRelation = sameRepo ? "same" : "other";
 


### PR DESCRIPTION
Follow-up to #766 for the Greptile P2 inline note.

This keeps `resolveWorkflowChatProgress` from routing same-repo detection through another helper after it has already resolved both Git identities for the parent and workflow cwd. The behavior is unchanged; the comparison now uses the resolved identities directly.

Validation:
- `node --experimental-strip-types --test /Users/nicobailon/.pi/agent/extensions/subagent/test/unit/workflow-chat-progress.test.ts`
- `npm run typecheck`
- `git diff --check`
