### PR TITLE
feat(rpc): publish structured async job snapshots

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -56,6 +56,16 @@ The DTO intentionally never exposes run, async, or tool IDs. Clients must ignore
 
 `pi.events` is in-process only. It does not reach separate Pi processes or child subagents; use the file lifecycle artifacts or `pi-intercom` for cross-process coordination.
 
+### External Pi RPC async snapshot
+
+The in-process request/reply bus above is available only to extensions in the same Pi process. Host applications running Pi in `--mode rpc` receive async job state through Pi's standard fire-and-forget extension UI protocol instead.
+
+When `ping.capabilities.rpcAsyncSnapshot` is advertised, it identifies the transport, widget key, payload prefix, and schema version. Version 1 uses `setWidget("subagent-async", string[])`; the first line starts with `PI_SUBAGENT_ASYNC_JSON:` followed by a bounded JSON snapshot.
+
+The snapshot is derived from the same `AsyncJobState` used by the TUI widget. It contains exact `asyncId` run identity, stable workflow keys or step indexes, lifecycle status, agent/task/model metadata, and bounded nested descendants. It omits working directories, artifact/session paths, tool arguments, recent output, and error text. Terminal snapshots are also attached to hidden `subagent-notify` message details for session replay.
+
+DTO types and the prefix constant are exported from `pi-subagents/async-rpc-snapshot`. Consumers must check `version`, ignore unknown fields, and treat the live widget as replace-by-snapshot state rather than appending rows.
+
 ## Launch contract preflight
 
 Use `pi-subagents/preflight` when an extension needs to inspect the resolved child launch contract before deciding whether to run anything:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "./intercom-bridge": "./src/api/intercom-bridge.ts",
     "./pi-args": "./src/api/pi-args.ts",
     "./shared-types": "./src/api/shared-types.ts",
