### PR TITLE
fix: animate quiet async running glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Retry transient Windows mission state lock creation failures and stabilize no-session steering recovery coverage.
+- Keep async widget running glyphs moving while children are quiet but active. Thanks to @bcanvural for #983.
 - Accept persisted async recovery descriptors that include internal turn-budget state fields (#985).
 - Keep tool argument previews on one physical terminal line so live widget updates do not leave stacked terminal frames. Thanks to @xz-dev for #972.
 - Recover durable async completions when a healthy native result watcher misses a filesystem event. Thanks to @xz-dev for #973.

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -74,6 +74,19 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			throw error;
 		}
 	};
+	const requestLastWidgetRender = () => {
+		const ctx = state.lastUiContext;
+		if (!ctx || state.widgetsSuspended || options.widgetEnabled === false) return;
+		try {
+			if (ctx.hasUI) (ctx.ui as { requestRender?: () => void }).requestRender?.();
+		} catch (error) {
+			if (error instanceof Error && error.message.includes("extension ctx is stale")) {
+				state.lastUiContext = null;
+				return;
+			}
+			throw error;
+		}
+	};
 	const refreshWidget = (ctx: ExtensionContext) => rerenderWidget(ctx);
 	const restoredControlEventCursor = (asyncDir: string) => {
 		try {
@@ -401,6 +414,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			}
 
 			if (widgetChanged) rerenderLastWidget();
+			else if (Array.from(state.asyncJobs.values()).some((job) => job.status === "running")) requestLastWidgetRender();
 		}, pollIntervalMs);
 		state.poller.unref?.();
 	};

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -16,6 +16,7 @@ import {
 	type NestedStepSummary,
 	type WorkflowNodeStatus,
 	MAX_WIDGET_JOBS,
+	POLL_INTERVAL_MS,
 	WIDGET_KEY,
 } from "../shared/types.ts";
 import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
@@ -627,7 +628,7 @@ function widgetStepActivity(step: NonNullable<AsyncJobState["steps"]>[number], s
 }
 
 
-function widgetChainDetails(job: AsyncJobState, theme: Theme, expanded = false, width = getTermWidth()): string[] {
+function widgetChainDetails(job: AsyncJobState, theme: Theme, expanded = false, width = getTermWidth(), frame?: number): string[] {
 	if (!job.steps?.length) return [];
 	const total = job.chainStepCount ?? job.steps.length;
 	const lines: string[] = [];
@@ -635,7 +636,7 @@ function widgetChainDetails(job: AsyncJobState, theme: Theme, expanded = false, 
 		const steps = job.steps.slice(span.start, span.start + span.count);
 		if (span.isParallel) {
 			const status = aggregateStepStatus(steps);
-			lines.push(`  ${widgetStepGlyph(status, theme, widgetStepsRunningSeed(steps))} Step ${span.stepIndex + 1}/${total}: ${themeBold(theme, "parallel group")} ${theme.fg("dim", "·")} ${theme.fg("dim", formatParallelOutcome(steps, span.count))}`);
+			lines.push(`  ${widgetStepGlyph(status, theme, widgetStepsRunningSeed(steps), frame)} Step ${span.stepIndex + 1}/${total}: ${themeBold(theme, "parallel group")} ${theme.fg("dim", "·")} ${theme.fg("dim", formatParallelOutcome(steps, span.count))}`);
 			continue;
 		}
 		const step = steps[0];
@@ -643,15 +644,15 @@ function widgetChainDetails(job: AsyncJobState, theme: Theme, expanded = false, 
 			lines.push(`  ${theme.fg("dim", `◦ Step ${span.stepIndex + 1}/${total}: pending`)}`);
 			continue;
 		}
-		lines.push(...foregroundStyleWidgetStepLines(job, theme, step, "Step", span.stepIndex + 1, total, expanded, width));
+		lines.push(...foregroundStyleWidgetStepLines(job, theme, step, "Step", span.stepIndex + 1, total, expanded, width, frame));
 	}
 	return lines;
 }
 
-function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded = false, width = getTermWidth()): string[] {
+function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded = false, width = getTermWidth(), frame?: number): string[] {
 	if (!job.steps?.length) return [];
 	if (job.mode !== "parallel" && job.mode !== "chain") return [];
-	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width);
+	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
 	const total = job.stepsTotal ?? job.steps.length;
 	const lines: string[] = [];
 	for (const [index, step] of job.steps.entries()) {
@@ -659,7 +660,7 @@ function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded =
 		const activity = widgetStepActivity(step, job.updatedAt);
 		const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
 		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
-		lines.push(`  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index))} ${itemTitle} ${index + 1}/${total}: ${step.agent} · ${widgetStepStatus(step.status, theme)}${modelDisplay}${activity ? ` · ${activity}` : ""}`)}`);
+		lines.push(`  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${step.agent} · ${widgetStepStatus(step.status, theme)}${modelDisplay}${activity ? ` · ${activity}` : ""}`)}`);
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, expanded ? 8 : 6)) lines.push(`    ${nestedLine}`);
 	}
 	return lines;
