### PR TITLE
fix: preserve workflow Herdr session roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Route Fleet inspector steering for live in-process workflow children through their foreground routes instead of the detached async queue. Thanks to [@ViktorBarzin](https://github.com/ViktorBarzin) for #1218 and #1216.
 - Resolve the workflowScript parser from pi-subagents instead of the caller's working directory, so workflows start in projects that do not install Acorn.
 - Treat provider subscription usage-limit errors as retryable model failures so `fallbackModels` can continue to the next configured model. Thanks to [@dwizzle204](https://github.com/dwizzle204) for #1215.
+- Preserve workflow async session roots for Herdr inspectors so workflow runs open with the same trusted session-root context as standalone runs. Thanks to [@hank-warren](https://github.com/hank-warren) for #1219.
 - Keep structured delegation integration coverage active when the test process inherits a subagent-child environment marker.
 - Bound repeated async-state queries to active, exact-id, and recent-terminal indexes instead of scanning the historical async root (#1162).
 - Keep retained workflow children resumable when their managed worktree cwd is preserved in the handoff manifest (#1172).

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -140,6 +140,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			mode: run.mode,
 			context: run.context,
 			cwd: run.cwd,
+			sessionRoot: run.sessionRoot,
 			agents: visibleSteps.map((step) => step.agent),
 			currentStep: run.currentStep,
 			chainStepCount: run.chainStepCount,

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -84,6 +84,7 @@ export interface AsyncRunSummary {
 	mode: SubagentRunMode;
 	context?: ContextSummary;
 	cwd?: string;
+	sessionRoot?: string;
 	startedAt: number;
 	lastUpdate?: number;
 	endedAt?: number;
@@ -318,6 +319,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		mode: status.mode,
 		...(summarizeContextModes(summarizedSteps.map((step) => step.context)) ? { context: summarizeContextModes(summarizedSteps.map((step) => step.context)) } : {}),
 		cwd: status.cwd,
+		...(status.sessionRoot ? { sessionRoot: status.sessionRoot } : {}),
 		startedAt: status.startedAt,
 		lastUpdate: status.lastUpdate,
 		endedAt: status.endedAt,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3880,6 +3880,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					lastUpdate: startedAt,
 					...(timeout !== undefined ? { deadlineAt: startedAt + timeout, timeoutMs: timeout } : {}),
 					cwd: workflowCwd,
+					...(workflowSessionRoot ? { sessionRoot: workflowSessionRoot } : {}),
 					pid: process.pid,
 					steps: [],
 					workflow: { trace: [], emits: [], console: [] },

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3848,6 +3848,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			};
 			if (workflowRunId) {
 				const toolCallId = _id;
+				const workflowSessionRoot = requestParams.sessionDir
+					? path.resolve(deps.expandTilde(requestParams.sessionDir))
+					: trustedSessionRootsForStatus(ctx, deps)[0];
 				const asyncDir = path.join(DIRS.async, workflowRunId);
 				const resultPath = resultFilePath(DIRS.results, workflowRunId);
 				const statusPath = path.join(asyncDir, "status.json");
@@ -3945,7 +3948,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					status.toolCount = toolCounts.length > 0 ? toolCounts.reduce((total, count) => total + count, 0) : undefined;
 					status.currentStep = runningSteps.length === 1 ? steps.indexOf(runningSteps[0]!) : undefined;
 				};
-				const workflowJob: AsyncJobState = { asyncId: workflowRunId, asyncDir, toolCallId, cwd: workflowCwd, status: "running", sessionId: currentSessionId ?? undefined, mode: "workflow", agents: [], steps: [], startedAt, updatedAt: startedAt, ...(timeout !== undefined ? { timeoutMs: timeout, deadlineAt: startedAt + timeout } : {}), workflow: status.workflow };
+				const workflowJob: AsyncJobState = { asyncId: workflowRunId, asyncDir, toolCallId, cwd: workflowCwd, ...(workflowSessionRoot ? { sessionRoot: workflowSessionRoot } : {}), status: "running", sessionId: currentSessionId ?? undefined, mode: "workflow", agents: [], steps: [], startedAt, updatedAt: startedAt, ...(timeout !== undefined ? { timeoutMs: timeout, deadlineAt: startedAt + timeout } : {}), workflow: status.workflow };
 				deps.state.asyncJobs.set(workflowRunId, workflowJob);
 				deps.state.fleetJobs ??= new Map();
 				deps.state.fleetJobs.set(workflowRunId, workflowJob);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1387,6 +1387,8 @@ export interface AsyncStatus {
 	usageBudget?: UsageBudgetState;
 	pid?: number;
 	cwd?: string;
+	/** Parent-resolved child session root retained for trusted restored transcript lookup. */
+	sessionRoot?: string;
 	currentStep?: number;
 	chainStepCount?: number;
 	pendingAppends?: number;

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -403,6 +403,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				mode: "workflow",
 				state: "running",
 				sessionId: "session-workflow",
+				sessionRoot: "/trusted/workflow-sessions",
 				startedAt: 1000,
 				lastUpdate: 2000,
 				steps: [{ agent: "scan", label: "scan", status: "running" }],
@@ -414,6 +415,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 60_000 });
 			tracker.restoreActiveJobs();
 			assert.deepEqual(state.asyncJobs.get("workflow-run")?.workflow?.emits, [{ stage: "scan" }]);
+			assert.equal(state.asyncJobs.get("workflow-run")?.sessionRoot, "/trusted/workflow-sessions");
 
 			fs.writeFileSync(statusPath, JSON.stringify({
 				runId: "workflow-run",

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -590,6 +590,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const workflowCwd = path.join(tempDir, "workflow-cwd");
 		fs.mkdirSync(workflowCwd);
 		const toolCallId = "call_demo|fc_demo";
+		const context = makeMinimalCtx(tempDir);
+		context.sessionManager.getSessionFile = () => path.join(tempDir, "parent-session.jsonl");
 
 		const result = await executor.execute(
 			toolCallId,
@@ -600,7 +602,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			},
 			new AbortController().signal,
 			undefined,
-			makeMinimalCtx(tempDir),
+			context,
 		);
 
 		assert.equal(result.isError, undefined);
@@ -614,6 +616,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(path.basename(result.details.asyncDir!), workflowRunId);
 		assert.equal(asyncJobs.has(workflowRunId), true);
 		assert.equal(asyncJobs.get(workflowRunId)?.cwd, workflowCwd);
+		assert.equal(asyncJobs.get(workflowRunId)?.sessionRoot, path.join(tempDir, ".pi/subagents", "sessions"));
 		assert.equal(asyncJobs.has(toolCallId), false);
 		assert.equal(fs.existsSync(path.join(DIRS.async, toolCallId)), false);
 		assert.match(result.content[0]?.text ?? "", /Async workflow/);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -621,7 +621,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(fs.existsSync(path.join(DIRS.async, toolCallId)), false);
 		assert.match(result.content[0]?.text ?? "", /Async workflow/);
 		const statusPath = path.join(result.details.asyncDir!, "status.json");
-		let status: { runId?: string; toolCallId?: string; cwd?: string; state?: string; steps?: Array<{ agent?: string; label?: string; workflowKey?: string; parentWorkflowRunId?: string }>; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; agent?: string; state?: string }> } } = {};
+		let status: { runId?: string; toolCallId?: string; cwd?: string; sessionRoot?: string; state?: string; steps?: Array<{ agent?: string; label?: string; workflowKey?: string; parentWorkflowRunId?: string }>; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; agent?: string; state?: string }> } } = {};
 		for (let attempt = 0; attempt < 100; attempt++) {
 			status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
 			if (status.state === "complete" || status.state === "failed") break;
@@ -631,6 +631,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(status.runId, workflowRunId);
 		assert.equal(status.toolCallId, toolCallId);
 		assert.equal(status.cwd, workflowCwd);
+		assert.equal(status.sessionRoot, path.join(tempDir, ".pi/subagents", "sessions"));
 		assert.equal(status.steps?.length, 1);
 		assert.deepEqual(status.steps?.map(({ agent, label, workflowKey }) => ({ agent, label, workflowKey })), [
 			{ agent: "echo", label: "work", workflowKey: "work" },


### PR DESCRIPTION
## Summary

Preserve workflow async session roots on the workflow job state so Herdr inspectors open workflow runs with the same trusted session-root context as standalone async runs.

Closes #1219.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern "starts workflow scripts asynchronously with a portable internal run id" test/integration/single-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test --test-name-pattern "passes live parent-owned custom session roots to standalone inspectors" test/unit/herdr-inspector.test.ts`
- `npm run typecheck`
- `git diff --check`