### PR TITLE
fix: omit undefined workflow return fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Omit undefined object fields from `workflowScript` return values so completed `runs.all` results are not discarded when callers include unsupported fields such as `status` (#930).
 - Keep child steering inbox `auto` requests queued between `agent_end` and `agent_settled` so settlement-time guidance is not sent as an idle prompt too early. Thanks to @jtac for #928.
 
 ## [0.45.1] - 2026-08-09

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -139,6 +139,25 @@ function assertJsonValue(value, path = "emit", seen = new Set()) {
   seen.delete(value);
 }
 
+function isPlainWorkflowObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === null || prototype === Object.prototype || prototype === contextObjectPrototype;
+}
+
+function omitUndefinedWorkflowValues(value, seen = new Set()) {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return value;
+  seen.add(value);
+  const normalized = Array.isArray(value)
+    ? value.map((entry) => entry === undefined ? null : omitUndefinedWorkflowValues(entry, seen))
+    : isPlainWorkflowObject(value) && Object.getOwnPropertySymbols(value).length === 0
+      ? Object.fromEntries(Object.entries(value).flatMap(([key, entry]) => entry === undefined ? [] : [[key, omitUndefinedWorkflowValues(entry, seen)]]))
+      : value;
+  seen.delete(value);
+  return normalized;
+}
+
 parentPort.on("message", async (message) => {
   if (message.type === "response") {
     const entry = pending.get(message.callId);
@@ -163,7 +182,7 @@ parentPort.on("message", async (message) => {
       return;
     }
     const value = await compiled.runInContext(context);
-    const persistedValue = value === undefined ? null : value;
+    const persistedValue = value === undefined ? null : omitUndefinedWorkflowValues(value);
     assertJsonValue(persistedValue, "return");
     parentPort.postMessage({ type: "complete", value: persistedValue });
   } catch (error) {

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -340,6 +340,25 @@ describe("scripted workflow runtime", () => {
 		});
 	});
 
+	it("omits undefined fields in workflow return objects", async () => {
+		const result = await runWorkflowScript({
+			script: `
+				const children = await runs.all([{ key: "review", agent: "worker", task: "review" }]);
+				return children.map((child) => ({
+					key: child.key,
+					status: child.status,
+					output: child.output,
+					values: [child.status],
+				}));
+			`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "completed", artifactPaths: [], results: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		assert.deepEqual(result.value, [{ key: "review", output: "completed", values: [null] }]);
+	});
+
 	it("rejects non-plain child result values", async () => {
 		await assert.rejects(
 			runWorkflowScript({
@@ -522,6 +541,7 @@ describe("scripted workflow runtime", () => {
 			`return 1n;`,
 			`return new (class Object { constructor() { this.ok = true; } })();`,
 			`const value = {}; value.self = value; return value;`,
+			`const value = {}; value[Symbol("hidden")] = true; return value;`,
 			`return () => true;`,
 			`return Symbol("value");`,
 		];


### PR DESCRIPTION
## Summary

Omit undefined plain-object fields from persisted `workflowScript` return values. This keeps completed `runs.all(...)` results usable when callers include unsupported fields such as `status`.

Fixes #930.

## Validation

- `node --experimental-strip-types --test test/unit/scripted-workflow.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- `git diff --check`

## Review

Fresh read-only review found one blocker around symbol-keyed properties being dropped before validation. The fix now preserves symbol-keyed objects for validation, and the invalid-return test covers that contract.
