### PR TITLE
🤖: Default Herdr panes to no focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
-- Keep Herdr project and inspector pane opens in the background by default, and move user focus only when callers explicitly set `focus: true`.
+- Keep Herdr project and inspector pane opens in the background by default, and move user focus only when callers explicitly set `focus: true`. Thanks to [@boggylp](https://github.com/boggylp) for #1226.
 - Stop failing child runs over the stale supervisor-bridge tool pair: when an explicit allowlist names `contact_supervisor`, neither it nor its legacy `intercom` companion is a strict tool requirement anymore, so 0.49-era agent configs and recovery descriptors no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. A lone `intercom` entry still requires a real external provider. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
 - Hash result-index session segments that encode as Windows paths or file-like names (`C:\...\session.jsonl`), keep reading the previous URI-encoded keys, and treat `EPERM`/`EACCES` as an empty index scan so leftover directories do not spam the parent session. Thanks to [@apoapostolov](https://github.com/apoapostolov) for #1211.
 - Add explicit `isolation: "none"` for schema-driven workflows without Git worktree setup, while retaining strict `isolation: "worktree"` behavior. Thanks to [@tlsneo](https://github.com/tlsneo) for #1203.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
+- Keep Herdr project and inspector pane opens in the background by default, and move user focus only when callers explicitly set `focus: true`.
 - Stop failing child runs over the stale supervisor-bridge tool pair: when an explicit allowlist names `contact_supervisor`, neither it nor its legacy `intercom` companion is a strict tool requirement anymore, so 0.49-era agent configs and recovery descriptors no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. A lone `intercom` entry still requires a real external provider. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
 - Hash result-index session segments that encode as Windows paths or file-like names (`C:\...\session.jsonl`), keep reading the previous URI-encoded keys, and treat `EPERM`/`EACCES` as an empty index scan so leftover directories do not spam the parent session. Thanks to [@apoapostolov](https://github.com/apoapostolov) for #1211.
 - Add explicit `isolation: "none"` for schema-driven workflows without Git worktree setup, while retaining strict `isolation: "worktree"` behavior. Thanks to [@tlsneo](https://github.com/tlsneo) for #1203.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
-- Keep Herdr project and inspector pane opens in the background by default, and move user focus only when callers explicitly set `focus: true`. Thanks to [@boggylp](https://github.com/boggylp) for #1226.
+- Keep Herdr project and inspector pane opens in the background by default, and move user focus only when callers explicitly set `focus: true`. The FleetView inspect key still focuses the pane it opens. Thanks to [@boggylp](https://github.com/boggylp) for #1226.
 - Stop failing child runs over the stale supervisor-bridge tool pair: when an explicit allowlist names `contact_supervisor`, neither it nor its legacy `intercom` companion is a strict tool requirement anymore, so 0.49-era agent configs and recovery descriptors no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. A lone `intercom` entry still requires a real external provider. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
 - Hash result-index session segments that encode as Windows paths or file-like names (`C:\...\session.jsonl`), keep reading the previous URI-encoded keys, and treat `EPERM`/`EACCES` as an empty index scan so leftover directories do not spam the parent session. Thanks to [@apoapostolov](https://github.com/apoapostolov) for #1211.
 - Add explicit `isolation: "none"` for schema-driven workflows without Git worktree setup, while retaining strict `isolation: "worktree"` behavior. Thanks to [@tlsneo](https://github.com/tlsneo) for #1203.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -38,7 +38,7 @@ Chaining is code-driven through `workflowScript`. Use `await runs.run(...)` for 
 | `missionId` | string | - | Attach a workflow to an existing project mission instead of creating its default enclosing mission. |
 | `mission` | object/false | auto-create | Override the default enclosing mission with `{ title \| summary, objective?, goal?, budget?, labels? }`. Set exactly one non-empty `title` or `summary`; `objective` and `labels` are optional. `goal` may only be `true`, requires `budget.tokens`, and enables continuation notices. Pass `false` for an intentionally ephemeral workflow with no mission for it or its children and no `state` global. Explicit mission persistence failures are strict. |
 | `handoffPath` | string | - | Aggregate handoff manifest required by `action: "worktree.discard"`. |
-| `focus` | boolean | true | Focus the newly split pane for `action: "inspector.open"` or `action: "project.open"`; not a standalone action. |
+| `focus` | boolean | false | Focus the newly split pane for `action: "inspector.open"` or `action: "project.open"`; not a standalone action. Panes open in the background unless you set `focus: true`. |
 | `view` | `fleet \| transcript` | - | Optional `status` view for the active fleet surface or transcript tail inspection. |
 | `lines` | number | `80` | Maximum transcript lines for `action: "status", view: "transcript"`; capped at 500. |
 | `agentScope` | `user \| project \| both` | `both` | Agent discovery scope. Project wins on collisions. |

--- a/src/inspectors/herdr/actions.ts
+++ b/src/inspectors/herdr/actions.ts
@@ -193,7 +193,7 @@ export async function handleHerdrInspectorAction(action: HerdrInspectorAction, p
 		if (live.ok) return result(`Herdr inspector pane ${existing.paneId} is already open for async run ${target.runId}.${params.focus ? " Herdr cannot refocus an arbitrary raw pane id; select it in the Herdr UI." : ""}`);
 	}
 	const splitArgs = ["pane", "split", "--current", "--direction", "right", "--cwd", status.cwd ?? deps.cwd];
-	if (params.focus !== false) splitArgs.push("--focus");
+	splitArgs.push(params.focus === true ? "--focus" : "--no-focus");
 	const split = await client.run(splitArgs, { timeoutMs: 15_000, signal: deps.signal });
 	if (split.ok === false) return result(formatHerdrError(split.error), true);
 	const paneId = extractPaneId(split.data);
@@ -225,7 +225,7 @@ export async function handleHerdrInspectorAction(action: HerdrInspectorAction, p
 		...(mission ? { missionId: mission.id, missionPath: mission.path } : {}),
 		paneId,
 		openedAt: now,
-		...(params.focus !== false ? { lastFocusedAt: now } : {}),
+		...(params.focus === true ? { lastFocusedAt: now } : {}),
 		herdrVersion: detected.data.versionText,
 		command,
 	};

--- a/src/inspectors/herdr/project-panes.ts
+++ b/src/inspectors/herdr/project-panes.ts
@@ -411,7 +411,7 @@ function createProjectPaneManagerInternal(options: InternalProjectPaneManagerOpt
 				}
 			}
 			const splitArgs = ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot];
-			if (input.focus !== false) splitArgs.push("--focus");
+			splitArgs.push(input.focus === true ? "--focus" : "--no-focus");
 			const split = await client.run(splitArgs, { timeoutMs: 15_000, signal: input.signal });
 			if (!split.ok) return projectPaneError(split.error.code, split.error.message, { projectRoot, details: split.error.details });
 			const paneId = extractPaneId(split.data);
@@ -430,7 +430,7 @@ function createProjectPaneManagerInternal(options: InternalProjectPaneManagerOpt
 				projectRoot,
 				paneId,
 				openedAt: now,
-				...(input.focus !== false ? { lastFocusedAt: now } : {}),
+				...(input.focus === true ? { lastFocusedAt: now } : {}),
 				herdrVersion: detected.data.versionText,
 				command,
 				...(startupMessage ? { startupMessage } : {}),

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -19,6 +19,7 @@ import { contextModeBadge, contextModeLabel } from "../runs/shared/context-mode.
 import { FLEET_STATUS_WIDGET_KEY } from "./fleet-status.ts";
 import { readFleetTranscript, renderFleetTranscript, type FleetTranscript } from "./fleet-transcript.ts";
 import { handleHerdrInspectorAction } from "../inspectors/herdr/actions.ts";
+import type { HerdrClient } from "../inspectors/herdr/client.ts";
 import { getLivePromptAudit, type LivePromptAudit, type PromptAuditView } from "../runs/foreground/prompt-audit.ts";
 
 const REFRESH_MS = 750;
@@ -109,6 +110,7 @@ export interface FleetViewOptions {
 	fleetKeybindings?: FleetKeybindingsConfig;
 	actions?: FleetActionHandlers;
 	copyText?: (text: string) => Promise<void> | void;
+	herdrClient?: HerdrClient;
 }
 
 function belongsToCurrentSession(sessionId: string | undefined, currentSessionId: string | null): boolean {
@@ -1330,11 +1332,13 @@ export async function openSubagentFleet(ctx: ExtensionContext, state: SubagentSt
 		inspect: async (input: { runId: string; asyncDir: string; index?: number }) => firstToolResultText(await handleHerdrInspectorAction("inspector.open", {
 			id: input.runId,
 			dir: input.asyncDir,
+			focus: true,
 			...(input.index !== undefined ? { index: input.index } : {}),
 		}, {
 			state,
 			sessionRoots: state.trustedSessionRoots,
 			cwd: state.baseCwd,
+			...(options.herdrClient ? { client: options.herdrClient } : {}),
 			...(state.authorityPolicy ? { authorityPolicy: state.authorityPolicy } : {}),
 			...(state.missionStoreConfig ? { missions: state.missionStoreConfig } : {}),
 		}), `Failed to open Herdr inspector for async run ${input.runId}.`),

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -10,6 +10,7 @@ import { persistForegroundRunHistory, restoreForegroundRunHistory } from "../../
 import { FLEET_STATUS_WIDGET_KEY } from "../../src/tui/fleet-status.ts";
 import { registerLivePromptAudit, rewritePromptWithGuidance } from "../../src/runs/foreground/prompt-audit.ts";
 import { getArtifactPaths, getArtifactsDir, getProjectArtifactsDir } from "../../src/shared/artifacts.ts";
+import type { HerdrClient } from "../../src/inspectors/herdr/client.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
@@ -1251,6 +1252,57 @@ describe("native subagent fleet", () => {
 
 			await openSubagentFleet(ctx as never, state, { asyncDirRoot: root, resultsDir: path.join(root, "results") });
 			assert.match(rendered, /worker/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("focuses the Herdr pane the operator opens with the inspect key", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-inspect-focus-"));
+		try {
+			const asyncDir = writeAsyncRun(root, { id: "run-focus", agents: ["worker"] });
+			const state = stateForTest();
+			state.asyncJobs.set("run-focus", {
+				asyncId: "run-focus",
+				asyncDir,
+				status: "running",
+				mode: "single",
+				agents: ["worker"],
+				startedAt: 100,
+				updatedAt: 200,
+			});
+			const calls: string[][] = [];
+			const herdrClient: HerdrClient = {
+				run: async <T>(args: string[]) => {
+					calls.push(args);
+					if (args[0] === "--version") return { ok: true, data: "herdr 0.7.5" as T };
+					if (args[0] === "pane" && args[1] === "split") return { ok: true, data: { pane: { pane_id: "w1:p9" } } as T };
+					return { ok: true, data: {} as T };
+				},
+			};
+			const ctx = {
+				hasUI: true,
+				ui: {
+					setWidget() {},
+					async custom(factory: (tui: unknown, theme: unknown, keybindings: unknown, done: (result: undefined) => void) => SubagentFleetComponent) {
+						const component = factory({ terminal: { rows: 32, columns: 100 }, requestRender() {} }, theme, undefined, () => {});
+						try {
+							component.render(100);
+							component.handleInput("H");
+							for (let attempt = 0; attempt < 500 && !calls.some((args) => args[0] === "pane" && args[1] === "split"); attempt++) {
+								await new Promise((resolve) => setImmediate(resolve));
+							}
+						} finally {
+							component.dispose();
+						}
+					},
+				},
+			};
+
+			await openSubagentFleet(ctx as never, state, { asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 60_000, herdrClient });
+			const split = calls.find((args) => args[0] === "pane" && args[1] === "split");
+			assert.ok(split, `no pane split call: ${JSON.stringify(calls)}`);
+			assert.deepEqual(split.slice(-1), ["--focus"]);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -111,6 +111,9 @@ describe("Herdr inspector", () => {
 			assert.equal(binding?.openedAt, "2026-01-01T00:00:00.000Z");
 			assert.equal(binding?.missionId, "mission-cross-project");
 			assert.equal(binding?.missionPath, path.join(missionDir, "mission-cross-project.json"));
+			assert.equal(binding?.lastFocusedAt, undefined);
+			const splitCall = calls.find((args) => args[0] === "pane" && args[1] === "split");
+			assert.deepEqual(splitCall?.slice(-1), ["--no-focus"]);
 			const runCall = calls.find((args) => args[0] === "pane" && args[1] === "run" && args[2] === "w1:p9");
 			assert.ok(runCall);
 			if (process.platform !== "win32") {
@@ -124,6 +127,21 @@ describe("Herdr inspector", () => {
 			assert.match(text(closed), /subagent run was not stopped/);
 			assert.equal(readHerdrInspectorBinding(asyncDir), undefined);
 			assert.ok(calls.some((args) => args.join(" ") === "pane close w1:p9"));
+
+			calls.length = 0;
+			const focusedOpened = await handleHerdrInspectorAction("inspector.open", { id: "run-123", focus: true }, {
+				cwd: root,
+				asyncDirRoot: root,
+				resultsDir: path.join(root, "results"),
+				client,
+				sessionRoots: [sessionRoot],
+				runnerPath: path.join(root, "runner.ts"),
+				now: () => new Date("2026-01-01T00:00:00.000Z"),
+			});
+			assert.equal(focusedOpened.isError, undefined, text(focusedOpened));
+			const focusedSplitCall = calls.find((args) => args[0] === "pane" && args[1] === "split");
+			assert.deepEqual(focusedSplitCall?.slice(-1), ["--focus"]);
+			assert.equal(readHerdrInspectorBinding(asyncDir)?.lastFocusedAt, "2026-01-01T00:00:00.000Z");
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
@@ -292,7 +310,8 @@ describe("Herdr inspector", () => {
 			assert.equal(binding?.projectRoot, projectRoot);
 			assert.equal(binding?.startupMessage, "Own this project mission.");
 			const splitCall = calls.find((args) => args[0] === "pane" && args[1] === "split");
-			assert.deepEqual(splitCall?.slice(0, 7), ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot]);
+			assert.deepEqual(splitCall, ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot, "--no-focus"]);
+			assert.equal(binding?.lastFocusedAt, undefined);
 			const runCall = calls.find((args) => args[0] === "pane" && args[1] === "run" && args[2] === "w1:p10");
 			assert.equal(runCall?.[3]?.startsWith("& "), process.platform === "win32");
 			if (process.platform !== "win32") assert.match(runCall?.[3] ?? "", /^sh -c 'exec \"\$0\" \"\$@\"' '/);
@@ -308,6 +327,17 @@ describe("Herdr inspector", () => {
 			assert.match(text(closed), /Closed Herdr project pane w1:p10/);
 			assert.equal(readHerdrProjectPaneBinding(root), undefined);
 			assert.ok(calls.some((args) => args.join(" ") === "pane close w1:p10"));
+
+			calls.length = 0;
+			const focused = await handleHerdrProjectPaneAction("project.open", { cwd: root, focus: true }, {
+				cwd: process.cwd(),
+				client,
+				now: () => new Date("2026-01-01T00:00:00.000Z"),
+			});
+			assert.equal(focused.isError, undefined, text(focused));
+			const focusedSplitCall = calls.find((args) => args[0] === "pane" && args[1] === "split");
+			assert.deepEqual(focusedSplitCall, ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot, "--focus"]);
+			assert.equal(readHerdrProjectPaneBinding(root)?.lastFocusedAt, "2026-01-01T00:00:00.000Z");
 		} finally {
 			if (previousPiBinary === undefined) delete process.env[PI_SUBAGENT_PI_BINARY_ENV];
 			else process.env[PI_SUBAGENT_PI_BINARY_ENV] = previousPiBinary;


### PR DESCRIPTION
🤖

## Summary

Unattended project and inspector panes moved Herdr focus unless the caller remembered to opt out. Subagents open those panes on their own and omit `focus`, so the disruptive case was the default. Both paths now pass `--no-focus` and take focus only on an explicit `focus: true`.

- Keep persisted focus timestamps aligned with actual focus requests.
- Request focus explicitly for the FleetView inspect key, the one caller whose pane open is a deliberate keypress.
- Correct the `focus` default in the tool reference, which still documented the old focused default.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/herdr-inspector.test.ts test/unit/fleet.test.ts`
- `npm run typecheck`
- `git diff --check`
