### PR TITLE
feat: add host-verified child gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added explicit project-local subagent refinement overlays through `/subagents-refine <agent>` and `refine`, `refine.show`, and `refine.rollback` actions.
 - Added opt-in goal missions that send one needs-attention continuation notice after idle parent turns, account linked-run token usage against a mission budget, pause or stop through `mission.update`, and name retained children when resume is the next ready action.
 - Added `steer`, `follow_up`, and `auto` delivery modes with delivered/queued receipts, bounded FIFO follow-ups, retained-child revival briefs, RPC parity, and Fleet mode selection.
+- Added one-command `gate` verification for direct and scripted workflow children, with host evidence and tracked-workspace memoization.
 - Added mission-scoped durable JSON state to `workflowScript` through `state.get(key)` and `state.set(key, value)`.
 - Added a session-scoped `children.list` roster for the last 10 completed retained workflow children and let `workflowScript` resume one through `runs.run` without changing its stored agent, model, or tool contract.
 

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -314,7 +314,7 @@ const SubagentParamsSchema = Type.Object({
 		],
 		description: "Agent/chain config for create/update. Object or JSON string; presence of steps creates a chain."
 	})),
-	workflowScript: Type.Optional(Type.String({ minLength: 1, description: "Trusted inline JavaScript statement body. Starts asynchronously by default; pass async:false for a small foreground run. Use explicit return for a useful result. Use await runs.run(key, {agent, task, worktree?}) or runs.run(key, {resume, task}), runs.all([...]), runs.status(id), runs.ref(s), emit(value), console, and return. Mission-attached workflows also have async state.get(key) and state.set(key, JSONValue) for durable mission state. Use ordinary JavaScript loops, branches, awaits, and arrays to mix sequential and parallel phases dynamically. Set worktree:true at workflow or child level for a separate managed worktree per child; child fields override workflow defaults. runs.run accepts one child only. No filesystem, shell, Pi tools, or host globals." })),
+	workflowScript: Type.Optional(Type.String({ minLength: 1, description: "Trusted inline JavaScript statement body. Starts async by default; pass async:false for a small foreground run. Use explicit return for output. Use await runs.run(key, {agent, task, worktree?, gate?}) or runs.run(key, {resume, task}), runs.all([...]), runs.status(id), runs.ref(s), emit(value), console, and return. Mission workflows also have async state.get(key) and state.set(key, JSONValue). Use ordinary JavaScript loops, branches, awaits, and arrays to mix sequential and parallel phases dynamically. Set worktree:true at workflow or child level for a separate managed worktree; child fields override workflow defaults. gate is one host-run command and cannot be combined with acceptance. runs.run accepts one child only. No filesystem, shell, Pi tools, or host globals." })),
 	chatProgress: Type.Optional(Type.String({ enum: ["auto", "off", "live-card"], description: "WorkflowScript chat progress projection. auto shows a live in-chat card only for watched foreground workflows in the same Git repository; it is off otherwise." })),
 	worktree: Type.Optional(Type.Boolean({ description: "Managed child isolation. true gives each workflow child a separate git worktree; an individual runs.run/runs.all item can override a workflow default with worktree:false." })),
 	step: Type.Optional(Type.Unsafe({ ...ChainItem, description: "One chain step for action='append-step' only. Not an execution mode." })),
