### PR TITLE
feat: mirror subagent progress into Orca tabs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,22 @@ With `"summary"`, a tool result looks like this:
 ✓ reviewer · completed
 ```
 
+## `orcaProgressTabs` (experimental)
+
+```json
+{
+  "orcaProgressTabs": {
+    "enabled": true
+  }
+}
+```
+
+Opt in to a best-effort Orca observer that creates one Orca terminal tab for each subagent child and mirrors its live tool, assistant, stdout, and stderr progress. Tab titles use a persistent worktree-local sequence (`subagent · <agent> · 1`, `... · 2`, and so on), so separate workflows and concurrent children do not reuse the same number. This does **not** replace Pi as the child runner: native Pi children keep the same process, lifecycle, status, control, artifact, and result paths. External CLI profiles also keep their existing runner and can mirror their stdout/stderr.
+
+The integration is off by default. When enabled, `pi-subagents` looks for executable `orca` on `PATH`, or uses the executable path in `PI_SUBAGENT_ORCA_BINARY`. If no executable is available, Orca is not running, the cwd is not an Orca-managed worktree, or `terminal create` fails, the authoritative subagent still runs normally. Tab creation is deliberately best-effort and never changes the child result.
+
+Set `enabled` to `false` (or remove the block) as a kill switch. In that state, `pi-subagents` does not invoke `orca` and creates no Orca tabs. The temporary mirror files contain child output, use private file modes where supported, and are removed shortly after the child finishes. On completion, the viewer exits back to the Orca terminal's shell prompt; the tab and its terminal scrollback remain open until the user closes the tab. A successfully completed native Pi child with a recorded session ends with a command that can remove that session; failed, stopped, timed-out, and sessionless children do not show the removal command.
+
 ## `asyncByDefault`
 
 ```json

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -315,6 +315,20 @@ The parser canonicalizes known enum synonyms, snake_case report keys and wrapper
 
 Acceptance fences are removed from normal output artifacts, while the raw child transcript remains intact and per-child metadata stores the complete acceptance ledger and parsed report. Explicit failed gates fail the run. Inferred gates remain observable without failing the run.
 
+## Orca progress tabs (experimental observer)
+
+Orca progress tabs are a global, opt-in observer, not an agent runner. Enable them in the extension config:
+
+```json
+{ "orcaProgressTabs": { "enabled": true } }
+```
+
+Every foreground or background child keeps running through its normal native Pi or `external-cli` path. For each logical child, the observer asks Orca to create a background terminal tab in that child's current worktree and mirrors progress into it. Titles receive a persistent worktree-local sequence number, including across separate workflow calls. Model/startup retries reuse the same tab. Parallel and chain children each receive their own tab; attaching an already-running async root does not create a duplicate. After the child finishes, its viewer returns to the terminal shell instead of ending the terminal session, so the tab and scrollback remain until the user closes them. Successful native Pi children with a known session append the exact `find`/`rm` command for that session; unsuccessful and sessionless children append only their terminal status.
+
+The observer requires executable `orca` on `PATH` (or `PI_SUBAGENT_ORCA_BINARY`) and a running Orca runtime that recognizes the child cwd. Availability and tab creation are best-effort: failures never fail, stop, or delay the subagent. Set `orcaProgressTabs.enabled` to `false` to guarantee that no Orca command or tab is created.
+
+Agent profile `runner.type` remains unchanged: supported values are native Pi (the default) and `external-cli`. Orca is intentionally not a profile runner and does not own subagent execution, completion, cancellation, artifacts, or result delivery.
+
 ## External CLI agent profiles
 
 Agent profiles can opt into a local one-shot command instead of a Pi child. External runners add no install dependency, but the configured executable must exist at runtime. They are async-only, receive one combined system/task prompt over stdin, and use argv arrays without a shell:

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -46,6 +46,18 @@ function validateArtifactConfig(value: unknown): void {
 	}
 }
 
