### PR TITLE
fix(workflows): report live child activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Prefix quoted Herdr pane commands with PowerShell's call operator on Windows. Thanks to @qsgy-edge for #921.
+- Report live child activity for async workflow runs instead of deriving a false activity age from the workflow launch time. Thanks to @alexei-led (Alexei Ledenev) for #920.
 - Expand `reads` home paths and apply configured reads to single-run launches. Thanks to @Adjuvant (Thomas Deacon) for #916.
 - Drop late workflow child responses after worker settlement. Thanks to @xz-dev (Xiangzhe) for #922.
 - Stabilize steering recovery tests by invalidating cached status metadata after fast test rewrites.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -207,7 +207,10 @@ function deriveAsyncActivityState(asyncDir: string, status: AsyncStatus): { acti
 	const currentStep = typeof status.currentStep === "number" ? status.steps?.[status.currentStep] : undefined;
 	return {
 		activityState: status.activityState,
-		lastActivityAt: status.lastActivityAt ?? outputFileMtime(outputPath) ?? currentStep?.lastActivityAt ?? currentStep?.startedAt ?? status.startedAt,
+		lastActivityAt: status.lastActivityAt
+			?? outputFileMtime(outputPath)
+			?? currentStep?.lastActivityAt
+			?? (status.mode === "workflow" ? undefined : currentStep?.startedAt ?? status.startedAt),
 	};
 }
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4254,6 +4254,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					if (job) {
 						job.status = status.state;
 						job.updatedAt = status.lastUpdate;
+						job.activityState = status.activityState;
+						job.lastActivityAt = status.lastActivityAt;
+						job.currentTool = status.currentTool;
+						job.currentToolStartedAt = status.currentToolStartedAt;
+						job.currentPath = status.currentPath;
+						job.turnCount = status.turnCount;
+						job.toolCount = status.toolCount;
+						job.currentStep = status.currentStep;
 						if (status.steps) {
 							job.steps = status.steps.map((step, index) => ({ ...step, index }));
 							job.agents = status.steps.map((step) => step.agent);
@@ -4263,6 +4271,26 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						}
 						job.workflow = status.workflow;
 					}
+				};
+				const projectWorkflowActivity = () => {
+					const runningSteps = (status.steps ?? []).filter((step) => step.status === "running");
+					const lastActivityAt = runningSteps.reduce<number | undefined>((latest, step) => step.lastActivityAt === undefined ? latest : Math.max(latest ?? step.lastActivityAt, step.lastActivityAt), undefined);
+					const activeToolStep = runningSteps
+						.filter((step) => step.currentTool)
+						.sort((left, right) => (left.lastActivityAt ?? 0) - (right.lastActivityAt ?? 0))
+						.at(-1);
+					status.activityState = runningSteps.some((step) => step.activityState === "needs_attention")
+						? "needs_attention"
+						: runningSteps.some((step) => step.activityState === "active_long_running") ? "active_long_running" : undefined;
+					status.lastActivityAt = lastActivityAt;
+					status.currentTool = activeToolStep?.currentTool;
+					status.currentToolStartedAt = activeToolStep?.currentToolStartedAt;
+					status.currentPath = activeToolStep?.currentPath;
+					const turnCounts = (status.steps ?? []).flatMap((step) => step.turnCount === undefined ? [] : [step.turnCount]);
+					const toolCounts = (status.steps ?? []).flatMap((step) => step.toolCount === undefined ? [] : [step.toolCount]);
+					status.turnCount = turnCounts.length > 0 ? turnCounts.reduce((total, count) => total + count, 0) : undefined;
+					status.toolCount = toolCounts.length > 0 ? toolCounts.reduce((total, count) => total + count, 0) : undefined;
+					status.currentStep = runningSteps.length === 1 ? status.steps?.indexOf(runningSteps[0]!) : undefined;
 				};
 				const workflowJob: AsyncJobState = { asyncId: workflowRunId, asyncDir, cwd: workflowCwd, status: "running", sessionId: currentSessionId ?? undefined, mode: "workflow", agents: [], steps: [], startedAt, updatedAt: startedAt, ...(timeout !== undefined ? { timeoutMs: timeout, deadlineAt: startedAt + timeout } : {}), workflow: status.workflow };
 				deps.state.asyncJobs.set(workflowRunId, workflowJob);
