### PR TITLE
Skip orphaned schedule directories so schedule restore cannot crash the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Keep schedule restore from crashing the extension at session start when a project has an orphaned schedule directory whose `schedule.json` is gone (for example after a git checkout that previously tracked it), by skipping orphaned directories instead of throwing.
 
 ### Added
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -235,7 +235,11 @@ class ScheduleStore {
 	}
 
 	list(): ScheduleRecord[] {
-		return this.ids().map((id) => this.get(id));
+		// Skip orphaned schedule directories (no schedule.json, e.g. removed by a git
+		// checkout that previously tracked it) instead of throwing and crashing restore.
+		return this.ids()
+			.map((id) => this.find(id))
+			.filter((schedule): schedule is ScheduleRecord => schedule !== undefined);
 	}
 
 	get(id: string): ScheduleRecord {

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -203,6 +203,25 @@ describe("project schedule management", () => {
 		assert.throws(() => manager.bindSession(context(h.ctx.cwd, "session-b")), /removed legacy agent target.*target\.workflowScript/i);
 	});
 
+	it("skips orphaned schedule directories without schedule.json", () => {
+		const h = harness();
+		const root = scheduledRunStorePath(h.ctx.cwd, undefined, path.join(h.root, "stores"));
+		const orphan = path.join(root, "orphaned-schedule");
+		fs.mkdirSync(orphan, { recursive: true });
+		fs.writeFileSync(path.join(orphan, "history.json"), JSON.stringify({ schemaVersion: 1, runs: [] }), "utf-8");
+		const manager = createScheduledRunManager({
+			config: { scheduledRuns: { enabled: true } },
+			storeRoot: path.join(h.root, "stores"),
+			now: () => h.clock.now,
+			timers: h.timers,
+			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
+		});
+
+		manager.bindSession(context(h.ctx.cwd, "session-b"));
+		assert.deepEqual(listScheduledRunSummaries(h.ctx.cwd, path.join(h.root, "stores")).map((schedule) => schedule.id), []);
+		manager.stop();
+	});
+
 	it("supports workflowScript targets and rejects unsafe or deferred shapes", async () => {
 		const h = harness();
 		const workflow = await h.manager.handleToolCall({ action: "schedule.create", id: "workflow", every: "6h", workflowScript: "return await runs.run('review', {agent:'reviewer'})" }, h.ctx);


### PR DESCRIPTION
## Problem

`ScheduleStore.list()` did `ids().map(get)`, and `get()` throws when a schedule directory has no `schedule.json`. A directory can lose only its `schedule.json` — for example a git checkout that removes a file the repository previously tracked while leaving the untracked `events.jsonl` / `history.json` / `runs/` behind. Every session start then crashed in `ScheduledRunManager.restore` → `bindSession` with:

```
error: Schedule '<id>' not found.
  at ScheduleStore.get
  at ScheduleStore.list
  at ScheduledRunManager.restore
  at ScheduledRunManager.selectProject
  at ScheduledRunManager.bindSession
```

## Fix

`list()` now maps through the existing `find()` helper and skips directories whose `schedule.json` is gone. `get()` still throws for explicit lookups, so `schedule.show` / `schedule.delete` keep their not-found errors.

## Test

New unit test creates an orphaned schedule directory and asserts `bindSession` + `listScheduledRunSummaries` tolerate it. Fails on main with the exact production error, passes with the fix.