### PR TITLE
tests: avoid deletion of real user files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Require workflowScript-only persisted schedule targets. Removed legacy agent-target restore conversion.
 
 ### Fixed
+- Prevent path-resolution tests from modifying or deleting the user's real `~/.agents` directory. Thanks to @meatcar for the report and fix in #865.
 - Show the target agent for simple scheduled one-child workflow scripts and mark dynamic scripts clearly.
 - Stop quiet async status widget animation redraws from spilling progress updates into the editor input area.
 

--- a/test/unit/path-resolution.test.ts
+++ b/test/unit/path-resolution.test.ts
@@ -6,29 +6,40 @@ import * as path from "node:path";
 import { discoverAgents } from "../../src/agents/agents.ts";
 import { resolveSkillPath, clearSkillCache } from "../../src/agents/skills.ts";
 
-const tmpDir = path.join(os.tmpdir(), "pi-path-resolution-test");
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-path-resolution-"));
 const cwdDir = path.join(tmpDir, "cwd");
+const homeDir = path.join(tmpDir, "home");
+const userAgentsDir = path.join(homeDir, ".agents");
+const userAgentsCanary = path.join(userAgentsDir, ".data-loss-canary");
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 
-const realHomeDir = os.homedir();
-const realUserAgentsDir = path.join(realHomeDir, ".agents");
-const userAgentsDirBackup = path.join(tmpDir, ".agents_backup");
+function restoreEnv(name: "HOME" | "USERPROFILE" | "PI_CODING_AGENT_DIR", value: string | undefined): void {
+	if (value === undefined) delete process.env[name];
+	else process.env[name] = value;
+}
 
 before(() => {
 	fs.mkdirSync(cwdDir, { recursive: true });
-
-	if (fs.existsSync(realUserAgentsDir)) {
-		fs.cpSync(realUserAgentsDir, userAgentsDirBackup, { recursive: true });
-	}
+	fs.mkdirSync(path.join(userAgentsDir, "skills"), { recursive: true });
+	fs.writeFileSync(userAgentsCanary, "preserve me");
+	process.env.HOME = homeDir;
+	process.env.USERPROFILE = homeDir;
+	assert.equal(os.homedir(), homeDir);
+	process.env.PI_CODING_AGENT_DIR = path.join(homeDir, ".pi", "agent");
 });
 
 after(() => {
-	if (fs.existsSync(userAgentsDirBackup)) {
-		fs.rmSync(realUserAgentsDir, { recursive: true, force: true });
-		fs.cpSync(userAgentsDirBackup, realUserAgentsDir, { recursive: true });
-	} else {
-		fs.rmSync(realUserAgentsDir, { recursive: true, force: true });
+	try {
+		assert.equal(fs.readFileSync(userAgentsCanary, "utf-8"), "preserve me");
+	} finally {
+		restoreEnv("HOME", originalHome);
+		restoreEnv("USERPROFILE", originalUserProfile);
+		restoreEnv("PI_CODING_AGENT_DIR", originalAgentDir);
+		clearSkillCache();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
 	}
-	fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("Path resolution for .agents and ~/.agents", () => {
@@ -44,7 +55,7 @@ describe("Path resolution for .agents and ~/.agents", () => {
 	});
 
 	test("should resolve skills in ~/.agents/skills", () => {
-		const userSkillsDir = path.join(realHomeDir, ".agents", "skills");
+		const userSkillsDir = path.join(userAgentsDir, "skills");
 		fs.mkdirSync(userSkillsDir, { recursive: true });
 		fs.writeFileSync(path.join(userSkillsDir, "test-skill-2.md"), "---\nname: test-skill-2\ndescription: test desc\n---\nSkill content");
 
@@ -79,8 +90,6 @@ describe("Path resolution for .agents and ~/.agents", () => {
 	});
 
 	test("should resolve agents in ~/.agents", () => {
-		const userAgentsDir = path.join(realHomeDir, ".agents");
-		fs.mkdirSync(userAgentsDir, { recursive: true });
 		fs.writeFileSync(
 			path.join(userAgentsDir, "test-agent-2.md"),
 			"---\nname: test-agent-2\ndescription: Test agent\n---\nAgent content"


### PR DESCRIPTION

## Summary

While working on #859, I found that the path-resolution tests could delete the real `~/.agents` directory when their backup step failed. A symlink caused that failure on my machine, and teardown still removed the live directory.

This PR teaches those tests to run inside an isolated temporary home and limits cleanup to test-owned paths. It is intended to be an immediate fix for the data-loss risk, not a long-term solution.

## Change

- Create a unique temporary root with `mkdtempSync`.
- Redirect `HOME`, `USERPROFILE`, and `PI_CODING_AGENT_DIR` for the test suite.
- Keep all fixture writes and cleanup beneath the temporary root.
- Restore the original environment during teardown.
- Clear the skill cache before removing the fixture.
- Retain a canary to detect accidental deletion of the isolated `.agents` directory.

## Validation

- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/path-resolution.test.ts` — 4/4 passed
- Verified that the real `~/.agents` fingerprint is unchanged before and after the focused test.
- Clean Node 24 full-suite run: unit 1,621 passed / 1 skipped; integration 697/697 passed; E2E skipped because the real Pi runtime packages were unavailable.
