### PR TITLE
fix: keep no-edit challenge reports successful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- Keep FleetView working when a session file path is longer than a short identity, instead of failing external-job inspection on every poll. Thanks to @albertgwo for #1121.
+- Keep FleetView working when a session file path is longer than a short identity, instead of failing external-job inspection on every poll. Thanks to @albertgwo for #1121 and @Don-Yin for #1122.
 
 ### Added
 - Add optional Orca progress tabs with bounded, sanitized mirrors for native Pi and external CLI children. Thanks to @hyein-cbio for #1080.
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Keep structured single-child runs from overriding output paths in the task, while preserving explicit and agent-configured outputs. Thanks to @pasemes for #1119.
+- Keep implementation challenge no-edit confirmations guarded after later implementation retractions (#1115).
 - Remove the native generic `intercom` compatibility fallback from supervisor coordination while preserving `contact_supervisor`, `subagent_supervisor`, and external `intercom` providers. Thanks to @jaudiger for #1107.
 - Report an actionable project-settings override when duplicate ambient Pi extensions prevent a child from starting (#1114).
 - Keep the FleetView overlay refreshed while open and count active leaf agents in the compact summary. Thanks to @Don-Yin for #1108.

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -23,15 +23,21 @@ const CURSOR_FILE_MUTATION_THINKING =
 	/(?:^|\n)\s*Cursor (?:edit|write)\s*:/i;
 
 const REVIVED_TASK_PREFIX = /^You are reviving a previous subagent conversation\.\n\nOriginal run: .+\nOriginal agent: .+(?:\nOriginal session file: .+)?\n\nUse the stored session context as background\. Answer the orchestrator's follow-up below\. Do not assume the original child process is still alive\.\n\nFollow-up:\n/;
-const IMPLEMENTATION_CHALLENGE_TASK_PATTERN = new RegExp(`${REVIVED_TASK_PREFIX.source}(?:Run )?implementation challenge pass (?:one|two|\\d+)\\b`, "i");
+const IMPLEMENTATION_CHALLENGE_FOLLOW_UP_PATTERN = /^(?:Run )?implementation challenge pass (?:one|two|\d+)(?:\s+and implement any better current[- ]scope change\.?|\s+for the accepted candidate\.\s+Reconsider it and implement any better current[- ]scope change\.?)?$/i;
 const NO_BETTER_CHANGE_NEEDED_PATTERN = /^\s*no (?:better|further|additional) (?:current[- ]scope )?(?:code |source |file )?(?:change|changes|edit|edits|patch|patches) (?:is|are) needed\b/i;
 const KEPT_CURRENT_IMPLEMENTATION_PATTERN = /\b(?:kept (?:the )?current (?:implementation|candidate|shape)|(?:the )?current (?:implementation|candidate|shape) was kept)\b/i;
 const NO_CHANGE_MADE_PATTERN = /\bno (?:new )?(?:(?:code|source|file|test)(?:\s*(?:,\s*or|,|\/|or)\s*(?:code|source|file|test))* changes?|changes?) (?:were|was) made\b/i;
 const NO_BETTER_CHANGE_QUALIFIER_PATTERN = /\b(?:do\s+not|don't|dont|not|never|cannot|can't|cant|unable|uncertain|unsure|unclear|disagree|wrong|false|reject|rejected|rejecting|maybe|might|may|\w+n['’]t)\b/i;
-const REPORT_SENTENCE_PATTERN = /[^.!?]+(?:[.!?]+(?=\s|$)|$)/g;
+const REPORT_SENTENCE_PATTERN = /[^.!?]+(?:[.!?]+(?=(?:["”'’]?\s)|["”'’]?$)|$)/g;
 const QUOTED_CLAIM_PATTERN = /["“]([^"”]+)["”]([.!?]?\s*[^.!?]*)/g;
 const QUOTED_CLAIM_REFERENCE_PATTERN = /\b(?:that|this|it|claim|report|message|disagree)\b/i;
 const CLAIM_CONTRADICTION_PATTERN = /\bbut\b[^.!?]*\b(?:uncertain|unsure|unclear|disagree|wrong|false|reject|rejected|rejecting)\b/i;
+const IMPLEMENTATION_RETRACTION_PATTERN = /\b(?:found|identified)\s+(?:(?:a|an|the)\s+)?(?:required|necessary|additional|better)?\s*(?:(?:code|source|file|test)\s+)?(?:changes?|edits?|patches?)\b|\b(?:(?:implementation|code|source|file|test)\s+)?work\s+(?:remains?|is\s+(?:needed|required))\b|\b(?:(?:a|an|the)\s+)?(?:(?:code|source|file|test)\s+)?(?:changes?|edits?|patches?)\s+(?:are|is)\s+(?:needed|required)\b|\b(?:required|necessary|additional|better)\s+(?:(?:code|source|file|test)\s+)?(?:changes?|edits?|patches?)\b|\b(?:I|we)?\s*need\s+(?:(?:code|source|file|test)\s+)?(?:changes?|edits?|patches?)\b|\b(?:need|needs|require|requires)\s+(?:to\s+)?(?:implement|make|apply)\b/i;
+const IMPLEMENTATION_RETRACTION_GLOBAL_PATTERN = new RegExp(IMPLEMENTATION_RETRACTION_PATTERN.source, "gi");
+const DIRECT_CLAIM_RETRACTION_PATTERN = /^\s*(?:I\s+)?(?:disagree|reject|retract)\b|\b(?:disagree|retract|retracted|retracting|reject|rejected|rejecting)\b[^.!?]*\b(?:that|this|it|claim|report|message)\b|\b(?:that|this|it|claim|report|message)\b[^.!?]*\b(?:is|was)\s+(?:rejected|retracted)\b/i;
+const NEGATED_RETRACTION_PREFIX_PATTERN = /\b(?:no|not|\w+n['’]t)\b(?:\s+\w+){0,2}\s*$/i;
+const REPORTED_CLAIM_PREFIX_PATTERN = /["“]|\b(?:prior|previous)\s+(?:message|report)\b|\b(?:said|stated|reported)\b/i;
+const POST_CLAIM_SEPARATOR_PATTERN = /^[\s,;:.—–'"“‘’-]+/;
 
 interface CompletionMutationGuardInput {
 	agent: string;
@@ -45,6 +51,11 @@ interface CompletionMutationGuardResult {
 	expectedMutation: boolean;
 	attemptedMutation: boolean;
 	triggered: boolean;
+}
+
+interface ReportSentence {
+	text: string;
+	offset: number;
 }
 
 export function hasMutationToolCapability(tools: string[] | undefined, mcpDirectTools: string[] | undefined): boolean {
@@ -93,15 +104,52 @@ export function hasMutationToolCall(messages: Message[]): boolean {
 	return false;
 }
 
-function hasUnqualifiedClaim(sentences: string[], pattern: RegExp): boolean {
-	return sentences.some((sentence) => {
-		const claim = sentence.match(pattern);
+function hasImplementationRetraction(text: string): boolean {
+	return Array.from(text.matchAll(IMPLEMENTATION_RETRACTION_GLOBAL_PATTERN)).some((retraction) =>
+		!NEGATED_RETRACTION_PREFIX_PATTERN.test(text.slice(0, retraction.index!)));
+}
+
+function hasDirectClaimRetraction(text: string): boolean {
+	return DIRECT_CLAIM_RETRACTION_PATTERN.test(text.replace(POST_CLAIM_SEPARATOR_PATTERN, ""));
+}
+
+function isInsideQuotedText(report: string, index: number): boolean {
+	let quote: "double" | "single" | undefined;
+	for (const char of report.slice(0, index)) {
+		if (quote === "double") {
+			if (char === "\"" || char === "”") quote = undefined;
+		} else if (quote === "single") {
+			if (char === "’") quote = undefined;
+		} else if (char === "\"" || char === "“") {
+			quote = "double";
+		} else if (char === "‘") {
+			quote = "single";
+		}
+	}
+	return quote !== undefined;
+}
+
+function unqualifiedClaimIndex(report: string, sentences: ReportSentence[], pattern: RegExp): number {
+	return sentences.findIndex((sentence) => {
+		const claim = sentence.text.match(pattern);
 		if (claim === null) return false;
-		const before = sentence.slice(0, claim.index!);
-		const after = sentence.slice(claim.index! + claim[0].length);
-		return !NO_BETTER_CHANGE_QUALIFIER_PATTERN.test(before)
-			&& !CLAIM_CONTRADICTION_PATTERN.test(after);
+		const before = sentence.text.slice(0, claim.index!);
+		const after = sentence.text.slice(claim.index! + claim[0].length);
+		const previous = before.trimEnd().at(-1);
+		return previous !== "'"
+			&& previous !== "‘"
+			&& !isInsideQuotedText(report, sentence.offset + claim.index!)
+			&& !REPORTED_CLAIM_PREFIX_PATTERN.test(before)
+			&& !NO_BETTER_CHANGE_QUALIFIER_PATTERN.test(before)
+			&& !CLAIM_CONTRADICTION_PATTERN.test(after)
+			&& !hasImplementationRetraction(after)
+			&& !hasDirectClaimRetraction(after);
 	});
+}
+
+function hasLaterClaimRetraction(sentences: ReportSentence[], claimIndex: number): boolean {
+	return sentences.slice(claimIndex + 1).some((sentence) => hasImplementationRetraction(sentence.text)
+		|| hasDirectClaimRetraction(sentence.text));
 }
 
 function explicitlyRejectsQuotedClaim(report: string): boolean {
@@ -113,6 +161,11 @@ function explicitlyRejectsQuotedClaim(report: string): boolean {
 	return false;
 }
 
+function isImplementationChallengeTask(task: string): boolean {
+	const followUp = task.replace(REVIVED_TASK_PREFIX, "");
+	return followUp !== task && IMPLEMENTATION_CHALLENGE_FOLLOW_UP_PATTERN.test(followUp.trim());
+}
+
 function reportsNoBetterChallengeChange(messages: Message[]): boolean {
 	const report = messages
 		.filter((message) => message.role === "assistant")
@@ -120,10 +173,17 @@ function reportsNoBetterChallengeChange(messages: Message[]): boolean {
 		.flatMap((part) => part.type === "text" ? [part.text] : [])
 		.join("\n");
 	if (explicitlyRejectsQuotedClaim(report)) return false;
-	const sentences = report.match(REPORT_SENTENCE_PATTERN) ?? [];
-	if (hasUnqualifiedClaim(sentences, NO_BETTER_CHANGE_NEEDED_PATTERN)) return true;
-	return hasUnqualifiedClaim(sentences, KEPT_CURRENT_IMPLEMENTATION_PATTERN)
-		&& hasUnqualifiedClaim(sentences, NO_CHANGE_MADE_PATTERN);
+	const sentences = Array.from(report.matchAll(REPORT_SENTENCE_PATTERN), (match) => ({
+		text: match[0],
+		offset: match.index!,
+	}));
+	const noBetterIndex = unqualifiedClaimIndex(report, sentences, NO_BETTER_CHANGE_NEEDED_PATTERN);
+	if (noBetterIndex >= 0) return !hasLaterClaimRetraction(sentences, noBetterIndex);
+	const keptIndex = unqualifiedClaimIndex(report, sentences, KEPT_CURRENT_IMPLEMENTATION_PATTERN);
+	const noChangeIndex = unqualifiedClaimIndex(report, sentences, NO_CHANGE_MADE_PATTERN);
+	return keptIndex >= 0
+		&& noChangeIndex >= 0
+		&& !hasLaterClaimRetraction(sentences, Math.min(keptIndex, noChangeIndex));
 }
 
 export function evaluateCompletionMutationGuard(input: CompletionMutationGuardInput): CompletionMutationGuardResult {
@@ -131,7 +191,7 @@ export function evaluateCompletionMutationGuard(input: CompletionMutationGuardIn
 		? expectsImplementationMutation(input.agent, input.task)
 		: false;
 	const attemptedMutation = hasMutationToolCall(input.messages);
-	const noEditChallengeComplete = IMPLEMENTATION_CHALLENGE_TASK_PATTERN.test(input.task)
+	const noEditChallengeComplete = isImplementationChallengeTask(input.task)
 		&& reportsNoBetterChallengeChange(input.messages);
 	return {
 		expectedMutation,

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -22,9 +22,16 @@ const READ_ONLY_BUILTIN_TOOLS = new Set([
 const CURSOR_FILE_MUTATION_THINKING =
 	/(?:^|\n)\s*Cursor (?:edit|write)\s*:/i;
 
-const IMPLEMENTATION_CHALLENGE_TASK_PATTERN = /^You are reviving a previous subagent conversation\.\n\nOriginal run: .+\nOriginal agent: .+(?:\nOriginal session file: .+)?\n\nUse the stored session context as background\. Answer the orchestrator's follow-up below\. Do not assume the original child process is still alive\.\n\nFollow-up:\nRun implementation challenge pass (?:one|two|\d+) and implement any better current-scope change\.$/;
-const NO_BETTER_CHANGE_NEEDED_PATTERN = /^\s*no (?:better|further|additional) (?:current[- ]scope )?(?:code |source |file )?(?:change|changes|edit|edits|patch|patches) (?:is|are) needed[.!]?\s*$/i;
-const NO_BETTER_CHANGE_QUALIFIER_PATTERN = /\b(?:do\s+not|don't|dont|not|never|cannot|can't|cant|unable|uncertain|unsure|unclear|maybe|might|may|\w+n['’]t)\b/i;
+const REVIVED_TASK_PREFIX = /^You are reviving a previous subagent conversation\.\n\nOriginal run: .+\nOriginal agent: .+(?:\nOriginal session file: .+)?\n\nUse the stored session context as background\. Answer the orchestrator's follow-up below\. Do not assume the original child process is still alive\.\n\nFollow-up:\n/;
+const IMPLEMENTATION_CHALLENGE_TASK_PATTERN = new RegExp(`${REVIVED_TASK_PREFIX.source}(?:Run )?implementation challenge pass (?:one|two|\\d+)\\b`, "i");
+const NO_BETTER_CHANGE_NEEDED_PATTERN = /^\s*no (?:better|further|additional) (?:current[- ]scope )?(?:code |source |file )?(?:change|changes|edit|edits|patch|patches) (?:is|are) needed\b/i;
+const KEPT_CURRENT_IMPLEMENTATION_PATTERN = /\b(?:kept (?:the )?current (?:implementation|candidate|shape)|(?:the )?current (?:implementation|candidate|shape) was kept)\b/i;
+const NO_CHANGE_MADE_PATTERN = /\bno (?:new )?(?:(?:code|source|file|test)(?:\s*(?:,\s*or|,|\/|or)\s*(?:code|source|file|test))* changes?|changes?) (?:were|was) made\b/i;
+const NO_BETTER_CHANGE_QUALIFIER_PATTERN = /\b(?:do\s+not|don't|dont|not|never|cannot|can't|cant|unable|uncertain|unsure|unclear|disagree|wrong|false|reject|rejected|rejecting|maybe|might|may|\w+n['’]t)\b/i;
+const REPORT_SENTENCE_PATTERN = /[^.!?]+(?:[.!?]+(?=\s|$)|$)/g;
+const QUOTED_CLAIM_PATTERN = /["“]([^"”]+)["”]([.!?]?\s*[^.!?]*)/g;
+const QUOTED_CLAIM_REFERENCE_PATTERN = /\b(?:that|this|it|claim|report|message|disagree)\b/i;
+const CLAIM_CONTRADICTION_PATTERN = /\bbut\b[^.!?]*\b(?:uncertain|unsure|unclear|disagree|wrong|false|reject|rejected|rejecting)\b/i;
 
 interface CompletionMutationGuardInput {
 	agent: string;
@@ -86,14 +93,37 @@ export function hasMutationToolCall(messages: Message[]): boolean {
 	return false;
 }
 
+function hasUnqualifiedClaim(sentences: string[], pattern: RegExp): boolean {
+	return sentences.some((sentence) => {
+		const claim = sentence.match(pattern);
+		if (claim === null) return false;
+		const before = sentence.slice(0, claim.index!);
+		const after = sentence.slice(claim.index! + claim[0].length);
+		return !NO_BETTER_CHANGE_QUALIFIER_PATTERN.test(before)
+			&& !CLAIM_CONTRADICTION_PATTERN.test(after);
+	});
+}
+
+function explicitlyRejectsQuotedClaim(report: string): boolean {
+	for (const [, claim, response] of report.matchAll(QUOTED_CLAIM_PATTERN)) {
+		if ((KEPT_CURRENT_IMPLEMENTATION_PATTERN.test(claim!) || NO_CHANGE_MADE_PATTERN.test(claim!))
+			&& NO_BETTER_CHANGE_QUALIFIER_PATTERN.test(response!)
+			&& QUOTED_CLAIM_REFERENCE_PATTERN.test(response!)) return true;
+	}
+	return false;
+}
+
 function reportsNoBetterChallengeChange(messages: Message[]): boolean {
 	const report = messages
 		.filter((message) => message.role === "assistant")
 		.flatMap((message) => message.content)
 		.flatMap((part) => part.type === "text" ? [part.text] : [])
 		.join("\n");
-	return NO_BETTER_CHANGE_NEEDED_PATTERN.test(report)
-		&& !NO_BETTER_CHANGE_QUALIFIER_PATTERN.test(report);
+	if (explicitlyRejectsQuotedClaim(report)) return false;
+	const sentences = report.match(REPORT_SENTENCE_PATTERN) ?? [];
+	if (hasUnqualifiedClaim(sentences, NO_BETTER_CHANGE_NEEDED_PATTERN)) return true;
+	return hasUnqualifiedClaim(sentences, KEPT_CURRENT_IMPLEMENTATION_PATTERN)
+		&& hasUnqualifiedClaim(sentences, NO_CHANGE_MADE_PATTERN);
 }
 
 export function evaluateCompletionMutationGuard(input: CompletionMutationGuardInput): CompletionMutationGuardResult {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -3745,6 +3745,58 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.doesNotMatch(eventsText, /Interrupt:/);
 	});
 
+	it("background implementation challenges keep explicit no-change reports successful", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: [
+			"Kept the current implementation. No new code or test changes were made in this challenge pass.",
+			"Reason: the current candidate is the smallest correct shape.",
+		].join("\n\n") });
+
+		const id = `async-no-change-challenge-${Date.now().toString(36)}`;
+		const sessionRoot = path.join(tempDir, "sessions");
+		const task = [
+			"You are reviving a previous subagent conversation.",
+			"",
+			"Original run: source-run",
+			"Original agent: worker",
+			"Original session file: /tmp/source-session.jsonl",
+			"",
+			"Use the stored session context as background. Answer the orchestrator's follow-up below. Do not assume the original child process is still alive.",
+			"",
+			"Follow-up:",
+			"Implementation challenge pass 1 for the accepted candidate. Reconsider it and implement any better current-scope change.",
+		].join("\n");
+
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task,
+			agentConfig: makeAgent("worker"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot,
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id, 10_000);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+		assert.equal(payload.success, true);
+		assert.equal(payload.exitCode, 0);
+		assert.equal(payload.results[0].success, true);
+		assert.match(String(payload.results[0].output), /Kept the current implementation/);
+		assert.doesNotMatch(String(payload.results[0].error ?? ""), /completed without making edits/);
+
+		const eventsText = fs.readFileSync(path.join(ASYNC_DIR, id, "events.jsonl"), "utf-8");
+		assert.doesNotMatch(eventsText, /Subagent failed: worker/);
+		assert.doesNotMatch(eventsText, /"reason":"completion_guard"/);
+	});
+
 	it("agent contract v1 keeps async acceptance and file-mutation effects separate from execution", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ output: "I’ll do that now and report back after implementing.\n```acceptance-report\n{\"criteriaSatisfied\":[{\"id\":\"criterion-1\",\"status\":\"not-satisfied\",\"evidence\":\"no proof\"}]}\n```" });
 		const id = `async-v1-separate-${Date.now().toString(36)}`;

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -25,17 +25,22 @@ function assistantText(text: string): Message {
 }
 
 test("implementation task with no mutation triggers the completion guard", () => {
-	const result = evaluateCompletionMutationGuard({
-		agent: "worker",
-		task: "Implement the approved fix",
-		messages: [assistantText("No better current-scope change is needed.")],
-	});
+	for (const report of [
+		"No better current-scope change is needed.",
+		"Kept the current implementation. No new code or test changes were made in this challenge pass.",
+	]) {
+		const result = evaluateCompletionMutationGuard({
+			agent: "worker",
+			task: "Implement the approved fix",
+			messages: [assistantText(report)],
+		});
 
-	assert.deepEqual(result, {
-		expectedMutation: true,
-		attemptedMutation: false,
-		triggered: true,
-	});
+		assert.deepEqual(result, {
+			expectedMutation: true,
+			attemptedMutation: false,
+			triggered: true,
+		});
+	}
 });
 
 function revivedTask(followUp: string): string {
@@ -55,18 +60,61 @@ function revivedTask(followUp: string): string {
 
 const implementationChallengeTask = revivedTask("Run implementation challenge pass two and implement any better current-scope change.");
 
-test("implementation challenges may complete with an explicit no-better-change report", () => {
-	const result = evaluateCompletionMutationGuard({
-		agent: "worker",
-		task: implementationChallengeTask,
-		messages: [assistantText("No better current-scope change is needed.")],
-	});
+test("implementation challenges may complete with explicit no-change reports", () => {
+	for (const report of [
+		"No better current-scope change is needed.",
+		[
+			"Kept the current implementation. No new code or test changes were made in this challenge pass.",
+			"Reason: the current candidate is the smallest correct shape.",
+		].join("\n\n"),
+		"The current implementation was kept. No code changes were made.",
+		"The current candidate was kept. No source changes were made.",
+		"The current shape was kept. No file or test changes were made.",
+		"Kept the current implementation. No code/source/file/test changes were made.",
+		"Kept the current implementation. No code, source, or test changes were made.",
+		"No better current-scope change is needed.\n\nReason: I cannot identify a smaller safe change.",
+		"No better current-scope change is needed because I did not identify a smaller safe change.",
+		"No better current-scope change is needed; I did not identify a smaller safe change.",
+		"No better current-scope change is needed, since I did not identify a smaller safe change.",
+		"No better current-scope change is needed, I did not identify a smaller safe change.",
+		"No better current-scope change is needed, the current implementation does not require further edits.",
+		"No better current-scope change is needed; the current implementation does not require further edits.",
+		"No better current-scope change is needed, but the current implementation does not require further edits.",
+		"Kept the current implementation. No code changes were made.\n\nReason: this does not need a broader rewrite.",
+		"Kept the current implementation; I did not identify a smaller safe change. No code changes were made.",
+		"Kept the current implementation. No code changes were made, since I did not identify a smaller safe change.",
+		"Kept the current implementation. No code changes were made, I did not identify a smaller safe change.",
+		"Kept the current implementation, the current candidate does not need more work. No code changes were made.",
+		"Kept the current implementation; the current candidate does not need more work. No code changes were made.",
+		"Kept the current implementation because I did not identify a smaller safe change. No code changes were made.",
+		"Kept the current implementation. No code changes were made because I did not identify a smaller safe change.",
+	]) {
+		const result = evaluateCompletionMutationGuard({
+			agent: "worker",
+			task: implementationChallengeTask,
+			messages: [assistantText(report)],
+		});
 
-	assert.deepEqual(result, {
-		expectedMutation: true,
-		attemptedMutation: false,
-		triggered: false,
-	});
+		assert.deepEqual(result, {
+			expectedMutation: true,
+			attemptedMutation: false,
+			triggered: false,
+		});
+	}
+});
+
+test("implementation challenge reports require both a kept-current rationale and no-change statement", () => {
+	for (const report of [
+		"Kept the current implementation.",
+		"No new code or test changes were made in this challenge pass.",
+		"Kept the current implementation. No new code or test changes were made, but I am uncertain.",
+	]) {
+		assert.equal(evaluateCompletionMutationGuard({
+			agent: "worker",
+			task: implementationChallengeTask,
+			messages: [assistantText(report)],
+		}).triggered, true, report);
+	}
 });
 
 test("revived implementation tasks that mention implementation challenge remain guarded", () => {
@@ -87,19 +135,21 @@ test("implementation challenge reports with negated or uncertain no-better-chang
 	for (const report of [
 		"I cannot say no better current-scope change is needed.",
 		"The previous message said \"No better current-scope change is needed\", but I disagree.",
+		"The previous message said \"Kept the current implementation. No code changes were made\", but I disagree.",
+		"The previous message said \"Kept the current implementation. No code changes were made\", but that was wrong.",
+		"The previous message said \"Kept the current implementation. No code changes were made\", but that was false.",
+		"The previous message said \"Kept the current implementation. No code changes were made\", but I reject that.",
+		"The previous message said \"Kept the current implementation. No code changes were made\". I reject that.",
+		"The previous message said \"Kept the current implementation. No code changes were made\". I reject this.",
+		"The previous message said \"Kept the current implementation. No code changes were made\". I disagree.",
+		"The previous message said \"Kept the current implementation. No code changes were made\", but it was rejected.",
+		"The previous message said \"Kept the current implementation. No code changes were made\", but I am rejecting it.",
 		"The prior report stated no better current-scope change is needed.",
 		"I don't think no better current-scope change is needed.",
 		"I dont think no better current-scope change is needed.",
 		"I do not think no better current-scope change is needed.",
 		"I cant say no better current-scope change is needed.",
 		"It is unclear whether no better current-scope change is needed.",
-		"No better current-scope change is needed. I cannot confirm the rest.",
-		"No better current-scope change is needed. I don't confirm the rest.",
-		"No better current-scope change is needed. This isn't confirmed.",
-		"No better current-scope change is needed. I couldn't confirm the rest.",
-		"No better current-scope change is needed. It won't be confirmed.",
-		"No better current-scope change is needed. This is not confirmed.",
-		"No better current-scope change is needed. I am uncertain.",
 		"Maybe no better current-scope change is needed.",
 	]) {
 		assert.equal(evaluateCompletionMutationGuard({
@@ -109,14 +159,6 @@ test("implementation challenge reports with negated or uncertain no-better-chang
 		}).triggered, true, report);
 	}
 
-	assert.equal(evaluateCompletionMutationGuard({
-		agent: "worker",
-		task: implementationChallengeTask,
-		messages: [
-			assistantText("No better current-scope change is needed."),
-			assistantText("I cannot confirm the rest."),
-		],
-	}).triggered, true);
 });
 
 test("declared read-only builtin tools suppress implementation-word false positives", () => {

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -74,6 +74,9 @@ test("implementation challenges may complete with explicit no-change reports", (
 		"Kept the current implementation. No code, source, or test changes were made.",
 		"No better current-scope change is needed.\n\nReason: I cannot identify a smaller safe change.",
 		"No better current-scope change is needed because I did not identify a smaller safe change.",
+		"No better current-scope change is needed because no work remains.",
+		"No better current-scope change is needed. I haven't identified required changes.",
+		"No better current-scope change is needed. I haven’t identified required changes.",
 		"No better current-scope change is needed; I did not identify a smaller safe change.",
 		"No better current-scope change is needed, since I did not identify a smaller safe change.",
 		"No better current-scope change is needed, I did not identify a smaller safe change.",
@@ -117,18 +120,91 @@ test("implementation challenge reports require both a kept-current rationale and
 	}
 });
 
-test("revived implementation tasks that mention implementation challenge remain guarded", () => {
-	const result = evaluateCompletionMutationGuard({
-		agent: "worker",
-		task: revivedTask("Fix the implementation challenge completion guard bug."),
-		messages: [assistantText("No better current-scope change is needed.")],
-	});
+test("implementation challenge reports require current kept/no-change claims", () => {
+	for (const report of [
+		"The previous message said \"Kept the current implementation. No code changes were made\".",
+		"The prior report stated Kept the current implementation. No code changes were made.",
+		"The previous message said \"Kept the current implementation. No code changes were made\". Kept the current implementation.",
+		"'Kept the current implementation. No code changes were made.'",
+	]) {
+		assert.equal(evaluateCompletionMutationGuard({
+			agent: "worker",
+			task: implementationChallengeTask,
+			messages: [assistantText(report)],
+		}).triggered, true, report);
+	}
+});
 
-	assert.deepEqual(result, {
-		expectedMutation: true,
-		attemptedMutation: false,
-		triggered: true,
-	});
+test("implementation challenge reports with later implementation retractions remain guarded", () => {
+	for (const report of [
+		"No better current-scope change is needed. I found a required code change.",
+		"Kept the current implementation. No code changes were made. Implementation work remains.",
+		"No better current-scope change is needed. A code change is needed.",
+		"Kept the current implementation. No code changes were made. I need to implement the fix.",
+		"No better current-scope change is needed, but I found a required code change.",
+		"No better current-scope change is needed\nI found a required code change.",
+		"No better current-scope change is needed. I found required changes.",
+		"No better current-scope change is needed. Code changes are needed.",
+		"No better current-scope change is needed. Changes are needed.",
+		"No better current-scope change is needed because no work remains. Code changes are needed.",
+		"No better current-scope change is needed. I need changes.",
+		"No better current-scope change is needed. We need edits.",
+		"Kept the current implementation. No code changes were made. I need changes.",
+		"Kept the current implementation. No code changes were made. We need patches.",
+		"No better current-scope change is needed. That claim is rejected.",
+		"No better current-scope change is needed. This report is retracted.",
+		"No better current-scope change is needed. Required changes.",
+		"No better current-scope change is needed. Need changes.",
+		"No better current-scope change is needed, I disagree.",
+		"No better current-scope change is needed; I disagree.",
+		"Kept the current implementation. No code changes were made, I reject.",
+		"Kept the current implementation. No code changes were made; I reject.",
+		"No better current-scope change is needed: I disagree.",
+		"No better current-scope change is needed — I disagree.",
+		"No better current-scope change is needed. \"I reject.\"",
+		"No better current-scope change is needed. 'I reject.'",
+		"No better current-scope change is needed. ‘I reject.’",
+		"Kept the current implementation. No code changes were made: I reject.",
+		"Kept the current implementation. No code changes were made. \"I retract.\"",
+		"No better current-scope change is needed. I disagree.",
+		"No better current-scope change is needed. I reject.",
+		"No better current-scope change is needed. I retract.",
+		"Kept the current implementation. No code changes were made. I disagree.",
+		"Kept the current implementation. No code changes were made. I reject.",
+		"Kept the current implementation. No code changes were made. I retract.",
+		"No better current-scope change is needed. I disagree with that.",
+		"No better current-scope change is needed. I retract that.",
+		"No better current-scope change is needed. I reject that.",
+		"Kept the current implementation. No code changes were made. I disagree with that.",
+		"Kept the current implementation. No code changes were made. I retract that.",
+		"Kept the current implementation. No code changes were made. I reject that.",
+	]) {
+		assert.equal(evaluateCompletionMutationGuard({
+			agent: "worker",
+			task: implementationChallengeTask,
+			messages: [assistantText(report)],
+		}).triggered, true, report);
+	}
+});
+
+test("revived implementation tasks that mention implementation challenge remain guarded", () => {
+	for (const followUp of [
+		"Fix the implementation challenge completion guard bug.",
+		"Implementation challenge pass 1. Implement the required fix.",
+		"Implementation challenge pass 1 and implement the fix.",
+	]) {
+		const result = evaluateCompletionMutationGuard({
+			agent: "worker",
+			task: revivedTask(followUp),
+			messages: [assistantText("No better current-scope change is needed.")],
+		});
+
+		assert.deepEqual(result, {
+			expectedMutation: true,
+			attemptedMutation: false,
+			triggered: true,
+		}, followUp);
+	}
 });
 
 test("implementation challenge reports with negated or uncertain no-better-change claims remain guarded", () => {


### PR DESCRIPTION
Fixes #1110.

No-edit retained-writer challenge reports are now delivered as successful results only when they clearly keep the current implementation and do not later retract that claim.

The guard keeps these boundaries intact:
- challenge follow-ups must match known implementation-challenge shapes before no-edit reports can succeed;
- current no-change claims must be unquoted and unreported;
- post-claim separators such as punctuation, dashes, whitespace, and quotes cannot hide direct reversals;
- direct reject/retract/disagree and work-needed reversals stay guarded;
- valid rationale negations, including contracted negations and no-work-remains rationale, still pass.

Validation:
- `test/unit/completion-guard.test.ts`
- focused async implementation-challenge integration test
- direct edge probes for current claims, quoted/reported claims, rationale negations, separator-normalized reversals, passive reversals, bare work-needed reversals, and mandatory challenge follow-ups
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Review gate:
- Fresh exact-head reviews through `ba6584b` found no issues after the Greptile and current-claim fixes.

Credit:
- The changelog now also credits @Don-Yin for #1122, whose long-session-id PR is superseded by the #1121 behavior now on `main`.
