### PR TITLE
test: retry async workflow child cleanup

### DIFF
--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -616,7 +616,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		}
 		assert.equal(fs.existsSync(childResultPath), true);
 		assert.equal(fs.existsSync(path.join(childDir, "workflow-result.json")), false);
-		fs.rmSync(childDir, { recursive: true, force: true });
+		fs.rmSync(childDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 		fs.rmSync(childResultPath, { force: true });
 	});
 


### PR DESCRIPTION
## Summary

Fix a post-merge Ubuntu CI cleanup race from #962. The failing test had already verified that ordinary async workflow children write their results through the watcher-owned path, then `fs.rmSync()` hit a transient `ENOTEMPTY` while removing the child async directory.

This adds bounded retries to that cleanup call only.

## Validation

- `node --experimental-strip-types --test --test-name-pattern='keeps ordinary async workflow child results in the watcher-owned path' test/integration/single-execution.test.ts`
- `npm run test:integration`
- `npm run typecheck`
- `git diff --check`

Follow-up to #962.
