### PR TITLE
fix: handle narrow TUI render widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Create default missions for static parallel-only chain launches, reject invalid explicit mission ids, and reject legacy `parallel` workflow child params.
+- Keep very narrow TUI result wrapping within its width budget and simplify Fleet nested status row construction.
 - Prevent path-resolution tests from modifying or deleting the user's real `~/.agents` directory. Thanks to @meatcar for the report and fix in #865.
 - Show the target agent for simple scheduled one-child workflow scripts and mark dynamic scripts clearly.
 - Stop quiet async status widget animation redraws from spilling progress updates into the editor input area.

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -100,21 +100,25 @@ function nestedFleetRows(children: NestedRunSummary[] | undefined): FleetNestedR
 		const steps = (child.mode === "parallel" || child.mode === "chain") ? child.steps ?? [] : [];
 		if (steps.length > 0) {
 			for (const step of steps) {
+				const modelThinking = formatModelThinking(step.model, step.thinking) || undefined;
+				const activity = nestedActivity(step);
 				rows.push({
 					name: step.agent,
 					state: step.status,
-					...(formatModelThinking(step.model, step.thinking) ? { modelThinking: formatModelThinking(step.model, step.thinking) } : {}),
-					...(nestedActivity(step) ? { activity: nestedActivity(step) } : {}),
+					...(modelThinking ? { modelThinking } : {}),
+					...(activity ? { activity } : {}),
 					...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),
 				});
 			}
 			continue;
 		}
+		const modelThinking = formatModelThinking(child.model, child.thinking) || undefined;
+		const activity = nestedActivity(child);
 		rows.push({
 			name: nestedRunLabel(child),
 			state: child.state,
-			...(formatModelThinking(child.model, child.thinking) ? { modelThinking: formatModelThinking(child.model, child.thinking) } : {}),
-			...(nestedActivity(child) ? { activity: nestedActivity(child) } : {}),
+			...(modelThinking ? { modelThinking } : {}),
+			...(activity ? { activity } : {}),
 			...(child.startedAt !== undefined ? { startedAt: child.startedAt } : {}),
 		});
 	}

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -53,6 +53,7 @@ const ansiStylePattern = /\x1b\[[0-9;]*m/y;
  * Uses Intl.Segmenter for proper Unicode/emoji handling (not char-by-char).
  */
 export function truncLine(text: string, maxWidth: number): string {
+	if (maxWidth <= 0) return "";
 	if (visibleWidth(text) <= maxWidth) return text;
 
 	const targetWidth = maxWidth - 1;
@@ -83,7 +84,7 @@ export function truncLine(text: string, maxWidth: number): string {
 		const textPortion = text.slice(i, end);
 		for (const seg of segmenter.segment(textPortion)) {
 			const grapheme = seg.segment;
-			const graphemeWidth = visibleWidth(grapheme);
+			const graphemeWidth = grapheme === "\x1b" ? 0 : visibleWidth(grapheme);
 
 			if (currentWidth + graphemeWidth > targetWidth) {
 				return result + activeStyles.join("") + "…";
@@ -111,6 +112,7 @@ function wrapPlainText(text: string, maxWidth: number): string[] {
 		for (const seg of segmenter.segment(rawLine)) {
 			const grapheme = seg.segment;
 			const graphemeWidth = visibleWidth(grapheme);
+			if (graphemeWidth > maxWidth) continue;
 			if (currentWidth > 0 && currentWidth + graphemeWidth > maxWidth) {
 				lines.push(current);
 				current = grapheme;

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -61,6 +61,25 @@ test("truncLine respects grapheme display width", () => {
 	assert.equal(visibleWidth(rendered), 5);
 });
 
+test("truncLine emits no marker at zero width", () => {
+	assert.equal(truncLine("abcdef", 0), "");
+});
+
+test("multiline rendering omits two-column graphemes at one-column width", () => {
+	const originalColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+	Object.defineProperty(process.stdout, "columns", { configurable: true, value: 5 });
+	try {
+		const rendered = componentText(renderSubagentResult({
+			content: [{ type: "text", text: "a🙂b\n🙂" }],
+		}, { expanded: true }, theme as any));
+		assert.deepEqual(rendered.split("\n"), ["a", "b"]);
+		for (const line of rendered.split("\n")) assert.ok(visibleWidth(line) <= 1);
+	} finally {
+		if (originalColumns) Object.defineProperty(process.stdout, "columns", originalColumns);
+		else delete (process.stdout as { columns?: number }).columns;
+	}
+});
+
 test("compact chain rendering uses workflow graph spans for dynamic fanout results", () => {
 	const component = renderSubagentResult({
 		content: [{ type: "text", text: "done" }],


### PR DESCRIPTION
## Summary

Keeps TUI presentation inside its width contract and removes small Fleet row duplication.

- Makes zero-width truncation return no visible marker.
- Omits over-wide graphemes during one-column plain-text wrapping.
- Computes compact Fleet nested-row model/activity strings once per row.
- Adds focused narrow-width render tests and an Unreleased changelog entry.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/render-helpers.test.ts test/unit/fleet-status.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh read-only review: `/tmp/pi-subagents-lane-c-review.md` returned no findings.
