### PR TITLE
feat: stabilize inline display and background completion delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Wake the originating parent session after a hidden successful background completion while preserving explicit `triggerTurn: false` delivery.
 - Preserve successful async completion when project-local artifact or mission files are removed before final bookkeeping by recreating artifact directories and recording missing-mission warnings.
 - Normalize undefined fields in workflow child results before scripts can return them, preserving artifact-only child output.
 - Show current-session async runs in the Fleet inspector even when this Pi process did not start them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added opt-in `inlineToolDisplay: "summary"` for a stable one-row inline subagent result while FleetView remains the live progress surface.
 - Added an observational `pi-subagents/external-runs` provider API for visible terminal work, without taking process ownership. Thanks to @nicobailon for #795.
 - Added narrow public entrypoints for extension consumers to access async stop requests, intercom session targeting, launch tool-plan resolution, and fork-task helpers without deep imports. Thanks to @shaneconner for #794.
 - FleetView nested trees now retain and display each leaf's effective model and thinking effort, including completed siblings while the owner remains active. Thanks to @fgpaz for #776.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Added opt-in `inlineToolDisplay: "summary"` for a stable one-row inline subagent result while FleetView remains the live progress surface.
+- Added opt-in `inlineToolDisplay: "summary"` for a stable one-row inline subagent result while FleetView remains the live progress surface. Thanks to @ryanbbrown for #805.
 - Added an observational `pi-subagents/external-runs` provider API for visible terminal work, without taking process ownership. Thanks to @nicobailon for #795.
 - Added narrow public entrypoints for extension consumers to access async stop requests, intercom session targeting, launch tool-plan resolution, and fork-task helpers without deep imports. Thanks to @shaneconner for #794.
 - FleetView nested trees now retain and display each leaf's effective model and thinking effort, including completed siblings while the owner remains active. Thanks to @fgpaz for #776.
@@ -30,7 +30,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
-- Wake the originating parent session after a hidden successful background completion while preserving explicit `triggerTurn: false` delivery.
+- Wake the originating parent session after a hidden successful background completion while preserving explicit `triggerTurn: false` delivery. Thanks to @ryanbbrown for #805.
 - Preserve successful async completion when project-local artifact or mission files are removed before final bookkeeping by recreating artifact directories and recording missing-mission warnings.
 - Normalize undefined fields in workflow child results before scripts can return them, preserving artifact-only child output.
 - Show current-session async runs in the Fleet inspector even when this Pi process did not start them.

--- a/README.md
+++ b/README.md
@@ -1244,6 +1244,14 @@ Controls the parent-facing `subagent` tool description registered at startup. `f
 
 `custom` reads `subagent-tool-description.md` from the project config directory, then from `~/.pi/agent/subagent-tool-description.md`. Missing, empty, unreadable, or oversized custom files fall back to the full description. Custom templates may use `{{fullDescription}}`, `{{compactDescription}}`, `{{safetyGuidance}}`, `{{agentDir}}`, and `{{projectConfigDir}}`; the safety guidance is always present so custom prose cannot remove the runtime guardrails. Restart Pi after changing the mode or custom file.
 
+### `inlineToolDisplay`
+
+```json
+{ "inlineToolDisplay": "summary" }
+```
+
+Controls the `subagent` tool result shown inline in chat. The default, `"rich"`, shows live child activity and expands to detailed output. `"summary"` keeps the inline result at one stable row for running, completed, failed, stopped, and paused runs; it does not animate, show elapsed time, preview child output, or change when Pi's expand key is pressed. FleetView remains available for live progress and detailed inspection.
+
 ### `asyncByDefault`
 
 ```json

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -24,7 +24,7 @@ import { ensureAccessibleDir } from "../shared/accessible-dir.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
-import { clearLegacyResultAnimationTimer, renderSubagentResult } from "../tui/render.ts";
+import { clearLegacyResultAnimationTimer, renderSubagentResult, renderSubagentSummary } from "../tui/render.ts";
 import { openSubagentFleet } from "../tui/fleet.ts";
 import { SubagentFleetStatus, resolveFleetViewPlacement } from "../tui/fleet-status.ts";
 import { SubagentParams } from "./schemas.ts";
