### PR TITLE
perf: avoid discarded widget line rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 - Move project-scoped pi-subagents storage from `.pi-subagents/` to `.pi/subagents/` for cleaner project roots. Thanks to @yceachan for #971.
 - Clarify the accepted mission launch object contract for tool callers.
-- Reduce repeated async status parsing and workflow trace projection work.
+- Reduce repeated async status parsing, workflow trace projection, and constrained widget rendering work.
 - Keep parsed async statuses cached beyond 50 runs while preserving per-read freshness checks. Thanks to @bcanvural for #982.
 
 ### Fixed

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1416,10 +1416,10 @@ function fitWidgetLineBudget(lines: string[], theme: Theme, width: number, expan
 	return [...lines.slice(0, visibleLines), truncLine(theme.fg("dim", hint), width)];
 }
 
-function fitAdaptiveWidgetLines(jobs: AsyncJobState[], lines: string[], theme: Theme, width: number, expanded: boolean, frame?: number): string[] {
+function fitAdaptiveWidgetLines(jobs: AsyncJobState[], buildLines: () => string[], theme: Theme, width: number, expanded: boolean, frame?: number): string[] {
 	if (expanded) {
 		resetWidgetLayoutSession();
-		return fitWidgetLineBudget(lines, theme, width, true);
+		return fitWidgetLineBudget(buildLines(), theme, width, true);
 	}
 
 	const hasMatchingSession = widgetSessionMatches(expanded);
@@ -1437,6 +1437,7 @@ function fitAdaptiveWidgetLines(jobs: AsyncJobState[], lines: string[], theme: T
 		return rendered.lines;
 	}
 
+	const lines = buildLines();
 	if (lines.length <= availableRows) {
 		widgetLayoutSession = { expanded, rows, columns, tier: "full", visibleJobKeys: [] };
 		return fitWidgetLineBudget(lines, theme, width, false);
@@ -1458,12 +1459,12 @@ function buildWidgetComponent(jobs: AsyncJobState[], expanded: boolean): (_tui: 
 		const container = new Container();
 		container.render = (renderWidth: number): string[] => {
 			const width = Math.max(0, renderWidth - 2);
-			const lines = expanded
+			const buildLines = (): string[] => expanded
 				? buildWidgetLines(jobs, theme, width, true)
 				: jobs.length === 1
 					? compactSingleWidgetLines(jobs[0]!, theme, width)
 					: buildWidgetLines(jobs, theme, width, false);
-			return fitAdaptiveWidgetLines(jobs, lines, theme, width, expanded).map((line) => paddedWidgetLine(line, renderWidth));
+			return fitAdaptiveWidgetLines(jobs, buildLines, theme, width, expanded).map((line) => paddedWidgetLine(line, renderWidth));
 		};
 		return container;
 	};

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -562,7 +562,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		});
 		assert.match(launch.details.launchContractDigest ?? "", /^[a-f0-9]{64}$/);
 		const payload = await readAsyncPayload(id);
-		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
+		const status = await waitForAsyncState(id, (candidate) => candidate.state === "complete" && candidate.runtimeAcknowledgedExtensions !== undefined);
 		assert.equal(payload.launchContractDigest, launch.details.launchContractDigest);
 		assert.equal(payload.results[0]?.launchContractDigest, launch.details.launchContractDigest);
 		assert.equal(status.launchContractDigest, launch.details.launchContractDigest);
@@ -4559,15 +4559,17 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	});
 
 	it("subagent_wait wakes when an async child is waiting on contact_supervisor", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const id = `async-supervisor-attention-${Date.now().toString(36)}`;
+		const replyReleasePath = path.join(tempDir, `${id}.reply`);
+		const finalReleasePath = path.join(tempDir, `${id}.final`);
 		mockPi.onCall({
 			steps: [
 				{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need a decision" })] },
-				{ delay: 5_000, jsonl: [events.toolEnd("contact_supervisor"), events.toolResult("contact_supervisor", "**Reply from supervisor:**\nProceed")] },
-				{ delay: 2_500, jsonl: [events.assistantMessage("Done")] },
+				{ waitForPath: replyReleasePath, jsonl: [events.toolEnd("contact_supervisor"), events.toolResult("contact_supervisor", "**Reply from supervisor:**\nProceed")] },
+				{ waitForPath: finalReleasePath, jsonl: [events.assistantMessage("Done")] },
 			],
 		});
 
-		const id = `async-supervisor-attention-${Date.now().toString(36)}`;
 		const asyncDir = path.join(ASYNC_DIR, id);
 		const eventsPath = path.join(asyncDir, "events.jsonl");
 		const resultPath = path.join(RESULTS_DIR, `${id}.json`);
@@ -4591,55 +4593,71 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			},
 		});
 
