### PR TITLE
perf: retain async status cache entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Move project-scoped pi-subagents storage from `.pi-subagents/` to `.pi/subagents/` for cleaner project roots. Thanks to @yceachan for #971.
 - Clarify the accepted mission launch object contract for tool callers.
 - Reduce repeated async status parsing and workflow trace projection work.
+- Keep parsed async statuses cached beyond 50 runs while preserving per-read freshness checks. Thanks to @bcanvural for #982.
 
 ### Fixed
 - Keep tool argument previews on one physical terminal line so live widget updates do not leave stacked terminal frames. Thanks to @xz-dev for #972.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -4,7 +4,7 @@ import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "
 import { formatActivityLabel, formatParallelOutcome } from "../../shared/status-format.ts";
 import { type ActivityState, type AsyncJobStep, type AsyncParallelGroupStatus, type AsyncStatus, type CostSummary, type Details, type LaunchResolvedChildExtensionsV1, type RuntimeAcknowledgedChildExtensionsV1, type NestedRunSummary, type SteeringStatus, type SubagentRunMode, type TokenUsage, type TurnBudgetState, type UsageBudgetState, type ChainCheckpointState } from "../../shared/types.ts";
 import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../shared/capability-ceiling.ts";
-import { readStatus } from "../../shared/utils.ts";
+import { pruneStatusCacheForAsyncRoot, readStatus } from "../../shared/utils.ts";
 import { attachRootChildrenToSteps, buildNestedRouteIndex, type NestedRoute, projectNestedEvents } from "../shared/nested-events.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { flatToLogicalStepIndex, normalizeParallelGroups } from "./parallel-groups.ts";
