### PR TITLE
fix: fall back to manifest resolution for workflow parser entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Resolve `/subagents-generate-profiles` provider probes through the shared Pi executable resolver so configured and Windows-specific Pi commands work. Thanks to [@Wumpf](https://github.com/Wumpf) for #1199.
 - Serialize same-worktree Orca progress-tab creation so numbered tabs appear left to right in sequence instead of racing in the UI. Thanks to [@hyein-cbio](https://github.com/hyein-cbio) for #1196.
 - Route Fleet inspector steering for live in-process workflow children through their foreground routes instead of the detached async queue. Thanks to [@ViktorBarzin](https://github.com/ViktorBarzin) for #1218 and #1216.
-- Resolve the workflowScript parser from pi-subagents instead of the caller's working directory, so workflows start in projects that do not install Acorn.
+- Resolve the workflowScript parser from pi-subagents instead of the caller's working directory, so workflows start in projects that do not install Acorn. Thanks to [@xz-dev](https://github.com/xz-dev) for #1214, following up #1190.
 - Treat provider subscription usage-limit errors as retryable model failures so `fallbackModels` can continue to the next configured model. Thanks to [@dwizzle204](https://github.com/dwizzle204) for #1215.
 - Keep structured delegation integration coverage active when the test process inherits a subagent-child environment marker.
 - Bound repeated async-state queries to active, exact-id, and recent-terminal indexes instead of scanning the historical async root (#1162).

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -1,4 +1,6 @@
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { dirname, resolve as resolvePath } from "node:path";
 import { Worker } from "node:worker_threads";
 
 const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
@@ -707,13 +709,32 @@ function workflowStringMetadata(params: Record<string, unknown>): Pick<WorkflowS
 	};
 }
 
+function resolveWorkflowParserEntry(): string {
+	try {
+		return requireFromPackage.resolve("acorn");
+	} catch (primaryError) {
+		// Some runtimes (e.g. Bun-compiled single-file binaries) fail bare
+		// package-specifier resolution through createRequire while subpath
+		// resolution still works. Resolve the manifest and derive the
+		// CommonJS entry from its "main" field instead.
+		try {
+			const manifestPath = requireFromPackage.resolve("acorn/package.json");
+			const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as { main?: unknown };
+			const entry = typeof manifest.main === "string" && manifest.main ? manifest.main : "./dist/acorn.js";
+			return resolvePath(dirname(manifestPath), entry);
+		} catch {
+			throw primaryError;
+		}
+	}
+}
+
 export async function runWorkflowScript(options: RunWorkflowScriptOptions): Promise<WorkflowScriptResult> {
 	if (!options.script.trim()) throw new Error("workflowScript must not be empty.");
 	if (options.timeoutMs !== undefined && (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1)) throw new Error("workflow script timeout must be a positive integer.");
 
 	let acornPath: string;
 	try {
-		acornPath = requireFromPackage.resolve("acorn");
+		acornPath = resolveWorkflowParserEntry();
 	} catch (error) {
 		throw new Error("Workflow parser dependency 'acorn' is unavailable from pi-subagents. Reinstall pi-subagents dependencies before launching workflowScript.", { cause: error });
 	}


### PR DESCRIPTION
## Summary

`runWorkflowScript` resolves its parser via `createRequire(import.meta.url).resolve("acorn")`. That call throws `MODULE_NOT_FOUND` under **Bun-compiled single-file Pi binaries** even when `node_modules/acorn` is present right next to `package.json`, so every `workflowScript` launch fails before the worker starts with:

```
Workflow parser dependency 'acorn' is unavailable from pi-subagents. Reinstall pi-subagents dependencies before launching workflowScript.
```

Reinstalling cannot help — the dependency was never missing. Observed under a Pi `pi-native` binary reporting `{ node: "v24.3.0", bun: "1.3.14" }`:

| resolution attempt | result |
| --- | --- |
| `createRequire(import.meta.url).resolve("acorn")` | ❌ `MODULE_NOT_FOUND` |
| same with explicit `{ paths: [pkgDir] }` | ❌ `MODULE_NOT_FOUND` |
| `resolve("acorn/package.json")` | ✅ works |
| `require("<abs path>/node_modules/acorn/dist/acorn.js")` | ✅ works |
| `await import("acorn")` | ✅ works |

Bare package-specifier resolution through `createRequire` is broken in that runtime while subpath resolution still works.

## Fix

Add `resolveWorkflowParserEntry()`: keep the existing bare-specifier resolution as the primary path, and on failure fall back to resolving `acorn/package.json` and deriving the CommonJS entry from the manifest's `main` field. If the manifest is unavailable too, the original error is rethrown so the actionable setup message is unchanged for genuinely missing dependencies.

## Validation

- `tsc --noEmit` clean
- `test/unit/scripted-workflow.test.ts`: 71/71 pass
- End-to-end in the affected runtime (Bun-compiled Pi binary, extension loaded from source): `runWorkflowScript` with top-level `await`, `Promise.all`, `console.log` capture and `emit()` completes and returns the expected value; before the patch the same probe reproduced the exact reported error.

Refs #1190.