### PR TITLE
perf: prefer watcher-first control inboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Clarify the accepted mission launch object contract for tool callers.
 - Reduce repeated async status parsing, workflow trace projection, and constrained widget rendering work.
 - Keep parsed async statuses cached beyond 50 runs while preserving per-read freshness checks. Thanks to @bcanvural for #982.
+- Prefer native control inbox watchers over per-process 250 ms polling, with polling retained as a fallback.
 
 ### Fixed
 - Omit missing configured read files from child task instructions.

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -22,6 +22,7 @@ export const NATIVE_SUPERVISOR_TOOL_NAME = "subagent_supervisor";
 const MAX_MESSAGE_BYTES = 64 * 1024;
 const DEFAULT_ASK_TIMEOUT_MS = 10 * 60 * 1000;
 const CHANNEL_POLL_MS = Math.min(POLL_INTERVAL_MS, 500);
+const CHANNEL_SAFETY_POLL_MS = 5000;
 const STALE_EMPTY_CHANNEL_AGE_MS = 60 * 1000;
 const STALE_EMPTY_CHANNEL_CLEANUP_INTERVAL_MS = 60 * 1000;
 
@@ -67,6 +68,13 @@ interface IntercomParams {
 	to?: string;
 	message?: string;
 	replyTo?: string;
+}
+
+type SupervisorWatch = (filename: fs.PathLike, listener: fs.WatchListener<string>) => fs.FSWatcher;
+
+interface NativeSupervisorChannelDeps {
+	platform?: NodeJS.Platform;
+	watch?: SupervisorWatch;
 }
 
 const ContactSupervisorParamsSchema = Type.Object({
@@ -626,10 +634,16 @@ function buildParentIntercomTool(pending: Map<string, PendingSupervisorRequest>,
 	};
 }
 
-export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentState): { start: () => void; dispose: () => void; pending: Map<string, PendingSupervisorRequest> } {
+export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentState, deps: NativeSupervisorChannelDeps = {}): { start: () => void; dispose: () => void; pending: Map<string, PendingSupervisorRequest> } {
+	const watch = deps.watch ?? fs.watch;
 	const pending = new Map<string, PendingSupervisorRequest>();
 	const seenFiles = new Set<string>();
+	const requestWatchers = new Map<string, fs.FSWatcher>();
+	let rootWatcher: fs.FSWatcher | undefined;
 	let poller: ReturnType<typeof setInterval> | undefined;
+	let safetyPoller: ReturnType<typeof setInterval> | undefined;
+	let deferredWatcherRefresh: ReturnType<typeof setImmediate> | undefined;
+	let started = false;
 	let lastStaleCleanupAt = 0;
 
 	const registerParentTools = (): void => {
@@ -696,17 +710,101 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		}
 	};
 
