### PR TITLE
Preserve Codex fork tool history

### DIFF
--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -213,8 +213,10 @@ const MAX_PORTABLE_TOOL_ID_LENGTH = 64;
 const COMPOSITE_TOOL_ID_APIS = new Set([
 	"azure-openai-responses",
 	"openai-completions",
+	"openai-codex-responses",
 	"openai-responses",
 ]);
+const PRESERVE_SUBAGENT_TOOL_HISTORY_APIS = new Set(["openai-codex-responses"]);
 
 function portableToolId(id: string): string {
 	if (PORTABLE_TOOL_ID_PATTERN.test(id) && id.length <= MAX_PORTABLE_TOOL_ID_LENGTH) return id;
@@ -251,17 +253,17 @@ function stripAssistantSubagentToolCallBlocks(message: unknown): unknown | undef
 	return { ...m, content: filteredContent };
 }
 
-export function stripParentOnlySubagentMessages(messages: unknown[], options: { sanitizeToolIds?: boolean } = {}): unknown[] {
-	const preserveCurrentFanoutToolHistory = process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1";
+export function stripParentOnlySubagentMessages(messages: unknown[], options: { sanitizeToolIds?: boolean; preserveSubagentToolHistory?: boolean } = {}): unknown[] {
+	const preserveSubagentToolHistory = options.preserveSubagentToolHistory ?? process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1";
 	const sanitizeToolIds = options.sanitizeToolIds ?? true;
 	let changed = false;
 	const filtered: unknown[] = [];
 	for (const message of messages) {
-		if (isParentOnlySubagentMessage(message) || (!preserveCurrentFanoutToolHistory && isSubagentToolResultMessage(message))) {
+		if (isParentOnlySubagentMessage(message) || (!preserveSubagentToolHistory && isSubagentToolResultMessage(message))) {
 			changed = true;
 			continue;
 		}
-		const stripped = preserveCurrentFanoutToolHistory ? message : stripAssistantSubagentToolCallBlocks(message);
+		const stripped = preserveSubagentToolHistory ? message : stripAssistantSubagentToolCallBlocks(message);
 		if (stripped === undefined) {
 			changed = true;
 			continue;
@@ -633,8 +635,10 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 
 	onRuntimeEvent("context", (event: unknown, ctx?: ExtensionContext) => {
 		if (!event || typeof event !== "object" || !("messages" in event) || !Array.isArray(event.messages)) return undefined;
+		const api = ctx?.model?.api ?? "";
 		const messages = stripParentOnlySubagentMessages(event.messages, {
-			sanitizeToolIds: !COMPOSITE_TOOL_ID_APIS.has(ctx?.model?.api ?? ""),
+			sanitizeToolIds: !COMPOSITE_TOOL_ID_APIS.has(api),
+			preserveSubagentToolHistory: PRESERVE_SUBAGENT_TOOL_HISTORY_APIS.has(api),
 		});
 		if (messages === event.messages) return undefined;
 		return { messages };

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -1191,7 +1191,7 @@ describe("subagent prompt runtime", () => {
 		});
 	});
 
-	it("bounds composite tool ids for Codex child context", () => {
+	it("preserves composite tool ids for Codex child context", () => {
 		let contextHandler: ((event: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) | undefined;
 		registerSubagentPromptRuntime({
 			on(event: string, handler: (payload: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) {
@@ -1202,18 +1202,11 @@ describe("subagent prompt runtime", () => {
 		const toolCallId = "call_N7iYNRPXLl9czpXh3bDyMpIL|fc_0e76718634eca88f016a76fdc89aec81919763fa7858f67a0d";
 		const messages = [
 			{ role: "user", content: "Task" },
-			{ role: "assistant", content: [{ type: "toolCall", id: toolCallId, name: "read", input: { path: "README.md" } }] },
-			{ role: "toolResult", toolName: "read", toolCallId, content: "file" },
+			{ role: "assistant", content: [{ type: "toolCall", id: toolCallId, name: "subagent", input: { agent: "delegate" } }] },
+			{ role: "toolResult", toolName: "subagent", toolCallId, content: "file" },
 		];
 
-		const context = contextHandler?.({ messages }, { model: { api: "openai-codex-responses" } });
-		assert.ok(context);
-		const mappedCallId = (context.messages[1] as { content: Array<{ id?: unknown }> }).content[0]?.id;
-		const mappedResultId = (context.messages[2] as { toolCallId?: unknown }).toolCallId;
-		assert.equal(typeof mappedCallId, "string");
-		assert.match(mappedCallId, /^[a-zA-Z0-9_-]+$/);
-		assert.ok(mappedCallId.length <= 64);
-		assert.equal(mappedResultId, mappedCallId);
+		assert.equal(contextHandler?.({ messages }, { model: { api: "openai-codex-responses" } }), undefined);
 	});
 
 	it("preserves composite tool ids for non-Codex APIs that normalize them", () => {


### PR DESCRIPTION
## Summary
- preserve composite Codex tool IDs in forked child context
- retain inherited subagent tool calls and results for Codex-compatible history replay

## Verification
- `node --experimental-strip-types --test test/unit/subagent-prompt-runtime.test.ts`
- `npm run typecheck`