### PR TITLE
fix: clarify steering receipts and nudges

### DIFF
--- a/src/inspectors/herdr/inspector-runner.ts
+++ b/src/inspectors/herdr/inspector-runner.ts
@@ -6,6 +6,7 @@ import { parseMissionRecord } from "../../missions/store.ts";
 import type { MissionRecord } from "../../missions/types.ts";
 import { requestAsyncSteer, requestAsyncStop } from "../../runs/background/control-channel.ts";
 import { formatAsyncRunTranscript } from "../../runs/background/fleet-view.ts";
+import { steeringReceipt } from "../../runs/background/steering.ts";
 import type { AsyncStatus } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 
@@ -112,7 +113,7 @@ export function submitInspectorControl(options: RunnerOptions, line: string): st
 			...(targetIndex !== undefined ? { targetIndex } : { targetIndexes: runningIndexes }),
 			source: "herdr-inspector",
 		});
-		return `Steering queued for run ${options.runId}.`;
+		return steeringReceipt(message, `Steering queued for run ${options.runId}.`);
 	}
 	if (command.startsWith("reply ")) throw new Error("Supervisor replies are owned by the parent Pi session; use subagent_supervisor/intercom there.");
 	throw new Error("Unknown control. Use steer <message>, stop, or status.");

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -507,6 +507,12 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				reconciliation.message ? `Diagnosis: ${reconciliation.message}` : undefined,
 				reconciliation.resultPath && fs.existsSync(reconciliation.resultPath) ? `Result: ${reconciliation.resultPath}` : undefined,
 			].filter((line): line is string => Boolean(line));
