### PR TITLE
fix: wait for settled steering idle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Keep child steering inbox `auto` requests queued between `agent_end` and `agent_settled` so settlement-time guidance is not sent as an idle prompt too early. Thanks to @jtac for #928.
+
 ## [0.45.1] - 2026-08-09
 
 ### Changed

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -30,6 +30,7 @@ import { drainOutstandingWork } from "../background/auto-drain.ts";
 const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
 const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
 export const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
+const STEERING_LEGACY_SETTLE_FALLBACK_MS = 1000;
 
 const STRUCTURED_OUTPUT_INSTRUCTIONS = [
 	"This subagent step has a strict structured output contract.",
@@ -330,7 +331,7 @@ function registerToolBudget(pi: ExtensionAPI, budget: ResolvedToolBudget | undef
 
 export function registerSteeringInbox(
 	pi: ExtensionAPI,
-	deps: { watch?: typeof fs.watch; nativeRealpath?: (filePath: string) => string } = {},
+	deps: { watch?: typeof fs.watch; nativeRealpath?: (filePath: string) => string; legacySettleFallbackMs?: number } = {},
 ): void {
 	const steerInbox = process.env[SUBAGENT_STEER_INBOX_ENV]?.trim();
 	if (!steerInbox) return;
@@ -343,11 +344,14 @@ export function registerSteeringInbox(
 	let disposed = false;
 	let agentRunning = false;
 	let inTurn = false;
+	let awaitingSettlement = false;
 	let flushing = false;
 	let started = false;
 	let canSteer = typeof sendUserMessage === "function";
 	let watcher: fs.FSWatcher | undefined;
 	let interval: NodeJS.Timeout | undefined;
+	let settleFallback: NodeJS.Timeout | undefined;
+	const legacySettleFallbackMs = deps.legacySettleFallbackMs ?? STEERING_LEGACY_SETTLE_FALLBACK_MS;
 	const acknowledge = (request: SteerRequest, state: "delivered" | "queued" | "failed", message: string, deliveryStatus?: SteerDeliveryStatus): void => {
 		if (!ackDir || !Number.isInteger(childIndex) || childIndex < 0) return;
 		writeSteerAckAt(steerAckPathFromDir(ackDir, request.id), {
@@ -375,7 +379,8 @@ export function registerSteeringInbox(
 					continue;
 				}
 				const requestedMode = request.mode ?? "steer";
-				const delivery = requestedMode === "follow_up" || (requestedMode === "auto" && inTurn) ? "followUp" as const : "steer" as const;
+				const autoCanUseIdle = requestedMode === "auto" && !agentRunning && !awaitingSettlement;
+				const delivery = requestedMode === "follow_up" || (requestedMode === "auto" && (inTurn || awaitingSettlement)) ? "followUp" as const : "steer" as const;
 				const pendingFollowUps = [...pending.values()].reduce((count, entries) => count + entries.filter((entry) => entry.deliveryStatus === "queued").length, 0);
 				if (delivery === "followUp" && queued.length + pendingFollowUps >= MAX_STEER_QUEUE_SIZE) {
 					acknowledge(request, "failed", `Follow-up queue is full (${MAX_STEER_QUEUE_SIZE} messages).`);
@@ -386,7 +391,7 @@ export function registerSteeringInbox(
 				entries.push({ request, deliveryStatus: delivery === "followUp" ? "queued" : "delivered" });
 				pending.set(formatted, entries);
 				try {
-					sendUserMessage(formatted, requestedMode === "auto" && !agentRunning ? undefined : { deliverAs: delivery });
+					sendUserMessage(formatted, autoCanUseIdle ? undefined : { deliverAs: delivery });
 				} catch (error) {
 					entries.pop();
 					if (entries.length === 0) pending.delete(formatted);
@@ -440,14 +445,59 @@ export function registerSteeringInbox(
 		flush();
 		return undefined;
 	};
+	const clearSettleFallback = (): void => {
+		if (!settleFallback) return;
+		clearTimeout(settleFallback);
+		settleFallback = undefined;
+	};
+	const markSettled = (): undefined => {
+		clearSettleFallback();
+		agentRunning = false;
+		inTurn = false;
+		awaitingSettlement = false;
+		return activate();
+	};
+	const armLegacySettleFallback = (): void => {
+		clearSettleFallback();
+		settleFallback = setTimeout(() => {
+			settleFallback = undefined;
+			if (disposed || !awaitingSettlement) return;
+			agentRunning = false;
+			inTurn = false;
+			awaitingSettlement = false;
+			activate();
+		}, legacySettleFallbackMs);
+		settleFallback.unref?.();
+	};
 
 	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown, ctx?: unknown) => unknown) => void;
 	// Register input before the watcher so an accepted extension input cannot race request dispatch.
 	onRuntimeEvent("input", onInput);
 	onRuntimeEvent("session_start", () => start());
-	onRuntimeEvent("agent_start", () => { agentRunning = true; return activate(); });
-	onRuntimeEvent("agent_end", () => { agentRunning = false; inTurn = false; return activate(); });
+	onRuntimeEvent("agent_start", () => {
+		clearSettleFallback();
+		agentRunning = true;
+		awaitingSettlement = false;
+		return activate();
+	});
+	onRuntimeEvent("agent_end", (event) => {
+		inTurn = false;
+		if ((event as { willRetry?: unknown } | undefined)?.willRetry === true) {
+			clearSettleFallback();
+			agentRunning = true;
+			awaitingSettlement = true;
+			return activate();
+		}
+		agentRunning = true;
+		awaitingSettlement = true;
+		armLegacySettleFallback();
+		return activate();
+	});
+	onRuntimeEvent("agent_settled", markSettled);
 	onRuntimeEvent("turn_start", () => {
+		clearSettleFallback();
+		agentRunning = true;
+		awaitingSettlement = false;
 		inTurn = true;
 		const next = queued.findIndex((entry) => entry.ready);
 		if (next >= 0) {
@@ -467,6 +517,7 @@ export function registerSteeringInbox(
 	onRuntimeEvent("session_shutdown", () => {
 		for (const entry of queued) acknowledge(entry.request, "failed", "Run ended before queued follow-up delivery.", "queued");
 		disposed = true;
+		clearSettleFallback();
 		try { watcher?.close(); } catch {}
 		if (interval) clearInterval(interval);
 	});

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -349,6 +349,105 @@ describe("subagent prompt runtime", () => {
 		}
 	});
 
+	it("queues auto steering after agent_end until agent_settled", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-settled-steering-runtime-"));
+		try {
+			const inbox = path.join(dir, "inbox");
+			process.env[SUBAGENT_STEER_INBOX_ENV] = inbox;
+			process.env[SUBAGENT_STEER_ACK_DIR_ENV] = path.join(dir, "control", "steer-acks", "0");
+			process.env[SUBAGENT_CHILD_INDEX_ENV] = "0";
+			const handlers = new Map<string, (payload?: unknown) => unknown>();
+			const sent: Array<{ content: string; deliverAs?: string }> = [];
+			registerSteeringInbox({
+				on(event: string, handler: (payload?: unknown) => unknown) { handlers.set(event, handler); },
+				sendUserMessage(content: string, options?: { deliverAs?: string }) { sent.push({ content, deliverAs: options?.deliverAs }); },
+			} as never);
+			handlers.get("session_start")?.({});
+			handlers.get("agent_start")?.({});
+			handlers.get("turn_start")?.({});
+			handlers.get("turn_end")?.({});
+			handlers.get("agent_end")?.({ willRetry: false });
+
+			writeSteerRequestToDir(inbox, { type: "steer", id: "settling-auto", ts: 1, message: "Wait for settled.", mode: "auto" });
+			handlers.get("message_start")?.({});
+			assert.equal(sent[0]?.deliverAs, "followUp");
+			handlers.get("input")?.({ source: "extension", streamingBehavior: "followUp", text: sent[0]?.content });
+			assert.equal(consumeSteerAcks(dir)[0]?.state, "queued");
+
+			handlers.get("agent_settled")?.({});
+			writeSteerRequestToDir(inbox, { type: "steer", id: "settled-auto", ts: 2, message: "Now idle.", mode: "auto" });
+			handlers.get("message_start")?.({});
+			assert.equal(sent[1]?.deliverAs, undefined);
+			handlers.get("input")?.({ source: "extension", text: sent[1]?.content });
+			assert.equal(consumeSteerAcks(dir)[0]?.deliveryStatus, "delivered");
+			handlers.get("session_shutdown")?.({});
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps auto steering queued while agent_end will retry", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-retry-steering-runtime-"));
+		try {
+			const inbox = path.join(dir, "inbox");
+			process.env[SUBAGENT_STEER_INBOX_ENV] = inbox;
+			process.env[SUBAGENT_STEER_ACK_DIR_ENV] = path.join(dir, "control", "steer-acks", "0");
+			process.env[SUBAGENT_CHILD_INDEX_ENV] = "0";
+			const handlers = new Map<string, (payload?: unknown) => unknown>();
+			const sent: Array<{ content: string; deliverAs?: string }> = [];
+			registerSteeringInbox({
+				on(event: string, handler: (payload?: unknown) => unknown) { handlers.set(event, handler); },
+				sendUserMessage(content: string, options?: { deliverAs?: string }) { sent.push({ content, deliverAs: options?.deliverAs }); },
+			} as never);
+			handlers.get("session_start")?.({});
+			handlers.get("agent_start")?.({});
+			handlers.get("turn_start")?.({});
+			handlers.get("turn_end")?.({});
+			handlers.get("agent_end")?.({ willRetry: true });
+
+			writeSteerRequestToDir(inbox, { type: "steer", id: "retry-auto", ts: 1, message: "Keep this guidance.", mode: "auto" });
+			handlers.get("message_start")?.({});
+			assert.equal(sent[0]?.deliverAs, "followUp");
+			handlers.get("input")?.({ source: "extension", streamingBehavior: "followUp", text: sent[0]?.content });
+			assert.equal(consumeSteerAcks(dir)[0]?.state, "queued");
+
+			handlers.get("turn_start")?.({});
+			const delivered = consumeSteerAcks(dir)[0];
+			assert.equal(delivered?.requestId, "retry-auto");
+			assert.equal(delivered?.deliveryStatus, "delivered");
+			handlers.get("session_shutdown")?.({});
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to idle delivery for runtimes without agent_settled", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-legacy-steering-runtime-"));
+		try {
+			const inbox = path.join(dir, "inbox");
+			process.env[SUBAGENT_STEER_INBOX_ENV] = inbox;
+			const handlers = new Map<string, (payload?: unknown) => unknown>();
+			const sent: Array<{ content: string; deliverAs?: string }> = [];
+			registerSteeringInbox({
+				on(event: string, handler: (payload?: unknown) => unknown) { handlers.set(event, handler); },
+				sendUserMessage(content: string, options?: { deliverAs?: string }) { sent.push({ content, deliverAs: options?.deliverAs }); },
+			} as never, { legacySettleFallbackMs: 5 });
+			handlers.get("session_start")?.({});
+			handlers.get("agent_start")?.({});
+			handlers.get("turn_start")?.({});
+			handlers.get("turn_end")?.({});
+			handlers.get("agent_end")?.({ willRetry: false });
+			await new Promise((resolve) => setTimeout(resolve, 20));
+
+			writeSteerRequestToDir(inbox, { type: "steer", id: "legacy-auto", ts: 1, message: "Legacy idle.", mode: "auto" });
+			handlers.get("message_start")?.({});
+			assert.equal(sent[0]?.deliverAs, undefined);
+			handlers.get("session_shutdown")?.({});
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("does not acknowledge sendUserMessage until the correlated Pi input event arrives", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-steering-ack-runtime-"));
 		try {


### PR DESCRIPTION
Summary:
- keep child steering `auto` requests in follow-up delivery between `agent_end` and `agent_settled`
- handle `agent_end.willRetry === true` as still settling/running
- add a bounded legacy fallback for runtimes that do not emit `agent_settled`
- add focused steering lifecycle regressions and changelog credit

Validation:
- `node --experimental-strip-types --test test/unit/subagent-prompt-runtime.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- `git diff --check`
- fresh read-only review: no issues found (`/tmp/pi-subagents-928-fresh-review.md`)

Closes #928
