### PR TITLE
feat: native @gotgenes/pi-permission-system compatibility

### DIFF
--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -3,41 +3,99 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { encodeNestedPathEnv, parseNestedPathEnv, type NestedPathEntry } from "./nested-path.ts";
-import { resolveMcpDirectToolSelections, type ResolvedMcpDirectToolSelection } from "./mcp-direct-tool-allowlist.ts";
+import {
+	encodeNestedPathEnv,
+	parseNestedPathEnv,
+	type NestedPathEntry,
+} from "./nested-path.ts";
+import {
+	resolveMcpDirectToolSelections,
+	type ResolvedMcpDirectToolSelection,
+} from "./mcp-direct-tool-allowlist.ts";
 import { resolvePiPackageRoot } from "./pi-spawn.ts";
 import { RUNTIME_EXTENSION_ACK_PATH_ENV } from "./runtime-acknowledged-extensions.ts";
-import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "./structured-output.ts";
-import { TEMP_ROOT_DIR, type JsonSchemaObject, type LaunchResolvedChildExtensionsV1, type ResolvedToolBudget } from "../../shared/types.ts";
+import {
+	STRUCTURED_OUTPUT_CAPTURE_ENV,
+	STRUCTURED_OUTPUT_SCHEMA_ENV,
+} from "./structured-output.ts";
+import {
+	TEMP_ROOT_DIR,
+	type JsonSchemaObject,
+	type LaunchResolvedChildExtensionsV1,
+	type ResolvedToolBudget,
+} from "../../shared/types.ts";
 import { THINKING_LEVELS } from "../../shared/model-info.ts";
-import { TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV, encodeToolBudgetEnv } from "./tool-budget.ts";
-import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, MCP_DIRECT_CHILD_TOOLS_ENV, REQUIRED_CHILD_TOOLS_ENV } from "./tool-availability.ts";
-import { CHILD_WATCHDOG_CONFIG_ENV, encodeChildWatchdogConfig, type ChildWatchdogConfig } from "../../watchdog/child-status.ts";
+import {
+	TOOL_BUDGET_ENV,
+	TOOL_BUDGET_ZERO_AUTH_ENV,
+	encodeToolBudgetEnv,
+} from "./tool-budget.ts";
+import {
+	CHILD_TOOL_DIAGNOSTIC_PATH_ENV,
+	MCP_DIRECT_CHILD_TOOLS_ENV,
+	REQUIRED_CHILD_TOOLS_ENV,
+} from "./tool-availability.ts";
+import {
+	CHILD_WATCHDOG_CONFIG_ENV,
+	encodeChildWatchdogConfig,
+	type ChildWatchdogConfig,
+} from "../../watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../background/wait-config.ts";
-import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../shared/utils.ts";
-import { encodePermissionRules, PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV, type PermissionRules } from "./permissions.ts";
-import { SUBAGENT_CAPABILITY_CEILING_ENV, capabilityCeilingAgentRestrictionSources, decodeSubagentCapabilityCeiling, encodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, isAgentAllowedByCapabilityCeiling, type ResolvedSubagentCapabilityCeiling, type SubagentCapabilityAudit } from "./capability-ceiling.ts";
+import {
+	PI_CODING_AGENT_PACKAGE_ROOT_ENV,
+	getAgentDir,
+} from "../../shared/utils.ts";
+import {
+	encodePermissionRules,
+	PERMISSION_AUDIT_PATH_ENV,
+	PERMISSION_POLICY_ENV,
+	type PermissionRules,
+} from "./permissions.ts";
+import {
+	SUBAGENT_CAPABILITY_CEILING_ENV,
+	capabilityCeilingAgentRestrictionSources,
+	decodeSubagentCapabilityCeiling,
+	encodeSubagentCapabilityCeiling,
+	intersectSubagentCapabilityCeilings,
+	isAgentAllowedByCapabilityCeiling,
+	type ResolvedSubagentCapabilityCeiling,
+	type SubagentCapabilityAudit,
+} from "./capability-ceiling.ts";
 
 const TASK_ARG_LIMIT = 8000;
 const MAX_LAUNCH_RESOLVED_EXTENSION_IDS = 32;
-const PROMPT_RUNTIME_EXTENSION_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-prompt-runtime.ts");
-const FANOUT_CHILD_EXTENSION_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "extension", "fanout-child.ts");
+const PROMPT_RUNTIME_EXTENSION_PATH = path.join(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"subagent-prompt-runtime.ts",
+);
+const FANOUT_CHILD_EXTENSION_PATH = path.join(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"..",
+	"extension",
+	"fanout-child.ts",
+);
 export const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
-export const SUBAGENT_ORCHESTRATOR_TARGET_ENV = "PI_SUBAGENT_ORCHESTRATOR_TARGET";
-export const SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV = "PI_SUBAGENT_ORCHESTRATOR_SESSION_ID";
-export const SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV = "PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR";
+export const SUBAGENT_ORCHESTRATOR_TARGET_ENV =
+	"PI_SUBAGENT_ORCHESTRATOR_TARGET";
+export const SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV =
+	"PI_SUBAGENT_ORCHESTRATOR_SESSION_ID";
+export const SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV =
+	"PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR";
 export const SUBAGENT_RUN_ID_ENV = "PI_SUBAGENT_RUN_ID";
 export const SUBAGENT_CHILD_AGENT_ENV = "PI_SUBAGENT_CHILD_AGENT";
 export const SUBAGENT_CHILD_INDEX_ENV = "PI_SUBAGENT_CHILD_INDEX";
 export const SUBAGENT_FANOUT_CHILD_ENV = "PI_SUBAGENT_FANOUT_CHILD";
 export const SUBAGENT_PARENT_EVENT_SINK_ENV = "PI_SUBAGENT_PARENT_EVENT_SINK";
-export const SUBAGENT_PARENT_CONTROL_INBOX_ENV = "PI_SUBAGENT_PARENT_CONTROL_INBOX";
+export const SUBAGENT_PARENT_CONTROL_INBOX_ENV =
+	"PI_SUBAGENT_PARENT_CONTROL_INBOX";
 export const SUBAGENT_PARENT_ROOT_RUN_ID_ENV = "PI_SUBAGENT_PARENT_ROOT_RUN_ID";
 export const SUBAGENT_PARENT_RUN_ID_ENV = "PI_SUBAGENT_PARENT_RUN_ID";
 export const SUBAGENT_PARENT_CHILD_INDEX_ENV = "PI_SUBAGENT_PARENT_CHILD_INDEX";
 export const SUBAGENT_PARENT_DEPTH_ENV = "PI_SUBAGENT_PARENT_DEPTH";
 export const SUBAGENT_PARENT_PATH_ENV = "PI_SUBAGENT_PARENT_PATH";
-export const SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV = "PI_SUBAGENT_PARENT_CAPABILITY_TOKEN";
+export const SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV =
+	"PI_SUBAGENT_PARENT_CAPABILITY_TOKEN";
 export const SUBAGENT_PARENT_SESSION_ENV = "PI_SUBAGENT_PARENT_SESSION";
 export const SUBAGENT_STEER_INBOX_ENV = "PI_SUBAGENT_STEER_INBOX";
 export const SUBAGENT_STEER_CAPABILITY_ENV = "PI_SUBAGENT_STEER_CAPABILITY";
@@ -105,17 +163,37 @@ export interface BuildPiArgsResult {
 }
 
 function sanitizeSupervisorChannelSegment(value: string): string {
-	return value.trim().replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "unknown";
+	return (
+		value
+			.trim()
+			.replace(/[^A-Za-z0-9._-]+/g, "-")
+			.replace(/^-+|-+$/g, "") || "unknown"
+	);
 }
 
