### PR TITLE
fix: dismiss recovered workflow displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Add a display-only dismiss action for reload-recovered running workflows without claiming or attempting to stop their work (#1010).
 - Stop the bundled reviewer from inheriting chain-only plan/progress reads in ad-hoc review runs. Thanks to @Ostii for #1000.
 - Remove mutation-capable tools from the bundled reviewer so read-only review lanes have a hard launch-time tool boundary (#1007).
 - Show the requested child agent in workflow started trace entries. Thanks to @albertgwo for #1001.

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -490,6 +490,10 @@ function stopAsyncRun(
 		throw new SubagentRpcError("not_found", `Async run '${initialRunId}' was not found in the active session.`);
 	}
 
+	if (initialStatus.mode === "workflow" && initialStatus.state === "running") {
+		throw new SubagentRpcError("invalid_state", `Workflow ${initialRunId} is not controlled by this extension runtime; reload recovery cannot stop it safely.`);
+	}
+
 	let status;
 	try {
 		status = reconcileAsyncRun(location.asyncDir, { resultsDir, kill: options.kill, now: options.now }).status;

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -263,10 +263,10 @@ const SubagentParamProperties = {
 	})),
 	name: Type.Optional(Type.String({ description: "Human-readable name for action='schedule.create'." })),
 	id: Type.Optional(Type.String({
-		description: "Run id or prefix for status, interrupt, stop, resume, steer, append-step, approve-checkpoint, reject-checkpoint, mission.attach-run, or the decision id for mission.resolve-decision."
+		description: "Run id or prefix for status, interrupt, stop, dismiss, resume, steer, append-step, approve-checkpoint, reject-checkpoint, mission.attach-run, or the decision id for mission.resolve-decision."
 	})),
 	runId: Type.Optional(Type.String({
-		description: "Target run ID for interrupt, stop, resume, steer, append-step, approve-checkpoint, reject-checkpoint, or mission.attach-run. Prefer id for new calls."
+		description: "Target run ID for interrupt, stop, dismiss, resume, steer, append-step, approve-checkpoint, reject-checkpoint, or mission.attach-run. Prefer id for new calls."
 	})),
 	dir: Type.Optional(Type.String({
 		description: "Async run directory for action='status', action='stop', action='resume', or action='steer'."

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -452,6 +452,10 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 			if (usedActiveIndex) updateActiveRunIndex(asyncDir, "failed");
 			continue;
 		}
+		if (status.displayDismissedAt !== undefined) {
+			if (usedActiveIndex) updateActiveRunIndex(asyncDir, "complete");
+			continue;
+		}
 		if (usedActiveIndex && !isActiveAsyncState(status.state)) updateActiveRunIndex(asyncDir, status.state);
 		// Filter before the nested-route lookup: the lookup builds an index over
 		// the nested-events directory, so deferring it for filtered-out runs keeps

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -7,6 +7,7 @@ import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { formatModelThinking } from "../../shared/formatters.ts";
 import { formatActivityLabel } from "../../shared/status-format.ts";
 import { DIRS, type AsyncStatus, type Details, type ForegroundResumeRun, type NestedRunSummary, type SteeringStatus, type SubagentState } from "../../shared/types.ts";
+import { readStatus } from "../../shared/utils.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { resolveSubagentResultStatus } from "../../intercom/result-intercom.ts";
 import { readProcessTerminal, sanitizeProcessTerminal } from "./process-terminal.ts";
@@ -315,6 +316,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 	}
 
 	if (asyncDir) {
+		const diskStatus = readStatus(asyncDir);
 		let reconciliation;
 		try {
 			reconciliation = reconcileAsyncRun(asyncDir, { resultsDir, kill: deps.kill, now: deps.now });
@@ -327,6 +329,22 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			};
 		}
 		const status = reconciliation.status;
+		if (!status && diskStatus?.displayDismissedAt !== undefined) {
+			if (params.view === "transcript") {
+				if (currentSessionId && diskStatus.sessionId !== currentSessionId) {
+					return {
+						content: [{ type: "text", text: "Transcript view is only available for async runs owned by the current session." }],
+						isError: true,
+						details: { mode: "single", results: [] },
+					};
+				}
+				return { content: [{ type: "text", text: formatAsyncRunTranscript(diskStatus, asyncDir, { index: params.index, lines: params.lines, sessionRoots: deps.sessionRoots }) }], details: { mode: "single", results: [] } };
+			}
+			return {
+				content: [{ type: "text", text: `Run: ${diskStatus.runId}\nState: display-dismissed\nDismissed: ${new Date(diskStatus.displayDismissedAt).toISOString()}\nNo running work was terminated.` }],
+				details: { mode: "single", results: [] },
+			};
+		}
 		const effectiveRunId = status?.runId ?? resolvedId ?? "unknown";
 		const logPath = path.join(asyncDir, `subagent-log-${effectiveRunId}.md`);
 		const eventsPath = path.join(asyncDir, "events.jsonl");

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -154,7 +154,7 @@ function terminalStatusFromResult(status: AsyncStatus, resultPath: string, now: 
 			modelAttempts: child?.modelAttempts ?? step.modelAttempts,
 		};
 	});
