### PR TITLE
fix: skip unavailable fallback models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
+- Skip fallback models that are unavailable in the active registry, so shared agent configs still run where their primary model is available. Thanks to [@JPFrancoia](https://github.com/JPFrancoia) for #1147.
 - Keep `mcp:<server>` direct tools available when pi-mcp-adapter cache identity includes a request-header command. Thanks to [@xz-dev](https://github.com/xz-dev) for #1141.
 - Fall back from an implicit `defaultContext: fork` to `fresh` when the parent session file or current leaf is not available yet, instead of failing the first launch. Explicit `context: "fork"` remains fail-fast. Thanks to [@hyein-cbio](https://github.com/hyein-cbio) for #1137.
 - Preserve a child's file-only report when its output path also names the workflow summary output.

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -163,17 +163,26 @@ export function resolveModelCandidate(
 	return model;
 }
 
-function resolveRequiredSubagentModelCandidate(
+function resolveSubagentModelCandidate(
 	model: string,
 	availableModels: AvailableModelInfo[] | undefined,
 	preferredProvider?: string,
-): string {
+): string | undefined {
 	if (!availableModels || availableModels.length === 0) return model;
 	const resolvedWhole = resolveBaseModelCandidate(model, availableModels, preferredProvider);
 	if (resolvedWhole) return resolvedWhole;
 	const { baseModel, thinkingSuffix } = splitThinkingSuffix(model);
 	const resolvedBase = thinkingSuffix ? resolveBaseModelCandidate(baseModel, availableModels, preferredProvider) : undefined;
-	if (resolvedBase) return `${resolvedBase}${thinkingSuffix}`;
+	return resolvedBase ? `${resolvedBase}${thinkingSuffix}` : undefined;
+}
+
+function resolveRequiredSubagentModelCandidate(
+	model: string,
+	availableModels: AvailableModelInfo[] | undefined,
+	preferredProvider?: string,
+): string {
+	const resolved = resolveSubagentModelCandidate(model, availableModels, preferredProvider);
+	if (resolved) return resolved;
 	throw new Error(`Unknown subagent model '${model}' in the active Pi model registry.`);
 }
 
@@ -278,8 +287,15 @@ export function buildModelCandidates(
 	for (let index = 0; index < rawCandidates.length; index++) {
 		const raw = rawCandidates[index];
 		if (!raw) continue;
-		const normalized = resolveRequiredSubagentModelCandidate(raw.trim(), availableModels, preferredProvider);
-		if (!normalized || seen.has(normalized)) continue;
+		const model = raw.trim();
+		const normalized = index === 0
+			? resolveRequiredSubagentModelCandidate(model, availableModels, preferredProvider)
+			: resolveSubagentModelCandidate(model, availableModels, preferredProvider);
+		if (!normalized) {
+			console.warn(`[pi-subagents] Skipping fallback model '${model}' because it is unavailable in this environment.`);
+			continue;
+		}
+		if (seen.has(normalized)) continue;
 		if ((index > 0 || options?.scope?.strict === true) && options?.scope?.enforce) {
 			const violation = checkModelScope(normalized, options.scope, "inherited");
 			if (violation) {

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -66,11 +66,22 @@ describe("model fallback helpers", () => {
 		);
 	});
 
-	it("rejects fallback models that the active registry cannot resolve", () => {
-		assert.throws(
-			() => buildModelCandidates("gpt-5-mini", ["does-not-exist"], availableModels),
-			/Unknown subagent model 'does-not-exist'/,
-		);
+	it("skips unavailable fallback models and warns once for each", () => {
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message: unknown) => warnings.push(String(message));
+		try {
+			assert.deepEqual(
+				buildModelCandidates("gpt-5-mini", ["does-not-exist", "also-unavailable"], availableModels),
+				["openai/gpt-5-mini"],
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+		assert.deepEqual(warnings, [
+			"[pi-subagents] Skipping fallback model 'does-not-exist' because it is unavailable in this environment.",
+			"[pi-subagents] Skipping fallback model 'also-unavailable' because it is unavailable in this environment.",
+		]);
 	});
 
 	it("detects retryable provider/model failures", () => {


### PR DESCRIPTION
## Summary

Fixes #1147 by keeping primary model validation strict while skipping fallback models that are unavailable in the active model registry.

This preserves shared agent configs across environments. If the primary model is available, the run starts. If a configured fallback is absent from that environment, it is skipped with a clear warning instead of failing preflight. Fallbacks that resolve in the registry still run through the existing model-scope checks.

## Validation

- `node --experimental-strip-types --test test/unit/model-fallback.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh exact-head review: `/tmp/pi-subagents-backlog-20260815T165245Z/wave-5-issue-1147-exact/pr-1147-gate-c78713c3-review.md`

## Credit

Thanks to [@JPFrancoia](https://github.com/JPFrancoia) for #1147.
