### PR TITLE
feat: move project storage under pi dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pi/todos/
+.pi/subagents/
 .pi-subagents/
 .DS_Store
 AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Move project-scoped pi-subagents storage from `.pi-subagents/` to `.pi/subagents/` for cleaner project roots. Thanks to @yceachan for #971.
 - Clarify the accepted mission launch object contract for tool callers.
 - Reduce repeated async status parsing and workflow trace projection work.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -228,7 +228,7 @@ How it works:
 
 - `refine` collects bounded evidence from that agent's recent runs in the project (statuses, errors, review findings, residual risks, output tails), then launches a fresh read-only proposal child to draft small guidance edits from that evidence.
 - Proposed guidance is validated before it is written. Edits that try to override safety, policy, tool, output, acceptance, developer, or system instructions are rejected, as are edits that target all agents or base agent files.
-- The accepted overlay is stored at `.pi-subagents/refinements/<agent>.md` with revision metadata and snapshots. Each `refine` or `refine.rollback` adds a snapshot, and `refine.rollback` restores the previous revision.
+- The accepted overlay is stored at `.pi/subagents/refinements/<agent>.md` with revision metadata and snapshots. Each `refine` or `refine.rollback` adds a snapshot, and `refine.rollback` restores the previous revision.
 - At launch, the current overlay is injected into that agent's child system prompt as a `<pi-subagents-refinement>` block scoped to this project. The base agent definition is never modified.
 
 `refine.show` prints the current overlay and revision history. Delete the overlay file to remove the refinement entirely.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,7 +133,7 @@ A user may explicitly call `subagent({ action: "grant-spawn-budget", additional:
 { "scheduledRuns": { "enabled": false, "maxPending": 20 } }
 ```
 
