### PR TITLE
fix: require recovery descriptor for revive guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Show resume-first guidance for failed async runs only when a matching recovery descriptor exists, so missing recovery data no longer points users to a resume command that cannot work. Thanks to [@graadient](https://github.com/graadient) for #1241.
+
 ## [0.51.0] - 2026-08-18
 
 ### Highlights

--- a/src/runs/background/resume-guidance.ts
+++ b/src/runs/background/resume-guidance.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import type { AsyncRunSummary } from "./async-status.ts";
+import { readAsyncRecoveryDescriptor } from "./async-resume.ts";
 
 const INTERCOM_DETACH_ERROR = "detached for intercom coordination";
 
@@ -15,11 +16,13 @@ function formatIntercomDetachGuidance(run: AsyncRunSummary): string | undefined 
 }
 
 export function formatAsyncReviveCommand(run: AsyncRunSummary): string | undefined {
-	const step = run.steps.find((candidate) => candidate.status === "failed" && candidate.sessionFile && fs.existsSync(candidate.sessionFile));
-	if (!step) {
-		if (run.steps.length === 1 && run.sessionFile && fs.existsSync(run.sessionFile)) {
-			return `subagent({ action: "resume", id: "${run.id}", message: "Continue from the persisted child session and report the result." })`;
-		}
+	const step = run.steps.find((candidate) => candidate.status === "failed");
+	const sessionFile = step?.sessionFile ?? (run.steps.length === 1 ? run.sessionFile : undefined);
+	if (!step || !sessionFile || !fs.existsSync(sessionFile)) return undefined;
+	try {
+		const descriptor = readAsyncRecoveryDescriptor(run.asyncDir);
+		if (!descriptor || descriptor.sourceRunId !== run.id || descriptor.agent !== step.agent) return undefined;
+	} catch {
 		return undefined;
 	}
 	const index = run.steps.length === 1 ? "" : `, index: ${step.index}`;

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { describe, it } from "node:test";
 import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { writeAsyncResultFile } from "../../src/runs/background/result-files.ts";
+import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
 import { WAIT_TOOL_ENABLED_ENV, resolveWaitToolConfig, waitForSubagents, type SubagentWaitDeps } from "../../src/runs/background/subagent-wait.ts";
 import { recordWaitCompletion } from "../../src/runs/background/wait-completions.ts";
 import type { AsyncStatus, SubagentState } from "../../src/shared/types.ts";
@@ -29,6 +30,23 @@ function writeStatus(asyncRoot: string, runId: string, state: AsyncStatus["state
 		"utf-8",
 	);
 	updateActiveRunIndex(dir, state);
+}
+
+function writeRecoveryDescriptor(asyncRoot: string, runId: string, agent: string, sessionFile: string, cwd: string): void {
+	fs.writeFileSync(path.join(asyncRoot, runId, "recovery-descriptor.json"), JSON.stringify({
+		version: 1,
+		sourceRunId: runId,
+		agent,
+		sessionFile,
+		cwd,
+		systemPromptMode: "append",
+		outputMode: "inline",
+		inheritProjectContext: false,
+		inheritSkills: false,
+		maxSubagentDepth: 0,
+		share: false,
+		runFanoutBudget: createRunFanoutBudget(runId, 64),
+	}), "utf-8");
 }
 
 function makeState(sessionId: string | null): SubagentState {
@@ -200,6 +218,7 @@ describe("subagent_wait tool", () => {
 			fs.writeFileSync(sessionFile, "{}\n", "utf-8");
 			const state = makeState("sess-1");
 			writeStatus(asyncRoot, "run-revive", "running", { sessionId: "sess-1", pid: 999999 });
+			writeRecoveryDescriptor(asyncRoot, "run-revive", "worker", sessionFile, root);
 			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
 				sleep: async () => writeStatus(asyncRoot, "run-revive", "failed", {
 					sessionId: "sess-1",
@@ -214,6 +233,52 @@ describe("subagent_wait tool", () => {
 			assert.match(text, /subagent\(\{ action: "resume", id: "run-revive", message:/);
 			assert.match(text, /before reporting failure or launching a replacement/);
 			assert.match(text, /only if revive fails or the user explicitly asks/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not advertise resume-first when the recovery descriptor is missing", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-no-recovery-descriptor-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const sessionFile = path.join(root, "worker-session.jsonl");
+			fs.writeFileSync(sessionFile, "{}\n", "utf-8");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-no-descriptor", "running", { sessionId: "sess-1", pid: 999999 });
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
+				sleep: async () => writeStatus(asyncRoot, "run-no-descriptor", "failed", {
+					sessionId: "sess-1",
+					steps: [{ agent: "worker", status: "failed", sessionFile }],
+				}),
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.doesNotMatch(textOf(result), /Resume-first/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("uses the single-child run session fallback with a matching recovery descriptor", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-run-session-fallback-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const sessionFile = path.join(root, "worker-session.jsonl");
+			fs.writeFileSync(sessionFile, "{}\n", "utf-8");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-session-fallback", "running", { sessionId: "sess-1", pid: 999999 });
+			writeRecoveryDescriptor(asyncRoot, "run-session-fallback", "worker", sessionFile, root);
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
+				sleep: async () => writeStatus(asyncRoot, "run-session-fallback", "failed", {
+					sessionId: "sess-1",
+					sessionFile,
+					steps: [{ agent: "worker", status: "failed" }],
+				}),
+			}));
+
+			assert.equal(result.isError, undefined);
+			assert.match(textOf(result), /Resume-first/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/wait-subscriptions.test.ts
+++ b/test/unit/wait-subscriptions.test.ts
@@ -8,6 +8,7 @@ import { registerWaitTool } from "../../src/runs/background/wait-tool.ts";
 import { createWaitSubscriptionManager } from "../../src/runs/background/wait-subscriptions.ts";
 import { recordWaitCompletion } from "../../src/runs/background/wait-completions.ts";
 import { inspectSubagentStatus } from "../../src/runs/background/run-status.ts";
+import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
 import { SUBAGENT_ASYNC_COMPLETE_EVENT, type IntercomEventBus, type SubagentState } from "../../src/shared/types.ts";
 
 function writeStatus(asyncRoot: string, runId: string, state: string, extra: object = {}): void {
@@ -22,6 +23,23 @@ function writeStatus(asyncRoot: string, runId: string, state: string, extra: obj
 		lastUpdate: now,
 		steps: [{ agent: "worker", status: state }],
 		...extra,
+	}), "utf-8");
+}
+
+function writeRecoveryDescriptor(asyncRoot: string, runId: string, agent: string, sessionFile: string, cwd: string): void {
+	fs.writeFileSync(path.join(asyncRoot, runId, "recovery-descriptor.json"), JSON.stringify({
+		version: 1,
+		sourceRunId: runId,
+		agent,
+		sessionFile,
+		cwd,
+		systemPromptMode: "append",
+		outputMode: "inline",
+		inheritProjectContext: false,
+		inheritSkills: false,
+		maxSubagentDepth: 0,
+		share: false,
+		runFanoutBudget: createRunFanoutBudget(runId, 64),
 	}), "utf-8");
 }
 
@@ -213,6 +231,7 @@ describe("non-blocking wait subscriptions", () => {
 			fs.writeFileSync(completedSessionFile, "{}\n", "utf-8");
 			fs.writeFileSync(failedSessionFile, "{}\n", "utf-8");
 			writeStatus(asyncRoot, "run-revive", "running", { sessionId: "session-a", pid: 999_999 });
+			writeRecoveryDescriptor(asyncRoot, "run-revive", "second", failedSessionFile, root);
 			manager.arm({ targetKind: "async", runId: "run-revive", requestedId: "run-revive", timeoutMs: 30_000 });
 
 			writeStatus(asyncRoot, "run-revive", "failed", {


### PR DESCRIPTION
## Summary

Fix failed async run guidance so `Resume-first` is shown only when the original child has the recovery descriptor needed for a successful resume.

The change also keeps the valid one-child `run.sessionFile` fallback, but guards it with the same descriptor check.

Fixes #1241.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/subagent-wait.test.ts test/unit/wait-subscriptions.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh read-only review: no issues found