+			const liveWorkflowControls = status.mode === "workflow" && deps.state?.currentSessionId === status.sessionId && deps.state?.workflowControllers?.has(status.runId)
+				? [...(deps.state?.foregroundControls.values() ?? [])].filter((control) => control.parentWorkflowRunId === status.runId
+					&& control.sessionId === status.sessionId
+					&& Boolean(control.workflowSteeringDir && fs.existsSync(control.workflowSteeringDir))
+					&& (control.activeChildren?.size ?? 0) > 0)
+				: [];
 			for (const [index, step] of (status.steps ?? []).entries()) {
 				const stepActivityText = step.status === "running" ? formatActivityLabel(step.lastActivityAt, step.activityState) : undefined;
 				const modelThinking = formatModelThinking(step.model, step.thinking);
@@ -527,7 +533,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				lines.push(...formatNestedRunStatusLines(step.children, { indent: "  ", commandHints: true, maxLines: 20 }));
 				const stepOutputPath = path.join(asyncDir, `output-${index}.log`);
 				if (stepOutputPath !== outputPath && fs.existsSync(stepOutputPath)) lines.push(`  Output: ${stepOutputPath}`);
-				if (step.status === "running" && step.runner?.type !== "external-cli") {
+				if (step.status === "running" && step.runner?.type !== "external-cli" && status.mode !== "workflow") {
 					lines.push(`  Intercom target: ${resolveSubagentIntercomTarget(status.runId, step.agent, index)} (if registered)`);
 					lines.push(`  Steer: subagent({ action: "steer", id: "${status.runId}", index: ${index}, message: "..." })`);
 				} else if (step.status === "running" && step.runner?.type === "external-cli") {
@@ -537,10 +543,18 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			const attached = new Set((status.steps ?? []).flatMap((step) => step.children?.map((child) => child.id) ?? []));
 			const unattached = nestedChildren.filter((child) => !attached.has(child.id));
 			lines.push(...formatNestedRunStatusLines(unattached, { indent: "", commandHints: true, maxLines: 20 }));
+			if (status.mode === "workflow" && status.state === "running") {
+				if (liveWorkflowControls.length === 0) lines.push("Steer: unavailable; no live foreground route is registered in the active session.");
+				else for (const control of liveWorkflowControls) {
+					for (const index of [...control.activeChildren!.keys()].sort((left, right) => left - right)) {
+						lines.push(`Steer live foreground child: subagent({ action: "steer", id: "${control.runId}", index: ${index}, message: "..." })`);
+					}
+				}
+			}
 			if (nestedWarning) lines.push(`Warning: ${nestedWarning}`);
 			if (status.sessionFile) lines.push(`Session: ${status.sessionFile}`);
 			const allExternal = (status.steps?.length ?? 0) > 0 && status.steps!.every((step) => step.runner?.type === "external-cli");
-			if (status.state === "running" && !allExternal) lines.push(`Steer running child: subagent({ action: "steer", id: "${status.runId}", message: "..." })`);
+			if (status.state === "running" && !allExternal && status.mode !== "workflow") lines.push(`Steer running child: subagent({ action: "steer", id: "${status.runId}", message: "..." })`);
 			if (status.state !== "running") {
 				lines.push(allExternal
 					? "Resume: unavailable; one-shot external CLI runners do not persist sessions."

--- a/src/runs/background/steering.ts
+++ b/src/runs/background/steering.ts
@@ -13,9 +13,19 @@ import type {
 	SteeringTargetStatus,
 } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
+import { previewDisplayText } from "../../shared/display-text.ts";
+import { redactSecretValues } from "../shared/permissions.ts";
 
 export const MAX_STEERING_REQUESTS = 20;
 export const STEERING_MESSAGE_PREVIEW_LIMIT = 160;
+
+export function steeringMessagePreview(message: string): string {
+	return previewDisplayText(redactSecretValues(message), STEERING_MESSAGE_PREVIEW_LIMIT);
+}
+
+export function steeringReceipt(message: string, receipt: string): string {
+	return `${receipt} Message: ${JSON.stringify(steeringMessagePreview(message))}`;
+}
 
 export function createSteeringStatus(): SteeringStatus {
 	return { requested: 0, scheduled: 0, pending: 0, delivered: 0, failed: 0, recovered: 0, recent: [] };
@@ -35,7 +45,7 @@ export function recordSteeringRequest(
 		id: input.id,
 		requestedAt: input.requestedAt,
 		...(input.source ? { source: input.source } : {}),
-		messagePreview: input.message.slice(0, STEERING_MESSAGE_PREVIEW_LIMIT),
+		messagePreview: steeringMessagePreview(input.message),
 		targets: input.targets.map((target) => ({ index: target.index, state: target.state, ...(target.reason ? { reason: target.reason } : {}) })),
 	};
 	status.requested++;

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -2735,8 +2735,16 @@ async function runSubagent(
 		.sort((left, right) => left.startedAt - right.startedAt)[0];
 	const supervisorAttentionSteps = new Map<number, ActivityState | undefined>();
 	const mutatingFailureWindowMs = 5 * 60_000;
-	const appendControlEvent = (event: ReturnType<typeof buildControlEvent>) => {
+	const appendControlEvent = (rawEvent: ReturnType<typeof buildControlEvent>) => {
 		if (!controlConfig.enabled) return;
+		const contextStep = statusPayload.steps[rawEvent.index ?? statusPayload.currentStep ?? 0];
+		const event = {
+			...rawEvent,
+			...(contextStep?.workflowKey ?? statusPayload.workflowKey ? { workflowKey: contextStep?.workflowKey ?? statusPayload.workflowKey } : {}),
+			...(contextStep?.phase ? { phase: contextStep.phase } : {}),
+			...(contextStep?.label ? { label: contextStep.label } : {}),
+			...(contextStep?.description ? { taskPreview: contextStep.description } : {}),
+		};
 		const childIntercomTarget = config.childIntercomTargets?.[event.index ?? statusPayload.currentStep];
 		const channels = event.type === "active_long_running"
 			? controlConfig.notifyChannels.filter((channel) => channel !== "intercom")

--- a/src/runs/foreground/async-steering-action.ts
+++ b/src/runs/foreground/async-steering-action.ts
@@ -8,7 +8,7 @@ import { readStatus } from "../../shared/utils.ts";
 import { consumeSteerAcks, deliverInterruptRequest, queueRevivalBrief, requestAsyncSteer, type SteerDeliveryMode, type SteerRequest } from "../background/control-channel.ts";
 import { resolveAsyncResumeTarget } from "../background/async-resume.ts";
 import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
-import { actionResultFromSteeringStatus, claimSteeringRecovery, createSteeringStatus, recordSteeringRequest, remainingSteeringRecoveryLimits, updateSteeringTarget, waitForSteeringAction } from "../background/steering.ts";
+import { actionResultFromSteeringStatus, claimSteeringRecovery, createSteeringStatus, recordSteeringRequest, remainingSteeringRecoveryLimits, steeringReceipt, updateSteeringTarget, waitForSteeringAction } from "../background/steering.ts";
 
 export async function steerAsyncRun(input: {
 	state: SubagentState;
@@ -72,7 +72,7 @@ export async function steerAsyncRun(input: {
 		recordSteeringRequest(status.steering, { id: request.id, requestedAt: request.ts, source: request.source, message: request.message, targets: [{ index: 0, state: "scheduled" }] });
 		writeAtomicJson(path.join(asyncDir, "status.json"), status);
 		const queued = { requestId: request.id, state: "scheduled" as const, deliveryStatus: "queued" as const, sourceRunId: status.runId, targets: [{ index: 0, state: "scheduled" as const }] };
-		return { content: [{ type: "text", text: `Follow-up queued for the next resume of retained async run ${status.runId} (request ${request.id}).` }], details: { mode: "management", results: [], steering: queued } };
+		return { content: [{ type: "text", text: steeringReceipt(request.message, `Follow-up queued for the next resume of retained async run ${status.runId} (request ${request.id}).`) }], details: { mode: "management", results: [], steering: queued } };
 	}
 	if (input.index !== undefined) {
 		if (input.index < 0 || input.index >= steps.length) {
@@ -135,17 +135,17 @@ export async function steerAsyncRun(input: {
 	const targets = targetIndexes.map((index) => ({ index, state: status.steps?.[index]?.status === "pending" ? "scheduled" as const : "pending" as const }));
 	if (targets.every((target) => target.state === "scheduled")) {
 		const scheduled = { requestId, state: "scheduled" as const, deliveryStatus: "queued" as const, sourceRunId: status.runId, targets };
-		return { content: [{ type: "text", text: `Steering scheduled for async run ${status.runId} (request ${requestId}).` }], details: { mode: "management", results: [], steering: scheduled } };
+		return { content: [{ type: "text", text: steeringReceipt(input.message, `Steering scheduled for async run ${status.runId} (request ${requestId}).`) }], details: { mode: "management", results: [], steering: scheduled } };
 	}
 	const waited = await waitForSteeringAction({ asyncDir, sourceRunId: status.runId, requestId, timeoutMs: input.ackTimeoutMs ?? 3_000, signal: input.signal });
 	const result = waited ?? { requestId, state: "pending" as const, deliveryStatus: "queued" as const, sourceRunId: status.runId, targets };
 	if (input.signal?.aborted) {
-		return { content: [{ type: "text", text: `Steering pending for async run ${status.runId} (request ${requestId}); caller aborted before recovery.` }], details: { mode: "management", results: [], steering: result } };
+		return { content: [{ type: "text", text: steeringReceipt(input.message, `Steering pending for async run ${status.runId} (request ${requestId}); caller aborted before recovery.`) }], details: { mode: "management", results: [], steering: result } };
 	}
 	const finalStatus = readStatus(asyncDir);
 	const finalResult = finalStatus?.steering ? actionResultFromSteeringStatus(finalStatus.steering, status.runId, requestId) : undefined;
 	if (finalResult?.state === "delivered") {
-		return { content: [{ type: "text", text: `Steering delivered for async run ${status.runId} (request ${requestId}).` }], details: { mode: "management", results: [], steering: finalResult } };
+		return { content: [{ type: "text", text: steeringReceipt(input.message, `Steering delivered for async run ${status.runId} (request ${requestId}).`) }], details: { mode: "management", results: [], steering: finalResult } };
 	}
 	const running = (finalStatus?.steps ?? status.steps ?? []).filter((step) => step.status === "running");
 	const recoveryAllowed = (input.mode ?? "steer") === "steer" && status.mode === "single" && status.isNested !== true && running.length === 1 && Boolean(finalStatus?.steering) && (input.index === undefined || input.index === 0);
@@ -160,7 +160,7 @@ export async function steerAsyncRun(input: {
 		try {
 			const latest = readStatus(asyncDir);
 			const latestResult = latest?.steering ? actionResultFromSteeringStatus(latest.steering, status.runId, requestId) : undefined;
-			if (latestResult?.state === "delivered") return { content: [{ type: "text", text: `Steering delivered for async run ${status.runId} (request ${requestId}).` }], details: { mode: "management", results: [], steering: latestResult } };
+			if (latestResult?.state === "delivered") return { content: [{ type: "text", text: steeringReceipt(input.message, `Steering delivered for async run ${status.runId} (request ${requestId}).`) }], details: { mode: "management", results: [], steering: latestResult } };
 			const committedAt = Date.now();
 			input.onBeforeRecoveryClaim?.(requestId, committedAt);
 			const { claimPath, markerPath } = claimSteeringRecovery(asyncDir, { requestId, sourceRunId: status.runId, committedAt });
@@ -170,7 +170,7 @@ export async function steerAsyncRun(input: {
 			if (preCommitResult?.state === "delivered" && preCommitResult.targets.every((target) => target.deliveredAt !== undefined && target.deliveredAt <= committedAt)) {
 				fs.rmSync(markerPath, { force: true });
 				fs.rmSync(claimPath, { force: true });
-				return { content: [{ type: "text", text: `Steering delivered for async run ${status.runId} (request ${requestId}).` }], details: { mode: "management", results: [], steering: preCommitResult } };
+				return { content: [{ type: "text", text: steeringReceipt(input.message, `Steering delivered for async run ${status.runId} (request ${requestId}).`) }], details: { mode: "management", results: [], steering: preCommitResult } };
 			}
 			try {
 				deliverInterruptRequest({ asyncDir, source: "steering-recovery" });
@@ -228,7 +228,7 @@ export async function steerAsyncRun(input: {
 			}
 			const recovered = paused.steering ? actionResultFromSteeringStatus(paused.steering, status.runId, requestId, revived.details.asyncId) : undefined;
 			appendSteeringNotice("recovered", `Steering recovered for run ${status.runId}; replacement ${revived.details.asyncId} launched.`);
-			return { content: [{ type: "text", text: `Steering recovered for async run ${status.runId}; replacement ${revived.details.asyncId} launched after the source paused.` }], details: { mode: "management", results: [], steering: recovered ?? { requestId, state: "recovered", sourceRunId: status.runId, replacementRunId: revived.details.asyncId, deliveryStatus: "delivered", targets: [{ index: input.index ?? 0, state: "recovered" }] } } };
+			return { content: [{ type: "text", text: steeringReceipt(input.message, `Steering recovered for async run ${status.runId}; replacement ${revived.details.asyncId} launched after the source paused.`) }], details: { mode: "management", results: [], steering: recovered ?? { requestId, state: "recovered", sourceRunId: status.runId, replacementRunId: revived.details.asyncId, deliveryStatus: "delivered", targets: [{ index: input.index ?? 0, state: "recovered" }] } } };
 		} catch (error) {
 			const reason = error instanceof Error ? error.message : String(error);
 			const failedStatus = readStatus(asyncDir);
@@ -242,13 +242,13 @@ export async function steerAsyncRun(input: {
 			}
 			const failed = failedStatus?.steering ? actionResultFromSteeringStatus(failedStatus.steering, status.runId, requestId) : undefined;
 			appendSteeringNotice("failed", `Steering failed for run ${status.runId}: ${reason}`);
-			return { content: [{ type: "text", text: `Steering failed for async run ${status.runId} (request ${requestId}): ${reason}` }], isError: true, details: { mode: "management", results: [], steering: failed ?? { requestId, state: "failed", sourceRunId: status.runId, deliveryStatus: "queued", targets: [{ index: input.index ?? 0, state: "failed", reason }] } } };
+			return { content: [{ type: "text", text: steeringReceipt(input.message, `Steering failed for async run ${status.runId} (request ${requestId}): ${reason}`) }], isError: true, details: { mode: "management", results: [], steering: failed ?? { requestId, state: "failed", sourceRunId: status.runId, deliveryStatus: "queued", targets: [{ index: input.index ?? 0, state: "failed", reason }] } } };
 		}
 	}
 	const stateText = result.state === "failed" ? "failed" : result.state === "partial" ? "partial" : result.deliveryStatus === "queued" ? "queued" : result.state === "delivered" ? "delivered" : result.state === "scheduled" ? "scheduled" : result.state === "recovered" ? "recovered" : "pending";
 	const isError = result.state === "failed" || result.state === "partial";
 	return {
-		content: [{ type: "text", text: `Steering ${stateText} for async run ${status.runId} (request ${requestId}).` }],
+		content: [{ type: "text", text: steeringReceipt(input.message, `Steering ${stateText} for async run ${status.runId} (request ${requestId}).`) }],
 		...(isError ? { isError: true } : {}),
 		details: { mode: "management", results: [], steering: result },
 	};

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -783,6 +783,7 @@ async function runSingleAttempt(
 				currentToolDurationMs: input.currentToolDurationMs ?? currentToolDurationMs(now),
 				currentPath: input.currentPath ?? progress.currentPath,
 				recentFailureSummary: input.recentFailureSummary,
+				taskPreview: task,
 			});
 			emitControlEvent(event);
 			return previous !== "needs_attention";
@@ -809,6 +810,7 @@ async function runSingleAttempt(
 				currentToolDurationMs: currentToolDurationMs(now),
 				currentPath: progress.currentPath,
 				elapsedMs: now - startTime,
+				taskPreview: task,
 			}));
 			return true;
 		};

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -53,6 +53,7 @@ import {
 import { discoverAvailableSkills, normalizeSkillInput } from "../../agents/skills.ts";
 import { buildAsyncRunnerSteps, DEFAULT_ASYNC_TIMEOUT_MS, executeAsyncChain, executeAsyncSingle, formatAsyncStartedMessage, isAsyncAvailable, workflowAwaitedAsyncResultPath } from "../background/async-execution.ts";
 import { updateActiveRunIndex } from "../background/active-run-index.ts";
+import { steeringReceipt } from "../background/steering.ts";
 import { acquireActiveAsyncCapacity, ActiveAsyncCapacityError, getActiveAsyncCapacitySnapshot, resolveMaxActiveAsyncRunsPerSession, transferActiveAsyncCapacity, type ActiveAsyncCapacityHandle } from "../background/active-async-capacity.ts";
 import { isScheduledRunAction, type ScheduledRunAction } from "../background/scheduled-runs.ts";
 import { enqueueChainAppendRequest, readPendingChainAppendRequests, runnerStepOutputNames } from "../background/chain-append.ts";
@@ -1368,12 +1369,12 @@ async function directNestedAsyncSteer(input: { target: ResolvedSubagentRunId & {
 	const targets = targetIndexes.map((index) => ({ index, state: steps[index]?.status === "pending" ? "scheduled" as const : "pending" as const }));
 	if (targets.every((target) => target.state === "scheduled")) {
 		const scheduled = { requestId, state: "scheduled" as const, deliveryStatus: "queued" as const, sourceRunId: run.id, targets };
-		return { content: [{ type: "text", text: `Steering scheduled for nested async run ${run.id} (request ${requestId}).` }], details: { mode: "management", results: [], steering: scheduled } };
+		return { content: [{ type: "text", text: steeringReceipt(input.message, `Steering scheduled for nested async run ${run.id} (request ${requestId}).`) }], details: { mode: "management", results: [], steering: scheduled } };
 	}
 	const waited = await waitForSteeringAction(omitUndefinedProperties({ asyncDir, sourceRunId: run.id, requestId, timeoutMs: 3_000, signal: input.signal }));
 	const result = waited ?? { requestId, state: "pending" as const, deliveryStatus: "queued" as const, sourceRunId: run.id, targets };
 	const stateText = result.state === "failed" ? "failed" : result.state === "partial" ? "partial" : result.deliveryStatus === "queued" ? "queued" : result.state === "delivered" ? "delivered" : "pending";
-	return { content: [{ type: "text", text: `Steering ${stateText} for nested async run ${run.id} (request ${requestId}).` }], ...(result.state === "failed" || result.state === "partial" ? { isError: true } : {}), details: { mode: "management", results: [], steering: result } };
+	return { content: [{ type: "text", text: steeringReceipt(input.message, `Steering ${stateText} for nested async run ${run.id} (request ${requestId}).`) }], ...(result.state === "failed" || result.state === "partial" ? { isError: true } : {}), details: { mode: "management", results: [], steering: result } };
 }
 
 async function interruptNestedRun(target: ResolvedSubagentRunId & { kind: "nested" }): Promise<AgentToolResult<Details>> {

--- a/src/runs/foreground/workflow-foreground-steering.ts
+++ b/src/runs/foreground/workflow-foreground-steering.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Details, ForegroundRunControl, SubagentState } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
+import { steeringReceipt } from "../background/steering.ts";
 import {
 	consumeSteerAckFromDir,
 	readSteerCapability,
@@ -146,18 +147,18 @@ export async function steerWorkflowForegroundTarget(input: {
 		targets: [target],
 	};
 	if (input.signal?.aborted) {
-		return { content: [{ type: "text", text: `Steering pending for foreground run ${control.runId} (request ${request.id}); caller aborted before acknowledgment.` }], details: { mode: "management", results: [], steering } };
+		return { content: [{ type: "text", text: steeringReceipt(request.message, `Steering pending for foreground run ${control.runId} (request ${request.id}); caller aborted before acknowledgment.`) }], details: { mode: "management", results: [], steering } };
 	}
 	if (ack?.state === "delivered") {
-		return { content: [{ type: "text", text: `Steering delivered for foreground run ${control.runId} (request ${request.id}).` }], details: { mode: "management", results: [], steering } };
+		return { content: [{ type: "text", text: steeringReceipt(request.message, `Steering delivered for foreground run ${control.runId} (request ${request.id}).`) }], details: { mode: "management", results: [], steering } };
 	}
 	if (ack?.state === "queued") {
-		return { content: [{ type: "text", text: `Steering queued for foreground run ${control.runId} (request ${request.id}).` }], details: { mode: "management", results: [], steering } };
+		return { content: [{ type: "text", text: steeringReceipt(request.message, `Steering queued for foreground run ${control.runId} (request ${request.id}).`) }], details: { mode: "management", results: [], steering } };
 	}
 	if (ack?.state === "failed") {
-		return { content: [{ type: "text", text: `Steering failed for foreground run ${control.runId} (request ${request.id}): ${ack.message}` }], isError: true, details: { mode: "management", results: [], steering } };
+		return { content: [{ type: "text", text: steeringReceipt(request.message, `Steering failed for foreground run ${control.runId} (request ${request.id}): ${ack.message}`) }], isError: true, details: { mode: "management", results: [], steering } };
 	}
-	return { content: [{ type: "text", text: `Steering pending for foreground run ${control.runId} (request ${request.id}); no acknowledgment was received.` }], details: { mode: "management", results: [], steering } };
+	return { content: [{ type: "text", text: steeringReceipt(request.message, `Steering pending for foreground run ${control.runId} (request ${request.id}); no acknowledgment was received.`) }], details: { mode: "management", results: [], steering } };
 }
 
 export function workflowForegroundSteeringDir(asyncDirRoot: string, workflowRunId: string, childRunId: string): string {

--- a/src/runs/shared/permissions.ts
+++ b/src/runs/shared/permissions.ts
@@ -14,6 +14,10 @@ const MAX_PREVIEW_BYTES = 2048;
 const SECRET_KEY = /(?:authorization|cookie|credential|password|secret|token|api[-_]?key)/i;
 const SECRET_VALUE = /\b(?:Bearer\s+\S+|(?:sk|ghp|github_pat|xox[baprs])[-_A-Za-z0-9]{8,})\b/gi;
 
+export function redactSecretValues(value: string): string {
+	return value.replace(SECRET_VALUE, "[redacted]");
+}
+
 export function validatePermissionRules(value: unknown, label: string): PermissionRules | undefined {
 	if (value === undefined) return undefined;
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object mapping tool names to allow, ask, or deny.`);
@@ -66,7 +70,7 @@ function redact(value: unknown, key = "", depth = 0): unknown {
 	if (Array.isArray(value)) return value.slice(0, 10).map((item) => redact(item, "", depth + 1));
 	if (value && typeof value === "object") return Object.fromEntries(Object.entries(value as Record<string, unknown>).slice(0, 20).map(([entryKey, entryValue]) => [entryKey, redact(entryValue, entryKey, depth + 1)]));
 	if (typeof value === "string") {
-		const redacted = value.replace(SECRET_VALUE, "[redacted]");
+		const redacted = redactSecretValues(value);
 		return redacted.length > 500 ? `${redacted.slice(0, 500)}…` : redacted;
 	}
 	return value;

--- a/src/runs/shared/subagent-control.ts
+++ b/src/runs/shared/subagent-control.ts
@@ -7,6 +7,8 @@ import {
 	type ResolvedControlConfig,
 } from "../../shared/types.ts";
 import { isToolTimeoutExempt } from "./tool-timeout.ts";
+import { createHash } from "node:crypto";
+import { previewDisplayText } from "../../shared/display-text.ts";
 
 const CONTROL_EVENT_TYPES: ControlEventType[] = ["active_long_running", "needs_attention"];
 const CONTROL_NOTIFICATION_CHANNELS: ControlNotificationChannel[] = ["event", "async", "intercom"];
@@ -116,6 +118,10 @@ export function buildControlEvent(input: {
 	currentPath?: string;
 	elapsedMs?: number;
 	recentFailureSummary?: string;
+	workflowKey?: string;
+	phase?: string;
+	label?: string;
+	taskPreview?: string;
 }): ControlEvent {
 	const ts = input.ts ?? Date.now();
 	const type = input.type ?? (input.to === "active_long_running" ? "active_long_running" : "needs_attention");
@@ -144,6 +150,10 @@ export function buildControlEvent(input: {
 		...(input.currentPath ? { currentPath: input.currentPath } : {}),
 		...(elapsedMs !== undefined ? { elapsedMs } : {}),
 		...(input.recentFailureSummary ? { recentFailureSummary: input.recentFailureSummary } : {}),
+		...(input.workflowKey ? { workflowKey: input.workflowKey } : {}),
+		...(input.phase ? { phase: input.phase } : {}),
+		...(input.label ? { label: input.label } : {}),
+		...(input.taskPreview ? { taskPreview: previewDisplayText(input.taskPreview, 160) } : {}),
 	};
 }
 
@@ -153,7 +163,8 @@ export function shouldNotifyControlEvent(config: ResolvedControlConfig, event: C
 
 export function controlNotificationKey(event: ControlEvent, childIntercomTarget?: string): string {
 	const childKey = childIntercomTarget ?? (event.index !== undefined ? `${event.runId}:${event.index}` : event.runId);
-	return `${childKey}:${event.type}:${event.reason ?? "idle"}`;
+	const contextHash = createHash("sha256").update(formatControlNudge(event)).digest("hex").slice(0, 8);
+	return `${childKey}:${event.type}:${event.reason ?? "idle"}:${contextHash}`;
 }
 
 export function claimControlNotification(config: ResolvedControlConfig, event: ControlEvent, seenKeys: Set<string>, childIntercomTarget?: string): boolean {
@@ -175,6 +186,17 @@ function formatLongRunningFacts(event: ControlEvent): string | undefined {
 	return facts.length > 0 ? facts.join(" | ") : undefined;
 }
 
+export function formatControlNudge(event: ControlEvent): string {
+	const scope = event.label ?? event.phase ?? event.workflowKey ?? event.taskPreview;
+	if (event.recentFailureSummary) return previewDisplayText(`Resolve the recent failure${scope ? ` for ${scope}` : ""}: ${event.recentFailureSummary}. Report the smallest next step or ask for a decision.`, 160);
+	if (event.currentTool || event.currentPath) {
+		const current = [event.currentTool ? `tool ${event.currentTool}` : undefined, event.currentPath ? `path ${event.currentPath}` : undefined].filter(Boolean).join(" at ");
+		return previewDisplayText(`Check ${current}${scope ? ` for ${scope}` : ""}. Report the smallest next step or ask for a decision.`, 160);
+	}
+	if (scope) return previewDisplayText(`Continue ${scope}. Report the smallest next step or ask for a decision.`, 160);
+	return "What are you blocked on? Reply with the smallest next step or ask for a decision.";
+}
+
 export function formatControlNoticeMessage(event: ControlEvent, childIntercomTarget?: string): string {
 	const runTarget = event.runId;
 	if (event.reason === "completion_guard") {
@@ -187,9 +209,9 @@ export function formatControlNoticeMessage(event: ControlEvent, childIntercomTar
 		].filter((line): line is string => Boolean(line)).join("\n");
 	}
 
-	const nudgeMessage = "What are you blocked on? Reply with the smallest next step or ask for a decision.";
-	const steerCommand = `subagent({ action: "steer", id: "${runTarget}", ${event.index !== undefined ? `index: ${event.index}, ` : ""}message: "${nudgeMessage}" })`;
-	const nestedResumeCommand = `subagent({ action: "resume", id: "${runTarget}", message: "${nudgeMessage}" })`;
+	const nudgeMessage = formatControlNudge(event);
+	const steerCommand = `subagent({ action: "steer", id: "${runTarget}", ${event.index !== undefined ? `index: ${event.index}, ` : ""}message: ${JSON.stringify(nudgeMessage)} })`;
+	const nestedResumeCommand = `subagent({ action: "resume", id: "${runTarget}", message: ${JSON.stringify(nudgeMessage)} })`;
 	if (event.type === "active_long_running") {
 		const facts = formatLongRunningFacts(event);
 		return [

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -214,6 +214,10 @@ export interface ControlEvent {
 	currentPath?: string;
 	elapsedMs?: number;
 	recentFailureSummary?: string;
+	workflowKey?: string;
+	phase?: string;
+	label?: string;
+	taskPreview?: string;
 }
 
 export type SubagentResultStatus = "completed" | "failed" | "paused" | "stopped" | "detached";

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -215,6 +215,7 @@ describe("async interrupt action", () => {
 			assert.equal(result.details.steering?.state, "delivered");
 			assert.equal(result.details.steering?.sourceRunId, childRunId);
 			assert.equal(request.message, "Focus on the failing test.");
+			assert.match(text(result), /Message: "Focus on the failing test\."/);
 		} finally {
 			cleanup(workflowRunId, asyncDir);
 		}

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -225,7 +225,7 @@ describe("Herdr inspector", () => {
 			assert.match(dashboard, /decision-1: Choose UX/);
 			assert.match(dashboard, /closing it does not stop the run/i);
 
-			assert.match(submitInspectorControl({ asyncDir, runId: "run-123", refreshMs: 1_500 }, "steer keep going"), /queued/);
+			assert.match(submitInspectorControl({ asyncDir, runId: "run-123", refreshMs: 1_500 }, "steer keep going"), /Steering queued for run run-123\. Message: "keep going"/);
 			assert.deepEqual(consumeSteerRequests(asyncDir).map((request) => ({ message: request.message, targetIndex: request.targetIndex, source: request.source })), [
 				{ message: "keep going", targetIndex: 0, source: "herdr-inspector" },
 			]);

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -1099,6 +1099,25 @@ describe("async run status inspection", () => {
 		}
 	});
 
+	it("does not advertise a workflow steering command without a live foreground route", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-workflow-route-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const asyncDir = path.join(asyncRoot, "workflow-live");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "workflow-live", sessionId: "session", mode: "workflow", state: "running", pid: 12345,
+				startedAt: 100, lastUpdate: 100, steps: [{ agent: "worker", status: "running", startedAt: 100 }],
+			}));
+			const result = inspectSubagentStatus({ id: "workflow-live" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results"), kill: () => true, now: () => 200 });
+			const text = textContent(result);
+			assert.match(text, /Steer: unavailable; no live foreground route is registered in the active session\./);
+			assert.doesNotMatch(text, /action: "steer", id: "workflow-live"/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects ambiguous async run id prefixes", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-ambiguous-"));
 		try {

--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -139,6 +139,7 @@ describe("acknowledged steering action", () => {
 			assert.equal(result.isError, undefined);
 			assert.equal(result.details.steering?.state, "delivered");
 			assert.match(result.content[0]!.text, /Steering delivered/);
+			assert.match(result.content[0]!.text, /Message: "correct course"/);
 		} finally {
 			removeAsyncDir(asyncDir);
 		}
@@ -330,6 +331,7 @@ describe("acknowledged steering action", () => {
 			const result = await action;
 			assert.equal(result.isError, undefined);
 			assert.equal(result.details.steering?.state, "recovered");
+			assert.match(result.content[0]!.text, /Message: "correct course"/);
 			assert.equal(result.details.steering?.replacementRunId, "replacement");
 			assert.ok(result.details.steering?.targets[0]?.lateDeliveredAt);
 			const limits = receivedLimits as { timeoutMs: number; absoluteDeadlineAt: number; turnBudget: unknown; toolBudget: unknown };

--- a/test/unit/steering.test.ts
+++ b/test/unit/steering.test.ts
@@ -3,11 +3,19 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { actionResultFromSteeringStatus, claimSteeringRecovery, createSteeringStatus, recordSteeringRequest, remainingSteeringRecoveryLimits, terminalSteeringNoticeState, updateSteeringTarget } from "../../src/runs/background/steering.ts";
+import { actionResultFromSteeringStatus, claimSteeringRecovery, createSteeringStatus, recordSteeringRequest, remainingSteeringRecoveryLimits, steeringMessagePreview, terminalSteeringNoticeState, updateSteeringTarget } from "../../src/runs/background/steering.ts";
 import { applySteeringRecoveryAgentConfig } from "../../src/runs/background/async-resume.ts";
 import type { AgentConfig } from "../../src/agents/agents.ts";
 
 describe("steering lifecycle ledger", () => {
+	it("redacts and bounds steering message previews", () => {
+		const secret = "ghp_1234567890abcdef";
+		const preview = steeringMessagePreview(`Use ${secret}\n${"x".repeat(200)}`);
+		assert.ok(preview.length <= 160);
+		assert.match(preview, /\[redacted\]/);
+		assert.doesNotMatch(preview, new RegExp(secret));
+	});
+
 	it("retains 20 recent requests while aggregate totals remain monotonic", () => {
 		const status = createSteeringStatus();
 		for (let index = 0; index < 21; index++) {

--- a/test/unit/subagent-control.test.ts
+++ b/test/unit/subagent-control.test.ts
@@ -198,6 +198,17 @@ describe("subagent control attention state", () => {
 
 		assert.match(message, /worker has had tool 'bash' open for 240s/);
 		assert.match(message, /Facts: tool bash 240s \| path scripts\/run-tests\.sh/);
+		assert.match(message, /message: "Check tool bash at path scripts\/run-tests\.sh\. Report the smallest next step or ask for a decision\."/);
+	});
+
+	it("uses bounded task context in nudges and de-duplicates distinct contexts", () => {
+		const first = buildControlEvent({ to: "needs_attention", runId: "run-1", agent: "reviewer", label: `release gate ${"x".repeat(200)}` });
+		const second = buildControlEvent({ to: "needs_attention", runId: "run-1", agent: "reviewer", label: "security gate" });
+		const firstMessage = formatControlNoticeMessage(first);
+		const nudge = firstMessage.match(/message: ("(?:[^"\\]|\\.)*")/)?.[1];
+		assert.ok(nudge);
+		assert.ok((JSON.parse(nudge) as string).length <= 160);
+		assert.notEqual(controlNotificationKey(first), controlNotificationKey(second));
 	});
 
 	it("formats supervisor-request notices with pending-channel guidance", () => {
@@ -235,8 +246,8 @@ describe("subagent control attention state", () => {
 		assert.match(message, /Subagent active but long-running: worker/);
 		assert.match(message, /Inspect status/);
 		assert.match(message, /steer for a top-level live async child, routed resume for a live nested child/);
-		assert.match(message, /Top-level live async nudge: subagent\(\{ action: "steer", id: "78f659a3", message: "What are you blocked on\?/);
-		assert.match(message, /Routed live nested nudge: subagent\(\{ action: "resume", id: "78f659a3", message: "What are you blocked on\?/);
+		assert.match(message, /Top-level live async nudge: subagent\(\{ action: "steer", id: "78f659a3", message: "Check tool edit at path src\/runs\/background\/async-status\.ts/);
+		assert.match(message, /Routed live nested nudge: subagent\(\{ action: "resume", id: "78f659a3", message: "Check tool edit at path src\/runs\/background\/async-status\.ts/);
 		assert.match(message, /15 turns/);
 		assert.match(message, /160000 tokens/);
 		assert.match(message, /path src\/runs\/background\/async-status\.ts/);
@@ -277,7 +288,7 @@ describe("subagent control attention state", () => {
 		const event = buildControlEvent({ to: "needs_attention", runId: "run-1", agent: "worker", index: 0 });
 		const seen = new Set<string>();
 
-		assert.equal(controlNotificationKey(event, "subagent-worker-run-1-1"), "subagent-worker-run-1-1:needs_attention:idle");
+		assert.match(controlNotificationKey(event, "subagent-worker-run-1-1"), /^subagent-worker-run-1-1:needs_attention:idle:[a-f0-9]{8}$/);
 		assert.equal(claimControlNotification(resolveControlConfig(), event, seen, "subagent-worker-run-1-1"), true);
 		assert.equal(claimControlNotification(resolveControlConfig(), event, seen, "subagent-worker-run-1-1"), false);
 


### PR DESCRIPTION
Addresses #1155, #1159, and #1160.

This makes steer receipts include a bounded redacted message preview, avoids over-promising stale foreground steer routes in status, and builds contextual needs-attention nudges from bounded existing control data. The active-agent routing audit found the remaining direct `.prompt()` calls create helper agents, not continuations of already-active agents.

Validation:
- `node --experimental-strip-types --test test/unit/steering.test.ts test/unit/steering-action.test.ts test/unit/async-interrupt-action.test.ts test/unit/subagent-control.test.ts test/unit/run-status.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review: `/tmp/steering-control-fix-review.md` found no source blockers after the targeted receipt-preview fix.