### PR TITLE
fix: keep contact_supervisor from requiring intercom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
+- Keep `contact_supervisor` out of strict child tool requirements so explicit agent allowlists that name it no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
 - Add explicit `isolation: "none"` for schema-driven workflows without Git worktree setup, while retaining strict `isolation: "worktree"` behavior. Thanks to [@tlsneo](https://github.com/tlsneo) for #1203.
 - Fail closed when an existing external-job `status.json` is unreadable or malformed, including an invalid `steps` shape, instead of starting a new provider job.
 - Describe `async:false` as a blocking parent wait, not a UI or foreground-only mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
-- Keep `contact_supervisor` out of strict child tool requirements so explicit agent allowlists that name it no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
+- Stop failing child runs over the stale supervisor-bridge tool pair: when an explicit allowlist names `contact_supervisor`, neither it nor its legacy `intercom` companion is a strict tool requirement anymore, so 0.49-era agent configs and recovery descriptors no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. A lone `intercom` entry still requires a real external provider. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
 - Add explicit `isolation: "none"` for schema-driven workflows without Git worktree setup, while retaining strict `isolation: "worktree"` behavior. Thanks to [@tlsneo](https://github.com/tlsneo) for #1203.
 - Fail closed when an existing external-job `status.json` is unreadable or malformed, including an invalid `steps` shape, instead of starting a new provider job.
 - Describe `async:false` as a blocking parent wait, not a UI or foreground-only mode.

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -433,13 +433,17 @@ export function resolvePiLaunchToolPlan(
 			...internalTools,
 		]),
 	];
+	// contact_supervisor stays in the --tools allowlist but is never a strict
+	// requirement: children register it at runtime through the native supervisor
+	// channel (or pi-intercom), so requiring it would fail bridge-injected and
+	// stale-descriptor allowlists that the child runtime satisfies anyway (#1207).
 	const requiredChildTools = explicitToolAllowlist
 		? [
 				...new Set([
 					...(input.tools !== undefined ? declaredBuiltinTools : []),
 					...(input.mcpDirectTools?.length ? effectiveMcpTools : []),
 					...internalTools,
-				]),
+				].filter((tool) => tool !== "contact_supervisor")),
 			]
 		: [];
 	const permSystemExt = capabilityCeiling?.denyExtensions

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -433,17 +433,20 @@ export function resolvePiLaunchToolPlan(
 			...internalTools,
 		]),
 	];
-	// contact_supervisor stays in the --tools allowlist but is never a strict
-	// requirement: children register it at runtime through the native supervisor
-	// channel (or pi-intercom), so requiring it would fail bridge-injected and
-	// stale-descriptor allowlists that the child runtime satisfies anyway (#1207).
+	// Supervisor-coordination names stay in the --tools allowlist but are never
+	// strict requirements: children register contact_supervisor at runtime through
+	// the native supervisor channel (or pi-intercom). The pre-0.50 bridge always
+	// appended intercom alongside contact_supervisor, so that exact pairing is
+	// legacy plumbing, not a user demand for an external intercom provider;
+	// a lone intercom entry stays strictly required (#1207).
+	const legacySupervisorPairing = declaredBuiltinTools.includes("contact_supervisor");
 	const requiredChildTools = explicitToolAllowlist
 		? [
 				...new Set([
 					...(input.tools !== undefined ? declaredBuiltinTools : []),
 					...(input.mcpDirectTools?.length ? effectiveMcpTools : []),
 					...internalTools,
-				].filter((tool) => tool !== "contact_supervisor")),
+				].filter((tool) => tool !== "contact_supervisor" && (!legacySupervisorPairing || tool !== "intercom"))),
 			]
 		: [];
 	const permSystemExt = capabilityCeiling?.denyExtensions

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -149,6 +149,7 @@ interface AsyncStatusPayload {
 interface MockPiCallRecord {
 	args?: string[];
 	systemPrompts?: Array<{ mode?: string; path?: string; text?: string; error?: string }>;
+	requiredChildTools?: string[];
 }
 
 function writeWatchdogSettings(projectDir: string, tailMs = 120_000): void {
@@ -417,6 +418,17 @@ function readMockPiArgs(mockPi: MockPi, index: number): string[] {
 	return payload.args;
 }
 
+function readMockPiRequiredTools(mockPi: MockPi, index: number): string[] {
+	const callFile = fs.readdirSync(mockPi.dir)
+		.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
+		.sort()
+		.at(index);
+	assert.ok(callFile, `expected recorded call ${index}`);
+	const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as MockPiCallRecord;
+	assert.ok(Array.isArray(payload.requiredChildTools), "expected recorded required child tools");
+	return payload.requiredChildTools;
+}
+
 function readMockPiArgsMatching(mockPi: MockPi, text: string): string[] {
 	const callFiles = fs.readdirSync(mockPi.dir)
 		.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
@@ -681,6 +693,12 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.deepEqual(status.runtimeAcknowledgedExtensions, runtimeAck);
 		assert.deepEqual(status.steps?.[0]?.runtimeAcknowledgedExtensions, runtimeAck);
 		assert.ok(!JSON.stringify(launch.details.launchResolvedExtensions).includes(tempDir), "projection should not expose raw extension paths");
+		// Stale supervisor-bridge pair: the --tools allowlist passes both names
+		// through, but PI_SUBAGENT_REQUIRED_TOOLS excludes them so the 0.50 child
+		// runtime cannot fail the run over the removed native intercom (#1207).
+		const recoveryCallArgs = readMockPiArgs(mockPi, 0);
+		assert.equal(recoveryCallArgs[recoveryCallArgs.indexOf("--tools") + 1], "read,intercom,contact_supervisor");
+		assert.deepEqual(readMockPiRequiredTools(mockPi, 0), ["read"]);
 	});
 
 	it("background parallel groups report usage budget state and block queued children", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/support/mock-pi-script.mjs
+++ b/test/support/mock-pi-script.mjs
@@ -209,6 +209,16 @@ function writeToolDiagnostic(response) {
 	}), "utf-8");
 }
 