+	const startPolling = (): void => {
+		if (poller) return;
+		poller = setInterval(poll, CHANNEL_POLL_MS);
+		poller.unref?.();
+	};
+	const startSafetyPolling = (): void => {
+		if (safetyPoller) return;
+		safetyPoller = setInterval(() => {
+			watchExistingRequestDirs();
+			poll();
+		}, CHANNEL_SAFETY_POLL_MS);
+		safetyPoller.unref?.();
+	};
+	const watchRequestDir = (requestsDir: string): void => {
+		if (requestWatchers.has(requestsDir)) return;
+		try {
+			const watcher = watch(requestsDir, () => poll());
+			watcher.on("error", () => {
+				try { watcher.close(); } catch {}
+				requestWatchers.delete(requestsDir);
+				startPolling();
+			});
+			watcher.unref?.();
+			requestWatchers.set(requestsDir, watcher);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") startPolling();
+		}
+	};
+	const watchExistingRequestDirs = (): void => {
+		let channelEntries: fs.Dirent[];
+		try {
+			channelEntries = fs.readdirSync(SUPERVISOR_CHANNEL_ROOT, { withFileTypes: true });
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			startPolling();
+			return;
+		}
+		for (const entry of channelEntries) {
+			if (entry.isDirectory()) watchRequestDir(path.join(SUPERVISOR_CHANNEL_ROOT, entry.name, REQUESTS_DIR));
+		}
+	};
+	const scheduleWatcherRefresh = (): void => {
+		if (deferredWatcherRefresh) return;
+		deferredWatcherRefresh = setImmediate(() => {
+			deferredWatcherRefresh = undefined;
+			if (!started) return;
+			watchExistingRequestDirs();
+			poll();
+		});
+		deferredWatcherRefresh.unref?.();
+	};
+
 	return {
 		start: () => {
-			if (poller) return;
+			if (started) return;
+			started = true;
 			registerParentTools();
 			poll();
-			poller = setInterval(poll, CHANNEL_POLL_MS);
-			poller.unref?.();
+			try {
+				fs.mkdirSync(SUPERVISOR_CHANNEL_ROOT, { recursive: true });
+				if ((deps.platform ?? process.platform) === "win32") {
+					startPolling();
+					return;
+				}
+				watchExistingRequestDirs();
+				rootWatcher = watch(SUPERVISOR_CHANNEL_ROOT, () => {
+					watchExistingRequestDirs();
+					poll();
+					scheduleWatcherRefresh();
+				});
+				rootWatcher.on("error", startPolling);
+				startSafetyPolling();
+				scheduleWatcherRefresh();
+			} catch {
+				startPolling();
+			}
 		},
 		dispose: () => {
+			started = false;
+			try {
+				rootWatcher?.close();
+			} catch {
+				// Best effort during shutdown.
+			}
+			rootWatcher = undefined;
+			for (const watcher of requestWatchers.values()) {
+				try { watcher.close(); } catch {}
+			}
+			requestWatchers.clear();
 			if (poller) clearInterval(poller);
 			poller = undefined;
+			if (safetyPoller) clearInterval(safetyPoller);
+			safetyPoller = undefined;
+			if (deferredWatcherRefresh) clearImmediate(deferredWatcherRefresh);
+			deferredWatcherRefresh = undefined;
 			pending.clear();
 			seenFiles.clear();
 		},

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -32,6 +32,7 @@ function writeJsonToExistingDir(filePath: string, payload: object): void {
 	}
 }
 export type ControlChannelTimers = { setInterval: typeof setInterval; clearInterval: typeof clearInterval };
