### PR TITLE
feat: stabilize inline display and completion delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added opt-in `inlineToolDisplay: "summary"` for a stable one-row inline subagent result while FleetView remains the live progress surface.
 - Added an observational `pi-subagents/external-runs` provider API for visible terminal work, without taking process ownership. Thanks to @nicobailon for #795.
 - Added durable non-blocking `subagent_wait({ id, nonBlocking: true })` subscriptions that return immediately, preserve exact run identity, remain visible in status, and wake the originating interactive session on terminal, attention, reconciliation-failure, or timeout outcomes.
 - Added narrow public entrypoints for extension consumers to access async stop requests, intercom session targeting, launch tool-plan resolution, and fork-task helpers without deep imports. Thanks to @shaneconner for #794.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Added opt-in `inlineToolDisplay: "summary"` for a stable one-row inline subagent result while FleetView remains the live progress surface.
+- Added opt-in `inlineToolDisplay: "summary"` for a stable one-row inline subagent result while FleetView remains the live progress surface. Thanks to @ryanbbrown for #805.
 - Added an observational `pi-subagents/external-runs` provider API for visible terminal work, without taking process ownership. Thanks to @nicobailon for #795.
 - Added durable non-blocking `subagent_wait({ id, nonBlocking: true })` subscriptions that return immediately, preserve exact run identity, remain visible in status, and wake the originating interactive session on terminal, attention, reconciliation-failure, or timeout outcomes.
 - Added narrow public entrypoints for extension consumers to access async stop requests, intercom session targeting, launch tool-plan resolution, and fork-task helpers without deep imports. Thanks to @shaneconner for #794.
@@ -40,6 +40,7 @@
 - Show a workflow lane manifest with mode and stable lane keys in the launch card instead of only `subagent workflow script`. Thanks to @nicobailon for #813.
 - Reject scalar or commandless verified acceptance before spawning a child; verified policies now require object form with at least one runtime command. Thanks to @ryanbbrown for #807.
 - Let every `runs.all` child settle and return ordered per-child outcomes instead of aborting siblings when one child fails; `runs.run` remains fail-fast. Thanks to @ryanbbrown for #807.
+- Wake the originating parent session after a hidden successful background completion while preserving explicit `triggerTurn: false` delivery. Thanks to @ryanbbrown for #805.
 - Preserve successful async completion when project-local artifact or mission files are removed before final bookkeeping by recreating artifact directories and recording missing-mission warnings.
 - Keep active Fleet inspector runs ahead of terminal history, which now sorts by recency instead of failure state so old failures do not look attached to current workflow work. Thanks to @nicobailon for #802.
 - Normalize undefined fields in workflow child results before scripts can return them, preserving artifact-only child output.

--- a/README.md
+++ b/README.md
@@ -1246,6 +1246,14 @@ Controls the parent-facing `subagent` tool description registered at startup. `f
 
 `custom` reads `subagent-tool-description.md` from the project config directory, then from `~/.pi/agent/subagent-tool-description.md`. Missing, empty, unreadable, or oversized custom files fall back to the full description. Custom templates may use `{{fullDescription}}`, `{{compactDescription}}`, `{{safetyGuidance}}`, `{{agentDir}}`, and `{{projectConfigDir}}`; the safety guidance is always present so custom prose cannot remove the runtime guardrails. Restart Pi after changing the mode or custom file.
 
+### `inlineToolDisplay`
+
+```json
+{ "inlineToolDisplay": "summary" }
+```
+
+Controls the `subagent` tool result shown inline in chat. The default, `"rich"`, shows live child activity and expands to detailed output. `"summary"` keeps the inline result at one stable row for running, completed, failed, stopped, and paused runs; it does not animate, show elapsed time, preview child output, or change when Pi's expand key is pressed. FleetView remains available for live progress and detailed inspection.
+
 ### `asyncByDefault`
 
 ```json

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -24,7 +24,7 @@ import { ensureAccessibleDir } from "../shared/accessible-dir.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
-import { clearLegacyResultAnimationTimer, renderSubagentResult } from "../tui/render.ts";
+import { clearLegacyResultAnimationTimer, renderSubagentResult, renderSubagentSummary } from "../tui/render.ts";
 import { openSubagentFleet } from "../tui/fleet.ts";
 import { SubagentFleetStatus, resolveFleetViewPlacement } from "../tui/fleet-status.ts";
 import { SubagentParams } from "./schemas.ts";
@@ -331,6 +331,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const fleetViewEnabled = config.fleetView !== false;
 	const fleetViewPlacement = resolveFleetViewPlacement(config.fleetViewPlacement);
 	const asyncWidgetEnabled = config.asyncWidget !== false;
