### PR TITLE
perf: move retention discovery to worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bound repeated async-state queries to active, exact-id, and recent-terminal indexes instead of scanning the historical async root (#1162).
 - Keep retained workflow children resumable when their managed worktree cwd is preserved in the handoff manifest (#1172).
 - Reclaim proven-safe async run and orphan result state after 30 days in bounded, locked cleanup passes with rename-first tombstones (#1163).
+- Move retention directory discovery to a read-only worker so full scans do not block the extension event loop (#1188).
 - Restore and list schedules after their project directory is deleted, and skip orphan schedule directories without letting create reuse their stale state. Thanks to [@ELA718](https://github.com/ELA718) for #1171 and [@colinb4987](https://github.com/colinb4987) for #1167.
 - Isolate test async state from the user temp root and write each missing-mission sync diagnostic only once (#1164, #1165).
 - Show FleetView transcript fallbacks for trusted session roots instead of warning about an untrusted session file. Thanks to [@aliceisjustplaying](https://github.com/aliceisjustplaying) for #1154.

--- a/async-retention-discovery-worker.mjs
+++ b/async-retention-discovery-worker.mjs
@@ -1,0 +1,180 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parentPort } from "node:worker_threads";
+
+const ACTIVE_RUN_INDEX_DIR = ".active-runs";
+const RESULT_TOMBSTONE_PREFIX = ".deleting-result-";
+
+function compareRelative(left, right) {
+	if (left < right) return -1;
+	if (left > right) return 1;
+	return 0;
+}
+
+function insertSmallest(entries, candidate, limit) {
+	if (limit <= 0) return;
+	const index = entries.findIndex((entry) => compareRelative(candidate.relative, entry.relative) < 0);
+	if (index === -1) entries.push(candidate);
+	else entries.splice(index, 0, candidate);
+	if (entries.length > limit) entries.pop();
+}
+
+function streamDirWindow(dir, limit, after, relativePath, usable) {
+	if (limit <= 0) return { entries: [], rawReads: 0, exhausted: true, cursorCleared: false };
+	let handle;
+	try {
+		handle = fs.opendirSync(dir);
+		const next = [];
+		const wrapped = [];
+		let rawReads = 0;
+		while (true) {
+			const entry = handle.readSync();
+			if (!entry) break;
+			rawReads += 1;
+			const relative = relativePath(entry);
+			if (!usable(entry, relative)) continue;
+			const candidate = { relative, name: entry.name };
+			insertSmallest(wrapped, candidate, limit);
+			if (after === undefined || compareRelative(relative, after) > 0) insertSmallest(next, candidate, limit);
+		}
+		const cursorCleared = after !== undefined && next.length === 0;
+		return { entries: cursorCleared ? wrapped : next, rawReads, exhausted: true, cursorCleared };
+	} catch (error) {
+		if (error?.code === "ENOENT") return { entries: [], rawReads: 0, exhausted: true, cursorCleared: false };
+		throw error;
+	} finally {
+		handle?.closeSync();
+	}
+}
+
+function discover(request) {
+	const startedAt = Date.now();
+	const cursor = structuredClone(request.cursor);
+	const raw = { reads: 0, exhausted: {} };
+	const record = (source, scan) => {
+		raw.reads += scan.rawReads;
+		raw.exhausted[source] = scan.exhausted;
+	};
+	const runScan = streamDirWindow(
+		request.asyncDirRoot,
+		request.runBudget,
+		cursor.runAfter,
+		(entry) => entry.name,
+		(entry) => entry.isDirectory() && entry.name !== ACTIVE_RUN_INDEX_DIR,
+	);
+	record("runs", runScan);
+	if (runScan.cursorCleared) delete cursor.runAfter;
+	const runCandidates = runScan.entries.slice(0, request.runBudget);
+	for (const candidate of runCandidates) cursor.runAfter = candidate.relative;
+
+	const resultCandidates = [];
+	const sourceLimit = Math.max(1, Math.ceil(request.resultBudget / 4));
+	const addFiles = (dir, kind, cursorTarget, source, budget = sourceLimit) => {
+		const remaining = Math.min(budget, request.resultBudget - resultCandidates.length);
+		if (remaining <= 0) return 0;
+		const before = resultCandidates.length;
+		const after = cursorTarget.type === "pending"
+			? cursor.resultPendingAfterBySession?.[cursorTarget.session]
+			: cursor[cursorTarget.key];
+		const scan = streamDirWindow(
+			dir,
+			remaining,
+			after,
+			(entry) => path.relative(request.resultsDir, path.join(dir, entry.name)),
+			(entry) => entry.isFile() && (entry.name.startsWith(RESULT_TOMBSTONE_PREFIX) || entry.name.endsWith(".json")),
+		);
+		record(source, scan);
+		if (scan.cursorCleared) {
+			if (cursorTarget.type === "pending") delete cursor.resultPendingAfterBySession?.[cursorTarget.session];
+			else delete cursor[cursorTarget.key];
+		}
+		for (const candidate of scan.entries.slice(0, remaining)) {
+			const tombstone = candidate.name.startsWith(RESULT_TOMBSTONE_PREFIX);
+			resultCandidates.push({
+				name: candidate.name,
+				relative: candidate.relative,
+				kind: tombstone ? "tombstone" : kind,
+				cursor: cursorTarget,
+			});
+			if (cursorTarget.type === "pending") {
+				cursor.resultPendingAfterBySession ??= {};
+				cursor.resultPendingAfterBySession[cursorTarget.session] = candidate.relative;
+			} else cursor[cursorTarget.key] = candidate.relative;
+		}
+		return resultCandidates.length - before;
+	};
+
+	addFiles(request.resultsDir, "public", { type: "result", key: "resultPublicAfter" }, "results.public");
+	const pendingRoot = path.join(request.resultsDir, "result-pending");
+	const pendingRemaining = Math.min(request.resultBudget, sourceLimit, request.resultBudget - resultCandidates.length);
+	const pendingScan = streamDirWindow(
+		pendingRoot,
+		pendingRemaining,
+		cursor.pendingSessionAfter,
+		(entry) => entry.name,
+		(entry) => entry.isDirectory(),
+	);
+	record("results.pendingSessions", pendingScan);
+	const livePendingSessions = new Set(pendingScan.entries.map((entry) => entry.relative));
+	if (cursor.resultPendingAfterBySession) {
+		let pruned = 0;
+		for (const session of Object.keys(cursor.resultPendingAfterBySession).sort()) {
+			if (pruned >= request.resultBudget) break;
+			if (!livePendingSessions.has(session) && !fs.existsSync(path.join(pendingRoot, session))) {
+				delete cursor.resultPendingAfterBySession[session];
+				pruned += 1;
+			}
+		}
+		if (Object.keys(cursor.resultPendingAfterBySession).length === 0) delete cursor.resultPendingAfterBySession;
+	}
+	if (pendingScan.cursorCleared) delete cursor.pendingSessionAfter;
+	const pendingSessions = pendingScan.entries.slice(0, pendingRemaining);
+	let pendingFileBudget = Math.min(sourceLimit, request.resultBudget - resultCandidates.length);
+	for (const session of pendingSessions) {
+		if (pendingFileBudget <= 0) break;
+		cursor.pendingSessionAfter = session.relative;
+		pendingFileBudget -= addFiles(
+			path.join(pendingRoot, session.name),
+			"pending",
+			{ type: "pending", session: session.relative },
+			`results.pending.${session.name}`,
+			pendingFileBudget,
+		);
+	}
+	addFiles(path.join(request.resultsDir, "completion-replay"), "replay", { type: "result", key: "resultReplayAfter" }, "results.replay");
+	addFiles(path.join(request.resultsDir, "output-archives"), "archive", { type: "result", key: "resultArchiveAfter" }, "results.archive");
+
+	const cursorOps = [];
+	for (const key of ["runAfter", "resultPublicAfter", "resultReplayAfter", "resultArchiveAfter", "pendingSessionAfter"]) {
+		if (cursor[key] === request.cursor[key]) continue;
+		cursorOps.push(cursor[key] === undefined ? { type: "delete", key } : { type: "set", key, value: cursor[key] });
+	}
+	const oldPending = request.cursor.resultPendingAfterBySession ?? {};
+	const nextPending = cursor.resultPendingAfterBySession ?? {};
+	for (const session of new Set([...Object.keys(oldPending), ...Object.keys(nextPending)])) {
+		if (oldPending[session] === nextPending[session]) continue;
+		cursorOps.push(nextPending[session] === undefined
+			? { type: "delete-pending", session }
+			: { type: "set-pending", session, value: nextPending[session] });
+	}
+	return {
+		type: "result",
+		passId: request.passId,
+		discoveryDurationMs: Math.max(0, Date.now() - startedAt),
+		rawReads: raw.reads,
+		sourceExhausted: raw.exhausted,
+		runCandidates,
+		resultCandidates,
+		cursorOps,
+	};
+}
+
+if (!parentPort) throw new Error("Async retention discovery requires a worker parent port.");
+parentPort.on("message", (request) => {
+	const passId = request?.passId;
+	try {
+		parentPort.postMessage(discover(request));
+	} catch (error) {
+		parentPort.postMessage({ type: "error", passId, error: error instanceof Error ? error.message : String(error) });
+	}
+});

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -472,11 +472,13 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			deliverIntercomResults: config.intercomBridge?.resultDelivery === true,
 		},
 	);
-	const asyncRetentionTimer = setTimeout(() => {
+	const asyncRetentionAbort = new AbortController();
+	const asyncRetentionTimer = setTimeout(async () => {
 		try {
-			cleanupAsyncRetention({
+			await cleanupAsyncRetention({
 				asyncDirRoot: DIRS.async,
 				resultsDir: DIRS.results,
+				signal: asyncRetentionAbort.signal,
 				protectedRunIds: new Set([
 					...state.asyncJobs.keys(),
 					...(state.workflowControllers?.keys() ?? []),
@@ -492,6 +494,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const runtimeCleanup = () => {
 		clearTimeout(resultIndexCleanupTimer);
 		clearTimeout(asyncRetentionTimer);
+		asyncRetentionAbort.abort();
 		stopResultWatcher();
 		state.currentSessionId = null;
 		completionNotifier.dispose();
@@ -899,6 +902,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		state.widgetsSuspended = false;
 		clearTimeout(resultIndexCleanupTimer);
 		clearTimeout(asyncRetentionTimer);
+		asyncRetentionAbort.abort();
 		stopResultWatcher();
 		state.currentSessionId = null;
 		state.parentSessionFile = null;

--- a/src/runs/background/async-retention.ts
+++ b/src/runs/background/async-retention.ts
@@ -93,6 +93,7 @@ export interface AsyncRetentionOptions {
 	processStartIdentity?: string;
 	isProcessAlive?: (pid: number) => boolean | undefined;
 	getProcessStartIdentity?: (pid: number) => string | undefined;
+	lstatSync?: typeof fs.lstatSync;
 	signal?: AbortSignal;
 	discoveryWorkerUrl?: URL;
 }
@@ -669,7 +670,9 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 		durationMs: 0,
 	};
 	const deletedIds: string[] = [];
+	const lstatSync = options.lstatSync ?? fs.lstatSync;
 	let commitStartedAt: number | undefined;
+	let cursorCommitUnsafe = false;
 	const finish = (): AsyncRetentionResult => {
 		if (commitStartedAt !== undefined) result.commitDurationMs = Math.max(0, Date.now() - commitStartedAt);
 		result.durationMs = Math.max(0, Date.now() - startedWall);
@@ -742,8 +745,9 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 			if (markCancelled()) return finish();
 			result.scanned += 1;
 			const runDir = path.join(options.asyncDirRoot, entry.name);
+			let mutationStateChanged = false;
 			try {
-				const stat = fs.lstatSync(runDir);
+				const stat = lstatSync(runDir);
 				if (!stat.isDirectory() || stat.isSymbolicLink()) {
 					increment(result.skipped, "unsafe-run-path");
 					continue;
@@ -769,6 +773,7 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 						increment(result.skipped, `recheck-${finalReason}`);
 						continue;
 					}
+					mutationStateChanged = true;
 					fs.rmSync(runDir, { recursive: true });
 					removeRunTombstoneMarker(maintenanceRoot, status!.runId);
 					result.reapedTombstones += 1;
@@ -777,18 +782,24 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 				}
 				const tombstone = path.join(options.asyncDirRoot, `${RUN_TOMBSTONE_PREFIX}${randomId()}`);
 				writeRunTombstoneMarker(maintenanceRoot, status!.runId, tombstone, currentTime);
+				mutationStateChanged = true;
 				try {
 					fs.renameSync(runDir, tombstone);
 				} catch (error) {
 					removeRunTombstoneMarker(maintenanceRoot, status!.runId);
+					mutationStateChanged = false;
 					throw error;
 				}
 				const recheckStatus = readStatus(tombstone);
 				const freshWaitReferences = parseWaitRunIds(waitSubscriptionsDir);
 				const recheckReason = freshWaitReferences.safe ? runSkipReason({ runDir: tombstone, status: recheckStatus, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds }) : "wait-references-unknown";
 				if (recheckReason) {
-					if (!fs.existsSync(runDir)) fs.renameSync(tombstone, runDir);
+					if (!fs.existsSync(runDir)) {
+						fs.renameSync(tombstone, runDir);
+						mutationStateChanged = false;
+					}
 					removeRunTombstoneMarker(maintenanceRoot, status!.runId);
+					if (mutationStateChanged) cursorCommitUnsafe = true;
 					increment(result.skipped, `recheck-${recheckReason}`);
 					continue;
 				}
@@ -797,6 +808,7 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 				result.deletedRuns += 1;
 				deletedIds.push(`run:${status!.runId}`);
 			} catch (error) {
+				if (mutationStateChanged) cursorCommitUnsafe = true;
 				if (!isNotFound(error)) result.errors.push(compactError(error));
 			}
 		}
@@ -804,8 +816,9 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 			if (markCancelled()) return finish();
 			result.scanned += 1;
 			const candidate: ResultCandidate = { ...discoveredCandidate, path: path.join(options.resultsDir, discoveredCandidate.relative) };
+			let mutationStateChanged = false;
 			try {
-				const stat = fs.lstatSync(candidate.path);
+				const stat = lstatSync(candidate.path);
 				if (!stat.isFile() || stat.isSymbolicLink()) {
 					increment(result.skipped, "unsafe-result-path");
 					continue;
@@ -828,18 +841,24 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 						continue;
 					}
 					fs.rmSync(candidate.path);
+					mutationStateChanged = true;
 					result.reapedTombstones += 1;
 					deletedIds.push(`result-tombstone:${resultRunId(candidate, data!)}`);
 					continue;
 				}
 				const tombstone = path.join(path.dirname(candidate.path), `${RESULT_TOMBSTONE_PREFIX}${candidate.kind}-${randomId()}`);
 				fs.renameSync(candidate.path, tombstone);
+				mutationStateChanged = true;
 				const tombstoneCandidate = { ...candidate, path: tombstone, kind: "tombstone" as const };
 				const recheckData = readJson(tombstone);
 				const freshWaitReferences = parseWaitRunIds(waitSubscriptionsDir);
 				const recheckReason = freshWaitReferences.safe ? resultSkipReason({ candidate: tombstoneCandidate, data: recheckData, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, maintenanceRoot, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds }) : "wait-references-unknown";
 				if (recheckReason) {
-					if (!fs.existsSync(candidate.path)) fs.renameSync(tombstone, candidate.path);
+					if (!fs.existsSync(candidate.path)) {
+						fs.renameSync(tombstone, candidate.path);
+						mutationStateChanged = false;
+					}
+					if (mutationStateChanged) cursorCommitUnsafe = true;
 					increment(result.skipped, `recheck-${recheckReason}`);
 					continue;
 				}
@@ -847,10 +866,11 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 				result.deletedResults += 1;
 				deletedIds.push(`result:${resultRunId(candidate, data!)}`);
 			} catch (error) {
+				if (mutationStateChanged) cursorCommitUnsafe = true;
 				if (!isNotFound(error)) result.errors.push(compactError(error));
 			}
 		}
-		if (result.errors.length > 0) {
+		if (cursorCommitUnsafe) {
 			increment(result.skipped, "commit-failure");
 			return finish();
 		}

--- a/src/runs/background/async-retention.ts
+++ b/src/runs/background/async-retention.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
+import { Worker } from "node:worker_threads";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import type { AsyncStatus } from "../../shared/types.ts";
 import { MISSION_BINDING_FILE } from "../../missions/lifecycle.ts";
@@ -47,16 +48,24 @@ interface ResultCandidate {
 	cursor: ResultCursorTarget;
 }
 
-interface StreamedDirEntry {
+interface DiscoveredRunCandidate {
+	name: string;
 	relative: string;
-	entry: fs.Dirent;
 }
 
-interface StreamedDirWindow {
-	entries: StreamedDirEntry[];
+type CursorOperation =
+	| { type: "set"; key: Exclude<keyof RetentionCursor, "version" | "resultPendingAfterBySession">; value: string }
+	| { type: "delete"; key: Exclude<keyof RetentionCursor, "version" | "resultPendingAfterBySession"> }
+	| { type: "set-pending"; session: string; value: string }
+	| { type: "delete-pending"; session: string };
+
+interface RetentionDiscovery {
+	discoveryDurationMs: number;
 	rawReads: number;
-	exhausted: boolean;
-	cursorCleared: boolean;
+	sourceExhausted: Record<string, boolean>;
+	runCandidates: DiscoveredRunCandidate[];
+	resultCandidates: Array<Omit<ResultCandidate, "path">>;
+	cursorOps: CursorOperation[];
 }
 
 interface RetentionLockOwner {
@@ -84,7 +93,8 @@ export interface AsyncRetentionOptions {
 	processStartIdentity?: string;
 	isProcessAlive?: (pid: number) => boolean | undefined;
 	getProcessStartIdentity?: (pid: number) => string | undefined;
-	opendirSync?: typeof fs.opendirSync;
+	signal?: AbortSignal;
+	discoveryWorkerUrl?: URL;
 }
 
 export interface AsyncRetentionResult {
@@ -97,6 +107,10 @@ export interface AsyncRetentionResult {
 	errors: string[];
 	rawReads: number;
 	sourceExhausted: Record<string, boolean>;
+	discoveryDurationMs: number;
+	commitDurationMs: number;
+	cancelled: boolean;
+	workerFailed: boolean;
 	durationMs: number;
 }
 
@@ -116,56 +130,6 @@ function listDir(dir: string): fs.Dirent[] {
 		if (isNotFound(error)) return [];
 		throw error;
 	}
-}
-
-function compareRelative(left: string, right: string): number {
-	if (left < right) return -1;
-	if (left > right) return 1;
-	return 0;
-}
-
-function insertSmallest(entries: StreamedDirEntry[], candidate: StreamedDirEntry, limit: number): void {
-	if (limit <= 0) return;
-	const index = entries.findIndex((entry) => compareRelative(candidate.relative, entry.relative) < 0);
-	if (index === -1) entries.push(candidate);
-	else entries.splice(index, 0, candidate);
-	if (entries.length > limit) entries.pop();
-}
-
-function streamDirWindow(dir: string, limit: number, after: string | undefined, relativePath: (entry: fs.Dirent) => string, usable: (entry: fs.Dirent, relative: string) => boolean, opendirSync = fs.opendirSync): StreamedDirWindow {
-	if (limit <= 0) return { entries: [], rawReads: 0, exhausted: true, cursorCleared: false };
-	let handle: fs.Dir | undefined;
-	try {
-		handle = opendirSync(dir);
-		const next: StreamedDirEntry[] = [];
-		const wrapped: StreamedDirEntry[] = [];
-		let rawReads = 0;
-		// Directories cannot be resumed by raw position through Node. The delayed
-		// cleanup pass enumerates to EOF, while this helper keeps only a bounded
-		// top-k selection so memory and mutations stay bounded by the batch.
-		while (true) {
-			const entry = handle.readSync();
-			if (!entry) break;
-			rawReads += 1;
-			const relative = relativePath(entry);
-			if (!usable(entry, relative)) continue;
-			const candidate = { relative, entry };
-			insertSmallest(wrapped, candidate, limit);
-			if (after === undefined || compareRelative(relative, after) > 0) insertSmallest(next, candidate, limit);
-		}
-		const cursorCleared = after !== undefined && next.length === 0;
-		return { entries: cursorCleared ? wrapped : next, rawReads, exhausted: true, cursorCleared };
-	} catch (error) {
-		if (isNotFound(error)) return { entries: [], rawReads: 0, exhausted: true, cursorCleared: false };
-		throw error;
-	} finally {
-		handle?.closeSync();
-	}
-}
-
-function recordSourceScan(result: AsyncRetentionResult, source: string, scan: Pick<StreamedDirWindow, "rawReads" | "exhausted">): void {
-	result.rawReads += scan.rawReads;
-	result.sourceExhausted[source] = scan.exhausted;
 }
 
 function readJson(filePath: string): Record<string, unknown> | undefined {
@@ -350,69 +314,6 @@ function parseWaitRunIds(dir: string): { runIds: Set<string>; safe: boolean } {
 function readCursor(root: string): RetentionCursor {
 	const value = readJson(path.join(root, CURSOR_NAME));
 	return value?.version === 1 ? value as unknown as RetentionCursor : { version: 1 };
-}
-
-function prunePendingSessionCursors(cursor: RetentionCursor, pendingRoot: string): void {
-	const cursors = cursor.resultPendingAfterBySession;
-	if (cursors === undefined) return;
-	for (const session of Object.keys(cursors)) {
-		if (!fs.existsSync(path.join(pendingRoot, session))) delete cursors[session];
-	}
-	if (Object.keys(cursors).length === 0) delete cursor.resultPendingAfterBySession;
-}
-
-function resultCandidates(resultsDir: string, cursor: RetentionCursor, pendingDirLimit: number, limit: number, result: AsyncRetentionResult, opendirSync: typeof fs.opendirSync): ResultCandidate[] {
-	const candidates: ResultCandidate[] = [];
-	const sourceLimit = Math.max(1, Math.ceil(limit / 4));
-	const addFiles = (dir: string, kind: ResultCandidate["kind"], cursorTarget: ResultCursorTarget, source: string, budget = sourceLimit): number => {
-		const remaining = Math.min(budget, limit - candidates.length);
-		if (remaining <= 0) return 0;
-		const before = candidates.length;
-		const after = cursorTarget.type === "pending" ? cursor.resultPendingAfterBySession?.[cursorTarget.session] : cursor[cursorTarget.key];
-		const scan = streamDirWindow(
-			dir,
-			remaining,
-			after,
-			(value) => path.relative(resultsDir, path.join(dir, value.name)),
-			(entry) => entry.isFile() && (entry.name.startsWith(RESULT_TOMBSTONE_PREFIX) || entry.name.endsWith(".json")),
-			opendirSync,
-		);
-		recordSourceScan(result, source, scan);
-		if (scan.cursorCleared) {
-			if (cursorTarget.type === "pending") delete cursor.resultPendingAfterBySession?.[cursorTarget.session];
-			else delete cursor[cursorTarget.key];
-		}
-		for (const { entry } of scan.entries.slice(0, remaining)) {
-			const fullPath = path.join(dir, entry.name);
-			const tombstone = entry.name.startsWith(RESULT_TOMBSTONE_PREFIX);
-			candidates.push({ path: fullPath, relative: path.relative(resultsDir, fullPath), kind: tombstone ? "tombstone" : kind, cursor: cursorTarget });
-		}
-		return candidates.length - before;
-	};
-	addFiles(resultsDir, "public", { type: "result", key: "resultPublicAfter" }, "results.public");
-	const pendingRoot = path.join(resultsDir, "result-pending");
-	prunePendingSessionCursors(cursor, pendingRoot);
-	const pendingRemaining = Math.min(pendingDirLimit, sourceLimit, limit - candidates.length);
-	const pendingScan = streamDirWindow(
-		pendingRoot,
-		pendingRemaining,
-		cursor.pendingSessionAfter,
-		(entry) => entry.name,
-		(entry) => entry.isDirectory(),
-		opendirSync,
-	);
-	recordSourceScan(result, "results.pendingSessions", pendingScan);
-	if (pendingScan.cursorCleared) delete cursor.pendingSessionAfter;
-	const pendingSessions = pendingScan.entries.slice(0, Math.min(pendingDirLimit, sourceLimit, limit - candidates.length));
-	let pendingFileBudget = Math.min(sourceLimit, limit - candidates.length);
-	for (const session of pendingSessions) {
-		if (pendingFileBudget <= 0) break;
-		cursor.pendingSessionAfter = session.relative;
-		pendingFileBudget -= addFiles(path.join(pendingRoot, session.entry.name), "pending", { type: "pending", session: session.relative }, `results.pending.${session.entry.name}`, pendingFileBudget);
-	}
-	addFiles(path.join(resultsDir, "completion-replay"), "replay", { type: "result", key: "resultReplayAfter" }, "results.replay");
-	addFiles(path.join(resultsDir, "output-archives"), "archive", { type: "result", key: "resultArchiveAfter" }, "results.archive");
-	return candidates;
 }
 
 function processStartIdentity(pid: number): string | undefined {
@@ -612,6 +513,10 @@ function appendMaintenanceLog(root: string, result: AsyncRetentionResult, now: n
 		errors: result.errors.length,
 		rawReads: result.rawReads,
 		sourceExhausted: result.sourceExhausted,
+		discoveryDurationMs: result.discoveryDurationMs,
+		commitDurationMs: result.commitDurationMs,
+		cancelled: result.cancelled,
+		workerFailed: result.workerFailed,
 		durationMs: result.durationMs,
 	})}\n`, "utf-8");
 }
@@ -620,7 +525,117 @@ function increment(record: Record<string, number>, key: string): void {
 	record[key] = (record[key] ?? 0) + 1;
 }
 
-export function cleanupAsyncRetention(options: AsyncRetentionOptions): AsyncRetentionResult {
+
+class RetentionCancelledError extends Error {}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function safeRelative(relative: string): boolean {
+	return relative.length > 0 && !path.isAbsolute(relative) && !relative.split(path.sep).includes("..");
+}
+
+function parseDiscoveryResult(message: unknown, passId: string, runBudget: number, resultBudget: number): RetentionDiscovery {
+	if (!isRecord(message) || message.type !== "result" || message.passId !== passId) throw new Error("Retention discovery worker returned a stale or malformed pass id.");
+	if (!Number.isFinite(message.discoveryDurationMs) || (message.discoveryDurationMs as number) < 0) throw new Error("Retention discovery worker returned an invalid duration.");
+	if (!Number.isInteger(message.rawReads) || (message.rawReads as number) < 0) throw new Error("Retention discovery worker returned an invalid raw-read count.");
+	if (!isRecord(message.sourceExhausted) || Object.values(message.sourceExhausted).some((value) => typeof value !== "boolean")) throw new Error("Retention discovery worker returned invalid source telemetry.");
+	if (!Array.isArray(message.runCandidates) || message.runCandidates.length > runBudget) throw new Error("Retention discovery worker exceeded the run budget.");
+	if (!Array.isArray(message.resultCandidates) || message.resultCandidates.length > resultBudget) throw new Error("Retention discovery worker exceeded the result budget.");
+	if (!Array.isArray(message.cursorOps) || message.cursorOps.length > runBudget + resultBudget + 8) throw new Error("Retention discovery worker returned invalid cursor operations.");
+	for (const candidate of message.runCandidates) {
+		if (!isRecord(candidate) || typeof candidate.name !== "string" || typeof candidate.relative !== "string" || !validRunId(candidate.name) || candidate.relative !== candidate.name) throw new Error("Retention discovery worker returned an unsafe run candidate.");
+	}
+	const resultKinds = new Set(["public", "pending", "replay", "archive", "tombstone"]);
+	const resultKeys = new Set(["resultPublicAfter", "resultReplayAfter", "resultArchiveAfter"]);
+	for (const candidate of message.resultCandidates) {
+		if (!isRecord(candidate) || typeof candidate.name !== "string" || typeof candidate.relative !== "string" || path.basename(candidate.name) !== candidate.name || !safeRelative(candidate.relative) || path.basename(candidate.relative) !== candidate.name || !resultKinds.has(candidate.kind as string) || !isRecord(candidate.cursor)) throw new Error("Retention discovery worker returned an unsafe result candidate.");
+		const cursor = candidate.cursor;
+		if (cursor.type === "pending") {
+			if (typeof cursor.session !== "string" || !validRunId(cursor.session) || path.dirname(candidate.relative) !== path.join("result-pending", cursor.session)) throw new Error("Retention discovery worker returned an invalid pending candidate.");
+		} else if (cursor.type === "result") {
+			if (typeof cursor.key !== "string" || !resultKeys.has(cursor.key)) throw new Error("Retention discovery worker returned an invalid result cursor.");
+			const expectedDir = cursor.key === "resultPublicAfter" ? "." : cursor.key === "resultReplayAfter" ? "completion-replay" : "output-archives";
+			if (path.dirname(candidate.relative) !== expectedDir) throw new Error("Retention discovery worker returned a result from the wrong source.");
+		} else throw new Error("Retention discovery worker returned an invalid result cursor target.");
+	}
+	const scalarKeys = new Set(["runAfter", "resultPublicAfter", "resultReplayAfter", "resultArchiveAfter", "pendingSessionAfter"]);
+	for (const operation of message.cursorOps) {
+		if (!isRecord(operation) || typeof operation.type !== "string") throw new Error("Retention discovery worker returned a malformed cursor operation.");
+		if (operation.type === "set" || operation.type === "delete") {
+			if (typeof operation.key !== "string" || !scalarKeys.has(operation.key) || (operation.type === "set" && (typeof operation.value !== "string" || !safeRelative(operation.value)))) throw new Error("Retention discovery worker returned an invalid scalar cursor operation.");
+		} else if (operation.type === "set-pending" || operation.type === "delete-pending") {
+			if (typeof operation.session !== "string" || !validRunId(operation.session) || (operation.type === "set-pending" && (typeof operation.value !== "string" || !safeRelative(operation.value)))) throw new Error("Retention discovery worker returned an invalid pending cursor operation.");
+		} else throw new Error("Retention discovery worker returned an unknown cursor operation.");
+	}
+	return message as unknown as RetentionDiscovery;
+}
+
+function runRetentionDiscovery(input: {
+	passId: string;
+	asyncDirRoot: string;
+	resultsDir: string;
+	cursor: RetentionCursor;
+	runBudget: number;
+	resultBudget: number;
+	workerUrl: URL;
+	signal?: AbortSignal;
+}): Promise<RetentionDiscovery> {
+	return new Promise((resolve, reject) => {
+		if (input.signal?.aborted) {
+			reject(new RetentionCancelledError("Retention discovery was cancelled."));
+			return;
+		}
+		const worker = new Worker(input.workerUrl);
+		let settled = false;
+		const cleanup = (): void => {
+			input.signal?.removeEventListener("abort", onAbort);
+			void worker.terminate();
+		};
+		const fail = (error: Error): void => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(error);
+		};
+		const onAbort = (): void => fail(new RetentionCancelledError("Retention discovery was cancelled."));
+		input.signal?.addEventListener("abort", onAbort, { once: true });
+		worker.once("error", (error) => fail(error));
+		worker.once("exit", (code) => {
+			if (!settled) fail(new Error(`Retention discovery worker exited before replying (${code}).`));
+		});
+		worker.once("message", (message: unknown) => {
+			if (settled) return;
+			try {
+				if (isRecord(message) && message.type === "error" && message.passId === input.passId) throw new Error(`Retention discovery failed: ${String(message.error)}`);
+				const discovery = parseDiscoveryResult(message, input.passId, input.runBudget, input.resultBudget);
+				settled = true;
+				cleanup();
+				resolve(discovery);
+			} catch (error) {
+				fail(error instanceof Error ? error : new Error(String(error)));
+			}
+		});
+		worker.postMessage({ type: "discover", passId: input.passId, asyncDirRoot: input.asyncDirRoot, resultsDir: input.resultsDir, cursor: input.cursor, runBudget: input.runBudget, resultBudget: input.resultBudget });
+	});
+}
+
+function applyCursorOperations(cursor: RetentionCursor, operations: CursorOperation[]): void {
+	for (const operation of operations) {
+		if (operation.type === "set") cursor[operation.key] = operation.value;
+		else if (operation.type === "delete") delete cursor[operation.key];
+		else if (operation.type === "set-pending") {
+			cursor.resultPendingAfterBySession ??= {};
+			cursor.resultPendingAfterBySession[operation.session] = operation.value;
+		} else {
+			delete cursor.resultPendingAfterBySession?.[operation.session];
+			if (cursor.resultPendingAfterBySession && Object.keys(cursor.resultPendingAfterBySession).length === 0) delete cursor.resultPendingAfterBySession;
+		}
+	}
+}
+
+export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Promise<AsyncRetentionResult> {
 	const startedWall = Date.now();
 	const now = options.now ?? Date.now;
 	const currentTime = now();
@@ -635,22 +650,37 @@ export function cleanupAsyncRetention(options: AsyncRetentionOptions): AsyncRete
 	const hostname = options.hostname ?? os.hostname();
 	const getProcessStartIdentity = options.getProcessStartIdentity ?? processStartIdentity;
 	const currentProcessStartIdentity = options.processStartIdentity ?? getProcessStartIdentity(pid) ?? (pid === process.pid ? `runtime:${Math.round(Date.now() - process.uptime() * 1000)}` : undefined);
-	const lockOwner: RetentionLockOwner = {
-		version: 1,
-		token: lockToken,
-		pid,
-		hostname,
-		startedAt: currentTime,
-		...(currentProcessStartIdentity ? { processStartIdentity: currentProcessStartIdentity } : {}),
-	};
+	const lockOwner: RetentionLockOwner = { version: 1, token: lockToken, pid, hostname, startedAt: currentTime, ...(currentProcessStartIdentity ? { processStartIdentity: currentProcessStartIdentity } : {}) };
 	const lockOptions = { hostname, isProcessAlive: options.isProcessAlive ?? processIsAlive, getProcessStartIdentity };
-	const result: AsyncRetentionResult = { acquired: false, scanned: 0, deletedRuns: 0, deletedResults: 0, reapedTombstones: 0, skipped: {}, errors: [], rawReads: 0, sourceExhausted: {}, durationMs: 0 };
-	const opendirSync = options.opendirSync ?? fs.opendirSync;
+	const result: AsyncRetentionResult = {
+		acquired: false,
+		scanned: 0,
+		deletedRuns: 0,
+		deletedResults: 0,
+		reapedTombstones: 0,
+		skipped: {},
+		errors: [],
+		rawReads: 0,
+		sourceExhausted: {},
+		discoveryDurationMs: 0,
+		commitDurationMs: 0,
+		cancelled: false,
+		workerFailed: false,
+		durationMs: 0,
+	};
 	const deletedIds: string[] = [];
+	let commitStartedAt: number | undefined;
 	const finish = (): AsyncRetentionResult => {
+		if (commitStartedAt !== undefined) result.commitDurationMs = Math.max(0, Date.now() - commitStartedAt);
 		result.durationMs = Math.max(0, Date.now() - startedWall);
 		appendMaintenanceLog(maintenanceRoot, result, currentTime, deletedIds);
 		return result;
+	};
+	const markCancelled = (): boolean => {
+		if (!options.signal?.aborted) return false;
+		result.cancelled = true;
+		increment(result.skipped, "cancelled");
+		return true;
 	};
 	fs.mkdirSync(maintenanceRoot, { recursive: true });
 	if (!acquireRetentionLock(lockDir, lockOwner, lockOptions)) {
@@ -659,23 +689,58 @@ export function cleanupAsyncRetention(options: AsyncRetentionOptions): AsyncRete
 	}
 	result.acquired = true;
 	try {
-		const waitReferences = parseWaitRunIds(options.waitSubscriptionsDir ?? path.join(maintenanceRoot, "wait-subscriptions"));
-		if (!waitReferences.safe) {
-			increment(result.skipped, "wait-references-unknown");
-			return finish();
-		}
+		if (markCancelled()) return finish();
 		const protectedRunIds = new Set(options.protectedRunIds ?? []);
 		const cutoff = currentTime - retentionMs;
 		const cursor = readCursor(maintenanceRoot);
 		const runBudget = Math.ceil(batchSize / 2);
 		const resultBudget = batchSize - runBudget;
-		const runScan = streamDirWindow(options.asyncDirRoot, runBudget, cursor.runAfter, (entry) => entry.name, (entry) => entry.isDirectory() && entry.name !== ACTIVE_RUN_INDEX_DIR, opendirSync);
-		recordSourceScan(result, "runs", runScan);
-		if (runScan.cursorCleared) delete cursor.runAfter;
-		const selectedRuns = runScan.entries.slice(0, runBudget);
-		for (const { entry, relative } of selectedRuns) {
+		const discoveryStartedAt = Date.now();
+		let discovery: RetentionDiscovery;
+		try {
+			discovery = await runRetentionDiscovery({
+				passId: randomUUID(),
+				asyncDirRoot: options.asyncDirRoot,
+				resultsDir: options.resultsDir,
+				cursor,
+				runBudget,
+				resultBudget,
+				workerUrl: options.discoveryWorkerUrl ?? new URL("../../../async-retention-discovery-worker.mjs", import.meta.url),
+				signal: options.signal,
+			});
+		} catch (error) {
+			result.discoveryDurationMs = Math.max(0, Date.now() - discoveryStartedAt);
+			if (error instanceof RetentionCancelledError) {
+				result.cancelled = true;
+				increment(result.skipped, "cancelled");
+			} else {
+				result.workerFailed = true;
+				increment(result.skipped, "worker-failure");
+				result.errors.push(compactError(error));
+			}
+			return finish();
+		}
+		result.discoveryDurationMs = Math.max(0, Date.now() - discoveryStartedAt);
+		result.rawReads = discovery.rawReads;
+		result.sourceExhausted = discovery.sourceExhausted;
+		commitStartedAt = Date.now();
+		if (markCancelled()) return finish();
+		if (parseLockOwner(lockDir)?.token !== lockToken) {
+			increment(result.skipped, "lock-owner-changed");
+			return finish();
+		}
+		const waitSubscriptionsDir = options.waitSubscriptionsDir ?? path.join(maintenanceRoot, "wait-subscriptions");
+		// This safety scan stays on the commit thread. Wait records are the active,
+		// swept subscription set. Each destructive action re-reads it to close the
+		// race with a newly armed wait.
+		const waitReferences = parseWaitRunIds(waitSubscriptionsDir);
+		if (!waitReferences.safe) {
+			increment(result.skipped, "wait-references-unknown");
+			return finish();
+		}
+		for (const entry of discovery.runCandidates) {
+			if (markCancelled()) return finish();
 			result.scanned += 1;
-			cursor.runAfter = relative;
 			const runDir = path.join(options.asyncDirRoot, entry.name);
 			try {
 				const stat = fs.lstatSync(runDir);
@@ -698,10 +763,8 @@ export function cleanupAsyncRetention(options: AsyncRetentionOptions): AsyncRete
 						increment(result.skipped, "tombstone-grace");
 						continue;
 					}
-					const freshWaitReferences = parseWaitRunIds(options.waitSubscriptionsDir ?? path.join(maintenanceRoot, "wait-subscriptions"));
-					const finalReason = freshWaitReferences.safe
-						? runSkipReason({ runDir, status, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds })
-						: "wait-references-unknown";
+					const freshWaitReferences = parseWaitRunIds(waitSubscriptionsDir);
+					const finalReason = freshWaitReferences.safe ? runSkipReason({ runDir, status, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds }) : "wait-references-unknown";
 					if (finalReason) {
 						increment(result.skipped, `recheck-${finalReason}`);
 						continue;
@@ -721,10 +784,8 @@ export function cleanupAsyncRetention(options: AsyncRetentionOptions): AsyncRete
 					throw error;
 				}
 				const recheckStatus = readStatus(tombstone);
-				const freshWaitReferences = parseWaitRunIds(options.waitSubscriptionsDir ?? path.join(maintenanceRoot, "wait-subscriptions"));
-				const recheckReason = freshWaitReferences.safe
-					? runSkipReason({ runDir: tombstone, status: recheckStatus, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds })
-					: "wait-references-unknown";
+				const freshWaitReferences = parseWaitRunIds(waitSubscriptionsDir);
+				const recheckReason = freshWaitReferences.safe ? runSkipReason({ runDir: tombstone, status: recheckStatus, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds }) : "wait-references-unknown";
 				if (recheckReason) {
 					if (!fs.existsSync(runDir)) fs.renameSync(tombstone, runDir);
 					removeRunTombstoneMarker(maintenanceRoot, status!.runId);
@@ -739,13 +800,10 @@ export function cleanupAsyncRetention(options: AsyncRetentionOptions): AsyncRete
 				if (!isNotFound(error)) result.errors.push(compactError(error));
 			}
 		}
-		const selectedResults = resultCandidates(options.resultsDir, cursor, resultBudget, resultBudget, result, opendirSync);
-		for (const candidate of selectedResults) {
+		for (const discoveredCandidate of discovery.resultCandidates) {
+			if (markCancelled()) return finish();
 			result.scanned += 1;
-			if (candidate.cursor.type === "pending") {
-				cursor.resultPendingAfterBySession ??= {};
-				cursor.resultPendingAfterBySession[candidate.cursor.session] = candidate.relative;
-			} else cursor[candidate.cursor.key] = candidate.relative;
+			const candidate: ResultCandidate = { ...discoveredCandidate, path: path.join(options.resultsDir, discoveredCandidate.relative) };
 			try {
 				const stat = fs.lstatSync(candidate.path);
 				if (!stat.isFile() || stat.isSymbolicLink()) {
@@ -763,10 +821,8 @@ export function cleanupAsyncRetention(options: AsyncRetentionOptions): AsyncRete
 						increment(result.skipped, "tombstone-grace");
 						continue;
 					}
-					const freshWaitReferences = parseWaitRunIds(options.waitSubscriptionsDir ?? path.join(maintenanceRoot, "wait-subscriptions"));
-					const finalReason = freshWaitReferences.safe
-						? resultSkipReason({ candidate, data, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, maintenanceRoot, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds })
-						: "wait-references-unknown";
+					const freshWaitReferences = parseWaitRunIds(waitSubscriptionsDir);
+					const finalReason = freshWaitReferences.safe ? resultSkipReason({ candidate, data, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, maintenanceRoot, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds }) : "wait-references-unknown";
 					if (finalReason) {
 						increment(result.skipped, `recheck-${finalReason}`);
 						continue;
@@ -780,10 +836,8 @@ export function cleanupAsyncRetention(options: AsyncRetentionOptions): AsyncRete
 				fs.renameSync(candidate.path, tombstone);
 				const tombstoneCandidate = { ...candidate, path: tombstone, kind: "tombstone" as const };
 				const recheckData = readJson(tombstone);
-				const freshWaitReferences = parseWaitRunIds(options.waitSubscriptionsDir ?? path.join(maintenanceRoot, "wait-subscriptions"));
-				const recheckReason = freshWaitReferences.safe
-					? resultSkipReason({ candidate: tombstoneCandidate, data: recheckData, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, maintenanceRoot, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds })
-					: "wait-references-unknown";
+				const freshWaitReferences = parseWaitRunIds(waitSubscriptionsDir);
+				const recheckReason = freshWaitReferences.safe ? resultSkipReason({ candidate: tombstoneCandidate, data: recheckData, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, maintenanceRoot, cutoff, protectedRunIds, waitRunIds: freshWaitReferences.runIds }) : "wait-references-unknown";
 				if (recheckReason) {
 					if (!fs.existsSync(candidate.path)) fs.renameSync(tombstone, candidate.path);
 					increment(result.skipped, `recheck-${recheckReason}`);
@@ -796,6 +850,16 @@ export function cleanupAsyncRetention(options: AsyncRetentionOptions): AsyncRete
 				if (!isNotFound(error)) result.errors.push(compactError(error));
 			}
 		}
+		if (result.errors.length > 0) {
+			increment(result.skipped, "commit-failure");
+			return finish();
+		}
+		if (markCancelled()) return finish();
+		if (parseLockOwner(lockDir)?.token !== lockToken) {
+			increment(result.skipped, "lock-owner-changed");
+			return finish();
+		}
+		applyCursorOperations(cursor, discovery.cursorOps);
 		writeAtomicJson(path.join(maintenanceRoot, CURSOR_NAME), cursor);
 		return finish();
 	} finally {

--- a/test/unit/async-retention.test.ts
+++ b/test/unit/async-retention.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, it } from "node:test";
 import { ASYNC_RETENTION_BATCH_SIZE, cleanupAsyncRetention } from "../../src/runs/background/async-retention.ts";
 
@@ -62,19 +63,8 @@ function writeRunTombstoneMarker(roots: ReturnType<typeof makeRoots>, runId: str
 	return markerPath;
 }
 
-function opendirWithRawOrder(targetDir: string, names: string[]): typeof fs.opendirSync {
-	const realOpendir = fs.opendirSync;
-	return ((dir: fs.PathLike, options?: Parameters<typeof fs.opendirSync>[1]) => {
-		if (path.resolve(String(dir)) !== path.resolve(targetDir)) return realOpendir(dir, options);
-		const entriesByName = new Map(fs.readdirSync(targetDir, { withFileTypes: true }).map((entry) => [entry.name, entry]));
-		const entries = names.map((name) => entriesByName.get(name)).filter((entry): entry is fs.Dirent => entry !== undefined);
-		let index = 0;
-		return { readSync: () => entries[index++] ?? null, closeSync: () => undefined } as unknown as fs.Dir;
-	}) as typeof fs.opendirSync;
-}
-
 describe("async retention cleanup", () => {
-	it("deletes old proven-terminal runs and orphan results through tombstones", () => {
+	it("deletes old proven-terminal runs and orphan results through tombstones", async () => {
 		const roots = makeRoots();
 		try {
 			const runDir = writeOldRun(roots.asyncDirRoot, "old-run");
@@ -91,7 +81,7 @@ describe("async retention cleanup", () => {
 			fs.utimesSync(resolvedHandoffDir, OLD / 1000, OLD / 1000);
 			const resultPath = writeOldResult(roots.resultsDir, "orphan-result");
 
-			const result = cleanupAsyncRetention(cleanupOptions(roots));
+			const result = await cleanupAsyncRetention(cleanupOptions(roots));
 
 			assert.equal(result.acquired, true);
 			assert.equal(result.deletedRuns, 4);
@@ -115,7 +105,7 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("fails closed for live, recent, resumable, wait, mission, workflow, handoff, and runtime references", () => {
+	it("fails closed for live, recent, resumable, wait, mission, workflow, handoff, and runtime references", async () => {
 		const roots = makeRoots();
 		try {
 			writeOldRun(roots.asyncDirRoot, "active", { state: "running" });
@@ -153,7 +143,7 @@ describe("async retention cleanup", () => {
 			fs.writeFileSync(path.join(roots.waitsDir, "wait.json"), JSON.stringify({ runId: "waited", expiresAt: NOW + DAY_MS }));
 			writeOldRun(roots.asyncDirRoot, "runtime");
 
-			const result = cleanupAsyncRetention({ ...cleanupOptions(roots), protectedRunIds: ["runtime"] });
+			const result = await cleanupAsyncRetention({ ...cleanupOptions(roots), protectedRunIds: ["runtime"] });
 
 			for (const runId of ["active", "paused", "recent", "resumable", "status-session", "step-session", "uninspectable-session", "malformed-ended-at", "malformed-last-update", "missing-mode", "non-finite-ended-at", "mission", "workflow", "nested", "handoff", "waited", "runtime"]) {
 				assert.equal(fs.existsSync(path.join(roots.asyncDirRoot, runId)), true, runId);
@@ -176,28 +166,28 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("uses one cleaner, reaps stale tombstones safely, and limits processed runs", () => {
+	it("uses one cleaner, reaps stale tombstones safely, and limits processed runs", async () => {
 		const roots = makeRoots();
 		try {
 			fs.mkdirSync(path.join(roots.root, ".async-retention.lock"));
-			const locked = cleanupAsyncRetention(cleanupOptions(roots));
+			const locked = await cleanupAsyncRetention(cleanupOptions(roots));
 			assert.equal(locked.acquired, false);
 			assert.equal(locked.skipped["lock-busy"], 1);
 			fs.rmSync(path.join(roots.root, ".async-retention.lock"), { recursive: true });
 			const liveLock = path.join(roots.root, ".async-retention.lock");
 			fs.mkdirSync(liveLock);
 			fs.writeFileSync(path.join(liveLock, "owner.json"), JSON.stringify({ pid: process.pid, startedAt: NOW - 6 * 60 * 1000 }));
-			const liveLockResult = cleanupAsyncRetention(cleanupOptions(roots));
+			const liveLockResult = await cleanupAsyncRetention(cleanupOptions(roots));
 			assert.equal(liveLockResult.acquired, false);
 			assert.equal(liveLockResult.skipped["lock-busy"], 1);
 			fs.rmSync(liveLock, { recursive: true });
 			fs.mkdirSync(liveLock);
 			fs.writeFileSync(path.join(liveLock, "owner.json"), JSON.stringify({ version: 1, token: "old-token", pid: process.pid, hostname: "test-host", processStartIdentity: "old-process", startedAt: NOW - 60_000 }));
-			const reusedPidLockResult = cleanupAsyncRetention({ ...cleanupOptions(roots), hostname: "test-host", processStartIdentity: "current-process", getProcessStartIdentity: () => "current-process" });
+			const reusedPidLockResult = await cleanupAsyncRetention({ ...cleanupOptions(roots), hostname: "test-host", processStartIdentity: "current-process", getProcessStartIdentity: () => "current-process" });
 			assert.equal(reusedPidLockResult.acquired, true);
 			fs.mkdirSync(liveLock);
 			fs.writeFileSync(path.join(liveLock, "owner.json"), JSON.stringify({ version: 1, token: "other-token", pid: process.pid, hostname: "test-host", processStartIdentity: "current-process", startedAt: NOW - 60_000 }));
-			const protectedLockResult = cleanupAsyncRetention({ ...cleanupOptions(roots), hostname: "test-host", processStartIdentity: "current-process", getProcessStartIdentity: () => "current-process" });
+			const protectedLockResult = await cleanupAsyncRetention({ ...cleanupOptions(roots), hostname: "test-host", processStartIdentity: "current-process", getProcessStartIdentity: () => "current-process" });
 			assert.equal(protectedLockResult.acquired, false);
 			assert.equal(JSON.parse(fs.readFileSync(path.join(liveLock, "owner.json"), "utf-8")).token, "other-token");
 			fs.rmSync(liveLock, { recursive: true });
@@ -212,21 +202,25 @@ describe("async retention cleanup", () => {
 			const mutatingReferences = (function* () {
 				fs.writeFileSync(path.join(liveLock, "owner.json"), JSON.stringify(replacementOwner));
 			})();
-			const changedOwnerResult = cleanupAsyncRetention({ ...cleanupOptions(roots), randomId: () => "owned-token", protectedRunIds: mutatingReferences, hostname: "test-host", processStartIdentity: "current-process", getProcessStartIdentity: () => "current-process" });
+			const cursorPath = path.join(roots.root, ".async-retention-cursor.json");
+			const cursorBeforeOwnerChange = fs.readFileSync(cursorPath, "utf-8");
+			const changedOwnerResult = await cleanupAsyncRetention({ ...cleanupOptions(roots), randomId: () => "owned-token", protectedRunIds: mutatingReferences, hostname: "test-host", processStartIdentity: "current-process", getProcessStartIdentity: () => "current-process" });
 			assert.equal(changedOwnerResult.acquired, true);
+			assert.equal(changedOwnerResult.skipped["lock-owner-changed"], 1);
+			assert.equal(fs.readFileSync(cursorPath, "utf-8"), cursorBeforeOwnerChange);
 			assert.equal(JSON.parse(fs.readFileSync(path.join(liveLock, "owner.json"), "utf-8")).token, "successor-token");
 			fs.rmSync(liveLock, { recursive: true });
 			const staleLock = path.join(roots.root, ".async-retention.lock");
 			fs.mkdirSync(staleLock);
 			fs.writeFileSync(path.join(staleLock, "owner.json"), JSON.stringify({ startedAt: NOW - 25 * 60 * 60 * 1000 }));
 			fs.utimesSync(staleLock, (NOW - 25 * 60 * 60 * 1000) / 1000, (NOW - 25 * 60 * 60 * 1000) / 1000);
-			const staleLockResult = cleanupAsyncRetention(cleanupOptions(roots));
+			const staleLockResult = await cleanupAsyncRetention(cleanupOptions(roots));
 			assert.equal(staleLockResult.acquired, true);
 
 			const tombstone = writeOldRun(roots.asyncDirRoot, ".deleting-run-stale", { runId: "stale-run" });
 			writeRunTombstoneMarker(roots, "stale-run", tombstone);
 			for (let index = 0; index < 110; index += 1) writeOldRun(roots.asyncDirRoot, `old-${String(index).padStart(3, "0")}`);
-			const result = cleanupAsyncRetention({ ...cleanupOptions(roots), randomId: () => `delete-${Math.random()}` });
+			const result = await cleanupAsyncRetention({ ...cleanupOptions(roots), randomId: () => `delete-${Math.random()}` });
 
 			assert.ok(result.scanned <= ASYNC_RETENTION_BATCH_SIZE);
 			assert.equal(fs.existsSync(tombstone), false);
@@ -237,13 +231,13 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("limits result candidates to the cleanup batch", () => {
+	it("limits result candidates to the cleanup batch", async () => {
 		const roots = makeRoots();
 		try {
 			for (let index = 0; index < 90; index += 1) writeOldResult(roots.resultsDir, `recent-result-${String(index).padStart(3, "0")}`, { endedAt: NOW - DAY_MS });
 			const stalePath = writeOldResult(roots.resultsDir, "zz-stale-result");
-			let result = cleanupAsyncRetention(cleanupOptions(roots));
-			for (let pass = 0; pass < 10 && fs.existsSync(stalePath); pass += 1) result = cleanupAsyncRetention(cleanupOptions(roots));
+			let result = await cleanupAsyncRetention(cleanupOptions(roots));
+			for (let pass = 0; pass < 10 && fs.existsSync(stalePath); pass += 1) result = await cleanupAsyncRetention(cleanupOptions(roots));
 			assert.equal(fs.existsSync(stalePath), false);
 			assert.ok(result.scanned <= ASYNC_RETENTION_BATCH_SIZE);
 			assert.ok(fs.readdirSync(roots.resultsDir).filter((name) => name.endsWith(".json")).length >= 60);
@@ -252,7 +246,7 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("keeps replay cleanup fair when pending results fill their source budget", () => {
+	it("keeps replay cleanup fair when pending results fill their source budget", async () => {
 		const roots = makeRoots();
 		try {
 			const pendingRoot = path.join(roots.resultsDir, "result-pending");
@@ -273,7 +267,7 @@ describe("async retention cleanup", () => {
 			fs.writeFileSync(replayPath, JSON.stringify({ version: 1, runId: "stale-replay", createdAt: OLD, expiresAt: OLD, completion: { runId: "stale-replay", mode: "single" } }));
 			fs.utimesSync(replayPath, OLD / 1000, OLD / 1000);
 
-			const result = cleanupAsyncRetention(cleanupOptions(roots));
+			const result = await cleanupAsyncRetention(cleanupOptions(roots));
 
 			assert.equal(fs.existsSync(replayPath), false);
 			assert.equal(result.deletedResults, 1);
@@ -283,18 +277,16 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("uses full delayed discovery so retained raw-order prefixes cannot starve stale runs", () => {
+	it("uses full delayed discovery so retained raw-order prefixes cannot starve stale runs", async () => {
 		const roots = makeRoots();
 		try {
 			for (const runId of ["recent-a", "recent-b", "recent-c", "recent-d"]) writeOldRun(roots.asyncDirRoot, runId, { endedAt: NOW - DAY_MS });
 			const victim = writeOldRun(roots.asyncDirRoot, "zz-old-victim");
-			const opendirSync = opendirWithRawOrder(roots.asyncDirRoot, ["recent-a", "recent-b", "recent-c", "recent-d", "zz-old-victim"]);
-
-			let result = cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 4, opendirSync });
+			let result = await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 4 });
 			for (let pass = 0; pass < 5 && fs.existsSync(victim); pass += 1) {
 				assert.ok(result.scanned <= ASYNC_RETENTION_BATCH_SIZE);
 				assert.ok(result.rawReads >= 5);
-				result = cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 4, opendirSync });
+				result = await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 4 });
 			}
 
 			assert.equal(fs.existsSync(victim), false);
@@ -303,15 +295,13 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("uses the same ordering for mixed-case cursor filtering and selection", () => {
+	it("uses the same ordering for mixed-case cursor filtering and selection", async () => {
 		const roots = makeRoots();
 		try {
 			writeOldRun(roots.asyncDirRoot, "a", { endedAt: NOW - DAY_MS });
 			const victim = writeOldRun(roots.asyncDirRoot, "B");
-			const opendirSync = opendirWithRawOrder(roots.asyncDirRoot, ["a", "B"]);
-
-			cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 1, opendirSync });
-			for (let pass = 0; pass < 3 && fs.existsSync(victim); pass += 1) cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 1, opendirSync });
+			await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 1 });
+			for (let pass = 0; pass < 3 && fs.existsSync(victim); pass += 1) await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 1 });
 
 			assert.equal(fs.existsSync(victim), false);
 		} finally {
@@ -319,12 +309,12 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("wraps a cursor and makes progress when no usable entries are after it", () => {
+	it("wraps a cursor and makes progress when no usable entries are after it", async () => {
 		const roots = makeRoots();
 		try {
 			const runDir = writeOldRun(roots.asyncDirRoot, "cursor-wrap");
 			fs.writeFileSync(path.join(roots.root, ".async-retention-cursor.json"), JSON.stringify({ version: 1, runAfter: "zzzz" }));
-			const wrapped = cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 1 });
+			const wrapped = await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 1 });
 			assert.equal(fs.existsSync(runDir), false);
 			assert.equal(wrapped.rawReads, 1);
 			assert.equal(wrapped.deletedRuns, 1);
@@ -333,7 +323,7 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("uses exact run tombstone markers for result blocking", () => {
+	it("uses exact run tombstone markers for result blocking", async () => {
 		const roots = makeRoots();
 		try {
 			const blockedResult = writeOldResult(roots.resultsDir, "blocked-result");
@@ -342,7 +332,7 @@ describe("async retention cleanup", () => {
 			fs.mkdirSync(blockingTombstone);
 			writeRunTombstoneMarker(roots, "blocked-result", blockingTombstone);
 
-			const result = cleanupAsyncRetention(cleanupOptions(roots));
+			const result = await cleanupAsyncRetention(cleanupOptions(roots));
 
 			assert.equal(fs.existsSync(blockedResult), true);
 			assert.equal(fs.existsSync(freeResult), false);
@@ -352,13 +342,13 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("removes a stray run tombstone marker when its tombstone is gone", () => {
+	it("removes a stray run tombstone marker when its tombstone is gone", async () => {
 		const roots = makeRoots();
 		try {
 			const resultPath = writeOldResult(roots.resultsDir, "stray-marker-result");
 			const markerPath = writeRunTombstoneMarker(roots, "stray-marker-result", path.join(roots.root, "missing-tombstone"));
 
-			const result = cleanupAsyncRetention(cleanupOptions(roots));
+			const result = await cleanupAsyncRetention(cleanupOptions(roots));
 
 			assert.equal(fs.existsSync(resultPath), false);
 			assert.equal(fs.existsSync(markerPath), false);
@@ -368,7 +358,7 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("advances pending result session windows beyond the first batch", () => {
+	it("advances pending result session windows beyond the first batch", async () => {
 		const roots = makeRoots();
 		try {
 			const pendingRoot = path.join(roots.resultsDir, "result-pending");
@@ -383,8 +373,8 @@ describe("async retention cleanup", () => {
 			for (let index = 0; index < 60; index += 1) writePending(`session-${String(index).padStart(3, "0")}`, `recent-${index}`, NOW - DAY_MS);
 			const stalePath = writePending("session-zz", "stale-pending", OLD);
 
-			let result = cleanupAsyncRetention(cleanupOptions(roots));
-			for (let pass = 0; pass < 5 && fs.existsSync(stalePath); pass += 1) result = cleanupAsyncRetention(cleanupOptions(roots));
+			let result = await cleanupAsyncRetention(cleanupOptions(roots));
+			for (let pass = 0; pass < 5 && fs.existsSync(stalePath); pass += 1) result = await cleanupAsyncRetention(cleanupOptions(roots));
 
 			assert.equal(fs.existsSync(stalePath), false);
 			assert.ok(result.scanned <= ASYNC_RETENTION_BATCH_SIZE);
@@ -393,7 +383,7 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("keeps pending result file cursors separate per session", () => {
+	it("keeps pending result file cursors separate per session", async () => {
 		const roots = makeRoots();
 		try {
 			const pendingRoot = path.join(roots.resultsDir, "result-pending");
@@ -409,10 +399,10 @@ describe("async retention cleanup", () => {
 			const stalePath = writePending("session-a", "zz-stale", OLD);
 			writePending("session-b", "recent-b", NOW - DAY_MS);
 
-			let result = cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 8 });
+			let result = await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 8 });
 			for (let pass = 0; pass < 20 && fs.existsSync(stalePath); pass += 1) {
 				assert.ok(result.scanned <= ASYNC_RETENTION_BATCH_SIZE);
-				result = cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 8 });
+				result = await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 8 });
 			}
 
 			assert.equal(fs.existsSync(stalePath), false);
@@ -421,7 +411,7 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("prunes pending result cursors for removed session directories", () => {
+	it("prunes pending result cursors for removed session directories", async () => {
 		const roots = makeRoots();
 		try {
 			const pendingRoot = path.join(roots.resultsDir, "result-pending");
@@ -438,7 +428,7 @@ describe("async retention cleanup", () => {
 				},
 			}));
 
-			cleanupAsyncRetention(cleanupOptions(roots));
+			await cleanupAsyncRetention(cleanupOptions(roots));
 
 			const cursor = JSON.parse(fs.readFileSync(path.join(roots.root, ".async-retention-cursor.json"), "utf-8")) as { resultPendingAfterBySession?: Record<string, string> };
 			assert.equal(cursor.resultPendingAfterBySession?.["removed-session"], undefined);
@@ -448,7 +438,7 @@ describe("async retention cleanup", () => {
 		}
 	});
 
-	it("keeps orphan results with recoverability or durable references", () => {
+	it("keeps orphan results with recoverability or durable references", async () => {
 		const roots = makeRoots();
 		try {
 			writeOldResult(roots.resultsDir, "waited-result");
@@ -485,7 +475,7 @@ describe("async retention cleanup", () => {
 			fs.utimesSync(replayPath, OLD / 1000, OLD / 1000);
 			fs.utimesSync(archivePath, OLD / 1000, OLD / 1000);
 
-			const result = cleanupAsyncRetention({ ...cleanupOptions(roots), protectedRunIds: ["runtime-result"] });
+			const result = await cleanupAsyncRetention({ ...cleanupOptions(roots), protectedRunIds: ["runtime-result"] });
 
 			for (const runId of ["waited-result", "workflow-result", "resumable-result", "mission-result", "recent-result", "malformed-age-result", "non-finite-age-result", "non-finite-timestamp-result", "uninspectable-session-result", "runtime-result"]) {
 				assert.equal(fs.existsSync(path.join(roots.resultsDir, `${runId}.json`)), true, runId);
@@ -501,6 +491,63 @@ describe("async retention cleanup", () => {
 			assert.equal(result.skipped.recent, 1);
 			assert.equal(result.skipped["unknown-age"], 3);
 			assert.equal(result.skipped["runtime-reference"], 1);
+		} finally {
+			fs.rmSync(roots.root, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the cursor unchanged for failed, malformed, and cancelled workers", async () => {
+		const roots = makeRoots();
+		try {
+			const cursorPath = path.join(roots.root, ".async-retention-cursor.json");
+			const cursorBytes = '{"version":1,"runAfter":"keep-me"}\n';
+			fs.writeFileSync(cursorPath, cursorBytes);
+			const malformedWorker = path.join(roots.root, "malformed-worker.mjs");
+			fs.writeFileSync(malformedWorker, 'import { parentPort } from "node:worker_threads"; parentPort.on("message", () => parentPort.postMessage({ type: "result", passId: "stale" }));');
+
+			const malformed = await cleanupAsyncRetention({ ...cleanupOptions(roots), discoveryWorkerUrl: pathToFileURL(malformedWorker) });
+
+			assert.equal(malformed.workerFailed, true);
+			assert.equal(malformed.skipped["worker-failure"], 1);
+			assert.equal(fs.readFileSync(cursorPath, "utf-8"), cursorBytes);
+
+			const failedWorker = path.join(roots.root, "failed-worker.mjs");
+			fs.writeFileSync(failedWorker, 'throw new Error("worker crash");');
+			const failed = await cleanupAsyncRetention({ ...cleanupOptions(roots), discoveryWorkerUrl: pathToFileURL(failedWorker) });
+			assert.equal(failed.workerFailed, true);
+			assert.match(failed.errors[0] ?? "", /worker crash/);
+			assert.equal(fs.readFileSync(cursorPath, "utf-8"), cursorBytes);
+
+			const hangingWorker = path.join(roots.root, "hanging-worker.mjs");
+			fs.writeFileSync(hangingWorker, 'import { parentPort } from "node:worker_threads"; parentPort.on("message", () => {});');
+			const abort = new AbortController();
+			const pending = cleanupAsyncRetention({ ...cleanupOptions(roots), discoveryWorkerUrl: pathToFileURL(hangingWorker), signal: abort.signal });
+			setImmediate(() => abort.abort());
+			const cancelled = await pending;
+
+			assert.equal(cancelled.cancelled, true);
+			assert.equal(cancelled.skipped.cancelled, 1);
+			assert.equal(fs.readFileSync(cursorPath, "utf-8"), cursorBytes);
+			assert.equal(fs.existsSync(path.join(roots.root, ".async-retention.lock")), false);
+		} finally {
+			fs.rmSync(roots.root, { recursive: true, force: true });
+		}
+	});
+
+	it("yields the extension event loop during full directory discovery", async () => {
+		const roots = makeRoots();
+		try {
+			for (let index = 0; index < 2_000; index += 1) fs.mkdirSync(path.join(roots.asyncDirRoot, `run-${index}`));
+			let yielded = false;
+			setImmediate(() => { yielded = true; });
+
+			const result = await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 2 });
+
+			assert.equal(yielded, true);
+			assert.ok(result.rawReads >= 2_000);
+			assert.equal(result.sourceExhausted.runs, true);
+			assert.equal(typeof result.discoveryDurationMs, "number");
+			assert.equal(typeof result.commitDurationMs, "number");
 		} finally {
 			fs.rmSync(roots.root, { recursive: true, force: true });
 		}

--- a/test/unit/async-retention.test.ts
+++ b/test/unit/async-retention.test.ts
@@ -534,6 +534,30 @@ describe("async retention cleanup", () => {
 		}
 	});
 
+	it("advances past a candidate with a read error when no mutation started", async () => {
+		const roots = makeRoots();
+		try {
+			const unreadable = writeOldRun(roots.asyncDirRoot, "aaa-unreadable");
+			const victim = writeOldRun(roots.asyncDirRoot, "zzz-victim");
+			const realLstatSync = fs.lstatSync;
+			const lstatSync = ((filePath: fs.PathLike, options?: Parameters<typeof fs.lstatSync>[1]) => {
+				if (path.resolve(String(filePath)) === path.resolve(unreadable)) throw Object.assign(new Error("read failed"), { code: "EIO" });
+				return realLstatSync(filePath, options);
+			}) as typeof fs.lstatSync;
+
+			const first = await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 2, lstatSync });
+			assert.deepEqual(first.errors, ["read failed"]);
+			assert.equal(first.skipped["commit-failure"], undefined);
+			assert.equal(fs.existsSync(victim), true);
+
+			const second = await cleanupAsyncRetention({ ...cleanupOptions(roots), batchSize: 2, lstatSync });
+			assert.equal(second.deletedRuns, 1);
+			assert.equal(fs.existsSync(victim), false);
+		} finally {
+			fs.rmSync(roots.root, { recursive: true, force: true });
+		}
+	});
+
 	it("yields the extension event loop during full directory discovery", async () => {
 		const roots = makeRoots();
 		try {

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -47,6 +47,8 @@ test("published extension APIs use supported package entrypoints", async () => {
 
 	assert.deepEqual(packageJson.pi?.extensions, ["./index.ts"]);
 	assert.equal(packageJson.files?.includes("index.ts"), true);
+	assert.equal(packageJson.files?.includes("*.mjs"), true);
+	assert.equal(fs.existsSync(path.join(projectRoot, "async-retention-discovery-worker.mjs")), true);
 	assert.equal(
 		fs.readFileSync(path.join(projectRoot, "index.ts"), "utf-8").trim(),
 		'export { default } from "./src/extension/index.ts";',


### PR DESCRIPTION
## Summary
- move async retention candidate discovery into a packaged read-only worker
- keep retention lock ownership, destructive mutations, safety rechecks, and cursor commits on the extension thread
- add worker failure, malformed response, cancellation, cursor byte-preservation, responsiveness, and package-manifest coverage

Closes #1188.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/async-retention.test.ts test/unit/package-manifest.test.ts`
- `npm run typecheck`
- `node --check async-retention-discovery-worker.mjs`
- `npm pack --dry-run --json` confirms `async-retention-discovery-worker.mjs` is included
- `git diff --check`
- fresh read-only review: no blockers

## Performance
This is intended as a responsiveness improvement. Retention source directory EOF scans move off the extension event loop. The bounded commit and active wait-subscription safety scans remain on the extension thread by design.
