### PR TITLE
fix: preserve stopped workflow child state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add simple terminal examples for FleetView, the async widget, and inline tool display. Thanks to @czottmann for #1050.
 
 ### Fixed
+- Show children interrupted by a parent-stopped workflow as stopped instead of failed, and preserve the workflow stop reason (#1060).
 - Tell parents to continue after an async launch only until the next dependency barrier, so they consume a child result before dependent work makes it obsolete. Thanks to @exuanbo for #1045.
 - Tell wait callers to reply and wait instead of reviving a wrapper that detached for intercom coordination. Thanks to @yayamaz for #1053.
 - Derive default `workflowScript` child report paths from the workflow output path while keeping the workflow aggregate report separate, and reject child output path collisions before launch (#1038).

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4990,12 +4990,20 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							if (entry.operation !== "run") continue;
 							const existing = workflowSteps.get(entry.key);
 							if (entry.state === "reused" && existing) continue;
-							const mapped = entry.state === "started" || entry.state === "reused" ? "running" : entry.state === "completed" ? "completed" : "failed";
+							const mapped = entry.state === "started" || entry.state === "reused"
+								? "running"
+								: entry.state === "completed"
+									? "completed"
+									: entry.state === "stopped"
+										? "stopped"
+										: "failed";
 							if (existing) {
 								existing.status = mapped;
 								if (entry.agent) existing.agent = entry.agent;
 								if (entry.runId) existing.runId = entry.runId;
 								if (entry.state === "failed" && !entry.runId && existing.async === undefined) existing.async = false;
+								if (entry.state === "stopped") existing.stopped = true;
+								else delete existing.stopped;
 								if (entry.error === undefined) delete existing.error;
 								else existing.error = entry.error;
 								if (entry.durationMs === undefined) delete existing.durationMs;
@@ -5010,6 +5018,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 									startedAt: Date.now(),
 									...(entry.runId ? { runId: entry.runId } : {}),
 									...(entry.state === "failed" && !entry.runId ? { async: false } : {}),
+									...(entry.state === "stopped" ? { stopped: true } : {}),
 								};
 								status.steps?.push(step);
 								workflowSteps.set(entry.key, step);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5084,7 +5084,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 									return execute(randomUUID(), childRequest, workflowSignal, (update) => {
 										const progress = update.details.progress?.[0];
 										const step = status.steps?.find((candidate) => candidate.workflowKey === key);
-										if (!progress || !step) return;
+										if (!progress || !step || step.stopped) return;
 										step.status = progress.status === "completed" ? "completed" : progress.status === "failed" ? "failed" : "running";
 										step.activityState = progress.activityState;
 										step.lastActivityAt = progress.lastActivityAt;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1086,7 +1086,7 @@ export interface Details {
 		trace: Array<{
 			operation: "run" | "status";
 			key: string;
-			state: "started" | "completed" | "failed" | "reused";
+			state: "started" | "completed" | "failed" | "stopped" | "reused";
 			agent?: string;
 			runId?: string;
 			phase?: string;

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1635,6 +1635,7 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 function workflowRowGlyph(row: WorkflowChatProgressRow, theme: Theme, frame?: number): string {
 	if (row.state === "running") return theme.fg("accent", runningGlyph(frame));
 	if (row.state === "complete") return theme.fg("success", "✓");
+	if (row.state === "stopped") return theme.fg("warning", "■");
 	return theme.fg("error", "✗");
 }
 
@@ -1642,6 +1643,7 @@ function workflowRowStateLabel(row: WorkflowChatProgressRow, theme: Theme): stri
 	const label = (row.state === "complete" ? "complete" : row.state).padEnd(8);
 	if (row.state === "running") return theme.fg("accent", label);
 	if (row.state === "complete") return theme.fg("success", label);
+	if (row.state === "stopped") return theme.fg("warning", label);
 	return theme.fg("error", label);
 }
 

--- a/src/workflows/chat-progress.ts
+++ b/src/workflows/chat-progress.ts
@@ -96,7 +96,7 @@ export function resolveWorkflowChatProgress(input: ResolveWorkflowChatProgressIn
 
 export interface WorkflowChatProgressRow {
 	key: string;
-	state: "running" | "complete" | "failed";
+	state: "running" | "complete" | "failed" | "stopped";
 	label?: string;
 	phase?: string;
 	runId?: string;
@@ -123,7 +123,13 @@ export function buildWorkflowChatProgressRows(trace: NonNullable<Details["workfl
 			continue;
 		}
 		const next: WorkflowChatProgressRow = existing ?? { key: entry.key, state: "running" };
-		next.state = entry.state === "completed" ? "complete" : entry.state === "failed" ? "failed" : "running";
+		next.state = entry.state === "completed"
+			? "complete"
+			: entry.state === "failed"
+				? "failed"
+				: entry.state === "stopped"
+					? "stopped"
+					: "running";
 		const label = cleanLabel(entry.label);
 		const phase = cleanLabel(entry.phase);
 		if (label) next.label = label;

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -642,6 +642,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				const target = known?.runId ?? keyOrRunId;
 				trace.push({ operation: "status", key: keyOrRunId, state: "started", ...(known?.runId ? { runId: known.runId } : {}) });
 				traceChanged();
+				if (settled) return;
 				respond(options.status(target, childController.signal).then((result) => {
 					if (settled) return result;
 					trace.push({ operation: "status", key: keyOrRunId, state: result.ok ? "completed" : "failed", ...(result.runId ? { runId: result.runId } : {}), ...(!result.ok ? { error: result.output } : {}) });

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -643,6 +643,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				trace.push({ operation: "status", key: keyOrRunId, state: "started", ...(known?.runId ? { runId: known.runId } : {}) });
 				traceChanged();
 				respond(options.status(target, childController.signal).then((result) => {
+					if (settled) return result;
 					trace.push({ operation: "status", key: keyOrRunId, state: result.ok ? "completed" : "failed", ...(result.runId ? { runId: result.runId } : {}), ...(!result.ok ? { error: result.output } : {}) });
 					traceChanged();
 					if (!result.ok) throw new Error(`Status '${keyOrRunId}' failed: ${result.output}`);

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -723,7 +723,14 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				admission = Promise.resolve().then(() => options.admit?.(calls));
 				if (batch) batchAdmissions.set(batch.id, admission);
 			}
-			const promise = admission.then(() => options.launch(key, { ...params, async: params.async ?? false }, childController.signal, { admitted: true })).then((result) => {
+			const promise = admission.then(() => {
+				if (settled || stoppedLaunches.has(key)) {
+					const reason = childController.signal.reason;
+					const text = reason instanceof Error ? reason.message : typeof reason === "string" ? reason : "Workflow script aborted.";
+					return { key, ok: false, output: text, error: text, artifactPaths: [] };
+				}
+				return options.launch(key, { ...params, async: params.async ?? false }, childController.signal, { admitted: true });
+			}).then((result) => {
 				const normalized = !result.ok && !result.error ? { ...result, error: result.output } : result;
 				if (stoppedLaunches.has(key)) return normalized;
 				children.set(key, normalized);

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -332,7 +332,7 @@ export interface WorkflowScriptChildResult {
 export interface WorkflowScriptTraceEntry {
 	operation: "run" | "status";
 	key: string;
-	state: "started" | "completed" | "failed" | "reused";
+	state: "started" | "completed" | "failed" | "stopped" | "reused";
 	/** Canonical child agent name when resolved launch or result data is available. */
 	agent?: string;
 	runId?: string;
@@ -492,6 +492,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 	const children = new Map<string, WorkflowScriptChildResult>();
 	const childOrder: string[] = [];
 	const launches = new Map<string, { fingerprint: string; promise: Promise<WorkflowScriptChildResult>; observed: boolean }>();
+	const stoppedLaunches = new Set<string>();
 	const batchAdmissions = new Map<string, Promise<void>>();
 	const observedRunCalls = new Set<number>();
 	const childController = new AbortController();
@@ -519,7 +520,30 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			else if (completionError) reject(new WorkflowScriptError(completionError.message, partial()));
 			else resolve({ value: outcome.value, ...partial() });
 		};
-		const onAbort = () => finish({ error: new Error("Workflow script aborted.") });
+		const onAbort = () => {
+			const signalReason = options.signal?.reason;
+			const error = signalReason instanceof Error
+				? signalReason
+				: typeof signalReason === "string"
+					? new Error(signalReason)
+					: new Error("Workflow script aborted.");
+			for (const key of launches.keys()) {
+				if (children.has(key)) continue;
+				stoppedLaunches.add(key);
+				const started = trace.findLast((entry) => entry.operation === "run" && entry.key === key && entry.state === "started");
+				trace.push({
+					operation: "run",
+					key,
+					state: "stopped",
+					...(started?.agent ? { agent: started.agent } : {}),
+					...(started?.phase ? { phase: started.phase } : {}),
+					...(started?.label ? { label: started.label } : {}),
+					error: error.message,
+				});
+			}
+			traceChanged();
+			finish({ error });
+		};
 		const timer = options.timeoutMs === undefined
 			? undefined
 			: setTimeout(() => finish({ error: new Error(`Workflow script timed out after ${options.timeoutMs}ms.`) }), options.timeoutMs);
@@ -699,6 +723,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			}
 			const promise = admission.then(() => options.launch(key, { ...params, async: params.async ?? false }, childController.signal, { admitted: true })).then((result) => {
 				const normalized = !result.ok && !result.error ? { ...result, error: result.output } : result;
+				if (stoppedLaunches.has(key)) return normalized;
 				children.set(key, normalized);
 				trace.push({ operation: "run", key, state: normalized.ok ? "completed" : "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(normalized.agent ? { agent: normalized.agent } : {}), ...(normalized.runId ? { runId: normalized.runId } : {}), ...(!normalized.ok ? { error: normalized.error ?? normalized.output } : {}) });
 				traceChanged();
@@ -706,6 +731,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			}, (error: unknown) => {
 				const text = error instanceof Error ? error.message : String(error);
 				const failure: WorkflowScriptChildResult = { key, ok: false, output: text, error: text, artifactPaths: [] };
+				if (stoppedLaunches.has(key)) return failure;
 				children.set(key, failure);
 				trace.push({ operation: "run", key, state: "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), error: text });
 				traceChanged();

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -555,6 +555,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			if (!settled && code !== 0) finish({ error: new Error(`Workflow worker exited with code ${code}.`) });
 		});
 		worker.on("message", (message: Record<string, unknown>) => {
+			if (settled) return;
 			if (message.type === "emit") {
 				try {
 					assertWorkflowJsonValue(message.value, "emit");

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -718,7 +718,10 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 					seenKeys.add(call.key);
 					return true;
 				});
-				admission = Promise.resolve().then(() => options.admit?.(calls));
+				admission = Promise.resolve().then(() => {
+					if (settled) return;
+					return options.admit?.(calls);
+				});
 				if (batch) batchAdmissions.set(batch.id, admission);
 			}
 			const promise = admission.then(() => {

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -706,9 +706,6 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			}
 
 			const startedAt = Date.now();
-			childOrder.push(key);
-			trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(params) });
-			traceChanged();
 			const batch = isRecord(message.args.batch) && typeof message.args.batch.id === "string" && Array.isArray(message.args.batch.calls)
 				? { id: message.args.batch.id, calls: message.args.batch.calls.filter((call): call is { key: string; params: Record<string, unknown> } => isRecord(call) && typeof call.key === "string" && isRecord(call.params)) }
 				: undefined;
@@ -747,6 +744,9 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				return failure;
 			});
 			launches.set(key, { fingerprint, promise, observed: callObserved });
+			childOrder.push(key);
+			trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(params) });
+			traceChanged();
 			respond(deliver(promise));
 		});
 

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -901,6 +901,13 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			if (status.steps?.some((step) => step.workflowKey === "review" && step.status === "running")) break;
 			await new Promise((resolve) => setTimeout(resolve, 20));
 		}
+		let childCall: string | undefined;
+		for (let attempt = 0; attempt < 100 && !childCall; attempt++) {
+			childCall = fs.readdirSync(mockPi.dir).find((name) => /^call-\d+-\d+-/.test(name));
+			if (!childCall) await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		const childPid = Number(childCall?.match(/^call-\d+-(\d+)-/)?.[1]);
+		assert.equal(Number.isInteger(childPid) && childPid > 0, true);
 
 		const stopped = await executor.execute(
 			"stop-workflow-child",
@@ -923,6 +930,26 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(status.steps?.[0]?.error, "Workflow stopped by user.");
 		assert.equal(status.workflow?.trace.some((entry) => entry.key === "review" && entry.state === "stopped"), true);
 		assert.equal(status.workflow?.trace.some((entry) => entry.key === "review" && entry.state === "failed"), false);
+
+		let childSettled = false;
+		for (let attempt = 0; attempt < 100; attempt++) {
+			try {
+				process.kill(childPid, 0);
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+					childSettled = true;
+					break;
+				}
+				throw error;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		assert.equal(childSettled, true, "child process must settle after the workflow stop");
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		status = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatus;
+		assert.equal(status.steps?.[0]?.status, "stopped");
+		assert.equal(status.steps?.[0]?.stopped, true);
+		assert.equal(status.steps?.[0]?.error, "Workflow stopped by user.");
 
 		fs.rmSync(started.details.asyncDir!, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 		fs.rmSync(path.join(DIRS.results, `${workflowRunId}.json`), { force: true });

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -882,6 +882,52 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.content[0]?.text ?? "", /Stop requested for async workflow workflow-stop/);
 	});
 
+	it("persists parent-stopped workflow children as stopped instead of failed", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ delay: 5_000, output: "too late" });
+		const workflowControllers = new Map<string, AbortController>();
+		const executor = makeExecutor([makeAgent("echo")], {}, false, undefined, true, new Map(), workflowControllers);
+		const started = await executor.execute(
+			`workflow-stop-child-${Date.now()}`,
+			{ workflowScript: `return await runs.run("review", { agent: "echo", task: "Wait" });` },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.ok(started.details.asyncId);
+		const workflowRunId = started.details.asyncId;
+		const statusPath = path.join(started.details.asyncDir!, "status.json");
+		for (let attempt = 0; attempt < 100; attempt++) {
+			const status = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatus;
+			if (status.steps?.some((step) => step.workflowKey === "review" && step.status === "running")) break;
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+
+		const stopped = await executor.execute(
+			"stop-workflow-child",
+			{ action: "stop", id: workflowRunId },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(stopped.isError, undefined);
+
+		let status: AsyncStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+		for (let attempt = 0; attempt < 100 && status.state !== "stopped"; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+		}
+		assert.equal(status.state, "stopped");
+		assert.equal(status.error, "Workflow stopped by user.");
+		assert.equal(status.steps?.[0]?.status, "stopped");
+		assert.equal(status.steps?.[0]?.stopped, true);
+		assert.equal(status.steps?.[0]?.error, "Workflow stopped by user.");
+		assert.equal(status.workflow?.trace.some((entry) => entry.key === "review" && entry.state === "stopped"), true);
+		assert.equal(status.workflow?.trace.some((entry) => entry.key === "review" && entry.state === "failed"), false);
+
+		fs.rmSync(started.details.asyncDir!, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+		fs.rmSync(path.join(DIRS.results, `${workflowRunId}.json`), { force: true });
+	});
+
 	it("reports completed async workflows as not running when stopped after completion", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const runId = `workflow-stop-complete-${Date.now()}`;
 		const asyncDir = path.join(DIRS.async, runId);

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -793,6 +793,7 @@ describe("scripted workflow runtime", () => {
 
 	it("marks a child stopped when abort fires during the started trace callback", async () => {
 		const controller = new AbortController();
+		let admitCount = 0;
 		let launchCount = 0;
 
 		await assert.rejects(
@@ -802,6 +803,9 @@ describe("scripted workflow runtime", () => {
 				onTrace(trace) {
 					const started = trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "started");
 					if (started && !controller.signal.aborted) controller.abort(new Error("Workflow stopped by user."));
+				},
+				admit() {
+					admitCount += 1;
 				},
 				async launch(key) {
 					launchCount += 1;
@@ -815,6 +819,7 @@ describe("scripted workflow runtime", () => {
 				&& !error.partial.trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "failed"),
 		);
 		await new Promise((resolve) => queueMicrotask(resolve));
+		assert.equal(admitCount, 0);
 		assert.equal(launchCount, 0);
 	});
 

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -829,4 +829,34 @@ describe("scripted workflow runtime", () => {
 			workerPrototype.postMessage = originalPostMessage;
 		}
 	});
+
+	it("drops a status response that settles after the workflow aborts", async () => {
+		const controller = new AbortController();
+		let traceLengths: number[] = [];
+		let resolveStatus!: (result: { key: string; ok: true; output: string; artifactPaths: string[] }) => void;
+		let markStatusStarted!: () => void;
+		const statusStarted = new Promise<void>((resolve) => { markStatusStarted = resolve; });
+
+		const workflow = runWorkflowScript({
+			script: `await runs.status("probe");`,
+			signal: controller.signal,
+			onTrace(trace) { traceLengths.push(trace.length); },
+			async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			status(key) {
+				markStatusStarted();
+				return new Promise((resolve) => { resolveStatus = resolve; });
+			},
+		});
+
+		await statusStarted;
+		controller.abort(new Error("Workflow stopped by user."));
+		await assert.rejects(workflow, (error: unknown) => error instanceof WorkflowScriptError
+			&& error.message === "Workflow stopped by user."
+			&& error.partial.trace.some((entry) => entry.operation === "status" && entry.key === "probe" && entry.state === "started")
+			&& !error.partial.trace.some((entry) => entry.operation === "status" && entry.key === "probe" && entry.state === "completed"));
+		const finalTraceLength = traceLengths.at(-1);
+		resolveStatus({ key: "probe", ok: true, output: "done", artifactPaths: [] });
+		await new Promise((resolve) => queueMicrotask(resolve));
+		assert.equal(traceLengths.at(-1), finalTraceLength);
+	});
 });

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -773,8 +773,11 @@ describe("scripted workflow runtime", () => {
 				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
 			});
 			await launchStarted;
-			controller.abort();
-			await assert.rejects(workflow, (error: unknown) => error instanceof WorkflowScriptError && /aborted/.test(error.message));
+			controller.abort(new Error("Workflow stopped by user."));
+			await assert.rejects(workflow, (error: unknown) => error instanceof WorkflowScriptError
+				&& error.message === "Workflow stopped by user."
+				&& error.partial.trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "stopped" && entry.error === "Workflow stopped by user.")
+				&& !error.partial.trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "failed"));
 			workflowSettled = true;
 			resolveLaunch({ key: "slow", ok: true, output: "done", artifactPaths: [], results: [] });
 			await new Promise((resolve) => queueMicrotask(resolve));

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -889,6 +889,33 @@ describe("scripted workflow runtime", () => {
 		}
 	});
 
+	it("does not dispatch status after abort fires during the status started trace callback", async () => {
+		const controller = new AbortController();
+		let statusCount = 0;
+
+		await assert.rejects(
+			runWorkflowScript({
+				script: `await runs.status("probe");`,
+				signal: controller.signal,
+				onTrace(trace) {
+					const started = trace.some((entry) => entry.operation === "status" && entry.key === "probe" && entry.state === "started");
+					if (started && !controller.signal.aborted) controller.abort(new Error("Workflow stopped by user."));
+				},
+				async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				async status(key) {
+					statusCount += 1;
+					return { key, ok: true, output: "done", artifactPaths: [] };
+				},
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError
+				&& error.message === "Workflow stopped by user."
+				&& error.partial.trace.some((entry) => entry.operation === "status" && entry.key === "probe" && entry.state === "started")
+				&& !error.partial.trace.some((entry) => entry.operation === "status" && entry.key === "probe" && entry.state === "completed"),
+		);
+		await new Promise((resolve) => queueMicrotask(resolve));
+		assert.equal(statusCount, 0);
+	});
+
 	it("drops a status response that settles after the workflow aborts", async () => {
 		const controller = new AbortController();
 		let traceLengths: number[] = [];

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -791,6 +791,38 @@ describe("scripted workflow runtime", () => {
 		}
 	});
 
+	it("does not launch a child after admission settles following workflow abort", async () => {
+		const controller = new AbortController();
+		let launchCount = 0;
+		let resolveAdmission!: () => void;
+		let markAdmissionStarted!: () => void;
+		const admissionStarted = new Promise<void>((resolve) => { markAdmissionStarted = resolve; });
+
+		const workflow = runWorkflowScript({
+			script: `await runs.run("slow", { agent: "worker", task: "wait" });`,
+			signal: controller.signal,
+			admit() {
+				markAdmissionStarted();
+				return new Promise<void>((resolve) => { resolveAdmission = resolve; });
+			},
+			async launch(key) {
+				launchCount += 1;
+				return { key, ok: true, output: "done", artifactPaths: [] };
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		await admissionStarted;
+		controller.abort(new Error("Workflow stopped by user."));
+		await assert.rejects(workflow, (error: unknown) => error instanceof WorkflowScriptError
+			&& error.message === "Workflow stopped by user."
+			&& error.partial.trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "stopped")
+			&& !error.partial.trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "failed"));
+		resolveAdmission();
+		await new Promise((resolve) => queueMicrotask(resolve));
+		assert.equal(launchCount, 0);
+	});
+
 	it("drops a child response that settles after the workflow aborts", async () => {
 		const workerPrototype = Worker.prototype as unknown as { postMessage(value: unknown, ...args: unknown[]): void };
 		const originalPostMessage = workerPrototype.postMessage;

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -748,6 +748,49 @@ describe("scripted workflow runtime", () => {
 		assert.equal(childAborted, true);
 	});
 
+	it("ignores a queued child launch message after workflow abort", async () => {
+		const originalOn = Worker.prototype.on;
+		const controller = new AbortController();
+		let launchCount = 0;
+		let deliverCapturedRunMessage: (() => void) | undefined;
+		let markRunMessageCaptured!: () => void;
+		const runMessageCaptured = new Promise<void>((resolve) => { markRunMessageCaptured = resolve; });
+
+		(Worker.prototype as unknown as { on: typeof Worker.prototype.on }).on = function (event: string | symbol, listener: (...args: unknown[]) => void) {
+			if (event !== "message") return originalOn.call(this, event, listener);
+			const wrapped = (message: Record<string, unknown>) => {
+				if (message.type === "call" && message.method === "run") {
+					deliverCapturedRunMessage = () => listener.call(this, message);
+					markRunMessageCaptured();
+					return;
+				}
+				listener.call(this, message);
+			};
+			return originalOn.call(this, event, wrapped);
+		};
+
+		try {
+			const workflow = runWorkflowScript({
+				script: `await runs.run("late", { agent: "worker", task: "wait" });`,
+				signal: controller.signal,
+				async launch(key) {
+					launchCount += 1;
+					return { key, ok: true, output: "too late", artifactPaths: [] };
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			});
+
+			await runMessageCaptured;
+			controller.abort(new Error("Workflow stopped by user."));
+			await assert.rejects(workflow, (error: unknown) => error instanceof WorkflowScriptError && error.message === "Workflow stopped by user.");
+			deliverCapturedRunMessage?.();
+			await new Promise((resolve) => queueMicrotask(resolve));
+			assert.equal(launchCount, 0);
+		} finally {
+			Worker.prototype.on = originalOn;
+		}
+	});
+
 	it("drops a child response that settles after the workflow aborts", async () => {
 		const workerPrototype = Worker.prototype as unknown as { postMessage(value: unknown, ...args: unknown[]): void };
 		const originalPostMessage = workerPrototype.postMessage;

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -791,6 +791,33 @@ describe("scripted workflow runtime", () => {
 		}
 	});
 
+	it("marks a child stopped when abort fires during the started trace callback", async () => {
+		const controller = new AbortController();
+		let launchCount = 0;
+
+		await assert.rejects(
+			runWorkflowScript({
+				script: `await runs.run("slow", { agent: "worker", task: "wait" });`,
+				signal: controller.signal,
+				onTrace(trace) {
+					const started = trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "started");
+					if (started && !controller.signal.aborted) controller.abort(new Error("Workflow stopped by user."));
+				},
+				async launch(key) {
+					launchCount += 1;
+					return { key, ok: true, output: "done", artifactPaths: [] };
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError
+				&& error.message === "Workflow stopped by user."
+				&& error.partial.trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "stopped")
+				&& !error.partial.trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "failed"),
+		);
+		await new Promise((resolve) => queueMicrotask(resolve));
+		assert.equal(launchCount, 0);
+	});
+
 	it("does not launch a child after admission settles following workflow abort", async () => {
 		const controller = new AbortController();
 		let launchCount = 0;

--- a/test/unit/workflow-chat-progress.test.ts
+++ b/test/unit/workflow-chat-progress.test.ts
@@ -215,6 +215,7 @@ describe("workflow chat progress rendering", () => {
 						{ operation: "run", key: "scout", state: "completed", runId: "run-scout", phase: "Validation", label: "Found renderer seam", durationMs: 12 },
 						{ operation: "run", key: "tests", state: "started", phase: "Validation", label: "focused integration suite" },
 						{ operation: "run", key: "review", state: "failed", phase: "Validation", label: "fresh-context UX review", error: "needs fixes" },
+						{ operation: "run", key: "stale", state: "stopped", phase: "Validation", label: "superseded exact-head review", error: "Workflow stopped by user." },
 					],
 					emits: [],
 					console: [],
@@ -228,6 +229,7 @@ describe("workflow chat progress rendering", () => {
 		assert.match(text, /complete\s+scout Found renderer seam/);
 		assert.match(text, /running\s+tests focused integration suite/);
 		assert.match(text, /failed\s+review fresh-context UX review .* needs fixes/);
+		assert.match(text, /stopped\s+stale superseded exact-head review .* Workflow stopped by user/);
 	});
 
 	it("applies main-window density settings to collapsed workflow live cards", () => {


### PR DESCRIPTION
Distinguish parent-stopped workflow children from failed child runs. Parent-stopped unfinished workflow children now persist and render as stopped, and late child/status settlement cannot rewrite stopped workflow traces.

Fixes #1060.

Validation:
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern="persists parent-stopped workflow children as stopped instead of failed" test/integration/single-execution.test.ts
- node --experimental-strip-types --test --test-name-pattern="queued child launch message|marks a child stopped when abort fires during the started trace callback|does not launch a child after admission settles following workflow abort|drops a child response that settles after the workflow aborts|does not dispatch status after abort fires during the status started trace callback|drops a status response that settles after the workflow aborts" test/unit/scripted-workflow.test.ts
- node --experimental-strip-types --test test/unit/scripted-workflow.test.ts test/unit/workflow-chat-progress.test.ts
- npm run typecheck
- git diff --check