+function validateOrcaProgressTabsConfig(value: unknown): void {
+	if (value === undefined) return;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("config.orcaProgressTabs must be a JSON object");
+	const config = value as Record<string, unknown>;
+	for (const key of Object.keys(config)) {
+		if (key !== "enabled") throw new Error(`config.orcaProgressTabs.${key} is not supported`);
+	}
+	if (config.enabled !== undefined && typeof config.enabled !== "boolean") {
+		throw new Error("config.orcaProgressTabs.enabled must be a boolean");
+	}
+}
+
 function validateMainWindowRendererConfig(value: unknown): void {
 	if (value === undefined) return;
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("config.mainWindowRenderer must be a JSON object");
@@ -85,6 +97,7 @@ function validateConfig(config: Record<string, unknown>): void {
 	validateFleetKeybindingsConfig(config.fleetKeybindings);
 	validateArtifactConfig(config.artifactConfig);
 	validateMainWindowRendererConfig(config.mainWindowRenderer);
+	validateOrcaProgressTabsConfig(config.orcaProgressTabs);
 }
 
 export function getConfigPath(): string {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -132,6 +132,7 @@ import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
 import { createBoundedByteTail, createBoundedLineReader, formatProtocolOutputLimit, MAX_CHILD_STDERR_BYTES, PI_AGGREGATE_EVENT_PROJECTOR, projectChildLifecycle, type ChildLifecycleAction, type ProtocolOutputLimit } from "../shared/child-protocol.ts";
 import { acquireSessionLease, type SessionLeaseRequest } from "../shared/session-lease.ts";
 import { buildExternalCliPrompt, runExternalCli } from "../shared/external-cli-runner.ts";
+import { createOrcaProgressTab, type OrcaProgressTab } from "../shared/orca-progress-tabs.ts";
 import { decodeSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
 import {
 	CHILD_WATCHDOG_CONFIG_ENV,
@@ -541,6 +542,7 @@ function runPiStreaming(
 	stopMessage?: string,
 	registerTurnBudgetAbort?: (abort: ((message: string, state?: TurnBudgetState) => void) | undefined) => void,
 	onWriterProcess?: (writer: { state: "none" | "spawning" } | { state: "running"; pid: number }) => void,
+	orcaProgressTab?: OrcaProgressTab,
 ): Promise<RunPiStreamingResult> {
 	return new Promise((resolve) => {
 		const startedAt = Date.now();
@@ -597,6 +599,7 @@ function runPiStreaming(
 		const writeOutputLine = (line: string) => {
 			if (!line.trim()) return;
 			outputStream.write(`${line}\n`);
+			orcaProgressTab?.append(`${line}\n`);
 		};
 
 		const writeOutputText = (text: string) => {
@@ -771,6 +774,7 @@ function runPiStreaming(
 			stderrTail.push(chunk);
 			stderrReader.push(chunk);
 			outputStream.write(chunk);
+			orcaProgressTab?.append(chunk.toString("utf-8"));
 		});
 		registerInterrupt?.(() => {
 			if (settled || timedOut || stopped) return;
@@ -1115,10 +1119,11 @@ interface SingleStepContext {
 	onWriterProcess?: (writer: { state: "none" | "spawning" } | { state: "running"; pid: number }) => void;
 	onExternalProcess?: (process: ExternalProcessStatus) => void;
 	skipAcceptance?: () => boolean;
+	orcaProgressTab?: OrcaProgressTab;
 }
 
 /** Run a single pi agent step, returning output and metadata */
-async function runSingleStep(
+async function runSingleStepInner(
 	step: SubagentStep,
 	ctx: SingleStepContext,
 ): Promise<StepResult & { completionGuardTriggered?: boolean }> {
@@ -1247,6 +1252,8 @@ async function runSingleStep(
 			timeoutMessage: ctx.timeoutMessage,
 			stopMessage: ctx.stopMessage,
 			onProcess: ctx.onExternalProcess,
+			onStdout: (chunk) => ctx.orcaProgressTab?.append(chunk.toString("utf-8")),
+			onStderr: (chunk) => ctx.orcaProgressTab?.append(chunk.toString("utf-8")),
 		}));
 		try { fs.writeFileSync(ctx.outputFile, external.output, "utf-8"); } catch { /* Observability output is best-effort. */ }
 		const resolvedOutput = step.outputPath && external.exitCode === 0
@@ -1433,6 +1440,7 @@ async function runSingleStep(
 			ctx.stopMessage,
 			ctx.registerTurnBudgetAbort,
 			ctx.onWriterProcess,
+			ctx.orcaProgressTab,
 		);
 		if (run.processCloseObservedAt !== undefined) {
 			writerProcesses.push({
@@ -1782,6 +1790,27 @@ async function runSingleStep(
 		writerAttemptCount,
 	});
 	return isAgentContractV1(step.agentContract) ? attachContractProjections(result as unknown as import("../../shared/types.ts").SingleResult) as unknown as typeof result : result;
+}
+
+async function runSingleStep(
+	step: SubagentStep,
+	ctx: SingleStepContext,
+): Promise<StepResult & { completionGuardTriggered?: boolean }> {
+	if (step.importAsyncRoot) return runSingleStepInner(step, ctx);
+	const orcaProgressTab = createOrcaProgressTab({
+		cwd: step.cwd ?? ctx.cwd,
+		runId: ctx.id,
+		agent: step.agent,
+		index: ctx.flatIndex,
+	});
+	try {
+		const result = await runSingleStepInner(step, { ...ctx, orcaProgressTab });
+		orcaProgressTab?.finish(result.stopped ? "stopped" : result.exitCode === 0 && !result.error ? "completed" : "failed", result.sessionFile);
+		return result;
+	} catch (error) {
+		orcaProgressTab?.finish("failed");
+		throw error;
+	}
 }
 
 type RunnerStatusStep = NonNullable<AsyncStatus["steps"]>[number] & {

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -57,6 +57,7 @@ import { evaluateCompletionMutationGuard } from "../shared/completion-guard.ts";
 import { arbitrateCompletionGuardRescue } from "../shared/llm-intent-arbiter.ts";
 import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
+import { createOrcaProgressTab, type OrcaProgressTab } from "../shared/orca-progress-tabs.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { resolvePermissionRules } from "../shared/permissions.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
@@ -302,6 +303,7 @@ async function runSingleAttempt(
 		outputSnapshot?: SingleOutputSnapshot;
 		originalTask?: string;
 		taskDelivery?: SubagentTaskDelivery;
+		orcaProgressTab?: OrcaProgressTab;
 	},
 ): Promise<SingleResult> {
 	const effectiveThinking = options.thinkingOverride ?? agent.thinking;
@@ -854,10 +856,12 @@ async function runSingleAttempt(
 			} catch {
 				rawStdoutTail.push(`${line}\n`);
 				shared.transcriptWriter?.writeStdoutLine(line);
+				shared.orcaProgressTab?.append(`${line}\n`);
 				// Non-JSON stdout lines are expected; only structured events are parsed.
 				return;
 			}
 			shared.transcriptWriter?.writeChildEvent(evt);
+			shared.orcaProgressTab?.event(evt);
 			if (evt.type === "agent_settled") agentSettledReceived = true;
 			applyChildLifecycle(projectChildLifecycle(evt));
 
@@ -1077,6 +1081,7 @@ async function runSingleAttempt(
 		proc.stderr.on("data", (chunk: Buffer) => {
 			stderrTail.push(chunk);
 			stderrReader.push(chunk);
+			shared.orcaProgressTab?.append(chunk.toString("utf-8"));
 		});
 		proc.on("exit", () => {
 			childExited = true;
@@ -1378,7 +1383,7 @@ async function runSingleAttempt(
 /**
  * Run a subagent synchronously (blocking until complete)
  */
-async function runSyncCompletion(
+async function runSyncCompletionInner(
 	runtimeCwd: string,
 	agents: AgentConfig[],
 	agentName: string,
@@ -1531,6 +1536,14 @@ async function runSyncCompletion(
 		}
 	}
 
+	const orcaProgressTab = createOrcaProgressTab({
+		cwd: options.cwd ?? runtimeCwd,
+		runId: options.runId,
+		agent: agentName,
+		index: options.index ?? 0,
+	});
+	if (orcaProgressTab) options.onOrcaProgressTabCreated?.(orcaProgressTab);
+
 	const persistResultMetadata = (target: SingleResult): void => {
 		persistSingleResultMetadata({
 			metadataPath: artifactPathsResult?.metadataPath,
@@ -1585,6 +1598,7 @@ async function runSyncCompletion(
 				outputSnapshot,
 				originalTask: task,
 				taskDelivery: taskDeliveryOverride,
+				orcaProgressTab,
 			});
 			lastResult = result;
 			if (startupAttemptIndex === 0) {
@@ -1811,6 +1825,27 @@ async function runSyncCompletion(
 	}
 
 	return result;
+}
+
+async function runSyncCompletion(
+	runtimeCwd: string,
+	agents: AgentConfig[],
+	agentName: string,
+	task: string,
+	options: RunSyncOptions,
+): Promise<SingleResult> {
+	let orcaProgressTab: OrcaProgressTab | undefined;
+	try {
+		const result = await runSyncCompletionInner(runtimeCwd, agents, agentName, task, {
+			...options,
+			onOrcaProgressTabCreated: (tab) => { orcaProgressTab = tab; },
+		});
+		orcaProgressTab?.finish(result.stopped ? "stopped" : result.exitCode === 0 && !result.error ? "completed" : "failed", result.sessionFile);
+		return result;
+	} catch (error) {
+		orcaProgressTab?.finish("failed");
+		throw error;
+	}
 }
 
 /**

--- a/src/runs/shared/external-cli-runner.ts
+++ b/src/runs/shared/external-cli-runner.ts
@@ -35,6 +35,8 @@ export function runExternalCli(input: {
 	timeoutMessage?: string;
 	stopMessage?: string;
 	onProcess?: (process: ExternalProcessStatus) => void;
+	onStdout?: (chunk: Buffer) => void;
+	onStderr?: (chunk: Buffer) => void;
 }): Promise<ExternalCliRunResult> {
 	return new Promise((resolve, reject) => {
 		const startedAt = Date.now();
@@ -65,11 +67,13 @@ export function runExternalCli(input: {
 		input.onProcess?.(initialProcess);
 		child.stdout.on("data", (chunk: Buffer) => {
 			stdoutStream.write(chunk);
+			input.onStdout?.(chunk);
 			stdoutTail = Buffer.concat([stdoutTail, chunk]);
 			if (stdoutTail.length > MAX_OUTPUT_TAIL_BYTES) stdoutTail = stdoutTail.subarray(stdoutTail.length - MAX_OUTPUT_TAIL_BYTES);
 		});
 		child.stderr.on("data", (chunk: Buffer) => {
 			stderrStream.write(chunk);
+			input.onStderr?.(chunk);
 			stderrTail = Buffer.concat([stderrTail, chunk]);
 			if (stderrTail.length > MAX_ERROR_TAIL_BYTES) stderrTail = stderrTail.subarray(stderrTail.length - MAX_ERROR_TAIL_BYTES);
 		});

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -1,0 +1,321 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import type { Message } from "@earendil-works/pi-ai";
+import { loadConfig } from "../../extension/config.ts";
+import { TEMP_ROOT_DIR, type OrcaProgressTabsConfig } from "../../shared/types.ts";
+import { extractTextFromContent, extractToolArgsPreview } from "../../shared/utils.ts";
+
+const ORCA_CREATE_TIMEOUT_MS = 20_000;
+const ORCA_KILL_GRACE_MS = 2_000;
+const CLEANUP_DELAY_MS = 5 * 60_000;
+const STALE_PROGRESS_MAX_AGE_MS = 24 * 60 * 60_000;
+const VIEWER_POLL_MS = 150;
+const COUNTER_LOCK_STALE_MS = 30_000;
+const COUNTER_LOCK_RETRIES = 200;
+const COUNTER_LOCK_RETRY_MS = 10;
+
+export interface OrcaProgressTab {
+	append(text: string): void;
+	event(event: { type?: string; message?: Message; toolName?: string; args?: unknown }): void;
+	finish(status: "completed" | "failed" | "stopped", sessionFile?: string): void;
+}
+
+function executableFile(candidate: string): boolean {
+	try {
+		const stats = fs.statSync(candidate);
+		if (!stats.isFile()) return false;
+		if (process.platform === "win32") return true;
+		fs.accessSync(candidate, fs.constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function executableNames(command: string, env: NodeJS.ProcessEnv): string[] {
+	if (process.platform !== "win32") return [command];
+	const extensions = (env.PATHEXT ?? ".EXE;.CMD;.BAT").split(";").filter(Boolean);
+	return [command, ...extensions.map((extension) => `${command}${extension.toLowerCase()}`), ...extensions.map((extension) => `${command}${extension.toUpperCase()}`)];
+}
+
+export function resolveOrcaCommand(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	const override = env.PI_SUBAGENT_ORCA_BINARY?.trim();
+	if (override) return executableFile(override) ? override : undefined;
+	for (const directory of (env.PATH ?? "").split(path.delimiter).filter(Boolean)) {
+		for (const name of executableNames("orca", env)) {
+			const candidate = path.join(directory, name);
+			if (executableFile(candidate)) return candidate;
+		}
+	}
+	return undefined;
+}
+
+function shellQuote(value: string): string {
+	if (process.platform === "win32") return `"${value.replace(/"/g, '\\"')}"`;
+	return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+const VIEWER_SCRIPT = [
+	"const fs=require('fs');",
+	"const log=process.argv[1],done=process.argv[2];",
+	"let offset=0,finishing=false;",
+	"function pump(){",
+	" try{const size=fs.statSync(log).size;if(size<offset)offset=0;if(size>offset){const fd=fs.openSync(log,'r');const b=Buffer.alloc(size-offset);fs.readSync(fd,b,0,b.length,offset);fs.closeSync(fd);offset=size;process.stdout.write(b);}}catch{}",
+	" if(!finishing&&fs.existsSync(done)){finishing=true;pump();setTimeout(()=>{try{fs.unlinkSync(done)}catch{}try{fs.unlinkSync(log)}catch{}process.exit(0)},250);}",
+	"}",
+	`const timer=setInterval(pump,${VIEWER_POLL_MS});`,
+	"pump();",
+	"process.on('exit',()=>clearInterval(timer));",
+].join("");
+
+function viewerCommand(logPath: string, donePath: string): string {
+	const invocation = [process.execPath, "-e", VIEWER_SCRIPT, logPath, donePath].map(shellQuote).join(" ");
+	// Do not replace or exit Orca's interactive shell. The short-lived viewer may
+	// finish and delete its mirror files, while the completed tab remains open at
+	// the shell prompt until the user closes it.
+	if (process.platform === "win32") return invocation;
+	return `printf '\\033[2J\\033[H'; ${invocation}`;
+}
+
+function progressRoot(): string {
+	return path.join(TEMP_ROOT_DIR, "orca-progress");
+}
+
+function pruneStaleProgressFiles(root: string, now = Date.now()): void {
+	try {
+		for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+			if (!entry.isFile() || (!entry.name.endsWith(".log") && !entry.name.endsWith(".done"))) continue;
+			const file = path.join(root, entry.name);
+			try {
+				if (now - fs.statSync(file).mtimeMs > STALE_PROGRESS_MAX_AGE_MS) fs.rmSync(file, { force: true });
+			} catch { /* best-effort stale cleanup */ }
+		}
+	} catch {
+		// The observer remains optional when temp cleanup is unavailable.
+	}
+}
+
+function safeSegment(value: unknown, fallback = "subagent"): string {
+	if (typeof value !== "string") return fallback;
+	return value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 48) || fallback;
+}
+
+function sleepSync(ms: number): void {
+	const signal = new Int32Array(new SharedArrayBuffer(4));
+	Atomics.wait(signal, 0, 0, ms);
+}
+
+function resolveSequenceScope(cwd: string): string {
+	let current = path.resolve(cwd);
+	try { current = fs.realpathSync(current); } catch { /* use the lexical cwd */ }
+	while (true) {
+		try {
+			if (fs.existsSync(path.join(current, ".git"))) return current;
+		} catch { /* keep walking */ }
+		const parent = path.dirname(current);
+		if (parent === current) return path.resolve(cwd);
+		current = parent;
+	}
+}
+
+function reserveTabSequence(root: string, cwd: string): number | undefined {
+	const key = createHash("sha256").update(resolveSequenceScope(cwd)).digest("hex").slice(0, 20);
+	const counterPath = path.join(root, `counter-${key}`);
+	const lockPath = `${counterPath}.lock`;
+	let locked = false;
+	for (let attempt = 0; attempt < COUNTER_LOCK_RETRIES; attempt++) {
+		try {
+			fs.mkdirSync(lockPath, { mode: 0o700 });
+			locked = true;
+			break;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") break;
+			try {
+				if (Date.now() - fs.statSync(lockPath).mtimeMs > COUNTER_LOCK_STALE_MS) {
+					fs.rmSync(lockPath, { recursive: true, force: true });
+					continue;
+				}
+			} catch { /* another process released the lock */ }
+			sleepSync(COUNTER_LOCK_RETRY_MS);
+		}
+	}
+	if (!locked) return undefined;
+	try {
+		let current = 0;
+		try {
+			const parsed = Number.parseInt(fs.readFileSync(counterPath, "utf-8"), 10);
+			if (Number.isSafeInteger(parsed) && parsed >= 0) current = parsed;
+		} catch { /* first tab for this worktree */ }
+		const next = current + 1;
+		try {
+			fs.writeFileSync(counterPath, `${next}\n`, { encoding: "utf-8", mode: 0o600 });
+			return next;
+		} catch {
+			return undefined;
+		}
+	} finally {
+		try { fs.rmSync(lockPath, { recursive: true, force: true }); } catch { /* stale lock cleanup handles crashes */ }
+	}
+}
+
+export function resolvePiSessionId(sessionFile: string | undefined): string | undefined {
+	if (!sessionFile) return undefined;
+	try {
+		const fd = fs.openSync(sessionFile, "r");
+		try {
+			const buffer = Buffer.alloc(16 * 1024);
+			const bytes = fs.readSync(fd, buffer, 0, buffer.length, 0);
+			const line = buffer.toString("utf-8", 0, bytes).split("\n", 1)[0];
+			if (!line) return undefined;
+			const header = JSON.parse(line) as { type?: unknown; id?: unknown };
+			if (header.type === "session" && typeof header.id === "string" && /^[A-Za-z0-9-]{8,}$/.test(header.id)) return header.id;
+			return undefined;
+		} finally {
+			fs.closeSync(fd);
+		}
+	} catch {
+		return undefined;
+	}
+}
+
+function scheduleCleanup(paths: string[]): void {
+	const timer = setTimeout(() => {
+		for (const file of paths) {
+			try { fs.rmSync(file, { force: true }); } catch { /* best-effort temp cleanup */ }
+		}
+	}, CLEANUP_DELAY_MS);
+	timer.unref?.();
+}
+
+export function createOrcaProgressTab(input: {
+	cwd: string;
+	runId: string;
+	agent: string;
+	index: number;
+	config?: OrcaProgressTabsConfig;
+	env?: NodeJS.ProcessEnv;
+	command?: string;
+}): OrcaProgressTab | undefined {
+	let config: OrcaProgressTabsConfig | undefined;
+	try {
+		config = input.config ?? loadConfig().orcaProgressTabs;
+	} catch {
+		return undefined;
+	}
+	if (config?.enabled !== true) return undefined;
+	const command = input.command ?? resolveOrcaCommand(input.env);
+	if (!command) return undefined;
+
+	const root = progressRoot();
+	try {
+		fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+	} catch {
+		return undefined;
+	}
+	pruneStaleProgressFiles(root);
+	const runId = safeSegment(input.runId, "run");
+	const agent = safeSegment(input.agent, "subagent");
+	const index = typeof input.index === "number" && Number.isInteger(input.index) && input.index >= 0 ? input.index : 0;
+	const cwd = typeof input.cwd === "string" && input.cwd ? input.cwd : process.cwd();
+	const tabSequence = reserveTabSequence(root, cwd);
+	if (tabSequence === undefined) return undefined;
+	const stem = `${runId}-${index}-${randomUUID()}`;
+	const logPath = path.join(root, `${stem}.log`);
+	const donePath = path.join(root, `${stem}.done`);
+	const title = `subagent · ${agent} · ${tabSequence}`;
+	try {
+		fs.writeFileSync(logPath, `pi-subagents / ${agent}\nrun ${runId} · child ${index + 1}\n${"─".repeat(48)}\n`, { encoding: "utf-8", mode: 0o600 });
+		fs.rmSync(donePath, { force: true });
+	} catch {
+		return undefined;
+	}
+
+	let available = true;
+	const logStream = fs.createWriteStream(logPath, { flags: "a", mode: 0o600 });
+	const failObserver = () => {
+		if (!available) return;
+		available = false;
+		logStream.destroy();
+		try { fs.rmSync(logPath, { force: true }); } catch { /* best effort */ }
+		try { fs.rmSync(donePath, { force: true }); } catch { /* best effort */ }
+	};
+	logStream.once("error", failObserver);
+	const writeProgress = (text: string) => {
+		if (!available || !text) return;
+		try { logStream.write(text); } catch { failObserver(); }
+	};
+	try {
+		const child = spawn(command, [
+			"terminal", "create",
+			"--worktree", `path:${path.resolve(cwd)}`,
+			"--title", title,
+			"--command", viewerCommand(logPath, donePath),
+			"--json",
+		], {
+			cwd,
+			stdio: "ignore",
+			windowsHide: true,
+			env: input.env ?? process.env,
+		});
+		let hardKillTimer: NodeJS.Timeout | undefined;
+		const timer = setTimeout(() => {
+			child.kill("SIGTERM");
+			hardKillTimer = setTimeout(() => child.kill("SIGKILL"), ORCA_KILL_GRACE_MS);
+			hardKillTimer.unref?.();
+		}, ORCA_CREATE_TIMEOUT_MS);
+		timer.unref?.();
+		const clearProcessTimers = () => {
+			clearTimeout(timer);
+			if (hardKillTimer) clearTimeout(hardKillTimer);
+		};
+		child.once("close", (code) => {
+			clearProcessTimers();
+			if (code !== 0) failObserver();
+		});
+		child.once("error", () => {
+			clearProcessTimers();
+			failObserver();
+		});
+		child.unref();
+	} catch {
+		failObserver();
+		return undefined;
+	}
+
+	let finished = false;
+	return {
+		append(text) {
+			if (finished) return;
+			writeProgress(text);
+		},
+		event(event) {
+			if (!available || finished) return;
+			if (event.type === "tool_execution_start" && event.toolName) {
+				const args = event.args && typeof event.args === "object" && !Array.isArray(event.args)
+					? extractToolArgsPreview(event.args as Record<string, unknown>)
+					: "";
+				writeProgress(`\n› ${event.toolName}${args ? `: ${args}` : ""}\n`);
+				return;
+			}
+			if ((event.type === "message_end" || event.type === "tool_result_end") && event.message) {
+				const text = extractTextFromContent(event.message.content);
+				if (text.trim()) writeProgress(`${text}${text.endsWith("\n") ? "" : "\n"}`);
+			}
+		},
+		finish(status, sessionFile) {
+			if (!available || finished) return;
+			finished = true;
+			const sessionId = status === "completed" ? resolvePiSessionId(sessionFile) : undefined;
+			const terminalMessage = sessionId
+				? `completed. To remove the Pi session of this subagent, run rm $(find ~/.pi/agent/sessions -name "*_${sessionId}.jsonl" -print -quit)`
+				: status;
+			logStream.end(`\n${"─".repeat(48)}\n${terminalMessage}\n`, () => {
+				if (!available) return;
+				try { fs.writeFileSync(donePath, `${status}\n`, { encoding: "utf-8", mode: 0o600 }); } catch { /* best effort */ }
+				scheduleCleanup([logPath, donePath]);
+			});
+		},
+	};
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1821,6 +1821,8 @@ export interface RunSyncOptions {
 	};
 	/** Private live callback for the exact child prompt after runtime acceptance injection. */
 	onEffectivePrompt?: (prompt: string) => void;
+	/** Internal lifecycle hook for the observer shared across retries of one logical child. */
+	onOrcaProgressTabCreated?: (tab: import("../runs/shared/orca-progress-tabs.ts").OrcaProgressTab) => void;
 }
 
 export type IntercomBridgeMode = "off" | "fork-only" | "always";
@@ -1882,6 +1884,11 @@ export const FLEET_KEYBINDING_ACTIONS = [
 export type FleetKeybindingAction = typeof FLEET_KEYBINDING_ACTIONS[number];
 export type FleetKeybindingsConfig = Partial<Record<FleetKeybindingAction, string[]>>;
 
+export interface OrcaProgressTabsConfig {
+	/** Create one Orca terminal tab per running subagent. Experimental and opt-in. */
+	enabled?: boolean;
+}
+
 export interface MainWindowRendererConfig {
 	/** Unit of horizontal space in main chat subagent call/result rows. Omit to preserve current spacing. Set 0 for no extra padding. */
 	horizontalSpacing?: number;
@@ -1907,6 +1914,8 @@ export interface ExtensionConfig {
 	inlineToolDisplay?: InlineToolDisplay;
 	/** Density controls for the main chat subagent call/result renderer. */
 	mainWindowRenderer?: MainWindowRendererConfig;
+	/** Experimental observer: mirror each native subagent's progress into a new Orca tab. */
+	orcaProgressTabs?: OrcaProgressTabsConfig;
 	forceTopLevelAsync?: boolean;
 	waitTool?: WaitToolConfig;
 	defaultSessionDir?: string;

--- a/test/integration/external-cli-runner.test.ts
+++ b/test/integration/external-cli-runner.test.ts
@@ -4,15 +4,30 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
+import { TEMP_ROOT_DIR } from "../../src/shared/types.ts";
 
 const tempDirs: string[] = [];
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	const progressDir = path.join(TEMP_ROOT_DIR, "orca-progress");
+	if (fs.existsSync(progressDir)) {
+		for (const name of fs.readdirSync(progressDir)) {
+			if (name.startsWith("orca-observer-external-")) fs.rmSync(path.join(progressDir, name), { force: true });
+		}
+	}
 });
 
-function runProcess(command: string, args: string[], cwd: string): Promise<number | null> {
+async function waitForFile(file: string): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	while (!fs.existsSync(file)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${file}`);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}
+
+function runProcess(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv = process.env): Promise<number | null> {
 	return new Promise((resolve, reject) => {
-		const child = spawn(command, args, { cwd, stdio: "inherit", shell: false });
+		const child = spawn(command, args, { cwd, stdio: "inherit", shell: false, env });
 		child.once("error", reject);
 		child.once("close", resolve);
 	});
@@ -58,5 +73,55 @@ describe("external CLI async lifecycle", () => {
 		const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
 		assert.equal(result.success, true);
 		assert.equal(result.results[0].runner.type, "external-cli");
+	});
+
+	it("mirrors a child into Orca without replacing its configured runner", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-orca-observer-"));
+		tempDirs.push(dir);
+		const asyncDir = path.join(dir, "async");
+		const agentDir = path.join(dir, "agent-dir");
+		const capture = path.join(dir, "orca-args.json");
+		const fakeOrca = path.join(dir, "orca");
+		fs.mkdirSync(asyncDir);
+		fs.mkdirSync(path.join(agentDir, "extensions", "subagent"), { recursive: true });
+		fs.writeFileSync(path.join(agentDir, "extensions", "subagent", "config.json"), JSON.stringify({ orcaProgressTabs: { enabled: true } }));
+		fs.writeFileSync(fakeOrca, `#!/usr/bin/env node\nrequire('fs').writeFileSync(process.env.ORCA_TEST_CAPTURE, JSON.stringify(process.argv.slice(2)))\n`);
+		fs.chmodSync(fakeOrca, 0o755);
+		const resultPath = path.join(dir, "result.json");
+		const configPath = path.join(dir, "config.json");
+		fs.writeFileSync(configPath, JSON.stringify({
+			id: "orca-observer-external",
+			steps: [{
+				agent: "external",
+				task: "Task text",
+				runner: { type: "external-cli", command: process.execPath, args: ["-e", "process.stdout.write('native runner output')"] },
+				systemPrompt: "System text",
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+			}],
+			resultPath,
+			cwd: dir,
+			placeholder: "{previous}",
+			artifactConfig: { enabled: false },
+			asyncDir,
+			resultMode: "single",
+		}));
+		const repo = path.resolve(import.meta.dirname, "../..");
+		const exitCode = await runProcess(
+			process.execPath,
+			[path.join(repo, "node_modules/jiti/lib/jiti-cli.mjs"), path.join(repo, "src/runs/background/subagent-runner.ts"), configPath],
+			repo,
+			{ ...process.env, PI_CODING_AGENT_DIR: agentDir, PI_SUBAGENT_ORCA_BINARY: fakeOrca, ORCA_TEST_CAPTURE: capture },
+		);
+		assert.equal(exitCode, 0);
+		const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+		assert.equal(result.results[0].runner.type, "external-cli");
+		assert.match(result.results[0].output, /native runner output/);
+		await waitForFile(capture);
+		const args = JSON.parse(fs.readFileSync(capture, "utf-8")) as string[];
+		assert.deepEqual(args.slice(0, 2), ["terminal", "create"]);
+		assert.equal(args[args.indexOf("--worktree") + 1], `path:${path.resolve(dir)}`);
+		assert.match(args[args.indexOf("--title") + 1], /subagent · external/);
 	});
 });

--- a/test/integration/orca-progress-tabs.test.ts
+++ b/test/integration/orca-progress-tabs.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { TEMP_ROOT_DIR } from "../../src/shared/types.ts";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+	const progressDir = path.join(TEMP_ROOT_DIR, "orca-progress");
+	for (const dir of tempDirs.splice(0)) {
+		const key = createHash("sha256").update(path.resolve(dir)).digest("hex").slice(0, 20);
+		fs.rmSync(path.join(progressDir, `counter-${key}`), { force: true });
+		fs.rmSync(path.join(progressDir, `counter-${key}.lock`), { recursive: true, force: true });
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+	if (fs.existsSync(progressDir)) {
+		for (const name of fs.readdirSync(progressDir)) {
+			if (name.startsWith("orca-observer-native-") || name.startsWith("concurrent-sequence-")) fs.rmSync(path.join(progressDir, name), { force: true });
+		}
+	}
+});
+
+function runProcess(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv): Promise<number | null> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, { cwd, stdio: "inherit", shell: false, env });
+		child.once("error", reject);
+		child.once("close", resolve);
+	});
+}
+
+async function waitForFile(file: string): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	while (!fs.existsSync(file)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${file}`);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}
+
+async function waitForFileCount(dir: string, count: number): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	while (fs.readdirSync(dir).length < count) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${count} files in ${dir}`);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}
+
+describe("Orca progress-tab observer", () => {
+	it("mirrors a native Pi child without replacing its execution path", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-orca-native-"));
+		tempDirs.push(dir);
+		const asyncDir = path.join(dir, "async");
+		const agentDir = path.join(dir, "agent-dir");
+		const capture = path.join(dir, "orca-args.json");
+		const fakeOrca = path.join(dir, "orca");
+		const fakePi = path.join(dir, "pi");
+		fs.mkdirSync(asyncDir);
+		fs.mkdirSync(path.join(agentDir, "extensions", "subagent"), { recursive: true });
+		fs.writeFileSync(path.join(agentDir, "extensions", "subagent", "config.json"), JSON.stringify({ orcaProgressTabs: { enabled: true } }));
+		fs.writeFileSync(fakeOrca, `#!/usr/bin/env node\nrequire('fs').writeFileSync(process.env.ORCA_TEST_CAPTURE, JSON.stringify(process.argv.slice(2)))\n`);
+		fs.chmodSync(fakeOrca, 0o755);
+		const childEvents = [
+			{ type: "tool_execution_start", toolName: "read", args: { path: "README.md" } },
+			{ type: "tool_execution_end", toolName: "read" },
+			{ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "native Pi result" }], stopReason: "stop", usage: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } } } },
+			{ type: "agent_settled" },
+		];
+		fs.writeFileSync(fakePi, `#!/usr/bin/env node\nfor (const event of ${JSON.stringify(childEvents)}) process.stdout.write(JSON.stringify(event)+'\\n')\n`);
+		fs.chmodSync(fakePi, 0o755);
+
+		const resultPath = path.join(dir, "result.json");
+		const configPath = path.join(dir, "config.json");
+		fs.writeFileSync(configPath, JSON.stringify({
+			id: "orca-observer-native",
+			steps: [{
+				agent: "worker",
+				task: "Read the repository",
+				systemPrompt: "Use native Pi",
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+			}],
+			resultPath,
+			cwd: dir,
+			placeholder: "{previous}",
+			artifactConfig: { enabled: false },
+			asyncDir,
+			resultMode: "single",
+		}));
+		const repo = path.resolve(import.meta.dirname, "../..");
+		const exitCode = await runProcess(
+			process.execPath,
+			[path.join(repo, "node_modules/jiti/lib/jiti-cli.mjs"), path.join(repo, "src/runs/background/subagent-runner.ts"), configPath],
+			repo,
+			{
+				...process.env,
+				PI_CODING_AGENT_DIR: agentDir,
+				PI_SUBAGENT_ORCA_BINARY: fakeOrca,
+				PI_SUBAGENT_PI_BINARY: fakePi,
+				ORCA_TEST_CAPTURE: capture,
+			},
+		);
+		assert.equal(exitCode, 0);
+		const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+		assert.equal(result.success, true);
+		assert.equal(result.results[0].runner, undefined);
+		assert.match(result.results[0].output, /native Pi result/);
+		assert.match(fs.readFileSync(path.join(asyncDir, "output-0.log"), "utf-8"), /read: README\.md[\s\S]*native Pi result/);
+
+		await waitForFile(capture);
+		const args = JSON.parse(fs.readFileSync(capture, "utf-8")) as string[];
+		assert.deepEqual(args.slice(0, 2), ["terminal", "create"]);
+		assert.equal(args[args.indexOf("--worktree") + 1], `path:${path.resolve(dir)}`);
+		assert.equal(args[args.indexOf("--title") + 1], "subagent · worker · 1");
+	});
+
+	it("allocates unique worktree-wide numbers across concurrent processes and nested cwd values", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-orca-counter-"));
+		tempDirs.push(dir);
+		fs.mkdirSync(path.join(dir, ".git"));
+		const nested = path.join(dir, "packages", "app");
+		fs.mkdirSync(nested, { recursive: true });
+		const captures = path.join(dir, "captures");
+		fs.mkdirSync(captures);
+		const fakeOrca = path.join(dir, "orca");
+		fs.writeFileSync(fakeOrca, `#!/usr/bin/env node\nconst fs=require('fs'),path=require('path');const args=process.argv.slice(2);fs.writeFileSync(path.join(process.env.ORCA_TEST_CAPTURE_DIR, process.pid+'.json'),JSON.stringify(args))\n`);
+		fs.chmodSync(fakeOrca, 0o755);
+		const repo = path.resolve(import.meta.dirname, "../..");
+		const moduleUrl = new URL("../../src/runs/shared/orca-progress-tabs.ts", import.meta.url).href;
+		const childScript = `import {createOrcaProgressTab} from ${JSON.stringify(moduleUrl)};const tab=createOrcaProgressTab({cwd:process.env.CHILD_CWD,runId:'concurrent-sequence',agent:'worker',index:0,config:{enabled:true}});if(!tab)throw new Error('tab unavailable');setTimeout(()=>tab.finish('failed'),100);setTimeout(()=>{},180);`;
+		const processes = Array.from({ length: 8 }, (_, index) => runProcess(
+			process.execPath,
+			["--experimental-strip-types", "--input-type=module", "--eval", childScript],
+			repo,
+			{ ...process.env, PI_SUBAGENT_ORCA_BINARY: fakeOrca, ORCA_TEST_CAPTURE_DIR: captures, CHILD_CWD: index % 2 === 0 ? dir : nested },
+		));
+		assert.deepEqual(await Promise.all(processes), Array(8).fill(0));
+		await waitForFileCount(captures, 8);
+		const titles = fs.readdirSync(captures).map((name) => {
+			const args = JSON.parse(fs.readFileSync(path.join(captures, name), "utf-8")) as string[];
+			return args[args.indexOf("--title") + 1];
+		}).sort((left, right) => Number(left.split(" · ").at(-1)) - Number(right.split(" · ").at(-1)));
+		assert.deepEqual(titles, Array.from({ length: 8 }, (_, index) => `subagent · worker · ${index + 1}`));
+	});
+});

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { afterEach, test } from "node:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createOrcaProgressTab, resolveOrcaCommand, resolvePiSessionId } from "../../src/runs/shared/orca-progress-tabs.ts";
+import { TEMP_ROOT_DIR } from "../../src/shared/types.ts";
+
+const tempDirs: string[] = [];
+
+function removeProgressFiles(prefix: string): void {
+	const root = path.join(TEMP_ROOT_DIR, "orca-progress");
+	if (!fs.existsSync(root)) return;
+	for (const name of fs.readdirSync(root)) {
+		if (name.startsWith(prefix)) fs.rmSync(path.join(root, name), { force: true });
+	}
+}
+
+afterEach(() => {
+	const progressRoot = path.join(TEMP_ROOT_DIR, "orca-progress");
+	for (const dir of tempDirs.splice(0)) {
+		const key = createHash("sha256").update(path.resolve(dir)).digest("hex").slice(0, 20);
+		fs.rmSync(path.join(progressRoot, `counter-${key}`), { force: true });
+		fs.rmSync(path.join(progressRoot, `counter-${key}.lock`), { recursive: true, force: true });
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+	removeProgressFiles("progress-");
+	removeProgressFiles("disabled-run-");
+});
+
+function tempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-orca-tabs-test-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function waitForFile(file: string): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	while (!fs.existsSync(file)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${file}`);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}
+
+test("resolveOrcaCommand only returns executable commands", () => {
+	const dir = tempDir();
+	const executable = path.join(dir, process.platform === "win32" ? "orca.cmd" : "orca");
+	fs.writeFileSync(executable, process.platform === "win32" ? "@exit /b 0\r\n" : "#!/bin/sh\nexit 0\n");
+	if (process.platform !== "win32") fs.chmodSync(executable, 0o755);
+	assert.equal(resolveOrcaCommand({ PATH: dir, PATHEXT: ".CMD" }), executable);
+	assert.equal(resolveOrcaCommand({ PATH: "", PI_SUBAGENT_ORCA_BINARY: path.join(dir, "missing") }), undefined);
+});
+
+test("an unavailable Orca command leaves native execution untouched", () => {
+	const dir = tempDir();
+	assert.equal(createOrcaProgressTab({
+		cwd: dir,
+		runId: "missing-orca",
+		agent: "worker",
+		index: 0,
+		config: { enabled: true },
+		env: { PATH: "", PI_SUBAGENT_ORCA_BINARY: path.join(dir, "missing") },
+	}), undefined);
+});
+
+test("malformed optional observer metadata cannot break child execution", async () => {
+	const dir = tempDir();
+	const capture = path.join(dir, "capture.json");
+	const fakeOrca = path.join(dir, "orca");
+	fs.writeFileSync(fakeOrca, `#!/usr/bin/env node\nrequire('fs').writeFileSync(process.env.ORCA_TEST_CAPTURE, JSON.stringify(process.argv.slice(2)))\n`);
+	fs.chmodSync(fakeOrca, 0o755);
+	const tab = createOrcaProgressTab({
+		cwd: dir,
+		runId: undefined,
+		agent: undefined,
+		index: undefined,
+		config: { enabled: true },
+		command: fakeOrca,
+		env: { ...process.env, ORCA_TEST_CAPTURE: capture },
+	} as never);
+	assert.ok(tab);
+	tab.finish("completed");
+	await waitForFile(capture);
+	const args = JSON.parse(fs.readFileSync(capture, "utf-8")) as string[];
+	assert.equal(args[args.indexOf("--title") + 1], "subagent · subagent · 1");
+	removeProgressFiles("run-0-");
+});
+
+test("disabled Orca progress tabs do not invoke Orca", async () => {
+	const dir = tempDir();
+	const capture = path.join(dir, "capture.json");
+	const fakeOrca = path.join(dir, "orca");
+	fs.writeFileSync(fakeOrca, `#!/usr/bin/env node\nrequire('fs').writeFileSync(process.env.ORCA_TEST_CAPTURE, JSON.stringify(process.argv.slice(2)))\n`);
+	fs.chmodSync(fakeOrca, 0o755);
+	const tab = createOrcaProgressTab({
+		cwd: dir,
+		runId: "disabled-run",
+		agent: "worker",
+		index: 0,
+		config: { enabled: false },
+		command: fakeOrca,
+		env: { ...process.env, ORCA_TEST_CAPTURE: capture },
+	});
+	assert.equal(tab, undefined);
+	await new Promise((resolve) => setTimeout(resolve, 100));
+	assert.equal(fs.existsSync(capture), false);
+});
+
+test("enabled tabs use a worktree sequence and successful Pi sessions get cleanup guidance", { skip: process.platform === "win32" }, async () => {
+	const dir = tempDir();
+	const capture = path.join(dir, "capture.json");
+	const secondCapture = path.join(dir, "capture-2.json");
+	const fakeOrca = path.join(dir, "orca");
+	fs.mkdirSync(path.join(dir, ".git"));
+	fs.writeFileSync(fakeOrca, `#!/usr/bin/env node\nrequire('fs').writeFileSync(process.env.ORCA_TEST_CAPTURE, JSON.stringify(process.argv.slice(2)))\n`);
+	fs.chmodSync(fakeOrca, 0o755);
+	const runId = `progress-${Date.now()}`;
+	const tab = createOrcaProgressTab({
+		cwd: dir,
+		runId,
+		agent: "worker",
+		index: 2,
+		config: { enabled: true },
+		command: fakeOrca,
+		env: { ...process.env, ORCA_TEST_CAPTURE: capture },
+	});
+	assert.ok(tab);
+	tab.append("starting\n");
+	tab.event({ type: "tool_execution_start", toolName: "read", args: { path: "README.md" } });
+	tab.event({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "done output" }] } as never });
+	const sessionId = "019ffd40-4859-7015-94e4-7d15c31885ef";
+	const sessionFile = path.join(dir, `2026-08-13T22-31-16-313Z_${sessionId}.jsonl`);
+	fs.writeFileSync(sessionFile, `${JSON.stringify({ type: "session", version: 3, id: sessionId })}\n`);
+	assert.equal(resolvePiSessionId(sessionFile), sessionId);
+	assert.equal(resolvePiSessionId(path.join(dir, `missing_${sessionId}.jsonl`)), undefined);
+	tab.finish("completed", sessionFile);
+
+	await waitForFile(capture);
+	const args = JSON.parse(fs.readFileSync(capture, "utf-8")) as string[];
+	assert.deepEqual(args.slice(0, 2), ["terminal", "create"]);
+	assert.equal(args[args.indexOf("--worktree") + 1], `path:${path.resolve(dir)}`);
+	assert.equal(args[args.indexOf("--title") + 1], "subagent · worker · 1");
+	const viewer = args[args.indexOf("--command") + 1];
+	assert.ok(viewer.includes(process.execPath));
+	assert.doesNotMatch(viewer, /(?:^|;)\s*exec\s/);
+	assert.doesNotMatch(viewer, /(?:&|;)\s*exit(?:\s|$)/);
+
+	const progressDir = path.join(TEMP_ROOT_DIR, "orca-progress");
+	const log = fs.readdirSync(progressDir).find((name) => name.startsWith(`${runId}-2-`) && name.endsWith(".log"));
+	assert.ok(log);
+	const text = fs.readFileSync(path.join(progressDir, log), "utf-8");
+	assert.match(text, /starting/);
+	assert.match(text, /› read: README\.md/);
+	assert.match(text, /done output/);
+	assert.ok(text.includes(`completed. To remove the Pi session of this subagent, run rm $(find ~/.pi/agent/sessions -name "*_${sessionId}.jsonl" -print -quit)`));
+
+	const nestedCwd = path.join(dir, "packages", "app");
+	fs.mkdirSync(nestedCwd, { recursive: true });
+	const secondTab = createOrcaProgressTab({
+		cwd: nestedCwd,
+		runId: `${runId}-second`,
+		agent: "worker",
+		index: 0,
+		config: { enabled: true },
+		command: fakeOrca,
+		env: { ...process.env, ORCA_TEST_CAPTURE: secondCapture },
+	});
+	assert.ok(secondTab);
+	secondTab.finish("failed", sessionFile);
+	await waitForFile(secondCapture);
+	const secondArgs = JSON.parse(fs.readFileSync(secondCapture, "utf-8")) as string[];
+	assert.equal(secondArgs[secondArgs.indexOf("--title") + 1], "subagent · worker · 2");
+	const secondLog = fs.readdirSync(progressDir).find((name) => name.startsWith(`${runId}-second-0-`) && name.endsWith(".log"));
+	assert.ok(secondLog);
+	const secondText = fs.readFileSync(path.join(progressDir, secondLog), "utf-8");
+	assert.match(secondText, /failed/);
+	assert.doesNotMatch(secondText, /To remove the Pi session/);
+});

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -253,6 +253,18 @@ Package skill content.
 		assert.throws(() => updateConfig((config) => config), /config\.mainWindowRenderer\.compactResultMaxLines must be a positive integer/);
 	});
 
