### PR TITLE
fix: make grouped result intercom opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Replace the duplicate advisor agent with an alias on the oracle agent.
 - Suppress stale foreground needs-attention transcript notices after the target run completes.
 - Retry zero-activity `SIGKILL` exits during child startup.
+- Make grouped-result intercom delivery opt-in while preserving local foreground output by default.
 - Resume the parent session after compaction while async subagent work remains active.
 - Avoid invoking `npm root -g` on Windows when the standard `%APPDATA%\\npm\\node_modules` global root is available, preserving custom terminal tab titles during agent and skill discovery. Thanks to @Suchwert for #767.
 - Preserved nested foreground failure events when resolved launch metadata is unavailable.

--- a/README.md
+++ b/README.md
@@ -1383,7 +1383,7 @@ Fields:
 
 - `mode`: default `always`; use `fork-only` to inject only for forked runs, or `off` to disable the bridge.
 - `instructionFile`: optional Markdown template replacing the default bridge instructions. `{orchestratorTarget}` is interpolated. Relative paths resolve from `~/.pi/agent/extensions/subagent/`.
-- `resultDelivery`: default `true`; attempts acknowledged grouped completion delivery through an external `subagent:result-intercom` listener. Set `false` when native parent notifications own completion delivery. Supervisor asks/progress remain active, and genuine enabled-transport acknowledgement failures remain visible.
+- `resultDelivery`: default `false`; set `true` only when an external `subagent:result-intercom` listener is installed. Enabled delivery waits for acknowledgement and reports acknowledgement failures. Supervisor asks/progress remain active.
 
 Bridge activation requires a targetable current parent session id, which `pi-subagents` passes to children automatically. It no longer depends on an external `pi-intercom` installation or per-agent extension allowlists.
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -249,7 +249,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		10 * 60 * 1000,
 		{
 			notifier: completionNotifier,
-			deliverIntercomResults: config.intercomBridge?.resultDelivery !== false,
+			deliverIntercomResults: config.intercomBridge?.resultDelivery === true,
 		},
 	);
 

