### PR TITLE
feat: cap logical child fan-out per run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add a durable per-run child fan-out budget with a default cap of 64 across static, dynamic, workflow, and nested child admissions. Thanks to @asjer for #1031.
 - Add a live Prompt Audit drawer to Fleet for current-session foreground children. Prompt text stays hidden until local reveal, is kept outside serializable Fleet state, and is redacted from foreground input, transcript, metadata, result, progress, and run-history artifacts (#1021).
 - Add a global `timeoutMs` config option that sets the default run deadline for single, parallel, and chain launches (foreground, plus plain single-agent async) when neither the call nor the selected agent provides a timeout. It reaches parallel (`tasks: [...]`) and chain launches, which never adopt an agent's frontmatter `timeoutMs` (that default applies to single-agent launches only), so a long fan-out no longer falls back to the built-in 30-minute default and gets killed mid-run. Explicit call `timeoutMs`/`maxRuntimeMs` and agent frontmatter defaults still win; composite async runs stay unbounded at the top level by design. Thanks to @shaharmor for #1018.
 - Add a `PI_SUBAGENT_TASK_DELIVERY` environment setting (`auto` | `file`, default `auto`) controlling how the task text reaches child Pi processes. `file` writes the task to a temp `task.md` referenced as `@<path>` instead of embedding it in argv, for hosts where endpoint protection (EDR) pre-execution command-line scanning denies children whose argv embeds a long natural-language task. Thanks to @yanqianglu for #1028.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ In the TUI, a persistent FleetView below the editor keeps active work visible. `
 
 Details, keybindings, and the machine-readable run artifacts are in [Observability](https://github.com/nicobailon/pi-subagents/blob/main/docs/observability.md).
 
+For bounded orchestration, `maxSubagentSpawnsPerRun` limits cumulative logical children in one run tree. It defaults to 64 and stays separate from active concurrency and the session-wide cumulative spawn budget. See [Configuration](https://github.com/nicobailon/pi-subagents/blob/main/docs/configuration.md#maxsubagentspawnsperrun).
+
 ## If something feels off
 
 ```text

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,16 @@ Caps simultaneously running children inside existing durable legacy multi-child 
 
 Optionally caps the total number of child subagent launches during one parent session, including completed and failed children, parallel task counts, static chain steps, and bounded dynamic fanout children. Sessions are unlimited by default. Set this value to `0` to disable a configured cap. `PI_SUBAGENT_MAX_SPAWNS_PER_SESSION` overrides the config for a process and follows the same positive-cap/zero-unlimited semantics.
 
+## `maxSubagentSpawnsPerRun`
+
+```json
+{ "maxSubagentSpawnsPerRun": 64 }
+```
+
+Caps cumulative logical child admissions in one top-level run tree. The default is `64`. `PI_SUBAGENT_MAX_SPAWNS_PER_RUN` overrides the config when it is a positive integer. Invalid, zero, or missing values fall back to the configured positive value or `64`.
+
+The budget counts single launches, expanded `tasks`/`count`, static chain steps and parallel groups, actual dynamic `expand` items, appended chain steps, workflow children, and nested child calls. Static and materialized dynamic groups are admitted atomically. Startup retries, model fallback, and retained-child resume reuse the original logical child claim. Claims are never released or refunded. This cap is independent from the session-wide cumulative spawn budget and `globalConcurrencyLimit`.
+
 `subagent({ action: "status" })`, fleet status, and `subagent({ action: "doctor" })` expose used, effective limit, remaining capacity, grants, and the remaining grant allowance. Static chains and parallel calls fail before creating run artifacts or starting partial work when their declared capacity cannot fit. Later retries or unbounded dynamic work are not guaranteed by that preflight.
 
 A user may explicitly call `subagent({ action: "grant-spawn-budget", additional: 10 })` from the root interactive parent after all children settle and confirm the native prompt. Grants are additive: they never erase cumulative usage, are rejected for unlimited sessions and child/headless callers, and total granted capacity cannot exceed the original configured cap. Compaction remains part of the same logical parent session and does not reset usage or grants; starting a new parent session does.

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { discoverAgentsAll, type AgentSource } from "../agents/agents.ts";
 import { isAsyncAvailable } from "../runs/background/async-execution.ts";
 import { formatSpawnBudgetSummary, getSpawnBudgetSnapshot } from "../runs/shared/spawn-budget.ts";
+import { decodeRunFanoutBudgetDescriptor, formatRunFanoutBudget, getRunFanoutBudgetSnapshot, RUN_FANOUT_BUDGET_ENV } from "../runs/shared/run-fanout-budget.ts";
 import { diagnoseIntercomBridge, type IntercomBridgeDiagnostic } from "../intercom/intercom-bridge.ts";
 import { discoverAvailableSkills, type SkillSource } from "../agents/skills.ts";
 import {
@@ -11,6 +12,7 @@ import {
 	TEMP_ROOT_DIR,
 	type ExtensionConfig,
 	type SubagentState,
+	resolveMaxSubagentSpawnsPerRun,
 } from "../shared/types.ts";
 
 interface DoctorPaths {
@@ -175,6 +177,20 @@ function formatSpawnBudgetSection(input: DoctorReportInput): string[] {
 	];
 }
 
+function formatRunFanoutSection(input: DoctorReportInput): string[] {
+	try {
+		const inherited = decodeRunFanoutBudgetDescriptor(process.env[RUN_FANOUT_BUDGET_ENV]);
+		if (inherited) {
+			return [`- usage: ${formatRunFanoutBudget(getRunFanoutBudgetSnapshot(inherited)).replace(/^Run fan-out: /, "")}`, `- root run: ${inherited.rootRunId}`, "- reset boundary: cumulative claims are never released; a new top-level run creates a new budget"];
+		}
+	} catch (error) {
+		return [`- inherited budget: invalid — ${errorText(error)}`];
+	}
+	const configured = resolveMaxSubagentSpawnsPerRun(input.config.maxSubagentSpawnsPerRun);
+	const source = process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN ? "environment" : input.config.maxSubagentSpawnsPerRun ? "config" : "default";
+	return [`- configured limit: ${configured} (${source})`, "- usage: available after a run starts", "- reset boundary: cumulative claims are never released; a new top-level run creates a new budget"];
+}
+
 function formatPermissionSystemSection(): string[] {
 	const lines: string[] = [];
 	const parentSession = process.env["PI_SUBAGENT_PARENT_SESSION"] ?? "";
@@ -214,6 +230,9 @@ export function buildDoctorReport(input: DoctorReportInput): string {
 		"",
 		"Spawn budget",
 		...formatSpawnBudgetSection(input),
+		"",
+		"Run fan-out budget",
+		...formatRunFanoutSection(input),
 		"",
 		"Permission system",
 		...formatPermissionSystemSection(),

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -12,6 +12,7 @@ import {
 	TEMP_ROOT_DIR,
 	type ExtensionConfig,
 	type SubagentState,
+	normalizeMaxSubagentSpawnsPerRun,
 	resolveMaxSubagentSpawnsPerRun,
 } from "../shared/types.ts";
 
@@ -187,7 +188,9 @@ function formatRunFanoutSection(input: DoctorReportInput): string[] {
 		return [`- inherited budget: invalid — ${errorText(error)}`];
 	}
 	const configured = resolveMaxSubagentSpawnsPerRun(input.config.maxSubagentSpawnsPerRun);
-	const source = process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN ? "environment" : input.config.maxSubagentSpawnsPerRun ? "config" : "default";
+	const source = normalizeMaxSubagentSpawnsPerRun(process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN) !== undefined
+		? "environment"
+		: normalizeMaxSubagentSpawnsPerRun(input.config.maxSubagentSpawnsPerRun) !== undefined ? "config" : "default";
 	return [`- configured limit: ${configured} (${source})`, "- usage: available after a run starts", "- reset boundary: cumulative claims are never released; a new top-level run creates a new budget"];
 }
 

--- a/src/extension/public-execution.ts
+++ b/src/extension/public-execution.ts
@@ -11,6 +11,8 @@ export interface PublicSubagentExecutionParams {
 	workflowScript?: unknown;
 	resume?: unknown;
 	clarify?: unknown;
+	runFanoutBudget?: unknown;
+	runFanoutAdmitted?: unknown;
 }
 
 export type PublicSubagentExecutionMode = "workflow" | "management";
@@ -24,6 +26,9 @@ export type PublicSubagentExecutionNormalization<T> =
  * Internal runs.run children and structured owned delegation bypass this boundary.
  */
 export function normalizePublicSubagentExecution<T extends PublicSubagentExecutionParams>(params: T): PublicSubagentExecutionNormalization<T> {
+	if (params.runFanoutBudget !== undefined || params.runFanoutAdmitted !== undefined) {
+		return { ok: false, error: "Public execution does not accept internal run fan-out fields.", mode: params.workflowScript !== undefined ? "workflow" : "management" };
+	}
 	const action = params.action;
 	if (action !== undefined && (typeof action !== "string" || !action.trim())) {
 		return { ok: false, error: "action must be a non-empty management/control action, or omit action and use workflowScript.", mode: "management" };

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -30,7 +30,7 @@ import { buildWorkflowGraphSnapshot } from "../shared/workflow-graph.ts";
 import { ChainOutputValidationError, validateChainOutputBindings } from "../shared/chain-outputs.ts";
 import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { resolveEffectiveAcceptance, validateAcceptanceInput, validateExecutionAcceptance } from "../shared/acceptance.ts";
-import { writeRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
+import { createRunFanoutBudget, writeRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 import {
 	type AcceptanceInput,
 	type AgentContract,
@@ -173,7 +173,7 @@ interface AsyncChainParams {
 	/** Global cap on simultaneously-running subagent tasks within the async run. */
 	globalConcurrencyLimit?: number;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
-	runFanoutBudget: RunFanoutBudgetDescriptor;
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
 }
@@ -223,7 +223,7 @@ interface AsyncSingleParams {
 	configToolBudget?: ResolvedToolBudget;
 	allowZeroToolBudget?: boolean;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
-	runFanoutBudget: RunFanoutBudgetDescriptor;
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
 }
@@ -971,9 +971,11 @@ export function executeAsyncChain(
 	const asyncDir = inheritedNestedRoute
 		? path.join(TEMP_ROOT_DIR, "nested-subagent-runs", inheritedNestedRoute.rootRunId, id)
 		: path.join(DIRS.async, id);
+	let runFanoutBudget: RunFanoutBudgetDescriptor;
 	try {
+		runFanoutBudget = params.runFanoutBudget ?? createRunFanoutBudget(id, 64);
 		fs.mkdirSync(asyncDir, { recursive: true });
-		writeRunFanoutBudgetDescriptor(asyncDir, params.runFanoutBudget);
+		writeRunFanoutBudgetDescriptor(asyncDir, runFanoutBudget);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		return {
@@ -1069,7 +1071,7 @@ export function executeAsyncChain(
 				timeoutMs: params.timeoutMs,
 				deadlineAt,
 				globalConcurrencyLimit: params.globalConcurrencyLimit,
-				runFanoutBudget: params.runFanoutBudget,
+				runFanoutBudget,
 				workflowGraph,
 				...(params.parentWorkflowRunId ? { parentWorkflowRunId: params.parentWorkflowRunId } : {}),
 				...(params.workflowKey ? { workflowKey: params.workflowKey } : {}),
@@ -1286,9 +1288,11 @@ export function executeAsyncSingle(
 	const asyncDir = inheritedNestedRoute
 		? path.join(TEMP_ROOT_DIR, "nested-subagent-runs", inheritedNestedRoute.rootRunId, id)
 		: path.join(DIRS.async, id);
+	let runFanoutBudget: RunFanoutBudgetDescriptor;
 	try {
+		runFanoutBudget = params.runFanoutBudget ?? createRunFanoutBudget(id, 64);
 		fs.mkdirSync(asyncDir, { recursive: true });
-		writeRunFanoutBudgetDescriptor(asyncDir, params.runFanoutBudget);
+		writeRunFanoutBudgetDescriptor(asyncDir, runFanoutBudget);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		return {
@@ -1384,7 +1388,7 @@ export function executeAsyncSingle(
 	const recoveryDescriptor: SteeringRecoveryDescriptor = {
 		version: 1,
 		launchContractDigest,
-		runFanoutBudget: params.runFanoutBudget,
+		runFanoutBudget,
 		sourceRunId: id,
 		...(params.agentContract ? { agentContract: params.agentContract } : {}),
 		agent,
@@ -1503,7 +1507,7 @@ export function executeAsyncSingle(
 				resultMode: "single",
 				launchContractDigest,
 				launchResolvedExtensions,
-				runFanoutBudget: params.runFanoutBudget,
+				runFanoutBudget,
 				...(params.parentWorkflowRunId ? { parentWorkflowRunId: params.parentWorkflowRunId } : {}),
 				...(params.workflowKey ? { workflowKey: params.workflowKey } : {}),
 				...(params.revivalLease ? { revivalLease: params.revivalLease } : {}),

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -30,6 +30,7 @@ import { buildWorkflowGraphSnapshot } from "../shared/workflow-graph.ts";
 import { ChainOutputValidationError, validateChainOutputBindings } from "../shared/chain-outputs.ts";
 import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { resolveEffectiveAcceptance, validateAcceptanceInput, validateExecutionAcceptance } from "../shared/acceptance.ts";
+import { writeRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 import {
 	type AcceptanceInput,
 	type AgentContract,
@@ -41,6 +42,7 @@ import {
 	type ResolvedControlConfig,
 	type ResolvedTurnBudget,
 	type ResolvedToolBudget,
+	type RunFanoutBudgetDescriptor,
 	type ToolBudgetConfig,
 	type SubagentRunMode,
 	type SteeringRecoveryDescriptor,
@@ -171,6 +173,7 @@ interface AsyncChainParams {
 	/** Global cap on simultaneously-running subagent tasks within the async run. */
 	globalConcurrencyLimit?: number;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	runFanoutBudget: RunFanoutBudgetDescriptor;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
 }
@@ -220,6 +223,7 @@ interface AsyncSingleParams {
 	configToolBudget?: ResolvedToolBudget;
 	allowZeroToolBudget?: boolean;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	runFanoutBudget: RunFanoutBudgetDescriptor;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
 }
@@ -648,7 +652,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			...(s.model !== undefined ? { model: s.model } : {}),
 		};
 	};
-	const buildSeqStep = (s: SequentialStep, sessionFile?: string, behaviorCwd?: string, progressPrecreated = false, resolvedBehavior?: ResolvedStepBehavior, flatIndex?: number, parallelOutputNamespace?: { stepIndex: number; taskIndex?: number }) => {
+	const buildSeqStep = (s: SequentialStep, sessionFile?: string, behaviorCwd?: string, progressPrecreated = false, resolvedBehavior?: ResolvedStepBehavior, flatIndex?: number, parallelOutputNamespace?: { stepIndex: number; taskIndex?: number }, runFanoutPath?: string) => {
 		const a = agents.find((x) => x.name === s.agent)!;
 		const externalRunner = a.runner?.type === "external-cli";
 		if (externalRunner) {
@@ -748,6 +752,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			parentSessionId: ctx.parentSessionId ?? ctx.currentSessionId,
 			permissionRules,
 			...(params.capabilityCeiling ? { capabilityCeiling: params.capabilityCeiling } : {}),
+			...(runFanoutPath ? { runFanoutPath } : {}),
 			agent: s.agent,
 			task,
 			...(a.runner ? { runner: a.runner } : {}),
@@ -839,7 +844,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 							}
 						}
 						const staticStep = nextFlatStep();
-						return buildSeqStep({ ...t, agentContract: t.agentContract ?? s.agentContract, gateOn: t.gateOn ?? s.gateOn }, staticStep.sessionFile, behaviorCwd, progressPrecreated, parallelBehaviors[taskIndex], staticStep.index, { stepIndex, taskIndex });
+						return buildSeqStep({ ...t, agentContract: t.agentContract ?? s.agentContract, gateOn: t.gateOn ?? s.gateOn }, staticStep.sessionFile, behaviorCwd, progressPrecreated, parallelBehaviors[taskIndex], staticStep.index, { stepIndex, taskIndex }, resultMode === "parallel" ? `tasks[${taskIndex}]` : `chain[${stepIndex}].parallel[${taskIndex}]`);
 					}),
 					concurrency: s.concurrency,
 					failFast: s.failFast,
@@ -884,7 +889,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 				};
 			}
 			const staticStep = nextFlatStep();
-			return buildSeqStep(s as SequentialStep, staticStep.sessionFile, undefined, false, undefined, staticStep.index);
+			return buildSeqStep(s as SequentialStep, staticStep.sessionFile, undefined, false, undefined, staticStep.index, undefined, `chain[${stepIndex}]`);
 		});
 		const steps = params.attachRoot
 			? [{
@@ -968,6 +973,7 @@ export function executeAsyncChain(
 		: path.join(DIRS.async, id);
 	try {
 		fs.mkdirSync(asyncDir, { recursive: true });
+		writeRunFanoutBudgetDescriptor(asyncDir, params.runFanoutBudget);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		return {
@@ -1063,6 +1069,7 @@ export function executeAsyncChain(
 				timeoutMs: params.timeoutMs,
 				deadlineAt,
 				globalConcurrencyLimit: params.globalConcurrencyLimit,
+				runFanoutBudget: params.runFanoutBudget,
 				workflowGraph,
 				...(params.parentWorkflowRunId ? { parentWorkflowRunId: params.parentWorkflowRunId } : {}),
 				...(params.workflowKey ? { workflowKey: params.workflowKey } : {}),
@@ -1281,6 +1288,7 @@ export function executeAsyncSingle(
 		: path.join(DIRS.async, id);
 	try {
 		fs.mkdirSync(asyncDir, { recursive: true });
+		writeRunFanoutBudgetDescriptor(asyncDir, params.runFanoutBudget);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		return {
@@ -1376,6 +1384,7 @@ export function executeAsyncSingle(
 	const recoveryDescriptor: SteeringRecoveryDescriptor = {
 		version: 1,
 		launchContractDigest,
+		runFanoutBudget: params.runFanoutBudget,
 		sourceRunId: id,
 		...(params.agentContract ? { agentContract: params.agentContract } : {}),
 		agent,
@@ -1494,6 +1503,7 @@ export function executeAsyncSingle(
 				resultMode: "single",
 				launchContractDigest,
 				launchResolvedExtensions,
+				runFanoutBudget: params.runFanoutBudget,
 				...(params.parentWorkflowRunId ? { parentWorkflowRunId: params.parentWorkflowRunId } : {}),
 				...(params.workflowKey ? { workflowKey: params.workflowKey } : {}),
 				...(params.revivalLease ? { revivalLease: params.revivalLease } : {}),

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -5,6 +5,7 @@ import type { AgentConfig } from "../../agents/agents.ts";
 import { validateAcceptanceInput } from "../shared/acceptance.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import { intersectSubagentCapabilityCeilings, parseSubagentCapabilityCeiling, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
+import { validateRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 import { resolveTurnBudgetConfig } from "../shared/turn-budget.ts";
 import { reconcileAsyncRun } from "./stale-run-reconciler.ts";
 
@@ -307,7 +308,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 		"subagentOnlyExtensions", "mcpDirectTools", "systemPrompt", "systemPromptMode", "inheritProjectContext", "inheritSkills", "skills",
 		"skillPath", "agentFilePath", "completionGuard", "memory", "outputPath", "outputMode", "structuredOutputSchema", "acceptance", "sessionDir", "artifactConfig",
 		"artifactsDir", "maxOutput", "controlConfig", "absoluteDeadlineAt", "initialTurnBudget", "initialToolBudget", "maxSubagentDepth", "share", "capabilityCeiling",
-		"launchResolvedExtensions",
+		"launchResolvedExtensions", "runFanoutBudget",
 	]);
 	for (const field of Object.keys(parsed)) {
 		if (!allowedFields.has(field)) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': unknown field '${field}'.`);
@@ -317,6 +318,11 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 		if (typeof parsed[field] !== "string" || !(parsed[field] as string).trim()) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${field} must be a non-empty string.`);
 	}
 	if (parsed.version !== 1) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': version must be 1.`);
+	try {
+		parsed.runFanoutBudget = validateRunFanoutBudgetDescriptor(parsed.runFanoutBudget);
+	} catch (error) {
+		throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${error instanceof Error ? error.message : String(error)}`);
+	}
 	if (parsed.capabilityCeiling !== undefined) parsed.capabilityCeiling = parseSubagentCapabilityCeiling(parsed.capabilityCeiling, `async recovery descriptor '${descriptorPath}' capabilityCeiling`);
 	if (parsed.agentContract !== undefined) {
 		if (!parsed.agentContract || typeof parsed.agentContract !== "object" || Array.isArray(parsed.agentContract)) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': agentContract must be an object.`);

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -7,7 +7,7 @@ import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from 
 import { pruneStatusCacheForAsyncRoot, readStatus } from "../../shared/utils.ts";
 import { attachRootChildrenToSteps, buildNestedRouteIndex, findNestedRouteForRootId, type NestedRoute, projectNestedEvents } from "../shared/nested-events.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
-import { formatRunFanoutBudget } from "../shared/run-fanout-budget.ts";
+import { formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 import { flatToLogicalStepIndex, normalizeParallelGroups } from "./parallel-groups.ts";
 import { contextModeLabel, summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
@@ -224,6 +224,8 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 	const { activityState, lastActivityAt } = deriveAsyncActivityState(asyncDir, status);
 	const processTerminal = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId })
 		?? sanitizeProcessTerminal(status.processTerminal, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId }, path.join(asyncDir, "status.json"));
