### PR TITLE
fix: restore fleet history and keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Read skill descriptions from YAML block scalars instead of exposing their markers. Thanks to @ashlineldridge for #945.
 - Collapse repeated subagent status snapshots in live widgets so status polling does not overflow the chat.
 - Give invalid `subagent` actions safe next steps and typo suggestions without suggesting destructive actions for ambiguous input.
+- Let the Fleet inspector use extension-local keybindings for terminals that intercept navigation keys. Thanks to @epheien for #940.
+- Restore completed foreground children from a compact Fleet history index after session resume. Thanks to @epheien for #946.
 - Compact noisy repeated subagent live-output lines and bound workflow live-card rows so progress stays readable in the TUI (#947).
 
 ## [0.45.2] - 2026-08-10

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,25 @@ Controls the persistent, navigable FleetView. The default is `true`. Set it to `
 
 Places the persistent FleetView either `"belowEditor"` or `"aboveEditor"`. The default is `"belowEditor"`; invalid values fall back to `"belowEditor"`.
 
+## `fleetKeybindings`
+
+```json
+{
+  "fleetKeybindings": {
+    "pageUp": ["u"],
+    "pageDown": ["d"],
+    "selectFirst": ["g"],
+    "selectLast": ["G"]
+  }
+}
+```
+
+Customizes only the full Fleet inspector opened by `/subagents-fleet` or FleetView inspection. It does not change Pi's global keybindings or the compact persistent FleetView.
+
+Each action accepts a non-empty array of key strings. Configured actions replace their defaults. Unset actions keep the defaults: `selectUp` is `up`/`k`, `selectDown` is `down`/`j`, `scrollUp` is `K`, `scrollDown` is `J`, `pageUp` is `pageUp`, `pageDown` is `pageDown`, `selectFirst` is `home`, `selectLast` is `end`, `toggleTools` is `x`/`X`/`ctrl+o`, `refresh` is `r`/`R`, `steer` is `s`, `stop` is `D`, `inspect` is `H`, and `close` is `escape`/`ctrl+c`/`q`.
+
+Prompt modes keep their fixed keys. For example, `Esc` still cancels steer text or stop confirmation even when the Fleet-level close binding is changed.
+
 ## `asyncWidget`
 
 ```json

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -37,7 +37,7 @@ FleetView replaces the legacy above-editor async widget by default. Successful b
 
 `/subagents-fleet` opens the live fleet inspector with current-session foreground work, recent async children, structured Markdown/tool transcripts, and completed output/session paths.
 
-Keys:
+Default keys:
 
 - `↑`/`↓` or `j`/`k` — select a child
 - `Shift+K`/`Shift+J` — scroll one line
@@ -48,6 +48,8 @@ Keys:
 - `s` — compose an acknowledged message to a selected live async child; Tab cycles `steer`, `follow_up`, and `auto`
 - `D` — stop a selected child's top-level async run after confirmation
 - `H` — open the selected active async child in a Herdr inspector pane (Herdr 0.7.5+)
+
+Set `fleetKeybindings` in the extension config to replace inspector-level keys when a terminal intercepts keys such as `PgUp`, `PgDn`, `Home`, or `End`. Prompt modes keep fixed keys such as `Esc`, `Enter`, `Tab`, and stop-confirmation `Y`/`N`.
 
 `Ctrl+Alt+F` opens the same inspector even while a foreground turn is active and slash input is queued.
 

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -1,13 +1,14 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ArtifactDirPreference, ExtensionConfig } from "../shared/types.ts";
+import { FLEET_KEYBINDING_ACTIONS, type ArtifactDirPreference, type ExtensionConfig } from "../shared/types.ts";
 import { validateMissionStoreConfig } from "../missions/store.ts";
 import { validateAuthorityPolicy } from "../policy/authority.ts";
 import { getAgentDir } from "../shared/utils.ts";
 import { validatePermissionConfig } from "../runs/shared/permissions.ts";
 
 const ARTIFACT_DIR_PREFERENCES = new Set<ArtifactDirPreference>(["project", "session", "temp"]);
