### PR TITLE
fix: nest workflow children in FleetView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Show workflow-owned foreground children and recursive nested runs as a bounded tree in FleetView. Thanks to @expoli for #1086.
 - Warn once, instead of on every heartbeat, when a long-running workflow child outlives its mission record. Thanks to @albertgwo for #1079.
 - Keep deleted-schedule timers from exiting Pi and re-arm recurring schedules after unexpected timer fire failures. Thanks to @albertgwo for #1084.
 

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -6,7 +6,7 @@ import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
 
 export const FLEET_STATUS_WIDGET_KEY = "subagent-fleet-status";
 
-// Six rows fit the accepted collapsed hierarchy: one owner, four direct leaves, and overflow.
+// Six rows fit the accepted collapsed hierarchy: one owner, four visible descendants, and overflow.
 const MAX_AGENT_ROWS = 6;
 const REFRESH_MS = 500;
 
@@ -16,6 +16,7 @@ type FleetStatusTui = {
 };
 type FleetStatusEntry = {
 	key: string;
+	parentKey?: string;
 	agent: string;
 	modelThinking?: string;
 	description?: string;
@@ -31,11 +32,13 @@ type FleetNestedRow = {
 	modelThinking?: string;
 	activity?: string;
 	startedAt?: number;
+	depth: number;
 	overflow?: number;
 };
 
 type FleetTreeRow =
 	| { kind: "owner"; entry: FleetStatusEntry }
+	| { kind: "child"; entry: FleetStatusEntry; last: boolean }
 	| { kind: "nested"; ownerKey: string; row: FleetNestedRow; last: boolean };
 
 export interface FleetStatusOptions {
@@ -94,44 +97,112 @@ function nestedStatusGlyph(state: FleetNestedRow["state"], theme: Theme): string
 	return theme.fg("warning", "■");
 }
 
-function nestedFleetRows(children: NestedRunSummary[] | undefined): FleetNestedRow[] {
-	const rows: FleetNestedRow[] = [];
-	for (const child of children ?? []) {
+function nestedStepDisplayCount(steps: NestedStepSummary[] | undefined, start = 0): number {
+	let count = 0;
+	for (let index = start; index < (steps?.length ?? 0); index++) {
+		count += 1 + nestedDisplayCount(steps![index]!.children);
+	}
+	return count;
+}
+
+function nestedDisplayCount(children: NestedRunSummary[] | undefined, start = 0): number {
+	let count = 0;
+	for (let index = start; index < (children?.length ?? 0); index++) {
+		const child = children![index]!;
 		const steps = (child.mode === "parallel" || child.mode === "chain") ? child.steps ?? [] : [];
-		if (steps.length > 0) {
-			for (const step of steps) {
-				const modelThinking = formatModelThinking(step.model, step.thinking) || undefined;
-				const activity = nestedActivity(step);
+		count += steps.length > 0 ? nestedStepDisplayCount(steps) : 1;
+		count += nestedDisplayCount(child.children);
+	}
+	return count;
+}
+
+function nestedFleetRows(children: NestedRunSummary[] | undefined, visibleLimit: number): FleetNestedRow[] {
+	const rows: FleetNestedRow[] = [];
+	let omitted = 0;
+	const appendRuns = (runs: NestedRunSummary[] | undefined, depth: number): boolean => {
+		for (let runIndex = 0; runIndex < (runs?.length ?? 0); runIndex++) {
+			const child = runs![runIndex]!;
+			const steps = (child.mode === "parallel" || child.mode === "chain") ? child.steps ?? [] : [];
+			if (steps.length > 0) {
+				for (let stepIndex = 0; stepIndex < steps.length; stepIndex++) {
+					if (rows.length >= visibleLimit) {
+						omitted += nestedStepDisplayCount(steps, stepIndex);
+						omitted += nestedDisplayCount(child.children);
+						omitted += nestedDisplayCount(runs, runIndex + 1);
+						return false;
+					}
+					const step = steps[stepIndex]!;
+					const modelThinking = formatModelThinking(step.model, step.thinking) || undefined;
+					const activity = nestedActivity(step);
+					rows.push({
+						name: step.agent,
+						state: step.status,
+						depth,
+						...(modelThinking ? { modelThinking } : {}),
+						...(activity ? { activity } : {}),
+						...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),
+					});
+					if (!appendRuns(step.children, depth + 1)) {
+						omitted += nestedStepDisplayCount(steps, stepIndex + 1);
+						omitted += nestedDisplayCount(child.children);
+						omitted += nestedDisplayCount(runs, runIndex + 1);
+						return false;
+					}
+				}
+			} else {
+				if (rows.length >= visibleLimit) {
+					omitted += nestedDisplayCount(runs, runIndex);
+					return false;
+				}
+				const modelThinking = formatModelThinking(child.model, child.thinking) || undefined;
+				const activity = nestedActivity(child);
 				rows.push({
-					name: step.agent,
-					state: step.status,
+					name: nestedRunLabel(child),
+					state: child.state,
+					depth,
 					...(modelThinking ? { modelThinking } : {}),
 					...(activity ? { activity } : {}),
-					...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),
+					...(child.startedAt !== undefined ? { startedAt: child.startedAt } : {}),
 				});
 			}
-			continue;
+			if (!appendRuns(child.children, depth + 1)) {
+				omitted += nestedDisplayCount(runs, runIndex + 1);
+				return false;
+			}
 		}
-		const modelThinking = formatModelThinking(child.model, child.thinking) || undefined;
-		const activity = nestedActivity(child);
-		rows.push({
-			name: nestedRunLabel(child),
-			state: child.state,
-			...(modelThinking ? { modelThinking } : {}),
-			...(activity ? { activity } : {}),
-			...(child.startedAt !== undefined ? { startedAt: child.startedAt } : {}),
-		});
-	}
-	const visible = rows.slice(0, 4);
-	if (rows.length > visible.length) visible.push({ name: `… +${rows.length - visible.length} more nested leaves`, state: "complete", overflow: rows.length - visible.length });
-	return visible;
+		return true;
+	};
+	appendRuns(children, 0);
+	if (omitted > 0) rows.push({ name: `… +${omitted} more nested leaves`, state: "complete", depth: 0, overflow: omitted });
+	return rows;
 }
 
 function fleetTreeRows(entries: FleetStatusEntry[]): FleetTreeRow[] {
 	const rows: FleetTreeRow[] = [];
+	const entryKeys = new Set(entries.map((entry) => entry.key));
+	const childrenByParent = new Map<string, FleetStatusEntry[]>();
 	for (const entry of entries) {
+		if (!entry.parentKey || !entryKeys.has(entry.parentKey)) continue;
+		const children = childrenByParent.get(entry.parentKey) ?? [];
+		children.push(entry);
+		childrenByParent.set(entry.parentKey, children);
+	}
+	for (const entry of entries) {
+		if (entry.parentKey && entryKeys.has(entry.parentKey)) continue;
 		rows.push({ kind: "owner", entry });
-		const nested = nestedFleetRows(entry.nestedChildren);
+		const attached = childrenByParent.get(entry.key) ?? [];
+		for (const [index, child] of attached.entries()) {
+			const nested = nestedFleetRows(child.nestedChildren, 3);
+			const laterRows = index < attached.length - 1 || Boolean(entry.nestedChildren?.length);
+			rows.push({ kind: "child", entry: child, last: !laterRows && nested.length === 0 });
+			for (const [nestedIndex, row] of nested.entries()) rows.push({
+				kind: "nested",
+				ownerKey: child.key,
+				row: { ...row, depth: row.depth + 1 },
+				last: nestedIndex === nested.length - 1 && !laterRows,
+			});
+		}
+		const nested = nestedFleetRows(entry.nestedChildren, attached.length > 0 ? 3 : 4);
 		for (const [index, row] of nested.entries()) rows.push({ kind: "nested", ownerKey: entry.key, row, last: index === nested.length - 1 });
 	}
 	return rows;
@@ -152,12 +223,18 @@ function foregroundDescription(control: { parentWorkflowRunId?: string; workflow
 
 export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntry[] {
 	const entries: FleetStatusEntry[] = [];
+	const activeWorkflowKeys = new Set([...state.asyncJobs.values()]
+		.filter((job) => job.mode === "workflow" && isActiveState(job.status))
+		.map((job) => `async:${job.asyncId}`));
 	for (const control of state.foregroundControls.values()) {
+		const parentKey = control.parentWorkflowRunId ? `async:${control.parentWorkflowRunId}` : undefined;
+		const linkedParentKey = parentKey && activeWorkflowKeys.has(parentKey) ? parentKey : undefined;
 		if (control.activeChildren) {
 			for (const child of [...control.activeChildren.values()].sort((left, right) => left.index - right.index)) {
 				const modelThinking = formatModelThinking(child.model, child.thinking) || undefined;
 				entries.push({
 					key: `foreground-active:${control.runId}:${child.index}`,
+					...(linkedParentKey ? { parentKey: linkedParentKey } : {}),
 					agent: child.agent,
 					...(modelThinking ? { modelThinking } : {}),
 					description: foregroundDescription(control, child.description),
@@ -174,6 +251,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 		const modelThinking = formatModelThinking(control.model, control.thinking) || undefined;
 		entries.push({
 			key: `foreground-active:${control.runId}:${control.currentIndex ?? 0}`,
+			...(linkedParentKey ? { parentKey: linkedParentKey } : {}),
 			agent: control.currentAgent ?? control.mode,
 			...(modelThinking ? { modelThinking } : {}),
 			description: foregroundDescription(control, control.description),
@@ -428,16 +506,16 @@ export class SubagentFleetStatus {
 		lines.push(truncateToWidth(`  ${this.bullet(0, selectedIndex, theme)} main`, width));
 
 		const tree = fleetTreeRows(this.entries);
-		const selectedTreeIndex = Math.max(0, tree.findIndex((row) => row.kind === "owner" && row.entry.key === this.selectedKey));
+		const selectedTreeIndex = Math.max(0, tree.findIndex((row) => (row.kind === "owner" || row.kind === "child") && row.entry.key === this.selectedKey));
 		const visibleCount = Math.min(this.maxAgentRows, tree.length);
 		const start = selectedTreeIndex < visibleCount ? 0 : selectedTreeIndex - visibleCount + 1;
 		const hiddenBelow = tree.length - (start + visibleCount);
 		if (start > 0) lines.push(rightAlign("", theme.fg("dim", `↑ ${start} more`), width));
 		for (let index = start; index < start + visibleCount; index++) {
 			const row = tree[index]!;
-			if (row.kind === "owner") {
+			if (row.kind === "owner" || row.kind === "child") {
 				const ownerIndex = this.entries.findIndex((entry) => entry.key === row.entry.key);
-				lines.push(this.renderEntry(ownerIndex + 1, selectedIndex, row.entry, width, theme));
+				lines.push(this.renderEntry(ownerIndex + 1, selectedIndex, row.entry, width, theme, row.kind === "child" ? (row.last ? "└─" : "├─") : undefined));
 			} else {
 				lines.push(this.renderNestedRow(row.row, row.last, width, theme));
 			}
@@ -446,9 +524,10 @@ export class SubagentFleetStatus {
 		return lines;
 	}
 
-	private renderEntry(rosterIndex: number, selectedIndex: number, entry: FleetStatusEntry, width: number, theme: Theme): string {
+	private renderEntry(rosterIndex: number, selectedIndex: number, entry: FleetStatusEntry, width: number, theme: Theme, branch?: string): string {
 		const agent = entry.modelThinking ? `${entry.agent} (${entry.modelThinking})` : entry.agent;
-		const left = `  ${this.bullet(rosterIndex, selectedIndex, theme)} ${theme.fg("muted", agent)} · ${entry.state}`;
+		const prefix = branch ? `    ${branch}` : " ";
+		const left = `${prefix} ${this.bullet(rosterIndex, selectedIndex, theme)} ${theme.fg("muted", agent)} · ${entry.state}`;
 		const elapsed = Date.now() - entry.startedAt;
 		const right = theme.fg("dim", `${formatFleetElapsed(elapsed)} · ${formatFleetTokens(entry.tokens)}`);
 		return rightAlign(left, right, width);
@@ -456,10 +535,11 @@ export class SubagentFleetStatus {
 
 	private renderNestedRow(row: FleetNestedRow, last: boolean, width: number, theme: Theme): string {
 		const marker = last ? "└─" : "├─";
-		if (row.overflow !== undefined) return truncateToWidth(`    ${marker} ${theme.fg("dim", `+${row.overflow} nested leaves`)}`, width);
+		const indent = "    ".repeat(row.depth + 1);
+		if (row.overflow !== undefined) return truncateToWidth(`${indent}${marker} ${theme.fg("dim", `+${row.overflow} nested leaves`)}`, width);
 		const modelThinking = row.modelThinking ? ` (${row.modelThinking})` : "";
 		const activity = row.activity ? ` · ${row.activity}` : "";
-		const left = `    ${marker} ${nestedStatusGlyph(row.state, theme)} ${theme.fg("muted", `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
+		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${theme.fg("muted", `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
 		const elapsed = row.startedAt !== undefined ? ` · ${formatFleetElapsed(Date.now() - row.startedAt)}` : "";
 		return truncateToWidth(`${left}${theme.fg("dim", elapsed)}`, width);
 	}
@@ -504,19 +584,21 @@ export class SubagentFleetStatus {
 			entries: this.entries.map((entry) => this.active
 				? [
 					entry.key,
+					entry.parentKey,
 					entry.agent,
 					entry.state,
 					entry.modelThinking,
 					entry.description,
 					Math.round((now - entry.startedAt) / 1000),
 					entry.tokens,
-					entry.nestedChildren?.map((child) => [
-						child.id,
-						child.state,
-						child.model,
-						child.thinking,
-						child.lastUpdate,
-						child.steps?.map((step) => [step.agent, step.status, step.model, step.thinking, step.lastActivityAt]),
+					nestedFleetRows(entry.nestedChildren, entry.parentKey ? 3 : 4).map((row) => [
+						row.name,
+						row.state,
+						row.modelThinking,
+						row.activity,
+						row.startedAt,
+						row.depth,
+						row.overflow,
 					]),
 				]
 				: [entry.key, entry.state, entry.tokens]),

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -186,8 +186,13 @@ export function collectFleetSnapshot(
 ): FleetSnapshot {
 	const items: FleetItem[] = [];
 	const activeForegroundIds = new Set<string>();
+	const trackedJobs = state.fleetJobs ?? state.asyncJobs;
+	const workflowParentIds = new Set([...trackedJobs.values()]
+		.filter((job) => job.mode === "workflow" && belongsToCurrentSession(job.sessionId, state.currentSessionId))
+		.map((job) => job.asyncId));
 	for (const control of [...state.foregroundControls.values()].sort((left, right) => right.updatedAt - left.updatedAt)) {
 		activeForegroundIds.add(control.runId);
+		if (control.parentWorkflowRunId && workflowParentIds.has(control.parentWorkflowRunId)) continue;
 		if (control.activeChildren) {
 			for (const child of [...control.activeChildren.values()].sort((left, right) => left.index - right.index)) {
 				items.push({
@@ -222,7 +227,7 @@ export function collectFleetSnapshot(
 	try {
 		let runs: AsyncRunSummary[];
 		const descriptions = new Map<string, string>();
-		const tracked = [...(state.fleetJobs ?? state.asyncJobs).values()]
+		const tracked = [...trackedJobs.values()]
 			.filter((job) => belongsToCurrentSession(job.sessionId, state.currentSessionId));
 		const byUpdate = (left: AsyncJobState, right: AsyncJobState) => (right.updatedAt ?? right.startedAt ?? 0) - (left.updatedAt ?? left.startedAt ?? 0);
 		const active = tracked.filter((job) => job.status === "queued" || job.status === "running").sort(byUpdate);
@@ -274,6 +279,27 @@ export function collectFleetSnapshot(
 		}
 	}
 	return { items, ...(error ? { error } : {}) };
+}
+
+function visibleWorkflowParentKeyForForegroundKey(state: SubagentState, key: string, items: FleetItem[]): string | undefined {
+	for (const control of state.foregroundControls.values()) {
+		if (!control.parentWorkflowRunId) continue;
+		let matches = false;
+		if (control.activeChildren) {
+			for (const child of control.activeChildren.values()) {
+				if (`foreground-active:${control.runId}:${child.index}` === key) {
+					matches = true;
+					break;
+				}
+			}
+		} else {
+			matches = `foreground-active:${control.runId}:${control.currentIndex ?? 0}` === key;
+		}
+		if (!matches) continue;
+		const parentKey = `async:${control.parentWorkflowRunId}`;
+		return items.some((item) => item.key === parentKey) ? parentKey : undefined;
+	}
+	return undefined;
 }
 
 function statusGlyph(item: FleetItem, theme: Theme): string {
@@ -665,7 +691,11 @@ export class SubagentFleetComponent implements Component {
 	private refresh(): void {
 		const previousKey = this.snapshot.items[this.selected]?.key ?? this.selectedKey;
 		this.snapshot = collectFleetSnapshot(this.state, this.options);
-		const preserved = previousKey ? this.snapshot.items.findIndex((item) => item.key === previousKey) : -1;
+		let preserved = previousKey ? this.snapshot.items.findIndex((item) => item.key === previousKey) : -1;
+		if (preserved < 0 && previousKey) {
+			const parentKey = visibleWorkflowParentKeyForForegroundKey(this.state, previousKey, this.snapshot.items);
+			if (parentKey) preserved = this.snapshot.items.findIndex((item) => item.key === parentKey);
+		}
 		this.selected = preserved >= 0 ? preserved : Math.min(this.selected, Math.max(0, this.snapshot.items.length - 1));
 		this.selectedKey = this.snapshot.items[this.selected]?.key;
 	}

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -417,6 +417,16 @@ describe("below-editor subagent FleetView", () => {
 				thinking: "medium",
 				startedAt: 10,
 				lastUpdate: 20,
+				...(index === 4 ? {
+					children: [{
+						id: "nested-hidden-child",
+						parentRunId: "nested-4",
+						depth: 2,
+						path: [{ runId: "supervisor", stepIndex: 0 }, { runId: "nested-4" }],
+						state: "running" as const,
+						agent: "hidden-child",
+					}],
+				} : {}),
 			})),
 		});
 		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
@@ -448,7 +458,8 @@ describe("below-editor subagent FleetView", () => {
 				assert.match(line!, new RegExp(state));
 			}
 			assert.doesNotMatch(lines, /leaf-4.*running/);
-			assert.match(lines, /\+1 nested leaves/);
+			assert.doesNotMatch(lines, /hidden-child/);
+			assert.match(lines, /\+2 nested leaves/);
 		} finally {
 			fleet.dispose();
 		}
@@ -592,6 +603,171 @@ describe("below-editor subagent FleetView", () => {
 			agent: "reviewer",
 			description: "workflow child: workflow-1 (review) · Review the change",
 		}]);
+	});
+
+	it("renders a workflow-owned foreground child under its workflow parent", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("workflow-1", {
+			asyncId: "workflow-1",
+			asyncDir: "/tmp/workflow-1",
+			status: "running",
+			mode: "workflow",
+			startedAt: 10,
+			updatedAt: 20,
+			nestedChildren: [{
+				id: "owner-nested",
+				parentRunId: "workflow-1",
+				depth: 1,
+				path: [{ runId: "workflow-1" }],
+				state: "running",
+				agent: "owner-nested",
+			}],
+		});
+		state.foregroundControls.set("child-1", {
+			runId: "child-1",
+			parentWorkflowRunId: "workflow-1",
+			workflowKey: "review",
+			mode: "single",
+			startedAt: 11,
+			updatedAt: 20,
+			activeChildren: new Map([[0, { index: 0, agent: "reviewer", startedAt: 11, updatedAt: 20 }]]),
+			nestedChildren: [{
+				id: "nested-review",
+				parentRunId: "child-1",
+				parentStepIndex: 0,
+				depth: 1,
+				path: [{ runId: "child-1", stepIndex: 0 }],
+				state: "running",
+				agent: "nested-reviewer",
+			}],
+		});
+		state.foregroundControls.set("child-2", {
+			runId: "child-2",
+			parentWorkflowRunId: "workflow-1",
+			workflowKey: "test",
+			mode: "single",
+			startedAt: 12,
+			updatedAt: 20,
+			activeChildren: new Map([[0, { index: 0, agent: "tester", startedAt: 12, updatedAt: 20 }]]),
+			nestedChildren: [{
+				id: "nested-test",
+				parentRunId: "child-2",
+				parentStepIndex: 0,
+				depth: 1,
+				path: [{ runId: "child-2", stepIndex: 0 }],
+				state: "running",
+				agent: "nested-tester",
+			}],
+		});
+		const entries = collectFleetStatusEntries(state);
+		assert.deepEqual(entries.map((entry) => [entry.key, entry.parentKey]), [
+			["async:workflow-1", undefined],
+			["foreground-active:child-1:0", "async:workflow-1"],
+			["foreground-active:child-2:0", "async:workflow-1"],
+		]);
+
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+		try {
+			fleet.setContext(ctx);
+			const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
+			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
+			const lines = component.render(120);
+			const workflowIndex = lines.findIndex((line) => line.includes("workflow · running"));
+			const childIndex = lines.findIndex((line) => line.includes("reviewer · running"));
+			const nestedIndex = lines.findIndex((line) => line.includes("nested-reviewer"));
+			const secondChildIndex = lines.findIndex((line) => line.includes("tester · running"));
+			const secondNestedIndex = lines.findIndex((line) => line.includes("nested-tester"));
+			const ownerNestedIndex = lines.findIndex((line) => line.includes("owner-nested"));
+			assert.ok(workflowIndex >= 0 && childIndex > workflowIndex && nestedIndex > childIndex);
+			assert.ok(secondChildIndex > nestedIndex && secondNestedIndex > secondChildIndex && ownerNestedIndex > secondNestedIndex);
+			assert.match(lines[childIndex]!, /├─.*reviewer/);
+			assert.match(lines[nestedIndex]!, /├─.*nested-reviewer/);
+			assert.match(lines[secondNestedIndex]!, /├─.*nested-tester/);
+			assert.match(lines[ownerNestedIndex]!, /└─.*owner-nested/);
+		} finally {
+			fleet.dispose();
+		}
+	});
+
+	it("renders recursive nested runs and steps within the existing row budget", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("supervisor", {
+			asyncId: "supervisor",
+			asyncDir: "/tmp/supervisor",
+			status: "running",
+			mode: "single",
+			startedAt: 10,
+			updatedAt: 20,
+			steps: [{ agent: "supervisor", index: 0, status: "running" }],
+			nestedChildren: [{
+				id: "level-one",
+				parentRunId: "supervisor",
+				parentStepIndex: 0,
+				depth: 1,
+				path: [{ runId: "supervisor", stepIndex: 0 }],
+				state: "running",
+				agent: "level-one",
+				children: [{
+					id: "level-two",
+					parentRunId: "level-one",
+					depth: 2,
+					path: [{ runId: "supervisor", stepIndex: 0 }, { runId: "level-one" }],
+					state: "running",
+					mode: "parallel",
+					steps: [{
+						agent: "level-two",
+						status: "running",
+						children: [0, 1, 2, 3].map((index) => ({
+							id: `leaf-${index}`,
+							parentRunId: "level-two",
+							depth: 3,
+							path: [{ runId: "level-two" }],
+							state: "running" as const,
+							agent: `leaf-${index}`,
+						})),
+					}],
+				}],
+			}],
+		});
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+		try {
+			fleet.setContext(ctx);
+			const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
+			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
+			const lines = component.render(140).join("\n");
+			assert.match(lines, /level-one/);
+			assert.match(lines, /level-two/);
+			assert.match(lines, /leaf-0/);
+			assert.match(lines, /leaf-1/);
+			assert.doesNotMatch(lines, /leaf-[23]/);
+			assert.match(lines, /\+2 nested leaves/);
+		} finally {
+			fleet.dispose();
+		}
 	});
 
 	it("uses the same item keys as the full inspector", () => {

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -367,15 +367,25 @@ describe("native subagent fleet", () => {
 		assert.equal(snapshot.items[0]?.agent, "workflow");
 	});
 
-	it("labels workflow-owned foreground children and opens their parent Herdr inspector", async () => {
+	it("hides workflow-owned foreground duplicates and opens the workflow parent inspector", async () => {
 		const state = stateForTest();
 		state.asyncJobs.set("workflow-1", {
 			asyncId: "workflow-1",
 			asyncDir: "/tmp/workflow-1",
+			sessionId: "session-current",
 			status: "running",
 			mode: "workflow",
 			startedAt: 10,
 			updatedAt: 20,
+		});
+		state.asyncJobs.set("unrelated", {
+			asyncId: "unrelated",
+			asyncDir: "/tmp/unrelated",
+			sessionId: "session-current",
+			status: "running",
+			mode: "single",
+			startedAt: 5,
+			updatedAt: 30,
 		});
 		state.foregroundControls.set("child-1", {
 			runId: "child-1",
@@ -387,8 +397,7 @@ describe("native subagent fleet", () => {
 			activeChildren: new Map([[0, { index: 0, agent: "reviewer", startedAt: 10, updatedAt: 20 }]]),
 		});
 		const snapshot = collectFleetSnapshot(state);
-		const child = snapshot.items.find((item) => item.key === "foreground-active:child-1:0");
-		assert.equal(child?.kind, "foreground-active");
+		assert.deepEqual(snapshot.items.map((item) => item.key), ["async:unrelated", "async:workflow-1"]);
 		const calls: Array<{ runId: string; asyncDir: string; index?: number }> = [];
 		const component = new SubagentFleetComponent(
 			{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
@@ -406,7 +415,7 @@ describe("native subagent fleet", () => {
 			},
 		);
 		try {
-			assert.ok(component.render(100).some((line) => line.includes("Workflow child of: workflow-1 (review)")));
+			assert.ok(component.render(100).some((line) => line.includes("workflow")));
 			component.handleInput("H");
 			await new Promise((resolve) => setImmediate(resolve));
 			assert.deepEqual(calls, [{ runId: "workflow-1", asyncDir: "/tmp/workflow-1" }]);


### PR DESCRIPTION
## Summary

Fixes #1086 by rendering workflow-owned foreground children under their workflow parent in the compact FleetView, while keeping the full Fleet inspector focused on the visible workflow parent instead of showing duplicate top-level rows.

It also renders recursive nested run/step summaries within the existing small row budget and folds extra descendants into the existing overflow row.

## Validation

- `node --experimental-strip-types --test test/unit/fleet-status.test.ts`
- `node --experimental-strip-types --test test/unit/fleet.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD && git diff --check && git show --check --oneline --stat HEAD`
- Fresh review: `/tmp/pi-subagents-backlog-20260814-post1081/issue-1086-followup-review-bcd64352.md`

Fixes #1086.