-function supervisorChannelDir(runId: string, agent: string, childIndex: number): string {
-	return path.join(TEMP_ROOT_DIR, "supervisor-channels", `${sanitizeSupervisorChannelSegment(runId)}-${sanitizeSupervisorChannelSegment(agent)}-${childIndex}`);
+function supervisorChannelDir(
+	runId: string,
+	agent: string,
+	childIndex: number,
+): string {
+	return path.join(
+		TEMP_ROOT_DIR,
+		"supervisor-channels",
+		`${sanitizeSupervisorChannelSegment(runId)}-${sanitizeSupervisorChannelSegment(agent)}-${childIndex}`,
+	);
 }
 
-export function applyThinkingSuffix(model: string | undefined, thinking: string | false | undefined, replaceExisting = false): string | undefined {
+export function applyThinkingSuffix(
+	model: string | undefined,
+	thinking: string | false | undefined,
+	replaceExisting = false,
+): string | undefined {
 	if (!model || !thinking) return model;
 	const colonIdx = model.lastIndexOf(":");
-	if (colonIdx !== -1 && THINKING_LEVELS.some((level) => level === model.substring(colonIdx + 1))) {
+	if (
+		colonIdx !== -1 &&
+		THINKING_LEVELS.some((level) => level === model.substring(colonIdx + 1))
+	) {
 		return replaceExisting ? `${model.slice(0, colonIdx)}:${thinking}` : model;
 	}
 	return `${model}:${thinking}`;
@@ -128,11 +206,13 @@ export interface ResolvePiLaunchToolPlanInput {
 	mcpDirectTools?: string[];
 	cwd?: string;
 	requireReadTool?: boolean;
-	structuredOutput?: boolean | {
-		schema: JsonSchemaObject;
-		schemaPath: string;
-		outputPath: string;
-	};
+	structuredOutput?:
+		| boolean
+		| {
+				schema: JsonSchemaObject;
+				schemaPath: string;
+				outputPath: string;
+		  };
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	inheritedCapabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	agentName?: string;
@@ -162,7 +242,10 @@ function extensionIdentifier(value: string): string {
 	return `sha256:${createHash("sha256").update(path.normalize(value.trim())).digest("hex").slice(0, 16)}`;
 }
 
-function boundedExtensionIdentifiers(values: string[]): { ids: string[]; omitted: number } {
+function boundedExtensionIdentifiers(values: string[]): {
+	ids: string[];
+	omitted: number;
+} {
 	const ids = [...new Set(values.map(extensionIdentifier))];
 	return {
 		ids: ids.slice(0, MAX_LAUNCH_RESOLVED_EXTENSION_IDS),
@@ -170,7 +253,15 @@ function boundedExtensionIdentifiers(values: string[]): { ids: string[]; omitted
 	};
 }
 
-export function projectLaunchResolvedChildExtensions(toolPlan: Pick<PiLaunchToolPlan, "runtimeExtensions" | "configuredExtensions" | "extensionArgs" | "disableAmbientExtensions">): LaunchResolvedChildExtensionsV1 {
+export function projectLaunchResolvedChildExtensions(
+	toolPlan: Pick<
+		PiLaunchToolPlan,
+		| "runtimeExtensions"
+		| "configuredExtensions"
+		| "extensionArgs"
+		| "disableAmbientExtensions"
+	>,
+): LaunchResolvedChildExtensionsV1 {
 	const runtime = boundedExtensionIdentifiers(toolPlan.runtimeExtensions);
 	const configured = boundedExtensionIdentifiers(toolPlan.configuredExtensions);
 	const effective = boundedExtensionIdentifiers(toolPlan.extensionArgs);
@@ -189,55 +280,190 @@ export function projectLaunchResolvedChildExtensions(toolPlan: Pick<PiLaunchTool
 	};
 }
 
-export function resolvePiLaunchToolPlan(input: ResolvePiLaunchToolPlanInput): PiLaunchToolPlan {
-	const capabilityCeiling = intersectSubagentCapabilityCeilings(input.capabilityCeiling, input.inheritedCapabilityCeiling);
-	const allowedToolSet = capabilityCeiling?.allowedTools === undefined ? undefined : new Set(capabilityCeiling.allowedTools);
-	const requestedBuiltinTools = input.tools?.filter((tool) => !(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js"))) ?? [];
-	if (input.requireReadTool && allowedToolSet && !allowedToolSet.has("read")) {
-		throw new Error(`Capability ceiling from ${capabilityCeiling?.sources.join(", ") || "unknown source"} excludes required tool 'read' for lazy skill loading.`);
+/**
+ * Resolve the permission-system extension entry point when installed.
+ * Returns the absolute path to the extension's main module, or undefined
+ * when the package is not installed. Callers can check `autoInject` config
+ * to decide whether to include it in child processes.
+ */
+export function resolvePermissionSystemExtension(): string | undefined {
+	try {
+		const agentDir = getAgentDir();
+		const candidates = [
+			// npm-scoped package (most common)
+			path.join(
+				agentDir,
+				"npm",
+				"node_modules",
+				"@gotgenes",
+				"pi-permission-system",
+			),
+			// direct extension directory (some layouts)
+			path.join(agentDir, "extensions", "pi-permission-system"),
+		];
+		for (const extDir of candidates) {
+			if (!fs.existsSync(extDir)) continue;
+			const pkgPath = path.join(extDir, "package.json");
+			if (!fs.existsSync(pkgPath)) continue;
+			const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
+				pi?: { extensions?: string[] };
+			};
+			const entry = pkg.pi?.extensions?.[0];
+			if (!entry) continue;
+			const resolved = path.resolve(extDir, entry);
+			if (fs.existsSync(resolved)) return resolved;
+		}
+		return undefined;
+	} catch {
+		return undefined;
 	}
-	const declaredBuiltinTools = input.tools === undefined
-		? (allowedToolSet ? [...allowedToolSet] : [])
-		: (input.requireReadTool && requestedBuiltinTools.length > 0 && !requestedBuiltinTools.includes("read") && !allowedToolSet
-			? ["read", ...requestedBuiltinTools]
-			: requestedBuiltinTools).filter((tool) => !allowedToolSet || allowedToolSet.has(tool));
+}
+
+export function resolvePiLaunchToolPlan(
+	input: ResolvePiLaunchToolPlanInput,
+): PiLaunchToolPlan {
+	const capabilityCeiling = intersectSubagentCapabilityCeilings(
+		input.capabilityCeiling,
+		input.inheritedCapabilityCeiling,
+	);
+	const allowedToolSet =
+		capabilityCeiling?.allowedTools === undefined
+			? undefined
+			: new Set(capabilityCeiling.allowedTools);
+	const requestedBuiltinTools =
+		input.tools?.filter(
+			(tool) =>
+				!(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")),
+		) ?? [];
+	if (input.requireReadTool && allowedToolSet && !allowedToolSet.has("read")) {
+		throw new Error(
+			`Capability ceiling from ${capabilityCeiling?.sources.join(", ") || "unknown source"} excludes required tool 'read' for lazy skill loading.`,
+		);
+	}
+	const declaredBuiltinTools =
+		input.tools === undefined
+			? allowedToolSet
+				? [...allowedToolSet]
+				: []
+			: (input.requireReadTool &&
+				requestedBuiltinTools.length > 0 &&
+				!requestedBuiltinTools.includes("read") &&
+				!allowedToolSet
+					? ["read", ...requestedBuiltinTools]
+					: requestedBuiltinTools
+				).filter((tool) => !allowedToolSet || allowedToolSet.has(tool));
 	const fanoutAuthorized = declaredBuiltinTools.includes("subagent");
-	const toolExtensionPaths: string[] = capabilityCeiling?.denyExtensions ? [] : (input.tools ?? []).filter((tool) => !requestedBuiltinTools.includes(tool) && (tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")));
-	const resolvedMcpSelections = capabilityCeiling?.denyExtensions ? [] : resolveMcpDirectToolSelections(input.mcpDirectTools, input.cwd);
-	const effectiveMcpSelections = resolvedMcpSelections.filter((selection) => !allowedToolSet || allowedToolSet.has(selection.name));
-	const effectiveMcpTools = effectiveMcpSelections.map((selection) => selection.name);
-	const explicitToolAllowlist = input.tools !== undefined || (input.mcpDirectTools?.length ?? 0) > 0 || allowedToolSet !== undefined;
+	const toolExtensionPaths: string[] = capabilityCeiling?.denyExtensions
+		? []
+		: (input.tools ?? []).filter(
+				(tool) =>
+					!requestedBuiltinTools.includes(tool) &&
+					(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")),
+			);
+	const resolvedMcpSelections = capabilityCeiling?.denyExtensions
+		? []
+		: resolveMcpDirectToolSelections(input.mcpDirectTools, input.cwd);
+	const effectiveMcpSelections = resolvedMcpSelections.filter(
+		(selection) => !allowedToolSet || allowedToolSet.has(selection.name),
+	);
+	const effectiveMcpTools = effectiveMcpSelections.map(
+		(selection) => selection.name,
+	);
+	const explicitToolAllowlist =
+		input.tools !== undefined ||
+		(input.mcpDirectTools?.length ?? 0) > 0 ||
+		allowedToolSet !== undefined;
 	const internalTools = input.structuredOutput ? ["structured_output"] : [];
-	const effectiveToolAllowlist = [...new Set([...declaredBuiltinTools, ...effectiveMcpTools, ...internalTools])];
-	const requiredChildTools = explicitToolAllowlist ? [...new Set([
-		...(input.tools !== undefined ? declaredBuiltinTools : []),
-		...(input.mcpDirectTools?.length ? effectiveMcpTools : []),
-		...internalTools,
-	])] : [];
-	const runtimeExtensions = fanoutAuthorized
-		? [PROMPT_RUNTIME_EXTENSION_PATH, FANOUT_CHILD_EXTENSION_PATH]
-		: [PROMPT_RUNTIME_EXTENSION_PATH];
-	const disableAmbientExtensions = capabilityCeiling?.denyExtensions === true || input.extensions !== undefined;
-	const configuredExtensions = capabilityCeiling?.denyExtensions ? [] : [...toolExtensionPaths, ...(input.extensions ?? []), ...(input.subagentOnlyExtensions ?? [])];
+	const effectiveToolAllowlist = [
+		...new Set([
+			...declaredBuiltinTools,
+			...effectiveMcpTools,
+			...internalTools,
+		]),
+	];
+	const requiredChildTools = explicitToolAllowlist
+		? [
+				...new Set([
+					...(input.tools !== undefined ? declaredBuiltinTools : []),
+					...(input.mcpDirectTools?.length ? effectiveMcpTools : []),
+					...internalTools,
+				]),
+			]
+		: [];
+	const permSystemExt = capabilityCeiling?.denyExtensions
+		? undefined
+		: resolvePermissionSystemExtension();
+	const runtimeExtensions = [
+		PROMPT_RUNTIME_EXTENSION_PATH,
+		...(fanoutAuthorized ? [FANOUT_CHILD_EXTENSION_PATH] : []),
+		...(permSystemExt ? [permSystemExt] : []),
+	];
+	const disableAmbientExtensions =
+		capabilityCeiling?.denyExtensions === true ||
+		input.extensions !== undefined;
+	const configuredExtensions = capabilityCeiling?.denyExtensions
+		? []
+		: [
+				...toolExtensionPaths,
+				...(input.extensions ?? []),
+				...(input.subagentOnlyExtensions ?? []),
+			];
 	const extensionArgs = disableAmbientExtensions
 		? [...new Set([...runtimeExtensions, ...configuredExtensions])]
-		: [...new Set([...runtimeExtensions, ...toolExtensionPaths, ...(input.subagentOnlyExtensions ?? [])])];
-	const requestedToolNames = input.tools !== undefined
-		? [...new Set([...requestedBuiltinTools, ...resolvedMcpSelections.map((selection) => selection.name)])]
+		: [
+				...new Set([
+					...runtimeExtensions,
+					...toolExtensionPaths,
+					...(input.subagentOnlyExtensions ?? []),
+				]),
+			];
+	const requestedToolNames =
+		input.tools !== undefined
+			? [
+					...new Set([
+						...requestedBuiltinTools,
+						...resolvedMcpSelections.map((selection) => selection.name),
+					]),
+				]
+			: undefined;
+	const capabilityAudit = capabilityCeiling
+		? ({
+				ceiling: capabilityCeiling,
+				...(requestedToolNames ? { requestedTools: requestedToolNames } : {}),
+				effectiveTools: effectiveToolAllowlist,
+				removedTools:
+					requestedToolNames?.filter(
+						(tool) => !effectiveToolAllowlist.includes(tool),
+					) ?? [],
+				internalTools,
+				extensionsDenied: capabilityCeiling.denyExtensions,
+				removedExtensionCount: capabilityCeiling.denyExtensions
+					? (input.extensions?.length ?? 0) +
+						(input.subagentOnlyExtensions?.length ?? 0) +
+						(input.tools ?? []).filter(
+							(tool) =>
+								tool.includes("/") ||
+								tool.endsWith(".ts") ||
+								tool.endsWith(".js"),
+						).length
+					: 0,
+				requestedMcpToolCount: input.mcpDirectTools?.length ?? 0,
+				effectiveMcpTools,
+				agentAllowed:
+					input.agentName === undefined
+						? true
+						: isAgentAllowedByCapabilityCeiling(
+								input.agentName,
+								capabilityCeiling,
+							),
+				...(capabilityCeilingAgentRestrictionSources(capabilityCeiling)
+					? {
+							agentRestrictionSources:
+								capabilityCeilingAgentRestrictionSources(capabilityCeiling),
+						}
+					: {}),
+			} satisfies SubagentCapabilityAudit)
 		: undefined;
-	const capabilityAudit = capabilityCeiling ? {
-		ceiling: capabilityCeiling,
-		...(requestedToolNames ? { requestedTools: requestedToolNames } : {}),
-		effectiveTools: effectiveToolAllowlist,
-		removedTools: requestedToolNames?.filter((tool) => !effectiveToolAllowlist.includes(tool)) ?? [],
-		internalTools,
-		extensionsDenied: capabilityCeiling.denyExtensions,
-		removedExtensionCount: capabilityCeiling.denyExtensions ? (input.extensions?.length ?? 0) + (input.subagentOnlyExtensions?.length ?? 0) + ((input.tools ?? []).filter((tool) => tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")).length) : 0,
-		requestedMcpToolCount: input.mcpDirectTools?.length ?? 0,
-		effectiveMcpTools,
-		agentAllowed: input.agentName === undefined ? true : isAgentAllowedByCapabilityCeiling(input.agentName, capabilityCeiling),
-		...(capabilityCeilingAgentRestrictionSources(capabilityCeiling) ? { agentRestrictionSources: capabilityCeilingAgentRestrictionSources(capabilityCeiling) } : {}),
-	} satisfies SubagentCapabilityAudit : undefined;
 	return {
 		...(capabilityCeiling ? { capabilityCeiling } : {}),
 		requestedBuiltinTools,
@@ -257,6 +483,15 @@ export function resolvePiLaunchToolPlan(input: ResolvePiLaunchToolPlanInput): Pi
 		disableAmbientExtensions,
 		...(capabilityAudit ? { capabilityAudit } : {}),
 	};
+}
+
+/** Escape XML-significant characters in a string for safe attribute interpolation. */
+function escapeXmlAttr(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/"/g, "&quot;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
 }
 
 export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
@@ -289,17 +524,23 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		requireReadTool: input.requireReadTool,
 		structuredOutput: input.structuredOutput,
 		capabilityCeiling: input.capabilityCeiling,
-		inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
+		inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(
+			process.env[SUBAGENT_CAPABILITY_CEILING_ENV],
+		),
 		agentName: input.childAgentName,
 	});
 	if (toolPlan.explicitToolAllowlist) {
-		args.push(toolPlan.effectiveToolAllowlist.length > 0 ? "--tools" : "--no-tools");
-		if (toolPlan.effectiveToolAllowlist.length > 0) args.push(toolPlan.effectiveToolAllowlist.join(","));
+		args.push(
+			toolPlan.effectiveToolAllowlist.length > 0 ? "--tools" : "--no-tools",
+		);
+		if (toolPlan.effectiveToolAllowlist.length > 0)
+			args.push(toolPlan.effectiveToolAllowlist.join(","));
 	}
 	if (toolPlan.disableAmbientExtensions) {
 		args.push("--no-extensions");
 	}
-	for (const extPath of toolPlan.extensionArgs) args.push("--extension", extPath);
+	for (const extPath of toolPlan.extensionArgs)
+		args.push("--extension", extPath);
 
 	if (!input.inheritProjectContext) {
 		args.push("--no-context-files");
@@ -313,8 +554,18 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));
 		const stem = (input.promptFileStem ?? "prompt").replace(/[^\w.-]/g, "_");
 		const promptPath = path.join(tempDir, `${stem}.md`);
-		fs.writeFileSync(promptPath, input.systemPrompt, { mode: 0o600 });
-		args.push(input.systemPromptMode === "replace" ? "--system-prompt" : "--append-system-prompt", promptPath);
+		// Inject <active_agent> tag so @gotgenes/pi-permission-system can
+		// resolve per-agent policy inside the child session.
+		const taggedPrompt = input.childAgentName
+			? `<active_agent name="${escapeXmlAttr(input.childAgentName)}"/>\n\n${input.systemPrompt}`
+			: input.systemPrompt;
+		fs.writeFileSync(promptPath, taggedPrompt, { mode: 0o600 });
+		args.push(
+			input.systemPromptMode === "replace"
+				? "--system-prompt"
+				: "--append-system-prompt",
+			promptPath,
+		);
 	}
 
 	if (input.task.length > TASK_ARG_LIMIT) {
@@ -329,58 +580,106 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	}
 
 	const env: Record<string, string | undefined> = {};
-	const piPackageRoot = process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] ?? resolvePiPackageRoot();
+	const piPackageRoot =
+		process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] ?? resolvePiPackageRoot();
 	if (piPackageRoot) env[PI_CODING_AGENT_PACKAGE_ROOT_ENV] = piPackageRoot;
-	if (!tempDir) tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));
-	const runtimeAcknowledgedExtensionsPath = path.join(tempDir, "runtime-acknowledged-extensions.json");
+	if (!tempDir)
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));
+	const runtimeAcknowledgedExtensionsPath = path.join(
+		tempDir,
+		"runtime-acknowledged-extensions.json",
+	);
 	env[RUNTIME_EXTENSION_ACK_PATH_ENV] = runtimeAcknowledgedExtensionsPath;
 	let toolDiagnosticPath: string | undefined;
 	if (toolPlan.requiredChildTools.length > 0) {
-		if (!tempDir) tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));
+		if (!tempDir)
+			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));
 		toolDiagnosticPath = path.join(tempDir, "tool-diagnostic.json");
 		env[REQUIRED_CHILD_TOOLS_ENV] = JSON.stringify(toolPlan.requiredChildTools);
 		env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV] = toolDiagnosticPath;
 	}
-	env[MCP_DIRECT_CHILD_TOOLS_ENV] = toolPlan.effectiveMcpTools.length > 0 ? JSON.stringify(toolPlan.effectiveMcpTools) : undefined;
+	env[MCP_DIRECT_CHILD_TOOLS_ENV] =
+		toolPlan.effectiveMcpTools.length > 0
+			? JSON.stringify(toolPlan.effectiveMcpTools)
+			: undefined;
 	env[SUBAGENT_CHILD_ENV] = "1";
 	env[SUBAGENT_FANOUT_CHILD_ENV] = toolPlan.fanoutAuthorized ? "1" : "0";
 	if (input.waitToolEnabled !== undefined) {
 		env[WAIT_TOOL_ENABLED_ENV] = input.waitToolEnabled ? "true" : "false";
 	}
-	const inheritedNestedRoute = Boolean(process.env[SUBAGENT_PARENT_EVENT_SINK_ENV] && process.env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] && process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV]);
-	const parentRunId = input.parentRunId ?? input.runId ?? (inheritedNestedRoute ? process.env[SUBAGENT_RUN_ID_ENV] : undefined) ?? process.env[SUBAGENT_PARENT_RUN_ID_ENV] ?? "";
-	const parentChildIndex = input.parentChildIndex !== undefined
-		? String(input.parentChildIndex)
-		: input.childIndex !== undefined
-			? String(input.childIndex)
-			: process.env[SUBAGENT_PARENT_CHILD_INDEX_ENV] ?? "";
+	const inheritedNestedRoute = Boolean(
+		process.env[SUBAGENT_PARENT_EVENT_SINK_ENV] &&
+			process.env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] &&
+			process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV],
+	);
+	const parentRunId =
+		input.parentRunId ??
+		input.runId ??
+		(inheritedNestedRoute ? process.env[SUBAGENT_RUN_ID_ENV] : undefined) ??
+		process.env[SUBAGENT_PARENT_RUN_ID_ENV] ??
+		"";
+	const parentChildIndex =
+		input.parentChildIndex !== undefined
+			? String(input.parentChildIndex)
+			: input.childIndex !== undefined
+				? String(input.childIndex)
+				: (process.env[SUBAGENT_PARENT_CHILD_INDEX_ENV] ?? "");
 	const inheritedDepth = Number(process.env[SUBAGENT_PARENT_DEPTH_ENV]);
