### PR TITLE
fix: cap portable Codex tool IDs

### DIFF
--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
@@ -205,6 +206,7 @@ function isSubagentToolCallBlock(block: unknown): boolean {
 	return b?.type === "toolCall" && b.name === "subagent";
 }
 
+const MAX_PORTABLE_TOOL_ID_LENGTH = 64;
 const PORTABLE_TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const COMPOSITE_TOOL_ID_APIS = new Set([
 	"azure-openai-responses",
@@ -214,8 +216,10 @@ const COMPOSITE_TOOL_ID_APIS = new Set([
 ]);
 
 function portableToolId(id: string): string {
-	if (PORTABLE_TOOL_ID_PATTERN.test(id)) return id;
-	return `tool_${Buffer.from(id).toString("base64url") || "empty"}`;
+	if (id.length <= MAX_PORTABLE_TOOL_ID_LENGTH && PORTABLE_TOOL_ID_PATTERN.test(id)) return id;
+	const encoded = `tool_${Buffer.from(id).toString("base64url") || "empty"}`;
+	if (encoded.length <= MAX_PORTABLE_TOOL_ID_LENGTH) return encoded;
+	return `tool_${createHash("sha256").update(id).digest("base64url")}`;
 }
 
 function sanitizeToolHistoryMessage(message: unknown): unknown {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -725,6 +725,26 @@ describe("subagent prompt runtime", () => {
 		]);
 	});
 
+	it("hashes oversized composite tool ids within Codex's limit", () => {
+		const compositeToolId = "call_N7iYNRPXLl9czpXh3bDyMpIL|fc_0e76718634eca88f016a76fdc89aec81919763fa7858f67a0d";
+		const assistant = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: compositeToolId, name: "bash", input: { command: "true" } }],
+		};
+		const result = { role: "toolResult", toolName: "bash", toolCallId: compositeToolId, content: "ok" };
+
+		const sanitized = stripParentOnlySubagentMessages([assistant, result]) as Array<{
+			content?: Array<{ id?: string }>;
+			toolCallId?: string;
+		}>;
+		const toolCallId = sanitized[0]?.content?.[0]?.id;
+
+		assert.ok(toolCallId);
+		assert.match(toolCallId, /^[A-Za-z0-9_-]+$/);
+		assert.ok(toolCallId.length <= 64);
+		assert.equal(sanitized[1]?.toolCallId, toolCallId);
+	});
+
 	it("preserves live nested subagent calls and results in fanout child context", () => {
 		const user = { role: "user", content: "Task" };
 		const subagentResult = { role: "toolResult", toolName: "subagent", content: "OK" };


### PR DESCRIPTION
Fixes Codex requests rejected when a composite tool id is base64url-encoded past the provider 64-character limit.

- preserve existing portable IDs at or below 64 characters
- preserve existing base64url mapping when it fits
- deterministically hash oversized IDs while retaining call/result linkage
- add regression coverage for the observed composite id