### PR TITLE
fix: enforce mission and workflow contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Require workflowScript-only persisted schedule targets. Removed legacy agent-target restore conversion.
 
 ### Fixed
+- Create default missions for static parallel-only chain launches, reject invalid explicit mission ids, and reject legacy `parallel` workflow child params.
 - Prevent path-resolution tests from modifying or deleting the user's real `~/.agents` directory. Thanks to @meatcar for the report and fix in #865.
 - Show the target agent for simple scheduled one-child workflow scripts and mark dynamic scripts clearly.
 - Stop quiet async status widget animation redraws from spilling progress updates into the editor input area.

--- a/src/missions/lifecycle.ts
+++ b/src/missions/lifecycle.ts
@@ -35,9 +35,16 @@ interface PersistedMissionBinding {
 }
 
 function workflowGoal(params: MissionLaunchParams): string | undefined {
-	return params.task?.trim()
+	const goal = params.task?.trim()
 		|| params.tasks?.find((task) => task.task?.trim())?.task?.trim()
 		|| params.chain?.find((step) => step.task?.trim())?.task?.trim();
+	if (goal) return goal;
+	for (const step of params.chain ?? []) {
+		const parallel = Array.isArray(step.parallel) ? step.parallel : step.parallel ? [step.parallel] : [];
+		const task = parallel.find((child) => child.task?.trim())?.task?.trim();
+		if (task) return task;
+	}
+	return undefined;
 }
 
 function conciseTitle(goal: string): string {
@@ -51,14 +58,15 @@ export function prepareMissionLaunch(input: {
 	config?: MissionStoreConfig;
 	ownerSessionId?: string;
 }): MissionLaunchBinding | undefined {
-	if (input.params.missionId && input.params.mission !== undefined) throw new Error("Use missionId or mission, not both");
+	const hasMissionId = input.params.missionId !== undefined;
+	if (hasMissionId && input.params.mission !== undefined) throw new Error("Use missionId or mission, not both");
 	if (input.params.mission === false) return undefined;
 	const goal = workflowGoal(input.params);
 	const missionsEnabled = input.config?.enabled !== false;
 	const shouldCreate = input.params.mission !== undefined || (missionsEnabled && goal !== undefined);
-	if (!input.params.missionId && !shouldCreate) return undefined;
+	if (!hasMissionId && !shouldCreate) return undefined;
 	const location = resolveMissionStoreLocation({ projectRoot: input.projectRoot, ...(input.config ? { config: input.config } : {}) });
-	if (input.params.missionId) {
+	if (hasMissionId) {
 		const missionId = validateMissionId(input.params.missionId);
 		readMission(location, missionId);
 		updateMission(location, missionId, { status: "active" });

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -37,7 +37,7 @@ const runFingerprints = new Map();
 function validateRunCall(key, params, label, fingerprints) {
   if (typeof key !== "string" || !runKeyPattern.test(key)) throw new Error(label + " has an invalid key.");
   if (!params || typeof params !== "object" || Array.isArray(params)) throw new Error(label + " requires a params object.");
-  if (Object.prototype.hasOwnProperty.call(params, "action") || Object.prototype.hasOwnProperty.call(params, "workflowScript") || Object.prototype.hasOwnProperty.call(params, "tasks") || Object.prototype.hasOwnProperty.call(params, "chain") || Object.prototype.hasOwnProperty.call(params, "concurrency") || Object.prototype.hasOwnProperty.call(params, "chainDir")) {
+  if (Object.prototype.hasOwnProperty.call(params, "action") || Object.prototype.hasOwnProperty.call(params, "workflowScript") || Object.prototype.hasOwnProperty.call(params, "tasks") || Object.prototype.hasOwnProperty.call(params, "chain") || Object.prototype.hasOwnProperty.call(params, "parallel") || Object.prototype.hasOwnProperty.call(params, "concurrency") || Object.prototype.hasOwnProperty.call(params, "chainDir")) {
     const hint = label === "runs.run" ? "; use runs.all(...) and JavaScript control flow for orchestration." : ".";
     throw new Error(label + " accepts one child via { agent, task } and execution controls only" + hint);
   }
@@ -392,7 +392,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			if (!isRecord(params)) return respond(Promise.reject(new Error(`runs.run('${key}', params) requires a params object.`)));
 			if (params.action !== undefined) return respond(Promise.reject(new Error(`runs.run('${key}') accepts execution params only; management action is not allowed.`)));
 			if (params.workflowScript !== undefined) return respond(Promise.reject(new Error(`runs.run('${key}') cannot start a nested workflow script.`)));
-			if (params.tasks !== undefined || params.chain !== undefined || params.concurrency !== undefined || params.chainDir !== undefined) {
+			if (params.tasks !== undefined || params.chain !== undefined || params.parallel !== undefined || params.concurrency !== undefined || params.chainDir !== undefined) {
 				return respond(Promise.reject(new Error(`runs.run('${key}') accepts one child via { agent, task }; use runs.all(...) and JavaScript control flow for orchestration.`)));
 			}
 			if (params.worktree !== undefined && typeof params.worktree !== "boolean") {

--- a/test/unit/mission-lifecycle.test.ts
+++ b/test/unit/mission-lifecycle.test.ts
@@ -52,6 +52,20 @@ describe("mission launch lifecycle", () => {
 			});
 			assert.equal(disabled, undefined);
 
+			const parallelOnly = prepareMissionLaunch({
+				params: { chain: [{ parallel: [{ task: "" }, { task: "Review parallel work" }] }] },
+				projectRoot: test.projectRoot,
+				config: test.missionConfig,
+			});
+			assert.ok(parallelOnly);
+			assert.equal(readMission(parallelOnly.location, parallelOnly.missionId).goal, "Review parallel work");
+
+			assert.throws(() => prepareMissionLaunch({
+				params: { missionId: "" },
+				projectRoot: test.projectRoot,
+				config: test.missionConfig,
+			}), /missionId/);
+
 			const perLaunchDisabled = prepareMissionLaunch({
 				params: { mission: false, task: "Ephemeral check" },
 				projectRoot: test.projectRoot,

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -168,6 +168,7 @@ describe("scripted workflow runtime", () => {
 			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, { key: "bad key", agent: "worker", task: "run" }]);`,
 			`return await runs.all([{ key: "same", agent: "worker", task: "one" }, { key: "same", agent: "worker", task: "two" }]);`,
 			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, { key: "nested", workflowScript: "return null" }]);`,
+			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, { key: "legacy", agent: "worker", task: "run", parallel: [{ task: "nested" }] }]);`,
 			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, { key: "undefined-action", agent: "worker", task: "run", action: undefined }]);`,
 			`return await runs.all([{ key: "valid", agent: "worker", task: "run" }, { key: "uncloneable", agent: "worker", task: () => "run" }]);`,
 			`const items = []; items[1] = { key: "valid", agent: "worker", task: "run" }; return await runs.all(items);`,
@@ -325,17 +326,19 @@ describe("scripted workflow runtime", () => {
 	});
 
 	it("rejects legacy orchestration params in runs.run", async () => {
-		let launches = 0;
-		await assert.rejects(
-			runWorkflowScript({
-				script: `return await runs.run("legacy", { tasks: [{ agent: "scout", task: "scan" }] });`,
-				timeoutMs: 2_000,
-				launch: async () => { launches++; return { ok: true, output: "unexpected" }; },
-				status: async () => ({ ok: true, output: "unused" }),
-			}),
-			(error: unknown) => error instanceof WorkflowScriptError && /accepts one child.*runs\.all/i.test(error.message),
-		);
-		assert.equal(launches, 0);
+		for (const params of [`tasks: [{ agent: "scout", task: "scan" }]`, `parallel: [{ agent: "scout", task: "scan" }]`]) {
+			let launches = 0;
+			await assert.rejects(
+				runWorkflowScript({
+					script: `return await runs.run("legacy", { ${params} });`,
+					timeoutMs: 2_000,
+					launch: async () => { launches++; return { ok: true, output: "unexpected" }; },
+					status: async () => ({ ok: true, output: "unused" }),
+				}),
+				(error: unknown) => error instanceof WorkflowScriptError && /accepts one child.*runs\.all/i.test(error.message),
+			);
+			assert.equal(launches, 0);
+		}
 	});
 
 	it("rejects a duplicate key with incompatible params", async () => {


### PR DESCRIPTION
## Summary

Tightens the mission and workflow launch contracts.

- Creates default missions for static parallel-only chain launches by using the first child task as the goal.
- Validates explicit `missionId` by presence, so empty ids fail instead of silently changing launch behavior.
- Rejects legacy `parallel` child params in `workflowScript` child launches.
- Adds Unreleased changelog coverage.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/mission-lifecycle.test.ts test/unit/scripted-workflow.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh read-only review: `/tmp/pi-subagents-lane-a-review.md` returned no findings.
