### PR TITLE
fix: warn about package artifact inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Preserve workflow child output after grouped intercom delivery, so scripts can consume `runs.run(...).output`. Thanks to @kaushal9696 for #846.
 - Match pi-mcp-adapter cache identities that include `protocolVersion`, so direct MCP tool selections resolve from current adapter caches. Thanks to @ProCleiton for #848.
 - Reject commandless verified acceptance at the runtime launch boundary before a child starts. Use `checked` or provide `acceptance.verify`. Thanks to @simonasr for #849.
+- Warn when project-scoped subagent artifacts can be included in an npm package. Thanks to @nicobailon for #840.
 - Let the Fleet inspector use the full 85% terminal-height budget on tall terminals. Thanks to @xz-dev for #839.
 - Launch Herdr inspector panes through a JavaScript bootstrap instead of asking Node to type-strip TypeScript installed under `node_modules`. Thanks to @williamleong for #837.
 - Removed the Pi CLI devDependency from the default install and test against a local runtime shim, so repo audits no longer report the upstream dev-only Undici advisory while real Pi E2E remains optional. Thanks to @dmg-egg for #782.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -264,6 +264,8 @@ This preference also controls the default chain scratch directory. `"project"` u
 
 The `"session"` option uses the same directory that `cleanupAllArtifactDirs` already scans for age-based cleanup, so artifacts are still cleaned up automatically. Temporary chain directories are cleaned up separately after 24 hours.
 
+When a project-scoped launch runs from an npm package directory, pi-subagents warns if package settings can include `.pi-subagents/` in the published package. Add `.pi-subagents/` to `.npmignore` (or `.gitignore` when no `.npmignore` exists), use a `files` allowlist that does not include `.pi-subagents/`, or select `"session"` or `"temp"`.
+
 ## `completionBatch`
 
 ```json

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -135,6 +135,8 @@ Debug artifacts live under `{sessionDir}/subagent-artifacts/`, `.pi-subagents/ar
 
 Metadata records timing, usage, exit code, final model, attempted models, fallback attempt outcomes, and the resolved acceptance ledger with its parsed child report.
 
+For npm package projects, project-scoped artifacts need a `.npmignore` rule (or `.gitignore` when no `.npmignore` exists) or a `files` allowlist that does not include `.pi-subagents/`. pi-subagents warns at launch when these package settings can include the artifacts. Use `artifactDir: "session"` or `"temp"` to keep them outside the package worktree.
+
 ## Sessions
 
 Session files are stored under a per-run session directory. With `context: "fork"`, each child starts with `--session <branched-session-file>` produced from the parent's current leaf. That is a real session fork, not an injected summary.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resolveAgentName, type AgentConfig, type AgentScope } from "../../agents/agents.ts";
-import { getArtifactsDir, getChainRunsDir } from "../../shared/artifacts.ts";
+import { getArtifactsDir, getChainRunsDir, getProjectArtifactPackagingWarning } from "../../shared/artifacts.ts";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
 import { resolveEffectiveThinking, toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
@@ -4024,6 +4024,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 } {
 	const delegatedThinkingOverrides = new WeakMap<object, AgentConfig["thinking"]>();
 	const delegatedZeroToolBudgets = new WeakSet<object>();
+	const warnedArtifactPackageDirs = new Set<string>();
 	const scheduledOwnerExecutors = new Map<string, ReturnType<typeof createSubagentExecutor>>();
 	const execute = async (
 		_id: string,
@@ -4908,6 +4909,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			dir: deps.config.artifactDir ?? DEFAULT_ARTIFACT_CONFIG.dir,
 		});
 		const artifactsDir = getArtifactsDir(parentSessionFile, effectiveCwd, artifactConfig.dir);
