### PR TITLE
refactor: simplify delegation contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Added optional `thinking` and `fallbackModels` fields to `/subagents` profile agent overrides, so a saved profile can pin reasoning effort and fallbacks (not just the model) — important for reasoning-sensitive models where the thinking level is load-bearing. Thanks to @dt-benedict for #741.
 
 ### Changed
+- Replaced the separate version-numbered extension delegation contracts with one structured owned-leaf delegation API, while keeping the unversioned prompt-template bridge as a temporary legacy fallback.
 - Removed the public top-level `tasks[]`, `chain[]`, static parallel controls, and `/chain`, `/parallel`, and `/run-chain` commands; `workflowScript` is now the sole public multi-agent orchestration surface. `append-step` now accepts a control-only `step` object.
 - Scripted workflows now start asynchronously by default as first-class status/fleet runs, stream trace and emitted progress, support stop by workflow id, preserve async child parentage, and present single + workflow as the public authoring surface.
 - `runs.ref()` now returns concise `[run <key>; id=<short-id>]` references; callers that need artifact, session, or handoff paths should read the child result `artifactPaths` or the corresponding status artifacts.

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Foreground and async runners share bounded child-protocol handling. A child JSON
 
 The stable v1 status/result fields are `lifecycleArtifactVersion`, `runId`/`id`, `sessionId`, `mode`, `state`, `startedAt`, `lastUpdate`, `endedAt`, `durationMs`, `cwd`, `asyncDir`, `sessionFile`, `outputFile`, `workflowGraph`, `steps`, `results`, `totalTokens`, `totalCost`, `model`/`attemptedModels`/`modelAttempts`, `toolCount`, `turnCount`, optional `launchResolvedExtensions`, optional `runtimeAcknowledgedExtensions`, and nested `children` when a child is allowed to launch subagents. `launchResolvedExtensions` is parent-resolved launch intent only: it reports opaque extension identifiers and whether ambient extensions were disabled, without exposing raw extension paths or claiming the child runtime acknowledged that those extensions loaded. Cooperating child extensions can acknowledge child-runtime registration by emitting `subagent:acknowledge-extension` on the child process `pi.events` bus with payload `{ id: string }`. Acknowledgement ids are self-declared opaque strings, must be non-empty, at most 128 characters, contain only `A-Z`, `a-z`, `0-9`, `.`, `_`, `:`, `@`, `+`, or `-`, and must not contain `/`, `\\`, or `..`. The reported `runtimeAcknowledgedExtensions` projection is `{ version: 1, source: "child-runtime", ids, omitted }`, deduplicates ids, keeps at most 32 ids, and counts additional valid unique ids in `omitted`. It is best-effort observability only: absence means no cooperating extension acknowledged, and presence means only that the extension registered in the child runtime, not that its tools, health checks, or features succeeded. Late acknowledgements after terminal serialization are ignored. `events.jsonl` records lifecycle transitions such as `subagent.run.started`, `subagent.step.started`, `subagent.step.completed`/`failed`/`paused`/`stopped`, control attention events, nested interrupt failures, and `subagent.run.completed`/`stopped`; run boundary events include the lifecycle artifact version. Consumers should read these JSON files instead of scraping terminal output; unknown fields and event types should be ignored for forward compatibility.
 
