### PR TITLE
fix: bound async tool-call index path segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Preserve a child's file-only report when its output path also names the workflow summary output.
 - Keep concurrent async result promotion from deleting a newer payload or another promoter's published result. Thanks to [@albertgwo](https://github.com/albertgwo) for #1130.
+- Bound opaque tool-call IDs used by async active-run and result indexes, preventing provider-generated IDs longer than the filesystem component limit from aborting background launches with `ENAMETOOLONG`. Optional active-run aliases now fail open without losing the authoritative run marker. Thanks to [@hlstwizard](https://github.com/hlstwizard) for #1131.
 
 ### Changed
 - Clarify that subagent reviews and gates should stay async unless foreground behavior is the actual requirement.

--- a/src/runs/background/active-run-index.ts
+++ b/src/runs/background/active-run-index.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AsyncStatus } from "../../shared/types.ts";
+import { encodeIndexSegment } from "./index-segment.ts";
 
 export const ACTIVE_RUN_INDEX_DIR = ".active-runs";
 export const DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS = 24 * 60 * 60 * 1000;
@@ -12,7 +13,7 @@ function indexDir(asyncDirRoot: string): string {
 }
 
 function toolCallIndexDir(asyncDirRoot: string, toolCallId: string): string {
-	return path.join(indexDir(asyncDirRoot), TOOL_CALL_INDEX_DIR, encodeURIComponent(toolCallId));
+	return path.join(indexDir(asyncDirRoot), TOOL_CALL_INDEX_DIR, encodeIndexSegment(toolCallId));
 }
 
 function toolCallIndexPath(asyncDir: string, toolCallId: string): string {
@@ -45,8 +46,11 @@ function releaseToolCallAliases(asyncDir: string): void {
 	try {
 		entries = fs.readdirSync(root, { withFileTypes: true });
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-		throw error;
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT" && code !== "ENOTDIR") {
+			console.error(`Failed to inspect async active-run tool-call index root '${root}':`, error);
+		}
+		return;
 	}
 	for (const entry of entries) {
 		if (!entry.isDirectory()) continue;
@@ -75,9 +79,15 @@ export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state
 		fs.mkdirSync(path.dirname(marker), { recursive: true });
 		fs.writeFileSync(marker, "", { flag: "a" });
 		if (toolCallId) {
-			const toolCallMarker = toolCallIndexPath(asyncDir, toolCallId);
-			fs.mkdirSync(path.dirname(toolCallMarker), { recursive: true });
-			fs.writeFileSync(toolCallMarker, "", { flag: "a" });
+			try {
+				const toolCallMarker = toolCallIndexPath(asyncDir, toolCallId);
+				fs.mkdirSync(path.dirname(toolCallMarker), { recursive: true });
+				fs.writeFileSync(toolCallMarker, "", { flag: "a" });
+			} catch (error) {
+				// Tool-call aliases are optional. The authoritative active-run marker
+				// must keep the launch discoverable even when alias indexing fails.
+				console.error(`Failed to write async active-run tool-call index for '${asyncDir}':`, error);
+			}
 		}
 		return;
 	}
@@ -110,7 +120,8 @@ export function readActiveRunToolCallIndex(asyncDirRoot: string, toolCallId: str
 			.filter((entry) => entry.isFile())
 			.map((entry) => entry.name);
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") return [];
 		throw error;
 	}
 }

