### PR TITLE
fix: survive a schedule deleted while its timer is armed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Warn once, instead of on every heartbeat, when a long-running workflow child outlives its mission record. Thanks to @albertgwo for #1079.
+
 ## [0.49.0] - 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Warn once, instead of on every heartbeat, when a long-running workflow child outlives its mission record. Thanks to @albertgwo for #1079.
+- Stop a deleted schedule from exiting Pi when another session still holds its armed timer. Thanks to @albertgwo for #1080.
 
 ## [0.49.0] - 2026-08-13
 

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -239,8 +239,15 @@ class ScheduleStore {
 	}
 
 	get(id: string): ScheduleRecord {
+		const record = this.find(id);
+		if (!record) throw new Error(`Schedule '${id}' not found.`);
+		return record;
+	}
+
+	/** Like {@link get}, but returns undefined when the schedule no longer exists. */
+	find(id: string): ScheduleRecord | undefined {
 		const file = path.join(scheduleDir(this.root, id, false, this.projectCwd), "schedule.json");
-		if (!fs.existsSync(file)) throw new Error(`Schedule '${id}' not found.`);
+		if (!fs.existsSync(file)) return undefined;
 		return parseSchedule(readJson(file, "schedule record"), file);
 	}
 
@@ -600,14 +607,26 @@ export class ScheduledRunManager {
 		if (schedule.paused) return;
 		const next = nextRunAt(schedule);
 		if (next === undefined) return;
-		const timer = this.timersApi.setTimeout(() => void this.fire(store, schedule.id), Math.min(Math.max(0, next - this.now()), MAX_TIMER_DELAY_MS));
+		const timer = this.timersApi.setTimeout(() => {
+			// A timer callback is outside every caller's try/catch, so an escaping
+			// rejection here reaches the process as an uncaught exception and exits
+			// Pi. Contain every failure to this one schedule.
+			void this.fire(store, schedule.id).catch((error) => {
+				console.warn(`[pi-subagents] Scheduled run '${schedule.id}' failed to fire: ${error instanceof Error ? error.message : String(error)}`);
+			});
+		}, Math.min(Math.max(0, next - this.now()), MAX_TIMER_DELAY_MS));
 		timer.unref?.();
 		this.timers.set(this.timerKey(store, schedule.id), timer);
 	}
 
 	private async fire(store: ScheduleStore, id: string): Promise<void> {
 		this.clearTimer(store, id);
-		const schedule = store.get(id);
+		// Schedules are project-scoped and shared, and `delete` only clears the
+		// timer inside the deleting process. Another session can therefore remove
+		// a schedule while this process still holds an armed timer for it; there
+		// is then nothing to run and nothing to re-arm.
+		const schedule = store.find(id);
+		if (!schedule) return;
 		const planned = duePlannedAt(schedule, this.now());
 		if (planned === undefined || schedule.paused) return;
 		if (planned > this.now()) return this.arm(schedule, store);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -108,7 +108,7 @@ import { inspectSubagentStatus } from "../background/run-status.ts";
 import { applyForceTopLevelAsyncOverride } from "../background/top-level-async.ts";
 import { handleMissionAction, MISSION_ACTIONS } from "../../missions/actions.ts";
 import { attachMissionToLaunchResult, prepareMissionLaunch, writeMissionAsyncBinding, type MissionLaunchBinding } from "../../missions/lifecycle.ts";
-import { updateMission } from "../../missions/store.ts";
+import { MissionNotFoundError, updateMission } from "../../missions/store.ts";
 import type { MissionWorkflowChildUpdate } from "../../missions/types.ts";
 import { createMissionWorkflowState } from "../../missions/workflow-state.ts";
 import { resolveAuthorityDecision } from "../../policy/authority.ts";
@@ -4500,6 +4500,14 @@ function duplicateSubagentCallResult(params: SubagentParamsLike): AgentToolResul
 
 const workflowLaunchObservers = new WeakMap<object, (launch: { agent: string; sessionFile?: string; async: boolean; runId?: string }) => void>();
 
+/**
+ * Missions whose record is gone from disk. Terminal-mission retention prunes
+ * records while long-running children are still reporting, and every later
+ * heartbeat would otherwise re-throw and re-warn. Warning once per mission
+ * keeps the console (and the TUI it renders into) usable.
+ */
+const missionsMissingFromStore = new Set<string>();
+
 function recordMissionWorkflowChild(
 	binding: MissionLaunchBinding | undefined,
 	workflowRunId: string,
@@ -4507,10 +4515,17 @@ function recordMissionWorkflowChild(
 	update: Omit<MissionWorkflowChildUpdate, "workflowRunId" | "key">,
 ): void {
 	if (!binding) return;
+	if (missionsMissingFromStore.has(binding.missionId)) return;
 	const { task: _task, ...durableUpdate } = update;
 	try {
 		updateMission(binding.location, binding.missionId, { upsertWorkflowChildren: [{ workflowRunId, key, ...durableUpdate }] });
 	} catch (error) {
+		if (error instanceof MissionNotFoundError) {
+			// No later update can succeed, so stop trying instead of warning per heartbeat.
+			missionsMissingFromStore.add(binding.missionId);
+			console.warn(`[pi-subagents] Mission '${binding.missionId}' is no longer in the mission store; stopped recording its workflow children. Terminal-mission retention can prune a mission while its run is still active.`);
+			return;
+		}
 		console.warn(`[pi-subagents] Failed to record mission workflow child '${key}': ${error instanceof Error ? error.message : String(error)}`);
 	}
 }


### PR DESCRIPTION
## Summary
- return early when a scheduled run fires for a schedule that no longer exists, instead of throwing from the store
- contain any other firing failure to that one schedule, so a timer callback can never exit Pi
- add `ScheduleStore.find`, a lookup that returns undefined rather than throwing; `get` keeps its throwing contract

Pi exits with an uncaught exception when a scheduled run fires for a deleted schedule:

```
pi exiting due to uncaughtException:
Error: Schedule 'topic-space-gate3-recertification-check' not found.
    at ScheduleStore.get (src/runs/background/scheduled-runs.ts:243:37)
    at ScheduledRunManager.fire (src/runs/background/scheduled-runs.ts:610:28)
    at Timeout.<anonymous> (src/runs/background/scheduled-runs.ts:603:61)
```

Schedules are project-scoped and shared, but `delete` clears the timer only inside the deleting process. Every other session holding an armed timer for that schedule then fires, throws from `store.get`, and dies. Because the throw happens in a timer callback it sits outside any caller's `try`/`catch`, so it reaches the process as an uncaught exception: deleting one schedule can take down every other session working on that project. A missing schedule has nothing to run and nothing to re-arm, so returning early is the correct behavior.

## Validation
- `npm run typecheck`
- scheduled-run unit tests (22 pass)
- harness reproducing the exact shape: firing for a deleted schedule rejects before the change and resolves cleanly after
