### PR TITLE
fix: keep forked subagent sessions out of pi -c top-level discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Speed up recent terminal run history reads when the marker history is large and the requested limit is small.
 - Reduce repeated serialization while applying async status snapshot byte caps (#1288).
 
+### Fixed
+- Keep forked subagent sessions out of top-level `pi -c` discovery by storing them under the parent session root. Thanks to [@xz-dev](https://github.com/xz-dev) for #1297.
+
 ## [0.52.1] - 2026-08-20
 
 ### Highlights

--- a/src/shared/fork-context.ts
+++ b/src/shared/fork-context.ts
@@ -208,7 +208,23 @@ export function createForkContextResolver(
 	const openSession = options.openSession
 		?? sessionManager.openSession
 		?? ((file: string, dir?: string) => SessionManager.open(file, dir));
-	const sessionDir = sessionManager.getSessionDir?.();
+	// Fork files must not land in the parent's top-level session directory.
+	// Pi's recent-session discovery (`pi -c` → findMostRecentSession) is
+	// non-recursive and picks the largest-mtime *.jsonl in that directory, so
+	// a still-running forked subagent — which keeps appending after the parent
+	// went idle — would hijack the next `pi -c` away from the conversation the
+	// user actually left. Nesting fork sessions in a per-parent directory keeps
+	// them invisible to that discovery; the `parentSession` header still
+	// records the tree relationship. The directory mirrors
+	// getSubagentSessionRoot() plus a "forks" level so fork files never sit
+	// loose next to run-N/ result directories. Derived from the file path
+	// rather than getSessionDir() so it also works when the manager cannot
+	// report its directory.
+	const sessionDir = path.join(
+		path.dirname(parentSessionFile),
+		path.basename(parentSessionFile, ".jsonl"),
+		"forks",
+	);
 	const cachedResolutions = new Map<number, ForkContextResolution>();
 
 	const resolveFork = (index = 0): ForkContextResolution => {

--- a/test/unit/fork-context.test.ts
+++ b/test/unit/fork-context.test.ts
@@ -192,6 +192,51 @@ describe("createForkContextResolver", () => {
 		}
 	});
 
+	it("nests forked sessions under a per-parent directory so pi -c never picks them", () => {
+		// Regression test: fork files used to be created as top-level siblings of
+		// the parent session. Pi's findMostRecentSession (`pi -c`) scans that
+		// directory non-recursively and picks the largest-mtime *.jsonl, so a
+		// still-running forked subagent out-writes the idle parent and the next
+		// `pi -c` resumed the subagent instead of the conversation the user left.
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-nested-"));
+		try {
+			const sessionDir = path.join(tempDir, "sessions");
+			const parent = SessionManager.create(tempDir, sessionDir);
+			parent.appendMessage({ role: "user", content: "parent prompt" });
+			parent.appendMessage({ role: "assistant", content: "parent response" });
+			const parentSessionFile = parent.getSessionFile();
+			const leafId = parent.getLeafId();
+
+			assert.ok(parentSessionFile);
+			assert.ok(leafId);
+
+			const resolver = createForkContextResolver({
+				getSessionFile: () => parentSessionFile,
+				getLeafId: () => leafId,
+				getSessionDir: () => sessionDir,
+			}, "fork");
+
+			const childSessionFile = resolver.sessionFileForIndex(0);
+			assert.ok(childSessionFile);
+			assert.equal(fs.existsSync(childSessionFile), true);
+
+			// The fork is nested under <sessionDir>/<parentBase>/forks/, never a
+			// top-level sibling of the parent.
+			assert.equal(
+				path.dirname(childSessionFile),
+				path.join(sessionDir, path.basename(parentSessionFile, ".jsonl"), "forks"),
+			);
+			// Top-level listing — what pi -c sees — still contains only the parent.
+			const topLevel = fs.readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"));
+			assert.deepEqual(topLevel, [path.basename(parentSessionFile)]);
+			// The official parentSession header still records the tree relationship.
+			const header = JSON.parse(fs.readFileSync(childSessionFile, "utf-8").split("\n")[0]);
+			assert.equal(header.parentSession, parentSessionFile);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("fails clearly for an unflushed user-only parent", () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-user-only-"));
 		try {


### PR DESCRIPTION
## Problem

When pi exits while a fork-context subagent (`context: "fork"`) is still running — or simply after one has written — the next `pi -c` resumes the **subagent's** session instead of the parent conversation.

### Root cause chain

1. `createForkContextResolver` calls pi core's `createBranchedSession(leafId)` through `SessionManager.open(parentSessionFile, sessionDir)` with `sessionDir` = the parent's **top-level** session directory. Pi core writes the fork file to `join(sessionDir, ...)` — as a sibling of the parent, with the official `parentSession` header.
2. The forked child process keeps appending to that file (`--session <forkFile>`), so its mtime advances past the parent's last write (the parent is idle while the subagent works).
3. `pi -c` → `findMostRecentSession` scans the top-level session dir **non-recursively** and picks the largest-mtime `*.jsonl`. It does not look at `parentSession` (and shouldn't blindly: user-driven `/fork` sessions carry the same header and *should* stay resumable).
4. No exit path — pi core shutdown, this extension's `session_shutdown`, or anything else — re-touches the parent file, so the ordering is already wrong before any exit, clean or otherwise.

Observed live: a parent session last written at 09:47Z, four fork children written 09:52–09:53Z; `pi -c` resumed one of the children. Because the fork only carries the parent's history up to the fork point, the resumed tree also appeared to have lost the parent's later turns.

## Fix

Derive the branched-session target directory from the parent session file instead of the top-level session directory:

```
<sessionDir>/<parentFileBase>/forks/<timestamp>_<id>.jsonl
```

This mirrors the existing `getSubagentSessionRoot()` convention already used for fresh-context subagent sessions (`<parentBase>/<runId>/run-N/`), and `trustedSessionRootsForStatus` already treats that per-parent root as trusted.

Fork files therefore never enter the non-recursive top-level candidate set at all — which is what makes the fix robust across **every** exit mode, including SIGKILL and host/VM crashes where no shutdown/exit hook can run (an mtime-touch approach cannot cover those).

## What stays the same

- The `parentSession` header is still written by pi core, so the session-tree relationship is preserved.
- Child processes resume fork files by absolute path via `--session`, so location is irrelevant to them.
- The fallback persistence path in `resolveFork` already `mkdirSync(path.dirname(sessionFile), { recursive: true })`, and pi core's `SessionManager` constructor creates the session dir recursively as well.

## Test

New regression test in `test/unit/fork-context.test.ts`: `nests forked sessions under a per-parent directory so pi -c never picks them` — drives the real `SessionManager` opener, asserts the fork lands in `<sessionDir>/<parentBase>/forks/`, that the top-level listing still contains only the parent, and that the `parentSession` header is intact.

`npm run typecheck` clean; `test/unit/fork-context.test.ts` 24/24 pass; full unit suite matches baseline (13 pre-existing failures in agent-management/package-agent tests reproduce identically on `upstream/main` without this change).