-	const parentDepth = input.parentDepth ?? (inheritedNestedRoute && Number.isFinite(inheritedDepth) ? inheritedDepth + 1 : 1);
+	const parentDepth =
+		input.parentDepth ??
+		(inheritedNestedRoute && Number.isFinite(inheritedDepth)
+			? inheritedDepth + 1
+			: 1);
 	const parentPath = input.parentPath ?? [
 		...parseNestedPathEnv(process.env[SUBAGENT_PARENT_PATH_ENV]),
-		...(parentRunId ? [{
-			runId: parentRunId,
-			...(parentChildIndex && /^\d+$/.test(parentChildIndex) ? { stepIndex: Number(parentChildIndex) } : {}),
-			...(input.childAgentName ? { agent: input.childAgentName } : {}),
-		}] : []),
+		...(parentRunId
+			? [
+					{
+						runId: parentRunId,
+						...(parentChildIndex && /^\d+$/.test(parentChildIndex)
+							? { stepIndex: Number(parentChildIndex) }
+							: {}),
+						...(input.childAgentName ? { agent: input.childAgentName } : {}),
+					},
+				]
+			: []),
 	];
 	env[SUBAGENT_PARENT_EVENT_SINK_ENV] = toolPlan.fanoutAuthorized
-		? input.parentEventSink ?? process.env[SUBAGENT_PARENT_EVENT_SINK_ENV] ?? ""
+		? (input.parentEventSink ??
+			process.env[SUBAGENT_PARENT_EVENT_SINK_ENV] ??
+			"")
 		: "";
 	env[SUBAGENT_PARENT_CONTROL_INBOX_ENV] = toolPlan.fanoutAuthorized
