### PR TITLE
fix(tui): let Fleet inspector use full height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Let the Fleet inspector use the full 85% terminal-height budget on tall terminals. Thanks to @xz-dev for #839.
 - Launch Herdr inspector panes through a JavaScript bootstrap instead of asking Node to type-strip TypeScript installed under `node_modules`. Thanks to @williamleong for #837.
 - Removed the Pi CLI devDependency from the default install and test against a local runtime shim, so repo audits no longer report the upstream dev-only Undici advisory while real Pi E2E remains optional. Thanks to @dmg-egg for #782.
 - Stream immediate and periodic progress for blocking foreground subagent runs, so long reasoning intervals remain visibly active. Thanks to @walter-erquinigo for #833.

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -780,7 +780,7 @@ export class SubagentFleetComponent implements Component {
 		if (width < 36) return [truncateToWidth("Subagent fleet needs at least 36 columns. Esc closes.", width)];
 		const innerWidth = width - 2;
 		const rows = this.tui.terminal?.rows ?? 32;
-		this.bodyHeight = Math.max(2, Math.min(30, Math.floor(rows * 0.85) - 6));
+		this.bodyHeight = Math.max(2, Math.floor(rows * 0.85) - 6);
 		const rosterWidth = Math.max(22, Math.min(46, Math.floor((innerWidth - 1) * 0.38)));
 		const detailWidth = Math.max(1, innerWidth - rosterWidth - 1);
 		const roster = this.rosterLines(rosterWidth);

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -261,6 +261,21 @@ describe("native subagent fleet", () => {
 		assert.ok(!snapshot.items.some((item) => item.runId === "terminal-0"));
 	});
 
+	it("uses the full 85% terminal-height budget for the inspector", () => {
+		const component = new SubagentFleetComponent(
+			{ terminal: { rows: 60, columns: 100 }, requestRender() {} } as never,
+			theme as never,
+			stateForTest(),
+			() => {},
+			{ refreshMs: 60_000 },
+		);
+		try {
+			assert.equal(component.render(100).length, 51);
+		} finally {
+			component.dispose();
+		}
+	});
+
 	it("renders selectable transcript detail and completed artifact paths within terminal width", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-render-"));
 		try {


### PR DESCRIPTION
## Summary

Remove the unexplained 30-row body cap from the native Fleet inspector so its rendered height matches the existing 85% overlay budget.

The inspector already uses `maxHeight: "85%"`; with the cap, terminals taller than about 47 rows rendered a fixed 36-row panel instead of using that budget.

## Verification

- Focused geometry regression: 1/1 passed
- Fleet unit suite: 20/21 passed; the one `output-0.log` artifact assertion reproduces on unchanged upstream/main
- Mutation check: restoring the cap fails with actual 36 vs expected 51 at 60 terminal rows
- E2E: 3/3 passed
- Independent review: APPROVED
- Scope: `src/tui/fleet.ts` and `test/unit/fleet.test.ts` only

## Notes

The separate FleetView hide/layout timing fix is already present in downstream fork main; this PR is only the independent height correction.