### PR TITLE
test: relax mission-store writer wait

### DIFF
--- a/test/unit/mission-store.test.ts
+++ b/test/unit/mission-store.test.ts
@@ -24,12 +24,13 @@ function fixture() {
 	return { root, projectRoot, agentDir, location };
 }
 
-async function waitForFile(filePath: string): Promise<void> {
-	for (let attempt = 0; attempt < 100; attempt++) {
+async function waitForFile(filePath: string, timeoutMs = 10_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
 		if (fs.existsSync(filePath)) return;
 		await new Promise((resolve) => setTimeout(resolve, 10));
 	}
-	throw new Error(`Timed out waiting for ${filePath}`);
+	throw new Error(`Timed out waiting for ${filePath} after ${timeoutMs} ms`);
 }
 
 describe("mission store", () => {


### PR DESCRIPTION
## Summary

Relax the `mission-store` test helper wait for the child writer readiness file. Windows CI hit the old 1s startup budget before the helper process could import and write `writer-ready`, while the actual lock assertion still remained valid.

This is a fix-forward for main CI run `31341441463` on `b2d88b80c28db7d7eacdc70bdc95324116db9d95`.

## Validation

- `node --experimental-strip-types --test --test-name-pattern='serializes workflow state writes behind the state-file lock' test/unit/mission-store.test.ts`
- `npm run typecheck`
- `git diff --check`

## Review

Fresh read-only review found no blockers: `/tmp/pi-subagents-main-ci-mission-store-review.md`.
