### PR TITLE
fix: bound external-run sessionId like a path, not a short identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Keep FleetView working when a session file path is longer than a short identity, instead of failing external-job inspection on every poll. Thanks to @albertgwo for #1114.
+
 ### Added
 - Show caller-owned external jobs in FleetView through a bounded push/cache API, without polling or exposing managed controls. Thanks to @ssyram for #1083.
 - Add a bounded current-status snapshot for async runs in RPC surfaces, without replaying terminal history. Thanks to @yanqianglu for #1078.

--- a/src/api/external-runs.ts
+++ b/src/api/external-runs.ts
@@ -7,6 +7,11 @@ export const EXTERNAL_RUN_LIMITS = {
 	maxCachedRuns: 100,
 	maxSnapshotRuns: 20,
 	maxIdentityLength: 160,
+	/**
+	 * A Pi session id is the session file path, which routinely exceeds a short
+	 * identity budget in nested worktrees, so it is bounded like the other paths.
+	 */
+	maxSessionIdLength: 4_096,
 	maxTextLength: 160,
 	maxPreviewLength: 4_096,
 	maxPathLength: 4_096,
@@ -82,9 +87,9 @@ function inputObject(value: unknown, field: string, allowed: Set<string>): Recor
 	return input;
 }
 
-function identity(value: unknown, field: string): string {
+function identity(value: unknown, field: string, maxLength: number = EXTERNAL_RUN_LIMITS.maxIdentityLength): string {
 	if (typeof value !== "string" || value.length === 0 || value.trim() !== value || value.includes("\0")) throw new Error(`${field} must be a non-empty trimmed string without NUL characters.`);
-	if (value.length > EXTERNAL_RUN_LIMITS.maxIdentityLength) throw new Error(`${field} must be at most ${EXTERNAL_RUN_LIMITS.maxIdentityLength} characters.`);
+	if (value.length > maxLength) throw new Error(`${field} must be at most ${maxLength} characters.`);
 	const safe = sanitizeDisplayText(value);
 	if (!safe || safe !== value) throw new Error(`${field} must contain only display-safe text.`);
 	return value;
@@ -119,7 +124,7 @@ function validateRun(value: unknown): ExternalRun {
 	const transcriptPath = displayText(run.transcriptPath, "External run transcriptPath", EXTERNAL_RUN_LIMITS.maxPathLength);
 	return {
 		id: identity(run.id, "External run id"),
-		sessionId: identity(run.sessionId, "External run sessionId"),
+		sessionId: identity(run.sessionId, "External run sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength),
 		source: displayText(run.source, "External run source", EXTERNAL_RUN_LIMITS.maxTextLength, true)!,
 		label: displayText(run.label, "External run label", EXTERNAL_RUN_LIMITS.maxTextLength, true)!,
 		state: state(run.state, "External run state"),
@@ -181,7 +186,7 @@ function getErrorMessage(error: unknown): string {
 
 /** Read a bounded cached snapshot for one Pi session. This never invokes third-party code. */
 export function snapshotExternalRuns(sessionId: string, options: ExternalRunSnapshotOptions = {}): readonly ExternalRun[] {
-	const safeSessionId = identity(sessionId, "External-run snapshot sessionId");
+	const safeSessionId = identity(sessionId, "External-run snapshot sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength);
 	const current = registry();
 	const runs: ExternalRun[] = [];
 	for (const [cacheKey, value] of current.runs.entries()) {


### PR DESCRIPTION
## Summary
- bound external-run `sessionId` with its own path-sized limit instead of the 160-character identity budget
- keep every other identity guarantee for it: non-empty, trimmed, NUL-free, and display-safe

FleetView fails to inspect external jobs on every poll when the session file path is long:

```
[pi-subagents] Failed to inspect external jobs: External-run snapshot sessionId must be at most 160 characters.
[pi-subagents] Failed to inspect external jobs: External-run snapshot sessionId must be at most 160 characters.
```

A Pi session id is the session file path, since `resolveCurrentSessionId` prefers `getSessionFile()`, and `fleet-status.ts` passes `state.currentSessionId` straight into `snapshotExternalRuns`. `validateRun` and `snapshotExternalRuns` checked it with `maxIdentityLength` (160) while validating `reportPath` and `transcriptPath` with `maxPathLength` (4096), so any sufficiently nested session exceeded the cap.

This is the normal case rather than an edge case: on the reporting machine 888 of 1500 session files exceed 160 characters, the longest at 190, driven by worktree paths such as `.../--Users-albert-Work-recora-health-back-end-.worktrees-avi-303-phase-c-apps-worldbuilder--/...`. The effect is that external jobs never appear, and because the warning prints while the TUI is drawing, it also interleaves with the live display.

## Validation
- `npm run typecheck`
- `npm run test:unit` (1988 pass, 2 skip). The single failure, `watchdog-lsp-diagnostics` "returns a failed result for malformed language-server JSON", is a known pre-existing flake under full-suite load that passes in isolation and reproduces on clean `main`.
- external-runs and fleet unit tests (77 pass)
- harness using the real 190-character path: `registerExternalRun` and `snapshotExternalRuns` both succeed and the run is visible, while a NUL-bearing id is still rejected
