### PR TITLE
perf: make async job tracking event-driven

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -25,6 +26,8 @@ jobs:
       - name: Unit tests
         run: npm test
       - name: Integration tests
+        timeout-minutes: 10
         run: npm run test:integration
       - name: E2E tests
+        timeout-minutes: 5
         run: npm run test:e2e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 - Avoid fully parsing stale cross-session result files during watcher recovery and reduce healthy watcher safety scans.
 - Index active async runs so status restoration no longer scans all historical run directories.
+- Refresh active async job state from filesystem events while reserving polling for slow liveness repair.
 - Add optional strict model-scope enforcement that rejects inherited and fallback models outside the configured allowlist. Thanks to @antonioc-cl for #995.
 - Trim legacy chain-control schema fields and guidance by default, saving 1,319 `o200k_base` tokens from the serialized default tool schema plus description versus `legacyChainControls: true`. Thanks to @tajquitgenius for #977.
 - Move project-scoped pi-subagents storage from `.pi-subagents/` to `.pi/subagents/` for cleaner project roots. Thanks to @yceachan for #971.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -430,6 +430,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		},
 		resolveCapabilityCeiling: (sessionId) => resolveCurrentSubagentCapabilityCeiling(sessionId),
 	});
+	const { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs, dispose: disposeAsyncJobTracker } = createAsyncJobTracker(pi, state, DIRS.async, {
+		widgetEnabled: asyncWidgetEnabled,
+	});
 	const { startResultWatcher, primeExistingResults, stopResultWatcher } = createResultWatcher(
 		pi,
 		state,
@@ -452,16 +455,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		supervisorChannel.dispose();
 		waitSubscriptionManager.dispose();
 		fleetStatus?.dispose();
-		if (state.poller) {
-			clearInterval(state.poller);
-			state.poller = null;
-		}
+		disposeAsyncJobTracker();
 	};
 	globalStore[runtimeCleanupStoreKey] = runtimeCleanup;
 
-	const { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs } = createAsyncJobTracker(pi, state, DIRS.async, {
-		widgetEnabled: asyncWidgetEnabled,
-	});
 	const executor = createSubagentExecutor({
 		pi,
 		state,
@@ -824,8 +821,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			delete globalStore[eventUnsubscribeStoreKey];
 		}
 		scheduledRunManager.stop();
-		if (state.poller) clearInterval(state.poller);
-		state.poller = null;
+		disposeAsyncJobTracker();
 		for (const timer of state.cleanupTimers.values()) {
 			clearTimeout(timer);
 		}

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -15,14 +15,15 @@ import {
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_STEERING_NOTICE_EVENT,
 } from "../../shared/types.ts";
-import { readStatus } from "../../shared/utils.ts";
+import { readStatus, resolveWatchPath } from "../../shared/utils.ts";
 import { normalizeParallelGroups } from "./parallel-groups.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
-import { hasLiveNestedDescendants, updateAsyncJobNestedProjection } from "../shared/nested-events.ts";
+import { findNestedRouteForRootId, hasLiveNestedDescendants, updateAsyncJobNestedProjection } from "../shared/nested-events.ts";
 import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 
 interface AsyncJobTrackerOptions {
 	completionRetentionMs?: number;
+	/** Slow safety sweep for liveness repair when filesystem events are missed. */
 	pollIntervalMs?: number;
 	resultsDir?: string;
 	widgetEnabled?: boolean;
@@ -34,6 +35,9 @@ const CONTROL_EVENT_READ_CHUNK_BYTES = 64 * 1024;
 const MAX_CONTROL_EVENT_LINE_BYTES = 1024 * 1024;
 const CONTROL_EVENT_SCAN_WINDOW_BYTES = 2 * 1024 * 1024;
 const MAX_RECENT_FLEET_JOBS = 20;
+const DEFAULT_LIVENESS_INTERVAL_MS = 5000;
+const EVENT_REFRESH_DEBOUNCE_MS = 25;
+const WATCH_ATTACHMENT_RETRY_MS = 100;
 
 function rememberFleetJob(state: SubagentState, job: AsyncJobState): void {
 	state.fleetJobs ??= new Map();
@@ -51,11 +55,17 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	handleComplete: (data: unknown) => void;
 	resetJobs: (ctx?: ExtensionContext) => void;
 	restoreActiveJobs: (ctx?: ExtensionContext) => void;
+	dispose: () => void;
 } {
 	const completionRetentionMs = options.completionRetentionMs ?? 10000;
-	const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+	const livenessIntervalMs = options.pollIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS;
 	const resultsDir = options.resultsDir ?? DIRS.results;
 	const steeringNoticeSeen = new Map<string, number>();
+	const jobWatchers = new Map<string, { watchers: Map<string, fs.FSWatcher>; retryTimer?: ReturnType<typeof setTimeout> }>();
+	const refreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	const runningJobIds = new Set<string>();
+	let rootWatcher: fs.FSWatcher | undefined;
+	let nextLivenessAt = Date.now() + livenessIntervalMs;
 	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
 		if (state.widgetsSuspended) return;
 		renderWidget(ctx, options.widgetEnabled === false ? [] : jobs);
@@ -94,6 +104,14 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
 			throw error;
+		}
+	};
+	const findNestedRouteForJob = (runId: string) => {
+		try {
+			return findNestedRouteForRootId(runId);
+		} catch (error) {
+			console.error(`Failed to resolve nested event route for '${runId}':`, error);
+			return undefined;
 		}
 	};
 	const summaryToJob = (run: AsyncRunSummary): AsyncJobState => {
@@ -144,6 +162,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			totalTokens: run.totalTokens,
 			sessionFile: run.sessionFile,
 			controlEventCursor: restoredControlEventCursor(run.asyncDir),
+			nestedRoute: findNestedRouteForJob(run.id),
 			nestedChildren: run.nestedChildren,
 			parentWorkflowRunId: run.parentWorkflowRunId,
 			workflowKey: run.workflowKey,
@@ -160,6 +179,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		cancelCleanup(asyncId);
 		const timer = setTimeout(() => {
 			state.cleanupTimers.delete(asyncId);
+			closeJobWatcher(asyncId);
 			state.asyncJobs.delete(asyncId);
 			rerenderLastWidget();
 		}, completionRetentionMs);
@@ -282,140 +302,245 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		}
 	};
 
