### PR TITLE
fix: speed up async result reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Reduce reload work for large async histories by indexing the async result inbox by session, observer, and tool-call id instead of scanning every old result file; also age stale terminal active markers and throttle replay cleanup scans.
+
 ## [0.49.0] - 2026-08-13
 
 ### Added

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -20,6 +20,7 @@ import { resolveStepBehavior } from "../shared/settings.ts";
 import { agentDefinitionDigest, AGENT_DEFINITION_PROJECTION_VERSION, launchBindingDigest } from "../shared/launch-contract.ts";
 import { DIRS, TEMP_ROOT_DIR } from "../shared/types.ts";
 import { processTerminalCandidatePath, processTerminalPath } from "../runs/background/process-terminal.ts";
+import { resultFilePath } from "../runs/background/result-files.ts";
 import { nestedResultsPath } from "../runs/shared/nested-events.ts";
 
 export const SUBAGENT_LAUNCH_CONTRACT_VERSION = 2 as const;
@@ -295,7 +296,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		: path.join(DIRS.async, runId);
 	const lifecycleResultPath = input.nestedRootRunId
 		? nestedResultsPath(input.nestedRootRunId, runId)
-		: path.join(DIRS.results, `${runId}.json`);
+		: resultFilePath(DIRS.results, runId);
 	if (!sessionDir) diagnostics.push({ code: "host_required", severity: "host-required", message: "No sessionRoot/sessionDir was supplied; exact child session paths require the Pi host session-root policy." });
 	if (input.availableModels === undefined && (input.model || agent.model || input.parentModel)) {
 		diagnostics.push({ code: "host_required", severity: "host-required", message: "No availableModels snapshot was supplied; model resolution may differ from the active Pi host registry." });

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -31,6 +31,7 @@ import { createSubagentParamsSchema } from "./schemas.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { createAsyncJobTracker } from "../runs/background/async-job-tracker.ts";
 import { getActiveAsyncCapacitySnapshot, resolveMaxActiveAsyncRunsPerSession } from "../runs/background/active-async-capacity.ts";
+import { cleanupResultIndexes } from "../runs/background/result-files.ts";
 import { createResultWatcher } from "../runs/background/result-watcher.ts";
 import { createScheduledRunManager } from "../runs/background/scheduled-runs.ts";
 import { registerSlashCommands } from "../slash/slash-commands.ts";
@@ -81,6 +82,13 @@ import {
 } from "./control-notices.ts";
 
 export { loadConfig, resolveAsyncByDefault } from "./config.ts";
+
+const SLOW_RELOAD_PHASE_MS = 250;
+
+function logSlowPhase(label: string, startedAt: number): void {
+	const elapsed = Date.now() - startedAt;
+	if (elapsed >= SLOW_RELOAD_PHASE_MS) console.error(`Subagent reload phase '${label}' took ${elapsed}ms.`);
+}
 
 function workflowLaneKeys(script: string): string[] {
 	const keys: string[] = [];
@@ -373,6 +381,14 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const tempArtifactsDir = getArtifactsDir(null);
 	const artifactCleanupDays = config.artifactConfig?.cleanupDays ?? DEFAULT_ARTIFACT_CONFIG.cleanupDays;
 	cleanupAllArtifactDirs(artifactCleanupDays);
+	const resultIndexCleanupTimer = setTimeout(() => {
+		try {
+			cleanupResultIndexes(DIRS.results);
+		} catch (error) {
+			console.error("Failed to clean stale subagent result indexes:", error);
+		}
+	}, 30_000);
+	resultIndexCleanupTimer.unref?.();
 
 	const state: SubagentState = {
 		baseCwd: "",
@@ -455,6 +471,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	);
 
 	const runtimeCleanup = () => {
+		clearTimeout(resultIndexCleanupTimer);
 		stopResultWatcher();
 		state.currentSessionId = null;
 		completionNotifier.dispose();
@@ -783,18 +800,38 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			}
 		}
 		state.lastUiContext = ctx;
+		let phaseStartedAt = Date.now();
 		refreshActiveAsyncCapacity();
+		logSlowPhase("active-capacity", phaseStartedAt);
+		phaseStartedAt = Date.now();
 		cleanupSessionArtifacts(ctx);
+		logSlowPhase("session-artifact-cleanup", phaseStartedAt);
 		state.foregroundControls.clear();
 		state.lastForegroundControlId = null;
+		phaseStartedAt = Date.now();
 		resetJobs(ctx);
+		logSlowPhase("reset-jobs", phaseStartedAt);
+		phaseStartedAt = Date.now();
 		restoreForegroundRunHistory(state, { resultsDir: DIRS.results });
+		logSlowPhase("foreground-history", phaseStartedAt);
+		phaseStartedAt = Date.now();
 		restoreActiveJobs(ctx);
+		logSlowPhase("active-job-restore", phaseStartedAt);
+		phaseStartedAt = Date.now();
 		scheduledRunManager.bindSession(ctx);
+		logSlowPhase("scheduled-runs", phaseStartedAt);
+		phaseStartedAt = Date.now();
 		restoreSlashFinalSnapshots(ctx.sessionManager.getEntries());
+		logSlowPhase("slash-snapshots", phaseStartedAt);
+		phaseStartedAt = Date.now();
 		waitSubscriptionManager.restore();
+		logSlowPhase("wait-subscriptions", phaseStartedAt);
+		phaseStartedAt = Date.now();
 		startResultWatcher();
+		logSlowPhase("result-watcher-start", phaseStartedAt);
+		phaseStartedAt = Date.now();
 		primeExistingResults({ triggerTurn: !recovering });
+		logSlowPhase("result-prime", phaseStartedAt);
 		fleetStatus?.setContext(ctx);
 	};
 
@@ -837,6 +874,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_shutdown", async () => {
 		state.widgetsSuspended = false;
+		clearTimeout(resultIndexCleanupTimer);
 		stopResultWatcher();
 		state.currentSessionId = null;
 		state.parentSessionFile = null;

--- a/src/runs/background/active-run-index.ts
+++ b/src/runs/background/active-run-index.ts
@@ -3,17 +3,61 @@ import * as path from "node:path";
 import type { AsyncStatus } from "../../shared/types.ts";
 
 export const ACTIVE_RUN_INDEX_DIR = ".active-runs";
+export const DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS = 24 * 60 * 60 * 1000;
+
+const TOOL_CALL_INDEX_DIR = "tool-calls";
 
 function indexDir(asyncDirRoot: string): string {
 	return path.join(asyncDirRoot, ACTIVE_RUN_INDEX_DIR);
+}
+
+function toolCallIndexDir(asyncDirRoot: string, toolCallId: string): string {
+	return path.join(indexDir(asyncDirRoot), TOOL_CALL_INDEX_DIR, encodeURIComponent(toolCallId));
+}
+
+function toolCallIndexPath(asyncDir: string, toolCallId: string): string {
+	return path.join(toolCallIndexDir(path.dirname(asyncDir), toolCallId), path.basename(asyncDir));
 }
 
 function markerPath(asyncDir: string): string {
 	return path.join(indexDir(path.dirname(asyncDir)), path.basename(asyncDir));
 }
 
+function removeEmptyAncestors(start: string, stop: string): void {
+	let current = start;
+	while (current !== stop && current.startsWith(`${stop}${path.sep}`)) {
+		try {
+			fs.rmdirSync(current);
+		} catch {
+			return;
+		}
+		current = path.dirname(current);
+	}
+}
+
 export function isActiveAsyncState(state: AsyncStatus["state"]): boolean {
 	return state === "queued" || state === "running";
+}
+
+function releaseToolCallAliases(asyncDir: string): void {
+	const root = path.join(indexDir(path.dirname(asyncDir)), TOOL_CALL_INDEX_DIR);
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(root, { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const aliasMarker = path.join(root, entry.name, path.basename(asyncDir));
+		try {
+			fs.rmSync(aliasMarker, { force: true });
+			removeEmptyAncestors(path.dirname(aliasMarker), root);
+		} catch {
+			// Alias cleanup must not affect the authoritative active-run marker.
+		}
+	}
 }
 
 export function releaseActiveRunIndex(asyncDir: string): void {
@@ -22,16 +66,31 @@ export function releaseActiveRunIndex(asyncDir: string): void {
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
 	}
+	releaseToolCallAliases(asyncDir);
 }
 
-export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state"]): void {
+export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state"], toolCallId?: string): void {
 	const marker = markerPath(asyncDir);
 	if (isActiveAsyncState(state)) {
 		fs.mkdirSync(path.dirname(marker), { recursive: true });
 		fs.writeFileSync(marker, "", { flag: "a" });
+		if (toolCallId) {
+			const toolCallMarker = toolCallIndexPath(asyncDir, toolCallId);
+			fs.mkdirSync(path.dirname(toolCallMarker), { recursive: true });
+			fs.writeFileSync(toolCallMarker, "", { flag: "a" });
+		}
 		return;
 	}
 	releaseActiveRunIndex(asyncDir);
+}
+
+export function activeRunMarkerAgeMs(asyncDir: string, now = Date.now()): number | undefined {
+	try {
+		return Math.max(0, now - fs.statSync(markerPath(asyncDir)).mtimeMs);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
+	}
 }
 
 export function readActiveRunIndex(asyncDirRoot: string): string[] | undefined {
@@ -41,6 +100,17 @@ export function readActiveRunIndex(asyncDirRoot: string): string[] | undefined {
 			.map((entry) => entry.name);
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
+	}
+}
+
+export function readActiveRunToolCallIndex(asyncDirRoot: string, toolCallId: string): string[] {
+	try {
+		return fs.readdirSync(toolCallIndexDir(asyncDirRoot, toolCallId), { withFileTypes: true })
+			.filter((entry) => entry.isFile())
+			.map((entry) => entry.name);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
 		throw error;
 	}
 }

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -59,6 +59,7 @@ import {
 	resolveChildMaxSubagentDepth,
 } from "../../shared/types.ts";
 import { nestedResultsPath, nestedSummaryFromAsyncStatus, resolveInheritedNestedRouteFromEnv, resolveNestedParentAddressFromEnv, writeNestedEvent } from "../shared/nested-events.ts";
+import { resultFilePath } from "./result-files.ts";
 import { appendTurnBudgetSystemPrompt, initialTurnBudgetState } from "../shared/turn-budget.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import { usageBudgetState } from "../shared/usage-budget.ts";
