### PR TITLE
fix: prompt parents to revive failed async runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Tell parents to revive resumable failed async runs before reporting failure or launching a replacement. Thanks to @Livan-pro for #938.
 - Persist the actual agent and session file for workflow children when they start so their sessions can resume after a parent restart. Thanks to @Livan-pro for #932.
 - Retry steering requests that remain pending after manual compaction and fail unresolved requests at shutdown. Thanks to @jtac for #933.
 - Omit undefined object fields from `workflowScript` return values so completed `runs.all` results are not discarded when callers include unsupported fields such as `status` (#930).

--- a/src/runs/background/resume-guidance.ts
+++ b/src/runs/background/resume-guidance.ts
@@ -1,0 +1,33 @@
+import * as fs from "node:fs";
+import type { AsyncRunSummary } from "./async-status.ts";
+
+export function formatAsyncReviveCommand(run: AsyncRunSummary): string | undefined {
+	const step = run.steps.find((candidate) => candidate.status === "failed" && candidate.sessionFile && fs.existsSync(candidate.sessionFile));
+	if (!step) {
+		if (run.steps.length === 1 && run.sessionFile && fs.existsSync(run.sessionFile)) {
+			return `subagent({ action: "resume", id: "${run.id}", message: "Continue from the persisted child session and report the result." })`;
+		}
+		return undefined;
+	}
+	const index = run.steps.length === 1 ? "" : `, index: ${step.index}`;
+	return `subagent({ action: "resume", id: "${run.id}"${index}, message: "Continue from the persisted child session and report the result." })`;
+}
+
+export function formatResumeFirstFailedRunDetail(run: AsyncRunSummary): string | undefined {
+	if (run.state !== "failed") return undefined;
+	const command = formatAsyncReviveCommand(run);
+	if (!command) return undefined;
+	return `Resume-first: failed run "${run.id}" has a persisted child session. Revive the original run with ${command} before reporting failure or launching a replacement. Launch a replacement only if revive fails or the user explicitly asks for one.`;
+}
+
+export function formatResumeFirstFailedRunsNote(runs: AsyncRunSummary[]): string {
+	const resumable = runs
+		.filter((run) => run.state === "failed")
+		.map((run) => ({ run, command: formatAsyncReviveCommand(run) }))
+		.filter((entry): entry is { run: AsyncRunSummary; command: string } => Boolean(entry.command));
+	if (resumable.length === 0) return "";
+	const guidance = resumable.length === 1
+		? `failed run "${resumable[0]!.run.id}" has a persisted child session. Revive the original run with ${resumable[0]!.command}`
+		: `${resumable.length} failed runs have persisted child sessions. Inspect status and revive each original run before retrying`;
+	return ` Resume-first: ${guidance} before reporting failure or launching a replacement. Launch a replacement only if revive fails or the user explicitly asks for one.`;
+}

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -62,6 +62,7 @@ import {
 } from "../../shared/types.ts";
 import { formatDuration, shortenPath } from "../../shared/formatters.ts";
 import { collectWaitCompletions } from "./wait-completions.ts";
+import { formatResumeFirstFailedRunsNote } from "./resume-guidance.ts";
 export { WAIT_TOOL_ENABLED_ENV, resolveWaitToolConfig, type ResolvedWaitToolConfig } from "./wait-config.ts";
 
 /** States that mean a run is still in flight (not yet resolved). */
@@ -604,6 +605,7 @@ export async function waitForSubagents(
 	let finishedAsyncCount: number;
 	let failedAsyncCount: number;
 	let completions: WaitCompletion[] | undefined;
+	let resumeGuidance = "";
 	const activeProviderIds = new Set(providerActive.map(backgroundWorkIdentity));
 	const providerFinishedCount = [...initialProviderIds].filter((id) => !activeProviderIds.has(id)).length;
 	try {
@@ -612,6 +614,7 @@ export async function waitForSubagents(
 		finishedAsyncCount = terminal.length;
 		failedAsyncCount = terminal.filter((run) => run.state === "failed").length;
 		terminalSummary = summarizeTerminalRuns(terminal, providerFinishedCount);
+		resumeGuidance = formatResumeFirstFailedRunsNote(terminal);
 		completions = collectWaitCompletions(terminal, deps.state, deps.resultsDir ?? DIRS.results);
 	} catch (error) {
 		return result(error instanceof Error ? error.message : String(error), true);
@@ -637,7 +640,7 @@ export async function waitForSubagents(
 				: `${initialAsyncIds.size} async run(s) and ${initialProviderIds.size} provider item(s)`;
 		const status = relevantAttention.length > 0 ? "attention required" : "done";
 		return result(
-			`Waited ${elapsed} for ${scope}; ${status}.${outcome}${attentionNote} Completion/control events have been observed; inspect status if a notification is not visible yet.`,
+			`Waited ${elapsed} for ${scope}; ${status}.${outcome}${resumeGuidance}${attentionNote} Completion/control events have been observed; inspect status if a notification is not visible yet.`,
 			deps.failOnFailedRuns === true && failedAsyncCount > 0,
 			completions,
 		);
@@ -654,7 +657,7 @@ export async function waitForSubagents(
 		? `${relevantAttention.length} of ${initialCount} ${subject} need attention`
 		: `${finishedCount} of ${initialCount} ${subject} finished`;
 	return result(
-		`Waited ${elapsed}; ${progress}.${outcome}${attentionNote}${remainder} Relevant completion/control events have been observed; inspect status if a notification is not visible yet.`,
+		`Waited ${elapsed}; ${progress}.${outcome}${resumeGuidance}${attentionNote}${remainder} Relevant completion/control events have been observed; inspect status if a notification is not visible yet.`,
 		deps.failOnFailedRuns === true && failedAsyncCount > 0,
 		completions,
 	);

--- a/src/runs/background/wait-subscriptions.ts
+++ b/src/runs/background/wait-subscriptions.ts
@@ -2,7 +2,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { listAsyncRuns } from "./async-status.ts";
+import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
+import { formatResumeFirstFailedRunDetail } from "./resume-guidance.ts";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import {
 	DIRS,
@@ -61,7 +62,7 @@ function parseRecord(value: unknown): WaitSubscriptionRecord | undefined {
 	return record as WaitSubscriptionRecord;
 }
 
-function needsAttention(run: ReturnType<typeof listAsyncRuns>[number]): boolean {
+function needsAttention(run: AsyncRunSummary): boolean {
 	return run.activityState === "needs_attention" || run.steps.some((step) => step.activityState === "needs_attention");
 }
 
@@ -166,7 +167,7 @@ export function createWaitSubscriptionManager(
 			return;
 		}
 		if (run.state !== "queued" && run.state !== "running") {
-			settle(record, run.state === "complete" ? "completed" : run.state, "Inspect the run status for its final output.");
+			settle(record, run.state === "complete" ? "completed" : run.state, formatResumeFirstFailedRunDetail(run) ?? "Inspect the run status for its final output.");
 		}
 	};
 

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -189,6 +189,33 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("tells blocking callers to revive resumable failed runs before replacing them", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-revive-first-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const sessionFile = path.join(root, "worker-session.jsonl");
+			fs.writeFileSync(sessionFile, "{}\n", "utf-8");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-revive", "running", { sessionId: "sess-1", pid: 999999 });
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
+				sleep: async () => writeStatus(asyncRoot, "run-revive", "failed", {
+					sessionId: "sess-1",
+					steps: [{ agent: "worker", status: "failed", sessionFile }],
+				}),
+			}));
+
+			assert.equal(result.isError, undefined);
+			const text = textOf(result);
+			assert.match(text, /1 failed/);
+			assert.match(text, /Resume-first/);
+			assert.match(text, /subagent\(\{ action: "resume", id: "run-revive", message:/);
+			assert.match(text, /before reporting failure or launching a replacement/);
+			assert.match(text, /only if revive fails or the user explicitly asks/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("surfaces terminal completion payloads from the result file in details.completions", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-completions-file-"));
 		try {

--- a/test/unit/wait-subscriptions.test.ts
+++ b/test/unit/wait-subscriptions.test.ts
@@ -186,6 +186,44 @@ describe("non-blocking wait subscriptions", () => {
 		}
 	});
 
+	it("tells the parent to revive the failed child before replacing resumable async runs", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-revive-first-"));
+		const asyncRoot = path.join(root, "runs");
+		const subscriptionsDir = path.join(root, "subscriptions");
+		const completedSessionFile = path.join(root, "completed-session.jsonl");
+		const failedSessionFile = path.join(root, "failed-session.jsonl");
+		const sent: string[] = [];
+		const state = makeState();
+		const manager = createWaitSubscriptionManager({
+			events: new TestBus(),
+			sendMessage(message: { content?: unknown }) { sent.push(String(message.content)); },
+		} as never, state, { asyncDirRoot: asyncRoot, subscriptionsDir, pollIntervalMs: 60_000, kill: () => true });
+		try {
+			fs.writeFileSync(completedSessionFile, "{}\n", "utf-8");
+			fs.writeFileSync(failedSessionFile, "{}\n", "utf-8");
+			writeStatus(asyncRoot, "run-revive", "running", { sessionId: "session-a", pid: 999_999 });
+			manager.arm({ targetKind: "async", runId: "run-revive", requestedId: "run-revive", timeoutMs: 30_000 });
+
+			writeStatus(asyncRoot, "run-revive", "failed", {
+				sessionId: "session-a",
+				steps: [
+					{ agent: "first", status: "complete", sessionFile: completedSessionFile },
+					{ agent: "second", status: "failed", sessionFile: failedSessionFile },
+				],
+			});
+			manager.reconcile();
+
+			const message = sent[0] ?? "";
+			assert.match(message, /Resume-first/);
+			assert.match(message, /subagent\(\{ action: "resume", id: "run-revive", index: 1, message:/);
+			assert.match(message, /before reporting failure or launching a replacement/);
+			assert.match(message, /only if revive fails or the user explicitly asks/);
+		} finally {
+			manager.dispose();
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("waits for foreground run restoration before reconciling a restored subscription", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-foreground-restore-"));
 		const subscriptionsDir = path.join(root, "subscriptions");


### PR DESCRIPTION
Fixes #938.

This adds resume-first guidance for failed async runs that still have a persisted child session. The guidance now appears in both non-blocking wait subscription wake messages and blocking `subagent_wait` summaries, so the parent is told to revive the original run before reporting failure or launching a replacement.

Validation:
- `node --experimental-strip-types --test test/unit/wait-subscriptions.test.ts test/unit/subagent-wait.test.ts`
- `git diff --check`
- `npm run test:unit`

Fresh review: `/tmp/pi-subagents-938-fresh-review.md` reported no findings.

Thanks to @Livan-pro for reporting #938.
