### PR TITLE
feat: expose public project pane lifecycle API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Expose a versioned `pi-subagents/project-panes` TypeScript API so other Pi extensions can deterministically open, inspect, and close project-owned Herdr panes without invoking the model-facing `subagent` tool. The structured status includes bounded pane runtime state and an opt-in idle-only close guard; Pi project trust remains an explicit human verification step.
 - Preserve short-lived completion replay records and bounded output archives so waits can recover consumed async result details after watcher delivery or restart.
 - Add `subagent({ action: "guide" })` and `/subagents-guide [topic]` to read current-version packaged guides.
 - Persist workflow child attempts, status heartbeats, session paths, and artifacts in their enclosing mission, and add explicit mission decision resolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Expose a versioned `pi-subagents/project-panes` TypeScript API so other Pi extensions can deterministically open, inspect, and close project-owned Herdr panes without invoking the model-facing `subagent` tool. The structured status includes bounded pane runtime state and an opt-in idle-only close guard; Pi project trust remains an explicit human verification step.
+- Expose a versioned `pi-subagents/project-panes` TypeScript API so other Pi extensions can deterministically open, inspect, and close project-owned Herdr panes without invoking the model-facing `subagent` tool. The structured status includes bounded pane runtime state and an opt-in idle-only close guard; Pi project trust remains an explicit human verification step. Thanks to @wiizard-chen for #949.
 - Preserve short-lived completion replay records and bounded output archives so waits can recover consumed async result details after watcher delivery or restart.
 - Add `subagent({ action: "guide" })` and `/subagents-guide [topic]` to read current-version packaged guides.
 - Persist workflow child attempts, status heartbeats, session paths, and artifacts in their enclosing mission, and add explicit mission decision resolution.

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -270,6 +270,23 @@ subagent({ action: "project.close", cwd: "/path/to/repo" })
 
 A project pane runs its own Pi session in the target directory, so subagents launched from that pane use that project's config, agents, skills, files, git state, and missions. The parent session keeps coordination authority; existing headless runs are not moved into the pane. Pane bindings live under `<projectRoot>/.pi-subagents/project-panes/herdr.json` and are only a local pointer to the Herdr pane.
 
+Other Pi extensions should use the versioned public TypeScript surface instead of invoking the model-facing tool or importing inspector internals:
+
+```ts
+import {
+  PROJECT_PANES_API_VERSION,
+  openProjectPane,
+  getProjectPaneStatus,
+  closeProjectPane,
+} from "pi-subagents/project-panes";
+
+const opened = await openProjectPane({ cwd: "/path/to/repo", focus: false });
+const status = await getProjectPaneStatus({ cwd: "/path/to/repo" });
+const closed = await closeProjectPane({ cwd: "/path/to/repo", requireIdle: true });
+```
+
+The API returns discriminated structured results with canonical project root, binding path, pane identity, bounded Herdr runtime fields, and stable error codes. `requireIdle: true` fails closed unless Herdr explicitly reports `agent_status: "idle"`; use it when an owning extension must not close a working or blocked pane. The API deliberately reports `trust: "human-verification-required"`: it never bypasses or claims to attest Pi's project-trust prompt. `PROJECT_PANES_API_VERSION` is currently `1`.
+
 ## Runtime files
 
 The main runtime files in this repository:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "./control-channel": "./src/api/control-channel.ts",
     "./intercom-bridge": "./src/api/intercom-bridge.ts",
     "./pi-args": "./src/api/pi-args.ts",
