### PR TITLE
fix(reads): expand home paths and wire reads into single runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Clarified mission-use policy in the packaged `pi-subagents` skill.
 
 ### Fixed
+- Expand `reads` home paths and apply configured reads to single-run launches. Thanks to @Adjuvant (Thomas Deacon) for #916.
 - Stabilize steering recovery tests by invalidating cached status metadata after fast test rewrites.
 
 ## [0.44.0] - 2026-08-08

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -15,7 +15,7 @@ import { appendAgentRefinementOverlay } from "../../agents/agent-refinements.ts"
 import { writePrivateAtomicJson } from "../../shared/atomic-json.ts";
 import { applyThinkingSuffix, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/pi-args.ts";
 import { injectOutputPathSystemPrompt, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
-import { buildChainInstructions, isCheckpointStep, isDynamicParallelStep, isParallelStep, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
+import { buildChainInstructions, isCheckpointStep, isDynamicParallelStep, isParallelStep, resolveChainPath, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import type { ContextMode } from "../shared/context-mode.ts";
 import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
@@ -192,6 +192,7 @@ interface AsyncSingleParams {
 	context?: ContextMode;
 	skills?: string[];
 	output?: string | boolean;
+	reads?: string[] | false;
 	outputMode?: "inline" | "file-only";
 	outputBaseDir?: string;
 	agentContract?: AgentContract;
@@ -1288,6 +1289,13 @@ export function executeAsyncSingle(
 	const validationError = validateFileOnlyOutputMode(outputMode, outputPath, `Async single run (${agent})`);
 	if (validationError) return formatAsyncStartError("single", validationError);
 	const taskWithOutputInstruction = injectSingleOutputInstruction(task, outputPath, agentConfig);
+	// Reads: caller override > agent defaultReads > none. `~`/`~/` expand to home;
+	// absolute paths pass through; relative paths resolve against the child cwd.
+	const reads = params.reads !== undefined ? params.reads : agentConfig.defaultReads ?? false;
+	const readsInstruction = Array.isArray(reads) && reads.length > 0
+		? `[Read from: ${reads.map((f) => resolveChainPath(f, runnerCwd)).join(", ")}]\n\n`
+		: "";
+	const taskText = readsInstruction + taskWithOutputInstruction;
 	const primaryModel = externalRunner ? undefined : resolveSubagentModelOverride(
 		params.modelOverride ?? agentConfig.model,
 		ctx.currentModel,
@@ -1415,7 +1423,7 @@ export function executeAsyncSingle(
 						permissionRules,
 						...(capabilityCeiling ? { capabilityCeiling } : {}),
 						agent,
-						task: taskWithOutputInstruction,
+						task: taskText,
 						...(agentConfig.runner ? { runner: agentConfig.runner } : {}),
 						...(params.context ? { context: params.context } : {}),
 						cwd: runnerCwd,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -36,6 +36,7 @@ import {
 	getStepAgents,
 	isParallelStep,
 	isDynamicParallelStep,
+	resolveChainPath,
 	resolveStepBehavior,
 	suppressProgressForReadOnlyTask,
 	taskDisallowsFileUpdates,
@@ -256,6 +257,8 @@ export interface SubagentParamsLike {
 	focus?: boolean;
 	skill?: string | string[] | boolean;
 	output?: string | boolean;
+	/** Internal-only; not part of the public tool schema. Wired for single-run reads (chain steps use their own field). */
+	reads?: string[] | false;
 	outputMode?: "inline" | "file-only";
 	outputSchema?: JsonSchemaObject;
 	agentScope?: unknown;
@@ -2562,6 +2565,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			skills,
 			output: effectiveOutput,
 			outputMode: effectiveOutputMode,
+			...(params.reads !== undefined ? { reads: params.reads } : {}),
 			outputBaseDir: resolveSingleRunOutputBaseDir(deps, artifactsDir, id),
 			modelOverride,
 			thinkingOverride: thinkingOverrideForTask(params.agent!, 0, modelOverride),
@@ -3590,6 +3594,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		data.modelScope === undefined ? {} : { scope: data.modelScope },
 	);
 	let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
+	let readsOverride: string[] | false | undefined = params.reads;
 	const rawOutput = params.output !== undefined ? params.output : agentConfig.output;
 	let effectiveOutput = normalizeSingleOutputOverride(rawOutput, agentConfig.output);
 	const effectiveOutputMode = params.outputMode ?? "inline";
@@ -3627,6 +3632,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		if (override?.model !== undefined) modelOverride = resolveEffectiveSubagentModel(override.model, agentConfig.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope });
 		if (override?.output !== undefined) effectiveOutput = normalizeSingleOutputOverride(override.output, agentConfig.output);
 		if (override?.skills !== undefined) skillOverride = override.skills;
+		if (override?.reads !== undefined) readsOverride = override.reads;
 
 		if (result.runInBackground) {
 			if (!isAsyncAvailable()) {
@@ -3666,6 +3672,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				skills: skillOverride === false ? [] : skillOverride,
 				output: effectiveOutput,
 				outputMode: effectiveOutputMode,
+				...(readsOverride !== undefined ? { reads: readsOverride } : {}),
 				outputBaseDir: resolveSingleRunOutputBaseDir(deps, artifactsDir, id),
 				modelOverride,
 				thinkingOverride: thinkingOverrideForTask(params.agent!, 0, modelOverride),
@@ -3702,6 +3709,13 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const structuredRuntime = params.outputSchema
 		? createStructuredOutputRuntime(params.outputSchema, artifactConfig.enabled ? path.join(artifactsDir, "structured-output", runId) : undefined)
 		: undefined;
+	// Reads: caller override > agent defaultReads > none. `~`/`~/` expand to home;
+	// absolute paths pass through; relative paths resolve against the child cwd.
+	const reads = readsOverride !== undefined ? readsOverride : agentConfig.defaultReads ?? false;
+	const readsInstruction = Array.isArray(reads) && reads.length > 0
+		? `[Read from: ${reads.map((f) => resolveChainPath(f, effectiveCwd)).join(", ")}]\n\n`
+		: "";
+	task = readsInstruction + task;
 	task = injectSingleOutputInstruction(task, outputPath, agentConfig);
 
 	let effectiveSkills: string[] | undefined;
@@ -4016,6 +4030,7 @@ function prepareWorkflowChildParams(params: SubagentParamsLike): SubagentParamsL
 		acceptance,
 		agentContract,
 		toolBudget,
+		reads,
 		...runParams
 	} = params;
 	return {
@@ -4027,6 +4042,7 @@ function prepareWorkflowChildParams(params: SubagentParamsLike): SubagentParamsL
 			...(model !== undefined ? { model } : {}),
 			...(skill !== undefined ? { skill } : {}),
 			...(output !== undefined ? { output } : {}),
+			...(reads !== undefined ? { reads } : {}),
 			...(outputMode !== undefined ? { outputMode } : {}),
 			...(outputSchema !== undefined ? { outputSchema } : {}),
 			...(acceptance !== undefined ? { acceptance } : {}),

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -3,6 +3,7 @@
  */
 
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentConfig } from "../agents/agents.ts";
 import { normalizeSkillInput } from "../agents/skills.ts";
@@ -334,10 +335,22 @@ export function suppressProgressForReadOnlyTask(behavior: ResolvedStepBehavior, 
 // =============================================================================
 
 /**
- * Resolve a file path: absolute paths pass through, relative paths get chainDir prepended.
+ * Expand a leading `~`/`~/` to the user's home directory. Other forms (relative,
+ * absolute, `~user/`) pass through unchanged.
  */
-function resolveChainPath(filePath: string, chainDir: string): string {
-	return path.isAbsolute(filePath) ? filePath : path.join(chainDir, filePath);
+export function expandHomePath(filePath: string): string {
+	if (filePath === "~") return os.homedir();
+	if (filePath.startsWith("~/")) return path.join(os.homedir(), filePath.slice(2));
+	return filePath;
+}
+
+/**
+ * Resolve a file path: `~`/`~/` expand to home first, then absolute paths pass
+ * through and relative paths get chainDir prepended.
+ */
+export function resolveChainPath(filePath: string, chainDir: string): string {
+	const expanded = expandHomePath(filePath);
+	return path.isAbsolute(expanded) ? expanded : path.join(chainDir, expanded);
 }
 
 /**

--- a/test/unit/reads-resolution.test.ts
+++ b/test/unit/reads-resolution.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, before, after } from "node:test";
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { expandHomePath, resolveChainPath } from "../../src/shared/settings.ts";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-reads-resolution-"));
+const homeDir = path.join(tmpDir, "home");
+const chainDir = path.join(tmpDir, "chain");
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+
+before(() => {
+	process.env.HOME = homeDir;
+	process.env.USERPROFILE = homeDir;
+	assert.equal(os.homedir(), homeDir);
+});
+
+after(() => {
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
+	if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+	else process.env.USERPROFILE = originalUserProfile;
+});
+
+describe("reads path resolution", () => {
+	describe("expandHomePath", () => {
+		test("expands bare ~ to the home directory", () => {
+			assert.equal(expandHomePath("~"), homeDir);
+		});
+
+		test("expands ~/ to the home directory", () => {
+			assert.equal(expandHomePath("~/"), homeDir);
+		});
+
+		test("expands ~/file to <home>/file", () => {
+			assert.equal(expandHomePath("~/.zprofile"), path.join(homeDir, ".zprofile"));
+		});
+
+		test("leaves absolute paths unchanged", () => {
+			assert.equal(expandHomePath("/etc/hosts"), "/etc/hosts");
+		});
+
+		test("leaves repository-relative paths unchanged", () => {
+			assert.equal(expandHomePath("docs/x.md"), "docs/x.md");
+		});
+	});
+
+	describe("resolveChainPath", () => {
+		test("expands ~ before resolving", () => {
+			assert.equal(
+				resolveChainPath("~/.zprofile", chainDir),
+				path.join(homeDir, ".zprofile"),
+			);
+		});
+
+		test("passes absolute paths through", () => {
+			assert.equal(resolveChainPath("/etc/hosts", chainDir), "/etc/hosts");
+		});
+
+		test("prepends chainDir to repository-relative paths", () => {
+			assert.equal(resolveChainPath("docs/x.md", chainDir), path.join(chainDir, "docs/x.md"));
+		});
+	});
+});


### PR DESCRIPTION
## Problem

Two defects around `reads` preloading:

1. **Single-run launches silently drop `reads`.** `executeAsyncSingle` and the `runSync` path never consumed a top-level `reads`, so `reads: ["~/<file>"]` got no preload at all.
2. **`~/` resolves against the chain dir, not home.** `resolveChainPath` had no `~` expansion, so chain-step `~/foo` became `<chainDir>/~/foo`.

Observed in the field (variety of models): a scout preloading `~/<existing-home-file>` instead read `<repo>/~/<existing-home-file>`; another spent ~70s searching `$HOME` before timing out.

## Fix

- `src/shared/settings.ts` — `expandHomePath` (`~`/`~/`; absolute and `~user/` pass through); `resolveChainPath` expands `~` first.
- `src/runs/background/async-execution.ts`, `src/runs/foreground/subagent-executor.ts` — build a `[Read from: …]` instruction from caller `reads` (fallback: agent `defaultReads` > none) for single-run, async, workflow-child, and clarify paths.

Resolution order: caller `reads` > agent `defaultReads` > none. Absolute paths pass through; relative paths resolve against the child cwd (unchanged).

## Test

`test/unit/reads-resolution.test.ts` — 8 cases: `~`, `~/`, `~/file`, absolute pass-through, plus `resolveChainPath` variants (expand-before-resolve, absolute pass-through, chainDir prepend).

## Validation

- `npm run typecheck` clean
- `npm test` — 1670 pass / 0 fail / 1 skip
