### PR TITLE
fix(tui): keep tool previews single-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Reduce repeated async status parsing and workflow trace projection work.
 
 ### Fixed
+- Keep tool argument previews on one physical terminal line so live widget updates do not leave stacked terminal frames. Thanks to @xz-dev for #972.
 - Recover durable async completions when a healthy native result watcher misses a filesystem event. Thanks to @xz-dev for #973.
 
 ## [0.46.0] - 2026-08-11

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -16,6 +16,7 @@ import {
 	SUBAGENT_PROCESS_TERMINAL_EVENT,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
 } from "../shared/types.ts";
+import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
 import { readStatus } from "../shared/utils.ts";
 import { SubagentParams } from "./schemas.ts";
 import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
@@ -101,12 +102,8 @@ const MAX_METADATA_LENGTH = 128;
 
 function displayText(value: unknown, maxLength: number): string | undefined {
 	if (typeof value !== "string") return undefined;
-	// Strip complete CSI/OSC/DCS/APC/PM strings and C1 controls before collapsing
-	// whitespace; never leave CSI parameters behind after removing ESC.
-	const normalized = value.slice(0, 4_096)
-		.replace(/\x1b\[[0-?]*[ -/]*[@-~]|\x9b[0-?]*[ -/]*[@-~]|\x1b][\s\S]*?(?:\x07|\x1b\\)|\x1b[PX^_][\s\S]*?\x1b\\|[\u0000-\u001f\u007f-\u009f]/g, " ")
-		.replace(/\s+/g, " ").trim();
-	return normalized ? normalized.slice(0, maxLength) : undefined;
+	const normalized = sanitizeDisplayText(value.slice(0, 4_096));
+	return normalized ? truncateDisplayText(normalized, maxLength) : undefined;
 }
 
 function publicTokens(value: unknown): { input: number; output: number; total: number } {

--- a/src/shared/display-text.ts
+++ b/src/shared/display-text.ts
@@ -1,0 +1,100 @@
+function codePointWidth(codePoint: number): 1 | 2 {
+	return codePoint > 0xffff ? 2 : 1;
+}
+
+function isWhitespaceOrControl(codePoint: number): boolean {
+	if (codePoint <= 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f)) return true;
+	if (codePoint >= 0xd800 && codePoint <= 0xdfff) return true;
+	return String.fromCodePoint(codePoint).trim().length === 0;
+}
+
+function consumeControlString(value: string, index: number, osc: boolean): number {
+	while (index < value.length) {
+		const codePoint = value.codePointAt(index)!;
+		const width = codePointWidth(codePoint);
+		if (osc && codePoint === 0x07) return index + width;
+		if (codePoint === 0x9c) return index + width;
+		if (codePoint === 0x1b && value.charCodeAt(index + 1) === 0x5c) return index + 2;
+		index += width;
+	}
+	return value.length;
+}
+
+function consumeCsi(value: string, index: number): number {
+	while (index < value.length) {
+		const codePoint = value.codePointAt(index)!;
+		const width = codePointWidth(codePoint);
+		if (codePoint >= 0x40 && codePoint <= 0x7e) return index + width;
+		index += width;
+	}
+	return value.length;
+}
+
+export function sanitizeDisplayText(value: string): string {
+	const output: string[] = [];
+	let pendingSpace = false;
+
+	const appendSpace = (): void => {
+		if (output.length > 0) pendingSpace = true;
+	};
+	const appendText = (text: string): void => {
+		if (pendingSpace) output.push(" ");
+		output.push(text);
+		pendingSpace = false;
+	};
+
+	for (let index = 0; index < value.length;) {
+		const codePoint = value.codePointAt(index)!;
+		const width = codePointWidth(codePoint);
+
+		if (codePoint === 0x1b) {
+			const next = value.charCodeAt(index + 1);
+			appendSpace();
+			if (next === 0x5b) {
+				index = consumeCsi(value, index + 2);
+				continue;
+			}
+			if (next === 0x5d || next === 0x50 || next === 0x58 || next === 0x5e || next === 0x5f) {
+				index = consumeControlString(value, index + 2, next === 0x5d);
+				continue;
+			}
+			index += next ? 2 : 1;
+			continue;
+		}
+
+		if (codePoint === 0x9b) {
+			appendSpace();
+			index = consumeCsi(value, index + width);
+			continue;
+		}
+		if (codePoint === 0x90 || codePoint === 0x98 || codePoint === 0x9d || codePoint === 0x9e || codePoint === 0x9f) {
+			appendSpace();
+			index = consumeControlString(value, index + width, codePoint === 0x9d);
+			continue;
+		}
+
+		if (isWhitespaceOrControl(codePoint)) appendSpace();
+		else appendText(String.fromCodePoint(codePoint));
+		index += width;
+	}
+
+	return output.join("");
+}
+
+export function truncateDisplayText(value: string, maxLength: number): string {
+	if (maxLength <= 0) return "";
+	if (value.length <= maxLength) return value;
+	let output = "";
+	for (const char of value) {
+		if (output.length + char.length > maxLength) break;
+		output += char;
+	}
+	return output;
+}
+
+export function previewDisplayText(value: string, maxLength: number): string {
+	const normalized = sanitizeDisplayText(value);
+	if (normalized.length <= maxLength) return normalized;
+	if (maxLength <= 3) return truncateDisplayText(normalized, maxLength);
+	return `${truncateDisplayText(normalized, maxLength - 3)}...`;
+}

