### PR TITLE
fix: make async interrupt delivery file-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Simplified async workflow activity projection and its regression test to reuse canonical status types.
 
+### Fixed
+- Prevent async interrupt requests from signaling unverified runner PIDs, including the shared host PID stored by workflows. Thanks to @kdasme for #925.
+
 ## [0.45.0] - 2026-08-09
 
 ### Added

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -9,9 +9,8 @@
  * This module adds a portable, file-based control inbox inside the run directory.
  * The parent drops an interrupt request file; the runner watches the inbox and
  * routes the request into its existing graceful `interruptRunner()` (pause +
- * resumable), identically on every platform. The OS signal is kept only as an
- * opportunistic fast-path; its failure is non-fatal because the file inbox is
- * authoritative.
+ * resumable), identically on every platform. The file inbox is authoritative and
+ * avoids signaling a PID that the extension cannot prove belongs to the runner.
  */
 
 import { randomUUID } from "node:crypto";
@@ -20,13 +19,6 @@ import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { POLL_INTERVAL_MS } from "../../shared/types.ts";
 import { resolveWatchPath } from "../../shared/utils.ts";
-
-/**
- * Opportunistic fast-path interrupt signal. On Unix `SIGUSR2` is trapped by the
- * runner; on Windows `process.kill(pid, "SIGBREAK")` is not deliverable
- * cross-process and throws `ENOSYS`, so the file inbox below is the real channel.
- */
-export const INTERRUPT_SIGNAL: NodeJS.Signals = process.platform === "win32" ? "SIGBREAK" : "SIGUSR2";
 
 export type ControlChannelFs = Pick<typeof fs, "mkdirSync" | "existsSync" | "rmSync" | "watch" | "readdirSync" | "readFileSync" | "realpathSync">;
 export type ControlChannelTimers = { setInterval: typeof setInterval; clearInterval: typeof clearInterval };
@@ -545,38 +537,13 @@ export function consumeCheckpointDecisionRequest(
 	return undefined;
 }
 