-    "./shared-types": "./src/api/shared-types.ts"
+    "./shared-types": "./src/api/shared-types.ts",
+    "./project-panes": "./src/api/project-panes.ts"
   },
   "repository": {
     "type": "git",

--- a/src/api/project-panes.ts
+++ b/src/api/project-panes.ts
@@ -1,0 +1,30 @@
+/**
+ * Public project-owned Herdr pane lifecycle API for other Pi extensions.
+ *
+ * This is the supported extension-to-extension surface. Callers must not
+ * import `src/inspectors/herdr/*` directly.
+ */
+export {
+	PROJECT_PANES_API_VERSION,
+	PROJECT_PANE_TRUST_STATUS,
+	createProjectPaneManager,
+	openProjectPane,
+	getProjectPaneStatus,
+	closeProjectPane,
+	readProjectPaneBinding,
+	projectPaneBindingPath,
+	type ProjectPaneManager,
+	type ProjectPaneManagerOptions,
+	type ProjectPaneCommandClient,
+	type OpenProjectPaneOptions,
+	type GetProjectPaneStatusOptions,
+	type CloseProjectPaneOptions,
+	type OpenProjectPaneData,
+	type ProjectPaneStatusData,
+	type CloseProjectPaneData,
+	type ProjectPaneRuntime,
+	type ProjectPaneError,
+	type ProjectPaneErrorCode,
+	type ProjectPaneResult,
+	type HerdrProjectPaneBinding,
+} from "../inspectors/herdr/project-panes.ts";

--- a/src/inspectors/herdr/project-panes.ts
+++ b/src/inspectors/herdr/project-panes.ts
@@ -4,10 +4,14 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { getPiSpawnCommand } from "../../runs/shared/pi-spawn.ts";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import type { Details } from "../../shared/types.ts";
-import { createHerdrClient, detectHerdr, type HerdrClient, type HerdrErrorCode, type HerdrResult } from "./client.ts";
+import { createHerdrClient, detectHerdr, type HerdrClient, type HerdrErrorCode } from "./client.ts";
 
 export const HERDR_PROJECT_PANE_ACTIONS = ["project.open", "project.status", "project.close"] as const;
 export type HerdrProjectPaneAction = typeof HERDR_PROJECT_PANE_ACTIONS[number];
+
+/** Versioned public contract exported through `pi-subagents/project-panes`. */
+export const PROJECT_PANES_API_VERSION = 1 as const;
+export const PROJECT_PANE_TRUST_STATUS = "human-verification-required" as const;
 
 export interface HerdrProjectPaneBinding {
 	schemaVersion: 1;
@@ -19,6 +23,105 @@ export interface HerdrProjectPaneBinding {
 	herdrVersion?: string;
 	command: string;
 	startupMessage?: string;
+}
+
+export interface ProjectPaneRuntime {
+	paneId: string;
+	agent?: string;
+	agentStatus: string;
+	cwd?: string;
+	foregroundCwd?: string;
+	focused?: boolean;
+	terminalTitle?: string;
+}
+
+export type ProjectPaneErrorCode = HerdrErrorCode
+	| "INVALID_PROJECT_ROOT"
+	| "INVALID_PANE_RESPONSE"
+	| "INVALID_BINDING"
+	| "PANE_NOT_IDLE"
+	| "PANE_OWNERSHIP_UNVERIFIED";
+
+export interface ProjectPaneError {
+	code: ProjectPaneErrorCode;
+	message: string;
+	projectRoot?: string;
+	bindingPath?: string;
+	details?: unknown;
+}
+
+export type ProjectPaneResult<T> =
+	| { ok: true; data: T }
+	| { ok: false; error: ProjectPaneError };
+
+interface ProjectPaneCommonData {
+	apiVersion: typeof PROJECT_PANES_API_VERSION;
+	projectRoot: string;
+	bindingPath: string;
+	trust: typeof PROJECT_PANE_TRUST_STATUS;
+}
+
+export interface OpenProjectPaneData extends ProjectPaneCommonData {
+	disposition: "opened" | "already-open";
+	binding: HerdrProjectPaneBinding;
+	runtime?: ProjectPaneRuntime;
+}
+
+export interface ProjectPaneStatusData extends ProjectPaneCommonData {
+	state: "absent" | "open" | "stale";
+	binding?: HerdrProjectPaneBinding;
+	runtime?: ProjectPaneRuntime;
+	ownership: "verified" | "unknown" | "mismatch";
+	safeToClose: boolean;
+	staleReason?: { code: HerdrErrorCode; message: string };
+}
+
+export interface CloseProjectPaneData extends ProjectPaneCommonData {
+	disposition: "closed" | "absent" | "stale-binding-removed";
+	binding?: HerdrProjectPaneBinding;
+	runtime?: ProjectPaneRuntime;
+}
+
+export interface OpenProjectPaneOptions {
+	cwd: string;
+	message?: string;
+	focus?: boolean;
+	signal?: AbortSignal;
+}
+
+export interface GetProjectPaneStatusOptions {
+	cwd: string;
+	signal?: AbortSignal;
+}
+
+export interface CloseProjectPaneOptions {
+	cwd: string;
+	/** Fail closed unless Herdr explicitly reports the owning Pi pane as idle. */
+	requireIdle?: boolean;
+	signal?: AbortSignal;
+}
+
+export interface ProjectPaneCommandClient {
+	run<T = unknown>(
+		args: string[],
+		options?: { timeoutMs?: number; signal?: AbortSignal; textOk?: boolean },
+	): Promise<{ ok: true; data: T } | { ok: false; error: { code: HerdrErrorCode; message: string; details?: unknown } }>;
+}
+
+export interface ProjectPaneManagerOptions {
+	client?: ProjectPaneCommandClient;
+	now?: () => Date;
+}
+
+export interface ProjectPaneManager {
+	open(options: OpenProjectPaneOptions): Promise<ProjectPaneResult<OpenProjectPaneData>>;
+	status(options: GetProjectPaneStatusOptions): Promise<ProjectPaneResult<ProjectPaneStatusData>>;
+	close(options: CloseProjectPaneOptions): Promise<ProjectPaneResult<CloseProjectPaneData>>;
+}
+
+interface InternalProjectPaneManagerOptions extends ProjectPaneManagerOptions {
+	/** Preserve the historical model-facing action behavior without weakening the public API defaults. */
+	legacyToolCompatibility?: boolean;
 }
 
 interface ProjectPaneParams {
@@ -34,11 +137,15 @@ interface ProjectPaneDeps {
 	now?: () => Date;
 }
 
-function result(text: string, isError = false): AgentToolResult<Details> {
+function toolResult(text: string, isError = false): AgentToolResult<Details> {
 	return { content: [{ type: "text", text }], ...(isError ? { isError: true } : {}), details: { mode: "management", results: [] } };
 }
 
-function formatHerdrError(input: { code: HerdrErrorCode; message: string }): string {
+function projectPaneError<T>(code: ProjectPaneErrorCode, message: string, fields: Omit<ProjectPaneError, "code" | "message"> = {}): ProjectPaneResult<T> {
+	return { ok: false, error: { code, message, ...fields } };
+}
+
+function formatProjectPaneError(input: { code: ProjectPaneErrorCode; message: string }): string {
 	return `Herdr project pane error (${input.code}): ${input.message}`;
 }
 
@@ -46,28 +153,82 @@ function projectPaneDir(projectRoot: string): string {
 	return path.join(projectRoot, ".pi-subagents", "project-panes");
 }
 
-function bindingPath(projectRoot: string): string {
+export function projectPaneBindingPath(projectRoot: string): string {
 	return path.join(projectPaneDir(projectRoot), "herdr.json");
 }
 
-function parseBinding(value: unknown): HerdrProjectPaneBinding | undefined {
+function parseBinding(value: unknown, strict = false): HerdrProjectPaneBinding | undefined {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
 	const input = value as Partial<HerdrProjectPaneBinding>;
 	if (input.schemaVersion !== 1 || input.kind !== "herdr-project-pane") return undefined;
 	if (typeof input.projectRoot !== "string" || typeof input.paneId !== "string" || typeof input.openedAt !== "string" || typeof input.command !== "string") return undefined;
+	if (strict) {
+		if (![input.projectRoot, input.paneId, input.openedAt, input.command].every((field) => field.trim().length > 0)) return undefined;
+		for (const field of ["lastFocusedAt", "herdrVersion", "startupMessage"] as const) {
+			if (input[field] !== undefined && typeof input[field] !== "string") return undefined;
+		}
+	}
 	return input as HerdrProjectPaneBinding;
 }
 
+interface BindingReadResult {
+	state: "absent" | "invalid" | "valid";
+	binding?: HerdrProjectPaneBinding;
+}
+
+function readBinding(projectRoot: string, strict: boolean): BindingReadResult {
+	const file = projectPaneBindingPath(projectRoot);
+	if (!fs.existsSync(file)) return { state: "absent" };
+	try {
+		const binding = parseBinding(JSON.parse(fs.readFileSync(file, "utf-8")), strict);
+		return binding ? { state: "valid", binding } : { state: "invalid" };
+	} catch {
+		return { state: "invalid" };
+	}
+}
+
+/** Legacy model-facing reader; preserves the original required-field-only parsing contract. */
 export function readHerdrProjectPaneBinding(projectRoot: string): HerdrProjectPaneBinding | undefined {
-	try { return parseBinding(JSON.parse(fs.readFileSync(bindingPath(projectRoot), "utf-8"))); } catch { return undefined; }
+	return readBinding(projectRoot, false).binding;
+}
+
+/** Strict public reader for extension integrations. */
+export function readProjectPaneBinding(projectRoot: string): HerdrProjectPaneBinding | undefined {
+	return readBinding(projectRoot, true).binding;
+}
+
+function paneRecord(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const record = value as Record<string, unknown>;
+	return record.pane && typeof record.pane === "object" && !Array.isArray(record.pane)
+		? record.pane as Record<string, unknown>
+		: record;
 }
 
 function extractPaneId(value: unknown): string | undefined {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
-	const record = value as Record<string, unknown>;
-	const pane = record.pane && typeof record.pane === "object" && !Array.isArray(record.pane) ? record.pane as Record<string, unknown> : record;
+	const pane = paneRecord(value);
+	if (!pane) return undefined;
 	for (const key of ["pane_id", "paneId", "id"]) if (typeof pane[key] === "string") return pane[key];
 	return undefined;
+}
+
+function projectPaneRuntime(value: unknown): ProjectPaneRuntime | undefined {
+	const pane = paneRecord(value);
+	const paneId = extractPaneId(value);
+	if (!pane || !paneId) return undefined;
+	const text = (key: string): string | undefined => typeof pane[key] === "string" ? pane[key] as string : undefined;
+	const agentStatus = text("agent_status") ?? text("agentStatus") ?? "unknown";
+	return {
+		paneId,
+		...(text("agent") ? { agent: text("agent") } : {}),
+		agentStatus: agentStatus.toLowerCase(),
+		...(text("cwd") ? { cwd: text("cwd") } : {}),
+		...(text("foreground_cwd") || text("foregroundCwd") ? { foregroundCwd: text("foreground_cwd") ?? text("foregroundCwd") } : {}),
+		...(typeof pane.focused === "boolean" ? { focused: pane.focused } : {}),
+		...(text("terminal_title_stripped") || text("terminal_title") || text("terminalTitle")
+			? { terminalTitle: text("terminal_title_stripped") ?? text("terminal_title") ?? text("terminalTitle") }
+			: {}),
+	};
 }
 
 function shellQuote(value: string): string {
@@ -75,20 +236,23 @@ function shellQuote(value: string): string {
 	return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-function resolveProjectRoot(params: ProjectPaneParams, deps: ProjectPaneDeps): string | { error: string } {
-	const requested = params.cwd?.trim() || deps.cwd;
+function resolveProjectRoot(requested: string): ProjectPaneResult<string> {
 	const resolved = path.resolve(requested);
 	try {
 		const stat = fs.statSync(resolved);
-		if (!stat.isDirectory()) return { error: `Project pane target '${resolved}' is not a directory.` };
-		return fs.realpathSync(resolved);
+		if (!stat.isDirectory()) return projectPaneError("INVALID_PROJECT_ROOT", `Project pane target '${resolved}' is not a directory.`, { projectRoot: resolved });
+		return { ok: true, data: fs.realpathSync(resolved) };
 	} catch (cause) {
-		return { error: `Project pane target '${resolved}' is unavailable: ${cause instanceof Error ? cause.message : String(cause)}` };
+		return projectPaneError("INVALID_PROJECT_ROOT", `Project pane target '${resolved}' is unavailable: ${cause instanceof Error ? cause.message : String(cause)}`, { projectRoot: resolved });
 	}
 }
 
-async function paneExists(client: HerdrClient, paneId: string, signal?: AbortSignal): Promise<HerdrResult<unknown>> {
-	return client.run(["pane", "get", paneId], { timeoutMs: 5_000, signal });
+async function inspectPane(client: HerdrClient, paneId: string, signal?: AbortSignal): Promise<ProjectPaneResult<ProjectPaneRuntime>> {
+	const live = await client.run(["pane", "get", paneId], { timeoutMs: 5_000, signal });
+	if (live.ok === false) return projectPaneError(live.error.code, live.error.message, { details: live.error.details });
+	const runtime = projectPaneRuntime(live.data);
+	if (!runtime) return projectPaneError("INVALID_PANE_RESPONSE", `Herdr pane get returned no pane runtime for '${paneId}'.`, { details: live.data });
+	return { ok: true, data: runtime };
 }
 
 function projectPaneCommand(message: string | undefined): string {
@@ -97,58 +261,218 @@ function projectPaneCommand(message: string | undefined): string {
 	return `${process.platform === "win32" ? "& " : ""}${[command.command, ...command.args].map(shellQuote).join(" ")}`;
 }
 
-export async function handleHerdrProjectPaneAction(action: HerdrProjectPaneAction, params: ProjectPaneParams, deps: ProjectPaneDeps): Promise<AgentToolResult<Details>> {
-	const projectRoot = resolveProjectRoot(params, deps);
-	if (typeof projectRoot !== "string") return result(projectRoot.error, true);
-	const client = deps.client ?? createHerdrClient();
-	const existing = readHerdrProjectPaneBinding(projectRoot);
+function canonicalRuntimePath(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	try { return fs.realpathSync(path.resolve(value)); } catch { return path.resolve(value); }
+}
 
-	if (action === "project.status") {
-		if (!existing) return result(`No Herdr project pane binding exists for ${projectRoot}.`);
-		const live = await paneExists(client, existing.paneId, deps.signal);
-		if (live.ok === false) return result(`${formatHerdrError(live.error)}\nBinding: ${bindingPath(projectRoot)}`, true);
-		return result(`Herdr project pane ${existing.paneId} is open for ${projectRoot}.\nBinding: ${bindingPath(projectRoot)}`);
-	}
+function projectPaneOwnership(runtime: ProjectPaneRuntime, binding: HerdrProjectPaneBinding, projectRoot: string): "verified" | "unknown" | "mismatch" {
+	if (runtime.paneId !== binding.paneId) return "mismatch";
+	const runtimeRoot = canonicalRuntimePath(runtime.cwd);
+	if (!runtimeRoot) return "unknown";
+	return runtimeRoot === projectRoot ? "verified" : "mismatch";
+}
 
-	if (action === "project.close") {
-		if (!existing) return result(`No Herdr project pane binding exists for ${projectRoot}.`);
-		const closed = await client.run(["pane", "close", existing.paneId], { timeoutMs: 10_000, signal: deps.signal });
-		if (closed.ok === false && closed.error.code !== "NOT_FOUND" && closed.error.code !== "PANE_GONE") return result(formatHerdrError(closed.error), true);
-		fs.rmSync(bindingPath(projectRoot), { force: true });
-		return result(`Closed Herdr project pane ${existing.paneId} for ${projectRoot}.`);
+function bindingForManager(projectRoot: string, legacyToolCompatibility: boolean | undefined): ProjectPaneResult<HerdrProjectPaneBinding | undefined> {
+	const read = readBinding(projectRoot, !legacyToolCompatibility);
+	if (read.state === "absent") return { ok: true, data: undefined };
+	if (read.state === "invalid") {
+		if (legacyToolCompatibility) return { ok: true, data: undefined };
+		return projectPaneError("INVALID_BINDING", `Project pane binding '${projectPaneBindingPath(projectRoot)}' is malformed.`, {
+			projectRoot, bindingPath: projectPaneBindingPath(projectRoot),
+		});
 	}
+	const binding = read.binding!;
+	if (!legacyToolCompatibility && canonicalRuntimePath(binding.projectRoot) !== projectRoot) {
+		return projectPaneError("INVALID_BINDING", `Project pane binding root '${binding.projectRoot}' does not match '${projectRoot}'.`, {
+			projectRoot, bindingPath: projectPaneBindingPath(projectRoot), details: binding,
+		});
+	}
+	return { ok: true, data: binding };
+}
 
-	const detected = await detectHerdr(client, deps.signal);
-	if (detected.ok === false) return result(formatHerdrError(detected.error), true);
-	if (existing) {
-		const live = await paneExists(client, existing.paneId, deps.signal);
-		if (live.ok) return result(`Herdr project pane ${existing.paneId} is already open for ${projectRoot}.${params.focus ? " Herdr cannot refocus an arbitrary raw pane id; select it in the Herdr UI." : ""}`);
-	}
-	const splitArgs = ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot];
-	if (params.focus !== false) splitArgs.push("--focus");
-	const split = await client.run(splitArgs, { timeoutMs: 15_000, signal: deps.signal });
-	if (split.ok === false) return result(formatHerdrError(split.error), true);
-	const paneId = extractPaneId(split.data);
-	if (!paneId) return result("Herdr project pane error (PANE_GONE): pane split returned no pane id.", true);
-	const startupMessage = params.message?.trim();
-	const command = projectPaneCommand(startupMessage);
-	const started = await client.run(["pane", "run", paneId, command], { timeoutMs: 15_000, signal: deps.signal });
-	if (started.ok === false) {
-		await client.run(["pane", "close", paneId], { timeoutMs: 5_000 });
-		return result(formatHerdrError(started.error), true);
-	}
-	const now = (deps.now?.() ?? new Date()).toISOString();
-	const binding: HerdrProjectPaneBinding = {
-		schemaVersion: 1,
-		kind: "herdr-project-pane",
+function common(projectRoot: string): ProjectPaneCommonData {
+	return {
+		apiVersion: PROJECT_PANES_API_VERSION,
 		projectRoot,
-		paneId,
-		openedAt: now,
-		...(params.focus !== false ? { lastFocusedAt: now } : {}),
-		herdrVersion: detected.data.versionText,
-		command,
-		...(startupMessage ? { startupMessage } : {}),
+		bindingPath: projectPaneBindingPath(projectRoot),
+		trust: PROJECT_PANE_TRUST_STATUS,
 	};
-	writeAtomicJson(bindingPath(projectRoot), binding);
-	return result(`Opened Herdr project pane ${paneId} for ${projectRoot}. The pane runs its own Pi session; subagents launched there belong to that project.`);
+}
+
+function createProjectPaneManagerInternal(options: InternalProjectPaneManagerOptions = {}): ProjectPaneManager {
+	const client = options.client ?? createHerdrClient();
+	return {
+		async status(input) {
+			const root = resolveProjectRoot(input.cwd);
+			if (!root.ok) return root;
+			const projectRoot = root.data;
+			const bindingResult = bindingForManager(projectRoot, options.legacyToolCompatibility);
+			if (!bindingResult.ok) return bindingResult;
+			const existing = bindingResult.data;
+			if (!existing) return { ok: true, data: { ...common(projectRoot), state: "absent", ownership: "unknown", safeToClose: true } };
+			const live = await inspectPane(client, existing.paneId, input.signal);
+			if (!live.ok) {
+				if (live.error.code === "INVALID_PANE_RESPONSE" && options.legacyToolCompatibility) {
+					const runtime: ProjectPaneRuntime = { paneId: existing.paneId, agentStatus: "unknown" };
+					return { ok: true, data: { ...common(projectRoot), state: "open", binding: existing, runtime, ownership: "unknown", safeToClose: false } };
+				}
+				if (live.error.code === "NOT_FOUND" || live.error.code === "PANE_GONE") {
+					return { ok: true, data: {
+						...common(projectRoot), state: "stale", binding: existing, ownership: "unknown", safeToClose: false,
+						staleReason: { code: live.error.code, message: live.error.message },
+					} };
+				}
+				return { ok: false, error: { ...live.error, projectRoot, bindingPath: projectPaneBindingPath(projectRoot) } };
+			}
+			const ownership = projectPaneOwnership(live.data, existing, projectRoot);
+			return { ok: true, data: {
+				...common(projectRoot), state: "open", binding: existing, runtime: live.data, ownership,
+				safeToClose: live.data.agentStatus === "idle" && ownership === "verified",
+			} };
+		},
+
+		async open(input) {
+			const root = resolveProjectRoot(input.cwd);
+			if (!root.ok) return root;
+			const projectRoot = root.data;
+			const detected = await detectHerdr(client, input.signal);
+			if (!detected.ok) return projectPaneError(detected.error.code, detected.error.message, { projectRoot, details: detected.error.details });
+			const bindingResult = bindingForManager(projectRoot, options.legacyToolCompatibility);
+			if (!bindingResult.ok) return bindingResult;
+			const existing = bindingResult.data;
+			if (existing) {
+				const live = await inspectPane(client, existing.paneId, input.signal);
+				if (live.ok) {
+					const ownership = projectPaneOwnership(live.data, existing, projectRoot);
+					if (!options.legacyToolCompatibility && ownership !== "verified") {
+						return projectPaneError("PANE_OWNERSHIP_UNVERIFIED", `Project pane '${existing.paneId}' ownership is '${ownership}' for '${projectRoot}'.`, {
+							projectRoot, bindingPath: projectPaneBindingPath(projectRoot), details: live.data,
+						});
+					}
+					return { ok: true, data: { ...common(projectRoot), disposition: "already-open", binding: existing, runtime: live.data } };
+				}
+				if (live.error.code === "INVALID_PANE_RESPONSE" && options.legacyToolCompatibility) {
+					return { ok: true, data: {
+						...common(projectRoot), disposition: "already-open", binding: existing,
+						runtime: { paneId: existing.paneId, agentStatus: "unknown" },
+					} };
+				}
+				const stale = live.error.code === "NOT_FOUND" || live.error.code === "PANE_GONE";
+				if (!stale && !options.legacyToolCompatibility) {
+					return { ok: false, error: { ...live.error, projectRoot, bindingPath: projectPaneBindingPath(projectRoot) } };
+				}
+			}
+			const splitArgs = ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot];
+			if (input.focus !== false) splitArgs.push("--focus");
+			const split = await client.run(splitArgs, { timeoutMs: 15_000, signal: input.signal });
+			if (!split.ok) return projectPaneError(split.error.code, split.error.message, { projectRoot, details: split.error.details });
+			const paneId = extractPaneId(split.data);
+			if (!paneId) return projectPaneError(options.legacyToolCompatibility ? "PANE_GONE" : "INVALID_PANE_RESPONSE", "Herdr pane split returned no pane id.", { projectRoot, details: split.data });
+			const startupMessage = input.message?.trim();
+			const command = projectPaneCommand(startupMessage);
+			const started = await client.run(["pane", "run", paneId, command], { timeoutMs: 15_000, signal: input.signal });
+			if (!started.ok) {
+				await client.run(["pane", "close", paneId], { timeoutMs: 5_000 });
+				return projectPaneError(started.error.code, started.error.message, { projectRoot, details: started.error.details });
+			}
+			const now = (options.now?.() ?? new Date()).toISOString();
+			const binding: HerdrProjectPaneBinding = {
+				schemaVersion: 1,
+				kind: "herdr-project-pane",
+				projectRoot,
+				paneId,
+				openedAt: now,
+				...(input.focus !== false ? { lastFocusedAt: now } : {}),
+				herdrVersion: detected.data.versionText,
+				command,
+				...(startupMessage ? { startupMessage } : {}),
+			};
+			writeAtomicJson(projectPaneBindingPath(projectRoot), binding);
+			return { ok: true, data: { ...common(projectRoot), disposition: "opened", binding } };
+		},
+
+		async close(input) {
+			const root = resolveProjectRoot(input.cwd);
+			if (!root.ok) return root;
+			const projectRoot = root.data;
+			const bindingResult = bindingForManager(projectRoot, options.legacyToolCompatibility);
+			if (!bindingResult.ok) return bindingResult;
+			const existing = bindingResult.data;
+			if (!existing) return { ok: true, data: { ...common(projectRoot), disposition: "absent" } };
+			let runtime: ProjectPaneRuntime | undefined;
+			if (input.requireIdle) {
+				const live = await inspectPane(client as HerdrClient, existing.paneId, input.signal);
+				if (!live.ok) {
+					if (live.error.code === "NOT_FOUND" || live.error.code === "PANE_GONE") {
+						fs.rmSync(projectPaneBindingPath(projectRoot), { force: true });
+						return { ok: true, data: { ...common(projectRoot), disposition: "stale-binding-removed", binding: existing } };
+					}
+					return { ok: false, error: { ...live.error, projectRoot, bindingPath: projectPaneBindingPath(projectRoot) } };
+				}
+				runtime = live.data;
+				const ownership = projectPaneOwnership(runtime, existing, projectRoot);
+				if (ownership !== "verified") {
+					return projectPaneError("PANE_OWNERSHIP_UNVERIFIED", `Project pane '${existing.paneId}' ownership is '${ownership}' for '${projectRoot}'.`, {
+						projectRoot, bindingPath: projectPaneBindingPath(projectRoot), details: runtime,
+					});
+				}
+				if (runtime.agentStatus !== "idle") {
+					return projectPaneError("PANE_NOT_IDLE", `Project pane '${existing.paneId}' is '${runtime.agentStatus}', not explicitly idle.`, {
+						projectRoot, bindingPath: projectPaneBindingPath(projectRoot), details: runtime,
+					});
+				}
+			}
+			const closed = await client.run(["pane", "close", existing.paneId], { timeoutMs: 10_000, signal: input.signal });
+			if (!closed.ok && closed.error.code !== "NOT_FOUND" && closed.error.code !== "PANE_GONE") {
+				return projectPaneError(closed.error.code, closed.error.message, { projectRoot, bindingPath: projectPaneBindingPath(projectRoot), details: closed.error.details });
+			}
+			const disposition: CloseProjectPaneData["disposition"] = closed.ok ? "closed" : "stale-binding-removed";
+			fs.rmSync(projectPaneBindingPath(projectRoot), { force: true });
+			return { ok: true, data: { ...common(projectRoot), disposition, binding: existing, ...(runtime ? { runtime } : {}) } };
+		},
+	};
+}
+
+export function createProjectPaneManager(options: ProjectPaneManagerOptions = {}): ProjectPaneManager {
+	return createProjectPaneManagerInternal(options);
+}
+
+export async function openProjectPane(options: OpenProjectPaneOptions): Promise<ProjectPaneResult<OpenProjectPaneData>> {
+	return createProjectPaneManager().open(options);
+}
+
+export async function getProjectPaneStatus(options: GetProjectPaneStatusOptions): Promise<ProjectPaneResult<ProjectPaneStatusData>> {
+	return createProjectPaneManager().status(options);
+}
+
+export async function closeProjectPane(options: CloseProjectPaneOptions): Promise<ProjectPaneResult<CloseProjectPaneData>> {
+	return createProjectPaneManager().close(options);
+}
+
+export async function handleHerdrProjectPaneAction(action: HerdrProjectPaneAction, params: ProjectPaneParams, deps: ProjectPaneDeps): Promise<AgentToolResult<Details>> {
+	const requested = params.cwd?.trim() || deps.cwd;
+	const manager = createProjectPaneManagerInternal({ client: deps.client, now: deps.now, legacyToolCompatibility: true });
+	if (action === "project.status") {
+		const status = await manager.status({ cwd: requested, signal: deps.signal });
+		if (!status.ok) return toolResult(formatProjectPaneError(status.error), true);
+		if (status.data.state === "absent") return toolResult(`No Herdr project pane binding exists for ${status.data.projectRoot}.`);
+		if (status.data.state === "stale") {
+			const reason = status.data.staleReason!;
+			return toolResult(`${formatProjectPaneError(reason)}\nBinding: ${status.data.bindingPath}`, true);
+		}
+		return toolResult(`Herdr project pane ${status.data.binding!.paneId} is open for ${status.data.projectRoot}.\nBinding: ${status.data.bindingPath}`);
+	}
+	if (action === "project.close") {
+		const closed = await manager.close({ cwd: requested, signal: deps.signal });
+		if (!closed.ok) return toolResult(formatProjectPaneError(closed.error), true);
+		if (closed.data.disposition === "absent") return toolResult(`No Herdr project pane binding exists for ${closed.data.projectRoot}.`);
+		return toolResult(`Closed Herdr project pane ${closed.data.binding!.paneId} for ${closed.data.projectRoot}.`);
+	}
+	const opened = await manager.open({ cwd: requested, message: params.message, focus: params.focus, signal: deps.signal });
+	if (!opened.ok) return toolResult(formatProjectPaneError(opened.error), true);
+	if (opened.data.disposition === "already-open") {
+		return toolResult(`Herdr project pane ${opened.data.binding.paneId} is already open for ${opened.data.projectRoot}.${params.focus ? " Herdr cannot refocus an arbitrary raw pane id; select it in the Herdr UI." : ""}`);
+	}
+	return toolResult(`Opened Herdr project pane ${opened.data.binding.paneId} for ${opened.data.projectRoot}. The pane runs its own Pi session; subagents launched there belong to that project.`);
 }

--- a/src/inspectors/herdr/project-panes.ts
+++ b/src/inspectors/herdr/project-panes.ts
@@ -39,6 +39,9 @@ export type ProjectPaneErrorCode = HerdrErrorCode
 	| "INVALID_PROJECT_ROOT"
 	| "INVALID_PANE_RESPONSE"
 	| "INVALID_BINDING"
+	| "BINDING_READ_FAILED"
+	| "BINDING_WRITE_FAILED"
+	| "BINDING_REMOVE_FAILED"
 	| "PANE_NOT_IDLE"
 	| "PANE_OWNERSHIP_UNVERIFIED";
 
@@ -171,16 +174,24 @@ function parseBinding(value: unknown, strict = false): HerdrProjectPaneBinding |
 	return input as HerdrProjectPaneBinding;
 }
 
-interface BindingReadResult {
-	state: "absent" | "invalid" | "valid";
-	binding?: HerdrProjectPaneBinding;
-}
+type BindingReadResult =
+	| { state: "absent" }
+	| { state: "invalid" }
+	| { state: "read-error"; cause: unknown }
+	| { state: "valid"; binding: HerdrProjectPaneBinding };
 
 function readBinding(projectRoot: string, strict: boolean): BindingReadResult {
 	const file = projectPaneBindingPath(projectRoot);
-	if (!fs.existsSync(file)) return { state: "absent" };
+	let raw: string;
 	try {
-		const binding = parseBinding(JSON.parse(fs.readFileSync(file, "utf-8")), strict);
+		raw = fs.readFileSync(file, "utf-8");
+	} catch (cause) {
+		const code = (cause as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") return { state: "absent" };
+		return { state: "read-error", cause };
+	}
+	try {
+		const binding = parseBinding(JSON.parse(raw), strict);
 		return binding ? { state: "valid", binding } : { state: "invalid" };
 	} catch {
 		return { state: "invalid" };
@@ -189,12 +200,26 @@ function readBinding(projectRoot: string, strict: boolean): BindingReadResult {
 
 /** Legacy model-facing reader; preserves the original required-field-only parsing contract. */
 export function readHerdrProjectPaneBinding(projectRoot: string): HerdrProjectPaneBinding | undefined {
-	return readBinding(projectRoot, false).binding;
+	const read = readBinding(projectRoot, false);
+	return read.state === "valid" ? read.binding : undefined;
 }
 
 /** Strict public reader for extension integrations. */
-export function readProjectPaneBinding(projectRoot: string): HerdrProjectPaneBinding | undefined {
-	return readBinding(projectRoot, true).binding;
+export function readProjectPaneBinding(projectRoot: string): ProjectPaneResult<HerdrProjectPaneBinding | undefined> {
+	const read = readBinding(projectRoot, true);
+	if (read.state === "absent") return { ok: true, data: undefined };
+	if (read.state === "read-error") {
+		const bindingPath = projectPaneBindingPath(projectRoot);
+		return projectPaneError("BINDING_READ_FAILED", `Failed to read project pane binding '${bindingPath}': ${read.cause instanceof Error ? read.cause.message : String(read.cause)}`, {
+			projectRoot, bindingPath, details: fileSystemErrorDetails(read.cause),
+		});
+	}
+	if (read.state === "invalid") {
+		return projectPaneError("INVALID_BINDING", `Project pane binding '${projectPaneBindingPath(projectRoot)}' is malformed.`, {
+			projectRoot, bindingPath: projectPaneBindingPath(projectRoot),
+		});
+	}
+	return { ok: true, data: read.binding };
 }
 
 function paneRecord(value: unknown): Record<string, unknown> | undefined {
@@ -276,13 +301,20 @@ function projectPaneOwnership(runtime: ProjectPaneRuntime, binding: HerdrProject
 function bindingForManager(projectRoot: string, legacyToolCompatibility: boolean | undefined): ProjectPaneResult<HerdrProjectPaneBinding | undefined> {
 	const read = readBinding(projectRoot, !legacyToolCompatibility);
 	if (read.state === "absent") return { ok: true, data: undefined };
+	if (read.state === "read-error") {
+		if (legacyToolCompatibility) return { ok: true, data: undefined };
+		const bindingPath = projectPaneBindingPath(projectRoot);
+		return projectPaneError("BINDING_READ_FAILED", `Failed to read project pane binding '${bindingPath}': ${read.cause instanceof Error ? read.cause.message : String(read.cause)}`, {
+			projectRoot, bindingPath, details: fileSystemErrorDetails(read.cause),
+		});
+	}
 	if (read.state === "invalid") {
 		if (legacyToolCompatibility) return { ok: true, data: undefined };
 		return projectPaneError("INVALID_BINDING", `Project pane binding '${projectPaneBindingPath(projectRoot)}' is malformed.`, {
 			projectRoot, bindingPath: projectPaneBindingPath(projectRoot),
 		});
 	}
-	const binding = read.binding!;
+	const binding = read.binding;
 	if (!legacyToolCompatibility && canonicalRuntimePath(binding.projectRoot) !== projectRoot) {
 		return projectPaneError("INVALID_BINDING", `Project pane binding root '${binding.projectRoot}' does not match '${projectRoot}'.`, {
 			projectRoot, bindingPath: projectPaneBindingPath(projectRoot), details: binding,
@@ -298,6 +330,24 @@ function common(projectRoot: string): ProjectPaneCommonData {
 		bindingPath: projectPaneBindingPath(projectRoot),
 		trust: PROJECT_PANE_TRUST_STATUS,
 	};
+}
+
+function fileSystemErrorDetails(cause: unknown): unknown {
+	if (!(cause instanceof Error)) return cause;
+	const code = (cause as NodeJS.ErrnoException).code;
+	return { name: cause.name, message: cause.message, ...(code ? { code } : {}) };
+}
+
+function removeProjectPaneBinding(projectRoot: string): ProjectPaneResult<void> {
+	const bindingPath = projectPaneBindingPath(projectRoot);
+	try {
+		fs.rmSync(bindingPath, { force: true });
+		return { ok: true, data: undefined };
+	} catch (cause) {
+		return projectPaneError("BINDING_REMOVE_FAILED", `Failed to remove project pane binding '${bindingPath}': ${cause instanceof Error ? cause.message : String(cause)}`, {
+			projectRoot, bindingPath, details: fileSystemErrorDetails(cause),
+		});
+	}
 }
 
 function createProjectPaneManagerInternal(options: InternalProjectPaneManagerOptions = {}): ProjectPaneManager {
@@ -388,7 +438,26 @@ function createProjectPaneManagerInternal(options: InternalProjectPaneManagerOpt
 				command,
 				...(startupMessage ? { startupMessage } : {}),
 			};
-			writeAtomicJson(projectPaneBindingPath(projectRoot), binding);
+			const bindingPath = projectPaneBindingPath(projectRoot);
+			try {
+				writeAtomicJson(bindingPath, binding);
+			} catch (cause) {
+				let cleanup: { paneClosed: true } | { paneClosed: false; error: unknown };
+				try {
+					const closed = await client.run(["pane", "close", paneId], { timeoutMs: 5_000 });
+					cleanup = closed.ok
+						? { paneClosed: true }
+						: { paneClosed: false, error: closed.error };
+				} catch (cleanupCause) {
+					cleanup = { paneClosed: false, error: fileSystemErrorDetails(cleanupCause) };
+				}
+				const cleanupMessage = cleanup.paneClosed
+					? ` The newly opened pane '${paneId}' was closed.`
+					: ` Cleanup could not close the newly opened pane '${paneId}'.`;
+				return projectPaneError("BINDING_WRITE_FAILED", `Failed to persist project pane binding '${bindingPath}': ${cause instanceof Error ? cause.message : String(cause)}.${cleanupMessage}`, {
+					projectRoot, bindingPath, details: { cause: fileSystemErrorDetails(cause), cleanup },
+				});
+			}
 			return { ok: true, data: { ...common(projectRoot), disposition: "opened", binding } };
 		},
 
@@ -405,7 +474,8 @@ function createProjectPaneManagerInternal(options: InternalProjectPaneManagerOpt
 				const live = await inspectPane(client as HerdrClient, existing.paneId, input.signal);
 				if (!live.ok) {
 					if (live.error.code === "NOT_FOUND" || live.error.code === "PANE_GONE") {
-						fs.rmSync(projectPaneBindingPath(projectRoot), { force: true });
+						const removed = removeProjectPaneBinding(projectRoot);
+						if (!removed.ok) return removed;
 						return { ok: true, data: { ...common(projectRoot), disposition: "stale-binding-removed", binding: existing } };
 					}
 					return { ok: false, error: { ...live.error, projectRoot, bindingPath: projectPaneBindingPath(projectRoot) } };
@@ -428,7 +498,8 @@ function createProjectPaneManagerInternal(options: InternalProjectPaneManagerOpt
 				return projectPaneError(closed.error.code, closed.error.message, { projectRoot, bindingPath: projectPaneBindingPath(projectRoot), details: closed.error.details });
 			}
 			const disposition: CloseProjectPaneData["disposition"] = closed.ok ? "closed" : "stale-binding-removed";
-			fs.rmSync(projectPaneBindingPath(projectRoot), { force: true });
+			const removed = removeProjectPaneBinding(projectRoot);
+			if (!removed.ok) return removed;
 			return { ok: true, data: { ...common(projectRoot), disposition, binding: existing, ...(runtime ? { runtime } : {}) } };
 		},
 	};

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -9,6 +9,7 @@ import { handleHerdrInspectorAction, readHerdrInspectorBinding } from "../../src
 import { createHerdrClient, detectHerdr, parseHerdrVersion, supportsRawPanes, type HerdrClient } from "../../src/inspectors/herdr/client.ts";
 import { formatInspectorDashboard, submitInspectorControl } from "../../src/inspectors/herdr/inspector-runner.ts";
 import { handleHerdrProjectPaneAction, readHerdrProjectPaneBinding } from "../../src/inspectors/herdr/project-panes.ts";
+import { PROJECT_PANES_API_VERSION, createProjectPaneManager } from "../../src/api/project-panes.ts";
 import { consumeSteerRequests, consumeStopRequest } from "../../src/runs/background/control-channel.ts";
 import { PI_SUBAGENT_PI_BINARY_ENV } from "../../src/runs/shared/pi-spawn.ts";
 import type { AsyncStatus } from "../../src/shared/types.ts";
@@ -191,6 +192,10 @@ describe("Herdr inspector", () => {
 					calls.push(args);
 					if (args[0] === "--version") return { ok: true, data: "herdr 0.7.5" as T };
 					if (args[0] === "pane" && args[1] === "split") return { ok: true, data: { pane: { pane_id: "w1:p10" } } as T };
+					if (args[0] === "pane" && args[1] === "get") return { ok: true, data: { pane: {
+						pane_id: "w1:p10", agent: "pi", agent_status: "idle", cwd: projectRoot,
+						foreground_cwd: projectRoot, focused: false, terminal_title_stripped: "Pi · project",
+					} } as T };
 					return { ok: true, data: {} as T };
 				},
 			};
@@ -217,6 +222,18 @@ describe("Herdr inspector", () => {
 			assert.equal(status.isError, undefined, text(status));
 			assert.match(text(status), /project pane w1:p10 is open/);
 
+			const manager = createProjectPaneManager({ client });
+			const publicStatus = await manager.status({ cwd: root });
+			assert.equal(publicStatus.ok, true);
+			if (publicStatus.ok) {
+				assert.equal(publicStatus.data.apiVersion, PROJECT_PANES_API_VERSION);
+				assert.equal(publicStatus.data.state, "open");
+				assert.equal(publicStatus.data.runtime?.agentStatus, "idle");
+				assert.equal(publicStatus.data.runtime?.cwd, projectRoot);
+				assert.equal(publicStatus.data.safeToClose, true);
+				assert.equal(publicStatus.data.trust, "human-verification-required");
+			}
+
 			const closed = await handleHerdrProjectPaneAction("project.close", { cwd: root }, { cwd: process.cwd(), client });
 			assert.equal(closed.isError, undefined, text(closed));
 			assert.match(text(closed), /Closed Herdr project pane w1:p10/);
@@ -225,6 +242,78 @@ describe("Herdr inspector", () => {
 		} finally {
 			if (previousPiBinary === undefined) delete process.env[PI_SUBAGENT_PI_BINARY_ENV];
 			else process.env[PI_SUBAGENT_PI_BINARY_ENV] = previousPiBinary;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed when an idle-only project pane close sees active work", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-project-pane-busy-"));
+		try {
+			const projectRoot = fs.realpathSync(root);
+			const calls: string[][] = [];
+			let opened = false;
+			const client: HerdrClient = {
+				run: async <T>(args: string[]) => {
+					calls.push(args);
+					if (args[0] === "--version") return { ok: true, data: "herdr 0.8.0" as T };
+					if (args[0] === "pane" && args[1] === "split") return { ok: true, data: { pane: { pane_id: "w1:p11" } } as T };
+					if (args[0] === "pane" && args[1] === "run") { opened = true; return { ok: true, data: {} as T }; }
+					if (args[0] === "pane" && args[1] === "get" && opened) return { ok: true, data: { pane: {
+						pane_id: "w1:p11", agent: "pi", agent_status: "working", cwd: projectRoot,
+					} } as T };
+					return { ok: true, data: {} as T };
+				},
+			};
+			const manager = createProjectPaneManager({ client });
+			const open = await manager.open({ cwd: root, focus: false });
+			assert.equal(open.ok, true);
+			const closed = await manager.close({ cwd: root, requireIdle: true });
+			assert.equal(closed.ok, false);
+			if (!closed.ok) assert.equal(closed.error.code, "PANE_NOT_IDLE");
+			assert.equal(calls.some((args) => args.join(" ") === "pane close w1:p11"), false);
+			assert.equal(readHerdrProjectPaneBinding(root)?.paneId, "w1:p11");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves legacy model-facing recovery for transient and opaque pane inspection results", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-project-pane-legacy-"));
+		try {
+			let splitCount = 0;
+			let getMode: "valid" | "timeout" | "opaque" = "valid";
+			const client: HerdrClient = {
+				run: async <T>(args: string[]) => {
+					if (args[0] === "--version") return { ok: true, data: "herdr 0.8.0" as T };
+					if (args[0] === "pane" && args[1] === "split") {
+						splitCount++;
+						return { ok: true, data: { pane: { pane_id: `w1:p3${splitCount}` } } as T };
+					}
+					if (args[0] === "pane" && args[1] === "get") {
+						if (getMode === "timeout") return { ok: false, error: { code: "TIMEOUT", message: "temporary" } };
+						if (getMode === "opaque") return { ok: true, data: {} as T };
+						return { ok: true, data: { pane: { pane_id: `w1:p3${splitCount}`, agent_status: "idle", cwd: root } } as T };
+					}
+					return { ok: true, data: {} as T };
+				},
+			};
+			const first = await handleHerdrProjectPaneAction("project.open", { cwd: root }, { cwd: root, client });
+			assert.equal(first.isError, undefined, text(first));
+			getMode = "timeout";
+			const recovered = await handleHerdrProjectPaneAction("project.open", { cwd: root }, { cwd: root, client });
+			assert.equal(recovered.isError, undefined, text(recovered));
+			assert.equal(splitCount, 2);
+			assert.equal(readHerdrProjectPaneBinding(root)?.paneId, "w1:p32");
+			getMode = "opaque";
+			const status = await handleHerdrProjectPaneAction("project.status", { cwd: root }, { cwd: root, client });
+			assert.equal(status.isError, undefined, text(status));
+			assert.match(text(status), /w1:p32 is open/);
+			const legacyBinding = readHerdrProjectPaneBinding(root)!;
+			fs.writeFileSync(path.join(root, ".pi-subagents", "project-panes", "herdr.json"), JSON.stringify({ ...legacyBinding, startupMessage: 42 }));
+			const closed = await handleHerdrProjectPaneAction("project.close", { cwd: root }, { cwd: root, client });
+			assert.equal(closed.isError, undefined, text(closed));
+			assert.equal(readHerdrProjectPaneBinding(root), undefined);
+		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -63,6 +63,7 @@ test("published extension APIs use supported package entrypoints", async () => {
 		"./intercom-bridge": "./src/api/intercom-bridge.ts",
 		"./pi-args": "./src/api/pi-args.ts",
 		"./shared-types": "./src/api/shared-types.ts",
+		"./project-panes": "./src/api/project-panes.ts",
 	});
 	const backgroundWork = await import("pi-subagents/background-work");
 	assert.equal(backgroundWork.BACKGROUND_WORK_PROTOCOL_VERSION, 1);
@@ -89,6 +90,11 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.equal(typeof sharedTypes.wrapForkTask, "function");
 	assert.equal(typeof sharedTypes.DEFAULT_FORK_PREAMBLE, "string");
 	assert.equal("TEMP_ROOT_DIR" in sharedTypes, false);
+	const projectPanes = await import("pi-subagents/project-panes");
+	assert.equal(projectPanes.PROJECT_PANES_API_VERSION, 1);
+	assert.equal(typeof projectPanes.openProjectPane, "function");
+	assert.equal(typeof projectPanes.getProjectPaneStatus, "function");
+	assert.equal(typeof projectPanes.closeProjectPane, "function");
 });
 
 test("direct @earendil-works runtime imports are declared for CI installs", () => {

--- a/test/unit/project-panes-public-api.test.ts
+++ b/test/unit/project-panes-public-api.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import {
+	PROJECT_PANES_API_VERSION,
+	PROJECT_PANE_TRUST_STATUS,
+	createProjectPaneManager,
+	openProjectPane,
+	getProjectPaneStatus,
+	closeProjectPane,
+	projectPaneBindingPath,
+	readProjectPaneBinding,
+	type ProjectPaneCommandClient,
+} from "pi-subagents/project-panes";
+
+describe("public project-panes package export", () => {
+	it("exposes the versioned extension-to-extension lifecycle surface", () => {
+		assert.equal(PROJECT_PANES_API_VERSION, 1);
+		assert.equal(PROJECT_PANE_TRUST_STATUS, "human-verification-required");
+		assert.equal(typeof createProjectPaneManager, "function");
+		assert.equal(typeof openProjectPane, "function");
+		assert.equal(typeof getProjectPaneStatus, "function");
+		assert.equal(typeof closeProjectPane, "function");
+		assert.equal(typeof readProjectPaneBinding, "function");
+	});
+
+	it("runs the structured lifecycle and verifies pane ownership before idle close", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-"));
+		try {
+			const projectRoot = fs.realpathSync(root);
+			const calls: string[][] = [];
+			let opened = false;
+			const client: ProjectPaneCommandClient = {
+				run: async <T>(args: string[]) => {
+					calls.push(args);
+					if (args[0] === "--version") return { ok: true, data: "herdr 0.8.0" as T };
+					if (args[0] === "pane" && args[1] === "split") return { ok: true, data: { pane: { pane_id: "w1:p20" } } as T };
+					if (args[0] === "pane" && args[1] === "run") { opened = true; return { ok: true, data: {} as T }; }
+					if (args[0] === "pane" && args[1] === "get" && opened) return { ok: true, data: { pane: {
+						pane_id: "w1:p20", agent: "pi", agent_status: "IDLE", cwd: projectRoot,
+						foreground_cwd: projectRoot, focused: false, terminal_title_stripped: "Pi · project",
+					} } as T };
+					return { ok: true, data: {} as T };
+				},
+			};
+			const manager = createProjectPaneManager({ client, now: () => new Date("2026-01-01T00:00:00.000Z") });
+			const open = await manager.open({ cwd: root, focus: false });
+			assert.equal(open.ok, true);
+			if (open.ok) {
+				assert.equal(open.data.disposition, "opened");
+				assert.equal(open.data.projectRoot, projectRoot);
+				assert.equal(open.data.trust, "human-verification-required");
+			}
+			const status = await manager.status({ cwd: root });
+			assert.equal(status.ok, true);
+			if (status.ok) {
+				assert.equal(status.data.state, "open");
+				assert.equal(status.data.runtime?.agentStatus, "idle");
+				assert.equal(status.data.ownership, "verified");
+				assert.equal(status.data.safeToClose, true);
+			}
+			const close = await manager.close({ cwd: root, requireIdle: true });
+			assert.equal(close.ok, true);
+			if (close.ok) assert.equal(close.data.disposition, "closed");
+			assert.equal(readProjectPaneBinding(root), undefined);
+			assert.ok(calls.some((args) => args.join(" ") === "pane close w1:p20"));
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("distinguishes a stale binding on the default close path", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-stale-"));
+		try {
+			const projectRoot = fs.realpathSync(root);
+			fs.mkdirSync(path.dirname(projectPaneBindingPath(projectRoot)), { recursive: true });
+			fs.writeFileSync(projectPaneBindingPath(projectRoot), JSON.stringify({
+				schemaVersion: 1, kind: "herdr-project-pane", projectRoot, paneId: "w1:p21",
+				openedAt: "2026-01-01T00:00:00.000Z", command: "pi",
+			}));
+			const client: ProjectPaneCommandClient = {
+				run: async () => ({ ok: false, error: { code: "NOT_FOUND", message: "gone" } }),
+			};
+			const result = await createProjectPaneManager({ client }).close({ cwd: root });
+			assert.equal(result.ok, true);
+			if (result.ok) assert.equal(result.data.disposition, "stale-binding-removed");
+			assert.equal(readProjectPaneBinding(root), undefined);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects idle close when Herdr pane ownership no longer matches the project", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-owner-"));
+		const other = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-other-"));
+		try {
+			const projectRoot = fs.realpathSync(root);
+			fs.mkdirSync(path.dirname(projectPaneBindingPath(projectRoot)), { recursive: true });
+			fs.writeFileSync(projectPaneBindingPath(projectRoot), JSON.stringify({
+				schemaVersion: 1, kind: "herdr-project-pane", projectRoot, paneId: "w1:p22",
+				openedAt: "2026-01-01T00:00:00.000Z", command: "pi",
+			}));
+			let closeCalled = false;
+			const client: ProjectPaneCommandClient = {
+				run: async <T>(args: string[]) => {
+					if (args[0] === "--version") return { ok: true, data: "herdr 0.8.0" as T };
+					if (args[1] === "get") return { ok: true, data: { pane: { pane_id: "w1:p22", agent_status: "idle", cwd: other } } as T };
+					if (args[1] === "close") closeCalled = true;
+					return { ok: true, data: {} as T };
+				},
+			};
+			const manager = createProjectPaneManager({ client });
+			const open = await manager.open({ cwd: root });
+			assert.equal(open.ok, false);
+			if (!open.ok) assert.equal(open.error.code, "PANE_OWNERSHIP_UNVERIFIED");
+			const result = await manager.close({ cwd: root, requireIdle: true });
+			assert.equal(result.ok, false);
+			if (!result.ok) assert.equal(result.error.code, "PANE_OWNERSHIP_UNVERIFIED");
+			assert.equal(closeCalled, false);
+			assert.equal(readProjectPaneBinding(root)?.paneId, "w1:p22");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+			fs.rmSync(other, { recursive: true, force: true });
+		}
+	});
+
+	it("does not expose or lifecycle-manage malformed public bindings as if they were absent", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-binding-"));
+		try {
+			const projectRoot = fs.realpathSync(root);
+			fs.mkdirSync(path.dirname(projectPaneBindingPath(projectRoot)), { recursive: true });
+			fs.writeFileSync(projectPaneBindingPath(projectRoot), JSON.stringify({
+				schemaVersion: 1, kind: "herdr-project-pane", projectRoot, paneId: "w1:p23",
+				openedAt: "2026-01-01T00:00:00.000Z", command: "pi", startupMessage: 42,
+			}));
+			assert.equal(readProjectPaneBinding(root), undefined);
+			let clientCalled = false;
+			const manager = createProjectPaneManager({ client: { run: async () => { clientCalled = true; return { ok: true, data: {} }; } } });
+			const status = await manager.status({ cwd: root });
+			assert.equal(status.ok, false);
+			if (!status.ok) assert.equal(status.error.code, "INVALID_BINDING");
+			const close = await manager.close({ cwd: root });
+			assert.equal(close.ok, false);
+			if (!close.ok) assert.equal(close.error.code, "INVALID_BINDING");
+			assert.equal(clientCalled, false);
+			assert.equal(fs.existsSync(projectPaneBindingPath(projectRoot)), true);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/project-panes-public-api.test.ts
+++ b/test/unit/project-panes-public-api.test.ts
@@ -64,7 +64,7 @@ describe("public project-panes package export", () => {
 			const close = await manager.close({ cwd: root, requireIdle: true });
 			assert.equal(close.ok, true);
 			if (close.ok) assert.equal(close.data.disposition, "closed");
-			assert.equal(readProjectPaneBinding(root), undefined);
+			assert.deepEqual(readProjectPaneBinding(root), { ok: true, data: undefined });
 			assert.ok(calls.some((args) => args.join(" ") === "pane close w1:p20"));
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
@@ -86,7 +86,92 @@ describe("public project-panes package export", () => {
 			const result = await createProjectPaneManager({ client }).close({ cwd: root });
 			assert.equal(result.ok, true);
 			if (result.ok) assert.equal(result.data.disposition, "stale-binding-removed");
-			assert.equal(readProjectPaneBinding(root), undefined);
+			assert.deepEqual(readProjectPaneBinding(root), { ok: true, data: undefined });
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("returns a structured error when an existing binding cannot be read", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-read-failure-"));
+		try {
+			const projectRoot = fs.realpathSync(root);
+			const bindingPath = projectPaneBindingPath(projectRoot);
+			fs.mkdirSync(bindingPath, { recursive: true });
+			const binding = readProjectPaneBinding(projectRoot);
+			assert.equal(binding.ok, false);
+			if (!binding.ok) {
+				assert.equal(binding.error.code, "BINDING_READ_FAILED");
+				assert.equal(binding.error.bindingPath, bindingPath);
+			}
+			let clientCalled = false;
+			const manager = createProjectPaneManager({ client: { run: async () => { clientCalled = true; return { ok: true, data: {} }; } } });
+			const status = await manager.status({ cwd: root });
+			assert.equal(status.ok, false);
+			if (!status.ok) {
+				assert.equal(status.error.code, "BINDING_READ_FAILED");
+				assert.equal(status.error.bindingPath, bindingPath);
+				assert.match(status.error.message, /Failed to read project pane binding/);
+				assert.match(String((status.error.details as { code?: unknown }).code), /EISDIR|EPERM|EACCES/);
+			}
+			assert.equal(clientCalled, false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("returns a structured error and closes the pane when binding persistence fails", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-write-failure-"));
+		try {
+			fs.writeFileSync(path.join(root, ".pi-subagents"), "directory collision");
+			const calls: string[][] = [];
+			const client: ProjectPaneCommandClient = {
+				run: async <T>(args: string[]) => {
+					calls.push(args);
+					if (args[0] === "--version") return { ok: true, data: "herdr 0.8.0" as T };
+					if (args[1] === "split") return { ok: true, data: { pane: { pane_id: "w1:p24" } } as T };
+					return { ok: true, data: {} as T };
+				},
+			};
+			const result = await createProjectPaneManager({ client }).open({ cwd: root, focus: false });
+			assert.equal(result.ok, false);
+			if (!result.ok) {
+				assert.equal(result.error.code, "BINDING_WRITE_FAILED");
+				assert.equal(result.error.bindingPath, projectPaneBindingPath(fs.realpathSync(root)));
+				assert.match(result.error.message, /newly opened pane 'w1:p24' was closed/);
+			}
+			assert.ok(calls.some((args) => args.join(" ") === "pane close w1:p24"));
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("returns a structured error when binding removal fails after closing the pane", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-remove-failure-"));
+		try {
+			const projectRoot = fs.realpathSync(root);
+			const bindingPath = projectPaneBindingPath(projectRoot);
+			fs.mkdirSync(path.dirname(bindingPath), { recursive: true });
+			fs.writeFileSync(bindingPath, JSON.stringify({
+				schemaVersion: 1, kind: "herdr-project-pane", projectRoot, paneId: "w1:p25",
+				openedAt: "2026-01-01T00:00:00.000Z", command: "pi",
+			}));
+			const client: ProjectPaneCommandClient = {
+				run: async <T>(args: string[]) => {
+					if (args.join(" ") === "pane close w1:p25") {
+						fs.rmSync(bindingPath);
+						fs.mkdirSync(bindingPath);
+					}
+					return { ok: true, data: {} as T };
+				},
+			};
+			const result = await createProjectPaneManager({ client }).close({ cwd: root });
+			assert.equal(result.ok, false);
+			if (!result.ok) {
+				assert.equal(result.error.code, "BINDING_REMOVE_FAILED");
+				assert.equal(result.error.bindingPath, bindingPath);
+			}
+			assert.equal(fs.statSync(bindingPath).isDirectory(), true);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
@@ -119,7 +204,9 @@ describe("public project-panes package export", () => {
 			assert.equal(result.ok, false);
 			if (!result.ok) assert.equal(result.error.code, "PANE_OWNERSHIP_UNVERIFIED");
 			assert.equal(closeCalled, false);
-			assert.equal(readProjectPaneBinding(root)?.paneId, "w1:p22");
+			const binding = readProjectPaneBinding(root);
+			assert.equal(binding.ok, true);
+			if (binding.ok) assert.equal(binding.data?.paneId, "w1:p22");
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 			fs.rmSync(other, { recursive: true, force: true });
@@ -135,7 +222,9 @@ describe("public project-panes package export", () => {
 				schemaVersion: 1, kind: "herdr-project-pane", projectRoot, paneId: "w1:p23",
 				openedAt: "2026-01-01T00:00:00.000Z", command: "pi", startupMessage: 42,
 			}));
-			assert.equal(readProjectPaneBinding(root), undefined);
+			const binding = readProjectPaneBinding(root);
+			assert.equal(binding.ok, false);
+			if (!binding.ok) assert.equal(binding.error.code, "INVALID_BINDING");
 			let clientCalled = false;
 			const manager = createProjectPaneManager({ client: { run: async () => { clientCalled = true; return { ok: true, data: {} }; } } });
 			const status = await manager.status({ cwd: root });


### PR DESCRIPTION
## Summary
- add a versioned `pi-subagents/project-panes` extension-to-extension API
- return structured pane/binding/runtime results while preserving model-facing management action compatibility
- add opt-in idle-only close with project ownership verification
- keep Pi project trust explicitly human-verified

## Validation
- `npm run typecheck`
- `npm run test:unit` (1704 pass, 1 platform skip)
- targeted Herdr/public API/package tests (21 pass)
- `npm pack --dry-run` includes the public API and docs
- async integration test that flaked in the combined suite passed 114/114 on isolated rerun

The API is intentionally narrow and does not expose inspector internals or bypass Pi Trust.