### PR TITLE
fix: recover run persistence after ENOSPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Avoid Darwin reload hangs by disabling native filesystem watchers in idle subagent transports and using demand-gated polling for live result, supervisor, control, and steering delivery. Thanks to [@youlikemodernart](https://github.com/youlikemodernart) for #1220.
+- Keep live workflow and child-run status/result persistence retrying after temporary filesystem-capacity failures instead of letting `ENOSPC`, quota, or file-descriptor exhaustion crash the host or runner. Thanks to [@ahmadaccino](https://github.com/ahmadaccino) for #1227.
 - Stop failing child runs over the stale supervisor-bridge tool pair: when an explicit allowlist names `contact_supervisor`, neither it nor its legacy `intercom` companion is a strict tool requirement anymore, so 0.49-era agent configs and recovery descriptors no longer fail as missing `intercom` after the 0.50.0 supervisor-channel cutover. A lone `intercom` entry still requires a real external provider. Thanks to [@MingTeer](https://github.com/MingTeer) for #1207.
 - Hash result-index session segments that encode as Windows paths or file-like names (`C:\...\session.jsonl`), keep reading the previous URI-encoded keys, and treat `EPERM`/`EACCES` as an empty index scan so leftover directories do not spam the parent session. Thanks to [@apoapostolov](https://github.com/apoapostolov) for #1211.
 - Add explicit `isolation: "none"` for schema-driven workflows without Git worktree setup, while retaining strict `isolation: "worktree"` behavior. Thanks to [@tlsneo](https://github.com/tlsneo) for #1203.

--- a/src/runs/background/active-run-index.ts
+++ b/src/runs/background/active-run-index.ts
@@ -4,6 +4,7 @@ import type { AsyncStatus } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { encodeIndexSegment } from "./index-segment.ts";
 import { updateTerminalRunIndex } from "./terminal-run-index.ts";
+import { isStorageCapacityError } from "../../shared/file-system-retry.ts";
 
 export const ACTIVE_RUN_INDEX_DIR = ".active-runs";
 export const DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS = 24 * 60 * 60 * 1000;
@@ -99,6 +100,7 @@ export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state
 		try {
 			updateTerminalRunIndex(asyncDir, status);
 		} catch (error) {
+			if (isStorageCapacityError(error)) throw error;
 			console.error(`Failed to write async terminal-run index for '${asyncDir}':`, error);
 		}
 	}

--- a/src/runs/background/active-run-index.ts
+++ b/src/runs/background/active-run-index.ts
@@ -76,7 +76,7 @@ export function releaseActiveRunIndex(asyncDir: string): void {
 	releaseToolCallAliases(asyncDir);
 }
 
-export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state"], toolCallId?: string): void {
+export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state"], toolCallId?: string, options: { retryCapacityErrors?: boolean } = {}): void {
 	const marker = markerPath(asyncDir);
 	if (isActiveAsyncState(state)) {
 		fs.mkdirSync(path.dirname(marker), { recursive: true });
@@ -100,7 +100,7 @@ export function updateActiveRunIndex(asyncDir: string, state: AsyncStatus["state
 		try {
 			updateTerminalRunIndex(asyncDir, status);
 		} catch (error) {
-			if (isStorageCapacityError(error)) throw error;
+			if (options.retryCapacityErrors && isStorageCapacityError(error)) throw error;
 			console.error(`Failed to write async terminal-run index for '${asyncDir}':`, error);
 		}
 	}

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -130,8 +130,8 @@ export function steerInboxClosedPath(asyncDir: string): string {
 	return path.join(controlInboxDir(asyncDir), STEER_INBOX_CLOSED_FILE);
 }
 
-export function closeSteerInbox(asyncDir: string, state: string): void {
-	writeAtomicJson(steerInboxClosedPath(asyncDir), { version: 1, closedAt: Date.now(), state });
+export function closeSteerInbox(asyncDir: string, state: string, write: (filePath: string, payload: object) => void = writeAtomicJson): void {
+	write(steerInboxClosedPath(asyncDir), { version: 1, closedAt: Date.now(), state });
 }
 
 /** Per-child inbox consumed by the child prompt runtime inside the Pi process. */

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -2383,7 +2383,7 @@ async function runSubagent(
 		if (state === lastIndexedStatusState && indexPersistence.pendingCount() === 0) return;
 		indexPersistence.write(asyncDir, { state, toolCallId: statusPayload.toolCallId }, (_filePath, payload) => {
 			const indexPayload = payload as { state: AsyncStatus["state"]; toolCallId?: string };
-			updateActiveRunIndex(asyncDir, indexPayload.state, indexPayload.toolCallId);
+			updateActiveRunIndex(asyncDir, indexPayload.state, indexPayload.toolCallId, { retryCapacityErrors: true });
 		});
 	};
 	const runPersistence = createCapacityResilientJsonWriter({

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -7,7 +7,9 @@ import type { Message } from "@earendil-works/pi-ai";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { writeAsyncResultFile, writePendingAsyncResultFile } from "./result-files.ts";
 import { createFileCoalescer } from "../../shared/file-coalescer.ts";
-import { isActiveAsyncState, updateActiveRunIndex } from "./active-run-index.ts";
+import { createCapacityResilientJsonWriter } from "../../shared/capacity-resilient-json.ts";
+import { isStorageCapacityError } from "../../shared/file-system-retry.ts";
+import { updateActiveRunIndex } from "./active-run-index.ts";
 import { createChildTranscriptWriter, type ChildTranscriptWriter } from "../../shared/child-transcript.ts";
 import { closeSteerInbox, consumeInterruptRequest, consumeSteerRequests, deliverInterruptRequest, deliverStopRequest, deliverTimeoutRequest, enqueueStepSteer, steerAcksDir, steerCapabilityPath, stepSteerInboxDir, watchAsyncControlInbox, type SteerAck, type SteerCapability, type SteerRequest } from "./control-channel.ts";
 import { appendJsonl as appendRawJsonl, formatOutputArtifactContent, getArtifactPaths, writeArtifact, writeMetadata } from "../../shared/artifacts.ts";
@@ -1113,6 +1115,7 @@ function writeRunLog(
 		shareUrl?: string;
 		shareError?: string;
 	},
+	write: (filePath: string, content: string) => void = (filePath, content) => fs.writeFileSync(filePath, content, "utf-8"),
 ): void {
 	const lines: string[] = [];
 	lines.push(`# Subagent run ${input.id}`);
@@ -1142,7 +1145,7 @@ function writeRunLog(
 	}
 	lines.push(input.summary.trim() || "(no output)");
 	lines.push("");
-	fs.writeFileSync(logPath, lines.join("\n"), "utf-8");
+	write(logPath, lines.join("\n"));
 }
 
 /** Context for running a single step */
@@ -2026,6 +2029,7 @@ function markParallelGroupSetupFailure(input: {
 	asyncDir: string;
 	runId: string;
 	stepIndex: number;
+	writeStatus: (status: RunnerStatusPayload) => void;
 }): void {
 	for (let taskIndex = 0; taskIndex < input.group.parallel.length; taskIndex++) {
 		const flatTaskIndex = input.groupStartFlatIndex + taskIndex;
@@ -2042,7 +2046,7 @@ function markParallelGroupSetupFailure(input: {
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.lastUpdate = input.failedAt;
 	input.statusPayload.outputFile = path.join(input.asyncDir, `output-${input.groupStartFlatIndex}.log`);
-	writeAtomicJson(input.statusPath, input.statusPayload);
+	input.writeStatus(input.statusPayload);
 	appendJsonl(input.eventsPath, JSON.stringify({
 		type: "subagent.parallel.completed",
 		ts: input.failedAt,
@@ -2062,6 +2066,7 @@ function markParallelGroupRunning(input: {
 	asyncDir: string;
 	runId: string;
 	stepIndex: number;
+	writeStatus: (status: RunnerStatusPayload) => void;
 }): void {
 	for (let taskIndex = 0; taskIndex < input.group.parallel.length; taskIndex++) {
 		const flatTaskIndex = input.groupStartFlatIndex + taskIndex;
@@ -2079,7 +2084,7 @@ function markParallelGroupRunning(input: {
 	input.statusPayload.lastActivityAt = input.groupStartTime;
 	input.statusPayload.lastUpdate = input.groupStartTime;
 	input.statusPayload.outputFile = path.join(input.asyncDir, `output-${input.groupStartFlatIndex}.log`);
-	writeAtomicJson(input.statusPath, input.statusPayload);
+	input.writeStatus(input.statusPayload);
 	appendJsonl(input.eventsPath, JSON.stringify({
 		type: "subagent.parallel.started",
 		ts: input.groupStartTime,
@@ -2365,9 +2370,37 @@ async function runSubagent(
 		outputFile: path.join(asyncDir, "output-0.log"),
 	});
 
-	fs.mkdirSync(asyncDir, { recursive: true });
-	writeAtomicJson(statusPath, statusPayload);
-	updateActiveRunIndex(asyncDir, statusPayload.state, statusPayload.toolCallId);
+	let lastIndexedStatusState: AsyncStatus["state"] | undefined;
+	const indexPersistence = createCapacityResilientJsonWriter({
+		keepAlive: true,
+		onSuccess: (_filePath, payload) => {
+			lastIndexedStatusState = (payload as { state: AsyncStatus["state"] }).state;
+		},
+		onError: (error, filePath) => console.error(`Failed to update async run index '${filePath}':`, error),
+	});
+	const queueActiveRunIndex = (): void => {
+		const state = statusPayload.state;
+		if (state === lastIndexedStatusState && indexPersistence.pendingCount() === 0) return;
+		indexPersistence.write(asyncDir, { state, toolCallId: statusPayload.toolCallId }, (_filePath, payload) => {
+			const indexPayload = payload as { state: AsyncStatus["state"]; toolCallId?: string };
+			updateActiveRunIndex(asyncDir, indexPayload.state, indexPayload.toolCallId);
+		});
+	};
+	const runPersistence = createCapacityResilientJsonWriter({
+		keepAlive: true,
+		onSuccess: (filePath) => {
+			if (filePath === statusPath) queueActiveRunIndex();
+		},
+		onError: (error, filePath) => console.error(`Failed to persist async run state '${filePath}':`, error),
+	});
+	try {
+		fs.mkdirSync(asyncDir, { recursive: true });
+	} catch (error) {
+		if (!isStorageCapacityError(error)) throw error;
+		console.error(`Failed to prepare async run storage '${asyncDir}' while storage is full:`, error);
+	}
+	runPersistence.write(statusPath, statusPayload);
+
 	let pendingParallelUsageCost: CostSummary = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
 	const currentUsageTotals = (): CostSummary => {
 		const cost = results.reduce<CostSummary>((sum, result) => ({
@@ -2440,7 +2473,6 @@ async function runSubagent(
 		statusPayload.workflowGraph = graph;
 	};
 	let finalResultCommitted = false;
-	let lastIndexedActiveState = isActiveAsyncState(statusPayload.state);
 	const statusResultState = (): AsyncStatus["state"] | undefined => {
 		if (statusPayload.state === "running" || statusPayload.state === "queued") return undefined;
 		return statusPayload.state;
@@ -2464,7 +2496,7 @@ async function runSubagent(
 		if (!state || finalResultCommitted || !config.sessionId) return;
 		const now = statusPayload.endedAt ?? statusPayload.lastUpdate ?? Date.now();
 		const summary = statusResultSummary(state);
-		writePendingAsyncResultFile(resultPath, omitUndefinedProperties({
+		runPersistence.write(resultPath, omitUndefinedProperties({
 			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
 			id,
 			runId: id,
@@ -2492,17 +2524,12 @@ async function runSubagent(
 			cwd,
 			sessionId: config.sessionId,
 			sessionFile: statusPayload.sessionFile ?? latestSessionFile,
-		}));
+		}), (filePath, payload) => writePendingAsyncResultFile(filePath, payload as Record<string, unknown>));
 	};
 	const writeStatusPayloadNow = (): void => {
 		refreshWorkflowGraph();
 		writeRecoverableStatusResult();
-		writeAtomicJson(statusPath, statusPayload);
-		const activeState = isActiveAsyncState(statusPayload.state);
-		if (activeState !== lastIndexedActiveState) {
-			updateActiveRunIndex(asyncDir, statusPayload.state, statusPayload.toolCallId);
-		}
-		lastIndexedActiveState = activeState;
+		runPersistence.write(statusPath, statusPayload);
 		emitNestedSelfEvent(statusPayload.state === "running" || statusPayload.state === "queued" ? "subagent.nested.updated" : "subagent.nested.completed");
 	};
 	const statusWriteCoalescer = createFileCoalescer(writeStatusPayloadNow, 100);
@@ -4036,6 +4063,7 @@ async function runSubagent(
 						asyncDir,
 						runId: id,
 						stepIndex,
+						writeStatus: () => writeStatusPayload(),
 					});
 					flatIndex += group.parallel.length;
 					break;
@@ -4063,6 +4091,7 @@ async function runSubagent(
 						asyncDir,
 						runId: id,
 						stepIndex,
+						writeStatus: () => writeStatusPayload(),
 					});
 					flatIndex += group.parallel.length;
 					break;
@@ -4094,6 +4123,7 @@ async function runSubagent(
 					asyncDir,
 					runId: id,
 					stepIndex,
+					writeStatus: () => writeStatusPayload(),
 				});
 				const parallelResults = await mapConcurrent(
 					group.parallel,
@@ -4806,7 +4836,7 @@ async function runSubagent(
 		turnBudgetExceeded: result.turnBudgetExceeded,
 	})));
 	statusPayload.state = stopped || signalTerminated ? "stopped" : timedOut || turnBudgetExceeded || usageBudgetExceeded || statusPayload.error ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : "failed";
-	closeSteerInbox(asyncDir, statusPayload.state);
+	closeSteerInbox(asyncDir, statusPayload.state, (filePath, payload) => runPersistence.write(filePath, payload));
 	disposeControlInbox();
 	for (const request of consumeSteerRequests(asyncDir)) deliverSteerRequest(request);
 	const effectiveSessionFile = sessionFile ?? latestSessionFile;
@@ -4858,7 +4888,7 @@ async function runSubagent(
 		}
 	}
 	try {
-		writeAsyncResultFile(resultPath, {
+		runPersistence.write(resultPath, {
 			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
 			id,
 			agent: agentName,
@@ -4951,7 +4981,7 @@ async function runSubagent(
 			shareError,
 			...(taskIndex !== undefined && { taskIndex }),
 			...(totalTasks !== undefined && { totalTasks }),
-		});
+		}, (filePath, payload) => { writeAsyncResultFile(filePath, payload as Record<string, unknown>); });
 		finalResultCommitted = true;
 	} catch (err) {
 		const message = `Failed to write result file ${resultPath}: ${err instanceof Error ? err.message : String(err)}`;
@@ -4992,7 +5022,11 @@ async function runSubagent(
 		sessionFile: effectiveSessionFile,
 		shareUrl,
 		shareError,
+	}), (filePath, content) => runPersistence.write(filePath, { content }, (_path, payload) => {
+		fs.writeFileSync(_path, (payload as { content: string }).content, "utf-8");
 	}));
+	if (runPersistence.pendingCount() === 0) runPersistence.dispose();
+	if (indexPersistence.pendingCount() === 0) indexPersistence.dispose();
 	if (config.runnerProcessInstanceId) {
 		const writers: Record<string, PiWriterProcessInstanceExitV1[]> = {};
 		const expectedWriters: Record<string, number> = {};

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -6,6 +6,8 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { findBlockingAgentDiagnostic, resolveAgentName, type AgentConfig, type AgentDiscoveryDiagnostic, type AgentScope } from "../../agents/agents.ts";
 import { getArtifactsDir, getChainRunsDir, getProjectArtifactPackagingWarning, getProjectSubagentsDir } from "../../shared/artifacts.ts";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { createCapacityResilientJsonWriter } from "../../shared/capacity-resilient-json.ts";
+import { isStorageCapacityError } from "../../shared/file-system-retry.ts";
 import { resolveEffectiveThinking, toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import {
 	beginForegroundChild,
@@ -1773,7 +1775,7 @@ async function resumeAsyncRun(input: {
 		const sourceStatus = readStatus(sourceAsyncDir);
 		if (sourceStatus?.steering) {
 			for (const brief of queuedBriefs) updateSteeringTarget(sourceStatus.steering, brief.request.id, target.index, "delivered", Date.now());
-			writeAtomicJson(path.join(sourceAsyncDir, "status.json"), sourceStatus);
+			createCapacityResilientJsonWriter({ keepAlive: true }).write(path.join(sourceAsyncDir, "status.json"), sourceStatus);
 		}
 	}
 
@@ -3888,14 +3890,44 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					workflow: { trace: [], emits: [], console: [] },
 					runFanoutBudget: getRunFanoutBudgetSnapshot(workflowFanoutBudget),
 				};
-				const appendWorkflowEvent = (event: Record<string, unknown>) => fs.appendFileSync(eventsPath, `${JSON.stringify({ ts: Date.now(), runId: workflowRunId, ...event })}\n`, "utf-8");
+				const appendWorkflowEvent = (event: Record<string, unknown>) => {
+					try {
+						fs.appendFileSync(eventsPath, `${JSON.stringify({ ts: Date.now(), runId: workflowRunId, ...event })}\n`, "utf-8");
+					} catch (error) {
+						if (!isStorageCapacityError(error)) throw error;
+						console.error(`Failed to append async workflow event while storage is full:`, error);
+					}
+				};
 				let indexedState: AsyncStatus["state"] | undefined;
+				const indexPersistence = createCapacityResilientJsonWriter({
+					keepAlive: true,
+					onSuccess: (_filePath, payload) => { indexedState = (payload as { state: AsyncStatus["state"] }).state; },
+					onError: (error, filePath) => console.error(`Failed to update async workflow index '${filePath}':`, error),
+				});
+				const queueActiveRunIndex = (): void => {
+					const state = status.state;
+					if (indexedState === state && indexPersistence.pendingCount() === 0) return;
+					indexPersistence.write(asyncDir, { state, toolCallId: status.toolCallId }, (_filePath, payload) => {
+						const indexPayload = payload as { state: AsyncStatus["state"]; toolCallId?: string };
+						updateActiveRunIndex(asyncDir, indexPayload.state, indexPayload.toolCallId);
+					});
+				};
+				const runPersistence = createCapacityResilientJsonWriter({
+					keepAlive: true,
+					onSuccess: (filePath) => { if (filePath === statusPath) queueActiveRunIndex(); },
+					onError: (error, filePath) => console.error(`Failed to persist async workflow state '${filePath}':`, error),
+					write: (filePath, payload) => filePath === resultPath
+						? writeAsyncResultFile(filePath, payload as Record<string, unknown>)
+						: writeAtomicJson(filePath, payload),
+				});
+				let initialPersistenceComplete = false;
 				const persist = () => {
 					status.lastUpdate = Date.now();
-					writeAtomicJson(statusPath, status);
-					if (indexedState !== status.state) {
-						updateActiveRunIndex(asyncDir, status.state, status.toolCallId);
-						indexedState = status.state;
+					if (initialPersistenceComplete) runPersistence.write(statusPath, status);
+					else {
+						writeAtomicJson(statusPath, status);
+						initialPersistenceComplete = true;
+						queueActiveRunIndex();
 					}
 					const job = deps.state.asyncJobs.get(workflowRunId);
 					if (job) {
@@ -3921,7 +3953,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				};
 				const writeWorkflowResult = (payload: Record<string, unknown>): boolean => {
 					try {
-						writeAsyncResultFile(resultPath, payload);
+						runPersistence.write(resultPath, payload);
 						return true;
 					} catch (error) {
 						const message = `Failed to write async workflow result ${resultPath}: ${error instanceof Error ? error.message : String(error)}`;
@@ -3955,7 +3987,16 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				deps.state.asyncJobs.set(workflowRunId, workflowJob);
 				deps.state.fleetJobs ??= new Map();
 				deps.state.fleetJobs.set(workflowRunId, workflowJob);
-				persist();
+				try {
+					persist();
+				} catch (error) {
+					deps.state.workflowControllers?.delete(workflowRunId);
+					deps.state.asyncJobs.delete(workflowRunId);
+					deps.state.fleetJobs?.delete(workflowRunId);
+					workflowCapacity?.rollback();
+					indexPersistence.dispose();
+					return { content: [{ type: "text", text: `Failed to create async workflow storage: ${error instanceof Error ? error.message : String(error)}` }], isError: true, details: { mode: "workflow", results: [] } };
+				}
 				appendWorkflowEvent({ type: "subagent.workflow.started" });
 				const { workflowScript, async: _workflowAsync, chatProgress: _chatProgress, ...workflowRequest } = requestParams;
 				void Promise.resolve().then(async () => {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3909,7 +3909,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					if (indexedState === state && indexPersistence.pendingCount() === 0) return;
 					indexPersistence.write(asyncDir, { state, toolCallId: status.toolCallId }, (_filePath, payload) => {
 						const indexPayload = payload as { state: AsyncStatus["state"]; toolCallId?: string };
-						updateActiveRunIndex(asyncDir, indexPayload.state, indexPayload.toolCallId);
+						updateActiveRunIndex(asyncDir, indexPayload.state, indexPayload.toolCallId, { retryCapacityErrors: true });
 					});
 				};
 				const runPersistence = createCapacityResilientJsonWriter({

--- a/src/shared/atomic-json.ts
+++ b/src/shared/atomic-json.ts
@@ -58,11 +58,21 @@ export function createAtomicJsonWriter(options: AtomicJsonWriterOptions = {}): (
 			path.dirname(filePath),
 			tempBaseName(filePath, pid, now(), random().toString(36).slice(2)),
 		);
+		let writeError: unknown;
 		try {
 			fsImpl.writeFileSync(tempPath, JSON.stringify(payload, null, 2), mode === undefined ? "utf-8" : { encoding: "utf-8", mode });
 			renameWithRetry(fsImpl, tempPath, filePath, renameRetryDelaysMs, wait);
+		} catch (error) {
+			writeError = error;
+			throw error;
 		} finally {
-			fsImpl.rmSync(tempPath, { force: true });
+			try {
+				fsImpl.rmSync(tempPath, { force: true });
+			} catch (cleanupError) {
+				// Preserve the write/rename failure: cleanup is best effort and must
+				// not hide the error callers need to classify or report.
+				if (writeError === undefined) throw cleanupError;
+			}
 		}
 	};
 }

--- a/src/shared/capacity-resilient-json.ts
+++ b/src/shared/capacity-resilient-json.ts
@@ -1,0 +1,102 @@
+import { isStorageCapacityError } from "./file-system-retry.ts";
+import { writeAtomicJson } from "./atomic-json.ts";
+
+type TimerApi = {
+	setTimeout(handler: () => void, delayMs: number): unknown;
+	clearTimeout(handle: unknown): void;
+};
+
+const defaultTimerApi: TimerApi = {
+	setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+	clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+export type CapacityResilientJsonWriterOptions = {
+	/** The underlying write operation. It must be atomic for each target path. */
+	write?: (filePath: string, payload: object) => void;
+	/** Keep retry timers referenced by the event loop (needed by child runners). */
+	keepAlive?: boolean;
+	retryDelayMs?: number;
+	timerApi?: TimerApi;
+	onError?: (error: unknown, filePath: string) => void;
+	onSuccess?: (filePath: string, payload: object) => void;
+};
+
+export type CapacityResilientJsonWriter = {
+	write(filePath: string, payload: object, writeOperation?: (filePath: string, payload: object) => void): void;
+	pendingCount(): number;
+	dispose(): void;
+};
+
+/**
+ * Defers only storage-capacity failures, retaining the newest payload per path.
+ * Initial/ordinary writes remain synchronous and preserve their throwing contract;
+ * only ENOSPC-like failures enter the guarded retry loop.
+ */
+export function createCapacityResilientJsonWriter(options: CapacityResilientJsonWriterOptions = {}): CapacityResilientJsonWriter {
+	const defaultWrite = options.write ?? writeAtomicJson;
+	const keepAlive = options.keepAlive ?? false;
+	const retryDelayMs = options.retryDelayMs ?? 1_000;
+	const timerApi = options.timerApi ?? defaultTimerApi;
+	const onError = options.onError ?? ((error, filePath) => console.error(`Failed to persist JSON '${filePath}':`, error));
+	const onSuccess = options.onSuccess;
+	const reportError = (error: unknown, filePath: string): void => {
+		try {
+			onError(error, filePath);
+		} catch (callbackError) {
+			console.error(`Failed to report JSON persistence error for '${filePath}':`, callbackError);
+		}
+	};
+	const notifySuccess = (filePath: string, payload: object): void => {
+		if (!onSuccess) return;
+		try {
+			onSuccess(filePath, payload);
+		} catch (error) {
+			reportError(error, filePath);
+		}
+	};
+	const pending = new Map<string, { payload: object; write: (filePath: string, payload: object) => void }>();
+	let retryTimer: unknown;
+
+	const scheduleRetry = (): void => {
+		if (retryTimer !== undefined) return;
+		retryTimer = timerApi.setTimeout(() => {
+			retryTimer = undefined;
+			for (const [filePath, entry] of pending) {
+				try {
+					entry.write(filePath, entry.payload);
+					pending.delete(filePath);
+					notifySuccess(filePath, entry.payload);
+				} catch (error) {
+					if (isStorageCapacityError(error)) continue;
+					pending.delete(filePath);
+					reportError(error, filePath);
+				}
+			}
+			if (pending.size > 0) scheduleRetry();
+		}, retryDelayMs);
+		if (!keepAlive && typeof retryTimer === "object" && retryTimer !== null && "unref" in retryTimer && typeof retryTimer.unref === "function") {
+			retryTimer.unref();
+		}
+	};
+
+	return {
+		write(filePath, payload, writeOperation = defaultWrite): void {
+			try {
+				writeOperation(filePath, payload);
+				pending.delete(filePath);
+				notifySuccess(filePath, payload);
+			} catch (error) {
+				if (!isStorageCapacityError(error)) throw error;
+				pending.set(filePath, { payload, write: writeOperation });
+				scheduleRetry();
+			}
+		},
+		pendingCount: () => pending.size,
+		dispose: (): void => {
+			if (retryTimer !== undefined) timerApi.clearTimeout(retryTimer);
+			retryTimer = undefined;
+			pending.clear();
+		},
+	};
+}

--- a/src/shared/file-system-retry.ts
+++ b/src/shared/file-system-retry.ts
@@ -1,6 +1,7 @@
 const WAIT_BUFFER = typeof SharedArrayBuffer !== "undefined" ? new SharedArrayBuffer(4) : undefined;
 const WAIT_VIEW = WAIT_BUFFER ? new Int32Array(WAIT_BUFFER) : undefined;
 const RETRYABLE_FILE_SYSTEM_ERROR_CODES = new Set(["EACCES", "EBUSY", "EPERM"]);
+const STORAGE_CAPACITY_ERROR_CODES = new Set(["EDQUOT", "EMFILE", "ENFILE", "ENOSPC"]);
 
 export const FS_RETRY_MAX_TOTAL_MS_ENV = "PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS";
 
@@ -72,6 +73,11 @@ export function waitForFileSystemRetry(delayMs: number): void {
 export function isRetryableFileSystemError(error: unknown): boolean {
 	const code = (error as NodeJS.ErrnoException | undefined)?.code;
 	return typeof code === "string" && RETRYABLE_FILE_SYSTEM_ERROR_CODES.has(code);
+}
+
+export function isStorageCapacityError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && STORAGE_CAPACITY_ERROR_CODES.has(code);
 }
 
 export function runFileSystemOperationWithRetry<T>(operation: () => T, options: FileSystemRetryOptions = {}): T {

--- a/test/unit/atomic-json.test.ts
+++ b/test/unit/atomic-json.test.ts
@@ -10,6 +10,7 @@ class FakeFs {
 	failMkdirCodes: string[] = [];
 	failRenameCodes: string[] = [];
 	writeOptions = new Map<string, unknown>();
+	failCleanup = false;
 
 	mkdirSync(dirPath: string): void {
 		this.madeDirs.push(dirPath);
@@ -41,6 +42,7 @@ class FakeFs {
 	}
 
 	rmSync(filePath: string): void {
+		if (this.failCleanup) throw new Error("cleanup failed");
 		this.files.delete(filePath);
 	}
 }
@@ -148,6 +150,14 @@ describe("writeAtomicJson", () => {
 		assert.equal(fakeFs.renameCalls, 1);
 		assert.deepEqual(waits, []);
 		assert.equal(fakeFs.files.size, 0);
+	});
+
+	it("does not let cleanup failures mask a write failure", () => {
+		const fakeFs = new FakeFs();
+		fakeFs.failRenameCodes = ["ENOSPC"];
+		fakeFs.failCleanup = true;
+		const writeAtomicJson = createWriter(fakeFs, []);
+		assert.throws(() => writeAtomicJson(path.join("/tmp", "status.json"), { state: "running" }), /ENOSPC/);
 	});
 
 	it("cleans up the temp file after retryable failures are exhausted", () => {

--- a/test/unit/capacity-resilient-json.test.ts
+++ b/test/unit/capacity-resilient-json.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createCapacityResilientJsonWriter } from "../../src/shared/capacity-resilient-json.ts";
+
+type TimerTask = { callback: () => void; delayMs: number };
+
+function createTimers() {
+	const tasks: TimerTask[] = [];
+	return {
+		timerApi: {
+			setTimeout(callback: () => void, delayMs: number): object {
+				const timer = { callback, delayMs };
+				tasks.push(timer);
+				return timer;
+			},
+			clearTimeout(timer: unknown): void {
+				const index = tasks.indexOf(timer as TimerTask);
+				if (index >= 0) tasks.splice(index, 1);
+			},
+		},
+		runNext(): void {
+			const timer = tasks.shift();
+			if (timer) timer.callback();
+		},
+		pendingCount: () => tasks.length,
+	};
+}
+
+function capacityError(code: string): NodeJS.ErrnoException {
+	return Object.assign(new Error(code), { code });
+}
+
+describe("createCapacityResilientJsonWriter", () => {
+	it("retains only the latest payload and retries after capacity recovers", () => {
+		const timers = createTimers();
+		const writes: object[] = [];
+		let available = false;
+		const writer = createCapacityResilientJsonWriter({
+			timerApi: timers.timerApi,
+			retryDelayMs: 25,
+			write: (_filePath, payload) => {
+				if (!available) throw capacityError("ENOSPC");
+				writes.push(payload);
+			},
+		});
+
+		writer.write("status.json", { state: "running" });
+		writer.write("status.json", { state: "complete" });
+		assert.equal(writer.pendingCount(), 1);
+		assert.equal(timers.pendingCount(), 1);
+		available = true;
+		timers.runNext();
+
+		assert.deepEqual(writes, [{ state: "complete" }]);
+		assert.equal(writer.pendingCount(), 0);
+		assert.equal(timers.pendingCount(), 0);
+	});
+
+	it("handles every storage-capacity code without escaping the retry timer", () => {
+		for (const code of ["ENOSPC", "EDQUOT", "EMFILE", "ENFILE"]) {
+			const timers = createTimers();
+			let attempts = 0;
+			let available = false;
+			const writer = createCapacityResilientJsonWriter({
+				timerApi: timers.timerApi,
+				write: () => {
+					attempts += 1;
+					if (!available) throw capacityError(code);
+				},
+			});
+			writer.write("status.json", { state: "running" });
+			assert.doesNotThrow(() => timers.runNext());
+			assert.equal(attempts, 2);
+			available = true;
+			timers.runNext();
+			assert.equal(writer.pendingCount(), 0);
+		}
+	});
+
+	it("preserves synchronous throwing for non-capacity failures", () => {
+		const writer = createCapacityResilientJsonWriter({ write: () => { throw new Error("invalid path"); } });
+		assert.throws(() => writer.write("status.json", {}), /invalid path/);
+	});
+
+	it("does not let error callbacks escape a retry timer", () => {
+		const timers = createTimers();
+		const writer = createCapacityResilientJsonWriter({
+			timerApi: timers.timerApi,
+			onError: () => { throw new Error("reporting failed"); },
+			write: (filePath) => {
+				if (filePath === "status.json") throw capacityError("ENOSPC");
+			},
+		});
+		writer.write("status.json", { state: "running" });
+		assert.doesNotThrow(() => timers.runNext());
+		assert.equal(writer.pendingCount(), 1);
+		writer.dispose();
+	});
+
+	it("notifies only after a write succeeds, including a deferred retry", () => {
+		const timers = createTimers();
+		const successfulPayloads: object[] = [];
+		let available = false;
+		const writer = createCapacityResilientJsonWriter({
+			timerApi: timers.timerApi,
+			onSuccess: (_filePath, payload) => successfulPayloads.push(payload),
+			write: () => { if (!available) throw capacityError("ENOSPC"); },
+		});
+		writer.write("status.json", { state: "running" });
+		assert.deepEqual(successfulPayloads, []);
+		available = true;
+		timers.runNext();
+		assert.deepEqual(successfulPayloads, [{ state: "running" }]);
+	});
+
+	it("orders deferred index work after authoritative status recovery", () => {
+		const timers = createTimers();
+		let statusAvailable = false;
+		let indexUpdates = 0;
+		const indexWriter = createCapacityResilientJsonWriter({
+			timerApi: timers.timerApi,
+			write: () => { indexUpdates += 1; },
+		});
+		const statusWriter = createCapacityResilientJsonWriter({
+			timerApi: timers.timerApi,
+			onSuccess: () => indexWriter.write("run", { state: "complete" }),
+			write: () => { if (!statusAvailable) throw capacityError("ENOSPC"); },
+		});
+		statusWriter.write("status", { state: "complete" });
+		assert.equal(indexUpdates, 0);
+		statusAvailable = true;
+		timers.runNext();
+		assert.equal(indexUpdates, 1);
+		statusWriter.dispose();
+		indexWriter.dispose();
+	});
+
+	it("reports non-capacity failures from a retry without throwing from the timer", () => {
+		const timers = createTimers();
+		const errors: unknown[] = [];
+		let attempts = 0;
+		const writer = createCapacityResilientJsonWriter({
+			timerApi: timers.timerApi,
+			onError: (error) => errors.push(error),
+			write: () => {
+				if (attempts++ === 0) throw capacityError("ENOSPC");
+				throw new Error("permission denied");
+			},
+		});
+		assert.doesNotThrow(() => writer.write("status.json", { state: "running" }));
+		assert.doesNotThrow(() => timers.runNext());
+		assert.equal(errors.length, 1);
+		assert.match(String(errors[0]), /permission denied/);
+	});
+});


### PR DESCRIPTION
## Summary

This is the maintainer replacement for #1227, rebased onto current `main` after the original branch conflicted in `CHANGELOG.md`.

It preserves the submitted behavior: capacity errors keep the newest unsaved run status, result, log, and steering-close payload in memory and retry after storage recovers. Non-capacity filesystem errors still surface. Initial workflow status creation still fails closed.

Thanks to [@ahmadaccino](https://github.com/ahmadaccino) for #1227.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/atomic-json.test.ts test/unit/capacity-resilient-json.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh exact-head review: no issues found
