### PR TITLE
fix: isolate async test roots and dedupe mission skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Restore and list schedules after their project directory is deleted, and skip orphan schedule directories without letting create reuse their stale state. Thanks to [@ELA718](https://github.com/ELA718) for #1171 and [@colinb4987](https://github.com/colinb4987) for #1167.
+- Isolate test async state from the user temp root and write each missing-mission sync diagnostic only once (#1164, #1165).
 - Keep workflowScript child-launch tracking working on Bun-built Pi by avoiding a hard dependency on V8 promise hooks and rejecting non-portable nested async helpers. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #1158 and [@rholak](https://github.com/rholak) for the version-window diagnosis.
 - Skip fallback models that are unavailable in the active registry, so shared agent configs still run where their primary model is available. Thanks to [@JPFrancoia](https://github.com/JPFrancoia) for #1147.
 - Sweep expired wait subscriptions armed by another session, so a record left behind by a session that never returns stops accumulating in the subscriptions directory. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1142.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "npm run test:unit",
-    "test:unit": "node --experimental-strip-types --test test/unit/*.test.ts",
+    "test:unit": "node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/*.test.ts",
     "test:integration": "node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/*.test.ts",
     "test:e2e": "node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/e2e/*.test.ts",
     "test:all": "npm run test:unit && npm run test:integration && npm run test:e2e"

--- a/src/missions/lifecycle.ts
+++ b/src/missions/lifecycle.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createHash } from "node:crypto";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { writePrivateAtomicJson } from "../shared/atomic-json.ts";
 import { PROMPT_REDACTED } from "../shared/utils.ts";
@@ -294,13 +295,17 @@ export function syncMissionFromAsyncCompletion(value: unknown): MissionRecord | 
 		current = readMission(binding.location, binding.missionId);
 	} catch (error) {
 		if (!(error instanceof MissionNotFoundError)) throw error;
+		const reason = "mission-record-missing";
+		const markerId = createHash("sha256").update(JSON.stringify([runId, binding.missionId, reason])).digest("hex");
+		const markerPath = path.join(event.asyncDir, `.mission-sync-skipped-${markerId}.json`);
 		try {
+			fs.writeFileSync(markerPath, `${JSON.stringify({ runId, missionId: binding.missionId, reason })}\n`, { encoding: "utf-8", mode: 0o600, flag: "wx" });
 			fs.appendFileSync(path.join(event.asyncDir, "events.jsonl"), `${JSON.stringify({
 				type: "subagent.mission.sync.skipped",
 				ts: Date.now(),
 				runId,
 				missionId: binding.missionId,
-				reason: "mission-record-missing",
+				reason,
 				missionPath: missionRecordPath(binding.location, binding.missionId),
 			})}\n`, "utf-8");
 		} catch {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2049,7 +2049,10 @@ export function resolveTempScopeId(options?: {
 
 const MAX_PARALLEL = 8;
 export const MAX_CONCURRENCY = 4;
-export const TEMP_ROOT_DIR = path.join(os.tmpdir(), `pi-subagents-${resolveTempScopeId()}`);
+const configuredTempRoot = process.env.PI_SUBAGENTS_TEMP_ROOT?.trim();
+export const TEMP_ROOT_DIR = configuredTempRoot
+	? path.resolve(configuredTempRoot)
+	: path.join(os.tmpdir(), `pi-subagents-${resolveTempScopeId()}`);
 export const RESULTS_DIR = path.join(TEMP_ROOT_DIR, "async-subagent-results");
 export const ASYNC_DIR = path.join(TEMP_ROOT_DIR, "async-subagent-runs");
 export const CHAIN_RUNS_DIR = path.join(TEMP_ROOT_DIR, "chain-runs");

--- a/test/support/isolated-temp-root.mjs
+++ b/test/support/isolated-temp-root.mjs
@@ -1,0 +1,9 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+if (!process.env.PI_SUBAGENTS_TEMP_ROOT) {
+	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-test-root-"));
+	process.env.PI_SUBAGENTS_TEMP_ROOT = tempRoot;
+	process.on("exit", () => fs.rmSync(tempRoot, { recursive: true, force: true }));
+}

--- a/test/support/real-session-runner.ts
+++ b/test/support/real-session-runner.ts
@@ -171,6 +171,7 @@ export async function runRealSubagentSession(options: RealSessionRunOptions): Pr
 	const envSnapshot = new Map([
 		["HOME", process.env.HOME],
 		["USERPROFILE", process.env.USERPROFILE],
+		["PI_SUBAGENTS_TEMP_ROOT", process.env.PI_SUBAGENTS_TEMP_ROOT],
 		["PI_CODING_AGENT_DIR", process.env.PI_CODING_AGENT_DIR],
 		["PI_SUBAGENT_EXTRA_AGENT_DIRS", process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS],
 		["PI_SUBAGENT_CHILD", process.env.PI_SUBAGENT_CHILD],
@@ -207,6 +208,7 @@ export async function runRealSubagentSession(options: RealSessionRunOptions): Pr
 		process.chdir(cwd);
 		process.env.HOME = home;
 		process.env.USERPROFILE = home;
+		process.env.PI_SUBAGENTS_TEMP_ROOT ??= path.join(home, "pi-subagents-temp");
 		process.env.PI_CODING_AGENT_DIR = home;
 		delete process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
 		delete process.env.PI_SUBAGENT_CHILD;

--- a/test/support/register-loader.mjs
+++ b/test/support/register-loader.mjs
@@ -11,5 +11,6 @@
  */
 
 import { register } from "node:module";
+import "./isolated-temp-root.mjs";
 
 register(new URL("./ts-loader.mjs", import.meta.url));

--- a/test/unit/mission-lifecycle.test.ts
+++ b/test/unit/mission-lifecycle.test.ts
@@ -232,8 +232,16 @@ describe("mission launch lifecycle", () => {
 				state: "complete",
 				success: true,
 			});
+			const repeated = syncMissionFromAsyncCompletion({
+				runId: "async-missing-mission",
+				asyncDir,
+				mode: "single",
+				state: "complete",
+				success: true,
+			});
 
 			assert.equal(completed, undefined);
+			assert.equal(repeated, undefined);
 			const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
 			assert.deepEqual(events, [{
 				type: "subagent.mission.sync.skipped",
@@ -244,6 +252,7 @@ describe("mission launch lifecycle", () => {
 				missionPath: path.join(binding.location.missionDir, `${binding.missionId}.json`),
 			}]);
 			assert.equal(typeof events[0]?.ts, "number");
+			assert.equal(fs.readdirSync(asyncDir).filter((name) => name.startsWith(".mission-sync-skipped-")).length, 1);
 		} finally {
 			fs.rmSync(test.root, { recursive: true, force: true });
 		}

--- a/test/unit/temp-paths.test.ts
+++ b/test/unit/temp-paths.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
+import { spawnSync } from "node:child_process";
 import { describe, it } from "node:test";
 import {
 	ASYNC_DIR,
@@ -53,6 +56,28 @@ describe("resolveTempScopeId", () => {
 });
 
 describe("shared temp paths", () => {
+	it("uses the explicit temp root before shared paths resolve", () => {
+		const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-temp-override-"));
+		const override = path.join(fixture, "async state");
+		const isolatedHome = path.join(fixture, "home");
+		try {
+			const moduleUrl = new URL("../../src/shared/types.ts", import.meta.url).href;
+			const script = `import { ASYNC_DIR, RESULTS_DIR, TEMP_ROOT_DIR } from ${JSON.stringify(moduleUrl)}; console.log(JSON.stringify({ ASYNC_DIR, RESULTS_DIR, TEMP_ROOT_DIR }));`;
+			const result = spawnSync(process.execPath, ["--experimental-strip-types", "--input-type=module", "--eval", script], {
+				encoding: "utf-8",
+				env: { ...process.env, HOME: isolatedHome, USERPROFILE: isolatedHome, PI_SUBAGENTS_TEMP_ROOT: override },
+			});
+			assert.equal(result.status, 0, result.stderr);
+			assert.deepEqual(JSON.parse(result.stdout.trim()), {
+				ASYNC_DIR: path.join(override, "async-subagent-runs"),
+				RESULTS_DIR: path.join(override, "async-subagent-results"),
+				TEMP_ROOT_DIR: override,
+			});
+		} finally {
+			fs.rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
 	it("anchors shared temp directories under one scoped root", () => {
 		assert.equal(path.dirname(RESULTS_DIR), TEMP_ROOT_DIR);
 		assert.equal(path.dirname(ASYNC_DIR), TEMP_ROOT_DIR);


### PR DESCRIPTION
Fixes #1164 and #1165.

This adds an explicit `PI_SUBAGENTS_TEMP_ROOT` override so tests can keep async temp state out of the user-scoped runtime root. It also deduplicates repeated `subagent.mission.sync.skipped` diagnostics for missing mission records with a per-run/mission/reason sidecar marker.

This does not implement #1162 scan/index bounds or #1163 retention cleanup. It only stops new test-root pollution and repeated skipped-event growth.

Validation:
- `node --experimental-strip-types --test test/unit/temp-paths.test.ts test/unit/mission-lifecycle.test.ts`
- `git diff --check`

Fresh review: `/tmp/async-growth-recovery-review.md` reported no issues.