### PR TITLE
fix(agents): resolve relative extension paths against the defining agent file

### DIFF
--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -27,7 +27,7 @@ import { discoverAvailableSkills, resolveSkills } from "./skills.ts";
 import {
 	buildProactiveSkillSubagentRecommendationLines,
 } from "./proactive-skills.ts";
-import { parseFrontmatter } from "./frontmatter.ts";
+import { parseFrontmatter, parseFrontmatterList } from "./frontmatter.ts";
 import { toModelInfo } from "../shared/model-info.ts";
 import { resolveSubagentModelOverride, type ParentModel } from "../runs/shared/model-fallback.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
@@ -196,6 +196,24 @@ function skillsWarning(cwd: string, agent: Pick<AgentConfig, "skills" | "skillPa
 	return missing.length ? `Warning: skills not found: ${missing.join(", ")}.` : undefined;
 }
 
+function withDeclaredExtensionPaths(config: AgentConfig, filePath: string): AgentConfig {
+	let frontmatter: Record<string, string>;
+	try {
+		({ frontmatter } = parseFrontmatter(fs.readFileSync(filePath, "utf-8")));
+	} catch {
+		return config;
+	}
+
+	const { extensions: _extensions, subagentOnlyExtensions: _subagentOnlyExtensions, ...withoutResolvedExtensions } = config;
+	return {
+		...withoutResolvedExtensions,
+		...(frontmatter.extensions !== undefined ? { extensions: parseFrontmatterList(frontmatter.extensions) ?? [] } : {}),
+		...(frontmatter.subagentOnlyExtensions !== undefined
+			? { subagentOnlyExtensions: parseFrontmatterList(frontmatter.subagentOnlyExtensions) ?? [] }
+			: {}),
+	};
+}
+
 export function editableAgentConfig(agent: AgentConfig): AgentConfig {
 	const { extensions: _extensions, ...withoutExtensions } = agent;
 	const base = agent.override?.base;
@@ -220,13 +238,13 @@ export function editableAgentConfig(agent: AgentConfig): AgentConfig {
 		...editable
 	} = withoutExtensions;
 	if (!base) {
-		return {
+		return withDeclaredExtensionPaths({
 			...withoutExtensions,
 			...(agent.extensionsFromDefault ? {} : agent.extensions !== undefined ? { extensions: [...agent.extensions] } : {}),
-		};
+		}, agent.filePath);
 	}
 
-	return {
+	return withDeclaredExtensionPaths({
 		...editable,
 		...(base.model !== undefined ? { model: base.model } : {}),
 		...(base.fallbackModels !== undefined ? { fallbackModels: [...base.fallbackModels] } : {}),
@@ -245,7 +263,7 @@ export function editableAgentConfig(agent: AgentConfig): AgentConfig {
 		...(base.extensions !== undefined ? { extensions: [...base.extensions] } : {}),
 		...(base.subagentOnlyExtensions !== undefined ? { subagentOnlyExtensions: [...base.subagentOnlyExtensions] } : {}),
 		...(base.completionGuard !== undefined ? { completionGuard: base.completionGuard } : {}),
-	};
+	}, agent.filePath);
 }
 
 function readAgentFrontmatterFields(filePath: string): Set<string> {

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -197,13 +197,7 @@ function skillsWarning(cwd: string, agent: Pick<AgentConfig, "skills" | "skillPa
 }
 
 function withDeclaredExtensionPaths(config: AgentConfig, filePath: string): AgentConfig {
-	let frontmatter: Record<string, string>;
-	try {
-		({ frontmatter } = parseFrontmatter(fs.readFileSync(filePath, "utf-8")));
-	} catch {
-		return config;
-	}
-
+	const { frontmatter } = parseFrontmatter(fs.readFileSync(filePath, "utf-8"));
 	const { extensions: _extensions, subagentOnlyExtensions: _subagentOnlyExtensions, ...withoutResolvedExtensions } = config;
 	return {
 		...withoutResolvedExtensions,

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -818,7 +818,13 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 	if ("content" in targetOrError) return targetOrError;
 	const target = targetOrError;
 	if (target.source !== "user" && target.source !== "project") return result(`Cannot update ${target.source} agent '${target.name}'. Eject it to user or project scope first.`, true);
-	const updated = editableAgentConfig(target);
+	let updated: AgentConfig;
+	try {
+		updated = editableAgentConfig(target);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return result(`Could not reread agent definition ${target.filePath} before updating '${target.name}': ${message}`, true);
+	}
 	const oldName = target.name;
 	if (hasKey(cfg, "name") && (typeof cfg.name !== "string" || !cfg.name.trim())) return result("config.name must be a non-empty string when provided.", true);
 	if (hasKey(cfg, "description") && (typeof cfg.description !== "string" || !cfg.description.trim())) return result("config.description must be a non-empty string when provided.", true);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1594,6 +1594,18 @@ function readAgentDefinitionFiles(dir: string): AgentDefinitionFile[] {
 	return files;
 }
 
+function resolveAgentRelativeExtensionPaths(paths: string[] | undefined, agentFilePath: string): string[] | undefined {
+	if (paths === undefined) return undefined;
+	const baseDir = path.dirname(agentFilePath);
+	return paths.map((entry) => {
+		const trimmed = entry.trim();
+		if (trimmed === "." || trimmed === ".." || trimmed.startsWith("./") || trimmed.startsWith("../")) {
+			return path.resolve(baseDir, trimmed);
+		}
+		return entry;
+	});
+}
+
 function loadAgentsFromDefinitionFiles(files: AgentDefinitionFile[], source: AgentSource, discoveryPriority?: number): { agents: AgentConfig[]; diagnostics: AgentDiscoveryDiagnostic[] } {
 	const agents: AgentConfig[] = [];
 	const diagnostics: AgentDiscoveryDiagnostic[] = [];
@@ -1685,8 +1697,8 @@ function loadAgentsFromDefinitionFiles(files: AgentDefinitionFile[], source: Age
 			else throw new Error(`Agent '${localName}' has invalid acceptanceRole frontmatter; expected 'read-only' or 'writer'.`);
 		}
 
-		const extensions = parseFrontmatterList(frontmatter.extensions);
-		const subagentOnlyExtensions = parseFrontmatterList(frontmatter.subagentOnlyExtensions);
+		const extensions = resolveAgentRelativeExtensionPaths(parseFrontmatterList(frontmatter.extensions), filePath);
+		const subagentOnlyExtensions = resolveAgentRelativeExtensionPaths(parseFrontmatterList(frontmatter.subagentOnlyExtensions), filePath);
 
 		const extraFields: Record<string, string> = {};
 		for (const [key, value] of Object.entries(frontmatter)) {

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -392,8 +392,8 @@ Do work
 		assert.deepEqual(worker?.skills, ["review-checklist", "safe-bash"]);
 		assert.deepEqual(worker?.skillPath, ["./private-skills", "../shared-skills"]);
 		assert.deepEqual(worker?.fallbackModels, ["openai/gpt-5-mini", "anthropic/claude-sonnet-4"]);
-		assert.deepEqual(worker?.extensions, ["./extension-one.ts", "./extension-two.ts"]);
-		assert.deepEqual(worker?.subagentOnlyExtensions, ["./child-only.ts", "./child-helper.ts"]);
+		assert.deepEqual(worker?.extensions, [path.join(dir, ".pi", "agents", "extension-one.ts"), path.join(dir, ".pi", "agents", "extension-two.ts")]);
+		assert.deepEqual(worker?.subagentOnlyExtensions, [path.join(dir, ".pi", "agents", "child-only.ts"), path.join(dir, ".pi", "agents", "child-helper.ts")]);
 	});
 
 	it("preserves MCP-only tools as an explicit empty builtin allowlist", () => {
@@ -439,8 +439,8 @@ Do work
 		assert.deepEqual(worker?.skills, ["review-checklist", "safe-bash"]);
 		assert.deepEqual(worker?.skillPath, ["./private-skills", "../shared-skills"]);
 		assert.deepEqual(worker?.fallbackModels, ["openai/gpt-5-mini", "anthropic/claude-sonnet-4"]);
-		assert.deepEqual(worker?.extensions, ["./extension-one.ts", "./extension-two.ts"]);
-		assert.deepEqual(worker?.subagentOnlyExtensions, ["./child-only.ts", "./child-helper.ts"]);
+		assert.deepEqual(worker?.extensions, [path.join(dir, ".pi", "agents", "extension-one.ts"), path.join(dir, ".pi", "agents", "extension-two.ts")]);
+		assert.deepEqual(worker?.subagentOnlyExtensions, [path.join(dir, ".pi", "agents", "child-only.ts"), path.join(dir, ".pi", "agents", "child-helper.ts")]);
 	});
 });
 
@@ -1495,7 +1495,7 @@ Do work
 
 		const result = discoverAgents(dir, "project");
 		const worker = result.agents.find((agent) => agent.name === "worker");
-		assert.deepEqual(worker?.subagentOnlyExtensions, ["./tools/child-search.ts", "/opt/pi/child-only.ts"]);
+		assert.deepEqual(worker?.subagentOnlyExtensions, [path.join(agentsDir, "tools", "child-search.ts"), "/opt/pi/child-only.ts"]);
 	});
 });
 

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -607,6 +607,25 @@ describe("agent management config parsing", () => {
 		assert.ok(readText(got).includes("Subagent-only extensions: " + path.join(tempDir, ".pi", "agents", "tools", "child-only.ts") + ", /opt/pi/child.ts"));
 	});
 