+    "./async-rpc-snapshot": "./src/api/async-rpc-snapshot.ts",
     "./project-panes": "./src/api/project-panes.ts"
   },
   "repository": {

--- a/src/api/async-rpc-snapshot.ts
+++ b/src/api/async-rpc-snapshot.ts
@@ -1,0 +1,6 @@
+export {
+	ASYNC_RPC_WIDGET_PREFIX,
+	type AsyncRpcChildSnapshot,
+	type AsyncRpcRunSnapshot,
+	type AsyncRpcSnapshot,
+} from "../runs/background/async-rpc-snapshot.ts";

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -32,6 +32,7 @@ import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foregro
 import { createAsyncJobTracker } from "../runs/background/async-job-tracker.ts";
 import { getActiveAsyncCapacitySnapshot, resolveMaxActiveAsyncRunsPerSession } from "../runs/background/active-async-capacity.ts";
 import { createResultWatcher } from "../runs/background/result-watcher.ts";
+import { buildAsyncRpcRunSnapshot } from "../runs/background/async-rpc-snapshot.ts";
 import { createScheduledRunManager } from "../runs/background/scheduled-runs.ts";
 import { registerSlashCommands } from "../slash/slash-commands.ts";
 import { registerPromptTemplateDelegationBridge } from "../slash/prompt-template-bridge.ts";
@@ -46,7 +47,7 @@ import { resolveWaitToolConfig } from "../runs/background/subagent-wait.ts";
 import { registerWaitTool } from "../runs/background/wait-tool.ts";
 import { createWaitSubscriptionManager } from "../runs/background/wait-subscriptions.ts";
 import { drainOutstandingWork } from "../runs/background/auto-drain.ts";
-import registerSubagentNotify, { parseSubagentNotifyContent, type SubagentNotifyDetails } from "../runs/background/notify.ts";
+import registerSubagentNotify, { parseSubagentNotifyContent, type CompletionNotification, type SubagentNotifyDetails } from "../runs/background/notify.ts";
 import { formatSteeringNotice, handleSubagentSteeringNotice, SUBAGENT_STEERING_MESSAGE_TYPE, type SubagentSteeringMessageDetails } from "./steering-notices.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
@@ -412,7 +413,28 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const supervisorChannel = createNativeSupervisorChannel(pi, state);
 	const waitSubscriptionManager = createWaitSubscriptionManager(pi, state);
 	const mainWatchdog = registerMainWatchdog(pi);
-	const completionNotifier = registerSubagentNotify(pi, state, { batchConfig: config.completionBatch });
+	const completionNotifier = registerSubagentNotify(pi, state, {
+		batchConfig: config.completionBatch,
+		getAsyncRpcRun: (result: CompletionNotification) => {
+			const id = typeof result.runId === "string" ? result.runId : typeof result.id === "string" ? result.id : undefined;
+			if (!id) return undefined;
+			const job = state.asyncJobs.get(id) ?? state.fleetJobs?.get(id);
+			if (!job) return undefined;
+			const run = buildAsyncRpcRunSnapshot(job);
+			const status = result.state === "paused" || result.state === "stopped" || result.state === "rejected"
+				? result.state
+				: result.success ? "complete" : "failed";
+			const children = run.children.map((child, index) => {
+				const outcome = result.results?.[index];
+				if (!outcome) return child;
+				const childStatus = outcome.status === "stopped" || outcome.stopped
+					? "stopped"
+					: outcome.status === "paused" ? "paused" : outcome.success === false ? "failed" : "complete";
+				return { ...child, status: childStatus };
+			});
+			return { ...run, status, children };
+		},
+	});
 	const fleetStatus = fleetViewEnabled
 		? new SubagentFleetStatus(state, async (itemKey) => {
 			const ctx = state.lastUiContext;

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -15,7 +15,9 @@ import {
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_PROCESS_TERMINAL_EVENT,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
+	WIDGET_KEY,
 } from "../shared/types.ts";
+import { ASYNC_RPC_WIDGET_PREFIX } from "../runs/background/async-rpc-snapshot.ts";
 import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
 import { readStatus } from "../shared/utils.ts";
 import { SubagentParams } from "./schemas.ts";
@@ -375,6 +377,7 @@ function pingData(ctx: ExtensionContext | null) {
 		capabilities: {
 			status: true,
 			fleetStatus: { version: 1 },
+			rpcAsyncSnapshot: { version: 1, transport: "extension-ui-widget", widgetKey: WIDGET_KEY, prefix: ASYNC_RPC_WIDGET_PREFIX },
 			asyncSpawn: true,
 			steer: true,
 			nonRecoveringSteer: true,

--- a/src/runs/background/async-rpc-snapshot.ts
+++ b/src/runs/background/async-rpc-snapshot.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import type { AsyncJobState, AsyncJobStep, NestedRunSummary, NestedStepSummary } from "../../shared/types.ts";
+
+export const ASYNC_RPC_WIDGET_PREFIX = "PI_SUBAGENT_ASYNC_JSON:";
+const MAX_RUNS = 64;
+const MAX_CHILDREN = 256;
+const MAX_DEPTH = 4;
+const MAX_TEXT = 2_000;
+
+export interface AsyncRpcChildSnapshot {
+	key: string;
+	index: number;
+	agent?: string;
+	label?: string;
+	task?: string;
+	status: string;
+	model?: string;
+	thinking?: string;
+	currentTool?: string;
+	durationMs?: number;
+	startedAt?: number;
+	endedAt?: number;
+	runId?: string;
+	children?: AsyncRpcChildSnapshot[];
+}
+
+export interface AsyncRpcRunSnapshot {
+	asyncId: string;
+	sessionId?: string;
+	mode?: string;
+	status: AsyncJobState["status"];
+	description?: string;
+	startedAt?: number;
+	updatedAt?: number;
+	currentStep?: number;
+	stepsTotal?: number;
+	children: AsyncRpcChildSnapshot[];
+}
+
+export interface AsyncRpcSnapshot {
+	version: 1;
+	sourceId: string;
+	revision: number;
+	generatedAt: number;
+	runs: AsyncRpcRunSnapshot[];
+}
+
+function text(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim().slice(0, MAX_TEXT) : undefined;
+}
+
+function finite(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function nestedStep(step: NestedStepSummary, index: number, depth: number): AsyncRpcChildSnapshot {
+	return {
+		key: text((step as { workflowKey?: unknown }).workflowKey) ?? `step:${index}`,
+		index,
+		status: step.status,
+		...(text(step.agent) ? { agent: text(step.agent) } : {}),
+		...(text(step.model) ? { model: text(step.model) } : {}),
+		...(text(step.thinking) ? { thinking: text(step.thinking) } : {}),
+		...(text(step.currentTool) ? { currentTool: text(step.currentTool) } : {}),
+		...(finite(step.startedAt) !== undefined ? { startedAt: finite(step.startedAt) } : {}),
+		...(finite(step.endedAt) !== undefined ? { endedAt: finite(step.endedAt) } : {}),
+		...(depth < MAX_DEPTH && step.children?.length
+			? { children: step.children.slice(0, MAX_CHILDREN).map((child, childIndex) => nestedRun(child, childIndex, depth + 1)) }
+			: {}),
+	};
+}
+
+function nestedRun(run: NestedRunSummary, index: number, depth: number): AsyncRpcChildSnapshot {
+	return {
+		key: text(run.id) ?? `nested:${index}`,
+		index,
+		status: run.state,
+		...(text(run.agent) ? { agent: text(run.agent) } : {}),
+		...(finite(run.startedAt) !== undefined ? { startedAt: finite(run.startedAt) } : {}),
+		...(finite(run.endedAt) !== undefined ? { endedAt: finite(run.endedAt) } : {}),
+		...(depth < MAX_DEPTH && run.steps?.length
+			? { children: run.steps.slice(0, MAX_CHILDREN).map((step, stepIndex) => nestedStep(step, stepIndex, depth + 1)) }
+			: {}),
+	};
+}
+
+function child(step: AsyncJobStep, fallbackIndex: number): AsyncRpcChildSnapshot {
+	const index = finite(step.index) ?? fallbackIndex;
+	return {
+		key: text(step.workflowKey) ?? `step:${index}`,
+		index,
+		status: step.status,
+		...(text(step.agent) ? { agent: text(step.agent) } : {}),
+		...(text(step.label) ? { label: text(step.label) } : {}),
+		...(text(step.description) ? { task: text(step.description) } : {}),
+		...(text(step.model) ? { model: text(step.model) } : {}),
+		...(text(step.thinking) ? { thinking: text(step.thinking) } : {}),
+		...(text(step.currentTool) ? { currentTool: text(step.currentTool) } : {}),
+		...(finite(step.durationMs) !== undefined ? { durationMs: finite(step.durationMs) } : {}),
+		...(finite(step.startedAt) !== undefined ? { startedAt: finite(step.startedAt) } : {}),
+		...(finite(step.endedAt) !== undefined ? { endedAt: finite(step.endedAt) } : {}),
+		...(text(step.runId) ? { runId: text(step.runId) } : {}),
+		...(step.children?.length
+			? { children: step.children.slice(0, MAX_CHILDREN).map((nested, nestedIndex) => nestedRun(nested, nestedIndex, 1)) }
+			: {}),
+	};
+}
+
+function jobChildren(job: AsyncJobState): AsyncRpcChildSnapshot[] {
+	const steps = (job.steps ?? []).slice(0, MAX_CHILDREN);
+	const attached = new Set(steps.flatMap((step) => step.children?.map((nested) => nested.id) ?? []));
+	const unattached = (job.nestedChildren ?? []).filter((nested) => !attached.has(nested.id));
+	return [
+		...steps.map(child),
+		...unattached.slice(0, Math.max(0, MAX_CHILDREN - steps.length)).map((nested, index) => nestedRun(nested, steps.length + index, 1)),
+	];
+}
+
+export function buildAsyncRpcRunSnapshot(job: AsyncJobState): AsyncRpcRunSnapshot {
+	return {
+		asyncId: job.asyncId,
+		status: job.status,
+		children: jobChildren(job),
+		...(text(job.sessionId) ? { sessionId: text(job.sessionId) } : {}),
+		...(text(job.mode) ? { mode: text(job.mode) } : {}),
+		...(text(job.description) ? { description: text(job.description) } : {}),
+		...(finite(job.startedAt) !== undefined ? { startedAt: finite(job.startedAt) } : {}),
+		...(finite(job.updatedAt) !== undefined ? { updatedAt: finite(job.updatedAt) } : {}),
+		...(finite(job.currentStep) !== undefined ? { currentStep: finite(job.currentStep) } : {}),
+		...(finite(job.stepsTotal) !== undefined ? { stepsTotal: finite(job.stepsTotal) } : {}),
+	};
+}
+
+const sourceId = randomUUID();
+let revision = 0;
+
+export function buildAsyncRpcSnapshotFromRuns(runs: AsyncRpcRunSnapshot[], now = Date.now()): AsyncRpcSnapshot {
+	return { version: 1, sourceId, revision: ++revision, generatedAt: now, runs: runs.slice(0, MAX_RUNS) };
+}
+
+export function buildAsyncRpcSnapshot(jobs: AsyncJobState[], now = Date.now()): AsyncRpcSnapshot {
+	return buildAsyncRpcSnapshotFromRuns(jobs.map(buildAsyncRpcRunSnapshot), now);
+}
+
+export function encodeAsyncRpcWidgetLines(jobs: AsyncJobState[], now = Date.now()): string[] {
+	return [`${ASYNC_RPC_WIDGET_PREFIX}${JSON.stringify(buildAsyncRpcSnapshot(jobs, now))}`];
+}

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -16,6 +16,7 @@ import {
 } from "./completion-batcher.ts";
 import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT, type ParallelHandoffReference, type SubagentState } from "../../shared/types.ts";
 import { isUnexplainedProcessSignal } from "../shared/process-signal.ts";
+import { buildAsyncRpcSnapshotFromRuns, type AsyncRpcRunSnapshot } from "./async-rpc-snapshot.ts";
 
 export interface SubagentNotifyDetails {
 	agent: string;
@@ -78,6 +79,7 @@ export interface RegisterSubagentNotifyOptions {
 	batchConfig?: CompletionBatchConfig;
 	timers?: NotifyTimerApi;
 	now?: () => number;
+	getAsyncRpcRun?: (result: CompletionNotification) => AsyncRpcRunSnapshot | undefined;
 }
 
 export interface CompletionNotifier {
@@ -164,6 +166,7 @@ interface PendingCompletion {
 	details: SubagentNotifyDetails;
 	triggerTurn: boolean;
 	resolve(accepted: boolean): void;
+	asyncRun?: AsyncRpcRunSnapshot;
 }
 
 function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage">, items: PendingCompletion[]): boolean {
@@ -171,12 +174,14 @@ function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage">, items: PendingCom
 	const details = items.map((item) => item.details);
 	const content = details.length === 1 ? formatSingleCompletion(details[0]!) : formatGroupedCompletion(details);
 	const display = details.some((detail) => detail.source === "foreground" || detail.status !== "completed");
+	const asyncRuns = items.flatMap((item) => item.asyncRun ? [item.asyncRun] : []);
 	try {
 		pi.sendMessage(
 			{
 				customType: "subagent-notify",
 				content,
 				display,
+				...(asyncRuns.length ? { details: { asyncSnapshot: buildAsyncRpcSnapshotFromRuns(asyncRuns) } } : {}),
 			},
 			{ triggerTurn: items.some((item) => item.triggerTurn) },
 		);
@@ -291,6 +296,7 @@ export default function registerSubagentNotify(
 			details,
 			triggerTurn: result.triggerTurn !== false,
 			resolve,
+			asyncRun: options.getAsyncRpcRun?.(result),
 		};
 		if (details.source === "foreground") {
 			emit([item]);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5073,6 +5073,13 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								if (budgetState?.exhausted) return workflowChildResult(key, buildRequestedModeError(childParams as SubagentParamsLike, usageBudgetExceededMessage(budgetState)));
 								const childPhase = typeof childParams.phase === "string" && childParams.phase.trim() ? childParams.phase.trim() : undefined;
 								const childLabel = typeof childParams.label === "string" && childParams.label.trim() ? childParams.label.trim() : undefined;
+								const workflowStep = workflowSteps.get(key);
+								if (workflowStep) {
+									if (typeof childParams.task === "string") workflowStep.description = childParams.task;
+									if (childLabel) workflowStep.label = childLabel;
+									if (childPhase) workflowStep.phase = childPhase;
+									persist();
+								}
 								recordMissionWorkflowChild(missionBinding, workflowRunId, key, {
 									status: "running",
 									...(typeof childParams.agent === "string" && childParams.agent.trim() ? { agent: childParams.agent.trim() } : {}),

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -20,6 +20,7 @@ import {
 	POLL_INTERVAL_MS,
 	WIDGET_KEY,
 } from "../shared/types.ts";
+import { encodeAsyncRpcWidgetLines } from "../runs/background/async-rpc-snapshot.ts";
 import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
 import { formatTokens, formatUsage, formatDuration, formatModelThinking, formatToolCall, shortenPath } from "../shared/formatters.ts";
 import { getDisplayItems, getSingleResultOutput } from "../shared/utils.ts";
@@ -1585,6 +1586,10 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 		return;
 	}
 	if (!ctx.hasUI) return;
+	if (ctx.mode === "rpc") {
+		ctx.ui.setWidget(WIDGET_KEY, encodeAsyncRpcWidgetLines(jobs));
+		return;
+	}
 	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, ctx.ui.getToolsExpanded?.() ?? false));
 }
 

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -100,11 +100,12 @@ async function waitForCondition(
 	}
 }
 
-function createUiContext() {
+function createUiContext(mode?: "rpc") {
 	const widgets: unknown[] = [];
 	let renderRequests = 0;
 	const ctx = {
 		hasUI: true,
+		...(mode ? { mode } : {}),
 		ui: {
 			theme: {
 				fg: (_theme: string, text: string) => text,
@@ -225,6 +226,27 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			removeTempDir(asyncRoot);
 		}
 	});
+
+it("emits a terminal RPC snapshot before retention clears the widget", async () => {
+	const asyncRoot = createTempDir("pi-async-job-tracker-rpc-terminal-");
+	try {
+		const state = createState();
+		const ui = createUiContext("rpc");
+		const recorder = createEventRecorder();
+		const tracker = createTracker(recorder.pi, state as never, asyncRoot, { completionRetentionMs: 5 });
+		tracker.resetJobs(ui.ctx as never);
+		tracker.handleStarted({ id: "run-rpc", asyncDir: path.join(asyncRoot, "run-rpc"), agent: "worker" });
+		tracker.handleComplete({ id: "run-rpc", success: true });
+		const terminalLines = [...ui.widgets].reverse().find((widget) => Array.isArray(widget)) as string[] | undefined;
+		assert.ok(terminalLines?.[0]?.startsWith("PI_SUBAGENT_ASYNC_JSON:"));
+		const snapshot = JSON.parse(terminalLines[0]!.slice("PI_SUBAGENT_ASYNC_JSON:".length)) as { runs: Array<{ status: string }> };
+		assert.equal(snapshot.runs[0]?.status, "complete");
+		await new Promise((resolve) => setTimeout(resolve, 40));
+		assert.equal(ui.widgets.at(-1), undefined);
+	} finally {
+		removeTempDir(asyncRoot);
+	}
+});
 
 	it("keeps the async widget cleared when it is disabled", () => {
 		const asyncRoot = createTempDir("pi-async-job-widget-disabled-");

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { extractToolArgsPreview } from "../../src/shared/utils.ts";
+import { ASYNC_RPC_WIDGET_PREFIX } from "../../src/runs/background/async-rpc-snapshot.ts";
 
 const { buildWidgetLines, clearLegacyResultAnimationTimer, renderWidget } = await import("../../src/tui/render.ts") as {
 	buildWidgetLines: (jobs: Array<Record<string, unknown>>, theme: { fg(name: string, text: string): string; bold(text: string): string }, width?: number, expanded?: boolean, frame?: number) => string[];
@@ -208,6 +209,26 @@ describe("subagent async widget rendering", () => {
 		assert.doesNotMatch(text, /widget truncated/);
 		assert.ok(lines.length <= 10, "collapsed component should stay under Pi's string-widget cap even though it bypasses it");
 	});
+
+it("publishes structured string lines instead of a component factory in RPC mode", () => {
+	const ui = createUiContext();
+	renderWidget({ ...ui.ctx, mode: "rpc" } as never, [{
+		asyncId: "workflow-1",
+		asyncDir: "/tmp/workflow-1",
+		status: "running",
+		mode: "workflow",
+		steps: [
+			{ index: 0, workflowKey: "a", agent: "worker", description: "dynamic a", status: "running" },
+			{ index: 1, workflowKey: "b", agent: "worker", description: "dynamic b", status: "completed" },
+			{ index: 2, workflowKey: "c", agent: "worker", description: "dynamic c", status: "running" },
+		],
+	}]);
+	const widget = ui.widgets.at(-1);
+	assert.ok(Array.isArray(widget));
+	assert.ok((widget as string[])[0]?.startsWith(ASYNC_RPC_WIDGET_PREFIX));
+	const payload = JSON.parse((widget as string[])[0]!.slice(ASYNC_RPC_WIDGET_PREFIX.length)) as { runs: Array<{ children: Array<{ key: string }> }> };
+	assert.deepEqual(payload.runs[0]?.children.map((child) => child.key), ["a", "b", "c"]);
+});
 
 	it("honors the component render width instead of the terminal width", () => {
 		resetWidgetLayout();

--- a/test/unit/async-rpc-snapshot.test.ts
+++ b/test/unit/async-rpc-snapshot.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ASYNC_RPC_WIDGET_PREFIX, buildAsyncRpcRunSnapshot, encodeAsyncRpcWidgetLines } from "../../src/runs/background/async-rpc-snapshot.ts";
+import type { AsyncJobState } from "../../src/shared/types.ts";
+
+describe("async RPC snapshot", () => {
+	it("projects runtime workflow steps without exposing artifact paths", () => {
+		const job: AsyncJobState = {
+			asyncId: "workflow-1",
+			asyncDir: "/secret/async-dir",
+			cwd: "/secret/repo",
+			status: "running",
+			mode: "workflow",
+			steps: [
+				{ agent: "worker", workflowKey: "a", description: "dynamic a", status: "running", index: 0, currentTool: "bash", currentToolArgs: "token=company-secret", recentOutput: ["company-secret"] },
+				{ agent: "worker", workflowKey: "b", description: "dynamic b", status: "completed", index: 1, recentOutput: ["done b"] },
+				{ agent: "worker", workflowKey: "c", description: "dynamic c", status: "running", index: 2 },
+			],
+		};
+		const run = buildAsyncRpcRunSnapshot(job);
+		assert.deepEqual(run.children.map((child) => child.key), ["a", "b", "c"]);
+		assert.deepEqual(run.children.map((child) => child.task), ["dynamic a", "dynamic b", "dynamic c"]);
+		assert.equal(JSON.stringify(run).includes("/secret"), false);
+		assert.equal(JSON.stringify(run).includes("company-secret"), false);
+	});
+
+	it("encodes a versioned string widget payload", () => {
+		const lines = encodeAsyncRpcWidgetLines([{ asyncId: "r1", asyncDir: "/tmp/r1", status: "queued", steps: [] }], 123);
+		assert.equal(lines.length, 1);
+		assert.ok(lines[0]!.startsWith(ASYNC_RPC_WIDGET_PREFIX));
+		const parsed = JSON.parse(lines[0]!.slice(ASYNC_RPC_WIDGET_PREFIX.length)) as { version: number; generatedAt: number; runs: Array<{ asyncId: string }> };
+		assert.equal(parsed.version, 1);
+		assert.equal(parsed.generatedAt, 123);
+		assert.equal(parsed.runs[0]?.asyncId, "r1");
+	});
+});

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -134,6 +134,16 @@ describe("registerSubagentNotify", () => {
 		});
 	});
 
+it("attaches a bounded terminal async snapshot to the durable notification", async () => {
+	const { notifier, sent } = createPi("session-a", {
+		getAsyncRpcRun: () => ({ asyncId: "run-1", status: "complete", mode: "workflow", children: [{ key: "a", index: 0, status: "complete", task: "task a" }] }),
+	});
+	assert.equal(await notifier.deliver(completionResult({ id: "run-1" })), true);
+	const message = sent[0]?.message as { details?: { asyncSnapshot?: { version?: number; runs?: Array<{ asyncId?: string }> } } };
+	assert.equal(message.details?.asyncSnapshot?.version, 1);
+	assert.equal(message.details?.asyncSnapshot?.runs?.[0]?.asyncId, "run-1");
+});
+
 	it("acknowledges direct delivery only after sendMessage accepts it", async () => {
 		const { notifier, sent } = createPi("session-a");
 		assert.equal(await notifier.deliver(completionResult({ id: "direct-accepted" })), true);

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -63,8 +63,11 @@ test("published extension APIs use supported package entrypoints", async () => {
 		"./intercom-bridge": "./src/api/intercom-bridge.ts",
 		"./pi-args": "./src/api/pi-args.ts",
 		"./shared-types": "./src/api/shared-types.ts",
+		"./async-rpc-snapshot": "./src/api/async-rpc-snapshot.ts",
 		"./project-panes": "./src/api/project-panes.ts",
 	});
+	const asyncRpcSnapshot = await import("pi-subagents/async-rpc-snapshot");
+	assert.equal(asyncRpcSnapshot.ASYNC_RPC_WIDGET_PREFIX, "PI_SUBAGENT_ASYNC_JSON:");
 	const backgroundWork = await import("pi-subagents/background-work");
 	assert.equal(backgroundWork.BACKGROUND_WORK_PROTOCOL_VERSION, 1);
 	assert.equal(backgroundWork.BACKGROUND_WORK_REGISTRY_KEY, "pi-subagents.background-work.v1");

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -99,6 +99,10 @@ describe("subagent extension RPC bridge", () => {
 			(reply as { data: { capabilities?: { fleetStatus?: unknown } } }).data.capabilities?.fleetStatus,
 			{ version: 1 },
 		);
+		assert.deepEqual(
+			(reply as { data: { capabilities?: { rpcAsyncSnapshot?: unknown } } }).data.capabilities?.rpcAsyncSnapshot,
+			{ version: 1, transport: "extension-ui-widget", widgetKey: "subagent-async", prefix: "PI_SUBAGENT_ASYNC_JSON:" },
+		);
 
 		bridge.dispose();
 	});


### PR DESCRIPTION
## Summary

Publish the async job tracker’s authoritative runtime state through Pi’s existing RPC `setWidget` string-array channel while preserving the current component widget in TUI mode.

RPC clients currently receive no usable async widget because component factories have no RPC wire representation. This adds a bounded, versioned `PI_SUBAGENT_ASYNC_JSON:` payload derived directly from `AsyncJobState`, including dynamic workflow steps and nested descendants.

Terminal snapshots are also attached to the existing hidden completion notification details, so clients can restore completed child rows from session history after the live widget is cleared.

## Design

- `ctx.mode === "tui"`: unchanged component widget
- `ctx.mode === "rpc"`: structured `string[]` widget
- exact run identity via `asyncId`
- stable child identity via `workflowKey` or step index
- bounded runs, children, nesting depth, and text lengths
- excludes working directories, artifact/session paths, tool arguments, recent output, and error text
- records workflow task/label/phase on runtime steps instead of parsing workflow source

## Validation

- `npm run typecheck`
- async snapshot unit tests: 2 passed
- notification unit tests: 26 passed
- RPC renderer test passed
- terminal-snapshot-before-clear tracker test passed
- existing render-widget integration suite: 35 passed
- `git diff --check`

The broader local suite reaches 1,880 passing tests; remaining failures are existing environment-sensitive tests involving process inspection, user-profile fixtures, and filesystem behavior. This PR is draft pending maintainer feedback and clean hosted CI.