### PR TITLE
Stream live status while waiting for subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added live status streaming for `subagent_wait` while it waits on subagent runs. Thanks to @walter-erquinigo for #832.
 - Added opt-in `inlineToolDisplay: "summary"` for a stable one-row inline subagent result while FleetView remains the live progress surface. Thanks to @ryanbbrown for #805.
 - Added project-scoped durable schedules with one-shot and fixed-interval triggers, `workflowScript` or agent targets, overlap/catch-up policy, text management actions, external `schedule.run-due`, and durable history/event/run receipts. Thanks to @nicobailon for #815.
 - Added an observational `pi-subagents/external-runs` provider API for visible terminal work, without taking process ownership. Thanks to @nicobailon for #795.

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -46,7 +46,7 @@ import {
 	type BackgroundWorkSnapshot,
 	type RegisteredBackgroundWorkItem,
 } from "../../api/background-work.ts";
-import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
+import { formatAsyncRunList, listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 import {
 	DIRS,
 	INTERCOM_DETACH_REQUEST_EVENT,
@@ -59,7 +59,7 @@ import {
 	type ForegroundResumeRun,
 	type SubagentState,
 } from "../../shared/types.ts";
-import { formatDuration } from "../../shared/formatters.ts";
+import { formatDuration, shortenPath } from "../../shared/formatters.ts";
 export { WAIT_TOOL_ENABLED_ENV, resolveWaitToolConfig, type ResolvedWaitToolConfig } from "./wait-config.ts";
 
 /** States that mean a run is still in flight (not yet resolved). */
@@ -311,6 +311,25 @@ function result(text: string, isError = false): AgentToolResult<Details> {
 	};
 }
 
+/** Build the live status shown while async work keeps subagent_wait blocked. */
+function asyncWaitUpdate(runs: AsyncRunSummary[], providerCount: number, elapsedMs: number): AgentToolResult<Details> {
+	const activity = runs.flatMap((run) => {
+		const activeSteps = run.steps.filter((step) => step.status === "pending" || step.status === "running");
+		if (activeSteps.length === 0) {
+			return [`${run.id}: ${run.state}`];
+		}
+		return activeSteps.map((step) => {
+			const current = step.currentTool ?? (step.status === "pending" ? "queued" : "thinking…");
+			return `${step.agent}: ${current}${step.currentPath ? ` ${shortenPath(step.currentPath)}` : ""}`;
+		});
+	});
+	const headline = [
+		`Waiting ${formatDuration(elapsedMs)} for ${runs.length} async run(s) and ${providerCount} provider item(s).`,
+		...activity,
+	].join(" · ");
+	return result([headline, runs.length > 0 ? formatAsyncRunList(runs) : ""].filter(Boolean).join("\n"));
+}
+
 const TRANSCRIPT_TAIL_BYTES = 128 * 1024;
 const TRANSCRIPT_PREVIEW_LINES = 3;
 const TRANSCRIPT_PREVIEW_WIDTH = 220;
@@ -549,6 +568,7 @@ export async function waitForSubagents(
 			...activeInitialRuns.map((run) => `${run.id} (${run.state})`),
 			...activeInitialProviderItems.map((item) => `${item.provider}/${item.id}`),
 		].join(", ");
+		deps.onUpdate?.(asyncWaitUpdate(activeInitialRuns, activeInitialProviderItems.length, now() - startedAt));
 		if (signal?.aborted) {
 			return result(`Wait aborted after ${formatDuration(now() - startedAt)}. Still active: ${stillActive}.`, true);
 		}

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -138,6 +138,39 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("streams active async run status while waiting", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-progress-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-live", "running", {
+				sessionId: "sess-1",
+				pid: 999999,
+				steps: [{
+					agent: "worker",
+					status: "running",
+					currentTool: "edit",
+					currentPath: "src/render.ts",
+					turnCount: 2,
+					toolCount: 4,
+				}],
+			});
+			const updates: string[] = [];
+			const result = await waitForSubagents({}, undefined, baseDeps(root, state, {
+				onUpdate: (update) => updates.push(textOf(update)),
+				sleep: async () => writeStatus(asyncRoot, "run-live", "complete", { sessionId: "sess-1" }),
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.equal(updates.length, 1);
+			assert.match(updates[0]!, /Waiting .* for 1 async run/);
+			assert.match(updates[0]!.split("\n")[0]!, /worker: edit .*src\/render\.ts/);
+			assert.match(updates[0]!, /run-live/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("surfaces failed terminal runs as errors only for internal auto-drain", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-drain-failure-"));
 		try {


### PR DESCRIPTION
## Summary
- stream live `subagent_wait` updates while async runs remain in flight
- show elapsed time and each active step's current tool/path in the pending tool row
- reuse the existing detailed async status formatter for expanded output
- cover async wait progress before completion

## Tests
- `node --experimental-strip-types --test test/unit/subagent-wait.test.ts` (29 passed)
- `npm run test:integration` (679 passed)
- `npm test` (1497 passed, 1 pre-existing `test/unit/fleet.test.ts` terminal-width assertion failure; the same test fails on unmodified `origin/main`)
