### PR TITLE
fix: reject extension worktree base directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add a global `timeoutMs` config option that sets the default run deadline for single, parallel, and chain launches (foreground, plus plain single-agent async) when neither the call nor the selected agent provides a timeout. It reaches parallel (`tasks: [...]`) and chain launches, which never adopt an agent's frontmatter `timeoutMs` (that default applies to single-agent launches only), so a long fan-out no longer falls back to the built-in 30-minute default and gets killed mid-run. Explicit call `timeoutMs`/`maxRuntimeMs` and agent frontmatter defaults still win; composite async runs stay unbounded at the top level by design. Thanks to @shaharmor for #1018.
 
 ### Fixed
+- Reject configured worktree base directories inside the agent extensions directory, including symlink aliases (#1014).
 - Align unnamed intercom fallback orchestrator targets with pi-intercom's 18-character registered presence names so subagents without an explicit session name can reach their orchestrator. Thanks to @mystery4f for #1017.
 ## [0.47.1] - 2026-08-12
 

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { resolveAuthorityDecision, type AuthorityPolicyConfig } from "../../policy/authority.ts";
 import { PROJECT_SUBAGENTS_RELATIVE_DIR } from "../../shared/artifacts.ts";
+import { getAgentDir } from "../../shared/utils.ts";
 
 export interface WorktreeSetup {
 	cwd: string;
@@ -149,11 +150,17 @@ function resolveRepoState(cwd: string): RepoState {
 
 function normalizeComparableCwd(cwd: string): string {
 	const resolved = path.resolve(cwd);
-	try {
-		return fs.realpathSync(resolved);
-	} catch {
-		// Use the unresolved absolute path when realpath resolution is unavailable.
-		return resolved;
+	let existing = resolved;
+	const missingSegments: string[] = [];
+	while (true) {
+		try {
+			return path.join(fs.realpathSync(existing), ...missingSegments.reverse());
+		} catch {
+			const parent = path.dirname(existing);
+			if (parent === existing) return resolved;
+			missingSegments.push(path.basename(existing));
+			existing = parent;
+		}
 	}
 }
 
@@ -196,6 +203,11 @@ function resolveWorktreeBaseDir(configuredBaseDir: string | undefined, repoRoot:
 
 	const expanded = trimmed.startsWith("~/") ? path.join(os.homedir(), trimmed.slice(2)) : trimmed;
 	const resolved = path.isAbsolute(expanded) ? expanded : path.resolve(repoRoot, expanded);
+	const extensionsDir = normalizeComparableCwd(path.join(getAgentDir(), "extensions"));
+	const relativeToExtensions = path.relative(extensionsDir, normalizeComparableCwd(resolved));
+	if (!relativeToExtensions || (!relativeToExtensions.startsWith(`..${path.sep}`) && relativeToExtensions !== ".." && !path.isAbsolute(relativeToExtensions))) {
+		throw new Error(`worktree base directory cannot be inside Pi extensions directory: ${extensionsDir}. Choose a directory outside it.`);
+	}
 	try {
 		fs.mkdirSync(resolved, { recursive: true });
 	} catch (error) {

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -125,6 +125,67 @@ describe("worktree", () => {
 		}
 	});
 
+	it("rejects worktree base directories inside Pi extensions", () => {
+		const repoDir = createRepo("pi-worktree-extension-dir-");
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-home-"));
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const previousHome = process.env.HOME;
+		const previousUserProfile = process.env.USERPROFILE;
+		const extensionsDir = path.join(tempHome, ".pi", "agent", "extensions");
+		try {
+			process.env.HOME = tempHome;
+			process.env.USERPROFILE = tempHome;
+			delete process.env.PI_CODING_AGENT_DIR;
+			assert.throws(
+				() => createWorktrees(repoDir, "extension-dir", 1, { baseDir: extensionsDir }),
+				/worktree base directory cannot be inside Pi extensions directory/i,
+			);
+			assert.throws(
+				() => createWorktrees(repoDir, "extension-subdir", 1, { baseDir: path.join(extensionsDir, "checkout") }),
+				/worktree base directory cannot be inside Pi extensions directory/i,
+			);
+		} finally {
+			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+			else process.env.USERPROFILE = previousUserProfile;
+			cleanupRepo(repoDir);
+			fs.rmSync(tempHome, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects symlinked worktree base directories inside Pi extensions", () => {
+		const repoDir = createRepo("pi-worktree-extension-symlink-");
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-home-"));
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const previousHome = process.env.HOME;
+		const previousUserProfile = process.env.USERPROFILE;
+		const extensionsDir = path.join(tempHome, ".pi", "agent", "extensions");
+		const aliasDir = path.join(tempHome, "extension-alias");
+		try {
+			process.env.HOME = tempHome;
+			process.env.USERPROFILE = tempHome;
+			delete process.env.PI_CODING_AGENT_DIR;
+			fs.mkdirSync(extensionsDir, { recursive: true });
+			fs.symlinkSync(extensionsDir, aliasDir, process.platform === "win32" ? "junction" : "dir");
+			assert.throws(
+				() => createWorktrees(repoDir, "extension-symlink", 1, { baseDir: path.join(aliasDir, "checkout") }),
+				/worktree base directory cannot be inside Pi extensions directory/i,
+			);
+		} finally {
+			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+			else process.env.USERPROFILE = previousUserProfile;
+			cleanupRepo(repoDir);
+			fs.rmSync(tempHome, { recursive: true, force: true });
+		}
+	});
+
 	it("uses PI_SUBAGENTS_WORKTREE_DIR when no base directory is configured", () => {
 		const repoDir = createRepo("pi-worktree-env-base-dir-");
 		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;


### PR DESCRIPTION
Fixes #1014.

This rejects configured subagent worktree base directories that resolve inside the Pi agent `extensions` directory. It also covers symlink aliases, so a worktree cannot be created where the extension loader can discover it as another extension.

Validation:
- `node --experimental-strip-types --test test/unit/worktree.test.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`
