### PR TITLE
fix: warn once for missing workflow missions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Warn once, instead of on every heartbeat, when a long-running workflow child outlives its mission record. Thanks to @albertgwo for #1079.
+
 ### Changed
 - Reduce reload work for large async histories by indexing the async result inbox by session, observer, and tool-call id instead of scanning every old result file; also age stale terminal active markers and throttle replay cleanup scans.
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -109,7 +109,7 @@ import { inspectSubagentStatus } from "../background/run-status.ts";
 import { applyForceTopLevelAsyncOverride } from "../background/top-level-async.ts";
 import { handleMissionAction, MISSION_ACTIONS } from "../../missions/actions.ts";
 import { attachMissionToLaunchResult, prepareMissionLaunch, writeMissionAsyncBinding, type MissionLaunchBinding } from "../../missions/lifecycle.ts";
-import { updateMission } from "../../missions/store.ts";
+import { MissionNotFoundError, updateMission } from "../../missions/store.ts";
 import type { MissionWorkflowChildUpdate } from "../../missions/types.ts";
 import { createMissionWorkflowState } from "../../missions/workflow-state.ts";
 import { resolveAuthorityDecision } from "../../policy/authority.ts";
@@ -4529,17 +4529,28 @@ function duplicateSubagentCallResult(params: SubagentParamsLike): AgentToolResul
 
 const workflowLaunchObservers = new WeakMap<object, (launch: { agent: string; sessionFile?: string; async: boolean; runId?: string }) => void>();
 
+/**
+ * Terminal-mission retention can remove a mission while its children still
+ * report. Remember it to prevent later heartbeats from warning repeatedly.
+ */
+const missionsMissingFromStore = new Set<string>();
+
 function recordMissionWorkflowChild(
 	binding: MissionLaunchBinding | undefined,
 	workflowRunId: string,
 	key: string,
 	update: Omit<MissionWorkflowChildUpdate, "workflowRunId" | "key">,
 ): void {
-	if (!binding) return;
+	if (!binding || missionsMissingFromStore.has(binding.missionId)) return;
 	const { task: _task, ...durableUpdate } = update;
 	try {
 		updateMission(binding.location, binding.missionId, { upsertWorkflowChildren: [{ workflowRunId, key, ...durableUpdate }] });
 	} catch (error) {
+		if (error instanceof MissionNotFoundError) {
+			missionsMissingFromStore.add(binding.missionId);
+			console.warn(`[pi-subagents] Mission '${binding.missionId}' is no longer in the mission store; stopped recording its workflow children. Terminal-mission retention can prune a mission while its run is still active.`);
+			return;
+		}
 		console.warn(`[pi-subagents] Failed to record mission workflow child '${key}': ${error instanceof Error ? error.message : String(error)}`);
 	}
 }

--- a/test/unit/workflow-chat-progress.test.ts
+++ b/test/unit/workflow-chat-progress.test.ts
@@ -202,6 +202,38 @@ describe("workflow chat progress rendering", () => {
 		}
 	});
 
+	it("warns once when a workflow child outlives its mission record", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-workflow-missing-mission-"));
+		const originalWarn = console.warn;
+		const warnings: string[] = [];
+		try {
+			const location = {
+				projectRoot: root,
+				missionDir: path.join(root, ".pi/subagents", "missions"),
+				globalIndexDir: path.join(root, ".pi/subagents", "mission-index"),
+				writeGlobalIndex: false,
+			};
+			const mission = createMission(location, { title: "Workflow", objective: "Track child" });
+			fs.rmSync(path.join(location.missionDir, `${mission.id}.json`));
+			console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+
+			for (const key of ["first", "second"]) {
+				await assert.rejects(
+					() => runMissionWorkflowChild({ missionId: mission.id, location, autoCreated: false }, "wf-missing-mission", key, "Prep", async () => {
+						throw new Error("child failed");
+					}),
+					/child failed/,
+				);
+			}
+
+			assert.equal(warnings.length, 1);
+			assert.match(warnings[0] ?? "", new RegExp(`Mission '${mission.id}' is no longer in the mission store`));
+		} finally {
+			console.warn = originalWarn;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("renders stable rows keyed by workflow trace entries", () => {
 		const text = componentText(renderSubagentResult({
 			content: [{ type: "text", text: "Workflow running." }],


### PR DESCRIPTION
## Summary

Reworks #1079 on current `main` so a workflow child warns once when its mission record has already been pruned, then skips later repeated mission updates for that mission id.

This preserves @albertgwo's reported fix from #1079 and keeps the contributor credit in `CHANGELOG.md`.

## Validation

- `node --experimental-strip-types --test test/unit/workflow-chat-progress.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `git show --check --oneline --stat HEAD`

## Performance impact

Disproved. The change adds one in-memory `Set` lookup and prevents repeated filesystem update attempts after the first missing mission.