### PR TITLE
fix: identify collapsed status targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - Clarified native supervisor messaging and optional external intercom result delivery in the docs and packaged skill.
+- Identify status and transcript targets before the spawn-budget summary in collapsed tool-result cards.
 - Point interactive async-launch guidance to `subagent_wait({ id, nonBlocking: true })` when an explicit wake is needed without blocking the current turn.
 
 ### Fixed

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4617,13 +4617,20 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			}
 			if (action === "status") {
 				if (!preserveActiveSession) deps.state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
-				const withBudget = (result: AgentToolResult<Details>) => withSpawnBudgetStatus(
-					result,
-					deps.state,
-					deps.config,
-					deps.state.currentSessionId,
-				);
 				const targetRunId = paramsWithResolvedCwd.id ?? paramsWithResolvedCwd.runId;
+				const target = targetRunId ? `run ${targetRunId}` : paramsWithResolvedCwd.dir ? `dir ${paramsWithResolvedCwd.dir}` : undefined;
+				const targetLabel = paramsWithResolvedCwd.view === "transcript"
+					? `Transcript target: ${target ?? "active run"}${paramsWithResolvedCwd.index !== undefined ? ` · child ${paramsWithResolvedCwd.index}` : ""}`
+					: `Status target: ${target ?? "active runs"}`;
+				const withBudget = (result: AgentToolResult<Details>) => {
+					const budgeted = withSpawnBudgetStatus(result, deps.state, deps.config, deps.state.currentSessionId);
+					return {
+						...budgeted,
+						content: budgeted.content.map((item, index) => index === 0 && item.type === "text"
+							? { ...item, text: `${targetLabel}\n${item.text}` }
+							: item),
+					};
+				};
 				const nestedScope = nestedResolutionScopeForExecutor(deps);
 				const sessionRoots = trustedSessionRootsForStatus(ctx, deps);
 				if (paramsWithResolvedCwd.view === "fleet") {
@@ -4648,7 +4655,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const message = error instanceof Error ? error.message : String(error);
 						return withBudget({ content: [{ type: "text", text: message }], isError: true, details: { mode: "management", results: [] } });
 					}
-				} else {
+				} else if (!paramsWithResolvedCwd.dir) {
 					const foreground = getForegroundControl(deps.state, undefined);
 					if (foreground && paramsWithResolvedCwd.view !== "transcript") return withBudget(foregroundStatusResult(foreground));
 					if (foreground && paramsWithResolvedCwd.view === "transcript") {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1575,7 +1575,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		const status = await executor.execute("status", { action: "status" }, new AbortController().signal, undefined, makeMinimalCtx(tempDir));
 
-		assert.match(status.content[0]?.text ?? "", /^Spawn budget: 3\/5 used, 2 remaining/);
+		assert.match(status.content[0]?.text ?? "", /^Status target: active runs\nSpawn budget: 3\/5 used, 2 remaining/);
 		assert.deepEqual(status.details?.spawnBudget, {
 			used: 3,
 			configuredLimit: 4,

--- a/test/unit/nested-control.test.ts
+++ b/test/unit/nested-control.test.ts
@@ -196,11 +196,52 @@ describe("nested control routing", () => {
 			const result = await createExecutor(state).execute("status", { action: "status", id: "root-control" }, new AbortController().signal, undefined, ctx(root));
 
 			assert.equal(result.isError, undefined);
+			assert.match(text(result), /^Status target: run root-control\nSpawn budget:/);
 			assert.match(text(result), /Run: root-control/);
 			assert.match(text(result), /↳ worker \[nested-foreground\] running/);
 			assert.match(text(result), /Status: subagent\(\{ action: "status", id: "nested-foreground" \}\)/);
+
+			const transcript = await createExecutor(state).execute("transcript", { action: "status", id: "root-control", index: 0, view: "transcript" }, new AbortController().signal, undefined, ctx(root));
+			assert.equal(transcript.isError, undefined);
+			assert.match(text(transcript), /^Transcript target: run root-control · child 0\nSpawn budget:/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("labels dir-target status output", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-status-dir-label-"));
+		const runId = `status-dir-${Date.now().toString(36)}`;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+		try {
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId,
+				mode: "single",
+				state: "running",
+				startedAt: 1,
+				lastUpdate: 1,
+				cwd: root,
+				steps: [{ agent: "worker", status: "running" }],
+			}), "utf-8");
+
+			const state = createState();
+			state.foregroundControls.set("foreground-live", { runId: "foreground-live", mode: "single", startedAt: 1, updatedAt: 1, currentAgent: "worker", currentIndex: 0 });
+			state.lastForegroundControlId = "foreground-live";
+			const executor = createExecutor(state);
+			const result = await executor.execute("status-dir", { action: "status", dir: asyncDir }, new AbortController().signal, undefined, ctx(root));
+
+			assert.equal(result.isError, undefined);
+			assert.ok(text(result).startsWith(`Status target: dir ${asyncDir}\nSpawn budget:`), text(result));
+			assert.match(text(result), new RegExp(`Run: ${runId}`));
+			assert.doesNotMatch(text(result), /foreground-live/);
+
+			const transcript = await executor.execute("transcript-dir", { action: "status", dir: asyncDir, view: "transcript" }, new AbortController().signal, undefined, ctx(root));
+			assert.ok(text(transcript).startsWith(`Transcript target: dir ${asyncDir}\nSpawn budget:`), text(transcript));
+			assert.doesNotMatch(text(transcript), /Live foreground transcript/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+			fs.rmSync(asyncDir, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
This makes collapsed `subagent status` and transcript result cards easier to distinguish by putting the selected target before the spawn-budget summary.

It also fixes explicit `dir` status/transcript handling so an active foreground run cannot mask the requested async directory target.

Validation:
- `node --experimental-strip-types --test test/unit/nested-control.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh exact-head review: no candidate-diff blocker
