### PR TITLE
fix(schedules): tolerate a project dir deleted after session bind

### DIFF
--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -152,7 +152,17 @@ function assertScheduleRoot(root: string, projectCwd: string | undefined, create
 		if (create) fs.mkdirSync(root, { recursive: true, mode: 0o700 });
 		return;
 	}
-	const projectPath = fs.realpathSync(projectCwd);
+	let projectPath: string;
+	try {
+		projectPath = fs.realpathSync(projectCwd);
+	} catch (error) {
+		// The project directory no longer exists (e.g. it was deleted while a
+		// session bound to it stays open). Treat it as having no schedules:
+		// ids()/list() then see a missing root and return empty, and the
+		// bind-time restore becomes a no-op instead of crashing the extension.
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
 	let existing = root;
 	while (!fs.existsSync(existing)) {
 		const parent = path.dirname(existing);

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -166,6 +166,22 @@ describe("project schedule management", () => {
 		assert.match(text(listed), /other/);
 	});
 
+	it("tolerates a project directory that was deleted after bind", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-schedule-test-"));
+		roots.push(root);
+		const deleted = path.join(root, "vanished-project");
+		fs.mkdirSync(deleted, { recursive: true });
+		const storeDir = path.join(deleted, ".pi/subagents/schedules");
+		const scheduleDir = path.join(storeDir, "night-review");
+		fs.mkdirSync(scheduleDir, { recursive: true });
+		fs.writeFileSync(path.join(scheduleDir, "schedule.json"), JSON.stringify({ schemaVersion: 1, id: "night-review", name: "Night review", cwd: deleted, createdAt: "2030-01-01T00:00:00Z", updatedAt: "2030-01-01T00:00:00Z", paused: false, trigger: { kind: "once", at: "2030-01-02T00:00:00Z" }, target: { workflowScript: "return runs.run('main', { agent: 'reviewer' })" } }));
+		fs.rmSync(deleted, { recursive: true });
+		// The whole bind-time restore path (restore -> list -> ids ->
+		// assertScheduleRoot) must not crash the extension on a dead cwd.
+		const records = listScheduledRunSummaries(deleted);
+		assert.deepEqual(records, []);
+	});
+
 	it("rejects direct schedule targets and requires workflowScript", async () => {
 		const h = harness();
 		const result = await h.manager.handleToolCall({ action: "schedule.create", id: "direct", every: "1h", agent: "worker", task: "Review" }, h.ctx);


### PR DESCRIPTION
## Problem

`assertScheduleRoot` (`src/runs/background/scheduled-runs.ts:150`) calls `fs.realpathSync(projectCwd)` unconditionally. When a pi session stays bound to a project directory that gets deleted (e.g. a repo is removed mid-session), every extension rebind — `/clear`, `newSession`, `finishSessionReplacement` — throws a raw `ENOENT` out of `bindSession → selectProject → restore`, which kills the **entire extension**, not just schedule restore.

Repro:
1. Open pi in a directory, then delete the directory from another shell.
2. `/clear` (or any rebind).
3. Extension dies with `ENOENT: no such file or directory, lstat '<deleted dir>'` at `assertScheduleRoot`.

## Fix

Treat a missing project cwd as "no schedules": catch `ENOENT` on the realpath and return early. `ids()` then sees a missing root and returns `[]`, so bind-time restore is a no-op instead of a crash. All subsequent `realpathSync` calls in the function only run when the project dir resolved successfully.

## Test

Added a regression test that writes a schedule record into a temp project, deletes the project, then asserts `listScheduledRunSummaries(deletedCwd)` returns `[]` rather than throwing — this exercises the exact `restore → list → ids → assertScheduleRoot` path that crashed.

Full unit suite: 2029 tests, 2015 pass. The single failing test (`herdr-inspector.test.ts`, "event loop has already resolved") is pre-existing on a clean tree (2028 tests / 2014 pass) and unrelated to this change.