--- a/src/shared/formatters.ts
+++ b/src/shared/formatters.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import type { Usage, SingleResult } from "./types.ts";
 import type { ChainStep } from "./settings.ts";
 import { isDynamicParallelStep, isParallelStep } from "./settings.ts";
+import { previewDisplayText, sanitizeDisplayText } from "./display-text.ts";
 import { splitKnownThinkingSuffix, THINKING_LEVELS } from "./model-info.ts";
 
 /**
@@ -100,8 +101,7 @@ export function formatToolCall(name: string, args: Record<string, unknown>, expa
 	switch (name) {
 		case "bash": {
 			const command = typeof args.command === "string" ? args.command : "";
-			const maxLength = expanded ? 240 : 60;
-			return `$ ${command.slice(0, maxLength)}${command.length > maxLength ? "..." : ""}`;
+			return `$ ${previewDisplayText(command, expanded ? 240 : 60)}`;
 		}
 		case "read":
 		case "write":
@@ -111,12 +111,10 @@ export function formatToolCall(name: string, args: Record<string, unknown>, expa
 				: typeof args.file_path === "string"
 					? args.file_path
 					: "";
-			return `${name} ${shortenPath(target)}`;
+			return `${name} ${sanitizeDisplayText(shortenPath(target))}`;
 		}
 		default: {
-			const s = JSON.stringify(args);
-			const maxLength = expanded ? 160 : 40;
-			return `${name} ${s.slice(0, maxLength)}${s.length > maxLength ? "..." : ""}`;
+			return `${name} ${previewDisplayText(JSON.stringify(args), expanded ? 160 : 40)}`;
 		}
 	}
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@earendil-works/pi-ai";
+import { previewDisplayText, sanitizeDisplayText, truncateDisplayText } from "./display-text.ts";
 import { formatToolCall } from "./formatters.ts";
 import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, NestedRunSummary, SingleResult, ToolCallSummary, Usage } from "./types.ts";
 
@@ -522,11 +523,8 @@ export function detectSubagentError(messages: Message[]): ErrorInfo {
  * Extract a preview of tool arguments for display
  */
 export function extractToolArgsPreview(args: Record<string, unknown>): string {
-	const truncatePreview = (value: string, maxLength: number): string =>
-		value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
-
 	const stringifyPreviewValue = (value: unknown): string | undefined => {
-		if (typeof value === "string" && value.trim().length > 0) return value;
+		if (typeof value === "string" && value.trim().length > 0) return sanitizeDisplayText(value);
 		if (typeof value === "number" || typeof value === "boolean") return String(value);
 		return undefined;
 	};
@@ -539,39 +537,32 @@ export function extractToolArgsPreview(args: Record<string, unknown>): string {
 		return `${first}${suffix}`;
 	};
 
-	// Handle MCP tool calls - show server/tool info
-	if (args.tool && typeof args.tool === "string") {
-		const server = args.server && typeof args.server === "string" ? `${args.server}/` : "";
-		const toolArgs = args.args && typeof args.args === "string" ? ` ${args.args.slice(0, 40)}` : "";
-		return `${server}${args.tool}${toolArgs}`;
+	if (typeof args.tool === "string") {
+		const server = typeof args.server === "string" ? `${sanitizeDisplayText(args.server)}/` : "";
+		const toolArgs = typeof args.args === "string" ? ` ${truncateDisplayText(sanitizeDisplayText(args.args), 40)}` : "";
+		return sanitizeDisplayText(`${server}${args.tool}${toolArgs}`);
 	}
 
 	const queriesPreview = previewArray(args.queries);
-	if (queriesPreview) return truncatePreview(queriesPreview, 60);
-	if (typeof args.query === "string" && args.query.trim().length > 0) return truncatePreview(args.query, 60);
-	if (typeof args.workflow === "string" && args.workflow.trim().length > 0) return `workflow=${truncatePreview(args.workflow, 48)}`;
+	if (queriesPreview) return previewDisplayText(queriesPreview, 60);
+	if (typeof args.query === "string" && args.query.trim().length > 0) return previewDisplayText(args.query, 60);
+	if (typeof args.workflow === "string" && args.workflow.trim().length > 0) return `workflow=${previewDisplayText(args.workflow, 48)}`;
 
-	if (typeof args.url === "string" && args.url.trim().length > 0) return truncatePreview(args.url, 60);
+	if (typeof args.url === "string" && args.url.trim().length > 0) return previewDisplayText(args.url, 60);
 	const urlsPreview = previewArray(args.urls);
-	if (urlsPreview) return truncatePreview(urlsPreview, 60);
-	if (typeof args.prompt === "string" && args.prompt.trim().length > 0) return truncatePreview(args.prompt, 60);
-	
+	if (urlsPreview) return previewDisplayText(urlsPreview, 60);
+	if (typeof args.prompt === "string" && args.prompt.trim().length > 0) return previewDisplayText(args.prompt, 60);
+
 	const previewKeys = ["command", "path", "file_path", "pattern", "query", "url", "task", "describe", "search"];
 	for (const key of previewKeys) {
-		if (args[key] && typeof args[key] === "string") {
-			const value = args[key] as string;
-			return truncatePreview(value, 60);
-		}
+		if (typeof args[key] === "string") return previewDisplayText(args[key], 60);
 	}
-	
-	// Fallback: show first string value found
+
 	for (const [key, value] of Object.entries(args)) {
+		const displayKey = sanitizeDisplayText(key);
 		const arrayPreview = previewArray(value);
-		if (arrayPreview) return `${key}=${truncatePreview(arrayPreview, 50)}`;
-		if (typeof value === "string" && value.length > 0) {
-			const preview = truncatePreview(value, 50);
-			return `${key}=${preview}`;
-		}
+		if (arrayPreview) return `${displayKey}=${previewDisplayText(arrayPreview, 50)}`;
+		if (typeof value === "string" && value.length > 0) return `${displayKey}=${previewDisplayText(value, 50)}`;
 	}
 	return "";
 }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -18,6 +18,7 @@ import {
 	MAX_WIDGET_JOBS,
 	WIDGET_KEY,
 } from "../shared/types.ts";
+import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
 import { formatTokens, formatUsage, formatDuration, formatModelThinking, formatToolCall, shortenPath } from "../shared/formatters.ts";
 import { getDisplayItems, getSingleResultOutput } from "../shared/utils.ts";
 import { flatToLogicalStepIndex } from "../runs/background/parallel-groups.ts";
@@ -320,6 +321,12 @@ function snapshotNowForProgress(progress: Pick<AgentProgress, "currentToolStarte
 	return progress.lastActivityAt;
 }
 
+function renderToolArgsPreview(value: string, maxLength: number, expanded: boolean): string {
+	const normalized = sanitizeDisplayText(value);
+	if (expanded || normalized.length <= maxLength) return normalized;
+	return `${truncateDisplayText(normalized, maxLength)}...`;
+}
+
 function formatCurrentToolLine(
 	progress: Pick<AgentProgress, "currentTool" | "currentToolArgs" | "currentToolStartedAt">,
 	availableWidth: number,
@@ -329,9 +336,7 @@ function formatCurrentToolLine(
 	if (!progress.currentTool) return undefined;
 	const maxToolArgsLen = Math.max(50, availableWidth - 20);
 	const toolArgsPreview = progress.currentToolArgs
-		? (expanded || progress.currentToolArgs.length <= maxToolArgsLen
-			? progress.currentToolArgs
-			: `${progress.currentToolArgs.slice(0, maxToolArgsLen)}...`)
+		? renderToolArgsPreview(progress.currentToolArgs, maxToolArgsLen, expanded)
 		: "";
 	const durationSuffix = progress.currentToolStartedAt !== undefined && snapshotNow !== undefined
 		? ` | ${formatDuration(Math.max(0, snapshotNow - progress.currentToolStartedAt))}`
@@ -1147,7 +1152,7 @@ function foregroundStyleWidgetStepLines(
 			if (liveStatus && liveStatus !== activity) lines.push(`    ${theme.fg("accent", liveStatus)}`);
 			for (const tool of step.recentTools?.slice(-3) ?? []) {
 				const maxArgsLen = Math.max(40, width - 30);
-				const argsPreview = tool.args.length <= maxArgsLen ? tool.args : `${tool.args.slice(0, maxArgsLen)}...`;
+				const argsPreview = renderToolArgsPreview(tool.args, maxArgsLen, expanded);
 				lines.push(`      ${theme.fg("dim", `${tool.tool}${argsPreview ? `: ${argsPreview}` : ""}`)}`);
 			}
 			for (const line of compactRecentOutputLines(step.recentOutput)) {
@@ -1870,9 +1875,7 @@ export function renderSubagentResult(
 			if (r.progress.recentTools?.length) {
 				for (const t of r.progress.recentTools.slice(-3)) {
 					const maxArgsLen = Math.max(40, w - 24);
-					const argsPreview = expanded || t.args.length <= maxArgsLen
-						? t.args
-						: `${t.args.slice(0, maxArgsLen)}...`;
+					const argsPreview = renderToolArgsPreview(t.args, maxArgsLen, expanded);
 					c.addChild(new Text(fit(theme.fg("dim", `${t.tool}: ${argsPreview}`)), 0, 0));
 				}
 			}
@@ -2103,9 +2106,7 @@ export function renderSubagentResult(
 			if (rProg.recentTools?.length) {
 				for (const t of rProg.recentTools.slice(-3)) {
 					const maxArgsLen = Math.max(40, w - 30);
-					const argsPreview = expanded || t.args.length <= maxArgsLen
-						? t.args
-						: `${t.args.slice(0, maxArgsLen)}...`;
+					const argsPreview = renderToolArgsPreview(t.args, maxArgsLen, expanded);
 					c.addChild(new Text(fit(theme.fg("dim", `      ${t.tool}: ${argsPreview}`)), 0, 0));
 				}
 			}

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
+import { extractToolArgsPreview } from "../../src/shared/utils.ts";
 
 const { buildWidgetLines, clearLegacyResultAnimationTimer, renderWidget } = await import("../../src/tui/render.ts") as {
 	buildWidgetLines: (jobs: Array<Record<string, unknown>>, theme: { fg(name: string, text: string): string; bold(text: string): string }, width?: number, expanded?: boolean, frame?: number) => string[];
@@ -14,6 +15,7 @@ const theme = {
 };
 
 const runningGlyphPattern = "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏●]";
+const malformedSurrogate = /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/u;
 
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -98,6 +100,57 @@ describe("subagent async widget rendering", () => {
 		assert.ok(text.indexOf("scout") < text.indexOf("queued"), "running row should precede queued summary");
 		assert.ok(text.indexOf("queued") < text.indexOf("reviewer"), "queued summary should precede completions");
 		assert.match(text, /⎿  read/);
+	});
+
+	it("returns one physical terminal line per widget line for tool previews", () => {
+		const preview = extractToolArgsPreview({ command: "first\r\n\t\x1b[31msecond\x1b[0m" });
+		const lines = buildWidgetLines([{
+			asyncId: "run-1",
+			asyncDir: "/tmp/run",
+			status: "running",
+			mode: "parallel",
+			agents: ["worker"],
+			activeParallelGroup: true,
+			runningSteps: 1,
+			completedSteps: 0,
+			stepsTotal: 1,
+			steps: [{
+				index: 0,
+				agent: "worker",
+				status: "running",
+				currentTool: "bash",
+				currentToolArgs: preview,
+				recentTools: [{ tool: "bash", args: preview, endMs: 1 }],
+			}],
+		}], theme, 120, true);
+
+		assert.match(lines.join("\n"), /first second/);
+		for (const line of lines) assert.doesNotMatch(line, /[\r\n]/);
+	});
+
+	it("does not split surrogate pairs when widget rows shorten previews again", () => {
+		const preview = `a${"😀".repeat(30)}`;
+		const lines = buildWidgetLines([{
+			asyncId: "run-1",
+			asyncDir: "/tmp/run",
+			status: "running",
+			mode: "parallel",
+			agents: ["worker"],
+			activeParallelGroup: true,
+			runningSteps: 1,
+			completedSteps: 0,
+			stepsTotal: 1,
+			steps: [{
+				index: 0,
+				agent: "worker",
+				status: "running",
+				currentTool: "bash",
+				currentToolArgs: preview,
+				recentTools: [{ tool: "bash", args: preview, endMs: 1 }],
+			}],
+		}], theme, 60, true);
+
+		for (const line of lines) assert.doesNotMatch(line, malformedSurrogate);
 	});
 
 	it("uses parallel running/done wording for async jobs with parallel groups", () => {

--- a/test/unit/foreground-tool-call-compaction.test.ts
+++ b/test/unit/foreground-tool-call-compaction.test.ts
@@ -50,6 +50,43 @@ describe("foreground tool-call compaction", () => {
 		assert.equal(result.toolCalls, undefined);
 	});
 
+	it("keeps live tool argument previews on one terminal line", () => {
+		const preview = extractToolArgsPreview({
+			command: "set +e\r\n\t\x1b[31mrun\x1b[0m \x1b]0;title\x07now\u0000",
+		});
+
+		assert.equal(preview, "set +e run now");
+		assert.doesNotMatch(preview, /[\r\n\t\x1b]/);
+	});
+
+	it("keeps completed bash tool-call previews on one terminal line", () => {
+		const preview = formatToolCall("bash", { command: "first\n\x1b[32msecond\x1b[0m" });
+
+		assert.equal(preview, "$ first second");
+		assert.doesNotMatch(preview, /[\r\n\t\x1b]/);
+	});
+
+	it("does not split surrogate pairs when truncating previews", () => {
+		const preview = extractToolArgsPreview({ command: "😀".repeat(31) });
+
+		assert.equal(preview, `${"😀".repeat(28)}...`);
+		assert.doesNotMatch(preview, /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/u);
+		assert.equal(extractToolArgsPreview({ command: `safe\ud800tail\udc00end` }), "safe tail end");
+	});
+
+	it("normalizes fallback argument keys before display", () => {
+		const preview = extractToolArgsPreview({ "bad\r\n\t\x1b[31mkey\x1b[0m\u0000": "value" });
+
+		assert.equal(preview, "bad key=value");
+		assert.doesNotMatch(preview, /[\u0000-\u001f\u007f-\u009f]/);
+	});
+
+	it("discards terminal string payloads while preserving readable suffixes", () => {
+		for (const control of ["\x1b]0;title\x07", "\x1bPpayload\x1b\\", "\x9d0;title\x9c"]) {
+			assert.equal(extractToolArgsPreview({ command: `before${control}after` }), "before after");
+		}
+	});
+
 	it("formats array-based web search previews clearly", () => {
 		assert.equal(
 			extractToolArgsPreview({

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -180,6 +180,34 @@ describe("subagent extension RPC bridge", () => {
 		bridge.dispose();
 	});
 
+	it("projects fleet text without control characters or malformed UTF-16", async () => {
+		const events = new FakeEvents();
+		const state = {
+			currentSessionId: "session-123",
+			foregroundControls: new Map(),
+			asyncJobs: new Map([["unicode", {
+				asyncId: "unicode", sessionId: "session-123", status: "running", mode: "single", startedAt: 1,
+				description: "start\n" + "😀".repeat(257),
+				agents: [`worker\ud800broken\udc00${"😀".repeat(45)}`],
+			}]]),
+		} as any;
+		const bridge = registerSubagentRpcBridge({
+			events, getContext: () => ctx("session-123", "session-123"), state,
+			execute: async () => ({ content: [], details: { mode: "management", results: [] } } as any),
+		});
+		const reply = await request(events, "fleet-unicode", "status");
+		const entry = (reply as any).data.fleet.entries[0];
+		const malformedSurrogate = /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/u;
+
+		assert.doesNotMatch(entry.agent, malformedSurrogate);
+		assert.doesNotMatch(entry.goal, malformedSurrogate);
+		assert.doesNotMatch(entry.goal, /[\r\n]/);
+		assert.ok(entry.agent.length <= 96);
+		assert.ok(entry.goal.length <= 512);
+		assert.match(entry.agent, /^worker broken/);
+		bridge.dispose();
+	});
+
 	it("projects resolved foreground model, effort, split usage, and goal", async () => {
 		const events = new FakeEvents();
 		const state = {


### PR DESCRIPTION
This replaces the draft approach in #972 with a smaller current-base implementation while preserving the contributor credit.

The change adds one shared display-text sanitizer for tool previews. It removes terminal controls, collapses whitespace and control characters, removes malformed UTF-16 surrogate code units, and truncates without splitting surrogate pairs. The same path now feeds live tool argument previews, completed tool-call summaries, RPC fleet text, and render-time secondary truncation.

Validation:
- `node --experimental-strip-types --test test/unit/foreground-tool-call-compaction.test.ts test/unit/rpc.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- `env -u PI_SUBAGENT_CHILD node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/*.test.ts`
- `npm run test:e2e` (expected runtime-package skip)

Fresh review found one renderer truncation issue. That was fixed and a targeted follow-up review found no issues.

Thanks to @xz-dev for the original #972 report and draft.
