### PR TITLE
fix: accept no-edit challenge passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Skip fallback models that are unavailable in the active registry, so shared agent configs still run where their primary model is available. Thanks to [@JPFrancoia](https://github.com/JPFrancoia) for #1147.
 - Sweep expired wait subscriptions armed by another session, so a record left behind by a session that never returns stops accumulating in the subscriptions directory. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1142.
+- Keep explicit no-change retained-writer implementation challenge passes successful instead of reporting a missing-edit failure (#1110).
 - Keep `mcp:<server>` direct tools available when pi-mcp-adapter cache identity includes a request-header command. Thanks to [@xz-dev](https://github.com/xz-dev) for #1141.
 - Fall back from an implicit `defaultContext: fork` to `fresh` when the parent session file or current leaf is not available yet, instead of failing the first launch. Explicit `context: "fork"` remains fail-fast. Thanks to [@hyein-cbio](https://github.com/hyein-cbio) for #1137.
 - Preserve a child's file-only report when its output path also names the workflow summary output.

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -24,9 +24,11 @@ const CURSOR_FILE_MUTATION_THINKING =
 
 const REVIVED_TASK_PREFIX = /^You are reviving a previous subagent conversation\.\n\nOriginal run: .+\nOriginal agent: .+(?:\nOriginal session file: .+)?\n\nUse the stored session context as background\. Answer the orchestrator's follow-up below\. Do not assume the original child process is still alive\.\n\nFollow-up:\n/;
 const IMPLEMENTATION_CHALLENGE_FOLLOW_UP_PATTERN = /^(?:Run )?implementation challenge pass (?:one|two|\d+)(?:\s+and implement any better current[- ]scope change\.?|\s+for the accepted candidate\.\s+Reconsider it and implement any better current[- ]scope change\.?)?$/i;
+const EXPLICIT_NO_EDIT_CHALLENGE_FOLLOW_UP_PATTERN = /^implementation challenge pass (?:one|two|\d+) for issue #\d+\.\n[\s\S]*\bif the current solution is best, make no file changes and explain why\.[\s\S]*$/i;
 const NO_BETTER_CHANGE_NEEDED_PATTERN = /^\s*no (?:better|further|additional) (?:current[- ]scope )?(?:code |source |file )?(?:change|changes|edit|edits|patch|patches) (?:is|are) needed\b/i;
 const KEPT_CURRENT_IMPLEMENTATION_PATTERN = /\b(?:kept (?:the )?current (?:implementation|candidate|shape)|(?:the )?current (?:implementation|candidate|shape) was kept)\b/i;
 const NO_CHANGE_MADE_PATTERN = /\bno (?:new )?(?:(?:code|source|file|test)(?:\s*(?:,\s*or|,|\/|or)\s*(?:code|source|file|test))* changes?|changes?) (?:were|was) made\b/i;
+const IMPLEMENTED_NO_FURTHER_CHANGE_PATTERN = /\bimplemented no (?:further|additional) (?:code |source |file |test )?(?:changes?|edits?|patches?)\b/i;
 const NO_BETTER_CHANGE_QUALIFIER_PATTERN = /\b(?:do\s+not|don't|dont|not|never|cannot|can't|cant|unable|uncertain|unsure|unclear|disagree|wrong|false|reject|rejected|rejecting|maybe|might|may|\w+n['’]t)\b/i;
 const REPORT_SENTENCE_PATTERN = /[^.!?]+(?:[.!?]+(?=(?:["”'’]?\s)|["”'’]?$)|$)/g;
 const QUOTED_CLAIM_PATTERN = /["“]([^"”]+)["”]([.!?]?\s*[^.!?]*)/g;
@@ -162,8 +164,9 @@ function explicitlyRejectsQuotedClaim(report: string): boolean {
 }
 
 function isImplementationChallengeTask(task: string): boolean {
-	const followUp = task.replace(REVIVED_TASK_PREFIX, "");
-	return followUp !== task && IMPLEMENTATION_CHALLENGE_FOLLOW_UP_PATTERN.test(followUp.trim());
+	const followUp = task.replace(REVIVED_TASK_PREFIX, "").trim();
+	return followUp !== task && (IMPLEMENTATION_CHALLENGE_FOLLOW_UP_PATTERN.test(followUp)
+		|| EXPLICIT_NO_EDIT_CHALLENGE_FOLLOW_UP_PATTERN.test(followUp));
 }
 
 function reportsNoBetterChallengeChange(messages: Message[]): boolean {
@@ -181,6 +184,8 @@ function reportsNoBetterChallengeChange(messages: Message[]): boolean {
 	if (noBetterIndex >= 0) return !hasLaterClaimRetraction(sentences, noBetterIndex);
 	const keptIndex = unqualifiedClaimIndex(report, sentences, KEPT_CURRENT_IMPLEMENTATION_PATTERN);
 	const noChangeIndex = unqualifiedClaimIndex(report, sentences, NO_CHANGE_MADE_PATTERN);
+	const implementedNoFurtherChangeIndex = unqualifiedClaimIndex(report, sentences, IMPLEMENTED_NO_FURTHER_CHANGE_PATTERN);
+	if (implementedNoFurtherChangeIndex >= 0) return !hasLaterClaimRetraction(sentences, implementedNoFurtherChangeIndex);
 	return keptIndex >= 0
 		&& noChangeIndex >= 0
 		&& !hasLaterClaimRetraction(sentences, Math.min(keptIndex, noChangeIndex));

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -59,6 +59,12 @@ function revivedTask(followUp: string): string {
 }
 
 const implementationChallengeTask = revivedTask("Run implementation challenge pass two and implement any better current-scope change.");
+const explicitNoEditChallengeTask = revivedTask([
+	"Implementation challenge pass 1 for issue #1147.",
+	"Are you absolutely sure this is the optimal current-scope architecture and implementation for the accepted contract?",
+	"If not, revise to a smaller or better-fitting shape. Do not add scope, public surface, config, abstractions, future-proofing, broad rewrites, or broader tests.",
+	"If the current solution is best, make no file changes and explain why. Re-run only focused checks affected by any change. Report whether changes were made.",
+].join("\n"));
 
 test("implementation challenges may complete with explicit no-change reports", () => {
 	for (const report of [
@@ -104,6 +110,14 @@ test("implementation challenges may complete with explicit no-change reports", (
 			triggered: false,
 		});
 	}
+});
+
+test("explicit no-edit challenge follow-ups accept no-further-change reports", () => {
+	assert.equal(evaluateCompletionMutationGuard({
+		agent: "worker",
+		task: explicitNoEditChallengeTask,
+		messages: [assistantText("Implemented no further changes.")],
+	}).triggered, false);
 });
 
 test("implementation challenge reports require both a kept-current rationale and no-change statement", () => {


### PR DESCRIPTION
Fixes #1110.

This keeps explicit no-edit retained-writer challenge passes successful when the follow-up allowed no file changes and the child reports `Implemented no further changes.` Ordinary implementation tasks with no edits still fail the mutation guard.

Validation on rebased head `ef0dbfc9`:
- `node --experimental-strip-types --test test/unit/completion-guard.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`

Fresh exact-head review is being rerun after the final rebase.