### PR TITLE
fix: validate acceptance and settle workflow siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Reject scalar or commandless verified acceptance before spawning a child; verified policies now require object form with at least one runtime command.
+- Let every `runs.all` child settle and return ordered per-child outcomes instead of aborting siblings when one child fails; `runs.run` remains fail-fast.
 - Preserve successful async completion when project-local artifact or mission files are removed before final bookkeeping by recreating artifact directories and recording missing-mission warnings.
 - Keep active Fleet inspector runs ahead of terminal history, which now sorts by recency instead of failure state so old failures do not look attached to current workflow work. Thanks to @nicobailon for #802.
 - Normalize undefined fields in workflow child results before scripts can return them, preserving artifact-only child output.

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -79,7 +79,7 @@ const AcceptanceEvidenceKinds = [
 
 const AcceptanceOverride = Type.Unsafe({
 	anyOf: [
-		{ type: "string", enum: ["auto", "attested", "checked", "verified"] },
+		{ type: "string", enum: ["auto", "attested", "checked"] },
 		{
 			type: "string",
 			enum: ["reviewed"],

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3874,6 +3874,7 @@ function workflowChildResult(key: string, result: AgentToolResult<Details>): Wor
 		ok: result.isError !== true,
 		...(result.details.runId || result.details.asyncId ? { runId: result.details.runId ?? result.details.asyncId } : {}),
 		output,
+		...(result.isError === true ? { error: output || "Child run failed." } : {}),
 		...(structured.length === 1 ? { structuredOutput: structured[0] } : structured.length > 1 ? { structuredOutput: structured } : {}),
 		artifactPaths: [...artifactPaths],
 		results: result.details.results,

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -169,6 +169,7 @@ export function validateAcceptanceInput(input: unknown, pathLabel = "acceptance"
 		if (input === "reviewed") errors.push(`${pathLabel} ${EXPLICIT_REVIEWED_UNAVAILABLE}`);
 		else if (!VALID_LEVELS.has(input as AcceptanceLevel)) errors.push(`${pathLabel} has invalid level '${input}'.`);
 		else if (input === "none") errors.push(`${pathLabel} level "none" requires a reason; use { level: "none", reason: "..." }.`);
+		else if (input === "verified") errors.push(`${pathLabel} level "verified" requires object form with at least one verify command.`);
 		return errors;
 	}
 	if (!input || typeof input !== "object" || Array.isArray(input)) {
@@ -232,7 +233,11 @@ export function validateAcceptanceInput(input: unknown, pathLabel = "acceptance"
 	} else if (value.evidence !== undefined) {
 		errors.push(`${pathLabel}.evidence must be an array. ${ACCEPTANCE_EVIDENCE_HELP}`);
 	}
-	if (value.verify !== undefined && !Array.isArray(value.verify)) errors.push(`${pathLabel}.verify must be an array.`);
+	if (value.level === "verified" && (!Array.isArray(value.verify) || value.verify.length === 0)) {
+		errors.push(`${pathLabel}.verify must contain at least one command when level is verified.`);
+	} else if (value.verify !== undefined && !Array.isArray(value.verify)) {
+		errors.push(`${pathLabel}.verify must be an array.`);
+	}
 	if (Array.isArray(value.verify)) {
 		for (const [index, command] of value.verify.entries()) {
 			if (!command || typeof command !== "object" || Array.isArray(command)) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -680,8 +680,8 @@ export interface AcceptanceConfig {
 	reason?: string;
 }
 
-/** Bare "none" is not accepted: use { level: "none", reason: "..." }; false remains a deprecated shorthand. */
-export type AcceptanceInput = Exclude<AcceptanceLevel, "none"> | false | AcceptanceConfig;
+/** Bare "none" and "verified" are not accepted; verified policies require object form with runtime commands. */
+export type AcceptanceInput = Exclude<AcceptanceLevel, "none" | "verified"> | false | AcceptanceConfig;
 
 export interface ResolvedAcceptanceGate extends AcceptanceGate {
 	id: string;

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -9,6 +9,13 @@ const { inspect } = require("node:util");
 
 let nextCallId = 0;
 const pending = new Map();
+const runKeyPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function stableRunJson(value) {
+  if (Array.isArray(value)) return "[" + value.map(stableRunJson).join(",") + "]";
+  if (value && typeof value === "object") return "{" + Object.keys(value).sort().map((key) => JSON.stringify(key) + ":" + stableRunJson(value[key])).join(",") + "}";
+  return JSON.stringify(value) ?? "undefined";
+}
 
 function hostCall(method, args) {
   return new Promise((resolve, reject) => {
@@ -25,15 +32,42 @@ function formatRef(result) {
   return "[" + parts.join("; ") + "]";
 }
 
+const runFingerprints = new Map();
+
+function validateRunCall(key, params, label, fingerprints) {
+  if (typeof key !== "string" || !runKeyPattern.test(key)) throw new Error(label + " has an invalid key.");
+  if (!params || typeof params !== "object" || Array.isArray(params)) throw new Error(label + " requires a params object.");
+  if (Object.prototype.hasOwnProperty.call(params, "action") || Object.prototype.hasOwnProperty.call(params, "workflowScript") || Object.prototype.hasOwnProperty.call(params, "tasks") || Object.prototype.hasOwnProperty.call(params, "chain") || Object.prototype.hasOwnProperty.call(params, "concurrency") || Object.prototype.hasOwnProperty.call(params, "chainDir")) {
+    const hint = label === "runs.run" ? "; use runs.all(...) and JavaScript control flow for orchestration." : ".";
+    throw new Error(label + " accepts one child via { agent, task } and execution controls only" + hint);
+  }
+  if (params.worktree !== undefined && typeof params.worktree !== "boolean") throw new Error(label + " worktree must be true or false.");
+  assertJsonValue(params, label + " params");
+  const fingerprint = stableRunJson(params);
+  const existing = fingerprints.get(key);
+  if (existing !== undefined && existing !== fingerprint) throw new Error("Duplicate workflow key '" + key + "' used with incompatible launch params.");
+  fingerprints.set(key, fingerprint);
+}
+
 const runs = Object.freeze({
-  run(key, params) { return hostCall("run", { key, params }); },
+  run(key, params) {
+    validateRunCall(key, params, "runs.run", runFingerprints);
+    return hostCall("run", { key, params });
+  },
   all(items) {
     if (!Array.isArray(items)) throw new Error("runs.all(items) requires an array.");
-    return Promise.all(items.map((item, index) => {
+    const fingerprints = new Map(runFingerprints);
+    const calls = [];
+    for (let index = 0; index < items.length; index++) {
+      if (!Object.prototype.hasOwnProperty.call(items, index)) throw new Error("runs.all items must not contain sparse entries.");
+      const item = items[index];
       if (!item || typeof item !== "object" || Array.isArray(item)) throw new Error("runs.all item " + index + " must be an object.");
       const { key, ...params } = item;
-      return hostCall("run", { key, params });
-    }));
+      validateRunCall(key, params, "runs.all item " + index, fingerprints);
+      calls.push({ key, params });
+    }
+    for (const { key, params } of calls) runFingerprints.set(key, stableRunJson(params));
+    return Promise.all(calls.map(({ key, params }) => hostCall("run", { key, params, collectFailure: true })));
   },
   status(keyOrRunId) { return hostCall("status", { keyOrRunId }); },
   ref: formatRef,
@@ -104,6 +138,7 @@ export interface WorkflowScriptChildResult {
 	ok: boolean;
 	runId?: string;
 	output: string;
+	error?: string;
 	structuredOutput?: unknown;
 	artifactPaths: string[];
 	results?: unknown[];
@@ -233,11 +268,15 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 	const consoleEntries: WorkflowScriptResult["console"] = [];
 	const trace: WorkflowScriptTraceEntry[] = [];
 	const children = new Map<string, WorkflowScriptChildResult>();
+	const childOrder: string[] = [];
 	const launches = new Map<string, { fingerprint: string; promise: Promise<WorkflowScriptChildResult> }>();
 	const childController = new AbortController();
 	let settled = false;
 
-	const partial = (): Omit<WorkflowScriptResult, "value"> => ({ emits, console: consoleEntries, trace, children: [...children.values()] });
+	const partial = (): Omit<WorkflowScriptResult, "value"> => ({ emits, console: consoleEntries, trace, children: childOrder.flatMap((key) => {
+		const child = children.get(key);
+		return child ? [child] : [];
+	}) });
 	const traceChanged = () => options.onTrace?.([...trace]);
 
 	return await new Promise<WorkflowScriptResult>((resolve, reject) => {
@@ -333,32 +372,42 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			if (params.worktree !== undefined && typeof params.worktree !== "boolean") {
 				return respond(Promise.reject(new Error(`runs.run('${key}') worktree must be true or false.`)));
 			}
+			const collectFailure = message.args.collectFailure === true;
+			const deliver = (promise: Promise<WorkflowScriptChildResult>) => collectFailure
+				? promise
+				: promise.then((result) => {
+					if (!result.ok) throw new Error(`Run '${key}' failed: ${result.error ?? result.output}`);
+					return result;
+				});
 			const fingerprint = stableJson(params);
 			const existing = launches.get(key);
 			if (existing) {
 				if (existing.fingerprint !== fingerprint) return respond(Promise.reject(new Error(`Duplicate workflow key '${key}' used with incompatible launch params.`)));
 				trace.push({ operation: "run", key, state: "reused", ...workflowStringMetadata(params) });
 				traceChanged();
-				return respond(existing.promise);
+				return respond(deliver(existing.promise));
 			}
 
 			const startedAt = Date.now();
+			childOrder.push(key);
 			trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(params) });
 			traceChanged();
-			const promise = options.launch(key, { ...params, async: params.async ?? false }, childController.signal).then((result) => {
-				children.set(key, result);
-				trace.push({ operation: "run", key, state: result.ok ? "completed" : "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(result.runId ? { runId: result.runId } : {}), ...(!result.ok ? { error: result.output } : {}) });
+			const promise = Promise.resolve().then(() => options.launch(key, { ...params, async: params.async ?? false }, childController.signal)).then((result) => {
+				const normalized = !result.ok && !result.error ? { ...result, error: result.output } : result;
+				children.set(key, normalized);
+				trace.push({ operation: "run", key, state: normalized.ok ? "completed" : "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(normalized.runId ? { runId: normalized.runId } : {}), ...(!normalized.ok ? { error: normalized.error ?? normalized.output } : {}) });
 				traceChanged();
-				if (!result.ok) throw new Error(`Run '${key}' failed: ${result.output}`);
-				return result;
+				return normalized;
 			}, (error: unknown) => {
 				const text = error instanceof Error ? error.message : String(error);
+				const failure: WorkflowScriptChildResult = { key, ok: false, output: text, error: text, artifactPaths: [] };
+				children.set(key, failure);
 				trace.push({ operation: "run", key, state: "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), error: text });
 				traceChanged();
-				throw new Error(`Run '${key}' failed: ${text}`);
+				return failure;
 			});
 			launches.set(key, { fingerprint, promise });
-			respond(promise);
+			respond(deliver(promise));
 		});
 
 		worker.postMessage({ type: "start", script: options.script });

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -602,6 +602,40 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(result.details.workflow?.trace.filter((entry) => entry.state === "completed").map((entry) => entry.key), ["scan", "review"]);
 	});
 
+	it("lets runs.all siblings settle when one child fails", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ exitCode: 1, stderr: "first child failed" });
+		mockPi.onCall({ output: "second child completed" });
+		const executor = makeExecutor([makeAgent("echo")]);
+
+		const result = await executor.execute(
+			"scripted-workflow-settlement",
+			{
+				async: false,
+				workflowScript: `
+					const children = await runs.all([
+						{ key: "first", agent: "echo", task: "First task" },
+						{ key: "second", agent: "echo", task: "Second task" }
+					]);
+					return children.map(({ key, ok, error }) => error === undefined ? { key, ok } : { key, ok, error });
+				`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		assert.equal(mockPi.callCount(), 2);
+		const value = result.details.workflow?.value as Array<{ key: string; ok: boolean; error?: string }>;
+		assert.deepEqual(value.map(({ key }) => key), ["first", "second"]);
+		assert.deepEqual(value.map(({ ok }) => ok).sort(), [false, true]);
+		const failed = value.find(({ ok }) => !ok);
+		const succeeded = value.find(({ ok }) => ok);
+		assert.match(failed?.error ?? "", /first child failed/);
+		assert.equal(succeeded?.error, undefined);
+		assert.deepEqual(result.details.workflow?.trace.filter((entry) => entry.state !== "started").map(({ state }) => state).sort(), ["completed", "failed"]);
+	});
+
 	it("gives parallel workflow children separate managed worktrees and durable handoffs", { skip: !createSubagentExecutor || process.platform === "win32" ? "executor unavailable or worktree paths differ on Windows" : undefined }, async () => {
 		execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
 		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });
@@ -796,6 +830,29 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.isError, true);
 		assert.match(result.content[0]?.text ?? "", /acceptance level "none" requires a reason/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
+	it("rejects invalid verified acceptance before spawning", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([makeAgent("echo")]);
+		const invalidPolicies = [
+			"verified",
+			{ level: "verified" },
+			{ level: "verified", verify: [] },
+		] as const;
+
+		for (const [index, acceptance] of invalidPolicies.entries()) {
+			const result = await executor.execute(
+				`invalid-verified-acceptance-${index}`,
+				{ agent: "echo", task: "Do work", acceptance: acceptance as never },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+
+			assert.equal(result.isError, true);
+			assert.match(result.content[0]?.text ?? "", /(?:verified.*object form|verify.*at least one command)/i);
+		}
 		assert.equal(mockPi.callCount(), 0);
 	});
 

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1049,6 +1049,11 @@ describe("acceptance gates", () => {
 	it("validates invalid disable and verify shapes", () => {
 		assert.deepEqual(validateAcceptanceInput({ level: "none" }), ["acceptance.reason is required when level is none."]);
 		assert.deepEqual(validateAcceptanceInput("none"), ["acceptance level \"none\" requires a reason; use { level: \"none\", reason: \"...\" }."]);
+		assert.deepEqual(validateAcceptanceInput("verified"), ["acceptance level \"verified\" requires object form with at least one verify command."]);
+		for (const input of [{ level: "verified" }, { level: "verified", verify: [] }]) {
+			assert.deepEqual(validateAcceptanceInput(input), ["acceptance.verify must contain at least one command when level is verified."]);
+		}
+		assert.deepEqual(validateAcceptanceInput({ level: "verified", verify: [{ id: "tests", command: "npm test" }] }), []);
 		assert.deepEqual(validateAcceptanceInput({ verify: [{ id: "missing-command" }] }), ["acceptance.verify[0].command is required."]);
 		assert.deepEqual(validateAcceptanceInput({ verify: [{ id: "fractional", command: "npm test", timeoutMs: 1.5 }] }), ["acceptance.verify[0].timeoutMs must be an integer >= 1."]);
 		assert.deepEqual(validateAcceptanceInput(false), []);

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -463,7 +463,7 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		assert.equal(hasAnyOfType(acceptanceSchema, "boolean"), true);
 		const acceptanceStringBranches = anyOfBranches(acceptanceSchema).filter((branch) => branch.type === "string");
 		const acceptanceLevelBranch = acceptanceStringBranches.find((branch) => Array.isArray(branch.enum) && branch.enum.includes("auto"));
-		assert.deepEqual(acceptanceLevelBranch?.enum, ["auto", "attested", "checked", "verified"], "evidence levels end at verified");
+		assert.deepEqual(acceptanceLevelBranch?.enum, ["auto", "attested", "checked"], "verified requires object form with runtime commands");
 		const reviewedRecoveryBranch = acceptanceStringBranches.find((branch) => Array.isArray(branch.enum) && branch.enum.includes("reviewed"));
 		assert.deepEqual(reviewedRecoveryBranch?.enum, ["reviewed"]);
 		assert.equal(reviewedRecoveryBranch?.deprecated, true);
@@ -498,6 +498,7 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 			{ action: "not-a-real-action" },
 			{ agent: "worker", task: "Fix", acceptance: "checked" },
 			{ agent: "worker", task: "Fix", acceptance: "reviewed" },
+			{ agent: "worker", task: "Fix", acceptance: { level: "verified", verify: [{ id: "tests", command: "npm test" }] } },
 			{ agent: "worker", task: "Fix", acceptance: { level: "none", reason: "parent will verify manually" } },
 			{ agent: "worker", task: "Fix", acceptance: { level: "checked", review: false } },
 			{ config: { name: "reviewer", description: "Review things" } },
@@ -511,6 +512,7 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		const invalidValues = [
 			{ skill: 123 },
 			{ agent: "worker", task: "Fix", acceptance: "none" },
+			{ agent: "worker", task: "Fix", acceptance: "verified" },
 			{ skill: [123] },
 			{ output: 123 },
 			{ timeoutMs: 0 },

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -41,6 +41,156 @@ describe("scripted workflow runtime", () => {
 		assert.deepEqual(emitSnapshots, [1]);
 	});
 
+	it("waits for every runs.all child and returns ordinary failures in input order", async () => {
+		let delayedFinished = false;
+		let delayedAborted = false;
+		const result = await runWorkflowScript({
+			script: `
+				const children = await runs.all([
+					{ key: "fails-first", agent: "worker", task: "fail" },
+					{ key: "finishes-later", agent: "worker", task: "finish" }
+				]);
+				return children.map(({ key, ok, error, results }) => error === undefined ? { key, ok, results } : { key, ok, error, results });
+			`,
+			timeoutMs: 2_000,
+			launch(key, _params, signal) {
+				if (key === "fails-first") {
+					return Promise.resolve({
+						key,
+						ok: false,
+						output: "acceptance rejected",
+						artifactPaths: [],
+						results: [{ acceptance: { status: "rejected" } }],
+					});
+				}
+				return new Promise((resolve, reject) => {
+					const timer = setTimeout(() => {
+						delayedFinished = true;
+						resolve({ key, ok: true, output: "completed", artifactPaths: [], results: [] });
+					}, 50);
+					signal.addEventListener("abort", () => {
+						delayedAborted = !delayedFinished;
+						clearTimeout(timer);
+						reject(signal.reason);
+					}, { once: true });
+				});
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		assert.equal(delayedFinished, true);
+		assert.equal(delayedAborted, false);
+		assert.deepEqual(result.value, [
+			{ key: "fails-first", ok: false, error: "acceptance rejected", results: [{ acceptance: { status: "rejected" } }] },
+			{ key: "finishes-later", ok: true, results: [] },
+		]);
+		assert.deepEqual(result.trace.filter((entry) => entry.operation === "run" && entry.state !== "started").map(({ key, state }) => ({ key, state })), [
+			{ key: "fails-first", state: "failed" },
+			{ key: "finishes-later", state: "completed" },
+		]);
+	});
+
+	it("returns runs.all launch errors without aborting successful siblings", async () => {
+		const result = await runWorkflowScript({
+			script: `
+				const children = await runs.all([
+					{ key: "cannot-launch", agent: "missing", task: "fail" },
+					{ key: "still-runs", agent: "worker", task: "finish" }
+				]);
+				return children.map(({ key, ok, error }) => error === undefined ? { key, ok } : { key, ok, error });
+			`,
+			timeoutMs: 2_000,
+			launch(key) {
+				if (key === "cannot-launch") throw new Error("agent is unavailable");
+				return new Promise((resolve) => setTimeout(() => resolve({ key, ok: true, output: "completed", artifactPaths: [], results: [] }), 25));
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		assert.deepEqual(result.value, [
+			{ key: "cannot-launch", ok: false, error: "agent is unavailable" },
+			{ key: "still-runs", ok: true },
+		]);
+		assert.deepEqual(result.children.map(({ key, ok, error }) => error === undefined ? { key, ok } : { key, ok, error }), [
+			{ key: "cannot-launch", ok: false, error: "agent is unavailable" },
+			{ key: "still-runs", ok: true },
+		]);
+	});
+
+	it("keeps runs.run fail-fast for ordinary child failures", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `return await runs.run("fails", { agent: "worker", task: "fail" });`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: false, output: "failed", artifactPaths: [], results: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && /Run 'fails' failed: failed/.test(error.message),
+		);
+	});
+
+	it("validates every runs.all item before launching children", async () => {
+		const malformedScripts = [
+			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, null]);`,
+			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, { key: "bad key", agent: "worker", task: "run" }]);`,
+			`return await runs.all([{ key: "same", agent: "worker", task: "one" }, { key: "same", agent: "worker", task: "two" }]);`,
+			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, { key: "nested", workflowScript: "return null" }]);`,
+			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, { key: "undefined-action", agent: "worker", task: "run", action: undefined }]);`,
+			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, { key: "uncloneable", agent: "worker", task: () => "run" }]);`,
+			`const items = []; items[1] = { key: "valid", agent: "worker", task: "run" }; return await runs.all(items);`,
+		];
+		for (const script of malformedScripts) {
+			let launches = 0;
+			await assert.rejects(
+				runWorkflowScript({
+					script,
+					timeoutMs: 2_000,
+					async launch(key) { launches++; return { key, ok: true, output: "unexpected", artifactPaths: [], results: [] }; },
+					async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				}),
+				(error: unknown) => error instanceof WorkflowScriptError && /runs\.all|Duplicate workflow key/.test(error.message),
+			);
+			assert.equal(launches, 0, script);
+		}
+	});
+
+	it("rejects a runs.all batch incompatible with an earlier key before dispatching the batch", async () => {
+		const launches: string[] = [];
+		await assert.rejects(
+			runWorkflowScript({
+				script: `
+					await runs.run("same", { agent: "worker", task: "one" });
+					return await runs.all([
+						{ key: "valid", agent: "worker", task: "run" },
+						{ key: "same", agent: "worker", task: "two" }
+					]);
+				`,
+				timeoutMs: 2_000,
+				async launch(key) { launches.push(key); return { key, ok: true, output: "ok", artifactPaths: [], results: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && /Duplicate workflow key 'same'/.test(error.message),
+		);
+		assert.deepEqual(launches, ["same"]);
+	});
+
+	it("reports host-side children in launch order", async () => {
+		const result = await runWorkflowScript({
+			script: `return await runs.all([
+				{ key: "slow", agent: "worker", task: "slow" },
+				{ key: "fast", agent: "worker", task: "fast" }
+			]);`,
+			timeoutMs: 2_000,
+			launch(key) {
+				return new Promise((resolve) => setTimeout(() => resolve({ key, ok: true, output: key, artifactPaths: [], results: [] }), key === "slow" ? 30 : 0));
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		assert.deepEqual((result.value as Array<{ key: string }>).map(({ key }) => key), ["slow", "fast"]);
+		assert.deepEqual(result.children.map(({ key }) => key), ["slow", "fast"]);
+	});
+
 	it("omits undefined child result fields before a script returns them", async () => {
 		const result = await runWorkflowScript({
 			script: `return await runs.run("artifact-only", { agent: "worker", task: "write output" });`,


### PR DESCRIPTION
## Summary

- reject scalar `acceptance: "verified"` and commandless verified policies before a child starts
- make `runs.all` validate the full batch before dispatch, then return every child outcome in input order
- keep `runs.run` fail-fast and keep workflow timeout and cancellation behavior unchanged

## Why

A verified policy without runtime commands previously ran the child and failed only during acceptance evaluation. Scalar verified acceptance could never succeed because the scalar form cannot supply commands.

`runs.all` also used fail-fast promise behavior. One failed child rejected the workflow and aborted the shared child controller, which could terminate unrelated siblings. `runs.all` now returns `ok: false` results, including launch errors, so the workflow script decides what is fatal.

## Validation

- focused unit tests: 76 passed
- focused single-execution integration tests: 2 passed
- remaining unit suite, excluding the unchanged Herdr inspector baseline failure: 1,569 passed, 1 skipped
- remaining integration files: 508 passed
- real Pi-session E2E tests: 3 passed
- `npm run typecheck`
- `git diff --check`

The full unfiltered suites have two existing local failures that reproduce on `upstream/main`: six Herdr inspector tests are cancelled because the fake timeout leaves the event loop empty, and one managed-worktree handoff test intermittently sees one of two handoffs under suite-wide load but passes when run alone.
