### PR TITLE
fix: resolve workflow parser from package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
+- Resolve the workflowScript parser from pi-subagents instead of the caller's working directory, so workflows start in projects that do not install Acorn.
 - Keep structured delegation integration coverage active when the test process inherits a subagent-child environment marker.
 - Bound repeated async-state queries to active, exact-id, and recent-terminal indexes instead of scanning the historical async root (#1162).
 - Keep retained workflow children resumable when their managed worktree cwd is preserved in the handoff manifest (#1172).

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -1,12 +1,14 @@
+import { createRequire } from "node:module";
 import { Worker } from "node:worker_threads";
 
 const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const requireFromPackage = createRequire(import.meta.url);
 
 const WORKER_SOURCE = String.raw`
-const { parentPort } = require("node:worker_threads");
+const { parentPort, workerData } = require("node:worker_threads");
 const vm = require("node:vm");
 const { inspect } = require("node:util");
-const { parse } = require("acorn");
+const { parse } = require(workerData.acornPath);
 
 let promiseHooks;
 try {
@@ -682,7 +684,13 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 	if (!options.script.trim()) throw new Error("workflowScript must not be empty.");
 	if (options.timeoutMs !== undefined && (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1)) throw new Error("workflow script timeout must be a positive integer.");
 
-	const worker = new Worker(WORKER_SOURCE, { eval: true });
+	let acornPath: string;
+	try {
+		acornPath = requireFromPackage.resolve("acorn");
+	} catch (error) {
+		throw new Error("Workflow parser dependency 'acorn' is unavailable from pi-subagents. Reinstall pi-subagents dependencies before launching workflowScript.", { cause: error });
+	}
+	const worker = new Worker(WORKER_SOURCE, { eval: true, workerData: { acornPath } });
 	const emits: unknown[] = [];
 	const consoleEntries: WorkflowScriptResult["console"] = [];
 	const trace: WorkflowScriptTraceEntry[] = [];

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, it } from "node:test";
 import { Worker } from "node:worker_threads";
 import { formatWorkflowJsonPreview, previewSimpleWorkflowRun, runWorkflowScript, WorkflowScriptError } from "../../src/workflows/scripted-workflow.ts";
@@ -18,6 +21,23 @@ describe("scripted workflow runtime", () => {
 
 		assert.equal(implicit.value, null);
 		assert.deepEqual(explicit.value, { answer: 42 });
+	});
+
+	it("resolves the workflow parser from pi-subagents outside the project cwd", async () => {
+		const originalCwd = process.cwd();
+		const emptyCwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-no-acorn-"));
+		try {
+			process.chdir(emptyCwd);
+			const result = await runWorkflowScript({
+				script: `return "done";`,
+				async launch(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			});
+			assert.equal(result.value, "done");
+		} finally {
+			process.chdir(originalCwd);
+			fs.rmSync(emptyCwd, { recursive: true, force: true });
+		}
 	});
 
 	it("guides invalid JavaScript caused by Markdown fence backticks", async () => {


### PR DESCRIPTION
## Summary
- resolve the workflowScript parser dependency from the installed `pi-subagents` package instead of the caller cwd
- pass the resolved Acorn path into the eval worker through `workerData`
- add a regression test that runs a workflow from an empty cwd without Acorn
- add an Unreleased changelog entry

Closes #1190.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/scripted-workflow.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh read-only review: no blockers

## Risk
Performance impact: none. The fix adds one package-local `require.resolve("acorn")` before workflow worker launch and keeps the existing worker lifecycle unchanged.
