### PR TITLE
test: isolate structured delegation registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
+- Keep structured delegation integration coverage active when the test process inherits a subagent-child environment marker.
 - Restore and list schedules after their project directory is deleted, and skip orphan schedule directories without letting create reuse their stale state. Thanks to [@ELA718](https://github.com/ELA718) for #1171 and [@colinb4987](https://github.com/colinb4987) for #1167.
 - Isolate test async state from the user temp root and write each missing-mission sync diagnostic only once (#1164, #1165).
 - Keep workflowScript child-launch tracking working on Bun-built Pi by avoiding a hard dependency on V8 promise hooks and rejecting non-portable nested async helpers. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #1158 and [@rholak](https://github.com/rholak) for the version-window diagnosis.

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -45,6 +45,7 @@ import { createRunFanoutBudget, encodeRunFanoutBudgetDescriptor, RUN_FANOUT_BUDG
 import { MainWatchdogRuntime } from "../../src/watchdog/runtime.ts";
 import { MAX_CHILD_PENDING_LINE_BYTES, MAX_CHILD_STDERR_BYTES } from "../../src/runs/shared/child-protocol.ts";
 import {
+	SUBAGENT_CHILD_ENV,
 	SUBAGENT_FANOUT_CHILD_ENV,
 	SUBAGENT_STEER_ACK_DIR_ENV,
 	SUBAGENT_STEER_CAPABILITY_ENV,
@@ -2629,7 +2630,14 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		} satisfies SubagentDelegationRequest;
 
 		try {
-			registerSubagentExtension(fakePi as never);
+			const previousChildEnv = process.env[SUBAGENT_CHILD_ENV];
+			delete process.env[SUBAGENT_CHILD_ENV];
+			try {
+				registerSubagentExtension(fakePi as never);
+			} finally {
+				if (previousChildEnv === undefined) delete process.env[SUBAGENT_CHILD_ENV];
+				else process.env[SUBAGENT_CHILD_ENV] = previousChildEnv;
+			}
 			for (const handler of runtimeHandlers.get("session_start") ?? []) {
 				await handler({ reason: "startup" }, ctx);
 			}


### PR DESCRIPTION
## Summary

Fixes the baseline `single-execution` integration test failure that kept PR #1174 red.

The test can run inside a delegated subagent process with `PI_SUBAGENT_CHILD` set. In that environment, `registerSubagentExtension()` intentionally skips normal parent extension registration. The test now clears that marker only around the synchronous registration call and restores the prior value in `finally`.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'routes registered structured text delegation through the concurrent executor' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review: `/tmp/main-red-concurrent-executor-review.md` reported no blockers.
