### PR TITLE
fix: sweep expired wait subscriptions armed by another session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Sweep expired wait subscriptions armed by another session, so a record left behind by a session that never returns stops accumulating in the subscriptions directory. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1142.
 - Fall back from an implicit `defaultContext: fork` to `fresh` when the parent session file or current leaf is not available yet, instead of failing the first launch. Explicit `context: "fork"` remains fail-fast. Thanks to [@hyein-cbio](https://github.com/hyein-cbio) for #1137.
 - Preserve a child's file-only report when its output path also names the workflow summary output.
 - Keep concurrent async result promotion from deleting a newer payload or another promoter's published result. Thanks to [@albertgwo](https://github.com/albertgwo) for #1130.

--- a/src/runs/background/wait-subscriptions.ts
+++ b/src/runs/background/wait-subscriptions.ts
@@ -21,6 +21,12 @@ import {
 
 const SUBSCRIPTION_VERSION = 1;
 const RECONCILE_INTERVAL_MS = 1_000;
+/**
+ * How often the subscriptions directory is re-scanned for expired records left
+ * by other sessions. Rare compared to RECONCILE_INTERVAL_MS because it costs a
+ * directory read, and nothing depends on the sweep being prompt.
+ */
+const FOREIGN_SWEEP_INTERVAL_MS = 60_000;
 
 export interface ArmWaitSubscriptionInput {
 	targetKind: "async" | "foreground";
@@ -95,6 +101,60 @@ export function createWaitSubscriptionManager(
 	state.waitSubscriptions = subscriptions;
 	const unresolvedRestoredForegroundTokens = new Set<string>();
 	let disposed = false;
+	let lastForeignSweepAt = 0;
+
+	/**
+	 * Remove expired records armed by another session.
+	 *
+	 * Only the owning session can be woken, so restore() never loads a foreign
+	 * record into `subscriptions` and reconcileRecord() returns before its
+	 * timeout branch. Nothing reconciles such a record and nothing expires it, so
+	 * a session that arms a wait and never comes back (forked, renamed, deleted)
+	 * leaves one file here per wait, forever.
+	 *
+	 * Runs on the reconcile timer as well as at restore(), because a record that
+	 * is still live when another session starts would otherwise never be looked
+	 * at again: restore() only fires on session_start, and reconcile() walks the
+	 * in-memory map, which holds current-session records only. A host that keeps
+	 * one session open for hours is exactly where that gap bites.
+	 *
+	 * Never throws: it runs from the reconcile timer.
+	 */
+	const sweepExpiredForeignSubscriptions = (force = false) => {
+		const sweptAt = now();
+		if (!force && sweptAt - lastForeignSweepAt < FOREIGN_SWEEP_INTERVAL_MS) return;
+		lastForeignSweepAt = sweptAt;
+		let files: string[];
+		try {
+			files = fs.readdirSync(subscriptionsDir).filter((file) => file.endsWith(".json"));
+		} catch (error) {
+			if (!isNotFound(error)) console.error(`Failed to scan wait subscriptions in '${subscriptionsDir}':`, error);
+			return;
+		}
+		for (const file of files) {
+			const filePath = path.join(subscriptionsDir, file);
+			let record: WaitSubscriptionRecord | undefined;
+			try {
+				record = parseRecord(JSON.parse(fs.readFileSync(filePath, "utf-8")));
+			} catch (error) {
+				console.error(`Ignoring invalid wait subscription '${filePath}':`, error);
+				continue;
+			}
+			if (!record || file !== `${record.token}.json`) continue;
+			// The owning session keeps its own expired records so reconcileRecord()
+			// can still settle them with the "timed out" notice callers expect.
+			if (record.sessionId === state.currentSessionId) continue;
+			if (sweptAt < record.expiresAt) continue;
+			try {
+				fs.unlinkSync(filePath);
+			} catch (error) {
+				// Losing this race is harmless: another session may have swept the
+				// same expired record. Anything else is reported and retried on the
+				// next sweep rather than interrupting the caller.
+				if (!isNotFound(error)) console.error(`Failed to remove expired wait subscription '${filePath}':`, error);
+			}
+		}
+	};
 
 	const remove = (record: WaitSubscriptionRecord) => {
 		try {
@@ -187,7 +247,11 @@ export function createWaitSubscriptionManager(
 	};
 
 	const reconcile = () => {
-		if (disposed || !state.currentSessionId) return;
+		if (disposed) return;
+		// Before the session check: with no current session every record is
+		// foreign, and expired ones should still be cleaned up.
+		sweepExpiredForeignSubscriptions();
+		if (!state.currentSessionId) return;
 		for (const record of [...subscriptions.values()]) {
 			try {
 				reconcileRecord(record);
@@ -233,6 +297,9 @@ export function createWaitSubscriptionManager(
 		restore() {
 			subscriptions.clear();
 			unresolvedRestoredForegroundTokens.clear();
+			// Unconditional: a process that starts without a session identity should
+			// still clear records nobody can act on.
+			sweepExpiredForeignSubscriptions(true);
 			if (!state.currentSessionId) return;
 			let files: string[];
 			try {
@@ -245,25 +312,7 @@ export function createWaitSubscriptionManager(
 				try {
 					const record = parseRecord(JSON.parse(fs.readFileSync(path.join(subscriptionsDir, file), "utf-8")));
 					if (!record || file !== `${record.token}.json`) continue;
-					// Sweep expired records armed by another session. Only the owning
-					// session can be woken, so restore() never loads a foreign record and
-					// reconcileRecord() returns before its timeout branch: nothing
-					// reconciles it, nothing expires it, and the file stays in this
-					// directory for the life of the machine. A session that arms a wait
-					// and never comes back (forked, renamed, deleted) leaks one file per
-					// wait, forever.
-					//
-					// The owning session keeps its own expired records so reconcileRecord()
-					// can still settle them with the "timed out" notice callers expect.
-					if (record.sessionId !== state.currentSessionId && now() >= record.expiresAt) {
-						try {
-							fs.unlinkSync(path.join(subscriptionsDir, file));
-						} catch (error) {
-							if (!isNotFound(error)) throw error;
-						}
-						continue;
-					}
-					if (record.sessionId === state.currentSessionId) {
+						if (record.sessionId === state.currentSessionId) {
 						subscriptions.set(record.token, record);
 						if (record.targetKind === "foreground" && !state.foregroundRuns?.has(record.runId)) unresolvedRestoredForegroundTokens.add(record.token);
 					}

--- a/src/runs/background/wait-subscriptions.ts
+++ b/src/runs/background/wait-subscriptions.ts
@@ -27,6 +27,14 @@ const RECONCILE_INTERVAL_MS = 1_000;
  * directory read, and nothing depends on the sweep being prompt.
  */
 const FOREIGN_SWEEP_INTERVAL_MS = 60_000;
+/**
+ * How far past expiry a record armed by another session is kept before it is
+ * swept. The owning session settles its own expired records with a "timed out"
+ * notice on the next restore(), so removing one the moment it expires would take
+ * that notice away from a session that simply had not resumed yet. A day is long
+ * enough for an ordinary return and short enough to bound the directory.
+ */
+const FOREIGN_SWEEP_GRACE_MS = 24 * 60 * 60 * 1000;
 
 export interface ArmWaitSubscriptionInput {
 	targetKind: "async" | "foreground";
@@ -112,6 +120,9 @@ export function createWaitSubscriptionManager(
 	 * a session that arms a wait and never comes back (forked, renamed, deleted)
 	 * leaves one file here per wait, forever.
 	 *
+	 * Kept for FOREIGN_SWEEP_GRACE_MS past expiry so an owner that resumes late
+	 * still finds its record and gets the timeout notice.
+	 *
 	 * Runs on the reconcile timer as well as at restore(), because a record that
 	 * is still live when another session starts would otherwise never be looked
 	 * at again: restore() only fires on session_start, and reconcile() walks the
@@ -144,7 +155,7 @@ export function createWaitSubscriptionManager(
 			// The owning session keeps its own expired records so reconcileRecord()
 			// can still settle them with the "timed out" notice callers expect.
 			if (record.sessionId === state.currentSessionId) continue;
-			if (sweptAt < record.expiresAt) continue;
+			if (sweptAt < record.expiresAt + FOREIGN_SWEEP_GRACE_MS) continue;
 			try {
 				fs.unlinkSync(filePath);
 			} catch (error) {

--- a/src/runs/background/wait-subscriptions.ts
+++ b/src/runs/background/wait-subscriptions.ts
@@ -245,6 +245,24 @@ export function createWaitSubscriptionManager(
 				try {
 					const record = parseRecord(JSON.parse(fs.readFileSync(path.join(subscriptionsDir, file), "utf-8")));
 					if (!record || file !== `${record.token}.json`) continue;
+					// Sweep expired records armed by another session. Only the owning
+					// session can be woken, so restore() never loads a foreign record and
+					// reconcileRecord() returns before its timeout branch: nothing
+					// reconciles it, nothing expires it, and the file stays in this
+					// directory for the life of the machine. A session that arms a wait
+					// and never comes back (forked, renamed, deleted) leaks one file per
+					// wait, forever.
+					//
+					// The owning session keeps its own expired records so reconcileRecord()
+					// can still settle them with the "timed out" notice callers expect.
+					if (record.sessionId !== state.currentSessionId && now() >= record.expiresAt) {
+						try {
+							fs.unlinkSync(path.join(subscriptionsDir, file));
+						} catch (error) {
+							if (!isNotFound(error)) throw error;
+						}
+						continue;
+					}
 					if (record.sessionId === state.currentSessionId) {
 						subscriptions.set(record.token, record);
 						if (record.targetKind === "foreground" && !state.foregroundRuns?.has(record.runId)) unresolvedRestoredForegroundTokens.add(record.token);

--- a/test/unit/wait-subscriptions.test.ts
+++ b/test/unit/wait-subscriptions.test.ts
@@ -432,3 +432,133 @@ describe("non-blocking wait subscriptions", () => {
 		}
 	});
 });
+
+describe("wait subscriptions armed by another session", () => {
+	function subscriptionFiles(dir: string): string[] {
+		try {
+			return fs.readdirSync(dir).filter((file) => file.endsWith(".json"));
+		} catch {
+			return [];
+		}
+	}
+
+	it("sweeps an expired record whose owning session never came back", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-orphan-"));
+		const subscriptionsDir = path.join(root, "subscriptions");
+		const sent: string[] = [];
+		const pi = {
+			events: new TestBus(),
+			sendMessage(message: { content?: unknown }) { sent.push(String(message.content)); },
+		};
+		let now = 1_000;
+		const owner = makeState("session-a");
+		const armer = createWaitSubscriptionManager(pi as never, owner, {
+			subscriptionsDir,
+			pollIntervalMs: 60_000,
+			now: () => now,
+		});
+		try {
+			armer.arm({ targetKind: "async", runId: "run-orphan", requestedId: "run-orphan", timeoutMs: 100 });
+			assert.equal(subscriptionFiles(subscriptionsDir).length, 1);
+			armer.dispose();
+
+			// A different session starts after the record has expired. Before this
+			// swept, the file was never loaded, never reconciled and never timed
+			// out, so it stayed on disk forever.
+			now = 1_101;
+			const other = makeState("session-b");
+			const restarted = createWaitSubscriptionManager(pi as never, other, {
+				subscriptionsDir,
+				pollIntervalMs: 60_000,
+				now: () => now,
+			});
+			try {
+				restarted.restore();
+				assert.deepEqual(subscriptionFiles(subscriptionsDir), [], "expired foreign record is removed");
+				assert.equal(sent.length, 0, "no wake is delivered to the wrong session");
+			} finally {
+				restarted.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps another session's record until it expires", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-foreign-live-"));
+		const subscriptionsDir = path.join(root, "subscriptions");
+		const pi = {
+			events: new TestBus(),
+			sendMessage() {},
+		};
+		let now = 1_000;
+		const owner = makeState("session-a");
+		const armer = createWaitSubscriptionManager(pi as never, owner, {
+			subscriptionsDir,
+			pollIntervalMs: 60_000,
+			now: () => now,
+		});
+		try {
+			armer.arm({ targetKind: "async", runId: "run-live", requestedId: "run-live", timeoutMs: 10_000 });
+			armer.dispose();
+
+			now = 1_500; // still well inside the window
+			const other = makeState("session-b");
+			const restarted = createWaitSubscriptionManager(pi as never, other, {
+				subscriptionsDir,
+				pollIntervalMs: 60_000,
+				now: () => now,
+			});
+			try {
+				restarted.restore();
+				assert.equal(subscriptionFiles(subscriptionsDir).length, 1, "an unexpired record still belongs to its owner");
+			} finally {
+				restarted.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("still gives the owning session its timeout notice after a restart", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-owner-timeout-"));
+		const asyncRoot = path.join(root, "runs");
+		const subscriptionsDir = path.join(root, "subscriptions");
+		const sent: string[] = [];
+		const pi = {
+			events: new TestBus(),
+			sendMessage(message: { content?: unknown }) { sent.push(String(message.content)); },
+		};
+		let now = 1_000;
+		writeStatus(asyncRoot, "run-owned", "running", { sessionId: "session-a", pid: 999_997 });
+		const first = createWaitSubscriptionManager(pi as never, makeState("session-a"), {
+			asyncDirRoot: asyncRoot,
+			subscriptionsDir,
+			pollIntervalMs: 60_000,
+			now: () => now,
+			kill: () => true,
+		});
+		try {
+			first.arm({ targetKind: "async", runId: "run-owned", requestedId: "run-owned", timeoutMs: 100 });
+			first.dispose();
+
+			now = 1_101; // expired, but this session owns it
+			const resumed = createWaitSubscriptionManager(pi as never, makeState("session-a"), {
+				asyncDirRoot: asyncRoot,
+				subscriptionsDir,
+				pollIntervalMs: 60_000,
+				now: () => now,
+				kill: () => true,
+			});
+			try {
+				resumed.restore();
+				assert.match(sent.shift() ?? "", /timed out/, "the owner is still told its wait expired");
+				assert.deepEqual(subscriptionFiles(subscriptionsDir), []);
+			} finally {
+				resumed.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/wait-subscriptions.test.ts
+++ b/test/unit/wait-subscriptions.test.ts
@@ -462,10 +462,10 @@ describe("wait subscriptions armed by another session", () => {
 			assert.equal(subscriptionFiles(subscriptionsDir).length, 1);
 			armer.dispose();
 
-			// A different session starts after the record has expired. Before this
+			// A different session starts well after the record expired. Before this
 			// swept, the file was never loaded, never reconciled and never timed
 			// out, so it stayed on disk forever.
-			now = 1_101;
+			now = 1_101 + 86400000;
 			const other = makeState("session-b");
 			const restarted = createWaitSubscriptionManager(pi as never, other, {
 				subscriptionsDir,
@@ -551,12 +551,46 @@ describe("wait subscriptions armed by another session", () => {
 				open.restore();
 				assert.equal(subscriptionFiles(subscriptionsDir).length, 1, "still live, so retained");
 
-				// The other session stays open past the record's expiry.
-				now = 1_000 + 30_000 + 120_000;
+				// The other session stays open past the record's expiry and grace.
+				now = 1_000 + 30_000 + 86400000 + 120_000;
 				open.reconcile();
 				assert.deepEqual(subscriptionFiles(subscriptionsDir), [], "expired record is swept without a restart");
 			} finally {
 				open.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps an expired foreign record through the grace window", () => {
+		// The owner settles its own expired records with a timeout notice on its next
+		// restore(). Sweeping the instant it expires would take that away from a
+		// session that had simply not resumed yet.
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-grace-"));
+		const subscriptionsDir = path.join(root, "subscriptions");
+		const pi = { events: new TestBus(), sendMessage() {} };
+		let now = 1_000;
+		const armer = createWaitSubscriptionManager(pi as never, makeState("session-a"), {
+			subscriptionsDir,
+			pollIntervalMs: 60_000,
+			now: () => now,
+		});
+		try {
+			armer.arm({ targetKind: "async", runId: "run-grace", requestedId: "run-grace", timeoutMs: 100 });
+			armer.dispose();
+
+			now = 1_101 + 60_000; // expired, but well inside the grace window
+			const other = createWaitSubscriptionManager(pi as never, makeState("session-b"), {
+				subscriptionsDir,
+				pollIntervalMs: 60_000,
+				now: () => now,
+			});
+			try {
+				other.restore();
+				assert.equal(subscriptionFiles(subscriptionsDir).length, 1, "owner can still collect its timeout notice");
+			} finally {
+				other.dispose();
 			}
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/wait-subscriptions.test.ts
+++ b/test/unit/wait-subscriptions.test.ts
@@ -520,6 +520,49 @@ describe("wait subscriptions armed by another session", () => {
 		}
 	});
 
+	it("sweeps a foreign record that expires while another session stays open", () => {
+		// restore() only fires on session_start and reconcile() walks the in-memory
+		// map, which holds current-session records only. A record that is still live
+		// when the next session starts is therefore retained by restore() and, without
+		// a periodic sweep, never looked at again once it expires.
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-late-expiry-"));
+		const subscriptionsDir = path.join(root, "subscriptions");
+		const pi = {
+			events: new TestBus(),
+			sendMessage() {},
+		};
+		let now = 1_000;
+		const armer = createWaitSubscriptionManager(pi as never, makeState("session-a"), {
+			subscriptionsDir,
+			pollIntervalMs: 60_000,
+			now: () => now,
+		});
+		try {
+			armer.arm({ targetKind: "async", runId: "run-late", requestedId: "run-late", timeoutMs: 30_000 });
+			armer.dispose();
+
+			const other = makeState("session-b");
+			const open = createWaitSubscriptionManager(pi as never, other, {
+				subscriptionsDir,
+				pollIntervalMs: 60_000,
+				now: () => now,
+			});
+			try {
+				open.restore();
+				assert.equal(subscriptionFiles(subscriptionsDir).length, 1, "still live, so retained");
+
+				// The other session stays open past the record's expiry.
+				now = 1_000 + 30_000 + 120_000;
+				open.reconcile();
+				assert.deepEqual(subscriptionFiles(subscriptionsDir), [], "expired record is swept without a restart");
+			} finally {
+				open.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("still gives the owning session its timeout notice after a restart", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-owner-timeout-"));
 		const asyncRoot = path.join(root, "runs");


### PR DESCRIPTION
## Problem

A wait subscription armed by one session is never cleaned up if that session does not come back.

`restore()` only loads records whose `sessionId` matches the current session, and `reconcileRecord()` returns immediately when it does not match:

```ts
// restore()
if (record.sessionId === state.currentSessionId) { subscriptions.set(record.token, record); }

// reconcileRecord()
if (record.sessionId !== state.currentSessionId) return;
```

Together these mean a foreign record is never loaded into memory, so it is never reconciled **and never reaches the timeout branch**. It is not "delivered late" — it is never evaluated at all. The file stays in `wait-subscriptions/` indefinitely, one per wait, for the life of the machine.

This is reachable in ordinary use: arm a non-blocking wait, then fork the session, resume a different one, or simply never open that session again. `session_start` is emitted with `reason: "resume" | "new" | "fork"` and a `previousSessionFile`, so a single runtime routinely moves between sessions.

## Repro

Against `main` (0.50.0), driving the real `createWaitSubscriptionManager`:

| scenario | wake delivered | files left |
| --- | --- | --- |
| control — owning session is current | 1 | 0 |
| run completes while another session is current | 0 | 1 |
| restart on another session, clock advanced 24h | 0 | 1 |

The third row is the point: even jumping far past `expiresAt`, nothing settles the record and nothing removes it.

## Change

`restore()` now removes a subscription file when it belongs to **another** session **and** has already expired.

Deliberately narrow:

- The owning session's expired records are left in place, so `reconcileRecord()` still settles them with the `timed out` notice callers expect. A new test covers that, to prevent this cleanup from swallowing it.
- Unexpired foreign records are left alone, so a session that returns still gets its wake. Also covered by a test.
- Delivery semantics are unchanged. `pi.sendMessage` targets the current session, so cross-session delivery is not attempted here.

## Trade-off

A session that returns *after* its wait expired will no longer receive the `timed out` notice if another session swept the record first. That seemed the right side of the trade: the wait has already exceeded its timeout (30 minutes by default), so the notice is stale, whereas the alternative is unbounded growth of a temp directory. Happy to gate the sweep behind a longer grace period instead if you would rather keep that notice.

## Tests

Three cases added to `test/unit/wait-subscriptions.test.ts`:

- `sweeps an expired record whose owning session never came back` — fails on `main`, passes with the change
- `keeps another session's record until it expires` — guards against over-deletion
- `still gives the owning session its timeout notice after a restart` — guards the regression above

`npm run typecheck` is clean.

On `npm run test:unit` I see 18 failures, but they are **pre-existing on `81fb689`**, not introduced here — I ran the suite with and without this change on the same machine:

| | tests | pass | fail |
| --- | --- | --- | --- |
| `main` (change stashed) | 2018 | 1976 | 18 |
| with this change | 2021 | 1979 | 18 |

The delta is exactly the three tests added here, and no failing test name appears in one run but not the other. They are all in the agent-management / agent-contract suites; `wait-subscriptions.test.ts` is fully green. Quite possibly environmental on Windows — flagging rather than claiming a green suite.
