### PR TITLE
test: stabilize steering status rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Changed
 - Clarified mission-use policy in the packaged `pi-subagents` skill.
 
+### Fixed
+- Stabilize steering recovery tests by invalidating cached status metadata after fast test rewrites.
+
 ## [0.44.0] - 2026-08-08
 
 ### Added

--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -28,9 +28,16 @@ function createState(): SubagentState {
 	};
 }
 
+let statusWriteMtimeMs = Date.now();
+
 function writeStatus(asyncDir: string, status: AsyncStatus): void {
 	fs.mkdirSync(asyncDir, { recursive: true });
-	writeAtomicJson(path.join(asyncDir, "status.json"), status);
+	const statusPath = path.join(asyncDir, "status.json");
+	writeAtomicJson(statusPath, status);
+	// readStatus is metadata-cached. Keep fast test rewrites monotonic.
+	statusWriteMtimeMs = Math.max(statusWriteMtimeMs + 1, Date.now());
+	const mtime = new Date(statusWriteMtimeMs);
+	fs.utimesSync(statusPath, mtime, mtime);
 }
 
 function runningStatus(runId: string, mode: AsyncStatus["mode"] = "single", count = 1): AsyncStatus {
@@ -364,9 +371,10 @@ describe("acknowledged steering action", () => {
 		writeStatus(asyncDir, runningStatus(runId));
 		writePrivateAtomicJson(path.join(asyncDir, "recovery-descriptor.json"), recoveryDescriptor(runId));
 		let recovered = false;
+		let recoveryCommitted = false;
 		let routed: AsyncStatus | undefined;
 		try {
-			const action = steerAsyncRun({
+			const result = await steerAsyncRun({
 				state: createState(), runId, message: "correct course", location: { asyncDir }, ackTimeoutMs: 25, recoveryTimeoutMs: 500, kill: () => true,
 				onRequestQueued: (requestPath) => {
 					const request = JSON.parse(fs.readFileSync(requestPath, "utf-8")) as SteerRequest;
@@ -374,12 +382,15 @@ describe("acknowledged steering action", () => {
 					projectRequest(routed, request, ["routed"]);
 					writeStatus(asyncDir, routed);
 				},
+				onRecoveryCommitted: () => {
+					recoveryCommitted = true;
+					if (routed) writeStatus(asyncDir, { ...routed, state: "paused", endedAt: Date.now(), steps: [{ ...routed.steps![0]!, status: "paused" }] });
+				},
 				recover: async () => { recovered = true; return successResult("replacement"); },
 			});
-			await waitUntil(() => fs.existsSync(interruptRequestPath(asyncDir)) ? true : undefined);
+			assert.ok(recoveryCommitted);
 			assert.ok(routed);
-			writeStatus(asyncDir, { ...routed, state: "paused", endedAt: Date.now(), steps: [{ ...routed.steps![0]!, status: "paused" }] });
-			const result = await action;
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
 			assert.equal(result.isError, true);
 			assert.equal(recovered, false);
 			assert.match(result.content[0]!.text, /no persisted child session|does not have a persisted session file/i);


### PR DESCRIPTION
Fixes the red `main` CI run at `b4be9680f6ce99ce16832478fe094b14ef67f603`.

Ubuntu failed in `test/unit/steering-action.test.ts` because fast test status rewrites could keep the same filesystem metadata and let `readStatus` return a stale cached projection. The test-local `writeStatus` helper now forces monotonic mtimes after each atomic rewrite.

Validation:
- `node --experimental-strip-types --test test/unit/steering-action.test.ts` passed 50 repeated runs
- `npm run typecheck` passed
- `npm test` passed
- Fresh review found no issues