### PR TITLE
feat: expose scheduledRuns.storeRoot to keep schedules out of project…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,6 +116,14 @@ A user may explicitly call `subagent({ action: "grant-spawn-budget", additional:
 
 Durable schedules are enabled by default and stored per project under `.pi-subagents/schedules/<id>/`. See [missions.md](missions.md#schedules) for usage.
 
+Set `storeRoot` to keep the durable schedule store **outside** project repositories, e.g. `~/.local/share/pi-subagents/schedules`. Each project's schedules are kept under its own `<storeRoot>/<sha256(cwd)>.slice(0,20)/<id>/` directory, so multiple projects never collide. The value must be an absolute path or start with `~/` (expanded via `os.homedir()`); relative, project-relative paths are rejected because a global store must not move with a transient worktree.
+
+```json
+{ "scheduledRuns": { "storeRoot": "~/.local/share/pi-subagents/schedules" } }
+```
+
+When omitted, behavior is identical to previous versions (per-project `.<cwd>/.pi-subagents/schedules`).
+
 ## `parallel`
 
 ```json

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { ArtifactDirPreference, ExtensionConfig } from "../shared/types.ts";
 import { validateMissionStoreConfig } from "../missions/store.ts";
@@ -7,6 +8,27 @@ import { getAgentDir } from "../shared/utils.ts";
 import { validatePermissionConfig } from "../runs/shared/permissions.ts";
 
 const ARTIFACT_DIR_PREFERENCES = new Set<ArtifactDirPreference>(["project", "session", "temp"]);
