### PR TITLE
fix: announce scheduled run completions and name their schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Fixed
+- Show a scheduled run's completion and name the schedule that produced it, so scheduled work no longer finishes silently in a session that cannot attribute it. Thanks to @albertgwo for #1245.
+
+### Fixed
 - Show resume-first guidance for failed async runs only when a matching recovery descriptor exists, so missing recovery data no longer points users to a resume command that cannot work. Thanks to [@graadient](https://github.com/graadient) for #1241.
 - Keep bundled agent discovery stable across hot package updates, so long-running sessions do not parse newer bundled agent files with older loaded code. Thanks to [@graadient](https://github.com/graadient) for #1242.
 

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -27,6 +27,8 @@ export interface SubagentNotifyDetails {
 	sessionLabel?: string;
 	sessionValue?: string;
 	handoffPath?: string;
+	/** Present when a durable schedule launched the run. */
+	scheduleOrigin?: { id: string; name?: string };
 }
 
 export interface CompletionNotification {
@@ -94,9 +96,14 @@ function formatSessionLine(details: SubagentNotifyDetails): string | undefined {
 export function formatSingleCompletion(details: SubagentNotifyDetails): string {
 	const sessionLine = formatSessionLine(details);
 	const taskKind = details.source === "foreground" ? "Detached foreground task" : "Background task";
+	const scheduleLine = details.scheduleOrigin
+		? `Scheduled run from **${details.scheduleOrigin.name ?? details.scheduleOrigin.id}** (schedule ${details.scheduleOrigin.id}).`
+		: undefined;
 	return [
 		`${taskKind} ${details.status}: **${details.agent}**${details.taskInfo ?? ""}`,
 		"",
+		scheduleLine,
+		scheduleLine ? "" : undefined,
 		details.resultPreview.trim() ? details.resultPreview : "(no output)",
 		details.handoffPath ? "" : undefined,
 		details.handoffPath ? `Parallel handoff: ${details.handoffPath}` : undefined,
@@ -111,7 +118,17 @@ export function parseSubagentNotifyContent(content: string): SubagentNotifyDetai
 	const lines = content.split("\n");
 	const match = (lines[0] ?? "").match(/^(Background task|Detached foreground task) (completed|failed|paused|stopped): \*\*(.+?)\*\*(?:\s+(\([^)]*\)))?$/);
 	if (!match) return undefined;
-	const body = lines.slice(2);
+	let body = lines.slice(2);
+	// Restore the schedule origin so a re-rendered notice keeps its attribution and
+	// does not fold the line into the result preview.
+	const scheduleMatch = (body[0] ?? "").match(/^Scheduled run from \*\*(.+?)\*\* \(schedule (.+?)\)\.$/);
+	let parsedScheduleOrigin: { id: string; name?: string } | undefined;
+	if (scheduleMatch) {
+		const label = scheduleMatch[1]!;
+		const id = scheduleMatch[2]!;
+		parsedScheduleOrigin = { id, ...(label === id ? {} : { name: label }) };
+		body = body.slice(body[1]?.trim() === "" ? 2 : 1);
+	}
 	let sessionIndex = -1;
 	for (let i = body.length - 1; i >= 1; i--) {
 		if (body[i - 1]?.trim() === "" && /^(Session|Session file|Session share error):\s+/.test(body[i]!)) {
@@ -138,6 +155,7 @@ export function parseSubagentNotifyContent(content: string): SubagentNotifyDetai
 		status: match[2] as SubagentNotifyDetails["status"],
 		...(match[1] === "Detached foreground task" ? { source: "foreground" as const } : {}),
 		...(match[4] ? { taskInfo: match[4] } : {}),
+		...(parsedScheduleOrigin ? { scheduleOrigin: parsedScheduleOrigin } : {}),
 		resultPreview,
 		...(handoffPath ? { handoffPath } : {}),
 		...(sessionLabel && sessionValue ? { sessionLabel, sessionValue } : {}),
@@ -151,7 +169,7 @@ export function formatGroupedCompletion(details: SubagentNotifyDetails[]): strin
 		const detail = details[index];
 		if (!detail) continue;
 		const sessionLine = formatSessionLine(detail);
-		blocks.push(`${index + 1}. ${detail.agent}${detail.taskInfo ?? ""}`);
+		blocks.push(`${index + 1}. ${detail.agent}${detail.taskInfo ?? ""}${detail.scheduleOrigin ? ` — scheduled run from ${detail.scheduleOrigin.name ?? detail.scheduleOrigin.id} (schedule ${detail.scheduleOrigin.id})` : ""}`);
 		blocks.push(detail.resultPreview.trim() ? detail.resultPreview : "(no output)");
 		if (detail.handoffPath) blocks.push(`Parallel handoff: ${detail.handoffPath}`);
 		if (sessionLine) blocks.push(sessionLine);
@@ -171,7 +189,7 @@ function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage">, items: PendingCom
 	if (items.length === 0) return true;
 	const details = items.map((item) => item.details);
 	const content = details.length === 1 ? formatSingleCompletion(details[0]!) : formatGroupedCompletion(details);
-	const display = details.some((detail) => detail.source === "foreground" || detail.status !== "completed");
+	const display = details.some((detail) => detail.source === "foreground" || detail.status !== "completed" || detail.scheduleOrigin !== undefined);
 	try {
 		pi.sendMessage(
 			{
@@ -226,9 +244,17 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 				: result.sessionFile
 					? { label: "Session file", value: result.sessionFile }
 					: undefined;
+	const scheduleOriginRaw = result.scheduleOrigin;
+	const scheduleOrigin = scheduleOriginRaw && typeof scheduleOriginRaw === "object" && typeof (scheduleOriginRaw as { id?: unknown }).id === "string"
+		? {
+			id: (scheduleOriginRaw as { id: string }).id,
+			...(typeof (scheduleOriginRaw as { name?: unknown }).name === "string" ? { name: (scheduleOriginRaw as { name: string }).name } : {}),
+		}
+		: undefined;
 	return {
 		agent,
 		status,
+		...(scheduleOrigin ? { scheduleOrigin } : {}),
 		...(result.source ? { source: result.source } : {}),
 		...(taskInfo ? { taskInfo } : {}),
 		resultPreview: summary,

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -346,6 +346,9 @@ function executionParams(schedule: ScheduleRecord): SubagentParamsLike {
 		context: "fresh",
 		cwd: schedule.cwd,
 		mission: false,
+		// Nobody is watching a schedule the way they watch a run they just launched,
+		// so the completion has to say which schedule produced it.
+		scheduleOrigin: { id: schedule.id, ...(schedule.name ? { name: schedule.name } : {}) },
 		...(schedule.timeoutMs === undefined ? {} : { timeoutMs: schedule.timeoutMs }),
 	};
 }

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -171,6 +171,7 @@ import {
 	resolveCurrentMaxSubagentDepth,
 	resolveMaxSubagentSpawnsPerRun,
 	wrapForkTask,
+	type ScheduleOrigin,
 } from "../../shared/types.ts";
 
 const MUTATING_MANAGEMENT_ACTIONS = new Set(["create", "update", "delete", "eject", "disable", "enable", "reset", "grant-spawn-budget", "watchdog.configure", "mission.create", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "inspector.open", "inspector.close", "project.open", "project.close", "worktree.discard", "refine", "refine.rollback", "dismiss", "schedule.create", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"]);
@@ -292,6 +293,8 @@ export interface SubagentParamsLike {
 	/** Internal workflow ownership metadata; not part of the public schema. */
 	workflowParentRunId?: string;
 	workflowKey?: string;
+	/** Set by the scheduler so this run's completion can name the schedule that produced it. */
+	scheduleOrigin?: ScheduleOrigin;
 	workflowChildAsyncId?: string;
 	workflowParentDeadlineAt?: number;
 	suppressRoutineResultIntercom?: boolean;
@@ -3994,7 +3997,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					status.toolCount = toolCounts.length > 0 ? toolCounts.reduce((total, count) => total + count, 0) : undefined;
 					status.currentStep = runningSteps.length === 1 ? steps.indexOf(runningSteps[0]!) : undefined;
 				};
-				const workflowJob: AsyncJobState = { asyncId: workflowRunId, asyncDir, toolCallId, cwd: workflowCwd, ...(workflowSessionRoot ? { sessionRoot: workflowSessionRoot } : {}), status: "running", sessionId: currentSessionId ?? undefined, mode: "workflow", agents: [], steps: [], startedAt, updatedAt: startedAt, ...(timeout !== undefined ? { timeoutMs: timeout, deadlineAt: startedAt + timeout } : {}), workflow: status.workflow };
+				const workflowJob: AsyncJobState = { asyncId: workflowRunId, asyncDir, toolCallId, cwd: workflowCwd, ...(workflowSessionRoot ? { sessionRoot: workflowSessionRoot } : {}), status: "running", sessionId: currentSessionId ?? undefined, mode: "workflow", agents: [], steps: [], startedAt, updatedAt: startedAt, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), ...(timeout !== undefined ? { timeoutMs: timeout, deadlineAt: startedAt + timeout } : {}), workflow: status.workflow };
 				deps.state.asyncJobs.set(workflowRunId, workflowJob);
 				deps.state.fleetJobs ??= new Map();
 				deps.state.fleetJobs.set(workflowRunId, workflowJob);
@@ -4198,7 +4201,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const resultSummary = appendWorkflowOutputWarning(summary, outputWarning);
 						const workflowUsage = sumResultsUsage(workflowResults);
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: workflow.trace, emits: workflow.emits, console: workflow.console }, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
-						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(status.error ? { error: status.error } : {}) });
 					} catch (error) {
@@ -4217,7 +4220,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						status = compactOptional<AsyncStatus>({ ...status, state, stopped: stopped || undefined, activityState: pauseForDetached ? "needs_attention" : undefined, error: error instanceof Error ? error.message : String(error), endedAt: Date.now(), workflow: { trace: partial.trace, emits: partial.emits, console: partial.console } });
 						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, status.error ?? (pauseForDetached ? "Workflow paused." : "Workflow failed."), producedChildOutputPaths);
 						const resultSummary = appendWorkflowOutputWarning(status.error ?? (pauseForDetached ? "Workflow paused." : "Workflow failed."), outputWarning);
-						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: resultSummary, error: status.error, stopped: status.stopped, activityState: status.activityState, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.detached ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: false, state: status.state, summary: resultSummary, error: status.error, stopped: status.stopped, activityState: status.activityState, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.detached ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, error: status.error, ...(status.activityState ? { activityState: status.activityState } : {}) });
 					} finally {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -409,6 +409,12 @@ export type ProcessTerminalV1 =
 		diagnostic?: string;
 	});
 
+/** Identifies the durable schedule that launched a run, so its completion is attributable. */
+export interface ScheduleOrigin {
+	id: string;
+	name?: string;
+}
+
 export type SteeringActionState = "delivered" | "scheduled" | "pending" | "partial" | "recovered" | "failed";
 export type SteeringTargetState = "scheduled" | "pending" | "routed" | "queued" | "delivered" | "late" | "failed" | "recovered";
 
@@ -1408,6 +1414,8 @@ export interface AsyncStatus {
 	workflow?: Details["workflow"];
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
+	/** Set when a durable schedule launched this run, so completions can name their origin. */
+	scheduleOrigin?: ScheduleOrigin;
 	steps?: Array<{
 		agent: string;
 		runner?: ExternalCliRunnerStatus | ExternalJobRunnerStatus;

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -531,3 +531,42 @@ describe("completion formatting helpers", () => {
 		assert.equal(details.status, "completed");
 	});
 });
+
+describe("scheduled completions", () => {
+	// A schedule fires with nobody watching, so its completion has to be visible to
+	// the operator and attributable by the agent that receives it.
+	const scheduledResult = {
+		id: "run-1",
+		source: "async" as const,
+		agent: "workflow",
+		success: true,
+		summary: "Workflow completed with 1 child run(s).",
+		scheduleOrigin: { id: "45daa203", name: "authz-facts-efficacy" },
+	};
+
+	it("carries the schedule origin from the result into the notice", () => {
+		const details = buildCompletionDetails(scheduledResult);
+		assert.deepEqual(details.scheduleOrigin, { id: "45daa203", name: "authz-facts-efficacy" });
+		assert.match(formatSingleCompletion(details), /Scheduled run from \*\*authz-facts-efficacy\*\* \(schedule 45daa203\)\./);
+	});
+
+	it("round-trips the origin without absorbing it into the result preview", () => {
+		const parsed = parseSubagentNotifyContent(formatSingleCompletion(buildCompletionDetails(scheduledResult)));
+		assert.deepEqual(parsed?.scheduleOrigin, { id: "45daa203", name: "authz-facts-efficacy" });
+		assert.equal(parsed?.resultPreview, "Workflow completed with 1 child run(s).");
+	});
+
+	it("keeps attribution when a scheduled run is batched with other completions", () => {
+		const { scheduleOrigin: _origin, ...plain } = scheduledResult;
+		const grouped = formatGroupedCompletion([buildCompletionDetails({ ...plain, agent: "worker" }), buildCompletionDetails(scheduledResult)]);
+		assert.match(grouped, /2\. workflow — scheduled run from authz-facts-efficacy \(schedule 45daa203\)/);
+		assert.doesNotMatch(grouped, /1\. worker —/);
+	});
+
+	it("leaves an ordinary successful completion without an origin", () => {
+		const { scheduleOrigin: _origin, ...withoutSchedule } = scheduledResult;
+		const parsed = parseSubagentNotifyContent(formatSingleCompletion(buildCompletionDetails(withoutSchedule)));
+		assert.equal(parsed?.scheduleOrigin, undefined);
+		assert.equal(parsed?.resultPreview, "Workflow completed with 1 child run(s).");
+	});
+});

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -369,7 +369,7 @@ describe("recurring schedule execution", () => {
 		h.clock.now += 3_600_000;
 		h.timers.fireAll();
 		assert.equal(h.launches.length, 1);
-		assert.deepEqual(h.launches[0]?.params, { workflowScript: "return runs.run('main', { agent: 'worker', task: 'Maintain backlog' })", async: true, context: "fresh", cwd: h.ctx.cwd, mission: false });
+		assert.deepEqual(h.launches[0]?.params, { workflowScript: "return runs.run('main', { agent: 'worker', task: 'Maintain backlog' })", async: true, context: "fresh", cwd: h.ctx.cwd, mission: false, scheduleOrigin: { id: "hourly", name: "workflowScript -> agent worker" } });
 		h.launches[0]!.resolve({ content: [{ type: "text", text: "Async worker" }], details: { mode: "single", results: [], asyncId: "async-1", asyncDir: "/tmp/async-1" } });
 		await flush();
 		assert.deepEqual([...h.manager.observedCompletionRunIds()], ["async-1"]);


### PR DESCRIPTION
## Summary
- record the launching schedule on the run and carry it through async status and the result payload into the completion notice
- always display a completion that came from a schedule, and name that schedule in the notice so the receiving agent can attribute it
- keep ordinary successful completions quiet, and restore the origin when a notice is re-parsed

A durable schedule that fired an hour later finished completely silently. Successful background completions are intentionally quiet, per `observability.md`: "Successful background completions stay quiet so inactive Pi tabs are not marked unread." That is right for a sibling run the operator just launched and is watching in FleetView, but a schedule has no live surface left once it ends, so the operator saw nothing and found the result only by running `schedule.history` by hand.

The completion did reach the creating session, and the agent was woken. Nothing identified it as scheduled work, so in the observed case the agent read it and replied:

```
This result references PR #12214 and a run key (`efficacy`) I never dispatched
That result is not from this lane.
```

It then discarded the result. The outcome was invisible to the operator and unattributable to the agent at the same time; either alone is recoverable, but together the run vanishes.

With this change the notice is shown and leads with `Scheduled run from **<name>** (schedule <id>).`, so the operator sees the outcome and the agent can recognize the work as its own.

## Validation
- `npm run typecheck`
- `npm run test:unit` (2143 pass, 3 skip). The single failure, `watchdog-lsp-diagnostics` "returns a failed result for malformed language-server JSON", is a known pre-existing flake under full-suite load that passes in isolation and reproduces on clean `main`.
- notify and scheduled-run unit tests (56 pass), including three new cases covering origin propagation, notice round-tripping, and ordinary completions staying quiet
- the existing scheduled-launch assertion was updated for the extended launch contract
