### PR TITLE
Fix auto steering between agent_end and agent_settled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Keep `auto` steering queued between `agent_end` and `agent_settled`, including retrying turns, while retaining immediate settled delivery and a bounded legacy fallback. (#928)
+
 ## [0.45.1] - 2026-08-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- Keep `auto` steering queued between `agent_end` and `agent_settled`, including retrying turns, while retaining immediate settled delivery and a bounded legacy fallback. (#928)
+- Keep `auto` steering on safe follow-up semantics after `agent_end` until a real `agent_settled`, while preserving explicit steer, immediate settled delivery, and legacy progress without inferring idle from elapsed time. (#928)
 
 ## [0.45.1] - 2026-08-09
 

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -67,6 +67,13 @@ const SUBAGENT_ORCHESTRATION_SKILL_NAME_PATTERN = /<name>\s*pi-subagents\s*<\/na
 const PROJECT_CONTEXT_HEADER = "\n\n# Project Context\n\nProject-specific instructions and guidelines:\n\n";
 const SKILLS_HEADER = "\n\nThe following skills provide specialized instructions for specific tasks.";
 const DATE_HEADER = "\nCurrent date:";
+const LEGACY_AGENT_SETTLEMENT_FALLBACK_MS = 1_000;
+
+function scheduleLegacyAgentSettlementFallback(callback: () => void): () => void {
+	const timer = setTimeout(callback, LEGACY_AGENT_SETTLEMENT_FALLBACK_MS);
+	timer.unref?.();
+	return () => clearTimeout(timer);
+}
 
 function readBooleanEnv(name: string): boolean | undefined {
 	const value = process.env[name];
@@ -330,7 +337,11 @@ function registerToolBudget(pi: ExtensionAPI, budget: ResolvedToolBudget | undef
 
 export function registerSteeringInbox(
 	pi: ExtensionAPI,
-	deps: { watch?: typeof fs.watch; nativeRealpath?: (filePath: string) => string } = {},
+	deps: {
+		watch?: typeof fs.watch;
+		nativeRealpath?: (filePath: string) => string;
+		scheduleLegacySettlementFallback?: (callback: () => void) => () => void;
+	} = {},
 ): void {
 	const steerInbox = process.env[SUBAGENT_STEER_INBOX_ENV]?.trim();
 	if (!steerInbox) return;
@@ -343,6 +354,8 @@ export function registerSteeringInbox(
 	let disposed = false;
 	let agentRunning = false;
 	let inTurn = false;
+	let awaitingAgentSettlement = false;
+	let cancelLegacySettlementFallback: (() => void) | undefined;
 	let flushing = false;
 	let started = false;
 	let canSteer = typeof sendUserMessage === "function";
@@ -375,7 +388,7 @@ export function registerSteeringInbox(
 					continue;
 				}
 				const requestedMode = request.mode ?? "steer";
-				const delivery = requestedMode === "follow_up" || (requestedMode === "auto" && inTurn) ? "followUp" as const : "steer" as const;
+				const delivery = requestedMode === "follow_up" || (requestedMode === "auto" && (inTurn || awaitingAgentSettlement)) ? "followUp" as const : "steer" as const;
 				const pendingFollowUps = [...pending.values()].reduce((count, entries) => count + entries.filter((entry) => entry.deliveryStatus === "queued").length, 0);
 				if (delivery === "followUp" && queued.length + pendingFollowUps >= MAX_STEER_QUEUE_SIZE) {
 					acknowledge(request, "failed", `Follow-up queue is full (${MAX_STEER_QUEUE_SIZE} messages).`);
@@ -440,15 +453,53 @@ export function registerSteeringInbox(
 		flush();
 		return undefined;
 	};
+	const cancelSettlementFallback = (): void => {
+		cancelLegacySettlementFallback?.();
+		cancelLegacySettlementFallback = undefined;
+	};
+	const settleAgent = (): undefined => {
+		cancelSettlementFallback();
+		agentRunning = false;
+		inTurn = false;
+		awaitingAgentSettlement = false;
+		return activate();
+	};
+	const armLegacySettlementFallback = (): void => {
+		cancelSettlementFallback();
+		const schedule = deps.scheduleLegacySettlementFallback ?? scheduleLegacyAgentSettlementFallback;
+		cancelLegacySettlementFallback = schedule(() => {
+			cancelLegacySettlementFallback = undefined;
+			if (disposed || !awaitingAgentSettlement) return;
+			agentRunning = false;
+			inTurn = false;
+			awaitingAgentSettlement = false;
+			activate();
+		});
+	};
 
 	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown, ctx?: unknown) => unknown) => void;
 	// Register input before the watcher so an accepted extension input cannot race request dispatch.
 	onRuntimeEvent("input", onInput);
 	onRuntimeEvent("session_start", () => start());
-	onRuntimeEvent("agent_start", () => { agentRunning = true; return activate(); });
-	onRuntimeEvent("agent_end", () => { agentRunning = false; inTurn = false; return activate(); });
+	onRuntimeEvent("agent_start", () => {
+		cancelSettlementFallback();
+		agentRunning = true;
+		return activate();
+	});
+	onRuntimeEvent("agent_end", (event) => {
+		agentRunning = true;
+		inTurn = false;
+		awaitingAgentSettlement = true;
+		if ((event as { willRetry?: unknown } | undefined)?.willRetry === true) cancelSettlementFallback();
+		else armLegacySettlementFallback();
+		return activate();
+	});
+	onRuntimeEvent("agent_settled", () => settleAgent());
 	onRuntimeEvent("turn_start", () => {
+		cancelSettlementFallback();
+		agentRunning = true;
 		inTurn = true;
+		awaitingAgentSettlement = false;
 		const next = queued.findIndex((entry) => entry.ready);
 		if (next >= 0) {
 			const [entry] = queued.splice(next, 1);
@@ -467,6 +518,7 @@ export function registerSteeringInbox(
 	onRuntimeEvent("session_shutdown", () => {
 		for (const entry of queued) acknowledge(entry.request, "failed", "Run ended before queued follow-up delivery.", "queued");
 		disposed = true;
+		cancelSettlementFallback();
 		try { watcher?.close(); } catch {}
 		if (interval) clearInterval(interval);
 	});

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -67,14 +67,6 @@ const SUBAGENT_ORCHESTRATION_SKILL_NAME_PATTERN = /<name>\s*pi-subagents\s*<\/na
 const PROJECT_CONTEXT_HEADER = "\n\n# Project Context\n\nProject-specific instructions and guidelines:\n\n";
 const SKILLS_HEADER = "\n\nThe following skills provide specialized instructions for specific tasks.";
 const DATE_HEADER = "\nCurrent date:";
-const LEGACY_AGENT_SETTLEMENT_FALLBACK_MS = 1_000;
-
-function scheduleLegacyAgentSettlementFallback(callback: () => void): () => void {
-	const timer = setTimeout(callback, LEGACY_AGENT_SETTLEMENT_FALLBACK_MS);
-	timer.unref?.();
-	return () => clearTimeout(timer);
-}
-
 function readBooleanEnv(name: string): boolean | undefined {
 	const value = process.env[name];
 	if (value === undefined) return undefined;
@@ -340,7 +332,6 @@ export function registerSteeringInbox(
 	deps: {
 		watch?: typeof fs.watch;
 		nativeRealpath?: (filePath: string) => string;
-		scheduleLegacySettlementFallback?: (callback: () => void) => () => void;
 	} = {},
 ): void {
 	const steerInbox = process.env[SUBAGENT_STEER_INBOX_ENV]?.trim();
@@ -355,7 +346,6 @@ export function registerSteeringInbox(
 	let agentRunning = false;
 	let inTurn = false;
 	let awaitingAgentSettlement = false;
-	let cancelLegacySettlementFallback: (() => void) | undefined;
 	let flushing = false;
 	let started = false;
 	let canSteer = typeof sendUserMessage === "function";
@@ -453,28 +443,11 @@ export function registerSteeringInbox(
 		flush();
 		return undefined;
 	};
-	const cancelSettlementFallback = (): void => {
-		cancelLegacySettlementFallback?.();
-		cancelLegacySettlementFallback = undefined;
-	};
 	const settleAgent = (): undefined => {
-		cancelSettlementFallback();
 		agentRunning = false;
 		inTurn = false;
 		awaitingAgentSettlement = false;
 		return activate();
-	};
-	const armLegacySettlementFallback = (): void => {
-		cancelSettlementFallback();
-		const schedule = deps.scheduleLegacySettlementFallback ?? scheduleLegacyAgentSettlementFallback;
-		cancelLegacySettlementFallback = schedule(() => {
-			cancelLegacySettlementFallback = undefined;
-			if (disposed || !awaitingAgentSettlement) return;
-			agentRunning = false;
-			inTurn = false;
-			awaitingAgentSettlement = false;
-			activate();
-		});
 	};
 
 	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown, ctx?: unknown) => unknown) => void;
@@ -482,24 +455,19 @@ export function registerSteeringInbox(
 	onRuntimeEvent("input", onInput);
 	onRuntimeEvent("session_start", () => start());
 	onRuntimeEvent("agent_start", () => {
-		cancelSettlementFallback();
 		agentRunning = true;
 		return activate();
 	});
-	onRuntimeEvent("agent_end", (event) => {
+	onRuntimeEvent("agent_end", () => {
 		agentRunning = true;
 		inTurn = false;
 		awaitingAgentSettlement = true;
-		if ((event as { willRetry?: unknown } | undefined)?.willRetry === true) cancelSettlementFallback();
-		else armLegacySettlementFallback();
 		return activate();
 	});
 	onRuntimeEvent("agent_settled", () => settleAgent());
 	onRuntimeEvent("turn_start", () => {
-		cancelSettlementFallback();
 		agentRunning = true;
 		inTurn = true;
-		awaitingAgentSettlement = false;
 		const next = queued.findIndex((entry) => entry.ready);
 		if (next >= 0) {
 			const [entry] = queued.splice(next, 1);
@@ -518,7 +486,6 @@ export function registerSteeringInbox(
 	onRuntimeEvent("session_shutdown", () => {
 		for (const entry of queued) acknowledge(entry.request, "failed", "Run ended before queued follow-up delivery.", "queued");
 		disposed = true;
-		cancelSettlementFallback();
 		try { watcher?.close(); } catch {}
 		if (interval) clearInterval(interval);
 	});

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -141,9 +141,6 @@ function createSteeringLifecycleHarness(prefix: string): {
 	inbox: string;
 	handlers: Map<string, (payload?: unknown) => unknown>;
 	sent: Array<{ content: string; deliverAs?: string }>;
-	fallbackScheduled(): boolean;
-	fallbackCancelled(): boolean;
-	runFallback(): void;
 	cleanup(): void;
 } {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -153,9 +150,6 @@ function createSteeringLifecycleHarness(prefix: string): {
 	process.env[SUBAGENT_CHILD_INDEX_ENV] = "0";
 	const handlers = new Map<string, (payload?: unknown) => unknown>();
 	const sent: Array<{ content: string; deliverAs?: string }> = [];
-	let fallback: (() => void) | undefined;
-	let fallbackActive = false;
-	let cancelled = false;
 	const fakeWatcher = { on() { return fakeWatcher; }, close() {} } as fs.FSWatcher;
 
 	registerSteeringInbox({
@@ -163,33 +157,16 @@ function createSteeringLifecycleHarness(prefix: string): {
 		sendUserMessage(content: string, options?: { deliverAs?: string }) { sent.push({ content, deliverAs: options?.deliverAs }); },
 	} as never, {
 		watch: (() => fakeWatcher) as typeof fs.watch,
-		scheduleLegacySettlementFallback(callback) {
-			fallback = callback;
-			fallbackActive = true;
-			cancelled = false;
-			return () => {
-				if (!fallbackActive) return;
-				fallbackActive = false;
-				cancelled = true;
-			};
-		},
 	});
-	handlers.get("session_start")?.({});
+	handlers.get("session_start")?.({ type: "session_start" });
 
 	return {
 		dir,
 		inbox,
 		handlers,
 		sent,
-		fallbackScheduled: () => fallbackActive,
-		fallbackCancelled: () => cancelled,
-		runFallback() {
-			assert.ok(fallbackActive && fallback, "legacy settlement fallback should be scheduled");
-			fallbackActive = false;
-			fallback();
-		},
 		cleanup() {
-			handlers.get("session_shutdown")?.({});
+			handlers.get("session_shutdown")?.({ type: "session_shutdown" });
 			fs.rmSync(dir, { recursive: true, force: true });
 		},
 	};
@@ -408,14 +385,32 @@ describe("subagent prompt runtime", () => {
 		}
 	});
 
-	it("queues auto guidance from agent_end until agent_settled and delivers it once", () => {
+	it("keeps delayed post-agent auto guidance safe beyond the legacy timeout", (context) => {
+		context.mock.timers.enable({ apis: ["setTimeout"] });
+		const runtime = createSteeringLifecycleHarness("subagent-agent-delayed-runtime-");
+		try {
+			runtime.handlers.get("agent_start")?.({ type: "agent_start" });
+			runtime.handlers.get("turn_start")?.({ type: "turn_start", turnIndex: 0, timestamp: 1 });
+			runtime.handlers.get("turn_end")?.({ type: "turn_end", turnIndex: 0, message: undefined });
+			runtime.handlers.get("agent_end")?.({ type: "agent_end", messages: [] });
+			context.mock.timers.tick(1_001);
+
+			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "delayed-gap", ts: 1, message: "Wait for the real continuation.", mode: "auto" });
+			runtime.handlers.get("message_start")?.({});
+			assert.equal(runtime.sent.length, 1);
+			assert.equal(runtime.sent[0]?.deliverAs, "followUp");
+		} finally {
+			runtime.cleanup();
+		}
+	});
+
+	it("queues auto guidance until a late agent_settled event and delivers it once", () => {
 		const runtime = createSteeringLifecycleHarness("subagent-agent-settled-runtime-");
 		try {
-			runtime.handlers.get("agent_start")?.({});
-			runtime.handlers.get("turn_start")?.({});
-			runtime.handlers.get("turn_end")?.({});
-			runtime.handlers.get("agent_end")?.({ willRetry: false });
-			assert.equal(runtime.fallbackScheduled(), true);
+			runtime.handlers.get("agent_start")?.({ type: "agent_start" });
+			runtime.handlers.get("turn_start")?.({ type: "turn_start", turnIndex: 0, timestamp: 1 });
+			runtime.handlers.get("turn_end")?.({ type: "turn_end", turnIndex: 0 });
+			runtime.handlers.get("agent_end")?.({ type: "agent_end", messages: [] });
 
 			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "settlement-gap", ts: 1, message: "Use the settled result.", mode: "auto" });
 			runtime.handlers.get("message_start")?.({});
@@ -424,11 +419,10 @@ describe("subagent prompt runtime", () => {
 			runtime.handlers.get("input")?.({ source: "extension", streamingBehavior: "followUp", text: runtime.sent[0]?.content });
 			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "queued");
 
-			assert.ok(runtime.handlers.has("agent_settled"));
-			runtime.handlers.get("agent_settled")?.({});
-			assert.equal(runtime.fallbackCancelled(), true);
+			runtime.handlers.get("message_update")?.({});
+			runtime.handlers.get("agent_settled")?.({ type: "agent_settled" });
 			assert.equal(runtime.sent.length, 1);
-			runtime.handlers.get("turn_start")?.({});
+			runtime.handlers.get("turn_start")?.({ type: "turn_start", turnIndex: 1, timestamp: 2 });
 			const delivered = consumeSteerAcks(runtime.dir);
 			assert.equal(delivered.length, 1);
 			assert.equal(delivered[0]?.requestId, "settlement-gap");
@@ -439,14 +433,13 @@ describe("subagent prompt runtime", () => {
 		}
 	});
 
-	it("keeps retrying agent_end auto guidance queued across the next turn", () => {
+	it("keeps real-shape agent_end auto guidance queued across a retry turn", () => {
 		const runtime = createSteeringLifecycleHarness("subagent-agent-retry-runtime-");
 		try {
-			runtime.handlers.get("agent_start")?.({});
-			runtime.handlers.get("turn_start")?.({});
-			runtime.handlers.get("turn_end")?.({});
-			runtime.handlers.get("agent_end")?.({ willRetry: true });
-			assert.equal(runtime.fallbackScheduled(), false);
+			runtime.handlers.get("agent_start")?.({ type: "agent_start" });
+			runtime.handlers.get("turn_start")?.({ type: "turn_start", turnIndex: 0, timestamp: 1 });
+			runtime.handlers.get("turn_end")?.({ type: "turn_end", turnIndex: 0 });
+			runtime.handlers.get("agent_end")?.({ type: "agent_end", messages: [] });
 
 			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "retry-gap", ts: 1, message: "Keep this for the retry.", mode: "auto" });
 			runtime.handlers.get("message_start")?.({});
@@ -455,26 +448,36 @@ describe("subagent prompt runtime", () => {
 			runtime.handlers.get("input")?.({ source: "extension", streamingBehavior: "followUp", text: runtime.sent[0]?.content });
 			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "queued");
 
-			runtime.handlers.get("agent_start")?.({});
-			runtime.handlers.get("turn_start")?.({});
+			runtime.handlers.get("agent_start")?.({ type: "agent_start" });
+			runtime.handlers.get("turn_start")?.({ type: "turn_start", turnIndex: 1, timestamp: 2 });
 			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "delivered");
 			assert.equal(runtime.sent.length, 1);
-			runtime.handlers.get("turn_end")?.({});
-			runtime.handlers.get("agent_end")?.({ willRetry: false });
-			runtime.handlers.get("agent_settled")?.({});
-			assert.equal(runtime.sent.length, 1);
+			runtime.handlers.get("turn_end")?.({ type: "turn_end", turnIndex: 1 });
+			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "retry-post-turn", ts: 2, message: "Remain safe before settlement.", mode: "auto" });
+			runtime.handlers.get("message_start")?.({});
+			assert.equal(runtime.sent[1]?.deliverAs, "followUp");
+			runtime.handlers.get("input")?.({ source: "extension", streamingBehavior: "followUp", text: runtime.sent[1]?.content });
+			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "queued");
+
+			runtime.handlers.get("agent_end")?.({ type: "agent_end", messages: [] });
+			runtime.handlers.get("agent_settled")?.({ type: "agent_settled" });
+			runtime.handlers.get("turn_start")?.({ type: "turn_start", turnIndex: 2, timestamp: 3 });
+			const retryDelivered = consumeSteerAcks(runtime.dir);
+			assert.equal(retryDelivered[0]?.requestId, "retry-post-turn");
+			assert.equal(retryDelivered[0]?.state, "delivered");
+			assert.equal(runtime.sent.length, 2);
 		} finally {
 			runtime.cleanup();
 		}
 	});
 
-	it("delivers auto guidance immediately after agent_settled", () => {
+	it("delivers auto guidance immediately only after agent_settled", () => {
 		const runtime = createSteeringLifecycleHarness("subagent-agent-idle-runtime-");
 		try {
-			runtime.handlers.get("agent_start")?.({});
-			runtime.handlers.get("agent_end")?.({ willRetry: false });
+			runtime.handlers.get("agent_start")?.({ type: "agent_start" });
+			runtime.handlers.get("agent_end")?.({ type: "agent_end", messages: [] });
 			assert.ok(runtime.handlers.has("agent_settled"));
-			runtime.handlers.get("agent_settled")?.({});
+			runtime.handlers.get("agent_settled")?.({ type: "agent_settled" });
 
 			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "settled-idle", ts: 1, message: "Deliver between turns.", mode: "auto" });
 			runtime.handlers.get("message_start")?.({});
@@ -489,20 +492,43 @@ describe("subagent prompt runtime", () => {
 		}
 	});
 
-	it("uses a deterministic bounded fallback when agent_settled is unavailable", () => {
+	it("lets legacy runtimes progress through safe follow-up without agent_settled", () => {
 		const runtime = createSteeringLifecycleHarness("subagent-agent-legacy-runtime-");
 		try {
-			runtime.handlers.get("agent_start")?.({});
-			runtime.handlers.get("agent_end")?.({ willRetry: false });
-			assert.equal(runtime.fallbackScheduled(), true);
-			runtime.runFallback();
+			runtime.handlers.get("agent_start")?.({ type: "agent_start" });
+			runtime.handlers.get("turn_start")?.({ type: "turn_start", turnIndex: 0, timestamp: 1 });
+			runtime.handlers.get("turn_end")?.({ type: "turn_end", turnIndex: 0 });
+			runtime.handlers.get("agent_end")?.({ type: "agent_end", messages: [] });
 
-			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "legacy-idle", ts: 1, message: "Deliver after fallback.", mode: "auto" });
+			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "legacy-follow-up", ts: 1, message: "Deliver safely without settlement.", mode: "auto" });
 			runtime.handlers.get("message_start")?.({});
 			assert.equal(runtime.sent.length, 1);
-			assert.equal(runtime.sent[0]?.deliverAs, undefined);
-			runtime.handlers.get("input")?.({ source: "extension", streamingBehavior: "steer", text: runtime.sent[0]?.content });
-			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "delivered");
+			assert.equal(runtime.sent[0]?.deliverAs, "followUp");
+			runtime.handlers.get("input")?.({ source: "extension", streamingBehavior: "followUp", text: runtime.sent[0]?.content });
+			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "queued");
+
+			runtime.handlers.get("turn_start")?.({ type: "turn_start", turnIndex: 1, timestamp: 2 });
+			const delivered = consumeSteerAcks(runtime.dir);
+			assert.equal(delivered[0]?.requestId, "legacy-follow-up");
+			assert.equal(delivered[0]?.state, "delivered");
+			runtime.handlers.get("turn_end")?.({ type: "turn_end", turnIndex: 1 });
+
+			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "legacy-late", ts: 2, message: "Stay safe without a settlement event.", mode: "auto" });
+			runtime.handlers.get("message_start")?.({});
+			assert.equal(runtime.sent[1]?.deliverAs, "followUp");
+		} finally {
+			runtime.cleanup();
+		}
+	});
+
+	it("preserves explicit steer delivery while awaiting settlement", () => {
+		const runtime = createSteeringLifecycleHarness("subagent-agent-explicit-steer-runtime-");
+		try {
+			runtime.handlers.get("agent_start")?.({ type: "agent_start" });
+			runtime.handlers.get("agent_end")?.({ type: "agent_end", messages: [] });
+			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "explicit-gap", ts: 1, message: "Interrupt explicitly.", mode: "steer" });
+			runtime.handlers.get("message_start")?.({});
+			assert.equal(runtime.sent[0]?.deliverAs, "steer");
 		} finally {
 			runtime.cleanup();
 		}

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -136,6 +136,65 @@ function setSupervisorEnv(): void {
 	process.env[SUBAGENT_CHILD_INDEX_ENV] = "0";
 }
 
+function createSteeringLifecycleHarness(prefix: string): {
+	dir: string;
+	inbox: string;
+	handlers: Map<string, (payload?: unknown) => unknown>;
+	sent: Array<{ content: string; deliverAs?: string }>;
+	fallbackScheduled(): boolean;
+	fallbackCancelled(): boolean;
+	runFallback(): void;
+	cleanup(): void;
+} {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	const inbox = path.join(dir, "inbox");
+	process.env[SUBAGENT_STEER_INBOX_ENV] = inbox;
+	process.env[SUBAGENT_STEER_ACK_DIR_ENV] = path.join(dir, "control", "steer-acks", "0");
+	process.env[SUBAGENT_CHILD_INDEX_ENV] = "0";
+	const handlers = new Map<string, (payload?: unknown) => unknown>();
+	const sent: Array<{ content: string; deliverAs?: string }> = [];
+	let fallback: (() => void) | undefined;
+	let fallbackActive = false;
+	let cancelled = false;
+	const fakeWatcher = { on() { return fakeWatcher; }, close() {} } as fs.FSWatcher;
+
+	registerSteeringInbox({
+		on(event: string, handler: (payload?: unknown) => unknown) { handlers.set(event, handler); },
+		sendUserMessage(content: string, options?: { deliverAs?: string }) { sent.push({ content, deliverAs: options?.deliverAs }); },
+	} as never, {
+		watch: (() => fakeWatcher) as typeof fs.watch,
+		scheduleLegacySettlementFallback(callback) {
+			fallback = callback;
+			fallbackActive = true;
+			cancelled = false;
+			return () => {
+				if (!fallbackActive) return;
+				fallbackActive = false;
+				cancelled = true;
+			};
+		},
+	});
+	handlers.get("session_start")?.({});
+
+	return {
+		dir,
+		inbox,
+		handlers,
+		sent,
+		fallbackScheduled: () => fallbackActive,
+		fallbackCancelled: () => cancelled,
+		runFallback() {
+			assert.ok(fallbackActive && fallback, "legacy settlement fallback should be scheduled");
+			fallbackActive = false;
+			fallback();
+		},
+		cleanup() {
+			handlers.get("session_shutdown")?.({});
+			fs.rmSync(dir, { recursive: true, force: true });
+		},
+	};
+}
+
 describe("subagent prompt runtime", () => {
 	it("registers no permission hook by default and routes ask only to the watchdog arbiter", async () => {
 		const handlers: Array<(event: { toolName?: string; input?: unknown }, ctx?: unknown) => unknown> = [];
@@ -346,6 +405,106 @@ describe("subagent prompt runtime", () => {
 			assert.match(failed?.message ?? "", /ended before queued follow-up/);
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("queues auto guidance from agent_end until agent_settled and delivers it once", () => {
+		const runtime = createSteeringLifecycleHarness("subagent-agent-settled-runtime-");
+		try {
+			runtime.handlers.get("agent_start")?.({});
+			runtime.handlers.get("turn_start")?.({});
+			runtime.handlers.get("turn_end")?.({});
+			runtime.handlers.get("agent_end")?.({ willRetry: false });
+			assert.equal(runtime.fallbackScheduled(), true);
+
+			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "settlement-gap", ts: 1, message: "Use the settled result.", mode: "auto" });
+			runtime.handlers.get("message_start")?.({});
+			assert.equal(runtime.sent.length, 1);
+			assert.equal(runtime.sent[0]?.deliverAs, "followUp");
+			runtime.handlers.get("input")?.({ source: "extension", streamingBehavior: "followUp", text: runtime.sent[0]?.content });
+			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "queued");
+
+			assert.ok(runtime.handlers.has("agent_settled"));
+			runtime.handlers.get("agent_settled")?.({});
+			assert.equal(runtime.fallbackCancelled(), true);
+			assert.equal(runtime.sent.length, 1);
+			runtime.handlers.get("turn_start")?.({});
+			const delivered = consumeSteerAcks(runtime.dir);
+			assert.equal(delivered.length, 1);
+			assert.equal(delivered[0]?.requestId, "settlement-gap");
+			assert.equal(delivered[0]?.state, "delivered");
+			assert.equal(runtime.sent.length, 1);
+		} finally {
+			runtime.cleanup();
+		}
+	});
+
+	it("keeps retrying agent_end auto guidance queued across the next turn", () => {
+		const runtime = createSteeringLifecycleHarness("subagent-agent-retry-runtime-");
+		try {
+			runtime.handlers.get("agent_start")?.({});
+			runtime.handlers.get("turn_start")?.({});
+			runtime.handlers.get("turn_end")?.({});
+			runtime.handlers.get("agent_end")?.({ willRetry: true });
+			assert.equal(runtime.fallbackScheduled(), false);
+
+			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "retry-gap", ts: 1, message: "Keep this for the retry.", mode: "auto" });
+			runtime.handlers.get("message_start")?.({});
+			assert.equal(runtime.sent.length, 1);
+			assert.equal(runtime.sent[0]?.deliverAs, "followUp");
+			runtime.handlers.get("input")?.({ source: "extension", streamingBehavior: "followUp", text: runtime.sent[0]?.content });
+			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "queued");
+
+			runtime.handlers.get("agent_start")?.({});
+			runtime.handlers.get("turn_start")?.({});
+			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "delivered");
+			assert.equal(runtime.sent.length, 1);
+			runtime.handlers.get("turn_end")?.({});
+			runtime.handlers.get("agent_end")?.({ willRetry: false });
+			runtime.handlers.get("agent_settled")?.({});
+			assert.equal(runtime.sent.length, 1);
+		} finally {
+			runtime.cleanup();
+		}
+	});
+
+	it("delivers auto guidance immediately after agent_settled", () => {
+		const runtime = createSteeringLifecycleHarness("subagent-agent-idle-runtime-");
+		try {
+			runtime.handlers.get("agent_start")?.({});
+			runtime.handlers.get("agent_end")?.({ willRetry: false });
+			assert.ok(runtime.handlers.has("agent_settled"));
+			runtime.handlers.get("agent_settled")?.({});
+
+			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "settled-idle", ts: 1, message: "Deliver between turns.", mode: "auto" });
+			runtime.handlers.get("message_start")?.({});
+			assert.equal(runtime.sent.length, 1);
+			assert.equal(runtime.sent[0]?.deliverAs, undefined);
+			runtime.handlers.get("input")?.({ source: "extension", streamingBehavior: "steer", text: runtime.sent[0]?.content });
+			const delivered = consumeSteerAcks(runtime.dir);
+			assert.equal(delivered[0]?.requestId, "settled-idle");
+			assert.equal(delivered[0]?.state, "delivered");
+		} finally {
+			runtime.cleanup();
+		}
+	});
+
+	it("uses a deterministic bounded fallback when agent_settled is unavailable", () => {
+		const runtime = createSteeringLifecycleHarness("subagent-agent-legacy-runtime-");
+		try {
+			runtime.handlers.get("agent_start")?.({});
+			runtime.handlers.get("agent_end")?.({ willRetry: false });
+			assert.equal(runtime.fallbackScheduled(), true);
+			runtime.runFallback();
+
+			writeSteerRequestToDir(runtime.inbox, { type: "steer", id: "legacy-idle", ts: 1, message: "Deliver after fallback.", mode: "auto" });
+			runtime.handlers.get("message_start")?.({});
+			assert.equal(runtime.sent.length, 1);
+			assert.equal(runtime.sent[0]?.deliverAs, undefined);
+			runtime.handlers.get("input")?.({ source: "extension", streamingBehavior: "steer", text: runtime.sent[0]?.content });
+			assert.equal(consumeSteerAcks(runtime.dir)[0]?.state, "delivered");
+		} finally {
+			runtime.cleanup();
 		}
 	});
 


### PR DESCRIPTION
## Summary

Fixes the steering-inbox race where `agent_end` was treated as idle before Pi emitted `agent_settled`.

- use the real extension `agent_end` shape without relying on listener-only `willRetry`
- keep `mode:auto` on safe `followUp` semantics through delayed post-agent work, retries/new turns, and legacy runtimes without `agent_settled`
- restore immediate between-turn auto delivery only after actual `agent_settled`
- preserve explicit steer, FIFO correlation, queued/delivered acknowledgements, exactly-once behavior, and shutdown handling
- add deterministic lifecycle regressions and changelog entry

## Validation

- focused prompt-runtime/child-protocol unit tests: 58/58
- focused lifecycle integration: 2/2
- `npm run typecheck`
- full-unit base/head comparison: same two pre-existing failures and six cancellations; repaired head adds six passing tests and no new failure
- independent exact-head review PASS at `5fd97a9d3e56e1451b4b3fecb870787879e4e36b`

## Residual

A separate pre-existing manual-compaction pending-acknowledgement gap is tracked in #933.

Closes #928.
