### PR TITLE
fix: clean fanout child control listeners on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Create default missions for static parallel-only chain launches, reject invalid explicit mission ids, and reject legacy `parallel` workflow child params.
 - Keep very narrow TUI result wrapping within its width budget and simplify Fleet nested status row construction.
+- Clean up fanout-child nested-control listeners on reload so stale listeners cannot duplicate resume handling.
 - Prevent path-resolution tests from modifying or deleting the user's real `~/.agents` directory. Thanks to @meatcar for the report and fix in #865.
 - Show the target agent for simple scheduled one-child workflow scripts and mark dynamic scripts clearly.
 - Stop quiet async status widget animation redraws from spilling progress updates into the editor input area.

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -7,7 +7,7 @@ import { getArtifactsDir } from "../shared/artifacts.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { resolveWaitToolConfig } from "../runs/background/wait-config.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../runs/shared/pi-args.ts";
-import { readNestedControlRequests, resolveNestedRouteFromEnv, writeNestedControlResult } from "../runs/shared/nested-events.ts";
+import { readNestedControlRequests, resolveNestedRouteFromEnv, type NestedRoute, writeNestedControlResult } from "../runs/shared/nested-events.ts";
 import { deliverSubagentIntercomMessageEvent } from "../intercom/result-intercom.ts";
 import { resolveSubagentIntercomTarget } from "../intercom/intercom-bridge.ts";
 import { SubagentParams } from "./schemas.ts";
@@ -50,25 +50,42 @@ function createChildSafeState(): SubagentState {
 	};
 }
 
-function startNestedControlInboxListener(pi: ExtensionAPI, state: SubagentState): NodeJS.Timeout | undefined {
-	let route;
+function resolveNestedControlRoute(): NestedRoute | undefined {
 	try {
-		route = resolveNestedRouteFromEnv();
+		return resolveNestedRouteFromEnv();
 	} catch {
 		return undefined;
 	}
-	if (!route) return undefined;
-	const seen = new Set<string>();
-	const inFlight = new Set<string>();
-	const pendingResults = new Map<string, Parameters<typeof writeNestedControlResult>[1]>();
+}
+
+function nestedControlRouteKey(route: NestedRoute): string {
+	return route.controlInbox;
+}
+
+interface NestedControlInboxState {
+	seen: Set<string>;
+	inFlight: Set<string>;
+	pendingResults: Map<string, Parameters<typeof writeNestedControlResult>[1]>;
+}
+
+interface NestedControlListenerEntry {
+	cleanup: () => void;
+	state: NestedControlInboxState;
+}
+
+function createNestedControlInboxState(): NestedControlInboxState {
+	return { seen: new Set(), inFlight: new Set(), pendingResults: new Map() };
+}
+
+function startNestedControlInboxListener(pi: ExtensionAPI, state: SubagentState, route: NestedRoute, inboxState: NestedControlInboxState): () => void {
 	const timer = setInterval(() => {
 		try {
 			for (const request of readNestedControlRequests(route)) {
-				if (seen.has(request.requestId) || inFlight.has(request.requestId)) continue;
-				inFlight.add(request.requestId);
+				if (inboxState.seen.has(request.requestId) || inboxState.inFlight.has(request.requestId)) continue;
+				inboxState.inFlight.add(request.requestId);
 				void (async () => {
 					try {
-						let result = pendingResults.get(request.requestId);
+						let result = inboxState.pendingResults.get(request.requestId);
 						if (!result) {
 							let ok = false;
 							let message = "Control request failed.";
@@ -107,15 +124,15 @@ function startNestedControlInboxListener(pi: ExtensionAPI, state: SubagentState)
 						try {
 							writeNestedControlResult(route, result);
 						} catch (error) {
-							pendingResults.set(request.requestId, result);
+							inboxState.pendingResults.set(request.requestId, result);
 							console.error(`Failed to write nested control result for request '${request.requestId}' targeting '${request.targetRunId}' via inbox '${route.controlInbox}'; keeping request for retry:`, error);
 							return;
 						}
-						pendingResults.delete(request.requestId);
-						seen.add(request.requestId);
+						inboxState.pendingResults.delete(request.requestId);
+						inboxState.seen.add(request.requestId);
 						try { fs.unlinkSync(request.filePath); } catch {}
 					} finally {
-						inFlight.delete(request.requestId);
+						inboxState.inFlight.delete(request.requestId);
 					}
 				})();
 			}
@@ -124,7 +141,7 @@ function startNestedControlInboxListener(pi: ExtensionAPI, state: SubagentState)
 		}
 	}, 200);
 	timer.unref?.();
-	return timer;
+	return () => clearInterval(timer);
 }
 
 export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): void {
@@ -169,5 +186,16 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 	};
 
 	pi.registerTool(tool);
-	startNestedControlInboxListener(pi, state);
+	const route = resolveNestedControlRoute();
+	if (!route) return;
+	const listenerCleanupKey = "__piSubagentFanoutChildNestedControlInboxCleanups";
+	const listenerCleanups = globalStore[listenerCleanupKey] instanceof Map
+		? globalStore[listenerCleanupKey] as Map<string, NestedControlListenerEntry>
+		: new Map<string, NestedControlListenerEntry>();
+	globalStore[listenerCleanupKey] = listenerCleanups;
+	const routeKey = nestedControlRouteKey(route);
+	const previous = listenerCleanups.get(routeKey);
+	previous?.cleanup();
+	const inboxState = previous?.state ?? createNestedControlInboxState();
+	listenerCleanups.set(routeKey, { state: inboxState, cleanup: startNestedControlInboxListener(pi, state, route, inboxState) });
 }

