### PR TITLE
fix: make reviewer lanes read-only by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- Stop the bundled reviewer from inheriting chain-only plan/progress reads in ad-hoc review runs. Thanks to @Ostii for #1000.
+- Remove mutation-capable tools from the bundled reviewer so read-only review lanes have a hard launch-time tool boundary (#1007).
+
 ## [0.47.0] - 2026-08-11
 
 ### Changed

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,12 +1,11 @@
 ---
 name: reviewer
 description: Versatile review specialist for code diffs, plans, proposed solutions, codebase health, and PR/issue validation
-tools: read, grep, find, ls, bash, edit, write, intercom
+tools: read, grep, find, ls, intercom
 thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
-defaultReads: plan.md, progress.md
 ---
 
 You are a disciplined review subagent. Your job is to inspect, evaluate, and report findings with evidence. You do not guess; you verify from the code, tests, docs, or requirements.
@@ -51,9 +50,9 @@ Review a PR or issue by understanding the context, then verifying:
 - Tests and docs are updated as needed.
 
 ## Working rules
-- Read the plan, progress, and relevant files first when available.
+- Read the relevant files first. Read plan and progress when the task supplies them.
 - Repo-local `progress.md` files are allowed scratch/memory files. Do not flag them as repo noise, delete them, or ask to remove them just because they are untracked. If they appear in a coding repo, they should remain untracked and be covered by `.gitignore`.
-- Use `bash` only for read-only inspection (e.g., `git diff`, `git log`, `git show`, test runs).
+- Do not use shell commands or write files. Report any test or Git command that a supervisor must run.
 - Do not invent issues. Only report problems you can justify from evidence.
 - Prefer small corrective edits over broad rewrites.
 - If everything looks good, say so plainly.

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -616,6 +616,27 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 		assert.equal(fs.existsSync(path.join(tempDir, "progress.md")), false);
 	});
 
