### PR TITLE
fix(async): drain durable completion results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Reduce repeated async status parsing and workflow trace projection work.
 
 ### Fixed
-- Recover durable async completions when a healthy native result watcher misses a filesystem event. Thanks to @xz-dev.
+- Recover durable async completions when a healthy native result watcher misses a filesystem event. Thanks to @xz-dev for #973.
 
 ## [0.46.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Reduce repeated async status parsing and workflow trace projection work.
 
+### Fixed
+- Recover durable async completions when a healthy native result watcher misses a filesystem event. Thanks to @xz-dev.
+
 ## [0.46.0] - 2026-08-11
 
 ### Added

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -126,6 +126,7 @@ export function createResultWatcher(
 	const processing = new Set<string>();
 	let deliveryActive = true;
 	let deliveryEpoch = 0;
+	let resultScanTimer: ReturnType<typeof setInterval> | null = null;
 	// The sole in-memory ownership lease. It is acquired for one active session
 	// and revoked before the watcher, queues, or callbacks are torn down.
 	let activeSessionId: string | null = null;
@@ -343,9 +344,15 @@ export function createResultWatcher(
 		}
 	};
 
+	const clearResultScan = () => {
+		if (resultScanTimer) timers.clearInterval(resultScanTimer);
+		resultScanTimer = null;
+	};
+
 	const startPolling = (reason: unknown) => {
 		state.watcher?.close();
 		state.watcher = null;
+		clearResultScan();
 		if (state.watcherRestartTimer) return;
 		console.error(`Subagent result watcher for '${resultsDir}' fell back to polling because native fs.watch is unavailable (${errorCode(reason) ?? "unknown error"}).`);
 		primeExistingResults();
@@ -354,6 +361,7 @@ export function createResultWatcher(
 	};
 
 	const scheduleRestart = () => {
+		clearResultScan();
 		if (state.watcherRestartTimer) return;
 		state.watcherRestartTimer = timers.setTimeout(() => {
 			state.watcherRestartTimer = null;
@@ -381,8 +389,11 @@ export function createResultWatcher(
 		}
 		try {
 			const watchDir = resolveWatchPath(resultsDir, fsApi.realpathSync.native);
-			state.watcher = fsApi.watch(watchDir, (event, file) => {
-				if (event !== "rename" || !file) return;
+			state.watcher = fsApi.watch(watchDir, (_event, file) => {
+				if (!file) {
+					primeExistingResults();
+					return;
+				}
 				const fileName = file.toString();
 				if (fileName.endsWith(".json")) scheduleResult(fileName, true);
 			});
@@ -394,6 +405,8 @@ export function createResultWatcher(
 				scheduleRestart();
 			});
 			state.watcher.unref?.();
+			resultScanTimer = timers.setInterval(primeExistingResults, POLL_INTERVAL_MS);
+			resultScanTimer.unref?.();
 		} catch (error) {
 			if (shouldPoll(error)) return startPolling(error);
 			console.error(`Failed to start subagent result watcher for '${resultsDir}':`, error);
@@ -413,6 +426,7 @@ export function createResultWatcher(
 			timers.clearInterval(state.watcherRestartTimer);
 		}
 		state.watcherRestartTimer = null;
+		clearResultScan();
 		state.resultFileCoalescer.clear();
 		pendingTriggerTurn.clear();
 		processing.clear();

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -422,6 +422,68 @@ describe("result watcher", () => {
 		}
 	});
 
+	it("drains durable results when an active fs.watch misses events", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-"));
+		try {
+			const emitted: Array<{ event: string; data: unknown }> = [];
+			const pi = {
+				events: {
+					on: () => () => {},
+					emit(event: string, data: unknown) {
+						emitted.push({ event, data });
+					},
+				},
+			};
+			const state = createState();
+			state.currentSessionId = "session-1";
+			let scan: (() => void) | undefined;
+			const fakeWatcher = {
+				on() {
+					return fakeWatcher;
+				},
+				close() {},
+				unref() {},
+			} as fs.FSWatcher;
+			const watcher = createResultWatcher(pi, state, resultsDir, 60_000, {
+				fs: { ...fs, watch: () => fakeWatcher },
+				deliverIntercomResults: false,
+				timers: {
+					setTimeout,
+					clearTimeout,
+					setInterval(handler: () => void) {
+						scan = handler;
+						return { unref() {} } as NodeJS.Timeout;
+					},
+					clearInterval() {
+						scan = undefined;
+					},
+				},
+			});
+			try {
+				watcher.startResultWatcher();
+				assert.equal(state.watcher, fakeWatcher);
+				for (const id of ["missed-a", "missed-b"]) {
+					fs.writeFileSync(path.join(resultsDir, `${id}.json`), JSON.stringify({
+						id,
+						sessionId: "session-1",
+						success: true,
+						state: "complete",
+						summary: "done",
+					}), "utf-8");
+				}
+				scan?.();
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			} finally {
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal(emitted.filter((entry) => entry.event === "subagent:async-complete").length, 2);
+			assert.deepEqual(fs.readdirSync(resultsDir).filter((file) => file.endsWith(".json")), []);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("falls back to polling when fs.watch throws EMFILE and preserves grouped intercom delivery", async () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-"));
 		try {


### PR DESCRIPTION
## Summary

- keep native `fs.watch` as the low-latency completion hint
- scan the durable async result directory every 3 seconds while that watcher is healthy
- drain valid result files even when the native watcher misses an event
- clear the scan on watcher fallback, restart, and shutdown

## Why

Async completions are already persisted as result JSON files before delivery. The watcher currently scans those files during startup and polling fallback, but a healthy native watcher can still miss an event without emitting an error. In that state the durable result remains on disk and completion delivery stalls until a later restart.

This treats the result directory as the authoritative queue. Native events still provide immediate delivery; the unref'd interval only supplies bounded recovery. A filename-less native event also triggers the same scan.

Existing scheduling, processing, completion deduplication, replay/archive persistence, grouped intercom delivery, and result deletion remain unchanged, so a native event racing the scan is coalesced by the current idempotency path.

## Related upstream work

- #118 introduced polling fallback for `EMFILE`/`ENOSPC` and was applied directly on main as `fa9e3007`; this PR covers the distinct case where `fs.watch` remains healthy but misses an event.
- #307 and #455 fixed native watcher path handling.
- #941 added completion replay and output archives after a result is consumed; this PR ensures an unobserved durable result reaches that existing consumption path.
- #12 addressed duplicate completion notifications; this PR reuses the current coalescing and processing guards rather than adding a second delivery path.

No existing open or closed PR was found for periodic durable scanning while the native watcher remains healthy.

## Validation

- focused result-watcher integration: 24/24 passed
- full integration suite: 718/718 passed
- `npm run typecheck`: passed
- E2E command: passed with the suite's current 0-test result
- unit suite: 1,734 passed, 1 failed, 1 skipped; the sole failure is the unrelated Fleet terminal-width artifact-path assertion and does not touch this three-file diff
- `git diff --check`: passed
- independent exact-head review completed before publication
