### PR TITLE
feat: expose async status snapshots over RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add a bounded current-status snapshot for async runs in RPC surfaces, without replaying terminal history. Thanks to @yanqianglu for #1078.
 - Add an optional `foregroundDetachShortcut` binding and show it in the running single-subagent card, so foreground work can be moved to the background without editing package source. Thanks to @Lewis-E for #1097.
 
 ### Fixed

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -20,6 +20,7 @@ import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text
 import { readStatus } from "../shared/utils.ts";
 import { SubagentParams } from "./schemas.ts";
 import { normalizePublicSubagentExecution } from "./public-execution.ts";
+import { ASYNC_STATUS_SNAPSHOT_KIND, ASYNC_STATUS_SNAPSHOT_VERSION, buildAsyncStatusSnapshotForState } from "../runs/background/async-status-snapshot.ts";
 
 export const SUBAGENT_RPC_PROTOCOL_VERSION = 1;
 export const SUBAGENT_RPC_REQUEST_EVENT = "subagents:rpc:v1:request";
@@ -375,6 +376,7 @@ function pingData(ctx: ExtensionContext | null) {
 		capabilities: {
 			status: true,
 			fleetStatus: { version: 1 },
+			asyncStatusSnapshot: { kind: ASYNC_STATUS_SNAPSHOT_KIND, version: ASYNC_STATUS_SNAPSHOT_VERSION },
 			asyncSpawn: true,
 			steer: true,
 			nonRecoveringSteer: true,
@@ -544,13 +546,15 @@ async function handleRequest(
 			request.method,
 			{ action: "status", ...normalizeTargetParams(request.params, "status") },
 		);
+		const sessionId = resolveCurrentSessionId(ctx.sessionManager);
 		return {
 			...status,
 			fleet: buildFleetStatus(
 				options.state,
 				fleetKeys,
-				resolveCurrentSessionId(ctx.sessionManager),
+				sessionId,
 			),
+			asyncSnapshot: buildAsyncStatusSnapshotForState(options.state, sessionId),
 		};
 	}
 	if (request.method === "steer") {

--- a/src/runs/background/async-status-snapshot.ts
+++ b/src/runs/background/async-status-snapshot.ts
@@ -1,0 +1,277 @@
+import { sanitizeDisplayText, truncateDisplayText } from "../../shared/display-text.ts";
+import type { AsyncJobState, AsyncJobStep, NestedRunSummary, NestedStepSummary, SubagentRunMode, SubagentState } from "../../shared/types.ts";
+
+export const ASYNC_STATUS_SNAPSHOT_KIND = "pi-subagents.async-status-snapshot";
+export const ASYNC_STATUS_SNAPSHOT_VERSION = 1;
+export const ASYNC_STATUS_SNAPSHOT_WIDGET_PREFIX = "PI_SUBAGENT_ASYNC_JSON:";
+
+const DEFAULT_MAX_RUNS = 20;
+const DEFAULT_MAX_CHILDREN_PER_NODE = 8;
+const DEFAULT_MAX_DEPTH = 3;
+const DEFAULT_MAX_STRING_LENGTH = 160;
+const DEFAULT_MAX_SERIALIZED_BYTES = 32 * 1024;
+
+export type AsyncStatusSnapshotState = "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
+export type AsyncStatusSnapshotKind = "subagent" | "workflow" | "step";
+
+export interface AsyncStatusSnapshotActivityV1 {
+	state?: string;
+	currentTool?: string;
+	lastActivityAt?: number;
+	currentToolStartedAt?: number;
+	turnCount?: number;
+	toolCount?: number;
+}
+
+export interface AsyncStatusSnapshotNodeV1 {
+	id: string;
+	kind: AsyncStatusSnapshotKind;
+	label: string;
+	state: AsyncStatusSnapshotState;
+	startedAt?: number;
+	updatedAt?: number;
+	endedAt?: number;
+	activity?: AsyncStatusSnapshotActivityV1;
+	children?: AsyncStatusSnapshotNodeV1[];
+}
+
+export interface AsyncStatusSnapshotCapsV1 {
+	maxRuns: number;
+	maxChildrenPerNode: number;
+	maxDepth: number;
+	maxStringLength: number;
+	maxSerializedBytes: number;
+}
+
+export interface AsyncStatusSnapshotOmittedV1 {
+	runs: number;
+	children: number;
+	byteLimitExceeded: boolean;
+}
+
+export interface AsyncStatusSnapshotV1 {
+	kind: typeof ASYNC_STATUS_SNAPSHOT_KIND;
+	version: typeof ASYNC_STATUS_SNAPSHOT_VERSION;
+	generatedAt: number;
+	caps: AsyncStatusSnapshotCapsV1;
+	omitted: AsyncStatusSnapshotOmittedV1;
+	runs: AsyncStatusSnapshotNodeV1[];
+}
+
+export interface AsyncStatusSnapshotOptions {
+	generatedAt?: number;
+	maxRuns?: number;
+	maxChildrenPerNode?: number;
+	maxDepth?: number;
+	maxStringLength?: number;
+	maxSerializedBytes?: number;
+}
+
+interface BuildContext {
+	caps: AsyncStatusSnapshotCapsV1;
+	omitted: AsyncStatusSnapshotOmittedV1;
+}
+
+function resolveCaps(options: AsyncStatusSnapshotOptions = {}): AsyncStatusSnapshotCapsV1 {
+	return {
+		maxRuns: Math.max(0, Math.floor(options.maxRuns ?? DEFAULT_MAX_RUNS)),
+		maxChildrenPerNode: Math.max(0, Math.floor(options.maxChildrenPerNode ?? DEFAULT_MAX_CHILDREN_PER_NODE)),
+		maxDepth: Math.max(0, Math.floor(options.maxDepth ?? DEFAULT_MAX_DEPTH)),
+		maxStringLength: Math.max(0, Math.floor(options.maxStringLength ?? DEFAULT_MAX_STRING_LENGTH)),
+		maxSerializedBytes: Math.max(256, Math.floor(options.maxSerializedBytes ?? DEFAULT_MAX_SERIALIZED_BYTES)),
+	};
+}
+
+function publicText(value: unknown, fallback: string, maxLength: number): string {
+	if (typeof value !== "string") return fallback;
+	const normalized = sanitizeDisplayText(value.slice(0, Math.max(0, maxLength * 4)));
+	return truncateDisplayText(normalized || fallback, maxLength);
+}
+
+function publicOptionalText(value: unknown, maxLength: number): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = sanitizeDisplayText(value.slice(0, Math.max(0, maxLength * 4)));
+	return normalized ? truncateDisplayText(normalized, maxLength) : undefined;
+}
+
+function publicTime(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function publicCount(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function normalizeState(value: string): AsyncStatusSnapshotState {
+	if (value === "completed") return "complete";
+	if (value === "pending") return "queued";
+	return value as AsyncStatusSnapshotState;
+}
+
+function terminalState(state: AsyncStatusSnapshotState): boolean {
+	return state === "complete" || state === "failed" || state === "paused" || state === "stopped" || state === "rejected";
+}
+
+function kindForMode(mode: SubagentRunMode | undefined): AsyncStatusSnapshotKind {
+	return mode === "workflow" ? "workflow" : "subagent";
+}
+
+function labelForAgents(agents: readonly string[] | undefined, fallback: string, maxLength: number): string {
+	if (!agents?.length) return publicText(fallback, fallback, maxLength);
+	const visible = agents.slice(0, 3).map((agent) => publicText(agent, "agent", maxLength)).join(", ");
+	const suffix = agents.length > 3 ? `, +${agents.length - 3} more` : "";
+	return truncateDisplayText(`${visible}${suffix}`, maxLength);
+}
+
+function activityFor(source: {
+	activityState?: unknown;
+	currentTool?: unknown;
+	lastActivityAt?: unknown;
+	currentToolStartedAt?: unknown;
+	turnCount?: unknown;
+	toolCount?: unknown;
+}, ctx: BuildContext): AsyncStatusSnapshotActivityV1 | undefined {
+	const activity: AsyncStatusSnapshotActivityV1 = {
+		...(typeof source.activityState === "string" ? { state: publicText(source.activityState, "unknown", ctx.caps.maxStringLength) } : {}),
+		...(publicOptionalText(source.currentTool, ctx.caps.maxStringLength) ? { currentTool: publicOptionalText(source.currentTool, ctx.caps.maxStringLength) } : {}),
+		...(publicTime(source.lastActivityAt) !== undefined ? { lastActivityAt: publicTime(source.lastActivityAt) } : {}),
+		...(publicTime(source.currentToolStartedAt) !== undefined ? { currentToolStartedAt: publicTime(source.currentToolStartedAt) } : {}),
+		...(publicCount(source.turnCount) !== undefined ? { turnCount: publicCount(source.turnCount) } : {}),
+		...(publicCount(source.toolCount) !== undefined ? { toolCount: publicCount(source.toolCount) } : {}),
+	};
+	return Object.keys(activity).length ? activity : undefined;
+}
+
+function appendBoundedChildren(children: AsyncStatusSnapshotNodeV1[], source: readonly AsyncStatusSnapshotNodeV1[], ctx: BuildContext): void {
+	const remaining = Math.max(0, ctx.caps.maxChildrenPerNode - children.length);
+	children.push(...source.slice(0, remaining));
+	ctx.omitted.children += Math.max(0, source.length - remaining);
+}
+
+function buildStepNode(step: AsyncJobStep | NestedStepSummary, index: number, depth: number, ctx: BuildContext): AsyncStatusSnapshotNodeV1 {
+	const state = normalizeState(step.status);
+	const updatedAt = publicTime(step.endedAt) ?? publicTime(step.lastActivityAt) ?? publicTime(step.startedAt);
+	const node: AsyncStatusSnapshotNodeV1 = {
+		id: publicText("workflowKey" in step && step.workflowKey ? step.workflowKey : "runId" in step && step.runId ? step.runId : `step:${index}`, `step:${index}`, ctx.caps.maxStringLength),
+		kind: "step",
+		label: publicText("label" in step && step.label ? step.label : step.agent, "step", ctx.caps.maxStringLength),
+		state,
+		...(publicTime(step.startedAt) !== undefined ? { startedAt: publicTime(step.startedAt) } : {}),
+		...(updatedAt !== undefined ? { updatedAt } : {}),
+		...(terminalState(state) && publicTime(step.endedAt) !== undefined ? { endedAt: publicTime(step.endedAt) } : {}),
+		...(activityFor(step, ctx) ? { activity: activityFor(step, ctx) } : {}),
+	};
+	if (depth < ctx.caps.maxDepth && step.children?.length) {
+		const nested = step.children.map((child, childIndex) => buildNestedNode(child, childIndex, depth + 1, ctx));
+		const bounded: AsyncStatusSnapshotNodeV1[] = [];
+		appendBoundedChildren(bounded, nested, ctx);
+		if (bounded.length) node.children = bounded;
+	} else if (step.children?.length) {
+		ctx.omitted.children += step.children.length;
+	}
+	return node;
+}
+
+function buildNestedNode(child: NestedRunSummary, index: number, depth: number, ctx: BuildContext): AsyncStatusSnapshotNodeV1 {
+	const state = normalizeState(child.state);
+	const updatedAt = publicTime(child.lastUpdate) ?? publicTime(child.endedAt) ?? publicTime(child.lastActivityAt) ?? publicTime(child.startedAt);
+	const node: AsyncStatusSnapshotNodeV1 = {
+		id: publicText(child.id, `nested:${index}`, ctx.caps.maxStringLength),
+		kind: kindForMode(child.mode),
+		label: child.agent ? publicText(child.agent, "subagent", ctx.caps.maxStringLength) : labelForAgents(child.agents, child.mode ?? "subagent", ctx.caps.maxStringLength),
+		state,
+		...(publicTime(child.startedAt) !== undefined ? { startedAt: publicTime(child.startedAt) } : {}),
+		...(updatedAt !== undefined ? { updatedAt } : {}),
+		...(terminalState(state) && publicTime(child.endedAt) !== undefined ? { endedAt: publicTime(child.endedAt) } : {}),
+		...(activityFor(child, ctx) ? { activity: activityFor(child, ctx) } : {}),
+	};
+	if (depth < ctx.caps.maxDepth) {
+		const nestedSteps = child.steps?.map((step, stepIndex) => buildStepNode(step, stepIndex, depth + 1, ctx)) ?? [];
+		const nestedChildren = child.children?.map((nested, childIndex) => buildNestedNode(nested, childIndex, depth + 1, ctx)) ?? [];
+		const bounded: AsyncStatusSnapshotNodeV1[] = [];
+		appendBoundedChildren(bounded, [...nestedSteps, ...nestedChildren], ctx);
+		if (bounded.length) node.children = bounded;
+	} else {
+		ctx.omitted.children += (child.steps?.length ?? 0) + (child.children?.length ?? 0);
+	}
+	return node;
+}
+
+function buildRunNode(job: AsyncJobState, ctx: BuildContext): AsyncStatusSnapshotNodeV1 {
+	const state = normalizeState(job.status);
+	const updatedAt = publicTime(job.updatedAt) ?? publicTime(job.startedAt);
+	const node: AsyncStatusSnapshotNodeV1 = {
+		id: publicText(job.asyncId, "async", ctx.caps.maxStringLength),
+		kind: kindForMode(job.mode),
+		label: labelForAgents(job.agents, job.mode ?? "subagent", ctx.caps.maxStringLength),
+		state,
+		...(publicTime(job.startedAt) !== undefined ? { startedAt: publicTime(job.startedAt) } : {}),
+		...(updatedAt !== undefined ? { updatedAt } : {}),
+		...(terminalState(state) && updatedAt !== undefined ? { endedAt: updatedAt } : {}),
+		...(activityFor(job, ctx) ? { activity: activityFor(job, ctx) } : {}),
+	};
+	if (ctx.caps.maxDepth > 0) {
+		const stepChildren = job.steps?.map((step, index) => buildStepNode(step, step.index ?? index, 1, ctx)) ?? [];
+		const nestedChildren = job.nestedChildren?.map((child, index) => buildNestedNode(child, index, 1, ctx)) ?? [];
+		const bounded: AsyncStatusSnapshotNodeV1[] = [];
+		appendBoundedChildren(bounded, [...stepChildren, ...nestedChildren], ctx);
+		if (bounded.length) node.children = bounded;
+	} else {
+		ctx.omitted.children += (job.steps?.length ?? 0) + (job.nestedChildren?.length ?? 0);
+	}
+	return node;
+}
+
+function snapshotBytes(snapshot: AsyncStatusSnapshotV1): number {
+	return Buffer.byteLength(JSON.stringify(snapshot), "utf8");
+}
+
+function enforceByteLimit(snapshot: AsyncStatusSnapshotV1): void {
+	while (snapshot.runs.length > 0 && snapshotBytes(snapshot) > snapshot.caps.maxSerializedBytes) {
+		snapshot.runs.pop();
+		snapshot.omitted.runs += 1;
+		snapshot.omitted.byteLimitExceeded = true;
+	}
+	if (snapshotBytes(snapshot) > snapshot.caps.maxSerializedBytes) snapshot.omitted.byteLimitExceeded = true;
+}
+
+export function buildAsyncStatusSnapshot(jobs: Iterable<AsyncJobState>, options: AsyncStatusSnapshotOptions = {}): AsyncStatusSnapshotV1 {
+	const caps = resolveCaps(options);
+	const ctx: BuildContext = { caps, omitted: { runs: 0, children: 0, byteLimitExceeded: false } };
+	const sorted = [...jobs].sort((left, right) => {
+		const leftUpdated = left.updatedAt ?? left.startedAt ?? 0;
+		const rightUpdated = right.updatedAt ?? right.startedAt ?? 0;
+		return rightUpdated - leftUpdated || left.asyncId.localeCompare(right.asyncId);
+	});
+	ctx.omitted.runs += Math.max(0, sorted.length - caps.maxRuns);
+	const snapshot: AsyncStatusSnapshotV1 = {
+		kind: ASYNC_STATUS_SNAPSHOT_KIND,
+		version: ASYNC_STATUS_SNAPSHOT_VERSION,
+		generatedAt: options.generatedAt ?? Date.now(),
+		caps,
+		omitted: ctx.omitted,
+		runs: sorted.slice(0, caps.maxRuns).map((job) => buildRunNode(job, ctx)),
+	};
+	enforceByteLimit(snapshot);
+	return snapshot;
+}
+
+export function asyncStatusSnapshotJobsForState(state: SubagentState | undefined, sessionId: string | null | undefined): AsyncJobState[] {
+	if (!state || !sessionId || state.currentSessionId !== sessionId) return [];
+	const jobs = new Map<string, AsyncJobState>();
+	for (const job of state.asyncJobs.values()) {
+		if (job.sessionId === sessionId) jobs.set(job.asyncId, job);
+	}
+	for (const job of state.fleetJobs?.values() ?? []) {
+		if (job.sessionId === sessionId && !jobs.has(job.asyncId)) jobs.set(job.asyncId, job);
+	}
+	return [...jobs.values()];
+}
+
+export function buildAsyncStatusSnapshotForState(state: SubagentState | undefined, sessionId: string | null | undefined, options: AsyncStatusSnapshotOptions = {}): AsyncStatusSnapshotV1 {
+	return buildAsyncStatusSnapshot(asyncStatusSnapshotJobsForState(state, sessionId), options);
+}
+
+export function encodeAsyncStatusSnapshotWidget(jobs: Iterable<AsyncJobState>, options: AsyncStatusSnapshotOptions = {}): string[] {
+	return [`${ASYNC_STATUS_SNAPSHOT_WIDGET_PREFIX}${JSON.stringify(buildAsyncStatusSnapshot(jobs, options))}`];
+}

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -28,6 +28,7 @@ import { formatNestedAggregate } from "../runs/shared/nested-render.ts";
 import { aggregateStepStatus, formatActivityLabel, formatAgentRunningLabel, formatParallelOutcome } from "../shared/status-format.ts";
 import { contextModeBadge, contextModePrefix } from "../runs/shared/context-mode.ts";
 import { buildWorkflowChatProgressRows, type WorkflowChatProgressRow } from "../workflows/chat-progress.ts";
+import { encodeAsyncStatusSnapshotWidget } from "../runs/background/async-status-snapshot.ts";
 
 type Theme = ExtensionContext["ui"]["theme"];
 
@@ -1601,6 +1602,10 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 		return;
 	}
 	if (!ctx.hasUI) return;
+	if ((ctx as { mode?: string }).mode === "rpc") {
+		ctx.ui.setWidget(WIDGET_KEY, encodeAsyncStatusSnapshotWidget(jobs));
+		return;
+	}
 	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, ctx.ui.getToolsExpanded?.() ?? false));
 }
 

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -209,6 +209,32 @@ describe("subagent async widget rendering", () => {
 		assert.ok(lines.length <= 10, "collapsed component should stay under Pi's string-widget cap even though it bypasses it");
 	});
 