@@ -1168,7 +1169,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 		`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
 		...formatNestedWidgetLines(job.nestedChildren, theme, width, expanded, job.updatedAt, expanded ? 12 : 6).map((line) => `  ${line}`),
 	];
-	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width);
+	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
 	const total = job.stepsTotal ?? job.steps.length;
 	const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
 	const lines: string[] = [];
@@ -1459,12 +1460,13 @@ function buildWidgetComponent(jobs: AsyncJobState[], expanded: boolean): (_tui: 
 		const container = new Container();
 		container.render = (renderWidth: number): string[] => {
 			const width = Math.max(0, renderWidth - 2);
+			const frame = Math.floor(Date.now() / POLL_INTERVAL_MS);
 			const buildLines = (): string[] => expanded
-				? buildWidgetLines(jobs, theme, width, true)
+				? buildWidgetLines(jobs, theme, width, true, frame)
 				: jobs.length === 1
-					? compactSingleWidgetLines(jobs[0]!, theme, width)
-					: buildWidgetLines(jobs, theme, width, false);
-			return fitAdaptiveWidgetLines(jobs, buildLines, theme, width, expanded).map((line) => paddedWidgetLine(line, renderWidth));
+					? compactSingleWidgetLines(jobs[0]!, theme, width, frame)
+					: buildWidgetLines(jobs, theme, width, false, frame);
+			return fitAdaptiveWidgetLines(jobs, buildLines, theme, width, expanded, frame).map((line) => paddedWidgetLine(line, renderWidth));
 		};
 		return container;
 	};
@@ -1494,7 +1496,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 		items.push([
 			`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
-			...widgetParallelAgentDetails(job, theme, expanded, width),
+			...widgetParallelAgentDetails(job, theme, expanded, width, frame),
 		]);
 		slots--;
 	}
