### PR TITLE
fix: isolate colliding inherited workflow outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve bundled role and parent prompts for source-first discovery in noisy codebases (#1247).
 
 ### Fixed
+- Isolate colliding inherited workflow child output defaults while preserving explicit output collision checks. Thanks to [@Reverier-Xu](https://github.com/Reverier-Xu) for #1253.
 - Show a scheduled run's completion and name the schedule that produced it, so scheduled work no longer finishes silently in a session that cannot attribute it. Thanks to [@albertgwo](https://github.com/albertgwo) for #1246.
 - Show resume-first guidance for failed async runs only when a matching recovery descriptor exists, so missing recovery data no longer points users to a resume command that cannot work. Thanks to [@graadient](https://github.com/graadient) for #1241.
 - Keep bundled agent discovery stable across hot package updates, so long-running sessions do not parse newer bundled agent files with older loaded code. Thanks to [@graadient](https://github.com/graadient) for #1242.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2911,6 +2911,12 @@ function appendWorkflowOutputWarning(text: string, warning: string | undefined):
 	return warning ? `${text}\n\n${warning}` : text;
 }
 
+function resolveWorkflowChildResumeOutputPath(params: Record<string, unknown>, state: SubagentState): string | undefined {
+	if (typeof params.resume !== "string") return undefined;
+	const target = resolveResumeTarget({ id: params.resume.trim(), index: params.index } as SubagentParamsLike, state);
+	return "recoveryDescriptor" in target ? target.recoveryDescriptor?.outputPath : undefined;
+}
+
 function resolveWorkflowChildOutputPath(input: {
 	ctxCwd: string;
 	workflowCwd: string;
@@ -2920,9 +2926,12 @@ function resolveWorkflowChildOutputPath(input: {
 	configuredOutputBaseDir?: string;
 	discoverAgents: (cwd: string, scope: AgentScope) => { agents: AgentConfig[] };
 	workflowAgentScope?: unknown;
+	state?: SubagentState;
 	key: string;
 	params: Record<string, unknown>;
-}): string | undefined {
+}): { path?: string; inherited: boolean } {
+	const resumeOutputPath = typeof input.params.resume === "string" ? resolveWorkflowChildResumeOutputPath(input.params, input.state!) : undefined;
+	if (typeof input.params.resume === "string") return { path: resumeOutputPath, inherited: false };
 	const rawOutput = input.params.output;
 	const hasExplicitOutput = typeof rawOutput === "string" || typeof rawOutput === "boolean";
 	const childCwd = typeof input.params.cwd === "string" ? resolveChildCwd(input.workflowCwd, input.params.cwd) : input.workflowCwd;
@@ -2937,7 +2946,10 @@ function resolveWorkflowChildOutputPath(input: {
 			: input.aggregateOutputPath
 				? workflowChildDefaultOutput(input.aggregateOutputPath, input.artifactsDir, input.workflowRunId, input.key)
 				: agentOutput;
-	return resolveSingleOutputPath(output, input.ctxCwd, childCwd, input.configuredOutputBaseDir);
+	return {
+		path: resolveSingleOutputPath(output, input.ctxCwd, childCwd, input.configuredOutputBaseDir),
+		inherited: !hasExplicitOutput && !input.aggregateOutputPath && agentOutput !== undefined,
+	};
 }
 
 function workflowChildOutputClaims(input: {
@@ -2949,18 +2961,35 @@ function workflowChildOutputClaims(input: {
 	configuredOutputBaseDir?: string;
 	discoverAgents: (cwd: string, scope: AgentScope) => { agents: AgentConfig[] };
 	workflowAgentScope?: unknown;
+	state: SubagentState;
 	claimedOutputPaths: Map<string, string>;
 	entries: Array<{ key: string; params: Record<string, unknown> }>;
-}): { error?: string; claims?: Map<string, string> } {
+}): { error?: string; claims?: Map<string, string>; overrides?: Map<string, string> } {
+	const resolvedEntries = input.entries.map(({ key, params }) => ({
+		key,
+		...resolveWorkflowChildOutputPath({ ...input, key, params }),
+	}));
+	const paths = new Map<string, number>();
+	for (const claimedPath of input.claimedOutputPaths.keys()) paths.set(claimedPath, 1);
+	for (const { path: resolved } of resolvedEntries) {
+		if (resolved) paths.set(resolved, (paths.get(resolved) ?? 0) + 1);
+	}
+	const overrides = new Map<string, string>();
+	for (const entry of resolvedEntries) {
+		if (entry.inherited && entry.path && (paths.get(entry.path) ?? 0) > 1) {
+			const output = workflowChildDefaultOutput(input.aggregateOutputPath, input.artifactsDir, input.workflowRunId, entry.key);
+			overrides.set(entry.key, output);
+			entry.path = output;
+		}
+	}
 	const claims = new Map(input.claimedOutputPaths);
-	for (const { key, params } of input.entries) {
-		const resolved = resolveWorkflowChildOutputPath({ ...input, key, params });
+	for (const { key, path: resolved } of resolvedEntries) {
 		if (!resolved) continue;
 		const previous = claims.get(resolved);
 		if (previous) return { error: `Workflow children '${previous}' and '${key}' resolve output to the same path: ${resolved}. Use distinct child output paths.` };
 		claims.set(resolved, key);
 	}
-	return { claims };
+	return { claims, overrides };
 }
 
 function applyWorkflowChildOutputClaims(target: Map<string, string>, claims: Map<string, string>): void {
@@ -2980,14 +3009,17 @@ function prepareWorkflowChildLaunchParams(input: {
 	configuredOutputBaseDir?: string;
 	discoverAgents: (cwd: string, scope: AgentScope) => { agents: AgentConfig[] };
 	workflowAgentScope?: unknown;
+	outputOverride?: string;
 	options?: { missionDetached?: boolean; suppressRoutineResultIntercom?: boolean; runFanoutBudget?: RunFanoutBudgetDescriptor; parentDeadlineAt?: number };
 }): SubagentParamsLike {
 	let childParams = input.childParams;
-	if (input.childParams.output === undefined && input.childParams.resume === undefined && input.aggregateOutputPath !== undefined) {
+	if (input.childParams.output === undefined && input.childParams.resume === undefined && input.outputOverride !== undefined) {
+		childParams = { ...input.childParams, output: input.outputOverride };
+	} else if (input.childParams.output === undefined && input.childParams.resume === undefined && input.aggregateOutputPath !== undefined) {
 		childParams = { ...input.childParams, output: workflowChildDefaultOutput(input.aggregateOutputPath, input.artifactsDir, input.parentWorkflowRunId, input.workflowKey) };
 	} else if (input.childParams.resume === undefined) {
 		const resolvedOutput = resolveWorkflowChildOutputPath({ ctxCwd: input.ctxCwd, workflowCwd: input.workflowCwd, artifactsDir: input.artifactsDir, workflowRunId: input.parentWorkflowRunId, aggregateOutputPath: input.aggregateOutputPath, configuredOutputBaseDir: input.configuredOutputBaseDir, discoverAgents: input.discoverAgents, workflowAgentScope: input.workflowAgentScope, key: input.workflowKey, params: input.childParams });
-		if (resolvedOutput) childParams = { ...input.childParams, output: resolvedOutput };
+		if (resolvedOutput.path) childParams = { ...input.childParams, output: resolvedOutput.path };
 	}
 	return prepareWorkflowLaunchParams(input.workflowDefaults, childParams, input.parentWorkflowRunId, input.workflowKey, input.options);
 }
@@ -3614,6 +3646,7 @@ export function prepareWorkflowLaunchParams(
 		return {
 			action: "resume",
 			id: childParams.resume.trim(),
+			...(childParams.index !== undefined ? { index: childParams.index as number } : {}),
 			message: typeof childParams.task === "string" ? childParams.task.trim() : "",
 			workflowParentRunId: parentWorkflowRunId,
 			workflowKey,
@@ -4023,6 +4056,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					const configuredOutputBaseDir = resolveConfiguredSingleRunOutputBaseDir(deps);
 					const workflowAggregateOutputPath = resolveWorkflowAggregateOutputPath(workflowOutput, ctx.cwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, workflowRunId), configuredOutputBaseDir);
 					const claimedOutputPaths = new Map<string, string>();
+					const childOutputOverrides = new Map<string, string>();
 					const producedChildOutputPaths = new Set<string>();
 					const workflowSteps = new Map<string, NonNullable<AsyncStatus["steps"]>[number]>();
 					let projectedTraceLength = 0;
@@ -4096,10 +4130,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							...(workflowState ? { state: workflowState } : {}),
 							onTrace: updateTrace,
 							admit: (calls) => {
-								const outputClaims = workflowChildOutputClaims({ ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, workflowRunId, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: deps.discoverAgents, workflowAgentScope: workflowChildDefaults.agentScope, claimedOutputPaths, entries: calls });
+								const outputClaims = workflowChildOutputClaims({ ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, workflowRunId, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: deps.discoverAgents, workflowAgentScope: workflowChildDefaults.agentScope, state: deps.state, claimedOutputPaths, entries: calls });
 								if (outputClaims.error) throw new Error(outputClaims.error);
 								status.runFanoutBudget = claimRunFanoutBatch(workflowFanoutBudget, calls.map(({ key }) => `workflow[${key}]`));
 								if (outputClaims.claims) applyWorkflowChildOutputClaims(claimedOutputPaths, outputClaims.claims);
+								if (outputClaims.overrides) for (const [key, output] of outputClaims.overrides) childOutputOverrides.set(key, output);
 								persist();
 							},
 							onEmit: (emits) => {
@@ -4123,7 +4158,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								});
 								const result = await runMissionWorkflowChild(missionBinding, workflowRunId, key, childPhase, () => {
 									const childRequest = bindMissionWorkflowChildAsyncLaunch(
-										{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams, parentWorkflowRunId: workflowRunId, workflowKey: key, ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: deps.discoverAgents, workflowAgentScope: workflowChildDefaults.agentScope, options: { missionDetached: detachWorkflowChildMissions, runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt } }), runFanoutAdmitted: admission.admitted },
+										{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams, parentWorkflowRunId: workflowRunId, workflowKey: key, ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: deps.discoverAgents, workflowAgentScope: workflowChildDefaults.agentScope, outputOverride: childOutputOverrides.get(key), options: { missionDetached: detachWorkflowChildMissions, runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt } }), runFanoutAdmitted: admission.admitted },
 										missionBinding,
 										deps.asyncByDefault,
 									);
@@ -4240,6 +4275,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const configuredOutputBaseDir = resolveConfiguredSingleRunOutputBaseDir(deps);
 			const workflowAggregateOutputPath = resolveWorkflowAggregateOutputPath(workflowOutput, ctx.cwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, _id), configuredOutputBaseDir);
 			const claimedOutputPaths = new Map<string, string>();
+			const childOutputOverrides = new Map<string, string>();
 			const producedChildOutputPaths = new Set<string>();
 			const workflowResults: SingleResult[] = [];
 			const workflowChildRunIds = new Map<string, string>();
@@ -4260,10 +4296,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						sendWorkflowProgress();
 					},
 					admit: (calls) => {
-						const outputClaims = workflowChildOutputClaims({ ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, workflowRunId: _id, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: deps.discoverAgents, workflowAgentScope: workflowChildDefaults.agentScope, claimedOutputPaths, entries: calls });
+						const outputClaims = workflowChildOutputClaims({ ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, workflowRunId: _id, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: deps.discoverAgents, workflowAgentScope: workflowChildDefaults.agentScope, state: deps.state, claimedOutputPaths, entries: calls });
 						if (outputClaims.error) throw new Error(outputClaims.error);
 						claimRunFanoutBatch(workflowFanoutBudget, calls.map(({ key }) => `workflow[${key}]`));
 						if (outputClaims.claims) applyWorkflowChildOutputClaims(claimedOutputPaths, outputClaims.claims);
+						if (outputClaims.overrides) for (const [key, output] of outputClaims.overrides) childOutputOverrides.set(key, output);
 					},
 					onEmit: (emits) => {
 						liveWorkflow = { ...liveWorkflow, emits };
@@ -4284,7 +4321,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						});
 						const result = await runMissionWorkflowChild(missionBinding, _id, key, childPhase, () => {
 							const childRequest = bindMissionWorkflowChildAsyncLaunch(
-								{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams, parentWorkflowRunId: _id, workflowKey: key, ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: deps.discoverAgents, workflowAgentScope: workflowChildDefaults.agentScope, options: { missionDetached: detachWorkflowChildMissions, suppressRoutineResultIntercom: chatProgress.mode === "live-card", runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt } }), runFanoutAdmitted: admission.admitted },
+								{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams, parentWorkflowRunId: _id, workflowKey: key, ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: deps.discoverAgents, workflowAgentScope: workflowChildDefaults.agentScope, outputOverride: childOutputOverrides.get(key), options: { missionDetached: detachWorkflowChildMissions, suppressRoutineResultIntercom: chatProgress.mode === "live-card", runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt } }), runFanoutAdmitted: admission.admitted },
 								missionBinding,
 								deps.asyncByDefault,
 							);

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -1012,7 +1012,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			if (!admission) {
 				const seenKeys = new Set<string>();
 				const calls = (batch?.calls ?? [{ key, params }]).filter((call) => {
-					if (seenKeys.has(call.key) || launches.has(call.key) || call.params.resume !== undefined) return false;
+					if (seenKeys.has(call.key) || launches.has(call.key)) return false;
 					seenKeys.add(call.key);
 					return true;
 				});

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -279,6 +279,10 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function pathContainsSegments(filePath: string, ...segments: string[]): boolean {
+	return segments.every((segment) => filePath.split(path.sep).includes(segment));
+}
+
 function writePackageSkill(packageRoot: string, skillName: string): void {
 	const skillDir = path.join(packageRoot, "skills", skillName);
 	fs.mkdirSync(skillDir, { recursive: true });
@@ -1614,6 +1618,131 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			assert.match(child.error ?? "", new RegExp(escapeRegExp(path.join(tempDir, relativeDuplicateOutput))));
 		}
 		assert.equal(mockPi.callCount(), 0);
+	});
+
+	it("isolates colliding inherited agent-default outputs for parallel workflow children", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "review report", matchArgIncludes: "Review" });
+		mockPi.onCall({ output: "monitor report", matchArgIncludes: "Monitor" });
+		const result = await makeExecutor([makeAgent("echo", { output: "context.md" })]).execute(
+			"scripted-workflow-parallel-inherited-output-collision",
+			{
+				async: false,
+				workflowScript: `return await runs.all([
+					{ key: "review", agent: "echo", task: "Review" },
+					{ key: "monitor", agent: "echo", task: "Monitor" }
+				]);`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		const children = result.details.workflow?.value as Array<{ ok: boolean }>;
+		assert.deepEqual(children.map(({ ok }) => ok), [true, true]);
+		const outputPaths = result.details.results.map(({ savedOutputPath }) => savedOutputPath ?? "").sort();
+		assert.equal(outputPaths.length, 2);
+		assert.notEqual(outputPaths[0], outputPaths[1]);
+		assert.ok(pathContainsSegments(outputPaths[0]!, "artifacts", "outputs"));
+		assert.ok(pathContainsSegments(outputPaths[1]!, "artifacts", "outputs"));
+		assert.match(path.basename(outputPaths[0]!), /^(monitor|review)\.md$/);
+		assert.match(path.basename(outputPaths[1]!), /^(monitor|review)\.md$/);
+		assert.deepEqual(outputPaths.map((outputPath) => fs.readFileSync(outputPath, "utf-8")).sort(), ["monitor report", "review report"]);
+		assert.equal(fs.existsSync(path.join(tempDir, "context.md")), false);
+	});
+
+	it("isolates inherited outputs that collide with a resumed child output", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const retainedRunId = `retained-output-${Date.now()}`;
+		const retainedAsyncDir = path.join(DIRS.async, retainedRunId);
+		const retainedSessionFile = path.join(tempDir, "retained-session.jsonl");
+		const retainedOutputPath = path.join(tempDir, "context.md");
+		const runFanoutBudget = createRunFanoutBudget(retainedRunId, 10);
+		fs.mkdirSync(retainedAsyncDir, { recursive: true });
+		fs.writeFileSync(retainedSessionFile, "{}\n", "utf-8");
+		fs.writeFileSync(path.join(retainedAsyncDir, "status.json"), JSON.stringify({
+			runId: retainedRunId,
+			sessionId: "session-123",
+			state: "failed",
+			cwd: tempDir,
+			sessionFile: retainedSessionFile,
+			steps: [
+				{ agent: "echo", status: "failed", sessionFile: retainedSessionFile },
+				{ agent: "echo", status: "failed", sessionFile: retainedSessionFile },
+			],
+		}), "utf-8");
+		fs.writeFileSync(path.join(retainedAsyncDir, "recovery-descriptor.json"), JSON.stringify({
+			version: 1,
+			runFanoutBudget,
+			sourceRunId: retainedRunId,
+			agent: "echo",
+			cwd: tempDir,
+			systemPromptMode: "append",
+			inheritProjectContext: true,
+			inheritSkills: true,
+			outputPath: retainedOutputPath,
+			outputMode: "inline",
+			maxSubagentDepth: 1,
+			share: false,
+		}), "utf-8");
+		mockPi.onCall({ output: "resumed report", matchArgIncludes: "Resume" });
+		mockPi.onCall({ output: "review report", matchArgIncludes: "Review" });
+
+		try {
+			const result = await makeExecutor([makeAgent("echo", { output: "context.md" })]).execute(
+				"scripted-workflow-resumed-inherited-output-collision",
+				{
+					async: false,
+					workflowScript: `return await runs.all([
+						{ key: "resume", resume: ${JSON.stringify(retainedRunId)}, index: 1, task: "Resume" },
+						{ key: "review", agent: "echo", task: "Review" }
+					]);`,
+				},
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+
+			assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+			const children = result.details.workflow?.value as Array<{ ok: boolean }>;
+			assert.deepEqual(children.map(({ ok }) => ok), [true, true]);
+			assert.equal(fs.readFileSync(retainedOutputPath, "utf-8"), "resumed report");
+			const outputPaths = result.details.results.map(({ savedOutputPath }) => savedOutputPath ?? "");
+			const inheritedOutputPaths = outputPaths.filter((outputPath) => outputPath && outputPath !== retainedOutputPath).sort();
+			assert.deepEqual(inheritedOutputPaths.map((outputPath) => path.basename(outputPath)), ["review.md"]);
+			assert.ok(inheritedOutputPaths.every((outputPath) => pathContainsSegments(outputPath, "artifacts", "outputs")));
+		} finally {
+			fs.rmSync(retainedAsyncDir, { recursive: true, force: true });
+			fs.rmSync(runFanoutBudget.directory, { recursive: true, force: true });
+		}
+	});
+
+	it("reroutes a later inherited agent-default output collision", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "first report", matchArgIncludes: "First" });
+		mockPi.onCall({ output: "second report", matchArgIncludes: "Second" });
+		const result = await makeExecutor([makeAgent("echo", { output: "context.md" })]).execute(
+			"scripted-workflow-sequential-inherited-output-collision",
+			{
+				async: false,
+				workflowScript: `
+					const first = await runs.run("first", { agent: "echo", task: "First" });
+					const second = await runs.run("second", { agent: "echo", task: "Second" });
+					return [first, second];
+				`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		const children = result.details.workflow?.value as Array<{ ok: boolean }>;
+		assert.deepEqual(children.map(({ ok }) => ok), [true, true]);
+		assert.equal(fs.readFileSync(path.join(tempDir, "context.md"), "utf-8"), "first report");
+		const outputPaths = result.details.results.map(({ savedOutputPath }) => savedOutputPath ?? "");
+		assert.equal(outputPaths[0], path.join(tempDir, "context.md"));
+		assert.ok(pathContainsSegments(outputPaths[1]!, "artifacts", "outputs"));
+		assert.equal(path.basename(outputPaths[1]!), "second.md");
+		assert.equal(fs.readFileSync(outputPaths[1]!, "utf-8"), "second report");
 	});
 
 	it("preserves a rejected file-only child report when its path matches workflow output", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {


### PR DESCRIPTION
## Summary

Fixes #1253 by treating omitted inherited workflow child outputs as soft claims. If two `runs.all()` siblings inherit the same agent default like `context.md`, the runtime now reroutes the colliding inherited claims to isolated per-key workflow artifacts instead of rejecting the fanout.

Explicit output collisions still fail before launch. `output: true` still requests the agent default and remains a hard claim.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check HEAD~1..HEAD`

Thanks to [@Reverier-Xu](https://github.com/Reverier-Xu) for #1253.