+	it("preserves relative extension paths during unrelated updates", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+		const agentPath = path.join(tempDir, ".pi", "agents", "portable.md");
+		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+		fs.writeFileSync(
+			agentPath,
+			"---\nname: portable\ndescription: Portable agent\nextensions: ./tools/parent.ts, package-extension\nsubagentOnlyExtensions: ../child.ts, ~/shared.ts\n---\nOriginal prompt.\n",
+		);
+
+		const updated = handleUpdate({ agent: "portable", config: { description: "Updated agent" } }, ctx);
+
+		assert.equal(updated.isError, false);
+		const content = fs.readFileSync(agentPath, "utf-8");
+		assert.match(content, /^description: Updated agent$/m);
+		assert.match(content, /^extensions: \.\/tools\/parent\.ts, package-extension$/m);
+		assert.match(content, /^subagentOnlyExtensions: \.\.\/child\.ts, ~\/shared\.ts$/m);
+		assert.ok(!content.includes(tempDir));
+	});
+
 	it("does not serialize settings overrides into custom agent frontmatter during updates", () => {
 		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-sonnet-4-6" }] } };
 		const settingsPath = path.join(tempDir, ".pi", "settings.json");

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -604,7 +604,7 @@ describe("agent management config parsing", () => {
 
 		const got = handleManagementAction("get", { agent: "child-tool-user" }, ctx);
 		assert.equal(got.isError, false);
-		assert.match(readText(got), /Subagent-only extensions: \.\/tools\/child-only\.ts, \/opt\/pi\/child\.ts/);
+		assert.ok(readText(got).includes("Subagent-only extensions: " + path.join(tempDir, ".pi", "agents", "tools", "child-only.ts") + ", /opt/pi/child.ts"));
 	});
 
 	it("does not serialize settings overrides into custom agent frontmatter during updates", () => {

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -644,6 +644,31 @@ describe("agent management config parsing", () => {
 		);
 	});
 
+	it("returns a structured error when a definition disappears after discovery", () => {
+		const agentPath = path.join(tempDir, ".pi", "agents", "removed-during-update.md");
+		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+		fs.writeFileSync(
+			agentPath,
+			"---\nname: removed-during-update\ndescription: Temporary agent\nextensions: ./tools/parent.ts\n---\nOriginal prompt.\n",
+		);
+		let cwdReads = 0;
+		const ctx = {
+			get cwd() {
+				cwdReads += 1;
+				// handleUpdate reads cwd again after discovery, which models the definition disappearing between reads.
+				if (cwdReads === 2) fs.unlinkSync(agentPath);
+				return tempDir;
+			},
+			modelRegistry: { getAvailable: () => [] },
+		};
+
+		const updated = handleUpdate({ agent: "removed-during-update", config: { description: "Updated agent" } }, ctx);
+
+		assert.equal(updated.isError, true);
+		assert.match(readText(updated), /Could not reread agent definition .*removed-during-update\.md before updating 'removed-during-update':.*ENOENT/);
+		assert.equal(fs.existsSync(agentPath), false);
+	});
+
 	it("does not serialize settings overrides into custom agent frontmatter during updates", () => {
 		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-sonnet-4-6" }] } };
 		const settingsPath = path.join(tempDir, ".pi", "settings.json");

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { handleCreate, handleList, handleManagementAction, handleUpdate } from "../../src/agents/agent-management.ts";
+import { editableAgentConfig, handleCreate, handleList, handleManagementAction, handleUpdate } from "../../src/agents/agent-management.ts";
 import { EXTRA_AGENT_DIRS_ENV } from "../../src/agents/agents.ts";
 import { clearSkillCache } from "../../src/agents/skills.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
@@ -624,6 +624,24 @@ describe("agent management config parsing", () => {
 		assert.match(content, /^extensions: \.\/tools\/parent\.ts, package-extension$/m);
 		assert.match(content, /^subagentOnlyExtensions: \.\.\/child\.ts, ~\/shared\.ts$/m);
 		assert.ok(!content.includes(tempDir));
+	});
+
+	it("fails when extension frontmatter cannot be reread", () => {
+		const filePath = path.join(tempDir, ".pi", "agents", "removed.md");
+		assert.throws(
+			() => editableAgentConfig({
+				name: "removed",
+				description: "Removed agent",
+				systemPromptMode: "replace",
+				inheritProjectContext: false,
+				inheritSkills: false,
+				systemPrompt: "Original prompt.",
+				source: "project",
+				filePath,
+				extensions: [path.join(tempDir, ".pi", "agents", "tools", "parent.ts")],
+			}),
+			/ENOENT/,
+		);
 	});
 
 	it("does not serialize settings overrides into custom agent frontmatter during updates", () => {

--- a/test/unit/default-extensions.test.ts
+++ b/test/unit/default-extensions.test.ts
@@ -84,7 +84,7 @@ describe("subagents.defaultExtensions", () => {
 		);
 		assert.deepEqual(
 			agents.find((agent) => agent.name === "explicit")?.extensions,
-			["./explicit.ts"],
+			[path.join(tempProject, ".pi", "agents", "explicit.ts")],
 		);
 		assert.deepEqual(
 			agents.find((agent) => agent.name === "disabled")?.extensions,
@@ -117,7 +117,7 @@ describe("subagents.defaultExtensions", () => {
 		);
 		assert.deepEqual(
 			agents.find((agent) => agent.name === "explicit")?.extensions,
-			["./frontmatter.ts"],
+			[path.join(tempProject, ".pi", "agents", "frontmatter.ts")],
 		);
 	});
 


### PR DESCRIPTION
## Problem

When an agent file declares a relative child-extension path:

```yaml
subagentOnlyExtensions: ../extensions/persona-child.ts
```

`pi-subagents` forwards the value unchanged to the child Pi process as `--extension`.
Pi resolves the relative path against the child's launch cwd (the parent project
directory), not against the directory containing the agent file that declared it.

This produces errors like:

```text
/Users/taylor/Documents/Projects/03-tools/extensions/persona-child.ts
Extension path does not exist
```

even though the agent file and its extension are co-located inside an installed
package (`~/.pi/agent/git/<host>/<repo>/agents/…` + `…/extensions/…`).

## Root cause

`loadAgentsFromDefinitionFiles()` in `src/agents/agents.ts` stores `extensions` and
`subagentOnlyExtensions` without resolving relative filesystem paths. The defining
agent file's directory (`filePath`) is known at discovery time but is not used.

## Fix

Add `resolveAgentRelativeExtensionPaths()` and apply it to both fields at discovery
time. Explicit `./` and `../` paths are resolved against `dirname(filePath)`;
absolute paths, `~/...` paths, and bare package/module specifiers are left untouched.

Settings-derived extensions (`defaultExtensions`, `agentOverrides`) are intentionally
not rewritten — only agent-frontmatter values are agent-file-relative.

Management serialization also restores these two values from the defining file's
original frontmatter before applying explicit updates. This keeps discovered absolute
runtime paths from leaking into portable agent definitions during unrelated edits.
If the definition cannot be reread, the update returns a structured management error
before serialization rather than falling back to the discovery-resolved runtime values.

## Tests

- `npm run typecheck` — passed.
- The prescribed five-file unit command ran 219 tests: 216 passed, 3 failed.
  The failures are accepted pre-existing unrelated environment-sensitive tests:
  - `loads packaged worker and oracle with fork defaultContext and advisor alias`
  - `gets only the effective agent detail and respects explicit scope`
  - `does not apply a malformed project diagnostic to an explicit user get`
- Focused changed assertions passed: 3 frontmatter tests, 4 agent-management tests,
  and all 7 `default-extensions` tests.

## Upstream drift

The prepared patch was based before upstream commit `3b5999a`, which refactored
`loadAgentsFromDir()` to delegate to `loadAgentsFromDefinitionFiles()`. The patch
was hand-applied at the equivalent discovery location (the parser call-site shifted
from the old `loadAgentsFromDir()` body to `loadAgentsFromDefinitionFiles()`); no
behavioral scope changed.
