### PR TITLE
fix: hash path-like session index segments and ignore EPERM scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Stop failing child runs over the stale supervisor-bridge tool pair: when an explicit allowlist names `contact_supervisor`, neither it nor its legacy `intercom` companion is a strict tool requirement anymore, so 0.49-era agent configs and recovery descriptors no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. A lone `intercom` entry still requires a real external provider. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
+- Hash result-index session segments that encode as Windows paths or file-like names (`C:\...\session.jsonl`), and treat `EPERM`/`EACCES` as an empty scan so leftover index directories do not spam the parent session.
 - Add explicit `isolation: "none"` for schema-driven workflows without Git worktree setup, while retaining strict `isolation: "worktree"` behavior. Thanks to [@tlsneo](https://github.com/tlsneo) for #1203.
 - Fail closed when an existing external-job `status.json` is unreadable or malformed, including an invalid `steps` shape, instead of starting a new provider job.
 - Describe `async:false` as a blocking parent wait, not a UI or foreground-only mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 - Stop failing child runs over the stale supervisor-bridge tool pair: when an explicit allowlist names `contact_supervisor`, neither it nor its legacy `intercom` companion is a strict tool requirement anymore, so 0.49-era agent configs and recovery descriptors no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. A lone `intercom` entry still requires a real external provider. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
-- Hash result-index session segments that encode as Windows paths or file-like names (`C:\...\session.jsonl`), and treat `EPERM`/`EACCES` as an empty scan so leftover index directories do not spam the parent session.
+- Hash result-index session segments that encode as Windows paths or file-like names (`C:\...\session.jsonl`), keep reading the previous URI-encoded keys, and treat `EPERM`/`EACCES` as an empty index scan so leftover directories do not spam the parent session. Thanks to [@apoapostolov](https://github.com/apoapostolov) for #1211.
 - Add explicit `isolation: "none"` for schema-driven workflows without Git worktree setup, while retaining strict `isolation: "worktree"` behavior. Thanks to [@tlsneo](https://github.com/tlsneo) for #1203.
 - Fail closed when an existing external-job `status.json` is unreadable or malformed, including an invalid `steps` shape, instead of starting a new provider job.
 - Describe `async:false` as a blocking parent wait, not a UI or foreground-only mode.

--- a/src/runs/background/index-segment.ts
+++ b/src/runs/background/index-segment.ts
@@ -6,6 +6,10 @@ import { createHash } from "node:crypto";
  * Portable short values retain the historical URI-encoded representation.
  * Oversized or non-portable values use a deterministic digest so callers can
  * resolve the same index without persisting a separate lookup table.
+ *
+ * Encoded backslashes and trailing file extensions are not portable. Pi session
+ * ids are often the full session `.jsonl` path. On Windows, `readdir` of a
+ * directory whose name ends in `.jsonl` or contains `%5C` can fail with EPERM.
  */
 export const MAX_INDEX_SEGMENT_BYTES = 255;
 const HASHED_INDEX_SEGMENT_PREFIX = "~sha256-";
@@ -20,7 +24,9 @@ function isPortableSegment(value: string): boolean {
 		&& value !== "."
 		&& value !== ".."
 		&& !value.endsWith(".")
-		&& !WINDOWS_RESERVED_NAME.test(value);
+		&& !WINDOWS_RESERVED_NAME.test(value)
+		&& !/%5C/i.test(value)
+		&& !/\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(value);
 }
 
 export function encodeIndexSegment(value: string, maxBytes = MAX_INDEX_SEGMENT_BYTES): string {

--- a/src/runs/background/index-segment.ts
+++ b/src/runs/background/index-segment.ts
@@ -39,3 +39,21 @@ export function encodeIndexSegment(value: string, maxBytes = MAX_INDEX_SEGMENT_B
 	if (Buffer.byteLength(encoded, "utf-8") <= maxBytes && isPortableSegment(encoded)) return encoded;
 	return hashedSegment(value);
 }
+
+function historicallyReadableSegment(value: string, maxBytes: number): string | undefined {
+	try {
+		const encoded = encodeURIComponent(value);
+		if (encoded.length === 0 || encoded === "." || encoded === ".." || encoded.endsWith(".") || WINDOWS_RESERVED_NAME.test(encoded)) return undefined;
+		if (Buffer.byteLength(encoded, "utf-8") > maxBytes) return undefined;
+		return encoded;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Current write key first, then the pre-hash URI-encoded key when it still fits. */
+export function indexSegmentAliases(value: string, maxBytes = MAX_INDEX_SEGMENT_BYTES): string[] {
+	const current = encodeIndexSegment(value, maxBytes);
+	const historical = historicallyReadableSegment(value, maxBytes);
+	return historical && historical !== current ? [current, historical] : [current];
+}

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { MISSION_BINDING_FILE } from "../../missions/lifecycle.ts";
-import { encodeIndexSegment, MAX_INDEX_SEGMENT_BYTES } from "./index-segment.ts";
+import { encodeIndexSegment, indexSegmentAliases, MAX_INDEX_SEGMENT_BYTES } from "./index-segment.ts";
 
 const RESULT_INDEX_VERSION = 1;
 const RESULT_INDEX_DIR = "result-index";
@@ -48,8 +48,16 @@ function sessionIndexDir(resultsDir: string, sessionId: string): string {
 	return path.join(resultsDir, RESULT_INDEX_DIR, SESSION_INDEX_DIR, encodeSegment(sessionId));
 }
 
+function sessionIndexDirs(resultsDir: string, sessionId: string): string[] {
+	return indexSegmentAliases(sessionId).map((segment) => path.join(resultsDir, RESULT_INDEX_DIR, SESSION_INDEX_DIR, segment));
+}
+
 function resultIndexPath(resultsDir: string, sessionId: string, runId: string): string {
 	return path.join(sessionIndexDir(resultsDir, sessionId), encodedJsonFileName(runId));
+}
+
+function resultIndexPaths(resultsDir: string, sessionId: string, runId: string): string[] {
+	return sessionIndexDirs(resultsDir, sessionId).map((dir) => path.join(dir, encodedJsonFileName(runId)));
 }
 
 function runIndexPath(resultsDir: string, runId: string): string {
@@ -58,6 +66,21 @@ function runIndexPath(resultsDir: string, runId: string): string {
 
 function resultPendingPath(resultsDir: string, sessionId: string, runId: string): string {
 	return path.join(resultsDir, RESULT_PENDING_DIR, encodeSegment(sessionId), encodedJsonFileName(runId));
+}
+
+function resultPendingPaths(resultsDir: string, sessionId: string, runId: string): string[] {
+	return indexSegmentAliases(sessionId).map((segment) => path.join(resultsDir, RESULT_PENDING_DIR, segment, encodedJsonFileName(runId)));
+}
+
+function pendingSessionDirs(resultsDir: string, sessionId: string): string[] {
+	return indexSegmentAliases(sessionId).map((segment) => path.join(resultsDir, RESULT_PENDING_DIR, segment));
+}
+
+function firstExistingResultFile(paths: string[]): string | undefined {
+	for (const filePath of paths) {
+		if (existingResultFile(filePath)) return filePath;
+	}
+	return undefined;
 }
 
 function observerIndexDir(resultsDir: string, observer: string): string {
@@ -153,15 +176,19 @@ export function writeAsyncResultFile(resultPath: string, data: Record<string, un
 export function removeResultIndex(resultsDir: string, sessionId: string | undefined, runId: string | undefined, toolCallId?: string): void {
 	if (!runId) return;
 	if (sessionId) {
-		try {
-			fs.rmSync(resultIndexPath(resultsDir, sessionId, runId), { force: true });
-		} catch {
-			// Index cleanup must not affect result delivery.
+		for (const indexPath of resultIndexPaths(resultsDir, sessionId, runId)) {
+			try {
+				fs.rmSync(indexPath, { force: true });
+			} catch {
+				// Index cleanup must not affect result delivery.
+			}
 		}
-		try {
-			fs.rmSync(resultPendingPath(resultsDir, sessionId, runId), { force: true });
-		} catch {
-			// Pending cleanup must not affect result delivery.
+		for (const pendingPath of resultPendingPaths(resultsDir, sessionId, runId)) {
+			try {
+				fs.rmSync(pendingPath, { force: true });
+			} catch {
+				// Pending cleanup must not affect result delivery.
+			}
 		}
 	}
 	try {
@@ -202,7 +229,7 @@ function existingResultFile(resultPath: string): boolean {
 }
 
 function pendingResultExists(resultsDir: string, sessionId: string, runId: string): boolean {
-	return existingResultFile(resultPendingPath(resultsDir, sessionId, runId));
+	return firstExistingResultFile(resultPendingPaths(resultsDir, sessionId, runId)) !== undefined;
 }
 
 function pendingResultPayloadMatches(filePath: string, sessionId: string, runId: string): boolean {
@@ -217,8 +244,8 @@ function pendingResultPayloadMatches(filePath: string, sessionId: string, runId:
 
 export function promotePendingResultFile(resultsDir: string, sessionId: string, runId: string, file = resultFileName(runId), options: { logFailure?: boolean } = {}): "none" | "promoted" | "pending" {
 	if (file !== path.basename(file) || !file.endsWith(".json")) return "none";
-	const pendingPath = resultPendingPath(resultsDir, sessionId, runId);
-	if (!existingResultFile(pendingPath)) return "none";
+	const pendingPath = firstExistingResultFile(resultPendingPaths(resultsDir, sessionId, runId));
+	if (!pendingPath) return "none";
 	const resultPath = path.join(resultsDir, file);
 	try {
 		// POSIX rename replaces the destination atomically. Deleting it first lets a
@@ -251,10 +278,9 @@ interface ResultPayloadLocation {
 
 function pendingResultLocationForSessionRun(resultsDir: string, sessionId: string, runId: string, file = resultFileName(runId)): ResultPayloadLocation | undefined {
 	if (file !== path.basename(file) || !file.endsWith(".json")) return undefined;
-	const pendingPath = resultPendingPath(resultsDir, sessionId, runId);
-	return existingResultFile(pendingPath) && pendingResultPayloadMatches(pendingPath, sessionId, runId)
-		? { file, path: pendingPath, state: "pending" }
-		: undefined;
+	const pendingPath = firstExistingResultFile(resultPendingPaths(resultsDir, sessionId, runId));
+	if (!pendingPath || !pendingResultPayloadMatches(pendingPath, sessionId, runId)) return undefined;
+	return { file, path: pendingPath, state: "pending" };
 }
 
 function resultPayloadLocationFromIndex(resultsDir: string, entry: ResultIndexEntry): ResultPayloadLocation | undefined {
@@ -269,15 +295,19 @@ function resultPayloadLocationFromIndex(resultsDir: string, entry: ResultIndexEn
 }
 
 function readResultIndexForSessionRun(resultsDir: string, sessionId: string, runId: string): ResultIndexEntry | undefined {
-	try {
-		const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(resultIndexPath(resultsDir, sessionId, runId), "utf-8")));
-		if (!entry || entry.sessionId !== sessionId || entry.runId !== runId) return undefined;
-		return entry;
-	} catch (error) {
-		const code = (error as NodeJS.ErrnoException).code;
-		if (code !== "ENOENT" && code !== "ENOTDIR") console.error(`Ignoring invalid async result index for '${runId}':`, error);
-		return undefined;
+	for (const indexPath of resultIndexPaths(resultsDir, sessionId, runId)) {
+		try {
+			const entry = parseResultIndexEntry(JSON.parse(fs.readFileSync(indexPath, "utf-8")));
+			if (!entry || entry.sessionId !== sessionId || entry.runId !== runId) continue;
+			return entry;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code !== "ENOENT" && code !== "ENOTDIR" && code !== "EPERM" && code !== "EACCES") {
+				console.error(`Ignoring invalid async result index for '${runId}':`, error);
+			}
+		}
 	}
+	return undefined;
 }
 
 export function resultPayloadPathForSessionRun(resultsDir: string, sessionId: string, runId: string): string | undefined {
@@ -357,39 +387,46 @@ function resultFilesFromIndexDir(resultsDir: string, dir: string, includePending
 }
 
 export function resultFilesForSession(resultsDir: string, sessionId: string): string[] {
-	return resultFilesFromIndexDir(resultsDir, sessionIndexDir(resultsDir, sessionId));
+	const files = new Set<string>();
+	for (const dir of sessionIndexDirs(resultsDir, sessionId)) {
+		for (const file of resultFilesFromIndexDir(resultsDir, dir)) files.add(file);
+	}
+	return [...files];
 }
 
 function pendingResultFilesForSession(resultsDir: string, sessionId: string): string[] {
-	const dir = path.join(resultsDir, RESULT_PENDING_DIR, encodeSegment(sessionId));
-	let entries: fs.Dirent[];
-	try {
-		entries = fs.readdirSync(dir, { withFileTypes: true });
-	} catch (error) {
-		const code = (error as NodeJS.ErrnoException).code;
-		if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES") return [];
-		throw error;
-	}
 	const files = new Set<string>();
-	for (const entry of entries) {
-		if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
-		const pendingPath = path.join(dir, entry.name);
+	for (const dir of pendingSessionDirs(resultsDir, sessionId)) {
+		let entries: fs.Dirent[];
 		try {
-			const data = JSON.parse(fs.readFileSync(pendingPath, "utf-8")) as Record<string, unknown>;
-			const runId = nonEmptyString(data.runId) ?? nonEmptyString(data.id);
-			if (runId && nonEmptyString(data.sessionId) === sessionId) files.add(resultFileName(runId));
+			entries = fs.readdirSync(dir, { withFileTypes: true });
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid pending async result '${pendingPath}':`, error);
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES") continue;
+			throw error;
+		}
+		for (const entry of entries) {
+			if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+			const pendingPath = path.join(dir, entry.name);
+			try {
+				const data = JSON.parse(fs.readFileSync(pendingPath, "utf-8")) as Record<string, unknown>;
+				const runId = nonEmptyString(data.runId) ?? nonEmptyString(data.id);
+				if (runId && nonEmptyString(data.sessionId) === sessionId) files.add(resultFileName(runId));
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid pending async result '${pendingPath}':`, error);
+			}
 		}
 	}
 	return [...files];
 }
 
 export function resultCandidateFilesForSession(resultsDir: string, sessionId: string): string[] {
-	return [...new Set([
-		...resultFilesFromIndexDir(resultsDir, sessionIndexDir(resultsDir, sessionId), true),
-		...pendingResultFilesForSession(resultsDir, sessionId),
-	])];
+	const files = new Set<string>();
+	for (const dir of sessionIndexDirs(resultsDir, sessionId)) {
+		for (const file of resultFilesFromIndexDir(resultsDir, dir, true)) files.add(file);
+	}
+	for (const file of pendingResultFilesForSession(resultsDir, sessionId)) files.add(file);
+	return [...files];
 }
 
 export function resultFilesForToolCall(resultsDir: string, toolCallId: string): string[] {

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -73,7 +73,7 @@ function resultPendingPath(resultsDir: string, sessionId: string, runId: string)
 }
 
 function resultPendingPaths(resultsDir: string, sessionId: string, runId: string): string[] {
-	return indexSegmentAliases(sessionId).map((segment) => path.join(resultsDir, RESULT_PENDING_DIR, segment, encodedJsonFileName(runId)));
+	return indexSegmentAliases(sessionId).flatMap((segment) => encodedJsonFileNames(runId).map((fileName) => path.join(resultsDir, RESULT_PENDING_DIR, segment, fileName)));
 }
 
 function pendingSessionDirs(resultsDir: string, sessionId: string): string[] {

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -332,7 +332,7 @@ function listIndexFiles(dir: string): string[] {
 			.map((entry) => path.join(dir, entry.name));
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code;
-		if (code === "ENOENT" || code === "ENOTDIR") return [];
+		if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES") return [];
 		throw error;
 	}
 	return files;
@@ -366,7 +366,8 @@ function pendingResultFilesForSession(resultsDir: string, sessionId: string): st
 	try {
 		entries = fs.readdirSync(dir, { withFileTypes: true });
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES") return [];
 		throw error;
 	}
 	const files = new Set<string>();
@@ -416,7 +417,8 @@ export function cleanupResultIndexes(resultsDir: string, now = Date.now(), maxAg
 		try {
 			entries = fs.readdirSync(dir, { withFileTypes: true });
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES") return;
 			throw error;
 		}
 		for (const entry of entries) {

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -246,6 +246,11 @@ function pendingResultPayloadMatches(filePath: string, sessionId: string, runId:
 	}
 }
 
+function assertPendingResultPayloadMatches(filePath: string, sessionId: string, runId: string): boolean {
+	const data = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, unknown>;
+	return (nonEmptyString(data.runId) ?? nonEmptyString(data.id)) === runId && nonEmptyString(data.sessionId) === sessionId;
+}
+
 export function promotePendingResultFile(resultsDir: string, sessionId: string, runId: string, file = resultFileName(runId), options: { logFailure?: boolean } = {}): "none" | "promoted" | "pending" {
 	if (file !== path.basename(file) || !file.endsWith(".json")) return "none";
 	const pendingPath = firstExistingResultFile(resultPendingPaths(resultsDir, sessionId, runId));
@@ -285,6 +290,12 @@ function pendingResultLocationForSessionRun(resultsDir: string, sessionId: strin
 	const pendingPath = firstExistingResultFile(resultPendingPaths(resultsDir, sessionId, runId));
 	if (!pendingPath || !pendingResultPayloadMatches(pendingPath, sessionId, runId)) return undefined;
 	return { file, path: pendingPath, state: "pending" };
+}
+
+export function fallbackResultPayloadPathForSessionRun(resultsDir: string, sessionId: string, runId: string): string | undefined {
+	const pendingPath = firstExistingResultFile(resultPendingPaths(resultsDir, sessionId, runId));
+	if (!pendingPath || !assertPendingResultPayloadMatches(pendingPath, sessionId, runId)) return undefined;
+	return pendingPath;
 }
 
 function resultPayloadLocationFromIndex(resultsDir: string, entry: ResultIndexEntry): ResultPayloadLocation | undefined {

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -32,6 +32,10 @@ function encodedJsonFileName(value: string): string {
 	return `${encodeIndexSegment(value, MAX_JSON_FILE_STEM_BYTES)}${JSON_EXTENSION}`;
 }
 
+function encodedJsonFileNames(value: string): string[] {
+	return indexSegmentAliases(value, MAX_JSON_FILE_STEM_BYTES).map((segment) => `${segment}${JSON_EXTENSION}`);
+}
+
 function nonEmptyString(value: unknown): string | undefined {
 	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
@@ -57,7 +61,7 @@ function resultIndexPath(resultsDir: string, sessionId: string, runId: string): 
 }
 
 function resultIndexPaths(resultsDir: string, sessionId: string, runId: string): string[] {
-	return sessionIndexDirs(resultsDir, sessionId).map((dir) => path.join(dir, encodedJsonFileName(runId)));
+	return sessionIndexDirs(resultsDir, sessionId).flatMap((dir) => encodedJsonFileNames(runId).map((fileName) => path.join(dir, fileName)));
 }
 
 function runIndexPath(resultsDir: string, runId: string): string {
@@ -302,7 +306,8 @@ function readResultIndexForSessionRun(resultsDir: string, sessionId: string, run
 			return entry;
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
-			if (code !== "ENOENT" && code !== "ENOTDIR" && code !== "EPERM" && code !== "EACCES") {
+			if (code === "EPERM" || code === "EACCES") throw error;
+			if (code !== "ENOENT" && code !== "ENOTDIR") {
 				console.error(`Ignoring invalid async result index for '${runId}':`, error);
 			}
 		}

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -140,6 +140,11 @@ function isNotFound(error: unknown): boolean {
 	return errorCode(error) === "ENOENT";
 }
 
+function isAccessDenied(error: unknown): boolean {
+	const code = errorCode(error);
+	return code === "EPERM" || code === "EACCES";
+}
+
 function shouldPoll(error: unknown): boolean {
 	const code = errorCode(error);
 	return code === "EMFILE" || code === "ENOSPC";
@@ -232,6 +237,7 @@ export function createResultWatcher(
 			return `${resultPath}:${stat.size}:${stat.mtimeMs}`;
 		} catch (error) {
 			identityCache.delete(file);
+			if (isAccessDenied(error)) throw error;
 			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
 			return undefined;
 		}
@@ -249,6 +255,7 @@ export function createResultWatcher(
 			return { identity, signature };
 		} catch (error) {
 			identityCache.delete(file);
+			if (isAccessDenied(error)) throw error;
 			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
 			return undefined;
 		}
@@ -293,10 +300,17 @@ export function createResultWatcher(
 	const handleResult = async (file: string, triggerTurn: boolean) => {
 		if (processing.has(file)) return;
 		let observed: ReadonlySet<string> | undefined;
-		if (!shouldProcessResult(file)) {
-			const runId = file === path.basename(file) && file.endsWith(".json") ? file.replace(/\.json$/i, "") : undefined;
-			observed = observedRunIds();
-			if (!runId || !observed.has(runId) || !shouldProcessResult(file, observed)) return;
+		try {
+			if (!shouldProcessResult(file)) {
+				const runId = file === path.basename(file) && file.endsWith(".json") ? file.replace(/\.json$/i, "") : undefined;
+				observed = observedRunIds();
+				if (!runId || !observed.has(runId) || !shouldProcessResult(file, observed)) return;
+			}
+		} catch (error) {
+			if (!isAccessDenied(error)) throw error;
+			console.error(`Failed to inspect subagent result file '${publicResultPath(file)}'; will retry:`, error);
+			scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+			return;
 		}
 		processing.add(file);
 		let resultPath = publicResultPath(file);
@@ -517,7 +531,10 @@ export function createResultWatcher(
 			if (!ownsSession(sessionId, epoch)) return;
 			if (!removeDeliveredResult(file, sessionId, runId, toolCallId)) scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
 		} catch (error) {
-			if (!isNotFound(error)) console.error(`Failed to process subagent result file '${resultPath}':`, error);
+			if (isAccessDenied(error)) {
+				console.error(`Failed to process subagent result file '${resultPath}'; will retry:`, error);
+				scheduleResult(file, triggerTurn, RETRY_DELAY_MS);
+			} else if (!isNotFound(error)) console.error(`Failed to process subagent result file '${resultPath}':`, error);
 		} finally {
 			processing.delete(file);
 		}

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -137,7 +137,8 @@ function errorCode(error: unknown): string | undefined {
 }
 
 function isNotFound(error: unknown): boolean {
-	return errorCode(error) === "ENOENT";
+	const code = errorCode(error);
+	return code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES";
 }
 
 function shouldPoll(error: unknown): boolean {

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -137,8 +137,7 @@ function errorCode(error: unknown): string | undefined {
 }
 
 function isNotFound(error: unknown): boolean {
-	const code = errorCode(error);
-	return code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES";
+	return errorCode(error) === "ENOENT";
 }
 
 function shouldPoll(error: unknown): boolean {

--- a/src/runs/background/wait-completions.ts
+++ b/src/runs/background/wait-completions.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import type { ArtifactPaths, SubagentState, WaitCompletion, WaitCompletionChild } from "../../shared/types.ts";
 import type { AsyncRunSummary } from "./async-status.ts";
 import { readCompletionReplay, writeCompletionReplay } from "./completion-replay.ts";
-import { resultFilePath, resultPayloadPathForSessionRun } from "./result-files.ts";
+import { fallbackResultPayloadPathForSessionRun, resultFilePath, resultPayloadPathForSessionRun } from "./result-files.ts";
 
 function asNonEmptyString(value: unknown): string | undefined {
 	return typeof value === "string" && value ? value : undefined;
@@ -12,6 +12,11 @@ function errorCode(error: unknown): string | undefined {
 	return typeof error === "object" && error !== null && "code" in error
 		? (error as NodeJS.ErrnoException).code
 		: undefined;
+}
+
+function isAccessDenied(error: unknown): boolean {
+	const code = errorCode(error);
+	return code === "EPERM" || code === "EACCES";
 }
 
 function errorMessage(error: unknown): string {
@@ -115,9 +120,21 @@ export function collectWaitCompletions(terminal: AsyncRunSummary[], state: Subag
 			continue;
 		}
 		const publicResultPath = resultFilePath(resultsDir, run.id);
-		const resultPath = run.sessionId
-			? resultPayloadPathForSessionRun(resultsDir, run.sessionId, run.id) ?? publicResultPath
-			: publicResultPath;
+		let resultPath = publicResultPath;
+		try {
+			resultPath = run.sessionId
+				? resultPayloadPathForSessionRun(resultsDir, run.sessionId, run.id) ?? publicResultPath
+				: publicResultPath;
+		} catch (error) {
+			if (!isAccessDenied(error) || !run.sessionId) throw error;
+			try {
+				resultPath = fallbackResultPayloadPathForSessionRun(resultsDir, run.sessionId, run.id) ?? publicResultPath;
+			} catch (fallbackError) {
+				throw new Error(`Failed to read subagent result '${publicResultPath}': ${errorMessage(fallbackError)}`, {
+					cause: fallbackError instanceof Error ? fallbackError : undefined,
+				});
+			}
+		}
 		try {
 			const raw = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as Record<string, unknown>;
 			completions.push(toWaitCompletion(raw, run.id));

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import * as fs from "node:fs";
+import fsDefault, * as fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
@@ -1755,6 +1756,56 @@ describe("result watcher", () => {
 			assert.equal(fs.existsSync(resultPath), false);
 			assert.deepEqual(emitted, ["subagent:async-complete"]);
 		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("retries delivery after a transient session index access denial", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-index-retry-"));
+		const originalError = console.error;
+		const originalReadFileSync = fsDefault.readFileSync;
+		try {
+			console.error = () => {};
+			const state = createState();
+			state.currentSessionId = "session-1";
+			const emitted: string[] = [];
+			const fakeWatcher = {
+				on() { return fakeWatcher; },
+				close() {},
+				unref() {},
+			} as fs.FSWatcher;
+			let watchEvent: ((event: string, file: string | Buffer | null) => void) | undefined;
+			const resultPath = path.join(resultsDir, "index-retry.json");
+			writeIndexedResult(resultPath, { id: "index-retry", runId: "index-retry", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1 });
+			let indexReads = 0;
+			fsDefault.readFileSync = ((file, ...args) => {
+				if (String(file).includes(`${path.sep}result-index${path.sep}`)) {
+					indexReads += 1;
+				}
+				if (indexReads === 2 && String(file).includes(`${path.sep}result-index${path.sep}`)) {
+					const error = new Error("permission denied") as NodeJS.ErrnoException;
+					error.code = "EACCES";
+					throw error;
+				}
+				return originalReadFileSync(file, ...args);
+			}) as typeof fsDefault.readFileSync;
+			syncBuiltinESMExports();
+
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit(event) { emitted.push(event); } } }, state, resultsDir, 60_000, {
+				fs: { ...fs, watch: (_path, callback) => { watchEvent = callback; return fakeWatcher; } },
+			});
+			try {
+				watcher.startResultWatcher();
+				watchEvent?.("change", "index-retry.json");
+				assert.equal(await waitForPredicate(() => emitted.includes("subagent:async-complete")), true);
+			} finally {
+				watcher.stopResultWatcher();
+			}
+			assert.equal(fs.existsSync(resultPath), false);
+		} finally {
+			console.error = originalError;
+			fsDefault.readFileSync = originalReadFileSync;
+			syncBuiltinESMExports();
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/completion-replay.test.ts
+++ b/test/unit/completion-replay.test.ts
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import { cleanupCompletionReplay, completionArchivePath, completionReplayPath, readCompletionArchive, readCompletionReplay, writeCompletionReplay, writeCompletionArchive } from "../../src/runs/background/completion-replay.ts";
 import { utf8Tail } from "../../src/shared/utf8.ts";
 import { collectWaitCompletions, recordWaitCompletion } from "../../src/runs/background/wait-completions.ts";
+import { writeAsyncResultFile } from "../../src/runs/background/result-files.ts";
 import type { AsyncRunSummary } from "../../src/runs/background/async-status.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
 
@@ -54,6 +55,75 @@ describe("completion replay", () => {
 			assert.equal(completions?.[0]?.results?.[0]?.agent, "worker");
 			assert.equal(completions?.[0]?.archivePath, replay?.archivePath);
 		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("surfaces pending completions when the direct session index is temporarily inaccessible", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-completion-index-denied-"));
+		const originalReadFileSync = fsCjs.readFileSync;
+		try {
+			const publicPath = path.join(resultsDir, "run-pending.json");
+			fs.mkdirSync(publicPath, { recursive: true });
+			writeAsyncResultFile(publicPath, {
+				id: "run-pending",
+				runId: "run-pending",
+				sessionId: "session-a",
+				agent: "worker",
+				success: true,
+				results: [{ agent: "worker", success: true, outputState: "present" }],
+			});
+			fsCjs.readFileSync = ((file, ...args) => {
+				if (String(file).includes(`${path.sep}result-index${path.sep}`)) {
+					const error = new Error("permission denied") as NodeJS.ErrnoException;
+					error.code = "EACCES";
+					throw error;
+				}
+				return originalReadFileSync(file, ...args);
+			}) as typeof fsCjs.readFileSync;
+			syncBuiltinESMExports();
+
+			const terminal = [{ id: "run-pending", sessionId: "session-a" }] as AsyncRunSummary[];
+			const completions = collectWaitCompletions(terminal, makeState(), resultsDir);
+			assert.equal(completions?.[0]?.runId, "run-pending");
+			assert.equal(completions?.[0]?.results?.[0]?.agent, "worker");
+		} finally {
+			fsCjs.readFileSync = originalReadFileSync;
+			syncBuiltinESMExports();
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("surfaces malformed pending payload errors when the direct session index is inaccessible", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-completion-index-denied-malformed-"));
+		const originalReadFileSync = fsCjs.readFileSync;
+		try {
+			const publicPath = path.join(resultsDir, "run-pending.json");
+			fs.mkdirSync(publicPath, { recursive: true });
+			writeAsyncResultFile(publicPath, {
+				id: "run-pending",
+				runId: "run-pending",
+				sessionId: "session-a",
+				success: true,
+			});
+			fs.rmSync(publicPath, { recursive: true, force: true });
+			const pendingDir = path.join(resultsDir, "result-pending", encodeURIComponent("session-a"));
+			fs.writeFileSync(path.join(pendingDir, "run-pending.json"), "{", "utf-8");
+			fsCjs.readFileSync = ((file, ...args) => {
+				if (String(file).includes(`${path.sep}result-index${path.sep}`)) {
+					const error = new Error("permission denied") as NodeJS.ErrnoException;
+					error.code = "EACCES";
+					throw error;
+				}
+				return originalReadFileSync(file, ...args);
+			}) as typeof fsCjs.readFileSync;
+			syncBuiltinESMExports();
+
+			const terminal = [{ id: "run-pending", sessionId: "session-a" }] as AsyncRunSummary[];
+			assert.throws(() => collectWaitCompletions(terminal, makeState(), resultsDir), /Failed to read/);
+		} finally {
+			fsCjs.readFileSync = originalReadFileSync;
+			syncBuiltinESMExports();
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/index-segment.test.ts
+++ b/test/unit/index-segment.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { ACTIVE_RUN_INDEX_DIR, readActiveRunToolCallIndex, releaseActiveRunIndex, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
-import { encodeIndexSegment, MAX_INDEX_SEGMENT_BYTES } from "../../src/runs/background/index-segment.ts";
+import { encodeIndexSegment, indexSegmentAliases, MAX_INDEX_SEGMENT_BYTES } from "../../src/runs/background/index-segment.ts";
 
 describe("bounded index segments", () => {
 	it("preserves legacy encoding for short values and hashes oversized opaque ids", () => {
@@ -30,6 +30,8 @@ describe("bounded index segments", () => {
 		assert.match(encodeIndexSegment(sessionId), /^~sha256-[a-f0-9]{64}$/);
 		assert.equal(encodeIndexSegment(sessionId), encodeIndexSegment(sessionId));
 		assert.match(encodeIndexSegment("session.jsonl"), /^~sha256-[a-f0-9]{64}$/);
+		assert.deepEqual(indexSegmentAliases(sessionId), [encodeIndexSegment(sessionId), encodeURIComponent(sessionId)]);
+		assert.deepEqual(indexSegmentAliases("session-a"), ["session-a"]);
 	});
 
 	it("indexes and releases active runs with oversized provider tool-call ids", () => {

--- a/test/unit/index-segment.test.ts
+++ b/test/unit/index-segment.test.ts
@@ -24,6 +24,14 @@ describe("bounded index segments", () => {
 		assert.notEqual(first, encodeIndexSegment(`${longId}other`));
 	});
 
+	it("hashes Windows session file paths that stay under the byte limit", () => {
+		const sessionId = String.raw`C:\Users\theap\.pi\agent\sessions\--C--Users-theap--\2026-08-17T07-29-51-353Z_01a00ea0-72f9-754f-82ca-2b74ded94746.jsonl`;
+		assert.ok(Buffer.byteLength(encodeURIComponent(sessionId), "utf-8") <= MAX_INDEX_SEGMENT_BYTES);
+		assert.match(encodeIndexSegment(sessionId), /^~sha256-[a-f0-9]{64}$/);
+		assert.equal(encodeIndexSegment(sessionId), encodeIndexSegment(sessionId));
+		assert.match(encodeIndexSegment("session.jsonl"), /^~sha256-[a-f0-9]{64}$/);
+	});
+
 	it("indexes and releases active runs with oversized provider tool-call ids", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-active-index-long-tool-call-"));
 		try {

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -327,6 +327,42 @@ describe("result file indexes", () => {
 		}
 	});
 
+	it("reads a pre-hash extension-like run index filename", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-legacy-run-"));
+		try {
+			const sessionId = "session-a";
+			const runId = "legacy.jsonl";
+			const resultPath = path.join(resultsDir, `${runId}.json`);
+			writeAsyncResultFile(resultPath, { id: runId, runId, sessionId, success: true });
+
+			const indexDir = path.join(resultsDir, "result-index", "sessions", encodeIndexSegment(sessionId));
+			const [currentFile] = fs.readdirSync(indexDir);
+			assert.ok(currentFile);
+			fs.renameSync(path.join(indexDir, currentFile), path.join(indexDir, `${runId}.json`));
+
+			assert.equal(resultPayloadPathForSessionRun(resultsDir, sessionId, runId), resultPath);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("throws access-denied direct session index reads", (t) => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-eacces-index-"));
+		const error = new Error("permission denied") as NodeJS.ErrnoException;
+		error.code = "EACCES";
+		try {
+			writeAsyncResultFile(path.join(resultsDir, "blocked.json"), { id: "blocked", runId: "blocked", sessionId: "session-a", success: true });
+			t.mock.method(fsDefault, "readFileSync", () => { throw error; });
+			syncBuiltinESMExports();
+
+			assert.throws(() => resultPayloadPathForSessionRun(resultsDir, "session-a", "blocked"), (thrown) => thrown === error);
+		} finally {
+			t.mock.restoreAll();
+			syncBuiltinESMExports();
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("returns no session candidates when the session index is unlistable", () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-eperm-scan-"));
 		const error = new Error("operation not permitted") as NodeJS.ErrnoException;

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -289,4 +289,38 @@ describe("result file indexes", () => {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}
 	});
+
+	it("round-trips results for Windows session file paths", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-win-session-"));
+		try {
+			const sessionId = String.raw`C:\Users\theap\.pi\agent\sessions\leaf.jsonl`;
+			const runId = "win-session-run";
+			const resultPath = path.join(resultsDir, `${runId}.json`);
+			writeAsyncResultFile(resultPath, { id: runId, runId, sessionId, success: true });
+
+			const sessionDirs = fs.readdirSync(path.join(resultsDir, "result-index", "sessions"));
+			assert.equal(sessionDirs.length, 1);
+			assert.match(sessionDirs[0]!, /^~sha256-[a-f0-9]{64}$/);
+			assert.deepEqual(resultFilesForSession(resultsDir, sessionId), [`${runId}.json`]);
+			assert.deepEqual(resultCandidateFilesForSession(resultsDir, sessionId), [`${runId}.json`]);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("returns no session candidates when the session index is unlistable", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-eperm-scan-"));
+		const error = new Error("operation not permitted") as NodeJS.ErrnoException;
+		error.code = "EPERM";
+		const originalReaddirSync = fsDefault.readdirSync;
+		try {
+			fsDefault.readdirSync = (() => { throw error; }) as typeof fsDefault.readdirSync;
+			syncBuiltinESMExports();
+			assert.deepEqual(resultCandidateFilesForSession(resultsDir, "session-a"), []);
+		} finally {
+			fsDefault.readdirSync = originalReaddirSync;
+			syncBuiltinESMExports();
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -346,6 +346,28 @@ describe("result file indexes", () => {
 		}
 	});
 
+	it("reads a pre-hash extension-like pending filename", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-legacy-pending-"));
+		const originalError = console.error;
+		try {
+			const sessionId = "session-a";
+			const runId = "legacy.jsonl";
+			const resultPath = path.join(resultsDir, `${runId}.json`);
+			fs.mkdirSync(resultPath);
+			console.error = () => {};
+			writePendingAsyncResultFile(resultPath, { id: runId, runId, sessionId, success: true });
+
+			const currentPath = pendingPath(resultsDir, sessionId, runId);
+			const historicalPath = path.join(path.dirname(currentPath), `${runId}.json`);
+			fs.renameSync(currentPath, historicalPath);
+
+			assert.equal(resultPayloadPathForSessionRun(resultsDir, sessionId, runId), historicalPath);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("throws access-denied direct session index reads", (t) => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-eacces-index-"));
 		const error = new Error("permission denied") as NodeJS.ErrnoException;

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -308,6 +308,25 @@ describe("result file indexes", () => {
 		}
 	});
 
+	it("reads a pre-hash URI-encoded session index after the encoding change", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-legacy-session-"));
+		try {
+			const sessionId = String.raw`C:\Users\theap\.pi\agent\sessions\leaf.jsonl`;
+			const runId = "legacy-session-run";
+			const resultPath = path.join(resultsDir, `${runId}.json`);
+			writeAsyncResultFile(resultPath, { id: runId, runId, sessionId, success: true });
+
+			const currentDir = path.join(resultsDir, "result-index", "sessions", encodeIndexSegment(sessionId));
+			const historicalDir = path.join(resultsDir, "result-index", "sessions", encodeURIComponent(sessionId));
+			fs.renameSync(currentDir, historicalDir);
+
+			assert.deepEqual(resultFilesForSession(resultsDir, sessionId), [`${runId}.json`]);
+			assert.equal(resultPayloadPathForSessionRun(resultsDir, sessionId, runId), resultPath);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("returns no session candidates when the session index is unlistable", () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-eperm-scan-"));
 		const error = new Error("operation not permitted") as NodeJS.ErrnoException;


### PR DESCRIPTION
Pi on Windows stores `currentSessionId` as the full session file path (`C:\Users\...\2026-08-17T....jsonl`). `encodeIndexSegment` kept the URI-encoded form because it is under 255 bytes. The result watcher then `readdir`s `result-index/sessions/C%3A%5C...jsonl` and Windows returns `EPERM` on every poll.

This change hashes those path-like / file-like segments (`%5C` or a trailing `.jsonl`) with the existing `~sha256-` scheme, and treats `EPERM`/`EACCES` as an empty index scan so leftover directories stop flooding the parent session.

I hit this on Win11 with pi-subagents 0.50.0. Unit tests cover the Windows session path and an unlistable session index.
