### PR TITLE
fix: make schedule restore skip missing state safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
+- Restore and list schedules after their project directory is deleted, and skip orphan schedule directories without letting create reuse their stale state. Thanks to [@ELA718](https://github.com/ELA718) for #1171 and [@colinb4987](https://github.com/colinb4987) for #1167.
 - Keep workflowScript child-launch tracking working on Bun-built Pi by avoiding a hard dependency on V8 promise hooks and rejecting non-portable nested async helpers. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #1158 and [@rholak](https://github.com/rholak) for the version-window diagnosis.
 - Skip fallback models that are unavailable in the active registry, so shared agent configs still run where their primary model is available. Thanks to [@JPFrancoia](https://github.com/JPFrancoia) for #1147.
 - Sweep expired wait subscriptions armed by another session, so a record left behind by a session that never returns stops accumulating in the subscriptions directory. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1142.

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -152,7 +152,13 @@ function assertScheduleRoot(root: string, projectCwd: string | undefined, create
 		if (create) fs.mkdirSync(root, { recursive: true, mode: 0o700 });
 		return;
 	}
-	const projectPath = fs.realpathSync(projectCwd);
+	let projectPath: string;
+	try {
+		projectPath = fs.realpathSync(projectCwd);
+	} catch (error) {
+		if (!create && (error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
 	let existing = root;
 	while (!fs.existsSync(existing)) {
 		const parent = path.dirname(existing);
@@ -235,7 +241,7 @@ class ScheduleStore {
 	}
 
 	list(): ScheduleRecord[] {
-		return this.ids().map((id) => this.get(id));
+		return this.ids().map((id) => this.find(id)).filter((record): record is ScheduleRecord => record !== undefined);
 	}
 
 	get(id: string): ScheduleRecord {
@@ -461,7 +467,7 @@ export class ScheduledRunManager {
 		if (this.deps.resolveCapabilityCeiling?.(sessionId)) return textResult("Cannot persist a schedule while a capability ceiling is active.", undefined, undefined, true);
 		if (store.list().length >= resolveMaxPending(this.deps.config)) return textResult(`Schedule limit reached (${resolveMaxPending(this.deps.config)}).`, undefined, undefined, true);
 		const id = validateScheduleId((params.id?.trim() || this.randomId()));
-		if (store.list().some((item) => item.id === id)) return textResult(`Schedule '${id}' already exists.`, undefined, undefined, true);
+		if (store.ids().includes(id)) return textResult(`Schedule '${id}' already exists.`, undefined, undefined, true);
 		const now = this.now();
 		let trigger: ScheduleTrigger;
 		if (at) {

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -166,6 +166,20 @@ describe("project schedule management", () => {
 		assert.match(text(listed), /other/);
 	});
 
+	it("treats a deleted project cwd as having no schedules during restore and listing", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-schedule-deleted-project-"));
+		roots.push(root);
+		const project = path.join(root, "project");
+		fs.mkdirSync(project);
+		fs.rmSync(project, { recursive: true });
+		assert.deepEqual(listScheduledRunSummaries(project), []);
+		const manager = createScheduledRunManager({
+			config: { scheduledRuns: { enabled: true } },
+			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
+		});
+		assert.doesNotThrow(() => manager.bindSession(context(project)));
+	});
+
 	it("rejects direct schedule targets and requires workflowScript", async () => {
 		const h = harness();
 		const result = await h.manager.handleToolCall({ action: "schedule.create", id: "direct", every: "1h", agent: "worker", task: "Review" }, h.ctx);
@@ -281,6 +295,35 @@ describe("project schedule management", () => {
 		const result = await h.manager.handleToolCall({ action: "schedule.list" }, h.ctx);
 		assert.equal(result.isError, true);
 		assert.match(text(result), /Failed to read schedule record/);
+	});
+
+	it("skips orphan schedule directories during restore and listing", async () => {
+		const h = harness();
+		h.manager.stop();
+		const root = scheduledRunStorePath(h.ctx.cwd, undefined, path.join(h.root, "stores"));
+		fs.mkdirSync(path.join(root, "orphan"), { recursive: true });
+		const manager = createScheduledRunManager({
+			config: { scheduledRuns: { enabled: true } },
+			storeRoot: path.join(h.root, "stores"),
+			timers: h.timers,
+			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
+		});
+		assert.doesNotThrow(() => manager.bindSession(h.ctx));
+		assert.match(text(await manager.handleToolCall({ action: "schedule.list" }, h.ctx)), /No project schedules/);
+	});
+
+	it("rejects same-id create when an orphan directory contains stale state", async () => {
+		const h = harness();
+		const root = scheduledRunStorePath(h.ctx.cwd, undefined, path.join(h.root, "stores"));
+		const dir = path.join(root, "orphan");
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, "active.lock"), "stale", "utf-8");
+		fs.writeFileSync(path.join(dir, "history.json"), JSON.stringify({ schemaVersion: 1, runs: [] }), "utf-8");
+		const result = await h.manager.handleToolCall({ action: "schedule.create", id: "orphan", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		assert.equal(result.isError, true);
+		assert.match(text(result), /already exists/);
+		assert.equal(fs.existsSync(path.join(dir, "schedule.json")), false);
+		assert.equal(fs.readFileSync(path.join(dir, "active.lock"), "utf-8"), "stale");
 	});
 
 	it("rejects schedule directories that escape through a symlink", async () => {


### PR DESCRIPTION
Combines the safe parts of #1171 and #1167 on current main.

This keeps schedule restore/list from crashing when the project cwd is deleted or when a schedule directory is missing `schedule.json`. It also keeps `schedule.create` fail-closed by rejecting an existing same-id directory, so a new schedule cannot inherit stale history, events, runs, or `active.lock` state.

Thanks to [@ELA718](https://github.com/ELA718) for #1171 and [@colinb4987](https://github.com/colinb4987) for #1167.

Validation:
- `node --experimental-strip-types --test test/unit/scheduled-runs.test.ts`
- `git diff --check`

Fresh review: `/tmp/schedule-recovery-review.md` reported no issues.