### PR TITLE
fix: carry requested agent on workflow start traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Stop the bundled reviewer from inheriting chain-only plan/progress reads in ad-hoc review runs. Thanks to @Ostii for #1000.
 - Remove mutation-capable tools from the bundled reviewer so read-only review lanes have a hard launch-time tool boundary (#1007).
+- Show the requested child agent in workflow started trace entries. Thanks to @albertgwo for #1001.
 
 ## [0.47.0] - 2026-08-11
 

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -469,10 +469,13 @@ function validateKey(value: unknown, owner = "runs.run"): string {
 	return value;
 }
 
-function workflowStringMetadata(params: Record<string, unknown>): Pick<WorkflowScriptTraceEntry, "phase" | "label"> {
+function workflowStringMetadata(params: Record<string, unknown>): Pick<WorkflowScriptTraceEntry, "phase" | "label" | "agent"> {
 	return {
 		...(typeof params.phase === "string" && params.phase.trim() ? { phase: params.phase.trim() } : {}),
 		...(typeof params.label === "string" && params.label.trim() ? { label: params.label.trim() } : {}),
+		// Requested agent name, so a child is identifiable while it runs. Launch
+		// resolution overwrites this with the canonical name on the terminal entry.
+		...(typeof params.agent === "string" && params.agent.trim() ? { agent: params.agent.trim() } : {}),
 	};
 }
 


### PR DESCRIPTION
## Summary

This is a maintainer replacement for #1001. It preserves @albertgwo's implementation commit and adds the required changelog credit on top of the current main branch.

The change carries the requested agent name onto workflow `started` trace entries so live workflow status can show the actual child agent before the child completes. Terminal trace entries still keep the resolved child agent authoritative.

## Validation

- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/scripted-workflow.test.ts`
- `git diff --check`

Thanks to @albertgwo for #1001.

Supersedes #1001.
