### PR TITLE
fix: do not read hyphenated adjectives as implementation intent, add LLM intent arbiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Fixed
 - Reject configured worktree base directories inside the agent extensions directory, including symlink aliases (#1014).
 - Align unnamed intercom fallback orchestrator targets with pi-intercom's 18-character registered presence names so subagents without an explicit session name can reach their orchestrator. Thanks to @mystery4f for #1017.
+- Stop reading hyphenated adjectives like "must-fix items" or "should-fix tests" as implementation intent, which made the completion mutation guard hard-fail read-only review runs with a false "completed without making edits" error. Severity compounds (must|should|needs + dash + verb) are stripped before verb matching across every mutation pattern (incl. update/add/apply/make/do siblings), the acceptance-level write-capability check, and the patch-scope pattern, while CLI flags ("eslint --fix", "prettier --write") and clause-level dashes ("branch—fix it") keep their write intent. Thanks to @MarcusNeufeldt for #1020.
+- Add an optional LLM intent arbiter: when the completion guard is about to hard-fail a run that made no edits, a model decides — from the task text alone, never the child's own report — whether the task actually instructed file changes; only a confident read-only verdict rescues the run, before any failure state is published. Covers single, parallel, and chain foreground runs; enabled by default; set `PI_SUBAGENTS_LLM_INTENT_ARBITER=0` to disable. Thanks to @MarcusNeufeldt for #1020.
+
 ## [0.47.1] - 2026-08-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -663,7 +663,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1450,7 +1449,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -34,6 +34,7 @@ import {
 import { discoverAvailableSkills, normalizeSkillInput } from "../../agents/skills.ts";
 import { INTERCOM_BRIDGE_MARKER } from "../../intercom/intercom-bridge.ts";
 import { runSync } from "./execution.ts";
+import { createTaskMutationArbiter } from "../shared/llm-intent-arbiter.ts";
 import { workflowForegroundSteeringLaunchOptions } from "./workflow-foreground-steering.ts";
 import {
 	beginForegroundChild,
@@ -388,6 +389,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
 				permissions: input.permissions,
 				parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
+				llmIntentArbiter: createTaskMutationArbiter(input.ctx),
 				...workflowForegroundSteeringLaunchOptions(input.foregroundControl, childIndex),
 				capabilityCeiling: input.capabilityCeiling,
 				context: input.contextForAgent?.(task.agent),
@@ -1369,6 +1371,7 @@ ${step.message}` : ""}` }],
 				r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
 				permissions: params.permissions,
 				parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
+				llmIntentArbiter: createTaskMutationArbiter(ctx),
 				...workflowForegroundSteeringLaunchOptions(params.foregroundControl, childIndex),
 				capabilityCeiling: params.capabilityCeiling,
 				context: params.contextForAgent?.(seqStep.agent),

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -54,6 +54,7 @@ import {
 import { buildSkillInjection, resolveSkillsWithFallback } from "../../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../../agents/agent-memory.ts";
 import { evaluateCompletionMutationGuard } from "../shared/completion-guard.ts";
+import { arbitrateCompletionGuardRescue } from "../shared/llm-intent-arbiter.ts";
 import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
@@ -1277,15 +1278,38 @@ async function runSingleAttempt(
 			mcpDirectTools: agent.mcpDirectTools,
 		})
 		: undefined;
