### PR TITLE
Fix `/subagents-generate-profiles` not resolving pi command properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
+- Resolve `/subagents-generate-profiles` provider probes through the shared Pi executable resolver so configured and Windows-specific Pi commands work. Thanks to [@Wumpf](https://github.com/Wumpf) for #1199.
 - Serialize same-worktree Orca progress-tab creation so numbered tabs appear left to right in sequence instead of racing in the UI. Thanks to [@hyein-cbio](https://github.com/hyein-cbio) for #1196.
 - Resolve the workflowScript parser from pi-subagents instead of the caller's working directory, so workflows start in projects that do not install Acorn.
 - Keep structured delegation integration coverage active when the test process inherits a subagent-child environment marker.

--- a/src/profiles/profiles.ts
+++ b/src/profiles/profiles.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { BUILTIN_AGENT_NAMES } from "../agents/agents.ts";
+import { getPiSpawnCommand } from "../runs/shared/pi-spawn.ts";
 import { findModelInfo, getSupportedThinkingLevels, splitKnownThinkingSuffix, toModelInfo } from "../shared/model-info.ts";
 import { getAgentDir } from "../shared/utils.ts";
 
@@ -340,7 +341,8 @@ async function probeModel(
 	if (typeof pi.exec !== "function") {
 		return { status: "skipped", message: "pi.exec is unavailable in this runtime." };
 	}
-	const result = await pi.exec("pi", ["-p", "--model", fullId, "--no-tools", 'Reply with exactly "OK".'], {
+	const spawnSpec = getPiSpawnCommand(["-p", "--model", fullId, "--no-tools", 'Reply with exactly "OK".']);
+	const result = await pi.exec(spawnSpec.command, spawnSpec.args, {
 		cwd: os.tmpdir(),
 		timeout: 45_000,
 	} as Record<string, unknown>);

--- a/test/unit/profiles.test.ts
+++ b/test/unit/profiles.test.ts
@@ -16,10 +16,12 @@ import {
 	refreshProviderModelCatalog,
 	readProviderModelCatalog,
 } from "../../src/profiles/profiles.ts";
+import { PI_SUBAGENT_PI_BINARY_ENV } from "../../src/runs/shared/pi-spawn.ts";
 
 let homeDir = "";
 const previousHome = process.env.HOME;
 const previousUserProfile = process.env.USERPROFILE;
+const previousPiBinary = process.env[PI_SUBAGENT_PI_BINARY_ENV];
 
 function makeCtx(cwd: string, models: Array<Record<string, unknown>>) {
 	return {
@@ -42,6 +44,8 @@ describe("profiles helpers", () => {
 		else process.env.HOME = previousHome;
 		if (previousUserProfile === undefined) delete process.env.USERPROFILE;
 		else process.env.USERPROFILE = previousUserProfile;
+		if (previousPiBinary === undefined) delete process.env[PI_SUBAGENT_PI_BINARY_ENV];
+		else process.env[PI_SUBAGENT_PI_BINARY_ENV] = previousPiBinary;
 		fs.rmSync(homeDir, { recursive: true, force: true });
 	});
 
@@ -146,11 +150,14 @@ describe("profiles helpers", () => {
 		);
 	});
 
-	it("refreshes a provider model catalog and writes a cache file", async () => {
+	it("refreshes a provider model catalog using the resolved Pi executable and writes a cache file", async () => {
+		const piBinary = path.join(homeDir, "pi-wrapper.exe");
+		process.env[PI_SUBAGENT_PI_BINARY_ENV] = piBinary;
 		const execCalls: string[] = [];
 		const execCwds: unknown[] = [];
 		const pi = {
-			exec: async (_command: string, args: string[], options?: Record<string, unknown>) => {
+			exec: async (command: string, args: string[], options?: Record<string, unknown>) => {
+				assert.equal(command, piBinary);
 				execCalls.push(args.join(" "));
 				execCwds.push(options?.cwd);
 				return { stdout: "OK\n", stderr: "", code: 0, killed: false };


### PR DESCRIPTION
I had some trouble with `/subagents-generate-profiles`  on my Windows machine. Turns out that this codepath didn't use `getPiSpawnCommand` like all other places.

Fixed and extended an existing test to check whether env vars are resolved correctly.