### PR TITLE
Enforce strict subagent model scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Add optional strict model-scope enforcement that rejects inherited and fallback models outside the configured allowlist. Thanks to @antonioc-cl for #995.
 - Trim legacy chain-control schema fields and guidance by default, with `legacyChainControls: true` available for direct legacy chain management. Thanks to @tajquitgenius for #977.
 - Move project-scoped pi-subagents storage from `.pi-subagents/` to `.pi/subagents/` for cleaner project roots. Thanks to @yceachan for #971.
 - Clarify the accepted mission launch object contract for tool callers.

--- a/docs/models.md
+++ b/docs/models.md
@@ -150,6 +150,7 @@ To keep subagents inside a budget or compliance profile, enforce a model scope. 
   "subagents": {
     "modelScope": {
       "enforce": true,
+      "strict": true,
       "allow": ["anthropic/*", "openai/gpt-5-*"]
     }
   }
@@ -158,7 +159,8 @@ To keep subagents inside a budget or compliance profile, enforce a model scope. 
 
 - `allow` is a list of glob patterns matched against the resolved `provider/id` (only `*` is special, case-insensitive). A resolved model that matches none of the patterns is rejected.
 - Models you pass explicitly — the tool-call `model`, `--model`, or a clarify pick — error and abort the run.
