### PR TITLE
fix: preserve structured single output intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add an optional `foregroundDetachShortcut` binding and show it in the running single-subagent card, so foreground work can be moved to the background without editing package source. Thanks to @Lewis-E for #1097.
 
 ### Fixed
+- Keep structured single-child runs from overriding output paths in the task, while preserving explicit and agent-configured outputs. Thanks to @pasemes for #1119.
 - Remove the native generic `intercom` compatibility fallback from supervisor coordination while preserving `contact_supervisor`, `subagent_supervisor`, and external `intercom` providers. Thanks to @jaudiger for #1107.
 - Report an actionable project-settings override when duplicate ambient Pi extensions prevent a child from starting (#1114).
 - Keep the FleetView overlay refreshed while open and count active leaf agents in the compact summary. Thanks to @Don-Yin for #1108.

--- a/src/extension/public-execution.ts
+++ b/src/extension/public-execution.ts
@@ -9,6 +9,7 @@ export interface PublicSubagentExecutionParams {
 	concurrency?: unknown;
 	chainDir?: unknown;
 	workflowScript?: unknown;
+	output?: unknown;
 	resume?: unknown;
 	clarify?: unknown;
 	runFanoutBudget?: unknown;
@@ -82,10 +83,11 @@ export function normalizePublicSubagentExecution<T extends PublicSubagentExecuti
 		if (params.task !== undefined && typeof params.task !== "string") {
 			return { ok: false, error: "Structured single-child task must be a string when provided.", mode: "workflow" };
 		}
-		const { agent: _agent, task: _task, ...workflowDefaults } = params;
+		const { agent: _agent, task: _task, output, ...workflowDefaults } = params;
 		const child = {
 			agent: params.agent.trim(),
 			...(params.task !== undefined ? { task: params.task } : {}),
+			output: output === undefined ? true : output,
 		};
 		return {
 			ok: true,

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -411,6 +411,41 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(JSON.stringify(result.details), /Converted structured single-child request/);
 	});
 
+	it("does not override structured single output unless configured by the agent", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		for (const params of [
+			{ agent: "echo", task: "Use the task output path", async: false },
+			{ agent: "echo", task: "Disable file output", output: false, async: false },
+		] as const) {
+			mockPi.onCall({ output: "Structured child completed" });
+			const result = await makeExecutor([makeAgent("echo")]).executePublic(
+				"structured-single-output",
+				params,
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+
+			assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+			assert.doesNotMatch(readCallArgs().join("\n"), /This path is authoritative for this run/);
+		}
+
+		mockPi.onCall({ output: "Agent report" });
+		const configuredPath = path.join(tempDir, "agent-report.md");
+		const configured = await makeExecutor([makeAgent("echo", { output: configuredPath })]).executePublic(
+			"structured-single-agent-output",
+			{ agent: "echo", task: "Use agent output", async: false },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(configured.isError, undefined, configured.content[0]?.text ?? "workflow failed");
+		const configuredTask = readCallArgs().join("\n");
+		assert.match(configuredTask, new RegExp(escapeRegExp(configuredPath)));
+		assert.match(configuredTask, /This path is authoritative for this run/);
+		assert.equal(fs.readFileSync(configuredPath, "utf-8"), "Agent report");
+	});
+
 	it("reports a user-requested foreground detach without supervisor guidance", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ steps: [{ delay: 500, jsonl: [events.assistantMessage("completed after user detach")] }] });
 		const state: SubagentState = {

--- a/test/unit/public-execution.test.ts
+++ b/test/unit/public-execution.test.ts
@@ -11,13 +11,19 @@ describe("public subagent execution normalization", () => {
 			params: {
 				context: "fresh",
 				async: false,
-				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", ${JSON.stringify({ agent: "worker", task })})`,
+				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", ${JSON.stringify({ agent: "worker", task, output: true })})`,
 			},
 		});
 		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker" }), {
 			ok: true,
 			params: {
-				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker"})`,
+				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":true})`,
+			},
+		});
+		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker", output: false }), {
+			ok: true,
+			params: {
+				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":false})`,
 			},
 		});
 		assert.deepEqual(normalizePublicSubagentExecution({ action: " list " }), { ok: true, params: { action: "list" } });

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -452,7 +452,7 @@ describe("subagent extension RPC bridge", () => {
 		assert.equal(executedParams.agent, undefined);
 		assert.equal(executedParams.task, undefined);
 		assert.equal(executedParams.async, true);
-		assert.match(executedParams.workflowScript, /runs\.run\("main", \{"agent":"worker","task":"Do work"\}\)/);
+		assert.match(executedParams.workflowScript, /runs\.run\("main", \{"agent":"worker","task":"Do work","output":true\}\)/);
 		bridge.dispose();
 	});
 

--- a/test/unit/slash-bridge.test.ts
+++ b/test/unit/slash-bridge.test.ts
@@ -71,7 +71,7 @@ describe("slash subagent bridge requester context", () => {
           assert.equal(executedParams.agent, undefined);
           assert.equal(executedParams.task, undefined);
           assert.equal(executedParams.async, false);
-          assert.match(executedParams.workflowScript, /runs\.run\("main", \{"agent":"worker","task":"work"\}\)/);
+          assert.match(executedParams.workflowScript, /runs\.run\("main", \{"agent":"worker","task":"work","output":true\}\)/);
           resolve();
         } catch (error) {
           reject(error);


### PR DESCRIPTION
Fixes #1119.

Structured single-child calls now preserve the caller's output intent instead of inventing a workflow artifact path and appending an authoritative output instruction.

This keeps three cases separate:
- omitted `output` does not add a runtime output override;
- `output: false` remains disabled;
- agent frontmatter `output` still works when the caller omits `output`.

Native workflow default artifacts and resume behavior are unchanged.

Validation:
- `node --experimental-strip-types --test test/unit/public-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern "does not override structured single output" test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Review gate:
- Fresh exact-head review at `ab11ce3` found no issues.

Credit:
- Thanks to @pasemes for reporting and isolating #1119.