-		? input.parentControlInbox ?? process.env[SUBAGENT_PARENT_CONTROL_INBOX_ENV] ?? ""
+		? (input.parentControlInbox ??
+			process.env[SUBAGENT_PARENT_CONTROL_INBOX_ENV] ??
+			"")
 		: "";
 	env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] = toolPlan.fanoutAuthorized
-		? input.parentRootRunId ?? process.env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] ?? input.runId ?? ""
+		? (input.parentRootRunId ??
+			process.env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] ??
+			input.runId ??
+			"")
 		: "";
-	env[SUBAGENT_PARENT_RUN_ID_ENV] = toolPlan.fanoutAuthorized ? parentRunId : "";
-	env[SUBAGENT_PARENT_CHILD_INDEX_ENV] = toolPlan.fanoutAuthorized ? parentChildIndex : "";
-	env[SUBAGENT_PARENT_DEPTH_ENV] = toolPlan.fanoutAuthorized ? String(parentDepth) : "";
-	env[SUBAGENT_PARENT_PATH_ENV] = toolPlan.fanoutAuthorized ? encodeNestedPathEnv(parentPath) : "";
+	env[SUBAGENT_PARENT_RUN_ID_ENV] = toolPlan.fanoutAuthorized
+		? parentRunId
+		: "";
+	env[SUBAGENT_PARENT_CHILD_INDEX_ENV] = toolPlan.fanoutAuthorized
+		? parentChildIndex
+		: "";
+	env[SUBAGENT_PARENT_DEPTH_ENV] = toolPlan.fanoutAuthorized
+		? String(parentDepth)
+		: "";
+	env[SUBAGENT_PARENT_PATH_ENV] = toolPlan.fanoutAuthorized
+		? encodeNestedPathEnv(parentPath)
+		: "";
 	env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] = toolPlan.fanoutAuthorized
-		? input.parentCapabilityToken ?? process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] ?? ""
+		? (input.parentCapabilityToken ??
+			process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] ??
+			"")
 		: "";
-	env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = input.inheritProjectContext ? "1" : "0";
+	env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = input.inheritProjectContext
+		? "1"
+		: "0";
 	env.PI_SUBAGENT_INHERIT_SKILLS = input.inheritSkills ? "1" : "0";
 	env[PI_INTERCOM_STABLE_ID_ENV] = input.intercomSessionName || undefined;
 	env[PI_INTERCOM_SESSION_ID_ENV] = undefined;
@@ -394,14 +693,25 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV] = input.parentSessionId;
 	}
 	const encodedPermissionRules = encodePermissionRules(input.permissionRules);
-	if (input.orchestratorIntercomTarget && input.parentSessionId && input.runId && input.childAgentName) {
+	if (
+		input.orchestratorIntercomTarget &&
+		input.parentSessionId &&
+		input.runId &&
+		input.childAgentName
+	) {
 		const childIndex = input.childIndex ?? 0;
-		const channelDir = supervisorChannelDir(input.runId, input.childAgentName, childIndex);
+		const channelDir = supervisorChannelDir(
+			input.runId,
+			input.childAgentName,
+			childIndex,
+		);
 		fs.mkdirSync(path.join(channelDir, "requests"), { recursive: true });
 		fs.mkdirSync(path.join(channelDir, "replies"), { recursive: true });
 		env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] = channelDir;
 	}
-	if (encodedPermissionRules) env[PERMISSION_AUDIT_PATH_ENV] = input.permissionAuditPath ?? path.join(tempDir, "permission-audit.jsonl");
+	if (encodedPermissionRules)
+		env[PERMISSION_AUDIT_PATH_ENV] =
+			input.permissionAuditPath ?? path.join(tempDir, "permission-audit.jsonl");
 	if (input.runId) {
 		env[SUBAGENT_RUN_ID_ENV] = input.runId;
 	}
@@ -411,12 +721,24 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	if (input.childIndex !== undefined) {
 		env[SUBAGENT_CHILD_INDEX_ENV] = String(input.childIndex);
 	}
-	if (!toolPlan.capabilityCeiling && input.mcpDirectTools?.length) env.MCP_DIRECT_TOOLS = input.mcpDirectTools.join(",");
-	else if (toolPlan.capabilityCeiling && toolPlan.effectiveMcpSelections.length && !toolPlan.capabilityCeiling.denyExtensions) env.MCP_DIRECT_TOOLS = toolPlan.effectiveMcpSelections.map((selection) => selection.selector).join(",");
+	if (!toolPlan.capabilityCeiling && input.mcpDirectTools?.length)
+		env.MCP_DIRECT_TOOLS = input.mcpDirectTools.join(",");
+	else if (
+		toolPlan.capabilityCeiling &&
+		toolPlan.effectiveMcpSelections.length &&
+		!toolPlan.capabilityCeiling.denyExtensions
+	)
+		env.MCP_DIRECT_TOOLS = toolPlan.effectiveMcpSelections
+			.map((selection) => selection.selector)
+			.join(",");
 	else env.MCP_DIRECT_TOOLS = "__none__";
-	const encodedCapabilityCeiling = encodeSubagentCapabilityCeiling(toolPlan.capabilityCeiling);
-	if (encodedCapabilityCeiling) env[SUBAGENT_CAPABILITY_CEILING_ENV] = encodedCapabilityCeiling;
-	if (encodedPermissionRules) env[PERMISSION_POLICY_ENV] = encodedPermissionRules;
+	const encodedCapabilityCeiling = encodeSubagentCapabilityCeiling(
+		toolPlan.capabilityCeiling,
+	);
+	if (encodedCapabilityCeiling)
+		env[SUBAGENT_CAPABILITY_CEILING_ENV] = encodedCapabilityCeiling;
+	if (encodedPermissionRules)
+		env[PERMISSION_POLICY_ENV] = encodedPermissionRules;
 	if (input.structuredOutput) {
 		env[STRUCTURED_OUTPUT_CAPTURE_ENV] = input.structuredOutput.outputPath;
 		env[STRUCTURED_OUTPUT_SCHEMA_ENV] = input.structuredOutput.schemaPath;
@@ -424,17 +746,27 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	if (input.steerInboxDir) {
 		env[SUBAGENT_STEER_INBOX_ENV] = input.steerInboxDir;
 	}
-	if (input.steerCapabilityPath) env[SUBAGENT_STEER_CAPABILITY_ENV] = input.steerCapabilityPath;
+	if (input.steerCapabilityPath)
+		env[SUBAGENT_STEER_CAPABILITY_ENV] = input.steerCapabilityPath;
 	if (input.steerAckDir) env[SUBAGENT_STEER_ACK_DIR_ENV] = input.steerAckDir;
 	const encodedToolBudget = encodeToolBudgetEnv(input.toolBudget);
 	if (encodedToolBudget) env[TOOL_BUDGET_ENV] = encodedToolBudget;
 	env[TOOL_BUDGET_ZERO_AUTH_ENV] = input.allowZeroToolBudget ? "1" : undefined;
 	const encodedChildWatchdog = encodeChildWatchdogConfig(input.childWatchdog);
-	if (encodedChildWatchdog) env[CHILD_WATCHDOG_CONFIG_ENV] = encodedChildWatchdog;
+	if (encodedChildWatchdog)
+		env[CHILD_WATCHDOG_CONFIG_ENV] = encodedChildWatchdog;
 
-	env[SUBAGENT_PARENT_SESSION_ENV] = input.parentSessionId ?? process.env[SUBAGENT_PARENT_SESSION_ENV] ?? "";
+	env[SUBAGENT_PARENT_SESSION_ENV] =
+		input.parentSessionId ?? process.env[SUBAGENT_PARENT_SESSION_ENV] ?? "";
 
-	return { args, env, tempDir, toolDiagnosticPath, runtimeAcknowledgedExtensionsPath, capabilityAudit: toolPlan.capabilityAudit };
+	return {
+		args,
+		env,
+		tempDir,
+		toolDiagnosticPath,
+		runtimeAcknowledgedExtensionsPath,
+		capabilityAudit: toolPlan.capabilityAudit,
+	};
 }
 
 export const parseParentPathEnv = parseNestedPathEnv;

