### PR TITLE
fix: normalize workflow child JSON results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Normalize undefined fields in workflow child results before scripts can return them, preserving artifact-only child output.
 - Show current-session async runs in the Fleet inspector even when this Pi process did not start them.
 - Replace the duplicate advisor agent with an alias on the oracle agent.
 - Suppress stale foreground needs-attention transcript notices after the target run completes.

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -152,6 +152,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function omitUndefinedWorkflowValues(value: unknown, seen = new Set<object>()): unknown {
+	if (value === null || typeof value !== "object") return value;
+	if (seen.has(value)) return value;
+	seen.add(value);
+	const normalized = Array.isArray(value)
+		? value.map((entry) => entry === undefined ? null : omitUndefinedWorkflowValues(entry, seen))
+		: isRecord(value)
+			? Object.fromEntries(Object.entries(value).flatMap(([key, entry]) => entry === undefined ? [] : [[key, omitUndefinedWorkflowValues(entry, seen)]]))
+			: value;
+	seen.delete(value);
+	return normalized;
+}
+
 export function assertWorkflowJsonValue(value: unknown, path = "value", seen = new Set<object>()): void {
 	if (value === null || typeof value === "string" || typeof value === "boolean") return;
 	if (typeof value === "number") {
@@ -276,7 +289,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 
 			const respond = (promise: Promise<WorkflowScriptChildResult>) => {
 				void promise.then(
-					(value) => worker.postMessage({ type: "response", callId: message.callId, ok: true, value }),
+					(value) => worker.postMessage({ type: "response", callId: message.callId, ok: true, value: omitUndefinedWorkflowValues(value) }),
 					(error: unknown) => worker.postMessage({ type: "response", callId: message.callId, ok: false, error: error instanceof Error ? error.message : String(error) }),
 				);
 			};

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -152,13 +152,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+	if (!isRecord(value)) return false;
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === null || prototype === Object.prototype;
+}
+
 function omitUndefinedWorkflowValues(value: unknown, seen = new Set<object>()): unknown {
 	if (value === null || typeof value !== "object") return value;
 	if (seen.has(value)) return value;
 	seen.add(value);
 	const normalized = Array.isArray(value)
 		? value.map((entry) => entry === undefined ? null : omitUndefinedWorkflowValues(entry, seen))
-		: isRecord(value)
+		: isPlainJsonObject(value)
 			? Object.fromEntries(Object.entries(value).flatMap(([key, entry]) => entry === undefined ? [] : [[key, omitUndefinedWorkflowValues(entry, seen)]]))
 			: value;
 	seen.delete(value);

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -41,6 +41,31 @@ describe("scripted workflow runtime", () => {
 		assert.deepEqual(emitSnapshots, [1]);
 	});
 
+	it("omits undefined child result fields before a script returns them", async () => {
+		const result = await runWorkflowScript({
+			script: `return await runs.run("artifact-only", { agent: "worker", task: "write output" });`,
+			timeoutMs: 2_000,
+			async launch(key) {
+				return {
+					key,
+					ok: true,
+					output: "Saved output.",
+					artifactPaths: ["/tmp/output.md"],
+					results: [{ messages: undefined, savedOutputPath: "/tmp/output.md" }],
+				};
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		assert.deepEqual(result.value, {
+			key: "artifact-only",
+			ok: true,
+			output: "Saved output.",
+			artifactPaths: ["/tmp/output.md"],
+			results: [{ savedOutputPath: "/tmp/output.md" }],
+		});
+	});
+
 	it("passes per-child worktree controls through runs.run and runs.all", async () => {
 		const launches: Array<{ key: string; worktree: unknown }> = [];
 		await runWorkflowScript({

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -66,6 +66,20 @@ describe("scripted workflow runtime", () => {
 		});
 	});
 
+	it("rejects non-plain child result values", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `return await runs.run("non-plain", { agent: "worker", task: "write output" });`,
+				timeoutMs: 2_000,
+				async launch(key) {
+					return { key, ok: true, output: "Saved output.", artifactPaths: [], results: [{ metadata: new Map([["source", "worker"]]) }] };
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && /return.*plain JSON objects/i.test(error.message),
+		);
+	});
+
 	it("passes per-child worktree controls through runs.run and runs.all", async () => {
 		const launches: Array<{ key: string; worktree: unknown }> = [];
 		await runWorkflowScript({


### PR DESCRIPTION
Closes #778.

Normalize `undefined` values in child results before they cross the workflow worker boundary. This lets artifact-only child results return cleanly while keeping the existing JSON validation for unsupported values.

Validation:
- `node --experimental-strip-types --test test/unit/scripted-workflow.test.ts`
- `npm run typecheck`