### PR TITLE
perf: reduce async status processing overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Reduce repeated async status parsing and workflow trace projection work.
+
 ## [0.46.0] - 2026-08-11
 
 ### Added

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { readStatus } from "../../shared/utils.ts";
 import { DIRS, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSummary, type SubagentRunMode } from "../../shared/types.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { normalizeParallelGroups } from "./parallel-groups.ts";
@@ -81,26 +82,6 @@ function appendJsonlBestEffort(filePath: string, payload: object): void {
 	} catch {
 		// Repair status/result writes are the important path. A broken or full
 		// diagnostic event log must not make stale-run reconciliation fail.
-	}
-}
-
-function readStatusFile(asyncDir: string): AsyncStatus | null {
-	const statusPath = path.join(asyncDir, "status.json");
-	let content: string;
-	try {
-		content = fs.readFileSync(statusPath, "utf-8");
-	} catch (error) {
-		if (isNotFoundError(error)) return null;
-		throw new Error(`Failed to read async status file '${statusPath}': ${getErrorMessage(error)}`, {
-			cause: error instanceof Error ? error : undefined,
-		});
-	}
-	try {
-		return JSON.parse(content) as AsyncStatus;
-	} catch (error) {
-		throw new Error(`Failed to parse async status file '${statusPath}': ${getErrorMessage(error)}`, {
-			cause: error instanceof Error ? error : undefined,
-		});
 	}
 }
 
@@ -348,7 +329,7 @@ export function checkPidLiveness(pid: number, kill: KillFn = process.kill): PidL
 
 export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOptions = {}): ReconcileAsyncRunResult {
 	const now = options.now?.() ?? Date.now();
-	const status = readStatusFile(asyncDir);
+	const status = readStatus(asyncDir);
 	const startedStatus = !status && options.startedRun ? buildStartedStatus(asyncDir, options.startedRun, now) : undefined;
 	const effectiveStatus = status ?? startedStatus;
 	if (!effectiveStatus) return { status: null, repaired: false };

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4483,10 +4483,24 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				void Promise.resolve().then(async () => {
 					const workflowResults: SingleResult[] = [];
 					const { action: _action, agent: _agent, task: _task, resume: _resume, tasks: _tasks, chain: _chain, concurrency: _concurrency, foregroundOnly: _foregroundOnly, clarify: _clarify, timeoutMs: _timeoutMs, maxRuntimeMs: _maxRuntimeMs, usageBudget: _usageBudget, missionId: _missionId, mission: _mission, ...workflowChildDefaults } = workflowRequest;
+					const workflowSteps = new Map<string, NonNullable<AsyncStatus["steps"]>[number]>();
+					let projectedTraceLength = 0;
+					let projectedTraceTail: NonNullable<Details["workflow"]>["trace"][number] | undefined;
 					const updateTrace = (trace: NonNullable<Details["workflow"]>["trace"]) => {
 						status.workflow = { ...(status.workflow ?? { emits: [], console: [] }), trace };
-						for (const entry of trace.filter((candidate) => candidate.operation === "run")) {
-							const existing = status.steps?.find((step) => step.workflowKey === entry.key);
+						const rebuild = trace.length < projectedTraceLength
+							|| (projectedTraceLength > 0 && trace[projectedTraceLength - 1] !== projectedTraceTail);
+						if (rebuild) {
+							workflowSteps.clear();
+							for (const step of status.steps ?? []) {
+								if (step.workflowKey) workflowSteps.set(step.workflowKey, step);
+							}
+							projectedTraceLength = 0;
+						}
+						for (let index = projectedTraceLength; index < trace.length; index += 1) {
+							const entry = trace[index]!;
+							if (entry.operation !== "run") continue;
+							const existing = workflowSteps.get(entry.key);
 							if (entry.state === "reused" && existing) continue;
 							const mapped = entry.state === "started" || entry.state === "reused" ? "running" : entry.state === "completed" ? "completed" : "failed";
 							if (existing) {
@@ -4497,9 +4511,13 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								if (entry.durationMs === undefined) delete existing.durationMs;
 								else existing.durationMs = entry.durationMs;
 							} else {
-								status.steps?.push({ agent: entry.agent ?? entry.key, label: entry.key, workflowKey: entry.key, parentWorkflowRunId: workflowRunId, status: mapped, startedAt: Date.now() });
+								const step: NonNullable<AsyncStatus["steps"]>[number] = { agent: entry.agent ?? entry.key, label: entry.key, workflowKey: entry.key, parentWorkflowRunId: workflowRunId, status: mapped, startedAt: Date.now() };
+								status.steps?.push(step);
+								workflowSteps.set(entry.key, step);
 							}
 						}
+						projectedTraceLength = trace.length;
+						projectedTraceTail = trace.at(-1);
 						projectWorkflowActivity();
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.trace", trace });

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -456,6 +456,17 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(status.workflow?.emits, ["starting"]);
 		assert.equal(mockPi.callCount(), 1);
 		assert.ok(status.workflow?.trace?.some((entry) => entry.key === "work" && entry.agent === "echo" && entry.state === "completed"));
+		const traceEvents = fs.readFileSync(path.join(result.details.asyncDir!, "events.jsonl"), "utf-8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as { type?: string; trace?: Array<{ key?: string; state?: string }> })
+			.filter((event) => event.type === "subagent.workflow.trace");
+		assert.equal(traceEvents.length, 2);
+		assert.deepEqual(traceEvents[0]?.trace?.map(({ key, state }) => ({ key, state })), [{ key: "work", state: "started" }]);
+		assert.deepEqual(traceEvents[1]?.trace?.map(({ key, state }) => ({ key, state })), [
+			{ key: "work", state: "started" },
+			{ key: "work", state: "completed" },
+		]);
 		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
 		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; cwd?: string; summary?: string; workflow?: { value?: unknown }; results?: Array<{ agent?: string; workflowKey?: string }> };
 		assert.equal(persistedResult.id, workflowRunId);


### PR DESCRIPTION
This reduces two repeated costs in live async orchestration without changing update cadence.

The stale-run reconciler now uses the existing metadata-aware `readStatus()` cache. Every poll still checks `mtime`, `ctime`, size, and inode, so atomic status replacements remain visible on the next poll. Result checks, PID liveness checks, repair writes, and the 250 ms poll remain unchanged.

Async workflows now project only newly appended trace entries through an invocation-local key map and cursor. A shortened or replaced trace prefix falls back to full replay. Every trace callback still projects activity, writes `status.json`, and appends the full trace event.

Benchmarks on this checkout:
- 2,000 unchanged reconciliations: 27.864 ms to 6.880 ms median.
- Synthetic 200-child trace projection: 11.753 ms to 0.044 ms median.

Validation:
- Typecheck passed.
- Unit suite: 1,735 passed, 1 skipped.
- Integration suite: 717 passed.
- Changed `single-execution` file: 184 passed.
- E2E suite completed with its expected missing-runtime skip.
- Fresh exact-head review completed before publication.
