### PR TITLE
fix: avoid inherited models for external cli children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Stop reading hyphenated adjectives like "must-fix items" or "should-fix tests" as implementation intent, which made the completion mutation guard hard-fail read-only review runs with a false "completed without making edits" error. Severity compounds (must|should|needs + dash + verb) are stripped before verb matching across every mutation pattern (incl. update/add/apply/make/do siblings), the acceptance-level write-capability check, and the patch-scope pattern, while CLI flags ("eslint --fix", "prettier --write") and clause-level dashes ("branch—fix it") keep their write intent. Thanks to @MarcusNeufeldt for #1020.
 - Add an optional LLM intent arbiter: when the completion guard is about to hard-fail a run that made no edits, a model decides — from the task text alone, never the child's own report — whether the task actually instructed file changes; only a confident read-only verdict rescues the run, before any failure state is published. Covers single, parallel, and chain foreground runs; enabled by default; set `PI_SUBAGENTS_LLM_INTENT_ARBITER=0` to disable. Thanks to @MarcusNeufeldt for #1020.
 - Tolerate empty-string entries in acceptance-report string-array fields instead of rejecting the whole report. Thanks to @hjiang for #1015.
+- Let single external-cli workflow children ignore inherited Pi models so model-less external runners start instead of failing preflight. Thanks to @twosunnus for #1016.
 
 ## [0.47.1] - 2026-08-12
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1015,7 +1015,10 @@ function applyBuiltinOverride(
 	};
 
 	if (override.description !== undefined) next.description = override.description;
-	if (override.model !== undefined) { if (override.model === false) delete next.model; else next.model = override.model; }
+	if (override.model !== undefined) {
+		if (override.model === false) delete next.model; else next.model = override.model;
+		delete next.modelSource;
+	}
 	if (override.fallbackModels !== undefined) { if (override.fallbackModels === false) delete next.fallbackModels; else next.fallbackModels = [...override.fallbackModels]; }
 	if (override.thinking !== undefined) { if (override.thinking === false) delete next.thinking; else next.thinking = override.thinking; }
 	if (override.systemPromptMode !== undefined) next.systemPromptMode = override.systemPromptMode;
@@ -1133,8 +1136,11 @@ function applyCustomAgentOverride(
 		mutable().description = override.description;
 		anyFilled = true;
 	}
