### PR TITLE
fix: keep fleet overlay live after external run support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add an optional `foregroundDetachShortcut` binding and show it in the running single-subagent card, so foreground work can be moved to the background without editing package source. Thanks to @Lewis-E for #1097.
 
 ### Fixed
+- Keep the FleetView overlay refreshed while open and count active leaf agents in the compact summary. Thanks to @Don-Yin for #1108.
 - Reject configured subagent models that are not in the active host model registry before spawning a child, instead of forwarding an invalid `--model` argument to Pi. Thanks to @DresvyanskiyDenis for #1093.
 - Start Herdr inspector and project pane commands with a shell-safe executable token, including paths that need quoting in Nushell. Thanks to @Rival for #1092.
 - Stop `agentContract.version` from using an `enum` on an integer, which Gemini's function-calling schema subset rejects (the property is dropped from the tool schema but stays in `required`, causing a `400: property is not defined` for every Gemini model). Integer bounds express the same constraint and are valid everywhere. Thanks to @MarcusNeufeldt for #1095.

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -18,6 +18,7 @@ type FleetStatusTui = {
 type FleetStatusEntry = {
 	key: string;
 	parentKey?: string;
+	workflowWrapper?: boolean;
 	agent: string;
 	modelThinking?: string;
 	description?: string;
@@ -223,6 +224,10 @@ function foregroundDescription(control: { parentWorkflowRunId?: string; workflow
 	return description ? `${workflow} · ${description}` : workflow;
 }
 
+function activeLeafAgentCount(entries: FleetStatusEntry[]): number {
+	return entries.filter((entry) => !entry.workflowWrapper).length;
+}
+
 export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntry[] {
 	const entries: FleetStatusEntry[] = [];
 	const activeWorkflowKeys = new Set([...state.asyncJobs.values()]
@@ -271,6 +276,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 			const latestEmit = job.workflow?.emits?.length ? formatWorkflowJsonPreview(job.workflow.emits.at(-1), 120) : undefined;
 			entries.push({
 				key: `async:${job.asyncId}`,
+				workflowWrapper: true,
 				agent: "workflow",
 				description: latestEmit !== undefined ? `latest emit: ${latestEmit}` : job.description,
 				startedAt,
@@ -519,8 +525,9 @@ export class SubagentFleetStatus {
 			const hasNativeRows = this.entries.some((entry) => !entry.external);
 			const showNativeSummary = hasNativeRows || Boolean(capacity?.used);
 			const asyncRuns = capacity && showNativeSummary ? `Async runs ${capacity.used}/${capacity.limit || "∞"}` : "";
+			const activeEntries = activeLeafAgentCount(this.entries);
 			const noun = this.entries.some((entry) => entry.external) ? "job" : "agent";
-			const agents = this.entries.length > 0 ? `${this.entries.length} active ${noun}${this.entries.length === 1 ? "" : "s"}` : "";
+			const agents = activeEntries > 0 ? `${activeEntries} active ${noun}${activeEntries === 1 ? "" : "s"}` : "";
 			const label = [agents, asyncRuns].filter(Boolean).join(" · ");
 			const detail = [showNativeSummary ? formatFleetTokens(tokens) : undefined, "↓/← to inspect"].filter(Boolean).join(" · ");
 			return [truncateToWidth(`  ${theme.fg("muted", label)} · ${theme.fg("dim", detail)}`, width)];

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -21,6 +21,7 @@ import { handleHerdrInspectorAction } from "../inspectors/herdr/actions.ts";
 import { getLivePromptAudit, type LivePromptAudit, type PromptAuditView } from "../runs/foreground/prompt-audit.ts";
 
 const REFRESH_MS = 750;
+const MIN_REFRESH_MS = 250;
 const MAX_RECENT_ASYNC_RUNS = 20;
 const MAX_FLEET_HISTORY_CANDIDATES = 100;
 const TRANSCRIPT_LINES = 200;
@@ -710,7 +711,8 @@ export class SubagentFleetComponent implements Component {
 	private actionBusy = false;
 	private transcriptCache: FleetTranscriptCache | undefined;
 	private disposed = false;
-	private readonly timer: ReturnType<typeof setInterval>;
+	private refreshTimer: ReturnType<typeof setTimeout> | undefined;
+	private readonly refreshMs: number;
 	private readonly tui: FleetTui;
 	private readonly theme: Theme;
 	private readonly markdownTheme: MarkdownTheme;
@@ -733,14 +735,31 @@ export class SubagentFleetComponent implements Component {
 		this.done = done;
 		this.options = options;
 		this.keybindings = resolveFleetKeybindings(options.fleetKeybindings);
+		this.refreshMs = Math.max(MIN_REFRESH_MS, options.refreshMs ?? REFRESH_MS);
 		this.selectedKey = options.initialKey;
 		this.refresh();
-		this.timer = setInterval(() => {
+		this.scheduleRefresh();
+	}
+
+	private scheduleRefresh(): void {
+		if (this.disposed || this.refreshTimer) return;
+		this.refreshTimer = setTimeout(() => {
+			this.refreshTimer = undefined;
 			if (this.disposed) return;
-			this.invalidate();
-			this.tui.requestRender();
-		}, options.refreshMs ?? REFRESH_MS);
-		this.timer.unref?.();
+			try {
+				this.invalidate();
+				this.tui.requestRender();
+			} finally {
+				this.scheduleRefresh();
+			}
+		}, this.refreshMs);
+		this.refreshTimer.unref?.();
+	}
+
+	private stopRefresh(): void {
+		this.disposed = true;
+		if (this.refreshTimer) clearTimeout(this.refreshTimer);
+		this.refreshTimer = undefined;
 	}
 
 	private refresh(): void {
@@ -1015,6 +1034,7 @@ export class SubagentFleetComponent implements Component {
 			return;
 		}
 		if (matchesFleetAction(data, this.keybindings, "close")) {
+			this.stopRefresh();
 			this.done(undefined);
 			return;
 		}
@@ -1239,8 +1259,7 @@ export class SubagentFleetComponent implements Component {
 	}
 
 	dispose(): void {
-		this.disposed = true;
-		clearInterval(this.timer);
+		this.stopRefresh();
 	}
 }
 

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -754,6 +754,9 @@ describe("below-editor subagent FleetView", () => {
 		try {
 			fleet.setContext(ctx);
 			const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
+			const compact = component.render(120);
+			assert.match(compact[0]!, /2 active agents/, "workflow wrappers must not be counted as leaf agents");
+			assert.doesNotMatch(compact[0]!, /3 active agents/);
 			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
 			const lines = component.render(120);
 			const workflowIndex = lines.findIndex((line) => line.includes("workflow · running"));

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -1434,6 +1434,40 @@ describe("native subagent fleet", () => {
 		}
 	});
 
+	it("periodically redraws only while the overlay remains open", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+		const state = stateForTest();
+		let renderRequests = 0;
+		let closed = false;
+		const tui = { terminal: { rows: 28, columns: 90 }, requestRender: () => { renderRequests++; } };
+		const component = new SubagentFleetComponent(
+			tui as never,
+			theme as never,
+			state,
+			() => { closed = true; },
+			{ refreshMs: 10 },
+		);
+		t.mock.timers.tick(249);
+		assert.equal(renderRequests, 0, "refresh cadence is bounded away from a hot loop");
+		t.mock.timers.tick(1);
+		assert.equal(renderRequests, 1);
+		component.handleInput("\x1b");
+		assert.equal(closed, true);
+		t.mock.timers.tick(1_000);
+		assert.equal(renderRequests, 1, "closing cancels periodic redraws");
+
+		const disposed = new SubagentFleetComponent(
+			tui as never,
+			theme as never,
+			state,
+			() => {},
+			{ refreshMs: 250 },
+		);
+		disposed.dispose();
+		t.mock.timers.tick(1_000);
+		assert.equal(renderRequests, 1, "disposing cancels periodic redraws");
+	});
+
 	it("refreshes the roster while the overlay remains open", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-refresh-"));
 		try {
@@ -1445,7 +1479,7 @@ describe("native subagent fleet", () => {
 				theme as never,
 				state,
 				() => {},
-				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 10 },
+				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 250 },
 			);
 			let invalidations = 0;
 			const originalInvalidate = component.invalidate.bind(component);
@@ -1457,7 +1491,7 @@ describe("native subagent fleet", () => {
 				assert.ok(component.render(90).some((line) => line.includes("No tracked children")));
 				const initialOutput = Array.from({ length: 40 }, (_, index) => `output line ${index}`).join("\n");
 				const asyncDir = writeAsyncRun(root, { id: "appeared-live", output: initialOutput });
-				await new Promise((resolve) => setTimeout(resolve, 35));
+				await new Promise((resolve) => setTimeout(resolve, 275));
 				let lines = component.render(90);
 				assert.ok(lines.some((line) => line.includes("appeared")));
 				assert.ok(lines.some((line) => line.includes("output line 39")));


### PR DESCRIPTION
Supersedes #1108.

This rebases @Don-Yin's Fleet overlay fix on top of the landed external FleetView work from #1106.

It keeps the Fleet inspector live while it is open by using a bounded self-scheduling refresh loop that stops on close and dispose. It also makes the compact below-editor widget count active leaf agents instead of workflow wrapper rows.

The rebase preserves the #1106 external-job contract: external jobs stay display-only, external-only compact status uses `job` wording, native async capacity and tokens stay hidden for external-only rows, and malformed external registry errors still warn instead of disappearing silently.

Credit: thanks to @Don-Yin for #1108.

Validation:
- `node --experimental-strip-types --test test/unit/fleet-status.test.ts test/unit/fleet.test.ts`
- `npm run typecheck`
- `git diff --check`

Review gate:
- Pending exact-head review: `/tmp/pi-subagents-backlog-20260814-post1081/pr-1108-fleet-overlay-review-3db88cb.md`
