### PR TITLE
fix: bound async result indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Keep structured delegation integration coverage active when the test process inherits a subagent-child environment marker.
+- Bound repeated async-state queries to active, exact-id, and recent-terminal indexes instead of scanning the historical async root (#1162).
 - Restore and list schedules after their project directory is deleted, and skip orphan schedule directories without letting create reuse their stale state. Thanks to [@ELA718](https://github.com/ELA718) for #1171 and [@colinb4987](https://github.com/colinb4987) for #1167.
 - Isolate test async state from the user temp root and write each missing-mission sync diagnostic only once (#1164, #1165).
 - Show FleetView transcript fallbacks for trusted session roots instead of warning about an untrusted session file. Thanks to [@aliceisjustplaying](https://github.com/aliceisjustplaying) for #1154.

--- a/src/runs/background/active-run-index.ts
+++ b/src/runs/background/active-run-index.ts
@@ -1,7 +1,9 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AsyncStatus } from "../../shared/types.ts";
+import { readStatus } from "../../shared/utils.ts";
 import { encodeIndexSegment } from "./index-segment.ts";
+import { updateTerminalRunIndex } from "./terminal-run-index.ts";
 
 export const ACTIVE_RUN_INDEX_DIR = ".active-runs";
 export const DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS = 24 * 60 * 60 * 1000;
@@ -92,6 +94,14 @@ export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state
 		return;
 	}
 	releaseActiveRunIndex(asyncDir);
+	const status = readStatus(asyncDir);
+	if (status && status.state === state) {
+		try {
+			updateTerminalRunIndex(asyncDir, status);
+		} catch (error) {
+			console.error(`Failed to write async terminal-run index for '${asyncDir}':`, error);
+		}
+	}
 }
 
 export function activeRunMarkerAgeMs(asyncDir: string, now = Date.now()): number | undefined {

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -8,7 +8,8 @@ import { intersectSubagentCapabilityCeilings, parseSubagentCapabilityCeiling, ty
 import { validateRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 import { resolveTurnBudgetConfig } from "../shared/turn-budget.ts";
 import { reconcileAsyncRun } from "./stale-run-reconciler.ts";
-import { resultFilePath } from "./result-files.ts";
+import { resultFilePath, resultPayloadPathForIndexedRun } from "./result-files.ts";
+import { canScanAsyncRunPrefix, MIN_SAFE_ASYNC_RUN_PREFIX_LENGTH } from "./run-id-query.ts";
 
 export interface AsyncResumeParams {
 	id?: string;
@@ -173,6 +174,8 @@ function prefixedRunIds(dir: string, prefix: string, suffix = ""): string[] {
 }
 
 function exactResultPath(resultsDir: string, runId: string): string | null {
+	const indexed = resultPayloadPathForIndexedRun(resultsDir, runId);
+	if (indexed) return indexed;
 	const resultPath = resultFilePath(resultsDir, runId);
 	assertInsideRoot(resultsDir, resultPath, "Async result file");
 	return fs.existsSync(resultPath) ? resultPath : null;
@@ -181,6 +184,7 @@ function exactResultPath(resultsDir: string, runId: string): string | null {
 export function findAsyncRunPrefixMatches(prefix: string, asyncDirRoot: string, resultsDir: string): Array<{ id: string; location: AsyncRunLocation }> {
 	const requestedId = assertRunId(prefix, "id");
 	if (!requestedId) return [];
+	if (!canScanAsyncRunPrefix(requestedId)) return [];
 	const asyncRoot = path.resolve(asyncDirRoot);
 	const resultRoot = path.resolve(resultsDir);
 	const matchingIds = prefixedRunIds(asyncRoot, requestedId).sort();
@@ -223,6 +227,10 @@ export function resolveAsyncRunLocation(params: AsyncResumeParams, asyncDirRoot:
 			resolvedId: requestedId,
 		};
 	}
+	if (requestedId.length < MIN_SAFE_ASYNC_RUN_PREFIX_LENGTH) {
+		throw new Error(`Async run id prefix '${requestedId}' is too short. Provide at least ${MIN_SAFE_ASYNC_RUN_PREFIX_LENGTH} characters.`);
+	}
+	if (!canScanAsyncRunPrefix(requestedId)) return { asyncDir: null, resultPath: null, resolvedId: requestedId };
 
 	const matching = findAsyncRunPrefixMatches(requestedId, asyncRoot, resultRoot);
 	if (matching.length === 0) return { asyncDir: null, resultPath: null, resolvedId: requestedId };

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -4,7 +4,7 @@ import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "
 import { formatActivityLabel, formatParallelOutcome } from "../../shared/status-format.ts";
 import { type ActivityState, type AsyncJobStep, type AsyncParallelGroupStatus, type AsyncStatus, type CostSummary, type Details, type LaunchResolvedChildExtensionsV1, type RuntimeAcknowledgedChildExtensionsV1, type NestedRunSummary, type SteeringStatus, type SubagentRunMode, type TokenUsage, type TurnBudgetState, type UsageBudgetState } from "../../shared/types.ts";
 import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../shared/capability-ceiling.ts";
-import { pruneStatusCacheForAsyncRoot, readStatus } from "../../shared/utils.ts";
+import { readStatus } from "../../shared/utils.ts";
 import { attachRootChildrenToSteps, buildNestedRouteIndex, findNestedRouteForRootId, type NestedRoute, projectNestedEvents } from "../shared/nested-events.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
@@ -13,6 +13,8 @@ import { contextModeLabel, summarizeContextModes, type ContextMode, type Context
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
 import { readProcessTerminal, sanitizeProcessTerminal } from "./process-terminal.ts";
 import { ACTIVE_RUN_INDEX_DIR, DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS, activeRunMarkerAgeMs, isActiveAsyncState, readActiveRunIndex, releaseActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
+import { readRecentTerminalRunIndex, TERMINAL_RUN_INDEX_DIR } from "./terminal-run-index.ts";
+import { canScanAsyncRunPrefix } from "./run-id-query.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
@@ -120,14 +122,18 @@ interface AsyncRunListOptions {
 	states?: Array<AsyncRunSummary["state"]>;
 	sessionId?: string;
 	limit?: number;
-	/** Limits status-file reads after candidates are ordered by status mtime. */
+	/** Limits terminal candidates using the timestamp embedded in index marker names. */
 	entryLimit?: number;
 	resultsDir?: string;
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 	now?: () => number;
 	reconcile?: boolean;
 	runId?: string;
+	/** The caller already holds a canonical run id; never interpret a miss as a prefix. */
+	exactRunId?: boolean;
 	includeNested?: boolean;
+	/** Explicit repair/debug escape hatch. Normal runtime paths must not set this. */
+	repairScan?: boolean;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -155,7 +161,7 @@ function isAsyncRunDir(root: string, entry: string): boolean {
 
 type TargetedAsyncRunResolution =
 	| { kind: "exact"; id: string }
-	| { kind: "scan" }
+	| { kind: "prefix" }
 	| { kind: "reject" };
 
 /**
@@ -163,13 +169,13 @@ type TargetedAsyncRunResolution =
  * accepting a path whose canonical location escaped the async root.
  */
 export function resolveTargetedAsyncRun(asyncDirRoot: string, id: string, sessionId?: string): TargetedAsyncRunResolution {
-	if (!id || id === "." || id === ".." || id === ACTIVE_RUN_INDEX_DIR || path.basename(id) !== id) return { kind: "reject" };
+	if (!id || id === "." || id === ".." || id === ACTIVE_RUN_INDEX_DIR || id === TERMINAL_RUN_INDEX_DIR || path.basename(id) !== id) return { kind: "reject" };
 	const asyncDir = path.join(asyncDirRoot, id);
 	let entryStat: fs.Stats;
 	try {
 		entryStat = fs.lstatSync(asyncDir);
 	} catch (error) {
-		if (isNotFoundError(error)) return { kind: "scan" };
+		if (isNotFoundError(error)) return canScanAsyncRunPrefix(id) ? { kind: "prefix" } : { kind: "reject" };
 		throw new Error(`Failed to inspect async run path '${asyncDir}': ${getErrorMessage(error)}`, {
 			cause: error instanceof Error ? error : undefined,
 		});
@@ -187,7 +193,7 @@ export function resolveTargetedAsyncRun(asyncDirRoot: string, id: string, sessio
 	}
 	if (sessionId !== undefined) {
 		const status = readStatus(asyncDir);
-		if (status?.sessionId !== sessionId) return { kind: "scan" };
+		if (status?.sessionId !== sessionId) return canScanAsyncRunPrefix(id) ? { kind: "prefix" } : { kind: "reject" };
 	}
 	return { kind: "exact", id };
 }
@@ -375,35 +381,39 @@ function sortRuns(runs: AsyncRunSummary[]): AsyncRunSummary[] {
 
 export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions = {}): AsyncRunSummary[] {
 	let entries: string[];
-	let scannedCompleteRoot = false;
-	let usedActiveIndex = false;
-	const activeOnly = options.runId === undefined
-		&& options.entryLimit === undefined
-		&& options.states !== undefined
-		&& options.states.length > 0
-		&& options.states.every(isActiveAsyncState);
+	const activeEntries = new Set<string>();
+	const wantsActive = options.states === undefined || options.states.some(isActiveAsyncState);
+	const wantsTerminal = options.states === undefined || options.states.some((state) => !isActiveAsyncState(state));
 	const includeNested = options.includeNested !== false;
 	try {
 		if (options.runId !== undefined) {
 			const resolution = resolveTargetedAsyncRun(asyncDirRoot, options.runId, options.sessionId);
 			entries = resolution.kind === "exact"
 				? [resolution.id]
-				: resolution.kind === "scan"
+				: resolution.kind === "prefix" && options.exactRunId !== true
 					? fs.readdirSync(asyncDirRoot).filter((entry) =>
 						(entry === options.runId || entry.startsWith(options.runId!))
 						&& resolveTargetedAsyncRun(asyncDirRoot, entry, options.sessionId).kind === "exact"
 					)
 					: [];
-		} else if (activeOnly) {
-			entries = (readActiveRunIndex(asyncDirRoot) ?? []).filter((entry) => {
-				if (resolveTargetedAsyncRun(asyncDirRoot, entry).kind === "exact") return true;
-				updateActiveRunIndex(path.join(asyncDirRoot, entry), "failed");
-				return false;
-			});
-			usedActiveIndex = true;
+		} else if (options.repairScan === true) {
+			entries = fs.readdirSync(asyncDirRoot).filter((entry) => entry !== ACTIVE_RUN_INDEX_DIR && entry !== TERMINAL_RUN_INDEX_DIR && isAsyncRunDir(asyncDirRoot, entry));
 		} else {
-			entries = fs.readdirSync(asyncDirRoot).filter((entry) => entry !== ACTIVE_RUN_INDEX_DIR && isAsyncRunDir(asyncDirRoot, entry));
-			scannedCompleteRoot = true;
+			const indexed = new Set<string>();
+			if (wantsActive) {
+				for (const entry of readActiveRunIndex(asyncDirRoot) ?? []) {
+					if (resolveTargetedAsyncRun(asyncDirRoot, entry).kind === "exact") {
+						indexed.add(entry);
+						activeEntries.add(entry);
+					} else {
+						updateActiveRunIndex(path.join(asyncDirRoot, entry), "failed");
+					}
+				}
+			}
+			if (wantsTerminal) {
+				for (const entry of readRecentTerminalRunIndex(asyncDirRoot, { sessionId: options.sessionId, ...(options.entryLimit !== undefined ? { limit: options.entryLimit } : {}) })) indexed.add(entry);
+			}
+			entries = [...indexed];
 		}
 	} catch (error) {
 		if (isNotFoundError(error)) return [];
@@ -411,28 +421,6 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 			cause: error instanceof Error ? error : undefined,
 		});
 	}
-
-	if (options.entryLimit !== undefined) {
-		scannedCompleteRoot = false;
-		const limit = Math.max(0, Math.floor(options.entryLimit));
-		entries = entries
-			.map((entry) => {
-				try {
-					return { entry, mtimeMs: fs.statSync(path.join(asyncDirRoot, entry, "status.json")).mtimeMs };
-				} catch (error) {
-					if (isNotFoundError(error)) return undefined;
-					throw new Error(`Failed to inspect async status file for '${entry}': ${getErrorMessage(error)}`, {
-						cause: error instanceof Error ? error : undefined,
-					});
-				}
-			})
-			.filter((candidate): candidate is { entry: string; mtimeMs: number } => candidate !== undefined)
-			.sort((left, right) => right.mtimeMs - left.mtimeMs)
-			.slice(0, limit)
-			.map((candidate) => candidate.entry);
-	}
-
-	if (scannedCompleteRoot) pruneStatusCacheForAsyncRoot(asyncDirRoot, entries);
 
 	const allowedStates = options.states ? new Set(options.states) : undefined;
 	const runs: AsyncRunSummary[] = [];
@@ -444,7 +432,7 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 	let nestedRouteIndex: Map<string, NestedRoute> | undefined;
 	const resolveNestedRoute = (rootRunId: string): NestedRoute | undefined => {
 		if (!includeNested) return undefined;
-		if (usedActiveIndex) return findNestedRouteForRootId(rootRunId);
+		if (activeEntries.has(rootRunId)) return findNestedRouteForRootId(rootRunId);
 		if (!nestedRouteIndex) nestedRouteIndex = buildNestedRouteIndex();
 		return nestedRouteIndex.get(rootRunId);
 	};
@@ -455,10 +443,10 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 			: reconcileAsyncRun(asyncDir, { resultsDir: options.resultsDir, kill: options.kill, now: options.now });
 		const status = (reconciliation?.status ?? readStatus(asyncDir)) as (AsyncStatus & { cwd?: string }) | null;
 		if (!status) {
-			if (usedActiveIndex) updateActiveRunIndex(asyncDir, "failed");
+			if (activeEntries.has(entry)) updateActiveRunIndex(asyncDir, "failed");
 			continue;
 		}
-		if (usedActiveIndex && !isActiveAsyncState(status.state)) {
+		if (activeEntries.has(entry) && !isActiveAsyncState(status.state)) {
 			const processTerminal = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId });
 			if (processTerminal?.state === "observed" || (activeRunMarkerAgeMs(asyncDir, options.now?.()) ?? 0) > DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS) releaseActiveRunIndex(asyncDir);
 		}

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -7,6 +7,7 @@ import { encodeIndexSegment, MAX_INDEX_SEGMENT_BYTES } from "./index-segment.ts"
 const RESULT_INDEX_VERSION = 1;
 const RESULT_INDEX_DIR = "result-index";
 const SESSION_INDEX_DIR = "sessions";
+const RUN_INDEX_DIR = "runs";
 const OBSERVER_INDEX_DIR = "observers";
 const TOOL_CALL_INDEX_DIR = "tool-calls";
 const RESULT_PENDING_DIR = "result-pending";
@@ -49,6 +50,10 @@ function sessionIndexDir(resultsDir: string, sessionId: string): string {
 
 function resultIndexPath(resultsDir: string, sessionId: string, runId: string): string {
 	return path.join(sessionIndexDir(resultsDir, sessionId), encodedJsonFileName(runId));
+}
+
+function runIndexPath(resultsDir: string, runId: string): string {
+	return path.join(resultsDir, RESULT_INDEX_DIR, RUN_INDEX_DIR, encodedJsonFileName(runId));
 }
 
 function resultPendingPath(resultsDir: string, sessionId: string, runId: string): string {
@@ -104,6 +109,11 @@ export function writeResultIndexForData(resultPath: string, data: Record<string,
 	};
 	const resultsDir = path.dirname(resultPath);
 	writeAtomicJson(resultIndexPath(resultsDir, sessionId, runId), entry);
+	try {
+		writeAtomicJson(runIndexPath(resultsDir, runId), entry);
+	} catch (error) {
+		console.error(`Failed to write async result run index for '${resultPath}':`, error);
+	}
 	const toolCallId = nonEmptyString(data.toolCallId);
 	try {
 		if (toolCallId) writeAtomicJson(toolCallIndexPath(resultsDir, toolCallId, runId), entry);
@@ -153,6 +163,11 @@ export function removeResultIndex(resultsDir: string, sessionId: string | undefi
 		} catch {
 			// Pending cleanup must not affect result delivery.
 		}
+	}
+	try {
+		fs.rmSync(runIndexPath(resultsDir, runId), { force: true });
+	} catch {
+		// Index cleanup must not affect result delivery.
 	}
 	if (toolCallId) {
 		try {
@@ -242,28 +257,6 @@ function pendingResultLocationForSessionRun(resultsDir: string, sessionId: strin
 		: undefined;
 }
 
-function pendingResultLocationForIndexedRun(resultsDir: string, runId: string): ResultPayloadLocation | undefined {
-	const root = path.join(resultsDir, RESULT_PENDING_DIR);
-	let sessions: fs.Dirent[];
-	try {
-		sessions = fs.readdirSync(root, { withFileTypes: true });
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Failed to inspect pending async result root '${root}':`, error);
-		return undefined;
-	}
-	for (const session of sessions) {
-		if (!session.isDirectory()) continue;
-		const pendingPath = path.join(root, session.name, encodedJsonFileName(runId));
-		try {
-			const data = JSON.parse(fs.readFileSync(pendingPath, "utf-8")) as Record<string, unknown>;
-			if ((nonEmptyString(data.runId) ?? nonEmptyString(data.id)) === runId) return { file: resultFileName(runId), path: pendingPath, state: "pending" };
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid pending async result '${pendingPath}':`, error);
-		}
-	}
-	return undefined;
-}
-
 function resultPayloadLocationFromIndex(resultsDir: string, entry: ResultIndexEntry): ResultPayloadLocation | undefined {
 	if (entry.file !== path.basename(entry.file) || !entry.file.endsWith(".json")) return undefined;
 	const pendingState = promotePendingResultFile(resultsDir, entry.sessionId, entry.runId, entry.file);
@@ -305,27 +298,24 @@ export function resultPayloadPathForMissionObserverRun(resultsDir: string, runId
 }
 
 export function resultPayloadPathForIndexedRun(resultsDir: string, runId: string): string | undefined {
-	const root = path.join(resultsDir, RESULT_INDEX_DIR, SESSION_INDEX_DIR);
-	let sessions: fs.Dirent[] = [];
+	const entryPath = runIndexPath(resultsDir, runId);
 	try {
-		sessions = fs.readdirSync(root, { withFileTypes: true });
+		const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(entryPath, "utf-8")));
+		if (!entry || entry.runId !== runId) {
+			fs.rmSync(entryPath, { force: true });
+			return undefined;
+		}
+		const location = resultPayloadLocationFromIndex(resultsDir, entry);
+		if (location) return location.path;
+		fs.rmSync(entryPath, { force: true });
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code;
-		if (code !== "ENOENT" && code !== "ENOTDIR") console.error(`Failed to inspect async result session index root '${root}':`, error);
-	}
-	for (const session of sessions) {
-		if (!session.isDirectory()) continue;
-		const entryPath = path.join(root, session.name, encodedJsonFileName(runId));
-		try {
-			const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(entryPath, "utf-8")));
-			if (!entry || entry.runId !== runId) continue;
-			const location = resultPayloadLocationFromIndex(resultsDir, entry);
-			if (location) return location.path;
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result index '${entryPath}':`, error);
+		if (code !== "ENOENT" && code !== "ENOTDIR") {
+			console.error(`Ignoring invalid async result run index '${entryPath}':`, error);
+			try { fs.rmSync(entryPath, { force: true }); } catch {}
 		}
 	}
-	return pendingResultLocationForIndexedRun(resultsDir, runId)?.path;
+	return undefined;
 }
 
 function indexedResultFile(resultsDir: string, entry: ResultIndexEntry, includePending = false): string | undefined {

--- a/src/runs/background/retained-children.ts
+++ b/src/runs/background/retained-children.ts
@@ -4,6 +4,7 @@ import { readAsyncRecoveryDescriptor } from "./async-resume.ts";
 import type { TokenUsage } from "../../shared/types.ts";
 
 const MAX_RETAINED_CHILDREN = 10;
+const MAX_RETAINED_CHILD_CANDIDATES = 100;
 const MAX_TASK_SUMMARY_LENGTH = 120;
 
 type RetainedChildState = "complete" | "failed" | "paused" | "stopped";
@@ -71,7 +72,7 @@ function boundedTaskSummary(value: string | undefined): string {
 }
 
 export function listRetainedChildren(asyncDirRoot: string, sessionId: string): RetainedChild[] {
-	const children = listAsyncRuns(asyncDirRoot, { sessionId, states: ["complete", "failed", "paused", "stopped"], reconcile: false })
+	const children = listAsyncRuns(asyncDirRoot, { sessionId, states: ["complete", "failed", "paused", "stopped"], entryLimit: MAX_RETAINED_CHILD_CANDIDATES, reconcile: false })
 		.flatMap((run) => {
 			if (!run.parentWorkflowRunId || run.steps.length !== 1) return [];
 			if (!isRetainedChildState(run.state)) return [];

--- a/src/runs/background/run-id-query.ts
+++ b/src/runs/background/run-id-query.ts
@@ -1,0 +1,7 @@
+export const MIN_SAFE_ASYNC_RUN_PREFIX_LENGTH = 8;
+const FULL_ASYNC_RUN_ID_LENGTH = 36;
+
+/** Full generated ids and longer exact identities never fall back to a root scan. */
+export function canScanAsyncRunPrefix(id: string): boolean {
+	return id.length >= MIN_SAFE_ASYNC_RUN_PREFIX_LENGTH && id.length < FULL_ASYNC_RUN_ID_LENGTH;
+}

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { resultFilePath, resultPayloadPathForSessionRun, writeAsyncResultFile } from "./result-files.ts";
-import { releaseActiveRunIndex, updateActiveRunIndex } from "./active-run-index.ts";
+import { updateActiveRunIndex } from "./active-run-index.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { DIRS, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSummary, type SubagentRunMode } from "../../shared/types.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
@@ -271,7 +271,7 @@ function writeFailedRepair(asyncDir: string, status: AsyncStatus, resultPath: st
 	const repair = buildFailedRepair(status, asyncDir, now, reason);
 	if (repair.result.sessionId) writeAsyncResultFile(resultPath, repair.result);
 	writeAtomicJson(path.join(asyncDir, "status.json"), repair.status);
-	if (repair.status.processTerminal?.state === "observed") releaseActiveRunIndex(asyncDir);
+	updateActiveRunIndex(asyncDir, repair.status.state, repair.status.toolCallId);
 	appendJsonlBestEffort(path.join(asyncDir, "events.jsonl"), {
 		type: "subagent.run.repaired_stale",
 		ts: now,
@@ -365,7 +365,7 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 			: undefined;
 		if (terminalStatus) {
 			writeAtomicJson(path.join(asyncDir, "status.json"), terminalStatus);
-			if (terminalStatus.processTerminal?.state === "observed") releaseActiveRunIndex(asyncDir);
+			updateActiveRunIndex(asyncDir, terminalStatus.state, terminalStatus.toolCallId);
 			return { status: terminalStatus, repaired: true, resultPath: existingResultPath, message: "Existing async result file was used to repair stale running status." };
 		}
 		if (effectiveStatus.displayDismissedAt === undefined) return { status: effectiveStatus, repaired: false, resultPath: existingResultPath };

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -278,19 +278,19 @@ function attentionRunsForSession(params: SubagentWaitParams, deps: SubagentWaitD
 	return activeRunsForSession(params, deps).filter((run) => needsAttention(run) && initialIds.has(run.id));
 }
 
-/** All runs (any state) for this session, for the final summary. */
-function allRunsForSession(params: SubagentWaitParams, deps: SubagentWaitDeps): AsyncRunSummary[] {
+/** Exact initial runs in any state, for the final summary. */
+function runsForIds(runIds: Iterable<string>, deps: SubagentWaitDeps): AsyncRunSummary[] {
 	const asyncDirRoot = deps.asyncDirRoot ?? DIRS.async;
 	const resultsDir = deps.resultsDir ?? DIRS.results;
-	const runs = listAsyncRuns(asyncDirRoot, {
+	return [...runIds].flatMap((runId) => listAsyncRuns(asyncDirRoot, {
 		sessionId: deps.state.currentSessionId ?? undefined,
 		resultsDir,
 		kill: deps.kill,
 		now: deps.now,
 		includeNested: false,
-		...(params.id ? { runId: params.id } : {}),
-	});
-	return params.id ? runs.filter((run) => matchesId(run, params.id!)) : runs;
+		runId,
+		exactRunId: true,
+	}));
 }
 
 function summarizeTerminalRuns(runs: AsyncRunSummary[], providerFinishedCount = 0): string {
@@ -611,7 +611,7 @@ export async function waitForSubagents(
 	const activeProviderIds = new Set(providerActive.map(backgroundWorkIdentity));
 	const providerFinishedCount = [...initialProviderIds].filter((id) => !activeProviderIds.has(id)).length;
 	try {
-		const allNow = allRunsForSession(waitParams, deps);
+		const allNow = runsForIds(initialAsyncIds, deps);
 		const terminal = allNow.filter((run) => !ACTIVE_STATES.includes(run.state) && initialAsyncIds.has(run.id));
 		finishedAsyncCount = terminal.length;
 		failedAsyncCount = terminal.filter((run) => run.state === "failed").length;

--- a/src/runs/background/terminal-run-index.ts
+++ b/src/runs/background/terminal-run-index.ts
@@ -1,0 +1,129 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AsyncStatus } from "../../shared/types.ts";
+import { readStatus } from "../../shared/utils.ts";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { encodeIndexSegment } from "./index-segment.ts";
+
+export const TERMINAL_RUN_INDEX_DIR = ".terminal-runs";
+
+const TERMINAL_RUN_INDEX_VERSION = 1;
+const TIMESTAMP_WIDTH = 16;
+
+interface TerminalRunIndexEntry {
+	version: 1;
+	runId: string;
+	sessionId: string;
+	endedAt: number;
+}
+
+function isTerminalState(state: AsyncStatus["state"]): boolean {
+	return state === "complete" || state === "failed" || state === "paused" || state === "stopped" || state === "rejected";
+}
+
+function indexRoot(asyncDirRoot: string): string {
+	return path.join(asyncDirRoot, TERMINAL_RUN_INDEX_DIR);
+}
+
+function sessionIndexDir(asyncDirRoot: string, sessionId: string): string {
+	return path.join(indexRoot(asyncDirRoot), encodeIndexSegment(sessionId));
+}
+
+function markerName(endedAt: number, runId: string): string {
+	return `${Math.max(0, Math.floor(endedAt)).toString().padStart(TIMESTAMP_WIDTH, "0")}-${encodeIndexSegment(runId)}.json`;
+}
+
+function markerPath(asyncDir: string, sessionId: string, endedAt: number): string {
+	return path.join(sessionIndexDir(path.dirname(asyncDir), sessionId), markerName(endedAt, path.basename(asyncDir)));
+}
+
+function parseEntry(value: unknown): TerminalRunIndexEntry | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const entry = value as Partial<TerminalRunIndexEntry>;
+	if (entry.version !== TERMINAL_RUN_INDEX_VERSION
+		|| typeof entry.runId !== "string" || !entry.runId
+		|| typeof entry.sessionId !== "string" || !entry.sessionId
+		|| typeof entry.endedAt !== "number" || !Number.isFinite(entry.endedAt)) return undefined;
+	return { version: TERMINAL_RUN_INDEX_VERSION, runId: entry.runId, sessionId: entry.sessionId, endedAt: entry.endedAt };
+}
+
+export function updateTerminalRunIndex(asyncDir: string, status: AsyncStatus): void {
+	if (!isTerminalState(status.state) || typeof status.sessionId !== "string" || !status.sessionId) return;
+	const endedAt = status.endedAt ?? status.lastUpdate ?? status.startedAt;
+	const marker = markerPath(asyncDir, status.sessionId, endedAt);
+	const entry: TerminalRunIndexEntry = {
+		version: TERMINAL_RUN_INDEX_VERSION,
+		runId: status.runId || path.basename(asyncDir),
+		sessionId: status.sessionId,
+		endedAt,
+	};
+	writeAtomicJson(marker, entry);
+}
+
+function removeInvalidMarker(marker: string): void {
+	try {
+		fs.rmSync(marker, { force: true });
+	} catch {
+		// An advisory marker can remain for a later read when cleanup is contended.
+	}
+}
+
+function markerFiles(dir: string): string[] {
+	try {
+		return fs.readdirSync(dir, { withFileTypes: true })
+			.filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+			.map((entry) => path.join(dir, entry.name));
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") return [];
+		throw error;
+	}
+}
+
+function sessionDirs(asyncDirRoot: string, sessionId: string | undefined): string[] {
+	if (sessionId) return [sessionIndexDir(asyncDirRoot, sessionId)];
+	try {
+		return fs.readdirSync(indexRoot(asyncDirRoot), { withFileTypes: true })
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => path.join(indexRoot(asyncDirRoot), entry.name));
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") return [];
+		throw error;
+	}
+}
+
+export function readRecentTerminalRunIndex(asyncDirRoot: string, options: { sessionId?: string; limit?: number } = {}): string[] {
+	const limit = options.limit === undefined ? Number.POSITIVE_INFINITY : Math.max(0, Math.floor(options.limit));
+	const candidates = sessionDirs(asyncDirRoot, options.sessionId)
+		.flatMap(markerFiles)
+		.sort((left, right) => path.basename(right).localeCompare(path.basename(left)))
+		.slice(0, limit);
+	const runIds: string[] = [];
+	const seen = new Set<string>();
+	for (const marker of candidates) {
+		let entry: TerminalRunIndexEntry | undefined;
+		try {
+			entry = parseEntry(JSON.parse(fs.readFileSync(marker, "utf-8")));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+		}
+		if (!entry || (options.sessionId !== undefined && entry.sessionId !== options.sessionId)) {
+			removeInvalidMarker(marker);
+			continue;
+		}
+		const asyncDir = path.join(asyncDirRoot, entry.runId);
+		const status = readStatus(asyncDir);
+		if (!status || !isTerminalState(status.state) || status.sessionId !== entry.sessionId || (status.runId && status.runId !== entry.runId)) {
+			removeInvalidMarker(marker);
+			continue;
+		}
+		if (seen.has(entry.runId)) {
+			removeInvalidMarker(marker);
+			continue;
+		}
+		seen.add(entry.runId);
+		runIds.push(entry.runId);
+	}
+	return runIds;
+}

--- a/src/runs/background/wait-subscriptions.ts
+++ b/src/runs/background/wait-subscriptions.ts
@@ -231,6 +231,7 @@ export function createWaitSubscriptionManager(
 		const runs = listAsyncRuns(asyncDirRoot, {
 			sessionId: record.sessionId,
 			runId: record.runId,
+			exactRunId: true,
 			resultsDir,
 			kill: options.kill,
 			now,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1562,7 +1562,7 @@ async function resumeAsyncRun(input: {
 				details: { mode: "chain", results: [] },
 			};
 		}
-		const runId = randomUUID().slice(0, 8);
+		const runId = randomUUID();
 		const topLevelResume = depth === 0 && !resolveInheritedNestedRouteFromEnv() && !input.params.workflowParentRunId;
 		let activeAsyncCapacity: ActiveAsyncCapacityHandle | undefined;
 		try {
@@ -1657,7 +1657,7 @@ async function resumeAsyncRun(input: {
 	if (target.source === "async" && !recoveryDescriptor) {
 		return { content: [{ type: "text", text: `Async child '${target.runId}' is missing its required run fan-out recovery identity. Start a new run instead.` }], isError: true, details: { mode: "management", results: [] } };
 	}
-	const runId = randomUUID().slice(0, 8);
+	const runId = randomUUID();
 	const topLevelResume = depth === 0 && !resolveInheritedNestedRouteFromEnv() && !input.params.workflowParentRunId;
 	let activeAsyncCapacity: ActiveAsyncCapacityHandle | undefined;
 	try {
@@ -4888,7 +4888,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const agents = intercomBridge.active
 			? discoveredAgents.map((agent) => applyIntercomBridgeToAgent(agent, intercomBridge))
 			: discoveredAgents;
-		const runId = randomUUID().slice(0, 8);
+		const runId = randomUUID();
 		const inheritedNestedRoute = resolveInheritedNestedRouteFromEnv();
 		const nestedParentAddress = inheritedNestedRoute ? resolveNestedParentAddressFromEnv() : undefined;
 		const shareEnabled = effectiveParams.share === true;

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -102,6 +102,7 @@ export function getAgentDir(): string {
 }
 
 const statusCache = new Map<string, { mtime: number; ctime: number; size: number; ino: number; status: AsyncStatus }>();
+const MAX_STATUS_CACHE_ENTRIES = 512;
 
 export function pruneStatusCacheForAsyncRoot(asyncDirRoot: string, runIds: Iterable<string>): number {
 	const root = path.resolve(asyncDirRoot);
@@ -163,6 +164,8 @@ export function readStatus(asyncDir: string): AsyncStatus | null {
 		&& cached.size === stat.size
 		&& cached.ino === stat.ino
 	) {
+		statusCache.delete(statusPath);
+		statusCache.set(statusPath, cached);
 		return cached.status;
 	}
 
@@ -195,6 +198,11 @@ export function readStatus(asyncDir: string): AsyncStatus | null {
 		ino: stat.ino,
 		status,
 	});
+	while (statusCache.size > MAX_STATUS_CACHE_ENTRIES) {
+		const oldest = statusCache.keys().next().value as string | undefined;
+		if (oldest === undefined) break;
+		statusCache.delete(oldest);
+	}
 	return status;
 }
 

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -1,17 +1,21 @@
 import assert from "node:assert/strict";
-import * as fs from "node:fs";
+import fsDefault, * as fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { formatAsyncRunList, listAsyncRuns } from "../../src/runs/background/async-status.ts";
 import { ACTIVE_RUN_INDEX_DIR, DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
+import { encodeIndexSegment } from "../../src/runs/background/index-segment.ts";
+import { TERMINAL_RUN_INDEX_DIR } from "../../src/runs/background/terminal-run-index.ts";
 import { claimRunFanoutBatch, createRunFanoutBudget, writeRunFanoutBudgetDescriptor } from "../../src/runs/shared/run-fanout-budget.ts";
 
 function createAsyncDir(root: string, id: string, status: Record<string, unknown>): string {
 	const dir = path.join(root, id);
 	fs.mkdirSync(dir, { recursive: true });
-	fs.writeFileSync(path.join(dir, "status.json"), JSON.stringify(status), "utf-8");
-	if (status.state === "queued" || status.state === "running") updateActiveRunIndex(dir, status.state);
+	const persisted = status.sessionId === undefined ? { ...status, sessionId: "session-a" } : status;
+	fs.writeFileSync(path.join(dir, "status.json"), JSON.stringify(persisted), "utf-8");
+	updateActiveRunIndex(dir, persisted.state as "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected");
 	return dir;
 }
 
@@ -341,7 +345,7 @@ describe("async status helpers", () => {
 		fs.writeFileSync(path.join(dir, "status.json"), "{not-json", "utf-8");
 		try {
 			assert.throws(
-				() => listAsyncRuns(root),
+				() => listAsyncRuns(root, { repairScan: true }),
 				/Failed to parse async status file/,
 			);
 		} finally {
@@ -604,6 +608,57 @@ describe("async status helpers", () => {
 
 			assert.deepEqual(runs.map((run) => run.id), ["active"]);
 		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("lists recent terminal runs from time-sortable session markers", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-terminal-index-"));
+		try {
+			for (let index = 1; index <= 3; index++) {
+				createAsyncDir(root, `terminal-${index}`, {
+					runId: `terminal-${index}`,
+					sessionId: "session-a",
+					mode: "single",
+					state: "complete",
+					startedAt: index,
+					endedAt: index * 100,
+					steps: [{ agent: "worker", status: "complete" }],
+				});
+			}
+
+			const runs = listAsyncRuns(root, { sessionId: "session-a", states: ["complete"], entryLimit: 2, reconcile: false });
+			assert.deepEqual(runs.map((run) => run.id), ["terminal-3", "terminal-2"]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("removes invalid terminal markers while reading the advisory index", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-terminal-heal-"));
+		try {
+			const marker = path.join(root, TERMINAL_RUN_INDEX_DIR, encodeIndexSegment("session-a"), "0000000000000100-missing.json");
+			fs.mkdirSync(path.dirname(marker), { recursive: true });
+			fs.writeFileSync(marker, JSON.stringify({ version: 1, runId: "missing", sessionId: "session-a", endedAt: 100 }));
+
+			assert.deepEqual(listAsyncRuns(root, { sessionId: "session-a", states: ["complete"], reconcile: false }), []);
+			assert.equal(fs.existsSync(marker), false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not enumerate the async root for full-id or unsafe-prefix misses", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-exact-miss-"));
+		const originalReaddirSync = fsDefault.readdirSync;
+		try {
+			fsDefault.readdirSync = (() => { throw new Error("async root enumerated"); }) as typeof fsDefault.readdirSync;
+			syncBuiltinESMExports();
+			assert.deepEqual(listAsyncRuns(root, { runId: "12345678-1234-1234-1234-123456789012", reconcile: false }), []);
+			assert.deepEqual(listAsyncRuns(root, { runId: "short", reconcile: false }), []);
+		} finally {
+			fsDefault.readdirSync = originalReaddirSync;
+			syncBuiltinESMExports();
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -260,9 +260,9 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		assert.equal(payload.mode, "single");
 		assert.equal(payload.children?.length, 1);
 		assert.equal(payload.children?.[0]?.agent, "worker");
-		assert.match(payload.children?.[0]?.intercomTarget ?? "", /^subagent-worker-[a-f0-9]+-1$/);
+		assert.match(payload.children?.[0]?.intercomTarget ?? "", /^subagent-worker-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}-1$/);
 		assert.match(String(payload.message ?? ""), /Intercom targets below identify child sessions used while they were running/);
-		assert.match(String(payload.message ?? ""), /Run intercom target: subagent-worker-[a-f0-9]+-1/);
+		assert.match(String(payload.message ?? ""), /Run intercom target: subagent-worker-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}-1/);
 		assert.match(result.content[0]?.text ?? "", /Delivered single subagent result via intercom\./);
 		assert.doesNotMatch(result.content[0]?.text ?? "", /Full child output from worker/);
 		assert.equal(result.details?.results?.[0]?.finalOutput, undefined);
@@ -627,6 +627,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			assert.equal(startedEvent?.goal, "[prompt redacted]");
 			const attachedId = result.details?.asyncId;
 			assert.ok(attachedId, "expected attached chain async id");
+			assert.match(attachedId, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
 			assert.match(result.details?.asyncDir ?? "", new RegExp(`${attachedId}$`));
 			const statusPath = path.join(result.details!.asyncDir!, "status.json");
 			await waitForFile(statusPath);
@@ -696,6 +697,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			assert.equal(attached.isError, undefined);
 			assert.match(attached.content[0]?.text ?? "", /Attached async subagent/);
 			assert.ok(attached.details?.asyncId, "expected attached chain async id");
+			assert.match(attached.details.asyncId, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
 			await waitForFile(path.join(RESULTS_DIR, `${attached.details.asyncId}.json`));
 		} finally {
 			fs.rmSync(sourceAsyncDir, { recursive: true, force: true });
@@ -739,6 +741,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 			assert.equal(result.isError, undefined);
 			assert.match(result.content[0]?.text ?? "", /Revived async subagent from/);
+			assert.match(result.details?.asyncId ?? "", /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
 			assert.match(result.content[0]?.text ?? "", /Agent: b/);
 			assert.match(result.content[0]?.text ?? "", new RegExp(secondSession.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 			const args = await readMockCallArgs(0);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -2756,7 +2756,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			const claims = fs.readdirSync(path.join(descriptor.directory, "claims"));
 			assert.equal(claims.length, 1);
 			const claim = JSON.parse(fs.readFileSync(path.join(descriptor.directory, "claims", claims[0]!), "utf-8")) as { path: string };
-			assert.match(claim.path, /^tasks\[0\]\/[a-f0-9]{8}\/single$/);
+			assert.match(claim.path, /^tasks\[0\]\/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/single$/);
 		} finally {
 			if (previous === undefined) delete process.env[RUN_FANOUT_BUDGET_ENV];
 			else process.env[RUN_FANOUT_BUDGET_ENV] = previous;

--- a/test/unit/async-resume.test.ts
+++ b/test/unit/async-resume.test.ts
@@ -18,8 +18,8 @@ describe("async resume lookup", () => {
 			const asyncRoot = path.join(root, "runs");
 			const sessionFile = path.join(root, "session.jsonl");
 			fs.writeFileSync(sessionFile, "", "utf-8");
-			writeJson(path.join(asyncRoot, "run-abc", "status.json"), {
-				runId: "run-abc",
+			writeJson(path.join(asyncRoot, "run-abcde", "status.json"), {
+				runId: "run-abcde",
 				mode: "single",
 				state: "complete",
 				startedAt: 100,
@@ -30,10 +30,10 @@ describe("async resume lookup", () => {
 				steps: [{ agent: "worker", status: "complete" }],
 			});
 
-			const target = resolveAsyncResumeTarget({ id: "run-a" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results") });
+			const target = resolveAsyncResumeTarget({ id: "run-abcd" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results") });
 
 			assert.equal(target.kind, "revive");
-			assert.equal(target.runId, "run-abc");
+			assert.equal(target.runId, "run-abcde");
 			assert.equal(target.agent, "worker");
 			assert.equal(target.sessionFile, sessionFile);
 			assert.equal(target.cwd, root);
@@ -352,15 +352,15 @@ describe("async resume lookup", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-resume-ambiguous-"));
 		try {
 			const asyncRoot = path.join(root, "runs");
-			writeJson(path.join(asyncRoot, "run-aa", "status.json"), {
-				runId: "run-aa",
+			writeJson(path.join(asyncRoot, "run-aaaa-1", "status.json"), {
+				runId: "run-aaaa-1",
 				mode: "single",
 				state: "running",
 				startedAt: 100,
 				steps: [{ agent: "scout", status: "running" }],
 			});
-			writeJson(path.join(asyncRoot, "run-ab", "status.json"), {
-				runId: "run-ab",
+			writeJson(path.join(asyncRoot, "run-aaaa-2", "status.json"), {
+				runId: "run-aaaa-2",
 				mode: "single",
 				state: "running",
 				startedAt: 100,
@@ -368,8 +368,12 @@ describe("async resume lookup", () => {
 			});
 
 			assert.throws(
+				() => resolveAsyncResumeTarget({ id: "run-aaaa" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results") }),
+				/Ambiguous async run id prefix 'run-aaaa' matched: run-aaaa-1, run-aaaa-2/,
+			);
+			assert.throws(
 				() => resolveAsyncResumeTarget({ id: "run-a" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results") }),
-				/Ambiguous async run id prefix 'run-a' matched: run-aa, run-ab/,
+				/at least 8 characters/,
 			);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -13,6 +13,7 @@ import { getArtifactPaths, getArtifactsDir, getProjectArtifactsDir } from "../..
 import type { SubagentState } from "../../src/shared/types.ts";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 
 function clearExternalRuns(): void {
 	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)];
@@ -55,11 +56,12 @@ function writeAsyncRun(root: string, input: {
 	if (input.output !== undefined) fs.writeFileSync(path.join(asyncDir, "output-0.log"), input.output, "utf-8");
 	const transcriptPath = input.transcript ? path.join(asyncDir, "transcript-0.jsonl") : undefined;
 	if (transcriptPath && input.transcript) fs.writeFileSync(transcriptPath, `${input.transcript.map((record) => JSON.stringify(record)).join("\n")}\n`, "utf-8");
+	const state = input.state ?? "running";
 	fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
 		runId: input.id,
 		sessionId: input.sessionId ?? "session-current",
 		mode: input.mode ?? (agents.length > 1 ? "parallel" : "single"),
-		state: input.state ?? "running",
+		state,
 		startedAt: 100,
 		lastUpdate: input.lastUpdate ?? 200,
 		currentStep: 0,
@@ -74,6 +76,7 @@ function writeAsyncRun(root: string, input: {
 		})),
 		...(input.output !== undefined ? { outputFile: "output-0.log" } : {}),
 	}, null, 2));
+	updateActiveRunIndex(asyncDir, state);
 	return asyncDir;
 }
 

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -15,6 +15,24 @@ function pendingPath(resultsDir: string, sessionId: string, runId: string): stri
 }
 
 describe("result file indexes", () => {
+	it("resolves run ids without enumerating session indexes", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-run-index-"));
+		const originalReaddirSync = fsDefault.readdirSync;
+		try {
+			const resultPath = path.join(resultsDir, "direct-run.json");
+			writeAsyncResultFile(resultPath, { id: "direct-run", runId: "direct-run", sessionId: "session-a", success: true });
+			fsDefault.readdirSync = (() => { throw new Error("result index enumerated"); }) as typeof fsDefault.readdirSync;
+			syncBuiltinESMExports();
+
+			assert.equal(resultPayloadPathForIndexedRun(resultsDir, "direct-run"), resultPath);
+			assert.equal(resultPayloadPathForIndexedRun(resultsDir, "missing-run"), undefined);
+		} finally {
+			fsDefault.readdirSync = originalReaddirSync;
+			syncBuiltinESMExports();
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("removes orphan index entries without deleting flat result files", () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-index-"));
 		try {
@@ -23,7 +41,7 @@ describe("result file indexes", () => {
 			fs.rmSync(path.join(resultsDir, "missing.json"));
 			fs.writeFileSync(path.join(resultsDir, "unindexed.json"), JSON.stringify({ id: "unindexed", sessionId: "session-a" }), "utf-8");
 
-			assert.equal(cleanupResultIndexes(resultsDir, Date.now() + 86_400_001, 86_400_000), 2);
+			assert.equal(cleanupResultIndexes(resultsDir, Date.now() + 86_400_001, 86_400_000), 3);
 
 			assert.deepEqual(resultFilesForSession(resultsDir, "session-a"), ["kept.json"]);
 			assert.equal(fs.existsSync(path.join(resultsDir, "kept.json")), true);
@@ -93,7 +111,7 @@ describe("result file indexes", () => {
 			assert.deepEqual(resultCandidateFilesForSession(resultsDir, sessionId), [`${runId}.json`]);
 			assert.equal(resultPayloadPathForSessionRun(resultsDir, sessionId, runId), payloadPath);
 			fs.rmSync(path.join(resultsDir, "result-index"), { recursive: true });
-			assert.equal(resultPayloadPathForIndexedRun(resultsDir, runId), payloadPath);
+			assert.equal(resultPayloadPathForIndexedRun(resultsDir, runId), undefined);
 		} finally {
 			console.error = originalError;
 			fs.rmSync(resultsDir, { recursive: true, force: true });
@@ -150,7 +168,7 @@ describe("result file indexes", () => {
 			assert.equal(fs.existsSync(resultPath), false);
 			assert.equal(fs.existsSync(pendingPath(resultsDir, "session-a", "blocked")), true);
 			assert.equal(resultPayloadPathForSessionRun(resultsDir, "session-a", "blocked"), pendingPath(resultsDir, "session-a", "blocked"));
-			assert.equal(resultPayloadPathForIndexedRun(resultsDir, "blocked"), pendingPath(resultsDir, "session-a", "blocked"));
+			assert.equal(resultPayloadPathForIndexedRun(resultsDir, "blocked"), undefined);
 			assert.deepEqual(resultCandidateFilesForSession(resultsDir, "session-a"), ["blocked.json"]);
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });

--- a/test/unit/retained-children.test.ts
+++ b/test/unit/retained-children.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { formatRetainedChildren, listRetainedChildren } from "../../src/runs/background/retained-children.ts";
+import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
 
 interface WriteRunOptions {
@@ -49,6 +50,7 @@ function writeRetainedRun(root: string, index: number, options: WriteRunOptions 
 			tokens: { input: index, output: index + 1, total: index * 2 + 1 },
 		}],
 	}), "utf-8");
+	updateActiveRunIndex(asyncDir, state);
 	if (options.recoveryDescriptor === "invalid") {
 		fs.writeFileSync(path.join(asyncDir, "recovery-descriptor.json"), JSON.stringify({
 			version: 2,

--- a/test/unit/run-id-resolver.test.ts
+++ b/test/unit/run-id-resolver.test.ts
@@ -84,11 +84,11 @@ describe("subagent run id resolver", () => {
 		try {
 			const asyncRoot = path.join(root, "runs");
 			const resultsDir = path.join(root, "results");
-			fs.mkdirSync(path.join(asyncRoot, "fanout-async"), { recursive: true });
-			nested("root-fanout", "fanout-nested");
+			fs.mkdirSync(path.join(asyncRoot, "fanout-x-async"), { recursive: true });
+			nested("root-fanout", "fanout-x-nested");
 			assert.throws(
-				() => resolveSubagentRunId("fanout", { asyncDirRoot: asyncRoot, resultsDir }),
-				/Ambiguous subagent run id prefix 'fanout' matched: async:fanout-async, nested:fanout-nested/,
+				() => resolveSubagentRunId("fanout-x", { asyncDirRoot: asyncRoot, resultsDir }),
+				/Ambiguous subagent run id prefix 'fanout-x' matched: async:fanout-x-async, nested:fanout-x-nested/,
 			);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
@@ -130,12 +130,12 @@ describe("subagent run id resolver", () => {
 		try {
 			const asyncRoot = path.join(root, "runs");
 			const resultsDir = path.join(root, "results");
-			fs.mkdirSync(path.join(asyncRoot, "dupe-one"), { recursive: true });
-			fs.mkdirSync(path.join(asyncRoot, "dupe-two"), { recursive: true });
+			fs.mkdirSync(path.join(asyncRoot, "dupe-aaa-one"), { recursive: true });
+			fs.mkdirSync(path.join(asyncRoot, "dupe-aaa-two"), { recursive: true });
 
 			assert.throws(
-				() => resolveSubagentRunId("dupe", { asyncDirRoot: asyncRoot, resultsDir }),
-				/Ambiguous subagent run id prefix 'dupe' matched: async:dupe-one, async:dupe-two/,
+				() => resolveSubagentRunId("dupe-aaa", { asyncDirRoot: asyncRoot, resultsDir }),
+				/Ambiguous subagent run id prefix 'dupe-aaa' matched: async:dupe-aaa-one, async:dupe-aaa-two/,
 			);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -1122,16 +1122,16 @@ describe("async run status inspection", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-ambiguous-"));
 		try {
 			const asyncRoot = path.join(root, "runs");
-			fs.mkdirSync(path.join(asyncRoot, "run-aa"), { recursive: true });
-			fs.mkdirSync(path.join(asyncRoot, "run-ab"), { recursive: true });
+			fs.mkdirSync(path.join(asyncRoot, "run-aaaa-one"), { recursive: true });
+			fs.mkdirSync(path.join(asyncRoot, "run-aaaa-two"), { recursive: true });
 
-			const result = inspectSubagentStatus({ id: "run-a" }, {
+			const result = inspectSubagentStatus({ id: "run-aaaa" }, {
 				asyncDirRoot: asyncRoot,
 				resultsDir: path.join(root, "results"),
 			});
 
 			assert.equal(result.isError, true);
-			assert.match(textContent(result), /Ambiguous subagent run id prefix 'run-a' matched: async:run-aa, async:run-ab/);
+			assert.match(textContent(result), /Ambiguous subagent run id prefix 'run-aaaa' matched: async:run-aaaa-one, async:run-aaaa-two/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -743,9 +743,9 @@ describe("subagent_wait tool", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-cross-kind-"));
 		try {
 			const state = makeState("sess-1");
-			writeStatus(path.join(root, "runs"), "shared-async", "running", { sessionId: "sess-1", pid: 999999 });
-			state.foregroundRuns = new Map([["shared-foreground", {
-				runId: "shared-foreground",
+			writeStatus(path.join(root, "runs"), "shared-x-async", "running", { sessionId: "sess-1", pid: 999999 });
+			state.foregroundRuns = new Map([["shared-x-foreground", {
+				runId: "shared-x-foreground",
 				mode: "single",
 				cwd: root,
 				sessionId: "sess-1",
@@ -753,11 +753,11 @@ describe("subagent_wait tool", () => {
 				children: [{ agent: "reviewer", index: 0, status: "detached", updatedAt: 1 }],
 			}]]);
 
-			const result = await waitForSubagents({ id: "shared" }, undefined, baseDeps(root, state));
+			const result = await waitForSubagents({ id: "shared-x" }, undefined, baseDeps(root, state));
 			assert.equal(result.isError, true);
-			assert.match(textOf(result), /Ambiguous subagent run id prefix "shared"/);
-			assert.match(textOf(result), /shared-async/);
-			assert.match(textOf(result), /shared-foreground/);
+			assert.match(textOf(result), /Ambiguous subagent run id prefix "shared-x"/);
+			assert.match(textOf(result), /shared-x-async/);
+			assert.match(textOf(result), /shared-x-foreground/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
@@ -768,15 +768,15 @@ describe("subagent_wait tool", () => {
 		try {
 			const asyncRoot = path.join(root, "runs");
 			const state = makeState("sess-1");
-			writeStatus(asyncRoot, "run-al", "running", { sessionId: "sess-2", pid: 999999 });
-			writeStatus(asyncRoot, "run-alpha", "running", { sessionId: "sess-1", pid: 999998 });
+			writeStatus(asyncRoot, "run-alph", "running", { sessionId: "sess-2", pid: 999999 });
+			writeStatus(asyncRoot, "run-alpha-current", "running", { sessionId: "sess-1", pid: 999998 });
 
-			const result = await waitForSubagents({ id: "run-al" }, undefined, baseDeps(root, state, {
-				sleep: async () => writeStatus(asyncRoot, "run-alpha", "complete", { sessionId: "sess-1" }),
+			const result = await waitForSubagents({ id: "run-alph" }, undefined, baseDeps(root, state, {
+				sleep: async () => writeStatus(asyncRoot, "run-alpha-current", "complete", { sessionId: "sess-1" }),
 			}));
 
 			assert.equal(result.isError, undefined);
-			assert.match(textOf(result), /run "run-al".*done/is);
+			assert.match(textOf(result), /run "run-alph".*done/is);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
@@ -856,9 +856,9 @@ describe("subagent_wait tool", () => {
 				if (polls === 1) writeStatus(asyncRoot, "run-alpha", "complete", { sessionId: "sess-1" });
 			};
 
-			const result = await waitForSubagents({ id: "run-al" }, undefined, baseDeps(root, state, { sleep }));
+			const result = await waitForSubagents({ id: "run-alph" }, undefined, baseDeps(root, state, { sleep }));
 			assert.equal(result.isError, undefined);
-			assert.match(textOf(result), /run "run-al".*done/is);
+			assert.match(textOf(result), /run "run-alph".*done/is);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
@@ -869,13 +869,14 @@ describe("subagent_wait tool", () => {
 		try {
 			const asyncRoot = path.join(root, "runs");
 			const state = makeState("sess-1");
-			writeStatus(asyncRoot, "run", "running", { sessionId: "sess-1", pid: 999999 });
-			writeStatus(asyncRoot, "run-alpha", "running", { sessionId: "sess-1", pid: 999998 });
+			writeStatus(asyncRoot, "prefix-aa-1", "running", { sessionId: "sess-1", pid: 999999 });
+			writeStatus(asyncRoot, "prefix-aa-2", "running", { sessionId: "sess-1", pid: 999998 });
+			writeStatus(asyncRoot, "run", "running", { sessionId: "sess-1", pid: 999997 });
 
-			const ambiguous = await waitForSubagents({ id: "ru" }, undefined, baseDeps(root, state));
+			const ambiguous = await waitForSubagents({ id: "prefix-aa" }, undefined, baseDeps(root, state));
 			assert.equal(ambiguous.isError, true);
-			assert.match(textOf(ambiguous), /Ambiguous subagent run id prefix "ru"/);
-			assert.match(textOf(ambiguous), /run-alpha/);
+			assert.match(textOf(ambiguous), /Ambiguous subagent run id prefix "prefix-aa"/);
+			assert.match(textOf(ambiguous), /prefix-aa-2/);
 
 			let polls = 0;
 			const exact = await waitForSubagents({ id: "run" }, undefined, baseDeps(root, state, {

--- a/test/unit/wait-subscriptions.test.ts
+++ b/test/unit/wait-subscriptions.test.ts
@@ -68,7 +68,7 @@ describe("non-blocking wait subscriptions", () => {
 			const asyncRoot = path.join(root, "runs");
 			writeStatus(asyncRoot, "run-alpha", "running", { sessionId: "session-a", pid: 999_999 });
 			let armed: { targetKind: "async" | "foreground"; runId: string; requestedId: string; timeoutMs: number } | undefined;
-			const result = await waitForSubagents({ id: "run-al", nonBlocking: true, timeoutMs: 5_000 }, undefined, {
+			const result = await waitForSubagents({ id: "run-alph", nonBlocking: true, timeoutMs: 5_000 }, undefined, {
 				state: makeState(),
 				asyncDirRoot: asyncRoot,
 				resultsDir: path.join(root, "results"),
@@ -82,7 +82,7 @@ describe("non-blocking wait subscriptions", () => {
 
 			assert.equal(result.isError, undefined);
 			assert.match(textOf(result), /Armed wait subscription wait-token/);
-			assert.deepEqual(armed, { targetKind: "async", runId: "run-alpha", requestedId: "run-al", timeoutMs: 5_000 });
+			assert.deepEqual(armed, { targetKind: "async", runId: "run-alpha", requestedId: "run-alph", timeoutMs: 5_000 });
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
@@ -370,7 +370,7 @@ describe("non-blocking wait subscriptions", () => {
 		}
 	});
 
-	it("wakes when async reconciliation throws", () => {
+	it("wakes when an exact async run cannot be reconciled", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-subscribe-reconcile-error-"));
 		const asyncRoot = path.join(root, "not-a-directory");
 		const subscriptionsDir = path.join(root, "subscriptions");
@@ -385,7 +385,7 @@ describe("non-blocking wait subscriptions", () => {
 		try {
 			const registration = manager.arm({ targetKind: "async", runId: "run-error", requestedId: "run-error", timeoutMs: 30_000 });
 			manager.reconcile();
-			assert.match(sent[0] ?? "", /reconciliation failed/);
+			assert.match(sent[0] ?? "", /could not be reconciled/);
 			assert.equal(state.waitSubscriptions?.has(registration.token), false);
 			assert.equal(fs.existsSync(path.join(subscriptionsDir, `${registration.token}.json`)), false);
 		} finally {


### PR DESCRIPTION
## Summary

Bounds async status, result, resume, attach, and wait lookups so unqualified scans use maintained indexes instead of session-root enumeration.

Full UUID misses no longer scan the async root. Safe prefix lookup stays limited to the approved 8-to-35 character prefix path. Generated async resume, attach, and workflow IDs now keep full UUID values.

Fixes #1162.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/run-id-resolver.test.ts test/unit/run-status.test.ts test/unit/async-resume.test.ts test/unit/result-files.test.ts test/unit/subagent-wait.test.ts test/unit/retained-children.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-status.test.ts`
- `npm run typecheck`
- `git diff --check 9ceb5650..HEAD`