### PR TITLE
feat: add resultScanLogging option to control slow result-scan logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Add the `resultScanLogging` config to control result scan logging. Thanks to [@apoapostolov](https://github.com/apoapostolov) for #1293.
 - Reuse validated workflow launch fingerprints during `runs.all` batch setup, reducing focused fingerprint bookkeeping time by 48.7% (#1287).
 - Speed up recent terminal run history reads when the marker history is large and the requested limit is small.
 - Reduce repeated serialization while applying async status snapshot byte caps (#1288).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 
-### Changed
+### Added
 - Add the `resultScanLogging` config to control result scan logging. Thanks to [@apoapostolov](https://github.com/apoapostolov) for #1293.
+
+### Changed
 - Reuse validated workflow launch fingerprints during `runs.all` batch setup, reducing focused fingerprint bookkeeping time by 48.7% (#1287).
 - Speed up recent terminal run history reads when the marker history is large and the requested limit is small.
 - Reduce repeated serialization while applying async status snapshot byte caps (#1288).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,16 @@ Blocking `subagent_wait({ id: "..." })` keeps the current tool call open until t
 
 This is different from `waitTool.enabled=false`, which returns immediately without registering any future wake. Provider items remain available only to blocking fleet-wide waits; non-blocking subscriptions require one async or remembered detached foreground run id.
 
+## `resultScanLogging`
+
+```json
+{ "resultScanLogging": "activity" }
+```
+
+Controls how slow result-index scans are logged. Defaults to `"all"`; valid values are `"all"`, `"activity"`, and `"off"`.
+
+The watcher logs `Subagent result scan inspected … scheduled …` through `console.error` whenever a result-index scan passes the slow threshold (500ms). With `"all"` (default) every slow scan is logged, including the periodic healthy rescan that inspects zero files while no async runs are pending. Those empty scans add noise to the session transcript with no signal; choose `"activity"` to log only scans that inspected or scheduled actual work, or `"off"` to silence slow-scan logging entirely. `"off"` does not disable result delivery or the watcher itself, only its slow-scan log line.
+
 ## `forceTopLevelAsync`
 
 ```json

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -110,6 +110,9 @@ function validateConfig(config: Record<string, unknown>): void {
 			|| config.maxActiveAsyncRunsPerSession < 0)) {
 		throw new Error("config.maxActiveAsyncRunsPerSession must be a non-negative integer");
 	}
+	if (config.resultScanLogging !== undefined && config.resultScanLogging !== "all" && config.resultScanLogging !== "activity" && config.resultScanLogging !== "off") {
+		throw new Error('config.resultScanLogging must be "all", "activity", or "off"');
+	}
 	validateMissionStoreConfig(config.missions);
 	validateAuthorityPolicy(config.authorityPolicy);
 	validatePermissionConfig(config.permissions);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -504,6 +504,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			observedCompletionRunIds: () => scheduledRunManager.observedCompletionRunIds(),
 			hasDeliveryDemand: hasResultDeliveryDemand,
 			deliverIntercomResults: config.intercomBridge?.resultDelivery === true,
+			resultScanLogging: config.resultScanLogging ?? "all",
 		},
 	);
 	const { startResultWatcher, primeExistingResults, stopResultWatcher } = resultWatcher;

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -57,6 +57,8 @@ type ResultWatcherDeps = {
 	coalesceDelayMs?: number;
 	/** Returns true while a durable completion source needs periodic delivery checks. */
 	hasDeliveryDemand?: () => boolean;
+	/** Control how slow result-index scans are logged. Defaults to \"all\". */
+	resultScanLogging?: "all" | "activity" | "off";
 	platform?: NodeJS.Platform;
 };
 
@@ -604,6 +606,12 @@ export function createResultWatcher(
 	const logScanStats = (stats: ResultScanStats) => {
 		const elapsed = Date.now() - stats.startedAt;
 		if (elapsed < SLOW_RESULT_SCAN_MS) return;
+		if (deps.resultScanLogging === "off") return;
+		// A scan that inspected and scheduled nothing is a quiet no-op (e.g. the
+		// healthy periodic rescan while no async runs are pending). Under
+		// "activity", skip it so empty scans do not burn context tokens in the
+		// session transcript.
+		if (deps.resultScanLogging === "activity" && stats.files === 0 && stats.scheduled === 0) return;
 		console.error(`Subagent result scan inspected ${stats.files} indexed result file(s), scheduled ${stats.scheduled} in ${elapsed}ms (${resultsDir}).`);
 	};
 	const indexedResultCandidates = (observed: ReadonlySet<string>): string[] => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2026,6 +2026,13 @@ export interface ExtensionConfig {
 	/** Artifact cleanup retention. Set cleanupDays to 0 to disable cleanup. */
 	artifactConfig?: Pick<ArtifactConfig, "cleanupDays">;
 	intercomBridge?: IntercomBridgeConfig;
+	/** Control how slow result-index scans are logged. Defaults to \"all\".
+	 *  - \"all\": log every slow scan, including scans that find nothing.
+	 *  - \"activity\": log only slow scans that found or scheduled work. Silences
+	 *    the periodic healthy rescan that inspects zero files while no async runs
+	 *    are pending, which otherwise spams the session transcript.
+	 *  - \"off\": never log slow result-index scans. */
+	resultScanLogging?: "all" | "activity" | "off";
 	proactiveSkillSubagents?: ProactiveSkillSubagentsConfig | false;
 	scheduledRuns?: ScheduledRunsConfig;
 	/** Durable mission behavior. Missions are automatic by default; set enabled:false to disable auto-create. Explicit mission actions/fields still work. */

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -2186,4 +2186,99 @@ describe("result watcher", () => {
 		}
 	});
 
+	describe("resultScanLogging", () => {
+		const slowScan = () => {
+			const deadline = Date.now() + 700;
+			while (Date.now() < deadline) { /* busy-wait: force elapsed past 500ms threshold */ }
+			return new Set<string>();
+		};
+
+		const captureScanErrors = (): { errors: string[]; restore: () => void } => {
+			const errors: string[] = [];
+			const originalError = console.error;
+			console.error = (...args: unknown[]) => {
+				const message = args.map(String).join(" ");
+				if (message.includes("Subagent result scan")) errors.push(message);
+			};
+			return { errors, restore: () => { console.error = originalError; } };
+		};
+
+		const runScan = (deps: Record<string, unknown>) => {
+			const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-scanlog-"));
+			const state = createState();
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				observedCompletionRunIds: slowScan,
+				...deps,
+			} as Parameters<typeof createRawResultWatcher>[4]);
+			try {
+				watcher.primeExistingResults();
+			} finally {
+				watcher.stopResultWatcher();
+				fs.rmSync(resultsDir, { recursive: true, force: true });
+			}
+		};
+
+		it('logs empty slow scans with the default "all" mode', () => {
+			const { errors, restore } = captureScanErrors();
+			try {
+				runScan({});
+				assert.equal(errors.length, 1);
+				assert.match(errors[0], /inspected 0 indexed result file\(s\), scheduled 0/);
+			} finally {
+				restore();
+			}
+		});
+
+		it('silences empty slow scans under "activity"', () => {
+			const { errors, restore } = captureScanErrors();
+			try {
+				runScan({ resultScanLogging: "activity" });
+				assert.equal(errors.length, 0);
+			} finally {
+				restore();
+			}
+		});
+
+		it('keeps slow scans that found work under "activity"', () => {
+			const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-scanlog-work-"));
+			const state = createState();
+			state.currentSessionId = "session-current";
+			writeIndexedResult(path.join(resultsDir, "activity-run.json"), { id: "activity-run", sessionId: "session-current", runId: "activity-run", success: true, summary: "done" });
+			const { errors, restore } = captureScanErrors();
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				observedCompletionRunIds: slowScan,
+				resultScanLogging: "activity",
+			});
+			try {
+				watcher.primeExistingResults();
+				assert.ok(errors.length >= 1, "expected a scan log for a scan that found work");
+				assert.match(errors[0], /inspected [1-9]/);
+			} finally {
+				watcher.stopResultWatcher();
+				restore();
+				fs.rmSync(resultsDir, { recursive: true, force: true });
+			}
+		});
+
+		it('silences all slow scans under "off"', () => {
+			const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-scanlog-off-"));
+			const state = createState();
+			state.currentSessionId = "session-current";
+			writeIndexedResult(path.join(resultsDir, "off-run.json"), { id: "off-run", sessionId: "session-current", runId: "off-run", success: true, summary: "done" });
+			const { errors, restore } = captureScanErrors();
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				observedCompletionRunIds: slowScan,
+				resultScanLogging: "off",
+			});
+			try {
+				watcher.primeExistingResults();
+				assert.equal(errors.length, 0);
+			} finally {
+				watcher.stopResultWatcher();
+				restore();
+				fs.rmSync(resultsDir, { recursive: true, force: true });
+			}
+		});
+	});
+
 });


### PR DESCRIPTION
## Summary

Adds a configurable `resultScanLogging` option to control `console.error` output from the result watcher's slow-scan log line.

Closes #1292.

## Problem

`logScanStats` in `src/runs/background/result-watcher.ts` emits

```
Subagent result scan inspected 0 indexed result file(s), scheduled 0 in 14588ms (.../async-subagent-results).
```

for **every** scan slower than 500ms — including the periodic healthy rescan that runs while no async runs are pending. On hosts where an empty scan is slow (observed 2–14s, the time is spent before file stat in `observedRunIds()`/candidate enumeration), that one line lands in the session transcript roughly every 60 seconds with zero signal, silently burning context tokens by the thousands over a long session.

## Change

New extension config key, `resultScanLogging`, read from `~/.pi/agent/extensions/subagent/config.json`:

- `"all"` (default): log every slow scan — current behavior, so this is backward compatible.
- `"activity"`: log only slow scans that inspected or scheduled actual work; empty scans become silent.
- `"off"`: never log the slow-scan line. Delivery is unaffected.

Wiring: type added to `ExtensionConfig`, strict validation in `loadConfig`, passed from the extension to `ResultWatcherDeps`, applied in `logScanStats`. Docs in `docs/configuration.md`.

## Validation

- `npm run typecheck` — clean.
- `npm run test:unit` — 2209 pass / 0 fail (4 skipped, pre-existing).
- `test/integration/result-watcher.test.ts` — 44 pass, including 4 new cases for `resultScanLogging` ("all" logs empty slow scans, "activity" silences empty but keeps scans that found work, "off" silences everything). The slow scan is forced deterministically by parking the `observedCompletionRunIds` dep past the 500ms threshold.

## Risk

- Default preserves existing behavior exactly; no delivery-path change.
- `"activity"` intentionally drops the empty-scan diagnostic. The slow empty scan still costs wall time; this only stops the log spam. If you'd rather attack the latency itself, that's #1162/#1188 territory — the option is a stopgap for the token burn.