@@ -4287,9 +4315,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								if (entry.durationMs === undefined) delete existing.durationMs;
 								else existing.durationMs = entry.durationMs;
 							} else {
-								status.steps?.push({ agent: entry.key, label: entry.key, workflowKey: entry.key, parentWorkflowRunId: workflowRunId, status: mapped });
+								status.steps?.push({ agent: entry.key, label: entry.key, workflowKey: entry.key, parentWorkflowRunId: workflowRunId, status: mapped, startedAt: Date.now() });
 							}
 						}
+						projectWorkflowActivity();
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.trace", trace });
 					};
@@ -4312,7 +4341,27 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								if (budgetState?.exhausted) return workflowChildResult(key, buildRequestedModeError(childParams as SubagentParamsLike, usageBudgetExceededMessage(budgetState)));
 								patchMissionObjective(childParams.task);
 								const childRequest = prepareWorkflowLaunchParams(workflowChildDefaults, childParams, workflowRunId, key, { missionDetached: detachWorkflowChildMissions });
-								const result = await execute(randomUUID(), childRequest, workflowSignal, undefined, ctx, preserveActiveSession);
+								const result = await execute(randomUUID(), childRequest, workflowSignal, (update) => {
+									const progress = update.details.progress?.[0];
+									const step = status.steps?.find((candidate) => candidate.workflowKey === key);
+									if (!progress || !step) return;
+									step.status = progress.status === "completed" ? "completed" : progress.status === "failed" ? "failed" : "running";
+									step.activityState = progress.activityState;
+									step.lastActivityAt = progress.lastActivityAt;
+									step.currentTool = progress.currentTool;
+									step.currentToolArgs = progress.currentToolArgs;
+									step.currentToolStartedAt = progress.currentToolStartedAt;
+									step.currentPath = progress.currentPath;
+									step.recentTools = progress.recentTools.map((tool) => ({ ...tool }));
+									step.recentOutput = [...progress.recentOutput];
+									step.turnCount = progress.turnCount;
+									step.toolCount = progress.toolCount;
+									step.model = progress.model;
+									step.thinking = progress.thinking;
+									step.error = progress.error;
+									projectWorkflowActivity();
+									persist();
+								}, ctx, preserveActiveSession);
 								workflowResults.push(...result.details.results);
 								const child = workflowChildResult(key, result);
 								if (result.details.asyncId) {

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -244,6 +244,28 @@ describe("async status helpers", () => {
 		}
 	});
 