+	const runFanoutBudgetDescriptor = readRunFanoutBudgetDescriptor(asyncDir);
+	const runFanoutBudget = runFanoutBudgetDescriptor ? getRunFanoutBudgetSnapshot(runFanoutBudgetDescriptor) : status.runFanoutBudget;
 	const steps = status.steps ?? [];
 	const chainStepCount = status.chainStepCount ?? steps.length;
 	const parallelGroups = normalizeParallelGroups(status.parallelGroups, steps.length, chainStepCount);
@@ -329,7 +331,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		...(nestedChildren.length ? { nestedChildren } : {}),
 		...(nestedWarnings.length ? { nestedWarnings } : {}),
 		...(processTerminal ? { processTerminal } : {}),
-		...(status.runFanoutBudget ? { runFanoutBudget: status.runFanoutBudget } : {}),
+		...(runFanoutBudget ? { runFanoutBudget } : {}),
 		...(status.launchContractDigest ? { launchContractDigest: status.launchContractDigest } : {}),
 		...(status.launchResolvedExtensions ? { launchResolvedExtensions: status.launchResolvedExtensions } : {}),
 		...(status.runtimeAcknowledgedExtensions ? { runtimeAcknowledgedExtensions: status.runtimeAcknowledgedExtensions } : {}),

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -7,6 +7,7 @@ import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from 
 import { pruneStatusCacheForAsyncRoot, readStatus } from "../../shared/utils.ts";
 import { attachRootChildrenToSteps, buildNestedRouteIndex, findNestedRouteForRootId, type NestedRoute, projectNestedEvents } from "../shared/nested-events.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