-/**
- * Parent side: portable interrupt = authoritative file request + best-effort OS
- * signal. The signal is only a latency optimization on Unix; ENOSYS on Windows
- * is swallowed because the file inbox is authoritative there. Other signal
- * failures are surfaced because they usually mean the runner is not alive to
- * consume the request.
- */
+/** Parent side: write the authoritative portable interrupt request. */
 export function deliverInterruptRequest(input: {
 	asyncDir: string;
-	pid?: number;
-	kill?: KillFn;
-	signal?: NodeJS.Signals;
 	now?: () => number;
 	source?: string;
 }): void {
-	const requestPath = requestAsyncInterrupt(input.asyncDir, input.source ? { source: input.source } : {}, { now: input.now });
-	if (typeof input.pid === "number" && input.pid > 0) {
-		try {
-			(input.kill ?? process.kill)(input.pid, input.signal ?? INTERRUPT_SIGNAL);
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOSYS") {
-				// File inbox is authoritative when custom cross-process signals are unavailable.
-				return;
-			}
-			try {
-				fs.rmSync(requestPath, { force: true });
-			} catch {
-				// Best effort cleanup; the caller still gets the signal failure.
-			}
-			throw error;
-		}
-	}
+	requestAsyncInterrupt(input.asyncDir, input.source ? { source: input.source } : {}, { now: input.now });
 }
 
 export function deliverTimeoutRequest(input: {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -2287,7 +2287,7 @@ async function runSubagent(
 			const nestedAsyncDir = run.asyncDir ?? resolveNestedAsyncDir(config.nestedRoute.rootRunId, run);
 			if (!nestedAsyncDir) continue;
 			try {
-				deliverInterruptRequest(omitUndefinedProperties({ asyncDir: nestedAsyncDir, pid: run.pid, source: "ancestor-interrupt" }));
+				deliverInterruptRequest({ asyncDir: nestedAsyncDir, source: "ancestor-interrupt" });
 			} catch (error) {
 				appendJsonl(eventsPath, JSON.stringify({
 					type: "subagent.nested.interrupt_failed",

--- a/src/runs/foreground/async-steering-action.ts
+++ b/src/runs/foreground/async-steering-action.ts
@@ -173,7 +173,7 @@ export async function steerAsyncRun(input: {
 				return { content: [{ type: "text", text: `Steering delivered for async run ${status.runId} (request ${requestId}).` }], details: { mode: "management", results: [], steering: preCommitResult } };
 			}
 			try {
-				deliverInterruptRequest({ asyncDir, pid: latest?.pid ?? status.pid, kill: input.kill, source: "steering-recovery" });
+				deliverInterruptRequest({ asyncDir, source: "steering-recovery" });
 			} catch (error) {
 				fs.rmSync(markerPath, { force: true });
 				fs.rmSync(claimPath, { force: true });

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -868,8 +868,15 @@ function interruptAsyncRun(
 			details: { mode: "management", results: [] },
 		};
 	}
+	if (status.mode === "workflow") {
+		return {
+			content: [{ type: "text", text: `Interrupt is unsupported for async workflow ${target.asyncId}; use stop instead.` }],
+			isError: true,
+			details: { mode: "management", results: [] },
+		};
+	}
 	try {
-		deliverInterruptRequest(omitUndefinedProperties({ asyncDir: target.asyncDir, pid: status.pid, kill, source: "interrupt-action" }));
+		deliverInterruptRequest({ asyncDir: target.asyncDir, source: "interrupt-action" });
 		const tracked = state.asyncJobs.get(target.asyncId);
 		if (tracked) {
 			delete tracked.activityState;
@@ -1178,7 +1185,7 @@ function directNestedAsyncInterrupt(target: ResolvedSubagentRunId & { kind: "nes
 	const pid = typeof status?.pid === "number" && status.pid > 0 ? status.pid : run.pid;
 	if (!status || status.state !== "running" || typeof pid !== "number" || pid <= 0) return undefined;
 	try {
-		deliverInterruptRequest({ asyncDir, pid, source: "nested-interrupt" });
+		deliverInterruptRequest({ asyncDir, source: "nested-interrupt" });
 		return { content: [{ type: "text", text: `Interrupt requested for nested async run ${run.id}.` }], details: { mode: "management", results: [] } };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -31,12 +31,12 @@ function writeJson(filePath: string, value: object): void {
 	fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
 }
 
-function createRunningAsync(state: SubagentState, runId: string, options: { track?: boolean; sessionId?: string; state?: "queued" | "running"; pid?: number } = {}): string {
+function createRunningAsync(state: SubagentState, runId: string, options: { track?: boolean; sessionId?: string; state?: "queued" | "running"; pid?: number; mode?: "single" | "workflow" } = {}): string {
 	const asyncDir = path.join(ASYNC_DIR, runId);
 	const runState = options.state ?? "running";
 	writeJson(path.join(asyncDir, "status.json"), {
 		runId,
-		mode: "single",
+		mode: options.mode ?? "single",
 		state: runState,
 		sessionId: options.sessionId ?? "session",
 		...(options.pid !== undefined ? { pid: options.pid } : runState === "running" ? { pid: 12345 } : {}),
@@ -180,7 +180,7 @@ describe("async interrupt action", () => {
 		}
 	});
 
-	it("interrupts a running async run resolved from disk after in-memory tracking is gone", async () => {
+	it("requests an interrupt without signaling a running async runner", async () => {
 		const state = createState();
 		const runId = `interrupt-disk-${Date.now().toString(36)}`;
 		const asyncDir = createRunningAsync(state, runId, { track: false });
@@ -194,7 +194,27 @@ describe("async interrupt action", () => {
 			assert.equal(result.isError, undefined);
 			assert.match(text(result), new RegExp(`Interrupt requested for async run ${runId}`));
 			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), true);
-			assert.deepEqual(kills, [{ pid: 12345, signal: 0 }, { pid: 12345, signal: process.platform === "win32" ? "SIGBREAK" : "SIGUSR2" }]);
+			assert.deepEqual(kills, [{ pid: 12345, signal: 0 }]);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("rejects workflow interrupt instead of signaling a shared host pid", async () => {
+		const state = createState();
+		const runId = `interrupt-workflow-host-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false, mode: "workflow", pid: process.pid });
+		try {
+			const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+			const result = await executorWithKill(state, (pid, signal) => {
+				kills.push({ pid, signal });
+				return true;
+			}).execute("interrupt", { action: "interrupt", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, true);
+			assert.match(text(result), new RegExp(`Interrupt is unsupported for async workflow ${runId}; use stop instead\\.`));
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), false);
+			assert.deepEqual(kills, [{ pid: process.pid, signal: 0 }]);
 		} finally {
 			cleanup(runId, asyncDir);
 		}
@@ -217,26 +237,6 @@ describe("async interrupt action", () => {
 			assert.match(text(result), /Interrupt is unsupported for one-shot external CLI async run/);
 			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), false);
 			assert.equal(JSON.parse(fs.readFileSync(statusPath, "utf-8")).state, "running");
-		} finally {
-			cleanup(runId, asyncDir);
-		}
-	});
-
-	it("reports success and writes the portable request when the signal is unavailable", async () => {
-		const state = createState();
-		const runId = `interrupt-enosys-${Date.now().toString(36)}`;
-		const asyncDir = createRunningAsync(state, runId);
-		try {
-			const result = await executorWithKill(state, (_pid, signal) => {
-				if (signal === 0) return true;
-				const error = new Error("kill ENOSYS") as NodeJS.ErrnoException;
-				error.code = "ENOSYS";
-				throw error;
-			}).execute("interrupt", { action: "interrupt", id: runId }, new AbortController().signal, undefined, ctx());
-
-			assert.equal(result.isError, undefined);
-			assert.match(text(result), new RegExp(`Interrupt requested for async run ${runId}`));
-			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), true);
 		} finally {
 			cleanup(runId, asyncDir);
 		}

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -287,75 +287,22 @@ describe("control channel: request file", () => {
 });
 
 describe("control channel: deliverInterruptRequest", () => {
-	it("writes the portable request and signals best-effort when kill succeeds", () => {
-		const asyncDir = tmpAsyncDir("pi-control-deliver-ok-");
+	it("writes the portable request without signaling an unverified pid", () => {
+		const asyncDir = tmpAsyncDir("pi-control-deliver-file-only-");
 		try {
 			const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
-			deliverInterruptRequest({
+			const unverifiedInput = {
 				asyncDir,
 				pid: 4242,
-				signal: "SIGUSR2",
-				kill: (pid, signal) => {
+				signal: "SIGUSR2" as NodeJS.Signals,
+				kill: (pid: number, signal?: NodeJS.Signals | 0) => {
 					kills.push({ pid, signal });
 					return true;
 				},
-			});
+			};
+			deliverInterruptRequest(unverifiedInput);
 			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
-			assert.deepEqual(kills, [{ pid: 4242, signal: "SIGUSR2" }]);
-		} finally {
-			cleanup(asyncDir);
-		}
-	});
-
-	it("still writes the request when the OS signal throws ENOSYS (Windows)", () => {
-		const asyncDir = tmpAsyncDir("pi-control-deliver-enosys-");
-		try {
-			assert.doesNotThrow(() =>
-				deliverInterruptRequest({
-					asyncDir,
-					pid: 4242,
-					kill: () => {
-						const error = new Error("kill ENOSYS") as NodeJS.ErrnoException;
-						error.code = "ENOSYS";
-						throw error;
-					},
-				}),
-			);
-			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
-		} finally {
-			cleanup(asyncDir);
-		}
-	});
-
-	it("surfaces non-portability signal failures and removes the stale request", () => {
-		const asyncDir = tmpAsyncDir("pi-control-deliver-esrch-");
-		try {
-			assert.throws(
-				() =>
-					deliverInterruptRequest({
-						asyncDir,
-						pid: 4242,
-						kill: () => {
-							const error = new Error("missing process") as NodeJS.ErrnoException;
-							error.code = "ESRCH";
-							throw error;
-						},
-					}),
-				/missing process/,
-			);
-			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
-		} finally {
-			cleanup(asyncDir);
-		}
-	});
-
-	it("skips signalling when no live pid is provided", () => {
-		const asyncDir = tmpAsyncDir("pi-control-deliver-nopid-");
-		try {
-			let killed = false;
-			deliverInterruptRequest({ asyncDir, kill: () => { killed = true; return true; } });
-			assert.equal(killed, false);
-			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
+			assert.deepEqual(kills, []);
 		} finally {
 			cleanup(asyncDir);
 		}

--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -236,52 +236,17 @@ describe("acknowledged steering action", () => {
 		}
 	});
 
-	it("releases the recovery claim when interrupt delivery definitively fails", async () => {
-		const runId = `steer-interrupt-failed-${Date.now().toString(36)}`;
-		const asyncDir = path.join(ASYNC_DIR, runId);
-		writeStatus(asyncDir, runningStatus(runId));
-		try {
-			let request: SteerRequest | undefined;
-			const action = steerAsyncRun({
-				state: createState(),
-				runId,
-				message: "correct course",
-				location: { asyncDir },
-				ackTimeoutMs: 25,
-				onRequestQueued: (requestPath) => {
-					request = JSON.parse(fs.readFileSync(requestPath, "utf-8")) as SteerRequest;
-					const routed = runningStatus(runId);
-					projectRequest(routed, request, ["routed"]);
-					writeStatus(asyncDir, routed);
-				},
-				kill: (_pid, signal) => {
-					if (signal === 0) return true;
-					const error = new Error("runner disappeared") as NodeJS.ErrnoException;
-					error.code = "ESRCH";
-					throw error;
-				},
-				recover: async () => successResult("replacement"),
-			});
-			const result = await action;
-			assert.ok(request);
-			assert.equal(result.isError, true);
-			assert.match(result.content[0]!.text, /Failed to commit steering recovery interrupt/);
-			const recoveryDir = path.join(asyncDir, "control", "steer-recovery");
-			assert.equal(fs.existsSync(path.join(recoveryDir, "claim.json")), false);
-			assert.equal(fs.existsSync(path.join(recoveryDir, `${Buffer.from(request.id).toString("base64url")}.json`)), false);
-		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
-		}
-	});
-
 	it("keeps the claim after an unconfirmed pause to prevent delayed duplicate recovery", async () => {
 		const runId = `steer-pause-unconfirmed-${Date.now().toString(36)}`;
 		const asyncDir = path.join(ASYNC_DIR, runId);
 		writeStatus(asyncDir, runningStatus(runId));
+		const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
 		try {
 			const action = steerAsyncRun({
 				state: createState(), runId, message: "correct course", location: { asyncDir },
-				ackTimeoutMs: 25, recoveryTimeoutMs: 50, kill: () => true,
+				ackTimeoutMs: 25,
+				recoveryTimeoutMs: 50,
+				kill: (pid, signal) => { kills.push({ pid, signal }); return true; },
 				onRequestQueued: (requestPath) => {
 					const request = JSON.parse(fs.readFileSync(requestPath, "utf-8")) as SteerRequest;
 					const routed = runningStatus(runId);
@@ -293,6 +258,8 @@ describe("acknowledged steering action", () => {
 			const result = await action;
 			assert.equal(result.isError, true);
 			assert.match(result.content[0]!.text, /claim remains committed to prevent a delayed duplicate/);
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
+			assert.deepEqual(kills, [{ pid: 12345, signal: 0 }]);
 			assert.equal(fs.existsSync(path.join(asyncDir, "control", "steer-recovery", "claim.json")), true);
 		} finally {
 			fs.rmSync(asyncDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes #925.

Async interrupt delivery now uses the run control inbox as the authoritative path and no longer sends `SIGUSR2` or `SIGBREAK` to an unverified PID. Async workflow interrupt fails closed and points users to `stop`, because workflow status can store the shared host PID and has no runner inbox consumer.

The change keeps stale PID liveness checks before reporting success for real async runner interrupts, and leaves `stop` as the explicit force action.

## Validation

- `node --experimental-strip-types --test test/unit/async-interrupt-action.test.ts test/unit/control-channel.test.ts test/unit/steering-action.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- `git diff --check`
- fresh read-only review on `d48ded0df1b1152648c04dc9d8763792ab62e3b2`

## Credit

Thanks to @kdasme for the report in #925.
