### PR TITLE
perf: reduce terminal index path work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Reuse validated workflow launch fingerprints during `runs.all` batch setup, reducing focused fingerprint bookkeeping time by 48.7% (#1287).
+- Speed up recent terminal run history reads when the marker history is large and the requested limit is small.
 
 ## [0.52.1] - 2026-08-20
 

--- a/src/runs/background/terminal-run-index.ts
+++ b/src/runs/background/terminal-run-index.ts
@@ -68,11 +68,16 @@ function removeInvalidMarker(marker: string): void {
 	}
 }
 
-function markerFiles(dir: string): string[] {
+interface MarkerFile {
+	dir: string;
+	name: string;
+}
+
+function markerFiles(dir: string): MarkerFile[] {
 	try {
 		return fs.readdirSync(dir, { withFileTypes: true })
 			.filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-			.map((entry) => path.join(dir, entry.name));
+			.map((entry) => ({ dir, name: entry.name }));
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code;
 		if (code === "ENOENT" || code === "ENOTDIR") return [];
@@ -93,12 +98,16 @@ function sessionDirs(asyncDirRoot: string, sessionId: string | undefined): strin
 	}
 }
 
+function recentMarkerFiles(dirs: string[], limit: number): string[] {
+	return dirs.flatMap(markerFiles)
+		.sort((left, right) => right.name.localeCompare(left.name))
+		.slice(0, limit)
+		.map((marker) => path.join(marker.dir, marker.name));
+}
+
 export function readRecentTerminalRunIndex(asyncDirRoot: string, options: { sessionId?: string; limit?: number } = {}): string[] {
 	const limit = options.limit === undefined ? Number.POSITIVE_INFINITY : Math.max(0, Math.floor(options.limit));
-	const candidates = sessionDirs(asyncDirRoot, options.sessionId)
-		.flatMap(markerFiles)
-		.sort((left, right) => path.basename(right).localeCompare(path.basename(left)))
-		.slice(0, limit);
+	const candidates = recentMarkerFiles(sessionDirs(asyncDirRoot, options.sessionId), limit);
 	const runIds: string[] = [];
 	const seen = new Set<string>();
 	for (const marker of candidates) {


### PR DESCRIPTION
Closes #1286.

This reduces terminal run history listing overhead for large marker directories and small limits. The change keeps the same newest-first marker ordering and still validates retained markers against terminal `status.json` files before returning run ids.

Evidence:
- Local benchmark on 30,000 terminal markers with limit 20: representative median 39.123 ms to 19.263 ms, 50.8% lower.
- Fresh review benchmark on 10,000 markers with limit 10: about 2.01x faster.
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-status.test.ts` passed in the writer lane.
- Fresh read-only review found no blockers.

Performance impact: positive and low risk. This touches terminal history listing only. Active status visibility, watcher cadence, and completion delivery are unchanged.
