### PR TITLE
test: wait for async status after result

### DIFF
--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -2942,7 +2942,6 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			exitCode: 0,
 		});
 		const id = `async-zero-exit-provider-error-${Date.now().toString(36)}`;
-		const asyncDir = path.join(ASYNC_DIR, id);
 		executeAsyncSingle(id, {
 			agent: "worker",
 			task: "Do work",
@@ -2964,8 +2963,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
 		assert.equal(payload.success, false);
 		assert.match(payload.results[0]?.error ?? "", /429 quota exceeded/);
-		const statusPayload = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")) as AsyncStatusPayload;
-		assert.equal(statusPayload.state, "failed");
+		const statusPayload = await waitForAsyncState(id, (status) => status.state === "failed");
 		assert.match(statusPayload.steps?.[0]?.error ?? "", /429 quota exceeded/);
 	});
 


### PR DESCRIPTION
Fixes the Windows main CI failure after #915.

#915 intentionally writes async result files before terminal status. This test waited for the result file and then immediately read `status.json`, so it could observe the documented result-before-status window on Windows. The test now waits for the terminal `failed` state before asserting the status error.

Validation:
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts --test-name-pattern 'background runs fail zero-exit provider errors when no fallback succeeds'`
- `node --experimental-strip-types --test test/unit/subagent-wait.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh targeted review: no blockers
