### PR TITLE
fix: improve invalid subagent action recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Preserve short-lived completion replay records and bounded output archives so waits can recover consumed async result details after watcher delivery or restart.
 - Add `subagent({ action: "guide" })` and `/subagents-guide [topic]` to read current-version packaged guides.
 
+### Fixed
+- Give invalid `subagent` actions safe next steps and typo suggestions without suggesting destructive actions for ambiguous input.
+
 ## [0.45.2] - 2026-08-10
 
 ### Fixed

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -94,7 +94,7 @@ Completed workflow children from the current parent session stay addressable as 
 
 `{ action: "guide" }` reads the packaged `README.md` from the installed version. Pass `topic` to read its packaged `docs/<topic>.md` file instead. Valid topics are `overview`, `workflows`, `agents`, `missions`, `observability`, `tool-reference`, `configuration`, `models`, `watchdog`, and `extension-api`. Unknown topics list the valid values and do not change files. Use `/subagents-guide [topic]` for the slash equivalent.
 
-Agent definitions are not loaded into context by default. Management actions let the LLM discover, inspect, create, update, and delete agents and chains at runtime.
+Agent definitions are not loaded into context by default. Management actions let the LLM discover, inspect, create, update, and delete agents and chains at runtime. An unknown action returns safe next steps (`status` and `list`) and may suggest a close non-destructive action. Destructive actions are only named for a near-complete one-character typo, and suggestions never execute an action.
 
 ```ts
 { action: "list" }

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -51,7 +51,7 @@ import {
 } from "../../shared/settings.ts";
 import { discoverAvailableSkills, normalizeSkillInput } from "../../agents/skills.ts";
 import { buildAsyncRunnerSteps, executeAsyncChain, executeAsyncSingle, formatAsyncStartedMessage, isAsyncAvailable } from "../background/async-execution.ts";
-import type { ScheduledRunAction } from "../background/scheduled-runs.ts";
+import { isScheduledRunAction, type ScheduledRunAction } from "../background/scheduled-runs.ts";
 import { enqueueChainAppendRequest, readPendingChainAppendRequests, runnerStepOutputNames } from "../background/chain-append.ts";
 import { ChainOutputValidationError, validateChainOutputBindingsWithContext } from "../shared/chain-outputs.ts";
 import { normalizeGateAcceptance, validateExecutionAcceptance } from "../shared/acceptance.ts";
@@ -152,6 +152,47 @@ import {
 } from "../../shared/types.ts";
 
 const MUTATING_MANAGEMENT_ACTIONS = new Set(["create", "update", "delete", "eject", "disable", "enable", "reset", "grant-spawn-budget", "watchdog.configure", "mission.create", "mission.update", "mission.attach-run", "mission.close", "inspector.open", "inspector.close", "project.open", "project.close", "worktree.discard", "refine", "refine.rollback", "schedule.create", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"]);
+const DESTRUCTIVE_MANAGEMENT_ACTIONS = new Set(["delete", "eject", "disable", "reset", "mission.close", "worktree.discard", "refine.rollback", "inspector.close", "project.close", "stop", "interrupt", "reject-checkpoint", "schedule.delete"]);
+
+function editDistance(left: string, right: string): number {
+	const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+	for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+		let diagonal = previous[0]!;
+		previous[0] = leftIndex;
+		for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+			const above = previous[rightIndex]!;
+			previous[rightIndex] = left[leftIndex - 1] === right[rightIndex - 1]
+				? diagonal
+				: Math.min(diagonal, above, previous[rightIndex - 1]!) + 1;
+			diagonal = above;
+		}
+	}
+	return previous[right.length]!;
+}
+
+function hasSingleAdjacentTransposition(left: string, right: string): boolean {
+	if (left.length !== right.length) return false;
+	const mismatch = [...left].findIndex((character, index) => character !== right[index]);
+	return mismatch >= 0
+		&& left[mismatch] === right[mismatch + 1]
+		&& left[mismatch + 1] === right[mismatch]
+		&& left.slice(mismatch + 2) === right.slice(mismatch + 2);
+}
+
+export function unknownSubagentActionMessage(action: string): string {
+	const requested = action.toLowerCase();
+	const suggestion = SUBAGENT_ACTIONS.find((candidate) => {
+		const distance = editDistance(requested, candidate);
+		const closeMatch = distance <= Math.max(1, Math.floor(candidate.length / 4)) || hasSingleAdjacentTransposition(requested, candidate);
+		if (DESTRUCTIVE_MANAGEMENT_ACTIONS.has(candidate)) return distance === 1 && requested.length >= candidate.length - 1;
+		return closeMatch;
+	});
+	const nextStep = 'Use subagent({ action: "status" }) to inspect runs or subagent({ action: "list" }) to inspect agents.';
+	const validActions = `Valid: ${SUBAGENT_ACTIONS.join(", ")}.`;
+	return suggestion
+		? `Unknown action: ${action}. Did you mean ${suggestion}? ${nextStep} ${validActions}`
+		: `Unknown action: ${action}. ${nextStep} ${validActions}`;
+}
 
 type UndefinedOmitted<T extends object> = {
 	[K in keyof T as undefined extends T[K] ? never : K]: T[K];
@@ -4914,6 +4955,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				return appendStepToAsyncChain(omitUndefinedProperties({ params: paramsWithResolvedCwd, requestCwd, ctx, deps, parentModel: requestParentModel }));
 			}
 			if (action.startsWith("schedule.")) {
+				if (!isScheduledRunAction(action)) {
+					return { content: [{ type: "text", text: unknownSubagentActionMessage(action) }], isError: true, details: { mode: "management", results: [] } };
+				}
 				if (deps.allowMutatingManagementActions === false && MUTATING_MANAGEMENT_ACTIONS.has(action)) {
 					return {
 						content: [{ type: "text", text: `Action '${action}' is not available from child-safe subagent fanout mode.` }],
@@ -5020,7 +5064,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			}
 			if (!(SUBAGENT_ACTIONS as readonly string[]).includes(action)) {
 				return {
-					content: [{ type: "text", text: `Unknown action: ${action}. Valid: ${SUBAGENT_ACTIONS.join(", ")}` }],
+					content: [{ type: "text", text: unknownSubagentActionMessage(action) }],
 					isError: true,
 					details: { mode: "management" as const, results: [] },
 				};

--- a/test/unit/subagent-action-recovery.test.ts
+++ b/test/unit/subagent-action-recovery.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import * as os from "node:os";
+import { describe, it } from "node:test";
+import { createSubagentExecutor, unknownSubagentActionMessage } from "../../src/runs/foreground/subagent-executor.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+function createState(): SubagentState {
+	return {
+		baseCwd: "",
+		currentSessionId: null,
+		asyncJobs: new Map(),
+		foregroundRuns: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		pendingForegroundControlNotices: new Map(),
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	};
+}
+
+function createExecutor() {
+	return createSubagentExecutor({
+		pi: { events: { emit() {}, on() { return () => {}; } }, getSessionName() { return "parent"; } } as any,
+		state: createState(),
+		config: { maxSubagentDepth: 2, control: {}, intercomBridge: {} } as any,
+		asyncByDefault: false,
+		tempArtifactsDir: os.tmpdir(),
+		getSubagentSessionRoot: () => os.tmpdir(),
+		expandTilde: (value) => value,
+		discoverAgents: () => ({ agents: [] }),
+	});
+}
+
+function ctx() {
+	return {
+		cwd: os.tmpdir(),
+		hasUI: false,
+		sessionManager: { getSessionId() { return "session"; }, getSessionFile() { return null; } },
+		modelRegistry: { getAvailable() { return []; } },
+	} as any;
+}
+
+describe("subagent action recovery", () => {
+	it("suggests a benign typo with safe next steps", () => {
+		const message = unknownSubagentActionMessage("statsu");
+
+		assert.match(message, /Unknown action: statsu\. Did you mean status\?/);
+		assert.match(message, /Use subagent\(\{ action: "status" \}\)/);
+		assert.match(message, /Valid: .*status/);
+	});
+
+	it("does not suggest a destructive near-miss", () => {
+		const message = unknownSubagentActionMessage("del");
+
+		assert.match(message, /Unknown action: del\./);
+		assert.doesNotMatch(message, /Did you mean delete\?/);
+		assert.match(message, /Valid: .*delete/);
+	});
+
+	it("returns a concise recovery error for an invalid action", async () => {
+		const result = await createExecutor().execute("invalid-action", { action: "statsu" }, new AbortController().signal, undefined, ctx());
+		assert.equal(result.isError, true);
+		assert.equal(result.content[0]?.type, "text");
+		assert.equal(result.content[0]?.text, unknownSubagentActionMessage("statsu"));
+	});
+
+	it("routes invalid schedule actions through common recovery", async () => {
+		const result = await createExecutor().execute("invalid-schedule-action", { action: "schedule.lsit" }, new AbortController().signal, undefined, ctx());
+		assert.equal(result.isError, true);
+		assert.equal(result.content[0]?.type, "text");
+		assert.equal(result.content[0]?.text, unknownSubagentActionMessage("schedule.lsit"));
+	});
+});


### PR DESCRIPTION
Improves invalid action recovery by routing unknown management actions through one concise helper with safe suggestions.

Invalid schedule-prefixed typos now use the same recovery path before scheduled-run dispatch, so near misses such as `schedule.lsit` show the standard unknown-action guidance instead of a narrow scheduler error.

Validation:
- `node --experimental-strip-types --test test/unit/subagent-action-recovery.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review plus targeted follow-up review: no findings
