### PR TITLE
fix: prevent narrow TUI render crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Prevent Pi from crashing when subagent status widgets and overlays are shown in narrow or resized terminal layouts. Thanks to @alanvardy for the report in #858 and @meatcar for the fix.
+
 ## [0.42.0] - 2026-08-06
 
 ### Added

--- a/src/runs/foreground/chain-clarify.ts
+++ b/src/runs/foreground/chain-clarify.ts
@@ -882,25 +882,22 @@ export class ChainClarifyComponent implements Component {
 		}
 	}
 
-	render(_width: number): string[] {
+	render(width: number): string[] {
+		let lines: string[] = [];
 		if (this.editingStep !== null) {
-			if (this.editMode === "model") {
-				return this.renderModelSelector();
+			if (this.editMode === "model") lines = this.renderModelSelector();
+			else if (this.editMode === "thinking") lines = this.renderThinkingSelector();
+			else if (this.editMode === "skills") lines = this.renderSkillSelector();
+			else lines = this.renderFullEditMode();
+		} else {
+			switch (this.mode) {
+				case 'single': lines = this.renderSingleMode(); break;
+				case 'parallel': lines = this.renderParallelMode(); break;
+				case 'chain': lines = this.renderChainMode(); break;
 			}
-			if (this.editMode === "thinking") {
-				return this.renderThinkingSelector();
-			}
-			if (this.editMode === "skills") {
-				return this.renderSkillSelector();
-			}
-			return this.renderFullEditMode();
 		}
-		// Mode-based navigation rendering
-		switch (this.mode) {
-			case 'single': return this.renderSingleMode();
-			case 'parallel': return this.renderParallelMode();
-			case 'chain': return this.renderChainMode();
-		}
+		const renderWidth = Math.max(0, Math.min(this.width, Math.floor(width)));
+		return lines.map((line) => truncateToWidth(line, renderWidth));
 	}
 
 	/** Render the model selector view */

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { keyText, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { Key, matchesKey, type Component, type TUI } from "@earendil-works/pi-tui";
+import { Key, matchesKey, truncateToWidth, type Component, type TUI } from "@earendil-works/pi-tui";
 import { BUILTIN_AGENT_NAMES, discoverAgents } from "../agents/agents.ts";
 import {
 	DEFAULT_PROVIDER_MODELS_MAX_AGE_DAYS,
@@ -281,7 +281,7 @@ class SubagentsStopSelector implements Component {
 	invalidate(): void {}
 
 	render(width: number): string[] {
-		const contentWidth = Math.max(40, Math.min(this.width, width || this.width));
+		const contentWidth = Math.max(0, Math.min(this.width, Math.floor(width)));
 		const lines = [this.theme.bold("Stop subagent run"), this.theme.fg("dim", "Select a current-session async run to stop, or a scheduled run to cancel."), ""];
 		const maxRows = 10;
 		const start = Math.max(0, Math.min(this.selected - maxRows + 1, Math.max(0, this.targets.length - maxRows)));
@@ -305,7 +305,7 @@ class SubagentsStopSelector implements Component {
 		} else {
 			lines.push(this.theme.fg("dim", "↑↓/jk select · Enter confirm · Esc cancel"));
 		}
-		return lines;
+		return lines.map((line) => truncateToWidth(line, contentWidth));
 	}
 }
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1291,7 +1291,8 @@ function collapsedWidgetLineBudget(rows: number): number {
 }
 
 function paddedWidgetLine(line: string, width: number): string {
-	const text = ` ${line} `;
+	if (width <= 2) return " ".repeat(Math.max(0, width));
+	const text = ` ${truncLine(line, width - 2)} `;
 	return `${text}${" ".repeat(Math.max(0, width - visibleWidth(text)))}`;
 }
 
@@ -1352,7 +1353,7 @@ function buildWidgetComponent(jobs: AsyncJobState[], expanded: boolean): (tui: {
 		widgetRequestRender = requestRender;
 		const container = new Container();
 		container.render = (renderWidth: number): string[] => {
-			const width = getTermWidth();
+			const width = Math.max(0, renderWidth - 2);
 			const frame = widgetAnimationFrame();
 			const lines = expanded
 				? buildWidgetLines(jobs, theme, width, true, frame)

--- a/test/integration/chain-clarify.test.ts
+++ b/test/integration/chain-clarify.test.ts
@@ -304,7 +304,7 @@ describe("chain clarify model display", { skip: !available ? "pi packages not av
 		assert.equal(component.getEffectiveModel(0), "github-copilot/gpt-5:high");
 	});
 
-	it("labels every shortcut and keeps the clarify overlay within 84 columns", () => {
+	it("labels every shortcut and keeps the clarify overlay within its allocated width", () => {
 		for (const mode of ["single", "parallel", "chain"] as const) {
 			const count = mode === "single" ? 1 : mode === "parallel" ? 2 : 4;
 			const component = new ChainClarifyComponent(
@@ -362,6 +362,23 @@ describe("chain clarify model display", { skip: !available ? "pi packages not av
 			}
 			for (const line of initialLines) {
 				assert.equal(visibleWidth(line), 84, `${mode} line did not match component width: ${line}`);
+			}
+			for (const width of [0, 1, 2, 3, 74]) {
+				for (const line of component.render(width)) {
+					assert.ok(visibleWidth(line) <= width, `${mode} line exceeded constrained render width: ${visibleWidth(line)} > ${width}`);
+				}
+			}
+
+			if (mode === "single") {
+				component.editingStep = 0;
+				component.enterModelSelector();
+				for (let index = 0; index < 100; index++) component.handleModelSelectorInput("x");
+				for (const width of [0, 1, 2, 3, 74, 84]) {
+					for (const line of component.render(width)) {
+						assert.ok(visibleWidth(line) <= width, `model selector line exceeded component width: ${visibleWidth(line)} > ${width}`);
+					}
+				}
+				component.editingStep = null;
 			}
 
 			component.handleInput("b");

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
 
 const { buildWidgetLines, clearLegacyResultAnimationTimer, renderWidget, requestWidgetRender } = await import("../../src/tui/render.ts") as {
 	buildWidgetLines: (jobs: Array<Record<string, unknown>>, theme: { fg(name: string, text: string): string; bold(text: string): string }, width?: number, expanded?: boolean, frame?: number) => string[];
@@ -154,6 +155,38 @@ describe("subagent async widget rendering", () => {
 		assert.match(text, /Press configured-expand-key for live detail/);
 		assert.doesNotMatch(text, /widget truncated/);
 		assert.ok(lines.length <= 10, "collapsed component should stay under Pi's string-widget cap even though it bypasses it");
+	});
+
+	it("honors the component render width instead of the terminal width", () => {
+		resetWidgetLayout();
+		withStdoutSize(50, 120, () => {
+			const ui = createUiContext();
+			renderWidget(ui.ctx as never, [{
+				asyncId: "run-narrow",
+				asyncDir: "/tmp/pi-subagents-uid-1000/async-subagent-runs/call_with_a_long_identifier",
+				status: "running",
+				mode: "parallel",
+				agents: ["correctness", "tests-maintainability"],
+				activeParallelGroup: true,
+				runningSteps: 2,
+				completedSteps: 0,
+				stepsTotal: 2,
+				steps: [
+					{ index: 0, agent: "correctness", status: "running" },
+					{ index: 1, agent: "tests-maintainability", status: "running" },
+				],
+			}]);
+
+			const widget = ui.widgets.at(-1);
+			for (const width of [0, 1, 2, 3, 74]) {
+				const lines = renderWidgetLines(widget, width);
+				assert.ok(lines.length > 0);
+				for (const line of lines) {
+					assert.ok(visibleWidth(line) <= width, `widget line exceeds render width: ${visibleWidth(line)} > ${width}`);
+				}
+			}
+		});
+		resetWidgetLayout();
 	});
 
 	it("locks crowded collapsed widget height for the current terminal session", () => {

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { beforeEach, describe, it } from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
 
 import { scheduledRunStorePath } from "../../src/runs/background/scheduled-runs.ts";
 import { SUBAGENT_FANOUT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
@@ -476,6 +477,64 @@ describe("subagents watchdog slash command", { skip: !available ? "watchdog comm
 describe("slash command custom message delivery", { skip: !available ? "slash-commands.ts not importable" : undefined }, () => {
 	beforeEach(() => {
 		clearSlashSnapshots?.();
+	});
+
+	it("/subagents-stop keeps the selector within its allocated width", async () => {
+		await withTempProject("pi-stop-selector-width-", async (root) => {
+			const id = "scheduled-width-check";
+			const nextRunAt = "2099-01-01T00:00:00.000Z";
+			const scheduleDir = path.join(scheduledRunStorePath(root), id);
+			fs.mkdirSync(scheduleDir, { recursive: true });
+			fs.writeFileSync(path.join(scheduleDir, "schedule.json"), JSON.stringify({
+				schemaVersion: 1,
+				id,
+				name: "A very long scheduled run name with wide characters 中文🙂",
+				cwd: root,
+				trigger: { kind: "once", at: nextRunAt, nextRunAt },
+				target: { agent: "scout", task: "Inspect" },
+				overlap: "skip",
+				catchUp: "latest",
+				paused: false,
+				createdAt: "2026-08-06T00:00:00.000Z",
+				updatedAt: "2026-08-06T00:00:00.000Z",
+			}), "utf-8");
+
+			const commands = new Map<string, RegisteredSlashCommand>();
+			const pi = {
+				events: createEventBus(),
+				registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+				registerShortcut() {},
+				sendMessage() {},
+			};
+			const rendered = new Map<number, string[]>();
+			registerSlashCommands!(pi as never, createState(root));
+			await commands.get("subagents-stop")!.handler("", createCommandContext({
+				cwd: root,
+				hasUI: true,
+				custom: async (factory) => {
+					const component = (factory as (
+						tui: { requestRender(): void },
+						theme: { fg(name: string, text: string): string; bold(text: string): string },
+						keybindings: unknown,
+						done: (result: unknown) => void,
+					) => { render(width: number): string[] })(
+						{ requestRender() {} },
+						{ fg: (_name, text) => text, bold: (text) => text },
+						{},
+						() => {},
+					);
+					for (const width of [0, 1, 2, 3, 32]) rendered.set(width, component.render(width));
+					return undefined;
+				},
+			}));
+
+			for (const [width, lines] of rendered) {
+				assert.ok(lines.length > 0);
+				for (const line of lines) {
+					assert.ok(visibleWidth(line) <= width, `stop selector line exceeds render width: ${visibleWidth(line)} > ${width}`);
+				}
+			}
+		});
 	});
 
 	it("/run accepts an agent without a task", async () => {


### PR DESCRIPTION
Fixes #858.

This is a maintainer replacement for #859 so the exact head can run the repo GitHub Actions gate from an origin branch.

It preserves @meatcar's narrow-layout TUI width fix and keeps visible changelog credit for @alanvardy’s report in #858 and @meatcar’s implementation in #859.

Validation run locally on this exact branch:

```text
node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'honors the component render width|labels every shortcut and keeps the clarify overlay within its allocated width|/subagents-stop keeps the selector within its allocated width' test/integration/render-widget.test.ts test/integration/chain-clarify.test.ts test/integration/slash-commands.test.ts
npm run typecheck
```
