### PR TITLE
fix: surface foreground workflow children in Herdr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Persist workflow child attempts, status heartbeats, session paths, and artifacts in their enclosing mission, and add explicit mission decision resolution.
 
 ### Fixed
+- Make live foreground workflow children visible as workflow-owned Fleet rows, route Herdr inspection to their workflow parent, and report their active and needs-attention state to Herdr. Thanks to @lukechen526 for #965.
 - Wait for retained-child resumes inside `workflowScript` to finish and return completed output before the script continues (#961).
 - Keep fork-context workflow children inside their managed worktree by aligning the persisted child session cwd before launch. Thanks to @flopsi for #953.
 - Show the resolved child agent in async workflow status while keeping the workflow key as its stable label. Thanks to @albertgwo for #955.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -37,7 +37,7 @@ import { registerPromptTemplateDelegationBridge } from "../slash/prompt-template
 import { registerMainWatchdog } from "../watchdog/register-main.ts";
 import { registerSlashSubagentBridge } from "../slash/slash-bridge.ts";
 import { createNativeSupervisorChannel } from "../intercom/native-supervisor-channel.ts";
-import { registerHerdrStatusBridge } from "../integrations/herdr-status.ts";
+import { registerHerdrStatusBridge, type HerdrStatusRun } from "../integrations/herdr-status.ts";
 import { registerSubagentRpcBridge } from "./rpc.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
 import { inspectSubagentStatus } from "../runs/background/run-status.ts";
@@ -307,6 +307,36 @@ class SubagentControlNoticeComponent implements Component {
 		lines.push(this.theme.fg("accent", `╰${borderChar.repeat(bodyWidth)}╯`));
 		return lines;
 	}
+}
+
+export function projectActiveHerdrRuns(state: SubagentState): HerdrStatusRun[] {
+	const active = (status: string) => status === "queued" || status === "running";
+	const foregroundChildrenByWorkflow = new Map<string, Array<{ agent: string; needsAttention: boolean }>>();
+	for (const control of state.foregroundControls.values()) {
+		if (!control.parentWorkflowRunId) continue;
+		const children = control.activeChildren?.size
+			? [...control.activeChildren.values()].map((child) => ({
+				agent: child.agent,
+				needsAttention: child.currentActivityState === "needs_attention",
+			}))
+			: control.currentAgent
+				? [{ agent: control.currentAgent, needsAttention: control.currentActivityState === "needs_attention" }]
+				: [];
+		if (children.length === 0) continue;
+		const existing = foregroundChildrenByWorkflow.get(control.parentWorkflowRunId) ?? [];
+		existing.push(...children);
+		foregroundChildrenByWorkflow.set(control.parentWorkflowRunId, existing);
+	}
+	return [...state.asyncJobs.values()]
+		.filter((job) => active(job.status))
+		.map((job) => {
+			const children = job.mode === "workflow" ? foregroundChildrenByWorkflow.get(job.asyncId) : undefined;
+			return {
+				id: job.asyncId,
+				agents: children?.length ? children.map((child) => child.agent) : job.agents,
+				needsAttention: job.activityState === "needs_attention" || children?.some((child) => child.needsAttention),
+			};
+		});
 }
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
@@ -621,13 +651,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const existingVisibleControlNotices = globalStore[controlNoticeSeenStoreKey];
 	const visibleControlNotices = existingVisibleControlNotices instanceof Set ? existingVisibleControlNotices as Set<string> : new Set<string>();
 	globalStore[controlNoticeSeenStoreKey] = visibleControlNotices;
