### PR TITLE
fix: suppress stale foreground control notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Fixed
 - Show current-session async runs in the Fleet inspector even when this Pi process did not start them.
 - Replace the duplicate advisor agent with an alias on the oracle agent.
+- Suppress stale foreground needs-attention transcript notices after the target run completes.
 - Resume the parent session after compaction while async subagent work remains active.
 - Avoid invoking `npm root -g` on Windows when the standard `%APPDATA%\\npm\\node_modules` global root is available, preserving custom terminal tab titles during agent and skill discovery. Thanks to @Suchwert for #767.
 - Preserved nested foreground failure events when resolved launch metadata is unavailable.

--- a/src/extension/control-notices.ts
+++ b/src/extension/control-notices.ts
@@ -20,11 +20,6 @@ export function formatSubagentControlNotice(details: SubagentControlMessageDetai
 	return details.noticeText ?? content ?? formatControlNoticeMessage(details.event, controlNoticeTarget(details));
 }
 
-function noticeTimerKey(details: SubagentControlMessageDetails): string {
-	const childIntercomTarget = controlNoticeTarget(details);
-	return `${details.event.runId}:${controlNotificationKey(details.event, childIntercomTarget)}`;
-}
-
 export function clearPendingForegroundControlNotices(state: SubagentState, runId?: string): void {
 	const pending = state.pendingForegroundControlNotices;
 	if (!pending) return;
@@ -56,37 +51,18 @@ function deliverControlNotice(input: {
 	);
 }
 
-function isForegroundNoticeStillActionable(state: SubagentState, details: SubagentControlMessageDetails): boolean {
-	const control = state.foregroundControls.get(details.event.runId);
-	if (!control) return false;
-	if (control.currentAgent && control.currentAgent !== details.event.agent) return false;
-	if (details.event.index !== undefined && control.currentIndex !== details.event.index) return false;
-	return control.currentActivityState === "needs_attention";
-}
-
 export function handleSubagentControlNotice(input: {
 	pi: Pick<ExtensionAPI, "sendMessage">;
 	state: SubagentState;
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;
-	foregroundDelayMs?: number;
 }): void {
 	if (!input.details?.event || input.details.event.type === "active_long_running") return;
-	if (input.details.source !== "foreground") {
-		deliverControlNotice(input);
+	if (input.details.source === "foreground") {
+		// A foreground tool blocks Pi from displaying this message. The run can
+		// finish before Pi flushes it, and queued messages cannot be withdrawn.
+		// Foreground control remains available through the live tool and fleet state.
 		return;
 	}
-
-	const pending = input.state.pendingForegroundControlNotices ?? new Map<string, ReturnType<typeof setTimeout>>();
-	input.state.pendingForegroundControlNotices = pending;
-	const timerKey = noticeTimerKey(input.details);
-	const existing = pending.get(timerKey);
-	if (existing) clearTimeout(existing);
-	const timer = setTimeout(() => {
-		pending.delete(timerKey);
-		if (!isForegroundNoticeStillActionable(input.state, input.details)) return;
-		deliverControlNotice(input);
-	}, input.foregroundDelayMs ?? 1000);
-	timer.unref?.();
-	pending.set(timerKey, timer);
+	deliverControlNotice(input);
 }

--- a/src/extension/control-notices.ts
+++ b/src/extension/control-notices.ts
@@ -20,16 +20,6 @@ export function formatSubagentControlNotice(details: SubagentControlMessageDetai
 	return details.noticeText ?? content ?? formatControlNoticeMessage(details.event, controlNoticeTarget(details));
 }
 
-export function clearPendingForegroundControlNotices(state: SubagentState, runId?: string): void {
-	const pending = state.pendingForegroundControlNotices;
-	if (!pending) return;
-	for (const [key, timer] of pending) {
-		if (runId !== undefined && !key.startsWith(`${runId}:`)) continue;
-		clearTimeout(timer);
-		pending.delete(key);
-	}
-}
-
 function deliverControlNotice(input: {
 	pi: Pick<ExtensionAPI, "sendMessage">;
 	visibleControlNotices: Set<string>;

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -37,7 +37,6 @@ function createChildSafeState(): SubagentState {
 		foregroundRuns: new Map(),
 		foregroundControls: new Map(),
 		lastForegroundControlId: null,
-		pendingForegroundControlNotices: new Map(),
 		cleanupTimers: new Map(),
 		lastUiContext: null,
 		poller: null,

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -67,7 +67,6 @@ import {
 	resolveMaxSubagentSpawnsPerSession,
 } from "../shared/types.ts";
 import {
-	clearPendingForegroundControlNotices,
 	formatSubagentControlNotice,
 	handleSubagentControlNotice,
 	SUBAGENT_CONTROL_MESSAGE_TYPE,
@@ -221,7 +220,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		foregroundRuns: new Map(),
 		foregroundControls: new Map(),
 		lastForegroundControlId: null,
-		pendingForegroundControlNotices: new Map(),
 		cleanupTimers: new Map(),
 		lastUiContext: null,
 		poller: null,
@@ -263,7 +261,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		scheduledRunManager.stop();
 		supervisorChannel.dispose();
 		fleetStatus?.dispose();
-		clearPendingForegroundControlNotices(state);
 		if (state.poller) {
 			clearInterval(state.poller);
 			state.poller = null;
@@ -560,7 +557,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}
 		state.lastUiContext = ctx;
 		cleanupSessionArtifacts(ctx);
-		clearPendingForegroundControlNotices(state);
 		state.foregroundControls.clear();
 		state.lastForegroundControlId = null;
 		resetJobs(ctx);
@@ -619,7 +615,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		scheduledRunManager.stop();
 		if (state.poller) clearInterval(state.poller);
 		state.poller = null;
-		clearPendingForegroundControlNotices(state);
 		for (const timer of state.cleanupTimers.values()) {
 			clearTimeout(timer);
 		}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -20,7 +20,6 @@ import {
 import { resolveExecutionAgentScope } from "../../agents/agent-scope.ts";
 import { handleManagementAction } from "../../agents/agent-management.ts";
 import { buildDoctorReport } from "../../extension/doctor.ts";
-import { clearPendingForegroundControlNotices } from "../../extension/control-notices.ts";
 import { runSync } from "./execution.ts";
 import { handleWatchdogToolAction, WATCHDOG_TOOL_ACTIONS } from "../../watchdog/tool-actions.ts";
 import type { MainWatchdogRuntime } from "../../watchdog/runtime.ts";
@@ -338,7 +337,6 @@ function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefine
 function removeForegroundControlIfIdle(state: SubagentState, runId: string): boolean {
 	const control = state.foregroundControls.get(runId);
 	if (control && (!foregroundSchedulingSettled(control) || (control.activeChildren?.size ?? 0) > 0)) return false;
-	clearPendingForegroundControlNotices(state, runId);
 	state.foregroundControls.delete(runId);
 	if (state.lastForegroundControlId === runId) state.lastForegroundControlId = null;
 	return true;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1544,7 +1544,6 @@ export interface SubagentState {
 	foregroundRuns?: Map<string, ForegroundResumeRun>;
 	foregroundControls: Map<string, ForegroundRunControl>;
 	lastForegroundControlId: string | null;
-	pendingForegroundControlNotices?: Map<string, ReturnType<typeof setTimeout>>;
 	cleanupTimers: Map<string, ReturnType<typeof setTimeout>>;
 	lastUiContext: ExtensionContext | null;
 	poller: NodeJS.Timeout | null;

--- a/test/unit/control-notices.test.ts
+++ b/test/unit/control-notices.test.ts
@@ -50,10 +50,6 @@ function makeRecorder() {
 	};
 }
 
-function wait(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 describe("subagent control notice delivery", () => {
 	it("delivers async needs-attention notices immediately", () => {
 		const state = makeState();
@@ -71,91 +67,34 @@ describe("subagent control notice delivery", () => {
 		assert.deepEqual(recorder.sent[0]?.options, { triggerTurn: true });
 	});
 
-	it("queues foreground needs-attention notices until the same step is still actionable", async () => {
+	it("does not queue a foreground notice that Pi could flush after completion", () => {
 		const state = makeState();
 		state.foregroundControls.set("run-1", {
 			runId: "run-1",
-			mode: "chain",
+			mode: "parallel",
 			startedAt: 0,
 			updatedAt: 0,
 			currentAgent: "worker",
 			currentIndex: 0,
 			currentActivityState: "needs_attention",
 		});
-		const recorder = makeRecorder();
+		const queued: Array<{ message: unknown; options: unknown }> = [];
+		const visible: Array<{ message: unknown; options: unknown }> = [];
+		const pi = {
+			sendMessage(message: unknown, options: unknown) {
+				queued.push({ message, options });
+			},
+		};
 
 		handleSubagentControlNotice({
-			pi: recorder.pi,
+			pi,
 			state,
 			visibleControlNotices: new Set(),
 			details: { source: "foreground", event: needsAttentionEvent() },
-			foregroundDelayMs: 10,
 		});
-
-		assert.equal(recorder.sent.length, 0);
-		await wait(25);
-		assert.equal(recorder.sent.length, 1);
-		assert.deepEqual(recorder.sent[0]?.options, { triggerTurn: false });
-	});
-
-	it("drops queued foreground notices when the run finishes before delivery", async () => {
-		const state = makeState();
-		state.foregroundControls.set("run-1", {
-			runId: "run-1",
-			mode: "chain",
-			startedAt: 0,
-			updatedAt: 0,
-			currentAgent: "worker",
-			currentIndex: 0,
-			currentActivityState: "needs_attention",
-		});
-		const recorder = makeRecorder();
-
-		handleSubagentControlNotice({
-			pi: recorder.pi,
-			state,
-			visibleControlNotices: new Set(),
-			details: { source: "foreground", event: needsAttentionEvent() },
-			foregroundDelayMs: 20,
-		});
-		clearPendingForegroundControlNotices(state, "run-1");
 		state.foregroundControls.delete("run-1");
+		visible.push(...queued);
 
-		await wait(35);
-		assert.equal(recorder.sent.length, 0);
-	});
-
-	it("drops queued foreground notices after the chain advances to another step", async () => {
-		const state = makeState();
-		state.foregroundControls.set("run-1", {
-			runId: "run-1",
-			mode: "chain",
-			startedAt: 0,
-			updatedAt: 0,
-			currentAgent: "worker",
-			currentIndex: 0,
-			currentActivityState: "needs_attention",
-		});
-		const recorder = makeRecorder();
-
-		handleSubagentControlNotice({
-			pi: recorder.pi,
-			state,
-			visibleControlNotices: new Set(),
-			details: { source: "foreground", event: needsAttentionEvent() },
-			foregroundDelayMs: 10,
-		});
-		state.foregroundControls.set("run-1", {
-			runId: "run-1",
-			mode: "chain",
-			startedAt: 0,
-			updatedAt: 0,
-			currentAgent: "writer",
-			currentIndex: 1,
-			currentActivityState: undefined,
-		});
-
-		await wait(25);
-		assert.equal(recorder.sent.length, 0);
+		assert.deepEqual(visible, []);
 	});
 });

--- a/test/unit/control-notices.test.ts
+++ b/test/unit/control-notices.test.ts
@@ -1,9 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import {
-	clearPendingForegroundControlNotices,
-	handleSubagentControlNotice,
-} from "../../src/extension/control-notices.ts";
+import { handleSubagentControlNotice } from "../../src/extension/control-notices.ts";
 import type { ControlEvent, SubagentState } from "../../src/shared/types.ts";
 
 function makeState(): SubagentState {
@@ -13,7 +10,6 @@ function makeState(): SubagentState {
 		asyncJobs: new Map(),
 		foregroundControls: new Map(),
 		lastForegroundControlId: null,
-		pendingForegroundControlNotices: new Map(),
 		cleanupTimers: new Map(),
 		lastUiContext: null,
 		poller: null,
@@ -60,7 +56,6 @@ describe("subagent control notice delivery", () => {
 			state,
 			visibleControlNotices: new Set(),
 			details: { source: "async", event: needsAttentionEvent() },
-			foregroundDelayMs: 20,
 		});
 
 		assert.equal(recorder.sent.length, 1);


### PR DESCRIPTION
## Summary

Fixes #772 by preventing foreground needs-attention notices from being enqueued as transcript messages that can surface after the target run has completed. Async notice delivery is unchanged, and foreground attention remains visible through live tool/Fleet state.

## Validation

- `node --experimental-strip-types --test test/unit/control-notices.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh read-only review found no release-risk findings.