@@ -351,6 +351,7 @@ const SubagentParamsSchema = Type.Object({
 	outputSchema: Type.Optional(JsonSchemaObject),
 	agentContract: Type.Optional(AgentContractOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
+	gate: Type.Optional(Type.String({ minLength: 1, description: "Host gate command. Cannot be combined with acceptance." })),
 });
 
 export const SubagentParams = keepTopLevelParameterDescriptions(SubagentParamsSchema);

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1635,6 +1635,8 @@ async function runSingleStep(
 			signal: combinedAbortSignal([ctx.timeoutSignal, ctx.stopSignal]),
 			abortMessage: ctx.stopSignal?.aborted ? ctx.stopMessage ?? "Subagent stopped by user." : ctx.timeoutMessage ?? "Subagent timed out.",
 			reportOptional: isAgentContractV1(step.agentContract),
+			artifactsDir: ctx.artifactsDir,
+			runId: ctx.id,
 		}))
 		: undefined;
 	const stoppedAfterAcceptance = finalResult?.stopped === true || ctx.stopSignal?.aborted === true;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -1701,6 +1701,8 @@ async function runSyncCompletion(
 					: undefined,
 				cwd: options.cwd ?? runtimeCwd,
 				reportOptional: isAgentContractV1(options.agentContract),
+				artifactsDir: options.artifactsDir,
+				runId: options.runId,
 			});
 		}
 	} catch (error) {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -52,7 +52,7 @@ import { buildAsyncRunnerSteps, executeAsyncChain, executeAsyncSingle, formatAsy
 import type { ScheduledRunAction } from "../background/scheduled-runs.ts";
 import { enqueueChainAppendRequest, readPendingChainAppendRequests, runnerStepOutputNames } from "../background/chain-append.ts";
 import { ChainOutputValidationError, validateChainOutputBindingsWithContext } from "../shared/chain-outputs.ts";
-import { validateExecutionAcceptance } from "../shared/acceptance.ts";
+import { normalizeGateAcceptance, validateExecutionAcceptance } from "../shared/acceptance.ts";
 import { createForkContextResolver, forkedChildRequiresThinkingOff } from "../../shared/fork-context.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBridge, resolveIntercomSessionTarget, resolveSubagentIntercomTarget, type IntercomBridgeState } from "../../intercom/intercom-bridge.ts";
@@ -260,6 +260,7 @@ export interface SubagentParamsLike {
 	agentScope?: unknown;
 	chainDir?: string;
 	acceptance?: AcceptanceInput;
+	gate?: string;
 	agentContract?: AgentContract;
 	schedule?: string;
 	scheduleName?: string;
@@ -3923,6 +3924,9 @@ export function prepareWorkflowLaunchParams(
 	options: { missionDetached?: boolean; suppressRoutineResultIntercom?: boolean } = {},
 ): SubagentParamsLike {
 	if (typeof childParams.resume === "string") {
+		if (childParams.gate !== undefined || workflowDefaults.gate !== undefined) {
+			throw new Error("gate is not supported with retained resume; resume uses the retained child contract.");
+		}
 		const timeoutMs = childParams.timeoutMs ?? childParams.maxRuntimeMs ?? workflowDefaults.timeoutMs ?? workflowDefaults.maxRuntimeMs;
 		const turnBudget = childParams.turnBudget ?? workflowDefaults.turnBudget;
 		const toolBudget = childParams.toolBudget ?? workflowDefaults.toolBudget;
@@ -3938,14 +3942,28 @@ export function prepareWorkflowLaunchParams(
 			...(toolBudget !== undefined ? { toolBudget: toolBudget as ToolBudgetConfig } : {}),
 		};
 	}
-	return prepareWorkflowChildParams({
+	const launchParams = {
 		...workflowDefaults,
 		...childParams,
 		...(options.missionDetached ? { mission: false } : {}),
 		workflowParentRunId: parentWorkflowRunId,
 		workflowKey,
 		...(options.suppressRoutineResultIntercom ? { suppressRoutineResultIntercom: true } : {}),
-	} as SubagentParamsLike);
+	} as SubagentParamsLike;
+	const normalizedGate = normalizeGateParams(launchParams);
+	if (normalizedGate.error || !normalizedGate.params) throw new Error(normalizedGate.error ?? "Invalid gate.");
+	return prepareWorkflowChildParams(normalizedGate.params);
+}
+
+function normalizeGateParams(params: SubagentParamsLike): { params?: SubagentParamsLike; error?: string } {
+	if (params.gate !== undefined && params.action === "resume") {
+		return { error: "gate is not supported with action='resume'; resume uses the retained child contract." };
+	}
+	const normalized = normalizeGateAcceptance(params.gate, params.acceptance);
+	if (normalized.error) return { error: normalized.error };
+	if (params.gate === undefined) return { params };
+	const { gate: _gate, ...rest } = params;
+	return { params: { ...rest, ...(normalized.acceptance !== undefined ? { acceptance: normalized.acceptance } : {}) } };
 }
 
 function prepareWorkflowChildParams(params: SubagentParamsLike): SubagentParamsLike {
@@ -4087,7 +4105,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		deps.state.foregroundRuns ??= new Map();
 		deps.state.foregroundControls ??= new Map();
 		deps.state.lastForegroundControlId ??= null;
-		const requestParams = params;
+		const normalizedGate = normalizeGateParams(params);
+		if (normalizedGate.error || !normalizedGate.params) return buildRequestedModeError(params, normalizedGate.error ?? "Invalid gate.");
+		const requestParams = normalizedGate.params;
 		const normalizedAction = typeof requestParams.action === "string" ? requestParams.action.trim() : requestParams.action;
 		if (requestParams.workflowScript !== undefined && normalizedAction === undefined) {
 			const parentCwd = ctx.cwd;

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type {
@@ -150,6 +151,13 @@ export function normalizeAcceptanceInput(input: AcceptanceInput | undefined): Ac
 	if (input === false) return { level: "none", reason: "disabled by deprecated false shorthand" };
 	if (typeof input === "string") return { level: input };
 	return { ...input };
+}
+
+export function normalizeGateAcceptance(gate: unknown, acceptance: AcceptanceInput | undefined): { acceptance?: AcceptanceInput; error?: string } {
+	if (gate === undefined) return { acceptance };
+	if (typeof gate !== "string" || !gate.trim()) return { error: "gate must be a non-empty command string." };
+	if (acceptance !== undefined) return { error: "gate cannot be combined with acceptance; use one gate command or acceptance.verify." };
+	return { acceptance: { level: "verified", verify: [{ id: "gate", command: gate.trim() }] } };
 }
 
 function explicitAcceptanceCanDisable(explicit: AcceptanceConfig): boolean {
@@ -959,6 +967,28 @@ function trimOutput(value: string): string | undefined {
 	return trimmed.length > 12_000 ? `${trimmed.slice(0, 12_000)}\n...[truncated]` : trimmed;
 }
 
+const SENSITIVE_ENV_KEY_PATTERN = /(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASS|AUTH|CREDENTIAL|COOKIE|SESSION|PRIVATE|API_KEY|ACCESS_KEY)(?:_|$)/i;
+
+function effectiveVerifyEnv(env: Record<string, string> | undefined): Record<string, string> {
+	const inherited = Object.fromEntries(Object.entries(process.env).flatMap(([key, value]) => {
+		return typeof value === "string" ? [[key, value]] : [];
+	}));
+	return { ...inherited, ...(env ?? {}) };
+}
+
+function verifyRedactionEnv(env: Record<string, string> | undefined): Record<string, string> {
+	return Object.fromEntries(Object.entries(effectiveVerifyEnv(env)).filter(([key, value]) => {
+		return value.length >= 4 && SENSITIVE_ENV_KEY_PATTERN.test(key);
+	}));
+}
+
+function redactVerifyEnv(value: string, env: Record<string, string> | undefined): string {
+	let redacted = value;
+	const secrets = [...new Set(Object.values(verifyRedactionEnv(env)).filter(Boolean))].sort((left, right) => right.length - left.length);
+	for (const secret of secrets) redacted = redacted.replaceAll(secret, "[REDACTED]");
+	return redacted;
+}
+
 function uniqueStrings(items: Array<string | undefined>): string[] {
 	return unique(items.map((item) => item?.trim()).filter((item): item is string => Boolean(item)));
 }
@@ -995,6 +1025,108 @@ export function aggregateAcceptanceReport(input: {
 	};
 }
 
+const DEFAULT_VERIFY_TIMEOUT_MS = 120_000;
+
+function hash(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+interface VerifyWorkspaceState {
+	kind: "git-tracked";
+	repoRoot: string;
+	cwdRelative: string;
+	head: string;
+	diffHash: string;
+}
+
+function readVerifyWorkspaceState(cwd: string): VerifyWorkspaceState | undefined {
+	const repo = spawnSync("git", ["rev-parse", "--show-toplevel"], { cwd, encoding: "utf-8" });
+	if (repo.status !== 0 || !repo.stdout.trim()) return undefined;
+	const repoRoot = fs.realpathSync(repo.stdout.trim());
+	const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf-8" });
+	const diff = spawnSync("git", ["diff", "--binary", "--full-index", "HEAD", "--"], { cwd: repoRoot, encoding: "utf-8", maxBuffer: 50 * 1024 * 1024 });
+	if (head.status !== 0 || diff.status !== 0 || !head.stdout.trim()) return undefined;
+	return {
+		kind: "git-tracked",
+		repoRoot,
+		cwdRelative: path.relative(repoRoot, fs.realpathSync(cwd)) || ".",
+		head: head.stdout.trim(),
+		diffHash: hash(diff.stdout),
+	};
+}
+
+function isCachedVerifyResult(value: unknown): value is AcceptanceVerifyResult {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const result = value as Partial<AcceptanceVerifyResult>;
+	return typeof result.id === "string"
+		&& typeof result.command === "string"
+		&& (typeof result.exitCode === "number" || result.exitCode === null)
+		&& (result.status === "passed" || result.status === "failed" || result.status === "timed-out" || result.status === "allowed-failure")
+		&& typeof result.durationMs === "number";
+}
+
+async function runMemoizedVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, options: {
+	signal?: AbortSignal;
+	abortMessage?: string;
+	artifactsDir?: string;
+	runId?: string;
+} = {}): Promise<AcceptanceVerifyResult> {
+	const cwd = command.cwd ? path.resolve(defaultCwd, command.cwd) : defaultCwd;
+	let workspaceState: VerifyWorkspaceState | undefined;
+	try {
+		workspaceState = readVerifyWorkspaceState(cwd);
+	} catch {
+		workspaceState = undefined;
+	}
+	if (!workspaceState || !options.artifactsDir || !options.runId) {
+		return runVerifyCommand(command, defaultCwd, options);
+	}
+	const envKeys = Object.keys(command.env ?? {}).sort();
+	const envHash = hash(JSON.stringify(Object.fromEntries(Object.entries(effectiveVerifyEnv(command.env)).sort(([left], [right]) => left.localeCompare(right)))));
+	const timeoutMs = command.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS;
+	const cacheKey = hash(JSON.stringify({
+		version: 1,
+		command: command.command,
+		cwdRelative: workspaceState.cwdRelative,
+		envKeys,
+		envHash,
+		timeoutMs,
+		allowFailure: command.allowFailure === true,
+		head: workspaceState.head,
+		diffHash: workspaceState.diffHash,
+	}));
+	const artifactPath = path.join(options.artifactsDir, "acceptance", "verify", options.runId, `${cacheKey}.json`);
+	try {
+		const cached = JSON.parse(fs.readFileSync(artifactPath, "utf-8")) as { cacheKey?: unknown; result?: unknown };
+		if (cached.cacheKey === cacheKey && isCachedVerifyResult(cached.result)) {
+			return { ...cached.result, id: command.id, command: command.command, cwd, artifactPath, cacheKey, memoized: true, envKeys, envHash, workspaceState };
+		}
+	} catch {
+		// A cache miss or unreadable artifact must not prevent host verification.
+	}
+	const result = await runVerifyCommand(command, defaultCwd, options);
+	const evidenced: AcceptanceVerifyResult = { ...result, artifactPath, cacheKey, memoized: false, envKeys, envHash, workspaceState };
+	try {
+		fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+		fs.writeFileSync(artifactPath, JSON.stringify({
+			version: 1,
+			cacheKey,
+			command: command.command,
+			cwdRelative: workspaceState.cwdRelative,
+			envKeys,
+			envHash,
+			timeoutMs,
+			allowFailure: command.allowFailure === true,
+			workspaceState,
+			result: evidenced,
+		}, null, 2), "utf-8");
+	} catch (error) {
+		evidenced.artifactError = error instanceof Error ? error.message : String(error);
+		delete evidenced.artifactPath;
+	}
+	return evidenced;
+}
+
 function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, options: { signal?: AbortSignal; abortMessage?: string } = {}): Promise<AcceptanceVerifyResult> {
 	return new Promise((resolve) => {
 		const startedAt = Date.now();
@@ -1006,7 +1138,7 @@ function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, 
 		let hardKill: NodeJS.Timeout | undefined;
 		const child = spawn(command.command, {
 			cwd,
-			env: { ...process.env, ...(command.env ?? {}) },
+			env: effectiveVerifyEnv(command.env),
 			shell: true,
 			stdio: ["ignore", "pipe", "pipe"],
 			windowsHide: true,
@@ -1034,13 +1166,13 @@ function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, 
 				finish({
 					exitCode: null,
 					status: "timed-out",
-					stdout: trimOutput(stdout),
-					stderr: trimOutput(stderr || options.abortMessage || "Acceptance verification timed out."),
+					stdout: trimOutput(redactVerifyEnv(stdout, command.env)),
+					stderr: trimOutput(redactVerifyEnv(stderr || options.abortMessage || "Acceptance verification timed out.", command.env)),
 				});
 			}, 1000);
 			hardKill.unref?.();
 		};
-		const timeout = setTimeout(abortVerification, command.timeoutMs ?? 120_000);
+		const timeout = setTimeout(abortVerification, command.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS);
 		timeout.unref?.();
 		if (options.signal?.aborted) abortVerification();
 		else options.signal?.addEventListener("abort", abortVerification, { once: true });
@@ -1055,15 +1187,17 @@ function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, 
 			finish({
 				exitCode,
 				status: timedOut ? "timed-out" : passed ? "passed" : command.allowFailure ? "allowed-failure" : "failed",
-				stdout: trimOutput(stdout),
-				stderr: trimOutput(stderr || (timedOut ? options.abortMessage ?? "" : "")),
+				stdout: trimOutput(redactVerifyEnv(stdout, command.env)),
+				stderr: trimOutput(redactVerifyEnv(stderr || (timedOut ? options.abortMessage ?? "" : ""), command.env)),
 			});
 		});
 		child.on("error", (error) => {
 			finish({
 				exitCode: timedOut ? null : 1,
 				status: timedOut ? "timed-out" : command.allowFailure ? "allowed-failure" : "failed",
-				stderr: timedOut ? trimOutput(stderr || options.abortMessage || "Acceptance verification timed out.") : error instanceof Error ? error.message : String(error),
+				stderr: timedOut
+					? trimOutput(redactVerifyEnv(stderr || options.abortMessage || "Acceptance verification timed out.", command.env))
+					: redactVerifyEnv(error instanceof Error ? error.message : String(error), command.env),
 			});
 		});
 	});
@@ -1085,6 +1219,8 @@ export async function evaluateAcceptance(input: {
 	signal?: AbortSignal;
 	abortMessage?: string;
 	reportOptional?: boolean;
+	artifactsDir?: string;
+	runId?: string;
 }): Promise<AcceptanceLedger> {
 	const acceptance = input.acceptance;
 	const initialStatus = acceptance.level === "none" ? "not-required" : "claimed";
@@ -1146,7 +1282,12 @@ export async function evaluateAcceptance(input: {
 		}
 		ledger.verifyRuns = [];
 		for (const command of acceptance.verify) {
-			ledger.verifyRuns.push(await runVerifyCommand(command, input.cwd, { signal: input.signal, abortMessage: input.abortMessage }));
+			ledger.verifyRuns.push(await runMemoizedVerifyCommand(command, input.cwd, {
+				signal: input.signal,
+				abortMessage: input.abortMessage,
+				artifactsDir: input.artifactsDir,
+				runId: input.runId,
+			}));
 			if (input.signal?.aborted) break;
 		}
 		if (ledger.verifyRuns.some((run) => run.status === "failed" || run.status === "timed-out")) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -742,6 +742,19 @@ export interface AcceptanceVerifyResult {
 	stdout?: string;
 	stderr?: string;
 	durationMs: number;
+	artifactPath?: string;
+	cacheKey?: string;
+	memoized?: boolean;
+	envKeys?: string[];
+	envHash?: string;
+	workspaceState?: {
+		kind: "git-tracked";
+		repoRoot: string;
+		cwdRelative: string;
+		head: string;
+		diffHash: string;
+	};
+	artifactError?: string;
 }
 
 export interface AcceptanceReviewResult {

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -42,6 +42,9 @@ function validateRunCall(key, params, label, fingerprints) {
     throw new Error(label + " accepts one child via { agent, task } and execution controls only" + hint);
   }
   if (params.worktree !== undefined && typeof params.worktree !== "boolean") throw new Error(label + " worktree must be true or false.");
+  if (params.gate !== undefined && (typeof params.gate !== "string" || !params.gate.trim())) throw new Error(label + " gate must be a non-empty command string.");
+  if (params.gate !== undefined && params.acceptance !== undefined) throw new Error(label + " gate cannot be combined with acceptance; use one gate command or acceptance.verify.");
+  if (params.gate !== undefined && params.resume !== undefined) throw new Error(label + " gate is not supported with retained resume.");
   if (params.resume !== undefined && (typeof params.resume !== "string" || !params.resume.trim())) throw new Error(label + " resume must be a non-empty retained run id.");
   if (params.resume !== undefined && params.agent !== undefined) throw new Error(label + " resume and agent are mutually exclusive.");
   if (params.resume !== undefined && (typeof params.task !== "string" || !params.task.trim())) throw new Error(label + " resume requires a non-empty task follow-up.");
@@ -437,6 +440,15 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			}
 			if (params.worktree !== undefined && typeof params.worktree !== "boolean") {
 				return respond(Promise.reject(new Error(`runs.run('${key}') worktree must be true or false.`)));
+			}
+			if (params.gate !== undefined && (typeof params.gate !== "string" || !params.gate.trim())) {
+				return respond(Promise.reject(new Error(`runs.run('${key}') gate must be a non-empty command string.`)));
+			}
+			if (params.gate !== undefined && params.acceptance !== undefined) {
+				return respond(Promise.reject(new Error(`runs.run('${key}') gate cannot be combined with acceptance; use one gate command or acceptance.verify.`)));
+			}
+			if (params.gate !== undefined && params.resume !== undefined) {
+				return respond(Promise.reject(new Error(`runs.run('${key}') gate is not supported with retained resume.`)));
 			}
 			if (params.resume !== undefined && (typeof params.resume !== "string" || !params.resume.trim())) {
 				return respond(Promise.reject(new Error(`runs.run('${key}') resume must be a non-empty retained run id.`)));

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -736,6 +736,88 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(result.details.workflow?.trace.filter((entry) => entry.state !== "started").map(({ state }) => state).sort(), ["completed", "failed"]);
 	});
 
+	it("runs a direct child gate as host-verified acceptance", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const markerFile = "direct-gate.txt";
+		const markerPath = path.join(tempDir, markerFile);
+		mockPi.onCall({ output: [
+			"done",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "implemented" }],
+				changedFiles: ["src/file.ts"],
+				testsAddedOrUpdated: ["test/file.test.ts"],
+				commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+				validationOutput: ["tests passed"],
+				residualRisks: [],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n") });
+		const executor = makeExecutor([makeAgent("echo")]);
+
+		const result = await executor.execute(
+			"direct-gate",
+			{ async: false, agent: "echo", task: "Validate the result without edits", gate: `${process.execPath} -e "require('node:fs').writeFileSync('${markerFile}','verified')"` },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "direct gate failed");
+		assert.equal(fs.readFileSync(markerPath, "utf-8"), "verified");
+		assert.equal(result.details.results[0]?.acceptance?.status, "verified");
+		assert.equal(result.details.results[0]?.acceptance?.verifyRuns[0]?.id, "gate");
+	});
+
+	it("lets runs.all siblings settle when one verified gate fails", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const acceptedReport = [
+			"done",
+			"```acceptance-report",
+			JSON.stringify({
+				criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "implemented" }],
+				changedFiles: ["src/file.ts"],
+				testsAddedOrUpdated: ["test/file.test.ts"],
+				commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+				validationOutput: ["tests passed"],
+				residualRisks: [],
+				noStagedFiles: true,
+			}),
+			"```",
+		].join("\n");
+		mockPi.onCall({ output: acceptedReport });
+		mockPi.onCall({ output: acceptedReport });
+		const executor = makeExecutor([makeAgent("echo")]);
+
+		const result = await executor.execute(
+			"scripted-workflow-gates",
+			{
+				async: false,
+				workflowScript: `
+					const children = await runs.all([
+						{ key: "fails-gate", agent: "echo", task: "First task", gate: ${JSON.stringify(`${process.execPath} -e "process.exit(7)"`)} },
+						{ key: "passes-gate", agent: "echo", task: "Second task", gate: ${JSON.stringify(`${process.execPath} -e "process.exit(0)"`)} }
+					]);
+					return children.map(({ key, ok }) => ({ key, ok }));
+				`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		assert.equal(mockPi.callCount(), 2);
+		assert.deepEqual(result.details.workflow?.value, [
+			{ key: "fails-gate", ok: false },
+			{ key: "passes-gate", ok: true },
+		]);
+		const [failed, passed] = result.details.results;
+		assert.equal(failed?.acceptance?.status, "rejected");
+		assert.equal(failed?.acceptance?.verifyRuns[0]?.status, "failed");
+		assert.equal(passed?.acceptance?.status, "verified");
+		assert.equal(passed?.acceptance?.verifyRuns[0]?.status, "passed");
+	});
+
 	it("gives parallel workflow children separate managed worktrees and durable handoffs", { skip: !createSubagentExecutor || process.platform === "win32" ? "executor unavailable or worktree paths differ on Windows" : undefined }, async () => {
 		execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
 		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -9,6 +10,7 @@ import {
 	aggregateAcceptanceReport,
 	evaluateAcceptance,
 	formatAcceptancePrompt,
+	normalizeGateAcceptance,
 	parseAcceptanceReport,
 	resolveEffectiveAcceptance,
 	stripAcceptanceReport,
@@ -43,6 +45,16 @@ function report(overrides: Record<string, unknown> = {}, fence = "acceptance-rep
 function tempRepo(): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-acceptance-"));
 	fs.writeFileSync(path.join(dir, "file.txt"), "hello\n", "utf-8");
+	return dir;
+}
+
+function tempGitRepo(): string {
+	const dir = tempRepo();
+	execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+	execFileSync("git", ["config", "user.name", "Test User"], { cwd: dir });
+	execFileSync("git", ["add", "file.txt"], { cwd: dir });
+	execFileSync("git", ["commit", "-m", "base"], { cwd: dir, stdio: "ignore" });
 	return dir;
 }
 
@@ -1046,6 +1058,92 @@ describe("acceptance gates", () => {
 		assert.equal(resolved.level, "checked");
 	});
 
+	it("normalizes one gate command and rejects acceptance combinations", () => {
+		assert.deepEqual(normalizeGateAcceptance(" npm run check ", undefined), {
+			acceptance: { level: "verified", verify: [{ id: "gate", command: "npm run check" }] },
+		});
+		assert.match(normalizeGateAcceptance("", undefined).error ?? "", /non-empty command string/);
+		assert.match(normalizeGateAcceptance("npm test", "checked").error ?? "", /cannot be combined with acceptance/);
+	});
+
+	it("keeps explicit acceptance.verify arrays as existing verified acceptance", async () => {
+		const cwd = tempGitRepo();
+		const artifactsDir = path.join(cwd, ".artifacts");
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "run explicit verification",
+				explicit: { level: "verified", verify: [
+					{ id: "one", command: `${process.execPath} -e "require('node:fs').writeFileSync('one.txt','ok')"` },
+					{ id: "two", command: `${process.execPath} -e "require('node:fs').writeFileSync('two.txt','ok')"` },
+				] },
+				agentContract: { version: 1 },
+			});
+			const ledger = await evaluateAcceptance({ acceptance, output: "done", cwd, reportOptional: true, artifactsDir, runId: "multi-verify" });
+			assert.equal(ledger.status, "verified");
+			assert.deepEqual(ledger.verifyRuns.map((run) => [run.id, run.status]), [["one", "passed"], ["two", "passed"]]);
+			assert.equal(fs.readFileSync(path.join(cwd, "one.txt"), "utf-8"), "ok");
+			assert.equal(fs.readFileSync(path.join(cwd, "two.txt"), "utf-8"), "ok");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("memoizes host verification by tracked Git state, including failures", async () => {
+		const cwd = tempGitRepo();
+		const artifactsDir = path.join(cwd, ".artifacts");
+		const previousInheritedSecret = process.env.GATE_INHERITED_SECRET;
+		process.env.GATE_INHERITED_SECRET = "host-secret-not-persisted";
+		try {
+			const passing = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "run gate",
+				explicit: { level: "verified", verify: [{ id: "gate", command: `${process.execPath} -e "process.stdout.write(process.env.GATE_SECRET+':'+process.env.GATE_INHERITED_SECRET);require('node:fs').appendFileSync('count.txt','x')"`, env: { GATE_SECRET: "not-persisted" } }] },
+				agentContract: { version: 1 },
+			});
+			const evaluate = () => evaluateAcceptance({ acceptance: passing, output: "done", cwd, reportOptional: true, artifactsDir, runId: "memo-run" });
+			const first = await evaluate();
+			const same = await evaluate();
+			fs.writeFileSync(path.join(cwd, "untracked.txt"), "ignored\n", "utf-8");
+			const untracked = await evaluate();
+			process.env.GATE_INHERITED_SECRET = "host-secret-changed";
+			const inheritedChanged = await evaluate();
+			fs.writeFileSync(path.join(cwd, "file.txt"), "tracked change\n", "utf-8");
+			const tracked = await evaluate();
+			assert.equal(fs.readFileSync(path.join(cwd, "count.txt"), "utf-8"), "xxx");
+			assert.equal(first.verifyRuns[0]?.memoized, false);
+			assert.equal(first.verifyRuns[0]?.stdout, "[REDACTED]:[REDACTED]");
+			assert.equal(same.verifyRuns[0]?.memoized, true);
+			assert.equal(untracked.verifyRuns[0]?.memoized, true);
+			assert.equal(inheritedChanged.verifyRuns[0]?.memoized, false);
+			assert.equal(inheritedChanged.verifyRuns[0]?.stdout, "[REDACTED]:[REDACTED]");
+			assert.equal(tracked.verifyRuns[0]?.memoized, false);
+			const artifact = fs.readFileSync(first.verifyRuns[0]!.artifactPath!, "utf-8");
+			assert.doesNotMatch(artifact, /not-persisted/);
+			assert.doesNotMatch(artifact, /host-secret-not-persisted/);
+			assert.doesNotMatch(artifact, /host-secret-changed/);
+			assert.match(artifact, /GATE_SECRET/);
+
+			const failing = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "run gate",
+				explicit: { level: "verified", verify: [{ id: "gate", command: `${process.execPath} -e "require('node:fs').appendFileSync('fail-count.txt','x');process.exit(7)"` }] },
+				agentContract: { version: 1 },
+			});
+			const failOnce = await evaluateAcceptance({ acceptance: failing, output: "done", cwd, reportOptional: true, artifactsDir, runId: "failure-run" });
+			const failCached = await evaluateAcceptance({ acceptance: failing, output: "done", cwd, reportOptional: true, artifactsDir, runId: "failure-run" });
+			assert.equal(failOnce.status, "rejected");
+			assert.equal(failCached.status, "rejected");
+			assert.equal(failCached.verifyRuns[0]?.memoized, true);
+			assert.equal(failCached.verifyRuns[0]?.exitCode, 7);
+			assert.equal(fs.readFileSync(path.join(cwd, "fail-count.txt"), "utf-8"), "x");
+		} finally {
+			if (previousInheritedSecret === undefined) delete process.env.GATE_INHERITED_SECRET;
+			else process.env.GATE_INHERITED_SECRET = previousInheritedSecret;
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("validates invalid disable and verify shapes", () => {
 		assert.deepEqual(validateAcceptanceInput({ level: "none" }), ["acceptance.reason is required when level is none."]);
 		assert.deepEqual(validateAcceptanceInput("none"), ["acceptance level \"none\" requires a reason; use { level: \"none\", reason: \"...\" }."]);
@@ -1054,6 +1152,7 @@ describe("acceptance gates", () => {
 			assert.match(validateAcceptanceInput(input).join("\n"), /at least one runtime command when level is verified.*Use level "checked" or provide a non-empty acceptance\.verify array/);
 		}
 		assert.deepEqual(validateAcceptanceInput({ level: "verified", verify: [{ id: "tests", command: "npm test" }] }), []);
+		assert.deepEqual(validateAcceptanceInput({ level: "verified", verify: [{ id: "tests", command: "npm test" }, { id: "lint", command: "npm run lint" }] }), []);
 		assert.deepEqual(validateAcceptanceInput({ level: "checked" }), []);
 		assert.deepEqual(validateAcceptanceInput({ verify: [{ id: "missing-command" }] }), ["acceptance.verify[0].command is required."]);
 		assert.deepEqual(validateAcceptanceInput({ verify: [{ id: "fractional", command: "npm test", timeoutMs: 1.5 }] }), ["acceptance.verify[0].timeoutMs must be an integer >= 1."]);

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -185,6 +185,10 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		const worktree = SubagentParams?.properties?.worktree;
 		assert.equal(worktree?.type, "boolean");
 		assert.match(String(worktree?.description ?? ""), /each workflow child/i);
+		const gate = SubagentParams?.properties?.gate;
+		assert.equal(gate?.type, "string");
+		assert.equal(gate?.minLength, 1);
+		assert.match(String(gate?.description ?? ""), /cannot be combined with acceptance/i);
 		const properties = SubagentParams?.properties as Record<string, unknown> | undefined;
 		assert.equal(properties?.task, undefined, "task should only exist inside workflowScript children");
 		assert.equal(properties?.clarify, undefined, "clarify should not be model-facing");

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -187,6 +187,35 @@ describe("scripted workflow runtime", () => {
 		]);
 	});
 
+	it("accepts one gate command and rejects gate with acceptance", async () => {
+		const launches: Record<string, unknown>[] = [];
+		await runWorkflowScript({
+			script: `return runs.run("gated", { agent: "worker", gate: "npm test" });`,
+			async launch(key, params) { launches.push(params); return { key, ok: true, output: "done", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(launches[0]?.gate, "npm test");
+		await assert.rejects(
+			runWorkflowScript({
+				script: `return runs.run("invalid", { agent: "worker", gate: "npm test", acceptance: "checked" });`,
+				async launch(key) { return { key, ok: true, output: "done", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && /gate cannot be combined with acceptance/.test(error.message),
+		);
+	});
+
+	it("rejects retained resume with gate", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `return runs.run("resume", { resume: "retained-run", task: "Continue", gate: "npm test" });`,
+				async launch(key) { return { key, ok: true, output: "done", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && /gate is not supported with retained resume/.test(error.message),
+		);
+	});
+
 	it("keeps runs.run fail-fast for ordinary child failures", async () => {
 		await assert.rejects(
 			runWorkflowScript({

--- a/test/unit/workflow-launch-params.test.ts
+++ b/test/unit/workflow-launch-params.test.ts
@@ -3,6 +3,48 @@ import { describe, it } from "node:test";
 import { prepareWorkflowLaunchParams } from "../../src/runs/foreground/subagent-executor.ts";
 
 describe("workflow launch params", () => {
+	it("places workflow child gates inside managed worktree tasks", () => {
+		assert.deepEqual(
+			prepareWorkflowLaunchParams(
+				{},
+				{ agent: "worker", task: "Implement", worktree: true, gate: "npm test" },
+				"workflow-run",
+				"gated",
+			),
+			{
+				worktree: true,
+				workflowParentRunId: "workflow-run",
+				workflowKey: "gated",
+				tasks: [{
+					agent: "worker",
+					task: "Implement",
+					acceptance: { level: "verified", verify: [{ id: "gate", command: "npm test" }] },
+				}],
+			},
+		);
+	});
+
+	it("rejects gate defaults on retained resume items", () => {
+		assert.throws(
+			() => prepareWorkflowLaunchParams(
+				{ gate: "npm test" },
+				{ resume: "retained-run", task: "Continue" },
+				"workflow-run",
+				"continue",
+			),
+			/gate is not supported with retained resume/,
+		);
+		assert.throws(
+			() => prepareWorkflowLaunchParams(
+				{},
+				{ resume: "retained-run", task: "Continue", gate: "npm test" },
+				"workflow-run",
+				"continue",
+			),
+			/gate is not supported with retained resume/,
+		);
+	});
+
 	it("preserves execution limits when routing retained resume items", () => {
 		assert.deepEqual(
 			prepareWorkflowLaunchParams(


### PR DESCRIPTION
Adds `gate` as a one-command host verification shorthand for child runs, while keeping the existing `acceptance.verify` surface and multi-command verified acceptance intact.

The gate result is recorded as host-verified evidence with tracked-workspace and effective-environment memoization. `gate` is rejected with retained resume so it cannot be silently dropped.

Validation passed locally:
- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/acceptance.test.ts test/unit/scripted-workflow.test.ts test/unit/schemas.test.ts test/unit/workflow-launch-params.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern="(runs a direct child gate|lets runs.all siblings settle when one verified gate fails)" test/integration/single-execution.test.ts`
- `git diff --check`
- `git diff HEAD^ --check`
- `git show --check --oneline --stat HEAD`

Closes #869.