### PR TITLE
fix: preserve async result payload delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- Preserve a child's file-only report when its output path also names the workflow summary output.
+- Keep concurrent async result promotion from deleting a newer payload or another promoter's published result. Thanks to [@albertgwo](https://github.com/albertgwo) for #1130.
+
 ### Changed
 - Clarify that subagent reviews and gates should stay async unless foreground behavior is the actual requirement.
 - Remove `prompts.render` from `workflowScript`; pass explicit task text to `runs.run` or use `/prompt-workflow` for reusable prompt templates.

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -199,10 +199,23 @@ export function promotePendingResultFile(resultsDir: string, sessionId: string, 
 	if (!existingResultFile(pendingPath)) return "none";
 	const resultPath = path.join(resultsDir, file);
 	try {
-		fs.rmSync(resultPath, { force: true });
+		// POSIX rename replaces the destination atomically. Deleting it first lets a
+		// losing promoter unlink the result that another promoter just published.
 		fs.renameSync(pendingPath, resultPath);
 		return existingResultFile(resultPath) ? "promoted" : "pending";
 	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "EEXIST" || code === "EPERM" || code === "EACCES") {
+			const pendingExists = existingResultFile(pendingPath);
+			const resultExists = existingResultFile(resultPath);
+			if (pendingExists) {
+				if (!resultExists && options.logFailure !== false) console.error(`Failed to promote pending async result '${pendingPath}' to '${resultPath}':`, error);
+				return "pending";
+			}
+			if (resultExists) return "promoted";
+			if (options.logFailure !== false) console.error(`Pending async result '${pendingPath}' disappeared without a promoted result at '${resultPath}'.`);
+			return "none";
+		}
 		if (options.logFailure !== false) console.error(`Failed to promote pending async result '${pendingPath}' to '${resultPath}':`, error);
 		return "pending";
 	}

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -399,6 +399,10 @@ export function resultFilesForToolCall(resultsDir: string, toolCallId: string): 
 	return resultFilesFromIndexDir(resultsDir, toolCallIndexDir(resultsDir, toolCallId));
 }
 
+export function resultCandidateFilesForToolCall(resultsDir: string, toolCallId: string): string[] {
+	return resultFilesFromIndexDir(resultsDir, toolCallIndexDir(resultsDir, toolCallId), true);
+}
+
 export function missionObserverResultFiles(resultsDir: string): string[] {
 	return resultFilesFromIndexDir(resultsDir, observerIndexDir(resultsDir, MISSION_OBSERVER));
 }