+import { formatRunFanoutBudget } from "../shared/run-fanout-budget.ts";
 import { flatToLogicalStepIndex, normalizeParallelGroups } from "./parallel-groups.ts";
 import { contextModeLabel, summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
@@ -106,6 +107,7 @@ export interface AsyncRunSummary {
 	nestedChildren?: NestedRunSummary[];
 	nestedWarnings?: string[];
 	processTerminal?: AsyncStatus["processTerminal"];
+	runFanoutBudget?: AsyncStatus["runFanoutBudget"];
 	launchResolvedExtensions?: LaunchResolvedChildExtensionsV1;
 	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
@@ -327,6 +329,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		...(nestedChildren.length ? { nestedChildren } : {}),
 		...(nestedWarnings.length ? { nestedWarnings } : {}),
 		...(processTerminal ? { processTerminal } : {}),
+		...(status.runFanoutBudget ? { runFanoutBudget: status.runFanoutBudget } : {}),
 		...(status.launchContractDigest ? { launchContractDigest: status.launchContractDigest } : {}),
 		...(status.launchResolvedExtensions ? { launchResolvedExtensions: status.launchResolvedExtensions } : {}),
 		...(status.runtimeAcknowledgedExtensions ? { runtimeAcknowledgedExtensions: status.runtimeAcknowledgedExtensions } : {}),
@@ -559,6 +562,7 @@ export function formatAsyncRunList(runs: AsyncRunSummary[], heading = "Active as
 		const attached = new Set(run.steps.flatMap((step) => step.children?.map((child) => child.id) ?? []));
 		const unattached = run.nestedChildren?.filter((child) => !attached.has(child.id)) ?? [];
 		lines.push(...formatNestedRunStatusLines(unattached, { indent: "  ", maxLines: 12 }));
+		if (run.runFanoutBudget) lines.push(`  ${formatRunFanoutBudget(run.runFanoutBudget)}`);
 		if (run.error) lines.push(`  Error: ${run.error}`);
 		for (const warning of run.nestedWarnings ?? []) lines.push(`  Warning: ${warning}`);
 		const outputPath = formatAsyncRunOutputPath(run);

--- a/src/runs/background/chain-append.ts
+++ b/src/runs/background/chain-append.ts
@@ -19,6 +19,7 @@ export interface ChainAppendRequest {
 export interface ChainAppendResult {
 	request: ChainAppendRequest;
 	pendingCount: number;
+	bookkeepingError?: string;
 }
 
 type StatusStep = NonNullable<AsyncStatus["steps"]>[number];
@@ -69,6 +70,7 @@ export function enqueueChainAppendRequest(input: {
 	runId: string;
 	steps: RunnerStep[];
 	now?: number;
+	admit?: (persist: () => void) => void;
 }): ChainAppendResult {
 	const status = readStatus(input.asyncDir);
 	if (!status) throw new Error(`No async run status found for '${input.runId}'.`);
@@ -85,20 +87,36 @@ export function enqueueChainAppendRequest(input: {
 		steps: input.steps,
 	};
 	fs.mkdirSync(appendDir(input.asyncDir), { recursive: true });
-	writeAtomicJson(appendRequestPath(input.asyncDir, request), request);
-	const pendingCount = countPendingChainAppendRequests(input.asyncDir);
+	const persist = () => writeAtomicJson(appendRequestPath(input.asyncDir, request), request);
+	if (input.admit) input.admit(persist);
+	else persist();
+	let pendingCount = 1;
+	const bookkeepingErrors: string[] = [];
+	try {
+		pendingCount = countPendingChainAppendRequests(input.asyncDir);
+	} catch (error) {
+		bookkeepingErrors.push(`pending append count failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
 	const statusPath = path.join(input.asyncDir, "status.json");
 	const updatedStatus = { ...status, pendingAppends: pendingCount, lastUpdate: request.createdAt };
-	writeAtomicJson(statusPath, updatedStatus);
-	appendJsonl(path.join(input.asyncDir, "events.jsonl"), JSON.stringify({
-		type: "subagent.chain.append.requested",
-		ts: request.createdAt,
-		runId: input.runId,
-		requestId: request.id,
-		stepCount: input.steps.length,
-		pendingAppends: pendingCount,
-	}));
-	return { request, pendingCount };
+	try {
+		writeAtomicJson(statusPath, updatedStatus);
+	} catch (error) {
+		bookkeepingErrors.push(`status update failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	try {
+		appendJsonl(path.join(input.asyncDir, "events.jsonl"), JSON.stringify({
+			type: "subagent.chain.append.requested",
+			ts: request.createdAt,
+			runId: input.runId,
+			requestId: request.id,
+			stepCount: input.steps.length,
+			pendingAppends: pendingCount,
+		}));
+	} catch (error) {
+		bookkeepingErrors.push(`event append failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	return { request, pendingCount, ...(bookkeepingErrors.length > 0 ? { bookkeepingError: bookkeepingErrors.join("; ") } : {}) };
 }
 
 function readAppendRequest(filePath: string): ChainAppendRequest | undefined {

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -19,6 +19,7 @@ import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-
 import { attachRootChildrenToSteps, findNestedRouteForRootId, projectNestedRegistryForRoot, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 import { readMissionBinding } from "../../missions/lifecycle.ts";
 import { formatWorkflowJsonPreview } from "../../workflows/scripted-workflow.ts";
+import { formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 
 interface RunStatusParams {
 	action?: string;
@@ -389,6 +390,8 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			const steeringText = formatSteeringSummary(status);
 			const processTerminal = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId })
 				?? sanitizeProcessTerminal(status.processTerminal, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId }, path.join(asyncDir, "status.json"));
+			const runFanoutBudgetDescriptor = readRunFanoutBudgetDescriptor(asyncDir);
+			const runFanoutBudget = runFanoutBudgetDescriptor ? getRunFanoutBudgetSnapshot(runFanoutBudgetDescriptor) : status.runFanoutBudget;
 			let missionId: string | undefined;
 			try {
 				missionId = readMissionBinding(asyncDir)?.missionId;
@@ -410,6 +413,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				statusActivityText ? `Activity: ${statusActivityText}` : undefined,
 				steeringText ? `Steering: ${steeringText}` : undefined,
 				`Mode: ${status.mode}`,
+				runFanoutBudget ? formatRunFanoutBudget(runFanoutBudget) : undefined,
 				status.parentWorkflowRunId ? `Workflow parent: ${status.parentWorkflowRunId}${status.workflowKey ? ` (${status.workflowKey})` : ""}` : undefined,
 				status.mode === "workflow" && workflowReturnPreview !== undefined ? `Return: ${workflowReturnPreview}` : undefined,
 				status.mode === "workflow" && workflowEmitPreview !== undefined ? `Latest emit: ${workflowEmitPreview}` : undefined,
@@ -466,7 +470,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			if (fs.existsSync(logPath)) lines.push(`Log: ${logPath}`);
 			if (fs.existsSync(eventsPath)) lines.push(`Events: ${eventsPath}`);
 
-			return { content: [{ type: "text", text: lines.join("\n") }], details: { mode: "single", results: [], ...(processTerminal ? { lifecycleStatus: { processTerminal } } : {}) } };
+			return { content: [{ type: "text", text: lines.join("\n") }], details: { mode: "single", results: [], ...(runFanoutBudget ? { runFanoutBudget } : {}), ...(processTerminal ? { lifecycleStatus: { processTerminal } } : {}) } };
 		}
 	}
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -32,6 +32,7 @@ import {
 	type ResolvedControlConfig,
 	type ResolvedTurnBudget,
 	type ResolvedToolBudget,
+	type RunFanoutBudgetDescriptor,
 	type SubagentRunMode,
 	type SubagentOutputState,
 	type UsageBudgetConfig,
@@ -77,6 +78,7 @@ import { createStructuredOutputRuntime, MISSING_STRUCTURED_OUTPUT_CALL_ERROR, re
 import { formatProcessSignalError, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
 import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection } from "../shared/dynamic-fanout.ts";
+import { claimRunFanoutBatch, getRunFanoutBudgetSnapshot } from "../shared/run-fanout-budget.ts";
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent } from "../shared/nested-events.ts";
 import { formatModelAttemptNote, isRetryableModelFailure } from "../shared/model-fallback.ts";
 import {
@@ -180,6 +182,7 @@ interface SubagentRunConfig {
 	/** Global cap on simultaneously-running subagent tasks within this run. */
 	globalConcurrencyLimit?: number;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	launchContractDigest?: string;
 	launchResolvedExtensions?: LaunchResolvedChildExtensionsV1;
 	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1;
@@ -1104,6 +1107,7 @@ interface SingleStepContext {
 	orchestratorIntercomTarget?: string;
 	nestedRoute?: NestedRouteInfo;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	onAttemptStart?: (attempt: { model?: string; thinking?: string }) => void;
 	onChildEvent?: (event: ChildEvent) => void;
 	onWriterProcess?: (writer: { state: "none" | "spawning" } | { state: "running"; pid: number }) => void;
@@ -1359,6 +1363,10 @@ async function runSingleStep(
 			parentControlInbox: ctx.nestedRoute?.controlInbox,
 			parentRootRunId: ctx.nestedRoute?.rootRunId,
 			parentCapabilityToken: ctx.nestedRoute?.capabilityToken,
+			runFanoutBudget: ctx.runFanoutBudget ? {
+				...ctx.runFanoutBudget,
+				...(step.runFanoutPath ? { parentPath: `${ctx.runFanoutBudget.parentPath ? `${ctx.runFanoutBudget.parentPath}/` : ""}${step.runFanoutPath}` } : {}),
+			} : undefined,
 			steerInboxDir: ctx.steerInboxDir,
 			steerCapabilityPath: ctx.steerCapabilityPath,
 			steerAckDir: ctx.steerAckDir,
@@ -2179,6 +2187,7 @@ async function runSubagent(
 		...(config.launchContractDigest ? { launchContractDigest: config.launchContractDigest } : {}),
 		...(config.launchResolvedExtensions ? { launchResolvedExtensions: config.launchResolvedExtensions } : {}),
 		...(config.capabilityCeiling ? { capabilityCeiling: config.capabilityCeiling } : {}),
+		...(config.runFanoutBudget ? { runFanoutBudget: getRunFanoutBudgetSnapshot(config.runFanoutBudget) } : {}),
 		...(config.parentWorkflowRunId ? { parentWorkflowRunId: config.parentWorkflowRunId } : {}),
 		...(config.workflowKey ? { workflowKey: config.workflowKey } : {}),
 		...(config.runnerProcessInstanceId ? { processTerminal: { version: 1 as const, state: "pending" as const, runId: id, runnerProcessInstanceId: config.runnerProcessInstanceId } } : {}),
@@ -3264,6 +3273,9 @@ async function runSubagent(
 					throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} materialized ${materialized.parallel.length} items that resolve output to the same path: ${step.parallel.outputPath}. Remove the explicit output path or use an inherited relative agent output so each item can be isolated.`);
 				}
 				if (materialized.collectedOnEmpty) await validateDynamicCollection(step.collect.outputSchema, materialized.collectedOnEmpty);
+				if (!config.runFanoutBudget) throw new Error("Async runner is missing its run fan-out budget identity.");
+				const runFanoutBudget = claimRunFanoutBatch(config.runFanoutBudget, materialized.parallel.map((_, itemIndex) => `chain[${stepIndex}].expand[${itemIndex}]`));
+				statusPayload.runFanoutBudget = runFanoutBudget;
 			} catch (error) {
 				const now = Date.now();
 				const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
@@ -3370,6 +3382,7 @@ async function runSubagent(
 				const materializedTask = step.parallel.namespaceOutputPath ? injectSingleOutputInstruction(taskText, outputPath, step.parallel) : taskText;
 				return omitUndefinedProperties({
 					...step.parallel,
+					runFanoutPath: `chain[${stepIndex}].expand[${itemIndex}]`,
 					task: materializedTask,
 					effectiveAcceptance: resolveEffectiveAcceptance(omitUndefinedProperties({
 						explicit: step.parallel.acceptanceInput,
@@ -3529,6 +3542,7 @@ async function runSubagent(
 					orchestratorIntercomTarget: config.controlIntercomTarget,
 					nestedRoute: config.nestedRoute,
 					capabilityCeiling: config.capabilityCeiling,
+					runFanoutBudget: config.runFanoutBudget,
 					registerInterrupt: (interrupt) => registerStepInterrupt(fi, interrupt),
 					registerTimeout: (interrupt) => registerStepTimeout(fi, interrupt),
 					registerStop: (stop) => registerStepStop(fi, stop),
@@ -3911,6 +3925,7 @@ async function runSubagent(
 							orchestratorIntercomTarget: config.controlIntercomTarget,
 							nestedRoute: config.nestedRoute,
 							capabilityCeiling: config.capabilityCeiling,
+							runFanoutBudget: config.runFanoutBudget,
 							registerInterrupt: (interrupt) => registerStepInterrupt(fi, interrupt),
 							registerTimeout: (interrupt) => registerStepTimeout(fi, interrupt),
 							registerStop: (stop) => registerStepStop(fi, stop),
@@ -4200,6 +4215,7 @@ async function runSubagent(
 				orchestratorIntercomTarget: config.controlIntercomTarget,
 				nestedRoute: config.nestedRoute,
 				capabilityCeiling: config.capabilityCeiling,
+				runFanoutBudget: config.runFanoutBudget,
 				registerInterrupt: (interrupt) => registerStepInterrupt(flatIndex, interrupt),
 				registerTimeout: (interrupt) => registerStepTimeout(flatIndex, interrupt),
 				registerStop: (stop) => registerStepStop(flatIndex, stop),

--- a/src/runs/foreground/chain-execution.ts
+++ b/src/runs/foreground/chain-execution.ts
@@ -73,6 +73,7 @@ import {
 	type ResolvedControlConfig,
 	type ResolvedTurnBudget,
 	type ResolvedToolBudget,
+	type RunFanoutBudgetDescriptor,
 	type SingleResult,
 	type ToolBudgetConfig,
 	type ChainCheckpointState,
@@ -88,6 +89,7 @@ import { ChainOutputValidationError, outputEntryFromResult, resolveOutputReferen
 import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection, type DynamicCollectedResult } from "../shared/dynamic-fanout.ts";
 import { acceptanceFailureMessage, aggregateAcceptanceReport, evaluateAcceptance, resolveEffectiveAcceptance } from "../shared/acceptance.ts";
+import { claimRunFanoutBatch, RunFanoutLimitError } from "../shared/run-fanout-budget.ts";
 import { isAgentContractV1 } from "../shared/agent-contract.ts";
 import type { ChainOutputMap } from "../../shared/types.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
@@ -169,6 +171,7 @@ interface ParallelChainRunInput {
 	configToolBudget?: ToolBudgetConfig;
 	globalSemaphore?: Semaphore;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	permissions?: PermissionConfig;
 	dynamic?: boolean;
 }
@@ -397,6 +400,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				llmIntentArbiter: createTaskMutationArbiter(input.ctx),
 				...workflowForegroundSteeringLaunchOptions(input.foregroundControl, childIndex),
 				capabilityCeiling: input.capabilityCeiling,
+				runFanoutBudget: input.runFanoutBudget ? { ...input.runFanoutBudget, parentPath: `${input.runFanoutBudget.parentPath ? `${input.runFanoutBudget.parentPath}/` : ""}chain[${input.stepIndex}]${input.dynamic ? `.expand[${taskIndex}]` : `.parallel[${taskIndex}]`}` } : undefined,
 				context: input.contextForAgent?.(task.agent),
 				cwd: taskCwd,
 				signal: input.signal,
@@ -548,6 +552,7 @@ interface ChainExecutionParams {
 	/** Global cap on simultaneously-running tasks within this chain. Defaults to DEFAULT_GLOBAL_CONCURRENCY_LIMIT. */
 	globalConcurrencyLimit?: number;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
 }
 
 interface ChainExecutionResult {
@@ -884,6 +889,7 @@ ${step.message}` : ""}` }],
 					configToolBudget: params.configToolBudget,
 					globalSemaphore,
 					permissions: params.permissions,
+					runFanoutBudget: params.runFanoutBudget,
 				});
 				globalTaskIndex += step.parallel.length;
 
@@ -1008,6 +1014,19 @@ ${step.message}` : ""}` }],
 				const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
 				dynamicGroupStatuses[stepIndex] = { status: "failed", error: message };
 				return buildChainExecutionErrorResult(message, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }));
+			}
+
+			try {
+				if (params.runFanoutBudget) claimRunFanoutBatch(params.runFanoutBudget, materialized.parallel.map((_, itemIndex) => `chain[${stepIndex}].expand[${itemIndex}]`));
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				dynamicGroupStatuses[stepIndex] = { status: "failed", error: message };
+				const result = buildChainExecutionErrorResult(message, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }));
+				if (error instanceof RunFanoutLimitError) {
+					result.details.runFanoutBudget = error.snapshot;
+					result.details.runFanoutRejection = error.rejection;
+				}
+				return result;
 			}
 
 			dynamicChildren[stepIndex] = materialized.items.map((item, itemIndex) => ({
@@ -1145,6 +1164,7 @@ ${step.message}` : ""}` }],
 				configToolBudget: params.configToolBudget,
 				globalSemaphore,
 				permissions: params.permissions,
+				runFanoutBudget: params.runFanoutBudget,
 				dynamic: true,
 			});
 			globalTaskIndex = dynamicStartIndex + reservedDynamicItems;
@@ -1384,6 +1404,7 @@ ${step.message}` : ""}` }],
 				llmIntentArbiter: createTaskMutationArbiter(ctx),
 				...workflowForegroundSteeringLaunchOptions(params.foregroundControl, childIndex),
 				capabilityCeiling: params.capabilityCeiling,
+				runFanoutBudget: params.runFanoutBudget ? { ...params.runFanoutBudget, parentPath: `${params.runFanoutBudget.parentPath ? `${params.runFanoutBudget.parentPath}/` : ""}chain[${stepIndex}]` } : undefined,
 				context: params.contextForAgent?.(seqStep.agent),
 				cwd: resolveChildCwd(cwd ?? ctx.cwd, seqStep.cwd),
 				signal,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -349,6 +349,7 @@ async function runSingleAttempt(
 		parentControlInbox: options.nestedRoute?.controlInbox,
 		parentRootRunId: options.nestedRoute?.rootRunId,
 		parentCapabilityToken: options.nestedRoute?.capabilityToken,
+		runFanoutBudget: options.runFanoutBudget,
 		parentSessionId: options.parentSessionId,
 		steerInboxDir: options.steerInboxDir,
 		steerCapabilityPath: options.steerCapabilityPath,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -65,7 +65,7 @@ import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBrid
 import { formatControlIntercomMessage, formatControlNoticeMessage, resolveControlConfig, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
 import { resolveTurnBudgetConfig } from "../shared/turn-budget.ts";
 import { formatSpawnBudget, getSpawnBudgetSnapshot, grantSpawnBudget, preflightSpawnBudget, preflightSpawnBudgetGrant, reserveSpawnBudget } from "../shared/spawn-budget.ts";
-import { claimRunFanoutBatch, createRunFanoutBudget, decodeRunFanoutBudgetDescriptor, formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetDescriptor, RunFanoutLimitError, RUN_FANOUT_BUDGET_ENV } from "../shared/run-fanout-budget.ts";
+import { claimRunFanoutBatch, claimRunFanoutBatchWithCommit, createRunFanoutBudget, decodeRunFanoutBudgetDescriptor, formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetDescriptor, RunFanoutLimitError, RUN_FANOUT_BUDGET_ENV, writeRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import { usageBudgetExceededMessage, usageBudgetState, validateUsageBudgetConfig } from "../shared/usage-budget.ts";
 import { intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
@@ -544,11 +544,13 @@ function runFanoutErrorResult(error: RunFanoutLimitError, mode: "single" | "para
 	return { content: [{ type: "text", text: error.message }], isError: true, details: { mode, results: [], runFanoutBudget: error.snapshot, runFanoutRejection: error.rejection } };
 }
 
-function withRunFanoutBudget(result: AgentToolResult<Details>, descriptor: RunFanoutBudgetDescriptor): AgentToolResult<Details> {
+function withRunFanoutBudget(result: AgentToolResult<Details>, descriptor: RunFanoutBudgetDescriptor, options: { annotateContent?: boolean } = {}): AgentToolResult<Details> {
 	const runFanoutBudget = getRunFanoutBudgetSnapshot(descriptor);
 	return {
 		...result,
-		content: result.content.map((item, index) => index === 0 && item.type === "text" ? { ...item, text: `${formatRunFanoutBudget(runFanoutBudget)}\n${item.text}` } : item),
+		content: options.annotateContent === false
+			? result.content
+			: result.content.map((item, index) => index === 0 && item.type === "text" ? { ...item, text: `${formatRunFanoutBudget(runFanoutBudget)}\n${item.text}` } : item),
 		details: { ...result.details, runFanoutBudget },
 	};
 }
@@ -1185,7 +1187,9 @@ function appendStepToAsyncChain(input: {
 	}
 
 	try {
-		const runFanoutBudget = readRunFanoutBudgetDescriptor(resolved.location.asyncDir);
+		const asyncDir = resolved.location.asyncDir;
+		if (!asyncDir) throw new Error(`Run '${resolved.id}' is missing its async directory.`);
+		const runFanoutBudget = readRunFanoutBudgetDescriptor(asyncDir);
 		if (!runFanoutBudget) throw new Error(`Run '${resolved.id}' is missing its run fan-out budget identity.`);
 		const startIndex = (status.chainStepCount ?? status.steps?.length ?? 0) + pendingAppendRequests.reduce((total, request) => total + request.steps.length, 0);
 		const appendPaths = chain.flatMap((step, localIndex) => {
@@ -1194,19 +1198,19 @@ function appendStepToAsyncChain(input: {
 			if (isParallelStep(step)) return step.parallel.map((_, itemIndex) => `chain[${absoluteIndex}].parallel[${itemIndex}]`);
 			return [`chain[${absoluteIndex}]`];
 		});
-		claimRunFanoutBatch(runFanoutBudget, appendPaths);
 		const result = enqueueChainAppendRequest({
-			asyncDir: resolved.location.asyncDir,
+			asyncDir,
 			runId: resolved.id,
 			steps: built.steps,
+			admit: (persist) => claimRunFanoutBatchWithCommit(runFanoutBudget, appendPaths, persist),
 		});
 		const stepText = built.steps.length === 1 ? "step" : "steps";
 		return {
 			content: [{
 				type: "text",
-				text: `Append queued for chain run ${resolved.id}: ${built.steps.length} ${stepText}. It becomes eligible after the chain's already-queued steps finish. Pending appends: ${result.pendingCount}.`,
+				text: `Append queued for chain run ${resolved.id}: ${built.steps.length} ${stepText}. It becomes eligible after the chain's already-queued steps finish. Pending appends: ${result.pendingCount}.${result.bookkeepingError ? ` Bookkeeping warning: ${result.bookkeepingError}` : ""}`,
 			}],
-			details: { mode: "management", results: [], asyncId: resolved.id, asyncDir: resolved.location.asyncDir },
+			details: { mode: "management", results: [], asyncId: resolved.id, asyncDir },
 		};
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -1613,6 +1617,9 @@ async function resumeAsyncRun(input: {
 	const revivalSessionFile = target.sessionFile;
 	if (!revivalSessionFile) {
 		return { content: [{ type: "text", text: `Async child '${target.runId}' has no persisted session file to resume.` }], isError: true, details: { mode: "management", results: [] } };
+	}
+	if (target.source === "async" && !recoveryDescriptor) {
+		return { content: [{ type: "text", text: `Async child '${target.runId}' is missing its required run fan-out recovery identity. Start a new run instead.` }], isError: true, details: { mode: "management", results: [] } };
 	}
 	const runId = randomUUID().slice(0, 8);
 	const recoveryAgentConfig = recoveryDescriptor ? applySteeringRecoveryAgentConfig(agentConfig, recoveryDescriptor) : agentConfig;
@@ -4496,6 +4503,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 } {
 	const delegatedThinkingOverrides = new WeakMap<object, AgentConfig["thinking"]>();
 	const delegatedZeroToolBudgets = new WeakSet<object>();
+	const delegatedExecutions = new WeakSet<object>();
 	const warnedArtifactPackageDirs = new Set<string>();
 	const scheduledOwnerExecutors = new Map<string, ReturnType<typeof createSubagentExecutor>>();
 	const execute = async (
@@ -4509,6 +4517,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const workflowLaunchObserver = workflowLaunchObservers.get(params);
 		const delegatedThinkingOverride = delegatedThinkingOverrides.get(params);
 		const allowZeroToolBudget = delegatedZeroToolBudgets.has(params);
+		const delegatedExecution = delegatedExecutions.has(params);
 		if (!preserveActiveSession) deps.state.baseCwd = ctx.cwd;
 		deps.state.foregroundRuns ??= new Map();
 		deps.state.foregroundControls ??= new Map();
@@ -4578,6 +4587,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				const startedAt = Date.now();
 				const currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
 				fs.mkdirSync(asyncDir, { recursive: true });
+				writeRunFanoutBudgetDescriptor(asyncDir, workflowFanoutBudget);
 				fs.mkdirSync(DIRS.results, { recursive: true });
 				const controller = new AbortController();
 				deps.state.workflowControllers ??= new Map();
@@ -5673,8 +5683,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const controlConfig = resolveControlConfig(deps.config.control, effectiveParams.control);
 		let runFanoutBudget: RunFanoutBudgetDescriptor;
 		try {
+			const inheritedRunFanoutBudget = effectiveParams.runFanoutBudget ? undefined : decodeRunFanoutBudgetDescriptor(process.env[RUN_FANOUT_BUDGET_ENV]);
 			runFanoutBudget = effectiveParams.runFanoutBudget
-				?? decodeRunFanoutBudgetDescriptor(process.env[RUN_FANOUT_BUDGET_ENV])
+				?? (inheritedRunFanoutBudget ? { ...inheritedRunFanoutBudget, parentPath: `${inheritedRunFanoutBudget.parentPath ? `${inheritedRunFanoutBudget.parentPath}/` : ""}${runId}` } : undefined)
 				?? createRunFanoutBudget(runId, resolveMaxSubagentSpawnsPerRun(deps.config.maxSubagentSpawnsPerRun));
 			if (!effectiveParams.runFanoutAdmitted) claimRunFanoutBatch(runFanoutBudget, staticRunFanoutPaths(effectiveParams));
 		} catch (error) {
@@ -5766,7 +5777,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const attachMission = (result: AgentToolResult<Details>): AgentToolResult<Details> => {
 			if (!missionBinding) return missionWarning ? { ...result, details: { ...result.details, missionWarning } } : result;
 			try {
-				return attachMissionToLaunchResult({ binding: missionBinding, result });
+				return attachMissionToLaunchResult({ binding: delegatedExecution ? { ...missionBinding, announceInContent: false } : missionBinding, result });
 			} catch (error) {
 				const warning = `Mission tracking unavailable after launch: ${error instanceof Error ? error.message : String(error)}`;
 				if (explicitMission) {
@@ -6002,20 +6013,21 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				writeNestedForegroundEvent("subagent.nested.started");
 				nestedForegroundStarted = true;
 			}
+			const runFanoutAnnotateContent = !delegatedExecution;
 			if (hasChain && effectiveParams.chain) {
 				const result = await runChainPath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget));
+				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget, { annotateContent: runFanoutAnnotateContent }));
 			}
 			if (hasTasks && effectiveParams.tasks) {
 				const result = await runParallelPath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget));
+				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget, { annotateContent: runFanoutAnnotateContent }));
 			}
 			if (hasSingle) {
 				const result = await runSinglePath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget));
+				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget, { annotateContent: runFanoutAnnotateContent }));
 			}
 		} catch (error) {
 			const errorResult = withForkThinkingNotes(toExecutionErrorResult(effectiveParams, error, contextPolicy.contextSummary), forkThinkingDowngrades);
@@ -6090,6 +6102,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		delete privateParams.delegatedAllowZeroToolBudget;
 		if (thinkingOverride !== undefined) delegatedThinkingOverrides.set(delegatedParams, thinkingOverride);
 		if (allowZeroToolBudget) delegatedZeroToolBudgets.add(delegatedParams);
+		delegatedExecutions.add(delegatedParams);
 		return execute(id, delegatedParams, signal, onUpdate, ctx);
 	};
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -65,6 +65,7 @@ import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBrid
 import { formatControlIntercomMessage, formatControlNoticeMessage, resolveControlConfig, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
 import { resolveTurnBudgetConfig } from "../shared/turn-budget.ts";
 import { formatSpawnBudget, getSpawnBudgetSnapshot, grantSpawnBudget, preflightSpawnBudget, preflightSpawnBudgetGrant, reserveSpawnBudget } from "../shared/spawn-budget.ts";
+import { claimRunFanoutBatch, createRunFanoutBudget, decodeRunFanoutBudgetDescriptor, formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetDescriptor, RunFanoutLimitError, RUN_FANOUT_BUDGET_ENV } from "../shared/run-fanout-budget.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import { usageBudgetExceededMessage, usageBudgetState, validateUsageBudgetConfig } from "../shared/usage-budget.ts";
 import { intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
@@ -145,6 +146,7 @@ import {
 	type ResolvedControlConfig,
 	type ResolvedTurnBudget,
 	type ResolvedToolBudget,
+	type RunFanoutBudgetDescriptor,
 	type SingleResult,
 	type ToolBudgetConfig,
 	type TurnBudgetConfig,
@@ -163,6 +165,7 @@ import {
 	resolveTopLevelParallelMaxTasks,
 	resolveChildMaxSubagentDepth,
 	resolveCurrentMaxSubagentDepth,
+	resolveMaxSubagentSpawnsPerRun,
 	wrapForkTask,
 } from "../../shared/types.ts";
 
@@ -286,6 +289,10 @@ export interface SubagentParamsLike {
 	workflowKey?: string;
 	workflowChildAsyncId?: string;
 	suppressRoutineResultIntercom?: boolean;
+	/** Internal inherited cumulative run-tree budget. */
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
+	/** Internal workflow host admission proof. */
+	runFanoutAdmitted?: boolean;
 	/** Internal durable-run compatibility fields. Public callers must use workflowScript. */
 	chain?: ChainStep[];
 	tasks?: TaskParam[];
@@ -406,6 +413,7 @@ interface ExecutionContextData {
 	parentSessionId: string | null;
 	parentPiSessionId?: string;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	runFanoutBudget: RunFanoutBudgetDescriptor;
 }
 
 function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefined): string {
@@ -520,6 +528,29 @@ function countRequestedSubagentSpawns(params: SubagentParamsLike, config: Extens
 		}, 0);
 	}
 	return params.agent ? 1 : 0;
+}
+
+function staticRunFanoutPaths(params: SubagentParamsLike): string[] {
+	if (params.tasks) return params.tasks.map((_, index) => `tasks[${index}]`);
+	if (params.chain) return params.chain.flatMap((step, stepIndex) => {
+		if (isDynamicParallelStep(step) || "checkpoint" in step) return [];
+		if (isParallelStep(step)) return step.parallel.map((_, itemIndex) => `chain[${stepIndex}].parallel[${itemIndex}]`);
+		return [`chain[${stepIndex}]`];
+	});
+	return params.agent ? ["single"] : [];
+}
+
+function runFanoutErrorResult(error: RunFanoutLimitError, mode: "single" | "parallel" | "chain"): AgentToolResult<Details> {
+	return { content: [{ type: "text", text: error.message }], isError: true, details: { mode, results: [], runFanoutBudget: error.snapshot, runFanoutRejection: error.rejection } };
+}
+
+function withRunFanoutBudget(result: AgentToolResult<Details>, descriptor: RunFanoutBudgetDescriptor): AgentToolResult<Details> {
+	const runFanoutBudget = getRunFanoutBudgetSnapshot(descriptor);
+	return {
+		...result,
+		content: result.content.map((item, index) => index === 0 && item.type === "text" ? { ...item, text: `${formatRunFanoutBudget(runFanoutBudget)}\n${item.text}` } : item),
+		details: { ...result.details, runFanoutBudget },
+	};
 }
 
 function foregroundStatusResult(control: SubagentState["foregroundControls"] extends Map<string, infer T> ? T : never): AgentToolResult<Details> {
@@ -1154,6 +1185,16 @@ function appendStepToAsyncChain(input: {
 	}
 
 	try {
+		const runFanoutBudget = readRunFanoutBudgetDescriptor(resolved.location.asyncDir);
+		if (!runFanoutBudget) throw new Error(`Run '${resolved.id}' is missing its run fan-out budget identity.`);
+		const startIndex = (status.chainStepCount ?? status.steps?.length ?? 0) + pendingAppendRequests.reduce((total, request) => total + request.steps.length, 0);
+		const appendPaths = chain.flatMap((step, localIndex) => {
+			const absoluteIndex = startIndex + localIndex;
+			if (isDynamicParallelStep(step) || "checkpoint" in step) return [];
+			if (isParallelStep(step)) return step.parallel.map((_, itemIndex) => `chain[${absoluteIndex}].parallel[${itemIndex}]`);
+			return [`chain[${absoluteIndex}]`];
+		});
+		claimRunFanoutBatch(runFanoutBudget, appendPaths);
 		const result = enqueueChainAppendRequest({
 			asyncDir: resolved.location.asyncDir,
 			runId: resolved.id,
@@ -1551,6 +1592,7 @@ async function resumeAsyncRun(input: {
 			controlIntercomTarget: intercomBridge.active ? intercomBridge.orchestratorTarget : undefined,
 			childIntercomTarget: intercomBridge.active ? (agent, index) => resolveSubagentIntercomTarget(runId, agent, index) : undefined,
 			globalConcurrencyLimit: input.deps.config.globalConcurrencyLimit,
+			runFanoutBudget: createRunFanoutBudget(runId, resolveMaxSubagentSpawnsPerRun(input.deps.config.maxSubagentSpawnsPerRun)),
 			capabilityCeiling: intersectSubagentCapabilityCeilings("capabilityCeiling" in target ? target.capabilityCeiling : undefined, resolveCurrentSubagentCapabilityCeiling(input.deps.state.currentSessionId)),
 		}));
 		if (result.isError) return result;
@@ -1631,6 +1673,7 @@ async function resumeAsyncRun(input: {
 		...(input.params.turnBudget !== undefined ? { turnBudget: input.params.turnBudget } : {}),
 		...(input.params.toolBudget !== undefined ? { toolBudget: input.params.toolBudget } : {}),
 		capabilityCeiling: intersectSubagentCapabilityCeilings("capabilityCeiling" in target ? target.capabilityCeiling : undefined, recoveryDescriptor?.capabilityCeiling, resolveCurrentSubagentCapabilityCeiling(input.deps.state.currentSessionId)),
+		runFanoutBudget: recoveryDescriptor?.runFanoutBudget ?? createRunFanoutBudget(runId, resolveMaxSubagentSpawnsPerRun(input.deps.config.maxSubagentSpawnsPerRun)),
 		parentWorkflowRunId: input.params.workflowParentRunId,
 		workflowKey: input.params.workflowKey,
 	}));
@@ -2672,6 +2715,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			usageBudget: data.usageBudget,
 			configToolBudget: data.configToolBudget,
 			capabilityCeiling: data.capabilityCeiling,
+			runFanoutBudget: data.runFanoutBudget,
 			globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 			parentWorkflowRunId: params.workflowParentRunId,
 			workflowKey: params.workflowKey,
@@ -2717,6 +2761,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			usageBudget: data.usageBudget,
 			configToolBudget: data.configToolBudget,
 			capabilityCeiling: data.capabilityCeiling,
+			runFanoutBudget: data.runFanoutBudget,
 			globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 			parentWorkflowRunId: params.workflowParentRunId,
 			workflowKey: params.workflowKey,
@@ -2784,6 +2829,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			usageBudget: data.usageBudget,
 			configToolBudget: data.configToolBudget,
 			capabilityCeiling: data.capabilityCeiling,
+			runFanoutBudget: data.runFanoutBudget,
 			parentWorkflowRunId: params.workflowParentRunId,
 			workflowKey: params.workflowKey,
 		}));
@@ -2874,6 +2920,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		permissions: deps.config.permissions,
 		globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 		capabilityCeiling: data.capabilityCeiling,
+		runFanoutBudget: data.runFanoutBudget,
 	}));
 
 	if (chainResult.requestedAsync) {
@@ -2934,6 +2981,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			usageBudget: data.usageBudget,
 			configToolBudget: data.configToolBudget,
 			capabilityCeiling: data.capabilityCeiling,
+			runFanoutBudget: data.runFanoutBudget,
 			globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 		}));
 	}
@@ -2980,6 +3028,7 @@ interface ForegroundParallelRunInput {
 	intercomEvents: IntercomEventBus;
 	parentSessionId: string | null;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	runFanoutBudget: RunFanoutBudgetDescriptor;
 	signal: AbortSignal;
 	runId: string;
 	sessionDirForIndex: (idx?: number) => string | undefined;
@@ -3263,6 +3312,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			llmIntentArbiter: createTaskMutationArbiter(input.ctx),
 			...workflowForegroundSteeringLaunchOptions(input.foregroundControl, index),
 			context: input.contextPolicy.contextForAgent(task.agent),
+			runFanoutBudget: { ...input.runFanoutBudget, parentPath: `${input.runFanoutBudget.parentPath ? `${input.runFanoutBudget.parentPath}/` : ""}tasks[${index}]` },
 			cwd: taskCwd,
 			signal: input.signal,
 			interruptSignal: interruptController.signal,
@@ -3555,6 +3605,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				toolBudget: data.toolBudget,
 				configToolBudget: data.configToolBudget,
 				globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
+				runFanoutBudget: data.runFanoutBudget,
 			}));
 		}
 	}
