### PR TITLE
refactor: simplify workflow activity projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Simplified async workflow activity projection and its regression test to reuse canonical status types.
+
 ## [0.45.0] - 2026-08-09
 
 ### Added

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4273,7 +4273,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					}
 				};
 				const projectWorkflowActivity = () => {
-					const runningSteps = (status.steps ?? []).filter((step) => step.status === "running");
+					const steps = status.steps ?? [];
+					const runningSteps = steps.filter((step) => step.status === "running");
 					const lastActivityAt = runningSteps.reduce<number | undefined>((latest, step) => step.lastActivityAt === undefined ? latest : Math.max(latest ?? step.lastActivityAt, step.lastActivityAt), undefined);
 					const activeToolStep = runningSteps
 						.filter((step) => step.currentTool)
@@ -4286,11 +4287,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					status.currentTool = activeToolStep?.currentTool;
 					status.currentToolStartedAt = activeToolStep?.currentToolStartedAt;
 					status.currentPath = activeToolStep?.currentPath;
-					const turnCounts = (status.steps ?? []).flatMap((step) => step.turnCount === undefined ? [] : [step.turnCount]);
-					const toolCounts = (status.steps ?? []).flatMap((step) => step.toolCount === undefined ? [] : [step.toolCount]);
+					const turnCounts = steps.flatMap((step) => step.turnCount === undefined ? [] : [step.turnCount]);
+					const toolCounts = steps.flatMap((step) => step.toolCount === undefined ? [] : [step.toolCount]);
 					status.turnCount = turnCounts.length > 0 ? turnCounts.reduce((total, count) => total + count, 0) : undefined;
 					status.toolCount = toolCounts.length > 0 ? toolCounts.reduce((total, count) => total + count, 0) : undefined;
-					status.currentStep = runningSteps.length === 1 ? status.steps?.indexOf(runningSteps[0]!) : undefined;
+					status.currentStep = runningSteps.length === 1 ? steps.indexOf(runningSteps[0]!) : undefined;
 				};
 				const workflowJob: AsyncJobState = { asyncId: workflowRunId, asyncDir, cwd: workflowCwd, status: "running", sessionId: currentSessionId ?? undefined, mode: "workflow", agents: [], steps: [], startedAt, updatedAt: startedAt, ...(timeout !== undefined ? { timeoutMs: timeout, deadlineAt: startedAt + timeout } : {}), workflow: status.workflow };
 				deps.state.asyncJobs.set(workflowRunId, workflowJob);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -35,7 +35,7 @@ import {
 	type SubagentDelegationResponse,
 	type SubagentDelegationStarted,
 } from "../../src/api/delegation.ts";
-import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, type SubagentState } from "../../src/shared/types.ts";
+import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, type AsyncStatus, type SubagentState } from "../../src/shared/types.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
 import { TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV } from "../../src/runs/shared/tool-budget.ts";
@@ -489,27 +489,20 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		const result = await executor.execute(
 			"workflow-live-activity",
-			{ workflowScript: `return await runs.run("main", { agent: "echo", task: "Inspect the file" });` },
+			{ workflowScript: `return runs.run("main", { agent: "echo", task: "Inspect the file" });` },
 			new AbortController().signal,
 			undefined,
 			makeMinimalCtx(tempDir),
 		);
-		const workflowRunId = result.details.asyncId!;
-		const statusPath = path.join(result.details.asyncDir!, "status.json");
+		const { asyncId: workflowRunId, asyncDir } = result.details;
+		assert.ok(workflowRunId);
+		assert.ok(asyncDir);
+		const statusPath = path.join(asyncDir, "status.json");
 		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
-		type WorkflowActivityStatus = {
-			state?: string;
-			activityState?: string;
-			lastActivityAt?: number;
-			currentTool?: string;
-			currentPath?: string;
-			toolCount?: number;
-			steps?: Array<{ status?: string; activityState?: string; lastActivityAt?: number; currentTool?: string; currentPath?: string; toolCount?: number }>;
-		};
-		let liveStatus: WorkflowActivityStatus | undefined;
+		let liveStatus: AsyncStatus | undefined;
 		const activityDeadline = Date.now() + 5_000;
 		while (Date.now() < activityDeadline && !fs.existsSync(resultPath)) {
-			const candidate = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as WorkflowActivityStatus;
+			const candidate = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatus;
 			if (candidate.activityState === "active_long_running" && candidate.steps?.[0]?.currentTool === "read") {
 				liveStatus = candidate;
 				break;
@@ -535,7 +528,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			if (Date.now() > completionDeadline) assert.fail("Timed out waiting for async workflow completion");
 			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
-		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true });
+		fs.rmSync(asyncDir, { recursive: true, force: true });
 		fs.rmSync(resultPath, { force: true });
 	});
 


### PR DESCRIPTION
## Summary

Simplify async workflow activity projection by reusing one normalized step collection.

Keep the regression test on the canonical `AsyncStatus` type, return the child promise directly, and narrow async launch metadata with runtime assertions instead of non-null assertions.

## Validation

- `npm run typecheck`
- `npm run test:integration` (709 passed)
- focused workflow activity integration test
- fresh TypeScript and four-vector deslop reviews
