### PR TITLE
fix: bound portable child tool ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Ignore stale extension-context errors from advisory foreground control notifications after reload. Thanks to @alexei-led for #905.
+- Bound inherited portable tool IDs to 64 characters for Codex-compatible child contexts while keeping tool calls and results paired. Thanks to @alexei-led for #903.
 - Preserve `workflow` mode when asynchronous workflow mission runs complete.
 - Serialize and merge each mission workflow-state write with the latest file so separate workflows do not drop unrelated keys.
 - Preserve `workflowScript` worktree children that detach for supervisor coordination instead of cleaning a live managed worktree. Thanks to @astarktc for #896.

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
@@ -206,16 +207,18 @@ function isSubagentToolCallBlock(block: unknown): boolean {
 }
 
 const PORTABLE_TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_PORTABLE_TOOL_ID_LENGTH = 64;
 const COMPOSITE_TOOL_ID_APIS = new Set([
 	"azure-openai-responses",
-	"openai-codex-responses",
 	"openai-completions",
 	"openai-responses",
 ]);
 
 function portableToolId(id: string): string {
-	if (PORTABLE_TOOL_ID_PATTERN.test(id)) return id;
-	return `tool_${Buffer.from(id).toString("base64url") || "empty"}`;
+	if (PORTABLE_TOOL_ID_PATTERN.test(id) && id.length <= MAX_PORTABLE_TOOL_ID_LENGTH) return id;
+	const encoded = `tool_${Buffer.from(id).toString("base64url") || "empty"}`;
+	if (encoded.length <= MAX_PORTABLE_TOOL_ID_LENGTH) return encoded;
+	return `tool_${createHash("sha256").update(id).digest("base64url")}`;
 }
 
 function sanitizeToolHistoryMessage(message: unknown): unknown {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -1020,7 +1020,32 @@ describe("subagent prompt runtime", () => {
 		});
 	});
 
-	it("preserves composite tool ids for APIs that normalize them", () => {
+	it("bounds composite tool ids for Codex child context", () => {
+		let contextHandler: ((event: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) | undefined;
+		registerSubagentPromptRuntime({
+			on(event: string, handler: (payload: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) {
+				if (event === "context") contextHandler = handler;
+			},
+		} as { on(event: string, handler: (payload: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined): void });
+
+		const toolCallId = "call_N7iYNRPXLl9czpXh3bDyMpIL|fc_0e76718634eca88f016a76fdc89aec81919763fa7858f67a0d";
+		const messages = [
+			{ role: "user", content: "Task" },
+			{ role: "assistant", content: [{ type: "toolCall", id: toolCallId, name: "read", input: { path: "README.md" } }] },
+			{ role: "toolResult", toolName: "read", toolCallId, content: "file" },
+		];
+
+		const context = contextHandler?.({ messages }, { model: { api: "openai-codex-responses" } });
+		assert.ok(context);
+		const mappedCallId = (context.messages[1] as { content: Array<{ id?: unknown }> }).content[0]?.id;
+		const mappedResultId = (context.messages[2] as { toolCallId?: unknown }).toolCallId;
+		assert.equal(typeof mappedCallId, "string");
+		assert.match(mappedCallId, /^[a-zA-Z0-9_-]+$/);
+		assert.ok(mappedCallId.length <= 64);
+		assert.equal(mappedResultId, mappedCallId);
+	});
+
+	it("preserves composite tool ids for non-Codex APIs that normalize them", () => {
 		let contextHandler: ((event: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) | undefined;
 		registerSubagentPromptRuntime({
 			on(event: string, handler: (payload: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) {
@@ -1035,7 +1060,7 @@ describe("subagent prompt runtime", () => {
 			{ role: "toolResult", toolName: "read", toolCallId, content: "file" },
 		];
 
-		assert.equal(contextHandler?.({ messages }, { model: { api: "openai-codex-responses" } }), undefined);
+		assert.equal(contextHandler?.({ messages }, { model: { api: "openai-responses" } }), undefined);
 	});
 
 	it("does not rewrite child context when no parent-only artifacts are present", () => {


### PR DESCRIPTION
Bounds inherited child-context tool IDs so Codex never receives a non-portable or over-64-character ID, while keeping tool call/result IDs paired and preserving the existing non-Codex composite-ID behavior.

Closes #903.

Credit: Thanks to @alexei-led for the report, repro ID, and suggested test shape in #903.

Validation:
- `node --experimental-strip-types --test test/unit/subagent-prompt-runtime.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review: no blockers on exact head `c7d755741e272e209701239c65b91d55f51b17d4`.