### PR TITLE
fix: trust live async session roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Clean up active-run limits and artifact packaging code without changing behavior.
 
 ### Fixed
+- Trust live Herdr session roots only when the parent executor registered them for that async run.
 - Let a workflow child disable the intercom bridge for one run with `intercomBridge: { mode: "off" }`, while normal async completion still works. Thanks to @jaudiger for #1072.
 - Recover sibling children after a detached workflow fails (#1066).
 - Show child session transcripts in standalone Herdr inspectors when the transcript is in a trusted session folder (#1069).

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -557,11 +557,13 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		const agents = firstGroupCount && firstGroupCount > 0
 			? rawAgents?.slice(0, firstGroupCount)
 			: rawAgents;
+		const sessionRoot = state.liveAsyncSessionRoots?.get(info.id);
+		state.liveAsyncSessionRoots?.delete(info.id);
 		state.asyncJobs.set(info.id, {
 			asyncId: info.id,
 			asyncDir,
 			...(typeof info.cwd === "string" ? { cwd: path.resolve(info.cwd) } : {}),
-			...(typeof info.sessionRoot === "string" ? { sessionRoot: path.resolve(info.sessionRoot) } : {}),
+			...(sessionRoot ? { sessionRoot } : {}),
 			status: "queued",
 			pid: typeof info.pid === "number" ? info.pid : undefined,
 			...(typeof info.sessionId === "string" ? { sessionId: info.sessionId } : {}),
@@ -638,6 +640,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		state.asyncJobs.clear();
 		state.fleetJobs?.clear();
 		state.foregroundControls?.clear();
+		state.liveAsyncSessionRoots?.clear();
 		state.lastForegroundControlId = null;
 		state.resultFileCoalescer.clear();
 		if (ctx?.hasUI) {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -6418,7 +6418,12 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		};
 
 		let nestedForegroundStarted = false;
+		let asyncLaunchFailed = false;
 		try {
+			if (effectiveAsync) {
+				deps.state.liveAsyncSessionRoots ??= new Map();
+				deps.state.liveAsyncSessionRoots.set(asyncRunId, sessionRoot);
+			}
 			if (workflowLaunchObserver) {
 				const singleTask = hasTasks && effectiveParams.tasks?.length === 1 ? effectiveParams.tasks[0] : undefined;
 				const launch = hasSingle
@@ -6432,7 +6437,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				}
 			}
 			const asyncResult = runAsyncPath(execData, deps);
-			if (asyncResult) return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(asyncResult, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget));
+			if (asyncResult) {
+				asyncLaunchFailed = asyncResult.isError === true;
+				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(asyncResult, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget));
+			}
 			if (foregroundControl) {
 				writeNestedForegroundEvent("subagent.nested.started");
 				nestedForegroundStarted = true;
@@ -6454,10 +6462,12 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				return attachMission(withRunFanoutBudget(withResolvedContext(withForkThinkingNotes(result, forkThinkingDowngrades), contextPolicy.contextSummary), runFanoutBudget, { annotateContent: runFanoutAnnotateContent }));
 			}
 		} catch (error) {
+			asyncLaunchFailed = effectiveAsync;
 			const errorResult = withForkThinkingNotes(toExecutionErrorResult(effectiveParams, error, contextPolicy.contextSummary), forkThinkingDowngrades);
 			if (nestedForegroundStarted) writeNestedForegroundEvent("subagent.nested.completed", errorResult);
 			return attachMission(errorResult);
 		} finally {
+			if (effectiveAsync && (asyncLaunchFailed || (activeAsyncCapacity && !activeAsyncCapacity.owner.runnerStartedAt))) deps.state.liveAsyncSessionRoots?.delete(asyncRunId);
 			if (activeAsyncCapacity && !activeAsyncCapacity.owner.runnerStartedAt) activeAsyncCapacity.rollback();
 			if (foregroundControl) {
 				settleForegroundSchedulingOwner(foregroundControl);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1669,6 +1669,8 @@ export interface SubagentState {
 	parentSessionFile?: string | null;
 	/** Extension-owned roots trusted for child session transcript reads. */
 	trustedSessionRoots?: string[];
+	/** Live async session roots created by this parent executor, keyed by run id. */
+	liveAsyncSessionRoots?: Map<string, string>;
 	/** Last valid parent session model observed for this session; used when continuation contexts omit ctx.model. */
 	lastParentModel?: { provider: string; id: string };
 	subagentInProgress?: boolean;

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -151,17 +151,50 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
-	it("stores parent-resolved session roots from async start events", () => {
+	it("stores only parent-registered session roots from async start events", () => {
 		const asyncRoot = createTempDir("pi-async-job-tracker-session-root-");
 		try {
 			const state = createState();
 			const recorder = createEventRecorder();
 			const tracker = createTracker(recorder.pi, state as never, asyncRoot);
 			const sessionRoot = path.join(asyncRoot, "custom-sessions");
+			state.liveAsyncSessionRoots = new Map([["run-custom-session", sessionRoot]]);
 
-			tracker.handleStarted({ id: "run-custom-session", asyncDir: path.join(asyncRoot, "run-custom-session"), agent: "worker", sessionRoot: path.join(sessionRoot, "..", "custom-sessions") });
+			tracker.handleStarted({ id: "run-custom-session", asyncDir: path.join(asyncRoot, "run-custom-session"), agent: "worker", sessionRoot: path.join(asyncRoot, "forged") });
 
-			assert.equal(state.asyncJobs.get("run-custom-session")?.sessionRoot, path.resolve(sessionRoot));
+			assert.equal(state.asyncJobs.get("run-custom-session")?.sessionRoot, sessionRoot);
+			assert.equal(state.liveAsyncSessionRoots.has("run-custom-session"), false);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("ignores unregistered session roots from async start events", () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-forged-session-root-");
+		try {
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot);
+
+			tracker.handleStarted({ id: "run-forged-session", asyncDir: path.join(asyncRoot, "run-forged-session"), agent: "worker", sessionRoot: path.join(asyncRoot, "forged") });
+
+			assert.equal(state.asyncJobs.get("run-forged-session")?.sessionRoot, undefined);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("clears pending live session roots on reset", () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-reset-session-root-");
+		try {
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot);
+			state.liveAsyncSessionRoots = new Map([["run-pending", path.join(asyncRoot, "sessions")]]);
+
+			tracker.resetJobs();
+
+			assert.equal(state.liveAsyncSessionRoots.size, 0);
 		} finally {
 			removeTempDir(asyncRoot);
 		}


### PR DESCRIPTION
## Summary

Fixes the live Herdr transcript trust path so async start events no longer decide which session root is trusted. The parent executor now records the live session root for the async run, and the tracker consumes that registered root when the run start event arrives.

This keeps valid custom session roots working while forged or unregistered `sessionRoot` event fields are ignored.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='stores only parent-registered session roots from async start events|ignores unregistered session roots from async start events|clears pending live session roots on reset|passes live parent-owned custom session roots to standalone inspectors|renders trusted child session fallback and refuses untrusted roots' test/integration/async-job-tracker.test.ts test/unit/herdr-inspector.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh follow-up review: no findings