@@ -1116,7 +1117,7 @@ export function executeAsyncChain(
 			{
 				id,
 				steps,
-				resultPath: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : path.join(DIRS.results, `${id}.json`),
+				resultPath: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : resultFilePath(DIRS.results, id),
 				cwd: runnerCwd,
 				placeholder: "{previous}",
 				maxOutput,
@@ -1571,7 +1572,7 @@ export function executeAsyncSingle(
 				],
 				resultPath: params.parentWorkflowRunId !== undefined && params.revivalLease !== undefined
 					? workflowAwaitedAsyncResultPath(asyncDir)
-					: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : path.join(DIRS.results, `${id}.json`),
+					: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : resultFilePath(DIRS.results, id),
 				cwd: runnerCwd,
 				placeholder: "{previous}",
 				maxOutput,

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -8,6 +8,7 @@ import { intersectSubagentCapabilityCeilings, parseSubagentCapabilityCeiling, ty
 import { validateRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 import { resolveTurnBudgetConfig } from "../shared/turn-budget.ts";
 import { reconcileAsyncRun } from "./stale-run-reconciler.ts";
+import { resultFilePath } from "./result-files.ts";
 
 export interface AsyncResumeParams {
 	id?: string;
@@ -172,7 +173,7 @@ function prefixedRunIds(dir: string, prefix: string, suffix = ""): string[] {
 }
 
 function exactResultPath(resultsDir: string, runId: string): string | null {
-	const resultPath = path.join(resultsDir, `${runId}.json`);
+	const resultPath = resultFilePath(resultsDir, runId);
 	assertInsideRoot(resultsDir, resultPath, "Async result file");
 	return fs.existsSync(resultPath) ? resultPath : null;
 }

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -183,10 +183,7 @@ export function findAsyncRunPrefixMatches(prefix: string, asyncDirRoot: string, 
 	if (!requestedId) return [];
 	const asyncRoot = path.resolve(asyncDirRoot);
 	const resultRoot = path.resolve(resultsDir);
-	const matchingIds = [...new Set([
-		...prefixedRunIds(asyncRoot, requestedId),
-		...prefixedRunIds(resultRoot, requestedId, ".json"),
-	])].sort();
+	const matchingIds = prefixedRunIds(asyncRoot, requestedId).sort();
 	return matchingIds.map((id) => {
 		const asyncDir = path.join(asyncRoot, id);
 		assertInsideRoot(asyncRoot, asyncDir, "Async run directory");

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -12,7 +12,7 @@ import { flatToLogicalStepIndex, normalizeParallelGroups } from "./parallel-grou
 import { contextModeLabel, summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
 import { readProcessTerminal, sanitizeProcessTerminal } from "./process-terminal.ts";
-import { ACTIVE_RUN_INDEX_DIR, isActiveAsyncState, readActiveRunIndex, releaseActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
+import { ACTIVE_RUN_INDEX_DIR, DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS, activeRunMarkerAgeMs, isActiveAsyncState, readActiveRunIndex, releaseActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
@@ -128,6 +128,7 @@ interface AsyncRunListOptions {
 	now?: () => number;
 	reconcile?: boolean;
 	runId?: string;
+	includeNested?: boolean;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -383,6 +384,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 		&& options.states !== undefined
 		&& options.states.length > 0
 		&& options.states.every(isActiveAsyncState);
+	const includeNested = options.includeNested !== false;
 	try {
 		if (options.runId !== undefined) {
 			const resolution = resolveTargetedAsyncRun(asyncDirRoot, options.runId, options.sessionId);
@@ -443,6 +445,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 	// entirely when no active runs match.
 	let nestedRouteIndex: Map<string, NestedRoute> | undefined;
 	const resolveNestedRoute = (rootRunId: string): NestedRoute | undefined => {
+		if (!includeNested) return undefined;
 		if (usedActiveIndex) return findNestedRouteForRootId(rootRunId);
 		if (!nestedRouteIndex) nestedRouteIndex = buildNestedRouteIndex();
 		return nestedRouteIndex.get(rootRunId);
@@ -459,7 +462,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 		}
 		if (usedActiveIndex && !isActiveAsyncState(status.state)) {
 			const processTerminal = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId });
-			if (processTerminal?.state === "observed") releaseActiveRunIndex(asyncDir);
+			if (processTerminal?.state === "observed" || (activeRunMarkerAgeMs(asyncDir, options.now?.()) ?? 0) > DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS) releaseActiveRunIndex(asyncDir);
 		}
 		if (status.displayDismissedAt !== undefined) continue;
 		// Filter before the nested-route lookup: the lookup builds an index over
@@ -470,7 +473,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 		if (options.sessionId && status.sessionId !== options.sessionId) continue;
 		const nestedWarnings: string[] = [];
 		let nestedRoute: NestedRoute | undefined;
-		if (options.reconcile !== false) {
+		if (options.reconcile !== false && includeNested) {
 			try {
 				nestedRoute = resolveNestedRoute(status.runId || path.basename(asyncDir));
 				if (nestedRoute) reconcileNestedAsyncDescendants(nestedRoute, { resultsDir: options.resultsDir, kill: options.kill, now: options.now });

--- a/src/runs/background/chain-root-attachment.ts
+++ b/src/runs/background/chain-root-attachment.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import * as path from "node:path";
+import { resultFilePath } from "./result-files.ts";
 import type { AcceptanceLedger, AsyncStatus, CostSummary, ModelAttempt } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 
@@ -195,5 +195,5 @@ export async function waitForImportedAsyncRoot(
 }
 
 export function resolveAsyncRootResultPath(resultsDir: string, runId: string): string {
-	return path.join(resultsDir, `${runId}.json`);
+	return resultFilePath(resultsDir, runId);
 }

--- a/src/runs/background/completion-replay.ts
+++ b/src/runs/background/completion-replay.ts
@@ -9,6 +9,8 @@ const ARCHIVE_VERSION = 1;
 const ARCHIVE_TEXT_LIMIT_BYTES = 64 * 1024;
 const REPLAY_DIR_NAME = "completion-replay";
 const ARCHIVE_DIR_NAME = "output-archives";
+const CLEANUP_INTERVAL_MS = 60_000;
+const lastCleanupByResultsDir = new Map<string, number>();
 
 export interface CompletionArchiveEntry {
 	agent?: string;
@@ -194,7 +196,7 @@ export function writeCompletionReplay(input: {
 		archivePath,
 	};
 	writePrivateAtomicJson(completionReplayPath(input.resultsDir, input.runId), record);
-	cleanupCompletionReplay(input.resultsDir, input.now, input.ttlMs);
+	cleanupCompletionReplayIfDue(input.resultsDir, input.now, input.ttlMs);
 	return record;
 }
 
@@ -231,6 +233,14 @@ export function readCompletionArchive(archivePath: string): CompletionArchive | 
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 		throw error;
 	}
+}
+
+export function cleanupCompletionReplayIfDue(resultsDir: string, now: number, maxAgeMs: number, intervalMs = CLEANUP_INTERVAL_MS): boolean {
+	const last = lastCleanupByResultsDir.get(resultsDir);
+	if (last !== undefined && now - last < intervalMs) return false;
+	lastCleanupByResultsDir.set(resultsDir, now);
+	cleanupCompletionReplay(resultsDir, now, maxAgeMs);
+	return true;
 }
 
 /** Opportunistically remove expired replay and orphan archive files without affecting delivery. */

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -100,12 +100,12 @@ export function writeResultIndexForData(resultPath: string, data: Record<string,
 }
 
 export function writeAsyncResultFile(resultPath: string, data: Record<string, unknown>): void {
-	writeAtomicJson(resultPath, data);
 	try {
 		writeResultIndexForData(resultPath, data);
 	} catch (error) {
 		console.error(`Failed to write async result index for '${resultPath}':`, error);
 	}
+	writeAtomicJson(resultPath, data);
 }
 
 export function removeResultIndex(resultsDir: string, sessionId: string | undefined, runId: string | undefined, toolCallId?: string): void {
@@ -164,9 +164,12 @@ function resultFilesFromIndexDir(resultsDir: string, dir: string): string[] {
 	for (const entryPath of listIndexFiles(dir)) {
 		try {
 			const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(entryPath, "utf-8")));
-			const resultFile = entry ? indexedResultFile(resultsDir, entry) : undefined;
+			if (!entry) {
+				fs.rmSync(entryPath, { force: true });
+				continue;
+			}
+			const resultFile = indexedResultFile(resultsDir, entry);
 			if (resultFile) candidates.add(resultFile);
-			else fs.rmSync(entryPath, { force: true });
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result index '${entryPath}':`, error);
 		}

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -1,0 +1,227 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { MISSION_BINDING_FILE } from "../../missions/lifecycle.ts";
+
+const RESULT_INDEX_VERSION = 1;
+const RESULT_INDEX_DIR = "result-index";
+const SESSION_INDEX_DIR = "sessions";
+const OBSERVER_INDEX_DIR = "observers";
+const TOOL_CALL_INDEX_DIR = "tool-calls";
+const MISSION_OBSERVER = "mission";
+
+export interface ResultIndexEntry {
+	version: 1;
+	runId: string;
+	sessionId: string;
+	file: string;
+	writtenAt: number;
+	asyncDir?: string;
+}
+
+function encodeSegment(value: string): string {
+	return encodeURIComponent(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function resultFileName(runId: string): string {
+	return `${runId}.json`;
+}
+
+export function resultFilePath(resultsDir: string, runId: string): string {
+	return path.join(resultsDir, resultFileName(runId));
+}
+
+function sessionIndexDir(resultsDir: string, sessionId: string): string {
+	return path.join(resultsDir, RESULT_INDEX_DIR, SESSION_INDEX_DIR, encodeSegment(sessionId));
+}
+
+function resultIndexPath(resultsDir: string, sessionId: string, runId: string): string {
+	return path.join(sessionIndexDir(resultsDir, sessionId), `${encodeSegment(runId)}.json`);
+}
+
+function observerIndexDir(resultsDir: string, observer: string): string {
+	return path.join(resultsDir, RESULT_INDEX_DIR, OBSERVER_INDEX_DIR, observer);
+}
+
+function observerIndexPath(resultsDir: string, observer: string, runId: string): string {
+	return path.join(observerIndexDir(resultsDir, observer), `${encodeSegment(runId)}.json`);
+}
+
+function toolCallIndexDir(resultsDir: string, toolCallId: string): string {
+	return path.join(resultsDir, RESULT_INDEX_DIR, TOOL_CALL_INDEX_DIR, encodeSegment(toolCallId));
+}
+
+function toolCallIndexPath(resultsDir: string, toolCallId: string, runId: string): string {
+	return path.join(toolCallIndexDir(resultsDir, toolCallId), `${encodeSegment(runId)}.json`);
+}
+
+function parseResultIndexEntry(value: unknown): ResultIndexEntry | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const record = value as Partial<ResultIndexEntry>;
+	if (record.version !== RESULT_INDEX_VERSION
+		|| typeof record.runId !== "string"
+		|| typeof record.sessionId !== "string"
+		|| typeof record.file !== "string"
+		|| typeof record.writtenAt !== "number") return undefined;
+	return {
+		version: RESULT_INDEX_VERSION,
+		runId: record.runId,
+		sessionId: record.sessionId,
+		file: record.file,
+		writtenAt: record.writtenAt,
+		...(typeof record.asyncDir === "string" ? { asyncDir: record.asyncDir } : {}),
+	};
+}
+
+export function writeResultIndexForData(resultPath: string, data: Record<string, unknown>): void {
+	const runId = nonEmptyString(data.runId) ?? nonEmptyString(data.id) ?? path.basename(resultPath, ".json");
+	const sessionId = nonEmptyString(data.sessionId);
+	if (!runId || !sessionId) return;
+	const file = path.basename(resultPath);
+	const entry: ResultIndexEntry = {
+		version: RESULT_INDEX_VERSION,
+		runId,
+		sessionId,
+		file,
+		writtenAt: Date.now(),
+		...(nonEmptyString(data.asyncDir) ? { asyncDir: nonEmptyString(data.asyncDir)! } : {}),
+	};
+	const resultsDir = path.dirname(resultPath);
+	writeAtomicJson(resultIndexPath(resultsDir, sessionId, runId), entry);
+	const toolCallId = nonEmptyString(data.toolCallId);
+	if (toolCallId) writeAtomicJson(toolCallIndexPath(resultsDir, toolCallId, runId), entry);
+	if (entry.asyncDir && fs.existsSync(path.join(entry.asyncDir, MISSION_BINDING_FILE))) {
+		writeAtomicJson(observerIndexPath(resultsDir, MISSION_OBSERVER, runId), entry);
+	}
+}
+
+export function writeAsyncResultFile(resultPath: string, data: Record<string, unknown>): void {
+	writeAtomicJson(resultPath, data);
+	try {
+		writeResultIndexForData(resultPath, data);
+	} catch (error) {
+		console.error(`Failed to write async result index for '${resultPath}':`, error);
+	}
+}
+
+export function removeResultIndex(resultsDir: string, sessionId: string | undefined, runId: string | undefined, toolCallId?: string): void {
+	if (!runId) return;
+	if (sessionId) {
+		try {
+			fs.rmSync(resultIndexPath(resultsDir, sessionId, runId), { force: true });
+		} catch {
+			// Index cleanup must not affect result delivery.
+		}
+	}
+	if (toolCallId) {
+		try {
+			fs.rmSync(toolCallIndexPath(resultsDir, toolCallId, runId), { force: true });
+		} catch {
+			// Index cleanup must not affect result delivery.
+		}
+	}
+	try {
+		fs.rmSync(observerIndexPath(resultsDir, MISSION_OBSERVER, runId), { force: true });
+	} catch {
+		// Index cleanup must not affect result delivery.
+	}
+}
+
+export function removeMissionObserverIndex(resultsDir: string, runId: string | undefined): void {
+	if (!runId) return;
+	try {
+		fs.rmSync(observerIndexPath(resultsDir, MISSION_OBSERVER, runId), { force: true });
+	} catch {
+		// Observer index cleanup must not affect result delivery.
+	}
+}
+
+function indexedResultFile(resultsDir: string, entry: ResultIndexEntry): string | undefined {
+	if (entry.file !== path.basename(entry.file) || !entry.file.endsWith(".json")) return undefined;
+	const resultPath = path.join(resultsDir, entry.file);
+	return fs.existsSync(resultPath) ? entry.file : undefined;
+}
+
+function listIndexFiles(dir: string): string[] {
+	let files: string[];
+	try {
+		files = fs.readdirSync(dir, { withFileTypes: true })
+			.filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+			.map((entry) => path.join(dir, entry.name));
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+	return files;
+}
+
+function resultFilesFromIndexDir(resultsDir: string, dir: string): string[] {
+	const candidates = new Set<string>();
+	for (const entryPath of listIndexFiles(dir)) {
+		try {
+			const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(entryPath, "utf-8")));
+			const resultFile = entry ? indexedResultFile(resultsDir, entry) : undefined;
+			if (resultFile) candidates.add(resultFile);
+			else fs.rmSync(entryPath, { force: true });
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result index '${entryPath}':`, error);
+		}
+	}
+	return [...candidates];
+}
+
+export function resultFilesForSession(resultsDir: string, sessionId: string): string[] {
+	return resultFilesFromIndexDir(resultsDir, sessionIndexDir(resultsDir, sessionId));
+}
+
+export function resultFilesForToolCall(resultsDir: string, toolCallId: string): string[] {
+	return resultFilesFromIndexDir(resultsDir, toolCallIndexDir(resultsDir, toolCallId));
+}
+
+export function missionObserverResultFiles(resultsDir: string): string[] {
+	return resultFilesFromIndexDir(resultsDir, observerIndexDir(resultsDir, MISSION_OBSERVER));
+}
+
+export function cleanupResultIndexes(resultsDir: string, now = Date.now(), maxAgeMs = 24 * 60 * 60 * 1000): number {
+	const root = path.join(resultsDir, RESULT_INDEX_DIR);
+	const cutoff = now - maxAgeMs;
+	let removed = 0;
+	const visit = (dir: string): void => {
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			throw error;
+		}
+		for (const entry of entries) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				visit(fullPath);
+				try { fs.rmdirSync(fullPath); } catch {}
+				continue;
+			}
+			if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+			try {
+				const stat = fs.statSync(fullPath);
+				const index = parseResultIndexEntry(JSON.parse(fs.readFileSync(fullPath, "utf-8")));
+				if (!index || (!indexedResultFile(resultsDir, index) && stat.mtimeMs <= cutoff)) {
+					fs.rmSync(fullPath, { force: true });
+					removed += 1;
+				}
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result index '${fullPath}':`, error);
+				try {
+					fs.rmSync(fullPath, { force: true });
+					removed += 1;
+				} catch {}
+			}
+		}
+	};
+	visit(root);
+	return removed;
+}

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -100,11 +100,7 @@ export function writeResultIndexForData(resultPath: string, data: Record<string,
 }
 
 export function writeAsyncResultFile(resultPath: string, data: Record<string, unknown>): void {
-	try {
-		writeResultIndexForData(resultPath, data);
-	} catch (error) {
-		console.error(`Failed to write async result index for '${resultPath}':`, error);
-	}
+	writeResultIndexForData(resultPath, data);
 	writeAtomicJson(resultPath, data);
 }
 

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -93,13 +93,22 @@ export function writeResultIndexForData(resultPath: string, data: Record<string,
 	const resultsDir = path.dirname(resultPath);
 	writeAtomicJson(resultIndexPath(resultsDir, sessionId, runId), entry);
 	const toolCallId = nonEmptyString(data.toolCallId);
-	if (toolCallId) writeAtomicJson(toolCallIndexPath(resultsDir, toolCallId, runId), entry);
-	if (entry.asyncDir && fs.existsSync(path.join(entry.asyncDir, MISSION_BINDING_FILE))) {
-		writeAtomicJson(observerIndexPath(resultsDir, MISSION_OBSERVER, runId), entry);
+	try {
+		if (toolCallId) writeAtomicJson(toolCallIndexPath(resultsDir, toolCallId, runId), entry);
+	} catch (error) {
+		console.error(`Failed to write async result tool-call index for '${resultPath}':`, error);
+	}
+	try {
+		if (entry.asyncDir && fs.existsSync(path.join(entry.asyncDir, MISSION_BINDING_FILE))) {
+			writeAtomicJson(observerIndexPath(resultsDir, MISSION_OBSERVER, runId), entry);
+		}
+	} catch (error) {
+		console.error(`Failed to write async result observer index for '${resultPath}':`, error);
 	}
 }
 
 export function writeAsyncResultFile(resultPath: string, data: Record<string, unknown>): void {
+	if (!nonEmptyString(data.sessionId)) throw new Error(`Cannot write async result '${resultPath}' without a sessionId.`);
 	writeResultIndexForData(resultPath, data);
 	writeAtomicJson(resultPath, data);
 }

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -8,6 +8,7 @@ const RESULT_INDEX_DIR = "result-index";
 const SESSION_INDEX_DIR = "sessions";
 const OBSERVER_INDEX_DIR = "observers";
 const TOOL_CALL_INDEX_DIR = "tool-calls";
+const RESULT_PENDING_DIR = "result-pending";
 const MISSION_OBSERVER = "mission";
 
 export interface ResultIndexEntry {
@@ -41,6 +42,10 @@ function sessionIndexDir(resultsDir: string, sessionId: string): string {
 
 function resultIndexPath(resultsDir: string, sessionId: string, runId: string): string {
 	return path.join(sessionIndexDir(resultsDir, sessionId), `${encodeSegment(runId)}.json`);
+}
+
+function resultPendingPath(resultsDir: string, sessionId: string, runId: string): string {
+	return path.join(resultsDir, RESULT_PENDING_DIR, encodeSegment(sessionId), `${encodeSegment(runId)}.json`);
 }
 
 function observerIndexDir(resultsDir: string, observer: string): string {
@@ -107,10 +112,25 @@ export function writeResultIndexForData(resultPath: string, data: Record<string,
 	}
 }
 
-export function writeAsyncResultFile(resultPath: string, data: Record<string, unknown>): void {
-	if (!nonEmptyString(data.sessionId)) throw new Error(`Cannot write async result '${resultPath}' without a sessionId.`);
+function writeIndexedPendingResultFile(resultPath: string, data: Record<string, unknown>): { runId: string; sessionId: string; resultsDir: string } {
+	const runId = nonEmptyString(data.runId) ?? nonEmptyString(data.id) ?? path.basename(resultPath, ".json");
+	const sessionId = nonEmptyString(data.sessionId);
+	if (!sessionId) throw new Error(`Cannot write async result '${resultPath}' without a sessionId.`);
+	const resultsDir = path.dirname(resultPath);
+	writeAtomicJson(resultPendingPath(resultsDir, sessionId, runId), data);
 	writeResultIndexForData(resultPath, data);
-	writeAtomicJson(resultPath, data);
+	return { runId, sessionId, resultsDir };
+}
+
+export function writePendingAsyncResultFile(resultPath: string, data: Record<string, unknown>): void {
+	writeIndexedPendingResultFile(resultPath, data);
+}
+
+export function writeAsyncResultFile(resultPath: string, data: Record<string, unknown>): { state: "public" | "pending" } {
+	const { runId, sessionId, resultsDir } = writeIndexedPendingResultFile(resultPath, data);
+	return promotePendingResultFile(resultsDir, sessionId, runId, path.basename(resultPath), { logFailure: false }) === "promoted"
+		? { state: "public" }
+		: { state: "pending" };
 }
 
 export function removeResultIndex(resultsDir: string, sessionId: string | undefined, runId: string | undefined, toolCallId?: string): void {
@@ -120,6 +140,11 @@ export function removeResultIndex(resultsDir: string, sessionId: string | undefi
 			fs.rmSync(resultIndexPath(resultsDir, sessionId, runId), { force: true });
 		} catch {
 			// Index cleanup must not affect result delivery.
+		}
+		try {
+			fs.rmSync(resultPendingPath(resultsDir, sessionId, runId), { force: true });
+		} catch {
+			// Pending cleanup must not affect result delivery.
 		}
 	}
 	if (toolCallId) {
@@ -145,10 +170,149 @@ export function removeMissionObserverIndex(resultsDir: string, runId: string | u
 	}
 }
 
-function indexedResultFile(resultsDir: string, entry: ResultIndexEntry): string | undefined {
+function existingResultFile(resultPath: string): boolean {
+	try {
+		return fs.statSync(resultPath).isFile();
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Failed to inspect async result payload '${resultPath}':`, error);
+		return false;
+	}
+}
+
+function pendingResultExists(resultsDir: string, sessionId: string, runId: string): boolean {
+	return existingResultFile(resultPendingPath(resultsDir, sessionId, runId));
+}
+
+function pendingResultPayloadMatches(filePath: string, sessionId: string, runId: string): boolean {
+	try {
+		const data = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, unknown>;
+		return (nonEmptyString(data.runId) ?? nonEmptyString(data.id)) === runId && nonEmptyString(data.sessionId) === sessionId;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid pending async result '${filePath}':`, error);
+		return false;
+	}
+}
+
+export function promotePendingResultFile(resultsDir: string, sessionId: string, runId: string, file = resultFileName(runId), options: { logFailure?: boolean } = {}): "none" | "promoted" | "pending" {
+	if (file !== path.basename(file) || !file.endsWith(".json")) return "none";
+	const pendingPath = resultPendingPath(resultsDir, sessionId, runId);
+	if (!existingResultFile(pendingPath)) return "none";
+	const resultPath = path.join(resultsDir, file);
+	try {
+		fs.rmSync(resultPath, { force: true });
+		fs.renameSync(pendingPath, resultPath);
+		return existingResultFile(resultPath) ? "promoted" : "pending";
+	} catch (error) {
+		if (options.logFailure !== false) console.error(`Failed to promote pending async result '${pendingPath}' to '${resultPath}':`, error);
+		return "pending";
+	}
+}
+
+interface ResultPayloadLocation {
+	file: string;
+	path: string;
+	state: "public" | "pending";
+}
+
+function pendingResultLocationForSessionRun(resultsDir: string, sessionId: string, runId: string, file = resultFileName(runId)): ResultPayloadLocation | undefined {
+	if (file !== path.basename(file) || !file.endsWith(".json")) return undefined;
+	const pendingPath = resultPendingPath(resultsDir, sessionId, runId);
+	return existingResultFile(pendingPath) && pendingResultPayloadMatches(pendingPath, sessionId, runId)
+		? { file, path: pendingPath, state: "pending" }
+		: undefined;
+}
+
+function pendingResultLocationForIndexedRun(resultsDir: string, runId: string): ResultPayloadLocation | undefined {
+	const root = path.join(resultsDir, RESULT_PENDING_DIR);
+	let sessions: fs.Dirent[];
+	try {
+		sessions = fs.readdirSync(root, { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Failed to inspect pending async result root '${root}':`, error);
+		return undefined;
+	}
+	for (const session of sessions) {
+		if (!session.isDirectory()) continue;
+		let sessionId: string;
+		try {
+			sessionId = decodeURIComponent(session.name);
+		} catch {
+			continue;
+		}
+		const location = pendingResultLocationForSessionRun(resultsDir, sessionId, runId);
+		if (location) return location;
+	}
+	return undefined;
+}
+
+function resultPayloadLocationFromIndex(resultsDir: string, entry: ResultIndexEntry): ResultPayloadLocation | undefined {
 	if (entry.file !== path.basename(entry.file) || !entry.file.endsWith(".json")) return undefined;
+	const pendingState = promotePendingResultFile(resultsDir, entry.sessionId, entry.runId, entry.file);
+	if (pendingState === "pending") {
+		return pendingResultLocationForSessionRun(resultsDir, entry.sessionId, entry.runId, entry.file);
+	}
 	const resultPath = path.join(resultsDir, entry.file);
-	return fs.existsSync(resultPath) ? entry.file : undefined;
+	if (pendingState === "promoted" || existingResultFile(resultPath)) return { file: entry.file, path: resultPath, state: "public" };
+	return undefined;
+}
+
+function readResultIndexForSessionRun(resultsDir: string, sessionId: string, runId: string): ResultIndexEntry | undefined {
+	try {
+		const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(resultIndexPath(resultsDir, sessionId, runId), "utf-8")));
+		if (!entry || entry.sessionId !== sessionId || entry.runId !== runId) return undefined;
+		return entry;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT" && code !== "ENOTDIR") console.error(`Ignoring invalid async result index for '${runId}':`, error);
+		return undefined;
+	}
+}
+
+export function resultPayloadPathForSessionRun(resultsDir: string, sessionId: string, runId: string): string | undefined {
+	const entry = readResultIndexForSessionRun(resultsDir, sessionId, runId);
+	return (entry ? resultPayloadLocationFromIndex(resultsDir, entry) : undefined)?.path
+		?? pendingResultLocationForSessionRun(resultsDir, sessionId, runId)?.path;
+}
+
+export function resultPayloadPathForMissionObserverRun(resultsDir: string, runId: string): string | undefined {
+	try {
+		const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(observerIndexPath(resultsDir, MISSION_OBSERVER, runId), "utf-8")));
+		if (!entry || entry.runId !== runId) return undefined;
+		return resultPayloadLocationFromIndex(resultsDir, entry)?.path;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result observer index for '${runId}':`, error);
+		return undefined;
+	}
+}
+
+export function resultPayloadPathForIndexedRun(resultsDir: string, runId: string): string | undefined {
+	const root = path.join(resultsDir, RESULT_INDEX_DIR, SESSION_INDEX_DIR);
+	let sessions: fs.Dirent[] = [];
+	try {
+		sessions = fs.readdirSync(root, { withFileTypes: true });
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT" && code !== "ENOTDIR") console.error(`Failed to inspect async result session index root '${root}':`, error);
+	}
+	for (const session of sessions) {
+		if (!session.isDirectory()) continue;
+		const entryPath = path.join(root, session.name, `${encodeSegment(runId)}.json`);
+		try {
+			const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(entryPath, "utf-8")));
+			if (!entry || entry.runId !== runId) continue;
+			const location = resultPayloadLocationFromIndex(resultsDir, entry);
+			if (location) return location.path;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result index '${entryPath}':`, error);
+		}
+	}
+	return pendingResultLocationForIndexedRun(resultsDir, runId)?.path;
+}
+
+function indexedResultFile(resultsDir: string, entry: ResultIndexEntry, includePending = false): string | undefined {
+	const location = resultPayloadLocationFromIndex(resultsDir, entry);
+	if (!location) return undefined;
+	return includePending || location.state === "public" ? location.file : undefined;
 }
 
 function listIndexFiles(dir: string): string[] {
@@ -158,13 +322,14 @@ function listIndexFiles(dir: string): string[] {
 			.filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
 			.map((entry) => path.join(dir, entry.name));
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") return [];
 		throw error;
 	}
 	return files;
 }
 
-function resultFilesFromIndexDir(resultsDir: string, dir: string): string[] {
+function resultFilesFromIndexDir(resultsDir: string, dir: string, includePending = false): string[] {
 	const candidates = new Set<string>();
 	for (const entryPath of listIndexFiles(dir)) {
 		try {
@@ -173,7 +338,7 @@ function resultFilesFromIndexDir(resultsDir: string, dir: string): string[] {
 				fs.rmSync(entryPath, { force: true });
 				continue;
 			}
-			const resultFile = indexedResultFile(resultsDir, entry);
+			const resultFile = indexedResultFile(resultsDir, entry, includePending);
 			if (resultFile) candidates.add(resultFile);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result index '${entryPath}':`, error);
@@ -186,12 +351,47 @@ export function resultFilesForSession(resultsDir: string, sessionId: string): st
 	return resultFilesFromIndexDir(resultsDir, sessionIndexDir(resultsDir, sessionId));
 }
 
+function pendingResultFilesForSession(resultsDir: string, sessionId: string): string[] {
+	const dir = path.join(resultsDir, RESULT_PENDING_DIR, encodeSegment(sessionId));
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(dir, { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+	const files = new Set<string>();
+	for (const entry of entries) {
+		if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+		const pendingPath = path.join(dir, entry.name);
+		try {
+			const data = JSON.parse(fs.readFileSync(pendingPath, "utf-8")) as Record<string, unknown>;
+			const runId = nonEmptyString(data.runId) ?? nonEmptyString(data.id);
+			if (runId && nonEmptyString(data.sessionId) === sessionId) files.add(resultFileName(runId));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid pending async result '${pendingPath}':`, error);
+		}
+	}
+	return [...files];
+}
+
+export function resultCandidateFilesForSession(resultsDir: string, sessionId: string): string[] {
+	return [...new Set([
+		...resultFilesFromIndexDir(resultsDir, sessionIndexDir(resultsDir, sessionId), true),
+		...pendingResultFilesForSession(resultsDir, sessionId),
+	])];
+}
+
 export function resultFilesForToolCall(resultsDir: string, toolCallId: string): string[] {
 	return resultFilesFromIndexDir(resultsDir, toolCallIndexDir(resultsDir, toolCallId));
 }
 
 export function missionObserverResultFiles(resultsDir: string): string[] {
 	return resultFilesFromIndexDir(resultsDir, observerIndexDir(resultsDir, MISSION_OBSERVER));
+}
+
+export function missionObserverResultCandidateFiles(resultsDir: string): string[] {
+	return resultFilesFromIndexDir(resultsDir, observerIndexDir(resultsDir, MISSION_OBSERVER), true);
 }
 
 export function cleanupResultIndexes(resultsDir: string, now = Date.now(), maxAgeMs = 24 * 60 * 60 * 1000): number {
@@ -217,7 +417,9 @@ export function cleanupResultIndexes(resultsDir: string, now = Date.now(), maxAg
 			try {
 				const stat = fs.statSync(fullPath);
 				const index = parseResultIndexEntry(JSON.parse(fs.readFileSync(fullPath, "utf-8")));
-				if (!index || (!indexedResultFile(resultsDir, index) && stat.mtimeMs <= cutoff)) {
+				const resultFile = index ? indexedResultFile(resultsDir, index) : undefined;
+				const pendingFile = index ? pendingResultExists(resultsDir, index.sessionId, index.runId) : false;
+				if (!index || (!resultFile && !pendingFile && stat.mtimeMs <= cutoff)) {
 					fs.rmSync(fullPath, { force: true });
 					removed += 1;
 				}

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.ts";
 import { createFileCoalescer } from "../../shared/file-coalescer.ts";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import {
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	type IntercomEventBus,
@@ -83,6 +84,7 @@ type ResultFileData = CompletionNotification & {
 	asyncDir?: string;
 	intercomTarget?: string;
 	parallelHandoff?: ParallelHandoffReference;
+	notificationDeliveredAt?: unknown;
 };
 
 type ResultFileIdentity = {
@@ -142,6 +144,16 @@ function isNotFound(error: unknown): boolean {
 function shouldPoll(error: unknown): boolean {
 	const code = errorCode(error);
 	return code === "EMFILE" || code === "ENOSPC";
+}
+
+function hasDeliveredNotification(data: ResultFileData): boolean {
+	return typeof data.notificationDeliveredAt === "number" && Number.isFinite(data.notificationDeliveredAt);
+}
+
+function markDeliveredNotification(resultPath: string, data: ResultFileData, runId: string, now: number): ResultFileData {
+	const marked = { ...data, runId, notificationDeliveredAt: now };
+	writeAtomicJson(resultPath, marked);
+	return marked;
 }
 
 /**
@@ -243,8 +255,9 @@ export function createResultWatcher(
 		if (!shouldProcessResult(file)) return;
 		processing.add(file);
 		try {
-			const data = parseResult(fsApi.readFileSync(resultPath, "utf-8"));
+			let data = parseResult(fsApi.readFileSync(resultPath, "utf-8"));
 			if (typeof data.sessionId !== "string" || !data.sessionId) return;
+			const sessionId = data.sessionId;
 			const runId = data.runId ?? data.id ?? file.replace(/\.json$/i, "");
 			const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : undefined;
 			let observerSucceeded = true;
@@ -262,12 +275,12 @@ export function createResultWatcher(
 			}
 			if (observerSucceeded) removeMissionObserverIndex(resultsDir, runId);
 			const epoch = deliveryEpoch;
-			if (!ownsSession(data.sessionId, epoch)) return;
+			if (!ownsSession(sessionId, epoch)) return;
 			// Recorded before dedupe and before the unlink below so subagent_wait can
 			// use the in-memory record or its bounded durable replay after cleanup.
 			recordWaitCompletion(state, runId, data, Date.now(), completionTtlMs, {
 				resultsDir,
-				sessionId: data.sessionId,
+				sessionId,
 			});
 			const hasExplicitNestedChildren = data.nestedChildren !== undefined;
 			let nestedChildren = compactNestedResultChildren(sanitizeNestedResultChildren(data.nestedChildren, resultPath, "nestedChildren"));
@@ -282,6 +295,7 @@ export function createResultWatcher(
 			}
 
 			const completionKey = buildCompletionKey(data, `result:${file}`);
+			const alreadyDelivered = hasDeliveredNotification(data);
 			const lastSeenAt = state.completionSeen.get(completionKey);
 			if (lastSeenAt !== undefined && Date.now() - lastSeenAt > completionTtlMs) {
 				state.completionSeen.delete(completionKey);
@@ -290,11 +304,11 @@ export function createResultWatcher(
 					scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 					return;
 				}
-				if (!ownsSession(data.sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
+				if (!ownsSession(sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
 				try {
 					fsApi.unlinkSync(resultPath);
 					identityCache.delete(file);
-					removeResultIndex(resultsDir, data.sessionId, runId, toolCallId);
+					removeResultIndex(resultsDir, sessionId, runId, toolCallId);
 				} catch (error) {
 					if (!isNotFound(error)) {
 						console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
@@ -348,6 +362,26 @@ export function createResultWatcher(
 				};
 			}), nestedChildren);
 
+			if (alreadyDelivered) {
+				markSeenWithTtl(state.completionSeen, completionKey, Date.now(), completionTtlMs);
+				if (!observerSucceeded) {
+					scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+					return;
+				}
+				if (!ownsSession(sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
+				try {
+					fsApi.unlinkSync(resultPath);
+					identityCache.delete(file);
+					removeResultIndex(resultsDir, sessionId, runId, toolCallId);
+				} catch (error) {
+					if (!isNotFound(error)) {
+						console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
+						scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+					}
+				}
+				return;
+			}
+
 			const intercomTarget = data.intercomTarget?.trim();
 			let intercomDelivered = false;
 			if (deliverIntercomResults && intercomTarget && triggerTurn) {
@@ -364,7 +398,7 @@ export function createResultWatcher(
 					asyncDir: data.asyncDir,
 					...(data.parallelHandoff ? { parallelHandoff: data.parallelHandoff } : {}),
 				}));
-				if (!ownsSession(data.sessionId, epoch)) return;
+				if (!ownsSession(sessionId, epoch)) return;
 				if (!intercomDelivered) console.error(`Subagent async grouped result intercom delivery was not acknowledged for '${resultPath}'.`);
 			}
 
@@ -388,8 +422,16 @@ export function createResultWatcher(
 					})) : [],
 				} : {}),
 			});
-			if (!ownsSession(data.sessionId, epoch)) return;
+			if (!ownsSession(sessionId, epoch)) return;
 			if (!accepted) {
+				scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+				return;
+			}
+			try {
+				data = markDeliveredNotification(resultPath, data, runId, Date.now());
+				identityCache.delete(file);
+			} catch (error) {
+				console.error(`Failed to mark subagent result notification delivered for '${resultPath}'; will retry:`, error);
 				scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 				return;
 			}
@@ -421,11 +463,11 @@ export function createResultWatcher(
 				scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 				return;
 			}
-			if (!ownsSession(data.sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
+			if (!ownsSession(sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
 			try {
 				fsApi.unlinkSync(resultPath);
 				identityCache.delete(file);
-				removeResultIndex(resultsDir, data.sessionId, runId, toolCallId);
+				removeResultIndex(resultsDir, sessionId, runId, toolCallId);
 			} catch (error) {
 				if (!isNotFound(error)) {
 					console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -22,12 +22,14 @@ import { projectNestedRegistryForRoot, sanitizeSummary } from "../shared/nested-
 import { resolveWatchPath } from "../../shared/utils.ts";
 import { recordWaitCompletion } from "./wait-completions.ts";
 import { MISSION_BINDING_FILE, syncMissionFromAsyncCompletion } from "../../missions/lifecycle.ts";
+import { missionObserverResultFiles, removeMissionObserverIndex, removeResultIndex, resultFilesForSession, writeResultIndexForData } from "./result-files.ts";
 import type { CompletionNotifier, CompletionNotification } from "./notify.ts";
 
 const WATCHER_RESTART_DELAY_MS = 3000;
 const POLL_INTERVAL_MS = 3000;
 const HEALTHY_SCAN_INTERVAL_MS = 60_000;
 const RETRY_DELAY_MS = 100;
+const SLOW_RESULT_SCAN_MS = 500;
 
 type ResultWatcherFs = Pick<typeof fs, "existsSync" | "readFileSync" | "unlinkSync" | "readdirSync" | "mkdirSync" | "realpathSync" | "statSync" | "watch">;
 
@@ -50,6 +52,8 @@ type ResultWatcherDeps = {
 	parseResult?: (raw: string) => ResultFileData;
 	/** External grouped-result transport. Disable when native completion notifications own delivery. */
 	deliverIntercomResults?: boolean;
+	/** Coalesces result-file events. Tests can lower this without changing retry timing. */
+	coalesceDelayMs?: number;
 };
 
 type ResultFileChild = {
@@ -86,6 +90,12 @@ type ResultFileIdentity = {
 	runId?: string;
 	asyncDir?: string;
 };
+
+interface ResultScanStats {
+	files: number;
+	scheduled: number;
+	startedAt: number;
+}
 
 function jsonStringProperty(raw: string, property: string): string | undefined {
 	const matches = raw.matchAll(new RegExp(`"${property}"\\s*:\\s*("(?:\\\\.|[^"\\\\])*")`, "g"));
@@ -177,16 +187,27 @@ export function createResultWatcher(
 		state.resultFileCoalescer.schedule(file, delayMs);
 	};
 
-	const inspectResult = (file: string): ResultFileIdentity | undefined => {
+	const resultSignature = (file: string): string | undefined => {
 		const resultPath = path.join(resultsDir, file);
 		try {
 			const stat = fsApi.statSync(resultPath);
-			const signature = `${stat.size}:${stat.mtimeMs}`;
+			return `${stat.size}:${stat.mtimeMs}`;
+		} catch (error) {
+			identityCache.delete(file);
+			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
+			return undefined;
+		}
+	};
+	const inspectResult = (file: string, knownSignature?: string): { identity: ResultFileIdentity; signature: string } | undefined => {
+		const resultPath = path.join(resultsDir, file);
+		try {
+			const signature = knownSignature ?? resultSignature(file);
+			if (!signature) return undefined;
 			const cached = identityCache.get(file);
-			if (cached?.signature === signature) return cached.identity;
+			if (cached?.signature === signature) return { identity: cached.identity, signature };
 			const identity = resultFileIdentity(fsApi.readFileSync(resultPath, "utf-8"), file);
 			identityCache.set(file, { signature, identity });
-			return identity;
+			return { identity, signature };
 		} catch (error) {
 			identityCache.delete(file);
 			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
@@ -203,9 +224,10 @@ export function createResultWatcher(
 		}
 	};
 
-	const shouldProcessResult = (file: string, observed?: ReadonlySet<string>): boolean => {
-		const identity = inspectResult(file);
-		if (!identity) return false;
+	const shouldProcessResult = (file: string, observed?: ReadonlySet<string>, knownSignature?: string): boolean => {
+		const inspected = inspectResult(file, knownSignature);
+		if (!inspected) return false;
+		const { identity } = inspected;
 		// Missing identity stays on the normal parser path so malformed or legacy
 		// files keep their existing diagnostics and compatibility behavior.
 		if (!identity.sessionId) return true;
@@ -224,16 +246,21 @@ export function createResultWatcher(
 			const data = parseResult(fsApi.readFileSync(resultPath, "utf-8"));
 			if (typeof data.sessionId !== "string" || !data.sessionId) return;
 			const runId = data.runId ?? data.id ?? file.replace(/\.json$/i, "");
+			const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : undefined;
+			let observerSucceeded = true;
 			try {
 				syncMissionFromAsyncCompletion({ ...data, runId });
 			} catch (error) {
+				observerSucceeded = false;
 				console.error(`Mission completion sync failed for '${resultPath}':`, error);
 			}
 			try {
 				deps.observeCompletion?.({ ...data, runId });
 			} catch (error) {
+				observerSucceeded = false;
 				console.error(`Completion observer failed for '${resultPath}':`, error);
 			}
+			if (observerSucceeded) removeMissionObserverIndex(resultsDir, runId);
 			const epoch = deliveryEpoch;
 			if (!ownsSession(data.sessionId, epoch)) return;
 			// Recorded before dedupe and before the unlink below so subagent_wait can
@@ -263,6 +290,7 @@ export function createResultWatcher(
 				try {
 					fsApi.unlinkSync(resultPath);
 					identityCache.delete(file);
+					removeResultIndex(resultsDir, data.sessionId, runId, toolCallId);
 				} catch (error) {
 					if (!isNotFound(error)) {
 						console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
@@ -389,6 +417,7 @@ export function createResultWatcher(
 			try {
 				fsApi.unlinkSync(resultPath);
 				identityCache.delete(file);
+				removeResultIndex(resultsDir, data.sessionId, runId, toolCallId);
 			} catch (error) {
 				if (!isNotFound(error)) {
 					console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
@@ -406,18 +435,38 @@ export function createResultWatcher(
 		const triggerTurn = pendingTriggerTurn.get(file) !== false;
 		pendingTriggerTurn.delete(file);
 		void handleResult(file, triggerTurn);
-	}, 50);
+	}, deps.coalesceDelayMs ?? 50);
 
+	const logScanStats = (stats: ResultScanStats) => {
+		const elapsed = Date.now() - stats.startedAt;
+		if (elapsed < SLOW_RESULT_SCAN_MS) return;
+		console.error(`Subagent result scan inspected ${stats.files} indexed result file(s), scheduled ${stats.scheduled} in ${elapsed}ms (${resultsDir}).`);
+	};
+	const indexedResultCandidates = (): string[] => {
+		const files = new Set<string>();
+		if (state.currentSessionId) {
+			for (const file of resultFilesForSession(resultsDir, state.currentSessionId)) files.add(file);
+		}
+		for (const runId of state.asyncJobs.keys()) files.add(`${runId}.json`);
+		for (const file of missionObserverResultFiles(resultsDir)) files.add(file);
+		for (const runId of observedRunIds()) files.add(`${runId}.json`);
+		return [...files];
+	};
 	const primeExistingResults = (options: { triggerTurn?: boolean } = {}) => {
 		try {
 			const triggerTurn = options.triggerTurn !== false;
-			fsApi.readdirSync(resultsDir)
-				.filter((f) => f.endsWith(".json"))
-				.forEach((file) => {
-					if (shouldProcessResult(file)) scheduleResult(file, triggerTurn);
-				});
+			const stats: ResultScanStats = { files: 0, scheduled: 0, startedAt: Date.now() };
+			for (const file of indexedResultCandidates()) {
+				stats.files += 1;
+				const signature = resultSignature(file);
+				if (!signature) continue;
+				if (!shouldProcessResult(file, undefined, signature)) continue;
+				stats.scheduled += 1;
+				scheduleResult(file, triggerTurn);
+			}
+			logScanStats(stats);
 		} catch (error) {
-			if (!isNotFound(error)) console.error(`Failed to scan subagent result directory '${resultsDir}':`, error);
+			if (!isNotFound(error)) console.error(`Failed to scan subagent result index in '${resultsDir}':`, error);
 		}
 	};
 
@@ -474,6 +523,11 @@ export function createResultWatcher(
 				const fileName = file.toString();
 				if (fileName.endsWith(".json")) {
 					identityCache.delete(fileName);
+					try {
+						writeResultIndexForData(path.join(resultsDir, fileName), JSON.parse(fsApi.readFileSync(path.join(resultsDir, fileName), "utf-8")) as Record<string, unknown>);
+					} catch {
+						// The writer may still be renaming the file; handleResult will retry from the normal result path.
+					}
 					scheduleResult(fileName, true);
 				}
 			});

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -286,6 +286,10 @@ export function createResultWatcher(
 			if (lastSeenAt !== undefined && Date.now() - lastSeenAt > completionTtlMs) {
 				state.completionSeen.delete(completionKey);
 			} else if (lastSeenAt !== undefined) {
+				if (!observerSucceeded) {
+					scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+					return;
+				}
 				if (!ownsSession(data.sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
 				try {
 					fsApi.unlinkSync(resultPath);
@@ -412,6 +416,10 @@ export function createResultWatcher(
 				});
 			} catch (error) {
 				console.error(`Completion observer failed for '${resultPath}':`, error);
+			}
+			if (!observerSucceeded) {
+				scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+				return;
 			}
 			if (!ownsSession(data.sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
 			try {

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -2,7 +2,6 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.ts";
 import { createFileCoalescer } from "../../shared/file-coalescer.ts";
-import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import {
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	type IntercomEventBus,
@@ -23,7 +22,7 @@ import { projectNestedRegistryForRoot, sanitizeSummary } from "../shared/nested-
 import { resolveWatchPath } from "../../shared/utils.ts";
 import { recordWaitCompletion } from "./wait-completions.ts";
 import { MISSION_BINDING_FILE, syncMissionFromAsyncCompletion } from "../../missions/lifecycle.ts";
-import { missionObserverResultFiles, removeMissionObserverIndex, removeResultIndex, resultFilesForSession, writeResultIndexForData } from "./result-files.ts";
+import { missionObserverResultCandidateFiles, promotePendingResultFile, removeMissionObserverIndex, removeResultIndex, resultCandidateFilesForSession, resultPayloadPathForIndexedRun, resultPayloadPathForMissionObserverRun, resultPayloadPathForSessionRun, writeAsyncResultFile, writeResultIndexForData } from "./result-files.ts";
 import type { CompletionNotifier, CompletionNotification } from "./notify.ts";
 
 const WATCHER_RESTART_DELAY_MS = 3000;
@@ -152,7 +151,7 @@ function hasDeliveredNotification(data: ResultFileData): boolean {
 
 function markDeliveredNotification(resultPath: string, data: ResultFileData, runId: string, now: number): ResultFileData {
 	const marked = { ...data, runId, notificationDeliveredAt: now };
-	writeAtomicJson(resultPath, marked);
+	writeAsyncResultFile(resultPath, marked);
 	return marked;
 }
 
@@ -199,21 +198,49 @@ export function createResultWatcher(
 		state.resultFileCoalescer.schedule(file, delayMs);
 	};
 
-	const resultSignature = (file: string): string | undefined => {
-		const resultPath = path.join(resultsDir, file);
+	const publicResultPath = (file: string): string => path.join(resultsDir, file);
+	const publicResultFileExists = (file: string): boolean => {
+		try {
+			return fsApi.statSync(publicResultPath(file)).isFile();
+		} catch (error) {
+			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${publicResultPath(file)}':`, error);
+			return false;
+		}
+	};
+	const resultPayloadPath = (file: string, observed?: ReadonlySet<string>): string | undefined => {
+		if (file !== path.basename(file) || !file.endsWith(".json")) return undefined;
+		const runId = file.replace(/\.json$/i, "");
+		const sessionResult = state.currentSessionId ? resultPayloadPathForSessionRun(resultsDir, state.currentSessionId, runId) : undefined;
+		if (sessionResult) return sessionResult;
+		const observerResult = resultPayloadPathForMissionObserverRun(resultsDir, runId);
+		if (observerResult) return observerResult;
+		if (observed?.has(runId)) {
+			const indexedResult = resultPayloadPathForIndexedRun(resultsDir, runId);
+			if (indexedResult) return indexedResult;
+		}
+		return publicResultFileExists(file) ? publicResultPath(file) : undefined;
+	};
+	const resultSignature = (file: string, observed?: ReadonlySet<string>): string | undefined => {
+		const resultPath = resultPayloadPath(file, observed);
+		if (!resultPath) {
+			identityCache.delete(file);
+			return undefined;
+		}
 		try {
 			const stat = fsApi.statSync(resultPath);
-			return `${stat.size}:${stat.mtimeMs}`;
+			if (!stat.isFile()) return undefined;
+			return `${resultPath}:${stat.size}:${stat.mtimeMs}`;
 		} catch (error) {
 			identityCache.delete(file);
 			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
 			return undefined;
 		}
 	};
-	const inspectResult = (file: string, knownSignature?: string): { identity: ResultFileIdentity; signature: string } | undefined => {
-		const resultPath = path.join(resultsDir, file);
+	const inspectResult = (file: string, knownSignature?: string, observed?: ReadonlySet<string>): { identity: ResultFileIdentity; signature: string } | undefined => {
+		const resultPath = resultPayloadPath(file, observed);
+		if (!resultPath) return undefined;
 		try {
-			const signature = knownSignature ?? resultSignature(file);
+			const signature = knownSignature ?? resultSignature(file, observed);
 			if (!signature) return undefined;
 			const cached = identityCache.get(file);
 			if (cached?.signature === signature) return { identity: cached.identity, signature };
@@ -237,7 +264,7 @@ export function createResultWatcher(
 	};
 
 	const shouldProcessResult = (file: string, observed?: ReadonlySet<string>, knownSignature?: string): boolean => {
-		const inspected = inspectResult(file, knownSignature);
+		const inspected = inspectResult(file, knownSignature, observed);
 		if (!inspected) return false;
 		const { identity } = inspected;
 		// Missing identity stays on the normal parser path so malformed or legacy
@@ -249,13 +276,55 @@ export function createResultWatcher(
 		return Boolean(deps.observeCompletion && !deps.observedCompletionRunIds);
 	};
 
-	const handleResult = async (file: string, triggerTurn: boolean) => {
-		const resultPath = path.join(resultsDir, file);
-		if (processing.has(file) || !fsApi.existsSync(resultPath)) return;
-		if (!shouldProcessResult(file)) return;
-		processing.add(file);
+	const removeDeliveredResult = (file: string, sessionId: string, runId: string, toolCallId: string | undefined): boolean => {
 		try {
-			let data = parseResult(fsApi.readFileSync(resultPath, "utf-8"));
+			if (publicResultFileExists(file)) fsApi.unlinkSync(publicResultPath(file));
+			identityCache.delete(file);
+			removeResultIndex(resultsDir, sessionId, runId, toolCallId);
+			return true;
+		} catch (error) {
+			if (!isNotFound(error)) {
+				console.error(`Failed to remove delivered subagent result '${publicResultPath(file)}'; will retry:`, error);
+				return false;
+			}
+			return true;
+		}
+	};
+	const handleResult = async (file: string, triggerTurn: boolean) => {
+		if (processing.has(file)) return;
+		let observed: ReadonlySet<string> | undefined;
+		if (!shouldProcessResult(file)) {
+			const runId = file === path.basename(file) && file.endsWith(".json") ? file.replace(/\.json$/i, "") : undefined;
+			observed = observedRunIds();
+			if (!runId || !observed.has(runId) || !shouldProcessResult(file, observed)) return;
+		}
+		processing.add(file);
+		let resultPath = publicResultPath(file);
+		try {
+			const payloadPath = resultPayloadPath(file, observed);
+			if (!payloadPath) return;
+			resultPath = payloadPath;
+			let raw = fsApi.readFileSync(resultPath, "utf-8");
+			let identity = resultFileIdentity(raw, file);
+			if (identity.sessionId && identity.runId) {
+				const pendingState = promotePendingResultFile(resultsDir, identity.sessionId, identity.runId, file);
+				if (pendingState === "promoted") {
+					identityCache.delete(file);
+					resultPath = publicResultPath(file);
+					raw = fsApi.readFileSync(resultPath, "utf-8");
+					identity = resultFileIdentity(raw, file);
+				} else if (pendingState === "pending") {
+					const pendingPath = resultPayloadPathForSessionRun(resultsDir, identity.sessionId, identity.runId);
+					if (!pendingPath) {
+						scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+						return;
+					}
+					resultPath = pendingPath;
+					raw = fsApi.readFileSync(resultPath, "utf-8");
+					identity = resultFileIdentity(raw, file);
+				}
+			}
+			let data = parseResult(raw);
 			if (typeof data.sessionId !== "string" || !data.sessionId) return;
 			const sessionId = data.sessionId;
 			const runId = data.runId ?? data.id ?? file.replace(/\.json$/i, "");
@@ -304,17 +373,8 @@ export function createResultWatcher(
 					scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 					return;
 				}
-				if (!ownsSession(sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
-				try {
-					fsApi.unlinkSync(resultPath);
-					identityCache.delete(file);
-					removeResultIndex(resultsDir, sessionId, runId, toolCallId);
-				} catch (error) {
-					if (!isNotFound(error)) {
-						console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
-						scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
-					}
-				}
+				if (!ownsSession(sessionId, epoch)) return;
+				if (!removeDeliveredResult(file, sessionId, runId, toolCallId)) scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 				return;
 			}
 
@@ -368,17 +428,8 @@ export function createResultWatcher(
 					scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 					return;
 				}
-				if (!ownsSession(sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
-				try {
-					fsApi.unlinkSync(resultPath);
-					identityCache.delete(file);
-					removeResultIndex(resultsDir, sessionId, runId, toolCallId);
-				} catch (error) {
-					if (!isNotFound(error)) {
-						console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
-						scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
-					}
-				}
+				if (!ownsSession(sessionId, epoch)) return;
+				if (!removeDeliveredResult(file, sessionId, runId, toolCallId)) scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 				return;
 			}
 
@@ -428,7 +479,7 @@ export function createResultWatcher(
 				return;
 			}
 			try {
-				data = markDeliveredNotification(resultPath, data, runId, Date.now());
+				data = markDeliveredNotification(publicResultPath(file), data, runId, Date.now());
 				identityCache.delete(file);
 			} catch (error) {
 				console.error(`Failed to mark subagent result notification delivered for '${resultPath}'; will retry:`, error);
@@ -463,17 +514,8 @@ export function createResultWatcher(
 				scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 				return;
 			}
-			if (!ownsSession(sessionId, epoch) || !fsApi.existsSync(resultPath)) return;
-			try {
-				fsApi.unlinkSync(resultPath);
-				identityCache.delete(file);
-				removeResultIndex(resultsDir, sessionId, runId, toolCallId);
-			} catch (error) {
-				if (!isNotFound(error)) {
-					console.error(`Failed to remove delivered subagent result '${resultPath}'; will retry:`, error);
-					scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
-				}
-			}
+			if (!ownsSession(sessionId, epoch)) return;
+			if (!removeDeliveredResult(file, sessionId, runId, toolCallId)) scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 		} catch (error) {
 			if (!isNotFound(error)) console.error(`Failed to process subagent result file '${resultPath}':`, error);
 		} finally {
@@ -492,25 +534,26 @@ export function createResultWatcher(
 		if (elapsed < SLOW_RESULT_SCAN_MS) return;
 		console.error(`Subagent result scan inspected ${stats.files} indexed result file(s), scheduled ${stats.scheduled} in ${elapsed}ms (${resultsDir}).`);
 	};
-	const indexedResultCandidates = (): string[] => {
+	const indexedResultCandidates = (observed: ReadonlySet<string>): string[] => {
 		const files = new Set<string>();
 		if (state.currentSessionId) {
-			for (const file of resultFilesForSession(resultsDir, state.currentSessionId)) files.add(file);
+			for (const file of resultCandidateFilesForSession(resultsDir, state.currentSessionId)) files.add(file);
 		}
 		for (const runId of state.asyncJobs.keys()) files.add(`${runId}.json`);
-		for (const file of missionObserverResultFiles(resultsDir)) files.add(file);
-		for (const runId of observedRunIds()) files.add(`${runId}.json`);
+		for (const file of missionObserverResultCandidateFiles(resultsDir)) files.add(file);
+		for (const runId of observed) files.add(`${runId}.json`);
 		return [...files];
 	};
 	const primeExistingResults = (options: { triggerTurn?: boolean } = {}) => {
 		try {
 			const triggerTurn = options.triggerTurn !== false;
 			const stats: ResultScanStats = { files: 0, scheduled: 0, startedAt: Date.now() };
-			for (const file of indexedResultCandidates()) {
+			const observed = observedRunIds();
+			for (const file of indexedResultCandidates(observed)) {
 				stats.files += 1;
-				const signature = resultSignature(file);
+				const signature = resultSignature(file, observed);
 				if (!signature) continue;
-				if (!shouldProcessResult(file, undefined, signature)) continue;
+				if (!shouldProcessResult(file, observed, signature)) continue;
 				stats.scheduled += 1;
 				scheduleResult(file, triggerTurn);
 			}

--- a/src/runs/background/run-id-resolver.ts
+++ b/src/runs/background/run-id-resolver.ts
@@ -3,6 +3,8 @@ import * as path from "node:path";
 import { DIRS, type SubagentState } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { findAsyncRunPrefixMatches, type AsyncRunLocation } from "./async-resume.ts";
+import { resultFilePath, resultFilesForToolCall } from "./result-files.ts";
+import { readActiveRunToolCallIndex } from "./active-run-index.ts";
 import { assertSafeNestedId, findNestedRunMatchesById, type NestedRoute, type NestedRunMatch, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 
 export type ResolvedSubagentRunId =
@@ -19,7 +21,7 @@ export interface ResolveSubagentRunIdDeps {
 
 function exactAsyncLocation(id: string, asyncDirRoot: string, resultsDir: string): AsyncRunLocation | undefined {
 	const asyncDir = path.join(asyncDirRoot, id);
-	const resultPath = path.join(resultsDir, `${id}.json`);
+	const resultPath = resultFilePath(resultsDir, id);
 	if (!fs.existsSync(asyncDir) && !fs.existsSync(resultPath)) return undefined;
 	return {
 		asyncDir: fs.existsSync(asyncDir) ? asyncDir : null,
@@ -52,39 +54,28 @@ function readWorkflowResultIdentity(resultPath: string): WorkflowResultIdentity 
 	};
 }
 
-function directoryEntries(root: string): string[] {
-	try {
-		return fs.readdirSync(root);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-		throw error;
-	}
-}
-
 function resultPathFor(resultsDir: string, runId: string): string | null {
-	const resultPath = path.join(resultsDir, `${runId}.json`);
+	const resultPath = resultFilePath(resultsDir, runId);
 	return fs.existsSync(resultPath) ? resultPath : null;
 }
 
-function toolCallIdMatches(value: string | undefined, query: string, options: { prefix?: boolean }): boolean {
-	if (value === undefined) return false;
-	return options.prefix === true ? value.startsWith(query) : value === query;
+function toolCallIdMatches(value: string | undefined, query: string): boolean {
+	return value === query;
 }
 
-function toolCallIdAsyncLocations(toolCallId: string, asyncDirRoot: string, resultsDir: string, options: { prefix?: boolean } = {}): AsyncRunMatch[] {
+function indexedToolCallIdAsyncLocations(toolCallId: string, asyncDirRoot: string, resultsDir: string): AsyncRunMatch[] {
 	const byId = new Map<string, AsyncRunLocation>();
-	for (const entry of directoryEntries(asyncDirRoot)) {
+	for (const entry of readActiveRunToolCallIndex(asyncDirRoot, toolCallId)) {
 		const asyncDir = path.join(asyncDirRoot, entry);
 		const status = readStatus(asyncDir);
-		if (!status || !toolCallIdMatches(status.toolCallId, toolCallId, options)) continue;
+		if (!status || !toolCallIdMatches(status.toolCallId, toolCallId)) continue;
 		const runId = status.runId || entry;
 		byId.set(runId, { asyncDir, resultPath: resultPathFor(resultsDir, runId), resolvedId: runId });
 	}
-	for (const entry of directoryEntries(resultsDir)) {
-		if (!entry.endsWith(".json")) continue;
+	for (const entry of resultFilesForToolCall(resultsDir, toolCallId)) {
 		const resultPath = path.join(resultsDir, entry);
 		const identity = readWorkflowResultIdentity(resultPath);
-		if (!identity || !toolCallIdMatches(identity.toolCallId, toolCallId, options)) continue;
+		if (!identity || !toolCallIdMatches(identity.toolCallId, toolCallId)) continue;
 		const runId = identity.runId ?? identity.id ?? entry.slice(0, -".json".length);
 		const asyncDir = path.join(asyncDirRoot, runId);
 		byId.set(runId, { asyncDir: fs.existsSync(asyncDir) ? asyncDir : null, resultPath, resolvedId: runId });
@@ -156,7 +147,7 @@ export function resolveSubagentRunId(id: string, deps: ResolveSubagentRunIdDeps 
 	if (exactAsync) return { kind: "async", id, location: exactAsync };
 	const exactLiveToolCallMatch = exactLiveAsyncToolCallMatch(deps.state, id, asyncDirRoot, resultsDir);
 	if (exactLiveToolCallMatch) return { kind: "async", id: exactLiveToolCallMatch.id, location: exactLiveToolCallMatch.location };
-	const exactToolCallIdMatches = toolCallIdAsyncLocations(id, asyncDirRoot, resultsDir);
+	const exactToolCallIdMatches = indexedToolCallIdAsyncLocations(id, asyncDirRoot, resultsDir);
 	if (exactToolCallIdMatches.length > 1) throw new Error(`Subagent tool-call id '${id}' is ambiguous across async runs. Use the returned asyncId instead.`);
 	if (exactToolCallIdMatches[0]) return { kind: "async", id: exactToolCallIdMatches[0].id, location: exactToolCallIdMatches[0].location };
 	const exactNested = findNestedRunMatchesById(id, nestedScope ? { scope: nestedScope } : {});
@@ -168,9 +159,6 @@ export function resolveSubagentRunId(id: string, deps: ResolveSubagentRunIdDeps 
 		matches.push({ kind: "foreground", id: foregroundId });
 	}
 	for (const match of asyncPrefixMatches(id, asyncDirRoot, resultsDir)) {
-		matches.push({ kind: "async", id: match.id, location: match.location });
-	}
-	for (const match of toolCallIdAsyncLocations(id, asyncDirRoot, resultsDir, { prefix: true })) {
 		matches.push({ kind: "async", id: match.id, location: match.location });
 	}
 	for (const match of findNestedRunMatchesById(id, nestedScope ? { prefix: true, scope: nestedScope } : { prefix: true })) {

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -361,6 +361,7 @@ export class ScheduledRunManager {
 	private readonly stores = new Map<string, ScheduleStore>();
 	private readonly contexts = new Map<string, ExtensionContext>();
 	private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
+	private readonly observedAsyncIds = new Set<string>();
 	private readonly now: () => number;
 	private readonly randomId: () => string;
 	private readonly timersApi: ScheduledRunTimers;
@@ -383,6 +384,7 @@ export class ScheduledRunManager {
 		this.store = undefined;
 		this.stores.clear();
 		this.contexts.clear();
+		this.observedAsyncIds.clear();
 	}
 
 	async handleToolCall(params: SubagentParamsLike, ctx: ExtensionContext): Promise<AgentToolResult<Details>> {
@@ -407,26 +409,7 @@ export class ScheduledRunManager {
 	}
 
 	observedCompletionRunIds(): Set<string> {
-		const runIds = new Set<string>();
-		for (const store of this.stores.values()) {
-			let ids: string[];
-			try {
-				ids = store.ids();
-			} catch (error) {
-				console.error(`Failed to inspect schedule store '${store.root}' during async completion discovery:`, error);
-				continue;
-			}
-			for (const id of ids) {
-				try {
-					for (const run of store.history(id)) {
-						if (run.state === "running" && run.asyncId) runIds.add(run.asyncId);
-					}
-				} catch (error) {
-					console.error(`Failed to inspect schedule '${id}' in '${store.root}' during async completion discovery:`, error);
-				}
-			}
-		}
-		return runIds;
+		return new Set(this.observedAsyncIds);
 	}
 
 	handleAsyncCompletion(payload: unknown): void {
@@ -566,6 +549,7 @@ export class ScheduledRunManager {
 	private restoreOne(store: ScheduleStore, schedule: ScheduleRecord): void {
 		if (schedule.activeRunId) {
 			const run = store.history(schedule.id).find((item) => item.id === schedule.activeRunId);
+			if (run?.state === "running" && run.asyncId) this.observedAsyncIds.add(run.asyncId);
 			const startedAt = run?.startedAt ? Date.parse(run.startedAt) : Number.NaN;
 			if (run?.state === "running" && run.asyncDir) {
 				try {
@@ -661,6 +645,7 @@ export class ScheduledRunManager {
 			if (result.isError || !asyncId) throw new Error(result.content.find((item) => item.type === "text")?.text ?? "Scheduled launch failed.");
 			run.asyncId = asyncId;
 			run.asyncDir = result.details?.asyncDir;
+			this.observedAsyncIds.add(asyncId);
 			store.writeRun(schedule, run, "schedule.run.attached_async");
 			this.arm(schedule, store);
 			return run;
@@ -695,6 +680,7 @@ export class ScheduledRunManager {
 			schedule.trigger.nextRunAt = nextAfter(schedule.trigger, planned, now);
 			store.writeRun(schedule, skipped, "schedule.skipped_overlap");
 		}
+		if (run.asyncId) this.observedAsyncIds.delete(run.asyncId);
 		run.state = success ? "completed" : "failed_run";
 		run.completedAt = timestamp(now);
 		if (!success && error) run.error = error;

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { resultFilePath, writeAsyncResultFile } from "./result-files.ts";
 import { releaseActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { DIRS, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSummary, type SubagentRunMode } from "../../shared/types.ts";
@@ -197,7 +198,7 @@ function buildStartedStatus(asyncDir: string, startedRun: StartedRunMetadata, no
 	};
 }
 
-function buildFailedRepair(status: AsyncStatus, asyncDir: string, now: number, reason?: string): { status: AsyncStatus; result: object; message: string } {
+function buildFailedRepair(status: AsyncStatus, asyncDir: string, now: number, reason?: string): { status: AsyncStatus; result: Record<string, unknown>; message: string } {
 	const runId = status.runId || path.basename(asyncDir);
 	const pid = typeof status.pid === "number" ? status.pid : "unknown";
 	const baseMessage = reason ?? `Async runner process ${pid} exited or disappeared before writing a result. Marked run failed by stale-run reconciliation.`;
@@ -259,7 +260,7 @@ function buildFailedRepair(status: AsyncStatus, asyncDir: string, now: number, r
 
 function writeFailedRepair(asyncDir: string, status: AsyncStatus, resultPath: string, now: number, reason?: string): ReconcileAsyncRunResult {
 	const repair = buildFailedRepair(status, asyncDir, now, reason);
-	writeAtomicJson(resultPath, repair.result);
+	writeAsyncResultFile(resultPath, repair.result);
 	writeAtomicJson(path.join(asyncDir, "status.json"), repair.status);
 	if (repair.status.processTerminal?.state === "observed") releaseActiveRunIndex(asyncDir);
 	appendJsonlBestEffort(path.join(asyncDir, "events.jsonl"), {
@@ -344,7 +345,7 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 		if (stepRecord.thinking !== undefined && typeof stepRecord.thinking !== "string") throw new Error(`Invalid async status file '${statusPath}': steps[${index}].thinking must be a string.`);
 	}
 	const runId = effectiveStatus.runId || path.basename(asyncDir);
-	const resultPath = path.join(options.resultsDir ?? DIRS.results, `${runId}.json`);
+	const resultPath = resultFilePath(options.resultsDir ?? DIRS.results, runId);
 	if (fs.existsSync(resultPath)) {
 		const terminalStatus = effectiveStatus.state === "running" || effectiveStatus.state === "queued"
 			? terminalStatusFromResult(effectiveStatus, resultPath, now)

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -260,7 +260,7 @@ function buildFailedRepair(status: AsyncStatus, asyncDir: string, now: number, r
 
 function writeFailedRepair(asyncDir: string, status: AsyncStatus, resultPath: string, now: number, reason?: string): ReconcileAsyncRunResult {
 	const repair = buildFailedRepair(status, asyncDir, now, reason);
-	writeAsyncResultFile(resultPath, repair.result);
+	if (repair.result.sessionId) writeAsyncResultFile(resultPath, repair.result);
 	writeAtomicJson(path.join(asyncDir, "status.json"), repair.status);
 	if (repair.status.processTerminal?.state === "observed") releaseActiveRunIndex(asyncDir);
 	appendJsonlBestEffort(path.join(asyncDir, "events.jsonl"), {
@@ -268,10 +268,10 @@ function writeFailedRepair(asyncDir: string, status: AsyncStatus, resultPath: st
 		ts: now,
 		runId: repair.status.runId,
 		pid: status.pid,
-		resultPath,
+		...(repair.result.sessionId ? { resultPath } : {}),
 		message: repair.message,
 	});
-	return { status: repair.status, repaired: true, resultPath, message: repair.message };
+	return { status: repair.status, repaired: true, ...(repair.result.sessionId ? { resultPath } : {}), message: repair.message };
 }
 
 function terminal(state: AsyncStatus["state"]): boolean {

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
-import { resultFilePath, writeAsyncResultFile } from "./result-files.ts";
+import { resultFilePath, resultPayloadPathForSessionRun, writeAsyncResultFile } from "./result-files.ts";
 import { releaseActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { DIRS, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSummary, type SubagentRunMode } from "../../shared/types.ts";
@@ -99,14 +99,23 @@ interface ResultChildOutcome {
 }
 
 interface ResultRepairData {
-	state: "complete" | "failed" | "paused" | "stopped";
+	state: "complete" | "failed" | "paused" | "stopped" | "rejected";
 	results?: ResultChildOutcome[];
+}
+
+function regularFileExists(filePath: string): boolean {
+	try {
+		return fs.statSync(filePath).isFile();
+	} catch (error) {
+		if (isNotFoundError(error)) return false;
+		throw error;
+	}
 }
 
 function readResultRepairData(resultPath: string): ResultRepairData | undefined {
 	try {
 		const data = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { success?: boolean; state?: string; exitCode?: number; results?: unknown };
-		const state = data.success ? "complete" : data.state === "stopped" ? "stopped" : data.state === "paused" || data.exitCode === 0 ? "paused" : "failed";
+		const state = data.success ? "complete" : data.state === "stopped" ? "stopped" : data.state === "rejected" ? "rejected" : data.state === "paused" || data.exitCode === 0 ? "paused" : "failed";
 		const results = Array.isArray(data.results)
 			? data.results.map((entry, index) => {
 				if (!entry || typeof entry !== "object" || Array.isArray(entry)) return {};
@@ -125,7 +134,7 @@ function readResultRepairData(resultPath: string): ResultRepairData | undefined 
 	}
 }
 
-function childState(overallState: ResultRepairData["state"], child: ResultChildOutcome | undefined): "complete" | "failed" | "paused" | "stopped" {
+function childState(overallState: ResultRepairData["state"], child: ResultChildOutcome | undefined): ResultRepairData["state"] {
 	if (child?.success === true) return "complete";
 	if (child?.success === false) return "failed";
 	return overallState;
@@ -275,7 +284,7 @@ function writeFailedRepair(asyncDir: string, status: AsyncStatus, resultPath: st
 }
 
 function terminal(state: AsyncStatus["state"]): boolean {
-	return state === "complete" || state === "failed" || state === "paused" || state === "stopped";
+	return state === "complete" || state === "failed" || state === "paused" || state === "stopped" || state === "rejected";
 }
 
 function* nestedRuns(children: NestedRunSummary[] | undefined): Generator<NestedRunSummary> {
@@ -345,17 +354,21 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 		if (stepRecord.thinking !== undefined && typeof stepRecord.thinking !== "string") throw new Error(`Invalid async status file '${statusPath}': steps[${index}].thinking must be a string.`);
 	}
 	const runId = effectiveStatus.runId || path.basename(asyncDir);
-	const resultPath = resultFilePath(options.resultsDir ?? DIRS.results, runId);
-	if (fs.existsSync(resultPath)) {
+	const resultsDir = options.resultsDir ?? DIRS.results;
+	const resultPath = resultFilePath(resultsDir, runId);
+	const existingResultPath = effectiveStatus.sessionId
+		? resultPayloadPathForSessionRun(resultsDir, effectiveStatus.sessionId, runId) ?? (regularFileExists(resultPath) ? resultPath : undefined)
+		: regularFileExists(resultPath) ? resultPath : undefined;
+	if (existingResultPath) {
 		const terminalStatus = effectiveStatus.state === "running" || effectiveStatus.state === "queued"
-			? terminalStatusFromResult(effectiveStatus, resultPath, now)
+			? terminalStatusFromResult(effectiveStatus, existingResultPath, now)
 			: undefined;
 		if (terminalStatus) {
 			writeAtomicJson(path.join(asyncDir, "status.json"), terminalStatus);
 			if (terminalStatus.processTerminal?.state === "observed") releaseActiveRunIndex(asyncDir);
-			return { status: terminalStatus, repaired: true, resultPath, message: "Existing async result file was used to repair stale running status." };
+			return { status: terminalStatus, repaired: true, resultPath: existingResultPath, message: "Existing async result file was used to repair stale running status." };
 		}
-		if (effectiveStatus.displayDismissedAt === undefined) return { status: effectiveStatus, repaired: false, resultPath };
+		if (effectiveStatus.displayDismissedAt === undefined) return { status: effectiveStatus, repaired: false, resultPath: existingResultPath };
 	}
 	if (effectiveStatus.displayDismissedAt !== undefined) {
 		return { status: null, repaired: false, resultPath };

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { writeAsyncResultFile } from "./result-files.ts";
 import { createFileCoalescer } from "../../shared/file-coalescer.ts";
 import { isActiveAsyncState, updateActiveRunIndex } from "./active-run-index.ts";
 import { createChildTranscriptWriter, type ChildTranscriptWriter } from "../../shared/child-transcript.ts";
@@ -2268,7 +2269,7 @@ async function runSubagent(
 
 	fs.mkdirSync(asyncDir, { recursive: true });
 	writeAtomicJson(statusPath, statusPayload);
-	updateActiveRunIndex(asyncDir, statusPayload.state);
+	updateActiveRunIndex(asyncDir, statusPayload.state, statusPayload.toolCallId);
 	let pendingParallelUsageCost: CostSummary = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
 	const currentUsageTotals = (): CostSummary => {
 		const cost = results.reduce<CostSummary>((sum, result) => ({
@@ -2346,8 +2347,8 @@ async function runSubagent(
 		refreshWorkflowGraph();
 		writeAtomicJson(statusPath, statusPayload);
 		const activeState = isActiveAsyncState(statusPayload.state);
-		if (activeState && activeState !== lastIndexedActiveState) {
-			updateActiveRunIndex(asyncDir, statusPayload.state);
+		if (activeState !== lastIndexedActiveState) {
+			updateActiveRunIndex(asyncDir, statusPayload.state, statusPayload.toolCallId);
 		}
 		lastIndexedActiveState = activeState;
 		emitNestedSelfEvent(statusPayload.state === "running" || statusPayload.state === "queued" ? "subagent.nested.updated" : "subagent.nested.completed");
@@ -4690,7 +4691,7 @@ async function runSubagent(
 	}
 	writeStatusPayload();
 	try {
-		writeAtomicJson(resultPath, {
+		writeAsyncResultFile(resultPath, {
 			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
 			id,
 			agent: agentName,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
-import { writeAsyncResultFile } from "./result-files.ts";
+import { writeAsyncResultFile, writePendingAsyncResultFile } from "./result-files.ts";
 import { createFileCoalescer } from "../../shared/file-coalescer.ts";
 import { isActiveAsyncState, updateActiveRunIndex } from "./active-run-index.ts";
 import { createChildTranscriptWriter, type ChildTranscriptWriter } from "../../shared/child-transcript.ts";
@@ -2342,9 +2342,66 @@ async function runSubagent(
 		for (const node of graph.nodes) updateNode(node);
 		statusPayload.workflowGraph = graph;
 	};
+	let finalResultCommitted = false;
 	let lastIndexedActiveState = isActiveAsyncState(statusPayload.state);
+	const statusResultState = (): AsyncStatus["state"] | undefined => {
+		if (statusPayload.state === "running" || statusPayload.state === "queued") return undefined;
+		if (statusPayload.state === "paused" && statusPayload.checkpoint?.status === "pending") return undefined;
+		return statusPayload.state;
+	};
+	const statusResultSummary = (state: AsyncStatus["state"]): string => {
+		if (statusPayload.error) return statusPayload.error;
+		if (state === "paused") return "Paused after interrupt. Waiting for explicit next action.";
+		if (state === "stopped") return stopMessage;
+		if (state === "rejected") return statusPayload.checkpoint?.name ? `Checkpoint '${statusPayload.checkpoint.name}' rejected.` : "Subagent rejected.";
+		return state === "complete" ? "Subagent completed." : "Subagent failed.";
+	};
+	const statusResultSuccess = (state: AsyncStatus["state"], step: RunnerStatusStep): boolean | undefined => {
+		if (step.status === "complete" || step.status === "completed") return true;
+		if (step.status === "failed" || step.status === "stopped" || step.status === "rejected") return false;
+		if (state === "complete") return true;
+		if (state === "failed" || state === "stopped" || state === "rejected") return false;
+		return undefined;
+	};
+	const writeRecoverableStatusResult = (): void => {
+		const state = statusResultState();
+		if (!state || finalResultCommitted || !config.sessionId) return;
+		const now = statusPayload.endedAt ?? statusPayload.lastUpdate ?? Date.now();
+		const summary = statusResultSummary(state);
+		writePendingAsyncResultFile(resultPath, omitUndefinedProperties({
+			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
+			id,
+			runId: id,
+			agent: statusPayload.steps.length === 1 ? statusPayload.steps[0]!.agent : statusPayload.mode === "parallel" ? `parallel:${statusPayload.steps.map((step) => step.agent).join("+")}` : `chain:${statusPayload.steps.map((step) => step.agent).join("->")}`,
+			mode: statusPayload.mode,
+			success: state === "complete",
+			state,
+			summary,
+			error: state === "failed" || state === "stopped" || state === "rejected" ? summary : undefined,
+			stopped: state === "stopped" ? true : undefined,
+			checkpoint: statusPayload.checkpoint,
+			results: statusPayload.steps.map((step) => omitUndefinedProperties({
+				agent: step.agent,
+				output: step.status === "complete" || step.status === "completed" ? "" : step.error ?? summary,
+				error: step.error,
+				success: statusResultSuccess(state, step),
+				sessionFile: step.sessionFile,
+				model: step.model,
+				attemptedModels: step.attemptedModels,
+				modelAttempts: step.modelAttempts,
+			})),
+			exitCode: state === "complete" || state === "paused" ? 0 : 1,
+			timestamp: now,
+			durationMs: Math.max(0, now - overallStartTime),
+			asyncDir,
+			cwd,
+			sessionId: config.sessionId,
+			sessionFile: statusPayload.sessionFile ?? latestSessionFile,
+		}));
+	};
 	const writeStatusPayloadNow = (): void => {
 		refreshWorkflowGraph();
+		writeRecoverableStatusResult();
 		writeAtomicJson(statusPath, statusPayload);
 		const activeState = isActiveAsyncState(statusPayload.state);
 		if (activeState !== lastIndexedActiveState) {
@@ -4689,7 +4746,6 @@ async function runSubagent(
 			statusPayload.error = `Step failed: ${failedStep.agent}`;
 		}
 	}
-	writeStatusPayload();
 	try {
 		writeAsyncResultFile(resultPath, {
 			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
@@ -4786,9 +4842,15 @@ async function runSubagent(
 			...(taskIndex !== undefined && { taskIndex }),
 			...(totalTasks !== undefined && { totalTasks }),
 		});
+		finalResultCommitted = true;
 	} catch (err) {
-		console.error(`Failed to write result file ${resultPath}:`, err);
+		const message = `Failed to write result file ${resultPath}: ${err instanceof Error ? err.message : String(err)}`;
+		console.error(message, err);
+		statusPayload.state = "failed";
+		statusPayload.error = message;
+		statusPayload.lastUpdate = Date.now();
 	}
+	writeStatusPayload();
 	appendJsonl(
 		eventsPath,
 		JSON.stringify({

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -267,6 +267,7 @@ function activeRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps
 		resultsDir,
 		kill: deps.kill,
 		now: deps.now,
+		includeNested: false,
 		...(params.id ? { runId: params.id } : {}),
 	});
 	return params.id ? runs.filter((run) => matchesId(run, params.id!)) : runs;
@@ -286,6 +287,7 @@ function allRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps): 
 		resultsDir,
 		kill: deps.kill,
 		now: deps.now,
+		includeNested: false,
 		...(params.id ? { runId: params.id } : {}),
 	});
 	return params.id ? runs.filter((run) => matchesId(run, params.id!)) : runs;

--- a/src/runs/background/wait-completions.ts
+++ b/src/runs/background/wait-completions.ts
@@ -1,8 +1,8 @@
 import * as fs from "node:fs";
-import * as path from "node:path";
 import type { ArtifactPaths, SubagentState, WaitCompletion, WaitCompletionChild } from "../../shared/types.ts";
 import type { AsyncRunSummary } from "./async-status.ts";
 import { readCompletionReplay, writeCompletionReplay } from "./completion-replay.ts";
+import { resultFilePath } from "./result-files.ts";
 
 function asNonEmptyString(value: unknown): string | undefined {
 	return typeof value === "string" && value ? value : undefined;
@@ -114,7 +114,7 @@ export function collectWaitCompletions(terminal: AsyncRunSummary[], state: Subag
 			completions.push(recorded.completion);
 			continue;
 		}
-		const resultPath = path.join(resultsDir, `${run.id}.json`);
+		const resultPath = resultFilePath(resultsDir, run.id);
 		try {
 			const raw = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as Record<string, unknown>;
 			completions.push(toWaitCompletion(raw, run.id));

--- a/src/runs/background/wait-completions.ts
+++ b/src/runs/background/wait-completions.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import type { ArtifactPaths, SubagentState, WaitCompletion, WaitCompletionChild } from "../../shared/types.ts";
 import type { AsyncRunSummary } from "./async-status.ts";
 import { readCompletionReplay, writeCompletionReplay } from "./completion-replay.ts";
-import { resultFilePath } from "./result-files.ts";
+import { resultFilePath, resultPayloadPathForSessionRun } from "./result-files.ts";
 
 function asNonEmptyString(value: unknown): string | undefined {
 	return typeof value === "string" && value ? value : undefined;
@@ -114,7 +114,10 @@ export function collectWaitCompletions(terminal: AsyncRunSummary[], state: Subag
 			completions.push(recorded.completion);
 			continue;
 		}
-		const resultPath = resultFilePath(resultsDir, run.id);
+		const publicResultPath = resultFilePath(resultsDir, run.id);
+		const resultPath = run.sessionId
+			? resultPayloadPathForSessionRun(resultsDir, run.sessionId, run.id) ?? publicResultPath
+			: publicResultPath;
 		try {
 			const raw = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as Record<string, unknown>;
 			completions.push(toWaitCompletion(raw, run.id));

--- a/src/runs/foreground/async-dismiss-action.ts
+++ b/src/runs/foreground/async-dismiss-action.ts
@@ -6,6 +6,7 @@ import { DIRS, type Details, type SubagentState } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { updateActiveRunIndex } from "../background/active-run-index.ts";
 import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
+import { resultFilePath } from "../background/result-files.ts";
 
 export function dismissRecoveredWorkflow(
 	state: SubagentState,
@@ -50,7 +51,7 @@ export function dismissRecoveredWorkflow(
 		};
 	}
 	let latestStatus = status;
-	const resultPath = path.join(DIRS.results, `${status.runId}.json`);
+	const resultPath = resultFilePath(DIRS.results, status.runId);
 	if (fs.existsSync(resultPath)) {
 		const reconciled = reconcileAsyncRun(asyncDir).status;
 		if (reconciled && reconciled.state !== "running") {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -101,6 +101,7 @@ import { stopAsyncRun } from "./async-stop-action.ts";
 import { dismissRecoveredWorkflow } from "./async-dismiss-action.ts";
 import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
 import { resolveAsyncRootResultPath, waitForImportedAsyncRoot } from "../background/chain-root-attachment.ts";
+import { resultFilePath, writeAsyncResultFile } from "../background/result-files.ts";
 import { attachRootChildrenToSteps, createNestedRoute, findNestedControlResult, resolveInheritedNestedRouteFromEnv, resolveNestedAsyncDir, resolveNestedParentAddressFromEnv, snapshotNestedEventFiles, updateForegroundNestedProjection, writeNestedControlRequest, writeNestedEvent, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 import { resolveSubagentRunId, type ResolvedSubagentRunId } from "../background/run-id-resolver.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
@@ -4916,7 +4917,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			if (workflowRunId) {
 				const toolCallId = _id;
 				const asyncDir = path.join(DIRS.async, workflowRunId);
-				const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
+				const resultPath = resultFilePath(DIRS.results, workflowRunId);
 				const statusPath = path.join(asyncDir, "status.json");
 				const eventsPath = path.join(asyncDir, "events.jsonl");
 				const startedAt = Date.now();
@@ -4955,7 +4956,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					status.lastUpdate = Date.now();
 					writeAtomicJson(statusPath, status);
 					if (indexedState !== status.state) {
-						updateActiveRunIndex(asyncDir, status.state);
+						updateActiveRunIndex(asyncDir, status.state, status.toolCallId);
 						indexedState = status.state;
 					}
 					const job = deps.state.asyncJobs.get(workflowRunId);
@@ -5184,7 +5185,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const resultSummary = appendWorkflowOutputWarning(summary, outputWarning);
 						const workflowUsage = sumResultsUsage(workflowResults);
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: workflow.trace, emits: workflow.emits, console: workflow.console }, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
-						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
+						writeAsyncResultFile(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: "complete" });
 					} catch (error) {
@@ -5193,7 +5194,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						status = compactOptional<AsyncStatus>({ ...status, state: stopped ? "stopped" : "failed", stopped: stopped || undefined, error: error instanceof Error ? error.message : String(error), endedAt: Date.now(), workflow: { trace: partial.trace, emits: partial.emits, console: partial.console } });
 						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, status.error ?? "Workflow failed.");
 						const resultSummary = appendWorkflowOutputWarning(status.error ?? "Workflow failed.", outputWarning);
-						writeAtomicJson(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: resultSummary, error: status.error, stopped: status.stopped, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
+						writeAsyncResultFile(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: resultSummary, error: status.error, stopped: status.stopped, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, error: status.error });
 					} finally {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4981,6 +4981,17 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						job.workflow = status.workflow;
 					}
 				};
+				const writeWorkflowResult = (payload: Record<string, unknown>): boolean => {
+					try {
+						writeAsyncResultFile(resultPath, payload);
+						return true;
+					} catch (error) {
+						const message = `Failed to write async workflow result ${resultPath}: ${error instanceof Error ? error.message : String(error)}`;
+						console.error(message, error);
+						appendWorkflowEvent({ type: "subagent.workflow.result_write_failed", error: message });
+						return false;
+					}
+				};
 				const projectWorkflowActivity = () => {
 					const steps = status.steps ?? [];
 					const runningSteps = steps.filter((step) => step.status === "running");
@@ -5185,16 +5196,16 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const resultSummary = appendWorkflowOutputWarning(summary, outputWarning);
 						const workflowUsage = sumResultsUsage(workflowResults);
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: workflow.trace, emits: workflow.emits, console: workflow.console }, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
-						writeAsyncResultFile(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
-						appendWorkflowEvent({ type: "subagent.workflow.completed", state: "complete" });
+						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(status.error ? { error: status.error } : {}) });
 					} catch (error) {
 						const partial = error instanceof WorkflowScriptError ? error.partial : { trace: [], emits: [], console: [], children: [] };
 						const stopped = controller.signal.aborted;
 						status = compactOptional<AsyncStatus>({ ...status, state: stopped ? "stopped" : "failed", stopped: stopped || undefined, error: error instanceof Error ? error.message : String(error), endedAt: Date.now(), workflow: { trace: partial.trace, emits: partial.emits, console: partial.console } });
 						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, status.error ?? "Workflow failed.");
 						const resultSummary = appendWorkflowOutputWarning(status.error ?? "Workflow failed.", outputWarning);
-						writeAsyncResultFile(resultPath, { id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: resultSummary, error: status.error, stopped: status.stopped, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt });
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: resultSummary, error: status.error, stopped: status.stopped, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, error: status.error });
 					} finally {

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -135,9 +135,9 @@ export function createNestedRoute(rootRunId: string): NestedRoute {
 	fs.mkdirSync(eventSink, { recursive: true, mode: 0o700 });
 	fs.mkdirSync(controlInbox, { recursive: true, mode: 0o700 });
 	const createdAt = Date.now();
-	fs.writeFileSync(path.join(routeRoot, ROUTE_FILE), `${JSON.stringify({ rootRunId, capabilityToken, createdAt })}\n`, { mode: 0o600 });
 	fs.mkdirSync(routeIndexDir(rootRunId), { recursive: true, mode: 0o700 });
 	writeAtomicJson(routeIndexPath(rootRunId, capabilityToken), { rootRunId, capabilityToken, routeRoot: path.basename(routeRoot), createdAt });
+	writeAtomicJson(path.join(routeRoot, ROUTE_FILE), { rootRunId, capabilityToken, createdAt });
 	return { rootRunId, eventSink, controlInbox, capabilityToken };
 }
 
@@ -546,8 +546,7 @@ function routeFromIndexEntry(rootRunId: string, filePath: string): NestedRoute |
 		};
 		validateRouteShape(route);
 		return route;
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") fs.rmSync(filePath, { force: true });
+	} catch {
 		return undefined;
 	}
 }

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -34,6 +34,7 @@ import { THINKING_LEVELS } from "../../shared/model-info.ts";
 export const NESTED_EVENTS_DIR = path.join(TEMP_ROOT_DIR, "nested-subagent-events");
 const ROUTE_FILE = "route.json";
 const REGISTRY_FILE = "registry.json";
+const ROUTE_INDEX_DIR = ".route-index";
 const MAX_EVENT_BYTES = 64 * 1024;
 const MAX_STEPS = 12;
 const MAX_CHILDREN = 16;
@@ -105,6 +106,18 @@ function commonRouteRoot(route: Pick<NestedRoute, "eventSink" | "controlInbox">)
 	return path.dirname(path.resolve(route.eventSink));
 }
 
+function routeIndexRoot(): string {
+	return path.join(NESTED_EVENTS_DIR, ROUTE_INDEX_DIR, "roots");
+}
+
+function routeIndexDir(rootRunId: string): string {
+	return path.join(routeIndexRoot(), encodeURIComponent(rootRunId));
+}
+
+function routeIndexPath(rootRunId: string, capabilityToken: string): string {
+	return path.join(routeIndexDir(rootRunId), `${encodeURIComponent(capabilityToken)}.json`);
+}
+
 function validateRouteShape(route: NestedRoute): void {
 	assertSafeId("rootRunId", route.rootRunId);
 	assertSafeId("capabilityToken", route.capabilityToken);
@@ -121,7 +134,10 @@ export function createNestedRoute(rootRunId: string): NestedRoute {
 	const controlInbox = path.join(routeRoot, "controls");
 	fs.mkdirSync(eventSink, { recursive: true, mode: 0o700 });
 	fs.mkdirSync(controlInbox, { recursive: true, mode: 0o700 });
-	fs.writeFileSync(path.join(routeRoot, ROUTE_FILE), `${JSON.stringify({ rootRunId, capabilityToken, createdAt: Date.now() })}\n`, { mode: 0o600 });
+	const createdAt = Date.now();
+	fs.writeFileSync(path.join(routeRoot, ROUTE_FILE), `${JSON.stringify({ rootRunId, capabilityToken, createdAt })}\n`, { mode: 0o600 });
+	fs.mkdirSync(routeIndexDir(rootRunId), { recursive: true, mode: 0o700 });
+	writeAtomicJson(routeIndexPath(rootRunId, capabilityToken), { rootRunId, capabilityToken, routeRoot: path.basename(routeRoot), createdAt });
 	return { rootRunId, eventSink, controlInbox, capabilityToken };
 }
 
@@ -515,68 +531,47 @@ function registryPath(route: NestedRoute): string {
 	return path.join(commonRouteRoot(route), REGISTRY_FILE);
 }
 
+function routeFromIndexEntry(rootRunId: string, filePath: string): NestedRoute | undefined {
+	try {
+		const metadata = JSON.parse(fs.readFileSync(filePath, "utf-8")) as { rootRunId?: unknown; capabilityToken?: unknown; routeRoot?: unknown };
+		if (metadata.rootRunId !== rootRunId || typeof metadata.capabilityToken !== "string" || typeof metadata.routeRoot !== "string") return undefined;
+		const routeRoot = path.join(NESTED_EVENTS_DIR, path.basename(metadata.routeRoot));
+		const routeFile = JSON.parse(fs.readFileSync(path.join(routeRoot, ROUTE_FILE), "utf-8")) as { rootRunId?: unknown; capabilityToken?: unknown };
+		if (routeFile.rootRunId !== rootRunId || routeFile.capabilityToken !== metadata.capabilityToken) return undefined;
+		const route = {
+			rootRunId,
+			eventSink: path.join(routeRoot, "events"),
+			controlInbox: path.join(routeRoot, "controls"),
+			capabilityToken: metadata.capabilityToken,
+		};
+		validateRouteShape(route);
+		return route;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") fs.rmSync(filePath, { force: true });
+		return undefined;
+	}
+}
+
 export function findNestedRouteForRootId(rootRunId: string): NestedRoute | undefined {
 	assertSafeId("rootRunId", rootRunId);
 	let entries: string[];
 	try {
-		entries = fs.readdirSync(NESTED_EVENTS_DIR);
+		entries = fs.readdirSync(routeIndexDir(rootRunId));
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
 		throw error;
 	}
 	for (const entry of entries) {
-		if (!entry.startsWith(`${rootRunId}-`)) continue;
-		const routeRoot = path.join(NESTED_EVENTS_DIR, entry);
-		try {
-			const metadata = JSON.parse(fs.readFileSync(path.join(routeRoot, ROUTE_FILE), "utf-8")) as { rootRunId?: unknown; capabilityToken?: unknown };
-			if (metadata.rootRunId !== rootRunId || typeof metadata.capabilityToken !== "string") continue;
-			const route = {
-				rootRunId,
-				eventSink: path.join(routeRoot, "events"),
-				controlInbox: path.join(routeRoot, "controls"),
-				capabilityToken: metadata.capabilityToken,
-			};
-			validateRouteShape(route);
-			return route;
-		} catch {
-			continue;
-		}
+		const route = routeFromIndexEntry(rootRunId, path.join(routeIndexDir(rootRunId), entry));
+		if (route) return route;
 	}
 	return undefined;
 }
 
-/**
- * Scan the nested-events directory once and index every route by its root run
- * id. Use this when resolving routes for many runs (e.g. listAsyncRuns) so the
- * cost is O(routes) total instead of O(runs * routes) from calling
- * findNestedRouteForRootId per run.
- */
 export function buildNestedRouteIndex(): Map<string, NestedRoute> {
-	let entries: string[];
-	try {
-		entries = fs.readdirSync(NESTED_EVENTS_DIR);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map();
-		throw error;
-	}
 	const index = new Map<string, NestedRoute>();
-	for (const entry of entries) {
-		const routeRoot = path.join(NESTED_EVENTS_DIR, entry);
-		try {
-			const metadata = JSON.parse(fs.readFileSync(path.join(routeRoot, ROUTE_FILE), "utf-8")) as { rootRunId?: unknown; capabilityToken?: unknown };
-			if (typeof metadata.rootRunId !== "string" || typeof metadata.capabilityToken !== "string") continue;
-			if (index.has(metadata.rootRunId)) continue;
-			const route: NestedRoute = {
-				rootRunId: metadata.rootRunId,
-				eventSink: path.join(routeRoot, "events"),
-				controlInbox: path.join(routeRoot, "controls"),
-				capabilityToken: metadata.capabilityToken,
-			};
-			validateRouteShape(route);
-			index.set(metadata.rootRunId, route);
-		} catch {
-			continue;
-		}
+	for (const route of listNestedRoutes()) {
+		if (!index.has(route.rootRunId)) index.set(route.rootRunId, route);
 	}
 	return index;
 }
@@ -630,27 +625,26 @@ function collectScopedNestedRuns(children: NestedRunSummary[] | undefined, scope
 }
 
 function listNestedRoutes(): NestedRoute[] {
-	let entries: string[];
+	let rootEntries: string[];
 	try {
-		entries = fs.readdirSync(NESTED_EVENTS_DIR);
+		rootEntries = fs.readdirSync(routeIndexRoot());
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
 		throw error;
 	}
 	const routes: NestedRoute[] = [];
-	for (const entry of entries) {
-		const routeRoot = path.join(NESTED_EVENTS_DIR, entry);
+	for (const rootEntry of rootEntries) {
+		let rootRunId: string;
 		try {
-			const metadata = JSON.parse(fs.readFileSync(path.join(routeRoot, ROUTE_FILE), "utf-8")) as { rootRunId?: unknown; capabilityToken?: unknown };
-			if (typeof metadata.rootRunId !== "string" || typeof metadata.capabilityToken !== "string") continue;
-			const route = {
-				rootRunId: metadata.rootRunId,
-				eventSink: path.join(routeRoot, "events"),
-				controlInbox: path.join(routeRoot, "controls"),
-				capabilityToken: metadata.capabilityToken,
-			};
-			validateRouteShape(route);
-			routes.push(route);
+			rootRunId = decodeURIComponent(rootEntry);
+		} catch {
+			continue;
+		}
+		try {
+			for (const entry of fs.readdirSync(path.join(routeIndexRoot(), rootEntry))) {
+				const route = routeFromIndexEntry(rootRunId, path.join(routeIndexRoot(), rootEntry, entry));
+				if (route) routes.push(route);
+			}
 		} catch {
 			continue;
 		}

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -533,11 +533,9 @@ function registryPath(route: NestedRoute): string {
 
 function routeFromIndexEntry(rootRunId: string, filePath: string): NestedRoute | undefined {
 	try {
-		const metadata = JSON.parse(fs.readFileSync(filePath, "utf-8")) as { rootRunId?: unknown; capabilityToken?: unknown; routeRoot?: unknown };
+		const metadata = JSON.parse(fs.readFileSync(filePath, "utf-8")) as { rootRunId?: unknown; capabilityToken?: unknown; routeRoot?: unknown; createdAt?: unknown };
 		if (metadata.rootRunId !== rootRunId || typeof metadata.capabilityToken !== "string" || typeof metadata.routeRoot !== "string") return undefined;
 		const routeRoot = path.join(NESTED_EVENTS_DIR, path.basename(metadata.routeRoot));
-		const routeFile = JSON.parse(fs.readFileSync(path.join(routeRoot, ROUTE_FILE), "utf-8")) as { rootRunId?: unknown; capabilityToken?: unknown };
-		if (routeFile.rootRunId !== rootRunId || routeFile.capabilityToken !== metadata.capabilityToken) return undefined;
 		const route = {
 			rootRunId,
 			eventSink: path.join(routeRoot, "events"),
@@ -545,6 +543,19 @@ function routeFromIndexEntry(rootRunId: string, filePath: string): NestedRoute |
 			capabilityToken: metadata.capabilityToken,
 		};
 		validateRouteShape(route);
+		if (!fs.statSync(route.eventSink).isDirectory() || !fs.statSync(route.controlInbox).isDirectory()) return undefined;
+		const routeFilePath = path.join(routeRoot, ROUTE_FILE);
+		try {
+			const routeFile = JSON.parse(fs.readFileSync(routeFilePath, "utf-8")) as { rootRunId?: unknown; capabilityToken?: unknown };
+			if (routeFile.rootRunId !== rootRunId || routeFile.capabilityToken !== metadata.capabilityToken) return undefined;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") return undefined;
+			try {
+				writeAtomicJson(routeFilePath, { rootRunId, capabilityToken: metadata.capabilityToken, createdAt: typeof metadata.createdAt === "number" ? metadata.createdAt : Date.now() });
+			} catch {
+				// The route index already carries enough data for reload lookup.
+			}
+		}
 		return route;
 	} catch {
 		return undefined;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -476,6 +476,52 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(typeof result, "boolean");
 	});
 
+	it("does not persist terminal async workflow status when the result index write fails", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const id = `async-workflow-result-index-failure-${Date.now().toString(36)}`;
+		const resultIndexPath = path.join(RESULTS_DIR, "result-index");
+		let asyncDir: string | undefined;
+		let resultPath: string | undefined;
+		let pendingPath: string | undefined;
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			fs.rmSync(resultIndexPath, { recursive: true, force: true });
+			fs.mkdirSync(RESULTS_DIR, { recursive: true });
+			fs.writeFileSync(resultIndexPath, "not a directory", "utf-8");
+			const executor = makeAsyncExecutor([]);
+			const context = makeMinimalCtx(tempDir);
+			context.sessionManager.getSessionId = () => "session-workflow-index";
+
+			const launch = await executor.execute(id, { workflowScript: "return 'done'", async: true }, new AbortController().signal, undefined, context);
+			assert.equal(launch.isError, undefined);
+			const asyncId = launch.details?.asyncId;
+			assert.ok(asyncId, "expected async workflow id");
+			asyncDir = path.join(ASYNC_DIR, asyncId);
+			resultPath = path.join(RESULTS_DIR, `${asyncId}.json`);
+			pendingPath = path.join(RESULTS_DIR, "result-pending", encodeURIComponent("session-workflow-index"), `${encodeURIComponent(asyncId)}.json`);
+
+			const eventsPath = path.join(asyncDir, "events.jsonl");
+			const deadline = Date.now() + 5_000;
+			let eventsText = "";
+			while (Date.now() <= deadline) {
+				eventsText = readIfExists(eventsPath) ?? "";
+				if (eventsText.includes("subagent.workflow.result_write_failed")) break;
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+			assert.match(eventsText, /subagent\.workflow\.result_write_failed/);
+			const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")) as AsyncStatusPayload;
+			assert.equal(status.state, "running");
+			assert.equal(fs.existsSync(resultPath), false);
+			assert.equal(fs.existsSync(pendingPath), true);
+		} finally {
+			console.error = originalError;
+			if (asyncDir) fs.rmSync(asyncDir, { recursive: true, force: true });
+			if (resultPath) fs.rmSync(resultPath, { recursive: true, force: true });
+			if (pendingPath) fs.rmSync(pendingPath, { force: true });
+			fs.rmSync(resultIndexPath, { recursive: true, force: true });
+		}
+	});
+
 	it("background parses split UTF-8 JSON and a final unterminated protocol line", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		const line = Buffer.from(JSON.stringify(events.assistantMessage("你好 from fragmented async JSON")));
 		const unicodeStart = line.indexOf(Buffer.from("你"));
@@ -487,7 +533,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.results[0]?.output, "你好 from fragmented async JSON");
 	});
 
-	it("persists terminal status before creating the result artifact", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+	it("persists terminal status with the result artifact", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ output: "completed output" });
 		const id = `async-terminal-status-${Date.now().toString(36)}`;
 		launchProtocolTest(id);

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -465,14 +465,16 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		try {
 			const runDir = path.join(asyncRoot, "run-nested-events");
 			fs.mkdirSync(runDir, { recursive: true });
-			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+			const statusPath = path.join(runDir, "status.json");
+			const statusPayload = {
 				runId: "run-nested-events",
 				mode: "single",
 				state: "running",
 				startedAt: 1000,
 				lastUpdate: 2000,
 				steps: [{ agent: "worker", status: "running" }],
-			}), "utf-8");
+			};
+			fs.writeFileSync(statusPath, JSON.stringify(statusPayload), "utf-8");
 			const state = createState();
 			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 60_000 });
 			tracker.handleStarted({ id: "run-nested-events", asyncDir: runDir, agent: "worker", nestedRoute });
@@ -495,8 +497,9 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 					agent: "nested-worker",
 				},
 			}), "utf-8");
+			fs.writeFileSync(statusPath, JSON.stringify({ ...statusPayload, lastUpdate: 3000 }), "utf-8");
 
-			await waitForCondition(() => state.asyncJobs.get("run-nested-events")?.nestedChildren?.[0]?.id === "nested-child", "evented nested child refresh", 1000);
+			await waitForCondition(() => state.asyncJobs.get("run-nested-events")?.nestedChildren?.[0]?.id === "nested-child", "evented nested child refresh", 3000);
 			assert.equal(state.asyncJobs.get("run-nested-events")?.steps?.[0]?.children?.[0]?.id, "nested-child");
 			tracker.resetJobs();
 		} finally {

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -853,6 +853,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				runId: "run-stale",
 				mode: "single",
 				state: "running",
+				sessionId: "session-stale",
 				pid: 12345,
 				startedAt: Date.now() - 1000,
 				lastUpdate: Date.now() - 1000,
@@ -870,7 +871,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				now: () => Date.now(),
 			});
 			tracker.resetJobs(ui.ctx as never);
-			tracker.handleStarted({ id: "run-stale", asyncDir: runDir, agent: "worker" });
+			tracker.handleStarted({ id: "run-stale", asyncDir: runDir, agent: "worker", sessionId: "session-stale" });
 
 			await waitForCondition(() => state.asyncJobs.size === 0, "stale async job cleanup");
 

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -344,8 +344,9 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		const routeRoot = path.dirname(nestedRoute.eventSink);
 		try {
 			const runDir = path.join(asyncRoot, "run-restored-nested");
+			const statusPath = path.join(runDir, "status.json");
 			fs.mkdirSync(runDir, { recursive: true });
-			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+			const statusPayload = {
 				runId: "run-restored-nested",
 				mode: "single",
 				state: "running",
@@ -353,7 +354,8 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				startedAt: 1000,
 				lastUpdate: 2000,
 				steps: [{ agent: "worker", status: "running" }],
-			}), "utf-8");
+			};
+			fs.writeFileSync(statusPath, JSON.stringify(statusPayload), "utf-8");
 			updateActiveRunIndex(runDir, "running");
 			const state = createState();
 			state.currentSessionId = "session-restored-nested";
@@ -379,8 +381,9 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 					agent: "nested-worker",
 				},
 			}), "utf-8");
+			fs.writeFileSync(statusPath, JSON.stringify({ ...statusPayload, lastUpdate: 3001 }), "utf-8");
 
-			await waitForCondition(() => state.asyncJobs.get("run-restored-nested")?.nestedChildren?.[0]?.id === "nested-child", "restored evented nested child refresh", 1000);
+			await waitForCondition(() => state.asyncJobs.get("run-restored-nested")?.nestedChildren?.[0]?.id === "nested-child", "restored evented nested child refresh", 3000);
 			assert.equal(state.asyncJobs.get("run-restored-nested")?.steps?.[0]?.children?.[0]?.id, "nested-child");
 			tracker.resetJobs();
 		} finally {

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -376,6 +376,7 @@ describe("async status helpers", () => {
 		try {
 			const asyncDir = createAsyncDir(root, "run-stale", {
 				runId: "run-stale",
+				sessionId: "session-stale",
 				mode: "single",
 				state: "running",
 				pid: 12345,

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { formatAsyncRunList, listAsyncRuns } from "../../src/runs/background/async-status.ts";
-import { ACTIVE_RUN_INDEX_DIR, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
+import { ACTIVE_RUN_INDEX_DIR, DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { claimRunFanoutBatch, createRunFanoutBudget, writeRunFanoutBudgetDescriptor } from "../../src/runs/shared/run-fanout-budget.ts";
 
 function createAsyncDir(root: string, id: string, status: Record<string, unknown>): string {
@@ -635,6 +635,31 @@ describe("async status helpers", () => {
 				instances: [{ kind: "runner", processInstanceId: "runner", closeObservedAt: 300, exitCode: 0, signal: null }],
 			}), "utf-8");
 			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false }), []);
+			assert.equal(fs.existsSync(markerPath), false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("prunes old terminal active markers without process-terminal proof", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-index-aged-prune-"));
+		try {
+			const asyncDir = createAsyncDir(root, "finished", {
+				runId: "finished",
+				mode: "single",
+				state: "complete",
+				startedAt: 100,
+				lastUpdate: 200,
+				displayDismissedAt: 250,
+				processTerminal: { version: 1, state: "unknown", runId: "finished", runnerProcessInstanceId: "runner", reason: "process-tree-unverified" },
+				steps: [{ agent: "worker", status: "complete" }],
+			});
+			updateActiveRunIndex(asyncDir, "running");
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "finished");
+			const oldTime = new Date(1_000);
+			fs.utimesSync(markerPath, oldTime, oldTime);
+
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false, now: () => 1_000 + DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS + 1 }), []);
 			assert.equal(fs.existsSync(markerPath), false);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });

--- a/test/integration/external-cli-runner.test.ts
+++ b/test/integration/external-cli-runner.test.ts
@@ -28,6 +28,7 @@ describe("external CLI async lifecycle", () => {
 		const configPath = path.join(dir, "config.json");
 		fs.writeFileSync(configPath, JSON.stringify({
 			id: "external-lifecycle",
+			sessionId: "session-external",
 			steps: [{
 				agent: "external",
 				task: "Task text",

--- a/test/integration/external-cli-runner.test.ts
+++ b/test/integration/external-cli-runner.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
+import { resultFilesForSession } from "../../src/runs/background/result-files.ts";
 
 const tempDirs: string[] = [];
 afterEach(() => {
@@ -59,5 +60,42 @@ describe("external CLI async lifecycle", () => {
 		const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
 		assert.equal(result.success, true);
 		assert.equal(result.results[0].runner.type, "external-cli");
+	});
+
+	it("keeps terminal status recoverable when public result publish fails", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-external-pending-result-"));
+		tempDirs.push(dir);
+		const asyncDir = path.join(dir, "async");
+		fs.mkdirSync(asyncDir);
+		const resultPath = path.join(dir, "result.json");
+		fs.mkdirSync(resultPath);
+		const configPath = path.join(dir, "config.json");
+		fs.writeFileSync(configPath, JSON.stringify({
+			id: "external-pending-result",
+			sessionId: "session-external",
+			steps: [{
+				agent: "external",
+				task: "Task text",
+				runner: { type: "external-cli", command: process.execPath, args: ["-e", "process.stdout.write('ok')"] },
+				inheritProjectContext: false,
+				inheritSkills: false,
+			}],
+			resultPath,
+			cwd: dir,
+			placeholder: "{previous}",
+			artifactConfig: { enabled: false },
+			asyncDir,
+			resultMode: "single",
+		}));
+		const repo = path.resolve(import.meta.dirname, "../..");
+		const exitCode = await runProcess(process.execPath, [path.join(repo, "node_modules/jiti/lib/jiti-cli.mjs"), path.join(repo, "src/runs/background/subagent-runner.ts"), configPath], repo);
+		assert.equal(exitCode, 0);
+		const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"));
+		assert.equal(status.state, "complete");
+
+		fs.rmSync(resultPath, { recursive: true, force: true });
+		assert.deepEqual(resultFilesForSession(dir, "session-external"), ["result.json"]);
+		const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+		assert.equal(result.success, true);
 	});
 });

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -5,7 +5,8 @@ import * as path from "node:path";
 import { describe, it } from "node:test";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { buildCompletionKey } from "../../src/runs/background/completion-dedupe.ts";
-import { createResultWatcher } from "../../src/runs/background/result-watcher.ts";
+import { createResultWatcher as createRawResultWatcher } from "../../src/runs/background/result-watcher.ts";
+import { writeAsyncResultFile } from "../../src/runs/background/result-files.ts";
 import { createScheduledRunManager, scheduledRunStorePath } from "../../src/runs/background/scheduled-runs.ts";
 import { prepareMissionLaunch, writeMissionAsyncBinding } from "../../src/missions/lifecycle.ts";
 import { readMission, updateMission } from "../../src/missions/store.ts";
@@ -32,6 +33,20 @@ function createState(): SubagentState {
 	};
 }
 
+function createResultWatcher(
+	pi: Parameters<typeof createRawResultWatcher>[0],
+	state: Parameters<typeof createRawResultWatcher>[1],
+	resultsDir: Parameters<typeof createRawResultWatcher>[2],
+	completionTtlMs: Parameters<typeof createRawResultWatcher>[3],
+	deps: Parameters<typeof createRawResultWatcher>[4] = {},
+): ReturnType<typeof createRawResultWatcher> {
+	return createRawResultWatcher(pi, state, resultsDir, completionTtlMs, { coalesceDelayMs: 0, ...deps });
+}
+
+function writeIndexedResult(filePath: string, data: Record<string, unknown>): void {
+	writeAsyncResultFile(filePath, data);
+}
+
 async function waitForPredicate(predicate: () => boolean, timeoutMs = 2_500): Promise<boolean> {
 	const deadline = Date.now() + timeoutMs;
 	while (!predicate()) {
@@ -55,24 +70,25 @@ describe("result watcher", () => {
 				},
 			};
 			const state = createState();
+			state.asyncJobs.set("session-run", { asyncId: "session-run", asyncDir: path.join(resultsDir, "session-run"), status: "running", startedAt: Date.now(), updatedAt: Date.now() });
 			const resultPath = path.join(resultsDir, "session-run.json");
-			fs.writeFileSync(resultPath, JSON.stringify({
+			writeIndexedResult(resultPath, {
 				id: "session-run",
 				sessionId: "session-current",
 				success: true,
 				summary: "done",
-			}), "utf-8");
+			});
 
 			const watcher = createResultWatcher(pi, state, resultsDir, 60_000);
 			try {
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 				assert.equal(emitted.length, 0);
 				assert.equal(fs.existsSync(resultPath), true);
 
 				state.currentSessionId = "session-current";
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -84,32 +100,22 @@ describe("result watcher", () => {
 		}
 	});
 
-	it("does not inspect scheduled observers while priming current-session results", async () => {
+	it("includes scheduled observer ids while priming current-session results", async () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-current-prime-"));
 		try {
 			const state = createState();
 			state.currentSessionId = "session-current";
-			let observedRunIdScans = 0;
-			fs.writeFileSync(path.join(resultsDir, "current.json"), JSON.stringify({
-				id: "current",
-				sessionId: "session-current",
-				success: true,
-				summary: "done",
-			}), "utf-8");
-			const watcher = createResultWatcher({
-				events: {
-					on: () => () => {},
-					emit() {},
-				},
-			}, state, resultsDir, 60_000, {
+			let observedRunIdLookups = 0;
+			writeIndexedResult(path.join(resultsDir, "current.json"), { id: "current", sessionId: "session-current", success: true, summary: "done" });
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
 				deliverIntercomResults: false,
 				observedCompletionRunIds() {
-					observedRunIdScans += 1;
-					return [];
+					observedRunIdLookups += 1;
+					return ["scheduled-a"];
 				},
 			});
 			watcher.primeExistingResults();
-			assert.equal(observedRunIdScans, 0);
+			assert.equal(observedRunIdLookups, 1);
 			watcher.stopResultWatcher();
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
@@ -133,13 +139,13 @@ describe("result watcher", () => {
 				unref() {},
 			} as fs.FSWatcher;
 			const writeResult = (id: string, sessionId: string) => {
-				fs.writeFileSync(path.join(resultsDir, `${id}.json`), JSON.stringify({
+				writeIndexedResult(path.join(resultsDir, `${id}.json`), {
 					id,
 					results: [{ structuredOutput: { sessionId: "nested-not-owner" } }],
 					sessionId,
 					success: true,
 					summary: "done",
-				}), "utf-8");
+				});
 			};
 			writeResult("startup-current", "session-current");
 			writeResult("startup-stale", "session-stale");
@@ -239,7 +245,7 @@ describe("result watcher", () => {
 					heartbeat: { status: "running" },
 				}],
 			});
-			fs.writeFileSync(path.join(resultsDir, "async-child.json"), JSON.stringify({
+			writeIndexedResult(path.join(resultsDir, "async-child.json"), {
 				id: "async-child",
 				runId: "async-child",
 				sessionId: "session-current",
@@ -251,7 +257,7 @@ describe("result watcher", () => {
 				parentWorkflowRunId: "workflow-1",
 				workflowKey: "background",
 				results: [{ agent: "worker", success: true, output: "done", artifactPaths: { outputPath } }],
-			}), "utf-8");
+			});
 			const state = createState();
 			state.currentSessionId = "session-current";
 			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
@@ -259,7 +265,7 @@ describe("result watcher", () => {
 			});
 			try {
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -308,7 +314,7 @@ describe("result watcher", () => {
 			const state = createState();
 			state.currentSessionId = "session-b";
 			const resultPath = path.join(resultsDir, "scheduled-a.json");
-			fs.writeFileSync(resultPath, JSON.stringify({ id: "scheduled-a", sessionId: "session-a", success: true, summary: "done" }), "utf-8");
+			writeIndexedResult(resultPath, { id: "scheduled-a", sessionId: "session-a", success: true, summary: "done" });
 			const watcher = createResultWatcher({
 				events: {
 					on: () => () => {},
@@ -316,12 +322,13 @@ describe("result watcher", () => {
 				},
 			}, state, resultsDir, 60_000, {
 				observeCompletion: (result) => manager.handleAsyncCompletion(result),
+				observedCompletionRunIds: () => manager.observedCompletionRunIds(),
 				notifier: { deliver: async () => assert.fail("inactive-session completion must not reach the live notifier") },
 			});
 			try {
 				watcher.startResultWatcher();
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -334,6 +341,104 @@ describe("result watcher", () => {
 		} finally {
 			manager.stop();
 			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("uses indexed result files and ignores unindexed stale files during reload", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-index-"));
+		try {
+			for (let i = 0; i < 300; i += 1) {
+				fs.writeFileSync(path.join(resultsDir, `stale-${i}.json`), JSON.stringify({ id: `stale-${i}`, sessionId: "session-stale", success: true, summary: "done" }), "utf-8");
+			}
+			writeIndexedResult(path.join(resultsDir, "current.json"), { id: "current", runId: "current", sessionId: "session-current", success: true, summary: "done" });
+			const parsedIds: string[] = [];
+			const state = createState();
+			state.currentSessionId = "session-current";
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				deliverIntercomResults: false,
+				parseResult(raw) {
+					const parsed = JSON.parse(raw) as { id: string };
+					parsedIds.push(parsed.id);
+					return parsed;
+				},
+			});
+			try {
+				watcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => !fs.existsSync(path.join(resultsDir, "current.json"))), true);
+			} finally {
+				watcher.stopResultWatcher();
+			}
+			assert.deepEqual(parsedIds, ["current"]);
+			assert.equal(fs.existsSync(path.join(resultsDir, "stale-0.json")), true);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("includes observer-known run ids when current-session results are also indexed", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-mixed-observer-"));
+		try {
+			const resultsDir = path.join(root, "results");
+			writeIndexedResult(path.join(resultsDir, "current.json"), { id: "current", runId: "current", sessionId: "session-current", success: true, summary: "current" });
+			writeIndexedResult(path.join(resultsDir, "scheduled-a.json"), { id: "scheduled-a", runId: "scheduled-a", sessionId: "session-a", success: true, summary: "scheduled" });
+			let observations = 0;
+			const state = createState();
+			state.currentSessionId = "session-current";
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				observedCompletionRunIds: () => ["scheduled-a"],
+				observeCompletion: (result) => { if (result.runId === "scheduled-a") observations += 1; },
+				notifier: { deliver: async () => true },
+			});
+			try {
+				watcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => observations === 1), true);
+				assert.equal(await waitForPredicate(() => !fs.existsSync(path.join(resultsDir, "current.json"))), true);
+			} finally {
+				watcher.stopResultWatcher();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("uses observed run ids directly without scanning a stale result pile", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-observed-index-"));
+		try {
+			for (let i = 0; i < 300; i += 1) {
+				fs.writeFileSync(path.join(resultsDir, `stale-${i}.json`), JSON.stringify({ id: `stale-${i}`, sessionId: "session-stale", success: true, summary: "done" }), "utf-8");
+			}
+			const resultPath = path.join(resultsDir, "scheduled-a.json");
+			writeIndexedResult(resultPath, { id: "scheduled-a", runId: "scheduled-a", sessionId: "session-a", success: true, summary: "done" });
+			let observations = 0;
+			let observed = true;
+			const makeWatcher = () => {
+				const state = createState();
+				state.currentSessionId = "session-b";
+				return createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+					observedCompletionRunIds: () => observed ? ["scheduled-a"] : [],
+					observeCompletion: () => { observations += 1; observed = false; },
+					notifier: { deliver: async () => assert.fail("observer-owned completion must not reach active delivery") },
+				});
+			};
+			let watcher = makeWatcher();
+			try {
+				watcher.primeExistingResults();
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			} finally {
+				watcher.stopResultWatcher();
+			}
+			watcher = makeWatcher();
+			try {
+				watcher.primeExistingResults();
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			} finally {
+				watcher.stopResultWatcher();
+			}
+			assert.equal(observations, 1);
+			assert.equal(fs.existsSync(resultPath), true);
+			assert.equal(fs.existsSync(path.join(resultsDir, "stale-0.json")), true);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});
 
@@ -351,7 +456,7 @@ describe("result watcher", () => {
 			const state = createState();
 			state.currentSessionId = "session-native";
 			const resultPath = path.join(resultsDir, "native-run.json");
-			fs.writeFileSync(resultPath, JSON.stringify({
+			writeIndexedResult(resultPath, {
 				id: "native-run",
 				runId: "native-run",
 				sessionId: "session-native",
@@ -361,14 +466,14 @@ describe("result watcher", () => {
 				summary: "Subagent process terminated by signal SIGTERM.",
 				results: [{ agent: "worker", output: "", success: false, exitCode: 1, processSignal: "SIGTERM" }],
 				intercomTarget: "native-parent",
-			}), "utf-8");
+			});
 			const watcher = createResultWatcher(pi, state, resultsDir, 60_000, {
 				deliverIntercomResults: false,
 				notifier: { deliver: async (result) => { delivered.push(result); return true; } },
 			});
 			try {
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -419,9 +524,8 @@ describe("result watcher", () => {
 			const ownerWatcher = createResultWatcher(owner.pi, ownerState, resultsDir, 60_000);
 			const otherWatcher = createResultWatcher(other.pi, otherState, resultsDir, 60_000);
 			const ownerResultPath = path.join(resultsDir, "owner-run.json");
-			const sessionlessResultPath = path.join(resultsDir, "sessionless-run.json");
 			try {
-				fs.writeFileSync(ownerResultPath, JSON.stringify({
+				writeIndexedResult(ownerResultPath, {
 					id: "owner-run",
 					agent: "worker",
 					mode: "single",
@@ -432,23 +536,12 @@ describe("result watcher", () => {
 					sessionId: "session-owner",
 					cwd: "/repo",
 					intercomTarget: "owner-target",
-				}), "utf-8");
-				fs.writeFileSync(sessionlessResultPath, JSON.stringify({
-					id: "sessionless-run",
-					agent: "worker",
-					mode: "single",
-					success: true,
-					state: "complete",
-					summary: "legacy cwd-scoped output",
-					results: [{ agent: "worker", output: "legacy cwd-scoped output", success: true }],
-					cwd: "/repo",
-					intercomTarget: "sessionless-target",
-				}), "utf-8");
+				});
 
 				otherWatcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 				ownerWatcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				ownerWatcher.stopResultWatcher();
 				otherWatcher.stopResultWatcher();
@@ -462,7 +555,6 @@ describe("result watcher", () => {
 			assert.equal(other.emitted.some((entry) => entry.event === "subagent:async-complete"), false);
 			assert.equal(other.emitted.some((entry) => entry.event === "subagent:result-intercom"), false);
 			assert.equal(fs.existsSync(ownerResultPath), false);
-			assert.equal(fs.existsSync(sessionlessResultPath), true);
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
@@ -482,6 +574,7 @@ describe("result watcher", () => {
 				},
 			};
 			const state = createState();
+			state.asyncJobs.set("bad", { asyncId: "bad", asyncDir: path.join(resultsDir, "bad"), status: "running", startedAt: Date.now(), updatedAt: Date.now() });
 			const watcher = createResultWatcher(pi, state, resultsDir, 60_000);
 			const originalError = console.error;
 			const logged: unknown[][] = [];
@@ -490,7 +583,7 @@ describe("result watcher", () => {
 			};
 			try {
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				console.error = originalError;
 				watcher.stopResultWatcher();
@@ -590,16 +683,16 @@ describe("result watcher", () => {
 				watcher.startResultWatcher();
 				assert.equal(state.watcher, fakeWatcher);
 				for (const id of ["missed-a", "missed-b"]) {
-					fs.writeFileSync(path.join(resultsDir, `${id}.json`), JSON.stringify({
+					writeIndexedResult(path.join(resultsDir, `${id}.json`), {
 						id,
 						sessionId: "session-1",
 						success: true,
 						state: "complete",
 						summary: "done",
-					}), "utf-8");
+					});
 				}
 				scan?.();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -669,7 +762,7 @@ describe("result watcher", () => {
 				assert.notEqual(state.watcherRestartTimer, null);
 
 				fs.writeFileSync(childSessionPath, "", "utf-8");
-				fs.writeFileSync(path.join(resultsDir, "async-fallback.json"), JSON.stringify({
+				writeIndexedResult(path.join(resultsDir, "async-fallback.json"), {
 					id: "async-fallback",
 					runId: "run-fallback",
 					agent: "parallel:a+b",
@@ -683,9 +776,9 @@ describe("result watcher", () => {
 					],
 					sessionId: "session-1",
 					intercomTarget: "subagent-chat-main",
-				}), "utf-8");
+				});
 				poll?.();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				console.error = originalError;
 				watcher.stopResultWatcher();
@@ -764,9 +857,9 @@ describe("result watcher", () => {
 				assert.equal(state.watcher, null);
 				assert.notEqual(state.watcherRestartTimer, null);
 
-				fs.writeFileSync(path.join(resultsDir, "done.json"), JSON.stringify({ sessionId: "session-1", summary: "done" }), "utf-8");
+				writeIndexedResult(path.join(resultsDir, "done.json"), { sessionId: "session-1", summary: "done" });
 				poll?.();
-				await new Promise((resolve) => setTimeout(resolve, 75));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				console.error = originalError;
 				watcher.stopResultWatcher();
@@ -811,7 +904,7 @@ describe("result watcher", () => {
 			const missingSession = path.join(resultsDir, "b-session.jsonl");
 			try {
 				fs.writeFileSync(firstSession, "", "utf-8");
-				fs.writeFileSync(path.join(resultsDir, "async-1.json"), JSON.stringify({
+				writeIndexedResult(path.join(resultsDir, "async-1.json"), {
 					id: "async-1",
 					runId: "run-123",
 					agent: "parallel:a+b",
@@ -828,9 +921,9 @@ describe("result watcher", () => {
 					asyncDir: "/tmp/async-1",
 					parallelHandoff: { version: 1, path: "/tmp/async-1/handoff.json", groupCount: 1, childCount: 2, changedPatches: 1, cleanupState: "complete" },
 					intercomTarget: "subagent-chat-main",
-				}), "utf-8");
+				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -882,7 +975,7 @@ describe("result watcher", () => {
 			state.currentSessionId = "session-1";
 			const watcher = createResultWatcher(pi, state, resultsDir, 60_000);
 			try {
-				fs.writeFileSync(path.join(resultsDir, "async-stopped.json"), JSON.stringify({
+				writeIndexedResult(path.join(resultsDir, "async-stopped.json"), {
 					id: "async-stopped",
 					runId: "async-stopped",
 					agent: "parallel:a+b",
@@ -897,9 +990,9 @@ describe("result watcher", () => {
 					],
 					sessionId: "session-1",
 					intercomTarget: "subagent-chat-main",
-				}, null, 2), "utf-8");
+				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -964,7 +1057,7 @@ describe("result watcher", () => {
 			const watcher = createResultWatcher(pi, state, resultsDir, 60_000);
 			const resultPath = path.join(resultsDir, "async-nested-root.json");
 			try {
-				fs.writeFileSync(resultPath, JSON.stringify({
+				writeIndexedResult(resultPath, {
 					id: "async-nested-root",
 					runId: "async-nested-root",
 					agent: "owner",
@@ -975,9 +1068,9 @@ describe("result watcher", () => {
 					results: [{ agent: "owner", output: "owner done", success: true }],
 					sessionId: "session-1",
 					intercomTarget: "subagent-chat-main",
-				}), "utf-8");
+				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -1032,7 +1125,7 @@ describe("result watcher", () => {
 				logged.push(args);
 			};
 			try {
-				fs.writeFileSync(resultPath, JSON.stringify({
+				writeIndexedResult(resultPath, {
 					id: "async-explicit-nested",
 					runId: "async-explicit-nested",
 					agent: "owner",
@@ -1055,9 +1148,9 @@ describe("result watcher", () => {
 					],
 					sessionId: "session-1",
 					intercomTarget: "subagent-chat-main",
-				}), "utf-8");
+				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				console.error = originalError;
 				watcher.stopResultWatcher();
@@ -1123,7 +1216,7 @@ describe("result watcher", () => {
 				logged.push(args);
 			};
 			try {
-				fs.writeFileSync(resultPath, JSON.stringify({
+				writeIndexedResult(resultPath, {
 					id: "async-nested-retry",
 					runId: "async-nested-retry",
 					agent: "owner",
@@ -1132,9 +1225,9 @@ describe("result watcher", () => {
 					summary: "owner done",
 					sessionId: "session-1",
 					intercomTarget: "subagent-chat-main",
-				}), "utf-8");
+				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 
 				assert.equal(fs.existsSync(resultPath), true);
 				assert.equal(emitted.length, 0);
@@ -1186,7 +1279,7 @@ describe("result watcher", () => {
 			state.currentSessionId = "session-1";
 			const watcher = createResultWatcher(pi, state, resultsDir, 60_000);
 			try {
-				fs.writeFileSync(path.join(resultsDir, "async-top-session.json"), JSON.stringify({
+				writeIndexedResult(path.join(resultsDir, "async-top-session.json"), {
 					id: "async-top-session",
 					mode: "parallel",
 					success: false,
@@ -1198,9 +1291,9 @@ describe("result watcher", () => {
 					sessionId: "session-1",
 					sessionFile: "/tmp/top-session.jsonl",
 					intercomTarget: "subagent-chat-main",
-				}), "utf-8");
+				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -1243,7 +1336,7 @@ describe("result watcher", () => {
 			state.currentSessionId = "session-1";
 			const watcher = createResultWatcher(pi, state, resultsDir, 60_000);
 			try {
-				fs.writeFileSync(path.join(resultsDir, "async-paused.json"), JSON.stringify({
+				writeIndexedResult(path.join(resultsDir, "async-paused.json"), {
 					id: "async-paused",
 					runId: "run-paused",
 					agent: "chain:a->b",
@@ -1257,9 +1350,9 @@ describe("result watcher", () => {
 					],
 					sessionId: "session-1",
 					intercomTarget: "subagent-chat-main",
-				}), "utf-8");
+				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -1301,7 +1394,7 @@ describe("result watcher", () => {
 				logged.push(args);
 			};
 			try {
-				fs.writeFileSync(path.join(resultsDir, "async-2.json"), JSON.stringify({
+				writeIndexedResult(path.join(resultsDir, "async-2.json"), {
 					id: "async-2",
 					runId: "run-456",
 					agent: "worker",
@@ -1310,9 +1403,9 @@ describe("result watcher", () => {
 					summary: "Worker summary",
 					sessionId: "session-1",
 					intercomTarget: "orchestrator",
-				}), "utf-8");
+				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				console.error = originalError;
 				watcher.stopResultWatcher();
@@ -1354,7 +1447,7 @@ describe("result watcher", () => {
 			const loggedWarning = () => logged.some((entry) => /Subagent async grouped result intercom delivery was not acknowledged/.test(String(entry[0] ?? "")));
 			let warned = false;
 			try {
-				fs.writeFileSync(path.join(resultsDir, "unacknowledged.json"), JSON.stringify({
+				writeIndexedResult(path.join(resultsDir, "unacknowledged.json"), {
 					id: "unacknowledged",
 					runId: "run-unacknowledged",
 					agent: "worker",
@@ -1363,7 +1456,7 @@ describe("result watcher", () => {
 					summary: "Worker summary",
 					sessionId: "session-1",
 					intercomTarget: "orchestrator",
-				}), "utf-8");
+				});
 				watcher.primeExistingResults();
 				warned = await waitForPredicate(loggedWarning);
 			} finally {
@@ -1410,7 +1503,7 @@ describe("result watcher", () => {
 				notifier: { async deliver(result) { delivered.push({ intercomDelivered: result.intercomDelivered }); return true; } },
 			});
 			try {
-				fs.writeFileSync(path.join(resultsDir, "acknowledged.json"), JSON.stringify({
+				writeIndexedResult(path.join(resultsDir, "acknowledged.json"), {
 					id: "acknowledged",
 					runId: "run-acknowledged",
 					agent: "worker",
@@ -1419,9 +1512,9 @@ describe("result watcher", () => {
 					summary: "Worker summary",
 					sessionId: "session-1",
 					intercomTarget: "orchestrator",
-				}), "utf-8");
+				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -1444,11 +1537,11 @@ describe("result watcher", () => {
 			const resultFile = "expired.json";
 			const result = { sessionId: "session-1", agent: "worker", success: true, summary: "new result", timestamp: 123 };
 			const resultPath = path.join(resultsDir, resultFile);
-			fs.writeFileSync(resultPath, JSON.stringify(result), "utf-8");
+			writeIndexedResult(resultPath, result);
 			state.completionSeen.set(buildCompletionKey(result, `result:${resultFile}`), Date.now() - 61_000);
 			try {
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 75));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -1471,10 +1564,10 @@ describe("result watcher", () => {
 				notifier: { async deliver() { attempts += 1; return attempts > 1; } },
 			});
 			const resultPath = path.join(resultsDir, "retry.json");
-			fs.writeFileSync(resultPath, JSON.stringify({ id: "retry", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1 }), "utf-8");
+			writeIndexedResult(resultPath, { id: "retry", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1 });
 			try {
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 50));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 				assert.equal(fs.existsSync(resultPath), true);
 				await new Promise((resolve) => setTimeout(resolve, 180));
 			} finally {
@@ -1499,12 +1592,12 @@ describe("result watcher", () => {
 				notifier: { deliver: () => new Promise<boolean>((resolve) => { accept = resolve; }) },
 			});
 			const resultPath = path.join(resultsDir, "stale.json");
-			fs.writeFileSync(resultPath, JSON.stringify({ id: "stale", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1 }), "utf-8");
+			writeIndexedResult(resultPath, { id: "stale", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1 });
 			watcher.primeExistingResults();
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			await new Promise((resolve) => setTimeout(resolve, 10));
 			watcher.stopResultWatcher();
 			accept(true);
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			await new Promise((resolve) => setTimeout(resolve, 10));
 			assert.equal(fs.existsSync(resultPath), true);
 			assert.deepEqual(emitted, []);
 		} finally {
@@ -1522,10 +1615,10 @@ describe("result watcher", () => {
 			const watcher = createResultWatcher({ events: { on: () => () => {}, emit(event) { emitted.push(event); } } }, state, resultsDir, 60_000, {
 				notifier: { async deliver(result) { delivered.push({ triggerTurn: result.triggerTurn }); return true; } },
 			});
-			fs.writeFileSync(path.join(resultsDir, "quiet.json"), JSON.stringify({ id: "quiet", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1, intercomTarget: "host" }), "utf-8");
+			writeIndexedResult(path.join(resultsDir, "quiet.json"), { id: "quiet", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1, intercomTarget: "host" });
 			try {
 				watcher.primeExistingResults({ triggerTurn: false });
-				await new Promise((resolve) => setTimeout(resolve, 75));
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			} finally {
 				watcher.stopResultWatcher();
 			}

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -541,7 +541,7 @@ describe("result watcher", () => {
 				otherWatcher.primeExistingResults();
 				await new Promise((resolve) => setTimeout(resolve, 10));
 				ownerWatcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 10));
+				assert.equal(await waitForPredicate(() => owner.emitted.some((entry) => entry.event === "subagent:async-complete")), true);
 			} finally {
 				ownerWatcher.stopResultWatcher();
 				otherWatcher.stopResultWatcher();

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -285,6 +285,39 @@ describe("result watcher", () => {
 		}
 	});
 
+	it("keeps result files until failed completion observers retry successfully", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-observer-retry-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const resultPath = path.join(resultsDir, "observer-retry.json");
+			writeIndexedResult(resultPath, { id: "observer-retry", runId: "observer-retry", sessionId: "session-current", success: true, summary: "done" });
+			const state = createState();
+			state.currentSessionId = "session-current";
+			let observerCalls = 0;
+			let deliveries = 0;
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				observeCompletion: () => {
+					observerCalls += 1;
+					if (observerCalls === 1) throw new Error("observer unavailable");
+				},
+				notifier: { deliver: async () => { deliveries += 1; return true; } },
+			});
+			try {
+				watcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => !fs.existsSync(resultPath) && observerCalls >= 2), true);
+			} finally {
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal(observerCalls, 2);
+			assert.equal(deliveries, 1);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("observes retained-project completions without changing active-session delivery", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-scheduled-"));
 		const resultsDir = path.join(root, "results");

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -318,6 +318,58 @@ describe("result watcher", () => {
 		}
 	});
 
+	it("does not redeliver user notification after reload while observer retry is pending", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-observer-reload-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const resultPath = path.join(resultsDir, "observer-reload.json");
+			writeIndexedResult(resultPath, { id: "observer-reload", runId: "observer-reload", sessionId: "session-current", success: true, summary: "done" });
+			let observerCalls = 0;
+			let deliveries = 0;
+			let emitted = 0;
+			const pi = { events: { on: () => () => {}, emit: () => { emitted += 1; } } };
+			const firstState = createState();
+			firstState.currentSessionId = "session-current";
+			const firstWatcher = createResultWatcher(pi, firstState, resultsDir, 60_000, {
+				observeCompletion: () => {
+					observerCalls += 1;
+					throw new Error("observer unavailable");
+				},
+				notifier: { deliver: async () => { deliveries += 1; return true; } },
+			});
+			try {
+				firstWatcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => {
+					if (deliveries !== 1 || !fs.existsSync(resultPath)) return false;
+					return typeof (JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { notificationDeliveredAt?: unknown }).notificationDeliveredAt === "number";
+				}), true);
+			} finally {
+				firstWatcher.stopResultWatcher();
+			}
+
+			const secondState = createState();
+			secondState.currentSessionId = "session-current";
+			const secondWatcher = createResultWatcher(pi, secondState, resultsDir, 60_000, {
+				observeCompletion: () => { observerCalls += 1; },
+				notifier: { deliver: async () => { deliveries += 1; return true; } },
+			});
+			try {
+				secondWatcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => !fs.existsSync(resultPath)), true);
+			} finally {
+				secondWatcher.stopResultWatcher();
+			}
+
+			assert.equal(observerCalls, 2);
+			assert.equal(deliveries, 1);
+			assert.equal(emitted, 1);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("observes retained-project completions without changing active-session delivery", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-scheduled-"));
 		const resultsDir = path.join(root, "results");

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -6,7 +6,7 @@ import { describe, it } from "node:test";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { buildCompletionKey } from "../../src/runs/background/completion-dedupe.ts";
 import { createResultWatcher as createRawResultWatcher } from "../../src/runs/background/result-watcher.ts";
-import { writeAsyncResultFile } from "../../src/runs/background/result-files.ts";
+import { writeAsyncResultFile, writePendingAsyncResultFile } from "../../src/runs/background/result-files.ts";
 import { createScheduledRunManager, scheduledRunStorePath } from "../../src/runs/background/scheduled-runs.ts";
 import { prepareMissionLaunch, writeMissionAsyncBinding } from "../../src/missions/lifecycle.ts";
 import { readMission, updateMission } from "../../src/missions/store.ts";
@@ -45,6 +45,10 @@ function createResultWatcher(
 
 function writeIndexedResult(filePath: string, data: Record<string, unknown>): void {
 	writeAsyncResultFile(filePath, data);
+}
+
+function pendingResultPath(resultsDir: string, sessionId: string, runId: string): string {
+	return path.join(resultsDir, "result-pending", encodeURIComponent(sessionId), `${encodeURIComponent(runId)}.json`);
 }
 
 async function waitForPredicate(predicate: () => boolean, timeoutMs = 2_500): Promise<boolean> {
@@ -429,6 +433,50 @@ describe("result watcher", () => {
 		}
 	});
 
+	it("delivers indexed pending results during reload when public promotion is blocked", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-pending-index-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const emitted: Array<{ event: string; data: unknown }> = [];
+			const delivered: unknown[] = [];
+			const state = createState();
+			state.currentSessionId = "session-current";
+			const resultPath = path.join(resultsDir, "pending-run.json");
+			fs.mkdirSync(resultPath, { recursive: true });
+			writePendingAsyncResultFile(resultPath, {
+				id: "pending-run",
+				runId: "pending-run",
+				sessionId: "session-current",
+				success: true,
+				state: "complete",
+				summary: "done from pending",
+			});
+			const watcher = createResultWatcher({
+				events: {
+					on: () => () => {},
+					emit(event: string, data: unknown) { emitted.push({ event, data }); },
+				},
+			}, state, resultsDir, 60_000, {
+				deliverIntercomResults: false,
+				notifier: { deliver: async (result) => { delivered.push(result); return true; } },
+			});
+			try {
+				watcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => emitted.some((entry) => entry.event === "subagent:async-complete")), true);
+			} finally {
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal((delivered[0] as { summary?: string } | undefined)?.summary, "done from pending");
+			assert.equal(fs.existsSync(pendingResultPath(resultsDir, "session-current", "pending-run")), false);
+			assert.equal(fs.statSync(resultPath).isDirectory(), true);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("uses indexed result files and ignores unindexed stale files during reload", async () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-index-"));
 		try {
@@ -483,6 +531,50 @@ describe("result watcher", () => {
 			}
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("delivers observed indexed pending results when public promotion is blocked", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-observed-pending-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			for (let i = 0; i < 300; i += 1) {
+				fs.writeFileSync(path.join(resultsDir, `stale-${i}.json`), JSON.stringify({ id: `stale-${i}`, sessionId: "session-stale", success: true, summary: "done" }), "utf-8");
+			}
+			const resultPath = path.join(resultsDir, "scheduled-pending.json");
+			fs.mkdirSync(resultPath, { recursive: true });
+			writePendingAsyncResultFile(resultPath, {
+				id: "scheduled-pending",
+				runId: "scheduled-pending",
+				sessionId: "session-a",
+				success: true,
+				state: "complete",
+				summary: "scheduled pending done",
+			});
+			let observations = 0;
+			const state = createState();
+			state.currentSessionId = "session-b";
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				observedCompletionRunIds: () => ["scheduled-pending"],
+				observeCompletion: (result) => {
+					if (result.runId === "scheduled-pending") observations += 1;
+				},
+				notifier: { deliver: async () => assert.fail("observer-owned completion must not reach active delivery") },
+			});
+			try {
+				watcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => observations === 1), true);
+			} finally {
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal(fs.existsSync(pendingResultPath(resultsDir, "session-a", "scheduled-pending")), true);
+			assert.equal(fs.statSync(resultPath).isDirectory(), true);
+			assert.equal(fs.existsSync(path.join(resultsDir, "stale-0.json")), true);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});
 

--- a/test/unit/completion-replay.test.ts
+++ b/test/unit/completion-replay.test.ts
@@ -4,7 +4,7 @@ import { createRequire, syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { cleanupCompletionReplay, completionArchivePath, readCompletionArchive, readCompletionReplay, writeCompletionArchive } from "../../src/runs/background/completion-replay.ts";
+import { cleanupCompletionReplay, completionArchivePath, completionReplayPath, readCompletionArchive, readCompletionReplay, writeCompletionReplay, writeCompletionArchive } from "../../src/runs/background/completion-replay.ts";
 import { utf8Tail } from "../../src/shared/utf8.ts";
 import { collectWaitCompletions, recordWaitCompletion } from "../../src/runs/background/wait-completions.ts";
 import type { AsyncRunSummary } from "../../src/runs/background/async-status.ts";
@@ -156,6 +156,46 @@ describe("completion replay", () => {
 			assert.equal(fs.existsSync(archivePath), true);
 		} finally {
 			fsCjs.rmSync = originalRmSync;
+			syncBuiltinESMExports();
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("throttles cleanup while writing completion replay records", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-completion-replay-throttle-"));
+		const originalReaddirSync = fsCjs.readdirSync;
+		let cleanupScans = 0;
+		try {
+			fsCjs.readdirSync = ((target: Parameters<typeof fs.readdirSync>[0], options?: Parameters<typeof fs.readdirSync>[1]) => {
+				if (String(target).includes(`${path.sep}completion-replay`)) cleanupScans += 1;
+				return originalReaddirSync(target, options as never);
+			}) as typeof fs.readdirSync;
+			syncBuiltinESMExports();
+
+			writeCompletionReplay({
+				resultsDir: root,
+				runId: "run-a",
+				sessionId: "session-a",
+				completion: { runId: "run-a" },
+				data: { summary: "done" },
+				now: 10_000,
+				ttlMs: 60_000,
+			});
+			writeCompletionReplay({
+				resultsDir: root,
+				runId: "run-b",
+				sessionId: "session-a",
+				completion: { runId: "run-b" },
+				data: { summary: "done" },
+				now: 10_001,
+				ttlMs: 60_000,
+			});
+
+			assert.equal(cleanupScans, 1);
+			assert.equal(fs.existsSync(completionReplayPath(root, "run-a")), true);
+			assert.equal(fs.existsSync(completionReplayPath(root, "run-b")), true);
+		} finally {
+			fsCjs.readdirSync = originalReaddirSync;
 			syncBuiltinESMExports();
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/nested-events.test.ts
+++ b/test/unit/nested-events.test.ts
@@ -39,9 +39,23 @@ const savedEnv = {
 	[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV]: process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV],
 };
 
-afterEach(() => {
+async function removeDirWithRetry(dir: string): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt++) {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+			return;
+		} catch (error) {
+			lastError = error;
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+	}
+	throw lastError;
+}
+
+afterEach(async () => {
 	for (const route of routes.splice(0)) {
-		fs.rmSync(path.dirname(route.eventSink), { recursive: true, force: true });
+		await removeDirWithRetry(path.dirname(route.eventSink));
 	}
 	for (const [key, value] of Object.entries(savedEnv)) {
 		if (value === undefined) delete process.env[key];

--- a/test/unit/nested-events.test.ts
+++ b/test/unit/nested-events.test.ts
@@ -97,6 +97,18 @@ describe("nested route index", () => {
 		const tokens = new Set([first.capabilityToken, second.capabilityToken]);
 		assert.ok(tokens.has(indexed.capabilityToken), "indexed route must be one of the two created routes");
 	});
+
+	it("does not drop a route index while the route file is not visible yet", () => {
+		const route = trackRoute("late-route-root");
+		const routeFile = path.join(path.dirname(route.eventSink), "route.json");
+		const routeJson = fs.readFileSync(routeFile, "utf-8");
+		fs.rmSync(routeFile);
+
+		assert.equal(buildNestedRouteIndex().get("late-route-root"), undefined);
+
+		fs.writeFileSync(routeFile, routeJson, "utf-8");
+		assert.equal(buildNestedRouteIndex().get("late-route-root")?.capabilityToken, route.capabilityToken);
+	});
 });
 
 describe("nested event route validation", () => {

--- a/test/unit/nested-events.test.ts
+++ b/test/unit/nested-events.test.ts
@@ -112,16 +112,13 @@ describe("nested route index", () => {
 		assert.ok(tokens.has(indexed.capabilityToken), "indexed route must be one of the two created routes");
 	});
 
-	it("does not drop a route index while the route file is not visible yet", () => {
+	it("recovers a route from its index when the route file is missing", () => {
 		const route = trackRoute("late-route-root");
 		const routeFile = path.join(path.dirname(route.eventSink), "route.json");
-		const routeJson = fs.readFileSync(routeFile, "utf-8");
 		fs.rmSync(routeFile);
 
-		assert.equal(buildNestedRouteIndex().get("late-route-root"), undefined);
-
-		fs.writeFileSync(routeFile, routeJson, "utf-8");
 		assert.equal(buildNestedRouteIndex().get("late-route-root")?.capabilityToken, route.capabilityToken);
+		assert.equal(JSON.parse(fs.readFileSync(routeFile, "utf-8")).capabilityToken, route.capabilityToken);
 	});
 });
 

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -39,7 +39,7 @@ describe("result file indexes", () => {
 		}
 	});
 
-	it("does not commit a result payload when its index cannot be written", () => {
+	it("does not commit a result payload when its session index cannot be written", () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-index-failure-"));
 		try {
 			fs.writeFileSync(path.join(resultsDir, "result-index"), "not a directory", "utf-8");
@@ -48,6 +48,37 @@ describe("result file indexes", () => {
 			assert.throws(() => writeAsyncResultFile(resultPath, { id: "blocked", runId: "blocked", sessionId: "session-a", success: true }));
 			assert.equal(fs.existsSync(resultPath), false);
 		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not commit a result payload without a session id", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-no-session-"));
+		try {
+			const resultPath = path.join(resultsDir, "blocked.json");
+
+			assert.throws(() => writeAsyncResultFile(resultPath, { id: "blocked", runId: "blocked", success: true }), /sessionId/);
+			assert.equal(fs.existsSync(resultPath), false);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("commits a result payload when only an optional index fails", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-optional-index-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			fs.mkdirSync(path.join(resultsDir, "result-index"), { recursive: true });
+			fs.writeFileSync(path.join(resultsDir, "result-index", "tool-calls"), "not a directory", "utf-8");
+			const resultPath = path.join(resultsDir, "kept.json");
+
+			writeAsyncResultFile(resultPath, { id: "kept", runId: "kept", sessionId: "session-a", toolCallId: "call-a", success: true });
+
+			assert.equal(fs.existsSync(resultPath), true);
+			assert.deepEqual(resultFilesForSession(resultsDir, "session-a"), ["kept.json"]);
+		} finally {
+			console.error = originalError;
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { cleanupResultIndexes, resultFilesForSession, writeAsyncResultFile } from "../../src/runs/background/result-files.ts";
+import { cleanupResultIndexes, resultFilesForSession, writeAsyncResultFile, writeResultIndexForData } from "../../src/runs/background/result-files.ts";
 
 describe("result file indexes", () => {
 	it("removes orphan index entries without deleting flat result files", () => {
@@ -19,6 +19,21 @@ describe("result file indexes", () => {
 			assert.deepEqual(resultFilesForSession(resultsDir, "session-a"), ["kept.json"]);
 			assert.equal(fs.existsSync(path.join(resultsDir, "kept.json")), true);
 			assert.equal(fs.existsSync(path.join(resultsDir, "unindexed.json")), true);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a valid index while the result payload is not visible yet", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-late-payload-"));
+		try {
+			const resultPath = path.join(resultsDir, "late.json");
+			writeResultIndexForData(resultPath, { id: "late", runId: "late", sessionId: "session-a", success: true });
+
+			assert.deepEqual(resultFilesForSession(resultsDir, "session-a"), []);
+
+			fs.writeFileSync(resultPath, JSON.stringify({ id: "late", runId: "late", sessionId: "session-a", success: true }), "utf-8");
+			assert.deepEqual(resultFilesForSession(resultsDir, "session-a"), ["late.json"]);
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -38,4 +38,17 @@ describe("result file indexes", () => {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});
+
+	it("does not commit a result payload when its index cannot be written", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-index-failure-"));
+		try {
+			fs.writeFileSync(path.join(resultsDir, "result-index"), "not a directory", "utf-8");
+			const resultPath = path.join(resultsDir, "blocked.json");
+
+			assert.throws(() => writeAsyncResultFile(resultPath, { id: "blocked", runId: "blocked", sessionId: "session-a", success: true }));
+			assert.equal(fs.existsSync(resultPath), false);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { cleanupResultIndexes, resultFilesForSession, writeAsyncResultFile } from "../../src/runs/background/result-files.ts";
+
+describe("result file indexes", () => {
+	it("removes orphan index entries without deleting flat result files", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-index-"));
+		try {
+			writeAsyncResultFile(path.join(resultsDir, "kept.json"), { id: "kept", runId: "kept", sessionId: "session-a", success: true });
+			writeAsyncResultFile(path.join(resultsDir, "missing.json"), { id: "missing", runId: "missing", sessionId: "session-a", toolCallId: "call-missing", success: true });
+			fs.rmSync(path.join(resultsDir, "missing.json"));
+			fs.writeFileSync(path.join(resultsDir, "unindexed.json"), JSON.stringify({ id: "unindexed", sessionId: "session-a" }), "utf-8");
+
+			assert.equal(cleanupResultIndexes(resultsDir, Date.now() + 86_400_001, 86_400_000), 2);
+
+			assert.deepEqual(resultFilesForSession(resultsDir, "session-a"), ["kept.json"]);
+			assert.equal(fs.existsSync(path.join(resultsDir, "kept.json")), true);
+			assert.equal(fs.existsSync(path.join(resultsDir, "unindexed.json")), true);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -3,7 +3,11 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { cleanupResultIndexes, resultFilesForSession, writeAsyncResultFile, writeResultIndexForData } from "../../src/runs/background/result-files.ts";
+import { cleanupResultIndexes, removeResultIndex, resultCandidateFilesForSession, resultFilesForSession, resultPayloadPathForIndexedRun, resultPayloadPathForSessionRun, writeAsyncResultFile, writePendingAsyncResultFile, writeResultIndexForData } from "../../src/runs/background/result-files.ts";
+
+function pendingPath(resultsDir: string, sessionId: string, runId: string): string {
+	return path.join(resultsDir, "result-pending", encodeURIComponent(sessionId), `${encodeURIComponent(runId)}.json`);
+}
 
 describe("result file indexes", () => {
 	it("removes orphan index entries without deleting flat result files", () => {
@@ -24,8 +28,50 @@ describe("result file indexes", () => {
 		}
 	});
 
-	it("keeps a valid index while the result payload is not visible yet", () => {
-		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-late-payload-"));
+	it("promotes an indexed pending result payload", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-pending-payload-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const resultPath = path.join(resultsDir, "late.json");
+			fs.mkdirSync(resultPath, { recursive: true });
+
+			assert.deepEqual(writeAsyncResultFile(resultPath, { id: "late", runId: "late", sessionId: "session-a", success: true }), { state: "pending" });
+			assert.equal(fs.existsSync(pendingPath(resultsDir, "session-a", "late")), true);
+			fs.rmSync(resultPath, { recursive: true, force: true });
+
+			assert.deepEqual(resultFilesForSession(resultsDir, "session-a"), ["late.json"]);
+			assert.equal(JSON.parse(fs.readFileSync(resultPath, "utf-8")).success, true);
+			assert.equal(fs.existsSync(pendingPath(resultsDir, "session-a", "late")), false);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("writes an indexed pending result without publishing it", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-pending-only-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const resultPath = path.join(resultsDir, "pending-only.json");
+			fs.mkdirSync(resultPath, { recursive: true });
+
+			writePendingAsyncResultFile(resultPath, { id: "pending-only", runId: "pending-only", sessionId: "session-a", success: true });
+
+			assert.equal(fs.statSync(resultPath).isDirectory(), true);
+			assert.deepEqual(resultFilesForSession(resultsDir, "session-a"), []);
+			assert.deepEqual(resultCandidateFilesForSession(resultsDir, "session-a"), ["pending-only.json"]);
+			assert.equal(resultPayloadPathForSessionRun(resultsDir, "session-a", "pending-only"), pendingPath(resultsDir, "session-a", "pending-only"));
+			assert.equal(resultPayloadPathForIndexedRun(resultsDir, "pending-only"), pendingPath(resultsDir, "session-a", "pending-only"));
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a legacy valid index while the result payload is not visible yet", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-legacy-late-payload-"));
 		try {
 			const resultPath = path.join(resultsDir, "late.json");
 			writeResultIndexForData(resultPath, { id: "late", runId: "late", sessionId: "session-a", success: true });
@@ -39,7 +85,7 @@ describe("result file indexes", () => {
 		}
 	});
 
-	it("does not commit a result payload when its session index cannot be written", () => {
+	it("keeps an unindexed pending result recoverable when its session index cannot be written", () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-index-failure-"));
 		try {
 			fs.writeFileSync(path.join(resultsDir, "result-index"), "not a directory", "utf-8");
@@ -47,6 +93,10 @@ describe("result file indexes", () => {
 
 			assert.throws(() => writeAsyncResultFile(resultPath, { id: "blocked", runId: "blocked", sessionId: "session-a", success: true }));
 			assert.equal(fs.existsSync(resultPath), false);
+			assert.equal(fs.existsSync(pendingPath(resultsDir, "session-a", "blocked")), true);
+			assert.equal(resultPayloadPathForSessionRun(resultsDir, "session-a", "blocked"), pendingPath(resultsDir, "session-a", "blocked"));
+			assert.equal(resultPayloadPathForIndexedRun(resultsDir, "blocked"), pendingPath(resultsDir, "session-a", "blocked"));
+			assert.deepEqual(resultCandidateFilesForSession(resultsDir, "session-a"), ["blocked.json"]);
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
@@ -60,6 +110,46 @@ describe("result file indexes", () => {
 			assert.throws(() => writeAsyncResultFile(resultPath, { id: "blocked", runId: "blocked", success: true }), /sessionId/);
 			assert.equal(fs.existsSync(resultPath), false);
 		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("prefers pending payload over an older public result", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-pending-wins-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const resultPath = path.join(resultsDir, "blocked.json");
+			writeAsyncResultFile(resultPath, { id: "blocked", runId: "blocked", sessionId: "session-a", success: false });
+			fs.rmSync(resultPath, { force: true });
+			fs.mkdirSync(resultPath, { recursive: true });
+
+			assert.deepEqual(writeAsyncResultFile(resultPath, { id: "blocked", runId: "blocked", sessionId: "session-a", success: true }), { state: "pending" });
+			fs.rmSync(resultPath, { recursive: true, force: true });
+			fs.writeFileSync(resultPath, JSON.stringify({ id: "blocked", runId: "blocked", sessionId: "session-a", success: false }), "utf-8");
+
+			assert.deepEqual(resultFilesForSession(resultsDir, "session-a"), ["blocked.json"]);
+			assert.equal(JSON.parse(fs.readFileSync(resultPath, "utf-8")).success, true);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("removes pending payloads with result indexes", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-pending-cleanup-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const resultPath = path.join(resultsDir, "pending-cleanup.json");
+			fs.mkdirSync(resultPath, { recursive: true });
+			writeAsyncResultFile(resultPath, { id: "pending-cleanup", runId: "pending-cleanup", sessionId: "session-a", success: true });
+
+			assert.equal(fs.existsSync(pendingPath(resultsDir, "session-a", "pending-cleanup")), true);
+			removeResultIndex(resultsDir, "session-a", "pending-cleanup");
+			assert.equal(fs.existsSync(pendingPath(resultsDir, "session-a", "pending-cleanup")), false);
+		} finally {
+			console.error = originalError;
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/run-id-resolver.test.ts
+++ b/test/unit/run-id-resolver.test.ts
@@ -141,6 +141,23 @@ describe("subagent run id resolver", () => {
 		}
 	});
 
+	it("does not resolve unindexed result files by prefix", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-id-result-prefix-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const resultsDir = path.join(root, "results");
+			fs.mkdirSync(resultsDir, { recursive: true });
+			fs.writeFileSync(path.join(resultsDir, "legacy-run.json"), JSON.stringify({ id: "legacy-run", sessionId: "session-a", success: true }), "utf-8");
+
+			const exact = resolveSubagentRunId("legacy-run", { asyncDirRoot: asyncRoot, resultsDir });
+			assert.equal(exact?.kind, "async");
+			assert.equal(exact?.id, "legacy-run");
+			assert.equal(resolveSubagentRunId("legacy", { asyncDirRoot: asyncRoot, resultsDir }), undefined);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("resolves workflow tool-call ids through active and result indexes", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-resolver-tool-call-index-"));
 		try {

--- a/test/unit/run-id-resolver.test.ts
+++ b/test/unit/run-id-resolver.test.ts
@@ -4,6 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import type { SubagentState } from "../../src/shared/types.ts";
+import { releaseActiveRunIndex, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
+import { resultFilePath, writeAsyncResultFile } from "../../src/runs/background/result-files.ts";
 import { resolveSubagentRunId } from "../../src/runs/background/run-id-resolver.ts";
 import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
 
@@ -134,6 +136,31 @@ describe("subagent run id resolver", () => {
 				() => resolveSubagentRunId("dupe", { asyncDirRoot: asyncRoot, resultsDir }),
 				/Ambiguous subagent run id prefix 'dupe' matched: async:dupe-one, async:dupe-two/,
 			);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves workflow tool-call ids through active and result indexes", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-resolver-tool-call-index-"));
+		try {
+			const asyncRoot = path.join(root, "async");
+			const resultsDir = path.join(root, "results");
+			const activeDir = path.join(asyncRoot, "workflow-active");
+			fs.mkdirSync(activeDir, { recursive: true });
+			fs.writeFileSync(path.join(activeDir, "status.json"), JSON.stringify({ runId: "workflow-active", toolCallId: "call-active", state: "running", mode: "workflow", startedAt: 1, lastUpdate: 1, steps: [] }), "utf-8");
+			updateActiveRunIndex(activeDir, "running", "call-active");
+
+			const active = resolveSubagentRunId("call-active", { asyncDirRoot: asyncRoot, resultsDir });
+			assert.equal(active?.kind, "async");
+			assert.equal(active?.id, "workflow-active");
+			releaseActiveRunIndex(activeDir);
+			assert.equal(resolveSubagentRunId("call-active", { asyncDirRoot: asyncRoot, resultsDir }), undefined);
+
+			writeAsyncResultFile(resultFilePath(resultsDir, "workflow-done"), { id: "workflow-done", runId: "workflow-done", toolCallId: "call-done", sessionId: "session-a", state: "complete", success: true });
+			const done = resolveSubagentRunId("call-done", { asyncDirRoot: asyncRoot, resultsDir });
+			assert.equal(done?.kind, "async");
+			assert.equal(done?.id, "workflow-done");
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -33,6 +33,7 @@ describe("async run status inspection", () => {
 			fs.writeFileSync(sessionFile, "", "utf-8");
 			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
 				runId: "run-stale",
+				sessionId: "session-current",
 				mode: "single",
 				state: "running",
 				pid: 12345,
@@ -668,6 +669,7 @@ describe("async run status inspection", () => {
 			}, null, 2), "utf-8");
 			fs.writeFileSync(path.join(nestedAsyncDir, "status.json"), JSON.stringify({
 				runId: "nested-stale",
+				sessionId: "session-nested",
 				mode: "single",
 				state: "running",
 				pid: 54321,

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -294,6 +294,7 @@ describe("recurring schedule execution", () => {
 		assert.deepEqual(h.launches[0]?.params, { workflowScript: "return runs.run('main', { agent: 'worker', task: 'Maintain backlog' })", async: true, context: "fresh", cwd: h.ctx.cwd, mission: false });
 		h.launches[0]!.resolve({ content: [{ type: "text", text: "Async worker" }], details: { mode: "single", results: [], asyncId: "async-1", asyncDir: "/tmp/async-1" } });
 		await flush();
+		assert.deepEqual([...h.manager.observedCompletionRunIds()], ["async-1"]);
 
 		let history = await h.manager.handleToolCall({ action: "schedule.history", id: "hourly" }, h.ctx);
 		assert.match(text(history), /running.*async async-1/);
@@ -304,6 +305,7 @@ describe("recurring schedule execution", () => {
 		assert.equal(fs.readdirSync(path.join(dir, "runs")).length, 1);
 
 		h.manager.handleAsyncCompletion({ runId: "async-1", success: true, summary: "Done" });
+		assert.deepEqual([...h.manager.observedCompletionRunIds()], []);
 		history = await h.manager.handleToolCall({ action: "schedule.history", id: "hourly" }, h.ctx);
 		assert.match(text(history), /completed.*async async-1/);
 		assert.equal(fs.existsSync(path.join(dir, "active.lock")), false);

--- a/test/unit/stale-run-reconciler.test.ts
+++ b/test/unit/stale-run-reconciler.test.ts
@@ -71,6 +71,37 @@ describe("async stale-run reconciliation", () => {
 		}
 	});
 
+	it("repairs sessionless stale status without writing an unindexed result", () => {
+		const root = tempRoot("pi-stale-run-sessionless-");
+		try {
+			const asyncDir = path.join(root, "run-sessionless");
+			const resultsDir = path.join(root, "results");
+			writeStatus(asyncDir, {
+				runId: "run-sessionless",
+				mode: "single",
+				state: "running",
+				pid: 12345,
+				startedAt: 1000,
+				lastUpdate: 1000,
+				currentStep: 0,
+				steps: [{ agent: "scout", status: "running", startedAt: 1000 }],
+			});
+
+			const result = reconcileAsyncRun(asyncDir, {
+				resultsDir,
+				kill: () => { throw errno("ESRCH"); },
+				now: () => 2000,
+			});
+
+			assert.equal(result.repaired, true);
+			assert.equal(result.resultPath, undefined);
+			assert.equal(JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")).state, "failed");
+			assert.equal(fs.existsSync(path.join(resultsDir, "run-sessionless.json")), false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("includes runner stderr diagnostics when repairing a stale startup crash", () => {
 		const root = tempRoot("pi-stale-run-stderr-");
 		try {
@@ -78,6 +109,7 @@ describe("async stale-run reconciliation", () => {
 			const resultsDir = path.join(root, "results");
 			writeStatus(asyncDir, {
 				runId: "run-dead-stderr",
+				sessionId: "session-current",
 				mode: "single",
 				state: "running",
 				pid: 12345,
@@ -113,6 +145,7 @@ describe("async stale-run reconciliation", () => {
 			const resultsDir = path.join(root, "results");
 			writeStatus(asyncDir, {
 				runId: "run-dead-events-dir",
+				sessionId: "session-current",
 				mode: "single",
 				state: "running",
 				pid: 12345,

--- a/test/unit/stale-run-reconciler.test.ts
+++ b/test/unit/stale-run-reconciler.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
+import { writeAsyncResultFile, writePendingAsyncResultFile } from "../../src/runs/background/result-files.ts";
 import { checkPidLiveness, reconcileAsyncRun } from "../../src/runs/background/stale-run-reconciler.ts";
 
 function tempRoot(prefix: string): string {
@@ -222,6 +223,100 @@ describe("async stale-run reconciliation", () => {
 			assert.deepEqual(result.status?.steps?.[1]?.attemptedModels, ["planned-worker", "careful"]);
 			assert.equal(result.status?.steps?.[1]?.sessionFile, workerSession);
 		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("repairs stale running status from an indexed pending result", () => {
+		const root = tempRoot("pi-stale-indexed-pending-result-");
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const asyncDir = path.join(root, "run-pending-result");
+			const resultsDir = path.join(root, "results");
+			writeStatus(asyncDir, {
+				runId: "run-pending-result",
+				sessionId: "session-current",
+				mode: "single",
+				state: "running",
+				pid: 12345,
+				startedAt: 1000,
+				lastUpdate: 1000,
+				currentStep: 0,
+				steps: [{ agent: "worker", status: "running", startedAt: 1000 }],
+			});
+			const publicResultPath = path.join(resultsDir, "run-pending-result.json");
+			fs.mkdirSync(publicResultPath, { recursive: true });
+			assert.deepEqual(writeAsyncResultFile(publicResultPath, {
+				id: "run-pending-result",
+				runId: "run-pending-result",
+				sessionId: "session-current",
+				success: true,
+				state: "complete",
+				summary: "already done",
+			}), { state: "pending" });
+
+			const result = reconcileAsyncRun(asyncDir, {
+				resultsDir,
+				kill: () => { throw errno("ESRCH"); },
+				now: () => 2000,
+			});
+
+			assert.equal(result.repaired, true);
+			assert.equal(result.status?.state, "complete");
+			assert.equal(result.status?.steps?.[0]?.status, "complete");
+			assert.equal(JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")).state, "complete");
+			assert.equal(fs.statSync(publicResultPath).isDirectory(), true);
+			assert.match(fs.readFileSync(result.resultPath!, "utf-8"), /already done/);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("repairs stale rejected status from an indexed pending status snapshot", () => {
+		const root = tempRoot("pi-stale-rejected-pending-result-");
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const asyncDir = path.join(root, "run-rejected");
+			const resultsDir = path.join(root, "results");
+			writeStatus(asyncDir, {
+				runId: "run-rejected",
+				sessionId: "session-current",
+				mode: "chain",
+				state: "rejected",
+				pid: 12345,
+				startedAt: 1000,
+				lastUpdate: 1000,
+				currentStep: 0,
+				checkpoint: { name: "review", status: "rejected", stepIndex: 0 },
+				steps: [{ agent: "checkpoint:review", status: "rejected", startedAt: 1000, error: "Checkpoint 'review' rejected." }],
+			});
+			const publicResultPath = path.join(resultsDir, "run-rejected.json");
+			fs.mkdirSync(publicResultPath, { recursive: true });
+			writePendingAsyncResultFile(publicResultPath, {
+				id: "run-rejected",
+				runId: "run-rejected",
+				sessionId: "session-current",
+				success: false,
+				state: "rejected",
+				summary: "Checkpoint 'review' rejected.",
+				results: [{ agent: "checkpoint:review", success: false, error: "Checkpoint 'review' rejected." }],
+			});
+
+			const result = reconcileAsyncRun(asyncDir, {
+				resultsDir,
+				kill: () => { throw errno("ESRCH"); },
+				now: () => 2000,
+			});
+
+			assert.equal(result.repaired, false);
+			assert.equal(result.status?.state, "rejected");
+			assert.equal(result.status?.steps?.[0]?.status, "rejected");
+			assert.match(fs.readFileSync(result.resultPath!, "utf-8"), /review/);
+		} finally {
+			console.error = originalError;
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -975,33 +975,31 @@ describe("subagent_wait tool", () => {
 				},
 			};
 
-			// A real timer-based sleep with a LONG poll interval; if wait waited for
-			// the poll it would take ~10s. The event should wake it in ~10ms.
 			let sleepCalls = 0;
-			const realSleep = (ms: number, signal?: AbortSignal) => new Promise<void>((resolve) => {
+			let sleepArmed!: () => void;
+			const armed = new Promise<void>((resolve) => { sleepArmed = resolve; });
+			const sleep = (_ms: number, signal?: AbortSignal) => new Promise<void>((resolve) => {
 				sleepCalls += 1;
-				const t = setTimeout(resolve, ms);
-				signal?.addEventListener("abort", () => { clearTimeout(t); resolve(); }, { once: true });
+				signal?.addEventListener("abort", resolve, { once: true });
+				sleepArmed();
 			});
 
-			const startedAt = Date.now();
 			const p = waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
 				events,
 				pollIntervalMs: 10_000,
-				sleep: realSleep,
+				sleep,
 			}));
 
-			// After a short delay, flip the run terminal and emit a completion event.
-			setTimeout(() => {
-				writeStatus(asyncRoot, "run-a", "complete", { sessionId: "sess-1" });
-				events.emit("subagent:async-complete", { id: "run-a" });
-			}, 15);
+			await armed;
+			writeStatus(asyncRoot, "run-a", "complete", { sessionId: "sess-1" });
+			events.emit("subagent:async-complete", { id: "run-a" });
 
-			const result = await p;
-			const elapsed = Date.now() - startedAt;
+			const result = await Promise.race([
+				p,
+				new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error("event wake did not resolve subagent_wait")), 1_000)),
+			]);
 			assert.equal(result.isError, undefined);
 			assert.match(textOf(result), /done/i);
-			assert.ok(elapsed < 5_000, `should wake via event, not the 10s poll; took ${elapsed}ms`);
 			assert.ok(sleepCalls >= 1, "poll-interval sleep still armed as fallback");
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
+import { writeAsyncResultFile } from "../../src/runs/background/result-files.ts";
 import { WAIT_TOOL_ENABLED_ENV, resolveWaitToolConfig, waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
 import { recordWaitCompletion } from "../../src/runs/background/wait-completions.ts";
 import type { AsyncStatus, SubagentState } from "../../src/shared/types.ts";
@@ -292,6 +293,45 @@ describe("subagent_wait tool", () => {
 			// The result file is the watcher's to consume; the wait must not delete it.
 			assert.equal(fs.existsSync(path.join(resultsDir, "run-a.json")), true);
 		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("surfaces terminal completion payloads from an indexed pending result file", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-completions-pending-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const asyncRoot = path.join(root, "runs");
+			const resultsDir = path.join(root, "results");
+			const publicResultPath = path.join(resultsDir, "run-pending.json");
+			fs.mkdirSync(publicResultPath, { recursive: true });
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-pending", "running", { sessionId: "sess-1", pid: 999999 });
+
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
+				sleep: async () => {
+					writeStatus(asyncRoot, "run-pending", "complete", { sessionId: "sess-1" });
+					assert.deepEqual(writeAsyncResultFile(publicResultPath, {
+						id: "run-pending",
+						runId: "run-pending",
+						sessionId: "sess-1",
+						agent: "worker",
+						mode: "single",
+						state: "complete",
+						success: true,
+						results: [{ agent: "worker", success: true, outputState: "present" }],
+					}), { state: "pending" });
+				},
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.equal(result.details.completions?.[0]?.runId, "run-pending");
+			assert.equal(result.details.completions?.[0]?.success, true);
+			assert.equal(result.details.completions?.[0]?.results?.[0]?.agent, "worker");
+			assert.equal(fs.statSync(publicResultPath).isDirectory(), true);
+		} finally {
+			console.error = originalError;
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});


### PR DESCRIPTION
## Summary

This indexes the async result inbox by session, tool-call, and mission observer so `/reload` no longer scans every stale flat result file. It also uses route indexes for nested route roots and ages stale terminal active markers outside the reload hot path.

## Validation

- `npm run typecheck`
- `npm run test:all`
- `git diff --check`
- fresh review: `.pi/subagents/reviews/reload-performance-fresh-review.main.md`
- follow-up review: `.pi/subagents/reviews/reload-performance-observer-followup.main.md`