### PR TITLE
fix: keep foreground subagent progress visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Stream immediate and periodic progress for blocking foreground subagent runs, so long reasoning intervals remain visibly active.
+
 ## [0.41.0] - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- Stream immediate and periodic progress for blocking foreground subagent runs, so long reasoning intervals remain visibly active.
+- Stream immediate and periodic progress for blocking foreground subagent runs, so long reasoning intervals remain visibly active. Thanks to @walter-erquinigo for #833.
 
 ## [0.41.0] - 2026-08-05
 

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -984,14 +984,14 @@ async function runSingleAttempt(
 			}
 		};
 
-		if (controlConfig.enabled) {
+		fireUpdate();
+		if (controlConfig.enabled || options.onUpdate) {
 			activityTimer = setInterval(() => {
-				if (processClosed || lifecycleFinished) return;
-				const now = Date.now();
-				if (updateActivityState(now)) {
-					progress.durationMs = now - startTime;
-					fireUpdate();
+				if (processClosed || lifecycleFinished) {
+					return;
 				}
+				updateActivityState(Date.now());
+				fireUpdate();
 			}, 1000);
 			activityTimer.unref?.();
 		}

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -2487,6 +2487,32 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok(result.progress.durationMs > 0, "should track duration");
 	});
 
+	it("streams progress while a foreground child has not emitted output", async () => {
+		const updates: Array<{ text: string; durationMs: number | undefined }> = [];
+		const releasePath = path.join(tempDir, "release-foreground-progress");
+		mockPi.onCall({ output: "Done", waitForPath: releasePath });
+
+		const runPromise = runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			onUpdate: (update: { content: Array<{ type: string; text?: string }>; details?: { progress?: ProgressSummary[] } }) => {
+				updates.push({
+					text: update.content[0]?.text ?? "",
+					durationMs: update.details?.progress?.[0]?.durationMs,
+				});
+			},
+		});
+		const deadline = Date.now() + 5_000;
+		while (updates.filter((update) => update.text === "(running...)").length < 2 && Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+		fs.writeFileSync(releasePath, "release", "utf-8");
+		const result = await runPromise;
+
+		const runningUpdates = updates.filter((update) => update.text === "(running...)");
+		assert.equal(result.exitCode, 0);
+		assert.ok(runningUpdates.length >= 2, "expected an initial update and a heartbeat before child output");
+		assert.ok((runningUpdates.at(-1)?.durationMs ?? 0) > (runningUpdates[0]?.durationMs ?? 0), "expected heartbeat duration to advance");
+	});
+
 	it("tracks live activity updates and exposes artifact paths while running", async () => {
 		const updates: Array<{ details?: { results?: Array<{ artifactPaths?: ArtifactPaths }>; progress?: ProgressSummary[] } }> = [];
 		mockPi.onCall({


### PR DESCRIPTION
## Summary

Follow-up to #832 for blocking foreground runs.

Foreground progress was only emitted after the child produced a parsed JSONL event. A child that spent a long time starting or reasoning before its first tool call therefore left Pi's tool card blank even though the process was still running.

This change:
- emits a running snapshot immediately after the foreground child starts;
- refreshes the snapshot once per second while `onUpdate` is attached;
- reuses the existing activity timer and cleanup path;
- covers single, parallel, and chain foreground execution through their shared `runSync` path.

## Validation

- `npm run typecheck`
- focused foreground progress integration test: pass
- `npm run test:e2e`: 3/3 pass
- full integration: 689/690; unrelated `async dynamic status shows a placeholder before materialization` timed out once, then passed in isolation
- full unit: existing environment-sensitive `test/unit/fleet.test.ts` artifact-path rendering assertion remains the sole failure; this change does not touch Fleet rendering
- `git diff --check`
