### PR TITLE
feat: add configurable foreground detach shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Add an optional `foregroundDetachShortcut` binding and show it in the running single-subagent card, so foreground work can be moved to the background without editing package source.
+- Add an optional `foregroundDetachShortcut` binding and show it in the running single-subagent card, so foreground work can be moved to the background without editing package source. Thanks to @Lewis-E for #1097.
 
 ### Fixed
 - Reject configured subagent models that are not in the active host model registry before spawning a child, instead of forwarding an invalid `--model` argument to Pi. Thanks to @DresvyanskiyDenis for #1093.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Add an optional `foregroundDetachShortcut` binding and show it in the running single-subagent card, so foreground work can be moved to the background without editing package source.
+
 ### Fixed
 - Reject configured subagent models that are not in the active host model registry before spawning a child, instead of forwarding an invalid `--model` argument to Pi. Thanks to @DresvyanskiyDenis for #1093.
 - Start Herdr inspector and project pane commands with a shell-safe executable token, including paths that need quoting in Nushell. Thanks to @Rival for #1092.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,22 @@ With `"summary"`, a tool result looks like this:
 ✓ reviewer · completed
 ```
 
+## `foregroundDetachShortcut`
+
+```json
+{ "foregroundDetachShortcut": "ctrl+b" }
+```
+
+Optionally binds a shortcut that detaches the active foreground single-subagent run without terminating it. The running foreground card shows the configured shortcut beside its live-detail hint. The default is unset, so pi-subagents does not reserve a global key.
+
+Pi binds `Ctrl+B` to editor cursor-left by default. The extension shortcut takes precedence, but Pi reports the conflict at startup. To reserve the key without that warning, override the editor action in `~/.pi/agent/keybindings.json`:
+
+```json
+{
+  "tui.editor.cursorLeft": "left"
+}
+```
+
 ## `asyncByDefault`
 
 ```json

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -81,6 +81,22 @@ Without a TUI, `/subagents-fleet` retains the textual `subagent({ action: "statu
 
 Use `/subagents-detach [run-id]` only for an active foreground single-subagent run you want to leave running without terminating; the eventual result remains available through status/wait.
 
+Set `foregroundDetachShortcut` in `~/.pi/agent/extensions/subagent/config.json` to bind the same action to a shortcut. The running foreground card shows the configured shortcut beside its live-detail hint:
+
+```json
+{
+  "foregroundDetachShortcut": "ctrl+b"
+}
+```
+
+Pi binds `Ctrl+B` to editor cursor-left by default. The extension shortcut takes precedence, but Pi reports the conflict at startup. To reserve the key without that warning, override the editor action in `~/.pi/agent/keybindings.json`:
+
+```json
+{
+  "tui.editor.cursorLeft": "left"
+}
+```
+
 If something feels misconfigured, run `/subagents-doctor` or ask: "Check whether subagents and intercom are set up correctly."
 
 ## Async run artifacts

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Key } from "@earendil-works/pi-tui";
 import { FLEET_KEYBINDING_ACTIONS, type ArtifactDirPreference, type ExtensionConfig } from "../shared/types.ts";
 import { validateMissionStoreConfig } from "../missions/store.ts";
 import { validateAuthorityPolicy } from "../policy/authority.ts";
@@ -9,6 +10,21 @@ import { validatePermissionConfig } from "../runs/shared/permissions.ts";
 
 const ARTIFACT_DIR_PREFERENCES = new Set<ArtifactDirPreference>(["project", "session", "temp"]);
 const FLEET_KEYBINDING_ACTION_SET = new Set<string>(FLEET_KEYBINDING_ACTIONS);
+const KEY_MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
+const BASE_KEY_IDS = new Set([
+	..."abcdefghijklmnopqrstuvwxyz0123456789",
+	...Object.values(Key).flatMap((value) => typeof value === "string" ? [value.toLowerCase()] : []),
+]);
+
+function isValidKeyId(value: string): boolean {
+	if (value !== value.trim()) return false;
+	const parts = value.toLowerCase().split("+");
+	const base = parts.pop();
+	if (!base || !BASE_KEY_IDS.has(base)) return false;
+	return parts.length <= KEY_MODIFIERS.size
+		&& new Set(parts).size === parts.length
+		&& parts.every((modifier) => KEY_MODIFIERS.has(modifier));
+}
 
 export function resolveScheduledStoreRoot(value: string): string {
 	const expanded = value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
@@ -66,6 +82,10 @@ function validateMainWindowRendererConfig(value: unknown): void {
 }
 
 function validateConfig(config: Record<string, unknown>): void {
+	if (config.foregroundDetachShortcut !== undefined
+		&& (typeof config.foregroundDetachShortcut !== "string" || !isValidKeyId(config.foregroundDetachShortcut))) {
+		throw new Error("config.foregroundDetachShortcut must be a valid keybinding string such as \"ctrl+b\"");
+	}
 	if (config.artifactDir !== undefined && !ARTIFACT_DIR_PREFERENCES.has(config.artifactDir as ArtifactDirPreference)) {
 		throw new Error(`config.artifactDir must be "project", "session", or "temp"`);
 	}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -263,12 +263,13 @@ function rebuildSlashResultContainer(
 	options: { expanded: boolean },
 	theme: ExtensionContext["ui"]["theme"],
 	rendererConfig?: MainWindowRendererConfig,
+	foregroundDetachShortcut?: string,
 ): void {
 	container.clear();
 	container.addChild(new Spacer(1));
 	const boxTheme = isSlashResultRunning(result) ? "toolPendingBg" : isSlashResultError(result) ? "toolErrorBg" : "toolSuccessBg";
 	const box = new Box(1, 1, (text: string) => theme.bg(boxTheme, text));
-	box.addChild(renderSubagentResult(result, options, theme, undefined, rendererConfig));
+	box.addChild(renderSubagentResult(result, options, theme, undefined, rendererConfig, foregroundDetachShortcut));
 	container.addChild(box);
 }
 
@@ -277,6 +278,7 @@ function createSlashResultComponent(
 	options: { expanded: boolean },
 	theme: ExtensionContext["ui"]["theme"],
 	rendererConfig?: MainWindowRendererConfig,
+	foregroundDetachShortcut?: string,
 ): Container {
 	const container = new Container();
 	let lastVersion = -1;
@@ -284,7 +286,7 @@ function createSlashResultComponent(
 		const snapshot = getSlashRenderableSnapshot(details);
 		if (snapshot.version !== lastVersion || isSlashResultRunning(snapshot.result)) {
 			lastVersion = snapshot.version;
-			rebuildSlashResultContainer(container, snapshot.result, options, theme, rendererConfig);
+			rebuildSlashResultContainer(container, snapshot.result, options, theme, rendererConfig, foregroundDetachShortcut);
 		}
 		return Container.prototype.render.call(container, width);
 	};
@@ -502,7 +504,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	pi.registerMessageRenderer<SlashMessageDetails>(SLASH_RESULT_TYPE, (message, options, theme) => {
 		const details = resolveSlashMessageDetails(message.details);
 		if (!details) return undefined;
-		return createSlashResultComponent(details, options, theme, config.mainWindowRenderer);
+		return createSlashResultComponent(details, options, theme, config.mainWindowRenderer, config.foregroundDetachShortcut);
 	});
 
 	pi.registerMessageRenderer<undefined>(SLASH_TEXT_RESULT_TYPE, (message, _options, _theme) => {
@@ -630,7 +632,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			const renderedResult = { ...result, isError: context.isError };
 			return summaryInlineToolDisplay
 				? renderSubagentSummary(renderedResult, options, theme)
-				: renderSubagentResult(renderedResult, options, theme, undefined, config.mainWindowRenderer);
+				: renderSubagentResult(renderedResult, options, theme, undefined, config.mainWindowRenderer, config.foregroundDetachShortcut);
 		},
 
 	};
@@ -660,7 +662,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}
 	});
 
-	registerSlashCommands(pi, state, { fleetKeybindings: config.fleetKeybindings });
+	registerSlashCommands(pi, state, {
+		fleetKeybindings: config.fleetKeybindings,
+		foregroundDetachShortcut: config.foregroundDetachShortcut,
+	});
 
 	const eventUnsubscribeStoreKey = "__piSubagentEventUnsubscribes";
 	const controlNoticeSeenStoreKey = "__piSubagentVisibleControlNotices";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1031,6 +1031,7 @@ export interface Details {
 	controlEvents?: ControlEvent[];
 	steering?: SteerActionResult;
 	asyncId?: string;
+	background?: boolean;
 	asyncDir?: string;
 	timeoutMs?: number;
 	deadlineAt?: number;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1907,6 +1907,8 @@ export interface MainWindowRendererConfig {
 
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
+	/** Optional shortcut that detaches the active foreground single-subagent run. */
+	foregroundDetachShortcut?: string;
 	/** Show the Claude Code-style navigable fleet. Defaults to true. */
 	fleetView?: boolean;
 	/** Place the persistent FleetView above or below the editor. Defaults to belowEditor. */

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { keyText, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { Key, matchesKey, truncateToWidth, type Component, type TUI } from "@earendil-works/pi-tui";
+import { Key, matchesKey, truncateToWidth, type Component, type KeyId, type TUI } from "@earendil-works/pi-tui";
 import { BUILTIN_AGENT_NAMES, discoverAgents } from "../agents/agents.ts";
 import { resolveExistingReadPaths } from "../shared/settings.ts";
 import {
@@ -631,7 +631,7 @@ function slashRunWorkflowScript(key: string, child: Record<string, unknown>): st
 export function registerSlashCommands(
 	pi: ExtensionAPI,
 	state: SubagentState,
-	options: { fleetKeybindings?: FleetKeybindingsConfig } = {},
+	options: { fleetKeybindings?: FleetKeybindingsConfig; foregroundDetachShortcut?: string } = {},
 ): void {
 	let fleetOpen = false;
 	const showFleet = async (ctx: ExtensionContext) => {
@@ -741,32 +741,41 @@ export function registerSlashCommands(
 		handler: async (ctx) => showFleet(ctx),
 	});
 
+	const detachForegroundRun = (args: string, ctx: ExtensionContext): void => {
+		const id = args.trim();
+		let control: ReturnType<typeof selectForegroundDetachControl>;
+		try {
+			control = selectForegroundDetachControl(state, id);
+		} catch (error) {
+			ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+			return;
+		}
+		if (!control) {
+			ctx.ui.notify(id ? `No active foreground run found for '${id}'.` : "No active foreground single-subagent run to detach.", "info");
+			return;
+		}
+		if (control.mode !== "single") {
+			ctx.ui.notify("/subagents-detach currently supports single-subagent runs only.", "error");
+			return;
+		}
+		if (!control.detach?.()) {
+			ctx.ui.notify(`Foreground run ${control.runId} is not currently detachable.`, "info");
+			return;
+		}
+		sendSlashText(pi, `Detached foreground run ${control.runId} without terminating its child. Use subagent({ action: "status", id: ${JSON.stringify(control.runId)} }) or subagent_wait({ id: ${JSON.stringify(control.runId)} }) to recover the eventual result. This does not daemonize the process or guarantee survival across Pi reload/restart.`);
+	};
+
 	pi.registerCommand("subagents-detach", {
 		description: "Detach the active foreground single-subagent run without terminating it",
-		handler: async (args, ctx) => {
-			const id = args.trim();
-			let control: ReturnType<typeof selectForegroundDetachControl>;
-			try {
-				control = selectForegroundDetachControl(state, id);
-			} catch (error) {
-				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
-				return;
-			}
-			if (!control) {
-				ctx.ui.notify(id ? `No active foreground run found for '${id}'.` : "No active foreground single-subagent run to detach.", "info");
-				return;
-			}
-			if (control.mode !== "single") {
-				ctx.ui.notify("/subagents-detach currently supports single-subagent runs only.", "error");
-				return;
-			}
-			if (!control.detach?.()) {
-				ctx.ui.notify(`Foreground run ${control.runId} is not currently detachable.`, "info");
-				return;
-			}
-			sendSlashText(pi, `Detached foreground run ${control.runId} without terminating its child. Use subagent({ action: "status", id: ${JSON.stringify(control.runId)} }) or subagent_wait({ id: ${JSON.stringify(control.runId)} }) to recover the eventual result. This does not daemonize the process or guarantee survival across Pi reload/restart.`);
-		},
+		handler: async (args, ctx) => detachForegroundRun(args, ctx),
 	});
+
+	if (options.foregroundDetachShortcut) {
+		pi.registerShortcut(options.foregroundDetachShortcut as KeyId, {
+			description: "Detach the active foreground subagent and keep it running in the background",
+			handler: async (ctx) => detachForegroundRun("", ctx),
+		});
+	}
 
 	pi.registerCommand("subagents-stop", {
 		description: "Stop a current-session async subagent run",

--- a/src/slash/slash-live-state.ts
+++ b/src/slash/slash-live-state.ts
@@ -81,6 +81,7 @@ function buildParallelInitialResult(params: SubagentParamsLike): AgentToolResult
 		content: [{ type: "text", text: tasks.map((task) => `${task.agent}: ${task.task}`).join("\n\n") }],
 		details: {
 			mode: "parallel",
+			...(params.async ? { background: true } : {}),
 			...(params.context ? { context: params.context } : {}),
 			results: tasks.map((task, index) => createPlaceholderResult(task.agent, task.task, "running", index)),
 			progress: tasks.map((task, index) => ({
@@ -136,6 +137,7 @@ function buildChainInitialResult(params: SubagentParamsLike): AgentToolResult<De
 		}],
 		details: {
 			mode: "chain",
+			...(params.async ? { background: true } : {}),
 			...(params.context ? { context: params.context } : {}),
 			results,
 			progress: results.map((result, index) => ({
@@ -164,6 +166,7 @@ function buildSingleInitialResult(params: SubagentParamsLike): AgentToolResult<D
 		content: [{ type: "text", text: task }],
 		details: {
 			mode: "single",
+			...(params.async ? { background: true } : {}),
 			...(params.context ? { context: params.context } : {}),
 			results: [createPlaceholderResult(agent, task, "running", 0)],
 			progress: [{

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -71,6 +71,22 @@ function liveDetailHintText(): string {
 	return `Press ${liveDetailKeyText()} for live detail`;
 }
 
+function foregroundSingleHintText(shortcut?: string): string {
+	if (!shortcut) return liveDetailHintText();
+	const label = shortcut
+		.split("+")
+		.map((part) => {
+			const normalized = part.trim().toLowerCase();
+			if (normalized === "ctrl") return "Ctrl";
+			if (normalized === "alt") return "Alt";
+			if (normalized === "shift") return "Shift";
+			if (normalized === "super") return "Super";
+			return normalized.length === 1 ? normalized.toUpperCase() : part.trim();
+		})
+		.join("+");
+	return `${liveDetailHintText()} · ${label} to run in background`;
+}
+
 function getTermWidth(): number {
 	return process.stdout.columns || 120;
 }
@@ -1588,7 +1604,14 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, ctx.ui.getToolsExpanded?.() ?? false));
 }
 
-function renderSingleCompact(d: Details, r: Details["results"][number], theme: Theme, layout: MainWindowRenderLayout, frame?: number): Component {
+function renderSingleCompact(
+	d: Details,
+	r: Details["results"][number],
+	theme: Theme,
+	layout: MainWindowRenderLayout,
+	frame?: number,
+	foregroundDetachShortcut?: string,
+): Component {
 	const output = r.truncation?.text || getSingleResultOutput(r);
 	const progress = r.progress || r.progressSummary;
 	const isRunning = isResultRunning(r);
@@ -1613,7 +1636,7 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 		for (const nestedLine of formatNestedWidgetLines(r.children, theme, width, false, progressSnapshotNow)) {
 			c.addChild(new Text(truncLine(`${detailIndent}${nestedLine}`, width), 0, 0));
 		}
-		c.addChild(new Text(truncLine(theme.fg("accent", `${detailIndent}${liveDetailHintText()}`), width), 0, 0));
+		c.addChild(new Text(truncLine(theme.fg("accent", `${detailIndent}${foregroundSingleHintText(foregroundDetachShortcut)}`), width), 0, 0));
 		if (r.artifactPaths) c.addChild(new Text(truncLine(theme.fg("dim", `${detailIndent}output: ${shortenPath(r.artifactPaths.outputPath)}`), width), 0, 0));
 		return c;
 	}
@@ -1845,6 +1868,7 @@ export function renderSubagentResult(
 	theme: Theme,
 	frame?: number,
 	rendererConfig?: MainWindowRendererConfig,
+	foregroundDetachShortcut?: string,
 ): Component {
 	const layout = resolveMainWindowRenderLayout(rendererConfig);
 	const compact = (component: Component): Component => capCompactMainWindowResult(component, layout, theme, !options.expanded);
@@ -1878,8 +1902,9 @@ export function renderSubagentResult(
 
 	if (d.mode === "single" && d.results.length === 1) {
 		const r = d.results[0];
+		const detachableShortcut = d.asyncId ? undefined : foregroundDetachShortcut;
 		if (!r) return compact(renderMultiCompact(d, theme, layout, frame));
-		if (!expanded) return compact(renderSingleCompact(d, r, theme, layout, frame));
+		if (!expanded) return compact(renderSingleCompact(d, r, theme, layout, frame, detachableShortcut));
 		const isRunning = isResultRunning(r);
 		const contextBadge = contextModeBadge(theme, r.context ?? d.context);
 		const output = r.truncation?.text || getSingleResultOutput(r);
@@ -1919,7 +1944,7 @@ export function renderSubagentResult(
 			if (liveStatusLine) {
 				c.addChild(new Text(fit(theme.fg("accent", liveStatusLine)), 0, 0));
 			}
-			c.addChild(new Text(fit(theme.fg("accent", liveDetailHintText())), 0, 0));
+			c.addChild(new Text(fit(theme.fg("accent", foregroundSingleHintText(detachableShortcut))), 0, 0));
 			if (r.artifactPaths) {
 				c.addChild(new Text(fit(theme.fg("dim", `Artifacts: ${shortenPath(r.artifactPaths.outputPath)}`)), 0, 0));
 			}

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1902,7 +1902,7 @@ export function renderSubagentResult(
 
 	if (d.mode === "single" && d.results.length === 1) {
 		const r = d.results[0];
-		const detachableShortcut = d.asyncId ? undefined : foregroundDetachShortcut;
+		const detachableShortcut = d.asyncId || d.background ? undefined : foregroundDetachShortcut;
 		if (!r) return compact(renderMultiCompact(d, theme, layout, frame));
 		if (!expanded) return compact(renderSingleCompact(d, r, theme, layout, frame, detachableShortcut));
 		const isRunning = isResultRunning(r);

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -46,6 +46,7 @@ interface RegisterSlashCommandsModule {
 			watcherRestartTimer: ReturnType<typeof setTimeout> | null;
 			resultFileCoalescer: { schedule(file: string, delayMs?: number): boolean; clear(): void };
 		},
+		options?: { foregroundDetachShortcut?: string },
 	) => void;
 }
 
@@ -477,6 +478,48 @@ describe("subagents watchdog slash command", { skip: !available ? "watchdog comm
 describe("slash command custom message delivery", { skip: !available ? "slash-commands.ts not importable" : undefined }, () => {
 	beforeEach(() => {
 		clearSlashSnapshots?.();
+	});
+
+	it("registers a configured foreground detach shortcut", async () => {
+		const shortcuts = new Map<string, { handler(ctx: unknown): Promise<void> }>();
+		const sent: unknown[] = [];
+		const state = createState(process.cwd());
+		let detachCalls = 0;
+		state.foregroundControls.set("run-123", {
+			runId: "run-123",
+			mode: "single",
+			updatedAt: Date.now(),
+			detach: () => {
+				detachCalls += 1;
+				return true;
+			},
+		});
+		state.lastForegroundControlId = "run-123";
+
+		registerSlashCommands!({
+			events: createEventBus(),
+			registerCommand() {},
+			registerShortcut(key: string, spec: { handler(ctx: unknown): Promise<void> }) {
+				shortcuts.set(key, spec);
+			},
+			sendMessage(message: unknown) { sent.push(message); },
+		}, state, { foregroundDetachShortcut: "ctrl+b" });
+
+		assert.ok(shortcuts.has("ctrl+b"));
+		await shortcuts.get("ctrl+b")!.handler(createCommandContext());
+		assert.equal(detachCalls, 1);
+		assert.match(String((sent[0] as { content?: unknown }).content ?? ""), /Detached foreground run run-123/);
+	});
+
+	it("does not reserve a foreground detach shortcut by default", () => {
+		const shortcuts = new Map<string, unknown>();
+		registerSlashCommands!({
+			events: createEventBus(),
+			registerCommand() {},
+			registerShortcut(key: string, spec: unknown) { shortcuts.set(key, spec); },
+			sendMessage() {},
+		}, createState(process.cwd()));
+		assert.equal(shortcuts.has("ctrl+b"), false);
 	});
 
 	it("/subagents-stop keeps the selector within its allocated width", async () => {

--- a/test/integration/slash-live-state.test.ts
+++ b/test/integration/slash-live-state.test.ts
@@ -63,6 +63,18 @@ describe("slash live state", { skip: !available ? "slash-live-state.ts not impor
 		assert.equal(snapshot.version > 0, true);
 	});
 
+	it("marks async initial slash snapshots as background", () => {
+		clearSlashSnapshots!();
+		const details = buildSlashInitialResult!("req-bg", {
+			workflowScript: "return runs.run(\"run\", { agent: \"scout\", task: \"inspect\" })",
+			async: true,
+		});
+
+		assert.equal(details.result.details.mode, "single");
+		assert.equal(details.result.details.background, true);
+		assert.equal(details.result.details.asyncId, undefined);
+	});
+
 	it("does not assign a parallel child update to another chain placeholder", () => {
 		clearSlashSnapshots!();
 		const details = buildSlashInitialResult!("req-parallel", {

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -241,6 +241,15 @@ Package skill content.
 		assert.throws(() => updateConfig((config) => config), /config\.fleetKeybindings\.pageUp entries must be non-empty strings/);
 	});
 
+	it("loads and validates the foreground detach shortcut", () => {
+		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
+		writeFile(configPath, JSON.stringify({ foregroundDetachShortcut: "ctrl+b" }));
+		assert.equal(loadConfig().foregroundDetachShortcut, "ctrl+b");
+
+		writeFile(configPath, JSON.stringify({ foregroundDetachShortcut: "banana" }));
+		assert.throws(() => updateConfig((config) => config), /config\.foregroundDetachShortcut must be a valid keybinding string/);
+	});
+
 	it("loads and validates main-window renderer density config", () => {
 		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
 		writeFile(configPath, JSON.stringify({ mainWindowRenderer: { horizontalSpacing: 0, compactResultMaxLines: 4 } }));

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -80,6 +80,40 @@ test("multiline rendering omits two-column graphemes at one-column width", () =>
 	}
 });
 
+test("running single-subagent cards show the configured detach shortcut", () => {
+	const running = {
+		...result("reviewer", ""),
+		progress: { status: "running", index: 0, agent: "reviewer", toolCount: 0, tokens: 0, durationMs: 0 },
+	};
+	const toolResult = {
+		content: [{ type: "text", text: "running" }],
+		details: { mode: "single", results: [running] },
+	};
+
+	const configured = componentText(renderSubagentResult(
+		toolResult as never,
+		{ expanded: false },
+		theme as any,
+		undefined,
+		undefined,
+		"ctrl+b",
+	));
+	assert.match(configured, /Ctrl\+B to run in background/);
+
+	const unconfigured = componentText(renderSubagentResult(toolResult as never, { expanded: false }, theme as any));
+	assert.doesNotMatch(unconfigured, /run in background/);
+
+	const alreadyBackground = componentText(renderSubagentResult(
+		{ ...toolResult, details: { ...toolResult.details, asyncId: "async-123" } } as never,
+		{ expanded: false },
+		theme as any,
+		undefined,
+		undefined,
+		"ctrl+b",
+	));
+	assert.doesNotMatch(alreadyBackground, /run in background/);
+});
+
 test("compact chain rendering uses workflow graph spans for dynamic fanout results", () => {
 	const component = renderSubagentResult({
 		content: [{ type: "text", text: "done" }],

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -112,6 +112,16 @@ test("running single-subagent cards show the configured detach shortcut", () => 
 		"ctrl+b",
 	));
 	assert.doesNotMatch(alreadyBackground, /run in background/);
+
+	const pendingBackground = componentText(renderSubagentResult(
+		{ ...toolResult, details: { ...toolResult.details, background: true } } as never,
+		{ expanded: false },
+		theme as any,
+		undefined,
+		undefined,
+		"ctrl+b",
+	));
+	assert.doesNotMatch(pendingBackground, /run in background/);
 });
 
 test("compact chain rendering uses workflow graph spans for dynamic fanout results", () => {


### PR DESCRIPTION
## What changed

- add a `foregroundDetachShortcut` setting that defaults to `Ctrl+Alt+B` and reuses `/subagents-detach`
- allow custom Pi key IDs or `false` to disable the binding
- show the active shortcut in running foreground single-subagent cards, but not on already-background runs
- document the default and customization options

## Testing

- `npm run typecheck`
- `npm run test:unit` (1,963 passed, 2 skipped; Git commit signing disabled for temporary worktree fixtures)
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/slash-commands.test.ts`