### PR TITLE
feat: add FleetView default expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Add opt-in `fleetViewDefaultExpanded` configuration so active FleetView rosters can open automatically.
+
 ### Fixed
 - Show workflow-owned foreground children and recursive nested runs as a bounded tree in FleetView. Thanks to @expoli for #1086.
 - Warn once, instead of on every heartbeat, when a long-running workflow child outlives its mission record. Thanks to @albertgwo for #1079.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,14 @@ Controls the persistent, navigable FleetView. The default is `true`. Set it to `
 
 Places the persistent FleetView either `"belowEditor"` or `"aboveEditor"`. The default is `"belowEditor"`; invalid values fall back to `"belowEditor"`.
 
+## `fleetViewDefaultExpanded`
+
+```json
+{ "fleetViewDefaultExpanded": true }
+```
+
+Starts FleetView expanded whenever active work first appears, showing `main` plus active child rows without requiring `↓` or `←`. The default is `false`, preserving the compact one-line summary. You can still press `Esc` or move up from `main` to collapse the roster for the current active fleet; it expands again after the fleet becomes idle and new work starts.
+
 ## `fleetKeybindings`
 
 ```json

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -72,6 +72,9 @@ function validateConfig(config: Record<string, unknown>): void {
 	if (config.legacyChainControls !== undefined && typeof config.legacyChainControls !== "boolean") {
 		throw new Error("config.legacyChainControls must be a boolean");
 	}
+	if (config.fleetViewDefaultExpanded !== undefined && typeof config.fleetViewDefaultExpanded !== "boolean") {
+		throw new Error("config.fleetViewDefaultExpanded must be a boolean");
+	}
 	if (config.maxActiveAsyncRunsPerSession !== undefined
 		&& (typeof config.maxActiveAsyncRunsPerSession !== "number"
 			|| !Number.isInteger(config.maxActiveAsyncRunsPerSession)

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -434,7 +434,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			const ctx = state.lastUiContext;
 			if (!ctx?.hasUI) return;
 			await openSubagentFleet(ctx, state, { initialKey: itemKey, asyncDirRoot: DIRS.async, resultsDir: DIRS.results, fleetKeybindings: config.fleetKeybindings });
-		}, { placement: fleetViewPlacement })
+		}, { placement: fleetViewPlacement, defaultExpanded: config.fleetViewDefaultExpanded === true })
 		: undefined;
 	let executorScheduled: ((id: string, params: SubagentParamsLike, signal: AbortSignal, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>) | undefined;
 	let goalTurnId = 0;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1911,6 +1911,8 @@ export interface ExtensionConfig {
 	fleetView?: boolean;
 	/** Place the persistent FleetView above or below the editor. Defaults to belowEditor. */
 	fleetViewPlacement?: FleetViewPlacement;
+	/** Start FleetView expanded whenever active work first appears. Defaults to false. */
+	fleetViewDefaultExpanded?: boolean;
 	/** Local keybindings for the full Fleet inspector. */
 	fleetKeybindings?: FleetKeybindingsConfig;
 	/** Show the under-editor async runs widget. Defaults to true, including when FleetView is enabled. */

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -45,6 +45,7 @@ export interface FleetStatusOptions {
 	refreshMs?: number;
 	maxAgentRows?: number;
 	placement?: FleetViewPlacement;
+	defaultExpanded?: boolean;
 }
 
 export function resolveFleetViewPlacement(value: unknown): FleetViewPlacement {
@@ -221,6 +222,17 @@ function foregroundDescription(control: { parentWorkflowRunId?: string; workflow
 	return description ? `${workflow} · ${description}` : workflow;
 }
 
+function collectFleetOwnerKeys(state: SubagentState): Set<string> {
+	const owners = new Set<string>();
+	for (const control of state.foregroundControls.values()) {
+		owners.add(`foreground:${control.runId}`);
+	}
+	for (const job of state.asyncJobs.values()) {
+		if (isActiveState(job.status)) owners.add(`async:${job.asyncId}`);
+	}
+	return owners;
+}
+
 export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntry[] {
 	const entries: FleetStatusEntry[] = [];
 	const activeWorkflowKeys = new Set([...state.asyncJobs.values()]
@@ -329,16 +341,18 @@ export class SubagentFleetStatus {
 	private inputUnsubscribe: (() => void) | undefined;
 	private timer: ReturnType<typeof setInterval> | undefined;
 	private widgetRegistered = false;
-	private active = false;
+	private active: boolean;
 	private selectedKey = "main";
 	private inspectorOpen = false;
 	private lastRenderKey = "";
 	private entries: FleetStatusEntry[] = [];
+	private ownerKeys = new Set<string>();
 	private readonly state: SubagentState;
 	private readonly openInspector: (itemKey: string) => Promise<void> | void;
 	private readonly refreshMs: number;
 	private readonly maxAgentRows: number;
 	private readonly placement: FleetViewPlacement;
+	private readonly defaultExpanded: boolean;
 
 	constructor(
 		state: SubagentState,
@@ -350,6 +364,8 @@ export class SubagentFleetStatus {
 		this.refreshMs = options.refreshMs ?? REFRESH_MS;
 		this.maxAgentRows = options.maxAgentRows ?? MAX_AGENT_ROWS;
 		this.placement = options.placement ?? "belowEditor";
+		this.defaultExpanded = options.defaultExpanded === true;
+		this.active = this.defaultExpanded;
 	}
 
 	setContext(ctx: ExtensionContext): void {
@@ -376,7 +392,8 @@ export class SubagentFleetStatus {
 		this.ctx = undefined;
 		this.ui = undefined;
 		this.entries = [];
-		this.active = false;
+		this.ownerKeys.clear();
+		this.active = this.defaultExpanded;
 		this.selectedKey = "main";
 		this.inspectorOpen = false;
 		this.lastRenderKey = "";
@@ -385,20 +402,31 @@ export class SubagentFleetStatus {
 	refresh(): void {
 		const ctx = this.getActiveUiContext();
 		if (!ctx) return;
-		if (this.state.widgetsSuspended) {
-			this.clearWidget();
-			return;
-		}
+		const previousOwnerKeys = this.ownerKeys;
+		const nextOwnerKeys = collectFleetOwnerKeys(this.state);
+		const startsNewFleet = nextOwnerKeys.size > 0
+			&& (previousOwnerKeys.size === 0 || ![...nextOwnerKeys].some((key) => previousOwnerKeys.has(key)));
+		this.ownerKeys = nextOwnerKeys;
 		this.entries = collectFleetStatusEntries(this.state);
+		if (this.defaultExpanded && startsNewFleet) {
+			this.active = true;
+			this.selectedKey = "main";
+		}
 		this.clampSelection();
-		if (this.inspectorOpen || this.state.fleetInspectorOpen) {
+		if (this.entries.length === 0 && !(this.state.activeAsyncCapacity?.used)) {
+			if (this.ownerKeys.size === 0) {
+				this.active = this.defaultExpanded;
+				this.selectedKey = "main";
+			}
 			this.lastRenderKey = "";
 			this.clearWidget();
 			return;
 		}
-		if (this.entries.length === 0 && !(this.state.activeAsyncCapacity?.used)) {
-			this.active = false;
-			this.selectedKey = "main";
+		if (this.state.widgetsSuspended) {
+			this.clearWidget();
+			return;
+		}
+		if (this.inspectorOpen || this.state.fleetInspectorOpen) {
 			this.lastRenderKey = "";
 			this.clearWidget();
 			return;
@@ -433,7 +461,7 @@ export class SubagentFleetStatus {
 		if (this.state.widgetsSuspended) return undefined;
 		const ctx = this.getActiveUiContext();
 		if (!ctx || this.entries.length === 0 || isKeyRelease(data)) return undefined;
-		if (this.inspectorOpen) return undefined;
+		if (this.inspectorOpen || this.state.fleetInspectorOpen) return undefined;
 		if (!this.editorHasFocus()) {
 			if (this.active) this.deactivate();
 			return undefined;

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -53,6 +53,205 @@ describe("below-editor subagent FleetView", () => {
 		assert.equal(resolveFleetViewPlacement("side"), "belowEditor");
 	});
 
+	it("starts expanded when defaultExpanded is configured", () => {
+		const state = stateForTest();
+		state.foregroundControls.set("run-worker", {
+			runId: "run-worker",
+			mode: "single",
+			startedAt: Date.now() - 1_000,
+			updatedAt: Date.now(),
+			currentAgent: "worker",
+		});
+
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000, defaultExpanded: true });
+		try {
+			fleet.setContext(ctx);
+			assert.ok(widgetFactory);
+			const lines = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme).render(80);
+			assert.ok(lines.length > 1);
+			assert.ok(lines.some((line) => line.includes("> main")));
+			assert.ok(lines.some((line) => line.includes("worker · running")));
+		} finally {
+			fleet.dispose();
+		}
+	});
+
+	it("preserves manual collapse for one fleet and re-expands a replacement fleet hidden during suspension", () => {
+		const state = stateForTest();
+		state.foregroundControls.set("run-worker", {
+			runId: "run-worker",
+			mode: "single",
+			startedAt: Date.now() - 1_000,
+			updatedAt: Date.now(),
+			currentAgent: "worker",
+		});
+
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000, defaultExpanded: true });
+		try {
+			fleet.setContext(ctx);
+			const tui = { requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor };
+			assert.ok(widgetFactory!(tui, theme).render(80).length > 1);
+
+			assert.deepEqual(fleet.handleKey("\x1b"), { consume: true });
+			assert.equal(widgetFactory!(tui, theme).render(80).length, 1);
+
+			state.foregroundControls.set("run-reviewer", {
+				runId: "run-reviewer",
+				mode: "single",
+				startedAt: Date.now(),
+				updatedAt: Date.now(),
+				currentAgent: "reviewer",
+			});
+			fleet.refresh();
+			assert.equal(widgetFactory!(tui, theme).render(80).length, 1, "joining the current fleet must not override manual collapse");
+
+			state.widgetsSuspended = true;
+			state.foregroundControls.clear();
+			state.foregroundControls.set("run-scout", {
+				runId: "run-scout",
+				mode: "single",
+				startedAt: Date.now(),
+				updatedAt: Date.now(),
+				currentAgent: "scout",
+			});
+			fleet.refresh();
+			state.widgetsSuspended = false;
+			fleet.refresh();
+			const replacementLines = widgetFactory!(tui, theme).render(80);
+			assert.ok(replacementLines.length > 1);
+			assert.ok(replacementLines.some((line) => line.includes("scout · running")));
+		} finally {
+			fleet.dispose();
+		}
+	});
+
+	it("keeps manual collapse across step transitions within one foreground run", () => {
+		const state = stateForTest();
+		state.foregroundControls.set("run-chain", {
+			runId: "run-chain",
+			mode: "chain",
+			startedAt: Date.now() - 1_000,
+			updatedAt: Date.now(),
+			currentAgent: "scout",
+			currentIndex: 0,
+		});
+
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000, defaultExpanded: true });
+		try {
+			fleet.setContext(ctx);
+			const tui = { requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor };
+			widgetFactory!(tui, theme);
+			assert.deepEqual(fleet.handleKey("\x1b"), { consume: true });
+
+			state.foregroundControls.set("run-chain", {
+				runId: "run-chain",
+				mode: "chain",
+				startedAt: Date.now() - 1_000,
+				updatedAt: Date.now(),
+				activeChildren: new Map(),
+			});
+			fleet.refresh();
+			state.foregroundControls.set("run-chain", {
+				runId: "run-chain",
+				mode: "chain",
+				startedAt: Date.now() - 1_000,
+				updatedAt: Date.now(),
+				currentAgent: "worker",
+				currentIndex: 1,
+			});
+			fleet.refresh();
+			assert.equal(widgetFactory!(tui, theme).render(80).length, 1);
+		} finally {
+			fleet.dispose();
+		}
+	});
+
+	it("preserves replacement-fleet expansion while the external inspector handles input", () => {
+		const state = stateForTest();
+		state.foregroundControls.set("run-worker", {
+			runId: "run-worker",
+			mode: "single",
+			startedAt: Date.now() - 1_000,
+			updatedAt: Date.now(),
+			currentAgent: "worker",
+		});
+
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000, defaultExpanded: true });
+		try {
+			fleet.setContext(ctx);
+			const tui = { requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor };
+			widgetFactory!(tui, theme);
+			assert.deepEqual(fleet.handleKey("\x1b"), { consume: true });
+
+			state.fleetInspectorOpen = true;
+			state.foregroundControls.clear();
+			state.foregroundControls.set("run-scout", {
+				runId: "run-scout",
+				mode: "single",
+				startedAt: Date.now(),
+				updatedAt: Date.now(),
+				currentAgent: "scout",
+			});
+			fleet.refresh();
+			tui.focusedComponent = {} as Editor;
+			assert.equal(fleet.handleKey("x"), undefined);
+
+			state.fleetInspectorOpen = false;
+			fleet.refresh();
+			assert.ok(widgetFactory!(tui, theme).render(80).length > 1);
+		} finally {
+			fleet.dispose();
+		}
+	});
+
 	it("renders main plus active children below the editor and bounds every line", () => {
 		const state = stateForTest();
 		state.activeAsyncCapacity = { used: 2, limit: 4 };

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -229,6 +229,15 @@ Package skill content.
 		assert.throws(() => updateConfig((config) => config), /config\.artifactDir must be "project", "session", or "temp"/);
 	});
 
+	it("loads and validates the FleetView default expansion config", () => {
+		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
+		writeFile(configPath, JSON.stringify({ fleetViewDefaultExpanded: true }));
+		assert.equal(loadConfig().fleetViewDefaultExpanded, true);
+
+		writeFile(configPath, JSON.stringify({ fleetViewDefaultExpanded: "yes" }));
+		assert.throws(() => updateConfig((config) => config), /config\.fleetViewDefaultExpanded must be a boolean/);
+	});
+
 	it("loads and validates Fleet keybinding config", () => {
 		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
 		writeFile(configPath, JSON.stringify({ fleetKeybindings: { pageUp: ["u"], pageDown: ["d"] } }));


### PR DESCRIPTION
## Summary

- add an opt-in `fleetViewDefaultExpanded` setting, preserving the compact default
- expand when a new active fleet appears while respecting manual collapse for the current fleet
- preserve lifecycle state across step transitions, widget suspension, and inspector ownership
- document and validate the setting with regression coverage

## Test plan

- `npm run typecheck`
- Node 24 unit suite: 1,939 passed, 0 failed, 0 cancelled, 2 skipped
- Node 24 integration suite: 788 passed, 0 failed
- E2E suite discovered successfully; runtime-dependent suite skipped because Pi runtime packages were unavailable
- `git diff --check`