--- a/test/unit/pi-args-permission-system.test.ts
+++ b/test/unit/pi-args-permission-system.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Permission-system compatibility tests:
+ * - <active_agent> tag injection into child system prompts
+ * - Permission-system extension auto-detection
+ */
+
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+	buildPiArgs,
+	resolvePermissionSystemExtension,
+	resolvePiLaunchToolPlan,
+} from "../../src/runs/shared/pi-args.ts";
+
+const originalEnv = {
+	HOME: process.env.HOME,
+	USERPROFILE: process.env.USERPROFILE,
+	PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+};
+const tempRoots: string[] = [];
+
+function createFixture() {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-args-perm-"));
+	tempRoots.push(root);
+	const home = path.join(root, "home");
+	const agentDir = path.join(home, ".pi", "agent");
+	const projectDir = path.join(root, "project");
+	fs.mkdirSync(agentDir, { recursive: true });
+	fs.mkdirSync(projectDir, { recursive: true });
+	process.env.HOME = home;
+	process.env.USERPROFILE = home;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	process.chdir(projectDir);
+	return { root, agentDir, projectDir };
+}
+
+afterEach(() => {
+	for (const key of Object.keys(originalEnv)) {
+		const value = originalEnv[key as keyof typeof originalEnv];
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	for (const root of tempRoots) {
+		try {
+			fs.rmSync(root, { recursive: true, force: true });
+		} catch {
+			// best effort
+		}
+	}
+	tempRoots.length = 0;
+});
+
+function readPromptFile(result: { tempDir?: string }): string {
+	assert.ok(result.tempDir, "expected a temp dir from buildPiArgs");
+	const files = fs.readdirSync(result.tempDir);
+	const promptFile = files.find((f: string) => f.endsWith(".md"));
+	assert.ok(promptFile, "expected a prompt.md file");
+	return fs.readFileSync(path.join(result.tempDir, promptFile), "utf-8");
+}
+
+describe("resolvePermissionSystemExtension", () => {
+	it("returns undefined when extension is not installed", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const result = resolvePermissionSystemExtension();
+		assert.equal(result, undefined);
+	});
+
+	it("returns undefined when extension dir exists but has no package.json", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const extDir = path.join(agentDir, "extensions", "pi-permission-system");
+		fs.mkdirSync(extDir, { recursive: true });
+		const result = resolvePermissionSystemExtension();
+		assert.equal(result, undefined);
+	});
+
+	it("returns undefined when package.json has no pi.extensions", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const extDir = path.join(agentDir, "extensions", "pi-permission-system");
+		fs.mkdirSync(extDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(extDir, "package.json"),
+			JSON.stringify({ name: "test" }),
+		);
+		const result = resolvePermissionSystemExtension();
+		assert.equal(result, undefined);
+	});
+
+	it("returns extension path when fully installed", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const extDir = path.join(agentDir, "extensions", "pi-permission-system");
+		fs.mkdirSync(extDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(extDir, "package.json"),
+			JSON.stringify({ name: "test", pi: { extensions: ["./src/index.ts"] } }),
+		);
+		fs.mkdirSync(path.join(extDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(extDir, "src", "index.ts"),
+			"export default () => {};",
+		);
+		const result = resolvePermissionSystemExtension();
+		assert.ok(result, "expected extension path");
+		if (!result) return; // narrow for TS
+		assert.ok(
+			result.endsWith(path.join("pi-permission-system", "src", "index.ts")),
+		);
+	});
+
+	it("returns undefined when entry file does not exist", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const extDir = path.join(agentDir, "extensions", "pi-permission-system");
+		fs.mkdirSync(extDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(extDir, "package.json"),
+			JSON.stringify({
+				name: "test",
+				pi: { extensions: ["./src/missing.ts"] },
+			}),
+		);
+		const result = resolvePermissionSystemExtension();
+		assert.equal(result, undefined);
+	});
+});
+
+describe("resolvePiLaunchToolPlan with permission system", () => {
+	it("appends permission system to runtimeExtensions when installed", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const extDir = path.join(agentDir, "extensions", "pi-permission-system");
+		fs.mkdirSync(path.join(extDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(extDir, "src", "index.ts"),
+			"export default () => {};",
+		);
+		fs.writeFileSync(
+			path.join(extDir, "package.json"),
+			JSON.stringify({ name: "test", pi: { extensions: ["./src/index.ts"] } }),
+		);
+
+		const plan = resolvePiLaunchToolPlan({});
+		const permExt = plan.runtimeExtensions.find((e) =>
+			e.includes("pi-permission-system"),
+		);
+		assert.ok(
+			permExt,
+			"permission system extension should be in runtimeExtensions",
+		);
+	});
+
+	it("does NOT include permission system when not installed", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+
+		const plan = resolvePiLaunchToolPlan({});
+		const permExt = plan.runtimeExtensions.find((e) =>
+			e.includes("pi-permission-system"),
+		);
+		assert.equal(permExt, undefined);
+	});
+
+	it("does NOT include permission system when denyExtensions is set", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const extDir = path.join(
+			agentDir,
+			"npm",
+			"node_modules",
+			"@gotgenes",
+			"pi-permission-system",
+		);
+		fs.mkdirSync(path.join(extDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(extDir, "src", "index.ts"),
+			"export default () => {};",
+		);
+		fs.writeFileSync(
+			path.join(extDir, "package.json"),
+			JSON.stringify({ name: "test", pi: { extensions: ["./src/index.ts"] } }),
+		);
+
+		const plan = resolvePiLaunchToolPlan({
+			capabilityCeiling: {
+				version: 1 as const,
+				allowedTools: ["read"],
+				denyExtensions: true,
+				sources: ["test"],
+			},
+		});
+		const permExt = plan.runtimeExtensions.find((e) =>
+			e.includes("pi-permission-system"),
+		);
+		assert.equal(permExt, undefined);
+	});
+});
+
+describe("buildPiArgs <active_agent> tag injection", () => {
+	it("prepends <active_agent> tag when childAgentName is set", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+
+		const result = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "test task",
+			sessionEnabled: false,
+			systemPrompt: "You are a helpful assistant.",
+			inheritProjectContext: false,
+			inheritSkills: false,
+			childAgentName: "reviewer",
+			promptFileStem: "reviewer",
+		});
+
+		const promptContent = readPromptFile(result);
+		assert.ok(
+			promptContent.startsWith('<active_agent name="reviewer"/>'),
+			`expected prompt to start with <active_agent> tag, got: ${promptContent.slice(0, 100)}`,
+		);
+		assert.ok(
+			promptContent.includes("You are a helpful assistant."),
+			"original prompt should be preserved after the tag",
+		);
+	});
+
+	it("does NOT inject tag when childAgentName is not set", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+
+		const result = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "test task",
+			sessionEnabled: false,
+			systemPrompt: "You are a helper.",
+			inheritProjectContext: false,
+			inheritSkills: false,
+			promptFileStem: "test",
+		});
+
+		const promptContent = readPromptFile(result);
+		assert.equal(
+			promptContent.includes("<active_agent"),
+			false,
+			"should not inject tag when no childAgentName",
+		);
+		assert.equal(promptContent, "You are a helper.");
+	});
+
+	it("does NOT inject tag when systemPrompt is empty", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+
+		const result = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "test task",
+			sessionEnabled: false,
+			systemPrompt: "",
+			inheritProjectContext: false,
+			inheritSkills: false,
+			childAgentName: "worker",
+			promptFileStem: "worker",
+		});
+
+		const promptContent = readPromptFile(result);
+		assert.ok(promptContent.startsWith('<active_agent name="worker"/>'));
+	});
+
+	it("escapes XML metacharacters in agent name", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+
+		const result = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "test task",
+			sessionEnabled: false,
+			systemPrompt: "System prompt here",
+			inheritProjectContext: false,
+			inheritSkills: false,
+			childAgentName: 'my "special" agent',
+			promptFileStem: "test",
+		});
+
+		const promptContent = readPromptFile(result);
+		assert.ok(
+			promptContent.startsWith('<active_agent name="my &quot;special&quot; agent"/>'),
+			`expected escaped tag, got: ${promptContent.slice(0, 120)}`,
+		);
+	});
+
+	it("runtimeExtensions include prompt runtime path (pre-existing behavior)", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+
+		const plan = resolvePiLaunchToolPlan({});
+		assert.ok(plan.runtimeExtensions.length >= 1);
+		const hasPromptRuntime = plan.runtimeExtensions.some((e) =>
+			e.endsWith("subagent-prompt-runtime.ts"),
+		);
+		assert.ok(
+			hasPromptRuntime,
+			"prompt runtime extension should always be included",
+		);
+	});
+});

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -4,12 +4,22 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { computeMcpServerHash } from "../../src/runs/shared/mcp-direct-tool-allowlist.ts";
-import { TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV } from "../../src/runs/shared/tool-budget.ts";
+import {
+	TOOL_BUDGET_ENV,
+	TOOL_BUDGET_ZERO_AUTH_ENV,
+} from "../../src/runs/shared/tool-budget.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
-import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, MCP_DIRECT_CHILD_TOOLS_ENV, REQUIRED_CHILD_TOOLS_ENV } from "../../src/runs/shared/tool-availability.ts";
+import {
+	CHILD_TOOL_DIAGNOSTIC_PATH_ENV,
+	MCP_DIRECT_CHILD_TOOLS_ENV,
+	REQUIRED_CHILD_TOOLS_ENV,
+} from "../../src/runs/shared/tool-availability.ts";
 import { CHILD_WATCHDOG_CONFIG_ENV } from "../../src/watchdog/child-status.ts";
-import { PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV } from "../../src/runs/shared/permissions.ts";
+import {
+	PERMISSION_AUDIT_PATH_ENV,
+	PERMISSION_POLICY_ENV,
+} from "../../src/runs/shared/permissions.ts";
 import {
 	SUBAGENT_FANOUT_CHILD_ENV,
 	SUBAGENT_PARENT_CHILD_INDEX_ENV,
@@ -38,18 +48,21 @@ const originalEnv = {
 	PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
 	PI_SUBAGENT_FANOUT_CHILD: process.env.PI_SUBAGENT_FANOUT_CHILD,
 	PI_SUBAGENT_PARENT_EVENT_SINK: process.env.PI_SUBAGENT_PARENT_EVENT_SINK,
-	PI_SUBAGENT_PARENT_CONTROL_INBOX: process.env.PI_SUBAGENT_PARENT_CONTROL_INBOX,
+	PI_SUBAGENT_PARENT_CONTROL_INBOX:
+		process.env.PI_SUBAGENT_PARENT_CONTROL_INBOX,
 	PI_SUBAGENT_PARENT_ROOT_RUN_ID: process.env.PI_SUBAGENT_PARENT_ROOT_RUN_ID,
 	PI_SUBAGENT_PARENT_RUN_ID: process.env.PI_SUBAGENT_PARENT_RUN_ID,
 	PI_SUBAGENT_PARENT_CHILD_INDEX: process.env.PI_SUBAGENT_PARENT_CHILD_INDEX,
 	PI_SUBAGENT_PARENT_DEPTH: process.env.PI_SUBAGENT_PARENT_DEPTH,
 	PI_SUBAGENT_PARENT_PATH: process.env.PI_SUBAGENT_PARENT_PATH,
-	PI_SUBAGENT_PARENT_CAPABILITY_TOKEN: process.env.PI_SUBAGENT_PARENT_CAPABILITY_TOKEN,
+	PI_SUBAGENT_PARENT_CAPABILITY_TOKEN:
+		process.env.PI_SUBAGENT_PARENT_CAPABILITY_TOKEN,
 	PI_SUBAGENT_PARENT_SESSION: process.env.PI_SUBAGENT_PARENT_SESSION,
 	PI_SUBAGENT_RUN_ID: process.env.PI_SUBAGENT_RUN_ID,
 	[MCP_DIRECT_CHILD_TOOLS_ENV]: process.env[MCP_DIRECT_CHILD_TOOLS_ENV],
 	[TOOL_BUDGET_ZERO_AUTH_ENV]: process.env[TOOL_BUDGET_ZERO_AUTH_ENV],
-	[PI_CODING_AGENT_PACKAGE_ROOT_ENV]: process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV],
+	[PI_CODING_AGENT_PACKAGE_ROOT_ENV]:
+		process.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV],
 	[PI_INTERCOM_STABLE_ID_ENV]: process.env[PI_INTERCOM_STABLE_ID_ENV],
 	[PI_INTERCOM_SESSION_ID_ENV]: process.env[PI_INTERCOM_SESSION_ID_ENV],
 	MCP_HASH_ROOT: process.env.MCP_HASH_ROOT,
