### PR TITLE
fix: harden workflow child launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Persist workflow child attempts, status heartbeats, session paths, and artifacts in their enclosing mission, and add explicit mission decision resolution.
 
 ### Fixed
+- Keep fork-context workflow children inside their managed worktree by aligning the persisted child session cwd before launch. Thanks to @flopsi for #953.
+- Show the resolved child agent in async workflow status while keeping the workflow key as its stable label. Thanks to @albertgwo for #955.
+- Reject workflow scripts that finish with unawaited child launches and name every launch that was aborted. Thanks to @zig-zag-zig for #957.
 - Reject mismatched completion replay archive paths so stale replay cleanup cannot delete another run's saved output archive.
 - Keep `git-root` project agent and package discovery stable when incidental `.pi` state appears in a nested linked worktree. Thanks to @klajdo-f for #950.
 - Read skill descriptions from YAML block scalars instead of exposing their markers. Thanks to @ashlineldridge for #945.

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import type { Message } from "@earendil-works/pi-ai";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { appendAgentRefinementOverlay } from "../../agents/agent-refinements.ts";
+import { alignForkedSessionCwd } from "../../shared/fork-context.ts";
 import {
 	ensureArtifactsDir,
 	formatOutputArtifactContent,
@@ -1416,6 +1417,9 @@ async function runSyncCompletion(
 	const acceptancePrompt = formatAcceptancePrompt(effectiveAcceptance, { reportOptional: isAgentContractV1(options.agentContract) });
 	const taskWithAcceptance = acceptancePrompt ? `${task}\n${acceptancePrompt}` : task;
 	const sessionEnabled = Boolean(options.sessionFile || options.sessionDir) || shareEnabled;
+	if (options.context === "fork" && options.sessionFile && existsSync(options.sessionFile)) {
+		alignForkedSessionCwd(options.sessionFile, options.cwd ?? runtimeCwd);
+	}
 	const skillNames = options.skills ?? agent.skills ?? [];
 	const skillCwd = options.cwd ?? runtimeCwd;
 	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4072,9 +4072,11 @@ function workflowChildResult(key: string, result: AgentToolResult<Details>): Wor
 		if (child.sessionFile) artifactPaths.add(child.sessionFile);
 	}
 	const structured = result.details.results.map((child) => child.structuredOutput).filter((value) => value !== undefined);
+	const resolvedAgents = [...new Set(result.details.results.map((child) => child.agent).filter((agent): agent is string => Boolean(agent)))];
 	return {
 		key,
 		ok,
+		...(resolvedAgents.length === 1 ? { agent: resolvedAgents[0] } : {}),
 		...(result.details.runId || result.details.asyncId ? { runId: result.details.runId ?? result.details.asyncId } : {}),
 		output,
 		...(!ok ? { error: receiptOutput || output || "Child run failed." } : {}),
@@ -4433,12 +4435,13 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							const mapped = entry.state === "started" || entry.state === "reused" ? "running" : entry.state === "completed" ? "completed" : "failed";
 							if (existing) {
 								existing.status = mapped;
+								if (entry.agent) existing.agent = entry.agent;
 								if (entry.error === undefined) delete existing.error;
 								else existing.error = entry.error;
 								if (entry.durationMs === undefined) delete existing.durationMs;
 								else existing.durationMs = entry.durationMs;
 							} else {
-								status.steps?.push({ agent: entry.key, label: entry.key, workflowKey: entry.key, parentWorkflowRunId: workflowRunId, status: mapped, startedAt: Date.now() });
+								status.steps?.push({ agent: entry.agent ?? entry.key, label: entry.key, workflowKey: entry.key, parentWorkflowRunId: workflowRunId, status: mapped, startedAt: Date.now() });
 							}
 						}
 						projectWorkflowActivity();
@@ -4540,14 +4543,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const summary = `Workflow completed with ${workflow.children.length} child run(s). Return: ${returnPreview}${emitPreview} Trace: ${workflow.trace.length} event(s).`;
 						const workflowUsage = sumResultsUsage(workflowResults);
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: workflow.trace, emits: workflow.emits, console: workflow.console }, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
-						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary, output: summary, results: workflow.children.map((child) => ({ agent: child.key, ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
+						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary, output: summary, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: "complete" });
 					} catch (error) {
 						const partial = error instanceof WorkflowScriptError ? error.partial : { trace: [], emits: [], console: [], children: [] };
 						const stopped = controller.signal.aborted;
 						status = compactOptional<AsyncStatus>({ ...status, state: stopped ? "stopped" : "failed", stopped: stopped || undefined, error: error instanceof Error ? error.message : String(error), endedAt: Date.now(), workflow: { trace: partial.trace, emits: partial.emits, console: partial.console } });
-						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: status.error, error: status.error, stopped: status.stopped, results: partial.children.map((child) => ({ agent: child.key, ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
+						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: status.error, error: status.error, stopped: status.stopped, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, error: status.error });
 					} finally {

--- a/src/shared/fork-context.ts
+++ b/src/shared/fork-context.ts
@@ -9,6 +9,7 @@ type SubagentExecutionContext = "fresh" | "fork";
 interface BranchSessionEntry {
 	type: string;
 	id?: string;
+	cwd?: string;
 	parentId?: string | null;
 	timestamp?: string;
 	message?: {
@@ -126,6 +127,18 @@ function readSessionEntries(sessionFile: string): BranchSessionEntry[] {
 			throw new Error(`Unable to inspect forked session ${sessionFile}: invalid JSONL on line ${index + 1}: ${cause.message}`, { cause });
 		}
 	});
+}
+
+/** Keep Pi from restoring a forked session into the parent's cwd instead of the child launch cwd. */
+export function alignForkedSessionCwd(sessionFile: string, cwd: string): void {
+	const entries = readSessionEntries(sessionFile);
+	const header = entries[0];
+	if (header?.type !== "session") throw new Error(`Forked session ${sessionFile} does not start with a session header.`);
+	const resolvedCwd = path.resolve(cwd);
+	const effectiveCwd = fs.realpathSync.native(resolvedCwd);
+	if (header.cwd === effectiveCwd) return;
+	header.cwd = effectiveCwd;
+	fs.writeFileSync(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, "utf-8");
 }
 
 export function createForkContextResolver(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1047,6 +1047,7 @@ export interface Details {
 			operation: "run" | "status";
 			key: string;
 			state: "started" | "completed" | "failed" | "reused";
+			agent?: string;
 			runId?: string;
 			phase?: string;
 			label?: string;

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -10,6 +10,9 @@ const { inspect } = require("node:util");
 let nextCallId = 0;
 const pending = new Map();
 const runKeyPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const trackedPromisePatch = Symbol("trackedPromisePatch");
+const trackedPromiseObservations = new WeakMap();
+let suppressRunObservation = 0;
 
 function stableRunJson(value) {
   if (Array.isArray(value)) return "[" + value.map(stableRunJson).join(",") + "]";
@@ -17,12 +20,124 @@ function stableRunJson(value) {
   return JSON.stringify(value) ?? "undefined";
 }
 
-function hostCall(method, args) {
-  return new Promise((resolve, reject) => {
-    const callId = ++nextCallId;
+function isDirectWorkflowScriptPromiseHandlerCall() {
+  const stack = new Error().stack;
+  if (typeof stack !== "string") return false;
+  const frame = stack.split("\n").slice(1).map((line) => line.trim()).find((line) =>
+    line &&
+    !line.includes("isDirectWorkflowScriptPromiseHandlerCall") &&
+    !line.includes("markObserved") &&
+    !line.includes("promise.then") &&
+    !line.includes("promise.catch") &&
+    !line.includes("promise.finally")
+  );
+  return frame ? frame.includes("workflow-script.js") && !frame.includes("at async ") : false;
+}
+
+function mergeObservations(...groups) {
+  const seen = new Set();
+  const merged = [];
+  for (const group of groups) {
+    for (const observation of group) {
+      if (!observation || typeof observation.callId !== "number" || typeof observation.key !== "string" || seen.has(observation.callId)) continue;
+      seen.add(observation.callId);
+      merged.push(observation);
+    }
+  }
+  return merged;
+}
+
+function trackedObservations(value) {
+  return value && (typeof value === "object" || typeof value === "function") ? trackedPromiseObservations.get(value) ?? [] : [];
+}
+
+function withSuppressedRunObservation(callback) {
+  suppressRunObservation += 1;
+  try {
+    return callback();
+  } finally {
+    suppressRunObservation -= 1;
+  }
+}
+
+function trackRunObservation(observations, promise) {
+  const merged = mergeObservations(trackedObservations(promise), observations);
+  if (merged.length === 0 || !promise || typeof promise.then !== "function") return promise;
+  trackedPromiseObservations.set(promise, merged);
+  if (promise[trackedPromisePatch]) return promise;
+
+  const observedCallIds = new Set();
+  const markObserved = () => {
+    if (suppressRunObservation > 0 || isDirectWorkflowScriptPromiseHandlerCall()) return;
+    for (const observation of trackedObservations(promise)) {
+      if (observedCallIds.has(observation.callId)) continue;
+      observedCallIds.add(observation.callId);
+      parentPort.postMessage({ type: "runObserved", callId: observation.callId, key: observation.key });
+    }
+  };
+  const originalThen = promise.then.bind(promise);
+  const originalCatch = promise.catch.bind(promise);
+  const originalFinally = promise.finally.bind(promise);
+  Object.defineProperty(promise, trackedPromisePatch, { value: true });
+  promise.then = (onFulfilled, onRejected) => {
+    markObserved();
+    return trackRunObservation(trackedObservations(promise), originalThen(onFulfilled, onRejected));
+  };
+  promise.catch = (onRejected) => {
+    markObserved();
+    return trackRunObservation(trackedObservations(promise), originalCatch(onRejected));
+  };
+  promise.finally = (onFinally) => {
+    markObserved();
+    return trackRunObservation(trackedObservations(promise), originalFinally(onFinally));
+  };
+  return promise;
+}
+
+function trackPromiseCombinator(items, createPromise) {
+  const values = Array.from(items);
+  const observations = mergeObservations(...values.map(trackedObservations));
+  const promise = withSuppressedRunObservation(() => createPromise(values));
+  return observations.length > 0 ? trackRunObservation(observations, promise) : promise;
+}
+
+const workflowPromise = new Proxy(Promise, {
+  construct(target, args) {
+    return new target(...args);
+  },
+  get(target, prop) {
+    if (prop === "all") return (items) => trackPromiseCombinator(items, (values) => target.all(values));
+    if (prop === "allSettled") return (items) => trackPromiseCombinator(items, (values) => target.allSettled(values));
+    if (prop === "race") return (items) => trackPromiseCombinator(items, (values) => target.race(values));
+    if (prop === "any") return (items) => trackPromiseCombinator(items, (values) => target.any(values));
+    if (prop === "resolve") return (value) => {
+      const observations = trackedObservations(value);
+      const promise = withSuppressedRunObservation(() => target.resolve(value));
+      return observations.length > 0 ? trackRunObservation(observations, promise) : promise;
+    };
+    const value = target[prop];
+    return typeof value === "function" ? value.bind(target) : value;
+  },
+});
+
+function hostCall(method, args, observation) {
+  const callId = ++nextCallId;
+  const promise = new Promise((resolve, reject) => {
     pending.set(callId, { resolve, reject });
     parentPort.postMessage({ type: "call", callId, method, args });
   });
+  return observation && typeof observation.key === "string"
+    ? trackRunObservation([{ key: observation.key, callId }], promise)
+    : promise;
+}
+
+function runHostCall(key, params, collectFailure) {
+  const callId = ++nextCallId;
+  const promise = new Promise((resolve, reject) => {
+    pending.set(callId, { resolve, reject });
+    parentPort.postMessage({ type: "call", callId, method: "run", args: { key, params, ...(collectFailure ? { collectFailure: true } : {}) } });
+  });
+  return { key, callId, promise };
 }
 
 function formatRef(result) {
@@ -58,7 +173,7 @@ function validateRunCall(key, params, label, fingerprints) {
 const runs = Object.freeze({
   run(key, params) {
     validateRunCall(key, params, "runs.run", runFingerprints);
-    return hostCall("run", { key, params });
+    return hostCall("run", { key, params }, { key });
   },
   all(items) {
     if (!Array.isArray(items)) throw new Error("runs.all(items) requires an array.");
@@ -73,7 +188,8 @@ const runs = Object.freeze({
       calls.push({ key, params });
     }
     for (const { key, params } of calls) runFingerprints.set(key, stableRunJson(params));
-    return Promise.all(calls.map(({ key, params }) => hostCall("run", { key, params, collectFailure: true })));
+    const launched = calls.map(({ key, params }) => runHostCall(key, params, true));
+    return trackRunObservation(launched.map(({ key, callId }) => ({ key, callId })), Promise.all(launched.map(({ promise }) => promise)));
   },
   status(keyOrRunId) { return hostCall("status", { keyOrRunId }); },
   ref: formatRef,
@@ -169,7 +285,7 @@ parentPort.on("message", async (message) => {
   }
   if (message.type !== "start") return;
   try {
-    const sandbox = { runs, emit(value) { assertJsonValue(value); parentPort.postMessage({ type: "emit", value }); }, console: capturedConsole };
+    const sandbox = { runs, Promise: workflowPromise, emit(value) { assertJsonValue(value); parentPort.postMessage({ type: "emit", value }); }, console: capturedConsole };
     if (message.stateEnabled) sandbox.state = state;
     const context = vm.createContext(sandbox, { codeGeneration: { strings: false, wasm: false } });
     contextObjectPrototype = vm.runInContext("Object.prototype", context);
@@ -194,6 +310,8 @@ parentPort.on("message", async (message) => {
 export interface WorkflowScriptChildResult {
 	key: string;
 	ok: boolean;
+	/** Canonical child agent name when launch resolution produced one. */
+	agent?: string;
 	runId?: string;
 	output: string;
 	error?: string;
@@ -206,6 +324,8 @@ export interface WorkflowScriptTraceEntry {
 	operation: "run" | "status";
 	key: string;
 	state: "started" | "completed" | "failed" | "reused";
+	/** Canonical child agent name when resolved launch or result data is available. */
+	agent?: string;
 	runId?: string;
 	durationMs?: number;
 	phase?: string;
@@ -355,7 +475,8 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 	const trace: WorkflowScriptTraceEntry[] = [];
 	const children = new Map<string, WorkflowScriptChildResult>();
 	const childOrder: string[] = [];
-	const launches = new Map<string, { fingerprint: string; promise: Promise<WorkflowScriptChildResult> }>();
+	const launches = new Map<string, { fingerprint: string; promise: Promise<WorkflowScriptChildResult>; observed: boolean }>();
+	const observedRunCalls = new Set<number>();
 	const childController = new AbortController();
 	let settled = false;
 
@@ -372,8 +493,13 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			if (timer) clearTimeout(timer);
 			options.signal?.removeEventListener("abort", onAbort);
 			void worker.terminate();
-			childController.abort("error" in outcome ? outcome.error : new Error("Workflow script completed; unawaited child launches are aborted."));
+			const unobservedKeys = "value" in outcome ? [...launches].filter(([, launch]) => !launch.observed).map(([key]) => key) : [];
+			const completionError = unobservedKeys.length > 0
+				? new Error(`workflowScript completed with unawaited runs.run launch(es): ${unobservedKeys.map((key) => `'${key}'`).join(", ")}. Await or return each launch.`)
+				: undefined;
+			childController.abort("error" in outcome ? outcome.error : completionError ?? new Error("Workflow script completed."));
 			if ("error" in outcome) reject(new WorkflowScriptError(outcome.error.message, partial()));
+			else if (completionError) reject(new WorkflowScriptError(completionError.message, partial()));
 			else resolve({ value: outcome.value, ...partial() });
 		};
 		const onAbort = () => finish({ error: new Error("Workflow script aborted.") });
@@ -418,6 +544,13 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				return finish({ value: message.value });
 			}
 			if (message.type === "error") return finish({ error: new Error(typeof message.error === "string" ? message.error : "Workflow script failed.") });
+			if (message.type === "runObserved" && typeof message.callId === "number") {
+				const key = typeof message.key === "string" ? message.key : undefined;
+				const launch = key ? launches.get(key) : undefined;
+				if (launch) launch.observed = true;
+				else observedRunCalls.add(message.callId);
+				return;
+			}
 			if (message.type !== "call" || typeof message.callId !== "number" || typeof message.method !== "string" || !isRecord(message.args)) return;
 
 			const respond = (promise: Promise<unknown>) => {
@@ -501,6 +634,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				return respond(Promise.reject(new Error(`runs.run('${key}') resume requires a non-empty task follow-up.`)));
 			}
 			const collectFailure = message.args.collectFailure === true;
+			const callObserved = observedRunCalls.delete(message.callId);
 			const deliver = (promise: Promise<WorkflowScriptChildResult>) => collectFailure
 				? promise
 				: promise.then((result) => {
@@ -511,6 +645,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			const existing = launches.get(key);
 			if (existing) {
 				if (existing.fingerprint !== fingerprint) return respond(Promise.reject(new Error(`Duplicate workflow key '${key}' used with incompatible launch params.`)));
+				if (callObserved) existing.observed = true;
 				trace.push({ operation: "run", key, state: "reused", ...workflowStringMetadata(params) });
 				traceChanged();
 				return respond(deliver(existing.promise));
@@ -523,7 +658,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			const promise = Promise.resolve().then(() => options.launch(key, { ...params, async: params.async ?? false }, childController.signal)).then((result) => {
 				const normalized = !result.ok && !result.error ? { ...result, error: result.output } : result;
 				children.set(key, normalized);
-				trace.push({ operation: "run", key, state: normalized.ok ? "completed" : "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(normalized.runId ? { runId: normalized.runId } : {}), ...(!normalized.ok ? { error: normalized.error ?? normalized.output } : {}) });
+				trace.push({ operation: "run", key, state: normalized.ok ? "completed" : "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(normalized.agent ? { agent: normalized.agent } : {}), ...(normalized.runId ? { runId: normalized.runId } : {}), ...(!normalized.ok ? { error: normalized.error ?? normalized.output } : {}) });
 				traceChanged();
 				return normalized;
 			}, (error: unknown) => {
@@ -534,7 +669,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				traceChanged();
 				return failure;
 			});
-			launches.set(key, { fingerprint, promise });
+			launches.set(key, { fingerprint, promise, observed: callObserved });
 			respond(deliver(promise));
 		});
 

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -142,6 +142,7 @@ interface RunSyncResult {
 
 interface MockPiCallRecord {
 	args?: string[];
+	cwd?: string;
 	systemPrompts?: Array<{ mode?: string; path?: string; text?: string; error?: string }>;
 }
 
@@ -301,7 +302,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		removeTempDir(tempDir);
 	});
 
-	function readCall(): { args: string[]; systemPrompts: NonNullable<MockPiCallRecord["systemPrompts"]> } {
+	function readCall(): { args: string[]; cwd?: string; systemPrompts: NonNullable<MockPiCallRecord["systemPrompts"]> } {
 		const callFile = fs.readdirSync(mockPi.dir)
 			.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
 			.sort()
@@ -309,7 +310,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok(callFile, "expected a recorded mock pi call");
 		const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as MockPiCallRecord;
 		assert.ok(Array.isArray(payload.args), "expected recorded args");
-		return { args: payload.args, systemPrompts: payload.systemPrompts ?? [] };
+		return { args: payload.args, cwd: payload.cwd, systemPrompts: payload.systemPrompts ?? [] };
 	}
 
 	function readCallArgs(): string[] {
@@ -404,7 +405,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 	it("starts workflow scripts asynchronously with a portable internal run id", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "async workflow child" });
 		const asyncJobs: SubagentState["asyncJobs"] = new Map();
-		const executor = makeExecutor([makeAgent("echo")], { missions: { globalIndex: false } }, false, undefined, true, asyncJobs);
+		const executor = makeExecutor([makeAgent("echo", { aliases: ["helper"] })], { missions: { globalIndex: false } }, false, undefined, true, asyncJobs);
 		const workflowCwd = path.join(tempDir, "workflow-cwd");
 		fs.mkdirSync(workflowCwd);
 		const toolCallId = "call_demo|fc_demo";
@@ -413,7 +414,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			toolCallId,
 			{
 				cwd: workflowCwd,
-				workflowScript: `emit("starting"); await runs.run("work", { agent: "echo", task: "Async work" }); return { answer: 42 };`,
+				workflowScript: `emit("starting"); await runs.run("work", { agent: "helper", task: "Async work" }); return { answer: 42 };`,
 				mission: { summary: "Review the active backlog", labels: ["github-backlog", "review"] },
 			},
 			new AbortController().signal,
@@ -436,7 +437,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(fs.existsSync(path.join(DIRS.async, toolCallId)), false);
 		assert.match(result.content[0]?.text ?? "", /Async workflow/);
 		const statusPath = path.join(result.details.asyncDir!, "status.json");
-		let status: { runId?: string; toolCallId?: string; cwd?: string; state?: string; steps?: Array<{ parentWorkflowRunId?: string }>; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; state?: string }> } } = {};
+		let status: { runId?: string; toolCallId?: string; cwd?: string; state?: string; steps?: Array<{ agent?: string; label?: string; workflowKey?: string; parentWorkflowRunId?: string }>; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; agent?: string; state?: string }> } } = {};
 		for (let attempt = 0; attempt < 100; attempt++) {
 			status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
 			if (status.state === "complete" || status.state === "failed") break;
@@ -447,18 +448,24 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(status.toolCallId, toolCallId);
 		assert.equal(status.cwd, workflowCwd);
 		assert.equal(status.steps?.length, 1);
+		assert.deepEqual(status.steps?.map(({ agent, label, workflowKey }) => ({ agent, label, workflowKey })), [
+			{ agent: "echo", label: "work", workflowKey: "work" },
+		]);
 		assert.ok(status.steps?.every((step) => step.parentWorkflowRunId === workflowRunId));
 		assert.deepEqual(status.workflow?.value, { answer: 42 });
 		assert.deepEqual(status.workflow?.emits, ["starting"]);
 		assert.equal(mockPi.callCount(), 1);
-		assert.ok(status.workflow?.trace?.some((entry) => entry.key === "work" && entry.state === "completed"));
+		assert.ok(status.workflow?.trace?.some((entry) => entry.key === "work" && entry.agent === "echo" && entry.state === "completed"));
 		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
-		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; cwd?: string; summary?: string; workflow?: { value?: unknown } };
+		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; cwd?: string; summary?: string; workflow?: { value?: unknown }; results?: Array<{ agent?: string; workflowKey?: string }> };
 		assert.equal(persistedResult.id, workflowRunId);
 		assert.equal(persistedResult.runId, workflowRunId);
 		assert.equal(persistedResult.toolCallId, toolCallId);
 		assert.equal(persistedResult.agent, "workflow");
 		assert.equal(persistedResult.cwd, workflowCwd);
+		assert.deepEqual(persistedResult.results?.map(({ agent, workflowKey }) => ({ agent, workflowKey })), [
+			{ agent: "echo", workflowKey: "work" },
+		]);
 		assert.match(persistedResult.summary ?? "", /Return: \{\n  "answer": 42\n\}/);
 		assert.deepEqual(persistedResult.workflow?.value, { answer: 42 });
 		assert.equal(fs.existsSync(path.join(DIRS.results, `${toolCallId}.json`)), false);
@@ -843,6 +850,57 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(handoff.groups[0]?.cleanup.state, "complete");
 		assert.equal(handoff.groups[0]?.cleanup.tasks[0]?.worktreeRemoved, true);
 
+	});
+
+	it("aligns a forked workflow child session with its managed worktree cwd", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });
+		execFileSync("git", ["config", "user.name", "Test User"], { cwd: tempDir });
+		fs.writeFileSync(path.join(tempDir, "base.txt"), "base\n", "utf-8");
+		execFileSync("git", ["add", "base.txt"], { cwd: tempDir });
+		execFileSync("git", ["commit", "-m", "base"], { cwd: tempDir, stdio: "ignore" });
+
+		const parentSessionFile = path.join(mockPi.dir, "parent-session.jsonl");
+		const childSessionFile = path.join(mockPi.dir, "forked-child-session.jsonl");
+		fs.writeFileSync(parentSessionFile, `${JSON.stringify({ type: "session", version: 3, id: "parent", cwd: tempDir })}\n`, "utf-8");
+		const ctx = makeMinimalCtx(tempDir);
+		Object.assign(ctx.sessionManager, {
+			getSessionFile: () => parentSessionFile,
+			getLeafId: () => "parent-leaf",
+			openSession: () => ({
+				createBranchedSession: () => {
+					fs.writeFileSync(childSessionFile, `${JSON.stringify({ type: "session", version: 3, id: "child", cwd: tempDir })}\n`, "utf-8");
+					return childSessionFile;
+				},
+			}),
+		});
+		mockPi.onCall({ output: "isolated fork child" });
+		const executor = makeExecutor([makeAgent("worker", { defaultContext: "fork" })]);
+
+		const result = await executor.execute(
+			"forked-worktree-workflow",
+			{ async: false, workflowScript: `return runs.run("isolated", { agent: "worker", task: "Work in isolation", worktree: true });` },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		const workflowValue = result.details.workflow?.value as { artifactPaths?: string[] } | undefined;
+		const handoffPath = workflowValue?.artifactPaths?.find((candidate) => candidate.endsWith(".json") && candidate.includes("handoffs"));
+		assert.ok(handoffPath, JSON.stringify(workflowValue));
+		const handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as {
+			groups: Array<{ cleanup: { tasks: Array<{ path: string }> } }>;
+		};
+		const managedWorktreeCwd = handoff.groups[0]?.cleanup.tasks[0]?.path;
+		assert.ok(managedWorktreeCwd);
+		const callCwd = readCall().cwd;
+		assert.ok(callCwd);
+		assert.notEqual(path.resolve(callCwd), path.resolve(tempDir));
+		assert.equal(path.basename(callCwd), path.basename(managedWorktreeCwd));
+		const sessionHeader = JSON.parse(fs.readFileSync(childSessionFile, "utf-8").split("\n", 1)[0]!) as { cwd?: string };
+		assert.ok(sessionHeader.cwd);
+		assert.equal(path.basename(sessionHeader.cwd), path.basename(callCwd));
 	});
 
 	it("lets runs.all siblings settle when one child fails", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/support/helpers.ts
+++ b/test/support/helpers.ts
@@ -43,7 +43,9 @@ export function createEventBus() {
 
 interface AgentConfig {
 	name: string;
+	aliases?: string[];
 	description?: string;
+	defaultContext?: "fresh" | "fork";
 	systemPrompt?: string;
 	model?: string;
 	fallbackModels?: string[];

--- a/test/support/mock-pi-script.mjs
+++ b/test/support/mock-pi-script.mjs
@@ -337,7 +337,7 @@ async function main() {
 	writeToolDiagnostic(response);
 	const callPath = path.join(queueDir, `call-${Date.now()}-${process.pid}-${Math.random().toString(16).slice(2)}.json`);
 	const callTempPath = `${callPath}.tmp-${process.pid}-${Date.now()}`;
-	fs.writeFileSync(callTempPath, JSON.stringify({ args, systemPrompts: readSystemPromptRecords(args) }), "utf-8");
+	fs.writeFileSync(callTempPath, JSON.stringify({ args, cwd: process.cwd(), systemPrompts: readSystemPromptRecords(args) }), "utf-8");
 	fs.renameSync(callTempPath, callPath);
 
 	if (typeof response.delay === "number" && response.delay > 0) {

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -490,21 +490,128 @@ describe("scripted workflow runtime", () => {
 		);
 	});
 
-	it("aborts an unawaited child launch when the script completes", async () => {
+	it("rejects and aborts an unawaited child launch when the script completes", async () => {
 		let childAborted = false;
+		await assert.rejects(
+			runWorkflowScript({
+				script: `runs.run("bg", { agent: "worker", task: "fire and forget" }); return "done";`,
+				timeoutMs: 2_000,
+				launch(_key, _params, signal) {
+					return new Promise((_resolve, reject) => signal.addEventListener("abort", () => {
+						childAborted = true;
+						reject(signal.reason);
+					}, { once: true }));
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError
+				&& error.message.includes("unawaited runs.run launch(es): 'bg'")
+				&& error.message.includes("Await or return each launch"),
+		);
+		assert.equal(childAborted, true);
+	});
+
+	it("rejects an unawaited child launch that settles before the script completes", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `runs.run("fast", { agent: "worker", task: "quick" }); await runs.status("probe"); return "done";`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "fast output", artifactPaths: [] }; },
+				async status(key) {
+					await Promise.resolve();
+					return { key, ok: true, output: "ok", artifactPaths: [] };
+				},
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError
+				&& error.message.includes("unawaited runs.run launch(es): 'fast'")
+				&& error.partial.children.some((child) => child.key === "fast"),
+		);
+	});
+
+	it("rejects an unawaited runs.all launch group", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `runs.all([{ key: "a", agent: "worker", task: "one" }]); return "done";`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && error.message.includes("unawaited runs.run launch(es): 'a'"),
+		);
+	});
+
+	it("rejects an unawaited native Promise.all over runs.run", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `Promise.all([runs.run("native", { agent: "worker", task: "one" })]); return "done";`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && error.message.includes("unawaited runs.run launch(es): 'native'"),
+		);
+	});
+
+	it("rejects fire-and-forget callbacks on a runs.run promise", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `runs.run("bg", { agent: "worker", task: "fire" }).then(() => {}); return "done";`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && error.message.includes("unawaited runs.run launch(es): 'bg'"),
+		);
+	});
+
+	it("rejects reading output from an unawaited runs.run promise", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `return runs.run("x", { agent: "worker", task: "run" }).output;`,
+				timeoutMs: 2_000,
+				launch(_key, _params, signal) {
+					return new Promise((_resolve, reject) => signal.addEventListener("abort", () => reject(signal.reason), { once: true }));
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && error.message.includes("unawaited runs.run launch(es): 'x'"),
+		);
+	});
+
+	it("names every outstanding workflow launch", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `runs.run("first", { agent: "worker", task: "one" }); runs.run("second", { agent: "worker", task: "two" }); return null;`,
+				timeoutMs: 2_000,
+				launch(_key, _params, signal) {
+					return new Promise((_resolve, reject) => signal.addEventListener("abort", () => reject(signal.reason), { once: true }));
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError
+				&& error.message.includes("'first', 'second'")
+				&& error.partial.children.length === 0,
+		);
+	});
+
+	it("accepts a directly returned runs.run promise", async () => {
 		const result = await runWorkflowScript({
-			script: `runs.run("bg", { agent: "worker", task: "fire and forget" }); return "done";`,
+			script: `return runs.run("direct", { agent: "worker", task: "run" });`,
 			timeoutMs: 2_000,
-			launch(_key, _params, signal) {
-				return new Promise((_resolve, reject) => signal.addEventListener("abort", () => {
-					childAborted = true;
-					reject(signal.reason);
-				}, { once: true }));
-			},
+			async launch(key) { return { key, ok: true, output: "direct output", artifactPaths: [] }; },
 			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
 		});
-		assert.equal(result.value, "done");
-		assert.equal(childAborted, true);
+		assert.equal((result.value as { output?: string }).output, "direct output");
+	});
+
+	it("accepts output from an explicitly awaited runs.run promise", async () => {
+		const result = await runWorkflowScript({
+			script: `return (await runs.run("awaited", { agent: "worker", task: "run" })).output;`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "awaited output", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(result.value, "awaited output");
 	});
 
 	it("rejects non-JSON-safe emitted values without persisting them", async () => {

--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -40,6 +40,10 @@ function writeStatus(asyncDir: string, status: AsyncStatus): void {
 	fs.utimesSync(statusPath, mtime, mtime);
 }
 
+function removeAsyncDir(asyncDir: string): void {
+	fs.rmSync(asyncDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 10 });
+}
+
 function runningStatus(runId: string, mode: AsyncStatus["mode"] = "single", count = 1): AsyncStatus {
 	return {
 		runId,
@@ -127,7 +131,7 @@ describe("acknowledged steering action", () => {
 			assert.equal(result.details.steering?.state, "delivered");
 			assert.match(result.content[0]!.text, /Steering delivered/);
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 
@@ -141,7 +145,7 @@ describe("acknowledged steering action", () => {
 			assert.equal(result.isError, true);
 			assert.match(result.content[0]!.text, /no longer accepts steering requests/);
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 
@@ -169,7 +173,7 @@ describe("acknowledged steering action", () => {
 			assert.equal(queued.message, "Review the docs");
 			assert.equal(queued.mode, "follow_up");
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 
@@ -192,7 +196,7 @@ describe("acknowledged steering action", () => {
 			assert.equal(recovered, false);
 			assert.equal(fs.existsSync(path.join(asyncDir, "control", "steer-recovery")), false);
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 
@@ -232,7 +236,7 @@ describe("acknowledged steering action", () => {
 			assert.ok(request);
 			assert.equal(fs.existsSync(path.join(asyncDir, "control", "steer-recovery", `${Buffer.from(request.id).toString("base64url")}.json`)), false);
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 
@@ -241,6 +245,7 @@ describe("acknowledged steering action", () => {
 		const asyncDir = path.join(ASYNC_DIR, runId);
 		writeStatus(asyncDir, runningStatus(runId));
 		const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+		let claimed = false;
 		try {
 			const action = steerAsyncRun({
 				state: createState(), runId, message: "correct course", location: { asyncDir },
@@ -253,16 +258,17 @@ describe("acknowledged steering action", () => {
 					projectRequest(routed, request, ["routed"]);
 					writeStatus(asyncDir, routed);
 				},
+				onRecoveryCommitted: () => { claimed = true; },
 				recover: async () => successResult("replacement"),
 			});
 			const result = await action;
-			assert.equal(result.isError, true);
+			assert.equal(claimed, true);
 			assert.match(result.content[0]!.text, /claim remains committed to prevent a delayed duplicate/);
 			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
 			assert.deepEqual(kills, [{ pid: 12345, signal: 0 }]);
 			assert.equal(fs.existsSync(path.join(asyncDir, "control", "steer-recovery", "claim.json")), true);
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 
@@ -328,7 +334,7 @@ describe("acknowledged steering action", () => {
 			assert.ok(persisted.steering?.recent[0]?.targets[0]?.lateDeliveredAt);
 			assert.equal(persisted.steps?.[0]?.steering?.recent[0]?.targets[0]?.state, "recovered");
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 
@@ -362,7 +368,7 @@ describe("acknowledged steering action", () => {
 			assert.equal(recovered, false);
 			assert.match(result.content[0]!.text, /no persisted child session|does not have a persisted session file/i);
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 
@@ -391,7 +397,7 @@ describe("acknowledged steering action", () => {
 			assert.equal(recovered, false);
 			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 
@@ -413,7 +419,7 @@ describe("acknowledged steering action", () => {
 			assert.equal(killed, false);
 			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
 		} finally {
-			fs.rmSync(asyncDir, { recursive: true, force: true });
+			removeAsyncDir(asyncDir);
 		}
 	});
 });


### PR DESCRIPTION
## Summary

This replaces the remaining workflow-child backlog items with one current-base fix:

- Keeps fork-context workflow children inside their managed worktree by aligning the forked child session cwd before launch.
- Shows the resolved child agent in async workflow status and persisted workflow results while keeping the workflow key separate.
- Fails `workflowScript` runs that finish with unawaited child launches and names every aborted launch.

Closes #953.
Closes #957.
Supersedes #955, preserving the useful agent-name status behavior and visible changelog credit for @albertgwo.

## Validation

- `node --experimental-strip-types --test test/unit/scripted-workflow.test.ts`
- `node --experimental-strip-types --test --test-name-pattern='starts workflow scripts asynchronously|aligns a forked workflow child session' test/integration/single-execution.test.ts`
- `node --experimental-strip-types --test test/unit/fork-context.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e` (skipped locally because Pi runtime packages are unavailable)
- `npm run typecheck`
- `git diff --check`

## Review

Fresh review found one persisted-result agent mapping issue. That was fixed and a targeted follow-up review reported no findings.
