### PR TITLE
perf: coalesce running status writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Move project-scoped pi-subagents storage from `.pi-subagents/` to `.pi/subagents/` for cleaner project roots. Thanks to @yceachan for #971.
 - Clarify the accepted mission launch object contract for tool callers.
 - Reduce repeated async status parsing, workflow trace projection, and constrained widget rendering work.
+- Coalesce rapid running-status writes while keeping terminal and attention status changes durable immediately.
 - Keep parsed async statuses cached beyond 50 runs while preserving per-read freshness checks. Thanks to @bcanvural for #982.
 - Prefer native control inbox watchers over per-process 250 ms polling, with polling retained as a fallback.
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { createFileCoalescer } from "../../shared/file-coalescer.ts";
 import { createChildTranscriptWriter, type ChildTranscriptWriter } from "../../shared/child-transcript.ts";
 import { closeSteerInbox, consumeInterruptRequest, consumeSteerRequests, deliverInterruptRequest, deliverStopRequest, deliverTimeoutRequest, enqueueStepSteer, steerAcksDir, steerCapabilityPath, stepSteerInboxDir, watchAsyncControlInbox, type SteerAck, type SteerCapability, type SteerRequest } from "./control-channel.ts";
 import { appendJsonl as appendRawJsonl, formatOutputArtifactContent, getArtifactPaths, writeArtifact, writeMetadata } from "../../shared/artifacts.ts";
@@ -2252,10 +2253,18 @@ async function runSubagent(
 		for (const node of graph.nodes) updateNode(node);
 		statusPayload.workflowGraph = graph;
 	};
