### PR TITLE
fix(herdr): invoke pane commands in PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Clarified mission-use policy in the packaged `pi-subagents` skill.
 
 ### Fixed
+- Prefix quoted Herdr pane commands with PowerShell's call operator on Windows.
 - Expand `reads` home paths and apply configured reads to single-run launches. Thanks to @Adjuvant (Thomas Deacon) for #916.
 - Stabilize steering recovery tests by invalidating cached status metadata after fast test rewrites.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Clarified mission-use policy in the packaged `pi-subagents` skill.
 
 ### Fixed
-- Prefix quoted Herdr pane commands with PowerShell's call operator on Windows.
+- Prefix quoted Herdr pane commands with PowerShell's call operator on Windows. Thanks to @qsgy-edge for #921.
 - Expand `reads` home paths and apply configured reads to single-run launches. Thanks to @Adjuvant (Thomas Deacon) for #916.
 - Stabilize steering recovery tests by invalidating cached status metadata after fast test rewrites.
 

--- a/src/inspectors/herdr/actions.ts
+++ b/src/inspectors/herdr/actions.ts
@@ -93,7 +93,7 @@ function inspectorCommand(input: { runnerPath: string; asyncDir: string; runId: 
 	const args = [process.execPath, input.runnerPath, "--async-dir", input.asyncDir, "--run-id", input.runId, "--allow-steer", String(input.allowSteer), "--allow-stop", String(input.allowStop)];
 	if (input.index !== undefined) args.push("--index", String(input.index));
 	if (input.missionPath) args.push("--mission-path", input.missionPath);
-	return args.map(shellQuote).join(" ");
+	return `${process.platform === "win32" ? "& " : ""}${args.map(shellQuote).join(" ")}`;
 }
 
 function missionForRun(asyncDir: string, cwd: string, config: MissionStoreConfig | undefined, runId: string): { id: string; path: string } | undefined {

--- a/src/inspectors/herdr/project-panes.ts
+++ b/src/inspectors/herdr/project-panes.ts
@@ -94,7 +94,7 @@ async function paneExists(client: HerdrClient, paneId: string, signal?: AbortSig
 function projectPaneCommand(message: string | undefined): string {
 	const args = message?.trim() ? [message.trim()] : [];
 	const command = getPiSpawnCommand(args);
-	return [command.command, ...command.args].map(shellQuote).join(" ");
+	return `${process.platform === "win32" ? "& " : ""}${[command.command, ...command.args].map(shellQuote).join(" ")}`;
 }
 
 export async function handleHerdrProjectPaneAction(action: HerdrProjectPaneAction, params: ProjectPaneParams, deps: ProjectPaneDeps): Promise<AgentToolResult<Details>> {

--- a/test/unit/herdr-inspector-bootstrap.test.ts
+++ b/test/unit/herdr-inspector-bootstrap.test.ts
@@ -46,6 +46,7 @@ describe("Herdr inspector bootstrap", () => {
 			});
 			assert.equal(opened.isError, undefined);
 			const command = calls.find((args) => args[0] === "pane" && args[1] === "run")?.[3] ?? "";
+			assert.equal(command.startsWith("& "), process.platform === "win32");
 			assert.doesNotMatch(command, /--experimental-strip-types/);
 			assert.match(command, /inspector-runner\.mjs/);
 		} finally {

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -209,6 +209,7 @@ describe("Herdr inspector", () => {
 			const splitCall = calls.find((args) => args[0] === "pane" && args[1] === "split");
 			assert.deepEqual(splitCall?.slice(0, 7), ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot]);
 			const runCall = calls.find((args) => args[0] === "pane" && args[1] === "run" && args[2] === "w1:p10");
+			assert.equal(runCall?.[3]?.startsWith("& "), process.platform === "win32");
 			assert.match(runCall?.[3] ?? "", /pi-bin/);
 			assert.match(runCall?.[3] ?? "", /Own this project mission\./);
 


### PR DESCRIPTION
## Summary

- prefix Herdr inspector commands with PowerShell's call operator on Windows
- apply the same fix to project-owned Herdr pane commands, which use the same quoted executable form
- cover both generated command paths on Windows and preserve their existing POSIX form

## Reproduction

Opening a Herdr inspector pane on Windows generated a command beginning with a quoted executable path:

```text
"C:\nvm4w\nodejs\node.exe" "...\inspector-runner.mjs" ...
```

PowerShell parses the second quoted path as an unexpected token unless the invocation starts with `&`.

## Verification

- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/herdr-inspector-bootstrap.test.ts test/unit/herdr-inspector.test.ts` — 8 passed
- manual PowerShell launch of the packaged `inspector-runner.mjs` with the generated `& "node.exe" ...` form — inspector dashboard rendered successfully
- `git diff --check`

`npm test` has the same 12 unrelated failures before and after this patch in the local Windows environment (package-agent discovery/management and offline npm discovery); the focused Herdr tests pass.
