### PR TITLE
fix: retry zero-activity SIGKILL startup exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Show current-session async runs in the Fleet inspector even when this Pi process did not start them.
 - Replace the duplicate advisor agent with an alias on the oracle agent.
 - Suppress stale foreground needs-attention transcript notices after the target run completes.
+- Retry zero-activity `SIGKILL` exits during child startup.
 - Resume the parent session after compaction while async subagent work remains active.
 - Avoid invoking `npm root -g` on Windows when the standard `%APPDATA%\\npm\\node_modules` global root is available, preserving custom terminal tab titles during agent and skill discovery. Thanks to @Suchwert for #767.
 - Preserved nested foreground failure events when resolved launch metadata is unavailable.

--- a/src/runs/shared/subagent-startup-retry.ts
+++ b/src/runs/shared/subagent-startup-retry.ts
@@ -1,4 +1,5 @@
 import type { Usage } from "../../shared/types.ts";
+import { formatProcessSignalError } from "./process-signal.ts";
 
 /**
  * Retry delays for child processes that exit before any model or tool activity.
@@ -9,6 +10,8 @@ export const SUBAGENT_STARTUP_RETRY_DELAYS_MS = [250, 750, 1500] as const;
 
 /** A genuine startup race should fail well before a model request can complete. */
 export const MAX_SUBAGENT_STARTUP_FAILURE_DURATION_MS = 2000;
+
+const SIGKILL_PROCESS_SIGNAL_ERROR = formatProcessSignalError("SIGKILL");
 
 export interface SubagentStartupFailureEvidence {
 	exitCode: number | null | undefined;
@@ -46,7 +49,7 @@ export function isRetryableSubagentStartupFailure(evidence: SubagentStartupFailu
 	return evidence.exitCode !== undefined
 		&& evidence.exitCode !== null
 		&& evidence.exitCode !== 0
-		&& !evidence.error?.trim()
+		&& (!evidence.error?.trim() || evidence.error === SIGKILL_PROCESS_SIGNAL_ERROR)
 		&& !evidence.finalOutput?.trim()
 		&& evidence.messageCount === 0
 		&& evidence.toolCount === 0
@@ -54,7 +57,7 @@ export function isRetryableSubagentStartupFailure(evidence: SubagentStartupFailu
 		&& evidence.durationMs >= 0
 		&& evidence.durationMs <= MAX_SUBAGENT_STARTUP_FAILURE_DURATION_MS
 		&& evidence.protocolError === undefined
-		&& (evidence.processSignal === undefined || evidence.processSignal === null)
+		&& (evidence.processSignal === undefined || evidence.processSignal === null || evidence.processSignal === "SIGKILL")
 		&& evidence.observedMutationAttempt !== true
 		&& evidence.detached !== true
 		&& evidence.interrupted !== true

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1832,8 +1832,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(mockPi.callCount(), 1);
 	});
 
-	it("does not retry a signaled child exit", { skip: process.platform === "win32" ? "POSIX child signal reporting is unavailable on Windows" : false }, async () => {
-		mockPi.onCall({ signal: "SIGKILL" });
+	it("does not retry non-SIGKILL signaled child exits", { skip: process.platform === "win32" ? "POSIX child signal reporting is unavailable on Windows" : false }, async () => {
+		mockPi.onCall({ signal: "SIGTERM" });
 		mockPi.onCall({ output: "must not run" });
 		const agents = [makeAgent("worker", { model: "openai/gpt-5-mini" })];
 
@@ -1843,8 +1843,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		});
 
 		assert.equal(result.exitCode, 1);
-		assert.equal(result.processSignal, "SIGKILL");
-		assert.equal(result.error, "Subagent process terminated by signal SIGKILL.");
+		assert.equal(result.processSignal, "SIGTERM");
+		assert.equal(result.error, "Subagent process terminated by signal SIGTERM.");
 		assert.equal(result.modelAttempts?.length, 1);
 		assert.equal(mockPi.callCount(), 1);
 	});

--- a/test/unit/subagent-startup-retry.test.ts
+++ b/test/unit/subagent-startup-retry.test.ts
@@ -35,13 +35,25 @@ describe("subagent startup retry", () => {
 		assert.equal(isRetryableSubagentStartupFailure(startupFailure()), true);
 	});
 
+	it("retries only the canonical zero-activity SIGKILL startup failure", () => {
+		assert.equal(
+			isRetryableSubagentStartupFailure(startupFailure({
+				processSignal: "SIGKILL",
+				error: "Subagent process terminated by signal SIGKILL.",
+			})),
+			true,
+		);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ processSignal: "SIGKILL" })), true);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ processSignal: "SIGTERM" })), false);
+		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ processSignal: "SIGKILL", error: "authentication failed" })), false);
+	});
+
 	it("rejects successful, long-running, and diagnosed exits", () => {
 		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ exitCode: 0 })), false);
 		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ durationMs: MAX_SUBAGENT_STARTUP_FAILURE_DURATION_MS + 1 })), false);
 		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ error: "authentication failed" })), false);
 		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ finalOutput: "partial response" })), false);
 		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ protocolError: { code: "protocol_output_limit" } })), false);
-		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ processSignal: "SIGKILL" })), false);
 	});
 
 	it("rejects any model, tool, usage, mutation, or lifecycle activity", () => {


### PR DESCRIPTION
## Summary

Fixes #769 by letting the existing zero-activity startup retry gate also cover SIGKILL-terminated child startups when the only error is the canonical generated SIGKILL message.

The original no-signal zero-activity retry remains intact; this PR only widens the signal/error guards for the narrow SIGKILL startup-race shape. Other signals, non-canonical errors, output, usage, tool/model activity, interrupts, timeouts, stopped runs, protocol errors, and mutation attempts still block retry.

## Validation

- `node --experimental-strip-types --test test/unit/subagent-startup-retry.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review raised a concern that non-SIGKILL zero-activity exits still retry. That is intentional existing behavior from #671 and is preserved here; #769 only fixes the SIGKILL interaction from #688.
