### PR TITLE
fix: sanitize tool previews to one terminal line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Persist workflow child attempts, status heartbeats, session paths, and artifacts in their enclosing mission, and add explicit mission decision resolution.
 
 ### Fixed
+- Keep tool argument previews on one physical terminal line so live widget updates do not leave stacked terminal frames. Thanks to @xz-dev for #972.
 - Suspend subagent status widgets during automatic compaction to prevent duplicate terminal frames.
 - Make live foreground workflow children visible as workflow-owned Fleet rows, route Herdr inspection to their workflow parent, and report their active and needs-attention state to Herdr. Thanks to @lukechen526 for #965.
 - Wait for retained-child resumes inside `workflowScript` to finish and return completed output before the script continues (#961).

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -16,7 +16,7 @@ import {
 	SUBAGENT_PROCESS_TERMINAL_EVENT,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
 } from "../shared/types.ts";
-import { readStatus } from "../shared/utils.ts";
+import { normalizeDisplayText, readStatus, truncateDisplayText } from "../shared/utils.ts";
 import { SubagentParams } from "./schemas.ts";
 import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
 import { normalizePublicSubagentExecution } from "./public-execution.ts";
@@ -101,12 +101,8 @@ const MAX_METADATA_LENGTH = 128;
 
 function displayText(value: unknown, maxLength: number): string | undefined {
 	if (typeof value !== "string") return undefined;
-	// Strip complete CSI/OSC/DCS/APC/PM strings and C1 controls before collapsing
-	// whitespace; never leave CSI parameters behind after removing ESC.
-	const normalized = value.slice(0, 4_096)
-		.replace(/\x1b\[[0-?]*[ -/]*[@-~]|\x9b[0-?]*[ -/]*[@-~]|\x1b][\s\S]*?(?:\x07|\x1b\\)|\x1b[PX^_][\s\S]*?\x1b\\|[\u0000-\u001f\u007f-\u009f]/g, " ")
-		.replace(/\s+/g, " ").trim();
-	return normalized ? normalized.slice(0, maxLength) : undefined;
+	const normalized = normalizeDisplayText(value.slice(0, 4_096));
+	return normalized ? truncateDisplayText(normalized, maxLength) : undefined;
 }
 
 function publicTokens(value: unknown): { input: number; output: number; total: number } {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -519,14 +519,141 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
 }
 
 /**
+ * Return at most maxLength UTF-16 code units without splitting a surrogate pair.
+ */
+export function truncateDisplayText(value: string, maxLength: number): string {
+	if (maxLength <= 0) return "";
+	if (value.length <= maxLength) return value;
+	const end = value.charCodeAt(maxLength - 1) >= 0xd800 && value.charCodeAt(maxLength - 1) <= 0xdbff
+		? maxLength - 1
+		: maxLength;
+	return value.slice(0, end);
+}
+
+/**
+ * Normalize untrusted text for single-line terminal display.
+ */
+export function normalizeDisplayText(value: string): string {
+	const output: string[] = [];
+	let pendingSpace = false;
+	let state: "text" | "csi" | "string" = "text";
+	let csiIntermediates = false;
+	let stringType: number | undefined;
+
+	const appendSpace = (): void => {
+		if (output.length > 0) pendingSpace = true;
+	};
+	const appendText = (text: string): void => {
+		if (pendingSpace) output.push(" ");
+		output.push(text);
+		pendingSpace = false;
+	};
+	const appendPlain = (codePoint: number): void => {
+		if (
+			codePoint <= 0x1f
+			|| (codePoint >= 0x7f && codePoint <= 0x9f)
+			|| codePoint === 0x20
+			|| codePoint === 0xa0
+			|| codePoint === 0x1680
+			|| (codePoint >= 0x2000 && codePoint <= 0x200a)
+			|| codePoint === 0x2028
+			|| codePoint === 0x2029
+			|| codePoint === 0x202f
+			|| codePoint === 0x205f
+			|| codePoint === 0x3000
+			|| codePoint === 0xfeff
+		) {
+			appendSpace();
+		} else if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
+			appendSpace();
+		} else {
+			appendText(String.fromCodePoint(codePoint));
+		}
+	};
+
+	for (let index = 0; index < value.length;) {
+		const codePoint = value.codePointAt(index)!;
+		const width = codePoint > 0xffff ? 2 : 1;
+
+		if (state === "string") {
+			if ((stringType === 0x5d && codePoint === 0x07) || codePoint === 0x9c) {
+				state = "text";
+				index += width;
+				continue;
+			}
+			if (codePoint === 0x1b && value.charCodeAt(index + 1) === 0x5c) {
+				state = "text";
+				index += 2;
+				continue;
+			}
+			index += width;
+			continue;
+		}
+
+		if (state === "csi") {
+			if (codePoint >= 0x40 && codePoint <= 0x7e) {
+				state = "text";
+				index += width;
+				continue;
+			}
+			if (!csiIntermediates && codePoint >= 0x30 && codePoint <= 0x3f) {
+				index += width;
+				continue;
+			}
+			if (codePoint >= 0x20 && codePoint <= 0x2f) {
+				csiIntermediates = true;
+				index += width;
+				continue;
+			}
+			state = "text";
+			continue;
+		}
+
+		if (codePoint === 0x9b || (codePoint === 0x1b && value.charCodeAt(index + 1) === 0x5b)) {
+			appendSpace();
+			state = "csi";
+			csiIntermediates = false;
+			index += codePoint === 0x9b ? 1 : 2;
+			continue;
+		}
+
+		if (codePoint === 0x90 || codePoint === 0x98 || codePoint === 0x9d || codePoint === 0x9e || codePoint === 0x9f) {
+			appendSpace();
+			state = "string";
+			stringType = codePoint === 0x9d ? 0x5d : codePoint;
+			index += 1;
+			continue;
+		}
+
+		if (codePoint === 0x1b) {
+			const introducer = value.charCodeAt(index + 1);
+			if (introducer === 0x5d || introducer === 0x50 || introducer === 0x58 || introducer === 0x5e || introducer === 0x5f) {
+				appendSpace();
+				state = "string";
+				stringType = introducer;
+				index += 2;
+				continue;
+			}
+		}
+
+		appendPlain(codePoint);
+		index += width;
+	}
+
+	return output.join("");
+}
+
+/**
  * Extract a preview of tool arguments for display
  */
 export function extractToolArgsPreview(args: Record<string, unknown>): string {
-	const truncatePreview = (value: string, maxLength: number): string =>
-		value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
+	const truncatePreview = (value: string, maxLength: number): string => {
+		const normalized = normalizeDisplayText(value);
+		return normalized.length > maxLength ? `${truncateDisplayText(normalized, maxLength - 3)}...` : normalized;
+	};
 
 	const stringifyPreviewValue = (value: unknown): string | undefined => {
-		if (typeof value === "string" && value.trim().length > 0) return value;
+		if (typeof value === "string" && value.trim().length > 0) return normalizeDisplayText(value);
 		if (typeof value === "number" || typeof value === "boolean") return String(value);
 		return undefined;
 	};
@@ -541,9 +668,9 @@ export function extractToolArgsPreview(args: Record<string, unknown>): string {
 
 	// Handle MCP tool calls - show server/tool info
 	if (args.tool && typeof args.tool === "string") {
-		const server = args.server && typeof args.server === "string" ? `${args.server}/` : "";
-		const toolArgs = args.args && typeof args.args === "string" ? ` ${args.args.slice(0, 40)}` : "";
-		return `${server}${args.tool}${toolArgs}`;
+		const server = args.server && typeof args.server === "string" ? `${normalizeDisplayText(args.server)}/` : "";
+		const toolArgs = args.args && typeof args.args === "string" ? ` ${truncateDisplayText(normalizeDisplayText(args.args), 40)}` : "";
+		return normalizeDisplayText(`${server}${args.tool}${toolArgs}`);
 	}
 
 	const queriesPreview = previewArray(args.queries);
@@ -566,11 +693,12 @@ export function extractToolArgsPreview(args: Record<string, unknown>): string {
 	
 	// Fallback: show first string value found
 	for (const [key, value] of Object.entries(args)) {
+		const displayKey = normalizeDisplayText(key);
 		const arrayPreview = previewArray(value);
-		if (arrayPreview) return `${key}=${truncatePreview(arrayPreview, 50)}`;
+		if (arrayPreview) return `${displayKey}=${truncatePreview(arrayPreview, 50)}`;
 		if (typeof value === "string" && value.length > 0) {
 			const preview = truncatePreview(value, 50);
-			return `${key}=${preview}`;
+			return `${displayKey}=${preview}`;
 		}
 	}
 	return "";

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
+import { extractToolArgsPreview } from "../../src/shared/utils.ts";
 
 const { buildWidgetLines, clearLegacyResultAnimationTimer, renderWidget } = await import("../../src/tui/render.ts") as {
 	buildWidgetLines: (jobs: Array<Record<string, unknown>>, theme: { fg(name: string, text: string): string; bold(text: string): string }, width?: number, expanded?: boolean, frame?: number) => string[];
@@ -98,6 +99,32 @@ describe("subagent async widget rendering", () => {
 		assert.ok(text.indexOf("scout") < text.indexOf("queued"), "running row should precede queued summary");
 		assert.ok(text.indexOf("queued") < text.indexOf("reviewer"), "queued summary should precede completions");
 		assert.match(text, /⎿  read/);
+	});
+
+	it("returns one physical terminal line per widget line for tool previews", () => {
+		const preview = extractToolArgsPreview({ command: "first\r\n\t\x1b[31msecond\x1b[0m" });
+		const lines = buildWidgetLines([{
+			asyncId: "run-1",
+			asyncDir: "/tmp/run",
+			status: "running",
+			mode: "parallel",
+			agents: ["worker"],
+			activeParallelGroup: true,
+			runningSteps: 1,
+			completedSteps: 0,
+			stepsTotal: 1,
+			steps: [{
+				index: 0,
+				agent: "worker",
+				status: "running",
+				currentTool: "bash",
+				currentToolArgs: preview,
+				recentTools: [{ tool: "bash", args: preview }],
+			}],
+		}], theme, 120, true);
+
+		assert.match(lines.join("\n"), /first second/);
+		for (const line of lines) assert.doesNotMatch(line, /[\r\n]/);
 	});
 
 	it("uses parallel running/done wording for async jobs with parallel groups", () => {

--- a/test/unit/foreground-tool-call-compaction.test.ts
+++ b/test/unit/foreground-tool-call-compaction.test.ts
@@ -50,6 +50,98 @@ describe("foreground tool-call compaction", () => {
 		assert.equal(result.toolCalls, undefined);
 	});
 
+	it("keeps tool argument previews on one physical terminal line", () => {
+		const preview = extractToolArgsPreview({
+			command: "set +e\r\n\t\x1b[31mrun\x1b[0m \x1b]0;title\x07now\u0000",
+		});
+
+		assert.equal(preview, "set +e run now");
+		assert.doesNotMatch(preview, /[\r\n\t\x1b]/);
+	});
+
+	it("normalizes fallback argument keys before display", () => {
+		const preview = extractToolArgsPreview({ "bad\r\n\t\x1b[31mkey\x1b[0m\u0000": "value" });
+
+		assert.equal(preview, "bad key=value");
+		assert.doesNotMatch(preview, /[\u0000-\u001f\u007f-\u009f]/);
+	});
+
+	it("discards C1 terminal string payloads and preserves readable suffixes", () => {
+		const strings = [
+			["DCS", "\x90"],
+			["SOS", "\x98"],
+			["OSC", "\x9d"],
+			["PM", "\x9e"],
+			["APC", "\x9f"],
+		] as const;
+		const cases = [
+			["OSC BEL", "\x9d0;title\x07"],
+			...strings.flatMap(([name, introducer]) => [
+				[`${name} C1 ST`, `${introducer}payload\x9c`],
+				[`${name} ESC ST`, `${introducer}payload\x1b\\`],
+			] as const),
+		] as const;
+		for (const [name, control] of cases) {
+			const preview = extractToolArgsPreview({ command: `before${control}after` });
+			assert.equal(preview, "before after", name);
+			assert.doesNotMatch(preview, /[\u0000-\u001f\u007f-\u009f]/, name);
+		}
+	});
+
+	it("truncates canonical previews without malformed UTF-16", () => {
+		const assertWellFormed = (value: string): void => assert.doesNotMatch(value, /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/u);
+		const command = extractToolArgsPreview({ command: "😀".repeat(31) });
+		const mcp = extractToolArgsPreview({ tool: "call", args: "😀".repeat(21) });
+
+		assert.equal(command, `${"😀".repeat(28)}...`);
+		assert.equal(command.length, 59);
+		assert.equal(mcp, `call ${"😀".repeat(20)}`);
+		assert.equal(mcp.length, 45);
+		assertWellFormed(command);
+		assertWellFormed(mcp);
+		assert.equal(extractToolArgsPreview({ command: `safe\ud800tail\udc00end` }), "safe tail end");
+		assert.equal(extractToolArgsPreview({ tool: "call", args: `safe\ud800tail\udc00end` }), "call safe tail end");
+	});
+
+	it("normalizes terminal strings in linear time before truncating previews", () => {
+		const incompleteIntroducers = ["\x1b]", "\x1bP", "\x1bX", "\x1b^", "\x1b_", "\x1b[", "\x9b"];
+		for (const introducer of incompleteIntroducers) {
+			const preview = extractToolArgsPreview({ command: introducer.repeat(2_048) });
+			assert.doesNotMatch(preview, /[\u0000-\u001f\u007f-\u009f]/);
+		}
+		assert.equal(extractToolArgsPreview({ command: "before\x1b]incomplete" }), "before");
+		assert.equal(extractToolArgsPreview({ command: "before\x1bPincomplete" }), "before");
+		assert.equal(extractToolArgsPreview({ command: "before\x1b[31" }), "before");
+
+		const completeControls = [
+			"\x1b[31m",
+			"\x9b32m",
+			"\x1b]0;title\x07",
+			"\x1b]0;title\x1b\\",
+			"\x1bPpayload\x1b\\",
+			"\x1bXpayload\x1b\\",
+			"\x1b^payload\x1b\\",
+			"\x1b_payload\x1b\\",
+		].join("");
+		assert.equal(
+			extractToolArgsPreview({ command: completeControls.repeat(1_024) + "meaningful-tail" }),
+			"meaningful-tail",
+		);
+
+		const measureIncompleteOsc = (count: number): number => {
+			const startedAt = performance.now();
+			extractToolArgsPreview({ command: "\x1b]".repeat(count) });
+			return performance.now() - startedAt;
+		};
+		measureIncompleteOsc(2_048);
+		const smallMs = measureIncompleteOsc(16_384);
+		const largeMs = measureIncompleteOsc(65_536);
+		assert.ok(
+			largeMs <= smallMs * 8 + 25,
+			`normalization scaled superlinearly: 32KiB=${smallMs.toFixed(1)}ms, 128KiB=${largeMs.toFixed(1)}ms`,
+		);
+	});
+
 	it("formats array-based web search previews clearly", () => {
 		assert.equal(
 			extractToolArgsPreview({

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -180,6 +180,33 @@ describe("subagent extension RPC bridge", () => {
 		bridge.dispose();
 	});
 
+	it("projects bounded fleet text without malformed UTF-16", async () => {
+		const events = new FakeEvents();
+		const state = {
+			currentSessionId: "session-123",
+			foregroundControls: new Map(),
+			asyncJobs: new Map([["unicode", {
+				asyncId: "unicode", sessionId: "session-123", status: "running", mode: "single", startedAt: 1,
+				description: "😀".repeat(257),
+				agents: [`worker\ud800broken\udc00${"😀".repeat(45)}`],
+			}]]),
+		} as any;
+		const bridge = registerSubagentRpcBridge({
+			events, getContext: () => ctx("session-123", "session-123"), state,
+			execute: async () => ({ content: [], details: { mode: "management", results: [] } } as any),
+		});
+		const reply = await request(events, "fleet-unicode", "status");
+		const entry = (reply as any).data.fleet.entries[0];
+
+		const malformedSurrogate = /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/u;
+		assert.doesNotMatch(entry.agent, malformedSurrogate);
+		assert.doesNotMatch(entry.goal, malformedSurrogate);
+		assert.ok(entry.agent.length <= 96);
+		assert.ok(entry.goal.length <= 512);
+		assert.match(entry.agent, /^worker broken/);
+		bridge.dispose();
+	});
+
 	it("projects resolved foreground model, effort, split usage, and goal", async () => {
 		const events = new FakeEvents();
 		const state = {


### PR DESCRIPTION
## Summary

Keep async tool previews on one physical terminal line so repeated widget updates replace the existing frame instead of leaving stacked rows in terminal scrollback.

- Normalize canonical tool argument previews before persistence and rendering.
- Strip 7-bit and C1 terminal control strings with a bounded linear scanner.
- Preserve readable text while truncating without splitting UTF-16 surrogate pairs.
- Reuse the same display normalization for the RPC Fleet projection.

## Root cause

Multiline shell commands could pass through `extractToolArgsPreview()` with embedded CR/LF, tabs, or terminal controls. The async widget then placed that preview inside one `Component.render()` array element. Pi TUI treats each element as one physical row, while the terminal rendered the embedded newline as additional rows. Differential redraw therefore moved relative to the wrong row count and left earlier live frames stacked below the current one.

## Validation

- Exact-baseline regressions fail on `80a4cc6`:
  - canonical preview controls remain;
  - widget current/recent tool rows contain embedded physical line breaks;
  - RPC output can split a surrogate pair.
- `test/unit/foreground-tool-call-compaction.test.ts`: 11/11 passed.
- Focused physical-line widget regression: 1/1 passed.
- RPC/Fleet focused suite: 80/80 passed during independent review.
- Focused committed-head suite: 49/49 passed.
- Linear sanitizer regression repeated without flakes; independent scaling remained near-linear.
- `npm run typecheck`: passed.
- `git diff --check`: passed.

## Review status

This PR is intentionally a **draft**. The change passed independent publication review with explicit residual risks, but it will remain draft until it has been exercised in the reporter's real terminal workflow.

## Residual risks

- Existing persisted previews created before this fix are not rewritten.
- Incomplete terminal control strings fail closed by discarding the unterminated remainder.
- A few downstream display-only slices outside this canonical persistence path remain unchanged.
