### PR TITLE
fix: preserve workflow child output after intercom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Verified scripted workflows can mix dynamic parallel and sequential phases with managed worktree isolation.
 
 ### Fixed
+- Preserve workflow child output after grouped intercom delivery, so scripts can consume `runs.run(...).output`. Thanks to @kaushal9696 for #846.
 - Let the Fleet inspector use the full 85% terminal-height budget on tall terminals. Thanks to @xz-dev for #839.
 - Launch Herdr inspector panes through a JavaScript bootstrap instead of asking Node to type-strip TypeScript installed under `node_modules`. Thanks to @williamleong for #837.
 - Removed the Pi CLI devDependency from the default install and test against a local runtime shim, so repo audits no longer report the upstream dev-only Undici advisory while real Pi E2E remains optional. Thanks to @dmg-egg for #782.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1631,6 +1631,7 @@ async function maybeBuildForegroundIntercomReceipt(input: {
 	mode: SubagentRunMode;
 	details: Details;
 	nestedChildren?: NestedRunSummary[];
+	preserveDetailsOutputs?: boolean;
 }): Promise<{ text: string; details: Details } | null> {
 	const payload = await emitForegroundResultIntercom({
 		pi: input.pi,
@@ -1645,7 +1646,7 @@ async function maybeBuildForegroundIntercomReceipt(input: {
 	if (!payload) return null;
 	return {
 		text: formatSubagentResultReceipt({ mode: input.mode, runId: input.runId, payload }),
-		details: stripDetailsOutputsForIntercomReceipt(input.details),
+		details: input.preserveDetailsOutputs ? input.details : stripDetailsOutputsForIntercomReceipt(input.details),
 	};
 }
 
@@ -3450,6 +3451,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				runId,
 				mode: "parallel",
 				details,
+				...(params.workflowParentRunId !== undefined ? { preserveDetailsOutputs: true } : {}),
 				...(foregroundControl?.nestedChildren?.length ? { nestedChildren: foregroundControl.nestedChildren } : {}),
 			});
 			if (intercomReceipt) {
@@ -3810,6 +3812,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			runId,
 			mode: "single",
 			details,
+			...(params.workflowParentRunId !== undefined ? { preserveDetailsOutputs: true } : {}),
 			...(foregroundControl?.nestedChildren?.length ? { nestedChildren: foregroundControl.nestedChildren } : {}),
 		});
 		if (intercomReceipt) {
@@ -3866,7 +3869,10 @@ function duplicateSubagentCallResult(params: SubagentParamsLike): AgentToolResul
 }
 
 function workflowChildResult(key: string, result: AgentToolResult<Details>): WorkflowScriptChildResult {
-	const output = result.content.map((part) => part.type === "text" ? part.text : "").filter(Boolean).join("\n");
+	const receiptOutput = result.content.map((part) => part.type === "text" ? part.text : "").filter(Boolean).join("\n");
+	const output = result.details.results.length === 1 && result.details.results[0]?.finalOutput !== undefined
+		? result.details.results[0].finalOutput
+		: receiptOutput;
 	const artifactPaths = new Set<string>();
 	if (result.details.asyncDir) artifactPaths.add(result.details.asyncDir);
 	if (result.details.parallelHandoff?.path) artifactPaths.add(result.details.parallelHandoff.path);
@@ -3881,7 +3887,7 @@ function workflowChildResult(key: string, result: AgentToolResult<Details>): Wor
 		ok: result.isError !== true,
 		...(result.details.runId || result.details.asyncId ? { runId: result.details.runId ?? result.details.asyncId } : {}),
 		output,
-		...(result.isError === true ? { error: output || "Child run failed." } : {}),
+		...(result.isError === true ? { error: receiptOutput || output || "Child run failed." } : {}),
 		...(structured.length === 1 ? { structuredOutput: structured[0] } : structured.length > 1 ? { structuredOutput: structured } : {}),
 		artifactPaths: [...artifactPaths],
 		results: result.details.results,

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -231,6 +231,23 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.match(String(payload.message ?? ""), /Full child output from worker/);
 	});
 
+	it("keeps child output available to workflow runs after grouped delivery", async () => {
+		mockPi.onCall({ output: "Workflow child output" });
+		const { executor, events } = makeExecutor({ resultDelivery: true });
+
+		const result = await executor.execute(
+			"workflow-intercom-output",
+			{ workflowScript: "const result = await runs.run('worker', { agent: 'worker', task: 'task' }); return result.output;", async: false },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(events.emitted.filter((entry) => entry.channel === "subagent:result-intercom").length, 1);
+		assert.match(result.content[0]?.text ?? "", /Workflow child output/);
+		assert.doesNotMatch(result.content[0]?.text ?? "", /Delivered single subagent result via intercom\./);
+	});
+
 	it("falls back to legacy foreground output when the bridge is inactive", async () => {
 		mockPi.onCall({ output: "Legacy foreground output" });
 		const { executor, events } = makeExecutor({ bridgeMode: "off" });


### PR DESCRIPTION
## Summary

Fix #846 by preserving child findings for workflow-owned `runs.run(...)` results after acknowledged grouped intercom delivery.

The compact receipt behavior stays in place for user-facing grouped intercom delivery, but workflow code now receives the child final output for programmatic branching.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/intercom-result-delivery.test.ts`
- `git diff --check`
- Fresh-context review: no issues found.

Thanks to @kaushal9696 for reporting #846.
