### PR TITLE
Fix fleet warnings for long Pi session IDs

### DIFF
--- a/src/api/external-runs.ts
+++ b/src/api/external-runs.ts
@@ -7,6 +7,7 @@ export const EXTERNAL_RUN_LIMITS = {
 	maxCachedRuns: 100,
 	maxSnapshotRuns: 20,
 	maxIdentityLength: 160,
+	maxSessionIdLength: 4_096,
 	maxTextLength: 160,
 	maxPreviewLength: 4_096,
 	maxPathLength: 4_096,
@@ -82,12 +83,16 @@ function inputObject(value: unknown, field: string, allowed: Set<string>): Recor
 	return input;
 }
 
-function identity(value: unknown, field: string): string {
+function identity(value: unknown, field: string, maxLength: number = EXTERNAL_RUN_LIMITS.maxIdentityLength): string {
 	if (typeof value !== "string" || value.length === 0 || value.trim() !== value || value.includes("\0")) throw new Error(`${field} must be a non-empty trimmed string without NUL characters.`);
-	if (value.length > EXTERNAL_RUN_LIMITS.maxIdentityLength) throw new Error(`${field} must be at most ${EXTERNAL_RUN_LIMITS.maxIdentityLength} characters.`);
+	if (value.length > maxLength) throw new Error(`${field} must be at most ${maxLength} characters.`);
 	const safe = sanitizeDisplayText(value);
 	if (!safe || safe !== value) throw new Error(`${field} must contain only display-safe text.`);
 	return value;
+}
+
+function sessionIdentity(value: unknown, field: string): string {
+	return identity(value, field, EXTERNAL_RUN_LIMITS.maxSessionIdLength);
 }
 
 function displayText(value: unknown, field: string, maxLength: number, required = false): string | undefined {
@@ -119,7 +124,7 @@ function validateRun(value: unknown): ExternalRun {
 	const transcriptPath = displayText(run.transcriptPath, "External run transcriptPath", EXTERNAL_RUN_LIMITS.maxPathLength);
 	return {
 		id: identity(run.id, "External run id"),
-		sessionId: identity(run.sessionId, "External run sessionId"),
+		sessionId: sessionIdentity(run.sessionId, "External run sessionId"),
 		source: displayText(run.source, "External run source", EXTERNAL_RUN_LIMITS.maxTextLength, true)!,
 		label: displayText(run.label, "External run label", EXTERNAL_RUN_LIMITS.maxTextLength, true)!,
 		state: state(run.state, "External run state"),
@@ -154,7 +159,7 @@ export function registerExternalRun(input: ExternalRun): ExternalRun {
 
 /** Update display fields for a registered external job without changing its identity or owner. */
 export function updateExternalRun(sessionId: string, id: string, update: ExternalRunUpdate): ExternalRun {
-	const safeSessionId = identity(sessionId, "External run sessionId");
+	const safeSessionId = sessionIdentity(sessionId, "External run sessionId");
 	const safeId = identity(id, "External run id");
 	const patch = inputObject(update, "External run update", UPDATE_FIELDS);
 	const current = registry();
@@ -168,7 +173,7 @@ export function updateExternalRun(sessionId: string, id: string, update: Externa
 
 /** Remove a cached external job. The caller remains responsible for its process and artifacts. */
 export function unregisterExternalRun(sessionId: string, id: string): boolean {
-	return registry().runs.delete(key(identity(sessionId, "External run sessionId"), identity(id, "External run id")));
+	return registry().runs.delete(key(sessionIdentity(sessionId, "External run sessionId"), identity(id, "External run id")));
 }
 
 function snapshotBytes(runs: readonly ExternalRun[]): number {
@@ -181,7 +186,7 @@ function getErrorMessage(error: unknown): string {
 
 /** Read a bounded cached snapshot for one Pi session. This never invokes third-party code. */
 export function snapshotExternalRuns(sessionId: string, options: ExternalRunSnapshotOptions = {}): readonly ExternalRun[] {
-	const safeSessionId = identity(sessionId, "External-run snapshot sessionId");
+	const safeSessionId = sessionIdentity(sessionId, "External-run snapshot sessionId");
 	const current = registry();
 	const runs: ExternalRun[] = [];
 	for (const [cacheKey, value] of current.runs.entries()) {

--- a/test/unit/external-runs.test.ts
+++ b/test/unit/external-runs.test.ts
@@ -61,6 +61,52 @@ test("external runs register, update, list, and unregister cached display record
 	clearRegistry();
 });
 
+test("long Pi session IDs work across register, snapshot, update, and unregister", () => {
+	clearRegistry();
+	const sessionId = `session-${"nested/".repeat(30)}`;
+	assert.ok(sessionId.length > EXTERNAL_RUN_LIMITS.maxIdentityLength);
+	assert.equal(registerExternalRun({
+		id: "long-session-run",
+		sessionId,
+		source: "tool",
+		label: "Long session",
+		state: "running",
+		startedAt: 1,
+	}).sessionId, sessionId);
+	assert.deepEqual(snapshotExternalRuns(sessionId).map((run) => run.id), ["long-session-run"]);
+	assert.equal(updateExternalRun(sessionId, "long-session-run", { currentAction: "Still running" }).currentAction, "Still running");
+	assert.equal(unregisterExternalRun(sessionId, "long-session-run"), true);
+	assert.deepEqual(snapshotExternalRuns(sessionId), []);
+	clearRegistry();
+});
+
+test("session and external-run IDs retain bounded display-safe validation", () => {
+	clearRegistry();
+	const input = {
+		id: "run",
+		sessionId: "session-a",
+		source: "tool",
+		label: "Validation",
+		state: "running" as const,
+		startedAt: 1,
+	};
+	assert.throws(
+		() => registerExternalRun({ ...input, id: "r".repeat(EXTERNAL_RUN_LIMITS.maxIdentityLength + 1) }),
+		/External run id must be at most 160 characters/,
+	);
+	assert.throws(
+		() => snapshotExternalRuns("s".repeat(EXTERNAL_RUN_LIMITS.maxSessionIdLength + 1)),
+		/External-run snapshot sessionId must be at most 4096 characters/,
+	);
+	for (const malformed of [" session-a", "session-a ", "session\n-a", "session\0-a"]) {
+		assert.throws(() => snapshotExternalRuns(malformed), /trimmed string without NUL|display-safe/);
+		assert.throws(() => registerExternalRun({ ...input, sessionId: malformed }), /trimmed string without NUL|display-safe/);
+		assert.throws(() => updateExternalRun(malformed, "run", {}), /trimmed string without NUL|display-safe/);
+		assert.throws(() => unregisterExternalRun(malformed, "run"), /trimmed string without NUL|display-safe/);
+	}
+	clearRegistry();
+});
+
 test("external run validation is atomic and display text is bounded", () => {
 	clearRegistry();
 	registerExternalRun({


### PR DESCRIPTION
## Summary
- allow Pi session IDs longer than the external-run ID limit while keeping them bounded at 4096 characters
- apply the same session-ID validation to register, update, snapshot, and unregister operations
- preserve trimmed, NUL-free, display-safe validation and the existing 160-character external run ID limit
- add focused tests for long valid session IDs and malformed/over-limit identifiers

## Validation
- `node --experimental-strip-types --test test/unit/external-runs.test.ts` (passes)
- `npm run typecheck` (passes)
- engine baseline `npm test -- --runInBand` (passes: 2001 passed, 3 skipped)
- `npm run test:all` (unit suite passes; integration suite has one unrelated existing 30-second timeout in `routes registered structured text delegation through the concurrent executor`, reporting 802 passed / 1 failed)

<!-- agent-candidate-manifest:v2
{
  "candidate": {
    "branch": "agent/20260815-001856-61965-fix-long-external-session-id",
    "commit": "605da82b63c4f75b20edb30b766778f132b5a157"
  },
  "checks": {
    "required": [
      "baseline"
    ],
    "results": [
      {
        "command_digest": "7459ef7bc992b60b1c10678c6e53375dbdfe8b737ea1fb3178f68d7531745e2e",
        "duration_ms": 28872,
        "engine_digest": "12532fcdc315ea8399a9e3a9f6dcf3947a0b93937d6bab0bf44775ffc5d7ae8b",
        "engine_version": 2,
        "environment_fingerprint": {
          "git": "git version 2.50.1 (Apple Git-155)",
          "machine": "arm64",
          "platform": "darwin",
          "python": "3.14.6"
        },
        "exit_code": 0,
        "id": "baseline",
        "output_digest": "5f14b14c2407ad90880e116e73a35d1df7b8e1731ac8c13307002a7e5686b3d2",
        "policy_commit": "a4a91788326dcde8dc50855dbe3ab447e5707473",
        "policy_digest": "7e5727a5ab5fe777f7303f9ec07e19525ec4946d98a79ea6459d0f60b7497a4d",
        "reused": false,
        "status": "passed",
        "subject_commit": "605da82b63c4f75b20edb30b766778f132b5a157",
        "tooling_digest": "2c585b505284a6dd0a1285c26d532da6f22ebd17b72e198d32c5df2a7c1f537b"
      }
    ]
  },
  "dependencies": [],
  "diff": {
    "changed_paths": [
      {
        "new_path": "src/api/external-runs.ts",
        "old_path": "src/api/external-runs.ts",
        "status": "M"
      },
      {
        "new_path": "test/unit/external-runs.test.ts",
        "old_path": "test/unit/external-runs.test.ts",
        "status": "M"
      }
    ]
  },
  "known_omissions": [],
  "manifest_digest": "7bd41b1904782d123b7296d5d9b70f27efb0528bb1f1ea43fd7ac55f49e74254",
  "policy": {
    "check_source": "derived",
    "config": {
      "attention_rules": [
        {
          "classification": "review",
          "id": "global-build-or-ci",
          "paths": [
            ".github/**",
            "Cargo.toml",
            "Cargo.lock",
            "package.json",
            "package-lock.json",
            "pyproject.toml",
            "uv.lock",
            "poetry.lock",
            "Makefile",
            "justfile"
          ]
        }
      ],
      "checks": {
        "baseline": {
          "argv": [
            "npm",
            "test",
            "--",
            "--runInBand"
          ],
          "outputs": [
            "coverage"
          ],
          "timeout_seconds": 240,
          "trusted_paths": [
            "package.json",
            "package-lock.json",
            "npm-shrinkwrap.json"
          ]
        }
      },
      "environment_fingerprint": [
        "platform",
        "machine",
        "python",
        "git"
      ],
      "environment_incompatibilities": [],
      "fast_gate": [
        "baseline"
      ],
      "max_fast_gate_seconds": 240,
      "ownership_areas": [
        {
          "id": "repository",
          "paths": [
            "**"
          ],
          "required_checks": [
            "baseline"
          ],
          "risk": "normal"
        }
      ],
      "remote": "origin",
      "schema_version": 1,
      "target_branch": "main",
      "trusted_tool_paths": []
    },
    "derivation_version": 1,
    "engine": {
      "digest": "12532fcdc315ea8399a9e3a9f6dcf3947a0b93937d6bab0bf44775ffc5d7ae8b",
      "version": 2
    },
    "evidence": [
      "package.json"
    ],
    "policy_digest": "7e5727a5ab5fe777f7303f9ec07e19525ec4946d98a79ea6459d0f60b7497a4d",
    "schema_version": 2,
    "target": {
      "branch": "main",
      "frozen_base": "a4a91788326dcde8dc50855dbe3ab447e5707473",
      "remote": "origin"
    }
  },
  "schema_version": 2,
  "scope": {
    "affected_ownership_areas": [
      "repository"
    ],
    "attention_triggers": [],
    "declared_no_touch_paths": [],
    "declared_writable_paths": [
      "src/api/external-runs.ts",
      "test/unit/external-runs.test.ts"
    ]
  },
  "target": {
    "branch": "main",
    "frozen_base": "a4a91788326dcde8dc50855dbe3ab447e5707473",
    "remote": "origin"
  },
  "task": {
    "id": "fix-long-external-session-id",
    "invocation_id": "20260815-001856-61965",
    "issue": null,
    "summary": "Allow bounded long Pi session IDs in external-run registry operations while retaining display-safe validation."
  }
}

agent-candidate-manifest:end -->
