### PR TITLE
fix: stop a promotion race from deleting a promoted async result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Stop a promotion race from deleting an already-promoted async result, and stop logging a failure when another session wins that race. Thanks to @albertgwo for #1130.
+
 ### Changed
 - Remove `prompts.render` from `workflowScript`; pass explicit task text to `runs.run` or use `/prompt-workflow` for reusable prompt templates.
 

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -198,11 +198,45 @@ export function promotePendingResultFile(resultsDir: string, sessionId: string, 
 	const pendingPath = resultPendingPath(resultsDir, sessionId, runId);
 	if (!existingResultFile(pendingPath)) return "none";
 	const resultPath = path.join(resultsDir, file);
+	// Concurrent sessions share this directory, so another watcher can promote the
+	// same pending file at any point below. Losing that race is expected; deleting
+	// the winner's promoted result is not.
+	const lostRace = (): "none" | "promoted" => {
+		if (existingResultFile(resultPath)) return "promoted";
+		if (options.logFailure !== false) console.error(`Pending async result '${pendingPath}' disappeared without a promoted result at '${resultPath}'.`);
+		return "none";
+	};
+	const finish = (): "promoted" | "pending" => existingResultFile(resultPath) ? "promoted" : "pending";
 	try {
-		fs.rmSync(resultPath, { force: true });
+		// Rename first. On POSIX this atomically replaces the destination, so a
+		// loser can never unlink the winner's freshly promoted result.
 		fs.renameSync(pendingPath, resultPath);
-		return existingResultFile(resultPath) ? "promoted" : "pending";
+		return finish();
 	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return lostRace();
+		if (code === "EEXIST" || code === "EPERM" || code === "EACCES") {
+			// Windows refuses to rename onto an existing file. A destination under
+			// this run id is that run's published result, so another promoter already
+			// won. Never delete it to force our own copy in; drop the now-redundant
+			// pending file instead, which keeps this path non-destructive.
+			if (existingResultFile(resultPath)) {
+				try {
+					fs.rmSync(pendingPath, { force: true });
+				} catch (cleanupError) {
+					if (options.logFailure !== false) console.error(`Failed to clear redundant pending async result '${pendingPath}':`, cleanupError);
+				}
+				return "promoted";
+			}
+			try {
+				fs.renameSync(pendingPath, resultPath);
+				return finish();
+			} catch (retryError) {
+				if ((retryError as NodeJS.ErrnoException).code === "ENOENT") return lostRace();
+				if (options.logFailure !== false) console.error(`Failed to promote pending async result '${pendingPath}' to '${resultPath}':`, retryError);
+				return "pending";
+			}
+		}
 		if (options.logFailure !== false) console.error(`Failed to promote pending async result '${pendingPath}' to '${resultPath}':`, error);
 		return "pending";
 	}


### PR DESCRIPTION
## Summary
- rename before removing, so the loser of a promotion race can no longer unlink the winner's freshly promoted result
- fall back to remove-then-rename only on the Windows errors that refuse an existing destination, and only while this call still owns a pending file
- treat a lost race as expected and silent when a promoted result is present, while still reporting the genuine anomaly where both the pending file and the promoted result are missing

Concurrent sessions share the async results directory, and `promotePendingResultFile` checked that the pending file existed and then did `rmSync(resultPath, { force: true })` before renaming. With two watchers this loses data: the winner promotes, the loser then removes the winner's destination and fails its own rename with `ENOENT`, so neither a pending nor a public result remains. The loser also logged a stack that reads like data loss:

```
Failed to promote pending async result
'.../result-pending/%2FUsers%2F.../<run>.json' to '.../<run>.json':
Error: ENOENT: no such file or directory, rename ...
    at promotePendingResultFile (src/runs/background/result-files.ts:203:8)
    at handleResult (src/runs/background/result-watcher.ts:304:27)
```

Renaming first fixes the destructive step, because POSIX `rename` atomically replaces the destination. The remove-then-rename path is kept for Windows, which refuses to rename onto an existing file, but it now runs only when this call still owns a pending file.

## Validation
- `npm run typecheck`
- `npm run test:unit` (2001 pass, 3 skip). The single failure, `watchdog-lsp-diagnostics` "returns a failed result for malformed language-server JSON", is a known pre-existing flake under full-suite load that passes in isolation and reproduces on clean `main`.
- result-files, result-watcher, and async-status tests (33 pass)
- harness replaying the exact interleaving: under the previous logic the winner's promoted result is deleted, and under this change it survives, the loser returns without logging, and a pending file that vanishes with no promoted result is still reported
