### PR TITLE
fix: warn once when a mission leaves the store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Warn once, instead of on every heartbeat, when a long-running workflow child outlives its mission record. Thanks to @albertgwo for #1079.
+
 ## [0.49.0] - 2026-08-13
 
 ### Added

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -108,7 +108,7 @@ import { inspectSubagentStatus } from "../background/run-status.ts";
 import { applyForceTopLevelAsyncOverride } from "../background/top-level-async.ts";
 import { handleMissionAction, MISSION_ACTIONS } from "../../missions/actions.ts";
 import { attachMissionToLaunchResult, prepareMissionLaunch, writeMissionAsyncBinding, type MissionLaunchBinding } from "../../missions/lifecycle.ts";
-import { updateMission } from "../../missions/store.ts";
+import { MissionNotFoundError, updateMission } from "../../missions/store.ts";
 import type { MissionWorkflowChildUpdate } from "../../missions/types.ts";
 import { createMissionWorkflowState } from "../../missions/workflow-state.ts";
 import { resolveAuthorityDecision } from "../../policy/authority.ts";
@@ -4500,6 +4500,14 @@ function duplicateSubagentCallResult(params: SubagentParamsLike): AgentToolResul
 
 const workflowLaunchObservers = new WeakMap<object, (launch: { agent: string; sessionFile?: string; async: boolean; runId?: string }) => void>();
 
+/**
+ * Missions whose record is gone from disk. Terminal-mission retention prunes
+ * records while long-running children are still reporting, and every later
+ * heartbeat would otherwise re-throw and re-warn. Warning once per mission
+ * keeps the console (and the TUI it renders into) usable.
+ */
+const missionsMissingFromStore = new Set<string>();
+
 function recordMissionWorkflowChild(
 	binding: MissionLaunchBinding | undefined,
 	workflowRunId: string,
@@ -4507,10 +4515,17 @@ function recordMissionWorkflowChild(
 	update: Omit<MissionWorkflowChildUpdate, "workflowRunId" | "key">,
 ): void {
 	if (!binding) return;
+	if (missionsMissingFromStore.has(binding.missionId)) return;
 	const { task: _task, ...durableUpdate } = update;
 	try {
 		updateMission(binding.location, binding.missionId, { upsertWorkflowChildren: [{ workflowRunId, key, ...durableUpdate }] });
 	} catch (error) {
+		if (error instanceof MissionNotFoundError) {
+			// No later update can succeed, so stop trying instead of warning per heartbeat.
+			missionsMissingFromStore.add(binding.missionId);
+			console.warn(`[pi-subagents] Mission '${binding.missionId}' is no longer in the mission store; stopped recording its workflow children. Terminal-mission retention can prune a mission while its run is still active.`);
+			return;
+		}
 		console.warn(`[pi-subagents] Failed to record mission workflow child '${key}': ${error instanceof Error ? error.message : String(error)}`);
 	}
 }


### PR DESCRIPTION
## Summary
- treat a missing mission record as terminal for that binding: warn once, then stop attempting further updates for it
- keep the existing per-child warning for every other failure
- credit the fix in `CHANGELOG.md` under Unreleased

`recordMissionWorkflowChild` warns on each failed update, and a long-running workflow child calls it on every heartbeat. When the mission record is gone, that becomes one warning per heartbeat for the life of the run:

```
[pi-subagents] Failed to record mission workflow child 'gate-packet-002': Mission '8cfcfb31-...' was not found i
 ⠸ gate-reviewer · step 1/1 · 33 tool uses · 4m59s
[pi-subagents] Failed to record mission workflow child 'gate-packet-002': Mission '8cfcfb31-...' was not found i
```

Because the warning goes straight to the console while the TUI is drawing, it also interleaves with the live run widget and truncates its lines, so the display becomes unreadable, as above.

The record can disappear under normal operation: `pruneTerminalMissions` retains the newest 200 terminal missions and runs on every `createMission` and `updateMission`, so an active run's mission can be pruned while its children still report. No later update can succeed once the record is gone, so retrying per heartbeat cannot recover anything.

## Validation
- rebased onto current `main` (v0.49.0); the guard sits alongside the newer `durableUpdate` destructuring
- `npm run typecheck`
- `npm run test:unit` (1895 pass, 2 skip). One unrelated failure, `watchdog-lsp-diagnostics` "returns a failed result for malformed language-server JSON", reproduces identically on clean `main` at v0.49.0 under the full suite and passes in isolation, so it is a pre-existing load-dependent flake rather than a regression from this change.
- harness replaying the guarded path over 350 heartbeats across two missing missions: 2 store attempts and 2 warnings, against 350 of each before