+	it("foreground chains resolve explicit reads inside the chain directory", async () => {
+		mockPi.onCall({ output: "Review done" });
+		const chainDir = path.join(tempDir, "chain-reads");
+		const runId = "chain-reads-run";
+		const runDir = path.join(chainDir, runId);
+		fs.mkdirSync(runDir, { recursive: true });
+		fs.writeFileSync(path.join(runDir, "plan.md"), "chain plan");
+		fs.writeFileSync(path.join(runDir, "progress.md"), "chain progress");
+
+		await executeChain!(makeChainParams(
+			[{ agent: "reviewer", task: "Review the chain artifacts.", reads: ["plan.md", "progress.md"] }],
+			[makeAgent("reviewer")],
+			{ chainDir, runId },
+		));
+
+		const taskArg = readCallArgs(0).at(-1) ?? "";
+		assert.ok(taskArg.includes("[Read from: "));
+		assert.ok(taskArg.includes(path.join(runDir, "plan.md")));
+		assert.ok(taskArg.includes(path.join(runDir, "progress.md")));
+	});
+
 	it("foreground chains still resolve defaultProgress inside the chain directory", async () => {
 		mockPi.onCall({ output: "Progress done" });
 		const agents = [makeAgent("reviewer", { defaultProgress: true })];

--- a/test/integration/parallel-execution.test.ts
+++ b/test/integration/parallel-execution.test.ts
@@ -15,6 +15,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { MockPi } from "../support/helpers.ts";
+import { discoverAgents } from "../../src/agents/agents.ts";
 import {
 	createEventBus,
 	createMockPi,
@@ -585,6 +586,28 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 		assert.equal(result.isError, undefined);
 		assert.equal(mockPi.callCount(), 2);
 		assert.equal(fs.existsSync(path.join(tempDir, "false")), false);
+	});
+
+	it("top-level parallel reviewer runs do not inherit bundled chain artifact reads", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		fs.writeFileSync(path.join(tempDir, "plan.md"), "chain plan");
+		fs.writeFileSync(path.join(tempDir, "progress.md"), "chain progress");
+		mockPi.onCall({ output: "Review done" });
+		const reviewer = discoverAgents(tempDir, "project").agents.find((agent) => agent.name === "reviewer");
+		assert.ok(reviewer, "expected bundled reviewer");
+		assert.equal(reviewer.defaultReads, undefined);
+		const executor = makeExecutor([reviewer]);
+
+		await executor.execute(
+			"parallel-reviewer-without-chain-artifacts",
+			{ tasks: [{ agent: "reviewer", task: "Review the supplied files." }] },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		const taskArg = readLastCallArgs().at(-1) ?? "";
+		assert.doesNotMatch(taskArg, /\[Read from:/);
+		assert.doesNotMatch(taskArg, /plan\.md|progress\.md/);
 	});
 
 	it("top-level parallel reads include existing files and omit missing files", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -27,6 +27,7 @@ import {
 	tryImport,
 } from "../support/helpers.ts";
 import registerSubagentExtension from "../../src/extension/index.ts";
+import { discoverAgents } from "../../src/agents/agents.ts";
 import {
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
 	SUBAGENT_DELEGATION_RESPONSE_EVENT,
@@ -3503,6 +3504,28 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.exitCode, 0);
 		assert.equal(result.finalOutput, "fresh assistant output");
 		assert.equal(fs.readFileSync(outputPath, "utf-8"), "fresh assistant output");
+	});
+
+	it("top-level reviewer runs do not inherit bundled chain artifact reads", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		fs.writeFileSync(path.join(tempDir, "plan.md"), "chain plan");
+		fs.writeFileSync(path.join(tempDir, "progress.md"), "chain progress");
+		mockPi.onCall({ output: "Review done" });
+		const reviewer = discoverAgents(tempDir, "project").agents.find((agent) => agent.name === "reviewer");
+		assert.ok(reviewer, "expected bundled reviewer");
+		assert.equal(reviewer.defaultReads, undefined);
+		const executor = makeExecutor([reviewer]);
+
+		await executor.execute(
+			"single-reviewer-without-chain-artifacts",
+			{ agent: "reviewer", task: "Review the supplied files." },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		const taskArg = readCallArgs().at(-1) ?? "";
+		assert.doesNotMatch(taskArg, /\[Read from:/);
+		assert.doesNotMatch(taskArg, /plan\.md|progress\.md/);
 	});
 
 	it("routes foreground single relative outputs to the run output artifact directory by default", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
+import { discoverAgents } from "../../src/agents/agents.ts";
 import { computeMcpServerHash } from "../../src/runs/shared/mcp-direct-tool-allowlist.ts";
 import {
 	TOOL_BUDGET_ENV,
@@ -727,6 +728,22 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			toolsArg.split(","),
 		);
 		assert.equal(env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV], toolDiagnosticPath);
+	});
+
+	it("launches the bundled reviewer without mutation-capable tools", () => {
+		const reviewer = discoverAgents(process.cwd(), "project").agents.find((agent) => agent.name === "reviewer");
+		assert.ok(reviewer, "expected bundled reviewer");
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "Review this change.",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: reviewer.tools,
+		});
+
+		assert.equal(args[args.indexOf("--tools") + 1], "read,grep,find,ls,intercom");
+		assert.doesNotMatch(args[args.indexOf("--tools") + 1] ?? "", /\b(?:bash|edit|write)\b/);
 	});
 
 	it("keeps structured_output available under explicit tool allowlists", () => {


### PR DESCRIPTION
## Summary

This fixes #1000 by removing the bundled reviewer `defaultReads` for `plan.md` and `progress.md`, so ad-hoc reviewer runs no longer receive chain-only root read hints.

It also addresses #1007 by making the bundled reviewer read-only at the launch tool boundary. The reviewer now keeps source inspection tools and supervisor coordination, but no longer receives `bash`, `edit`, or `write`.

## Validation

- `node --experimental-strip-types --test test/unit/pi-args.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='top-level reviewer runs do not inherit bundled chain artifact reads' test/integration/single-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='top-level parallel reviewer runs do not inherit bundled chain artifact reads' test/integration/parallel-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='foreground chains resolve explicit reads inside the chain directory' test/integration/chain-execution.test.ts`
- `npm run typecheck`
- `git diff --check`

Thanks to @Ostii for reporting #1000.

Fixes #1000.
Fixes #1007.
