### PR TITLE
fix: diagnose duplicate child extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Remove the native generic `intercom` compatibility fallback from supervisor coordination while preserving `contact_supervisor`, `subagent_supervisor`, and external `intercom` providers. Thanks to @jaudiger for #1107.
+- Report an actionable project-settings override when duplicate ambient Pi extensions prevent a child from starting (#1114).
 - Keep the FleetView overlay refreshed while open and count active leaf agents in the compact summary. Thanks to @Don-Yin for #1108.
 - Keep user-requested foreground detaches from showing supervisor-response recovery guidance. Thanks to @Lewis-E for #1109.
 - Reject configured subagent models that are not in the active host model registry before spawning a child, instead of forwarding an invalid `--model` argument to Pi. Thanks to @DresvyanskiyDenis for #1093.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -85,6 +85,7 @@ import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDi
 import { formatModelAttemptNote, isRetryableModelFailure } from "../shared/model-fallback.ts";
 import {
 	SUBAGENT_STARTUP_RETRY_DELAYS_MS,
+	formatSubagentExtensionConflictError,
 	formatSubagentStartupRetryExhaustedError,
 	formatSubagentStartupRetryNote,
 	isRetryableSubagentStartupFailure,
@@ -1606,15 +1607,21 @@ async function runSingleStep(
 			stopped: run.stopped,
 			turnBudgetExceeded: run.turnBudgetExceeded,
 		})) ? formatProcessSignalError(run.processSignal!) : undefined;
-		const error = toolAvailabilityError
-			?? completionGuardError
-			?? structuredError
-			?? emptyOutputError
-			?? (hiddenError?.hasError
-				? hiddenError.details
-					? `${hiddenError.errorType} failed (exit ${effectiveExitCode}): ${hiddenError.details}`
-					: `${hiddenError.errorType} failed with exit code ${effectiveExitCode}`
-				: run.error || signalError || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined));
+		const error = formatSubagentExtensionConflictError(
+			toolAvailabilityError
+				?? completionGuardError
+				?? structuredError
+				?? emptyOutputError
+				?? (hiddenError?.hasError
+					? hiddenError.details
+						? `${hiddenError.errorType} failed (exit ${effectiveExitCode}): ${hiddenError.details}`
+						: `${hiddenError.errorType} failed with exit code ${effectiveExitCode}`
+					: run.error || signalError || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined)),
+			{
+				agent: step.agent,
+				ambientExtensionsEnabled: launchResolvedExtensions?.disableAmbientExtensions === false,
+			},
+		);
 		const attempt: ModelAttempt = omitUndefinedProperties({
 			model: candidate ?? run.model ?? step.model ?? "default",
 			success: effectiveExitCode === 0 && !error,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -76,6 +76,7 @@ import {
 } from "../shared/model-fallback.ts";
 import {
 	SUBAGENT_STARTUP_RETRY_DELAYS_MS,
+	formatSubagentExtensionConflictError,
 	formatSubagentStartupRetryExhaustedError,
 	formatSubagentStartupRetryNote,
 	isRetryableSubagentStartupFailure,
@@ -1347,6 +1348,10 @@ async function runSingleAttempt(
 		};
 		return result;
 	}
+	result.error = formatSubagentExtensionConflictError(result.error, {
+		agent: agent.name,
+		ambientExtensionsEnabled: !launchResolvedExtensions.disableAmbientExtensions,
+	});
 	if (result.error && result.exitCode === 0) {
 		result.exitCode = 1;
 	}

--- a/src/runs/shared/subagent-startup-retry.ts
+++ b/src/runs/shared/subagent-startup-retry.ts
@@ -12,6 +12,7 @@ export const SUBAGENT_STARTUP_RETRY_DELAYS_MS = [250, 750, 1500] as const;
 export const MAX_SUBAGENT_STARTUP_FAILURE_DURATION_MS = 2000;
 
 const SIGKILL_PROCESS_SIGNAL_ERROR = formatProcessSignalError("SIGKILL");
+const EXTENSION_REGISTRATION_CONFLICT_PATTERN = /Failed to load extension\b[^\n]*:\s*(?:Tool|Flag)\s+"[^"]+"\s+conflicts with\b/i;
 
 export interface SubagentStartupFailureEvidence {
 	exitCode: number | null | undefined;
@@ -29,6 +30,17 @@ export interface SubagentStartupFailureEvidence {
 	timedOut?: boolean;
 	stopped?: boolean;
 	turnBudgetExceeded?: boolean;
+}
+
+export function formatSubagentExtensionConflictError(
+	error: string | undefined,
+	input: { agent: string; ambientExtensionsEnabled: boolean },
+): string | undefined {
+	if (!error || !input.ambientExtensionsEnabled || !EXTENSION_REGISTRATION_CONFLICT_PATTERN.test(error)) return error;
+	const settings = JSON.stringify({
+		subagents: { agentOverrides: { [input.agent]: { extensions: [] } } },
+	});
+	return `${error}\n\nSubagent startup loaded conflicting ambient Pi extensions. Retry this run after disabling ambient extension discovery for agent ${JSON.stringify(input.agent)} in project .pi/settings.json: ${settings}. Replace the empty array with only the required extension entry paths when this agent needs extension tools.`;
 }
 
 function hasUsage(usage: Usage): boolean {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -568,6 +568,19 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(status.steps?.[0]?.error, "Detached for intercom coordination before task completion.");
 	});
 
+	it("persists actionable guidance for ambient extension registration conflicts", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			exitCode: 1,
+			stderr: 'Error: Failed to load extension "/tmp/pi-mcp-adapter-clone/index.ts": Flag "--mcp-config" conflicts with /tmp/pi-mcp-adapter/index.ts',
+		});
+		const id = `async-extension-conflict-${Date.now().toString(36)}`;
+		launchProtocolTest(id);
+		const payload = await readAsyncPayload(id);
+		assert.equal(payload.success, false);
+		assert.match(payload.results[0]?.error ?? "", /loaded conflicting ambient Pi extensions/);
+		assert.match(payload.results[0]?.error ?? "", /"worker":\{"extensions":\[\]\}/);
+	});
+
 	it("persists absent output provenance when async lifecycle text is synthetic", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ jsonl: [mockAssistantMessage("", "tool_use")], stderr: "mock child failure", exitCode: 1 });
 		const id = `async-output-absent-${Date.now().toString(36)}`;

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -6359,6 +6359,20 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(firstDetachResponse, true);
 	});
 
