### PR TITLE
fix: prioritize active Fleet runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Fixed
 - Preserve successful async completion when project-local artifact or mission files are removed before final bookkeeping by recreating artifact directories and recording missing-mission warnings.
+- Keep active Fleet inspector runs ahead of terminal history, which now sorts by recency instead of failure state so old failures do not look attached to current workflow work. Thanks to @nicobailon for #802.
 - Normalize undefined fields in workflow child results before scripts can return them, preserving artifact-only child output.
 - Show current-session async runs in the Fleet inspector even when this Pi process did not start them.
 - Replace the duplicate advisor agent with an alias on the oracle agent.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -117,6 +117,8 @@ interface AsyncRunListOptions {
 	states?: Array<AsyncRunSummary["state"]>;
 	sessionId?: string;
 	limit?: number;
+	/** Limits status-file reads after candidates are ordered by status mtime. */
+	entryLimit?: number;
 	resultsDir?: string;
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 	now?: () => number;
@@ -382,6 +384,25 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 		throw new Error(`Failed to list async runs in '${asyncDirRoot}': ${getErrorMessage(error)}`, {
 			cause: error instanceof Error ? error : undefined,
 		});
+	}
+
+	if (options.entryLimit !== undefined) {
+		const limit = Math.max(0, Math.floor(options.entryLimit));
+		entries = entries
+			.map((entry) => {
+				try {
+					return { entry, mtimeMs: fs.statSync(path.join(asyncDirRoot, entry, "status.json")).mtimeMs };
+				} catch (error) {
+					if (isNotFoundError(error)) return undefined;
+					throw new Error(`Failed to inspect async status file for '${entry}': ${getErrorMessage(error)}`, {
+						cause: error instanceof Error ? error : undefined,
+					});
+				}
+			})
+			.filter((candidate): candidate is { entry: string; mtimeMs: number } => candidate !== undefined)
+			.sort((left, right) => right.mtimeMs - left.mtimeMs)
+			.slice(0, limit)
+			.map((candidate) => candidate.entry);
 	}
 
 	const allowedStates = options.states ? new Set(options.states) : undefined;

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -18,6 +18,7 @@ import { handleHerdrInspectorAction } from "../inspectors/herdr/actions.ts";
 
 const REFRESH_MS = 750;
 const MAX_RECENT_ASYNC_RUNS = 20;
+const MAX_FLEET_HISTORY_CANDIDATES = 100;
 const TRANSCRIPT_LINES = 200;
 
 type Theme = ExtensionContext["ui"]["theme"];
@@ -173,27 +174,31 @@ export function collectFleetSnapshot(
 	try {
 		let runs: AsyncRunSummary[];
 		const descriptions = new Map<string, string>();
+		const tracked = [...(state.fleetJobs ?? state.asyncJobs).values()]
+			.filter((job) => belongsToCurrentSession(job.sessionId, state.currentSessionId));
+		const byUpdate = (left: AsyncJobState, right: AsyncJobState) => (right.updatedAt ?? right.startedAt ?? 0) - (left.updatedAt ?? left.startedAt ?? 0);
+		const active = tracked.filter((job) => job.status === "queued" || job.status === "running").sort(byUpdate);
+		const recent = tracked.filter((job) => job.status !== "queued" && job.status !== "running").sort(byUpdate).slice(0, options.limit ?? MAX_RECENT_ASYNC_RUNS);
+		const trackedRuns: AsyncRunSummary[] = [];
+		for (const job of [...active, ...recent]) {
+			try {
+				trackedRuns.push(trackedJobSummary(job));
+				if (job.description) descriptions.set(job.asyncId, job.description);
+			} catch (cause) {
+				error = `Failed to inspect async run '${job.asyncId}': ${cause instanceof Error ? cause.message : String(cause)}`;
+			}
+		}
 		if (options.asyncDirRoot !== undefined) {
-			runs = listAsyncRuns(options.asyncDirRoot, {
+			const trackedIds = new Set(trackedRuns.map((run) => run.id));
+			const history = listAsyncRuns(options.asyncDirRoot, {
 				...(state.currentSessionId ? { sessionId: state.currentSessionId } : {}),
+				entryLimit: MAX_FLEET_HISTORY_CANDIDATES,
 				resultsDir: options.resultsDir ?? DIRS.results,
 				reconcile: false,
-			});
+			}).filter((run) => !trackedIds.has(run.id));
+			runs = [...trackedRuns, ...history];
 		} else {
-			const tracked = [...(state.fleetJobs ?? state.asyncJobs).values()]
-				.filter((job) => belongsToCurrentSession(job.sessionId, state.currentSessionId));
-			const byUpdate = (left: AsyncJobState, right: AsyncJobState) => (right.updatedAt ?? right.startedAt ?? 0) - (left.updatedAt ?? left.startedAt ?? 0);
-			const active = tracked.filter((job) => job.status === "queued" || job.status === "running").sort(byUpdate);
-			const recent = tracked.filter((job) => job.status !== "queued" && job.status !== "running").sort(byUpdate).slice(0, options.limit ?? MAX_RECENT_ASYNC_RUNS);
-			runs = [];
-			for (const job of [...active, ...recent]) {
-				try {
-					runs.push(trackedJobSummary(job));
-					if (job.description) descriptions.set(job.asyncId, job.description);
-				} catch (cause) {
-					error = `Failed to inspect async run '${job.asyncId}': ${cause instanceof Error ? cause.message : String(cause)}`;
-				}
-			}
+			runs = trackedRuns;
 		}
 		for (const run of orderFleetAsyncRuns(runs, options.limit ?? MAX_RECENT_ASYNC_RUNS)) {
 			items.push(...asyncItems(run, descriptions.get(run.id)));

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -123,6 +123,14 @@ function asyncItems(run: AsyncRunSummary, description?: string): FleetItem[] {
 	}));
 }
 
