### PR TITLE
fix: accept mission summary launch alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added native `@gotgenes/pi-permission-system` compatibility for child processes. Thanks to @jagaliano for #847.
 
 ### Fixed
+- Accept `mission.summary` as a title alias for workflow launches, so child runs start normally.
 - Keep async subagent widget spinners moving during quiet running periods without adding extra polling.
 - Preserve workflow child output after grouped intercom delivery, so scripts can consume `runs.run(...).output`. Thanks to @kaushal9696 for #846.
 - Match pi-mcp-adapter cache identities that include `protocolVersion`, so direct MCP tool selections resolve from current adapter caches. Thanks to @ProCleiton for #848.

--- a/src/missions/actions.ts
+++ b/src/missions/actions.ts
@@ -101,17 +101,19 @@ export function validateMissionLaunch(value: unknown): MissionLaunchInput {
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("mission must be an object");
 	const input = value as Record<string, unknown>;
 	for (const key of Object.keys(input)) {
-		if (key !== "title" && key !== "goal" && key !== "labels") throw new Error(`mission.${key} is unknown`);
+		if (key !== "title" && key !== "summary" && key !== "goal" && key !== "labels") throw new Error(`mission.${key} is unknown`);
 	}
-	if (typeof input.title !== "string" || !input.title.trim()) throw new Error("mission.title must be a non-empty string");
+	if (input.title !== undefined && input.summary !== undefined) throw new Error("mission.title and mission.summary cannot both be set");
+	const title = input.title ?? input.summary;
+	if (typeof title !== "string" || !title.trim()) throw new Error("mission.title or mission.summary must be a non-empty string");
 	if (input.goal !== undefined && (typeof input.goal !== "string" || !input.goal.trim())) throw new Error("mission.goal must be a non-empty string");
 	if (input.labels !== undefined && (!Array.isArray(input.labels) || input.labels.some((label) => typeof label !== "string" || !label.trim()))) {
 		throw new Error("mission.labels must contain only non-empty strings");
 	}
 	return {
-		title: input.title.trim(),
-		...(typeof input.goal === "string" ? { goal: input.goal.trim() } : {}),
-		...(Array.isArray(input.labels) ? { labels: input.labels as string[] } : {}),
+		title: title.trim(),
+		...(input.goal !== undefined ? { goal: input.goal.trim() } : {}),
+		...(input.labels !== undefined ? { labels: input.labels.map((label) => label.trim()) } : {}),
 	};
 }
 

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -384,7 +384,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		const result = await executor.execute(
 			runId,
-			{ workflowScript: `emit("starting"); await runs.run("work", { agent: "echo", task: "Async work" }); return { answer: 42 };` },
+			{
+				workflowScript: `emit("starting"); await runs.run("work", { agent: "echo", task: "Async work" }); return { answer: 42 };`,
+				mission: { summary: "Review the active backlog", labels: ["github-backlog", "review"] },
+			},
 			new AbortController().signal,
 			undefined,
 			makeMinimalCtx(tempDir),
@@ -404,6 +407,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(status.state, "complete");
 		assert.deepEqual(status.workflow?.value, { answer: 42 });
 		assert.deepEqual(status.workflow?.emits, ["starting"]);
+		assert.equal(mockPi.callCount(), 1);
 		assert.ok(status.workflow?.trace?.some((entry) => entry.key === "work" && entry.state === "completed"));
 		const persistedResult = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${runId}.json`), "utf-8")) as { agent?: string; summary?: string; workflow?: { value?: unknown } };
 		assert.equal(persistedResult.agent, "workflow");

--- a/test/unit/mission-lifecycle.test.ts
+++ b/test/unit/mission-lifecycle.test.ts
@@ -71,6 +71,15 @@ describe("mission launch lifecycle", () => {
 				config: { ...test.missionConfig, enabled: false },
 			});
 			assert.ok(explicit);
+
+			const summaryAlias = prepareMissionLaunch({
+				params: { mission: { summary: "Review active backlog", labels: ["review"] }, task: "Review the current diff" },
+				projectRoot: test.projectRoot,
+				config: test.missionConfig,
+			});
+			assert.ok(summaryAlias);
+			assert.deepEqual(readMission(summaryAlias.location, summaryAlias.missionId).labels, ["review"]);
+			assert.equal(readMission(summaryAlias.location, summaryAlias.missionId).title, "Review active backlog");
 		} finally {
 			fs.rmSync(test.root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

Accept `mission.summary` as a launch-time alias for the canonical mission title. This fixes async `workflowScript` calls that pass a mission object with `summary` and `labels`, so child runs start instead of failing with `mission.summary is unknown`.

The validator now rejects ambiguous calls that set both `title` and `summary`.

## Validation

- `npm run typecheck -- --pretty false`
- `node --experimental-strip-types --test test/unit/mission-lifecycle.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='starts workflow scripts asynchronously by default and persists live status' test/integration/single-execution.test.ts`
- `git diff --check`

Fresh review found no concrete release risks.

Closes #856.
