### PR TITLE
fix: suggest alternate subagent model provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Suggest the unique alternate provider model when an explicit qualified subagent model is unavailable, without resolving across providers. Thanks to [@lallenlowe](https://github.com/lallenlowe) for #1280.
 - Tolerate extra fields on registered external-job providers (for example `kind`, `wakeChannels`, or additional operations) so one evolving provider no longer breaks registry reads for every provider. Job payload validation stays strict.
 
 ## [0.52.0] - 2026-08-19

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -341,7 +341,7 @@ const SubagentParamProperties = {
 	})),
 	outputMode: Type.Optional(OutputModeOverride),
 	skill: Type.Optional(SkillOverride),
-	model: Type.Optional(Type.String({ description: "Default child model override (e.g. 'anthropic/claude-sonnet-4')" })),
+	model: Type.Optional(Type.String({ description: "Default child model override. Full provider/id values are accepted; bare ids resolve from the active registry." })),
 	outputSchema: Type.Optional(JsonSchemaObject),
 	agentContract: Type.Optional(AgentContractOverride),
 	acceptance: Type.Optional(AcceptanceOverride),

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -205,6 +205,21 @@ function resolveSubagentModelCandidate(
 	return resolvedBase ? `${resolvedBase}${thinkingSuffix}` : undefined;
 }
 
+function suggestAlternateProviderModel(
+	model: string,
+	availableModels: AvailableModelInfo[] | undefined,
+): string | undefined {
+	if (!availableModels || availableModels.length === 0) return undefined;
+	const { baseModel, thinkingSuffix } = splitThinkingSuffix(model);
+	const { queryProvider, queryIdRaw } = splitQualifiedModelQuery(baseModel, availableModels);
+	if (queryProvider === undefined) return undefined;
+	const suggestion = resolveBaseModelCandidate(queryIdRaw, availableModels);
+	if (!suggestion) return undefined;
+	const matched = availableModels.find((entry) => entry.fullId === suggestion);
+	if (!matched || normalizeModelSegment(matched.provider) === queryProvider) return undefined;
+	return `${suggestion}${thinkingSuffix}`;
+}
+
 function resolveRequiredSubagentModelCandidate(
 	model: string,
 	availableModels: AvailableModelInfo[] | undefined,
@@ -212,7 +227,10 @@ function resolveRequiredSubagentModelCandidate(
 ): string {
 	const resolved = resolveSubagentModelCandidate(model, availableModels, preferredProvider);
 	if (resolved) return resolved;
-	throw new Error(`Unknown subagent model '${model}' in the active Pi model registry.`);
+	const suggestion = suggestAlternateProviderModel(model, availableModels);
+	throw new Error(
+		`Unknown subagent model '${model}' in the active Pi model registry.${suggestion ? ` Did you mean '${suggestion}'?` : ""}`,
+	);
 }
 
 export interface ResolveSubagentModelOverrideOptions {

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -235,6 +235,28 @@ describe("resolveSubagentModelOverride (cross-session inherit, issue #266)", () 
 		);
 	});
 
+	it("suggests a unique alternate provider without resolving across providers", () => {
+		assert.throws(
+			() => resolveSubagentModelOverride("openai/claude-sonnet-4:high", parentModel, availableModels),
+			/Unknown subagent model 'openai\/claude-sonnet-4:high'.*Did you mean 'anthropic\/claude-sonnet-4:high'\?/,
+		);
+	});
+
+	it("does not suggest an alternate provider when the bare id is ambiguous or absent", () => {
+		const ambiguous = [
+			...availableModels,
+			{ provider: "github-copilot", id: "claude-sonnet-4", fullId: "github-copilot/claude-sonnet-4" },
+		];
+		assert.throws(
+			() => resolveSubagentModelOverride("openai/claude-sonnet-4", parentModel, ambiguous),
+			(error: unknown) => !String(error).includes("Did you mean"),
+		);
+		assert.throws(
+			() => resolveSubagentModelOverride("openai/does-not-exist", parentModel, availableModels),
+			(error: unknown) => !String(error).includes("Did you mean"),
+		);
+	});
+
 	it("returns undefined when inheriting but no parent model is known", () => {
 		// No parent session model available: fall back to the prior behavior of
 		// emitting no override rather than inventing an invalid one.


### PR DESCRIPTION
## Summary

Fixes #1280 by improving the hard error for an unknown explicit subagent model. If the caller used a qualified `provider/id` and the bare id has one unique match under another provider, the error now suggests that exact `provider/id` without resolving across providers.

The top-level `model` parameter description now also says full `provider/id` values and bare ids are accepted.

Thanks to [@lallenlowe](https://github.com/lallenlowe) for reporting #1280.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/schemas.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

`npm run test:unit` currently has one unrelated local baseline failure on unchanged `main`: `test/unit/agent-disabled.test.ts` sees the ambient `gpt-pro` package agent in the agent-facing list output.
