### PR TITLE
fix: survive deleted schedules with armed timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Warn once, instead of on every heartbeat, when a long-running workflow child outlives its mission record. Thanks to @albertgwo for #1079.
+- Keep deleted-schedule timers from exiting Pi and re-arm recurring schedules after unexpected timer fire failures. Thanks to @albertgwo for #1084.
 
 ### Changed
 - Reduce reload work for large async histories by indexing the async result inbox by session, observer, and tool-call id instead of scanning every old result file; also age stale terminal active markers and throttle replay cleanup scans.

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -239,8 +239,15 @@ class ScheduleStore {
 	}
 
 	get(id: string): ScheduleRecord {
+		const record = this.find(id);
+		if (!record) throw new Error(`Schedule '${id}' not found.`);
+		return record;
+	}
+
+	/** Like {@link get}, but returns undefined when the schedule no longer exists. */
+	find(id: string): ScheduleRecord | undefined {
 		const file = path.join(scheduleDir(this.root, id, false, this.projectCwd), "schedule.json");
-		if (!fs.existsSync(file)) throw new Error(`Schedule '${id}' not found.`);
+		if (!fs.existsSync(file)) return undefined;
 		return parseSchedule(readJson(file, "schedule record"), file);
 	}
 
@@ -546,7 +553,7 @@ export class ScheduledRunManager {
 		for (const schedule of store.list()) this.restoreOne(store, schedule);
 	}
 
