### PR TITLE
fix: parse block scalar skill descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Keep `git-root` project agent and package discovery stable when incidental `.pi` state appears in a nested linked worktree. Thanks to @klajdo-f for #950.
+- Read skill descriptions from YAML block scalars instead of exposing their markers. Thanks to @ashlineldridge for #945.
 - Give invalid `subagent` actions safe next steps and typo suggestions without suggesting destructive actions for ambiguous input.
 - Compact noisy repeated subagent live-output lines and bound workflow live-card rows so progress stays readable in the TUI (#947).
 

--- a/src/agents/frontmatter.ts
+++ b/src/agents/frontmatter.ts
@@ -83,12 +83,13 @@ export function parseFrontmatter(content: string): { frontmatter: Record<string,
 	let currentBlockLines: string[] | null = null;
 	let currentIndent: number | null = null;
 	let currentFolded = false;
+	let currentLiteral = false;
 
 	for (const line of lines) {
 		const indent = line.search(/\S|$/); // position of first non-whitespace char
 		const trimmed = line.trim();
 
-		if (currentKey !== null && currentBlockLines !== null && (indent > (currentIndent ?? 0) || (currentFolded && trimmed === ""))) {
+		if (currentKey !== null && currentBlockLines !== null && (indent > (currentIndent ?? 0) || ((currentFolded || currentLiteral) && trimmed === ""))) {
 			// This line is part of the current block value
 			currentBlockLines.push(line);
 			continue;
@@ -109,6 +110,7 @@ export function parseFrontmatter(content: string): { frontmatter: Record<string,
 			currentBlockLines = null;
 			currentIndent = null;
 			currentFolded = false;
+			currentLiteral = false;
 		}
 
 		const match = line.match(/^([\w-]+):\s*(.*)$/);
@@ -119,13 +121,15 @@ export function parseFrontmatter(content: string): { frontmatter: Record<string,
 			const isQuoted = (rawValue.startsWith('"') && rawValue.endsWith('"')) || (rawValue.startsWith("'") && rawValue.endsWith("'"));
 			const value = isQuoted ? rawValue.slice(1, -1) : rawValue;
 			const isFolded = !isQuoted && (rawValue === ">" || rawValue === ">-");
+			const isLiteral = !isQuoted && (rawValue === "|" || rawValue === "|-");
 
-			if (value === "" || isFolded) {
-				// Key with empty value or folded block indicator — defer storing until we see indent
+			if (value === "" || isFolded || isLiteral) {
+				// Key with empty value or block scalar indicator — defer storing until we see indent
 				currentKey = key;
 				currentBlockLines = [];
 				currentIndent = indent;
 				currentFolded = isFolded;
+				currentLiteral = isLiteral;
 			} else {
 				// Simple key: value
 				frontmatter[key] = value;

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -6,6 +6,7 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { parseFrontmatter } from "./frontmatter.ts";
 import { getAgentDir, getProjectConfigDir } from "../shared/utils.ts";
 
 export type SkillSource =
@@ -395,15 +396,7 @@ function chooseHigherPrioritySkill(existing: CachedSkillEntry | undefined, candi
 }
 
 function parseSkillDescription(content: string): string | undefined {
-	const normalized = content.replace(/\r\n/g, "\n");
-	if (!normalized.startsWith("---")) return undefined;
-
-	const endIndex = normalized.indexOf("\n---", 3);
-	if (endIndex === -1) return undefined;
-
-	const frontmatter = normalized.slice(3, endIndex).trim();
-	const match = frontmatter.match(/^description:\s*(.+)$/m);
-	return match?.[1]?.trim().replace(/^['\"]|['\"]$/g, "");
+	return parseFrontmatter(content).frontmatter.description;
 }
 
 function maybeReadSkillDescription(filePath: string): string | undefined {

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -139,6 +139,18 @@ body`);
 		assert.equal(parsed.frontmatter.other, ">-");
 	});
 
+	it("preserves lines for | and |-", () => {
+		for (const indicator of ["|", "|-"]) {
+			const parsed = parseFrontmatter(`---
+description: ${indicator}
+  first line
+  second line
+---
+body`);
+			assert.equal(parsed.frontmatter.description, "first line\nsecond line");
+		}
+	});
+
 	it("preserves more-indented lines and repeated whitespace-only separators", () => {
 		const parsed = parseFrontmatter(`---
 description: >

--- a/test/unit/skills-fallback.test.ts
+++ b/test/unit/skills-fallback.test.ts
@@ -80,6 +80,29 @@ describe("skills filesystem fallback", () => {
 		assert.equal(discovered?.description, "Test description");
 	});
 
+	it("reads block scalar descriptions for discovery and child injection", () => {
+		const cases = [
+			["|", "first line\nsecond line"],
+			["|-", "first line\nsecond line"],
+			[">", "first line second line"],
+			[">-", "first line second line"],
+		] as const;
+
+		for (const [index, [indicator]] of cases.entries()) {
+			makeProjectSkill(tempDir, `block-scalar-${index}`, "Use block scalar metadata.", `${indicator}\n  first line\n  second line`);
+		}
+
+		for (const [index, [, description]] of cases.entries()) {
+			const name = `block-scalar-${index}`;
+			const discovered = discoverAvailableSkills(tempDir).find((skill) => skill.name === name);
+			assert.equal(discovered?.description, description);
+
+			const { resolved, missing } = resolveSkills([name], tempDir);
+			assert.deepEqual(missing, []);
+			assert.match(buildSkillInjection(resolved), new RegExp(`<description>${description.replace("\n", "\\n")}</description>`));
+		}
+	});
+
 	it("discovers project skills nested below grouping directories", () => {
 		writeSkillFile(
 			path.join(tempDir, ".pi", "skills", "shell", "issue-262-nested-skill"),


### PR DESCRIPTION
## Summary

Parse skill descriptions through the shared frontmatter reader so YAML block scalar descriptions produce description text instead of exposing `|`, `|-`, `>`, or `>-` markers.

Fixes #945.

## Validation

- `node --experimental-strip-types --test test/unit/agent-frontmatter.test.ts test/unit/skills-fallback.test.ts`
- `npm run typecheck`
- `git diff --check 0d744101107f5cb84b37fa964b4446f165b9e2c5..d61aca8cd73e05d7afd1a2e46c14742c7d121c27`

## Notes

Changelog credit is included for @ashlineldridge.