-Other Pi extensions can use the versioned in-process event-bus RPC instead of scraping slash output or calling internal modules. Listen for `subagents:rpc:v1:ready`, send requests on `subagents:rpc:v1:request`, and read replies from `subagents:rpc:v1:reply:<requestId>`. The `ping` capability metadata also advertises `events.asyncComplete` for exact process-local completion correlation after RPC `spawn`. Delegation v1/v2 progress updates carry `runId` as soon as foreground execution allocates it, so a caller can retain the package-owned revival target even if its own tool turn is interrupted before the terminal response. Foreground `details.results[]` rows also include a numeric `index` that is unique within the run and stable across partial progress snapshots and the final result; use `(runId, index)` instead of row position to correlate single, counted parallel, and chain children.
+Other Pi extensions can use the versioned in-process event-bus RPC instead of scraping slash output or calling internal modules. Listen for `subagents:rpc:v1:ready`, send requests on `subagents:rpc:v1:request`, and read replies from `subagents:rpc:v1:reply:<requestId>`. The `ping` capability metadata also advertises `events.asyncComplete` for exact process-local completion correlation after RPC `spawn`. Structured delegation progress updates carry `runId` as soon as foreground execution allocates it, so a caller can retain the package-owned revival target even if its own tool turn is interrupted before the terminal response. Foreground `details.results[]` rows also include a numeric `index` that is unique within the run and stable across partial progress snapshots and the final result; use `(runId, index)` instead of row position to correlate single, counted parallel, and chain children.
 
 ```typescript
 const requestId = crypto.randomUUID();
@@ -748,7 +748,7 @@ Important fields:
 | `acceptance` | Acceptance default for single-agent launches. Use a scalar level such as `checked` or an inline/block YAML map such as `{ level: "none", reason: "lightweight lookup" }`. Explicit call values win; chain and parallel acceptance remains task/step configuration. |
 | `acceptanceRole` | Optional `read-only` or `writer` role for automatic acceptance inference. Explicit task mutation or no-edit intent wins; otherwise the declared role replaces agent-name guessing. This does not grant or revoke tools. |
 | `completionGuard` | Set `false` only for non-implementation agents that may mention implementation words while using mutation-capable tools such as `bash`. |
-| `interactive` | Parsed for compatibility but not enforced in v1. |
+| `interactive` | Parsed for compatibility but not currently enforced. |
 | `maxSubagentDepth` | Tightens nested delegation for this agent's children. |
 | `memory` | Opt-in role-specific persistent memory. `memory: { scope: "project" \| "user", path: "<name>" }` injects the first lines of a `MEMORY.md` from a dedicated `agent-memory/` directory into the child system prompt. Agents with write tools (`edit`/`write`/`bash`) get a read-write block; read-only agents get a read-only fallback. Project scope resolves under `<project>/.pi/agent-memory/`, user scope under `~/.pi/agent/agent-memory/`. Paths are validated against traversal and symlink escape. |
 
@@ -893,9 +893,12 @@ console.log(result.contract.digest, result.contract.tools.effectiveAllowlist);
 
 Preflight covers ordinary single-agent launch resolution under public contract version 2: selected agent identity and shadowed candidates, a versioned parsed-definition digest (including system prompt and launch-affecting model, tool, skill, extension, output, and memory fields), fresh/fork context, effective model and thinking, skill and tool resolution, direct MCP selections, runtime/configured extensions, artifact/session paths, async lifecycle/status/result/event/process-terminal paths, package/lifecycle versions, capability-ceiling audit data, and stable digests. `launchContractDigest` is the canonical digest of the caller task, effective system prompt (including the resolved `turnBudget` prompt augmentation when supplied), model candidates, effective tools/extensions/MCP (including inherited capability ceilings), output binding, and structured-output schema that ordinary foreground and async execution report in results/status/events and metadata. Runtime acceptance prose and output-task annotations are intentionally excluded because side-effect-free preflight does not resolve those host/runtime augmentations; the contract version and task digest make that boundary explicit. Raw prompts are not exposed in public contract output. It is side-effect-free for launch state: it does not create child sessions, temp prompt files, structured-output runtimes, tool-diagnostic files, or run artifacts. Some host-owned facts, such as exact fork snapshots, nested async roots, and live model registries, can only be proven by the Pi host; those appear as `host_required` diagnostics instead of silently pretending to be exact.
 
-### Delegation v1
+### Structured delegation API
 
-The compatibility v1 contract runs one configured foreground agent per request:
+Other Pi extensions can ask `pi-subagents` to run one configured foreground leaf
+agent through the structured delegation API. It uses the established
+`prompt-template:subagent:*` event family and the same executor as the
+`subagent` tool; it does not add another launcher.
 
 ```ts
 import {
@@ -906,51 +909,6 @@ import {
 } from "pi-subagents/delegation";
 
 const request: SubagentDelegationRequest = {
-  version: 1,
-  requestId: crypto.randomUUID(),
-  agent: "reviewer",
-  task: "Review the supplied evidence.",
-  context: "fresh",
-  cwd: ctx.cwd,
-  timeoutMs: 120_000,
-  toolBudget: { soft: 10, hard: 16, block: "*" },
-};
-
-const unsubscribe = pi.events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => {
-  const response = payload as SubagentDelegationResponse;
-  if (response.requestId !== request.requestId) return;
-  unsubscribe();
-  // Inspect response.status and the metadata present for this run.
-});
-pi.events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, request);
-```
-
-The contract uses the established `prompt-template:subagent:*` event transport and the same executor as the `subagent` tool; it does not add another launcher. New integrations must send `version: 1`. Requests are strict and single-agent only. They can set fresh or fork context, model, cwd, timeout, turn and tool-call budgets, skills, output behavior, acceptance, and artifact capture. Unknown or malformed fields return `invalid_request` before execution.
-
-Responses distinguish completion, failure, timeout, cancellation, interruption,
-turn or tool-budget exhaustion, explicit acceptance failure, invalid requests,
-and unavailable active context. Optional metadata is omitted when unavailable.
-Request IDs must be unique while active; duplicate active IDs are ignored so the
-original request keeps ownership of its terminal response. Emit
-`SUBAGENT_DELEGATION_CANCEL_EVENT` with the same version and request ID to cancel
-queued or active work.
-
-### Delegation v2
-
-V2 is the owned-leaf contract for workflow supervisors. Independent requests
-can overlap through the delegated executor without weakening the ordinary
-model-facing tool's one-foreground-call-per-turn guard.
-
-```ts
-import {
-  SUBAGENT_DELEGATION_REQUEST_EVENT,
-  SUBAGENT_DELEGATION_RESPONSE_EVENT,
-  type SubagentDelegationV2Request,
-  type SubagentDelegationV2Response,
-} from "pi-subagents/delegation";
-
-const request: SubagentDelegationV2Request = {
-  version: 2,
   requestId: crypto.randomUUID(),
   ownerRunId: workflowRunId,
   nodeId: "review-accuracy",
@@ -971,8 +929,8 @@ const request: SubagentDelegationV2Request = {
 };
 
 const unsubscribe = pi.events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => {
-  const response = payload as SubagentDelegationV2Response;
-  if (response.version !== 2 || response.requestId !== request.requestId) return;
+  const response = payload as SubagentDelegationResponse;
+  if (response.requestId !== request.requestId) return;
   if (response.ownerRunId !== request.ownerRunId || response.nodeId !== request.nodeId) return;
   unsubscribe();
   // Inspect response.status, response.result, response.usage, model, and thinking.
@@ -993,22 +951,28 @@ Terminal usage reports input, output, cache-read, cache-write, cost, turns, tool
 calls, and duration alongside the effective model and thinking level when
 known. Schemas are capped at 64 KiB; tasks and returned text/structured values
 are capped at 1 MiB, with smaller bounds on identity/configuration strings and
-a maximum v2 `timeoutMs` of 2,147,483,647. V2 alone accepts
+a maximum `timeoutMs` of 2,147,483,647. Structured delegation accepts
 `toolBudget: { hard: 0, block: "*" }` to block the first tool call and run a
-zero-tool leaf; delegation v1 and ordinary model-facing/configured budgets keep
-their existing minimum of one. The foreground bridge retains up to 8,192 exact
-pending-cancellation and settled-attempt identities per extension
-context. If either history fills, it fails closed with `unavailable_context`
-for later v2 starts rather than evicting identity facts; lifecycle reset clears
-the bounded history.
+zero-tool leaf; ordinary model-facing/configured budgets keep their existing
+minimum of one. The foreground bridge retains up to 8,192 exact
+pending-cancellation and settled-attempt identities per extension context. If
+either history fills, it fails closed with `unavailable_context` for later
+starts rather than evicting identity facts; lifecycle reset clears the bounded
+history.
 
-Delegation requires an active extension context. Emit requests from a supported event callback or queued application step, not by recursively invoking the `subagent` tool inside another tool's `tool_call` hook. The caller selects a configured agent, but agent discovery and effective tools remain package-owned. A request cannot grant arbitrary tools, and tool restrictions are not an operating-system sandbox. The detached RPC remains async-only; this API is foreground-only.
+Delegation requires an active extension context. Emit requests from a supported
+event callback or queued application step, not by recursively invoking the
+`subagent` tool inside another tool's `tool_call` hook. The caller selects a
+configured agent, but agent discovery and effective tools remain package-owned.
+A request cannot grant arbitrary tools, and tool restrictions are not an
+operating-system sandbox. The detached RPC remains async-only; this API is
+foreground-only.
 
-Existing prompt-template payloads and delegation v1 continue over the same event
-family. V2 remains foreground-only and inherits the configured agent's current
-tools, skills, context, model policy, and workspace authority; it is not a
-sandbox or a durable task broker. `pi-subagents/delegation` is the canonical
-contract for extension integrations.
+Unversioned prompt-template payloads with `requestId`, `agent`, `task`,
+`context`, `model`, and `cwd` are still accepted as a legacy bridge while we
+validate whether any integrations still use them. New integrations should use
+the structured owned-leaf request above. `pi-subagents/delegation` is the
+canonical contract for extension integrations.
 
 ## Capability ceilings
 

--- a/src/api/delegation.ts
+++ b/src/api/delegation.ts
@@ -1,8 +1,7 @@
-export const SUBAGENT_DELEGATION_PROTOCOL_VERSION = 1 as const;
-export const SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION = 2 as const;
-
-// This is the established extension-to-extension transport. The public API
-// intentionally reuses it instead of adding a second event protocol.
+// This is the established extension-to-extension transport. The structured
+// delegation API intentionally reuses it instead of adding a second event
+// protocol. Unstructured payloads on the same events remain the legacy
+// prompt-template bridge while we validate whether any integrations still use it.
 export const SUBAGENT_DELEGATION_REQUEST_EVENT = "prompt-template:subagent:request";
 export const SUBAGENT_DELEGATION_STARTED_EVENT = "prompt-template:subagent:started";
 export const SUBAGENT_DELEGATION_UPDATE_EVENT = "prompt-template:subagent:update";
@@ -20,114 +19,36 @@ export interface SubagentDelegationToolBudget {
 	block?: string[] | "*";
 }
 
-export interface SubagentDelegationAgentContract {
-	version: 1;
-}
-
 export type SubagentDelegationJsonSchemaObject = Record<string, unknown>;
 
-export interface SubagentDelegationExecutionResult {
-	status: "completed" | "failed" | "paused" | "stopped" | "detached";
-	success: boolean;
-	exitCode: number;
-	error?: string;
-	interrupted?: boolean;
-	timedOut?: boolean;
-	stopped?: boolean;
-	detached?: boolean;
-}
+export type SubagentDelegationThinking = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
-export interface SubagentDelegationReviewResult {
-	status: "not-requested" | "review-required" | "reviewed" | "blockers";
-	findings?: Array<{ severity: "blocker" | "non-blocking"; file?: string; issue: string; rationale: string }>;
-}
-
-export interface SubagentDelegationEffectsResult {
-	fileMutation?: {
-		status: "not-requested" | "not-applicable" | "observed" | "missing";
-		expected: boolean;
-		attempted: boolean;
-		message?: string;
-	};
-}
-
-export type SubagentDelegationAcceptanceEvidence =
-	| "changed-files"
-	| "tests-added"
-	| "commands-run"
-	| "validation-output"
-	| "residual-risks"
-	| "no-staged-files"
-	| "diff-summary"
-	| "review-findings"
-	| "manual-notes";
-
-export interface SubagentDelegationAcceptanceCriterion {
-	id: string;
-	must: string;
-	evidence?: SubagentDelegationAcceptanceEvidence[];
-	severity?: "required" | "recommended";
-}
-
-export interface SubagentDelegationAcceptanceVerifyCommand {
-	id: string;
-	command: string;
-	timeoutMs?: number;
-	cwd?: string;
-	env?: Record<string, string>;
-	allowFailure?: boolean;
-}
-
-export interface SubagentDelegationAcceptanceReview {
-	agent?: string;
-	focus?: string;
-	required?: boolean;
-}
-
-interface SubagentDelegationAcceptanceFields {
-	criteria?: Array<string | SubagentDelegationAcceptanceCriterion>;
-	evidence?: SubagentDelegationAcceptanceEvidence[];
-	verify?: SubagentDelegationAcceptanceVerifyCommand[];
-	review?: SubagentDelegationAcceptanceReview | false;
-	stopRules?: string[];
-}
-
-export type SubagentDelegationAcceptanceConfig = SubagentDelegationAcceptanceFields & (
-	| { level: "none"; reason: string }
-	| { level?: "auto" | "attested" | "checked" | "verified"; reason?: string }
-);
-
-export type SubagentDelegationAcceptance =
-	| "auto"
-	| "attested"
-	| "checked"
-	| "verified"
-	| false
-	| SubagentDelegationAcceptanceConfig;
+export type SubagentDelegationResultRequest =
+	| { kind: "text" }
+	| { kind: "structured"; schema: SubagentDelegationJsonSchemaObject };
 
 export interface SubagentDelegationRequest {
-	version: typeof SUBAGENT_DELEGATION_PROTOCOL_VERSION;
 	requestId: string;
+	ownerRunId: string;
+	nodeId: string;
 	agent: string;
 	task: string;
 	context: "fresh" | "fork";
 	cwd: string;
 	model?: string;
+	thinking?: SubagentDelegationThinking;
 	timeoutMs?: number;
 	turnBudget?: SubagentDelegationTurnBudget;
 	toolBudget?: SubagentDelegationToolBudget;
 	skill?: string | string[] | boolean;
-	output?: string | boolean;
-	outputMode?: "inline" | "file-only";
-	outputSchema?: SubagentDelegationJsonSchemaObject;
-	agentContract?: SubagentDelegationAgentContract;
-	acceptance?: SubagentDelegationAcceptance;
 	artifacts?: boolean;
+	result: SubagentDelegationResultRequest;
 }
 
 export interface SubagentDelegationStarted {
-	version: typeof SUBAGENT_DELEGATION_PROTOCOL_VERSION;
 	requestId: string;
+	ownerRunId: string;
+	nodeId: string;
 }
 
 export interface SubagentDelegationUpdate extends SubagentDelegationStarted {
@@ -154,102 +75,14 @@ export type SubagentDelegationStatus =
 	| "structured_output_failed"
 	| "acceptance_failed"
 	| "invalid_request"
-	| "unavailable_context";
+	| "unavailable_context"
+	| "duplicate_node";
 
-export type SubagentDelegationAcceptanceStatus =
-	| "pending"
-	| "not-required"
-	| "claimed"
-	| "attested"
-	| "checked"
-	| "verified"
-	| "review-required"
-	| "reviewed"
-	| "accepted"
-	| "rejected";
-
-export interface SubagentDelegationAcceptanceResult {
-	status: SubagentDelegationAcceptanceStatus;
-	evidenceStatus: Exclude<SubagentDelegationAcceptanceStatus, "review-required" | "reviewed" | "accepted">;
-	explicit: boolean;
-}
-
-export interface SubagentDelegationResponse extends SubagentDelegationStarted {
-	status: SubagentDelegationStatus;
-	error?: string;
-	runId?: string;
-	childIndex?: number;
-	agent?: string;
-	model?: string;
-	exitCode?: number;
-	execution?: SubagentDelegationExecutionResult;
-	output?: string;
-	outputPath?: string;
-	sessionFile?: string;
-	acceptance?: SubagentDelegationAcceptanceResult;
-	review?: SubagentDelegationReviewResult;
-	effects?: SubagentDelegationEffectsResult;
-	turns?: number;
-	toolCount?: number;
-	durationMs?: number;
-	tokens?: number;
-	warnings?: string[];
-}
-
-export interface SubagentDelegationCancel extends SubagentDelegationStarted {}
-
-export type SubagentDelegationV2Thinking = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
-
-export type SubagentDelegationV2ResultRequest =
-	| { kind: "text" }
-	| { kind: "structured"; schema: SubagentDelegationJsonSchemaObject };
-
-export interface SubagentDelegationV2Request {
-	version: typeof SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION;
-	requestId: string;
-	ownerRunId: string;
-	nodeId: string;
-	agent: string;
-	task: string;
-	context: "fresh" | "fork";
-	cwd: string;
-	model?: string;
-	thinking?: SubagentDelegationV2Thinking;
-	timeoutMs?: number;
-	turnBudget?: SubagentDelegationTurnBudget;
-	toolBudget?: SubagentDelegationToolBudget;
-	skill?: string | string[] | boolean;
-	artifacts?: boolean;
-	result: SubagentDelegationV2ResultRequest;
-}
-
-export interface SubagentDelegationV2Started {
-	version: typeof SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION;
-	requestId: string;
-	ownerRunId: string;
-	nodeId: string;
-}
-
-export interface SubagentDelegationV2Update extends SubagentDelegationV2Started {
-	runId?: string;
-	currentTool?: string;
-	currentToolArgs?: string;
-	recentOutput?: string;
-	recentOutputLines?: string[];
-	recentTools?: Array<{ tool: string; args: string }>;
-	model?: string;
-	toolCount?: number;
-	durationMs?: number;
-	tokens?: number;
-}
-
-export type SubagentDelegationV2Status = SubagentDelegationStatus | "duplicate_node";
-
-export type SubagentDelegationV2Value =
+export type SubagentDelegationValue =
 	| { kind: "text"; text: string }
 	| { kind: "structured"; value: unknown };
 
-export interface SubagentDelegationV2Usage {
+export interface SubagentDelegationUsage {
 	input: number;
 	output: number;
 	cacheRead: number;
@@ -260,8 +93,8 @@ export interface SubagentDelegationV2Usage {
 	durationMs: number;
 }
 
-export interface SubagentDelegationV2TerminalResponse extends SubagentDelegationV2Started {
-	status: Exclude<SubagentDelegationV2Status, "invalid_request">;
+export interface SubagentDelegationTerminalResponse extends SubagentDelegationStarted {
+	status: Exclude<SubagentDelegationStatus, "invalid_request">;
 	error?: string;
 	runId?: string;
 	agent?: string;
@@ -269,13 +102,12 @@ export interface SubagentDelegationV2TerminalResponse extends SubagentDelegation
 	thinking?: string;
 	exitCode?: number;
 	launchContractDigest?: string;
-	result?: SubagentDelegationV2Value;
-	usage?: SubagentDelegationV2Usage;
+	result?: SubagentDelegationValue;
+	usage?: SubagentDelegationUsage;
 }
 
-/** A malformed V2 request can only be correlated by the valid identity fields it supplied. */
-export interface SubagentDelegationV2InvalidResponse {
-	version: typeof SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION;
+/** A malformed structured request can only be correlated by the valid identity fields it supplied. */
+export interface SubagentDelegationInvalidResponse {
 	requestId: string;
 	ownerRunId?: string;
 	nodeId?: string;
@@ -283,6 +115,6 @@ export interface SubagentDelegationV2InvalidResponse {
 	error?: string;
 }
 
-export type SubagentDelegationV2Response = SubagentDelegationV2TerminalResponse | SubagentDelegationV2InvalidResponse;
+export type SubagentDelegationResponse = SubagentDelegationTerminalResponse | SubagentDelegationInvalidResponse;
 
-export interface SubagentDelegationV2Cancel extends SubagentDelegationV2Started {}
+export interface SubagentDelegationCancel extends SubagentDelegationStarted {}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -381,7 +381,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		getContext: () => state.lastUiContext,
 		execute: (requestId, params, signal, ctx, onUpdate) =>
 			executeSubagentCollapsed(requestId, params, signal, onUpdate, ctx),
-		executeVersioned: (requestId, params, signal, ctx, onUpdate) => {
+		executeStructured: (requestId, params, signal, ctx, onUpdate) => {
 			if (ctx.hasUI) ctx.ui.setToolsExpanded(false);
 			return executor.executeDelegated(requestId, params, signal, onUpdate, ctx);
 		},

--- a/src/slash/delegation-adapters.ts
+++ b/src/slash/delegation-adapters.ts
@@ -1,24 +1,13 @@
 import {
-	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
-	type SubagentDelegationAcceptanceResult,
-	type SubagentDelegationEffectsResult,
-	type SubagentDelegationExecutionResult,
 	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
-	type SubagentDelegationReviewResult,
 	type SubagentDelegationStatus,
+	type SubagentDelegationThinking,
 	type SubagentDelegationUpdate,
-	type SubagentDelegationV2Request,
-	type SubagentDelegationV2Response,
-	type SubagentDelegationV2Thinking,
-	type SubagentDelegationV2Value,
-	type SubagentDelegationV2Update,
+	type SubagentDelegationValue,
 } from "../api/delegation.ts";
 import type { AcceptanceInput, AgentContract, EffectsProjection, ExecutionProjection, JsonSchemaObject, ReviewProjection, ToolBudgetConfig, TurnBudgetConfig, Usage } from "../shared/types.ts";
-import { isAgentContractV1 } from "../runs/shared/agent-contract.ts";
 import { cloneJsonWithinByteLimit } from "./delegation-json.ts";
-
 
 export interface PromptTemplateDelegationRequest {
 	requestId: string;
@@ -66,6 +55,12 @@ export interface PromptTemplateDelegationUpdate {
 	taskProgress?: PromptTemplateDelegationTaskProgress[];
 }
 
+interface DelegationAcceptanceSnapshot {
+	status: string;
+	evidenceStatus?: string;
+	explicit?: boolean;
+}
+
 export interface PromptTemplateBridgeResult {
 	isError?: boolean;
 	content?: unknown;
@@ -94,7 +89,7 @@ export interface PromptTemplateBridgeResult {
 			sessionFile?: string;
 			agentContract?: AgentContract;
 			execution?: ExecutionProjection;
-			acceptance?: SubagentDelegationAcceptanceResult;
+			acceptance?: DelegationAcceptanceSnapshot;
 			review?: ReviewProjection;
 			effects?: EffectsProjection;
 			usage?: Usage;
@@ -126,7 +121,7 @@ export interface DelegatedSubagentExecutionParams {
 	cwd: string;
 	timeoutMs?: number;
 	turnBudget?: TurnBudgetConfig;
-	/** Internal-only strict turn-boundary enforcement for versioned foreground delegation. */
+	/** Internal-only strict turn-boundary enforcement for structured foreground delegation. */
 	enforceHardTurnLimit?: boolean;
 	toolBudget?: ToolBudgetConfig;
 	skill?: string | string[] | boolean;
@@ -137,14 +132,13 @@ export interface DelegatedSubagentExecutionParams {
 	acceptance?: AcceptanceInput;
 	artifacts?: boolean;
 	/** Internal-only thinking override accepted by executeDelegated. */
-	delegatedThinkingOverride?: SubagentDelegationV2Thinking;
-	/** Internal-only V2 capability accepted and stripped by executeDelegated. */
+	delegatedThinkingOverride?: SubagentDelegationThinking;
+	/** Internal-only capability accepted and stripped by executeDelegated. */
 	delegatedAllowZeroToolBudget?: true;
 	async: false;
 	foregroundOnly: true;
 	clarify: false;
 }
-
 
 export function parsePromptTemplateRequest(data: unknown): PromptTemplateDelegationRequest | undefined {
 	if (!data || typeof data !== "object") return undefined;
@@ -317,30 +311,6 @@ export function toSubagentDelegationExecutionParams(request: SubagentDelegationR
 		enforceHardTurnLimit: true,
 		toolBudget: request.toolBudget,
 		skill: request.skill,
-		output: request.output,
-		outputMode: request.outputMode,
-		outputSchema: request.outputSchema,
-		agentContract: request.agentContract,
-		acceptance: request.acceptance,
-		artifacts: request.artifacts,
-		async: false,
-		foregroundOnly: true,
-		clarify: false,
-	};
-}
-
-export function toSubagentDelegationV2ExecutionParams(request: SubagentDelegationV2Request): DelegatedSubagentExecutionParams {
-	return {
-		agent: request.agent,
-		task: request.task,
-		context: request.context,
-		cwd: request.cwd,
-		model: request.model,
-		timeoutMs: request.timeoutMs,
-		turnBudget: request.turnBudget,
-		enforceHardTurnLimit: true,
-		toolBudget: request.toolBudget,
-		skill: request.skill,
 		output: false,
 		...(request.result.kind === "structured" ? { outputSchema: request.result.schema } : {}),
 		acceptance: false,
@@ -353,33 +323,13 @@ export function toSubagentDelegationV2ExecutionParams(request: SubagentDelegatio
 	};
 }
 
-export function toSubagentDelegationUpdate(requestId: string, result: PromptTemplateBridgeResult): SubagentDelegationUpdate | undefined {
-	const legacy = toDelegationUpdate(requestId, result);
-	if (!legacy) return undefined;
-	return {
-		version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-		requestId,
-		...(legacy.runId ? { runId: legacy.runId } : {}),
-		...(legacy.currentTool ? { currentTool: legacy.currentTool } : {}),
-		...(legacy.currentToolArgs ? { currentToolArgs: legacy.currentToolArgs } : {}),
-		...(legacy.recentOutput ? { recentOutput: legacy.recentOutput } : {}),
-		...(legacy.recentOutputLines ? { recentOutputLines: legacy.recentOutputLines } : {}),
-		...(legacy.recentTools ? { recentTools: legacy.recentTools } : {}),
-		...(legacy.model ? { model: legacy.model } : {}),
-		...(typeof legacy.toolCount === "number" ? { toolCount: legacy.toolCount } : {}),
-		...(typeof legacy.durationMs === "number" ? { durationMs: legacy.durationMs } : {}),
-		...(typeof legacy.tokens === "number" ? { tokens: legacy.tokens } : {}),
-	};
-}
-
-export function toSubagentDelegationV2Update(
-	request: SubagentDelegationV2Request,
+export function toSubagentDelegationUpdate(
+	request: SubagentDelegationRequest,
 	result: PromptTemplateBridgeResult,
-): SubagentDelegationV2Update | undefined {
+): SubagentDelegationUpdate | undefined {
 	const legacy = toDelegationUpdate(request.requestId, result);
 	if (!legacy) return undefined;
 	return {
-		version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 		requestId: request.requestId,
 		ownerRunId: request.ownerRunId,
 		nodeId: request.nodeId,
@@ -407,66 +357,30 @@ function resolveSubagentDelegationStatus(
 	if (child?.structuredOutputFailed) return "structured_output_failed";
 	if (child?.turnBudgetExceeded) return "turn_budget_exhausted";
 	if (child?.toolBudgetBlocked) return "tool_budget_exhausted";
-	if (!isAgentContractV1(child.agentContract) && child?.acceptance?.status === "rejected" && child.acceptance.explicit) return "acceptance_failed";
+	if (child?.acceptance?.status === "rejected" && child.acceptance.explicit) return "acceptance_failed";
 	if (result.details?.stopped || child?.stopped || child?.interrupted) return "interrupted";
 	if (result.isError || child?.error || (typeof child?.exitCode === "number" && child.exitCode !== 0)) return "failed";
 	return "completed";
 }
 
+const MAX_RESULT_BYTES = 1024 * 1024;
+
 export function toSubagentDelegationResponse(
-	requestId: string,
+	request: SubagentDelegationRequest,
 	result: PromptTemplateBridgeResult,
 	aborted: boolean,
 ): SubagentDelegationResponse {
 	const child = result.details?.results?.[0];
 	const progress = child?.progressSummary ?? result.details?.progress?.[0];
-	const warnings = [child?.skillsWarning, child?.outputSaveError, child?.transcriptError]
-		.filter((warning): warning is string => typeof warning === "string" && warning.length > 0);
-	const status = resolveSubagentDelegationStatus(result, aborted);
-	const fallbackError = status === "failed" ? firstTextContent(result.content) : undefined;
-	return {
-		version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-		requestId,
-		status,
-		...(child?.error || fallbackError ? { error: child?.error ?? fallbackError } : {}),
-		...(result.details?.runId ? { runId: result.details.runId } : {}),
-		...(child ? { childIndex: 0 } : {}),
-		...(child?.agent ? { agent: child.agent } : {}),
-		...(child?.model ? { model: child.model } : {}),
-		...(typeof child?.exitCode === "number" ? { exitCode: child.exitCode } : {}),
-		...(child?.execution ? { execution: child.execution as SubagentDelegationExecutionResult } : {}),
-		...(child?.finalOutput ? { output: child.finalOutput } : {}),
-		...(child?.savedOutputPath ? { outputPath: child.savedOutputPath } : {}),
-		...(child?.sessionFile ? { sessionFile: child.sessionFile } : {}),
-		...(child?.acceptance ? { acceptance: { status: child.acceptance.status, evidenceStatus: child.acceptance.evidenceStatus, explicit: child.acceptance.explicit } } : {}),
-		...(child?.review ? { review: child.review as SubagentDelegationReviewResult } : {}),
-		...(child?.effects ? { effects: child.effects as SubagentDelegationEffectsResult } : {}),
-		...(typeof child?.usage?.turns === "number" ? { turns: child.usage.turns } : {}),
-		...(typeof progress?.toolCount === "number" ? { toolCount: progress.toolCount } : {}),
-		...(typeof progress?.durationMs === "number" ? { durationMs: progress.durationMs } : {}),
-		...(typeof progress?.tokens === "number" ? { tokens: progress.tokens } : {}),
-		...(warnings.length > 0 ? { warnings } : {}),
-	};
-}
-
-const MAX_V2_RESULT_BYTES = 1024 * 1024;
-
-export function toSubagentDelegationV2Response(
-	request: SubagentDelegationV2Request,
-	result: PromptTemplateBridgeResult,
-	aborted: boolean,
-): SubagentDelegationV2Response {
-	const child = result.details?.results?.[0];
-	const progress = child?.progressSummary ?? result.details?.progress?.[0];
 	let status = resolveSubagentDelegationStatus(result, aborted);
 	let error = child?.error ?? (status === "failed" ? firstTextContent(result.content) : undefined);
-	let projectedResult: SubagentDelegationV2Value | undefined;
+	let projectedResult: SubagentDelegationValue | undefined;
 	if (status === "completed") {
 		if (request.result.kind === "text") {
 			if (typeof child?.finalOutput !== "string") {
 				status = "failed";
 				error = "Delegated subagent did not capture a text result.";
-			} else if (Buffer.byteLength(child.finalOutput, "utf8") > MAX_V2_RESULT_BYTES) {
+			} else if (Buffer.byteLength(child.finalOutput, "utf8") > MAX_RESULT_BYTES) {
 				status = "failed";
 				error = "Delegated text result exceeds 1 MiB when UTF-8 encoded.";
 			} else {
@@ -476,7 +390,7 @@ export function toSubagentDelegationV2Response(
 			status = "failed";
 			error = "Delegated subagent did not capture the requested structured result.";
 		} else {
-			const inspected = cloneJsonWithinByteLimit(child.structuredOutput, MAX_V2_RESULT_BYTES);
+			const inspected = cloneJsonWithinByteLimit(child.structuredOutput, MAX_RESULT_BYTES);
 			if (inspected.ok === false) {
 				status = "failed";
 				error = inspected.reason === "too_large"
@@ -490,7 +404,6 @@ export function toSubagentDelegationV2Response(
 	const usage = child?.usage;
 	const childLaunchContractDigest = (child as { launchContractDigest?: string } | undefined)?.launchContractDigest;
 	return {
-		version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 		requestId: request.requestId,
 		ownerRunId: request.ownerRunId,
 		nodeId: request.nodeId,

--- a/src/slash/delegation-request.ts
+++ b/src/slash/delegation-request.ts
@@ -1,40 +1,15 @@
 import {
-	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	type SubagentDelegationRequest,
-	type SubagentDelegationV2Request,
 } from "../api/delegation.ts";
-import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
 import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
 import { cloneJsonWithinByteLimit } from "./delegation-json.ts";
 
 export type SubagentDelegationParseResult =
-	| { ok: true; request: SubagentDelegationRequest | SubagentDelegationV2Request }
-	| { ok: false; version?: 1 | 2; requestId?: string; ownerRunId?: string; nodeId?: string; error: string };
+	| { ok: true; request: SubagentDelegationRequest }
+	| { ok: false; requestId?: string; ownerRunId?: string; nodeId?: string; error: string };
 
-const v1SupportedFields = new Set([
-	"version",
-	"requestId",
-	"agent",
-	"task",
-	"context",
-	"cwd",
-	"model",
-	"timeoutMs",
-	"turnBudget",
-	"toolBudget",
-	"skill",
-	"output",
-	"outputMode",
-	"outputSchema",
-	"agentContract",
-	"acceptance",
-	"artifacts",
-]);
-
-const v2SupportedFields = new Set([
-	"version",
+const supportedFields = new Set([
 	"requestId",
 	"ownerRunId",
 	"nodeId",
@@ -52,13 +27,13 @@ const v2SupportedFields = new Set([
 	"result",
 ]);
 
-const v2ThinkingLevels = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+const thinkingLevels = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
 const MAX_SCHEMA_BYTES = 64 * 1024;
-const MAX_V2_TASK_BYTES = 1024 * 1024;
-const MAX_V2_CWD_BYTES = 32 * 1024;
-const MAX_V2_SHORT_TEXT_BYTES = 1024;
-const MAX_V2_SKILL_ENTRIES = 256;
-const MAX_V2_SKILL_AGGREGATE_BYTES = 64 * 1024;
+const MAX_TASK_BYTES = 1024 * 1024;
+const MAX_CWD_BYTES = 32 * 1024;
+const MAX_SHORT_TEXT_BYTES = 1024;
+const MAX_SKILL_ENTRIES = 256;
+const MAX_SKILL_AGGREGATE_BYTES = 64 * 1024;
 
 function nonEmptyString(value: unknown): value is string {
 	return typeof value === "string" && value.trim().length > 0;
@@ -69,10 +44,26 @@ function validateId(value: unknown): string | undefined {
 	return value;
 }
 
-function validateSharedFields(
-	value: Record<string, unknown>,
-	identity: { requestId: string; version?: 1 | 2; ownerRunId?: string; nodeId?: string },
-): SubagentDelegationParseResult | undefined {
+export function parseSubagentDelegationRequest(data: unknown): SubagentDelegationParseResult {
+	if (!data || typeof data !== "object" || Array.isArray(data)) {
+		return { ok: false, error: "Delegation request must be an object." };
+	}
+	const value = data as Record<string, unknown>;
+	const requestId = validateId(value.requestId);
+	if (!requestId) {
+		return { ok: false, error: "Delegation requestId must be a non-empty string of at most 256 characters without newlines." };
+	}
+	const ownerRunId = validateId(value.ownerRunId);
+	if (!ownerRunId) {
+		return { ok: false, requestId, error: "Delegation ownerRunId must be a non-empty string of at most 256 characters without newlines." };
+	}
+	const nodeId = validateId(value.nodeId);
+	if (!nodeId) {
+		return { ok: false, requestId, ownerRunId, error: "Delegation nodeId must be a non-empty string of at most 256 characters without newlines." };
+	}
+	const identity = { requestId, ownerRunId, nodeId };
+	const unsupportedField = Object.keys(value).find((key) => !supportedFields.has(key));
+	if (unsupportedField) return { ok: false, ...identity, error: `Unsupported delegation field: ${unsupportedField}.` };
 	if (!nonEmptyString(value.agent)) return { ok: false, ...identity, error: "Delegation agent must be a non-empty string." };
 	if (!nonEmptyString(value.task)) return { ok: false, ...identity, error: "Delegation task must be a non-empty string." };
 	if (value.context !== "fresh" && value.context !== "fork") {
@@ -86,8 +77,8 @@ function validateSharedFields(
 		return { ok: false, ...identity, error: "timeoutMs must be an integer >= 1." };
 	}
 	const timeoutMs = typeof value.timeoutMs === "number" ? value.timeoutMs : undefined;
-	if (identity.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION && timeoutMs !== undefined && timeoutMs > 2_147_483_647) {
-		return { ok: false, ...identity, error: "timeoutMs must be <= 2147483647 for delegation v2." };
+	if (timeoutMs !== undefined && timeoutMs > 2_147_483_647) {
+		return { ok: false, ...identity, error: "timeoutMs must be <= 2147483647." };
 	}
 	const turnBudget = resolveTurnBudgetConfig(value.turnBudget);
 	if (turnBudget.error) return { ok: false, ...identity, error: turnBudget.error };
@@ -97,11 +88,7 @@ function validateSharedFields(
 			return { ok: false, ...identity, error: `toolBudget.${unsupportedToolBudgetField} is not supported.` };
 		}
 	}
-	const toolBudget = validateToolBudgetConfig(
-		value.toolBudget,
-		"toolBudget",
-		identity.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION ? { minimumHard: 0 } : undefined,
-	);
+	const toolBudget = validateToolBudgetConfig(value.toolBudget, "toolBudget", { minimumHard: 0 });
 	if (toolBudget.error) return { ok: false, ...identity, error: toolBudget.error };
 	if (value.skill !== undefined) {
 		const validSkill = typeof value.skill === "boolean"
@@ -114,46 +101,29 @@ function validateSharedFields(
 	if (value.artifacts !== undefined && typeof value.artifacts !== "boolean") {
 		return { ok: false, ...identity, error: "artifacts must be a boolean." };
 	}
-	return undefined;
-}
-
-function parseV2(value: Record<string, unknown>, requestId: string): SubagentDelegationParseResult {
-	const ownerRunId = validateId(value.ownerRunId);
-	if (!ownerRunId) {
-		return { ok: false, version: 2, requestId, error: "Delegation ownerRunId must be a non-empty string of at most 256 characters without newlines." };
-	}
-	const nodeId = validateId(value.nodeId);
-	if (!nodeId) {
-		return { ok: false, version: 2, requestId, ownerRunId, error: "Delegation nodeId must be a non-empty string of at most 256 characters without newlines." };
-	}
-	const identity = { version: 2 as const, requestId, ownerRunId, nodeId };
-	const unsupportedField = Object.keys(value).find((key) => !v2SupportedFields.has(key));
-	if (unsupportedField) return { ok: false, ...identity, error: `Unsupported delegation field: ${unsupportedField}.` };
-	const sharedError = validateSharedFields(value, identity);
-	if (sharedError) return sharedError;
-	if (Buffer.byteLength(value.task as string, "utf8") > MAX_V2_TASK_BYTES) {
+	if (Buffer.byteLength(value.task as string, "utf8") > MAX_TASK_BYTES) {
 		return { ok: false, ...identity, error: "Delegation task exceeds 1 MiB when UTF-8 encoded." };
 	}
-	if (Buffer.byteLength(value.cwd as string, "utf8") > MAX_V2_CWD_BYTES) {
+	if (Buffer.byteLength(value.cwd as string, "utf8") > MAX_CWD_BYTES) {
 		return { ok: false, ...identity, error: "Delegation cwd exceeds 32 KiB when UTF-8 encoded." };
 	}
-	if (Buffer.byteLength(value.agent as string, "utf8") > MAX_V2_SHORT_TEXT_BYTES) {
+	if (Buffer.byteLength(value.agent as string, "utf8") > MAX_SHORT_TEXT_BYTES) {
 		return { ok: false, ...identity, error: "Delegation agent exceeds 1 KiB when UTF-8 encoded." };
 	}
-	if (typeof value.model === "string" && Buffer.byteLength(value.model, "utf8") > MAX_V2_SHORT_TEXT_BYTES) {
+	if (typeof value.model === "string" && Buffer.byteLength(value.model, "utf8") > MAX_SHORT_TEXT_BYTES) {
 		return { ok: false, ...identity, error: "Delegation model exceeds 1 KiB when UTF-8 encoded." };
 	}
 	const skillEntries = typeof value.skill === "string" ? [value.skill] : Array.isArray(value.skill) ? value.skill as string[] : [];
-	if (skillEntries.length > MAX_V2_SKILL_ENTRIES) {
+	if (skillEntries.length > MAX_SKILL_ENTRIES) {
 		return { ok: false, ...identity, error: "Delegation skill supports at most 256 entries." };
 	}
-	if (skillEntries.some((entry) => Buffer.byteLength(entry, "utf8") > MAX_V2_SHORT_TEXT_BYTES)) {
+	if (skillEntries.some((entry) => Buffer.byteLength(entry, "utf8") > MAX_SHORT_TEXT_BYTES)) {
 		return { ok: false, ...identity, error: "Delegation skill entry exceeds 1 KiB when UTF-8 encoded." };
 	}
-	if (skillEntries.reduce((total, entry) => total + Buffer.byteLength(entry, "utf8"), 0) > MAX_V2_SKILL_AGGREGATE_BYTES) {
+	if (skillEntries.reduce((total, entry) => total + Buffer.byteLength(entry, "utf8"), 0) > MAX_SKILL_AGGREGATE_BYTES) {
 		return { ok: false, ...identity, error: "Delegation skill entries exceed 64 KiB in aggregate when UTF-8 encoded." };
 	}
-	if (value.thinking !== undefined && (typeof value.thinking !== "string" || !v2ThinkingLevels.has(value.thinking))) {
+	if (value.thinking !== undefined && (typeof value.thinking !== "string" || !thinkingLevels.has(value.thinking))) {
 		return { ok: false, ...identity, error: "thinking must be one of off, minimal, low, medium, high, xhigh, or max." };
 	}
 	if (!value.result || typeof value.result !== "object" || Array.isArray(value.result)) {
@@ -191,60 +161,6 @@ function parseV2(value: Record<string, unknown>, requestId: string): SubagentDel
 			result: structuredSchema
 				? { kind: "structured", schema: structuredSchema }
 				: { kind: "text" },
-		} as unknown as SubagentDelegationV2Request,
+		} as unknown as SubagentDelegationRequest,
 	};
-}
-
-function parseV1(value: Record<string, unknown>, requestId: string): SubagentDelegationParseResult {
-	const unsupportedField = Object.keys(value).find((key) => !v1SupportedFields.has(key));
-	if (unsupportedField) return { ok: false, requestId, error: `Unsupported delegation field: ${unsupportedField}.` };
-	const sharedError = validateSharedFields(value, { requestId });
-	if (sharedError) return sharedError;
-	if (value.output !== undefined && typeof value.output !== "boolean" && !nonEmptyString(value.output)) {
-		return { ok: false, requestId, error: "output must be a boolean or non-empty string." };
-	}
-	if (value.outputMode !== undefined && value.outputMode !== "inline" && value.outputMode !== "file-only") {
-		return { ok: false, requestId, error: "outputMode must be inline or file-only." };
-	}
-	if (value.outputMode === "file-only" && !nonEmptyString(value.output)) {
-		return { ok: false, requestId, error: 'outputMode "file-only" requires output to be a non-empty path.' };
-	}
-	if (value.outputSchema !== undefined && (!value.outputSchema || typeof value.outputSchema !== "object" || Array.isArray(value.outputSchema))) {
-		return { ok: false, requestId, error: "outputSchema must be a JSON Schema object." };
-	}
-	if (value.agentContract !== undefined) {
-		if (!value.agentContract || typeof value.agentContract !== "object" || Array.isArray(value.agentContract)) return { ok: false, requestId, error: "agentContract must be an object." };
-		const contract = value.agentContract as Record<string, unknown>;
-		if (contract.version !== 1 || Object.keys(contract).some((key) => key !== "version")) return { ok: false, requestId, error: "agentContract must be { version: 1 }." };
-	}
-	const acceptanceErrors = validateAcceptanceInput(value.acceptance);
-	if (acceptanceErrors.length > 0) return { ok: false, requestId, error: acceptanceErrors.join(" ") };
-	return { ok: true, request: value as unknown as SubagentDelegationRequest };
-}
-
-export function parseSubagentDelegationRequest(data: unknown): SubagentDelegationParseResult {
-	if (!data || typeof data !== "object" || Array.isArray(data)) {
-		return { ok: false, error: "Delegation request must be an object." };
-	}
-	const value = data as Record<string, unknown>;
-	const requestId = validateId(value.requestId);
-	if (value.version !== SUBAGENT_DELEGATION_PROTOCOL_VERSION && value.version !== SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
-		return {
-			...(requestId ? { requestId } : {}),
-			ok: false,
-			error: `Unsupported delegation protocol version: ${String(value.version)}.`,
-		};
-	}
-	if (!requestId) {
-		return { ok: false, error: "Delegation requestId must be a non-empty string of at most 256 characters without newlines." };
-	}
-	if (value.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
-		// Preserve the v1 parser's historical diagnostic for a v1-shaped payload
-		// whose version alone was changed to 2.
-		if (!Object.hasOwn(value, "ownerRunId") && !Object.hasOwn(value, "nodeId") && !Object.hasOwn(value, "result")) {
-			return { ok: false, version: 2, requestId, error: "Unsupported delegation protocol version: 2." };
-		}
-		return parseV2(value, requestId);
-	}
-	return parseV1(value, requestId);
 }

--- a/src/slash/prompt-template-bridge.ts
+++ b/src/slash/prompt-template-bridge.ts
@@ -1,16 +1,12 @@
 import {
 	SUBAGENT_DELEGATION_CANCEL_EVENT,
-	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
 	SUBAGENT_DELEGATION_RESPONSE_EVENT,
 	SUBAGENT_DELEGATION_STARTED_EVENT,
 	SUBAGENT_DELEGATION_UPDATE_EVENT,
+	type SubagentDelegationInvalidResponse,
 	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
-	type SubagentDelegationV2InvalidResponse,
-	type SubagentDelegationV2Request,
-	type SubagentDelegationV2Response,
 } from "../api/delegation.ts";
 import { parseSubagentDelegationRequest } from "./delegation-request.ts";
 import {
@@ -21,9 +17,6 @@ import {
 	toSubagentDelegationExecutionParams,
 	toSubagentDelegationResponse,
 	toSubagentDelegationUpdate,
-	toSubagentDelegationV2ExecutionParams,
-	toSubagentDelegationV2Response,
-	toSubagentDelegationV2Update,
 	type DelegatedSubagentExecutionParams,
 	type PromptTemplateBridgeResult,
 	type PromptTemplateDelegationRequest,
@@ -51,11 +44,8 @@ interface PromptTemplateBridgeOptions<Ctx extends { cwd?: string }> {
 		ctx: Ctx,
 		onUpdate: (result: PromptTemplateBridgeResult) => void,
 	) => Promise<PromptTemplateBridgeResult>;
-	/**
-	 * Concurrent-safe executor for strict versioned delegation requests.
-	 * Non-versioned prompt-template requests retain the ordinary single-dispatch guard.
-	 */
-	executeVersioned?: (
+	/** Concurrent-safe executor for structured delegation requests. */
+	executeStructured?: (
 		requestId: string,
 		params: DelegatedSubagentExecutionParams,
 		signal: AbortSignal,
@@ -64,32 +54,43 @@ interface PromptTemplateBridgeOptions<Ctx extends { cwd?: string }> {
 	) => Promise<PromptTemplateBridgeResult>;
 }
 
+function hasStructuredDelegationMarker(data: unknown): boolean {
+	if (!data || typeof data !== "object" || Array.isArray(data)) return false;
+	const value = data as Record<string, unknown>;
+	return Object.hasOwn(value, "ownerRunId")
+		|| Object.hasOwn(value, "nodeId")
+		|| Object.hasOwn(value, "result")
+		|| Object.hasOwn(value, "version");
+}
+
+function validId(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0 && value.length <= 256 && !/[\r\n]/.test(value);
+}
+
 export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: string }>(
 	options: PromptTemplateBridgeOptions<Ctx>,
 ): {
 	cancelAll: () => void;
 	dispose: () => void;
 } {
-	// Legacy and V1 retain requestId-only correlation. V2 attempts are isolated by
-	// their complete wire identity, while logical-node ownership is tracked separately.
-	const controllers = new Map<string, AbortController>();
-	const pendingCancels = new Map<string, true>();
-	const v2Controllers = new Map<string, AbortController>();
-	const pendingV2Cancels = new Map<string, true>();
-	const activeV2Nodes = new Map<string, { attemptKey: string; controller: AbortController }>();
-	const settledV2Attempts = new Map<string, true>();
+	const legacyControllers = new Map<string, AbortController>();
+	const pendingLegacyCancels = new Map<string, true>();
+	const attemptControllers = new Map<string, AbortController>();
+	const pendingAttemptCancels = new Map<string, true>();
+	const activeOwnedNodes = new Map<string, { attemptKey: string; controller: AbortController }>();
+	const settledAttempts = new Map<string, true>();
 	const subscriptions: Array<() => void> = [];
 	let disposed = false;
-	let v2IdentitySaturated = false;
+	let identitySaturated = false;
 
 	const subscribe = (event: string, handler: (data: unknown) => void): void => {
 		const unsubscribe = options.events.on(event, handler);
 		if (typeof unsubscribe === "function") subscriptions.push(unsubscribe);
 	};
-	const ownsRequest = (requestId: string, controller: AbortController): boolean =>
-		!disposed && controllers.get(requestId) === controller;
-	const ownsV2Attempt = (attemptKey: string, controller: AbortController): boolean =>
-		!disposed && v2Controllers.get(attemptKey) === controller;
+	const ownsLegacyRequest = (requestId: string, controller: AbortController): boolean =>
+		!disposed && legacyControllers.get(requestId) === controller;
+	const ownsAttempt = (attemptKey: string, controller: AbortController): boolean =>
+		!disposed && attemptControllers.get(attemptKey) === controller;
 	const boundedRemember = (map: Map<string, true>, key: string): void => {
 		map.delete(key);
 		map.set(key, true);
@@ -99,28 +100,27 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 			map.delete(oldest);
 		}
 	};
-	const rememberV2Identity = (map: Map<string, true>, key: string): void => {
-		if (map.has(key) || v2IdentitySaturated) return;
+	const rememberIdentity = (map: Map<string, true>, key: string): void => {
+		if (map.has(key) || identitySaturated) return;
 		if (map.size >= 8_192) {
-			v2IdentitySaturated = true;
+			identitySaturated = true;
 			return;
 		}
 		map.set(key, true);
 		if (map.size === 8_192) {
-			// V2 identity facts are security state, not an LRU cache. Saturate as
-			// soon as the bounded history fills so no later untracked attempt can
-			// start, rather than evicting a cancellation or settled-attempt fact.
-			v2IdentitySaturated = true;
+			// Exact cancellation and terminal-attempt facts are security state, not an
+			// LRU cache. Once full, fail closed rather than evicting identity facts.
+			identitySaturated = true;
 		}
 	};
-	const v2NodeKey = (ownerRunId: string, nodeId: string): string => JSON.stringify([ownerRunId, nodeId]);
-	const v2AttemptKey = (requestId: string, ownerRunId: string, nodeId: string): string => JSON.stringify([requestId, ownerRunId, nodeId]);
-	const rememberPendingCancel = (requestId: string): void => {
-		boundedRemember(pendingCancels, requestId);
+	const nodeKey = (ownerRunId: string, nodeId: string): string => JSON.stringify([ownerRunId, nodeId]);
+	const attemptKey = (requestId: string, ownerRunId: string, nodeId: string): string => JSON.stringify([requestId, ownerRunId, nodeId]);
+	const rememberPendingLegacyCancel = (requestId: string): void => {
+		boundedRemember(pendingLegacyCancels, requestId);
 	};
-	const emitV2Terminal = (attemptKey: string, payload: SubagentDelegationV2Response): void => {
-		if (disposed || settledV2Attempts.has(attemptKey)) return;
-		rememberV2Identity(settledV2Attempts, attemptKey);
+	const emitTerminal = (key: string, payload: SubagentDelegationResponse): void => {
+		if (disposed || settledAttempts.has(key)) return;
+		rememberIdentity(settledAttempts, key);
 		options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, payload);
 	};
 
@@ -128,79 +128,58 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 		if (!data || typeof data !== "object" || Array.isArray(data)) return;
 		const value = data as Record<string, unknown>;
 		const requestId = value.requestId;
-		if (typeof requestId !== "string" || !requestId.trim() || requestId.length > 256 || /[\r\n]/.test(requestId)) return;
-		if (Object.hasOwn(value, "version")) {
-			if (value.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
-				if (Object.keys(value).some((key) => key !== "version" && key !== "requestId" && key !== "ownerRunId" && key !== "nodeId")) return;
-				const ownerRunId = value.ownerRunId;
-				const nodeId = value.nodeId;
-				if (typeof ownerRunId !== "string" || !ownerRunId.trim() || ownerRunId.length > 256 || /[\r\n]/.test(ownerRunId)) return;
-				if (typeof nodeId !== "string" || !nodeId.trim() || nodeId.length > 256 || /[\r\n]/.test(nodeId)) return;
-				const attemptKey = v2AttemptKey(requestId, ownerRunId, nodeId);
-				const controller = v2Controllers.get(attemptKey);
-				if (controller) controller.abort();
-				else rememberV2Identity(pendingV2Cancels, attemptKey);
-				return;
-			}
-			if (value.version !== SUBAGENT_DELEGATION_PROTOCOL_VERSION) return;
-			if (Object.keys(value).some((key) => key !== "version" && key !== "requestId")) return;
+		if (!validId(requestId)) return;
+		if (hasStructuredDelegationMarker(data)) {
+			if (Object.keys(value).some((key) => key !== "requestId" && key !== "ownerRunId" && key !== "nodeId")) return;
+			const ownerRunId = value.ownerRunId;
+			const nodeId = value.nodeId;
+			if (!validId(ownerRunId) || !validId(nodeId)) return;
+			const key = attemptKey(requestId, ownerRunId, nodeId);
+			const controller = attemptControllers.get(key);
+			if (controller) controller.abort();
+			else rememberIdentity(pendingAttemptCancels, key);
+			return;
 		}
-		const controller = controllers.get(requestId);
+		const controller = legacyControllers.get(requestId);
 		if (controller) {
 			controller.abort();
 			return;
 		}
-		rememberPendingCancel(requestId);
+		rememberPendingLegacyCancel(requestId);
 	});
 
 	subscribe(PROMPT_TEMPLATE_SUBAGENT_REQUEST_EVENT, async (data) => {
-		const isVersioned = !!data && typeof data === "object" && Object.hasOwn(data, "version");
+		const structuredPayload = hasStructuredDelegationMarker(data);
 		let requestId: string;
 		let params: DelegatedSubagentExecutionParams;
-		let versionedRequest: SubagentDelegationRequest | SubagentDelegationV2Request | undefined;
-		let v2Request: SubagentDelegationV2Request | undefined;
-		let v2Key: string | undefined;
+		let structuredRequest: SubagentDelegationRequest | undefined;
+		let key: string | undefined;
 		let legacyRequest: PromptTemplateDelegationRequest | undefined;
 
-		if (isVersioned) {
+		if (structuredPayload) {
 			const parsed = parseSubagentDelegationRequest(data);
 			if (parsed.ok === false) {
 				if (!disposed && parsed.requestId) {
-					if (parsed.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
-						const payload = {
-							version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
-							requestId: parsed.requestId,
-							...(parsed.ownerRunId ? { ownerRunId: parsed.ownerRunId } : {}),
-							...(parsed.nodeId ? { nodeId: parsed.nodeId } : {}),
-							status: "invalid_request",
-							error: parsed.error,
-						} satisfies SubagentDelegationV2InvalidResponse;
-						if (parsed.ownerRunId && parsed.nodeId) {
-							const attemptKey = v2AttemptKey(parsed.requestId, parsed.ownerRunId, parsed.nodeId);
-							if (!v2Controllers.has(attemptKey)) emitV2Terminal(attemptKey, payload);
-						} else {
-							options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, payload);
-						}
-					} else if (!controllers.has(parsed.requestId)) {
-						options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
-							version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-							requestId: parsed.requestId,
-							status: "invalid_request",
-							error: parsed.error,
-						} satisfies SubagentDelegationResponse);
+					const payload = {
+						requestId: parsed.requestId,
+						...(parsed.ownerRunId ? { ownerRunId: parsed.ownerRunId } : {}),
+						...(parsed.nodeId ? { nodeId: parsed.nodeId } : {}),
+						status: "invalid_request",
+						error: parsed.error,
+					} satisfies SubagentDelegationInvalidResponse;
+					if (parsed.ownerRunId && parsed.nodeId) {
+						const attemptedKey = attemptKey(parsed.requestId, parsed.ownerRunId, parsed.nodeId);
+						if (!attemptControllers.has(attemptedKey)) emitTerminal(attemptedKey, payload);
+					} else {
+						options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, payload);
 					}
 				}
 				return;
 			}
-			versionedRequest = parsed.request;
+			structuredRequest = parsed.request;
 			requestId = parsed.request.requestId;
-			if (parsed.request.version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
-				v2Request = parsed.request;
-				v2Key = v2AttemptKey(requestId, parsed.request.ownerRunId, parsed.request.nodeId);
-				params = toSubagentDelegationV2ExecutionParams(parsed.request);
-			} else {
-				params = toSubagentDelegationExecutionParams(parsed.request);
-			}
+			key = attemptKey(requestId, parsed.request.ownerRunId, parsed.request.nodeId);
+			params = toSubagentDelegationExecutionParams(parsed.request);
 		} else {
 			if (data && typeof data === "object" && !Array.isArray(data)) {
 				const legacy = data as Record<string, unknown>;
@@ -222,39 +201,34 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 			params = toLegacyExecutionParams(legacyRequest);
 		}
 
-		// Legacy and V1 keep requestId-only ownership. V2 retransmission and terminal
-		// suppression use the full tuple, independently from logical-node ownership.
-		if (!v2Request && controllers.has(requestId)) return;
-		if (v2Request && v2Key) {
-			if (v2Controllers.has(v2Key) || settledV2Attempts.has(v2Key)) return;
-			if (pendingV2Cancels.delete(v2Key)) {
-				emitV2Terminal(v2Key, {
-					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+		if (!structuredRequest && legacyControllers.has(requestId)) return;
+		if (structuredRequest && key) {
+			if (attemptControllers.has(key) || settledAttempts.has(key)) return;
+			if (pendingAttemptCancels.delete(key)) {
+				emitTerminal(key, {
 					requestId,
-					ownerRunId: v2Request.ownerRunId,
-					nodeId: v2Request.nodeId,
+					ownerRunId: structuredRequest.ownerRunId,
+					nodeId: structuredRequest.nodeId,
 					status: "cancelled",
 				});
 				return;
 			}
-			if (v2IdentitySaturated) {
+			if (identitySaturated) {
 				options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
-					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 					requestId,
-					ownerRunId: v2Request.ownerRunId,
-					nodeId: v2Request.nodeId,
+					ownerRunId: structuredRequest.ownerRunId,
+					nodeId: structuredRequest.nodeId,
 					status: "unavailable_context",
-					error: "Delegation v2 identity capacity is exhausted for this extension context.",
-				} satisfies SubagentDelegationV2Response);
+					error: "Delegation identity capacity is exhausted for this extension context.",
+				} satisfies SubagentDelegationResponse);
 				return;
 			}
-			const active = activeV2Nodes.get(v2NodeKey(v2Request.ownerRunId, v2Request.nodeId));
+			const active = activeOwnedNodes.get(nodeKey(structuredRequest.ownerRunId, structuredRequest.nodeId));
 			if (active) {
-				emitV2Terminal(v2Key, {
-					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+				emitTerminal(key, {
 					requestId,
-					ownerRunId: v2Request.ownerRunId,
-					nodeId: v2Request.nodeId,
+					ownerRunId: structuredRequest.ownerRunId,
+					nodeId: structuredRequest.nodeId,
 					status: "duplicate_node",
 				});
 				return;
@@ -262,22 +236,14 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 		}
 		const ctx = options.getContext();
 		if (!ctx) {
-			if (v2Request && v2Key) {
-				emitV2Terminal(v2Key, {
-					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+			if (structuredRequest && key) {
+				emitTerminal(key, {
 					requestId,
-					ownerRunId: v2Request.ownerRunId,
-					nodeId: v2Request.nodeId,
+					ownerRunId: structuredRequest.ownerRunId,
+					nodeId: structuredRequest.nodeId,
 					status: "unavailable_context",
 					error: "No active extension context for delegated subagent execution.",
 				});
-			} else if (versionedRequest) {
-				options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
-					version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-					requestId,
-					status: "unavailable_context",
-					error: "No active extension context for delegated subagent execution.",
-				} satisfies SubagentDelegationResponse);
 			} else if (legacyRequest) {
 				options.events.emit(PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT, {
 					...legacyRequest,
@@ -290,29 +256,22 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 		}
 
 		const controller = new AbortController();
-		if (v2Request && v2Key) {
-			v2Controllers.set(v2Key, controller);
-			activeV2Nodes.set(v2NodeKey(v2Request.ownerRunId, v2Request.nodeId), { attemptKey: v2Key, controller });
+		if (structuredRequest && key) {
+			attemptControllers.set(key, controller);
+			activeOwnedNodes.set(nodeKey(structuredRequest.ownerRunId, structuredRequest.nodeId), { attemptKey: key, controller });
 		} else {
-			controllers.set(requestId, controller);
-			if (pendingCancels.delete(requestId)) controller.abort();
+			legacyControllers.set(requestId, controller);
+			if (pendingLegacyCancels.delete(requestId)) controller.abort();
 		}
 		if (controller.signal.aborted) {
-			if (v2Request && v2Key) {
-				emitV2Terminal(v2Key, {
-					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+			if (structuredRequest && key) {
+				emitTerminal(key, {
 					requestId,
-					ownerRunId: v2Request.ownerRunId,
-					nodeId: v2Request.nodeId,
+					ownerRunId: structuredRequest.ownerRunId,
+					nodeId: structuredRequest.nodeId,
 					status: "cancelled",
 				});
-				activeV2Nodes.delete(v2NodeKey(v2Request.ownerRunId, v2Request.nodeId));
-			} else if (versionedRequest) {
-				options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
-					version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-					requestId,
-					status: "cancelled",
-				} satisfies SubagentDelegationResponse);
+				activeOwnedNodes.delete(nodeKey(structuredRequest.ownerRunId, structuredRequest.nodeId));
 			} else if (legacyRequest) {
 				options.events.emit(PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT, {
 					...legacyRequest,
@@ -321,23 +280,21 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 					errorText: "Delegated prompt cancelled.",
 				} satisfies PromptTemplateDelegationResponse);
 			}
-			if (v2Key) v2Controllers.delete(v2Key);
-			else controllers.delete(requestId);
+			if (key) attemptControllers.delete(key);
+			else legacyControllers.delete(requestId);
 			return;
 		}
 
 		options.events.emit(
-			versionedRequest ? SUBAGENT_DELEGATION_STARTED_EVENT : PROMPT_TEMPLATE_SUBAGENT_STARTED_EVENT,
-			v2Request
-				? { version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION, requestId, ownerRunId: v2Request.ownerRunId, nodeId: v2Request.nodeId }
-				: versionedRequest
-					? { version: SUBAGENT_DELEGATION_PROTOCOL_VERSION, requestId }
-					: { requestId },
+			structuredRequest ? SUBAGENT_DELEGATION_STARTED_EVENT : PROMPT_TEMPLATE_SUBAGENT_STARTED_EVENT,
+			structuredRequest
+				? { requestId, ownerRunId: structuredRequest.ownerRunId, nodeId: structuredRequest.nodeId }
+				: { requestId },
 		);
 
 		try {
-			const executeRequest = versionedRequest && options.executeVersioned
-				? options.executeVersioned
+			const executeRequest = structuredRequest && options.executeStructured
+				? options.executeStructured
 				: options.execute;
 			const result = await executeRequest(
 				requestId,
@@ -345,14 +302,9 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 				controller.signal,
 				ctx,
 				(update) => {
-					if (v2Key ? !ownsV2Attempt(v2Key, controller) : !ownsRequest(requestId, controller)) return;
-					if (v2Request) {
-						const payload = toSubagentDelegationV2Update(v2Request, update);
-						if (payload) options.events.emit(SUBAGENT_DELEGATION_UPDATE_EVENT, payload);
-						return;
-					}
-					if (versionedRequest) {
-						const payload = toSubagentDelegationUpdate(requestId, update);
+					if (key ? !ownsAttempt(key, controller) : !ownsLegacyRequest(requestId, controller)) return;
+					if (structuredRequest) {
+						const payload = toSubagentDelegationUpdate(structuredRequest, update);
 						if (payload) options.events.emit(SUBAGENT_DELEGATION_UPDATE_EVENT, payload);
 						return;
 					}
@@ -360,14 +312,9 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 					if (payload) options.events.emit(PROMPT_TEMPLATE_SUBAGENT_UPDATE_EVENT, payload);
 				},
 			);
-			if (v2Key ? !ownsV2Attempt(v2Key, controller) : !ownsRequest(requestId, controller)) return;
-			if (v2Request && v2Key) {
-				emitV2Terminal(v2Key, toSubagentDelegationV2Response(v2Request, result, controller.signal.aborted));
-			} else if (versionedRequest) {
-				options.events.emit(
-					SUBAGENT_DELEGATION_RESPONSE_EVENT,
-					toSubagentDelegationResponse(requestId, result, controller.signal.aborted),
-				);
+			if (key ? !ownsAttempt(key, controller) : !ownsLegacyRequest(requestId, controller)) return;
+			if (structuredRequest && key) {
+				emitTerminal(key, toSubagentDelegationResponse(structuredRequest, result, controller.signal.aborted));
 			} else if (legacyRequest) {
 				options.events.emit(
 					PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT,
@@ -377,23 +324,15 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 				);
 			}
 		} catch (error) {
-			if (v2Key ? !ownsV2Attempt(v2Key, controller) : !ownsRequest(requestId, controller)) return;
-			if (v2Request && v2Key) {
-				emitV2Terminal(v2Key, {
-					version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
+			if (key ? !ownsAttempt(key, controller) : !ownsLegacyRequest(requestId, controller)) return;
+			if (structuredRequest && key) {
+				emitTerminal(key, {
 					requestId,
-					ownerRunId: v2Request.ownerRunId,
-					nodeId: v2Request.nodeId,
+					ownerRunId: structuredRequest.ownerRunId,
+					nodeId: structuredRequest.nodeId,
 					status: controller.signal.aborted ? "cancelled" : "failed",
 					...(controller.signal.aborted ? {} : { error: error instanceof Error ? error.message : String(error) }),
 				});
-			} else if (versionedRequest) {
-				options.events.emit(SUBAGENT_DELEGATION_RESPONSE_EVENT, {
-					version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-					requestId,
-					status: controller.signal.aborted ? "cancelled" : "failed",
-					...(controller.signal.aborted ? {} : { error: error instanceof Error ? error.message : String(error) }),
-				} satisfies SubagentDelegationResponse);
 			} else if (legacyRequest) {
 				options.events.emit(PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT, {
 					...legacyRequest,
@@ -403,40 +342,40 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 				} satisfies PromptTemplateDelegationResponse);
 			}
 		} finally {
-			if (v2Key) {
-				if (v2Controllers.get(v2Key) === controller) v2Controllers.delete(v2Key);
-			} else if (controllers.get(requestId) === controller) controllers.delete(requestId);
-			if (v2Request) {
-				const key = v2NodeKey(v2Request.ownerRunId, v2Request.nodeId);
-				if (activeV2Nodes.get(key)?.controller === controller) activeV2Nodes.delete(key);
+			if (key) {
+				if (attemptControllers.get(key) === controller) attemptControllers.delete(key);
+			} else if (legacyControllers.get(requestId) === controller) legacyControllers.delete(requestId);
+			if (structuredRequest) {
+				const ownedNodeKey = nodeKey(structuredRequest.ownerRunId, structuredRequest.nodeId);
+				if (activeOwnedNodes.get(ownedNodeKey)?.controller === controller) activeOwnedNodes.delete(ownedNodeKey);
 			}
 		}
 	});
 
 	return {
 		cancelAll: () => {
-			for (const controller of controllers.values()) controller.abort();
-			for (const controller of v2Controllers.values()) controller.abort();
-			controllers.clear();
-			v2Controllers.clear();
-			pendingCancels.clear();
-			pendingV2Cancels.clear();
-			activeV2Nodes.clear();
-			settledV2Attempts.clear();
-			v2IdentitySaturated = false;
+			for (const controller of legacyControllers.values()) controller.abort();
+			for (const controller of attemptControllers.values()) controller.abort();
+			legacyControllers.clear();
+			attemptControllers.clear();
+			pendingLegacyCancels.clear();
+			pendingAttemptCancels.clear();
+			activeOwnedNodes.clear();
+			settledAttempts.clear();
+			identitySaturated = false;
 		},
 		dispose: () => {
 			disposed = true;
-			for (const controller of controllers.values()) controller.abort();
-			for (const controller of v2Controllers.values()) controller.abort();
-			controllers.clear();
-			v2Controllers.clear();
+			for (const controller of legacyControllers.values()) controller.abort();
+			for (const controller of attemptControllers.values()) controller.abort();
+			legacyControllers.clear();
+			attemptControllers.clear();
 			for (const unsubscribe of subscriptions) unsubscribe();
 			subscriptions.length = 0;
-			pendingCancels.clear();
-			pendingV2Cancels.clear();
-			activeV2Nodes.clear();
-			settledV2Attempts.clear();
+			pendingLegacyCancels.clear();
+			pendingAttemptCancels.clear();
+			activeOwnedNodes.clear();
+			settledAttempts.clear();
 		},
 	};
 }

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -28,17 +28,12 @@ import {
 } from "../support/helpers.ts";
 import registerSubagentExtension from "../../src/extension/index.ts";
 import {
-	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
 	SUBAGENT_DELEGATION_RESPONSE_EVENT,
 	SUBAGENT_DELEGATION_STARTED_EVENT,
-	SUBAGENT_DELEGATION_UPDATE_EVENT,
+	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
-	type SubagentDelegationUpdate,
-	type SubagentDelegationV2Request,
-	type SubagentDelegationV2Response,
-	type SubagentDelegationV2Started,
+	type SubagentDelegationStarted,
 } from "../../src/api/delegation.ts";
 import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, type SubagentState } from "../../src/shared/types.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
@@ -726,7 +721,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.details.usageBudget?.exhausted, true);
 	});
 
-	it("admits a zero run-level tool budget only for marked v2 delegated execution", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+	it("admits a zero run-level tool budget only for marked structured delegated execution", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const zeroBudget = { hard: 0, block: "*" as const };
 		const params = { agent: "echo", task: "Answer without tools", toolBudget: zeroBudget };
 		const ctx = makeMinimalCtx(tempDir);
@@ -742,27 +737,27 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(ordinary.isError, true);
 		assert.match(ordinary.content[0]?.text ?? "", /toolBudget\.hard must be an integer >= 1/);
 
-		const v1Delegated = await executor.executeDelegated(
-			"v1-delegated-zero-budget",
+		const unmarkedDelegated = await executor.executeDelegated(
+			"unmarked-delegated-zero-budget",
 			params,
 			new AbortController().signal,
 			undefined,
 			ctx,
 		);
-		assert.equal(v1Delegated.isError, true);
-		assert.match(v1Delegated.content[0]?.text ?? "", /toolBudget\.hard must be an integer >= 1/);
+		assert.equal(unmarkedDelegated.isError, true);
+		assert.match(unmarkedDelegated.content[0]?.text ?? "", /toolBudget\.hard must be an integer >= 1/);
 
 		mockPi.onCall({ echoEnv: [TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV] });
-		const v2Delegated = await executor.executeDelegated(
-			"v2-delegated-zero-budget",
+		const structuredDelegated = await executor.executeDelegated(
+			"structured-delegated-zero-budget",
 			{ ...params, delegatedAllowZeroToolBudget: true },
 			new AbortController().signal,
 			undefined,
 			ctx,
 		);
-		assert.equal(v2Delegated.isError, undefined);
-		assert.deepEqual(v2Delegated.details.toolBudget, zeroBudget);
-		const env = JSON.parse(v2Delegated.content[0]?.text ?? "{}") as Record<string, string>;
+		assert.equal(structuredDelegated.isError, undefined);
+		assert.deepEqual(structuredDelegated.details.toolBudget, zeroBudget);
+		const env = JSON.parse(structuredDelegated.content[0]?.text ?? "{}") as Record<string, string>;
 		assert.deepEqual(JSON.parse(env[TOOL_BUDGET_ENV] ?? "null"), zeroBudget);
 		assert.equal(env[TOOL_BUDGET_ZERO_AUTH_ENV], "1");
 		assert.equal(mockPi.callCount(), 1);
@@ -890,101 +885,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(mockPi.callCount(), 2);
 	});
 
-	it("routes registered strict v1 delegation through the concurrent executor", async () => {
-		mockPi.onCall({
-			steps: [
-				{ jsonl: [events.toolStart("read", { path: "package.json" })], delay: 20 },
-				{ jsonl: [events.toolEnd("read"), events.toolResult("read", "{}")], delay: 20 },
-				{ jsonl: [events.assistantMessage("registered first delegated call")] },
-			],
-		});
-		mockPi.onCall({ output: "registered second delegated call", delay: 100 });
-		const extensionEvents = createEventBus();
-		const runtimeHandlers = new Map<string, Array<(event: unknown, ctx: ReturnType<typeof makeMinimalCtx>) => void>>();
-		const fakePi = new Proxy({
-			events: extensionEvents,
-			on(event: string, handler: (event: unknown, ctx: ReturnType<typeof makeMinimalCtx>) => void) {
-				const handlers = runtimeHandlers.get(event) ?? [];
-				handlers.push(handler);
-				runtimeHandlers.set(event, handlers);
-				return () => runtimeHandlers.set(event, (runtimeHandlers.get(event) ?? []).filter((entry) => entry !== handler));
-			},
-			registerTool() {},
-			registerCommand() {},
-			registerShortcut() {},
-			registerMessageRenderer() {},
-			sendMessage() {},
-			getSessionName() { return undefined; },
-		}, {
-			get(target, prop) {
-				if (prop in target) return target[prop as keyof typeof target];
-				return () => undefined;
-			},
-		});
-		const ctx = {
-			...makeMinimalCtx(tempDir),
-			sessionManager: {
-				getSessionId: () => "registered-delegation-session",
-				getSessionFile: () => path.join(tempDir, "registered-delegation-session.jsonl"),
-				getEntries: () => [],
-			},
-		};
-		const responses: SubagentDelegationResponse[] = [];
-		const updates: SubagentDelegationUpdate[] = [];
-		extensionEvents.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationResponse));
-		extensionEvents.on(SUBAGENT_DELEGATION_UPDATE_EVENT, (payload) => updates.push(payload as SubagentDelegationUpdate));
-
-		try {
-			registerSubagentExtension(fakePi as never);
-			for (const handler of runtimeHandlers.get("session_start") ?? []) {
-				await handler({ reason: "startup" }, ctx);
-			}
-			extensionEvents.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
-				version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-				requestId: "registered-a",
-				agent: "worker",
-				task: "First registered delegated call",
-				context: "fresh",
-				cwd: tempDir,
-				agentContract: { version: 1 },
-			});
-			extensionEvents.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
-				version: SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-				requestId: "registered-b",
-				agent: "reviewer",
-				task: "Second registered delegated call",
-				context: "fresh",
-				cwd: tempDir,
-				agentContract: { version: 1 },
-			});
-
-			const callDeadlineAt = Date.now() + 30_000;
-			while (mockPi.callCount() < 2 && Date.now() < callDeadlineAt) {
-				await new Promise((resolve) => setTimeout(resolve, 20));
-			}
-			assert.equal(mockPi.callCount(), 2, "registered strict v1 requests should bypass the ordinary one-call guard");
-
-			const responseDeadlineAt = Date.now() + 30_000;
-			while (responses.length < 2 && Date.now() < responseDeadlineAt) {
-				await new Promise((resolve) => setTimeout(resolve, 20));
-			}
-			assert.deepEqual(responses.map((response) => response.requestId).sort(), ["registered-a", "registered-b"]);
-			assert.ok(responses.every((response) => response.status === "completed"));
-			assert.deepEqual(responses.map((response) => response.output).sort(), [
-				"registered first delegated call",
-				"registered second delegated call",
-			]);
-			const toolResponse = responses.find((response) => response.output === "registered first delegated call");
-			assert.ok(toolResponse);
-			assert.equal(updates.some((update) => update.requestId === toolResponse.requestId && update.currentTool === "read"), true);
-		} finally {
-			for (const handler of runtimeHandlers.get("session_shutdown") ?? []) {
-				await handler({}, ctx);
-			}
-		}
-	});
-
-	it("routes registered strict v2 text delegation through the concurrent executor", async () => {
+	it("routes registered structured text delegation through the concurrent executor", async () => {
 		const literalJsonText = '{"looks":"json"}';
 		mockPi.onCall({
 			steps: [
@@ -1011,7 +912,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 				},
 			],
 		});
-		mockPi.onCall({ output: "registered v2 second node", delay: 100 });
+		mockPi.onCall({ output: "registered structured second node", delay: 100 });
 		const extensionEvents = createEventBus();
 		const runtimeHandlers = new Map<string, Array<(event: unknown, ctx: ReturnType<typeof makeMinimalCtx>) => void>>();
 		const fakePi = new Proxy({
@@ -1040,28 +941,27 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 				getAvailable: () => [{ provider: "mock", id: "test-model", reasoning: true }],
 			},
 			sessionManager: {
-				getSessionId: () => "registered-delegation-v2-session",
-				getSessionFile: () => path.join(tempDir, "registered-delegation-v2-session.jsonl"),
+				getSessionId: () => "registered-delegation-session",
+				getSessionFile: () => path.join(tempDir, "registered-delegation-session.jsonl"),
 				getEntries: () => [],
 			},
 		};
-		const started: SubagentDelegationV2Started[] = [];
-		const responses: SubagentDelegationV2Response[] = [];
+		const started: SubagentDelegationStarted[] = [];
+		const responses: SubagentDelegationResponse[] = [];
 		extensionEvents.on(SUBAGENT_DELEGATION_STARTED_EVENT, (payload) => {
-			if ((payload as { version?: unknown }).version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
-				started.push(payload as SubagentDelegationV2Started);
+			if ((payload as { ownerRunId?: unknown }).ownerRunId === "owner-delegation") {
+				started.push(payload as SubagentDelegationStarted);
 			}
 		});
 		extensionEvents.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => {
-			if ((payload as { version?: unknown }).version === SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION) {
-				responses.push(payload as SubagentDelegationV2Response);
+			if ((payload as { ownerRunId?: unknown }).ownerRunId === "owner-delegation") {
+				responses.push(payload as SubagentDelegationResponse);
 			}
 		});
 
 		const firstRequest = {
-			version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
-			requestId: "registered-v2-a",
-			ownerRunId: "owner-v2",
+			requestId: "registered-a",
+			ownerRunId: "owner-delegation",
 			nodeId: "node-a",
 			agent: "worker",
 			task: "Return literal JSON-looking text",
@@ -1070,11 +970,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			model: "mock/test-model",
 			thinking: "high",
 			result: { kind: "text" },
-		} satisfies SubagentDelegationV2Request;
+		} satisfies SubagentDelegationRequest;
 		const secondRequest = {
-			version: SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
-			requestId: "registered-v2-b",
-			ownerRunId: "owner-v2",
+			requestId: "registered-b",
+			ownerRunId: "owner-delegation",
 			nodeId: "node-b",
 			agent: "reviewer",
 			task: "Run the second logical node",
@@ -1083,7 +982,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			model: "mock/test-model",
 			thinking: "high",
 			result: { kind: "text" },
-		} satisfies SubagentDelegationV2Request;
+		} satisfies SubagentDelegationRequest;
 
 		try {
 			registerSubagentExtension(fakePi as never);
@@ -1097,10 +996,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			while (mockPi.callCount() < 2 && responses.length < 2 && Date.now() < callDeadlineAt) {
 				await new Promise((resolve) => setTimeout(resolve, 20));
 			}
-			assert.equal(mockPi.callCount(), 2, `different V2 logical nodes should use the concurrent delegated execution path: ${JSON.stringify(responses)}`);
+			assert.equal(mockPi.callCount(), 2, `different logical nodes should use the concurrent delegated execution path: ${JSON.stringify(responses)}`);
 			assert.deepEqual(started.map(({ requestId, ownerRunId, nodeId }) => ({ requestId, ownerRunId, nodeId })).sort((a, b) => a.nodeId.localeCompare(b.nodeId)), [
-				{ requestId: "registered-v2-a", ownerRunId: "owner-v2", nodeId: "node-a" },
-				{ requestId: "registered-v2-b", ownerRunId: "owner-v2", nodeId: "node-b" },
+				{ requestId: "registered-a", ownerRunId: "owner-delegation", nodeId: "node-a" },
+				{ requestId: "registered-b", ownerRunId: "owner-delegation", nodeId: "node-b" },
 			]);
 
 			const responseDeadlineAt = Date.now() + 30_000;
@@ -1112,7 +1011,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			const terminalResponses = responses.filter((response) => response.status !== "invalid_request");
 			assert.equal(terminalResponses.length, 2);
 			for (const response of terminalResponses) {
-				assert.equal(response.ownerRunId, "owner-v2");
+				assert.equal(response.ownerRunId, "owner-delegation");
 				assert.equal(response.model, "mock/test-model:high");
 				assert.equal(response.thinking, "high");
 				assert.match(response.launchContractDigest ?? "", /^[0-9a-f]{64}$/);
@@ -1138,7 +1037,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 				toolCalls: 1,
 			});
 			assert.equal(typeof literalResponse.usage?.durationMs, "number");
-			const plainResponse = terminalResponses.find((response) => response.result?.kind === "text" && response.result.text === "registered v2 second node");
+			const plainResponse = terminalResponses.find((response) => response.result?.kind === "text" && response.result.text === "registered structured second node");
 			assert.ok(plainResponse);
 		} finally {
 			for (const handler of runtimeHandlers.get("session_shutdown") ?? []) {

--- a/test/unit/delegation-api.test.ts
+++ b/test/unit/delegation-api.test.ts
@@ -3,18 +3,12 @@ import { describe, it } from "node:test";
 
 import {
 	SUBAGENT_DELEGATION_CANCEL_EVENT,
-	SUBAGENT_DELEGATION_PROTOCOL_VERSION,
-	SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION,
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
 	SUBAGENT_DELEGATION_RESPONSE_EVENT,
 	SUBAGENT_DELEGATION_STARTED_EVENT,
 	SUBAGENT_DELEGATION_UPDATE_EVENT,
-	type SubagentDelegationAcceptance,
 	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
-	type SubagentDelegationV2InvalidResponse,
-	type SubagentDelegationV2Request,
-	type SubagentDelegationV2Response,
 } from "../../src/api/delegation.ts";
 import { parseSubagentDelegationRequest } from "../../src/slash/delegation-request.ts";
 import {
@@ -50,18 +44,7 @@ function tick(): Promise<void> {
 	return new Promise((resolve) => setImmediate(resolve));
 }
 
-const acceptance: SubagentDelegationAcceptance = {
-	level: "verified",
-	criteria: [{ id: "criterion-1", must: "Verify the result", evidence: ["validation-output"], severity: "required" }],
-	evidence: ["commands-run", "validation-output"],
-	verify: [{ id: "test", command: "npm test", timeoutMs: 1_000, cwd: "/repo", env: { CI: "true" }, allowFailure: false }],
-	review: { agent: "reviewer", focus: "correctness", required: false },
-	stopRules: ["Stop on verification failure"],
-	reason: "Explicit verification contract",
-};
-
-const v2Request: SubagentDelegationV2Request = {
-	version: 2,
+const request: SubagentDelegationRequest = {
 	requestId: "attempt-1",
 	ownerRunId: "owner-1",
 	nodeId: "node-1",
@@ -79,29 +62,8 @@ const v2Request: SubagentDelegationV2Request = {
 	result: { kind: "structured", schema: { type: "object", properties: { ok: { type: "boolean" } } } },
 };
 
-const request: SubagentDelegationRequest = {
-	version: 1,
-	requestId: "delegation-1",
-	agent: "reviewer",
-	task: "Review evidence",
-	context: "fresh",
-	cwd: "/repo",
-	model: "openai/gpt-5",
-	timeoutMs: 1_000,
-	turnBudget: { maxTurns: 4, graceTurns: 1 },
-	toolBudget: { soft: 3, hard: 5, block: "*" },
-	skill: ["review"],
-	output: "result.md",
-	outputMode: "file-only",
-	outputSchema: { type: "object", properties: { ok: { type: "boolean" } } },
-	agentContract: { version: 1 },
-	acceptance: "checked",
-	artifacts: true,
-};
-
 describe("public subagent delegation contract", () => {
 	it("uses the existing prompt-template event family as the only transport", () => {
-		assert.equal(SUBAGENT_DELEGATION_PROTOCOL_VERSION, 1);
 		assert.equal(SUBAGENT_DELEGATION_REQUEST_EVENT, "prompt-template:subagent:request");
 		assert.equal(SUBAGENT_DELEGATION_STARTED_EVENT, "prompt-template:subagent:started");
 		assert.equal(SUBAGENT_DELEGATION_UPDATE_EVENT, "prompt-template:subagent:update");
@@ -109,28 +71,27 @@ describe("public subagent delegation contract", () => {
 		assert.equal(SUBAGENT_DELEGATION_CANCEL_EVENT, "prompt-template:subagent:cancel");
 	});
 
-	it("strictly parses the complete v2 request and enforces its independent allowlists and bounds", () => {
-		assert.equal(SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION, 2);
-		assert.deepEqual(parseSubagentDelegationRequest(v2Request), { ok: true, request: v2Request });
+	it("strictly parses the structured owned-leaf request", () => {
+		assert.deepEqual(parseSubagentDelegationRequest(request), { ok: true, request });
 		const malformed = [
-			[{ ...v2Request, ownerRunId: "bad\nowner" }, /ownerRunId.*256 characters without newlines/],
-			[{ ...v2Request, nodeId: "x".repeat(257) }, /nodeId.*256 characters without newlines/],
-			[{ ...v2Request, thinking: "extreme" }, /thinking must be one of/],
-			[{ ...v2Request, output: false }, /Unsupported delegation field: output/],
-			[{ ...v2Request, outputMode: "inline" }, /Unsupported delegation field: outputMode/],
-			[{ ...v2Request, agentContract: { version: 1 } }, /Unsupported delegation field: agentContract/],
-			[{ ...v2Request, acceptance: false }, /Unsupported delegation field: acceptance/],
-			[{ ...v2Request, result: { kind: "text", schema: {} } }, /result.schema is not supported/],
-			[{ ...v2Request, result: { kind: "structured" } }, /result.schema must be a JSON Schema object/],
-			[{ ...v2Request, task: "é".repeat(524_289) }, /task exceeds 1 MiB/],
-			[{ ...v2Request, cwd: "é".repeat(16_385) }, /cwd exceeds 32 KiB/],
-			[{ ...v2Request, agent: "é".repeat(513) }, /agent exceeds 1 KiB/],
-			[{ ...v2Request, model: "é".repeat(513) }, /model exceeds 1 KiB/],
-			[{ ...v2Request, skill: "é".repeat(513) }, /skill entry exceeds 1 KiB/],
-			[{ ...v2Request, skill: Array.from({ length: 257 }, () => "x") }, /skill supports at most 256 entries/],
-			[{ ...v2Request, skill: Array.from({ length: 256 }, () => "x".repeat(257)) }, /skill entries exceed 64 KiB in aggregate/],
-			[{ ...v2Request, result: { kind: "structured", schema: { value: "x".repeat(65_536) } } }, /result.schema exceeds 64 KiB/],
-			[{ ...v2Request, timeoutMs: 2_147_483_648 }, /timeoutMs must be <= 2147483647 for delegation v2/],
+			[{ ...request, version: 99 }, /Unsupported delegation field: version/],
+			[{ ...request, ownerRunId: "bad\nowner" }, /ownerRunId.*256 characters without newlines/],
+			[{ ...request, nodeId: "x".repeat(257) }, /nodeId.*256 characters without newlines/],
+			[{ ...request, thinking: "extreme" }, /thinking must be one of/],
+			[{ ...request, output: false }, /Unsupported delegation field: output/],
+			[{ ...request, acceptance: false }, /Unsupported delegation field: acceptance/],
+			[{ ...request, agentContract: { version: 1 } }, /Unsupported delegation field: agentContract/],
+			[{ ...request, result: { kind: "text", schema: {} } }, /result.schema is not supported/],
+			[{ ...request, result: { kind: "structured" } }, /result.schema must be a JSON Schema object/],
+			[{ ...request, task: "é".repeat(524_289) }, /task exceeds 1 MiB/],
+			[{ ...request, cwd: "é".repeat(16_385) }, /cwd exceeds 32 KiB/],
+			[{ ...request, agent: "é".repeat(513) }, /agent exceeds 1 KiB/],
+			[{ ...request, model: "é".repeat(513) }, /model exceeds 1 KiB/],
+			[{ ...request, skill: "é".repeat(513) }, /skill entry exceeds 1 KiB/],
+			[{ ...request, skill: Array.from({ length: 257 }, () => "x") }, /skill supports at most 256 entries/],
+			[{ ...request, skill: Array.from({ length: 256 }, () => "x".repeat(257)) }, /skill entries exceed 64 KiB in aggregate/],
+			[{ ...request, result: { kind: "structured", schema: { value: "x".repeat(65_536) } } }, /result.schema exceeds 64 KiB/],
+			[{ ...request, timeoutMs: 2_147_483_648 }, /timeoutMs must be <= 2147483647/],
 		] as const;
 		for (const [input, expected] of malformed) {
 			const parsed = parseSubagentDelegationRequest(input);
@@ -139,24 +100,20 @@ describe("public subagent delegation contract", () => {
 		}
 	});
 
-	it("accepts an exact zero tool budget only for v2", () => {
+	it("accepts exact zero tool budgets for structured delegated leaves", () => {
 		const zeroBudget = { hard: 0, block: "*" as const };
-		const parsedV2 = parseSubagentDelegationRequest({ ...v2Request, toolBudget: zeroBudget });
-		assert.equal(parsedV2.ok, true);
-		if (parsedV2.ok) assert.deepEqual(parsedV2.request.toolBudget, zeroBudget);
-
-		const parsedV1 = parseSubagentDelegationRequest({ ...request, toolBudget: zeroBudget });
-		assert.equal(parsedV1.ok, false);
-		if (!parsedV1.ok) assert.equal(parsedV1.error, "toolBudget.hard must be an integer >= 1.");
+		const parsed = parseSubagentDelegationRequest({ ...request, toolBudget: zeroBudget });
+		assert.equal(parsed.ok, true);
+		if (parsed.ok) assert.deepEqual(parsed.request.toolBudget, zeroBudget);
 		for (const soft of [0, 1]) {
-			assert.equal(parseSubagentDelegationRequest({ ...v2Request, toolBudget: { ...zeroBudget, soft } }).ok, false);
+			assert.equal(parseSubagentDelegationRequest({ ...request, toolBudget: { ...zeroBudget, soft } }).ok, false);
 		}
 	});
 
-	it("rejects non-JSON v2 schemas without executing toJSON hooks", () => {
+	it("rejects non-JSON schemas without executing toJSON hooks", () => {
 		let calls = 0;
 		const parsed = parseSubagentDelegationRequest({
-			...v2Request,
+			...request,
 			result: {
 				kind: "structured",
 				schema: { toJSON: () => { calls++; return {}; } },
@@ -167,40 +124,7 @@ describe("public subagent delegation contract", () => {
 		assert.equal(calls, 0);
 	});
 
-	it("strictly parses the complete v1 request", () => {
-		assert.deepEqual(parseSubagentDelegationRequest(request), { ok: true, request });
-		const requestWithAcceptance = { ...request, acceptance };
-		assert.deepEqual(parseSubagentDelegationRequest(requestWithAcceptance), { ok: true, request: requestWithAcceptance });
-	});
-
-	it("rejects unsupported versions, unknown fields, aliases, and malformed controls", () => {
-		const malformed = [
-			[{ ...request, version: 2 }, /Unsupported delegation protocol version/],
-			[{ ...request, tools: ["write"] }, /Unsupported delegation field: tools/],
-			[{ ...request, maxRuntimeMs: 1_000 }, /Unsupported delegation field: maxRuntimeMs/],
-			[{ ...request, timeoutMs: 0 }, /timeoutMs must be an integer >= 1/],
-			[{ ...request, turnBudget: { maxTurns: 0 } }, /turnBudget.maxTurns/],
-			[{ ...request, turnBudget: { maxTurns: 1, extra: true } }, /turnBudget.extra is not supported/],
-			[{ ...request, toolBudget: { hard: 1, soft: 2 } }, /toolBudget.soft must be <=/],
-			[{ ...request, toolBudget: { hard: 1, extra: true } }, /toolBudget.extra is not supported/],
-			[{ ...request, skill: [] }, /skill must/],
-			[{ ...request, output: "" }, /output must/],
-			[{ ...request, output: false, outputMode: "file-only" }, /outputMode.*output.*path/],
-			[{ ...request, outputSchema: [] }, /outputSchema must be a JSON Schema object/],
-			[{ ...request, agentContract: { version: 2 } }, /agentContract must be \{ version: 1 \}/],
-			[{ ...request, agentContract: { version: 1, extra: true } }, /agentContract must be \{ version: 1 \}/],
-			[{ ...request, acceptance: "none" }, /level "none" requires a reason/],
-			[{ ...request, acceptance: { level: "none" } }, /reason is required/],
-			[{ ...request, artifacts: "yes" }, /artifacts must be a boolean/],
-		] as const;
-		for (const [input, expected] of malformed) {
-			const parsed = parseSubagentDelegationRequest(input);
-			assert.equal(parsed.ok, false);
-			if (!parsed.ok) assert.match(parsed.error, expected);
-		}
-	});
-
-	it("runs v2 through the versioned executor and preserves literal text with full effective metadata", async () => {
+	it("runs structured delegation through the concurrent executor and preserves literal text metadata", async () => {
 		const events = new FakeEvents();
 		let ordinaryCalls = 0;
 		let observedParams: Record<string, unknown> | undefined;
@@ -211,13 +135,13 @@ describe("public subagent delegation contract", () => {
 				ordinaryCalls++;
 				return { details: { mode: "single", results: [] } };
 			},
-			executeVersioned: async (_id, params, _signal, _ctx, onUpdate) => {
+			executeStructured: async (_id, params, _signal, _ctx, onUpdate) => {
 				observedParams = params as unknown as Record<string, unknown>;
-				onUpdate({ details: { mode: "single", runId: "run-v2", results: [{ agent: "reviewer", model: "openai/gpt-5", thinking: "high" }], progress: [{ currentTool: "read" }] } });
+				onUpdate({ details: { mode: "single", runId: "run-1", results: [{ agent: "reviewer", model: "openai/gpt-5", thinking: "high" }], progress: [{ currentTool: "read" }] } });
 				return {
 					details: {
 						mode: "single",
-						runId: "run-v2",
+						runId: "run-1",
 						results: [{
 							agent: "reviewer",
 							exitCode: 0,
@@ -232,20 +156,19 @@ describe("public subagent delegation contract", () => {
 				};
 			},
 		});
-		const textRequest = { ...v2Request, result: { kind: "text" as const } };
+		const textRequest = { ...request, result: { kind: "text" as const } };
 		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
 		const updatePromise = once(events, SUBAGENT_DELEGATION_UPDATE_EVENT);
 		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
 		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, textRequest);
-		assert.deepEqual(await startedPromise, { version: 2, requestId: "attempt-1", ownerRunId: "owner-1", nodeId: "node-1" });
-		assert.deepEqual(await updatePromise, { version: 2, requestId: "attempt-1", ownerRunId: "owner-1", nodeId: "node-1", runId: "run-v2", currentTool: "read", model: "openai/gpt-5" });
+		assert.deepEqual(await startedPromise, { requestId: "attempt-1", ownerRunId: "owner-1", nodeId: "node-1" });
+		assert.deepEqual(await updatePromise, { requestId: "attempt-1", ownerRunId: "owner-1", nodeId: "node-1", runId: "run-1", currentTool: "read", model: "openai/gpt-5" });
 		assert.deepEqual(await responsePromise, {
-			version: 2,
 			requestId: "attempt-1",
 			ownerRunId: "owner-1",
 			nodeId: "node-1",
 			status: "completed",
-			runId: "run-v2",
+			runId: "run-1",
 			agent: "reviewer",
 			model: "openai/gpt-5",
 			thinking: "high",
@@ -253,7 +176,7 @@ describe("public subagent delegation contract", () => {
 			launchContractDigest: "launch-contract-digest",
 			result: { kind: "text", text: '{"looks":"json"}' },
 			usage: { input: 2, output: 3, cacheRead: 4, cacheWrite: 5, cost: 0.01, turns: 2, toolCalls: 6, durationMs: 7 },
-		} satisfies SubagentDelegationV2Response);
+		} satisfies SubagentDelegationResponse);
 		assert.equal(ordinaryCalls, 0);
 		assert.deepEqual(observedParams, {
 			agent: "reviewer",
@@ -278,7 +201,7 @@ describe("public subagent delegation contract", () => {
 		bridge.dispose();
 	});
 
-	it("projects structured v2 values and fails missing or oversized captures", async () => {
+	it("projects structured values and fails missing or oversized captures", async () => {
 		const cases = [
 			[{ ok: true }, "completed", { kind: "structured", value: { ok: true } }],
 			[undefined, "failed", undefined],
@@ -289,8 +212,8 @@ describe("public subagent delegation contract", () => {
 			const bridge = registerPromptTemplateDelegationBridge({
 				events,
 				getContext: () => ({ cwd: "/repo" }),
-				execute: async () => { throw new Error("ordinary executor must remain separate"); },
-				executeVersioned: async () => ({
+				execute: async () => { throw new Error("legacy executor must remain separate"); },
+				executeStructured: async () => ({
 					details: {
 						mode: "single",
 						results: [{
@@ -303,8 +226,8 @@ describe("public subagent delegation contract", () => {
 				}),
 			});
 			const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-			events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: `structured-${expectedStatus}-${Math.random()}` });
-			const response = await responsePromise as SubagentDelegationV2Response;
+			events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: `structured-${expectedStatus}-${Math.random()}` });
+			const response = await responsePromise as SubagentDelegationResponse;
 			assert.equal(response.status, expectedStatus);
 			assert.deepEqual(response.result, expectedResult);
 			if (expectedStatus === "failed") assert.match(response.error ?? "", /structured result/);
@@ -312,91 +235,44 @@ describe("public subagent delegation contract", () => {
 		}
 	});
 
-	it("rejects non-JSON structured results without executing toJSON hooks", async () => {
-		let calls = 0;
-		const events = new FakeEvents();
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => { throw new Error("ordinary executor must remain separate"); },
-			executeVersioned: async () => ({
-				details: {
-					mode: "single",
-					results: [{
-						agent: "reviewer",
-						exitCode: 0,
-						structuredOutput: { toJSON: () => { calls++; return {}; } },
-						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
-					}],
-				},
-			}),
-		});
-		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "unsafe-structured" });
-		const response = await responsePromise as SubagentDelegationV2Response;
-		assert.equal(response.status, "failed");
-		assert.match(response.error ?? "", /structured result is not plain JSON data/);
-		assert.equal(calls, 0);
-		bridge.dispose();
-	});
-
-	it("rejects v2 text results exceeding 1 MiB when UTF-8 encoded", async () => {
-		const events = new FakeEvents();
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => { throw new Error("ordinary executor must remain separate"); },
-			executeVersioned: async () => ({
-				details: { mode: "single", results: [{ agent: "reviewer", exitCode: 0, finalOutput: "é".repeat(524_289) }] },
-			}),
-		});
-		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "oversized-text", result: { kind: "text" } });
-		const response = await responsePromise as SubagentDelegationV2Response;
-		assert.equal(response.status, "failed");
-		assert.match(response.error ?? "", /text result exceeds 1 MiB/);
-		assert.equal("result" in response, false);
-		bridge.dispose();
-	});
-
-	it("isolates v2 logical-node ownership, exact cancellation, pre-cancellation, and reuse", async () => {
+	it("isolates logical-node ownership, exact cancellation, pre-cancellation, and reuse", async () => {
 		const events = new FakeEvents();
 		const releases = new Map<string, () => void>();
-		const responses: SubagentDelegationV2Response[] = [];
-		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationV2Response));
+		const responses: SubagentDelegationResponse[] = [];
+		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationResponse));
 		const bridge = registerPromptTemplateDelegationBridge({
 			events,
 			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => { throw new Error("ordinary executor must remain separate"); },
-			executeVersioned: async (id, params, signal) => await new Promise((resolve, reject) => {
+			execute: async () => { throw new Error("legacy executor must remain separate"); },
+			executeStructured: async (id, params, signal) => await new Promise((resolve, reject) => {
 				releases.set(id, () => resolve({ details: { mode: "single", results: [{ agent: params.agent, exitCode: 0, finalOutput: id, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 } }] } }));
 				signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
 			}),
 		});
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "owner-a", result: { kind: "text" } });
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "owner-b", result: { kind: "text" } });
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "owner-b", result: { kind: "text" } });
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "other-node", nodeId: "node-2", result: { kind: "text" } });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "owner-a", result: { kind: "text" } });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "owner-b", result: { kind: "text" } });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "owner-b", result: { kind: "text" } });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "other-node", nodeId: "node-2", result: { kind: "text" } });
 		while (!releases.has("owner-a") || !releases.has("other-node")) await tick();
 		await tick();
 		assert.equal(responses.find((entry) => entry.requestId === "owner-b")?.status, "duplicate_node");
 		assert.equal(responses.filter((entry) => entry.requestId === "owner-b").length, 1);
-		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "owner-a", ownerRunId: "wrong", nodeId: "node-1" });
-		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "owner-a", ownerRunId: "owner-1", nodeId: "wrong" });
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { requestId: "owner-a", ownerRunId: "wrong", nodeId: "node-1" });
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { requestId: "owner-a", ownerRunId: "owner-1", nodeId: "wrong" });
 		await tick();
 		assert.equal(responses.some((entry) => entry.requestId === "owner-a"), false);
-		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "owner-a", ownerRunId: "owner-1", nodeId: "node-1" });
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { requestId: "owner-a", ownerRunId: "owner-1", nodeId: "node-1" });
 		while (!responses.some((entry) => entry.requestId === "owner-a")) await tick();
 		assert.equal(responses.find((entry) => entry.requestId === "owner-a")?.status, "cancelled");
 		releases.get("other-node")?.();
 		while (!responses.some((entry) => entry.requestId === "other-node")) await tick();
 
-		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "pre", ownerRunId: "owner-1", nodeId: "node-1" });
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "pre", result: { kind: "text" } });
+		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { requestId: "pre", ownerRunId: "owner-1", nodeId: "node-1" });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "pre", result: { kind: "text" } });
 		while (!responses.some((entry) => entry.requestId === "pre")) await tick();
 		assert.equal(responses.find((entry) => entry.requestId === "pre")?.status, "cancelled");
 
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "reuse", result: { kind: "text" } });
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "reuse", result: { kind: "text" } });
 		while (!releases.has("reuse")) await tick();
 		releases.get("reuse")?.();
 		while (!responses.some((entry) => entry.requestId === "reuse")) await tick();
@@ -404,512 +280,37 @@ describe("public subagent delegation contract", () => {
 		bridge.dispose();
 	});
 
-	it("keys concurrent v2 attempts and retransmissions by the full identity tuple", async () => {
+	it("retains the unversioned prompt-template bridge as legacy fallback", async () => {
 		const events = new FakeEvents();
-		const releases = new Map<string, () => void>();
-		const responses: SubagentDelegationV2Response[] = [];
-		let executeCalls = 0;
-		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationV2Response));
+		let structuredCalls = 0;
+		let legacyCalls = 0;
 		const bridge = registerPromptTemplateDelegationBridge({
 			events,
 			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => { throw new Error("ordinary executor must remain separate"); },
-			executeVersioned: async (_id, params) => {
-				executeCalls++;
-				if (typeof params.task !== "string") throw new Error("expected a single delegated task");
-				const task = params.task;
-				await new Promise<void>((resolve) => releases.set(task, resolve));
-				return { details: { mode: "single", results: [{ agent: params.agent, exitCode: 0, finalOutput: task }] } };
+			execute: async () => {
+				legacyCalls++;
+				return { content: [{ type: "text", text: "legacy done" }], details: { mode: "single", results: [{ agent: "reviewer", finalOutput: "legacy done", exitCode: 0 }] } };
+			},
+			executeStructured: async () => {
+				structuredCalls++;
+				return { details: { mode: "single", results: [] } };
 			},
 		});
-		const first = { ...v2Request, requestId: "shared-attempt", task: "first", result: { kind: "text" as const } };
-		const second = { ...first, ownerRunId: "owner-2", nodeId: "node-2", task: "second" };
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, first);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, second);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, first);
-		for (let index = 0; index < 5 && releases.size < 2; index++) await tick();
-		assert.equal(releases.size, 2);
-		assert.equal(executeCalls, 2);
-		releases.get("first")?.();
-		releases.get("second")?.();
-		while (responses.length < 2) await tick();
-		assert.deepEqual(responses.map(({ ownerRunId, nodeId, status }) => ({ ownerRunId, nodeId, status })).sort((a, b) => (a.ownerRunId ?? "").localeCompare(b.ownerRunId ?? "")), [
-			{ ownerRunId: "owner-1", nodeId: "node-1", status: "completed" },
-			{ ownerRunId: "owner-2", nodeId: "node-2", status: "completed" },
-		]);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, first);
-		await tick();
-		assert.equal(executeCalls, 2);
-		assert.equal(responses.length, 2);
-		bridge.dispose();
-	});
-
-	it("applies exact v2 pre-cancellation despite logical-node and bare-id conflicts", async () => {
-		const events = new FakeEvents();
-		const releases = new Map<string, () => void>();
-		const activeSignals = new Map<string, AbortSignal>();
-		const responses: SubagentDelegationV2Response[] = [];
-		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationV2Response));
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => { throw new Error("ordinary executor must remain separate"); },
-			executeVersioned: async (_id, params, signal) => {
-				if (typeof params.task !== "string") throw new Error("expected a single delegated task");
-				const task = params.task;
-				activeSignals.set(task, signal);
-				await new Promise<void>((resolve) => releases.set(task, resolve));
-				return { details: { mode: "single", results: [{ agent: params.agent, exitCode: 0, finalOutput: task }] } };
-			},
-		});
-
-		const logicalOwner = { ...v2Request, requestId: "logical-owner", task: "logical-owner", result: { kind: "text" as const } };
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, logicalOwner);
-		while (!releases.has("logical-owner")) await tick();
-		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "logical-pre", ownerRunId: "owner-1", nodeId: "node-1" });
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...logicalOwner, requestId: "logical-pre", task: "must-not-run" });
-		await tick();
-		assert.equal(responses.find((entry) => entry.requestId === "logical-pre")?.status, "cancelled");
-		assert.equal(activeSignals.get("logical-owner")?.aborted, false);
-		assert.equal(releases.has("must-not-run"), false);
-
-		const bareOwner = { ...v2Request, requestId: "shared-bare", ownerRunId: "owner-2", nodeId: "node-2", task: "bare-owner", result: { kind: "text" as const } };
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, bareOwner);
-		while (!releases.has("bare-owner")) await tick();
-		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "shared-bare", ownerRunId: "owner-3", nodeId: "node-3" });
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...bareOwner, ownerRunId: "owner-3", nodeId: "node-3", task: "also-must-not-run" });
-		await tick();
-		assert.equal(responses.find((entry) => entry.ownerRunId === "owner-3")?.status, "cancelled");
-		assert.equal(activeSignals.get("bare-owner")?.aborted, false);
-		assert.equal(releases.has("also-must-not-run"), false);
-
-		releases.get("logical-owner")?.();
-		releases.get("bare-owner")?.();
-		bridge.dispose();
-	});
-
-	it("suppresses v2 terminal events after disposal", async () => {
-		const events = new FakeEvents();
-		const responses: unknown[] = [];
-		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload));
-		let rejectExecution: ((error: Error) => void) | undefined;
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => { throw new Error("ordinary executor must remain separate"); },
-			executeVersioned: async () => await new Promise((_resolve, reject) => { rejectExecution = reject; }),
-		});
-		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...v2Request, requestId: "dispose-v2", result: { kind: "text" } });
-		await startedPromise;
-		bridge.dispose();
-		rejectExecution?.(new Error("aborted"));
-		await tick();
-		assert.deepEqual(responses, []);
-	});
-
-	it("runs one v1 request through the existing executor and returns structured metadata", async () => {
-		const events = new FakeEvents();
-		let executeCalls = 0;
-		let observedRequest: unknown;
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async (_requestId, delegatedRequest, _signal, _ctx, onUpdate) => {
-				executeCalls++;
-				observedRequest = delegatedRequest;
-				onUpdate({
-					details: {
-						mode: "single",
-						results: [{ agent: "reviewer", model: "openai/gpt-5" }],
-						progress: [{ index: 0, agent: "reviewer", currentTool: "read", recentOutput: ["line 1"], recentTools: [], toolCount: 1, tokens: 42, durationMs: 10 }],
-					},
-				});
-				return {
-					details: {
-						mode: "single",
-						runId: "run-1",
-						results: [{
-							agent: "reviewer",
-							exitCode: 0,
-							model: "openai/gpt-5",
-							finalOutput: "done",
-							savedOutputPath: "/repo/result.md",
-							sessionFile: "/tmp/session.jsonl",
-							usage: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0, cost: 0.01, turns: 2 },
-							progressSummary: { toolCount: 4, tokens: 5, durationMs: 6 },
-							agentContract: { version: 1 },
-							execution: { status: "completed", success: true, exitCode: 0 },
-							acceptance: { status: "checked", evidenceStatus: "checked", explicit: true },
-							review: { status: "not-requested" },
-							effects: { fileMutation: { status: "missing", expected: true, attempted: false } },
-							skillsWarning: "Skills not found: review",
-						}],
-					},
-				};
-			},
-		});
-		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
-		const updatePromise = once(events, SUBAGENT_DELEGATION_UPDATE_EVENT);
 		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, request);
-
-		assert.deepEqual(await startedPromise, { version: 1, requestId: "delegation-1" });
-		assert.deepEqual(await updatePromise, {
-			version: 1,
-			requestId: "delegation-1",
-			currentTool: "read",
-			recentOutput: "line 1",
-			recentOutputLines: ["line 1"],
-			model: "openai/gpt-5",
-			toolCount: 1,
-			durationMs: 10,
-			tokens: 42,
-		});
-		const response = await responsePromise as SubagentDelegationResponse;
-		assert.equal(executeCalls, 1);
-		assert.deepEqual(observedRequest, {
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+			requestId: "legacy-1",
 			agent: "reviewer",
-			task: "Review evidence",
+			task: "Legacy prompt-template delegation",
 			context: "fresh",
-			cwd: "/repo",
 			model: "openai/gpt-5",
-			timeoutMs: 1_000,
-			turnBudget: { maxTurns: 4, graceTurns: 1 },
-			enforceHardTurnLimit: true,
-			toolBudget: { soft: 3, hard: 5, block: "*" },
-			skill: ["review"],
-			output: "result.md",
-			outputMode: "file-only",
-			outputSchema: { type: "object", properties: { ok: { type: "boolean" } } },
-			agentContract: { version: 1 },
-			acceptance: "checked",
-			artifacts: true,
-			async: false,
-			foregroundOnly: true,
-			clarify: false,
+			cwd: "/repo",
 		});
-		assert.equal(response.status, "completed");
-		assert.equal(response.runId, "run-1");
-		assert.equal(response.agent, "reviewer");
-		assert.equal(response.output, "done");
-		assert.equal(response.outputPath, "/repo/result.md");
-		assert.equal(response.sessionFile, "/tmp/session.jsonl");
-		assert.deepEqual(response.execution, { status: "completed", success: true, exitCode: 0 });
-		assert.deepEqual(response.review, { status: "not-requested" });
-		assert.deepEqual(response.effects, { fileMutation: { status: "missing", expected: true, attempted: false } });
-		assert.equal(response.turns, 2);
-		assert.equal(response.toolCount, 4);
-		assert.equal(response.tokens, 5);
-		assert.deepEqual(response.acceptance, { status: "checked", evidenceStatus: "checked", explicit: true });
-		assert.deepEqual(response.warnings, ["Skills not found: review"]);
+		const response = await responsePromise as { requestId: string; isError: boolean; contentText?: string };
+		assert.equal(response.requestId, "legacy-1");
+		assert.equal(response.isError, false);
+		assert.equal(response.contentText, "legacy done");
+		assert.equal(legacyCalls, 1);
+		assert.equal(structuredCalls, 0);
 		bridge.dispose();
-	});
-
-	it("routes independent v1 requests through the concurrent-safe delegated executor", async () => {
-		const events = new FakeEvents();
-		let ordinaryCalls = 0;
-		let active = 0;
-		let maxActive = 0;
-		let started = 0;
-		let release!: () => void;
-		const barrier = new Promise<void>((resolve) => { release = resolve; });
-		const responses: SubagentDelegationResponse[] = [];
-		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (value) => responses.push(value as SubagentDelegationResponse));
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => {
-				ordinaryCalls++;
-				return { details: { mode: "single", results: [] } };
-			},
-			executeVersioned: async (_id, params) => {
-				active++;
-				started++;
-				maxActive = Math.max(maxActive, active);
-				await barrier;
-				active--;
-				return {
-					details: {
-						mode: "single",
-						results: [{
-							agent: params.agent,
-							exitCode: 0,
-							finalOutput: params.task,
-							usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
-						}],
-					},
-				};
-			},
-		});
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "parallel-a", task: "A" });
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "parallel-b", task: "B" });
-		while (started < 2) await tick();
-		assert.equal(maxActive, 2);
-		assert.equal(ordinaryCalls, 0);
-		release();
-		while (responses.length < 2) await tick();
-		assert.deepEqual(responses.map((response) => response.requestId).sort(), ["parallel-a", "parallel-b"]);
-		assert.ok(responses.every((response) => response.status === "completed"));
-		bridge.dispose();
-	});
-
-	it("returns correlated invalid-request and unavailable-context statuses without executing", async () => {
-		const events = new FakeEvents();
-		let executeCalls = 0;
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => null,
-			execute: async () => {
-				executeCalls++;
-				return { details: { mode: "single", results: [] } };
-			},
-		});
-		const invalidPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, version: 2, requestId: "invalid-1" });
-		assert.deepEqual(await invalidPromise, {
-			version: 2,
-			requestId: "invalid-1",
-			status: "invalid_request",
-			error: "Unsupported delegation protocol version: 2.",
-		} satisfies SubagentDelegationV2InvalidResponse);
-
-		const unavailablePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "unavailable-1" });
-		const unavailable = await unavailablePromise as SubagentDelegationResponse;
-		assert.equal(unavailable.status, "unavailable_context");
-		assert.equal(executeCalls, 0);
-		bridge.dispose();
-	});
-
-	it("maps terminal executor outcomes without failing inferred acceptance", async () => {
-		const cases = [
-			[{ timedOut: true }, "timed_out"],
-			[{ interrupted: true }, "interrupted"],
-			[{ stopped: true }, "interrupted"],
-			[{ turnBudgetExceeded: true }, "turn_budget_exhausted"],
-			[{ toolBudgetBlocked: true }, "tool_budget_exhausted"],
-			[{ turnBudgetExceeded: true, structuredOutputFailed: true }, "structured_output_failed"],
-			[{ acceptance: { status: "rejected", explicit: true } }, "acceptance_failed"],
-			[{ agentContract: { version: 1 }, acceptance: { status: "rejected", explicit: true } }, "completed"],
-			[{ acceptance: { status: "rejected", explicit: false } }, "completed"],
-			[{ exitCode: 1, error: "failed" }, "failed"],
-		] as const;
-		for (const [child, expectedStatus] of cases) {
-			const events = new FakeEvents();
-			const bridge = registerPromptTemplateDelegationBridge({
-				events,
-				getContext: () => ({ cwd: "/repo" }),
-				execute: async () => ({
-					isError: expectedStatus !== "completed",
-					details: {
-						mode: "single",
-						results: [{
-							agent: "reviewer",
-							exitCode: 0,
-							usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
-							...child,
-						}],
-					},
-				}),
-			});
-			const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-			events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: `case-${expectedStatus}-${Math.random()}` });
-			assert.equal((await responsePromise as SubagentDelegationResponse).status, expectedStatus);
-			bridge.dispose();
-		}
-	});
-
-	it("ignores malformed versioned cancellation without aborting the owner", async () => {
-		const events = new FakeEvents();
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => { throw new Error("ordinary executor must not own a strict v1 request"); },
-			executeVersioned: async (_id, _params, signal) => await new Promise((_resolve, reject) => {
-				signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
-			}),
-		});
-		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
-		const responses: unknown[] = [];
-		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload));
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "strict-cancel-1" });
-		await startedPromise;
-		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 2, requestId: "strict-cancel-1" });
-		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 1, requestId: "strict-cancel-1", reason: "extra" });
-		await tick();
-		assert.deepEqual(responses, []);
-		events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 1, requestId: "strict-cancel-1" });
-		await tick();
-		assert.equal((responses[0] as SubagentDelegationResponse).status, "cancelled");
-		bridge.dispose();
-	});
-
-	it("preserves active request ownership when a duplicate requestId arrives", async () => {
-		const events = new FakeEvents();
-		let executeCalls = 0;
-		let finish: (() => void) | undefined;
-		const responses: unknown[] = [];
-		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload));
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => {
-				executeCalls++;
-				await new Promise<void>((resolve) => { finish = resolve; });
-				return { details: { mode: "single", results: [{ agent: "reviewer", exitCode: 0, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } }] } };
-			},
-		});
-		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "duplicate-1" });
-		await startedPromise;
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "duplicate-1" });
-		await tick();
-		assert.equal(executeCalls, 1);
-		assert.equal(responses.length, 0);
-		finish?.();
-		await tick();
-		assert.equal(responses.length, 1);
-		assert.equal((responses[0] as SubagentDelegationResponse).status, "completed");
-		bridge.dispose();
-	});
-
-	it("bounds pending cancellation IDs and applies retained pre-cancellation once", async () => {
-		const events = new FakeEvents();
-		let executeCalls = 0;
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => {
-				executeCalls++;
-				return { details: { mode: "single", results: [{ agent: "reviewer", exitCode: 0, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } }] } };
-			},
-		});
-		for (let index = 0; index < 300; index++) {
-			events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, { version: 1, requestId: `cancel-${index}` });
-		}
-
-		const evictedPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "cancel-0" });
-		assert.equal((await evictedPromise as SubagentDelegationResponse).status, "completed");
-
-		const retainedPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "cancel-299" });
-		assert.equal((await retainedPromise as SubagentDelegationResponse).status, "cancelled");
-		assert.equal(executeCalls, 1);
-		bridge.dispose();
-	});
-
-	it("fails closed instead of evicting exact v2 cancellation identity", async () => {
-		const events = new FakeEvents();
-		let executeCalls = 0;
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => {
-				executeCalls++;
-				return { details: { mode: "single", results: [{ agent: "reviewer", exitCode: 0, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } }] } };
-			},
-		});
-		for (let index = 0; index < 8_192; index++) {
-			events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, {
-				version: 2,
-				requestId: `attempt-${index}`,
-				ownerRunId: "saturated-owner",
-				nodeId: `node-${index}`,
-			});
-		}
-
-		const retainedPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
-			...v2Request,
-			requestId: "attempt-0",
-			ownerRunId: "saturated-owner",
-			nodeId: "node-0",
-		});
-		assert.equal((await retainedPromise as SubagentDelegationV2Response).status, "cancelled");
-
-		const overflowPromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
-			...v2Request,
-			requestId: "overflow-attempt",
-			ownerRunId: "saturated-owner",
-			nodeId: "overflow-node",
-		});
-		const overflow = await overflowPromise as SubagentDelegationV2Response;
-		assert.equal(overflow.status, "unavailable_context");
-		assert.match(overflow.error ?? "", /identity capacity/i);
-		assert.equal(executeCalls, 0);
-		bridge.dispose();
-	});
-
-	it("fails closed when settled v2 identity history reaches capacity", async () => {
-		const events = new FakeEvents();
-		const responses: SubagentDelegationV2Response[] = [];
-		let executeCalls = 0;
-		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationV2Response));
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async (requestId) => {
-				executeCalls++;
-				return { details: { mode: "single", results: [{ agent: "reviewer", exitCode: 0, finalOutput: requestId }] } };
-			},
-		});
-		for (let index = 0; index < 8_192; index++) {
-			events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
-				...v2Request,
-				requestId: `settled-${index}`,
-				ownerRunId: "settled-owner",
-				nodeId: `settled-node-${index}`,
-				result: { kind: "text" },
-			});
-		}
-		for (let attempt = 0; responses.length < 8_192 && attempt < 100; attempt++) await tick();
-		assert.equal(responses.length, 8_192);
-		assert.equal(executeCalls, 8_192);
-
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
-			...v2Request,
-			requestId: "settled-overflow",
-			ownerRunId: "settled-owner",
-			nodeId: "settled-overflow-node",
-			result: { kind: "text" },
-		});
-		await tick();
-		assert.equal(responses.at(-1)?.status, "unavailable_context");
-		assert.equal(executeCalls, 8_192);
-
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
-			...v2Request,
-			requestId: "settled-0",
-			ownerRunId: "settled-owner",
-			nodeId: "settled-node-0",
-			result: { kind: "text" },
-		});
-		await tick();
-		assert.equal(responses.length, 8_193);
-		assert.equal(executeCalls, 8_192);
-		bridge.dispose();
-	});
-
-	it("suppresses stale terminal events after disposal", async () => {
-		const events = new FakeEvents();
-		const responses: unknown[] = [];
-		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload));
-		let rejectExecution: ((error: Error) => void) | undefined;
-		const bridge = registerPromptTemplateDelegationBridge({
-			events,
-			getContext: () => ({ cwd: "/repo" }),
-			execute: async () => await new Promise((_resolve, reject) => { rejectExecution = reject; }),
-		});
-		const startedPromise = once(events, SUBAGENT_DELEGATION_STARTED_EVENT);
-		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, requestId: "dispose-1" });
-		await startedPromise;
-		bridge.dispose();
-		rejectExecution?.(new Error("aborted"));
-		await tick();
-		assert.deepEqual(responses, []);
 	});
 });