-	const ensurePoller = () => {
-		if (state.poller) return;
-		state.poller = setInterval(() => {
-			if (state.asyncJobs.size === 0) {
-				rerenderLastWidget([]);
-				if (state.poller) {
-					clearInterval(state.poller);
-					state.poller = null;
-				}
-				return;
-			}
+	const closeJobWatcher = (asyncId: string) => {
+		const watched = jobWatchers.get(asyncId);
+		if (watched?.retryTimer) clearTimeout(watched.retryTimer);
+		for (const watcher of watched?.watchers.values() ?? []) watcher.close();
+		jobWatchers.delete(asyncId);
+		const timer = refreshTimers.get(asyncId);
+		if (timer) clearTimeout(timer);
+		refreshTimers.delete(asyncId);
+		runningJobIds.delete(asyncId);
+	};
 
-			let widgetChanged = false;
-			for (const job of state.asyncJobs.values()) {
-				const widgetStateBefore = widgetRenderKey(job);
-				let nestedRefreshFailed = false;
-				const refreshNestedProjection = () => {
-					try {
-						updateAsyncJobNestedProjection(job);
-					} catch (error) {
-						nestedRefreshFailed = true;
-						console.error(`Failed to refresh nested async descendants for '${job.asyncDir}':`, error);
-					}
-				};
-				const reconcileNestedDescendants = () => {
-					try {
-						if (job.nestedRoute) reconcileNestedAsyncDescendants(job.nestedRoute, { resultsDir, kill: options.kill, now: options.now });
-					} catch (error) {
-						nestedRefreshFailed = true;
-						console.error(`Failed to refresh nested async descendants for '${job.asyncDir}':`, error);
-					}
+	const refreshJob = (job: AsyncJobState): boolean => {
+		const widgetStateBefore = widgetRenderKey(job);
+		let nestedRefreshFailed = false;
+		const refreshNestedProjection = () => {
+			try {
+				updateAsyncJobNestedProjection(job);
+			} catch (error) {
+				nestedRefreshFailed = true;
+				console.error(`Failed to refresh nested async descendants for '${job.asyncDir}':`, error);
+			}
+		};
+		try {
+			emitNewControlEvents(job);
+			try {
+				if (job.nestedRoute) reconcileNestedAsyncDescendants(job.nestedRoute, { resultsDir, kill: options.kill, now: options.now });
+			} catch (error) {
+				nestedRefreshFailed = true;
+				console.error(`Failed to refresh nested async descendants for '${job.asyncDir}':`, error);
+			}
+			refreshNestedProjection();
+			const reconciliation = reconcileAsyncRun(job.asyncDir, {
+				resultsDir,
+				kill: options.kill,
+				now: options.now,
+				startedRun: {
+					runId: job.asyncId,
+					pid: job.pid,
+					sessionId: job.sessionId,
+					mode: job.mode,
+					agents: job.agents,
+					chainStepCount: job.chainStepCount,
+					parallelGroups: job.parallelGroups,
+					startedAt: job.startedAt,
+					sessionFile: job.sessionFile,
+				},
+			});
+			const status = reconciliation.status ?? readStatus(job.asyncDir);
+			if (status) {
+				const previousStatus = job.status;
+				job.status = status.state;
+				if (job.status === "running") runningJobIds.add(job.asyncId);
+				else runningJobIds.delete(job.asyncId);
+				if (job.status !== "complete" && job.status !== "failed" && job.status !== "paused" && job.status !== "stopped") cancelCleanup(job.asyncId);
+				job.sessionId = status.sessionId ?? job.sessionId;
+				job.activityState = status.activityState;
+				job.lastActivityAt = status.lastActivityAt ?? job.lastActivityAt;
+				job.currentTool = status.currentTool;
+				job.currentToolStartedAt = status.currentToolStartedAt;
+				job.currentPath = status.currentPath;
+				job.turnCount = status.turnCount ?? job.turnCount;
+				job.toolCount = status.toolCount ?? job.toolCount;
+				job.steering = status.steering ?? job.steering;
+				job.mode = status.mode;
+				job.parentWorkflowRunId = status.parentWorkflowRunId ?? job.parentWorkflowRunId;
+				job.workflowKey = status.workflowKey ?? job.workflowKey;
+				job.workflow = status.workflow ?? job.workflow;
+				job.currentStep = status.currentStep ?? job.currentStep;
+				job.chainStepCount = status.chainStepCount ?? job.chainStepCount;
+				job.startedAt = status.startedAt ?? job.startedAt;
+				if (status.lastUpdate !== undefined) job.updatedAt = status.lastUpdate;
+				if (status.steps?.length) {
+					const groups = normalizeParallelGroups(status.parallelGroups, status.steps.length, status.chainStepCount ?? status.steps.length);
+					job.parallelGroups = groups.length ? groups : job.parallelGroups;
+					job.hasParallelGroups = groups.length > 0 || job.hasParallelGroups;
+					const activeGroup = status.currentStep !== undefined
+						? groups.find((group) => status.currentStep! >= group.start && status.currentStep! < group.start + group.count)
+						: undefined;
+					const visibleSteps = activeGroup
+						? status.steps.slice(activeGroup.start, activeGroup.start + activeGroup.count).map((step, index) => ({ ...step, index: activeGroup.start + index }))
+						: status.steps.map((step, index) => ({ ...step, index }));
+					job.activeParallelGroup = Boolean(activeGroup);
+					job.agents = visibleSteps.map((step) => step.agent);
+					job.steps = visibleSteps;
 					refreshNestedProjection();
-				};
-				try {
-					emitNewControlEvents(job);
-					reconcileNestedDescendants();
-					const reconciliation = reconcileAsyncRun(job.asyncDir, {
-						resultsDir,
-						kill: options.kill,
-						now: options.now,
-						startedRun: {
-							runId: job.asyncId,
-							pid: job.pid,
-							sessionId: job.sessionId,
-							mode: job.mode,
-							agents: job.agents,
-							chainStepCount: job.chainStepCount,
-							parallelGroups: job.parallelGroups,
-							startedAt: job.startedAt,
-							sessionFile: job.sessionFile,
-						},
-					});
-					const status = reconciliation.status ?? readStatus(job.asyncDir);
-					if (status) {
-						const previousStatus = job.status;
-						job.status = status.state;
-						if (job.status !== "complete" && job.status !== "failed" && job.status !== "paused" && job.status !== "stopped") cancelCleanup(job.asyncId);
-						job.sessionId = status.sessionId ?? job.sessionId;
-						job.activityState = status.activityState;
-						job.lastActivityAt = status.lastActivityAt ?? job.lastActivityAt;
-						job.currentTool = status.currentTool;
-						job.currentToolStartedAt = status.currentToolStartedAt;
-						job.currentPath = status.currentPath;
-						job.turnCount = status.turnCount ?? job.turnCount;
-						job.toolCount = status.toolCount ?? job.toolCount;
-						job.steering = status.steering ?? job.steering;
-						job.mode = status.mode;
-						job.parentWorkflowRunId = status.parentWorkflowRunId ?? job.parentWorkflowRunId;
-						job.workflowKey = status.workflowKey ?? job.workflowKey;
-						job.workflow = status.workflow ?? job.workflow;
-						job.currentStep = status.currentStep ?? job.currentStep;
-						job.chainStepCount = status.chainStepCount ?? job.chainStepCount;
-						job.startedAt = status.startedAt ?? job.startedAt;
-						if (status.lastUpdate !== undefined) job.updatedAt = status.lastUpdate;
-						if (status.steps?.length) {
-							const groups = normalizeParallelGroups(status.parallelGroups, status.steps.length, status.chainStepCount ?? status.steps.length);
-							job.parallelGroups = groups.length ? groups : job.parallelGroups;
-							job.hasParallelGroups = groups.length > 0 || job.hasParallelGroups;
-							const activeGroup = status.currentStep !== undefined
-								? groups.find((group) => status.currentStep! >= group.start && status.currentStep! < group.start + group.count)
-								: undefined;
-							const visibleSteps = activeGroup
-								? status.steps.slice(activeGroup.start, activeGroup.start + activeGroup.count).map((step, index) => ({ ...step, index: activeGroup.start + index }))
-								: status.steps.map((step, index) => ({ ...step, index }));
-							job.activeParallelGroup = Boolean(activeGroup);
-							job.agents = visibleSteps.map((step) => step.agent);
-							job.steps = visibleSteps;
-							refreshNestedProjection();
-							job.stepsTotal = visibleSteps.length;
-							job.runningSteps = visibleSteps.filter((step) => step.status === "running").length;
-							job.completedSteps = visibleSteps.filter((step) => step.status === "complete" || step.status === "completed").length;
-							if (status.state === "complete") job.completedSteps = visibleSteps.length;
-						}
-						job.sessionDir = status.sessionDir ?? job.sessionDir;
-						job.outputFile = status.outputFile ?? job.outputFile;
-						job.totalTokens = status.totalTokens ?? job.totalTokens;
-						job.timeoutMs = status.timeoutMs ?? job.timeoutMs;
-						job.deadlineAt = status.deadlineAt ?? job.deadlineAt;
-						job.timedOut = status.timedOut ?? job.timedOut;
-						job.stopped = status.stopped ?? job.stopped;
-						job.turnBudget = status.turnBudget ?? job.turnBudget;
-						job.turnBudgetExceeded = status.turnBudgetExceeded ?? job.turnBudgetExceeded;
-						job.wrapUpRequested = status.wrapUpRequested ?? job.wrapUpRequested;
-						job.sessionFile = status.sessionFile ?? job.sessionFile;
-						if (job.status === "complete" || job.status === "failed" || job.status === "paused" || job.status === "stopped") {
-							rememberFleetJob(state, job);
-							if (!nestedRefreshFailed && !hasLiveNestedDescendants(job.nestedChildren) && (previousStatus !== job.status || !state.cleanupTimers.has(job.asyncId))) {
-								scheduleCleanup(job.asyncId);
-							}
-						}
-						if (widgetRenderKey(job) !== widgetStateBefore) widgetChanged = true;
-						continue;
-					}
-					if (job.status === "queued") {
-						job.status = "running";
-						job.updatedAt = Date.now();
-					}
-				} catch (error) {
-					if (job.status !== "failed") {
-						console.error(`Failed to read async status for '${job.asyncDir}':`, error);
-						job.status = "failed";
-						job.updatedAt = Date.now();
-					}
+					job.stepsTotal = visibleSteps.length;
+					job.runningSteps = visibleSteps.filter((step) => step.status === "running").length;
+					job.completedSteps = visibleSteps.filter((step) => step.status === "complete" || step.status === "completed").length;
+					if (status.state === "complete") job.completedSteps = visibleSteps.length;
+				}
+				job.sessionDir = status.sessionDir ?? job.sessionDir;
+				job.outputFile = status.outputFile ?? job.outputFile;
+				job.totalTokens = status.totalTokens ?? job.totalTokens;
+				job.timeoutMs = status.timeoutMs ?? job.timeoutMs;
+				job.deadlineAt = status.deadlineAt ?? job.deadlineAt;
+				job.timedOut = status.timedOut ?? job.timedOut;
+				job.stopped = status.stopped ?? job.stopped;
+				job.turnBudget = status.turnBudget ?? job.turnBudget;
+				job.turnBudgetExceeded = status.turnBudgetExceeded ?? job.turnBudgetExceeded;
+				job.wrapUpRequested = status.wrapUpRequested ?? job.wrapUpRequested;
+				job.sessionFile = status.sessionFile ?? job.sessionFile;
+				if (job.status === "complete" || job.status === "failed" || job.status === "paused" || job.status === "stopped") {
 					rememberFleetJob(state, job);
-					if (!hasLiveNestedDescendants(job.nestedChildren) && !state.cleanupTimers.has(job.asyncId)) {
+					if (!nestedRefreshFailed && !hasLiveNestedDescendants(job.nestedChildren) && (previousStatus !== job.status || !state.cleanupTimers.has(job.asyncId))) {
 						scheduleCleanup(job.asyncId);
 					}
 				}
-				if (widgetRenderKey(job) !== widgetStateBefore) widgetChanged = true;
+				return widgetRenderKey(job) !== widgetStateBefore;
 			}
+			if (job.status === "queued") {
+				job.status = "running";
+				job.updatedAt = Date.now();
+				runningJobIds.add(job.asyncId);
+			}
+		} catch (error) {
+			if (job.status !== "failed") {
+				console.error(`Failed to read async status for '${job.asyncDir}':`, error);
+				job.status = "failed";
+				job.updatedAt = Date.now();
+			}
+			runningJobIds.delete(job.asyncId);
+			rememberFleetJob(state, job);
+			if (!hasLiveNestedDescendants(job.nestedChildren) && !state.cleanupTimers.has(job.asyncId)) scheduleCleanup(job.asyncId);
+		}
+		return widgetRenderKey(job) !== widgetStateBefore;
+	};
 
-			if (widgetChanged) rerenderLastWidget();
-			else if (Array.from(state.asyncJobs.values()).some((job) => job.status === "running")) requestLastWidgetRender();
-		}, pollIntervalMs);
+	const scheduleJobRefresh = (asyncId: string, delayMs = EVENT_REFRESH_DEBOUNCE_MS) => {
+		if (refreshTimers.has(asyncId)) return;
+		const timer = setTimeout(() => {
+			refreshTimers.delete(asyncId);
+			const job = state.asyncJobs.get(asyncId);
+			if (job && refreshJob(job)) rerenderLastWidget();
+		}, delayMs);
+		timer.unref?.();
+		refreshTimers.set(asyncId, timer);
+	};
+
+	const watchJob = (job: AsyncJobState) => {
+		const watched = jobWatchers.get(job.asyncId) ?? { watchers: new Map<string, fs.FSWatcher>() };
+		const active = job.status === "queued" || job.status === "running";
+		const watchPath = (watchPath: string): boolean => {
+			if (watched.watchers.has(watchPath)) return true;
+			const nestedEventSink = job.nestedRoute?.eventSink === watchPath;
+			let watcher: fs.FSWatcher;
+			try {
+				watcher = fs.watch(resolveWatchPath(watchPath), (_event, file) => {
+					const rawFileName = file?.toString();
+					const fileName = rawFileName ?? path.basename(watchPath);
+					const nestedEventFile = nestedEventSink && (!rawFileName || rawFileName.endsWith(".json") || rawFileName.endsWith(".jsonl"));
+					if (fileName === "status.json" || fileName === "events.jsonl" || nestedEventFile) {
+						scheduleJobRefresh(job.asyncId);
+					}
+					if (watchPath !== job.asyncDir && !nestedEventSink) {
+						watcher.close();
+						watched.watchers.delete(watchPath);
+						watchJob(job);
+					}
+				});
+			} catch {
+				return false;
+			}
+			watcher.on("error", () => {
+				watcher.close();
+				watched.watchers.delete(watchPath);
+				if (watchPath.endsWith("status.json") || nestedEventSink) watchJob(job);
+			});
+			watcher.unref?.();
+			watched.watchers.set(watchPath, watcher);
+			return true;
+		};
+		watchPath(job.asyncDir);
+		const statusPath = path.join(job.asyncDir, "status.json");
+		const hadStatusWatcher = watched.watchers.has(statusPath);
+		const statusWatched = watchPath(statusPath);
+		if (statusWatched && !hadStatusWatcher) scheduleJobRefresh(job.asyncId);
+		watchPath(path.join(job.asyncDir, "events.jsonl"));
+		if (job.nestedRoute) watchPath(job.nestedRoute.eventSink);
+		if (!statusWatched && active && !watched.retryTimer) {
+			watched.retryTimer = setTimeout(() => {
+				watched.retryTimer = undefined;
+				const current = state.asyncJobs.get(job.asyncId);
+				if (current) watchJob(current);
+			}, WATCH_ATTACHMENT_RETRY_MS);
+			watched.retryTimer.unref?.();
+		} else if (statusWatched && watched.retryTimer) {
+			clearTimeout(watched.retryTimer);
+			watched.retryTimer = undefined;
+		}
+		if (watched.watchers.size > 0 || watched.retryTimer) jobWatchers.set(job.asyncId, watched);
+		else jobWatchers.delete(job.asyncId);
+	};
+
+	const watchAsyncRoot = () => {
+		if (rootWatcher) return;
+		try {
+			rootWatcher = fs.watch(resolveWatchPath(asyncDirRoot), (_event, file) => {
+				const runDirName = file?.toString();
+				for (const job of state.asyncJobs.values()) {
+					if (jobWatchers.has(job.asyncId) || (runDirName && path.basename(job.asyncDir) !== runDirName)) continue;
+					watchJob(job);
+					if (jobWatchers.has(job.asyncId)) scheduleJobRefresh(job.asyncId);
+				}
+			});
+			rootWatcher.on("error", () => {
+				rootWatcher?.close();
+				rootWatcher = undefined;
+			});
+			rootWatcher.unref?.();
+		} catch {
+			// The liveness sweep retries if the async root is not available yet.
+		}
+	};
+
+	const ensurePoller = () => {
+		watchAsyncRoot();
+		if (state.poller) return;
+		nextLivenessAt = Date.now() + livenessIntervalMs;
+		state.poller = setInterval(() => {
+			if (state.asyncJobs.size === 0) {
+				rerenderLastWidget([]);
+				if (state.poller) clearInterval(state.poller);
+				state.poller = null;
+				rootWatcher?.close();
+				rootWatcher = undefined;
+				return;
+			}
+			const now = Date.now();
+			if (now >= nextLivenessAt) {
+				nextLivenessAt = now + livenessIntervalMs;
+				let widgetChanged = false;
+				for (const job of state.asyncJobs.values()) {
+					watchJob(job);
+					if (refreshJob(job)) widgetChanged = true;
+				}
+				if (widgetChanged) rerenderLastWidget();
+			}
+			if (runningJobIds.size > 0) requestLastWidgetRender();
+		}, Math.min(POLL_INTERVAL_MS, livenessIntervalMs));
 		state.poller.unref?.();
 	};
 
@@ -457,7 +582,10 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			workflowKey: info.workflowKey,
 			controlEventCursor: 0,
 		});
-		rememberFleetJob(state, state.asyncJobs.get(info.id)!);
+		const job = state.asyncJobs.get(info.id)!;
+		rememberFleetJob(state, job);
+		watchJob(job);
+		scheduleJobRefresh(info.id, 0);
 		ensurePoller();
 		rerenderLastWidget();
 	};
@@ -471,9 +599,14 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		let nestedRefreshFailed = false;
 		if (job) {
 			job.status = result.state ?? (result.success ? "complete" : "failed");
+			runningJobIds.delete(asyncId);
 			job.stopped = result.stopped ?? job.stopped;
 			job.updatedAt = Date.now();
-			if (result.asyncDir) job.asyncDir = result.asyncDir;
+			if (result.asyncDir && result.asyncDir !== job.asyncDir) {
+				closeJobWatcher(asyncId);
+				job.asyncDir = result.asyncDir;
+				watchJob(job);
+			}
 			try {
 				updateAsyncJobNestedProjection(job);
 			} catch (error) {
@@ -486,10 +619,20 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		if (!nestedRefreshFailed && !hasLiveNestedDescendants(job?.nestedChildren)) scheduleCleanup(asyncId);
 	};
 
+	const dispose = () => {
+		if (state.poller) clearInterval(state.poller);
+		state.poller = null;
+		rootWatcher?.close();
+		rootWatcher = undefined;
+		for (const asyncId of jobWatchers.keys()) closeJobWatcher(asyncId);
+		for (const timer of refreshTimers.values()) clearTimeout(timer);
+		refreshTimers.clear();
+		runningJobIds.clear();
+	};
+
 	const resetJobs = (ctx?: ExtensionContext) => {
-		for (const timer of state.cleanupTimers.values()) {
-			clearTimeout(timer);
-		}
+		dispose();
+		for (const timer of state.cleanupTimers.values()) clearTimeout(timer);
 		state.cleanupTimers.clear();
 		state.asyncJobs.clear();
 		state.fleetJobs?.clear();
@@ -515,12 +658,14 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		for (const run of runs) {
 			const job = summaryToJob(run);
 			state.asyncJobs.set(run.id, job);
+			if (job.status === "running") runningJobIds.add(job.asyncId);
 			rememberFleetJob(state, job);
+			watchJob(job);
 		}
 		if (runs.length === 0) return;
 		ensurePoller();
 		rerenderLastWidget();
 	};
 
-	return { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs };
+	return { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs, dispose };
 }

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { getProjectArtifactsDir } from "../../src/shared/artifacts.ts";
 import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { SubagentFleetComponent } from "../../src/tui/fleet.ts";
+import { createNestedRoute } from "../../src/runs/shared/nested-events.ts";
 import { createTempDir, removeTempDir, tryImport } from "../support/helpers.ts";
 
 interface AsyncJobTrackerModule {
@@ -31,6 +32,20 @@ interface AsyncJobTrackerModule {
 
 const trackerMod = await tryImport<AsyncJobTrackerModule>("./src/runs/background/async-job-tracker.ts");
 const available = !!trackerMod;
+
+type AsyncJobTracker = ReturnType<AsyncJobTrackerModule["createAsyncJobTracker"]>;
+const activeTrackers = new Set<AsyncJobTracker>();
+
+function createTracker(...args: Parameters<AsyncJobTrackerModule["createAsyncJobTracker"]>): AsyncJobTracker {
+	const tracker = trackerMod!.createAsyncJobTracker(...args);
+	activeTrackers.add(tracker);
+	return tracker;
+}
+
+afterEach(() => {
+	for (const tracker of activeTrackers) tracker.resetJobs();
+	activeTrackers.clear();
+});
 
 function createState() {
 	return {
@@ -120,7 +135,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		try {
 			const state = createState();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot);
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot);
 			(state as { lastUiContext: unknown }).lastUiContext = {
 				get hasUI() {
 					throw new Error("This extension ctx is stale after session replacement or reload.");
@@ -142,7 +157,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const state = createState();
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				completionRetentionMs: 5,
 			});
 			tracker.resetJobs(ui.ctx as never);
@@ -168,7 +183,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const state = createState();
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				widgetEnabled: false,
 			});
 			tracker.resetJobs(ui.ctx as never);
@@ -230,7 +245,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			state.currentSessionId = "session-restored";
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.resetJobs(ui.ctx as never);
@@ -271,7 +286,58 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
-	it("restores workflow state and refreshes live workflow progress after reload", async () => {
+	it("refreshes restored nested async children from event files before the liveness sweep", async () => {
+		const asyncRoot = createTempDir("pi-async-job-restore-nested-events-");
+		const nestedRoute = createNestedRoute("run-restored-nested");
+		const routeRoot = path.dirname(nestedRoute.eventSink);
+		try {
+			const runDir = path.join(asyncRoot, "run-restored-nested");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-restored-nested",
+				mode: "single",
+				state: "running",
+				sessionId: "session-restored-nested",
+				startedAt: 1000,
+				lastUpdate: 2000,
+				steps: [{ agent: "worker", status: "running" }],
+			}), "utf-8");
+			updateActiveRunIndex(runDir, "running");
+			const state = createState();
+			state.currentSessionId = "session-restored-nested";
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 60_000 });
+			tracker.restoreActiveJobs();
+			assert.equal(state.asyncJobs.get("run-restored-nested")?.nestedRoute?.eventSink, nestedRoute.eventSink);
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+			fs.writeFileSync(path.join(nestedRoute.eventSink, "0000000003000-child.json"), JSON.stringify({
+				type: "subagent.nested.started",
+				ts: 3000,
+				rootRunId: nestedRoute.rootRunId,
+				parentRunId: "run-restored-nested",
+				parentStepIndex: 0,
+				capabilityToken: nestedRoute.capabilityToken,
+				child: {
+					id: "nested-child",
+					parentRunId: "run-restored-nested",
+					parentStepIndex: 0,
+					depth: 1,
+					path: [{ runId: "run-restored-nested", stepIndex: 0 }],
+					state: "running",
+					agent: "nested-worker",
+				},
+			}), "utf-8");
+
+			await waitForCondition(() => state.asyncJobs.get("run-restored-nested")?.nestedChildren?.[0]?.id === "nested-child", "restored evented nested child refresh", 1000);
+			assert.equal(state.asyncJobs.get("run-restored-nested")?.steps?.[0]?.children?.[0]?.id, "nested-child");
+			tracker.resetJobs();
+		} finally {
+			removeTempDir(asyncRoot);
+			removeTempDir(routeRoot);
+		}
+	});
+
+	it("refreshes restored workflow status from filesystem events before the liveness sweep", async () => {
 		const asyncRoot = createTempDir("pi-async-job-restore-workflow-");
 		try {
 			const runDir = path.join(asyncRoot, "workflow-run");
@@ -290,7 +356,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			updateActiveRunIndex(runDir, "running");
 			const state = createState();
 			state.currentSessionId = "session-workflow";
-			const tracker = trackerMod!.createAsyncJobTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 10 });
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 60_000 });
 			tracker.restoreActiveJobs();
 			assert.deepEqual(state.asyncJobs.get("workflow-run")?.workflow?.emits, [{ stage: "scan" }]);
 