-	if (override.model !== undefined) {
-		fill("model", ["model"], override.model === false ? undefined : override.model);
+	if (override.model !== undefined && !agentHasFrontmatterField(agent, "model")) {
+		const target = mutable();
+		if (override.model === false) delete target.model; else target.model = override.model;
+		delete target.modelSource;
+		anyFilled = true;
 	}
 	if (override.fallbackModels !== undefined) {
 		fill(

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2726,7 +2726,12 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const normalizedSkills = normalizeSkillInput(params.skill);
 		const skills = normalizedSkills === false ? [] : normalizedSkills;
 		const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, a.maxSubagentDepth);
-		const modelOverride = resolveEffectiveSubagentModel(params.model as string | undefined, a.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope });
+		const externalRunnerWithoutExplicitModel = a.runner?.type === "external-cli"
+			&& params.model === undefined
+			&& (a.model === undefined || (a.modelSource?.type === "subagents.defaultModel" && a.model === a.modelSource.model));
+		const modelOverride = externalRunnerWithoutExplicitModel
+			? undefined
+			: resolveEffectiveSubagentModel(params.model as string | undefined, a.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope });
 		return executeAsyncSingle(id, compactOptional<Parameters<typeof executeAsyncSingle>[1]>({
 			agent: params.agent!,
 			task: shouldForkAgent(contextPolicy, params.agent!) ? wrapForkTask(params.task ?? "") : (params.task ?? ""),
@@ -2748,7 +2753,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			...(params.reads !== undefined ? { reads: params.reads } : {}),
 			outputBaseDir: resolveSingleRunOutputBaseDir(deps, artifactsDir, id),
 			modelOverride,
-			thinkingOverride: thinkingOverrideForTask(params.agent!, 0, modelOverride),
+			thinkingOverride: externalRunnerWithoutExplicitModel ? undefined : thinkingOverrideForTask(params.agent!, 0, modelOverride),
 			maxSubagentDepth,
 			waitToolEnabled: deps.waitToolEnabled,
 			worktreeSetupHook: deps.config.worktreeSetupHook,

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -494,6 +494,105 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		fs.rmSync(resultPath, { force: true });
 	});
 
+	it("runs an external CLI workflow child with subagents.defaultModel configured", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const markerPath = path.join(tempDir, "external-started");
+		const executor = makeExecutor([
+			makeAgent("external", {
+				runner: { type: "external-cli", command: process.execPath, args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "started"); process.stdout.write("external result")`] },
+				model: "mock/default-model",
+				modelSource: { type: "subagents.defaultModel", scope: "user", path: "/settings.json", model: "mock/default-model" },
+			}),
+		]);
+		const ctx = { ...makeMinimalCtx(tempDir), model: { provider: "mock", id: "parent-model" } };
+		const started = await executor.execute(
+			`external-workflow-${Date.now()}`,
+			{ workflowScript: `return await runs.run("external", { agent: "external", task: "Run external", async: true });` },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+
+		assert.equal(started.isError, undefined);
+		assert.ok(started.details.asyncId);
+		const workflowResultPath = path.join(DIRS.results, `${started.details.asyncId}.json`);
+		let workflowResult: { state?: string; results?: Array<{ output?: string; runId?: string }> } = {};
+		for (let attempt = 0; attempt < 100; attempt++) {
+			if (fs.existsSync(workflowResultPath)) workflowResult = JSON.parse(fs.readFileSync(workflowResultPath, "utf-8"));
+			if (workflowResult.state === "complete" || workflowResult.state === "failed") break;
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		assert.equal(workflowResult.state, "complete");
+		assert.match(workflowResult.results?.[0]?.output ?? "", /Async: external/);
+		for (let attempt = 0; attempt < 100 && !fs.existsSync(markerPath); attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		assert.equal(fs.readFileSync(markerPath, "utf-8"), "started");
+		assert.equal(mockPi.callCount(), 0);
+
+		fs.rmSync(started.details.asyncDir!, { recursive: true, force: true });
+		fs.rmSync(workflowResultPath, { force: true });
+	});
+
+	it("rejects explicit model overrides for external CLI agents", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([
+			makeAgent("external", {
+				runner: { type: "external-cli", command: process.execPath, args: ["-e", "process.stdout.write('unreachable')"] },
+			}),
+		]);
+		const result = await executor.execute(
+			"external-explicit-model",
+			{ agent: "external", task: "Run external", async: true, model: "mock/override" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /does not support: model override/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
+	it("rejects external CLI agent models that differ from inherited subagents.defaultModel", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([
+			makeAgent("external", {
+				runner: { type: "external-cli", command: process.execPath, args: ["-e", "process.stdout.write('unreachable')"] },
+				model: "mock/override-model",
+				modelSource: { type: "subagents.defaultModel", scope: "user", path: "/settings.json", model: "mock/default-model" },
+			}),
+		]);
+		const result = await executor.execute(
+			"external-agent-override-model",
+			{ agent: "external", task: "Run external", async: true },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /does not support: model override/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
+	it("rejects external CLI agent models that equal inherited subagents.defaultModel without provenance", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([
+			makeAgent("external", {
+				runner: { type: "external-cli", command: process.execPath, args: ["-e", "process.stdout.write('unreachable')"] },
+				model: "mock/default-model",
+			}),
+		]);
+		const result = await executor.execute(
+			"external-agent-same-value-override-model",
+			{ agent: "external", task: "Run external", async: true },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /does not support: model override/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
 	it("projects live child activity into async workflow status", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({
 			steps: [

--- a/test/unit/agent-overrides.test.ts
+++ b/test/unit/agent-overrides.test.ts
@@ -80,8 +80,27 @@ describe("builtin agent overrides", () => {
 		assert.equal(scout?.modelSource?.type, "subagents.defaultModel");
 		assert.equal(scout?.modelSource?.scope, "user");
 		assert.equal(builtins.find((agent) => agent.name === "worker")?.model, "deepseek-v4-flash");
-		assert.equal(builtins.find((agent) => agent.name === "oracle")?.model, "deepseek-v4-pro");
-		assert.equal(builtins.find((agent) => agent.name === "reviewer")?.model, undefined);
+		const oracle = builtins.find((agent) => agent.name === "oracle");
+		assert.equal(oracle?.model, "deepseek-v4-pro");
+		assert.equal(oracle?.modelSource, undefined);
+		const reviewer = builtins.find((agent) => agent.name === "reviewer");
+		assert.equal(reviewer?.model, undefined);
+		assert.equal(reviewer?.modelSource, undefined);
+	});
+
+	it("clears subagents.defaultModel provenance for same-value agent model overrides", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: {
+				defaultModel: "deepseek-v4-flash",
+				agentOverrides: {
+					worker: { model: "deepseek-v4-flash" },
+				},
+			},
+		});
+
+		const worker = discoverAgentsAll(tempProject).builtin.find((agent) => agent.name === "worker");
+		assert.equal(worker?.model, "deepseek-v4-flash");
+		assert.equal(worker?.modelSource, undefined);
 	});
 
 	it("prefers project subagents.defaultModel over user defaultModel", () => {


### PR DESCRIPTION
## Summary
Fixes #1016.

Single external-cli workflow children now skip only inherited Pi model state. They no longer turn the parent model or a discovery-applied `subagents.defaultModel` into a Pi `modelOverride`, so model-less external commands can start and use their own configuration.

Explicit model configuration still fails closed for external-cli. The branch keeps per-run model overrides rejected, keeps explicit external-cli frontmatter model rejection in agent loading, and adds coverage for the `agentOverrides` edge case where an override model differs from a stale `subagents.defaultModel` source.

Thanks to @twosunnus for the report and reproduction in #1016.

## Validation
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='external CLI' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review: `/Users/nicobailon/Documents/docs/pi-subagents-backlog-2026-08-12/issue-1016-review-final.md`
- Follow-up review: `/Users/nicobailon/Documents/docs/pi-subagents-backlog-2026-08-12/issue-1016-review-followup.md`