@@ -97,7 +110,11 @@ function writeMcpFixture(
 	} = {},
 ): void {
 	const serverName = options.serverName ?? "chrome-devtools";
-	const definition = { command: "npx", args: ["chrome-devtools-mcp"], ...(options.definition ?? {}) };
+	const definition = {
+		command: "npx",
+		args: ["chrome-devtools-mcp"],
+		...(options.definition ?? {}),
+	};
 	writeJson(options.configPath ?? path.join(fixture.agentDir, "mcp.json"), {
 		...(options.settings ? { settings: options.settings } : {}),
 		mcpServers: {
@@ -136,8 +153,16 @@ afterEach(() => {
 
 describe("buildPiArgs session wiring", () => {
 	it("projects launch-resolved extension identifiers without raw paths", () => {
-		const privateExt = path.join(os.tmpdir(), "private-extension-root", "secret-extension.ts");
-		const toolExt = path.join(os.tmpdir(), "tool-extension-root", "tool-extension.ts");
+		const privateExt = path.join(
+			os.tmpdir(),
+			"private-extension-root",
+			"secret-extension.ts",
+		);
+		const toolExt = path.join(
+			os.tmpdir(),
+			"tool-extension-root",
+			"tool-extension.ts",
+		);
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", toolExt],
 			extensions: [privateExt],
@@ -149,13 +174,26 @@ describe("buildPiArgs session wiring", () => {
 		assert.equal(projection.version, 1);
 		assert.equal(projection.source, "launch-resolved");
 		assert.equal(projection.disableAmbientExtensions, true);
-		assert.equal(projection.runtime.length, 1);
+		assert.ok(
+			projection.runtime.length >= 1,
+			`expected at least 1 runtime extension, got ${projection.runtime.length}`,
+		);
 		assert.equal(projection.configured.length, 3);
-		assert.equal(projection.effective.length, 4);
-		for (const id of [...projection.runtime, ...projection.configured, ...projection.effective]) {
+		assert.ok(
+			projection.effective.length >= 4,
+			`expected at least 4 effective extensions, got ${projection.effective.length}`,
+		);
+		for (const id of [
+			...projection.runtime,
+			...projection.configured,
+			...projection.effective,
+		]) {
 			assert.match(id, /^sha256:[a-f0-9]{16}$/);
 		}
-		assert.ok(!JSON.stringify(projection).includes(os.tmpdir()), "projection should not expose raw extension paths");
+		assert.ok(
+			!JSON.stringify(projection).includes(os.tmpdir()),
+			"projection should not expose raw extension paths",
+		);
 	});
 
 	it("uses --session when sessionFile is provided", () => {
@@ -175,8 +213,14 @@ describe("buildPiArgs session wiring", () => {
 			assert.ok(args.includes("--session"));
 			assert.ok(args.includes(sessionFile));
 			assert.ok(fs.existsSync(path.dirname(sessionFile)));
-			assert.ok(!args.includes("--session-dir"), "--session-dir should not be emitted with --session");
-			assert.ok(!args.includes("--no-session"), "--no-session should not be emitted with --session");
+			assert.ok(
+				!args.includes("--session-dir"),
+				"--session-dir should not be emitted with --session",
+			);
+			assert.ok(
+				!args.includes("--no-session"),
+				"--no-session should not be emitted with --session",
+			);
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -225,16 +269,28 @@ describe("buildPiArgs session wiring", () => {
 	});
 
 	it("passes the effective wait-tool setting explicitly to children", () => {
-		assert.equal(buildPiArgs({
-			baseArgs: [], task: "test", sessionEnabled: false,
-			inheritProjectContext: true, inheritSkills: true,
-			waitToolEnabled: false,
-		}).env[WAIT_TOOL_ENABLED_ENV], "false");
-		assert.equal(buildPiArgs({
-			baseArgs: [], task: "test", sessionEnabled: false,
-			inheritProjectContext: true, inheritSkills: true,
-			waitToolEnabled: true,
-		}).env[WAIT_TOOL_ENABLED_ENV], "true");
+		assert.equal(
+			buildPiArgs({
+				baseArgs: [],
+				task: "test",
+				sessionEnabled: false,
+				inheritProjectContext: true,
+				inheritSkills: true,
+				waitToolEnabled: false,
+			}).env[WAIT_TOOL_ENABLED_ENV],
+			"false",
+		);
+		assert.equal(
+			buildPiArgs({
+				baseArgs: [],
+				task: "test",
+				sessionEnabled: false,
+				inheritProjectContext: true,
+				inheritSkills: true,
+				waitToolEnabled: true,
+			}).env[WAIT_TOOL_ENABLED_ENV],
+			"true",
+		);
 	});
 
 	it("passes child watchdog config only when explicitly provided", () => {
@@ -316,7 +372,6 @@ describe("buildPiArgs model wiring", () => {
 		assert.ok(!args.includes("--models"));
 	});
 
-
 	it("preserves thinking suffixes on model args", () => {
 		const { args } = buildPiArgs({
 			baseArgs: ["-p"],
@@ -328,7 +383,10 @@ describe("buildPiArgs model wiring", () => {
 			inheritSkills: false,
 		});
 
-		assert.equal(applyThinkingSuffix("openai-codex/gpt-5.4-mini", "high"), "openai-codex/gpt-5.4-mini:high");
+		assert.equal(
+			applyThinkingSuffix("openai-codex/gpt-5.4-mini", "high"),
+			"openai-codex/gpt-5.4-mini:high",
+		);
 		assert.ok(args.includes("--model"));
 		assert.ok(args.includes("openai-codex/gpt-5.4-mini:high"));
 	});
@@ -344,9 +402,18 @@ describe("buildPiArgs model wiring", () => {
 			inheritSkills: false,
 		});
 
-		assert.equal(applyThinkingSuffix("openai/gpt-5", "max"), "openai/gpt-5:max");
-		assert.equal(applyThinkingSuffix("openai/gpt-5:max", "high"), "openai/gpt-5:max");
-		assert.equal(applyThinkingSuffix("openai/gpt-5:max", "high", true), "openai/gpt-5:high");
+		assert.equal(
+			applyThinkingSuffix("openai/gpt-5", "max"),
+			"openai/gpt-5:max",
+		);
+		assert.equal(
+			applyThinkingSuffix("openai/gpt-5:max", "high"),
+			"openai/gpt-5:max",
+		);
+		assert.equal(
+			applyThinkingSuffix("openai/gpt-5:max", "high", true),
+			"openai/gpt-5:high",
+		);
 		assert.ok(args.includes("--model"));
 		assert.ok(args.includes("openai/gpt-5:max"));
 	});
@@ -362,8 +429,14 @@ describe("buildPiArgs model wiring", () => {
 			inheritSkills: false,
 		});
 
-		assert.equal(applyThinkingSuffix("anthropic/claude-haiku-4-5", "off"), "anthropic/claude-haiku-4-5:off");
-		assert.equal(applyThinkingSuffix("anthropic/claude-haiku-4-5:high", "off", true), "anthropic/claude-haiku-4-5:off");
+		assert.equal(
+			applyThinkingSuffix("anthropic/claude-haiku-4-5", "off"),
+			"anthropic/claude-haiku-4-5:off",
+		);
+		assert.equal(
+			applyThinkingSuffix("anthropic/claude-haiku-4-5:high", "off", true),
+			"anthropic/claude-haiku-4-5:off",
+		);
 		assert.ok(args.includes("--model"));
 		assert.ok(args.includes("anthropic/claude-haiku-4-5:off"));
 	});
@@ -445,8 +518,16 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			inheritSkills: true,
 		});
 
-		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
-		assert.ok(extensionArgs.some((arg) => arg.endsWith(path.join("src", "runs", "shared", "subagent-prompt-runtime.ts"))));
+		const extensionArgs = args.filter(
+			(arg, index) => args[index - 1] === "--extension",
+		);
+		assert.ok(
+			extensionArgs.some((arg) =>
+				arg.endsWith(
+					path.join("src", "runs", "shared", "subagent-prompt-runtime.ts"),
+				),
+			),
+		);
 		assert.ok(args.includes("--no-context-files"));
 		assert.equal(env.PI_SUBAGENT_CHILD, "1");
 		assert.equal(env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT, "0");
@@ -475,7 +556,11 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			toolBudget: { soft: 2, hard: 3, block: ["read"] },
 		});
 
-		assert.deepEqual(JSON.parse(env[TOOL_BUDGET_ENV] ?? "{}"), { soft: 2, hard: 3, block: ["read"] });
+		assert.deepEqual(JSON.parse(env[TOOL_BUDGET_ENV] ?? "{}"), {
+			soft: 2,
+			hard: 3,
+			block: ["read"],
+		});
 		assert.equal(env[TOOL_BUDGET_ZERO_AUTH_ENV], undefined);
 	});
 
@@ -536,16 +621,25 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			childIndex: 2,
 		});
 
-		assert.equal(env.PI_SUBAGENT_INTERCOM_SESSION_NAME, "subagent-worker-78f659a3");
+		assert.equal(
+			env.PI_SUBAGENT_INTERCOM_SESSION_NAME,
+			"subagent-worker-78f659a3",
+		);
 		assert.equal(env[PI_INTERCOM_STABLE_ID_ENV], "subagent-worker-78f659a3");
 		assert.equal(env[PI_INTERCOM_SESSION_ID_ENV], undefined);
 		assert.equal(env.PI_SUBAGENT_ORCHESTRATOR_TARGET, "subagent-chat-parent");
-		assert.equal(env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV], "session-parent-123");
+		assert.equal(
+			env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV],
+			"session-parent-123",
+		);
 		assert.equal(env.PI_SUBAGENT_RUN_ID, "78f659a3");
 		assert.equal(env.PI_SUBAGENT_CHILD_AGENT, "worker");
 		assert.equal(env.PI_SUBAGENT_CHILD_INDEX, "2");
 		assert.equal(typeof env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV], "string");
-		assert.match(env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] ?? "", /supervisor-channels/);
+		assert.match(
+			env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV] ?? "",
+			/supervisor-channels/,
+		);
 	});
 
 	it("clears inherited pi-intercom identity when no child intercom session name is set", () => {
@@ -580,7 +674,10 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env.PI_SUBAGENT_ORCHESTRATOR_TARGET, undefined);
 		assert.equal(env[PERMISSION_POLICY_ENV], JSON.stringify({ write: "ask" }));
 		assert.equal(env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV], undefined);
