### PR TITLE
fix(tui): unify renderer status and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Preserve actionable multi-line subagent tool errors in collapsed result rendering. Thanks to @xz-dev for #824.
 - Sanitize Fleet transcript content and warnings before terminal display while preserving normal Unicode and formatting. Thanks to @xz-dev for #823.
 - Unified subagent status presentation across compact, expanded, and Fleet views, including terminal interruption precedence and terminal-safe selection markers. Thanks to @xz-dev for #822.
+- Display model and thinking metadata consistently in expanded multi-result and async Fleet views. Thanks to @xz-dev for #825.
 - Keep the under-editor async status widget visible by default while FleetView is enabled, including after active runs restore following reload. Thanks to @nicobailon for #804.
 - Restore active under-editor subagent status after management calls, so `status` and `list` do not hide running disk-backed work. Thanks to @nicobailon for #816.
 - Allow direct single-child `worktree: true` launches to use managed isolation without requiring `workflowScript`. Thanks to @nicobailon for #808.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Kept durable schedule timers and completion ownership isolated per project, recorded elapsed overlaps without queueing an immediate rerun, rejected symlink-backed schedule paths, and made the deferred mission contract explicit. Thanks to @nicobailon for #815.
 - Preserve actionable multi-line subagent tool errors in collapsed result rendering. Thanks to @xz-dev for #824.
 - Sanitize Fleet transcript content and warnings before terminal display while preserving normal Unicode and formatting. Thanks to @xz-dev for #823.
