### PR TITLE
docs: explain that a host's session lifetime owns completion wakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Preserve workflow child task output when neither the workflow nor child configures an output file (#1136).
 
 ### Changed
+- Document that a host's session lifetime owns completion wakes, and how to key an idle check on live run state rather than parent activity. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1144.
 - Clarify that subagent reviews and gates should stay async unless foreground behavior is the actual requirement.
 - Remove `prompts.render` from `workflowScript`; pass explicit task text to `runs.run` or use `/prompt-workflow` for reusable prompt templates.
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -323,6 +323,25 @@ const closed = await closeProjectPane({ cwd: "/path/to/repo", requireIdle: true 
 
 The API returns discriminated structured results with canonical project root, binding path, pane identity, bounded Herdr runtime fields, and stable error codes. `requireIdle: true` fails closed unless Herdr explicitly reports `agent_status: "idle"`; use it when an owning extension must not close a working or blocked pane. The API deliberately reports `trust: "human-verification-required"`: it never bypasses or claims to attest Pi's project-trust prompt. `PROJECT_PANES_API_VERSION` is currently `1`.
 
+## Host session lifetime and completion wakes
+
+A host that embeds this extension owns whether completion wakes can be delivered at all.
+
+The wake path lives in the extension instance. `createWaitSubscriptionManager` reconciles on a one-second interval plus the async, foreground, control, and intercom event channels, and delivers through `pi.sendMessage(..., { triggerTurn: true })`. Dispose the session and that reconcile loop goes with it.
+
+Detached children do not stop when the session does. They are the host process's children, not the session's, so the run keeps going, completes, and notifies nobody. What is lost is the notification, not the work.
+
+This matters because "is the parent busy?" is the wrong idle signal. A parent that launches a detached run and hands control back — which is what the async launch output tells it to do — is not prompting, streaming, compacting, or running a shell command. A host that reaps sessions on those signals alone will dispose exactly the session that was waiting to be woken.
+
+If your host reclaims idle sessions, keep a session alive while it still has live detached work:
+
+- Read run state from the status files under the async run directory rather than from event traffic. A long, quiet workflow sends almost nothing to the parent, so recent-activity heuristics conclude the wrong thing.
+- Treat `queued`, `running`, and `paused` as live; `complete`, `failed`, `stopped`, and `rejected` are terminal.
+- Age runs out by `lastUpdate` so a wedged run cannot pin a session forever. Live runs rewrite `status.json` continuously.
+- Note that `sessionId` in `status.json` is the parent's session *file path*, not a bare session id.
+
+The symptom when this is missed is quiet and easy to misattribute: subagents appear never to report back, which looks like a fault in this extension rather than in the host that disposed the listener.
+
 ## Runtime files
 
 The main runtime files in this repository:

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -336,9 +336,10 @@ This matters because "is the parent busy?" is the wrong idle signal. A parent th
 If your host reclaims idle sessions, keep a session alive while it still has live detached work:
 
 - Read run state from the status files under the async run directory rather than from event traffic. A long, quiet workflow sends almost nothing to the parent, so recent-activity heuristics conclude the wrong thing.
-- Treat `queued`, `running`, and `paused` as live; `complete`, `failed`, `stopped`, and `rejected` are terminal.
-- Age runs out by `lastUpdate` so a wedged run cannot pin a session forever. Live runs rewrite `status.json` continuously.
-- Note that `sessionId` in `status.json` is the parent's session *file path*, not a bare session id.
+- Treat `queued` and `running` as live, matching `isActiveAsyncState`. `paused` is not: an interrupted run is finalized as paused. The one live exception is a workflow blocked on a pending checkpoint, whose runner is still waiting for a decision — check `checkpoint.status === "pending"` if you want to keep those sessions open too.
+- Do not treat `lastUpdate` as a heartbeat. The runner advances it in memory every second but only rewrites `status.json` when the activity classification changes, so a live run inside one long quiet tool call leaves a stale file behind. Judging liveness by file age will reap exactly the run you meant to protect.
+- Prefer the recorded runner `pid`, which stays true through a silent tool call and goes false when the runner dies. Keep file age only as a fallback for runs that record no pid, and give it a wide window.
+- Match `sessionId` in `status.json` against both forms. It is resolved as `getSessionFile() ?? getSessionId()`, so it is normally the parent's session *file path*, but a session that is not persisted records a bare session id instead.
 
 The symptom when this is missed is quiet and easy to misattribute: subagents appear never to report back, which looks like a fault in this extension rather than in the host that disposed the listener.
 


### PR DESCRIPTION
## Problem

Nothing in the docs warns an embedding host that disposing an idle session silently disables completion wakes.

The wake path is owned by the extension instance: `createWaitSubscriptionManager` reconciles on a 1s interval plus a set of event channels, and `settle()` delivers through `pi.sendMessage(..., { triggerTurn: true })`. Dispose the session and that reconcile loop goes with it. The detached children do not stop — they are the *host's* child processes, not the session's — so the run continues, completes, and notifies nobody.

The failure mode is quiet and easy to misattribute. From the user's side it looks exactly like "subagents never ping back", which points at this extension, when the actual cause is the host reaping the session that was waiting.

Concretely, in a host that shut sessions down after 10 minutes idle:

- the parent launched a detached run and handed control back, as the tool output tells it to
- the host's idle check only knew about the parent's own activity — prompt, stream, compaction, bash — none of which a detached subagent is
- ~10 minutes later the session was disposed, taking the reconcile loop with it
- the run completed 15 minutes after that, into nothing

The fix belonged in the host, not here. But the constraint is invisible unless you go reading `wait-subscriptions.ts`, so it seems worth stating in the docs.

## Change

Docs only. Adds a short section for embedders covering:

- what a session's lifetime owns (the reconcile loop, and therefore every completion wake)
- that detached children outlive the session, so disposing it loses the notification rather than the work
- that "is the parent busy?" is the wrong idle signal, and live run state is the right one
- that run status files age out, so keeping a session alive on live work does not pin it forever on a wedged run

No behaviour change, no code touched.