+function readRequiredToolsEnv() {
+	try {
+		const encoded = process.env.PI_SUBAGENT_REQUIRED_TOOLS;
+		const parsed = encoded === undefined ? [] : JSON.parse(encoded);
+		return Array.isArray(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function isJsonMode(args) {
 	for (let i = 0; i < args.length; i++) {
 		if (args[i] === "--mode") {
@@ -337,7 +347,7 @@ async function main() {
 	writeToolDiagnostic(response);
 	const callPath = path.join(queueDir, `call-${Date.now()}-${process.pid}-${Math.random().toString(16).slice(2)}.json`);
 	const callTempPath = `${callPath}.tmp-${process.pid}-${Date.now()}`;
-	fs.writeFileSync(callTempPath, JSON.stringify({ args, cwd: process.cwd(), systemPrompts: readSystemPromptRecords(args) }), "utf-8");
+	fs.writeFileSync(callTempPath, JSON.stringify({ args, cwd: process.cwd(), systemPrompts: readSystemPromptRecords(args), requiredChildTools: readRequiredToolsEnv() }), "utf-8");
 	fs.renameSync(callTempPath, callPath);
 
 	if (typeof response.delay === "number" && response.delay > 0) {

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -806,8 +806,8 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			toolsArg,
 			"read,grep,find,ls,bash,edit,write,contact_supervisor",
 		);
-		// contact_supervisor is runtime-registered in children, so it is never a
-		// strict requirement even when the explicit allowlist names it (#1207).
+		// Supervisor-coordination names are runtime-registered in children, so
+		// they are never strict requirements even when named explicitly (#1207).
 		assert.deepEqual(
 			JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"),
 			["read", "grep", "find", "ls", "bash", "edit", "write"],
@@ -815,7 +815,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV], toolDiagnosticPath);
 	});
 
-	it("keeps explicit intercom tools strict while excluding contact_supervisor from requirements", () => {
+	it("strips the legacy supervisor pairing from requirements", () => {
 		const { args, env } = buildPiArgs({
 			baseArgs: ["-p"],
 			task: "hello",
@@ -828,6 +828,26 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(
 			args[args.indexOf("--tools") + 1],
 			"read,intercom,contact_supervisor",
+		);
+		assert.deepEqual(
+			JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"),
+			["read"],
+		);
+	});
+
+	it("keeps a lone explicit intercom tool strict", () => {
+		const { args, env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read", "intercom"],
+		});
+
+		assert.equal(
+			args[args.indexOf("--tools") + 1],
+			"read,intercom",
 		);
 		assert.deepEqual(
 			JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"),

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -806,11 +806,33 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			toolsArg,
 			"read,grep,find,ls,bash,edit,write,contact_supervisor",
 		);
+		// contact_supervisor is runtime-registered in children, so it is never a
+		// strict requirement even when the explicit allowlist names it (#1207).
 		assert.deepEqual(
 			JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"),
-			toolsArg.split(","),
+			["read", "grep", "find", "ls", "bash", "edit", "write"],
 		);
 		assert.equal(env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV], toolDiagnosticPath);
+	});
+
+	it("keeps explicit intercom tools strict while excluding contact_supervisor from requirements", () => {
+		const { args, env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read", "intercom", "contact_supervisor"],
+		});
+
+		assert.equal(
+			args[args.indexOf("--tools") + 1],
+			"read,intercom,contact_supervisor",
+		);
+		assert.deepEqual(
+			JSON.parse(env[REQUIRED_CHILD_TOOLS_ENV] ?? "[]"),
+			["read", "intercom"],
+		);
 	});
 
 	it("launches the bundled reviewer without mutation-capable tools", () => {


### PR DESCRIPTION
Since 0.50.0, a child run whose agent declares an explicit tools list that includes contact_supervisor can fail with `Agent 'coder' requested unavailable child tools: intercom.` even though the agent never requested a tool named intercom. It shows up either as an immediate launch failure or as a failed status on an otherwise completed run after contact_supervisor worked.

The 0.50.0 supervisor-channel cutover (#1107) removed the native generic intercom fallback and stopped the bridge from appending intercom to agent tool lists, but it also deleted the child-side satisfier for that name. Any tool array that still carries intercom, for example from a recovery descriptor or a parent session with pre-0.50 extension code resident, is replayed verbatim into PI_SUBAGENT_REQUIRED_TOOLS by resolvePiLaunchToolPlan(), so the 0.50 child can never satisfy it.

The pre-0.50 bridge always appended intercom alongside contact_supervisor, so that exact pairing is legacy plumbing rather than a user demand for an external intercom provider. This strips both names from the strict required-tools set whenever contact_supervisor is declared, while leaving the --tools allowlist untouched. An intercom entry that appears on its own, without contact_supervisor, stays strictly required, so the existing guarantee that a required intercom name needs a real registered provider is unchanged.

Thanks to @MingTeer for #1207.

Fixes #1207
