### PR TITLE
feat: add file task delivery mode and SIGKILL startup-retry escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - Add a global `timeoutMs` config option that sets the default run deadline for single, parallel, and chain launches (foreground, plus plain single-agent async) when neither the call nor the selected agent provides a timeout. It reaches parallel (`tasks: [...]`) and chain launches, which never adopt an agent's frontmatter `timeoutMs` (that default applies to single-agent launches only), so a long fan-out no longer falls back to the built-in 30-minute default and gets killed mid-run. Explicit call `timeoutMs`/`maxRuntimeMs` and agent frontmatter defaults still win; composite async runs stay unbounded at the top level by design. Thanks to @shaharmor for #1018.
+- Add a `PI_SUBAGENT_TASK_DELIVERY` environment setting (`auto` | `file`, default `auto`) controlling how the task text reaches child Pi processes. `file` writes the task to a temp `task.md` referenced as `@<path>` instead of embedding it in argv, for hosts where endpoint protection (EDR) pre-execution command-line scanning denies children whose argv embeds a long natural-language task. Thanks to @yanqianglu for #1028.
+- Escalate startup retries to file task delivery after an unexplained zero-activity `SIGKILL` child exit, so EDR-denied launches self-heal on retry in both foreground and background runs. Thanks to @yanqianglu for #1028.
 
 ### Fixed
 - Explain when a requested mission is scoped to another worktree by naming the current project root and mission directory (#1024).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,6 +208,16 @@ export PI_SUBAGENT_PI_BINARY=/path/to/pi-or-wrapper
 
 Overrides the command used to launch child Pi processes. Package wrappers can set this to their own `pi`/agent binary so subagents inherit wrapper flags, environment setup, and bundled resources without relying on `PATH` ordering. Empty or whitespace-only values are ignored.
 
+## `PI_SUBAGENT_TASK_DELIVERY`
+
+```bash
+export PI_SUBAGENT_TASK_DELIVERY=file   # auto | file (default: auto)
+```
+
+Controls how the task text reaches the child Pi process. `auto` (default) passes short tasks as an inline argv token and writes tasks longer than 8000 characters to a temp `task.md` referenced as `@<path>`. `file` always uses a temp file, keeping the task out of argv entirely.
+
+Use `file` on hosts where endpoint protection (EDR) pre-execution scanning denies child processes whose command line embeds a long natural-language task — that denial surfaces as an immediate zero-activity `SIGKILL`. Independently of this setting, startup retries automatically escalate to file delivery after an unexplained zero-activity `SIGKILL`. Empty, whitespace-only, or unrecognized values fall back to `auto`.
+
 ## `intercomBridge`
 
 ```json

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -68,7 +68,7 @@ import {
 	DEFAULT_GLOBAL_CONCURRENCY_LIMIT,
 	Semaphore,
 } from "../shared/parallel-utils.ts";
-import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/pi-args.ts";
+import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { outputEntryFromAsyncResult, resolveOutputReferences } from "../shared/chain-outputs.ts";
 import { createStructuredOutputRuntime, MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput } from "../shared/structured-output.ts";
@@ -1306,6 +1306,9 @@ async function runSingleStep(
 
 	let modelIndex = 0;
 	let startupAttemptIndex = 0;
+	// Escalated to "file" after an unexplained zero-activity startup failure so
+	// retries keep the task text out of argv (endpoint pre-exec scans may deny it).
+	let taskDeliveryOverride: SubagentTaskDelivery | undefined;
 	modelAttemptsLoop: while (modelIndex < candidates.length) {
 		if (ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break;
 		const candidate = candidates[modelIndex];
@@ -1331,6 +1334,7 @@ async function runSingleStep(
 			parentSessionId: step.parentSessionId,
 			baseArgs: ["--mode", "json", "-p"],
 			task,
+			taskDelivery: taskDeliveryOverride,
 			sessionEnabled,
 			sessionDir,
 			sessionFile: step.sessionFile,
@@ -1583,6 +1587,10 @@ async function runSingleStep(
 			});
 			const shouldRetry = await waitForSubagentStartupRetry(retryDelayMs, [ctx.timeoutSignal, ctx.stopSignal]);
 			if (!shouldRetry || ctx.skipAcceptance?.()) break modelAttemptsLoop;
+			if (!taskDeliveryOverride && run.processSignal === "SIGKILL") {
+				taskDeliveryOverride = "file";
+				attemptNotes.push("[startup-retry] retrying with file task delivery to keep the task text out of the child process argv.");
+			}
 			attempt.error = retryNote;
 			attemptNotes.push(retryNote);
 			startupAttemptIndex += 1;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -59,7 +59,7 @@ import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { resolvePermissionRules } from "../shared/permissions.ts";
-import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/pi-args.ts";
+import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV } from "../shared/capability-ceiling.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
@@ -292,6 +292,7 @@ async function runSingleAttempt(
 		attemptNotes: string[];
 		outputSnapshot?: SingleOutputSnapshot;
 		originalTask?: string;
+		taskDelivery?: SubagentTaskDelivery;
 	},
 ): Promise<SingleResult> {
 	const effectiveThinking = options.thinkingOverride ?? agent.thinking;
@@ -313,6 +314,7 @@ async function runSingleAttempt(
 	const { args, env: sharedEnv, tempDir, toolDiagnosticPath, runtimeAcknowledgedExtensionsPath, capabilityAudit } = buildPiArgs({
 		baseArgs: ["--mode", "json", "-p"],
 		task,
+		taskDelivery: shared.taskDelivery,
 		sessionEnabled: shared.sessionEnabled,
 		sessionDir: options.sessionDir,
 		sessionFile: options.sessionFile,
@@ -1550,6 +1552,9 @@ async function runSyncCompletion(
 	};
 	let lastResult: SingleResult | undefined;
 	const modelsToTry = candidates.length > 0 ? candidates : [undefined];
+	// Escalated to "file" after an unexplained zero-activity startup failure so
+	// retries keep the task text out of argv (endpoint pre-exec scans may deny it).
+	let taskDeliveryOverride: SubagentTaskDelivery | undefined;
 	modelAttemptsLoop: for (let modelIndex = 0; modelIndex < modelsToTry.length; modelIndex++) {
 		const candidate = modelsToTry[modelIndex];
 		for (let startupAttemptIndex = 0; ; startupAttemptIndex++) {
@@ -1568,6 +1573,7 @@ async function runSyncCompletion(
 					.filter((modelCandidate): modelCandidate is string => Boolean(modelCandidate)),
 				outputSnapshot,
 				originalTask: task,
+				taskDelivery: taskDeliveryOverride,
 			});
 			lastResult = result;
 			if (startupAttemptIndex === 0) {
@@ -1635,6 +1641,10 @@ async function runSyncCompletion(
 						if (result.progress) result.progress.error = cancellationError;
 					}
 					break modelAttemptsLoop;
+				}
+				if (!taskDeliveryOverride && result.processSignal === "SIGKILL") {
+					taskDeliveryOverride = "file";
+					attemptNotes.push("[startup-retry] retrying with file task delivery to keep the task text out of the child process argv.");
 				}
 				attempt.error = retryNote;
 				attemptNotes.push(retryNote);

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -63,6 +63,32 @@ import {
 } from "./capability-ceiling.ts";
 
 const TASK_ARG_LIMIT = 8000;
+
+/**
+ * Env override for how the task text reaches the child process. Endpoint
+ * protection (EDR) pre-execution command-line scanning may deny exec of
+ * children whose argv embeds a long natural-language task, which surfaces
+ * as an immediate zero-activity SIGKILL. File delivery keeps the task out
+ * of argv entirely.
+ */
+export const SUBAGENT_TASK_DELIVERY_ENV = "PI_SUBAGENT_TASK_DELIVERY";
+
+export type SubagentTaskDelivery = "auto" | "file";
+
+export function resolveSubagentTaskDelivery(
+	env: NodeJS.ProcessEnv = process.env,
+): SubagentTaskDelivery {
+	return env[SUBAGENT_TASK_DELIVERY_ENV]?.trim().toLowerCase() === "file"
+		? "file"
+		: "auto";
+}
+
+function shouldDeliverTaskViaFile(
+	task: string,
+	delivery: SubagentTaskDelivery,
+): boolean {
+	return delivery === "file" || task.length > TASK_ARG_LIMIT;
+}
 const MAX_LAUNCH_RESOLVED_EXTENSION_IDS = 32;
 const PROMPT_RUNTIME_EXTENSION_PATH = path.join(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -149,6 +175,12 @@ export interface BuildPiArgsInput {
 	permissionRules?: PermissionRules;
 	permissionAuditPath?: string;
 	childWatchdog?: ChildWatchdogConfig;
+	/**
+	 * Per-launch override of the task delivery mode. Startup-retry paths set
+	 * this to "file" after an unexplained zero-activity SIGKILL so the retry
+	 * keeps the task text out of the child's argv.
+	 */
+	taskDelivery?: SubagentTaskDelivery;
 	waitToolEnabled?: boolean;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 }
@@ -585,7 +617,12 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		);
 	}
 
-	if (input.task.length > TASK_ARG_LIMIT) {
+	if (
+		shouldDeliverTaskViaFile(
+			input.task,
+			input.taskDelivery ?? resolveSubagentTaskDelivery(),
+		)
+	) {
 		if (!tempDir) {
 			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));
 		}

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -322,6 +322,13 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		return readCall().args;
 	}
 
+	function readAllCallArgs(): string[][] {
+		return fs.readdirSync(mockPi.dir)
+			.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
+			.sort()
+			.map((name) => (JSON.parse(fs.readFileSync(path.join(mockPi.dir, name), "utf-8")) as MockPiCallRecord).args);
+	}
+
 	function makeExecutor(
 		agents = [makeAgent("echo")],
 		config: Record<string, unknown> = {},
@@ -2675,6 +2682,29 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.progress.recentOutput.join("\n"), /\[startup-retry\].*same model/i);
 		assert.equal(result.progress.recentOutput.filter((line) => line.startsWith("[startup-retry]")).length, 1);
 		assert.equal(mockPi.callCount(), 2);
+	});
+
+	it("escalates to file task delivery after a zero-activity SIGKILL startup exit", { skip: process.platform === "win32" ? "POSIX child signal reporting is unavailable on Windows" : false }, async () => {
+		mockPi.onCall({ signal: "SIGKILL" });
+		mockPi.onCall({ output: "Recovered via file delivery" });
+		const agents = [makeAgent("worker", { model: "openai/gpt-5-mini" })];
+
+		const result = await runSync(tempDir, agents, "worker", "Do work", {
+			runId: "startup-sigkill-file-delivery-sync",
+			acceptance: false,
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.finalOutput, "Recovered via file delivery");
+		assert.equal(mockPi.callCount(), 2);
+		const [firstArgs, retryArgs] = readAllCallArgs();
+		assert.ok(firstArgs?.includes("Task: Do work"), "first attempt should deliver the task inline");
+		const retryTaskArg = retryArgs?.at(-1) ?? "";
+		assert.ok(
+			retryTaskArg.startsWith("@") && retryTaskArg.endsWith("task.md"),
+			`retry should reference a task file instead of inline argv, got: ${retryTaskArg}`,
+		);
+		assert.match(result.progress.recentOutput.join("\n"), /\[startup-retry\].*file task delivery/i);
 	});
 
 	it("does not retry a non-zero exit after tool activity", async () => {

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -68,6 +68,7 @@ const originalEnv = {
 	[PI_INTERCOM_SESSION_ID_ENV]: process.env[PI_INTERCOM_SESSION_ID_ENV],
 	MCP_HASH_ROOT: process.env.MCP_HASH_ROOT,
 	MCP_HASH_TOKEN: process.env.MCP_HASH_TOKEN,
+	PI_SUBAGENT_TASK_DELIVERY: process.env.PI_SUBAGENT_TASK_DELIVERY,
 };
 const originalCwd = process.cwd();
 const tempRoots: string[] = [];
@@ -478,6 +479,88 @@ describe("buildPiArgs model wiring", () => {
 		assert.ok(args.includes("--model"));
 		assert.ok(args.includes(model));
 		assert.ok(!args.includes(`${model}:high`));
+	});
+});
+
+describe("buildPiArgs task delivery", () => {
+	const longTask = "x".repeat(8001);
+
+	function taskFileFromArgs(args: string[]): string | undefined {
+		const ref = args.find((arg) => arg.startsWith("@") && arg.endsWith("task.md"));
+		return ref ? ref.slice(1) : undefined;
+	}
+
+	it("delivers short tasks inline by default", () => {
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.ok(args.includes("Task: hello"));
+		assert.equal(taskFileFromArgs(args), undefined);
+	});
+
+	it("delivers tasks over the argv limit via a temp file by default", () => {
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: longTask,
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		const taskFile = taskFileFromArgs(args);
+		assert.ok(taskFile, "expected an @task.md argv reference");
+		assert.equal(fs.readFileSync(taskFile, "utf-8"), `Task: ${longTask}`);
+		assert.ok(!args.includes(`Task: ${longTask}`));
+	});
+
+	it("delivers short tasks via file when PI_SUBAGENT_TASK_DELIVERY=file", () => {
+		process.env.PI_SUBAGENT_TASK_DELIVERY = "file";
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		const taskFile = taskFileFromArgs(args);
+		assert.ok(taskFile, "expected an @task.md argv reference");
+		assert.equal(fs.readFileSync(taskFile, "utf-8"), "Task: hello");
+		assert.ok(!args.includes("Task: hello"));
+	});
+
+
+	it("falls back to auto when PI_SUBAGENT_TASK_DELIVERY is invalid", () => {
+		process.env.PI_SUBAGENT_TASK_DELIVERY = "carrier-pigeon";
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: longTask,
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.ok(taskFileFromArgs(args), "expected file delivery for over-limit task");
+	});
+
+	it("lets the per-launch taskDelivery override beat the env setting", () => {
+		delete process.env.PI_SUBAGENT_TASK_DELIVERY;
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			taskDelivery: "file",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.ok(taskFileFromArgs(args), "expected an @task.md argv reference");
+		assert.ok(!args.includes("Task: hello"));
 	});
 });
 


### PR DESCRIPTION
## Problem

On hosts running endpoint protection (EDR) with fail-closed pre-execution command-line scanning, spawning a child Pi process with a natural-language task embedded inline in argv can get the exec denied before the process produces any output. The parent observes an immediate, unexplained zero-activity `SIGKILL` (child exits within ~100–200ms, no messages, no usage), which retries with the identical argv and fails the same way every time.

A/B on an affected host: the same task delivered via a `@task.md` file reference succeeds; the same task inline in argv is killed.

## Changes

1. **`PI_SUBAGENT_TASK_DELIVERY` environment setting** (`auto` | `file`, default `auto`). `file` always writes the task to a temp `task.md` referenced as `@<path>`, keeping the task text out of argv entirely. `auto` preserves today's behavior (inline under 8000 chars, file above). Unrecognized values fall back to `auto`. Documented in `docs/configuration.md`.

2. **Automatic escalation on startup retry.** When a startup attempt is classified as a retryable zero-activity failure *and* the child died with `SIGKILL`, subsequent startup retries escalate to file delivery — in both the foreground runner and the background runner (which covers async runs). Affected launches self-heal with no configuration, and the escalation is recorded in the run's attempt notes.

Default behavior is unchanged for everyone else.

## Tests

- Unit: delivery-mode resolution — short task inline by default, over-limit task via file by default, `PI_SUBAGENT_TASK_DELIVERY=file` forces file for short tasks, invalid values fall back to `auto`, per-launch `taskDelivery` override beats env.
- Integration: foreground run where the first mock child exits via `SIGKILL` and the retry succeeds — asserts attempt 1 argv contains the inline task and attempt 2 argv references `@...task.md`.
- `npm run typecheck` clean; full unit suite and the touched integration suites pass.
