### PR TITLE
fix: restore async status after management calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 - Keep the under-editor async status widget visible by default while FleetView is enabled, including after active runs restore following reload. Thanks to @nicobailon for #804.
+- Restore active under-editor subagent status after management calls, so `status` and `list` do not hide running disk-backed work. Thanks to @nicobailon for #816.
 - Allow direct single-child `worktree: true` launches to use managed isolation without requiring `workflowScript`. Thanks to @nicobailon for #808.
 - Isolated each mock Pi test queue so late child processes cannot consume or lose responses after the next test resets the harness. Thanks to @nicobailon for #810.
 - Preserve successful async completion when project-local artifact or mission files are removed before final bookkeeping by recreating artifact directories and recording missing-mission warnings.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -517,6 +517,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		if (event.toolName !== "subagent") return;
 		if (!ctx.hasUI) return;
 		state.lastUiContext = ctx;
+		restoreActiveJobs(ctx);
 		fleetStatus?.setContext(ctx);
 		fleetStatus?.refresh();
 		if (state.asyncJobs.size > 0) {

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -281,6 +281,49 @@ describe("subagent extension child mode", () => {
 		}
 	});
 
+	it("restores disk-backed active status after a management tool result", () => {
+		const script = String.raw`
+			import * as fs from "node:fs";
+			import * as path from "node:path";
+			import registerSubagentExtension from "./index.ts";
+			import { DIRS } from "./src/shared/types.ts";
+			const eventHandlers = new Map();
+			const handlers = new Map();
+			const events = { on(channel, handler) { eventHandlers.set(channel, handler); return () => {}; }, emit() {} };
+			const widgets = [];
+			const fakePi = new Proxy({
+				events,
+				on(channel, handler) { handlers.set(channel, handler); },
+				registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+				sendMessage() {}, getSessionName() { return undefined; },
+			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+			const runId = "management-refresh-" + crypto.randomUUID();
+			const sessionId = "session-" + runId;
+			const ctx = {
+				cwd: process.cwd(), hasUI: true,
+				ui: { setWidget(key, value) { widgets.push({ key, value }); }, requestRender() {}, theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } } },
+				sessionManager: { getSessionId() { return sessionId; }, getSessionFile() { return null; }, getEntries() { return []; } },
+				modelRegistry: { getAvailable() { return []; } },
+			};
+			const asyncDir = path.join(DIRS.async, runId);
+			fs.rmSync(asyncDir, { recursive: true, force: true });
+			registerSubagentExtension(fakePi);
+			handlers.get("session_start")({}, ctx);
+			widgets.length = 0;
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId, sessionId, mode: "workflow", state: "running",
+				startedAt: Date.now(), lastUpdate: Date.now(), cwd: process.cwd(), pid: process.pid,
+			}), "utf-8");
+			handlers.get("tool_result")({ toolName: "subagent" }, ctx);
+			const fleetWidgets = widgets.filter((entry) => entry.key === "subagent-fleet-status");
+			if (!fleetWidgets.some((entry) => typeof entry.value === "function")) throw new Error("management result did not restore active fleet status: " + JSON.stringify(fleetWidgets));
+			handlers.get("session_shutdown")();
+			fs.rmSync(asyncDir, { recursive: true, force: true });
+		`;
+		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" });
+	});
+
 	it("disposes pending completion notifications on session shutdown", () => {
 		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-notify-shutdown-"));
 		const configDir = path.join(agentDir, "extensions", "subagent");


### PR DESCRIPTION
Fixes #816.

Restore durable active async runs before refreshing the under-editor status after a UI `subagent` result. This keeps a running disk-backed workflow visible after management calls such as `status` or `list`.

Validation:
- `node --experimental-strip-types --test test/unit/index-child-registration.test.ts`
- `npm run typecheck`
- `git diff --check`