--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -82,12 +82,12 @@ export function resolveIntercomBridgeMode(value: unknown): IntercomBridgeMode {
 
 function resolveIntercomBridgeConfig(value: ExtensionConfig["intercomBridge"]): Required<IntercomBridgeConfig> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) {
-		return { mode: "always", instructionFile: "", resultDelivery: true };
+		return { mode: "always", instructionFile: "", resultDelivery: false };
 	}
 	return {
 		mode: resolveIntercomBridgeMode(value.mode),
 		instructionFile: typeof value.instructionFile === "string" ? value.instructionFile : "",
-		resultDelivery: value.resultDelivery !== false,
+		resultDelivery: value.resultDelivery === true,
 	};
 }
 

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -206,7 +206,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 	it("single foreground runs emit one grouped event and return a compact receipt", async () => {
 		mockPi.onCall({ output: "Full child output from worker" });
-		const { executor, events } = makeExecutor();
+		const { executor, events } = makeExecutor({ resultDelivery: true });
 
 		const result = await executor.execute(
 			"single-intercom",
@@ -265,7 +265,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 	it("falls back to legacy foreground output when grouped delivery is not acknowledged", async () => {
 		mockPi.onCall({ output: "Unacknowledged foreground output" });
-		const { executor, events } = makeExecutor({ acknowledgeResults: false });
+		const { executor, events } = makeExecutor({ resultDelivery: true, acknowledgeResults: false });
 
 		const result = await executor.execute(
 			"single-no-ack",
@@ -281,7 +281,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 	it("top-level parallel runs emit one grouped event containing all children", async () => {
 		mockPi.onCall({ output: "Parallel child output" });
-		const { executor, events } = makeExecutor({ agents: [makeAgent("a"), makeAgent("b")] });
+		const { executor, events } = makeExecutor({ resultDelivery: true, agents: [makeAgent("a"), makeAgent("b")] });
 
 		const result = await executor.execute(
 			"parallel-intercom",
@@ -313,7 +313,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		execFileSync("git", ["add", "base.txt"], { cwd: tempDir });
 		execFileSync("git", ["commit", "-m", "base"], { cwd: tempDir, stdio: "ignore" });
 		mockPi.onCall({ output: "Worktree child output" });
-		const { executor, events } = makeExecutor();
+		const { executor, events } = makeExecutor({ resultDelivery: true });
 
 		const result = await executor.execute(
 			"workflow-worktree-live-card",
@@ -464,7 +464,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 	it("chain runs emit one grouped event containing all executed children", async () => {
 		mockPi.onCall({ output: "Chain child output" });
-		const { executor, events } = makeExecutor({ agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });
+		const { executor, events } = makeExecutor({ resultDelivery: true, agents: [makeAgent("a"), makeAgent("b"), makeAgent("c")] });
 
 		const result = await executor.execute(
 			"chain-intercom",
@@ -1723,7 +1723,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 	it("mixed foreground outcomes produce failed grouped status and receipt counts", async () => {
 		mockPi.onCall({ matchArgIncludes: "task-a", output: "Parallel child success", exitCode: 0 });
 		mockPi.onCall({ matchArgIncludes: "task-b", output: "Parallel child failure", stderr: "Parallel child failure", exitCode: 1 });
-		const { executor, events } = makeExecutor({ agents: [makeAgent("a"), makeAgent("b")] });
+		const { executor, events } = makeExecutor({ resultDelivery: true, agents: [makeAgent("a"), makeAgent("b")] });
 
 		const result = await executor.execute(
 			"parallel-mixed-intercom",
@@ -1746,7 +1746,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 	it("does not treat a synthetic foreground startup error as child output", async () => {
 		mockPi.onCall({ output: "", stderr: "mock startup failure", exitCode: 1 });
-		const { executor, events } = makeExecutor({ agents: [makeAgent("worker")] });
+		const { executor, events } = makeExecutor({ resultDelivery: true, agents: [makeAgent("worker")] });
 
 		await executor.execute(
 			"foreground-synthetic-error",

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -950,7 +950,7 @@ describe("result watcher", () => {
 		}
 	});
 
-	it("logs one unacknowledged grouped async intercom delivery before completing", async () => {
+	it("uses local completion fallback silently when no grouped-result listener is available", async () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-"));
 		try {
 			const emitted: Array<{ event: string; data: unknown }> = [];
@@ -966,7 +966,7 @@ describe("result watcher", () => {
 			};
 			const state = createState();
 			state.currentSessionId = "session-1";
-			const watcher = createResultWatcher(pi, state, resultsDir, 60_000);
+			const watcher = createResultWatcher(pi, state, resultsDir, 60_000, { deliverIntercomResults: false });
 			const originalError = console.error;
 			const logged: unknown[][] = [];
 			console.error = (...args: unknown[]) => {
@@ -984,23 +984,64 @@ describe("result watcher", () => {
 					intercomTarget: "orchestrator",
 				}), "utf-8");
 				watcher.primeExistingResults();
-				const deadline = Date.now() + 1000;
-				while (true) {
-					const sawWarning = logged.some((entry) => /Subagent async grouped result intercom delivery was not acknowledged/.test(String(entry[0] ?? "")));
-					const sawCompletion = emitted.some((entry) => entry.event === "subagent:async-complete");
-					if ((sawWarning && sawCompletion) || Date.now() > deadline) break;
-					await new Promise((resolve) => setTimeout(resolve, 25));
-				}
+				await new Promise((resolve) => setTimeout(resolve, 100));
 			} finally {
 				console.error = originalError;
 				watcher.stopResultWatcher();
 			}
 
-			const grouped = emitted.filter((entry) => entry.event === "subagent:result-intercom");
-			assert.equal(grouped.length, 1);
-			assert.match(String((grouped[0]?.data as { message?: string } | undefined)?.message ?? ""), /output unknown/);
-			assert.doesNotMatch(String((grouped[0]?.data as { message?: string } | undefined)?.message ?? ""), /Inspect that output before retrying/);
+			assert.equal(emitted.some((entry) => entry.event === "subagent:result-intercom"), false);
 			assert.equal(emitted.some((entry) => entry.event === "subagent:async-complete"), true);
+			assert.equal(logged.some((entry) => /Subagent async grouped result intercom delivery was not acknowledged/.test(String(entry[0] ?? ""))), false);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("warns when an available grouped-result listener does not acknowledge delivery", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-unacknowledged-listener-"));
+		try {
+			const emitted: Array<{ event: string; data: unknown }> = [];
+			const listeners = new Map<string, Set<(payload: unknown) => void>>();
+			const pi = {
+				events: {
+					on(event: string, handler: (payload: unknown) => void) {
+						const eventListeners = listeners.get(event) ?? new Set();
+						eventListeners.add(handler);
+						listeners.set(event, eventListeners);
+						return () => eventListeners.delete(handler);
+					},
+					emit(event: string, data: unknown) {
+						emitted.push({ event, data });
+						for (const handler of listeners.get(event) ?? []) handler(data);
+					},
+				},
+			};
+			const state = createState();
+			state.currentSessionId = "session-1";
+			const watcher = createResultWatcher(pi, state, resultsDir, 60_000);
+			const originalError = console.error;
+			const logged: unknown[][] = [];
+			console.error = (...args: unknown[]) => { logged.push(args); };
+			try {
+				fs.writeFileSync(path.join(resultsDir, "unacknowledged.json"), JSON.stringify({
+					id: "unacknowledged",
+					runId: "run-unacknowledged",
+					agent: "worker",
+					success: true,
+					state: "complete",
+					summary: "Worker summary",
+					sessionId: "session-1",
+					intercomTarget: "orchestrator",
+				}), "utf-8");
+				watcher.primeExistingResults();
+				await new Promise((resolve) => setTimeout(resolve, 600));
+			} finally {
+				console.error = originalError;
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal(emitted.filter((entry) => entry.event === "subagent:result-intercom").length, 1);
 			assert.equal(logged.some((entry) => /Subagent async grouped result intercom delivery was not acknowledged/.test(String(entry[0] ?? ""))), true);
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });

--- a/test/unit/intercom-bridge.test.ts
+++ b/test/unit/intercom-bridge.test.ts
@@ -98,7 +98,7 @@ describe("resolveIntercomBridge", () => {
 		});
 
 		assert.equal(bridge.active, true);
-		assert.equal(bridge.resultDelivery, true);
+		assert.equal(bridge.resultDelivery, false);
 		assert.equal(bridge.orchestratorTarget, "main");
 		assert.equal(bridge.extensionDir, NATIVE_INTERCOM_EXTENSION_DIR);
 	});


### PR DESCRIPTION
## Summary
- make grouped result intercom delivery explicit opt-in through intercomBridge.resultDelivery
- keep local foreground output as the default fallback when grouped delivery is disabled
- update docs and tests for enabled, disabled, and unacknowledged delivery

Closes #771.

## Tests
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='single foreground runs emit one grouped event|falls back to legacy foreground output when grouped delivery is not acknowledged|top-level parallel runs emit one grouped event|chain runs emit one grouped event|mixed foreground outcomes produce failed grouped status|does not treat a synthetic foreground startup error|keeps native foreground output without attempting external grouped delivery|suppresses successful worktree child receipts' test/integration/intercom-result-delivery.test.ts
- npm run typecheck