### PR TITLE
fix: show workflow lane manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Restore active under-editor subagent status after management calls, so `status` and `list` do not hide running disk-backed work. Thanks to @nicobailon for #816.
 - Allow direct single-child `worktree: true` launches to use managed isolation without requiring `workflowScript`. Thanks to @nicobailon for #808.
 - Isolated each mock Pi test queue so late child processes cannot consume or lose responses after the next test resets the harness. Thanks to @nicobailon for #810.
+- Show a workflow lane manifest with mode and stable lane keys in the launch card instead of only `subagent workflow script`. Thanks to @nicobailon for #813.
 - Reject scalar or commandless verified acceptance before spawning a child; verified policies now require object form with at least one runtime command. Thanks to @ryanbbrown for #807.
 - Let every `runs.all` child settle and return ordered per-child outcomes instead of aborting siblings when one child fails; `runs.run` remains fail-fast. Thanks to @ryanbbrown for #807.
 - Preserve successful async completion when project-local artifact or mission files are removed before final bookkeeping by recreating artifact directories and recording missing-mission warnings.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -76,6 +76,31 @@ import {
 
 export { loadConfig, resolveAsyncByDefault } from "./config.ts";
 
+function workflowLaneKeys(script: string): string[] {
+	const keys: string[] = [];
+	const seen = new Set<string>();
+	const add = (key: string): void => {
+		if (!seen.has(key)) {
+			seen.add(key);
+			keys.push(key);
+		}
+	};
+	const commentsOrWhitespace = String.raw`(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*)*`;
+	const literal = String.raw`(["'])([^"'\r\n]+)\1`;
+	for (const match of script.matchAll(new RegExp(String.raw`\bruns\.run\s*\(\s*${literal}(?=${commentsOrWhitespace}(?:,|\)))`, "g"))) add(match[2]!);
+	for (const match of script.matchAll(new RegExp(String.raw`\bkey\s*:\s*${literal}(?=${commentsOrWhitespace}(?:,|\}))`, "g"))) add(match[2]!);
+	return keys;
+}
+
+function formatWorkflowManifest(script: string, async: unknown, asyncByDefault: boolean, clarify: unknown): string {
+	const keys = workflowLaneKeys(script);
+	const mode = clarify === true || (async ?? asyncByDefault) !== true ? "foreground" : "background";
+	if (keys.length === 0) return `workflow script · ${mode}`;
+	const visibleKeys = keys.slice(0, 4).join(", ");
+	const remainder = keys.length > 4 ? `, +${keys.length - 4}` : "";
+	return `workflow · ${mode} · ${keys.length} lane${keys.length === 1 ? "" : "s"}: ${visibleKeys}${remainder}`;
+}
+
 /**
  * Derive subagent session base directory from parent session file.
  * If parent session is ~/.pi/agent/sessions/abc123.jsonl,
@@ -419,7 +444,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			}
 			if (args.workflowScript)
 				return new Text(
-					`${theme.fg("toolTitle", theme.bold("subagent "))}workflow script`,
+					`${theme.fg("toolTitle", theme.bold("subagent "))}${formatWorkflowManifest(args.workflowScript, args.async, asyncByDefault, args.clarify)}`,
 					0,
 					0,
 				);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -118,6 +118,60 @@ function workflowLaneKeys(script: string): string[] {
 		return { end: script.length };
 	};
 
+	const collectRunsAllKeys = (start: number): number => {
+		let index = skipTrivia(start);
+		if (script[index] !== "(") return start;
+		index = skipTrivia(index + 1);
+		if (script[index] !== "[") return start;
+		let arrayDepth = 1;
+		let objectDepth = 0;
+		let directChildObject = false;
+		let expectingElement = true;
+		for (index += 1; index < script.length; index += 1) {
+			index = skipTrivia(index);
+			const literal = readLiteral(index);
+			if (literal) {
+				index = literal.end - 1;
+				continue;
+			}
+			if (script[index] === "[") {
+				arrayDepth += 1;
+				expectingElement = false;
+				continue;
+			}
+			if (script[index] === "]") {
+				arrayDepth -= 1;
+				if (arrayDepth === 0) return index + 1;
+				continue;
+			}
+			if (script[index] === "{") {
+				objectDepth += 1;
+				if (objectDepth === 1) directChildObject = arrayDepth === 1 && expectingElement;
+				expectingElement = false;
+				continue;
+			}
+			if (script[index] === "}") {
+				objectDepth -= 1;
+				if (objectDepth === 0) directChildObject = false;
+				continue;
+			}
+			if (script[index] === "," && arrayDepth === 1 && objectDepth === 0) {
+				expectingElement = true;
+				continue;
+			}
+			if (directChildObject && objectDepth === 1 && !isIdentifier(script[index - 1]) && script.startsWith("key", index) && !isIdentifier(script[index + 3])) {
+				const colon = skipTrivia(index + 3);
+				const key = script[colon] === ":" ? readLiteral(skipTrivia(colon + 1)) : undefined;
+				if (key) {
+					const next = skipTrivia(key.end);
+					if (key.key !== undefined && (script[next] === "," || script[next] === "}")) add(key.key);
+					index = key.end - 1;
+				}
+			}
+		}
+		return index;
+	};
+
 	for (let index = 0; index < script.length;) {
 		index = skipTrivia(index);
 		const literal = readLiteral(index);
@@ -135,22 +189,17 @@ function workflowLaneKeys(script: string): string[] {
 				continue;
 			}
 		}
-		if (!isIdentifier(script[index - 1]) && script.startsWith("key", index) && !isIdentifier(script[index + 3])) {
-			const colon = skipTrivia(index + 3);
-			const key = script[colon] === ":" ? readLiteral(skipTrivia(colon + 1)) : undefined;
-			if (key) {
-				const next = skipTrivia(key.end);
-				if (key.key !== undefined && (script[next] === "," || script[next] === "}")) add(key.key);
-				index = key.end;
-				continue;
-			}
+		if (!isIdentifier(script[index - 1]) && script.startsWith("runs.all", index) && !isIdentifier(script[index + 8])) {
+			index = collectRunsAllKeys(index + 8);
+			continue;
 		}
 		index += 1;
 	}
 	return keys;
 }
 
-function formatWorkflowManifest(script: string, async: unknown): string {
+function formatWorkflowManifest(script: string, async: unknown, clarify: unknown): string {
+	if (clarify === true) return "workflow script · rejected: clarify UI unsupported";
 	const keys = workflowLaneKeys(script);
 	// The workflow executor starts background work unless callers pass async:false.
 	const mode = async === false ? "foreground" : "background";
@@ -503,7 +552,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			}
 			if (args.workflowScript)
 				return new Text(
-					`${theme.fg("toolTitle", theme.bold("subagent "))}${formatWorkflowManifest(args.workflowScript, args.async)}`,
+					`${theme.fg("toolTitle", theme.bold("subagent "))}${formatWorkflowManifest(args.workflowScript, args.async, args.clarify)}`,
 					0,
 					0,
 				);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -85,16 +85,75 @@ function workflowLaneKeys(script: string): string[] {
 			keys.push(key);
 		}
 	};
-	const commentsOrWhitespace = String.raw`(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*)*`;
-	const literal = String.raw`(["'])([^"'\r\n]+)\1`;
-	for (const match of script.matchAll(new RegExp(String.raw`\bruns\.run\s*\(\s*${literal}(?=${commentsOrWhitespace}(?:,|\)))`, "g"))) add(match[2]!);
-	for (const match of script.matchAll(new RegExp(String.raw`\bkey\s*:\s*${literal}(?=${commentsOrWhitespace}(?:,|\}))`, "g"))) add(match[2]!);
+	const isIdentifier = (char: string | undefined): boolean => char !== undefined && /[\w$]/.test(char);
+	const skipTrivia = (start: number): number => {
+		let index = start;
+		while (index < script.length) {
+			if (/\s/.test(script[index]!)) index += 1;
+			else if (script.startsWith("//", index)) {
+				const end = script.indexOf("\n", index + 2);
+				index = end === -1 ? script.length : end + 1;
+			} else if (script.startsWith("/*", index)) {
+				const end = script.indexOf("*/", index + 2);
+				index = end === -1 ? script.length : end + 2;
+			} else break;
+		}
+		return index;
+	};
+	const readLiteral = (start: number): { key?: string; end: number } | undefined => {
+		const quote = script[start];
+		if (quote !== "'" && quote !== '"' && quote !== "`") return undefined;
+		let index = start + 1;
+		let dynamicTemplate = false;
+		while (index < script.length) {
+			if (script[index] === "\\") {
+				index += 2;
+				continue;
+			}
+			if (quote === "`" && script.startsWith("${", index)) dynamicTemplate = true;
+			if (script[index] === quote) return { key: dynamicTemplate ? undefined : script.slice(start + 1, index), end: index + 1 };
+			if (quote !== "`" && /[\r\n]/.test(script[index]!)) return { end: index + 1 };
+			index += 1;
+		}
+		return { end: script.length };
+	};
+
+	for (let index = 0; index < script.length;) {
+		index = skipTrivia(index);
+		const literal = readLiteral(index);
+		if (literal) {
+			index = literal.end;
+			continue;
+		}
+		if (!isIdentifier(script[index - 1]) && script.startsWith("runs.run", index) && !isIdentifier(script[index + 8])) {
+			const open = skipTrivia(index + 8);
+			const key = script[open] === "(" ? readLiteral(skipTrivia(open + 1)) : undefined;
+			if (key) {
+				const next = skipTrivia(key.end);
+				if (key.key !== undefined && (script[next] === "," || script[next] === ")")) add(key.key);
+				index = key.end;
+				continue;
+			}
+		}
+		if (!isIdentifier(script[index - 1]) && script.startsWith("key", index) && !isIdentifier(script[index + 3])) {
+			const colon = skipTrivia(index + 3);
+			const key = script[colon] === ":" ? readLiteral(skipTrivia(colon + 1)) : undefined;
+			if (key) {
+				const next = skipTrivia(key.end);
+				if (key.key !== undefined && (script[next] === "," || script[next] === "}")) add(key.key);
+				index = key.end;
+				continue;
+			}
+		}
+		index += 1;
+	}
 	return keys;
 }
 
