### PR TITLE
fix: avoid Windows npm root title clobber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Avoid invoking `npm root -g` on Windows when the standard `%APPDATA%\\npm\\node_modules` global root is available, preserving custom terminal tab titles during agent and skill discovery. Thanks to @Suchwert for #767.
 - Launch standalone Pi child processes directly instead of prepending the resolved Pi CLI script path. Thanks to @ZacharyQin for #764.
 - Kept foreground `workflowScript` live-card runs from flooding chat with routine successful child-result intercom messages while preserving failure surfacing and final artifact references.
 - Project oversized redundant Pi `turn_end` and `agent_end` child events to bounded lifecycle records instead of failing image-heavy runs with `protocol_output_limit`, while preserving `agent_end.willRetry` drain behavior. Thanks to @barto-sh for #743.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Fixed
 - Avoid invoking `npm root -g` on Windows when the standard `%APPDATA%\\npm\\node_modules` global root is available, preserving custom terminal tab titles during agent and skill discovery. Thanks to @Suchwert for #767.
+- Preserved nested foreground failure events when resolved launch metadata is unavailable.
 - Launch standalone Pi child processes directly instead of prepending the resolved Pi CLI script path. Thanks to @ZacharyQin for #764.
 - Kept foreground `workflowScript` live-card runs from flooding chat with routine successful child-result intercom messages while preserving failure surfacing and final artifact references.
 - Project oversized redundant Pi `turn_end` and `agent_end` child events to bounded lifecycle records instead of failing image-heavy runs with `protocol_output_limit`, while preserving `agent_end.willRetry` drain behavior. Thanks to @barto-sh for #743.

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -330,6 +330,21 @@ function getGlobalNpmRoot(): string | null {
 	const offline = process.env.PI_OFFLINE?.toLowerCase();
 	if (offline === "1" || offline === "true" || offline === "yes") return null;
 	if (cachedGlobalNpmRoot !== null) return cachedGlobalNpmRoot;
+
+	const windowsGlobalRoot = process.platform === "win32" && process.env.APPDATA
+		? path.join(process.env.APPDATA, "npm", "node_modules")
+		: undefined;
+	if (windowsGlobalRoot) {
+		try {
+			if (fs.statSync(windowsGlobalRoot).isDirectory()) {
+				cachedGlobalNpmRoot = fs.realpathSync(windowsGlobalRoot);
+				return cachedGlobalNpmRoot;
+			}
+		} catch {
+			// Fall through if the directory disappears while resolving it.
+		}
+	}
+
 	try {
 		cachedGlobalNpmRoot = fs.realpathSync(execSync("npm root -g", { encoding: "utf-8", timeout: 5000 }).trim());
 		return cachedGlobalNpmRoot;

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -125,8 +125,23 @@ function getGlobalNpmRoot(): string | null {
 	const offline = process.env.PI_OFFLINE?.toLowerCase();
 	if (offline === "1" || offline === "true" || offline === "yes") return null;
 	if (cachedGlobalNpmRoot !== null) return cachedGlobalNpmRoot;
+
+	const windowsGlobalRoot = process.platform === "win32" && process.env.APPDATA
+		? path.join(process.env.APPDATA, "npm", "node_modules")
+		: undefined;
+	if (windowsGlobalRoot) {
+		try {
+			if (fs.statSync(windowsGlobalRoot).isDirectory()) {
+				cachedGlobalNpmRoot = fs.realpathSync(windowsGlobalRoot);
+				return cachedGlobalNpmRoot;
+			}
+		} catch {
+			// Fall through if the directory disappears while resolving it.
+		}
+	}
+
 	try {
-		cachedGlobalNpmRoot = execSync("npm root -g", { encoding: "utf-8", timeout: 5000 }).trim();
+		cachedGlobalNpmRoot = fs.realpathSync(execSync("npm root -g", { encoding: "utf-8", timeout: 5000 }).trim());
 		return cachedGlobalNpmRoot;
 	} catch {
 		// Global npm root is optional in constrained environments.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5017,16 +5017,22 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const errorText = result?.isError
 				? result.content.find((item) => item.type === "text")?.text
 				: undefined;
-			const startedLaunches = collectStaticLaunchSummaries({
-				params: effectiveParams,
-				agents,
-				parentModel: requestParentModel,
-				availableModels: ctx.modelRegistry.getAvailable().map(toModelInfo),
-				currentProvider: requestParentModel?.provider,
-				modelScope,
-				thinkingOverrideForTask: forkThinkingOverrideForTask,
-				dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
-			});
+			let startedLaunches: StaticLaunchSummary[];
+			try {
+				startedLaunches = collectStaticLaunchSummaries({
+					params: effectiveParams,
+					agents,
+					parentModel: requestParentModel,
+					availableModels: ctx.modelRegistry.getAvailable().map(toModelInfo),
+					currentProvider: requestParentModel?.provider,
+					modelScope,
+					thinkingOverrideForTask: forkThinkingOverrideForTask,
+					dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
+				});
+			} catch (error) {
+				console.error("Failed to resolve nested foreground launch metadata:", error);
+				startedLaunches = selectedAgentNames.map((agent) => ({ agent }));
+			}
 			const agentsForSummary = startedLaunches.map((launch) => launch.agent);
 			const leafIntercomTarget = intercomBridge.active && agentsForSummary[0]
 				? resolveSubagentIntercomTarget(runId, agentsForSummary[0], 0)

--- a/test/unit/skills-fallback.test.ts
+++ b/test/unit/skills-fallback.test.ts
@@ -52,6 +52,13 @@ async function importSkillsFresh() {
 	return await import(`${pathToFileURL(modulePath).href}?bust=${bust}`) as typeof import("../../src/agents/skills.ts");
 }
 
+async function importAgentsFresh() {
+	const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+	const modulePath = path.resolve(projectRoot, "src/agents/agents.ts");
+	const bust = `${Date.now()}-${Math.random()}`;
+	return await import(`${pathToFileURL(modulePath).href}?bust=${bust}`) as typeof import("../../src/agents/agents.ts");
+}
+
 describe("skills filesystem fallback", () => {
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-skills-fallback-"));
@@ -355,6 +362,124 @@ describe("skills filesystem fallback", () => {
 			},
 		);
 		assert.deepEqual(fs.readFileSync(marker, "utf-8").trim().split(/\r?\n/), ["npm-root-called", "npm-root-called"]);
+	});
+
+	it("uses the Windows APPDATA npm root without invoking npm", async () => {
+		const appData = path.join(tempDir, "appdata");
+		const packageRoot = path.join(appData, "npm", "node_modules", "windows-global-package");
+		const marker = path.join(tempDir, "npm-called");
+		const binDir = path.join(tempDir, "bin");
+		fs.mkdirSync(binDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(binDir, "npm"),
+			`#!/bin/sh\ntouch "${marker}"\nexit 1\n`,
+			{ encoding: "utf-8", mode: 0o755 },
+		);
+		writeSkillFile(path.join(packageRoot, "skills", "windows-global-skill"), "Use the Windows global skill.");
+		fs.writeFileSync(
+			path.join(packageRoot, "package.json"),
+			JSON.stringify({
+				name: "windows-global-package",
+				pi: { skills: ["./skills"] },
+				"pi-subagents": { agents: ["./agents"] },
+			}, null, 2),
+			"utf-8",
+		);
+		fs.mkdirSync(path.join(packageRoot, "agents"), { recursive: true });
+		fs.writeFileSync(path.join(packageRoot, "agents", "windows-global-agent.md"), `---
+name: windows-global-agent
+description: Loaded from the Windows global npm root.
+---
+
+Windows global agent.
+`, "utf-8");
+
+		const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+		const previousAppData = process.env.APPDATA;
+		const previousPath = process.env.PATH;
+		try {
+			Object.defineProperty(process, "platform", { value: "win32" });
+			process.env.APPDATA = appData;
+			process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
+
+			const skills = await importSkillsFresh();
+			assert.ok(skills.discoverAvailableSkills(tempDir).some((skill) => skill.name === "windows-global-skill"));
+
+			const agents = await importAgentsFresh();
+			assert.ok(agents.discoverAgents(tempDir, "both").agents.some((agent) => agent.name === "windows-global-agent"));
+			assert.equal(fs.existsSync(marker), false, "npm root -g should not run when APPDATA has a global root");
+		} finally {
+			if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+			if (previousAppData === undefined) delete process.env.APPDATA;
+			else process.env.APPDATA = previousAppData;
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("falls back to npm when the Windows APPDATA npm root is invalid", async () => {
+		const appData = path.join(tempDir, "appdata-file");
+		const fallbackRoot = path.join(tempDir, "fallback-global-root");
+		const packageRoot = path.join(fallbackRoot, "fallback-global-package");
+		const marker = path.join(tempDir, "npm-called");
+		const binDir = path.join(tempDir, "bin");
+		fs.mkdirSync(path.join(appData, "npm"), { recursive: true });
+		fs.writeFileSync(path.join(appData, "npm", "node_modules"), "not a directory", "utf-8");
+		fs.mkdirSync(binDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(binDir, "npm"),
+			`#!/bin/sh\ntouch "${marker}"\nprintf '%s\\n' "${fallbackRoot}"\n`,
+			{ encoding: "utf-8", mode: 0o755 },
+		);
+		fs.writeFileSync(
+			path.join(binDir, "cmd.exe"),
+			`#!/bin/sh\nexec sh -c "npm root -g"\n`,
+			{ encoding: "utf-8", mode: 0o755 },
+		);
+		writeSkillFile(path.join(packageRoot, "skills", "fallback-global-skill"), "Use the fallback global skill.");
+		fs.writeFileSync(
+			path.join(packageRoot, "package.json"),
+			JSON.stringify({
+				name: "fallback-global-package",
+				pi: { skills: ["./skills"] },
+				"pi-subagents": { agents: ["./agents"] },
+			}, null, 2),
+			"utf-8",
+		);
+		fs.mkdirSync(path.join(packageRoot, "agents"), { recursive: true });
+		fs.writeFileSync(path.join(packageRoot, "agents", "fallback-global-agent.md"), `---
+name: fallback-global-agent
+description: Loaded from npm fallback global root.
+---
+
+Fallback global agent.
+`, "utf-8");
+
+		const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+		const previousAppData = process.env.APPDATA;
+		const previousPath = process.env.PATH;
+		const previousComSpec = process.env.ComSpec;
+		try {
+			Object.defineProperty(process, "platform", { value: "win32" });
+			process.env.APPDATA = appData;
+			process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
+			process.env.ComSpec = path.join(binDir, "cmd.exe");
+
+			const skills = await importSkillsFresh();
+			assert.ok(skills.discoverAvailableSkills(tempDir).some((skill) => skill.name === "fallback-global-skill"));
+
+			const agents = await importAgentsFresh();
+			assert.ok(agents.discoverAgents(tempDir, "both").agents.some((agent) => agent.name === "fallback-global-agent"));
+			assert.equal(fs.existsSync(marker), true, "npm root -g should run when APPDATA root is invalid");
+		} finally {
+			if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+			if (previousAppData === undefined) delete process.env.APPDATA;
+			else process.env.APPDATA = previousAppData;
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+			if (previousComSpec === undefined) delete process.env.ComSpec;
+			else process.env.ComSpec = previousComSpec;
+		}
 	});
 
 	it("falls back to the runtime cwd when the execution cwd lacks the skill", () => {

--- a/test/unit/skills-fallback.test.ts
+++ b/test/unit/skills-fallback.test.ts
@@ -428,8 +428,13 @@ Windows global agent.
 		fs.mkdirSync(binDir, { recursive: true });
 		fs.writeFileSync(
 			path.join(binDir, "npm"),
-			`#!/bin/sh\ntouch "${marker}"\nprintf '%s\\n' "${fallbackRoot}"\n`,
+			`#!/bin/sh\ntouch "$PI_TEST_NPM_MARKER"\nprintf '%s\\n' "$PI_TEST_FALLBACK_ROOT"\n`,
 			{ encoding: "utf-8", mode: 0o755 },
+		);
+		fs.writeFileSync(
+			path.join(binDir, "npm.cmd"),
+			`@echo off\r\necho called > "%PI_TEST_NPM_MARKER%"\r\necho %PI_TEST_FALLBACK_ROOT%\r\n`,
+			"utf-8",
 		);
 		fs.writeFileSync(
 			path.join(binDir, "cmd.exe"),
@@ -459,11 +464,15 @@ Fallback global agent.
 		const previousAppData = process.env.APPDATA;
 		const previousPath = process.env.PATH;
 		const previousComSpec = process.env.ComSpec;
+		const previousMarkerEnv = process.env.PI_TEST_NPM_MARKER;
+		const previousFallbackRootEnv = process.env.PI_TEST_FALLBACK_ROOT;
 		try {
 			Object.defineProperty(process, "platform", { value: "win32" });
 			process.env.APPDATA = appData;
 			process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
-			process.env.ComSpec = path.join(binDir, "cmd.exe");
+			if (os.platform() !== "win32") process.env.ComSpec = path.join(binDir, "cmd.exe");
+			process.env.PI_TEST_NPM_MARKER = marker;
+			process.env.PI_TEST_FALLBACK_ROOT = fallbackRoot;
 
 			const skills = await importSkillsFresh();
 			assert.ok(skills.discoverAvailableSkills(tempDir).some((skill) => skill.name === "fallback-global-skill"));
@@ -479,6 +488,10 @@ Fallback global agent.
 			else process.env.PATH = previousPath;
 			if (previousComSpec === undefined) delete process.env.ComSpec;
 			else process.env.ComSpec = previousComSpec;
+			if (previousMarkerEnv === undefined) delete process.env.PI_TEST_NPM_MARKER;
+			else process.env.PI_TEST_NPM_MARKER = previousMarkerEnv;
+			if (previousFallbackRootEnv === undefined) delete process.env.PI_TEST_FALLBACK_ROOT;
+			else process.env.PI_TEST_FALLBACK_ROOT = previousFallbackRootEnv;
 		}
 	});
 


### PR DESCRIPTION
Fixes #767.

This makes agent and skill discovery prefer the standard `%APPDATA%\npm\node_modules` root on Windows when it is a real directory, avoiding the `npm root -g` subprocess that clobbers Windows Terminal tab titles. If that path is absent or invalid, discovery falls back to the existing `npm root -g` behavior.

Validation:
- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/skills-fallback.test.ts`

Changelog credits @Suchwert for the report.