-Durable schedules are enabled by default and stored per project under `.pi-subagents/schedules/<id>/`. See [missions.md](missions.md#schedules) for usage.
+Durable schedules are enabled by default and stored per project under `.pi/subagents/schedules/<id>/`. See [missions.md](missions.md#schedules) for usage.
 
 Set `storeRoot` to keep durable schedules outside project repositories. It must be an absolute path or a `~/` path, which expands from the user home directory. Each project is stored under a hash of its resolved working directory, so projects do not share schedules.
 
@@ -141,7 +141,7 @@ Set `storeRoot` to keep durable schedules outside project repositories. It must 
 { "scheduledRuns": { "storeRoot": "~/.local/share/pi-subagents/schedules" } }
 ```
 
-When `storeRoot` is omitted, schedules remain at `<cwd>/.pi-subagents/schedules`.
+When `storeRoot` is omitted, schedules remain at `<cwd>/.pi/subagents/schedules`.
 
 ## `parallel`
 
@@ -245,7 +245,7 @@ stdin is a JSON object with `repoRoot`, `worktreePath`, `agentCwd`, `branch`, `i
 {
   "missions": {
     "enabled": true,
-    "directory": ".pi-subagents/missions",
+    "directory": ".pi/subagents/missions",
     "globalIndex": true,
     "retainTerminal": 200
   }
@@ -283,15 +283,15 @@ Each fixed action resolves to `"auto"`, `"confirm"`, or `"forbid"`. This is inte
 
 Controls where subagent artifact files (inputs, outputs, transcripts, metadata) are stored:
 
-- `"project"` (default): writes to `<cwd>/.pi-subagents/artifacts/`.
+- `"project"` (default): writes to `<cwd>/.pi/subagents/artifacts/`.
 - `"session"`: stores artifacts under pi's session directory (`~/.pi/agent/sessions/<session>/subagent-artifacts/`), keeping the working directory clean.
 - `"temp"`: uses the OS temp directory.
 
-This preference also controls the default chain scratch directory. `"project"` uses `<cwd>/.pi-subagents/chain-runs/`, while `"session"` and `"temp"` use the user-scoped temp chain directory.
+This preference also controls the default chain scratch directory. `"project"` uses `<cwd>/.pi/subagents/chain-runs/`, while `"session"` and `"temp"` use the user-scoped temp chain directory.
 
 The `"session"` option uses the same directory that `cleanupAllArtifactDirs` already scans for age-based cleanup, so artifacts are still cleaned up automatically. Temporary chain directories are cleaned up separately after 24 hours.
 
-When a project-scoped launch runs from an npm package directory, pi-subagents warns if package settings can include `.pi-subagents/` in the published package. Add `.pi-subagents/` to `.npmignore` (or `.gitignore` when no `.npmignore` exists), use a `files` allowlist that does not include `.pi-subagents/`, or select `"session"` or `"temp"`.
+When a project-scoped launch runs from an npm package directory, pi-subagents warns if package settings can include `.pi/subagents/` in the published package. Add `.pi/subagents/` to `.npmignore` (or `.gitignore` when no `.npmignore` exists), use a `files` allowlist that does not include `.pi/subagents/`, or select `"session"` or `"temp"`.
 
 ## `completionBatch`
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -268,7 +268,7 @@ subagent({ action: "project.status", cwd: "/path/to/repo" })
 subagent({ action: "project.close", cwd: "/path/to/repo" })
 ```
 
-A project pane runs its own Pi session in the target directory, so subagents launched from that pane use that project's config, agents, skills, files, git state, and missions. The parent session keeps coordination authority; existing headless runs are not moved into the pane. Pane bindings live under `<projectRoot>/.pi-subagents/project-panes/herdr.json` and are only a local pointer to the Herdr pane.
+A project pane runs its own Pi session in the target directory, so subagents launched from that pane use that project's config, agents, skills, files, git state, and missions. The parent session keeps coordination authority; existing headless runs are not moved into the pane. Pane bindings live under `<projectRoot>/.pi/subagents/project-panes/herdr.json` and are only a local pointer to the Herdr pane.
 
 Other Pi extensions should use the versioned public TypeScript surface instead of invoking the model-facing tool or importing inspector internals:
 

--- a/docs/missions.md
+++ b/docs/missions.md
@@ -11,7 +11,7 @@ Missions are durable wrappers around runs. The noun map:
 - **Run** — one actual subagent execution.
 - **Receipt** — proof or a link for an external outcome, such as a PR, CI check, deployment, or release.
 
-Ordinary workflow launches create one enclosing mission by default, with detailed JSON records under `<cwd>/.pi-subagents/missions/` linking objectives, run ids, lifecycle status, decisions, artifact paths, and delivery receipts. Workflow children do not create separate missions. Each workflow child attempt is stored in the enclosing mission with its stable workflow key, run id when known, agent, task metadata, timestamps, session and artifact paths, and latest status heartbeat.
+Ordinary workflow launches create one enclosing mission by default, with detailed JSON records under `<cwd>/.pi/subagents/missions/` linking objectives, run ids, lifecycle status, decisions, artifact paths, and delivery receipts. Workflow children do not create separate missions. Each workflow child attempt is stored in the enclosing mission with its stable workflow key, run id when known, agent, task metadata, timestamps, session and artifact paths, and latest status heartbeat.
 
 Behavior:
 
@@ -19,7 +19,7 @@ Behavior:
 - Human receipts end with `Mission: <id> (<status>)`, while JSON/structured output text stays unchanged and `details.missionId` is authoritative.
 - Pass `mission: false` for an intentionally ephemeral workflow. It creates no mission for the workflow or its children and has no `state` global.
 - Set `missions.enabled: false` to disable automatic mission creation; explicit mission fields and actions still work.
-- A workflow with a mission can use `await state.get(key)` and `await state.set(key, value)` for durable JSON state. Missing keys return `undefined`. Keys use the same format as `runs.run` keys. Each set takes the state-file lock, reads the latest file, merges the key, and atomically writes `<cwd>/.pi-subagents/missions/<mission-id>/state.json`. The complete file cannot exceed 256 KiB. Each workflow caches the file on its first `get`. A `mission:false` workflow has no `state` global.
+- A workflow with a mission can use `await state.get(key)` and `await state.set(key, value)` for durable JSON state. Missing keys return `undefined`. Keys use the same format as `runs.run` keys. Each set takes the state-file lock, reads the latest file, merges the key, and atomically writes `<cwd>/.pi/subagents/missions/<mission-id>/state.json`. The complete file cannot exceed 256 KiB. Each workflow caches the file on its first `get`. A `mission:false` workflow has no `state` global.
 
 An explicit `mission` object must have exactly one non-empty `title` or `summary`. `objective` and `labels` are optional. When supplied, `goal` must be `true` and requires `budget: { tokens: <positive integer> }`.
 
@@ -83,7 +83,7 @@ Mission storage configuration (`missions.directory`, `retainTerminal`, `globalIn
 
 ## Schedules
 
-Durable schedules are enabled by default and stored per project under `.pi-subagents/schedules/<id>/`.
+Durable schedules are enabled by default and stored per project under `.pi/subagents/schedules/<id>/`.
 
 Create a one-shot schedule:
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -126,7 +126,7 @@ Foreground and async runners share bounded child-protocol handling:
 
 ## Chain and debug artifacts
 
-Each chain run creates a scratch directory under its resolved chain root. With the default `artifactDir: "project"`, that root is `<cwd>/.pi-subagents/chain-runs/`. With `artifactDir: "session"` or `"temp"`, it is user-scoped temp storage:
+Each chain run creates a scratch directory under its resolved chain root. With the default `artifactDir: "project"`, that root is `<cwd>/.pi/subagents/chain-runs/`. With `artifactDir: "session"` or `"temp"`, it is user-scoped temp storage:
 
 ```text
 <tmpdir>/pi-subagents-<scope>/chain-runs/{runId}/
@@ -134,7 +134,7 @@ Each chain run creates a scratch directory under its resolved chain root. With t
 
 A run directory may contain files such as `context.md`, `plan.md`, `progress.md`, and `parallel-{stepIndex}/.../output.md`. User-scoped temp chain directories older than 24 hours are cleaned up on extension startup; project-local and explicit persistent roots are not age-scanned.
 
-Debug artifacts live under `{sessionDir}/subagent-artifacts/`, `.pi-subagents/artifacts/` for project-scoped runs, or a user-scoped temp artifact directory. Single-run relative `output` files are saved under `{artifactsDir}/outputs/{runId}/` unless `singleRunOutputBaseDir` is configured. Per task you may see:
+Debug artifacts live under `{sessionDir}/subagent-artifacts/`, `.pi/subagents/artifacts/` for project-scoped runs, or a user-scoped temp artifact directory. Single-run relative `output` files are saved under `{artifactsDir}/outputs/{runId}/` unless `singleRunOutputBaseDir` is configured. Per task you may see:
 
 - `{runId}_{agent}_input.md`
 - `{runId}_{agent}_output.md`
@@ -143,7 +143,7 @@ Debug artifacts live under `{sessionDir}/subagent-artifacts/`, `.pi-subagents/ar
 
 Metadata records timing, usage, exit code, final model, attempted models, fallback attempt outcomes, and the resolved acceptance ledger with its parsed child report.
 
-For npm package projects, project-scoped artifacts need a `.npmignore` rule (or `.gitignore` when no `.npmignore` exists) or a `files` allowlist that does not include `.pi-subagents/`. pi-subagents warns at launch when these package settings can include the artifacts. Use `artifactDir: "session"` or `"temp"` to keep them outside the package worktree.
+For npm package projects, project-scoped artifacts need a `.npmignore` rule (or `.gitignore` when no `.npmignore` exists) or a `files` allowlist that does not include `.pi/subagents/`. pi-subagents warns at launch when these package settings can include the artifacts. Use `artifactDir: "session"` or `"temp"` to keep them outside the package worktree.
 
 ## Sessions
 

--- a/docs/watchdog.md
+++ b/docs/watchdog.md
@@ -11,7 +11,7 @@ It reviews repo edits, not ordinary conversation:
 - It runs at the safe `agent_end` boundary, only when the current agent or child writer changed the final repo state since the start of that turn.
 - Multiple edits in one turn are coalesced into one review of the final changed state.
 - Unchanged/reverted diffs are skipped.
-- Generated `.pi-subagents/` or `tmp/` artifacts do not trigger review.
+- Generated `.pi/subagents/` or `tmp/` artifacts do not trigger review.
 - In orchestrated runs, each writing child can review its own edited worktree, and the parent can still review the aggregate repo diff after child changes are applied.
 
 ## Choosing a model

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -158,7 +158,7 @@ A cooperating terminal runtime can register read-only external records through `
 
 ### Scheduled subagent runs
 
-Schedules are durable project records under `.pi-subagents/schedules/`. They are enabled by default; set `{ "scheduledRuns": { "enabled": false } }` in `~/.pi/agent/extensions/subagent/config.json` to disable them. Only schedule explicit work the user asked for.
+Schedules are durable project records under `.pi/subagents/schedules/`. They are enabled by default; set `{ "scheduledRuns": { "enabled": false } }` in `~/.pi/agent/extensions/subagent/config.json` to disable them. Only schedule explicit work the user asked for.
 
 ```typescript
 // One-shot reviewer
@@ -235,7 +235,7 @@ The subagent watchdog is an **opt-in** adversarial change reviewer. It is not th
 
 When enabled, it reviews actual repo edits at safe `agent_end` boundaries only if
 the final worktree state changed during that turn. Unchanged or reverted diffs and
-generated `.pi-subagents/` / temp artifacts do not trigger review. Writing children
+generated `.pi/subagents/` / temp artifacts do not trigger review. Writing children
 can review their own worktree; the parent can still review the aggregate diff after
 child changes land. Enabled watchdogs also run changed-file TypeScript/JavaScript
 LSP diagnostics before the model pass when `typescript-language-server` is available.
@@ -298,7 +298,7 @@ Routing rule:
 - Several projects with independent work: one async `workflowScript` whose child keys include repo slugs and whose child calls set explicit `cwd`; keep publication and merge decisions serial per repo.
 - Different project, substantial or long-running work: open a project-owned Herdr pane rooted there when a separate visible project session is useful, then give that project Pi session a narrow mission/result contract. Do not model it as ordinary child nesting, and do not expect existing headless runs to move into the pane.
 
-Project panes run a separate Pi session from the target directory. Subagents launched inside that pane use that project's config, agents, skills, files, git state, and mission records. The pane binding lives under `<projectRoot>/.pi-subagents/project-panes/herdr.json`. For ordinary headless delegation to another repo, prefer explicit `cwd` first; reserve project panes for visible or persistent project ownership.
+Project panes run a separate Pi session from the target directory. Subagents launched inside that pane use that project's config, agents, skills, files, git state, and mission records. The pane binding lives under `<projectRoot>/.pi/subagents/project-panes/herdr.json`. For ordinary headless delegation to another repo, prefer explicit `cwd` first; reserve project panes for visible or persistent project ownership.
 
 ```typescript
 subagent({ action: "mission.create", mission: { title: "Ship auth refresh", objective: "Implement and validate refresh handling" } })
@@ -340,7 +340,7 @@ single-writer pattern instead.
 
 Git worktrees start from tracked files, so ignored or untracked build state
 such as `node_modules` may be absent. The clean-check ignores pi-subagents'
-own `.pi-subagents/` runtime state, including default mission records, but still
+own `.pi/subagents/` runtime state, including default mission records, but still
 rejects ordinary source/config changes. `pi-subagents` attempts to symlink the
 root checkout's `node_modules` into each managed worktree when it exists, but
 agents should still treat dependency setup as an explicit bootstrap step before

--- a/skills/pi-subagents/references/management-authoring-rpc.md
+++ b/skills/pi-subagents/references/management-authoring-rpc.md
@@ -28,7 +28,7 @@ subagent({ action: "refine.show", agent: "reviewer" })
 subagent({ action: "refine.rollback", agent: "reviewer" })
 ```
 
-`refine` builds a bounded project-local guidance overlay for one agent from recent run evidence, using a fresh read-only proposal child; validated guidance is stored under `.pi-subagents/refinements/<agent>.md` with revision snapshots and is injected into that agent's child system prompt for this project. `refine.show` prints the current overlay and history; `refine.rollback` restores the previous revision. Guidance that tries to override safety, policy, tool, output, acceptance, developer, or system instructions is rejected. `/subagents-refine <agent>` is the slash equivalent.
+`refine` builds a bounded project-local guidance overlay for one agent from recent run evidence, using a fresh read-only proposal child; validated guidance is stored under `.pi/subagents/refinements/<agent>.md` with revision snapshots and is injected into that agent's child system prompt for this project. `refine.show` prints the current overlay and history; `refine.rollback` restores the previous revision. Guidance that tries to override safety, policy, tool, output, acceptance, developer, or system instructions is rejected. `/subagents-refine <agent>` is the slash equivalent.
 
 ### Create an agent
 

--- a/src/inspectors/herdr/project-panes.ts
+++ b/src/inspectors/herdr/project-panes.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { getPiSpawnCommand } from "../../runs/shared/pi-spawn.ts";
+import { getProjectSubagentsDir } from "../../shared/artifacts.ts";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import type { Details } from "../../shared/types.ts";
 import { createHerdrClient, detectHerdr, type HerdrClient, type HerdrErrorCode } from "./client.ts";
@@ -153,7 +154,7 @@ function formatProjectPaneError(input: { code: ProjectPaneErrorCode; message: st
 }
 
 function projectPaneDir(projectRoot: string): string {
-	return path.join(projectRoot, ".pi-subagents", "project-panes");
+	return path.join(getProjectSubagentsDir(projectRoot), "project-panes");
 }
 
 export function projectPaneBindingPath(projectRoot: string): string {

--- a/src/missions/store.ts
+++ b/src/missions/store.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getProjectSubagentsDir } from "../shared/artifacts.ts";
 import { writePrivateAtomicJson } from "../shared/atomic-json.ts";
 import { getAgentDir } from "../shared/utils.ts";
 import {
@@ -290,7 +291,7 @@ export function resolveMissionStoreLocation(input: {
 	const projectRoot = path.resolve(input.projectRoot);
 	const missionDir = input.config?.directory
 		? expandConfiguredPath(input.config.directory, projectRoot)
-		: path.join(projectRoot, ".pi-subagents", "missions");
+		: path.join(getProjectSubagentsDir(projectRoot), "missions");
 	const globalIndexDir = input.config?.globalIndexDir
 		? expandConfiguredPath(input.config.globalIndexDir, projectRoot)
 		: path.join(input.agentDir ?? getAgentDir(), "missions", "index");

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { getProjectSubagentsDir } from "../../shared/artifacts.ts";
 import { writePrivateAtomicJson } from "../../shared/atomic-json.ts";
 import { shortenPath } from "../../shared/formatters.ts";
 import type { AsyncStatus, Details, ExtensionConfig } from "../../shared/types.ts";
@@ -87,7 +88,7 @@ export function scheduledRunsEnabled(config: ExtensionConfig): boolean {
 }
 
 export function scheduledRunStorePath(cwd: string, _sessionId?: string, root?: string): string {
-	if (!root) return path.join(path.resolve(cwd), ".pi-subagents", "schedules");
+	if (!root) return path.join(getProjectSubagentsDir(path.resolve(cwd)), "schedules");
 	const projectKey = createHash("sha256").update(path.resolve(cwd)).digest("hex").slice(0, 20);
 	return path.join(root, projectKey);
 }

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resolveAgentName, type AgentConfig, type AgentScope } from "../../agents/agents.ts";
-import { getArtifactsDir, getChainRunsDir, getProjectArtifactPackagingWarning } from "../../shared/artifacts.ts";
+import { getArtifactsDir, getChainRunsDir, getProjectArtifactPackagingWarning, getProjectSubagentsDir } from "../../shared/artifacts.ts";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { ChainClarifyComponent, type ChainClarifyResult } from "./chain-clarify.ts";
 import { resolveEffectiveThinking, toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
@@ -1450,7 +1450,7 @@ async function resumeAsyncRun(input: {
 		inheritProjectContext: recoveryDescriptor.inheritProjectContext,
 		inheritSkills: recoveryDescriptor.inheritSkills,
 		source: "project",
-		filePath: recoveryDescriptor.agentFilePath ?? path.join(recoveryDescriptor.cwd, ".pi-subagents-recovery-agent"),
+		filePath: recoveryDescriptor.agentFilePath ?? path.join(getProjectSubagentsDir(recoveryDescriptor.cwd), "recovery-agent"),
 	} : undefined);
 	if (!agentConfig) {
 		return {

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { resolveAuthorityDecision, type AuthorityPolicyConfig } from "../../policy/authority.ts";
+import { PROJECT_SUBAGENTS_RELATIVE_DIR } from "../../shared/artifacts.ts";
 
 export interface WorktreeSetup {
 	cwd: string;
@@ -135,9 +136,9 @@ function resolveRepoState(cwd: string): RepoState {
 	const cwdRelative = resolveRepoCwdRelative(cwd);
 	const toplevel = runGitChecked(cwd, ["rev-parse", "--show-toplevel"]).trim();
 
-	// pi-subagents writes durable runtime state under .pi-subagents/ by default;
+	// pi-subagents writes durable runtime state under .pi/subagents/ by default;
 	// that state must not make managed isolation unusable for later runs.
-	const status = runGitChecked(toplevel, ["status", "--porcelain", "--", ":!.pi-subagents"]);
+	const status = runGitChecked(toplevel, ["status", "--porcelain", "--", `:!${PROJECT_SUBAGENTS_RELATIVE_DIR}`]);
 	if (status.trim().length > 0) {
 		throw new Error("worktree isolation requires a clean git working tree. Commit or stash changes first.");
 	}

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -3,19 +3,19 @@ import * as path from "node:path";
 import { CHAIN_RUNS_DIR, TEMP_ARTIFACTS_DIR, type ArtifactPaths, type ArtifactDirPreference } from "./types.ts";
 import { getAgentDir } from "./utils.ts";
 const CLEANUP_MARKER_FILE = ".last-cleanup";
-const PROJECT_ARTIFACT_ROOT = ".pi-subagents";
+export const PROJECT_SUBAGENTS_RELATIVE_DIR = ".pi/subagents";
 
 const PROJECT_ARTIFACT_PATHS = [
-	`${PROJECT_ARTIFACT_ROOT}/artifacts/output.md`,
-	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker_input.md`,
-	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker_output.md`,
-	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker.jsonl`,
-	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker_transcript.jsonl`,
-	`${PROJECT_ARTIFACT_ROOT}/artifacts/run_worker_meta.json`,
-	`${PROJECT_ARTIFACT_ROOT}/artifacts/progress/run/progress.md`,
-	`${PROJECT_ARTIFACT_ROOT}/artifacts/outputs/output.md`,
-	`${PROJECT_ARTIFACT_ROOT}/artifacts/outputs/run/output.md`,
-	`${PROJECT_ARTIFACT_ROOT}/chain-runs/run.json`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/artifacts/output.md`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/artifacts/run_worker_input.md`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/artifacts/run_worker_output.md`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/artifacts/run_worker.jsonl`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/artifacts/run_worker_transcript.jsonl`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/artifacts/run_worker_meta.json`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/artifacts/progress/run/progress.md`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/artifacts/outputs/output.md`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/artifacts/outputs/run/output.md`,
+	`${PROJECT_SUBAGENTS_RELATIVE_DIR}/chain-runs/run.json`,
 ];
 
 function globMatchesPath(pattern: string, filePath: string): boolean {
@@ -59,7 +59,7 @@ function normalizePattern(pattern: string): string {
 
 function patternMatchesArtifactPath(pattern: string, artifactPath: string): boolean {
 	const normalized = normalizePattern(pattern);
-	return normalized === PROJECT_ARTIFACT_ROOT
+	return normalized === PROJECT_SUBAGENTS_RELATIVE_DIR
 		|| normalized === "*"
 		|| artifactPath.startsWith(`${normalized}/`)
 		|| globMatchesPath(normalized, artifactPath);
@@ -127,11 +127,11 @@ export function getProjectArtifactPackagingWarning(cwd: string): string | undefi
 	const ignorePath = fs.existsSync(npmIgnorePath) ? npmIgnorePath : path.join(cwd, ".gitignore");
 	if (filesIncludeArtifacts === undefined && ignoreFileExcludesProjectArtifacts(ignorePath)) return undefined;
 
-	return "Project-scoped subagent artifacts can be included when this package is published. Add '.pi-subagents/' to .npmignore, restrict package.json files, or set artifactDir to 'session' or 'temp'.";
+	return "Project-scoped subagent artifacts can be included when this package is published. Add '.pi/subagents/' to .npmignore, restrict package.json files, or set artifactDir to 'session' or 'temp'.";
 }
 
 export function getProjectSubagentsDir(cwd: string): string {
-	return path.join(cwd, PROJECT_ARTIFACT_ROOT);
+	return path.join(cwd, PROJECT_SUBAGENTS_RELATIVE_DIR);
 }
 
 export function getProjectArtifactsDir(cwd: string): string {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1844,7 +1844,7 @@ export interface ExtensionConfig {
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
 	worktreeBaseDir?: string;
-	/** Where to store subagent artifact files. Defaults to "project" (cwd/.pi-subagents). Set to "session" for pi session dir, or "temp" for OS temp. */
+	/** Where to store subagent artifact files. Defaults to "project" (cwd/.pi/subagents). Set to "session" for pi session dir, or "temp" for OS temp. */
 	artifactDir?: ArtifactDirPreference;
 	intercomBridge?: IntercomBridgeConfig;
 	proactiveSkillSubagents?: ProactiveSkillSubagentsConfig | false;

--- a/src/watchdog/change-signature.ts
+++ b/src/watchdog/change-signature.ts
@@ -2,10 +2,11 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { PROJECT_SUBAGENTS_RELATIVE_DIR } from "../shared/artifacts.ts";
 
-const IGNORED_CHANGE_PREFIXES = [".pi-subagents/", "tmp/", "node_modules/"];
-const IGNORED_CHANGE_PATHS = new Set([".pi-subagents", "tmp", "node_modules"]);
-const IGNORED_CHANGE_SEGMENTS = new Set([".git", ".pi-subagents", "node_modules"]);
+const IGNORED_CHANGE_PREFIXES = [`${PROJECT_SUBAGENTS_RELATIVE_DIR}/`, "tmp/", "node_modules/"];
+const IGNORED_CHANGE_PATHS = new Set([PROJECT_SUBAGENTS_RELATIVE_DIR, "tmp", "node_modules"]);
+const IGNORED_CHANGE_SEGMENTS = new Set([".git", "node_modules"]);
 
 const DEFAULT_MAX_HASH_FILE_BYTES = 64 * 1024 * 1024;
 const DEFAULT_MAX_HASH_TOTAL_BYTES = 64 * 1024 * 1024;

--- a/test/integration/acceptance-file-report.test.ts
+++ b/test/integration/acceptance-file-report.test.ts
@@ -325,7 +325,7 @@ describe("acceptance file reports", { skip: !runSync ? "pi packages not availabl
 				agentConfig: makeAgent("worker", { completionGuard: false }),
 				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-file-report" },
 				artifactConfig,
-				artifactsDir: path.join(tempDir, ".pi-subagents", "artifacts"),
+				artifactsDir: path.join(tempDir, ".pi/subagents", "artifacts"),
 				shareEnabled: false,
 				maxSubagentDepth: 2,
 				output: outputPath,

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -738,7 +738,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const outputPath = payload.results[0]?.artifactPaths?.outputPath;
 		assert.ok(outputPath?.startsWith(`${expectedDir}${path.sep}`));
 		assert.equal(fs.readFileSync(outputPath, "utf-8"), "async session artifact");
-		assert.equal(fs.existsSync(path.join(tempDir, ".pi-subagents", "artifacts")), false);
+		assert.equal(fs.existsSync(path.join(tempDir, ".pi/subagents", "artifacts")), false);
 	});
 
 	it("persists async capability ceiling audit to status, results, events, and metadata", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
@@ -792,7 +792,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			agentConfig: makeAgent("worker", { completionGuard: false }),
 			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
 			artifactConfig: { enabled: true, includeInput: true, includeOutput: true, includeJsonl: false, includeMetadata: true, cleanupDays: 7 },
-			artifactsDir: path.join(tempDir, ".pi-subagents", "artifacts"),
+			artifactsDir: path.join(tempDir, ".pi/subagents", "artifacts"),
 			shareEnabled: false,
 			maxSubagentDepth: 2,
 			acceptance: false,
@@ -812,7 +812,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	it("recreates project-local artifact directories removed before async completion", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ delay: 800, output: "completed after artifact cleanup" });
 		const id = `async-artifact-dir-recovery-${Date.now().toString(36)}`;
-		const artifactsDir = path.join(tempDir, ".pi-subagents", "artifacts");
+		const artifactsDir = path.join(tempDir, ".pi/subagents", "artifacts");
 		executeAsyncSingle(id, {
 			agent: "worker",
 			task: "Complete after generated artifacts are cleaned",
@@ -827,7 +827,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 
 		await waitForMockPiCall(mockPi, 0);
 		assert.equal(fs.existsSync(artifactsDir), true);
-		fs.rmSync(path.join(tempDir, ".pi-subagents"), { recursive: true, force: true });
+		fs.rmSync(path.join(tempDir, ".pi/subagents"), { recursive: true, force: true });
 
 		const payload = await readAsyncPayload(id);
 		assert.equal(payload.success, true);
@@ -1169,7 +1169,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 				includeMetadata: true,
 				cleanupDays: 7,
 			},
-			artifactsDir: path.join(tempDir, ".pi-subagents", "artifacts"),
+			artifactsDir: path.join(tempDir, ".pi/subagents", "artifacts"),
 			shareEnabled: false,
 			maxSubagentDepth: 2,
 			timeoutMs,
@@ -1642,7 +1642,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(status.sessionId, "session-123");
 		assert.equal(status.steps?.[0]?.acceptance?.status, "review-required");
 		assert.equal(status.steps?.[0]?.acceptance?.evidenceStatus, "checked");
-		const outputPath = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", asyncId, "async-top-output.md");
+		const outputPath = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", asyncId, "async-top-output.md");
 		const outputDeadline = Date.now() + 5_000;
 		while (!fs.existsSync(outputPath)) {
 			if (Date.now() > outputDeadline) {
@@ -1655,7 +1655,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.ok(callFile, "expected a recorded mock pi call");
 		const args = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
 		const taskArg = args.at(-1) ?? "";
-		const progressPath = path.join(tempDir, ".pi-subagents", "artifacts", "progress", asyncId, "progress.md");
+		const progressPath = path.join(tempDir, ".pi/subagents", "artifacts", "progress", asyncId, "progress.md");
 		assert.ok(taskArg.includes(`[Read from: ${path.join(tempDir, "input.md")}]`));
 		assert.ok(taskArg.includes(`Update progress at: ${progressPath}`));
 		assert.ok(taskArg.includes(`Write your findings to exactly this path: ${outputPath}`));
@@ -1686,7 +1686,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			assert.equal(payload.success, true);
 			assert.equal(payload.results[0]?.output?.split("\n\nOutput saved to:")[0], "first async report");
 			assert.equal(payload.results[1]?.output?.split("\n\nOutput saved to:")[0], "second async report");
-			const outputDir = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", launch.details?.asyncId as string);
+			const outputDir = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", launch.details?.asyncId as string);
 			const authoritativePaths = [
 				path.join(outputDir, "parallel-0", "0-worker", "context.md"),
 				path.join(outputDir, "parallel-0", "1-worker", "context.md"),
@@ -1755,7 +1755,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 
 		const payload = await readAsyncPayload(launch.details?.asyncId as string);
 		assert.equal(payload.success, true);
-		const outputDir = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", launch.details?.asyncId as string);
+		const outputDir = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", launch.details?.asyncId as string);
 		assert.equal(fs.readFileSync(path.join(outputDir, "first.md"), "utf-8"), "first explicit report");
 		assert.equal(fs.readFileSync(path.join(outputDir, "second.md"), "utf-8"), "second explicit report");
 		assert.ok(payload.results[0]?.artifactPaths?.outputPath?.endsWith("_worker_0_output.md"));
@@ -1771,7 +1771,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			agents: [makeAgent("worker", { output: "context.md" })],
 			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-chain-output" },
 			artifactConfig: { enabled: true, includeInput: false, includeOutput: true, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
-			artifactsDir: path.join(tempDir, ".pi-subagents", "artifacts"),
+			artifactsDir: path.join(tempDir, ".pi/subagents", "artifacts"),
 			shareEnabled: false,
 			maxSubagentDepth: 2,
 		});
@@ -1779,7 +1779,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(launch.isError, undefined);
 		const payload = await readAsyncPayload(id);
 		assert.equal(payload.success, true);
-		const outputDir = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", id);
+		const outputDir = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", id);
 		const authoritativePaths = [
 			path.join(outputDir, "parallel-0", "0-worker", "context.md"),
 			path.join(outputDir, "parallel-0", "1-worker", "context.md"),
@@ -2083,7 +2083,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			agents: [makeAgent("producer"), makeAgent("reviewer", { output: "context.md" }), makeAgent("consumer")],
 			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-dynamic" },
 			artifactConfig: { enabled: true, includeInput: false, includeOutput: true, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
-			artifactsDir: path.join(tempDir, ".pi-subagents", "artifacts"),
+			artifactsDir: path.join(tempDir, ".pi/subagents", "artifacts"),
 			shareEnabled: false,
 			maxSubagentDepth: 2,
 		});
@@ -2100,7 +2100,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const collected = payload.outputs?.reviews?.structured as Array<{ key: string; structured: unknown }>;
 		assert.deepEqual(collected.map((item) => item.key), ["src/a.ts", "src/b.ts"]);
 		assert.deepEqual(collected.map((item) => item.structured), [{ ok: "a" }, { ok: "b" }]);
-		const outputDir = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", id);
+		const outputDir = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", id);
 		const dynamicOutputPaths = [
 			path.join(outputDir, "dynamic-1", "0-reviewer", "context.md"),
 			path.join(outputDir, "dynamic-1", "1-reviewer", "context.md"),
@@ -2494,7 +2494,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			const args = await waitForMockPiArgs(mockPi, 0);
 			const taskArg = args.at(-1) ?? "";
 			assert.ok(taskArg.includes(`[Read from: ${path.join(worktreeCwd, "input.md")}]`));
-			assert.ok(taskArg.includes(`Write your findings to exactly this path: ${path.join(repoDir, ".pi-subagents", "artifacts", "outputs", asyncId, "report.md")}`));
+			assert.ok(taskArg.includes(`Write your findings to exactly this path: ${path.join(repoDir, ".pi/subagents", "artifacts", "outputs", asyncId, "report.md")}`));
 			const resultPath = await waitForAsyncResultFile(asyncId, 90_000);
 			const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
 			const status = await waitForAsyncState(asyncId, (candidate) => candidate.state === "complete");

--- a/test/integration/parallel-execution.test.ts
+++ b/test/integration/parallel-execution.test.ts
@@ -406,7 +406,7 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 
 		const runId = result.details?.runId;
 		assert.ok(runId, "expected run id in details");
-		const outputPath = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", runId, "parallel-output.md");
+		const outputPath = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", runId, "parallel-output.md");
 		assert.equal(result.isError, undefined);
 		assert.equal(fs.readFileSync(outputPath, "utf-8"), "Saved report");
 		assert.equal(result.details?.results?.[0]?.savedOutputPath, outputPath);
@@ -485,7 +485,7 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 
 		const runId = result.details?.runId;
 		assert.ok(runId, "expected run id in details");
-		const outputPath = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", runId, "parallel-file-only.md");
+		const outputPath = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", runId, "parallel-file-only.md");
 		const text = result.content[0]?.text ?? "";
 		assert.equal(result.isError, undefined);
 		assert.match(text, /Output saved to:/);
@@ -553,7 +553,7 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 
 			const runId = result.details?.runId;
 			assert.ok(runId, "expected run id in details");
-			const outputDir = path.join(tempDir, ".pi-subagents", "artifacts", "outputs", runId);
+			const outputDir = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", runId);
 			const firstOutputPath = path.join(outputDir, "parallel-0", "0-echo", "context.md");
 			const secondOutputPath = path.join(outputDir, "parallel-0", "1-echo", "context.md");
 			assert.equal(result.isError, undefined);
@@ -628,7 +628,7 @@ Inspect
 		);
 		const runId = result.details?.runId;
 		assert.ok(runId, "expected run id in details");
-		const expectedProgressPath = path.join(tempDir, ".pi-subagents", "artifacts", "progress", runId, "progress.md");
+		const expectedProgressPath = path.join(tempDir, ".pi/subagents", "artifacts", "progress", runId, "progress.md");
 
 		const args = readLastCallArgs();
 		const taskArg = args.at(-1) ?? "";

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -342,7 +342,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			config,
 			asyncByDefault,
 			tempArtifactsDir: tempDir,
-			getSubagentSessionRoot: () => path.join(tempDir, ".pi-subagents", "sessions"),
+			getSubagentSessionRoot: () => path.join(tempDir, ".pi/subagents", "sessions"),
 			expandTilde: (value: string) => value,
 			discoverAgents: () => ({ agents }),
 			allowMutatingManagementActions,
@@ -773,7 +773,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.details.results.length, 2);
 		assert.equal(result.details.workflow?.value && (result.details.workflow.value as { stateType?: unknown }).stateType, "object");
 		assert.ok(result.details.missionId);
-		const missionDir = path.join(tempDir, ".pi-subagents", "missions");
+		const missionDir = path.join(tempDir, ".pi/subagents", "missions");
 		const missionFiles = fs.readdirSync(missionDir).filter((entry) => entry.endsWith(".json"));
 		assert.equal(missionFiles.length, 1);
 		const mission = JSON.parse(fs.readFileSync(path.join(missionDir, missionFiles[0]!), "utf-8")) as { objective?: string };
@@ -807,7 +807,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.details.missionId, undefined);
 		assert.match(result.details.missionWarning ?? "", /Mission tracking unavailable/);
 		assert.equal(result.details.results.length, 2);
-		const missionDir = path.join(tempDir, ".pi-subagents", "missions");
+		const missionDir = path.join(tempDir, ".pi/subagents", "missions");
 		const missionFiles = fs.existsSync(missionDir) ? fs.readdirSync(missionDir).filter((entry) => entry.endsWith(".json")) : [];
 		assert.equal(missionFiles.length, 1);
 	});
@@ -828,7 +828,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(first.isError, undefined, first.content[0]?.text ?? "first workflow failed");
 		assert.ok(first.details.missionId);
 		assert.deepEqual(first.details.workflow?.value, { count: 1 });
-		const statePath = path.join(tempDir, ".pi-subagents", "missions", first.details.missionId, "state.json");
+		const statePath = path.join(tempDir, ".pi/subagents", "missions", first.details.missionId, "state.json");
 		assert.equal(fs.existsSync(statePath), true);
 
 		const second = await executor.execute(
@@ -1989,7 +1989,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			config: { control: { enabled: true, activeNoticeAfterTurns: 2, activeNoticeAfterMs: 999_999, activeNoticeAfterTokens: 999_999, notifyOn: ["active_long_running"], notifyChannels: ["event"] } },
 			asyncByDefault: false,
 			tempArtifactsDir: tempDir,
-			getSubagentSessionRoot: () => path.join(tempDir, ".pi-subagents", "sessions"),
+			getSubagentSessionRoot: () => path.join(tempDir, ".pi/subagents", "sessions"),
 			expandTilde: (value: string) => value,
 			discoverAgents: () => ({ agents: [makeAgent("echo")] }),
 			allowMutatingManagementActions: true,
@@ -3353,7 +3353,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.details?.artifacts?.dir, expectedDir);
 		assert.ok(result.details?.artifacts?.files[0]?.outputPath.startsWith(`${expectedDir}${path.sep}`));
 		assert.equal(fs.readFileSync(result.details.artifacts.files[0].outputPath, "utf-8"), "session artifact result");
-		assert.equal(fs.existsSync(path.join(tempDir, ".pi-subagents", "artifacts")), false);
+		assert.equal(fs.existsSync(path.join(tempDir, ".pi/subagents", "artifacts")), false);
 	});
 
 	for (const artifactDir of ["session", "temp"] as const) {
@@ -3375,8 +3375,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			const taskArg = readCallArgs().at(-1) ?? "";
 			assert.equal(result.isError, undefined);
 			assert.ok(taskArg.includes(`${CHAIN_RUNS_DIR}${path.sep}`), taskArg);
-			assert.equal(fs.existsSync(path.join(tempDir, ".pi-subagents", "chain-runs")), false);
-			assert.equal(fs.existsSync(path.join(tempDir, ".pi-subagents", "artifacts")), false);
+			assert.equal(fs.existsSync(path.join(tempDir, ".pi/subagents", "chain-runs")), false);
+			assert.equal(fs.existsSync(path.join(tempDir, ".pi/subagents", "artifacts")), false);
 		});
 	}
 
@@ -3476,7 +3476,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		const taskArg = readCallArgs().at(-1) ?? "";
 		assert.equal(result.isError, undefined);
-		assert.match(taskArg, new RegExp(`Write your findings to exactly this path: ${escapeRegExp(path.join(tempDir, ".pi-subagents", "artifacts", "outputs"))}.*context\\.md`));
+		assert.match(taskArg, new RegExp(`Write your findings to exactly this path: ${escapeRegExp(path.join(tempDir, ".pi/subagents", "artifacts", "outputs"))}.*context\\.md`));
 		assert.equal(fs.existsSync(path.join(tempDir, "context.md")), false);
 	});
 

--- a/test/unit/agent-refinements.test.ts
+++ b/test/unit/agent-refinements.test.ts
@@ -37,7 +37,7 @@ function writeProjectAgent(name = "worker"): void {
 }
 
 function writeEvidence(agent = "worker"): void {
-	const dir = path.join(tempDir, ".pi-subagents", "artifacts");
+	const dir = path.join(tempDir, ".pi/subagents", "artifacts");
 	fs.mkdirSync(dir, { recursive: true });
 	fs.writeFileSync(path.join(dir, "run_worker_meta.json"), JSON.stringify({
 		runId: "run",
@@ -64,7 +64,7 @@ describe("agent refinements", () => {
 	});
 
 	it("uses a project-local path and rejects traversal", () => {
-		assert.equal(getAgentRefinementPath(tempDir, "worker"), path.join(tempDir, ".pi-subagents", "refinements", "worker.md"));
+		assert.equal(getAgentRefinementPath(tempDir, "worker"), path.join(tempDir, ".pi/subagents", "refinements", "worker.md"));
 		assert.throws(() => getAgentRefinementPath(tempDir, "../worker"), /cannot be used/);
 	});
 

--- a/test/unit/artifacts.test.ts
+++ b/test/unit/artifacts.test.ts
@@ -30,35 +30,35 @@ describe("project-local artifact paths", () => {
 
 	it("warns only when package settings can include project artifacts", () => {
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "unsafe" })) ?? "", /\.npmignore/);
-		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "gitignored" }, { name: ".gitignore", content: ".pi-subagents/\n" })), undefined);
-		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "globignored" }, { name: ".npmignore", content: "**/.pi-subagents/**\n" })), undefined);
-		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "classignored" }, { name: ".npmignore", content: "[.]pi-subagents/**\n" })), undefined);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "explicit-files-over-ignore", files: [".pi-subagents/**"] }, { name: ".npmignore", content: ".pi-subagents/\n" })) ?? "", /artifactDir/);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "gitignored" }, { name: ".gitignore", content: ".pi/subagents/\n" })), undefined);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "globignored" }, { name: ".npmignore", content: "**/.pi/subagents/**\n" })), undefined);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "classignored" }, { name: ".npmignore", content: "[.]pi/subagents/**\n" })), undefined);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "explicit-files-over-ignore", files: [".pi/subagents/**"] }, { name: ".npmignore", content: ".pi/subagents/\n" })) ?? "", /artifactDir/);
 		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "restricted", files: ["src/**"] })), undefined);
 		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "malformed-pattern", files: ["[z-a]"] })), undefined);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "broad", files: ["**/*"] })) ?? "", /artifactDir/);
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "root-wildcard", files: ["*"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "included", files: [".pi-subagents/**"] })) ?? "", /artifactDir/);
-		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "excluded-after-include", files: [".pi-subagents/**", "!.pi-subagents/**"] })), undefined);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "artifacts-included", files: [".pi-subagents/artifacts/**"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "artifacts-directory-included", files: [".pi-subagents/artifacts"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-input-included", files: [".pi-subagents/artifacts/*_input.md"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-output-included", files: [".pi-subagents/artifacts/*_output.md"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-jsonl-included", files: [".pi-subagents/artifacts/*.jsonl"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-meta-included", files: [".pi-subagents/artifacts/*_meta.json"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "progress-included", files: [".pi-subagents/artifacts/progress/**"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "outputs-included", files: [".pi-subagents/artifacts/outputs/**"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "nested-output-included", files: [".pi-subagents/artifacts/outputs/*/*.md"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "chain-runs-included", files: [".pi-subagents/chain-runs/**"] })) ?? "", /artifactDir/);
-		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "chain-runs-directory-included", files: [".pi-subagents/chain-runs"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "included", files: [".pi/subagents/**"] })) ?? "", /artifactDir/);
+		assert.equal(getProjectArtifactPackagingWarning(packageDir({ name: "excluded-after-include", files: [".pi/subagents/**", "!.pi/subagents/**"] })), undefined);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "artifacts-included", files: [".pi/subagents/artifacts/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "artifacts-directory-included", files: [".pi/subagents/artifacts"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-input-included", files: [".pi/subagents/artifacts/*_input.md"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-output-included", files: [".pi/subagents/artifacts/*_output.md"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-jsonl-included", files: [".pi/subagents/artifacts/*.jsonl"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "dynamic-meta-included", files: [".pi/subagents/artifacts/*_meta.json"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "progress-included", files: [".pi/subagents/artifacts/progress/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "outputs-included", files: [".pi/subagents/artifacts/outputs/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "nested-output-included", files: [".pi/subagents/artifacts/outputs/*/*.md"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "chain-runs-included", files: [".pi/subagents/chain-runs/**"] })) ?? "", /artifactDir/);
+		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "chain-runs-directory-included", files: [".pi/subagents/chain-runs"] })) ?? "", /artifactDir/);
 	});
 
-	it("places generated subagent files under .pi-subagents for a project cwd", () => {
+	it("places generated subagent files under .pi/subagents for a project cwd", () => {
 		const cwd = path.join("tmp", "repo");
-		assert.equal(getProjectSubagentsDir(cwd), path.join(cwd, ".pi-subagents"));
-		assert.equal(getProjectArtifactsDir(cwd), path.join(cwd, ".pi-subagents", "artifacts"));
-		assert.equal(getProjectChainRunsDir(cwd), path.join(cwd, ".pi-subagents", "chain-runs"));
-		assert.equal(getArtifactsDir(null, cwd), path.join(cwd, ".pi-subagents", "artifacts"));
+		assert.equal(getProjectSubagentsDir(cwd), path.join(cwd, ".pi/subagents"));
+		assert.equal(getProjectArtifactsDir(cwd), path.join(cwd, ".pi/subagents", "artifacts"));
+		assert.equal(getProjectChainRunsDir(cwd), path.join(cwd, ".pi/subagents", "chain-runs"));
+		assert.equal(getArtifactsDir(null, cwd), path.join(cwd, ".pi/subagents", "artifacts"));
 	});
 
 	it("routes chain scratch files according to the artifact preference", () => {

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -76,7 +76,7 @@ describe("Herdr inspector", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-inspector-"));
 		try {
 			const { asyncDir } = writeRun(root);
-			const missionDir = path.join(root, "other-project", ".pi-subagents", "missions");
+			const missionDir = path.join(root, "other-project", ".pi/subagents", "missions");
 			fs.writeFileSync(path.join(asyncDir, "mission.json"), JSON.stringify({
 				schemaVersion: 1,
 				missionId: "mission-cross-project",
@@ -296,7 +296,7 @@ describe("Herdr inspector", () => {
 			assert.equal(status.isError, undefined, text(status));
 			assert.match(text(status), /w1:p32 is open/);
 			const legacyBinding = readHerdrProjectPaneBinding(root)!;
-			fs.writeFileSync(path.join(root, ".pi-subagents", "project-panes", "herdr.json"), JSON.stringify({ ...legacyBinding, startupMessage: 42 }));
+			fs.writeFileSync(path.join(root, ".pi/subagents", "project-panes", "herdr.json"), JSON.stringify({ ...legacyBinding, startupMessage: 42 }));
 			const closed = await handleHerdrProjectPaneAction("project.close", { cwd: root }, { cwd: root, client });
 			assert.equal(closed.isError, undefined, text(closed));
 			assert.equal(readHerdrProjectPaneBinding(root), undefined);

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -126,7 +126,7 @@ Project prompt.
 			assert.equal(result.contract.tools.capabilityAudit?.removedExtensionCount, 1);
 			assert.equal(result.contract.tools.disableAmbientExtensions, true);
 			assert.equal(result.contract.roots.sessionFile, path.join(sessionRoot, "run-123", "run-0", "session.jsonl"));
-			assert.equal(result.contract.roots.outputPath, path.join(cwd, ".pi-subagents", "artifacts", "outputs", "run-123", "report.md"));
+			assert.equal(result.contract.roots.outputPath, path.join(cwd, ".pi/subagents", "artifacts", "outputs", "run-123", "report.md"));
 			assert.equal(result.contract.roots.lifecycle?.statusPath.endsWith(path.join("run-123", "status.json")), true);
 			assert.equal(result.contract.roots.lifecycle?.eventsPath.endsWith(path.join("run-123", "events.jsonl")), true);
 			assert.equal(result.contract.roots.lifecycle?.processTerminalPath.endsWith(path.join("run-123", "process-terminal.json")), true);
@@ -147,7 +147,7 @@ Project prompt.
 			assert.equal(repeated.ok, true);
 			assert.equal(repeated.contract.digest, result.contract.digest);
 			assert.equal(fs.existsSync(sessionRoot), false);
-			assert.equal(fs.existsSync(path.join(cwd, ".pi-subagents")), false);
+			assert.equal(fs.existsSync(path.join(cwd, ".pi/subagents")), false);
 		} finally {
 			handle.dispose();
 		}

--- a/test/unit/project-panes-public-api.test.ts
+++ b/test/unit/project-panes-public-api.test.ts
@@ -123,7 +123,8 @@ describe("public project-panes package export", () => {
 	it("returns a structured error and closes the pane when binding persistence fails", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-write-failure-"));
 		try {
-			fs.writeFileSync(path.join(root, ".pi-subagents"), "directory collision");
+			fs.mkdirSync(path.join(root, ".pi"));
+			fs.writeFileSync(path.join(root, ".pi/subagents"), "directory collision");
 			const calls: string[][] = [];
 			const client: ProjectPaneCommandClient = {
 				run: async <T>(args: string[]) => {

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -107,7 +107,7 @@ describe("schedule helpers", () => {
 		const root = path.join("tmp", "schedules");
 		assert.equal(scheduledRunStorePath("project", "a", root), scheduledRunStorePath("project", "b", root));
 		assert.notEqual(scheduledRunStorePath("project", "a", root), scheduledRunStorePath("other", "a", root));
-		assert.equal(scheduledRunStorePath("/project"), path.join(path.resolve("/project"), ".pi-subagents", "schedules"));
+		assert.equal(scheduledRunStorePath("/project"), path.join(path.resolve("/project"), ".pi/subagents", "schedules"));
 	});
 
 	it("parses one-shot and fixed interval forms strictly", () => {
@@ -261,7 +261,7 @@ describe("project schedule management", () => {
 		assert.equal(fs.existsSync(path.join(outside, "schedule.json")), false);
 	});
 
-	it("rejects a default project schedule root that escapes through .pi-subagents", async () => {
+	it("rejects a default project schedule root that escapes through .pi/subagents", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-schedule-root-link-"));
 		roots.push(root);
 		const project = path.join(root, "project");
@@ -274,7 +274,8 @@ describe("project schedule management", () => {
 			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
 		});
 		manager.bindSession(ctx);
-		fs.symlinkSync(outside, path.join(project, ".pi-subagents"), process.platform === "win32" ? "junction" : "dir");
+		fs.mkdirSync(path.join(project, ".pi"));
+		fs.symlinkSync(outside, path.join(project, ".pi/subagents"), process.platform === "win32" ? "junction" : "dir");
 
 		const result = await manager.handleToolCall({ action: "schedule.create", id: "escaped-root", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, ctx);
 		assert.equal(result.isError, true);

--- a/test/unit/single-output.test.ts
+++ b/test/unit/single-output.test.ts
@@ -76,8 +76,8 @@ describe("resolveSingleOutputPath", () => {
 	});
 
 	it("resolves relative output paths against an explicit artifact base", () => {
-		const resolved = resolveSingleOutputPath("reviews/report.md", "/runtime", "/requested", "/repo/.pi-subagents/artifacts/outputs/run-1");
-		assert.equal(resolved, path.resolve("/repo/.pi-subagents/artifacts/outputs/run-1", "reviews/report.md"));
+		const resolved = resolveSingleOutputPath("reviews/report.md", "/runtime", "/requested", "/repo/.pi/subagents/artifacts/outputs/run-1");
+		assert.equal(resolved, path.resolve("/repo/.pi/subagents/artifacts/outputs/run-1", "reviews/report.md"));
 	});
 });
 

--- a/test/unit/workflow-chat-progress.test.ts
+++ b/test/unit/workflow-chat-progress.test.ts
@@ -152,8 +152,8 @@ describe("workflow chat progress rendering", () => {
 		try {
 			const location = {
 				projectRoot: root,
-				missionDir: path.join(root, ".pi-subagents", "missions"),
-				globalIndexDir: path.join(root, ".pi-subagents", "mission-index"),
+				missionDir: path.join(root, ".pi/subagents", "missions"),
+				globalIndexDir: path.join(root, ".pi/subagents", "mission-index"),
 				writeGlobalIndex: false,
 			};
 			const mission = createMission(location, { title: "Workflow", objective: "Track child" });
@@ -177,8 +177,8 @@ describe("workflow chat progress rendering", () => {
 		try {
 			const location = {
 				projectRoot: root,
-				missionDir: path.join(root, ".pi-subagents", "missions"),
-				globalIndexDir: path.join(root, ".pi-subagents", "mission-index"),
+				missionDir: path.join(root, ".pi/subagents", "missions"),
+				globalIndexDir: path.join(root, ".pi/subagents", "mission-index"),
 				writeGlobalIndex: false,
 			};
 			const mission = createMission(location, { title: "Workflow", objective: "Track child" });

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -163,8 +163,8 @@ describe("worktree", () => {
 		const repoDir = createRepo("pi-worktree-runtime-artifacts-");
 		let setup: WorktreeSetup | undefined;
 		try {
-			fs.mkdirSync(path.join(repoDir, ".pi-subagents", "missions"), { recursive: true });
-			fs.writeFileSync(path.join(repoDir, ".pi-subagents", "missions", "mission.json"), "{}\n", "utf-8");
+			fs.mkdirSync(path.join(repoDir, ".pi/subagents", "missions"), { recursive: true });
+			fs.writeFileSync(path.join(repoDir, ".pi/subagents", "missions", "mission.json"), "{}\n", "utf-8");
 			setup = createWorktrees(repoDir, "runtime-artifacts", 1);
 			assert.equal(setup.worktrees.length, 1);
 		} finally {


### PR DESCRIPTION
Closes #971.

This moves project-scoped pi-subagents storage from a root `.pi-subagents/` directory to `.pi/subagents/` so project roots stay cleaner.

The hard cutover updates project artifact helpers and callers for artifacts, chain runs, missions, schedules, refinements, project panes, fallback recovery agent paths, generated ignores, docs, and path assertions. Shared temp and session storage behavior is unchanged.

Validation:
- `npm test -- --test-reporter=spec test/unit/artifacts.test.ts test/unit/scheduled-runs.test.ts test/unit/worktree.test.ts test/unit/project-panes-public-api.test.ts test/unit/herdr-inspector.test.ts test/unit/agent-refinements.test.ts test/unit/preflight.test.ts test/unit/workflow-chat-progress.test.ts` passed through the unit script.
- `npm run typecheck`
- `git diff --check`
- The broad focused integration subset hit the repeated scheduled-workflow result-file timing flake. The exact failing test then passed with `env -u PI_SUBAGENT_CHILD node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'scheduled workflows keep owner status and registries isolated from the live session' test/integration/async-execution.test.ts`.

Fresh review found no issues on the exact rebased head.

Thanks to @yceachan for #971.
