### PR TITLE
fix: reject unresolved subagent models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Reject configured subagent models that are not in the active host model registry before spawning a child, instead of forwarding an invalid `--model` argument to Pi. Thanks to @DresvyanskiyDenis for #1093.
 - Start Herdr inspector and project pane commands with a shell-safe executable token, including paths that need quoting in Nushell. Thanks to @Rival for #1092.
 - Stop `agentContract.version` from using an `enum` on an integer, which Gemini's function-calling schema subset rejects (the property is dropped from the tool schema but stays in `required`, causing a `400: property is not defined` for every Gemini model). Integer bounds express the same constraint and are valid everywhere. Thanks to @MarcusNeufeldt for #1095.
 - Show workflow-owned foreground children and recursive nested runs as a bounded tree in FleetView. Thanks to @expoli for #1086.

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -260,13 +260,18 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 	}
 	if (resolvedSkills.missing.length > 0) diagnostics.push({ code: "missing_skill", severity: "error", message: `Missing skills: ${resolvedSkills.missing.join(", ")}` });
 
+	const externalRunner = agent.runner?.type === "external-cli";
 	const availableModels = normalizeAvailableModels(input.availableModels);
 	const preferredProvider = input.preferredProvider ?? input.parentModel?.provider;
-	const primaryModel = resolveEffectiveSubagentModel(input.model, agent.model, input.parentModel, availableModels, preferredProvider, { scope: discovered.modelScope });
+	const primaryModel = externalRunner
+		? undefined
+		: resolveEffectiveSubagentModel(input.model, agent.model, input.parentModel, availableModels, preferredProvider, { scope: discovered.modelScope });
 	const effectiveThinkingConfig = input.thinking !== undefined ? input.thinking : agent.thinking;
