### PR TITLE
feat: add external run observation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added an observational `pi-subagents/external-runs` provider API for visible terminal work, without taking process ownership. Thanks to @nicobailon for #795.
 - Added narrow public entrypoints for extension consumers to access async stop requests, intercom session targeting, launch tool-plan resolution, and fork-task helpers without deep imports. Thanks to @shaneconner for #794.
 - FleetView nested trees now retain and display each leaf's effective model and thinking effort, including completed siblings while the owner remains active. Thanks to @fgpaz for #776.
 - Restored same-repo watched `workflowScript` live chat progress cards, with `chatProgress` controls and Git-worktree-aware same-repo detection.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./index.ts",
     "./background-work": "./src/api/background-work.ts",
+    "./external-runs": "./src/api/external-runs.ts",
     "./delegation": "./src/api/delegation.ts",
     "./capability-ceiling": "./src/api/capability-ceiling.ts",
     "./preflight": "./src/api/preflight.ts",

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -151,6 +151,12 @@ Use diagnostics when setup or child startup looks wrong:
 subagent({ action: "doctor" })
 ```
 
+### External terminal work
+
+Use native `subagent` runs for unattended implementation, review, and gate work that needs managed isolation, durable artifacts, and process controls. Use `interactive_shell` for visible terminal work, alternate CLIs, trust prompts, and recovery.
+
+A cooperating terminal runtime can register read-only external records through `pi-subagents/external-runs`. Records include the source, session, state, optional report path, and completion reason. They are observations only: pi-subagents does not start, stop, steer, or otherwise own the foreign process. Run unattended raw terminal agents in an explicit isolated cwd or worktree; do not use a live project checkout as disposable review space.
+
 ### Scheduled subagent runs
 
 Scheduled runs defer a subagent launch until a future time. They are enabled by default; set `{ "scheduledRuns": { "enabled": false } }` in `~/.pi/agent/extensions/subagent/config.json` to disable them. Only schedule explicit delayed runs the user asked for; do not schedule runs speculatively.

--- a/src/api/external-runs.ts
+++ b/src/api/external-runs.ts
@@ -1,0 +1,129 @@
+export const EXTERNAL_RUN_REGISTRY_VERSION = 1;
+export const EXTERNAL_RUN_REGISTRY_KEY = "pi-subagents.external-runs.v1";
+
+const MAX_PROVIDERS = 100;
+const MAX_RUNS_PER_PROVIDER = 10_000;
+const MAX_TEXT_LENGTH = 4_096;
+
+export type ExternalRunState = "running" | "completed" | "failed" | "stopped";
+export type ExternalRunCompletionReason = "exit" | "timeout" | "user-kill" | "auto-close-quiet" | "crash" | "unknown";
+
+/** An observational record for work owned by another runtime. */
+export interface ExternalRun {
+	id: string;
+	sessionId: string;
+	source: string;
+	state: ExternalRunState;
+	command?: string;
+	cwd?: string;
+	isolationPath?: string;
+	owner?: string;
+	completionReason?: ExternalRunCompletionReason;
+	reportPath?: string;
+	startedAt?: number;
+	completedAt?: number;
+	exitCode?: number | null;
+	residualRisks?: string[];
+}
+
+export interface ExternalRunProvider {
+	name: string;
+	listExternalRuns(): readonly ExternalRun[];
+}
+
+export interface RegisteredExternalRun extends ExternalRun {
+	provider: string;
+}
+
+interface ExternalRunRegistry {
+	version: typeof EXTERNAL_RUN_REGISTRY_VERSION;
+	providers: Map<string, ExternalRunProvider>;
+}
+
+function registry(): ExternalRunRegistry {
+	const key = Symbol.for(EXTERNAL_RUN_REGISTRY_KEY);
+	const target = globalThis as Record<PropertyKey, unknown>;
+	const existing = target[key];
+	if (existing === undefined) {
+		const created: ExternalRunRegistry = { version: EXTERNAL_RUN_REGISTRY_VERSION, providers: new Map() };
+		target[key] = created;
+		return created;
+	}
+	if (!existing || typeof existing !== "object" || Array.isArray(existing)) throw new Error(`Malformed external-run registry at Symbol.for("${EXTERNAL_RUN_REGISTRY_KEY}").`);
+	const candidate = existing as Partial<ExternalRunRegistry>;
+	if (candidate.version !== EXTERNAL_RUN_REGISTRY_VERSION || !(candidate.providers instanceof Map)) throw new Error(`Unsupported external-run registry at Symbol.for("${EXTERNAL_RUN_REGISTRY_KEY}").`);
+	return candidate as ExternalRunRegistry;
+}
+
+function text(value: unknown, field: string, required = false): string | undefined {
+	if (value === undefined && !required) return undefined;
+	if (typeof value !== "string" || value.length === 0 || value.trim() !== value || value.includes("\0")) throw new Error(`${field} must be a non-empty trimmed string without NUL characters.`);
+	if (value.length > MAX_TEXT_LENGTH) throw new Error(`${field} must be at most ${MAX_TEXT_LENGTH} characters.`);
+	return value;
+}
+
+function timestamp(value: unknown, field: string): number | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) throw new Error(`${field} must be a non-negative finite number.`);
+	return value;
+}
+
+function validateRun(value: unknown, provider: string, index: number): ExternalRun {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`External-run provider '${provider}' item ${index} must be an object.`);
+	const run = value as Record<string, unknown>;
+	const fields = new Set(["id", "sessionId", "source", "state", "command", "cwd", "isolationPath", "owner", "completionReason", "reportPath", "startedAt", "completedAt", "exitCode", "residualRisks"]);
+	const unknown = Object.keys(run).filter((key) => !fields.has(key));
+	if (unknown.length) throw new Error(`External-run provider '${provider}' item ${index} has unknown fields: ${unknown.join(", ")}.`);
+	if (!["running", "completed", "failed", "stopped"].includes(run.state as string)) throw new Error(`External-run provider '${provider}' item ${index} state is invalid.`);
+	if (run.completionReason !== undefined && !["exit", "timeout", "user-kill", "auto-close-quiet", "crash", "unknown"].includes(run.completionReason as string)) throw new Error(`External-run provider '${provider}' item ${index} completionReason is invalid.`);
+	if (run.exitCode !== undefined && run.exitCode !== null && (!Number.isInteger(run.exitCode) || !Number.isFinite(run.exitCode))) throw new Error(`External-run provider '${provider}' item ${index} exitCode must be an integer or null.`);
+	if (run.residualRisks !== undefined && (!Array.isArray(run.residualRisks) || run.residualRisks.some((risk, riskIndex) => text(risk, `External-run provider '${provider}' item ${index} residualRisks[${riskIndex}]`, true) === undefined))) throw new Error(`External-run provider '${provider}' item ${index} residualRisks must be an array of strings.`);
+	return {
+		id: text(run.id, `External-run provider '${provider}' item ${index} id`, true)!,
+		sessionId: text(run.sessionId, `External-run provider '${provider}' item ${index} sessionId`, true)!,
+		source: text(run.source, `External-run provider '${provider}' item ${index} source`, true)!,
+		state: run.state as ExternalRunState,
+		...(text(run.command, `External-run provider '${provider}' item ${index} command`) !== undefined ? { command: text(run.command, `External-run provider '${provider}' item ${index} command`) } : {}),
+		...(text(run.cwd, `External-run provider '${provider}' item ${index} cwd`) !== undefined ? { cwd: text(run.cwd, `External-run provider '${provider}' item ${index} cwd`) } : {}),
+		...(text(run.isolationPath, `External-run provider '${provider}' item ${index} isolationPath`) !== undefined ? { isolationPath: text(run.isolationPath, `External-run provider '${provider}' item ${index} isolationPath`) } : {}),
+		...(text(run.owner, `External-run provider '${provider}' item ${index} owner`) !== undefined ? { owner: text(run.owner, `External-run provider '${provider}' item ${index} owner`) } : {}),
+		...(run.completionReason !== undefined ? { completionReason: run.completionReason as ExternalRunCompletionReason } : {}),
+		...(text(run.reportPath, `External-run provider '${provider}' item ${index} reportPath`) !== undefined ? { reportPath: text(run.reportPath, `External-run provider '${provider}' item ${index} reportPath`) } : {}),
+		...(timestamp(run.startedAt, `External-run provider '${provider}' item ${index} startedAt`) !== undefined ? { startedAt: timestamp(run.startedAt, `External-run provider '${provider}' item ${index} startedAt`) } : {}),
+		...(timestamp(run.completedAt, `External-run provider '${provider}' item ${index} completedAt`) !== undefined ? { completedAt: timestamp(run.completedAt, `External-run provider '${provider}' item ${index} completedAt`) } : {}),
+		...(run.exitCode !== undefined ? { exitCode: run.exitCode as number | null } : {}),
+		...(run.residualRisks !== undefined ? { residualRisks: [...run.residualRisks] as string[] } : {}),
+	};
+}
+
+/** Register an observational provider. pi-subagents never starts, stops, or steers these processes. */
+export function registerExternalRunProvider(provider: ExternalRunProvider): () => void {
+	if (!provider || typeof provider !== "object" || Array.isArray(provider) || Object.keys(provider).some((key) => key !== "name" && key !== "listExternalRuns")) throw new Error("External-run provider must contain only name and listExternalRuns.");
+	const name = text(provider.name, "External-run provider name", true)!;
+	if (typeof provider.listExternalRuns !== "function") throw new Error(`External-run provider '${name}' must expose listExternalRuns().`);
+	const current = registry();
+	if (!current.providers.has(name) && current.providers.size >= MAX_PROVIDERS) throw new Error(`External-run registry supports at most ${MAX_PROVIDERS} providers.`);
+	current.providers.set(name, provider);
+	return () => { if (current.providers.get(name) === provider) current.providers.delete(name); };
+}
+
+/** Snapshot records for one Pi session. Records are read-only observations of foreign process ownership. */
+export function snapshotExternalRuns(sessionId: string): readonly RegisteredExternalRun[] {
+	text(sessionId, "External-run snapshot sessionId", true);
+	const records: RegisteredExternalRun[] = [];
+	const identities = new Set<string>();
+	for (const [name, provider] of registry().providers) {
+		if (provider.name !== name) throw new Error(`External-run registry key '${name}' does not match provider name '${provider.name}'.`);
+		const runs = provider.listExternalRuns();
+		if (!Array.isArray(runs)) throw new Error(`External-run provider '${name}' listExternalRuns() must return an array.`);
+		if (runs.length > MAX_RUNS_PER_PROVIDER) throw new Error(`External-run provider '${name}' returned more than ${MAX_RUNS_PER_PROVIDER} runs.`);
+		runs.forEach((value, index) => {
+			const run = validateRun(value, name, index);
+			const identity = `${name}\0${run.sessionId}\0${run.id}`;
+			if (identities.has(identity)) throw new Error(`External-run provider '${name}' returned duplicate run '${run.id}' for session '${run.sessionId}'.`);
+			identities.add(identity);
+			if (run.sessionId === sessionId) records.push({ provider: name, ...run });
+		});
+	}
+	return records;
+}

--- a/test/unit/external-runs.test.ts
+++ b/test/unit/external-runs.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	EXTERNAL_RUN_REGISTRY_KEY,
+	registerExternalRunProvider,
+	snapshotExternalRuns,
+} from "../../src/api/external-runs.ts";
+
+function clearRegistry(): void {
+	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)];
+}
+
+test("external-run providers expose scoped observational records without controls", () => {
+	clearRegistry();
+	const dispose = registerExternalRunProvider({
+		name: "interactive-shell",
+		listExternalRuns: () => [{
+			id: "review-794",
+			sessionId: "session-a",
+			source: "interactive_shell",
+			state: "completed",
+			completionReason: "auto-close-quiet",
+			cwd: "/tmp/review",
+			reportPath: "/tmp/review.md",
+			exitCode: null,
+			residualRisks: ["The terminal runtime owns process control."],
+		}],
+	});
+	assert.deepEqual(snapshotExternalRuns("session-a"), [{
+		provider: "interactive-shell",
+		id: "review-794",
+		sessionId: "session-a",
+		source: "interactive_shell",
+		state: "completed",
+		completionReason: "auto-close-quiet",
+		cwd: "/tmp/review",
+		reportPath: "/tmp/review.md",
+		exitCode: null,
+		residualRisks: ["The terminal runtime owns process control."],
+	}]);
+	assert.deepEqual(snapshotExternalRuns("session-b"), []);
+	dispose();
+	clearRegistry();
+});
+
+test("external-run providers reject malformed and duplicate records", () => {
+	clearRegistry();
+	assert.throws(() => registerExternalRunProvider({ name: " bad", listExternalRuns: () => [] }), /trimmed/);
+	registerExternalRunProvider({
+		name: "interactive-shell",
+		listExternalRuns: () => [
+			{ id: "run", sessionId: "session-a", source: "interactive_shell", state: "running", extra: true },
+		] as never,
+	});
+	assert.throws(() => snapshotExternalRuns("session-a"), /unknown fields: extra/);
+	clearRegistry();
+	registerExternalRunProvider({
+		name: "interactive-shell",
+		listExternalRuns: () => [
+			{ id: "run", sessionId: "session-a", source: "interactive_shell", state: "running" },
+			{ id: "run", sessionId: "session-a", source: "interactive_shell", state: "running" },
+		],
+	});
+	assert.throws(() => snapshotExternalRuns("session-a"), /duplicate run 'run'/);
+	clearRegistry();
+});

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -56,6 +56,7 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.deepEqual(packageJson.exports, {
 		".": "./index.ts",
 		"./background-work": "./src/api/background-work.ts",
+		"./external-runs": "./src/api/external-runs.ts",
 		"./capability-ceiling": "./src/api/capability-ceiling.ts",
 		"./delegation": "./src/api/delegation.ts",
 		"./preflight": "./src/api/preflight.ts",
@@ -67,6 +68,9 @@ test("published extension APIs use supported package entrypoints", async () => {
 	const backgroundWork = await import("pi-subagents/background-work");
 	assert.equal(backgroundWork.BACKGROUND_WORK_PROTOCOL_VERSION, 1);
 	assert.equal(backgroundWork.BACKGROUND_WORK_REGISTRY_KEY, "pi-subagents.background-work.v1");
+	const externalRuns = await import("pi-subagents/external-runs");
+	assert.equal(externalRuns.EXTERNAL_RUN_REGISTRY_VERSION, 1);
+	assert.equal(typeof externalRuns.registerExternalRunProvider, "function");
 	const capability = await import("pi-subagents/capability-ceiling");
 	assert.equal(capability.SUBAGENT_CAPABILITY_CEILING_VERSION, 1);
 	assert.equal(capability.SUBAGENT_CAPABILITY_CEILING_REGISTRY_KEY, "pi-subagents.capability-ceiling.v1");


### PR DESCRIPTION
Closes #795.\n\nAdds a small public provider registry for observing terminal work owned by another runtime. The API has no process-control methods, includes completion/report-path metadata, and documents safe routing between `subagent` and `interactive_shell`.