### PR TITLE
fix: cap oversized composite tool IDs in child context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Serialize and merge each mission workflow-state write with the latest file so separate workflows do not drop unrelated keys.
 - Preserve `workflowScript` worktree children that detach for supervisor coordination instead of cleaning a live managed worktree. Thanks to @astarktc for #896.
 - Accept schema-valid structured output after a child recovers from an earlier tool error. Thanks to @white-hat for the report in #888.
+- Cap oversized inherited composite tool-call ids at the provider's 64-character limit while preserving correlation between calls and results.
 
 ## [0.43.0] - 2026-08-07
 

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
@@ -205,6 +206,7 @@ function isSubagentToolCallBlock(block: unknown): boolean {
 	return b?.type === "toolCall" && b.name === "subagent";
 }
 
+const MAX_PORTABLE_TOOL_ID_LENGTH = 64;
 const PORTABLE_TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const COMPOSITE_TOOL_ID_APIS = new Set([
 	"azure-openai-responses",
@@ -214,8 +216,10 @@ const COMPOSITE_TOOL_ID_APIS = new Set([
 ]);
 
 function portableToolId(id: string): string {
-	if (PORTABLE_TOOL_ID_PATTERN.test(id)) return id;
-	return `tool_${Buffer.from(id).toString("base64url") || "empty"}`;
+	if (id.length <= MAX_PORTABLE_TOOL_ID_LENGTH && PORTABLE_TOOL_ID_PATTERN.test(id)) return id;
+	const encoded = `tool_${Buffer.from(id).toString("base64url") || "empty"}`;
+	if (encoded.length <= MAX_PORTABLE_TOOL_ID_LENGTH) return encoded;
+	return `tool_${createHash("sha256").update(id).digest("base64url")}`;
 }
 
 function sanitizeToolHistoryMessage(message: unknown): unknown {

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -215,17 +215,21 @@ const COMPOSITE_TOOL_ID_APIS = new Set([
 	"openai-responses",
 ]);
 
-function portableToolId(id: string): string {
-	if (id.length <= MAX_PORTABLE_TOOL_ID_LENGTH && PORTABLE_TOOL_ID_PATTERN.test(id)) return id;
+function portableToolId(id: string, preserveCompositeToolIds = false): string {
+	if (
+		id.length <= MAX_PORTABLE_TOOL_ID_LENGTH &&
+		(PORTABLE_TOOL_ID_PATTERN.test(id) || (preserveCompositeToolIds && id.includes("|")))
+	)
+		return id;
 	const encoded = `tool_${Buffer.from(id).toString("base64url") || "empty"}`;
 	if (encoded.length <= MAX_PORTABLE_TOOL_ID_LENGTH) return encoded;
 	return `tool_${createHash("sha256").update(id).digest("base64url")}`;
 }
 
-function sanitizeToolHistoryMessage(message: unknown): unknown {
+function sanitizeToolHistoryMessage(message: unknown, preserveCompositeToolIds = false): unknown {
 	const m = message as { role?: string; content?: unknown; toolCallId?: unknown };
 	if (m?.role === "toolResult" && typeof m.toolCallId === "string") {
-		const toolCallId = portableToolId(m.toolCallId);
+		const toolCallId = portableToolId(m.toolCallId, preserveCompositeToolIds);
 		return toolCallId === m.toolCallId ? message : { ...m, toolCallId };
 	}
 	if (m?.role !== "assistant" || !Array.isArray(m.content)) return message;
@@ -233,7 +237,7 @@ function sanitizeToolHistoryMessage(message: unknown): unknown {
 	const content = m.content.map((block) => {
 		const b = block as { type?: string; id?: unknown };
 		if (b?.type !== "toolCall" || typeof b.id !== "string") return block;
-		const id = portableToolId(b.id);
+		const id = portableToolId(b.id, preserveCompositeToolIds);
 		if (id === b.id) return block;
 		changed = true;
 		return { ...b, id };
@@ -250,7 +254,10 @@ function stripAssistantSubagentToolCallBlocks(message: unknown): unknown | undef
 	return { ...m, content: filteredContent };
 }
 
-export function stripParentOnlySubagentMessages(messages: unknown[], options: { sanitizeToolIds?: boolean } = {}): unknown[] {
+export function stripParentOnlySubagentMessages(
+	messages: unknown[],
+	options: { sanitizeToolIds?: boolean; preserveCompositeToolIds?: boolean } = {},
+): unknown[] {
 	const preserveCurrentFanoutToolHistory = process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1";
 	const sanitizeToolIds = options.sanitizeToolIds ?? true;
 	let changed = false;
@@ -265,7 +272,9 @@ export function stripParentOnlySubagentMessages(messages: unknown[], options: { 
 			changed = true;
 			continue;
 		}
-		const sanitized = sanitizeToolIds ? sanitizeToolHistoryMessage(stripped) : stripped;
+		const sanitized = sanitizeToolIds
+			? sanitizeToolHistoryMessage(stripped, options.preserveCompositeToolIds)
+			: stripped;
 		if (stripped !== message || sanitized !== stripped) changed = true;
 		filtered.push(sanitized);
 	}
@@ -558,7 +567,7 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 	onRuntimeEvent("context", (event: unknown, ctx?: ExtensionContext) => {
 		if (!event || typeof event !== "object" || !("messages" in event) || !Array.isArray(event.messages)) return undefined;
 		const messages = stripParentOnlySubagentMessages(event.messages, {
-			sanitizeToolIds: !COMPOSITE_TOOL_ID_APIS.has(ctx?.model?.api ?? ""),
+			preserveCompositeToolIds: COMPOSITE_TOOL_ID_APIS.has(ctx?.model?.api ?? ""),
 		});
 		if (messages === event.messages) return undefined;
 		return { messages };

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -725,6 +725,26 @@ describe("subagent prompt runtime", () => {
 		]);
 	});
 
+	it("hashes oversized composite tool ids within Codex's limit", () => {
+		const compositeToolId = "call_N7iYNRPXLl9czpXh3bDyMpIL|fc_0e76718634eca88f016a76fdc89aec81919763fa7858f67a0d";
+		const assistant = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: compositeToolId, name: "bash", input: { command: "true" } }],
+		};
+		const result = { role: "toolResult", toolName: "bash", toolCallId: compositeToolId, content: "ok" };
+
+		const sanitized = stripParentOnlySubagentMessages([assistant, result]) as Array<{
+			content?: Array<{ id?: string }>;
+			toolCallId?: string;
+		}>;
+		const toolCallId = sanitized[0]?.content?.[0]?.id;
+
+		assert.ok(toolCallId);
+		assert.match(toolCallId, /^[A-Za-z0-9_-]+$/);
+		assert.ok(toolCallId.length <= 64);
+		assert.equal(sanitized[1]?.toolCallId, toolCallId);
+	});
+
 	it("preserves live nested subagent calls and results in fanout child context", () => {
 		const user = { role: "user", content: "Task" };
 		const subagentResult = { role: "toolResult", toolName: "subagent", content: "OK" };

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -1040,7 +1040,7 @@ describe("subagent prompt runtime", () => {
 		});
 	});
 
-	it("preserves composite tool ids for APIs that normalize them", () => {
+	it("caps oversized composite tool ids for APIs that normally preserve them", () => {
 		let contextHandler: ((event: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) | undefined;
 		registerSubagentPromptRuntime({
 			on(event: string, handler: (payload: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) {
@@ -1051,6 +1051,31 @@ describe("subagent prompt runtime", () => {
 		const toolCallId = "call_7XJjvAJfk07117JO8LgBCZjY|fc_0e92b09b28010bac016a756e9e79cc8197b01825a5dc3d9eaa";
 		const messages = [
 			{ role: "user", content: "Task" },
+			{ role: "assistant", content: [{ type: "toolCall", id: toolCallId, name: "read", input: { path: "README.md" } }] },
+			{ role: "toolResult", toolName: "read", toolCallId, content: "file" },
+		];
+
+		const rewritten = contextHandler?.({ messages }, { model: { api: "openai-codex-responses" } });
+		assert.ok(rewritten);
+		const rewrittenAssistant = rewritten.messages[1] as { content: Array<{ id: string }> };
+		const rewrittenResult = rewritten.messages[2] as { toolCallId: string };
+		const rewrittenId = rewrittenAssistant.content[0]?.id;
+		assert.ok(rewrittenId);
+		assert.match(rewrittenId, /^[A-Za-z0-9_-]+$/);
+		assert.ok(rewrittenId.length <= 64);
+		assert.equal(rewrittenResult.toolCallId, rewrittenId);
+	});
+
+	it("preserves short composite tool ids for APIs that normalize them", () => {
+		let contextHandler: ((event: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) | undefined;
+		registerSubagentPromptRuntime({
+			on(event: string, handler: (payload: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) {
+				if (event === "context") contextHandler = handler;
+			},
+		} as { on(event: string, handler: (payload: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined): void });
+
+		const toolCallId = "call_short|fc_short";
+		const messages = [
 			{ role: "assistant", content: [{ type: "toolCall", id: toolCallId, name: "read", input: { path: "README.md" } }] },
 			{ role: "toolResult", toolName: "read", toolCallId, content: "file" },
 		];


### PR DESCRIPTION
## Summary

- cap inherited tool-call IDs at OpenAI's 64-character limit
- preserve short composite IDs for APIs that normalize them
- deterministically hash oversized IDs while keeping assistant calls and tool results correlated

## Root cause

`pi-subagents` skipped tool-ID sanitization for `openai-codex-responses`. Generated composite IDs such as `call_*|fc_*` can be 116 characters. On a resumed/detached child turn, OpenAI rejects the raw ID before the model runs:

```
Invalid 'input[2].call_id': string too long. Expected a string with maximum length 64, but got a string with length 116 instead.
```

## Verification

- `HOME=$(mktemp -d) npm run typecheck` — pass
- `HOME=$(mktemp -d) npm run test:all` — pass
- replayed a copy of a real failed parallel-tool session — `SESSION_REPLAY_OK`
- replayed a copy of a real failed supervisor/reviewer session — `SUPERVISOR_REPLAY_OK`

Original session files were not modified.
