### PR TITLE
fix: tolerate empty-string entries in acceptance-report string arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Align unnamed intercom fallback orchestrator targets with pi-intercom's 18-character registered presence names so subagents without an explicit session name can reach their orchestrator. Thanks to @mystery4f for #1017.
 - Stop reading hyphenated adjectives like "must-fix items" or "should-fix tests" as implementation intent, which made the completion mutation guard hard-fail read-only review runs with a false "completed without making edits" error. Severity compounds (must|should|needs + dash + verb) are stripped before verb matching across every mutation pattern (incl. update/add/apply/make/do siblings), the acceptance-level write-capability check, and the patch-scope pattern, while CLI flags ("eslint --fix", "prettier --write") and clause-level dashes ("branch—fix it") keep their write intent. Thanks to @MarcusNeufeldt for #1020.
 - Add an optional LLM intent arbiter: when the completion guard is about to hard-fail a run that made no edits, a model decides — from the task text alone, never the child's own report — whether the task actually instructed file changes; only a confident read-only verdict rescues the run, before any failure state is published. Covers single, parallel, and chain foreground runs; enabled by default; set `PI_SUBAGENTS_LLM_INTENT_ARBITER=0` to disable. Thanks to @MarcusNeufeldt for #1020.
+- Tolerate empty-string entries in acceptance-report string-array fields instead of rejecting the whole report. Thanks to @hjiang for #1015.
 
 ## [0.47.1] - 2026-08-12
 

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -433,6 +433,7 @@ export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig, opt
 		"",
 		"Finish with a fenced JSON block tagged `acceptance-report` in this shape:",
 		"Use empty arrays when no items apply; array fields contain strings unless object entries are shown.",
+		"Empty-string entries (`[\"\"]`) are ignored; use `[]` when nothing applies.",
 		"`criteriaSatisfied[].status` must be exactly one of: satisfied, not-satisfied, not-applicable.",
 		"`commandsRun[].result` must be exactly one of: passed, failed, not-run.",
 		"`manualNotes` and `notes` are optional strings; an empty string means no note and does not satisfy `manual-notes` evidence.",
