### PR TITLE
fix: name the child agent in workflow run status

### DIFF
--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4427,7 +4427,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								if (entry.durationMs === undefined) delete existing.durationMs;
 								else existing.durationMs = entry.durationMs;
 							} else {
-								status.steps?.push({ agent: entry.key, label: entry.key, workflowKey: entry.key, parentWorkflowRunId: workflowRunId, status: mapped, startedAt: Date.now() });
+								status.steps?.push({ agent: entry.agent ?? entry.key, ...(entry.agent && entry.agent !== entry.key ? {} : { label: entry.key }), workflowKey: entry.key, parentWorkflowRunId: workflowRunId, status: mapped, startedAt: Date.now() });
 							}
 						}
 						projectWorkflowActivity();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1050,6 +1050,8 @@ export interface Details {
 			runId?: string;
 			phase?: string;
 			label?: string;
+			/** Resolved child agent name, so status surfaces can name the agent rather than the caller's stable key. */
+			agent?: string;
 			durationMs?: number;
 			error?: string;
 		}>;

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -210,6 +210,8 @@ export interface WorkflowScriptTraceEntry {
 	durationMs?: number;
 	phase?: string;
 	label?: string;
+	/** Resolved child agent name, so status surfaces can name the agent rather than the caller's stable key. */
+	agent?: string;
 	error?: string;
 }
 
@@ -338,10 +340,11 @@ function validateKey(value: unknown, owner = "runs.run"): string {
 	return value;
 }
 
-function workflowStringMetadata(params: Record<string, unknown>): Pick<WorkflowScriptTraceEntry, "phase" | "label"> {
+function workflowStringMetadata(params: Record<string, unknown>): Pick<WorkflowScriptTraceEntry, "phase" | "label" | "agent"> {
 	return {
 		...(typeof params.phase === "string" && params.phase.trim() ? { phase: params.phase.trim() } : {}),
 		...(typeof params.label === "string" && params.label.trim() ? { label: params.label.trim() } : {}),
+		...(typeof params.agent === "string" && params.agent.trim() ? { agent: params.agent.trim() } : {}),
 	};
 }
 


### PR DESCRIPTION
## Summary
- carry the resolved child agent name on the workflow run trace entry
- name workflow status steps by that agent, keeping the caller's stable key as the label only when no agent name is available
- leave run targeting unchanged, since status, transcript, and nested addressing still key off `workflowKey`

Before this, `runs.run("budget-pot-oracle", { agent: "oracle" })` rendered in FleetView as `budget-pot-oracle (budget-pot-oracle)`, because the trace entry carried only the caller's key and the parent used it for both the agent and the label. Watching a fleet gave no way to tell which agent each row was without opening every run. Foreground rows were unaffected, so this only showed up for workflow children.

## Validation
- `npm run typecheck`
- `npm run test:unit` (1711 pass, 1 skip)
- targeted scripted-workflow and fleet tests (84 pass)

One open question for review: the key is dropped as the label whenever an agent name exists, so several parallel children of the same agent render identically, matching how foreground parallel rows already behave. Happy to always show both if you would rather keep the key visible.