@@ -304,11 +370,86 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				steps: [{ agent: "scan", label: "scan", status: "complete" }, { agent: "review", label: "review", status: "running" }],
 				workflow: { trace: [{ operation: "run", key: "review", state: "started" }], emits: [{ stage: "review" }], console: [] },
 			}), "utf-8");
-			await waitForCondition(() => JSON.stringify(state.asyncJobs.get("workflow-run")?.workflow?.emits) === JSON.stringify([{ stage: "review" }]), "workflow poll refresh", 1000);
+			await waitForCondition(() => JSON.stringify(state.asyncJobs.get("workflow-run")?.workflow?.emits) === JSON.stringify([{ stage: "review" }]), "evented workflow refresh", 1000);
 			assert.equal(state.asyncJobs.get("workflow-run")?.workflow?.trace[0]?.key, "review");
 			tracker.resetJobs();
 		} finally {
 			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("refreshes newly started runs when status appears after the run directory", async () => {
+		const asyncRoot = createTempDir("pi-async-job-late-status-");
+		try {
+			const runDir = path.join(asyncRoot, "late-status-run");
+			fs.mkdirSync(runDir, { recursive: true });
+			const state = createState();
+			state.currentSessionId = "session-late-status";
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 60_000 });
+			tracker.handleStarted({ id: "late-status-run", asyncDir: runDir, sessionId: "session-late-status", agent: "worker" });
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "late-status-run",
+				mode: "single",
+				state: "running",
+				sessionId: "session-late-status",
+				startedAt: 1000,
+				lastUpdate: 3000,
+				steps: [{ agent: "worker", status: "running", currentTool: "read" }],
+			}), "utf-8");
+
+			await waitForCondition(() => state.asyncJobs.get("late-status-run")?.steps?.[0]?.currentTool === "read", "late status refresh before liveness", 1000);
+			tracker.resetJobs();
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("refreshes nested async children from event files before the liveness sweep", async () => {
+		const asyncRoot = createTempDir("pi-async-job-nested-events-");
+		const nestedRoute = createNestedRoute("run-nested-events");
+		const routeRoot = path.dirname(nestedRoute.eventSink);
+		try {
+			const runDir = path.join(asyncRoot, "run-nested-events");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-nested-events",
+				mode: "single",
+				state: "running",
+				startedAt: 1000,
+				lastUpdate: 2000,
+				steps: [{ agent: "worker", status: "running" }],
+			}), "utf-8");
+			const state = createState();
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 60_000 });
+			tracker.handleStarted({ id: "run-nested-events", asyncDir: runDir, agent: "worker", nestedRoute });
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+			fs.writeFileSync(path.join(nestedRoute.eventSink, "0000000003000-child.json"), JSON.stringify({
+				type: "subagent.nested.started",
+				ts: 3000,
+				rootRunId: nestedRoute.rootRunId,
+				parentRunId: "run-nested-events",
+				parentStepIndex: 0,
+				capabilityToken: nestedRoute.capabilityToken,
+				child: {
+					id: "nested-child",
+					parentRunId: "run-nested-events",
+					parentStepIndex: 0,
+					depth: 1,
+					path: [{ runId: "run-nested-events", stepIndex: 0 }],
+					state: "running",
+					agent: "nested-worker",
+				},
+			}), "utf-8");
+
+			await waitForCondition(() => state.asyncJobs.get("run-nested-events")?.nestedChildren?.[0]?.id === "nested-child", "evented nested child refresh", 1000);
+			assert.equal(state.asyncJobs.get("run-nested-events")?.steps?.[0]?.children?.[0]?.id, "nested-child");
+			tracker.resetJobs();
+		} finally {
+			removeTempDir(asyncRoot);
+			removeTempDir(routeRoot);
 		}
 	});
 
