### PR TITLE
perf: filter stale result watcher payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [0.47.0] - 2026-08-11
 
 ### Changed
+- Avoid fully parsing stale cross-session result files during watcher recovery and reduce healthy watcher safety scans.
 - Add optional strict model-scope enforcement that rejects inherited and fallback models outside the configured allowlist. Thanks to @antonioc-cl for #995.
 - Trim legacy chain-control schema fields and guidance by default, saving 1,319 `o200k_base` tokens from the serialized default tool schema plus description versus `legacyChainControls: true`. Thanks to @tajquitgenius for #977.
 - Move project-scoped pi-subagents storage from `.pi-subagents/` to `.pi/subagents/` for cleaner project roots. Thanks to @yceachan for #971.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -438,6 +438,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		{
 			notifier: completionNotifier,
 			observeCompletion: (result) => scheduledRunManager.handleAsyncCompletion(result),
+			observedCompletionRunIds: () => scheduledRunManager.observedCompletionRunIds(),
 			deliverIntercomResults: config.intercomBridge?.resultDelivery === true,
 		},
 	);

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -21,14 +21,15 @@ import {
 import { projectNestedRegistryForRoot, sanitizeSummary } from "../shared/nested-events.ts";
 import { resolveWatchPath } from "../../shared/utils.ts";
 import { recordWaitCompletion } from "./wait-completions.ts";
-import { syncMissionFromAsyncCompletion } from "../../missions/lifecycle.ts";
+import { MISSION_BINDING_FILE, syncMissionFromAsyncCompletion } from "../../missions/lifecycle.ts";
 import type { CompletionNotifier, CompletionNotification } from "./notify.ts";
 
 const WATCHER_RESTART_DELAY_MS = 3000;
 const POLL_INTERVAL_MS = 3000;
+const HEALTHY_SCAN_INTERVAL_MS = 60_000;
 const RETRY_DELAY_MS = 100;
 
-type ResultWatcherFs = Pick<typeof fs, "existsSync" | "readFileSync" | "unlinkSync" | "readdirSync" | "mkdirSync" | "realpathSync" | "watch">;
+type ResultWatcherFs = Pick<typeof fs, "existsSync" | "readFileSync" | "unlinkSync" | "readdirSync" | "mkdirSync" | "realpathSync" | "statSync" | "watch">;
 
 type ResultWatcherTimers = {
 	setTimeout: typeof setTimeout;
@@ -43,6 +44,10 @@ type ResultWatcherDeps = {
 	notifier?: Pick<CompletionNotifier, "deliver">;
 	/** Receives persisted completions before active-session delivery filtering. */
 	observeCompletion?: (result: CompletionNotification & { runId: string }) => void;
+	/** Returns cross-session run ids that the completion observer currently owns. */
+	observedCompletionRunIds?: () => Iterable<string>;
+	/** Parses a relevant result payload after its lightweight identity check. */
+	parseResult?: (raw: string) => ResultFileData;
 	/** External grouped-result transport. Disable when native completion notifications own delivery. */
 	deliverIntercomResults?: boolean;
 };
@@ -75,6 +80,33 @@ type ResultFileData = CompletionNotification & {
 	intercomTarget?: string;
 	parallelHandoff?: ParallelHandoffReference;
 };
+
+type ResultFileIdentity = {
+	sessionId?: string;
+	runId?: string;
+	asyncDir?: string;
+};
+
+function jsonStringProperty(raw: string, property: string): string | undefined {
+	const matches = raw.matchAll(new RegExp(`"${property}"\\s*:\\s*("(?:\\\\.|[^"\\\\])*")`, "g"));
+	let encoded: string | undefined;
+	for (const match of matches) encoded = match[1];
+	if (!encoded) return undefined;
+	try {
+		const value = JSON.parse(encoded) as unknown;
+		return typeof value === "string" && value ? value : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function resultFileIdentity(raw: string, file: string): ResultFileIdentity {
+	return {
+		sessionId: jsonStringProperty(raw, "sessionId"),
+		runId: file.replace(/\.json$/i, ""),
+		asyncDir: jsonStringProperty(raw, "asyncDir"),
+	};
+}
 
 function sanitizeNestedResultChildren(value: unknown, resultPath: string, label: string): NestedRunSummary[] | undefined {
 	if (value === undefined) return undefined;
@@ -121,9 +153,11 @@ export function createResultWatcher(
 	const fsApi = deps.fs ?? fs;
 	const timers = deps.timers ?? { setTimeout, clearTimeout, setInterval, clearInterval };
 	const notifier = deps.notifier ?? { deliver: async () => true };
+	const parseResult = deps.parseResult ?? ((raw: string) => JSON.parse(raw) as ResultFileData);
 	const deliverIntercomResults = deps.deliverIntercomResults !== false;
 	const pendingTriggerTurn = new Map<string, boolean>();
 	const processing = new Set<string>();
+	const identityCache = new Map<string, { signature: string; identity: ResultFileIdentity }>();
 	let deliveryActive = true;
 	let deliveryEpoch = 0;
 	let resultScanTimer: ReturnType<typeof setInterval> | null = null;
@@ -143,12 +177,51 @@ export function createResultWatcher(
 		state.resultFileCoalescer.schedule(file, delayMs);
 	};
 
+	const inspectResult = (file: string): ResultFileIdentity | undefined => {
+		const resultPath = path.join(resultsDir, file);
+		try {
+			const stat = fsApi.statSync(resultPath);
+			const signature = `${stat.size}:${stat.mtimeMs}`;
+			const cached = identityCache.get(file);
+			if (cached?.signature === signature) return cached.identity;
+			const identity = resultFileIdentity(fsApi.readFileSync(resultPath, "utf-8"), file);
+			identityCache.set(file, { signature, identity });
+			return identity;
+		} catch (error) {
+			identityCache.delete(file);
+			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
+			return undefined;
+		}
+	};
+
+	const observedRunIds = (): ReadonlySet<string> => {
+		try {
+			return new Set(deps.observedCompletionRunIds?.() ?? []);
+		} catch (error) {
+			console.error("Failed to inspect observed subagent completion ids:", error);
+			return new Set();
+		}
+	};
+
+	const shouldProcessResult = (file: string, observed?: ReadonlySet<string>): boolean => {
+		const identity = inspectResult(file);
+		if (!identity) return false;
+		// Missing identity stays on the normal parser path so malformed or legacy
+		// files keep their existing diagnostics and compatibility behavior.
+		if (!identity.sessionId) return true;
+		if (identity.sessionId === state.currentSessionId) return true;
+		if (identity.asyncDir && fsApi.existsSync(path.join(identity.asyncDir, MISSION_BINDING_FILE))) return true;
+		if (identity.runId && (observed ?? observedRunIds()).has(identity.runId)) return true;
+		return Boolean(deps.observeCompletion && !deps.observedCompletionRunIds);
+	};
+
 	const handleResult = async (file: string, triggerTurn: boolean) => {
 		const resultPath = path.join(resultsDir, file);
 		if (processing.has(file) || !fsApi.existsSync(resultPath)) return;
+		if (!shouldProcessResult(file)) return;
 		processing.add(file);
 		try {
-			const data = JSON.parse(fsApi.readFileSync(resultPath, "utf-8")) as ResultFileData;
+			const data = parseResult(fsApi.readFileSync(resultPath, "utf-8"));
 			if (typeof data.sessionId !== "string" || !data.sessionId) return;
 			const runId = data.runId ?? data.id ?? file.replace(/\.json$/i, "");
 			try {
@@ -189,6 +262,7 @@ export function createResultWatcher(
 				if (!ownsSession(data.sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
 				try {
 					fsApi.unlinkSync(resultPath);
+					identityCache.delete(file);
 				} catch (error) {
 					if (!isNotFound(error)) {
 						console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
@@ -314,6 +388,7 @@ export function createResultWatcher(
 			if (!ownsSession(data.sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
 			try {
 				fsApi.unlinkSync(resultPath);
+				identityCache.delete(file);
 			} catch (error) {
 				if (!isNotFound(error)) {
 					console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
@@ -338,7 +413,9 @@ export function createResultWatcher(
 			const triggerTurn = options.triggerTurn !== false;
 			fsApi.readdirSync(resultsDir)
 				.filter((f) => f.endsWith(".json"))
-				.forEach((file) => scheduleResult(file, triggerTurn));
+				.forEach((file) => {
+					if (shouldProcessResult(file)) scheduleResult(file, triggerTurn);
+				});
 		} catch (error) {
 			if (!isNotFound(error)) console.error(`Failed to scan subagent result directory '${resultsDir}':`, error);
 		}
@@ -395,7 +472,10 @@ export function createResultWatcher(
 					return;
 				}
 				const fileName = file.toString();
-				if (fileName.endsWith(".json")) scheduleResult(fileName, true);
+				if (fileName.endsWith(".json")) {
+					identityCache.delete(fileName);
+					scheduleResult(fileName, true);
+				}
 			});
 			state.watcher.on("error", (error) => {
 				if (shouldPoll(error)) return startPolling(error);
@@ -405,7 +485,7 @@ export function createResultWatcher(
 				scheduleRestart();
 			});
 			state.watcher.unref?.();
-			resultScanTimer = timers.setInterval(primeExistingResults, POLL_INTERVAL_MS);
+			resultScanTimer = timers.setInterval(primeExistingResults, HEALTHY_SCAN_INTERVAL_MS);
 			resultScanTimer.unref?.();
 		} catch (error) {
 			if (shouldPoll(error)) return startPolling(error);
@@ -430,6 +510,7 @@ export function createResultWatcher(
 		state.resultFileCoalescer.clear();
 		pendingTriggerTurn.clear();
 		processing.clear();
+		identityCache.clear();
 	};
 
 	return { startResultWatcher, primeExistingResults, stopResultWatcher };

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -406,6 +406,29 @@ export class ScheduledRunManager {
 		}
 	}
 
+	observedCompletionRunIds(): Set<string> {
+		const runIds = new Set<string>();
+		for (const store of this.stores.values()) {
+			let ids: string[];
+			try {
+				ids = store.ids();
+			} catch (error) {
+				console.error(`Failed to inspect schedule store '${store.root}' during async completion discovery:`, error);
+				continue;
+			}
+			for (const id of ids) {
+				try {
+					for (const run of store.history(id)) {
+						if (run.state === "running" && run.asyncId) runIds.add(run.asyncId);
+					}
+				} catch (error) {
+					console.error(`Failed to inspect schedule '${id}' in '${store.root}' during async completion discovery:`, error);
+				}
+			}
+		}
+		return runIds;
+	}
+
 	handleAsyncCompletion(payload: unknown): void {
 		if (!payload || typeof payload !== "object") return;
 		const data = payload as { id?: unknown; runId?: unknown; success?: unknown; state?: unknown; summary?: unknown };

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -84,6 +84,133 @@ describe("result watcher", () => {
 		}
 	});
 
+	it("does not inspect scheduled observers while priming current-session results", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-current-prime-"));
+		try {
+			const state = createState();
+			state.currentSessionId = "session-current";
+			let observedRunIdScans = 0;
+			fs.writeFileSync(path.join(resultsDir, "current.json"), JSON.stringify({
+				id: "current",
+				sessionId: "session-current",
+				success: true,
+				summary: "done",
+			}), "utf-8");
+			const watcher = createResultWatcher({
+				events: {
+					on: () => () => {},
+					emit() {},
+				},
+			}, state, resultsDir, 60_000, {
+				deliverIntercomResults: false,
+				observedCompletionRunIds() {
+					observedRunIdScans += 1;
+					return [];
+				},
+			});
+			watcher.primeExistingResults();
+			assert.equal(observedRunIdScans, 0);
+			watcher.stopResultWatcher();
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("skips full parsing for unrelated sessions during priming, safety scans, and native watch events", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-filter-"));
+		try {
+			const emitted: Array<{ event: string; data: unknown }> = [];
+			const parsedIds: string[] = [];
+			const state = createState();
+			state.currentSessionId = "session-current";
+			let safetyScan: (() => void) | undefined;
+			let watchEvent: ((event: string, file: string | Buffer | null) => void) | undefined;
+			let safetyScanIntervalMs: number | undefined;
+			let observedRunIdScans = 0;
+			const fakeWatcher = {
+				on() { return fakeWatcher; },
+				close() {},
+				unref() {},
+			} as fs.FSWatcher;
+			const writeResult = (id: string, sessionId: string) => {
+				fs.writeFileSync(path.join(resultsDir, `${id}.json`), JSON.stringify({
+					id,
+					results: [{ structuredOutput: { sessionId: "nested-not-owner" } }],
+					sessionId,
+					success: true,
+					summary: "done",
+				}), "utf-8");
+			};
+			writeResult("startup-current", "session-current");
+			writeResult("startup-stale", "session-stale");
+			const watcher = createResultWatcher({
+				events: {
+					on: () => () => {},
+					emit(event: string, data: unknown) { emitted.push({ event, data }); },
+				},
+			}, state, resultsDir, 60_000, {
+				deliverIntercomResults: false,
+				observedCompletionRunIds() {
+					observedRunIdScans += 1;
+					return [];
+				},
+				parseResult(raw) {
+					const parsed = JSON.parse(raw) as { id: string };
+					parsedIds.push(parsed.id);
+					return parsed;
+				},
+				fs: {
+					...fs,
+					watch(_dir, listener) {
+						watchEvent = listener as typeof watchEvent;
+						return fakeWatcher;
+					},
+				},
+				timers: {
+					setTimeout,
+					clearTimeout,
+					setInterval(handler: () => void, delay?: number) {
+						safetyScan = handler;
+						safetyScanIntervalMs = delay;
+						return { unref() {} } as NodeJS.Timeout;
+					},
+					clearInterval() { safetyScan = undefined; },
+				},
+			});
+			try {
+				watcher.startResultWatcher();
+				watcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => !fs.existsSync(path.join(resultsDir, "startup-current.json"))), true);
+				assert.deepEqual(parsedIds, ["startup-current"]);
+				assert.equal(safetyScanIntervalMs, 60_000);
+
+				writeResult("scan-current", "session-current");
+				writeResult("scan-stale", "session-stale");
+				safetyScan?.();
+				assert.equal(await waitForPredicate(() => !fs.existsSync(path.join(resultsDir, "scan-current.json"))), true);
+				assert.deepEqual(parsedIds, ["startup-current", "scan-current"]);
+
+				const scansBeforeWatchEvents = observedRunIdScans;
+				watchEvent?.("rename", "watch-current.json");
+				writeResult("watch-current", "session-current");
+				assert.equal(await waitForPredicate(() => !fs.existsSync(path.join(resultsDir, "watch-current.json"))), true);
+				assert.equal(observedRunIdScans, scansBeforeWatchEvents);
+
+				writeResult("watch-stale", "session-stale");
+				watchEvent?.("rename", "watch-stale.json");
+				assert.equal(await waitForPredicate(() => observedRunIdScans > scansBeforeWatchEvents), true);
+				assert.deepEqual(parsedIds, ["startup-current", "scan-current", "watch-current"]);
+			} finally {
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal(emitted.filter((entry) => entry.event === "subagent:async-complete").length, 3);
+			assert.deepEqual(fs.readdirSync(resultsDir).filter((file) => file.endsWith(".json")).sort(), ["scan-stale.json", "startup-stale.json", "watch-stale.json"]);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("syncs mission workflow child completion before result cleanup", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-mission-"));
 		const resultsDir = path.join(root, "results");


### PR DESCRIPTION
## Summary

Avoid full result parsing and scheduling for stale result files that belong to other sessions. The watcher now performs a lightweight identity check, keeps scheduled-run observer discovery lazy, and uses a slower healthy safety scan while preserving fallback polling.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/result-watcher.test.ts` (`26/26`)
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh review and targeted follow-up review found no remaining issues.
