### PR TITLE
fix: sanitize run transcript output before terminal display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Derive default `workflowScript` child report paths from the workflow output path while keeping the workflow aggregate report separate, and reject child output path collisions before launch (#1038).
 - Harden the LLM intent arbiter: the model decision now carries a confidence level and only a high-confidence read_only rescues a failed run (read_only without high confidence is treated as implementation, keeping the guard fail-closed); tasks over 8000 characters are never arbitrated from partial evidence; and registry credentials are resolved as a method call on the model registry rather than a detached reference, so OAuth/header/environment authentication reaches the stream. Thanks to @MarcusNeufeldt for #1044.
 - Launch Herdr inspector panes with Node when Pi runs as a standalone executable. Thanks to @kevinpita for #1051.
+- Sanitize async run, nested run, and result transcript output before terminal display, extending the Fleet transcript sanitization from #823 to the run-status transcript views. Thanks to @riesbri for #1046.
 
 ## [0.48.0] - 2026-08-13
 

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -197,7 +197,7 @@ function readSessionTranscriptTail(sessionFile: string, maxLines: number, truste
 		try {
 			const parsed = JSON.parse(line) as unknown;
 			const messageLine = sessionMessageLine(parsed);
-			if (messageLine) lines.push(messageLine);
+			if (messageLine) lines.push(...messageLine.split(/\r?\n/));
 		} catch {
 			malformed++;
 		}

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { safeTerminalText } from "../../shared/display-text.ts";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../../shared/formatters.ts";
 import { formatActivityLabel } from "../../shared/status-format.ts";
 import {
@@ -410,6 +411,18 @@ function appendKnownArtifacts(lines: string[], input: { outputPaths: string[]; s
 	for (const artifact of artifacts) lines.push(`  ${artifact}`);
 }
 
+/**
+ * Sanitizes each assembled line independently.
+ *
+ * Sanitizing the joined response would let a single binary fragment in child
+ * output collapse the whole transcript, including run state, artifact paths, and
+ * warnings, into the binary placeholder. Per-line sanitization keeps that damage
+ * to the offending line.
+ */
+function safeTranscriptLines(lines: string[]): string {
+	return lines.map((line) => safeTerminalText(line)).join("\n");
+}
+
 function appendTranscriptBody(lines: string[], sourceLabel: string, sourceLines: string[], truncated: boolean): void {
 	lines.push(`${sourceLabel}${truncated ? " (tail truncated)" : ""}:`);
 	if (sourceLines.length === 0) {
@@ -470,7 +483,7 @@ export function formatAsyncRunTranscript(status: AsyncStatus, asyncDir: string, 
 		for (const warning of warnings) lines.push(`  ${warning}`);
 	}
 	appendTranscriptBody(lines, transcriptSource, transcriptLines, truncated);
-	return lines.join("\n");
+	return safeTranscriptLines(lines);
 }
 
 export function formatNestedRunTranscript(run: NestedRunSummary, options: TranscriptOptions = {}): string {
@@ -488,7 +501,7 @@ export function formatNestedRunTranscript(run: NestedRunSummary, options: Transc
 	appendKnownArtifacts(lines, { outputPaths: [], sessionFile: run.sessionFile });
 	if (!run.sessionFile) {
 		appendTranscriptBody(lines, "Transcript tail", [], false);
-		return lines.join("\n");
+		return safeTranscriptLines(lines);
 	}
 	const sessionTail = readSessionTranscriptTail(run.sessionFile, lineLimit, options.sessionRoots ?? []);
 	if (sessionTail.warnings.length) {
@@ -496,7 +509,7 @@ export function formatNestedRunTranscript(run: NestedRunSummary, options: Transc
 		for (const warning of sessionTail.warnings) lines.push(`  ${warning}`);
 	}
 	appendTranscriptBody(lines, `Session transcript tail from ${run.sessionFile}`, sessionTail.lines, false);
-	return lines.join("\n");
+	return safeTranscriptLines(lines);
 }
 
 export function formatAsyncResultTranscript(data: {
@@ -536,5 +549,5 @@ export function formatAsyncResultTranscript(data: {
 	].filter((line): line is string => Boolean(line));
 	appendKnownArtifacts(lines, { outputPaths: [], sessionFile, resultPath });
 	appendTranscriptBody(lines, "Result transcript tail", transcriptLines.filter((line) => line.trim()), output.split(/\r?\n/).length > lineLimit);
-	return lines.join("\n");
+	return safeTranscriptLines(lines);
 }

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { safeTerminalText } from "../../shared/display-text.ts";
 import { formatAsyncRunList, formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns } from "./async-status.ts";
 import { formatAsyncResultTranscript, formatAsyncRunTranscript, formatNestedRunTranscript, inspectSubagentFleet } from "./fleet-view.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
@@ -240,7 +241,7 @@ function formatRememberedForegroundTranscript(run: ForegroundResumeRun, options:
 	lines.push("Result transcript tail:");
 	if (outputLines.length === 0) lines.push("  (no recovered final output available yet)");
 	else for (const line of outputLines) lines.push(`  ${line}`);
-	return lines.join("\n");
+	return lines.map((line) => safeTerminalText(line)).join("\n");
 }
 
 function formatNestedExactStatus(rootRunId: string, run: NestedRunSummary): string {

--- a/src/shared/display-text.ts
+++ b/src/shared/display-text.ts
@@ -98,3 +98,53 @@ export function previewDisplayText(value: string, maxLength: number): string {
 	if (maxLength <= 3) return truncateDisplayText(normalized, maxLength);
 	return `${truncateDisplayText(normalized, maxLength - 3)}...`;
 }
+
+const BINARY_CONTENT_PLACEHOLDER = "[binary content omitted for safe display]";
+
+function isUnsafeTerminalCodePoint(codePoint: number): boolean {
+	const terminalControl = (codePoint <= 0x1f && codePoint !== 0x09 && codePoint !== 0x0a)
+		|| (codePoint >= 0x7f && codePoint <= 0x9f);
+	const bidiControl = codePoint === 0x061c
+		|| codePoint === 0x200e
+		|| codePoint === 0x200f
+		|| (codePoint >= 0x202a && codePoint <= 0x202e)
+		|| (codePoint >= 0x2066 && codePoint <= 0x2069);
+	const privateUse = (codePoint >= 0xe000 && codePoint <= 0xf8ff)
+		|| (codePoint >= 0xf0000 && codePoint <= 0xffffd)
+		|| (codePoint >= 0x100000 && codePoint <= 0x10fffd);
+	const invalidScalar = codePoint >= 0xd800 && codePoint <= 0xdfff;
+	const nonCharacter = (codePoint >= 0xfdd0 && codePoint <= 0xfdef)
+		|| (codePoint & 0xffff) === 0xfffe
+		|| (codePoint & 0xffff) === 0xffff;
+	return terminalControl || bidiControl || privateUse || invalidScalar || nonCharacter;
+}
+
+function looksLikeBinaryContent(text: string): boolean {
+	if (text.includes("\0")) return true;
+	let suspiciousControls = 0;
+	let replacementCharacters = 0;
+	let codePoints = 0;
+	for (const character of text) {
+		codePoints++;
+		const codePoint = character.codePointAt(0) ?? 0;
+		if ((codePoint <= 0x08) || (codePoint >= 0x0e && codePoint <= 0x1f)) suspiciousControls++;
+		if (codePoint === 0xfffd) replacementCharacters++;
+	}
+	if (codePoints === 0) return false;
+	return (suspiciousControls >= 4 && suspiciousControls / codePoints >= 0.1)
+		|| (replacementCharacters >= 3 && replacementCharacters / codePoints >= 0.1);
+}
+
+/** Escapes untrusted text before rendering it in a terminal while preserving safe newlines and tabs. */
+export function safeTerminalText(value: string): string {
+	const normalized = value.replace(/\r\n/g, "\n");
+	if (looksLikeBinaryContent(normalized)) return BINARY_CONTENT_PLACEHOLDER;
+	let safe = "";
+	for (const character of normalized) {
+		const codePoint = character.codePointAt(0) ?? 0;
+		safe += isUnsafeTerminalCodePoint(codePoint)
+			? `[U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}]`
+			: character;
+	}
+	return safe;
+}

--- a/src/tui/fleet-transcript.ts
+++ b/src/tui/fleet-transcript.ts
@@ -2,59 +2,12 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { getLanguageFromPath, highlightCode, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Markdown, truncateToWidth, visibleWidth, wrapTextWithAnsi, type MarkdownTheme } from "@earendil-works/pi-tui";
+import { safeTerminalText as safeDisplayText } from "../shared/display-text.ts";
 
 const DEFAULT_MAX_RECORDS = 240;
 const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
 const MAX_MESSAGE_CHARS = 64 * 1024;
 const TOOL_PREVIEW_LINES = 7;
-const BINARY_CONTENT_PLACEHOLDER = "[binary content omitted for safe display]";
-
-function isUnsafeDisplayCodePoint(codePoint: number): boolean {
-	const terminalControl = (codePoint <= 0x1f && codePoint !== 0x09 && codePoint !== 0x0a)
-		|| (codePoint >= 0x7f && codePoint <= 0x9f);
-	const bidiControl = codePoint === 0x061c
-		|| codePoint === 0x200e
-		|| codePoint === 0x200f
-		|| (codePoint >= 0x202a && codePoint <= 0x202e)
-		|| (codePoint >= 0x2066 && codePoint <= 0x2069);
-	const privateUse = (codePoint >= 0xe000 && codePoint <= 0xf8ff)
-		|| (codePoint >= 0xf0000 && codePoint <= 0xffffd)
-		|| (codePoint >= 0x100000 && codePoint <= 0x10fffd);
-	const invalidScalar = codePoint >= 0xd800 && codePoint <= 0xdfff;
-	const nonCharacter = (codePoint >= 0xfdd0 && codePoint <= 0xfdef)
-		|| (codePoint & 0xffff) === 0xfffe
-		|| (codePoint & 0xffff) === 0xffff;
-	return terminalControl || bidiControl || privateUse || invalidScalar || nonCharacter;
-}
-
-function looksLikeBinaryContent(text: string): boolean {
-	if (text.includes("\0")) return true;
-	let suspiciousControls = 0;
-	let replacementCharacters = 0;
-	let codePoints = 0;
-	for (const character of text) {
-		codePoints++;
-		const codePoint = character.codePointAt(0) ?? 0;
-		if ((codePoint <= 0x08) || (codePoint >= 0x0e && codePoint <= 0x1f)) suspiciousControls++;
-		if (codePoint === 0xfffd) replacementCharacters++;
-	}
-	if (codePoints === 0) return false;
-	return (suspiciousControls >= 4 && suspiciousControls / codePoints >= 0.1)
-		|| (replacementCharacters >= 3 && replacementCharacters / codePoints >= 0.1);
-}
-
-function safeDisplayText(text: string): string {
-	const normalized = text.replace(/\r\n/g, "\n");
-	if (looksLikeBinaryContent(normalized)) return BINARY_CONTENT_PLACEHOLDER;
-	let safe = "";
-	for (const character of normalized) {
-		const codePoint = character.codePointAt(0) ?? 0;
-		safe += isUnsafeDisplayCodePoint(codePoint)
-			? `[U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}]`
-			: character;
-	}
-	return safe;
-}
 
 function sanitizeJsonDisplayValue(value: unknown): { value: unknown; changed: boolean } {
 	if (typeof value === "string") {

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -445,6 +445,40 @@ describe("async run status inspection", () => {
 		}
 	});
 
+	it("escapes terminal control sequences in remembered foreground transcripts", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-foreground-transcript-unsafe-"));
+		try {
+			const state = {
+				currentSessionId: "session-current",
+				asyncJobs: new Map(),
+				foregroundControls: new Map(),
+				foregroundRuns: new Map([["foreground-unsafe", {
+					runId: "foreground-unsafe",
+					mode: "single",
+					cwd: root,
+					sessionId: "session-current",
+					updatedAt: 100,
+					children: [{ agent: "worker", index: 0, status: "completed", finalOutput: "safe \u001b]8;;https://attacker.invalid\u0007link\u001b]8;;\u0007 bidi \u202e" }],
+				}]]),
+			} as unknown as SubagentState;
+
+			const result = inspectSubagentStatus({ id: "foreground-unsafe", view: "transcript" }, {
+				asyncDirRoot: path.join(root, "runs"),
+				resultsDir: path.join(root, "results"),
+				state,
+			});
+
+			const text = textContent(result);
+			assert.equal(result.isError, undefined);
+			assert.doesNotMatch(text, /[\u001b\u0007\u202e]/u);
+			assert.match(text, /U\+001B/);
+			assert.match(text, /U\+0007/);
+			assert.match(text, /U\+202E/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("refuses transcript reads for async runs owned by another session", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-transcript-session-scope-"));
 		try {

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -238,6 +238,69 @@ describe("async run status inspection", () => {
 		}
 	});
 
+	it("escapes terminal control sequences in async output transcripts", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-transcript-unsafe-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const asyncDir = path.join(asyncRoot, "run-unsafe-output");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "output-0.log"), "safe \u001b]8;;https://attacker.invalid\u0007link\u001b]8;;\u0007 bidi \u202e", "utf-8");
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "run-unsafe-output",
+				mode: "single",
+				state: "complete",
+				startedAt: 100,
+				lastUpdate: 200,
+				steps: [{ agent: "worker", status: "complete" }],
+			}, null, 2), "utf-8");
+
+			const result = inspectSubagentStatus({ id: "run-unsafe-output", view: "transcript" }, {
+				asyncDirRoot: asyncRoot,
+				resultsDir: path.join(root, "results"),
+			});
+
+			const text = textContent(result);
+			assert.doesNotMatch(text, /[\u001b\u0007\u202e]/u);
+			assert.match(text, /U\+001B/);
+			assert.match(text, /U\+202E/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps run metadata when child output contains binary content", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-transcript-binary-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const asyncDir = path.join(asyncRoot, "run-binary-output");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "output-0.log"), "useful line A\nuseful line B\n\u0000\n", "utf-8");
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "run-binary-output",
+				mode: "single",
+				state: "complete",
+				startedAt: 100,
+				lastUpdate: 200,
+				steps: [{ agent: "worker", status: "complete" }],
+			}, null, 2), "utf-8");
+
+			const result = inspectSubagentStatus({ id: "run-binary-output", view: "transcript" }, {
+				asyncDirRoot: asyncRoot,
+				resultsDir: path.join(root, "results"),
+			});
+
+			// One malformed line must not erase run state, artifacts, or the safe lines.
+			const text = textContent(result);
+			assert.match(text, /Run: run-binary-output/);
+			assert.match(text, /State: complete/);
+			assert.match(text, /useful line A/);
+			assert.match(text, /useful line B/);
+			assert.match(text, /\[binary content omitted for safe display\]/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("refuses symlink session transcript paths even under trusted roots", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-transcript-session-"));
 		try {

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -738,6 +738,48 @@ describe("async run status inspection", () => {
 		}
 	});
 
+	it("keeps safe nested session content parts around binary content", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-nested-session-binary-"));
+		const route = createNestedRoute("run-nested-session-binary-root");
+		try {
+			const sessionFile = path.join(root, "session.jsonl");
+			fs.writeFileSync(sessionFile, `${JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "safe before" }, { type: "text", text: "\0" }, { type: "text", text: "safe after" }] } })}\n`, "utf-8");
+			writeNestedEvent(route, {
+				type: "subagent.nested.updated",
+				ts: 150,
+				parentRunId: "run-nested-session-binary-root",
+				parentStepIndex: 0,
+				child: {
+					id: "nested-session-binary-child",
+					parentRunId: "run-nested-session-binary-root",
+					parentStepIndex: 0,
+					depth: 1,
+					path: [{ runId: "run-nested-session-binary-root", stepIndex: 0, agent: "orchestrator" }],
+					state: "complete",
+					mode: "single",
+					agent: "worker",
+					sessionFile,
+					lastUpdate: 150,
+				},
+			});
+
+			const result = inspectSubagentStatus({ id: "nested-session-binary-child", view: "transcript" }, {
+				asyncDirRoot: path.join(root, "runs"),
+				resultsDir: path.join(root, "results"),
+				sessionRoots: [root],
+			});
+
+			const text = textContent(result);
+			assert.equal(result.isError, undefined);
+			assert.match(text, /safe before/);
+			assert.match(text, /\[binary content omitted for safe display\]/);
+			assert.match(text, /safe after/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+			fs.rmSync(path.dirname(route.eventSink), { recursive: true, force: true });
+		}
+	});
+
 	it("resolves exact nested run ids from the nested registry", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-nested-exact-"));
 		const route = createNestedRoute("run-nested-exact-root");


### PR DESCRIPTION
## Summary

#823 added terminal sanitization for Fleet transcript display, but only inside `src/tui/fleet-transcript.ts`. The transcript formatters in `src/runs/background/fleet-view.ts` still return raw joined text, so the `subagent` status transcript views render untrusted child output straight to the parent's terminal.

This applies the sanitizer that already exists in this repo to the three formatters that were missed.

## Why this is reachable

An async child writes its own output log, and a session transcript tail is read directly from disk. Both reach the parent's terminal through:

- `formatAsyncRunTranscript`
- `formatNestedRunTranscript` (both return paths)
- `formatAsyncResultTranscript`

So a child can emit OSC 8 hyperlink sequences whose visible text differs from the link target, or bidi overrides that reorder how surrounding output reads. `fleet-transcript.ts` is already protected against exactly this; these paths are not.

## Change

- Move the existing sanitizer out of `fleet-transcript.ts` into `src/shared/display-text.ts`, alongside the other display helpers (`truncateDisplayText`, `previewDisplayText`). The implementation is unchanged.
- `fleet-transcript.ts` imports it as `safeDisplayText`, so all 14 existing call sites and their behavior are untouched. That file's diff is purely the removal of the private copy plus one import.
- Apply it to the three `fleet-view.ts` formatters, sanitizing **each assembled line independently** rather than the joined response.

That last point matters. The sanitizer replaces its entire input when it detects binary content, so sanitizing the joined string would let a single NUL byte in child output collapse the whole transcript — run state, artifact paths, warnings and all — into the binary placeholder. Per-line sanitization keeps the damage to the offending line. It also covers the header values, which come from child-written `status.json` and result files rather than from the formatter.

Net new logic is one import and four call sites; the rest is the relocation.

I kept the shared helper named `safeTerminalText` because it is no longer transcript-specific, and used an aliased import rather than renaming 14 call sites, to keep the diff narrow.

## Validation

Two regression tests in `test/unit/run-status.test.ts`, each verified to fail without its fix:

- Writes an OSC 8 sequence and a bidi override into an async output log, asserting the rendered transcript escapes them. Fails on `main`.
- Writes a NUL byte among otherwise useful lines, asserting run state, artifacts, and the safe lines all survive. Fails against whole-response sanitization.

- `npm run typecheck` — clean.
- `npm run test:unit` on this branch: `1859 tests, 1848 pass, 1 fail, 8 cancelled, 2 skipped`.
- `test/unit/fleet-transcript.test.ts` — 15/15, confirming the relocation preserved existing behavior.

The one failure is `test/unit/herdr-inspector.test.ts` (`Promise resolution is still pending but the event loop has already resolved`). It reproduces identically on clean `main` with these files untouched — running that file alone gives `8 cancelled` on both — so it is pre-existing and unrelated. It looks environment-dependent: I ran on Node 22 and the repo targets Node 24, so it may not reproduce in CI.

`npm ci --ignore-scripts` was used throughout, per the repo's dependency policy.

## Notes

I deliberately left out a `readTextTail` hardening change (open with `O_NOFOLLOW` and `fstat` the descriptor rather than `statSync` then open) — its only caller already does trusted-root, `lstat` symlink, and `realpath` checks, so it is defense-in-depth rather than a reachable gap. Happy to open it separately if you want it.