@@ -612,9 +613,17 @@ function normalizeAcceptanceReportValue(value: unknown, pathLabel = ""): { value
 			case "testsAddedOrUpdated":
 			case "validationOutput":
 			case "residualRisks":
-			case "reviewFindings":
-				normalized[canonical] = typeof fieldValue === "string" ? [fieldValue] : fieldValue;
+			case "reviewFindings": {
+				// Tolerate empty-string entries ("[\"\"]"): models write them for "no items"
+				// and a single empty entry must not reject the whole report. Drop them at
+				// parse time; non-string entries are kept so validateStringArrayField still
+				// flags structural garbage.
+				const items = typeof fieldValue === "string" ? [fieldValue] : fieldValue;
+				normalized[canonical] = Array.isArray(items)
+					? items.filter((item) => typeof item !== "string" || item.trim().length > 0)
+					: items;
 				break;
+			}
 			case "noStagedFiles": {
 				const token = typeof fieldValue === "string" ? fieldValue.trim().toLowerCase() : undefined;
 				normalized[canonical] = token === "true" ? true : token === "false" ? false : fieldValue;

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -245,6 +245,7 @@ describe("acceptance gates", () => {
 		assert.match(prompt, /Patch the bug/);
 		assert.match(prompt, /```acceptance-report/);
 		assert.match(prompt, /array fields contain strings/);
+		assert.match(prompt, /empty-string entr(?:y|ies).*\[\s*""\s*\]/i);
 		assert.match(prompt, /criteriaSatisfied\[\]\.status.*satisfied, not-satisfied, not-applicable/);
 		assert.match(prompt, /commandsRun\[\]\.result.*passed, failed, not-run/);
 		assert.match(prompt, /manualNotes.*optional strings.*empty string.*does not satisfy.*manual-notes/);
@@ -482,13 +483,42 @@ describe("acceptance gates", () => {
 			[{ criteriaSatisfied: [{ id: "criterion-1", status: "maybe", evidence: "proof" }] }, /criteriaSatisfied\[0\]\.status.*got "maybe"/],
 			[{ criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "proof", confidence: 1 }] }, /criteriaSatisfied\[0\]\.confidence: unsupported acceptance criterion field/],
 			[{ criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "proof" }, { id: "Criterion_1", status: "satisfied", evidence: "proof" }] }, /duplicate normalized criterion id 'criterion-1'/],
-			[{ reviewFindings: [""] }, /reviewFindings\[0\]: expected non-empty string; got ""/],
+			[{ reviewFindings: [{}] }, /reviewFindings\[0\]: expected non-empty string; got object/],
 			[{ noStagedFiles: "yes" }, /noStagedFiles: expected boolean; got "yes"/],
 		] as const) {
 			const parsed = parseAcceptanceReport(report(overrides));
 			assert.equal(parsed.report, undefined);
 			assert.match(parsed.error ?? "", expected);
 		}
+	});
+
+	it("tolerates empty-string entries in string-array fields by dropping them at parse time", () => {
+		// A model writing ["\"\""] for "no items" must not fail the whole report.
+		for (const field of ["changedFiles", "testsAddedOrUpdated", "validationOutput", "residualRisks", "reviewFindings"] as const) {
+			const parsed = parseAcceptanceReport(report({ [field]: [""] }));
+			assert.equal(parsed.error, undefined, `${field}: ["\"\""] should parse`);
+			assert.deepEqual(parsed.report?.[field], [], `${field}: empty-string entries dropped`);
+		}
+
+		// Mixed arrays keep only meaningful entries.
+		const mixed = parseAcceptanceReport(report({ reviewFindings: ["blocker: file.ts:12", ""] }));
+		assert.equal(mixed.error, undefined);
+		assert.deepEqual(mixed.report?.reviewFindings, ["blocker: file.ts:12"]);
+
+		// Whitespace-only entries are treated as empty.
+		const whitespace = parseAcceptanceReport(report({ validationOutput: ["  "] }));
+		assert.equal(whitespace.error, undefined);
+		assert.deepEqual(whitespace.report?.validationOutput, []);
+
+		// A single string is still coerced to a one-item array.
+		const coerced = parseAcceptanceReport(report({ changedFiles: "src/file.ts" }));
+		assert.equal(coerced.error, undefined);
+		assert.deepEqual(coerced.report?.changedFiles, ["src/file.ts"]);
+
+		// Structural garbage (non-string entries) is still rejected.
+		const invalid = parseAcceptanceReport(report({ reviewFindings: [{}] }));
+		assert.equal(invalid.report, undefined);
+		assert.match(invalid.error ?? "", /reviewFindings\[0\]: expected non-empty string; got object/);
 	});
 
 	it("accepts empty optional note strings without treating them as evidence", async () => {


### PR DESCRIPTION
## Problem

Chain subagents (e.g. the `scout` agent in a scout → planner → worker → reviewer chain) occasionally end their structured `acceptance-report` with `[""]` for a field that has no items. The report parser (`validateStringArrayField`) requires every entry in a string-array field to be a non-empty string, so **one placeholder empty-string entry rejects the entire report** — a run that exited 0 with complete, correct findings is marked `rejected` (runtime check `attestation` fails with e.g. `validationOutput[0]: expected non-empty string; got ""`).

## Fix

Two small changes in `src/runs/shared/acceptance.ts`:

1. **Parse-time tolerance** — `normalizeAcceptanceReportValue` now drops empty/whitespace-only entries from the five string-array fields (`changedFiles`, `testsAddedOrUpdated`, `validationOutput`, `residualRisks`, `reviewFindings`). Non-string entries are **kept**, so structural garbage (objects, numbers) still fails validation exactly as before.
2. **Contract clarity** — `formatAcceptancePrompt` now tells the model: *"An empty-string entry (\`[""]\`) is invalid and fails the report — use \`[]\` when nothing applies."*

## Tests

- Empty-string entries now parse to `[]` for all five fields.
- Mixed arrays (`["real finding", ""]`) keep only meaningful entries.
- Single-string coercion (`changedFiles: "src/file.ts"`) is unaffected.
- Non-string entries (`reviewFindings: [{}]`) are still rejected with `expected non-empty string; got object`.
- Updated the existing "blank evidence" rejection case to use a non-string entry, since `[""]` is now tolerated by design.

`test/unit/acceptance.test.ts`: 46/46 pass (`node --experimental-strip-types --test test/unit/acceptance.test.ts`).

## Motivation

Real-world failure: a read-only scout ran cleanly (exit 0, full findings with file paths and line ranges) but was rejected purely because its optional `validationOutput` field contained `[""]`. The tolerance preserves the validator's job (reject garbage) while not punishing models for using an empty string to mean "no items".