### PR TITLE
perf: index active async runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Avoid fully parsing stale cross-session result files during watcher recovery and reduce healthy watcher safety scans.
+- Index active async runs so status restoration no longer scans all historical run directories.
 - Add optional strict model-scope enforcement that rejects inherited and fallback models outside the configured allowlist. Thanks to @antonioc-cl for #995.
 - Trim legacy chain-control schema fields and guidance by default, saving 1,319 `o200k_base` tokens from the serialized default tool schema plus description versus `legacyChainControls: true`. Thanks to @tajquitgenius for #977.
 - Move project-scoped pi-subagents storage from `.pi-subagents/` to `.pi/subagents/` for cleaner project roots. Thanks to @yceachan for #971.

--- a/src/runs/background/active-run-index.ts
+++ b/src/runs/background/active-run-index.ts
@@ -1,0 +1,42 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AsyncStatus } from "../../shared/types.ts";
+
+export const ACTIVE_RUN_INDEX_DIR = ".active-runs";
+
+function indexDir(asyncDirRoot: string): string {
+	return path.join(asyncDirRoot, ACTIVE_RUN_INDEX_DIR);
+}
+
+function markerPath(asyncDir: string): string {
+	return path.join(indexDir(path.dirname(asyncDir)), path.basename(asyncDir));
+}
+
+export function isActiveAsyncState(state: AsyncStatus["state"]): boolean {
+	return state === "queued" || state === "running";
+}
+
+export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state"]): void {
+	const marker = markerPath(asyncDir);
+	if (isActiveAsyncState(state)) {
+		fs.mkdirSync(path.dirname(marker), { recursive: true });
+		fs.writeFileSync(marker, "", { flag: "a" });
+		return;
+	}
+	try {
+		fs.rmSync(marker);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+}
+
+export function readActiveRunIndex(asyncDirRoot: string): string[] | undefined {
+	try {
+		return fs.readdirSync(indexDir(asyncDirRoot), { withFileTypes: true })
+			.filter((entry) => entry.isFile())
+			.map((entry) => entry.name);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
+	}
+}

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -5,12 +5,13 @@ import { formatActivityLabel, formatParallelOutcome } from "../../shared/status-
 import { type ActivityState, type AsyncJobStep, type AsyncParallelGroupStatus, type AsyncStatus, type CostSummary, type Details, type LaunchResolvedChildExtensionsV1, type RuntimeAcknowledgedChildExtensionsV1, type NestedRunSummary, type SteeringStatus, type SubagentRunMode, type TokenUsage, type TurnBudgetState, type UsageBudgetState, type ChainCheckpointState } from "../../shared/types.ts";
 import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../shared/capability-ceiling.ts";
 import { pruneStatusCacheForAsyncRoot, readStatus } from "../../shared/utils.ts";