-	const completionGuardTriggered = completionGuard?.triggered === true && !observedMutationAttempt;
+	let completionGuardTriggered = completionGuard?.triggered === true && !observedMutationAttempt;
+	// The classifier is deliberately narrow, so a read-only review task can
+	// still be misread as implementation. Arbitrate BEFORE any failure side
+	// effect is published (effects, exit code, progress, notifications,
+	// acceptance, output persistence): only a confident read-only verdict
+	// rescues, and the task text alone is evidence — never the child's own
+	// final message.
+	let arbiterRescued = false;
+	if (completionGuardTriggered) {
+		const arbitration = await arbitrateCompletionGuardRescue({
+			guardTriggered: true,
+			task: shared.originalTask ?? task,
+			arbiter: options.llmIntentArbiter,
+		});
+		completionGuardTriggered = arbitration.triggered;
+		arbiterRescued = arbitration.rescued;
+	}
 	if (completionGuard) {
 		result.effects = {
 			...(result.effects ?? {}),
 			fileMutation: {
-				status: completionGuard.expectedMutation ? completionGuardTriggered ? "missing" : "observed" : "not-applicable",
+				status: completionGuard.expectedMutation
+					? completionGuardTriggered
+						? "missing"
+						: arbiterRescued
+							? "not-applicable"
+							: "observed"
+					: "not-applicable",
 				expected: completionGuard.expectedMutation,
 				attempted: completionGuard.attemptedMutation || observedMutationAttempt,
 				...(completionGuardTriggered ? { message: "Subagent completed without making edits for an implementation task." } : {}),
+				...(arbiterRescued ? { resolvedBy: "llm-intent-arbiter" } : {}),
 			},
 		};
 	}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -71,6 +71,7 @@ import { isAgentContractV1 } from "../shared/agent-contract.ts";
 import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { cleanupStructuredOutputRuntime, createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, mapConcurrent, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
+import { createTaskMutationArbiter } from "../shared/llm-intent-arbiter.ts";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../shared/parallel-utils.ts";
 import { discardPreservedWorktrees, formatParallelHandoffError, formatParallelHandoffReference, parallelHandoffPath, writeParallelHandoffGroup, writePendingParallelHandoff } from "../shared/parallel-handoff.ts";
 import { summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
@@ -3216,6 +3217,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 		const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskText, compactOptional<Parameters<typeof runSync>[4]>({
 			permissions: input.permissions,
 			parentSessionId: input.ctx.sessionManager.getSessionId() ?? undefined,
+			llmIntentArbiter: createTaskMutationArbiter(input.ctx),
 			...workflowForegroundSteeringLaunchOptions(input.foregroundControl, index),
 			context: input.contextPolicy.contextForAgent(task.agent),
 			cwd: taskCwd,
@@ -3938,6 +3940,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		r = await runSync(ctx.cwd, agents, params.agent!, task, compactOptional<Parameters<typeof runSync>[4]>({
 			permissions: deps.config.permissions,
 			parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
+			llmIntentArbiter: createTaskMutationArbiter(ctx),
 			...workflowForegroundSteeringLaunchOptions(foregroundControl, 0),
 			context: data.contextPolicy.contextForAgent(params.agent!),
 			cwd: effectiveCwd,

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -23,7 +23,7 @@ import type {
 	SubagentRunMode,
 } from "../../shared/types.ts";
 import { isAgentContractV1 } from "./agent-contract.ts";
-import { classifyTaskMutationIntent, taskMayMutate } from "./task-intent.ts";
+import { classifyTaskMutationIntent, stripSeverityCompounds, taskMayMutate } from "./task-intent.ts";
 
 const LEVEL_RANK: Record<Exclude<AcceptanceLevel, "auto">, number> = {
 	none: 0,
@@ -93,7 +93,7 @@ function inferLevel(input: {
 	const rolePatchTask = input.acceptanceRole !== undefined
 		&& intent.kind !== "read-only"
 		&& !/\b(?:do not|don't|must not)\s+patch\b/.test(task)
-		&& /\bpatch\s+(?:(?:\.{0,2}[\\/])?(?:[\w.-]+[\\/])+[\w.-]+|[\w.-]+\.[a-z0-9]+\b|(?:the\s+)?parser\b)/.test(task);
+		&& /\bpatch\s+(?:(?:\.{0,2}[\\/])?(?:[\w.-]+[\\/])+[\w.-]+|[\w.-]+\.[a-z0-9]+\b|(?:the\s+)?parser\b)/.test(stripSeverityCompounds(task));
 	const taskMayWrite = readOnlyTask ? false : taskMayMutate(input.task ?? "") || intent.kind === "implementation" || rolePatchTask;
 	const readOnlyAgent = input.acceptanceRole === "read-only"
 		|| (input.acceptanceRole === undefined && /\b(?:reviewer|oracle|scout|researcher|analyst)\b/.test(agent));

--- a/src/runs/shared/llm-intent-arbiter.ts
+++ b/src/runs/shared/llm-intent-arbiter.ts
@@ -1,0 +1,285 @@
+import { Agent, type AgentTool, type StreamFn } from "@earendil-works/pi-agent-core";
+import { convertToLlm, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { streamSimple } from "@earendil-works/pi-ai/compat";
+import { Type, type Static } from "typebox";
+
+/**
+ * LLM intent arbiter for the completion mutation guard.
+ *
+ * The regex classifier (task-intent.ts) is deliberately narrow, so exotic
+ * review wording can still look like an implementation task ("to fix this,
+ * compare the outputs", verbs inside URLs or quoted text). When the guard is
+ * about to hard-fail a run that made no edits, this arbiter asks a model
+ * whether the task actually instructed file changes. It can only downgrade a
+ * failure to a pass; every error, timeout, or non-read-only verdict keeps the
+ * guard's original behavior.
+ *
+ * Enabled by default; set PI_SUBAGENTS_LLM_INTENT_ARBITER=0 to disable.
+ */
+
+const COMPLETION_GUARD_ERROR_PREFIX =
+	"Subagent completed without making edits for an implementation task.";
+
+export type TaskMutationVerdict = "read-only" | "implementation" | "unavailable";
+
+export type TaskMutationArbiter = (task: string) => Promise<TaskMutationVerdict>;
+
+const DecisionParams = Type.Object(
+	{
+		classification: Type.String({ enum: ["read_only", "implementation"] }),
+		reason: Type.String({ description: "One concise reason for this classification." }),
+	},
+	{ additionalProperties: false },
+);
+
+type DecisionParams = Static<typeof DecisionParams>;
+
+interface ArbiterRuntime {
+	model: NonNullable<RegistryModel>;
+	baseStreamFn: StreamFn;
+	timeoutMs: number;
+}
+
+interface ArbiterAuth {
+	apiKey?: string;
+	headers?: Record<string, string>;
+	env?: Record<string, string>;
+}
+
+export interface TaskMutationArbiterOptions {
+	/** Explicit "provider/id" model override (tests, config). */
+	model?: string;
+	/** Injectable stream function (tests). */
+	streamFn?: StreamFn;
+	timeoutMs?: number;
+}
+
+const DEFAULT_ARBITER_TIMEOUT_MS = 10_000;
+
+type RegistryModel = ReturnType<NonNullable<ExtensionContext["modelRegistry"]["find"]>>;
+
+function resolveArbiterModel(
+	ctx: ExtensionContext,
+	options?: TaskMutationArbiterOptions,
+): NonNullable<RegistryModel> | null {
+	const registry = ctx.modelRegistry as {
+		find?: (provider: string, modelId: string) => RegistryModel | undefined;
+		getAvailable?: () => Array<{ provider?: string; id?: string }>;
+	};
+	const explicit = options?.model?.trim();
+	if (explicit) {
+		const [provider, id] = explicit.split("/");
+		if (provider && id) return registry.find?.(provider, id) ?? null;
+		return null;
+	}
+	if (ctx.model) return ctx.model as NonNullable<RegistryModel>;
+	const first = registry.getAvailable?.()[0];
+	if (first?.provider && first.id) return registry.find?.(first.provider, first.id) ?? null;
+	return null;
+}
+
+function resolveArbiterRuntime(
+	ctx: ExtensionContext,
+	options?: TaskMutationArbiterOptions,
+): ArbiterRuntime | null {
+	const model = resolveArbiterModel(ctx, options);
+	if (!model?.provider || !model.id) return null;
+	const registry = ctx.modelRegistry as {
+		getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
+	};
+	const modelApi = (model as { api?: string }).api;
+	const registered = registry.getRegisteredProviderConfig?.(model.provider);
+	const baseStreamFn = options?.streamFn
+		?? (registered?.streamSimple && registered.api === modelApi
+			? registered.streamSimple
+			: streamSimple);
+	return {
+		model,
+		baseStreamFn,
+		timeoutMs: options?.timeoutMs ?? DEFAULT_ARBITER_TIMEOUT_MS,
+	};
+}
+
+async function resolveArbiterAuth(
+	ctx: ExtensionContext,
+	model: RegistryModel,
+): Promise<ArbiterAuth> {
+	const getAuth = (ctx.modelRegistry as {
+		getApiKeyAndHeaders?: (m: RegistryModel) => Promise<{
+			ok: boolean;
+			apiKey?: string;
+			headers?: Record<string, string>;
+			env?: Record<string, string>;
+			error?: string;
+		}>;
+	}).getApiKeyAndHeaders;
+	if (!getAuth) return {};
+	try {
+		const auth = await getAuth(model);
+		if (auth.ok === false) return {};
+		return {
+			...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
+			...(auth.headers ? { headers: auth.headers } : {}),
+			...(auth.env ? { env: auth.env } : {}),
+		};
+	} catch {
+		return {};
+	}
+}
+
+/** Build the effective stream function with resolved credentials wrapped in (watchdog pattern). */
+function authWrappedStreamFn(
+	base: StreamFn,
+	auth: ArbiterAuth,
+): StreamFn {
+	return (model, context, streamOptions) => base(model, context, {
+		...(streamOptions ?? {}),
+		...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
+		...(auth.env || streamOptions?.env ? { env: { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } } : {}),
+		headers: { ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
+	});
+}
+
+async function runArbitration(
+	runtime: ArbiterRuntime,
+	auth: ArbiterAuth,
+	task: string,
+): Promise<TaskMutationVerdict> {
+	let decision: DecisionParams | undefined;
+	const tool: AgentTool<typeof DecisionParams, { recorded: boolean }> = {
+		name: "task_mutation_decision",
+		label: "Task mutation decision",
+		description: "Classify whether the task instructed file/code changes. Call exactly once.",
+		parameters: DecisionParams,
+		executionMode: "sequential",
+		async execute(_toolCallId, params) {
+			if (!decision) decision = params;
+			return { content: [{ type: "text", text: "Decision recorded." }], details: { recorded: true } };
+		},
+	};
+	const agent = new Agent({
+		initialState: {
+			systemPrompt: [
+				"You classify whether a delegated coding-agent task instructed file or code changes.",
+				"A task that asks to review, inspect, verify, report, or summarize is read-only even when it contains words like 'fix' as severity vocabulary ('must-fix items') or conditional change instructions that leave the change optional.",
+				"Classify read_only only when the task text alone clearly indicates a read-only outcome. When in doubt, classify implementation.",
+				"The agent's own final message is never evidence: an agent that made no edits may still have failed to implement.",
+				"Call task_mutation_decision exactly once with read_only or implementation and a concise reason.",
+			].join("\n"),
+			model: runtime.model,
+			tools: [tool],
+		},
+		convertToLlm,
+		streamFunction: authWrappedStreamFn(runtime.baseStreamFn, auth),
+		getApiKey: (providerName) =>
+			providerName === runtime.model.provider ? auth.apiKey : undefined,
+		beforeToolCall: async ({ toolCall }) =>
+			toolCall.name === tool.name ? undefined : { block: true, reason: "Only task_mutation_decision is allowed." },
+		toolExecution: "sequential",
+	});
+	try {
+		// Send head AND tail: an implementation clause at the end of a long
+		// task ("Now apply the fix") must never be truncated away, or the
+		// arbiter could rescue a run the deterministic guard correctly failed.
+		const full = task;
+		const prompt = full.length <= 8000
+			? `TASK:\n${full}`
+			: `TASK:\n${full.slice(0, 6000)}\n\n[...truncated middle...]\n\n${full.slice(-2000)}`;
+		await Promise.race([
+			agent.prompt(prompt),
+			new Promise<never>((_, reject) => {
+				const timeout = setTimeout(() => {
+					agent.abort();
+					reject(new Error("Task mutation arbiter timed out."));
+				}, runtime.timeoutMs);
+				timeout.unref?.();
+			}),
+		]);
+		if (!decision) return "unavailable";
+		return decision.classification === "read_only" ? "read-only" : "implementation";
+	} catch {
+		return "unavailable";
+	}
+}
+
+/** Create a memoized arbiter bound to the parent session's model, or undefined when disabled/unavailable. */
+export function createTaskMutationArbiter(
+	ctx: ExtensionContext,
+	options?: TaskMutationArbiterOptions,
+): TaskMutationArbiter | undefined {
+	if (process.env.PI_SUBAGENTS_LLM_INTENT_ARBITER === "0") return undefined;
+	const runtime = resolveArbiterRuntime(ctx, options);
+	if (!runtime) return undefined;
+	const cache = new Map<string, TaskMutationVerdict>();
+	return async (task) => {
+		const key = `${task.length}:${task.slice(0, 160)}`;
+		const cached = cache.get(key);
+		if (cached) return cached;
+		const auth = await resolveArbiterAuth(ctx, runtime.model);
+		const verdict = await runArbitration(runtime, auth, task);
+		if (cache.size > 200) cache.clear();
+		cache.set(key, verdict);
+		return verdict;
+	};
+}
+
+export function isCompletionGuardFailure(result: { error?: string }): boolean {
+	return result.error?.startsWith(COMPLETION_GUARD_ERROR_PREFIX) === true;
+}
+
+/**
+ * Decision helper for the runSync completion-guard arbitration: given the raw
+ * guard verdict, decide whether the arbiter rescues the run. Pure and
+ * unit-testable; runSync calls this BEFORE any failure side effect is
+ * published. Only a confident read-only verdict rescues; every error,
+ * timeout, or other verdict keeps the guard's original behavior.
+ */
+export async function arbitrateCompletionGuardRescue(input: {
+	guardTriggered: boolean;
+	task: string;
+	arbiter?: TaskMutationArbiter;
+}): Promise<{ triggered: boolean; rescued: boolean }> {
+	if (!input.guardTriggered || !input.arbiter) {
+		return { triggered: input.guardTriggered, rescued: false };
+	}
+	try {
+		const verdict = await input.arbiter(input.task);
+		if (verdict === "read-only") return { triggered: false, rescued: true };
+		return { triggered: true, rescued: false };
+	} catch {
+		return { triggered: true, rescued: false };
+	}
+}
+
+/**
+ * When the completion guard hard-failed a run and the arbiter classifies the
+ * task as read-only, clear the failure. Returns true when rescued. All other
+ * verdicts and every failure mode keep the original guard behavior.
+ *
+ * Classification uses the task text only: the agent's own final message is
+ * never evidence, so a child that failed to implement cannot talk its way
+ * out of the guard by claiming the work was read-only.
+ */
+export async function maybeRescueCompletionGuardFailure(
+	result: { exitCode?: number; error?: string },
+	task: string,
+	arbiter: TaskMutationArbiter | undefined,
+): Promise<boolean> {
+	if (!arbiter || !isCompletionGuardFailure(result)) return false;
+	const verdict = await arbitrateWithGuard(arbiter, task);
+	if (verdict !== "read-only") return false;
+	result.exitCode = 0;
+	delete result.error;
+	return true;
+}
+
+async function arbitrateWithGuard(
+	arbiter: TaskMutationArbiter,
+	task: string,
+): Promise<TaskMutationVerdict> {
+	try {
+		return await arbiter(task);
+	} catch {
+		return "unavailable";
+	}
+}

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -70,6 +70,18 @@ const RESEARCH_AGENT_PATTERNS = [
 	/\bresearch(?:er)?\b/i,
 ];
 
+// Review/severity vocabulary like "must-fix items" or "should-fix tests" is not
+// the verb. Rather than dash-guarding every pattern (which would also suppress
+// CLI flags like "--fix" and genuine clause-level dashes like "branch—fix it"),
+// strip the known severity compounds (must|should|needs + dash + verb) from the
+// task text before matching. Dash coverage: ASCII hyphen + U+2010..U+2015.
+const SEVERITY_COMPOUND_PATTERN = /\b(?:must|should|needs)[\-\u2010-\u2015](?:fix|edit|update|add|remove|replace|create|apply|make|do|implement|modify|delete|patch)\b/gi;
+
+function stripSeverityCompounds(task: string): string {
+	return task.replace(SEVERITY_COMPOUND_PATTERN, " ");
+}
+export { stripSeverityCompounds };
+
 const FIX_OR_PATCH_IMPLEMENTATION_PATTERN = /\b(?:fix|patch)\s+(?:(?:it|this|that|them|each|any|all|these|those)\b|(?:(?:a|an|the|any|all)\s+)?(?:(?:failing|failed|broken|flaky|red|cold|start|current|existing|reported|approved|known|regression|unit|integration|e2e|source|typescript|type-?script|ts|type-?check|compiler)\s+)*(?:bug|defect|issues?|problems?|failures?|regressions?|tests?|errors?|items?|typos?|code|source|implementation|component|function|module|class|method|logic|file|files|readme|docs?|changelog|package\.json|config|manifest|extension|prompt|command|lint(?:ing)?|build|ci|type-?check|type\s+checking)\b)/i;
 
 const WORKER_IMPLEMENTATION_PATTERNS = [
@@ -146,7 +158,7 @@ function hasImplementationIntent(agent: string, taskText: string): boolean {
 }
 
 export function classifyTaskMutationIntent(agent: string, task: string): TaskMutationIntent {
-	const taskText = stripFrameworkInstructions(task);
+	const taskText = stripSeverityCompounds(stripFrameworkInstructions(task));
 	const taskTextWithoutScopedConstraints = stripPatterns(taskText, SCOPED_NO_EDIT_CONSTRAINT_PATTERNS);
 	const prohibitions = analyzeNoEditProhibitions(taskTextWithoutScopedConstraints);
 	if (prohibitions.present) {
@@ -164,7 +176,11 @@ export function expectsImplementationMutation(agent: string, task: string): bool
 	return classifyTaskMutationIntent(agent, task).kind === "implementation";
 }
 
-/** Bare write verbs that make a task write-capable for acceptance inference. */
+/** Bare write verbs that make a task write-capable for acceptance inference.
+ * Severity compounds ("must-fix items") are stripped before matching, so they
+ * are not write imperatives, while CLI flags ("--fix", "-w"), clause-level
+ * dashes ("branch—fix it"), and hyphenated imperatives ("hot-fix the bug")
+ * all stay write-capable. */
 const MAY_MUTATE_VERB_PATTERN = /\b(?:fix|implement|update|write|edit|modify|migrate|delete|remove|refactor|commit)\b/i;
 
 /**
@@ -174,7 +190,7 @@ const MAY_MUTATE_VERB_PATTERN = /\b(?:fix|implement|update|write|edit|modify|mig
  * does.
  */
 export function taskMayMutate(task: string): boolean {
-	const taskText = stripPatterns(stripFrameworkInstructions(task), SCOPED_NO_EDIT_CONSTRAINT_PATTERNS);
+	const taskText = stripPatterns(stripSeverityCompounds(stripFrameworkInstructions(task)), SCOPED_NO_EDIT_CONSTRAINT_PATTERNS);
 	const prohibitions = analyzeNoEditProhibitions(taskText);
 	if (prohibitions.blanket) return false;
 	return MAY_MUTATE_VERB_PATTERN.test(stripPatterns(prohibitions.strippedText, READ_ONLY_DELIVERABLE_PATTERNS));

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -328,6 +328,7 @@ export interface FileMutationEffect {
 	expected: boolean;
 	attempted: boolean;
 	message?: string;
+	resolvedBy?: "llm-intent-arbiter";
 }
 
 export interface EffectsProjection {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1733,6 +1733,8 @@ export interface RunSyncOptions {
 	nestedRoute?: NestedRouteInfo;
 	/** Override the agent's default model (format: "provider/id" or just "id") */
 	modelOverride?: string;
+	/** LLM intent arbiter for the completion mutation guard (rescues read-only review runs). */
+	llmIntentArbiter?: import("../runs/shared/llm-intent-arbiter.ts").TaskMutationArbiter;
 	/** Override the agent's default thinking level for this run */
 	thinkingOverride?: AgentConfig["thinking"];
 	/** Registry models available for heuristic bare-model resolution */

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -53,6 +53,24 @@ test("declared read-only builtin tools suppress implementation-word false positi
 	});
 });
 
+test("hyphenated fix adjectives in review tasks do not trigger the completion guard", () => {
+	const result = evaluateCompletionMutationGuard({
+		agent: "worker",
+		task: "Return a review with the top 2-3 must-fix items.",
+		messages: [assistantText("Review: findings with severity labels.")],
+	});
+
+	assert.deepEqual(result, {
+		expectedMutation: false,
+		attemptedMutation: false,
+		triggered: false,
+	});
+	assert.equal(
+		expectsImplementationMutation("worker", "Return a review with the top 2-3 must-fix items."),
+		false,
+	);
+});
+
 test("read-only issue drafting tasks do not trigger on suggested fix wording", () => {
 	const task = "Draft GitHub issue for pi-subagents bug from current conversation. Include title, environment/context, reproduction steps, actual/expected, logs excerpt, suspected cause, suggested fix. Terse but complete. No tools needed.";
 	const result = evaluateCompletionMutationGuard({

--- a/test/unit/llm-intent-arbiter.test.ts
+++ b/test/unit/llm-intent-arbiter.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	arbitrateCompletionGuardRescue,
+	createTaskMutationArbiter,
+	isCompletionGuardFailure,
+	maybeRescueCompletionGuardFailure,
+	type TaskMutationArbiter,
+} from "../../src/runs/shared/llm-intent-arbiter.ts";
+
+const GUARD_ERROR =
+	"Subagent completed without making edits for an implementation task.\nIt appears to have returned planning or scratchpad output instead of applying changes.";
+
+function fakeCtx(overrides: { models?: Array<{ provider?: string; id?: string; api?: string }> } = {}) {
+	const models = overrides.models ?? [{ provider: "test", id: "model-1", api: "test-api" }];
+	return {
+		model: models[0],
+		modelRegistry: {
+			getAvailable: () => models,
+			getRegisteredProviderConfig: () => undefined,
+		},
+	} as never;
+}
+
+function stubArbiter(verdict: "read-only" | "implementation" | "unavailable" | "throw"): TaskMutationArbiter {
+	return async () => {
+		if (verdict === "throw") throw new Error("boom");
+		return verdict;
+	};
+}
+
+describe("arbitrateCompletionGuardRescue", () => {
+	it("rescues only a confident read-only verdict", async () => {
+		const rescued = await arbitrateCompletionGuardRescue({
+			guardTriggered: true,
+			task: "t",
+			arbiter: stubArbiter("read-only"),
+		});
+		assert.deepEqual(rescued, { triggered: false, rescued: true });
+		for (const verdict of ["implementation", "unavailable"] as const) {
+			const kept = await arbitrateCompletionGuardRescue({
+				guardTriggered: true,
+				task: "t",
+				arbiter: stubArbiter(verdict),
+			});
+			assert.deepEqual(kept, { triggered: true, rescued: false }, verdict);
+		}
+	});
+
+	it("keeps the guard verdict without an arbiter or on arbiter failure", async () => {
+		assert.deepEqual(
+			await arbitrateCompletionGuardRescue({ guardTriggered: true, task: "t" }),
+			{ triggered: true, rescued: false },
+		);
+		assert.deepEqual(
+			await arbitrateCompletionGuardRescue({ guardTriggered: true, task: "t", arbiter: stubArbiter("throw") }),
+			{ triggered: true, rescued: false },
+		);
+		assert.deepEqual(
+			await arbitrateCompletionGuardRescue({ guardTriggered: false, task: "t", arbiter: stubArbiter("read-only") }),
+			{ triggered: false, rescued: false },
+		);
+	});
+});
+
+describe("isCompletionGuardFailure", () => {
+	it("recognizes the guard error prefix", () => {
+		assert.equal(isCompletionGuardFailure({ error: GUARD_ERROR }), true);
+		assert.equal(isCompletionGuardFailure({ error: "Some other failure." }), false);
+		assert.equal(isCompletionGuardFailure({}), false);
+	});
+});
+
+describe("maybeRescueCompletionGuardFailure", () => {
+	it("keeps the failure without an arbiter", async () => {
+		const result = { exitCode: 1, error: GUARD_ERROR };
+		const rescued = await maybeRescueCompletionGuardFailure(result, "task", undefined);
+		assert.equal(rescued, false);
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.error, GUARD_ERROR);
+	});
+
+	it("rescues only a confident read-only verdict", async () => {
+		for (const verdict of ["implementation", "unavailable"] as const) {
+			const result = { exitCode: 1, error: GUARD_ERROR };
+			const rescued = await maybeRescueCompletionGuardFailure(result, "task", stubArbiter(verdict));
+			assert.equal(rescued, false, verdict);
+			assert.equal(result.exitCode, 1);
+			assert.equal(result.error, GUARD_ERROR);
+		}
+		const result = { exitCode: 1, error: GUARD_ERROR };
+		const rescued = await maybeRescueCompletionGuardFailure(result, "task", stubArbiter("read-only"));
+		assert.equal(rescued, true);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.error, undefined);
+	});
+
+	it("fails closed when the arbiter throws", async () => {
+		const result = { exitCode: 1, error: GUARD_ERROR };
+		const rescued = await maybeRescueCompletionGuardFailure(result, "task", stubArbiter("throw"));
+		assert.equal(rescued, false);
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.error, GUARD_ERROR);
+	});
+
+	it("does not touch unrelated failures", async () => {
+		const result = { exitCode: 1, error: "Something else broke." };
+		const rescued = await maybeRescueCompletionGuardFailure(result, "task", stubArbiter("read-only"));
+		assert.equal(rescued, false);
+		assert.equal(result.exitCode, 1);
+	});
+});
+
+describe("createTaskMutationArbiter", () => {
+	it("is disabled by the env opt-out", () => {
+		const previous = process.env.PI_SUBAGENTS_LLM_INTENT_ARBITER;
+		process.env.PI_SUBAGENTS_LLM_INTENT_ARBITER = "0";
+		try {
+			assert.equal(createTaskMutationArbiter(fakeCtx()), undefined);
+		} finally {
+			if (previous === undefined) delete process.env.PI_SUBAGENTS_LLM_INTENT_ARBITER;
+			else process.env.PI_SUBAGENTS_LLM_INTENT_ARBITER = previous;
+		}
+	});
+
+	it("returns undefined when no model can be resolved", () => {
+		assert.equal(createTaskMutationArbiter(fakeCtx({ models: [] })), undefined);
+	});
+
+	it("returns a working arbiter bound to the host model", async () => {
+		const arbiter = createTaskMutationArbiter(fakeCtx(), {
+			streamFn: async () => {
+				throw new Error("not reached in this seam test");
+			},
+		});
+		assert.notEqual(arbiter, undefined);
+		// Without a scripted stream the underlying Agent call cannot succeed;
+		// the arbiter must degrade to "unavailable" rather than throw.
+		const verdict = await arbiter!("task");
+		assert.equal(verdict, "unavailable");
+	});
+
+	it("memoizes verdicts per task/message key", async () => {
+		let streamCalls = 0;
+		const arbiter = createTaskMutationArbiter(fakeCtx(), {
+			streamFn: async () => {
+				streamCalls += 1;
+				throw new Error("fail");
+			},
+		})!;
+		const v1 = await arbiter("t", "m");
+		const v2 = await arbiter("t", "m");
+		assert.equal(v1, "unavailable");
+		assert.equal(v2, "unavailable");
+		assert.equal(streamCalls, 1); // second call served from cache
+	});
+});

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -61,6 +61,45 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Create a summary").kind, "unknown");
 	});
 
+	it("does not read hyphenated fix adjectives as the fix verb", () => {
+		// Core regression: "must-fix items" in review output specs (fails on old code).
+		assert.equal(classifyTaskMutationIntent("worker", "Return a review with the top 2-3 must-fix items").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "Return a review with the top 2-3 must-fix items.").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "Review and report MUST-FIX items").kind, "unknown");
+		// should-fix with a noun from the pattern's alternation (also fails on old code).
+		assert.equal(classifyTaskMutationIntent("worker", "List should-fix tests with severity labels").kind, "unknown");
+		// Same class for other verbs: hyphenated adjective + verb.
+		assert.equal(classifyTaskMutationIntent("worker", "Return must-edit findings").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "Return must-update items").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "List should-add files").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "Return must-apply changes").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "List should-make changes").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "must-do those fixes").kind, "unknown");
+		// Dash coverage: U+2010 hyphen, U+2011 non-breaking hyphen, en/em dashes.
+		assert.equal(classifyTaskMutationIntent("worker", "Return the must\u2010fix items").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "Return the must\u2011fix items").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "Return the must\u2013fix items").kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", "Return the must\u2014fix items").kind, "unknown");
+		// Clause-level em/en dashes are punctuation, not compounds: "branch—fix it".
+		assert.equal(classifyTaskMutationIntent("worker", "Inspect the failing branch\u2014fix it.").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Inspect the failing branch\u2013fix it.").kind, "implementation");
+		assert.equal(taskMayMutate("Inspect the failing branch\u2014fix it."), true);
+		// Hyphenated genuine imperatives stay write-capable.
+		assert.equal(taskMayMutate("hot-fix the bug"), true);
+		assert.equal(taskMayMutate("quick-fix that bug"), true);
+		// Genuine imperative usage keeps classifying as implementation.
+		assert.equal(classifyTaskMutationIntent("worker", "Go through the list and fix items one by one").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "fix items on the sprint board").kind, "implementation");
+		// CLI flags keep write intent: "--fix" / "-w" are not hyphenated adjectives.
+		assert.equal(classifyTaskMutationIntent("worker", "Run eslint --fix code").kind, "implementation");
+		assert.equal(taskMayMutate("Run eslint --fix code"), true);
+		// "--write" was never a classifier verb (pre-existing unknown); the
+		// regression guard is that write-capability survives for acceptance.
+		assert.equal(taskMayMutate("Run prettier --write files"), true);
+		// Guard-facing mirror: the completion guard must not expect mutation.
+		assert.equal(expectsImplementationMutation("worker", "Return a review with the top 2-3 must-fix items"), false);
+	});
+
 	it("expectsImplementationMutation mirrors the classifier", () => {
 		assert.equal(expectsImplementationMutation("worker", "Do not modify tests; implement the fix"), true);
 		assert.equal(expectsImplementationMutation("worker", "Review the diff and suggest fixes only. Do not edit files."), false);


### PR DESCRIPTION
## Why this PR exists

A read-only review task phrased with severity vocabulary — *"Return a review with the top 2-3 **must-fix items**"* — was classified as an **implementation** task by the task-intent classifier. The verb-detection patterns matched the "fix" inside the hyphenated adjective because `\b` treats the hyphen as a word boundary, so "must-fix items" read as the imperative "fix items".

Downstream, the completion mutation guard (which expects file changes whenever a write-capable agent's task classifies as implementation) hard-failed the run:

> Subagent completed without making edits for an implementation task. It appears to have returned planning or scratchpad output instead of applying changes.

…even though the agent had correctly executed a read-only review and explicitly reported `noStagedFiles: true` / "no files changed". The acceptance layer also inferred a `checked` implementation contract ("Implement the requested change without widening scope") for pure review tasks. This is exactly how the incident surfaced: three independent review subagents completed full, correct reviews and were all marked failed.

The same bug class also triggered via other verbs ("must-**edit** findings", "must-**update** items", "should-**add** files", "must-**apply** changes"), and the acceptance-level write-capability check had the identical blind spot.

## Proposed solution — two layers

### 1. Deterministic: strip severity compounds before verb matching

Review/severity vocabulary like `must-fix` / `should-fix` is not the verb. Instead of dash-guarding every pattern (which also suppresses CLI flags like `--fix` and clause-level dashes like `branch—fix it`), the classifier **strips known severity compounds** — `must|should|needs` + any dash (ASCII hyphen, U+2010 hyphen, U+2011 non-breaking hyphen, figure/en/em dashes, horizontal bar) + verb — from the task text before matching. This applies to:

- `FIX_OR_PATCH_IMPLEMENTATION_PATTERN` (`fix/patch <noun>`)
- every bare-verb pattern (worker + general): `implement/edit/modify/refactor/delete`, `update/add/remove/replace/create`, `apply …`, `make … changes`, `do those fixes`
- `MAY_MUTATE_VERB_PATTERN` — the acceptance-level write-capability check
- the `rolePatchTask` scope pattern in `acceptance.ts`

Because only the severity compounds are removed — not all dashed verbs — the following all keep their write intent:

- **CLI flags**: "Run eslint --fix code" → implementation + write-capable
- **Clause-level dashes**: "Inspect the failing branch—fix it." → implementation (the em dash is punctuation, not a compound)
- **Hyphenated genuine imperatives**: "hot-fix the bug", "quick-fix that bug" → implementation

Genuine imperatives ("Go through the list and fix items one by one") also still classify as implementation. The only residual gap is non-severity adjectival compounds in review-speak (e.g. "quick-fix items") — a rare phrasing, documented in the classifier comment.

### 2. Robustness: LLM intent arbiter (new)

Regex classification has a long tail of vocabulary traps that no pattern patch can exhaust. Instead of whack-a-mole, the new `src/runs/shared/llm-intent-arbiter.ts` adds judgment at the failure boundary:

- **Where**: inside `runSync` (`execution.ts`), at the exact point the completion guard fires — **before any failure side effect is published** (effects, exit code, progress status, needs-attention notification, acceptance evaluation, output persistence). This covers single, parallel, and chain foreground runs uniformly; the decision is extracted into a pure `arbitrateCompletionGuardRescue` helper.
- **Evidence**: the **task text alone** — never the child's own final message, so a failed implementation cannot talk its way out by claiming the work was read-only. Head *and* tail of the task are sent (an implementation clause at the end of a long task is never truncated away).
- **Fail-closed**: only a confident `read_only` verdict rescues. Every error, timeout, `implementation`, or unresolved verdict keeps the guard's original behavior. Rescues are recorded on the result (`fileMutation.resolvedBy: "llm-intent-arbiter"`).
- **Auth**: resolves the parent model's credentials via `modelRegistry.getApiKeyAndHeaders` (OAuth, headers, env — the watchdog pattern), wraps the host stream function, and supplies `getApiKey` to the agent; 10s timeout; memoized per task.
- Enabled by default; opt out with `PI_SUBAGENTS_LLM_INTENT_ARBITER=0`. Detached async runs (separate runner process) keep the deterministic fix — a documented follow-up.

## How it was tested

**Unit** (all passing, incl. regressions that fail on the old code):
- `task-intent.test.ts` — "must-fix items" (incl. punctuation/uppercase variants), "should-fix tests", sibling verbs ("must-edit", "must-update", "should-add", "must-apply", "should-make", "must-do"), U+2010/U+2011/en/em-dash compounds, **the clause-dash pair** ("Return the must—fix items" → non-implementation; "Inspect the failing branch—fix it." → implementation + write-capable), **CLI-flag controls**, hyphenated-imperative controls, `expectsImplementationMutation` mirror.
- `completion-guard.test.ts` — guard-level regression: review task with "must-fix items" → `triggered: false`.
- `llm-intent-arbiter.test.ts` (new, 13 tests) — verdict mapping, fail-closed on error/timeout/implementation, rescue semantics, the runSync arbitration-decision helper (single + stub arbiter), env opt-out, memoization.
- Typecheck clean. Focused suites 46/46.

**Full suite vs. baseline** (baseline verified in a `main` worktree):
- baseline: 1786 tests / 1752 pass / 19 fail → with this PR: 1799 / 1765 / 19. The 19 are pre-existing environmental failures, identical set; +13 tests, +13 passes, zero regressions.

**End-to-end** (fresh pi sessions running the patched extension):
- Review task with "must-fix items", zero edits → child **succeeds** (hard failure before this PR).
- "Investigate the failing tests and **fix the reported regression bug**" + honest no-edit report → child **succeeds via the LLM arbiter** — the classifier still (correctly) says implementation, so only the arbiter could rescue it.
- Spawn from a pre-patch session (async runner process loads the patched code fresh) → `ok: true`.

**Design review feedback incorporated** (Greptile + Codex + independent review): arbitration moved before failure state publication (no contradictory success/failure state, no missing output files); child-authored output removed from arbiter evidence; all sibling verb patterns covered; CLI flags and clause-level dashes preserved; auth credentials forwarded; full dash range covered; runSync decision extracted and unit-tested.

Changelog entries added under `[Unreleased]` with contributor credit.