+	it("does not infer workflow activity from the workflow launch time", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-workflow-no-false-activity-"));
+		try {
+			const now = Date.now();
+			createAsyncDir(root, "workflow-running", {
+				runId: "workflow-running",
+				mode: "workflow",
+				state: "running",
+				startedAt: now - 120_000,
+				lastUpdate: now - 120_000,
+				steps: [{ agent: "main", workflowKey: "main", status: "running", startedAt: now - 120_000 }],
+			});
+
+			const runs = listAsyncRuns(root, { states: ["running"] });
+			assert.equal(runs[0]?.lastActivityAt, undefined);
+			assert.equal(runs[0]?.steps[0]?.lastActivityAt, undefined);
+			assert.doesNotMatch(formatAsyncRunList(runs), /active 2m ago/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("does not smear run-level attention state across running siblings when step metadata exists", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-step-attention-"));
 		try {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -466,6 +466,79 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		fs.rmSync(resultPath, { force: true });
 	});
 
+	it("projects live child activity into async workflow status", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("read", { path: "src/example.ts" })] },
+				{ delay: 2_500, jsonl: [events.toolEnd("read"), events.toolResult("read", "contents")] },
+				{ jsonl: [events.assistantMessage("Done")] },
+			],
+		});
+		const asyncJobs: SubagentState["asyncJobs"] = new Map();
+		const executor = makeExecutor([makeAgent("echo")], {
+			control: {
+				enabled: true,
+				needsAttentionAfterMs: 100,
+				activeNoticeAfterMs: 100,
+				activeNoticeAfterTurns: 999_999,
+				activeNoticeAfterTokens: 999_999,
+				notifyOn: ["active_long_running", "needs_attention"],
+				notifyChannels: ["event"],
+			},
+		}, false, undefined, true, asyncJobs);
+
+		const result = await executor.execute(
+			"workflow-live-activity",
+			{ workflowScript: `return await runs.run("main", { agent: "echo", task: "Inspect the file" });` },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		const workflowRunId = result.details.asyncId!;
+		const statusPath = path.join(result.details.asyncDir!, "status.json");
+		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
+		type WorkflowActivityStatus = {
+			state?: string;
+			activityState?: string;
+			lastActivityAt?: number;
+			currentTool?: string;
+			currentPath?: string;
+			toolCount?: number;
+			steps?: Array<{ status?: string; activityState?: string; lastActivityAt?: number; currentTool?: string; currentPath?: string; toolCount?: number }>;
+		};
+		let liveStatus: WorkflowActivityStatus | undefined;
+		const activityDeadline = Date.now() + 5_000;
+		while (Date.now() < activityDeadline && !fs.existsSync(resultPath)) {
+			const candidate = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as WorkflowActivityStatus;
+			if (candidate.activityState === "active_long_running" && candidate.steps?.[0]?.currentTool === "read") {
+				liveStatus = candidate;
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+
+		assert.ok(liveStatus, "expected workflow status to expose live child activity");
+		assert.equal(liveStatus.activityState, "active_long_running");
+		assert.equal(typeof liveStatus.lastActivityAt, "number");
+		assert.equal(liveStatus.currentTool, "read");
+		assert.match(liveStatus.currentPath ?? "", /src[/\\]example\.ts$/);
+		assert.equal(liveStatus.toolCount, 1);
+		assert.equal(liveStatus.steps?.[0]?.status, "running");
+		assert.equal(liveStatus.steps?.[0]?.activityState, "active_long_running");
+		assert.equal(typeof liveStatus.steps?.[0]?.lastActivityAt, "number");
+		assert.equal(liveStatus.steps?.[0]?.toolCount, 1);
+		assert.equal(asyncJobs.get(workflowRunId)?.activityState, "active_long_running");
+		assert.equal(asyncJobs.get(workflowRunId)?.steps?.[0]?.currentTool, "read");
+
+		const completionDeadline = Date.now() + 5_000;
+		while (!fs.existsSync(resultPath)) {
+			if (Date.now() > completionDeadline) assert.fail("Timed out waiting for async workflow completion");
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true });
+		fs.rmSync(resultPath, { force: true });
+	});
+
 	it("rejects an invalid async workflow usage budget before creating run state", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const asyncJobs: SubagentState["asyncJobs"] = new Map();
 		const executor = makeExecutor([makeAgent("echo")], {}, false, undefined, true, asyncJobs);


### PR DESCRIPTION
Fix workflow-mode async status so it does not report launch time as live activity. Project running child progress into workflow step and parent status, including attention state, tools, paths, and counters.

Add focused coverage for the false activity fallback and the live workflow child status path. Credit @alexei-led for the report.

Closes #920

Validation:
- `node --experimental-strip-types --test test/integration/async-status.test.ts`
- focused `projects live child activity into async workflow status` test
- `npm run typecheck`
- `git diff --check`