-	const model = applyThinkingSuffix(primaryModel, effectiveThinkingConfig, input.thinking !== undefined);
-	const modelCandidates = buildModelCandidates(primaryModel, agent.fallbackModels, availableModels, preferredProvider, { scope: discovered.modelScope })
-		.map((candidate) => applyThinkingSuffix(candidate, effectiveThinkingConfig, input.thinking !== undefined) ?? candidate);
+	const model = externalRunner ? undefined : applyThinkingSuffix(primaryModel, effectiveThinkingConfig, input.thinking !== undefined);
+	const modelCandidates = externalRunner
+		? []
+		: buildModelCandidates(primaryModel, agent.fallbackModels, availableModels, preferredProvider, { scope: discovered.modelScope })
+			.map((candidate) => applyThinkingSuffix(candidate, effectiveThinkingConfig, input.thinking !== undefined) ?? candidate);
 	let toolPlan: PiLaunchToolPlan;
 	try {
 		toolPlan = resolvePiLaunchToolPlan({
@@ -298,7 +303,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		? nestedResultsPath(input.nestedRootRunId, runId)
 		: resultFilePath(DIRS.results, runId);
 	if (!sessionDir) diagnostics.push({ code: "host_required", severity: "host-required", message: "No sessionRoot/sessionDir was supplied; exact child session paths require the Pi host session-root policy." });
-	if (input.availableModels === undefined && (input.model || agent.model || input.parentModel)) {
+	if (!externalRunner && input.availableModels === undefined && (input.model || agent.model || input.parentModel)) {
 		diagnostics.push({ code: "host_required", severity: "host-required", message: "No availableModels snapshot was supplied; model resolution may differ from the active Pi host registry." });
 	}
 	if (resolvedSkills.missing.length > 0) {

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -1429,11 +1429,13 @@ export function executeAsyncSingle(
 	const structuredOutput = params.structuredOutputSchema
 		? createStructuredOutputRuntime(params.structuredOutputSchema, path.join(asyncDir, "structured-output"))
 		: undefined;
-	const modelCandidates = buildModelCandidates(primaryModel, agentConfig.fallbackModels, availableModels, ctx.currentModelProvider, { scope: ctx.modelScope })
-		.flatMap((candidate) => {
-			const resolved = applyThinkingSuffix(candidate, effectiveThinking, params.thinkingOverride !== undefined);
-			return resolved ? [resolved] : [];
-		});
+	const modelCandidates = externalRunner
+		? []
+		: buildModelCandidates(primaryModel, agentConfig.fallbackModels, availableModels, ctx.currentModelProvider, { scope: ctx.modelScope })
+			.flatMap((candidate) => {
+				const resolved = applyThinkingSuffix(candidate, effectiveThinking, params.thinkingOverride !== undefined);
+				return resolved ? [resolved] : [];
+			});
 	const effectiveSystemPrompt = appendTurnBudgetSystemPrompt(systemPrompt, params.turnBudget);
 	const toolPlan = resolvePiLaunchToolPlan({
 		tools: agentConfig.tools,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2511,16 +2511,19 @@ function resolveStaticLaunchSummary(input: {
 	thinkingOverrideForTask: ForkThinkingOverrideForTask;
 }): StaticLaunchSummary {
 	const agentConfig = input.agents.find((agent) => agent.name === input.agent);
-	const model = resolveEffectiveSubagentModel(
-		input.explicitModel,
-		agentConfig?.model,
-		input.parentModel,
-		input.availableModels,
-		input.currentProvider,
-		input.modelScope === undefined ? {} : { scope: input.modelScope },
-	);
-	const thinkingOverride = input.thinkingOverrideForTask(input.agent, input.index, model);
-	const thinking = resolveEffectiveThinking(model, thinkingOverride ?? agentConfig?.thinking);
+	const externalRunner = agentConfig?.runner?.type === "external-cli";
+	const model = externalRunner
+		? undefined
+		: resolveEffectiveSubagentModel(
+			input.explicitModel,
+			agentConfig?.model,
+			input.parentModel,
+			input.availableModels,
+			input.currentProvider,
+			input.modelScope === undefined ? {} : { scope: input.modelScope },
+		);
+	const thinkingOverride = externalRunner ? undefined : input.thinkingOverrideForTask(input.agent, input.index, model);
+	const thinking = externalRunner ? undefined : resolveEffectiveThinking(model, thinkingOverride ?? agentConfig?.thinking);
 	return {
 		agent: input.agent,
 		...(model ? { model } : {}),
@@ -2880,8 +2883,8 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const externalRunnerWithoutExplicitModel = a.runner?.type === "external-cli"
 			&& params.model === undefined
 			&& (a.model === undefined || (a.modelSource?.type === "subagents.defaultModel" && a.model === a.modelSource.model));
-		const modelOverride = externalRunnerWithoutExplicitModel
-			? undefined
+		const modelOverride = a.runner?.type === "external-cli"
+			? params.model ?? (externalRunnerWithoutExplicitModel ? undefined : a.model)
 			: resolveEffectiveSubagentModel(params.model as string | undefined, a.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope });
 		return executeAsyncSingle(id, compactOptional<Parameters<typeof executeAsyncSingle>[1]>({
 			agent: params.agent!,
@@ -3764,7 +3767,9 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		...(task.model !== undefined ? { model: task.model } : {}),
 	}));
 	const modelOverrides: (string | undefined)[] = tasks.map((_, i) =>
-		resolveEffectiveSubagentModel(behaviorOverrides[i]?.model, agentConfigs[i]?.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope }),
+		agentConfigs[i]?.runner?.type === "external-cli"
+			? undefined
+			: resolveEffectiveSubagentModel(behaviorOverrides[i]?.model, agentConfigs[i]?.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope }),
 	);
 
 	if (params.clarify === true && ctx.hasUI) {
@@ -3799,7 +3804,9 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		for (let i = 0; i < result.behaviorOverrides.length; i++) {
 			const override = result.behaviorOverrides[i];
 			if (override?.model !== undefined) {
-				modelOverrides[i] = resolveEffectiveSubagentModel(override.model, agentConfigs[i]?.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope });
+				modelOverrides[i] = agentConfigs[i]?.runner?.type === "external-cli"
+					? undefined
+					: resolveEffectiveSubagentModel(override.model, agentConfigs[i]?.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope });
 				behaviorOverrides[i]!.model = override.model;
 			}
 			if (override?.output !== undefined) behaviorOverrides[i]!.output = override.output;
@@ -6064,6 +6071,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const parentModel = requestParentModel;
 			prepareForkThinking = (agentName, index, modelOverride) => {
 				const agentConfig = agents.find((agent) => agent.name === agentName);
+				if (agentConfig?.runner?.type === "external-cli") {
+					forkThinkingRequirements.set(index, true);
+					return;
+				}
 				const primaryModel = resolveEffectiveSubagentModel(
 					modelOverride,
 					agentConfig?.model,

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -163,6 +163,20 @@ export function resolveModelCandidate(
 	return model;
 }
 
+function resolveRequiredSubagentModelCandidate(
+	model: string,
+	availableModels: AvailableModelInfo[] | undefined,
+	preferredProvider?: string,
+): string {
+	if (!availableModels || availableModels.length === 0) return model;
+	const resolvedWhole = resolveBaseModelCandidate(model, availableModels, preferredProvider);
+	if (resolvedWhole) return resolvedWhole;
+	const { baseModel, thinkingSuffix } = splitThinkingSuffix(model);
+	const resolvedBase = thinkingSuffix ? resolveBaseModelCandidate(baseModel, availableModels, preferredProvider) : undefined;
+	if (resolvedBase) return `${resolvedBase}${thinkingSuffix}`;
+	throw new Error(`Unknown subagent model '${model}' in the active Pi model registry.`);
+}
+
 export interface ResolveSubagentModelOverrideOptions {
 	/** When set with `enforce: true`, out-of-scope models are rejected. */
 	scope?: ModelScopeConfig;
@@ -207,7 +221,7 @@ export function resolveSubagentModelOverride(
 	if (explicit === undefined) {
 		resolved = parentModel ? `${parentModel.provider}/${parentModel.id}` : undefined;
 	} else {
-		resolved = resolveModelCandidate(explicit, availableModels, preferredProvider);
+		resolved = resolveRequiredSubagentModelCandidate(explicit, availableModels, preferredProvider);
 	}
 	if (resolved && options?.scope?.enforce) {
 		const source: ModelSource = explicit === undefined ? "inherited" : (options.source ?? "inherited");
@@ -264,7 +278,7 @@ export function buildModelCandidates(
 	for (let index = 0; index < rawCandidates.length; index++) {
 		const raw = rawCandidates[index];
 		if (!raw) continue;
-		const normalized = resolveModelCandidate(raw.trim(), availableModels, preferredProvider);
+		const normalized = resolveRequiredSubagentModelCandidate(raw.trim(), availableModels, preferredProvider);
 		if (!normalized || seen.has(normalized)) continue;
 		if ((index > 0 || options?.scope?.strict === true) && options?.scope?.enforce) {
 			const violation = checkModelScope(normalized, options.scope, "inherited");

--- a/test/integration/chain-execution.test.ts
+++ b/test/integration/chain-execution.test.ts
@@ -538,7 +538,7 @@ describe("chain execution — sequential", { skip: !available ? "pi packages not
 				{
 					ctx: {
 						...makeMinimalCtx(tempDir),
-						model: { provider: "github-copilot" },
+						model: { provider: "github-copilot", id: "gpt-5-mini" },
 						modelRegistry: {
 							getAvailable: () => [
 								{ provider: "openai", id: "gpt-5-mini" },

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -577,6 +577,74 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		fs.rmSync(workflowResultPath, { force: true });
 	});
 
+	it("runs external CLI agents with fallback models without registry validation", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const markerPath = path.join(tempDir, "external-fallback-started");
+		const executor = makeExecutor([
+			makeAgent("external", {
+				runner: { type: "external-cli", command: process.execPath, args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "started")`] },
+				fallbackModels: ["mock/fallback"],
+			}),
+		]);
+		const result = await executor.execute(
+			"external-fallback-model",
+			{ agent: "external", task: "Run external", async: true },
+			new AbortController().signal,
+			undefined,
+			{
+				...makeMinimalCtx(tempDir),
+				modelRegistry: { getAvailable: () => [{ provider: "other", id: "known" }] },
+			},
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.doesNotMatch(result.content[0]?.text ?? "", /Unknown subagent model/);
+		for (let attempt = 0; attempt < 100 && !fs.existsSync(markerPath); attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		assert.equal(fs.readFileSync(markerPath, "utf-8"), "started");
+		assert.equal(mockPi.callCount(), 0);
+
+		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true });
+		fs.rmSync(path.join(DIRS.results, "external-fallback-model.json"), { force: true });
+	});
+
+	it("rejects external CLI fork context before fallback model validation", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const markerPath = path.join(tempDir, "external-fork-started");
+		const parentSessionFile = path.join(mockPi.dir, "external-fork-parent.jsonl");
+		fs.writeFileSync(parentSessionFile, `${JSON.stringify({ type: "session", version: 3, id: "parent", cwd: tempDir })}\n`, "utf-8");
+		const ctx = makeMinimalCtx(tempDir);
+		Object.assign(ctx.sessionManager, {
+			getSessionFile: () => parentSessionFile,
+			getLeafId: () => "parent-leaf",
+			openSession: () => ({
+				createBranchedSession: () => parentSessionFile,
+			}),
+		});
+		const executor = makeExecutor([
+			makeAgent("external", {
+				runner: { type: "external-cli", command: process.execPath, args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "started")`] },
+				defaultContext: "fork",
+				fallbackModels: ["mock/fallback"],
+			}),
+		]);
+		const result = await executor.execute(
+			"external-fork-fallback",
+			{ agent: "external", task: "Run external", async: true },
+			new AbortController().signal,
+			undefined,
+			{
+				...ctx,
+				modelRegistry: { getAvailable: () => [{ provider: "other", id: "known" }] },
+			},
+		);
+
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /does not support: fork context/);
+		assert.doesNotMatch(result.content[0]?.text ?? "", /Unknown subagent model/);
+		assert.equal(mockPi.callCount(), 0);
+		assert.equal(fs.existsSync(markerPath), false);
+	});
+
 	it("rejects explicit model overrides for external CLI agents", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const executor = makeExecutor([
 			makeAgent("external", {
@@ -588,11 +656,15 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			{ agent: "external", task: "Run external", async: true, model: "mock/override" },
 			new AbortController().signal,
 			undefined,
-			makeMinimalCtx(tempDir),
+			{
+				...makeMinimalCtx(tempDir),
+				modelRegistry: { getAvailable: () => [{ provider: "other", id: "known" }] },
+			},
 		);
 
 		assert.equal(result.isError, true);
 		assert.match(result.content[0]?.text ?? "", /does not support: model override/);
+		assert.doesNotMatch(result.content[0]?.text ?? "", /Unknown subagent model/);
 		assert.equal(mockPi.callCount(), 0);
 	});
 
@@ -3296,6 +3368,18 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.exitCode, 0);
 		assert.equal(result.model, "openai/gpt-4o");
+	});
+
+	it("rejects an unresolved agent model before spawning Pi", async () => {
+		const agents = [makeAgent("echo", { model: "fast" })];
+
+		await assert.rejects(
+			runSync(tempDir, agents, "echo", "Task", {
+				availableModels: [{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" }],
+			}),
+			/Unknown subagent model 'fast'/,
+		);
+		assert.equal(mockPi.callCount(), 0);
 	});
 
 	it("prefers the parent session provider for ambiguous bare model ids", async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -604,8 +604,18 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(fs.readFileSync(markerPath, "utf-8"), "started");
 		assert.equal(mockPi.callCount(), 0);
 
-		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true });
-		fs.rmSync(path.join(DIRS.results, "external-fallback-model.json"), { force: true });
+		assert.ok(result.details.asyncId);
+		const resultPath = path.join(DIRS.results, `${result.details.asyncId}.json`);
+		let runResult: { state?: string } = {};
+		for (let attempt = 0; attempt < 100; attempt++) {
+			if (fs.existsSync(resultPath)) runResult = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+			if (runResult.state === "complete" || runResult.state === "failed") break;
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		assert.equal(runResult.state, "complete");
+
+		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+		fs.rmSync(resultPath, { force: true });
 	});
 
 	it("rejects external CLI fork context before fallback model validation", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -66,6 +66,13 @@ describe("model fallback helpers", () => {
 		);
 	});
 
+	it("rejects fallback models that the active registry cannot resolve", () => {
+		assert.throws(
+			() => buildModelCandidates("gpt-5-mini", ["does-not-exist"], availableModels),
+			/Unknown subagent model 'does-not-exist'/,
+		);
+	});
+
 	it("detects retryable provider/model failures", () => {
 		assert.equal(isRetryableModelFailure("rate limit exceeded for provider"), true);
 		assert.equal(isRetryableModelFailure("model unavailable"), true);
@@ -144,6 +151,17 @@ describe("resolveSubagentModelOverride (cross-session inherit, issue #266)", () 
 		assert.equal(
 			resolveSubagentModelOverride("gpt-5-mini", parentModel, availableModels),
 			"openai/gpt-5-mini",
+		);
+	});
+
+	it("rejects explicit models that the active registry cannot resolve", () => {
+		assert.throws(
+			() => resolveSubagentModelOverride("does-not-exist", parentModel, availableModels),
+			/Unknown subagent model 'does-not-exist'/,
+		);
+		assert.throws(
+			() => resolveSubagentModelOverride("does-not-exist:high", parentModel, availableModels),
+			/Unknown subagent model 'does-not-exist:high'/,
 		);
 	});
 

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -154,6 +154,54 @@ Project prompt.
 		}
 	});
 
+	it("rejects an unresolved configured model when the host registry is available", async () => {
+		const cwd = path.join(tempDir, "repo-unresolved-model");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Project worker
+model: fast
+---
+Project prompt.
+`);
+
+		await assert.rejects(
+			resolveSubagentLaunchContract({
+				agent: "worker",
+				cwd,
+				availableModels: [{ provider: "test", id: "primary", fullId: "test/primary" }],
+			}),
+			/Unknown subagent model 'fast'/,
+		);
+	});
+
+	it("bypasses native model validation for external CLI runners", async () => {
+		const cwd = path.join(tempDir, "repo-external-model");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeJson(path.join(process.env.HOME!, ".pi", "agent", "settings.json"), {
+			subagents: { defaultModel: "mock/default-model" },
+		});
+		writeAgent(path.join(cwd, ".pi", "agents", "external.md"), `---
+name: external
+description: External runner
+runner:
+  type: external-cli
+  command: ${JSON.stringify(process.execPath)}
+---
+Project prompt.
+`);
+
+		const result = await resolveSubagentLaunchContract({
+			agent: "external",
+			cwd,
+			availableModels: [{ provider: "other", id: "known", fullId: "other/known" }],
+		});
+
+		assert.equal(result.ok, true);
+		assert.equal(result.contract.model, undefined);
+		assert.deepEqual(result.contract.modelCandidates, []);
+	});
+
 	it("resolves agent aliases to the canonical launch contract agent", async () => {
 		const cwd = path.join(tempDir, "repo-alias");
 		fs.mkdirSync(cwd, { recursive: true });


### PR DESCRIPTION
Fixes #1093.

Configured native Pi subagent models now fail before child spawn when they cannot resolve against a non-empty active host model registry. The check covers explicit model overrides, agent models, fallback models, and fork-session model preparation.

External CLI runners stay outside native Pi model validation. They bypass model registry checks in preflight, direct async launch, fallback candidate preparation, and fork-session preparation. Unsupported external-cli options still fail through the external-cli unsupported-option guard instead of a native registry error.

Thanks to @DresvyanskiyDenis for the report.

Validation before publish:
- `node --experimental-strip-types --test test/unit/model-fallback.test.ts test/unit/preflight.test.ts`
- `node --experimental-strip-types --test --test-name-pattern 'rejects an unresolved agent model before spawning Pi|runs an external CLI workflow child with subagents.defaultModel configured|runs external CLI agents with fallback models without registry validation|rejects external CLI fork context before fallback model validation|rejects explicit model overrides for external CLI agents|rejects external CLI agent models that differ from inherited subagents.defaultModel|rejects external CLI agent models that equal inherited subagents.defaultModel without provenance' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh exact-head review passed with no release blockers: `/tmp/pi-subagents-backlog-20260814-post1081/issue-1093-model-id-final-review-dff4821.main.md`.