-	const writeStatusPayload = (): void => {
+	const writeStatusPayloadNow = (): void => {
 		refreshWorkflowGraph();
 		writeAtomicJson(statusPath, statusPayload);
 		emitNestedSelfEvent(statusPayload.state === "running" || statusPayload.state === "queued" ? "subagent.nested.updated" : "subagent.nested.completed");
+	};
+	const statusWriteCoalescer = createFileCoalescer(writeStatusPayloadNow, 100);
+	const writeStatusPayload = (immediate = true): void => {
+		if (immediate || statusPayload.state !== "running" || statusPayload.activityState !== undefined) {
+			if (!statusWriteCoalescer.flush(statusPath)) writeStatusPayloadNow();
+			return;
+		}
+		statusWriteCoalescer.schedule(statusPath);
 	};
 	const updateExternalProcess = (index: number, process: ExternalProcessStatus): void => {
 		requiredStatusStep(statusPayload, index).externalProcess = process;
@@ -2783,7 +2792,7 @@ async function runSubagent(
 			step.lastActivityAt = now;
 			statusPayload.lastActivityAt = now;
 			statusPayload.lastUpdate = now;
-			writeStatusPayload();
+			writeStatusPayload(false);
 			return;
 		}
 		if (event.type === "tool_execution_start" && event.toolName) {
@@ -2919,7 +2928,7 @@ async function runSubagent(
 		statusPayload.lastActivityAt = now;
 		statusPayload.lastUpdate = now;
 		maybeEmitActiveLongRunning(flatIndex, now);
-		writeStatusPayload();
+		writeStatusPayload(false);
 	};
 	const updateRunnerActivityState = (now: number): boolean => {
 		if (!controlConfig.enabled) return false;
@@ -4480,6 +4489,7 @@ async function runSubagent(
 			statusPayload.error = `Step failed: ${failedStep.agent}`;
 		}
 	}
+	writeStatusPayload();
 	try {
 		writeAtomicJson(resultPath, {
 			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
@@ -4633,7 +4643,6 @@ async function runSubagent(
 			console.error(`Failed to write process-terminal candidate for '${id}':`, error);
 		}
 	}
-	writeStatusPayload();
 }
 
 async function waitForStartupControl(

--- a/src/runs/foreground/async-steering-action.ts
+++ b/src/runs/foreground/async-steering-action.ts
@@ -219,15 +219,14 @@ export async function steerAsyncRun(input: {
 			const limits = remainingSteeringRecoveryLimits(recoveryTarget.recoveryDescriptor, paused);
 			const revived = await input.recover(limits);
 			if (revived.isError || !revived.details.asyncId) throw new Error(revived.content[0]?.type === "text" ? revived.content[0].text : "Replacement launch failed; source run remains paused.");
-			const sourceStatus = readStatus(asyncDir);
-			const targetIndex = input.index ?? sourceStatus?.steering?.recent.find((request) => request.id === requestId)?.targets[0]?.index ?? status.steps?.findIndex((step) => step.status === "running") ?? -1;
-			if (sourceStatus?.state === "paused" && sourceStatus.steering && targetIndex >= 0) {
-				updateSteeringTarget(sourceStatus.steering, requestId, targetIndex, "recovered", Date.now(), { replacementRunId: revived.details.asyncId });
-				const stepSteering = sourceStatus.steps?.[targetIndex]?.steering;
+			const targetIndex = input.index ?? paused.steering?.recent.find((request) => request.id === requestId)?.targets[0]?.index ?? status.steps?.findIndex((step) => step.status === "running") ?? -1;
+			if (paused.steering && targetIndex >= 0) {
+				updateSteeringTarget(paused.steering, requestId, targetIndex, "recovered", Date.now(), { replacementRunId: revived.details.asyncId });
+				const stepSteering = paused.steps?.[targetIndex]?.steering;
 				if (stepSteering) updateSteeringTarget(stepSteering, requestId, targetIndex, "recovered", Date.now(), { replacementRunId: revived.details.asyncId });
-				writeAtomicJson(path.join(asyncDir, "status.json"), sourceStatus);
+				writeAtomicJson(path.join(asyncDir, "status.json"), paused);
 			}
-			const recovered = sourceStatus?.steering ? actionResultFromSteeringStatus(sourceStatus.steering, status.runId, requestId, revived.details.asyncId) : undefined;
+			const recovered = paused.steering ? actionResultFromSteeringStatus(paused.steering, status.runId, requestId, revived.details.asyncId) : undefined;
 			appendSteeringNotice("recovered", `Steering recovered for run ${status.runId}; replacement ${revived.details.asyncId} launched.`);
 			return { content: [{ type: "text", text: `Steering recovered for async run ${status.runId}; replacement ${revived.details.asyncId} launched after the source paused.` }], details: { mode: "management", results: [], steering: recovered ?? { requestId, state: "recovered", sourceRunId: status.runId, replacementRunId: revived.details.asyncId, deliveryStatus: "delivered", targets: [{ index: input.index ?? 0, state: "recovered" }] } } };
 		} catch (error) {

--- a/src/shared/file-coalescer.ts
+++ b/src/shared/file-coalescer.ts
@@ -5,6 +5,7 @@ interface TimerApi {
 
 interface FileCoalescer {
 	schedule(file: string, delayMs?: number): boolean;
+	flush(file: string): boolean;
 	clear(): void;
 }
 
@@ -28,6 +29,14 @@ export function createFileCoalescer(
 				handler(file);
 			}, delayMs);
 			pending.set(file, timer);
+			return true;
+		},
+		flush(file: string): boolean {
+			const timer = pending.get(file);
+			if (timer === undefined) return false;
+			timerApi.clearTimeout(timer);
+			pending.delete(file);
+			handler(file);
 			return true;
 		},
 		clear(): void {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -96,6 +96,7 @@ interface AsyncStatusPayload {
 	currentTool?: string;
 	currentPath?: string;
 	state?: string;
+	endedAt?: number;
 	launchContractDigest?: string;
 	launchResolvedExtensions?: LaunchResolvedExtensions;
 	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedExtensions;
@@ -483,6 +484,16 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const payload = await readAsyncPayload(id);
 		assert.equal(payload.success, true);
 		assert.equal(payload.results[0]?.output, "你好 from fragmented async JSON");
+	});
+
+	it("persists terminal status before creating the result artifact", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "completed output" });
+		const id = `async-terminal-status-${Date.now().toString(36)}`;
+		launchProtocolTest(id);
+		await waitForAsyncResultFile(id);
+		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
+		assert.equal(status.state, "complete");
+		assert.equal(status.endedAt !== undefined, true);
 	});
 
 	it("persists absent output provenance when async lifecycle text is synthetic", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/unit/file-coalescer.test.ts
+++ b/test/unit/file-coalescer.test.ts
@@ -53,6 +53,21 @@ describe("createFileCoalescer", () => {
 		assert.deepEqual(events.sort(), ["a.json", "b.json"]);
 	});
 
+	it("flushes a pending file immediately without a duplicate timer write", () => {
+		const events: string[] = [];
+		const timers = createFakeTimers();
+		const coalescer = createFileCoalescer((file) => events.push(file), 50, timers.timerApi);
+		coalescer.schedule("status.json");
+		coalescer.schedule("status.json");
+		assert.equal(timers.pendingCount(), 1);
+		assert.equal(coalescer.flush("status.json"), true);
+		assert.deepEqual(events, ["status.json"]);
+		assert.equal(timers.pendingCount(), 0);
+		timers.runAll();
+		assert.deepEqual(events, ["status.json"]);
+		assert.equal(coalescer.flush("status.json"), false);
+	});
+
 	it("clear cancels all pending handlers", () => {
 		const events: string[] = [];
 		const timers = createFakeTimers();


### PR DESCRIPTION
## Summary

Coalesce bursty running-status writes from async subagents. Normal running activity snapshots now use a short coalescing window, while initial, terminal, attention, and other externally visible states still flush immediately.

## Validation

- `node --experimental-strip-types --test test/unit/file-coalescer.test.ts` (`4/4`)
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'persists terminal status before creating the result artifact' test/integration/async-execution.test.ts` (`1/1`)
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh review found no issues.