+	it("uses a bounded string-array snapshot widget in RPC mode", () => {
+		const ui = createUiContext();
+		(ui.ctx as { mode?: string }).mode = "rpc";
+		renderWidget(ui.ctx as never, [{
+			asyncId: "run-rpc",
+			asyncDir: "/tmp/private-run-rpc",
+			cwd: "/repo/private",
+			status: "running",
+			mode: "single",
+			agents: ["worker"],
+			currentTool: "bash",
+			steps: [{ agent: "worker", status: "running", currentToolArgs: "private args" }],
+		}]);
+
+		const widget = ui.widgets.at(-1);
+		assert.ok(Array.isArray(widget), "RPC mode should install a string-array widget payload");
+		const [line] = widget as string[];
+		assert.ok(line?.startsWith("PI_SUBAGENT_ASYNC_JSON:"));
+		const snapshot = JSON.parse(line.slice("PI_SUBAGENT_ASYNC_JSON:".length));
+		assert.equal(snapshot.kind, "pi-subagents.async-status-snapshot");
+		assert.equal(snapshot.version, 1);
+		assert.equal(snapshot.runs[0].id, "run-rpc");
+		assert.equal(JSON.stringify(snapshot).includes("/tmp/private-run-rpc"), false);
+		assert.equal(JSON.stringify(snapshot).includes("private args"), false);
+	});
+
 	it("honors the component render width instead of the terminal width", () => {
 		resetWidgetLayout();
 		withStdoutSize(50, 120, () => {

--- a/test/unit/async-status-snapshot.test.ts
+++ b/test/unit/async-status-snapshot.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	ASYNC_STATUS_SNAPSHOT_KIND,
+	ASYNC_STATUS_SNAPSHOT_VERSION,
+	ASYNC_STATUS_SNAPSHOT_WIDGET_PREFIX,
+	buildAsyncStatusSnapshot,
+	buildAsyncStatusSnapshotForState,
+	encodeAsyncStatusSnapshotWidget,
+} from "../../src/runs/background/async-status-snapshot.ts";
+
+const privateNeedle = "PRIVATE_LEAK_NEEDLE";
+
+function json(value: unknown): string {
+	return JSON.stringify(value);
+}
+
+describe("async status snapshot", () => {
+	it("projects current async jobs with a versioned safe shape", () => {
+		const snapshot = buildAsyncStatusSnapshot([{
+			asyncId: "run-1",
+			asyncDir: `/tmp/${privateNeedle}/run`,
+			cwd: `/repo/${privateNeedle}`,
+			sessionRoot: `/sessions/${privateNeedle}`,
+			sessionDir: `/session-dir/${privateNeedle}`,
+			outputFile: `/output/${privateNeedle}.log`,
+			sessionFile: `/session-file/${privateNeedle}.jsonl`,
+			sessionId: "session-a",
+			status: "running",
+			mode: "parallel",
+			agents: ["worker"],
+			description: `task ${privateNeedle}`,
+			startedAt: 100,
+			updatedAt: 150,
+			currentTool: "bash\n\u001b]8;;bad\u0007",
+			currentPath: `/current/${privateNeedle}`,
+			steps: [{
+				index: 0,
+				agent: "worker",
+				status: "running",
+				startedAt: 110,
+				currentTool: "read",
+				currentToolArgs: `args ${privateNeedle}`,
+				recentOutput: [`output ${privateNeedle}`],
+				error: `error ${privateNeedle}`,
+				transcriptPath: `/transcript/${privateNeedle}.jsonl`,
+			}],
+		}], { generatedAt: 200 });
+
+		assert.equal(snapshot.kind, ASYNC_STATUS_SNAPSHOT_KIND);
+		assert.equal(snapshot.version, ASYNC_STATUS_SNAPSHOT_VERSION);
+		assert.equal(snapshot.generatedAt, 200);
+		assert.equal(snapshot.runs.length, 1);
+		assert.deepEqual(snapshot.runs[0], {
+			id: "run-1",
+			kind: "subagent",
+			label: "worker",
+			state: "running",
+			startedAt: 100,
+			updatedAt: 150,
+			activity: { currentTool: "bash" },
+			children: [{
+				id: "step:0",
+				kind: "step",
+				label: "worker",
+				state: "running",
+				startedAt: 110,
+				updatedAt: 110,
+				activity: { currentTool: "read" },
+			}],
+		});
+		assert.equal(json(snapshot).includes(privateNeedle), false);
+		assert.equal(json(snapshot).includes("currentPath"), false);
+		assert.equal(json(snapshot).includes("currentToolArgs"), false);
+		assert.equal(json(snapshot).includes("recentOutput"), false);
+		assert.equal(json(snapshot).includes("transcriptPath"), false);
+	});
+
+	it("normalizes pending child steps to queued", () => {
+		const snapshot = buildAsyncStatusSnapshot([{
+			asyncId: "run",
+			asyncDir: "/tmp/run",
+			status: "queued",
+			agents: ["worker"],
+			steps: [{ agent: "worker", status: "pending" }],
+		} as any], { generatedAt: 1 });
+
+		assert.equal(snapshot.runs[0]?.children?.[0]?.state, "queued");
+	});
+
+	it("applies run, child, depth, string, and byte caps", () => {
+		const jobs = Array.from({ length: 5 }, (_, runIndex) => ({
+			asyncId: `run-${runIndex}`,
+			asyncDir: `/tmp/run-${runIndex}`,
+			status: "running" as const,
+			mode: "workflow" as const,
+			agents: [`agent-${runIndex}-${"x".repeat(50)}`],
+			startedAt: runIndex,
+			updatedAt: runIndex,
+			steps: Array.from({ length: 5 }, (_, stepIndex) => ({
+				agent: `child-${stepIndex}-${"y".repeat(50)}`,
+				status: "running" as const,
+				children: [{
+					id: `nested-${stepIndex}`,
+					parentRunId: `run-${runIndex}`,
+					depth: 1,
+					path: [],
+					state: "running" as const,
+					agent: "nested",
+				}],
+			})),
+		}));
+
+		const snapshot = buildAsyncStatusSnapshot(jobs, {
+			generatedAt: 10,
+			maxRuns: 2,
+			maxChildrenPerNode: 2,
+			maxDepth: 1,
+			maxStringLength: 16,
+			maxSerializedBytes: 1200,
+		});
+
+		assert.equal(snapshot.runs.length, 2);
+		assert.equal(snapshot.omitted.runs, 3);
+		assert.equal(snapshot.runs[0]?.children?.length, 2);
+		assert.ok(snapshot.omitted.children >= 6);
+		assert.ok((snapshot.runs[0]?.label.length ?? 0) <= 16);
+		assert.ok(Buffer.byteLength(json(snapshot), "utf8") <= 1200);
+
+		const byteCapped = buildAsyncStatusSnapshot(jobs, { maxSerializedBytes: 512 });
+		assert.equal(byteCapped.omitted.byteLimitExceeded, true);
+		assert.ok(Buffer.byteLength(json(byteCapped), "utf8") <= 512);
+	});
+
+	it("uses current-session state and retained fleet jobs without rebuilding history", () => {
+		const state = {
+			currentSessionId: "session-a",
+			foregroundControls: new Map(),
+			asyncJobs: new Map([["active", { asyncId: "active", asyncDir: "/tmp/active", sessionId: "session-a", status: "running", agents: ["worker"] }]]),
+			fleetJobs: new Map([
+				["terminal", { asyncId: "terminal", asyncDir: "/tmp/terminal", sessionId: "session-a", status: "complete", agents: ["reviewer"], updatedAt: 300, outputFile: `/tmp/${privateNeedle}.log` }],
+				["foreign", { asyncId: "foreign", asyncDir: "/tmp/foreign", sessionId: "other", status: "running", agents: ["hidden"] }],
+			]),
+		} as any;
+
+		const snapshot = buildAsyncStatusSnapshotForState(state, "session-a", { generatedAt: 1 });
+		assert.deepEqual(snapshot.runs.map((run) => run.id).sort(), ["active", "terminal"]);
+		assert.equal(snapshot.runs.find((run) => run.id === "terminal")?.endedAt, 300);
+		assert.equal(json(snapshot).includes(privateNeedle), false);
+		assert.deepEqual(buildAsyncStatusSnapshotForState(state, "other").runs, []);
+	});
+
+	it("encodes RPC widget payloads as a string-array snapshot", () => {
+		const lines = encodeAsyncStatusSnapshotWidget([{ asyncId: "run", asyncDir: "/tmp/run", status: "queued", agents: ["planner"] } as any], { generatedAt: 5 });
+		assert.equal(lines.length, 1);
+		assert.ok(lines[0]?.startsWith(ASYNC_STATUS_SNAPSHOT_WIDGET_PREFIX));
+		const snapshot = JSON.parse(lines[0]!.slice(ASYNC_STATUS_SNAPSHOT_WIDGET_PREFIX.length));
+		assert.equal(snapshot.kind, ASYNC_STATUS_SNAPSHOT_KIND);
+		assert.equal(snapshot.version, 1);
+		assert.equal(snapshot.runs[0].id, "run");
+	});
+});

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -134,6 +134,14 @@ describe("registerSubagentNotify", () => {
 		});
 	});
 
+	it("does not attach async status snapshots to subagent-notify details", async () => {
+		const { notifier, sent } = createPi("session-a");
+		assert.equal(await notifier.deliver(completionResult({ id: "direct-no-snapshot" })), true);
+		const message = sent[0]?.message as { customType?: string; details?: Record<string, unknown> } | undefined;
+		assert.equal(message?.customType, "subagent-notify");
+		assert.equal(message?.details?.asyncSnapshot, undefined);
+	});
+
 	it("acknowledges direct delivery only after sendMessage accepts it", async () => {
 		const { notifier, sent } = createPi("session-a");
 		assert.equal(await notifier.deliver(completionResult({ id: "direct-accepted" })), true);

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -99,6 +99,10 @@ describe("subagent extension RPC bridge", () => {
 			(reply as { data: { capabilities?: { fleetStatus?: unknown } } }).data.capabilities?.fleetStatus,
 			{ version: 1 },
 		);
+		assert.deepEqual(
+			(reply as { data: { capabilities?: { asyncStatusSnapshot?: unknown } } }).data.capabilities?.asyncStatusSnapshot,
+			{ kind: "pi-subagents.async-status-snapshot", version: 1 },
+		);
 
 		bridge.dispose();
 	});
@@ -204,6 +208,51 @@ describe("subagent extension RPC bridge", () => {
 		assert.equal(entry.goal, undefined);
 		assert.ok(entry.agent.length <= 96);
 		assert.match(entry.agent, /^worker broken/);
+		bridge.dispose();
+	});
+
+	it("adds a bounded current async status snapshot to status replies", async () => {
+		const events = new FakeEvents();
+		const state = {
+			currentSessionId: "/sessions/parent.jsonl",
+			foregroundControls: new Map(),
+			asyncJobs: new Map([["run-1", {
+				asyncId: "run-1",
+				asyncDir: "/tmp/PRIVATE_RPC_LEAK/run-1",
+				cwd: "/repo/PRIVATE_RPC_LEAK",
+				sessionDir: "/sessions/PRIVATE_RPC_LEAK",
+				outputFile: "/tmp/PRIVATE_RPC_LEAK/output.log",
+				sessionId: "/sessions/parent.jsonl",
+				status: "running",
+				mode: "single",
+				agents: ["worker"],
+				currentTool: "read",
+				steps: [{ agent: "worker", status: "running", currentToolArgs: "PRIVATE_RPC_LEAK args", recentOutput: ["PRIVATE_RPC_LEAK output"] }],
+			}]]),
+			fleetJobs: new Map([["done", {
+				asyncId: "done",
+				asyncDir: "/tmp/done",
+				sessionId: "/sessions/parent.jsonl",
+				status: "complete",
+				agents: ["reviewer"],
+				updatedAt: 50,
+			}]]),
+		} as any;
+		const bridge = registerSubagentRpcBridge({
+			events,
+			getContext: () => ctx("runtime-session-id", "/sessions/parent.jsonl"),
+			state,
+			execute: async () => ({ content: [], details: { mode: "management", results: [] } } as any),
+		});
+
+		const reply = await request(events, "async-snapshot", "status");
+		const snapshot = (reply as any).data.asyncSnapshot;
+		assert.equal(snapshot.kind, "pi-subagents.async-status-snapshot");
+		assert.equal(snapshot.version, 1);
+		assert.deepEqual(snapshot.runs.map((run: { id: string }) => run.id).sort(), ["done", "run-1"]);
+		assert.equal(JSON.stringify(snapshot).includes("PRIVATE_RPC_LEAK"), false);
+		assert.equal(JSON.stringify(snapshot).includes("currentToolArgs"), false);
+		assert.equal(JSON.stringify(snapshot).includes("recentOutput"), false);
 		bridge.dispose();
 	});
 


### PR DESCRIPTION
## Summary

Supersedes draft PR #1078 with a bounded current-status snapshot for async runs on RPC surfaces.

The snapshot is a versioned, whitelist-only projection of current runtime state. It keeps terminal result files canonical, avoids replay history, and leaves `subagent-notify` details compatible with the existing renderer.

Thanks to @yanqianglu for the original #1078 draft and direction.

## What changed

- Add a v1 async status snapshot with explicit run, child, depth, string, and byte caps.
- Expose the snapshot through RPC `status` and RPC widget transport.
- Preserve normal TUI component widget rendering.
- Keep `subagent-notify.details` free of snapshot payloads.
- Add focused tests for snapshot shape, caps, leak prevention, RPC status/widget behavior, and notification compatibility.

## Validation

- `node --experimental-strip-types --test test/unit/async-status-snapshot.test.ts test/unit/rpc.test.ts test/unit/notify.test.ts`
- `node --experimental-strip-types --test test/integration/render-widget.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- `git diff --check`

Review note: the first review found that pending child steps could emit `state: "pending"`; the current head maps that case to `queued` and includes a regression test.
