### PR TITLE
test: relax steering recovery timing

### DIFF
--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -291,8 +291,8 @@ describe("acknowledged steering action", () => {
 				runId,
 				message: "correct course",
 				location: { asyncDir },
-				ackTimeoutMs: 25,
-				recoveryTimeoutMs: 500,
+				ackTimeoutMs: 250,
+				recoveryTimeoutMs: 1_000,
 				kill: () => true,
 				onRequestQueued: (requestPath) => {
 					request = JSON.parse(fs.readFileSync(requestPath, "utf-8")) as SteerRequest;


### PR DESCRIPTION
## Summary

Fix a post-merge Ubuntu CI unit-test timeout after #963. The steering recovery test used very tight synthetic timeouts, then occasionally missed the recovery interrupt marker under CI scheduling.

This keeps the test on the timeout-driven recovery path, but gives it a small deterministic margin that is still well below the product defaults.

## Validation

- `node --experimental-strip-types --test --test-name-pattern='pauses and revives a single run with only its remaining budgets' test/unit/steering-action.test.ts` repeated 5 times
- `npm run test:unit`
- `npm run typecheck`
- `git diff --check`

Follow-up to #963.
