### PR TITLE
fix(tui): show model thinking consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Scheduled subagent runs are now enabled by default; set `{ "scheduledRuns": { "enabled": false } }` to opt out.
 
 ### Fixed
+- Display model and thinking metadata consistently in expanded multi-result and async Fleet views. Thanks to @xz-dev for #825.
 - Keep the under-editor async status widget visible by default while FleetView is enabled, including after active runs restore following reload. Thanks to @nicobailon for #804.
 - Restore active under-editor subagent status after management calls, so `status` and `list` do not hide running disk-backed work. Thanks to @nicobailon for #816.
 - Allow direct single-child `worktree: true` launches to use managed isolation without requiring `workflowScript`. Thanks to @nicobailon for #808.

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -406,7 +406,7 @@ function itemStats(item: FleetItem): string[] {
 		tokens = item.child.tokens;
 		tools = item.child.toolCount;
 	} else {
-		model = item.step?.model;
+		model = formatModelThinking(item.step?.model, item.step?.thinking) || undefined;
 		tokens = item.step?.tokens?.total ?? (item.index === undefined ? item.run.totalTokens?.total : undefined);
 		tools = item.step?.toolCount ?? (item.index === undefined ? item.run.toolCount : undefined);
 		const terminalRun = item.state !== "queued" && item.state !== "running" && item.state !== "pending";

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1839,7 +1839,7 @@ export function renderSubagentResult(
 					? theme.fg("warning", "warning")
 					: theme.fg("success", "done");
 		const stats = rProg ? ` | ${rProg.toolCount} tools, ${formatDuration(rProg.durationMs)}` : "";
-		const modelDisplay = modelThinkingBadge(theme, r.model);
+		const modelDisplay = modelThinkingBadge(theme, r.model ?? rProg?.model, r.thinking ?? rProg?.thinking);
 		const stepLabel = entry.rowLabel ?? resultRowLabel(multiLabel, i, stepNumber);
 		const contextBadge = contextModeBadge(theme, r.context);
 		const stepHeader = rRunning

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -495,6 +495,23 @@ describe("renderSubagentResult fork indicator", () => {
 		}, { expanded: false }, theme).render(160).join("\n");
 		assert.match(multi, /Agent 1\/2: scout \(claude-haiku-4-5 · thinking low\)/);
 		assert.match(multi, /Agent 2\/2: worker \(gpt-5-mini\)/);
+
+		const expanded = renderSubagentResult!({
+			content: [{ type: "text", text: "done" }],
+			details: {
+				mode: "parallel",
+				totalSteps: 1,
+				results: [{
+					agent: "reviewer",
+					task: "review",
+					exitCode: 0,
+					messages: [],
+					usage: emptyUsage,
+					progressSummary: { toolCount: 1, tokens: 42, durationMs: 3_000, model: "openai-codex/gpt-5.5", thinking: "high" },
+				}],
+			},
+		}, { expanded: true }, theme).render(160).join("\n");
+		assert.match(expanded, /reviewer \(gpt-5\.5 · thinking high\)/);
 	});
 
 	it("keeps running compact result output stable when progress is unchanged", async () => {

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -35,6 +35,8 @@ function writeAsyncRun(root: string, input: {
 	lastUpdate?: number;
 	agents?: string[];
 	contexts?: Array<"fresh" | "fork">;
+	models?: string[];
+	thinking?: string[];
 	output?: string;
 	transcript?: Array<Record<string, unknown>>;
 }): string {
@@ -55,6 +57,8 @@ function writeAsyncRun(root: string, input: {
 		steps: agents.map((agent, index) => ({
 			agent,
 			...(input.contexts?.[index] ? { context: input.contexts[index] } : {}),
+			...(input.models?.[index] ? { model: input.models[index] } : {}),
+			...(input.thinking?.[index] ? { thinking: input.thinking[index] } : {}),
 			status: input.state === "complete" ? "complete" : input.state === "failed" ? "failed" : index === 0 ? "running" : "pending",
 			startedAt: 100,
 			...(index === 0 ? { sessionFile: path.join(asyncDir, `${agent}.jsonl`), ...(transcriptPath ? { transcriptPath } : {}) } : {}),
@@ -170,6 +174,32 @@ describe("native subagent fleet", () => {
 			assert.equal(snapshot.error, undefined);
 			assert.equal(snapshot.items.length, 20);
 			assert.ok(!snapshot.items.some((item) => item.runId === "old-invalid"));
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("shows async model and thinking metadata in the structured header", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-model-thinking-"));
+		try {
+			writeAsyncRun(root, {
+				id: "model-thinking",
+				state: "running",
+				models: ["openai-codex/gpt-5.5"],
+				thinking: ["high"],
+			});
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 32, columns: 100 }, requestRender() {} } as never,
+				theme as never,
+				stateForTest(),
+				() => {},
+				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 60_000, markdownTheme },
+			);
+			try {
+				assert.ok(component.render(100).some((line) => line.includes("gpt-5.5 · thinking high")));
+			} finally {
+				component.dispose();
+			}
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

- show effective thinking metadata in expanded multi-result rows
- format async Fleet model/thinking metadata through the same helper used by foreground rows

## Scope

This remains an intentionally small display-only fix: two production lines plus focused regression coverage. It does not change model resolution, fallback behavior, protocol fields, or the existing provider-name display policy.

Related context: #72 and the earlier stale #133 established that requested/runtime model display accuracy is a valid UI concern. This PR only fixes the two current rendering inconsistencies on latest `main`.

## Validation

- focused expanded-result suite: 28 passed
- focused async Fleet model/thinking regression: 1 passed
- integration suite: 678 passed
- E2E suite: 3 passed
- `npm run typecheck`
- `git diff --check`

The full unit command still has the same 12 environment/project-discovery failures as unmodified `main`; the changed-surface regressions pass.
