### PR TITLE
feat: configure scheduled run store root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Added `scheduledRuns.storeRoot` for durable schedules outside project repositories. Thanks to @ProCleiton for #891 and the prior #890 implementation.
+
 ## [0.43.0] - 2026-08-07
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,6 +116,14 @@ A user may explicitly call `subagent({ action: "grant-spawn-budget", additional:
 
 Durable schedules are enabled by default and stored per project under `.pi-subagents/schedules/<id>/`. See [missions.md](missions.md#schedules) for usage.
 
+Set `storeRoot` to keep durable schedules outside project repositories. It must be an absolute path or a `~/` path, which expands from the user home directory. Each project is stored under a hash of its resolved working directory, so projects do not share schedules.
+
+```json
+{ "scheduledRuns": { "storeRoot": "~/.local/share/pi-subagents/schedules" } }
+```
+
+When `storeRoot` is omitted, schedules remain at `<cwd>/.pi-subagents/schedules`.
+
 ## `parallel`
 
 ```json

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { ArtifactDirPreference, ExtensionConfig } from "../shared/types.ts";
 import { validateMissionStoreConfig } from "../missions/store.ts";
@@ -7,6 +8,31 @@ import { getAgentDir } from "../shared/utils.ts";
 import { validatePermissionConfig } from "../runs/shared/permissions.ts";
 
 const ARTIFACT_DIR_PREFERENCES = new Set<ArtifactDirPreference>(["project", "session", "temp"]);
+
+export function resolveScheduledStoreRoot(value: string): string {
+	const expanded = value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
+	if (!path.isAbsolute(expanded)) throw new Error(`config.scheduledRuns.storeRoot must be an absolute path or "~/...", got ${JSON.stringify(value)}`);
+	return path.normalize(expanded);
+}
+
+function validateScheduledRunsConfig(value: unknown): void {
+	if (value === undefined) return;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("config.scheduledRuns must be a JSON object");
+	const storeRoot = (value as Record<string, unknown>).storeRoot;
+	if (storeRoot === undefined) return;
+	if (typeof storeRoot !== "string" || !storeRoot.trim()) throw new Error("config.scheduledRuns.storeRoot must be a non-empty string");
+	resolveScheduledStoreRoot(storeRoot);
+}
+
+function validateConfig(config: Record<string, unknown>): void {
+	if (config.artifactDir !== undefined && !ARTIFACT_DIR_PREFERENCES.has(config.artifactDir as ArtifactDirPreference)) {
+		throw new Error(`config.artifactDir must be "project", "session", or "temp"`);
+	}
+	validateMissionStoreConfig(config.missions);
+	validateAuthorityPolicy(config.authorityPolicy);
+	validatePermissionConfig(config.permissions);
+	validateScheduledRunsConfig(config.scheduledRuns);
+}
 
 export function getConfigPath(): string {
 	return path.join(getAgentDir(), "extensions", "subagent", "config.json");
@@ -18,13 +44,7 @@ function readConfigForUpdate(configPath = getConfigPath()): ExtensionConfig {
 	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
 		throw new Error(`Subagent config at '${configPath}' must be a JSON object`);
 	}
-	const config = parsed as Record<string, unknown>;
-	if (config.artifactDir !== undefined && !ARTIFACT_DIR_PREFERENCES.has(config.artifactDir as ArtifactDirPreference)) {
-		throw new Error(`config.artifactDir must be "project", "session", or "temp"`);
-	}
-	validateMissionStoreConfig(config.missions);
-	validateAuthorityPolicy(config.authorityPolicy);
-	validatePermissionConfig(config.permissions);
+	validateConfig(parsed as Record<string, unknown>);
 	return parsed as ExtensionConfig;
 }
 