-		assert.equal(env[PERMISSION_AUDIT_PATH_ENV], path.join(tempDir!, "permission-audit.jsonl"));
+		assert.equal(
+			env[PERMISSION_AUDIT_PATH_ENV],
+			path.join(tempDir!, "permission-audit.jsonl"),
+		);
 	});
 
 	it("does not create a supervisor channel without an exact parent session id", () => {
@@ -607,12 +704,27 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			sessionEnabled: false,
 			inheritProjectContext: false,
 			inheritSkills: false,
-			tools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+			tools: [
+				"read",
+				"grep",
+				"find",
+				"ls",
+				"bash",
+				"edit",
+				"write",
+				"contact_supervisor",
+			],
 		});
 
 		const toolsArg = args[args.indexOf("--tools") + 1];
-		assert.equal(toolsArg, "read,grep,find,ls,bash,edit,write,contact_supervisor");
-		assert.deepEqual(JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"), toolsArg.split(","));
+		assert.equal(
+			toolsArg,
+			"read,grep,find,ls,bash,edit,write,contact_supervisor",
+		);
+		assert.deepEqual(
+			JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"),
+			toolsArg.split(","),
+		);
 		assert.equal(env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV], toolDiagnosticPath);
 	});
 
@@ -631,8 +743,15 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			},
 		});
 
-		assert.equal(args[args.indexOf("--tools") + 1], "read,fixture_search,structured_output");
-		assert.deepEqual(JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"), ["read", "fixture_search", "structured_output"]);
+		assert.equal(
+			args[args.indexOf("--tools") + 1],
+			"read,fixture_search,structured_output",
+		);
+		assert.deepEqual(JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"), [
+			"read",
+			"fixture_search",
+			"structured_output",
+		]);
 	});
 
 	it("forwards the Pi package root to child processes for host peer resolution", () => {
@@ -702,7 +821,10 @@ describe("buildPiArgs system prompt mode wiring", () => {
 				}),
 				computeMcpServerHash({
 					url: "https://example.test/$env:MCP_HASH_TOKEN",
-					headers: { Authorization: "Bearer ${MCP_HASH_TOKEN}", Secret: "!op read test" },
+					headers: {
+						Authorization: "Bearer ${MCP_HASH_TOKEN}",
+						Secret: "!op read test",
+					},
 					auth: "bearer",
 					bearerTokenEnv: "MCP_HASH_TOKEN",
 				}),
@@ -730,10 +852,27 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			mcpDirectTools: ["chrome-devtools"],
 		});
 
-		assert.equal(args[args.indexOf("--tools") + 1], "read,bash,chrome_devtools_take_screenshot,chrome_devtools_click");
+		assert.equal(
+			args[args.indexOf("--tools") + 1],
+			"read,bash,chrome_devtools_take_screenshot,chrome_devtools_click",
+		);
 		assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
-		assert.equal(env[REQUIRED_CHILD_TOOLS_ENV], JSON.stringify(["read", "bash", "chrome_devtools_take_screenshot", "chrome_devtools_click"]));
-		assert.equal(env[MCP_DIRECT_CHILD_TOOLS_ENV], JSON.stringify(["chrome_devtools_take_screenshot", "chrome_devtools_click"]));
+		assert.equal(
+			env[REQUIRED_CHILD_TOOLS_ENV],
+			JSON.stringify([
+				"read",
+				"bash",
+				"chrome_devtools_take_screenshot",
+				"chrome_devtools_click",
+			]),
+		);
+		assert.equal(
+			env[MCP_DIRECT_CHILD_TOOLS_ENV],
+			JSON.stringify([
+				"chrome_devtools_take_screenshot",
+				"chrome_devtools_click",
+			]),
+		);
 	});
 
 	it("emits --no-tools for explicit empty tool allowlists", () => {
@@ -769,7 +908,10 @@ describe("buildPiArgs system prompt mode wiring", () => {
 				mcpDirectTools: ["chrome-devtools"],
 			});
 
-			assert.equal(args[args.indexOf("--tools") + 1], "chrome_devtools_take_screenshot,chrome_devtools_click");
+			assert.equal(
+				args[args.indexOf("--tools") + 1],
+				"chrome_devtools_take_screenshot,chrome_devtools_click",
+			);
 			assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
 		}
 	});
@@ -778,7 +920,9 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		for (const requireReadTool of [false, true]) {
 			const fixture = createMcpFixture();
 			writeJson(path.join(fixture.agentDir, "mcp.json"), {
-				mcpServers: { "chrome-devtools": { command: "npx", args: ["chrome-devtools-mcp"] } },
+				mcpServers: {
+					"chrome-devtools": { command: "npx", args: ["chrome-devtools-mcp"] },
+				},
 			});
 
 			const { args, env } = buildPiArgs({
@@ -815,7 +959,10 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			mcpDirectTools: ["github/search_repositories"],
 		});
 
-		assert.equal(args[args.indexOf("--tools") + 1], "read,github_search_repositories");
+		assert.equal(
+			args[args.indexOf("--tools") + 1],
+			"read,github_search_repositories",
+		);
 	});
 
 	it("matches adapter prefix modes for direct MCP names", () => {
@@ -864,13 +1011,18 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			mcpDirectTools: ["browser-mcp"],
 		});
 
-		assert.equal(args[args.indexOf("--tools") + 1], "read,browser_mcp_navigate,browser_mcp_get_console_logs");
+		assert.equal(
+			args[args.indexOf("--tools") + 1],
+			"read,browser_mcp_navigate,browser_mcp_get_console_logs",
+		);
 	});
 
 	it("falls back to explicit builtins when direct MCP cache or config is missing or invalid", () => {
 		const missingFixture = createMcpFixture();
 		writeJson(path.join(missingFixture.agentDir, "mcp.json"), {
-			mcpServers: { "chrome-devtools": { command: "npx", args: ["chrome-devtools-mcp"] } },
+			mcpServers: {
+				"chrome-devtools": { command: "npx", args: ["chrome-devtools-mcp"] },
+			},
 		});
 		const missingCache = buildPiArgs({
 			baseArgs: ["-p"],
@@ -881,10 +1033,15 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			tools: ["read", "bash"],
 			mcpDirectTools: ["chrome-devtools"],
 		});
-		assert.equal(missingCache.args[missingCache.args.indexOf("--tools") + 1], "read,bash");
+		assert.equal(
+			missingCache.args[missingCache.args.indexOf("--tools") + 1],
+			"read,bash",
+		);
 
 		const invalidFixture = createMcpFixture();
-		writeMcpFixture(invalidFixture, { cachedAt: Date.now() - 8 * 24 * 60 * 60 * 1000 });
+		writeMcpFixture(invalidFixture, {
+			cachedAt: Date.now() - 8 * 24 * 60 * 60 * 1000,
+		});
 		const staleCache = buildPiArgs({
 			baseArgs: ["-p"],
 			task: "hello",
@@ -894,7 +1051,10 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			tools: ["read", "bash"],
 			mcpDirectTools: ["chrome-devtools"],
 		});
-		assert.equal(staleCache.args[staleCache.args.indexOf("--tools") + 1], "read,bash");
+		assert.equal(
+			staleCache.args[staleCache.args.indexOf("--tools") + 1],
+			"read,bash",
+		);
 	});
 
 	it("resolves project MCP config from the child cwd and expands PI_CODING_AGENT_DIR", () => {
@@ -936,9 +1096,20 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			mcpDirectTools: ["chrome-devtools"],
 		});
 
-		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
-		assert.equal(args[args.indexOf("--tools") + 1], "read,chrome_devtools_take_screenshot");
-		assert.ok(extensionArgs.some((arg) => arg.endsWith(path.join("src", "runs", "shared", "subagent-prompt-runtime.ts"))));
+		const extensionArgs = args.filter(
+			(arg, index) => args[index - 1] === "--extension",
+		);
+		assert.equal(
+			args[args.indexOf("--tools") + 1],
+			"read,chrome_devtools_take_screenshot",
+		);
+		assert.ok(
+			extensionArgs.some((arg) =>
+				arg.endsWith(
+					path.join("src", "runs", "shared", "subagent-prompt-runtime.ts"),
+				),
+			),
+		);
 		assert.ok(extensionArgs.includes("./custom-tool.ts"));
 		assert.ok(extensionArgs.includes("./allowed-ext.ts"));
 	});
@@ -955,7 +1126,9 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			subagentOnlyExtensions: ["./child-tool.ts"],
 		});
 
-		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
+		const extensionArgs = args.filter(
+			(arg, index) => args[index - 1] === "--extension",
+		);
 		assert.ok(args.includes("--no-extensions"));
 		assert.equal(args[args.indexOf("--tools") + 1], "read");
 		assert.ok(extensionArgs.includes("./main-allowed-ext.ts"));
@@ -978,7 +1151,9 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			parentCapabilityToken: "token-1",
 		});
 
-		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
+		const extensionArgs = args.filter(
+			(arg, index) => args[index - 1] === "--extension",
+		);
 		assert.equal(args[args.indexOf("--tools") + 1], "read,subagent");
 		assert.equal(env[SUBAGENT_FANOUT_CHILD_ENV], "1");
 		assert.equal(env[SUBAGENT_PARENT_EVENT_SINK_ENV], "/tmp/root/events");