+function orderFleetAsyncRuns(runs: AsyncRunSummary[], terminalLimit: number): AsyncRunSummary[] {
+	const updatedAt = (run: AsyncRunSummary) => run.lastUpdate ?? run.endedAt ?? run.startedAt;
+	const byNewest = (left: AsyncRunSummary, right: AsyncRunSummary) => updatedAt(right) - updatedAt(left);
+	const active = runs.filter((run) => run.state === "queued" || run.state === "running").sort(byNewest);
+	const terminal = runs.filter((run) => run.state !== "queued" && run.state !== "running").sort(byNewest);
+	return [...active, ...terminal.slice(0, terminalLimit)];
+}
+
 export function collectFleetSnapshot(
 	state: SubagentState,
 	options: { asyncDirRoot?: string; resultsDir?: string; limit?: number } = {},
@@ -168,7 +176,6 @@ export function collectFleetSnapshot(
 		if (options.asyncDirRoot !== undefined) {
 			runs = listAsyncRuns(options.asyncDirRoot, {
 				...(state.currentSessionId ? { sessionId: state.currentSessionId } : {}),
-				limit: options.limit ?? MAX_RECENT_ASYNC_RUNS,
 				resultsDir: options.resultsDir ?? DIRS.results,
 				reconcile: false,
 			});
@@ -188,7 +195,9 @@ export function collectFleetSnapshot(
 				}
 			}
 		}
-		for (const run of runs) items.push(...asyncItems(run, descriptions.get(run.id)));
+		for (const run of orderFleetAsyncRuns(runs, options.limit ?? MAX_RECENT_ASYNC_RUNS)) {
+			items.push(...asyncItems(run, descriptions.get(run.id)));
+		}
 	} catch (cause) {
 		error = cause instanceof Error ? cause.message : String(cause);
 	}

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -30,7 +30,9 @@ function stateForTest(): SubagentState {
 function writeAsyncRun(root: string, input: {
 	id: string;
 	sessionId?: string;
-	state?: "running" | "complete";
+	state?: "running" | "complete" | "failed";
+	mode?: "single" | "parallel" | "workflow";
+	lastUpdate?: number;
 	agents?: string[];
 	contexts?: Array<"fresh" | "fork">;
 	output?: string;
@@ -45,15 +47,15 @@ function writeAsyncRun(root: string, input: {
 	fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
 		runId: input.id,
 		sessionId: input.sessionId ?? "session-current",
-		mode: agents.length > 1 ? "parallel" : "single",
+		mode: input.mode ?? (agents.length > 1 ? "parallel" : "single"),
 		state: input.state ?? "running",
 		startedAt: 100,
-		lastUpdate: 200,
+		lastUpdate: input.lastUpdate ?? 200,
 		currentStep: 0,
 		steps: agents.map((agent, index) => ({
 			agent,
 			...(input.contexts?.[index] ? { context: input.contexts[index] } : {}),
-			status: input.state === "complete" ? "complete" : index === 0 ? "running" : "pending",
+			status: input.state === "complete" ? "complete" : input.state === "failed" ? "failed" : index === 0 ? "running" : "pending",
 			startedAt: 100,
 			...(index === 0 ? { sessionFile: path.join(asyncDir, `${agent}.jsonl`), ...(transcriptPath ? { transcriptPath } : {}) } : {}),
 		})),
@@ -124,6 +126,20 @@ describe("native subagent fleet", () => {
 				"foreground-recent:foreground-recent:0",
 			]);
 			assert.equal(snapshot.error, undefined);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps active workflows ahead of older failed terminal history", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-history-"));
+		try {
+			writeAsyncRun(root, { id: "older-failed", state: "failed", lastUpdate: 100 });
+			writeAsyncRun(root, { id: "newer-complete", state: "complete", lastUpdate: 300 });
+			writeAsyncRun(root, { id: "active-workflow", mode: "workflow", state: "running", lastUpdate: 200 });
+
+			const snapshot = collectFleetSnapshot(stateForTest(), { asyncDirRoot: root, resultsDir: path.join(root, "results") });
+			assert.deepEqual(snapshot.items.map((item) => item.runId), ["active-workflow", "newer-complete", "older-failed"]);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -131,15 +131,45 @@ describe("native subagent fleet", () => {
 		}
 	});
 
-	it("keeps active workflows ahead of older failed terminal history", () => {
+	it("keeps tracked active workflows ahead of older failed terminal history", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-history-"));
 		try {
 			writeAsyncRun(root, { id: "older-failed", state: "failed", lastUpdate: 100 });
 			writeAsyncRun(root, { id: "newer-complete", state: "complete", lastUpdate: 300 });
-			writeAsyncRun(root, { id: "active-workflow", mode: "workflow", state: "running", lastUpdate: 200 });
+			const state = stateForTest();
+			state.fleetJobs = new Map([["active-workflow", {
+				asyncId: "active-workflow",
+				asyncDir: path.join(root, "active-workflow"),
+				sessionId: "session-current",
+				status: "running",
+				mode: "workflow",
+				agents: ["worker"],
+				startedAt: 100,
+				updatedAt: 200,
+			}]]);
+
+			const snapshot = collectFleetSnapshot(state, { asyncDirRoot: root, resultsDir: path.join(root, "results") });
+			assert.deepEqual(snapshot.items.map((item) => item.runId), ["active-workflow", "newer-complete", "older-failed"]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("bounds Fleet history status-file reads", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-bounded-history-"));
+		try {
+			for (let index = 0; index < 100; index++) {
+				const asyncDir = writeAsyncRun(root, { id: `recent-${index}`, state: "complete", lastUpdate: index });
+				fs.utimesSync(path.join(asyncDir, "status.json"), 1_000 + index, 1_000 + index);
+			}
+			const oldDir = writeAsyncRun(root, { id: "old-invalid", state: "failed", lastUpdate: 0 });
+			fs.writeFileSync(path.join(oldDir, "status.json"), "{not-json", "utf8");
+			fs.utimesSync(path.join(oldDir, "status.json"), 1, 1);
 
 			const snapshot = collectFleetSnapshot(stateForTest(), { asyncDirRoot: root, resultsDir: path.join(root, "results") });
-			assert.deepEqual(snapshot.items.map((item) => item.runId), ["active-workflow", "newer-complete", "older-failed"]);
+			assert.equal(snapshot.error, undefined);
+			assert.equal(snapshot.items.length, 20);
+			assert.ok(!snapshot.items.some((item) => item.runId === "old-invalid"));
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
Fixes #802.

Fleet snapshots now place active queued/running runs before terminal history, and sort terminal history by recency rather than terminal state. This keeps old failures visible without making them look attached to a current workflow.

Validation:
- `node --experimental-strip-types --test test/unit/fleet.test.ts`
- `npm run typecheck`
- `git diff --check`
