### PR TITLE
test: stabilize managed worktree workflow fixture

### DIFF
--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -338,7 +338,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			config,
 			asyncByDefault,
 			tempArtifactsDir: tempDir,
-			getSubagentSessionRoot: () => tempDir,
+			getSubagentSessionRoot: () => path.join(tempDir, ".pi-subagents", "sessions"),
 			expandTilde: (value: string) => value,
 			discoverAgents: () => ({ agents }),
 			allowMutatingManagementActions,
@@ -698,7 +698,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		);
 
 		assert.equal(result.isError, undefined);
-		assert.equal(mockPi.callCount(), 2);
+		assert.equal(mockPi.callCount(), 2, result.content[0]?.text ?? "workflow produced no output");
 		assert.equal(fs.existsSync(path.join(tempDir, "feature-a.txt")), false);
 		assert.equal(fs.existsSync(path.join(tempDir, "feature-b.txt")), false);
 		const output = result.content[0]?.text ?? "";


### PR DESCRIPTION
The managed-worktree workflow test used the temporary Git repository itself as the mock child session root. If the first child completed before the second child started, its untracked session directory made the fixture repository dirty. The second child then correctly refused to create a worktree.

This puts mock sessions under `.pi-subagents/sessions`, which the managed-worktree cleanliness check already excludes as runtime state. It also includes the workflow output in the child-count assertion so future failures keep their trace.

Validation:
- forced child A to finish before child B started: passed
- exact failing integration test: 100/100 repeated passes
- adjacent managed-worktree integration tests: passed
- `npm run typecheck`: passed
- `git diff --check`: passed
