### PR TITLE
fix: suspend widgets during auto-compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Persist workflow child attempts, status heartbeats, session paths, and artifacts in their enclosing mission, and add explicit mission decision resolution.
 
 ### Fixed
+- Suspend subagent status widgets during automatic compaction to prevent duplicate terminal frames.
 - Make live foreground workflow children visible as workflow-owned Fleet rows, route Herdr inspection to their workflow parent, and report their active and needs-attention state to Herdr. Thanks to @lukechen526 for #965.
 - Wait for retained-child resumes inside `workflowScript` to finish and return completed output before the script continues (#961).
 - Keep fork-context workflow children inside their managed worktree by aligning the persisted child session cwd before launch. Thanks to @flopsi for #953.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -392,6 +392,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		lastUiContext: null,
 		poller: null,
 		completionSeen: new Map(),
+		widgetsSuspended: false,
 		watcher: null,
 		watcherRestartTimer: null,
 		resultFileCoalescer: {
@@ -713,7 +714,22 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}
 	};
 
+	const suspendWidgetsForCompaction = () => {
+		if (state.widgetsSuspended) return;
+		state.widgetsSuspended = true;
+		if (state.lastUiContext?.hasUI) state.lastUiContext.ui.setWidget(WIDGET_KEY, undefined);
+		fleetStatus?.refresh();
+	};
+	const resumeWidgetsAfterCompaction = () => {
+		if (!state.widgetsSuspended) return;
+		state.widgetsSuspended = false;
+		const ctx = state.lastUiContext;
+		if (ctx?.hasUI) refreshWidget(ctx);
+		fleetStatus?.refresh();
+	};
+
 	const resetSessionState = (ctx: ExtensionContext, recovering: boolean) => {
+		state.widgetsSuspended = false;
 		state.baseCwd = ctx.cwd;
 		goalTurnId = 0;
 		state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
@@ -752,7 +768,16 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	};
 
 	pi.on("agent_start", () => {
+		resumeWidgetsAfterCompaction();
 		herdrStatusBridge.agentStarted();
+	});
+
+	pi.on("agent_settled", () => {
+		resumeWidgetsAfterCompaction();
+	});
+
+	pi.on("session_before_compact", (event) => {
+		if (event.reason !== "manual") suspendWidgetsForCompaction();
 	});
 
 	pi.on("session_compact", () => {
@@ -780,6 +805,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("session_shutdown", async () => {
+		state.widgetsSuspended = false;
 		stopResultWatcher();
 		state.currentSessionId = null;
 		state.parentSessionFile = null;

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -57,6 +57,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	const resultsDir = options.resultsDir ?? DIRS.results;
 	const steeringNoticeSeen = new Map<string, number>();
 	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
+		if (state.widgetsSuspended) return;
 		renderWidget(ctx, options.widgetEnabled === false ? [] : jobs);
 		(ctx.ui as { requestRender?: () => void }).requestRender?.();
 	};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1614,6 +1614,8 @@ export interface SubagentState {
 	fleetJobs?: Map<string, AsyncJobState>;
 	/** Suppress dynamic status widgets while the fleet overlay owns the viewport. */
 	fleetInspectorOpen?: boolean;
+	/** Temporarily suppress dynamic widgets while Pi compacts the session. */
+	widgetsSuspended?: boolean;
 	foregroundRuns?: Map<string, ForegroundResumeRun>;
 	foregroundControls: Map<string, ForegroundRunControl>;
 	lastForegroundControlId: string | null;

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -307,26 +307,22 @@ export class SubagentFleetStatus {
 	refresh(): void {
 		const ctx = this.getActiveUiContext();
 		if (!ctx) return;
+		if (this.state.widgetsSuspended) {
+			this.clearWidget();
+			return;
+		}
 		this.entries = collectFleetStatusEntries(this.state);
 		this.clampSelection();
 		if (this.inspectorOpen || this.state.fleetInspectorOpen) {
 			this.lastRenderKey = "";
-			if (this.widgetRegistered) {
-				ctx.ui.setWidget(FLEET_STATUS_WIDGET_KEY, undefined);
-				this.widgetRegistered = false;
-				this.tui = undefined;
-			}
+			this.clearWidget();
 			return;
 		}
 		if (this.entries.length === 0) {
 			this.active = false;
 			this.selectedKey = "main";
 			this.lastRenderKey = "";
-			if (this.widgetRegistered) {
-				ctx.ui.setWidget(FLEET_STATUS_WIDGET_KEY, undefined);
-				this.widgetRegistered = false;
-				this.tui = undefined;
-			}
+			this.clearWidget();
 			return;
 		}
 
@@ -356,6 +352,7 @@ export class SubagentFleetStatus {
 	}
 
 	handleKey(data: string): { consume?: boolean; data?: string } | undefined {
+		if (this.state.widgetsSuspended) return undefined;
 		const ctx = this.getActiveUiContext();
 		if (!ctx || this.entries.length === 0 || isKeyRelease(data)) return undefined;
 		if (this.inspectorOpen) return undefined;
@@ -534,6 +531,13 @@ export class SubagentFleetStatus {
 			this.clearUiRegistration();
 			return undefined;
 		}
+	}
+
+	private clearWidget(): void {
+		if (!this.widgetRegistered) return;
+		this.ui?.setWidget(FLEET_STATUS_WIDGET_KEY, undefined);
+		this.widgetRegistered = false;
+		this.tui = undefined;
 	}
 
 	private clearUiRegistration(): void {

--- a/test/unit/compaction-resume.test.ts
+++ b/test/unit/compaction-resume.test.ts
@@ -15,23 +15,53 @@ describe("async compaction resume", () => {
 			const handlers = new Map();
 			const events = { listeners: new Map(), on(name, handler) { this.listeners.set(name, handler); return () => this.listeners.delete(name); }, emit(name, payload) { this.listeners.get(name)?.(payload); } };
 			const sent = [];
+			const widgets = [];
+			let renders = 0;
 			const pi = new Proxy({
 				events,
 				on(name, handler) { handlers.set(name, handler); },
 				registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
 				sendMessage(message, options) { sent.push({ message, options }); }, getSessionName() { return undefined; },
 			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
-			const ctx = { cwd: process.cwd(), hasUI: true, ui: { setWidget() {}, requestRender() {}, theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } } }, sessionManager: { getSessionId() { return "compact-session"; }, getSessionFile() { return null; }, getEntries() { return []; } }, modelRegistry: { getAvailable() { return []; } } };
+			const ctx = { cwd: process.cwd(), hasUI: true, ui: { setWidget(key, value) { widgets.push([key, value]); }, requestRender() { renders++; }, onTerminalInput() { return () => {}; }, getEditorText() { return ""; }, notify() {}, theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } } }, sessionManager: { getSessionId() { return "compact-session"; }, getSessionFile() { return null; }, getEntries() { return []; } }, modelRegistry: { getAvailable() { return []; } } };
 			registerSubagentExtension(pi);
 			handlers.get("session_start")({}, ctx);
 			sent.length = 0;
 			events.emit("subagent:async-started", { id: "running", pid: 1, sessionId: "compact-session", mode: "single", agent: "worker", asyncDir: path.join(os.tmpdir(), "pi-compaction-test-running") });
-			handlers.get("session_compact")();
-			if (sent.length !== 1 || sent[0].options?.triggerTurn !== true || sent[0].message?.customType !== "subagent-compaction-resume") throw new Error(JSON.stringify(sent));
-			sent.length = 0;
+			widgets.length = 0;
+			renders = 0;
+			handlers.get("session_before_compact")({ reason: "threshold", signal: new AbortController().signal });
+			const cleared = widgets.filter(([key, value]) => value === undefined).map(([key]) => key).sort();
+			if (JSON.stringify(cleared) !== JSON.stringify(["subagent-async", "subagent-fleet-status"])) throw new Error(JSON.stringify(widgets));
+			widgets.length = 0;
 			events.emit("subagent:async-complete", { id: "running", sessionId: "compact-session", agent: "worker", success: true, summary: "done" });
-			handlers.get("session_compact")();
+			events.emit("subagent:async-started", { id: "running-2", pid: 2, sessionId: "compact-session", mode: "single", agent: "worker", asyncDir: path.join(os.tmpdir(), "pi-compaction-test-running-2") });
+			if (widgets.length !== 0 || renders !== 0) throw new Error("widgets repainted during compaction");
+			handlers.get("session_compact")({ reason: "threshold" });
+			if (widgets.length !== 0) throw new Error("widgets restored inside compaction hook");
+			handlers.get("agent_start")();
+			const restored = widgets.filter(([_, value]) => value !== undefined).map(([key]) => key).sort();
+			if (JSON.stringify(restored) !== JSON.stringify(["subagent-async", "subagent-fleet-status"])) throw new Error(JSON.stringify(widgets));
+			if (sent.length !== 1 || sent[0].options?.triggerTurn !== true || sent[0].message?.customType !== "subagent-compaction-resume") throw new Error(JSON.stringify(sent));
+
+			sent.length = 0;
+			events.emit("subagent:async-complete", { id: "running-2", sessionId: "compact-session", agent: "worker", success: true, summary: "done" });
+			handlers.get("session_before_compact")({ reason: "threshold", signal: new AbortController().signal });
+			handlers.get("session_compact")({ reason: "threshold" });
+			handlers.get("agent_settled")();
 			if (sent.some((entry) => entry.message?.customType === "subagent-compaction-resume")) throw new Error("resumed without active work");
+
+			events.emit("subagent:async-started", { id: "running-3", pid: 3, sessionId: "compact-session", mode: "single", agent: "worker", asyncDir: path.join(os.tmpdir(), "pi-compaction-test-running-3") });
+			widgets.length = 0;
+			handlers.get("session_before_compact")({ reason: "overflow", signal: new AbortController().signal });
+			widgets.length = 0;
+			handlers.get("agent_settled")();
+			if (!widgets.some(([_, value]) => value !== undefined)) throw new Error("widgets did not recover after compaction failure");
+
+			widgets.length = 0;
+			handlers.get("session_before_compact")({ reason: "manual", signal: new AbortController().signal });
+			if (widgets.length !== 0) throw new Error("manual compaction changed widget state");
+			await handlers.get("session_shutdown")();
 		`;
 		const env = { ...process.env };
 		delete env.PI_SUBAGENT_CHILD;


### PR DESCRIPTION
While Pi was auto-compacting, the detailed async widget and Fleet status widget continued repainting. Their changing frames could be left duplicated around the compaction loader.

This suspends only those two UI projections for threshold and overflow compaction. Background polling, reconciliation, persistence, completion delivery, and job state updates continue unchanged. The latest widget state returns at the next `agent_start` after successful compaction or at `agent_settled` after cancellation or failure.

Manual compaction remains unchanged because the reproduced issue was automatic compaction and Pi's public `session_compact` event represents successful compaction only.

Validation:
- Focused compaction lifecycle test passed.
- Fleet and async tracker tests: 46 passed.
- Typecheck passed.
- Unit suite: 1,735 passed, 1 skipped.
- Integration suite: 717 passed.
- E2E suite completed with its expected missing-runtime skip.
- Fresh exact-head lifecycle/TUI review found no issues.