--- a/src/runs/background/index-segment.ts
+++ b/src/runs/background/index-segment.ts
@@ -1,0 +1,35 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Keep opaque index keys below common filesystem component limits.
+ *
+ * Portable short values retain the historical URI-encoded representation.
+ * Oversized or non-portable values use a deterministic digest so callers can
+ * resolve the same index without persisting a separate lookup table.
+ */
+export const MAX_INDEX_SEGMENT_BYTES = 255;
+const HASHED_INDEX_SEGMENT_PREFIX = "~sha256-";
+const WINDOWS_RESERVED_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
+
+function hashedSegment(value: string): string {
+	return `${HASHED_INDEX_SEGMENT_PREFIX}${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function isPortableSegment(value: string): boolean {
+	return value.length > 0
+		&& value !== "."
+		&& value !== ".."
+		&& !value.endsWith(".")
+		&& !WINDOWS_RESERVED_NAME.test(value);
+}
+
+export function encodeIndexSegment(value: string): string {
+	let encoded: string;
+	try {
+		encoded = encodeURIComponent(value);
+	} catch {
+		return hashedSegment(value);
+	}
+	if (Buffer.byteLength(encoded, "utf-8") <= MAX_INDEX_SEGMENT_BYTES && isPortableSegment(encoded)) return encoded;
+	return hashedSegment(value);
+}

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { MISSION_BINDING_FILE } from "../../missions/lifecycle.ts";
+import { encodeIndexSegment } from "./index-segment.ts";
 
 const RESULT_INDEX_VERSION = 1;
 const RESULT_INDEX_DIR = "result-index";
@@ -57,7 +58,7 @@ function observerIndexPath(resultsDir: string, observer: string, runId: string):
 }
 
 function toolCallIndexDir(resultsDir: string, toolCallId: string): string {
-	return path.join(resultsDir, RESULT_INDEX_DIR, TOOL_CALL_INDEX_DIR, encodeSegment(toolCallId));
+	return path.join(resultsDir, RESULT_INDEX_DIR, TOOL_CALL_INDEX_DIR, encodeIndexSegment(toolCallId));
 }
 
 function toolCallIndexPath(resultsDir: string, toolCallId: string, runId: string): string {

--- a/test/unit/index-segment.test.ts
+++ b/test/unit/index-segment.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import fsDefault, * as fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { ACTIVE_RUN_INDEX_DIR, readActiveRunToolCallIndex, releaseActiveRunIndex, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
+import { encodeIndexSegment, MAX_INDEX_SEGMENT_BYTES } from "../../src/runs/background/index-segment.ts";
+
+describe("bounded index segments", () => {
+	it("preserves legacy encoding for short values and hashes oversized opaque ids", () => {
+		assert.equal(encodeIndexSegment("call/a+b="), encodeURIComponent("call/a+b="));
+		assert.equal(encodeIndexSegment("x".repeat(255)), "x".repeat(255));
+		assert.match(encodeIndexSegment("x".repeat(256)), /^~sha256-[a-f0-9]{64}$/);
+		for (const unsafe of ["", ".", "..", "CON", "nul.txt", "trailing."]) {
+			assert.match(encodeIndexSegment(unsafe), /^~sha256-[a-f0-9]{64}$/);
+		}
+
+		const longId = `call_${"opaque/+=".repeat(80)}`;
+		const first = encodeIndexSegment(longId);
+		assert.equal(first, encodeIndexSegment(longId));
+		assert.match(first, /^~sha256-[a-f0-9]{64}$/);
+		assert.ok(Buffer.byteLength(first, "utf-8") <= MAX_INDEX_SEGMENT_BYTES);
+		assert.notEqual(first, encodeIndexSegment(`${longId}other`));
+	});
+
+	it("indexes and releases active runs with oversized provider tool-call ids", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-active-index-long-tool-call-"));
+		try {
+			const asyncDir = path.join(root, "workflow-run");
+			const toolCallId = `call_${"opaque/+=".repeat(80)}`;
+			assert.ok(Buffer.byteLength(encodeURIComponent(toolCallId), "utf-8") > 255);
+			fs.mkdirSync(asyncDir, { recursive: true });
+
+			updateActiveRunIndex(asyncDir, "running", toolCallId);
+
+			assert.deepEqual(readActiveRunToolCallIndex(root, toolCallId), ["workflow-run"]);
+			const aliases = fs.readdirSync(path.join(root, ACTIVE_RUN_INDEX_DIR, "tool-calls"));
+			assert.equal(aliases.length, 1);
+			assert.ok(Buffer.byteLength(aliases[0]!, "utf-8") <= MAX_INDEX_SEGMENT_BYTES);
+
+			releaseActiveRunIndex(asyncDir);
+			assert.equal(fs.existsSync(path.join(root, ACTIVE_RUN_INDEX_DIR, "workflow-run")), false);
+			assert.deepEqual(readActiveRunToolCallIndex(root, toolCallId), []);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("throws non-missing tool-call index read failures", (t) => {
+		const error = new Error("permission denied") as NodeJS.ErrnoException;
+		error.code = "EACCES";
+		t.mock.method(fsDefault, "readdirSync", () => {
+			throw error;
+		});
+		syncBuiltinESMExports();
+		try {
+			assert.throws(() => readActiveRunToolCallIndex("/tmp/async", "call-a"), (thrown) => thrown === error);
+		} finally {
+			t.mock.restoreAll();
+			syncBuiltinESMExports();
+		}
+	});
+
+	it("keeps the authoritative marker when optional tool-call indexing fails", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-active-index-optional-alias-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const asyncDir = path.join(root, "workflow-run");
+			const aliasRoot = path.join(root, ACTIVE_RUN_INDEX_DIR, "tool-calls");
+			fs.mkdirSync(path.dirname(aliasRoot), { recursive: true });
+			fs.writeFileSync(aliasRoot, "not a directory", "utf-8");
+			fs.mkdirSync(asyncDir, { recursive: true });
+
+			assert.doesNotThrow(() => updateActiveRunIndex(asyncDir, "running", "call-a"));
+			assert.equal(fs.existsSync(path.join(root, ACTIVE_RUN_INDEX_DIR, "workflow-run")), true);
+			assert.deepEqual(readActiveRunToolCallIndex(root, "call-a"), []);
+			assert.doesNotThrow(() => releaseActiveRunIndex(asyncDir));
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -4,7 +4,7 @@ import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { cleanupResultIndexes, removeResultIndex, resultCandidateFilesForSession, resultFilesForSession, resultPayloadPathForIndexedRun, resultPayloadPathForSessionRun, writeAsyncResultFile, writePendingAsyncResultFile, writeResultIndexForData } from "../../src/runs/background/result-files.ts";
+import { cleanupResultIndexes, removeResultIndex, resultCandidateFilesForSession, resultFilesForSession, resultFilesForToolCall, resultPayloadPathForIndexedRun, resultPayloadPathForSessionRun, writeAsyncResultFile, writePendingAsyncResultFile, writeResultIndexForData } from "../../src/runs/background/result-files.ts";
 
 function pendingPath(resultsDir: string, sessionId: string, runId: string): string {
 	return path.join(resultsDir, "result-pending", encodeURIComponent(sessionId), `${encodeURIComponent(runId)}.json`);
@@ -177,6 +177,24 @@ describe("result file indexes", () => {
 			assert.equal(fs.existsSync(pendingPath(resultsDir, "session-a", "pending-cleanup")), false);
 		} finally {
 			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("indexes results with oversized provider tool-call ids", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-long-tool-call-"));
+		try {
+			const runId = "workflow-long-tool-call";
+			const toolCallId = `call_${"opaque/+=".repeat(80)}`;
+			const resultPath = path.join(resultsDir, `${runId}.json`);
+
+			writeAsyncResultFile(resultPath, { id: runId, runId, sessionId: "session-a", toolCallId, success: true });
+
+			assert.deepEqual(resultFilesForToolCall(resultsDir, toolCallId), [`${runId}.json`]);
+			removeResultIndex(resultsDir, "session-a", runId, toolCallId);
+			assert.deepEqual(resultFilesForToolCall(resultsDir, toolCallId), []);
+			assert.equal(fs.existsSync(resultPath), true);
+		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/run-id-resolver.test.ts
+++ b/test/unit/run-id-resolver.test.ts
@@ -218,6 +218,27 @@ describe("subagent run id resolver", () => {
 		}
 	});
 
+	it("resolves oversized workflow tool-call ids through bounded indexes", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-resolver-long-tool-call-index-"));
+		try {
+			const asyncRoot = path.join(root, "async");
+			const resultsDir = path.join(root, "results");
+			const toolCallId = `call_${"界".repeat(100)}`;
+			const activeDir = path.join(asyncRoot, "workflow-active-long");
+			fs.mkdirSync(activeDir, { recursive: true });
+			fs.writeFileSync(path.join(activeDir, "status.json"), JSON.stringify({ runId: "workflow-active-long", toolCallId, state: "running", mode: "workflow", startedAt: 1, lastUpdate: 1, steps: [] }), "utf-8");
+			updateActiveRunIndex(activeDir, "running", toolCallId);
+
+			assert.equal(resolveSubagentRunId(toolCallId, { asyncDirRoot: asyncRoot, resultsDir })?.id, "workflow-active-long");
+			releaseActiveRunIndex(activeDir);
+
+			writeAsyncResultFile(resultFilePath(resultsDir, "workflow-done-long"), { id: "workflow-done-long", runId: "workflow-done-long", toolCallId, sessionId: "session-a", state: "complete", success: true });
+			assert.equal(resolveSubagentRunId(toolCallId, { asyncDirRoot: asyncRoot, resultsDir })?.id, "workflow-done-long");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects unsafe nested id tokens before lookup", () => {
 		assert.throws(() => resolveSubagentRunId("../run"), /safe id token/);
 		assert.throws(() => resolveSubagentRunId("a/b"), /safe id token/);


### PR DESCRIPTION
## Summary

This lands the bounded tool-call index path segment fix from #1131 on the current `main` branch after #1133.

It keeps short portable path segments compatible, hashes oversized or non-portable tool-call IDs into bounded filesystem components, and keeps optional active-run/result indexes fail-open so the authoritative marker or result remains available.

Thanks to [@hlstwizard](https://github.com/hlstwizard) for #1131.

## Validation

- `node --experimental-strip-types --test test/unit/index-segment.test.ts test/unit/result-files.test.ts test/unit/run-id-resolver.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
