### PR TITLE
fix: suppress revive guidance after intercom detach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Tell parents to continue after an async launch only until the next dependency barrier, so they consume a child result before dependent work makes it obsolete. Thanks to @exuanbo for #1045.
+- Tell wait callers to reply and wait instead of reviving a wrapper that detached for intercom coordination. Thanks to @yayamaz for #1053.
 - Derive default `workflowScript` child report paths from the workflow output path while keeping the workflow aggregate report separate, and reject child output path collisions before launch (#1038).
 - Harden the LLM intent arbiter: the model decision now carries a confidence level and only a high-confidence read_only rescues a failed run (read_only without high confidence is treated as implementation, keeping the guard fail-closed); tasks over 8000 characters are never arbitrated from partial evidence; and registry credentials are resolved as a method call on the model registry rather than a detached reference, so OAuth/header/environment authentication reaches the stream. Thanks to @MarcusNeufeldt for #1044.
 - Launch Herdr inspector panes with Node when Pi runs as a standalone executable. Thanks to @kevinpita for #1051.

--- a/src/runs/background/resume-guidance.ts
+++ b/src/runs/background/resume-guidance.ts
@@ -1,6 +1,18 @@
 import * as fs from "node:fs";
 import type { AsyncRunSummary } from "./async-status.ts";
 
+const INTERCOM_DETACH_ERROR = "detached for intercom coordination";
+
+// Persisted async status has no structured intercom-detach marker yet.
+function isIntercomDetached(run: AsyncRunSummary): boolean {
+	return run.error?.toLowerCase().includes(INTERCOM_DETACH_ERROR) === true;
+}
+
+function formatIntercomDetachGuidance(run: AsyncRunSummary): string | undefined {
+	if (!isIntercomDetached(run)) return undefined;
+	return `Run "${run.id}" detached for intercom coordination. Reply to the supervisor request first, then wait with subagent_wait({ id: "${run.id}" }). Use subagent({ action: "status", id: "${run.id}" }) to recover the result; do not resume or launch a replacement while it remains detached.`;
+}
+
 export function formatAsyncReviveCommand(run: AsyncRunSummary): string | undefined {
 	const step = run.steps.find((candidate) => candidate.status === "failed" && candidate.sessionFile && fs.existsSync(candidate.sessionFile));
 	if (!step) {
@@ -15,19 +27,26 @@ export function formatAsyncReviveCommand(run: AsyncRunSummary): string | undefin
 
 export function formatResumeFirstFailedRunDetail(run: AsyncRunSummary): string | undefined {
 	if (run.state !== "failed") return undefined;
+	const detachGuidance = formatIntercomDetachGuidance(run);
+	if (detachGuidance) return detachGuidance;
 	const command = formatAsyncReviveCommand(run);
 	if (!command) return undefined;
 	return `Resume-first: failed run "${run.id}" has a persisted child session. Revive the original run with ${command} before reporting failure or launching a replacement. Launch a replacement only if revive fails or the user explicitly asks for one.`;
 }
 
 export function formatResumeFirstFailedRunsNote(runs: AsyncRunSummary[]): string {
-	const resumable = runs
-		.filter((run) => run.state === "failed")
+	const failedRuns = runs.filter((run) => run.state === "failed");
+	const detachGuidance = failedRuns
+		.map(formatIntercomDetachGuidance)
+		.filter((guidance): guidance is string => Boolean(guidance));
+	const resumable = failedRuns
+		.filter((run) => !isIntercomDetached(run))
 		.map((run) => ({ run, command: formatAsyncReviveCommand(run) }))
 		.filter((entry): entry is { run: AsyncRunSummary; command: string } => Boolean(entry.command));
-	if (resumable.length === 0) return "";
-	const guidance = resumable.length === 1
-		? `failed run "${resumable[0]!.run.id}" has a persisted child session. Revive the original run with ${resumable[0]!.command}`
-		: `${resumable.length} failed runs have persisted child sessions. Inspect status and revive each original run before retrying`;
-	return ` Resume-first: ${guidance} before reporting failure or launching a replacement. Launch a replacement only if revive fails or the user explicitly asks for one.`;
+	const resumeGuidance = resumable.length === 0
+		? ""
+		: resumable.length === 1
+			? ` Resume-first: failed run "${resumable[0]!.run.id}" has a persisted child session. Revive the original run with ${resumable[0]!.command} before reporting failure or launching a replacement. Launch a replacement only if revive fails or the user explicitly asks for one.`
+			: ` Resume-first: ${resumable.length} failed runs have persisted child sessions. Inspect status and revive each original run before reporting failure or launching a replacement. Launch a replacement only if revive fails or the user explicitly asks for one.`;
+	return `${detachGuidance.length > 0 ? ` ${detachGuidance.join(" ")}` : ""}${resumeGuidance}`;
 }

--- a/src/runs/background/resume-guidance.ts
+++ b/src/runs/background/resume-guidance.ts
@@ -3,9 +3,10 @@ import type { AsyncRunSummary } from "./async-status.ts";
 
 const INTERCOM_DETACH_ERROR = "detached for intercom coordination";
 
-// Persisted async status has no structured intercom-detach marker yet.
 function isIntercomDetached(run: AsyncRunSummary): boolean {
-	return run.error?.toLowerCase().includes(INTERCOM_DETACH_ERROR) === true;
+	return run.steps.some((step) => step.execution?.status === "detached"
+		|| step.error?.toLowerCase().includes(INTERCOM_DETACH_ERROR) === true)
+		|| run.error?.toLowerCase().includes(INTERCOM_DETACH_ERROR) === true;
 }
 
 function formatIntercomDetachGuidance(run: AsyncRunSummary): string | undefined {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -143,6 +143,8 @@ import {
 	type ChildWatchdogStateSnapshot,
 } from "../../watchdog/child-status.ts";
 
+const INTERCOM_DETACH_RECEIPT = "Detached for intercom coordination before task completion.";
+
 interface SubagentRunConfig {
 	id: string;
 	steps: RunnerStep[];
@@ -1693,6 +1695,7 @@ async function runSingleStep(
 	const acceptanceFailure = effectiveAcceptance ? acceptanceFailureMessage(effectiveAcceptance) : undefined;
 	const acceptanceCanFailRun = acceptanceFailure && effectiveAcceptance?.explicit && (finalResult?.exitCode ?? 1) === 0 && !finalResult?.interrupted && !timedOutAfterAcceptance && !stoppedAfterAcceptance && !turnBudgetExceeded && !isAgentContractV1(step.agentContract);
 	const effectiveFinalExitCode = timedOutAfterAcceptance || stoppedAfterAcceptance || turnBudgetExceeded ? 1 : acceptanceCanFailRun ? 1 : finalResult?.exitCode ?? 1;
+	const intercomDetachReceipt = finalResult?.finalOutput === INTERCOM_DETACH_RECEIPT;
 	const effectiveFinalError = stoppedAfterAcceptance
 		? ctx.stopMessage ?? "Subagent stopped by user."
 		: timedOutAfterAcceptance
@@ -1701,7 +1704,7 @@ async function runSingleStep(
 				? finalResult?.error ?? (turnBudget ? turnBudgetExceededMessage(turnBudget, turnBudget.turnCount) : "Subagent exceeded turn budget.")
 				: acceptanceCanFailRun
 					? (finalResult?.error ? `${finalResult.error}\n${acceptanceFailure}` : acceptanceFailure)
-					: finalResult?.error;
+					: finalResult?.error ?? (intercomDetachReceipt ? INTERCOM_DETACH_RECEIPT : undefined);
 
 	const artifactErrors = artifactPaths && ctx.artifactConfig?.enabled !== false
 		? persistStepArtifacts({

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -497,6 +497,17 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(status.endedAt !== undefined, true);
 	});
 
+	it("persists intercom detach receipts on failed async steps", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "Detached for intercom coordination before task completion.", exitCode: -2 });
+		const id = `async-intercom-detach-${Date.now().toString(36)}`;
+		launchProtocolTest(id);
+		await waitForAsyncResultFile(id);
+		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
+		assert.equal(status.state, "failed");
+		assert.equal(status.error, "Step failed: worker");
+		assert.equal(status.steps?.[0]?.error, "Detached for intercom coordination before task completion.");
+	});
+
 	it("persists absent output provenance when async lifecycle text is synthetic", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ jsonl: [mockAssistantMessage("", "tool_use")], stderr: "mock child failure", exitCode: 1 });
 		const id = `async-output-absent-${Date.now().toString(36)}`;

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -229,8 +229,8 @@ describe("subagent_wait tool", () => {
 			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
 				sleep: async () => writeStatus(asyncRoot, "run-detached", "failed", {
 					sessionId: "sess-1",
-					error: "Wrapper failed after child detached for INTERCOM coordination before task completion.",
-					steps: [{ agent: "worker", status: "failed", sessionFile }],
+					error: "Step failed: worker",
+					steps: [{ agent: "worker", status: "failed", sessionFile, error: "Detached for intercom coordination before task completion." }],
 				}),
 			}));
 

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -218,6 +218,32 @@ describe("subagent_wait tool", () => {
 		}
 	});
 
+	it("tells blocking callers to reply and wait for intercom-detached failed runs", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-intercom-detach-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const sessionFile = path.join(root, "worker-session.jsonl");
+			fs.writeFileSync(sessionFile, "{}\n", "utf-8");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-detached", "running", { sessionId: "sess-1", pid: 999999 });
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
+				sleep: async () => writeStatus(asyncRoot, "run-detached", "failed", {
+					sessionId: "sess-1",
+					error: "Wrapper failed after child detached for INTERCOM coordination before task completion.",
+					steps: [{ agent: "worker", status: "failed", sessionFile }],
+				}),
+			}));
+
+			const text = textOf(result);
+			assert.match(text, /Reply to the supervisor request first/);
+			assert.match(text, /wait with subagent_wait/);
+			assert.match(text, /do not resume or launch a replacement/);
+			assert.doesNotMatch(text, /Resume-first/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("surfaces terminal completion payloads from the result file in details.completions", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-completions-file-"));
 		try {

--- a/test/unit/wait-subscriptions.test.ts
+++ b/test/unit/wait-subscriptions.test.ts
@@ -235,6 +235,40 @@ describe("non-blocking wait subscriptions", () => {
 		}
 	});
 
+	it("tells the parent to reply and wait for an intercom-detached failed async run", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-intercom-detach-"));
+		const asyncRoot = path.join(root, "runs");
+		const subscriptionsDir = path.join(root, "subscriptions");
+		const sessionFile = path.join(root, "worker-session.jsonl");
+		const sent: string[] = [];
+		const state = makeState();
+		const manager = createWaitSubscriptionManager({
+			events: new TestBus(),
+			sendMessage(message: { content?: unknown }) { sent.push(String(message.content)); },
+		} as never, state, { asyncDirRoot: asyncRoot, subscriptionsDir, pollIntervalMs: 60_000, kill: () => true });
+		try {
+			fs.writeFileSync(sessionFile, "{}\n", "utf-8");
+			writeStatus(asyncRoot, "run-detached", "running", { sessionId: "session-a", pid: 999_999 });
+			manager.arm({ targetKind: "async", runId: "run-detached", requestedId: "run-detached", timeoutMs: 30_000 });
+
+			writeStatus(asyncRoot, "run-detached", "failed", {
+				sessionId: "session-a",
+				error: "Wrapper failed after child detached for INTERCOM coordination before task completion.",
+				steps: [{ agent: "worker", status: "failed", sessionFile }],
+			});
+			manager.reconcile();
+
+			const message = sent[0] ?? "";
+			assert.match(message, /Reply to the supervisor request first/);
+			assert.match(message, /wait with subagent_wait/);
+			assert.match(message, /do not resume or launch a replacement/);
+			assert.doesNotMatch(message, /Resume-first/);
+		} finally {
+			manager.dispose();
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("waits for foreground run restoration before reconciling a restored subscription", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-foreground-restore-"));
 		const subscriptionsDir = path.join(root, "subscriptions");

--- a/test/unit/wait-subscriptions.test.ts
+++ b/test/unit/wait-subscriptions.test.ts
@@ -253,8 +253,8 @@ describe("non-blocking wait subscriptions", () => {
 
 			writeStatus(asyncRoot, "run-detached", "failed", {
 				sessionId: "session-a",
-				error: "Wrapper failed after child detached for INTERCOM coordination before task completion.",
-				steps: [{ agent: "worker", status: "failed", sessionFile }],
+				error: "Step failed: worker",
+				steps: [{ agent: "worker", status: "failed", sessionFile, error: "Detached for intercom coordination before task completion." }],
 			});
 			manager.reconcile();
 


### PR DESCRIPTION
Suppress revive-first guidance when a failed async wait is caused by a child wrapper detaching for intercom coordination.

Fixes #1053.

Validation:
- node --experimental-strip-types --test test/unit/subagent-wait.test.ts test/unit/wait-subscriptions.test.ts
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern="persists intercom detach receipts on failed async steps" test/integration/async-execution.test.ts
- npm run typecheck
- git diff --check origin/main..HEAD
- fresh exact-head review: No issues found