--- a/src/runs/background/run-id-resolver.ts
+++ b/src/runs/background/run-id-resolver.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { DIRS, type SubagentState } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { findAsyncRunPrefixMatches, type AsyncRunLocation } from "./async-resume.ts";
-import { resultFilePath, resultFilesForToolCall } from "./result-files.ts";
+import { resultCandidateFilesForToolCall, resultFilePath, resultPayloadPathForIndexedRun } from "./result-files.ts";
 import { readActiveRunToolCallIndex } from "./active-run-index.ts";
 import { assertSafeNestedId, findNestedRunMatchesById, type NestedRoute, type NestedRunMatch, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 
@@ -21,11 +21,12 @@ export interface ResolveSubagentRunIdDeps {
 
 function exactAsyncLocation(id: string, asyncDirRoot: string, resultsDir: string): AsyncRunLocation | undefined {
 	const asyncDir = path.join(asyncDirRoot, id);
-	const resultPath = resultFilePath(resultsDir, id);
-	if (!fs.existsSync(asyncDir) && !fs.existsSync(resultPath)) return undefined;
+	const asyncDirExists = fs.existsSync(asyncDir);
+	const resultPath = resultPathFor(resultsDir, id);
+	if (!asyncDirExists && !resultPath) return undefined;
 	return {
-		asyncDir: fs.existsSync(asyncDir) ? asyncDir : null,
-		resultPath: fs.existsSync(resultPath) ? resultPath : null,
+		asyncDir: asyncDirExists ? asyncDir : null,
+		resultPath,
 		resolvedId: id,
 	};
 }
@@ -55,7 +56,7 @@ function readWorkflowResultIdentity(resultPath: string): WorkflowResultIdentity 
 }
 
 function resultPathFor(resultsDir: string, runId: string): string | null {
-	const resultPath = resultFilePath(resultsDir, runId);
+	const resultPath = resultPayloadPathForIndexedRun(resultsDir, runId) ?? resultFilePath(resultsDir, runId);
 	return fs.existsSync(resultPath) ? resultPath : null;
 }
 
@@ -72,11 +73,12 @@ function indexedToolCallIdAsyncLocations(toolCallId: string, asyncDirRoot: strin
 		const runId = status.runId || entry;
 		byId.set(runId, { asyncDir, resultPath: resultPathFor(resultsDir, runId), resolvedId: runId });
 	}
-	for (const entry of resultFilesForToolCall(resultsDir, toolCallId)) {
-		const resultPath = path.join(resultsDir, entry);
+	for (const entry of resultCandidateFilesForToolCall(resultsDir, toolCallId)) {
+		const runIdFromFile = entry.slice(0, -".json".length);
+		const resultPath = resultPayloadPathForIndexedRun(resultsDir, runIdFromFile) ?? path.join(resultsDir, entry);
 		const identity = readWorkflowResultIdentity(resultPath);
 		if (!identity || !toolCallIdMatches(identity.toolCallId, toolCallId)) continue;
-		const runId = identity.runId ?? identity.id ?? entry.slice(0, -".json".length);
+		const runId = identity.runId ?? identity.id ?? runIdFromFile;
 		const asyncDir = path.join(asyncDirRoot, runId);
 		byId.set(runId, { asyncDir: fs.existsSync(asyncDir) ? asyncDir : null, resultPath, resolvedId: runId });
 	}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3300,8 +3300,8 @@ function workflowChildDefaultOutput(aggregateOutputPath: string | undefined, art
 	return path.join(artifactsDir, "outputs", workflowRunId, `${workflowKey}.md`);
 }
 
-function writeWorkflowAggregateOutput(outputPath: string | undefined, text: string): string | undefined {
-	if (!outputPath) return undefined;
+function writeWorkflowAggregateOutput(outputPath: string | undefined, text: string, childOutputPaths: ReadonlyMap<string, string>): string | undefined {
+	if (!outputPath || childOutputPaths.has(outputPath)) return undefined;
 	try {
 		fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 		fs.writeFileSync(outputPath, text, "utf-8");
@@ -3358,7 +3358,6 @@ function workflowChildOutputClaims(input: {
 	for (const { key, params } of input.entries) {
 		const resolved = resolveWorkflowChildOutputPath({ ...input, key, params });
 		if (!resolved) continue;
-		if (input.aggregateOutputPath && resolved === input.aggregateOutputPath) return { error: `Workflow child '${key}' output resolves to the workflow aggregate output path: ${resolved}. Use a distinct child output path.` };
 		const previous = claims.get(resolved);
 		if (previous) return { error: `Workflow children '${previous}' and '${key}' resolve output to the same path: ${resolved}. Use distinct child output paths.` };
 		claims.set(resolved, key);
@@ -5220,7 +5219,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const returnPreview = formatWorkflowValue(workflow.value).slice(0, 1_000);
 						const emitPreview = workflow.emits.length > 0 ? ` Emitted: ${workflow.emits.map(formatWorkflowValue).join(", ").slice(0, 1_000)}` : "";
 						const summary = `Workflow completed with ${workflow.children.length} child run(s). Return: ${returnPreview}${emitPreview} Trace: ${workflow.trace.length} event(s).`;
-						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, summary);
+						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, summary, claimedOutputPaths);
 						const resultSummary = appendWorkflowOutputWarning(summary, outputWarning);
 						const workflowUsage = sumResultsUsage(workflowResults);
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: workflow.trace, emits: workflow.emits, console: workflow.console }, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
@@ -5241,7 +5240,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							}
 						}
 						status = compactOptional<AsyncStatus>({ ...status, state, stopped: stopped || undefined, activityState: pauseForDetached ? "needs_attention" : undefined, error: error instanceof Error ? error.message : String(error), endedAt: Date.now(), workflow: { trace: partial.trace, emits: partial.emits, console: partial.console } });
-						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, status.error ?? (pauseForDetached ? "Workflow paused." : "Workflow failed."));
+						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, status.error ?? (pauseForDetached ? "Workflow paused." : "Workflow failed."), claimedOutputPaths);
 						const resultSummary = appendWorkflowOutputWarning(status.error ?? (pauseForDetached ? "Workflow paused." : "Workflow failed."), outputWarning);
 						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: resultSummary, error: status.error, stopped: status.stopped, activityState: status.activityState, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.detached ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
@@ -5345,7 +5344,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (workflow.console.length > 0) sections.push(`Console:\n${workflow.console.map((entry) => `[${entry.level}] ${entry.text}`).join("\n")}`);
 				if (traceLines.length > 0) sections.push(`Call trace:\n${traceLines.join("\n")}`);
 				const workflowText = sections.join("\n\n");
-				const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, workflowText);
+				const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, workflowText, claimedOutputPaths);
 				const displayText = appendWorkflowOutputWarning(workflowText, outputWarning);
 				return attachWorkflowMission(withRunFanoutBudget({
 					content: [{ type: "text", text: displayText }],
@@ -5360,7 +5359,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (partial.console.length > 0) sections.push(`Console:\n${partial.console.map((entry) => `[${entry.level}] ${entry.text}`).join("\n")}`);
 				if (traceLines.length > 0) sections.push(`Call trace:\n${traceLines.join("\n")}`);
 				const workflowText = sections.join("\n\n");
-				const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, workflowText);
+				const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, workflowText, claimedOutputPaths);
 				const displayText = appendWorkflowOutputWarning(workflowText, outputWarning);
 				return attachWorkflowMission(withRunFanoutBudget({
 					content: [{ type: "text", text: displayText }],

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3300,9 +3300,10 @@ function workflowChildDefaultOutput(aggregateOutputPath: string | undefined, art
 	return path.join(artifactsDir, "outputs", workflowRunId, `${workflowKey}.md`);
 }
 
-function writeWorkflowAggregateOutput(outputPath: string | undefined, text: string, childOutputPaths: ReadonlyMap<string, string>): string | undefined {
-	if (!outputPath || childOutputPaths.has(outputPath)) return undefined;
+function writeWorkflowAggregateOutput(outputPath: string | undefined, text: string, producedChildOutputPaths: ReadonlySet<string>): string | undefined {
+	if (!outputPath) return undefined;
 	try {
+		if (producedChildOutputPaths.has(outputPath)) return undefined;
 		fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 		fs.writeFileSync(outputPath, text, "utf-8");
 		return undefined;
@@ -5050,6 +5051,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					const configuredOutputBaseDir = resolveConfiguredSingleRunOutputBaseDir(deps);
 					const workflowAggregateOutputPath = resolveWorkflowAggregateOutputPath(workflowOutput, ctx.cwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, workflowRunId), configuredOutputBaseDir);
 					const claimedOutputPaths = new Map<string, string>();
+					const producedChildOutputPaths = new Set<string>();
 					const workflowSteps = new Map<string, NonNullable<AsyncStatus["steps"]>[number]>();
 					let projectedTraceLength = 0;
 					let projectedTraceTail: NonNullable<Details["workflow"]>["trace"][number] | undefined;
@@ -5191,6 +5193,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 									}, ctx, preserveActiveSession);
 								});
 								workflowResults.push(...result.details.results);
+								for (const childResult of result.details.results) {
+									if (childResult.savedOutputPath) producedChildOutputPaths.add(childResult.savedOutputPath);
+								}
 								const child = workflowChildResult(key, result);
 								const step = status.steps?.find((candidate) => candidate.workflowKey === key);
 								if (step) {
@@ -5219,7 +5224,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const returnPreview = formatWorkflowValue(workflow.value).slice(0, 1_000);
 						const emitPreview = workflow.emits.length > 0 ? ` Emitted: ${workflow.emits.map(formatWorkflowValue).join(", ").slice(0, 1_000)}` : "";
 						const summary = `Workflow completed with ${workflow.children.length} child run(s). Return: ${returnPreview}${emitPreview} Trace: ${workflow.trace.length} event(s).`;
-						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, summary, claimedOutputPaths);
+						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, summary, producedChildOutputPaths);
 						const resultSummary = appendWorkflowOutputWarning(summary, outputWarning);
 						const workflowUsage = sumResultsUsage(workflowResults);
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: workflow.trace, emits: workflow.emits, console: workflow.console }, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
@@ -5240,7 +5245,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							}
 						}
 						status = compactOptional<AsyncStatus>({ ...status, state, stopped: stopped || undefined, activityState: pauseForDetached ? "needs_attention" : undefined, error: error instanceof Error ? error.message : String(error), endedAt: Date.now(), workflow: { trace: partial.trace, emits: partial.emits, console: partial.console } });
