### PR TITLE
fix: preserve async completion artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Preserve successful async completion when project-local artifact or mission files are removed before final bookkeeping by recreating artifact directories and recording missing-mission warnings.
 - Normalize undefined fields in workflow child results before scripts can return them, preserving artifact-only child output.
 - Show current-session async runs in the Fleet inspector even when this Pi process did not start them.
 - Replace the duplicate advisor agent with an alias on the oracle agent.

--- a/src/missions/lifecycle.ts
+++ b/src/missions/lifecycle.ts
@@ -5,7 +5,7 @@ import { writePrivateAtomicJson } from "../shared/atomic-json.ts";
 import type { Details, SubagentRunMode } from "../shared/types.ts";
 import { validateMissionLaunch } from "./actions.ts";
 import type { MissionArtifact, MissionRecord, MissionRunLink, MissionRunMode, MissionStatus, MissionStoreConfig, MissionStoreLocation } from "./types.ts";
-import { createMission, missionRecordPath, readMission, resolveMissionStoreLocation, updateMission, validateMissionId } from "./store.ts";
+import { createMission, MissionNotFoundError, missionRecordPath, readMission, resolveMissionStoreLocation, updateMission, validateMissionId } from "./store.ts";
 
 export const MISSION_BINDING_FILE = "mission.json";
 
@@ -267,7 +267,25 @@ export function syncMissionFromAsyncCompletion(value: unknown): MissionRecord | 
 	const runId = typeof event.runId === "string" ? event.runId : typeof event.id === "string" ? event.id : undefined;
 	if (!runId) throw new Error("Async mission completion is missing runId");
 	const runStatus = typeof event.state === "string" ? event.state : event.success === true ? "completed" : "failed";
