### PR TITLE
test: stabilize result watcher completion waits

### DIFF
--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -1101,7 +1101,7 @@ describe("result watcher", () => {
 					intercomTarget: "subagent-chat-main",
 				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 10));
+				assert.equal(await waitForPredicate(() => emitted.some((entry) => entry.event === "subagent:async-complete") && emitted.some((entry) => entry.event === "subagent:result-intercom")), true);
 			} finally {
 				watcher.stopResultWatcher();
 			}
@@ -1248,7 +1248,7 @@ describe("result watcher", () => {
 					intercomTarget: "subagent-chat-main",
 				});
 				watcher.primeExistingResults();
-				await new Promise((resolve) => setTimeout(resolve, 10));
+				assert.equal(await waitForPredicate(() => !fs.existsSync(resultPath) && emitted.some((entry) => entry.event === "subagent:async-complete") && emitted.some((entry) => entry.event === "subagent:result-intercom")), true);
 			} finally {
 				watcher.stopResultWatcher();
 			}


### PR DESCRIPTION
## Summary

Stabilizes two remaining Windows-sensitive `result-watcher` integration checks by replacing fixed 10 ms sleeps with existing condition-based waits.

This is test-only. It does not change production result delivery.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'emits async completion plus one grouped intercom result event when an intercom target is present|enriches async completion and intercom payloads with nested registry children before deletion' test/integration/result-watcher.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/result-watcher.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review: `/tmp/pi-subagents-backlog-20260814-post1081/result-watcher-windows-race-review-f468147.md`
