### PR TITLE
feat: allow a host to bound synchronous filesystem retry sleeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
+
 ### Fixed
 - Keep `mcp:<server>` direct tools available when pi-mcp-adapter cache identity includes a request-header command. Thanks to [@xz-dev](https://github.com/xz-dev) for #1141.
 - Fall back from an implicit `defaultContext: fork` to `fresh` when the parent session file or current leaf is not available yet, instead of failing the first launch. Explicit `context: "fork"` remains fail-fast. Thanks to [@hyein-cbio](https://github.com/hyein-cbio) for #1137.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -437,3 +437,19 @@ Controls smart batching of async-completion notifications. When several backgrou
 ## `permissions`
 
 Native child tool permission rules. See [watchdog.md](watchdog.md#native-child-tool-permissions).
+
+## `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS`
+
+Caps the total time a single retried filesystem operation may sleep, in milliseconds. Environment-only; there is no config key.
+
+Atomic status and result writes retry on `EACCES`, `EBUSY`, and `EPERM`, which on Windows are usually a scanner or a sibling process holding the destination of a rename for a moment. The retry ladder sleeps up to about 7.9s in total, and it sleeps *synchronously* — `Atomics.wait` parks the calling thread rather than spinning.
+
+That is the right trade-off for a CLI. It is the wrong one for a long-lived process that loads `pi-subagents` in-process and runs those writers on its event loop: one contended rename stalls everything it serves for the length of the ladder, and because the thread is parked rather than busy, it presents as an unresponsive process sitting at 0% CPU. A wide fanout makes contention on a single `status.json` likely.
+
+Set this to bound that stall. The ladder keeps its number of attempts and only the sleeps shrink, because `run-fanout-budget` and mission state locking use the ladder's length as their attempt budget:
+
+```text
+PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS=1000
+```
+
+Unset by default, so behaviour is unchanged unless you opt in. Opting in trades lock-wait tolerance for responsiveness: entries clamped to `0` return immediately, so contention that would previously have been waited out surfaces as an error sooner. Values that are not a non-negative integer fail instead of being coerced.

--- a/src/shared/file-system-retry.ts
+++ b/src/shared/file-system-retry.ts
@@ -2,7 +2,49 @@ const WAIT_BUFFER = typeof SharedArrayBuffer !== "undefined" ? new SharedArrayBu
 const WAIT_VIEW = WAIT_BUFFER ? new Int32Array(WAIT_BUFFER) : undefined;
 const RETRYABLE_FILE_SYSTEM_ERROR_CODES = new Set(["EACCES", "EBUSY", "EPERM"]);
 
-export const DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS = [10, 25, 50, 100, 200, 500, 1000, 2000, 4000] as const;
+export const FS_RETRY_MAX_TOTAL_MS_ENV = "PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS";
+
+const BASE_FILE_SYSTEM_RETRY_DELAYS_MS = [10, 25, 50, 100, 200, 500, 1000, 2000, 4000] as const;
+
+/**
+ * Clamp the retry ladder to a total sleep budget, preserving its length.
+ *
+ * waitForFileSystemRetry blocks the calling thread, so the ladder above is also
+ * a ceiling on how long a single contended rename can stall that thread: about
+ * 7.9s. That is fine for a short-lived CLI. A long-lived host that loads this
+ * extension in-process runs the same writers on its event loop, where an 8s
+ * stall stops it serving anything at all -- and because Atomics.wait parks
+ * rather than spins, it presents as an unresponsive process at 0% CPU.
+ *
+ * The length is preserved deliberately: run-fanout-budget.ts and
+ * workflow-state.ts index this array by attempt number and treat running off
+ * the end as "timed out acquiring lock". Shortening it would quietly shrink
+ * those attempt budgets too, so only the sleeps shrink here.
+ *
+ * Unset by default, so behaviour is unchanged unless a host opts in. Opting in
+ * trades lock-wait tolerance for responsiveness: entries clamped to 0 return
+ * immediately, so contention that would previously have been waited out is
+ * surfaced as an error sooner.
+ */
+export function resolveFileSystemRetryDelays(
+	env: NodeJS.ProcessEnv = process.env,
+	base: readonly number[] = BASE_FILE_SYSTEM_RETRY_DELAYS_MS,
+): readonly number[] {
+	const raw = env[FS_RETRY_MAX_TOTAL_MS_ENV];
+	if (raw === undefined || raw.trim() === "") return base;
+	const budget = Number(raw);
+	if (!Number.isInteger(budget) || budget < 0) {
+		throw new Error(`${FS_RETRY_MAX_TOTAL_MS_ENV} must be a non-negative integer number of milliseconds.`);
+	}
+	let spent = 0;
+	return base.map((delayMs) => {
+		const allowed = Math.max(0, Math.min(delayMs, budget - spent));
+		spent += allowed;
+		return allowed;
+	});
+}
+
+export const DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS = resolveFileSystemRetryDelays();
 
 export type FileSystemRetryOptions = {
 	retryDelaysMs?: readonly number[];

--- a/test/unit/file-system-retry.test.ts
+++ b/test/unit/file-system-retry.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	FS_RETRY_MAX_TOTAL_MS_ENV,
+	resolveFileSystemRetryDelays,
+	runFileSystemOperationWithRetry,
+} from "../../src/shared/file-system-retry.ts";
+
+const BASE = [10, 25, 50, 100, 200, 500, 1000, 2000, 4000];
+const total = (delays: readonly number[]): number => delays.reduce((sum, value) => sum + value, 0);
+
+describe("file system retry budget", () => {
+	it("is unchanged when the environment variable is unset or blank", () => {
+		assert.deepEqual(resolveFileSystemRetryDelays({}, BASE), BASE);
+		assert.deepEqual(resolveFileSystemRetryDelays({ [FS_RETRY_MAX_TOTAL_MS_ENV]: "" }, BASE), BASE);
+		assert.deepEqual(resolveFileSystemRetryDelays({ [FS_RETRY_MAX_TOTAL_MS_ENV]: "   " }, BASE), BASE);
+	});
+
+	it("clamps the total sleep to the configured budget", () => {
+		const delays = resolveFileSystemRetryDelays({ [FS_RETRY_MAX_TOTAL_MS_ENV]: "1000" }, BASE);
+		assert.equal(total(delays), 1000);
+		assert.deepEqual(delays, [10, 25, 50, 100, 200, 500, 115, 0, 0]);
+	});
+
+	it("keeps the ladder length, because callers use it as an attempt budget", () => {
+		// run-fanout-budget.ts and workflow-state.ts index this array by attempt
+		// number and treat an undefined entry as "timed out acquiring lock".
+		// Dropping entries would silently shrink those budgets.
+		for (const budget of ["0", "1", "250", "100000"]) {
+			const delays = resolveFileSystemRetryDelays({ [FS_RETRY_MAX_TOTAL_MS_ENV]: budget }, BASE);
+			assert.equal(delays.length, BASE.length, `length preserved for budget ${budget}`);
+			assert.ok(delays.every((value) => Number.isInteger(value) && value >= 0));
+		}
+	});
+
+	it("never exceeds the base ladder, even for a huge budget", () => {
+		assert.deepEqual(resolveFileSystemRetryDelays({ [FS_RETRY_MAX_TOTAL_MS_ENV]: "99999999" }, BASE), BASE);
+	});
+
+	it("supports a zero budget as retry-without-sleeping", () => {
+		const delays = resolveFileSystemRetryDelays({ [FS_RETRY_MAX_TOTAL_MS_ENV]: "0" }, BASE);
+		assert.equal(total(delays), 0);
+		let attempts = 0;
+		const slept: number[] = [];
+		assert.throws(() => runFileSystemOperationWithRetry(() => {
+			attempts += 1;
+			throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+		}, { retryDelaysMs: delays, wait: (delayMs) => slept.push(delayMs) }), /EPERM/);
+		assert.equal(attempts, BASE.length + 1, "all attempts still run");
+		// waitForFileSystemRetry returns immediately for <= 0, so the thread is
+		// never parked even though wait() is still called between attempts.
+		assert.ok(slept.every((value) => value === 0), "no non-zero sleep is requested");
+	});
+
+	it("rejects values that are not a non-negative integer", () => {
+		for (const value of ["-1", "abc", "1.5", "NaN", "1e3ms"]) {
+			assert.throws(
+				() => resolveFileSystemRetryDelays({ [FS_RETRY_MAX_TOTAL_MS_ENV]: value }, BASE),
+				new RegExp(FS_RETRY_MAX_TOTAL_MS_ENV),
+				`rejects ${value}`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Problem

`waitForFileSystemRetry` blocks the calling thread with `Atomics.wait`, and the default ladder sleeps up to about **7.9s** in total for one contended operation.

That is the right trade-off for a CLI. It is the wrong one for a long-lived process that loads `pi-subagents` in-process, where the same atomic status writers run on the host's event loop. One contended `status.json` rename stalls everything that process serves for the length of the ladder. Because `Atomics.wait` parks the thread rather than spinning, it does not look like a busy loop — it looks like an unresponsive process sitting at **0% CPU**, which sends you looking in the wrong place.

Observed while embedding this extension in a web host on Windows:

- HTTP stopped responding while the process sat at 0% CPU
- `EPERM` on the tmp → final rename recurred every **~8.4s**, matching the ladder (7,885ms) plus the write and unlink around it
- a 64-wide fanout, with several processes renaming onto one `status.json`, made the contention easy to hit

Two details make this hard to work around downstream. `writeAtomicJson` and `writePrivateAtomicJson` are module-level singletons built with no options, so an embedder cannot pass `retryDelaysMs`. And the exhausted retry surfaces as an uncaught exception from a status write, which the host then has to catch.

## Change

Adds `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS`, an environment-only cap on the total sleep of one retried operation.

**Unset by default, so behaviour is unchanged unless a host opts in.**

The ladder keeps its length and only the sleeps shrink. That is deliberate, and it is the part I would have got wrong without reading the callers: `run-fanout-budget.ts` and `workflow-state.ts` index this array **by attempt number** and treat running off the end as `Timed out acquiring …`. Dropping entries to shorten the ladder would quietly shrink those lock budgets as well, which is a different change from the one intended here.

```text
PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS=1000
# [10, 25, 50, 100, 200, 500, 115, 0, 0] — same 9 attempts, 1s of sleep
```

## Trade-off

Opting in trades lock-wait tolerance for responsiveness: entries clamped to `0` return immediately, so contention that would previously have been waited out surfaces as an error sooner. That is why this is opt-in rather than a new default. If you would rather express the ceiling differently — a config key, a per-writer option, or making the wait async where the caller already is — I am happy to redo it that way; the goal is that a host embedding this can bound the stall at all.

## Tests

`test/unit/file-system-retry.test.ts` (new): unchanged when unset or blank, clamps to the budget, **preserves ladder length** for every budget, never exceeds the base ladder, supports `0` as retry-without-sleeping, and rejects non-integer or negative values instead of coercing them.

`npm run typecheck` is clean.

On `npm run test:unit` I see 18 failures, all **pre-existing on `47552b5`** and unrelated to this change (agent-management / agent-contract suites). Measured on the same machine, this branch versus `main`, so the count can be compared rather than taken on trust.