-import { attachRootChildrenToSteps, buildNestedRouteIndex, type NestedRoute, projectNestedEvents } from "../shared/nested-events.ts";
+import { attachRootChildrenToSteps, buildNestedRouteIndex, findNestedRouteForRootId, type NestedRoute, projectNestedEvents } from "../shared/nested-events.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { flatToLogicalStepIndex, normalizeParallelGroups } from "./parallel-groups.ts";
 import { contextModeLabel, summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
 import { readProcessTerminal, sanitizeProcessTerminal } from "./process-terminal.ts";
+import { ACTIVE_RUN_INDEX_DIR, isActiveAsyncState, readActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
@@ -160,7 +161,7 @@ type TargetedAsyncRunResolution =
  * accepting a path whose canonical location escaped the async root.
  */
 export function resolveTargetedAsyncRun(asyncDirRoot: string, id: string, sessionId?: string): TargetedAsyncRunResolution {
-	if (!id || id === "." || id === ".." || path.basename(id) !== id) return { kind: "reject" };
+	if (!id || id === "." || id === ".." || id === ACTIVE_RUN_INDEX_DIR || path.basename(id) !== id) return { kind: "reject" };
 	const asyncDir = path.join(asyncDirRoot, id);
 	let entryStat: fs.Stats;
 	try {
@@ -371,6 +372,12 @@ function sortRuns(runs: AsyncRunSummary[]): AsyncRunSummary[] {
 export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions = {}): AsyncRunSummary[] {
 	let entries: string[];
 	let scannedCompleteRoot = false;
+	let usedActiveIndex = false;
+	const activeOnly = options.runId === undefined
+		&& options.entryLimit === undefined
+		&& options.states !== undefined
+		&& options.states.length > 0
+		&& options.states.every(isActiveAsyncState);
 	try {
 		if (options.runId !== undefined) {
 			const resolution = resolveTargetedAsyncRun(asyncDirRoot, options.runId, options.sessionId);
@@ -382,8 +389,15 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 						&& resolveTargetedAsyncRun(asyncDirRoot, entry, options.sessionId).kind === "exact"
 					)
 					: [];
+		} else if (activeOnly) {
+			entries = (readActiveRunIndex(asyncDirRoot) ?? []).filter((entry) => {
+				if (resolveTargetedAsyncRun(asyncDirRoot, entry).kind === "exact") return true;
+				updateActiveRunIndex(path.join(asyncDirRoot, entry), "failed");
+				return false;
+			});
+			usedActiveIndex = true;
 		} else {
-			entries = fs.readdirSync(asyncDirRoot).filter((entry) => isAsyncRunDir(asyncDirRoot, entry));
+			entries = fs.readdirSync(asyncDirRoot).filter((entry) => entry !== ACTIVE_RUN_INDEX_DIR && isAsyncRunDir(asyncDirRoot, entry));
 			scannedCompleteRoot = true;
 		}
 	} catch (error) {
@@ -424,6 +438,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 	// entirely when no active runs match.
 	let nestedRouteIndex: Map<string, NestedRoute> | undefined;
 	const resolveNestedRoute = (rootRunId: string): NestedRoute | undefined => {
+		if (usedActiveIndex) return findNestedRouteForRootId(rootRunId);
 		if (!nestedRouteIndex) nestedRouteIndex = buildNestedRouteIndex();
 		return nestedRouteIndex.get(rootRunId);
 	};
@@ -433,7 +448,11 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 			? undefined
 			: reconcileAsyncRun(asyncDir, { resultsDir: options.resultsDir, kill: options.kill, now: options.now });
 		const status = (reconciliation?.status ?? readStatus(asyncDir)) as (AsyncStatus & { cwd?: string }) | null;
-		if (!status) continue;
+		if (!status) {
+			if (usedActiveIndex) updateActiveRunIndex(asyncDir, "failed");
+			continue;
+		}
+		if (usedActiveIndex && !isActiveAsyncState(status.state)) updateActiveRunIndex(asyncDir, status.state);
 		// Filter before the nested-route lookup: the lookup builds an index over
 		// the nested-events directory, so deferring it for filtered-out runs keeps
 		// restoration at load from scanning that directory when no active runs

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { updateActiveRunIndex } from "./active-run-index.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { DIRS, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSummary, type SubagentRunMode } from "../../shared/types.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
@@ -258,6 +259,7 @@ function writeFailedRepair(asyncDir: string, status: AsyncStatus, resultPath: st
 	const repair = buildFailedRepair(status, asyncDir, now, reason);
 	writeAtomicJson(resultPath, repair.result);
 	writeAtomicJson(path.join(asyncDir, "status.json"), repair.status);
+	updateActiveRunIndex(asyncDir, repair.status.state);
 	appendJsonlBestEffort(path.join(asyncDir, "events.jsonl"), {
 		type: "subagent.run.repaired_stale",
 		ts: now,
@@ -348,6 +350,7 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 			: undefined;
 		if (terminalStatus) {
 			writeAtomicJson(path.join(asyncDir, "status.json"), terminalStatus);
+			updateActiveRunIndex(asyncDir, terminalStatus.state);
 			return { status: terminalStatus, repaired: true, resultPath, message: "Existing async result file was used to repair stale running status." };
 		}
 		return { status: effectiveStatus, repaired: false, resultPath };

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { createFileCoalescer } from "../../shared/file-coalescer.ts";
+import { isActiveAsyncState, updateActiveRunIndex } from "./active-run-index.ts";
 import { createChildTranscriptWriter, type ChildTranscriptWriter } from "../../shared/child-transcript.ts";
 import { closeSteerInbox, consumeInterruptRequest, consumeSteerRequests, deliverInterruptRequest, deliverStopRequest, deliverTimeoutRequest, enqueueStepSteer, steerAcksDir, steerCapabilityPath, stepSteerInboxDir, watchAsyncControlInbox, type SteerAck, type SteerCapability, type SteerRequest } from "./control-channel.ts";
 import { appendJsonl as appendRawJsonl, formatOutputArtifactContent, getArtifactPaths, writeArtifact, writeMetadata } from "../../shared/artifacts.ts";
@@ -2181,6 +2182,7 @@ async function runSubagent(
 
 	fs.mkdirSync(asyncDir, { recursive: true });
 	writeAtomicJson(statusPath, statusPayload);
+	updateActiveRunIndex(asyncDir, statusPayload.state);
 	let pendingParallelUsageCost: CostSummary = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
 	const currentUsageTotals = (): CostSummary => {
 		const cost = results.reduce<CostSummary>((sum, result) => ({
@@ -2253,9 +2255,15 @@ async function runSubagent(
 		for (const node of graph.nodes) updateNode(node);
 		statusPayload.workflowGraph = graph;
 	};
+	let lastIndexedActiveState = isActiveAsyncState(statusPayload.state);
 	const writeStatusPayloadNow = (): void => {
 		refreshWorkflowGraph();
 		writeAtomicJson(statusPath, statusPayload);
+		const activeState = isActiveAsyncState(statusPayload.state);
+		if (activeState !== lastIndexedActiveState) {
+			updateActiveRunIndex(asyncDir, statusPayload.state);
+			lastIndexedActiveState = activeState;
+		}
 		emitNestedSelfEvent(statusPayload.state === "running" || statusPayload.state === "queued" ? "subagent.nested.updated" : "subagent.nested.completed");
 	};
 	const statusWriteCoalescer = createFileCoalescer(writeStatusPayloadNow, 100);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -53,6 +53,7 @@ import {
 } from "../../shared/settings.ts";
 import { discoverAvailableSkills, normalizeSkillInput } from "../../agents/skills.ts";
 import { buildAsyncRunnerSteps, DEFAULT_ASYNC_TIMEOUT_MS, executeAsyncChain, executeAsyncSingle, formatAsyncStartedMessage, isAsyncAvailable, workflowAwaitedAsyncResultPath } from "../background/async-execution.ts";
+import { updateActiveRunIndex } from "../background/active-run-index.ts";
 import { isScheduledRunAction, type ScheduledRunAction } from "../background/scheduled-runs.ts";
 import { enqueueChainAppendRequest, readPendingChainAppendRequests, runnerStepOutputNames } from "../background/chain-append.ts";
 import { ChainOutputValidationError, validateChainOutputBindingsWithContext } from "../shared/chain-outputs.ts";
@@ -4464,9 +4465,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					workflow: { trace: [], emits: [], console: [] },
 				};
 				const appendWorkflowEvent = (event: Record<string, unknown>) => fs.appendFileSync(eventsPath, `${JSON.stringify({ ts: Date.now(), runId: workflowRunId, ...event })}\n`, "utf-8");
+				let indexedState: AsyncStatus["state"] | undefined;
 				const persist = () => {
 					status.lastUpdate = Date.now();
 					writeAtomicJson(statusPath, status);
+					if (indexedState !== status.state) {
+						updateActiveRunIndex(asyncDir, status.state);
+						indexedState = status.state;
+					}
 					const job = deps.state.asyncJobs.get(workflowRunId);
 					if (job) {
 						job.status = status.state;

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { getProjectArtifactsDir } from "../../src/shared/artifacts.ts";
+import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { SubagentFleetComponent } from "../../src/tui/fleet.ts";
 import { createTempDir, removeTempDir, tryImport } from "../support/helpers.ts";
 
@@ -223,6 +224,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 					message: "old notice",
 				},
 			})}\n`, "utf-8");
+			updateActiveRunIndex(runDir, "running");
 
 			const state = createState();
 			state.currentSessionId = "session-restored";
@@ -285,6 +287,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				steps: [{ agent: "scan", label: "scan", status: "running" }],
 				workflow: { trace: [{ operation: "run", key: "scan", state: "started" }], emits: [{ stage: "scan" }], console: [] },
 			}), "utf-8");
+			updateActiveRunIndex(runDir, "running");
 			const state = createState();
 			state.currentSessionId = "session-workflow";
 			const tracker = trackerMod!.createAsyncJobTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 10 });
@@ -324,6 +327,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				workflowKey: "review",
 				steps: [{ agent: "reviewer", status: "running" }],
 			}), "utf-8");
+			updateActiveRunIndex(runDir, "running");
 			const state = createState();
 			state.currentSessionId = "session-workflow";
 			const tracker = trackerMod!.createAsyncJobTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 10 });
@@ -359,6 +363,8 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				startedAt: 1000,
 				steps: [{ agent: "worker", status: "running" }],
 			}), "utf-8");
+			updateActiveRunIndex(ownerDir, "running");
+			updateActiveRunIndex(otherDir, "running");
 
 			const state = createState();
 			state.currentSessionId = "session-owner";
@@ -408,6 +414,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const runDir = path.join(asyncRoot, "run-bad-status");
 			fs.mkdirSync(runDir, { recursive: true });
 			fs.writeFileSync(path.join(runDir, "status.json"), "{bad json", "utf-8");
+			updateActiveRunIndex(runDir, "running");
 
 			const state = createState();
 			state.currentSessionId = "session-bad";

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -4,11 +4,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { formatAsyncRunList, listAsyncRuns } from "../../src/runs/background/async-status.ts";
+import { ACTIVE_RUN_INDEX_DIR, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 
 function createAsyncDir(root: string, id: string, status: Record<string, unknown>): string {
 	const dir = path.join(root, id);
 	fs.mkdirSync(dir, { recursive: true });
 	fs.writeFileSync(path.join(dir, "status.json"), JSON.stringify(status), "utf-8");
+	if (status.state === "queued" || status.state === "running") updateActiveRunIndex(dir, status.state);
 	return dir;
 }
 
@@ -566,32 +568,51 @@ describe("async status helpers", () => {
 		}
 	});
 
-	it("filters terminal runs to active states without scanning nested routes per run", () => {
-		// Regression guard: load-time restoration calls listAsyncRuns with a
-		// queued/running filter over every run dir on disk. The nested-route
-		// lookup must be skipped for runs that fail the state filter, otherwise
-		// session start freezes when many stale run dirs have accumulated.
-		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-filter-"));
+	it("lists indexed active runs without reading historical status files", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-indexed-"));
 		try {
 			for (let i = 0; i < 200; i++) {
-				createAsyncDir(root, `run-${i}`, {
-					runId: `run-${i}`,
+				createAsyncDir(root, `terminal-${i}`, {
+					runId: `terminal-${i}`,
 					mode: "single",
 					state: "complete",
 					startedAt: 100,
-					lastUpdate: 200,
 					steps: [{ agent: "reviewer", status: "complete" }],
 				});
 			}
+			fs.writeFileSync(path.join(root, "terminal-0", "status.json"), "{not-json", "utf-8");
+			createAsyncDir(root, "active", {
+				runId: "active",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
 
-			const start = Date.now();
-			const runs = listAsyncRuns(root, { states: ["queued", "running"] });
-			const elapsed = Date.now() - start;
+			const runs = listAsyncRuns(root, { states: ["queued", "running"], reconcile: false });
 
-			assert.equal(runs.length, 0);
-			// 200 terminal dirs filtered to active states should resolve in well
-			// under a second. The old per-run nested-route scan blew past this.
-			assert.ok(elapsed < 1000, `listAsyncRuns took ${elapsed}ms for 200 terminal runs`);
+			assert.deepEqual(runs.map((run) => run.id), ["active"]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("prunes terminal active markers while preserving history listing", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-index-prune-"));
+		try {
+			const asyncDir = createAsyncDir(root, "finished", {
+				runId: "finished",
+				mode: "single",
+				state: "complete",
+				startedAt: 100,
+				lastUpdate: 200,
+				steps: [{ agent: "worker", status: "complete" }],
+			});
+			updateActiveRunIndex(asyncDir, "running");
+
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false }), []);
+			assert.equal(fs.existsSync(path.join(root, ACTIVE_RUN_INDEX_DIR, "finished")), false);
+			assert.deepEqual(listAsyncRuns(root, { states: ["complete"], reconcile: false }).map((run) => run.id), ["finished"]);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -36,6 +36,7 @@ import {
 	type SubagentDelegationStarted,
 } from "../../src/api/delegation.ts";
 import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, type AsyncStatus, type SubagentState } from "../../src/shared/types.ts";
+import { ACTIVE_RUN_INDEX_DIR } from "../../src/runs/background/active-run-index.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
 import { TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV } from "../../src/runs/shared/tool-budget.ts";
@@ -525,6 +526,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok(asyncDir);
 		const statusPath = path.join(asyncDir, "status.json");
 		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
+		const activeMarkerPath = path.join(DIRS.async, ACTIVE_RUN_INDEX_DIR, workflowRunId);
+		assert.equal(fs.existsSync(activeMarkerPath), true);
 		let liveStatus: AsyncStatus | undefined;
 		const activityDeadline = Date.now() + 5_000;
 		while (Date.now() < activityDeadline && !fs.existsSync(resultPath)) {
@@ -557,6 +560,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			if (Date.now() > completionDeadline) assert.fail("Timed out waiting for async workflow completion");
 			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
+		assert.equal(fs.existsSync(activeMarkerPath), false);
 		fs.rmSync(asyncDir, { recursive: true, force: true });
 		fs.rmSync(resultPath, { force: true });
 	});

--- a/test/unit/background-work.test.ts
+++ b/test/unit/background-work.test.ts
@@ -11,8 +11,9 @@ import {
 	snapshotBackgroundWork,
 	type BackgroundWorkSnapshot,
 } from "../../src/api/background-work.ts";
+import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
-import type { SubagentState } from "../../src/shared/types.ts";
+import type { AsyncStatus, SubagentState } from "../../src/shared/types.ts";
 
 function clearRegistry(): void {
 	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(BACKGROUND_WORK_REGISTRY_KEY)];
@@ -37,7 +38,7 @@ function makeState(sessionId = "session-a"): SubagentState {
 	} as SubagentState;
 }
 
-function writeStatus(root: string, id: string, state: string, sessionId = "session-a"): void {
+function writeStatus(root: string, id: string, state: AsyncStatus["state"], sessionId = "session-a"): void {
 	const dir = path.join(root, id);
 	fs.mkdirSync(dir, { recursive: true });
 	const now = Date.now();
@@ -51,6 +52,7 @@ function writeStatus(root: string, id: string, state: string, sessionId = "sessi
 		pid: 999999,
 		steps: [{ agent: "worker", status: state }],
 	}));
+	updateActiveRunIndex(dir, state);
 }
 
 function waitDeps(root: string, state: SubagentState, backgroundWork: SubagentWaitDeps["backgroundWork"], sleep: () => Promise<void>): SubagentWaitDeps {

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -484,11 +484,12 @@ describe("subagent extension child mode", () => {
 		}
 	});
 
-	it("restores disk-backed active status after a management tool result", () => {
+	it("restores indexed active status after a management tool result", () => {
 		const script = String.raw`
 			import * as fs from "node:fs";
 			import * as path from "node:path";
 			import registerSubagentExtension from "./index.ts";
+			import { updateActiveRunIndex } from "./src/runs/background/active-run-index.ts";
 			import { DIRS } from "./src/shared/types.ts";
 			const eventHandlers = new Map();
 			const handlers = new Map();
@@ -518,6 +519,7 @@ describe("subagent extension child mode", () => {
 				runId, sessionId, mode: "workflow", state: "running",
 				startedAt: Date.now(), lastUpdate: Date.now(), cwd: process.cwd(), pid: process.pid,
 			}), "utf-8");
+			updateActiveRunIndex(asyncDir, "running");
 			handlers.get("tool_result")({ toolName: "subagent" }, ctx);
 			const fleetWidgets = widgets.filter((entry) => entry.key === "subagent-fleet-status");
 			if (!fleetWidgets.some((entry) => typeof entry.value === "function")) throw new Error("management result did not restore active fleet status: " + JSON.stringify(fleetWidgets));

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
+import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { inspectSubagentStatus } from "../../src/runs/background/run-status.ts";
 import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
 import { TEMP_ROOT_DIR, type SubagentState } from "../../src/shared/types.ts";
@@ -286,6 +287,7 @@ describe("async run status inspection", () => {
 					{ agent: "reviewer", status: "pending" },
 				],
 			}, null, 2), "utf-8");
+			updateActiveRunIndex(asyncDir, "running");
 			const state = {
 				foregroundControls: new Map([["fg-run", {
 					runId: "fg-run",
@@ -346,6 +348,8 @@ describe("async run status inspection", () => {
 				lastUpdate: 200,
 				steps: [{ agent: "reviewer", status: "running", startedAt: 100 }],
 			}, null, 2), "utf-8");
+			updateActiveRunIndex(currentDir, "running");
+			updateActiveRunIndex(otherDir, "running");
 			const state = {
 				currentSessionId: "session-current",
 				asyncJobs: new Map(),
@@ -459,6 +463,7 @@ describe("async run status inspection", () => {
 				steering: { requested: 2, scheduled: 1, pending: 1, delivered: 2, failed: 0, recovered: 1, lastRequestedAt: 150, lastDeliveredAt: 150, recent: [{ id: "request", requestedAt: 150, message: "guidance", targets: [{ index: 0, state: "recovered", recoveredAt: 180, lateDeliveredAt: 190 }] }] },
 				steps: [{ agent: "worker", status: "running", startedAt: 100, steering: { requested: 2, scheduled: 1, pending: 1, delivered: 2, failed: 0, recovered: 1, lastRequestedAt: 150, lastDeliveredAt: 150, recent: [{ id: "request", requestedAt: 150, message: "guidance", targets: [{ index: 0, state: "recovered", recoveredAt: 180, lateDeliveredAt: 190 }] }] } }],
 			}, null, 2), "utf-8");
+			updateActiveRunIndex(asyncDir, "running");
 
 			const exact = inspectSubagentStatus({ id: "run-steered" }, {
 				asyncDirRoot: asyncRoot,
@@ -649,6 +654,7 @@ describe("async run status inspection", () => {
 				lastUpdate: 100,
 				steps: [{ agent: "orchestrator", status: "running", startedAt: 100 }],
 			}, null, 2), "utf-8");
+			updateActiveRunIndex(asyncDir, "running");
 
 			const result = inspectSubagentStatus({}, { asyncDirRoot: asyncRoot, resultsDir, kill: () => true, now: () => 200 });
 

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -3,11 +3,12 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
+import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { WAIT_TOOL_ENABLED_ENV, resolveWaitToolConfig, waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
 import { recordWaitCompletion } from "../../src/runs/background/wait-completions.ts";
-import type { SubagentState } from "../../src/shared/types.ts";
+import type { AsyncStatus, SubagentState } from "../../src/shared/types.ts";
 
-function writeStatus(asyncRoot: string, runId: string, state: string, extra: object = {}): void {
+function writeStatus(asyncRoot: string, runId: string, state: AsyncStatus["state"], extra: object = {}): void {
 	const dir = path.join(asyncRoot, runId);
 	fs.mkdirSync(dir, { recursive: true });
 	// Use a recent timestamp so the stale-run reconciler doesn't mark a live
@@ -26,6 +27,7 @@ function writeStatus(asyncRoot: string, runId: string, state: string, extra: obj
 		}),
 		"utf-8",
 	);
+	updateActiveRunIndex(dir, state);
 }
 
 function makeState(sessionId: string | null): SubagentState {


### PR DESCRIPTION
## Summary

Add an active async-run marker index so active-only listing uses verified active ids instead of scanning historical run dirs. Current async writers create and remove markers for active and terminal states, and active-only restore treats the marker index as the contract.

## Validation

- `node --experimental-strip-types --test --test-name-pattern 'restores indexed active status after a management tool result' test/unit/index-child-registration.test.ts` (`1/1`)
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-status.test.ts` (`23/23`)
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='projects live child activity into async workflow status' test/integration/single-execution.test.ts` (`1/1`)
- `npm run typecheck`
- `git diff --check`
- Fresh review and targeted follow-up review were clean before the current CI-test cleanup; a final follow-up review is running.
