### PR TITLE
refactor: clean up unreleased helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Add `tools: "inherit"` for builtin role overrides, so one role can inherit Pi's normal tools and extensions without shadowing the agent file. Thanks to @estanexanavsem for #1047 and @davidarny for #1049.
 - Add simple terminal examples for FleetView, the async widget, and inline tool display. Thanks to @czottmann for #1050.
 
+### Changed
+- Clean up unreleased active-capacity and artifact packaging helpers without changing runtime behavior.
+
 ### Fixed
 - Show children interrupted by a parent-stopped workflow as stopped instead of failed, and preserve the workflow stop reason (#1060).
 - Keep subagent artifacts and automatic mission records outside project worktrees by default, so read-only workflows do not make clean-tree checks fail (#1062).

--- a/src/runs/background/active-async-capacity.ts
+++ b/src/runs/background/active-async-capacity.ts
@@ -194,10 +194,6 @@ function runnerReleaseVerdict(owner: ActiveAsyncCapacityOwnerV1, status: AsyncSt
 		: { state: "retained", reason: `process-terminal proof is ${proof?.state ?? "missing"}` };
 }
 
-function runnerCanRelease(owner: ActiveAsyncCapacityOwnerV1, status: AsyncStatus): boolean {
-	return runnerReleaseVerdict(owner, status).state === "releasable";
-}
-
 function workflowReleaseVerdict(owner: ActiveAsyncCapacityOwnerV1, status: AsyncStatus | null, liveWorkflowRunIds: ReadonlySet<string>): ActiveAsyncCapacityReleaseVerdict {
 	if (!status) return { state: "retained", reason: "status file is missing or unreadable" };
 	if (status.sessionId !== owner.ownerSessionId) return { state: "retained", reason: `status session ${status.sessionId ?? "unknown"} does not match owner session ${owner.ownerSessionId}` };
@@ -224,18 +220,6 @@ function workflowReleaseVerdict(owner: ActiveAsyncCapacityOwnerV1, status: Async
 		if (proof?.state !== "observed" || proof.runId !== step.runId) return { state: "retained", reason: `async workflow child ${label} process-terminal proof is ${proof?.state ?? "missing"}` };
 	}
 	return { state: "releasable", reason: "workflow is terminal, controller is gone, and async children have observed proof" };
-}
-
-function workflowCanRelease(owner: ActiveAsyncCapacityOwnerV1, status: AsyncStatus, liveWorkflowRunIds: ReadonlySet<string>): boolean {
-	return workflowReleaseVerdict(owner, status, liveWorkflowRunIds).state === "releasable";
-}
-
-function ownerCanRelease(owner: ActiveAsyncCapacityOwnerV1, liveWorkflowRunIds: ReadonlySet<string>): boolean {
-	const status = readStatus(owner.asyncDir);
-	if (!status) return false;
-	return owner.kind === "runner"
-		? runnerCanRelease(owner, status)
-		: workflowCanRelease(owner, status, liveWorkflowRunIds);
 }
 
 function ownerReleaseVerdict(owner: ActiveAsyncCapacityOwnerV1, liveWorkflowRunIds: ReadonlySet<string>): ActiveAsyncCapacityReleaseVerdict {
@@ -298,7 +282,7 @@ export function reconcileActiveAsyncCapacity(
 			|| owner.ownerSessionId !== sessionId
 			|| owner.ownerSessionKey !== activeAsyncCapacitySessionKey(sessionId)
 			|| path.basename(dir) !== `slot-${owner.slot}`
-			|| !ownerCanRelease(owner, liveWorkflowRunIds)) continue;
+			|| ownerReleaseVerdict(owner, liveWorkflowRunIds).state !== "releasable") continue;
 		removeOwnedSlot(dir, owner, options);
 	}
 	return snapshotFor(sessionId, limit, rootDir);

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -65,10 +65,6 @@ function patternMatchesArtifactPath(pattern: string, artifactPath: string): bool
 		|| globMatchesPath(normalized, artifactPath);
 }
 
-function patternMatchesProjectArtifacts(pattern: string): boolean {
-	return PROJECT_ARTIFACT_PATHS.some((artifactPath) => patternMatchesArtifactPath(pattern, artifactPath));
-}
-
 function ignoreFileExcludesProjectArtifacts(filePath: string): boolean {
 	if (!fs.existsSync(filePath)) return false;
 	try {


### PR DESCRIPTION
## Summary

This is a small unreleased TypeScript cleanup pass.

It removes redundant active-capacity release wrapper helpers now that the richer release verdict helper owns the decision, and drops an unused artifact packaging wrapper. Runtime behavior is unchanged.

## Validation

- `node --experimental-strip-types --test test/unit/active-async-capacity.test.ts test/unit/artifacts.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review: `/Users/nicobailon/.pi/agent/backlog-artifacts/pi-subagents/ts-cleanup-unreleased-review.md`