@@ -987,9 +1162,15 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env[SUBAGENT_PARENT_RUN_ID_ENV], "parent-run");
 		assert.equal(env[SUBAGENT_PARENT_CHILD_INDEX_ENV], "1");
 		assert.equal(env[SUBAGENT_PARENT_DEPTH_ENV], "1");
-		assert.deepEqual(JSON.parse(env[SUBAGENT_PARENT_PATH_ENV] ?? "[]"), [{ runId: "parent-run", stepIndex: 1 }]);
+		assert.deepEqual(JSON.parse(env[SUBAGENT_PARENT_PATH_ENV] ?? "[]"), [
+			{ runId: "parent-run", stepIndex: 1 },
+		]);
 		assert.equal(env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV], "token-1");
-		assert.ok(extensionArgs.some((arg) => arg.endsWith(path.join("src", "extension", "fanout-child.ts"))));
+		assert.ok(
+			extensionArgs.some((arg) =>
+				arg.endsWith(path.join("src", "extension", "fanout-child.ts")),
+			),
+		);
 	});
 
 	it("clears all fanout routing env values for non-fanout children", () => {
@@ -1008,7 +1189,9 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			parentCapabilityToken: "token-should-not-leak",
 		});
 
-		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
+		const extensionArgs = args.filter(
+			(arg, index) => args[index - 1] === "--extension",
+		);
 		assert.equal(env[SUBAGENT_FANOUT_CHILD_ENV], "0");
 		assert.equal(env[SUBAGENT_PARENT_EVENT_SINK_ENV], "");
 		assert.equal(env[SUBAGENT_PARENT_CONTROL_INBOX_ENV], "");
@@ -1018,7 +1201,11 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env[SUBAGENT_PARENT_DEPTH_ENV], "");
 		assert.equal(env[SUBAGENT_PARENT_PATH_ENV], "");
 		assert.equal(env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV], "");
-		assert.ok(!extensionArgs.some((arg) => arg.endsWith(path.join("src", "extension", "fanout-child.ts"))));
+		assert.ok(
+			!extensionArgs.some((arg) =>
+				arg.endsWith(path.join("src", "extension", "fanout-child.ts")),
+			),
+		);
 	});
 
 	it("inherits routing env only for authorized fanout children", () => {
@@ -1029,7 +1216,11 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		process.env[SUBAGENT_RUN_ID_ENV] = "owner-run";
 		process.env[SUBAGENT_PARENT_CHILD_INDEX_ENV] = "4";
 		process.env[SUBAGENT_PARENT_DEPTH_ENV] = "2";
-		process.env[SUBAGENT_PARENT_PATH_ENV] = JSON.stringify([{ runId: "root-run", stepIndex: 0 }, { runId: "../unsafe", stepIndex: 1 }, { runId: "owner-run", stepIndex: 1 }]);
+		process.env[SUBAGENT_PARENT_PATH_ENV] = JSON.stringify([
+			{ runId: "root-run", stepIndex: 0 },
+			{ runId: "../unsafe", stepIndex: 1 },
+			{ runId: "owner-run", stepIndex: 1 },
+		]);
 		process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] = "inherited-token";
 
 		const fanout = buildPiArgs({
@@ -1040,14 +1231,27 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			inheritSkills: false,
 			tools: ["subagent"],
 		});
-		assert.equal(fanout.env[SUBAGENT_PARENT_EVENT_SINK_ENV], "/tmp/inherited/events");
-		assert.equal(fanout.env[SUBAGENT_PARENT_CONTROL_INBOX_ENV], "/tmp/inherited/control");
+		assert.equal(
+			fanout.env[SUBAGENT_PARENT_EVENT_SINK_ENV],
+			"/tmp/inherited/events",
+		);
+		assert.equal(
+			fanout.env[SUBAGENT_PARENT_CONTROL_INBOX_ENV],
+			"/tmp/inherited/control",
+		);
 		assert.equal(fanout.env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV], "inherited-root");
 		assert.equal(fanout.env[SUBAGENT_PARENT_RUN_ID_ENV], "owner-run");
 		assert.equal(fanout.env[SUBAGENT_PARENT_CHILD_INDEX_ENV], "4");
 		assert.equal(fanout.env[SUBAGENT_PARENT_DEPTH_ENV], "3");
-		assert.deepEqual(JSON.parse(fanout.env[SUBAGENT_PARENT_PATH_ENV] ?? "[]"), [{ runId: "root-run", stepIndex: 0 }, { runId: "owner-run", stepIndex: 1 }, { runId: "owner-run", stepIndex: 4 }]);
-		assert.equal(fanout.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV], "inherited-token");
+		assert.deepEqual(JSON.parse(fanout.env[SUBAGENT_PARENT_PATH_ENV] ?? "[]"), [
+			{ runId: "root-run", stepIndex: 0 },
+			{ runId: "owner-run", stepIndex: 1 },
+			{ runId: "owner-run", stepIndex: 4 },
+		]);
+		assert.equal(
+			fanout.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV],
+			"inherited-token",
+		);
 
 		const nonFanout = buildPiArgs({
 			baseArgs: ["-p"],
@@ -1076,7 +1280,9 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		process.env[SUBAGENT_RUN_ID_ENV] = "ancestor-run";
 		process.env[SUBAGENT_PARENT_CHILD_INDEX_ENV] = "4";
 		process.env[SUBAGENT_PARENT_DEPTH_ENV] = "1";
-		process.env[SUBAGENT_PARENT_PATH_ENV] = JSON.stringify([{ runId: "root-run", stepIndex: 0 }]);
+		process.env[SUBAGENT_PARENT_PATH_ENV] = JSON.stringify([
+			{ runId: "root-run", stepIndex: 0 },
+		]);
 		process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] = "inherited-token";
 
 		const { env } = buildPiArgs({
@@ -1093,7 +1299,10 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env[SUBAGENT_PARENT_RUN_ID_ENV], "current-nested-run");
 		assert.equal(env[SUBAGENT_PARENT_CHILD_INDEX_ENV], "2");
 		assert.equal(env[SUBAGENT_PARENT_DEPTH_ENV], "2");
-		assert.deepEqual(JSON.parse(env[SUBAGENT_PARENT_PATH_ENV] ?? "[]"), [{ runId: "root-run", stepIndex: 0 }, { runId: "current-nested-run", stepIndex: 2 }]);
+		assert.deepEqual(JSON.parse(env[SUBAGENT_PARENT_PATH_ENV] ?? "[]"), [
+			{ runId: "root-run", stepIndex: 0 },
+			{ runId: "current-nested-run", stepIndex: 2 },
+		]);
 	});
 
 	it("does not let direct MCP tools authorize child fanout", () => {
@@ -1114,10 +1323,16 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			mcpDirectTools: ["delegator"],
 		});
 
-		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
+		const extensionArgs = args.filter(
+			(arg, index) => args[index - 1] === "--extension",
+		);
 		assert.equal(args[args.indexOf("--tools") + 1], "read,delegator_subagent");
 		assert.equal(env[SUBAGENT_FANOUT_CHILD_ENV], "0");
-		assert.ok(!extensionArgs.some((arg) => arg.endsWith(path.join("src", "extension", "fanout-child.ts"))));
+		assert.ok(
+			!extensionArgs.some((arg) =>
+				arg.endsWith(path.join("src", "extension", "fanout-child.ts")),
+			),
+		);
 	});
 
 	it("keeps child-safe fanout registration in explicit extensions mode", () => {
@@ -1131,10 +1346,16 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			extensions: ["./agent-allowed-ext.ts"],
 		});
 
-		const extensionArgs = args.filter((arg, index) => args[index - 1] === "--extension");
+		const extensionArgs = args.filter(
+			(arg, index) => args[index - 1] === "--extension",
+		);
 		assert.ok(args.includes("--no-extensions"));
 		assert.equal(env[SUBAGENT_FANOUT_CHILD_ENV], "1");
-		assert.ok(extensionArgs.some((arg) => arg.endsWith(path.join("src", "extension", "fanout-child.ts"))));
+		assert.ok(
+			extensionArgs.some((arg) =>
+				arg.endsWith(path.join("src", "extension", "fanout-child.ts")),
+			),
+		);
 		assert.ok(extensionArgs.includes("./agent-allowed-ext.ts"));
 	});
 


### PR DESCRIPTION

## Problem

`nicobailon/pi-subagents` spawns children via subprocess (`pi -p`) with `--no-extensions` by default. The permission system never loads in children — all `deny`/`ask` rules, path gates, bash patterns, and MCP server rules are silently bypassed inside subagents.

## Solution

Two targeted changes in `src/runs/shared/pi-args.ts`:

1. **Auto-detect & append permission extension** — `resolvePermissionSystemExtension()` locates `@gotgenes/pi-permission-system` in the npm install directory and appends its entry point to `runtimeExtensions`. Respects `capabilityCeiling.denyExtensions` — skips injection when extensions are denied.

2. **Inject `<active_agent>` identity tag** — child system prompts get `<active_agent name="agentName"/>` prepended (XML-escaped). The permission system parses this to resolve per-agent `permission:` frontmatter rules.

## What already worked

- `PI_SUBAGENT_CHILD=1` env var → permission system detects subprocess children
- `PI_SUBAGENT_PARENT_SESSION` env var → `ask` prompts forward to parent UI
- `permission:` frontmatter parsing in agent config → flows through to child launch

## Files

| File | Change |
|---|---|
| `src/runs/shared/pi-args.ts` | New `resolvePermissionSystemExtension()` export. Extension gated on `denyExtensions`. `<active_agent>` tag with XML escaping. |
| `test/unit/pi-args.test.ts` | Two count assertions relaxed to `>=`. |
| `test/unit/pi-args-permission-system.test.ts` | New — 13 tests covering tag injection, XML escaping, extension detection, and `denyExtensions` bypass prevention. |

## Verification

- 63/63 tests pass (50 original + 13 new)
- Permission system detected in npm install directory
- `<active_agent>` tag XML-escaped for agent names with metacharacters
- Extension skipped when `capabilityCeiling.denyExtensions` is true
- Graceful when not installed: `resolvePermissionSystemExtension()` returns `undefined`