### PR TITLE
Fix fleet steer routing for in-process workflow children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Skip malformed agent definitions during discovery so valid agents still list and launch, while showing their configuration errors in management diagnostics (#1200).
 - Resolve `/subagents-generate-profiles` provider probes through the shared Pi executable resolver so configured and Windows-specific Pi commands work. Thanks to [@Wumpf](https://github.com/Wumpf) for #1199.
 - Serialize same-worktree Orca progress-tab creation so numbered tabs appear left to right in sequence instead of racing in the UI. Thanks to [@hyein-cbio](https://github.com/hyein-cbio) for #1196.
+- Route Fleet inspector steering for live in-process workflow children through their foreground routes instead of the detached async queue. Thanks to [@ViktorBarzin](https://github.com/ViktorBarzin) for #1218 and #1216.
 - Resolve the workflowScript parser from pi-subagents instead of the caller's working directory, so workflows start in projects that do not install Acorn.
 - Keep structured delegation integration coverage active when the test process inherits a subagent-child environment marker.
 - Bound repeated async-state queries to active, exact-id, and recent-terminal indexes instead of scanning the historical async root (#1162).

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -14,6 +14,7 @@ import { listAsyncRuns, type AsyncRunSummary } from "../runs/background/async-st
 import { steerAsyncRun } from "../runs/foreground/async-steering-action.ts";
 import type { SteerDeliveryMode } from "../runs/background/control-channel.ts";
 import { stopAsyncRun } from "../runs/foreground/async-stop-action.ts";
+import { resolveWorkflowForegroundSteeringTarget, steerWorkflowForegroundTarget } from "../runs/foreground/workflow-foreground-steering.ts";
 import { contextModeBadge, contextModeLabel } from "../runs/shared/context-mode.ts";
 import { FLEET_STATUS_WIDGET_KEY } from "./fleet-status.ts";
 import { readFleetTranscript, renderFleetTranscript, type FleetTranscript } from "./fleet-transcript.ts";
@@ -1279,14 +1280,25 @@ export async function openSubagentFleet(ctx: ExtensionContext, state: SubagentSt
 		await copyToClipboard(text);
 	});
 	const actions = options.actions ?? {
-		steer: async (input: { runId: string; asyncDir: string; index?: number; message: string; mode: SteerDeliveryMode }) => firstToolResultText(await steerAsyncRun({
-			state,
-			runId: input.runId,
-			...(input.index !== undefined ? { index: input.index } : {}),
-			message: input.message,
-			mode: input.mode,
-			location: { asyncDir: input.asyncDir, resolvedId: input.runId } as Parameters<typeof steerAsyncRun>[0]["location"],
-		}), `Failed to steer async run ${input.runId}.`),
+		steer: async (input: { runId: string; asyncDir: string; index?: number; message: string; mode: SteerDeliveryMode }) => {
+			const status = readStatus(input.asyncDir);
+			const liveWorkflowRunId = status?.mode === "workflow" && state.workflowControllers?.has(status.runId || input.runId)
+				? status.runId || input.runId
+				: undefined;
+			if (liveWorkflowRunId) {
+				const route = resolveWorkflowForegroundSteeringTarget({ state, workflowRunId: liveWorkflowRunId, asyncDirRoot: options.asyncDirRoot ?? DIRS.async });
+				if (!route.ok) return { text: route.message, isError: true };
+				return firstToolResultText(await steerWorkflowForegroundTarget({ target: route.target, message: input.message, mode: input.mode, ...(input.index !== undefined ? { index: input.index } : {}) }), `Failed to steer foreground run ${input.runId}.`);
+			}
+			return firstToolResultText(await steerAsyncRun({
+				state,
+				runId: input.runId,
+				...(input.index !== undefined ? { index: input.index } : {}),
+				message: input.message,
+				mode: input.mode,
+				location: { asyncDir: input.asyncDir, resolvedId: input.runId } as Parameters<typeof steerAsyncRun>[0]["location"],
+			}), `Failed to steer async run ${input.runId}.`);
+		},
 		stop: (input: { runId: string; asyncDir: string; index?: number }) => firstToolResultText(stopAsyncRun(state, input.runId, undefined, { asyncDir: input.asyncDir, resolvedId: input.runId }), `Failed to stop async run ${input.runId}.`),
 		inspect: async (input: { runId: string; asyncDir: string; index?: number }) => firstToolResultText(await handleHerdrInspectorAction("inspector.open", {
 			id: input.runId,

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -194,9 +194,22 @@ export function collectFleetSnapshot(
 	const workflowParentIds = new Set([...trackedJobs.values()]
 		.filter((job) => job.mode === "workflow" && belongsToCurrentSession(job.sessionId, state.currentSessionId))
 		.map((job) => job.asyncId));
+	const workflowForegroundChildCounts = new Map<string, number>();
+	const liveWorkflowForegroundControls = new Set<ForegroundRunControl>();
+	for (const control of state.foregroundControls.values()) {
+		const activeChildCount = control.activeChildren?.size ?? 0;
+		if (!control.parentWorkflowRunId
+			|| !workflowParentIds.has(control.parentWorkflowRunId)
+			|| !belongsToCurrentSession(control.sessionId, state.currentSessionId)
+			|| !control.workflowSteeringDir
+			|| activeChildCount === 0) continue;
+		liveWorkflowForegroundControls.add(control);
+		workflowForegroundChildCounts.set(control.parentWorkflowRunId, (workflowForegroundChildCounts.get(control.parentWorkflowRunId) ?? 0) + activeChildCount);
+	}
 	for (const control of [...state.foregroundControls.values()].sort((left, right) => right.updatedAt - left.updatedAt)) {
 		activeForegroundIds.add(control.runId);
-		if (control.parentWorkflowRunId && workflowParentIds.has(control.parentWorkflowRunId)) continue;
+		if (control.parentWorkflowRunId && workflowParentIds.has(control.parentWorkflowRunId)
+			&& ((workflowForegroundChildCounts.get(control.parentWorkflowRunId) ?? 0) <= 1 || !liveWorkflowForegroundControls.has(control))) continue;
 		if (control.activeChildren) {
 			for (const child of [...control.activeChildren.values()].sort((left, right) => left.index - right.index)) {
 				items.push({
@@ -841,6 +854,18 @@ export class SubagentFleetComponent implements Component {
 		return { item };
 	}
 
+	private selectedSteerAction(): { runId: string; asyncDir: string; index?: number } | { reason: string } {
+		const item = this.snapshot.items[this.selected];
+		if (item?.kind === "foreground-active" && item.control.parentWorkflowRunId) {
+			const parent = this.state.asyncJobs.get(item.control.parentWorkflowRunId) ?? this.state.fleetJobs?.get(item.control.parentWorkflowRunId);
+			if (!parent || !isActionableAsyncState(parent.status)) return { reason: "The parent workflow is no longer available for steering." };
+			return { runId: item.runId, asyncDir: parent.asyncDir, ...(item.index !== undefined ? { index: item.index } : {}) };
+		}
+		const target = this.selectedAsyncAction();
+		if ("reason" in target) return target;
+		return { runId: target.item.runId, asyncDir: target.item.run.asyncDir, ...(target.item.index !== undefined ? { index: target.item.index } : {}) };
+	}
+
 	private selectedHerdrInspectAction(): { runId: string; asyncDir: string; index?: number } | { reason: string } {
 		const item = this.snapshot.items[this.selected];
 		if (!item) return { reason: "No child is selected." };
@@ -998,12 +1023,12 @@ export class SubagentFleetComponent implements Component {
 					this.setActionNotice({ text: "Steer message cannot be empty.", isError: true });
 					return;
 				}
-				const target = this.selectedAsyncAction();
+				const target = this.selectedSteerAction();
 				if ("reason" in target || !this.options.actions) {
 					this.setActionNotice({ text: "reason" in target ? target.reason : "Fleet controls are unavailable in this context.", isError: true });
 					return;
 				}
-				this.runAction(() => this.options.actions!.steer({ runId: target.item.runId, asyncDir: target.item.run.asyncDir, ...(target.item.index !== undefined ? { index: target.item.index } : {}), message, mode: this.steerMode }));
+				this.runAction(() => this.options.actions!.steer({ ...target, message, mode: this.steerMode }));
 				return;
 			}
 			if (matchesKey(data, "tab") || data === "\t") {
@@ -1071,7 +1096,7 @@ export class SubagentFleetComponent implements Component {
 			return;
 		}
 		if (matchesFleetAction(data, this.keybindings, "steer")) {
-			const target = this.selectedAsyncAction();
+			const target = this.selectedSteerAction();
 			if ("reason" in target || !this.options.actions) this.setActionNotice({ text: "reason" in target ? target.reason : "Fleet controls are unavailable in this context.", isError: true });
 			else {
 				this.actionNotice = undefined;
@@ -1286,7 +1311,9 @@ export async function openSubagentFleet(ctx: ExtensionContext, state: SubagentSt
 				? status.runId || input.runId
 				: undefined;
 			if (liveWorkflowRunId) {
-				const route = resolveWorkflowForegroundSteeringTarget({ state, workflowRunId: liveWorkflowRunId, asyncDirRoot: options.asyncDirRoot ?? DIRS.async });
+				const route = state.foregroundControls.get(input.runId)?.parentWorkflowRunId === liveWorkflowRunId
+					? resolveWorkflowForegroundSteeringTarget({ state, childRunId: input.runId, asyncDirRoot: options.asyncDirRoot ?? DIRS.async })
+					: resolveWorkflowForegroundSteeringTarget({ state, workflowRunId: liveWorkflowRunId, asyncDirRoot: options.asyncDirRoot ?? DIRS.async });
 				if (!route.ok) return { text: route.message, isError: true };
 				return firstToolResultText(await steerWorkflowForegroundTarget({ target: route.target, message: input.message, mode: input.mode, ...(input.index !== undefined ? { index: input.index } : {}) }), `Failed to steer foreground run ${input.runId}.`);
 			}

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -507,7 +507,7 @@ describe("native subagent fleet", () => {
 		assert.equal(snapshot.items[0]?.agent, "workflow");
 	});
 
-	it("hides workflow-owned foreground duplicates and opens the workflow parent inspector", async () => {
+	it("shows selectable workflow children only when multiple are live", async () => {
 		const state = stateForTest();
 		state.asyncJobs.set("workflow-1", {
 			asyncId: "workflow-1",
@@ -531,14 +531,42 @@ describe("native subagent fleet", () => {
 			runId: "child-1",
 			parentWorkflowRunId: "workflow-1",
 			workflowKey: "review",
+			workflowSteeringDir: "/tmp/workflow-1/control/workflow-foreground/child-1",
+			sessionId: "session-current",
 			mode: "single",
 			startedAt: 10,
 			updatedAt: 20,
 			activeChildren: new Map([[0, { index: 0, agent: "reviewer", startedAt: 10, updatedAt: 20 }]]),
 		});
+		assert.deepEqual(collectFleetSnapshot(state).items.map((item) => item.key), ["async:unrelated", "async:workflow-1"]);
+		state.foregroundControls.get("child-1")!.activeChildren!.set(1, { index: 1, agent: "writer", startedAt: 11, updatedAt: 21 });
+		assert.deepEqual(collectFleetSnapshot(state).items.map((item) => item.key), [
+			"foreground-active:child-1:0",
+			"foreground-active:child-1:1",
+			"async:unrelated",
+			"async:workflow-1",
+		]);
+		state.foregroundControls.get("child-1")!.activeChildren!.delete(1);
+		state.foregroundControls.set("child-2", {
+			runId: "child-2",
+			parentWorkflowRunId: "workflow-1",
+			workflowKey: "verify",
+			workflowSteeringDir: "/tmp/workflow-1/control/workflow-foreground/child-2",
+			sessionId: "session-current",
+			mode: "single",
+			startedAt: 11,
+			updatedAt: 21,
+			activeChildren: new Map([[0, { index: 0, agent: "verifier", startedAt: 11, updatedAt: 21 }]]),
+		});
 		const snapshot = collectFleetSnapshot(state);
-		assert.deepEqual(snapshot.items.map((item) => item.key), ["async:unrelated", "async:workflow-1"]);
-		const calls: Array<{ runId: string; asyncDir: string; index?: number }> = [];
+		assert.deepEqual(snapshot.items.map((item) => item.key), [
+			"foreground-active:child-2:0",
+			"foreground-active:child-1:0",
+			"async:unrelated",
+			"async:workflow-1",
+		]);
+		const steerCalls: Array<{ runId: string; asyncDir: string; index?: number; message: string; mode: string }> = [];
+		const inspectCalls: Array<{ runId: string; asyncDir: string; index?: number }> = [];
 		const component = new SubagentFleetComponent(
 			{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
 			theme as never,
@@ -548,17 +576,22 @@ describe("native subagent fleet", () => {
 				initialKey: "foreground-active:child-1:0",
 				refreshMs: 60_000,
 				actions: {
-					async steer() { return { text: "unused" }; },
+					async steer(input) { steerCalls.push(input); return { text: "Steering queued." }; },
 					stop() { return { text: "unused" }; },
-					async inspect(input) { calls.push(input); return { text: "Inspector opened." }; },
+					async inspect(input) { inspectCalls.push(input); return { text: "Inspector opened." }; },
 				},
 			},
 		);
 		try {
 			assert.ok(component.render(100).some((line) => line.includes("workflow")));
+			component.handleInput("s");
+			for (const char of "check the failure") component.handleInput(char);
+			component.handleInput("\r");
+			await new Promise((resolve) => setImmediate(resolve));
+			assert.deepEqual(steerCalls, [{ runId: "child-1", asyncDir: "/tmp/workflow-1", index: 0, message: "check the failure", mode: "steer" }]);
 			component.handleInput("H");
 			await new Promise((resolve) => setImmediate(resolve));
-			assert.deepEqual(calls, [{ runId: "workflow-1", asyncDir: "/tmp/workflow-1" }]);
+			assert.deepEqual(inspectCalls, [{ runId: "workflow-1", asyncDir: "/tmp/workflow-1" }]);
 		} finally {
 			component.dispose();
 		}


### PR DESCRIPTION
# Fix fleet steering for live workflow runs

## What and why

The fleet inspector currently sends every steer action through the detached-run control-file channel. For a live workflow whose children run in the extension process, that queue has no consumer, so the inspector can report a queued request that never reaches a child.

This change routes a workflow row through the foreground steering path when its workflow controller is live. Other runs continue using `steerAsyncRun`.

## Root cause

The default handler in `src/tui/fleet.ts` calls `steerAsyncRun` without checking whether the selected async directory represents an in-process workflow. `steerAsyncRun` writes to `control/steer-requests/`, which detached runner processes consume.

Live workflow children use `control/workflow-foreground/<childRunId>/` and are reachable through `resolveWorkflowForegroundSteeringTarget` plus `steerWorkflowForegroundTarget`. The `subagent` tool's steer action already uses this distinction; the fleet handler did not.

## Scope

- Detect workflow status only when a matching live workflow controller exists.
- Reuse the foreground resolver and acknowledged delivery path.
- Preserve the existing detached-run path.
- Do not change fleet inspector controls or input behavior.

## Test notes

- Manually verified that fleet steering reached live workflow children and appeared in their logs.
- Manually verified that detached-run steering still used the existing async channel.
- Verified that the patch applies cleanly to the npm-shipped 0.48.0 source. The npm artifact does not ship `test/`; run `npm test` in the upstream checkout.