-						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, status.error ?? (pauseForDetached ? "Workflow paused." : "Workflow failed."), claimedOutputPaths);
+						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, status.error ?? (pauseForDetached ? "Workflow paused." : "Workflow failed."), producedChildOutputPaths);
 						const resultSummary = appendWorkflowOutputWarning(status.error ?? (pauseForDetached ? "Workflow paused." : "Workflow failed."), outputWarning);
 						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: resultSummary, error: status.error, stopped: status.stopped, activityState: status.activityState, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.detached ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
@@ -5261,6 +5266,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const configuredOutputBaseDir = resolveConfiguredSingleRunOutputBaseDir(deps);
 			const workflowAggregateOutputPath = resolveWorkflowAggregateOutputPath(workflowOutput, ctx.cwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, _id), configuredOutputBaseDir);
 			const claimedOutputPaths = new Map<string, string>();
+			const producedChildOutputPaths = new Set<string>();
 			const workflowResults: SingleResult[] = [];
 			let liveWorkflow: NonNullable<Details["workflow"]> = { trace: [], emits: [], console: [] };
 			const sendWorkflowProgress = () => {
@@ -5322,6 +5328,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							}, ctx, preserveActiveSession);
 						});
 						workflowResults.push(...result.details.results);
+						for (const childResult of result.details.results) {
+							if (childResult.savedOutputPath) producedChildOutputPaths.add(childResult.savedOutputPath);
+						}
 						if (result.details.asyncDir && missionBinding) writeMissionAsyncBinding(result.details.asyncDir, missionBinding);
 						const child = workflowChildResult(key, result);
 						const childStatus = missionWorkflowChildStatus(result);
