### PR TITLE
fix: tolerate extra fields on external-job providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Tolerate extra fields on registered external-job providers (for example `kind`, `wakeChannels`, or additional operations) so one evolving provider no longer breaks registry reads for every provider. Job payload validation stays strict.
+
 ## [0.52.0] - 2026-08-19
 
 ### Highlights

--- a/src/api/external-job-provider.ts
+++ b/src/api/external-job-provider.ts
@@ -146,8 +146,9 @@ export function validateExternalJobResult(provider: string, value: unknown, fiel
 function validateProvider(value: unknown): ExternalJobProvider {
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("External-job provider must be an object.");
 	const provider = value as Record<string, unknown>;
-	const unknownFields = Object.keys(provider).filter((key) => !["name", "start", "status", "result", "reattach"].includes(key));
-	if (unknownFields.length > 0) throw new Error(`External-job provider has unknown fields: ${unknownFields.join(", ")}.`);
+	// Tolerate extra provider fields (for example kind, wakeChannels, or future
+	// operations) so one evolving provider cannot poison registry reads for all
+	// providers. Payload validation stays strict.
 	const name = validateString(provider.name, "External-job provider name", MAX_PROVIDER_NAME_LENGTH);
 	for (const op of ["start", "status", "result", "reattach"] as const) {
 		if (typeof provider[op] !== "function") throw new Error(`External-job provider '${name}' must expose ${op}().`);

--- a/test/unit/external-job-runner.test.ts
+++ b/test/unit/external-job-runner.test.ts
@@ -712,4 +712,27 @@ describe("external-job runner bridge", () => {
 		assert.equal(result.providerJobId, "job-slow");
 		assert.equal(starts, 1);
 	});
+
+	it("tolerates extra provider fields such as kind, wakeChannels, and follow", async () => {
+		const dir = tempDir("pi-external-job-extra-fields-");
+		registerExternalJobProvider({
+			name: "surf-oracle",
+			kind: "external-job",
+			wakeChannels: ["surf-oracle:finished"],
+			follow: () => { throw new Error("follow must not be called"); },
+			start: () => ({ providerJobId: "job-extra", state: "completed" }),
+			status: () => ({ providerJobId: "job-extra", state: "completed" }),
+			reattach: () => ({ providerJobId: "job-extra", state: "completed" }),
+			result: () => ({ providerJobId: "job-extra", state: "completed", output: "advisor result" }),
+		} as never);
+
+		const result = await serviceUntil(dir, requestExternalJobOperation(dir, {
+			operation: "status",
+			provider: "surf-oracle",
+			providerJobId: "job-extra",
+		}));
+
+		assert.equal(result.providerJobId, "job-extra");
+		assert.equal(result.state, "completed");
+	});
 });


### PR DESCRIPTION
Surf's `surf-oracle` provider registers with `kind`, `wakeChannels`, and a `follow` operation. `validateProvider` rejected any field beyond `name` plus the four core operations, and because `listExternalJobProviders` re-validates on every read, one nonconforming provider in the shared registry broke lookups for every provider.

This drops the unknown-field rejection on the provider object. The required contract stays: `name` plus `start`/`status`/`result`/`reattach` functions, and job payload validation (`validateExternalJobHandle`/`validateExternalJobResult`) is unchanged and strict.

Test: registers a provider carrying the extra fields and asserts a bridge `status` operation succeeds.