### PR TITLE
fix: keep Herdr pane command executables bare for non-POSIX shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Start Herdr inspector and project pane commands with a shell-safe executable token, including paths that need quoting in Nushell. Thanks to @Rival for #1092.
 - Stop `agentContract.version` from using an `enum` on an integer, which Gemini's function-calling schema subset rejects (the property is dropped from the tool schema but stays in `required`, causing a `400: property is not defined` for every Gemini model). Integer bounds express the same constraint and are valid everywhere. Thanks to @MarcusNeufeldt for #1095.
 - Show workflow-owned foreground children and recursive nested runs as a bounded tree in FleetView. Thanks to @expoli for #1086.
 - Warn once, instead of on every heartbeat, when a long-running workflow child outlives its mission record. Thanks to @albertgwo for #1079.

--- a/src/inspectors/herdr/actions.ts
+++ b/src/inspectors/herdr/actions.ts
@@ -12,6 +12,7 @@ import { readStatus } from "../../shared/utils.ts";
 import { resolveSubagentRunId } from "../../runs/background/run-id-resolver.ts";
 import { resolveNodeExecutable } from "../../shared/node-executable.ts";
 import { createHerdrClient, detectHerdr, type HerdrClient, type HerdrErrorCode, type HerdrResult } from "./client.ts";
+import { formatShellCommand } from "./shell-command.ts";
 
 export const HERDR_INSPECTOR_ACTIONS = ["inspector.open", "inspector.status", "inspector.close"] as const;
 export type HerdrInspectorAction = typeof HERDR_INSPECTOR_ACTIONS[number];
@@ -86,16 +87,11 @@ function extractPaneId(value: unknown): string | undefined {
 	return undefined;
 }
 
