### PR TITLE
fix: sanitize runId in foreground subagent executor output paths

### DIFF
--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2861,8 +2861,11 @@ function resolveConfiguredSingleRunOutputBaseDir(deps: ExecutorDeps): string | u
 		: undefined;
 }
 
-function sanitizeRunPathSegment(value: string): string {
-	return value.trim().replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "") || "unknown";
+export function sanitizeRunPathSegment(value: string, maxBytes = 120): string {
+	const sanitized = value.trim().replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
+	if (!sanitized) return "unknown";
+	if (Buffer.byteLength(sanitized, "utf-8") <= maxBytes) return sanitized;
+	return sanitized.slice(0, maxBytes).replace(/_+$/, "") || "unknown";
 }
 
 function resolveSingleRunOutputBaseDir(deps: ExecutorDeps, artifactsDir: string, runId: string): string {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2861,8 +2861,12 @@ function resolveConfiguredSingleRunOutputBaseDir(deps: ExecutorDeps): string | u
 		: undefined;
 }
 
+function sanitizeRunPathSegment(value: string): string {
+	return value.trim().replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "") || "unknown";
+}
+
 function resolveSingleRunOutputBaseDir(deps: ExecutorDeps, artifactsDir: string, runId: string): string {
-	return resolveConfiguredSingleRunOutputBaseDir(deps) ?? path.join(artifactsDir, "outputs", runId);
+	return resolveConfiguredSingleRunOutputBaseDir(deps) ?? path.join(artifactsDir, "outputs", sanitizeRunPathSegment(runId));
 }
 
 function resolveWorkflowAggregateOutputPath(
@@ -2881,7 +2885,7 @@ function workflowChildDefaultOutput(aggregateOutputPath: string | undefined, art
 		const parsed = path.parse(aggregateOutputPath);
 		return path.join(parsed.dir, `${parsed.name}.${workflowKey}${parsed.ext || ".md"}`);
 	}
-	return path.join(artifactsDir, "outputs", workflowRunId, `${workflowKey}.md`);
+	return path.join(artifactsDir, "outputs", sanitizeRunPathSegment(workflowRunId), `${workflowKey}.md`);
 }
 
 function writeWorkflowAggregateOutput(outputPath: string | undefined, text: string, producedChildOutputPaths: ReadonlySet<string>): string | undefined {

--- a/test/unit/workflow-launch-params.test.ts
+++ b/test/unit/workflow-launch-params.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { prepareWorkflowLaunchParams } from "../../src/runs/foreground/subagent-executor.ts";
+import { prepareWorkflowLaunchParams, sanitizeRunPathSegment } from "../../src/runs/foreground/subagent-executor.ts";
 
 describe("workflow launch params", () => {
 	it("keeps omitted workflow child async foreground", () => {
@@ -219,5 +219,27 @@ describe("workflow launch params", () => {
 				toolBudget: { soft: 2, hard: 4, block: "*" },
 			},
 		);
+	});
+
+	describe("sanitizeRunPathSegment", () => {
+		it("replaces Windows-invalid characters and trims separators", () => {
+			assert.equal(sanitizeRunPathSegment("call_VfdHQygxGeL1L49ez04A4tf7|WtnJ9gVpB/jdQGWbnKhfMgDqPGUGmNw"), "call_VfdHQygxGeL1L49ez04A4tf7_WtnJ9gVpB_jdQGWbnKhfMgDqPGUGmNw");
+			assert.equal(sanitizeRunPathSegment(":::path//sub?*<file>|name:::"), "path_sub_file_name");
+			assert.equal(sanitizeRunPathSegment("   ___invalid___   "), "invalid");
+		});
+
+		it("falls back to unknown for empty or all-invalid strings", () => {
+			assert.equal(sanitizeRunPathSegment(""), "unknown");
+			assert.equal(sanitizeRunPathSegment("   "), "unknown");
+			assert.equal(sanitizeRunPathSegment("???///|||"), "unknown");
+		});
+
+		it("bounds oversized segments to the maximum byte length", () => {
+			const longId = "a".repeat(200);
+			const sanitized = sanitizeRunPathSegment(longId, 120);
+			assert.equal(sanitized.length, 120);
+			assert.equal(Buffer.byteLength(sanitized, "utf-8"), 120);
+			assert.equal(sanitized, "a".repeat(120));
+		});
 	});
 });


### PR DESCRIPTION
## Description

When subagents are dispatched (such as via foreground workflows or MCP tool calls), the `runId` passed to `resolveSingleRunOutputBaseDir` and `workflowChildDefaultOutput` in `subagent-executor.ts` can be the caller tool-call ID (e.g. `call_VfdHQygxGeL1L49ez04A4tf7|WtnJ9gVpB...`).

On Windows, these IDs often contain characters that are illegal in file/directory paths (such as `|`, `+`, `/`, `\`), or base64 segments that cause deep directory nesting or exceed path lengths, resulting in `ENOENT: no such file or directory, mkdir` errors when a subagent attempts to write its output to `subagent-artifacts/outputs/...`.

This PR adds `sanitizeRunPathSegment()` in `subagent-executor.ts` to ensure `runId` and `workflowRunId` path components are cleaned before joining into artifact output directory paths.

## Note for Maintainer
Maintainers might also want to review whether other areas where raw `toolCallId` / external `runId` values are joined into filesystem paths on Windows (across other background or nested runner handlers) need similar sanitization or hashing.