+- Unified subagent status presentation across compact, expanded, and Fleet views, including terminal interruption precedence and terminal-safe selection markers. Thanks to @xz-dev for #822.
 - Keep the under-editor async status widget visible by default while FleetView is enabled, including after active runs restore following reload. Thanks to @nicobailon for #804.
 - Restore active under-editor subagent status after management calls, so `status` and `list` do not hide running disk-backed work. Thanks to @nicobailon for #816.
 - Allow direct single-child `worktree: true` launches to use managed isolation without requiring `workflowScript`. Thanks to @nicobailon for #808.

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -406,7 +406,7 @@ function itemStats(item: FleetItem): string[] {
 		tokens = item.child.tokens;
 		tools = item.child.toolCount;
 	} else {
-		model = item.step?.model;
+		model = formatModelThinking(item.step?.model, item.step?.thinking) || undefined;
 		tokens = item.step?.tokens?.total ?? (item.index === undefined ? item.run.totalTokens?.total : undefined);
 		tools = item.step?.toolCount ?? (item.index === undefined ? item.run.toolCount : undefined);
 		const terminalRun = item.state !== "queued" && item.state !== "running" && item.state !== "pending";

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1617,8 +1617,8 @@ export function renderSubagentSummary(
 ): Component {
 	const details = result.details;
 	const results = details?.results ?? [];
-	const hasTerminalResult = results.some(hasTerminalResultFlag);
-	const running = !hasTerminalResult && (
+	const hasSingleTerminalResult = results.length === 1 && hasTerminalResultFlag(results[0]!);
+	const running = !hasSingleTerminalResult && (
 		options.isPartial === true
 		|| Boolean(details?.asyncId && details.mode !== "management")
 		|| Boolean(details && detailsHaveRunningResult(details))

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1618,7 +1618,8 @@ export function renderSubagentSummary(
 	const details = result.details;
 	const results = details?.results ?? [];
 	const hasSingleTerminalResult = results.length === 1 && hasTerminalResultFlag(results[0]!);
-	const running = !hasSingleTerminalResult && (
+	const hasOnlyTerminalResults = results.length > 0 && results.every(hasTerminalResultFlag);
+	const running = !hasSingleTerminalResult && !hasOnlyTerminalResults && (
 		options.isPartial === true
 		|| Boolean(details?.asyncId && details.mode !== "management")
 		|| Boolean(details && detailsHaveRunningResult(details))

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -309,6 +309,13 @@ function hasTerminalResultFlag(result: Details["results"][number]): boolean {
 	return Boolean(result.detached || result.stopped || result.interrupted);
 }
 
+function hasTerminalResult(result: Details["results"][number]): boolean {
+	if (hasTerminalResultFlag(result)) return true;
+	const status = result.progress?.status;
+	if (status === "running" || status === "pending") return false;
+	return result.exitCode !== undefined;
+}
+
 function isResultRunning(result: Details["results"][number], status = result.progress?.status): boolean {
 	return status === "running" && !hasTerminalResultFlag(result);
 }
@@ -1617,8 +1624,8 @@ export function renderSubagentSummary(
 ): Component {
 	const details = result.details;
 	const results = details?.results ?? [];
-	const hasSingleTerminalResult = results.length === 1 && hasTerminalResultFlag(results[0]!);
-	const hasOnlyTerminalResults = results.length > 0 && results.every(hasTerminalResultFlag);
+	const hasSingleTerminalResult = results.length === 1 && hasTerminalResult(results[0]!);
+	const hasOnlyTerminalResults = results.length > 0 && results.every(hasTerminalResult);
 	const running = !hasSingleTerminalResult && !hasOnlyTerminalResults && (
 		options.isPartial === true
 		|| Boolean(details?.asyncId && details.mode !== "management")

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -278,17 +278,74 @@ function resultStatusLine(result: Details["results"][number], output: string): s
 	return "Done";
 }
 
-function resultGlyph(result: Details["results"][number], output: string, theme: Theme, running = result.progress?.status === "running", seed = progressRunningSeed(result.progress ?? result.progressSummary), frame?: number): string {
-	if (running) {
-		if (frame !== undefined) return theme.fg("accent", runningGlyph((seed ?? 0) + frame));
-		return theme.fg("accent", runningGlyph(seed));
+type ResultPresentation = {
+	glyph: string;
+	label: "running" | "detached" | "stopped" | "paused" | "failed" | "completed";
+	tone: "accent" | "warning" | "error" | "success";
+};
+
+function semanticResultPresentation(input: {
+	running?: boolean;
+	detached?: boolean;
+	stopped?: boolean;
+	interrupted?: boolean;
+	failed?: boolean;
+	completedWithoutOutput?: boolean;
+	seed?: number;
+	frame?: number;
+}): ResultPresentation {
+	if (input.running) {
+		const glyph = input.frame !== undefined ? runningGlyph((input.seed ?? 0) + input.frame) : runningGlyph(input.seed);
+		return { glyph, label: "running", tone: "accent" };
 	}
-	if (result.detached) return theme.fg("warning", "■");
-	if (result.stopped) return theme.fg("warning", "■");
-	if (result.interrupted) return theme.fg("warning", "■");
-	if (result.exitCode !== 0) return theme.fg("error", "✗");
-	if (hasEmptyTextOutputWithoutOutputTarget(result.task, output)) return theme.fg("warning", "✓");
-	return theme.fg("success", "✓");
+	if (input.detached) return { glyph: "■", label: "detached", tone: "warning" };
+	if (input.stopped) return { glyph: "■", label: "stopped", tone: "warning" };
+	if (input.interrupted) return { glyph: "■", label: "paused", tone: "warning" };
+	if (input.failed) return { glyph: "✗", label: "failed", tone: "error" };
+	return { glyph: "✓", label: "completed", tone: input.completedWithoutOutput ? "warning" : "success" };
+}
+
+function hasTerminalResultFlag(result: Details["results"][number]): boolean {
+	return Boolean(result.detached || result.stopped || result.interrupted);
+}
+
+function isResultRunning(result: Details["results"][number], status = result.progress?.status): boolean {
+	return status === "running" && !hasTerminalResultFlag(result);
+}
+
+function detailsHaveRunningResult(details: Details): boolean {
+	return details.progress?.some((progress) => {
+		if (progress.status !== "running") return false;
+		const result = details.results.find((entry) => entry.progress?.index === progress.index) ?? details.results[progress.index];
+		return !result || !hasTerminalResultFlag(result);
+	})
+		|| details.results.some((result) => isResultRunning(result))
+		|| workflowGraphHasStatus(details, ["running"]);
+}
+
+function resultPresentation(result: Details["results"][number], output: string, running = isResultRunning(result), seed = progressRunningSeed(result.progress ?? result.progressSummary), frame?: number): ResultPresentation {
+	return semanticResultPresentation({
+		running,
+		detached: result.detached,
+		stopped: result.stopped,
+		interrupted: result.interrupted,
+		failed: result.exitCode !== 0,
+		completedWithoutOutput: hasEmptyTextOutputWithoutOutputTarget(result.task, output),
+		seed,
+		frame,
+	});
+}
+
+function resultGlyph(result: Details["results"][number], output: string, theme: Theme, running = isResultRunning(result), seed = progressRunningSeed(result.progress ?? result.progressSummary), frame?: number): string {
+	const presentation = resultPresentation(result, output, running, seed, frame);
+	return theme.fg(presentation.tone, presentation.glyph);
+}
+
+function styledResultPresentation(presentation: ResultPresentation, theme: Theme): { glyph: string; label: string } {
+	return {
+		glyph: theme.fg(presentation.tone, presentation.glyph),
+		label: theme.fg(presentation.tone, presentation.label),
+	};
 }
 
 function compactCurrentActivity(progress: AgentProgress): string {
@@ -640,14 +697,12 @@ function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "pr
 				|| details.progress?.find((progress) => progress.agent === result.agent && progress.status === "running");
 			const index = result.progress?.index ?? progressFromArray?.index ?? i;
 			if (index < 0 || index >= totalCount) continue;
-			const status = result.progress?.status
-				?? (result.stopped
-					? "stopped"
-					: result.interrupted || result.detached
-						? "detached"
-						: result.exitCode === 0
-							? "completed"
-							: "failed");
+			const status = result.stopped
+				? "stopped"
+				: result.interrupted || result.detached
+					? "detached"
+					: result.progress?.status
+						?? (result.exitCode === 0 ? "completed" : "failed");
 			statuses[index] = status;
 		}
 		const running = statuses.filter((status) => status === "running").length;
@@ -668,8 +723,8 @@ function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "pr
 		let done = 0;
 		for (let index = groupStart; index < groupEnd; index++) {
 			const progressEntry = details.progress?.find((progress) => progress.index === index);
-			const resultEntry = details.results.find((result) => result.progress?.index === index);
-			if (progressEntry?.status === "running") {
+			const resultEntry = details.results.find((result) => result.progress?.index === index) ?? details.results[index];
+			if (progressEntry?.status === "running" && (!resultEntry || !hasTerminalResultFlag(resultEntry))) {
 				running++;
 				continue;
 			}
@@ -1360,7 +1415,7 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 function renderSingleCompact(d: Details, r: Details["results"][number], theme: Theme, frame?: number): Component {
 	const output = r.truncation?.text || getSingleResultOutput(r);
 	const progress = r.progress || r.progressSummary;
-	const isRunning = r.progress?.status === "running";
+	const isRunning = isResultRunning(r);
 	const contextBadge = contextModeBadge(theme, r.context ?? d.context);
 	const stats = statJoin(theme, [
 		r.usage?.turns ? `⟳ ${r.usage.turns}` : "",
@@ -1448,14 +1503,12 @@ function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>
 }
 
 function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component {
-	const hasRunning = d.progress?.some((p) => p.status === "running")
-		|| d.results.some((r) => r.progress?.status === "running")
-		|| workflowGraphHasStatus(d, ["running"]);
-	const stopped = d.results.some((r) => r.stopped && r.progress?.status !== "running")
+	const hasRunning = detailsHaveRunningResult(d);
+	const stopped = d.results.some((r) => r.stopped)
 		|| workflowGraphHasStatus(d, ["stopped"]);
-	const failed = d.results.some((r) => !r.stopped && r.exitCode !== 0 && r.progress?.status !== "running")
+	const failed = d.results.some((r) => !hasTerminalResultFlag(r) && r.exitCode !== 0 && !isResultRunning(r))
 		|| workflowGraphHasStatus(d, ["failed"]);
-	const paused = d.results.some((r) => (r.interrupted || r.detached) && r.progress?.status !== "running")
+	const paused = d.results.some((r) => r.interrupted || r.detached)
 		|| workflowGraphHasStatus(d, ["paused", "detached"]);
 	let totalSummary = d.progressSummary;
 	if (!totalSummary) {
@@ -1474,15 +1527,15 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 	const multiLabel = buildMultiProgressLabel(d, hasRunning);
 	const itemTitle = multiLabel.itemTitle;
 	const stats = statJoin(theme, [multiLabel.headerLabel, formatProgressStats(theme, totalSummary), formatTotalCostStat(d.totalCost)]);
-	const glyph = hasRunning
-		? theme.fg("accent", runningGlyph(frame !== undefined ? (runningSeed(progressRunningSeed(totalSummary), d.currentStepIndex) ?? 0) + frame : runningSeed(progressRunningSeed(totalSummary), d.currentStepIndex)))
-		: stopped
-			? theme.fg("warning", "■")
-			: failed
-				? theme.fg("error", "✗")
-			: paused
-				? theme.fg("warning", "■")
-				: theme.fg("success", "✓");
+	const aggregatePresentation = semanticResultPresentation({
+		running: hasRunning,
+		stopped,
+		interrupted: paused,
+		failed,
+		seed: runningSeed(progressRunningSeed(totalSummary), d.currentStepIndex),
+		frame,
+	});
+	const glyph = theme.fg(aggregatePresentation.tone, aggregatePresentation.glyph);
 	const contextBadge = contextModeBadge(theme, d.context);
 	const c = new Container();
 	const width = getTermWidth() - 4;
@@ -1519,7 +1572,7 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 		const output = getSingleResultOutput(r);
 		const progressFromArray = d.progress?.find((p) => p.index === i) || d.progress?.find((p) => p.agent === r.agent && p.status === "running");
 		const rProg = r.progress || progressFromArray || r.progressSummary;
-		const rRunning = rProg && "status" in rProg && rProg.status === "running";
+		const rRunning = rProg && "status" in rProg && isResultRunning(r, rProg.status);
 		const rPending = rProg && "status" in rProg && rProg.status === "pending";
 		const stepNumber = r.progress?.index !== undefined ? r.progress.index + 1 : progressFromArray?.index !== undefined ? progressFromArray.index + 1 : i + 1;
 		const stepStats = formatProgressStats(theme, rProg);
@@ -1629,16 +1682,10 @@ export function renderSubagentResult(
 		const r = d.results[0];
 		if (!r) return renderMultiCompact(d, theme, frame);
 		if (!expanded) return renderSingleCompact(d, r, theme, frame);
-		const isRunning = r.progress?.status === "running";
-		const icon = isRunning
-			? theme.fg("warning", "running")
-			: r.detached
-				? theme.fg("warning", "detached")
-				: r.exitCode === 0
-					? theme.fg("success", "ok")
-					: theme.fg("error", "failed");
+		const isRunning = isResultRunning(r);
 		const contextBadge = contextModeBadge(theme, r.context ?? d.context);
 		const output = r.truncation?.text || getSingleResultOutput(r);
+		const presentation = styledResultPresentation(resultPresentation(r, output, isRunning, undefined, frame), theme);
 
 		const progressInfo = isRunning && r.progress
 			? ` | ${r.progress.toolCount} tools, ${formatTokens(r.progress.tokens)} tok, ${formatDuration(r.progress.durationMs)}`
@@ -1650,7 +1697,7 @@ export function renderSubagentResult(
 		const fit = (text: string) => expanded ? text : truncLine(text, w);
 		const toolCallLines = getToolCallLines(r, expanded);
 		const c = new Container();
-		c.addChild(new Text(fit(`${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${contextBadge}${progressInfo}`), 0, 0));
+		c.addChild(new Text(fit(`${presentation.glyph} ${theme.fg("toolTitle", theme.bold(r.agent))}${contextBadge}${progressInfo} ${theme.fg("dim", "·")} ${presentation.label}`), 0, 0));
 		c.addChild(new Spacer(1));
 		const taskMaxLen = Math.max(20, w - 8);
 		const taskPreview = expanded || r.task.length <= taskMaxLen
@@ -1731,31 +1778,26 @@ export function renderSubagentResult(
 
 	if (!expanded) return renderMultiCompact(d, theme, frame);
 
-	const hasRunning = d.progress?.some((p) => p.status === "running") 
-		|| d.results.some((r) => r.progress?.status === "running")
-		|| workflowGraphHasStatus(d, ["running"]);
-	const ok = d.results.filter((r) => r.progress?.status === "completed" || (r.exitCode === 0 && r.progress?.status !== "running")).length;
-	const hasEmptyWithoutTarget = d.results.some((r) =>
+	const hasRunning = detailsHaveRunningResult(d);
+	const stopped = d.results.some((r) => r.stopped)
+		|| workflowGraphHasStatus(d, ["stopped"]);
+	const failed = d.results.some((r) => !hasTerminalResultFlag(r) && r.exitCode !== 0 && !isResultRunning(r))
+		|| workflowGraphHasStatus(d, ["failed"]);
+	const paused = d.results.some((r) => r.interrupted || r.detached)
+		|| workflowGraphHasStatus(d, ["paused", "detached"]);
+	const completedWithoutOutput = d.results.some((r) =>
 		r.exitCode === 0
 		&& r.progress?.status !== "running"
 		&& hasEmptyTextOutputWithoutOutputTarget(r.task, getSingleResultOutput(r)),
 	);
-	const hasWorkflowFailure = workflowGraphHasStatus(d, ["failed"]);
-	const hasWorkflowStop = d.results.some((r) => r.stopped && r.progress?.status !== "running") || workflowGraphHasStatus(d, ["stopped"]);
-	const hasWorkflowPause = workflowGraphHasStatus(d, ["paused", "detached"]);
-	const icon = hasRunning
-		? theme.fg("warning", "running")
-		: hasEmptyWithoutTarget
-			? theme.fg("warning", "warning")
-			: hasWorkflowFailure
-				? theme.fg("error", "failed")
-				: hasWorkflowStop
-					? theme.fg("warning", "stopped")
-					: hasWorkflowPause
-						? theme.fg("warning", "paused")
-					: ok === d.results.length
-						? theme.fg("success", "ok")
-						: theme.fg("error", "failed");
+	const presentation = styledResultPresentation(semanticResultPresentation({
+		running: hasRunning,
+		stopped,
+		interrupted: paused,
+		failed,
+		completedWithoutOutput,
+		frame,
+	}), theme);
 
 	const totalSummary =
 		d.progressSummary ||
@@ -1792,22 +1834,14 @@ export function renderSubagentResult(
 		? d.chainAgents
 				.map((agent, i) => {
 					const result = d.results[i];
-					const isFailed = result && result.exitCode !== 0 && result.progress?.status !== "running";
-					const isComplete = result && result.exitCode === 0 && result.progress?.status !== "running";
-					const isEmptyWithoutTarget = result
-						? Boolean(isComplete) && hasEmptyTextOutputWithoutOutputTarget(result.task, getSingleResultOutput(result))
-						: false;
 					const isCurrent = i === (d.currentStepIndex ?? d.results.length);
-					const stepIcon = isFailed
-						? theme.fg("error", "failed")
-						: isEmptyWithoutTarget
-							? theme.fg("warning", "warning")
-							: isComplete
-								? theme.fg("success", "done")
-								: isCurrent && hasRunning
-									? theme.fg("warning", "running")
-									: theme.fg("dim", "pending");
-					return `${stepIcon} ${agent}${contextModeBadge(theme, result?.context)}`;
+					const stepPresentation = result
+						? styledResultPresentation(resultPresentation(result, getSingleResultOutput(result), isCurrent && hasRunning && !hasTerminalResultFlag(result)), theme)
+						: undefined;
+					const stepStatus = stepPresentation
+						? `${stepPresentation.glyph} ${stepPresentation.label}`
+						: theme.fg("dim", "◦ pending");
+					return `${stepStatus} ${agent}${contextModeBadge(theme, result?.context)}`;
 				})
 				.join(theme.fg("dim", " → "))
 		: null;
@@ -1817,7 +1851,7 @@ export function renderSubagentResult(
 	const c = new Container();
 	c.addChild(
 		new Text(
-			fit(`${icon} ${theme.fg("toolTitle", theme.bold(modeLabel))}${contextBadge} · ${multiLabel.headerLabel}${summaryStr}`),
+			fit(`${presentation.glyph} ${theme.fg("toolTitle", theme.bold(modeLabel))}${contextBadge} · ${multiLabel.headerLabel}${summaryStr} ${theme.fg("dim", "·")} ${presentation.label}`),
 			0,
 			0,
 		),
@@ -1864,24 +1898,18 @@ export function renderSubagentResult(
 		const progressFromArray = d.progress?.find((p) => p.index === i) 
 			|| d.progress?.find((p) => p.agent === r.agent && p.status === "running");
 		const rProg = r.progress || progressFromArray || r.progressSummary;
-		const rRunning = rProg?.status === "running";
+		const rRunning = isResultRunning(r, rProg?.status);
 		const stepNumber = typeof rProg?.index === "number" ? rProg.index + 1 : i + 1;
 
 		const resultOutput = getSingleResultOutput(r);
-		const statusIcon = rRunning
-			? theme.fg("warning", "running")
-			: r.exitCode !== 0
-				? theme.fg("error", "failed")
-				: hasEmptyTextOutputWithoutOutputTarget(r.task, resultOutput)
-					? theme.fg("warning", "warning")
-					: theme.fg("success", "done");
+		const rowPresentation = styledResultPresentation(resultPresentation(r, resultOutput, rRunning, progressRunningSeed(rProg), frame), theme);
 		const stats = rProg ? ` | ${rProg.toolCount} tools, ${formatDuration(rProg.durationMs)}` : "";
 		const modelDisplay = modelThinkingBadge(theme, r.model);
 		const stepLabel = entry.rowLabel ?? resultRowLabel(multiLabel, i, stepNumber);
 		const contextBadge = contextModeBadge(theme, r.context);
 		const stepHeader = rRunning
-			? `${statusIcon} ${stepLabel}: ${theme.bold(theme.fg("warning", r.agent))}${contextBadge}${modelDisplay}${stats}`
-			: `${statusIcon} ${stepLabel}: ${theme.bold(r.agent)}${contextBadge}${modelDisplay}${stats}`;
+			? `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(theme.fg("warning", r.agent))}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`
+			: `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(r.agent)}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`;
 		const toolCallLines = getToolCallLines(r, expanded);
 		c.addChild(new Text(fit(stepHeader), 0, 0));
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1904,7 +1904,7 @@ export function renderSubagentResult(
 		const resultOutput = getSingleResultOutput(r);
 		const rowPresentation = styledResultPresentation(resultPresentation(r, resultOutput, rRunning, progressRunningSeed(rProg), frame), theme);
 		const stats = rProg ? ` | ${rProg.toolCount} tools, ${formatDuration(rProg.durationMs)}` : "";
-		const modelDisplay = modelThinkingBadge(theme, r.model);
+		const modelDisplay = modelThinkingBadge(theme, r.model ?? rProg?.model, r.thinking ?? rProg?.thinking);
 		const stepLabel = entry.rowLabel ?? resultRowLabel(multiLabel, i, stepNumber);
 		const contextBadge = contextModeBadge(theme, r.context);
 		const stepHeader = rRunning

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1504,12 +1504,14 @@ function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>
 
 function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component {
 	const hasRunning = detailsHaveRunningResult(d);
+	const detached = d.results.some((r) => r.detached)
+		|| workflowGraphHasStatus(d, ["detached"]);
 	const stopped = d.results.some((r) => r.stopped)
 		|| workflowGraphHasStatus(d, ["stopped"]);
 	const failed = d.results.some((r) => !hasTerminalResultFlag(r) && r.exitCode !== 0 && !isResultRunning(r))
 		|| workflowGraphHasStatus(d, ["failed"]);
-	const paused = d.results.some((r) => r.interrupted || r.detached)
-		|| workflowGraphHasStatus(d, ["paused", "detached"]);
+	const paused = d.results.some((r) => r.interrupted)
+		|| workflowGraphHasStatus(d, ["paused"]);
 	let totalSummary = d.progressSummary;
 	if (!totalSummary) {
 		let sawProgress = false;
@@ -1529,6 +1531,7 @@ function renderMultiCompact(d: Details, theme: Theme, frame?: number): Component
 	const stats = statJoin(theme, [multiLabel.headerLabel, formatProgressStats(theme, totalSummary), formatTotalCostStat(d.totalCost)]);
 	const aggregatePresentation = semanticResultPresentation({
 		running: hasRunning,
+		detached,
 		stopped,
 		interrupted: paused,
 		failed,
@@ -1779,19 +1782,23 @@ export function renderSubagentResult(
 	if (!expanded) return renderMultiCompact(d, theme, frame);
 
 	const hasRunning = detailsHaveRunningResult(d);
+	const detached = d.results.some((r) => r.detached)
+		|| workflowGraphHasStatus(d, ["detached"]);
 	const stopped = d.results.some((r) => r.stopped)
 		|| workflowGraphHasStatus(d, ["stopped"]);
 	const failed = d.results.some((r) => !hasTerminalResultFlag(r) && r.exitCode !== 0 && !isResultRunning(r))
 		|| workflowGraphHasStatus(d, ["failed"]);
-	const paused = d.results.some((r) => r.interrupted || r.detached)
-		|| workflowGraphHasStatus(d, ["paused", "detached"]);
+	const paused = d.results.some((r) => r.interrupted)
+		|| workflowGraphHasStatus(d, ["paused"]);
 	const completedWithoutOutput = d.results.some((r) =>
-		r.exitCode === 0
-		&& r.progress?.status !== "running"
+		!hasTerminalResultFlag(r)
+		&& r.exitCode === 0
+		&& !isResultRunning(r)
 		&& hasEmptyTextOutputWithoutOutputTarget(r.task, getSingleResultOutput(r)),
 	);
 	const presentation = styledResultPresentation(semanticResultPresentation({
 		running: hasRunning,
+		detached,
 		stopped,
 		interrupted: paused,
 		failed,

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1617,17 +1617,18 @@ export function renderSubagentSummary(
 ): Component {
 	const details = result.details;
 	const results = details?.results ?? [];
-	const running = options.isPartial === true
+	const hasTerminalResult = results.some(hasTerminalResultFlag);
+	const running = !hasTerminalResult && (
+		options.isPartial === true
 		|| Boolean(details?.asyncId && details.mode !== "management")
-		|| details?.progress?.some((progress) => progress.status === "running")
-		|| results.some((entry) => entry.progress?.status === "running")
-		|| Boolean(details && workflowGraphHasStatus(details, ["running"]));
-	const stopped = results.some((entry) => entry.stopped && entry.progress?.status !== "running")
+		|| Boolean(details && detailsHaveRunningResult(details))
+	);
+	const stopped = results.some((entry) => entry.stopped)
 		|| Boolean(details && workflowGraphHasStatus(details, ["stopped"]));
-	const paused = results.some((entry) => (entry.interrupted || entry.detached) && entry.progress?.status !== "running")
+	const paused = results.some((entry) => entry.interrupted || entry.detached)
 		|| Boolean(details && workflowGraphHasStatus(details, ["paused", "detached"]));
 	const failed = result.isError === true
-		|| results.some((entry) => !entry.stopped && !entry.interrupted && !entry.detached && entry.exitCode !== 0 && entry.progress?.status !== "running")
+		|| results.some((entry) => !hasTerminalResultFlag(entry) && entry.exitCode !== 0 && !isResultRunning(entry))
 		|| Boolean(details && workflowGraphHasStatus(details, ["failed"]));
 	const state = running ? "running" : failed ? "failed" : stopped ? "stopped" : paused ? "paused" : "completed";
 	const glyph = state === "running"

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -548,6 +548,62 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.doesNotMatch(summary, /running/);
 	});
 
+	it("keeps all-completed async aggregate inline summaries terminal", () => {
+		for (const mode of ["parallel", "chain"] as const) {
+			const progress = ["writer", "reviewer"].map((agent, index) => ({
+				index,
+				agent,
+				status: "completed" as const,
+				task: "review",
+				recentTools: [],
+				recentOutput: [],
+				toolCount: 1,
+				tokens: 42,
+				durationMs: 1_000,
+			}));
+			const summary = renderSubagentSummary!({
+				content: [{ type: "text", text: "done" }],
+				details: {
+					mode,
+					asyncId: `async-${mode}`,
+					progress,
+					results: progress.map((entry) => ({ agent: entry.agent, task: "review", exitCode: 0, messages: [], usage: emptyUsage, progress: entry })),
+				},
+			}, {}, theme).render(120).join("\n");
+
+			assert.match(summary, /· completed$/, mode);
+			assert.doesNotMatch(summary, /running/, mode);
+		}
+	});
+
+	it("keeps all-failed async aggregate inline summaries terminal", () => {
+		for (const mode of ["parallel", "chain"] as const) {
+			const progress = ["writer", "reviewer"].map((agent, index) => ({
+				index,
+				agent,
+				status: "failed" as const,
+				task: "review",
+				recentTools: [],
+				recentOutput: [],
+				toolCount: 1,
+				tokens: 42,
+				durationMs: 1_000,
+			}));
+			const summary = renderSubagentSummary!({
+				content: [{ type: "text", text: "failed" }],
+				details: {
+					mode,
+					asyncId: `async-${mode}`,
+					progress,
+					results: progress.map((entry) => ({ agent: entry.agent, task: "review", exitCode: 1, error: "boom", messages: [], usage: emptyUsage, progress: entry })),
+				},
+			}, {}, theme).render(120).join("\n");
+
+			assert.match(summary, /· failed$/, mode);
+			assert.doesNotMatch(summary, /running/, mode);
+		}
+	});
+
 	it("uses shared semantic status presentation for expanded multi-result rows", () => {
 		const results = [
 			{

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { keyText } from "@earendil-works/pi-coding-agent";
 
+type RenderTheme = {
+	fg(name: string, text: string): string;
+	bold(text: string): string;
+};
+
 type RenderSubagentResult = (
 	result: {
 		content: Array<{ type: "text"; text: string }>;
@@ -13,15 +18,23 @@ type RenderSubagentResult = (
 		};
 	},
 	options: { expanded: boolean },
-	theme: {
-		fg(name: string, text: string): string;
-		bold(text: string): string;
+	theme: RenderTheme,
+) => { render(width: number): string[] };
+
+type RenderSubagentSummary = (
+	result: {
+		content: Array<{ type: "text"; text: string }>;
+		details?: { mode: "single" | "parallel" | "chain" | "management"; results: unknown[]; progress?: unknown[]; asyncId?: string };
 	},
+	options: { isPartial?: boolean },
+	theme: RenderTheme,
 ) => { render(width: number): string[] };
 
 let renderSubagentResult: RenderSubagentResult | undefined;
-({ renderSubagentResult } = await import("../../src/tui/render.ts") as {
+let renderSubagentSummary: RenderSubagentSummary | undefined;
+({ renderSubagentResult, renderSubagentSummary } = await import("../../src/tui/render.ts") as {
 	renderSubagentResult?: RenderSubagentResult;
+	renderSubagentSummary?: RenderSubagentSummary;
 });
 
 const theme = {
@@ -427,6 +440,48 @@ describe("renderSubagentResult fork indicator", () => {
 			assert.equal(firstGrapheme(compact), testCase.glyph, `${testCase.name} compact glyph`);
 			assert.equal(firstGrapheme(expanded), testCase.glyph, `${testCase.name} expanded glyph`);
 			assert.match((expanded.split("\n")[0] ?? "").trimEnd(), new RegExp(`reviewer(?: \\| [^·]+)? · ${testCase.label}$`), `${testCase.name} expanded label`);
+		}
+	});
+
+	it("keeps terminal results terminal in inline summaries with stale progress", () => {
+		const progress = {
+			index: 0,
+			agent: "reviewer",
+			status: "running",
+			task: "review",
+			recentTools: [],
+			recentOutput: [],
+			toolCount: 1,
+			tokens: 42,
+			durationMs: 1_000,
+		};
+		const cases = [
+			{ name: "detached", state: "paused", flag: { detached: true } },
+			{ name: "stopped", state: "stopped", flag: { stopped: true } },
+			{ name: "interrupted", state: "paused", flag: { interrupted: true } },
+		] as const;
+
+		for (const testCase of cases) {
+			const summary = renderSubagentSummary!({
+				content: [{ type: "text", text: testCase.name }],
+				details: {
+					mode: "single",
+					asyncId: "async-review",
+					progress: [progress],
+					results: [{
+						agent: "reviewer",
+						task: "review",
+						exitCode: 0,
+						messages: [],
+						usage: emptyUsage,
+						progress,
+						...testCase.flag,
+					}],
+				},
+			}, {}, theme).render(120).join("\n");
+
+			assert.match(summary, new RegExp(`· ${testCase.state}$`), testCase.name);
+			assert.doesNotMatch(summary, /running/, testCase.name);
 		}
 	});
 

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -485,6 +485,35 @@ describe("renderSubagentResult fork indicator", () => {
 		}
 	});
 
+	it("keeps aggregate inline summaries running when another child is terminal", () => {
+		const progress = (index: number, agent: string) => ({
+			index,
+			agent,
+			status: "running" as const,
+			task: "review",
+			recentTools: [],
+			recentOutput: [],
+			toolCount: 1,
+			tokens: 42,
+			durationMs: 1_000,
+		});
+		const stoppedProgress = progress(0, "stopped-reviewer");
+		const runningProgress = progress(1, "running-reviewer");
+		const summary = renderSubagentSummary!({
+			content: [{ type: "text", text: "mixed" }],
+			details: {
+				mode: "parallel",
+				progress: [stoppedProgress, runningProgress],
+				results: [
+					{ agent: "stopped-reviewer", task: "review", exitCode: 1, messages: [], usage: emptyUsage, stopped: true, progress: stoppedProgress },
+					{ agent: "running-reviewer", task: "review", exitCode: 0, messages: [], usage: emptyUsage, progress: runningProgress },
+				],
+			},
+		}, {}, theme).render(120).join("\n");
+
+		assert.match(summary, /· running$/);
+	});
+
 	it("uses shared semantic status presentation for expanded multi-result rows", () => {
 		const results = [
 			{

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -503,6 +503,7 @@ describe("renderSubagentResult fork indicator", () => {
 			content: [{ type: "text", text: "mixed" }],
 			details: {
 				mode: "parallel",
+				asyncId: "async-review",
 				progress: [stoppedProgress, runningProgress],
 				results: [
 					{ agent: "stopped-reviewer", task: "review", exitCode: 1, messages: [], usage: emptyUsage, stopped: true, progress: stoppedProgress },
@@ -512,6 +513,39 @@ describe("renderSubagentResult fork indicator", () => {
 		}, {}, theme).render(120).join("\n");
 
 		assert.match(summary, /· running$/);
+	});
+
+	it("keeps all-terminal async aggregate inline summaries terminal", () => {
+		const progress = (index: number, agent: string) => ({
+			index,
+			agent,
+			status: "running" as const,
+			task: "review",
+			recentTools: [],
+			recentOutput: [],
+			toolCount: 1,
+			tokens: 42,
+			durationMs: 1_000,
+		});
+		const stoppedProgress = progress(0, "stopped-reviewer");
+		const pausedProgress = progress(1, "paused-reviewer");
+		const detachedProgress = progress(2, "detached-reviewer");
+		const summary = renderSubagentSummary!({
+			content: [{ type: "text", text: "all terminal" }],
+			details: {
+				mode: "parallel",
+				asyncId: "async-review",
+				progress: [stoppedProgress, pausedProgress, detachedProgress],
+				results: [
+					{ agent: "stopped-reviewer", task: "review", exitCode: 1, messages: [], usage: emptyUsage, stopped: true, progress: stoppedProgress },
+					{ agent: "paused-reviewer", task: "review", exitCode: 1, messages: [], usage: emptyUsage, interrupted: true, progress: pausedProgress },
+					{ agent: "detached-reviewer", task: "review", exitCode: 0, messages: [], usage: emptyUsage, detached: true, progress: detachedProgress },
+				],
+			},
+		}, {}, theme).render(120).join("\n");
+
+		assert.match(summary, /· stopped$/);
+		assert.doesNotMatch(summary, /running/);
 	});
 
 	it("uses shared semantic status presentation for expanded multi-result rows", () => {

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -373,8 +373,26 @@ describe("renderSubagentResult fork indicator", () => {
 				label: "running",
 				extra: { progress: { index: 0, agent: "reviewer", status: "running", task: "review", recentTools: [], recentOutput: [], toolCount: 0, tokens: 0, durationMs: 0 } },
 			},
-			{ name: "detached", glyph: "■", label: "detached", extra: { detached: true, detachedReason: "continuing externally" } },
-			{ name: "stopped", glyph: "■", label: "stopped", extra: { stopped: true, exitCode: 1 } },
+			{
+				name: "detached",
+				glyph: "■",
+				label: "detached",
+				extra: {
+					detached: true,
+					detachedReason: "continuing externally",
+					progress: { index: 0, agent: "reviewer", status: "running", task: "review", recentTools: [], recentOutput: [], toolCount: 1, tokens: 42, durationMs: 1000 },
+				},
+			},
+			{
+				name: "stopped",
+				glyph: "■",
+				label: "stopped",
+				extra: {
+					stopped: true,
+					exitCode: 1,
+					progress: { index: 0, agent: "reviewer", status: "running", task: "review", recentTools: [], recentOutput: [], toolCount: 1, tokens: 42, durationMs: 1000 },
+				},
+			},
 			{
 				name: "interrupted",
 				glyph: "■",
@@ -408,14 +426,32 @@ describe("renderSubagentResult fork indicator", () => {
 
 			assert.equal(firstGrapheme(compact), testCase.glyph, `${testCase.name} compact glyph`);
 			assert.equal(firstGrapheme(expanded), testCase.glyph, `${testCase.name} expanded glyph`);
-			assert.match(expanded.split("\n")[0] ?? "", new RegExp(`reviewer(?: \\| [^·]+)? · ${testCase.label}$`), `${testCase.name} expanded label`);
+			assert.match((expanded.split("\n")[0] ?? "").trimEnd(), new RegExp(`reviewer(?: \\| [^·]+)? · ${testCase.label}$`), `${testCase.name} expanded label`);
 		}
 	});
 
 	it("uses shared semantic status presentation for expanded multi-result rows", () => {
 		const results = [
-			{ agent: "detached-agent", task: "one", exitCode: 0, detached: true, finalOutput: "output", messages: [], usage: emptyUsage },
-			{ agent: "stopped-agent", task: "two", exitCode: 1, stopped: true, finalOutput: "output", messages: [], usage: emptyUsage },
+			{
+				agent: "detached-agent",
+				task: "one",
+				exitCode: 0,
+				detached: true,
+				finalOutput: "output",
+				messages: [],
+				usage: emptyUsage,
+				progress: { index: 0, agent: "detached-agent", status: "running" as const, task: "one", recentTools: [], recentOutput: [], toolCount: 1, tokens: 42, durationMs: 1000 },
+			},
+			{
+				agent: "stopped-agent",
+				task: "two",
+				exitCode: 1,
+				stopped: true,
+				finalOutput: "output",
+				messages: [],
+				usage: emptyUsage,
+				progress: { index: 1, agent: "stopped-agent", status: "running" as const, task: "two", recentTools: [], recentOutput: [], toolCount: 1, tokens: 42, durationMs: 1000 },
+			},
 			{
 				agent: "paused-agent",
 				task: "three",
@@ -439,8 +475,9 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(compact, /^■ parallel/);
 		assert.match(compact, /■ Agent 3\/5: paused-agent/);
 		assert.doesNotMatch(compact, /running agent/);
-		assert.match(expanded, /■ Agent 1\/5: detached-agent · detached/);
-		assert.match(expanded, /■ Agent 2\/5: stopped-agent · stopped/);
+		assert.match(expanded, /^■ parallel[^\n]* · detached/);
+		assert.match(expanded, /■ Agent 1\/5: detached-agent[^\n]* · detached/);
+		assert.match(expanded, /■ Agent 2\/5: stopped-agent[^\n]* · stopped/);
 		assert.match(expanded, /■ Agent 3\/5: paused-agent[^\n]* · paused/);
 		assert.doesNotMatch(expanded, /running agent/);
 		assert.match(expanded, /✗ Agent 4\/5: failed-agent · failed/);

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -365,6 +365,114 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(unwrap(expanded), /precisefailingtoolsequenceattheend\./);
 	});
 
+	it("uses the same semantic status presentation in compact and expanded single results", () => {
+		const cases = [
+			{
+				name: "running",
+				glyph: "⠋",
+				label: "running",
+				extra: { progress: { index: 0, agent: "reviewer", status: "running", task: "review", recentTools: [], recentOutput: [], toolCount: 0, tokens: 0, durationMs: 0 } },
+			},
+			{ name: "detached", glyph: "■", label: "detached", extra: { detached: true, detachedReason: "continuing externally" } },
+			{ name: "stopped", glyph: "■", label: "stopped", extra: { stopped: true, exitCode: 1 } },
+			{
+				name: "interrupted",
+				glyph: "■",
+				label: "paused",
+				extra: {
+					interrupted: true,
+					exitCode: 1,
+					progress: { index: 0, agent: "reviewer", status: "running", task: "review", recentTools: [], recentOutput: [], toolCount: 1, tokens: 42, durationMs: 1000 },
+				},
+			},
+			{ name: "failed", glyph: "✗", label: "failed", extra: { exitCode: 1, error: "boom" } },
+			{ name: "completed", glyph: "✓", label: "completed", extra: {} },
+		] as const;
+
+		for (const testCase of cases) {
+			const child = {
+				agent: "reviewer",
+				task: "review",
+				exitCode: 0,
+				finalOutput: "review complete",
+				messages: [],
+				usage: emptyUsage,
+				...testCase.extra,
+			};
+			const result = {
+				content: [{ type: "text" as const, text: testCase.name }],
+				details: { mode: "single" as const, results: [child] },
+			};
+			const compact = renderSubagentResult!(result, { expanded: false }, theme).render(120).join("\n");
+			const expanded = renderSubagentResult!(result, { expanded: true }, theme).render(120).join("\n");
+
+			assert.equal(firstGrapheme(compact), testCase.glyph, `${testCase.name} compact glyph`);
+			assert.equal(firstGrapheme(expanded), testCase.glyph, `${testCase.name} expanded glyph`);
+			assert.match(expanded.split("\n")[0] ?? "", new RegExp(`reviewer(?: \\| [^·]+)? · ${testCase.label}$`), `${testCase.name} expanded label`);
+		}
+	});
+
+	it("uses shared semantic status presentation for expanded multi-result rows", () => {
+		const results = [
+			{ agent: "detached-agent", task: "one", exitCode: 0, detached: true, finalOutput: "output", messages: [], usage: emptyUsage },
+			{ agent: "stopped-agent", task: "two", exitCode: 1, stopped: true, finalOutput: "output", messages: [], usage: emptyUsage },
+			{
+				agent: "paused-agent",
+				task: "three",
+				exitCode: 1,
+				interrupted: true,
+				finalOutput: "Interrupted. Waiting for explicit next action.",
+				messages: [],
+				usage: emptyUsage,
+				progress: { index: 2, agent: "paused-agent", status: "running" as const, task: "three", recentTools: [], recentOutput: [], toolCount: 1, tokens: 42, durationMs: 1000 },
+			},
+			{ agent: "failed-agent", task: "four", exitCode: 1, error: "boom", finalOutput: "output", messages: [], usage: emptyUsage },
+			{ agent: "completed-agent", task: "five", exitCode: 0, finalOutput: "output", messages: [], usage: emptyUsage },
+		];
+		const result = {
+			content: [{ type: "text" as const, text: "mixed" }],
+			details: { mode: "parallel" as const, totalSteps: results.length, results },
+		};
+		const compact = renderSubagentResult!(result, { expanded: false }, theme).render(160).join("\n");
+		const expanded = renderSubagentResult!(result, { expanded: true }, theme).render(160).join("\n");
+
+		assert.match(compact, /^■ parallel/);
+		assert.match(compact, /■ Agent 3\/5: paused-agent/);
+		assert.doesNotMatch(compact, /running agent/);
+		assert.match(expanded, /■ Agent 1\/5: detached-agent · detached/);
+		assert.match(expanded, /■ Agent 2\/5: stopped-agent · stopped/);
+		assert.match(expanded, /■ Agent 3\/5: paused-agent[^\n]* · paused/);
+		assert.doesNotMatch(expanded, /running agent/);
+		assert.match(expanded, /✗ Agent 4\/5: failed-agent · failed/);
+		assert.match(expanded, /✓ Agent 5\/5: completed-agent · completed/);
+	});
+
+	it("renders a stale-running interrupted aggregate as paused", () => {
+		const result = {
+			content: [{ type: "text" as const, text: "paused" }],
+			details: {
+				mode: "parallel" as const,
+				totalSteps: 1,
+				results: [{
+					agent: "paused-agent",
+					task: "pause",
+					exitCode: 1,
+					interrupted: true,
+					finalOutput: "Interrupted. Waiting for explicit next action.",
+					messages: [],
+					usage: emptyUsage,
+					progress: { index: 0, agent: "paused-agent", status: "running" as const, task: "pause", recentTools: [], recentOutput: [], toolCount: 1, tokens: 42, durationMs: 1000 },
+				}],
+			},
+		};
+
+		const compact = renderSubagentResult!(result, { expanded: false }, theme).render(160).join("\n");
+		const expanded = renderSubagentResult!(result, { expanded: true }, theme).render(160).join("\n");
+
+		assert.match(compact, /^■ parallel/);
+		assert.match(expanded, /^■ parallel[^\n]* · paused/);
+	});
+
 	it("uses glyph-first compact rendering for completed subagents", () => {
 		const widget = renderSubagentResult!({
 			content: [{ type: "text", text: "done" }],

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -603,6 +603,23 @@ describe("renderSubagentResult fork indicator", () => {
 		}, { expanded: false }, theme).render(160).join("\n");
 		assert.match(multi, /Agent 1\/2: scout \(claude-haiku-4-5 · thinking low\)/);
 		assert.match(multi, /Agent 2\/2: worker \(gpt-5-mini\)/);
+
+		const expanded = renderSubagentResult!({
+			content: [{ type: "text", text: "done" }],
+			details: {
+				mode: "parallel",
+				totalSteps: 1,
+				results: [{
+					agent: "reviewer",
+					task: "review",
+					exitCode: 0,
+					messages: [],
+					usage: emptyUsage,
+					progressSummary: { toolCount: 1, tokens: 42, durationMs: 3_000, model: "openai-codex/gpt-5.5", thinking: "high" },
+				}],
+			},
+		}, { expanded: true }, theme).render(160).join("\n");
+		assert.match(expanded, /reviewer \(gpt-5\.5 · thinking high\)/);
 	});
 
 	it("keeps running compact result output stable when progress is unchanged", async () => {

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -106,6 +106,7 @@ describe("below-editor subagent FleetView", () => {
 			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
 			const expandedLines = component.render(80);
 			assert.ok(expandedLines.some((line) => line.includes("> main")));
+			assert.ok(expandedLines.some((line) => line.includes("  worker-0")), "unselected agents use blank focus space");
 			assert.ok(expandedLines.every((line) => !/[⏺◯]/u.test(line)), "selection avoids terminal-ambiguous circle glyphs");
 			assert.ok(expandedLines.some((line) => line.includes("worker-0 (fable-5 · thinking low)")));
 			assert.ok(expandedLines.some((line) => line.includes("11s · ↓ 13.1k tokens")));

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -35,6 +35,8 @@ function writeAsyncRun(root: string, input: {
 	lastUpdate?: number;
 	agents?: string[];
 	contexts?: Array<"fresh" | "fork">;
+	models?: string[];
+	thinking?: string[];
 	output?: string;
 	transcript?: Array<Record<string, unknown>>;
 }): string {
@@ -55,6 +57,8 @@ function writeAsyncRun(root: string, input: {
 		steps: agents.map((agent, index) => ({
 			agent,
 			...(input.contexts?.[index] ? { context: input.contexts[index] } : {}),
+			...(input.models?.[index] ? { model: input.models[index] } : {}),
+			...(input.thinking?.[index] ? { thinking: input.thinking[index] } : {}),
 			status: input.state === "complete" ? "complete" : input.state === "failed" ? "failed" : index === 0 ? "running" : "pending",
 			startedAt: 100,
 			...(index === 0 ? { sessionFile: path.join(asyncDir, `${agent}.jsonl`), ...(transcriptPath ? { transcriptPath } : {}) } : {}),
@@ -170,6 +174,32 @@ describe("native subagent fleet", () => {
 			assert.equal(snapshot.error, undefined);
 			assert.equal(snapshot.items.length, 20);
 			assert.ok(!snapshot.items.some((item) => item.runId === "old-invalid"));
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("shows async model and thinking metadata in the structured header", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-model-thinking-"));
+		try {
+			writeAsyncRun(root, {
+				id: "model-thinking",
+				state: "running",
+				models: ["openai-codex/gpt-5.5"],
+				thinking: ["high"],
+			});
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 32, columns: 100 }, requestRender() {} } as never,
+				theme as never,
+				stateForTest(),
+				() => {},
+				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 60_000, markdownTheme },
+			);
+			try {
+				assert.ok(component.render(100).some((line) => line.includes("gpt-5.5 · thinking high")));
+			} finally {
+				component.dispose();
+			}
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
Combines @xz-dev\u2019s #822 lifecycle/status presentation with #825 model and thinking fallbacks.

This replacement applies #822 first, then uses `r.model ?? rProg?.model` and `r.thinking ?? rProg?.thinking` in expanded rows and the matching async Fleet formatter. It preserves both changelog credits and leaves #826\u2019s inactive-roster compaction scope alone.

Validation:
- focused renderer integration test
- focused Fleet and Fleet status unit tests
- `npm run typecheck`
- `git diff --check`