@@ -3634,6 +3685,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			intercomEvents: deps.pi.events,
 			parentSessionId: data.parentSessionId,
 			capabilityCeiling: data.capabilityCeiling,
+			runFanoutBudget: data.runFanoutBudget,
 			signal,
 			runId,
 			sessionDirForIndex,
@@ -3919,6 +3971,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				toolBudget: effectiveToolBudget.toolBudget,
 				usageBudget: data.usageBudget,
 				allowZeroToolBudget: data.allowZeroToolBudget && effectiveToolBudget.toolBudget === data.toolBudget,
+				runFanoutBudget: data.runFanoutBudget,
 			}));
 		}
 	}
@@ -3993,6 +4046,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			llmIntentArbiter: createTaskMutationArbiter(ctx),
 			...workflowForegroundSteeringLaunchOptions(foregroundControl, 0),
 			context: data.contextPolicy.contextForAgent(params.agent!),
+			runFanoutBudget: params.runFanoutAdmitted ? data.runFanoutBudget : { ...data.runFanoutBudget, parentPath: `${data.runFanoutBudget.parentPath ? `${data.runFanoutBudget.parentPath}/` : ""}single` },
 			cwd: effectiveCwd,
 			signal,
 			interruptSignal: interruptController.signal,
@@ -4266,7 +4320,7 @@ export function prepareWorkflowLaunchParams(
 	childParams: Record<string, unknown>,
 	parentWorkflowRunId: string,
 	workflowKey: string,
-	options: { missionDetached?: boolean; suppressRoutineResultIntercom?: boolean } = {},
+	options: { missionDetached?: boolean; suppressRoutineResultIntercom?: boolean; runFanoutBudget?: RunFanoutBudgetDescriptor } = {},
 ): SubagentParamsLike {
 	if (typeof childParams.resume === "string") {
 		if (childParams.gate !== undefined || workflowDefaults.gate !== undefined) {
@@ -4294,6 +4348,7 @@ export function prepareWorkflowLaunchParams(
 		...(options.missionDetached ? { mission: false } : {}),
 		workflowParentRunId: parentWorkflowRunId,
 		workflowKey,
+		...(options.runFanoutBudget ? { runFanoutBudget: { ...options.runFanoutBudget, parentPath: `${options.runFanoutBudget.parentPath ? `${options.runFanoutBudget.parentPath}/` : ""}workflow[${workflowKey}]` } } : {}),
 		...(options.suppressRoutineResultIntercom ? { suppressRoutineResultIntercom: true } : {}),
 	} as SubagentParamsLike;
 	const normalizedGate = normalizeGateParams(launchParams);
@@ -4472,6 +4527,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const chatProgressResult = resolveWorkflowChatProgress({ requested: requestParams.chatProgress, parentCwd, workflowCwd, background: requestParams.async !== false });
 			if (chatProgressResult.error) return { content: [{ type: "text", text: chatProgressResult.error }], isError: true, details: { mode: "workflow", results: [] } };
 			const chatProgress = chatProgressResult.projection!;
+			let workflowFanoutBudget: RunFanoutBudgetDescriptor;
+			try {
+				workflowFanoutBudget = requestParams.runFanoutBudget
+					?? decodeRunFanoutBudgetDescriptor(process.env[RUN_FANOUT_BUDGET_ENV])
+					?? createRunFanoutBudget(_id, resolveMaxSubagentSpawnsPerRun(deps.config.maxSubagentSpawnsPerRun));
+			} catch (error) {
+				return { content: [{ type: "text", text: error instanceof Error ? error.message : String(error) }], isError: true, details: { mode: "workflow", results: [] } };
+			}
 			const explicitMission = requestParams.missionId !== undefined || requestParams.mission !== undefined;
 			const autoMission = !explicitMission;
 			const workflowPreview = autoMission ? previewSimpleWorkflowRun(requestParams.workflowScript) : undefined;
@@ -4532,6 +4595,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					pid: process.pid,
 					steps: [],
 					workflow: { trace: [], emits: [], console: [] },
+					runFanoutBudget: getRunFanoutBudgetSnapshot(workflowFanoutBudget),
 				};
 				const appendWorkflowEvent = (event: Record<string, unknown>) => fs.appendFileSync(eventsPath, `${JSON.stringify({ ts: Date.now(), runId: workflowRunId, ...event })}\n`, "utf-8");
 				let indexedState: AsyncStatus["state"] | undefined;
@@ -4642,13 +4706,17 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							prompts: workflowPrompts,
 							...(workflowState ? { state: workflowState } : {}),
 							onTrace: updateTrace,
+							admit: (calls) => {
+								status.runFanoutBudget = claimRunFanoutBatch(workflowFanoutBudget, calls.map(({ key }) => `workflow[${key}]`));
+								persist();
+							},
 							onEmit: (emits) => {
 								// Each emit is validated at the host boundary in runWorkflowScript before onEmit fires.
 								status.workflow = { ...(status.workflow ?? { trace: [], console: [] }), emits };
 								persist();
 								appendWorkflowEvent({ type: "subagent.workflow.emit", value: emits.at(-1) });
 							},
-							launch: async (key, childParams, workflowSignal) => {
+							launch: async (key, childParams, workflowSignal, admission) => {
 								if (workflowUsageBudget.budget && childParams.async === true) return workflowChildResult(key, buildRequestedModeError(childParams as SubagentParamsLike, "workflow usageBudget does not support async runs.run launches."));
 								const budgetState = usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults));
 								if (budgetState?.exhausted) return workflowChildResult(key, buildRequestedModeError(childParams as SubagentParamsLike, usageBudgetExceededMessage(budgetState)));
@@ -4663,7 +4731,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								});
 								const result = await runMissionWorkflowChild(missionBinding, workflowRunId, key, childPhase, () => {
 									const childRequest = bindMissionWorkflowChildAsyncLaunch(
-										prepareWorkflowLaunchParams(workflowChildDefaults, childParams, workflowRunId, key, { missionDetached: detachWorkflowChildMissions }),
+										{ ...prepareWorkflowLaunchParams(workflowChildDefaults, childParams, workflowRunId, key, { missionDetached: detachWorkflowChildMissions, runFanoutBudget: workflowFanoutBudget }), runFanoutAdmitted: admission.admitted },
 										missionBinding,
 										deps.asyncByDefault,
 									);
@@ -4742,10 +4810,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						deps.state.workflowControllers?.delete(workflowRunId);
 					}
 				});
-				return attachWorkflowMission({
+				return attachWorkflowMission(withRunFanoutBudget({
 					content: [{ type: "text", text: formatAsyncStartedMessage(`Async workflow [${workflowRunId}]`, ctx.hasUI === true) }],
 					details: { mode: "workflow", runId: workflowRunId, toolCallId, asyncId: workflowRunId, asyncDir, results: [], chatProgress },
-				});
+				}, workflowFanoutBudget));
 			}
 			const { workflowScript: _workflowScript, action: _action, agent: _agent, task: _task, resume: _resume, tasks: _tasks, chain: _chain, concurrency: _concurrency, async: _async, foregroundOnly: _foregroundOnly, clarify: _clarify, timeoutMs: _timeoutMs, maxRuntimeMs: _maxRuntimeMs, usageBudget: _usageBudget, chatProgress: _chatProgress, missionId: _missionId, mission: _mission, ...workflowChildDefaults } = requestParams;
 			const workflowResults: SingleResult[] = [];
@@ -4765,11 +4833,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						liveWorkflow = { ...liveWorkflow, trace };
 						sendWorkflowProgress();
 					},
+					admit: (calls) => {
+						claimRunFanoutBatch(workflowFanoutBudget, calls.map(({ key }) => `workflow[${key}]`));
+					},
 					onEmit: (emits) => {
 						liveWorkflow = { ...liveWorkflow, emits };
 						sendWorkflowProgress();
 					},
-					launch: async (key, childParams, workflowSignal) => {
+					launch: async (key, childParams, workflowSignal, admission) => {
 						if (workflowUsageBudget.budget && childParams.async === true) return workflowChildResult(key, buildRequestedModeError(childParams as SubagentParamsLike, "workflow usageBudget does not support async runs.run launches."));
 						const budgetState = usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults));
 						if (budgetState?.exhausted) return workflowChildResult(key, buildRequestedModeError(childParams as SubagentParamsLike, usageBudgetExceededMessage(budgetState)));
@@ -4784,7 +4855,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						});
 						const result = await runMissionWorkflowChild(missionBinding, _id, key, childPhase, () => {
 							const childRequest = bindMissionWorkflowChildAsyncLaunch(
-								prepareWorkflowLaunchParams(workflowChildDefaults, childParams, _id, key, { missionDetached: detachWorkflowChildMissions, suppressRoutineResultIntercom: chatProgress.mode === "live-card" }),
+								{ ...prepareWorkflowLaunchParams(workflowChildDefaults, childParams, _id, key, { missionDetached: detachWorkflowChildMissions, suppressRoutineResultIntercom: chatProgress.mode === "live-card", runFanoutBudget: workflowFanoutBudget }), runFanoutAdmitted: admission.admitted },
 								missionBinding,
 								deps.asyncByDefault,
 							);
@@ -4825,10 +4896,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (workflow.emits.length > 0) sections.push(`Emitted:\n${workflow.emits.map(formatWorkflowValue).join("\n")}`);
 				if (workflow.console.length > 0) sections.push(`Console:\n${workflow.console.map((entry) => `[${entry.level}] ${entry.text}`).join("\n")}`);
 				if (traceLines.length > 0) sections.push(`Call trace:\n${traceLines.join("\n")}`);
-				return attachWorkflowMission({
+				return attachWorkflowMission(withRunFanoutBudget({
 					content: [{ type: "text", text: sections.join("\n\n") }],
 					details: compactOptional<Details>({ mode: "workflow", runId: _id, results: workflow.children.flatMap((child) => (child.results ?? []) as SingleResult[]), totalChildUsage: sumResultsUsage(workflowResults), totalCost: sumResultsCost(workflowResults), usageBudget: usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults)), workflow: { value: workflow.value, trace: workflow.trace, emits: workflow.emits, console: workflow.console }, chatProgress }),
-				});
+				}, workflowFanoutBudget));
 			} catch (error) {
 				const partial = error instanceof WorkflowScriptError ? error.partial : { trace: [], emits: [], console: [], children: [] };
 				const text = error instanceof Error ? error.message : String(error);
@@ -4837,11 +4908,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (partial.emits.length > 0) sections.push(`Emitted:\n${partial.emits.map(formatWorkflowValue).join("\n")}`);
 				if (partial.console.length > 0) sections.push(`Console:\n${partial.console.map((entry) => `[${entry.level}] ${entry.text}`).join("\n")}`);
 				if (traceLines.length > 0) sections.push(`Call trace:\n${traceLines.join("\n")}`);
-				return attachWorkflowMission({
+				return attachWorkflowMission(withRunFanoutBudget({
 					content: [{ type: "text", text: sections.join("\n\n") }],
 					isError: true,
 					details: compactOptional<Details>({ mode: "workflow", runId: _id, results: partial.children.flatMap((child) => (child.results ?? []) as SingleResult[]), totalChildUsage: sumResultsUsage(workflowResults), totalCost: sumResultsCost(workflowResults), usageBudget: usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults)), workflow: { trace: partial.trace, emits: partial.emits, console: partial.console }, chatProgress }),
-				});
+				}, workflowFanoutBudget));
 			}
 		}
 		const directParams = prepareWorkflowChildParams(requestParams);
@@ -5600,6 +5671,16 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		);
 		if (foregroundTimeout.error) return buildRequestedModeError(effectiveParams, foregroundTimeout.error);
 		const controlConfig = resolveControlConfig(deps.config.control, effectiveParams.control);
+		let runFanoutBudget: RunFanoutBudgetDescriptor;
+		try {
+			runFanoutBudget = effectiveParams.runFanoutBudget
+				?? decodeRunFanoutBudgetDescriptor(process.env[RUN_FANOUT_BUDGET_ENV])
+				?? createRunFanoutBudget(runId, resolveMaxSubagentSpawnsPerRun(deps.config.maxSubagentSpawnsPerRun));
+			if (!effectiveParams.runFanoutAdmitted) claimRunFanoutBatch(runFanoutBudget, staticRunFanoutPaths(effectiveParams));
+		} catch (error) {
+			if (error instanceof RunFanoutLimitError) return runFanoutErrorResult(error, foregroundMode);
+			return buildRequestedModeError(effectiveParams, error instanceof Error ? error.message : String(error));
+		}
 
 		const artifactConfig: ArtifactConfig = omitUndefinedProperties({
 			...DEFAULT_ARTIFACT_CONFIG,
@@ -5741,6 +5822,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			parentSessionId: requestSessionId,
 			parentPiSessionId: requestPiSessionId,
 			capabilityCeiling: resolveCurrentSubagentCapabilityCeiling(requestSessionId),
+			runFanoutBudget,
 		});
 
 		const foregroundDescription = selectedAgentNames.length === 1
