### PR TITLE
feat: add external job runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Add stable-key `runs.steer` to `workflowScript`, with foreground and async transport routing, structured receipts, trace entries, and unawaited-call enforcement (#1186).
 - Document and cover rolling `workflowScript` fanout with `runs.run`, `Promise.race`, `runs.steer`, and `Promise.all` instead of adding separate child-run event helpers (#1187).
+- Add `runner.type: external-job` with the exported provider bridge, Surf GPT Pro `gpt-pro` profile, and docs for external advisor data boundaries (#1189).
 - Add `defaultSubagentContext: "fork"` to prefer forked context for all launches that omit an explicit context (#1161).
 - Allow `defaultSubagentContext: "fresh"` to override agent fork defaults for launches that omit an explicit context.
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.

--- a/agents/gpt-pro.md
+++ b/agents/gpt-pro.md
@@ -1,0 +1,17 @@
+---
+name: gpt-pro
+description: Surf GPT Pro advisory runner through the external-job provider bridge
+runner:
+  type: external-job
+  provider: surf-oracle
+async: true
+systemPromptMode: replace
+inheritProjectContext: false
+inheritSkills: false
+---
+
+You are a read-only GPT Pro advisor reached through Surf Oracle.
+
+Review the supplied task and context.
+Return clear advice, risks, and recommended next steps.
+Do not claim you edited files or ran local tools.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -41,11 +41,44 @@ Builtins load at the lowest priority, so a user or project agent with the same n
 | `worker` | Implementation work, including approved oracle handoffs. It edits files, validates, and escalates unapproved decisions instead of guessing. |
 | `reviewer` | Code review and small fixes. It checks the implementation against the task/plan, tests, edge cases, and simplicity. |
 | `oracle` | A second opinion before acting. It challenges assumptions, catches drift, and recommends the safest next move without editing. |
+| `gpt-pro` | Read-only Surf GPT Pro advice through the `surf-oracle` external-job provider bridge. |
 | `delegate` | A lightweight general delegate when you want a child agent that behaves close to the parent session. |
 
 Rule of thumb: `scout` before you understand the code, `researcher` before you trust external facts, `worker` to implement, `reviewer` to check, and `oracle` when the decision itself feels risky.
 
 `oracle` is an advisory reviewer that critiques direction and proposes an execution prompt without editing files. `advisor` is the same bundled role under the Claude Code-compatible name.
+
+`gpt-pro` uses `runner.type: external-job` with provider `surf-oracle`. It starts through the same `subagent({ agent: "gpt-pro" })` mental model as any other agent, but the work is owned by Surf through the external-job provider bridge. The Pi async run remains the source of truth for status, artifacts, wake/wait, mission attachment, retention, and diagnostics.
+
+Claude Code can be configured as a read-only advisor with `runner.type: external-cli` when the Claude Code CLI is installed and you have verified the flags for your local version. pi-subagents does not ship or enforce Claude Code flags. Use a project or user agent like this only after checking your CLI help:
+
+```yaml
+---
+name: claude-advisor
+description: Read-only Claude Code advisor through the local CLI
+runner:
+  type: external-cli
+  command: claude
+  args: ["<verified-read-only-flags>"]
+  promptDelivery: stdin
+async: true
+---
+
+Review the task and return advice only. Do not edit files.
+```
+
+### Advisory runner data boundary
+
+Native `oracle` runs inside Pi and can use its configured read tools. `claude-advisor` sends the assembled prompt to the configured local external CLI through stdin. `gpt-pro` sends the assembled prompt to the registered Surf provider. Provider options and a prompt digest are persisted in Pi run state. The prompt text is delivered through the local host bridge to the provider and is not stored in the public result payload. Do not place secrets in advisory prompts unless the target provider is approved to receive them.
+
+### External-job state table
+
+| Durable file | Owner | States | Release predicate | Rollback predicate | Stale-head behavior | Fail-closed cases |
+|--------------|-------|--------|-------------------|--------------------|---------------------|-------------------|
+| `status.json` step `runner` and `externalJob` | pi-subagents async runner | `queued`, `running`, `completed`, `failed`, `stopped`, `blocked` | Provider `result` returns terminal data and the async result is written | Provider start/status/result/reattach returns an error | If a status file already has a provider job id, recovery calls `reattach` and `result`; it refuses to start a new prompt when the provider or prompt digest differs | Missing provider, capacity conflict, malformed provider response, bridge timeout, prompt digest mismatch |
+| `result.json` or session result payload | pi-subagents async runner | `complete`, `failed`, `stopped` | All steps reach terminal state and result publication succeeds or is recoverably indexed | Result write fails and pending result repair records the terminal state | Stale status can repair from an existing result file | Unindexed sessionless stale failure |
+| `external-job-requests/` and `external-job-responses/` | Host-mediated provider bridge | pending request, terminal response | Host process writes a matching response and removes the request | Bridge timeout or malformed request response | Requests are operation-scoped. Recovery sends `reattach`/`result`, not `start`, when job metadata exists | Provider not registered, host bridge not loaded, malformed request, provider exception |
+| Provider artifact path | External provider | provider-defined terminal artifact | Provider returns `artifactPath`, or Pi writes returned text to `external-job-<index>.result.md` | Provider reports failure or no result | Existing artifact path is retained in `status.json` | Missing artifact with no text output returns a terminal message instead of inventing content |
 
 The `researcher` builtin uses `web_search`, `fetch_content`, and `get_search_content`. Those require [pi-web-access](https://github.com/nicobailon/pi-web-access):
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -263,6 +263,26 @@ Semantics:
 
 Child processes do not gain provider tools or extensions automatically. Add `subagent_wait` to the child agent's `tools` allowlist and load each provider through `extensions` or `subagentOnlyExtensions`. The parent's effective `waitTool` setting is serialized through foreground, async, resume, chain, parallel, and fanout launch paths; `PI_SUBAGENT_WAIT_TOOL_ENABLED` keeps precedence.
 
+## External job provider bridge
+
+Extensions that own long-running advisor jobs can register a process-local provider for `runner.type: external-job` agents:
+
+```ts
+import { registerExternalJobProvider } from "pi-subagents/external-job-provider";
+
+const dispose = registerExternalJobProvider({
+  name: "surf-oracle",
+  start: ({ prompt, promptDigest, cwd, runId, stepIndex, agent, options }) => startSurfJob({ prompt, promptDigest, cwd, runId, stepIndex, agent, options }),
+  status: (providerJobId) => getSurfJobStatus(providerJobId),
+  result: (providerJobId) => getSurfJobResult(providerJobId),
+  reattach: (providerJobId) => reattachSurfJob(providerJobId),
+});
+```
+
+The provider returns handles with `providerJobId`, `state`, optional `handleUrl`/`conversationUrl`, optional `failureCode`/`failureMessage`, and optional `blockingJobId` for capacity conflicts. `result` can also return `output` and/or `artifactPath`.
+
+The async runner process does not import provider internals. It writes operation requests into its async run directory. The parent Pi process services those requests against the registered provider and writes operation responses. If the provider is not registered, the bridge fails closed with an actionable error. If a run is recovered after provider job metadata exists, the runner calls `reattach` and `result`; it does not call `start` again.
+
 ## Herdr integration
 
 When Pi runs inside [Herdr](https://herdr.dev), pi-subagents automatically reports active async-run counts through Herdr pane metadata.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -328,7 +328,7 @@ Every foreground or background child keeps running through its normal native Pi 
 
 The observer supports macOS and Linux and is disabled on Windows. It requires executable `orca` on `PATH` (or `PI_SUBAGENT_ORCA_BINARY`) and a running Orca runtime that recognizes the child cwd. Availability and tab creation are best-effort: failures never fail, stop, or delay the subagent. Set `orcaProgressTabs.enabled` to `false` to guarantee that no Orca command or tab is created.
 
-Agent profile `runner.type` remains unchanged: supported values are native Pi (the default) and `external-cli`. Orca is intentionally not a profile runner and does not own subagent execution, completion, cancellation, artifacts, or result delivery.
+Agent profile `runner.type` supports native Pi (the default), `external-cli`, and `external-job`. Orca is intentionally not a profile runner and does not own subagent execution, completion, cancellation, artifacts, or result delivery.
 
 ## External CLI agent profiles
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./index.ts",
     "./background-work": "./src/api/background-work.ts",
+    "./external-job-provider": "./src/api/external-job-provider.ts",
     "./external-runs": "./src/api/external-runs.ts",
     "./delegation": "./src/api/delegation.ts",
     "./capability-ceiling": "./src/api/capability-ceiling.ts",

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -26,6 +26,14 @@ An agent may set `runner.type: external-cli` with a non-empty `command`, optiona
 
 External CLI profiles are async-only and one-shot. They support lifecycle artifacts, stdout/stderr logs, timeout, and stop. Full stdout and stderr are retained in their log files, while the final stdout response and stderr error kept in memory are each limited to their last 64 KiB. They do not support foreground/clarify, steer/resume/interrupt-as-pause, Pi models/tools/extensions/skills, tool or turn budgets, structured output, nested subagents, fallbacks, or sessions.
 
+### External job profiles
+
+An agent may set `runner.type: external-job` with a non-empty `provider` and optional JSON `options`. The bundled `gpt-pro` agent uses provider `surf-oracle`. The provider must be registered in the host Pi process through `pi-subagents/external-job-provider`; the async runner talks to that parent-owned registry through a local operation bridge.
+
+External job profiles are async-only. The provider owns the remote job and Pi owns the async run record. Status persists provider name, provider job id, prompt digest, provider options, handle/conversation URLs when supplied, result artifact path, last known state, and provider failure code/message. Recovery uses existing provider job metadata to call `reattach` and `result`; it refuses to redispatch a prompt when the persisted provider job does not match the prompt digest.
+
+External job profiles do not support foreground/clarify, steer/resume, Pi models/tools/extensions/skills, tool or turn budgets, structured output, native child permissions, fallbacks, or Pi child sessions. Capacity conflicts fail closed and include the blocking provider job id when the provider supplies it.
+
 ### Single agent
 
 ```typescript

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -72,6 +72,14 @@ function hasKey(obj: Record<string, unknown>, key: string): boolean {
 	return Object.prototype.hasOwnProperty.call(obj, key);
 }
 
+function isJsonSerializable(value: unknown): boolean {
+	if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+	if (typeof value === "number") return Number.isFinite(value);
+	if (Array.isArray(value)) return value.every(isJsonSerializable);
+	if (value && typeof value === "object") return Object.values(value).every(isJsonSerializable);
+	return false;
+}
+
 function asDisambiguationScope(scope: unknown): ManagementScope | undefined {
 	if (scope === "user" || scope === "project") return scope;
 	return undefined;
@@ -332,7 +340,11 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 				&& Object.keys(runner).every((key) => ["type", "command", "args", "promptDelivery"].includes(key))) {
 				const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
 				target.runner = { type: "external-cli", command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
-			} else return "config.runner must be { type: 'pi' } or { type: 'external-cli', command: string, args?: string[], promptDelivery?: 'stdin' }.";
+			} else if (runner.type === "external-job" && typeof runner.provider === "string" && runner.provider.trim() === runner.provider && runner.provider
+				&& (runner.options === undefined || (runner.options && typeof runner.options === "object" && !Array.isArray(runner.options) && isJsonSerializable(runner.options)))
+				&& Object.keys(runner).every((key) => ["type", "provider", "options"].includes(key))) {
+				target.runner = { type: "external-job", provider: runner.provider, ...(runner.options ? { options: runner.options as Record<string, unknown> } : {}) };
+			} else return "config.runner must be { type: 'pi' }, { type: 'external-cli', command: string, args?: string[], promptDelivery?: 'stdin' }, or { type: 'external-job', provider: string, options?: object }.";
 		} else return "config.runner must be an object, false, or empty string when provided.";
 	}
 	if (hasKey(cfg, "model")) {
@@ -492,7 +504,7 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 			target.toolBudget = cfg.toolBudget as ToolBudgetConfig;
 		}
 	}
-	if (target.runner?.type === "external-cli") {
+	if (target.runner?.type === "external-cli" || target.runner?.type === "external-job") {
 		const unsupported = [
 			target.tools?.length || target.mcpDirectTools?.length ? "tools" : undefined,
 			target.model ? "model" : undefined,
@@ -505,7 +517,7 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 			target.completionGuard !== undefined ? "completionGuard" : undefined,
 			target.toolBudget ? "toolBudget" : undefined,
 		].filter((field): field is string => Boolean(field));
-		if (unsupported.length > 0) return `config.runner type 'external-cli' does not support Pi-only fields: ${unsupported.join(", ")}.`;
+		if (unsupported.length > 0) return `config.runner type '${target.runner.type}' does not support Pi-only fields: ${unsupported.join(", ")}.`;
 	}
 	return undefined;
 }

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -38,6 +38,7 @@ export interface AgentMemoryConfig {
 export const BUILTIN_AGENT_NAMES = [
 	"advisor",
 	"delegate",
+	"gpt-pro",
 	"oracle",
 	"researcher",
 	"reviewer",
@@ -1448,6 +1449,14 @@ function isLegacyAgentSkillPath(rootDir: string, filePath: string): boolean {
 	return parts.some((part, index) => part === ".agents" && parts[index + 1] === "skills");
 }
 
+function isJsonSerializable(value: unknown): boolean {
+	if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+	if (typeof value === "number") return Number.isFinite(value);
+	if (Array.isArray(value)) return value.every(isJsonSerializable);
+	if (value && typeof value === "object") return Object.values(value).every(isJsonSerializable);
+	return false;
+}
+
 function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string): AgentRunnerConfig | undefined {
 	if (raw === undefined || !raw.trim()) return undefined;
 	let parsed: unknown;
@@ -1464,8 +1473,24 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 		if (Object.keys(runner).some((key) => key !== "type")) throw new Error(`Agent '${agentName}' has invalid Pi runner frontmatter; only 'type' is supported.`);
 		return { type: "pi" };
 	}
+	if (runner.type === "external-job") {
+		if (typeof runner.provider !== "string" || !runner.provider.trim() || runner.provider.trim() !== runner.provider) {
+			throw new Error(`Agent '${agentName}' external-job runner requires a non-empty trimmed provider string.`);
+		}
+		if (runner.options !== undefined && (!runner.options || typeof runner.options !== "object" || Array.isArray(runner.options) || !isJsonSerializable(runner.options))) {
+			throw new Error(`Agent '${agentName}' external-job runner options must be a JSON-serializable object.`);
+		}
+		const supported = new Set(["type", "provider", "options"]);
+		const unknown = Object.keys(runner).filter((key) => !supported.has(key));
+		if (unknown.length > 0) throw new Error(`Agent '${agentName}' external-job runner has unsupported fields: ${unknown.join(", ")}.`);
+		return {
+			type: "external-job",
+			provider: runner.provider,
+			...(runner.options ? { options: runner.options as Record<string, unknown> } : {}),
+		};
+	}
 	if (runner.type !== "external-cli") {
-		throw new Error(`Agent '${agentName}' has invalid runner.type; expected 'pi' or 'external-cli'.`);
+		throw new Error(`Agent '${agentName}' has invalid runner.type; expected 'pi', 'external-cli', or 'external-job'.`);
 	}
 	if (typeof runner.command !== "string" || !runner.command.trim()) {
 		throw new Error(`Agent '${agentName}' external-cli runner requires a non-empty command string.`);
@@ -1489,11 +1514,11 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 }
 
 function validateExternalRunnerProfile(frontmatter: Record<string, string>, agentName: string, runner: AgentRunnerConfig | undefined): void {
-	if (runner?.type !== "external-cli") return;
+	if (runner?.type !== "external-cli" && runner?.type !== "external-job") return;
 	const unsupported = ["tools", "model", "fallbackModels", "thinking", "extensions", "subagentOnlyExtensions", "maxSubagentDepth", "completionGuard", "skills", "skill", "skillPath", "toolBudget", "permission", "permissions"]
 		.filter((field) => frontmatter[field] !== undefined);
 	if (unsupported.length > 0) {
-		throw new Error(`Agent '${agentName}' uses runner.type='external-cli' and declares unsupported Pi-only fields: ${unsupported.join(", ")}.`);
+		throw new Error(`Agent '${agentName}' uses runner.type='${runner.type}' and declares unsupported Pi-only fields: ${unsupported.join(", ")}.`);
 	}
 }
 

--- a/src/api/external-job-provider.ts
+++ b/src/api/external-job-provider.ts
@@ -1,0 +1,180 @@
+export const EXTERNAL_JOB_PROVIDER_PROTOCOL_VERSION = 1;
+export const EXTERNAL_JOB_PROVIDER_REGISTRY_KEY = "pi-subagents.external-job-providers.v1";
+
+const MAX_PROVIDER_NAME_LENGTH = 128;
+const MAX_PROVIDERS = 100;
+const MAX_JOB_ID_LENGTH = 256;
+const MAX_FAILURE_CODE_LENGTH = 128;
+const MAX_FAILURE_MESSAGE_LENGTH = 4_096;
+const MAX_URL_LENGTH = 4_096;
+
+export type ExternalJobState = "queued" | "running" | "completed" | "failed" | "stopped" | "blocked";
+export type ExternalJobOperation = "start" | "status" | "result" | "reattach";
+
+export type ExternalJobOptions = Record<string, unknown>;
+
+export interface ExternalJobStartInput {
+	prompt: string;
+	promptDigest: string;
+	cwd: string;
+	runId: string;
+	stepIndex: number;
+	agent: string;
+	options: ExternalJobOptions;
+	sessionId?: string;
+}
+
+export interface ExternalJobHandle {
+	providerJobId: string;
+	state: ExternalJobState;
+	handleUrl?: string;
+	conversationUrl?: string;
+	failureCode?: string;
+	failureMessage?: string;
+	blockingJobId?: string;
+}
+
+export interface ExternalJobResult extends ExternalJobHandle {
+	output?: string;
+	artifactPath?: string;
+}
+
+export interface ExternalJobProvider {
+	name: string;
+	start(input: ExternalJobStartInput): Promise<ExternalJobHandle> | ExternalJobHandle;
+	status(providerJobId: string): Promise<ExternalJobHandle> | ExternalJobHandle;
+	result(providerJobId: string): Promise<ExternalJobResult> | ExternalJobResult;
+	reattach(providerJobId: string): Promise<ExternalJobHandle> | ExternalJobHandle;
+}
+
+export class ExternalJobProviderError extends Error {
+	readonly code: string;
+	readonly blockingJobId?: string;
+
+	constructor(message: string, options: { code: string; blockingJobId?: string; cause?: unknown }) {
+		super(message, options.cause === undefined ? undefined : { cause: options.cause });
+		this.name = "ExternalJobProviderError";
+		this.code = options.code;
+		this.blockingJobId = options.blockingJobId;
+	}
+}
+
+interface ExternalJobProviderRegistry {
+	version: typeof EXTERNAL_JOB_PROVIDER_PROTOCOL_VERSION;
+	providers: Map<string, ExternalJobProvider>;
+}
+
+function registry(): ExternalJobProviderRegistry {
+	const key = Symbol.for(EXTERNAL_JOB_PROVIDER_REGISTRY_KEY);
+	const globalObject = globalThis as Record<PropertyKey, unknown>;
+	const existing = globalObject[key];
+	if (existing === undefined) {
+		const created: ExternalJobProviderRegistry = {
+			version: EXTERNAL_JOB_PROVIDER_PROTOCOL_VERSION,
+			providers: new Map(),
+		};
+		globalObject[key] = created;
+		return created;
+	}
+	if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+		throw new Error(`Malformed external-job provider registry at Symbol.for("${EXTERNAL_JOB_PROVIDER_REGISTRY_KEY}").`);
+	}
+	const candidate = existing as Partial<ExternalJobProviderRegistry>;
+	if (candidate.version !== EXTERNAL_JOB_PROVIDER_PROTOCOL_VERSION || !(candidate.providers instanceof Map)) {
+		throw new Error(`Unsupported external-job provider registry at Symbol.for("${EXTERNAL_JOB_PROVIDER_REGISTRY_KEY}").`);
+	}
+	return candidate as ExternalJobProviderRegistry;
+}
+
+function validateString(value: unknown, field: string, maxLength: number): string {
+	if (typeof value !== "string" || value.length === 0 || value.trim() !== value) {
+		throw new Error(`${field} must be a non-empty string without leading or trailing whitespace.`);
+	}
+	if (value.length > maxLength) throw new Error(`${field} must be at most ${maxLength} characters.`);
+	if (value.includes("\0")) throw new Error(`${field} must not contain NUL characters.`);
+	return value;
+}
+
+function validateOptionalString(value: unknown, field: string, maxLength: number): string | undefined {
+	if (value === undefined) return undefined;
+	return validateString(value, field, maxLength);
+}
+
+function validateState(value: unknown, field: string): ExternalJobState {
+	if (value === "queued" || value === "running" || value === "completed" || value === "failed" || value === "stopped" || value === "blocked") return value;
+	throw new Error(`${field} must be queued, running, completed, failed, stopped, or blocked.`);
+}
+
+function validateHandle(provider: string, value: unknown, field: string, extraFields: readonly string[] = []): ExternalJobHandle {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${field} from external-job provider '${provider}' must be an object.`);
+	const handle = value as Record<string, unknown>;
+	const supported = new Set(["providerJobId", "state", "handleUrl", "conversationUrl", "failureCode", "failureMessage", "blockingJobId", ...extraFields]);
+	const unknown = Object.keys(handle).filter((key) => !supported.has(key));
+	if (unknown.length > 0) throw new Error(`${field} from external-job provider '${provider}' has unknown fields: ${unknown.join(", ")}.`);
+	return {
+		providerJobId: validateString(handle.providerJobId, `${field}.providerJobId`, MAX_JOB_ID_LENGTH),
+		state: validateState(handle.state, `${field}.state`),
+		...(validateOptionalString(handle.handleUrl, `${field}.handleUrl`, MAX_URL_LENGTH) ? { handleUrl: validateOptionalString(handle.handleUrl, `${field}.handleUrl`, MAX_URL_LENGTH) } : {}),
+		...(validateOptionalString(handle.conversationUrl, `${field}.conversationUrl`, MAX_URL_LENGTH) ? { conversationUrl: validateOptionalString(handle.conversationUrl, `${field}.conversationUrl`, MAX_URL_LENGTH) } : {}),
+		...(validateOptionalString(handle.failureCode, `${field}.failureCode`, MAX_FAILURE_CODE_LENGTH) ? { failureCode: validateOptionalString(handle.failureCode, `${field}.failureCode`, MAX_FAILURE_CODE_LENGTH) } : {}),
+		...(validateOptionalString(handle.failureMessage, `${field}.failureMessage`, MAX_FAILURE_MESSAGE_LENGTH) ? { failureMessage: validateOptionalString(handle.failureMessage, `${field}.failureMessage`, MAX_FAILURE_MESSAGE_LENGTH) } : {}),
+		...(validateOptionalString(handle.blockingJobId, `${field}.blockingJobId`, MAX_JOB_ID_LENGTH) ? { blockingJobId: validateOptionalString(handle.blockingJobId, `${field}.blockingJobId`, MAX_JOB_ID_LENGTH) } : {}),
+	};
+}
+
+export function validateExternalJobHandle(provider: string, value: unknown, field = "External-job handle"): ExternalJobHandle {
+	return validateHandle(provider, value, field);
+}
+
+export function validateExternalJobResult(provider: string, value: unknown, field = "External-job result"): ExternalJobResult {
+	const result = validateHandle(provider, value, field, ["output", "artifactPath"]) as ExternalJobResult;
+	const record = value as Record<string, unknown>;
+	const output = validateOptionalString(record.output, `${field}.output`, 1024 * 1024);
+	const artifactPath = validateOptionalString(record.artifactPath, `${field}.artifactPath`, MAX_URL_LENGTH);
+	return {
+		...result,
+		...(output !== undefined ? { output } : {}),
+		...(artifactPath !== undefined ? { artifactPath } : {}),
+	};
+}
+
+function validateProvider(value: unknown): ExternalJobProvider {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("External-job provider must be an object.");
+	const provider = value as Record<string, unknown>;
+	const unknownFields = Object.keys(provider).filter((key) => !["name", "start", "status", "result", "reattach"].includes(key));
+	if (unknownFields.length > 0) throw new Error(`External-job provider has unknown fields: ${unknownFields.join(", ")}.`);
+	const name = validateString(provider.name, "External-job provider name", MAX_PROVIDER_NAME_LENGTH);
+	for (const op of ["start", "status", "result", "reattach"] as const) {
+		if (typeof provider[op] !== "function") throw new Error(`External-job provider '${name}' must expose ${op}().`);
+	}
+	return value as ExternalJobProvider;
+}
+
+export function registerExternalJobProvider(provider: ExternalJobProvider): () => void {
+	const validated = validateProvider(provider);
+	const current = registry();
+	if (!current.providers.has(validated.name) && current.providers.size >= MAX_PROVIDERS) {
+		throw new Error(`External-job provider registry supports at most ${MAX_PROVIDERS} providers.`);
+	}
+	current.providers.set(validated.name, validated);
+	return () => {
+		if (current.providers.get(validated.name) === validated) current.providers.delete(validated.name);
+	};
+}
+
+export function listExternalJobProviders(): readonly ExternalJobProvider[] {
+	const current = registry();
+	if (current.providers.size > MAX_PROVIDERS) throw new Error(`External-job provider registry contains more than ${MAX_PROVIDERS} providers.`);
+	const providers: ExternalJobProvider[] = [];
+	for (const [key, value] of current.providers) {
+		const provider = validateProvider(value);
+		if (key !== provider.name) throw new Error(`External-job provider registry key '${key}' does not match provider name '${provider.name}'.`);
+		providers.push(provider);
+	}
+	return providers;
+}
+
+export function getExternalJobProvider(name: string): ExternalJobProvider | undefined {
+	const safeName = validateString(name, "External-job provider name", MAX_PROVIDER_NAME_LENGTH);
+	return listExternalJobProviders().find((provider) => provider.name === safeName);
+}

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -277,7 +277,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 	}
 	if (resolvedSkills.missing.length > 0) diagnostics.push({ code: "missing_skill", severity: "error", message: `Missing skills: ${resolvedSkills.missing.join(", ")}` });
 
-	const externalRunner = agent.runner?.type === "external-cli";
+	const externalRunner = agent.runner?.type === "external-cli" || agent.runner?.type === "external-job";
 	const availableModels = normalizeAvailableModels(input.availableModels);
 	const preferredProvider = input.preferredProvider ?? input.parentModel?.provider;
 	const primaryModel = externalRunner

--- a/src/api/shared-types.ts
+++ b/src/api/shared-types.ts
@@ -9,6 +9,8 @@ export {
 	type ControlEvent,
 	type Details,
 	type ExecutionProjection,
+	type ExternalJobRunnerStatus,
+	type ExternalJobStatus,
 	type JsonSchemaObject,
 	type OutputMode,
 	type ReviewProjection,

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -713,7 +713,8 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 	};
 	const buildSeqStep = (s: SequentialStep, sessionFile?: string, behaviorCwd?: string, progressPrecreated = false, resolvedBehavior?: ResolvedStepBehavior, flatIndex?: number, parallelOutputNamespace?: { stepIndex: number; taskIndex?: number }, runFanoutPath?: string) => {
 		const a = agents.find((x) => x.name === s.agent)!;
-		const externalRunner = a.runner?.type === "external-cli";
+		const externalRunner = a.runner?.type === "external-cli" || a.runner?.type === "external-job";
+		const externalRunnerType = a.runner?.type;
 		if (externalRunner) {
 			const unsupported: string[] = [];
 			if (s.model !== undefined) unsupported.push("model override");
@@ -721,7 +722,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			if (s.acceptance !== undefined || params.agentContract !== undefined || s.agentContract !== undefined) unsupported.push("acceptance/agent contract");
 			if (s.toolBudget !== undefined || params.toolBudget !== undefined || a.toolBudget !== undefined || params.configToolBudget !== undefined) unsupported.push("tool budget");
 			if (params.contextForAgent?.(s.agent) === "fork") unsupported.push("fork context");
-			if (unsupported.length > 0) throw new AsyncStartValidationError(`Agent '${a.name}' uses runner.type='external-cli' and does not support: ${unsupported.join(", ")}.`);
+			if (unsupported.length > 0) throw new AsyncStartValidationError(`Agent '${a.name}' uses runner.type='${externalRunnerType}' and does not support: ${unsupported.join(", ")}.`);
 		}
 		try {
 			assertAgentAllowedByCapabilityCeiling(a.name, intersectSubagentCapabilityCeilings(params.capabilityCeiling, decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV])));
@@ -812,7 +813,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		const launchResolvedExtensions = externalRunner ? undefined : projectLaunchResolvedChildExtensions(toolPlan);
 		const permissionRules = resolvePermissionRules(ctx.permissions, a.permissions);
 		if (externalRunner && permissionRules) {
-			throw new AsyncStartValidationError(`Agent '${a.name}' uses runner.type='external-cli', which cannot enforce native Pi child permission rules.`);
+			throw new AsyncStartValidationError(`Agent '${a.name}' uses runner.type='${externalRunnerType}', which cannot enforce native Pi child permission rules.`);
 		}
 		return {
 			parentSessionId: ctx.parentSessionId ?? ctx.currentSessionId,
@@ -1326,7 +1327,8 @@ export function executeAsyncSingle(
 	const task = params.task ?? "";
 	const acceptanceErrors = validateAcceptanceInput(params.acceptance);
 	if (acceptanceErrors.length > 0) return formatAsyncStartError("single", acceptanceErrors.join(" "));
-	const externalRunner = agentConfig.runner?.type === "external-cli";
+	const externalRunner = agentConfig.runner?.type === "external-cli" || agentConfig.runner?.type === "external-job";
+	const externalRunnerType = agentConfig.runner?.type;
 	const permissionRules = resolvePermissionRules(ctx.permissions, agentConfig.permissions);
 	if (externalRunner) {
 		const unsupported: string[] = [];
@@ -1338,7 +1340,7 @@ export function executeAsyncSingle(
 		if (params.context === "fork") unsupported.push("fork context");
 		if ((params.skills?.length ?? 0) > 0) unsupported.push("skills");
 		if (permissionRules) unsupported.push("native Pi child permissions");
-		if (unsupported.length > 0) return formatAsyncStartError("single", `Agent '${agentConfig.name}' uses runner.type='external-cli' and does not support: ${unsupported.join(", ")}.`);
+		if (unsupported.length > 0) return formatAsyncStartError("single", `Agent '${agentConfig.name}' uses runner.type='${externalRunnerType}' and does not support: ${unsupported.join(", ")}.`);
 	}
 	const capabilityCeiling = intersectSubagentCapabilityCeilings(params.capabilityCeiling ?? resolveCurrentSubagentCapabilityCeiling(ctx.currentSessionId), decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]));
 	try {

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -20,6 +20,7 @@ import { normalizeParallelGroups } from "./parallel-groups.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
 import { findNestedRouteForRootId, hasLiveNestedDescendants, updateAsyncJobNestedProjection } from "../shared/nested-events.ts";
 import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
+import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, serviceExternalJobBridgeRequests } from "../shared/external-job-bridge.ts";
 
 interface AsyncJobTrackerOptions {
 	completionRetentionMs?: number;
@@ -327,6 +328,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		};
 		try {
 			emitNewControlEvents(job);
+			serviceExternalJobBridgeRequests(job.asyncDir);
 			try {
 				if (job.nestedRoute) reconcileNestedAsyncDescendants(job.nestedRoute, { resultsDir, kill: options.kill, now: options.now });
 			} catch (error) {
@@ -453,7 +455,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 					const rawFileName = file?.toString();
 					const fileName = rawFileName ?? path.basename(watchPath);
 					const nestedEventFile = nestedEventSink && (!rawFileName || rawFileName.endsWith(".json") || rawFileName.endsWith(".jsonl"));
-					if (fileName === "status.json" || fileName === "events.jsonl" || nestedEventFile) {
+					if (fileName === "status.json" || fileName === "events.jsonl" || fileName === EXTERNAL_JOB_BRIDGE_REQUEST_DIR || fileName.endsWith(".json") || nestedEventFile) {
 						scheduleJobRefresh(job.asyncId);
 					}
 					if (watchPath !== job.asyncDir && !nestedEventSink) {
@@ -480,6 +482,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		const statusWatched = watchPath(statusPath);
 		if (statusWatched && !hadStatusWatcher) scheduleJobRefresh(job.asyncId);
 		watchPath(path.join(job.asyncDir, "events.jsonl"));
+		watchPath(path.join(job.asyncDir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR));
 		if (job.nestedRoute) watchPath(job.nestedRoute.eventSink);
 		if (!statusWatched && active && !watched.retryTimer) {
 			watched.retryTimer = setTimeout(() => {

--- a/src/runs/background/retained-children.ts
+++ b/src/runs/background/retained-children.ts
@@ -51,7 +51,7 @@ function retainedSessionFile(sessionFile: string | undefined): RetainedChildResu
 
 function childResumability(run: AsyncRunSummary, step: AsyncRunSummary["steps"][number]): RetainedChildResumability {
 	if (run.state === "stopped" || step.status === "stopped") return { state: "not-resumable", reason: "stopped run" };
-	if (step.runner?.type === "external-cli") return { state: "not-resumable", reason: "external CLI runner" };
+	if (step.runner?.type === "external-cli" || step.runner?.type === "external-job") return { state: "not-resumable", reason: "external runner" };
 	const session = retainedSessionFile(step.sessionFile ?? run.sessionFile);
 	if (session.state === "not-resumable") return session;
 	let recoveryDescriptor: ReturnType<typeof readAsyncRecoveryDescriptor>;

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -529,15 +529,21 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 					lines.push(`  Runner: external-cli (${step.runner.command}${step.runner.args.length ? ` ${step.runner.args.join(" ")}` : ""})`);
 					if (step.externalProcess?.pid !== undefined) lines.push(`  Process: ${step.externalProcess.pid}`);
 					if (step.externalProcess) lines.push(`  Stdout: ${step.externalProcess.stdoutPath}`, `  Stderr: ${step.externalProcess.stderrPath}`);
+				} else if (step.runner?.type === "external-job") {
+					lines.push(`  Runner: external-job (${step.runner.provider})`);
+					if (step.externalJob?.providerJobId) lines.push(`  Provider job: ${step.externalJob.providerJobId}`);
+					if (step.externalJob?.state) lines.push(`  Provider state: ${step.externalJob.state}`);
+					if (step.externalJob?.conversationUrl) lines.push(`  Conversation: ${step.externalJob.conversationUrl}`);
+					if (step.externalJob?.resultArtifactPath) lines.push(`  Result artifact: ${step.externalJob.resultArtifactPath}`);
 				}
 				lines.push(...formatNestedRunStatusLines(step.children, { indent: "  ", commandHints: true, maxLines: 20 }));
 				const stepOutputPath = path.join(asyncDir, `output-${index}.log`);
 				if (stepOutputPath !== outputPath && fs.existsSync(stepOutputPath)) lines.push(`  Output: ${stepOutputPath}`);
-				if (step.status === "running" && step.runner?.type !== "external-cli" && status.mode !== "workflow") {
+				if (step.status === "running" && step.runner?.type !== "external-cli" && step.runner?.type !== "external-job" && status.mode !== "workflow") {
 					lines.push(`  Intercom target: ${resolveSubagentIntercomTarget(status.runId, step.agent, index)} (if registered)`);
 					lines.push(`  Steer: subagent({ action: "steer", id: "${status.runId}", index: ${index}, message: "..." })`);
-				} else if (step.status === "running" && step.runner?.type === "external-cli") {
-					lines.push("  Steer: unavailable; one-shot external CLI runners do not accept live messages.");
+				} else if (step.status === "running" && (step.runner?.type === "external-cli" || step.runner?.type === "external-job")) {
+					lines.push("  Steer: unavailable; external runners do not accept live messages.");
 				}
 			}
 			const attached = new Set((status.steps ?? []).flatMap((step) => step.children?.map((child) => child.id) ?? []));
@@ -553,11 +559,11 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			}
 			if (nestedWarning) lines.push(`Warning: ${nestedWarning}`);
 			if (status.sessionFile) lines.push(`Session: ${status.sessionFile}`);
-			const allExternal = (status.steps?.length ?? 0) > 0 && status.steps!.every((step) => step.runner?.type === "external-cli");
+			const allExternal = (status.steps?.length ?? 0) > 0 && status.steps!.every((step) => step.runner?.type === "external-cli" || step.runner?.type === "external-job");
 			if (status.state === "running" && !allExternal && status.mode !== "workflow") lines.push(`Steer running child: subagent({ action: "steer", id: "${status.runId}", message: "..." })`);
 			if (status.state !== "running") {
 				lines.push(allExternal
-					? "Resume: unavailable; one-shot external CLI runners do not persist sessions."
+					? "Resume: unavailable; external runners do not persist Pi sessions."
 					: formatResumeGuidance(status.runId, status.steps ?? [], status.sessionFile, { stopped: status.state === "stopped" || status.stopped === true }));
 			}
 			if (fs.existsSync(logPath)) lines.push(`Log: ${logPath}`);

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -17,6 +17,8 @@ import {
 	type ActivityState,
 	type ArtifactConfig,
 	type ExternalCliRunnerStatus,
+	type ExternalJobRunnerStatus,
+	type ExternalJobStatus,
 	type ExternalProcessStatus,
 	type ArtifactPaths,
 	type AsyncParallelGroupStatus,
@@ -135,6 +137,7 @@ import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
 import { createBoundedByteTail, createBoundedLineReader, formatProtocolOutputLimit, MAX_CHILD_STDERR_BYTES, PI_AGGREGATE_EVENT_PROJECTOR, projectChildLifecycle, type ChildLifecycleAction, type ProtocolOutputLimit } from "../shared/child-protocol.ts";
 import { acquireSessionLease, type SessionLeaseRequest } from "../shared/session-lease.ts";
 import { buildExternalCliPrompt, runExternalCli } from "../shared/external-cli-runner.ts";
+import { runExternalJob } from "../shared/external-job-runner.ts";
 import { createOrcaProgressTab, type OrcaProgressTab } from "../shared/orca-progress-tabs.ts";
 import { decodeSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
 import {
@@ -249,8 +252,9 @@ interface StepResult {
 	watchdog?: import("../../shared/types.ts").ChildWatchdogProgress;
 	writerProcesses?: PiWriterProcessInstanceExitV1[];
 	writerAttemptCount?: number;
-	runner?: ExternalCliRunnerStatus;
+	runner?: ExternalCliRunnerStatus | ExternalJobRunnerStatus;
 	externalProcess?: ExternalProcessStatus;
+	externalJob?: ExternalJobStatus;
 }
 
 function persistStepArtifacts(input: {
@@ -1183,6 +1187,7 @@ interface SingleStepContext {
 	onChildEvent?: (event: ChildEvent) => void;
 	onWriterProcess?: (writer: { state: "none" | "spawning" } | { state: "running"; pid: number }) => void;
 	onExternalProcess?: (process: ExternalProcessStatus) => void;
+	onExternalJob?: (status: ExternalJobStatus) => void;
 	skipAcceptance?: () => boolean;
 	orcaProgressTab?: OrcaProgressTab;
 }
@@ -1357,6 +1362,69 @@ async function runSingleStepInner(
 			metadataSaveError: artifactErrors.metadataSaveError,
 			runner,
 			externalProcess: external.externalProcess,
+		});
+	}
+
+	if (step.runner?.type === "external-job") {
+		const runner: ExternalJobRunnerStatus = {
+			type: "external-job",
+			provider: step.runner.provider,
+			options: step.runner.options ?? {},
+			capabilities: { stop: false, steer: false, resume: false, structuredOutput: false, toolEvents: false },
+		};
+		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
+		const external = await runExternalJob(omitUndefinedProperties({
+			provider: runner.provider,
+			options: runner.options,
+			cwd: step.cwd ?? ctx.cwd,
+			prompt: buildExternalCliPrompt(step.systemPrompt ?? "", task),
+			asyncDir: path.dirname(ctx.outputFile),
+			stepIndex: ctx.flatIndex,
+			runId: ctx.id,
+			agent: step.agent,
+			sessionId: step.parentSessionId,
+			registerTimeout: ctx.registerTimeout,
+			registerStop: ctx.registerStop,
+			timeoutMessage: ctx.timeoutMessage,
+			stopMessage: ctx.stopMessage,
+			onExternalJob: ctx.onExternalJob,
+		}));
+		try { fs.writeFileSync(ctx.outputFile, external.output, "utf-8"); } catch { /* Observability output is best-effort. */ }
+		const resolvedOutput = step.outputPath && external.exitCode === 0
+			? resolveSingleOutput(step.outputPath, external.output, outputSnapshot)
+			: { fullOutput: external.output };
+		const outputReference = resolvedOutput.savedPath ? formatSavedOutputReference(resolvedOutput.savedPath, resolvedOutput.fullOutput) : undefined;
+		const finalizedOutput = finalizeSingleOutput(omitUndefinedProperties({
+			fullOutput: resolvedOutput.fullOutput,
+			outputPath: step.outputPath,
+			outputMode: step.outputMode,
+			exitCode: external.exitCode,
+			savedPath: resolvedOutput.savedPath,
+			outputReference,
+			saveError: resolvedOutput.saveError,
+		}));
+		const artifactErrors = artifactPaths && ctx.artifactConfig?.enabled !== false
+			? persistStepArtifacts({
+				artifactPaths,
+				artifactConfig: ctx.artifactConfig,
+				output: formatOutputArtifactContent(omitUndefinedProperties({ output: resolvedOutput.fullOutput, error: external.error, metadataPath: ctx.artifactConfig?.includeMetadata === false ? undefined : artifactPaths.metadataPath })),
+				metadata: { runId: ctx.id, agent: step.agent, task: PROMPT_REDACTED, runner, externalJob: external.externalJob, exitCode: external.exitCode, error: external.error, timestamp: Date.now() },
+			})
+			: {};
+		return omitUndefinedProperties({
+			agent: step.agent,
+			context: step.context,
+			output: finalizedOutput.displayOutput,
+			outputState: external.output.trim() ? "present" : "absent",
+			exitCode: external.exitCode,
+			error: external.error,
+			timedOut: external.timedOut,
+			stopped: external.stopped,
+			artifactPaths,
+			outputSaveError: artifactErrors.outputSaveError,
+			metadataSaveError: artifactErrors.metadataSaveError,
+			runner,
+			externalJob: external.externalJob,
 		});
 	}
 
@@ -1891,15 +1959,25 @@ type RunnerStatusStep = NonNullable<AsyncStatus["steps"]>[number] & {
 	description?: string;
 };
 
-function externalRunnerStatus(runner: SubagentStep["runner"]): ExternalCliRunnerStatus | undefined {
-	if (runner?.type !== "external-cli") return undefined;
-	return {
-		type: "external-cli",
-		command: runner.command,
-		args: runner.args ?? [],
-		promptDelivery: runner.promptDelivery ?? "stdin",
-		capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false },
-	};
+function externalRunnerStatus(runner: SubagentStep["runner"]): ExternalCliRunnerStatus | ExternalJobRunnerStatus | undefined {
+	if (runner?.type === "external-cli") {
+		return {
+			type: "external-cli",
+			command: runner.command,
+			args: runner.args ?? [],
+			promptDelivery: runner.promptDelivery ?? "stdin",
+			capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false },
+		};
+	}
+	if (runner?.type === "external-job") {
+		return {
+			type: "external-job",
+			provider: runner.provider,
+			options: runner.options ?? {},
+			capabilities: { stop: false, steer: false, resume: false, structuredOutput: false, toolEvents: false },
+		};
+	}
+	return undefined;
 }
 
 function appendCapabilityCeilingAppliedEvent(eventsPath: string, runId: string, stepIndex: number, agent: string, result: StepResult): void {
@@ -2437,6 +2515,11 @@ async function runSubagent(
 	};
 	const updateExternalProcess = (index: number, process: ExternalProcessStatus): void => {
 		requiredStatusStep(statusPayload, index).externalProcess = process;
+		statusPayload.lastUpdate = Date.now();
+		writeStatusPayload();
+	};
+	const updateExternalJob = (index: number, externalJob: ExternalJobStatus): void => {
+		requiredStatusStep(statusPayload, index).externalJob = externalJob;
 		statusPayload.lastUpdate = Date.now();
 		writeStatusPayload();
 	};
@@ -3727,6 +3810,7 @@ async function runSubagent(
 					onChildEvent: (event) => updateStepFromChildEvent(fi, event),
 					onWriterProcess,
 					onExternalProcess: (process) => updateExternalProcess(fi, process),
+					onExternalJob: (externalJob) => updateExternalJob(fi, externalJob),
 					skipAcceptance: () => timedOut || stopped,
 				}), config.deadlineAt);
 				const taskEndTime = Date.now();
@@ -4111,6 +4195,7 @@ async function runSubagent(
 							onChildEvent: (event) => updateStepFromChildEvent(fi, event),
 							onWriterProcess,
 							onExternalProcess: (process) => updateExternalProcess(fi, process),
+							onExternalJob: (externalJob) => updateExternalJob(fi, externalJob),
 							skipAcceptance: () => timedOut || stopped,
 						}), config.deadlineAt);
 						if (task.sessionFile) {
@@ -4431,6 +4516,7 @@ async function runSubagent(
 				onChildEvent: (event) => updateStepFromChildEvent(flatIndex, event),
 				onWriterProcess,
 				onExternalProcess: (process) => updateExternalProcess(flatIndex, process),
+				onExternalJob: (externalJob) => updateExternalJob(flatIndex, externalJob),
 				skipAcceptance: () => timedOut || stopped,
 				}), config.deadlineAt);
 			} catch (error) {
@@ -4485,6 +4571,7 @@ async function runSubagent(
 				toolBudgetBlocked: singleResult.toolBudgetBlocked,
 				runner: singleResult.runner,
 				externalProcess: singleResult.externalProcess,
+				externalJob: singleResult.externalJob,
 			}));
 			if (seqStep.outputName) {
 				outputs[seqStep.outputName] = outputEntryFromAsyncResult({
@@ -4824,6 +4911,7 @@ async function runSubagent(
 				runtimeAcknowledgedExtensions: r.runtimeAcknowledgedExtensions,
 				runner: r.runner,
 				externalProcess: r.externalProcess,
+				externalJob: r.externalJob,
 				execution: r.execution,
 				review: r.review,
 				effects: r.effects,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -992,9 +992,9 @@ function interruptAsyncRun(
 		};
 	}
 	const activeSteps = status.steps?.filter((step) => step.status === "running") ?? [];
-	if (activeSteps.length > 0 && activeSteps.every((step) => step.runner?.type === "external-cli")) {
+	if (activeSteps.length > 0 && activeSteps.every((step) => step.runner?.type === "external-cli" || step.runner?.type === "external-job")) {
 		return {
-			content: [{ type: "text", text: `Interrupt is unsupported for one-shot external CLI async run ${target.asyncId}; use stop instead.` }],
+			content: [{ type: "text", text: `Interrupt is unsupported for external async run ${target.asyncId}; use stop instead.` }],
 			isError: true,
 			details: { mode: "management", results: [] },
 		};
@@ -1406,10 +1406,10 @@ async function steerNestedRun(input: { target: ResolvedSubagentRunId & { kind: "
 
 function externalRunnerControlError(asyncDir: string, action: "steer" | "resume"): AgentToolResult<Details> | undefined {
 	const status = readStatus(asyncDir);
-	if (!status?.steps?.length || !status.steps.every((step) => step.runner?.type === "external-cli")) return undefined;
+	if (!status?.steps?.length || !status.steps.every((step) => step.runner?.type === "external-cli" || step.runner?.type === "external-job")) return undefined;
 	const message = action === "steer"
-		? "One-shot external CLI runners do not accept live steer messages."
-		: "One-shot external CLI runners do not persist sessions and cannot be resumed.";
+		? "External runners do not accept live steer messages."
+		: "External runners do not persist Pi sessions and cannot be resumed.";
 	return { content: [{ type: "text", text: message }], isError: true, details: { mode: "management", results: [] } };
 }
 
@@ -2524,7 +2524,7 @@ function resolveStaticLaunchSummary(input: {
 	thinkingOverrideForTask: ForkThinkingOverrideForTask;
 }): StaticLaunchSummary {
 	const agentConfig = input.agents.find((agent) => agent.name === input.agent);
-	const externalRunner = agentConfig?.runner?.type === "external-cli";
+	const externalRunner = agentConfig?.runner?.type === "external-cli" || agentConfig?.runner?.type === "external-job";
 	const model = externalRunner
 		? undefined
 		: resolveEffectiveSubagentModel(
@@ -2760,10 +2760,10 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const normalizedSkills = normalizeSkillInput(params.skill);
 		const skills = normalizedSkills === false ? [] : normalizedSkills;
 		const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, a.maxSubagentDepth);
-		const externalRunnerWithoutExplicitModel = a.runner?.type === "external-cli"
+		const externalRunnerWithoutExplicitModel = (a.runner?.type === "external-cli" || a.runner?.type === "external-job")
 			&& params.model === undefined
 			&& (a.model === undefined || (a.modelSource?.type === "subagents.defaultModel" && a.model === a.modelSource.model));
-		const modelOverride = a.runner?.type === "external-cli"
+		const modelOverride = a.runner?.type === "external-cli" || a.runner?.type === "external-job"
 			? params.model ?? (externalRunnerWithoutExplicitModel ? undefined : a.model)
 			: resolveEffectiveSubagentModel(params.model as string | undefined, a.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope });
 		return executeAsyncSingle(id, compactOptional<Parameters<typeof executeAsyncSingle>[1]>({
@@ -4964,7 +4964,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const parentModel = requestParentModel;
 			prepareForkThinking = (agentName, index, modelOverride) => {
 				const agentConfig = agents.find((agent) => agent.name === agentName);
-				if (agentConfig?.runner?.type === "external-cli") {
+				if (agentConfig?.runner?.type === "external-cli" || agentConfig?.runner?.type === "external-job") {
 					forkThinkingRequirements.set(index, true);
 					return;
 				}
@@ -5005,9 +5005,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				: (effectiveParams.chain ?? []).flatMap((step) => getStepAgents(step as ChainStep));
 		const externalAgent = selectedAgentNames
 			.map((name) => agents.find((agent) => agent.name === name))
-			.find((agent) => agent?.runner?.type === "external-cli");
+			.find((agent) => agent?.runner?.type === "external-cli" || agent?.runner?.type === "external-job");
 		if (externalAgent && (!effectiveAsync || effectiveParams.foregroundOnly === true)) {
-			return buildRequestedModeError(effectiveParams, `Agent '${externalAgent.name}' uses runner.type='external-cli', which currently supports async/background execution only. Omit async or pass async:true; clarify and foregroundOnly are unsupported.`);
+			return buildRequestedModeError(effectiveParams, `Agent '${externalAgent.name}' uses runner.type='${externalAgent.runner?.type}', which currently supports async/background execution only. Omit async or pass async:true; clarify and foregroundOnly are unsupported.`);
 		}
 		const foregroundTimeout = resolveSingleAgentLaunchTimeout(
 			effectiveParams,

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -18,6 +18,7 @@ const EXTERNAL_JOB_BRIDGE_RESPONSE_DIR = "external-job-responses";
 const DEFAULT_OPERATION_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 50;
 const MAX_REQUESTS_PER_SWEEP = 100;
+const START_CLAIM_STALE_MS = DEFAULT_OPERATION_TIMEOUT_MS;
 
 interface ExternalJobBridgeRequest {
 	id: string;
@@ -61,6 +62,10 @@ function requestPath(asyncDir: string, id: string): string {
 	return path.join(requestDir(asyncDir), `${id}.json`);
 }
 
+function startClaimPath(asyncDir: string, id: string): string {
+	return path.join(requestDir(asyncDir), `${id}.claim.json`);
+}
+
 function responsePath(asyncDir: string, id: string): string {
 	return path.join(responseDir(asyncDir), `${id}.json`);
 }
@@ -71,6 +76,14 @@ function sleep(ms: number): Promise<void> {
 
 function readJson<T>(filePath: string): T {
 	return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "EEXIST";
+}
+
+function isNotFoundError(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
 function bridgeError(error: unknown): { code: string; message: string; blockingJobId?: string } {
@@ -144,6 +157,29 @@ async function executeBridgeRequest(request: ExternalJobBridgeRequest): Promise<
 	}
 }
 
+function claimStartRequest(asyncDir: string, filePath: string, request: ExternalJobBridgeRequest): { request: ExternalJobBridgeRequest; filePath: string } | undefined {
+	const claimed: ExternalJobBridgeRequest = { ...request, claimedAt: Date.now() };
+	const claimPath = startClaimPath(asyncDir, request.id);
+	let fd: number;
+	try {
+		fd = fs.openSync(claimPath, "wx");
+	} catch (error) {
+		if (isAlreadyExistsError(error)) return undefined;
+		throw error;
+	}
+	try {
+		fs.writeFileSync(fd, JSON.stringify(claimed), "utf-8");
+	} finally {
+		fs.closeSync(fd);
+	}
+	fs.rmSync(filePath, { force: true });
+	return { request: claimed, filePath: claimPath };
+}
+
+function startClaimIsStale(request: ExternalJobBridgeRequest): boolean {
+	return Date.now() - (request.claimedAt ?? request.createdAt) >= START_CLAIM_STALE_MS;
+}
+
 export function serviceExternalJobBridgeRequests(asyncDir: string): void {
 	let files: string[];
 	try {
@@ -154,58 +190,68 @@ export function serviceExternalJobBridgeRequests(asyncDir: string): void {
 	}
 	fs.mkdirSync(responseDir(asyncDir), { recursive: true });
 	for (const file of files) {
-		const filePath = path.join(requestDir(asyncDir), file);
-		let request: ExternalJobBridgeRequest;
-		try {
-			request = assertRequest(readJson(filePath), filePath);
-		} catch (error) {
-			const id = file.replace(/\.json$/, "");
-			writeAtomicJson(responsePath(asyncDir, id), {
-				id,
-				ok: false,
-				operation: "status",
-				provider: "unknown",
-				code: "malformed-request",
-				message: error instanceof Error ? error.message : String(error),
-				completedAt: Date.now(),
-			} satisfies ExternalJobBridgeResponse);
-			fs.rmSync(filePath, { force: true });
-			continue;
-		}
-		if (inFlight.has(request.id) || fs.existsSync(responsePath(asyncDir, request.id))) continue;
-		if (request.operation === "start" && request.claimedAt !== undefined) {
-			writeAtomicJson(responsePath(asyncDir, request.id), {
-				id: request.id,
-				ok: false,
-				operation: request.operation,
-				provider: request.provider,
-				code: "start-dispatch-unknown",
-				message: `External-job start for provider '${request.provider}' was already claimed by a previous host process, but no provider job id was committed. Refusing to redispatch the prompt automatically.`,
-				completedAt: Date.now(),
-			} satisfies ExternalJobBridgeResponse);
-			fs.rmSync(filePath, { force: true });
-			continue;
-		}
-		const claimedRequest = request.operation === "start" ? { ...request, claimedAt: Date.now() } : request;
-		if (claimedRequest !== request) writeAtomicJson(filePath, claimedRequest);
-		inFlight.add(claimedRequest.id);
-		void executeBridgeRequest(claimedRequest).then((response) => {
-			writeAtomicJson(responsePath(asyncDir, claimedRequest.id), response);
-			fs.rmSync(filePath, { force: true });
-		}).catch((error) => {
-			writeAtomicJson(responsePath(asyncDir, claimedRequest.id), {
-				id: claimedRequest.id,
-				ok: false,
-				operation: claimedRequest.operation,
-				provider: claimedRequest.provider,
-				code: "bridge-error",
-				message: error instanceof Error ? error.message : String(error),
-				completedAt: Date.now(),
-			} satisfies ExternalJobBridgeResponse);
-		}).finally(() => {
-			inFlight.delete(claimedRequest.id);
-		});
+		serviceExternalJobBridgeRequestFile(asyncDir, file);
 	}
+}
+
+export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: string): void {
+	fs.mkdirSync(responseDir(asyncDir), { recursive: true });
+	const filePath = path.join(requestDir(asyncDir), file);
+	let request: ExternalJobBridgeRequest;
+	try {
+		request = assertRequest(readJson(filePath), filePath);
+	} catch (error) {
+		if (isNotFoundError(error)) return;
+		const id = file.replace(/\.json$/, "");
+		writeAtomicJson(responsePath(asyncDir, id), {
+			id,
+			ok: false,
+			operation: "status",
+			provider: "unknown",
+			code: "malformed-request",
+			message: error instanceof Error ? error.message : String(error),
+			completedAt: Date.now(),
+		} satisfies ExternalJobBridgeResponse);
+		fs.rmSync(filePath, { force: true });
+		return;
+	}
+	if (inFlight.has(request.id) || fs.existsSync(responsePath(asyncDir, request.id))) return;
+	const claimedStartFile = file.endsWith(".claim.json");
+	if (request.operation === "start" && (claimedStartFile || request.claimedAt !== undefined)) {
+		if (!startClaimIsStale(request)) return;
+		writeAtomicJson(responsePath(asyncDir, request.id), {
+			id: request.id,
+			ok: false,
+			operation: request.operation,
+			provider: request.provider,
+			code: "start-dispatch-unknown",
+			message: `External-job start for provider '${request.provider}' was already claimed by a previous host process, but no provider job id was committed. Refusing to redispatch the prompt automatically.`,
+			completedAt: Date.now(),
+		} satisfies ExternalJobBridgeResponse);
+		fs.rmSync(filePath, { force: true });
+		fs.rmSync(requestPath(asyncDir, request.id), { force: true });
+		return;
+	}
+	const claimed = request.operation === "start" ? claimStartRequest(asyncDir, filePath, request) : { request, filePath };
+	if (!claimed) return;
+	const claimedRequest = claimed.request;
+	inFlight.add(claimedRequest.id);
+	void executeBridgeRequest(claimedRequest).then((response) => {
+		writeAtomicJson(responsePath(asyncDir, claimedRequest.id), response);
+		fs.rmSync(claimed.filePath, { force: true });
+	}).catch((error) => {
+		writeAtomicJson(responsePath(asyncDir, claimedRequest.id), {
+			id: claimedRequest.id,
+			ok: false,
+			operation: claimedRequest.operation,
+			provider: claimedRequest.provider,
+			code: "bridge-error",
+			message: error instanceof Error ? error.message : String(error),
+			completedAt: Date.now(),
+		} satisfies ExternalJobBridgeResponse);
+	}).finally(() => {
+		inFlight.delete(claimedRequest.id);
+	});
 }
 
 export async function requestExternalJobOperation<T extends ExternalJobHandle | ExternalJobResult>(asyncDir: string, request: Omit<ExternalJobBridgeRequest, "id" | "createdAt">, timeoutMs = DEFAULT_OPERATION_TIMEOUT_MS): Promise<T> {

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import {
@@ -27,6 +29,14 @@ interface ExternalJobBridgeRequest {
 	start?: ExternalJobStartInput;
 	createdAt: number;
 	claimedAt?: number;
+}
+
+interface ExternalJobClaimOwner {
+	version: 1;
+	pid: number;
+	hostname: string;
+	claimedAt: number;
+	processStartIdentity?: string;
 }
 
 type ExternalJobBridgeResponse = {
@@ -65,6 +75,10 @@ function startClaimDir(asyncDir: string, id: string): string {
 	return path.join(requestDir(asyncDir), `${id}.claim`);
 }
 
+function startClaimTempDir(asyncDir: string, id: string): string {
+	return path.join(requestDir(asyncDir), `${id}.claim.tmp-${randomUUID()}`);
+}
+
 function responsePath(asyncDir: string, id: string): string {
 	return path.join(responseDir(asyncDir), `${id}.json`);
 }
@@ -77,8 +91,54 @@ function readJson<T>(filePath: string): T {
 	return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
 }
 
-function isAlreadyExistsError(error: unknown): boolean {
-	return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "EEXIST";
+function processStartIdentity(pid: number): string | undefined {
+	if (process.platform === "linux") {
+		try {
+			const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf-8");
+			const commandEnd = stat.lastIndexOf(")");
+			if (commandEnd === -1) return undefined;
+			const fields = stat.slice(commandEnd + 1).trim().split(/\s+/);
+			const startTicks = fields[19];
+			return startTicks ? `linux:${startTicks}` : undefined;
+		} catch {
+			return undefined;
+		}
+	}
+	if (process.platform === "darwin" || process.platform === "freebsd") {
+		const result = spawnSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf-8" });
+		const started = result.status === 0 ? result.stdout.trim() : "";
+		return started ? `${process.platform}:${started}` : undefined;
+	}
+	return undefined;
+}
+
+function processIsAlive(pid: number): boolean | undefined {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ESRCH") return false;
+		if (code === "EPERM") return true;
+		return undefined;
+	}
+}
+
+function currentClaimOwner(): ExternalJobClaimOwner {
+	const startIdentity = processStartIdentity(process.pid);
+	return {
+		version: 1,
+		pid: process.pid,
+		hostname: os.hostname(),
+		claimedAt: Date.now(),
+		...(startIdentity ? { processStartIdentity: startIdentity } : {}),
+	};
+}
+
+function isClaimConflictError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null || !("code" in error)) return false;
+	const code = (error as NodeJS.ErrnoException).code;
+	return code === "EEXIST" || code === "ENOTEMPTY" || code === "EPERM";
 }
 
 function isNotFoundError(error: unknown): boolean {
@@ -157,23 +217,56 @@ async function executeBridgeRequest(request: ExternalJobBridgeRequest): Promise<
 }
 
 function claimStartRequest(asyncDir: string, filePath: string, request: ExternalJobBridgeRequest): { request: ExternalJobBridgeRequest; filePath: string } | undefined {
-	const claimed: ExternalJobBridgeRequest = { ...request, claimedAt: Date.now() };
+	const owner = currentClaimOwner();
+	const claimed: ExternalJobBridgeRequest = { ...request, claimedAt: owner.claimedAt };
 	const claimDir = startClaimDir(asyncDir, request.id);
+	const tempClaimDir = startClaimTempDir(asyncDir, request.id);
 	try {
-		fs.mkdirSync(claimDir);
+		fs.mkdirSync(tempClaimDir);
+		writeAtomicJson(path.join(tempClaimDir, "owner.json"), owner);
+		writeAtomicJson(path.join(tempClaimDir, "request.json"), claimed);
+		fs.renameSync(tempClaimDir, claimDir);
 	} catch (error) {
-		if (isAlreadyExistsError(error)) return undefined;
+		fs.rmSync(tempClaimDir, { recursive: true, force: true });
+		if (isClaimConflictError(error)) return undefined;
 		throw error;
 	}
-	writeAtomicJson(path.join(claimDir, "request.json"), claimed);
 	fs.rmSync(filePath, { force: true });
 	return { request: claimed, filePath: claimDir };
+}
+
+function parseClaimOwner(value: unknown): ExternalJobClaimOwner | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const owner = value as Partial<ExternalJobClaimOwner>;
+	if (owner.version !== 1 || typeof owner.pid !== "number" || !Number.isInteger(owner.pid) || owner.pid <= 0 || typeof owner.hostname !== "string" || typeof owner.claimedAt !== "number") return undefined;
+	if (owner.processStartIdentity !== undefined && typeof owner.processStartIdentity !== "string") return undefined;
+	return owner as ExternalJobClaimOwner;
+}
+
+function claimOwnerIsDead(owner: ExternalJobClaimOwner | undefined): boolean {
+	if (!owner || owner.hostname !== os.hostname()) return false;
+	const alive = processIsAlive(owner.pid);
+	if (alive === false) return true;
+	if (alive !== true || !owner.processStartIdentity) return false;
+	const currentIdentity = processStartIdentity(owner.pid);
+	return currentIdentity !== undefined && currentIdentity !== owner.processStartIdentity;
+}
+
+function readClaimOwner(claimDir: string): ExternalJobClaimOwner | undefined {
+	try {
+		return parseClaimOwner(readJson(path.join(claimDir, "owner.json")));
+	} catch {
+		return undefined;
+	}
 }
 
 export function serviceExternalJobBridgeRequests(asyncDir: string): void {
 	let files: string[];
 	try {
-		files = fs.readdirSync(requestDir(asyncDir)).filter((file) => file.endsWith(".json")).slice(0, MAX_REQUESTS_PER_SWEEP);
+		files = fs.readdirSync(requestDir(asyncDir), { withFileTypes: true })
+			.filter((entry) => (entry.isFile() && entry.name.endsWith(".json")) || (entry.isDirectory() && entry.name.endsWith(".claim")))
+			.map((entry) => entry.name)
+			.slice(0, MAX_REQUESTS_PER_SWEEP);
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
 		throw error;
@@ -186,6 +279,10 @@ export function serviceExternalJobBridgeRequests(asyncDir: string): void {
 
 export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: string): void {
 	fs.mkdirSync(responseDir(asyncDir), { recursive: true });
+	if (file.endsWith(".claim")) {
+		serviceExternalJobStartClaim(asyncDir, file);
+		return;
+	}
 	const filePath = path.join(requestDir(asyncDir), file);
 	let request: ExternalJobBridgeRequest;
 	try {
@@ -227,6 +324,34 @@ export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: stri
 	}).finally(() => {
 		inFlight.delete(claimedRequest.id);
 	});
+}
+
+function serviceExternalJobStartClaim(asyncDir: string, file: string): void {
+	const claimDir = path.join(requestDir(asyncDir), file);
+	const owner = readClaimOwner(claimDir);
+	if (!owner && fs.existsSync(requestPath(asyncDir, file.replace(/\.claim$/, ""))) && !fs.existsSync(responsePath(asyncDir, file.replace(/\.claim$/, "")))) {
+		fs.rmSync(claimDir, { recursive: true, force: true });
+		return;
+	}
+	if (!claimOwnerIsDead(owner)) return;
+	let request: ExternalJobBridgeRequest;
+	try {
+		request = assertRequest(readJson(path.join(claimDir, "request.json")), path.join(claimDir, "request.json"));
+	} catch {
+		return;
+	}
+	if (request.operation !== "start" || fs.existsSync(responsePath(asyncDir, request.id))) return;
+	writeAtomicJson(responsePath(asyncDir, request.id), {
+		id: request.id,
+		ok: false,
+		operation: request.operation,
+		provider: request.provider,
+		code: "start-dispatch-abandoned",
+		message: `External-job start for provider '${request.provider}' was claimed by a host process that is no longer alive before a provider job id was committed. Refusing to redispatch the prompt automatically.`,
+		completedAt: Date.now(),
+	} satisfies ExternalJobBridgeResponse);
+	fs.rmSync(claimDir, { recursive: true, force: true });
+	fs.rmSync(requestPath(asyncDir, request.id), { force: true });
 }
 
 export async function requestExternalJobOperation<T extends ExternalJobHandle | ExternalJobResult>(asyncDir: string, request: Omit<ExternalJobBridgeRequest, "id" | "createdAt">, timeoutMs = DEFAULT_OPERATION_TIMEOUT_MS): Promise<T> {

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -1,0 +1,214 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import {
+	ExternalJobProviderError,
+	getExternalJobProvider,
+	validateExternalJobHandle,
+	validateExternalJobResult,
+	type ExternalJobHandle,
+	type ExternalJobOperation,
+	type ExternalJobResult,
+	type ExternalJobStartInput,
+} from "../../api/external-job-provider.ts";
+
+export const EXTERNAL_JOB_BRIDGE_REQUEST_DIR = "external-job-requests";
+const EXTERNAL_JOB_BRIDGE_RESPONSE_DIR = "external-job-responses";
+const DEFAULT_OPERATION_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 50;
+const MAX_REQUESTS_PER_SWEEP = 100;
+
+interface ExternalJobBridgeRequest {
+	id: string;
+	operation: ExternalJobOperation;
+	provider: string;
+	providerJobId?: string;
+	start?: ExternalJobStartInput;
+	createdAt: number;
+}
+
+type ExternalJobBridgeResponse = {
+	id: string;
+	ok: true;
+	operation: ExternalJobOperation;
+	provider: string;
+	result: ExternalJobHandle | ExternalJobResult;
+	completedAt: number;
+} | {
+	id: string;
+	ok: false;
+	operation: ExternalJobOperation;
+	provider: string;
+	code: string;
+	message: string;
+	blockingJobId?: string;
+	completedAt: number;
+};
+
+const inFlight = new Set<string>();
+
+function requestDir(asyncDir: string): string {
+	return path.join(asyncDir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+}
+
+function responseDir(asyncDir: string): string {
+	return path.join(asyncDir, EXTERNAL_JOB_BRIDGE_RESPONSE_DIR);
+}
+
+function requestPath(asyncDir: string, id: string): string {
+	return path.join(requestDir(asyncDir), `${id}.json`);
+}
+
+function responsePath(asyncDir: string, id: string): string {
+	return path.join(responseDir(asyncDir), `${id}.json`);
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readJson<T>(filePath: string): T {
+	return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
+}
+
+function bridgeError(error: unknown): { code: string; message: string; blockingJobId?: string } {
+	if (error instanceof ExternalJobProviderError) {
+		return { code: error.code, message: error.message, ...(error.blockingJobId ? { blockingJobId: error.blockingJobId } : {}) };
+	}
+	if (error && typeof error === "object") {
+		const record = error as Record<string, unknown>;
+		const code = typeof record.code === "string" && record.code.trim() ? record.code : "provider-error";
+		const blockingJobId = typeof record.blockingJobId === "string" && record.blockingJobId.trim() ? record.blockingJobId : undefined;
+		return {
+			code,
+			message: error instanceof Error ? error.message : String(error),
+			...(blockingJobId ? { blockingJobId } : {}),
+		};
+	}
+	return { code: "provider-error", message: String(error) };
+}
+
+function assertRequest(value: unknown, filePath: string): ExternalJobBridgeRequest {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`External-job bridge request '${filePath}' must be an object.`);
+	const request = value as ExternalJobBridgeRequest;
+	if (typeof request.id !== "string" || !request.id) throw new Error(`External-job bridge request '${filePath}' has invalid id.`);
+	if (request.operation !== "start" && request.operation !== "status" && request.operation !== "result" && request.operation !== "reattach") throw new Error(`External-job bridge request '${filePath}' has invalid operation.`);
+	if (typeof request.provider !== "string" || !request.provider.trim()) throw new Error(`External-job bridge request '${filePath}' has invalid provider.`);
+	if (typeof request.createdAt !== "number") throw new Error(`External-job bridge request '${filePath}' has invalid createdAt.`);
+	if (request.operation === "start") {
+		if (!request.start || typeof request.start !== "object" || Array.isArray(request.start)) throw new Error(`External-job bridge start request '${filePath}' is missing start input.`);
+	} else if (typeof request.providerJobId !== "string" || !request.providerJobId.trim()) {
+		throw new Error(`External-job bridge ${request.operation} request '${filePath}' is missing providerJobId.`);
+	}
+	return request;
+}
+
+async function executeBridgeRequest(request: ExternalJobBridgeRequest): Promise<ExternalJobBridgeResponse> {
+	const provider = getExternalJobProvider(request.provider);
+	if (!provider) {
+		return {
+			id: request.id,
+			ok: false,
+			operation: request.operation,
+			provider: request.provider,
+			code: "provider-unavailable",
+			message: `External-job provider '${request.provider}' is not registered. Load the Surf Pi extension and its external-job provider bridge before starting this agent.`,
+			completedAt: Date.now(),
+		};
+	}
+	try {
+		const raw = request.operation === "start"
+			? await provider.start(request.start!)
+			: request.operation === "status"
+				? await provider.status(request.providerJobId!)
+				: request.operation === "reattach"
+					? await provider.reattach(request.providerJobId!)
+					: await provider.result(request.providerJobId!);
+		const result = request.operation === "result"
+			? validateExternalJobResult(provider.name, raw, "External-job bridge result")
+			: validateExternalJobHandle(provider.name, raw, "External-job bridge handle");
+		return { id: request.id, ok: true, operation: request.operation, provider: request.provider, result, completedAt: Date.now() };
+	} catch (error) {
+		const details = bridgeError(error);
+		return {
+			id: request.id,
+			ok: false,
+			operation: request.operation,
+			provider: request.provider,
+			...details,
+			completedAt: Date.now(),
+		};
+	}
+}
+
+export function serviceExternalJobBridgeRequests(asyncDir: string): void {
+	let files: string[];
+	try {
+		files = fs.readdirSync(requestDir(asyncDir)).filter((file) => file.endsWith(".json")).slice(0, MAX_REQUESTS_PER_SWEEP);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	fs.mkdirSync(responseDir(asyncDir), { recursive: true });
+	for (const file of files) {
+		const filePath = path.join(requestDir(asyncDir), file);
+		let request: ExternalJobBridgeRequest;
+		try {
+			request = assertRequest(readJson(filePath), filePath);
+		} catch (error) {
+			const id = file.replace(/\.json$/, "");
+			writeAtomicJson(responsePath(asyncDir, id), {
+				id,
+				ok: false,
+				operation: "status",
+				provider: "unknown",
+				code: "malformed-request",
+				message: error instanceof Error ? error.message : String(error),
+				completedAt: Date.now(),
+			} satisfies ExternalJobBridgeResponse);
+			fs.rmSync(filePath, { force: true });
+			continue;
+		}
+		if (inFlight.has(request.id) || fs.existsSync(responsePath(asyncDir, request.id))) continue;
+		inFlight.add(request.id);
+		void executeBridgeRequest(request).then((response) => {
+			writeAtomicJson(responsePath(asyncDir, request.id), response);
+			fs.rmSync(filePath, { force: true });
+		}).catch((error) => {
+			writeAtomicJson(responsePath(asyncDir, request.id), {
+				id: request.id,
+				ok: false,
+				operation: request.operation,
+				provider: request.provider,
+				code: "bridge-error",
+				message: error instanceof Error ? error.message : String(error),
+				completedAt: Date.now(),
+			} satisfies ExternalJobBridgeResponse);
+		}).finally(() => {
+			inFlight.delete(request.id);
+		});
+	}
+}
+
+export async function requestExternalJobOperation<T extends ExternalJobHandle | ExternalJobResult>(asyncDir: string, request: Omit<ExternalJobBridgeRequest, "id" | "createdAt">, timeoutMs = DEFAULT_OPERATION_TIMEOUT_MS): Promise<T> {
+	const id = randomUUID();
+	fs.mkdirSync(requestDir(asyncDir), { recursive: true });
+	fs.mkdirSync(responseDir(asyncDir), { recursive: true });
+	writeAtomicJson(requestPath(asyncDir, id), { ...request, id, createdAt: Date.now() } satisfies ExternalJobBridgeRequest);
+	const deadline = Date.now() + timeoutMs;
+	const outPath = responsePath(asyncDir, id);
+	while (!fs.existsSync(outPath)) {
+		if (Date.now() >= deadline) {
+			throw new ExternalJobProviderError(
+				`External-job provider bridge did not respond to ${request.operation} for provider '${request.provider}' within ${timeoutMs}ms.`,
+				{ code: "bridge-timeout" },
+			);
+		}
+		await sleep(POLL_INTERVAL_MS);
+	}
+	const response = readJson<ExternalJobBridgeResponse>(outPath);
+	fs.rmSync(outPath, { force: true });
+	if (!response.ok) throw new ExternalJobProviderError(response.message, { code: response.code, ...(response.blockingJobId ? { blockingJobId: response.blockingJobId } : {}) });
+	return response.result as T;
+}

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -81,6 +81,14 @@ function startClaimTempDir(asyncDir: string, id: string): string {
 	return path.join(requestDir(asyncDir), `${id}.claim.tmp-${randomUUID()}`);
 }
 
+function startClaimCompletedPath(claimDir: string): string {
+	return path.join(claimDir, "completed.json");
+}
+
+function completedStartClaimExists(asyncDir: string, id: string): boolean {
+	return fs.existsSync(startClaimCompletedPath(startClaimDir(asyncDir, id)));
+}
+
 function responsePath(asyncDir: string, id: string): string {
 	return path.join(responseDir(asyncDir), `${id}.json`);
 }
@@ -266,7 +274,7 @@ export function serviceExternalJobBridgeRequests(asyncDir: string): void {
 	let files: string[];
 	try {
 		files = fs.readdirSync(requestDir(asyncDir), { withFileTypes: true })
-			.filter((entry) => (entry.isFile() && entry.name.endsWith(".json")) || (entry.isDirectory() && entry.name.endsWith(".claim")))
+			.filter((entry) => (entry.isFile() && entry.name.endsWith(".json") && !completedStartClaimExists(asyncDir, entry.name.replace(/\.json$/, ""))) || (entry.isDirectory() && entry.name.endsWith(".claim") && !fs.existsSync(startClaimCompletedPath(path.join(requestDir(asyncDir), entry.name)))))
 			.map((entry) => entry.name)
 			.slice(0, MAX_REQUESTS_PER_SWEEP);
 	} catch (error) {
@@ -304,6 +312,10 @@ export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: stri
 		fs.rmSync(filePath, { force: true });
 		return;
 	}
+	if (request.operation === "start" && completedStartClaimExists(asyncDir, request.id)) {
+		fs.rmSync(filePath, { force: true });
+		return;
+	}
 	if (inFlight.has(request.id) || fs.existsSync(responsePath(asyncDir, request.id))) return;
 	if (request.operation === "start" && request.claimedAt !== undefined) return;
 	const claimed = request.operation === "start" ? claimStartRequest(asyncDir, filePath, request) : { request, filePath };
@@ -312,7 +324,11 @@ export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: stri
 	inFlight.add(claimedRequest.id);
 	void executeBridgeRequest(claimedRequest).then((response) => {
 		writeAtomicJson(responsePath(asyncDir, claimedRequest.id), response);
-		fs.rmSync(claimed.filePath, { recursive: true, force: true });
+		if (claimedRequest.operation === "start") {
+			writeAtomicJson(startClaimCompletedPath(claimed.filePath), { completedAt: Date.now() });
+		} else {
+			fs.rmSync(claimed.filePath, { recursive: true, force: true });
+		}
 	}).catch((error) => {
 		writeAtomicJson(responsePath(asyncDir, claimedRequest.id), {
 			id: claimedRequest.id,
@@ -323,6 +339,7 @@ export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: stri
 			message: error instanceof Error ? error.message : String(error),
 			completedAt: Date.now(),
 		} satisfies ExternalJobBridgeResponse);
+		if (claimedRequest.operation === "start") writeAtomicJson(startClaimCompletedPath(claimed.filePath), { completedAt: Date.now() });
 	}).finally(() => {
 		inFlight.delete(claimedRequest.id);
 	});
@@ -330,6 +347,7 @@ export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: stri
 
 function serviceExternalJobStartClaim(asyncDir: string, file: string): void {
 	const claimDir = path.join(requestDir(asyncDir), file);
+	if (fs.existsSync(startClaimCompletedPath(claimDir))) return;
 	const owner = readClaimOwner(claimDir);
 	if (!owner && fs.existsSync(requestPath(asyncDir, file.replace(/\.claim$/, ""))) && !fs.existsSync(responsePath(asyncDir, file.replace(/\.claim$/, "")))) {
 		fs.rmSync(claimDir, { recursive: true, force: true });

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -85,8 +85,28 @@ function startClaimCompletedPath(claimDir: string): string {
 	return path.join(claimDir, "completed.json");
 }
 
+function startClaimHandlePath(claimDir: string): string {
+	return path.join(claimDir, "handle.json");
+}
+
 function completedStartClaimExists(asyncDir: string, id: string): boolean {
 	return fs.existsSync(startClaimCompletedPath(startClaimDir(asyncDir, id)));
+}
+
+function cancelStartRequest(asyncDir: string, request: ExternalJobBridgeRequest): boolean {
+	const claimDir = startClaimDir(asyncDir, request.id);
+	const tempClaimDir = startClaimTempDir(asyncDir, request.id);
+	try {
+		fs.mkdirSync(tempClaimDir);
+		writeAtomicJson(startClaimCompletedPath(tempClaimDir), { completedAt: Date.now() });
+		fs.renameSync(tempClaimDir, claimDir);
+	} catch (error) {
+		fs.rmSync(tempClaimDir, { recursive: true, force: true });
+		if (isClaimConflictError(error)) return false;
+		throw error;
+	}
+	fs.rmSync(requestPath(asyncDir, request.id), { force: true });
+	return true;
 }
 
 function responsePath(asyncDir: string, id: string): string {
@@ -188,7 +208,7 @@ function assertRequest(value: unknown, filePath: string): ExternalJobBridgeReque
 	return request;
 }
 
-async function executeBridgeRequest(request: ExternalJobBridgeRequest): Promise<ExternalJobBridgeResponse> {
+async function executeBridgeRequest(request: ExternalJobBridgeRequest, claimDir?: string): Promise<ExternalJobBridgeResponse> {
 	const provider = getExternalJobProvider(request.provider);
 	if (!provider) {
 		return {
@@ -212,6 +232,7 @@ async function executeBridgeRequest(request: ExternalJobBridgeRequest): Promise<
 		const result = request.operation === "result"
 			? validateExternalJobResult(provider.name, raw, "External-job bridge result")
 			: validateExternalJobHandle(provider.name, raw, "External-job bridge handle");
+		if (request.operation === "start" && claimDir) writeAtomicJson(startClaimHandlePath(claimDir), result);
 		return { id: request.id, ok: true, operation: request.operation, provider: request.provider, result, completedAt: Date.now() };
 	} catch (error) {
 		const details = bridgeError(error);
@@ -270,6 +291,14 @@ function readClaimOwner(claimDir: string): ExternalJobClaimOwner | undefined {
 	}
 }
 
+function readClaimHandle(provider: string, claimDir: string): ExternalJobHandle | undefined {
+	try {
+		return validateExternalJobHandle(provider, readJson(startClaimHandlePath(claimDir)), "External-job bridge recovered start handle");
+	} catch {
+		return undefined;
+	}
+}
+
 export function serviceExternalJobBridgeRequests(asyncDir: string): void {
 	let files: string[];
 	try {
@@ -322,7 +351,7 @@ export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: stri
 	if (!claimed) return;
 	const claimedRequest = claimed.request;
 	inFlight.add(claimedRequest.id);
-	void executeBridgeRequest(claimedRequest).then((response) => {
+	void executeBridgeRequest(claimedRequest, claimedRequest.operation === "start" ? claimed.filePath : undefined).then((response) => {
 		writeAtomicJson(responsePath(asyncDir, claimedRequest.id), response);
 		if (claimedRequest.operation === "start") {
 			writeAtomicJson(startClaimCompletedPath(claimed.filePath), { completedAt: Date.now() });
@@ -361,6 +390,20 @@ function serviceExternalJobStartClaim(asyncDir: string, file: string): void {
 		return;
 	}
 	if (request.operation !== "start" || fs.existsSync(responsePath(asyncDir, request.id))) return;
+	const handle = readClaimHandle(request.provider, claimDir);
+	if (handle) {
+		writeAtomicJson(responsePath(asyncDir, request.id), {
+			id: request.id,
+			ok: true,
+			operation: request.operation,
+			provider: request.provider,
+			result: handle,
+			completedAt: Date.now(),
+		} satisfies ExternalJobBridgeResponse);
+		writeAtomicJson(startClaimCompletedPath(claimDir), { completedAt: Date.now() });
+		fs.rmSync(requestPath(asyncDir, request.id), { force: true });
+		return;
+	}
 	writeAtomicJson(responsePath(asyncDir, request.id), {
 		id: request.id,
 		ok: false,
@@ -378,13 +421,18 @@ export async function requestExternalJobOperation<T extends ExternalJobHandle | 
 	const id = randomUUID();
 	fs.mkdirSync(requestDir(asyncDir), { recursive: true });
 	fs.mkdirSync(responseDir(asyncDir), { recursive: true });
-	writeAtomicJson(requestPath(asyncDir, id), { ...request, id, createdAt: Date.now() } satisfies ExternalJobBridgeRequest);
+	const bridgeRequest = { ...request, id, createdAt: Date.now() } satisfies ExternalJobBridgeRequest;
+	writeAtomicJson(requestPath(asyncDir, id), bridgeRequest);
 	const deadline = request.operation === "start" ? undefined : Date.now() + timeoutMs;
 	const outPath = responsePath(asyncDir, id);
 	while (!fs.existsSync(outPath)) {
 		const canceled = cancel?.();
 		if (canceled) {
-			fs.rmSync(requestPath(asyncDir, id), { force: true });
+			if (request.operation === "start" && !cancelStartRequest(asyncDir, bridgeRequest)) {
+				await sleep(POLL_INTERVAL_MS);
+				continue;
+			}
+			if (request.operation !== "start") fs.rmSync(requestPath(asyncDir, id), { force: true });
 			throw canceled;
 		}
 		if (deadline !== undefined && Date.now() >= deadline) {

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -18,7 +18,6 @@ const EXTERNAL_JOB_BRIDGE_RESPONSE_DIR = "external-job-responses";
 const DEFAULT_OPERATION_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 50;
 const MAX_REQUESTS_PER_SWEEP = 100;
-const START_CLAIM_STALE_MS = DEFAULT_OPERATION_TIMEOUT_MS;
 
 interface ExternalJobBridgeRequest {
 	id: string;
@@ -62,8 +61,8 @@ function requestPath(asyncDir: string, id: string): string {
 	return path.join(requestDir(asyncDir), `${id}.json`);
 }
 
-function startClaimPath(asyncDir: string, id: string): string {
-	return path.join(requestDir(asyncDir), `${id}.claim.json`);
+function startClaimDir(asyncDir: string, id: string): string {
+	return path.join(requestDir(asyncDir), `${id}.claim`);
 }
 
 function responsePath(asyncDir: string, id: string): string {
@@ -159,25 +158,16 @@ async function executeBridgeRequest(request: ExternalJobBridgeRequest): Promise<
 
 function claimStartRequest(asyncDir: string, filePath: string, request: ExternalJobBridgeRequest): { request: ExternalJobBridgeRequest; filePath: string } | undefined {
 	const claimed: ExternalJobBridgeRequest = { ...request, claimedAt: Date.now() };
-	const claimPath = startClaimPath(asyncDir, request.id);
-	let fd: number;
+	const claimDir = startClaimDir(asyncDir, request.id);
 	try {
-		fd = fs.openSync(claimPath, "wx");
+		fs.mkdirSync(claimDir);
 	} catch (error) {
 		if (isAlreadyExistsError(error)) return undefined;
 		throw error;
 	}
-	try {
-		fs.writeFileSync(fd, JSON.stringify(claimed), "utf-8");
-	} finally {
-		fs.closeSync(fd);
-	}
+	writeAtomicJson(path.join(claimDir, "request.json"), claimed);
 	fs.rmSync(filePath, { force: true });
-	return { request: claimed, filePath: claimPath };
-}
-
-function startClaimIsStale(request: ExternalJobBridgeRequest): boolean {
-	return Date.now() - (request.claimedAt ?? request.createdAt) >= START_CLAIM_STALE_MS;
+	return { request: claimed, filePath: claimDir };
 }
 
 export function serviceExternalJobBridgeRequests(asyncDir: string): void {
@@ -216,29 +206,14 @@ export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: stri
 		return;
 	}
 	if (inFlight.has(request.id) || fs.existsSync(responsePath(asyncDir, request.id))) return;
-	const claimedStartFile = file.endsWith(".claim.json");
-	if (request.operation === "start" && (claimedStartFile || request.claimedAt !== undefined)) {
-		if (!startClaimIsStale(request)) return;
-		writeAtomicJson(responsePath(asyncDir, request.id), {
-			id: request.id,
-			ok: false,
-			operation: request.operation,
-			provider: request.provider,
-			code: "start-dispatch-unknown",
-			message: `External-job start for provider '${request.provider}' was already claimed by a previous host process, but no provider job id was committed. Refusing to redispatch the prompt automatically.`,
-			completedAt: Date.now(),
-		} satisfies ExternalJobBridgeResponse);
-		fs.rmSync(filePath, { force: true });
-		fs.rmSync(requestPath(asyncDir, request.id), { force: true });
-		return;
-	}
+	if (request.operation === "start" && request.claimedAt !== undefined) return;
 	const claimed = request.operation === "start" ? claimStartRequest(asyncDir, filePath, request) : { request, filePath };
 	if (!claimed) return;
 	const claimedRequest = claimed.request;
 	inFlight.add(claimedRequest.id);
 	void executeBridgeRequest(claimedRequest).then((response) => {
 		writeAtomicJson(responsePath(asyncDir, claimedRequest.id), response);
-		fs.rmSync(claimed.filePath, { force: true });
+		fs.rmSync(claimed.filePath, { recursive: true, force: true });
 	}).catch((error) => {
 		writeAtomicJson(responsePath(asyncDir, claimedRequest.id), {
 			id: claimedRequest.id,

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -234,10 +234,10 @@ export async function requestExternalJobOperation<T extends ExternalJobHandle | 
 	fs.mkdirSync(requestDir(asyncDir), { recursive: true });
 	fs.mkdirSync(responseDir(asyncDir), { recursive: true });
 	writeAtomicJson(requestPath(asyncDir, id), { ...request, id, createdAt: Date.now() } satisfies ExternalJobBridgeRequest);
-	const deadline = Date.now() + timeoutMs;
+	const deadline = request.operation === "start" ? undefined : Date.now() + timeoutMs;
 	const outPath = responsePath(asyncDir, id);
 	while (!fs.existsSync(outPath)) {
-		if (Date.now() >= deadline) {
+		if (deadline !== undefined && Date.now() >= deadline) {
 			throw new ExternalJobProviderError(
 				`External-job provider bridge did not respond to ${request.operation} for provider '${request.provider}' within ${timeoutMs}ms.`,
 				{ code: "bridge-timeout" },

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -26,6 +26,7 @@ interface ExternalJobBridgeRequest {
 	providerJobId?: string;
 	start?: ExternalJobStartInput;
 	createdAt: number;
+	claimedAt?: number;
 }
 
 type ExternalJobBridgeResponse = {
@@ -96,6 +97,7 @@ function assertRequest(value: unknown, filePath: string): ExternalJobBridgeReque
 	if (request.operation !== "start" && request.operation !== "status" && request.operation !== "result" && request.operation !== "reattach") throw new Error(`External-job bridge request '${filePath}' has invalid operation.`);
 	if (typeof request.provider !== "string" || !request.provider.trim()) throw new Error(`External-job bridge request '${filePath}' has invalid provider.`);
 	if (typeof request.createdAt !== "number") throw new Error(`External-job bridge request '${filePath}' has invalid createdAt.`);
+	if (request.claimedAt !== undefined && typeof request.claimedAt !== "number") throw new Error(`External-job bridge request '${filePath}' has invalid claimedAt.`);
 	if (request.operation === "start") {
 		if (!request.start || typeof request.start !== "object" || Array.isArray(request.start)) throw new Error(`External-job bridge start request '${filePath}' is missing start input.`);
 	} else if (typeof request.providerJobId !== "string" || !request.providerJobId.trim()) {
@@ -171,22 +173,37 @@ export function serviceExternalJobBridgeRequests(asyncDir: string): void {
 			continue;
 		}
 		if (inFlight.has(request.id) || fs.existsSync(responsePath(asyncDir, request.id))) continue;
-		inFlight.add(request.id);
-		void executeBridgeRequest(request).then((response) => {
-			writeAtomicJson(responsePath(asyncDir, request.id), response);
-			fs.rmSync(filePath, { force: true });
-		}).catch((error) => {
+		if (request.operation === "start" && request.claimedAt !== undefined) {
 			writeAtomicJson(responsePath(asyncDir, request.id), {
 				id: request.id,
 				ok: false,
 				operation: request.operation,
 				provider: request.provider,
+				code: "start-dispatch-unknown",
+				message: `External-job start for provider '${request.provider}' was already claimed by a previous host process, but no provider job id was committed. Refusing to redispatch the prompt automatically.`,
+				completedAt: Date.now(),
+			} satisfies ExternalJobBridgeResponse);
+			fs.rmSync(filePath, { force: true });
+			continue;
+		}
+		const claimedRequest = request.operation === "start" ? { ...request, claimedAt: Date.now() } : request;
+		if (claimedRequest !== request) writeAtomicJson(filePath, claimedRequest);
+		inFlight.add(claimedRequest.id);
+		void executeBridgeRequest(claimedRequest).then((response) => {
+			writeAtomicJson(responsePath(asyncDir, claimedRequest.id), response);
+			fs.rmSync(filePath, { force: true });
+		}).catch((error) => {
+			writeAtomicJson(responsePath(asyncDir, claimedRequest.id), {
+				id: claimedRequest.id,
+				ok: false,
+				operation: claimedRequest.operation,
+				provider: claimedRequest.provider,
 				code: "bridge-error",
 				message: error instanceof Error ? error.message : String(error),
 				completedAt: Date.now(),
 			} satisfies ExternalJobBridgeResponse);
 		}).finally(() => {
-			inFlight.delete(request.id);
+			inFlight.delete(claimedRequest.id);
 		});
 	}
 }

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -57,6 +57,8 @@ type ExternalJobBridgeResponse = {
 	completedAt: number;
 };
 
+export type ExternalJobBridgeCancel = () => ExternalJobProviderError | undefined;
+
 const inFlight = new Set<string>();
 
 function requestDir(asyncDir: string): string {
@@ -354,7 +356,7 @@ function serviceExternalJobStartClaim(asyncDir: string, file: string): void {
 	fs.rmSync(requestPath(asyncDir, request.id), { force: true });
 }
 
-export async function requestExternalJobOperation<T extends ExternalJobHandle | ExternalJobResult>(asyncDir: string, request: Omit<ExternalJobBridgeRequest, "id" | "createdAt">, timeoutMs = DEFAULT_OPERATION_TIMEOUT_MS): Promise<T> {
+export async function requestExternalJobOperation<T extends ExternalJobHandle | ExternalJobResult>(asyncDir: string, request: Omit<ExternalJobBridgeRequest, "id" | "createdAt">, timeoutMs = DEFAULT_OPERATION_TIMEOUT_MS, cancel?: ExternalJobBridgeCancel): Promise<T> {
 	const id = randomUUID();
 	fs.mkdirSync(requestDir(asyncDir), { recursive: true });
 	fs.mkdirSync(responseDir(asyncDir), { recursive: true });
@@ -362,6 +364,11 @@ export async function requestExternalJobOperation<T extends ExternalJobHandle | 
 	const deadline = request.operation === "start" ? undefined : Date.now() + timeoutMs;
 	const outPath = responsePath(asyncDir, id);
 	while (!fs.existsSync(outPath)) {
+		const canceled = cancel?.();
+		if (canceled) {
+			fs.rmSync(requestPath(asyncDir, id), { force: true });
+			throw canceled;
+		}
 		if (deadline !== undefined && Date.now() >= deadline) {
 			throw new ExternalJobProviderError(
 				`External-job provider bridge did not respond to ${request.operation} for provider '${request.provider}' within ${timeoutMs}ms.`,

--- a/src/runs/shared/external-job-runner.ts
+++ b/src/runs/shared/external-job-runner.ts
@@ -1,0 +1,195 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ExternalJobProviderError, type ExternalJobHandle, type ExternalJobResult, type ExternalJobState } from "../../api/external-job-provider.ts";
+import type { ExternalJobStatus } from "../../shared/types.ts";
+import { requestExternalJobOperation } from "./external-job-bridge.ts";
+
+const STATUS_POLL_INTERVAL_MS = 1_000;
+
+export interface ExternalJobRunResult {
+	output: string;
+	exitCode: number;
+	error?: string;
+	timedOut?: boolean;
+	stopped?: boolean;
+	externalJob: ExternalJobStatus;
+}
+
+export function externalJobPromptDigest(prompt: string): string {
+	return createHash("sha256").update(prompt).digest("hex");
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function terminal(state: ExternalJobState): boolean {
+	return state === "completed" || state === "failed" || state === "stopped" || state === "blocked";
+}
+
+function formatError(error: ExternalJobProviderError, provider: string): string {
+	const blocking = error.blockingJobId ? ` Blocking provider job: ${error.blockingJobId}.` : "";
+	return `External-job provider '${provider}' failed closed (${error.code}): ${error.message}.${blocking}`;
+}
+
+function readExistingExternalJob(asyncDir: string, stepIndex: number): ExternalJobStatus | undefined {
+	try {
+		const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")) as { steps?: Array<{ externalJob?: ExternalJobStatus }> };
+		return status.steps?.[stepIndex]?.externalJob;
+	} catch {
+		return undefined;
+	}
+}
+
+function statusFromHandle(input: {
+	provider: string;
+	promptDigest: string;
+	options: Record<string, unknown>;
+	startedAt?: number;
+	previous?: ExternalJobStatus;
+	handle: ExternalJobHandle;
+	resultArtifactPath?: string;
+}): ExternalJobStatus {
+	return {
+		provider: input.provider,
+		providerJobId: input.handle.providerJobId,
+		promptDigest: input.promptDigest,
+		options: input.options,
+		handleUrl: input.handle.handleUrl ?? input.previous?.handleUrl,
+		conversationUrl: input.handle.conversationUrl ?? input.previous?.conversationUrl,
+		resultArtifactPath: input.resultArtifactPath ?? input.previous?.resultArtifactPath,
+		state: input.handle.state,
+		failureCode: input.handle.failureCode,
+		failureMessage: input.handle.failureMessage,
+		blockingJobId: input.handle.blockingJobId,
+		startedAt: input.previous?.startedAt ?? input.startedAt,
+		updatedAt: Date.now(),
+	};
+}
+
+function failureStatus(input: {
+	provider: string;
+	promptDigest: string;
+	options: Record<string, unknown>;
+	previous?: ExternalJobStatus;
+	code: string;
+	message: string;
+	blockingJobId?: string;
+}): ExternalJobStatus {
+	return {
+		provider: input.provider,
+		providerJobId: input.previous?.providerJobId,
+		promptDigest: input.promptDigest,
+		options: input.options,
+		handleUrl: input.previous?.handleUrl,
+		conversationUrl: input.previous?.conversationUrl,
+		resultArtifactPath: input.previous?.resultArtifactPath,
+		state: input.blockingJobId ? "blocked" : "failed",
+		failureCode: input.code,
+		failureMessage: input.message,
+		blockingJobId: input.blockingJobId,
+		startedAt: input.previous?.startedAt,
+		updatedAt: Date.now(),
+	};
+}
+
+function resultOutput(result: ExternalJobResult, artifactPath: string | undefined): string {
+	if (result.output?.trim()) return result.output.trim();
+	if (artifactPath) return `External job finished. Result artifact: ${artifactPath}`;
+	return "External job finished without text output.";
+}
+
+export async function runExternalJob(input: {
+	provider: string;
+	options?: Record<string, unknown>;
+	cwd: string;
+	prompt: string;
+	asyncDir: string;
+	stepIndex: number;
+	runId: string;
+	agent: string;
+	sessionId?: string;
+	registerTimeout?: (stop: (() => void) | undefined) => void;
+	registerStop?: (stop: (() => void) | undefined) => void;
+	timeoutMessage?: string;
+	stopMessage?: string;
+	onExternalJob?: (status: ExternalJobStatus) => void;
+}): Promise<ExternalJobRunResult> {
+	const provider = input.provider;
+	const options = input.options ?? {};
+	const promptDigest = externalJobPromptDigest(input.prompt);
+	const startedAt = Date.now();
+	let timedOut = false;
+	let stopped = false;
+	let current = readExistingExternalJob(input.asyncDir, input.stepIndex);
+	const timeout = () => { timedOut = true; };
+	const stop = () => { stopped = true; };
+	input.registerTimeout?.(timeout);
+	input.registerStop?.(stop);
+	const publish = (status: ExternalJobStatus) => {
+		current = status;
+		input.onExternalJob?.(status);
+	};
+	try {
+		let handle: ExternalJobHandle;
+		if (current?.providerJobId) {
+			if (current.provider !== provider || current.promptDigest !== promptDigest) {
+				const message = `Existing external job '${current.providerJobId}' does not match provider or prompt digest. Refusing to redispatch prompt.`;
+				const status = failureStatus({ provider, promptDigest, options, previous: current, code: "recovery-mismatch", message });
+				publish(status);
+				return { output: message, exitCode: 1, error: message, externalJob: status };
+			}
+			handle = await requestExternalJobOperation<ExternalJobHandle>(input.asyncDir, { operation: "reattach", provider, providerJobId: current.providerJobId });
+		} else {
+			handle = await requestExternalJobOperation<ExternalJobHandle>(input.asyncDir, {
+				operation: "start",
+				provider,
+				start: {
+					prompt: input.prompt,
+					promptDigest,
+					cwd: input.cwd,
+					runId: input.runId,
+					stepIndex: input.stepIndex,
+					agent: input.agent,
+					options,
+					...(input.sessionId ? { sessionId: input.sessionId } : {}),
+				},
+			});
+		}
+		publish(statusFromHandle({ provider, promptDigest, options, startedAt, previous: current, handle }));
+		while (!terminal(handle.state)) {
+			if (timedOut || stopped) {
+				const message = stopped
+					? input.stopMessage ?? `Subagent stopped locally; external provider job '${handle.providerJobId}' may still be running.`
+					: input.timeoutMessage ?? `Subagent timed out locally; external provider job '${handle.providerJobId}' may still be running.`;
+				return { output: message, exitCode: 1, error: message, ...(timedOut ? { timedOut: true } : {}), ...(stopped ? { stopped: true } : {}), externalJob: current! };
+			}
+			await sleep(STATUS_POLL_INTERVAL_MS);
+			handle = await requestExternalJobOperation<ExternalJobHandle>(input.asyncDir, { operation: "status", provider, providerJobId: handle.providerJobId });
+			publish(statusFromHandle({ provider, promptDigest, options, previous: current, handle }));
+		}
+		const result = await requestExternalJobOperation<ExternalJobResult>(input.asyncDir, { operation: "result", provider, providerJobId: handle.providerJobId });
+		let artifactPath = result.artifactPath;
+		if (!artifactPath && result.output !== undefined) {
+			artifactPath = path.join(input.asyncDir, `external-job-${input.stepIndex}.result.md`);
+			fs.writeFileSync(artifactPath, result.output, "utf-8");
+		}
+		const finalStatus = statusFromHandle({ provider, promptDigest, options, previous: current, handle: result, resultArtifactPath: artifactPath });
+		publish(finalStatus);
+		const output = resultOutput(result, artifactPath);
+		const error = result.state === "completed" ? undefined : result.failureMessage ?? `External job ${result.state}.`;
+		return { output, exitCode: result.state === "completed" ? 0 : 1, ...(error ? { error } : {}), externalJob: finalStatus };
+	} catch (error) {
+		const providerError = error instanceof ExternalJobProviderError
+			? error
+			: new ExternalJobProviderError(error instanceof Error ? error.message : String(error), { code: "provider-error", cause: error });
+		const message = formatError(providerError, provider);
+		const status = failureStatus({ provider, promptDigest, options, previous: current, code: providerError.code, message, ...(providerError.blockingJobId ? { blockingJobId: providerError.blockingJobId } : {}) });
+		publish(status);
+		return { output: message, exitCode: 1, error: message, externalJob: status };
+	} finally {
+		input.registerTimeout?.(undefined);
+		input.registerStop?.(undefined);
+	}
+}

--- a/src/runs/shared/external-job-runner.ts
+++ b/src/runs/shared/external-job-runner.ts
@@ -100,6 +100,13 @@ function resultOutput(result: ExternalJobResult, artifactPath: string | undefine
 	return "External job finished without text output.";
 }
 
+function blocksStartRedispatch(status: ExternalJobStatus, provider: string, promptDigest: string): boolean {
+	return status.provider === provider
+		&& status.promptDigest === promptDigest
+		&& !status.providerJobId
+		&& status.failureCode !== "provider-unavailable";
+}
+
 export async function runExternalJob(input: {
 	provider: string;
 	options?: Record<string, unknown>;
@@ -142,6 +149,13 @@ export async function runExternalJob(input: {
 			}
 			handle = await requestExternalJobOperation<ExternalJobHandle>(input.asyncDir, { operation: "reattach", provider, providerJobId: current.providerJobId });
 		} else {
+			if (current && blocksStartRedispatch(current, provider, promptDigest)) {
+				const message = `External-job start for provider '${provider}' previously ended without a durable provider job id. Refusing to redispatch the prompt automatically.`;
+				const status = failureStatus({ provider, promptDigest, options, previous: current, code: "start-redispatch-blocked", message });
+				publish(status);
+				return { output: message, exitCode: 1, error: message, externalJob: status };
+			}
+			publish({ provider, promptDigest, options, state: "queued", startedAt, updatedAt: Date.now() });
 			handle = await requestExternalJobOperation<ExternalJobHandle>(input.asyncDir, {
 				operation: "start",
 				provider,

--- a/src/runs/shared/external-job-runner.ts
+++ b/src/runs/shared/external-job-runner.ts
@@ -138,6 +138,13 @@ export async function runExternalJob(input: {
 		current = status;
 		input.onExternalJob?.(status);
 	};
+	const localCancellation = () => {
+		if (!timedOut && !stopped) return undefined;
+		const message = stopped
+			? input.stopMessage ?? `Subagent stopped locally before external provider '${provider}' returned a job id. The provider start may still be running.`
+			: input.timeoutMessage ?? `Subagent timed out locally before external provider '${provider}' returned a job id. The provider start may still be running.`;
+		return new ExternalJobProviderError(message, { code: stopped ? "local-stop" : "local-timeout" });
+	};
 	try {
 		let handle: ExternalJobHandle;
 		if (current?.providerJobId) {
@@ -156,7 +163,7 @@ export async function runExternalJob(input: {
 				return { output: message, exitCode: 1, error: message, externalJob: status };
 			}
 			publish({ provider, promptDigest, options, state: "queued", startedAt, updatedAt: Date.now() });
-			handle = await requestExternalJobOperation<ExternalJobHandle>(input.asyncDir, {
+				handle = await requestExternalJobOperation<ExternalJobHandle>(input.asyncDir, {
 				operation: "start",
 				provider,
 				start: {
@@ -169,7 +176,7 @@ export async function runExternalJob(input: {
 					options,
 					...(input.sessionId ? { sessionId: input.sessionId } : {}),
 				},
-			});
+			}, undefined, localCancellation);
 		}
 		publish(statusFromHandle({ provider, promptDigest, options, startedAt, previous: current, handle }));
 		while (!terminal(handle.state)) {
@@ -201,7 +208,7 @@ export async function runExternalJob(input: {
 		const message = formatError(providerError, provider);
 		const status = failureStatus({ provider, promptDigest, options, previous: current, code: providerError.code, message, ...(providerError.blockingJobId ? { blockingJobId: providerError.blockingJobId } : {}) });
 		publish(status);
-		return { output: message, exitCode: 1, error: message, externalJob: status };
+		return { output: message, exitCode: 1, error: message, ...(timedOut ? { timedOut: true } : {}), ...(stopped ? { stopped: true } : {}), externalJob: status };
 	} finally {
 		input.registerTimeout?.(undefined);
 		input.registerStop?.(undefined);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1290,6 +1290,11 @@ export type AgentRunnerConfig =
 		command: string;
 		args?: string[];
 		promptDelivery?: "stdin";
+	}
+	| {
+		type: "external-job";
+		provider: string;
+		options?: Record<string, unknown>;
 	};
 
 export interface ExternalCliRunnerStatus {
@@ -1304,6 +1309,35 @@ export interface ExternalCliRunnerStatus {
 		structuredOutput: false;
 		toolEvents: false;
 	};
+}
+
+export interface ExternalJobRunnerStatus {
+	type: "external-job";
+	provider: string;
+	options: Record<string, unknown>;
+	capabilities: {
+		stop: false;
+		steer: false;
+		resume: false;
+		structuredOutput: false;
+		toolEvents: false;
+	};
+}
+
+export interface ExternalJobStatus {
+	provider: string;
+	providerJobId?: string;
+	promptDigest: string;
+	options: Record<string, unknown>;
+	handleUrl?: string;
+	conversationUrl?: string;
+	resultArtifactPath?: string;
+	state: "queued" | "running" | "completed" | "failed" | "stopped" | "blocked";
+	failureCode?: string;
+	failureMessage?: string;
+	blockingJobId?: string;
+	startedAt?: number;
+	updatedAt?: number;
 }
 
 export interface ExternalProcessStatus {
@@ -1371,8 +1405,9 @@ export interface AsyncStatus {
 	workflowKey?: string;
 	steps?: Array<{
 		agent: string;
-		runner?: ExternalCliRunnerStatus;
+		runner?: ExternalCliRunnerStatus | ExternalJobRunnerStatus;
 		externalProcess?: ExternalProcessStatus;
+		externalJob?: ExternalJobStatus;
 		/** Resolved launch context for this child step. */
 		context?: "fresh" | "fork";
 		/** Short caller-facing task/goal shown in fleet surfaces when available. */

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -215,6 +215,26 @@ Review carefully.`.replace(" description:", "description:"));
 		assert.deepEqual(discoverAgents(project, "project").agents.find((agent) => agent.name === "external")?.runner, external.runner);
 	}));
 
+	it("parses and serializes an external-job runner", () => withTempHome(() => {
+		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-external-job-agent-"));
+		tempDirs.push(project);
+		writeAgent(path.join(project, ".pi", "agents", "gpt-pro.md"), `---
+name: gpt-pro
+description: Surf GPT Pro advisor
+runner:
+  type: external-job
+  provider: surf-oracle
+  options:
+    tier: pro
+async: true
+---
+Review carefully.`);
+
+		const gptPro = discoverAgents(project, "project").agents.find((agent) => agent.name === "gpt-pro")!;
+		assert.deepEqual(gptPro.runner, { type: "external-job", provider: "surf-oracle", options: { tier: "pro" } });
+		assert.match(serializeAgent(gptPro), /runner:\n  type: external-job\n  provider: surf-oracle/);
+	}));
+
 	it("rejects invalid and Pi-only external runner fields", () => withTempHome(() => {
 		const invalidCases = [
 			"type: unknown\n  command: node",
@@ -222,12 +242,14 @@ Review carefully.`.replace(" description:", "description:"));
 			"type: external-cli\n  command: node\n  args: nope",
 			"type: external-cli\n  command: node\n  args: [ok, 1]",
 			"type: external-cli\n  command: node\n  promptDelivery: argv",
+			"type: external-job\n  provider: ''",
+			"type: external-job\n  provider: surf-oracle\n  options: []",
 		];
 		for (const [index, runner] of invalidCases.entries()) {
 			const project = fs.mkdtempSync(path.join(os.tmpdir(), `pi-subagents-invalid-runner-${index}-`));
 			tempDirs.push(project);
 			writeAgent(path.join(project, ".pi", "agents", "external.md"), `---\nname: external\ndescription: External\nrunner:\n  ${runner}\n---\nBody`);
-			assert.throws(() => discoverAgents(project, "project"), /invalid runner\.type|non-empty command|args must be an array of strings|promptDelivery must be 'stdin'/);
+			assert.throws(() => discoverAgents(project, "project"), /invalid runner\.type|non-empty command|args must be an array of strings|promptDelivery must be 'stdin'|provider string|options must be a JSON-serializable object/);
 		}
 		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-runner-pi-only-"));
 		tempDirs.push(project);
@@ -1481,6 +1503,7 @@ Do work
 			const builtins = discoverAgentsAll(dir).builtin;
 			assert.ok(builtins.length > 0);
 			for (const agent of builtins) {
+				if (agent.runner?.type === "external-cli" || agent.runner?.type === "external-job") continue;
 				assert.ok(agent.tools && agent.tools.length > 0, `${agent.name} should have explicit tools frontmatter`);
 			}
 		} finally {

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -586,25 +586,27 @@ describe("async interrupt action", () => {
 		}
 	});
 
-	it("rejects interrupt for a running external CLI run without writing a pause request", async () => {
-		const state = createState();
-		const runId = `interrupt-external-${Date.now().toString(36)}`;
-		const asyncDir = createRunningAsync(state, runId, { track: false });
-		const statusPath = path.join(asyncDir, "status.json");
-		const status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
-		status.steps[0].runner = { type: "external-cli" };
-		fs.writeFileSync(statusPath, JSON.stringify(status), "utf-8");
-		try {
-			const result = await executorWithKill(state, () => {
-				throw new Error("external interrupt should not signal the runner");
-			}).execute("interrupt", { action: "interrupt", id: runId }, new AbortController().signal, undefined, ctx());
+	it("rejects interrupt for a running external runner without writing a pause request", async () => {
+		for (const runner of [{ type: "external-cli" }, { type: "external-job", provider: "surf-oracle", options: {} }]) {
+			const state = createState();
+			const runId = `interrupt-external-${runner.type}-${Date.now().toString(36)}`;
+			const asyncDir = createRunningAsync(state, runId, { track: false });
+			const statusPath = path.join(asyncDir, "status.json");
+			const status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+			status.steps[0].runner = runner;
+			fs.writeFileSync(statusPath, JSON.stringify(status), "utf-8");
+			try {
+				const result = await executorWithKill(state, () => {
+					throw new Error("external interrupt should not signal the runner");
+				}).execute("interrupt", { action: "interrupt", id: runId }, new AbortController().signal, undefined, ctx());
 
-			assert.equal(result.isError, true);
-			assert.match(text(result), /Interrupt is unsupported for one-shot external CLI async run/);
-			assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), false);
-			assert.equal(JSON.parse(fs.readFileSync(statusPath, "utf-8")).state, "running");
-		} finally {
-			cleanup(runId, asyncDir);
+				assert.equal(result.isError, true);
+				assert.match(text(result), new RegExp(`Interrupt is unsupported for external async run ${runId}; use stop instead\\.`));
+				assert.equal(fs.existsSync(path.join(asyncDir, "control", "interrupt.json")), false);
+				assert.equal(JSON.parse(fs.readFileSync(statusPath, "utf-8")).state, "running");
+			} finally {
+				cleanup(runId, asyncDir);
+			}
 		}
 	});
 

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -142,7 +142,7 @@ describe("external-job runner bridge", () => {
 		assert.match(result.error ?? "", /job-blocking/);
 	});
 
-	it("does not redispatch a claimed start request after host restart", () => {
+	it("does not redispatch a partial claimed start request after host restart", () => {
 		const dir = tempDir("pi-external-job-claimed-start-");
 		let starts = 0;
 		registerExternalJobProvider({
@@ -154,12 +154,12 @@ describe("external-job runner bridge", () => {
 		});
 		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
 		fs.mkdirSync(requestDir, { recursive: true });
+		fs.mkdirSync(path.join(requestDir, "start-timeout.claim"));
 		fs.writeFileSync(path.join(requestDir, "start-timeout.json"), JSON.stringify({
 			id: "start-timeout",
 			operation: "start",
 			provider: "surf-oracle",
 			createdAt: 1,
-			claimedAt: 2,
 			start: {
 				prompt: "prompt",
 				promptDigest: externalJobPromptDigest("prompt"),
@@ -174,11 +174,8 @@ describe("external-job runner bridge", () => {
 		serviceExternalJobBridgeRequests(dir);
 
 		assert.equal(starts, 0);
-		const response = JSON.parse(fs.readFileSync(path.join(dir, "external-job-responses", "start-timeout.json"), "utf-8"));
-		assert.equal(response.ok, false);
-		assert.equal(response.code, "start-dispatch-unknown");
-		assert.match(response.message, /Refusing to redispatch/);
-		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.json")), false);
+		assert.equal(fs.existsSync(path.join(dir, "external-job-responses", "start-timeout.json")), false);
+		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.json")), true);
 	});
 
 	it("does not dispatch a start request twice while the first claim is active", async () => {
@@ -224,6 +221,42 @@ describe("external-job runner bridge", () => {
 		assert.equal(response.ok, true);
 		assert.equal(response.result.providerJobId, "job-race");
 		assert.equal(starts, 1);
+	});
+
+	it("does not fail an old active start claim while provider start may still be running", () => {
+		const dir = tempDir("pi-external-job-long-active-claim-");
+		let starts = 0;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => { starts += 1; return { providerJobId: "job-duplicate", state: "completed" }; },
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		fs.mkdirSync(requestDir, { recursive: true });
+		fs.writeFileSync(path.join(requestDir, "start-long.json"), JSON.stringify({
+			id: "start-long",
+			operation: "start",
+			provider: "surf-oracle",
+			createdAt: 1,
+			claimedAt: 2,
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-long",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		}), "utf-8");
+
+		serviceExternalJobBridgeRequestFile(dir, "start-long.json");
+
+		assert.equal(starts, 0);
+		assert.equal(fs.existsSync(path.join(dir, "external-job-responses", "start-long.json")), false);
+		assert.equal(fs.existsSync(path.join(requestDir, "start-long.json")), true);
 	});
 
 	it("ignores a stale start request snapshot after another host claimed it", async () => {

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { EXTERNAL_JOB_PROVIDER_REGISTRY_KEY, ExternalJobProviderError, registerExternalJobProvider } from "../../src/api/external-job-provider.ts";
-import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, serviceExternalJobBridgeRequests } from "../../src/runs/shared/external-job-bridge.ts";
+import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, serviceExternalJobBridgeRequestFile, serviceExternalJobBridgeRequests } from "../../src/runs/shared/external-job-bridge.ts";
 import { externalJobPromptDigest, runExternalJob } from "../../src/runs/shared/external-job-runner.ts";
 
 const tempDirs: string[] = [];
@@ -32,6 +32,14 @@ async function serviceUntil<T>(asyncDir: string, promise: Promise<T>): Promise<T
 		await new Promise((resolve) => setTimeout(resolve, 10));
 	}
 	return promise;
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	while (!fs.existsSync(filePath)) {
+		if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${filePath}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
 }
 
 describe("external-job runner bridge", () => {
@@ -171,6 +179,96 @@ describe("external-job runner bridge", () => {
 		assert.equal(response.code, "start-dispatch-unknown");
 		assert.match(response.message, /Refusing to redispatch/);
 		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.json")), false);
+	});
+
+	it("does not dispatch a start request twice while the first claim is active", async () => {
+		const dir = tempDir("pi-external-job-active-claim-");
+		let starts = 0;
+		let resolveStart: ((value: { providerJobId: string; state: "completed" }) => void) | undefined;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => {
+				starts += 1;
+				return new Promise((resolve) => { resolveStart = resolve; });
+			},
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		fs.mkdirSync(requestDir, { recursive: true });
+		fs.writeFileSync(path.join(requestDir, "start-race.json"), JSON.stringify({
+			id: "start-race",
+			operation: "start",
+			provider: "surf-oracle",
+			createdAt: Date.now(),
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-race",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		}), "utf-8");
+
+		serviceExternalJobBridgeRequests(dir);
+		serviceExternalJobBridgeRequests(dir);
+
+		assert.equal(starts, 1);
+		assert.equal(fs.existsSync(path.join(dir, "external-job-responses", "start-race.json")), false);
+		resolveStart!({ providerJobId: "job-race", state: "completed" });
+		await waitForFile(path.join(dir, "external-job-responses", "start-race.json"));
+		const response = JSON.parse(fs.readFileSync(path.join(dir, "external-job-responses", "start-race.json"), "utf-8"));
+		assert.equal(response.ok, true);
+		assert.equal(response.result.providerJobId, "job-race");
+		assert.equal(starts, 1);
+	});
+
+	it("ignores a stale start request snapshot after another host claimed it", async () => {
+		const dir = tempDir("pi-external-job-stale-snapshot-");
+		let starts = 0;
+		let resolveStart: ((value: { providerJobId: string; state: "completed" }) => void) | undefined;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => {
+				starts += 1;
+				return new Promise((resolve) => { resolveStart = resolve; });
+			},
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		fs.mkdirSync(requestDir, { recursive: true });
+		fs.writeFileSync(path.join(requestDir, "start-stale.json"), JSON.stringify({
+			id: "start-stale",
+			operation: "start",
+			provider: "surf-oracle",
+			createdAt: Date.now(),
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-stale",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		}), "utf-8");
+
+		serviceExternalJobBridgeRequests(dir);
+		serviceExternalJobBridgeRequestFile(dir, "start-stale.json");
+
+		assert.equal(starts, 1);
+		assert.equal(fs.existsSync(path.join(dir, "external-job-responses", "start-stale.json")), false);
+		resolveStart!({ providerJobId: "job-stale", state: "completed" });
+		await waitForFile(path.join(dir, "external-job-responses", "start-stale.json"));
+		const response = JSON.parse(fs.readFileSync(path.join(dir, "external-job-responses", "start-stale.json"), "utf-8"));
+		assert.equal(response.ok, true);
+		assert.equal(response.result.providerJobId, "job-stale");
+		assert.equal(starts, 1);
 	});
 
 	it("does not start again after a bridge timeout without provider job id", async () => {

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { EXTERNAL_JOB_PROVIDER_REGISTRY_KEY, ExternalJobProviderError, registerExternalJobProvider } from "../../src/api/external-job-provider.ts";
-import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, serviceExternalJobBridgeRequestFile, serviceExternalJobBridgeRequests } from "../../src/runs/shared/external-job-bridge.ts";
+import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, requestExternalJobOperation, serviceExternalJobBridgeRequestFile, serviceExternalJobBridgeRequests } from "../../src/runs/shared/external-job-bridge.ts";
 import { externalJobPromptDigest, runExternalJob } from "../../src/runs/shared/external-job-runner.ts";
 
 const tempDirs: string[] = [];
@@ -343,5 +343,46 @@ describe("external-job runner bridge", () => {
 		assert.equal(result.externalJob.failureCode, "start-redispatch-blocked");
 		assert.match(result.error ?? "", /Refusing to redispatch/);
 		assert.equal(fs.existsSync(path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR)), false);
+	});
+
+	it("waits for a slow start response instead of timing out without provider job id", async () => {
+		const dir = tempDir("pi-external-job-slow-start-");
+		let starts = 0;
+		let settled = false;
+		let resolveStart: ((value: { providerJobId: string; state: "completed" }) => void) | undefined;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => {
+				starts += 1;
+				return new Promise((resolve) => { resolveStart = resolve; });
+			},
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+		const operation = requestExternalJobOperation(dir, {
+			operation: "start",
+			provider: "surf-oracle",
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-slow",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		}, 1).finally(() => { settled = true; });
+
+		serviceExternalJobBridgeRequests(dir);
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		assert.equal(starts, 1);
+		assert.equal(settled, false);
+
+		resolveStart!({ providerJobId: "job-slow", state: "completed" });
+		const result = await serviceUntil(dir, operation);
+
+		assert.equal(result.providerJobId, "job-slow");
+		assert.equal(starts, 1);
 	});
 });

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { EXTERNAL_JOB_PROVIDER_REGISTRY_KEY, ExternalJobProviderError, registerExternalJobProvider } from "../../src/api/external-job-provider.ts";
-import { serviceExternalJobBridgeRequests } from "../../src/runs/shared/external-job-bridge.ts";
+import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, serviceExternalJobBridgeRequests } from "../../src/runs/shared/external-job-bridge.ts";
 import { externalJobPromptDigest, runExternalJob } from "../../src/runs/shared/external-job-runner.ts";
 
 const tempDirs: string[] = [];
@@ -132,5 +132,85 @@ describe("external-job runner bridge", () => {
 		assert.equal(result.externalJob.state, "blocked");
 		assert.equal(result.externalJob.blockingJobId, "job-blocking");
 		assert.match(result.error ?? "", /job-blocking/);
+	});
+
+	it("does not redispatch a claimed start request after host restart", () => {
+		const dir = tempDir("pi-external-job-claimed-start-");
+		let starts = 0;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => { starts += 1; return { providerJobId: "job-duplicate", state: "completed" }; },
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		fs.mkdirSync(requestDir, { recursive: true });
+		fs.writeFileSync(path.join(requestDir, "start-timeout.json"), JSON.stringify({
+			id: "start-timeout",
+			operation: "start",
+			provider: "surf-oracle",
+			createdAt: 1,
+			claimedAt: 2,
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-timeout",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		}), "utf-8");
+
+		serviceExternalJobBridgeRequests(dir);
+
+		assert.equal(starts, 0);
+		const response = JSON.parse(fs.readFileSync(path.join(dir, "external-job-responses", "start-timeout.json"), "utf-8"));
+		assert.equal(response.ok, false);
+		assert.equal(response.code, "start-dispatch-unknown");
+		assert.match(response.message, /Refusing to redispatch/);
+		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.json")), false);
+	});
+
+	it("does not start again after a bridge timeout without provider job id", async () => {
+		const dir = tempDir("pi-external-job-timeout-retry-");
+		const prompt = "prompt";
+		fs.writeFileSync(path.join(dir, "status.json"), JSON.stringify({
+			steps: [{
+				externalJob: {
+					provider: "surf-oracle",
+					promptDigest: externalJobPromptDigest(prompt),
+					options: {},
+					state: "failed",
+					failureCode: "bridge-timeout",
+					failureMessage: "Bridge timed out before a provider job id was committed.",
+				},
+			}],
+		}), "utf-8");
+		let starts = 0;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => { starts += 1; return { providerJobId: "job-2", state: "completed" }; },
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+
+		const result = await runExternalJob({
+			provider: "surf-oracle",
+			cwd: dir,
+			prompt,
+			asyncDir: dir,
+			stepIndex: 0,
+			runId: "run-timeout-retry",
+			agent: "gpt-pro",
+		});
+
+		assert.equal(starts, 0);
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.externalJob.failureCode, "start-redispatch-blocked");
+		assert.match(result.error ?? "", /Refusing to redispatch/);
+		assert.equal(fs.existsSync(path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR)), false);
 	});
 });

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -308,6 +308,47 @@ describe("external-job runner bridge", () => {
 		assert.equal(fs.existsSync(claimDir), false);
 	});
 
+	it("recovers a persisted start handle from a dead owner claim", () => {
+		const dir = tempDir("pi-external-job-dead-owner-handle-");
+		let starts = 0;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => { starts += 1; return { providerJobId: "job-duplicate", state: "completed" }; },
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		const claimDir = path.join(requestDir, "start-recovered.claim");
+		fs.mkdirSync(claimDir, { recursive: true });
+		fs.writeFileSync(path.join(claimDir, "owner.json"), JSON.stringify({ version: 1, pid: 9_999_999, hostname: os.hostname(), claimedAt: 1 }), "utf-8");
+		fs.writeFileSync(path.join(claimDir, "request.json"), JSON.stringify({
+			id: "start-recovered",
+			operation: "start",
+			provider: "surf-oracle",
+			createdAt: 1,
+			claimedAt: 2,
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-recovered",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		}), "utf-8");
+		fs.writeFileSync(path.join(claimDir, "handle.json"), JSON.stringify({ providerJobId: "job-recovered", state: "running" }), "utf-8");
+
+		serviceExternalJobBridgeRequests(dir);
+
+		assert.equal(starts, 0);
+		const response = JSON.parse(fs.readFileSync(path.join(dir, "external-job-responses", "start-recovered.json"), "utf-8"));
+		assert.equal(response.ok, true);
+		assert.equal(response.result.providerJobId, "job-recovered");
+		assert.equal(fs.existsSync(path.join(claimDir, "completed.json")), true);
+	});
+
 	it("ignores a stale start request snapshot after another host claimed it", async () => {
 		const dir = tempDir("pi-external-job-stale-snapshot-");
 		let starts = 0;
@@ -513,17 +554,35 @@ describe("external-job runner bridge", () => {
 			agent: "gpt-pro",
 			registerTimeout: (registered) => { timeout = registered; },
 		});
-		serviceExternalJobBridgeRequests(dir);
-		await new Promise((resolve) => setTimeout(resolve, 20));
-
 		timeout!();
 		const result = await operation;
 
-		assert.equal(starts, 1);
+		assert.equal(starts, 0);
 		assert.equal(result.exitCode, 1);
 		assert.equal(result.timedOut, true);
 		assert.equal(result.externalJob.failureCode, "local-timeout");
 		assert.match(result.error ?? "", /timed out locally/);
+		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		const tombstone = fs.readdirSync(requestDir).find((entry) => entry.endsWith(".claim"));
+		assert.ok(tombstone);
+		const staleId = tombstone.replace(/\.claim$/, "");
+		fs.writeFileSync(path.join(requestDir, `${staleId}.json`), JSON.stringify({
+			id: staleId,
+			operation: "start",
+			provider: "surf-oracle",
+			createdAt: Date.now(),
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-local-timeout",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		}), "utf-8");
+		serviceExternalJobBridgeRequests(dir);
+		assert.equal(starts, 0);
 	});
 
 	it("waits for a slow start response instead of timing out without provider job id", async () => {

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -142,7 +142,7 @@ describe("external-job runner bridge", () => {
 		assert.match(result.error ?? "", /job-blocking/);
 	});
 
-	it("does not redispatch a partial claimed start request after host restart", () => {
+	it("recovers an incomplete start claim and dispatches the original request once", async () => {
 		const dir = tempDir("pi-external-job-claimed-start-");
 		let starts = 0;
 		registerExternalJobProvider({
@@ -172,10 +172,15 @@ describe("external-job runner bridge", () => {
 		}), "utf-8");
 
 		serviceExternalJobBridgeRequests(dir);
+		serviceExternalJobBridgeRequests(dir);
+		await waitForFile(path.join(dir, "external-job-responses", "start-timeout.json"));
+		const response = JSON.parse(fs.readFileSync(path.join(dir, "external-job-responses", "start-timeout.json"), "utf-8"));
 
-		assert.equal(starts, 0);
-		assert.equal(fs.existsSync(path.join(dir, "external-job-responses", "start-timeout.json")), false);
-		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.json")), true);
+		assert.equal(starts, 1);
+		assert.equal(response.ok, true);
+		assert.equal(response.result.providerJobId, "job-duplicate");
+		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.claim")), false);
+		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.json")), false);
 	});
 
 	it("does not dispatch a start request twice while the first claim is active", async () => {
@@ -234,8 +239,11 @@ describe("external-job runner bridge", () => {
 			result: () => ({ providerJobId: "unused", state: "completed" }),
 		});
 		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		const claimDir = path.join(requestDir, "start-long.claim");
 		fs.mkdirSync(requestDir, { recursive: true });
-		fs.writeFileSync(path.join(requestDir, "start-long.json"), JSON.stringify({
+		fs.mkdirSync(claimDir);
+		fs.writeFileSync(path.join(claimDir, "owner.json"), JSON.stringify({ version: 1, pid: process.pid, hostname: os.hostname(), claimedAt: 1 }), "utf-8");
+		fs.writeFileSync(path.join(claimDir, "request.json"), JSON.stringify({
 			id: "start-long",
 			operation: "start",
 			provider: "surf-oracle",
@@ -252,11 +260,52 @@ describe("external-job runner bridge", () => {
 			},
 		}), "utf-8");
 
-		serviceExternalJobBridgeRequestFile(dir, "start-long.json");
+		serviceExternalJobBridgeRequestFile(dir, "start-long.claim");
 
 		assert.equal(starts, 0);
 		assert.equal(fs.existsSync(path.join(dir, "external-job-responses", "start-long.json")), false);
-		assert.equal(fs.existsSync(path.join(requestDir, "start-long.json")), true);
+		assert.equal(fs.existsSync(claimDir), true);
+	});
+
+	it("settles an abandoned start claim without redispatching", () => {
+		const dir = tempDir("pi-external-job-abandoned-claim-");
+		let starts = 0;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => { starts += 1; return { providerJobId: "job-duplicate", state: "completed" }; },
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		const claimDir = path.join(requestDir, "start-abandoned.claim");
+		fs.mkdirSync(claimDir, { recursive: true });
+		fs.writeFileSync(path.join(claimDir, "owner.json"), JSON.stringify({ version: 1, pid: 9_999_999, hostname: os.hostname(), claimedAt: 1 }), "utf-8");
+		fs.writeFileSync(path.join(claimDir, "request.json"), JSON.stringify({
+			id: "start-abandoned",
+			operation: "start",
+			provider: "surf-oracle",
+			createdAt: 1,
+			claimedAt: 2,
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-abandoned",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		}), "utf-8");
+
+		serviceExternalJobBridgeRequests(dir);
+
+		assert.equal(starts, 0);
+		const response = JSON.parse(fs.readFileSync(path.join(dir, "external-job-responses", "start-abandoned.json"), "utf-8"));
+		assert.equal(response.ok, false);
+		assert.equal(response.code, "start-dispatch-abandoned");
+		assert.match(response.message, /Refusing to redispatch/);
+		assert.equal(fs.existsSync(claimDir), false);
 	});
 
 	it("ignores a stale start request snapshot after another host claimed it", async () => {

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -179,7 +179,7 @@ describe("external-job runner bridge", () => {
 		assert.equal(starts, 1);
 		assert.equal(response.ok, true);
 		assert.equal(response.result.providerJobId, "job-duplicate");
-		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.claim")), false);
+		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.claim")), true);
 		assert.equal(fs.existsSync(path.join(requestDir, "start-timeout.json")), false);
 	});
 
@@ -350,6 +350,100 @@ describe("external-job runner bridge", () => {
 		const response = JSON.parse(fs.readFileSync(path.join(dir, "external-job-responses", "start-stale.json"), "utf-8"));
 		assert.equal(response.ok, true);
 		assert.equal(response.result.providerJobId, "job-stale");
+		assert.equal(starts, 1);
+	});
+
+	it("does not redispatch after a completed start claim", async () => {
+		const dir = tempDir("pi-external-job-completed-claim-");
+		let starts = 0;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => { starts += 1; return { providerJobId: "job-completed", state: "completed" }; },
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		fs.mkdirSync(requestDir, { recursive: true });
+		const request = {
+			id: "start-completed",
+			operation: "start",
+			provider: "surf-oracle",
+			createdAt: Date.now(),
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-completed",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		};
+		fs.writeFileSync(path.join(requestDir, "start-completed.json"), JSON.stringify(request), "utf-8");
+
+		serviceExternalJobBridgeRequests(dir);
+		await waitForFile(path.join(dir, "external-job-responses", "start-completed.json"));
+		fs.rmSync(path.join(dir, "external-job-responses", "start-completed.json"), { force: true });
+		fs.writeFileSync(path.join(requestDir, "start-completed.json"), JSON.stringify(request), "utf-8");
+		serviceExternalJobBridgeRequests(dir);
+
+		assert.equal(starts, 1);
+		assert.equal(fs.existsSync(path.join(requestDir, "start-completed.claim")), true);
+	});
+
+	it("does not let completed start claims starve later requests", async () => {
+		const dir = tempDir("pi-external-job-completed-claim-starvation-");
+		let starts = 0;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => { starts += 1; return { providerJobId: "job-after-tombstones", state: "completed" }; },
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+		const requestDir = path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR);
+		fs.mkdirSync(requestDir, { recursive: true });
+		for (let index = 0; index < 100; index += 1) {
+			const id = `000-${String(index).padStart(3, "0")}`;
+			const claimDir = path.join(requestDir, `${id}.claim`);
+			fs.mkdirSync(claimDir);
+			fs.writeFileSync(path.join(claimDir, "completed.json"), JSON.stringify({ completedAt: 1 }), "utf-8");
+			fs.writeFileSync(path.join(requestDir, `${id}.json`), JSON.stringify({
+				id,
+				operation: "start",
+				provider: "surf-oracle",
+				createdAt: Date.now(),
+				start: {
+					prompt: "stale prompt",
+					promptDigest: externalJobPromptDigest("stale prompt"),
+					cwd: dir,
+					runId: "run-stale-completed",
+					stepIndex: 0,
+					agent: "gpt-pro",
+					options: {},
+				},
+			}), "utf-8");
+		}
+		fs.writeFileSync(path.join(requestDir, "zzz.json"), JSON.stringify({
+			id: "zzz",
+			operation: "start",
+			provider: "surf-oracle",
+			createdAt: Date.now(),
+			start: {
+				prompt: "prompt",
+				promptDigest: externalJobPromptDigest("prompt"),
+				cwd: dir,
+				runId: "run-after-tombstones",
+				stepIndex: 0,
+				agent: "gpt-pro",
+				options: {},
+			},
+		}), "utf-8");
+
+		serviceExternalJobBridgeRequests(dir);
+		await waitForFile(path.join(dir, "external-job-responses", "zzz.json"));
+
 		assert.equal(starts, 1);
 	});
 

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -394,6 +394,44 @@ describe("external-job runner bridge", () => {
 		assert.equal(fs.existsSync(path.join(dir, EXTERNAL_JOB_BRIDGE_REQUEST_DIR)), false);
 	});
 
+	it("stops waiting for start when local timeout fires before a provider job id", async () => {
+		const dir = tempDir("pi-external-job-start-local-timeout-");
+		let starts = 0;
+		let timeout: (() => void) | undefined;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => {
+				starts += 1;
+				return new Promise(() => {});
+			},
+			status: () => ({ providerJobId: "unused", state: "completed" }),
+			reattach: () => ({ providerJobId: "unused", state: "completed" }),
+			result: () => ({ providerJobId: "unused", state: "completed" }),
+		});
+
+		const operation = runExternalJob({
+			provider: "surf-oracle",
+			cwd: dir,
+			prompt: "prompt",
+			asyncDir: dir,
+			stepIndex: 0,
+			runId: "run-local-timeout",
+			agent: "gpt-pro",
+			registerTimeout: (registered) => { timeout = registered; },
+		});
+		serviceExternalJobBridgeRequests(dir);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		timeout!();
+		const result = await operation;
+
+		assert.equal(starts, 1);
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.timedOut, true);
+		assert.equal(result.externalJob.failureCode, "local-timeout");
+		assert.match(result.error ?? "", /timed out locally/);
+	});
+
 	it("waits for a slow start response instead of timing out without provider job id", async () => {
 		const dir = tempDir("pi-external-job-slow-start-");
 		let starts = 0;

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { EXTERNAL_JOB_PROVIDER_REGISTRY_KEY, ExternalJobProviderError, registerExternalJobProvider } from "../../src/api/external-job-provider.ts";
+import { serviceExternalJobBridgeRequests } from "../../src/runs/shared/external-job-bridge.ts";
+import { externalJobPromptDigest, runExternalJob } from "../../src/runs/shared/external-job-runner.ts";
+
+const tempDirs: string[] = [];
+
+function clearRegistry(): void {
+	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_JOB_PROVIDER_REGISTRY_KEY)];
+}
+
+afterEach(() => {
+	clearRegistry();
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(prefix: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function serviceUntil<T>(asyncDir: string, promise: Promise<T>): Promise<T> {
+	let done = false;
+	void promise.finally(() => { done = true; });
+	while (!done) {
+		serviceExternalJobBridgeRequests(asyncDir);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	return promise;
+}
+
+describe("external-job runner bridge", () => {
+	it("starts a provider job and persists result artifact metadata", async () => {
+		const dir = tempDir("pi-external-job-start-");
+		let startInput: { promptDigest: string; options: Record<string, unknown> } | undefined;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: (input) => {
+				startInput = { promptDigest: input.promptDigest, options: input.options };
+				return { providerJobId: "job-1", state: "completed", conversationUrl: "https://surf.example/jobs/job-1" };
+			},
+			status: () => ({ providerJobId: "job-1", state: "completed" }),
+			reattach: () => ({ providerJobId: "job-1", state: "completed" }),
+			result: () => ({ providerJobId: "job-1", state: "completed", output: "advisor result" }),
+		});
+
+		const result = await serviceUntil(dir, runExternalJob({
+			provider: "surf-oracle",
+			options: { tier: "pro" },
+			cwd: dir,
+			prompt: "prompt text",
+			asyncDir: dir,
+			stepIndex: 0,
+			runId: "run-1",
+			agent: "gpt-pro",
+		}));
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.output, "advisor result");
+		assert.equal(result.externalJob.providerJobId, "job-1");
+		assert.equal(result.externalJob.conversationUrl, "https://surf.example/jobs/job-1");
+		assert.equal(result.externalJob.resultArtifactPath, path.join(dir, "external-job-0.result.md"));
+		assert.equal(fs.readFileSync(result.externalJob.resultArtifactPath!, "utf-8"), "advisor result");
+		assert.deepEqual(startInput, { promptDigest: externalJobPromptDigest("prompt text"), options: { tier: "pro" } });
+	});
+
+	it("reattaches an existing provider job instead of redispatching the prompt", async () => {
+		const dir = tempDir("pi-external-job-reattach-");
+		const prompt = "same prompt";
+		fs.writeFileSync(path.join(dir, "status.json"), JSON.stringify({
+			steps: [{
+				externalJob: {
+					provider: "surf-oracle",
+					providerJobId: "job-existing",
+					promptDigest: externalJobPromptDigest(prompt),
+					options: {},
+					state: "running",
+				},
+			}],
+		}), "utf-8");
+		let reattached = false;
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => { throw new Error("start must not be called"); },
+			reattach: (providerJobId) => { reattached = true; return { providerJobId, state: "completed" }; },
+			status: (providerJobId) => ({ providerJobId, state: "completed" }),
+			result: (providerJobId) => ({ providerJobId, state: "completed", output: "recovered result" }),
+		});
+
+		const result = await serviceUntil(dir, runExternalJob({
+			provider: "surf-oracle",
+			cwd: dir,
+			prompt,
+			asyncDir: dir,
+			stepIndex: 0,
+			runId: "run-reattach",
+			agent: "gpt-pro",
+		}));
+
+		assert.equal(reattached, true);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.externalJob.providerJobId, "job-existing");
+		assert.equal(result.output, "recovered result");
+	});
+
+	it("fails closed with the blocking provider job on capacity conflicts", async () => {
+		const dir = tempDir("pi-external-job-capacity-");
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			start: () => { throw new ExternalJobProviderError("Surf capacity is occupied", { code: "capacity", blockingJobId: "job-blocking" }); },
+			status: () => ({ providerJobId: "unused", state: "failed" }),
+			reattach: () => ({ providerJobId: "unused", state: "failed" }),
+			result: () => ({ providerJobId: "unused", state: "failed" }),
+		});
+
+		const result = await serviceUntil(dir, runExternalJob({
+			provider: "surf-oracle",
+			cwd: dir,
+			prompt: "prompt",
+			asyncDir: dir,
+			stepIndex: 0,
+			runId: "run-capacity",
+			agent: "gpt-pro",
+		}));
+
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.externalJob.state, "blocked");
+		assert.equal(result.externalJob.blockingJobId, "job-blocking");
+		assert.match(result.error ?? "", /job-blocking/);
+	});
+});

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -57,6 +57,7 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.deepEqual(packageJson.exports, {
 		".": "./index.ts",
 		"./background-work": "./src/api/background-work.ts",
+		"./external-job-provider": "./src/api/external-job-provider.ts",
 		"./external-runs": "./src/api/external-runs.ts",
 		"./capability-ceiling": "./src/api/capability-ceiling.ts",
 		"./delegation": "./src/api/delegation.ts",
@@ -70,6 +71,10 @@ test("published extension APIs use supported package entrypoints", async () => {
 	const backgroundWork = await import("pi-subagents/background-work");
 	assert.equal(backgroundWork.BACKGROUND_WORK_PROTOCOL_VERSION, 1);
 	assert.equal(backgroundWork.BACKGROUND_WORK_REGISTRY_KEY, "pi-subagents.background-work.v1");
+	const externalJobProvider = await import("pi-subagents/external-job-provider");
+	assert.equal(externalJobProvider.EXTERNAL_JOB_PROVIDER_PROTOCOL_VERSION, 1);
+	assert.equal(externalJobProvider.EXTERNAL_JOB_PROVIDER_REGISTRY_KEY, "pi-subagents.external-job-providers.v1");
+	assert.equal(typeof externalJobProvider.registerExternalJobProvider, "function");
 	const externalRuns = await import("pi-subagents/external-runs");
 	assert.equal(externalRuns.EXTERNAL_RUN_REGISTRY_VERSION, 2);
 	assert.equal(typeof externalRuns.registerExternalRun, "function");

--- a/test/unit/retained-children.test.ts
+++ b/test/unit/retained-children.test.ts
@@ -13,7 +13,7 @@ interface WriteRunOptions {
 	state?: "complete" | "failed" | "paused" | "stopped";
 	stepStatus?: "complete" | "completed" | "failed" | "paused" | "stopped";
 	sessionFile?: "present" | "missing" | "omitted";
-	runner?: "external-cli";
+	runner?: "external-cli" | "external-job";
 	recoveryDescriptor?: "present" | "missing" | "invalid";
 	recoverySourceRunId?: string;
 	recoveryAgent?: string;
@@ -47,6 +47,7 @@ function writeRetainedRun(root: string, index: number, options: WriteRunOptions 
 			description: `  Task ${index}  with   spacing ${"x".repeat(140)}  `,
 			endedAt: 1_000 + index,
 			...(options.runner === "external-cli" ? { runner: { type: "external-cli", command: "codex", args: [], promptDelivery: "stdin", capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false } } } : {}),
+			...(options.runner === "external-job" ? { runner: { type: "external-job", provider: "surf-oracle", options: {}, capabilities: { stop: false, steer: false, resume: false, structuredOutput: false, toolEvents: false } } } : {}),
 			...(options.sessionFile === "omitted" ? {} : { sessionFile }),
 			tokens: { input: index, output: index + 1, total: index * 2 + 1 },
 		}],
@@ -140,16 +141,18 @@ describe("retained child roster", () => {
 			writeRetainedRun(root, 6, { recoveryDescriptor: "invalid" });
 			writeRetainedRun(root, 7, { recoverySourceRunId: "other-run" });
 			writeRetainedRun(root, 8, { recoveryAgent: "reviewer" });
+			writeRetainedRun(root, 9, { runner: "external-job" });
 
 			const children = listRetainedChildren(path.join(root, "runs"), "parent-a");
 			const formatted = formatRetainedChildren(children);
 
 			assert.deepEqual(children.map((child) => [child.runId, child.resumability]), [
+				["child-9", { state: "not-resumable", reason: "external runner" }],
 				["child-8", { state: "not-resumable", reason: "recovery descriptor belongs to agent reviewer" }],
 				["child-7", { state: "not-resumable", reason: "recovery descriptor belongs to run other-run" }],
 				["child-6", { state: "not-resumable", reason: `invalid recovery descriptor: Invalid async recovery descriptor '${path.join(root, "runs", "child-6", "recovery-descriptor.json")}': version must be 1.` }],
 				["child-5", { state: "not-resumable", reason: "missing recovery descriptor" }],
-				["child-4", { state: "not-resumable", reason: "external CLI runner" }],
+				["child-4", { state: "not-resumable", reason: "external runner" }],
 				["child-3", { state: "not-resumable", reason: "stopped run" }],
 				["child-2", { state: "not-resumable", reason: `persisted session file is missing: ${path.join(root, "sessions", "child-2.jsonl")}` }],
 				["child-1", { state: "not-resumable", reason: "no persisted session file" }],
@@ -158,7 +161,7 @@ describe("retained child roster", () => {
 			assert.match(formatted, /resumability: not resumable \(recovery descriptor belongs to run other-run\)/);
 			assert.match(formatted, /resumability: not resumable \(invalid recovery descriptor:/);
 			assert.match(formatted, /resumability: not resumable \(missing recovery descriptor\)/);
-			assert.match(formatted, /resumability: not resumable \(external CLI runner\)/);
+			assert.match(formatted, /resumability: not resumable \(external runner\)/);
 			assert.match(formatted, /resumability: not resumable \(stopped run\)/);
 			assert.match(formatted, /resumability: not resumable \(no persisted session file\)/);
 			assert.doesNotMatch(formatted, /resume: subagent/);


### PR DESCRIPTION
## Summary
- add `runner.type: external-job` for provider-owned durable advisory jobs
- export `pi-subagents/external-job-provider` so host extensions can register providers
- mediate provider operations through the host process for async runner jobs
- add the packaged `gpt-pro` agent profile for Surf Oracle
- document external-job, Claude advisor config, and advisor data boundaries

Closes #1189.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/external-job-runner.test.ts test/unit/agent-frontmatter.test.ts test/unit/package-manifest.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh read-only review: no blockers
- focused registry-key review: no blockers

## Notes
This uses the `pi-subagents.external-job-providers.v1` registry key expected by Surf PR #190. It does not add an `advisor.*` action namespace and does not import Surf internals.
