### PR TITLE
fix: hide console windows for spawned bookkeeping processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Improve bundled role and parent prompts for source-first discovery in noisy codebases (#1247).
 
 ### Fixed
-- Stop Windows opening a console window for each child process spawned for bookkeeping. `spawnSync` and `execFileSync` default to `windowsHide: false`, so the Git, `gh` and PowerShell probes used for process liveness, acceptance snapshots, worktree commands, chat progress and LSP diagnostics each flashed a console window on Windows, which made a busy run disruptive to work alongside. POSIX-only probes are left untouched. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt).
+- Stop Windows opening a console window for each child process spawned for bookkeeping. `spawnSync` and `execFileSync` default to `windowsHide: false`, so the Git, `gh` and PowerShell probes used for process liveness, acceptance snapshots, worktree commands, chat progress and LSP diagnostics each flashed a console window on Windows, which made a busy run disruptive to work alongside. POSIX-only probes are left untouched. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt) for #1274.
 - Keep completed inspect RPC output available from the durable completion replay after result delivery consumes its one-shot payload, including per-child inline result tails (#1254).
 - Wake the idle parent when an async workflow child needs attention, and persist that control event on the enclosing workflow. Status already showed the stall; the parent notice did not. Thanks to [@Yibo-Zhang](https://github.com/Yibo-Zhang) for #1266.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Improve bundled role and parent prompts for source-first discovery in noisy codebases (#1247).
 
 ### Fixed
+- Stop Windows opening a console window for each child process spawned for bookkeeping. `spawnSync` and `execFileSync` default to `windowsHide: false`, so the Git, `gh` and PowerShell probes used for process liveness, acceptance snapshots, worktree commands, chat progress and LSP diagnostics each flashed a console window on Windows, which made a busy run disruptive to work alongside. POSIX-only probes are left untouched. Thanks to [@MarcusNeufeldt](https://github.com/MarcusNeufeldt).
 - Keep completed inspect RPC output available from the durable completion replay after result delivery consumes its one-shot payload, including per-child inline result tails (#1254).
 - Wake the idle parent when an async workflow child needs attention, and persist that control event on the enclosing workflow. Status already showed the stall; the parent notice did not. Thanks to [@Yibo-Zhang](https://github.com/Yibo-Zhang) for #1266.
 

--- a/src/missions/workflow-state.ts
+++ b/src/missions/workflow-state.ts
@@ -59,7 +59,7 @@ function psProcessStartKey(pid: number): string | undefined {
 
 function windowsProcessStartKey(pid: number): string | undefined {
 	try {
-		const raw = execFileSync("powershell.exe", ["-NoProfile", "-Command", `(Get-CimInstance Win32_Process -Filter \"ProcessId=${pid}\").CreationDate`], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 1000 }).trim();
+		const raw = execFileSync("powershell.exe", ["-NoProfile", "-Command", `(Get-CimInstance Win32_Process -Filter \"ProcessId=${pid}\").CreationDate`], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 1000, windowsHide: true }).trim();
 		return raw ? `win:${raw}` : undefined;
 	} catch {
 		return undefined;

--- a/src/runs/background/async-retention.ts
+++ b/src/runs/background/async-retention.ts
@@ -330,7 +330,7 @@ function processStartIdentity(pid: number): string | undefined {
 		}
 	}
 	if (process.platform === "win32") {
-		const result = spawnSync("powershell.exe", ["-NoProfile", "-Command", `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").CreationDate`], { encoding: "utf-8" });
+		const result = spawnSync("powershell.exe", ["-NoProfile", "-Command", `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").CreationDate`], { encoding: "utf-8", windowsHide: true });
 		const started = result.status === 0 ? result.stdout.trim() : "";
 		return started ? `win:${started}` : undefined;
 	}

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1064,7 +1064,7 @@ async function exportSessionHtml(sessionFile: string, outputDir: string, piPacka
 
 function createShareLink(htmlPath: string): { shareUrl: string; gistUrl: string } | { error: string } {
 	try {
-		const auth = spawnSync("gh", ["auth", "status"], { encoding: "utf-8" });
+		const auth = spawnSync("gh", ["auth", "status"], { encoding: "utf-8", windowsHide: true });
 		if (auth.status !== 0) {
 			return { error: "GitHub CLI is not logged in. Run 'gh auth login' first." };
 		}
@@ -1073,7 +1073,7 @@ function createShareLink(htmlPath: string): { shareUrl: string; gistUrl: string 
 	}
 
 	try {
-		const result = spawnSync("gh", ["gist", "create", htmlPath], { encoding: "utf-8" });
+		const result = spawnSync("gh", ["gist", "create", htmlPath], { encoding: "utf-8", windowsHide: true });
 		if (result.status !== 0) {
 			const err = (result.stderr || "").trim() || "Failed to create gist.";
 			return { error: err };

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -946,7 +946,7 @@ function reportEvidenceStatus(report: AcceptanceReport, kind: AcceptanceEvidence
 }
 
 function checkNoStagedFiles(cwd: string): AcceptanceRuntimeCheck {
-	const result = spawnSync("git", ["status", "--short"], { cwd, encoding: "utf-8" });
+	const result = spawnSync("git", ["status", "--short"], { cwd, encoding: "utf-8", windowsHide: true });
 	if (result.status !== 0) {
 		return { id: "no-staged-files", status: "not-applicable", message: "git status unavailable; no staged-files check skipped" };
 	}
@@ -1053,11 +1053,11 @@ interface VerifyWorkspaceState {
 }
 
 function readVerifyWorkspaceState(cwd: string): VerifyWorkspaceState | undefined {
-	const repo = spawnSync("git", ["rev-parse", "--show-toplevel"], { cwd, encoding: "utf-8" });
+	const repo = spawnSync("git", ["rev-parse", "--show-toplevel"], { cwd, encoding: "utf-8", windowsHide: true });
 	if (repo.status !== 0 || !repo.stdout.trim()) return undefined;
 	const repoRoot = fs.realpathSync(repo.stdout.trim());
-	const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf-8" });
-	const diff = spawnSync("git", ["diff", "--binary", "--full-index", "HEAD", "--"], { cwd: repoRoot, encoding: "utf-8", maxBuffer: 50 * 1024 * 1024 });
+	const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf-8", windowsHide: true });
+	const diff = spawnSync("git", ["diff", "--binary", "--full-index", "HEAD", "--"], { cwd: repoRoot, encoding: "utf-8", maxBuffer: 50 * 1024 * 1024, windowsHide: true });
 	if (head.status !== 0 || diff.status !== 0 || !head.stdout.trim()) return undefined;
 	return {
 		kind: "git-tracked",

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -115,7 +115,7 @@ interface RepoState {
 const DEFAULT_WORKTREE_SETUP_HOOK_TIMEOUT_MS = 30000;
 
 function runGit(cwd: string, args: string[]): GitResult {
-	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8" });
+	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8", windowsHide: true });
 	return {
 		stdout: result.stdout ?? "",
 		stderr: result.stderr ?? "",
@@ -338,6 +338,7 @@ function runWorktreeSetupHook(
 	input: WorktreeSetupHookInput,
 ): string[] {
 	const result = spawnSync(hook.hookPath, [], {
+		windowsHide: true,
 		cwd: input.worktreePath,
 		encoding: "utf-8",
 		input: JSON.stringify(input),

--- a/src/watchdog/change-signature.ts
+++ b/src/watchdog/change-signature.ts
@@ -38,7 +38,7 @@ export interface WatchdogRepoChangeSignature {
 }
 
 function git(cwd: string, args: string[]): string | undefined {
-	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 });
+	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024, windowsHide: true });
 	if (result.status !== 0) return undefined;
 	return result.stdout;
 }

--- a/src/watchdog/lsp-diagnostics.ts
+++ b/src/watchdog/lsp-diagnostics.ts
@@ -444,6 +444,7 @@ async function collectWithTypeScriptLanguageServer(input: {
 }): Promise<WatchdogLspResult> {
 	const started = Date.now();
 	const child = spawn(input.command.command, input.command.args, {
+		windowsHide: true,
 		cwd: input.root,
 		stdio: "pipe",
 		env: { ...process.env, NO_COLOR: "1" },

--- a/src/workflows/chat-progress.ts
+++ b/src/workflows/chat-progress.ts
@@ -26,7 +26,7 @@ interface ResolveWorkflowChatProgressInput {
 }
 
 function git(cwd: string, args: string[]): string | undefined {
-	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8" });
+	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8", windowsHide: true });
 	if (result.status !== 0) return undefined;
 	const output = result.stdout.trim();
 	return output || undefined;


### PR DESCRIPTION
## Problem

On Windows, running a workflow makes console windows flash up and steal focus. Under a busy fan-out or a test run it is a steady stream, which makes the machine hard to work on while pi-subagents is doing anything.

The cause is that `child_process` defaults `windowsHide` to `false`. When the spawning process has no console of its own, Windows allocates a **new console window** for each child. pi-subagents spawns a lot of short-lived helpers purely for bookkeeping, so each one flashes a window.

This is most visible when the host runs headless — for example a long-lived server process started by a Windows Scheduled Task, which has no console to inherit. In an interactive terminal the children inherit that console and nothing is visible, which is why this is easy to miss.

## What this changes

Adds `windowsHide: true` to the thirteen spawn sites that can run on Windows:

| File | Sites | Spawned for |
| --- | --- | --- |
| `src/missions/workflow-state.ts` | 1 | PowerShell process-liveness probe |
| `src/runs/background/async-retention.ts` | 1 | PowerShell process-liveness probe |
| `src/runs/background/subagent-runner.ts` | 2 | `gh auth status`, `gh gist create` |
| `src/runs/shared/acceptance.ts` | 4 | `git status`, `git rev-parse` ×2, `git diff` |
| `src/runs/shared/worktree.ts` | 2 | `git -C …`, acceptance hook |
| `src/watchdog/change-signature.ts` | 1 | `git -C …` |
| `src/watchdog/lsp-diagnostics.ts` | 1 | language server |
| `src/workflows/chat-progress.ts` | 1 | `git -C …` |

The package already uses this flag for its orca watchdog spawns, so this only makes the treatment consistent with existing practice rather than introducing a new convention.

## Deliberately not changed

- **POSIX-only probes**, where the flag would be inert: the `ps` / `/bin/ps` calls in `workflow-state.ts`, `async-retention.ts`, `owned-process-tree.ts`, `session-lease.ts` and `external-job-bridge.ts`.
- **`orca-progress-tabs.ts`** — already sets the flag on all of its spawns.
- **Test files.** There are ~124 unhidden spawn sites under `test/`, which is why running the suites on Windows is noisy. I left them alone to keep this diff to runtime behaviour; happy to do them as a follow-up if you would take it.

`windowsHide` only affects whether a console window is created. It does not change stdio, exit codes, or process trees, so there should be no behavioural change beyond the windows not appearing.

## Testing

- `npm run typecheck` — clean.
- Targeted run of the suites covering every touched module (`acceptance`, `async-retention`, `watchdog-change-signature`, `watchdog-lsp-diagnostics`, `workflow-chat-progress`, `worktree`, `orca-progress-tabs`, `session-lease`, `owned-process-tree`): **148 tests, 122 pass, 3 fail**, identical to the same selection on unmodified `main`. The three failures are pre-existing in my environment and unrelated (`acceptance` host-verification cases).
- Re-ran that selection three times to confirm stability; one earlier run also failed `returns a failed result for malformed language-server JSON`, which passes in isolation both with and without this change and passed on all three re-runs. It looks timing-sensitive under load rather than affected here.

I did not run the full suites for this change, since the point of it is that those runs are disruptive on Windows.

## Note

The same pattern exists in the pi host packages themselves, which I am reporting separately upstream — this PR only covers pi-subagents.