-	private restoreOne(store: ScheduleStore, schedule: ScheduleRecord): void {
+	private restoreOne(store: ScheduleStore, schedule: ScheduleRecord, notBefore?: number, rearm = true): void {
 		if (schedule.activeRunId) {
 			const run = store.history(schedule.id).find((item) => item.id === schedule.activeRunId);
 			if (run?.state === "running" && run.asyncId) this.observedAsyncIds.add(run.asyncId);
@@ -572,26 +579,59 @@ export class ScheduledRunManager {
 				fs.rmSync(path.join(store.directory(schedule.id), "active.lock"), { force: true });
 			}
 		}
-		if (schedule.paused) return;
+		if (!rearm || schedule.paused) return;
 		const next = nextRunAt(schedule);
 		if (next === undefined) return;
-		if (!schedule.activeRunId && next < this.now() && schedule.catchUp === "none") this.recordMissed(store, schedule, next, "timer");
-		this.arm(schedule, store);
+		if (!schedule.activeRunId && next < this.now() && schedule.catchUp === "none") {
+			try {
+				this.recordMissed(store, schedule, next, "timer");
+			} catch (error) {
+				if (notBefore !== undefined) this.arm(schedule, store, notBefore);
+				throw error;
+			}
+		}
+		this.arm(schedule, store, notBefore);
 	}
 
-	private arm(schedule: ScheduleRecord, store: ScheduleStore): void {
+	private arm(schedule: ScheduleRecord, store: ScheduleStore, notBefore?: number): void {
 		this.clearTimer(store, schedule.id);
 		if (schedule.paused) return;
 		const next = nextRunAt(schedule);
 		if (next === undefined) return;
-		const timer = this.timersApi.setTimeout(() => void this.fire(store, schedule.id), Math.min(Math.max(0, next - this.now()), MAX_TIMER_DELAY_MS));
+		const timer = this.timersApi.setTimeout(() => {
+			// A timer callback is outside every caller's try/catch, so an escaping
+			// rejection here reaches the process as an uncaught exception and exits
+			// Pi. Contain every failure to this one schedule.
+			void this.fire(store, schedule.id).catch((error) => {
+				console.warn(`[pi-subagents] Scheduled run '${schedule.id}' failed to fire: ${error instanceof Error ? error.message : String(error)}`);
+				this.restoreAfterFireError(store, schedule.id);
+			});
+		}, Math.min(Math.max(0, next - this.now(), (notBefore ?? 0) - this.now()), MAX_TIMER_DELAY_MS));
 		timer.unref?.();
 		this.timers.set(this.timerKey(store, schedule.id), timer);
 	}
 
+	private restoreAfterFireError(store: ScheduleStore, id: string): void {
+		try {
+			const schedule = store.find(id);
+			if (!schedule) return;
+			const now = this.now();
+			const planned = schedule.trigger.kind === "interval" ? duePlannedAt(schedule, now) : undefined;
+			const notBefore = planned !== undefined && planned <= now ? Date.parse(nextAfter(schedule.trigger, planned, now)!) : undefined;
+			this.restoreOne(store, schedule, notBefore, schedule.trigger.kind === "interval");
+		} catch (error) {
+			console.warn(`[pi-subagents] Scheduled run '${id}' could not be restored after fire failure: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
 	private async fire(store: ScheduleStore, id: string): Promise<void> {
 		this.clearTimer(store, id);
-		const schedule = store.get(id);
+		// Schedules are project-scoped and shared, and `delete` only clears the
+		// timer inside the deleting process. Another session can therefore remove
+		// a schedule while this process still holds an armed timer for it; there
+		// is then nothing to run and nothing to re-arm.
+		const schedule = store.find(id);
+		if (!schedule) return;
 		const planned = duePlannedAt(schedule, this.now());
 		if (planned === undefined || schedule.paused) return;
 		if (planned > this.now()) return this.arm(schedule, store);

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -66,7 +66,7 @@ function context(cwd: string, sessionId = "session-a"): ExtensionContext {
 	} as unknown as ExtensionContext;
 }
 
-function harness(options: { cwd?: string; sessionId?: string; now?: number; config?: ExtensionConfig } = {}): Harness {
+function harness(options: { cwd?: string; sessionId?: string; now?: number; config?: ExtensionConfig; randomId?: () => string } = {}): Harness {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-schedule-test-"));
 	roots.push(root);
 	const project = options.cwd ?? path.join(root, "project");
@@ -80,7 +80,7 @@ function harness(options: { cwd?: string; sessionId?: string; now?: number; conf
 		config: options.config ?? { scheduledRuns: { enabled: true } },
 		storeRoot: path.join(root, "stores"),
 		now: () => clock.now,
-		randomId: () => `id-${++id}`,
+		randomId: options.randomId ?? (() => `id-${++id}`),
 		timers,
 		launch: (params, launchCtx) => new Promise((resolve) => launches.push({ params: params as Record<string, unknown>, ctx: launchCtx, resolve: resolve as Launch["resolve"] })) as never,
 	});
@@ -237,6 +237,41 @@ describe("project schedule management", () => {
 		assert.match(text(await h.manager.handleToolCall({ action: "schedule.list" }, h.ctx)), /No project schedules/);
 	});
 
+	it("ignores schedules deleted by another session while a timer is still armed", async () => {
+		const first = harness();
+		await first.manager.handleToolCall({ action: "schedule.create", id: "stale", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, first.ctx);
+		const secondTimers = new FakeTimers();
+		const second = createScheduledRunManager({
+			config: { scheduledRuns: { enabled: true } },
+			storeRoot: path.join(first.root, "stores"),
+			now: () => first.clock.now,
+			timers: secondTimers,
+			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
+		});
+		const secondCtx = context(first.ctx.cwd, "session-b");
+		second.bindSession(secondCtx);
+		assert.equal(first.timers.values.size, 1);
+		assert.equal(secondTimers.values.size, 1);
+
+		assert.match(text(await second.handleToolCall({ action: "schedule.delete", id: "stale" }, secondCtx)), /Deleted/);
+		assert.equal(secondTimers.values.size, 0);
+		assert.equal(first.timers.values.size, 1);
+		first.clock.now += 3_600_000;
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message?: unknown) => void warnings.push(String(message));
+		try {
+			first.timers.fireAll();
+			await flush();
+		} finally {
+			console.warn = originalWarn;
+		}
+		assert.deepEqual(warnings, []);
+		assert.equal(first.launches.length, 0);
+		assert.equal(first.timers.values.size, 0);
+		assert.match(text(await first.manager.handleToolCall({ action: "schedule.list" }, first.ctx)), /No project schedules/);
+	});
+
 	it("reports corrupt project schedule records instead of dropping them", async () => {
 		const h = harness();
 		const root = scheduledRunStorePath(h.ctx.cwd, undefined, path.join(h.root, "stores"));
@@ -311,6 +346,74 @@ describe("recurring schedule execution", () => {
 		assert.equal(fs.existsSync(path.join(dir, "active.lock")), false);
 		const shown = await h.manager.handleToolCall({ action: "schedule.show", id: "hourly" }, h.ctx);
 		assert.match(text(shown), /2030-01-01T02:00:00.000Z/, "next occurrence advances from the planned time without completion drift");
+	});
+
+	it("delays retrying an overdue recurring schedule after an unexpected timer failure", async () => {
+		const h = harness({ randomId: () => { throw new Error("persistent id failure"); } });
+		await h.manager.handleToolCall({ action: "schedule.create", id: "hourly", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		h.clock.now += 3_600_000;
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message?: unknown) => void warnings.push(String(message));
+		try {
+			h.timers.fireAll();
+			await flush();
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		assert.equal(h.launches.length, 0);
+		assert.equal(h.timers.values.size, 1);
+		assert.equal([...h.timers.values.values()][0]?.delay, 3_600_000);
+		assert.match(warnings[0] ?? "", /failed to fire: persistent id failure/);
+		const shown = await h.manager.handleToolCall({ action: "schedule.show", id: "hourly" }, h.ctx);
+		assert.match(text(shown), /State: scheduled/);
+		assert.match(text(shown), /2030-01-01T01:00:00.000Z/);
+	});
+
+	it("re-arms overdue catch-up-none schedules when missed-run recovery fails", async () => {
+		const h = harness({ randomId: () => { throw new Error("persistent id failure"); } });
+		await h.manager.handleToolCall({ action: "schedule.create", id: "none", every: "1h", catchUp: "none", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		h.clock.now += 2 * 3_600_000;
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message?: unknown) => void warnings.push(String(message));
+		try {
+			h.timers.fireAll();
+			await flush();
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		assert.equal(h.launches.length, 0);
+		assert.equal(h.timers.values.size, 1);
+		assert.equal([...h.timers.values.values()][0]?.delay, 3_600_000);
+		assert.match(warnings[0] ?? "", /failed to fire: persistent id failure/);
+		assert.match(warnings[1] ?? "", /could not be restored after fire failure: persistent id failure/);
+		const shown = await h.manager.handleToolCall({ action: "schedule.show", id: "none" }, h.ctx);
+		assert.match(text(shown), /2030-01-01T01:00:00.000Z/);
+	});
+
+	it("does not immediately retry an overdue one-shot after an unexpected timer failure", async () => {
+		const h = harness({ randomId: () => { throw new Error("persistent id failure"); } });
+		await h.manager.handleToolCall({ action: "schedule.create", id: "once", at: "+1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		h.clock.now += 3_600_000;
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message?: unknown) => void warnings.push(String(message));
+		try {
+			h.timers.fireAll();
+			await flush();
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		assert.equal(h.launches.length, 0);
+		assert.equal(h.timers.values.size, 0);
+		assert.match(warnings[0] ?? "", /failed to fire: persistent id failure/);
+		const shown = await h.manager.handleToolCall({ action: "schedule.show", id: "once" }, h.ctx);
+		assert.match(text(shown), /State: scheduled/);
+		assert.match(text(shown), /2030-01-01T01:00:00.000Z/);
 	});
 
 	it("run-due launches the latest missed occurrence while catchUp none records a miss", async () => {


### PR DESCRIPTION
## Summary

Reworks #1084 on current `main` and keeps only the schedule deletion fix.

The change lets a process ignore a schedule timer after another session has already deleted that schedule. Direct management lookups still report missing schedules, and unexpected timer failures are contained to the timer callback.

Thanks @albertgwo for the original #1084 fix and report.

## Validation

- `node --experimental-strip-types --test test/unit/scheduled-runs.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git show --check --oneline --stat HEAD`

## Performance impact

Disproved. The path still uses one timer and one schedule lookup when a timer fires. It adds no polling, watcher, reload, status, render, FleetView, or filesystem scan loop.
