### PR TITLE
refactor: clean up subagent polish seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - Clarified native supervisor messaging and optional external intercom result delivery in the docs and packaged skill.
+- Tightened internal typing for chain output overrides and status target rendering.
 - Identify status and transcript targets before the spawn-budget summary in collapsed tool-result cards.
 - Point interactive async-launch guidance to `subagent_wait({ id, nonBlocking: true })` when an explicit wake is needed without blocking the current turn.
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1880,6 +1880,19 @@ function getRequestedModeLabel(params: SubagentParamsLike): Details["mode"] {
 	return "single";
 }
 
+function formatStatusTargetLabel(params: Pick<SubagentParamsLike, "dir" | "index" | "view">, targetRunId: string | undefined): string {
+	let target: string;
+	if (targetRunId) {
+		target = `run ${targetRunId}`;
+	} else if (params.dir) {
+		target = `dir ${params.dir}`;
+	} else {
+		target = params.view === "transcript" ? "active run" : "active runs";
+	}
+	if (params.view !== "transcript") return `Status target: ${target}`;
+	return `Transcript target: ${target}${params.index !== undefined ? ` · child ${params.index}` : ""}`;
+}
+
 interface AgentDefaultContextPolicy {
 	params: SubagentParamsLike;
 	contextForAgent(agentName: string): ContextMode;
@@ -4618,10 +4631,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			if (action === "status") {
 				if (!preserveActiveSession) deps.state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
 				const targetRunId = paramsWithResolvedCwd.id ?? paramsWithResolvedCwd.runId;
-				const target = targetRunId ? `run ${targetRunId}` : paramsWithResolvedCwd.dir ? `dir ${paramsWithResolvedCwd.dir}` : undefined;
-				const targetLabel = paramsWithResolvedCwd.view === "transcript"
-					? `Transcript target: ${target ?? "active run"}${paramsWithResolvedCwd.index !== undefined ? ` · child ${paramsWithResolvedCwd.index}` : ""}`
-					: `Status target: ${target ?? "active runs"}`;
+				const hasDirectoryTarget = Boolean(paramsWithResolvedCwd.dir);
+				const targetLabel = formatStatusTargetLabel(paramsWithResolvedCwd, targetRunId);
 				const withBudget = (result: AgentToolResult<Details>) => {
 					const budgeted = withSpawnBudgetStatus(result, deps.state, deps.config, deps.state.currentSessionId);
 					return {
@@ -4655,7 +4666,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const message = error instanceof Error ? error.message : String(error);
 						return withBudget({ content: [{ type: "text", text: message }], isError: true, details: { mode: "management", results: [] } });
 					}
-				} else if (!paramsWithResolvedCwd.dir) {
+				} else if (!hasDirectoryTarget) {
 					const foreground = getForegroundControl(deps.state, undefined);
 					if (foreground && paramsWithResolvedCwd.view !== "transcript") return withBudget(foregroundStatusResult(foreground));
 					if (foreground && paramsWithResolvedCwd.view === "transcript") {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -23,8 +23,10 @@ export interface ResolvedStepBehavior {
 	model?: string;
 }
 
+export type OutputOverrideInput = string | boolean;
+
 export interface StepOverrides {
-	output?: string | false;
+	output?: OutputOverrideInput;
 	outputMode?: OutputMode;
 	reads?: string[] | false;
 	progress?: boolean;
@@ -51,7 +53,7 @@ export interface SequentialStep {
 	as?: string;
 	outputSchema?: JsonSchemaObject;
 	cwd?: string;
-	output?: string | false;
+	output?: OutputOverrideInput;
 	outputMode?: OutputMode;
 	reads?: string[] | false;
 	progress?: boolean;
@@ -73,7 +75,7 @@ export interface ParallelTaskItem {
 	outputSchema?: JsonSchemaObject;
 	cwd?: string;
 	count?: number;
-	output?: string | false;
+	output?: OutputOverrideInput;
 	outputMode?: OutputMode;
 	reads?: string[] | false;
 	progress?: boolean;
@@ -125,7 +127,7 @@ export interface CheckpointStep {
 	agent?: string;
 	task?: string;
 	as?: string;
-	output?: string | false;
+	output?: OutputOverrideInput;
 	outputMode?: OutputMode;
 	reads?: string[] | false;
 	progress?: boolean;

--- a/test/integration/template-resolution.test.ts
+++ b/test/integration/template-resolution.test.ts
@@ -173,10 +173,10 @@ describe("resolveStepBehavior", { skip: !available ? "pi packages not available"
 
 	it("ignores boolean and string true output overrides", () => {
 		const config = { name: "test", output: "report.md" };
-		assert.equal(resolveStepBehavior(config, { output: true } as any).output, "report.md");
-		assert.equal(resolveStepBehavior(config, { output: "true" } as any).output, "report.md");
-		assert.equal(resolveStepBehavior({ name: "test" }, { output: true } as any).output, false);
-		assert.equal(resolveStepBehavior({ name: "test" }, { output: "true" } as any).output, false);
+		assert.equal(resolveStepBehavior(config, { output: true }).output, "report.md");
+		assert.equal(resolveStepBehavior(config, { output: "true" }).output, "report.md");
+		assert.equal(resolveStepBehavior({ name: "test" }, { output: true }).output, false);
+		assert.equal(resolveStepBehavior({ name: "test" }, { output: "true" }).output, false);
 	});
 
 	it("defaults to false when agent has no config", () => {


### PR DESCRIPTION
This is a small follow-up polish pass after the backlog fixes landed.

It tightens the chain `output` override type so the TypeScript surface matches the real tool-input boundary, removes the boolean-output test casts, and keeps status target label rendering in one local helper.

Validation:
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/template-resolution.test.ts`
- `node --experimental-strip-types --test test/unit/nested-control.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'reports structured spawn-budget usage through status' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh exact-head review: no blockers
