### PR TITLE
fix: collapse live status snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - Keep `git-root` project agent and package discovery stable when incidental `.pi` state appears in a nested linked worktree. Thanks to @klajdo-f for #950.
 - Read skill descriptions from YAML block scalars instead of exposing their markers. Thanks to @ashlineldridge for #945.
+- Collapse repeated subagent status snapshots in live widgets so status polling does not overflow the chat.
 - Give invalid `subagent` actions safe next steps and typo suggestions without suggesting destructive actions for ambiguous input.
 - Compact noisy repeated subagent live-output lines and bound workflow live-card rows so progress stays readable in the TUI (#947).
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -208,6 +208,10 @@ const noisyStatusPatterns = [
 	/^i(?:'m|’m| am)\b/i,
 	/\bso i (?:will|need|can)\b/i,
 	/^(?:checking|fetching|reading|inspecting|verifying|collecting|confirming|polling)\b/i,
+	/^(?:async\s+subagent\s+)?[\w.-]+\s*·\s*(?:step|agent)\s+\d+\/\d+\s*·/i,
+	/^(?:Step|Agent)\s+\d+\/\d+:\s+[\w.-]+\s*·\s*(?:running|queued|pending|complete|completed)\b/i,
+	/^Press\s+\S+\s+for\s+live\s+detail$/i,
+	/^output:\s+.+\/async-subagent-runs\//i,
 ];
 const liveOutputWordSignalPattern = /\b(?:access denied|denied|error|exception|fail(?:ed|ure)?|fatal|panic|rejected|timeout|timed out|unable|warning)\b/i;
 const liveOutputCodeSignalPattern = /\bE[A-Z0-9_]{2,}\b/;
@@ -235,29 +239,42 @@ function latestActivityText(line: string): string {
 		.replace(/^i(?:'m|’m| am)\s+/i, "");
 }
 
-function compactRecentOutputLines(recentOutput: string[] | undefined): string[] {
-	const lines = (recentOutput ?? []).map(oneLine).filter((line) => line && line !== "(running...)");
-	if (lines.length <= 5) return lines;
-
-	const noisyCount = lines.filter(isNoisyStatusLine).length;
-	if (noisyCount < 4 || noisyCount !== lines.length) {
-		const tail = lines.slice(-5);
-		const hiddenSignals = lines.slice(0, -5).filter(hasLiveOutputSignal);
-		if (hiddenSignals.length === 0) return tail;
-		return [
-			`… ${hiddenSignals.length} older signal ${hiddenSignals.length === 1 ? "line" : "lines"}: ${hiddenSignals.at(-1)}`,
-			...lines.slice(-4),
-		];
-	}
-
+function progressUpdateSummary(lines: string[]): string {
 	const counts = new Map<string, number>();
 	for (const line of lines) counts.set(line.toLowerCase(), (counts.get(line.toLowerCase()) ?? 0) + 1);
 	const exactRepeatCount = Math.max(...counts.values());
 	const latest = latestActivityText(lines[lines.length - 1]!);
 	const repeat = exactRepeatCount > 1 ? ` · repeated ${exactRepeatCount}×` : "";
+	return `↻ ${lines.length} progress updates${repeat} · latest: ${latest}`;
+}
+
+function compactRecentOutputLines(recentOutput: string[] | undefined): string[] {
+	const lines = (recentOutput ?? []).map(oneLine).filter((line) => line && line !== "(running...)");
+	const noisyLines = lines.filter(isNoisyStatusLine);
+	const otherLines = lines.filter((line) => !isNoisyStatusLine(line));
+	if (noisyLines.length >= 4 && !otherLines.some(hasLiveOutputSignal)) {
+		if (otherLines.length === 0) {
+			return [
+				progressUpdateSummary(noisyLines),
+				"pattern: repeated short status lines",
+			];
+		}
+		const visibleTail = otherLines.slice(-3);
+		const hiddenSignals = otherLines.slice(0, -3).filter(hasLiveOutputSignal);
+		return [
+			progressUpdateSummary(noisyLines),
+			...(hiddenSignals.length > 0 ? [`… ${hiddenSignals.length} older signal ${hiddenSignals.length === 1 ? "line" : "lines"}: ${hiddenSignals.at(-1)}`] : []),
+			...visibleTail,
+		].slice(0, 5);
+	}
+	if (lines.length <= 5) return lines;
+
+	const tail = lines.slice(-5);
+	const hiddenSignals = lines.slice(0, -5).filter(hasLiveOutputSignal);
+	if (hiddenSignals.length === 0) return tail;
 	return [
-		`↻ ${lines.length} progress updates${repeat} · latest: ${latest}`,
-		"pattern: repeated short status lines",
+		`… ${hiddenSignals.length} older signal ${hiddenSignals.length === 1 ? "line" : "lines"}: ${hiddenSignals.at(-1)}`,
+		...lines.slice(-4),
 	];
 }
 

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -523,6 +523,51 @@ describe("subagent async widget rendering", () => {
 		assert.doesNotMatch(expandedText, /required plan first/);
 	});
 
+	it("compacts repeated subagent status snapshots inside mixed live output", () => {
+		const now = Date.now();
+		const job = {
+			asyncId: "run-status-snapshots",
+			asyncDir: "/tmp/status-snapshots",
+			status: "running",
+			mode: "parallel",
+			agents: ["reviewer"],
+			activeParallelGroup: true,
+			runningSteps: 1,
+			completedSteps: 0,
+			stepsTotal: 1,
+			updatedAt: now,
+			steps: [
+				{
+					index: 0,
+					agent: "reviewer",
+					status: "running",
+					currentTool: "bash",
+					currentToolArgs: "set -euo pipefail",
+					currentToolStartedAt: now - 2000,
+					recentOutput: [
+						"reviewer · step 1/1 · 11 tool uses · 3m27s",
+						"Step 1/1: reviewer · running (gpt-5.5 · thinking xhigh) · 4 turns · 11 tool uses",
+						"reviewer · step 1/1 · 11 tool uses · 3m29s",
+						"Step 1/1: reviewer · running (gpt-5.5 · thinking xhigh) · 4 turns · 11 tool uses",
+						"reviewer · step 1/1 · 11 tool uses · 3m32s",
+						"Step 1/1: reviewer · running (gpt-5.5 · thinking xhigh) · 4 turns · 11 tool uses",
+						"repo=nicobailon/pi-subagents",
+						"sha=d61aca... | 2m32s",
+						"output: /var/folders/x/T/pi-subagents-uid-501/async-subagent-runs/run-status-snapshots/output.log",
+					],
+				},
+			],
+		};
+
+		const expandedText = buildWidgetLines([job], theme, 180, true).join("\n");
+		assert.match(expandedText, /↻ 7 progress updates/);
+		assert.match(expandedText, /latest: output: \/var\/folders\/x\/T\/pi-subagents-uid-501\/async-subagent-runs\/run-status-snapshots\/output.log/);
+		assert.match(expandedText, /repo=nicobailon\/pi-subagents/);
+		assert.match(expandedText, /sha=d61aca\.\.\. \| 2m32s/);
+		assert.doesNotMatch(expandedText, /3m27s/);
+		assert.doesNotMatch(expandedText, /3m29s/);
+	});
+
 	it("keeps mixed live output raw instead of hiding non-status lines", () => {
 		const now = Date.now();
 		const job = {


### PR DESCRIPTION
## Summary

This fixes the live widget overflow seen when repeated child status snapshots are copied into recent output. The renderer now treats those snapshot lines as noisy progress output and collapses them, while leaving real signal and error output visible.

## Validation

- `node --experimental-strip-types --test test/integration/render-widget.test.ts test/unit/widget-nested-render.test.ts`
- `npm run typecheck`
- `git diff --check a4fc59aac1b9cfd4dc313eea3b930e315cb394f4..HEAD`
- Fresh review: `/tmp/pi-subagents-backlog-20260810T145442Z/status-overflow-review.md`
