### PR TITLE
docs: document council context fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 - Keep forked subagent sessions out of top-level `pi -c` discovery by storing them under the parent session root. Thanks to [@xz-dev](https://github.com/xz-dev) for #1297.
+- Preserve `/council` advisor context defaults during fallback and cross-exam runs (#1298).
 
 ## [0.52.1] - 2026-08-20
 


### PR DESCRIPTION
Changelog-only follow-up after PR #1299 landed the council context implementation and closed #1298.

This adds the missing Unreleased changelog line for the council advisor context fix. No implementation files change.

Validation:
- Fresh review: no issues found at 39349a342a1ced506fdcccbf474287632836a36a
- `git diff --check origin/main...HEAD`