### PR TITLE
fix: verify async process tree cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Escalate startup retries to file task delivery after an unexplained zero-activity `SIGKILL` child exit, so EDR-denied launches self-heal on retry in both foreground and background runs. Thanks to @yanqianglu for #1028.
 
 ### Fixed
+- Terminate async Pi writers as owned POSIX process groups on stop and timeout, and keep terminal process proof unknown until process-tree exit is verified. Thanks to @asjer for #1030.
 - Explain when a requested mission is scoped to another worktree by naming the current project root and mission directory (#1024).
 - Preserve the configured output reference when explicit acceptance rejects an otherwise completed foreground child, so useful reports remain available (#1023).
 - Reject configured worktree base directories inside the agent extensions directory, including symlink aliases (#1014).

--- a/src/runs/background/active-run-index.ts
+++ b/src/runs/background/active-run-index.ts
@@ -16,6 +16,14 @@ export function isActiveAsyncState(state: AsyncStatus["state"]): boolean {
 	return state === "queued" || state === "running";
 }
 
+export function releaseActiveRunIndex(asyncDir: string): void {
+	try {
+		fs.rmSync(markerPath(asyncDir));
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+}
+
 export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state"]): void {
 	const marker = markerPath(asyncDir);
 	if (isActiveAsyncState(state)) {
@@ -23,11 +31,7 @@ export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state
 		fs.writeFileSync(marker, "", { flag: "a" });
 		return;
 	}
-	try {
-		fs.rmSync(marker);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-	}
+	releaseActiveRunIndex(asyncDir);
 }
 
 export function readActiveRunIndex(asyncDirRoot: string): string[] | undefined {

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -11,7 +11,7 @@ import { flatToLogicalStepIndex, normalizeParallelGroups } from "./parallel-grou
 import { contextModeLabel, summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
 import { readProcessTerminal, sanitizeProcessTerminal } from "./process-terminal.ts";
-import { ACTIVE_RUN_INDEX_DIR, isActiveAsyncState, readActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
+import { ACTIVE_RUN_INDEX_DIR, isActiveAsyncState, readActiveRunIndex, releaseActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
@@ -452,11 +452,11 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 			if (usedActiveIndex) updateActiveRunIndex(asyncDir, "failed");
 			continue;
 		}
-		if (status.displayDismissedAt !== undefined) {
-			if (usedActiveIndex) updateActiveRunIndex(asyncDir, "complete");
-			continue;
+		if (usedActiveIndex && !isActiveAsyncState(status.state)) {
+			const processTerminal = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId });
+			if (processTerminal?.state === "observed") releaseActiveRunIndex(asyncDir);
 		}
-		if (usedActiveIndex && !isActiveAsyncState(status.state)) updateActiveRunIndex(asyncDir, status.state);
+		if (status.displayDismissedAt !== undefined) continue;
 		// Filter before the nested-route lookup: the lookup builds an index over
 		// the nested-events directory, so deferring it for filtered-out runs keeps
 		// restoration at load from scanning that directory when no active runs

--- a/src/runs/background/owned-process-tree.ts
+++ b/src/runs/background/owned-process-tree.ts
@@ -1,0 +1,104 @@
+import { spawnSync } from "node:child_process";
+import type { ProcessTreeTerminalV1 } from "../../shared/types.ts";
+
+const DEFAULT_TERM_GRACE_MS = 3000;
+const DEFAULT_KILL_VERIFY_MS = 1000;
+const VERIFY_INTERVAL_MS = 25;
+
+type SignalResult = "sent" | "absent" | { diagnostic: string };
+
+function diagnostic(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function signalProcess(id: number, signal: NodeJS.Signals): SignalResult {
+	try {
+		process.kill(id, signal);
+		return "sent";
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ESRCH") return "absent";
+		return { diagnostic: diagnostic(error) };
+	}
+}
+
+function activeProcessGroupMembers(processGroupId: number): number[] | { diagnostic: string } {
+	const result = spawnSync("ps", ["-axo", "pid=,pgid=,stat="], { encoding: "utf-8" });
+	if (result.error || result.status !== 0) {
+		return { diagnostic: result.error ? diagnostic(result.error) : (result.stderr.trim() || `ps exited with ${result.status}`) };
+	}
+	const members: number[] = [];
+	for (const line of result.stdout.split("\n")) {
+		const match = /^\s*(\d+)\s+(\d+)\s+(\S+)/.exec(line);
+		if (!match || Number(match[2]) !== processGroupId || match[3]!.startsWith("Z")) continue;
+		members.push(Number(match[1]));
+	}
+	return members;
+}
+
+async function waitUntilGroupTerminal(
+	processGroupId: number,
+	timeoutMs: number,
+): Promise<false | { state: "enumeration-failed" | "still-active"; diagnostic: string }> {
+	const deadline = Date.now() + timeoutMs;
+	while (true) {
+		const members = activeProcessGroupMembers(processGroupId);
+		if (Array.isArray(members) && members.length === 0) return false;
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) {
+			if (!Array.isArray(members)) return { state: "enumeration-failed", diagnostic: members.diagnostic };
+			return { state: "still-active", diagnostic: `Process group ${processGroupId} still has active members: ${members.join(", ")}.` };
+		}
+		await new Promise<void>((resolve) => setTimeout(resolve, Math.min(VERIFY_INTERVAL_MS, remaining)));
+	}
+}
+
+function observed(processGroupId: number): ProcessTreeTerminalV1 {
+	return { state: "observed", mechanism: "posix-process-group", processGroupId, verifiedAt: Date.now() };
+}
+
+/** Owns one writer process group and arbitrates its cleanup exactly once. */
+export interface OwnedProcessTreeController {
+	terminate(): Promise<ProcessTreeTerminalV1>;
+	finishAfterWriterClose(): Promise<ProcessTreeTerminalV1>;
+}
+
+export function createOwnedProcessTreeController(
+	pid: number,
+	options: { termGraceMs?: number; killVerifyMs?: number } = {},
+): OwnedProcessTreeController {
+	let termination: Promise<ProcessTreeTerminalV1> | undefined;
+	const posixGroupOwned = process.platform !== "win32";
+	const target = posixGroupOwned ? -pid : pid;
+
+	const terminate = (): Promise<ProcessTreeTerminalV1> => {
+		if (termination) return termination;
+		termination = (async () => {
+			if (!posixGroupOwned) {
+				signalProcess(target, "SIGTERM");
+				return { state: "unknown", reason: "unsupported-platform" };
+			}
+			const term = signalProcess(target, "SIGTERM");
+			if (term !== "sent" && term !== "absent") {
+				return { state: "unknown", reason: "signal-failed", diagnostic: term.diagnostic };
+			}
+			const termExit = await waitUntilGroupTerminal(pid, options.termGraceMs ?? DEFAULT_TERM_GRACE_MS);
+			if (termExit === false) return observed(pid);
+
+			const kill = signalProcess(target, "SIGKILL");
+			if (kill !== "sent" && kill !== "absent") {
+				const members = activeProcessGroupMembers(pid);
+				if (!Array.isArray(members) || members.length > 0) {
+					return { state: "unknown", reason: "signal-failed", diagnostic: kill.diagnostic };
+				}
+			}
+			const killExit = await waitUntilGroupTerminal(pid, options.killVerifyMs ?? DEFAULT_KILL_VERIFY_MS);
+			if (killExit !== false) {
+				return { state: "unknown", reason: "verification-failed", diagnostic: killExit.diagnostic };
+			}
+			return observed(pid);
+		})();
+		return termination;
+	};
+
+	return { terminate, finishAfterWriterClose: terminate };
+}

--- a/src/runs/background/process-terminal.ts
+++ b/src/runs/background/process-terminal.ts
@@ -10,6 +10,7 @@ import {
 	type ProcessTerminalV1,
 } from "../../shared/types.ts";
 import { canonicalSessionId, inspectSessionLease } from "../shared/session-lease.ts";
+import { releaseActiveRunIndex } from "./active-run-index.ts";
 
 export interface ProcessTerminalCandidate {
 	version: 1;
@@ -40,9 +41,19 @@ function validProcessInstance(value: unknown, kind?: "runner" | "pi-writer"): va
 	if (typeof value.closeObservedAt !== "number" || !Number.isFinite(value.closeObservedAt)) return false;
 	if (typeof value.exitCode !== "number" && value.exitCode !== null) return false;
 	if (typeof value.signal !== "string" && value.signal !== null) return false;
-	return value.kind === "runner"
-		? value.attempt === undefined
-		: typeof value.attempt === "number" && Number.isInteger(value.attempt) && value.attempt >= 0;
+	if (value.kind === "runner") return value.attempt === undefined;
+	if (typeof value.attempt !== "number" || !Number.isInteger(value.attempt) || value.attempt < 0 || !isRecord(value.processTree)) return false;
+	if (value.processTree.state === "observed") {
+		return value.processTree.mechanism === "posix-process-group"
+			&& typeof value.processTree.processGroupId === "number"
+			&& Number.isInteger(value.processTree.processGroupId)
+			&& value.processTree.processGroupId > 0
+			&& typeof value.processTree.verifiedAt === "number"
+			&& Number.isFinite(value.processTree.verifiedAt);
+	}
+	return value.processTree.state === "unknown"
+		&& ["unsupported-platform", "signal-failed", "verification-failed"].includes(String(value.processTree.reason))
+		&& (value.processTree.diagnostic === undefined || typeof value.processTree.diagnostic === "string");
 }
 
 function validInstance(value: unknown): value is ProcessInstanceExitV1 {
@@ -249,6 +260,8 @@ export function finalizeProcessTerminal(
 				proof = unknownProof(runId, runnerClose.processInstanceId, "canonical-session-release-unverified");
 			} else if (inconsistentWriters || (allWriters.length === 0 && expectedEntries.length === 0)) {
 				proof = unknownProof(runId, runnerClose.processInstanceId, "writer-close-unverified");
+			} else if (allWriters.some((writer) => writer.kind === "pi-writer" && writer.processTree.state !== "observed")) {
+				proof = unknownProof(runId, runnerClose.processInstanceId, "process-tree-unverified");
 			} else {
 				const runner: ProcessInstanceExitV1 = { kind: "runner", ...runnerClose };
 				const canonicalSession = session && sessionProjection(candidate, session);
@@ -271,6 +284,7 @@ export function finalizeProcessTerminal(
 	try {
 		writeAtomicJson(processTerminalPath(asyncDir), proof);
 		durable = true;
+		if (proof.state === "observed") releaseActiveRunIndex(asyncDir);
 		overlayStatus(asyncDir, proof, candidateForOverlay);
 		fs.appendFileSync(path.join(asyncDir, "events.jsonl"), `${JSON.stringify({ type: "subagent.run.process_terminal", lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION, ts: Date.now(), runId, processTerminal: proof })}\n`, "utf-8");
 	} catch {

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
-import { updateActiveRunIndex } from "./active-run-index.ts";
+import { releaseActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { DIRS, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSummary, type SubagentRunMode } from "../../shared/types.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
@@ -261,7 +261,7 @@ function writeFailedRepair(asyncDir: string, status: AsyncStatus, resultPath: st
 	const repair = buildFailedRepair(status, asyncDir, now, reason);
 	writeAtomicJson(resultPath, repair.result);
 	writeAtomicJson(path.join(asyncDir, "status.json"), repair.status);
-	updateActiveRunIndex(asyncDir, repair.status.state);
+	if (repair.status.processTerminal?.state === "observed") releaseActiveRunIndex(asyncDir);
 	appendJsonlBestEffort(path.join(asyncDir, "events.jsonl"), {
 		type: "subagent.run.repaired_stale",
 		ts: now,
@@ -351,7 +351,7 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 			: undefined;
 		if (terminalStatus) {
 			writeAtomicJson(path.join(asyncDir, "status.json"), terminalStatus);
-			updateActiveRunIndex(asyncDir, terminalStatus.state);
+			if (terminalStatus.processTerminal?.state === "observed") releaseActiveRunIndex(asyncDir);
 			return { status: terminalStatus, repaired: true, resultPath, message: "Existing async result file was used to repair stale running status." };
 		}
 		if (effectiveStatus.displayDismissedAt === undefined) return { status: effectiveStatus, repaired: false, resultPath };

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -25,6 +25,8 @@ import {
 	type LaunchResolvedChildExtensionsV1,
 	type RuntimeAcknowledgedChildExtensionsV1,
 	type ModelAttempt,
+	type PiWriterProcessInstanceExitV1,
+	type ProcessTreeTerminalV1,
 	type NestedRouteInfo,
 	type NestedRunSummary,
 	type ResolvedControlConfig,
@@ -85,6 +87,7 @@ import {
 	waitForSubagentStartupRetry,
 } from "../shared/subagent-startup-retry.ts";
 import { markProcessTerminalCandidateLeaseRelease, writeProcessTerminalCandidate, type ProcessTerminalCandidate } from "./process-terminal.ts";
+import { createOwnedProcessTreeController, type OwnedProcessTreeController } from "./owned-process-tree.ts";
 import { createSteeringStatus, recordSteeringRequest, steeringStatus, terminalSteeringNoticeState, updateSteeringTarget } from "./steering.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { PROMPT_REDACTED, detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput, hasEmptyTerminalAssistantResponse, readStatus } from "../../shared/utils.ts";
@@ -232,7 +235,7 @@ interface StepResult {
 	structuredOutputSchemaPath?: string;
 	acceptance?: import("../../shared/types.ts").AcceptanceLedger;
 	watchdog?: import("../../shared/types.ts").ChildWatchdogProgress;
-	writerProcesses?: Array<{ processInstanceId: string; kind: "pi-writer"; attempt: number; closeObservedAt: number; exitCode: number | null; signal: string | null }>;
+	writerProcesses?: PiWriterProcessInstanceExitV1[];
 	writerAttemptCount?: number;
 	runner?: ExternalCliRunnerStatus;
 	externalProcess?: ExternalProcessStatus;
@@ -512,6 +515,7 @@ interface RunPiStreamingResult {
 	processInstanceId: string;
 	processCloseObservedAt?: number;
 	processSignal?: string | null;
+	processTree: ProcessTreeTerminalV1;
 }
 
 function runPiStreaming(
@@ -548,7 +552,9 @@ function runPiStreaming(
 			stdio: ["ignore", "pipe", "pipe"],
 			env: spawnEnv,
 			windowsHide: true,
+			detached: process.platform !== "win32",
 		});
+		let processTreeController: OwnedProcessTreeController | undefined;
 		const stderrTail = createBoundedByteTail();
 		const rawStdoutTail = createBoundedByteTail();
 		const messages: Message[] = [];
@@ -556,6 +562,7 @@ function runPiStreaming(
 		let model: string | undefined;
 		let writerRegistrationError: string | undefined;
 		if (typeof child.pid === "number") {
+			processTreeController = createOwnedProcessTreeController(child.pid);
 			try {
 				onWriterProcess?.({ state: "running", pid: child.pid });
 			} catch (writerError) {
@@ -703,7 +710,6 @@ function runPiStreaming(
 		// a lingering stdio holder after `exit`, or a child that never exits.
 		const FINAL_STOP_GRACE_MS = 1000;
 		const HARD_KILL_MS = 3000;
-		const TIMEOUT_HARD_KILL_MS = 3000;
 		let childExited = false;
 		let forcedTerminationSignal = false;
 		let cleanTerminalAssistantStopReceived = false;
@@ -711,7 +717,6 @@ function runPiStreaming(
 		let finalDrainTimer: NodeJS.Timeout | undefined;
 		let finalHardKillTimer: NodeJS.Timeout | undefined;
 		let watchdogTailTimer: NodeJS.Timeout | undefined;
-		let timeoutHardKillTimer: NodeJS.Timeout | undefined;
 		let turnBudgetTerminationTimer: NodeJS.Timeout | undefined;
 		let turnBudgetHardKillTimer: NodeJS.Timeout | undefined;
 		let protocolHardKillTimer: NodeJS.Timeout | undefined;
@@ -776,22 +781,16 @@ function runPiStreaming(
 			timedOut = true;
 			interrupted = false;
 			error = timeoutMessage ?? "Subagent timed out.";
-			trySignalChild(child, "SIGTERM");
-			timeoutHardKillTimer = setTimeout(() => {
-				if (!settled) trySignalChild(child, "SIGKILL");
-			}, TIMEOUT_HARD_KILL_MS);
-			timeoutHardKillTimer.unref?.();
+			if (processTreeController) void processTreeController.terminate();
+			else trySignalChild(child, "SIGTERM");
 		});
 		registerStop?.(() => {
 			if (settled || timedOut || stopped) return;
 			stopped = true;
 			interrupted = false;
 			error = stopMessage ?? "Subagent stopped by user.";
-			trySignalChild(child, "SIGTERM");
-			timeoutHardKillTimer = setTimeout(() => {
-				if (!settled) trySignalChild(child, "SIGKILL");
-			}, TIMEOUT_HARD_KILL_MS);
-			timeoutHardKillTimer.unref?.();
+			if (processTreeController) void processTreeController.terminate();
+			else trySignalChild(child, "SIGTERM");
 		});
 		registerTurnBudgetAbort?.((message, state) => {
 			if (settled || timedOut || stopped || turnBudgetExceeded) return;
@@ -820,10 +819,6 @@ function runPiStreaming(
 				finalHardKillTimer = undefined;
 			}
 			clearWatchdogTailTimer();
-			if (timeoutHardKillTimer) {
-				clearTimeout(timeoutHardKillTimer);
-				timeoutHardKillTimer = undefined;
-			}
 			if (turnBudgetTerminationTimer) {
 				clearTimeout(turnBudgetTerminationTimer);
 				turnBudgetTerminationTimer = undefined;
@@ -885,9 +880,12 @@ function runPiStreaming(
 			childExited = true;
 			clearDrainTimers();
 		});
-		child.on("close", (exitCode, signal) => {
+		child.on("close", async (exitCode, signal) => {
 			settled = true;
 			const processCloseObservedAt = Date.now();
+			const processTree = processTreeController
+				? await processTreeController.finishAfterWriterClose()
+				: { state: "unknown" as const, reason: "verification-failed" as const, diagnostic: "Writer PID was unavailable." };
 			try {
 				onWriterProcess?.({ state: "none" });
 			} catch {
@@ -939,6 +937,7 @@ function runPiStreaming(
 				processInstanceId,
 				processCloseObservedAt,
 				processSignal: signal,
+				processTree,
 			}));
 		});
 
@@ -961,7 +960,7 @@ function runPiStreaming(
 			const stderr = stderrTail.text();
 			const finalOutput = getFinalOutput(messages) || rawStdoutTail.text().trim();
 			const spawnErrorMessage = spawnError instanceof Error ? spawnError.message : String(spawnError);
-			resolve(omitUndefinedProperties({ stderr, exitCode: 1, messages, usage, toolCount, durationMs: Date.now() - startedAt, model, error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? turnBudgetMessage : error ?? assistantError ?? spawnErrorMessage, protocolError, finalOutput: (timedOut || stopped) && !finalOutput.trim() ? (stopped ? stopMessage ?? "Subagent stopped by user." : timeoutMessage ?? "Subagent timed out.") : finalOutput, outputState: finalOutput.trim() ? "present" : "absent", timedOut, stopped, turnBudget, turnBudgetExceeded, wrapUpRequested: turnBudget?.outcome === "wrap-up-requested" || turnBudget?.outcome === "termination-deferred" || turnBudgetExceeded || undefined, observedMutationAttempt, structuredOutputToolInvoked, structuredOutputMessageStartIndex, watchdog: childWatchdogState, processInstanceId }));
+			resolve(omitUndefinedProperties({ stderr, exitCode: 1, messages, usage, toolCount, durationMs: Date.now() - startedAt, model, error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : turnBudgetExceeded ? turnBudgetMessage : error ?? assistantError ?? spawnErrorMessage, protocolError, finalOutput: (timedOut || stopped) && !finalOutput.trim() ? (stopped ? stopMessage ?? "Subagent stopped by user." : timeoutMessage ?? "Subagent timed out.") : finalOutput, outputState: finalOutput.trim() ? "present" : "absent", timedOut, stopped, turnBudget, turnBudgetExceeded, wrapUpRequested: turnBudget?.outcome === "wrap-up-requested" || turnBudget?.outcome === "termination-deferred" || turnBudgetExceeded || undefined, observedMutationAttempt, structuredOutputToolInvoked, structuredOutputMessageStartIndex, watchdog: childWatchdogState, processInstanceId, processTree: { state: "unknown", reason: "verification-failed", diagnostic: spawnErrorMessage } }));
 		});
 	});
 }
@@ -1292,7 +1291,7 @@ async function runSingleStep(
 	let capabilityAudit: import("../shared/capability-ceiling.ts").SubagentCapabilityAudit | undefined;
 	let launchResolvedExtensions = step.launchResolvedExtensions;
 	const modelAttempts: ModelAttempt[] = [];
-	const writerProcesses: Array<{ processInstanceId: string; kind: "pi-writer"; attempt: number; closeObservedAt: number; exitCode: number | null; signal: string | null }> = [];
+	const writerProcesses: PiWriterProcessInstanceExitV1[] = [];
 	let writerAttemptCount = 0;
 	const attemptNotes: string[] = [];
 	const eventsPath = path.join(path.dirname(ctx.outputFile), "events.jsonl");
@@ -1433,6 +1432,7 @@ async function runSingleStep(
 				closeObservedAt: run.processCloseObservedAt,
 				exitCode: run.exitCode,
 				signal: run.processSignal ?? null,
+				processTree: run.processTree,
 			});
 		}
 		if (run.turnBudget) turnBudget = run.turnBudget;
@@ -2268,10 +2268,10 @@ async function runSubagent(
 		refreshWorkflowGraph();
 		writeAtomicJson(statusPath, statusPayload);
 		const activeState = isActiveAsyncState(statusPayload.state);
-		if (activeState !== lastIndexedActiveState) {
+		if (activeState && activeState !== lastIndexedActiveState) {
 			updateActiveRunIndex(asyncDir, statusPayload.state);
-			lastIndexedActiveState = activeState;
 		}
+		lastIndexedActiveState = activeState;
 		emitNestedSelfEvent(statusPayload.state === "running" || statusPayload.state === "queued" ? "subagent.nested.updated" : "subagent.nested.completed");
 	};
 	const statusWriteCoalescer = createFileCoalescer(writeStatusPayloadNow, 100);
@@ -3043,7 +3043,6 @@ async function runSubagent(
 		if (stopped || timedOut || interrupted || statusPayload.state !== "running") return;
 		stopped = true;
 		const now = Date.now();
-		statusPayload.state = "stopped";
 		statusPayload.stopped = true;
 		statusPayload.error = stopMessage;
 		currentActivityState = undefined;
@@ -3076,7 +3075,6 @@ async function runSubagent(
 		timedOut = true;
 		const now = Date.now();
 		const message = timeoutMessage ?? "Subagent timed out.";
-		statusPayload.state = "failed";
 		statusPayload.timedOut = true;
 		statusPayload.error = message;
 		currentActivityState = undefined;
@@ -4446,6 +4444,9 @@ async function runSubagent(
 		clearTimeout(timeoutTimer);
 		timeoutTimer = undefined;
 	}
+	if (!timedOut && !stopped && !interrupted && config.timeoutMs !== undefined && results.some((result) => result.timedOut === true && result.error === timeoutMessage)) {
+		timedOut = true;
+	}
 	const signalTerminated = !stopped && !timedOut && !turnBudgetExceeded && !interrupted && results.some((result) => result.exitCode !== 0 && isUnexplainedProcessSignal(omitUndefinedProperties({
 		processSignal: result.processSignal,
 		interrupted: result.interrupted,
@@ -4638,7 +4639,7 @@ async function runSubagent(
 		shareError,
 	}));
 	if (config.runnerProcessInstanceId) {
-		const writers: Record<string, Array<{ processInstanceId: string; kind: "pi-writer"; attempt: number; closeObservedAt: number; exitCode: number | null; signal: string | null }>> = {};
+		const writers: Record<string, PiWriterProcessInstanceExitV1[]> = {};
 		const expectedWriters: Record<string, number> = {};
 		for (const [index, result] of results.entries()) {
 			writers[String(index)] = result.writerProcesses ?? [];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -344,6 +344,7 @@ export type ProcessTerminalReason =
 	| "runner-candidate-missing"
 	| "runner-instance-mismatch"
 	| "writer-close-unverified"
+	| "process-tree-unverified"
 	| "canonical-session-unavailable"
 	| "canonical-session-lease-active"
 	| "canonical-session-release-unverified"
@@ -358,6 +359,19 @@ export interface RunnerProcessInstanceExitV1 {
 	signal: string | null;
 }
 
+export type ProcessTreeTerminalV1 =
+	| {
+		state: "observed";
+		mechanism: "posix-process-group";
+		processGroupId: number;
+		verifiedAt: number;
+	}
+	| {
+		state: "unknown";
+		reason: "unsupported-platform" | "signal-failed" | "verification-failed";
+		diagnostic?: string;
+	};
+
 export interface PiWriterProcessInstanceExitV1 {
 	processInstanceId: string;
 	kind: "pi-writer";
@@ -365,6 +379,7 @@ export interface PiWriterProcessInstanceExitV1 {
 	closeObservedAt: number;
 	exitCode: number | null;
 	signal: string | null;
+	processTree: ProcessTreeTerminalV1;
 }
 
 export type ProcessInstanceExitV1 = RunnerProcessInstanceExitV1 | PiWriterProcessInstanceExitV1;

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -597,7 +597,7 @@ describe("async status helpers", () => {
 		}
 	});
 
-	it("prunes terminal active markers while preserving history listing", () => {
+	it("keeps terminal active markers until observed process-terminal proof releases them", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-index-prune-"));
 		try {
 			const asyncDir = createAsyncDir(root, "finished", {
@@ -606,13 +606,26 @@ describe("async status helpers", () => {
 				state: "complete",
 				startedAt: 100,
 				lastUpdate: 200,
+				displayDismissedAt: 250,
+				processTerminal: { version: 1, state: "unknown", runId: "finished", runnerProcessInstanceId: "runner", reason: "process-tree-unverified" },
 				steps: [{ agent: "worker", status: "complete" }],
 			});
 			updateActiveRunIndex(asyncDir, "running");
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "finished");
 
 			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false }), []);
-			assert.equal(fs.existsSync(path.join(root, ACTIVE_RUN_INDEX_DIR, "finished")), false);
-			assert.deepEqual(listAsyncRuns(root, { states: ["complete"], reconcile: false }).map((run) => run.id), ["finished"]);
+			assert.equal(fs.existsSync(markerPath), true);
+
+			fs.writeFileSync(path.join(asyncDir, "process-terminal.json"), JSON.stringify({
+				version: 1,
+				state: "observed",
+				runId: "finished",
+				runnerProcessInstanceId: "runner",
+				observedAt: 300,
+				instances: [{ kind: "runner", processInstanceId: "runner", closeObservedAt: 300, exitCode: 0, signal: null }],
+			}), "utf-8");
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false }), []);
+			assert.equal(fs.existsSync(markerPath), false);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/owned-process-tree.test.ts
+++ b/test/unit/owned-process-tree.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import { createOwnedProcessTreeController } from "../../src/runs/background/owned-process-tree.ts";
+
+function processIsActive(pid: number): boolean {
+	const result = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf-8" });
+	return result.status === 0 && Boolean(result.stdout.trim()) && !result.stdout.trim().startsWith("Z");
+}
+
+test("owned process tree fails closed when process-group ownership is unsupported", { skip: process.platform !== "win32" }, async () => {
+	const proof = await createOwnedProcessTreeController(999_999).terminate();
+	assert.deepEqual(proof, { state: "unknown", reason: "unsupported-platform" });
+});
+
+test("owned process tree kills descendants and verifies a TERM-resistant POSIX group", { skip: process.platform === "win32" }, async () => {
+	const writer = spawn(process.execPath, ["-e", `
+		const { spawn } = require("node:child_process");
+		const child = spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"], { stdio: "ignore" });
+		process.on("SIGTERM", () => {});
+		process.stdout.write(String(child.pid) + "\\n");
+		setInterval(() => {}, 1000);
+	`], { detached: true, stdio: ["ignore", "pipe", "ignore"] });
+	assert.ok(writer.pid);
+	const grandchildPid = await new Promise<number>((resolve, reject) => {
+		writer.once("error", reject);
+		writer.stdout!.once("data", (chunk) => resolve(Number(String(chunk).trim())));
+	});
+	const proof = await createOwnedProcessTreeController(writer.pid, { termGraceMs: 50, killVerifyMs: 1000 }).terminate();
+	assert.equal(proof.state, "observed", JSON.stringify(proof));
+	assert.equal(processIsActive(writer.pid), false);
+	assert.equal(processIsActive(grandchildPid), false);
+
+	const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-process-tree-ps-"));
+	const realPs = spawnSync("sh", ["-c", "command -v ps"], { encoding: "utf-8" }).stdout.trim();
+	const marker = path.join(fixtureDir, "failed-once");
+	const originalPath = process.env.PATH;
+	try {
+		fs.writeFileSync(path.join(fixtureDir, "ps"), `#!/bin/sh\nif [ ! -e "$PI_TEST_PS_MARKER" ]; then\n  : > "$PI_TEST_PS_MARKER"\n  exit 1\nfi\nexec "$PI_TEST_REAL_PS" "$@"\n`);
+		fs.chmodSync(path.join(fixtureDir, "ps"), 0o755);
+		process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+		process.env.PI_TEST_PS_MARKER = marker;
+		process.env.PI_TEST_REAL_PS = realPs;
+		const enumerationFailureWriter = spawn(process.execPath, ["-e", `
+			process.on("SIGTERM", () => {});
+			process.stdout.write("ready\\n");
+			setInterval(() => {}, 1000);
+		`], { detached: true, stdio: ["ignore", "pipe", "ignore"] });
+		assert.ok(enumerationFailureWriter.pid);
+		await new Promise<void>((resolve, reject) => {
+			enumerationFailureWriter.once("error", reject);
+			enumerationFailureWriter.stdout!.once("data", () => resolve());
+		});
+		const termGraceMs = 50;
+		const startedAt = Date.now();
+		const failedProof = await createOwnedProcessTreeController(enumerationFailureWriter.pid, { termGraceMs, killVerifyMs: 1000 }).terminate();
+		assert.ok(Date.now() - startedAt >= termGraceMs, "enumeration failure still waits through the TERM grace before SIGKILL");
+		assert.equal(failedProof.state, "observed", JSON.stringify(failedProof));
+		assert.equal(processIsActive(enumerationFailureWriter.pid), false);
+	} finally {
+		process.env.PATH = originalPath;
+		delete process.env.PI_TEST_PS_MARKER;
+		delete process.env.PI_TEST_REAL_PS;
+		fs.rmSync(fixtureDir, { recursive: true, force: true });
+	}
+});

--- a/test/unit/process-terminal.test.ts
+++ b/test/unit/process-terminal.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import test from "node:test";
+import { ACTIVE_RUN_INDEX_DIR, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import {
 	finalizeProcessTerminal,
 	processTerminalPath,
@@ -27,6 +28,7 @@ test("process-terminal proof requires the matching runner instance and writer cl
 					closeObservedAt: 10,
 					exitCode: 0,
 					signal: null,
+					processTree: { state: "observed", mechanism: "posix-process-group", processGroupId: 123, verifiedAt: 11 },
 				}],
 			},
 		});
@@ -82,6 +84,57 @@ test("process-terminal rejects missing writer close evidence", () => {
 	}
 });
 
+test("process-terminal fails closed when process-tree verification is unknown", () => {
+	const asyncDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-process-terminal-"));
+	try {
+		writeProcessTerminalCandidate(asyncDir, {
+			version: 1,
+			runId: "run-tree-unknown",
+			runnerProcessInstanceId: "runner-tree-unknown",
+			expectedWriters: { "0": 1 },
+			writers: {
+				"0": [{
+					processInstanceId: "writer-tree-unknown",
+					kind: "pi-writer",
+					attempt: 0,
+					closeObservedAt: 10,
+					exitCode: 1,
+					signal: "SIGKILL",
+					processTree: { state: "unknown", reason: "verification-failed", diagnostic: "still live" },
+				}],
+			},
+		});
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ runId: "run-tree-unknown", state: "failed", lifecycleArtifactVersion: 3, steps: [{ agent: "worker", status: "failed" }] }));
+		fs.writeFileSync(path.join(asyncDir, "events.jsonl"), "");
+		updateActiveRunIndex(asyncDir, "running");
+		const markerPath = path.join(path.dirname(asyncDir), ACTIVE_RUN_INDEX_DIR, path.basename(asyncDir));
+		const proof = finalizeProcessTerminal(asyncDir, "run-tree-unknown", {
+			processInstanceId: "runner-tree-unknown",
+			closeObservedAt: 20,
+			exitCode: 1,
+			signal: null,
+		});
+		assert.equal(proof.state, "unknown");
+		assert.equal(proof.reason, "process-tree-unverified");
+		assert.equal(fs.existsSync(markerPath), true);
+		fs.rmSync(processTerminalPath(asyncDir), { force: true });
+		const candidatePath = path.join(asyncDir, "process-terminal-candidate.json");
+		const candidate = JSON.parse(fs.readFileSync(candidatePath, "utf-8"));
+		candidate.writers["0"][0].processTree = { state: "observed", mechanism: "posix-process-group", processGroupId: 126, verifiedAt: 21 };
+		fs.writeFileSync(candidatePath, JSON.stringify(candidate));
+		const observed = finalizeProcessTerminal(asyncDir, "run-tree-unknown", {
+			processInstanceId: "runner-tree-unknown",
+			closeObservedAt: 30,
+			exitCode: 1,
+			signal: null,
+		});
+		assert.equal(observed.state, "observed");
+		assert.equal(fs.existsSync(markerPath), false);
+	} finally {
+		fs.rmSync(asyncDir, { recursive: true, force: true });
+	}
+});
+
 test("malformed process-terminal sidecars project unknown instead of throwing", () => {
 	const asyncDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-process-terminal-"));
 	try {
@@ -112,7 +165,7 @@ test("process-terminal preserves stopped non-resumability and requires lease rel
 			runnerProcessInstanceId: "stopped-runner",
 			expectedWriters: { "0": 1 },
 			writers: {
-				"0": [{ processInstanceId: "stopped-writer", kind: "pi-writer", attempt: 0, closeObservedAt: 10, exitCode: 0, signal: null }],
+				"0": [{ processInstanceId: "stopped-writer", kind: "pi-writer", attempt: 0, closeObservedAt: 10, exitCode: 0, signal: null, processTree: { state: "observed", mechanism: "posix-process-group", processGroupId: 124, verifiedAt: 11 } }],
 			},
 			revivalLeaseToken: "lease-token",
 			revivalLeaseReleaseAcknowledged: false,
@@ -161,7 +214,7 @@ test("process-terminal rejects cross-run observed sidecars and inconsistent expe
 			runnerProcessInstanceId: "runner-1",
 			expectedWriters: { "0": 0 },
 			writers: {
-				"0": [{ processInstanceId: "unexpected-writer", kind: "pi-writer", attempt: 0, closeObservedAt: 10, exitCode: 0, signal: null }],
+				"0": [{ processInstanceId: "unexpected-writer", kind: "pi-writer", attempt: 0, closeObservedAt: 10, exitCode: 0, signal: null, processTree: { state: "observed", mechanism: "posix-process-group", processGroupId: 125, verifiedAt: 11 } }],
 			},
 		});
 		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ runId: "actual-run", state: "complete", lifecycleArtifactVersion: 3, steps: [{ agent: "worker", status: "complete" }] }));


### PR DESCRIPTION
Fixes #1030.

This adds a first process-tree cleanup slice for async writer stop and timeout handling. POSIX writers now run in an owned process group, stop/timeout cleanup signals the group, and process-terminal proof stays unknown unless the owned group is verified as exited. Unsupported or unverifiable cleanup fails closed instead of publishing observed proof.

Thanks to @asjer for the report.

Validation:

- `node --experimental-strip-types --test test/unit/owned-process-tree.test.ts test/unit/process-terminal.test.ts`
- `npm run typecheck`
- `git diff --check`
