### PR TITLE
fix: launch Herdr inspector with Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - Harden the LLM intent arbiter: the model decision now carries a confidence level and only a high-confidence read_only rescues a failed run (read_only without high confidence is treated as implementation, keeping the guard fail-closed); tasks over 8000 characters are never arbitrated from partial evidence; and registry credentials are resolved as a method call on the model registry rather than a detached reference, so OAuth/header/environment authentication reaches the stream. Thanks to @MarcusNeufeldt for #1044.
+- Launch Herdr inspector panes with Node when Pi runs as a standalone executable. Thanks to @kevinpita for #1051.
 
 ## [0.48.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### Fixed
 - Derive default `workflowScript` child report paths from the workflow output path while keeping the workflow aggregate report separate, and reject child output path collisions before launch (#1038).
-
-### Fixed
 - Harden the LLM intent arbiter: the model decision now carries a confidence level and only a high-confidence read_only rescues a failed run (read_only without high confidence is treated as implementation, keeping the guard fail-closed); tasks over 8000 characters are never arbitrated from partial evidence; and registry credentials are resolved as a method call on the model registry rather than a detached reference, so OAuth/header/environment authentication reaches the stream. Thanks to @MarcusNeufeldt for #1044.
 - Launch Herdr inspector panes with Node when Pi runs as a standalone executable. Thanks to @kevinpita for #1051.
 

--- a/src/inspectors/herdr/actions.ts
+++ b/src/inspectors/herdr/actions.ts
@@ -10,6 +10,7 @@ import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { DIRS, type Details, type SubagentState } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { resolveSubagentRunId } from "../../runs/background/run-id-resolver.ts";
+import { resolveNodeExecutable } from "../../shared/node-executable.ts";
 import { createHerdrClient, detectHerdr, type HerdrClient, type HerdrErrorCode, type HerdrResult } from "./client.ts";
 
 export const HERDR_INSPECTOR_ACTIONS = ["inspector.open", "inspector.status", "inspector.close"] as const;
@@ -90,7 +91,7 @@ function shellQuote(value: string): string {
 }
 
 function inspectorCommand(input: { runnerPath: string; asyncDir: string; runId: string; index?: number; missionPath?: string; allowSteer: boolean; allowStop: boolean }): string {
-	const args = [process.execPath, input.runnerPath, "--async-dir", input.asyncDir, "--run-id", input.runId, "--allow-steer", String(input.allowSteer), "--allow-stop", String(input.allowStop)];
+	const args = [resolveNodeExecutable(), input.runnerPath, "--async-dir", input.asyncDir, "--run-id", input.runId, "--allow-steer", String(input.allowSteer), "--allow-stop", String(input.allowStop)];
 	if (input.index !== undefined) args.push("--index", String(input.index));
 	if (input.missionPath) args.push("--mission-path", input.missionPath);
 	return `${process.platform === "win32" ? "& " : ""}${args.map(shellQuote).join(" ")}`;

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -19,6 +19,7 @@ import { buildChainInstructions, isCheckpointStep, isDynamicParallelStep, isPara
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import type { ContextMode } from "../shared/context-mode.ts";
 import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
+import { resolveNodeExecutable } from "../../shared/node-executable.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../../agents/agent-memory.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV, PROMPT_REDACTED, resolveChildCwd } from "../../shared/utils.ts";
@@ -299,27 +300,6 @@ export function isAsyncAvailable(): boolean {
 	return jitiCliPath !== undefined;
 }
 
-function isNodeExecutableName(execPath: string): boolean {
-	const basename = path.basename(execPath).toLowerCase();
-	return basename === "node" || basename === "node.exe" || basename === "nodejs" || basename === "nodejs.exe";
-}
-
-function canUseCurrentNodeExecutable(execPath: string): boolean {
-	try {
-		fs.accessSync(execPath, process.platform === "win32" ? fs.constants.F_OK : fs.constants.X_OK);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-function resolveAsyncRunnerNodeCommand(): string {
-	if (isNodeExecutableName(process.execPath) && canUseCurrentNodeExecutable(process.execPath)) {
-		return process.execPath;
-	}
-	return process.platform === "win32" ? "node.exe" : "node";
-}
-
 export function resolveAsyncRunnerLogPaths(cfg: object): { stdoutPath: string; stderrPath: string } | undefined {
 	const asyncDir = typeof (cfg as { asyncDir?: unknown }).asyncDir === "string"
 		? (cfg as { asyncDir: string }).asyncDir
@@ -486,7 +466,7 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, onProcessTerminal
 	const launchConfig = { ...cfg, runnerProcessInstanceId };
 	fs.writeFileSync(cfgPath, JSON.stringify(launchConfig));
 	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
-	const nodeCommand = resolveAsyncRunnerNodeCommand();
+	const nodeCommand = resolveNodeExecutable();
 	const launchForStartup = launchConfig as typeof launchConfig & { asyncDir?: unknown; id?: unknown; sessionId?: unknown; revivalLease?: unknown };
 	const launchAsyncDir = typeof launchForStartup.asyncDir === "string" ? launchForStartup.asyncDir : undefined;
 	const launchRunId = typeof launchForStartup.id === "string" ? launchForStartup.id : suffix;

--- a/src/shared/node-executable.ts
+++ b/src/shared/node-executable.ts
@@ -1,0 +1,21 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+function isNodeExecutableName(execPath: string): boolean {
+	const basename = path.basename(execPath).toLowerCase();
+	return basename === "node" || basename === "node.exe" || basename === "nodejs" || basename === "nodejs.exe";
+}
+
+function canUseNodeExecutable(execPath: string): boolean {
+	try {
+		fs.accessSync(execPath, process.platform === "win32" ? fs.constants.F_OK : fs.constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function resolveNodeExecutable(execPath = process.execPath): string {
+	if (isNodeExecutableName(execPath) && canUseNodeExecutable(execPath)) return execPath;
+	return process.platform === "win32" ? "node.exe" : "node";
+}

--- a/test/unit/herdr-inspector-bootstrap.test.ts
+++ b/test/unit/herdr-inspector-bootstrap.test.ts
@@ -78,7 +78,7 @@ describe("Herdr inspector bootstrap", () => {
 			assert.equal(opened.isError, undefined);
 			const command = calls.find((args) => args[0] === "pane" && args[1] === "run")?.[3] ?? "";
 			assert.equal(command.startsWith("& "), process.platform === "win32");
-			assert.match(command, process.platform === "win32" ? /'node\.exe'/ : /^'node' /);
+			assert.match(command, process.platform === "win32" ? /^& "node\.exe" / : /^'node' /);
 			assert.doesNotMatch(command, /(?:^|[\\/])pi(?:\.exe)?'/);
 		} finally {
 			process.execPath = originalExecPath;

--- a/test/unit/herdr-inspector-bootstrap.test.ts
+++ b/test/unit/herdr-inspector-bootstrap.test.ts
@@ -54,6 +54,38 @@ describe("Herdr inspector bootstrap", () => {
 		}
 	});
 
+	it("uses PATH node when Pi is a standalone executable", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-bootstrap-standalone-"));
+		const originalExecPath = process.execPath;
+		try {
+			writeCompletedRun(root);
+			process.execPath = path.join(root, process.platform === "win32" ? "pi.exe" : "pi");
+			const calls: string[][] = [];
+			const client: HerdrClient = {
+				run: async <T>(args: string[]) => {
+					calls.push(args);
+					if (args[0] === "--version") return { ok: true, data: "herdr 0.7.5" as T };
+					if (args[0] === "pane" && args[1] === "split") return { ok: true, data: { pane: { pane_id: "w1:p9" } } as T };
+					return { ok: true, data: {} as T };
+				},
+			};
+			const opened = await handleHerdrInspectorAction("inspector.open", { id: "run-123" }, {
+				cwd: root,
+				asyncDirRoot: root,
+				resultsDir: path.join(root, "results"),
+				client,
+			});
+			assert.equal(opened.isError, undefined);
+			const command = calls.find((args) => args[0] === "pane" && args[1] === "run")?.[3] ?? "";
+			assert.equal(command.startsWith("& "), process.platform === "win32");
+			assert.match(command, process.platform === "win32" ? /'node\.exe'/ : /^'node' /);
+			assert.doesNotMatch(command, /(?:^|[\\/])pi(?:\.exe)?'/);
+		} finally {
+			process.execPath = originalExecPath;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("starts the packaged bootstrap with ordinary Node", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-bootstrap-run-"));
 		try {

--- a/test/unit/node-executable.test.ts
+++ b/test/unit/node-executable.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { resolveNodeExecutable } from "../../src/shared/node-executable.ts";
+
+describe("Node executable resolution", () => {
+	it("uses an executable Node path", () => {
+		assert.equal(resolveNodeExecutable(process.execPath), process.execPath);
+	});
+
+	it("falls back to PATH node for a standalone Pi executable", () => {
+		assert.equal(resolveNodeExecutable(path.join(os.tmpdir(), process.platform === "win32" ? "pi.exe" : "pi")), process.platform === "win32" ? "node.exe" : "node");
+	});
+
+	it("falls back to PATH node for a stale Node path", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-node-executable-"));
+		try {
+			const staleNode = path.join(root, process.platform === "win32" ? "node.exe" : "node");
+			assert.equal(resolveNodeExecutable(staleNode), process.platform === "win32" ? "node.exe" : "node");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- resolve the Node executable independently from `process.execPath`
- use the shared resolver for Herdr inspectors and async runners
- add regression coverage for standalone Pi executables and stale Node paths

## Reported environment

This occurred on NixOS with Pi 0.84.1 and pi-subagents 0.48.0. Pi was installed as a standalone executable in the Nix store:

```text
/nix/store/...-pi-coding-agent-0.84.1/lib/pi/pi
```

In this environment, `process.execPath` points to that Pi executable instead of Node. Opening a Herdr inspector produced:

```text
Error: Unknown options: --async-dir, --run-id, --allow-steer, --allow-stop
```

## Problem

Standalone Pi distributions can set `process.execPath` to the `pi` executable. The Herdr inspector then runs this command:

```text
pi inspector-runner.mjs --async-dir ...
```

Pi parses the inspector arguments as its own options and exits with `Unknown options`.

## Tests

- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/herdr-inspector.test.ts test/unit/herdr-inspector-bootstrap.test.ts test/unit/node-executable.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='spawns the async runner with node when process.execPath is not node|falls back to PATH node when node-like process.execPath is stale' test/integration/async-execution.test.ts`