### PR TITLE
docs: add current UI display examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add main-window renderer density controls for subagent call/result spacing and collapsed result height. Thanks to @pierre-mgmt for #1048.
 - Add `debug.run` for async run lifecycle diagnostics without exposing prompts, secrets, or transcripts (#1037).
 - Add `tools: "inherit"` for builtin role overrides, so one role can inherit Pi's normal tools and extensions without shadowing the agent file. Thanks to @estanexanavsem for #1047 and @davidarny for #1049.
+- Add simple terminal examples for FleetView, the async widget, and inline tool display. Thanks to @czottmann for #1050.
 
 ### Fixed
 - Tell parents to continue after an async launch only until the next dependency barrier, so they consume a child result before dependent work makes it obsolete. Thanks to @exuanbo for #1045.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,12 @@ Controls only the main chat `subagent` call/result renderer. It does not change 
 
 `compactResultMaxLines` is a positive integer. It caps only collapsed rich-result rows and adds an expand hint when rows are hidden. Expanded output remains uncapped.
 
+With `"summary"`, a tool result looks like this:
+
+```text
+✓ reviewer · completed
+```
+
 ## `asyncByDefault`
 
 ```json

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,12 +23,13 @@ subagent({ action: "status", id: "..." })      // one run
 
 Or ask naturally: "Show me the current async runs."
 
-The under-editor async widget gives a short view while work runs:
+The under-editor async widget gives a short view while work runs. Its expand key follows your Pi keybinding:
 
 ```text
-● scout
+async subagent worker · background
+● worker · running
   ⎿  reading src/auth.ts
-  Ctrl+O to expand
+  Press configured-expand-key for live detail
 ```
 
 To inspect one background child in text, use `subagent({ action: "status", id: "...", view: "transcript" })`; add `index` for a specific child in a parallel or chain run.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,13 +23,35 @@ subagent({ action: "status", id: "..." })      // one run
 
 Or ask naturally: "Show me the current async runs."
 
+The under-editor async widget gives a short view while work runs:
+
+```text
+● scout
+  ⎿  reading src/auth.ts
+  Ctrl+O to expand
+```
+
 To inspect one background child in text, use `subagent({ action: "status", id: "...", view: "transcript" })`; add `index` for a specific child in a parallel or chain run.
 
 ## FleetView
 
 In the TUI, a persistent FleetView below the editor keeps active work visible as a compact summary. Set `fleetViewPlacement` to `"aboveEditor"` to move it above the editor.
 
-When the focused editor is empty, press `↓` or `←` to expand the summary into `main` plus active children with task, elapsed time, and token totals. Then use `↑`/`↓` or `j`/`k` to select a child and `Enter` to inspect it. Printable navigation keys are never intercepted before activation.
+```text
+2 active agents · ↓ 4.2k tokens · ↓/← to inspect
+```
+
+After you expand it:
+
+```text
+↑↓/jk select · enter inspect · esc back
+
+> main
+    scout · running                  1m 12s · ↓ 2.8k tokens
+    reviewer · running                 38s · ↓ 1.4k tokens
+```
+
+When the focused editor is empty, press `↓` or `←` to expand the summary into `main` plus active children with agent name, state, elapsed time, and token totals. Then use `↑`/`↓` or `j`/`k` to select a child and `Enter` to inspect it. Printable navigation keys are never intercepted before activation.
 
 FleetView replaces the legacy above-editor async widget by default. Successful background completions stay quiet so inactive Pi tabs are not marked unread, while failed or paused completions still notify the originating session. Parallel runs show every active child independently. Chains with parallel groups keep their grouped shape in progress and results, so failed or paused agents stay visible next to completed ones. When a child is explicitly allowed to fan out with `tools: subagent`, its nested runs appear under that parent child in the main status tree instead of being hidden inside the child process.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,9 +27,10 @@ The under-editor async widget gives a short view while work runs. Its expand key
 
 ```text
 async subagent worker · background
-● worker · running
-  ⎿  reading src/auth.ts
-  Press configured-expand-key for live detail
+● worker
+  ● Step 1/1: worker · running
+    ⎿  reading src/auth.ts
+    Press configured-expand-key for live detail
 ```
 
 To inspect one background child in text, use `subagent({ action: "status", id: "...", view: "transcript" })`; add `index` for a specific child in a parallel or chain run.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -29,7 +29,7 @@ The under-editor async widget gives a short view while work runs. Its expand key
 async subagent worker · background
 ● worker
   ● Step 1/1: worker · running
-    ⎿  reading src/auth.ts
+    ⎿  read: src/auth.ts | 2.0s
     Press configured-expand-key for live detail
 ```
 


### PR DESCRIPTION
Add current terminal examples for Fleet, async widget, inline result, and live activity display.

Fixes #1050.

Validation:
- git diff --check origin/main..HEAD
- fresh exact-head docs review: No issues found