### PR TITLE
fix: quote Windows executable paths with spaces in acceptance verify commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Add the `resultScanLogging` config to control result scan logging. Thanks to [@apoapostolov](https://github.com/apoapostolov) for #1293.
 
+### Fixed
+- Quote only confidently identified leading Windows executable paths in acceptance verification commands. Thanks to [@srcKod](https://github.com/srcKod) for #1294.
+
 ### Changed
 - Reuse validated workflow launch fingerprints during `runs.all` batch setup, reducing focused fingerprint bookkeeping time by 48.7% (#1287).
 - Speed up recent terminal run history reads when the marker history is large and the requested limit is small.

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -1140,6 +1140,41 @@ async function runMemoizedVerifyCommand(command: AcceptanceVerifyCommand, defaul
 	return evidenced;
 }
 
+/**
+ * On Windows with `shell: true`, cmd.exe parses the command line itself and an
+ * unquoted executable path containing spaces (e.g. `C:\Program Files\...\tool.exe`)
+ * is split at the first space, so cmd tries to run `C:\Program` and fails.
+ *
+ * The command line is ambiguous (we cannot know where the executable ends), so
+ * we only act when we can identify the executable confidently: when the first
+ * whitespace-delimited token does NOT end in a Windows executable extension but
+ * a longer prefix of the command line DOES (e.g. `C:\Program Files\v\tool.exe`).
+ * That prefix is quoted; everything after it is preserved as arguments.
+ *
+ * Commands that already start with a quote, single-token commands, and commands
+ * whose first token already ends in an executable extension are returned
+ * unchanged. Non-Windows platforms pass the command through untouched.
+ */
+export function quoteExecutableForShell(command: string, platform: string = process.platform): string {
+	if (platform !== "win32") return command;
+	const trimmed = command.trimStart();
+	if (trimmed.startsWith("\"")) return command;
+	const firstSpace = trimmed.indexOf(" ");
+	if (firstSpace === -1) return command;
+	const firstToken = trimmed.slice(0, firstSpace);
+	if (/\.(exe|bat|cmd|com|ps1)$/i.test(firstToken)) return command;
+	const match = trimmed.match(/^([^"\s].*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
+	const executable = match?.[1];
+	if (!executable) return command;
+	// Refuse to quote when the candidate prefix contains flag-like tokens
+	// (e.g. `tool --input file.exe`): that means the extension belongs to an
+	// argument, not the executable.
+	if (/\s-/.test(executable)) return command;
+	const rest = trimmed.slice(executable.length);
+	const leading = command.slice(0, command.length - trimmed.length);
+	return `${leading}"${executable}"${rest}`;
+}
+
 function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, options: { signal?: AbortSignal; abortMessage?: string } = {}): Promise<AcceptanceVerifyResult> {
 	return new Promise((resolve) => {
 		const startedAt = Date.now();
@@ -1149,7 +1184,7 @@ function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, 
 		let timedOut = false;
 		let settled = false;
 		let hardKill: NodeJS.Timeout | undefined;
-		const child = spawn(command.command, {
+		const child = spawn(quoteExecutableForShell(command.command), {
 			cwd,
 			env: effectiveVerifyEnv(command.env),
 			shell: true,

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -1162,6 +1162,7 @@ export function quoteExecutableForShell(command: string, platform: string = proc
 	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?\\[^"<>|&*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
 	const executable = match?.[1];
 	if (!executable || !/\s/.test(executable)) return command;
+	if (/[A-Za-z]:\\/.test(executable.slice(3))) return command;
 	const rest = trimmed.slice(executable.length);
 	const leading = command.slice(0, command.length - trimmed.length);
 	return `${leading}"${executable}"${rest}`;

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -1145,11 +1145,9 @@ async function runMemoizedVerifyCommand(command: AcceptanceVerifyCommand, defaul
  * unquoted executable path containing spaces (e.g. `C:\Program Files\...\tool.exe`)
  * is split at the first space, so cmd tries to run `C:\Program` and fails.
  *
- * The command line is ambiguous (we cannot know where the executable ends), so
- * we only act when we can identify the executable confidently: when the first
- * whitespace-delimited token does NOT end in a Windows executable extension but
- * a longer prefix of the command line DOES (e.g. `C:\Program Files\v\tool.exe`).
- * That prefix is quoted; everything after it is preserved as arguments.
+ * The command line is ambiguous, so only an unquoted absolute drive path at the
+ * start is safe to identify as an executable. That path is quoted; everything
+ * after it is preserved as arguments.
  *
  * Commands that already start with a quote, single-token commands, and commands
  * whose first token already ends in an executable extension are returned
@@ -1159,17 +1157,9 @@ export function quoteExecutableForShell(command: string, platform: string = proc
 	if (platform !== "win32") return command;
 	const trimmed = command.trimStart();
 	if (trimmed.startsWith("\"")) return command;
-	const firstSpace = trimmed.indexOf(" ");
-	if (firstSpace === -1) return command;
-	const firstToken = trimmed.slice(0, firstSpace);
-	if (/\.(exe|bat|cmd|com|ps1)$/i.test(firstToken)) return command;
-	const match = trimmed.match(/^([^"\s].*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
+	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&()*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
 	const executable = match?.[1];
 	if (!executable) return command;
-	// Refuse to quote when the candidate prefix contains flag-like tokens
-	// (e.g. `tool --input file.exe`): that means the extension belongs to an
-	// argument, not the executable.
-	if (/\s-/.test(executable)) return command;
 	const rest = trimmed.slice(executable.length);
 	const leading = command.slice(0, command.length - trimmed.length);
 	return `${leading}"${executable}"${rest}`;

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -1157,6 +1157,8 @@ export function quoteExecutableForShell(command: string, platform: string = proc
 	if (platform !== "win32") return command;
 	const trimmed = command.trimStart();
 	if (trimmed.startsWith("\"")) return command;
+	const firstToken = trimmed.match(/^\S+/)?.[0];
+	if (/\.(?:exe|bat|cmd|com|ps1)$/i.test(firstToken ?? "")) return command;
 	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?\\[^"<>|&*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
 	const executable = match?.[1];
 	if (!executable || !/\s/.test(executable)) return command;

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -1157,7 +1157,7 @@ export function quoteExecutableForShell(command: string, platform: string = proc
 	if (platform !== "win32") return command;
 	const trimmed = command.trimStart();
 	if (trimmed.startsWith("\"")) return command;
-	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&()*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
+	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
 	const executable = match?.[1];
 	if (!executable || !/\s/.test(executable)) return command;
 	const rest = trimmed.slice(executable.length);

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -1161,11 +1161,26 @@ export function quoteExecutableForShell(command: string, platform: string = proc
 	if (/\.(?:exe|bat|cmd|com|ps1)$/i.test(firstToken ?? "")) return command;
 	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?\\[^"<>|&*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
 	const executable = match?.[1];
-	if (!executable || !/\s/.test(executable)) return command;
-	if (/[A-Za-z]:\\/.test(executable.slice(3))) return command;
-	const rest = trimmed.slice(executable.length);
-	const leading = command.slice(0, command.length - trimmed.length);
-	return `${leading}"${executable}"${rest}`;
+	if (executable && /\s/.test(executable) && !/[A-Za-z]:\\/.test(executable.slice(3))) {
+		const rest = trimmed.slice(executable.length);
+		const leading = command.slice(0, command.length - trimmed.length);
+		return `${leading}"${executable}"${rest}`;
+	}
+	const extensionlessSpacedFilenameMatch = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?)(?=\s+--|$)/i);
+	const extensionlessSpacedFilename = extensionlessSpacedFilenameMatch?.[1];
+	if (extensionlessSpacedFilename && /\s/.test(extensionlessSpacedFilename.slice(0, extensionlessSpacedFilename.lastIndexOf("\\"))) && !/[A-Za-z]:\\/.test(extensionlessSpacedFilename.slice(3))) {
+		const rest = trimmed.slice(extensionlessSpacedFilename.length);
+		const leading = command.slice(0, command.length - trimmed.length);
+		return `${leading}"${extensionlessSpacedFilename}"${rest}`;
+	}
+	const extensionlessMatch = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?\\[^"<>|&*?\s\r\n]+)(?=\s|$)/i);
+	const extensionlessExecutable = extensionlessMatch?.[1];
+	if (extensionlessExecutable && /\s/.test(extensionlessExecutable) && !/[A-Za-z]:\\/.test(extensionlessExecutable.slice(3)) && !/\s/.test(extensionlessExecutable.slice(extensionlessExecutable.lastIndexOf("\\") + 1))) {
+		const rest = trimmed.slice(extensionlessExecutable.length);
+		const leading = command.slice(0, command.length - trimmed.length);
+		return `${leading}"${extensionlessExecutable}"${rest}`;
+	}
+	return command;
 }
 
 function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, options: { signal?: AbortSignal; abortMessage?: string } = {}): Promise<AcceptanceVerifyResult> {

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -1145,9 +1145,9 @@ async function runMemoizedVerifyCommand(command: AcceptanceVerifyCommand, defaul
  * unquoted executable path containing spaces (e.g. `C:\Program Files\...\tool.exe`)
  * is split at the first space, so cmd tries to run `C:\Program` and fails.
  *
- * The command line is ambiguous, so only an unquoted absolute drive path at the
- * start is safe to identify as an executable. That path is quoted; everything
- * after it is preserved as arguments.
+ * The command line is ambiguous, so only an unquoted absolute drive path with
+ * spaces at the start is safe to identify as an executable. That path is
+ * quoted; everything after it is preserved as arguments.
  *
  * Commands that already start with a quote, single-token commands, and commands
  * whose first token already ends in an executable extension are returned
@@ -1159,7 +1159,7 @@ export function quoteExecutableForShell(command: string, platform: string = proc
 	if (trimmed.startsWith("\"")) return command;
 	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&()*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
 	const executable = match?.[1];
-	if (!executable) return command;
+	if (!executable || !/\s/.test(executable)) return command;
 	const rest = trimmed.slice(executable.length);
 	const leading = command.slice(0, command.length - trimmed.length);
 	return `${leading}"${executable}"${rest}`;

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -1146,8 +1146,8 @@ async function runMemoizedVerifyCommand(command: AcceptanceVerifyCommand, defaul
  * is split at the first space, so cmd tries to run `C:\Program` and fails.
  *
  * The command line is ambiguous, so only an unquoted absolute drive path with
- * spaces at the start is safe to identify as an executable. That path is
- * quoted; everything after it is preserved as arguments.
+ * a space in a directory component is safe to identify as an executable. That
+ * path is quoted; everything after it is preserved as arguments.
  *
  * Commands that already start with a quote, single-token commands, and commands
  * whose first token already ends in an executable extension are returned
@@ -1157,7 +1157,7 @@ export function quoteExecutableForShell(command: string, platform: string = proc
 	if (platform !== "win32") return command;
 	const trimmed = command.trimStart();
 	if (trimmed.startsWith("\"")) return command;
-	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
+	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?\\[^"<>|&*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
 	const executable = match?.[1];
 	if (!executable || !/\s/.test(executable)) return command;
 	const rest = trimmed.slice(executable.length);

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1228,15 +1228,38 @@ describe("quoteExecutableForShell", () => {
 		);
 	});
 
-	it("leaves a command with a later drive-root executable argument unchanged", () => {
-		const command = "C:\\Program Files\\Tool\\verify C:\\path\\to\\file.exe";
-		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	it("quotes an extensionless spaced executable before a later drive-root argument", () => {
+		assert.equal(
+			quoteExecutableForShell("C:\\Program Files\\Tool\\verify C:\\path\\to\\file.exe", "win32"),
+			"\"C:\\Program Files\\Tool\\verify\" C:\\path\\to\\file.exe",
+		);
+	});
+
+	it("quotes an extensionless spaced executable before a flag argument", () => {
+		assert.equal(
+			quoteExecutableForShell("C:\\Program Files\\Tool\\verify --flag", "win32"),
+			"\"C:\\Program Files\\Tool\\verify\" --flag",
+		);
+	});
+
+	it("quotes an extensionless spaced executable filename before a flag argument", () => {
+		assert.equal(
+			quoteExecutableForShell("C:\\Program Files\\my tool --flag", "win32"),
+			"\"C:\\Program Files\\my tool\" --flag",
+		);
 	});
 
 	it("quotes a spaced executable before a later drive-root executable argument", () => {
 		assert.equal(
 			quoteExecutableForShell("C:\\Program Files\\Tool\\verify.exe C:\\path\\to\\file.exe", "win32"),
 			"\"C:\\Program Files\\Tool\\verify.exe\" C:\\path\\to\\file.exe",
+		);
+	});
+
+	it("quotes a spaced executable filename", () => {
+		assert.equal(
+			quoteExecutableForShell("C:\\Program Files\\my tool.exe --flag", "win32"),
+			"\"C:\\Program Files\\my tool.exe\" --flag",
 		);
 	});
 
@@ -1264,8 +1287,25 @@ describe("quoteExecutableForShell", () => {
 		assert.equal(quoteExecutableForShell(command, "win32"), command);
 	});
 
+	it("quotes a shallow spaced executable filename", () => {
+		assert.equal(
+			quoteExecutableForShell("C:\\Program Files\\node script.exe", "win32"),
+			"\"C:\\Program Files\\node script.exe\"",
+		);
+	});
+
+	it("leaves ambiguous shell syntax in extensionless commands unchanged", () => {
+		const command = "C:\\Program Files\\Tool\\verify&echo C:\\arg";
+		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	});
+
 	it("leaves a spaced executable argument after an executable unchanged", () => {
 		const command = "C:\\tools\\tool.exe C:\\Program Files\\data\\file.exe";
+		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	});
+
+	it("leaves a spaced executable-looking argument after an extensionless executable unchanged", () => {
+		const command = "C:\\tools\\verify C:\\Program Files\\data\\file.exe";
 		assert.equal(quoteExecutableForShell(command, "win32"), command);
 	});
 

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1221,6 +1221,13 @@ describe("quoteExecutableForShell", () => {
 		);
 	});
 
+	it("quotes an unquoted Windows executable path with parentheses", () => {
+		assert.equal(
+			quoteExecutableForShell("C:\\Program Files (x86)\\vendor\\tool.exe --flag", "win32"),
+			"\"C:\\Program Files (x86)\\vendor\\tool.exe\" --flag",
+		);
+	});
+
 	it("leaves an already-quoted command unchanged", () => {
 		const command = "\"C:\\Program Files\\vendor\\tool.exe\" --flag";
 		assert.equal(quoteExecutableForShell(command, "win32"), command);

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1228,6 +1228,18 @@ describe("quoteExecutableForShell", () => {
 		);
 	});
 
+	it("leaves a command with a later drive-root executable argument unchanged", () => {
+		const command = "C:\\Program Files\\Tool\\verify C:\\path\\to\\file.exe";
+		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	});
+
+	it("quotes a spaced executable before a later drive-root executable argument", () => {
+		assert.equal(
+			quoteExecutableForShell("C:\\Program Files\\Tool\\verify.exe C:\\path\\to\\file.exe", "win32"),
+			"\"C:\\Program Files\\Tool\\verify.exe\" C:\\path\\to\\file.exe",
+		);
+	});
+
 	it("leaves an already-quoted command unchanged", () => {
 		const command = "\"C:\\Program Files\\vendor\\tool.exe\" --flag";
 		assert.equal(quoteExecutableForShell(command, "win32"), command);

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1247,6 +1247,11 @@ describe("quoteExecutableForShell", () => {
 		assert.equal(quoteExecutableForShell(command, "win32"), command);
 	});
 
+	it("leaves an executable followed by an executable-looking argument unchanged", () => {
+		const command = "C:\\tools\\node script.exe";
+		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	});
+
 	it("passes commands through unchanged on non-Windows platforms", () => {
 		const command = "/opt/my tools/runner --flag";
 		assert.equal(quoteExecutableForShell(command, "linux"), command);

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1235,6 +1235,11 @@ describe("quoteExecutableForShell", () => {
 		assert.equal(quoteExecutableForShell(command, "win32"), command);
 	});
 
+	it("leaves a Windows executable path without spaces unchanged", () => {
+		const command = "C:\\tools\\tool.exe --flag";
+		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	});
+
 	it("passes commands through unchanged on non-Windows platforms", () => {
 		const command = "/opt/my tools/runner --flag";
 		assert.equal(quoteExecutableForShell(command, "linux"), command);

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -12,6 +12,7 @@ import {
 	formatAcceptancePrompt,
 	normalizeGateAcceptance,
 	parseAcceptanceReport,
+	quoteExecutableForShell,
 	resolveEffectiveAcceptance,
 	stripAcceptanceReport,
 	validateAcceptanceInput,
@@ -1209,5 +1210,39 @@ describe("acceptance gates", () => {
 		assert.match(validateAcceptanceInput({ review: { required: "yes" } }).join("\n"), /acceptance\.review\.required must be a boolean/);
 		assert.match(validateAcceptanceInput({ stopRules: [123] }).join("\n"), /acceptance\.stopRules\[0\] must be a string/);
 		assert.match(validateAcceptanceInput({ surprise: true }).join("\n"), /acceptance\.surprise is not supported/);
+	});
+});
+
+describe("quoteExecutableForShell", () => {
+	it("quotes an unquoted Windows executable path containing spaces", () => {
+		assert.equal(
+			quoteExecutableForShell("C:\\Program Files\\vendor\\tool.exe --flag", "win32"),
+			"\"C:\\Program Files\\vendor\\tool.exe\" --flag",
+		);
+	});
+
+	it("leaves an already-quoted command unchanged", () => {
+		const command = "\"C:\\Program Files\\vendor\\tool.exe\" --flag";
+		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	});
+
+	it("leaves a single-token command unchanged", () => {
+		assert.equal(quoteExecutableForShell("phpunit", "win32"), "phpunit");
+	});
+
+	it("leaves a first token without spaces unchanged", () => {
+		const command = "node script.js --check";
+		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	});
+
+	it("passes commands through unchanged on non-Windows platforms", () => {
+		const command = "/opt/my tools/runner --flag";
+		assert.equal(quoteExecutableForShell(command, "linux"), command);
+		assert.equal(quoteExecutableForShell(command, "darwin"), command);
+	});
+
+	it("does not quote when the extension belongs to a flag argument", () => {
+		const command = "tool --input file.exe";
+		assert.equal(quoteExecutableForShell(command, "win32"), command);
 	});
 });

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1241,8 +1241,9 @@ describe("quoteExecutableForShell", () => {
 		assert.equal(quoteExecutableForShell(command, "darwin"), command);
 	});
 
-	it("does not quote when the extension belongs to a flag argument", () => {
-		const command = "tool --input file.exe";
-		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	it("leaves ambiguous Windows commands unchanged", () => {
+		for (const command of ["tool file.exe", "cmd /c tool.exe", "echo hi > out.exe"]) {
+			assert.equal(quoteExecutableForShell(command, "win32"), command);
+		}
 	});
 });

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1252,6 +1252,11 @@ describe("quoteExecutableForShell", () => {
 		assert.equal(quoteExecutableForShell(command, "win32"), command);
 	});
 
+	it("leaves a spaced executable argument after an executable unchanged", () => {
+		const command = "C:\\tools\\tool.exe C:\\Program Files\\data\\file.exe";
+		assert.equal(quoteExecutableForShell(command, "win32"), command);
+	});
+
 	it("passes commands through unchanged on non-Windows platforms", () => {
 		const command = "/opt/my tools/runner --flag";
 		assert.equal(quoteExecutableForShell(command, "linux"), command);


### PR DESCRIPTION
## Problem

On Windows, acceptance `verify` commands run through `cmd.exe` (`spawn(..., { shell: true })`). An unquoted executable path containing spaces is split at the first space, so a verify command like:

```
C:\Program Files\PHP\php.exe vendor/bin/phpunit
```

makes cmd try to run `C:\Program` and the verify step fails with `'C:\Program' is not recognized as an internal or external command` — even though the command works fine in a real terminal. This affects any tool installed under `Program Files` (PHP, Composer-installed binaries, most vendor toolchains).

## Fix

`quoteExecutableForShell()` quotes the leading executable when it can be identified confidently:

- The first whitespace-delimited token does **not** end in a Windows executable extension, but a longer prefix of the command line **does** (e.g. `C:\Program Files\vendor\tool.exe`) → that prefix is quoted, everything after it is preserved as arguments.
- Already-quoted commands, single-token commands, and commands whose first token already ends in an executable extension are returned unchanged.
- Refuses to quote when the candidate prefix contains flag-like tokens (e.g. `tool --input file.exe`), so an extension belonging to an argument is never misquoted.
- Non-Windows platforms pass the command through untouched.

## Tests

6 new unit tests in `test/unit/acceptance.test.ts` covering: quoting a spaced path, already-quoted passthrough, single-token passthrough, no-space first token, flag-argument guard, and non-Windows passthrough. Full file: 52/52 passing, `tsc --noEmit` clean.