@@ -330,7 +471,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			updateActiveRunIndex(runDir, "running");
 			const state = createState();
 			state.currentSessionId = "session-workflow";
-			const tracker = trackerMod!.createAsyncJobTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 10 });
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 10 });
 			tracker.restoreActiveJobs();
 			assert.equal(state.asyncJobs.get("workflow-child")?.parentWorkflowRunId, "workflow-parent");
 			assert.equal(state.asyncJobs.get("workflow-child")?.workflowKey, "review");
@@ -368,7 +509,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const state = createState();
 			state.currentSessionId = "session-owner";
-			const tracker = trackerMod!.createAsyncJobTracker(createEventRecorder().pi, state as never, asyncRoot, {
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.restoreActiveJobs();
@@ -385,7 +526,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		try {
 			const state = createState();
 			state.currentSessionId = "session-owner";
-			const tracker = trackerMod!.createAsyncJobTracker(createEventRecorder().pi, state as never, asyncRoot, {
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, {
 				completionRetentionMs: 5,
 				pollIntervalMs: 10,
 			});
@@ -425,7 +566,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				errors.push(args);
 			};
 
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.resetJobs(ui.ctx as never);
@@ -444,7 +585,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		try {
 			const state = createState();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot);
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot);
 
 			tracker.handleStarted({
 				id: "run-parallel-start",
@@ -501,7 +642,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const state = createState();
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.resetJobs(ui.ctx as never);
@@ -541,7 +682,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const state = createState();
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.resetJobs(ui.ctx as never);
@@ -601,7 +742,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const state = createState();
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				completionRetentionMs: 5,
 				pollIntervalMs: 10,
 			});
@@ -613,6 +754,35 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			assert.equal(state.asyncJobs.size, 0);
 			assert.ok(ui.renderRequests > 0, "expected polling cleanup to request a rerender");
 			assert.equal(ui.widgets.at(-1), undefined);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("watches run directories created after the start event", async () => {
+		const asyncRoot = createTempDir("pi-async-job-late-dir-");
+		try {
+			const runDir = path.join(asyncRoot, "run-late-dir");
+			const state = createState();
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, {
+				completionRetentionMs: 5,
+				pollIntervalMs: 60_000,
+			});
+			tracker.handleStarted({ id: "run-late-dir", asyncDir: runDir, agent: "worker" });
+			await waitForCondition(() => state.asyncJobs.get("run-late-dir")?.status === "running", "initial event refresh");
+
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-late-dir",
+				mode: "single",
+				state: "complete",
+				startedAt: Date.now() - 1000,
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "complete" }],
+			}), "utf-8");
+
+			await waitForCondition(() => !state.asyncJobs.has("run-late-dir"), "evented terminal cleanup");
+			tracker.resetJobs();
 		} finally {
 			removeTempDir(asyncRoot);
 		}
