### PR TITLE
fix: pass trusted session roots to fleet transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Keep structured delegation integration coverage active when the test process inherits a subagent-child environment marker.
 - Restore and list schedules after their project directory is deleted, and skip orphan schedule directories without letting create reuse their stale state. Thanks to [@ELA718](https://github.com/ELA718) for #1171 and [@colinb4987](https://github.com/colinb4987) for #1167.
 - Isolate test async state from the user temp root and write each missing-mission sync diagnostic only once (#1164, #1165).
+- Show FleetView transcript fallbacks for trusted session roots instead of warning about an untrusted session file. Thanks to [@aliceisjustplaying](https://github.com/aliceisjustplaying) for #1154.
 - Keep workflowScript child-launch tracking working on Bun-built Pi by avoiding a hard dependency on V8 promise hooks and rejecting non-portable nested async helpers. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #1158 and [@rholak](https://github.com/rholak) for the version-window diagnosis.
 - Skip fallback models that are unavailable in the active registry, so shared agent configs still run where their primary model is available. Thanks to [@JPFrancoia](https://github.com/JPFrancoia) for #1147.
 - Sweep expired wait subscriptions armed by another session, so a record left behind by a session that never returns stops accumulating in the subscriptions directory. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1142.

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -478,10 +478,15 @@ function externalElapsedEnd(run: ExternalRun): number {
 	return terminal ? (run.endedAt ?? run.updatedAt ?? Date.now()) : Date.now();
 }
 
-function asyncDetail(item: Extract<FleetItem, { kind: "async" }>): string[] {
+function asyncDetail(item: Extract<FleetItem, { kind: "async" }>, state: SubagentState): string[] {
 	const status = readStatus(item.run.asyncDir);
 	if (status) {
-		return formatAsyncRunTranscript(status, item.run.asyncDir, { index: item.index, lines: TRANSCRIPT_LINES }).split("\n");
+		const trackedJob = state.fleetJobs?.get(item.runId) ?? state.asyncJobs.get(item.runId);
+		return formatAsyncRunTranscript(status, item.run.asyncDir, {
+			index: item.index,
+			lines: TRANSCRIPT_LINES,
+			sessionRoots: uniquePaths([...(state.trustedSessionRoots ?? []), trackedJob?.sessionRoot]),
+		}).split("\n");
 	}
 	const outputPath = item.index !== undefined ? path.join(item.run.asyncDir, `output-${item.index}.log`) : undefined;
 	return [
@@ -527,7 +532,7 @@ function detailLines(item: FleetItem | undefined, error: string | undefined, sta
 			? foregroundRecentDetail(item, state)
 			: item.kind === "external"
 				? externalDetail(item)
-				: asyncDetail(item);
+				: asyncDetail(item, state);
 	if (error) lines.unshift(`Fleet scan warning: ${error}`, "");
 	return lines;
 }

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -876,6 +876,33 @@ describe("native subagent fleet", () => {
 		}
 	});
 
+	it("passes current-session trusted roots to async session transcript fallback", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-session-fallback-"));
+		try {
+			const asyncDir = writeAsyncRun(root, { id: "async-session-fallback" });
+			const sessionFile = path.join(asyncDir, "worker.jsonl");
+			fs.writeFileSync(sessionFile, `${JSON.stringify({ role: "assistant", content: "TRUSTED SESSION FALLBACK" })}\n`, "utf-8");
+			const state = stateForTest();
+			state.trustedSessionRoots = [asyncDir];
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 32, columns: 100 }, requestRender() {} } as never,
+				theme as never,
+				state,
+				() => {},
+				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 60_000 },
+			);
+			try {
+				const rendered = component.render(100).join("\n");
+				assert.match(rendered, /TRUSTED SESSION FALLBACK/);
+				assert.doesNotMatch(rendered, /without a trusted root|Session read failed/);
+			} finally {
+				component.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("renders structured tool activity and assistant Markdown when a child transcript is available", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-structured-"));
 		try {


### PR DESCRIPTION
Replacement for #1154, rebased on current main after the original fork branch could not be updated through the available token scope.\n\nThis preserves the submitted FleetView trusted-session transcript fix and adds Unreleased changelog credit.\n\nThanks to [@aliceisjustplaying](https://github.com/aliceisjustplaying) for #1154.\n\nValidation:\n- `node --experimental-strip-types --test test/unit/fleet.test.ts --test-name-pattern 'trusted session'`\n- `node --experimental-strip-types --test test/unit/fleet.test.ts`\n- `git diff --check`