### PR TITLE
fix: wake parent when async workflow children stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve bundled role and parent prompts for source-first discovery in noisy codebases (#1247).
 
 ### Fixed
+- Wake the idle parent when an async workflow child needs attention, and persist that control event on the enclosing workflow. Status already showed the stall; the parent notice did not. Thanks to [@Yibo-Zhang](https://github.com/Yibo-Zhang) for #1266.
 - Resolve Hugging Face-style `owner/name` model ids against the registry instead of treating every slash as `provider/id`. Fully qualified `huggingface/owner/name` still wins, and a first path segment that matches a registered provider still means `provider/id`. Thanks to [@mr-brobot](https://github.com/mr-brobot) for #1264.
 - Make Surf's `gpt-pro` agent an optional package integration instead of a pi-subagents builtin. Users who disabled the old builtin workaround should remove `agentOverrides.gpt-pro.disabled` before using Surf's package agent. Thanks to [@binhex](https://github.com/binhex) for #1256.
 - Keep public structured single-child calls synchronous when `asyncByDefault:false` and `async` is omitted. Thanks to [@Nofuture123](https://github.com/Nofuture123) for #1257.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -956,11 +956,48 @@ function emitAdvisoryControlEvent(pi: ExtensionAPI, channel: string, payload: un
 	}
 }
 
+function persistAsyncWorkflowControlEvent(input: {
+	job: AsyncJobState;
+	event: ControlEvent;
+	controlConfig: ResolvedControlConfig;
+	intercomBridge: IntercomBridgeState;
+	childIntercomTarget?: string;
+}): void {
+	const channels = input.event.type === "active_long_running"
+		? input.controlConfig.notifyChannels.filter((channel) => channel !== "intercom")
+		: input.controlConfig.notifyChannels;
+	if (channels.length === 0) return;
+	const record = {
+		ts: Date.now(),
+		runId: input.job.asyncId,
+		type: "subagent.control",
+		event: input.event,
+		channels,
+		childIntercomTarget: input.childIntercomTarget,
+		noticeText: formatControlNoticeMessage(input.event, input.childIntercomTarget),
+		...(input.intercomBridge.active && input.intercomBridge.orchestratorTarget && channels.includes("intercom")
+			? {
+				intercom: {
+					to: input.intercomBridge.orchestratorTarget,
+					message: formatControlIntercomMessage(input.event, input.childIntercomTarget),
+				},
+			}
+			: {}),
+	};
+	try {
+		fs.appendFileSync(path.join(input.job.asyncDir, "events.jsonl"), `${JSON.stringify(record)}\n`, "utf-8");
+	} catch (error) {
+		if (!isStorageCapacityError(error)) throw error;
+		console.error("Failed to append async workflow control event while storage is full:", error);
+	}
+}
+
 function emitControlNotification(input: {
 	pi: ExtensionAPI;
 	controlConfig: ResolvedControlConfig;
 	intercomBridge: IntercomBridgeState;
 	event: ControlEvent;
+	source?: "foreground" | "async";
 }): void {
 	if (!shouldNotifyControlEvent(input.controlConfig, input.event)) return;
 	const childIntercomTarget = input.intercomBridge.active
@@ -968,7 +1005,7 @@ function emitControlNotification(input: {
 		: undefined;
 	const payload = {
 		event: input.event,
-		source: "foreground" as const,
+		source: input.source ?? "foreground",
 		childIntercomTarget,
 		noticeText: formatControlNoticeMessage(input.event, childIntercomTarget),
 	};
@@ -1878,14 +1915,32 @@ function formatFailedSingleRunOutput(result: SingleResult, displayOutput: string
 	return lines.join("\n");
 }
 
-function createForegroundControlNotifier(data: Pick<ExecutionContextData, "controlConfig" | "intercomBridge">, deps: Pick<ExecutorDeps, "pi" | "state">): (event: ControlEvent) => void {
+function createForegroundControlNotifier(data: Pick<ExecutionContextData, "controlConfig" | "intercomBridge" | "params">, deps: Pick<ExecutorDeps, "pi" | "state">): (event: ControlEvent) => void {
 	return (event) => {
 		applyControlEventToRememberedForegroundRun(deps.state, event);
+		const parentWorkflowRunId = data.params.workflowParentRunId;
+		const asyncWorkflow = typeof parentWorkflowRunId === "string" ? deps.state.asyncJobs.get(parentWorkflowRunId) : undefined;
+		const workflowKey = typeof data.params.workflowKey === "string" && data.params.workflowKey.trim()
+			? data.params.workflowKey.trim()
+			: undefined;
+		const enriched = workflowKey && !event.workflowKey ? { ...event, workflowKey } : event;
+		if (asyncWorkflow) {
+			persistAsyncWorkflowControlEvent({
+				job: asyncWorkflow,
+				event: enriched,
+				controlConfig: data.controlConfig,
+				intercomBridge: data.intercomBridge,
+				childIntercomTarget: data.intercomBridge.active
+					? resolveSubagentIntercomTarget(enriched.runId, enriched.agent, enriched.index)
+					: undefined,
+			});
+		}
 		emitControlNotification({
 			pi: deps.pi,
 			controlConfig: data.controlConfig,
 			intercomBridge: data.intercomBridge,
-			event,
+			event: enriched,
+			source: asyncWorkflow ? "async" : "foreground",
 		});
 	};
 }

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -27,6 +27,7 @@ import {
 	tryImport,
 } from "../support/helpers.ts";
 import registerSubagentExtension from "../../src/extension/index.ts";
+import { handleSubagentControlNotice } from "../../src/extension/control-notices.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
 import {
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
@@ -36,7 +37,7 @@ import {
 	type SubagentDelegationResponse,
 	type SubagentDelegationStarted,
 } from "../../src/api/delegation.ts";
-import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, TEMP_ARTIFACTS_DIR, type AsyncStatus, type SubagentState } from "../../src/shared/types.ts";
+import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, SUBAGENT_CONTROL_EVENT, TEMP_ARTIFACTS_DIR, type AsyncStatus, type ControlEvent, type SubagentState } from "../../src/shared/types.ts";
 import { ACTIVE_RUN_INDEX_DIR } from "../../src/runs/background/active-run-index.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
@@ -944,6 +945,98 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
 		assert.equal(fs.existsSync(activeMarkerPath), false);
+		fs.rmSync(asyncDir, { recursive: true, force: true });
+		fs.rmSync(resultPath, { force: true });
+	});
+
+	it("notifies the parent when an async workflow child needs attention", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("read", { path: "src/example.ts" }), events.toolEnd("read"), events.toolResult("read", "contents")] },
+				{ delay: 2_500, jsonl: [events.assistantMessage("Done")] },
+			],
+		});
+		const asyncJobs: SubagentState["asyncJobs"] = new Map();
+		const piEvents = createEventBus();
+		const controlPayloads: Array<{ event?: ControlEvent; source?: string }> = [];
+		piEvents.on(SUBAGENT_CONTROL_EVENT, (payload) => {
+			controlPayloads.push(payload as { event?: ControlEvent; source?: string });
+		});
+		const executor = makeExecutor([makeAgent("echo")], {
+			control: {
+				enabled: true,
+				needsAttentionAfterMs: 100,
+				activeNoticeAfterMs: 999_999,
+				activeNoticeAfterTurns: 999_999,
+				activeNoticeAfterTokens: 999_999,
+				notifyOn: ["needs_attention"],
+				notifyChannels: ["event"],
+			},
+		}, false, undefined, true, asyncJobs, undefined, undefined, piEvents);
+
+		const result = await executor.execute(
+			"workflow-child-attention-notice",
+			{ workflowScript: `return runs.run("stalled-review", { agent: "echo", task: "Inspect the file" });` },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		const { asyncId: workflowRunId, asyncDir } = result.details;
+		assert.ok(workflowRunId);
+		assert.ok(asyncDir);
+		const statusPath = path.join(asyncDir, "status.json");
+		const eventsPath = path.join(asyncDir, "events.jsonl");
+		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
+		let liveStatus: AsyncStatus | undefined;
+		const activityDeadline = Date.now() + 5_000;
+		while (Date.now() < activityDeadline && !fs.existsSync(resultPath)) {
+			if (fs.existsSync(statusPath)) {
+				const candidate = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatus;
+				if (candidate.activityState === "needs_attention" && !candidate.steps?.[0]?.currentTool) {
+					liveStatus = candidate;
+					break;
+				}
+			}
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+
+		assert.ok(liveStatus, "expected workflow status to expose idle child attention");
+		assert.equal(liveStatus.activityState, "needs_attention");
+		assert.equal(liveStatus.steps?.[0]?.activityState, "needs_attention");
+		assert.equal(liveStatus.steps?.[0]?.workflowKey, "stalled-review");
+
+		const attentionPayload = controlPayloads.find((payload) => payload.event?.type === "needs_attention");
+		assert.ok(attentionPayload, "expected a live parent control event");
+		assert.equal(attentionPayload.source, "async");
+		assert.equal(attentionPayload.event?.workflowKey, "stalled-review");
+		assert.equal(attentionPayload.event?.reason, "idle");
+		const sent: Array<{ options?: { triggerTurn?: boolean } }> = [];
+		handleSubagentControlNotice({
+			pi: { sendMessage(_message, options) { sent.push({ options: options as { triggerTurn?: boolean } }); } },
+			state: { asyncJobs } as SubagentState,
+			visibleControlNotices: new Set(),
+			details: { event: attentionPayload.event!, source: "async" },
+		});
+		assert.equal(sent.length, 1);
+		assert.deepEqual(sent[0]?.options, { triggerTurn: true });
+
+		assert.equal(fs.existsSync(eventsPath), true);
+		const controlRecords = fs.readFileSync(eventsPath, "utf-8")
+			.split("\n")
+			.filter((line) => line.trim())
+			.map((line) => JSON.parse(line) as { type?: string; event?: ControlEvent; runId?: string })
+			.filter((record) => record.type === "subagent.control");
+		const persisted = controlRecords.find((record) => record.event?.type === "needs_attention");
+		assert.ok(persisted, "expected a persisted workflow control event");
+		assert.equal(persisted.runId, workflowRunId);
+		assert.equal(persisted.event?.workflowKey, "stalled-review");
+		assert.equal(controlRecords.filter((record) => record.event?.type === "needs_attention").length, 1);
+
+		const completionDeadline = Date.now() + 5_000;
+		while (!fs.existsSync(resultPath)) {
+			if (Date.now() > completionDeadline) assert.fail("Timed out waiting for async workflow completion");
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
 		fs.rmSync(asyncDir, { recursive: true, force: true });
 		fs.rmSync(resultPath, { force: true });
 	});


### PR DESCRIPTION
## Summary
- Async `workflowScript` children already showed `needs_attention` in status, but the parent got no unsolicited notice or wake because those in-process children were tagged `source: "foreground"` and dropped.
- Persist `subagent.control` on the enclosing workflow `events.jsonl` and deliver the live event as `source: "async"` so an idle parent wakes. Blocking foreground tools keep the existing drop.
- Thanks to [@Yibo-Zhang](https://github.com/Yibo-Zhang) for #1266.

## Test plan
- [x] Focused integration test for idle workflow-child attention, persisted control event, live `source: "async"` payload, and `triggerTurn: true`
- [x] Existing live-activity projection test
- [x] Full `test/integration/single-execution.test.ts`
- [x] Control-notice unit tests
- [x] `tsc --noEmit`
- [ ] CI green
- [ ] Greptile comments on this head addressed or dismissed

Fixes #1266

Made with [Cursor](https://cursor.com)