### PR TITLE
fix: avoid Darwin reload watcher hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
+- Avoid Darwin reload hangs by disabling native filesystem watchers in idle subagent transports and using demand-gated polling for live result, supervisor, control, and steering delivery. Thanks to [@youlikemodernart](https://github.com/youlikemodernart) for #1220.
 - Stop failing child runs over the stale supervisor-bridge tool pair: when an explicit allowlist names `contact_supervisor`, neither it nor its legacy `intercom` companion is a strict tool requirement anymore, so 0.49-era agent configs and recovery descriptors no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. A lone `intercom` entry still requires a real external provider. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
 - Hash result-index session segments that encode as Windows paths or file-like names (`C:\...\session.jsonl`), keep reading the previous URI-encoded keys, and treat `EPERM`/`EACCES` as an empty index scan so leftover directories do not spam the parent session. Thanks to [@apoapostolov](https://github.com/apoapostolov) for #1211.
 - Add explicit `isolation: "none"` for schema-driven workflows without Git worktree setup, while retaining strict `isolation: "worktree"` behavior. Thanks to [@tlsneo](https://github.com/tlsneo) for #1203.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -31,7 +31,7 @@ import { createSubagentParamsSchema } from "./schemas.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { createAsyncJobTracker } from "../runs/background/async-job-tracker.ts";
 import { getActiveAsyncCapacitySnapshot, resolveMaxActiveAsyncRunsPerSession } from "../runs/background/active-async-capacity.ts";
-import { cleanupResultIndexes } from "../runs/background/result-files.ts";
+import { cleanupResultIndexes, missionObserverResultCandidateFiles } from "../runs/background/result-files.ts";
 import { ASYNC_RETENTION_DELAY_MS, cleanupAsyncRetention } from "../runs/background/async-retention.ts";
 import { createResultWatcher } from "../runs/background/result-watcher.ts";
 import { createScheduledRunManager } from "../runs/background/scheduled-runs.ts";
@@ -457,10 +457,18 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		},
 		resolveCapabilityCeiling: (sessionId) => resolveCurrentSubagentCapabilityCeiling(sessionId),
 	});
+	let refreshResultDelivery = () => {};
+	const hasResultDeliveryDemand = () => {
+		if ([...state.asyncJobs.values()].some((job) => job.status === "queued" || job.status === "running")) return true;
+		if (state.foregroundControls.size > 0) return true;
+		if (scheduledRunManager.observedCompletionRunIds().size > 0) return true;
+		return missionObserverResultCandidateFiles(DIRS.results).length > 0;
+	};
 	const { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs, dispose: disposeAsyncJobTracker } = createAsyncJobTracker(pi, state, DIRS.async, {
 		widgetEnabled: asyncWidgetEnabled,
+		onJobTerminal: () => refreshResultDelivery(),
 	});
-	const { startResultWatcher, primeExistingResults, stopResultWatcher } = createResultWatcher(
+	const resultWatcher = createResultWatcher(
 		pi,
 		state,
 		DIRS.results,
@@ -469,9 +477,12 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			notifier: completionNotifier,
 			observeCompletion: (result) => scheduledRunManager.handleAsyncCompletion(result),
 			observedCompletionRunIds: () => scheduledRunManager.observedCompletionRunIds(),
+			hasDeliveryDemand: hasResultDeliveryDemand,
 			deliverIntercomResults: config.intercomBridge?.resultDelivery === true,
 		},
 	);
+	const { startResultWatcher, primeExistingResults, stopResultWatcher } = resultWatcher;
+	refreshResultDelivery = resultWatcher.refreshResultDelivery;
 	const asyncRetentionAbort = new AbortController();
 	const asyncRetentionTimer = setTimeout(async () => {
 		try {
@@ -519,6 +530,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		getSubagentSessionRoot,
 		expandTilde,
 		discoverAgents,
+		activateSupervisorTransport: () => supervisorChannel.activateTransport(),
+		refreshResultDelivery: () => refreshResultDelivery(),
 	});
 	executorScheduled = executor.executeScheduled;
 
@@ -726,10 +739,13 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	};
 	const asyncStartedHandler = (payload: unknown) => {
 		handleStarted(payload);
+		supervisorChannel.activateTransport();
+		refreshResultDelivery();
 		fleetStatus?.refresh();
 	};
 	const asyncCompleteHandler = (payload: unknown) => {
 		handleComplete(payload);
+		refreshResultDelivery();
 		refreshActiveAsyncCapacity();
 		scheduledRunManager.handleAsyncCompletion(payload);
 		fleetStatus?.refresh();
@@ -897,6 +913,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		});
 		rpcBridge.emitReady(ctx);
 		supervisorChannel.start();