+	it("loads and validates experimental Orca progress-tab config", () => {
+		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true } }));
+		assert.deepEqual(loadConfig().orcaProgressTabs, { enabled: true });
+
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: "yes" } }));
+		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.enabled must be a boolean/);
+
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true, focus: true } }));
+		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.focus is not supported/);
+	});
+
 	it("hardens and redacts existing run history while recording", () => {
 		const historyPath = path.join(agentDir, "run-history.jsonl");
 		fs.mkdirSync(agentDir, { recursive: true, mode: 0o755 });


### PR DESCRIPTION
## Summary

- add an experimental, explicitly opt-in Orca progress-tab observer for subagent children
- preserve native Pi and `external-cli` as the authoritative runners while mirroring live progress best-effort
- keep one tab per logical foreground/background/parallel/chain child, reuse it across startup/model retries, and retain the tab and scrollback after completion
- allocate unique persistent tab sequence numbers per Git worktree, including across concurrent processes
- show session cleanup guidance only for successfully completed native Pi children with a verified session header

## Design

The integration is enabled only with:

```json
{
  "orcaProgressTabs": {
    "enabled": true
  }
}
```

Orca-specific behavior is localized in `src/runs/shared/orca-progress-tabs.ts`. Existing execution, retry, cancellation, status, result, and artifact paths are unchanged. Missing Orca binaries, unavailable runtimes, tab creation failures, malformed optional metadata, and mirror I/O failures are isolated from child execution.

`external-cli` remains Orca-agnostic and exposes only generic stdout/stderr observation callbacks.

## Validation

- `PI_SUBAGENT_ORCA_BINARY=/definitely/missing/orca npm run test:all`
  - unit: 1,895 passed, 2 skipped, 0 failed
  - integration: 769 passed, 0 failed
  - e2e: 0 failed
- `npm run typecheck`
- `git diff --check`
- CodeRabbit CLI review: no findings
