### PR TITLE
refactor: clarify gate normalization results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Require workflowScript-only persisted schedule targets. Removed legacy agent-target restore conversion.
 
 ### Fixed
+- Represent gate normalization with explicit success and failure results, removing ambiguous internal states without changing gate behavior.
 - Preserve live composite child tool-call ids for APIs that normalize them, preventing context rewriting from breaking the next tool-loop turn.
 - Sanitize inherited child tool history ids so forked subagent context stays provider-portable.
 - Prevent async workflow result finalization from reading stale extension contexts after session replacement or reload.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3951,19 +3951,23 @@ export function prepareWorkflowLaunchParams(
 		...(options.suppressRoutineResultIntercom ? { suppressRoutineResultIntercom: true } : {}),
 	} as SubagentParamsLike;
 	const normalizedGate = normalizeGateParams(launchParams);
-	if (normalizedGate.error || !normalizedGate.params) throw new Error(normalizedGate.error ?? "Invalid gate.");
+	if (!normalizedGate.ok) throw new Error(normalizedGate.error);
 	return prepareWorkflowChildParams(normalizedGate.params);
 }
 
-function normalizeGateParams(params: SubagentParamsLike): { params?: SubagentParamsLike; error?: string } {
+type GateParamsNormalizationResult =
+	| { ok: true; params: SubagentParamsLike }
+	| { ok: false; error: string };
+
+function normalizeGateParams(params: SubagentParamsLike): GateParamsNormalizationResult {
 	if (params.gate !== undefined && params.action === "resume") {
-		return { error: "gate is not supported with action='resume'; resume uses the retained child contract." };
+		return { ok: false, error: "gate is not supported with action='resume'; resume uses the retained child contract." };
 	}
 	const normalized = normalizeGateAcceptance(params.gate, params.acceptance);
-	if (normalized.error) return { error: normalized.error };
-	if (params.gate === undefined) return { params };
+	if (!normalized.ok) return { ok: false, error: normalized.error };
+	if (params.gate === undefined) return { ok: true, params };
 	const { gate: _gate, ...rest } = params;
-	return { params: { ...rest, ...(normalized.acceptance !== undefined ? { acceptance: normalized.acceptance } : {}) } };
+	return { ok: true, params: { ...rest, ...(normalized.acceptance !== undefined ? { acceptance: normalized.acceptance } : {}) } };
 }
 
 function prepareWorkflowChildParams(params: SubagentParamsLike): SubagentParamsLike {
@@ -4106,7 +4110,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		deps.state.foregroundControls ??= new Map();
 		deps.state.lastForegroundControlId ??= null;
 		const normalizedGate = normalizeGateParams(params);
-		if (normalizedGate.error || !normalizedGate.params) return buildRequestedModeError(params, normalizedGate.error ?? "Invalid gate.");
+		if (!normalizedGate.ok) return buildRequestedModeError(params, normalizedGate.error);
 		const requestParams = normalizedGate.params;
 		const normalizedAction = typeof requestParams.action === "string" ? requestParams.action.trim() : requestParams.action;
 		if (requestParams.workflowScript !== undefined && normalizedAction === undefined) {

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -153,11 +153,15 @@ export function normalizeAcceptanceInput(input: AcceptanceInput | undefined): Ac
 	return { ...input };
 }
 
-export function normalizeGateAcceptance(gate: unknown, acceptance: AcceptanceInput | undefined): { acceptance?: AcceptanceInput; error?: string } {
-	if (gate === undefined) return { acceptance };
-	if (typeof gate !== "string" || !gate.trim()) return { error: "gate must be a non-empty command string." };
-	if (acceptance !== undefined) return { error: "gate cannot be combined with acceptance; use one gate command or acceptance.verify." };
-	return { acceptance: { level: "verified", verify: [{ id: "gate", command: gate.trim() }] } };
+type GateAcceptanceNormalizationResult =
+	| { ok: true; acceptance?: AcceptanceInput }
+	| { ok: false; error: string };
+
+export function normalizeGateAcceptance(gate: unknown, acceptance: AcceptanceInput | undefined): GateAcceptanceNormalizationResult {
+	if (gate === undefined) return acceptance === undefined ? { ok: true } : { ok: true, acceptance };
+	if (typeof gate !== "string" || !gate.trim()) return { ok: false, error: "gate must be a non-empty command string." };
+	if (acceptance !== undefined) return { ok: false, error: "gate cannot be combined with acceptance; use one gate command or acceptance.verify." };
+	return { ok: true, acceptance: { level: "verified", verify: [{ id: "gate", command: gate.trim() }] } };
 }
 
 function explicitAcceptanceCanDisable(explicit: AcceptanceConfig): boolean {

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1060,10 +1060,15 @@ describe("acceptance gates", () => {
 
 	it("normalizes one gate command and rejects acceptance combinations", () => {
 		assert.deepEqual(normalizeGateAcceptance(" npm run check ", undefined), {
+			ok: true,
 			acceptance: { level: "verified", verify: [{ id: "gate", command: "npm run check" }] },
 		});
-		assert.match(normalizeGateAcceptance("", undefined).error ?? "", /non-empty command string/);
-		assert.match(normalizeGateAcceptance("npm test", "checked").error ?? "", /cannot be combined with acceptance/);
+		const emptyGate = normalizeGateAcceptance("", undefined);
+		assert.equal(emptyGate.ok, false);
+		assert.match(emptyGate.error, /non-empty command string/);
+		const conflictingGate = normalizeGateAcceptance("npm test", "checked");
+		assert.equal(conflictingGate.ok, false);
+		assert.match(conflictingGate.error, /cannot be combined with acceptance/);
 	});
 
 	it("keeps explicit acceptance.verify arrays as existing verified acceptance", async () => {


### PR DESCRIPTION
This is a narrow TypeScript cleanup for the unreleased `gate` seam.

It replaces the internal optional success/error bags used by gate normalization with explicit `ok` result unions. That makes invalid result states unrepresentable while preserving the same gate behavior and error text.

Validation run locally:

- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/acceptance.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e` skipped the real Pi-session suite because runtime packages were unavailable

Fresh exact-head review found no blockers.
