### PR TITLE
fix: keep fleet overlay live and count leaf agents

### DIFF
--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -17,6 +17,7 @@ type FleetStatusTui = {
 type FleetStatusEntry = {
 	key: string;
 	parentKey?: string;
+	workflowWrapper?: boolean;
 	agent: string;
 	modelThinking?: string;
 	description?: string;
@@ -221,6 +222,10 @@ function foregroundDescription(control: { parentWorkflowRunId?: string; workflow
 	return description ? `${workflow} · ${description}` : workflow;
 }
 
+function activeLeafAgentCount(entries: FleetStatusEntry[]): number {
+	return entries.filter((entry) => !entry.workflowWrapper).length;
+}
+
 export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntry[] {
 	const entries: FleetStatusEntry[] = [];
 	const activeWorkflowKeys = new Set([...state.asyncJobs.values()]
@@ -269,6 +274,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 			const latestEmit = job.workflow?.emits?.length ? formatWorkflowJsonPreview(job.workflow.emits.at(-1), 120) : undefined;
 			entries.push({
 				key: `async:${job.asyncId}`,
+				workflowWrapper: true,
 				agent: "workflow",
 				description: latestEmit !== undefined ? `latest emit: ${latestEmit}` : job.description,
 				startedAt,
@@ -496,7 +502,8 @@ export class SubagentFleetStatus {
 			const tokens = this.entries.reduce((total, entry) => total + entry.tokens, 0);
 			const capacity = this.state.activeAsyncCapacity;
 			const asyncRuns = capacity ? `Async runs ${capacity.used}/${capacity.limit || "∞"}` : "";
-			const agents = this.entries.length > 0 ? `${this.entries.length} active ${this.entries.length === 1 ? "agent" : "agents"}` : "";
+			const activeAgents = activeLeafAgentCount(this.entries);
+			const agents = activeAgents > 0 ? `${activeAgents} active ${activeAgents === 1 ? "agent" : "agents"}` : "";
 			const label = [agents, asyncRuns].filter(Boolean).join(" · ");
 			return [truncateToWidth(`  ${theme.fg("muted", label)} · ${theme.fg("dim", `${formatFleetTokens(tokens)} · ↓/← to inspect`)}`, width)];
 		}

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -20,6 +20,7 @@ import { handleHerdrInspectorAction } from "../inspectors/herdr/actions.ts";
 import { getLivePromptAudit, type LivePromptAudit, type PromptAuditView } from "../runs/foreground/prompt-audit.ts";
 
 const REFRESH_MS = 750;
+const MIN_REFRESH_MS = 250;
 const MAX_RECENT_ASYNC_RUNS = 20;
 const MAX_FLEET_HISTORY_CANDIDATES = 100;
 const TRANSCRIPT_LINES = 200;
@@ -655,7 +656,8 @@ export class SubagentFleetComponent implements Component {
 	private actionBusy = false;
 	private transcriptCache: FleetTranscriptCache | undefined;
 	private disposed = false;
-	private readonly timer: ReturnType<typeof setInterval>;
+	private refreshTimer: ReturnType<typeof setTimeout> | undefined;
+	private readonly refreshMs: number;
 	private readonly tui: FleetTui;
 	private readonly theme: Theme;
 	private readonly markdownTheme: MarkdownTheme;
@@ -678,14 +680,31 @@ export class SubagentFleetComponent implements Component {
 		this.done = done;
 		this.options = options;
 		this.keybindings = resolveFleetKeybindings(options.fleetKeybindings);
+		this.refreshMs = Math.max(MIN_REFRESH_MS, options.refreshMs ?? REFRESH_MS);
 		this.selectedKey = options.initialKey;
 		this.refresh();
-		this.timer = setInterval(() => {
+		this.scheduleRefresh();
+	}
+
+	private scheduleRefresh(): void {
+		if (this.disposed || this.refreshTimer) return;
+		this.refreshTimer = setTimeout(() => {
+			this.refreshTimer = undefined;
 			if (this.disposed) return;
-			this.invalidate();
-			this.tui.requestRender();
-		}, options.refreshMs ?? REFRESH_MS);
-		this.timer.unref?.();
+			try {
+				this.invalidate();
+				this.tui.requestRender();
+			} finally {
+				this.scheduleRefresh();
+			}
+		}, this.refreshMs);
+		this.refreshTimer.unref?.();
+	}
+
+	private stopRefresh(): void {
+		this.disposed = true;
+		if (this.refreshTimer) clearTimeout(this.refreshTimer);
+		this.refreshTimer = undefined;
 	}
 
 	private refresh(): void {
@@ -958,6 +977,7 @@ export class SubagentFleetComponent implements Component {
 			return;
 		}
 		if (matchesFleetAction(data, this.keybindings, "close")) {
+			this.stopRefresh();
 			this.done(undefined);
 			return;
 		}
@@ -1178,8 +1198,7 @@ export class SubagentFleetComponent implements Component {
 	}
 
 	dispose(): void {
-		this.disposed = true;
-		clearInterval(this.timer);
+		this.stopRefresh();
 	}
 }
 

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -682,6 +682,9 @@ describe("below-editor subagent FleetView", () => {
 		try {
 			fleet.setContext(ctx);
 			const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
+			const compact = component.render(120);
+			assert.match(compact[0]!, /2 active agents/, "workflow wrappers must not be counted as leaf agents");
+			assert.doesNotMatch(compact[0]!, /3 active agents/);
 			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
 			const lines = component.render(120);
 			const workflowIndex = lines.findIndex((line) => line.includes("workflow · running"));

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -1297,6 +1297,40 @@ describe("native subagent fleet", () => {
 		}
 	});
 
+	it("periodically redraws only while the overlay remains open", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+		const state = stateForTest();
+		let renderRequests = 0;
+		let closed = false;
+		const tui = { terminal: { rows: 28, columns: 90 }, requestRender: () => { renderRequests++; } };
+		const component = new SubagentFleetComponent(
+			tui as never,
+			theme as never,
+			state,
+			() => { closed = true; },
+			{ refreshMs: 10 },
+		);
+		t.mock.timers.tick(249);
+		assert.equal(renderRequests, 0, "refresh cadence is bounded away from a hot loop");
+		t.mock.timers.tick(1);
+		assert.equal(renderRequests, 1);
+		component.handleInput("\x1b");
+		assert.equal(closed, true);
+		t.mock.timers.tick(1_000);
+		assert.equal(renderRequests, 1, "closing cancels periodic redraws");
+
+		const disposed = new SubagentFleetComponent(
+			tui as never,
+			theme as never,
+			state,
+			() => {},
+			{ refreshMs: 250 },
+		);
+		disposed.dispose();
+		t.mock.timers.tick(1_000);
+		assert.equal(renderRequests, 1, "disposing cancels periodic redraws");
+	});
+
 	it("refreshes the roster while the overlay remains open", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-refresh-"));
 		try {
@@ -1308,7 +1342,7 @@ describe("native subagent fleet", () => {
 				theme as never,
 				state,
 				() => {},
-				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 10 },
+				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 250 },
 			);
 			let invalidations = 0;
 			const originalInvalidate = component.invalidate.bind(component);
@@ -1320,7 +1354,7 @@ describe("native subagent fleet", () => {
 				assert.ok(component.render(90).some((line) => line.includes("No tracked children")));
 				const initialOutput = Array.from({ length: 40 }, (_, index) => `output line ${index}`).join("\n");
 				const asyncDir = writeAsyncRun(root, { id: "appeared-live", output: initialOutput });
-				await new Promise((resolve) => setTimeout(resolve, 35));
+				await new Promise((resolve) => setTimeout(resolve, 275));
 				let lines = component.render(90);
 				assert.ok(lines.some((line) => line.includes("appeared")));
 				assert.ok(lines.some((line) => line.includes("output line 39")));


### PR DESCRIPTION
## Summary
- replace the fleet overlay's unbounded interval with a bounded, self-scheduling 750ms redraw (250ms minimum)
- cancel redraws immediately on close as well as component disposal
- keep workflow wrapper rows in the inspector while excluding them from the compact active-agent count
- add deterministic fake-timer coverage for redraw cadence/lifecycle and render coverage for workflow leaf counts

## Validation
- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/fleet.test.ts`
- `node --experimental-strip-types --test test/unit/fleet-status.test.ts`
- `npm run test:e2e` (runtime-dependent suite skipped as expected)

The repository-wide unit run currently has one unrelated existing failure in `subagent-prompt-runtime.test.ts` (`headless auto-drain is always registered`, expected 1 handler, observed 2). The integration run exceeded 300 seconds and also surfaced unrelated async-execution timing failures before timeout.
