### PR TITLE
fix(tui): preserve actionable tool errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Fixed
 - Kept durable schedule timers and completion ownership isolated per project, recorded elapsed overlaps without queueing an immediate rerun, rejected symlink-backed schedule paths, and made the deferred mission contract explicit. Thanks to @nicobailon for #815.
+- Preserve actionable multi-line subagent tool errors in collapsed result rendering. Thanks to @xz-dev for #824.
 - Keep the under-editor async status widget visible by default while FleetView is enabled, including after active runs restore following reload. Thanks to @nicobailon for #804.
 - Restore active under-editor subagent status after management calls, so `status` and `list` do not hide running disk-backed work. Thanks to @nicobailon for #816.
 - Allow direct single-child `worktree: true` launches to use managed isolation without requiring `workflowScript`. Thanks to @nicobailon for #808.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -568,9 +568,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 		renderResult(result, options, theme, context) {
 			clearLegacyResultAnimationTimer(context);
+			const renderedResult = { ...result, isError: context.isError };
 			return summaryInlineToolDisplay
-				? renderSubagentSummary(result, options, theme)
-				: renderSubagentResult(result, options, theme);
+				? renderSubagentSummary(renderedResult, options, theme)
+				: renderSubagentResult(renderedResult, options, theme);
 		},
 
 	};

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -140,6 +140,50 @@ describe("subagent extension child mode", () => {
 		}
 	});
 
+	it("keeps registered tool errors actionable while successful results stay collapsed", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./index.ts";
+			const events = { on() { return () => {}; }, emit() {} };
+			let registeredTool;
+			const fakePi = new Proxy({
+				events,
+				registerTool(tool) { if (tool.name === "subagent") registeredTool = tool; },
+				registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+				sendMessage() {}, getSessionName() { return undefined; },
+			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+			registerSubagentExtension(fakePi);
+			if (!registeredTool) throw new Error("tool not registered");
+
+			const theme = { fg(_name, text) { return text; }, bold(text) { return text; } };
+			const render = (text, isError) => registeredTool.renderResult({
+				content: [{ type: "text", text }],
+				details: { mode: "management", results: [] },
+			}, { expanded: false }, theme, { isError, state: {} }).render(120).join("\n");
+
+			const error = render("Agent configuration is invalid.\nSet tools to an array.\nRetry the subagent call.", true);
+			if (!error.includes("Set tools to an array.")) throw new Error("error remediation was hidden: " + error);
+			if (!error.includes("Retry the subagent call.")) throw new Error("error retry guidance was hidden: " + error);
+			if (error.includes("3 lines")) throw new Error("error was collapsed: " + error);
+
+			const success = render("Managed agents:\n- reviewer\n- writer", false);
+			if (!success.includes("Managed agents: · 3 lines")) throw new Error("success summary was not collapsed: " + success);
+			if (success.includes("- reviewer") || success.includes("- writer")) throw new Error("success details were not collapsed: " + success);
+		`;
+
+		execFileSync(
+			process.execPath,
+			[
+				"--experimental-strip-types",
+				"--import",
+				"./test/support/register-loader.mjs",
+				"--input-type=module",
+				"--eval",
+				script,
+			],
+			{ cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" },
+		);
+	});
+
 	it("does not animate foreground results on a timer", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./index.ts";
@@ -250,6 +294,10 @@ describe("subagent extension child mode", () => {
 					content: [{ type: "text", text: "aggregate output that must not appear" }],
 					details: { mode: "parallel", results: [{ ...base, agent: "stopped", exitCode: 1, stopped: true }, { ...base, agent: "failed", exitCode: 1, stopped: false }] },
 				}, { expanded: true, isPartial: false }, theme, { state: {} }).render(120);
+				const contextError = registeredTool.renderResult({
+					content: [{ type: "text", text: "Agent configuration is invalid." }],
+					details: { mode: "management", results: [] },
+				}, { expanded: false, isPartial: false }, theme, { isError: true, state: {} }).render(120);
 				if (running.length !== 1 || running[0] !== "● delegate · running") throw new Error("unexpected running summary: " + JSON.stringify(running));
 				if (asyncSingle.length !== 1 || asyncSingle[0] !== "● single · running") throw new Error("unexpected async single summary: " + JSON.stringify(asyncSingle));
 				if (asyncChain.length !== 1 || asyncChain[0] !== "● chain · running") throw new Error("unexpected async chain summary: " + JSON.stringify(asyncChain));
@@ -259,6 +307,7 @@ describe("subagent extension child mode", () => {
 				if (failed.length !== 1 || failed[0] !== "✗ delegate · failed") throw new Error("unexpected failed summary: " + JSON.stringify(failed));
 				if (failedWithPaused.length !== 1 || failedWithPaused[0] !== "✗ parallel · failed") throw new Error("unexpected paused aggregate summary: " + JSON.stringify(failedWithPaused));
 				if (failedWithStopped.length !== 1 || failedWithStopped[0] !== "✗ parallel · failed") throw new Error("unexpected stopped aggregate summary: " + JSON.stringify(failedWithStopped));
+				if (contextError.length !== 1 || contextError[0] !== "✗ management · failed") throw new Error("unexpected context error summary: " + JSON.stringify(contextError));
 			`;
 			const env = parentToolEnv();
 			env.PI_CODING_AGENT_DIR = agentDir;


### PR DESCRIPTION
## Summary

- forward Pi `context.isError` to both custom subagent result renderers
- keep actionable multi-line errors visible in the rich renderer
- preserve @xz-dev/#824 changelog credit

## Validation

- `node --experimental-strip-types --test test/unit/index-child-registration.test.ts`
- `npm run typecheck`
- `git diff --check`