### PR TITLE
fix: sanitize foreground output path segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS` so a host embedding the extension can bound how long a contended filesystem retry blocks its thread. Unset by default. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1143.
 
 ### Fixed
+- Sanitize foreground workflow output path segments derived from provider run IDs, so Windows launches do not fail when tool-call IDs contain path-invalid characters. Thanks to [@maxime-louward-shift](https://github.com/maxime-louward-shift) for #1235.
 - Route async completion notification and cleanup only to the parent Pi process that launched the run, so concurrent windows sharing one session file cannot consume each other's results. Thanks to [@wangjianming](https://github.com/wangjianming) for #1225.
 - Clarify `workflowScript` fanout guidance: use awaited `runs.all` for ordinary parallel work, while stored `runs.run` promises remain only for fully observed advanced rolling fanout. Explain that async workflows have no inline `live-card` projection (#1229, #1230).
 - Keep extension reload cleanup scoped to the replaced session runtime, so concurrent Pi sessions in one process do not remove each other's subscriptions or parent-session identity. Thanks to [@ryanbbrown](https://github.com/ryanbbrown) for #1222.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2862,8 +2862,11 @@ function resolveConfiguredSingleRunOutputBaseDir(deps: ExecutorDeps): string | u
 		: undefined;
 }
 
-function sanitizeRunPathSegment(value: string): string {
-	return value.trim().replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "") || "unknown";
+export function sanitizeRunPathSegment(value: string, maxBytes = 120): string {
+	const sanitized = value.trim().replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
+	if (!sanitized) return "unknown";
+	if (Buffer.byteLength(sanitized, "utf-8") <= maxBytes) return sanitized;
+	return sanitized.slice(0, maxBytes).replace(/_+$/, "") || "unknown";
 }
 
 function resolveSingleRunOutputBaseDir(deps: ExecutorDeps, artifactsDir: string, runId: string): string {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2862,8 +2862,12 @@ function resolveConfiguredSingleRunOutputBaseDir(deps: ExecutorDeps): string | u
 		: undefined;
 }
 
+function sanitizeRunPathSegment(value: string): string {
+	return value.trim().replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "") || "unknown";
+}
+
 function resolveSingleRunOutputBaseDir(deps: ExecutorDeps, artifactsDir: string, runId: string): string {
-	return resolveConfiguredSingleRunOutputBaseDir(deps) ?? path.join(artifactsDir, "outputs", runId);
+	return resolveConfiguredSingleRunOutputBaseDir(deps) ?? path.join(artifactsDir, "outputs", sanitizeRunPathSegment(runId));
 }
 
 function resolveWorkflowAggregateOutputPath(
@@ -2882,7 +2886,7 @@ function workflowChildDefaultOutput(aggregateOutputPath: string | undefined, art
 		const parsed = path.parse(aggregateOutputPath);
 		return path.join(parsed.dir, `${parsed.name}.${workflowKey}${parsed.ext || ".md"}`);
 	}
-	return path.join(artifactsDir, "outputs", workflowRunId, `${workflowKey}.md`);
+	return path.join(artifactsDir, "outputs", sanitizeRunPathSegment(workflowRunId), `${workflowKey}.md`);
 }
 
 function writeWorkflowAggregateOutput(outputPath: string | undefined, text: string, producedChildOutputPaths: ReadonlySet<string>): string | undefined {

--- a/test/unit/workflow-launch-params.test.ts
+++ b/test/unit/workflow-launch-params.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { prepareWorkflowLaunchParams } from "../../src/runs/foreground/subagent-executor.ts";
+import { prepareWorkflowLaunchParams, sanitizeRunPathSegment } from "../../src/runs/foreground/subagent-executor.ts";
 
 describe("workflow launch params", () => {
 	it("keeps omitted workflow child async foreground", () => {
@@ -219,5 +219,27 @@ describe("workflow launch params", () => {
 				toolBudget: { soft: 2, hard: 4, block: "*" },
 			},
 		);
+	});
+
+	describe("sanitizeRunPathSegment", () => {
+		it("replaces Windows-invalid characters and trims separators", () => {
+			assert.equal(sanitizeRunPathSegment("call_VfdHQygxGeL1L49ez04A4tf7|WtnJ9gVpB/jdQGWbnKhfMgDqPGUGmNw"), "call_VfdHQygxGeL1L49ez04A4tf7_WtnJ9gVpB_jdQGWbnKhfMgDqPGUGmNw");
+			assert.equal(sanitizeRunPathSegment(":::path//sub?*<file>|name:::"), "path_sub_file_name");
+			assert.equal(sanitizeRunPathSegment("   ___invalid___   "), "invalid");
+		});
+
+		it("falls back to unknown for empty or all-invalid strings", () => {
+			assert.equal(sanitizeRunPathSegment(""), "unknown");
+			assert.equal(sanitizeRunPathSegment("   "), "unknown");
+			assert.equal(sanitizeRunPathSegment("???///|||"), "unknown");
+		});
+
+		it("bounds oversized segments to the maximum byte length", () => {
+			const longId = "a".repeat(200);
+			const sanitized = sanitizeRunPathSegment(longId, 120);
+			assert.equal(sanitized.length, 120);
+			assert.equal(Buffer.byteLength(sanitized, "utf-8"), 120);
+			assert.equal(sanitized, "a".repeat(120));
+		});
 	});
 });


### PR DESCRIPTION
This is a maintainer-owned replacement for #1235. It cherry-picks @maxime-louward-shift's foreground output-path sanitization commits onto current `main` and adds the required changelog credit.

The fix sanitizes only filesystem path segments derived from provider/tool-call IDs. It does not change the canonical run ID used for status, logs, maps, or user-facing IDs.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-launch-params.test.ts`
- `npm run typecheck`
- `git diff --check`

Thanks to @maxime-louward-shift for #1235. The changelog credit is included here.

Supersedes #1235.
