### PR TITLE
fix: resolve owner/name model ids without assuming a provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve bundled role and parent prompts for source-first discovery in noisy codebases (#1247).
 
 ### Fixed
+- Resolve Hugging Face-style `owner/name` model ids against the registry instead of treating every slash as `provider/id`. Fully qualified `huggingface/owner/name` still wins, and a first path segment that matches a registered provider still means `provider/id`. Thanks to [@mr-brobot](https://github.com/mr-brobot) for #1264.
 - Make Surf's `gpt-pro` agent an optional package integration instead of a pi-subagents builtin. Users who disabled the old builtin workaround should remove `agentOverrides.gpt-pro.disabled` before using Surf's package agent. Thanks to [@binhex](https://github.com/binhex) for #1256.
 - Keep public structured single-child calls synchronous when `asyncByDefault:false` and `async` is omitted. Thanks to [@Nofuture123](https://github.com/Nofuture123) for #1257.
 - Trust the running parent session model when no model is configured, so gateway and proxy parent models can launch children outside the host registry. Thanks to [@Nofuture123](https://github.com/Nofuture123) for #1258.

--- a/docs/models.md
+++ b/docs/models.md
@@ -141,6 +141,8 @@ You do not have to spell a model exactly. Model ids are matched fuzzily against 
 
 Exact `provider/id` matches still win, and a qualified provider query never silently switches providers — it only matches within the named provider. Ambiguous bare ids that exist under multiple providers still require a provider prefix or the current session's provider to disambiguate.
 
+Registry ids that themselves contain `/` (Hugging Face `owner/name`) resolve the same way as Pi's main agent: `thinkingmachines/Inkling` becomes `huggingface/thinkingmachines/Inkling` when that id is unique or offered by the current session provider. A first path segment that matches a registered provider still means `provider/id`.
+
 ## Model scope enforcement
 
 To keep subagents inside a budget or compliance profile, enforce a model scope. Put `subagents.modelScope` in user or project settings (project overrides user):

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -67,21 +67,65 @@ function stripTrailingDateStamp(segment: string): string {
 	return segment;
 }
 
+function isRegisteredProvider(provider: string, availableModels: AvailableModelInfo[]): boolean {
+	const normalized = normalizeModelSegment(provider);
+	return availableModels.some((entry) => normalizeModelSegment(entry.provider) === normalized);
+}
+
+/**
+ * Split `provider/id` only when the first path segment is a registered provider.
+ * Hugging Face-style `owner/name` ids therefore stay intact unless `owner` is
+ * itself a provider in the active registry. `:` and `.` keep the same rule.
+ */
+function splitQualifiedModelQuery(
+	baseModel: string,
+	availableModels: AvailableModelInfo[],
+): { queryProvider?: string; queryIdRaw: string } {
+	const slashIdx = baseModel.indexOf("/");
+	if (slashIdx !== -1) {
+		const providerPart = baseModel.slice(0, slashIdx);
+		if (isRegisteredProvider(providerPart, availableModels)) {
+			return { queryProvider: normalizeModelSegment(providerPart), queryIdRaw: baseModel.slice(slashIdx + 1) };
+		}
+		return { queryIdRaw: baseModel };
+	}
+	const providerSeparators = [":", "."];
+	for (const separator of providerSeparators) {
+		const separatorIdx = baseModel.indexOf(separator);
+		if (separatorIdx <= 0) continue;
+		const providerPart = baseModel.slice(0, separatorIdx);
+		if (!isRegisteredProvider(providerPart, availableModels)) continue;
+		return { queryProvider: normalizeModelSegment(providerPart), queryIdRaw: baseModel.slice(separatorIdx + 1) };
+	}
+	return { queryIdRaw: baseModel };
+}
+
+function resolveExactIdMatches(
+	baseModel: string,
+	availableModels: AvailableModelInfo[],
+	preferredProvider?: string,
+): string | undefined {
+	const exactMatches = availableModels.filter((entry) => entry.id === baseModel);
+	if (preferredProvider) {
+		const preferredMatch = exactMatches.find((entry) => entry.provider === preferredProvider);
+		if (preferredMatch) return preferredMatch.fullId;
+	}
+	if (exactMatches.length === 1) return exactMatches[0]!.fullId;
+	return undefined;
+}
+
 function resolveBaseModelCandidate(
 	baseModel: string,
 	availableModels: AvailableModelInfo[],
 	preferredProvider?: string,
 ): string | undefined {
-	if (baseModel.includes("/")) {
-		const exact = availableModels.find((entry) => entry.fullId === baseModel);
-		if (exact) return exact.fullId;
-	} else {
-		const exactMatches = availableModels.filter((entry) => entry.id === baseModel);
-		if (preferredProvider) {
-			const preferredMatch = exactMatches.find((entry) => entry.provider === preferredProvider);
-			if (preferredMatch) return preferredMatch.fullId;
-		}
-		if (exactMatches.length === 1) return exactMatches[0]!.fullId;
+	const exact = availableModels.find((entry) => entry.fullId === baseModel);
+	if (exact) return exact.fullId;
+
+	const { queryProvider } = splitQualifiedModelQuery(baseModel, availableModels);
+	if (queryProvider === undefined) {
+		const exactId = resolveExactIdMatches(baseModel, availableModels, preferredProvider);
+		if (exactId) return exactId;
 	}
 
 	return fuzzyResolveModel(baseModel, availableModels, preferredProvider);
@@ -90,7 +134,9 @@ function resolveBaseModelCandidate(
 /**
  * Fuzzy-resolve a base model id (thinking suffix already stripped) against the
  * registry, tolerating separator, case, and optional date-stamp differences so
- * users do not have to spell provider/model exactly. A qualified `provider/id`
+ * users do not have to spell provider/model exactly. A slash is a provider
+ * prefix only when that prefix is a registered provider; otherwise the whole
+ * string is the model id (Hugging Face `owner/name`). A qualified provider
  * query only matches within the named provider — this never silently switches
  * providers for security/cost-sensitive configs. Returns the matched `fullId`,
  * or `undefined` when there is no match or the match is ambiguous across
@@ -101,24 +147,7 @@ export function fuzzyResolveModel(
 	availableModels: AvailableModelInfo[],
 	preferredProvider?: string,
 ): string | undefined {
-	let queryProvider: string | undefined;
-	let queryIdRaw = baseModel;
-	const slashIdx = baseModel.indexOf("/");
-	if (slashIdx !== -1) {
-		queryProvider = normalizeModelSegment(baseModel.slice(0, slashIdx));
-		queryIdRaw = baseModel.slice(slashIdx + 1);
-	} else {
-		const providerSeparators = [":", "."];
-		for (const separator of providerSeparators) {
-			const separatorIdx = baseModel.indexOf(separator);
-			if (separatorIdx <= 0) continue;
-			const providerPart = normalizeModelSegment(baseModel.slice(0, separatorIdx));
-			if (!availableModels.some((entry) => normalizeModelSegment(entry.provider) === providerPart)) continue;
-			queryProvider = providerPart;
-			queryIdRaw = baseModel.slice(separatorIdx + 1);
-			break;
-		}
-	}
+	const { queryProvider, queryIdRaw } = splitQualifiedModelQuery(baseModel, availableModels);
 	const queryId = normalizeModelSegment(queryIdRaw);
 	const queryIdNoDate = stripTrailingDateStamp(queryId);
 

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -20,6 +20,42 @@ describe("model fallback helpers", () => {
 		assert.equal(resolveModelCandidate("openai/gpt-5-mini", availableModels), "openai/gpt-5-mini");
 	});
 
+	it("resolves unique owner/name ids when the owner is not a registered provider", () => {
+		const registry = [
+			...availableModels,
+			{ provider: "huggingface", id: "thinkingmachines/Inkling", fullId: "huggingface/thinkingmachines/Inkling" },
+		];
+		assert.equal(resolveModelCandidate("thinkingmachines/Inkling", registry), "huggingface/thinkingmachines/Inkling");
+		assert.equal(
+			resolveModelCandidate("huggingface/thinkingmachines/Inkling", registry),
+			"huggingface/thinkingmachines/Inkling",
+		);
+		assert.equal(
+			resolveModelCandidate("thinkingmachines/Inkling:high", registry),
+			"huggingface/thinkingmachines/Inkling:high",
+		);
+	});
+
+	it("prefers the current provider for an ambiguous owner/name id", () => {
+		const registry = [
+			{ provider: "huggingface", id: "thinkingmachines/Inkling", fullId: "huggingface/thinkingmachines/Inkling" },
+			{ provider: "together", id: "thinkingmachines/Inkling", fullId: "together/thinkingmachines/Inkling" },
+		];
+		assert.equal(resolveModelCandidate("thinkingmachines/Inkling", registry), "thinkingmachines/Inkling");
+		assert.equal(
+			resolveModelCandidate("thinkingmachines/Inkling", registry, "huggingface"),
+			"huggingface/thinkingmachines/Inkling",
+		);
+	});
+
+	it("treats a registered provider prefix as provider/id, not owner/name", () => {
+		const registry = [
+			{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" },
+			{ provider: "huggingface", id: "openai/gpt-5-mini", fullId: "huggingface/openai/gpt-5-mini" },
+		];
+		assert.equal(resolveModelCandidate("openai/gpt-5-mini", registry), "openai/gpt-5-mini");
+	});
+
 	it("resolves a bare id when there is exactly one registry match", () => {
 		assert.equal(resolveModelCandidate("gpt-5-mini", availableModels), "openai/gpt-5-mini");
 	});
@@ -177,6 +213,17 @@ describe("resolveSubagentModelOverride (cross-session inherit, issue #266)", () 
 		);
 	});
 
+	it("resolves owner/name frontmatter models against the registry", () => {
+		const models = [
+			...availableModels,
+			{ provider: "huggingface", id: "thinkingmachines/Inkling", fullId: "huggingface/thinkingmachines/Inkling" },
+		];
+		assert.equal(
+			resolveSubagentModelOverride("thinkingmachines/Inkling", parentModel, models, "huggingface"),
+			"huggingface/thinkingmachines/Inkling",
+		);
+	});
+
 	it("rejects explicit models that the active registry cannot resolve", () => {
 		assert.throws(
 			() => resolveSubagentModelOverride("does-not-exist", parentModel, availableModels),
@@ -270,6 +317,18 @@ describe("fuzzyResolveModel / normalizeModelSegment", () => {
 		assert.equal(fuzzyResolveModel("Anthropic:Claude-Sonnet-4", registry), "anthropic/claude-sonnet-4");
 		assert.equal(fuzzyResolveModel("anthropic.claude.haiku.4.5", registry), "anthropic/claude-haiku-4-5");
 		assert.equal(fuzzyResolveModel("anthropic/claude.haiku.4.5", registry), "anthropic/claude-haiku-4-5");
+	});
+
+	it("fuzzy-matches owner/name ids when the owner is not a registered provider", () => {
+		const hfRegistry = [
+			...registry,
+			{ provider: "huggingface", id: "thinkingmachines/Inkling", fullId: "huggingface/thinkingmachines/Inkling" },
+		];
+		assert.equal(fuzzyResolveModel("ThinkingMachines/Inkling", hfRegistry), "huggingface/thinkingmachines/Inkling");
+		assert.equal(
+			fuzzyResolveModel("huggingface/ThinkingMachines/Inkling", hfRegistry),
+			"huggingface/thinkingmachines/Inkling",
+		);
 	});
 
 	it("does not switch providers for a qualified query", () => {

--- a/test/unit/model-info.test.ts
+++ b/test/unit/model-info.test.ts
@@ -20,6 +20,22 @@ describe("model info helpers", () => {
 		assert.equal(findModelInfo("openai/gpt-5-mini:high", ambiguousModels, "github-copilot")?.fullId, "openai/gpt-5-mini");
 	});
 
+	it("matches owner/name registry ids without treating the owner as a provider", () => {
+		const hfModels: ModelInfo[] = [
+			{
+				provider: "huggingface",
+				id: "thinkingmachines/Inkling",
+				fullId: "huggingface/thinkingmachines/Inkling",
+				reasoning: true,
+			},
+		];
+		assert.equal(findModelInfo("thinkingmachines/Inkling", hfModels)?.fullId, "huggingface/thinkingmachines/Inkling");
+		assert.equal(
+			findModelInfo("huggingface/thinkingmachines/Inkling", hfModels)?.fullId,
+			"huggingface/thinkingmachines/Inkling",
+		);
+	});
+
 	it("preserves registry API metadata", () => {
 		assert.equal(toModelInfo({ provider: "gateway", id: "model", api: "anthropic-messages" }).api, "anthropic-messages");
 	});


### PR DESCRIPTION
## Summary

Hugging Face model ids are `owner/name` (for example `thinkingmachines/Inkling`). Subagent resolution treated any `/` as `provider/id`, so that id was parsed as provider `thinkingmachines` and failed with `Unknown subagent model`. Pi's main agent already accepts `defaultProvider: huggingface` plus `defaultModel: thinkingmachines/Inkling`.

This keeps exact `provider/id` matches first. If the first path segment is not a registered provider, the whole string is matched as a registry id, including unique `owner/name` ids and the current session provider when that id exists on more than one provider. A first segment that is a registered provider still means `provider/id`. No new frontmatter `provider` field — that name already belongs to `runner.provider`.

Closes #1264

## Test plan

- [x] `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts test/unit/model-info.test.ts`
- [x] `npm run typecheck`
- [ ] CI green
- [ ] Greptile comments addressed or dismissed with a reason

Made with [Cursor](https://cursor.com)