@@ -1511,7 +1513,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 		items.push([
 			`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
-			...widgetParallelAgentDetails(job, theme, expanded, width),
+			...widgetParallelAgentDetails(job, theme, expanded, width, frame),
 		]);
 		slots--;
 	}

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -514,36 +514,38 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
-	it("rerenders changed polled status but not unchanged bookkeeping", async () => {
+	it("repaints unchanged running widgets without rebuilding them and stops at terminal status", async () => {
 		const asyncRoot = createTempDir("pi-async-job-tracker-");
+		let tracker: ReturnType<AsyncJobTrackerModule["createAsyncJobTracker"]> | undefined;
 		try {
 			const runDir = path.join(asyncRoot, "run-unchanged");
 			fs.mkdirSync(runDir, { recursive: true });
-			const writeStatus = (lastUpdate: number, toolCount?: number) => fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+			const writeStatus = (lastUpdate: number, toolCount?: number, state = "running") => fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
 				runId: "run-unchanged",
 				mode: "single",
-				state: "running",
+				state,
 				startedAt: 1000,
 				lastUpdate,
 				...(toolCount !== undefined ? { toolCount } : {}),
-				steps: [{ agent: "worker", status: "running", startedAt: 1000 }],
+				steps: [{ agent: "worker", status: state === "running" ? "running" : "complete", startedAt: 1000 }],
 			}), "utf-8");
 			writeStatus(2000);
 
 			const state = createState();
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.resetJobs(ui.ctx as never);
 			tracker.handleStarted({ id: "run-unchanged", asyncDir: runDir, agent: "worker" });
 
 			const requestsAfterStart = ui.renderRequests;
-			await new Promise((resolve) => setTimeout(resolve, 35));
+			await waitForCondition(() => state.asyncJobs.get("run-unchanged")?.updatedAt === 2000, "first status load");
 			assert.ok(ui.renderRequests > requestsAfterStart, "first status load should redraw the widget");
 
 			const requestsAfterStatusLoaded = ui.renderRequests;
+			const widgetsAfterStatusLoaded = ui.widgets.length;
 			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
 				type: "subagent.control",
 				channels: ["event"],
@@ -556,14 +558,21 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 					message: "worker needs attention",
 				},
 			})}\n`, "utf-8");
-			await new Promise((resolve) => setTimeout(resolve, 40));
-			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-event"), true);
-			assert.equal(ui.renderRequests, requestsAfterStatusLoaded, "unchanged status and control cursors should not request widget redraws");
+			await waitForCondition(() => recorder.events.some((event) => event.channel === "subagent:control-event"), "control event delivery");
+			await waitForCondition(() => ui.renderRequests > requestsAfterStatusLoaded, "running widget cadence repaint");
+			assert.equal(ui.widgets.length, widgetsAfterStatusLoaded, "unchanged running status must not replace the widget component");
 
 			writeStatus(3000, 1);
-			await new Promise((resolve) => setTimeout(resolve, 40));
-			assert.ok(ui.renderRequests > requestsAfterStatusLoaded, "changed non-terminal status should redraw the widget");
+			await waitForCondition(() => state.asyncJobs.get("run-unchanged")?.toolCount === 1, "changed status load");
+			assert.ok(ui.widgets.length > widgetsAfterStatusLoaded, "changed status should replace the widget component");
+
+			writeStatus(4000, 1, "complete");
+			await waitForCondition(() => state.asyncJobs.get("run-unchanged")?.status === "complete", "terminal status load");
+			const requestsAfterTerminal = ui.renderRequests;
+			await new Promise((resolve) => setTimeout(resolve, 35));
+			assert.equal(ui.renderRequests, requestsAfterTerminal, "terminal-only jobs must not request cadence repaints");
 		} finally {
+			tracker?.resetJobs();
 			removeTempDir(asyncRoot);
 		}
 	});

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -772,26 +772,25 @@ describe("subagent async widget rendering", () => {
 	});
 
 	it("uses logical chain steps after an async chain parallel group finishes", () => {
-		const lines = buildWidgetLines([
-			{
-				asyncId: "run-chain",
-				asyncDir: "/tmp/chain",
-				status: "running",
-				mode: "chain",
-				agents: ["scout", "reviewer", "auditor", "writer"],
-				activeParallelGroup: false,
-				currentStep: 3,
-				chainStepCount: 2,
-				parallelGroups: [{ start: 0, count: 3, stepIndex: 0 }],
-				stepsTotal: 4,
-				steps: [
-					{ index: 0, agent: "scout", status: "complete" },
-					{ index: 1, agent: "reviewer", status: "complete" },
-					{ index: 2, agent: "auditor", status: "complete" },
-					{ index: 3, agent: "writer", status: "running", toolCount: 1 },
-				],
-			},
-		], theme, 180);
+		const job = {
+			asyncId: "run-chain",
+			asyncDir: "/tmp/chain",
+			status: "running",
+			mode: "chain",
+			agents: ["scout", "reviewer", "auditor", "writer"],
+			activeParallelGroup: false,
+			currentStep: 3,
+			chainStepCount: 2,
+			parallelGroups: [{ start: 0, count: 3, stepIndex: 0 }],
+			stepsTotal: 4,
+			steps: [
+				{ index: 0, agent: "scout", status: "complete" },
+				{ index: 1, agent: "reviewer", status: "complete" },
+				{ index: 2, agent: "auditor", status: "complete" },
+				{ index: 3, agent: "writer", status: "running", toolCount: 1 },
+			],
+		};
+		const lines = buildWidgetLines([job], theme, 180, false, 0);
 
 		const text = lines.join("\n");
 		assert.match(text, /async subagent chain \(2\)/);
@@ -802,6 +801,13 @@ describe("subagent async widget rendering", () => {
 		assert.match(text, outputPathPattern("/tmp/chain/output-3.log"));
 		assert.doesNotMatch(text, /step 4\/4/);
 		assert.doesNotMatch(text, /Step 4\/4/);
+
+		const second = buildWidgetLines([job], theme, 180, false, 1);
+		assert.notEqual(
+			firstRunningGlyph(lines.find((line) => line.includes("Step 2/2")) ?? ""),
+			firstRunningGlyph(second.find((line) => line.includes("Step 2/2")) ?? ""),
+			"logical chain step glyph should advance with the render frame",
+		);
 	});
 
 	it("omits zero-running labels for pending active async parallel groups", () => {
@@ -921,7 +927,7 @@ describe("subagent async widget rendering", () => {
 		assert.equal(firstGrapheme(first[1] ?? ""), firstGrapheme(second[1] ?? ""));
 	});
 
-	it("keeps component widget output stable without job data changes", () => {
+	it("advances component running glyphs with the render clock", () => {
 		const originalNow = Date.now;
 		let renderRequests = 0;
 		try {
@@ -939,31 +945,55 @@ describe("subagent async widget rendering", () => {
 				stepsTotal: 1,
 				updatedAt: 1_000,
 				steps: [{ index: 0, agent: "reviewer", status: "running" }],
+			}, {
+				asyncId: "run-other",
+				asyncDir: "/tmp/other",
+				status: "running",
+				mode: "single",
+				agents: ["scout"],
+				updatedAt: 1_000,
 			}]);
 			const component = (ui.widgets.at(-1) as (_tui: { requestRender(): void }, widgetTheme: typeof theme) => { render(width: number): string[] })(
 				{ requestRender: () => { renderRequests += 1; } },
 				theme,
 			);
-			const first = component.render(180).join("\n");
+			const first = component.render(180);
 
-			Date.now = () => 1_600;
-			const second = component.render(180).join("\n");
+			Date.now = () => 1_250;
+			const second = component.render(180);
+			const withoutRunningGlyphs = (lines: string[]) => lines.map((line) => line.replace(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/gu, ""));
 
-			assert.equal(renderRequests, 0, "quiet progress must not schedule editor-wide redraws");
-			assert.equal(second, first, "elapsed wall time alone must not change the widget");
+			assert.equal(renderRequests, 0, "the component must not own the repaint cadence");
+			assert.notDeepEqual(second, first, "the render clock should advance quiet running glyphs");
+			assert.deepEqual(withoutRunningGlyphs(second), withoutRunningGlyphs(first), "only running glyphs should change");
+			assert.notEqual(firstRunningGlyph(first[0] ?? ""), firstRunningGlyph(second[0] ?? ""), "header glyph should advance");
+			assert.notEqual(firstRunningGlyph(first[1] ?? ""), firstRunningGlyph(second[1] ?? ""), "job glyph should advance");
+			assert.notEqual(
+				firstRunningGlyph(first.find((line) => line.includes("Agent 1/1")) ?? ""),
+				firstRunningGlyph(second.find((line) => line.includes("Agent 1/1")) ?? ""),
+				"step glyph should advance",
+			);
 		} finally {
 			Date.now = originalNow;
 			renderWidget(createUiContext().ctx as never, []);
 		}
 	});
 
-	it("does not animate queued-only widgets", async () => {
-		const ui = createUiContext();
-		renderWidget(ui.ctx as never, [{ asyncId: "queued-only", asyncDir: "/tmp/queued", status: "queued", agents: ["planner"] }]);
-		const initialWidgetCount = ui.widgets.length;
-		await new Promise((resolve) => setTimeout(resolve, 190));
-		assert.equal(ui.widgets.length, initialWidgetCount, "static queued widget should not refresh at animation cadence");
-		assert.equal(ui.renderRequests, 0);
+	it("does not animate queued-only widgets", () => {
+		const originalNow = Date.now;
+		try {
+			Date.now = () => 1_000;
+			const ui = createUiContext();
+			renderWidget(ui.ctx as never, [{ asyncId: "queued-only", asyncDir: "/tmp/queued", status: "queued", agents: ["planner"] }]);
+			const component = (ui.widgets.at(-1) as (_tui: unknown, widgetTheme: typeof theme) => { render(width: number): string[] })(undefined, theme);
+			const first = component.render(180);
+			Date.now = () => 1_250;
+			assert.deepEqual(component.render(180), first);
+			assert.equal(ui.renderRequests, 0);
+		} finally {
+			Date.now = originalNow;
+			renderWidget(createUiContext().ctx as never, []);
+		}
 	});
 
 	it("clears legacy result row animation timers", async () => {


### PR DESCRIPTION
## Summary

Fixes #983 by making quiet running async widget glyphs advance from the existing render cadence, even when progress counters do not change.

The tracker now requests a repaint on the existing poll cadence while tracked jobs are running, but it does not rebuild the widget with `setWidget()` unless status data changes. Queued-only and terminal widgets stay static.

Thanks to @bcanvural for reporting #983.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'uses logical chain steps after an async chain parallel group finishes|advances component running glyphs with the render clock|does not animate queued-only widgets' test/integration/render-widget.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'repaints unchanged running widgets without rebuilding them and stops at terminal status' test/integration/async-job-tracker.test.ts`
- `npm run typecheck`
- `git diff --check`

No release or tag is included.