-function formatWorkflowManifest(script: string, async: unknown, asyncByDefault: boolean, clarify: unknown): string {
+function formatWorkflowManifest(script: string, async: unknown): string {
 	const keys = workflowLaneKeys(script);
-	const mode = clarify === true || (async ?? asyncByDefault) !== true ? "foreground" : "background";
+	// The workflow executor starts background work unless callers pass async:false.
+	const mode = async === false ? "foreground" : "background";
 	if (keys.length === 0) return `workflow script · ${mode}`;
 	const visibleKeys = keys.slice(0, 4).join(", ");
 	const remainder = keys.length > 4 ? `, +${keys.length - 4}` : "";
@@ -444,7 +503,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			}
 			if (args.workflowScript)
 				return new Text(
-					`${theme.fg("toolTitle", theme.bold("subagent "))}${formatWorkflowManifest(args.workflowScript, args.async, asyncByDefault, args.clarify)}`,
+					`${theme.fg("toolTitle", theme.bold("subagent "))}${formatWorkflowManifest(args.workflowScript, args.async)}`,
 					0,
 					0,
 				);

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -93,13 +93,15 @@ describe("subagent extension child mode", () => {
 			const templateWorkflow = registeredTool.renderCall({ workflowScript: "return runs.run(\`template\`, {agent:'worker'});", async: false }, theme).text;
 			const commentedWorkflow = registeredTool.renderCall({ workflowScript: "// runs.run('ignored', {agent:'worker'})\nconst note = \"key: 'also-ignored'\"; return runs.run('real', {agent:'worker'});" }, theme).text;
 			const dynamicKeyWorkflow = registeredTool.renderCall({ workflowScript: "return runs.all([{key: 'review-' + item, agent: 'reviewer'}]);" }, theme).text;
+			const ordinaryKeyWorkflow = registeredTool.renderCall({ workflowScript: "const config = {key: 'secret'}; return runs.all([{agent: 'reviewer', config: {key: 'nested'}, key: 'review'}]);" }, theme).text;
 			if (!single.includes("worker [async]")) throw new Error("expected async single badge, got " + single);
 			if (!workflow.includes("background · 3 lanes: scan, correctness, tests")) throw new Error("expected workflow manifest, got " + workflow);
 			if (!foregroundWorkflow.includes("foreground · 1 lane: publish")) throw new Error("expected foreground workflow manifest, got " + foregroundWorkflow);
-			if (!clarifiedWorkflow.includes("background · 1 lane: clarify")) throw new Error("expected workflow executor mode despite clarify, got " + clarifiedWorkflow);
+			if (!clarifiedWorkflow.includes("rejected: clarify UI unsupported")) throw new Error("expected clarified workflow rejection, got " + clarifiedWorkflow);
 			if (!templateWorkflow.includes("foreground · 1 lane: template")) throw new Error("expected static template lane, got " + templateWorkflow);
 			if (!commentedWorkflow.includes("background · 1 lane: real")) throw new Error("expected lexical lane filtering, got " + commentedWorkflow);
 			if (!dynamicKeyWorkflow.includes("workflow script · background")) throw new Error("expected dynamic key fallback, got " + dynamicKeyWorkflow);
+			if (!ordinaryKeyWorkflow.includes("background · 1 lane: review") || ordinaryKeyWorkflow.includes("secret") || ordinaryKeyWorkflow.includes("nested")) throw new Error("expected only runs.all child key, got " + ordinaryKeyWorkflow);
 		`;
 		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" });
 	});

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -85,9 +85,13 @@ describe("subagent extension child mode", () => {
 			if (!registeredTool) throw new Error("tool not registered");
 			const theme = { fg(_name, text) { return text; }, bold(text) { return text; } };
 			const single = registeredTool.renderCall({ agent: "worker", async: true }, theme).text;
-			const workflow = registeredTool.renderCall({ workflowScript: "return null" }, theme).text;
+			const workflow = registeredTool.renderCall({
+				workflowScript: "const scan = await runs.run('scan', {agent:'worker'}); return runs.all([{key:'correctness',agent:'reviewer'},{key:'tests',agent:'reviewer'}]);",
+			}, theme).text;
+			const foregroundWorkflow = registeredTool.renderCall({ workflowScript: "return runs.run('publish', {agent:'worker'});", async: false }, theme).text;
 			if (!single.includes("worker [async]")) throw new Error("expected async single badge, got " + single);
-			if (!workflow.includes("workflow script")) throw new Error("expected workflow label, got " + workflow);
+			if (!workflow.includes("background · 3 lanes: scan, correctness, tests")) throw new Error("expected workflow manifest, got " + workflow);
+			if (!foregroundWorkflow.includes("foreground · 1 lane: publish")) throw new Error("expected foreground workflow manifest, got " + foregroundWorkflow);
 		`;
 		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" });
 	});

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -90,22 +90,26 @@ describe("subagent extension child mode", () => {
 			}, theme).text;
 			const foregroundWorkflow = registeredTool.renderCall({ workflowScript: "return runs.run('publish', {agent:'worker'});", async: false }, theme).text;
 			const clarifiedWorkflow = registeredTool.renderCall({ workflowScript: "return runs.run('clarify', {agent:'worker'});", async: true, clarify: true }, theme).text;
+			const templateWorkflow = registeredTool.renderCall({ workflowScript: "return runs.run(\`template\`, {agent:'worker'});", async: false }, theme).text;
+			const commentedWorkflow = registeredTool.renderCall({ workflowScript: "// runs.run('ignored', {agent:'worker'})\nconst note = \"key: 'also-ignored'\"; return runs.run('real', {agent:'worker'});" }, theme).text;
 			const dynamicKeyWorkflow = registeredTool.renderCall({ workflowScript: "return runs.all([{key: 'review-' + item, agent: 'reviewer'}]);" }, theme).text;
 			if (!single.includes("worker [async]")) throw new Error("expected async single badge, got " + single);
 			if (!workflow.includes("background · 3 lanes: scan, correctness, tests")) throw new Error("expected workflow manifest, got " + workflow);
 			if (!foregroundWorkflow.includes("foreground · 1 lane: publish")) throw new Error("expected foreground workflow manifest, got " + foregroundWorkflow);
-			if (!clarifiedWorkflow.includes("foreground · 1 lane: clarify")) throw new Error("expected clarified foreground workflow, got " + clarifiedWorkflow);
+			if (!clarifiedWorkflow.includes("background · 1 lane: clarify")) throw new Error("expected workflow executor mode despite clarify, got " + clarifiedWorkflow);
+			if (!templateWorkflow.includes("foreground · 1 lane: template")) throw new Error("expected static template lane, got " + templateWorkflow);
+			if (!commentedWorkflow.includes("background · 1 lane: real")) throw new Error("expected lexical lane filtering, got " + commentedWorkflow);
 			if (!dynamicKeyWorkflow.includes("workflow script · background")) throw new Error("expected dynamic key fallback, got " + dynamicKeyWorkflow);
 		`;
 		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" });
 	});
 
-	it("uses the configured async default and comment-aware literal lane keys in workflow manifests", () => {
+	it("shows omitted workflow async as background even when asyncByDefault is false", () => {
 		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-workflow-manifest-config-"));
 		try {
 			const configDir = path.join(agentDir, "extensions", "subagent");
 			fs.mkdirSync(configDir, { recursive: true });
-			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ asyncByDefault: false }), "utf-8");
+			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ asyncByDefault: false, forceTopLevelAsync: true }), "utf-8");
 			const script = String.raw`
 				import registerSubagentExtension from "./index.ts";
 				const events = { on() { return () => {}; }, emit() {} };
@@ -119,7 +123,12 @@ describe("subagent extension child mode", () => {
 				const result = registeredTool.renderCall({
 					workflowScript: "return runs.run('scan' /* stable lane */, {agent:'worker'});",
 				}, theme).text;
-				if (!result.includes("foreground · 1 lane: scan")) throw new Error("expected configured foreground manifest, got " + result);
+				const explicitForeground = registeredTool.renderCall({
+					workflowScript: "return runs.run('publish', {agent:'worker'});",
+					async: false,
+				}, theme).text;
+				if (!result.includes("background · 1 lane: scan")) throw new Error("expected workflow executor background manifest, got " + result);
+				if (!explicitForeground.includes("foreground · 1 lane: publish")) throw new Error("expected workflow executor foreground manifest, got " + explicitForeground);
 			`;
 			const env = parentToolEnv();
 			env.PI_CODING_AGENT_DIR = agentDir;

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -89,11 +89,44 @@ describe("subagent extension child mode", () => {
 				workflowScript: "const scan = await runs.run('scan', {agent:'worker'}); return runs.all([{key:'correctness',agent:'reviewer'},{key:'tests',agent:'reviewer'}]);",
 			}, theme).text;
 			const foregroundWorkflow = registeredTool.renderCall({ workflowScript: "return runs.run('publish', {agent:'worker'});", async: false }, theme).text;
+			const clarifiedWorkflow = registeredTool.renderCall({ workflowScript: "return runs.run('clarify', {agent:'worker'});", async: true, clarify: true }, theme).text;
+			const dynamicKeyWorkflow = registeredTool.renderCall({ workflowScript: "return runs.all([{key: 'review-' + item, agent: 'reviewer'}]);" }, theme).text;
 			if (!single.includes("worker [async]")) throw new Error("expected async single badge, got " + single);
 			if (!workflow.includes("background · 3 lanes: scan, correctness, tests")) throw new Error("expected workflow manifest, got " + workflow);
 			if (!foregroundWorkflow.includes("foreground · 1 lane: publish")) throw new Error("expected foreground workflow manifest, got " + foregroundWorkflow);
+			if (!clarifiedWorkflow.includes("foreground · 1 lane: clarify")) throw new Error("expected clarified foreground workflow, got " + clarifiedWorkflow);
+			if (!dynamicKeyWorkflow.includes("workflow script · background")) throw new Error("expected dynamic key fallback, got " + dynamicKeyWorkflow);
 		`;
 		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" });
+	});
+
+	it("uses the configured async default and comment-aware literal lane keys in workflow manifests", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-workflow-manifest-config-"));
+		try {
+			const configDir = path.join(agentDir, "extensions", "subagent");
+			fs.mkdirSync(configDir, { recursive: true });
+			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ asyncByDefault: false }), "utf-8");
+			const script = String.raw`
+				import registerSubagentExtension from "./index.ts";
+				const events = { on() { return () => {}; }, emit() {} };
+				let registeredTool;
+				const fakePi = new Proxy({
+					events, registerTool(tool) { if (tool.name === "subagent") registeredTool = tool; },
+					registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {}, sendMessage() {}, getSessionName() {},
+				}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+				registerSubagentExtension(fakePi);
+				const theme = { fg(_name, text) { return text; }, bold(text) { return text; } };
+				const result = registeredTool.renderCall({
+					workflowScript: "return runs.run('scan' /* stable lane */, {agent:'worker'});",
+				}, theme).text;
+				if (!result.includes("foreground · 1 lane: scan")) throw new Error("expected configured foreground manifest, got " + result);
+			`;
+			const env = parentToolEnv();
+			env.PI_CODING_AGENT_DIR = agentDir;
+			execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
 	});
 
 	it("does not animate foreground results on a timer", () => {


### PR DESCRIPTION
Closes #813.

The workflow launch card now shows whether the run is foreground or background plus stable `runs.run` / `runs.all` lane keys. The raw workflow script remains available through the existing expandable tool details.

Validation:
- `node --experimental-strip-types --test test/unit/index-child-registration.test.ts`
- `npm run typecheck`
- `git diff --check`