@@ -197,6 +197,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const fleetViewEnabled = config.fleetView !== false;
 	const fleetViewPlacement = resolveFleetViewPlacement(config.fleetViewPlacement);
 	const asyncWidgetEnabled = config.asyncWidget === true || (!fleetViewEnabled && config.asyncWidget !== false);
+	const summaryInlineToolDisplay = config.inlineToolDisplay === "summary";
 	const tempArtifactsDir = getArtifactsDir(null);
 	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
 
@@ -430,7 +431,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 		renderResult(result, options, theme, context) {
 			clearLegacyResultAnimationTimer(context);
-			return renderSubagentResult(result, options, theme);
+			return summaryInlineToolDisplay
+				? renderSubagentSummary(result, options, theme)
+				: renderSubagentResult(result, options, theme);
 		},
 
 	};

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -178,7 +178,7 @@ function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage">, items: PendingCom
 				content,
 				display,
 			},
-			{ triggerTurn: display && items.some((item) => item.triggerTurn) },
+			{ triggerTurn: items.some((item) => item.triggerTurn) },
 		);
 		return true;
 	} catch {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1699,6 +1699,7 @@ export interface ProactiveSkillSubagentsConfig {
 }
 
 export type ToolDescriptionMode = "full" | "compact" | "custom";
+export type InlineToolDisplay = "rich" | "summary";
 
 export interface ScheduledRunsConfig {
 	enabled?: boolean;
@@ -1718,6 +1719,8 @@ export interface ExtensionConfig {
 	asyncWidget?: boolean;
 	/** Tool description variant registered for the parent-facing subagent tool. Defaults to full. */
 	toolDescriptionMode?: ToolDescriptionMode;
+	/** Inline chat rendering for the subagent tool. Defaults to rich. */
+	inlineToolDisplay?: InlineToolDisplay;
 	forceTopLevelAsync?: boolean;
 	waitTool?: WaitToolConfig;
 	defaultSessionDir?: string;

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1554,6 +1554,42 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 	return c;
 }
 
+export function renderSubagentSummary(
+	result: AgentToolResult<Details>,
+	options: { isPartial?: boolean },
+	theme: Theme,
+): Component {
+	const details = result.details;
+	const results = details?.results ?? [];
+	const running = options.isPartial === true
+		|| details?.progress?.some((progress) => progress.status === "running")
+		|| results.some((entry) => entry.progress?.status === "running")
+		|| Boolean(details && workflowGraphHasStatus(details, ["running"]));
+	const stopped = results.some((entry) => entry.stopped && entry.progress?.status !== "running")
+		|| Boolean(details && workflowGraphHasStatus(details, ["stopped"]));
+	const paused = results.some((entry) => (entry.interrupted || entry.detached) && entry.progress?.status !== "running")
+		|| Boolean(details && workflowGraphHasStatus(details, ["paused", "detached"]));
+	const failed = result.isError === true
+		|| results.some((entry) => !entry.stopped && entry.exitCode !== 0 && entry.progress?.status !== "running")
+		|| Boolean(details && workflowGraphHasStatus(details, ["failed"]));
+	const state = running ? "running" : stopped ? "stopped" : paused ? "paused" : failed ? "failed" : "completed";
+	const glyph = state === "running"
+		? theme.fg("accent", STATIC_RUNNING_GLYPH)
+		: state === "completed"
+			? theme.fg("success", "✓")
+			: state === "failed"
+				? theme.fg("error", "✗")
+				: theme.fg("warning", "■");
+	const label = details?.mode === "single" && results.length === 1
+		? results[0]?.agent || "subagent"
+		: details?.mode || "subagent";
+	return new Text(
+		truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold(label))} ${theme.fg("dim", "·")} ${theme.fg(state === "failed" ? "error" : state === "completed" ? "success" : state === "running" ? "accent" : "warning", state)}`, getTermWidth() - 4),
+		0,
+		0,
+	);
+}
+
 /**
  * Render a subagent result
  */

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -143,6 +143,53 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
+	it("keeps summary inline tool display to one stable row while running, completed, and stopped", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-inline-display-config-"));
+		try {
+			const configDir = path.join(agentDir, "extensions", "subagent");
+			fs.mkdirSync(configDir, { recursive: true });
+			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ inlineToolDisplay: "summary" }), "utf-8");
+
+			const script = String.raw`
+				import registerSubagentExtension from "./index.ts";
+				const events = { on() { return () => {}; }, emit() {} };
+				let registeredTool;
+				const fakePi = new Proxy({
+					events,
+					registerTool(tool) { if (tool.name === "subagent") registeredTool = tool; },
+					registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {}, sendMessage() {}, getSessionName() {},
+				}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+				registerSubagentExtension(fakePi);
+				if (!registeredTool) throw new Error("tool not registered");
+				const theme = { fg(_name, text) { return text; }, bold(text) { return text; } };
+				const base = {
+					agent: "delegate", task: "quiet", messages: [],
+					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+				};
+				const running = registeredTool.renderResult({
+					content: [{ type: "text", text: "partial output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 0, progress: { status: "running", index: 0, agent: "delegate", toolCount: 2, tokens: 300, durationMs: 20_000 } }] },
+				}, { expanded: false, isPartial: true }, theme, { state: {} }).render(120);
+				const completed = registeredTool.renderResult({
+					content: [{ type: "text", text: "completed output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 0 }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				const stopped = registeredTool.renderResult({
+					content: [{ type: "text", text: "cancelled output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 1, stopped: true, error: "Cancelled by user" }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				if (running.length !== 1 || running[0] !== "● delegate · running") throw new Error("unexpected running summary: " + JSON.stringify(running));
+				if (completed.length !== 1 || completed[0] !== "✓ delegate · completed") throw new Error("unexpected completed summary: " + JSON.stringify(completed));
+				if (stopped.length !== 1 || stopped[0] !== "■ delegate · stopped") throw new Error("unexpected stopped summary: " + JSON.stringify(stopped));
+			`;
+			const env = parentToolEnv();
+			env.PI_CODING_AGENT_DIR = agentDir;
+			execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
 	it("registers only subagent_wait and honors waitTool disabled config", () => {
 		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-wait-tool-config-"));
 		try {

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -143,7 +143,7 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
-	it("keeps summary inline tool display to one stable row while running, completed, and stopped", () => {
+	it("keeps summary inline tool display to one stable row for every supported state", () => {
 		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-inline-display-config-"));
 		try {
 			const configDir = path.join(agentDir, "extensions", "subagent");
@@ -178,9 +178,19 @@ describe("subagent extension child mode", () => {
 					content: [{ type: "text", text: "cancelled output that must not appear" }],
 					details: { mode: "single", results: [{ ...base, exitCode: 1, stopped: true, error: "Cancelled by user" }] },
 				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				const paused = registeredTool.renderResult({
+					content: [{ type: "text", text: "paused output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 1, interrupted: true }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				const failed = registeredTool.renderResult({
+					content: [{ type: "text", text: "failed output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 1, stopped: false }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
 				if (running.length !== 1 || running[0] !== "● delegate · running") throw new Error("unexpected running summary: " + JSON.stringify(running));
 				if (completed.length !== 1 || completed[0] !== "✓ delegate · completed") throw new Error("unexpected completed summary: " + JSON.stringify(completed));
 				if (stopped.length !== 1 || stopped[0] !== "■ delegate · stopped") throw new Error("unexpected stopped summary: " + JSON.stringify(stopped));
+				if (paused.length !== 1 || paused[0] !== "■ delegate · paused") throw new Error("unexpected paused summary: " + JSON.stringify(paused));
+				if (failed.length !== 1 || failed[0] !== "✗ delegate · failed") throw new Error("unexpected failed summary: " + JSON.stringify(failed));
 			`;
 			const env = parentToolEnv();
 			env.PI_CODING_AGENT_DIR = agentDir;

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -110,7 +110,7 @@ function completionResult(overrides: Record<string, unknown> = {}) {
 }
 
 describe("registerSubagentNotify", () => {
-	it("uses a fallback summary when a background completion is empty", () => {
+	it("keeps a successful background completion hidden while waking the originating session", () => {
 		const { events, sent } = createPi();
 
 		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
@@ -130,7 +130,7 @@ describe("registerSubagentNotify", () => {
 				content: "Background task completed: **worker**\n\n(no output)",
 				display: false,
 			},
-			options: { triggerTurn: false },
+			options: { triggerTurn: true },
 		});
 	});
 
@@ -138,6 +138,12 @@ describe("registerSubagentNotify", () => {
 		const { notifier, sent } = createPi("session-a");
 		assert.equal(await notifier.deliver(completionResult({ id: "direct-accepted" })), true);
 		assert.equal(sent.length, 1);
+	});
+
+	it("does not wake the session when background delivery explicitly disables triggerTurn", async () => {
+		const { notifier, sent } = createPi("session-a");
+		assert.equal(await notifier.deliver(completionResult({ id: "direct-silent", triggerTurn: false })), true);
+		assert.deepEqual(sent[0]!.options, { triggerTurn: false });
 	});
 
 	it("suppresses local delivery after an acknowledged grouped intercom relay", async () => {
@@ -219,7 +225,7 @@ describe("registerSubagentNotify", () => {
 				content: `Background task completed: **worker** (2/3)\n\n${summary}`,
 				display: false,
 			},
-			options: { triggerTurn: false },
+			options: { triggerTurn: true },
 		});
 	});
 
@@ -243,7 +249,7 @@ describe("registerSubagentNotify", () => {
 				content: "Background task completed: **worker**\n\nDone\n\nSession file: /tmp/session.jsonl",
 				display: false,
 			},
-			options: { triggerTurn: false },
+			options: { triggerTurn: true },
 		}]);
 	});
 
@@ -332,7 +338,7 @@ describe("registerSubagentNotify", () => {
 			content,
 			display: false,
 		});
-		assert.deepEqual(sent[0]!.options, { triggerTurn: false });
+		assert.deepEqual(sent[0]!.options, { triggerTurn: true });
 	});
 
 	it("ignores successes from other sessions instead of grouping them", () => {


### PR DESCRIPTION
## Summary

- add opt-in `inlineToolDisplay: "summary"` configuration
- keep inline subagent results to one static row across running, completion, expansion, and cancellation
- preserve the existing rich renderer by default and leave FleetView unchanged
- wake the originating parent after hidden successful background completions
- preserve explicit `triggerTurn: false` delivery for callers that require silent completion

## Why

The rich foreground renderer has an unavoidable tradeoff between timer-driven full-TUI redraw pressure and frozen event-driven clocks and spinners. Summary mode gives users a stable chat row while FleetView remains the live progress and inspection surface. It never renders child output, elapsed time, or variable-height activity inline.

Successful background completion messages are intentionally hidden so inactive tabs are not marked unread. Their visibility was also suppressing `triggerTurn`, however, so an idle parent never resumed even when delivery requested a wakeup. Message visibility and turn delivery are independent Pi controls; this change keeps the message hidden while honoring the requested `triggerTurn` value.

## Verification

Run with Node 24.19.0:

- typecheck passed
- unit suite: 1,569 passed, 0 failed, 1 skipped
- E2E suite: 3 passed
- inline renderer regression covers running, completed, stopped, paused, and failed rendering at exactly one row, including expanded results
- notification regressions cover hidden successful wakeups and explicit `triggerTurn: false`
- real Pi session confirmed that a hidden successful background completion wakes the idle parent

The integration suite reported 674 passed and one failure in `gives parallel workflow children separate managed worktrees and durable handoffs`. That unrelated worktree test passed on an immediate focused rerun.