@@ -36,6 +56,7 @@ export function saveConfig(config: ExtensionConfig, configPath = getConfigPath()
 export function updateConfig(updater: (config: ExtensionConfig) => ExtensionConfig): ExtensionConfig {
 	const configPath = getConfigPath();
 	const next = updater(readConfigForUpdate(configPath));
+	validateConfig(next as Record<string, unknown>);
 	saveConfig(next, configPath);
 	return next;
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -50,7 +50,7 @@ import { formatSteeringNotice, handleSubagentSteeringNotice, SUBAGENT_STEERING_M
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
-import { loadConfig, resolveAsyncByDefault } from "./config.ts";
+import { loadConfig, resolveAsyncByDefault, resolveScheduledStoreRoot } from "./config.ts";
 import { buildSubagentToolDescription } from "./tool-description.ts";
 import { collectGoalContinuationNotices } from "../missions/goal-driver.ts";
 import { syncMissionFromAsyncCompletion } from "../missions/lifecycle.ts";
@@ -383,8 +383,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		: undefined;
 	let executorScheduled: ((id: string, params: SubagentParamsLike, signal: AbortSignal, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>) | undefined;
 	let goalTurnId = 0;
+	const scheduledStoreRoot = config.scheduledRuns?.storeRoot === undefined ? undefined : resolveScheduledStoreRoot(config.scheduledRuns.storeRoot);
 	const scheduledRunManager = createScheduledRunManager({
 		config,
+		storeRoot: scheduledStoreRoot,
 		launch: (params, ctx, signal) => {
 			if (!executorScheduled) {
 				return Promise.resolve({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1736,6 +1736,8 @@ export type InlineToolDisplay = "rich" | "summary";
 export interface ScheduledRunsConfig {
 	enabled?: boolean;
 	maxPending?: number;
+	/** Absolute or `~/` root for per-project durable schedules. */
+	storeRoot?: string;
 }
 
 export type FleetViewPlacement = "aboveEditor" | "belowEditor";

--- a/test/unit/scheduled-store-root.test.ts
+++ b/test/unit/scheduled-store-root.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { getConfigPath, loadConfig, resolveScheduledStoreRoot, saveConfig, updateConfig } from "../../src/extension/config.ts";
+
+const AGENT_DIR_ENV = "PI_CODING_AGENT_DIR";
+const HOME_ENV = "HOME";
+const USERPROFILE_ENV = "USERPROFILE";
+let agentDir: string;
+let homeDir: string;
+let previousAgentDir: string | undefined;
+let previousHome: string | undefined;
+let previousUserProfile: string | undefined;
+
+beforeEach(() => {
+	previousAgentDir = process.env[AGENT_DIR_ENV];
+	previousHome = process.env[HOME_ENV];
+	previousUserProfile = process.env[USERPROFILE_ENV];
+	agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-schedule-store-root-"));
+	homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-schedule-home-"));
+	process.env[AGENT_DIR_ENV] = agentDir;
+	process.env[HOME_ENV] = homeDir;
+	process.env[USERPROFILE_ENV] = homeDir;
+});
+
+afterEach(() => {
+	if (previousAgentDir === undefined) delete process.env[AGENT_DIR_ENV];
+	else process.env[AGENT_DIR_ENV] = previousAgentDir;
+	if (previousHome === undefined) delete process.env[HOME_ENV];
+	else process.env[HOME_ENV] = previousHome;
+	if (previousUserProfile === undefined) delete process.env[USERPROFILE_ENV];
+	else process.env[USERPROFILE_ENV] = previousUserProfile;
+	fs.rmSync(agentDir, { recursive: true, force: true });
+	fs.rmSync(homeDir, { recursive: true, force: true });
+});
+
+describe("config.scheduledRuns.storeRoot", () => {
+	it("accepts an absolute path and expands a ~/ path", () => {
+		const absolute = path.join(os.tmpdir(), "pi-subagents-schedules");
+		assert.equal(resolveScheduledStoreRoot(absolute), path.normalize(absolute));
+		assert.equal(resolveScheduledStoreRoot("~/pi-subagents/schedules"), path.join(homeDir, "pi-subagents", "schedules"));
+	});
+
+	it("rejects project-relative paths during config load", () => {
+		saveConfig({ scheduledRuns: { storeRoot: "schedules" } });
+		const originalError = console.error;
+		console.error = () => {};
+		try {
+			assert.deepEqual(loadConfig(), {});
+		} finally {
+			console.error = originalError;
+		}
+	});
+
+	it("rejects project-relative paths during config update", () => {
+		assert.throws(() => updateConfig(() => ({ scheduledRuns: { storeRoot: "./schedules" } })), /absolute path/);
+		assert.equal(fs.existsSync(getConfigPath()), false);
+	});
+
+	it("preserves a configured store root", () => {
+		const storeRoot = path.join(os.tmpdir(), "pi-subagents-schedules");
+		saveConfig({ scheduledRuns: { storeRoot } });
+		assert.equal(loadConfig().scheduledRuns?.storeRoot, storeRoot);
+	});
+});


### PR DESCRIPTION
## Summary
- add `scheduledRuns.storeRoot` for schedule storage outside project repositories
- validate absolute and `~/` roots, reject relative roots, and wire the resolved root into the scheduler
- document the option and add portable focused tests

Credits @ProCleiton for the report in #891 and the prior implementation work in #890.

Fixes #891.

## Validation
- `node --experimental-strip-types --test test/unit/scheduled-store-root.test.ts test/unit/scheduled-runs.test.ts test/unit/config-dir-runtime.test.ts test/unit/pi-coding-agent-dir.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- fresh exact-head review: `/tmp/pi-subagents-queue-20260807/reports/issue891-review.md`
