### PR TITLE
fix: match MCP cache protocol hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Keep async subagent widget spinners moving during quiet running periods without adding extra polling.
 - Preserve workflow child output after grouped intercom delivery, so scripts can consume `runs.run(...).output`. Thanks to @kaushal9696 for #846.
+- Match pi-mcp-adapter cache identities that include `protocolVersion`, so direct MCP tool selections resolve from current adapter caches. Thanks to @ProCleiton for #848.
 - Let the Fleet inspector use the full 85% terminal-height budget on tall terminals. Thanks to @xz-dev for #839.
 - Launch Herdr inspector panes through a JavaScript bootstrap instead of asking Node to type-strip TypeScript installed under `node_modules`. Thanks to @williamleong for #837.
 - Removed the Pi CLI devDependency from the default install and test against a local runtime shim, so repo audits no longer report the upstream dev-only Undici advisory while real Pi E2E remains optional. Thanks to @dmg-egg for #782.

--- a/src/runs/shared/mcp-direct-tool-allowlist.ts
+++ b/src/runs/shared/mcp-direct-tool-allowlist.ts
@@ -38,6 +38,7 @@ interface ServerEntry {
 	exposeResources?: boolean;
 	includeTools?: string[];
 	excludeTools?: string[];
+	protocolVersion?: string;
 	directTools?: boolean | string[];
 }
 
@@ -284,6 +285,7 @@ export function computeMcpServerHash(definition: ServerEntry): string {
 		exposeResources: definition.exposeResources,
 		includeTools: definition.includeTools,
 		excludeTools: definition.excludeTools,
+		protocolVersion: definition.protocolVersion,
 	};
 	return createHash("sha256").update(stableStringify(identity)).digest("hex");
 }

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -94,6 +94,7 @@ function writeMcpFixture(
 		resources?: Array<{ name: string; uri: string; description?: string }>;
 		configPath?: string;
 		cachedAt?: number;
+		configHash?: string;
 	} = {},
 ): void {
 	const serverName = options.serverName ?? "chrome-devtools";
@@ -108,7 +109,7 @@ function writeMcpFixture(
 		version: 1,
 		servers: {
 			[serverName]: {
-				configHash: computeMcpServerHash(definition),
+				configHash: options.configHash ?? computeMcpServerHash(definition),
 				cachedAt: options.cachedAt ?? Date.now(),
 				tools: options.tools ?? [
 					{ name: "take_screenshot" },
@@ -676,16 +677,20 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(args[args.indexOf("--tools") + 1], "read,bash");
 	});
 
-	it("includes adapter tool filters in MCP cache identity", () => {
+	it("includes adapter tool filters and protocol version in MCP cache identity", () => {
 		const base = { command: "npx", args: ["browser-mcp"] };
 
 		assert.notEqual(
 			computeMcpServerHash(base),
 			computeMcpServerHash({ ...base, includeTools: ["browser_navigate"] }),
 		);
+		assert.notEqual(
+			computeMcpServerHash(base),
+			computeMcpServerHash({ ...base, protocolVersion: "2025-03-26" }),
+		);
 	});
 
-	it("matches pi-mcp-adapter 2.15.0 metadata cache hashes", () => {
+	it("matches pi-mcp-adapter 2.20.1 metadata cache hashes", () => {
 		process.env.MCP_HASH_ROOT = "/tmp/mcp-root";
 		process.env.MCP_HASH_TOKEN = "token-value";
 
@@ -709,9 +714,9 @@ describe("buildPiArgs system prompt mode wiring", () => {
 				computeMcpServerHash({ socket: "{env:MCP_HASH_ROOT}/rmcp.sock" }),
 			],
 			[
-				"8af47bd5a801f42bd252789826df883c6f4db6f1d425b82f8561d75063fbe3a8",
-				"77db141e556d24c3740a4b4f0cd50d8c23309a28062282cc1ca724207359ef5a",
-				"77f7f77a3e8df990d8c78e99ca81508fd8d1f954e814ee7cbfa46719f71eb46b",
+				"e78fc93f972eabed6a17c81a253765e013089b082dc8c0a05e9dfe6cb0cb8248",
+				"90c5d968d664477fe0c72f3978c744ae9e44c8b0adc529685d0c5f337061b4a5",
+				"a1d6c326455134aa82feb4523939d6f987f85577fa4cae410f6fb8408cbf750d",
 			],
 		);
 	});
@@ -734,6 +739,28 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
 		assert.equal(env[REQUIRED_CHILD_TOOLS_ENV], JSON.stringify(["read", "bash", "chrome_devtools_take_screenshot", "chrome_devtools_click"]));
 		assert.equal(env[MCP_DIRECT_CHILD_TOOLS_ENV], JSON.stringify(["chrome_devtools_take_screenshot", "chrome_devtools_click"]));
+	});
+
+	it("resolves direct MCP tool selections from adapter-style protocol version cache entries", () => {
+		const fixture = createMcpFixture();
+		writeMcpFixture(fixture, {
+			serverName: "github",
+			definition: { command: "github-mcp", protocolVersion: "2025-03-26" },
+			configHash: "25b77b7189f1c5fe80b028cb84eb393532528231ac39081fe97c4e2ee7fa086b",
+			tools: [{ name: "search_repositories" }],
+		});
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["github/search_repositories"],
+		});
+
+		assert.equal(args[args.indexOf("--tools") + 1], "read,github_search_repositories");
 	});
 
 	it("emits --no-tools for explicit empty tool allowlists", () => {


### PR DESCRIPTION
## Summary

Fix #848 by including `protocolVersion` in the MCP server cache hash identity. This makes pi-subagents agree with pi-mcp-adapter 2.20.1 cache entries, so `mcp:<server>` frontmatter can resolve cached direct tools again.

## Validation

- `node --experimental-strip-types --test test/unit/pi-args.test.ts test/unit/preflight.test.ts`
- `git diff --check origin/main...HEAD`
- Fresh-context review: no findings.

Thanks to @ProCleiton for the report in #848.