-function shellQuote(value: string): string {
-	if (process.platform === "win32") return `"${value.replaceAll('"', '\\"')}"`;
-	return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
 function inspectorCommand(input: { runnerPath: string; asyncDir: string; runId: string; index?: number; missionPath?: string; allowSteer: boolean; allowStop: boolean; sessionRoots: string[] }): string {
-	const args = [resolveNodeExecutable(), input.runnerPath, "--async-dir", input.asyncDir, "--run-id", input.runId, "--allow-steer", String(input.allowSteer), "--allow-stop", String(input.allowStop), "--session-roots", JSON.stringify(input.sessionRoots)];
+	const args = [input.runnerPath, "--async-dir", input.asyncDir, "--run-id", input.runId, "--allow-steer", String(input.allowSteer), "--allow-stop", String(input.allowStop), "--session-roots", JSON.stringify(input.sessionRoots)];
 	if (input.index !== undefined) args.push("--index", String(input.index));
 	if (input.missionPath) args.push("--mission-path", input.missionPath);
-	return `${process.platform === "win32" ? "& " : ""}${args.map(shellQuote).join(" ")}`;
+	return formatShellCommand(resolveNodeExecutable(), args);
 }
 
 function missionForRun(asyncDir: string, cwd: string, config: MissionStoreConfig | undefined, runId: string): { id: string; path: string } | undefined {

--- a/src/inspectors/herdr/project-panes.ts
+++ b/src/inspectors/herdr/project-panes.ts
@@ -6,6 +6,7 @@ import { getProjectSubagentsDir } from "../../shared/artifacts.ts";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import type { Details } from "../../shared/types.ts";
 import { createHerdrClient, detectHerdr, type HerdrClient, type HerdrErrorCode } from "./client.ts";
+import { formatShellCommand } from "./shell-command.ts";
 
 export const HERDR_PROJECT_PANE_ACTIONS = ["project.open", "project.status", "project.close"] as const;
 export type HerdrProjectPaneAction = typeof HERDR_PROJECT_PANE_ACTIONS[number];
@@ -257,11 +258,6 @@ function projectPaneRuntime(value: unknown): ProjectPaneRuntime | undefined {
 	};
 }
 
-function shellQuote(value: string): string {
-	if (process.platform === "win32") return `"${value.replaceAll('"', '\\"')}"`;
-	return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
 function resolveProjectRoot(requested: string): ProjectPaneResult<string> {
 	const resolved = path.resolve(requested);
 	try {
@@ -284,7 +280,7 @@ async function inspectPane(client: HerdrClient, paneId: string, signal?: AbortSi
 function projectPaneCommand(message: string | undefined): string {
 	const args = message?.trim() ? [message.trim()] : [];
 	const command = getPiSpawnCommand(args);
-	return `${process.platform === "win32" ? "& " : ""}${[command.command, ...command.args].map(shellQuote).join(" ")}`;
+	return formatShellCommand(command.command, command.args);
 }
 
 function canonicalRuntimePath(value: string | undefined): string | undefined {

--- a/src/inspectors/herdr/shell-command.ts
+++ b/src/inspectors/herdr/shell-command.ts
@@ -1,0 +1,16 @@
+function shellQuote(value: string, platform: NodeJS.Platform): string {
+	if (platform === "win32") return `"${value.replaceAll('"', '\\"')}"`;
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function isBareExecutable(value: string): boolean {
+	return /^[\w./@:-]+$/.test(value);
+}
+
+export function formatShellCommand(exe: string, args: readonly string[], platform: NodeJS.Platform = process.platform): string {
+	const quotedArgs = args.map((arg) => shellQuote(arg, platform));
+	if (platform === "win32") return `& ${[shellQuote(exe, platform), ...quotedArgs].join(" ")}`;
+	// Nushell treats a leading quoted token as a string, so use a bare invoker for paths that need quoting.
+	const invocation = isBareExecutable(exe) ? exe : `sh -c 'exec "$0" "$@"' ${shellQuote(exe, platform)}`;
+	return [invocation, ...quotedArgs].join(" ");
+}

--- a/test/unit/herdr-inspector-bootstrap.test.ts
+++ b/test/unit/herdr-inspector-bootstrap.test.ts
@@ -78,7 +78,7 @@ describe("Herdr inspector bootstrap", () => {
 			assert.equal(opened.isError, undefined);
 			const command = calls.find((args) => args[0] === "pane" && args[1] === "run")?.[3] ?? "";
 			assert.equal(command.startsWith("& "), process.platform === "win32");
-			assert.match(command, process.platform === "win32" ? /^& "node\.exe" / : /^'node' /);
+			assert.match(command, process.platform === "win32" ? /^& "node\.exe" / : /^node /);
 			assert.doesNotMatch(command, /(?:^|[\\/])pi(?:\.exe)?'/);
 		} finally {
 			process.execPath = originalExecPath;

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -113,6 +113,9 @@ describe("Herdr inspector", () => {
 			assert.equal(binding?.missionPath, path.join(missionDir, "mission-cross-project.json"));
 			const runCall = calls.find((args) => args[0] === "pane" && args[1] === "run" && args[2] === "w1:p9");
 			assert.ok(runCall);
+			if (process.platform !== "win32") {
+				assert.ok(!/^[']/.test(runCall[3] ?? ""), `pane run command must not open with a quoted executable; Nushell parses it as a string expression: ${runCall[3]}`);
+			}
 			assert.match(runCall[3] ?? "", /--allow-steer.*true.*--allow-stop.*true/);
 			assert.match(runCall[3] ?? "", /--session-roots.*sessions/);
 
@@ -258,7 +261,7 @@ describe("Herdr inspector", () => {
 	});
 
 	it("opens, reports, and closes a project-owned Herdr pane", async () => {
-		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-project-pane-"));
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi=herdr project pane-"));
 		const previousPiBinary = process.env[PI_SUBAGENT_PI_BINARY_ENV];
 		process.env[PI_SUBAGENT_PI_BINARY_ENV] = path.join(root, "pi-bin");
 		try {
@@ -292,6 +295,7 @@ describe("Herdr inspector", () => {
 			assert.deepEqual(splitCall?.slice(0, 7), ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot]);
 			const runCall = calls.find((args) => args[0] === "pane" && args[1] === "run" && args[2] === "w1:p10");
 			assert.equal(runCall?.[3]?.startsWith("& "), process.platform === "win32");
+			if (process.platform !== "win32") assert.match(runCall?.[3] ?? "", /^sh -c 'exec \"\$0\" \"\$@\"' '/);
 			assert.match(runCall?.[3] ?? "", /pi-bin/);
 			assert.match(runCall?.[3] ?? "", /Own this project mission\./);
 

--- a/test/unit/herdr-shell-command.test.ts
+++ b/test/unit/herdr-shell-command.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { formatShellCommand } from "../../src/inspectors/herdr/shell-command.ts";
+
+describe("formatShellCommand on POSIX shells", () => {
+	const platform: NodeJS.Platform = "linux";
+
+	it("keeps a shell-safe executable bare so Nushell parses it as a command", () => {
+		assert.equal(
+			formatShellCommand("/usr/bin/node", ["/home/u/.pi/inspector-runner.mjs", "--async-dir", "/tmp/run-1|fc_abc"], platform),
+			"/usr/bin/node '/home/u/.pi/inspector-runner.mjs' '--async-dir' '/tmp/run-1|fc_abc'",
+		);
+	});
+
+	it("keeps bare command names bare", () => {
+		assert.equal(formatShellCommand("pi", ["review the diff"], platform), "pi 'review the diff'");
+	});
+
+	it("uses a bare sh invoker for an executable containing spaces and equals", () => {
+		assert.equal(
+			formatShellCommand("/opt/My Tools/node=bin", ["--flag"], platform),
+			`sh -c 'exec "$0" "$@"' '/opt/My Tools/node=bin' '--flag'`,
+		);
+	});
+
+	it("quotes executable paths and arguments containing quotes", () => {
+		assert.equal(
+			formatShellCommand("/opt/My Tools/it's node", ["it's", "a|b"], platform),
+			"sh -c 'exec \"$0\" \"$@\"' '/opt/My Tools/it'\\''s node' 'it'\\''s' 'a|b'",
+		);
+	});
+
+	it("executes an equals-sign path through the shell wrapper", { skip: process.platform === "win32" }, () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi herdr shell="));
+		try {
+			const executable = path.join(root, "tool=' value");
+			fs.writeFileSync(executable, "#!/bin/sh\nprintf '%s' \"$1\"\n", "utf-8");
+			fs.chmodSync(executable, 0o755);
+			const launched = spawnSync("/bin/sh", ["-c", formatShellCommand(executable, ["arg=' value"], platform)], { encoding: "utf-8" });
+			assert.equal(launched.status, 0, launched.stderr);
+			assert.equal(launched.stdout, "arg=' value");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("formatShellCommand on Windows PowerShell", () => {
+	it("prefixes the call operator and preserves argument quoting", () => {
+		assert.equal(
+			formatShellCommand("C:\\Program Files\\nodejs\\node.exe", ["two words", 'say "hi"'], "win32"),
+			'& "C:\\Program Files\\nodejs\\node.exe" "two words" "say \\"hi\\""',
+		);
+	});
+});


### PR DESCRIPTION
Herdr pane run types command text into the user's default interactive shell inside a freshly split pane. inspectorCommand() and projectPaneCommand() quoted every token POSIX-style, so the executable itself arrived as '/usr/bin/node' ... On Nushell a leading quoted token parses as a string expression, not a command invocation, and the pane died with nu::parser::parse_mismatch (expected operator).

Extract a shared formatShellCommand() helper that keeps shell-safe executables bare (valid in POSIX shells, Fish, and Nushell alike) and only falls back to quoting for paths with shell-significant characters. Windows output keeps the PowerShell '& ' call operator unchanged.