### PR TITLE
test: avoid package agent ordering assumption

### DIFF
--- a/test/unit/agent-disabled.test.ts
+++ b/test/unit/agent-disabled.test.ts
@@ -177,7 +177,7 @@ describe("builtin agent disabling", () => {
 			{ cwd: tempProject, modelRegistry: { getAvailable: () => [] } },
 		));
 
-		assert.match(text, /Executable agents:\n- helper \(project\): Helper/);
+		assert.match(text, /^- helper \(project\): Helper$/m);
 		assert.doesNotMatch(text, /Disabled builtins:/);
 		for (const name of disabledBuiltinNames) {
 			assert.doesNotMatch(text, new RegExp(`^- ${name} \\(builtin`, "m"));


### PR DESCRIPTION
## Summary

Fixes #1282 by making the disabled-builtin list assertion independent of ambient package agents. The test now checks the exact project helper row anywhere in the executable-agent list instead of requiring it to be the first row after the heading.

Runtime package-agent discovery is unchanged.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-disabled.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

A prior `npm run test:unit` run in this lane passed the fixed test but stopped on a separate full-suite/order issue in `test/unit/subagent-prompt-runtime.test.ts`. The exact file passes on unchanged `main` when run alone, so this PR leaves that separate surface unchanged.