+	const summaryInlineToolDisplay = config.inlineToolDisplay === "summary";
 	const tempArtifactsDir = getArtifactsDir(null);
 	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
 
@@ -566,7 +567,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 		renderResult(result, options, theme, context) {
 			clearLegacyResultAnimationTimer(context);
-			return renderSubagentResult(result, options, theme);
+			return summaryInlineToolDisplay
+				? renderSubagentSummary(result, options, theme)
+				: renderSubagentResult(result, options, theme);
 		},
 
 	};

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -178,7 +178,7 @@ function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage">, items: PendingCom
 				content,
 				display,
 			},
-			{ triggerTurn: display && items.some((item) => item.triggerTurn) },
+			{ triggerTurn: items.some((item) => item.triggerTurn) },
 		);
 		return true;
 	} catch {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1712,6 +1712,7 @@ export interface ProactiveSkillSubagentsConfig {
 }
 
 export type ToolDescriptionMode = "full" | "compact" | "custom";
+export type InlineToolDisplay = "rich" | "summary";
 
 export interface ScheduledRunsConfig {
 	enabled?: boolean;
@@ -1731,6 +1732,8 @@ export interface ExtensionConfig {
 	asyncWidget?: boolean;
 	/** Tool description variant registered for the parent-facing subagent tool. Defaults to full. */
 	toolDescriptionMode?: ToolDescriptionMode;
+	/** Inline chat rendering for the subagent tool. Defaults to rich. */
+	inlineToolDisplay?: InlineToolDisplay;
 	forceTopLevelAsync?: boolean;
 	waitTool?: WaitToolConfig;
 	defaultSessionDir?: string;

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1573,7 +1573,7 @@ export function renderSubagentSummary(
 	const failed = result.isError === true
 		|| results.some((entry) => !entry.stopped && !entry.interrupted && !entry.detached && entry.exitCode !== 0 && entry.progress?.status !== "running")
 		|| Boolean(details && workflowGraphHasStatus(details, ["failed"]));
-	const state = running ? "running" : stopped ? "stopped" : failed ? "failed" : paused ? "paused" : "completed";
+	const state = running ? "running" : failed ? "failed" : stopped ? "stopped" : paused ? "paused" : "completed";
 	const glyph = state === "running"
 		? theme.fg("accent", STATIC_RUNNING_GLYPH)
 		: state === "completed"

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1562,6 +1562,7 @@ export function renderSubagentSummary(
 	const details = result.details;
 	const results = details?.results ?? [];
 	const running = options.isPartial === true
+		|| Boolean(details?.asyncId && details.mode !== "management")
 		|| details?.progress?.some((progress) => progress.status === "running")
 		|| results.some((entry) => entry.progress?.status === "running")
 		|| Boolean(details && workflowGraphHasStatus(details, ["running"]));
@@ -1570,9 +1571,9 @@ export function renderSubagentSummary(
 	const paused = results.some((entry) => (entry.interrupted || entry.detached) && entry.progress?.status !== "running")
 		|| Boolean(details && workflowGraphHasStatus(details, ["paused", "detached"]));
 	const failed = result.isError === true
-		|| results.some((entry) => !entry.stopped && entry.exitCode !== 0 && entry.progress?.status !== "running")
+		|| results.some((entry) => !entry.stopped && !entry.interrupted && !entry.detached && entry.exitCode !== 0 && entry.progress?.status !== "running")
 		|| Boolean(details && workflowGraphHasStatus(details, ["failed"]));
-	const state = running ? "running" : stopped ? "stopped" : paused ? "paused" : failed ? "failed" : "completed";
+	const state = running ? "running" : stopped ? "stopped" : failed ? "failed" : paused ? "paused" : "completed";
 	const glyph = state === "running"
 		? theme.fg("accent", STATIC_RUNNING_GLYPH)
 		: state === "completed"

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1554,6 +1554,42 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 	return c;
 }
 
+export function renderSubagentSummary(
+	result: AgentToolResult<Details>,
+	options: { isPartial?: boolean },
+	theme: Theme,
+): Component {
+	const details = result.details;
+	const results = details?.results ?? [];
+	const running = options.isPartial === true
+		|| details?.progress?.some((progress) => progress.status === "running")
+		|| results.some((entry) => entry.progress?.status === "running")
+		|| Boolean(details && workflowGraphHasStatus(details, ["running"]));
+	const stopped = results.some((entry) => entry.stopped && entry.progress?.status !== "running")
+		|| Boolean(details && workflowGraphHasStatus(details, ["stopped"]));
+	const paused = results.some((entry) => (entry.interrupted || entry.detached) && entry.progress?.status !== "running")
+		|| Boolean(details && workflowGraphHasStatus(details, ["paused", "detached"]));
+	const failed = result.isError === true
+		|| results.some((entry) => !entry.stopped && entry.exitCode !== 0 && entry.progress?.status !== "running")
+		|| Boolean(details && workflowGraphHasStatus(details, ["failed"]));
+	const state = running ? "running" : stopped ? "stopped" : paused ? "paused" : failed ? "failed" : "completed";
+	const glyph = state === "running"
+		? theme.fg("accent", STATIC_RUNNING_GLYPH)
+		: state === "completed"
+			? theme.fg("success", "✓")
+			: state === "failed"
+				? theme.fg("error", "✗")
+				: theme.fg("warning", "■");
+	const label = details?.mode === "single" && results.length === 1
+		? results[0]?.agent || "subagent"
+		: details?.mode || "subagent";
+	return new Text(
+		truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold(label))} ${theme.fg("dim", "·")} ${theme.fg(state === "failed" ? "error" : state === "completed" ? "success" : state === "running" ? "accent" : "warning", state)}`, getTermWidth() - 4),
+		0,
+		0,
+	);
+}
+
 /**
  * Render a subagent result
  */

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -246,6 +246,10 @@ describe("subagent extension child mode", () => {
 					content: [{ type: "text", text: "aggregate output that must not appear" }],
 					details: { mode: "parallel", results: [{ ...base, agent: "paused", exitCode: 1, interrupted: true }, { ...base, agent: "failed", exitCode: 1, stopped: false }] },
 				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				const failedWithStopped = registeredTool.renderResult({
+					content: [{ type: "text", text: "aggregate output that must not appear" }],
+					details: { mode: "parallel", results: [{ ...base, agent: "stopped", exitCode: 1, stopped: true }, { ...base, agent: "failed", exitCode: 1, stopped: false }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
 				if (running.length !== 1 || running[0] !== "● delegate · running") throw new Error("unexpected running summary: " + JSON.stringify(running));
 				if (asyncSingle.length !== 1 || asyncSingle[0] !== "● single · running") throw new Error("unexpected async single summary: " + JSON.stringify(asyncSingle));
 				if (asyncChain.length !== 1 || asyncChain[0] !== "● chain · running") throw new Error("unexpected async chain summary: " + JSON.stringify(asyncChain));
@@ -253,7 +257,8 @@ describe("subagent extension child mode", () => {
 				if (stopped.length !== 1 || stopped[0] !== "■ delegate · stopped") throw new Error("unexpected stopped summary: " + JSON.stringify(stopped));
 				if (paused.length !== 1 || paused[0] !== "■ delegate · paused") throw new Error("unexpected paused summary: " + JSON.stringify(paused));
 				if (failed.length !== 1 || failed[0] !== "✗ delegate · failed") throw new Error("unexpected failed summary: " + JSON.stringify(failed));
-				if (failedWithPaused.length !== 1 || failedWithPaused[0] !== "✗ parallel · failed") throw new Error("unexpected aggregate summary: " + JSON.stringify(failedWithPaused));
+				if (failedWithPaused.length !== 1 || failedWithPaused[0] !== "✗ parallel · failed") throw new Error("unexpected paused aggregate summary: " + JSON.stringify(failedWithPaused));
+				if (failedWithStopped.length !== 1 || failedWithStopped[0] !== "✗ parallel · failed") throw new Error("unexpected stopped aggregate summary: " + JSON.stringify(failedWithStopped));
 			`;
 			const env = parentToolEnv();
 			env.PI_CODING_AGENT_DIR = agentDir;

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -218,6 +218,14 @@ describe("subagent extension child mode", () => {
 					content: [{ type: "text", text: "partial output that must not appear" }],
 					details: { mode: "single", results: [{ ...base, exitCode: 0, progress: { status: "running", index: 0, agent: "delegate", toolCount: 2, tokens: 300, durationMs: 20_000 } }] },
 				}, { expanded: false, isPartial: true }, theme, { state: {} }).render(120);
+				const asyncSingle = registeredTool.renderResult({
+					content: [{ type: "text", text: "Async: delegate [single-run]" }],
+					details: { mode: "single", runId: "single-run", asyncId: "single-run", asyncDir: "/tmp/single-run", results: [] },
+				}, { expanded: false }, theme, { state: {} }).render(120);
+				const asyncChain = registeredTool.renderResult({
+					content: [{ type: "text", text: "Async chain [chain-run]" }],
+					details: { mode: "chain", runId: "chain-run", asyncId: "chain-run", asyncDir: "/tmp/chain-run", results: [] },
+				}, { expanded: false }, theme, { state: {} }).render(120);
 				const completed = registeredTool.renderResult({
 					content: [{ type: "text", text: "completed output that must not appear" }],
 					details: { mode: "single", results: [{ ...base, exitCode: 0 }] },
@@ -234,11 +242,18 @@ describe("subagent extension child mode", () => {
 					content: [{ type: "text", text: "failed output that must not appear" }],
 					details: { mode: "single", results: [{ ...base, exitCode: 1, stopped: false }] },
 				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				const failedWithPaused = registeredTool.renderResult({
+					content: [{ type: "text", text: "aggregate output that must not appear" }],
+					details: { mode: "parallel", results: [{ ...base, agent: "paused", exitCode: 1, interrupted: true }, { ...base, agent: "failed", exitCode: 1, stopped: false }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
 				if (running.length !== 1 || running[0] !== "● delegate · running") throw new Error("unexpected running summary: " + JSON.stringify(running));
+				if (asyncSingle.length !== 1 || asyncSingle[0] !== "● single · running") throw new Error("unexpected async single summary: " + JSON.stringify(asyncSingle));
+				if (asyncChain.length !== 1 || asyncChain[0] !== "● chain · running") throw new Error("unexpected async chain summary: " + JSON.stringify(asyncChain));
 				if (completed.length !== 1 || completed[0] !== "✓ delegate · completed") throw new Error("unexpected completed summary: " + JSON.stringify(completed));
 				if (stopped.length !== 1 || stopped[0] !== "■ delegate · stopped") throw new Error("unexpected stopped summary: " + JSON.stringify(stopped));
 				if (paused.length !== 1 || paused[0] !== "■ delegate · paused") throw new Error("unexpected paused summary: " + JSON.stringify(paused));
 				if (failed.length !== 1 || failed[0] !== "✗ delegate · failed") throw new Error("unexpected failed summary: " + JSON.stringify(failed));
+				if (failedWithPaused.length !== 1 || failedWithPaused[0] !== "✗ parallel · failed") throw new Error("unexpected aggregate summary: " + JSON.stringify(failedWithPaused));
 			`;
 			const env = parentToolEnv();
 			env.PI_CODING_AGENT_DIR = agentDir;

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -191,7 +191,7 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
-	it("keeps summary inline tool display to one stable row while running, completed, and stopped", () => {
+	it("keeps summary inline tool display to one stable row for every supported state", () => {
 		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-inline-display-config-"));
 		try {
 			const configDir = path.join(agentDir, "extensions", "subagent");
@@ -226,9 +226,19 @@ describe("subagent extension child mode", () => {
 					content: [{ type: "text", text: "cancelled output that must not appear" }],
 					details: { mode: "single", results: [{ ...base, exitCode: 1, stopped: true, error: "Cancelled by user" }] },
 				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				const paused = registeredTool.renderResult({
+					content: [{ type: "text", text: "paused output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 1, interrupted: true }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				const failed = registeredTool.renderResult({
+					content: [{ type: "text", text: "failed output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 1, stopped: false }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
 				if (running.length !== 1 || running[0] !== "● delegate · running") throw new Error("unexpected running summary: " + JSON.stringify(running));
 				if (completed.length !== 1 || completed[0] !== "✓ delegate · completed") throw new Error("unexpected completed summary: " + JSON.stringify(completed));
 				if (stopped.length !== 1 || stopped[0] !== "■ delegate · stopped") throw new Error("unexpected stopped summary: " + JSON.stringify(stopped));
+				if (paused.length !== 1 || paused[0] !== "■ delegate · paused") throw new Error("unexpected paused summary: " + JSON.stringify(paused));
+				if (failed.length !== 1 || failed[0] !== "✗ delegate · failed") throw new Error("unexpected failed summary: " + JSON.stringify(failed));
 			`;
 			const env = parentToolEnv();
 			env.PI_CODING_AGENT_DIR = agentDir;

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -191,6 +191,53 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
+	it("keeps summary inline tool display to one stable row while running, completed, and stopped", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-inline-display-config-"));
+		try {
+			const configDir = path.join(agentDir, "extensions", "subagent");
+			fs.mkdirSync(configDir, { recursive: true });
+			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ inlineToolDisplay: "summary" }), "utf-8");
+
+			const script = String.raw`
+				import registerSubagentExtension from "./index.ts";
+				const events = { on() { return () => {}; }, emit() {} };
+				let registeredTool;
+				const fakePi = new Proxy({
+					events,
+					registerTool(tool) { if (tool.name === "subagent") registeredTool = tool; },
+					registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {}, sendMessage() {}, getSessionName() {},
+				}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+				registerSubagentExtension(fakePi);
+				if (!registeredTool) throw new Error("tool not registered");
+				const theme = { fg(_name, text) { return text; }, bold(text) { return text; } };
+				const base = {
+					agent: "delegate", task: "quiet", messages: [],
+					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+				};
+				const running = registeredTool.renderResult({
+					content: [{ type: "text", text: "partial output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 0, progress: { status: "running", index: 0, agent: "delegate", toolCount: 2, tokens: 300, durationMs: 20_000 } }] },
+				}, { expanded: false, isPartial: true }, theme, { state: {} }).render(120);
+				const completed = registeredTool.renderResult({
+					content: [{ type: "text", text: "completed output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 0 }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				const stopped = registeredTool.renderResult({
+					content: [{ type: "text", text: "cancelled output that must not appear" }],
+					details: { mode: "single", results: [{ ...base, exitCode: 1, stopped: true, error: "Cancelled by user" }] },
+				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				if (running.length !== 1 || running[0] !== "● delegate · running") throw new Error("unexpected running summary: " + JSON.stringify(running));
+				if (completed.length !== 1 || completed[0] !== "✓ delegate · completed") throw new Error("unexpected completed summary: " + JSON.stringify(completed));
+				if (stopped.length !== 1 || stopped[0] !== "■ delegate · stopped") throw new Error("unexpected stopped summary: " + JSON.stringify(stopped));
+			`;
+			const env = parentToolEnv();
+			env.PI_CODING_AGENT_DIR = agentDir;
+			execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
 	it("registers only subagent_wait and honors waitTool disabled config", () => {
 		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-wait-tool-config-"));
 		try {

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -110,7 +110,7 @@ function completionResult(overrides: Record<string, unknown> = {}) {
 }
 
 describe("registerSubagentNotify", () => {
-	it("uses a fallback summary when a background completion is empty", () => {
+	it("keeps a successful background completion hidden while waking the originating session", () => {
 		const { events, sent } = createPi();
 
 		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
@@ -130,7 +130,7 @@ describe("registerSubagentNotify", () => {
 				content: "Background task completed: **worker**\n\n(no output)",
 				display: false,
 			},
-			options: { triggerTurn: false },
+			options: { triggerTurn: true },
 		});
 	});
 
@@ -138,6 +138,12 @@ describe("registerSubagentNotify", () => {
 		const { notifier, sent } = createPi("session-a");
 		assert.equal(await notifier.deliver(completionResult({ id: "direct-accepted" })), true);
 		assert.equal(sent.length, 1);
+	});
+
+	it("does not wake the session when background delivery explicitly disables triggerTurn", async () => {
+		const { notifier, sent } = createPi("session-a");
+		assert.equal(await notifier.deliver(completionResult({ id: "direct-silent", triggerTurn: false })), true);
+		assert.deepEqual(sent[0]!.options, { triggerTurn: false });
 	});
 
 	it("suppresses local delivery after an acknowledged grouped intercom relay", async () => {
@@ -219,7 +225,7 @@ describe("registerSubagentNotify", () => {
 				content: `Background task completed: **worker** (2/3)\n\n${summary}`,
 				display: false,
 			},
-			options: { triggerTurn: false },
+			options: { triggerTurn: true },
 		});
 	});
 
@@ -243,7 +249,7 @@ describe("registerSubagentNotify", () => {
 				content: "Background task completed: **worker**\n\nDone\n\nSession file: /tmp/session.jsonl",
 				display: false,
 			},
-			options: { triggerTurn: false },
+			options: { triggerTurn: true },
 		}]);
 	});
 
@@ -332,7 +338,7 @@ describe("registerSubagentNotify", () => {
 			content,
 			display: false,
 		});
-		assert.deepEqual(sent[0]!.options, { triggerTurn: false });
+		assert.deepEqual(sent[0]!.options, { triggerTurn: true });
 	});
 
 	it("ignores successes from other sessions instead of grouping them", () => {


### PR DESCRIPTION
## Summary

- Replaces contributor PR #805 on current `main` after #811 and #817 landed.
- Adds opt-in `inlineToolDisplay: "summary"` for a static one-row tool renderer, while retaining rich rendering by default and FleetView for detail.
- Wakes the parent after hidden successful background completion, while preserving explicit `triggerTurn: false`.

Preserves @ryanbbrown / #805 credit in `CHANGELOG.md`.

## Validation

- `node --experimental-strip-types --test test/unit/notify.test.ts`
- `node --experimental-strip-types --test test/unit/index-child-registration.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`