### PR TITLE
fix: reconcile fleet inspector runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Show current-session async runs in the Fleet inspector even when this Pi process did not start them.
 - Resume the parent session after compaction while async subagent work remains active.
 - Avoid invoking `npm root -g` on Windows when the standard `%APPDATA%\\npm\\node_modules` global root is available, preserving custom terminal tab titles during agent and skill discovery. Thanks to @Suchwert for #767.
 - Preserved nested foreground failure events when resolved launch metadata is unavailable.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -241,7 +241,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		? new SubagentFleetStatus(state, async (itemKey) => {
 			const ctx = state.lastUiContext;
 			if (!ctx?.hasUI) return;
-			await openSubagentFleet(ctx, state, { initialKey: itemKey });
+			await openSubagentFleet(ctx, state, { initialKey: itemKey, asyncDirRoot: DIRS.async, resultsDir: DIRS.results });
 		}, { placement: fleetViewPlacement })
 		: undefined;
 	const { startResultWatcher, primeExistingResults, stopResultWatcher } = createResultWatcher(

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -648,7 +648,7 @@ export function registerSlashCommands(
 		}
 		fleetOpen = true;
 		try {
-			await openSubagentFleet(ctx, state);
+			await openSubagentFleet(ctx, state, { asyncDirRoot: DIRS.async, resultsDir: DIRS.results });
 		} finally {
 			fleetOpen = false;
 		}

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -509,6 +509,34 @@ describe("native subagent fleet", () => {
 		}
 	});
 
+	it("shows disk-only current-session async runs when the overlay opens", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-overlay-reconcile-"));
+		try {
+			writeAsyncRun(root, { id: "disk-only", agents: ["worker"] });
+			const state = stateForTest();
+			let rendered = "";
+			const ctx = {
+				hasUI: true,
+				ui: {
+					setWidget() {},
+					async custom(factory: (tui: unknown, theme: unknown, keybindings: unknown, done: (result: undefined) => void) => SubagentFleetComponent) {
+						const component = factory({ terminal: { rows: 32 }, requestRender() {} }, theme, undefined, () => {});
+						try {
+							rendered = component.render(100).join("\n");
+						} finally {
+							component.dispose();
+						}
+					},
+				},
+			};
+
+			await openSubagentFleet(ctx as never, state, { asyncDirRoot: root, resultsDir: path.join(root, "results") });
+			assert.match(rendered, /worker/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("suppresses the status widget for the full inspector lifecycle", async () => {
 		const state = stateForTest();
 		let hidden = 0;


### PR DESCRIPTION
## Summary

Fixes #768 by opening the Fleet inspector with the shared async/results directories, so the inspector can render current-session async runs from disk even if this Pi process did not witness them starting.

## Validation

- `node --experimental-strip-types --test test/unit/fleet.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh read-only review found no release-risk findings.
