### PR TITLE
fix(tui): preserve actionable tool errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Preserve actionable multi-line subagent tool errors in collapsed result rendering. Thanks to @xz-dev for #824.
 - Keep the under-editor async status widget visible by default while FleetView is enabled, including after active runs restore following reload. Thanks to @nicobailon for #804.
 - Restore active under-editor subagent status after management calls, so `status` and `list` do not hide running disk-backed work. Thanks to @nicobailon for #816.
 - Allow direct single-child `worktree: true` launches to use managed isolation without requiring `workflowScript`. Thanks to @nicobailon for #808.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -433,7 +433,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 		renderResult(result, options, theme, context) {
 			clearLegacyResultAnimationTimer(context);
-			return renderSubagentResult(result, options, theme);
+			return renderSubagentResult({ ...result, isError: context.isError }, options, theme);
 		},
 
 	};

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -92,6 +92,53 @@ describe("subagent extension child mode", () => {
 		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" });
 	});
 
+	it("keeps registered tool errors actionable while successful results stay collapsed", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./index.ts";
+			const events = { on() { return () => {}; }, emit() {} };
+			let registeredTool;
+			const fakePi = new Proxy({
+				events,
+				registerTool(tool) { if (tool.name === "subagent") registeredTool = tool; },
+				registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+				sendMessage() {}, getSessionName() { return undefined; },
+			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+			registerSubagentExtension(fakePi);
+			if (!registeredTool) throw new Error("tool not registered");
+
+			const theme = { fg(_name, text) { return text; }, bold(text) { return text; } };
+			const render = (text, isError) => registeredTool.renderResult({
+				content: [{ type: "text", text }],
+				details: { mode: "management", results: [] },
+			}, { expanded: false }, theme, {
+				isError,
+				state: {},
+			}).render(120).join("\n");
+
+			const error = render("Agent configuration is invalid.\nSet tools to an array.\nRetry the subagent call.", true);
+			if (!error.includes("Set tools to an array.")) throw new Error("error remediation was hidden: " + error);
+			if (!error.includes("Retry the subagent call.")) throw new Error("error retry guidance was hidden: " + error);
+			if (error.includes("3 lines")) throw new Error("error was collapsed: " + error);
+
+			const success = render("Managed agents:\n- reviewer\n- writer", false);
+			if (!success.includes("Managed agents: · 3 lines")) throw new Error("success summary was not collapsed: " + success);
+			if (success.includes("- reviewer") || success.includes("- writer")) throw new Error("success details were not collapsed: " + success);
+		`;
+
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-strip-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" },
+		);
+	});
+
 	it("does not animate foreground results on a timer", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./index.ts";


### PR DESCRIPTION
## Summary

- forward Pi's authoritative `context.isError` flag into the custom subagent result renderer
- keep multi-line actionable tool errors visible instead of applying the normal collapsed success summary
- preserve the existing collapsed behavior for successful structured results

## Root cause

Pi intentionally provides error state through the custom renderer context. The result passed to `renderResult` does not retain that flag, so `renderSubagentResult` could mistake an error for a normal result and collapse it.

## Validation

- registered-tool boundary regression: 15 passed
- integration suite: 678 passed
- E2E suite: 3 passed
- `npm run typecheck`
- `git diff --check`

The full unit command still has the same 12 environment/project-discovery failures as unmodified `main`; the changed registration test passes.
