### PR TITLE
docs: clarify non-blocking subagent waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Clarified native supervisor messaging and optional external intercom result delivery in the docs and packaged skill.
+- Point interactive async-launch guidance to `subagent_wait({ id, nonBlocking: true })` when an explicit wake is needed without blocking the current turn.
 
 ### Fixed
 - Preserve `workflowScript` worktree children that detach for supervisor coordination instead of cleaning a live managed worktree. Thanks to @astarktc for #896.

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -269,7 +269,8 @@ export function formatAsyncStartedMessage(headline: string, interactive: boolean
 		? [
 			"The async run is detached and running in the background.",
 			"You are in an interactive session. By default, return control to the user now; Pi will wake you on completion when the run finishes or needs attention. Do NOT call subagent_wait() merely to wait, and do not run sleep/polling loops to wait for it.",
-			"Override that default and call subagent_wait() before ending the turn only when the current request is run-to-completion — for example, the user asked you to report results back here before continuing, or a skill must finish in one turn. In that case, call subagent_wait() to block until the run completes so its results are delivered in this turn instead of deferred.",
+			"When you need an explicit wake for one known run but do not need same-turn results, call subagent_wait({ id: \"...\", nonBlocking: true }) to arm a subscription and return immediately.",
+			"Override the default and call blocking subagent_wait() before ending the turn only when the current request is run-to-completion — for example, the user asked you to report results back here before continuing, or a skill must finish in one turn. In that case, call subagent_wait() to block until the run completes so its results are delivered in this turn instead of deferred.",
 			"Otherwise, continue any independent work or return control to the user. Use subagent({ action: \"status\", id: \"...\" }) for a one-shot status/result or to inspect a blocked/stale run, never as a wait loop.",
 		]
 		: [

--- a/test/unit/async-execution.test.ts
+++ b/test/unit/async-execution.test.ts
@@ -29,11 +29,13 @@ describe("async runner execution", () => {
 		const interactive = formatAsyncStartedMessage("Async: worker [interactive]", true);
 		assert.match(interactive, /interactive session[\s\S]*return control/i);
 		assert.match(interactive, /do not call subagent_wait\(\) merely to wait/i);
+		assert.match(interactive, /nonBlocking: true/);
 		assert.doesNotMatch(interactive, /auto-drains current-session background work/i);
 
 		const headless = formatAsyncStartedMessage("Async: worker [headless]", false);
 		assert.match(headless, /non-interactive run.*auto-drains current-session background work at agent_end/i);
 		assert.match(headless, /call subagent_wait\(\).*results before it ends/i);
+		assert.doesNotMatch(headless, /nonBlocking: true/);
 		assert.doesNotMatch(headless, /By default, return control to the user/i);
 	});
 


### PR DESCRIPTION
Clarifies the async launch guidance for interactive sessions. It now points callers that need a wake for one known run, but do not need same-turn results, to the existing `subagent_wait({ id, nonBlocking: true })` subscription path.

Blocking `subagent_wait()` guidance remains limited to run-to-completion requests.

This is follow-up context for closed #798; it does not reopen or close that issue.

Tests: `node --experimental-strip-types --test test/unit/async-execution.test.ts`; `npm run typecheck`.