### PR TITLE
feat: add builtin tool inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add `debug.run` for async run lifecycle diagnostics without exposing prompts, secrets, or transcripts (#1037).
+- Add `subagents.inheritBuiltinTools` to let builtin roles inherit Pi's ambient tools and extensions. Thanks to @davidarny for #1049.
 
 ## [0.48.0] - 2026-08-13
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -90,7 +90,7 @@ To let every builtin role use Pi's normal tools and ambient extensions instead o
 }
 ```
 
-An explicit `agentOverrides.<name>.tools` entry still wins for that role. Project settings take precedence over user settings.
+An explicit `agentOverrides.<name>.tools` entry in the winning configuration scope still wins for that role. Project settings take precedence over user settings, including `inheritBuiltinTools`.
 
 Disable and restore:
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -80,6 +80,18 @@ Supported override fields: `description`, `model`, `fallbackModels`, `thinking`,
 - Project overrides beat user overrides.
 - Matching user and project agents also receive override fields that their frontmatter leaves unset, so a shared project config agent can keep the persona while local settings choose the model.
 
+To let every builtin role use Pi's normal tools and ambient extensions instead of its bundled tool allowlist, set `subagents.inheritBuiltinTools: true`:
+
+```json
+{
+  "subagents": {
+    "inheritBuiltinTools": true
+  }
+}
+```
+
+An explicit `agentOverrides.<name>.tools` entry still wins for that role. Project settings take precedence over user settings.
+
 Disable and restore:
 
 - `disabled: true` hides a builtin from runtime discovery and agent-facing `subagent({ action: "list" })` output.

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -163,6 +163,7 @@ interface SubagentSettings {
 	defaultModel?: string;
 	defaultThinking?: string;
 	defaultExtensions?: string[];
+	inheritBuiltinTools?: boolean;
 	disableBuiltins?: boolean;
 	disableThinking?: boolean;
 	modelScope?: ModelScopeConfig;
@@ -904,6 +905,13 @@ function readSubagentSettings(filePath: string | null): SubagentSettings {
 		}
 		defaultExtensions = subagentsObject.defaultExtensions.map((item) => item.trim());
 	}
+	let inheritBuiltinTools: boolean | undefined;
+	if ("inheritBuiltinTools" in subagentsObject) {
+		if (typeof subagentsObject.inheritBuiltinTools !== "boolean") {
+			throw new Error(`Subagent settings in '${filePath}' have invalid 'inheritBuiltinTools'; expected a boolean.`);
+		}
+		inheritBuiltinTools = subagentsObject.inheritBuiltinTools;
+	}
 	const modelScope = parseModelScopeConfig(subagentsObject.modelScope, { filePath });
 
 	const parsed: Record<string, BuiltinAgentOverrideConfig> = {};
@@ -913,6 +921,7 @@ function readSubagentSettings(filePath: string | null): SubagentSettings {
 		...(defaultModel !== undefined ? { defaultModel } : {}),
 		...(defaultThinking !== undefined ? { defaultThinking } : {}),
 		...(defaultExtensions !== undefined ? { defaultExtensions } : {}),
+		...(inheritBuiltinTools !== undefined ? { inheritBuiltinTools } : {}),
 		...(disableBuiltins !== undefined ? { disableBuiltins } : {}),
 		...(disableThinking !== undefined ? { disableThinking } : {}),
 		...(modelScope !== undefined ? { modelScope } : {}),
@@ -1048,6 +1057,11 @@ function clearBuiltinThinking(agent: AgentConfig, meta: { scope: "user" | "proje
 	return { ...next, override: agent.override ?? { ...meta, base: cloneOverrideBase(agent) } };
 }
 
+function clearBuiltinToolAllowlist(agent: AgentConfig): AgentConfig {
+	const { tools: _tools, mcpDirectTools: _mcpDirectTools, ...next } = agent;
+	return next;
+}
+
 function applyBuiltinOverrides(
 	builtinAgents: AgentConfig[],
 	userSettings: SubagentSettings,
@@ -1059,6 +1073,10 @@ function applyBuiltinOverrides(
 	const userBulkDisabled = projectSettings.disableBuiltins === undefined && userSettings.disableBuiltins === true;
 	const projectThinkingConfigured = projectSettings.disableThinking !== undefined && projectSettingsPath !== null;
 	const disableThinking = projectThinkingConfigured ? projectSettings.disableThinking === true : userSettings.disableThinking === true;
+	const projectToolInheritanceConfigured = projectSettings.inheritBuiltinTools !== undefined && projectSettingsPath !== null;
+	const inheritBuiltinTools = projectToolInheritanceConfigured
+		? projectSettings.inheritBuiltinTools === true
+		: userSettings.inheritBuiltinTools === true;
 	const disableThinkingMeta = projectThinkingConfigured
 		? { scope: "project" as const, path: projectSettingsPath! }
 		: { scope: "user" as const, path: userSettingsPath };
@@ -1067,39 +1085,49 @@ function applyBuiltinOverrides(
 		if (!disableThinking || hasExplicitThinkingOverride) return agent;
 		return clearBuiltinThinking(agent, disableThinkingMeta);
 	};
+	const applyGlobalToolInheritance = (agent: AgentConfig, hasExplicitToolsOverride: boolean): AgentConfig => {
+		if (!inheritBuiltinTools || hasExplicitToolsOverride) return agent;
+		return clearBuiltinToolAllowlist(agent);
+	};
+	const applyGlobals = (agent: AgentConfig, hasExplicitThinkingOverride: boolean, hasExplicitToolsOverride: boolean): AgentConfig =>
+		applyGlobalThinking(applyGlobalToolInheritance(agent, hasExplicitToolsOverride), hasExplicitThinkingOverride);
 
 	return builtinAgents.map((agent) => {
 		const projectOverride = projectSettings.overrides[agent.name];
 		if (projectOverride && projectSettingsPath) {
-			return applyGlobalThinking(
+			return applyGlobals(
 				applyBuiltinOverride(agent, projectOverride, { scope: "project", path: projectSettingsPath }),
 				projectOverride.thinking !== undefined,
+				projectOverride.tools !== undefined,
 			);
 		}
 
 		if (projectBulkDisabled && projectSettingsPath) {
-			return applyGlobalThinking(
+			return applyGlobals(
 				applyBuiltinOverride(agent, { disabled: true }, { scope: "project", path: projectSettingsPath }),
+				false,
 				false,
 			);
 		}
 
 		const userOverride = userSettings.overrides[agent.name];
 		if (userOverride) {
-			return applyGlobalThinking(
+			return applyGlobals(
 				applyBuiltinOverride(agent, userOverride, { scope: "user", path: userSettingsPath }),
 				!projectThinkingConfigured && userOverride.thinking !== undefined,
+				!projectToolInheritanceConfigured && userOverride.tools !== undefined,
 			);
 		}
 
 		if (userBulkDisabled) {
-			return applyGlobalThinking(
+			return applyGlobals(
 				applyBuiltinOverride(agent, { disabled: true }, { scope: "user", path: userSettingsPath }),
+				false,
 				false,
 			);
 		}
 
-		return applyGlobalThinking(agent, false);
+		return applyGlobals(agent, false, false);
 	});
 }
 

--- a/test/unit/agent-overrides.test.ts
+++ b/test/unit/agent-overrides.test.ts
@@ -88,6 +88,65 @@ describe("builtin agent overrides", () => {
 		assert.equal(reviewer?.modelSource, undefined);
 	});
 
+	it("lets builtin agents inherit Pi's normal tools when configured", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: {
+				inheritBuiltinTools: true,
+				agentOverrides: {
+					reviewer: { tools: ["read", "mcp:github/search"] },
+				},
+			},
+		});
+
+		const builtins = discoverAgentsAll(tempProject).builtin;
+		for (const agent of builtins.filter((agent) => agent.name !== "reviewer")) {
+			assert.equal(agent.tools, undefined, `${agent.name} should inherit normal tools`);
+			assert.equal(agent.mcpDirectTools, undefined, `${agent.name} should inherit normal MCP tools`);
+		}
+		const reviewer = builtins.find((agent) => agent.name === "reviewer");
+		assert.deepEqual(reviewer?.tools, ["read"]);
+		assert.deepEqual(reviewer?.mcpDirectTools, ["github/search"]);
+	});
+
+	it("prefers project inheritBuiltinTools over the user setting", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { inheritBuiltinTools: true },
+		});
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { inheritBuiltinTools: false },
+		});
+
+		const researcher = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "researcher");
+		assert.deepEqual(researcher?.tools, ["read", "write", "web_search", "fetch_content", "get_search_content", "intercom"]);
+	});
+
+	it("lets project inheritBuiltinTools override a user role allowlist", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { agentOverrides: { researcher: { tools: ["read"] } } },
+		});
+		writeJson(path.join(tempProject, ".pi", "settings.json"), {
+			subagents: { inheritBuiltinTools: true },
+		});
+
+		const researcher = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "researcher");
+		assert.equal(researcher?.tools, undefined);
+		assert.equal(researcher?.mcpDirectTools, undefined);
+	});
+
+	it("surfaces malformed inheritBuiltinTools settings", () => {
+		const settingsPath = path.join(tempHome, ".pi", "agent", "settings.json");
+		writeJson(settingsPath, {
+			subagents: { inheritBuiltinTools: "true" },
+		});
+
+		assert.throws(
+			() => discoverAgents(tempProject, "both"),
+			(error: unknown) => error instanceof Error
+				&& error.message.includes(settingsPath)
+				&& error.message.includes("inheritBuiltinTools"),
+		);
+	});
+
 	it("clears subagents.defaultModel provenance for same-value agent model overrides", () => {
 		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
 			subagents: {


### PR DESCRIPTION
Closes #1047

Adds `subagents.inheritBuiltinTools`, a global opt-in that removes builtin role tool allowlists so child sessions inherit Pi's normal ambient tools and extensions.

- Keeps the default strict allowlists unchanged.
- Keeps explicit per-role `tools` settings within the winning config scope.
- Gives project settings precedence over user settings.
- Documents the setting and covers parsing and precedence with unit tests.

Checks:
- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/agent-overrides.test.ts`

The full unit command is environment-sensitive here because the checkout discovers global user agent definitions under `~/.agents`; the focused tests pass in their isolated test home.