### PR TITLE
fix: honor artifact cleanup retention config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Honor configured artifact cleanup retention days and let `0` disable artifact cleanup. Thanks to @elecnix for #1012.
 - Add a display-only dismiss action for reload-recovered running workflows without claiming or attempting to stop their work (#1010).
 - Stop the bundled reviewer from inheriting chain-only plan/progress reads in ad-hoc review runs. Thanks to @Ostii for #1000.
 - Remove mutation-capable tools from the bundled reviewer so read-only review lanes have a hard launch-time tool boundary (#1007).

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -37,6 +37,15 @@ function validateFleetKeybindingsConfig(value: unknown): void {
 	}
 }
 
+function validateArtifactConfig(value: unknown): void {
+	if (value === undefined) return;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("config.artifactConfig must be a JSON object");
+	const cleanupDays = (value as Record<string, unknown>).cleanupDays;
+	if (cleanupDays !== undefined && (typeof cleanupDays !== "number" || !Number.isInteger(cleanupDays) || cleanupDays < 0)) {
+		throw new Error("config.artifactConfig.cleanupDays must be a non-negative integer");
+	}
+}
+
 function validateConfig(config: Record<string, unknown>): void {
 	if (config.artifactDir !== undefined && !ARTIFACT_DIR_PREFERENCES.has(config.artifactDir as ArtifactDirPreference)) {
 		throw new Error(`config.artifactDir must be "project", "session", or "temp"`);
@@ -49,6 +58,7 @@ function validateConfig(config: Record<string, unknown>): void {
 	validatePermissionConfig(config.permissions);
 	validateScheduledRunsConfig(config.scheduledRuns);
 	validateFleetKeybindingsConfig(config.fleetKeybindings);
+	validateArtifactConfig(config.artifactConfig);
 }
 
 export function getConfigPath(): string {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -366,7 +366,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const asyncWidgetEnabled = config.asyncWidget !== false;
 	const summaryInlineToolDisplay = config.inlineToolDisplay === "summary";
 	const tempArtifactsDir = getArtifactsDir(null);
-	cleanupAllArtifactDirs(DEFAULT_ARTIFACT_CONFIG.cleanupDays);
+	const artifactCleanupDays = config.artifactConfig?.cleanupDays ?? DEFAULT_ARTIFACT_CONFIG.cleanupDays;
+	cleanupAllArtifactDirs(artifactCleanupDays);
 
 	const state: SubagentState = {
 		baseCwd: "",
@@ -706,7 +707,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		try {
 			const sessionFile = ctx.sessionManager.getSessionFile();
 			if (sessionFile) {
-				cleanupOldArtifacts(getArtifactsDir(sessionFile), DEFAULT_ARTIFACT_CONFIG.cleanupDays);
+				cleanupOldArtifacts(getArtifactsDir(sessionFile), artifactCleanupDays);
 			}
 		} catch {
 			// Cleanup failures should not block session lifecycle events.

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -228,7 +228,7 @@ export function appendJsonl(filePath: string, line: string): void {
 }
 
 export function cleanupOldArtifacts(dir: string, maxAgeDays: number): void {
-	if (!fs.existsSync(dir)) return;
+	if (maxAgeDays <= 0 || !fs.existsSync(dir)) return;
 
 	const markerPath = path.join(dir, CLEANUP_MARKER_FILE);
 	const now = Date.now();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1856,6 +1856,8 @@ export interface ExtensionConfig {
 	worktreeBaseDir?: string;
 	/** Where to store subagent artifact files. Defaults to "project" (cwd/.pi/subagents). Set to "session" for pi session dir, or "temp" for OS temp. */
 	artifactDir?: ArtifactDirPreference;
+	/** Artifact cleanup retention. Set cleanupDays to 0 to disable cleanup. */
+	artifactConfig?: Pick<ArtifactConfig, "cleanupDays">;
 	intercomBridge?: IntercomBridgeConfig;
 	proactiveSkillSubagents?: ProactiveSkillSubagentsConfig | false;
 	scheduledRuns?: ScheduledRunsConfig;

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -91,12 +91,13 @@ describe("PI_CODING_AGENT_DIR runtime paths", () => {
 
 		process.env.PI_CODING_AGENT_DIR = agentDir;
 		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
-		writeFile(configPath, JSON.stringify({ asyncByDefault: true, maxSubagentDepth: 3, artifactDir: "session" }));
+		writeFile(configPath, JSON.stringify({ asyncByDefault: true, maxSubagentDepth: 3, artifactDir: "session", artifactConfig: { cleanupDays: 9007199254740991 } }));
 
 		const config = loadConfig();
 		assert.equal(config.asyncByDefault, true);
 		assert.equal(config.maxSubagentDepth, 3);
 		assert.equal(config.artifactDir, "session");
+		assert.equal(config.artifactConfig?.cleanupDays, Number.MAX_SAFE_INTEGER);
 	});
 
 	it("discovers user agents, chains, and settings under the configured agent dir", () => {
@@ -204,6 +205,9 @@ Package skill content.
 		fs.utimesSync(artifactPath, oldTime, oldTime);
 
 		cleanupAllArtifactDirs(0);
+		assert.equal(fs.existsSync(artifactPath), true);
+
+		cleanupAllArtifactDirs(1 / 24 / 60 / 60 / 1000);
 		assert.equal(fs.existsSync(artifactPath), false);
 	});
 


### PR DESCRIPTION
Fixes #1012.

This wires the configured artifact cleanup retention into both cleanup call sites. The default stays at 7 days. Setting `artifactConfig.cleanupDays` to `0` now disables artifact cleanup instead of deleting everything immediately.

Thanks to @elecnix for the report and suggested fix.

Validation:
- `node --experimental-strip-types --test test/unit/pi-coding-agent-dir.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