@@ -5915,7 +5997,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				}
 			}
 			const asyncResult = runAsyncPath(execData, deps);
-			if (asyncResult) return attachMission(withResolvedContext(withForkThinkingNotes(asyncResult, forkThinkingDowngrades), contextPolicy.contextSummary));
+			if (asyncResult) return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(asyncResult, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget));
 			if (foregroundControl) {
 				writeNestedForegroundEvent("subagent.nested.started");
 				nestedForegroundStarted = true;
@@ -5923,17 +6005,17 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			if (hasChain && effectiveParams.chain) {
 				const result = await runChainPath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return attachMission(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary));
+				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget));
 			}
 			if (hasTasks && effectiveParams.tasks) {
 				const result = await runParallelPath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return attachMission(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary));
+				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget));
 			}
 			if (hasSingle) {
 				const result = await runSinglePath(execData, deps);
 				writeNestedForegroundEvent("subagent.nested.completed", result);
-				return attachMission(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary));
+				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget));
 			}
 		} catch (error) {
 			const errorResult = withForkThinkingNotes(toExecutionErrorResult(effectiveParams, error, contextPolicy.contextSummary), forkThinkingDowngrades);

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -61,6 +61,8 @@ export interface RunnerSubagentStep {
 	toolBudget?: import("../../shared/types.ts").ResolvedToolBudget;
 	capabilityCeiling?: import("./capability-ceiling.ts").ResolvedSubagentCapabilityCeiling;
 	capabilityAudit?: import("./capability-ceiling.ts").SubagentCapabilityAudit;
+	/** Private stable logical-child path for inherited run fan-out accounting. */
+	runFanoutPath?: string;
 }
 
 export interface RunnerCheckpointStep {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -23,8 +23,10 @@ import {
 	type JsonSchemaObject,
 	type LaunchResolvedChildExtensionsV1,
 	type ResolvedToolBudget,
+	type RunFanoutBudgetDescriptor,
 } from "../../shared/types.ts";
 import { THINKING_LEVELS } from "../../shared/model-info.ts";
+import { encodeRunFanoutBudgetDescriptor, RUN_FANOUT_BUDGET_ENV } from "./run-fanout-budget.ts";
 import {
 	TOOL_BUDGET_ENV,
 	TOOL_BUDGET_ZERO_AUTH_ENV,
@@ -162,6 +164,7 @@ export interface BuildPiArgsInput {
 	parentDepth?: number;
 	parentPath?: NestedPathEntry[];
 	parentCapabilityToken?: string;
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	steerInboxDir?: string;
 	steerCapabilityPath?: string;
 	steerAckDir?: string;
@@ -731,6 +734,9 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 			process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] ??
 			"")
 		: "";
+	env[RUN_FANOUT_BUDGET_ENV] = toolPlan.fanoutAuthorized
+		? (input.runFanoutBudget ? encodeRunFanoutBudgetDescriptor(input.runFanoutBudget) : process.env[RUN_FANOUT_BUDGET_ENV])
+		: undefined;
 	env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = input.inheritProjectContext
 		? "1"
 		: "0";

--- a/src/runs/shared/run-fanout-budget.ts
+++ b/src/runs/shared/run-fanout-budget.ts
@@ -1,0 +1,257 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+	TEMP_ROOT_DIR,
+	type RunFanoutBudgetDescriptor,
+	type RunFanoutBudgetSnapshot,
+	type RunFanoutRejection,
+} from "../../shared/types.ts";
+
+export const DEFAULT_MAX_SUBAGENT_SPAWNS_PER_RUN = 64;
+export const RUN_FANOUT_BUDGET_ENV = "PI_SUBAGENT_RUN_FANOUT_BUDGET";
+const RUN_FANOUT_ROOT = path.join(TEMP_ROOT_DIR, "run-fanout-budgets");
+
+interface ManifestV1 {
+	version: 1;
+	rootRunId: string;
+	limit: number;
+	createdAt: number;
+}
+
+interface ClaimV1 {
+	version: 1;
+	claimId: string;
+	path: string;
+	claimedAt: number;
+}
+
+export class RunFanoutLimitError extends Error {
+	readonly rejection: RunFanoutRejection;
+	readonly snapshot: RunFanoutBudgetSnapshot;
+
+	constructor(rejection: RunFanoutRejection) {
+		super(formatRunFanoutRejection(rejection));
+		this.name = "RunFanoutLimitError";
+		this.rejection = rejection;
+		this.snapshot = { used: rejection.used, limit: rejection.limit, remaining: rejection.remaining };
+	}
+}
+
+function safeRootRunId(rootRunId: string): string {
+	return rootRunId.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 120) || randomUUID();
+}
+
+function parseManifest(value: unknown): ManifestV1 | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const manifest = value as Partial<ManifestV1>;
+	if (manifest.version !== 1 || typeof manifest.rootRunId !== "string" || !manifest.rootRunId
+		|| !Number.isInteger(manifest.limit) || (manifest.limit ?? 0) <= 0
+		|| typeof manifest.createdAt !== "number" || !Number.isFinite(manifest.createdAt)) return undefined;
+	return manifest as ManifestV1;
+}
+
+function readManifest(directory: string): ManifestV1 {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(fs.readFileSync(path.join(directory, "manifest.json"), "utf-8"));
+	} catch (error) {
+		throw new Error(`Run fan-out budget manifest is unreadable at '${directory}': ${error instanceof Error ? error.message : String(error)}`);
+	}
+	const manifest = parseManifest(parsed);
+	if (!manifest) throw new Error(`Run fan-out budget manifest is invalid at '${directory}'.`);
+	return manifest;
+}
+
+function validateDirectory(directory: string): string {
+	const resolved = path.resolve(directory);
+	const root = path.resolve(RUN_FANOUT_ROOT);
+	if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+		throw new Error("Run fan-out budget directory is outside the managed budget root.");
+	}
+	return resolved;
+}
+
+export function createRunFanoutBudget(rootRunId: string, limit: number): RunFanoutBudgetDescriptor {
+	if (!Number.isInteger(limit) || limit <= 0) throw new Error("Run fan-out limit must be a positive integer.");
+	fs.mkdirSync(RUN_FANOUT_ROOT, { recursive: true, mode: 0o700 });
+	let directory: string;
+	do directory = path.join(RUN_FANOUT_ROOT, `${safeRootRunId(rootRunId)}-${randomUUID()}`);
+	while (fs.existsSync(directory));
+	fs.mkdirSync(path.join(directory, "claims"), { recursive: true, mode: 0o700 });
+	const manifest: ManifestV1 = { version: 1, rootRunId, limit, createdAt: Date.now() };
+	fs.writeFileSync(path.join(directory, "manifest.json"), `${JSON.stringify(manifest)}\n`, { mode: 0o600, flag: "wx" });
+	return { version: 1, rootRunId, directory, limit };
+}
+
+export function validateRunFanoutBudgetDescriptor(value: unknown): RunFanoutBudgetDescriptor {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Run fan-out budget descriptor is missing or invalid.");
+	const descriptor = value as Partial<RunFanoutBudgetDescriptor>;
+	if (descriptor.version !== 1 || typeof descriptor.rootRunId !== "string" || !descriptor.rootRunId
+		|| typeof descriptor.directory !== "string" || !descriptor.directory
+		|| !Number.isInteger(descriptor.limit) || (descriptor.limit ?? 0) <= 0
+		|| (descriptor.parentPath !== undefined && typeof descriptor.parentPath !== "string")) {
+		throw new Error("Run fan-out budget descriptor is invalid.");
+	}
+	const directory = validateDirectory(descriptor.directory);
+	const manifest = readManifest(directory);
+	if (manifest.rootRunId !== descriptor.rootRunId || manifest.limit !== descriptor.limit) {
+		throw new Error("Run fan-out budget descriptor does not match its manifest.");
+	}
+	return { version: 1, rootRunId: descriptor.rootRunId, directory, limit: descriptor.limit, ...(descriptor.parentPath ? { parentPath: descriptor.parentPath } : {}) };
+}
+
+export function writeRunFanoutBudgetDescriptor(asyncDir: string, descriptor: RunFanoutBudgetDescriptor): void {
+	const valid = validateRunFanoutBudgetDescriptor(descriptor);
+	fs.mkdirSync(asyncDir, { recursive: true });
+	fs.writeFileSync(path.join(asyncDir, "run-fanout-budget.json"), `${JSON.stringify(valid)}\n`, { mode: 0o600 });
+}
+
+export function readRunFanoutBudgetDescriptor(asyncDir: string | undefined): RunFanoutBudgetDescriptor | undefined {
+	if (!asyncDir) return undefined;
+	const descriptorPath = path.join(asyncDir, "run-fanout-budget.json");
+	if (!fs.existsSync(descriptorPath)) return undefined;
+	try {
+		return validateRunFanoutBudgetDescriptor(JSON.parse(fs.readFileSync(descriptorPath, "utf-8")));
+	} catch (error) {
+		throw new Error(`Invalid persisted run fan-out budget '${descriptorPath}': ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+export function encodeRunFanoutBudgetDescriptor(descriptor: RunFanoutBudgetDescriptor): string {
+	return Buffer.from(JSON.stringify(validateRunFanoutBudgetDescriptor(descriptor)), "utf-8").toString("base64url");
+}
+
+export function decodeRunFanoutBudgetDescriptor(encoded: string | undefined): RunFanoutBudgetDescriptor | undefined {
+	if (!encoded) return undefined;
+	try {
+		return validateRunFanoutBudgetDescriptor(JSON.parse(Buffer.from(encoded, "base64url").toString("utf-8")));
+	} catch (error) {
+		throw new Error(`Invalid inherited run fan-out budget: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+const CLAIM_LOCK_WAIT_MS = 5_000;
+const CLAIM_LOCK_RETRY_MS = 10;
+const claimLockWaitArray = new Int32Array(new SharedArrayBuffer(4));
+
+function processIsAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function withClaimLock<T>(directory: string, callback: () => T): T {
+	const lockPath = path.join(directory, "claim.lock");
+	const token = randomUUID();
+	const deadline = Date.now() + CLAIM_LOCK_WAIT_MS;
+	while (true) {
+		try {
+			fs.mkdirSync(lockPath, { mode: 0o700 });
+			fs.writeFileSync(path.join(lockPath, "owner.json"), `${JSON.stringify({ pid: process.pid, token })}\n`, { mode: 0o600 });
+			break;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+			let stale = false;
+			try {
+				const parsed = JSON.parse(fs.readFileSync(path.join(lockPath, "owner.json"), "utf-8")) as Partial<{ pid: number }>;
+				stale = Number.isInteger(parsed.pid) && (parsed.pid ?? 0) > 0 && !processIsAlive(parsed.pid!);
+			} catch {
+				try { stale = Date.now() - fs.statSync(lockPath).mtimeMs >= CLAIM_LOCK_WAIT_MS; } catch {}
+			}
+			if (stale) {
+				const stalePath = path.join(directory, `claim.stale-${randomUUID()}`);
+				try {
+					fs.renameSync(lockPath, stalePath);
+					fs.rmSync(stalePath, { recursive: true, force: true });
+					continue;
+				} catch (takeoverError) {
+					if (!(["ENOENT", "EEXIST"] as Array<string | undefined>).includes((takeoverError as NodeJS.ErrnoException).code)) throw takeoverError;
+				}
+			}
+			if (Date.now() >= deadline) throw new Error(`Timed out waiting for run fan-out admission lock at '${directory}'.`);
+			Atomics.wait(claimLockWaitArray, 0, 0, CLAIM_LOCK_RETRY_MS);
+		}
+	}
+	try { return callback(); }
+	finally {
+		try {
+			const current = JSON.parse(fs.readFileSync(path.join(lockPath, "owner.json"), "utf-8")) as Partial<{ token: string }>;
+			if (current.token === token) fs.rmSync(lockPath, { recursive: true, force: true });
+		} catch {}
+	}
+}
+
+function claimCount(directory: string): number {
+	const claimsDir = path.join(directory, "claims");
+	let entries: fs.Dirent[];
+	try { entries = fs.readdirSync(claimsDir, { withFileTypes: true }); }
+	catch { return Number.POSITIVE_INFINITY; }
+	return entries.filter((entry) => /^\d{6}\.json$/.test(entry.name)).length;
+}
+
+export function getRunFanoutBudgetSnapshot(descriptor: RunFanoutBudgetDescriptor): RunFanoutBudgetSnapshot {
+	const valid = validateRunFanoutBudgetDescriptor(descriptor);
+	const used = claimCount(valid.directory);
+	if (!Number.isFinite(used)) return { used: valid.limit, limit: valid.limit, remaining: 0 };
+	return { used, limit: valid.limit, remaining: Math.max(0, valid.limit - used) };
+}
+
+export function childRunFanoutBudget(descriptor: RunFanoutBudgetDescriptor, childPath: string): RunFanoutBudgetDescriptor {
+	const [qualified] = qualifyRunFanoutPaths(descriptor, [childPath]);
+	return { ...descriptor, parentPath: qualified };
+}
+
+export function qualifyRunFanoutPaths(descriptor: RunFanoutBudgetDescriptor, paths: string[]): string[] {
+	const prefix = descriptor.parentPath?.trim();
+	return paths.map((item) => prefix ? `${prefix}/${item}` : item);
+}
+
+export function claimRunFanoutBatch(descriptor: RunFanoutBudgetDescriptor, paths: string[]): RunFanoutBudgetSnapshot {
+	const valid = validateRunFanoutBudgetDescriptor(descriptor);
+	if (paths.length === 0) return getRunFanoutBudgetSnapshot(valid);
+	const qualified = qualifyRunFanoutPaths(valid, paths);
+	return withClaimLock(valid.directory, () => {
+		const before = getRunFanoutBudgetSnapshot(valid);
+		if (qualified.length > before.remaining) {
+			throw new RunFanoutLimitError({ code: "RUN_FANOUT_LIMIT", path: qualified[before.remaining] ?? qualified[0]!, requested: qualified.length, ...before });
+		}
+		const created: string[] = [];
+		try {
+			for (const claimPath of qualified) {
+				for (let slot = 0; slot < valid.limit; slot++) {
+					const slotPath = path.join(valid.directory, "claims", `${String(slot).padStart(6, "0")}.json`);
+					try {
+						const fd = fs.openSync(slotPath, "wx", 0o600);
+						try {
+							const claim: ClaimV1 = { version: 1, claimId: randomUUID(), path: claimPath, claimedAt: Date.now() };
+							fs.writeFileSync(fd, `${JSON.stringify(claim)}\n`, "utf-8");
+						} finally { fs.closeSync(fd); }
+						created.push(slotPath);
+						break;
+					} catch (error) {
+						if ((error as NodeJS.ErrnoException).code === "EEXIST") continue;
+						throw error;
+					}
+				}
+			}
+			return getRunFanoutBudgetSnapshot(valid);
+		} catch (error) {
+			for (const slotPath of created) {
+				try { fs.unlinkSync(slotPath); } catch {}
+			}
+			throw error;
+		}
+	});
+}
+
+export function formatRunFanoutBudget(snapshot: RunFanoutBudgetSnapshot): string {
+	return `Run fan-out: ${snapshot.used}/${snapshot.limit} used, ${snapshot.remaining} remaining`;
+}
+
+export function formatRunFanoutRejection(rejection: RunFanoutRejection): string {
+	return `Run fan-out limit reached at ${rejection.path} (${rejection.used}/${rejection.limit} used; ${rejection.requested} requested, ${rejection.remaining} remaining). No children from this admission group were started. Start a new top-level run or raise config.maxSubagentSpawnsPerRun.`;
+}

--- a/src/runs/shared/run-fanout-budget.ts
+++ b/src/runs/shared/run-fanout-budget.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS, waitForFileSystemRetry } from "../../shared/file-system-retry.ts";
 import {
 	TEMP_ROOT_DIR,
 	type RunFanoutBudgetDescriptor,
@@ -8,7 +9,6 @@ import {
 	type RunFanoutRejection,
 } from "../../shared/types.ts";
 
-export const DEFAULT_MAX_SUBAGENT_SPAWNS_PER_RUN = 64;
 export const RUN_FANOUT_BUDGET_ENV = "PI_SUBAGENT_RUN_FANOUT_BUDGET";
 const RUN_FANOUT_ROOT = path.join(TEMP_ROOT_DIR, "run-fanout-budgets");
 
@@ -64,12 +64,18 @@ function readManifest(directory: string): ManifestV1 {
 }
 
 function validateDirectory(directory: string): string {
-	const resolved = path.resolve(directory);
-	const root = path.resolve(RUN_FANOUT_ROOT);
-	if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
-		throw new Error("Run fan-out budget directory is outside the managed budget root.");
+	let realDirectory: string;
+	let realRoot: string;
+	try {
+		realDirectory = fs.realpathSync(path.resolve(directory));
+		realRoot = fs.realpathSync(path.resolve(RUN_FANOUT_ROOT));
+	} catch (error) {
+		throw new Error(`Run fan-out budget directory is unavailable: ${error instanceof Error ? error.message : String(error)}`);
 	}
-	return resolved;
+	if (realDirectory !== realRoot && !realDirectory.startsWith(`${realRoot}${path.sep}`)) {
+		throw new Error("Run fan-out budget directory resolves outside the managed budget root.");
+	}
+	return realDirectory;
 }
 
 export function createRunFanoutBudget(rootRunId: string, limit: number): RunFanoutBudgetDescriptor {
@@ -131,57 +137,70 @@ export function decodeRunFanoutBudgetDescriptor(encoded: string | undefined): Ru
 	}
 }
 
-const CLAIM_LOCK_WAIT_MS = 5_000;
-const CLAIM_LOCK_RETRY_MS = 10;
-const claimLockWaitArray = new Int32Array(new SharedArrayBuffer(4));
+interface AdmissionLockOwner {
+	pid: number;
+	token: string;
+}
 
-function processIsAlive(pid: number): boolean {
+const ADMISSION_LOCK_STALE_MS = 60_000;
+
+function readAdmissionLockOwner(lockPath: string): AdmissionLockOwner | undefined {
 	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (error) {
-		return (error as NodeJS.ErrnoException).code === "EPERM";
+		const owner = JSON.parse(fs.readFileSync(path.join(lockPath, "owner.json"), "utf-8")) as Partial<AdmissionLockOwner>;
+		if (Number.isSafeInteger(owner.pid) && (owner.pid ?? 0) > 0 && typeof owner.token === "string" && owner.token) return owner as AdmissionLockOwner;
+	} catch {}
+	return undefined;
+}
+
+function admissionLockIsStale(lockPath: string): boolean {
+	const owner = readAdmissionLockOwner(lockPath);
+	if (owner) {
+		try {
+			process.kill(owner.pid, 0);
+			return false;
+		} catch (error) {
+			return (error as NodeJS.ErrnoException).code !== "EPERM";
+		}
+	}
+	try { return Date.now() - fs.statSync(lockPath).mtimeMs > ADMISSION_LOCK_STALE_MS; }
+	catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
 	}
 }
 
-function withClaimLock<T>(directory: string, callback: () => T): T {
-	const lockPath = path.join(directory, "claim.lock");
-	const token = randomUUID();
-	const deadline = Date.now() + CLAIM_LOCK_WAIT_MS;
-	while (true) {
+function withAdmissionLock<T>(directory: string, operation: () => T): T {
+	const lockPath = path.join(directory, "admission.lock");
+	const owner: AdmissionLockOwner = { pid: process.pid, token: randomUUID() };
+	for (let attempt = 0; ; attempt++) {
 		try {
 			fs.mkdirSync(lockPath, { mode: 0o700 });
-			fs.writeFileSync(path.join(lockPath, "owner.json"), `${JSON.stringify({ pid: process.pid, token })}\n`, { mode: 0o600 });
+			try { fs.writeFileSync(path.join(lockPath, "owner.json"), JSON.stringify(owner), { mode: 0o600 }); }
+			catch (error) {
+				fs.rmSync(lockPath, { recursive: true, force: true });
+				throw error;
+			}
 			break;
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-			let stale = false;
-			try {
-				const parsed = JSON.parse(fs.readFileSync(path.join(lockPath, "owner.json"), "utf-8")) as Partial<{ pid: number }>;
-				stale = Number.isInteger(parsed.pid) && (parsed.pid ?? 0) > 0 && !processIsAlive(parsed.pid!);
-			} catch {
-				try { stale = Date.now() - fs.statSync(lockPath).mtimeMs >= CLAIM_LOCK_WAIT_MS; } catch {}
-			}
-			if (stale) {
-				const stalePath = path.join(directory, `claim.stale-${randomUUID()}`);
+			if (admissionLockIsStale(lockPath)) {
+				const stalePath = path.join(directory, `admission.stale-${randomUUID()}`);
 				try {
 					fs.renameSync(lockPath, stalePath);
 					fs.rmSync(stalePath, { recursive: true, force: true });
 					continue;
-				} catch (takeoverError) {
-					if (!(["ENOENT", "EEXIST"] as Array<string | undefined>).includes((takeoverError as NodeJS.ErrnoException).code)) throw takeoverError;
+				} catch (reclaimError) {
+					if ((reclaimError as NodeJS.ErrnoException).code !== "ENOENT") throw reclaimError;
 				}
 			}
-			if (Date.now() >= deadline) throw new Error(`Timed out waiting for run fan-out admission lock at '${directory}'.`);
-			Atomics.wait(claimLockWaitArray, 0, 0, CLAIM_LOCK_RETRY_MS);
+			const delay = DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS[attempt];
+			if (delay === undefined) throw new Error(`Timed out acquiring run fan-out admission lock at '${directory}'.`);
+			waitForFileSystemRetry(delay);
 		}
 	}
-	try { return callback(); }
+	try { return operation(); }
 	finally {
-		try {
-			const current = JSON.parse(fs.readFileSync(path.join(lockPath, "owner.json"), "utf-8")) as Partial<{ token: string }>;
-			if (current.token === token) fs.rmSync(lockPath, { recursive: true, force: true });
-		} catch {}
+		if (readAdmissionLockOwner(lockPath)?.token === owner.token) fs.rmSync(lockPath, { recursive: true, force: true });
 	}
 }
 
@@ -189,14 +208,15 @@ function claimCount(directory: string): number {
 	const claimsDir = path.join(directory, "claims");
 	let entries: fs.Dirent[];
 	try { entries = fs.readdirSync(claimsDir, { withFileTypes: true }); }
-	catch { return Number.POSITIVE_INFINITY; }
+	catch (error) {
+		throw new Error(`Run fan-out claims directory is unreadable at '${claimsDir}': ${error instanceof Error ? error.message : String(error)}`);
+	}
 	return entries.filter((entry) => /^\d{6}\.json$/.test(entry.name)).length;
 }
 
 export function getRunFanoutBudgetSnapshot(descriptor: RunFanoutBudgetDescriptor): RunFanoutBudgetSnapshot {
 	const valid = validateRunFanoutBudgetDescriptor(descriptor);
 	const used = claimCount(valid.directory);
-	if (!Number.isFinite(used)) return { used: valid.limit, limit: valid.limit, remaining: 0 };
 	return { used, limit: valid.limit, remaining: Math.max(0, valid.limit - used) };
 }
 
@@ -210,11 +230,11 @@ export function qualifyRunFanoutPaths(descriptor: RunFanoutBudgetDescriptor, pat
 	return paths.map((item) => prefix ? `${prefix}/${item}` : item);
 }
 
-export function claimRunFanoutBatch(descriptor: RunFanoutBudgetDescriptor, paths: string[]): RunFanoutBudgetSnapshot {
+function commitRunFanoutBatch<T>(descriptor: RunFanoutBudgetDescriptor, paths: string[], commit: (snapshot: RunFanoutBudgetSnapshot) => T): T {
 	const valid = validateRunFanoutBudgetDescriptor(descriptor);
-	if (paths.length === 0) return getRunFanoutBudgetSnapshot(valid);
+	if (paths.length === 0) return commit(getRunFanoutBudgetSnapshot(valid));
 	const qualified = qualifyRunFanoutPaths(valid, paths);
-	return withClaimLock(valid.directory, () => {
+	return withAdmissionLock(valid.directory, () => {
 		const before = getRunFanoutBudgetSnapshot(valid);
 		if (qualified.length > before.remaining) {
 			throw new RunFanoutLimitError({ code: "RUN_FANOUT_LIMIT", path: qualified[before.remaining] ?? qualified[0]!, requested: qualified.length, ...before });
@@ -226,11 +246,11 @@ export function claimRunFanoutBatch(descriptor: RunFanoutBudgetDescriptor, paths
 					const slotPath = path.join(valid.directory, "claims", `${String(slot).padStart(6, "0")}.json`);
 					try {
 						const fd = fs.openSync(slotPath, "wx", 0o600);
+						created.push(slotPath);
 						try {
 							const claim: ClaimV1 = { version: 1, claimId: randomUUID(), path: claimPath, claimedAt: Date.now() };
 							fs.writeFileSync(fd, `${JSON.stringify(claim)}\n`, "utf-8");
 						} finally { fs.closeSync(fd); }
-						created.push(slotPath);
 						break;
 					} catch (error) {
 						if ((error as NodeJS.ErrnoException).code === "EEXIST") continue;
@@ -238,7 +258,7 @@ export function claimRunFanoutBatch(descriptor: RunFanoutBudgetDescriptor, paths
 					}
 				}
 			}
-			return getRunFanoutBudgetSnapshot(valid);
+			return commit(getRunFanoutBudgetSnapshot(valid));
 		} catch (error) {
 			for (const slotPath of created) {
 				try { fs.unlinkSync(slotPath); } catch {}
@@ -246,6 +266,14 @@ export function claimRunFanoutBatch(descriptor: RunFanoutBudgetDescriptor, paths
 			throw error;
 		}
 	});
+}
+
+export function claimRunFanoutBatch(descriptor: RunFanoutBudgetDescriptor, paths: string[]): RunFanoutBudgetSnapshot {
+	return commitRunFanoutBatch(descriptor, paths, (snapshot) => snapshot);
+}
+
+export function claimRunFanoutBatchWithCommit<T>(descriptor: RunFanoutBudgetDescriptor, paths: string[], commit: () => T): T {
+	return commitRunFanoutBatch(descriptor, paths, commit);
 }
 
 export function formatRunFanoutBudget(snapshot: RunFanoutBudgetSnapshot): string {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -478,9 +478,30 @@ export interface SteeringNotice {
 	currentSessionId?: string;
 }
 
+export interface RunFanoutBudgetDescriptor {
+	version: 1;
+	rootRunId: string;
+	directory: string;
+	limit: number;
+	parentPath?: string;
+}
+
+export interface RunFanoutBudgetSnapshot {
+	used: number;
+	limit: number;
+	remaining: number;
+}
+
+export interface RunFanoutRejection extends RunFanoutBudgetSnapshot {
+	code: "RUN_FANOUT_LIMIT";
+	path: string;
+	requested: number;
+}
+
 export interface SteeringRecoveryDescriptor {
 	version: 1;
 	launchContractDigest?: string;
+	runFanoutBudget: RunFanoutBudgetDescriptor;
 	sourceRunId: string;
 	agentContract?: AgentContract;
 	agent: string;
@@ -1040,6 +1061,8 @@ export interface Details {
 	// Aggregated cost across all agents in the run
 	totalCost?: CostSummary;
 	spawnBudget?: SpawnBudgetSnapshot;
+	runFanoutBudget?: RunFanoutBudgetSnapshot;
+	runFanoutRejection?: RunFanoutRejection;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	capabilityAudit?: SubagentCapabilityAudit;
 	parallelHandoff?: ParallelHandoffReference;
@@ -1339,6 +1362,8 @@ export interface AsyncStatus {
 	workflowGraph?: WorkflowGraphSnapshot;
 	checkpoint?: ChainCheckpointState;
 	processTerminal?: ProcessTerminalV1;
+	runFanoutBudget?: RunFanoutBudgetSnapshot;
+	runFanoutBudgetDescriptor?: RunFanoutBudgetDescriptor;
 	launchContractDigest?: string;
 	launchResolvedExtensions?: LaunchResolvedChildExtensionsV1;
 	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensionsV1;
@@ -1752,6 +1777,7 @@ export interface RunSyncOptions {
 	/** Effective parent wait-tool setting propagated to the child runtime. */
 	waitToolEnabled?: boolean;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	nestedRoute?: NestedRouteInfo;
 	/** Override the agent's default model (format: "provider/id" or just "id") */
 	modelOverride?: string;
@@ -1866,6 +1892,8 @@ export interface ExtensionConfig {
 	maxSubagentDepth?: number;
 	/** Optional cumulative session cap. Unset or 0 means unlimited. */
 	maxSubagentSpawnsPerSession?: number;
+	/** Cumulative logical-child cap for one top-level run tree. Defaults to 64. */
+	maxSubagentSpawnsPerRun?: number;
 	/** Global cap on simultaneously-running subagent tasks within a single run. Defaults to 20. */
 	globalConcurrencyLimit?: number;
 	/**
@@ -2091,6 +2119,19 @@ export function resolveMaxSubagentSpawnsPerSession(configMaxSpawns?: number): nu
 	if (envMaxSpawns !== undefined) return envMaxSpawns === 0 ? undefined : envMaxSpawns;
 	const configuredMaxSpawns = normalizeMaxSubagentSpawnsPerSession(configMaxSpawns);
 	return configuredMaxSpawns === 0 ? undefined : configuredMaxSpawns;
+}
+
+export const DEFAULT_MAX_SUBAGENT_SPAWNS_PER_RUN = 64;
+
+export function normalizeMaxSubagentSpawnsPerRun(value: unknown): number | undefined {
+	const normalized = normalizeNonNegativeInteger(value);
+	return normalized !== undefined && normalized > 0 ? normalized : undefined;
+}
+
+export function resolveMaxSubagentSpawnsPerRun(configMaxSpawns?: number): number {
+	return normalizeMaxSubagentSpawnsPerRun(process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN)
+		?? normalizeMaxSubagentSpawnsPerRun(configMaxSpawns)
+		?? DEFAULT_MAX_SUBAGENT_SPAWNS_PER_RUN;
 }
 
 // ============================================================================

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -131,11 +131,11 @@ function hostCall(method, args, observation) {
     : promise;
 }
 
-function runHostCall(key, params, collectFailure) {
+function runHostCall(key, params, collectFailure, batch) {
   const callId = ++nextCallId;
   const promise = new Promise((resolve, reject) => {
     pending.set(callId, { resolve, reject });
-    parentPort.postMessage({ type: "call", callId, method: "run", args: { key, params, ...(collectFailure ? { collectFailure: true } : {}) } });
+    parentPort.postMessage({ type: "call", callId, method: "run", args: { key, params, ...(collectFailure ? { collectFailure: true } : {}), ...(batch ? { batch } : {}) } });
   });
   return { key, callId, promise };
 }
@@ -188,7 +188,8 @@ const runs = Object.freeze({
       calls.push({ key, params });
     }
     for (const { key, params } of calls) runFingerprints.set(key, stableRunJson(params));
-    const launched = calls.map(({ key, params }) => runHostCall(key, params, true));
+    const batch = { id: "batch-" + (++nextCallId), calls };
+    const launched = calls.map(({ key, params }) => runHostCall(key, params, true, batch));
     return trackRunObservation(launched.map(({ key, callId }) => ({ key, callId })), Promise.all(launched.map(({ promise }) => promise)));
   },
   status(keyOrRunId) { return hostCall("status", { keyOrRunId }); },
@@ -363,7 +364,8 @@ export interface RunWorkflowScriptOptions {
 	script: string;
 	timeoutMs?: number;
 	signal?: AbortSignal;
-	launch: (key: string, params: Record<string, unknown>, signal: AbortSignal) => Promise<WorkflowScriptChildResult>;
+	admit?: (calls: Array<{ key: string; params: Record<string, unknown> }>) => void | Promise<void>;
+	launch: (key: string, params: Record<string, unknown>, signal: AbortSignal, admission: { admitted: boolean }) => Promise<WorkflowScriptChildResult>;
 	status: (keyOrRunId: string, signal: AbortSignal) => Promise<WorkflowScriptChildResult>;
 	state?: {
 		get: (key: string) => unknown | Promise<unknown>;
@@ -490,6 +492,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 	const children = new Map<string, WorkflowScriptChildResult>();
 	const childOrder: string[] = [];
 	const launches = new Map<string, { fingerprint: string; promise: Promise<WorkflowScriptChildResult>; observed: boolean }>();
+	const batchAdmissions = new Map<string, Promise<void>>();
 	const observedRunCalls = new Set<number>();
 	const childController = new AbortController();
 	let settled = false;
@@ -680,7 +683,21 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			childOrder.push(key);
 			trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(params) });
 			traceChanged();
-			const promise = Promise.resolve().then(() => options.launch(key, { ...params, async: params.async ?? false }, childController.signal)).then((result) => {
+			const batch = isRecord(message.args.batch) && typeof message.args.batch.id === "string" && Array.isArray(message.args.batch.calls)
+				? { id: message.args.batch.id, calls: message.args.batch.calls.filter((call): call is { key: string; params: Record<string, unknown> } => isRecord(call) && typeof call.key === "string" && isRecord(call.params)) }
+				: undefined;
+			let admission = batch ? batchAdmissions.get(batch.id) : undefined;
+			if (!admission) {
+				const seenKeys = new Set<string>();
+				const calls = (batch?.calls ?? [{ key, params }]).filter((call) => {
+					if (seenKeys.has(call.key) || launches.has(call.key) || call.params.resume !== undefined) return false;
+					seenKeys.add(call.key);
+					return true;
+				});
+				admission = Promise.resolve().then(() => options.admit?.(calls));
+				if (batch) batchAdmissions.set(batch.id, admission);
+			}
+			const promise = admission.then(() => options.launch(key, { ...params, async: params.async ?? false }, childController.signal, { admitted: true })).then((result) => {
 				const normalized = !result.ok && !result.error ? { ...result, error: result.output } : result;
 				children.set(key, normalized);
 				trace.push({ operation: "run", key, state: normalized.ok ? "completed" : "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(normalized.agent ? { agent: normalized.agent } : {}), ...(normalized.runId ? { runId: normalized.runId } : {}), ...(!normalized.ok ? { error: normalized.error ?? normalized.output } : {}) });

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -572,6 +572,8 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			acceptance: false,
 		});
 		assert.match(launch.details.launchContractDigest ?? "", /^[a-f0-9]{64}$/);
+		const recovery = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "recovery-descriptor.json"), "utf-8")) as { runFanoutBudget?: { rootRunId?: string; limit?: number } };
+		assert.deepEqual(recovery.runFanoutBudget && { rootRunId: recovery.runFanoutBudget.rootRunId, limit: recovery.runFanoutBudget.limit }, { rootRunId: id, limit: 64 });
 		const payload = await readAsyncPayload(id);
 		const status = await waitForAsyncState(id, (candidate) => candidate.state === "complete" && candidate.runtimeAcknowledgedExtensions !== undefined);
 		assert.equal(payload.launchContractDigest, launch.details.launchContractDigest);

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -27,6 +27,7 @@ describe("async status helpers", () => {
 				lastUpdate: 200,
 				cwd: "/repo-a",
 				currentStep: 1,
+				runFanoutBudget: { used: 2, limit: 64, remaining: 62 },
 				outputFile,
 				steps: [
 					{ agent: "scout", status: "complete", durationMs: 10, description: "Inspect auth only" },
@@ -51,7 +52,9 @@ describe("async status helpers", () => {
 			assert.equal(runs[0]?.steps[1]?.status, "running");
 			assert.equal(runs[0]?.steps[0]?.description, "Inspect auth only");
 			assert.equal(runs[0]?.steps[1]?.description, "Patch billing only");
-			assert.match(formatAsyncRunList(runs), /output: .*output-1\.log/);
+			const text = formatAsyncRunList(runs);
+			assert.match(text, /Run fan-out: 2\/64 used, 62 remaining/);
+			assert.match(text, /output: .*output-1\.log/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { describe, it } from "node:test";
 import { formatAsyncRunList, listAsyncRuns } from "../../src/runs/background/async-status.ts";
 import { ACTIVE_RUN_INDEX_DIR, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
+import { claimRunFanoutBatch, createRunFanoutBudget, writeRunFanoutBudgetDescriptor } from "../../src/runs/shared/run-fanout-budget.ts";
 
 function createAsyncDir(root: string, id: string, status: Record<string, unknown>): string {
 	const dir = path.join(root, id);
@@ -17,9 +18,10 @@ function createAsyncDir(root: string, id: string, status: Record<string, unknown
 describe("async status helpers", () => {
 	it("lists only requested states and includes flattened step summaries", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-"));
+		let budgetDirectory: string | undefined;
 		try {
 			const outputFile = path.join(root, "run-a", "output-1.log");
-			createAsyncDir(root, "run-a", {
+			const runDir = createAsyncDir(root, "run-a", {
 				runId: "run-a",
 				mode: "chain",
 				state: "running",
@@ -34,6 +36,10 @@ describe("async status helpers", () => {
 					{ agent: "worker", status: "running", durationMs: 20, description: "Patch billing only" },
 				],
 			});
+			const descriptor = createRunFanoutBudget("run-a", 64);
+			budgetDirectory = descriptor.directory;
+			writeRunFanoutBudgetDescriptor(runDir, descriptor);
+			claimRunFanoutBatch(descriptor, ["chain[0]", "chain[1]", "chain[1]/single"]);
 			createAsyncDir(root, "run-b", {
 				runId: "run-b",
 				mode: "single",
@@ -53,10 +59,11 @@ describe("async status helpers", () => {
 			assert.equal(runs[0]?.steps[0]?.description, "Inspect auth only");
 			assert.equal(runs[0]?.steps[1]?.description, "Patch billing only");
 			const text = formatAsyncRunList(runs);
-			assert.match(text, /Run fan-out: 2\/64 used, 62 remaining/);
+			assert.match(text, /Run fan-out: 3\/64 used, 61 remaining/);
 			assert.match(text, /output: .*output-1\.log/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
+			if (budgetDirectory) fs.rmSync(budgetDirectory, { recursive: true, force: true });
 		}
 	});
 

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import { after, afterEach, before, beforeEach, describe, it } from "node:test";
 import { ASYNC_DIR, INTERCOM_DETACH_REQUEST_EVENT, RESULTS_DIR, SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT } from "../../src/shared/types.ts";
 import { waitForSubagents } from "../../src/runs/background/subagent-wait.ts";
+import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
 import { sessionLeaseDir } from "../../src/runs/shared/session-lease.ts";
 import type { MockPi } from "../support/helpers.ts";
 import {
@@ -82,6 +83,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 	let mockPi: MockPi;
 	let originalHome: string | undefined;
 	let originalUserProfile: string | undefined;
+	let budgetDirectories: string[] = [];
 
 	before(() => {
 		originalHome = process.env.HOME;
@@ -112,6 +114,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 	afterEach(() => {
 		removeTempDir(tempDir);
+		for (const directory of budgetDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
 	});
 
 	async function readMockCallArgs(index: number): Promise<string[]> {
@@ -160,6 +163,25 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			if (Date.now() > deadline) assert.fail(`Timed out waiting for path cleanup: ${filePath}`);
 			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
+	}
+
+	function writeRecoveryDescriptor(asyncDir: string, runId: string, agent = "worker", overrides: Record<string, unknown> = {}): void {
+		const runFanoutBudget = createRunFanoutBudget(runId, 64);
+		budgetDirectories.push(runFanoutBudget.directory);
+		fs.writeFileSync(path.join(asyncDir, "recovery-descriptor.json"), JSON.stringify({
+			version: 1,
+			runFanoutBudget,
+			sourceRunId: runId,
+			agent,
+			cwd: tempDir,
+			systemPromptMode: "replace",
+			inheritProjectContext: false,
+			inheritSkills: false,
+			outputMode: "inline",
+			maxSubagentDepth: 2,
+			share: false,
+			...overrides,
+		}, null, 2), "utf-8");
 	}
 
 	function makeExecutor(options: { bridgeMode?: "always" | "off"; resultDelivery?: boolean; agents?: ReturnType<typeof makeAgent>[]; acknowledgeResults?: boolean; kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean } = {}) {
@@ -270,6 +292,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				sessionFile,
 				steps: [{ agent: "worker", status: "complete", sessionFile }],
 			}, null, 2), "utf-8");
+			writeRecoveryDescriptor(sourceAsyncDir, sourceRunId);
 			const { executor } = makeExecutor();
 
 			const result = await executor.execute(
@@ -846,6 +869,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 					{ agent: "b", status: "complete", sessionFile: secondSession, model: "anthropic/claude-sonnet-4", thinking: "high" },
 				],
 			}, null, 2), "utf-8");
+			writeRecoveryDescriptor(asyncDir, runId, "b", { model: "anthropic/claude-sonnet-4:high" });
 			const { executor } = makeExecutor({ agents: [makeAgent("a"), makeAgent("b")] });
 
 			const result = await executor.execute(
@@ -887,6 +911,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				sessionFile,
 				steps: [{ agent: "worker", status: "complete", launchContractDigest: "source-launch-contract-digest" }],
 			}, null, 2), "utf-8");
+			writeRecoveryDescriptor(asyncDir, runId, "worker", { launchContractDigest: "source-launch-contract-digest" });
 			const { executor, events } = makeExecutor();
 
 			const result = await executor.execute(
@@ -932,21 +957,12 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				runId, sessionId: "session-123", mode: "single", state: "paused", startedAt: 100, lastUpdate: 200, cwd: tempDir,
 				steps: [{ agent: "removed-worker", status: "paused", sessionFile }],
 			}, null, 2), "utf-8");
-			fs.writeFileSync(path.join(asyncDir, "recovery-descriptor.json"), JSON.stringify({
-				version: 1,
-				sourceRunId: runId,
-				agent: "removed-worker",
-				cwd: tempDir,
+			writeRecoveryDescriptor(asyncDir, runId, "removed-worker", {
 				model: "anthropic/claude-sonnet-4:high",
 				tools: ["read"],
 				systemPrompt: "Original persisted prompt",
-				systemPromptMode: "replace",
-				inheritProjectContext: false,
-				inheritSkills: false,
-				outputMode: "inline",
 				maxSubagentDepth: 1,
-				share: false,
-			}, null, 2), "utf-8");
+			});
 			const { executor } = makeExecutor({ agents: [] });
 
 			const result = await executor.execute(
@@ -992,6 +1008,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			sessionFile,
 			steps: [{ agent: "worker", status: "complete" }],
 		}, null, 2), "utf-8");
+		writeRecoveryDescriptor(sourceAsyncDir, sourceRunId);
 		try {
 			const { executor } = makeExecutor();
 			const first = await executor.execute(

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -41,6 +41,7 @@ import { ACTIVE_RUN_INDEX_DIR } from "../../src/runs/background/active-run-index
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
 import { TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV } from "../../src/runs/shared/tool-budget.ts";
+import { createRunFanoutBudget, encodeRunFanoutBudgetDescriptor, RUN_FANOUT_BUDGET_ENV } from "../../src/runs/shared/run-fanout-budget.ts";
 import { MainWatchdogRuntime } from "../../src/watchdog/runtime.ts";
 import { MAX_CHILD_PENDING_LINE_BYTES, MAX_CHILD_STDERR_BYTES } from "../../src/runs/shared/child-protocol.ts";
 import {
@@ -394,6 +395,19 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.isError, true);
 		assert.match(result.content[0]?.text ?? "", /Direct execution was removed/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
+	it("rejects internal fan-out fields from public workflows", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([makeAgent("echo")]);
+		for (const params of [
+			{ workflowScript: `return runs.run("main", { agent: "echo", task: "work" })`, runFanoutBudget: { version: 1 } },
+			{ workflowScript: `return runs.run("main", { agent: "echo", task: "work" })`, runFanoutAdmitted: true },
+		] as const) {
+			const result = await executor.executePublic("private-fanout", params, new AbortController().signal, undefined, makeMinimalCtx(tempDir));
+			assert.equal(result.isError, true);
+			assert.match(result.content[0]?.text ?? "", /does not accept internal run fan-out fields/);
+		}
 		assert.equal(mockPi.callCount(), 0);
 	});
 
@@ -1910,6 +1924,27 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(second.isError, true);
 		assert.match(second.content[0]?.text ?? "", /Subagent spawn limit reached for this session \(1\/1 used, 1 requested\)/);
 		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("qualifies inherited nested claims with the generated nested run id", async () => {
+		mockPi.onCall({ output: "nested completed" });
+		const descriptor = createRunFanoutBudget("root-run", 2);
+		const previous = process.env[RUN_FANOUT_BUDGET_ENV];
+		try {
+			process.env[RUN_FANOUT_BUDGET_ENV] = encodeRunFanoutBudgetDescriptor({ ...descriptor, parentPath: "tasks[0]" });
+			const executor = makeExecutor([makeAgent("echo")]);
+			const result = await executor.execute("nested", { agent: "echo", task: "Nested work" }, new AbortController().signal, undefined, makeMinimalCtx(tempDir));
+
+			assert.equal(result.isError, undefined, result.content[0]?.text ?? "nested run failed");
+			const claims = fs.readdirSync(path.join(descriptor.directory, "claims"));
+			assert.equal(claims.length, 1);
+			const claim = JSON.parse(fs.readFileSync(path.join(descriptor.directory, "claims", claims[0]!), "utf-8")) as { path: string };
+			assert.match(claim.path, /^tasks\[0\]\/[a-f0-9]{8}\/single$/);
+		} finally {
+			if (previous === undefined) delete process.env[RUN_FANOUT_BUDGET_ENV];
+			else process.env[RUN_FANOUT_BUDGET_ENV] = previous;
+			fs.rmSync(descriptor.directory, { recursive: true, force: true });
+		}
 	});
 
 	it("rejects an over-limit static run fan-out before creating session artifacts", async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1124,6 +1124,30 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(result.details.workflow?.trace.filter((entry) => entry.state !== "started").map(({ state }) => state).sort(), ["completed", "failed"]);
 	});
 
+	it("rejects an over-limit runs.all batch before launching any workflow child", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([makeAgent("echo")], { maxSubagentSpawnsPerRun: 1 });
+
+		const result = await executor.execute(
+			"scripted-workflow-fanout-limit",
+			{
+				async: false,
+				workflowScript: `return await runs.all([
+					{ key: "first", agent: "echo", task: "First task" },
+					{ key: "second", agent: "echo", task: "Second task" }
+				]);`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		assert.equal(mockPi.callCount(), 0);
+		const children = result.details.workflow?.value as Array<{ ok: boolean; error?: string }>;
+		assert.deepEqual(children.map(({ ok }) => ok), [false, false]);
+		for (const child of children) assert.match(child.error ?? "", /workflow\[second\].*0\/1 used; 2 requested, 1 remaining/);
+	});
+
 	it("runs a direct child gate as host-verified acceptance", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const markerFile = "direct-gate.txt";
 		const markerPath = path.join(tempDir, markerFile);
@@ -1886,6 +1910,25 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(second.isError, true);
 		assert.match(second.content[0]?.text ?? "", /Subagent spawn limit reached for this session \(1\/1 used, 1 requested\)/);
 		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("rejects an over-limit static run fan-out before creating session artifacts", async () => {
+		const sessionDir = path.join(tempDir, "run-fanout-preflight");
+		const executor = makeExecutor([makeAgent("echo"), makeAgent("second")], { maxSubagentSpawnsPerRun: 1 });
+		const result = await executor.execute(
+			"run-fanout-preflight",
+			{ tasks: [{ agent: "echo", task: "First" }, { agent: "second", task: "Second" }], sessionDir },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /Run fan-out limit reached at tasks\[1\] \(0\/1 used; 2 requested, 1 remaining\)/);
+		assert.deepEqual(result.details.runFanoutBudget, { used: 0, limit: 1, remaining: 1 });
+		assert.equal(result.details.runFanoutRejection?.path, "tasks[1]");
+		assert.equal(fs.existsSync(sessionDir), false);
+		assert.equal(mockPi.callCount(), 0);
 	});
 
 	it("reports structured spawn-budget usage through status", async () => {

--- a/test/unit/async-recovery-descriptor.test.ts
+++ b/test/unit/async-recovery-descriptor.test.ts
@@ -2,8 +2,21 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { readAsyncRecoveryDescriptor } from "../../src/runs/background/async-resume.ts";
+import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
+
+const budgetDirectories: string[] = [];
+
+function runFanoutBudget(runId: string) {
+	const descriptor = createRunFanoutBudget(runId, 64);
+	budgetDirectories.push(descriptor.directory);
+	return descriptor;
+}
+
+afterEach(() => {
+	for (const directory of budgetDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
 
 describe("async recovery descriptor", () => {
 	it("accepts launchContractDigest written by async execution", () => {
@@ -13,6 +26,7 @@ describe("async recovery descriptor", () => {
 			fs.writeFileSync(path.join(root, "recovery-descriptor.json"), JSON.stringify({
 				version: 1,
 				launchContractDigest: digest,
+				runFanoutBudget: runFanoutBudget("run-digest"),
 				sourceRunId: "run-digest",
 				agent: "worker",
 				cwd: root,
@@ -38,6 +52,7 @@ describe("async recovery descriptor", () => {
 			fs.writeFileSync(path.join(root, "recovery-descriptor.json"), JSON.stringify({
 				version: 1,
 				launchContractDigest: {},
+				runFanoutBudget: runFanoutBudget("run-bad-digest"),
 				sourceRunId: "run-digest",
 				agent: "worker",
 				cwd: root,

--- a/test/unit/async-resume.test.ts
+++ b/test/unit/async-resume.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { buildRevivedAsyncTask, resolveAsyncResumeTarget } from "../../src/runs/background/async-resume.ts";
+import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
 
 function writeJson(filePath: string, value: object): void {
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -97,7 +98,7 @@ describe("async resume lookup", () => {
 				steps: [{ agent: "worker", status: "paused", sessionFile }],
 			});
 			const descriptor = {
-				version: 1, sourceRunId: "run-descriptor", agent: "worker", cwd: root, systemPromptMode: "replace",
+				version: 1, runFanoutBudget: createRunFanoutBudget("run-descriptor", 64), sourceRunId: "run-descriptor", agent: "worker", cwd: root, systemPromptMode: "replace",
 				inheritProjectContext: false, inheritSkills: false, outputMode: "inline", maxSubagentDepth: 2, share: false,
 			};
 			writeJson(path.join(asyncDir, "recovery-descriptor.json"), { ...descriptor, token: "must-not-be-accepted" });
@@ -141,6 +142,7 @@ describe("async resume lookup", () => {
 			});
 			const descriptor = {
 				version: 1,
+				runFanoutBudget: createRunFanoutBudget("run-turn-budget", 64),
 				sourceRunId: "run-turn-budget",
 				agent: "worker",
 				cwd: root,
@@ -195,6 +197,7 @@ describe("async resume lookup", () => {
 			});
 			writeJson(path.join(asyncDir, "recovery-descriptor.json"), {
 				version: 1,
+				runFanoutBudget: createRunFanoutBudget("run-acceptance", 64),
 				sourceRunId: "run-acceptance",
 				agent: "worker",
 				cwd: root,
@@ -244,6 +247,7 @@ describe("async resume lookup", () => {
 			});
 			writeJson(path.join(asyncDir, "recovery-descriptor.json"), {
 				version: 1,
+				runFanoutBudget: createRunFanoutBudget("run-reviewed-acceptance", 64),
 				sourceRunId: "run-reviewed-acceptance",
 				agent: "worker",
 				cwd: root,
@@ -288,6 +292,7 @@ describe("async resume lookup", () => {
 			});
 			writeJson(path.join(asyncDir, "recovery-descriptor.json"), {
 				version: 1,
+				runFanoutBudget: createRunFanoutBudget("run-inferred-acceptance", 64),
 				sourceRunId: "run-inferred-acceptance",
 				agent: "worker",
 				cwd: root,

--- a/test/unit/chain-append.test.ts
+++ b/test/unit/chain-append.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../src/runs/background/chain-append.ts";
 import type { AsyncStatus } from "../../src/shared/types.ts";
 import type { RunnerStep } from "../../src/runs/shared/parallel-utils.ts";
+import { claimRunFanoutBatchWithCommit, createRunFanoutBudget, getRunFanoutBudgetSnapshot } from "../../src/runs/shared/run-fanout-budget.ts";
 import { PROMPT_REDACTED } from "../../src/shared/utils.ts";
 import { createTempDir, removeTempDir } from "../support/helpers.ts";
 
@@ -68,6 +69,75 @@ describe("chain append requests", () => {
 			assert.equal(consumed[0]!.id, result.request.id);
 			assert.equal(countPendingChainAppendRequests(asyncDir), 0);
 		} finally {
+			removeTempDir(root);
+		}
+	});
+
+	it("persists the request inside the admission callback", () => {
+		const root = createTempDir("pi-chain-append-admission-");
+		try {
+			const asyncDir = path.join(root, "run-admission");
+			writeStatus(asyncDir, {
+				runId: "run-admission",
+				mode: "chain",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "scout", status: "running" }],
+			});
+			let admitted = false;
+			const result = enqueueChainAppendRequest({
+				asyncDir,
+				runId: "run-admission",
+				steps: [runnerStep("worker")],
+				now: 200,
+				admit: (persist) => {
+					assert.equal(countPendingChainAppendRequests(asyncDir), 0);
+					persist();
+					admitted = true;
+				},
+			});
+
+			assert.equal(admitted, true);
+			assert.equal(result.pendingCount, 1);
+		} finally {
+			removeTempDir(root);
+		}
+	});
+
+	it("reports accepted appends and keeps admission claims when bookkeeping fails after persistence", () => {
+		const root = createTempDir("pi-chain-append-bookkeeping-");
+		const budget = createRunFanoutBudget("append-bookkeeping", 1);
+		try {
+			const asyncDir = path.join(root, "run-bookkeeping");
+			writeStatus(asyncDir, {
+				runId: "run-bookkeeping",
+				mode: "chain",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "scout", status: "running" }],
+			});
+			const statusPath = path.join(asyncDir, "status.json");
+			fs.mkdirSync(path.join(asyncDir, "events.jsonl"));
+
+			const result = enqueueChainAppendRequest({
+				asyncDir,
+				runId: "run-bookkeeping",
+				steps: [runnerStep("worker")],
+				now: 200,
+				admit: (persist) => claimRunFanoutBatchWithCommit(budget, ["chain[1]"], () => {
+					persist();
+					fs.rmSync(statusPath, { force: true });
+					fs.mkdirSync(statusPath);
+				}),
+			});
+
+			assert.equal(result.pendingCount, 1);
+			assert.match(result.bookkeepingError ?? "", /status update failed/);
+			assert.match(result.bookkeepingError ?? "", /event append failed/);
+			assert.equal(readPendingChainAppendRequests(asyncDir).length, 1);
+			assert.deepEqual(getRunFanoutBudgetSnapshot(budget), { used: 1, limit: 1, remaining: 0 });
+		} finally {
+			fs.rmSync(budget.directory, { recursive: true, force: true });
 			removeTempDir(root);
 		}
 	});

--- a/test/unit/doctor.test.ts
+++ b/test/unit/doctor.test.ts
@@ -116,6 +116,8 @@ describe("buildDoctorReport", () => {
 			assert.match(report, /Spawn budget\n- usage: 3\/5 used, 2 remaining \(configured 4; granted 1; grant allowance 3\)/);
 			assert.match(report, /- recent grants: \+1 at 1970-01-01T00:00:00\.000Z \(4 → 5\)/);
 			assert.match(report, /new parent session resets usage and grants; compaction does not/);
+			assert.match(report, /Run fan-out budget\n- configured limit: 64 \(default\)/);
+			assert.match(report, /cumulative claims are never released; a new top-level run creates a new budget/);
 			assert.match(report, /- skills: total 2 \(project 1, user-package 1\)/);
 			assert.match(report, /- bridge: active/);
 			assert.match(report, /- supervisor channel: available \(native:pi-subagents-supervisor-channel\)/);

--- a/test/unit/doctor.test.ts
+++ b/test/unit/doctor.test.ts
@@ -127,6 +127,30 @@ describe("buildDoctorReport", () => {
 		}
 	});
 
+	it("reports the effective source when the run fan-out environment value is invalid", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-doctor-fanout-source-"));
+		const previous = process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN;
+		try {
+			process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN = "invalid";
+			const report = buildDoctorReport({
+				cwd: root,
+				config: { maxSubagentSpawnsPerRun: 12 },
+				state: makeState(root),
+				deps: {
+					isAsyncAvailable: () => true,
+					discoverAgentsAll: () => ({ builtin: [], user: [], project: [], chains: [], userDir: root, projectDir: root, userChainDir: root, projectChainDir: root, userSettingsPath: path.join(root, "user.json"), projectSettingsPath: path.join(root, "project.json") }),
+					discoverAvailableSkills: () => [],
+					diagnoseIntercomBridge: () => ({ active: false, mode: "off", wantsIntercom: false, supervisorChannelAvailable: false, extensionDir: "none" }),
+				},
+			});
+			assert.match(report, /Run fan-out budget\n- configured limit: 12 \(config\)/);
+		} finally {
+			if (previous === undefined) delete process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN;
+			else process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN = previous;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps reporting when a directory or discovery check fails", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-doctor-failure-"));
 		try {

--- a/test/unit/public-execution.test.ts
+++ b/test/unit/public-execution.test.ts
@@ -12,6 +12,17 @@ describe("public subagent execution normalization", () => {
 		);
 	});
 
+	it("rejects private run fan-out fields at the public boundary", () => {
+		for (const params of [
+			{ workflowScript: "return 1", runFanoutBudget: { version: 1 } },
+			{ workflowScript: "return 1", runFanoutAdmitted: true },
+		] as const) {
+			const result = normalizePublicSubagentExecution(params);
+			assert.equal(result.ok, false);
+			if (!result.ok) assert.match(result.error, /does not accept internal run fan-out fields/);
+		}
+	});
+
 	it("rejects removed public execution shapes", () => {
 		for (const params of [
 			{ action: " " },

--- a/test/unit/run-fanout-budget.test.ts
+++ b/test/unit/run-fanout-budget.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import { afterEach, describe, it } from "node:test";
 import {
 	claimRunFanoutBatch,
+	claimRunFanoutBatchWithCommit,
 	createRunFanoutBudget,
 	decodeRunFanoutBudgetDescriptor,
 	encodeRunFanoutBudgetDescriptor,
@@ -15,10 +17,12 @@ import {
 import { resolveMaxSubagentSpawnsPerRun } from "../../src/shared/types.ts";
 
 const directories: string[] = [];
+const externalDirectories: string[] = [];
 const previousEnv = process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN;
 
 afterEach(() => {
 	for (const directory of directories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+	for (const directory of externalDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
 	if (previousEnv === undefined) delete process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN;
 	else process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN = previousEnv;
 });
@@ -64,26 +68,54 @@ describe("run fan-out budget", () => {
 		assert.deepEqual(getRunFanoutBudgetSnapshot(descriptor), { used: 1, limit: 2, remaining: 1 });
 	});
 
-	it("admits exactly one simultaneous process for the last slot", async () => {
-		const descriptor = budget(1);
-		const modulePath = fileURLToPath(new URL("../../src/runs/shared/run-fanout-budget.ts", import.meta.url));
-		const script = `import { claimRunFanoutBatch } from ${JSON.stringify(modulePath)}; const descriptor = JSON.parse(process.argv[1]); try { claimRunFanoutBatch(descriptor, [process.argv[2]]); process.stdout.write("admitted"); } catch { process.stdout.write("rejected"); }`;
-		const launch = (claimPath: string) => new Promise<string>((resolve, reject) => {
-			const child = spawn(process.execPath, ["--experimental-strip-types", "--input-type=module", "--eval", script, JSON.stringify(descriptor), claimPath], { stdio: ["ignore", "pipe", "pipe"] });
-			let stdout = "";
-			let stderr = "";
-			child.stdout.on("data", (chunk) => { stdout += chunk; });
-			child.stderr.on("data", (chunk) => { stderr += chunk; });
-			child.on("error", reject);
-			child.on("close", (code) => code === 0 ? resolve(stdout) : reject(new Error(stderr)));
-		});
-
-		assert.deepEqual((await Promise.all([launch("nested[a]"), launch("nested[b]")])).sort(), ["admitted", "rejected"]);
-		assert.deepEqual(getRunFanoutBudgetSnapshot(descriptor), { used: 1, limit: 1, remaining: 0 });
+	it("rolls back a batch when its commit fails", () => {
+		const descriptor = budget(2);
+		claimRunFanoutBatch(descriptor, ["existing"]);
+		assert.throws(
+			() => claimRunFanoutBatchWithCommit(descriptor, ["append"], () => { throw new Error("enqueue failed"); }),
+			/enqueue failed/,
+		);
+		assert.deepEqual(getRunFanoutBudgetSnapshot(descriptor), { used: 1, limit: 2, remaining: 1 });
 	});
 
-	it("fails closed when descriptor identity does not match the manifest", () => {
+	it("reports claims-directory I/O errors instead of ordinary exhaustion", () => {
+		const descriptor = budget(2);
+		fs.rmSync(path.join(descriptor.directory, "claims"), { recursive: true });
+		fs.writeFileSync(path.join(descriptor.directory, "claims"), "not a directory", "utf-8");
+		assert.throws(() => getRunFanoutBudgetSnapshot(descriptor), /claims directory is unreadable.*ENOTDIR/);
+	});
+
+	it("admits exactly one simultaneous two-slot batch at limit two", async () => {
+		const moduleUrl = new URL("../../src/runs/shared/run-fanout-budget.ts", import.meta.url).href;
+		const script = `import { claimRunFanoutBatch } from ${JSON.stringify(moduleUrl)}; const descriptor = JSON.parse(process.argv[1]); try { claimRunFanoutBatch(descriptor, [process.argv[2] + "[0]", process.argv[2] + "[1]"]); process.stdout.write("admitted"); } catch { process.stdout.write("rejected"); }`;
+		for (let iteration = 0; iteration < 12; iteration++) {
+			const descriptor = budget(2);
+			const launch = (claimPath: string) => new Promise<string>((resolve, reject) => {
+				const child = spawn(process.execPath, ["--experimental-strip-types", "--input-type=module", "--eval", script, JSON.stringify(descriptor), claimPath], { stdio: ["ignore", "pipe", "pipe"] });
+				let stdout = "";
+				let stderr = "";
+				child.stdout.on("data", (chunk) => { stdout += chunk; });
+				child.stderr.on("data", (chunk) => { stderr += chunk; });
+				child.on("error", reject);
+				child.on("close", (code) => code === 0 ? resolve(stdout) : reject(new Error(stderr)));
+			});
+
+			assert.deepEqual((await Promise.all([launch("group-a"), launch("group-b")])).sort(), ["admitted", "rejected"], `iteration ${iteration}`);
+			assert.deepEqual(getRunFanoutBudgetSnapshot(descriptor), { used: 2, limit: 2, remaining: 0 });
+		}
+	});
+
+	it("fails closed when descriptor identity or managed-root containment is invalid", () => {
 		const descriptor = budget(2);
 		assert.throws(() => validateRunFanoutBudgetDescriptor({ ...descriptor, limit: 3 }), /does not match/);
+
+		const outside = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-fanout-outside-"));
+		externalDirectories.push(outside);
+		fs.mkdirSync(path.join(outside, "claims"));
+		fs.writeFileSync(path.join(outside, "manifest.json"), JSON.stringify({ version: 1, rootRunId: descriptor.rootRunId, limit: 2, createdAt: Date.now() }));
+		const linked = path.join(path.dirname(descriptor.directory), `linked-${Date.now()}`);
+		fs.symlinkSync(outside, linked, process.platform === "win32" ? "junction" : "dir");
+		directories.push(linked);
+		assert.throws(() => validateRunFanoutBudgetDescriptor({ ...descriptor, directory: linked }), /resolves outside/);
 	});
 });

--- a/test/unit/run-fanout-budget.test.ts
+++ b/test/unit/run-fanout-budget.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, it } from "node:test";
+import {
+	claimRunFanoutBatch,
+	createRunFanoutBudget,
+	decodeRunFanoutBudgetDescriptor,
+	encodeRunFanoutBudgetDescriptor,
+	getRunFanoutBudgetSnapshot,
+	RunFanoutLimitError,
+	validateRunFanoutBudgetDescriptor,
+} from "../../src/runs/shared/run-fanout-budget.ts";
+import { resolveMaxSubagentSpawnsPerRun } from "../../src/shared/types.ts";
+
+const directories: string[] = [];
+const previousEnv = process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN;
+
+afterEach(() => {
+	for (const directory of directories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+	if (previousEnv === undefined) delete process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN;
+	else process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN = previousEnv;
+});
+
+function budget(limit: number) {
+	const descriptor = createRunFanoutBudget(`test-${Date.now()}-${Math.random()}`, limit);
+	directories.push(descriptor.directory);
+	return descriptor;
+}
+
+describe("run fan-out budget", () => {
+	it("resolves environment over config and falls back to 64", () => {
+		delete process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN;
+		assert.equal(resolveMaxSubagentSpawnsPerRun(undefined), 64);
+		assert.equal(resolveMaxSubagentSpawnsPerRun(12), 12);
+		for (const invalid of [0, -1, 1.5, "bad"]) assert.equal(resolveMaxSubagentSpawnsPerRun(invalid as number), 64);
+		process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN = "7";
+		assert.equal(resolveMaxSubagentSpawnsPerRun(12), 7);
+		for (const invalid of ["0", "-1", "1.5", "bad"]) {
+			process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN = invalid;
+			assert.equal(resolveMaxSubagentSpawnsPerRun(undefined), 64);
+		}
+	});
+
+	it("persists claims and rejects the responsible next path at the exact cap", () => {
+		const descriptor = budget(2);
+		assert.deepEqual(claimRunFanoutBatch(descriptor, ["tasks[0]", "tasks[1]"]), { used: 2, limit: 2, remaining: 0 });
+		const restored = decodeRunFanoutBudgetDescriptor(encodeRunFanoutBudgetDescriptor(descriptor));
+		assert.deepEqual(getRunFanoutBudgetSnapshot(restored!), { used: 2, limit: 2, remaining: 0 });
+		assert.throws(() => claimRunFanoutBatch(descriptor, ["tasks[2]"]), (error: unknown) => {
+			assert.ok(error instanceof RunFanoutLimitError);
+			assert.equal(error.rejection.path, "tasks[2]");
+			assert.equal(error.rejection.used, 2);
+			assert.equal(error.rejection.remaining, 0);
+			return true;
+		});
+	});
+
+	it("rolls back only the failed admission batch", () => {
+		const descriptor = budget(2);
+		claimRunFanoutBatch(descriptor, ["single"]);
+		assert.throws(() => claimRunFanoutBatch(descriptor, ["chain[0]", "chain[1]"]), RunFanoutLimitError);
+		assert.deepEqual(getRunFanoutBudgetSnapshot(descriptor), { used: 1, limit: 2, remaining: 1 });
+	});
+
+	it("admits exactly one simultaneous process for the last slot", async () => {
+		const descriptor = budget(1);
+		const modulePath = fileURLToPath(new URL("../../src/runs/shared/run-fanout-budget.ts", import.meta.url));
+		const script = `import { claimRunFanoutBatch } from ${JSON.stringify(modulePath)}; const descriptor = JSON.parse(process.argv[1]); try { claimRunFanoutBatch(descriptor, [process.argv[2]]); process.stdout.write("admitted"); } catch { process.stdout.write("rejected"); }`;
+		const launch = (claimPath: string) => new Promise<string>((resolve, reject) => {
+			const child = spawn(process.execPath, ["--experimental-strip-types", "--input-type=module", "--eval", script, JSON.stringify(descriptor), claimPath], { stdio: ["ignore", "pipe", "pipe"] });
+			let stdout = "";
+			let stderr = "";
+			child.stdout.on("data", (chunk) => { stdout += chunk; });
+			child.stderr.on("data", (chunk) => { stderr += chunk; });
+			child.on("error", reject);
+			child.on("close", (code) => code === 0 ? resolve(stdout) : reject(new Error(stderr)));
+		});
+
+		assert.deepEqual((await Promise.all([launch("nested[a]"), launch("nested[b]")])).sort(), ["admitted", "rejected"]);
+		assert.deepEqual(getRunFanoutBudgetSnapshot(descriptor), { used: 1, limit: 1, remaining: 0 });
+	});
+
+	it("fails closed when descriptor identity does not match the manifest", () => {
+		const descriptor = budget(2);
+		assert.throws(() => validateRunFanoutBudgetDescriptor({ ...descriptor, limit: 3 }), /does not match/);
+	});
+});

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { inspectSubagentStatus } from "../../src/runs/background/run-status.ts";
 import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
+import { claimRunFanoutBatch, createRunFanoutBudget, writeRunFanoutBudgetDescriptor } from "../../src/runs/shared/run-fanout-budget.ts";
 import { TEMP_ROOT_DIR, type SubagentState } from "../../src/shared/types.ts";
 
 function errno(code: string): NodeJS.ErrnoException {
@@ -22,6 +23,7 @@ function textContent(result: ReturnType<typeof inspectSubagentStatus>): string {
 describe("async run status inspection", () => {
 	it("repairs stale running status and reports diagnosis plus result path", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-stale-"));
+		let budgetDirectory: string | undefined;
 		try {
 			const asyncRoot = path.join(root, "runs");
 			const resultsDir = path.join(root, "results");
@@ -40,6 +42,10 @@ describe("async run status inspection", () => {
 				sessionFile,
 				steps: [{ agent: "scout", status: "running", startedAt: 100, sessionFile }],
 			}, null, 2), "utf-8");
+			const descriptor = createRunFanoutBudget("run-stale", 64);
+			budgetDirectory = descriptor.directory;
+			writeRunFanoutBudgetDescriptor(asyncDir, descriptor);
+			claimRunFanoutBatch(descriptor, ["single"]);
 
 			const result = inspectSubagentStatus({ id: "run-stale" }, {
 				asyncDirRoot: asyncRoot,
@@ -51,6 +57,8 @@ describe("async run status inspection", () => {
 			const text = textContent(result);
 			assert.equal(result.isError, undefined);
 			assert.match(text, /State: failed/);
+			assert.match(text, /Run fan-out: 1\/64 used, 63 remaining/);
+			assert.deepEqual(result.details.runFanoutBudget, { used: 1, limit: 64, remaining: 63 });
 			assert.match(text, /Diagnosis: Async runner process 12345 exited or disappeared/);
 			assert.match(text, new RegExp(`Result: ${path.join(resultsDir, "run-stale.json").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
 			assert.match(text, /Step 1: scout failed, error: Async runner process 12345 exited or disappeared/);
@@ -60,6 +68,7 @@ describe("async run status inspection", () => {
 			assert.equal(resultJson.results[0].sessionFile, sessionFile);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
+			if (budgetDirectory) fs.rmSync(budgetDirectory, { recursive: true, force: true });
 		}
 	});
 

--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -2,11 +2,12 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { writeAtomicJson, writePrivateAtomicJson } from "../../src/shared/atomic-json.ts";
 import { closeSteerInbox, interruptRequestPath, steerRequestsDir, writeSteerAck, type SteerRequest } from "../../src/runs/background/control-channel.ts";
 import { steerAsyncRun } from "../../src/runs/foreground/async-steering-action.ts";
 import { createSteeringStatus, recordSteeringRequest, updateSteeringTarget } from "../../src/runs/background/steering.ts";
+import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
 import { ASYNC_DIR, type AsyncStatus, type Details, type SteeringRecoveryDescriptor, type SteeringTargetState, type SubagentState } from "../../src/shared/types.ts";
 
 function createState(): SubagentState {
@@ -29,6 +30,11 @@ function createState(): SubagentState {
 }
 
 let statusWriteMtimeMs = Date.now();
+const budgetDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of budgetDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
 
 function writeStatus(asyncDir: string, status: AsyncStatus): void {
 	fs.mkdirSync(asyncDir, { recursive: true });
@@ -91,8 +97,11 @@ async function readRequest(asyncDir: string): Promise<SteerRequest> {
 }
 
 function recoveryDescriptor(runId: string): SteeringRecoveryDescriptor {
+	const runFanoutBudget = createRunFanoutBudget(runId, 64);
+	budgetDirectories.push(runFanoutBudget.directory);
 	return {
 		version: 1,
+		runFanoutBudget,
 		sourceRunId: runId,
 		agent: "worker-0",
 		cwd: os.tmpdir(),


### PR DESCRIPTION
## Summary

Adds a finite per-run child fan-out cap with default 64 and `PI_SUBAGENT_MAX_SPAWNS_PER_RUN` support.

The cap is distinct from the session spawn budget and active async capacity. It uses a durable run-tree ledger, cumulative non-refunded claims, nested propagation, strict recovery identity, public-boundary filtering for internal descriptors, serialized batch admission, and status/Doctor projection.

Closes #1031.

## Validation

- `node --experimental-strip-types --test test/unit/public-execution.test.ts test/unit/run-fanout-budget.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='rejects internal fan-out fields from public workflows|rejects an over-limit runs.all batch|rejects an over-limit static run fan-out|lets runs.all siblings settle' test/integration/single-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/chain-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='lists only requested states and includes flattened step summaries' test/integration/async-status.test.ts`
- `node --experimental-strip-types --test test/unit/async-resume.test.ts test/unit/pi-args.test.ts test/unit/doctor.test.ts test/unit/run-status.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review reports: `issue-1031-review-560441d.md`, `issue-1031-review-followup-b8b5edf.md`

Thanks to @asjer for #1031.