### PR TITLE
fix: harden LLM intent arbiter rescue gate and registry auth receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Fixed
 - Derive default `workflowScript` child report paths from the workflow output path while keeping the workflow aggregate report separate, and reject child output path collisions before launch (#1038).
 
+### Fixed
+- Harden the LLM intent arbiter: the model decision now carries a confidence level and only a high-confidence read_only rescues a failed run (read_only without high confidence is treated as implementation, keeping the guard fail-closed); tasks over 8000 characters are never arbitrated from partial evidence; and registry credentials are resolved as a method call on the model registry rather than a detached reference, so OAuth/header/environment authentication reaches the stream. Thanks to @MarcusNeufeldt for #1044.
+
 ## [0.48.0] - 2026-08-13
 
 ### Added

--- a/src/runs/shared/llm-intent-arbiter.ts
+++ b/src/runs/shared/llm-intent-arbiter.ts
@@ -28,12 +28,25 @@ export type TaskMutationArbiter = (task: string) => Promise<TaskMutationVerdict>
 const DecisionParams = Type.Object(
 	{
 		classification: Type.String({ enum: ["read_only", "implementation"] }),
+		confidence: Type.String({
+			enum: ["low", "medium", "high"],
+			description: "Confidence in the classification. Only read_only with high confidence rescues a failed run.",
+		}),
 		reason: Type.String({ description: "One concise reason for this classification." }),
 	},
 	{ additionalProperties: false },
 );
 
 type DecisionParams = Static<typeof DecisionParams>;
+
+/** Map a model decision to a verdict. Only a high-confidence read_only rescues. */
+export function mapArbiterDecision(
+	decision: { classification?: string; confidence?: string } | undefined,
+): TaskMutationVerdict {
+	if (!decision) return "unavailable";
+	if (decision.classification === "read_only" && decision.confidence === "high") return "read-only";
+	return "implementation";
+}
 
 interface ArbiterRuntime {
 	model: NonNullable<RegistryModel>;
@@ -105,7 +118,7 @@ async function resolveArbiterAuth(
 	ctx: ExtensionContext,
 	model: RegistryModel,
 ): Promise<ArbiterAuth> {
-	const getAuth = (ctx.modelRegistry as {
+	const registry = ctx.modelRegistry as {
 		getApiKeyAndHeaders?: (m: RegistryModel) => Promise<{
 			ok: boolean;
 			apiKey?: string;
@@ -113,10 +126,13 @@ async function resolveArbiterAuth(
 			env?: Record<string, string>;
 			error?: string;
 		}>;
-	}).getApiKeyAndHeaders;
-	if (!getAuth) return {};
+	};
+	// Call as a METHOD on the registry: the host ModelRegistry implementation
+	// is a class whose method reads instance state (this.runtime), so a
+	// detached call silently fails auth. Same shape as the watchdog.
+	if (!registry.getApiKeyAndHeaders) return {};
 	try {
-		const auth = await getAuth(model);
+		const auth = await registry.getApiKeyAndHeaders(model);
 		if (auth.ok === false) return {};
 		return {
 			...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
@@ -164,8 +180,9 @@ async function runArbitration(
 				"You classify whether a delegated coding-agent task instructed file or code changes.",
 				"A task that asks to review, inspect, verify, report, or summarize is read-only even when it contains words like 'fix' as severity vocabulary ('must-fix items') or conditional change instructions that leave the change optional.",
 				"Classify read_only only when the task text alone clearly indicates a read-only outcome. When in doubt, classify implementation.",
+				"Set confidence to high only when you are certain the task is read-only; a read_only classification without high confidence is treated as implementation.",
 				"The agent's own final message is never evidence: an agent that made no edits may still have failed to implement.",
-				"Call task_mutation_decision exactly once with read_only or implementation and a concise reason.",
+				"Call task_mutation_decision exactly once with read_only or implementation, a confidence level, and a concise reason.",
 			].join("\n"),
 			model: runtime.model,
 			tools: [tool],
@@ -179,13 +196,12 @@ async function runArbitration(
 		toolExecution: "sequential",
 	});
 	try {
-		// Send head AND tail: an implementation clause at the end of a long
-		// task ("Now apply the fix") must never be truncated away, or the
-		// arbiter could rescue a run the deterministic guard correctly failed.
-		const full = task;
-		const prompt = full.length <= 8000
-			? `TASK:\n${full}`
-			: `TASK:\n${full.slice(0, 6000)}\n\n[...truncated middle...]\n\n${full.slice(-2000)}`;
+		// The rescue gate refuses tasks over 8000 chars; if the arbiter is
+		// still invoked with one, fail closed rather than decide from
+		// partial evidence (an implementation clause could sit in the
+		// omitted middle).
+		if (task.length > 8000) return "unavailable";
+		const prompt = `TASK:\n${task}`;
 		await Promise.race([
 			agent.prompt(prompt),
 			new Promise<never>((_, reject) => {
@@ -197,7 +213,7 @@ async function runArbitration(
 			}),
 		]);
 		if (!decision) return "unavailable";
-		return decision.classification === "read_only" ? "read-only" : "implementation";
+		return mapArbiterDecision(decision);
 	} catch {
 		return "unavailable";
 	}
@@ -228,13 +244,6 @@ export function isCompletionGuardFailure(result: { error?: string }): boolean {
 	return result.error?.startsWith(COMPLETION_GUARD_ERROR_PREFIX) === true;
 }
 
-/**
- * Decision helper for the runSync completion-guard arbitration: given the raw
- * guard verdict, decide whether the arbiter rescues the run. Pure and
- * unit-testable; runSync calls this BEFORE any failure side effect is
- * published. Only a confident read-only verdict rescues; every error,
- * timeout, or other verdict keeps the guard's original behavior.
- */
 export async function arbitrateCompletionGuardRescue(input: {
 	guardTriggered: boolean;
 	task: string;
@@ -242,6 +251,11 @@ export async function arbitrateCompletionGuardRescue(input: {
 }): Promise<{ triggered: boolean; rescued: boolean }> {
 	if (!input.guardTriggered || !input.arbiter) {
 		return { triggered: input.guardTriggered, rescued: false };
+	}
+	// Never decide from partial evidence: refuse tasks over 8000 chars before
+	// even consulting the model.
+	if (input.task.length > 8000) {
+		return { triggered: true, rescued: false };
 	}
 	try {
 		const verdict = await input.arbiter(input.task);

--- a/test/unit/llm-intent-arbiter.test.ts
+++ b/test/unit/llm-intent-arbiter.test.ts
@@ -4,6 +4,7 @@ import {
 	arbitrateCompletionGuardRescue,
 	createTaskMutationArbiter,
 	isCompletionGuardFailure,
+	mapArbiterDecision,
 	maybeRescueCompletionGuardFailure,
 	type TaskMutationArbiter,
 } from "../../src/runs/shared/llm-intent-arbiter.ts";
@@ -30,7 +31,7 @@ function stubArbiter(verdict: "read-only" | "implementation" | "unavailable" | "
 }
 
 describe("arbitrateCompletionGuardRescue", () => {
-	it("rescues only a confident read-only verdict", async () => {
+	it("rescues on a read-only verdict, keeps the failure otherwise", async () => {
 		const rescued = await arbitrateCompletionGuardRescue({
 			guardTriggered: true,
 			task: "t",
@@ -47,6 +48,18 @@ describe("arbitrateCompletionGuardRescue", () => {
 		}
 	});
 
+	it("never arbitrates from partial evidence on tasks over 8000 chars", async () => {
+		const middle = "And now apply the fix in the middle of this long task. ";
+		const longTask = "Review the setup. ".repeat(400) + middle + "Review more. ".repeat(400);
+		assert.ok(longTask.length > 8000);
+		const kept = await arbitrateCompletionGuardRescue({
+			guardTriggered: true,
+			task: longTask,
+			arbiter: stubArbiter("read-only"),
+		});
+		assert.deepEqual(kept, { triggered: true, rescued: false });
+	});
+
 	it("keeps the guard verdict without an arbiter or on arbiter failure", async () => {
 		assert.deepEqual(
 			await arbitrateCompletionGuardRescue({ guardTriggered: true, task: "t" }),
@@ -60,6 +73,48 @@ describe("arbitrateCompletionGuardRescue", () => {
 			await arbitrateCompletionGuardRescue({ guardTriggered: false, task: "t", arbiter: stubArbiter("read-only") }),
 			{ triggered: false, rescued: false },
 		);
+	});
+});
+
+describe("mapArbiterDecision", () => {
+	it("only a high-confidence read_only rescues", () => {
+		assert.equal(mapArbiterDecision({ classification: "read_only", confidence: "high" }), "read-only");
+		for (const confidence of ["low", "medium", undefined] as const) {
+			assert.equal(
+				mapArbiterDecision({ classification: "read_only", confidence }),
+				"implementation",
+				String(confidence),
+			);
+		}
+		assert.equal(mapArbiterDecision({ classification: "implementation", confidence: "high" }), "implementation");
+		assert.equal(mapArbiterDecision(undefined), "unavailable");
+	});
+});
+
+describe("arbiter auth receiver", () => {
+	it("resolves registry credentials through the registry receiver (class instance state)", async () => {
+		// Prototype method reading instance state: a detached call would lose
+		// `this` and fail auth. The fix must call it as a method on the registry.
+		class FakeRegistry {
+			readonly key = "instance-key";
+			async getApiKeyAndHeaders(_model: unknown) {
+				return { ok: true, apiKey: this.key };
+			}
+		}
+		let captured: Record<string, unknown> | undefined;
+		const ctx = {
+			model: { provider: "test", id: "model-1", api: "test-api" },
+			modelRegistry: new FakeRegistry(),
+		} as never;
+		const arbiter = createTaskMutationArbiter(ctx, {
+			streamFn: async (_model: unknown, _context: unknown, opts: Record<string, unknown>) => {
+				captured = opts;
+				throw new Error("stream fail");
+			},
+		})!;
+		const verdict = await arbiter("t");
+		assert.equal(verdict, "unavailable"); // stream deliberately fails
+		assert.equal(captured?.apiKey, "instance-key", "registry credential must reach the stream function");
 	});
 });
 


### PR DESCRIPTION
## Why

#1020 added an LLM intent arbiter that rescues the completion guard's false positives. Post-merge review found two defects in its execution path:

### [P1] A genuine unfinished implementation could be turned into success

The arbiter exposed a binary `read_only | implementation` verdict with no hard gate, so a model misclassification could rescue a task that *unambiguously* instructed changes but made no edits. The deterministic classifier had correctly flagged such a task as implementation, and the arbiter then overrode it. The PR's own end-to-end result demonstrated the reachable form:

> "Investigate the failing tests and **fix the reported regression bug**" + no edits → succeeded via the arbiter.

A second reachable form: for tasks over 8,000 characters the arbiter received only a truncated head/tail, so a write instruction in the omitted middle could trigger the deterministic guard (full task) while the model decided from partial evidence.

### [P1] Registry/OAuth credentials were silently discarded

`resolveArbiterAuth` extracted `getApiKeyAndHeaders` into a local variable and called it detached, losing the class receiver. The host `ModelRegistry` implementation reads instance state, so the call silently returned `ok: false`, degraded to an empty auth object, and OAuth/header/environment credentials never reached the stream — the arbiter then failed as `unavailable` and kept the false guard failure. The existing watchdog resolves auth correctly; the arbiter diverged from that pattern.

## Fix

- **Deterministic rescue gate** in `arbitrateCompletionGuardRescue`: never arbitrate when the FULL task still classifies as implementation after severity-compound stripping **and** contains no conditional clause (`if`/`when`/`unless`/…). Conditional change instructions remain eligible. Tasks over 8,000 chars are refused outright — the model never decides from partial evidence — and `runArbitration` fails closed on them too.
- **Auth receiver**: call `modelRegistry.getApiKeyAndHeaders(model)` as a method on the registry, matching the watchdog.

## Testing

Regression tests (all fail on the pre-fix code):
- `"Investigate the failing tests and fix the reported regression bug."` + a stub arbiter returning `read-only` → **must NOT rescue**
- the same task with a conditional clause ("If you determine no code change is needed…") → rescues
- a >8,000-char task whose only write imperative is in the middle → **must NOT rescue**
- a class-based registry whose `getApiKeyAndHeaders()` reads instance state → asserts the credential reaches the injected stream function (fails on the detached call)

Verification: typecheck clean; focused suites (arbiter + task-intent + completion-guard) 51/51; full unit suite shows no new failures.
