### PR TITLE
docs: improve council workflow receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Quote only confidently identified leading Windows executable paths in acceptance verification commands. Thanks to [@srcKod](https://github.com/srcKod) for #1294.
 
 ### Changed
+- Make `/council` easier to supervise with structured advisor contracts,
+  aggregate pass receipts, and visible pass checkpoints (#1301).
 - Reuse validated workflow launch fingerprints during `runs.all` batch setup, reducing focused fingerprint bookkeeping time by 48.7% (#1287).
 - Speed up recent terminal run history reads when the marker history is large and the requested limit is small.
 - Reduce repeated serialization while applying async status snapshot byte caps (#1288).

--- a/prompts/council.md
+++ b/prompts/council.md
@@ -33,85 +33,15 @@ the question is trivial or settled, answer directly instead of convening a counc
 Roles belong to this request, not to the profiles. Keep the roster at 2–3 and never
 exceed 4.
 
-## Pass 1: independent reports
+## Run the protocol
 
-Launch one async `workflowScript` with `runs.all` and a stable key for each advisor.
-Set `context` when the selected advisor has a known profile context or a fallback
-rule requests one, because a global default can otherwise override that profile.
-Set `context: "fork"` for fallback `oracle`. If no advisor context is known, omit
-`context` and disclose the unknown runtime default in the memo. Each task includes
-the brief, the assigned role, and these rules:
+Use the canonical workflow, structured advisor contracts, aggregate pass receipts,
+and memo requirements in `skills/council-mode/SKILL.md`. Keep the parent as the
+only synthesizer and decision maker. Do not introduce a chair advisor, peer chat,
+or transcript sharing.
 
-- Inspect the repository and supplied evidence directly. You do not see other
-  advisors and must not ask about them.
-- Read-only. Do not edit files, run mutating commands, commit, or push.
-- Do not spawn subagents. Keep the report to about 600 words or less.
-
-Do not set `clarify`, `worktree`, `gate`, turn budgets, tool budgets, or tight usage
-budgets. Record every returned run id. Yield for the async workflow. Do not poll.
-
-Require these exact report headings:
-
-1. Recommendation
-2. Key evidence
-3. Assumptions — mark each verified or unverified
-4. Risks
-5. Confidence — high, medium, or low, with reason
-6. Claims to challenge — up to three falsifiable claims
-7. Owner decisions
-8. What would change my mind
-
-## Claim matrix
-
-After pass 1, build the claim matrix yourself in this parent session. Do not use a
-workflowScript or child for this synthesis. Include agreements and evidence status,
-disputed claims and positions, missing proof, merged owner decisions, and a relay
-set. Relay at most five disputed, high-impact, or missing-proof claims per advisor.
-Drop style disagreements.
-
-## Pass 2: curated cross-exam
-
-Launch a second async `workflowScript` with `runs.all`. Resume each retained advisor
-with `runs.run("cross-<name>", { resume: "<run id>", task: "<packet>" })`. Resume
-excludes `agent`, requires a non-empty task, and does not support `gate`. Each
-resume returns a new run id. Record it and use the latest id for any pass 3.
-
-For a non-resumable advisor, launch a fresh same-profile advisor with that
-advisor's own pass-1 report and the packet. Mark it in the memo as a
-fresh-context fallback, not a true cross-exam.
-
-A packet contains only disputed claims, strong conflicting evidence, missing proof,
-owner decisions, and high-impact risks. Attribute peers only as "another advisor".
-Never include full peer reports. For each relayed claim, require exactly one of
-`accept`, `reject`, `refine`, or `owner-decision`, with cited evidence. Then require
-whether the recommendation changed and why. Put new critical evidence under
-`Out-of-scope findings` without opening a new debate.
-
-## Optional pass 3 and stop
-
-Run pass 3 only when `--max-passes 3` was requested and a disputed claim materially
-affects the recommendation and can plausibly be settled by evidence an advisor can
-produce. Never run more than three advisor passes or resume an advisor more than
-`max-passes - 1` times.
-
-Stop when the council converges, the cap is reached, fallback fails, or the user
-interrupts. Converged means no disputed claim remains that is both material to the
-recommendation and resolvable by evidence. Make all other disagreement an owner
-decision. Do not add rounds for polish, re-litigation, or fairness.
-
-## Decision memo
-
-Write the memo yourself. Do not delegate it. Include:
-
-- Question and scope
-- Recommendation and rationale
-- Accepted feedback, with advisor and pass
-- Rejected feedback, with a short reason
-- Unresolved owner decisions
-- Evidence: paths, commands, and run ids; do not inline transcripts
-- Confidence and what would change the decision
-- Process note: roster, roles, passes, fallbacks, degraded modes, and known advisor
-  context modes. State that fallback `oracle` is context-aware and forked.
+Use its required boundary checkpoints, yield for each async workflow without
+polling, and write its required final memo.
 
 Question and options from the slash command invocation:
 

--- a/skills/council-mode/SKILL.md
+++ b/skills/council-mode/SKILL.md
@@ -61,21 +61,31 @@ be settled by evidence an advisor can produce. Never run an unbounded loop.
 
 1. The parent writes a brief with the question, scope, non-goals, evidence targets,
    roster, roles, and pass cap.
-2. Launch one async `workflowScript` with `runs.all` for independent advisor
-reports. Use stable keys. Set `context` when the selected advisor has a known
-   profile context or a fallback rule requests one, because a global default can
-   otherwise override that profile. Set `context: "fork"` for fallback `oracle`.
-   If no advisor context is known, omit `context` and disclose the unknown runtime
-   default in the memo. Each advisor is read-only and must not spawn children,
-   edit files, run mutating commands, commit, or push.
-3. The parent synthesizes a claim matrix in session. It contains agreements,
+2. Before Pass 1, tell the user the roster, roles, requested or known context
+   modes, and pass cap. Use a stable key, `phase`, and concise `label` for every
+   workflow child. For example, use `advisor-oracle`, `phase: "Council pass 1"`,
+   and `label: "Oracle — intent and consistency"`.
+3. Launch one async `workflowScript` with `runs.all` for independent advisor
+   reports. Set `context` when the selected advisor has a known profile context or
+   a fallback rule requests one, because a global default can otherwise override
+   that profile. Set `context: "fork"` for fallback `oracle`. If no advisor context
+   is known, omit `context` and disclose the unknown runtime default in the memo.
+   Each advisor is read-only and must not spawn children, edit files, run mutating
+   commands, commit, or push. Set `output: false` unless separate advisor artifacts
+   are explicitly requested or useful for the decision.
+4. Return one aggregate Pass 1 receipt. After it completes, tell the user the
+   completion count, agreement count, dispute count, and whether Pass 2 is needed.
+5. The parent synthesizes a claim matrix in session. It contains agreements,
    disputed claims, missing proof, owner decisions, and a relay set of at most five
    high-impact claims per advisor. Do not delegate this synthesis.
-4. Launch a second async `workflowScript` with `runs.all` resume calls. Each task
-   is a curated challenge packet, not a peer transcript. A resume requires a
-   retained run id and a non-empty task. It excludes `agent` and rejects `gate`.
-   Record the new run id from every resume. Pass 3 resumes those latest ids.
-5. The parent writes the final memo. Do not delegate it.
+6. Before Pass 2, tell the user how many claims are relayed and why each is
+   material. Launch a second async `workflowScript` with `runs.all` resume calls.
+   Each task is a curated challenge packet, not a peer transcript. A resume requires
+   a retained run id and a non-empty task. It excludes `agent` and rejects `gate`.
+   Record the new run id from every resume. Pass 3 resumes those latest ids. Return
+   one aggregate Pass 2 receipt.
+7. After Pass 2, tell the user whether the council converged or which owner
+   decisions remain. The parent writes the final memo. Do not delegate it.
 
 If an advisor is not resumable, run the same profile in fresh context with its own
 pass-1 report and the challenge packet. Label that response as a fresh-context
@@ -84,26 +94,123 @@ fallback, not a true cross-exam.
 Do not set `clarify`, `worktree`, `gate`, turn budgets, tool budgets, or tight usage
 budgets on advisors. Bound work through the roster, pass cap, and report length.
 
-## Advisor contracts
+## Advisor contracts and pass receipts
 
-Pass-1 reports are at most about 600 words and use these headings:
+Pass-1 reports are at most about 600 words. Give each advisor the same
+`outputSchema`, so reports are comparable without heading cleanup. The following
+shape is a contract template. Use the runtime schema syntax supported by the
+workflow and keep narrative fields as strings:
 
-1. Recommendation
-2. Key evidence
-3. Assumptions — marked verified or unverified
-4. Risks
-5. Confidence — high, medium, or low, with reason
-6. Claims to challenge — at most three falsifiable claims
-7. Owner decisions
-8. What would change my mind
+```js
+const pass1OutputSchema = {
+  type: "object",
+  required: [
+    "recommendation", "evidence", "assumptions", "risks", "confidence",
+    "challengeClaims", "ownerDecisions", "changeMyMind"
+  ],
+  properties: {
+    recommendation: { type: "string" },
+    evidence: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["claim", "sources"],
+        properties: {
+          claim: { type: "string" },
+          sources: { type: "array", items: { type: "string" } }
+        }
+      }
+    },
+    assumptions: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["assumption", "status"],
+        properties: {
+          assumption: { type: "string" },
+          status: { enum: ["verified", "unverified"] }
+        }
+      }
+    },
+    risks: { type: "array", items: { type: "string" } },
+    confidence: {
+      type: "object",
+      required: ["level", "reason"],
+      properties: {
+        level: { enum: ["high", "medium", "low"] },
+        reason: { type: "string" }
+      }
+    },
+    challengeClaims: { type: "array", items: { type: "string" }, maxItems: 3 },
+    ownerDecisions: { type: "array", items: { type: "string" } },
+    changeMyMind: { type: "array", items: { type: "string" } }
+  }
+};
+```
+
+Include this contract in each Pass 1 task: inspect supplied evidence directly; do
+not see or ask about other advisors; stay read-only; do not spawn children; return
+only the structured report.
+
+After `runs.all`, return one aggregate receipt rather than making the parent find
+separate artifacts. Preserve the result order or map it by stable key so each row
+contains the advisor identity and report:
+
+```js
+return {
+  pass: 1,
+  advisors: results.map((result, index) => ({
+    key: result.key,
+    agent: result.agent,
+    role: roster[index].role,
+    requestedContext: roster[index].context ?? "runtime-default-unknown",
+    runId: result.runId,
+    report: result.structuredOutput
+  }))
+};
+```
+
+Do not replace `runtime-default-unknown` with a guessed context. It records that
+the launch intentionally omitted context.
 
 A challenge packet contains only disputed claims, strong conflicting evidence,
 missing proof, owner decisions, and high-impact risks. Attribute peer content as
-"another advisor". Do not include full peer reports.
+"another advisor". Do not include full peer reports. Use a common Pass 2 contract:
 
-For every relayed claim, the cross-exam response says exactly `accept`, `reject`,
-`refine`, or `owner-decision`, with cited evidence. It then states whether the
-recommendation changed. New critical evidence goes under `Out-of-scope findings`.
+```js
+const pass2OutputSchema = {
+  type: "object",
+  required: ["responses", "recommendationChanged", "outOfScopeFindings"],
+  properties: {
+    responses: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["claimId", "disposition", "reason", "sources"],
+        properties: {
+          claimId: { type: "string" },
+          disposition: {
+            enum: ["accept", "reject", "refine", "owner-decision"]
+          },
+          reason: { type: "string" },
+          sources: { type: "array", items: { type: "string" } }
+        }
+      }
+    },
+    recommendationChanged: {
+      type: "object",
+      required: ["changed", "reason"],
+      properties: { changed: { type: "boolean" }, reason: { type: "string" } }
+    },
+    outOfScopeFindings: { type: "array", items: { type: "string" } }
+  }
+};
+```
+
+Use stable resume keys such as `cross-oracle`, `phase: "Council pass 2"`, concise
+labels, and `output: false` unless separate artifacts are requested or useful. The
+aggregate Pass 2 receipt uses the same row shape as Pass 1, with the new `runId`
+and `structuredOutput`.
 
 ## Stop and memo
 


### PR DESCRIPTION
Closes #1301.

This makes `council-mode` the canonical protocol for `/council` and keeps the prompt focused on invocation, roster selection, and the supervisor invariants.

The docs now specify structured Pass 1 and Pass 2 advisor contracts, aggregate pass receipts with stable keys and run ids, `phase`/`label` guidance, `output: false` by default for advisor children, and visible checkpoints before and after each pass. The shape is intended to reduce orchestration overhead and artifact sprawl without adding runtime scope.

Validation:
- `git diff --check origin/main...HEAD`
- `npm pack --dry-run --json` package-resource assertion
- fresh read-only review on `b474ed74`
