### PR TITLE
fix: support Pi 0.84 agent stream API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Clean up unreleased active-capacity and artifact packaging helpers without changing runtime behavior.
 
 ### Fixed
+- Keep watchdog reviews, permission arbitration, Prompt Audit rewriting, and completion intent arbitration on their authenticated provider stream across the Pi 0.81 and 0.84 agent constructor APIs. Thanks to @nuzayets for #1067.
 - Show children interrupted by a parent-stopped workflow as stopped instead of failed, and preserve the workflow stop reason (#1060).
 - Keep subagent artifacts and automatic mission records outside project worktrees by default, so read-only workflows do not make clean-tree checks fail (#1062).
 - Tell parents to continue after an async launch only until the next dependency barrier, so they consume a child result before dependent work makes it obsolete. Thanks to @exuanbo for #1045.

--- a/src/runs/foreground/prompt-audit.ts
+++ b/src/runs/foreground/prompt-audit.ts
@@ -1,7 +1,8 @@
 import { Agent, type StreamFn, type ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { convertToLlm, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
-import type { Model } from "@earendil-works/pi-ai";
+import type { Model, ProviderHeaders } from "@earendil-works/pi-ai";
+import { agentStreamOptions } from "../../shared/agent-stream-options.ts";
 import type { ForegroundRunControl } from "../../shared/types.ts";
 export type PromptAuditView = "authored" | "runtime" | "effective";
 
@@ -42,7 +43,7 @@ function finalAssistantText(agent: Agent): string {
 	return "";
 }
 
-async function resolveRewriteAuth(ctx: ExtensionContext, model: RegistryModel): Promise<{ apiKey?: string; headers?: Record<string, string>; env?: Record<string, string> }> {
+async function resolveRewriteAuth(ctx: ExtensionContext, model: RegistryModel): Promise<{ apiKey?: string; headers?: ProviderHeaders; env?: Record<string, string> }> {
 	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 	if (auth.ok === false) throw new Error(`Prompt redo model auth failed for ${fullModelId(model)}: ${auth.error}`);
 	return {
@@ -91,7 +92,7 @@ export async function rewritePromptWithGuidance(input: {
 			tools: [],
 		},
 		convertToLlm,
-		streamFunction: streamFn,
+		...agentStreamOptions(streamFn),
 		getApiKey: (providerName) => providerName === model.provider ? auth.apiKey : undefined,
 		toolExecution: "sequential",
 	});

--- a/src/runs/shared/llm-intent-arbiter.ts
+++ b/src/runs/shared/llm-intent-arbiter.ts
@@ -2,7 +2,9 @@ import { createHash } from "node:crypto";
 import { Agent, type AgentTool, type StreamFn } from "@earendil-works/pi-agent-core";
 import { convertToLlm, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
+import type { ProviderHeaders } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
+import { agentStreamOptions } from "../../shared/agent-stream-options.ts";
 
 /**
  * LLM intent arbiter for the completion mutation guard.
@@ -56,7 +58,7 @@ interface ArbiterRuntime {
 
 interface ArbiterAuth {
 	apiKey?: string;
-	headers?: Record<string, string>;
+	headers?: ProviderHeaders;
 	env?: Record<string, string>;
 }
 
@@ -122,7 +124,7 @@ async function resolveArbiterAuth(
 		getApiKeyAndHeaders?: (m: RegistryModel) => Promise<{
 			ok: boolean;
 			apiKey?: string;
-			headers?: Record<string, string>;
+			headers?: ProviderHeaders;
 			env?: Record<string, string>;
 			error?: string;
 		}>;
@@ -188,7 +190,7 @@ async function runArbitration(
 			tools: [tool],
 		},
 		convertToLlm,
-		streamFunction: authWrappedStreamFn(runtime.baseStreamFn, auth),
+		...agentStreamOptions(authWrappedStreamFn(runtime.baseStreamFn, auth)),
 		getApiKey: (providerName) =>
 			providerName === runtime.model.provider ? auth.apiKey : undefined,
 		beforeToolCall: async ({ toolCall }) =>

--- a/src/shared/agent-stream-options.ts
+++ b/src/shared/agent-stream-options.ts
@@ -1,0 +1,5 @@
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+
+export function agentStreamOptions(streamFn: StreamFn): { streamFunction: StreamFn; streamFn: StreamFn } {
+	return { streamFunction: streamFn, streamFn };
+}

--- a/src/watchdog/permission-arbiter.ts
+++ b/src/watchdog/permission-arbiter.ts
@@ -3,6 +3,7 @@ import { convertToLlm, type ExtensionContext } from "@earendil-works/pi-coding-a
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type, type Static } from "typebox";
 import { appendPermissionAudit, permissionArgsPreview } from "../runs/shared/permissions.ts";
+import { agentStreamOptions } from "../shared/agent-stream-options.ts";
 import { decodeChildWatchdogConfig } from "./child-status.ts";
 import { childResolvedConfig } from "./register-child.ts";
 import { resolveWatchdogReviewModel } from "./review.ts";
@@ -112,7 +113,7 @@ export function createWatchdogPermissionArbiter(options: WatchdogPermissionArbit
 					tools: [tool],
 				},
 				convertToLlm,
-				streamFunction: streamFn,
+				...agentStreamOptions(streamFn),
 				getApiKey: (providerName) => providerName === selection.model.provider ? auth.apiKey : undefined,
 				beforeToolCall: async ({ toolCall }) => toolCall.name === tool.name ? undefined : { block: true, reason: `Permission arbiter tool '${toolCall.name}' is not allowed.` },
 				toolExecution: "sequential",

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -1,9 +1,10 @@
 import { Agent, type AgentTool, type StreamFn, type ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { createReadOnlyTools, convertToLlm, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
-import type { Model } from "@earendil-works/pi-ai";
+import type { Model, ProviderHeaders } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
 import { resolveModelCandidate } from "../runs/shared/model-fallback.ts";
+import { agentStreamOptions } from "../shared/agent-stream-options.ts";
 import { resolveEffectiveThinking, splitKnownThinkingSuffix, THINKING_LEVELS, toModelInfo } from "../shared/model-info.ts";
 import type { WatchdogReviewFunction, WatchdogReviewRequest } from "./runtime.ts";
 import {
@@ -36,7 +37,7 @@ type RegistryModel = Model<any>;
 
 interface WatchdogReviewAuth {
 	apiKey?: string;
-	headers?: Record<string, string>;
+	headers?: ProviderHeaders;
 	env?: Record<string, string>;
 }
 
@@ -280,7 +281,7 @@ export function createMainWatchdogReview(provider: WatchdogContextProvider, opti
 				tools,
 			},
 			convertToLlm,
-			streamFunction: streamFn,
+			...agentStreamOptions(streamFn),
 			getApiKey: (providerName) => providerName === selection.model.provider ? auth.apiKey : undefined,
 			beforeToolCall: async ({ toolCall }) => WATCHDOG_ALLOWED_TOOL_NAMES.has(toolCall.name)
 				? undefined

--- a/test/unit/agent-stream-options.test.ts
+++ b/test/unit/agent-stream-options.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { agentStreamOptions } from "../../src/shared/agent-stream-options.ts";
+
+describe("agent stream options", () => {
+	it("supports the Pi 0.81 and 0.84 constructor option names", () => {
+		const streamFn: StreamFn = () => { throw new Error("not called"); };
+		const options = agentStreamOptions(streamFn);
+
+		assert.equal(options.streamFunction, streamFn);
+		assert.equal(options.streamFn, streamFn);
+	});
+});


### PR DESCRIPTION
## Problem

Pi 0.81's `Agent` constructor requires `streamFunction`, while Pi 0.84 requires `streamFn`. pi-subagents currently passes only the 0.81 name. On Pi 0.84, the constructor silently falls back to its default stream instead of using the authenticated, provider-scoped stream selected by pi-subagents.

This affects main watchdog reviews, watchdog permission decisions, Prompt Audit rewrites, and completion-intent arbitration.

Pi 0.84 also allows `null` provider header values to suppress defaults, which the local `Record<string, string>` auth types reject.

## Solution

- Supply the selected stream under both constructor option names through one small compatibility helper, preserving support for the tested Pi 0.81 baseline and current Pi 0.84.
- Use Pi's `ProviderHeaders` type for forwarded authentication headers.
- Add a focused regression test that locks both constructor option names.

## Validation

- `npm run typecheck` against the repository's Pi 0.81 dependency baseline
- `npm test` — 1,883 passed, 2 skipped
- `npm run typecheck` against exact Pi 0.84.1 packages
- affected unit tests against exact Pi 0.84.1 packages — 59 passed