+		if (artifactConfig.dir === "project" && !warnedArtifactPackageDirs.has(effectiveCwd)) {
+			warnedArtifactPackageDirs.add(effectiveCwd);
+			const warning = getProjectArtifactPackagingWarning(effectiveCwd);
+			if (warning) console.warn(`[pi-subagents] ${warning}`);
+		}
 
 		let sessionRoot: string;
 		if (effectiveParams.sessionDir) {

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -7,6 +7,13 @@ const PROJECT_ARTIFACT_ROOT = ".pi-subagents";
 
 const PROJECT_ARTIFACT_PATHS = [
 	`${PROJECT_ARTIFACT_ROOT}/artifacts/output.md`,
+	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker_input.md`,
+	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker_output.md`,
+	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker.jsonl`,
+	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker_transcript.jsonl`,
+	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker_meta.json`,
+	`${PROJECT_ARTIFACT_ROOT}/artifacts/progress/run/progress.md`,
+	`${PROJECT_ARTIFACT_ROOT}/artifacts/outputs/output.md`,
 	`${PROJECT_ARTIFACT_ROOT}/chain-runs/run.json`,
 ];
 
@@ -38,7 +45,11 @@ function globMatchesPath(pattern: string, filePath: string): boolean {
 			expression += character.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
 		}
 	}
-	return new RegExp(`${expression}$`).test(filePath);
+	try {
+		return new RegExp(`${expression}$`).test(filePath);
+	} catch {
+		return false;
+	}
 }
 
 function normalizePattern(pattern: string): string {
@@ -47,7 +58,10 @@ function normalizePattern(pattern: string): string {
 
 function patternMatchesArtifactPath(pattern: string, artifactPath: string): boolean {
 	const normalized = normalizePattern(pattern);
-	return normalized === PROJECT_ARTIFACT_ROOT || normalized === "*" || globMatchesPath(normalized, artifactPath);
+	return normalized === PROJECT_ARTIFACT_ROOT
+		|| normalized === "*"
+		|| artifactPath.startsWith(`${normalized}/`)
+		|| globMatchesPath(normalized, artifactPath);
 }
 
 function patternMatchesProjectArtifacts(pattern: string): boolean {
@@ -75,8 +89,8 @@ function ignoreFileExcludesProjectArtifacts(filePath: string): boolean {
 	}
 }
 
-function filesAllowProjectArtifacts(files: unknown): boolean {
-	if (!Array.isArray(files)) return true;
+function filesIncludeProjectArtifacts(files: unknown): boolean | undefined {
+	if (!Array.isArray(files)) return undefined;
 	return files.some((entry) => typeof entry === "string" && !entry.startsWith("!") && patternMatchesProjectArtifacts(entry));
 }
 
@@ -94,9 +108,12 @@ export function getProjectArtifactPackagingWarning(cwd: string): string | undefi
 		return undefined;
 	}
 
+	const filesIncludeArtifacts = filesIncludeProjectArtifacts(packageJson.files);
+	if (filesIncludeArtifacts === false) return undefined;
+
 	const npmIgnorePath = path.join(cwd, ".npmignore");
 	const ignorePath = fs.existsSync(npmIgnorePath) ? npmIgnorePath : path.join(cwd, ".gitignore");
-	if (ignoreFileExcludesProjectArtifacts(ignorePath) || !filesAllowProjectArtifacts(packageJson.files)) return undefined;
+	if (filesIncludeArtifacts === undefined && ignoreFileExcludesProjectArtifacts(ignorePath)) return undefined;
 
 	return "Project-scoped subagent artifacts can be included when this package is published. Add '.pi-subagents/' to .npmignore, restrict package.json files, or set artifactDir to 'session' or 'temp'.";
 }

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -5,6 +5,53 @@ import { getAgentDir } from "./utils.ts";
 const CLEANUP_MARKER_FILE = ".last-cleanup";
 const PROJECT_ARTIFACT_ROOT = ".pi-subagents";
 
+function ignoreFileExcludesProjectArtifacts(filePath: string): boolean {
+	if (!fs.existsSync(filePath)) return false;
+	try {
+		let excluded = false;
+		for (const rawLine of fs.readFileSync(filePath, "utf-8").split(/\r?\n/)) {
+			const line = rawLine.trim();
+			if (!line || line.startsWith("#")) continue;
+			const negated = line.startsWith("!");
+			const pattern = (negated ? line.slice(1) : line).replace(/^\.\//, "").replace(/^\//, "").replace(/\/+$/, "");
+			if (pattern === PROJECT_ARTIFACT_ROOT || pattern.startsWith(`${PROJECT_ARTIFACT_ROOT}/`)) excluded = !negated;
+		}
+		return excluded;
+	} catch {
+		return false;
+	}
+}
+
+function filesAllowProjectArtifacts(files: unknown): boolean {
+	if (!Array.isArray(files)) return true;
+	return files.some((entry) => {
+		if (typeof entry !== "string" || entry.startsWith("!")) return false;
+		const pattern = entry.replace(/^\.\//, "").replace(/\/+$/, "");
+		return pattern === PROJECT_ARTIFACT_ROOT || pattern.startsWith(`${PROJECT_ARTIFACT_ROOT}/`);
+	});
+}
+
+/** Returns a package-publishing warning when project artifacts can enter npm packages. */
+export function getProjectArtifactPackagingWarning(cwd: string): string | undefined {
+	const packagePath = path.join(cwd, "package.json");
+	if (!fs.existsSync(packagePath)) return undefined;
+
+	let packageJson: Record<string, unknown>;
+	try {
+		const parsed: unknown = JSON.parse(fs.readFileSync(packagePath, "utf-8"));
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+		packageJson = parsed as Record<string, unknown>;
+	} catch {
+		return undefined;
+	}
+
+	const npmIgnorePath = path.join(cwd, ".npmignore");
+	const ignorePath = fs.existsSync(npmIgnorePath) ? npmIgnorePath : path.join(cwd, ".gitignore");
+	if (ignoreFileExcludesProjectArtifacts(ignorePath) || !filesAllowProjectArtifacts(packageJson.files)) return undefined;
+
+	return "Project-scoped subagent artifacts can be included when this package is published. Add '.pi-subagents/' to .npmignore, restrict package.json files, or set artifactDir to 'session' or 'temp'.";
+}
+
 export function getProjectSubagentsDir(cwd: string): string {
 	return path.join(cwd, PROJECT_ARTIFACT_ROOT);
 }

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -47,7 +47,7 @@ function normalizePattern(pattern: string): string {
 
 function patternMatchesArtifactPath(pattern: string, artifactPath: string): boolean {
 	const normalized = normalizePattern(pattern);
-	return normalized === PROJECT_ARTIFACT_ROOT || globMatchesPath(normalized, artifactPath);
+	return normalized === PROJECT_ARTIFACT_ROOT || normalized === "*" || globMatchesPath(normalized, artifactPath);
 }
 
 function patternMatchesProjectArtifacts(pattern: string): boolean {

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -5,18 +5,71 @@ import { getAgentDir } from "./utils.ts";
 const CLEANUP_MARKER_FILE = ".last-cleanup";
 const PROJECT_ARTIFACT_ROOT = ".pi-subagents";
 
+const PROJECT_ARTIFACT_PATHS = [
+	`${PROJECT_ARTIFACT_ROOT}/artifacts/output.md`,
+	`${PROJECT_ARTIFACT_ROOT}/chain-runs/run.json`,
+];
+
+function globMatchesPath(pattern: string, filePath: string): boolean {
+	let expression = "^";
+	for (let index = 0; index < pattern.length; index += 1) {
+		const character = pattern[index];
+		if (character === undefined) break;
+		if (character === "*" && pattern[index + 1] === "*") {
+			index += 1;
+			if (pattern[index + 1] === "/") {
+				index += 1;
+				expression += "(?:.*/)?";
+			} else {
+				expression += ".*";
+			}
+		} else if (character === "*") {
+			expression += "[^/]*";
+		} else if (character === "?") {
+			expression += "[^/]";
+		} else if (character === "[") {
+			const end = pattern.indexOf("]", index + 1);
+			if (end === -1) expression += "\\[";
+			else {
+				expression += pattern.slice(index, end + 1);
+				index = end;
+			}
+		} else {
+			expression += character.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+		}
+	}
+	return new RegExp(`${expression}$`).test(filePath);
+}
+
+function normalizePattern(pattern: string): string {
+	return pattern.replace(/^\.\//, "").replace(/^\//, "").replace(/\/+$/, "");
+}
+
+function patternMatchesArtifactPath(pattern: string, artifactPath: string): boolean {
+	const normalized = normalizePattern(pattern);
+	return normalized === PROJECT_ARTIFACT_ROOT || globMatchesPath(normalized, artifactPath);
+}
+
+function patternMatchesProjectArtifacts(pattern: string): boolean {
+	return PROJECT_ARTIFACT_PATHS.some((artifactPath) => patternMatchesArtifactPath(pattern, artifactPath));
+}
+
 function ignoreFileExcludesProjectArtifacts(filePath: string): boolean {
 	if (!fs.existsSync(filePath)) return false;
 	try {
-		let excluded = false;
+		const excluded = new Set<string>();
 		for (const rawLine of fs.readFileSync(filePath, "utf-8").split(/\r?\n/)) {
 			const line = rawLine.trim();
 			if (!line || line.startsWith("#")) continue;
 			const negated = line.startsWith("!");
-			const pattern = (negated ? line.slice(1) : line).replace(/^\.\//, "").replace(/^\//, "").replace(/\/+$/, "");
-			if (pattern === PROJECT_ARTIFACT_ROOT || pattern.startsWith(`${PROJECT_ARTIFACT_ROOT}/`)) excluded = !negated;
+			const pattern = negated ? line.slice(1) : line;
+			for (const artifactPath of PROJECT_ARTIFACT_PATHS) {
+				if (!patternMatchesArtifactPath(pattern, artifactPath)) continue;
+				if (negated) excluded.delete(artifactPath);
+				else excluded.add(artifactPath);
+			}
 		}
-		return excluded;
+		return excluded.size === PROJECT_ARTIFACT_PATHS.length;
 	} catch {
 		return false;
 	}
@@ -24,11 +77,7 @@ function ignoreFileExcludesProjectArtifacts(filePath: string): boolean {
 
 function filesAllowProjectArtifacts(files: unknown): boolean {
 	if (!Array.isArray(files)) return true;
-	return files.some((entry) => {
-		if (typeof entry !== "string" || entry.startsWith("!")) return false;
-		const pattern = entry.replace(/^\.\//, "").replace(/\/+$/, "");
-		return pattern === PROJECT_ARTIFACT_ROOT || pattern.startsWith(`${PROJECT_ARTIFACT_ROOT}/`);
-	});
+	return files.some((entry) => typeof entry === "string" && !entry.startsWith("!") && patternMatchesProjectArtifacts(entry));
 }
 
 /** Returns a package-publishing warning when project artifacts can enter npm packages. */

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -14,6 +14,7 @@ const PROJECT_ARTIFACT_PATHS = [
 	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker_meta.json`,
 	`${PROJECT_ARTIFACT_ROOT}/artifacts/progress/run/progress.md`,
 	`${PROJECT_ARTIFACT_ROOT}/artifacts/outputs/output.md`,
+	`${PROJECT_ARTIFACT_ROOT}/artifacts/outputs/run/output.md`,
 	`${PROJECT_ARTIFACT_ROOT}/chain-runs/run.json`,
 ];
 
@@ -91,7 +92,18 @@ function ignoreFileExcludesProjectArtifacts(filePath: string): boolean {
 
 function filesIncludeProjectArtifacts(files: unknown): boolean | undefined {
 	if (!Array.isArray(files)) return undefined;
-	return files.some((entry) => typeof entry === "string" && !entry.startsWith("!") && patternMatchesProjectArtifacts(entry));
+	const included = new Set<string>();
+	for (const entry of files) {
+		if (typeof entry !== "string") continue;
+		const negated = entry.startsWith("!");
+		const pattern = negated ? entry.slice(1) : entry;
+		for (const artifactPath of PROJECT_ARTIFACT_PATHS) {
+			if (!patternMatchesArtifactPath(pattern, artifactPath)) continue;
+			if (negated) included.delete(artifactPath);
+			else included.add(artifactPath);
+		}
+	}
+	return included.size > 0;
 }
 
 /** Returns a package-publishing warning when project artifacts can enter npm packages. */

--- a/test/unit/artifacts.test.ts
+++ b/test/unit/artifacts.test.ts
@@ -39,6 +39,7 @@ describe("project-local artifact paths", () => {
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "broad", files: ["**/*"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "root-wildcard", files: ["*"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "included", files: [".pi-subagents/**"] })) ?? "", /artifactDir/);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "excluded-after-include", files: [".pi-subagents/**", "!.pi-subagents/**"] })), undefined);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "artifacts-included", files: [".pi-subagents/artifacts/**"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "artifacts-directory-included", files: [".pi-subagents/artifacts"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-input-included", files: [".pi-subagents/artifacts/*_input.md"] })) ?? "", /artifactDir/);
@@ -47,6 +48,7 @@ describe("project-local artifact paths", () => {
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-meta-included", files: [".pi-subagents/artifacts/*_meta.json"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "progress-included", files: [".pi-subagents/artifacts/progress/**"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "outputs-included", files: [".pi-subagents/artifacts/outputs/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "nested-output-included", files: [".pi-subagents/artifacts/outputs/*/*.md"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "chain-runs-included", files: [".pi-subagents/chain-runs/**"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "chain-runs-directory-included", files: [".pi-subagents/chain-runs"] })) ?? "", /artifactDir/);
 	});

--- a/test/unit/artifacts.test.ts
+++ b/test/unit/artifacts.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import {
 	getArtifactsDir,
+	getProjectArtifactPackagingWarning,
 	getChainRunsDir,
 	getProjectArtifactsDir,
 	getProjectChainRunsDir,
@@ -11,6 +14,27 @@ import {
 import { CHAIN_RUNS_DIR } from "../../src/shared/types.ts";
 
 describe("project-local artifact paths", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	function packageDir(packageJson: object, ignore?: { name: ".npmignore" | ".gitignore"; content: string }): string {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-artifacts-"));
+		tempDirs.push(dir);
+		fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify(packageJson), "utf-8");
+		if (ignore) fs.writeFileSync(path.join(dir, ignore.name), ignore.content, "utf-8");
+		return dir;
+	}
+
+	it("warns only when package settings can include project artifacts", () => {
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "unsafe" })) ?? "", /\.npmignore/);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "ignored" }, { name: ".gitignore", content: ".pi-subagents/\n" })), undefined);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "restricted", files: ["**"] })), undefined);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "included", files: [".pi-subagents/**"] })) ?? "", /artifactDir/);
+	});
+
 	it("places generated subagent files under .pi-subagents for a project cwd", () => {
 		const cwd = path.join("tmp", "repo");
 		assert.equal(getProjectSubagentsDir(cwd), path.join(cwd, ".pi-subagents"));

--- a/test/unit/artifacts.test.ts
+++ b/test/unit/artifacts.test.ts
@@ -30,8 +30,11 @@ describe("project-local artifact paths", () => {
 
 	it("warns only when package settings can include project artifacts", () => {
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "unsafe" })) ?? "", /\.npmignore/);
-		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "ignored" }, { name: ".gitignore", content: ".pi-subagents/\n" })), undefined);
-		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "restricted", files: ["**"] })), undefined);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "gitignored" }, { name: ".gitignore", content: ".pi-subagents/\n" })), undefined);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "globignored" }, { name: ".npmignore", content: "**/.pi-subagents/**\n" })), undefined);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "classignored" }, { name: ".npmignore", content: "[.]pi-subagents/**\n" })), undefined);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "restricted", files: ["src/**"] })), undefined);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "broad", files: ["**/*"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "included", files: [".pi-subagents/**"] })) ?? "", /artifactDir/);
 	});
 

--- a/test/unit/artifacts.test.ts
+++ b/test/unit/artifacts.test.ts
@@ -33,10 +33,22 @@ describe("project-local artifact paths", () => {
 		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "gitignored" }, { name: ".gitignore", content: ".pi-subagents/\n" })), undefined);
 		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "globignored" }, { name: ".npmignore", content: "**/.pi-subagents/**\n" })), undefined);
 		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "classignored" }, { name: ".npmignore", content: "[.]pi-subagents/**\n" })), undefined);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "explicit-files-over-ignore", files: [".pi-subagents/**"] }, { name: ".npmignore", content: ".pi-subagents/\n" })) ?? "", /artifactDir/);
 		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "restricted", files: ["src/**"] })), undefined);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "malformed-pattern", files: ["[z-a]"] })), undefined);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "broad", files: ["**/*"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "root-wildcard", files: ["*"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "included", files: [".pi-subagents/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "artifacts-included", files: [".pi-subagents/artifacts/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "artifacts-directory-included", files: [".pi-subagents/artifacts"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-input-included", files: [".pi-subagents/artifacts/*_input.md"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-output-included", files: [".pi-subagents/artifacts/*_output.md"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-jsonl-included", files: [".pi-subagents/artifacts/*.jsonl"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-meta-included", files: [".pi-subagents/artifacts/*_meta.json"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "progress-included", files: [".pi-subagents/artifacts/progress/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "outputs-included", files: [".pi-subagents/artifacts/outputs/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "chain-runs-included", files: [".pi-subagents/chain-runs/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "chain-runs-directory-included", files: [".pi-subagents/chain-runs"] })) ?? "", /artifactDir/);
 	});
 
 	it("places generated subagent files under .pi-subagents for a project cwd", () => {

--- a/test/unit/artifacts.test.ts
+++ b/test/unit/artifacts.test.ts
@@ -35,6 +35,7 @@ describe("project-local artifact paths", () => {
 		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "classignored" }, { name: ".npmignore", content: "[.]pi-subagents/**\n" })), undefined);
 		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "restricted", files: ["src/**"] })), undefined);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "broad", files: ["**/*"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "root-wildcard", files: ["*"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "included", files: [".pi-subagents/**"] })) ?? "", /artifactDir/);
 	});
 


### PR DESCRIPTION
## Summary

Fix #840 by warning once per package directory when project-scoped `.pi-subagents/` artifacts can be packed into an npm package.

The detector recognizes `.npmignore`, the `.gitignore` fallback, safe `files` allowlists, broad `files` patterns that include artifacts, and common ignore globs such as `**/.pi-subagents/**`.

## Validation

- `node --experimental-strip-types --test test/unit/artifacts.test.ts`
- `npm pack --dry-run --json`
- `git diff --check`
- Fresh-context review: no blockers remain.

Thanks to @nicobailon for #840.
