### PR TITLE
fix(workflows): drop responses after worker settlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - Prefix quoted Herdr pane commands with PowerShell's call operator on Windows. Thanks to @qsgy-edge for #921.
 - Expand `reads` home paths and apply configured reads to single-run launches. Thanks to @Adjuvant (Thomas Deacon) for #916.
+- Drop late workflow child responses after worker settlement. Thanks to @xz-dev (Xiangzhe) for #922.
 - Stabilize steering recovery tests by invalidating cached status metadata after fast test rewrites.
 
 ## [0.44.0] - 2026-08-08

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -385,8 +385,12 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 
 			const respond = (promise: Promise<unknown>) => {
 				void promise.then(
-					(value) => worker.postMessage({ type: "response", callId: message.callId, ok: true, value: omitUndefinedWorkflowValues(value) }),
-					(error: unknown) => worker.postMessage({ type: "response", callId: message.callId, ok: false, error: error instanceof Error ? error.message : String(error) }),
+					(value) => {
+						if (!settled) worker.postMessage({ type: "response", callId: message.callId, ok: true, value: omitUndefinedWorkflowValues(value) });
+					},
+					(error: unknown) => {
+						if (!settled) worker.postMessage({ type: "response", callId: message.callId, ok: false, error: error instanceof Error ? error.message : String(error) });
+					},
 				);
 			};
 

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { Worker } from "node:worker_threads";
 import { formatWorkflowJsonPreview, previewSimpleWorkflowRun, runWorkflowScript, WorkflowScriptError } from "../../src/workflows/scripted-workflow.ts";
 
 describe("scripted workflow runtime", () => {
@@ -570,5 +571,41 @@ describe("scripted workflow runtime", () => {
 			(error: unknown) => error instanceof WorkflowScriptError && /timed out after 500ms/.test(error.message),
 		);
 		assert.equal(childAborted, true);
+	});
+
+	it("drops a child response that settles after the workflow aborts", async () => {
+		const workerPrototype = Worker.prototype as unknown as { postMessage(value: unknown, ...args: unknown[]): void };
+		const originalPostMessage = workerPrototype.postMessage;
+		const controller = new AbortController();
+		let workflowSettled = false;
+		let postSettlementResponses = 0;
+		let resolveLaunch!: (result: { key: string; ok: true; output: string; artifactPaths: string[]; results: never[] }) => void;
+		let markLaunchStarted!: () => void;
+		const launchStarted = new Promise<void>((resolve) => { markLaunchStarted = resolve; });
+		workerPrototype.postMessage = function (value, ...args) {
+			if (workflowSettled && typeof value === "object" && value !== null && "type" in value && value.type === "response") postSettlementResponses++;
+			originalPostMessage.call(this, value, ...args);
+		};
+
+		try {
+			const workflow = runWorkflowScript({
+				script: `await runs.run("slow", { agent: "worker", task: "wait" });`,
+				signal: controller.signal,
+				launch() {
+					markLaunchStarted();
+					return new Promise((resolve) => { resolveLaunch = resolve; });
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			});
+			await launchStarted;
+			controller.abort();
+			await assert.rejects(workflow, (error: unknown) => error instanceof WorkflowScriptError && /aborted/.test(error.message));
+			workflowSettled = true;
+			resolveLaunch({ key: "slow", ok: true, output: "done", artifactPaths: [], results: [] });
+			await new Promise((resolve) => queueMicrotask(resolve));
+			assert.equal(postSettlementResponses, 0);
+		} finally {
+			workerPrototype.postMessage = originalPostMessage;
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- drop late scripted-workflow host responses after the workflow has settled
- prevent Bun from calling `postMessage` on a terminated Worker
- add a regression for a child launch that settles after the workflow timeout

## Root cause

`finish()` marks the workflow settled and terminates its Worker, but an in-flight `runs.run` or `runs.status` Promise can still settle afterward. The shared `respond()` continuations previously called `worker.postMessage(...)` unconditionally. Bun 1.3.14 throws `InvalidStateError: Worker has been terminated` in that situation, turning an expected workflow timeout into a secondary process-level error.

The response has no recipient after settlement, so both continuations now drop it when `settled` is true. Timeout, abort, child cancellation, and the primary `WorkflowScriptError` behavior remain unchanged.

## Verification

- red regression on the unfixed baseline: observed one post-settlement response attempt
- `node --experimental-strip-types --test test/unit/scripted-workflow.test.ts` — 29 passed
- `npm run typecheck` — passed
- Bun 1.3.14 delayed-settlement reproduction — 3/3 exited 0 with the expected timeout and no `InvalidStateError`
- focused regression repeated independently — 20/20 passed

No related existing issue or PR was found using the exact error and scripted-workflow timeout/Worker-settlement searches.
