### PR TITLE
fix: keep workflow artifacts out of repos by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - Show children interrupted by a parent-stopped workflow as stopped instead of failed, and preserve the workflow stop reason (#1060).
+- Keep subagent artifacts and automatic mission records outside project worktrees by default, so read-only workflows do not make clean-tree checks fail (#1062).
 - Tell parents to continue after an async launch only until the next dependency barrier, so they consume a child result before dependent work makes it obsolete. Thanks to @exuanbo for #1045.
 - Tell wait callers to reply and wait instead of reviving a wrapper that detached for intercom coordination. Thanks to @yayamaz for #1053.
 - Derive default `workflowScript` child report paths from the workflow output path while keeping the workflow aggregate report separate, and reject child output path collisions before launch (#1038).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,7 +320,6 @@ stdin is a JSON object with `repoRoot`, `worktreePath`, `agentCwd`, `branch`, `i
 {
   "missions": {
     "enabled": true,
-    "directory": ".pi/subagents/missions",
     "globalIndex": true,
     "retainTerminal": 200
   }
@@ -329,7 +328,8 @@ stdin is a JSON object with `repoRoot`, `worktreePath`, `agentCwd`, `branch`, `i
 
 Automatic missions are enabled by default for ordinary launches with a task. Use per-launch `mission: false` for intentionally ephemeral work, or set `enabled: false` to disable automatic creation globally; explicit mission actions and `missionId`/`mission` launch fields still work.
 
-- `directory` may be absolute, `~/...`, or project-relative.
+- Mission records default to a project-keyed directory under pi's agent directory (`~/.pi/agent/missions/projects/<project-hash>/`). This keeps the project worktree clean.
+- `directory` may be absolute, `~/...`, or project-relative. Set it to `.pi/subagents/missions` to opt in to project-scoped records.
 - `retainTerminal` is a positive count (default `200`); pruning removes only the oldest completed, failed, or cancelled records and their pointers, never planned, active, waiting, needs-decision, or corrupt records.
 - The user-global index contains pointers only; missing-record pointers self-heal when globally listed. Set `globalIndex: false` to disable writes or `globalIndexDir` to redirect it.
 
@@ -358,11 +358,11 @@ Each fixed action resolves to `"auto"`, `"confirm"`, or `"forbid"`. This is inte
 
 Controls where subagent artifact files (inputs, outputs, transcripts, metadata) are stored:
 
-- `"project"` (default): writes to `<cwd>/.pi/subagents/artifacts/`.
-- `"session"`: stores artifacts under pi's session directory (`~/.pi/agent/sessions/<session>/subagent-artifacts/`), keeping the working directory clean.
+- `"project"`: writes to `<cwd>/.pi/subagents/artifacts/`.
+- `"session"` (default): stores artifacts under pi's session directory (`~/.pi/agent/sessions/<session>/subagent-artifacts/`), keeping the working directory clean. It falls back to the OS temp directory when no session file exists.
 - `"temp"`: uses the OS temp directory.
 
-This preference also controls the default chain scratch directory. `"project"` uses `<cwd>/.pi/subagents/chain-runs/`, while `"session"` and `"temp"` use the user-scoped temp chain directory.
+This preference also controls the default chain scratch directory. `"project"` uses `<cwd>/.pi/subagents/chain-runs/`, while the default `"session"` and `"temp"` use the user-scoped temp chain directory.
 
 The `"session"` option uses the same directory that `cleanupAllArtifactDirs` already scans for age-based cleanup, so artifacts are still cleaned up automatically. Temporary chain directories are cleaned up separately after 24 hours.
 

--- a/docs/missions.md
+++ b/docs/missions.md
@@ -11,7 +11,7 @@ Missions are durable wrappers around runs. The noun map:
 - **Run** — one actual subagent execution.
 - **Receipt** — proof or a link for an external outcome, such as a PR, CI check, deployment, or release.
 
-Ordinary workflow launches create one enclosing mission by default, with detailed JSON records under `<cwd>/.pi/subagents/missions/` linking objectives, run ids, lifecycle status, decisions, artifact paths, and delivery receipts. Workflow children do not create separate missions. Each workflow child attempt is stored in the enclosing mission with its stable workflow key, run id when known, agent, task metadata, timestamps, session and artifact paths, and latest status heartbeat.
+Ordinary workflow launches create one enclosing mission by default, with detailed JSON records under `~/.pi/agent/missions/projects/<project-hash>/` linking objectives, run ids, lifecycle status, decisions, artifact paths, and delivery receipts. Workflow children do not create separate missions. Each workflow child attempt is stored in the enclosing mission with its stable workflow key, run id when known, agent, task metadata, timestamps, session and artifact paths, and latest status heartbeat.
 
 Behavior:
 
@@ -19,7 +19,7 @@ Behavior:
 - Human receipts end with `Mission: <id> (<status>)`, while JSON/structured output text stays unchanged and `details.missionId` is authoritative.
 - Pass `mission: false` for an intentionally ephemeral workflow. It creates no mission for the workflow or its children and has no `state` global.
 - Set `missions.enabled: false` to disable automatic mission creation; explicit mission fields and actions still work.
-- A workflow with a mission can use `await state.get(key)` and `await state.set(key, value)` for durable JSON state. Missing keys return `undefined`. Keys use the same format as `runs.run` keys. Each set takes the state-file lock, reads the latest file, merges the key, and atomically writes `<cwd>/.pi/subagents/missions/<mission-id>/state.json`. The complete file cannot exceed 256 KiB. Each workflow caches the file on its first `get`. A `mission:false` workflow has no `state` global.
+- A workflow with a mission can use `await state.get(key)` and `await state.set(key, value)` for durable JSON state. Missing keys return `undefined`. Keys use the same format as `runs.run` keys. Each set takes the state-file lock, reads the latest file, merges the key, and atomically writes `<mission-directory>/<mission-id>/state.json`. The complete file cannot exceed 256 KiB. Each workflow caches the file on its first `get`. A `mission:false` workflow has no `state` global.
 
 An explicit `mission` object must have exactly one non-empty `title` or `summary`. `objective` and `labels` are optional. When supplied, `goal` must be `true` and requires `budget: { tokens: <positive integer> }`.
 

--- a/docs/missions.md
+++ b/docs/missions.md
@@ -13,6 +13,8 @@ Missions are durable wrappers around runs. The noun map:
 
 Ordinary workflow launches create one enclosing mission by default, with detailed JSON records under `~/.pi/agent/missions/projects/<project-hash>/` linking objectives, run ids, lifecycle status, decisions, artifact paths, and delivery receipts. Workflow children do not create separate missions. Each workflow child attempt is stored in the enclosing mission with its stable workflow key, run id when known, agent, task metadata, timestamps, session and artifact paths, and latest status heartbeat.
 
+Records created under the old default `<project>/.pi/subagents/missions` stay on disk. Continue them by setting `missions.directory` to that path for the project or by copying the record into the new agent-dir project store. There is no automatic migration.
+
 Behavior:
 
 - Automatic persistence failures do not block the run and are reported as `details.missionWarning`. Explicit `missionId` and `mission` requests remain strict before launch.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -150,7 +150,7 @@ Foreground and async runners share bounded child-protocol handling:
 
 ## Chain and debug artifacts
 
-Each chain run creates a scratch directory under its resolved chain root. With the default `artifactDir: "project"`, that root is `<cwd>/.pi/subagents/chain-runs/`. With `artifactDir: "session"` or `"temp"`, it is user-scoped temp storage:
+Each chain run creates a scratch directory under its resolved chain root. With the default `artifactDir: "session"` or with `"temp"`, it is user-scoped temp storage. With `artifactDir: "project"`, the root is `<cwd>/.pi/subagents/chain-runs/`:
 
 ```text
 <tmpdir>/pi-subagents-<scope>/chain-runs/{runId}/

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -285,7 +285,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		return { ok: false, code: "denied_required_tool", message, diagnostics };
 	}
 	const artifactsEnabled = input.artifacts !== false;
-	const artifactsDir = artifactsEnabled ? getArtifactsDir(input.parentSessionFile ?? null, effectiveCwd, input.artifactDir ?? "project") : undefined;
+	const artifactsDir = artifactsEnabled ? getArtifactsDir(input.parentSessionFile ?? null, effectiveCwd, input.artifactDir) : undefined;
 	const artifactPaths = artifactsDir ? getArtifactPaths(artifactsDir, runId, agent.name, 0) : undefined;
 	const outputPath = resolveSingleOutputPath(behavior.output, effectiveCwd, effectiveCwd, artifactsDir ? path.join(artifactsDir, "outputs", runId) : undefined);
 	const sessionRoot = input.sessionDir ? path.resolve(input.sessionDir) : input.sessionRoot ? path.join(path.resolve(input.sessionRoot), runId) : undefined;

--- a/src/missions/store.ts
+++ b/src/missions/store.ts
@@ -2,7 +2,6 @@ import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getProjectSubagentsDir } from "../shared/artifacts.ts";
 import { writePrivateAtomicJson } from "../shared/atomic-json.ts";
 import { getAgentDir } from "../shared/utils.ts";
 import {
@@ -259,6 +258,11 @@ function expandConfiguredPath(value: string, projectRoot: string): string {
 	return path.isAbsolute(expanded) ? path.normalize(expanded) : path.resolve(projectRoot, expanded);
 }
 
+function projectMissionDirectory(agentDir: string, projectRoot: string): string {
+	const projectKey = createHash("sha256").update(projectRoot).digest("hex");
+	return path.join(agentDir, "missions", "projects", projectKey);
+}
+
 export function validateMissionStoreConfig(value: unknown, label = "config.missions"): MissionStoreConfig | undefined {
 	if (value === undefined) return undefined;
 	const input = asObject(value, label);
@@ -289,12 +293,13 @@ export function resolveMissionStoreLocation(input: {
 	agentDir?: string;
 }): MissionStoreLocation {
 	const projectRoot = path.resolve(input.projectRoot);
+	const agentDir = input.agentDir ?? getAgentDir();
 	const missionDir = input.config?.directory
 		? expandConfiguredPath(input.config.directory, projectRoot)
-		: path.join(getProjectSubagentsDir(projectRoot), "missions");
+		: projectMissionDirectory(agentDir, projectRoot);
 	const globalIndexDir = input.config?.globalIndexDir
 		? expandConfiguredPath(input.config.globalIndexDir, projectRoot)
-		: path.join(input.agentDir ?? getAgentDir(), "missions", "index");
+		: path.join(agentDir, "missions", "index");
 	return {
 		projectRoot,
 		missionDir,

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -144,7 +144,7 @@ export function getProjectChainRunsDir(cwd: string): string {
 
 export function getChainRunsDir(
 	projectCwd: string,
-	dirPreference: ArtifactDirPreference = "project",
+	dirPreference: ArtifactDirPreference = "session",
 ): string {
 	switch (dirPreference) {
 		case "project":
@@ -160,7 +160,7 @@ export function getChainRunsDir(
 export function getArtifactsDir(
 	sessionFile: string | null,
 	projectCwd?: string,
-	dirPreference: ArtifactDirPreference = "project",
+	dirPreference: ArtifactDirPreference = "session",
 ): string {
 	switch (dirPreference) {
 		case "session":

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1942,7 +1942,7 @@ export interface ExtensionConfig {
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
 	worktreeBaseDir?: string;
-	/** Where to store subagent artifact files. Defaults to "project" (cwd/.pi/subagents). Set to "session" for pi session dir, or "temp" for OS temp. */
+	/** Where to store subagent artifact files. Defaults to "session" (the pi session directory, or OS temp when unavailable). Set to "project" for cwd/.pi/subagents. */
 	artifactDir?: ArtifactDirPreference;
 	/** Artifact cleanup retention. Set cleanupDays to 0 to disable cleanup. */
 	artifactConfig?: Pick<ArtifactConfig, "cleanupDays">;
@@ -1966,7 +1966,7 @@ export const DEFAULT_MAX_OUTPUT: Required<MaxOutputConfig> = {
 
 export const DEFAULT_ARTIFACT_CONFIG: ArtifactConfig = {
 	enabled: true,
-	dir: "project",
+	dir: "session",
 	includeInput: true,
 	includeOutput: true,
 	includeJsonl: false,

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -510,6 +510,7 @@ function transcriptTarget(item: FleetItem, state: SubagentState): { path: string
 			item.run.asyncDir,
 			fleetArtifactsRoot(state, state.baseCwd),
 			trackedJob?.cwd ? fleetArtifactsRoot(state, trackedJob.cwd) : undefined,
+			item.run.sessionFile ? getArtifactsDir(item.run.sessionFile, item.run.cwd ?? state.baseCwd, state.artifactDirPreference) : undefined,
 		]),
 	};
 }

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -473,7 +473,7 @@ function fleetArtifactsRoot(state: SubagentState, cwd: string): string {
 	return getArtifactsDir(
 		state.parentSessionFile ?? null,
 		cwd,
-		state.artifactDirPreference ?? "project",
+		state.artifactDirPreference,
 	);
 }
 

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -2623,7 +2623,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			const args = await waitForMockPiArgs(mockPi, 0);
 			const taskArg = args.at(-1) ?? "";
 			assert.match(taskArg, new RegExp(`\\[Read from: ${escapeRegExp(path.join(worktreeCwd, "input.md"))}\\]`));
-			assert.ok(taskArg.includes(`Write your findings to exactly this path: ${path.join(repoDir, ".pi/subagents", "artifacts", "outputs", asyncId, "report.md")}`));
+			assert.ok(taskArg.includes(`Write your findings to exactly this path: ${path.join(TEMP_ARTIFACTS_DIR, "outputs", asyncId, "report.md")}`));
 			const resultPath = await waitForAsyncResultFile(asyncId, 90_000);
 			const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
 			const status = await waitForAsyncState(asyncId, (candidate) => candidate.state === "complete");

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -20,7 +20,7 @@ import { waitForSubagents } from "../../src/runs/background/subagent-wait.ts";
 import { writeAtomicJson } from "../../src/shared/atomic-json.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { MAX_CHILD_PENDING_LINE_BYTES, MAX_CHILD_STDERR_BYTES } from "../../src/runs/shared/child-protocol.ts";
-import { SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_LIFECYCLE_ARTIFACT_VERSION } from "../../src/shared/types.ts";
+import { SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_LIFECYCLE_ARTIFACT_VERSION, TEMP_ARTIFACTS_DIR } from "../../src/shared/types.ts";
 import { registerSubagentCapabilityCeiling } from "../../src/api/capability-ceiling.ts";
 import { resolveSubagentLaunchContract } from "../../src/api/preflight.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
@@ -1771,7 +1771,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(status.sessionId, "session-123");
 		assert.equal(status.steps?.[0]?.acceptance?.status, "review-required");
 		assert.equal(status.steps?.[0]?.acceptance?.evidenceStatus, "checked");
-		const outputPath = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", asyncId, "async-top-output.md");
+		const outputPath = path.join(TEMP_ARTIFACTS_DIR, "outputs", asyncId, "async-top-output.md");
 		const outputDeadline = Date.now() + 5_000;
 		while (!fs.existsSync(outputPath)) {
 			if (Date.now() > outputDeadline) {
@@ -1784,7 +1784,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.ok(callFile, "expected a recorded mock pi call");
 		const args = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")).args as string[];
 		const taskArg = args.at(-1) ?? "";
-		const progressPath = path.join(tempDir, ".pi/subagents", "artifacts", "progress", asyncId, "progress.md");
+		const progressPath = path.join(TEMP_ARTIFACTS_DIR, "progress", asyncId, "progress.md");
 		assert.ok(taskArg.includes(`[Read from: ${path.join(tempDir, "input.md")}]`));
 		assert.ok(taskArg.includes(`Update progress at: ${progressPath}`));
 		assert.ok(taskArg.includes(`Write your findings to exactly this path: ${outputPath}`));
@@ -1815,7 +1815,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			assert.equal(payload.success, true);
 			assert.equal(payload.results[0]?.output?.split("\n\nOutput saved to:")[0], "first async report");
 			assert.equal(payload.results[1]?.output?.split("\n\nOutput saved to:")[0], "second async report");
-			const outputDir = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", launch.details?.asyncId as string);
+			const outputDir = path.join(TEMP_ARTIFACTS_DIR, "outputs", launch.details?.asyncId as string);
 			const authoritativePaths = [
 				path.join(outputDir, "parallel-0", "0-worker", "context.md"),
 				path.join(outputDir, "parallel-0", "1-worker", "context.md"),
@@ -1884,7 +1884,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 
 		const payload = await readAsyncPayload(launch.details?.asyncId as string);
 		assert.equal(payload.success, true);
-		const outputDir = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", launch.details?.asyncId as string);
+		const outputDir = path.join(TEMP_ARTIFACTS_DIR, "outputs", launch.details?.asyncId as string);
 		assert.equal(fs.readFileSync(path.join(outputDir, "first.md"), "utf-8"), "first explicit report");
 		assert.equal(fs.readFileSync(path.join(outputDir, "second.md"), "utf-8"), "second explicit report");
 		assert.ok(payload.results[0]?.artifactPaths?.outputPath?.endsWith("_worker_0_output.md"));

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
-import { getProjectArtifactsDir } from "../../src/shared/artifacts.ts";
+import { getArtifactsDir } from "../../src/shared/artifacts.ts";
 import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { SubagentFleetComponent } from "../../src/tui/fleet.ts";
 import { createNestedRoute } from "../../src/runs/shared/nested-events.ts";
@@ -204,10 +204,12 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		try {
 			const runDir = path.join(asyncRoot, "run-restored");
 			const customCwd = path.join(asyncRoot, "custom-cwd");
-			const artifactsRoot = getProjectArtifactsDir(customCwd);
+			const sessionFile = path.join(asyncRoot, "sessions", "session-restored.jsonl");
+			const artifactsRoot = getArtifactsDir(sessionFile, customCwd);
 			const transcriptPath = path.join(artifactsRoot, "run-restored_reviewer_transcript.jsonl");
 			fs.mkdirSync(runDir, { recursive: true });
 			fs.mkdirSync(artifactsRoot, { recursive: true });
+			fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
 			fs.writeFileSync(transcriptPath, `${JSON.stringify({ recordType: "message", role: "assistant", text: "Restored custom cwd transcript" })}\n`, "utf-8");
 			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
 				runId: "run-restored",
@@ -215,6 +217,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				state: "running",
 				sessionId: "session-restored",
 				cwd: customCwd,
+				sessionFile,
 				startedAt: 1000,
 				lastUpdate: 2000,
 				currentStep: 1,

--- a/test/integration/parallel-execution.test.ts
+++ b/test/integration/parallel-execution.test.ts
@@ -17,6 +17,7 @@ import * as path from "node:path";
 import type { MockPi } from "../support/helpers.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
 import { getLivePromptAudit } from "../../src/runs/foreground/prompt-audit.ts";
+import { TEMP_ARTIFACTS_DIR } from "../../src/shared/types.ts";
 import {
 	createEventBus,
 	createMockPi,
@@ -445,7 +446,7 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 
 		const runId = result.details?.runId;
 		assert.ok(runId, "expected run id in details");
-		const outputPath = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", runId, "parallel-output.md");
+		const outputPath = path.join(TEMP_ARTIFACTS_DIR, "outputs", runId, "parallel-output.md");
 		assert.equal(result.isError, undefined);
 		assert.equal(fs.readFileSync(outputPath, "utf-8"), "Saved report");
 		assert.equal(result.details?.results?.[0]?.savedOutputPath, outputPath);
@@ -524,7 +525,7 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 
 		const runId = result.details?.runId;
 		assert.ok(runId, "expected run id in details");
-		const outputPath = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", runId, "parallel-file-only.md");
+		const outputPath = path.join(TEMP_ARTIFACTS_DIR, "outputs", runId, "parallel-file-only.md");
 		const text = result.content[0]?.text ?? "";
 		assert.equal(result.isError, undefined);
 		assert.match(text, /Output saved to:/);
@@ -592,7 +593,7 @@ describe("parallel agent execution", { skip: !piAvailable ? "pi packages not ava
 
 			const runId = result.details?.runId;
 			assert.ok(runId, "expected run id in details");
-			const outputDir = path.join(tempDir, ".pi/subagents", "artifacts", "outputs", runId);
+			const outputDir = path.join(TEMP_ARTIFACTS_DIR, "outputs", runId);
 			const firstOutputPath = path.join(outputDir, "parallel-0", "0-echo", "context.md");
 			const secondOutputPath = path.join(outputDir, "parallel-0", "1-echo", "context.md");
 			assert.equal(result.isError, undefined);
@@ -705,7 +706,7 @@ Inspect
 		);
 		const runId = result.details?.runId;
 		assert.ok(runId, "expected run id in details");
-		const expectedProgressPath = path.join(tempDir, ".pi/subagents", "artifacts", "progress", runId, "progress.md");
+		const expectedProgressPath = path.join(path.dirname(parentSessionFile), "subagent-artifacts", "progress", runId, "progress.md");
 
 		const args = readLastCallArgs();
 		const taskArg = args.at(-1) ?? "";

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -224,7 +224,7 @@ describe("result watcher", () => {
 			const binding = prepareMissionLaunch({
 				params: { mission: { title: "Workflow mission" }, task: "Run async child" },
 				projectRoot: project,
-				config: { globalIndexDir: path.join(root, "global-index") },
+				config: { directory: path.join(root, "missions"), globalIndexDir: path.join(root, "global-index") },
 				ownerSessionId: "session-current",
 			});
 			assert.ok(binding);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1081,46 +1081,56 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 	});
 
 	it("shares durable workflow state across a mission and omits it for mission:false", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
-		const executor = makeExecutor([makeAgent("echo")], { missions: { globalIndex: false } });
-		const first = await executor.execute(
-			"mission-state-first",
-			{
-				async: false,
-				mission: { title: "Stateful workflow" },
-				workflowScript: `await state.set("review.stage", { count: 1 }); return await state.get("review.stage");`,
-			},
-			new AbortController().signal,
-			undefined,
-			makeMinimalCtx(tempDir),
-		);
-		assert.equal(first.isError, undefined, first.content[0]?.text ?? "first workflow failed");
-		assert.ok(first.details.missionId);
-		assert.deepEqual(first.details.workflow?.value, { count: 1 });
-		const location = resolveMissionStoreLocation({ projectRoot: tempDir });
-		const statePath = missionStatePath(location, first.details.missionId);
-		assert.equal(fs.existsSync(statePath), true);
-		assert.equal(path.relative(tempDir, statePath).startsWith(".."), true);
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const projectDir = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(projectDir);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		try {
+			const executor = makeExecutor([makeAgent("echo")], { missions: { globalIndex: false } });
+			const first = await executor.execute(
+				"mission-state-first",
+				{
+					async: false,
+					mission: { title: "Stateful workflow" },
+					workflowScript: `await state.set("review.stage", { count: 1 }); return await state.get("review.stage");`,
+				},
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(projectDir),
+			);
+			assert.equal(first.isError, undefined, first.content[0]?.text ?? "first workflow failed");
+			assert.ok(first.details.missionId);
+			assert.deepEqual(first.details.workflow?.value, { count: 1 });
+			const location = resolveMissionStoreLocation({ projectRoot: projectDir, agentDir });
+			const statePath = missionStatePath(location, first.details.missionId);
+			assert.equal(fs.existsSync(statePath), true);
+			assert.equal(path.relative(projectDir, statePath).startsWith(".."), true);
 
-		const second = await executor.execute(
-			"mission-state-second",
-			{ async: false, missionId: first.details.missionId, workflowScript: `return await state.get("review.stage");` },
-			new AbortController().signal,
-			undefined,
-			makeMinimalCtx(tempDir),
-		);
-		assert.equal(second.isError, undefined, second.content[0]?.text ?? "second workflow failed");
-		assert.deepEqual(second.details.workflow?.value, { count: 1 });
+			const second = await executor.execute(
+				"mission-state-second",
+				{ async: false, missionId: first.details.missionId, workflowScript: `return await state.get("review.stage");` },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(projectDir),
+			);
+			assert.equal(second.isError, undefined, second.content[0]?.text ?? "second workflow failed");
+			assert.deepEqual(second.details.workflow?.value, { count: 1 });
 
-		const ephemeral = await executor.execute(
-			"mission-state-off",
-			{ async: false, mission: false, workflowScript: `return typeof state;` },
-			new AbortController().signal,
-			undefined,
-			makeMinimalCtx(tempDir),
-		);
-		assert.equal(ephemeral.isError, undefined, ephemeral.content[0]?.text ?? "ephemeral workflow failed");
-		assert.equal(ephemeral.details.workflow?.value, "undefined");
-		assert.equal(ephemeral.details.missionId, undefined);
+			const ephemeral = await executor.execute(
+				"mission-state-off",
+				{ async: false, mission: false, workflowScript: `return typeof state;` },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(projectDir),
+			);
+			assert.equal(ephemeral.isError, undefined, ephemeral.content[0]?.text ?? "ephemeral workflow failed");
+			assert.equal(ephemeral.details.workflow?.value, "undefined");
+			assert.equal(ephemeral.details.missionId, undefined);
+		} finally {
+			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		}
 	});
 
 	it("runs a direct single child in a managed worktree", { skip: !createSubagentExecutor || process.platform === "win32" ? "executor unavailable or worktree paths differ on Windows" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -294,6 +294,7 @@ function writePackageSkill(packageRoot: string, skillName: string): void {
 describe("single sync execution", { skip: !available ? "pi packages not available" : undefined }, () => {
 	let tempDir: string;
 	let mockPi: MockPi;
+	let previousAgentDir: string | undefined;
 
 	before(() => {
 		mockPi = createMockPi();
@@ -306,10 +307,14 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 	beforeEach(() => {
 		tempDir = createTempDir();
+		previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = path.join(tempDir, "agent");
 		mockPi.reset();
 	});
 
 	afterEach(() => {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		removeTempDir(tempDir);
 	});
 

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -293,6 +293,7 @@ function writePackageSkill(packageRoot: string, skillName: string): void {
 
 describe("single sync execution", { skip: !available ? "pi packages not available" : undefined }, () => {
 	let tempDir: string;
+	let agentDir: string;
 	let mockPi: MockPi;
 	let previousAgentDir: string | undefined;
 
@@ -307,14 +308,16 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 	beforeEach(() => {
 		tempDir = createTempDir();
+		agentDir = createTempDir("pi-subagent-agent-");
 		previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-		process.env.PI_CODING_AGENT_DIR = path.join(tempDir, "agent");
+		process.env.PI_CODING_AGENT_DIR = agentDir;
 		mockPi.reset();
 	});
 
 	afterEach(() => {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		removeTempDir(agentDir);
 		removeTempDir(tempDir);
 	});
 

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -36,7 +36,7 @@ import {
 	type SubagentDelegationResponse,
 	type SubagentDelegationStarted,
 } from "../../src/api/delegation.ts";
-import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, type AsyncStatus, type SubagentState } from "../../src/shared/types.ts";
+import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, TEMP_ARTIFACTS_DIR, type AsyncStatus, type SubagentState } from "../../src/shared/types.ts";
 import { ACTIVE_RUN_INDEX_DIR } from "../../src/runs/background/active-run-index.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
@@ -4144,7 +4144,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		const taskArg = readCallArgs().at(-1) ?? "";
 		assert.equal(result.isError, undefined);
-		assert.match(taskArg, new RegExp(`Write your findings to exactly this path: ${escapeRegExp(path.join(tempDir, ".pi/subagents", "artifacts", "outputs"))}.*context\\.md`));
+		assert.match(taskArg, new RegExp(`Write your findings to exactly this path: ${escapeRegExp(path.join(TEMP_ARTIFACTS_DIR, "outputs"))}.*context\\.md`));
 		assert.equal(fs.existsSync(path.join(tempDir, "context.md")), false);
 	});
 

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -996,39 +996,55 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		fs.rmSync(asyncDir, { recursive: true, force: true });
 	});
 
-	it("routes workflow children through one automatic mission", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+	it("keeps a git worktree clean while routing workflow children through one automatic mission", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "scanned auth" });
 		mockPi.onCall({ output: "reviewed auth" });
-		const executor = makeExecutor([makeAgent("echo")], { missions: { globalIndex: false } });
+		const projectDir = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(projectDir);
+		execFileSync("git", ["init"], { cwd: projectDir, stdio: "ignore" });
+		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: projectDir });
+		execFileSync("git", ["config", "user.name", "Test User"], { cwd: projectDir });
+		fs.writeFileSync(path.join(projectDir, "base.txt"), "base\n", "utf-8");
+		execFileSync("git", ["add", "base.txt"], { cwd: projectDir });
+		execFileSync("git", ["commit", "-m", "base"], { cwd: projectDir, stdio: "ignore" });
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		try {
+			const executor = makeExecutor([makeAgent("echo")], { missions: { globalIndex: false } });
+			const result = await executor.execute(
+				"scripted-workflow",
+				{
+					async: false,
+					workflowScript: `
+						const stateType = typeof state;
+						const scan = await runs.run("scan", { agent: "echo", task: "Scan auth" });
+						const review = await runs.run("review", { agent: "echo", task: "Review: " + scan.output });
+						return { output: review.output, stateType };
+					`,
+				},
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(projectDir),
+			);
 
-		const result = await executor.execute(
-			"scripted-workflow",
-			{
-				async: false,
-				workflowScript: `
-					const stateType = typeof state;
-					const scan = await runs.run("scan", { agent: "echo", task: "Scan auth" });
-					const review = await runs.run("review", { agent: "echo", task: "Review: " + scan.output });
-					return { output: review.output, stateType };
-				`,
-			},
-			new AbortController().signal,
-			undefined,
-			makeMinimalCtx(tempDir),
-		);
-
-		assert.equal(result.isError, undefined);
-		assert.match(result.content[0]?.text ?? "", /reviewed auth/);
-		assert.equal(result.details.mode, "workflow");
-		assert.equal(result.details.results.length, 2);
-		assert.equal(result.details.workflow?.value && (result.details.workflow.value as { stateType?: unknown }).stateType, "object");
-		assert.ok(result.details.missionId);
-		const missionDir = path.join(tempDir, ".pi/subagents", "missions");
-		const missionFiles = fs.readdirSync(missionDir).filter((entry) => entry.endsWith(".json"));
-		assert.equal(missionFiles.length, 1);
-		const mission = JSON.parse(fs.readFileSync(path.join(missionDir, missionFiles[0]!), "utf-8")) as { objective?: string };
-		assert.equal(mission.objective, utils.PROMPT_REDACTED);
-		assert.deepEqual(result.details.workflow?.trace.filter((entry) => entry.state === "completed").map((entry) => entry.key), ["scan", "review"]);
+			assert.equal(result.isError, undefined);
+			assert.match(result.content[0]?.text ?? "", /reviewed auth/);
+			assert.equal(result.details.mode, "workflow");
+			assert.equal(result.details.results.length, 2);
+			assert.equal(result.details.workflow?.value && (result.details.workflow.value as { stateType?: unknown }).stateType, "object");
+			assert.ok(result.details.missionId);
+			const missionFiles = fs.readdirSync(path.join(agentDir, "missions", "projects"), { recursive: true })
+				.filter((entry) => typeof entry === "string" && entry.endsWith(".json"));
+			assert.equal(missionFiles.length, 1);
+			const mission = JSON.parse(fs.readFileSync(path.join(agentDir, "missions", "projects", missionFiles[0]!), "utf-8")) as { objective?: string };
+			assert.equal(mission.objective, utils.PROMPT_REDACTED);
+			assert.deepEqual(result.details.workflow?.trace.filter((entry) => entry.state === "completed").map((entry) => entry.key), ["scan", "review"]);
+			assert.equal(execFileSync("git", ["status", "--porcelain"], { cwd: projectDir, encoding: "utf-8" }), "");
+		} finally {
+			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		}
 	});
 
 	it("keeps workflow children mission-detached when automatic mission persistence fails", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
@@ -1036,7 +1052,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		mockPi.onCall({ output: "reviewed auth" });
 		const blockedIndex = path.join(tempDir, "blocked-mission-index");
 		fs.writeFileSync(blockedIndex, "not a directory", "utf-8");
-		const executor = makeExecutor([makeAgent("echo")], { missions: { globalIndexDir: blockedIndex } });
+		const executor = makeExecutor([makeAgent("echo")], { missions: { directory: ".pi/subagents/missions", globalIndexDir: blockedIndex } });
 
 		const result = await executor.execute(
 			"scripted-workflow-mission-warning",

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -56,6 +56,8 @@ import {
 	SUBAGENT_PARENT_RUN_ID_ENV,
 } from "../../src/runs/shared/pi-args.ts";
 import { createNestedRoute, nestedRouteEnv, parseNestedEventRecords } from "../../src/runs/shared/nested-events.ts";
+import { resolveMissionStoreLocation } from "../../src/missions/store.ts";
+import { missionStatePath } from "../../src/missions/workflow-state.ts";
 
 interface ModelAttempt {
 	success?: boolean;
@@ -1094,8 +1096,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(first.isError, undefined, first.content[0]?.text ?? "first workflow failed");
 		assert.ok(first.details.missionId);
 		assert.deepEqual(first.details.workflow?.value, { count: 1 });
-		const statePath = path.join(tempDir, ".pi/subagents", "missions", first.details.missionId, "state.json");
+		const location = resolveMissionStoreLocation({ projectRoot: tempDir });
+		const statePath = missionStatePath(location, first.details.missionId);
 		assert.equal(fs.existsSync(statePath), true);
+		assert.equal(path.relative(tempDir, statePath).startsWith(".."), true);
 
 		const second = await executor.execute(
 			"mission-state-second",

--- a/test/unit/artifacts.test.ts
+++ b/test/unit/artifacts.test.ts
@@ -11,7 +11,7 @@ import {
 	getProjectChainRunsDir,
 	getProjectSubagentsDir,
 } from "../../src/shared/artifacts.ts";
-import { CHAIN_RUNS_DIR } from "../../src/shared/types.ts";
+import { CHAIN_RUNS_DIR, TEMP_ARTIFACTS_DIR } from "../../src/shared/types.ts";
 
 describe("project-local artifact paths", () => {
 	const tempDirs: string[] = [];
@@ -53,24 +53,26 @@ describe("project-local artifact paths", () => {
 		assert.match(getProjectArtifactPackagingWarning(packageDir({ name: "chain-runs-directory-included", files: [".pi/subagents/chain-runs"] })) ?? "", /artifactDir/);
 	});
 
-	it("places generated subagent files under .pi/subagents for a project cwd", () => {
+	it("keeps project-scoped paths available as an explicit opt-in", () => {
 		const cwd = path.join("tmp", "repo");
 		assert.equal(getProjectSubagentsDir(cwd), path.join(cwd, ".pi/subagents"));
 		assert.equal(getProjectArtifactsDir(cwd), path.join(cwd, ".pi/subagents", "artifacts"));
 		assert.equal(getProjectChainRunsDir(cwd), path.join(cwd, ".pi/subagents", "chain-runs"));
-		assert.equal(getArtifactsDir(null, cwd), path.join(cwd, ".pi/subagents", "artifacts"));
+		assert.equal(getArtifactsDir(null, cwd, "project"), path.join(cwd, ".pi/subagents", "artifacts"));
 	});
 
 	it("routes chain scratch files according to the artifact preference", () => {
 		const cwd = path.join("tmp", "repo");
-		assert.equal(getChainRunsDir(cwd), getProjectChainRunsDir(cwd));
+		assert.equal(getChainRunsDir(cwd), CHAIN_RUNS_DIR);
 		assert.equal(getChainRunsDir(cwd, "project"), getProjectChainRunsDir(cwd));
 		assert.equal(getChainRunsDir(cwd, "session"), CHAIN_RUNS_DIR);
 		assert.equal(getChainRunsDir(cwd, "temp"), CHAIN_RUNS_DIR);
 	});
 
-	it("keeps the session artifact fallback when no project cwd is available", () => {
+	it("defaults artifacts to the session directory and falls back to temp", () => {
+		const cwd = path.join("tmp", "repo");
 		const sessionFile = path.join("tmp", "sessions", "parent.jsonl");
-		assert.equal(getArtifactsDir(sessionFile), path.join("tmp", "sessions", "subagent-artifacts"));
+		assert.equal(getArtifactsDir(sessionFile, cwd), path.join("tmp", "sessions", "subagent-artifacts"));
+		assert.equal(getArtifactsDir(null, cwd), path.join(TEMP_ARTIFACTS_DIR));
 	});
 });

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -536,6 +536,7 @@ describe("native subagent fleet", () => {
 			fs.writeFileSync(outputPath, "restored foreground output", "utf-8");
 
 			const state = stateForTest();
+			state.artifactDirPreference = "project";
 			state.foregroundRuns!.set("restored", {
 				runId: "restored",
 				mode: "single",
@@ -556,6 +557,7 @@ describe("native subagent fleet", () => {
 
 			const restored = stateForTest();
 			restored.baseCwd = cwd;
+			restored.artifactDirPreference = "project";
 			assert.equal(restoreForegroundRunHistory(restored, { resultsDir }), 1);
 			const snapshot = collectFleetSnapshot(restored);
 			assert.deepEqual(snapshot.items.map((item) => item.key), ["foreground-recent:restored:0"]);
@@ -636,6 +638,7 @@ describe("native subagent fleet", () => {
 			const cwd = path.join(root, "project");
 			const artifactsRoot = getProjectArtifactsDir(cwd);
 			const state = stateForTest();
+			state.artifactDirPreference = "project";
 			for (let index = 0; index < 3; index++) {
 				const outputPath = path.join(artifactsRoot, "outputs", `run-${index}`, "output.md");
 				fs.mkdirSync(path.dirname(outputPath), { recursive: true });
@@ -654,6 +657,7 @@ describe("native subagent fleet", () => {
 
 			const restored = stateForTest();
 			restored.baseCwd = cwd;
+			restored.artifactDirPreference = "project";
 			assert.equal(restoreForegroundRunHistory(restored, { resultsDir, limit: 2 }), 2);
 			assert.deepEqual([...restored.foregroundRuns!.keys()], ["run-2", "run-1"]);
 
@@ -802,6 +806,7 @@ describe("native subagent fleet", () => {
 			fs.writeFileSync(path.join(asyncDir, "status.json"), "{in-flight status", "utf-8");
 			const state = stateForTest();
 			state.baseCwd = path.join(root, "parent-cwd");
+			state.artifactDirPreference = "project";
 			state.asyncJobs.set("async-custom-cwd", {
 				asyncId: "async-custom-cwd",
 				asyncDir,
@@ -883,6 +888,7 @@ describe("native subagent fleet", () => {
 		try {
 			const state = stateForTest();
 			state.baseCwd = path.join(root, "parent-cwd");
+			state.artifactDirPreference = "project";
 			const effectiveCwd = path.join(root, "effective-cwd");
 			const now = Date.now();
 			state.foregroundControls.set("foreground-live", {

--- a/test/unit/mission-lifecycle.test.ts
+++ b/test/unit/mission-lifecycle.test.ts
@@ -17,7 +17,7 @@ function projectFixture() {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-mission-lifecycle-"));
 	const projectRoot = path.join(root, "project");
 	fs.mkdirSync(projectRoot, { recursive: true });
-	return { root, projectRoot, missionConfig: { globalIndexDir: path.join(root, "global-index") } };
+	return { root, projectRoot, missionConfig: { directory: ".pi/subagents/missions", globalIndexDir: path.join(root, "global-index") } };
 }
 
 describe("mission launch lifecycle", () => {

--- a/test/unit/mission-store.test.ts
+++ b/test/unit/mission-store.test.ts
@@ -34,6 +34,20 @@ async function waitForFile(filePath: string, timeoutMs = 10_000): Promise<void> 
 }
 
 describe("mission store", () => {
+	it("stores default missions outside the project and preserves configured project storage", () => {
+		const test = fixture();
+		try {
+			assert.equal(path.relative(test.projectRoot, test.location.missionDir).startsWith(".."), true);
+			assert.equal(test.location.missionDir.startsWith(path.join(test.agentDir, "missions", "projects")), true);
+			assert.equal(
+				resolveMissionStoreLocation({ projectRoot: test.projectRoot, agentDir: test.agentDir, config: { directory: ".pi/subagents/missions" } }).missionDir,
+				path.join(test.projectRoot, ".pi/subagents", "missions"),
+			);
+		} finally {
+			fs.rmSync(test.root, { recursive: true, force: true });
+		}
+	});
+
 	it("creates, reads, updates, lists, and globally indexes project missions", () => {
 		const test = fixture();
 		try {

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -214,7 +214,7 @@ Package skill content.
 	it("resolves configured artifact directory preferences", () => {
 		const sessionFile = path.join(agentDir, "sessions", "session-1", "session.jsonl");
 
-		assert.equal(getArtifactsDir(sessionFile, cwd), getProjectArtifactsDir(cwd));
+		assert.equal(getArtifactsDir(sessionFile, cwd), path.join(path.dirname(sessionFile), "subagent-artifacts"));
 		assert.equal(getArtifactsDir(sessionFile, cwd, "project"), getProjectArtifactsDir(cwd));
 		assert.equal(getArtifactsDir(sessionFile, cwd, "session"), path.join(path.dirname(sessionFile), "subagent-artifacts"));
 		assert.equal(getArtifactsDir(sessionFile, cwd, "temp"), TEMP_ARTIFACTS_DIR);

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -7,6 +7,7 @@ import { registerSubagentCapabilityCeiling, resolveSubagentCapabilityCeiling } f
 import { resolveSubagentLaunchContract, SUBAGENT_LAUNCH_CONTRACT_VERSION } from "../../src/api/preflight.ts";
 import { clearSkillCache } from "../../src/agents/skills.ts";
 import { computeMcpServerHash } from "../../src/runs/shared/mcp-direct-tool-allowlist.ts";
+import { TEMP_ARTIFACTS_DIR } from "../../src/shared/types.ts";
 
 let tempDir = "";
 let previousHome: string | undefined;
@@ -126,7 +127,7 @@ Project prompt.
 			assert.equal(result.contract.tools.capabilityAudit?.removedExtensionCount, 1);
 			assert.equal(result.contract.tools.disableAmbientExtensions, true);
 			assert.equal(result.contract.roots.sessionFile, path.join(sessionRoot, "run-123", "run-0", "session.jsonl"));
-			assert.equal(result.contract.roots.outputPath, path.join(cwd, ".pi/subagents", "artifacts", "outputs", "run-123", "report.md"));
+			assert.equal(result.contract.roots.outputPath, path.join(TEMP_ARTIFACTS_DIR, "outputs", "run-123", "report.md"));
 			assert.equal(result.contract.roots.lifecycle?.statusPath.endsWith(path.join("run-123", "status.json")), true);
 			assert.equal(result.contract.roots.lifecycle?.eventsPath.endsWith(path.join("run-123", "events.jsonl")), true);
 			assert.equal(result.contract.roots.lifecycle?.processTerminalPath.endsWith(path.join("run-123", "process-terminal.json")), true);


### PR DESCRIPTION
Move default workflow artifacts and automatic mission state out of target repositories so read-only workflowScript lanes do not dirty clean-tree gates. Explicit project-scoped artifact and mission directories remain available.

Fixes #1062.

Validation:
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern="shares durable workflow state across a mission and omits it for mission:false|keeps a git worktree clean while routing workflow children through one automatic mission|keeps workflow children mission-detached when automatic mission persistence fails" test/integration/single-execution.test.ts
- node --experimental-strip-types --test test/unit/artifacts.test.ts test/unit/mission-store.test.ts test/unit/pi-coding-agent-dir.test.ts
- node --experimental-strip-types --test test/unit/preflight.test.ts test/unit/fleet.test.ts test/unit/fleet-status.test.ts test/unit/fleet-transcript.test.ts
- node --experimental-strip-types --test test/unit/mission-lifecycle.test.ts test/unit/mission-goal-driver.test.ts test/unit/workflow-chat-progress.test.ts test/unit/herdr-inspector.test.ts
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern="top-level async parallel conversion preserves output, reads, and progress|async top-level parallel isolates inherited output|async top-level parallel preserves distinct explicit output destinations|top-level async worktree parallel keeps existing reads and writes output under project artifacts" test/integration/async-execution.test.ts
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern="top-level parallel output saves use per-task output paths|top-level parallel file-only output aggregates concise file references|isolates foreground inherited output|top-level parallel defaultProgress uses isolated run storage" test/integration/parallel-execution.test.ts
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern="routes foreground single relative outputs to the run output artifact directory by default" test/integration/single-execution.test.ts
- node --experimental-strip-types --test --test-name-pattern="restores active async runs into the widget after reset|renders configured session and temp transcripts" test/integration/async-job-tracker.test.ts test/unit/fleet.test.ts
- npm run typecheck
- git diff --check
