### PR TITLE
fix: preserve detached workflow worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Clarified native supervisor messaging and optional external intercom result delivery in the docs and packaged skill.
 
 ### Fixed
+- Preserve `workflowScript` worktree children that detach for supervisor coordination instead of cleaning a live managed worktree. Thanks to @astarktc for #896.
 - Accept schema-valid structured output after a child recovers from an earlier tool error. Thanks to @white-hat for the report in #888.
 
 ## [0.43.0] - 2026-08-07

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3323,10 +3323,11 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 	);
 	if (errorResult) return errorResult;
 
-	let worktreeFinalized = false;
+	let worktreeCleanupHandled = false;
+	let pendingHandoff: Details["parallelHandoff"];
 	try {
 		if (worktreeSetup) {
-			writePendingParallelHandoff({
+			pendingHandoff = writePendingParallelHandoff({
 				manifestPath: parallelHandoffPath(artifactsDir, runId),
 				runId,
 				mode: "parallel",
@@ -3429,10 +3430,13 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			updateForegroundNestedProjection(foregroundControl);
 			attachRootChildrenToSteps(runId, results, foregroundControl.nestedChildren);
 		}
+		const detached = results.find((result) => result.detached);
 		let handoff: ReturnType<typeof finalizeParallelWorktreeHandoff> | undefined;
 		if (worktreeSetup) {
-			worktreeFinalized = true;
-			handoff = finalizeParallelWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: effectiveCwd, tasks, results });
+			worktreeCleanupHandled = true;
+			handoff = detached
+				? { suffix: pendingHandoff ? formatParallelHandoffReference(pendingHandoff) : "", reference: pendingHandoff }
+				: finalizeParallelWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: effectiveCwd, tasks, results });
 		}
 		const interrupted = results.find((result) => result.interrupted);
 		const totalCost = sumResultsCost(results);
@@ -3455,11 +3459,10 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				details,
 			};
 		}
-		const detachedIndex = results.findIndex((result) => result.detached);
-		const detached = detachedIndex >= 0 ? results[detachedIndex] : undefined;
 		if (detached) {
+			const handoffSuffix = handoff?.suffix ? `\n\n${handoff.suffix}` : "";
 			return {
-				content: [{ type: "text", text: `Parallel run detached for intercom coordination (${detached.agent}). Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.` }],
+				content: [{ type: "text", text: `Parallel run detached for intercom coordination (${detached.agent}). Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.${handoffSuffix}` }],
 				details,
 			};
 		}
@@ -3508,7 +3511,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			details,
 		};
 	} finally {
-		if (worktreeSetup && !worktreeFinalized) cleanupWorktrees(worktreeSetup);
+		if (worktreeSetup && !worktreeCleanupHandled) cleanupWorktrees(worktreeSetup);
 	}
 }
 
@@ -3895,6 +3898,8 @@ function workflowChildResult(key: string, result: AgentToolResult<Details>): Wor
 	const output = result.details.results.length === 1 && result.details.results[0]?.finalOutput !== undefined
 		? result.details.results[0].finalOutput
 		: receiptOutput;
+	const detached = result.details.results.some((child) => child.detached);
+	const ok = result.isError !== true && !detached;
 	const artifactPaths = new Set<string>();
 	if (result.details.asyncDir) artifactPaths.add(result.details.asyncDir);
 	if (result.details.parallelHandoff?.path) artifactPaths.add(result.details.parallelHandoff.path);
