### PR TITLE
fix(mcp): match request header cache identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Keep `mcp:<server>` direct tools available when pi-mcp-adapter cache identity includes a request-header command. Thanks to [@xz-dev](https://github.com/xz-dev) for #1141.
 - Fall back from an implicit `defaultContext: fork` to `fresh` when the parent session file or current leaf is not available yet, instead of failing the first launch. Explicit `context: "fork"` remains fail-fast. Thanks to [@hyein-cbio](https://github.com/hyein-cbio) for #1137.
 - Preserve a child's file-only report when its output path also names the workflow summary output.
 - Keep concurrent async result promotion from deleting a newer payload or another promoter's published result. Thanks to [@albertgwo](https://github.com/albertgwo) for #1130.

--- a/src/runs/shared/mcp-direct-tool-allowlist.ts
+++ b/src/runs/shared/mcp-direct-tool-allowlist.ts
@@ -32,6 +32,12 @@ interface ServerEntry {
 	cwd?: string;
 	url?: string;
 	headers?: Record<string, string>;
+	requestHeadersCommand?: {
+		command: string;
+		args?: string[];
+		env?: Record<string, string>;
+		timeoutMs?: number;
+	};
 	auth?: "oauth" | "bearer" | false;
 	bearerToken?: string;
 	bearerTokenEnv?: string;
@@ -279,6 +285,14 @@ export function computeMcpServerHash(definition: ServerEntry): string {
 		cwd: resolveConfigPath(definition.cwd),
 		url: resolveServerUrl(definition),
 		headers: interpolateEnvRecord(definition.headers),
+		requestHeadersCommand: definition.requestHeadersCommand
+			? {
+				command: interpolateEnvVars(definition.requestHeadersCommand.command),
+				args: definition.requestHeadersCommand.args?.map(interpolateEnvVars),
+				env: interpolateEnvRecord(definition.requestHeadersCommand.env),
+				timeoutMs: definition.requestHeadersCommand.timeoutMs,
+			}
+			: undefined,
 		auth: definition.auth,
 		bearerToken: resolveBearerToken(definition),
 		bearerTokenEnv: definition.bearerTokenEnv,

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -909,7 +909,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		);
 	});
 
-	it("matches pi-mcp-adapter 2.20.1 metadata cache hashes", () => {
+	it("matches pi-mcp-adapter 2.26.0 metadata cache hashes", () => {
 		process.env.MCP_HASH_ROOT = "/tmp/mcp-root";
 		process.env.MCP_HASH_TOKEN = "token-value";
 
@@ -930,15 +930,21 @@ describe("buildPiArgs system prompt mode wiring", () => {
 						Authorization: "Bearer ${MCP_HASH_TOKEN}",
 						Secret: "!op read test",
 					},
+					requestHeadersCommand: {
+						command: "headers --token $env:MCP_HASH_TOKEN",
+						args: ["--root", "{env:MCP_HASH_ROOT}"],
+						env: { TOKEN: "${MCP_HASH_TOKEN}", SECRET_COMMAND: "!op read test" },
+						timeoutMs: 2500,
+					},
 					auth: "bearer",
 					bearerTokenEnv: "MCP_HASH_TOKEN",
 				}),
 				computeMcpServerHash({ socket: "{env:MCP_HASH_ROOT}/rmcp.sock" }),
 			],
 			[
-				"e78fc93f972eabed6a17c81a253765e013089b082dc8c0a05e9dfe6cb0cb8248",
-				"90c5d968d664477fe0c72f3978c744ae9e44c8b0adc529685d0c5f337061b4a5",
-				"a1d6c326455134aa82feb4523939d6f987f85577fa4cae410f6fb8408cbf750d",
+				"2c6d629872df1d4243906b17c57ebf688d8be0426e471bc2b0c956d952823c63",
+				"a7d142f0300b3fc6cce3039823eab3d9da9635a20f8d0c5d1c414d6c2da83968",
+				"592c6a094c7ba78133bffa5498e268e70dac7b9c450f9c23d9a46585a54edb50",
 			],
 		);
 	});
@@ -985,7 +991,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		writeMcpFixture(fixture, {
 			serverName: "github",
 			definition: { command: "github-mcp", protocolVersion: "2025-03-26" },
-			configHash: "25b77b7189f1c5fe80b028cb84eb393532528231ac39081fe97c4e2ee7fa086b",
+			configHash: "e2be19d9c42c791c8c125397cc9a5c1b592effe15c422a7f7d5fbf2eb6397251",
 			tools: [{ name: "search_repositories" }],
 		});
 


### PR DESCRIPTION
## Summary

- include `requestHeadersCommand` in pi-mcp-adapter metadata cache identity calculation
- interpolate its command, arguments, and environment exactly like pi-mcp-adapter 2.26.0
- update direct-tool cache hash fixtures to the current adapter contract

## Problem

pi-subagents validates cached MCP metadata by independently computing the same server identity hash as pi-mcp-adapter. pi-mcp-adapter 2.26.0 includes `requestHeadersCommand` in that identity, but pi-subagents does not.

When any configured MCP server uses `requestHeadersCommand`, every cached entry has a different hash from the one pi-subagents expects. `mcp:<server>` then resolves no direct tools, so the child receives neither the requested MCP tool names nor their declarations.

This was reproduced with `mcp:perplexity` and `mcp:tavily`: both current cache entries were fresh and populated, but the resolver returned empty arrays. With this change, the same real configuration resolves all selected direct tools.

## Validation

- `npm run typecheck`
- focused `test/unit/pi-args.test.ts` MCP cases: 3 passed
- `npm run test:e2e`: skipped because runtime peer packages are unavailable in the fixture environment
- real resolver smoke against pi-mcp-adapter 2.26.0 cache:
  - Perplexity: 4 direct tools
  - Tavily: 5 direct tools
- independent reviewer: approved, no blockers or non-blockers

The full unit and integration suites were attempted. Existing unrelated package-discovery/worktree/host-verification tests failed or exceeded the 300-second runner limit; the focused MCP tests and typecheck remained green.