-	return {
+	const terminalStatus: AsyncStatus = {
 		...status,
 		state: repair.state,
 		...(status.lifecycleArtifactVersion === 3 && (!status.processTerminal || status.processTerminal.state === "pending") ? {
@@ -166,6 +166,8 @@ function terminalStatusFromResult(status: AsyncStatus, resultPath: string, now: 
 		endedAt: status.endedAt ?? now,
 		steps,
 	};
+	delete terminalStatus.displayDismissedAt;
+	return terminalStatus;
 }
 
 function buildStartedStatus(asyncDir: string, startedRun: StartedRunMetadata, now: number): AsyncStatus {
@@ -341,7 +343,6 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 		if (stepRecord.model !== undefined && typeof stepRecord.model !== "string") throw new Error(`Invalid async status file '${statusPath}': steps[${index}].model must be a string.`);
 		if (stepRecord.thinking !== undefined && typeof stepRecord.thinking !== "string") throw new Error(`Invalid async status file '${statusPath}': steps[${index}].thinking must be a string.`);
 	}
-
 	const runId = effectiveStatus.runId || path.basename(asyncDir);
 	const resultPath = path.join(options.resultsDir ?? DIRS.results, `${runId}.json`);
 	if (fs.existsSync(resultPath)) {
@@ -353,7 +354,10 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 			updateActiveRunIndex(asyncDir, terminalStatus.state);
 			return { status: terminalStatus, repaired: true, resultPath, message: "Existing async result file was used to repair stale running status." };
 		}
-		return { status: effectiveStatus, repaired: false, resultPath };
+		if (effectiveStatus.displayDismissedAt === undefined) return { status: effectiveStatus, repaired: false, resultPath };
+	}
+	if (effectiveStatus.displayDismissedAt !== undefined) {
+		return { status: null, repaired: false, resultPath };
 	}
 
 	if (effectiveStatus.state !== "running" || typeof effectiveStatus.pid !== "number") {

--- a/src/runs/foreground/async-dismiss-action.ts
+++ b/src/runs/foreground/async-dismiss-action.ts
@@ -1,0 +1,85 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { DIRS, type Details, type SubagentState } from "../../shared/types.ts";
+import { readStatus } from "../../shared/utils.ts";
+import { updateActiveRunIndex } from "../background/active-run-index.ts";
+import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
+
+export function dismissRecoveredWorkflow(
+	state: SubagentState,
+	location: { asyncDir: string | null; resolvedId?: string },
+): AgentToolResult<Details> {
+	const asyncDir = location.asyncDir;
+	const runId = location.resolvedId ?? (asyncDir ? path.basename(asyncDir) : "requested");
+	if (!asyncDir) {
+		return {
+			content: [{ type: "text", text: `Recovered workflow '${runId}' has no disk status to dismiss.` }],
+			isError: true,
+			details: { mode: "management", results: [] },
+		};
+	}
+	const status = readStatus(asyncDir);
+	if (!status || status.mode !== "workflow") {
+		return {
+			content: [{ type: "text", text: `Run '${runId}' is not a recovered workflow.` }],
+			isError: true,
+			details: { mode: "management", results: [] },
+		};
+	}
+	if (!state.currentSessionId || status.sessionId !== state.currentSessionId) {
+		return {
+			content: [{ type: "text", text: `Recovered workflow '${runId}' was not found in the active session.` }],
+			isError: true,
+			details: { mode: "management", results: [] },
+		};
+	}
+	if (state.workflowControllers?.has(status.runId) || state.workflowControllers?.has(runId)) {
+		return {
+			content: [{ type: "text", text: `Workflow '${runId}' still has a live controller and cannot be dismissed.` }],
+			isError: true,
+			details: { mode: "management", results: [] },
+		};
+	}
+	if (status.state !== "running") {
+		return {
+			content: [{ type: "text", text: `Recovered workflow '${runId}' is ${status.state}, not running.` }],
+			isError: true,
+			details: { mode: "management", results: [] },
+		};
+	}
+	let latestStatus = status;
+	const resultPath = path.join(DIRS.results, `${status.runId}.json`);
+	if (fs.existsSync(resultPath)) {
+		const reconciled = reconcileAsyncRun(asyncDir).status;
+		if (reconciled && reconciled.state !== "running") {
+			return {
+				content: [{ type: "text", text: `Recovered workflow '${runId}' is ${reconciled.state}, not running.` }],
+				isError: true,
+				details: { mode: "management", results: [] },
+			};
+		}
+		if (reconciled) latestStatus = reconciled;
+	}
+
+	const dismissed = { ...latestStatus, displayDismissedAt: Date.now() };
+	writeAtomicJson(path.join(asyncDir, "status.json"), dismissed);
+	const repaired = reconcileAsyncRun(asyncDir).status;
+	if (repaired && repaired.state !== "running") {
+		return {
+			content: [{ type: "text", text: `Recovered workflow '${runId}' is ${repaired.state}, not running.` }],
+			isError: true,
+			details: { mode: "management", results: [] },
+		};
+	}
+	updateActiveRunIndex(asyncDir, "complete");
+	state.asyncJobs.delete(status.runId);
+	state.asyncJobs.delete(runId);
+	state.fleetJobs?.delete(status.runId);
+	state.fleetJobs?.delete(runId);
+	return {
+		content: [{ type: "text", text: `Dismissed recovered workflow ${status.runId} from the display. No running work was terminated.` }],
+		details: { mode: "management", results: [] },
+	};
+}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -94,6 +94,7 @@ import {
 	workflowForegroundSteeringLaunchOptions,
 } from "./workflow-foreground-steering.ts";
 import { stopAsyncRun } from "./async-stop-action.ts";
+import { dismissRecoveredWorkflow } from "./async-dismiss-action.ts";
 import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
 import { resolveAsyncRootResultPath, waitForImportedAsyncRoot } from "../background/chain-root-attachment.ts";
 import { attachRootChildrenToSteps, createNestedRoute, findNestedControlResult, resolveInheritedNestedRouteFromEnv, resolveNestedAsyncDir, resolveNestedParentAddressFromEnv, snapshotNestedEventFiles, updateForegroundNestedProjection, writeNestedControlRequest, writeNestedEvent, type NestedRunResolutionScope } from "../shared/nested-events.ts";
@@ -163,7 +164,7 @@ import {
 	wrapForkTask,
 } from "../../shared/types.ts";
 
-const MUTATING_MANAGEMENT_ACTIONS = new Set(["create", "update", "delete", "eject", "disable", "enable", "reset", "grant-spawn-budget", "watchdog.configure", "mission.create", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "inspector.open", "inspector.close", "project.open", "project.close", "worktree.discard", "refine", "refine.rollback", "schedule.create", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"]);
+const MUTATING_MANAGEMENT_ACTIONS = new Set(["create", "update", "delete", "eject", "disable", "enable", "reset", "grant-spawn-budget", "watchdog.configure", "mission.create", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "inspector.open", "inspector.close", "project.open", "project.close", "worktree.discard", "refine", "refine.rollback", "dismiss", "schedule.create", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"]);
 const DESTRUCTIVE_MANAGEMENT_ACTIONS = new Set(["delete", "eject", "disable", "reset", "mission.close", "worktree.discard", "refine.rollback", "inspector.close", "project.close", "stop", "interrupt", "reject-checkpoint", "schedule.delete"]);
 
 function editDistance(left: string, right: string): number {
@@ -5255,6 +5256,28 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				}
 				return deps.handleScheduledRunAction(paramsWithResolvedCwd, ctx);
 			}
+			if (deps.allowMutatingManagementActions === false && MUTATING_MANAGEMENT_ACTIONS.has(action)) {
+				return {
+					content: [{ type: "text", text: `Action '${action}' is not available from child-safe subagent fanout mode.` }],
+					isError: true,
+					details: { mode: "management" as const, results: [] },
+				};
+			}
+			if (action === "dismiss") {
+				const targetRunId = paramsWithResolvedCwd.runId ?? paramsWithResolvedCwd.id;
+				if (!targetRunId) return { content: [{ type: "text", text: "action='dismiss' requires id." }], isError: true, details: { mode: "management", results: [] } };
+				let resolved: ResolvedSubagentRunId | undefined;
+				try {
+					resolved = resolveSubagentRunId(targetRunId, omitUndefinedProperties({ state: deps.state, nested: nestedResolutionScopeForExecutor(deps) }));
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					return { content: [{ type: "text", text: message }], isError: true, details: { mode: "management", results: [] } };
+				}
+				if (resolved?.kind !== "async") {
+					return { content: [{ type: "text", text: `Run '${targetRunId}' is not a recovered workflow.` }], isError: true, details: { mode: "management", results: [] } };
+				}
+				return dismissRecoveredWorkflow(deps.state, resolved.location);
+			}
 			if (action === "stop") {
 				const targetRunId = paramsWithResolvedCwd.runId ?? paramsWithResolvedCwd.id;
 				const workflowController = targetRunId ? deps.state.workflowControllers?.get(targetRunId) : undefined;
@@ -5266,6 +5289,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (paramsWithResolvedCwd.dir) {
 					try {
 						const location = resolveAsyncRunLocation(paramsWithResolvedCwd, DIRS.async, DIRS.results);
+						const existingStatus = readStatus(location.asyncDir ?? "");
+						if (existingStatus?.mode === "workflow" && existingStatus.state === "running") {
+							return { content: [{ type: "text", text: `Workflow ${existingStatus.runId} is not controlled by this extension runtime; reload recovery cannot stop it safely.` }], isError: true, details: { mode: "management", results: [] } };
+						}
 						const stopResult = stopAsyncRun(deps.state, location.resolvedId ?? targetRunId ?? path.basename(location.asyncDir ?? paramsWithResolvedCwd.dir), deps.kill, location);
 						return stopResult ?? { content: [{ type: "text", text: `No running or queued async run was found for '${targetRunId ?? paramsWithResolvedCwd.dir}'.` }], isError: true, details: { mode: "management", results: [] } };
 					} catch (error) {
@@ -5346,13 +5373,6 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			if (!(SUBAGENT_ACTIONS as readonly string[]).includes(action)) {
 				return {
 					content: [{ type: "text", text: unknownSubagentActionMessage(action) }],
-					isError: true,
-					details: { mode: "management" as const, results: [] },
-				};
-			}
-			if (deps.allowMutatingManagementActions === false && MUTATING_MANAGEMENT_ACTIONS.has(action)) {
-				return {
-					content: [{ type: "text", text: `Action '${action}' is not available from child-safe subagent fanout mode.` }],
 					isError: true,
 					details: { mode: "management" as const, results: [] },
 				};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1290,6 +1290,8 @@ export interface AsyncStatus {
 	context?: "fresh" | "fork" | "mixed";
 	isNested?: boolean;
 	state: "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
+	/** Display-only dismissal marker for a reload-orphaned workflow. */
+	displayDismissedAt?: number;
 	error?: string;
 	activityState?: ActivityState;
 	lastActivityAt?: number;
@@ -1961,7 +1963,7 @@ export const SLASH_SUBAGENT_CANCEL_EVENT = "subagent:slash:cancel";
 export const POLL_INTERVAL_MS = 250;
 export const MAX_WIDGET_JOBS = 4;
 export const DEFAULT_SUBAGENT_MAX_DEPTH = 2;
-export const SUBAGENT_ACTIONS = ["list", "get", "models", "children.list", "guide", "create", "update", "delete", "eject", "disable", "enable", "reset", "mission.create", "mission.list", "mission.show", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "worktree.discard", "refine", "refine.show", "refine.rollback", "inspector.open", "inspector.status", "inspector.close", "project.open", "project.status", "project.close", "status", "grant-spawn-budget", "interrupt", "resume", "steer", "stop", "append-step", "approve-checkpoint", "reject-checkpoint", "doctor", "watchdog.status", "watchdog.check", "watchdog.configure", "watchdog.recommend-model", "schedule.create", "schedule.list", "schedule.show", "schedule.history", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"] as const;
+export const SUBAGENT_ACTIONS = ["list", "get", "models", "children.list", "guide", "create", "update", "delete", "eject", "disable", "enable", "reset", "mission.create", "mission.list", "mission.show", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "worktree.discard", "refine", "refine.show", "refine.rollback", "inspector.open", "inspector.status", "inspector.close", "project.open", "project.status", "project.close", "status", "grant-spawn-budget", "interrupt", "resume", "steer", "stop", "dismiss", "append-step", "approve-checkpoint", "reject-checkpoint", "doctor", "watchdog.status", "watchdog.check", "watchdog.configure", "watchdog.recommend-model", "schedule.create", "schedule.list", "schedule.show", "schedule.history", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"] as const;
 
 export const DEFAULT_FORK_PREAMBLE =
 	"You are a delegated subagent running from a fork of the parent session. " +

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -4,6 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { consumeSteerRequests, consumeSteerRequestsFromDir, stepSteerInboxDir, writeSteerAck } from "../../src/runs/background/control-channel.ts";
+import { listAsyncRuns } from "../../src/runs/background/async-status.ts";
+import { inspectSubagentStatus } from "../../src/runs/background/run-status.ts";
 import { createSubagentExecutor } from "../../src/runs/foreground/subagent-executor.ts";
 import { steerWorkflowForegroundTarget, workflowForegroundSteeringDir } from "../../src/runs/foreground/workflow-foreground-steering.ts";
 import { ASYNC_DIR, RESULTS_DIR, type SubagentState } from "../../src/shared/types.ts";
@@ -94,7 +96,7 @@ async function waitUntil<T>(read: () => T | undefined, timeoutMs = 5_000): Promi
 	throw new Error("Timed out waiting for async control test condition.");
 }
 
-function executorWithKill(state: SubagentState, kill: (pid: number, signal?: NodeJS.Signals | 0) => boolean) {
+function executorWithKill(state: SubagentState, kill: (pid: number, signal?: NodeJS.Signals | 0) => boolean, options: { allowMutatingManagementActions?: boolean } = {}) {
 	return createSubagentExecutor({
 		pi: { events: { emit() {}, on() { return () => {}; } }, getSessionName() { return "parent"; } } as any,
 		state,
@@ -105,6 +107,7 @@ function executorWithKill(state: SubagentState, kill: (pid: number, signal?: Nod
 		expandTilde: (value) => value,
 		discoverAgents: () => ({ agents: [] }),
 		kill,
+		...options,
 	});
 }
 
@@ -117,8 +120,8 @@ function ctx() {
 	} as any;
 }
 
-function text(result: Awaited<ReturnType<ReturnType<typeof executorWithKill>["execute"]>>): string {
-	return result.content[0]?.type === "text" ? result.content[0].text : "";
+function text(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content[0]?.type === "text" ? result.content[0].text ?? "" : "";
 }
 
 describe("async interrupt action", () => {
@@ -457,6 +460,163 @@ describe("async interrupt action", () => {
 			assert.deepEqual(kills, [{ pid: 12345, signal: 0 }]);
 		} finally {
 			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("dismisses only a reload-recovered running workflow without terminating work", async () => {
+		const state = createState();
+		state.currentSessionId = "session";
+		const runId = `dismiss-workflow-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false, sessionId: "session", mode: "workflow" });
+		try {
+			const result = await executorWithKill(state, () => {
+				throw new Error("dismiss must not inspect or signal the workflow pid");
+			}).execute("dismiss", { action: "dismiss", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, undefined);
+			assert.match(text(result), /Dismissed recovered workflow/);
+			assert.match(text(result), /No running work was terminated/);
+			const dismissed = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+			assert.equal(dismissed.state, "running");
+			assert.equal(typeof dismissed.displayDismissedAt, "number");
+			assert.equal(listAsyncRuns(ASYNC_DIR, { states: ["running"], sessionId: "session", kill: () => {
+				throw new Error("dismissed workflow listing must not inspect the pid");
+			} }).some((run) => run.id === runId), false);
+			const statusResult = inspectSubagentStatus({ action: "status", id: runId }, { state, kill: () => {
+				throw new Error("dismissed workflow status must not inspect the pid");
+			} });
+			const statusText = text(statusResult);
+			assert.match(statusText, /State: display-dismissed/);
+			assert.match(statusText, /No running work was terminated/);
+			assert.doesNotMatch(statusText, /Steer/);
+			const transcriptResult = inspectSubagentStatus({ action: "status", id: runId, view: "transcript" }, { state, kill: () => {
+				throw new Error("dismissed workflow transcript must not inspect the pid");
+			} });
+			assert.doesNotMatch(text(transcriptResult), /Status file not found/);
+			const stopResult = await executorWithKill(state, () => {
+				throw new Error("dismissed workflow stop must not inspect or signal the pid");
+			}).execute("stop-dismissed", { action: "stop", id: runId }, new AbortController().signal, undefined, ctx());
+			assert.equal(stopResult.isError, true);
+			assert.doesNotMatch(text(stopResult), /Stop requested/);
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "stop.json")), false);
+			const stopDirResult = await executorWithKill(state, () => {
+				throw new Error("dismissed workflow stop by dir must not inspect or signal the pid");
+			}).execute("stop-dismissed-dir", { action: "stop", dir: asyncDir }, new AbortController().signal, undefined, ctx());
+			assert.equal(stopDirResult.isError, true);
+			assert.doesNotMatch(text(stopDirResult), /Stop requested/);
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "stop.json")), false);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("rejects transcript view for display-dismissed workflows from another session", async () => {
+		const state = createState();
+		state.currentSessionId = "session";
+		const runId = `dismiss-other-session-transcript-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false, sessionId: "other-session", mode: "workflow" });
+		try {
+			const statusPath = path.join(asyncDir, "status.json");
+			writeJson(statusPath, { ...JSON.parse(fs.readFileSync(statusPath, "utf-8")), displayDismissedAt: Date.now() });
+			fs.writeFileSync(path.join(asyncDir, "output-0.log"), "SECRET_OTHER_SESSION_OUTPUT", "utf-8");
+
+			const result = inspectSubagentStatus({ action: "status", id: runId, view: "transcript", index: 0 }, { state, kill: () => true });
+
+			assert.equal(result.isError, true);
+			assert.match(text(result), /owned by the current session/);
+			assert.doesNotMatch(text(result), /SECRET_OTHER_SESSION_OUTPUT/);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("shows terminal status when a result appears after display dismissal", async () => {
+		const state = createState();
+		state.currentSessionId = "session";
+		const runId = `dismiss-then-complete-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false, sessionId: "session", mode: "workflow" });
+		try {
+			const dismissResult = await executorWithKill(state, () => true).execute("dismiss", { action: "dismiss", id: runId }, new AbortController().signal, undefined, ctx());
+			assert.equal(dismissResult.isError, undefined);
+			writeJson(path.join(RESULTS_DIR, `${runId}.json`), { runId, mode: "workflow", success: true, results: [] });
+
+			const statusResult = inspectSubagentStatus({ action: "status", id: runId }, { state, kill: () => true });
+			const statusText = text(statusResult);
+			assert.match(statusText, /State: complete/);
+			assert.doesNotMatch(statusText, /State: display-dismissed/);
+			const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+			assert.equal(status.state, "complete");
+			assert.equal(status.displayDismissedAt, undefined);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("rejects dismiss when a stale running workflow has a terminal result", async () => {
+		const state = createState();
+		state.currentSessionId = "session";
+		const runId = `dismiss-terminal-result-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false, sessionId: "session", mode: "workflow" });
+		writeJson(path.join(RESULTS_DIR, `${runId}.json`), { runId, mode: "workflow", success: true, results: [] });
+		try {
+			const result = await executorWithKill(state, () => {
+				throw new Error("terminal workflow dismiss must not inspect or signal the pid");
+			}).execute("dismiss-terminal-result", { action: "dismiss", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, true);
+			assert.match(text(result), /complete, not running/);
+			const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+			assert.equal(status.state, "complete");
+			assert.equal(status.displayDismissedAt, undefined);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("rejects dismiss from child-safe fanout mode", async () => {
+		const state = createState();
+		state.currentSessionId = "session";
+		const runId = `dismiss-child-safe-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false, sessionId: "session", mode: "workflow" });
+		try {
+			const result = await executorWithKill(state, () => true, { allowMutatingManagementActions: false })
+				.execute("dismiss-child-safe", { action: "dismiss", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, true);
+			assert.match(text(result), /child-safe subagent fanout mode/);
+			assert.equal(JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")).displayDismissedAt, undefined);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("rejects dismiss for live-controller, non-workflow, terminal, and other-session runs", async () => {
+		const cases = [
+			{ name: "live", mode: "workflow" as const, sessionId: "session", state: "running" as const, controller: true, pattern: /live controller/ },
+			{ name: "non-workflow", mode: "single" as const, sessionId: "session", state: "running" as const, pattern: /not a recovered workflow/ },
+			{ name: "terminal", mode: "workflow" as const, sessionId: "session", state: "running" as const, terminal: true, pattern: /complete, not running/ },
+			{ name: "other-session", mode: "workflow" as const, sessionId: "other", state: "running" as const, pattern: /active session/ },
+		];
+		for (const candidate of cases) {
+			const state = createState();
+			state.currentSessionId = "session";
+			const runId = `dismiss-${candidate.name}-${Date.now().toString(36)}`;
+			const asyncDir = createRunningAsync(state, runId, { track: false, sessionId: candidate.sessionId, mode: candidate.mode });
+			if (candidate.controller) state.workflowControllers = new Map([[runId, new AbortController()]]);
+			if (candidate.terminal) {
+				const statusPath = path.join(asyncDir, "status.json");
+				writeJson(statusPath, { ...JSON.parse(fs.readFileSync(statusPath, "utf-8")), state: "complete" });
+			}
+			try {
+				const result = await executorWithKill(state, () => {
+					throw new Error("dismiss rejection must not inspect or signal pids");
+				}).execute("dismiss", { action: "dismiss", id: runId }, new AbortController().signal, undefined, ctx());
+				assert.equal(result.isError, true, candidate.name);
+				assert.match(text(result), candidate.pattern, candidate.name);
+				assert.equal(JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")).displayDismissedAt, undefined, candidate.name);
+			} finally {
+				cleanup(runId, asyncDir);
+			}
 		}
 	});
 

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -627,6 +627,52 @@ describe("subagent extension RPC bridge", () => {
 		}
 	});
 
+	it("rejects stop requests for reload-recovered workflows", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-rpc-stop-workflow-"));
+		try {
+			const events = new FakeEvents();
+			const asyncRoot = path.join(root, "runs");
+			const resultsDir = path.join(root, "results");
+			const asyncDir = path.join(asyncRoot, "workflow-run");
+			let killCalls = 0;
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "workflow-run",
+				sessionId: "/sessions/parent.jsonl",
+				mode: "workflow",
+				state: "running",
+				pid: 4242,
+				startedAt: 100,
+				lastUpdate: 100,
+				steps: [{ agent: "worker", status: "running", startedAt: 100 }],
+			}, null, 2), "utf-8");
+			const bridge = registerSubagentRpcBridge({
+				events,
+				getContext: () => ctx(),
+				execute: async () => assert.fail("stop should not call executor"),
+				asyncDirRoot: asyncRoot,
+				resultsDir,
+				kill: () => {
+					killCalls++;
+					return true;
+				},
+				now: () => 150,
+			});
+
+			const reply = await request(events, "stop-workflow", "stop", { id: "workflow-run" });
+
+			assert.equal(reply.success, false);
+			assert.equal((reply as { error: { code: string; message: string } }).error.code, "invalid_state");
+			assert.match((reply as { error: { message: string } }).error.message, /reload recovery cannot stop it safely/);
+			assert.equal(fs.existsSync(stopRequestPath(asyncDir)), false);
+			assert.equal(killCalls, 0);
+
+			bridge.dispose();
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects stop requests for async runs from a different session", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-rpc-stop-session-"));
 		try {


### PR DESCRIPTION
## Summary

Fixes #1010.

This adds a display-only `dismiss` action for reload-recovered running workflows. It does not stop or signal any work. It only hides workflow records that belong to the current session, are still marked running, have no live workflow controller in this runtime, and have no terminal result to reconcile.

It also keeps the existing stop paths from falsely reporting success for recovered workflows.

## Validation

- `node --experimental-strip-types --test test/unit/async-interrupt-action.test.ts test/unit/rpc.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`