@@ -370,6 +370,7 @@ function sortRuns(runs: AsyncRunSummary[]): AsyncRunSummary[] {
 
 export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions = {}): AsyncRunSummary[] {
 	let entries: string[];
+	let scannedCompleteRoot = false;
 	try {
 		if (options.runId !== undefined) {
 			const resolution = resolveTargetedAsyncRun(asyncDirRoot, options.runId, options.sessionId);
@@ -383,6 +384,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 					: [];
 		} else {
 			entries = fs.readdirSync(asyncDirRoot).filter((entry) => isAsyncRunDir(asyncDirRoot, entry));
+			scannedCompleteRoot = true;
 		}
 	} catch (error) {
 		if (isNotFoundError(error)) return [];
@@ -392,6 +394,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 	}
 
 	if (options.entryLimit !== undefined) {
+		scannedCompleteRoot = false;
 		const limit = Math.max(0, Math.floor(options.entryLimit));
 		entries = entries
 			.map((entry) => {
@@ -409,6 +412,8 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 			.slice(0, limit)
 			.map((candidate) => candidate.entry);
 	}
+
+	if (scannedCompleteRoot) pruneStatusCacheForAsyncRoot(asyncDirRoot, entries);
 
 	const allowedStates = options.states ? new Set(options.states) : undefined;
 	const runs: AsyncRunSummary[] = [];

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -102,6 +102,23 @@ export function getAgentDir(): string {
 
 const statusCache = new Map<string, { mtime: number; ctime: number; size: number; ino: number; status: AsyncStatus }>();
 
+export function pruneStatusCacheForAsyncRoot(asyncDirRoot: string, runIds: Iterable<string>): number {
+	const root = path.resolve(asyncDirRoot);
+	const currentStatusPaths = new Set(
+		Array.from(runIds, (runId) => path.resolve(root, runId, "status.json")),
+	);
+	let removed = 0;
+	for (const statusPath of statusCache.keys()) {
+		const resolved = path.resolve(statusPath);
+		const relative = path.relative(root, resolved);
+		if (relative && !relative.startsWith("..") && !path.isAbsolute(relative) && !currentStatusPaths.has(resolved)) {
+			statusCache.delete(statusPath);
+			removed++;
+		}
+	}
+	return removed;
+}
+
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
@@ -128,7 +145,10 @@ export function readStatus(asyncDir: string): AsyncStatus | null {
 	try {
 		stat = fs.statSync(statusPath);
 	} catch (error) {
-		if (isNotFoundError(error)) return null;
+		if (isNotFoundError(error)) {
+			statusCache.delete(statusPath);
+			return null;
+		}
 		throw new Error(`Failed to inspect async status file '${statusPath}': ${getErrorMessage(error)}`, {
 			cause: error instanceof Error ? error : undefined,
 		});
@@ -149,7 +169,10 @@ export function readStatus(asyncDir: string): AsyncStatus | null {
 	try {
 		content = fs.readFileSync(statusPath, "utf-8");
 	} catch (error) {
-		if (isNotFoundError(error)) return null;
+		if (isNotFoundError(error)) {
+			statusCache.delete(statusPath);
+			return null;
+		}
 		throw new Error(`Failed to read async status file '${statusPath}': ${getErrorMessage(error)}`, {
 			cause: error instanceof Error ? error : undefined,
 		});
@@ -171,10 +194,6 @@ export function readStatus(asyncDir: string): AsyncStatus | null {
 		ino: stat.ino,
 		status,
 	});
-	if (statusCache.size > 50) {
-		const firstKey = statusCache.keys().next().value;
-		if (firstKey) statusCache.delete(firstKey);
-	}
 	return status;
 }
 

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -230,6 +230,7 @@ interface AsyncExecutionModule {
 
 interface UtilsModule {
 	readStatus(dir: string): { runId: string; state: string; mode: string } | null;
+	pruneStatusCacheForAsyncRoot(root: string, runIds: Iterable<string>): number;
 }
 
 interface TypesModule {
@@ -254,6 +255,7 @@ const isAsyncAvailable = asyncMod?.isAsyncAvailable;
 const executeAsyncSingle = asyncMod?.executeAsyncSingle;
 const executeAsyncChain = asyncMod?.executeAsyncChain;
 const readStatus = utils?.readStatus;
+const pruneStatusCacheForAsyncRoot = utils?.pruneStatusCacheForAsyncRoot;
 const ASYNC_DIR = typesMod?.ASYNC_DIR;
 const RESULTS_DIR = typesMod?.RESULTS_DIR;
 const TEMP_ROOT_DIR = typesMod?.TEMP_ROOT_DIR;
@@ -2518,33 +2520,49 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		}
 	});
 
-	it("readStatus caches unchanged files and invalidates same-mtime replacements", () => {
-		const dir = createTempDir();
+	it("readStatus caches ordered sweeps above 50 files and invalidates same-mtime replacements", () => {
+		const root = createTempDir();
 		try {
-			const statusPath = path.join(dir, "status.json");
 			const fixedTimestamp = new Date(1_700_000_000_000);
-			const statusData = {
-				runId: "cache-test",
-				state: "running",
-				mode: "single",
-				startedAt: fixedTimestamp.getTime(),
-			};
-			fs.writeFileSync(statusPath, JSON.stringify(statusData));
-			fs.utimesSync(statusPath, fixedTimestamp, fixedTimestamp);
+			const dirs = Array.from({ length: 51 }, (_, index) => {
+				const dir = path.join(root, `run-${index}`);
+				const statusPath = path.join(dir, "status.json");
+				fs.mkdirSync(dir);
+				fs.writeFileSync(statusPath, JSON.stringify({
+					runId: `cache-test-${index}`,
+					state: "running",
+					mode: "single",
+					startedAt: fixedTimestamp.getTime(),
+				}));
+				fs.utimesSync(statusPath, fixedTimestamp, fixedTimestamp);
+				return dir;
+			});
 
-			const cached = readStatus(dir);
-			assert.ok(cached);
-			assert.strictEqual(readStatus(dir), cached);
+			const cached = dirs.map((dir) => readStatus(dir));
+			cached.forEach((status) => assert.ok(status));
+			dirs.forEach((dir, index) => assert.strictEqual(readStatus(dir), cached[index]));
 
-			writeAtomicJson(statusPath, { ...statusData, state: "stopped" });
+			const replacedDir = dirs[25]!;
+			const cachedStatus = cached[25];
+			assert.ok(cachedStatus);
+			const statusPath = path.join(replacedDir, "status.json");
+			writeAtomicJson(statusPath, { ...cachedStatus, state: "stopped" });
 			fs.utimesSync(statusPath, fixedTimestamp, fixedTimestamp);
 			assert.equal(fs.statSync(statusPath).mtimeMs, fixedTimestamp.getTime());
-			const replaced = readStatus(dir);
+			const replaced = readStatus(replacedDir);
 			assert.ok(replaced);
 			assert.equal(replaced.state, "stopped");
-			assert.notStrictEqual(replaced, cached);
+			assert.notStrictEqual(replaced, cachedStatus);
+
+			fs.rmSync(statusPath);
+			assert.equal(readStatus(replacedDir), null);
+
+			const removedDir = dirs[50]!;
+			assert.ok(readStatus(removedDir));
+			fs.rmSync(removedDir, { recursive: true, force: true });
+			assert.equal(pruneStatusCacheForAsyncRoot(root, dirs.slice(0, 50).map((dir) => path.basename(dir))), 1);
 		} finally {
-			removeTempDir(dir);
+			removeTempDir(root);
 		}
 	});
 


### PR DESCRIPTION
This improves async status reads for large async-run directories without reducing freshness.

`readStatus()` no longer evicts cached entries at 50 paths. It still performs a `statSync()` on each read and only returns cached JSON when `mtimeMs`, `ctimeMs`, `size`, and `ino` still match, so the status view stays fresh while ordered sweeps over more than 50 runs can reuse parsed JSON.

This update also addresses the Greptile cache-retention concern. Complete async-root scans now prune cached `status.json` entries for run directories that no longer exist. Targeted scans and `entryLimit` subset scans do not prune, so partial views cannot discard valid entries for unscanned runs.

Validation:
- Focused cache regression for more than 50 statuses, same-mtime replacement invalidation, and removed-run pruning.
- `test/integration/async-status.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review found no blockers.

Fixes #982.
