### PR TITLE
fix(tui): sanitize Fleet transcript display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 ### Fixed
 - Kept durable schedule timers and completion ownership isolated per project, recorded elapsed overlaps without queueing an immediate rerun, rejected symlink-backed schedule paths, and made the deferred mission contract explicit. Thanks to @nicobailon for #815.
 - Preserve actionable multi-line subagent tool errors in collapsed result rendering. Thanks to @xz-dev for #824.
+- Sanitize Fleet transcript content and warnings before terminal display while preserving normal Unicode and formatting. Thanks to @xz-dev for #823.
 - Keep the under-editor async status widget visible by default while FleetView is enabled, including after active runs restore following reload. Thanks to @nicobailon for #804.
 - Restore active under-editor subagent status after management calls, so `status` and `list` do not hide running disk-backed work. Thanks to @nicobailon for #816.
 - Allow direct single-child `worktree: true` launches to use managed isolation without requiring `workflowScript`. Thanks to @nicobailon for #808.

--- a/src/tui/fleet-transcript.ts
+++ b/src/tui/fleet-transcript.ts
@@ -70,7 +70,7 @@ function sanitizeJsonDisplayValue(value: unknown): { value: unknown; changed: bo
 	}
 	if (value && typeof value === "object") {
 		let changed = false;
-		const sanitized: Record<string, unknown> = {};
+		const sanitized: Record<string, unknown> = Object.create(null);
 		for (const [key, nested] of Object.entries(value)) {
 			const safeKey = safeDisplayText(key);
 			const safeValue = sanitizeJsonDisplayValue(nested);

--- a/src/tui/fleet-transcript.ts
+++ b/src/tui/fleet-transcript.ts
@@ -7,6 +7,89 @@ const DEFAULT_MAX_RECORDS = 240;
 const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
 const MAX_MESSAGE_CHARS = 64 * 1024;
 const TOOL_PREVIEW_LINES = 7;
+const BINARY_CONTENT_PLACEHOLDER = "[binary content omitted for safe display]";
+
+function isUnsafeDisplayCodePoint(codePoint: number): boolean {
+	const terminalControl = (codePoint <= 0x1f && codePoint !== 0x09 && codePoint !== 0x0a)
+		|| (codePoint >= 0x7f && codePoint <= 0x9f);
+	const bidiControl = codePoint === 0x061c
+		|| codePoint === 0x200e
+		|| codePoint === 0x200f
+		|| (codePoint >= 0x202a && codePoint <= 0x202e)
+		|| (codePoint >= 0x2066 && codePoint <= 0x2069);
+	const privateUse = (codePoint >= 0xe000 && codePoint <= 0xf8ff)
+		|| (codePoint >= 0xf0000 && codePoint <= 0xffffd)
+		|| (codePoint >= 0x100000 && codePoint <= 0x10fffd);
+	const invalidScalar = codePoint >= 0xd800 && codePoint <= 0xdfff;
+	const nonCharacter = (codePoint >= 0xfdd0 && codePoint <= 0xfdef)
+		|| (codePoint & 0xffff) === 0xfffe
+		|| (codePoint & 0xffff) === 0xffff;
+	return terminalControl || bidiControl || privateUse || invalidScalar || nonCharacter;
+}
+
+function looksLikeBinaryContent(text: string): boolean {
+	if (text.includes("\0")) return true;
+	let suspiciousControls = 0;
+	let replacementCharacters = 0;
+	let codePoints = 0;
+	for (const character of text) {
+		codePoints++;
+		const codePoint = character.codePointAt(0) ?? 0;
+		if ((codePoint <= 0x08) || (codePoint >= 0x0e && codePoint <= 0x1f)) suspiciousControls++;
+		if (codePoint === 0xfffd) replacementCharacters++;
+	}
+	if (codePoints === 0) return false;
+	return (suspiciousControls >= 4 && suspiciousControls / codePoints >= 0.1)
+		|| (replacementCharacters >= 3 && replacementCharacters / codePoints >= 0.1);
+}
+
+function safeDisplayText(text: string): string {
+	const normalized = text.replace(/\r\n/g, "\n");
+	if (looksLikeBinaryContent(normalized)) return BINARY_CONTENT_PLACEHOLDER;
+	let safe = "";
+	for (const character of normalized) {
+		const codePoint = character.codePointAt(0) ?? 0;
+		safe += isUnsafeDisplayCodePoint(codePoint)
+			? `[U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}]`
+			: character;
+	}
+	return safe;
+}
+
+function sanitizeJsonDisplayValue(value: unknown): { value: unknown; changed: boolean } {
+	if (typeof value === "string") {
+		const safe = safeDisplayText(value);
+		return { value: safe, changed: safe !== value };
+	}
+	if (Array.isArray(value)) {
+		const sanitized = value.map(sanitizeJsonDisplayValue);
+		return {
+			value: sanitized.map((entry) => entry.value),
+			changed: sanitized.some((entry) => entry.changed),
+		};
+	}
+	if (value && typeof value === "object") {
+		let changed = false;
+		const sanitized: Record<string, unknown> = {};
+		for (const [key, nested] of Object.entries(value)) {
+			const safeKey = safeDisplayText(key);
+			const safeValue = sanitizeJsonDisplayValue(nested);
+			sanitized[safeKey] = safeValue.value;
+			changed ||= safeKey !== key || safeValue.changed;
+		}
+		return { value: changed ? sanitized : value, changed };
+	}
+	return { value, changed: false };
+}
+
+function safeToolArgsPayload(payload: string): string {
+	try {
+		const sanitized = sanitizeJsonDisplayValue(JSON.parse(payload));
+		return sanitized.changed ? JSON.stringify(sanitized.value) : payload;
+	} catch {
+		return safeDisplayText(payload);
+	}
+}
 
 type Theme = ExtensionContext["ui"]["theme"];
 
@@ -142,6 +225,27 @@ function clipMessage(text: string): string {
 	return `${text.slice(0, MAX_MESSAGE_CHARS)}\n\n… message truncated`;
 }
 
+function safeTranscriptEvent(event: FleetTranscriptEvent): FleetTranscriptEvent {
+	if (event.kind === "assistant") {
+		return {
+			...event,
+			text: safeDisplayText(event.text),
+			...(event.model ? { model: safeDisplayText(event.model) } : {}),
+		};
+	}
+	if (event.kind === "user" || event.kind === "notice") {
+		return { ...event, text: safeDisplayText(event.text) };
+	}
+	return {
+		...event,
+		name: safeDisplayText(event.name),
+		...(event.args !== undefined ? { args: safeDisplayText(event.args) } : {}),
+		...(event.argsPayload !== undefined ? { argsPayload: safeToolArgsPayload(event.argsPayload) } : {}),
+		...(event.output !== undefined ? { output: safeDisplayText(event.output) } : {}),
+		...(event.error !== undefined ? { error: safeDisplayText(event.error) } : {}),
+	};
+}
+
 function findTool(
 	events: FleetTranscriptEvent[],
 	toolCallId: string | undefined,
@@ -274,13 +378,13 @@ function parseTranscriptLines(lines: string[], conversationStarted = false): { e
 	for (const event of events) {
 		if (event.kind === "tool") delete (event as MutableToolEvent).resultSeen;
 	}
-	return { events, malformed, explicitTruncation };
+	return { events: events.map(safeTranscriptEvent), malformed, explicitTruncation };
 }
 
 export function readFleetTranscript(filePath: string, options: FleetTranscriptReadOptions): FleetTranscript {
 	const validated = validateTranscriptPath(filePath, options.trustedRoots);
 	if (!validated.resolvedPath) {
-		return { path: filePath, events: [], truncated: false, ...(validated.warning ? { warning: validated.warning } : {}) };
+		return { path: filePath, events: [], truncated: false, ...(validated.warning ? { warning: safeDisplayText(validated.warning) } : {}) };
 	}
 	const maxRecords = Math.max(1, options.maxRecords ?? DEFAULT_MAX_RECORDS);
 	const tail = readTailLines(validated.resolvedPath, Math.max(1024, options.maxBytes ?? DEFAULT_MAX_BYTES));
@@ -295,7 +399,7 @@ export function readFleetTranscript(filePath: string, options: FleetTranscriptRe
 		path: filePath,
 		events: parsed.events,
 		truncated: tail.truncated || tail.lines.length > maxRecords || parsed.explicitTruncation,
-		...(warnings.length ? { warning: warnings.join(" ") } : {}),
+		...(warnings.length ? { warning: safeDisplayText(warnings.join(" ")) } : {}),
 	};
 }
 
@@ -404,12 +508,13 @@ export function renderFleetTranscript(
 	const lines: string[] = [];
 	if (transcript.truncated) lines.push(bounded(theme.fg("dim", "↑ Earlier activity omitted"), width));
 	if (transcript.warning) {
-		for (const line of renderWrapped(transcript.warning, Math.max(1, width - 2))) {
+		for (const line of renderWrapped(safeDisplayText(transcript.warning), Math.max(1, width - 2))) {
 			lines.push(bounded(`${theme.fg("warning", "!")} ${theme.fg("warning", line)}`, width));
 		}
 	}
 
-	for (const event of transcript.events) {
+	for (const rawEvent of transcript.events) {
+		const event = safeTranscriptEvent(rawEvent);
 		if (event.kind === "tool") {
 			if (options.expandedTools && (event.output || event.argsPayload || event.error)) {
 				lines.push(...renderExpandedTool(event, width, theme));

--- a/src/tui/fleet-transcript.ts
+++ b/src/tui/fleet-transcript.ts
@@ -85,7 +85,7 @@ function sanitizeJsonDisplayValue(value: unknown): { value: unknown; changed: bo
 function safeToolArgsPayload(payload: string): string {
 	try {
 		const sanitized = sanitizeJsonDisplayValue(JSON.parse(payload));
-		return sanitized.changed ? JSON.stringify(sanitized.value) : payload;
+		return sanitized.changed ? JSON.stringify(sanitized.value) : safeDisplayText(payload);
 	} catch {
 		return safeDisplayText(payload);
 	}

--- a/test/unit/fleet-transcript.test.ts
+++ b/test/unit/fleet-transcript.test.ts
@@ -175,16 +175,20 @@ describe("Fleet inspector structured transcript", () => {
 		try {
 			const safePayload = '{\r\n\t"path": "src/tui/fleet.ts",\r\n\t"lines": [1, 2]\r\n}';
 			const unsafePayload = '{\n  "value": "\\u001b"\n}';
+			const protoPayload = '{"nested":{"__proto__":"\\u001b"}}';
 			const transcriptPath = writeTranscript(root, [
 				{ recordType: "tool_start", toolName: "safe", argsPayload: safePayload },
 				{ recordType: "tool_start", toolName: "unsafe", argsPayload: unsafePayload },
+				{ recordType: "tool_start", toolName: "proto", argsPayload: protoPayload },
 			]);
 			const transcript = readFleetTranscript(transcriptPath, { trustedRoots: [root] });
 			const tools = transcript.events.filter((event) => event.kind === "tool");
 			assert.equal(tools[0]?.kind, "tool");
 			assert.equal(tools[1]?.kind, "tool");
+			assert.equal(tools[2]?.kind, "tool");
 			if (tools[0]?.kind === "tool") assert.equal(tools[0].argsPayload, safePayload);
 			if (tools[1]?.kind === "tool") assert.equal(tools[1].argsPayload, '{"value":"[U+001B]"}');
+			if (tools[2]?.kind === "tool") assert.equal(tools[2].argsPayload, '{"nested":{"__proto__":"[U+001B]"}}');
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/fleet-transcript.test.ts
+++ b/test/unit/fleet-transcript.test.ts
@@ -174,10 +174,12 @@ describe("Fleet inspector structured transcript", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-args-payload-"));
 		try {
 			const safePayload = '{\r\n\t"path": "src/tui/fleet.ts",\r\n\t"lines": [1, 2]\r\n}';
+			const standaloneCarriageReturnPayload = '{\r"safe": true\r}';
 			const unsafePayload = '{\n  "value": "\\u001b"\n}';
 			const protoPayload = '{"nested":{"__proto__":"\\u001b"}}';
 			const transcriptPath = writeTranscript(root, [
 				{ recordType: "tool_start", toolName: "safe", argsPayload: safePayload },
+				{ recordType: "tool_start", toolName: "standalone-cr", argsPayload: standaloneCarriageReturnPayload },
 				{ recordType: "tool_start", toolName: "unsafe", argsPayload: unsafePayload },
 				{ recordType: "tool_start", toolName: "proto", argsPayload: protoPayload },
 			]);
@@ -186,9 +188,11 @@ describe("Fleet inspector structured transcript", () => {
 			assert.equal(tools[0]?.kind, "tool");
 			assert.equal(tools[1]?.kind, "tool");
 			assert.equal(tools[2]?.kind, "tool");
-			if (tools[0]?.kind === "tool") assert.equal(tools[0].argsPayload, safePayload);
-			if (tools[1]?.kind === "tool") assert.equal(tools[1].argsPayload, '{"value":"[U+001B]"}');
-			if (tools[2]?.kind === "tool") assert.equal(tools[2].argsPayload, '{"nested":{"__proto__":"[U+001B]"}}');
+			assert.equal(tools[3]?.kind, "tool");
+			if (tools[0]?.kind === "tool") assert.equal(tools[0].argsPayload, safePayload.replace(/\r\n/g, "\n"));
+			if (tools[1]?.kind === "tool") assert.equal(tools[1].argsPayload, '{[U+000D]"safe": true[U+000D]}');
+			if (tools[2]?.kind === "tool") assert.equal(tools[2].argsPayload, '{"value":"[U+001B]"}');
+			if (tools[3]?.kind === "tool") assert.equal(tools[3].argsPayload, '{"nested":{"__proto__":"[U+001B]"}}');
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/fleet-transcript.test.ts
+++ b/test/unit/fleet-transcript.test.ts
@@ -127,8 +127,108 @@ describe("Fleet inspector structured transcript", () => {
 			}],
 		};
 		const rendered = renderFleetTranscript(transcript, 24, theme as never, markdownTheme, { expandedTools: true });
+		assert.doesNotMatch(rendered.join("\n"), /\u001b/u);
+		assert.ok(rendered.some((line) => line.includes("U+001B")));
 		for (const line of rendered) {
 			assert.ok(visibleWidth(line) <= 24, `line exceeded width: ${JSON.stringify(line)}`);
+		}
+	});
+
+	it("escapes unsafe transcript code points across messages, notices, and tool fields", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-unsafe-transcript-"));
+		try {
+			const unsafe = "escape:\u001b carriage:\r bidi:\u202e private:\ue000 invalid:\ud800";
+			const transcriptPath = writeTranscript(root, [
+				{ recordType: "message", role: "assistant", text: `**safe Markdown**\n${unsafe}` },
+				{ recordType: "message", role: "user", text: `supervisor ${unsafe}` },
+				{ recordType: "stderr", text: `notice ${unsafe}` },
+				{ recordType: "tool_start", toolName: "custom", argsPreview: `preview ${unsafe}`, argsPayload: JSON.stringify({ value: unsafe }) },
+				{ recordType: "message", role: "toolResult", toolName: "custom", text: `output ${unsafe}`, isError: false },
+				{ recordType: "tool_start", toolName: "failing", argsPreview: "failure" },
+				{ recordType: "message", role: "toolResult", toolName: "failing", text: `error ${unsafe}`, isError: true },
+			]);
+
+			const transcript = readFleetTranscript(transcriptPath, { trustedRoots: [root] });
+			const serialized = JSON.stringify(transcript.events);
+			assert.doesNotMatch(serialized, /[\u001b\r\u202e\ue000\ud800]/u);
+			assert.match(serialized, /U\+001B/);
+			assert.match(serialized, /U\+000D/);
+			assert.match(serialized, /U\+202E/);
+			assert.match(serialized, /U\+E000/);
+			assert.match(serialized, /U\+D800/);
+
+			const compact = renderFleetTranscript(transcript, 44, theme as never, markdownTheme);
+			assert.ok(compact.some((line) => line.includes("preview escape:[U+001B]")));
+			const rendered = renderFleetTranscript(transcript, 44, theme as never, markdownTheme, { expandedTools: true });
+			assert.ok(rendered.some((line) => line.includes("safe Markdown")));
+			assert.ok(rendered.some((line) => line.includes("output escape:[U+001B]")));
+			assert.ok(rendered.some((line) => line.includes("error escape:[U+001B]")));
+			assert.doesNotMatch(rendered.join("\n"), /[\u001b\u202e\ue000\ud800]/u);
+			for (const line of [...compact, ...rendered]) assert.ok(visibleWidth(line) <= 44, `line exceeded width: ${JSON.stringify(line)}`);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves safe tool argument JSON formatting while sanitizing decoded values", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-args-payload-"));
+		try {
+			const safePayload = '{\r\n\t"path": "src/tui/fleet.ts",\r\n\t"lines": [1, 2]\r\n}';
+			const unsafePayload = '{\n  "value": "\\u001b"\n}';
+			const transcriptPath = writeTranscript(root, [
+				{ recordType: "tool_start", toolName: "safe", argsPayload: safePayload },
+				{ recordType: "tool_start", toolName: "unsafe", argsPayload: unsafePayload },
+			]);
+			const transcript = readFleetTranscript(transcriptPath, { trustedRoots: [root] });
+			const tools = transcript.events.filter((event) => event.kind === "tool");
+			assert.equal(tools[0]?.kind, "tool");
+			assert.equal(tools[1]?.kind, "tool");
+			if (tools[0]?.kind === "tool") assert.equal(tools[0].argsPayload, safePayload);
+			if (tools[1]?.kind === "tool") assert.equal(tools[1].argsPayload, '{"value":"[U+001B]"}');
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("replaces obvious binary transcript content with a warning placeholder", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-binary-transcript-"));
+		try {
+			const binary = "PNG\u0000\u0001\u0002payload";
+			const transcriptPath = writeTranscript(root, [
+				{ recordType: "message", role: "assistant", text: binary },
+				{ recordType: "tool_start", toolName: "custom", argsPreview: binary, argsPayload: JSON.stringify({ data: binary }) },
+				{ recordType: "message", role: "toolResult", toolName: "custom", text: binary, isError: false },
+			]);
+
+			const transcript = readFleetTranscript(transcriptPath, { trustedRoots: [root] });
+			const serialized = JSON.stringify(transcript.events);
+			assert.doesNotMatch(serialized, /[\u0000-\u0002]/u);
+			assert.match(serialized, /binary content omitted/i);
+
+			const rendered = renderFleetTranscript(transcript, 36, theme as never, markdownTheme, { expandedTools: true });
+			assert.ok(rendered.some((line) => /binary content omitted/i.test(line)));
+			for (const line of rendered) assert.ok(visibleWidth(line) <= 36, `line exceeded width: ${JSON.stringify(line)}`);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves normal Unicode, newlines, tabs, Markdown, code highlighting, and width", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-unicode-transcript-"));
+		try {
+			const text = "## Résumé 世界 👩🏽‍💻\r\n\r\n```ts\r\nconst café = \"☕\";\r\n```\r\n\tindented";
+			const transcriptPath = writeTranscript(root, [{ recordType: "message", role: "assistant", text }]);
+			const transcript = readFleetTranscript(transcriptPath, { trustedRoots: [root] });
+			assert.equal(transcript.events[0]?.kind, "assistant");
+			if (transcript.events[0]?.kind === "assistant") assert.equal(transcript.events[0].text, text.replace(/\r\n/g, "\n"));
+
+			const rendered = renderFleetTranscript(transcript, 28, theme as never, markdownTheme);
+			assert.ok(rendered.some((line) => line.includes("Résumé 世界")));
+			assert.ok(rendered.some((line) => line.includes("const café")));
+			assert.ok(rendered.some((line) => line.includes("indented")));
+			for (const line of rendered) assert.ok(visibleWidth(line) <= 28, `line exceeded width: ${JSON.stringify(line)}`);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});
 
@@ -272,6 +372,25 @@ describe("Fleet inspector structured transcript", () => {
 			const transcript = readFleetTranscript(transcriptPath, { trustedRoots: [trustedRoot] });
 			assert.deepEqual(transcript.events, []);
 			assert.match(transcript.warning ?? "", /outside trusted roots/);
+		} finally {
+			fs.rmSync(trustedRoot, { recursive: true, force: true });
+			fs.rmSync(outsideRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("sanitizes read-boundary warnings before other Fleet views consume them", () => {
+		const trustedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-warning-trusted-"));
+		const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-warning-outside-"));
+		try {
+			writeTranscript(outsideRoot, [{ recordType: "message", role: "assistant", text: "secret" }]);
+			const transcript = readFleetTranscript(path.join(outsideRoot, "unsafe-\u001b[31m.jsonl"), { trustedRoots: [trustedRoot] });
+			assert.deepEqual(transcript.events, []);
+			assert.doesNotMatch(transcript.warning ?? "", /\u001b/u);
+			assert.match(transcript.warning ?? "", /U\+001B/);
+
+			const rendered = renderFleetTranscript(transcript, 40, theme as never, markdownTheme);
+			assert.doesNotMatch(rendered.join("\n"), /\u001b/u);
+			for (const line of rendered) assert.ok(visibleWidth(line) <= 40, `line exceeded width: ${JSON.stringify(line)}`);
 		} finally {
 			fs.rmSync(trustedRoot, { recursive: true, force: true });
 			fs.rmSync(outsideRoot, { recursive: true, force: true });


### PR DESCRIPTION
Ports the intended Fleet transcript display sanitization from #823 onto current `main`.

Preserves the visible `@xz-dev` / #823 changelog credit.

Focused test and `npm run typecheck` pass.