### PR TITLE
fix: preserve output on acceptance rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Explain when a requested mission is scoped to another worktree by naming the current project root and mission directory (#1024).
+- Preserve the configured output reference when explicit acceptance rejects an otherwise completed foreground child, so useful reports remain available (#1023).
 - Reject configured worktree base directories inside the agent extensions directory, including symlink aliases (#1014).
 - Align unnamed intercom fallback orchestrator targets with pi-intercom's 18-character registered presence names so subagents without an explicit session name can reach their orchestrator. Thanks to @mystery4f for #1017.
 - Stop reading hyphenated adjectives like "must-fix items" or "should-fix tests" as implementation intent, which made the completion mutation guard hard-fail read-only review runs with a false "completed without making edits" error. Severity compounds (must|should|needs + dash + verb) are stripped before verb matching across every mutation pattern (incl. update/add/apply/make/do siblings), the acceptance-level write-capability check, and the patch-scope pattern, while CLI flags ("eslint --fix", "prettier --write") and clause-level dashes ("branch—fix it") keep their write intent. Thanks to @MarcusNeufeldt for #1020.

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -66,7 +66,7 @@ import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput } from "../shared/structured-output.ts";
 import { formatProcessSignalError, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
 import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
-import { captureSingleOutputSnapshot, extractChildWrittenOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
+import { captureSingleOutputSnapshot, extractChildWrittenOutput, finalizeSingleOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
 import {
 	buildModelCandidates,
 	formatModelAttemptNote,
@@ -1750,7 +1750,32 @@ async function runSyncCompletion(
 	stripAcceptanceReportsFromMessages(result.messages);
 	if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.interrupted && !result.timedOut && !isAgentContractV1(options.agentContract)) {
 		result.exitCode = 1;
+		if (result.savedOutputPath) {
+			result.finalOutput = finalizeSingleOutput({
+				fullOutput: result.finalOutput ?? "",
+				outputPath: options.outputPath,
+				outputMode: result.outputMode,
+				exitCode: result.exitCode,
+				preserveSavedOutput: true,
+				savedPath: result.savedOutputPath,
+				outputReference: result.outputReference,
+			}).displayOutput;
+			artifactOutputByResult.set(result, result.finalOutput);
+		}
 		result.error = result.error ? `${result.error}\n${acceptanceFailure}` : acceptanceFailure;
+		if (artifactPathsResult && options.artifactConfig?.enabled !== false && options.artifactConfig?.includeOutput !== false) {
+			try {
+				writeArtifact(artifactPathsResult.outputPath, formatOutputArtifactContent({
+					output: artifactOutputByResult.get(result) ?? result.finalOutput ?? "",
+					error: result.error,
+					transcriptPath: result.transcriptPath,
+					metadataPath: options.artifactConfig?.includeMetadata === false ? undefined : artifactPathsResult.metadataPath,
+				}));
+			} catch (error) {
+				const message = `Artifact output post-processing failed: ${error instanceof Error ? error.message : String(error)}`;
+				result.outputSaveError = result.outputSaveError ? `${result.outputSaveError}\n${message}` : message;
+			}
+		}
 		if (result.progress) {
 			result.progress.status = "failed";
 			result.progress.error = result.error;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4029,12 +4029,14 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	if (r.artifactPaths) allArtifactPaths.push(r.artifactPaths);
 
 	const fullOutput = getSingleResultOutput(r);
+	const preserveRejectedSavedOutput = r.acceptance?.explicit && r.acceptance.status === "rejected" && r.savedOutputPath !== undefined;
 	const finalizedOutput = finalizeSingleOutput(omitUndefinedProperties({
 		fullOutput,
 		truncatedOutput: r.truncation?.text,
 		outputPath,
 		outputMode: r.outputMode,
 		exitCode: r.exitCode,
+		preserveSavedOutput: preserveRejectedSavedOutput,
 		savedPath: r.savedOutputPath,
 		outputReference: r.outputReference,
 		saveError: r.outputSaveError,

--- a/src/runs/shared/single-output.ts
+++ b/src/runs/shared/single-output.ts
@@ -214,17 +214,19 @@ export function finalizeSingleOutput(params: {
 	outputPath?: string;
 	outputMode?: OutputMode;
 	exitCode: number;
+	/** Keep the saved-output reference when a post-run acceptance gate rejects an otherwise completed child. */
+	preserveSavedOutput?: boolean;
 	savedPath?: string;
 	outputReference?: SavedOutputReference;
 	saveError?: string;
 }): { displayOutput: string; savedPath?: string; outputReference?: SavedOutputReference; saveError?: string } {
 	let displayOutput = params.truncatedOutput || params.fullOutput;
-	if (params.exitCode === 0 && params.savedPath) {
+	if ((params.exitCode === 0 || params.preserveSavedOutput) && params.savedPath) {
 		const outputReference = params.outputReference ?? formatSavedOutputReference(params.savedPath, params.fullOutput);
 		if (params.outputMode === "file-only") {
 			return { displayOutput: outputReference.message, savedPath: params.savedPath, outputReference };
 		}
-		displayOutput += `\n\n${outputReference.message}`;
+		if (!displayOutput.includes(outputReference.message)) displayOutput += `\n\n${outputReference.message}`;
 		return { displayOutput, savedPath: params.savedPath, outputReference };
 	}
 	if (params.exitCode === 0 && params.saveError && params.outputPath) {

--- a/test/integration/acceptance-file-report.test.ts
+++ b/test/integration/acceptance-file-report.test.ts
@@ -235,6 +235,8 @@ describe("acceptance file reports", { skip: !runSync ? "pi packages not availabl
 
 			assert.equal(result.acceptance?.status, "rejected");
 			assert.equal(result.exitCode, 1);
+			assert.match(result.finalOutput ?? "", /Output saved to:/);
+			assert.match(result.finalOutput ?? "", new RegExp(outputPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 			assert.match(result.error ?? "", /Acceptance rejected: Required criterion 'criterion-1' was reported as not-satisfied\./);
 			assert.ok(result.artifactPaths);
 			const metadata = JSON.parse(fs.readFileSync(result.artifactPaths.metadataPath, "utf-8")) as { exitCode?: number; error?: string; acceptance?: AcceptanceSummary };
@@ -242,6 +244,91 @@ describe("acceptance file reports", { skip: !runSync ? "pi packages not availabl
 			assert.match(metadata.error ?? "", /Acceptance rejected/);
 			assert.equal(metadata.acceptance?.status, "rejected");
 			assert.equal(metadata.acceptance?.runtimeChecks?.find((check) => check.id === "criterion:criterion-1")?.status, "failed");
+			const outputArtifact = fs.readFileSync(result.artifactPaths.outputPath, "utf-8");
+			assert.match(outputArtifact, /Output saved to:/);
+			assert.match(outputArtifact, new RegExp(outputPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+		});
+
+		it("inline mode keeps one saved output reference after rejection", { skip: !createSubagentExecutor ? "executor not available" : undefined }, async () => {
+			const outputPath = path.join(tempDir, "report.md");
+			const artifactsDir = path.join(tempDir, "rejected-inline-artifacts");
+			conflictingReportsCall(outputPath, "satisfied", "not-satisfied");
+			const executor = createSubagentExecutor!({
+				pi: { events: createEventBus(), getSessionName: () => undefined },
+				state: { baseCwd: tempDir, currentSessionId: null, asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null },
+				config: { artifactDir: "temp" },
+				asyncByDefault: false,
+				tempArtifactsDir: artifactsDir,
+				getSubagentSessionRoot: () => tempDir,
+				expandTilde: (p: string) => p,
+				discoverAgents: () => ({ agents: [makeAgent("worker", { completionGuard: false })] }),
+			});
+
+			const result = await executor.execute(
+				"acceptance-inline-single-reference-rejection",
+				{
+					agent: "worker",
+					task: "Write the findings report.",
+					output: outputPath,
+					acceptance: { level: "checked", criteria: ["Report the findings"] },
+				},
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+
+			assert.equal(result.isError, true);
+			const content = result.content[0]?.text ?? "";
+			assert.equal(content.match(/Output saved to:/g)?.length, 1);
+			assert.match(content, new RegExp(outputPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+			assert.equal(result.details?.results?.[0]?.acceptance?.status, "rejected");
+			assert.match(result.details?.results?.[0]?.finalOutput ?? "", /Output saved to:/);
+		});
+
+		it("inline mode keeps the saved output visible after maxOutput truncation on rejection", { skip: !createSubagentExecutor ? "executor not available" : undefined }, async () => {
+			const outputPath = path.join(tempDir, "report.md");
+			const artifactsDir = path.join(tempDir, "rejected-max-output-artifacts");
+			const fileReport = `# Findings\n${"Saved report detail. ".repeat(300)}\n${acceptanceReport("satisfied", "from child-written file")}`;
+			mockPi.onCall({
+				jsonl: [
+					...events.completedWrite(outputPath, fileReport),
+					events.assistantMessage(`Report written to the output file.\n${acceptanceReport("not-satisfied", "from assistant text")}`),
+				],
+				writeFiles: [{ path: outputPath, content: fileReport }],
+			});
+			const executor = createSubagentExecutor!({
+				pi: { events: createEventBus(), getSessionName: () => undefined },
+				state: { baseCwd: tempDir, currentSessionId: null, asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null },
+				config: { artifactDir: "temp" },
+				asyncByDefault: false,
+				tempArtifactsDir: artifactsDir,
+				getSubagentSessionRoot: () => tempDir,
+				expandTilde: (p: string) => p,
+				discoverAgents: () => ({ agents: [makeAgent("worker", { completionGuard: false })] }),
+			});
+
+			const result = await executor.execute(
+				"acceptance-inline-max-output-rejection",
+				{
+					agent: "worker",
+					task: "Write the findings report.",
+					output: outputPath,
+					acceptance: { level: "checked", criteria: ["Report the findings"] },
+					maxOutput: { bytes: 40, lines: 1 },
+				},
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+
+			assert.equal(result.isError, true);
+			const content = result.content[0]?.text ?? "";
+			assert.match(content, /\[TRUNCATED:/);
+			assert.match(content, /Output saved to:/);
+			assert.match(content, new RegExp(outputPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+			assert.doesNotMatch(content, /Saved report detail/);
+			assert.equal(result.details?.results?.[0]?.acceptance?.status, "rejected");
+			assert.match(result.details?.results?.[0]?.finalOutput ?? "", /Output saved to:/);
 		});
 
 		it("inline mode accepts on the text report regardless of a failing file report", async () => {

--- a/test/unit/single-output.test.ts
+++ b/test/unit/single-output.test.ts
@@ -309,4 +309,32 @@ describe("finalizeSingleOutput", () => {
 
 		assert.equal(result.displayOutput, "truncated output");
 	});
+
+	it("preserves the saved-output reference for acceptance-only failures", () => {
+		const result = finalizeSingleOutput({
+			fullOutput: "useful output",
+			outputPath: "/tmp/review.md",
+			outputMode: "file-only",
+			exitCode: 1,
+			preserveSavedOutput: true,
+			savedPath: "/tmp/review.md",
+		});
+
+		assert.match(result.displayOutput, /^Output saved to:/);
+		assert.doesNotMatch(result.displayOutput, /useful output/);
+	});
+
+	it("does not duplicate an existing saved-output reference", () => {
+		const outputReference = formatSavedOutputReference("/tmp/review.md", "useful output");
+		const result = finalizeSingleOutput({
+			fullOutput: `useful output\n\n${outputReference.message}`,
+			outputPath: "/tmp/review.md",
+			exitCode: 1,
+			preserveSavedOutput: true,
+			savedPath: "/tmp/review.md",
+			outputReference,
+		});
+
+		assert.equal(result.displayOutput.match(/Output saved to:/g)?.length, 1);
+	});
 });


### PR DESCRIPTION
## Summary
Fixes #1023.

This implements a narrow first slice from the stale/output handling issue: when explicit acceptance rejects an otherwise completed foreground child, the result keeps the configured saved-output reference so the useful report path remains available even though the run fails.

The change intentionally does not cover stale-head suppression, report-path collision detection, workflow policy, or a broader acceptance-failure envelope.

## Validation
- `node --experimental-strip-types --test test/unit/single-output.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/acceptance-file-report.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review: `/Users/nicobailon/Documents/docs/pi-subagents-backlog-2026-08-12/issue-1023-review.md`
