### PR TITLE
feat: add external FleetView runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Show caller-owned external jobs in FleetView through a bounded push/cache API, without polling or exposing managed controls. Thanks to @ssyram for #1083.
 - Add a bounded current-status snapshot for async runs in RPC surfaces, without replaying terminal history. Thanks to @yanqianglu for #1078.
 - Add an optional `foregroundDetachShortcut` binding and show it in the running single-subagent card, so foreground work can be moved to the background without editing package source. Thanks to @Lewis-E for #1097.
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -56,6 +56,42 @@ The DTO intentionally never exposes run, async, or tool IDs. Clients must ignore
 
 `pi.events` is in-process only. It does not reach separate Pi processes or child subagents; use the file lifecycle artifacts or `pi-intercom` for cross-process coordination.
 
+## External jobs in FleetView
+
+Use `pi-subagents/external-runs` to publish display-only current-session jobs owned by another extension:
+
+```ts
+import {
+  registerExternalRun,
+  updateExternalRun,
+  unregisterExternalRun,
+} from "pi-subagents/external-runs";
+
+registerExternalRun({
+  id: "dependency-review",
+  sessionId: ctx.sessionManager.getSessionId(),
+  source: "interactive-shell",
+  label: "Dependency review",
+  state: "running",
+  startedAt: Date.now(),
+  currentAction: "Inspecting package metadata",
+});
+
+updateExternalRun(ctx.sessionManager.getSessionId(), "dependency-review", {
+  state: "completed",
+  updatedAt: Date.now(),
+  endedAt: Date.now(),
+  preview: "No dependency blockers found.",
+  reportPath: "/tmp/dependency-review.md",
+});
+
+unregisterExternalRun(ctx.sessionManager.getSessionId(), "dependency-review");
+```
+
+The API validates and caches bounded display fields when the caller registers or updates a job. FleetView reads that cache only. It does not poll caller code. `snapshotExternalRuns(sessionId)` and `listExternalRuns(sessionId)` return bounded current-session snapshots. By default, malformed cached records throw with the validation error. Display-only Fleet callers can pass `{ ignoreMalformed: true, onMalformedRecord }` to remove bad records and keep rendering with a programmatic diagnostic.
+
+External jobs are observational. The caller owns execution, persistence, cancellation, and result delivery. FleetView does not expose stop, steer, resume, cancel, or Herdr controls for them. Supplied report and transcript paths are shown as bounded text only; FleetView does not read arbitrary external paths.
+
 ## Launch contract preflight
 
 Use `pi-subagents/preflight` when an extension needs to inspect the resolved child launch contract before deciding whether to run anything:

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -154,7 +154,7 @@ subagent({ action: "doctor" })
 
 Use native `subagent` runs for unattended implementation, review, and gate work that needs managed isolation, durable artifacts, and process controls. Use `interactive_shell` for visible terminal work, alternate CLIs, trust prompts, and recovery.
 
-A cooperating terminal runtime can register read-only external records through `pi-subagents/external-runs`. Records include the source, session, state, optional report path, and completion reason. They are observations only: pi-subagents does not start, stop, steer, or otherwise own the foreign process. Run unattended raw terminal agents in an explicit isolated cwd or worktree; do not use a live project checkout as disposable review space.
+A cooperating terminal runtime can publish display-only external jobs through `pi-subagents/external-runs`. Records include the session, source, label, lifecycle state, current action, bounded preview, and optional report or transcript path text. They are cached observations only: pi-subagents does not start, stop, steer, resume, cancel, read arbitrary paths for, or otherwise own the foreign process. Run unattended raw terminal agents in an explicit isolated cwd or worktree; do not use a live project checkout as disposable review space.
 
 ### Scheduled subagent runs
 

--- a/src/api/external-runs.ts
+++ b/src/api/external-runs.ts
@@ -1,129 +1,210 @@
-export const EXTERNAL_RUN_REGISTRY_VERSION = 1;
-export const EXTERNAL_RUN_REGISTRY_KEY = "pi-subagents.external-runs.v1";
+import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
 
-const MAX_PROVIDERS = 100;
-const MAX_RUNS_PER_PROVIDER = 10_000;
-const MAX_TEXT_LENGTH = 4_096;
+export const EXTERNAL_RUN_REGISTRY_VERSION = 2;
+export const EXTERNAL_RUN_REGISTRY_KEY = "pi-subagents.external-runs.v2";
 
-export type ExternalRunState = "running" | "completed" | "failed" | "stopped";
-export type ExternalRunCompletionReason = "exit" | "timeout" | "user-kill" | "auto-close-quiet" | "crash" | "unknown";
+export const EXTERNAL_RUN_LIMITS = {
+	maxCachedRuns: 100,
+	maxSnapshotRuns: 20,
+	maxIdentityLength: 160,
+	maxTextLength: 160,
+	maxPreviewLength: 4_096,
+	maxPathLength: 4_096,
+	maxSerializedBytes: 32 * 1_024,
+} as const;
 
-/** An observational record for work owned by another runtime. */
+export type ExternalRunState = "queued" | "running" | "completed" | "failed" | "stopped";
+
+/** A display-only record for work owned by another extension or runtime. */
 export interface ExternalRun {
 	id: string;
 	sessionId: string;
 	source: string;
+	label: string;
 	state: ExternalRunState;
-	command?: string;
-	cwd?: string;
-	isolationPath?: string;
-	owner?: string;
-	completionReason?: ExternalRunCompletionReason;
+	startedAt: number;
+	updatedAt?: number;
+	endedAt?: number;
+	currentAction?: string;
+	preview?: string;
 	reportPath?: string;
-	startedAt?: number;
-	completedAt?: number;
-	exitCode?: number | null;
-	residualRisks?: string[];
+	transcriptPath?: string;
 }
 
-export interface ExternalRunProvider {
-	name: string;
-	listExternalRuns(): readonly ExternalRun[];
-}
+export type ExternalRunUpdate = Partial<Omit<ExternalRun, "id" | "sessionId" | "source">>;
 