@@ -3906,10 +3911,10 @@ function workflowChildResult(key: string, result: AgentToolResult<Details>): Wor
 	const structured = result.details.results.map((child) => child.structuredOutput).filter((value) => value !== undefined);
 	return {
 		key,
-		ok: result.isError !== true,
+		ok,
 		...(result.details.runId || result.details.asyncId ? { runId: result.details.runId ?? result.details.asyncId } : {}),
 		output,
-		...(result.isError === true ? { error: receiptOutput || output || "Child run failed." } : {}),
+		...(!ok ? { error: receiptOutput || output || "Child run failed." } : {}),
 		...(structured.length === 1 ? { structuredOutput: structured[0] } : structured.length > 1 ? { structuredOutput: structured } : {}),
 		artifactPaths: [...artifactPaths],
 		results: result.details.results,

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -324,9 +324,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		initialAsyncJobs: SubagentState["asyncJobs"] = new Map(),
 		workflowControllers?: Map<string, AbortController>,
 		handleScheduledRunAction?: Parameters<typeof createSubagentExecutor>[0]["handleScheduledRunAction"],
+		piEvents = createEventBus(),
 	) {
 		return createSubagentExecutor!({
-			pi: { events: createEventBus(), getSessionName: () => undefined },
+			pi: { events: piEvents, getSessionName: () => undefined },
 			state: {
 				baseCwd: tempDir,
 				currentSessionId: initialSpawnState?.sessionId ?? null,
@@ -895,6 +896,87 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(worktreePaths.size, 2);
 		for (const worktreePath of worktreePaths) assert.equal(fs.existsSync(worktreePath), false);
 		assert.match(result.content[0]?.text ?? "", /handoffs/);
+	});
+
+	it("preserves a workflow worktree when its child detaches for supervisor coordination", { skip: !createSubagentExecutor || process.platform === "win32" ? "executor unavailable or worktree paths differ on Windows" : undefined }, async () => {
+		execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });
+		execFileSync("git", ["config", "user.name", "Test User"], { cwd: tempDir });
+		fs.writeFileSync(path.join(tempDir, "base.txt"), "base\n", "utf-8");
+		execFileSync("git", ["add", "base.txt"], { cwd: tempDir });
+		execFileSync("git", ["commit", "-m", "base"], { cwd: tempDir, stdio: "ignore" });
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need a decision" })] },
+				{ delay: 500, jsonl: [events.assistantMessage("done after coordination")] },
+			],
+		});
+		const piEvents = createEventBus();
+		const executor = makeExecutor(
+			[makeAgent("worker", { systemPrompt: "Intercom orchestration channel:" })],
+			{},
+			false,
+			undefined,
+			true,
+			new Map(),
+			undefined,
+			undefined,
+			piEvents,
+		);
+		let detachAccepted = false;
+		piEvents.on(INTERCOM_DETACH_RESPONSE_EVENT, (payload) => {
+			if ((payload as { requestId?: unknown }).requestId === "workflow-worktree-detach") {
+				detachAccepted ||= (payload as { accepted?: unknown }).accepted === true;
+			}
+		});
+		const detachTimer = setInterval(() => {
+			if (!detachAccepted) piEvents.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "workflow-worktree-detach" });
+		}, 10);
+		detachTimer.unref();
+
+		const result = await executor.execute(
+			"scripted-workflow-detached-worktree",
+			{
+				async: false,
+				workflowScript: `
+					const children = await runs.all([
+						{ key: "detaches", agent: "worker", task: "Ask then continue", worktree: true }
+					]);
+					return children.map(({ key, ok, artifactPaths }) => ({ key, ok, artifactPaths }));
+				`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		clearInterval(detachTimer);
+
+		assert.equal(detachAccepted, true);
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		assert.match(result.content[0]?.text ?? "", /run detaches: failed/);
+		const workflowValue = result.details.workflow?.value as Array<{ ok: boolean; artifactPaths: string[] }>;
+		assert.equal(workflowValue[0]?.ok, false);
+		const handoffPath = workflowValue[0]?.artifactPaths.find((candidate) => candidate.endsWith(".json"));
+		assert.ok(handoffPath, result.content[0]?.text ?? "missing pending handoff");
+		const handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as {
+			groups: Array<{
+				cleanup: { state: string; tasks: Array<{ path: string; branch: string; preserved: boolean; worktreeRemoved: boolean; branchRemoved: boolean }> };
+			}>;
+		};
+		const cleanup = handoff.groups[0]?.cleanup;
+		assert.equal(cleanup?.state, "partial");
+		assert.equal(cleanup?.tasks[0]?.preserved, true);
+		assert.equal(cleanup?.tasks[0]?.worktreeRemoved, false);
+		assert.equal(cleanup?.tasks[0]?.branchRemoved, false);
+		const worktreePath = cleanup?.tasks[0]?.path;
+		const branch = cleanup?.tasks[0]?.branch;
+		assert.ok(worktreePath);
+		assert.ok(branch);
+		assert.equal(fs.existsSync(worktreePath), true, "live detached worktree must remain present");
+
+		await new Promise((resolve) => setTimeout(resolve, 750));
+		execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: tempDir });
+		execFileSync("git", ["branch", "-D", branch], { cwd: tempDir, stdio: "ignore" });
 	});
 
 	it("inherits workflow-level worktree isolation and allows a child opt-out", { skip: !createSubagentExecutor || process.platform === "win32" ? "executor unavailable or worktree paths differ on Windows" : undefined }, async () => {


### PR DESCRIPTION
## Summary

Preserves managed workflow worktrees when a `runs.all` child detaches for supervisor coordination. The parallel foreground path now returns the pending handoff reference instead of finalizing and cleaning the worktree before the child reaches an authoritative terminal result.

The workflow child result also treats detached receipts as not successful, so the workflow trace no longer reports this state as a normal completed child.

Fixes #896.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern "gives parallel workflow children separate managed worktrees|preserves a workflow worktree when its child detaches" test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

## Review

Fresh read-only review passed with no blocking findings on `667b887ba7e92867e4a93c196d81517756316697`.

## Credit

Thanks to @astarktc for reporting #896.
