### PR TITLE
chore: remove legacy subagent compatibility surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Preserve workflow child task output when neither the workflow nor child configures an output file (#1136).
 
 ### Changed
+- Remove legacy subagent tool compatibility fields for append-step control, schedule aliases, async recovery metadata, and string mission goals.
 - Clarify that subagent reviews and gates should stay async unless foreground behavior is the actual requirement.
 - Remove `prompts.render` from `workflowScript`; pass explicit task text to `runs.run` or use `/prompt-workflow` for reusable prompt templates.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,14 +28,6 @@ Controls the parent-facing `subagent` tool description registered at startup. `f
 
 `custom` reads `subagent-tool-description.md` from the project config directory, then from `~/.pi/agent/subagent-tool-description.md`. Missing, empty, unreadable, or oversized custom files fall back to the full description. Custom templates may use `{{fullDescription}}`, `{{compactDescription}}`, `{{safetyGuidance}}`, `{{agentDir}}`, and `{{projectConfigDir}}`; the safety guidance is always present so custom prose cannot remove the runtime guardrails. Restart Pi after changing the mode or custom file.
 
-## `legacyChainControls`
-
-```json
-{ "legacyChainControls": true }
-```
-
-Defaults to `false`. The default registered model-facing tool schema and description omit the legacy `append-step` `step` schema and legacy checkpoint controls. This does not change runtime support for existing durable legacy chains. Set this to `true` before directly managing a legacy chain with `append-step`, `approve-checkpoint`, or `reject-checkpoint`.
-
 ## `inlineToolDisplay`
 
 ```json

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -194,7 +194,6 @@ subagent({ action: "resume", id: "<nested-run-id>", message: "follow-up for a ne
 subagent({ action: "steer", id: "<run-id>", message: "guidance for the running child" })
 subagent({ action: "steer", id: "<run-id>", mode: "follow_up", message: "check this after the current turn" })
 subagent({ action: "steer", id: "<run-id>", index: 1, mode: "auto", message: "guidance for child 2" })
-subagent({ action: "append-step", id: "<run-id>", step: { agent: "worker", task: "Continue from {previous}" } })
 subagent({ action: "approve-checkpoint", id: "<run-id>" })
 subagent({ action: "reject-checkpoint", id: "<run-id>" })
 subagent({ action: "doctor" })
@@ -239,10 +238,6 @@ The optional `mode` is `steer` by default and keeps the current interrupt behavi
 Only a top-level single run may interrupt after the acknowledgment deadline and recover after a further 15-second pause/revival bound; durable multi-child and nested runs never auto-interrupt. Recovery launches a replacement only after the source is confirmed paused, a valid persisted session exists, and deadline, turn, and tool budgets remain. It preserves the original child contract and remaining limits; otherwise the source stays paused with an explicit failure. Late acceptance is recorded but cannot cancel committed recovery.
 
 The persisted `steering` ledger retains 20 requests and replaces the old `steerCount`/`lastSteerAt` fields.
-
-### append-step
-
-`append-step` requires `legacyChainControls: true`. The default registered model-facing schema omits this legacy control surface. When enabled, it accepts exactly one `step` object for an existing durable chain for a top-level async chain whose status is still `running`. The step is persisted in the run directory and becomes eligible only after the chain's already-queued steps finish. Completed, failed, rejected, paused, foreground, single, and non-chain runs reject appends.
 
 ## Acceptance gates
 

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -112,15 +112,10 @@ While children run, the persistent FleetView and the collapsed foreground tool-r
 
 Inspect async runs with `subagent({ action: "status", id: "..." })` or `subagent({ action: "status" })` for active runs. Use `subagent({ action: "status", view: "fleet" })` when supervising several active foreground/background runs and `subagent({ action: "status", id: "...", view: "transcript", index: 0 })` when you need the latest child output without digging through artifacts. If a delegated fanout child launches nested runs, the parent status view shows them as a tree and you can target a nested run directly with its nested id.
 
-Stop a current-session top-level async run with `stop` (or `/subagents-stop`). Stopped runs finish as `stopped`/cancelled and are not resumable. For an active foreground single-subagent run, `/subagents-detach [run-id]` leaves the child running without terminating it and returns the eventual result through status/wait. Append one more step to the tail of a still-running durable chain with `append-step` (`step` must contain exactly one step object). Use checkpoint steps for planned human gates; they pause without launching a child and are approved or rejected through current-session control actions:
+Stop a current-session top-level async run with `stop` (or `/subagents-stop`). Stopped runs finish as `stopped`/cancelled and are not resumable. For an active foreground single-subagent run, `/subagents-detach [run-id]` leaves the child running without terminating it and returns the eventual result through status/wait. Checkpoint steps pause without launching a child and wait for a current-session decision.
 
 ```typescript
 subagent({ action: "stop", id: "run-id" })
-subagent({
-  action: "append-step",
-  id: "run-id",
-  step: { checkpoint: "review", message: "Approve the next implementation step?" }
-})
 subagent({ action: "approve-checkpoint", id: "run-id" })
 subagent({ action: "reject-checkpoint", id: "run-id" })
 ```
@@ -185,7 +180,7 @@ Humans can use `/subagents-doctor` for the same read-only report. It checks runt
 
 ### Subagent control
 
-Subagent control is the runtime visibility and intervention layer for delegated runs. It is separate from lifecycle status. Lifecycle status says whether a child is `queued`, `running`, `paused`, `complete`, `stopped`, `failed`, or `rejected`. Activity reporting is factual: it tracks the last observed activity time and the current tool when known. It does not pretend to know that a child is truly stuck. Manual top-level async cancellation uses `stop` / `/subagents-stop`; a live async chain can gain one more tail step via `append-step`, and a paused async chain checkpoint can be decided with `approve-checkpoint` or `reject-checkpoint`.
+Subagent control is the runtime visibility and intervention layer for delegated runs. It is separate from lifecycle status. Lifecycle status says whether a child is `queued`, `running`, `paused`, `complete`, `stopped`, `failed`, or `rejected`. Activity reporting is factual: it tracks the last observed activity time and the current tool when known. It does not pretend to know that a child is truly stuck. Manual top-level async cancellation uses `stop` / `/subagents-stop`, and paused async chain checkpoints use `approve-checkpoint` or `reject-checkpoint`.
 
 Default behavior is intentionally conservative. When no activity has been observed past the configured threshold, the run emits a `needs_attention` control event. Foreground runs can push this as a `subagent:control-event` event, and async runs persist it to `events.jsonl` so the parent tracker can surface it without constant manual polling. Notification-worthy control events are also inserted into the visible transcript so both the user and the parent agent can see them, with a proactive hint plus concrete `nudge`, `status`, and `interrupt` options. Visible notifications fire once per child run and attention state.
 

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -101,9 +101,6 @@ function validateConfig(config: Record<string, unknown>): void {
 	if (config.artifactDir !== undefined && !ARTIFACT_DIR_PREFERENCES.has(config.artifactDir as ArtifactDirPreference)) {
 		throw new Error(`config.artifactDir must be "project", "session", or "temp"`);
 	}
-	if (config.legacyChainControls !== undefined && typeof config.legacyChainControls !== "boolean") {
-		throw new Error("config.legacyChainControls must be a boolean");
-	}
 	if (config.maxActiveAsyncRunsPerSession !== undefined
 		&& (typeof config.maxActiveAsyncRunsPerSession !== "number"
 			|| !Number.isInteger(config.maxActiveAsyncRunsPerSession)

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -171,13 +171,13 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 		allowMutatingManagementActions: false,
 	});
 
-	const params = createSubagentParamsSchema(config);
+	const params = createSubagentParamsSchema();
 	const tool: ToolDefinition<typeof params, Details> = {
 		name: "subagent",
 		label: "Subagent",
 		description: [
 			"Delegate to subagents from child-safe fanout mode.",
-			`Allowed management/control actions: list, get, status, interrupt, resume, steer${config.legacyChainControls === true ? ", append-step" : ""}, doctor.`,
+			"Allowed management/control actions: list, get, status, interrupt, resume, steer, doctor.",
 			"Mutating management actions (create, update, delete, eject, disable, enable, reset, grant-spawn-budget) are blocked in this mode.",
 		].join("\n"),
 		parameters: params,

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -592,7 +592,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	});
 
 
-	const parameters = createSubagentParamsSchema(config);
+	const parameters = createSubagentParamsSchema();
 	const tool: ToolDefinition<typeof parameters, Details> = {
 		name: "subagent",
 		label: "Subagent",

--- a/src/extension/public-execution.ts
+++ b/src/extension/public-execution.ts
@@ -47,6 +47,9 @@ export function normalizePublicSubagentExecution<T extends PublicSubagentExecuti
 	}
 	if (normalizedAction !== undefined) {
 		const legacyAction = normalizedAction.toLowerCase();
+		if (legacyAction === "append-step") {
+			return { ok: false, error: "Legacy append-step control was removed from the public subagent tool; use current workflowScript orchestration.", mode: "management" };
+		}
 		if (legacyAction === "single") {
 			return { ok: false, error: "action='single' is not supported. Omit action and pass { agent, task } for one child.", mode: "workflow" };
 		}
@@ -71,7 +74,7 @@ export function normalizePublicSubagentExecution<T extends PublicSubagentExecuti
 		return { ok: true, params: { ...params, action: normalizedAction } };
 	}
 	if (params.step !== undefined) {
-		return { ok: false, error: "step is only available with action='append-step'; it is not an execution mode.", mode: "workflow" };
+		return { ok: false, error: "step is not a public execution field; use workflowScript for orchestration.", mode: "workflow" };
 	}
 	if (params.workflowScript !== undefined && (params.agent !== undefined || params.task !== undefined)) {
 		return { ok: false, error: "Structured single-child execution cannot be combined with workflowScript.", mode: "workflow" };

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -188,7 +188,7 @@ export const DynamicCollectSchema = Type.Object({
 
 // Flattened so chain steps do not need an object-shape anyOf/oneOf union.
 export const ChainItem = Type.Object({
-	checkpoint: Type.Optional(Type.String({ description: "Approval checkpoint name. Pauses the chain without launching a child until approve-checkpoint or reject-checkpoint is called." })),
+	checkpoint: Type.Optional(Type.String({ description: "Approval checkpoint name. Pauses the chain without launching a child until a checkpoint decision is delivered." })),
 	message: Type.Optional(Type.String({ description: "Optional approval message shown while the checkpoint is paused." })),
 	agent: Type.Optional(Type.String({ description: "Sequential step agent name" })),
 	task: Type.Optional(Type.String({
@@ -264,10 +264,10 @@ const SubagentParamProperties = {
 	})),
 	name: Type.Optional(Type.String({ description: "Human-readable name for action='schedule.create'." })),
 	id: Type.Optional(Type.String({
-		description: "Run id/prefix for status/debug.run, interrupt, steer, append-step, approve-checkpoint, reject-checkpoint, or mission."
+		description: "Run id/prefix for status/debug.run, interrupt, steer, or mission.attach-run."
 	})),
 	runId: Type.Optional(Type.String({
-		description: "Target run ID for debug.run, interrupt, steer, append-step, or mission.attach-run. Prefer id."
+		description: "Target run ID for debug.run, interrupt, steer, or mission.attach-run. Prefer id."
 	})),
 	dir: Type.Optional(Type.String({
 		description: "Async run directory for status/debug.run, stop, resume, or steer."
@@ -288,8 +288,6 @@ const SubagentParamProperties = {
 	target: Type.Optional(Type.String({ enum: ["main", "children", "child"], description: "Target for watchdog actions." })),
 	focus: Type.Optional(Type.Boolean({ description: "Focus the new Herdr pane for inspector.open or project.open." })),
 	thinking: Type.Optional(Type.Unsafe({ anyOf: [{ type: "string" }, { type: "boolean", enum: [false] }], description: "Thinking level for action='watchdog.configure' (off/minimal/low/medium/high/xhigh/max, inherit, or false for off)." })),
-	schedule: Type.Optional(Type.String({ deprecated: true, description: "Removed one-shot schedule field. Use action='schedule.create' with at." })),
-	scheduleName: Type.Optional(Type.String({ deprecated: true, description: "Removed schedule display field. Use name." })),
 	at: Type.Optional(Type.String({ description: "One-shot trigger for action='schedule.create': a relative delay such as '+10m' or an ISO timestamp with timezone." })),
 	every: Type.Optional(Type.String({ description: "Fixed recurring interval for action='schedule.create', such as '30m', '6h', '2d', or '2w'." })),
 	on: Type.Optional(Type.Unsafe({ anyOf: [{ type: "string" }, { type: "integer" }], description: "Calendar selector reserved for a later schedule slice." })),
@@ -319,7 +317,6 @@ const SubagentParamProperties = {
 	workflowScript: Type.Optional(Type.String({ minLength: 1, description: "Trusted inline JavaScript statement body. Normally async unless asyncByDefault:false; set async:true when async matters. Use async:false only for foreground behavior, never reviews or gates. Use explicit return for output. Use await runs.run(key, {agent, task, worktree?, gate?}) or runs.run(key, {resume, task}), runs.all([...]), runs.status(id), runs.ref(s), emit(value), console, and return. Mission workflows also have async state.get(key) and state.set(key, JSONValue). Compose sequential and parallel phases dynamically. Set worktree:true at workflow or child level for a separate managed worktree; child fields override workflow defaults. gate is one host-run command and cannot be combined with acceptance. runs.run accepts one child only. No filesystem, shell, Pi tools, or host globals." })),
 	chatProgress: Type.Optional(Type.String({ enum: ["auto", "off", "live-card"], description: "WorkflowScript chat progress projection. auto shows a live in-chat card only for watched foreground workflows in the same Git repository; it is off otherwise." })),
 	worktree: Type.Optional(Type.Boolean({ description: "Managed child isolation. true gives each workflow child a separate git worktree; an individual runs.run/runs.all item can override a workflow default with worktree:false." })),
-	step: Type.Optional(Type.Unsafe({ ...ChainItem, description: "One chain step for action='append-step' only. Not an execution mode." })),
 	context: Type.Optional(Type.String({
 		enum: ["fresh", "fork"],
 		description: "'fresh' or 'fork' to branch from parent session. Explicit context overrides every child. If omitted, each agent uses its own defaultContext; implicit fork needs a persisted parent session and leaf, else fresh.",
@@ -357,26 +354,12 @@ const SubagentParamProperties = {
 	gate: Type.Optional(Type.String({ minLength: 1, description: "Host gate command. Cannot be combined with acceptance." })),
 };
 
-const { step: _legacyChainStep, ...subagentParamPropertiesWithoutStep } = SubagentParamProperties;
-const trimmedSubagentParamProperties = {
-	...subagentParamPropertiesWithoutStep,
-	id: Type.Optional(Type.String({
-		description: "Run id/prefix for status/debug.run, interrupt, steer, or mission.attach-run."
-	})),
-	runId: Type.Optional(Type.String({
-		description: "Target run ID for debug.run, interrupt, steer, or mission.attach-run. Prefer id."
-	})),
-};
 const SubagentParamsSchema = Type.Object(SubagentParamProperties);
-const TrimmedSubagentParamsSchema = Type.Object(trimmedSubagentParamProperties);
 
 export const SubagentParams = keepTopLevelParameterDescriptions(SubagentParamsSchema);
-export const SubagentParamsWithoutLegacyChainControls = keepTopLevelParameterDescriptions(TrimmedSubagentParamsSchema);
 
-export function createSubagentParamsSchema(options: { legacyChainControls?: boolean } = {}): typeof SubagentParams | typeof SubagentParamsWithoutLegacyChainControls {
-	return options.legacyChainControls === true
-		? SubagentParams
-		: SubagentParamsWithoutLegacyChainControls;
+export function createSubagentParamsSchema(): typeof SubagentParams {
+	return SubagentParams;
 }
 
 const SubagentWaitParamsSchema = Type.Object({

--- a/src/extension/tool-description.ts
+++ b/src/extension/tool-description.ts
@@ -29,8 +29,6 @@ EXECUTION:
 MANAGEMENT / CONTROL (use action; omit execution fields):
 • list, get, models, guide, children.list, create, update, delete, eject, disable, enable, reset, status, debug.run, doctor, grant-spawn-budget, worktree.discard, refine/refine.show/refine.rollback, mission.create/list/show/update/resolve-decision/attach-run/close, inspector.open/status/close, project.open/status/close, and watchdog actions remain available. Use {action:"guide", topic:"overview"} for packaged current-version help; topics are overview, workflows, agents, missions, observability, tool-reference, configuration, models, watchdog, and extension-api.
 • status, interrupt, stop, resume, and steer manage live or persisted runs. Use status view:"fleet" for an overview or view:"transcript" with id and optional index to tail output.
-• { action: "append-step", id: "...", step: {agent:"agent-c", task:"Use {previous}"} } appends one step to an already-running durable legacy chain. step is control-only, not an execution mode.
-• approve-checkpoint and reject-checkpoint decide a paused durable legacy chain checkpoint.
 • Create durable project schedules with { action:"schedule.create", id?, name?, at:"+10m" | ISO, workflowScript:"return runs.run('main', {agent:'worker', task:'...'})" } or { every:"6h", workflowScript:"..." }. Manage them with schedule.list/show/history/pause/resume/run/run-due/delete. This first slice supports fixed intervals; calendar schedules and schedule mission attachment are deferred.
 
 ${SUBAGENT_SAFETY_GUIDANCE}`;
@@ -46,7 +44,6 @@ EXECUTE:
 
 MANAGE / CONTROL:
 • Use action without execution fields for list/get/models/guide/authoring, refine/refine.show/refine.rollback, mission, watchdog, status, interrupt, stop, resume, steer, script-only scheduling, diagnostics, and other management actions. guide reads shipped current-version docs by topic.
-• append-step uses step:{...} only for an already-running durable legacy chain; step is not an execution mode.
 • A mission object needs exactly one non-empty title or summary; objective and labels are optional. goal may only be true and requires budget:{tokens}.
 
 ASYNC / SAFETY:
@@ -157,20 +154,7 @@ function withMandatorySafetyGuidance(description: string): string {
 		: SUBAGENT_SAFETY_GUIDANCE;
 }
 
-const LEGACY_CHAIN_CONTROL_GUIDANCE_LINES = new Set([
-	'• { action: "append-step", id: "...", step: {agent:"agent-c", task:"Use {previous}"} } appends one step to an already-running durable legacy chain. step is control-only, not an execution mode.',
-	"• approve-checkpoint and reject-checkpoint decide a paused durable legacy chain checkpoint.",
-	"• append-step uses step:{...} only for an already-running durable legacy chain; step is not an execution mode.",
-]);
-
-function withoutLegacyChainControlGuidance(description: string): string {
-	return description
-		.split("\n")
-		.filter((line) => !LEGACY_CHAIN_CONTROL_GUIDANCE_LINES.has(line.trim()))
-		.join("\n");
-}
-
-export function buildSubagentToolDescription(config: Pick<ExtensionConfig, "toolDescriptionMode" | "legacyChainControls"> = {}, options?: ToolDescriptionOptions): string {
+export function buildSubagentToolDescription(config: Pick<ExtensionConfig, "toolDescriptionMode"> = {}, options?: ToolDescriptionOptions): string {
 	const mode = resolveToolDescriptionMode(config, options);
 	let description: string;
 	if (mode === "compact") description = COMPACT_SUBAGENT_TOOL_DESCRIPTION;
@@ -182,5 +166,5 @@ export function buildSubagentToolDescription(config: Pick<ExtensionConfig, "tool
 			description = FULL_SUBAGENT_TOOL_DESCRIPTION;
 		}
 	} else description = FULL_SUBAGENT_TOOL_DESCRIPTION;
-	return config.legacyChainControls === true ? description : withoutLegacyChainControlGuidance(description);
+	return description;
 }

--- a/src/missions/store.ts
+++ b/src/missions/store.ts
@@ -77,11 +77,6 @@ function nonNegativeTokenCount(value: unknown, label: string): number {
 	return value as number;
 }
 
-function parseStoredGoal(value: unknown, label: string): { goal?: MissionGoal; legacyObjective?: string } {
-	if (typeof value === "string") return { legacyObjective: requiredString(value, label).trim() };
-	return { goal: parseGoal(value, label) };
-}
-
 function parseGoal(value: unknown, label: string): MissionGoal {
 	const input = asObject(value, label);
 	if (input.status !== "active" && input.status !== "paused" && input.status !== "budget-exhausted") throw new Error(`${label}.status is invalid`);
@@ -223,18 +218,18 @@ export function parseMissionRecord(value: unknown, source = "mission record"): M
 	const decisions = input.decisions as unknown[];
 	const artifacts = input.artifacts as unknown[];
 	const receipts = (input.receipts ?? []) as unknown[];
-	const parsedGoal = input.goal !== undefined ? parseStoredGoal(input.goal, `${source}.goal`) : {};
+	const goal = input.goal !== undefined ? parseGoal(input.goal, `${source}.goal`) : undefined;
 	const budget = input.budget !== undefined ? parseBudget(input.budget, `${source}.budget`) : undefined;
 	const usage = input.usage !== undefined ? parseUsage(input.usage, `${source}.usage`) : undefined;
-	const objective = optionalString(input.objective, `${source}.objective`)?.trim() ?? parsedGoal.legacyObjective;
+	const objective = optionalString(input.objective, `${source}.objective`)?.trim();
 	if (!objective) throw new Error(`${source}.objective must be a non-empty string`);
-	if (parsedGoal.goal && !budget) throw new Error(`${source}.budget is required for a goal mission`);
+	if (goal && !budget) throw new Error(`${source}.budget is required for a goal mission`);
 	return {
 		schemaVersion: 1,
 		id: validateMissionId(input.id, `${source}.id`),
 		title: requiredString(input.title, `${source}.title`),
 		objective,
-		...(parsedGoal.goal ? { goal: parsedGoal.goal } : {}),
+		...(goal ? { goal } : {}),
 		...(budget ? { budget } : {}),
 		...(usage ? { usage } : {}),
 		status: missionStatus(input.status, `${source}.status`),

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -261,12 +261,7 @@ function validateStatusForResume(status: AsyncStatus | null, source: string): vo
 	}
 }
 
-function normalizeRecoveryAcceptance(value: unknown, descriptorPath: string): AcceptanceInput | undefined {
-	if (value && typeof value === "object" && !Array.isArray(value) && ("explicit" in value || "inferredReason" in value)) {
-		const { explicit, inferredReason: _inferredReason, ...publicAcceptance } = value as Record<string, unknown>;
-		if (explicit === false) return undefined;
-		value = publicAcceptance;
-	}
+function normalizeRecoveryAcceptance(value: unknown, descriptorPath: string): AcceptanceInput {
 	const errors = validateAcceptanceInput(value, "recoveryDescriptor.acceptance");
 	if (errors.length) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${errors.join(" ")}`);
 	return value as AcceptanceInput;
@@ -395,11 +390,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 		if (!Array.isArray(control.notifyOn) || control.notifyOn.some((item) => item !== "active_long_running" && item !== "needs_attention")) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': controlConfig.notifyOn is invalid.`);
 		if (!Array.isArray(control.notifyChannels) || control.notifyChannels.some((item) => item !== "event" && item !== "async" && item !== "intercom")) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': controlConfig.notifyChannels is invalid.`);
 	}
-	if (parsed.acceptance !== undefined) {
-		const acceptance = normalizeRecoveryAcceptance(parsed.acceptance, descriptorPath);
-		if (acceptance === undefined) delete parsed.acceptance;
-		else parsed.acceptance = acceptance;
-	}
+	if (parsed.acceptance !== undefined) parsed.acceptance = normalizeRecoveryAcceptance(parsed.acceptance, descriptorPath);
 	return parsed as unknown as SteeringRecoveryDescriptor;
 }
 

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -474,7 +474,7 @@ export class ScheduledRunManager {
 		const schedule: ScheduleRecord = {
 			schemaVersion: 1,
 			id,
-			name: params.name?.trim() || params.scheduleName?.trim() || targetLabel(target.target!),
+			name: params.name?.trim() || targetLabel(target.target!),
 			cwd: path.resolve(params.cwd ?? ctx.cwd),
 			trigger,
 			target: target.target!,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -338,8 +338,6 @@ export interface SubagentParamsLike {
 	acceptance?: AcceptanceInput;
 	gate?: string;
 	agentContract?: AgentContract;
-	schedule?: string;
-	scheduleName?: string;
 	at?: string;
 	every?: string;
 	on?: string | number;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1927,8 +1927,6 @@ export interface ExtensionConfig {
 	asyncWidget?: boolean;
 	/** Tool description variant registered for the parent-facing subagent tool. Defaults to full. */
 	toolDescriptionMode?: ToolDescriptionMode;
-	/** Include legacy append-step and checkpoint controls in the registered tool schema. Defaults to false. */
-	legacyChainControls?: boolean;
 	/** Inline chat rendering for the subagent tool. Defaults to rich. */
 	inlineToolDisplay?: InlineToolDisplay;
 	/** Density controls for the main chat subagent call/result renderer. */
@@ -2090,7 +2088,7 @@ export const SLASH_SUBAGENT_CANCEL_EVENT = "subagent:slash:cancel";
 export const POLL_INTERVAL_MS = 250;
 export const MAX_WIDGET_JOBS = 4;
 export const DEFAULT_SUBAGENT_MAX_DEPTH = 2;
-export const SUBAGENT_ACTIONS = ["list", "get", "models", "children.list", "guide", "create", "update", "delete", "eject", "disable", "enable", "reset", "mission.create", "mission.list", "mission.show", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "worktree.discard", "refine", "refine.show", "refine.rollback", "inspector.open", "inspector.status", "inspector.close", "project.open", "project.status", "project.close", "status", "debug.run", "grant-spawn-budget", "interrupt", "resume", "steer", "stop", "dismiss", "append-step", "approve-checkpoint", "reject-checkpoint", "doctor", "watchdog.status", "watchdog.check", "watchdog.configure", "watchdog.recommend-model", "schedule.create", "schedule.list", "schedule.show", "schedule.history", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"] as const;
+export const SUBAGENT_ACTIONS = ["list", "get", "models", "children.list", "guide", "create", "update", "delete", "eject", "disable", "enable", "reset", "mission.create", "mission.list", "mission.show", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "worktree.discard", "refine", "refine.show", "refine.rollback", "inspector.open", "inspector.status", "inspector.close", "project.open", "project.status", "project.close", "status", "debug.run", "grant-spawn-budget", "interrupt", "resume", "steer", "stop", "dismiss", "approve-checkpoint", "reject-checkpoint", "doctor", "watchdog.status", "watchdog.check", "watchdog.configure", "watchdog.recommend-model", "schedule.create", "schedule.list", "schedule.show", "schedule.history", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"] as const;
 
 export const DEFAULT_FORK_PREAMBLE =
 	"You are a delegated subagent running from a fork of the parent session. " +

--- a/test/unit/async-resume.test.ts
+++ b/test/unit/async-resume.test.ts
@@ -185,7 +185,7 @@ describe("async resume lookup", () => {
 		}
 	});
 
-	it("accepts legacy resolved acceptance metadata in recovery descriptors", () => {
+	it("accepts current acceptance metadata in recovery descriptors", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-acceptance-"));
 		try {
 			const asyncRoot = path.join(root, "runs");
@@ -211,8 +211,6 @@ describe("async resume lookup", () => {
 				share: false,
 				acceptance: {
 					level: "attested",
-					explicit: true,
-					inferredReason: ["async write-capable or risky run"],
 					criteria: [{ id: "criterion-1", must: "Return evidence", evidence: ["manual-notes"], severity: "required" }],
 					evidence: ["manual-notes", "residual-risks"],
 					verify: [],
@@ -235,7 +233,7 @@ describe("async resume lookup", () => {
 		}
 	});
 
-	it("rejects stale explicit reviewed acceptance metadata in recovery descriptors", () => {
+	it("rejects reviewed acceptance metadata in recovery descriptors", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-reviewed-acceptance-"));
 		try {
 			const asyncRoot = path.join(root, "runs");
@@ -261,8 +259,6 @@ describe("async resume lookup", () => {
 				share: false,
 				acceptance: {
 					level: "reviewed",
-					explicit: true,
-					inferredReason: ["async write-capable or risky run"],
 					criteria: ["Return evidence"],
 					evidence: ["validation-output"],
 					verify: [],
@@ -280,7 +276,7 @@ describe("async resume lookup", () => {
 		}
 	});
 
-	it("drops inferred legacy acceptance metadata from recovery descriptors", () => {
+	it("rejects legacy acceptance metadata in recovery descriptors", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-inferred-acceptance-"));
 		try {
 			const asyncRoot = path.join(root, "runs");
@@ -305,21 +301,20 @@ describe("async resume lookup", () => {
 				maxSubagentDepth: 2,
 				share: false,
 				acceptance: {
-					level: "reviewed",
+					level: "attested",
 					explicit: false,
 					inferredReason: ["async write-capable or risky run"],
 					criteria: [],
 					evidence: [],
 					verify: [],
-					review: { agent: "reviewer", required: true },
 					stopRules: [],
 				},
 			});
 
-			const target = resolveAsyncResumeTarget({ id: "run-inferred-acceptance" }, { asyncDirRoot: asyncRoot, resultsDir });
-
-			assert.equal(target.kind, "revive");
-			assert.equal(target.recoveryDescriptor?.acceptance, undefined);
+			assert.throws(
+				() => resolveAsyncResumeTarget({ id: "run-inferred-acceptance" }, { asyncDirRoot: asyncRoot, resultsDir }),
+				/recoveryDescriptor\.acceptance\.(explicit|inferredReason) is not supported/i,
+			);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -212,7 +212,7 @@ describe("Herdr inspector", () => {
 					schemaVersion: 1,
 					id: "mission-1",
 					title: "Ship inspector",
-					goal: "Inspect safely",
+					goal: { status: "active" },
 					status: "active",
 					createdAt: "2026-01-01T00:00:00.000Z",
 					updatedAt: "2026-01-01T00:00:00.000Z",

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -920,11 +920,10 @@ describe("subagent extension child mode", () => {
 		);
 	});
 
-	it("trims legacy chain controls from the child-safe fanout tool by default", () => {
-		const readRegisteredTool = (legacyChainControls: boolean): { description: string; properties: string[]; id: string; runId: string } => {
+	it("omits legacy chain controls from the child-safe fanout tool", () => {
+		const readRegisteredTool = (): { description: string; properties: string[]; id: string; runId: string } => {
 			const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fanout-schema-"));
 			fs.mkdirSync(path.join(agentDir, "extensions", "subagent"), { recursive: true });
-			fs.writeFileSync(path.join(agentDir, "extensions", "subagent", "config.json"), JSON.stringify({ legacyChainControls }), "utf-8");
 			const script = String.raw`
 				import registerFanoutChildSubagentExtension from "./src/extension/fanout-child.ts";
 				import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
@@ -942,13 +941,9 @@ describe("subagent extension child mode", () => {
 			return JSON.parse(output) as { description: string; properties: string[]; id: string; runId: string };
 		};
 
-		const trimmed = readRegisteredTool(false);
-		assert.equal(trimmed.properties.includes("step"), false);
-		assert.doesNotMatch(`${trimmed.description}\n${trimmed.id}\n${trimmed.runId}`, /append-step|approve-checkpoint|reject-checkpoint/);
-
-		const legacy = readRegisteredTool(true);
-		assert.equal(legacy.properties.includes("step"), true);
-		assert.match(`${legacy.description}\n${legacy.id}\n${legacy.runId}`, /append-step/);
+		const tool = readRegisteredTool();
+		assert.equal(tool.properties.includes("step"), false);
+		assert.doesNotMatch(`${tool.description}\n${tool.id}\n${tool.runId}`, /append-step|approve-checkpoint|reject-checkpoint/);
 	});
 
 	it("lets fanout children call read-only list but blocks mutating management actions", () => {

--- a/test/unit/mission-store.test.ts
+++ b/test/unit/mission-store.test.ts
@@ -344,15 +344,13 @@ describe("mission store", () => {
 		}
 	});
 
-	it("loads older records that do not have receipts or objective", () => {
+	it("loads older records that do not have receipts", () => {
 		const test = fixture();
 		try {
 			const created = createMission(test.location, { title: "Older record", objective: "Stay readable" });
 			const recordPath = path.join(test.location.missionDir, `${created.id}.json`);
 			const raw = JSON.parse(fs.readFileSync(recordPath, "utf-8")) as Record<string, unknown>;
 			delete raw.receipts;
-			delete raw.objective;
-			raw.goal = "Stay readable";
 			fs.writeFileSync(recordPath, JSON.stringify(raw), "utf-8");
 
 			const mission = readMission(test.location, created.id);

--- a/test/unit/public-execution.test.ts
+++ b/test/unit/public-execution.test.ts
@@ -27,6 +27,8 @@ describe("public subagent execution normalization", () => {
 			},
 		});
 		assert.deepEqual(normalizePublicSubagentExecution({ action: " list " }), { ok: true, params: { action: "list" } });
+		assert.deepEqual(normalizePublicSubagentExecution({ action: "approve-checkpoint", id: "run" }), { ok: true, params: { action: "approve-checkpoint", id: "run" } });
+		assert.deepEqual(normalizePublicSubagentExecution({ action: "reject-checkpoint", id: "run" }), { ok: true, params: { action: "reject-checkpoint", id: "run" } });
 		assert.deepEqual(
 			normalizePublicSubagentExecution({ action: " schedule.create ", every: "1h", workflowScript: "return 1" }),
 			{ ok: true, params: { action: "schedule.create", every: "1h", workflowScript: "return 1" } },
@@ -50,6 +52,7 @@ describe("public subagent execution normalization", () => {
 			{ action: "single" },
 			{ action: "parallel" },
 			{ action: "chain" },
+			{ action: "append-step", id: "run", step: { agent: "worker" } },
 			{ agent: "" },
 			{ agent: 42 },
 			{ task: "work" },

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -199,19 +199,12 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		assert.ok(properties?.output, "output remains a workflow child default");
 	});
 
-	it("omits legacy chain controls by default and includes them when enabled", () => {
-		for (const name of ["tasks", "chain", "concurrency", "chainDir"]) {
+	it("omits removed legacy chain and schedule fields", () => {
+		for (const name of ["tasks", "chain", "concurrency", "chainDir", "step", "schedule", "scheduleName"]) {
 			assert.equal((SubagentParams?.properties as Record<string, unknown> | undefined)?.[name], undefined, `${name} should not be public`);
 		}
 
-		const trimmed = (schemas.createSubagentParamsSchema as (options?: { legacyChainControls?: boolean }) => SubagentParamsSchema)();
-		assert.equal(trimmed.properties?.step, undefined);
-		assert.doesNotMatch(JSON.stringify(trimmed), /append-step|approve-checkpoint|reject-checkpoint/);
-
-		const full = (schemas.createSubagentParamsSchema as (options: { legacyChainControls: boolean }) => SubagentParamsSchema)({ legacyChainControls: true });
-		const stepSchema = (full.properties as Record<string, JsonSchemaNode> | undefined)?.step;
-		assert.equal(stepSchema?.type, "object");
-		assert.match(String(stepSchema?.description ?? ""), /append-step.*only/i);
+		assert.doesNotMatch(JSON.stringify(SubagentParams), /append-step|approve-checkpoint|reject-checkpoint|scheduleName/);
 	});
 
 	it("allows runtime validation of management and control action strings", () => {
@@ -279,21 +272,11 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		assert.match(String(idSchema.description ?? ""), /status/i);
 		assert.match(String(idSchema.description ?? ""), /interrupt/i);
 		assert.match(String(idSchema.description ?? ""), /steer/i);
-		assert.match(String(idSchema.description ?? ""), /append-step/i);
-		assert.match(String(idSchema.description ?? ""), /approve-checkpoint/i);
-		assert.match(String(idSchema.description ?? ""), /reject-checkpoint/i);
-
-		const stepSchema = (SubagentParams?.properties as Record<string, JsonSchemaNode> | undefined)?.step;
-		assert.equal((stepSchema?.properties as Record<string, JsonSchemaNode> | undefined)?.checkpoint?.type, "string");
-		assert.equal((stepSchema?.properties as Record<string, JsonSchemaNode> | undefined)?.message?.type, "string");
-
 		const runIdSchema = SubagentParams?.properties?.runId;
 		assert.ok(runIdSchema, "runId schema should exist");
 		assert.equal(runIdSchema.type, "string");
 		assert.match(String(runIdSchema.description ?? ""), /interrupt/i);
 		assert.match(String(runIdSchema.description ?? ""), /steer/i);
-		assert.match(String(runIdSchema.description ?? ""), /append-step/i);
-
 		const dirSchema = SubagentParams?.properties?.dir;
 		assert.ok(dirSchema, "dir schema should exist");
 		assert.equal(dirSchema.type, "string");
@@ -512,11 +495,6 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		assert.equal(acceptanceObjectBranch.additionalProperties, true);
 		assert.equal(JSON.stringify(acceptanceObjectBranch).includes('"anyOf"'), false);
 
-		const step = (SubagentParams?.properties as Record<string, JsonSchemaNode> | undefined)?.step;
-		assert.equal(step?.type, "object");
-		assert.equal(step?.additionalProperties, false);
-		assert.equal((step?.properties as Record<string, JsonSchemaNode> | undefined)?.agent?.type, "string");
-
 	});
 
 	it("validates representative flexible field values with TypeBox compiler", { skip: !CompileSchema ? "typebox compiler not available" : undefined }, () => {
@@ -526,7 +504,6 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		const validValues = [
 			{ skill: "review" },
 			{ workflowScript: "return await runs.run(\"one\", {agent: \"reviewer\", task: \"check\"})" },
-			{ action: "append-step", id: "run-1", step: { agent: "reviewer", task: "Continue" } },
 			{ skill: false },
 			{ action: "get", agent: "worker" },
 			{ workflowScript: "return runs.run('main', { agent: 'worker', task: 'Fix', acceptance: false })", timeoutMs: 1000 },

--- a/test/unit/subagent-action-recovery.test.ts
+++ b/test/unit/subagent-action-recovery.test.ts
@@ -54,6 +54,14 @@ describe("subagent action recovery", () => {
 		assert.match(message, /Valid: .*status/);
 	});
 
+	it("does not list removed append-step control", () => {
+		const message = unknownSubagentActionMessage("not-a-real-action");
+
+		assert.doesNotMatch(message, /append-step/);
+		assert.match(message, /approve-checkpoint/);
+		assert.match(message, /reject-checkpoint/);
+	});
+
 	it("does not suggest a destructive near-miss", () => {
 		const message = unknownSubagentActionMessage("del");
 

--- a/test/unit/tool-description.test.ts
+++ b/test/unit/tool-description.test.ts
@@ -54,14 +54,8 @@ describe("registered subagent tool description", () => {
 		assert.match(description, /status\.json/);
 	});
 
-	it("includes legacy chain-control guidance when enabled", () => {
-		const description = buildSubagentToolDescription({ legacyChainControls: true });
-		assert.match(description, /append-step.*step:/i);
-		assert.match(description, /approve-checkpoint|reject-checkpoint/);
-	});
-
 	it("offers a compact mode that keeps the two-tier contract and safety guidance", () => {
-		const description = buildSubagentToolDescription({ toolDescriptionMode: "compact", legacyChainControls: true });
+		const description = buildSubagentToolDescription({ toolDescriptionMode: "compact" });
 		assert.equal(description, COMPACT_SUBAGENT_TOOL_DESCRIPTION);
 		assert.match(description, /^Run one child with \{ agent, task\? \}; use \{ workflowScript \} for orchestration/i);
 		assert.match(description, /SINGLE .*starts exactly one child through the workflow runtime/i);
@@ -166,7 +160,7 @@ describe("registered subagent tool description", () => {
 		const warnings: string[] = [];
 
 		const description = buildSubagentToolDescription(
-			{ toolDescriptionMode: "custom", legacyChainControls: true },
+			{ toolDescriptionMode: "custom" },
 			{ cwd, agentDir, warn: (message) => warnings.push(message) },
 		);
 
@@ -178,7 +172,7 @@ describe("registered subagent tool description", () => {
 		const warnings: string[] = [];
 
 		const description = buildSubagentToolDescription(
-			{ toolDescriptionMode: "tiny", legacyChainControls: true } as never,
+			{ toolDescriptionMode: "tiny" } as never,
 			{ warn: (message) => warnings.push(message) },
 		);
 
@@ -232,11 +226,11 @@ describe("registered subagent tool description", () => {
 
 	it("registers full, compact, custom, and fallback descriptions from extension config", () => {
 		const defaultAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tool-desc-default-"));
-		writeExtensionConfig(defaultAgentDir, { legacyChainControls: true });
+		writeExtensionConfig(defaultAgentDir, {});
 		assert.equal(readRegisteredTool(defaultAgentDir).description, FULL_SUBAGENT_TOOL_DESCRIPTION);
 
 		const compactAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tool-desc-compact-"));
-		writeExtensionConfig(compactAgentDir, { toolDescriptionMode: "compact", legacyChainControls: true });
+		writeExtensionConfig(compactAgentDir, { toolDescriptionMode: "compact" });
 		assert.equal(readRegisteredTool(compactAgentDir).description, COMPACT_SUBAGENT_TOOL_DESCRIPTION);
 
 		const customAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tool-desc-custom-"));
@@ -247,11 +241,11 @@ describe("registered subagent tool description", () => {
 		assert.match(customDescription, /SAFETY-CRITICAL SUBAGENT GUIDANCE/);
 
 		const missingCustomAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tool-desc-missing-"));
-		writeExtensionConfig(missingCustomAgentDir, { toolDescriptionMode: "custom", legacyChainControls: true });
+		writeExtensionConfig(missingCustomAgentDir, { toolDescriptionMode: "custom" });
 		assert.equal(readRegisteredTool(missingCustomAgentDir).description, FULL_SUBAGENT_TOOL_DESCRIPTION);
 
 		const invalidAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tool-desc-invalid-"));
-		writeExtensionConfig(invalidAgentDir, { toolDescriptionMode: "tiny", legacyChainControls: true });
+		writeExtensionConfig(invalidAgentDir, { toolDescriptionMode: "tiny" });
 		assert.equal(readRegisteredTool(invalidAgentDir).description, FULL_SUBAGENT_TOOL_DESCRIPTION);
 	});
 
@@ -260,13 +254,5 @@ describe("registered subagent tool description", () => {
 		const tool = readRegisteredTool(agentDir);
 		assert.equal(tool.properties.includes("step"), false);
 		assert.doesNotMatch(tool.description, /append-step|approve-checkpoint|reject-checkpoint/);
-	});
-
-	it("registers legacy chain controls when enabled", () => {
-		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tool-desc-legacy-"));
-		writeExtensionConfig(agentDir, { legacyChainControls: true });
-		const tool = readRegisteredTool(agentDir);
-		assert.equal(tool.properties.includes("step"), true);
-		assert.match(tool.description, /append-step.*step:/i);
 	});
 });


### PR DESCRIPTION
## Summary

Remove legacy subagent compatibility surfaces that are no longer model-facing or supported:

- remove `legacyChainControls` config and `step` schema exposure
- remove deprecated `schedule` / `scheduleName` aliases
- remove legacy async recovery acceptance metadata parsing
- remove string mission `goal` migration support
- remove stale docs, guide text, and action recovery entries for legacy chain controls

## Validation

- `npm run typecheck`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e` (suite skipped because runtime packages are unavailable)
- fresh review gate: no open findings
