### PR TITLE
fix: align intercom fallback orchestrator target length with pi-intercom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+### Fixed
+- Align unnamed intercom fallback orchestrator targets with pi-intercom's 18-character registered presence names so subagents without an explicit session name can reach their orchestrator. Thanks to @mystery4f for #1017.
 ## [0.47.1] - 2026-08-12
 
 ### Fixed

--- a/src/intercom/intercom-bridge.ts
+++ b/src/intercom/intercom-bridge.ts
@@ -63,7 +63,10 @@ export function resolveIntercomSessionTarget(sessionName: string | undefined, se
 	if (trimmedName) return trimmedName;
 	const fallbackSessionId = intercomSessionId?.trim() || sessionId;
 	const normalizedSessionId = fallbackSessionId.startsWith("session-") ? fallbackSessionId.slice("session-".length) : fallbackSessionId;
-	return `${DEFAULT_INTERCOM_TARGET_PREFIX}-${normalizedSessionId.slice(0, 8)}`;
+	// NOTE: keep slice length in sync with pi-intercom's resolveIntercomPresenceName
+	// (index.ts: DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX + slice(0, 18)); mismatched lengths
+	// make fallback orchestrator targets unresolvable ("Session not found").
+	return `${DEFAULT_INTERCOM_TARGET_PREFIX}-${normalizedSessionId.slice(0, 18)}`;
 }
 
 function sanitizeIntercomTargetPart(value: string): string {

--- a/test/unit/intercom-bridge.test.ts
+++ b/test/unit/intercom-bridge.test.ts
@@ -52,7 +52,8 @@ describe("resolveIntercomSessionTarget", () => {
 	});
 
 	it("uses the current pi-intercom runtime id for unnamed fallback when present", () => {
-		assert.equal(resolveIntercomSessionTarget(undefined, "session-12345678", "session-stableabcdef"), "subagent-chat-stableab");
+		assert.equal(resolveIntercomSessionTarget(undefined, "session-12345678", "session-stableabcdef"), "subagent-chat-stableabcdef");
+		assert.equal(resolveIntercomSessionTarget(undefined, "session-12345678", "session-abcdefghijklmnopqrst"), "subagent-chat-abcdefghijklmnopqr");
 	});
 });
 


### PR DESCRIPTION
## Problem

Subagents intermittently fail to reach their orchestrator over intercom:

```
✗ intercom action=send
Message to "subagent-chat-019ff4f1" was not delivered: Session not found
```

## Root cause

`resolveIntercomSessionTarget` in `src/intercom/intercom-bridge.ts` builds the **fallback** orchestrator target as `subagent-chat-` + `sessionId.slice(0, 8)`, but pi-intercom registers the presence name as `subagent-chat-` + `sessionId.slice(0, 18)` (see `resolveIntercomPresenceName` in pi-intercom's `index.ts`).

For any session **without an explicit session name** (e.g. a subagent whose `PI_SUBAGENT_INTERCOM_SESSION_NAME` is empty), the child resolves its orchestrator target through this fallback path. The 8-char target:

- does not equal the 18-char registered presence name (`byName` miss),
- does not prefix the session UUID (`byIdPrefix` miss — the id does not start with `subagent-chat`),
- is not a session id (`byId` miss).

`resolveSessionTarget` returns `null`, the raw string is forwarded to the broker, and the broker answers `Session not found`.

## Reproduction

Launch a subagent from a session that has no explicit intercom session name, then from the child:

```
intercom({ action: "send", to: "<orchestratorTarget>", message: "probe" })
```

Observed target from `PI_SUBAGENT_ORCHESTRATOR_TARGET`: `subagent-chat-019ff4f1` (8 chars).
Observed registered presence name of the same session: `subagent-chat-019ff4f1-db04-79d6` (18 chars).
Result: `Message to "subagent-chat-019ff4f1" was not delivered: Session not found`.

Verified on pi-subagents 0.47.1 + pi-intercom (npm `0.10.0` / GitHub latest at `v0.10.0-1-gc9675a5`).

## Fix

Slice to **18** characters, matching pi-intercom's `resolveIntercomPresenceName` registration format exactly:

```ts
return `${DEFAULT_INTERCOM_TARGET_PREFIX}-${normalizedSessionId.slice(0, 18)}`;
```

## Verification

- Unit: `resolveIntercomSessionTarget(undefined, sessionId)` now returns `subagent-chat-` + 18-char prefix, identical to the registered presence name.
- The fix only affects the fallback path (sessions without an explicit name); named sessions are unchanged.

## Notes

- Alternative one-line fix on the pi-intercom side would be slicing the registered name to 8 chars, but the presence name is user-visible in `intercom list` and 18 chars carries more disambiguating information; aligning the orchestrator target to the registration format keeps the public surface stable.
