### PR TITLE
chore: remove polish changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ### Changed
 - Clarified native supervisor messaging and optional external intercom result delivery in the docs and packaged skill.
-- Tightened internal typing for chain output overrides and status target rendering.
 - Identify status and transcript targets before the spawn-budget summary in collapsed tool-result cards.
 - Point interactive async-launch guidance to `subagent_wait({ id, nonBlocking: true })` when an explicit wake is needed without blocking the current turn.
 


### PR DESCRIPTION
Removes the changelog note from the internal TypeScript polish pass. That cleanup did not need release-note surface area.

Validation:
- `node --experimental-strip-types --test --test-name-pattern 'pauses and revives a single run with only its remaining budgets' test/unit/steering-action.test.ts`
- `git diff --check`