--- a/test/unit/nested-control.test.ts
+++ b/test/unit/nested-control.test.ts
@@ -19,6 +19,7 @@ import {
 import { ASYNC_DIR, type SubagentState } from "../../src/shared/types.ts";
 
 const routeRoots: string[] = [];
+const fanoutListenerCleanupKey = "__piSubagentFanoutChildNestedControlInboxCleanups";
 const savedEnv = {
 	[SUBAGENT_CHILD_ENV]: process.env[SUBAGENT_CHILD_ENV],
 	[SUBAGENT_FANOUT_CHILD_ENV]: process.env[SUBAGENT_FANOUT_CHILD_ENV],
@@ -31,6 +32,15 @@ const savedEnv = {
 };
 
 afterEach(() => {
+	const globalStore = globalThis as Record<string, unknown>;
+	const listenerCleanups = globalStore[fanoutListenerCleanupKey];
+	if (listenerCleanups instanceof Map) {
+		for (const entry of listenerCleanups.values()) {
+			if (typeof entry === "function") entry();
+			else if (entry && typeof entry === "object" && typeof (entry as { cleanup?: unknown }).cleanup === "function") (entry as { cleanup: () => void }).cleanup();
+		}
+	}
+	delete globalStore[fanoutListenerCleanupKey];
 	for (const root of routeRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 	for (const [key, value] of Object.entries(savedEnv)) {
 		if (value === undefined) delete process.env[key];
@@ -482,6 +492,69 @@ describe("nested control routing", () => {
 			assert.equal(fs.existsSync(requestPath), false);
 		} finally {
 			console.error = originalError;
+		}
+	});
+
+	it("cleans the prior listener on reload and processes a resume request once", async () => {
+		const route = createNestedRoute("root-reload-listener");
+		routeRoots.push(path.dirname(route.eventSink));
+		setNestedRouteEnv(route, "root-reload-listener");
+		process.env[SUBAGENT_CHILD_ENV] = "1";
+		process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
+		const registrations: string[] = [];
+		const activeIntervals = new Set<ReturnType<typeof setInterval>>();
+		const originalSetInterval = globalThis.setInterval;
+		const originalClearInterval = globalThis.clearInterval;
+		globalThis.setInterval = ((...args: Parameters<typeof setInterval>) => {
+			const interval = originalSetInterval(...args);
+			activeIntervals.add(interval);
+			return interval;
+		}) as typeof setInterval;
+		globalThis.clearInterval = ((interval: ReturnType<typeof setInterval>) => {
+			activeIntervals.delete(interval);
+			return originalClearInterval(interval);
+		}) as typeof clearInterval;
+		try {
+			const makePi = () => ({
+				events: { emit() {}, on() { return () => {}; } },
+				registerTool() { registrations.push("subagent"); },
+				getSessionName() { return "child"; },
+			}) as any;
+			const firstPi = makePi();
+
+			registerFanoutChildSubagentExtension(firstPi);
+			registerFanoutChildSubagentExtension(firstPi);
+			registerFanoutChildSubagentExtension(makePi());
+			assert.equal(activeIntervals.size, 1);
+
+			const unrelatedRoute = createNestedRoute("root-unrelated-listener");
+			routeRoots.push(path.dirname(unrelatedRoute.eventSink));
+			setNestedRouteEnv(unrelatedRoute, "root-unrelated-listener");
+			registerFanoutChildSubagentExtension(makePi());
+			assert.equal(activeIntervals.size, 2);
+
+			delete process.env[SUBAGENT_PARENT_EVENT_SINK_ENV];
+			delete process.env[SUBAGENT_PARENT_CONTROL_INBOX_ENV];
+			delete process.env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV];
+			delete process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV];
+			registerFanoutChildSubagentExtension(makePi());
+			assert.equal(activeIntervals.size, 2);
+
+			setNestedRouteEnv(route, "root-reload-listener");
+			writeNestedControlRequest(route, {
+				ts: Date.now(),
+				requestId: "reload-resume-once",
+				targetRunId: "missing-run",
+				action: "resume",
+				message: "continue",
+			});
+
+			await waitFor(() => readNestedControlResults(route).length === 1);
+			assert.equal(registrations.length, 4);
+			assert.equal(readNestedControlResults(route)[0]?.requestId, "reload-resume-once");
+		} finally {
+			globalThis.setInterval = originalSetInterval;
+			globalThis.clearInterval = originalClearInterval;
 		}
 	});
 


### PR DESCRIPTION
## Summary

Makes fanout child nested-control listener ownership safe across reloads.

- Keys listener cleanup by nested control inbox route.
- Replaces only same-route listeners on reload.
- Preserves shared `seen`, `inFlight`, and pending-result state across same-route listener replacement.
- Keeps unrelated routes active and leaves existing listeners untouched when no nested route is present.
- Adds focused nested-control coverage and an Unreleased changelog entry.

## Validation

- `node --experimental-strip-types --test test/unit/nested-control.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh read-only review found a route cleanup bug; fixed.
- First follow-up review found an in-flight duplicate-delivery race; fixed.
- Second follow-up review: `/tmp/pi-subagents-lane-b-followup-review-2.md` returned no findings.