@@ -5344,7 +5353,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (workflow.console.length > 0) sections.push(`Console:\n${workflow.console.map((entry) => `[${entry.level}] ${entry.text}`).join("\n")}`);
 				if (traceLines.length > 0) sections.push(`Call trace:\n${traceLines.join("\n")}`);
 				const workflowText = sections.join("\n\n");
-				const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, workflowText, claimedOutputPaths);
+				const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, workflowText, producedChildOutputPaths);
 				const displayText = appendWorkflowOutputWarning(workflowText, outputWarning);
 				return attachWorkflowMission(withRunFanoutBudget({
 					content: [{ type: "text", text: displayText }],
@@ -5359,7 +5368,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (partial.console.length > 0) sections.push(`Console:\n${partial.console.map((entry) => `[${entry.level}] ${entry.text}`).join("\n")}`);
 				if (traceLines.length > 0) sections.push(`Call trace:\n${traceLines.join("\n")}`);
 				const workflowText = sections.join("\n\n");
-				const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, workflowText, claimedOutputPaths);
+				const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, workflowText, producedChildOutputPaths);
 				const displayText = appendWorkflowOutputWarning(workflowText, outputWarning);
 				return attachWorkflowMission(withRunFanoutBudget({
 					content: [{ type: "text", text: displayText }],

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1526,55 +1526,42 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			assert.match(child.error ?? "", new RegExp(escapeRegExp(path.join(tempDir, relativeDuplicateOutput))));
 		}
 		assert.equal(mockPi.callCount(), 0);
+	});
 
-		const aggregate = await executor.execute(
-			"scripted-workflow-aggregate-child-output",
+	it("preserves a rejected file-only child report when its path matches workflow output", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const usefulReport = "# Review findings\n\nThe implementation loses the final report.";
+		const sharedOutput = path.join(tempDir, "review.md");
+		mockPi.onCall({ stdoutRaw: `${JSON.stringify(events.assistantMessage(usefulReport))}\n` });
+		const executor = makeExecutor([makeAgent("reviewer", { tools: ["read"], completionGuard: false })]);
+
+		const result = await executor.execute(
+			"scripted-workflow-file-only-acceptance-collision",
 			{
 				async: false,
 				output: sharedOutput,
-				workflowScript: `return await runs.all([
-					{ key: "review", agent: "echo", task: "Review", output: ${JSON.stringify(sharedOutput)} },
-					{ key: "monitor", agent: "echo", task: "Monitor" }
-				]);`,
+				workflowScript: `
+					const child = await runs.run("review", {
+						agent: "reviewer",
+						task: "Write a structured review report.",
+						output: ${JSON.stringify(sharedOutput)},
+						outputMode: "file-only",
+						acceptance: { level: "checked", criteria: ["Return the structured review report"] }
+					});
+					if (!child.ok) throw new Error(child.error);
+					return child;
+				`,
 			},
 			new AbortController().signal,
 			undefined,
 			makeMinimalCtx(tempDir),
 		);
 
-		assert.equal(aggregate.isError, undefined, aggregate.content[0]?.text ?? "workflow failed");
-		const aggregateChildren = aggregate.details.workflow?.value as Array<{ ok: boolean; error?: string }>;
-		assert.deepEqual(aggregateChildren.map(({ ok }) => ok), [false, false]);
-		for (const child of aggregateChildren) {
-			assert.match(child.error ?? "", /Workflow child 'review' output resolves to the workflow aggregate output path/);
-			assert.match(child.error ?? "", new RegExp(escapeRegExp(sharedOutput)));
-		}
-		assert.equal(mockPi.callCount(), 0);
-
-		const relativeAggregateOutput = "relative-aggregate.md";
-		const relativeAggregate = await executor.execute(
-			"scripted-workflow-relative-aggregate-child-output",
-			{
-				async: false,
-				output: relativeAggregateOutput,
-				workflowScript: `return await runs.all([
-					{ key: "review", agent: "echo", task: "Review", output: ${JSON.stringify(relativeAggregateOutput)} },
-					{ key: "monitor", agent: "echo", task: "Monitor" }
-				]);`,
-			},
-			new AbortController().signal,
-			undefined,
-			makeMinimalCtx(tempDir),
-		);
-
-		assert.equal(relativeAggregate.isError, undefined, relativeAggregate.content[0]?.text ?? "workflow failed");
-		const relativeAggregateChildren = relativeAggregate.details.workflow?.value as Array<{ ok: boolean; error?: string }>;
-		assert.deepEqual(relativeAggregateChildren.map(({ ok }) => ok), [false, false]);
-		for (const child of relativeAggregateChildren) {
-			assert.match(child.error ?? "", /Workflow child 'review' output resolves to the workflow aggregate output path/);
-			assert.match(child.error ?? "", new RegExp(escapeRegExp(path.join(tempDir, relativeAggregateOutput))));
-		}
-		assert.equal(mockPi.callCount(), 0);
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", new RegExp(escapeRegExp(sharedOutput)));
+		assert.equal(result.details.results[0]?.acceptance?.status, "rejected");
+		assert.match(result.details.results[0]?.acceptance?.runtimeChecks[0]?.message ?? "", /Structured acceptance report not found/);
+		assert.equal(result.details.results[0]?.savedOutputPath, sharedOutput);
+		assert.deepEqual(fs.readFileSync(sharedOutput), Buffer.from(usefulReport));
 	});
 
 	it("rejects sequential workflow child output collisions before launch", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
@@ -1610,31 +1597,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const configuredBase = path.join(tempDir, "configured-outputs");
 		const workflowOutput = "shared.md";
 
-		const aggregateResult = await makeExecutor([makeAgent("echo")], { singleRunOutputBaseDir: configuredBase }).execute(
-			"scripted-workflow-configured-output-base-collision",
-			{
-				async: false,
-				output: workflowOutput,
-				workflowScript: `return await runs.all([
-					{ key: "review", agent: "echo", task: "Review", output: ${JSON.stringify(workflowOutput)} },
-					{ key: "monitor", agent: "echo", task: "Monitor" }
-				]);`,
-			},
-			new AbortController().signal,
-			undefined,
-			makeMinimalCtx(tempDir),
-		);
-
-		assert.equal(aggregateResult.isError, undefined, aggregateResult.content[0]?.text ?? "workflow failed");
-		const aggregateChildren = aggregateResult.details.workflow?.value as Array<{ ok: boolean; error?: string }>;
-		assert.deepEqual(aggregateChildren.map(({ ok }) => ok), [false, false]);
 		const resolvedSharedOutput = path.join(configuredBase, workflowOutput);
-		for (const child of aggregateChildren) {
-			assert.match(child.error ?? "", /Workflow child 'review' output resolves to the workflow aggregate output path/);
-			assert.match(child.error ?? "", new RegExp(escapeRegExp(resolvedSharedOutput)));
-		}
-		assert.equal(mockPi.callCount(), 0);
-
 		const agentDefaultResult = await makeExecutor([makeAgent("echo", { output: workflowOutput })], { singleRunOutputBaseDir: configuredBase }).execute(
 			"scripted-workflow-configured-agent-default-output-collision",
 			{

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1564,6 +1564,40 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(fs.readFileSync(sharedOutput), Buffer.from(usefulReport));
 	});
 
+	it("replaces stale workflow output when a child claims its path but writes no report", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const sharedOutput = path.join(tempDir, "failed-review.md");
+		fs.writeFileSync(sharedOutput, "stale workflow output", "utf-8");
+		mockPi.onCall({ exitCode: 1, stderr: "review child failed before writing output" });
+		const executor = makeExecutor([makeAgent("reviewer", { completionGuard: false })]);
+
+		const result = await executor.execute(
+			"scripted-workflow-missing-child-output-collision",
+			{
+				async: false,
+				output: sharedOutput,
+				workflowScript: `
+					const child = await runs.run("review", {
+						agent: "reviewer",
+						task: "Write a review report.",
+						output: ${JSON.stringify(sharedOutput)},
+						outputMode: "file-only"
+					});
+					if (!child.ok) throw new Error(child.error);
+					return child;
+				`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /review child failed before writing output/);
+		const workflowOutput = fs.readFileSync(sharedOutput, "utf-8");
+		assert.match(workflowOutput, /Workflow failed:.*review child failed before writing output/s);
+		assert.doesNotMatch(workflowOutput, /stale workflow output/);
+	});
+
 	it("rejects sequential workflow child output collisions before launch", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "first report" });
 		const executor = makeExecutor([makeAgent("echo")]);

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import * as fs from "node:fs";
+import fsDefault, * as fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
@@ -132,6 +133,32 @@ describe("result file indexes", () => {
 			assert.equal(JSON.parse(fs.readFileSync(resultPath, "utf-8")).success, true);
 		} finally {
 			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a newer pending payload readable when Windows cannot replace the public result", (t) => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-windows-pending-wins-"));
+		try {
+			const resultPath = path.join(resultsDir, "blocked.json");
+			writeAsyncResultFile(resultPath, { id: "blocked", runId: "blocked", sessionId: "session-a", success: false });
+			writePendingAsyncResultFile(resultPath, { id: "blocked", runId: "blocked", sessionId: "session-a", success: true });
+
+			t.mock.method(fsDefault, "renameSync", () => {
+				const error = new Error("destination exists") as NodeJS.ErrnoException;
+				error.code = "EEXIST";
+				throw error;
+			});
+			syncBuiltinESMExports();
+
+			const payloadPath = resultPayloadPathForSessionRun(resultsDir, "session-a", "blocked");
+			assert.equal(payloadPath, pendingPath(resultsDir, "session-a", "blocked"));
+			assert.equal(JSON.parse(fs.readFileSync(payloadPath, "utf-8")).success, true);
+			assert.equal(JSON.parse(fs.readFileSync(resultPath, "utf-8")).success, false);
+			assert.equal(fs.existsSync(pendingPath(resultsDir, "session-a", "blocked")), true);
+		} finally {
+			t.mock.restoreAll();
+			syncBuiltinESMExports();
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/run-id-resolver.test.ts
+++ b/test/unit/run-id-resolver.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
-import * as fs from "node:fs";
+import fsDefault, * as fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import type { SubagentState } from "../../src/shared/types.ts";
 import { releaseActiveRunIndex, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
-import { resultFilePath, writeAsyncResultFile } from "../../src/runs/background/result-files.ts";
+import { resultFilePath, writeAsyncResultFile, writePendingAsyncResultFile } from "../../src/runs/background/result-files.ts";
 import { resolveSubagentRunId } from "../../src/runs/background/run-id-resolver.ts";
 import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
 
@@ -179,6 +180,40 @@ describe("subagent run id resolver", () => {
 			assert.equal(done?.kind, "async");
 			assert.equal(done?.id, "workflow-done");
 		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("prefers a newer pending payload when resolving run and tool-call ids", (t) => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-resolver-pending-payload-"));
+		try {
+			const asyncRoot = path.join(root, "async");
+			const resultsDir = path.join(root, "results");
+			const resultPath = resultFilePath(resultsDir, "workflow-done");
+			writeAsyncResultFile(resultPath, { id: "workflow-done", runId: "workflow-done", toolCallId: "call-done", sessionId: "session-a", success: false });
+			writePendingAsyncResultFile(resultPath, { id: "workflow-done", runId: "workflow-done", toolCallId: "call-done", sessionId: "session-a", success: true });
+
+			t.mock.method(fsDefault, "renameSync", () => {
+				const error = new Error("destination exists") as NodeJS.ErrnoException;
+				error.code = "EEXIST";
+				throw error;
+			});
+			syncBuiltinESMExports();
+
+			const pendingPath = path.join(resultsDir, "result-pending", "session-a", "workflow-done.json");
+			const byRunId = resolveSubagentRunId("workflow-done", { asyncDirRoot: asyncRoot, resultsDir });
+			assert.equal(byRunId?.kind, "async");
+			assert.equal(byRunId?.kind === "async" ? byRunId.location.resultPath : undefined, pendingPath);
+
+			const byToolCallId = resolveSubagentRunId("call-done", { asyncDirRoot: asyncRoot, resultsDir });
+			assert.equal(byToolCallId?.kind, "async");
+			assert.equal(byToolCallId?.id, "workflow-done");
+			assert.equal(byToolCallId?.kind === "async" ? byToolCallId.location.resultPath : undefined, pendingPath);
+			assert.equal(JSON.parse(fs.readFileSync(pendingPath, "utf-8")).success, true);
+			assert.equal(JSON.parse(fs.readFileSync(resultPath, "utf-8")).success, false);
+		} finally {
+			t.mock.restoreAll();
+			syncBuiltinESMExports();
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});


### PR DESCRIPTION
## Summary

Fixes two async result-delivery edge cases:

- preserves a child file-only report when the workflow summary output claims the same path
- keeps concurrent async result promotion from deleting a newer payload or resolving stale public data

This supersedes #1130 while preserving the contributor credit for [@albertgwo](https://github.com/albertgwo). Fixes #1128.

## Validation

- `node --experimental-strip-types --test test/unit/run-id-resolver.test.ts`
- `node --experimental-strip-types --test test/unit/result-files.test.ts`
- `node --experimental-strip-types --test test/integration/acceptance-file-report.test.ts`
- `node --experimental-strip-types --test --test-name-pattern='preserves a rejected file-only child report when its path matches workflow output' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh exact-head review: `/tmp/pi-subagents-backlog-20260815T042535Z/landing-1128-1130-gate-ec755507-review.md` (`No issues found`)