@@ -637,7 +807,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const state = createState();
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				completionRetentionMs: 5,
 				pollIntervalMs: 10,
 				resultsDir,
@@ -666,7 +836,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const state = createState();
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				completionRetentionMs: 5,
 				pollIntervalMs: 10,
 				resultsDir,
@@ -718,7 +888,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const state = createState();
 			const ui = createUiContext();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				completionRetentionMs: 5,
 				pollIntervalMs: 10,
 			});
@@ -745,7 +915,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			fs.writeFileSync(path.join(runDir, "status.json"), "{", "utf-8");
 			const state = createState();
 			const recorder = createEventRecorder();
-			tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				completionRetentionMs: 5,
 				pollIntervalMs: 10,
 			});
@@ -792,7 +962,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const state = createState();
 			const recorder = createEventRecorder();
-			tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				completionRetentionMs: 5,
 				pollIntervalMs: 10,
 			});
@@ -827,7 +997,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			fs.mkdirSync(runDir, { recursive: true });
 			const state = createState();
 			const recorder = createEventRecorder();
-			tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				completionRetentionMs: 1_000,
 				pollIntervalMs: 10,
 			});
@@ -887,7 +1057,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const state = createState();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.handleStarted({ id: "run-partial", asyncDir: runDir, agent: "worker" });
@@ -943,7 +1113,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const state = createState();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.handleStarted({ id: "run-chunked-control", asyncDir: runDir, agent: "worker" });
@@ -1007,7 +1177,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				controlEventCursor: 0,
 			});
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.ensurePoller();
@@ -1058,7 +1228,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const state = createState();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.handleStarted({ id: "run-new-large-control", asyncDir: runDir, agent: "worker" });
@@ -1125,7 +1295,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				updatedAt: Date.now(),
 			});
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.ensurePoller();
@@ -1165,7 +1335,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const state = createState();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.handleStarted({ id: "run-clear-tool", asyncDir: runDir, agent: "worker" });
@@ -1223,7 +1393,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const state = createState();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.handleStarted({ id: "run-channels", asyncDir: runDir, agent: "worker" });
@@ -1265,7 +1435,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const state = createState();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.handleStarted({ id: "run-active-intercom", asyncDir: runDir, agent: "worker" });
@@ -1309,7 +1479,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const state = createState();
 			const recorder = createEventRecorder();
-			const tracker = trackerMod!.createAsyncJobTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
 				pollIntervalMs: 10,
 			});
 			tracker.handleStarted({ id: "run-3", asyncDir: runDir, agent: "worker" });


### PR DESCRIPTION
## Summary

Make async job tracking event-driven. The tracker now refreshes jobs from coalesced filesystem events, keeps slow liveness repair as a fallback, and keeps the 250 ms path limited to widget repaint scheduling.

The final pass also watches `status.json` and `events.jsonl` directly and retries late `status.json` watcher attachment for normal async launches where the run directory exists before the status file.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-job-tracker.test.ts` (`30/30`)
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh review plus targeted follow-up reviews found no remaining issues.
