### PR TITLE
fix: preserve council advisor context defaults

### DIFF
--- a/prompts/council.md
+++ b/prompts/council.md
@@ -22,9 +22,11 @@ the question is trivial or settled, answer directly instead of convening a counc
   unknown agent.
 - Otherwise list agents with `subagent({ action: "list" })`, then prefer 2–3
   executable names that start with `council-`.
-- If fewer than two profiles are available, fill the roster with fresh-context
-  `reviewer`, then `scout`, until it has two advisors. Note the fallback in the
-  memo.
+- If fewer than two profiles are available, fill the roster with `oracle`, then
+  `reviewer`, until it has two advisors. Launch fallback `oracle` with
+  `context: "fork"` so global defaults cannot remove its parent-chat context.
+  Let `reviewer` use its normal profile context. Note the fallback and known
+  context modes in the memo.
 - Use the normal single-oracle loop only when a requested roster or unavailable
   builtins leaves fewer than two advisors. Label the memo as degraded mode.
 
@@ -34,14 +36,14 @@ exceed 4.
 ## Pass 1: independent reports
 
 Launch one async `workflowScript` with `runs.all` and a stable key for each advisor.
-Every advisor run sets `context: "fresh"` explicitly. This is required for fallback
-`reviewer` and `scout` advisors and also applies to `council-*` advisors. Each task
-includes the brief, the assigned role, and these rules:
+Set `context` when the selected advisor has a known profile context or a fallback
+rule requests one, because a global default can otherwise override that profile.
+Set `context: "fork"` for fallback `oracle`. If no advisor context is known, omit
+`context` and disclose the unknown runtime default in the memo. Each task includes
+the brief, the assigned role, and these rules:
 
-Use `{ key, agent, context: "fresh", task }` for every `runs.all` launch item.
-
-- Fresh context. Inspect the repository and supplied evidence directly. You do not
-  see other advisors and must not ask about them.
+- Inspect the repository and supplied evidence directly. You do not see other
+  advisors and must not ask about them.
 - Read-only. Do not edit files, run mutating commands, commit, or push.
 - Do not spawn subagents. Keep the report to about 600 words or less.
 
@@ -108,7 +110,8 @@ Write the memo yourself. Do not delegate it. Include:
 - Unresolved owner decisions
 - Evidence: paths, commands, and run ids; do not inline transcripts
 - Confidence and what would change the decision
-- Process note: roster, roles, passes, fallbacks, and degraded modes
+- Process note: roster, roles, passes, fallbacks, degraded modes, and known advisor
+  context modes. State that fallback `oracle` is context-aware and forked.
 
 Question and options from the slash command invocation:
 

--- a/skills/council-mode/SKILL.md
+++ b/skills/council-mode/SKILL.md
@@ -18,7 +18,8 @@ trivial or settled question, or for implementation work. Read
 
 Roles such as architect, skeptic, operator, and performance reviewer belong to the
 `/council` request. A `council-*` profile defines only model, tools, context, and
-output defaults.
+output defaults. Its profile configuration or explicit invocation owns its context
+choice.
 
 Create model-based profiles in your user or project agent directory. Do not add
 them to this package. This is a valid example; roles still come from `/council`:
@@ -44,11 +45,13 @@ concise, cited advice using the report contract in the council task.
 
 After `subagent({ action: "list" })`, prefer 2–3 executable names that start with
 `council-`. The prefix is a naming convention, not runtime selection. If fewer
-than two profiles are available, fill the roster with fresh-context `reviewer`, then
-`scout`, until it has two advisors. Note the fallback in the memo. Use the
-normal single-oracle consultation loop only when a requested roster or unavailable
-builtins leaves fewer than two advisors. Label that result as degraded mode. Never
-use more than four advisors.
+than two profiles are available, fill the roster with `oracle`, then `reviewer`,
+until it has two advisors. Launch fallback `oracle` with `context: "fork"` so
+global defaults cannot remove its parent-chat context. Let fallback `reviewer`
+use its normal profile context. Note the fallback and known context modes in the
+memo. Use the normal single-oracle consultation loop only when a requested roster
+or unavailable builtins leaves fewer than two advisors.
+Label that result as degraded mode. Never use more than four advisors.
 
 Pass 1 is independent reports. Pass 2 is one cross-exam. The default pass cap is
 2. Run pass 3 only when `--max-passes 3` was requested and a material dispute can
@@ -58,12 +61,13 @@ be settled by evidence an advisor can produce. Never run an unbounded loop.
 
 1. The parent writes a brief with the question, scope, non-goals, evidence targets,
    roster, roles, and pass cap.
-2. Launch one async `workflowScript` with `runs.all` for independent fresh-context
-advisor reports. Use stable keys and set `context: "fresh"` explicitly on every
-advisor run. This is required for fallback `reviewer` and `scout` advisors and
-   also applies to `council-*` advisors. Each advisor is read-only and must not
-   spawn children, edit files, run mutating commands, commit, or push.
-   Use `{ key, agent, context: "fresh", task }` for every `runs.all` launch item.
+2. Launch one async `workflowScript` with `runs.all` for independent advisor
+reports. Use stable keys. Set `context` when the selected advisor has a known
+   profile context or a fallback rule requests one, because a global default can
+   otherwise override that profile. Set `context: "fork"` for fallback `oracle`.
+   If no advisor context is known, omit `context` and disclose the unknown runtime
+   default in the memo. Each advisor is read-only and must not spawn children,
+   edit files, run mutating commands, commit, or push.
 3. The parent synthesizes a claim matrix in session. It contains agreements,
    disputed claims, missing proof, owner decisions, and a relay set of at most five
    high-impact claims per advisor. Do not delegate this synthesis.
@@ -110,8 +114,9 @@ decisions. Never add a round for polish or symmetry.
 
 The parent memo states the question and scope, recommendation, rationale, accepted
 and rejected feedback with reasons, owner decisions, evidence and run ids,
-confidence, what would change the decision, and the roster, roles, passes, and
-fallbacks.
+confidence, what would change the decision, and the roster, roles, passes,
+fallbacks, and known advisor context modes. State that fallback `oracle` is
+context-aware and forked.
 
 Council mode is not agent-to-agent chat, a transcript dump, mutation authority,
 auto-escalation to writer lanes, or a council UI. Escalate to a writer only after


### PR DESCRIPTION
Closes #1298.

This follows up #1296 after owner feedback on council fallback behavior.

It changes the packaged `/council` prompt and `council-mode` skill so the default fallback is `oracle` + `reviewer`, not `reviewer` + `scout`. It also stops forcing every advisor to `context: "fresh"`; advisors use their profile/default context unless the user or profile explicitly requests otherwise. The fallback oracle keeps its normal forked context so it can see the parent conversation and preserve owner intent.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-overrides.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-frontmatter.test.ts test/unit/skills-fallback.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm pack --dry-run --json` package-resource assertion

Fresh review found no issues on `48e482a39942f26d9e1f56d8b4c7f491556381ea`.