### PR TITLE
fix: bound async result session path segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Preserve a child's file-only report when its output path also names the workflow summary output.
 - Keep concurrent async result promotion from deleting a newer payload or another promoter's published result. Thanks to [@albertgwo](https://github.com/albertgwo) for #1130.
 - Bound opaque tool-call IDs used by async active-run and result indexes, preventing provider-generated IDs longer than the filesystem component limit from aborting background launches with `ENAMETOOLONG`. Optional active-run aliases now fail open without losing the authoritative run marker. Thanks to [@hlstwizard](https://github.com/hlstwizard) for #1131.
+- Bound async result session and run path segments so long identities do not make `subagent_wait` fail with `ENAMETOOLONG`. Thanks to [@zhouatie](https://github.com/zhouatie) for #1135.
 
 ### Changed
 - Clarify that subagent reviews and gates should stay async unless foreground behavior is the actual requirement.

--- a/src/runs/background/index-segment.ts
+++ b/src/runs/background/index-segment.ts
@@ -23,13 +23,13 @@ function isPortableSegment(value: string): boolean {
 		&& !WINDOWS_RESERVED_NAME.test(value);
 }
 
-export function encodeIndexSegment(value: string): string {
+export function encodeIndexSegment(value: string, maxBytes = MAX_INDEX_SEGMENT_BYTES): string {
 	let encoded: string;
 	try {
 		encoded = encodeURIComponent(value);
 	} catch {
 		return hashedSegment(value);
 	}
-	if (Buffer.byteLength(encoded, "utf-8") <= MAX_INDEX_SEGMENT_BYTES && isPortableSegment(encoded)) return encoded;
+	if (Buffer.byteLength(encoded, "utf-8") <= maxBytes && isPortableSegment(encoded)) return encoded;
 	return hashedSegment(value);
 }

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { MISSION_BINDING_FILE } from "../../missions/lifecycle.ts";
-import { encodeIndexSegment } from "./index-segment.ts";
+import { encodeIndexSegment, MAX_INDEX_SEGMENT_BYTES } from "./index-segment.ts";
 
 const RESULT_INDEX_VERSION = 1;
 const RESULT_INDEX_DIR = "result-index";
@@ -11,6 +11,8 @@ const OBSERVER_INDEX_DIR = "observers";
 const TOOL_CALL_INDEX_DIR = "tool-calls";
 const RESULT_PENDING_DIR = "result-pending";
 const MISSION_OBSERVER = "mission";
+const JSON_EXTENSION = ".json";
+const MAX_JSON_FILE_STEM_BYTES = MAX_INDEX_SEGMENT_BYTES - Buffer.byteLength(JSON_EXTENSION, "utf-8");
 
 export interface ResultIndexEntry {
 	version: 1;
@@ -22,7 +24,11 @@ export interface ResultIndexEntry {
 }
 
 function encodeSegment(value: string): string {
-	return encodeURIComponent(value);
+	return encodeIndexSegment(value);
+}
+
+function encodedJsonFileName(value: string): string {
+	return `${encodeIndexSegment(value, MAX_JSON_FILE_STEM_BYTES)}${JSON_EXTENSION}`;
 }
 
 function nonEmptyString(value: unknown): string | undefined {
@@ -30,7 +36,7 @@ function nonEmptyString(value: unknown): string | undefined {
 }
 
 export function resultFileName(runId: string): string {
-	return `${runId}.json`;
+	return `${runId}${JSON_EXTENSION}`;
 }
 
 export function resultFilePath(resultsDir: string, runId: string): string {
@@ -42,11 +48,11 @@ function sessionIndexDir(resultsDir: string, sessionId: string): string {
 }
 
 function resultIndexPath(resultsDir: string, sessionId: string, runId: string): string {
-	return path.join(sessionIndexDir(resultsDir, sessionId), `${encodeSegment(runId)}.json`);
+	return path.join(sessionIndexDir(resultsDir, sessionId), encodedJsonFileName(runId));
 }
 
 function resultPendingPath(resultsDir: string, sessionId: string, runId: string): string {
-	return path.join(resultsDir, RESULT_PENDING_DIR, encodeSegment(sessionId), `${encodeSegment(runId)}.json`);
+	return path.join(resultsDir, RESULT_PENDING_DIR, encodeSegment(sessionId), encodedJsonFileName(runId));
 }
 
 function observerIndexDir(resultsDir: string, observer: string): string {
@@ -54,7 +60,7 @@ function observerIndexDir(resultsDir: string, observer: string): string {
 }
 
 function observerIndexPath(resultsDir: string, observer: string, runId: string): string {
-	return path.join(observerIndexDir(resultsDir, observer), `${encodeSegment(runId)}.json`);
+	return path.join(observerIndexDir(resultsDir, observer), encodedJsonFileName(runId));
 }
 
 function toolCallIndexDir(resultsDir: string, toolCallId: string): string {
@@ -62,7 +68,7 @@ function toolCallIndexDir(resultsDir: string, toolCallId: string): string {
 }
 
 function toolCallIndexPath(resultsDir: string, toolCallId: string, runId: string): string {
-	return path.join(toolCallIndexDir(resultsDir, toolCallId), `${encodeSegment(runId)}.json`);
+	return path.join(toolCallIndexDir(resultsDir, toolCallId), encodedJsonFileName(runId));
 }
 
 function parseResultIndexEntry(value: unknown): ResultIndexEntry | undefined {
@@ -247,14 +253,13 @@ function pendingResultLocationForIndexedRun(resultsDir: string, runId: string): 
 	}
 	for (const session of sessions) {
 		if (!session.isDirectory()) continue;
-		let sessionId: string;
+		const pendingPath = path.join(root, session.name, encodedJsonFileName(runId));
 		try {
-			sessionId = decodeURIComponent(session.name);
-		} catch {
-			continue;
+			const data = JSON.parse(fs.readFileSync(pendingPath, "utf-8")) as Record<string, unknown>;
+			if ((nonEmptyString(data.runId) ?? nonEmptyString(data.id)) === runId) return { file: resultFileName(runId), path: pendingPath, state: "pending" };
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid pending async result '${pendingPath}':`, error);
 		}
-		const location = pendingResultLocationForSessionRun(resultsDir, sessionId, runId);
-		if (location) return location;
 	}
 	return undefined;
 }
@@ -310,7 +315,7 @@ export function resultPayloadPathForIndexedRun(resultsDir: string, runId: string
 	}
 	for (const session of sessions) {
 		if (!session.isDirectory()) continue;
-		const entryPath = path.join(root, session.name, `${encodeSegment(runId)}.json`);
+		const entryPath = path.join(root, session.name, encodedJsonFileName(runId));
 		try {
 			const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(entryPath, "utf-8")));
 			if (!entry || entry.runId !== runId) continue;

--- a/src/shared/atomic-json.ts
+++ b/src/shared/atomic-json.ts
@@ -1,8 +1,11 @@
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS, runFileSystemOperationWithRetry, waitForFileSystemRetry } from "./file-system-retry.ts";
 
 type AtomicJsonFs = Pick<typeof fs, "mkdirSync" | "writeFileSync" | "renameSync" | "rmSync">;
+
+const MAX_PATH_COMPONENT_BYTES = 255;
 
 type AtomicJsonWriterOptions = {
 	fs?: AtomicJsonFs;
@@ -28,6 +31,13 @@ function renameWithRetry(
 	}, { retryDelaysMs, wait });
 }
 
+function tempBaseName(filePath: string, pid: number, nowMs: number, randomId: string): string {
+	const suffix = `.${pid}.${nowMs}.${randomId}.tmp`;
+	const preferred = `.${path.basename(filePath)}${suffix}`;
+	if (Buffer.byteLength(preferred, "utf-8") <= MAX_PATH_COMPONENT_BYTES) return preferred;
+	return `.${createHash("sha256").update(path.basename(filePath)).digest("hex")}${suffix}`;
+}
+
 export function createAtomicJsonWriter(options: AtomicJsonWriterOptions = {}): (filePath: string, payload: object) => void {
 	const fsImpl = options.fs ?? fs;
 	const now = options.now ?? Date.now;
@@ -46,7 +56,7 @@ export function createAtomicJsonWriter(options: AtomicJsonWriterOptions = {}): (
 		}, { retryDelaysMs: directoryRetryDelaysMs, wait });
 		const tempPath = path.join(
 			path.dirname(filePath),
-			`.${path.basename(filePath)}.${pid}.${now()}.${random().toString(36).slice(2)}.tmp`,
+			tempBaseName(filePath, pid, now(), random().toString(36).slice(2)),
 		);
 		try {
 			fsImpl.writeFileSync(tempPath, JSON.stringify(payload, null, 2), mode === undefined ? "utf-8" : { encoding: "utf-8", mode });

--- a/test/unit/atomic-json.test.ts
+++ b/test/unit/atomic-json.test.ts
@@ -105,6 +105,20 @@ describe("writeAtomicJson", () => {
 		assert.deepEqual([...fakeFs.writeOptions.values()], [{ encoding: "utf-8", mode: 0o600 }]);
 	});
 
+	it("keeps temporary names below the component limit for long target names", () => {
+		const fakeFs = new FakeFs();
+		const waits: number[] = [];
+		const writeAtomicJson = createWriter(fakeFs, waits);
+		const targetPath = path.join("/tmp", `${"x".repeat(250)}.json`);
+
+		writeAtomicJson(targetPath, { state: "running" });
+
+		const [tempPath] = fakeFs.writeOptions.keys();
+		assert.ok(tempPath);
+		assert.ok(Buffer.byteLength(path.basename(tempPath), "utf-8") <= 255);
+		assert.equal(fakeFs.files.get(targetPath), JSON.stringify({ state: "running" }, null, 2));
+	});
+
 	it("uses longer default retries for transient Windows rename locks", () => {
 		const fakeFs = new FakeFs();
 		fakeFs.failRenameCodes = ["EPERM", "EPERM", "EPERM", "EPERM", "EPERM", "EPERM"];

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -4,10 +4,14 @@ import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
+import { encodeIndexSegment, MAX_INDEX_SEGMENT_BYTES } from "../../src/runs/background/index-segment.ts";
 import { cleanupResultIndexes, removeResultIndex, resultCandidateFilesForSession, resultFilesForSession, resultFilesForToolCall, resultPayloadPathForIndexedRun, resultPayloadPathForSessionRun, writeAsyncResultFile, writePendingAsyncResultFile, writeResultIndexForData } from "../../src/runs/background/result-files.ts";
 
+const JSON_EXTENSION = ".json";
+const MAX_JSON_FILE_STEM_BYTES = MAX_INDEX_SEGMENT_BYTES - Buffer.byteLength(JSON_EXTENSION, "utf-8");
+
 function pendingPath(resultsDir: string, sessionId: string, runId: string): string {
-	return path.join(resultsDir, "result-pending", encodeURIComponent(sessionId), `${encodeURIComponent(runId)}.json`);
+	return path.join(resultsDir, "result-pending", encodeIndexSegment(sessionId), `${encodeIndexSegment(runId, MAX_JSON_FILE_STEM_BYTES)}${JSON_EXTENSION}`);
 }
 
 describe("result file indexes", () => {
@@ -65,6 +69,56 @@ describe("result file indexes", () => {
 			assert.deepEqual(resultCandidateFilesForSession(resultsDir, "session-a"), ["pending-only.json"]);
 			assert.equal(resultPayloadPathForSessionRun(resultsDir, "session-a", "pending-only"), pendingPath(resultsDir, "session-a", "pending-only"));
 			assert.equal(resultPayloadPathForIndexedRun(resultsDir, "pending-only"), pendingPath(resultsDir, "session-a", "pending-only"));
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps pending results for long session ids below filesystem component limits", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-long-session-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const sessionId = `/Users/zhouatie/.config/pi/sessions/${"界".repeat(100)}.jsonl`;
+			const runId = "pending-long-session";
+			const resultPath = path.join(resultsDir, `${runId}.json`);
+			fs.mkdirSync(resultPath);
+
+			writePendingAsyncResultFile(resultPath, { id: runId, runId, sessionId, success: true });
+
+			const payloadPath = pendingPath(resultsDir, sessionId, runId);
+			assert.ok(Buffer.byteLength(path.basename(path.dirname(payloadPath)), "utf-8") <= 255);
+			assert.equal(fs.existsSync(payloadPath), true);
+			assert.deepEqual(resultCandidateFilesForSession(resultsDir, sessionId), [`${runId}.json`]);
+			assert.equal(resultPayloadPathForSessionRun(resultsDir, sessionId, runId), payloadPath);
+			fs.rmSync(path.join(resultsDir, "result-index"), { recursive: true });
+			assert.equal(resultPayloadPathForIndexedRun(resultsDir, runId), payloadPath);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps pending results for near-limit run ids below filesystem component limits", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-long-run-"));
+		const originalError = console.error;
+		try {
+			console.error = () => {};
+			const sessionId = "session-a";
+			for (const runId of ["x".repeat(250), "y".repeat(251)]) {
+				const resultPath = path.join(resultsDir, `${runId}.json`);
+				if (runId.length === 250) fs.mkdirSync(resultPath);
+				writePendingAsyncResultFile(resultPath, { id: runId, runId, sessionId, success: true });
+
+				const payloadPath = pendingPath(resultsDir, sessionId, runId);
+				const pendingFile = path.basename(payloadPath);
+				assert.ok(Buffer.byteLength(pendingFile, "utf-8") <= 255);
+				assert.equal(fs.existsSync(payloadPath), true);
+				assert.equal(resultPayloadPathForSessionRun(resultsDir, sessionId, runId), payloadPath);
+			}
+			assert.equal(path.basename(pendingPath(resultsDir, sessionId, "x".repeat(250))), `${"x".repeat(250)}.json`);
+			assert.match(path.basename(pendingPath(resultsDir, sessionId, "y".repeat(251))), /^~sha256-[a-f0-9]{64}\.json$/);
 		} finally {
 			console.error = originalError;
 			fs.rmSync(resultsDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes #1135 by bounding async result session and run path segments before they become filesystem components. This keeps `subagent_wait` from failing with `ENAMETOOLONG` when the session identity is a long path with expanded Unicode bytes.

The pending-result fallback still reads the same candidate file per pending session directory when the session index is absent. Atomic JSON temp names now stay below the component limit too.

Thanks to [@zhouatie](https://github.com/zhouatie) for #1135.

## Validation

- `node --experimental-strip-types --test test/unit/atomic-json.test.ts test/unit/index-segment.test.ts test/unit/result-files.test.ts test/unit/run-id-resolver.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh exact-head review: `/tmp/pi-subagents-backlog-20260815T042535Z/issue-1135-review-followup.md`