-	const current = readMission(binding.location, binding.missionId);
+	let current: MissionRecord;
+	try {
+		current = readMission(binding.location, binding.missionId);
+	} catch (error) {
+		if (!(error instanceof MissionNotFoundError)) throw error;
+		try {
+			fs.appendFileSync(path.join(event.asyncDir, "events.jsonl"), `${JSON.stringify({
+				type: "subagent.mission.sync.skipped",
+				ts: Date.now(),
+				runId,
+				missionId: binding.missionId,
+				reason: "mission-record-missing",
+				missionPath: missionRecordPath(binding.location, binding.missionId),
+			})}\n`, "utf-8");
+		} catch {
+			// Mission bookkeeping is secondary to preserving the completed async result.
+		}
+		return undefined;
+	}
 	const completedAt = new Date().toISOString();
 	const artifacts: MissionArtifact[] = [
 		{ kind: "status", path: path.join(event.asyncDir, "status.json") },

--- a/src/missions/store.ts
+++ b/src/missions/store.ts
@@ -309,13 +309,26 @@ export function createMission(location: MissionStoreLocation, input: MissionCrea
 	return created;
 }
 
+export class MissionNotFoundError extends Error {
+	readonly code = "MISSION_NOT_FOUND";
+	readonly missionId: string;
+	readonly missionDir: string;
+
+	constructor(missionId: string, missionDir: string) {
+		super(`Mission '${missionId}' was not found in ${missionDir}`);
+		this.name = "MissionNotFoundError";
+		this.missionId = missionId;
+		this.missionDir = missionDir;
+	}
+}
+
 export function readMission(location: MissionStoreLocation, missionId: string): MissionRecord {
 	const filePath = missionRecordPath(location, missionId);
 	let raw: string;
 	try {
 		raw = fs.readFileSync(filePath, "utf-8");
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new Error(`Mission '${missionId}' was not found in ${location.missionDir}`);
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new MissionNotFoundError(missionId, location.missionDir);
 		throw error;
 	}
 	try {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -254,7 +254,7 @@ function persistStepArtifacts(input: {
 		try {
 			writeMetadata(input.artifactPaths.metadataPath, input.metadata);
 		} catch (error) {
-			errors.metadataSaveError = error instanceof Error ? error.message : String(error);
+			errors.metadataSaveError = `Artifact metadata post-processing failed: ${error instanceof Error ? error.message : String(error)}`;
 		}
 	}
 	return errors;

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -7,7 +7,7 @@ import type { Message } from "@earendil-works/pi-ai";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { createChildTranscriptWriter, type ChildTranscriptWriter } from "../../shared/child-transcript.ts";
 import { closeSteerInbox, consumeInterruptRequest, consumeSteerRequests, deliverInterruptRequest, deliverStopRequest, deliverTimeoutRequest, enqueueStepSteer, steerAcksDir, steerCapabilityPath, stepSteerInboxDir, watchAsyncControlInbox, type SteerAck, type SteerCapability, type SteerRequest } from "./control-channel.ts";
-import { appendJsonl as appendRawJsonl, formatOutputArtifactContent, getArtifactPaths } from "../../shared/artifacts.ts";
+import { appendJsonl as appendRawJsonl, formatOutputArtifactContent, getArtifactPaths, writeArtifact, writeMetadata } from "../../shared/artifacts.ts";
 import { PI_CODING_AGENT_PACKAGE, getPiSpawnCommand, resolveInstalledPiPackageRoot } from "../shared/pi-spawn.ts";
 import { captureSingleOutputSnapshot, extractChildWrittenOutput, finalizeSingleOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, injectSingleOutputInstruction, resolveSingleOutput, type SingleOutputSnapshot } from "../shared/single-output.ts";
 import {
@@ -215,6 +215,8 @@ interface StepResult {
 	modelAttempts?: ModelAttempt[];
 	totalCost?: CostSummary;
 	artifactPaths?: ArtifactPaths;
+	outputSaveError?: string;
+	metadataSaveError?: string;
 	truncated?: boolean;
 	transcriptPath?: string;
 	transcriptError?: string;
@@ -232,6 +234,30 @@ interface StepResult {
 	writerAttemptCount?: number;
 	runner?: ExternalCliRunnerStatus;
 	externalProcess?: ExternalProcessStatus;
+}
+
+function persistStepArtifacts(input: {
+	artifactPaths: ArtifactPaths;
+	artifactConfig?: Partial<ArtifactConfig>;
+	output: string;
+	metadata: object;
+}): { outputSaveError?: string; metadataSaveError?: string } {
+	const errors: { outputSaveError?: string; metadataSaveError?: string } = {};
+	if (input.artifactConfig?.includeOutput !== false) {
+		try {
+			writeArtifact(input.artifactPaths.outputPath, input.output);
+		} catch (error) {
+			errors.outputSaveError = `Artifact output post-processing failed: ${error instanceof Error ? error.message : String(error)}`;
+		}
+	}
+	if (input.artifactConfig?.includeMetadata !== false) {
+		try {
+			writeMetadata(input.artifactPaths.metadataPath, input.metadata);
+		} catch (error) {
+			errors.metadataSaveError = error instanceof Error ? error.message : String(error);
+		}
+	}
+	return errors;
 }
 
 const ASYNC_INTERRUPT_SIGNAL: NodeJS.Signals = process.platform === "win32" ? "SIGBREAK" : "SIGUSR2";
@@ -1219,14 +1245,14 @@ async function runSingleStep(
 			outputReference,
 			saveError: resolvedOutput.saveError,
 		}));
-		if (artifactPaths && ctx.artifactConfig?.enabled !== false) {
-			if (ctx.artifactConfig?.includeOutput !== false) {
-				fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent(omitUndefinedProperties({ output: resolvedOutput.fullOutput, error: external.error, metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath })), "utf-8");
-			}
-			if (ctx.artifactConfig?.includeMetadata !== false) {
-				fs.writeFileSync(artifactPaths.metadataPath, JSON.stringify({ runId: ctx.id, agent: step.agent, task, runner, externalProcess: external.externalProcess, exitCode: external.exitCode, error: external.error, timestamp: Date.now() }, null, 2), "utf-8");
-			}
-		}
+		const artifactErrors = artifactPaths && ctx.artifactConfig?.enabled !== false
+			? persistStepArtifacts({
+				artifactPaths,
+				artifactConfig: ctx.artifactConfig,
+				output: formatOutputArtifactContent(omitUndefinedProperties({ output: resolvedOutput.fullOutput, error: external.error, metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath })),
+				metadata: { runId: ctx.id, agent: step.agent, task, runner, externalProcess: external.externalProcess, exitCode: external.exitCode, error: external.error, timestamp: Date.now() },
+			})
+			: {};
 		return omitUndefinedProperties({
 			agent: step.agent,
 			context: step.context,
@@ -1238,6 +1264,8 @@ async function runSingleStep(
 			stopped: external.stopped,
 			processSignal: external.processSignal,
 			artifactPaths,
+			outputSaveError: artifactErrors.outputSaveError,
+			metadataSaveError: artifactErrors.metadataSaveError,
 			runner,
 			externalProcess: external.externalProcess,
 		});
@@ -1634,41 +1662,37 @@ async function runSingleStep(
 					? (finalResult?.error ? `${finalResult.error}\n${acceptanceFailure}` : acceptanceFailure)
 					: finalResult?.error;
 
-	if (artifactPaths && ctx.artifactConfig?.enabled !== false) {
-		if (ctx.artifactConfig?.includeOutput !== false) {
-			fs.writeFileSync(artifactPaths.outputPath, formatOutputArtifactContent(omitUndefinedProperties({
+	const artifactErrors = artifactPaths && ctx.artifactConfig?.enabled !== false
+		? persistStepArtifacts({
+			artifactPaths,
+			artifactConfig: ctx.artifactConfig,
+			output: formatOutputArtifactContent(omitUndefinedProperties({
 				output,
 				error: effectiveFinalError,
 				transcriptPath: transcriptWriter ? artifactPaths.transcriptPath : undefined,
 				metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath,
-			})), "utf-8");
-		}
-		if (ctx.artifactConfig?.includeMetadata !== false) {
-			fs.writeFileSync(
-				artifactPaths.metadataPath,
-				JSON.stringify({
-					runId: ctx.id,
-					agent: step.agent,
-					task,
-					exitCode: effectiveFinalExitCode,
-					model: finalResult?.model,
-					attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
-					modelAttempts,
-					error: effectiveFinalError,
-					acceptance: effectiveAcceptance,
-					...(capabilityAudit ? { capabilityCeiling: capabilityAudit.ceiling, capabilityAudit } : {}),
-					launchContractDigest: actualLaunchContractDigest,
-					launchResolvedExtensions,
-					...((finalResult as (RunPiStreamingResult & { runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1 }) | undefined)?.runtimeAcknowledgedExtensions ? { runtimeAcknowledgedExtensions: (finalResult as RunPiStreamingResult & { runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1 }).runtimeAcknowledgedExtensions } : {}),
-					...(transcriptWriter ? { transcriptPath: artifactPaths.transcriptPath } : {}),
-					transcriptError: transcriptWriter?.getError(),
-					skills: step.skills,
-					timestamp: Date.now(),
-				}, null, 2),
-				"utf-8",
-			);
-		}
-	}
+			})),
+			metadata: {
+				runId: ctx.id,
+				agent: step.agent,
+				task,
+				exitCode: effectiveFinalExitCode,
+				model: finalResult?.model,
+				attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
+				modelAttempts,
+				error: effectiveFinalError,
+				acceptance: effectiveAcceptance,
+				...(capabilityAudit ? { capabilityCeiling: capabilityAudit.ceiling, capabilityAudit } : {}),
+				launchContractDigest: actualLaunchContractDigest,
+				launchResolvedExtensions,
+				...((finalResult as (RunPiStreamingResult & { runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1 }) | undefined)?.runtimeAcknowledgedExtensions ? { runtimeAcknowledgedExtensions: (finalResult as RunPiStreamingResult & { runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1 }).runtimeAcknowledgedExtensions } : {}),
+				...(transcriptWriter ? { transcriptPath: artifactPaths.transcriptPath } : {}),
+				transcriptError: transcriptWriter?.getError(),
+				skills: step.skills,
+				timestamp: Date.now(),
+			},
+		})
+		: {};
 
 	const result: StepResult & { completionGuardTriggered?: boolean } = omitUndefinedProperties({
 		agent: step.agent,
@@ -1687,6 +1711,8 @@ async function runSingleStep(
 		modelAttempts,
 		totalCost: costSummaryFromAttempts(modelAttempts),
 		artifactPaths,
+		outputSaveError: artifactErrors.outputSaveError,
+		metadataSaveError: artifactErrors.metadataSaveError,
 		transcriptPath: transcriptWriter ? artifactPaths?.transcriptPath : undefined,
 		transcriptError: transcriptWriter?.getError(),
 		interrupted: timedOutAfterAcceptance || stoppedAfterAcceptance || turnBudgetExceeded ? false : finalResult?.interrupted,
@@ -4464,6 +4490,8 @@ async function runSubagent(
 				modelAttempts: r.modelAttempts,
 				totalCost: r.totalCost,
 				artifactPaths: r.artifactPaths,
+				outputSaveError: r.outputSaveError,
+				metadataSaveError: r.metadataSaveError,
 				truncated: r.truncated,
 				transcriptPath: r.transcriptPath,
 				transcriptError: r.transcriptError,

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -76,6 +76,7 @@ export function ensureArtifactsDir(dir: string): void {
 }
 
 export function writeArtifact(filePath: string, content: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
 	fs.writeFileSync(filePath, content, "utf-8");
 }
 
@@ -93,6 +94,7 @@ export function formatOutputArtifactContent(input: {
 }
 
 export function writeMetadata(filePath: string, metadata: object): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
 	fs.writeFileSync(filePath, JSON.stringify(metadata, null, 2), "utf-8");
 }
 

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -80,7 +80,7 @@ interface AsyncResultPayload {
 	totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
 	usageBudget?: UsageBudgetState;
 	checkpoint?: { name?: string; status?: string };
-	results: Array<{ agent?: string; launchContractDigest?: string; launchResolvedExtensions?: LaunchResolvedExtensions; runtimeAcknowledgedExtensions?: RuntimeAcknowledgedExtensions; output?: string; outputState?: "present" | "absent" | "unknown"; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string }; capabilityCeiling?: { version?: number; allowedTools?: string[]; denyExtensions?: boolean; sources?: string[] }; capabilityAudit?: { effectiveTools?: string[]; removedTools?: string[]; extensionsDenied?: boolean } }>;
+	results: Array<{ agent?: string; launchContractDigest?: string; launchResolvedExtensions?: LaunchResolvedExtensions; runtimeAcknowledgedExtensions?: RuntimeAcknowledgedExtensions; output?: string; outputState?: "present" | "absent" | "unknown"; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string }; outputSaveError?: string; metadataSaveError?: string; capabilityCeiling?: { version?: number; allowedTools?: string[]; denyExtensions?: boolean; sources?: string[] }; capabilityAudit?: { effectiveTools?: string[]; removedTools?: string[]; extensionsDenied?: boolean } }>;
 	outputs?: Record<string, { text?: string; structured?: unknown }>;
 	workflowGraph?: { nodes?: Array<{ kind?: string; label?: string; phase?: string; status?: string; acceptanceStatus?: string; error?: string; outputName?: string; structured?: boolean; children?: Array<{ label?: string; outputName?: string; itemKey?: string; status?: string; acceptanceStatus?: string; error?: string }> }> };
 	parallelHandoff?: { version?: number; path?: string; groupCount?: number; childCount?: number; changedPatches?: number; cleanupState?: string };
@@ -807,6 +807,37 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(artifact, /Error:\nmodel unavailable/);
 		assert.match(artifact, /Transcript:/);
 		assert.match(artifact, /Metadata:/);
+	});
+
+	it("recreates project-local artifact directories removed before async completion", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ delay: 800, output: "completed after artifact cleanup" });
+		const id = `async-artifact-dir-recovery-${Date.now().toString(36)}`;
+		const artifactsDir = path.join(tempDir, ".pi-subagents", "artifacts");
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Complete after generated artifacts are cleaned",
+			agentConfig: makeAgent("worker", { completionGuard: false }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: true, includeInput: true, includeOutput: true, includeJsonl: false, includeMetadata: true, cleanupDays: 7 },
+			artifactsDir,
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+
+		await waitForMockPiCall(mockPi, 0);
+		assert.equal(fs.existsSync(artifactsDir), true);
+		fs.rmSync(path.join(tempDir, ".pi-subagents"), { recursive: true, force: true });
+
+		const payload = await readAsyncPayload(id);
+		assert.equal(payload.success, true);
+		assert.equal(payload.results[0]?.outputSaveError, undefined);
+		assert.equal(payload.results[0]?.metadataSaveError, undefined);
+		const outputPath = payload.results[0]?.artifactPaths?.outputPath;
+		const metadataPath = payload.results[0]?.artifactPaths?.metadataPath;
+		assert.ok(outputPath && metadataPath);
+		assert.equal(fs.readFileSync(outputPath, "utf-8"), "completed after artifact cleanup");
+		assert.equal((JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { exitCode?: number }).exitCode, 0);
 	});
 
 	it("background keeps only a bounded UTF-8 stderr tail", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/unit/mission-lifecycle.test.ts
+++ b/test/unit/mission-lifecycle.test.ts
@@ -132,6 +132,50 @@ describe("mission launch lifecycle", () => {
 		}
 	});
 
+	it("records a bounded warning when an async mission record disappeared before completion", () => {
+		const test = projectFixture();
+		try {
+			const asyncDir = path.join(test.root, "async-run-missing-mission");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			const binding = prepareMissionLaunch({
+				params: { mission: { title: "Disposable mission record" }, task: "Run later" },
+				projectRoot: test.projectRoot,
+				config: test.missionConfig,
+			});
+			assert.ok(binding);
+			attachMissionToLaunchResult({
+				binding,
+				result: {
+					content: [{ type: "text", text: "Async started" }],
+					details: { mode: "single", runId: "async-missing-mission", asyncId: "async-missing-mission", asyncDir, results: [] },
+				},
+			});
+			fs.rmSync(binding.location.missionDir, { recursive: true, force: true });
+
+			const completed = syncMissionFromAsyncCompletion({
+				runId: "async-missing-mission",
+				asyncDir,
+				mode: "single",
+				state: "complete",
+				success: true,
+			});
+
+			assert.equal(completed, undefined);
+			const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
+			assert.deepEqual(events, [{
+				type: "subagent.mission.sync.skipped",
+				ts: events[0]?.ts,
+				runId: "async-missing-mission",
+				missionId: binding.missionId,
+				reason: "mission-record-missing",
+				missionPath: path.join(binding.location.missionDir, `${binding.missionId}.json`),
+			}]);
+			assert.equal(typeof events[0]?.ts, "number");
+		} finally {
+			fs.rmSync(test.root, { recursive: true, force: true });
+		}
+	});
+
 	it("binds an async launch and reconciles terminal status and artifacts", () => {
 		const test = projectFixture();
 		try {


### PR DESCRIPTION
Closes #797.

Recreates missing artifact parent directories during final async persistence and retains non-fatal artifact write errors on child results. Missing project-local mission records now produce a bounded lifecycle warning instead of throwing through the completion event handler.

Validation:
- `node --experimental-strip-types --test test/unit/artifacts.test.ts test/unit/mission-lifecycle.test.ts`
- `node --experimental-strip-types --test --test-name-pattern='recreates project-local artifact directories removed before async completion' test/integration/async-execution.test.ts`
- `npm run typecheck`
- `git diff --check`