### PR TITLE
fix: distinguish user-requested foreground detaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Keep the FleetView overlay refreshed while open and count active leaf agents in the compact summary. Thanks to @Don-Yin for #1108.
+- Keep user-requested foreground detaches from showing supervisor-response recovery guidance. Thanks to @Lewis-E for #1109.
 - Reject configured subagent models that are not in the active host model registry before spawning a child, instead of forwarding an invalid `--model` argument to Pi. Thanks to @DresvyanskiyDenis for #1093.
 - Start Herdr inspector and project pane commands with a shell-safe executable token, including paths that need quoting in Nushell. Thanks to @Rival for #1092.
 - Stop `agentContract.version` from using an `enum` on an integer, which Gemini's function-calling schema subset rejects (the property is dropped from the tool schema but stays in `required`, causing a `400: property is not defined` for every Gemini model). Integer bounds express the same constraint and are valid everywhere. Thanks to @MarcusNeufeldt for #1095.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4491,8 +4491,14 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	}
 
 	if (r.detached) {
+		const recovery = `subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.`;
+		const message = r.detachedReason === "intercom coordination"
+			? `Detached for intercom coordination: ${params.agent}. Reply to the supervisor request first, then wait with ${recovery}`
+			: r.detachedReason === "user request"
+				? `Detached at user request: ${params.agent}. Wait with ${recovery}`
+				: `Detached before task completion: ${params.agent}. Wait with ${recovery}`;
 		return {
-			content: [{ type: "text", text: `Detached for intercom coordination: ${params.agent}. Reply to the supervisor request first, then wait with subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.` }],
+			content: [{ type: "text", text: message }],
 			details,
 		};
 	}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4491,12 +4491,13 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	}
 
 	if (r.detached) {
-		const recovery = `subagent_wait({ id: "${runId}" }). Use subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.`;
+		const statusRecovery = `subagent({ action: "status", id: "${runId}" }) to recover the result; do not resume or launch a replacement while it remains detached.`;
+		const blockingRecovery = `subagent_wait({ id: "${runId}" }). Use ${statusRecovery}`;
 		const message = r.detachedReason === "intercom coordination"
-			? `Detached for intercom coordination: ${params.agent}. Reply to the supervisor request first, then wait with ${recovery}`
+			? `Detached for intercom coordination: ${params.agent}. Reply to the supervisor request first, then wait with ${blockingRecovery}`
 			: r.detachedReason === "user request"
-				? `Detached at user request: ${params.agent}. Wait with ${recovery}`
-				: `Detached before task completion: ${params.agent}. Wait with ${recovery}`;
+				? `Detached at user request: ${params.agent}. The child continues independently. Register a completion wake-up with subagent_wait({ id: "${runId}", nonBlocking: true }), or use ${statusRecovery}`
+				: `Detached before task completion: ${params.agent}. Wait with ${blockingRecovery}`;
 		return {
 			content: [{ type: "text", text: message }],
 			details,

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -451,7 +451,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const text = result.content.map((part) => part.type === "text" ? part.text : "").join("\n");
 		assert.equal(result.details.results[0]?.detachedReason, "user request");
 		assert.match(text, /Detached at user request/);
-		assert.doesNotMatch(text, /intercom coordination|supervisor request/);
+		assert.match(text, /subagent_wait\(\{ id: "[^"]+", nonBlocking: true \}\)/);
+		assert.doesNotMatch(text, /intercom coordination|supervisor request|Wait with subagent_wait/);
+		assert.doesNotMatch(text, /subagent_wait\(\{ id: "[^"]+" \}\)/);
 
 		let terminalChild = state.foregroundRuns?.get(control.runId)?.children[0];
 		for (let attempt = 0; attempt < 250 && terminalChild?.status !== "completed"; attempt++) {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -411,6 +411,52 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(JSON.stringify(result.details), /Converted structured single-child request/);
 	});
 
+	it("reports a user-requested foreground detach without supervisor guidance", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ steps: [{ delay: 500, jsonl: [events.assistantMessage("completed after user detach")] }] });
+		const state: SubagentState = {
+			baseCwd: tempDir,
+			currentSessionId: null,
+			asyncJobs: new Map(),
+			foregroundControls: new Map(),
+			lastForegroundControlId: null,
+		};
+		const executor = createSubagentExecutor!({
+			pi: { events: createEventBus(), getSessionName: () => undefined },
+			state,
+			config: {},
+			asyncByDefault: false,
+			tempArtifactsDir: tempDir,
+			getSubagentSessionRoot: () => path.join(tempDir, ".pi/subagents", "sessions"),
+			expandTilde: (value: string) => value,
+			discoverAgents: () => ({ agents: [makeAgent("echo")] }),
+			allowMutatingManagementActions: true,
+		});
+
+		const pending = executor.execute(
+			"user-detach-guidance",
+			{ agent: "echo", task: "Keep working", async: false },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		let control = state.lastForegroundControlId ? state.foregroundControls.get(state.lastForegroundControlId) : undefined;
+		for (let attempt = 0; attempt < 100 && !control?.detach; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			control = state.lastForegroundControlId ? state.foregroundControls.get(state.lastForegroundControlId) : undefined;
+		}
+		assert.ok(control?.detach, "foreground detach control should become available");
+		assert.equal(control.detach(), true);
+
+		const result = await pending;
+		const text = result.content.map((part) => part.type === "text" ? part.text : "").join("\n");
+		assert.equal(result.details.results[0]?.detachedReason, "user request");
+		assert.match(text, /Detached at user request/);
+		assert.doesNotMatch(text, /intercom coordination|supervisor request/);
+
+		// Let the detached mock child reach its terminal callback before test teardown removes its files.
+		await new Promise((resolve) => setTimeout(resolve, 600));
+	});
+
 	it("rejects action='single' with execution fields", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const executor = makeExecutor([makeAgent("echo")]);
 		const result = await executor.executePublic("single-alias", { action: "single", agent: "echo", task: "work" }, new AbortController().signal, undefined, makeMinimalCtx(tempDir));

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -453,8 +453,13 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(text, /Detached at user request/);
 		assert.doesNotMatch(text, /intercom coordination|supervisor request/);
 
-		// Let the detached mock child reach its terminal callback before test teardown removes its files.
-		await new Promise((resolve) => setTimeout(resolve, 600));
+		let terminalChild = state.foregroundRuns?.get(control.runId)?.children[0];
+		for (let attempt = 0; attempt < 250 && terminalChild?.status !== "completed"; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			terminalChild = state.foregroundRuns?.get(control.runId)?.children[0];
+		}
+		assert.equal(terminalChild?.status, "completed", "detached child should reach its terminal callback before teardown");
+		assert.equal(terminalChild.finalOutput, "completed after user detach");
 	});
 
 	it("rejects action='single' with execution fields", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {


### PR DESCRIPTION
## What changed

- distinguish user-requested foreground detaches from intercom-coordination detaches
- keep supervisor-response guidance exclusive to real intercom handoffs
- add a regression test covering the user-requested detach receipt

## Why

Followup to https://github.com/nicobailon/pi-subagents/pull/1097

Manual shortcut detaches set `detachedReason` to `user request`, but the single-run executor labeled every detached result as intercom coordination. That produced a false instruction to answer a supervisor request even though no request existed.

## Testing

- `npm run typecheck`
- `npm run test:unit` (1,974 passed, 2 skipped)
- targeted user-detach and intercom-detach regressions (5 passed)
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/slash-commands.test.ts` (18 passed)