### PR TITLE
fix: persist workflow child resume metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Persist the actual agent and session file for workflow children when they start so their sessions can resume after a parent restart. Thanks to @Livan-pro for #932.
 - Retry steering requests that remain pending after manual compaction and fail unresolved requests at shutdown. Thanks to @jtac for #933.
 - Omit undefined object fields from `workflowScript` return values so completed `runs.all` results are not discarded when callers include unsupported fields such as `status` (#930).
 - Keep child steering inbox `auto` requests queued between `agent_end` and `agent_settled` so settlement-time guidance is not sent as an idle prompt too early. Thanks to @jtac for #928.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3942,6 +3942,8 @@ function duplicateSubagentCallResult(params: SubagentParamsLike): AgentToolResul
 	};
 }
 
+const workflowLaunchObservers = new WeakMap<object, (launch: { agent: string; sessionFile?: string }) => void>();
+
 function workflowChildResult(key: string, result: AgentToolResult<Details>): WorkflowScriptChildResult {
 	const receiptOutput = result.content.map((part) => part.type === "text" ? part.text : "").filter(Boolean).join("\n");
 	const output = result.details.results.length === 1 && result.details.results[0]?.finalOutput !== undefined
@@ -4159,6 +4161,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		ctx: ExtensionContext,
 		preserveActiveSession = false,
 	): Promise<AgentToolResult<Details>> => {
+		const workflowLaunchObserver = workflowLaunchObservers.get(params);
 		const delegatedThinkingOverride = delegatedThinkingOverrides.get(params);
 		const allowZeroToolBudget = delegatedZeroToolBudgets.has(params);
 		if (!preserveActiveSession) deps.state.baseCwd = ctx.cwd;
@@ -4349,6 +4352,13 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								if (budgetState?.exhausted) return workflowChildResult(key, buildRequestedModeError(childParams as SubagentParamsLike, usageBudgetExceededMessage(budgetState)));
 								patchMissionObjective(childParams.task);
 								const childRequest = prepareWorkflowLaunchParams(workflowChildDefaults, childParams, workflowRunId, key, { missionDetached: detachWorkflowChildMissions });
+								workflowLaunchObservers.set(childRequest, (launch) => {
+									const step = status.steps?.find((candidate) => candidate.workflowKey === key);
+									if (!step) return;
+									step.agent = launch.agent;
+									step.sessionFile = launch.sessionFile;
+									persist();
+								});
 								const result = await execute(randomUUID(), childRequest, workflowSignal, (update) => {
 									const progress = update.details.progress?.[0];
 									const step = status.steps?.find((candidate) => candidate.workflowKey === key);
@@ -5421,6 +5431,18 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 
 		let nestedForegroundStarted = false;
 		try {
+			if (workflowLaunchObserver) {
+				const singleTask = hasTasks && effectiveParams.tasks?.length === 1 ? effectiveParams.tasks[0] : undefined;
+				const launch = hasSingle
+					? { agent: effectiveParams.agent!, sessionFile: childSessionFileForTask(effectiveParams.agent!, 0, effectiveParams.model) }
+					: singleTask
+						? { agent: singleTask.agent, sessionFile: childSessionFileForTask(singleTask.agent, 0, singleTask.model) }
+						: undefined;
+				if (launch) {
+					workflowLaunchObservers.delete(params);
+					workflowLaunchObserver(launch);
+				}
+			}
 			const asyncResult = runAsyncPath(execData, deps);
 			if (asyncResult) return attachMission(withResolvedContext(withForkThinkingNotes(asyncResult, forkThinkingDowngrades), contextPolicy.contextSummary));
 			if (foregroundControl) {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -517,6 +517,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(liveStatus.currentPath ?? "", /src[/\\]example\.ts$/);
 		assert.equal(liveStatus.toolCount, 1);
 		assert.equal(liveStatus.steps?.[0]?.status, "running");
+		assert.equal(liveStatus.steps?.[0]?.agent, "echo");
+		assert.match(liveStatus.steps?.[0]?.sessionFile ?? "", /session\.jsonl$/);
+		assert.equal(fs.existsSync(liveStatus.steps?.[0]?.sessionFile ?? ""), true);
 		assert.equal(liveStatus.steps?.[0]?.activityState, "active_long_running");
 		assert.equal(typeof liveStatus.steps?.[0]?.lastActivityAt, "number");
 		assert.equal(liveStatus.steps?.[0]?.toolCount, 1);
@@ -616,6 +619,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			await new Promise((resolve) => setTimeout(resolve, 20));
 		}
 		assert.ok(childRunId);
+		const workflowStatus = JSON.parse(fs.readFileSync(path.join(started.details.asyncDir!, "status.json"), "utf-8")) as AsyncStatus;
+		const workflowStepSessionFile = workflowStatus.steps?.[0]?.sessionFile ?? "";
+		assert.equal(workflowStatus.steps?.[0]?.agent, "echo");
+		assert.match(workflowStepSessionFile, /session\.jsonl$/);
 		const childDir = path.join(DIRS.async, childRunId);
 		const childStatusPath = path.join(childDir, "status.json");
 		let childStatus: { state?: string; mode?: string; parentWorkflowRunId?: string; workflowKey?: string; parallelHandoff?: { path?: string } } = {};
@@ -635,6 +642,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const childResult = JSON.parse(fs.readFileSync(childResultPath, "utf-8")) as { parentWorkflowRunId?: string; workflowKey?: string };
 		assert.equal(childResult.parentWorkflowRunId, workflowRunId);
 		assert.equal(childResult.workflowKey, "background");
+		assert.equal(fs.existsSync(workflowStepSessionFile), true);
 		fs.rmSync(started.details.asyncDir!, { recursive: true, force: true });
 		fs.rmSync(workflowResultPath, { force: true });
 		fs.rmSync(childDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Persist workflow child resume metadata in `status.steps` as soon as the child starts. This records the actual child agent and session JSONL path so a restarted parent can resume workflow children from the existing conversation file.

Fixes #932.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='projects live child activity into async workflow status|persists workflow parent metadata in an async worktree child status and result' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`

## Review

Fresh review found one blocker for `worktree: true` children. The follow-up fix now covers the one-task path, and targeted follow-up review found no blockers: `/tmp/pi-subagents-932-followup-review.md`.
