### PR TITLE
fix: normalize chain output overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - Ignore stale extension-context errors from advisory foreground control notifications after reload. Thanks to @alexei-led for #905.
 - Bound inherited portable tool IDs to 64 characters for Codex-compatible child contexts while keeping tool calls and results paired. Thanks to @alexei-led for #903.
+- Prevent boolean chain `output` values from crashing clarify rendering. Thanks to @ftoleedo for #901.
 - Preserve `workflow` mode when asynchronous workflow mission runs complete.
 - Serialize and merge each mission workflow-state write with the latest file so separate workflows do not drop unrelated keys.
 - Preserve `workflowScript` worktree children that detach for supervisor coordination instead of cleaning a live managed worktree. Thanks to @astarktc for #896.

--- a/src/runs/foreground/chain-clarify.ts
+++ b/src/runs/foreground/chain-clarify.ts
@@ -532,7 +532,7 @@ export class ChainClarifyComponent implements Component {
 			buffer = template.split("\n")[0] ?? "";
 		} else if (mode === "output") {
 			const behavior = this.getEffectiveBehavior(this.selectedStep);
-			buffer = behavior.output === false ? "" : (behavior.output || "");
+			buffer = typeof behavior.output === "string" ? behavior.output : "";
 		} else if (mode === "reads") {
 			const behavior = this.getEffectiveBehavior(this.selectedStep);
 			buffer = behavior.reads === false ? "" : (behavior.reads?.join(", ") || "");
@@ -1165,7 +1165,9 @@ export class ChainClarifyComponent implements Component {
 
 		const writesValue = behavior.output === false
 			? th.fg("dim", "(disabled)")
-			: (behavior.output || th.fg("dim", "(none)"));
+			: (typeof behavior.output === "string" && behavior.output
+				? behavior.output
+				: th.fg("dim", "(none)"));
 		const writesLabel = th.fg("dim", "writes: ");
 		lines.push(this.row(`     ${writesLabel}${truncateToWidth(writesValue, innerW - 14)}`));
 
@@ -1296,7 +1298,9 @@ export class ChainClarifyComponent implements Component {
 
 			const writesValue = behavior.output === false
 				? th.fg("dim", "(disabled)")
-				: (behavior.output || th.fg("dim", "(none)"));
+				: (typeof behavior.output === "string" && behavior.output
+					? behavior.output
+					: th.fg("dim", "(none)"));
 			const writesLabel = th.fg("dim", "writes: ");
 			lines.push(this.row(`     ${writesLabel}${truncateToWidth(writesValue, innerW - 14)}`));
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -32,8 +32,10 @@ export interface StepOverrides {
 	model?: string;
 }
 
-function normalizeOutputOverride(output: string | false | undefined): string | false | undefined {
-	return output === "false" ? false : output;
+function normalizeOutputOverride(output: unknown): string | false | undefined {
+	if (output === false || output === "false") return false;
+	if (output === true || output === "true") return undefined;
+	return typeof output === "string" && output.length > 0 ? output : undefined;
 }
 
 // =============================================================================

--- a/test/integration/chain-clarify.test.ts
+++ b/test/integration/chain-clarify.test.ts
@@ -304,6 +304,35 @@ describe("chain clarify model display", { skip: !available ? "pi packages not av
 		assert.equal(component.getEffectiveModel(0), "github-copilot/gpt-5:high");
 	});
 
+	it("renders malformed chain output values without throwing", () => {
+		const component = new ChainClarifyComponent(
+			{ requestRender() {} },
+			{ fg(_key: string, text: string) { return text; } },
+			[{
+				name: "worker",
+				description: "",
+				systemPrompt: "",
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+				source: "user",
+				filePath: "worker.md",
+			}],
+			["Task"],
+			"Task",
+			undefined,
+			[{ output: true, outputMode: "inline", reads: false, progress: false, skills: [], model: undefined }],
+			[],
+			undefined,
+			[],
+			() => {},
+			"chain",
+		);
+
+		assert.doesNotThrow(() => component.render(84));
+		assert.match(component.render(84).map(stripAnsi).join("\n"), /writes: \(none\)/);
+	});
+
 	it("labels every shortcut and keeps the clarify overlay within its allocated width", () => {
 		for (const mode of ["single", "parallel", "chain"] as const) {
 			const count = mode === "single" ? 1 : mode === "parallel" ? 2 : 4;

--- a/test/integration/template-resolution.test.ts
+++ b/test/integration/template-resolution.test.ts
@@ -171,6 +171,14 @@ describe("resolveStepBehavior", { skip: !available ? "pi packages not available"
 		assert.equal(behavior.output, false);
 	});
 
+	it("ignores boolean and string true output overrides", () => {
+		const config = { name: "test", output: "report.md" };
+		assert.equal(resolveStepBehavior(config, { output: true } as any).output, "report.md");
+		assert.equal(resolveStepBehavior(config, { output: "true" } as any).output, "report.md");
+		assert.equal(resolveStepBehavior({ name: "test" }, { output: true } as any).output, false);
+		assert.equal(resolveStepBehavior({ name: "test" }, { output: "true" } as any).output, false);
+	});
+
 	it("defaults to false when agent has no config", () => {
 		const config = { name: "test" };
 		const behavior = resolveStepBehavior(config, {});


### PR DESCRIPTION
Fixes #901.

This normalizes chain step and parallel `output` overrides before clarify rendering. `true` and `"true"` now fall through to the existing default behavior, while `false` and `"false"` still disable output.

Validation:
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/template-resolution.test.ts test/integration/chain-clarify.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh exact-head review: no blockers
