### PR TITLE
fix: honor async opt-out for public single calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve bundled role and parent prompts for source-first discovery in noisy codebases (#1247).
 
 ### Fixed
+- Keep public structured single-child calls synchronous when `asyncByDefault:false` and `async` is omitted. Thanks to [@Nofuture123](https://github.com/Nofuture123) for #1257.
 - Isolate colliding inherited workflow child output defaults while preserving explicit output collision checks. Thanks to [@Reverier-Xu](https://github.com/Reverier-Xu) for #1253.
 - Show a scheduled run's completion and name the schedule that produced it, so scheduled work no longer finishes silently in a session that cannot attribute it. Thanks to [@albertgwo](https://github.com/albertgwo) for #1246.
 - Show resume-first guidance for failed async runs only when a matching recovery descriptor exists, so missing recovery data no longer points users to a resume command that cannot work. Thanks to [@graadient](https://github.com/graadient) for #1241.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -611,6 +611,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	const slashBridge = registerSlashSubagentBridge({
 		events: pi.events,
+		asyncByDefault,
 		getContext: () => state.lastUiContext,
 		execute: (id, params, signal, onUpdate, ctx) =>
 			executeSubagentCollapsed(id, params, signal, onUpdate, ctx),

--- a/src/extension/public-execution.ts
+++ b/src/extension/public-execution.ts
@@ -13,6 +13,7 @@ export interface PublicSubagentExecutionParams {
 	workflowScript?: unknown;
 	isolation?: unknown;
 	worktree?: unknown;
+	async?: unknown;
 	output?: unknown;
 	resume?: unknown;
 	clarify?: unknown;
@@ -30,7 +31,7 @@ export type PublicSubagentExecutionNormalization<T> =
  * Enforce the public execution cutover before requests reach the executor.
  * Internal runs.run children and structured owned delegation bypass this boundary.
  */
-export function normalizePublicSubagentExecution<T extends PublicSubagentExecutionParams>(params: T): PublicSubagentExecutionNormalization<T> {
+export function normalizePublicSubagentExecution<T extends PublicSubagentExecutionParams>(params: T, options: { asyncByDefault?: boolean } = {}): PublicSubagentExecutionNormalization<T> {
 	if (params.isolation !== undefined) {
 		if (params.isolation !== "none" && params.isolation !== "worktree") {
 			return { ok: false, error: "isolation must be 'none' or 'worktree'.", mode: params.workflowScript !== undefined ? "workflow" : "management" };
@@ -120,6 +121,7 @@ export function normalizePublicSubagentExecution<T extends PublicSubagentExecuti
 			ok: true,
 			params: {
 				...workflowDefaults,
+				...(params.async === undefined && options.asyncByDefault === false ? { async: false } : {}),
 				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", ${JSON.stringify(child)})`,
 			} as T,
 		};

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5563,7 +5563,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		onUpdate: ((r: AgentToolResult<Details>) => void) | undefined,
 		ctx: ExtensionContext,
 	): Promise<AgentToolResult<Details>> => {
-		const normalized = normalizePublicSubagentExecution(params);
+		const normalized = normalizePublicSubagentExecution(params, { asyncByDefault: deps.asyncByDefault });
 		if (!normalized.ok) {
 			return Promise.resolve({ content: [{ type: "text", text: normalized.error }], isError: true, details: { mode: normalized.mode, results: [] } });
 		}

--- a/src/slash/slash-bridge.ts
+++ b/src/slash/slash-bridge.ts
@@ -39,6 +39,7 @@ interface EventBus {
 
 interface SlashBridgeOptions {
 	events: EventBus;
+	asyncByDefault: boolean;
 	getContext: () => ExtensionContext | null;
 	execute: (
 		id: string,
@@ -79,7 +80,7 @@ export function registerSlashSubagentBridge(options: SlashBridgeOptions): {
 		const request = data as Partial<SlashSubagentRequest>;
 		if (typeof request.requestId !== "string" || !request.params) return;
 		const { requestId } = request as SlashSubagentRequest;
-		const normalized = normalizePublicSubagentExecution((request as SlashSubagentRequest).params);
+		const normalized = normalizePublicSubagentExecution((request as SlashSubagentRequest).params, { asyncByDefault: options.asyncByDefault });
 		if (!normalized.ok) {
 			options.events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, {
 				requestId,

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -418,6 +418,23 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(JSON.stringify(result.details), /Converted structured single-child request/);
 	});
 
+	it("keeps public structured single-child calls foreground when async is disabled by default", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "Structured child used the foreground default" });
+		const executor = makeExecutor([makeAgent("echo")], {}, false);
+
+		const result = await executor.executePublic(
+			"structured-single-foreground-default",
+			{ agent: "echo", task: "Run through workflow" },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined);
+		assert.match(result.content[0]?.text ?? "", /Structured child used the foreground default/);
+		assert.equal(result.details.asyncId, undefined);
+	});
+
 	it("does not override structured single output unless configured by the agent", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		for (const params of [
 			{ agent: "echo", task: "Use the task output path", async: false },

--- a/test/unit/public-execution.test.ts
+++ b/test/unit/public-execution.test.ts
@@ -20,6 +20,20 @@ describe("public subagent execution normalization", () => {
 				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":true})`,
 			},
 		});
+		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker" }, { asyncByDefault: false }), {
+			ok: true,
+			params: {
+				async: false,
+				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":true})`,
+			},
+		});
+		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker", async: true }, { asyncByDefault: false }), {
+			ok: true,
+			params: {
+				async: true,
+				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":true})`,
+			},
+		});
 		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker", output: false }), {
 			ok: true,
 			params: {


### PR DESCRIPTION
## Summary

Honor `asyncByDefault:false` for public `{ agent, task }` calls that omit `async`, while preserving explicit `async:true` and `async:false`.

Closes #1257.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/public-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='structured single-child' test/integration/single-execution.test.ts`\n- `npm run typecheck`\n- `git diff --check`\n\nFresh exact-head review found no issues.\n\nThanks to [@Nofuture123](https://github.com/Nofuture123) for #1257.