### PR TITLE
fix: observe awaited workflow runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Changed
 - Reduce reload work for large async histories by indexing the async result inbox by session, observer, and tool-call id instead of scanning every old result file; also age stale terminal active markers and throttle replay cleanup scans.
 
+### Fixed
+- Count native `await` use of `runs.run`, `runs.all`, and launch-containing Promise combinators as consumed without allowing fire-and-forget launches. Thanks to @kebinzhi for #1082.
+
 ## [0.49.0] - 2026-08-13
 
 ### Added

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -4,15 +4,23 @@ const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 const WORKER_SOURCE = String.raw`
 const { parentPort } = require("node:worker_threads");
+const { promiseHooks } = require("node:v8");
 const vm = require("node:vm");
 const { inspect } = require("node:util");
 
+if (!promiseHooks || typeof promiseHooks.createHook !== "function") throw new Error("workflowScript requires node:v8 promiseHooks.createHook support.");
+
 let nextCallId = 0;
+let topLevelWorkflowPromise;
+let suppressNativePromiseConsumption = 0;
+const activeNativePromises = [];
 const pending = new Map();
 const runKeyPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
-const trackedPromisePatch = Symbol("trackedPromisePatch");
-const trackedPromiseObservations = new WeakMap();
-let suppressRunObservation = 0;
+const trackedPromiseTrackers = new WeakMap();
+const trackedPromiseTargets = new WeakMap();
+let nativePromiseTrackers = new WeakMap();
+let nativePromiseParents = new WeakMap();
+const observedRunCallIds = new Set();
 
 function stableRunJson(value) {
   if (Array.isArray(value)) return "[" + value.map(stableRunJson).join(",") + "]";
@@ -23,15 +31,47 @@ function stableRunJson(value) {
 function isDirectWorkflowScriptPromiseHandlerCall() {
   const stack = new Error().stack;
   if (typeof stack !== "string") return false;
-  const frame = stack.split("\n").slice(1).map((line) => line.trim()).find((line) =>
-    line &&
-    !line.includes("isDirectWorkflowScriptPromiseHandlerCall") &&
-    !line.includes("markObserved") &&
-    !line.includes("promise.then") &&
-    !line.includes("promise.catch") &&
-    !line.includes("promise.finally")
-  );
-  return frame ? frame.includes("workflow-script.js") && !frame.includes("at async ") : false;
+  return stack.split("\n").some((line) => line.includes("workflow-script.js") && !line.includes("at async "));
+}
+
+function nativePromiseTracker(promise) {
+  if (!promise || (typeof promise !== "object" && typeof promise !== "function")) return undefined;
+  let tracker = nativePromiseTrackers.get(promise);
+  if (!tracker) {
+    tracker = { observations: [], consumed: false, dependencies: [] };
+    nativePromiseTrackers.set(promise, tracker);
+  }
+  return tracker;
+}
+
+function promiseObservationTracker(value) {
+  if (!value || (typeof value !== "object" && typeof value !== "function")) return undefined;
+  return trackedPromiseTrackers.get(value) ?? nativePromiseTrackers.get(value);
+}
+
+function addTrackerDependency(tracker, dependency) {
+  if (!dependency) return;
+  tracker.dependencies ??= [];
+  if (!tracker.dependencies.includes(dependency)) tracker.dependencies.push(dependency);
+  if (tracker.consumed) markTrackedObservationsConsumed(dependency);
+}
+
+function descendsFromTopLevelWorkflow(promise) {
+  const seen = new Set();
+  for (let current = promise; current && !seen.has(current); current = nativePromiseParents.get(current)) {
+    if (current === topLevelWorkflowPromise) return true;
+    seen.add(current);
+  }
+  return false;
+}
+
+function withSuppressedNativePromiseConsumption(callback) {
+  suppressNativePromiseConsumption++;
+  try {
+    return callback();
+  } finally {
+    suppressNativePromiseConsumption--;
+  }
 }
 
 function mergeObservations(...groups) {
@@ -47,63 +87,107 @@ function mergeObservations(...groups) {
   return merged;
 }
 
-function trackedObservations(value) {
-  return value && (typeof value === "object" || typeof value === "function") ? trackedPromiseObservations.get(value) ?? [] : [];
+function trackedObservationTracker(value) {
+  return value && (typeof value === "object" || typeof value === "function") ? trackedPromiseTrackers.get(value) : undefined;
 }
 
-function withSuppressedRunObservation(callback) {
-  suppressRunObservation += 1;
-  try {
-    return callback();
-  } finally {
-    suppressRunObservation -= 1;
+function trackedPromiseTarget(value) {
+  return value && (typeof value === "object" || typeof value === "function") ? trackedPromiseTargets.get(value) ?? value : value;
+}
+
+function addTrackedObservations(tracker, observations) {
+  tracker.observations = mergeObservations(tracker.observations, observations);
+  if (!tracker.consumed) return;
+  for (const observation of tracker.observations) {
+    if (observedRunCallIds.has(observation.callId)) continue;
+    observedRunCallIds.add(observation.callId);
+    parentPort.postMessage({ type: "runObserved", callId: observation.callId, key: observation.key });
   }
 }
 
-function trackRunObservation(observations, promise) {
-  const merged = mergeObservations(trackedObservations(promise), observations);
-  if (merged.length === 0 || !promise || typeof promise.then !== "function") return promise;
-  trackedPromiseObservations.set(promise, merged);
-  if (promise[trackedPromisePatch]) return promise;
+function markTrackedObservationsConsumed(tracker, seen = new Set()) {
+  if (seen.has(tracker)) return;
+  seen.add(tracker);
+  tracker.consumed = true;
+  addTrackedObservations(tracker, []);
+  for (const dependency of tracker.dependencies ?? []) markTrackedObservationsConsumed(dependency, seen);
+}
 
-  const observedCallIds = new Set();
-  const markObserved = () => {
-    if (suppressRunObservation > 0 || isDirectWorkflowScriptPromiseHandlerCall()) return;
-    for (const observation of trackedObservations(promise)) {
-      if (observedCallIds.has(observation.callId)) continue;
-      observedCallIds.add(observation.callId);
-      parentPort.postMessage({ type: "runObserved", callId: observation.callId, key: observation.key });
-    }
-  };
-  const originalThen = promise.then.bind(promise);
-  const originalCatch = promise.catch.bind(promise);
-  const originalFinally = promise.finally.bind(promise);
-  Object.defineProperty(promise, trackedPromisePatch, { value: true });
-  promise.then = (onFulfilled, onRejected) => {
-    markObserved();
-    return trackRunObservation(trackedObservations(promise), originalThen(onFulfilled, onRejected));
-  };
-  promise.catch = (onRejected) => {
-    markObserved();
-    return trackRunObservation(trackedObservations(promise), originalCatch(onRejected));
-  };
-  promise.finally = (onFinally) => {
-    markObserved();
-    return trackRunObservation(trackedObservations(promise), originalFinally(onFinally));
-  };
-  return promise;
+function consumeTrackedObservations(tracker) {
+  if (isDirectWorkflowScriptPromiseHandlerCall()) return;
+  const activePromise = activeNativePromises.at(-1);
+  if (activePromise === topLevelWorkflowPromise || descendsFromTopLevelWorkflow(activePromise)) {
+    markTrackedObservationsConsumed(tracker);
+  } else if (activePromise) {
+    addTrackerDependency(nativePromiseTracker(activePromise), tracker);
+  } else {
+    markTrackedObservationsConsumed(tracker);
+  }
+}
+
+function trackObservationTracker(tracker, promise, allowFutureObservations = false) {
+  const target = trackedPromiseTarget(promise);
+  if ((!allowFutureObservations && tracker.observations.length === 0) || !target || typeof target.then !== "function") return promise;
+
+  const tracked = new Proxy(target, {
+    get(promiseTarget, prop) {
+      if (prop === "then") return function promiseThen(onFulfilled, onRejected) {
+        consumeTrackedObservations(tracker);
+        return trackObservationTracker({ observations: tracker.observations, consumed: false, dependencies: [tracker] }, promiseTarget.then(onFulfilled, onRejected), true);
+      };
+      if (prop === "catch") return function promiseCatch(onRejected) {
+        consumeTrackedObservations(tracker);
+        return trackObservationTracker({ observations: tracker.observations, consumed: false, dependencies: [tracker] }, promiseTarget.catch(onRejected), true);
+      };
+      if (prop === "finally") return function promiseFinally(onFinally) {
+        consumeTrackedObservations(tracker);
+        return trackObservationTracker({ observations: tracker.observations, consumed: false, dependencies: [tracker] }, promiseTarget.finally(onFinally), true);
+      };
+      return Reflect.get(promiseTarget, prop, promiseTarget);
+    },
+  });
+  trackedPromiseTrackers.set(tracked, tracker);
+  trackedPromiseTargets.set(tracked, target);
+  return tracked;
+}
+
+function trackRunObservation(observations, promise) {
+  const tracker = trackedObservationTracker(promise) ?? { observations: [], consumed: false };
+  addTrackedObservations(tracker, observations);
+  return trackObservationTracker(tracker, promise);
 }
 
 function trackPromiseCombinator(items, createPromise) {
   const values = Array.from(items);
-  const observations = mergeObservations(...values.map(trackedObservations));
-  const promise = withSuppressedRunObservation(() => createPromise(values));
-  return observations.length > 0 ? trackRunObservation(observations, promise) : promise;
+  const dependencies = [...new Set(values.map(promiseObservationTracker).filter(Boolean))];
+  const promise = withSuppressedNativePromiseConsumption(() => createPromise(values.map(trackedPromiseTarget)));
+  if (dependencies.length === 0) return promise;
+  return trackObservationTracker({ observations: [], consumed: false, dependencies }, promise, true);
 }
 
 const workflowPromise = new Proxy(Promise, {
-  construct(target, args) {
-    return new target(...args);
+  construct(target, [executor]) {
+    if (typeof executor !== "function") return new target(executor);
+    const tracker = { observations: [], consumed: false };
+    const promise = new target((resolve, reject) => {
+      let settled = false;
+      try {
+        executor((value) => {
+          if (settled) return;
+          settled = true;
+          addTrackerDependency(tracker, promiseObservationTracker(value));
+          resolve(trackedPromiseTarget(value));
+        }, (reason) => {
+          if (settled) return;
+          settled = true;
+          reject(reason);
+        });
+      } catch (error) {
+        settled = true;
+        throw error;
+      }
+    });
+    return trackObservationTracker(tracker, promise, true);
   },
   get(target, prop) {
     if (prop === "all") return (items) => trackPromiseCombinator(items, (values) => target.all(values));
@@ -111,9 +195,10 @@ const workflowPromise = new Proxy(Promise, {
     if (prop === "race") return (items) => trackPromiseCombinator(items, (values) => target.race(values));
     if (prop === "any") return (items) => trackPromiseCombinator(items, (values) => target.any(values));
     if (prop === "resolve") return (value) => {
-      const observations = trackedObservations(value);
-      const promise = withSuppressedRunObservation(() => target.resolve(value));
-      return observations.length > 0 ? trackRunObservation(observations, promise) : promise;
+      const dependency = promiseObservationTracker(value);
+      const promise = withSuppressedNativePromiseConsumption(() => target.resolve(trackedPromiseTarget(value)));
+      if (!dependency) return promise;
+      return trackObservationTracker({ observations: [], consumed: false, dependencies: [dependency] }, promise, true);
     };
     const value = target[prop];
     return typeof value === "function" ? value.bind(target) : value;
@@ -306,7 +391,63 @@ parentPort.on("message", async (message) => {
       parentPort.postMessage({ type: "error", error: formatWorkflowScriptSyntaxError(error) });
       return;
     }
-    const value = await compiled.runInContext(context);
+    const nativePromisePrototype = vm.runInContext("(async () => {})().constructor.prototype", context);
+    const nativeThenDescriptor = Object.getOwnPropertyDescriptor(nativePromisePrototype, "then");
+    if (!nativeThenDescriptor || typeof nativeThenDescriptor.value !== "function") throw new Error("workflowScript could not inspect the VM Promise.prototype.then method.");
+    const nativeThen = nativeThenDescriptor.value;
+    let stopWorkflowPromiseHook;
+    let value;
+    try {
+      Object.defineProperty(nativePromisePrototype, "then", {
+        ...nativeThenDescriptor,
+        value: function workflowPromiseThen(...args) {
+          if (isDirectWorkflowScriptPromiseHandlerCall() || suppressNativePromiseConsumption > 0) {
+            return withSuppressedNativePromiseConsumption(() => Reflect.apply(nativeThen, this, args));
+          }
+          return Reflect.apply(nativeThen, this, args);
+        },
+      });
+      stopWorkflowPromiseHook = promiseHooks.createHook({
+        before(promise) {
+          activeNativePromises.push(promise);
+        },
+        after(promise) {
+          const index = activeNativePromises.lastIndexOf(promise);
+          if (index !== -1) activeNativePromises.splice(index, 1);
+        },
+        init(promise, parent) {
+          const childTracker = nativePromiseTracker(promise);
+          if (!parent) return;
+          nativePromiseParents.set(promise, parent);
+          const parentTracker = nativePromiseTracker(parent);
+          addTrackerDependency(childTracker, parentTracker);
+          const activePromise = activeNativePromises.at(-1);
+          if (activePromise && activePromise !== parent) {
+            addTrackerDependency(nativePromiseTracker(activePromise), parentTracker);
+          } else if (!activePromise && suppressNativePromiseConsumption === 0) {
+            markTrackedObservationsConsumed(parentTracker);
+          }
+        },
+      });
+      const workflowResultPromise = compiled.runInContext(context);
+      topLevelWorkflowPromise = workflowResultPromise;
+      markTrackedObservationsConsumed(nativePromiseTracker(workflowResultPromise));
+      value = await workflowResultPromise;
+    } finally {
+      try {
+        stopWorkflowPromiseHook?.();
+      } finally {
+        try {
+          Object.defineProperty(nativePromisePrototype, "then", nativeThenDescriptor);
+        } finally {
+          topLevelWorkflowPromise = undefined;
+          activeNativePromises.length = 0;
+          suppressNativePromiseConsumption = 0;
+          nativePromiseTrackers = new WeakMap();
+          nativePromiseParents = new WeakMap();
+        }
+      }
+    }
     const persistedValue = value === undefined ? null : omitUndefinedWorkflowValues(value);
     assertJsonValue(persistedValue, "return");
     parentPort.postMessage({ type: "complete", value: persistedValue });

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -591,6 +591,133 @@ describe("scripted workflow runtime", () => {
 		);
 	});
 
+	it("rejects an unawaited new Promise wrapper over runs.run", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `new Promise((resolve) => resolve(runs.run("wrapped", { agent: "worker", task: "fire" }))); return "done";`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && error.message.includes("unawaited runs.run launch(es): 'wrapped'"),
+		);
+	});
+
+	it("rejects an unawaited async helper wrapper over runs.run", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `async function helper() { return runs.run("async-bare", { agent: "worker", task: "run" }); } helper(); return "done";`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && error.message.includes("unawaited runs.run launch(es): 'async-bare'"),
+		);
+	});
+
+	it("accepts an awaited async helper wrapper over runs.run", async () => {
+		const result = await runWorkflowScript({
+			script: `async function helper() { return runs.run("async-awaited", { agent: "worker", task: "run" }); } const child = await helper(); return child.output;`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "helper output", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(result.value, "helper output");
+	});
+
+	it("accepts awaited and returned handlers on async helper wrappers", async () => {
+		const handlers = [
+			{ name: "then", chain: "then((value) => value)" },
+			{ name: "catch", chain: "catch(() => ({ output: 'fallback' }))" },
+			{ name: "finally", chain: "finally(() => {})" },
+		];
+		for (const mode of ["await", "return"] as const) {
+			for (const { name, chain } of handlers) {
+				const key = `${mode}-${name}`;
+				const expression = `helper().${chain}`;
+				const result = await runWorkflowScript({
+					script: `async function helper() { return runs.run("${key}", { agent: "worker", task: "run" }); } ${mode === "await" ? `const child = await ${expression}; return child.output;` : `return ${expression};`}`,
+					timeoutMs: 2_000,
+					async launch(key) { return { key, ok: true, output: "helper chain output", artifactPaths: [] }; },
+					async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				});
+				assert.equal(mode === "await" ? result.value : (result.value as { output: string }).output, "helper chain output");
+			}
+		}
+	});
+
+	it("rejects a nested dropped async helper propagation wrapper", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `async function inner() { return runs.run("nested-bare", { agent: "worker", task: "run" }); } async function outer() { return inner(); } outer(); return "done";`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && error.message.includes("unawaited runs.run launch(es): 'nested-bare'"),
+		);
+	});
+
+	it("accepts awaited and returned nested async helper wrappers", async () => {
+		for (const mode of ["await", "return"] as const) {
+			const key = `nested-${mode}`;
+			const result = await runWorkflowScript({
+				script: `async function inner() { return runs.run("${key}", { agent: "worker", task: "run" }); } async function outer() { return inner(); } ${mode === "await" ? "const child = await outer(); return child.output;" : "return outer();"}`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "nested output", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			});
+			assert.equal(mode === "await" ? result.value : (result.value as { output: string }).output, "nested output");
+		}
+	});
+
+	it("counts an explicit internal helper await as observed", async () => {
+		const result = await runWorkflowScript({
+			script: `async function helper() { return await runs.run("internal-await", { agent: "worker", task: "run" }); } helper(); return "done";`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "helper output", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(result.value, "done");
+	});
+
+	it("rejects detached handlers on async helper wrappers", async () => {
+		const handlers = [
+			{ key: "async-then", chain: "then(() => {})" },
+			{ key: "async-catch", chain: "catch(() => {})" },
+			{ key: "async-finally", chain: "finally(() => {})" },
+		];
+		for (const { key, chain } of handlers) {
+			await assert.rejects(
+				runWorkflowScript({
+					script: `async function helper() { return runs.run("${key}", { agent: "worker", task: "run" }); } helper().${chain}; return "done";`,
+					timeoutMs: 2_000,
+					async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+					async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				}),
+				(error: unknown) => error instanceof WorkflowScriptError && error.message.includes(`unawaited runs.run launch(es): '${key}'`),
+			);
+		}
+	});
+
+	it("rejects a launch passed to an ignored repeated Promise resolution", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `
+				await new Promise((resolve) => {
+					resolve("done");
+					Promise.resolve().then(() => resolve(runs.run("ignored", { agent: "worker", task: "fire" })));
+				});
+				return "done";
+			`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && error.message.includes("unawaited runs.run launch(es): 'ignored'"),
+		);
+	});
+
 	it("rejects fire-and-forget callbacks on a runs.run promise", async () => {
 		await assert.rejects(
 			runWorkflowScript({
@@ -601,6 +728,25 @@ describe("scripted workflow runtime", () => {
 			}),
 			(error: unknown) => error instanceof WorkflowScriptError && error.message.includes("unawaited runs.run launch(es): 'bg'"),
 		);
+	});
+
+	it("rejects detached promise handlers after an await", async () => {
+		const handlers = [
+			{ key: "bg-then", chain: "then(() => {})" },
+			{ key: "bg-catch", chain: "catch(() => {})" },
+			{ key: "bg-finally", chain: "finally(() => {})" },
+		];
+		for (const { key, chain } of handlers) {
+			await assert.rejects(
+				runWorkflowScript({
+					script: `await Promise.resolve(); runs.run("${key}", { agent: "worker", task: "fire" }).${chain}; return "done";`,
+					timeoutMs: 2_000,
+					async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+					async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				}),
+				(error: unknown) => error instanceof WorkflowScriptError && error.message.includes(`unawaited runs.run launch(es): '${key}'`),
+			);
+		}
 	});
 
 	it("rejects reading output from an unawaited runs.run promise", async () => {
@@ -643,14 +789,111 @@ describe("scripted workflow runtime", () => {
 		assert.equal((result.value as { output?: string }).output, "direct output");
 	});
 
-	it("accepts output from an explicitly awaited runs.run promise", async () => {
+	it("accepts a docs-style awaited runs.run launch", async () => {
 		const result = await runWorkflowScript({
-			script: `return (await runs.run("awaited", { agent: "worker", task: "run" })).output;`,
+			script: `const child = await runs.run("awaited", { agent: "worker", task: "run" }); return child.output;`,
 			timeoutMs: 2_000,
 			async launch(key) { return { key, ok: true, output: "awaited output", artifactPaths: [] }; },
 			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
 		});
 		assert.equal(result.value, "awaited output");
+	});
+
+	it("accepts a docs-style awaited runs.all launch group", async () => {
+		const result = await runWorkflowScript({
+			script: `const children = await runs.all([{ key: "one", agent: "worker", task: "run" }]); return children[0].output;`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "group output", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(result.value, "group output");
+	});
+
+	it("accepts sequential awaited launches that use the first output", async () => {
+		const tasks: unknown[] = [];
+		const result = await runWorkflowScript({
+			script: `
+				const first = await runs.run("first", { agent: "worker", task: "plan" });
+				const second = await runs.run("second", { agent: "worker", task: first.output });
+				return second.output;
+			`,
+			timeoutMs: 2_000,
+			async launch(key, params) {
+				tasks.push(params.task);
+				return { key, ok: true, output: key === "first" ? "first output" : "second output", artifactPaths: [] };
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.deepEqual(tasks, ["plan", "first output"]);
+		assert.equal(result.value, "second output");
+	});
+
+	it("accepts an awaited native Promise combinator over launches", async () => {
+		const result = await runWorkflowScript({
+			script: `const children = await Promise.all([runs.run("native", { agent: "worker", task: "run" })]); return children[0].output;`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "native output", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(result.value, "native output");
+	});
+
+	it("accepts Promise.resolve over a pending helper wrapper", async () => {
+		const result = await runWorkflowScript({
+			script: `
+				const helper = new Promise((resolve) => Promise.resolve().then(() =>
+					resolve(runs.run("resolve-helper", { agent: "worker", task: "run" }))
+				));
+				const child = await Promise.resolve(helper);
+				return child.output;
+			`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "resolved helper output", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(result.value, "resolved helper output");
+	});
+
+	it("accepts Promise.all over a pending helper wrapper", async () => {
+		const result = await runWorkflowScript({
+			script: `
+				const helper = new Promise((resolve) => Promise.resolve().then(() =>
+					resolve(runs.run("combo-later", { agent: "worker", task: "run" }))
+				));
+				const children = await Promise.all([helper]);
+				return children[0].output;
+			`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "pending helper output", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(result.value, "pending helper output");
+	});
+
+	it("accepts an awaited then chain over a pending helper wrapper", async () => {
+		const result = await runWorkflowScript({
+			script: `
+				const helper = new Promise((resolve) => Promise.resolve().then(() =>
+					resolve(runs.run("chain-later", { agent: "worker", task: "run" }))
+				));
+				const child = await helper.then((value) => value);
+				return child.output;
+			`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "chain output", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(result.value, "chain output");
+	});
+
+	it("accepts an awaited new Promise wrapper over runs.run", async () => {
+		const result = await runWorkflowScript({
+			script: `const child = await new Promise((resolve) => resolve(runs.run("wrapped", { agent: "worker", task: "run" }))); return child.output;`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, output: "wrapped output", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(result.value, "wrapped output");
 	});
 
 	it("rejects non-JSON-safe emitted values without persisting them", async () => {


### PR DESCRIPTION
## Summary

Fixes #1082 by making awaited `runs.run`, `runs.all`, and launch-containing Promise wrappers count as consumed without weakening the fire-and-forget guard.

The fix uses a worker-local `node:v8` `promiseHooks` graph plus tracked Promise proxies. It observes direct `await`, direct `return`, awaited or returned helper chains, `Promise.resolve`, native Promise combinators, and awaited `.then/.catch/.finally` chains. It still rejects bare launches, dropped propagation helpers, detached handlers, detached `Promise.resolve`, bare combinators, and ignored repeated resolutions.

Thanks @kebinzhi for the report and reproduction.

## Validation

- `npx -y node@24 --experimental-strip-types --test test/unit/scripted-workflow.test.ts`
- `node --experimental-strip-types --test test/unit/scripted-workflow.test.ts`
- targeted 45-case contract matrix on Node 24 and Node 25
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `git show --check --oneline --stat HEAD`
- fresh exact-head review: no release blockers at `4681a90e`

## Performance impact

The Promise hook runs only inside the dedicated workflow worker while that workflow script executes, and graph state is cleared when the workflow settles. The host Promise prototype is not patched.

A local Node 24 benchmark measured the `promiseHooks` graph at about `+1.6 µs` for a simple workflow start, `+112 µs` for 100 awaited Promises, and `+58 µs` for 100 `Promise.all` inputs. The oracle/review path found this safer and more complete than the earlier async-hooks classifier.
