### PR TITLE
fix: preserve Orca progress mirror under backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Keep Orca progress tabs from treating write-stream backpressure as mirror truncation.
 - Clarify retained-child resumability and native supervisor coordination guidance. Thanks to @ELA718 for #1126.
 - Stop advertising an `output-<index>.log` artifact in run transcripts when that file was never written, so workflow runs no longer point at a path that cannot exist. Thanks to @lbijeau for #1124.
 - Keep FleetView working when a session file path is longer than a short identity, instead of failing external-job inspection on every poll. Thanks to @albertgwo for #1121 and @Don-Yin for #1122.

--- a/src/api/external-runs.ts
+++ b/src/api/external-runs.ts
@@ -95,6 +95,8 @@ function identity(value: unknown, field: string, maxLength: number = EXTERNAL_RU
 	return value;
 }
 
+function displayText(value: unknown, field: string, maxLength: number): string | undefined;
+function displayText(value: unknown, field: string, maxLength: number, required: true): string;
 function displayText(value: unknown, field: string, maxLength: number, required = false): string | undefined {
 	if (value === undefined && !required) return undefined;
 	if (typeof value !== "string" || value.length === 0) throw new Error(`${field} must be a non-empty string.`);
@@ -103,6 +105,8 @@ function displayText(value: unknown, field: string, maxLength: number, required 
 	return truncateDisplayText(safe, maxLength);
 }
 
+function timestamp(value: unknown, field: string): number | undefined;
+function timestamp(value: unknown, field: string, required: true): number;
 function timestamp(value: unknown, field: string, required = false): number | undefined {
 	if (value === undefined && !required) return undefined;
 	if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0 || value > 8_640_000_000_000_000) throw new Error(`${field} must be a non-negative safe timestamp.`);
@@ -110,8 +114,8 @@ function timestamp(value: unknown, field: string, required = false): number | un
 }
 
 function state(value: unknown, field: string): ExternalRunState {
-	if (!["queued", "running", "completed", "failed", "stopped"].includes(value as string)) throw new Error(`${field} is invalid.`);
-	return value as ExternalRunState;
+	if (value === "queued" || value === "running" || value === "completed" || value === "failed" || value === "stopped") return value;
+	throw new Error(`${field} is invalid.`);
 }
 
 function validateRun(value: unknown): ExternalRun {
@@ -125,10 +129,10 @@ function validateRun(value: unknown): ExternalRun {
 	return {
 		id: identity(run.id, "External run id"),
 		sessionId: identity(run.sessionId, "External run sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength),
-		source: displayText(run.source, "External run source", EXTERNAL_RUN_LIMITS.maxTextLength, true)!,
-		label: displayText(run.label, "External run label", EXTERNAL_RUN_LIMITS.maxTextLength, true)!,
+		source: displayText(run.source, "External run source", EXTERNAL_RUN_LIMITS.maxTextLength, true),
+		label: displayText(run.label, "External run label", EXTERNAL_RUN_LIMITS.maxTextLength, true),
 		state: state(run.state, "External run state"),
-		startedAt: timestamp(run.startedAt, "External run startedAt", true)!,
+		startedAt: timestamp(run.startedAt, "External run startedAt", true),
 		...(updatedAt !== undefined ? { updatedAt } : {}),
 		...(endedAt !== undefined ? { endedAt } : {}),
 		...(currentAction ? { currentAction } : {}),

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -298,7 +298,7 @@ export function createOrcaProgressTab(input: {
 		}
 		scheduledBytes += bytes;
 		try {
-			if (!logStream.write(text)) truncated = true;
+			logStream.write(text);
 		} catch {
 			failObserver();
 		}

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -297,6 +297,30 @@ test("viewer strips split terminal control sequences across poll ticks", { skip:
 	assert.doesNotMatch(output, /\u001b|31m|secret|title|\u0000|\u0001|\r|\t|\u007f/);
 });
 
+test("mirror output keeps small writes that hit stream backpressure before the byte limit", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	const dir = tempDir();
+	const capture = path.join(dir, "capture.json");
+	const fakeOrca = writeCaptureOrca(dir);
+	const runId = `progress-backpressure-${Date.now()}`;
+	const tab = createOrcaProgressTab({
+		cwd: dir,
+		runId,
+		agent: "worker",
+		index: 0,
+		config: { enabled: true },
+		command: fakeOrca,
+		env: { ...process.env, ORCA_TEST_CAPTURE: capture },
+	});
+	assert.ok(tab);
+	for (let index = 0; index < 2_000; index++) tab.append(`line-${index.toString().padStart(4, "0")} ${"x".repeat(80)}\n`);
+	tab.finish("completed");
+	const log = progressFile(`${runId}-0-`, ".log");
+	await waitForFile(log.replace(/\.log$/, ".done"));
+	const text = fs.readFileSync(log, "utf-8");
+	assert.match(text, /line-1999/);
+	assert.doesNotMatch(text, /progress mirror truncated/);
+});
+
 test("mirror output truncates at a finite byte bound", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
 	const dir = tempDir();
 	const capture = path.join(dir, "capture.json");


### PR DESCRIPTION
This TS quality polish pass focuses on the current unreleased changes.

It fixes Orca progress tab mirroring so Node write-stream backpressure does not get reported as mirror truncation. The byte counter still enforces the existing 1 MiB mirror cap. It also tightens the external-run boundary helpers so required fields narrow through overloads instead of non-null assertions, and state validation uses literal narrowing.

Validation:
- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/external-runs.test.ts test/unit/orca-progress-tabs.test.ts`
- `npm run test:unit`
- Fresh-context review: no blocking findings
