### PR TITLE
fix: resume after compaction with async work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Resume the parent session after compaction while async subagent work remains active.
 - Avoid invoking `npm root -g` on Windows when the standard `%APPDATA%\\npm\\node_modules` global root is available, preserving custom terminal tab titles during agent and skill discovery. Thanks to @Suchwert for #767.
 - Preserved nested foreground failure events when resolved launch metadata is unavailable.
 - Launch standalone Pi child processes directly instead of prepending the resolved Pi CLI script path. Thanks to @ZacharyQin for #764.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -576,6 +576,19 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		herdrStatusBridge.agentStarted();
 	});
 
+	pi.on("session_compact", () => {
+		const hasActiveAsyncWork = [...state.asyncJobs.values()].some((job) => job.status === "queued" || job.status === "running");
+		if (!hasActiveAsyncWork || state.lastUiContext?.hasUI !== true) return;
+		pi.sendMessage(
+			{
+				customType: "subagent-compaction-resume",
+				content: "Compaction is complete. Resume the parent task now; background subagent results will arrive separately when ready.",
+				display: false,
+			},
+			{ triggerTurn: true },
+		);
+	});
+
 	pi.on("session_start", (event, ctx) => {
 		const recovering = event.reason === "startup" || event.reason === "reload" || event.reason === "resume";
 		resetSessionState(ctx, recovering);

--- a/test/unit/compaction-resume.test.ts
+++ b/test/unit/compaction-resume.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+describe("async compaction resume", () => {
+	it("continues an interactive parent after compaction while async work is active", () => {
+		const script = String.raw`
+			import os from "node:os";
+			import path from "node:path";
+			import registerSubagentExtension from "./index.ts";
+			const handlers = new Map();
+			const events = { listeners: new Map(), on(name, handler) { this.listeners.set(name, handler); return () => this.listeners.delete(name); }, emit(name, payload) { this.listeners.get(name)?.(payload); } };
+			const sent = [];
+			const pi = new Proxy({
+				events,
+				on(name, handler) { handlers.set(name, handler); },
+				registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+				sendMessage(message, options) { sent.push({ message, options }); }, getSessionName() { return undefined; },
+			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+			const ctx = { cwd: process.cwd(), hasUI: true, ui: { setWidget() {}, requestRender() {}, theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } } }, sessionManager: { getSessionId() { return "compact-session"; }, getSessionFile() { return null; }, getEntries() { return []; } }, modelRegistry: { getAvailable() { return []; } } };
+			registerSubagentExtension(pi);
+			handlers.get("session_start")({}, ctx);
+			sent.length = 0;
+			events.emit("subagent:async-started", { id: "running", pid: 1, sessionId: "compact-session", mode: "single", agent: "worker", asyncDir: path.join(os.tmpdir(), "pi-compaction-test-running") });
+			handlers.get("session_compact")();
+			if (sent.length !== 1 || sent[0].options?.triggerTurn !== true || sent[0].message?.customType !== "subagent-compaction-resume") throw new Error(JSON.stringify(sent));
+			sent.length = 0;
+			events.emit("subagent:async-complete", { id: "running", sessionId: "compact-session", agent: "worker", success: true, summary: "done" });
+			handlers.get("session_compact")();
+			if (sent.some((entry) => entry.message?.customType === "subagent-compaction-resume")) throw new Error("resumed without active work");
+		`;
+		const env = { ...process.env };
+		delete env.PI_SUBAGENT_CHILD;
+		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+		assert.ok(true);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #780 by resuming the interactive parent after Pi compaction when async subagent work is still queued or running.

The extension now listens for `session_compact` and, only for UI-backed sessions with active async jobs, sends a hidden `triggerTurn` continuation. Async completion delivery remains separate and unchanged.

## Validation

- `node --experimental-strip-types --test test/unit/compaction-resume.test.ts`
- `npm run typecheck`
- `git diff --check main...HEAD`

Fresh read-only review found no release-risk findings.