+
+/**
+ * Expands a configured schedule store root. Accepts an absolute path or a
+ * `~`-prefixed path (expanded via os.homedir). Rejects project-relative paths:
+ * a global schedule store must not move with a transient worktree.
+ */
+export function resolveScheduledStoreRoot(value: string): string {
+	const expanded = value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
+	const normalized = path.isAbsolute(expanded) ? path.normalize(expanded) : null;
+	if (!normalized) throw new Error(`config.scheduledRuns.storeRoot must be an absolute path or "~/...", got ${JSON.stringify(value)}`);
+	return normalized;
+}
+
+function validateScheduledRunsConfig(value: unknown): void {
+	if (value === undefined) return;
+	const config = value as Record<string, unknown>;
+	const storeRoot = config.storeRoot;
+	if (storeRoot === undefined) return;
+	if (typeof storeRoot !== "string" || storeRoot.trim() === "") throw new Error("config.scheduledRuns.storeRoot must be a non-empty string");
+	resolveScheduledStoreRoot(storeRoot);
+}
 
 export function getConfigPath(): string {
 	return path.join(getAgentDir(), "extensions", "subagent", "config.json");
@@ -25,6 +47,7 @@ function readConfigForUpdate(configPath = getConfigPath()): ExtensionConfig {
 	validateMissionStoreConfig(config.missions);
 	validateAuthorityPolicy(config.authorityPolicy);
 	validatePermissionConfig(config.permissions);
+	validateScheduledRunsConfig(config.scheduledRuns);
 	return parsed as ExtensionConfig;
 }
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -50,7 +50,7 @@ import { formatSteeringNotice, handleSubagentSteeringNotice, SUBAGENT_STEERING_M
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
-import { loadConfig, resolveAsyncByDefault } from "./config.ts";
+import { loadConfig, resolveAsyncByDefault, resolveScheduledStoreRoot } from "./config.ts";
 import { buildSubagentToolDescription } from "./tool-description.ts";
 import { collectGoalContinuationNotices } from "../missions/goal-driver.ts";
 import { syncMissionFromAsyncCompletion } from "../missions/lifecycle.ts";
@@ -77,7 +77,7 @@ import {
 	type SubagentControlMessageDetails,
 } from "./control-notices.ts";
 
-export { loadConfig, resolveAsyncByDefault } from "./config.ts";
+export { loadConfig, resolveAsyncByDefault, resolveScheduledStoreRoot } from "./config.ts";
 
 function workflowLaneKeys(script: string): string[] {
 	const keys: string[] = [];
@@ -383,8 +383,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		: undefined;
 	let executorScheduled: ((id: string, params: SubagentParamsLike, signal: AbortSignal, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>) | undefined;
 	let goalTurnId = 0;
+	const scheduledStoreRoot = config.scheduledRuns?.storeRoot ? resolveScheduledStoreRoot(config.scheduledRuns.storeRoot) : undefined;
 	const scheduledRunManager = createScheduledRunManager({
 		config,
+		storeRoot: scheduledStoreRoot,
 		launch: (params, ctx, signal) => {
 			if (!executorScheduled) {
 				return Promise.resolve({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1736,6 +1736,16 @@ export type InlineToolDisplay = "rich" | "summary";
 export interface ScheduledRunsConfig {
 	enabled?: boolean;
 	maxPending?: number;
+	/**
+	 * Optional root directory for the durable schedule store. When set, schedules
+	 * are persisted under `<storeRoot>/<sha256(cwd).slice(0,20)>` instead of the
+	 * default `<cwd>/.pi-subagents/schedules`, keeping runtime state out of project
+	 * repositories. Supports `~` (expanded via os.homedir). Must be an absolute
+	 * path or `~`-prefixed — a project-relative root is rejected because a global
+	 * store must not vary per transient worktree. When omitted, behavior is
+	 * identical to previous versions.
+	 */
+	storeRoot?: string;
 }
 
 export type FleetViewPlacement = "aboveEditor" | "belowEditor";

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -261,6 +261,15 @@ describe("project schedule management", () => {
 		assert.equal(fs.existsSync(path.join(outside, "schedule.json")), false);
 	});
 
+	it("persists schedules under an external store root instead of the project cwd", async () => {
+		const h = harness();
+		await h.manager.handleToolCall({ action: "schedule.create", id: "external", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		const externalRoot = scheduledRunStorePath(path.resolve(h.ctx.cwd), undefined, path.join(h.root, "stores"));
+		// The schedule record lives under the external store root, not <cwd>/.pi-subagents.
+		assert.equal(fs.existsSync(path.join(externalRoot, "external", "schedule.json")), true);
+		assert.equal(fs.existsSync(path.join(path.resolve(h.ctx.cwd), ".pi-subagents", "schedules", "external")), false);
+	});
+
 	it("rejects a default project schedule root that escapes through .pi-subagents", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-schedule-root-link-"));
 		roots.push(root);

--- a/test/unit/scheduled-store-root.test.ts
+++ b/test/unit/scheduled-store-root.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { loadConfig, resolveScheduledStoreRoot, saveConfig } from "../../src/extension/config.ts";
+import type { ExtensionConfig } from "../../src/shared/types.ts";
+
+const AGENT_DIR_ENV = "PI_CODING_AGENT_DIR";
+let agentDir: string;
+
+beforeEach(() => {
+	agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-config-store-root-"));
+	process.env[AGENT_DIR_ENV] = agentDir;
+});
+
+afterEach(() => {
+	delete process.env[AGENT_DIR_ENV];
+	fs.rmSync(agentDir, { recursive: true, force: true });
+});
+
+describe("config.scheduledRuns.storeRoot", () => {
+	it("resolves an absolute store root unchanged", () => {
+		const absolute = "/var/lib/pi-subagents/schedules";
+		assert.equal(resolveScheduledStoreRoot(absolute), absolute);
+	});
+
+	it("expands a ~/ prefixed store root against os.homedir()", () => {
+		assert.equal(resolveScheduledStoreRoot("~/pi-subagents/schedules"), path.join(os.homedir(), "pi-subagents/schedules"));
+		assert.equal(resolveScheduledStoreRoot("~/"), os.homedir());
+	});
+
+	it("rejects a project-relative store root because a global store must not move per worktree", () => {
+		assert.throws(() => resolveScheduledStoreRoot("tmp/schedules"), /absolute path/);
+		assert.throws(() => resolveScheduledStoreRoot("./stores"), /absolute path/);
+		assert.throws(() => resolveScheduledStoreRoot("stores"), /absolute path/);
+	});
+
+	it("round-trips a valid absolute storeRoot through save/load config", () => {
+		const storeRoot = path.join(os.tmpdir(), "pi-subagents-global-schedules");
+		saveConfig({ scheduledRuns: { storeRoot } });
+		const config = loadConfig() as ExtensionConfig;
+		assert.equal(config?.scheduledRuns?.storeRoot, storeRoot);
+	});
+
+	it("round-trips a ~/ storeRoot through save/load config", () => {
+		saveConfig({ scheduledRuns: { storeRoot: "~/pi-subagents/schedules" } });
+		const config = loadConfig() as ExtensionConfig;
+		assert.equal(config?.scheduledRuns?.storeRoot, "~/pi-subagents/schedules");
+	});
+
+	it("rejects a non-empty invalid storeRoot on load", () => {
+		saveConfig({ scheduledRuns: { storeRoot: "relative/store" } });
+		// loadConfig catches validation and returns {} — valid values are preserved,
+		// invalid configuration is rejected to avoid silently using a broken path.
+		assert.deepEqual(loadConfig(), {});
+	});
+
+	it("keeps a config without storeRoot valid (backward compatible)", () => {
+		saveConfig({ scheduledRuns: { enabled: true } });
+		const config = loadConfig() as ExtensionConfig;
+		assert.equal(config?.scheduledRuns?.enabled, true);
+		assert.equal(config?.scheduledRuns?.storeRoot, undefined);
+	});
+});


### PR DESCRIPTION
… repos

schedules are persisted per project under <cwd>/.pi-subagents/schedules, which leaves runtime state inside project repositories. The schedule store authority (scheduledRunStorePath with a root, ScheduledRunManager deps.storeRoot) already supported an external store but it was not reachable from config.

Add an optional scheduledRuns.storeRoot to the extension config. When set, each project's schedules live under <storeRoot>/<sha256(cwd).slice(0,20)>, so multiple projects never collide and nothing pollutes the repo.

- config.ts: resolveScheduledStoreRoot expands ~/ via os.homedir and rejects project-relative paths (a global store must not move with a transient worktree); validateScheduledRunsConfig validates the option.
- index.ts: expand storeRoot and thread it into createScheduledRunManager.
- Docs + unit tests for expansion, rejection, config round-trip, and external-root persistence.

Backward compatible: without storeRoot the behavior is identical to before.