+		supervisorChannel.activateTransport();
 	});
 
 	pi.on("session_shutdown", async () => {

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -14,6 +14,7 @@ import {
 } from "../runs/shared/pi-args.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
 import { writeAtomicJson } from "../shared/atomic-json.ts";
+import { shouldUseNativeFsWatch } from "../shared/watch-strategy.ts";
 
 const SUPERVISOR_CHANNEL_ROOT = path.join(TEMP_ROOT_DIR, "supervisor-channels");
 const REQUESTS_DIR = "requests";
@@ -75,6 +76,7 @@ type SupervisorWatch = (filename: fs.PathLike, listener: fs.WatchListener<string
 interface NativeSupervisorChannelDeps {
 	platform?: NodeJS.Platform;
 	watch?: SupervisorWatch;
+	timers?: Pick<typeof globalThis, "setInterval" | "clearInterval" | "setImmediate" | "clearImmediate">;
 }
 
 const ContactSupervisorParamsSchema = Type.Object({
@@ -612,8 +614,9 @@ function buildParentSupervisorTool(pending: Map<string, PendingSupervisorRequest
 	};
 }
 
-export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentState, deps: NativeSupervisorChannelDeps = {}): { start: () => void; dispose: () => void; pending: Map<string, PendingSupervisorRequest> } {
+export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentState, deps: NativeSupervisorChannelDeps = {}): { start: () => void; activateTransport: () => void; dispose: () => void; pending: Map<string, PendingSupervisorRequest> } {
 	const watch = deps.watch ?? fs.watch;
+	const timers = deps.timers ?? globalThis;
 	const pending = new Map<string, PendingSupervisorRequest>();
 	const seenFiles = new Set<string>();
 	const requestWatchers = new Map<string, fs.FSWatcher>();
@@ -623,6 +626,13 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	let deferredWatcherRefresh: ReturnType<typeof setImmediate> | undefined;
 	let started = false;
 	let lastStaleCleanupAt = 0;
+	const platform = deps.platform ?? process.platform;
+	const useNativeWatcher = () => shouldUseNativeFsWatch("supervisor-channel", platform) && platform !== "win32";
+	const hasTransportDemand = () => {
+		if (pending.size > 0) return true;
+		if (state.foregroundControls.size > 0) return true;
+		return [...state.asyncJobs.values()].some((job) => job.status === "queued" || job.status === "running");
+	};
 
 	const registerParentTools = (): void => {
 		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pending, state));
@@ -689,12 +699,18 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 
 	const startPolling = (): void => {
 		if (poller) return;
-		poller = setInterval(poll, CHANNEL_POLL_MS);
+		poller = timers.setInterval(() => {
+			poll();
+			if (!useNativeWatcher() && platform === "darwin" && !hasTransportDemand()) {
+				if (poller) timers.clearInterval(poller);
+				poller = undefined;
+			}
+		}, CHANNEL_POLL_MS);
 		poller.unref?.();
 	};
 	const startSafetyPolling = (): void => {
 		if (safetyPoller) return;
-		safetyPoller = setInterval(() => {
+		safetyPoller = timers.setInterval(() => {
 			watchExistingRequestDirs();
 			poll();
 		}, CHANNEL_SAFETY_POLL_MS);
@@ -730,7 +746,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	};
 	const scheduleWatcherRefresh = (): void => {
 		if (deferredWatcherRefresh) return;
-		deferredWatcherRefresh = setImmediate(() => {
+		deferredWatcherRefresh = timers.setImmediate(() => {
 			deferredWatcherRefresh = undefined;
 			if (!started) return;
 			watchExistingRequestDirs();
@@ -740,6 +756,11 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	};
 
 	return {
+		activateTransport: () => {
+			if (!started) return;
+			poll();
+			if (!useNativeWatcher() && hasTransportDemand()) startPolling();
+		},
 		start: () => {
 			if (started) return;
 			started = true;
@@ -747,8 +768,8 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 			poll();
 			try {
 				fs.mkdirSync(SUPERVISOR_CHANNEL_ROOT, { recursive: true });
-				if ((deps.platform ?? process.platform) === "win32") {
-					startPolling();
+				if (!useNativeWatcher()) {
+					if (platform === "win32") startPolling();
 					return;
 				}
 				watchExistingRequestDirs();
@@ -776,11 +797,11 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 				try { watcher.close(); } catch {}
 			}
 			requestWatchers.clear();
-			if (poller) clearInterval(poller);
+			if (poller) timers.clearInterval(poller);
 			poller = undefined;
-			if (safetyPoller) clearInterval(safetyPoller);
+			if (safetyPoller) timers.clearInterval(safetyPoller);
 			safetyPoller = undefined;
-			if (deferredWatcherRefresh) clearImmediate(deferredWatcherRefresh);
+			if (deferredWatcherRefresh) timers.clearImmediate(deferredWatcherRefresh);
 			deferredWatcherRefresh = undefined;
 			pending.clear();
 			seenFiles.clear();

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -21,6 +21,7 @@ import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-
 import { findNestedRouteForRootId, hasLiveNestedDescendants, updateAsyncJobNestedProjection } from "../shared/nested-events.ts";
 import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, serviceExternalJobBridgeRequests } from "../shared/external-job-bridge.ts";
+import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
 
 interface AsyncJobTrackerOptions {
 	completionRetentionMs?: number;
@@ -28,6 +29,9 @@ interface AsyncJobTrackerOptions {
 	pollIntervalMs?: number;
 	resultsDir?: string;
 	widgetEnabled?: boolean;
+	platform?: NodeJS.Platform;
+	onJobTerminal?: () => void;
+	watch?: typeof fs.watch;
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 	now?: () => number;
 }
@@ -67,6 +71,9 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	const runningJobIds = new Set<string>();
 	let rootWatcher: fs.FSWatcher | undefined;
 	let nextLivenessAt = Date.now() + livenessIntervalMs;
+	const watch = options.watch ?? fs.watch;
+	const useNativeWatcher = () => shouldUseNativeFsWatch("async-job-tracker", options.platform);
+	const terminalStatus = (status: string) => status === "complete" || status === "failed" || status === "paused" || status === "stopped";
 	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
 		if (state.widgetsSuspended) return;
 		renderWidget(ctx, options.widgetEnabled === false ? [] : jobs);
@@ -407,7 +414,8 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				job.turnBudgetExceeded = status.turnBudgetExceeded ?? job.turnBudgetExceeded;
 				job.wrapUpRequested = status.wrapUpRequested ?? job.wrapUpRequested;
 				job.sessionFile = status.sessionFile ?? job.sessionFile;
-				if (job.status === "complete" || job.status === "failed" || job.status === "paused" || job.status === "stopped") {
+				if (terminalStatus(job.status)) {
+					if (!terminalStatus(previousStatus)) options.onJobTerminal?.();
 					rememberFleetJob(state, job);
 					if (!nestedRefreshFailed && !hasLiveNestedDescendants(job.nestedChildren) && (previousStatus !== job.status || !state.cleanupTimers.has(job.asyncId))) {
 						scheduleCleanup(job.asyncId);
@@ -445,6 +453,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	};
 
 	const watchJob = (job: AsyncJobState) => {
+		if (!useNativeWatcher()) return;
 		const watched = jobWatchers.get(job.asyncId) ?? { watchers: new Map<string, fs.FSWatcher>() };
 		const active = job.status === "queued" || job.status === "running";
 		const watchPath = (watchPath: string): boolean => {
@@ -452,7 +461,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			const nestedEventSink = job.nestedRoute?.eventSink === watchPath;
 			let watcher: fs.FSWatcher;
 			try {
-				watcher = fs.watch(resolveWatchPath(watchPath), (_event, file) => {
+				watcher = watch(resolveWatchPath(watchPath), (_event, file) => {
 					const rawFileName = file?.toString();
 					const fileName = rawFileName ?? path.basename(watchPath);
 					const nestedEventFile = nestedEventSink && (!rawFileName || rawFileName.endsWith(".json") || rawFileName.endsWith(".jsonl"));
@@ -501,9 +510,10 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	};
 
 	const watchAsyncRoot = () => {
+		if (!useNativeWatcher()) return;
 		if (rootWatcher) return;
 		try {
-			rootWatcher = fs.watch(resolveWatchPath(asyncDirRoot), (_event, file) => {
+			rootWatcher = watch(resolveWatchPath(asyncDirRoot), (_event, file) => {
 				const runDirName = file?.toString();
 				for (const job of state.asyncJobs.values()) {
 					if (jobWatchers.has(job.asyncId) || (runDirName && path.basename(job.asyncDir) !== runDirName)) continue;

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -18,6 +18,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { POLL_INTERVAL_MS } from "../../shared/types.ts";
+import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
 import { resolveWatchPath } from "../../shared/utils.ts";
 
 export type ControlChannelFs = Pick<typeof fs, "mkdirSync" | "existsSync" | "rmSync" | "watch" | "readdirSync" | "readFileSync" | "realpathSync">;
@@ -580,6 +581,7 @@ export function watchAsyncControlInbox(
 		onSteerAck?: (ack: SteerAck) => void;
 		pollIntervalMs?: number;
 		safetyPollIntervalMs?: number;
+		platform?: NodeJS.Platform;
 		fs?: ControlChannelFs;
 		timers?: ControlChannelTimers;
 	},
@@ -647,12 +649,16 @@ export function watchAsyncControlInbox(
 		for (const entry of entries) watchDir(path.join(ackRoot, entry));
 	};
 	try {
-		watchDir(dir);
-		watchDir(steerRequestsDir(asyncDir), true);
-		watchDir(steerCapabilitiesDir(asyncDir), true);
-		watchDir(path.join(dir, STEER_ACKS_DIR), true);
-		watchExistingSteerAckDirs();
-		startSafetyPolling();
+		if (shouldUseNativeFsWatch("runner-control-inbox", opts.platform)) {
+			watchDir(dir);
+			watchDir(steerRequestsDir(asyncDir), true);
+			watchDir(steerCapabilitiesDir(asyncDir), true);
+			watchDir(path.join(dir, STEER_ACKS_DIR), true);
+			watchExistingSteerAckDirs();
+			startSafetyPolling();
+		} else {
+			startPolling();
+		}
 	} catch {
 		startPolling();
 	}

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.ts";
 import { createFileCoalescer } from "../../shared/file-coalescer.ts";
+import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
 import {
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	type IntercomEventBus,
@@ -54,6 +55,9 @@ type ResultWatcherDeps = {
 	deliverIntercomResults?: boolean;
 	/** Coalesces result-file events. Tests can lower this without changing retry timing. */
 	coalesceDelayMs?: number;
+	/** Returns true while a durable completion source needs periodic delivery checks. */
+	hasDeliveryDemand?: () => boolean;
+	platform?: NodeJS.Platform;
 };
 
 type ResultFileChild = {
@@ -174,6 +178,7 @@ export function createResultWatcher(
 ): {
 	startResultWatcher: () => void;
 	primeExistingResults: (options?: { triggerTurn?: boolean }) => void;
+	refreshResultDelivery: () => void;
 	stopResultWatcher: () => void;
 } {
 	const fsApi = deps.fs ?? fs;
@@ -584,6 +589,30 @@ export function createResultWatcher(
 		if (resultScanTimer) timers.clearInterval(resultScanTimer);
 		resultScanTimer = null;
 	};
+	const useNativeWatcher = () => shouldUseNativeFsWatch("result-delivery", deps.platform);
+	const hasDeliveryDemand = () => {
+		try {
+			return deps.hasDeliveryDemand?.() === true;
+		} catch (error) {
+			console.error("Failed to inspect subagent result delivery demand:", error);
+			return false;
+		}
+	};
+	const clearResultPoller = () => {
+		if (!state.watcherRestartTimer) return;
+		timers.clearTimeout(state.watcherRestartTimer);
+		timers.clearInterval(state.watcherRestartTimer);
+		state.watcherRestartTimer = null;
+	};
+	const startDemandPolling = () => {
+		if (!deliveryActive || useNativeWatcher() || state.watcherRestartTimer) return;
+		if (!hasDeliveryDemand()) return;
+		state.watcherRestartTimer = timers.setInterval(() => {
+			primeExistingResults();
+			if (!hasDeliveryDemand()) clearResultPoller();
+		}, POLL_INTERVAL_MS);
+		state.watcherRestartTimer.unref?.();
+	};
 
 	const startPolling = (reason: unknown) => {
 		state.watcher?.close();
@@ -622,6 +651,10 @@ export function createResultWatcher(
 			timers.clearTimeout(state.watcherRestartTimer);
 			timers.clearInterval(state.watcherRestartTimer);
 			state.watcherRestartTimer = null;
+		}
+		if (!useNativeWatcher()) {
+			startDemandPolling();
+			return;
 		}
 		try {
 			const watchDir = resolveWatchPath(resultsDir, fsApi.realpathSync.native);
@@ -665,11 +698,7 @@ export function createResultWatcher(
 		deliveryEpoch += 1;
 		state.watcher?.close();
 		state.watcher = null;
-		if (state.watcherRestartTimer) {
-			timers.clearTimeout(state.watcherRestartTimer);
-			timers.clearInterval(state.watcherRestartTimer);
-		}
-		state.watcherRestartTimer = null;
+		clearResultPoller();
 		clearResultScan();
 		state.resultFileCoalescer.clear();
 		pendingTriggerTurn.clear();
@@ -677,5 +706,5 @@ export function createResultWatcher(
 		identityCache.clear();
 	};
 
-	return { startResultWatcher, primeExistingResults, stopResultWatcher };
+	return { startResultWatcher, primeExistingResults, stopResultWatcher, refreshResultDelivery: () => { primeExistingResults(); startDemandPolling(); } };
 }

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -378,6 +378,8 @@ interface ExecutorDeps {
 	expandTilde: (p: string) => string;
 	discoverAgents: (cwd: string, scope: AgentScope) => { agents: AgentConfig[]; agentDiagnostics?: AgentDiscoveryDiagnostic[]; modelScope?: ModelScopeConfig };
 	allowMutatingManagementActions?: boolean;
+	activateSupervisorTransport?: () => void;
+	refreshResultDelivery?: () => void;
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 }
 
@@ -5294,6 +5296,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			};
 			deps.state.foregroundControls.set(runId, foregroundControl);
 			deps.state.lastForegroundControlId = runId;
+			deps.activateSupervisorTransport?.();
+			deps.refreshResultDelivery?.();
 		}
 
 		const writeNestedForegroundEvent = (type: "subagent.nested.started" | "subagent.nested.completed", result?: AgentToolResult<Details>): void => {

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { registerNativeSupervisorClient } from "../../intercom/native-supervisor-channel.ts";
+import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
 import { decodePermissionRules, permissionDecision, PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV } from "./permissions.ts";
 import { consumeSteerRequestsFromDir, MAX_STEER_QUEUE_SIZE, steerAckPathFromDir, writeSteerAckAt, writeSteerCapabilityAt, writeSteerRequestToDir, type SteerDeliveryStatus, type SteerRequest } from "../background/control-channel.ts";
 import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_INDEX_ENV, SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_STEER_ACK_DIR_ENV, SUBAGENT_STEER_CAPABILITY_ENV, SUBAGENT_STEER_INBOX_ENV } from "./pi-args.ts";
@@ -337,6 +338,7 @@ export function registerSteeringInbox(
 		nativeRealpath?: (filePath: string) => string;
 		legacySettleFallbackMs?: number;
 		safetyPollIntervalMs?: number;
+		platform?: NodeJS.Platform;
 		timers?: Pick<typeof globalThis, "setInterval" | "clearInterval">;
 	} = {},
 ): void {
@@ -449,13 +451,17 @@ export function registerSteeringInbox(
 			safetyInterval = (deps.timers?.setInterval ?? setInterval)(flush, deps.safetyPollIntervalMs ?? STEERING_SAFETY_POLL_INTERVAL_MS) as NodeJS.Timeout;
 			safetyInterval.unref?.();
 		};
-		try {
-			watcher = (deps.watch ?? fs.watch)(resolveWatchPath(steerInbox, deps.nativeRealpath), () => flush());
-			watcher.on("error", startPolling);
-			startSafetyPolling();
-		} catch {
-			watcher = undefined;
+		if (!shouldUseNativeFsWatch("child-steering-inbox", deps.platform)) {
 			startPolling();
+		} else {
+			try {
+				watcher = (deps.watch ?? fs.watch)(resolveWatchPath(steerInbox, deps.nativeRealpath), () => flush());
+				watcher.on("error", startPolling);
+				startSafetyPolling();
+			} catch {
+				watcher = undefined;
+				startPolling();
+			}
 		}
 	};
 	const activate = (): undefined => {

--- a/src/shared/watch-strategy.ts
+++ b/src/shared/watch-strategy.ts
@@ -1,0 +1,10 @@
+export type FileWatchPurpose =
+	| "result-delivery"
+	| "supervisor-channel"
+	| "async-job-tracker"
+	| "runner-control-inbox"
+	| "child-steering-inbox";
+
+export function shouldUseNativeFsWatch(_purpose: FileWatchPurpose, platform: NodeJS.Platform = process.platform): boolean {
+	return platform !== "darwin";
+}

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -18,6 +18,9 @@ interface AsyncJobTrackerModule {
 			pollIntervalMs?: number;
 			resultsDir?: string;
 			widgetEnabled?: boolean;
+			platform?: NodeJS.Platform;
+			onJobTerminal?: () => void;
+			watch?: typeof fs.watch;
 			kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 			now?: () => number;
 		},
@@ -37,6 +40,7 @@ type AsyncJobTracker = ReturnType<AsyncJobTrackerModule["createAsyncJobTracker"]
 const activeTrackers = new Set<AsyncJobTracker>();
 
 function createTracker(...args: Parameters<AsyncJobTrackerModule["createAsyncJobTracker"]>): AsyncJobTracker {
+	args[3] = { platform: "linux", ...(args[3] ?? {}) };
 	const tracker = trackerMod!.createAsyncJobTracker(...args);
 	activeTrackers.add(tracker);
 	return tracker;
@@ -457,6 +461,53 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			}), "utf-8");
 
 			await waitForCondition(() => state.asyncJobs.get("late-status-run")?.steps?.[0]?.currentTool === "read", "late status refresh before liveness", 1000);
+			tracker.resetJobs();
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("uses polling without native watchers on Darwin and fires terminal delivery hooks once", async () => {
+		const asyncRoot = createTempDir("pi-async-job-darwin-poll-");
+		try {
+			const runDir = path.join(asyncRoot, "darwin-run");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "darwin-run",
+				mode: "single",
+				state: "running",
+				startedAt: 1000,
+				lastUpdate: 1000,
+				steps: [{ agent: "worker", status: "running" }],
+			}), "utf-8");
+			const state = createState();
+			let nativeWatchCalls = 0;
+			let terminalHooks = 0;
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, {
+				platform: "darwin",
+				pollIntervalMs: 10,
+				onJobTerminal: () => terminalHooks++,
+				watch: (() => {
+					nativeWatchCalls++;
+					throw new Error("Darwin tracker must not create native watchers");
+				}) as typeof fs.watch,
+			});
+			tracker.handleStarted({ id: "darwin-run", asyncDir: runDir, agent: "worker" });
+
+			await waitForCondition(() => state.asyncJobs.get("darwin-run")?.status === "running", "darwin polling started");
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "darwin-run",
+				mode: "single",
+				state: "complete",
+				startedAt: 1000,
+				lastUpdate: 2000,
+				steps: [{ agent: "worker", status: "complete" }],
+			}), "utf-8");
+
+			await waitForCondition(() => state.asyncJobs.get("darwin-run")?.status === "complete", "darwin terminal refresh");
+			await new Promise((resolve) => setTimeout(resolve, 30));
+			assert.equal(nativeWatchCalls, 0);
+			assert.equal(terminalHooks, 1);
 			tracker.resetJobs();
 		} finally {
 			removeTempDir(asyncRoot);

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -41,7 +41,7 @@ function createResultWatcher(
 	completionTtlMs: Parameters<typeof createRawResultWatcher>[3],
 	deps: Parameters<typeof createRawResultWatcher>[4] = {},
 ): ReturnType<typeof createRawResultWatcher> {
-	return createRawResultWatcher(pi, state, resultsDir, completionTtlMs, { coalesceDelayMs: 0, ...deps });
+	return createRawResultWatcher(pi, state, resultsDir, completionTtlMs, { platform: "linux", coalesceDelayMs: 0, ...deps });
 }
 
 function writeIndexedResult(filePath: string, data: Record<string, unknown>): void {
@@ -62,6 +62,70 @@ async function waitForPredicate(predicate: () => boolean, timeoutMs = 2_500): Pr
 }
 
 describe("result watcher", () => {
+	it("does not create Darwin native watchers or idle timers", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-darwin-idle-"));
+		try {
+			let watchCalls = 0;
+			const intervals: number[] = [];
+			const state = createState();
+			state.currentSessionId = "session-1";
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				platform: "darwin",
+				hasDeliveryDemand: () => false,
+				fs: { ...fs, watch: (() => { watchCalls += 1; throw new Error("Darwin must not use fs.watch."); }) as typeof fs.watch },
+				timers: {
+					setTimeout,
+					clearTimeout,
+					setInterval: ((_handler: () => void, delay?: number) => { intervals.push(delay ?? 0); return { unref() {} } as NodeJS.Timeout; }) as typeof setInterval,
+					clearInterval,
+				},
+			});
+			try {
+				watcher.startResultWatcher();
+			} finally {
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal(watchCalls, 0);
+			assert.deepEqual(intervals, []);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("uses demand-gated Darwin polling for result delivery", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-darwin-demand-"));
+		try {
+			let demand = true;
+			let poll: (() => void) | undefined;
+			let cleared = false;
+			const state = createState();
+			state.currentSessionId = "session-1";
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				platform: "darwin",
+				hasDeliveryDemand: () => demand,
+				fs: { ...fs, watch: (() => { throw new Error("Darwin must not use fs.watch."); }) as typeof fs.watch },
+				timers: {
+					setTimeout,
+					clearTimeout,
+					setInterval: ((handler: () => void, delay?: number) => { assert.equal(delay, 3000); poll = handler; return { unref() {} } as NodeJS.Timeout; }) as typeof setInterval,
+					clearInterval: (() => { cleared = true; }) as typeof clearInterval,
+				},
+			});
+			try {
+				watcher.startResultWatcher();
+				assert.equal(typeof poll, "function");
+				demand = false;
+				poll?.();
+				assert.equal(cleared, true);
+			} finally {
+				watcher.stopResultWatcher();
+			}
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("processes deferred session-scoped results after session identity is restored", async () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-session-"));
 		try {

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -377,7 +377,7 @@ describe("control channel: watchAsyncControlInbox", () => {
 		try {
 			const nativeDir = path.join(path.dirname(asyncDir), "native-control-path");
 			const h = harness(nativeDir);
-			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers });
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers, platform: "linux" });
 			assert.equal(h.watchedDir(), nativeDir);
 			dispose();
 		} finally {
@@ -389,7 +389,7 @@ describe("control channel: watchAsyncControlInbox", () => {
 		const asyncDir = tmpAsyncDir("pi-control-watch-no-poll-");
 		try {
 			const h = harness();
-			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers });
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers, platform: "linux" });
 			assert.deepEqual(h.intervalDelays(), [5000]);
 			dispose();
 		} finally {
@@ -401,10 +401,23 @@ describe("control channel: watchAsyncControlInbox", () => {
 		const asyncDir = tmpAsyncDir("pi-control-watch-fallback-");
 		try {
 			const h = harness();
-			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers });
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers, platform: "linux" });
 			h.triggerError();
 			h.triggerError();
 			assert.deepEqual(h.intervalDelays(), [5000, 250]);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("uses portable polling without native watchers on Darwin", () => {
+		const asyncDir = tmpAsyncDir("pi-control-watch-darwin-");
+		try {
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt() {}, fs: h.fsImpl, timers: h.timers, platform: "darwin" });
+			assert.equal(h.watchedDir(), undefined);
+			assert.deepEqual(h.intervalDelays(), [250]);
 			dispose();
 		} finally {
 			cleanup(asyncDir);
@@ -417,7 +430,7 @@ describe("control channel: watchAsyncControlInbox", () => {
 			requestAsyncInterrupt(asyncDir);
 			let fired = 0;
 			const h = harness();
-			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt: () => fired++, fs: h.fsImpl, timers: h.timers });
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt: () => fired++, fs: h.fsImpl, timers: h.timers, platform: "linux" });
 			assert.equal(fired, 1);
 			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), false);
 			dispose();
@@ -431,7 +444,7 @@ describe("control channel: watchAsyncControlInbox", () => {
 		try {
 			let fired = 0;
 			const h = harness();
-			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt: () => fired++, fs: h.fsImpl, timers: h.timers });
+			const dispose = watchAsyncControlInbox(asyncDir, { onInterrupt: () => fired++, fs: h.fsImpl, timers: h.timers, platform: "linux" });
 			assert.equal(fired, 0);
 
 			requestAsyncInterrupt(asyncDir);
@@ -467,6 +480,7 @@ describe("control channel: watchAsyncControlInbox", () => {
 				onStop: () => events.push("stop"),
 				fs: h.fsImpl,
 				timers: h.timers,
+				platform: "linux",
 			});
 
 			assert.deepEqual(events, ["stop", "interrupt"]);
@@ -487,6 +501,7 @@ describe("control channel: watchAsyncControlInbox", () => {
 				onSteer: (request) => steers.push({ message: request.message, targetIndex: request.targetIndex }),
 				fs: h.fsImpl,
 				timers: h.timers,
+				platform: "linux",
 			});
 
 			requestAsyncSteer(asyncDir, { message: "go narrower", targetIndex: 0, id: "s", ts: 1 });
@@ -510,6 +525,7 @@ describe("control channel: watchAsyncControlInbox", () => {
 				onSteer: (request) => steers.push(request.message),
 				fs: h.fsImpl,
 				timers: h.timers,
+				platform: "linux",
 			});
 
 			const watchedSteerDir = fs.realpathSync.native(steerRequestsDir(asyncDir));

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -144,7 +144,7 @@ describe("native supervisor channel", () => {
 			) => { sent.push({ message, options }); },
 			getSessionName: () => "shared-name",
 		};
-		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx));
+		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx), { platform: "darwin" });
 
 		assert.deepEqual(registeredTools, []);
 		channel.start();
@@ -192,6 +192,81 @@ describe("native supervisor channel", () => {
 		assert.deepEqual(sent.map((message) => message.details?.id), [requestId]);
 	});
 
+	it("registers idle Darwin sessions without native watchers or polling", () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const pi = {
+			getAllTools: () => [],
+			registerTool: () => {},
+			sendMessage: () => {},
+			getSessionName: () => "shared-name",
+		};
+		let watchCalls = 0;
+		const intervals: number[] = [];
+		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx), {
+			platform: "darwin",
+			watch: (() => { watchCalls += 1; throw new Error("Darwin must not call fs.watch."); }) as never,
+			timers: {
+				setInterval: ((_handler: () => void, delay?: number) => { intervals.push(delay ?? 0); return { unref() {} } as NodeJS.Timeout; }) as typeof setInterval,
+				clearInterval: (() => {}) as typeof clearInterval,
+				setImmediate,
+				clearImmediate,
+			},
+		});
+
+		channel.start();
+		channel.dispose();
+
+		assert.equal(watchCalls, 0);
+		assert.deepEqual(intervals, []);
+	});
+
+	it("activates Darwin supervisor polling only while child work is live", () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const pi = {
+			getAllTools: () => [],
+			registerTool: () => {},
+			sendMessage: () => {},
+			getSessionName: () => "shared-name",
+		};
+		const state = makeState(currentSessionId, ctx);
+		state.foregroundControls.set("run-a", { runId: "run-a", startedAt: Date.now(), updatedAt: Date.now(), activeChildren: new Map(), schedulingOwners: 1 } as never);
+		const intervals: number[] = [];
+		const channel = createNativeSupervisorChannel(pi as never, state, {
+			platform: "darwin",
+			watch: (() => { throw new Error("Darwin must not call fs.watch."); }) as never,
+			timers: {
+				setInterval: ((_handler: () => void, delay?: number) => { intervals.push(delay ?? 0); return { unref() {} } as NodeJS.Timeout; }) as typeof setInterval,
+				clearInterval: (() => {}) as typeof clearInterval,
+				setImmediate,
+				clearImmediate,
+			},
+		});
+
+		channel.start();
+		channel.activateTransport();
+		channel.dispose();
+
+		assert.deepEqual(intervals, [250]);
+	});
+
 	it("delivers requests written under an existing request directory by watch event", async () => {
 		const currentSessionId = `session-${randomUUID()}`;
 		const runId = `run-${randomUUID()}`;
@@ -212,11 +287,19 @@ describe("native supervisor channel", () => {
 			sendMessage: (message: { details?: { id?: string } }) => { sent.push(message); },
 			getSessionName: () => "shared-name",
 		};
-		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx));
+		const watchListeners: fs.WatchListener<string>[] = [];
+		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx), {
+			platform: "linux",
+			watch: ((_filename: fs.PathLike, listener: fs.WatchListener<string>) => {
+				watchListeners.push(listener);
+				return { on: () => {}, close: () => {}, unref: () => {} } as unknown as fs.FSWatcher;
+			}) as never,
+		});
 
 		try {
 			channel.start();
 			const requestId = writeRequest({ sessionId: currentSessionId, runId });
+			for (const listener of watchListeners) listener("rename", `${requestId}.json`);
 			await waitForCondition(() => sent.some((message) => message.details?.id === requestId), "supervisor request watch delivery");
 		} finally {
 			channel.dispose();

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -244,6 +244,7 @@ describe("subagent prompt runtime", () => {
 				},
 				sendUserMessage() {},
 			} as { on(event: string, handler: (payload?: unknown) => unknown): void; sendUserMessage(): void }, {
+				platform: "linux",
 				nativeRealpath(target) {
 					assert.equal(target, inbox);
 					return nativeInbox;
@@ -264,6 +265,41 @@ describe("subagent prompt runtime", () => {
 			handlers.get("session_start")?.({});
 			assert.equal(watchedDir, nativeInbox);
 			assert.deepEqual(intervalDelays, [5000]);
+			handlers.get("session_shutdown")?.({});
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("uses polling without native steering watchers on Darwin", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-steering-darwin-runtime-"));
+		try {
+			const inbox = path.join(dir, "steer");
+			process.env[SUBAGENT_STEER_INBOX_ENV] = inbox;
+			const handlers = new Map<string, (payload?: unknown) => unknown>();
+			const intervalDelays: number[] = [];
+			let watchCalls = 0;
+
+			registerSteeringInbox({
+				on(event: string, handler: (payload?: unknown) => unknown) {
+					handlers.set(event, handler);
+				},
+				sendUserMessage() {},
+			} as { on(event: string, handler: (payload?: unknown) => unknown): void; sendUserMessage(): void }, {
+				platform: "darwin",
+				watch: (() => { watchCalls += 1; throw new Error("Darwin must not use fs.watch."); }) as typeof fs.watch,
+				timers: {
+					setInterval: ((_handler: Parameters<typeof setInterval>[0], delay?: number) => {
+						intervalDelays.push(delay ?? 0);
+						return { unref() {} };
+					}) as typeof setInterval,
+					clearInterval: (() => {}) as typeof clearInterval,
+				},
+			});
+
+			handlers.get("session_start")?.({});
+			assert.equal(watchCalls, 0);
+			assert.deepEqual(intervalDelays, [250]);
 			handlers.get("session_shutdown")?.({});
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });

--- a/test/unit/watch-strategy.test.ts
+++ b/test/unit/watch-strategy.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { shouldUseNativeFsWatch, type FileWatchPurpose } from "../../src/shared/watch-strategy.ts";
+
+const purposes: FileWatchPurpose[] = [
+	"result-delivery",
+	"supervisor-channel",
+	"async-job-tracker",
+	"runner-control-inbox",
+	"child-steering-inbox",
+];
+
+describe("watch strategy", () => {
+	it("disables native filesystem watchers on Darwin", () => {
+		for (const purpose of purposes) assert.equal(shouldUseNativeFsWatch(purpose, "darwin"), false);
+	});
+
+	it("keeps native filesystem watchers on non-Darwin platforms", () => {
+		for (const purpose of purposes) {
+			assert.equal(shouldUseNativeFsWatch(purpose, "linux"), true);
+			assert.equal(shouldUseNativeFsWatch(purpose, "win32"), true);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1220 by removing Darwin native `fs.watch` usage from the subagent watcher transports that can block `/reload` in `uv__fsevents_close`.

The change adds one shared watcher policy. On Darwin, result delivery and supervisor transport are idle-cheap: no native watchers and no idle timers. Result delivery starts only while there is durable completion demand, and supervisor transport starts only around live child work or pending supervisor requests. Active runner control, child steering, and async tracking reuse their existing active-scoped polling paths on Darwin. Non-Darwin platforms keep the native watcher paths.

## State table

| Owner | State | Durable files | Enter | Exit | Work in state | Release predicate | Rollback predicate | Fail-closed behavior |
|---|---|---|---|---|---|---|---|---|
| Watch policy | native non-Darwin | n/a | process start | never | existing `fs.watch` behavior | non-Darwin watcher tests stay green | Darwin native watch is observed | n/a |
| Result delivery Darwin | idle | result index, pending results | session start after one-shot prime | delivery demand appears | none | idle reload passes with no watcher/timer | idle interval exists | durable results wait on disk |
| Result delivery Darwin | demand poll | result payloads | async start/restore, foreground child, scheduler observer, mission candidate | demand empty | 3s indexed prime plus immediate terminal refresh | completions deliver and poller self-stops | missed durable result delivery | next demand or explicit wait re-primes |
| Supervisor Darwin | registered idle | request/reply dirs | session start | child work or pending request | one poll only | idle reload passes | 250ms poll while no demand | request files stay durable |
| Supervisor Darwin | active poll | request/reply dirs | child spawn/start or pending request | no live child and no pending request | 250ms poll | supervisor request delivery works | poller survives idle | request files stay durable |
| Async tracker Darwin | active poll | async status dirs | jobs exist | jobs terminal/removed | existing job poller and terminal hook | terminal hook fires once | tracker native watch exists | liveness sweep corrects state |
| Runner control Darwin | child-active poll | control dirs | runner starts | runner exits | existing 250ms polling | interrupt/stop/steer deliver | native control watcher exists | control files remain durable |
| Child steering Darwin | child-active poll | steering inbox | child session starts | child exits | existing 250ms polling | steering delivers and acks | native steering watcher exists | requests stay in inbox |

## Validation

- Focused watcher suites: 160 pass, 0 fail.
- `npm run test:unit`: 2126 pass, 3 skipped, 0 fail.
- `npm run test:integration`: 674 pass, 0 fail.
- `npm run test:e2e`: skipped because Pi runtime packages are unavailable in this checkout.
- `npm run typecheck`: pass.
- `git diff --check HEAD~1 HEAD`: pass.
- Manual macOS PTY reload gates: idle reload, seeded completed-result reload, and seeded active-restored reload all reached the reload-complete notice.

## Notes

Changelog credits @youlikemodernart for #1220.