+const CONTROL_SAFETY_POLL_INTERVAL_MS = 5000;
 type KillFn = (pid: number, signal?: NodeJS.Signals | 0) => unknown;
 
 export interface InterruptRequest {
@@ -621,9 +622,9 @@ export function deliverCheckpointDecisionRequest(input: {
 
 /**
  * Runner side: watch the control inbox and route interrupt requests into
- * `onInterrupt`. Uses `fs.watch` when available plus an interval poll as a
- * portable safety net (covers filesystems/platforms where `fs.watch` is
- * unreliable). Fires once per distinct request. Returns a disposer.
+ * `onInterrupt`. Uses `fs.watch` when available and starts interval polling
+ * only when native watching is unavailable or fails. Fires once per distinct
+ * request. Returns a disposer.
  */
 export function watchAsyncControlInbox(
 	asyncDir: string,
@@ -636,6 +637,7 @@ export function watchAsyncControlInbox(
 		onSteerCapability?: (capability: SteerCapability) => void;
 		onSteerAck?: (ack: SteerAck) => void;
 		pollIntervalMs?: number;
+		safetyPollIntervalMs?: number;
 		fs?: ControlChannelFs;
 		timers?: ControlChannelTimers;
 	},
@@ -669,27 +671,63 @@ export function watchAsyncControlInbox(
 	// Handle a request that may have arrived before the watcher started.
 	check();
 
-	let watcher: fs.FSWatcher | undefined;
-	try {
-		watcher = fsImpl.watch(resolveWatchPath(dir, fsImpl.realpathSync.native), () => check());
-		watcher.on?.("error", () => {
-			// fs.watch can emit on transient FS errors; the interval poll keeps us live.
+	const watchers: fs.FSWatcher[] = [];
+	const watchedDirs = new Set<string>();
+	let interval: ReturnType<typeof setInterval> | undefined;
+	let safetyInterval: ReturnType<typeof setInterval> | undefined;
+	const startPolling = (): void => {
+		if (interval || disposed) return;
+		interval = timers.setInterval(check, opts.pollIntervalMs ?? POLL_INTERVAL_MS);
+		interval.unref?.();
+	};
+	const startSafetyPolling = (): void => {
+		if (safetyInterval || disposed) return;
+		safetyInterval = timers.setInterval(check, opts.safetyPollIntervalMs ?? CONTROL_SAFETY_POLL_INTERVAL_MS);
+		safetyInterval.unref?.();
+	};
+	const watchDir = (target: string, create = false): void => {
+		if (disposed || watchedDirs.has(target)) return;
+		if (create) fsImpl.mkdirSync(target, { recursive: true });
+		const watcher = fsImpl.watch(resolveWatchPath(target, fsImpl.realpathSync.native), () => {
+			watchExistingSteerAckDirs();
+			check();
 		});
+		watcher.on?.("error", startPolling);
+		watchers.push(watcher);
+		watchedDirs.add(target);
+	};
+	const watchExistingSteerAckDirs = (): void => {
+		const ackRoot = path.join(dir, STEER_ACKS_DIR);
+		let entries: string[];
+		try {
+			entries = fsImpl.readdirSync(ackRoot).filter((name) => /^\d+$/.test(name));
+		} catch {
+			return;
+		}
+		for (const entry of entries) watchDir(path.join(ackRoot, entry));
+	};
+	try {
+		watchDir(dir);
+		watchDir(steerRequestsDir(asyncDir), true);
+		watchDir(steerCapabilitiesDir(asyncDir), true);
+		watchDir(path.join(dir, STEER_ACKS_DIR), true);
+		watchExistingSteerAckDirs();
+		startSafetyPolling();
 	} catch {
-		watcher = undefined;
+		startPolling();
 	}
-
-	const interval = timers.setInterval(check, opts.pollIntervalMs ?? POLL_INTERVAL_MS);
-	interval.unref?.();
 
 	return () => {
 		if (disposed) return;
 		disposed = true;
-		try {
-			watcher?.close();
-		} catch {
-			// ignore
+		for (const watcher of watchers) {
+			try {
+				watcher.close();
+			} catch {
+				// ignore
+			}
 		}
-		timers.clearInterval(interval);
+		if (interval) timers.clearInterval(interval);
+		if (safetyInterval) timers.clearInterval(safetyInterval);
 	};
 }

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -31,6 +31,7 @@ const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEX
 const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
 export const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
 const STEERING_LEGACY_SETTLE_FALLBACK_MS = 1000;
+const STEERING_SAFETY_POLL_INTERVAL_MS = 5000;
 
 const STRUCTURED_OUTPUT_INSTRUCTIONS = [
 	"This subagent step has a strict structured output contract.",
@@ -331,7 +332,13 @@ function registerToolBudget(pi: ExtensionAPI, budget: ResolvedToolBudget | undef
 
 export function registerSteeringInbox(
 	pi: ExtensionAPI,
-	deps: { watch?: typeof fs.watch; nativeRealpath?: (filePath: string) => string; legacySettleFallbackMs?: number } = {},
+	deps: {
+		watch?: typeof fs.watch;
+		nativeRealpath?: (filePath: string) => string;
+		legacySettleFallbackMs?: number;
+		safetyPollIntervalMs?: number;
+		timers?: Pick<typeof globalThis, "setInterval" | "clearInterval">;
+	} = {},
 ): void {
 	const steerInbox = process.env[SUBAGENT_STEER_INBOX_ENV]?.trim();
 	if (!steerInbox) return;
@@ -350,6 +357,7 @@ export function registerSteeringInbox(
 	let canSteer = typeof sendUserMessage === "function";
 	let watcher: fs.FSWatcher | undefined;
 	let interval: NodeJS.Timeout | undefined;
+	let safetyInterval: NodeJS.Timeout | undefined;
 	let settleFallback: NodeJS.Timeout | undefined;
 	const legacySettleFallbackMs = deps.legacySettleFallbackMs ?? STEERING_LEGACY_SETTLE_FALLBACK_MS;
 	const acknowledge = (request: SteerRequest, state: "delivered" | "queued" | "failed", message: string, deliveryStatus?: SteerDeliveryStatus): void => {
@@ -431,14 +439,24 @@ export function registerSteeringInbox(
 			return;
 		}
 		started = true;
+		const startPolling = (): void => {
+			if (interval || disposed) return;
+			interval = (deps.timers?.setInterval ?? setInterval)(flush, 250) as NodeJS.Timeout;
+			interval.unref?.();
+		};
+		const startSafetyPolling = (): void => {
+			if (safetyInterval || disposed) return;
+			safetyInterval = (deps.timers?.setInterval ?? setInterval)(flush, deps.safetyPollIntervalMs ?? STEERING_SAFETY_POLL_INTERVAL_MS) as NodeJS.Timeout;
+			safetyInterval.unref?.();
+		};
 		try {
 			watcher = (deps.watch ?? fs.watch)(resolveWatchPath(steerInbox, deps.nativeRealpath), () => flush());
-			watcher.on("error", () => {});
+			watcher.on("error", startPolling);
+			startSafetyPolling();
 		} catch {
 			watcher = undefined;
+			startPolling();
 		}
-		interval = setInterval(flush, 250);
-		interval.unref?.();
 	};
 	const activate = (): undefined => {
 		start();
@@ -534,7 +552,8 @@ export function registerSteeringInbox(
 		disposed = true;
 		clearSettleFallback();
 		try { watcher?.close(); } catch {}
-		if (interval) clearInterval(interval);
+		if (interval) (deps.timers?.clearInterval ?? clearInterval)(interval);
+		if (safetyInterval) (deps.timers?.clearInterval ?? clearInterval)(safetyInterval);
 	});
 }
 

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -313,14 +313,19 @@ describe("control channel: watchAsyncControlInbox", () => {
 	type WatchHarness = {
 		fsImpl: import("../../src/runs/background/control-channel.ts").ControlChannelFs;
 		timers: import("../../src/runs/background/control-channel.ts").ControlChannelTimers;
-		trigger: () => void;
+		trigger: (dir?: string) => void;
+		triggerError: (dir?: string) => void;
 		closed: () => boolean;
+		intervalCount: () => number;
+		intervalDelays: () => number[];
 		watchedDir: () => string | undefined;
 	};
 
 	function harness(nativeDir?: string): WatchHarness {
-		let listener: (() => void) | undefined;
+		const listeners = new Map<string, () => void>();
+		const errorListeners = new Map<string, () => void>();
 		let closed = false;
+		const intervalDelays: number[] = [];
 		let watchedDir: string | undefined;
 		const realpathSync = ((target: fs.PathLike, options?: unknown) => fs.realpathSync(target, options as BufferEncoding)) as typeof fs.realpathSync;
 		realpathSync.native = ((target: fs.PathLike) => nativeDir ?? fs.realpathSync.native(target)) as typeof fs.realpathSync.native;
@@ -333,15 +338,38 @@ describe("control channel: watchAsyncControlInbox", () => {
 			realpathSync,
 			watch: ((dir: string, cb: () => void) => {
 				watchedDir = dir;
-				listener = cb;
-				return { close: () => { closed = true; }, on: () => {} };
+				listeners.set(dir, cb);
+				return {
+					close: () => { closed = true; },
+					on: (event: string, handler: () => void) => {
+						if (event === "error") errorListeners.set(dir, handler);
+					},
+				};
 			}),
 		} as unknown as WatchHarness["fsImpl"];
 		const timers = {
-			setInterval: (() => ({ unref() {} })) as unknown as typeof setInterval,
+			setInterval: ((_handler: Parameters<typeof setInterval>[0], delay?: number) => {
+				intervalDelays.push(delay ?? 0);
+				return { unref() {} };
+			}) as unknown as typeof setInterval,
 			clearInterval: (() => {}) as unknown as typeof clearInterval,
 		};
-		return { fsImpl, timers, trigger: () => listener?.(), closed: () => closed, watchedDir: () => watchedDir };
+		return {
+			fsImpl,
+			timers,
+			trigger: (dir?: string) => {
+				if (dir) listeners.get(dir)?.();
+				else for (const listener of listeners.values()) listener();
+			},
+			triggerError: (dir?: string) => {
+				if (dir) errorListeners.get(dir)?.();
+				else for (const listener of errorListeners.values()) listener();
+			},
+			closed: () => closed,
+			intervalCount: () => intervalDelays.length,
+			intervalDelays: () => [...intervalDelays],
+			watchedDir: () => watchedDir,
+		};
 	}
 
 	it("registers the native canonical control inbox path", () => {
@@ -351,6 +379,32 @@ describe("control channel: watchAsyncControlInbox", () => {
 			const h = harness(nativeDir);
 			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers });
 			assert.equal(h.watchedDir(), nativeDir);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("does not start fast polling when native watch is available", () => {
+		const asyncDir = tmpAsyncDir("pi-control-watch-no-poll-");
+		try {
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers });
+			assert.deepEqual(h.intervalDelays(), [5000]);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("starts portable polling once when the native watcher fails", () => {
+		const asyncDir = tmpAsyncDir("pi-control-watch-fallback-");
+		try {
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers });
+			h.triggerError();
+			h.triggerError();
+			assert.deepEqual(h.intervalDelays(), [5000, 250]);
 			dispose();
 		} finally {
 			cleanup(asyncDir);
@@ -440,6 +494,32 @@ describe("control channel: watchAsyncControlInbox", () => {
 
 			assert.equal(interrupted, 0);
 			assert.deepEqual(steers, [{ message: "go narrower", targetIndex: 0 }]);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("delivers later steer files from the watched request directory without polling", () => {
+		const asyncDir = tmpAsyncDir("pi-control-watch-steer-nested-");
+		try {
+			const steers: string[] = [];
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, {
+				onInterrupt() {},
+				onSteer: (request) => steers.push(request.message),
+				fs: h.fsImpl,
+				timers: h.timers,
+			});
+
+			const watchedSteerDir = fs.realpathSync.native(steerRequestsDir(asyncDir));
+			requestAsyncSteer(asyncDir, { message: "first", id: "s1", ts: 1 });
+			h.trigger(watchedSteerDir);
+			requestAsyncSteer(asyncDir, { message: "second", id: "s2", ts: 2 });
+			h.trigger(watchedSteerDir);
+
+			assert.deepEqual(steers, ["first", "second"]);
+			assert.deepEqual(h.intervalDelays(), [5000]);
 			dispose();
 		} finally {
 			cleanup(asyncDir);

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -94,6 +94,14 @@ function ageChannel(channelDir: string, ageMs: number): void {
 	}
 }
 
+async function waitForCondition(condition: () => boolean, description: string): Promise<void> {
+	const deadline = Date.now() + 1000;
+	while (!condition()) {
+		if (Date.now() > deadline) assert.fail(`Timed out waiting for ${description}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
 function restoreEnv(): void {
 	for (const [key, value] of Object.entries(savedEnv)) {
 		if (value === undefined) delete process.env[key];
@@ -147,6 +155,72 @@ describe("native supervisor channel", () => {
 		assert.deepEqual(sent[0]?.options, { triggerTurn: true });
 		assert.equal(channel.pending.has(matchingId), false, "disposed channel clears pending requests");
 		assert.equal(sent.some(({ message }) => message.details?.id === otherId), false);
+	});
+
+	it("uses polling instead of native watchers on Windows", () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const requestId = writeRequest({ sessionId: currentSessionId, runId: `run-${randomUUID()}` });
+		const sent: Array<{ details?: { id?: string } }> = [];
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const pi = {
+			getAllTools: () => [],
+			registerTool: () => {},
+			sendMessage: (message: { details?: { id?: string } }) => { sent.push(message); },
+			getSessionName: () => "shared-name",
+		};
+		let watchCalls = 0;
+		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx), {
+			platform: "win32",
+			watch: (() => {
+				watchCalls += 1;
+				throw new Error("Windows supervisor channel must not call fs.watch.");
+			}) as never,
+		});
+
+		channel.start();
+		channel.dispose();
+
+		assert.equal(watchCalls, 0);
+		assert.deepEqual(sent.map((message) => message.details?.id), [requestId]);
+	});
+
+	it("delivers requests written under an existing request directory by watch event", async () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		makeEmptyChannel(runId);
+		const sent: Array<{ details?: { id?: string } }> = [];
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const pi = {
+			getAllTools: () => [],
+			registerTool: () => {},
+			sendMessage: (message: { details?: { id?: string } }) => { sent.push(message); },
+			getSessionName: () => "shared-name",
+		};
+		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx));
+
+		try {
+			channel.start();
+			const requestId = writeRequest({ sessionId: currentSessionId, runId });
+			await waitForCondition(() => sent.some((message) => message.details?.id === requestId), "supervisor request watch delivery");
+		} finally {
+			channel.dispose();
+		}
 	});
 
 	it("prunes stale empty supervisor channel directories before polling", () => {

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -235,6 +235,7 @@ describe("subagent prompt runtime", () => {
 			process.env[SUBAGENT_STEER_INBOX_ENV] = inbox;
 			const handlers = new Map<string, (payload?: unknown) => unknown>();
 			let watchedDir: fs.PathLike | undefined;
+			const intervalDelays: number[] = [];
 			const fakeWatcher = { on() { return fakeWatcher; }, close() {} } as fs.FSWatcher;
 
 			registerSteeringInbox({
@@ -251,10 +252,18 @@ describe("subagent prompt runtime", () => {
 					watchedDir = target;
 					return fakeWatcher;
 				}) as typeof fs.watch,
+				timers: {
+					setInterval: ((_handler: Parameters<typeof setInterval>[0], delay?: number) => {
+						intervalDelays.push(delay ?? 0);
+						return { unref() {} };
+					}) as typeof setInterval,
+					clearInterval: (() => {}) as typeof clearInterval,
+				},
 			});
 
 			handlers.get("session_start")?.({});
 			assert.equal(watchedDir, nativeInbox);
+			assert.deepEqual(intervalDelays, [5000]);
 			handlers.get("session_shutdown")?.({});
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Prefer watcher-first control inbox delivery instead of permanent fast polling. Runner control, child steering, and supervisor inbox paths now rely on native watch when available, keep fast polling for watcher setup/runtime failures, and keep a slow safety scan for silent missed filesystem events.

The supervisor channel avoids recursive `fs.watch` on Windows and watches concrete request directories so requests written under existing child channel directories are still delivered by watcher event first.

## Validation

- `node --experimental-strip-types --test test/unit/control-channel.test.ts test/unit/subagent-prompt-runtime.test.ts test/unit/native-supervisor-channel.test.ts` (`81/81`)
- `npm run typecheck`
- `git diff --check`
- Fresh review and targeted follow-up review found the supervisor request-directory gap; a final targeted review is running for the exact fix.
