### PR TITLE
test: stabilize Windows integration timing

### DIFF
--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -1000,7 +1000,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	});
 
 	it("background treats agent_settled as a clean terminal watermark", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
-		mockPi.onCall({ jsonl: [mockAssistantMessage("settled async without a terminal assistant stop", "tool_use"), { type: "agent_settled" }], keepAliveAfterFinalMessageMs: 5000 });
+		mockPi.onCall({ jsonl: [mockAssistantMessage("settled async without a terminal assistant stop", "tool_use"), { type: "agent_settled" }], keepAliveAfterFinalMessageMs: 15_000 });
 		const id = `async-lifecycle-settled-${Date.now().toString(36)}`;
 		const startedAt = Date.now();
 		launchProtocolTest(id);
@@ -1008,7 +1008,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.success, true);
 		assert.equal(payload.results[0]?.error, undefined);
 		assert.equal(payload.results[0]?.output, "settled async without a terminal assistant stop");
-		assert.ok(Date.now() - startedAt < 4000, "agent_settled should trigger bounded child cleanup");
+		assert.ok(Date.now() - startedAt < 10_000, "agent_settled should trigger bounded child cleanup");
 	});
 
 	it("keeps named output references literal in async single tasks", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
@@ -3031,7 +3031,14 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.results[0].modelAttempts.length, 2);
 		assert.deepEqual(payload.results[0].totalCost, { inputTokens: 110, outputTokens: 55, costUsd: 0.011 });
 		assert.deepEqual(payload.totalCost, { inputTokens: 110, outputTokens: 55, costUsd: 0.011 });
-		const statusPayload = await waitForAsyncState(id, (candidate) => candidate.state === "complete" && candidate.totalCost !== undefined);
+		const statusPayload = await waitForAsyncState(id, (candidate) => candidate.state === "complete"
+			&& candidate.lifecycleArtifactVersion !== undefined
+			&& candidate.totalTokens?.total !== undefined
+			&& candidate.totalCost !== undefined
+			&& candidate.steps[0]?.model !== undefined
+			&& candidate.steps[0]?.thinking !== undefined
+			&& candidate.steps[0]?.tokens?.total !== undefined
+			&& candidate.steps[0]?.totalCost !== undefined);
 		assert.equal(statusPayload.lifecycleArtifactVersion, SUBAGENT_LIFECYCLE_ARTIFACT_VERSION);
 		assert.equal(statusPayload.steps[0]?.model, "anthropic/claude-sonnet-4:low");
 		assert.equal(statusPayload.steps[0]?.thinking, "low");

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -932,6 +932,7 @@ describe("result watcher", () => {
 			});
 			const originalError = console.error;
 			const childSessionPath = path.join(resultsDir, "a-session.jsonl");
+			const resultPath = path.join(resultsDir, "async-fallback.json");
 			console.error = () => {};
 			try {
 				watcher.startResultWatcher();
@@ -939,7 +940,7 @@ describe("result watcher", () => {
 				assert.notEqual(state.watcherRestartTimer, null);
 
 				fs.writeFileSync(childSessionPath, "", "utf-8");
-				writeIndexedResult(path.join(resultsDir, "async-fallback.json"), {
+				writeIndexedResult(resultPath, {
 					id: "async-fallback",
 					runId: "run-fallback",
 					agent: "parallel:a+b",
@@ -955,7 +956,7 @@ describe("result watcher", () => {
 					intercomTarget: "subagent-chat-main",
 				});
 				poll?.();
-				await new Promise((resolve) => setTimeout(resolve, 10));
+				assert.equal(await waitForPredicate(() => emitted.some((entry) => entry.event === "subagent:async-complete") && !fs.existsSync(resultPath)), true);
 			} finally {
 				console.error = originalError;
 				watcher.stopResultWatcher();
@@ -964,7 +965,7 @@ describe("result watcher", () => {
 			const intercomEvents = emitted.filter((entry) => entry.event === "subagent:result-intercom");
 			assert.equal(intercomEvents.length, 1);
 			assert.equal(emitted.some((entry) => entry.event === "subagent:async-complete"), true);
-			assert.equal(fs.existsSync(path.join(resultsDir, "async-fallback.json")), false);
+			assert.equal(fs.existsSync(resultPath), false);
 			const payload = intercomEvents[0]?.data as { mode?: string; status?: string; message?: string; children?: Array<{ status?: string; summary?: string; sessionPath?: string }> };
 			const completion = emitted.find((entry) => entry.event === "subagent:async-complete")?.data as { results?: Array<{ status?: string; summary?: string; sessionPath?: string }> } | undefined;
 			assert.equal(payload.mode, "parallel");
@@ -1327,7 +1328,7 @@ describe("result watcher", () => {
 					intercomTarget: "subagent-chat-main",
 				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 10));
+				assert.equal(await waitForPredicate(() => !fs.existsSync(resultPath) && emitted.some((entry) => entry.event === "subagent:async-complete")), true);
 			} finally {
 				console.error = originalError;
 				watcher.stopResultWatcher();


### PR DESCRIPTION
## Summary

Stabilizes four Windows-only integration timing races that made `main` red and blocked unrelated PR gates.

This is test-only. It replaces fixed sleeps with observable completion waits in the result watcher tests, keeps the `agent_settled` cleanup test below the mock's natural exit, and waits for exact fallback status fields before asserting them.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='falls back to polling when fs.watch throws EMFILE|filters malformed explicit nested children' test/integration/result-watcher.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='background treats agent_settled as a clean terminal watermark' test/integration/async-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='background runs record fallback attempts and final model' test/integration/async-execution.test.ts`
- `git diff --check origin/main...HEAD && git diff --check && git show --check --oneline --stat HEAD`
- Fresh review: `/tmp/pi-subagents-backlog-20260814-post1081/windows-ci-red-review-34cebad.md`
