### PR TITLE
fix: carry the requested agent on started workflow trace entries

### DIFF
--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -469,10 +469,13 @@ function validateKey(value: unknown, owner = "runs.run"): string {
 	return value;
 }
 
-function workflowStringMetadata(params: Record<string, unknown>): Pick<WorkflowScriptTraceEntry, "phase" | "label"> {
+function workflowStringMetadata(params: Record<string, unknown>): Pick<WorkflowScriptTraceEntry, "phase" | "label" | "agent"> {
 	return {
 		...(typeof params.phase === "string" && params.phase.trim() ? { phase: params.phase.trim() } : {}),
 		...(typeof params.label === "string" && params.label.trim() ? { label: params.label.trim() } : {}),
+		// Requested agent name, so a child is identifiable while it runs. Launch
+		// resolution overwrites this with the canonical name on the terminal entry.
+		...(typeof params.agent === "string" && params.agent.trim() ? { agent: params.agent.trim() } : {}),
 	};
 }
 


### PR DESCRIPTION
## Summary
- carry the requested child agent name on `started` workflow trace entries, not just the terminal one
- keep launch resolution authoritative, so the canonical agent name still overwrites the requested one when the child settles

Follow-up to `2439218 fix: harden workflow child launches`, which attaches the resolved agent to the terminal trace entry. Because `started` carries no agent, the parent falls back to the caller's stable key while a child runs, so a fleet shows rows like `budget-pot-oracle` for every in-flight child and real agent names appear only as rows complete. Observed on v0.46.0:

```
state=started    key=budget-pot-oracle    agent=(undefined)
state=completed  key=budget-pot-oracle    agent=oracle
```

With this change the `started` entry reports `oracle`, so a child is identifiable for its whole lifetime. Aliases and retained resume are unaffected, since the terminal entry still reports the resolved name.

## Validation
- `npm run typecheck`
- `npm run test:unit` (1764 pass, 1 skip)
- harness replaying the parent's step projection and widget naming over a three-child `runs.all`, confirming in-flight rows read `oracle, worker, worker` rather than `budget-pot-oracle, w1, w2`