-	const activeHerdrRuns = () => [...state.asyncJobs.values()]
-		.filter((job) => job.status === "queued" || job.status === "running")
-		.map((job) => ({
-			id: job.asyncId,
-			agents: job.agents,
-			needsAttention: job.activityState === "needs_attention",
-		}));
+	const activeHerdrRuns = () => projectActiveHerdrRuns(state);
 	const herdrStatusBridge = registerHerdrStatusBridge({
 		events: pi.events,
 		getRuns: activeHerdrRuns,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4168,6 +4168,7 @@ export function prepareWorkflowLaunchParams(
 	}
 	const launchParams = {
 		...workflowDefaults,
+		async: false,
 		...childParams,
 		...(options.missionDetached ? { mission: false } : {}),
 		workflowParentRunId: parentWorkflowRunId,
@@ -5589,6 +5590,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				runId,
 				sessionId: requestSessionId,
 				mode: foregroundMode,
+				...(effectiveParams.workflowParentRunId ? { parentWorkflowRunId: effectiveParams.workflowParentRunId } : {}),
+				...(effectiveParams.workflowKey ? { workflowKey: effectiveParams.workflowKey } : {}),
 				startedAt: Date.now(),
 				updatedAt: Date.now(),
 				cwd: effectiveCwd,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1541,6 +1541,10 @@ export interface ForegroundChildControl {
 
 export interface ForegroundRunControl {
 	runId: string;
+	/** Workflow shell that owns this live foreground child, when applicable. */
+	parentWorkflowRunId?: string;
+	/** Stable workflow lane key for this live foreground child. */
+	workflowKey?: string;
 	/** Originating parent session; required for public fleet projection. */
 	sessionId?: string;
 	mode: SubagentRunMode;

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -144,6 +144,12 @@ function isStaleExtensionContextError(error: unknown): boolean {
 			|| error.message.includes("Extension context no longer active"));
 }
 
+function foregroundDescription(control: { parentWorkflowRunId?: string; workflowKey?: string }, description: string | undefined): string | undefined {
+	if (!control.parentWorkflowRunId) return description;
+	const workflow = `workflow child: ${control.parentWorkflowRunId}${control.workflowKey ? ` (${control.workflowKey})` : ""}`;
+	return description ? `${workflow} · ${description}` : workflow;
+}
+
 export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntry[] {
 	const entries: FleetStatusEntry[] = [];
 	for (const control of state.foregroundControls.values()) {
@@ -154,7 +160,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 					key: `foreground-active:${control.runId}:${child.index}`,
 					agent: child.agent,
 					...(modelThinking ? { modelThinking } : {}),
-					description: child.description,
+					description: foregroundDescription(control, child.description),
 					startedAt: child.startedAt,
 					tokens: child.tokens ?? 0,
 					state: "running",
@@ -170,7 +176,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 			key: `foreground-active:${control.runId}:${control.currentIndex ?? 0}`,
 			agent: control.currentAgent ?? control.mode,
 			...(modelThinking ? { modelThinking } : {}),
-			description: control.description,
+			description: foregroundDescription(control, control.description),
 			startedAt: control.startedAt,
 			tokens: control.tokens ?? 0,
 			state: "running",

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -289,6 +289,7 @@ function foregroundActiveDetail(item: Extract<FleetItem, { kind: "foreground-act
 		"Source: foreground",
 		`State: running`,
 		`Mode: ${control.mode}`,
+		control.parentWorkflowRunId ? `Workflow child of: ${control.parentWorkflowRunId}${control.workflowKey ? ` (${control.workflowKey})` : ""}` : undefined,
 		item.index !== undefined ? `Child: ${item.index} (${item.agent})` : `Agent: ${item.agent}`,
 		modelThinking ? `Model: ${modelThinking}` : undefined,
 		`Started: ${new Date(live.startedAt).toISOString()}`,
@@ -648,6 +649,19 @@ export class SubagentFleetComponent implements Component {
 		return { item };
 	}
 
+	private selectedHerdrInspectAction(): { runId: string; asyncDir: string; index?: number } | { reason: string } {
+		const item = this.snapshot.items[this.selected];
+		if (!item) return { reason: "No child is selected." };
+		if (item.kind === "async") {
+			if (!isActionableAsyncState(item.run.state) || !isActionableAsyncState(item.state)) return { reason: `Selected child is ${item.state}; controls require a running or queued async child.` };
+			return { runId: item.runId, asyncDir: item.run.asyncDir, ...(item.index !== undefined ? { index: item.index } : {}) };
+		}
+		if (item.kind !== "foreground-active" || !item.control.parentWorkflowRunId) return { reason: "Fleet controls are available for current-session top-level async runs only." };
+		const parent = this.state.asyncJobs.get(item.control.parentWorkflowRunId) ?? this.state.fleetJobs?.get(item.control.parentWorkflowRunId);
+		if (!parent || !isActionableAsyncState(parent.status)) return { reason: "The parent workflow is no longer available for Herdr inspection." };
+		return { runId: parent.asyncId, asyncDir: parent.asyncDir };
+	}
+
 	private actionLines(): string[] {
 		const lines: string[] = [];
 		if (this.actionBusy) lines.push(this.theme.fg("accent", "Action pending..."));
@@ -784,9 +798,9 @@ export class SubagentFleetComponent implements Component {
 			return;
 		}
 		if (matchesFleetAction(data, this.keybindings, "inspect")) {
-			const target = this.selectedAsyncAction();
+			const target = this.selectedHerdrInspectAction();
 			if ("reason" in target || !this.options.actions?.inspect) this.setActionNotice({ text: "reason" in target ? target.reason : "Herdr inspector controls are unavailable in this context.", isError: true });
-			else this.runAction(() => this.options.actions!.inspect!({ runId: target.item.runId, asyncDir: target.item.run.asyncDir, ...(target.item.index !== undefined ? { index: target.item.index } : {}) }));
+			else this.runAction(() => this.options.actions!.inspect!(target));
 			return;
 		}
 		if (matchesFleetAction(data, this.keybindings, "stop")) {

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -550,6 +550,24 @@ describe("below-editor subagent FleetView", () => {
 		assert.deepEqual(collectFleetSnapshot(state).items.map((item) => item.key), entries.map((entry) => entry.key));
 	});
 
+	it("labels workflow-owned foreground children", () => {
+		const state = stateForTest();
+		state.foregroundControls.set("child-1", {
+			runId: "child-1",
+			parentWorkflowRunId: "workflow-1",
+			workflowKey: "review",
+			mode: "single",
+			startedAt: 10,
+			updatedAt: 20,
+			activeChildren: new Map([[0, { index: 0, agent: "reviewer", description: "Review the change", startedAt: 10, updatedAt: 20 }]]),
+		});
+
+		assert.deepEqual(collectFleetStatusEntries(state).map((entry) => ({ agent: entry.agent, description: entry.description })), [{
+			agent: "reviewer",
+			description: "workflow child: workflow-1 (review) · Review the change",
+		}]);
+	});
+
 	it("uses the same item keys as the full inspector", () => {
 		const state = stateForTest();
 		state.foregroundControls.set("foreground", {

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -229,6 +229,54 @@ describe("native subagent fleet", () => {
 		assert.equal(snapshot.items[0]?.agent, "workflow");
 	});
 
+	it("labels workflow-owned foreground children and opens their parent Herdr inspector", async () => {
+		const state = stateForTest();
+		state.asyncJobs.set("workflow-1", {
+			asyncId: "workflow-1",
+			asyncDir: "/tmp/workflow-1",
+			status: "running",
+			mode: "workflow",
+			startedAt: 10,
+			updatedAt: 20,
+		});
+		state.foregroundControls.set("child-1", {
+			runId: "child-1",
+			parentWorkflowRunId: "workflow-1",
+			workflowKey: "review",
+			mode: "single",
+			startedAt: 10,
+			updatedAt: 20,
+			activeChildren: new Map([[0, { index: 0, agent: "reviewer", startedAt: 10, updatedAt: 20 }]]),
+		});
+		const snapshot = collectFleetSnapshot(state);
+		const child = snapshot.items.find((item) => item.key === "foreground-active:child-1:0");
+		assert.equal(child?.kind, "foreground-active");
+		const calls: Array<{ runId: string; asyncDir: string; index?: number }> = [];
+		const component = new SubagentFleetComponent(
+			{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
+			theme as never,
+			state,
+			() => {},
+			{
+				initialKey: "foreground-active:child-1:0",
+				refreshMs: 60_000,
+				actions: {
+					async steer() { return { text: "unused" }; },
+					stop() { return { text: "unused" }; },
+					async inspect(input) { calls.push(input); return { text: "Inspector opened." }; },
+				},
+			},
+		);
+		try {
+			assert.ok(component.render(100).some((line) => line.includes("Workflow child of: workflow-1 (review)")));
+			component.handleInput("H");
+			await new Promise((resolve) => setImmediate(resolve));
+			assert.deepEqual(calls, [{ runId: "workflow-1", asyncDir: "/tmp/workflow-1" }]);
+		} finally {
+			component.dispose();
+		}
+	});
+
 	it("keeps every active async run ahead of the bounded recent-completion window", () => {
 		const state = stateForTest();
 		for (let index = 0; index < 22; index++) {

--- a/test/unit/herdr-status-bridge.test.ts
+++ b/test/unit/herdr-status-bridge.test.ts
@@ -5,6 +5,8 @@ import {
 	registerHerdrStatusBridge,
 	type HerdrStatusBridgeEvents,
 } from "../../src/integrations/herdr-status.ts";
+import { projectActiveHerdrRuns } from "../../src/extension/index.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
 import {
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_ASYNC_STARTED_EVENT,
@@ -52,7 +54,58 @@ class FakeEvents implements HerdrStatusBridgeEvents {
 	}
 }
 
+function stateForTest(): SubagentState {
+	return {
+		baseCwd: process.cwd(),
+		currentSessionId: "session-current",
+		asyncJobs: new Map(),
+		fleetJobs: new Map(),
+		foregroundRuns: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	};
+}
+
 describe("Herdr status bridge", () => {
+	it("projects foreground workflow children onto the parent run without a shell duplicate", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("workflow-1", {
+			asyncId: "workflow-1",
+			asyncDir: "/tmp/workflow-1",
+			status: "running",
+			mode: "workflow",
+			agents: ["workflow"],
+		});
+		state.foregroundControls.set("child-1", {
+			runId: "child-1",
+			parentWorkflowRunId: "workflow-1",
+			workflowKey: "review",
+			mode: "single",
+			startedAt: 10,
+			updatedAt: 20,
+			activeChildren: new Map([[0, {
+				index: 0,
+				agent: "reviewer",
+				startedAt: 10,
+				updatedAt: 20,
+				currentActivityState: "needs_attention",
+			}]]),
+		});
+
+		assert.deepEqual(projectActiveHerdrRuns(state), [{
+			id: "workflow-1",
+			agents: ["reviewer"],
+			needsAttention: true,
+		}]);
+	});
+
 	it("reports an async run as visible and semantically busy", async () => {
 		const events = new FakeEvents();
 		const commands: string[][] = [];

--- a/test/unit/workflow-launch-params.test.ts
+++ b/test/unit/workflow-launch-params.test.ts
@@ -3,6 +3,42 @@ import { describe, it } from "node:test";
 import { prepareWorkflowLaunchParams } from "../../src/runs/foreground/subagent-executor.ts";
 
 describe("workflow launch params", () => {
+	it("keeps omitted workflow child async foreground", () => {
+		assert.deepEqual(
+			prepareWorkflowLaunchParams(
+				{},
+				{ agent: "worker", task: "Run" },
+				"workflow-run",
+				"run",
+			),
+			{
+				agent: "worker",
+				task: "Run",
+				async: false,
+				workflowParentRunId: "workflow-run",
+				workflowKey: "run",
+			},
+		);
+	});
+
+	it("preserves explicit async workflow children", () => {
+		assert.deepEqual(
+			prepareWorkflowLaunchParams(
+				{},
+				{ agent: "worker", task: "Run", async: true },
+				"workflow-run",
+				"run",
+			),
+			{
+				agent: "worker",
+				task: "Run",
+				async: true,
+				workflowParentRunId: "workflow-run",
+				workflowKey: "run",
+			},
+		);
+	});
+
 	it("places workflow child gates inside managed worktree tasks", () => {
 		assert.deepEqual(
 			prepareWorkflowLaunchParams(
@@ -13,6 +49,7 @@ describe("workflow launch params", () => {
 			),
 			{
 				worktree: true,
+				async: false,
 				workflowParentRunId: "workflow-run",
 				workflowKey: "gated",
 				tasks: [{


### PR DESCRIPTION
## Summary

Fixes #965 by keeping default workflow children foreground and making that foreground ownership visible in Fleet and Herdr.

The change adds live workflow ownership metadata to foreground controls, labels workflow-owned foreground rows in Fleet, routes `H` on those rows to the parent workflow inspector, and projects the active child agents and attention state onto the parent workflow for Herdr without double-counting the workflow shell.

Thanks to @lukechen526 for #965.

## Validation

- `node --experimental-strip-types --test test/unit/workflow-launch-params.test.ts test/unit/fleet.test.ts test/unit/fleet-status.test.ts test/unit/herdr-status-bridge.test.ts`
- `npm run test:unit`
- `npm run test:integration`
- `npm run typecheck`
- `git diff 991992706742f6d98c520d344b2122301fd31dc4..HEAD --check`
- `git show --check --oneline --stat HEAD`