--- a/test/unit/delegation-api.test.ts
+++ b/test/unit/delegation-api.test.ts
@@ -280,6 +280,171 @@ describe("public subagent delegation contract", () => {
 		bridge.dispose();
 	});
 
+	it("keys concurrent structured attempts and retransmissions by the full identity tuple", async () => {
+		const events = new FakeEvents();
+		const releases = new Map<string, () => void>();
+		const responses: SubagentDelegationResponse[] = [];
+		let executeCalls = 0;
+		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationResponse));
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("legacy executor must remain separate"); },
+			executeStructured: async (_id, params) => {
+				executeCalls++;
+				if (typeof params.task !== "string") throw new Error("expected a single delegated task");
+				const task = params.task;
+				await new Promise<void>((resolve) => releases.set(task, resolve));
+				return {
+					details: {
+						mode: "single",
+						results: [{
+							agent: params.agent,
+							exitCode: 0,
+							finalOutput: task,
+							usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+						}],
+					},
+				};
+			},
+		});
+		const first = { ...request, requestId: "shared-attempt", task: "first", result: { kind: "text" as const } };
+		const second = { ...first, ownerRunId: "owner-2", nodeId: "node-2", task: "second" };
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, first);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, second);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, first);
+		for (let index = 0; index < 5 && releases.size < 2; index++) await tick();
+		assert.equal(releases.size, 2);
+		assert.equal(executeCalls, 2);
+		releases.get("first")?.();
+		releases.get("second")?.();
+		while (responses.length < 2) await tick();
+		assert.deepEqual(responses.map(({ ownerRunId, nodeId, status }) => ({ ownerRunId, nodeId, status })).sort((a, b) => a.ownerRunId.localeCompare(b.ownerRunId)), [
+			{ ownerRunId: "owner-1", nodeId: "node-1", status: "completed" },
+			{ ownerRunId: "owner-2", nodeId: "node-2", status: "completed" },
+		]);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, first);
+		await tick();
+		assert.equal(executeCalls, 2);
+		assert.equal(responses.length, 2);
+		bridge.dispose();
+	});
+
+	it("fails closed instead of evicting structured identity state", async () => {
+		const events = new FakeEvents();
+		const responses: SubagentDelegationResponse[] = [];
+		let executeCalls = 0;
+		events.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => responses.push(payload as SubagentDelegationResponse));
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("legacy executor must remain separate"); },
+			executeStructured: async (requestId) => {
+				executeCalls++;
+				return {
+					details: {
+						mode: "single",
+						results: [{
+							agent: "reviewer",
+							exitCode: 0,
+							finalOutput: requestId,
+							usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+						}],
+					},
+				};
+			},
+		});
+
+		for (let index = 0; index < 8_192; index++) {
+			events.emit(SUBAGENT_DELEGATION_CANCEL_EVENT, {
+				requestId: `cancelled-${index}`,
+				ownerRunId: "saturated-owner",
+				nodeId: `cancelled-node-${index}`,
+			});
+		}
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+			...request,
+			requestId: "cancelled-0",
+			ownerRunId: "saturated-owner",
+			nodeId: "cancelled-node-0",
+			result: { kind: "text" },
+		});
+		while (!responses.some((entry) => entry.requestId === "cancelled-0")) await tick();
+		assert.equal(responses.at(-1)?.status, "cancelled");
+
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+			...request,
+			requestId: "cancel-overflow",
+			ownerRunId: "saturated-owner",
+			nodeId: "cancel-overflow-node",
+			result: { kind: "text" },
+		});
+		while (!responses.some((entry) => entry.requestId === "cancel-overflow")) await tick();
+		assert.equal(responses.at(-1)?.status, "unavailable_context");
+		assert.match(responses.at(-1)?.error ?? "", /identity capacity/i);
+		assert.equal(executeCalls, 0);
+		bridge.dispose();
+
+		const settledEvents = new FakeEvents();
+		const settledResponses: SubagentDelegationResponse[] = [];
+		let settledExecuteCalls = 0;
+		settledEvents.on(SUBAGENT_DELEGATION_RESPONSE_EVENT, (payload) => settledResponses.push(payload as SubagentDelegationResponse));
+		const settledBridge = registerPromptTemplateDelegationBridge({
+			events: settledEvents,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("legacy executor must remain separate"); },
+			executeStructured: async (requestId) => {
+				settledExecuteCalls++;
+				return {
+					details: {
+						mode: "single",
+						results: [{
+							agent: "reviewer",
+							exitCode: 0,
+							finalOutput: requestId,
+							usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+						}],
+					},
+				};
+			},
+		});
+		for (let index = 0; index < 8_192; index++) {
+			settledEvents.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+				...request,
+				requestId: `settled-${index}`,
+				ownerRunId: "settled-owner",
+				nodeId: `settled-node-${index}`,
+				result: { kind: "text" },
+			});
+		}
+		for (let attempt = 0; settledResponses.length < 8_192 && attempt < 100; attempt++) await tick();
+		assert.equal(settledResponses.length, 8_192);
+		assert.equal(settledExecuteCalls, 8_192);
+
+		settledEvents.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+			...request,
+			requestId: "settled-overflow",
+			ownerRunId: "settled-owner",
+			nodeId: "settled-overflow-node",
+			result: { kind: "text" },
+		});
+		await tick();
+		assert.equal(settledResponses.at(-1)?.status, "unavailable_context");
+		assert.equal(settledExecuteCalls, 8_192);
+
+		settledEvents.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, {
+			...request,
+			requestId: "settled-0",
+			ownerRunId: "settled-owner",
+			nodeId: "settled-node-0",
+			result: { kind: "text" },
+		});
+		await tick();
+		assert.equal(settledResponses.length, 8_193);
+		assert.equal(settledExecuteCalls, 8_192);
+		settledBridge.dispose();
+	});
+
 	it("retains the unversioned prompt-template bridge as legacy fallback", async () => {
 		const events = new FakeEvents();
 		let structuredCalls = 0;

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -67,8 +67,6 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.equal(capability.SUBAGENT_CAPABILITY_CEILING_VERSION, 1);
 	assert.equal(capability.SUBAGENT_CAPABILITY_CEILING_REGISTRY_KEY, "pi-subagents.capability-ceiling.v1");
 	const delegation = await import("pi-subagents/delegation");
-	assert.equal(delegation.SUBAGENT_DELEGATION_PROTOCOL_VERSION, 1);
-	assert.equal(delegation.SUBAGENT_DELEGATION_V2_PROTOCOL_VERSION, 2);
 	assert.equal(delegation.SUBAGENT_DELEGATION_REQUEST_EVENT, "prompt-template:subagent:request");
 	const preflight = await import("pi-subagents/preflight");
 	assert.equal(preflight.SUBAGENT_LAUNCH_CONTRACT_VERSION, 2);


### PR DESCRIPTION
## Summary

Replaces the separate version-numbered extension delegation contracts with one structured owned-leaf delegation API. The unversioned prompt-template bridge remains as a temporary legacy fallback while we validate whether any integrations still use it.

This removes the v1/v2 public delegation exports and internal branch naming, keeps full-tuple ownership/cancellation semantics, and updates docs/tests around the semantic contract.

## Validation

- `npm run typecheck -- --pretty false`
- `node --experimental-strip-types --test test/unit/delegation-api.test.ts test/unit/package-manifest.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`
- `npm pack --dry-run`
- Fresh-context reviewer: no concrete release-risk findings