+	it("returns actionable guidance for ambient extension registration conflicts", async () => {
+		mockPi.onCall({
+			exitCode: 1,
+			stderr: 'Error: Failed to load extension "/tmp/pi-mcp-adapter-clone/index.ts": Tool "mcpScript" conflicts with /tmp/pi-mcp-adapter/index.ts',
+		});
+		const agents = makeAgentConfigs(["echo"]);
+
+		const result = await runSync(tempDir, agents, "echo", "Task", {});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /loaded conflicting ambient Pi extensions/);
+		assert.match(result.error ?? "", /"echo":\{"extensions":\[\]\}/);
+	});
+
 	it("handles stderr without exit code as info (not error)", async () => {
 		mockPi.onCall({ output: "Success", stderr: "Warning: something", exitCode: 0 });
 		const agents = makeAgentConfigs(["echo"]);

--- a/test/unit/subagent-startup-retry.test.ts
+++ b/test/unit/subagent-startup-retry.test.ts
@@ -4,6 +4,7 @@ import type { Usage } from "../../src/shared/types.ts";
 import {
 	MAX_SUBAGENT_STARTUP_FAILURE_DURATION_MS,
 	SUBAGENT_STARTUP_RETRY_DELAYS_MS,
+	formatSubagentExtensionConflictError,
 	formatSubagentStartupRetryExhaustedError,
 	formatSubagentStartupRetryNote,
 	isRetryableSubagentStartupFailure,
@@ -67,6 +68,20 @@ describe("subagent startup retry", () => {
 		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ timedOut: true })), false);
 		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ stopped: true })), false);
 		assert.equal(isRetryableSubagentStartupFailure(startupFailure({ turnBudgetExceeded: true })), false);
+	});
+
+	it("adds actionable guidance for ambient extension registration conflicts", () => {
+		const conflict = 'Error: Failed to load extension "/tmp/pi-mcp-adapter-clone/index.ts": Tool "mcpScript" conflicts with /tmp/pi-mcp-adapter/index.ts\nError: Failed to load extension "/tmp/pi-mcp-adapter-clone/index.ts": Flag "--mcp-config" conflicts with /tmp/pi-mcp-adapter/index.ts';
+		const formatted = formatSubagentExtensionConflictError(conflict, {
+			agent: "reviewer",
+			ambientExtensionsEnabled: true,
+		});
+
+		assert.match(formatted ?? "", /loaded conflicting ambient Pi extensions/);
+		assert.match(formatted ?? "", /\.pi\/settings\.json/);
+		assert.match(formatted ?? "", /\{"subagents":\{"agentOverrides":\{"reviewer":\{"extensions":\[\]\}\}\}\}/);
+		assert.equal(formatSubagentExtensionConflictError(conflict, { agent: "reviewer", ambientExtensionsEnabled: false }), conflict);
+		assert.equal(formatSubagentExtensionConflictError("authentication failed", { agent: "reviewer", ambientExtensionsEnabled: true }), "authentication failed");
 	});
 
 	it("formats retry and exhaustion diagnostics without task content", () => {


### PR DESCRIPTION
Fixes #1114.

When a child process fails before its first model turn because ambient Pi extensions register duplicate tools or flags, the failure now keeps Pi's original conflict error and adds an actionable `subagents.agentOverrides` fix.

The diagnostic suggests disabling ambient extensions for the affected agent with `extensions: []`, or using a non-empty extension allowlist when that agent needs specific extension entry points. It does not silently retry without ambient extensions.

Validation at `e165f6d`:
- `test/unit/subagent-startup-retry.test.ts`
- focused foreground ambient-conflict integration test
- focused async ambient-conflict integration test
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Review gate:
- Fresh exact-head review at `ead07bf` found no issues.