-		const attentionDeadline = Date.now() + 10_000;
-		let statusDuringAttention: AsyncStatusPayload | undefined;
-		while (Date.now() < attentionDeadline && !fs.existsSync(resultPath)) {
-			if (fs.existsSync(statusPath)) {
+		const releaseMockChild = () => {
+			if (!fs.existsSync(replyReleasePath)) fs.writeFileSync(replyReleasePath, "release", "utf-8");
+			if (!fs.existsSync(finalReleasePath)) fs.writeFileSync(finalReleasePath, "release", "utf-8");
+		};
+		const releaseSupervisorReply = () => {
+			if (!fs.existsSync(replyReleasePath)) fs.writeFileSync(replyReleasePath, "release", "utf-8");
+		};
+		try {
+			const attentionDeadline = Date.now() + 10_000;
+			let statusDuringAttention: AsyncStatusPayload | undefined;
+			while (Date.now() < attentionDeadline && !fs.existsSync(resultPath)) {
+				if (fs.existsSync(statusPath)) {
+					const nextStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatusPayload;
+					if (nextStatus.currentTool === "contact_supervisor" && nextStatus.activityState === "needs_attention") {
+						statusDuringAttention = nextStatus;
+						break;
+					}
+				}
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
+			assert.ok(statusDuringAttention, "expected status.json to expose the blocking supervisor request");
+
+			try {
+				const waitResult = await waitForSubagents({ id, timeoutMs: 3_500 }, undefined, {
+					state: { currentSessionId: "session-1", foregroundRuns: new Map(), asyncJobs: new Map(), cleanupTimers: new Map(), resultFileCoalescer: new Map() },
+					pollIntervalMs: 100,
+					events: createEventBus(),
+				});
+				const waitText = waitResult.content[0]?.text ?? "";
+				assert.equal(waitResult.isError, undefined);
+				assert.match(waitText, /attention required/i);
+				assert.match(waitText, new RegExp(id));
+				assert.match(waitText, /intercom\(\{ action: "pending" \}\)/);
+				assert.equal(fs.existsSync(resultPath), false, "wait should return before the child completes");
+			} finally {
+				releaseSupervisorReply();
+			}
+
+			const eventText = fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf-8") : "";
+			assert.match(eventText, /"type":"needs_attention"/);
+			assert.match(eventText, /"reason":"supervisor_request"/);
+			assert.equal(statusDuringAttention.activityState, "needs_attention");
+			assert.equal(statusDuringAttention.steps?.[0]?.activityState, "needs_attention");
+			assert.equal(statusDuringAttention.currentTool, "contact_supervisor");
+			assert.equal(statusDuringAttention.steps?.[0]?.currentTool, "contact_supervisor");
+
+			const clearDeadline = Date.now() + 10_000;
+			let statusAfterReply: AsyncStatusPayload | undefined;
+			while (Date.now() < clearDeadline && !fs.existsSync(resultPath)) {
 				const nextStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatusPayload;
-				if (nextStatus.currentTool === "contact_supervisor" && nextStatus.activityState === "needs_attention") {
-					statusDuringAttention = nextStatus;
+				if (nextStatus.state === "running" && !nextStatus.currentTool && !nextStatus.steps?.[0]?.currentTool) {
+					statusAfterReply = nextStatus;
 					break;
 				}
+				await new Promise((resolve) => setTimeout(resolve, 100));
 			}
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			assert.ok(statusAfterReply, "expected the child to keep running after the supervisor reply");
+			assert.equal(statusAfterReply.activityState, undefined);
+			assert.equal(statusAfterReply.steps?.[0]?.activityState, undefined);
+
+			fs.writeFileSync(finalReleasePath, "release", "utf-8");
+			await waitForAsyncResultFile(id);
+		} finally {
+			releaseMockChild();
 		}
-		assert.ok(statusDuringAttention, "expected status.json to expose the blocking supervisor request");
-
-		const waitResult = await waitForSubagents({ id, timeoutMs: 3_500 }, undefined, {
-			state: { currentSessionId: "session-1", foregroundRuns: new Map(), asyncJobs: new Map(), cleanupTimers: new Map(), resultFileCoalescer: new Map() },
-			pollIntervalMs: 100,
-			events: createEventBus(),
-		});
-		const waitText = waitResult.content[0]?.text ?? "";
-		assert.equal(waitResult.isError, undefined);
-		assert.match(waitText, /attention required/i);
-		assert.match(waitText, new RegExp(id));
-		assert.match(waitText, /intercom\(\{ action: "pending" \}\)/);
-		assert.equal(fs.existsSync(resultPath), false, "wait should return before the child completes");
-
-		const eventText = fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf-8") : "";
-		assert.match(eventText, /"type":"needs_attention"/);
-		assert.match(eventText, /"reason":"supervisor_request"/);
-		assert.equal(statusDuringAttention.activityState, "needs_attention");
-		assert.equal(statusDuringAttention.steps?.[0]?.activityState, "needs_attention");
-		assert.equal(statusDuringAttention.currentTool, "contact_supervisor");
-		assert.equal(statusDuringAttention.steps?.[0]?.currentTool, "contact_supervisor");
-
-		const clearDeadline = Date.now() + 10_000;
-		let statusAfterReply: AsyncStatusPayload | undefined;
-		while (Date.now() < clearDeadline && !fs.existsSync(resultPath)) {
-			const nextStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatusPayload;
-			if (nextStatus.state === "running" && !nextStatus.currentTool && !nextStatus.steps?.[0]?.currentTool) {
-				statusAfterReply = nextStatus;
-				break;
-			}
-			await new Promise((resolve) => setTimeout(resolve, 100));
-		}
-		assert.ok(statusAfterReply, "expected the child to keep running after the supervisor reply");
-		assert.equal(statusAfterReply.activityState, undefined);
-		assert.equal(statusAfterReply.steps?.[0]?.activityState, undefined);
-
-		await waitForAsyncResultFile(id);
 	});
 
 	it("background runs escalate repeated mutating tool failures", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -1018,7 +1018,7 @@ describe("result watcher", () => {
 
 				fs.rmSync(registryPath, { force: true });
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 650));
+				assert.equal(await waitForPredicate(() => !fs.existsSync(resultPath) && emitted.some((entry) => entry.event === "subagent:async-complete")), true);
 			} finally {
 				console.error = originalError;
 				watcher.stopResultWatcher();


### PR DESCRIPTION
This reduces repeated work in constrained async widget renders.

`fitAdaptiveWidgetLines()` now builds full-detail rows lazily for established collapsed `single-line` and `progressive` sessions. First renders, resized renders, expanded renders, and full-detail/full-tier paths still build full rows, so status and progress freshness are unchanged.

The PR also keeps the deterministic integration-test fixes added during gate hardening:
- supervisor-attention wait uses release files instead of fixed sleeps;
- result-watcher retry waits for the actual deletion and completion event;
- launch-digest assertions wait for final status metadata.

Validation after rebasing on current main:
- focused render/widget tests passed;
- exact supervisor-attention test passed;
- exact result-watcher retry test passed;
- exact launch-digest test passed;
- `npm run typecheck` passed;
- `git diff --check` passed;
- fresh review found no blockers.

Benchmark from the original candidate showed constrained async-widget component rendering improved by 79.9% to 92.0%, with `setWidget` and `requestRender` counts unchanged.