+const FLEET_KEYBINDING_ACTION_SET = new Set<string>(FLEET_KEYBINDING_ACTIONS);
 
 export function resolveScheduledStoreRoot(value: string): string {
 	const expanded = value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
@@ -24,6 +25,18 @@ function validateScheduledRunsConfig(value: unknown): void {
 	resolveScheduledStoreRoot(storeRoot);
 }
 
+function validateFleetKeybindingsConfig(value: unknown): void {
+	if (value === undefined) return;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("config.fleetKeybindings must be a JSON object");
+	for (const [action, bindings] of Object.entries(value)) {
+		if (!FLEET_KEYBINDING_ACTION_SET.has(action)) throw new Error(`config.fleetKeybindings.${action} is not a supported Fleet action`);
+		if (!Array.isArray(bindings) || bindings.length === 0) throw new Error(`config.fleetKeybindings.${action} must be a non-empty array of strings`);
+		for (const binding of bindings) {
+			if (typeof binding !== "string" || !binding.trim()) throw new Error(`config.fleetKeybindings.${action} entries must be non-empty strings`);
+		}
+	}
+}
+
 function validateConfig(config: Record<string, unknown>): void {
 	if (config.artifactDir !== undefined && !ARTIFACT_DIR_PREFERENCES.has(config.artifactDir as ArtifactDirPreference)) {
 		throw new Error(`config.artifactDir must be "project", "session", or "temp"`);
@@ -32,6 +45,7 @@ function validateConfig(config: Record<string, unknown>): void {
 	validateAuthorityPolicy(config.authorityPolicy);
 	validatePermissionConfig(config.permissions);
 	validateScheduledRunsConfig(config.scheduledRuns);
+	validateFleetKeybindingsConfig(config.fleetKeybindings);
 }
 
 export function getConfigPath(): string {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -53,6 +53,7 @@ import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import { loadConfig, resolveAsyncByDefault, resolveScheduledStoreRoot } from "./config.ts";
 import { buildSubagentToolDescription } from "./tool-description.ts";
 import { collectGoalContinuationNotices } from "../missions/goal-driver.ts";
+import { restoreForegroundRunHistory } from "../runs/foreground/foreground-history.ts";
 import { syncMissionFromAsyncCompletion } from "../missions/lifecycle.ts";
 import { resolveMissionStoreLocation } from "../missions/store.ts";
 import { listRetainedChildren } from "../runs/background/retained-children.ts";
@@ -378,7 +379,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		? new SubagentFleetStatus(state, async (itemKey) => {
 			const ctx = state.lastUiContext;
 			if (!ctx?.hasUI) return;
-			await openSubagentFleet(ctx, state, { initialKey: itemKey, asyncDirRoot: DIRS.async, resultsDir: DIRS.results });
+			await openSubagentFleet(ctx, state, { initialKey: itemKey, asyncDirRoot: DIRS.async, resultsDir: DIRS.results, fleetKeybindings: config.fleetKeybindings });
 		}, { placement: fleetViewPlacement })
 		: undefined;
 	let executorScheduled: ((id: string, params: SubagentParamsLike, signal: AbortSignal, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>) | undefined;
@@ -603,7 +604,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}
 	});
 
-	registerSlashCommands(pi, state);
+	registerSlashCommands(pi, state, { fleetKeybindings: config.fleetKeybindings });
 
 	const eventUnsubscribeStoreKey = "__piSubagentEventUnsubscribes";
 	const controlNoticeSeenStoreKey = "__piSubagentVisibleControlNotices";
@@ -722,6 +723,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		state.foregroundControls.clear();
 		state.lastForegroundControlId = null;
 		resetJobs(ctx);
+		restoreForegroundRunHistory(state, { resultsDir: DIRS.results });
 		restoreActiveJobs(ctx);
 		scheduledRunManager.bindSession(ctx);
 		restoreSlashFinalSnapshots(ctx.sessionManager.getEntries());

--- a/src/runs/foreground/foreground-history.ts
+++ b/src/runs/foreground/foreground-history.ts
@@ -1,0 +1,138 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ForegroundResumeChild, ForegroundResumeRun, SubagentState } from "../../shared/types.ts";
+import { DIRS } from "../../shared/types.ts";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
+
+export const MAX_REMEMBERED_FOREGROUND_RUNS = 50;
+const HISTORY_VERSION = 1;
+const MAX_INLINE_OUTPUT_BYTES = 64 * 1024;
+
+interface ForegroundHistoryIndex {
+	version: 1;
+	runs: ForegroundResumeRun[];
+}
+
+function historyPath(resultsDir: string): string {
+	return path.join(resultsDir, "foreground-history.json");
+}
+
+function boundedTail(value: string): string {
+	const buffer = Buffer.from(value, "utf-8");
+	if (buffer.byteLength <= MAX_INLINE_OUTPUT_BYTES) return value;
+	return buffer.subarray(buffer.byteLength - MAX_INLINE_OUTPUT_BYTES).toString("utf-8");
+}
+
+function compactChild(child: ForegroundResumeChild): ForegroundResumeChild {
+	const outputPath = child.artifactPaths?.outputPath ?? child.savedOutputPath;
+	return {
+		agent: child.agent,
+		index: child.index,
+		...(child.context ? { context: child.context } : {}),
+		...(child.sessionFile ? { sessionFile: child.sessionFile } : {}),
+		...(child.model ? { model: child.model } : {}),
+		...(child.thinking ? { thinking: child.thinking } : {}),
+		status: child.status,
+		...(child.activityState ? { activityState: child.activityState } : {}),
+		...(child.lastActivityAt !== undefined ? { lastActivityAt: child.lastActivityAt } : {}),
+		...(child.currentTool ? { currentTool: child.currentTool } : {}),
+		...(child.currentToolStartedAt !== undefined ? { currentToolStartedAt: child.currentToolStartedAt } : {}),
+		...(child.currentPath ? { currentPath: child.currentPath } : {}),
+		...(child.turnCount !== undefined ? { turnCount: child.turnCount } : {}),
+		...(child.tokens !== undefined ? { tokens: child.tokens } : {}),
+		...(child.toolCount !== undefined ? { toolCount: child.toolCount } : {}),
+		...(child.exitCode !== undefined ? { exitCode: child.exitCode } : {}),
+		...(child.error ? { error: child.error } : {}),
+		...(!outputPath && child.finalOutput ? { finalOutput: boundedTail(child.finalOutput) } : {}),
+		...(child.outputState ? { outputState: child.outputState } : {}),
+		...(child.outputMode ? { outputMode: child.outputMode } : {}),
+		...(child.savedOutputPath ? { savedOutputPath: child.savedOutputPath } : {}),
+		...(child.outputSaveError ? { outputSaveError: child.outputSaveError } : {}),
+		...(child.artifactPaths ? { artifactPaths: child.artifactPaths } : {}),
+		...(child.transcriptPath ? { transcriptPath: child.transcriptPath } : {}),
+		...(child.transcriptError ? { transcriptError: child.transcriptError } : {}),
+		...(child.acceptance ? { acceptance: child.acceptance } : {}),
+		...(child.launchContractDigest ? { launchContractDigest: child.launchContractDigest } : {}),
+		...(child.capabilityCeiling ? { capabilityCeiling: child.capabilityCeiling } : {}),
+		...(child.updatedAt !== undefined ? { updatedAt: child.updatedAt } : {}),
+	};
+}
+
+function isRestorableForegroundStatus(status: unknown): status is ForegroundResumeChild["status"] {
+	return status === "completed" || status === "failed" || status === "paused" || status === "stopped";
+}
+
+function compactRun(run: ForegroundResumeRun): ForegroundResumeRun | undefined {
+	if (!run.sessionId) return undefined;
+	if (run.children.length === 0 || !run.children.every((child) => isRestorableForegroundStatus(child.status))) return undefined;
+	return {
+		runId: run.runId,
+		mode: run.mode,
+		cwd: run.cwd,
+		sessionId: run.sessionId,
+		updatedAt: run.updatedAt,
+		children: run.children.map(compactChild),
+	};
+}
+
+function readIndex(resultsDir: string): ForegroundHistoryIndex {
+	const filePath = historyPath(resultsDir);
+	if (!fs.existsSync(filePath)) return { version: HISTORY_VERSION, runs: [] };
+	try {
+		const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { version: HISTORY_VERSION, runs: [] };
+		const record = parsed as Partial<ForegroundHistoryIndex>;
+		if (record.version !== HISTORY_VERSION || !Array.isArray(record.runs)) return { version: HISTORY_VERSION, runs: [] };
+		return { version: HISTORY_VERSION, runs: record.runs.filter(isRestorableRun) };
+	} catch {
+		return { version: HISTORY_VERSION, runs: [] };
+	}
+}
+
+function isRestorableRun(value: unknown): value is ForegroundResumeRun {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const run = value as Partial<ForegroundResumeRun>;
+	return typeof run.runId === "string" && Boolean(run.runId)
+		&& (run.mode === "single" || run.mode === "parallel" || run.mode === "chain")
+		&& typeof run.cwd === "string" && Boolean(run.cwd)
+		&& typeof run.sessionId === "string" && Boolean(run.sessionId)
+		&& typeof run.updatedAt === "number" && Number.isFinite(run.updatedAt)
+		&& Array.isArray(run.children)
+		&& run.children.length > 0
+		&& run.children.every((child) => Boolean(child && typeof child === "object" && !Array.isArray(child)
+			&& typeof (child as Partial<ForegroundResumeChild>).agent === "string"
+			&& typeof (child as Partial<ForegroundResumeChild>).index === "number"
+			&& isRestorableForegroundStatus((child as Partial<ForegroundResumeChild>).status)));
+}
+
+function sortAndBound(runs: ForegroundResumeRun[], limit: number): ForegroundResumeRun[] {
+	return [...runs].sort((left, right) => right.updatedAt - left.updatedAt).slice(0, limit);
+}
+
+export function persistForegroundRunHistory(state: SubagentState, options: { resultsDir?: string; limit?: number } = {}): void {
+	const resultsDir = options.resultsDir ?? DIRS.results;
+	const limit = options.limit ?? MAX_REMEMBERED_FOREGROUND_RUNS;
+	const existing = readIndex(resultsDir);
+	const merged = new Map(existing.runs.map((run) => [run.runId, run]));
+	for (const run of state.foregroundRuns?.values() ?? []) {
+		const compact = compactRun(run);
+		if (compact) merged.set(compact.runId, compact);
+	}
+	const runs = sortAndBound([...merged.values()], limit);
+	writeAtomicJson(historyPath(resultsDir), { version: HISTORY_VERSION, runs });
+}
+
+export function restoreForegroundRunHistory(state: SubagentState, options: { resultsDir?: string; sessionId?: string | null; limit?: number } = {}): number {
+	const sessionId = options.sessionId ?? state.currentSessionId;
+	if (!sessionId) return 0;
+	const index = readIndex(options.resultsDir ?? DIRS.results);
+	const runs = sortAndBound(index.runs.filter((run) => run.sessionId === sessionId), options.limit ?? MAX_REMEMBERED_FOREGROUND_RUNS);
+	state.foregroundRuns ??= new Map();
+	let restored = 0;
+	for (const run of runs) {
+		if (state.foregroundRuns.has(run.runId)) continue;
+		state.foregroundRuns.set(run.runId, run);
+		restored += 1;
+	}
+	return restored;
+}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -17,6 +17,7 @@ import {
 	settleForegroundSchedulingOwner,
 	updateForegroundChild,
 } from "./foreground-control.ts";
+import { persistForegroundRunHistory, MAX_REMEMBERED_FOREGROUND_RUNS } from "./foreground-history.ts";
 import { resolveExecutionAgentScope } from "../../agents/agent-scope.ts";
 import { handleManagementAction } from "../../agents/agent-management.ts";
 import { handleRefinementAction } from "../../agents/agent-refinements.ts";
@@ -518,12 +519,20 @@ function foregroundStatusResult(control: SubagentState["foregroundControls"] ext
 
 function trimRememberedForegroundRuns(state: SubagentState): void {
 	if (!state.foregroundRuns) return;
-	while (state.foregroundRuns.size > 50) {
+	while (state.foregroundRuns.size > MAX_REMEMBERED_FOREGROUND_RUNS) {
 		const oldestTerminal = [...state.foregroundRuns.values()]
 			.filter((run) => !run.children.some((child) => child.status === "detached"))
 			.sort((left, right) => left.updatedAt - right.updatedAt)[0];
 		if (!oldestTerminal) break;
 		state.foregroundRuns.delete(oldestTerminal.runId);
+	}
+}
+
+function persistRememberedForegroundRuns(state: SubagentState): void {
+	try {
+		persistForegroundRunHistory(state);
+	} catch (error) {
+		console.error("Failed to persist foreground run history:", error);
 	}
 }
 
@@ -593,6 +602,7 @@ function rememberForegroundRun(state: SubagentState, input: { runId: string; mod
 		}),
 	});
 	trimRememberedForegroundRuns(state);
+	persistRememberedForegroundRuns(state);
 }
 
 function applyControlEventToRememberedForegroundRun(state: SubagentState, event: ControlEvent): void {
@@ -668,6 +678,7 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		...(input.result.capabilityAudit ? { capabilityAudit: input.result.capabilityAudit } : {}),
 	});
 	trimRememberedForegroundRuns(state);
