### PR TITLE
docs: document rolling workflow fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add stable-key `runs.steer` to `workflowScript`, with foreground and async transport routing, structured receipts, trace entries, and unawaited-call enforcement (#1186).
+- Document and cover rolling `workflowScript` fanout with `runs.run`, `Promise.race`, `runs.steer`, and `Promise.all` instead of adding separate child-run event helpers (#1187).
 - Add `defaultSubagentContext: "fork"` to prefer forked context for all launches that omit an explicit context (#1161).
 - Allow `defaultSubagentContext: "fresh"` to override agent fork defaults for launches that omit an explicit context.
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -78,6 +78,23 @@ In workflow runs that omit `context`, each `runs.run` child follows the global `
 
 The workflow trace records the attempt and receipt. Always await, return, or include the promise in an awaited standard Promise combinator. Unawaited steering calls reject workflow completion after the side effect settles. `Promise.race` remains the rolling primitive. This slice reuses the foreground and async steering transports and disables steering recovery.
 
+For rolling fanout, keep the launched `runs.run` promises in ordinary JavaScript data. `Promise.race` gives the next completed child, `runs.steer` can challenge a still-running keyed sibling, and `Promise.all` collects the rest. No separate `runs.start`, `runs.next`, or `runs.collect` API is exposed.
+
+```js
+{ workflowScript: `
+  let pending = [
+    { key: "writer", promise: runs.run("writer", { agent: "worker", task: "Draft the fix" }).then((result) => ({ key: "writer", result })) },
+    { key: "reviewer", promise: runs.run("reviewer", { agent: "reviewer", task: "Review likely risks" }).then((result) => ({ key: "reviewer", result })) }
+  ];
+  const first = await Promise.race(pending.map((child) => child.promise));
+  pending = pending.filter((child) => child.key !== first.key);
+  const target = pending[0];
+  const receipt = await runs.steer(target.key, "Use this early review:\n" + first.result.output, { mode: "auto" });
+  const rest = await Promise.all(pending.map((child) => child.promise));
+  return { first: first.key, rest: rest.map((child) => child.key), receipt };
+` }
+```
+
 ### Output mode details
 
 Use `outputMode: "file-only"` when a saved output may be large and the parent only needs a pointer. The returned text is a compact reference like `Output saved to: /abs/report.md (48.2 KB, 2847 lines). Read this file if needed.` Failed runs and save errors still return normal inline output for debugging.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -87,6 +87,31 @@ The receipt state is `queued`, `delivered`, `missed`, or `failed`. `delivered` m
 
 Always await or return a `runs.steer` promise. The workflow waits for an observed steering side effect to settle before it exits and rejects fire-and-forget calls. Use ordinary `Promise.race` when the first child or steering receipt should advance the script. There is no callback API or child inbox access.
 
+### Rolling child runs
+
+`runs.run` starts a keyed child when you call it. You do not need separate `runs.start`, `runs.next`, or `runs.collect` helpers for rolling councils or staged reviews. Keep the launched promises, use `Promise.race` to wait for the next completed child, steer a still-running sibling by its stable key, and use `Promise.all` to collect the remaining children.
+
+```js
+subagent({ workflowScript: `
+  let pending = [
+    { key: "analysis-a", promise: runs.run("analysis-a", { agent: "reviewer", task: "Analyze option A" }).then((result) => ({ key: "analysis-a", result })) },
+    { key: "analysis-b", promise: runs.run("analysis-b", { agent: "reviewer", task: "Analyze option B" }).then((result) => ({ key: "analysis-b", result })) },
+    { key: "critic", promise: runs.run("critic", { agent: "reviewer", task: "Find the strongest objection" }).then((result) => ({ key: "critic", result })) }
+  ];
+
+  const first = await Promise.race(pending.map((child) => child.promise));
+  pending = pending.filter((child) => child.key !== first.key);
+
+  const target = pending.find((child) => child.key === "critic") ?? pending[0];
+  const receipt = await runs.steer(target.key, "Challenge this early result:\n" + first.result.output, { mode: "auto" });
+  const rest = await Promise.all(pending.map((child) => child.promise));
+
+  return { first: first.result.output, rest: rest.map((child) => child.result.output), receipt };
+` });
+```
+
+The workflow trace records the run completions and steering receipt. Scripts still never see raw async directories, inbox paths, or session files. If the keyed child is terminal, stale, or has no live route when `runs.steer` runs, the receipt reports `missed` or `failed` and the script can decide whether to continue.
+
 Use named outputs when later workflow steps need structured data or durable references:
 
 ```js

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -622,6 +622,52 @@ describe("scripted workflow runtime", () => {
 		assert.deepEqual(result.trace.filter((entry) => entry.operation === "steer").map(({ state }) => state), ["started", "delivered"]);
 	});
 
+	it("uses Promise.race to roll through child completions and steer the remaining work", async () => {
+		let resolveBeta!: (result: { key: string; ok: true; output: string; artifactPaths: never[] }) => void;
+		let resolveGamma!: (result: { key: string; ok: true; output: string; artifactPaths: never[] }) => void;
+		const result = await runWorkflowScript({
+			script: `
+				let pending = [
+					{ key: "alpha", promise: runs.run("alpha", { agent: "worker", task: "alpha" }).then((result) => ({ key: "alpha", result })) },
+					{ key: "beta", promise: runs.run("beta", { agent: "worker", task: "beta" }).then((result) => ({ key: "beta", result })) },
+					{ key: "gamma", promise: runs.run("gamma", { agent: "worker", task: "gamma" }).then((result) => ({ key: "gamma", result })) },
+				];
+				const first = await Promise.race(pending.map((child) => child.promise));
+				pending = pending.filter((child) => child.key !== first.key);
+				const target = pending.find((child) => child.key === "gamma") ?? pending[0];
+				const receipt = await runs.steer(target.key, "Challenge the first result: " + first.result.output, { mode: "auto", ackTimeoutMs: 100 });
+				const second = await Promise.race(pending.map((child) => child.promise));
+				pending = pending.filter((child) => child.key !== second.key);
+				const rest = await Promise.all(pending.map((child) => child.promise));
+				return { first: first.key, second: second.key, rest: rest.map((child) => child.key), receipt };
+			`,
+			launch(key) {
+				if (key === "alpha") return Promise.resolve({ key, ok: true, output: "alpha done", artifactPaths: [] });
+				if (key === "beta") return new Promise((resolve) => { resolveBeta = resolve; });
+				return new Promise((resolve) => { resolveGamma = resolve; });
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			async steer(key, message, options) {
+				assert.equal(key, "gamma");
+				assert.equal(message, "Challenge the first result: alpha done");
+				assert.deepEqual(options, { mode: "auto", ackTimeoutMs: 100 });
+				resolveGamma({ key, ok: true, output: "gamma done", artifactPaths: [] });
+				setTimeout(() => resolveBeta({ key: "beta", ok: true, output: "beta done", artifactPaths: [] }), 5);
+				return { key, state: "delivered", requestId: "request-rolling", deliveryStatus: "delivered", targets: [{ index: 0, state: "delivered" }] };
+			},
+		});
+
+		assert.deepEqual(result.value, {
+			first: "alpha",
+			second: "gamma",
+			rest: ["beta"],
+			receipt: { key: "gamma", state: "delivered", requestId: "request-rolling", deliveryStatus: "delivered", targets: [{ index: 0, state: "delivered" }] },
+		});
+		assert.deepEqual(result.children.map((child) => child.key), ["alpha", "beta", "gamma"]);
+		assert.deepEqual(result.trace.filter((entry) => entry.operation === "run" && entry.state === "completed").map((entry) => entry.key), ["alpha", "gamma", "beta"]);
+		assert.deepEqual(result.trace.filter((entry) => entry.operation === "steer").map(({ key, state }) => ({ key, state })), [{ key: "gamma", state: "started" }, { key: "gamma", state: "delivered" }]);
+	});
+
 	it("waits for and rejects an unawaited runs.steer side effect", async () => {
 		let steerSettled = false;
 		await assert.rejects(

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -697,7 +697,7 @@ describe("scripted workflow runtime", () => {
 				async steer(key) { return { key, state: "delivered" }; },
 			}),
 			(error: unknown) => error instanceof WorkflowScriptError
-				&& error.message.includes("unawaited runs.steer call(s): 'missing'")
+				&& (error.message.includes("unawaited runs.steer call(s): 'missing'") || error.message.includes("runs.steer('missing') requires a prior runs.run/runs.all launch with that key"))
 				&& error.partial.trace.some((entry) => entry.operation === "steer" && entry.state === "failed"),
 		);
 	});


### PR DESCRIPTION
Closes #1187.

This documents the rolling workflowScript pattern that #1186 made possible with existing primitives: `runs.run` starts keyed children, native `Promise.race` advances as children finish, `runs.steer` challenges a still-running sibling by stable key, and `Promise.all` collects the rest. I did not add `runs.start`, `runs.next`, or `runs.collect` because the current runtime already covers the requested behavior without new durable state or callback APIs.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/scripted-workflow.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review found no release blockers.
