### PR TITLE
test: isolate mock Pi queues between tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 - Allow direct single-child `worktree: true` launches to use managed isolation without requiring `workflowScript`. Thanks to @nicobailon for #808.
+- Isolated each mock Pi test queue so late child processes cannot consume or lose responses after the next test resets the harness. Thanks to @nicobailon for #810.
 - Preserve successful async completion when project-local artifact or mission files are removed before final bookkeeping by recreating artifact directories and recording missing-mission warnings.
 - Keep active Fleet inspector runs ahead of terminal history, which now sorts by recency instead of failure state so old failures do not look attached to current workflow work. Thanks to @nicobailon for #802.
 - Normalize undefined fields in workflow child results before scripts can return them, preserving artifact-only child output.

--- a/test/support/mock-pi.ts
+++ b/test/support/mock-pi.ts
@@ -69,7 +69,8 @@ function listQueueFiles(queueDir: string, prefix: string): string[] {
 
 export function createMockPi(): MockPi {
 	const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-mock-cli-"));
-	const queueDir = path.join(rootDir, "queue");
+	let queueGeneration = 0;
+	let queueDir = path.join(rootDir, `queue-${queueGeneration}`);
 	const binDir = path.join(rootDir, "bin");
 	const piPackageDir = path.join(rootDir, "pi-package");
 	const cliScriptPath = path.join(piPackageDir, "dist", "cli.mjs");
@@ -144,12 +145,10 @@ export function createMockPi(): MockPi {
 		},
 		reset() {
 			nextSequence = 0;
+			queueGeneration += 1;
+			queueDir = path.join(rootDir, `queue-${queueGeneration}`);
 			ensureDir(queueDir);
-			for (const entry of fs.readdirSync(queueDir)) {
-				try {
-					fs.rmSync(path.join(queueDir, entry), { recursive: true, force: true });
-				} catch {}
-			}
+			if (installed) process.env.MOCK_PI_QUEUE_DIR = queueDir;
 		},
 		callCount() {
 			return listQueueFiles(queueDir, CALL_PREFIX).length;

--- a/test/unit/mock-pi.test.ts
+++ b/test/unit/mock-pi.test.ts
@@ -1,0 +1,22 @@
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import { after, describe, it } from "node:test";
+import { createMockPi } from "../support/mock-pi.ts";
+
+describe("mock Pi queue isolation", () => {
+	const mockPi = createMockPi();
+	after(() => mockPi.uninstall());
+
+	it("keeps the prior queue for children that inherited it before reset", () => {
+		mockPi.install();
+		mockPi.reset();
+		const priorQueue = mockPi.dir;
+		mockPi.onCall({ output: "prior response" });
+
+		mockPi.reset();
+
+		assert.notEqual(mockPi.dir, priorQueue);
+		assert.ok(fs.readdirSync(priorQueue).some((name) => name.startsWith("pending-")));
+		assert.equal(fs.readdirSync(mockPi.dir).length, 0);
+	});
+});


### PR DESCRIPTION
Fixes #810.

Each mock harness reset now switches the parent process to a fresh queue rather than deleting the queue inherited by already-started child processes. This keeps late child responses isolated from the next test.

Validation:
- `node --experimental-strip-types --test test/unit/mock-pi.test.ts`
- `node --experimental-strip-types --test --test-name-pattern="gives parallel workflow children separate managed worktrees and durable handoffs" test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`