### PR TITLE
fix: avoid enum-on-integer in agentContract.version (Gemini schema rejection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Stop `agentContract.version` from using an `enum` on an integer, which Gemini's function-calling schema subset rejects (the property is dropped from the tool schema but stays in `required`, causing a `400: property is not defined` for every Gemini model). Integer bounds express the same constraint and are valid everywhere. Thanks to @MarcusNeufeldt for #1095.
 - Show workflow-owned foreground children and recursive nested runs as a bounded tree in FleetView. Thanks to @expoli for #1086.
 - Warn once, instead of on every heartbeat, when a long-running workflow child outlives its mission record. Thanks to @albertgwo for #1079.
 - Keep deleted-schedule timers from exiting Pi and re-arm recurring schedules after unexpected timer fire failures. Thanks to @albertgwo for #1084.

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -93,7 +93,7 @@ const AcceptanceOverride = Type.Unsafe({
 });
 
 const AgentContractOverride = Type.Object({
-	version: Type.Integer({ enum: [1], description: "Enable compatibility behavior for this run/child." }),
+	version: Type.Integer({ minimum: 1, maximum: 1, description: "Enable compatibility behavior for this run/child." }),
 }, { additionalProperties: false, description: "Compatibility behavior. Omit for the default behavior." });
 
 const ChainGateOverride = Type.String({

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -225,6 +225,17 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		assert.doesNotMatch(description, /orchestration\./);
 	});
 
+	it("keeps agentContract.version as integer bounds without an enum (Gemini schema subset)", () => {
+		const agentContract = (SubagentParams?.properties as Record<string, JsonSchemaNode> | undefined)?.agentContract;
+		assert.ok(agentContract, "agentContract schema should exist");
+		const version = (agentContract.properties as Record<string, JsonSchemaNode> | undefined)?.version;
+		assert.ok(version, "agentContract.version schema should exist");
+		assert.equal(version.type, "integer");
+		assert.equal(version.minimum, 1);
+		assert.equal(version.maximum, 1);
+		assert.equal(version.enum, undefined);
+	});
+
 	it("documents workflow timeout aliases and turn budget", () => {
 		const timeoutSchema = SubagentParams?.properties?.timeoutMs;
 		const maxRuntimeSchema = SubagentParams?.properties?.maxRuntimeMs;


### PR DESCRIPTION
## Problem

`AgentContractOverride.version` is declared as a required integer with an `enum`:

```ts
version: Type.Integer({ enum: [1], description: "…" }),
```

Gemini's function-calling schema subset only allows `enum` on **strings**. pi's Gemini translator therefore drops the `version` property but keeps it in the object's `required` array, and the model call fails:

```
GenerateContentRequest.tools[…].parameters.properties[agentContract].required[0]: property is not defined
```

This breaks **every Gemini model** for anyone with the extension installed — the tool list fails validation before any message is sent. (OpenAI/Anthropic don't validate this, which is why it only surfaces on Gemini.)

Isolation matrix that pinpointed it:

| schema shape | result |
|---|---|
| `{type:"integer", enum:[1]}` in required | **400 — the error** |
| `{type:"integer"}` in required | accepted |
| `{type:"integer", enum:[1]}` not required | accepted |
| `{type:"string", enum:["1"]}` in required | accepted |

## Fix

```ts
version: Type.Integer({ minimum: 1, maximum: 1, description: "…" }),
```

Integer bounds express the same "must be 1" constraint without an `enum`, so the schema is valid everywhere. The runtime already enforces `contract.version === 1` via `isAgentContractV1`, so behavior is unchanged on every provider.

## Verification

- Typecheck clean.
- No other instance of the enum-on-integer shape exists in the tool schemas (checked the rest of `schemas.ts`, the shipped package, and the tool list).