-export interface RegisteredExternalRun extends ExternalRun {
-	provider: string;
+export interface ExternalRunSnapshotOptions {
+	onMalformedRecord?: (message: string) => void;
+	ignoreMalformed?: boolean;
 }
 
 interface ExternalRunRegistry {
 	version: typeof EXTERNAL_RUN_REGISTRY_VERSION;
-	providers: Map<string, ExternalRunProvider>;
+	runs: Map<string, ExternalRun>;
 }
+
+const RUN_FIELDS = new Set([
+	"id",
+	"sessionId",
+	"source",
+	"label",
+	"state",
+	"startedAt",
+	"updatedAt",
+	"endedAt",
+	"currentAction",
+	"preview",
+	"reportPath",
+	"transcriptPath",
+]);
+const UPDATE_FIELDS = new Set([...RUN_FIELDS].filter((field) => field !== "id" && field !== "sessionId" && field !== "source"));
 
 function registry(): ExternalRunRegistry {
 	const key = Symbol.for(EXTERNAL_RUN_REGISTRY_KEY);
 	const target = globalThis as Record<PropertyKey, unknown>;
 	const existing = target[key];
 	if (existing === undefined) {
-		const created: ExternalRunRegistry = { version: EXTERNAL_RUN_REGISTRY_VERSION, providers: new Map() };
+		const created: ExternalRunRegistry = { version: EXTERNAL_RUN_REGISTRY_VERSION, runs: new Map() };
 		target[key] = created;
 		return created;
 	}
 	if (!existing || typeof existing !== "object" || Array.isArray(existing)) throw new Error(`Malformed external-run registry at Symbol.for("${EXTERNAL_RUN_REGISTRY_KEY}").`);
 	const candidate = existing as Partial<ExternalRunRegistry>;
-	if (candidate.version !== EXTERNAL_RUN_REGISTRY_VERSION || !(candidate.providers instanceof Map)) throw new Error(`Unsupported external-run registry at Symbol.for("${EXTERNAL_RUN_REGISTRY_KEY}").`);
+	if (candidate.version !== EXTERNAL_RUN_REGISTRY_VERSION || !(candidate.runs instanceof Map)) throw new Error(`Unsupported external-run registry at Symbol.for("${EXTERNAL_RUN_REGISTRY_KEY}").`);
 	return candidate as ExternalRunRegistry;
 }
 
-function text(value: unknown, field: string, required = false): string | undefined {
-	if (value === undefined && !required) return undefined;
+function inputObject(value: unknown, field: string, allowed: Set<string>): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${field} must be an object.`);
+	const input = value as Record<string, unknown>;
+	const unknown = Object.keys(input).filter((key) => !allowed.has(key));
+	if (unknown.length) throw new Error(`${field} has unknown fields: ${unknown.join(", ")}.`);
+	return input;
+}
+
+function identity(value: unknown, field: string): string {
 	if (typeof value !== "string" || value.length === 0 || value.trim() !== value || value.includes("\0")) throw new Error(`${field} must be a non-empty trimmed string without NUL characters.`);
-	if (value.length > MAX_TEXT_LENGTH) throw new Error(`${field} must be at most ${MAX_TEXT_LENGTH} characters.`);
+	if (value.length > EXTERNAL_RUN_LIMITS.maxIdentityLength) throw new Error(`${field} must be at most ${EXTERNAL_RUN_LIMITS.maxIdentityLength} characters.`);
+	const safe = sanitizeDisplayText(value);
+	if (!safe || safe !== value) throw new Error(`${field} must contain only display-safe text.`);
 	return value;
 }
 
-function timestamp(value: unknown, field: string): number | undefined {
-	if (value === undefined) return undefined;
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) throw new Error(`${field} must be a non-negative finite number.`);
+function displayText(value: unknown, field: string, maxLength: number, required = false): string | undefined {
+	if (value === undefined && !required) return undefined;
+	if (typeof value !== "string" || value.length === 0) throw new Error(`${field} must be a non-empty string.`);
+	const safe = sanitizeDisplayText(value.slice(0, Math.max(maxLength * 4, maxLength)));
+	if (!safe) throw new Error(`${field} must contain displayable text.`);
+	return truncateDisplayText(safe, maxLength);
+}
+
+function timestamp(value: unknown, field: string, required = false): number | undefined {
+	if (value === undefined && !required) return undefined;
+	if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0 || value > 8_640_000_000_000_000) throw new Error(`${field} must be a non-negative safe timestamp.`);
 	return value;
 }
 
-function validateRun(value: unknown, provider: string, index: number): ExternalRun {
-	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`External-run provider '${provider}' item ${index} must be an object.`);
-	const run = value as Record<string, unknown>;
-	const fields = new Set(["id", "sessionId", "source", "state", "command", "cwd", "isolationPath", "owner", "completionReason", "reportPath", "startedAt", "completedAt", "exitCode", "residualRisks"]);
-	const unknown = Object.keys(run).filter((key) => !fields.has(key));
-	if (unknown.length) throw new Error(`External-run provider '${provider}' item ${index} has unknown fields: ${unknown.join(", ")}.`);
-	if (!["running", "completed", "failed", "stopped"].includes(run.state as string)) throw new Error(`External-run provider '${provider}' item ${index} state is invalid.`);
-	if (run.completionReason !== undefined && !["exit", "timeout", "user-kill", "auto-close-quiet", "crash", "unknown"].includes(run.completionReason as string)) throw new Error(`External-run provider '${provider}' item ${index} completionReason is invalid.`);
-	if (run.exitCode !== undefined && run.exitCode !== null && (!Number.isInteger(run.exitCode) || !Number.isFinite(run.exitCode))) throw new Error(`External-run provider '${provider}' item ${index} exitCode must be an integer or null.`);
-	if (run.residualRisks !== undefined && (!Array.isArray(run.residualRisks) || run.residualRisks.some((risk, riskIndex) => text(risk, `External-run provider '${provider}' item ${index} residualRisks[${riskIndex}]`, true) === undefined))) throw new Error(`External-run provider '${provider}' item ${index} residualRisks must be an array of strings.`);
+function state(value: unknown, field: string): ExternalRunState {
+	if (!["queued", "running", "completed", "failed", "stopped"].includes(value as string)) throw new Error(`${field} is invalid.`);
+	return value as ExternalRunState;
+}
+
+function validateRun(value: unknown): ExternalRun {
+	const run = inputObject(value, "External run", RUN_FIELDS);
+	const updatedAt = timestamp(run.updatedAt, "External run updatedAt");
+	const endedAt = timestamp(run.endedAt, "External run endedAt");
+	const currentAction = displayText(run.currentAction, "External run currentAction", EXTERNAL_RUN_LIMITS.maxTextLength);
+	const preview = displayText(run.preview, "External run preview", EXTERNAL_RUN_LIMITS.maxPreviewLength);
+	const reportPath = displayText(run.reportPath, "External run reportPath", EXTERNAL_RUN_LIMITS.maxPathLength);
+	const transcriptPath = displayText(run.transcriptPath, "External run transcriptPath", EXTERNAL_RUN_LIMITS.maxPathLength);
 	return {
-		id: text(run.id, `External-run provider '${provider}' item ${index} id`, true)!,
-		sessionId: text(run.sessionId, `External-run provider '${provider}' item ${index} sessionId`, true)!,
-		source: text(run.source, `External-run provider '${provider}' item ${index} source`, true)!,
-		state: run.state as ExternalRunState,
-		...(text(run.command, `External-run provider '${provider}' item ${index} command`) !== undefined ? { command: text(run.command, `External-run provider '${provider}' item ${index} command`) } : {}),
-		...(text(run.cwd, `External-run provider '${provider}' item ${index} cwd`) !== undefined ? { cwd: text(run.cwd, `External-run provider '${provider}' item ${index} cwd`) } : {}),
-		...(text(run.isolationPath, `External-run provider '${provider}' item ${index} isolationPath`) !== undefined ? { isolationPath: text(run.isolationPath, `External-run provider '${provider}' item ${index} isolationPath`) } : {}),
-		...(text(run.owner, `External-run provider '${provider}' item ${index} owner`) !== undefined ? { owner: text(run.owner, `External-run provider '${provider}' item ${index} owner`) } : {}),
-		...(run.completionReason !== undefined ? { completionReason: run.completionReason as ExternalRunCompletionReason } : {}),
-		...(text(run.reportPath, `External-run provider '${provider}' item ${index} reportPath`) !== undefined ? { reportPath: text(run.reportPath, `External-run provider '${provider}' item ${index} reportPath`) } : {}),
-		...(timestamp(run.startedAt, `External-run provider '${provider}' item ${index} startedAt`) !== undefined ? { startedAt: timestamp(run.startedAt, `External-run provider '${provider}' item ${index} startedAt`) } : {}),
-		...(timestamp(run.completedAt, `External-run provider '${provider}' item ${index} completedAt`) !== undefined ? { completedAt: timestamp(run.completedAt, `External-run provider '${provider}' item ${index} completedAt`) } : {}),
-		...(run.exitCode !== undefined ? { exitCode: run.exitCode as number | null } : {}),
-		...(run.residualRisks !== undefined ? { residualRisks: [...run.residualRisks] as string[] } : {}),
+		id: identity(run.id, "External run id"),
+		sessionId: identity(run.sessionId, "External run sessionId"),
+		source: displayText(run.source, "External run source", EXTERNAL_RUN_LIMITS.maxTextLength, true)!,
+		label: displayText(run.label, "External run label", EXTERNAL_RUN_LIMITS.maxTextLength, true)!,
+		state: state(run.state, "External run state"),
+		startedAt: timestamp(run.startedAt, "External run startedAt", true)!,
+		...(updatedAt !== undefined ? { updatedAt } : {}),
+		...(endedAt !== undefined ? { endedAt } : {}),
+		...(currentAction ? { currentAction } : {}),
+		...(preview ? { preview } : {}),
+		...(reportPath ? { reportPath } : {}),
+		...(transcriptPath ? { transcriptPath } : {}),
 	};
 }
 
-/** Register an observational provider. pi-subagents never starts, stops, or steers these processes. */
-export function registerExternalRunProvider(provider: ExternalRunProvider): () => void {
-	if (!provider || typeof provider !== "object" || Array.isArray(provider) || Object.keys(provider).some((key) => key !== "name" && key !== "listExternalRuns")) throw new Error("External-run provider must contain only name and listExternalRuns.");
-	const name = text(provider.name, "External-run provider name", true)!;
-	if (typeof provider.listExternalRuns !== "function") throw new Error(`External-run provider '${name}' must expose listExternalRuns().`);
-	const current = registry();
-	if (!current.providers.has(name) && current.providers.size >= MAX_PROVIDERS) throw new Error(`External-run registry supports at most ${MAX_PROVIDERS} providers.`);
-	current.providers.set(name, provider);
-	return () => { if (current.providers.get(name) === provider) current.providers.delete(name); };
+function key(sessionId: string, id: string): string {
+	return `${sessionId}\0${id}`;
 }
 
-/** Snapshot records for one Pi session. Records are read-only observations of foreign process ownership. */
-export function snapshotExternalRuns(sessionId: string): readonly RegisteredExternalRun[] {
-	text(sessionId, "External-run snapshot sessionId", true);
-	const records: RegisteredExternalRun[] = [];
-	const identities = new Set<string>();
-	for (const [name, provider] of registry().providers) {
-		if (provider.name !== name) throw new Error(`External-run registry key '${name}' does not match provider name '${provider.name}'.`);
-		const runs = provider.listExternalRuns();
-		if (!Array.isArray(runs)) throw new Error(`External-run provider '${name}' listExternalRuns() must return an array.`);
-		if (runs.length > MAX_RUNS_PER_PROVIDER) throw new Error(`External-run provider '${name}' returned more than ${MAX_RUNS_PER_PROVIDER} runs.`);
-		runs.forEach((value, index) => {
-			const run = validateRun(value, name, index);
-			const identity = `${name}\0${run.sessionId}\0${run.id}`;
-			if (identities.has(identity)) throw new Error(`External-run provider '${name}' returned duplicate run '${run.id}' for session '${run.sessionId}'.`);
-			identities.add(identity);
-			if (run.sessionId === sessionId) records.push({ provider: name, ...run });
-		});
-	}
-	return records;
+function clone(run: ExternalRun): ExternalRun {
+	return { ...run };
 }
+
+/** Register one current-session external job. pi-subagents never controls the job. */
+export function registerExternalRun(input: ExternalRun): ExternalRun {
+	const run = validateRun(input);
+	const current = registry();
+	const runKey = key(run.sessionId, run.id);
+	if (current.runs.has(runKey)) throw new Error(`External run '${run.id}' is already registered for session '${run.sessionId}'.`);
+	if (current.runs.size >= EXTERNAL_RUN_LIMITS.maxCachedRuns) throw new Error(`External-run registry supports at most ${EXTERNAL_RUN_LIMITS.maxCachedRuns} cached runs.`);
+	current.runs.set(runKey, run);
+	return clone(run);
+}
+
+/** Update display fields for a registered external job without changing its identity or owner. */
+export function updateExternalRun(sessionId: string, id: string, update: ExternalRunUpdate): ExternalRun {
+	const safeSessionId = identity(sessionId, "External run sessionId");
+	const safeId = identity(id, "External run id");
+	const patch = inputObject(update, "External run update", UPDATE_FIELDS);
+	const current = registry();
+	const runKey = key(safeSessionId, safeId);
+	const previous = current.runs.get(runKey);
+	if (!previous) throw new Error(`External run '${safeId}' is not registered for session '${safeSessionId}'.`);
+	const next = validateRun({ ...previous, ...patch });
+	current.runs.set(runKey, next);
+	return clone(next);
+}
+
+/** Remove a cached external job. The caller remains responsible for its process and artifacts. */
+export function unregisterExternalRun(sessionId: string, id: string): boolean {
+	return registry().runs.delete(key(identity(sessionId, "External run sessionId"), identity(id, "External run id")));
+}
+
+function snapshotBytes(runs: readonly ExternalRun[]): number {
+	return Buffer.byteLength(JSON.stringify(runs), "utf8");
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+/** Read a bounded cached snapshot for one Pi session. This never invokes third-party code. */
+export function snapshotExternalRuns(sessionId: string, options: ExternalRunSnapshotOptions = {}): readonly ExternalRun[] {
+	const safeSessionId = identity(sessionId, "External-run snapshot sessionId");
+	const current = registry();
+	const runs: ExternalRun[] = [];
+	for (const [cacheKey, value] of current.runs.entries()) {
+		try {
+			const run = validateRun(value);
+			if (run.sessionId === safeSessionId) runs.push(run);
+		} catch (error) {
+			const message = `Malformed cached external run '${cacheKey}': ${getErrorMessage(error)}`;
+			if (!options.ignoreMalformed) throw new Error(message, { cause: error instanceof Error ? error : undefined });
+			current.runs.delete(cacheKey);
+			options.onMalformedRecord?.(message);
+		}
+	}
+	runs.sort((left, right) => {
+		const leftActive = left.state === "queued" || left.state === "running";
+		const rightActive = right.state === "queued" || right.state === "running";
+		if (leftActive !== rightActive) return leftActive ? -1 : 1;
+		return (right.updatedAt ?? right.endedAt ?? right.startedAt) - (left.updatedAt ?? left.endedAt ?? left.startedAt) || left.id.localeCompare(right.id);
+	});
+	const snapshot = runs.slice(0, EXTERNAL_RUN_LIMITS.maxSnapshotRuns).map(clone);
+	while (snapshot.length > 0 && snapshotBytes(snapshot) > EXTERNAL_RUN_LIMITS.maxSerializedBytes) snapshot.pop();
+	return snapshot;
+}
+
+/** Alias for callers that prefer list terminology. */
+export const listExternalRuns = snapshotExternalRuns;

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { type EditorComponent, isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { snapshotExternalRuns } from "../api/external-runs.ts";
 import { formatModelThinking } from "../shared/formatters.ts";
 import type { AsyncJobStep, FleetViewPlacement, NestedRunSummary, NestedStepSummary, SubagentState } from "../shared/types.ts";
 import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
@@ -23,6 +24,7 @@ type FleetStatusEntry = {
 	startedAt: number;
 	tokens: number;
 	state: string;
+	external?: true;
 	nestedChildren?: NestedRunSummary[];
 };
 
@@ -319,6 +321,25 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 		}
 	}
 
+	if (state.currentSessionId) {
+		try {
+			for (const run of snapshotExternalRuns(state.currentSessionId, { ignoreMalformed: true, onMalformedRecord: (message) => console.warn(`[pi-subagents] Removed ${message}`) })) {
+				if (!isActiveState(run.state)) continue;
+				entries.push({
+					key: `external:${run.id}`,
+					agent: `external · ${run.label}`,
+					description: run.currentAction ?? `source: ${run.source}`,
+					startedAt: run.startedAt,
+					tokens: 0,
+					state: run.state,
+					external: true,
+				});
+			}
+		} catch (cause) {
+			console.warn(`[pi-subagents] Failed to inspect external jobs: ${cause instanceof Error ? cause.message : String(cause)}`);
+		}
+	}
+
 	return entries.sort((left, right) => left.startedAt - right.startedAt || left.key.localeCompare(right.key));
 }
 
@@ -495,10 +516,14 @@ export class SubagentFleetStatus {
 		if (!this.active) {
 			const tokens = this.entries.reduce((total, entry) => total + entry.tokens, 0);
 			const capacity = this.state.activeAsyncCapacity;
-			const asyncRuns = capacity ? `Async runs ${capacity.used}/${capacity.limit || "∞"}` : "";
-			const agents = this.entries.length > 0 ? `${this.entries.length} active ${this.entries.length === 1 ? "agent" : "agents"}` : "";
+			const hasNativeRows = this.entries.some((entry) => !entry.external);
+			const showNativeSummary = hasNativeRows || Boolean(capacity?.used);
+			const asyncRuns = capacity && showNativeSummary ? `Async runs ${capacity.used}/${capacity.limit || "∞"}` : "";
+			const noun = this.entries.some((entry) => entry.external) ? "job" : "agent";
+			const agents = this.entries.length > 0 ? `${this.entries.length} active ${noun}${this.entries.length === 1 ? "" : "s"}` : "";
 			const label = [agents, asyncRuns].filter(Boolean).join(" · ");
-			return [truncateToWidth(`  ${theme.fg("muted", label)} · ${theme.fg("dim", `${formatFleetTokens(tokens)} · ↓/← to inspect`)}`, width)];
+			const detail = [showNativeSummary ? formatFleetTokens(tokens) : undefined, "↓/← to inspect"].filter(Boolean).join(" · ");
+			return [truncateToWidth(`  ${theme.fg("muted", label)} · ${theme.fg("dim", detail)}`, width)];
 		}
 		const roster = this.rosterKeys();
 		const selectedIndex = Math.max(0, roster.indexOf(this.selectedKey));
@@ -529,7 +554,7 @@ export class SubagentFleetStatus {
 		const prefix = branch ? `    ${branch}` : " ";
 		const left = `${prefix} ${this.bullet(rosterIndex, selectedIndex, theme)} ${theme.fg("muted", agent)} · ${entry.state}`;
 		const elapsed = Date.now() - entry.startedAt;
-		const right = theme.fg("dim", `${formatFleetElapsed(elapsed)} · ${formatFleetTokens(entry.tokens)}`);
+		const right = theme.fg("dim", entry.external ? formatFleetElapsed(elapsed) : `${formatFleetElapsed(elapsed)} · ${formatFleetTokens(entry.tokens)}`);
 		return rightAlign(left, right, width);
 	}
 
@@ -589,6 +614,7 @@ export class SubagentFleetStatus {
 					entry.state,
 					entry.modelThinking,
 					entry.description,
+					entry.external,
 					Math.round((now - entry.startedAt) / 1000),
 					entry.tokens,
 					nestedFleetRows(entry.nestedChildren, entry.parentKey ? 3 : 4).map((row) => [
@@ -601,7 +627,7 @@ export class SubagentFleetStatus {
 						row.overflow,
 					]),
 				]
-				: [entry.key, entry.state, entry.tokens]),
+				: [entry.key, entry.state, entry.external, entry.tokens]),
 		});
 	}
 

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { getMarkdownTheme, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type MarkdownTheme } from "@earendil-works/pi-tui";
+import { snapshotExternalRuns, type ExternalRun } from "../api/external-runs.ts";
 import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../shared/formatters.ts";
 import { DIRS, type AsyncJobState, type Details, type FleetKeybindingAction, type FleetKeybindingsConfig, type ForegroundChildControl, type ForegroundResumeChild, type ForegroundResumeRun, type ForegroundRunControl, type SubagentState } from "../shared/types.ts";
@@ -77,6 +78,7 @@ export type FleetItem = (
 	| { key: string; kind: "foreground-active"; runId: string; index?: number; agent: string; state: "running"; updatedAt: number; control: ForegroundRunControl; activeChild?: ForegroundChildControl }
 	| { key: string; kind: "foreground-recent"; runId: string; index: number; agent: string; state: ForegroundResumeChild["status"]; updatedAt: number; run: ForegroundResumeRun; child: ForegroundResumeChild }
 	| { key: string; kind: "async"; runId: string; index?: number; agent: string; state: string; updatedAt: number; run: AsyncRunSummary; step?: AsyncStep }
+	| { key: string; kind: "external"; runId: string; agent: string; state: ExternalRun["state"]; updatedAt: number; run: ExternalRun }
 ) & { description?: string };
 
 export interface FleetSnapshot {
@@ -258,6 +260,26 @@ export function collectFleetSnapshot(
 		}
 	} catch (cause) {
 		error = cause instanceof Error ? cause.message : String(cause);
+	}
+
+	if (state.currentSessionId) {
+		try {
+			for (const run of snapshotExternalRuns(state.currentSessionId, { ignoreMalformed: true, onMalformedRecord: (message) => console.warn(`[pi-subagents] Removed ${message}`) })) {
+				items.push({
+					key: `external:${run.id}`,
+					kind: "external",
+					runId: run.id,
+					agent: run.label,
+					state: run.state,
+					updatedAt: run.updatedAt ?? run.endedAt ?? run.startedAt,
+					run,
+					...(run.currentAction ? { description: run.currentAction } : {}),
+				});
+			}
+		} catch (cause) {
+			const message = `Failed to inspect external jobs: ${cause instanceof Error ? cause.message : String(cause)}`;
+			error = error ? `${error}; ${message}` : message;
+		}
 	}
 
 	const recentForeground = [...(state.foregroundRuns?.values() ?? [])]
@@ -450,6 +472,11 @@ function foregroundRecentDetail(item: Extract<FleetItem, { kind: "foreground-rec
 	return lines.filter((line): line is string => line !== undefined);
 }
 
+function externalElapsedEnd(run: ExternalRun): number {
+	const terminal = run.state !== "queued" && run.state !== "running";
+	return terminal ? (run.endedAt ?? run.updatedAt ?? Date.now()) : Date.now();
+}
+
 function asyncDetail(item: Extract<FleetItem, { kind: "async" }>): string[] {
 	const status = readStatus(item.run.asyncDir);
 	if (status) {
@@ -470,13 +497,36 @@ function asyncDetail(item: Extract<FleetItem, { kind: "async" }>): string[] {
 	].filter((line): line is string => line !== undefined);
 }
 
+function externalDetail(item: Extract<FleetItem, { kind: "external" }>): string[] {
+	return [
+		`Run: ${item.runId}`,
+		"Source: external · display-only",
+		`Owner: ${item.run.source}`,
+		`State: ${item.state}`,
+		`Started: ${new Date(item.run.startedAt).toISOString()}`,
+		item.run.updatedAt !== undefined ? `Updated: ${new Date(item.run.updatedAt).toISOString()}` : undefined,
+		item.run.endedAt !== undefined ? `Ended: ${new Date(item.run.endedAt).toISOString()}` : undefined,
+		`Elapsed: ${formatDuration(Math.max(0, externalElapsedEnd(item.run) - item.run.startedAt))}`,
+		item.run.currentAction ? `Current action: ${item.run.currentAction}` : undefined,
+		item.run.reportPath ? `Report path: ${item.run.reportPath}` : undefined,
+		item.run.transcriptPath ? `Transcript path: ${item.run.transcriptPath}` : undefined,
+		"",
+		"Preview",
+		item.run.preview ?? "(no preview supplied)",
+		"",
+		"The owning extension controls execution, persistence, cancellation, and results.",
+	].filter((line): line is string => line !== undefined);
+}
+
 function detailLines(item: FleetItem | undefined, error: string | undefined, state: SubagentState): string[] {
-	if (!item) return [error ? `Fleet scan failed: ${error}` : "No current-session foreground or recent async children.", "", "New runs appear here automatically while this inspector remains open."];
+	if (!item) return [error ? `Fleet scan failed: ${error}` : "No current-session Fleet jobs.", "", "New jobs appear here automatically while this inspector remains open."];
 	const lines = item.kind === "foreground-active"
 		? foregroundActiveDetail(item, state)
 		: item.kind === "foreground-recent"
 			? foregroundRecentDetail(item, state)
-			: asyncDetail(item);
+			: item.kind === "external"
+				? externalDetail(item)
+				: asyncDetail(item);
 	if (error) lines.unshift(`Fleet scan warning: ${error}`, "");
 	return lines;
 }
@@ -504,6 +554,7 @@ function fleetArtifactsRoot(state: SubagentState, cwd: string): string {
 }
 
 function transcriptTarget(item: FleetItem, state: SubagentState): { path: string; trustedRoots: string[] } | undefined {
+	if (item.kind === "external") return undefined;
 	if (item.kind === "foreground-active") {
 		const artifactsRoot = fleetArtifactsRoot(state, item.control.cwd ?? state.baseCwd);
 		return {
@@ -548,10 +599,12 @@ function itemContext(item: FleetItem): string | undefined {
 }
 
 function itemMode(item: FleetItem): string {
+	if (item.kind === "external") return "display-only";
 	return item.kind === "foreground-active" ? item.control.mode : item.run.mode;
 }
 
 function itemSource(item: FleetItem): string {
+	if (item.kind === "external") return `external · ${item.run.source}`;
 	if (item.kind === "async") return "background";
 	return item.kind === "foreground-active" ? "foreground · live" : "foreground · recent";
 }
@@ -571,6 +624,8 @@ function itemStats(item: FleetItem): string[] {
 		model = formatModelThinking(item.child.model, item.child.thinking) || undefined;
 		tokens = item.child.tokens;
 		tools = item.child.toolCount;
+	} else if (item.kind === "external") {
+		durationMs = Math.max(0, externalElapsedEnd(item.run) - item.run.startedAt);
 	} else {
 		model = formatModelThinking(item.step?.model, item.step?.thinking) || undefined;
 		tokens = item.step?.tokens?.total ?? (item.index === undefined ? item.run.totalTokens?.total : undefined);
@@ -590,7 +645,7 @@ function itemStats(item: FleetItem): string[] {
 function structuredHeader(item: FleetItem, width: number, theme: Theme, conversationState: string, promptSummary?: string): string[] {
 	const lines: string[] = [];
 	lines.push(rightAligned(` ${statusGlyph(item, theme)} ${theme.bold(item.agent)}`, theme.fg("dim", item.state), width));
-	const child = item.index !== undefined ? ` · child ${item.index + 1}` : "";
+	const child = "index" in item && item.index !== undefined ? ` · child ${item.index + 1}` : "";
 	const context = itemContext(item);
 	const identity = `${itemSource(item)} · ${item.runId.slice(0, 8)}${child} · ${itemMode(item)}${context ? ` ${context}` : ""}`;
 	lines.push(`  ${theme.fg("dim", identity)}`);
@@ -755,6 +810,7 @@ export class SubagentFleetComponent implements Component {
 	private selectedAsyncAction(): { item: Extract<FleetItem, { kind: "async" }> } | { reason: string } {
 		const item = this.snapshot.items[this.selected];
 		if (!item) return { reason: "No child is selected." };
+		if (item.kind === "external") return { reason: "External jobs are display-only and remain controlled by their owning extension." };
 		if (item.kind !== "async") return { reason: "Fleet controls are available for current-session top-level async runs only." };
 		if (!isActionableAsyncState(item.run.state) || !isActionableAsyncState(item.state)) return { reason: `Selected child is ${item.state}; controls require a running or queued async child.` };
 		return { item };
@@ -763,6 +819,7 @@ export class SubagentFleetComponent implements Component {
 	private selectedHerdrInspectAction(): { runId: string; asyncDir: string; index?: number } | { reason: string } {
 		const item = this.snapshot.items[this.selected];
 		if (!item) return { reason: "No child is selected." };
+		if (item.kind === "external") return { reason: "External jobs are display-only and have no Herdr controls." };
 		if (item.kind === "async") {
 			if (!isActionableAsyncState(item.run.state) || !isActionableAsyncState(item.state)) return { reason: `Selected child is ${item.state}; controls require a running or queued async child.` };
 			return { runId: item.runId, asyncDir: item.run.asyncDir, ...(item.index !== undefined ? { index: item.index } : {}) };
@@ -1147,7 +1204,9 @@ export class SubagentFleetComponent implements Component {
 		];
 		const lines = [this.theme.fg("border", `╭${"─".repeat(innerWidth)}╮`)];
 		const selected = this.snapshot.items[this.selected];
-		const title = ` ${this.theme.bold("Subagent fleet inspector")} ${this.theme.fg("dim", "· live controls")}`;
+		const title = selected?.kind === "external"
+			? ` ${this.theme.bold("Fleet inspector")} ${this.theme.fg("dim", "· external display-only")}`
+			: ` ${this.theme.bold("Subagent fleet inspector")} ${this.theme.fg("dim", "· live controls")}`;
 		const selectedStatus = selected
 			? `${statusGlyph(selected, this.theme)} ${selected.agent} · ${selected.state} `
 			: this.theme.fg("dim", "no children ");
@@ -1166,7 +1225,9 @@ export class SubagentFleetComponent implements Component {
 		const position = this.snapshot.items.length ? `${this.selected + 1}/${this.snapshot.items.length}` : "0/0";
 		const footer = this.promptAuditOpen
 			? ` j/k child · 1/2/3 view · g redo with guidance · c copy · Esc close Prompt Audit · ${position}`
-			: ` ${bindingLabel(this.keybindings, "selectUp")}/${bindingLabel(this.keybindings, "selectDown")} agent · p Prompt Audit · ${bindingLabel(this.keybindings, "inspect")} Herdr · ${bindingLabel(this.keybindings, "steer")} steer · ${bindingLabel(this.keybindings, "stop")} stop · ${bindingLabel(this.keybindings, "toggleTools")} tools · ${bindingLabel(this.keybindings, "refresh")} refresh · ${bindingLabel(this.keybindings, "close")} close · ${position}`;
+			: selected?.kind === "external"
+				? ` ${bindingLabel(this.keybindings, "selectUp")}/${bindingLabel(this.keybindings, "selectDown")} job · display-only · ${bindingLabel(this.keybindings, "refresh")} refresh · ${bindingLabel(this.keybindings, "close")} close · ${position}`
+				: ` ${bindingLabel(this.keybindings, "selectUp")}/${bindingLabel(this.keybindings, "selectDown")} agent · p Prompt Audit · ${bindingLabel(this.keybindings, "inspect")} Herdr · ${bindingLabel(this.keybindings, "steer")} steer · ${bindingLabel(this.keybindings, "stop")} stop · ${bindingLabel(this.keybindings, "toggleTools")} tools · ${bindingLabel(this.keybindings, "refresh")} refresh · ${bindingLabel(this.keybindings, "close")} close · ${position}`;
 		lines.push(this.theme.fg("border", "│") + fit(this.theme.fg("dim", footer), innerWidth) + this.theme.fg("border", "│"));
 		lines.push(this.theme.fg("border", `╰${"─".repeat(innerWidth)}╯`));
 		return lines.map((line) => truncateToWidth(line, width));

--- a/test/unit/external-runs.test.ts
+++ b/test/unit/external-runs.test.ts
@@ -1,66 +1,159 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+	EXTERNAL_RUN_LIMITS,
 	EXTERNAL_RUN_REGISTRY_KEY,
-	registerExternalRunProvider,
+	EXTERNAL_RUN_REGISTRY_VERSION,
+	listExternalRuns,
+	registerExternalRun,
 	snapshotExternalRuns,
+	unregisterExternalRun,
+	updateExternalRun,
 } from "../../src/api/external-runs.ts";
 
 function clearRegistry(): void {
 	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)];
 }
 
-test("external-run providers expose scoped observational records without controls", () => {
+test("external runs register, update, list, and unregister cached display records", () => {
 	clearRegistry();
-	const dispose = registerExternalRunProvider({
-		name: "interactive-shell",
-		listExternalRuns: () => [{
-			id: "review-794",
-			sessionId: "session-a",
-			source: "interactive_shell",
-			state: "completed",
-			completionReason: "auto-close-quiet",
-			cwd: "/tmp/review",
-			reportPath: "/tmp/review.md",
-			exitCode: null,
-			residualRisks: ["The terminal runtime owns process control."],
-		}],
-	});
-	assert.deepEqual(snapshotExternalRuns("session-a"), [{
-		provider: "interactive-shell",
-		id: "review-794",
+	assert.deepEqual(registerExternalRun({
+		id: "review-1083",
 		sessionId: "session-a",
-		source: "interactive_shell",
-		state: "completed",
-		completionReason: "auto-close-quiet",
-		cwd: "/tmp/review",
-		reportPath: "/tmp/review.md",
-		exitCode: null,
-		residualRisks: ["The terminal runtime owns process control."],
-	}]);
+		source: "interactive-shell",
+		label: "Dependency review",
+		state: "running",
+		startedAt: 100,
+		currentAction: "Inspecting package metadata",
+	}), {
+		id: "review-1083",
+		sessionId: "session-a",
+		source: "interactive-shell",
+		label: "Dependency review",
+		state: "running",
+		startedAt: 100,
+		currentAction: "Inspecting package metadata",
+	});
 	assert.deepEqual(snapshotExternalRuns("session-b"), []);
-	dispose();
+	assert.deepEqual(updateExternalRun("session-a", "review-1083", {
+		state: "completed",
+		updatedAt: 190,
+		endedAt: 200,
+		preview: "Review complete",
+		reportPath: "/tmp/review.md",
+	}), {
+		id: "review-1083",
+		sessionId: "session-a",
+		source: "interactive-shell",
+		label: "Dependency review",
+		state: "completed",
+		startedAt: 100,
+		updatedAt: 190,
+		endedAt: 200,
+		currentAction: "Inspecting package metadata",
+		preview: "Review complete",
+		reportPath: "/tmp/review.md",
+	});
+	assert.deepEqual(listExternalRuns("session-a"), snapshotExternalRuns("session-a"));
+	assert.equal(unregisterExternalRun("session-a", "review-1083"), true);
+	assert.equal(unregisterExternalRun("session-a", "review-1083"), false);
+	assert.deepEqual(snapshotExternalRuns("session-a"), []);
 	clearRegistry();
 });
 
-test("external-run providers reject malformed and duplicate records", () => {
+test("external run validation is atomic and display text is bounded", () => {
 	clearRegistry();
-	assert.throws(() => registerExternalRunProvider({ name: " bad", listExternalRuns: () => [] }), /trimmed/);
-	registerExternalRunProvider({
-		name: "interactive-shell",
-		listExternalRuns: () => [
-			{ id: "run", sessionId: "session-a", source: "interactive_shell", state: "running", extra: true },
-		] as never,
+	registerExternalRun({
+		id: "run",
+		sessionId: "session-a",
+		source: "tool",
+		label: "Initial",
+		state: "running",
+		startedAt: 1,
 	});
-	assert.throws(() => snapshotExternalRuns("session-a"), /unknown fields: extra/);
+	assert.throws(
+		() => updateExternalRun("session-a", "run", { state: "invalid" as never, label: "Changed" }),
+		/state is invalid/,
+	);
+	assert.equal(snapshotExternalRuns("session-a")[0]?.label, "Initial");
+	const updated = updateExternalRun("session-a", "run", {
+		label: `\u001b[31m${"x".repeat(EXTERNAL_RUN_LIMITS.maxTextLength + 20)}`,
+		preview: `line 1\n${"p".repeat(EXTERNAL_RUN_LIMITS.maxPreviewLength + 20)}`,
+	});
+	assert.equal(updated.label.length, EXTERNAL_RUN_LIMITS.maxTextLength);
+	assert.ok(updated.preview!.length <= EXTERNAL_RUN_LIMITS.maxPreviewLength);
+	assert.doesNotMatch(updated.label, /\u001b/);
+	assert.doesNotMatch(updated.preview!, /\n/);
+	assert.throws(
+		() => registerExternalRun({ id: "unsafe\nrun", sessionId: "session-a", source: "tool", label: "Unsafe", state: "running", startedAt: 1 }),
+		/display-safe/,
+	);
+	assert.throws(
+		() => registerExternalRun({ id: "extra", sessionId: "session-a", source: "tool", label: "Extra", state: "running", startedAt: 1, cwd: "/private" } as never),
+		/unknown fields: cwd/,
+	);
+	assert.throws(
+		() => registerExternalRun({ id: "invalid-date", sessionId: "session-a", source: "tool", label: "Invalid date", state: "running", startedAt: Number.MAX_SAFE_INTEGER }),
+		/safe timestamp/,
+	);
 	clearRegistry();
-	registerExternalRunProvider({
-		name: "interactive-shell",
-		listExternalRuns: () => [
-			{ id: "run", sessionId: "session-a", source: "interactive_shell", state: "running" },
-			{ id: "run", sessionId: "session-a", source: "interactive_shell", state: "running" },
-		],
-	});
-	assert.throws(() => snapshotExternalRuns("session-a"), /duplicate run 'run'/);
+});
+
+test("external snapshots throw on malformed cached records by default", () => {
+	clearRegistry();
+	try {
+		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)] = {
+			version: EXTERNAL_RUN_REGISTRY_VERSION,
+			runs: new Map<string, unknown>([
+				["session-a\0bad", { id: "bad", sessionId: "session-a", source: "tool", label: "Bad", state: "running", startedAt: Number.NaN }],
+				["session-a\0good", { id: "good", sessionId: "session-a", source: "tool", label: "Good", state: "running", startedAt: 1 }],
+			]),
+		};
+		assert.throws(
+			() => snapshotExternalRuns("session-a"),
+			/Malformed cached external run 'session-a\0bad': External run startedAt must be a non-negative safe timestamp/,
+		);
+	} finally {
+		clearRegistry();
+	}
+});
+
+test("external snapshots can remove malformed cached records for display-only callers", () => {
+	clearRegistry();
+	const diagnostics: string[] = [];
+	try {
+		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)] = {
+			version: EXTERNAL_RUN_REGISTRY_VERSION,
+			runs: new Map<string, unknown>([
+				["session-a\0bad", { id: "bad", sessionId: "session-a", source: "tool", label: "Bad", state: "running", startedAt: Number.NaN }],
+				["session-a\0good", { id: "good", sessionId: "session-a", source: "tool", label: "Good", state: "running", startedAt: 1 }],
+			]),
+		};
+		assert.deepEqual(snapshotExternalRuns("session-a", { ignoreMalformed: true, onMalformedRecord: (message) => diagnostics.push(message) }).map((run) => run.id), ["good"]);
+		assert.deepEqual(diagnostics, ["Malformed cached external run 'session-a\0bad': External run startedAt must be a non-negative safe timestamp."]);
+		assert.deepEqual(snapshotExternalRuns("session-a").map((run) => run.id), ["good"]);
+	} finally {
+		clearRegistry();
+	}
+});
+
+test("external snapshots apply count and serialized byte caps without provider callbacks", () => {
+	clearRegistry();
+	for (let index = 0; index < EXTERNAL_RUN_LIMITS.maxSnapshotRuns + 5; index++) {
+		registerExternalRun({
+			id: `run-${index}`,
+			sessionId: "session-a",
+			source: "tool",
+			label: `Run ${index}`,
+			state: index === 0 ? "running" : "completed",
+			startedAt: index,
+			updatedAt: index,
+			preview: "p".repeat(EXTERNAL_RUN_LIMITS.maxPreviewLength),
+		});
+	}
+	const snapshot = snapshotExternalRuns("session-a");
+	assert.ok(snapshot.length <= EXTERNAL_RUN_LIMITS.maxSnapshotRuns);
+	assert.ok(Buffer.byteLength(JSON.stringify(snapshot), "utf8") <= EXTERNAL_RUN_LIMITS.maxSerializedBytes);
+	assert.equal(snapshot[0]?.id, "run-0", "active jobs sort ahead of terminal jobs");
 	clearRegistry();
 });

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { Editor, type EditorComponent, visibleWidth } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { SubagentState } from "../../src/shared/types.ts";
+import { EXTERNAL_RUN_REGISTRY_KEY, EXTERNAL_RUN_REGISTRY_VERSION, registerExternalRun } from "../../src/api/external-runs.ts";
 import { collectFleetSnapshot } from "../../src/tui/fleet.ts";
 import {
 	FLEET_STATUS_WIDGET_KEY,
@@ -12,6 +13,10 @@ import {
 	formatFleetTokens,
 	resolveFleetViewPlacement,
 } from "../../src/tui/fleet-status.ts";
+
+function clearExternalRuns(): void {
+	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)];
+}
 
 function stateForTest(): SubagentState {
 	return {
@@ -44,6 +49,73 @@ describe("below-editor subagent FleetView", () => {
 		assert.equal(formatFleetTokens(999), "↓ 999 tokens");
 		assert.equal(formatFleetTokens(13_100), "↓ 13.1k tokens");
 		assert.equal(formatFleetTokens(1_250_000), "↓ 1.3M tokens");
+	});
+
+	it("renders cached external jobs with an external marker and elapsed time", () => {
+		clearExternalRuns();
+		registerExternalRun({
+			id: "external-review",
+			sessionId: "session-current",
+			source: "interactive-shell",
+			label: "Dependency review",
+			state: "running",
+			startedAt: Date.now() - 11_000,
+			currentAction: "Inspecting package metadata",
+		});
+		const state = stateForTest();
+		state.activeAsyncCapacity = { used: 0, limit: 0 };
+		assert.deepEqual(collectFleetStatusEntries(state).map((entry) => ({ key: entry.key, agent: entry.agent, description: entry.description })), [{
+			key: "external:external-review",
+			agent: "external · Dependency review",
+			description: "Inspecting package metadata",
+		}]);
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+		try {
+			fleet.setContext(ctx);
+			const tui = { requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor };
+			const component = widgetFactory!(tui, theme);
+			const compact = component.render(80)[0]!;
+			assert.match(compact, /1 active job/);
+			assert.doesNotMatch(compact, /Async runs|tokens/);
+			fleet.handleKey("\x1b[B");
+			const expanded = component.render(80).join("\n");
+			assert.match(expanded, /external · Dependency review · running/);
+			assert.match(expanded, /11s/);
+			assert.doesNotMatch(expanded.split("\n").find((line) => line.includes("Dependency review"))!, /tokens/);
+		} finally {
+			fleet.dispose();
+			clearExternalRuns();
+		}
+	});
+
+	it("warns when compact FleetView cannot inspect external jobs", () => {
+		clearExternalRuns();
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message?: unknown) => warnings.push(String(message));
+		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)] = {
+			version: EXTERNAL_RUN_REGISTRY_VERSION + 1,
+			runs: new Map(),
+		};
+		try {
+			assert.deepEqual(collectFleetStatusEntries(stateForTest()), []);
+			assert.match(warnings[0]!, /Failed to inspect external jobs/);
+		} finally {
+			console.warn = originalWarn;
+			clearExternalRuns();
+		}
 	});
 
 	it("resolves configured FleetView placement with a below-editor fallback", () => {

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { visibleWidth, type MarkdownTheme } from "@earendil-works/pi-tui";
+import { EXTERNAL_RUN_REGISTRY_KEY, EXTERNAL_RUN_REGISTRY_VERSION, registerExternalRun } from "../../src/api/external-runs.ts";
 import { collectFleetSnapshot, openSubagentFleet, SubagentFleetComponent } from "../../src/tui/fleet.ts";
 import { persistForegroundRunHistory, restoreForegroundRunHistory } from "../../src/runs/foreground/foreground-history.ts";
 import { FLEET_STATUS_WIDGET_KEY } from "../../src/tui/fleet-status.ts";
@@ -12,6 +13,10 @@ import { getArtifactPaths, getArtifactsDir, getProjectArtifactsDir } from "../..
 import type { SubagentState } from "../../src/shared/types.ts";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+
+function clearExternalRuns(): void {
+	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)];
+}
 
 function stateForTest(): SubagentState {
 	return {
@@ -165,6 +170,138 @@ describe("native subagent fleet", () => {
 			assert.equal(snapshot.error, undefined);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("shows cached external jobs as display-only without reading paths or invoking controls", async () => {
+		clearExternalRuns();
+		registerExternalRun({
+			id: "external-review",
+			sessionId: "session-current",
+			source: "interactive-shell",
+			label: "Dependency review",
+			state: "completed",
+			startedAt: 100,
+			updatedAt: 200,
+			currentAction: "Inspecting package metadata",
+			preview: "No dependency blockers found.",
+			reportPath: "/outside/trusted/roots/report.md",
+			transcriptPath: "/outside/trusted/roots/transcript.jsonl",
+		});
+		const state = stateForTest();
+		const snapshot = collectFleetSnapshot(state);
+		assert.equal(snapshot.error, undefined);
+		assert.deepEqual(snapshot.items.map((item) => ({ key: item.key, kind: item.kind, agent: item.agent })), [{
+			key: "external:external-review",
+			kind: "external",
+			agent: "Dependency review",
+		}]);
+		let steerCalls = 0;
+		let stopCalls = 0;
+		let inspectCalls = 0;
+		const component = new SubagentFleetComponent(
+			{ terminal: { rows: 32, columns: 120 }, requestRender() {} } as never,
+			theme as never,
+			state,
+			() => {},
+			{
+				refreshMs: 60_000,
+				markdownTheme,
+				actions: {
+					async steer() { steerCalls++; return { text: "unexpected" }; },
+					stop() { stopCalls++; return { text: "unexpected" }; },
+					async inspect() { inspectCalls++; return { text: "unexpected" }; },
+				},
+			},
+		);
+		try {
+			const initial = component.render(120).join("\n");
+			assert.match(initial, /Fleet inspector.*external display-only/);
+			assert.match(initial, /Source: external · display-only/);
+			assert.match(initial, /Owner: interactive-shell/);
+			assert.match(initial, /Inspecting package metadata/);
+			assert.match(initial, /Elapsed: 100ms/);
+			assert.match(initial, /No dependency blockers found/);
+			assert.match(initial, /Report path: \/outside\/trusted\/roots\/report\.md/);
+			assert.match(initial, /Transcript path: \/outside\/trusted\/roots\/transcript\.jsonl/);
+			assert.doesNotMatch(initial, /Herdr ·|steer ·|stop ·/);
+			component.handleInput("H");
+			assert.match(component.render(120).join("\n"), /display-only and have no Herdr controls/);
+			component.handleInput("s");
+			assert.match(component.render(120).join("\n"), /display-only and remain controlled/);
+			component.handleInput("D");
+			assert.match(component.render(120).join("\n"), /display-only and remain controlled/);
+			await new Promise((resolve) => setImmediate(resolve));
+			assert.deepEqual({ steerCalls, stopCalls, inspectCalls }, { steerCalls: 0, stopCalls: 0, inspectCalls: 0 });
+		} finally {
+			component.dispose();
+			clearExternalRuns();
+		}
+	});
+
+	it("keeps running external elapsed time live when endedAt is present", () => {
+		clearExternalRuns();
+		try {
+			const startedAt = Date.now() - 5_000;
+			registerExternalRun({
+				id: "external-running",
+				sessionId: "session-current",
+				source: "interactive-shell",
+				label: "Running external job",
+				state: "running",
+				startedAt,
+				updatedAt: startedAt + 100,
+				endedAt: startedAt + 100,
+			});
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 32, columns: 120 }, requestRender() {} } as never,
+				theme as never,
+				stateForTest(),
+				() => {},
+				{ refreshMs: 60_000, markdownTheme },
+			);
+			try {
+				const rendered = component.render(120).join("\n");
+				assert.match(rendered, /Elapsed: 5\.0s/);
+				assert.doesNotMatch(rendered, /Elapsed: 100ms/);
+			} finally {
+				component.dispose();
+			}
+		} finally {
+			clearExternalRuns();
+		}
+	});
+
+	it("ignores malformed cached external jobs while rendering Fleet", () => {
+		clearExternalRuns();
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message?: unknown) => warnings.push(String(message));
+		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)] = {
+			version: EXTERNAL_RUN_REGISTRY_VERSION,
+			runs: new Map<string, unknown>([[
+				"session-current\0bad",
+				{ id: "bad", sessionId: "session-current", source: "tool", label: "Bad external", state: "running", startedAt: Number.NaN },
+			]]),
+		};
+		const state = stateForTest();
+		const component = new SubagentFleetComponent(
+			{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
+			theme as never,
+			state,
+			() => {},
+			{ refreshMs: 60_000, markdownTheme },
+		);
+		try {
+			const snapshot = collectFleetSnapshot(state);
+			assert.equal(snapshot.error, undefined);
+			assert.deepEqual(snapshot.items, []);
+			assert.match(warnings[0]!, /Removed Malformed cached external run/);
+			assert.match(component.render(100).join("\n"), /No current-session Fleet jobs/);
+		} finally {
+			console.warn = originalWarn;
+			component.dispose();
+			clearExternalRuns();
 		}
 	});
 

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -69,8 +69,11 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.equal(backgroundWork.BACKGROUND_WORK_PROTOCOL_VERSION, 1);
 	assert.equal(backgroundWork.BACKGROUND_WORK_REGISTRY_KEY, "pi-subagents.background-work.v1");
 	const externalRuns = await import("pi-subagents/external-runs");
-	assert.equal(externalRuns.EXTERNAL_RUN_REGISTRY_VERSION, 1);
-	assert.equal(typeof externalRuns.registerExternalRunProvider, "function");
+	assert.equal(externalRuns.EXTERNAL_RUN_REGISTRY_VERSION, 2);
+	assert.equal(typeof externalRuns.registerExternalRun, "function");
+	assert.equal(typeof externalRuns.updateExternalRun, "function");
+	assert.equal(typeof externalRuns.snapshotExternalRuns, "function");
+	assert.equal(typeof externalRuns.unregisterExternalRun, "function");
 	const capability = await import("pi-subagents/capability-ceiling");
 	assert.equal(capability.SUBAGENT_CAPABILITY_CEILING_VERSION, 1);
 	assert.equal(capability.SUBAGENT_CAPABILITY_CEILING_REGISTRY_KEY, "pi-subagents.capability-ceiling.v1");


### PR DESCRIPTION
## Summary

Closes #1083 by replacing the old pull-based `pi-subagents/external-runs` provider seam with a bounded push/cache API for caller-owned external jobs.

External jobs now appear in FleetView as display-only records. Fleet reads only cached summaries, never polls caller code on the render path, and does not expose managed Herdr, steer, stop, resume, cancel, or path-reading controls for those records.

Thanks to @ssyram for the #1083 request and API direction.

## What changed

- Add `registerExternalRun`, `updateExternalRun`, `snapshotExternalRuns` / `listExternalRuns`, and `unregisterExternalRun` at the existing `pi-subagents/external-runs` export.
- Bound cached external job records by count, string length, preview/path length, and serialized snapshot bytes.
- Remove malformed cached records with a warning before Fleet renders external jobs.
- Add compact Fleet rows and full Fleet inspector items for external jobs.
- Keep external report/transcript paths as display text only.
- Update extension API docs, bundled skill guidance, changelog credit, and focused tests.

## Validation

- Malformed external-cache Fleet render repro from the exact-head review
- `node --experimental-strip-types --test test/unit/external-runs.test.ts test/unit/fleet-status.test.ts test/unit/fleet.test.ts test/unit/package-manifest.test.ts`
- `npm run typecheck`
- `env -u PI_SUBAGENT_STEER_INBOX -u PI_SUBAGENT_STEER_CAPABILITY -u PI_SUBAGENT_STEER_ACK_DIR npm run test:unit`
- `git diff --check`
