### PR TITLE
fix: use portable async workflow run ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Require workflowScript-only persisted schedule targets. Removed legacy agent-target restore conversion.
 
 ### Fixed
+- Use portable internal ids for async workflow directories and preserve host tool-call ids as correlation metadata. Thanks to @DrunkenDonkey80 for #889.
 - Represent gate normalization with explicit success and failure results, removing ambiguous internal states without changing gate behavior.
 - Preserve live composite child tool-call ids for APIs that normalize them, preventing context rewriting from breaking the next tool-loop turn.
 - Sanitize inherited child tool history ids so forked subagent context stays provider-portable.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -65,6 +65,7 @@ interface AsyncRunStepSummary {
 export interface AsyncRunSummary {
 	id: string;
 	asyncDir: string;
+	toolCallId?: string;
 	sessionId?: string;
 	state: "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
 	error?: string;
@@ -288,6 +289,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 	return {
 		id: status.runId || path.basename(asyncDir),
 		asyncDir,
+		...(status.toolCallId ? { toolCallId: status.toolCallId } : {}),
 		...(status.sessionId ? { sessionId: status.sessionId } : {}),
 		state: status.state,
 		...(status.error ? { error: status.error } : {}),

--- a/src/runs/background/run-id-resolver.ts
+++ b/src/runs/background/run-id-resolver.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { DIRS, type SubagentState } from "../../shared/types.ts";
+import { readStatus } from "../../shared/utils.ts";
 import { findAsyncRunPrefixMatches, type AsyncRunLocation } from "./async-resume.ts";
 import { assertSafeNestedId, findNestedRunMatchesById, type NestedRoute, type NestedRunMatch, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 
@@ -25,6 +26,70 @@ function exactAsyncLocation(id: string, asyncDirRoot: string, resultsDir: string
 		resultPath: fs.existsSync(resultPath) ? resultPath : null,
 		resolvedId: id,
 	};
+}
+
+type AsyncRunMatch = { id: string; location: AsyncRunLocation };
+
+type WorkflowResultIdentity = {
+	id?: string;
+	runId?: string;
+	toolCallId?: string;
+};
+
+function readWorkflowResultIdentity(resultPath: string): WorkflowResultIdentity | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as unknown;
+	} catch {
+		return undefined;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+	const record = parsed as Record<string, unknown>;
+	return {
+		...(typeof record.id === "string" ? { id: record.id } : {}),
+		...(typeof record.runId === "string" ? { runId: record.runId } : {}),
+		...(typeof record.toolCallId === "string" ? { toolCallId: record.toolCallId } : {}),
+	};
+}
+
+function directoryEntries(root: string): string[] {
+	try {
+		return fs.readdirSync(root);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+}
+
+function resultPathFor(resultsDir: string, runId: string): string | null {
+	const resultPath = path.join(resultsDir, `${runId}.json`);
+	return fs.existsSync(resultPath) ? resultPath : null;
+}
+
+function toolCallIdMatches(value: string | undefined, query: string, options: { prefix?: boolean }): boolean {
+	if (value === undefined) return false;
+	return options.prefix === true ? value.startsWith(query) : value === query;
+}
+
+function toolCallIdAsyncLocations(toolCallId: string, asyncDirRoot: string, resultsDir: string, options: { prefix?: boolean } = {}): AsyncRunMatch[] {
+	const byId = new Map<string, AsyncRunLocation>();
+	for (const entry of directoryEntries(asyncDirRoot)) {
+		const asyncDir = path.join(asyncDirRoot, entry);
+		const status = readStatus(asyncDir);
+		if (!status || !toolCallIdMatches(status.toolCallId, toolCallId, options)) continue;
+		const runId = status.runId || entry;
+		byId.set(runId, { asyncDir, resultPath: resultPathFor(resultsDir, runId), resolvedId: runId });
+	}
+	for (const entry of directoryEntries(resultsDir)) {
+		if (!entry.endsWith(".json")) continue;
+		const resultPath = path.join(resultsDir, entry);
+		const identity = readWorkflowResultIdentity(resultPath);
+		if (!identity || !toolCallIdMatches(identity.toolCallId, toolCallId, options)) continue;
+		const runId = identity.runId ?? identity.id ?? entry.slice(0, -".json".length);
+		const asyncDir = path.join(asyncDirRoot, runId);
+		byId.set(runId, { asyncDir: fs.existsSync(asyncDir) ? asyncDir : null, resultPath, resolvedId: runId });
+	}
+	return [...byId.entries()].map(([id, location]) => ({ id, location }));
 }
 
 function foregroundIds(state: SubagentState | undefined): string[] {
@@ -73,6 +138,9 @@ export function resolveSubagentRunId(id: string, deps: ResolveSubagentRunIdDeps 
 	if (hasExactForegroundId(deps.state, id)) return { kind: "foreground", id };
 	const exactAsync = exactAsyncLocation(id, asyncDirRoot, resultsDir);
 	if (exactAsync) return { kind: "async", id, location: exactAsync };
+	const exactToolCallIdMatches = toolCallIdAsyncLocations(id, asyncDirRoot, resultsDir);
+	if (exactToolCallIdMatches.length > 1) throw new Error(`Subagent tool-call id '${id}' is ambiguous across async runs. Use the returned asyncId instead.`);
+	if (exactToolCallIdMatches[0]) return { kind: "async", id: exactToolCallIdMatches[0].id, location: exactToolCallIdMatches[0].location };
 	const exactNested = findNestedRunMatchesById(id, nestedScope ? { scope: nestedScope } : {});
 	if (exactNested.length > 1) throw new Error(`Nested run id '${id}' is ambiguous across authorized registries. Provide the full id after stale registries are cleaned up.`);
 	if (exactNested[0]) return { kind: "nested", id, match: exactNested[0] };
@@ -82,6 +150,9 @@ export function resolveSubagentRunId(id: string, deps: ResolveSubagentRunIdDeps 
 		matches.push({ kind: "foreground", id: foregroundId });
 	}
 	for (const match of asyncPrefixMatches(id, asyncDirRoot, resultsDir)) {
+		matches.push({ kind: "async", id: match.id, location: match.location });
+	}
+	for (const match of toolCallIdAsyncLocations(id, asyncDirRoot, resultsDir, { prefix: true })) {
 		matches.push({ kind: "async", id: match.id, location: match.location });
 	}
 	for (const match of findNestedRunMatchesById(id, nestedScope ? { prefix: true, scope: nestedScope } : { prefix: true })) {

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -382,6 +382,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			const workflowEmitPreview = status.workflow?.emits.length ? formatWorkflowJsonPreview(status.workflow.emits.at(-1), 240) : undefined;
 			const lines = [
 				`Run: ${status.runId}`,
+				status.toolCallId ? `Tool call: ${status.toolCallId}` : undefined,
 				missionId ? `Mission: ${missionId}` : undefined,
 				`State: ${status.state}`,
 				processTerminal ? `Process terminal: ${processTerminal.state}${processTerminal.reason ? ` (${processTerminal.reason})` : ""}` : undefined,
@@ -454,7 +455,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 	if (resultPath) {
 		try {
 			const raw = fs.readFileSync(resultPath, "utf-8");
-			const data = JSON.parse(raw) as { id?: string; runId?: string; agent?: string; success?: boolean; summary?: string; output?: string; exitCode?: number; state?: string; stopped?: boolean; timedOut?: boolean; turnBudgetExceeded?: boolean; processSignal?: string | null; sessionFile?: string; parallelHandoff?: { path?: string }; results?: Array<{ agent?: string; output?: string; summary?: string; sessionFile?: string; state?: string; success?: boolean; exitCode?: number | null; stopped?: boolean; timedOut?: boolean; turnBudgetExceeded?: boolean; interrupted?: boolean; processSignal?: string | null }> };
+			const data = JSON.parse(raw) as { id?: string; runId?: string; toolCallId?: string; agent?: string; success?: boolean; summary?: string; output?: string; exitCode?: number; state?: string; stopped?: boolean; timedOut?: boolean; turnBudgetExceeded?: boolean; processSignal?: string | null; sessionFile?: string; parallelHandoff?: { path?: string }; results?: Array<{ agent?: string; output?: string; summary?: string; sessionFile?: string; state?: string; success?: boolean; exitCode?: number | null; stopped?: boolean; timedOut?: boolean; turnBudgetExceeded?: boolean; interrupted?: boolean; processSignal?: string | null }> };
 			if (params.view === "transcript") {
 				try {
 					return { content: [{ type: "text", text: formatAsyncResultTranscript(data, resultPath, { index: params.index, lines: params.lines }) }], details: { mode: "single", results: [] } };
@@ -479,7 +480,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				? "stopped"
 				: data.success ? "complete" : data.state === "paused" || data.exitCode === 0 ? "paused" : "failed";
 			const runId = data.runId ?? data.id ?? resolvedId;
-			const lines = [`Run: ${runId}`, `State: ${status}`, `Result: ${resultPath}`];
+			const lines = [`Run: ${runId}`, data.toolCallId ? `Tool call: ${data.toolCallId}` : undefined, `State: ${status}`, `Result: ${resultPath}`].filter((line): line is string => Boolean(line));
 			if (data.parallelHandoff?.path) lines.push(`Parallel handoff: ${data.parallelHandoff.path}`);
 			const children = Array.isArray(data.results) ? data.results : data.agent ? [{ agent: data.agent, sessionFile: data.sessionFile }] : [];
 			lines.push(formatResumeGuidance(runId, children, data.sessionFile, { stopped: status === "stopped" }));

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4149,7 +4149,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				}
 			};
 			if (requestParams.async !== false) {
-				const workflowRunId = _id;
+				const toolCallId = _id;
+				const workflowRunId = randomUUID();
 				const asyncDir = path.join(DIRS.async, workflowRunId);
 				const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
 				const statusPath = path.join(asyncDir, "status.json");
@@ -4163,6 +4164,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				deps.state.workflowControllers.set(workflowRunId, controller);
 				let status: AsyncStatus = {
 					runId: workflowRunId,
+					toolCallId,
 					sessionId: currentSessionId ?? undefined,
 					mode: "workflow",
 					state: "running",
@@ -4257,21 +4259,21 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: workflow.trace, emits: workflow.emits, console: workflow.console }, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: "complete" });
-						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary, output: summary, results: workflow.children.map((child) => ({ agent: child.key, output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: parentCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
+						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary, output: summary, results: workflow.children.map((child) => ({ agent: child.key, output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: parentCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
 					} catch (error) {
 						const partial = error instanceof WorkflowScriptError ? error.partial : { trace: [], emits: [], console: [], children: [] };
 						const stopped = controller.signal.aborted;
 						status = compactOptional<AsyncStatus>({ ...status, state: stopped ? "stopped" : "failed", stopped: stopped || undefined, error: error instanceof Error ? error.message : String(error), endedAt: Date.now(), workflow: { trace: partial.trace, emits: partial.emits, console: partial.console } });
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, error: status.error });
-						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: status.error, error: status.error, stopped: status.stopped, results: partial.children.map((child) => ({ agent: child.key, output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: parentCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
+						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: status.error, error: status.error, stopped: status.stopped, results: partial.children.map((child) => ({ agent: child.key, output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: parentCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
 					} finally {
 						deps.state.workflowControllers?.delete(workflowRunId);
 					}
 				});
 				return attachWorkflowMission({
 					content: [{ type: "text", text: formatAsyncStartedMessage(`Async workflow [${workflowRunId}]`, ctx.hasUI === true) }],
-					details: { mode: "workflow", runId: workflowRunId, asyncId: workflowRunId, asyncDir, results: [], chatProgress },
+					details: { mode: "workflow", runId: workflowRunId, toolCallId, asyncId: workflowRunId, asyncDir, results: [], chatProgress },
 				});
 			}
 			const { workflowScript: _workflowScript, action: _action, agent: _agent, task: _task, resume: _resume, tasks: _tasks, chain: _chain, concurrency: _concurrency, async: _async, foregroundOnly: _foregroundOnly, clarify: _clarify, timeoutMs: _timeoutMs, maxRuntimeMs: _maxRuntimeMs, usageBudget: _usageBudget, chatProgress: _chatProgress, missionId: _missionId, mission: _mission, ...workflowChildDefaults } = requestParams;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -950,6 +950,8 @@ export interface SpawnBudgetSnapshot {
 export interface Details {
 	mode: SubagentResultMode | "management";
 	runId?: string;
+	/** Host tool-call id retained when it differs from the internal run id. */
+	toolCallId?: string;
 	/** Run-level context summary. "mixed" when children resolved to different modes. */
 	context?: "fresh" | "fork" | "mixed";
 	results: SingleResult[];
@@ -1246,6 +1248,8 @@ export interface ExternalProcessStatus {
 export interface AsyncStatus {
 	lifecycleArtifactVersion?: SubagentLifecycleArtifactVersion;
 	runId: string;
+	/** Host tool-call id retained when it differs from the internal run id. */
+	toolCallId?: string;
 	sessionId?: string;
 	mode: SubagentRunMode;
 	context?: "fresh" | "fork" | "mixed";

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -399,13 +399,14 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(forwarded?.workflowScript, "return runs.run('main', { agent: 'echo' })");
 	});
 
-	it("starts workflow scripts asynchronously by default and persists live status", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+	it("starts workflow scripts asynchronously with a portable internal run id", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "async workflow child" });
-		const executor = makeExecutor([makeAgent("echo")], { missions: { globalIndex: false } });
-		const runId = `scripted-workflow-async-${Date.now()}`;
+		const asyncJobs: SubagentState["asyncJobs"] = new Map();
+		const executor = makeExecutor([makeAgent("echo")], { missions: { globalIndex: false } }, false, undefined, true, asyncJobs);
+		const toolCallId = "call_demo|fc_demo";
 
 		const result = await executor.execute(
-			runId,
+			toolCallId,
 			{
 				workflowScript: `emit("starting"); await runs.run("work", { agent: "echo", task: "Async work" }); return { answer: 42 };`,
 				mission: { summary: "Review the active backlog", labels: ["github-backlog", "review"] },
@@ -417,26 +418,44 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.isError, undefined);
 		assert.equal(result.details.mode, "workflow");
-		assert.equal(result.details.asyncId, runId);
+		assert.equal(result.details.toolCallId, toolCallId);
+		assert.ok(result.details.asyncId);
+		const workflowRunId = result.details.asyncId;
+		assert.equal(result.details.runId, workflowRunId);
+		assert.notEqual(workflowRunId, toolCallId);
+		assert.match(workflowRunId, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+		assert.equal(path.basename(result.details.asyncDir!), workflowRunId);
+		assert.equal(asyncJobs.has(workflowRunId), true);
+		assert.equal(asyncJobs.has(toolCallId), false);
+		assert.equal(fs.existsSync(path.join(DIRS.async, toolCallId)), false);
 		assert.match(result.content[0]?.text ?? "", /Async workflow/);
 		const statusPath = path.join(result.details.asyncDir!, "status.json");
-		let status: { state?: string; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; state?: string }> } } = {};
+		let status: { runId?: string; toolCallId?: string; state?: string; steps?: Array<{ parentWorkflowRunId?: string }>; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; state?: string }> } } = {};
 		for (let attempt = 0; attempt < 100; attempt++) {
 			status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
 			if (status.state === "complete" || status.state === "failed") break;
 			await new Promise((resolve) => setTimeout(resolve, 20));
 		}
 		assert.equal(status.state, "complete");
+		assert.equal(status.runId, workflowRunId);
+		assert.equal(status.toolCallId, toolCallId);
+		assert.equal(status.steps?.length, 1);
+		assert.ok(status.steps?.every((step) => step.parentWorkflowRunId === workflowRunId));
 		assert.deepEqual(status.workflow?.value, { answer: 42 });
 		assert.deepEqual(status.workflow?.emits, ["starting"]);
 		assert.equal(mockPi.callCount(), 1);
 		assert.ok(status.workflow?.trace?.some((entry) => entry.key === "work" && entry.state === "completed"));
-		const persistedResult = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${runId}.json`), "utf-8")) as { agent?: string; summary?: string; workflow?: { value?: unknown } };
+		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
+		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; summary?: string; workflow?: { value?: unknown } };
+		assert.equal(persistedResult.id, workflowRunId);
+		assert.equal(persistedResult.runId, workflowRunId);
+		assert.equal(persistedResult.toolCallId, toolCallId);
 		assert.equal(persistedResult.agent, "workflow");
 		assert.match(persistedResult.summary ?? "", /Return: \{\n  "answer": 42\n\}/);
 		assert.deepEqual(persistedResult.workflow?.value, { answer: 42 });
+		assert.equal(fs.existsSync(path.join(DIRS.results, `${toolCallId}.json`)), false);
 		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true });
-		fs.rmSync(path.join(DIRS.results, `${runId}.json`), { force: true });
+		fs.rmSync(resultPath, { force: true });
 	});
 
 	it("rejects an invalid async workflow usage budget before creating run state", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
@@ -475,8 +494,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		);
 
 		assert.equal(started.isError, undefined);
-		assert.equal(started.details.asyncId, runId);
-		const resultPath = path.join(DIRS.results, `${runId}.json`);
+		assert.ok(started.details.asyncId);
+		assert.notEqual(started.details.asyncId, runId);
+		const resultPath = path.join(DIRS.results, `${started.details.asyncId}.json`);
 		let persisted: { state?: string; summary?: string; results?: Array<{ success?: boolean; output?: string }> } = {};
 		for (let attempt = 0; attempt < 100; attempt++) {
 			if (fs.existsSync(resultPath)) persisted = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
@@ -502,14 +522,16 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		execFileSync("git", ["commit", "-m", "base"], { cwd: tempDir, stdio: "ignore" });
 		mockPi.onCall({ output: "async child done" });
 		const executor = makeExecutor([makeAgent("echo")]);
-		const workflowRunId = `scripted-workflow-parent-${Date.now()}`;
+		const toolCallId = `scripted-workflow-parent-${Date.now()}`;
 		const started = await executor.execute(
-			workflowRunId,
+			toolCallId,
 			{ workflowScript: `const child = await runs.run("background", { agent: "echo", task: "Async child", async: true, worktree: true }); return child.runId;` },
 			new AbortController().signal,
 			undefined,
 			makeMinimalCtx(tempDir),
 		);
+		assert.ok(started.details.asyncId);
+		const workflowRunId = started.details.asyncId;
 		const workflowResultPath = path.join(DIRS.results, `${workflowRunId}.json`);
 		let childRunId: string | undefined;
 		for (let attempt = 0; attempt < 150; attempt++) {


### PR DESCRIPTION
## Summary
- use a generated portable workflow run id for async `workflowScript` storage and lookup
- keep the original host tool-call id as correlation metadata
- add a focused regression for composite provider ids such as `call_demo|fc_demo`

Fixes #889.

## Validation
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'portable internal run id|rejects async child launches from budgeted async workflows|persists workflow parent metadata' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- fresh exact-head review: `/tmp/pi-subagents-queue-20260807/reports/issue889-rebased-review.md`

Credits @DrunkenDonkey80 for the report in #889.