+	persistRememberedForegroundRuns(state);
 	const output = getSingleResultOutput(input.result).trim();
 	const success = terminalStatus === "completed";
 	const summary = !success && input.result.error

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1782,12 +1782,34 @@ export interface ScheduledRunsConfig {
 
 export type FleetViewPlacement = "aboveEditor" | "belowEditor";
 
+export const FLEET_KEYBINDING_ACTIONS = [
+	"close",
+	"scrollUp",
+	"scrollDown",
+	"selectUp",
+	"selectDown",
+	"selectFirst",
+	"selectLast",
+	"pageUp",
+	"pageDown",
+	"refresh",
+	"steer",
+	"inspect",
+	"stop",
+	"toggleTools",
+] as const;
+
+export type FleetKeybindingAction = typeof FLEET_KEYBINDING_ACTIONS[number];
+export type FleetKeybindingsConfig = Partial<Record<FleetKeybindingAction, string[]>>;
+
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
 	/** Show the Claude Code-style navigable fleet. Defaults to true. */
 	fleetView?: boolean;
 	/** Place the persistent FleetView above or below the editor. Defaults to belowEditor. */
 	fleetViewPlacement?: FleetViewPlacement;
+	/** Local keybindings for the full Fleet inspector. */
+	fleetKeybindings?: FleetKeybindingsConfig;
 	/** Show the under-editor async runs widget. Defaults to true, including when FleetView is enabled. */
 	asyncWidget?: boolean;
 	/** Tool description variant registered for the parent-facing subagent tool. Defaults to full. */

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -41,6 +41,7 @@ import {
 	SLASH_SUBAGENT_UPDATE_EVENT,
 	DIRS,
 	type Details,
+	type FleetKeybindingsConfig,
 	type JsonSchemaObject,
 	type SingleResult,
 	type SubagentState,
@@ -629,6 +630,7 @@ function slashRunWorkflowScript(key: string, child: Record<string, unknown>): st
 export function registerSlashCommands(
 	pi: ExtensionAPI,
 	state: SubagentState,
+	options: { fleetKeybindings?: FleetKeybindingsConfig } = {},
 ): void {
 	let fleetOpen = false;
 	const showFleet = async (ctx: ExtensionContext) => {
@@ -643,7 +645,7 @@ export function registerSlashCommands(
 		}
 		fleetOpen = true;
 		try {
-			await openSubagentFleet(ctx, state, { asyncDirRoot: DIRS.async, resultsDir: DIRS.results });
+			await openSubagentFleet(ctx, state, { asyncDirRoot: DIRS.async, resultsDir: DIRS.results, fleetKeybindings: options.fleetKeybindings });
 		} finally {
 			fleetOpen = false;
 		}

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -2,10 +2,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { getMarkdownTheme, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type MarkdownTheme } from "@earendil-works/pi-tui";
+import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type MarkdownTheme } from "@earendil-works/pi-tui";
 import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../shared/formatters.ts";
-import { DIRS, type AsyncJobState, type Details, type ForegroundChildControl, type ForegroundResumeChild, type ForegroundResumeRun, type ForegroundRunControl, type SubagentState } from "../shared/types.ts";
+import { DIRS, type AsyncJobState, type Details, type FleetKeybindingAction, type FleetKeybindingsConfig, type ForegroundChildControl, type ForegroundResumeChild, type ForegroundResumeRun, type ForegroundRunControl, type SubagentState } from "../shared/types.ts";
 import { readStatus } from "../shared/utils.ts";
 import { formatAsyncRunTranscript } from "../runs/background/fleet-view.ts";
 import { listAsyncRuns, type AsyncRunSummary } from "../runs/background/async-status.ts";
@@ -21,6 +21,47 @@ const REFRESH_MS = 750;
 const MAX_RECENT_ASYNC_RUNS = 20;
 const MAX_FLEET_HISTORY_CANDIDATES = 100;
 const TRANSCRIPT_LINES = 200;
+const OUTPUT_TAIL_BYTES = 64 * 1024;
+
+export const DEFAULT_FLEET_KEYBINDINGS: Record<FleetKeybindingAction, string[]> = {
+	close: ["escape", "ctrl+c", "q"],
+	scrollUp: ["K"],
+	scrollDown: ["J"],
+	selectUp: ["up", "k"],
+	selectDown: ["down", "j"],
+	selectFirst: ["home"],
+	selectLast: ["end"],
+	pageUp: ["pageUp"],
+	pageDown: ["pageDown"],
+	refresh: ["r", "R"],
+	steer: ["s"],
+	inspect: ["H"],
+	stop: ["D"],
+	toggleTools: ["x", "X", "ctrl+o"],
+};
+
+type ResolvedFleetKeybindings = Record<FleetKeybindingAction, string[]>;
+
+export function resolveFleetKeybindings(config: FleetKeybindingsConfig | undefined): ResolvedFleetKeybindings {
+	return Object.fromEntries(
+		Object.entries(DEFAULT_FLEET_KEYBINDINGS).map(([action, defaults]) => [action, config?.[action as FleetKeybindingAction] ?? defaults]),
+	) as ResolvedFleetKeybindings;
+}
+
+function matchesFleetBinding(data: string, binding: string): boolean {
+	const key = /^[A-Z]$/.test(binding) ? `shift+${binding.toLowerCase()}` : binding;
+	return matchesKey(data, key as Parameters<typeof matchesKey>[1]);
+}
+
+function matchesFleetAction(data: string, bindings: ResolvedFleetKeybindings, action: FleetKeybindingAction): boolean {
+	return bindings[action].some((binding) => matchesFleetBinding(data, binding));
+}
+
+function bindingLabel(bindings: ResolvedFleetKeybindings, action: FleetKeybindingAction): string {
+	return bindings[action]
+		.map((binding) => binding === "up" ? "↑" : binding === "down" ? "↓" : binding === "escape" ? "Esc" : binding === "return" ? "Enter" : binding)
+		.join("/");
+}
 
 type Theme = ExtensionContext["ui"]["theme"];
 type FleetTui = {
@@ -57,6 +98,7 @@ export interface FleetViewOptions {
 	refreshMs?: number;
 	initialKey?: string;
 	markdownTheme?: MarkdownTheme;
+	fleetKeybindings?: FleetKeybindingsConfig;
 	actions?: FleetActionHandlers;
 }
 
@@ -260,7 +302,59 @@ function foregroundActiveDetail(item: Extract<FleetItem, { kind: "foreground-act
 	return lines.filter((line): line is string => line !== undefined);
 }
 
-function foregroundRecentDetail(item: Extract<FleetItem, { kind: "foreground-recent" }>): string[] {
+function pathWithin(base: string, candidate: string): boolean {
+	const resolvedBase = path.resolve(base);
+	const resolvedCandidate = path.resolve(candidate);
+	return resolvedCandidate === resolvedBase || resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`);
+}
+
+function trustedFileTail(filePath: string, trustedRoots: string[]): { text?: string; warning?: string; unavailable?: string } {
+	const resolvedPath = path.resolve(filePath);
+	if (trustedRoots.length === 0 || !trustedRoots.some((root) => pathWithin(root, resolvedPath))) return { warning: `output artifact is outside trusted roots: ${filePath}` };
+	let stat: fs.Stats;
+	try {
+		stat = fs.lstatSync(resolvedPath);
+	} catch (error) {
+		if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return { unavailable: `output artifact unavailable: ${filePath}` };
+		return { warning: `output artifact could not be inspected: ${error instanceof Error ? error.message : String(error)}` };
+	}
+	if (stat.isSymbolicLink()) return { warning: `output artifact refused a symlink: ${filePath}` };
+	if (!stat.isFile()) return { warning: `output artifact is not a file: ${filePath}` };
+	try {
+		const realPath = fs.realpathSync(resolvedPath);
+		const realRoots = trustedRoots.filter((root) => fs.existsSync(root)).map((root) => fs.realpathSync(root));
+		if (!realRoots.some((root) => pathWithin(root, realPath))) return { warning: `output artifact resolves outside trusted roots: ${filePath}` };
+		const fd = fs.openSync(realPath, "r");
+		try {
+			const bytes = Math.min(stat.size, OUTPUT_TAIL_BYTES);
+			const buffer = Buffer.alloc(bytes);
+			fs.readSync(fd, buffer, 0, bytes, stat.size - bytes);
+			return { text: buffer.toString("utf-8") };
+		} finally {
+			fs.closeSync(fd);
+		}
+	} catch (error) {
+		return { warning: `output artifact could not be read: ${error instanceof Error ? error.message : String(error)}` };
+	}
+}
+
+function foregroundRecentOutputLines(item: Extract<FleetItem, { kind: "foreground-recent" }>, state: SubagentState): string[] {
+	const outputPath = item.child.artifactPaths?.outputPath ?? item.child.savedOutputPath;
+	const output = item.child.finalOutput
+		? { text: item.child.finalOutput }
+		: outputPath
+			? trustedFileTail(path.isAbsolute(outputPath) ? outputPath : path.resolve(item.run.cwd, outputPath), uniquePaths([
+				fleetArtifactsRoot(state, item.run.cwd),
+				fleetArtifactsRoot(state, state.baseCwd),
+			]))
+			: undefined;
+	if (output?.warning) return [`(${output.warning})`];
+	if (output?.unavailable) return [`(${output.unavailable})`];
+	const outputLines = (output?.text ?? "").split(/\r?\n/).filter((line) => line.trim()).slice(-TRANSCRIPT_LINES);
+	return outputLines.length ? outputLines : ["(no recovered output available)"];
+}
+
+function foregroundRecentDetail(item: Extract<FleetItem, { kind: "foreground-recent" }>, state: SubagentState): string[] {
 	const { child, run } = item;
 	const outputPath = child.artifactPaths?.outputPath ?? child.savedOutputPath;
 	const modelThinking = formatModelThinking(child.model, child.thinking);
@@ -281,8 +375,7 @@ function foregroundRecentDetail(item: Extract<FleetItem, { kind: "foreground-rec
 		"",
 		"Result transcript tail",
 	];
-	const outputLines = (child.finalOutput ?? "").split(/\r?\n/).filter((line) => line.trim()).slice(-TRANSCRIPT_LINES);
-	lines.push(...(outputLines.length ? outputLines : ["(no recovered output available)"]));
+	lines.push(...foregroundRecentOutputLines(item, state));
 	return lines.filter((line): line is string => line !== undefined);
 }
 
@@ -306,12 +399,12 @@ function asyncDetail(item: Extract<FleetItem, { kind: "async" }>): string[] {
 	].filter((line): line is string => line !== undefined);
 }
 
-function detailLines(item: FleetItem | undefined, error: string | undefined): string[] {
+function detailLines(item: FleetItem | undefined, error: string | undefined, state: SubagentState): string[] {
 	if (!item) return [error ? `Fleet scan failed: ${error}` : "No current-session foreground or recent async children.", "", "New runs appear here automatically while this inspector remains open."];
 	const lines = item.kind === "foreground-active"
 		? foregroundActiveDetail(item)
 		: item.kind === "foreground-recent"
-			? foregroundRecentDetail(item)
+			? foregroundRecentDetail(item, state)
 			: asyncDetail(item);
 	if (error) lines.unshift(`Fleet scan warning: ${error}`, "");
 	return lines;
@@ -497,6 +590,7 @@ export class SubagentFleetComponent implements Component {
 	private readonly state: SubagentState;
 	private readonly done: (result: undefined) => void;
 	private readonly options: FleetViewOptions;
+	private readonly keybindings: ResolvedFleetKeybindings;
 
 	constructor(
 		tui: FleetTui,
@@ -511,6 +605,7 @@ export class SubagentFleetComponent implements Component {
 		this.state = state;
 		this.done = done;
 		this.options = options;
+		this.keybindings = resolveFleetKeybindings(options.fleetKeybindings);
 		this.selectedKey = options.initialKey;
 		this.refresh();
 		this.timer = setInterval(() => {
@@ -657,25 +752,25 @@ export class SubagentFleetComponent implements Component {
 			}
 			return;
 		}
-		if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c") || matchesKey(data, "q")) {
+		if (matchesFleetAction(data, this.keybindings, "close")) {
 			this.done(undefined);
 			return;
 		}
-		if (matchesKey(data, Key.shift("k"))) return this.scrollDetail(-1);
-		if (matchesKey(data, Key.shift("j"))) return this.scrollDetail(1);
-		if (matchesKey(data, "up") || matchesKey(data, "k")) return this.moveSelection(-1);
-		if (matchesKey(data, "down") || matchesKey(data, "j")) return this.moveSelection(1);
-		if (matchesKey(data, "home")) return this.moveSelection(-this.snapshot.items.length);
-		if (matchesKey(data, "end")) return this.moveSelection(this.snapshot.items.length);
-		if (matchesKey(data, "pageUp")) return this.scrollDetail(-this.detailViewportHeight);
-		if (matchesKey(data, "pageDown")) return this.scrollDetail(this.detailViewportHeight);
-		if (data.toLowerCase() === "r") {
+		if (matchesFleetAction(data, this.keybindings, "scrollUp")) return this.scrollDetail(-1);
+		if (matchesFleetAction(data, this.keybindings, "scrollDown")) return this.scrollDetail(1);
+		if (matchesFleetAction(data, this.keybindings, "selectUp")) return this.moveSelection(-1);
+		if (matchesFleetAction(data, this.keybindings, "selectDown")) return this.moveSelection(1);
+		if (matchesFleetAction(data, this.keybindings, "selectFirst")) return this.moveSelection(-this.snapshot.items.length);
+		if (matchesFleetAction(data, this.keybindings, "selectLast")) return this.moveSelection(this.snapshot.items.length);
+		if (matchesFleetAction(data, this.keybindings, "pageUp")) return this.scrollDetail(-this.detailViewportHeight);
+		if (matchesFleetAction(data, this.keybindings, "pageDown")) return this.scrollDetail(this.detailViewportHeight);
+		if (matchesFleetAction(data, this.keybindings, "refresh")) {
 			this.transcriptCache = undefined;
 			this.refresh();
 			this.tui.requestRender();
 			return;
 		}
-		if (data === "s") {
+		if (matchesFleetAction(data, this.keybindings, "steer")) {
 			const target = this.selectedAsyncAction();
 			if ("reason" in target || !this.options.actions) this.setActionNotice({ text: "reason" in target ? target.reason : "Fleet controls are unavailable in this context.", isError: true });
 			else {
@@ -687,13 +782,13 @@ export class SubagentFleetComponent implements Component {
 			}
 			return;
 		}
-		if (data === "H") {
+		if (matchesFleetAction(data, this.keybindings, "inspect")) {
 			const target = this.selectedAsyncAction();
 			if ("reason" in target || !this.options.actions?.inspect) this.setActionNotice({ text: "reason" in target ? target.reason : "Herdr inspector controls are unavailable in this context.", isError: true });
 			else this.runAction(() => this.options.actions!.inspect!({ runId: target.item.runId, asyncDir: target.item.run.asyncDir, ...(target.item.index !== undefined ? { index: target.item.index } : {}) }));
 			return;
 		}
-		if (data === "D") {
+		if (matchesFleetAction(data, this.keybindings, "stop")) {
 			const target = this.selectedAsyncAction();
 			if ("reason" in target || !this.options.actions) this.setActionNotice({ text: "reason" in target ? target.reason : "Fleet controls are unavailable in this context.", isError: true });
 			else {
@@ -705,7 +800,7 @@ export class SubagentFleetComponent implements Component {
 			}
 			return;
 		}
-		if (data.toLowerCase() === "x" || matchesKey(data, "ctrl+o")) {
+		if (matchesFleetAction(data, this.keybindings, "toggleTools")) {
 			this.expandedTools = !this.expandedTools;
 			this.transcriptCache = undefined;
 			this.tui.requestRender();
@@ -766,7 +861,7 @@ export class SubagentFleetComponent implements Component {
 			}
 		}
 
-		const raw = detailLines(selected, this.snapshot.error);
+		const raw = detailLines(selected, this.snapshot.error, this.state);
 		if (transcriptWarning) raw.unshift(`Transcript preview warning: ${transcriptWarning}`, "");
 		const lines: string[] = [];
 		for (const line of raw) {
@@ -823,7 +918,7 @@ export class SubagentFleetComponent implements Component {
 		}
 		lines.push(this.theme.fg("border", `├${"─".repeat(rosterWidth)}┴${"─".repeat(detailWidth)}┤`));
 		const position = this.snapshot.items.length ? `${this.selected + 1}/${this.snapshot.items.length}` : "0/0";
-		const footer = ` ↑↓/jk agent · H Herdr · s steer · D stop · x/Ctrl+O tools · r refresh · Esc close · ${position}`;
+		const footer = ` ${bindingLabel(this.keybindings, "selectUp")}/${bindingLabel(this.keybindings, "selectDown")} agent · ${bindingLabel(this.keybindings, "inspect")} Herdr · ${bindingLabel(this.keybindings, "steer")} steer · ${bindingLabel(this.keybindings, "stop")} stop · ${bindingLabel(this.keybindings, "toggleTools")} tools · ${bindingLabel(this.keybindings, "refresh")} refresh · ${bindingLabel(this.keybindings, "close")} close · ${position}`;
 		lines.push(this.theme.fg("border", "│") + fit(this.theme.fg("dim", footer), innerWidth) + this.theme.fg("border", "│"));
 		lines.push(this.theme.fg("border", `╰${"─".repeat(innerWidth)}╯`));
 		return lines.map((line) => truncateToWidth(line, width));

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { describe, it } from "node:test";
 import { visibleWidth, type MarkdownTheme } from "@earendil-works/pi-tui";
 import { collectFleetSnapshot, openSubagentFleet, SubagentFleetComponent } from "../../src/tui/fleet.ts";
+import { persistForegroundRunHistory, restoreForegroundRunHistory } from "../../src/runs/foreground/foreground-history.ts";
 import { FLEET_STATUS_WIDGET_KEY } from "../../src/tui/fleet-status.ts";
 import { getArtifactPaths, getArtifactsDir, getProjectArtifactsDir } from "../../src/shared/artifacts.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
@@ -259,6 +260,232 @@ describe("native subagent fleet", () => {
 		assert.equal(snapshot.items[0]?.runId, "active-old");
 		assert.equal(snapshot.items.find((item) => item.runId === "terminal-21")?.state, "complete");
 		assert.ok(!snapshot.items.some((item) => item.runId === "terminal-0"));
+	});
+
+	it("accepts default Fleet navigation from Kitty CSI-u input", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-kitty-default-"));
+		try {
+			writeAsyncRun(root, { id: "newer", lastUpdate: 300 });
+			writeAsyncRun(root, { id: "older", lastUpdate: 200 });
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
+				theme as never,
+				stateForTest(),
+				() => {},
+				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 60_000 },
+			);
+			try {
+				const selectedLine = () => component.render(100).find((line) => line.includes("›")) ?? "";
+				assert.match(selectedLine(), /newer/);
+				component.handleInput("\x1b[106;1u");
+				assert.match(selectedLine(), /older/);
+			} finally {
+				component.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("uses custom Fleet keybindings without applying them inside modal text input", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-custom-keys-"));
+		try {
+			writeAsyncRun(root, { id: "newer", lastUpdate: 300 });
+			writeAsyncRun(root, { id: "older", lastUpdate: 200 });
+			const state = stateForTest();
+			let closed = false;
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
+				theme as never,
+				state,
+				() => { closed = true; },
+				{
+					asyncDirRoot: root,
+					resultsDir: path.join(root, "results"),
+					refreshMs: 60_000,
+					fleetKeybindings: {
+						selectDown: ["n"],
+						selectUp: ["p"],
+						steer: ["m"],
+						close: ["z"],
+					},
+					actions: {
+						async steer() { return { text: "unused" }; },
+						stop() { return { text: "unused" }; },
+					},
+				},
+			);
+			try {
+				const selectedLine = () => component.render(100).find((line) => line.includes("›")) ?? "";
+				assert.match(selectedLine(), /newer/);
+				component.handleInput("j");
+				assert.match(selectedLine(), /newer/, "default j should not move when selectDown is overridden");
+				component.handleInput("\x1b[110;1u");
+				assert.match(selectedLine(), /older/, "custom selectDown should accept Kitty CSI-u input");
+				component.handleInput("p");
+				assert.match(selectedLine(), /newer/);
+				component.handleInput("m");
+				component.handleInput("m");
+				assert.ok(component.render(100).some((line) => line.includes("Steer message (steer): m")));
+				component.handleInput("\x1b");
+				component.handleInput("z");
+				assert.equal(closed, true);
+			} finally {
+				component.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("restores current-session completed foreground history from the compact index", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-foreground-history-"));
+		try {
+			const resultsDir = path.join(root, "results");
+			const cwd = path.join(root, "project");
+			const artifactsRoot = getProjectArtifactsDir(cwd);
+			fs.mkdirSync(artifactsRoot, { recursive: true });
+			const outputPath = path.join(artifactsRoot, "outputs", "restored", "output.md");
+			fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+			fs.writeFileSync(outputPath, "restored foreground output", "utf-8");
+
+			const state = stateForTest();
+			state.foregroundRuns!.set("restored", {
+				runId: "restored",
+				mode: "single",
+				cwd,
+				sessionId: "session-current",
+				updatedAt: 200,
+				children: [{ agent: "worker", index: 0, status: "completed", finalOutput: "do not persist this when an artifact exists", savedOutputPath: outputPath }],
+			});
+			state.foregroundRuns!.set("other-session", {
+				runId: "other-session",
+				mode: "single",
+				cwd,
+				sessionId: "session-other",
+				updatedAt: 300,
+				children: [{ agent: "outsider", index: 0, status: "completed", savedOutputPath: outputPath }],
+			});
+			persistForegroundRunHistory(state, { resultsDir });
+
+			const restored = stateForTest();
+			restored.baseCwd = cwd;
+			assert.equal(restoreForegroundRunHistory(restored, { resultsDir }), 1);
+			const snapshot = collectFleetSnapshot(restored);
+			assert.deepEqual(snapshot.items.map((item) => item.key), ["foreground-recent:restored:0"]);
+
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
+				theme as never,
+				restored,
+				() => {},
+				{ refreshMs: 60_000 },
+			);
+			try {
+				const lines = component.render(100);
+				assert.ok(lines.some((line) => line.includes("restored foreground output")));
+				assert.ok(!lines.some((line) => line.includes("do not persist")));
+			} finally {
+				component.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not restore nonterminal foreground history rows", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-foreground-terminal-"));
+		try {
+			const resultsDir = path.join(root, "results");
+			fs.mkdirSync(resultsDir, { recursive: true });
+			fs.writeFileSync(path.join(resultsDir, "foreground-history.json"), JSON.stringify({
+				version: 1,
+				runs: [
+					{
+						runId: "stale-running",
+						mode: "single",
+						cwd: root,
+						sessionId: "session-current",
+						updatedAt: 300,
+						children: [{ agent: "worker", index: 0, status: "running", currentTool: "bash" }],
+					},
+					{
+						runId: "terminal",
+						mode: "single",
+						cwd: root,
+						sessionId: "session-current",
+						updatedAt: 200,
+						children: [{ agent: "reviewer", index: 0, status: "completed", finalOutput: "done" }],
+					},
+				],
+			}, null, 2), "utf-8");
+
+			const restored = stateForTest();
+			restored.baseCwd = root;
+			assert.equal(restoreForegroundRunHistory(restored, { resultsDir }), 1);
+			assert.deepEqual([...restored.foregroundRuns!.keys()], ["terminal"]);
+			assert.deepEqual(collectFleetSnapshot(restored).items.map((item) => item.key), ["foreground-recent:terminal:0"]);
+
+			const state = stateForTest();
+			state.foregroundRuns!.set("stale-running", {
+				runId: "stale-running",
+				mode: "single",
+				cwd: root,
+				sessionId: "session-current",
+				updatedAt: 400,
+				children: [{ agent: "worker", index: 0, status: "running" as never }],
+			});
+			persistForegroundRunHistory(state, { resultsDir });
+			const persisted = JSON.parse(fs.readFileSync(path.join(resultsDir, "foreground-history.json"), "utf-8")) as { runs: Array<{ runId: string }> };
+			assert.deepEqual(persisted.runs.map((run) => run.runId), ["terminal"]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps restored foreground rows when output artifacts are unavailable and bounds history", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-foreground-missing-"));
+		try {
+			const resultsDir = path.join(root, "results");
+			const cwd = path.join(root, "project");
+			const artifactsRoot = getProjectArtifactsDir(cwd);
+			const state = stateForTest();
+			for (let index = 0; index < 3; index++) {
+				const outputPath = path.join(artifactsRoot, "outputs", `run-${index}`, "output.md");
+				fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+				fs.writeFileSync(outputPath, `output ${index}`, "utf-8");
+				state.foregroundRuns!.set(`run-${index}`, {
+					runId: `run-${index}`,
+					mode: "single",
+					cwd,
+					sessionId: "session-current",
+					updatedAt: index,
+					children: [{ agent: "worker", index: 0, status: "completed", savedOutputPath: outputPath }],
+				});
+			}
+			persistForegroundRunHistory(state, { resultsDir, limit: 2 });
+			fs.rmSync(path.join(artifactsRoot, "outputs", "run-2", "output.md"), { force: true });
+
+			const restored = stateForTest();
+			restored.baseCwd = cwd;
+			assert.equal(restoreForegroundRunHistory(restored, { resultsDir, limit: 2 }), 2);
+			assert.deepEqual([...restored.foregroundRuns!.keys()], ["run-2", "run-1"]);
+
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
+				theme as never,
+				restored,
+				() => {},
+				{ initialKey: "foreground-recent:run-2:0", refreshMs: 60_000 },
+			);
+			try {
+				assert.ok(component.render(100).some((line) => line.includes("output artifact unavailable")));
+			} finally {
+				component.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("uses the full 85% terminal-height budget for the inspector", () => {

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -225,6 +225,18 @@ Package skill content.
 		assert.throws(() => updateConfig((config) => config), /config\.artifactDir must be "project", "session", or "temp"/);
 	});
 
+	it("loads and validates Fleet keybinding config", () => {
+		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
+		writeFile(configPath, JSON.stringify({ fleetKeybindings: { pageUp: ["u"], pageDown: ["d"] } }));
+		assert.deepEqual(loadConfig().fleetKeybindings, { pageUp: ["u"], pageDown: ["d"] });
+
+		writeFile(configPath, JSON.stringify({ fleetKeybindings: { missing: ["m"] } }));
+		assert.throws(() => updateConfig((config) => config), /config\.fleetKeybindings\.missing is not a supported Fleet action/);
+
+		writeFile(configPath, JSON.stringify({ fleetKeybindings: { pageUp: [""] } }));
+		assert.throws(() => updateConfig((config) => config), /config\.fleetKeybindings\.pageUp entries must be non-empty strings/);
+	});
+
 	it("hardens and redacts existing run history while recording", () => {
 		const historyPath = path.join(agentDir, "run-history.jsonl");
 		fs.mkdirSync(agentDir, { recursive: true, mode: 0o755 });


### PR DESCRIPTION
## Summary

This adds extension-local Fleet inspector keybindings and restores completed foreground child history for the current session after resume.

`fleetKeybindings` customizes only the full Fleet inspector. It does not change Pi global keybindings or prompt/modal keys. The completed foreground history uses a compact current-session index so resumed sessions can inspect completed foreground children in Fleet without changing `children.list` semantics.

Fixes #940.
Fixes #946.

## Validation

- `node --experimental-strip-types --test test/unit/fleet.test.ts test/unit/pi-coding-agent-dir.test.ts`
- `npm run typecheck`
- `git diff --check f8251ed927bdc7849183130c6e0ecd9f3d4cfc63..HEAD`
- Fresh review: `/tmp/pi-subagents-backlog-20260810T145442Z/fleet-final-review.md`

The final commit only changed author metadata after review. The source tree is unchanged from reviewed commit `fbf677a722740de67c68cf3467e55913fc333442`.
