### PR TITLE
fix: snapshot bundled agent definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Show resume-first guidance for failed async runs only when a matching recovery descriptor exists, so missing recovery data no longer points users to a resume command that cannot work. Thanks to [@graadient](https://github.com/graadient) for #1241.
+- Keep bundled agent discovery stable across hot package updates, so long-running sessions do not parse newer bundled agent files with older loaded code. Thanks to [@graadient](https://github.com/graadient) for #1242.
 
 ## [0.51.0] - 2026-08-18
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1573,22 +1573,32 @@ function parseAgentAcceptanceFrontmatter(raw: string | undefined, agentName: str
 	return parsed as AcceptanceInput;
 }
 
-function loadAgentsFromDir(dir: string, source: AgentSource, discoveryPriority?: number): { agents: AgentConfig[]; diagnostics: AgentDiscoveryDiagnostic[] } {
-	const agents: AgentConfig[] = [];
-	const diagnostics: AgentDiscoveryDiagnostic[] = [];
+interface AgentDefinitionFile {
+	filePath: string;
+	content: string;
+}
 
+function readAgentDefinitionFiles(dir: string): AgentDefinitionFile[] {
+	const files: AgentDefinitionFile[] = [];
 	for (const filePath of listFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"))) {
 		if (isLegacyAgentSkillPath(dir, filePath)) {
 			continue;
 		}
 
-		let content: string;
 		try {
-			content = fs.readFileSync(filePath, "utf-8");
+			files.push({ filePath, content: fs.readFileSync(filePath, "utf-8") });
 		} catch {
 			continue;
 		}
+	}
+	return files;
+}
 
+function loadAgentsFromDefinitionFiles(files: AgentDefinitionFile[], source: AgentSource, discoveryPriority?: number): { agents: AgentConfig[]; diagnostics: AgentDiscoveryDiagnostic[] } {
+	const agents: AgentConfig[] = [];
+	const diagnostics: AgentDiscoveryDiagnostic[] = [];
+
+	for (const { filePath, content } of files) {
 		let name: string | undefined;
 		let runtimeName: string | undefined;
 		let packageSpecified = false;
@@ -1760,6 +1770,10 @@ function loadAgentsFromDir(dir: string, source: AgentSource, discoveryPriority?:
 	return { agents, diagnostics };
 }
 
+function loadAgentsFromDir(dir: string, source: AgentSource, discoveryPriority?: number): { agents: AgentConfig[]; diagnostics: AgentDiscoveryDiagnostic[] } {
+	return loadAgentsFromDefinitionFiles(readAgentDefinitionFiles(dir), source, discoveryPriority);
+}
+
 function loadChainsFromDir(dir: string, source: AgentSource): { chains: ChainConfig[]; diagnostics: ChainDiscoveryDiagnostic[] } {
 	const chains = new Map<string, ChainConfig>();
 	const diagnostics: ChainDiscoveryDiagnostic[] = [];
@@ -1821,6 +1835,7 @@ function resolveNearestProjectChainDirs(cwd: string): { readDirs: string[]; pref
 	};
 }
 const BUILTIN_AGENTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "agents");
+const BUILTIN_AGENT_DEFINITION_FILES = readAgentDefinitionFiles(BUILTIN_AGENTS_DIR);
 
 export const EXTRA_AGENT_DIRS_ENV = "PI_SUBAGENT_EXTRA_AGENT_DIRS";
 
@@ -1855,7 +1870,7 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 		includeProject: scope !== "user",
 	});
 
-	const builtinLoaded = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
+	const builtinLoaded = loadAgentsFromDefinitionFiles(BUILTIN_AGENT_DEFINITION_FILES, "builtin");
 	const builtinAgents = applyBuiltinOverrides(
 		applySubagentDefaults(builtinLoaded.agents, defaultModel, defaultThinking, defaultExtensions),
 		userSettings,
@@ -1937,7 +1952,7 @@ export function discoverAgentsAll(cwd: string): {
 	const defaultExtensions = resolveSubagentDefaultExtensions(userSettings, projectSettings, projectSettingsPath);
 	const packageSubagentPaths = collectPackageSubagentPaths(cwd);
 
-	const builtinLoaded = loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin");
+	const builtinLoaded = loadAgentsFromDefinitionFiles(BUILTIN_AGENT_DEFINITION_FILES, "builtin");
 	const builtin = applyBuiltinOverrides(
 		applySubagentDefaults(builtinLoaded.agents, defaultModel, defaultThinking, defaultExtensions),
 		userSettings,

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -540,6 +540,40 @@ Do work
 		assert.equal(agents.some((candidate) => candidate.name === "planner"), false);
 		assert.equal(agents.some((candidate) => candidate.name === "context-builder"), false);
 	});
+
+	it("keeps bundled agent definitions from module load during package file updates", () => {
+		const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-builtin-hot-update-"));
+		tempDirs.push(fixture);
+		fs.cpSync(path.join(process.cwd(), "src"), path.join(fixture, "src"), { recursive: true });
+		fs.cpSync(path.join(process.cwd(), "agents"), path.join(fixture, "agents"), { recursive: true });
+		fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(fixture, "node_modules"), process.platform === "win32" ? "junction" : "dir");
+		writeJson(path.join(fixture, "package.json"), { type: "module" });
+		writeAgent(path.join(fixture, "challenge.mjs"), `
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { discoverAgentsAll } from "./src/agents/agents.ts";
+
+const gptProPath = path.join(process.cwd(), "agents", "gpt-pro.md");
+fs.writeFileSync(gptProPath, \`---
+name: gpt-pro
+description: Future Surf GPT Pro advisor
+runner:
+  type: future-external-job
+---
+
+Review with the future runner.
+\`, "utf-8");
+
+const discovered = discoverAgentsAll(process.cwd());
+const gptPro = discovered.builtin.find((candidate) => candidate.name === "gpt-pro");
+
+		assert.equal(gptPro?.runner?.type, "external-job");
+		assert.equal(discovered.agentDiagnostics?.some((diagnostic) => diagnostic.filePath === gptProPath), false);
+`);
+
+		execFileSync(process.execPath, ["--experimental-strip-types", "challenge.mjs"], { cwd: fixture, stdio: "pipe" });
+	});
 });
 
 describe("agent frontmatter launch defaults", () => {


### PR DESCRIPTION
## Summary

Snapshot bundled built-in agent definitions at module load so long-running Pi sessions do not parse newer bundled agent files with older loaded parser code after a package update.

Package, user, and project agent directories remain mutable and are still read during discovery.

Fixes #1242.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-frontmatter.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh read-only review: no issues found