-- Models that come from agent frontmatter, `subagents.defaultModel`, or the inherited parent session model only warn, so existing configurations keep working while you tighten the scope.
+- By default, models from agent frontmatter, `subagents.defaultModel`, the inherited parent session model, or fallback chains only warn and remain available, so existing configurations keep working while you tighten the scope.
+- Set `strict: true` with `enforce: true` to reject every resolved out-of-scope model. This includes inherited models and fallback candidates. An invalid fallback fails the run instead of being removed from the candidate chain.
 - `enforce: true` requires a non-empty `allow` list; otherwise the config is rejected at load time.
 
 ## Profiles and provider model catalogs

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -191,7 +191,8 @@ function defaultScopeWarn(violation: ModelScopeViolation): void {
  *
  * An explicitly requested model string is resolved via {@link resolveModelCandidate}.
  * When `options.scope.enforce` is on, an out-of-scope resolved model throws for
- * an explicit (`source: "explicit"`) request and warns for an inherited one.
+ * an explicit (`source: "explicit"`) request and warns for an inherited one,
+ * unless strict scope enforcement makes inherited violations hard errors.
  */
 export function resolveSubagentModelOverride(
 	requestedModel: string | boolean | undefined,
@@ -245,7 +246,7 @@ export function resolveEffectiveSubagentModel(
 }
 
 export interface BuildModelCandidatesOptions {
-	/** Fallback models are inherited agent config and warn, rather than error, when out of scope. */
+	/** Fallback models warn by default and throw when strict scope enforcement is enabled. */
 	scope?: ModelScopeConfig;
 	onWarn?: (violation: ModelScopeViolation) => void;
 }
@@ -265,9 +266,12 @@ export function buildModelCandidates(
 		if (!raw) continue;
 		const normalized = resolveModelCandidate(raw.trim(), availableModels, preferredProvider);
 		if (!normalized || seen.has(normalized)) continue;
-		if (index > 0 && options?.scope?.enforce) {
+		if ((index > 0 || options?.scope?.strict === true) && options?.scope?.enforce) {
 			const violation = checkModelScope(normalized, options.scope, "inherited");
-			if (violation) (options.onWarn ?? defaultScopeWarn)(violation);
+			if (violation) {
+				if (violation.severity === "error") throw new Error(violation.message);
+				(options.onWarn ?? defaultScopeWarn)(violation);
+			}
 		}
 		seen.add(normalized);
 		candidates.push(normalized);

--- a/src/runs/shared/model-scope.ts
+++ b/src/runs/shared/model-scope.ts
@@ -6,7 +6,8 @@
  * where the model came from: an explicit caller-supplied model (`--model`,
  * tool-call `model`, or a TUI clarify pick) is a hard error, while a model
  * inherited from agent frontmatter / `defaultModel` / the parent session only
- * emits a warning so existing configurations keep working.
+ * emits a warning so existing configurations keep working. Optional strict
+ * enforcement makes inherited models hard errors too.
  *
  * The decision logic ({@link checkModelScope}) is a pure function of its
  * inputs so it can be unit-tested without touching the filesystem or config.
@@ -16,6 +17,8 @@ import { splitKnownThinkingSuffix } from "../../shared/model-info.ts";
 
 export interface ModelScopeConfig {
 	enforce?: boolean;
+	/** Reject inherited and fallback models outside the allowlist instead of warning. */
+	strict?: boolean;
 	/** Glob-style allow patterns (only `*` is special), matched against `provider/id`. */
 	allow?: string[];
 }
@@ -67,7 +70,7 @@ export function checkModelScope(
 	if (allow.some((pattern) => matchesScopePattern(model, pattern))) return undefined;
 
 	const baseModel = stripThinkingSuffix(model);
-	const severity: ModelScopeViolation["severity"] = source === "explicit" ? "error" : "warn";
+	const severity: ModelScopeViolation["severity"] = source === "explicit" || scope.strict === true ? "error" : "warn";
 	return {
 		model: baseModel,
 		severity,
@@ -100,6 +103,13 @@ export function parseModelScopeConfig(
 			throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.enforce'; expected a boolean.`);
 		}
 		config.enforce = input.enforce;
+	}
+
+	if ("strict" in input) {
+		if (typeof input.strict !== "boolean") {
+			throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.strict'; expected a boolean.`);
+		}
+		config.strict = input.strict;
 	}
 
 	if ("allow" in input) {

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -335,6 +335,15 @@ describe("resolveSubagentModelOverride scope enforcement", () => {
 		assert.equal(warnings.length, 1);
 	});
 
+	it("throws for an inherited parent-session model in strict mode", () => {
+		assert.throws(
+			() => resolveSubagentModelOverride(undefined, parentModel, availableModels, undefined, {
+				scope: { ...scope, strict: true },
+			}),
+			/deepseek\/deepseek-v4.*outside the configured subagent model scope/,
+		);
+	});
+
 	it("passes through an in-scope explicit model without warning or error", () => {
 		const warnings: string[] = [];
 		const resolved = resolveSubagentModelOverride("gpt-5-mini", parentModel, availableModels, undefined, {
@@ -378,5 +387,23 @@ describe("resolveSubagentModelOverride scope enforcement", () => {
 		assert.deepEqual(candidates, ["openai/gpt-5-mini", "deepseek/deepseek-v4"]);
 		assert.equal(warnings.length, 1);
 		assert.match(warnings[0]!, /deepseek\/deepseek-v4/);
+	});
+
+	it("throws for an out-of-scope primary candidate in strict mode", () => {
+		assert.throws(
+			() => buildModelCandidates("deepseek/deepseek-v4", undefined, availableModels, undefined, {
+				scope: { ...scope, strict: true },
+			}),
+			/deepseek\/deepseek-v4.*outside the configured subagent model scope/,
+		);
+	});
+
+	it("throws instead of pruning an out-of-scope fallback in strict mode", () => {
+		assert.throws(
+			() => buildModelCandidates("gpt-5-mini", ["deepseek/deepseek-v4"], availableModels, undefined, {
+				scope: { ...scope, strict: true },
+			}),
+			/deepseek\/deepseek-v4.*outside the configured subagent model scope/,
+		);
 	});
 });

--- a/test/unit/model-scope-settings.test.ts
+++ b/test/unit/model-scope-settings.test.ts
@@ -42,10 +42,10 @@ describe("subagents.modelScope discovery", () => {
 
 	it("exposes a user modelScope from discoverAgents", () => {
 		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
-			subagents: { modelScope: { enforce: true, allow: ["anthropic/*", "openai/gpt-5-*"] } },
+			subagents: { modelScope: { enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"] } },
 		});
 		const result = discoverAgents(tempProject, "both");
-		assert.deepEqual(result.modelScope, { enforce: true, allow: ["anthropic/*", "openai/gpt-5-*"] });
+		assert.deepEqual(result.modelScope, { enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"] });
 	});
 
 	it("returns undefined when no modelScope is configured", () => {

--- a/test/unit/model-scope.test.ts
+++ b/test/unit/model-scope.test.ts
@@ -81,6 +81,11 @@ describe("checkModelScope", () => {
 		assert.equal(violation?.severity, "warn");
 	});
 
+	it("returns an error violation for an inherited model in strict mode", () => {
+		const violation = checkModelScope("deepseek/deepseek-v4", { ...scope, strict: true }, "inherited");
+		assert.equal(violation?.severity, "error");
+	});
+
 	it("defaults to inherited (warn) severity when source is omitted-ish via inherited", () => {
 		// Caller passes "inherited" for frontmatter/parent-inherited models.
 		assert.equal(checkModelScope("meta/llama-4", scope, "inherited")?.severity, "warn");
@@ -105,8 +110,8 @@ describe("parseModelScopeConfig", () => {
 
 	it("parses a well-formed config", () => {
 		assert.deepEqual(
-			parseModelScopeConfig({ enforce: true, allow: ["anthropic/*", "openai/gpt-5-*"] }, meta),
-			{ enforce: true, allow: ["anthropic/*", "openai/gpt-5-*"] },
+			parseModelScopeConfig({ enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"] }, meta),
+			{ enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"] },
 		);
 	});
 
@@ -128,6 +133,10 @@ describe("parseModelScopeConfig", () => {
 
 	it("rejects a non-boolean enforce", () => {
 		assert.throws(() => parseModelScopeConfig({ enforce: "yes" }, meta), /invalid 'modelScope.enforce'/);
+	});
+
+	it("rejects a non-boolean strict value", () => {
+		assert.throws(() => parseModelScopeConfig({ strict: "yes" }, meta), /invalid 'modelScope.strict'/);
 	});
 
 	it("rejects a non-array allow", () => {


### PR DESCRIPTION
Closes #995.

Adds opt-in strict model-scope enforcement with `subagents.modelScope.strict: true`. Default non-strict behavior stays warn-only for inherited and fallback out-of-scope model candidates.

This also rejects strict inherited, fallback, and already-resolved primary candidates at the shared model-candidate boundary.

Validation:
- `node --experimental-strip-types --test test/unit/model-scope.test.ts test/unit/model-fallback.test.ts test/unit/model-scope-settings.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- fresh read-only review: `/tmp/pi-subagents-backlog-20260811-resume/issue-995-fresh-review-ca870e90.md`

Credit to @antonioc-cl for reporting the strict-scope gap and the requested configuration shape.
