### PR TITLE
test: relax steering no-session timing

### DIFF
--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -348,7 +348,7 @@ describe("acknowledged steering action", () => {
 		let routed: AsyncStatus | undefined;
 		try {
 			const result = await steerAsyncRun({
-				state: createState(), runId, message: "correct course", location: { asyncDir }, ackTimeoutMs: 25, recoveryTimeoutMs: 500, kill: () => true,
+				state: createState(), runId, message: "correct course", location: { asyncDir }, ackTimeoutMs: 250, recoveryTimeoutMs: 1_000, kill: () => true,
 				onRequestQueued: (requestPath) => {
 					const request = JSON.parse(fs.readFileSync(requestPath, "utf-8")) as SteerRequest;
 					routed = runningStatus(runId);


### PR DESCRIPTION
Follow-up to #966.

Post-merge main CI failed on Ubuntu in the synthetic no-session steering recovery test. The test used a 25 ms ack timeout and 500 ms recovery timeout, which was too tight under CI scheduling. This keeps the same assertions and only gives the recovery path the same timing budget as the adjacent steering recovery test.

Validation:
- focused failing test repeated 5 times
- `npm run test:unit`
- `npm run typecheck`
- `git diff --check`
- fresh read-only review: no findings
