### PR TITLE
fix(herdr): launch inspector through jiti bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Launch Herdr inspector panes through a JavaScript bootstrap instead of asking Node to type-strip TypeScript installed under `node_modules`. Thanks to @williamleong for #837.
 - Removed the Pi CLI devDependency from the default install and test against a local runtime shim, so repo audits no longer report the upstream dev-only Undici advisory while real Pi E2E remains optional. Thanks to @dmg-egg for #782.
 - Stream immediate and periodic progress for blocking foreground subagent runs, so long reasoning intervals remain visibly active. Thanks to @walter-erquinigo for #833.
 

--- a/inspector-runner.mjs
+++ b/inspector-runner.mjs
@@ -1,0 +1,11 @@
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { runInspector } = await jiti.import("./src/inspectors/herdr/inspector-runner.ts");
+
+try {
+	runInspector();
+} catch (cause) {
+	process.stderr.write(`Herdr inspector failed: ${cause instanceof Error ? cause.message : String(cause)}\n`);
+	process.exitCode = 1;
+}

--- a/src/inspectors/herdr/actions.ts
+++ b/src/inspectors/herdr/actions.ts
@@ -90,7 +90,7 @@ function shellQuote(value: string): string {
 }
 
 function inspectorCommand(input: { runnerPath: string; asyncDir: string; runId: string; index?: number; missionPath?: string; allowSteer: boolean; allowStop: boolean }): string {
-	const args = [process.execPath, "--experimental-strip-types", input.runnerPath, "--async-dir", input.asyncDir, "--run-id", input.runId, "--allow-steer", String(input.allowSteer), "--allow-stop", String(input.allowStop)];
+	const args = [process.execPath, input.runnerPath, "--async-dir", input.asyncDir, "--run-id", input.runId, "--allow-steer", String(input.allowSteer), "--allow-stop", String(input.allowStop)];
 	if (input.index !== undefined) args.push("--index", String(input.index));
 	if (input.missionPath) args.push("--mission-path", input.missionPath);
 	return args.map(shellQuote).join(" ");
@@ -195,7 +195,7 @@ export async function handleHerdrInspectorAction(action: HerdrInspectorAction, p
 	const paneId = extractPaneId(split.data);
 	if (!paneId) return result("Herdr inspector error (PANE_GONE): pane split returned no pane id.", true);
 	const mission = missionForRun(target.asyncDir, deps.cwd, deps.missions, target.runId);
-	const runnerPath = deps.runnerPath ?? fileURLToPath(new URL("./inspector-runner.ts", import.meta.url));
+	const runnerPath = deps.runnerPath ?? fileURLToPath(new URL("../../../inspector-runner.mjs", import.meta.url));
 	const command = inspectorCommand({
 		runnerPath,
 		asyncDir: target.asyncDir,

--- a/test/unit/herdr-inspector-bootstrap.test.ts
+++ b/test/unit/herdr-inspector-bootstrap.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { handleHerdrInspectorAction } from "../../src/inspectors/herdr/actions.ts";
+import type { HerdrClient } from "../../src/inspectors/herdr/client.ts";
+import type { AsyncStatus } from "../../src/shared/types.ts";
+
+function writeCompletedRun(root: string): { asyncDir: string; status: AsyncStatus } {
+	const asyncDir = path.join(root, "run-123");
+	fs.mkdirSync(asyncDir, { recursive: true });
+	const status: AsyncStatus = {
+		runId: "run-123",
+		mode: "single",
+		state: "completed",
+		startedAt: Date.now() - 1_000,
+		cwd: root,
+		steps: [{ agent: "worker", status: "completed", recentOutput: ["done"] }],
+	};
+	fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+	return { asyncDir, status };
+}
+
+describe("Herdr inspector bootstrap", () => {
+	it("uses ordinary Node for the inspector pane command", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-bootstrap-command-"));
+		try {
+			writeCompletedRun(root);
+			const calls: string[][] = [];
+			const client: HerdrClient = {
+				run: async <T>(args: string[]) => {
+					calls.push(args);
+					if (args[0] === "--version") return { ok: true, data: "herdr 0.7.5" as T };
+					if (args[0] === "pane" && args[1] === "split") return { ok: true, data: { pane: { pane_id: "w1:p9" } } as T };
+					return { ok: true, data: {} as T };
+				},
+			};
+			const opened = await handleHerdrInspectorAction("inspector.open", { id: "run-123" }, {
+				cwd: root,
+				asyncDirRoot: root,
+				resultsDir: path.join(root, "results"),
+				client,
+			});
+			assert.equal(opened.isError, undefined);
+			const command = calls.find((args) => args[0] === "pane" && args[1] === "run")?.[3] ?? "";
+			assert.doesNotMatch(command, /--experimental-strip-types/);
+			assert.match(command, /inspector-runner\.mjs/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("starts the packaged bootstrap with ordinary Node", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-bootstrap-run-"));
+		try {
+			const { asyncDir, status } = writeCompletedRun(root);
+			const bootstrap = fileURLToPath(new URL("../../inspector-runner.mjs", import.meta.url));
+			const launched = spawnSync(process.execPath, [bootstrap, "--async-dir", asyncDir, "--run-id", status.runId], { encoding: "utf-8" });
+			assert.equal(launched.status, 0, launched.stderr);
+			assert.match(launched.stdout, /pi-subagents inspector for run-123/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- launch Herdr inspector panes through a shipped `inspector-runner.mjs` bootstrap
- load the existing TypeScript inspector implementation with the package's pinned `jiti` runtime dependency
- remove Node's unsupported `--experimental-strip-types` invocation for a `.ts` file installed below `node_modules`
- add focused coverage for the generated pane command and ordinary-Node bootstrap launch

## Verification

- `node --experimental-strip-types --test test/unit/herdr-inspector-bootstrap.test.ts`
- `npm run typecheck`
- `npm pack` extraction into a temporary `node_modules/pi-subagents` path, then ordinary-Node execution of `inspector-runner.mjs`

`npm test` currently reports 1,590 passing tests and six cancelled tests in the pre-existing `test/unit/herdr-inspector.test.ts` timeout path under Node v22.22.2; this change does not modify that client/timer code.

Fixes #838