### PR TITLE
fix: show low-noise workflow progress in fleet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Quote only confidently identified leading Windows executable paths in acceptance verification commands. Thanks to [@srcKod](https://github.com/srcKod) for #1294.
 
 ### Changed
+- Show bounded workflow progress in Fleet detail views while keeping workflow
+  parents as the only actionable async items (#1304).
 - Make `/council` easier to supervise with structured advisor contracts,
   aggregate pass receipts, and visible pass checkpoints (#1301).
 - Reuse validated workflow launch fingerprints during `runs.all` batch setup, reducing focused fingerprint bookkeeping time by 48.7% (#1287).

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -324,7 +324,8 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	};
 
 	const refreshJob = (job: AsyncJobState): boolean => {
-		const widgetStateBefore = widgetRenderKey(job);
+		const widgetExpanded = state.lastUiContext?.hasUI ? state.lastUiContext.ui.getToolsExpanded?.() ?? false : false;
+		const widgetStateBefore = widgetRenderKey(job, widgetExpanded);
 		let nestedRefreshFailed = false;
 		const refreshNestedProjection = () => {
 			try {
@@ -422,7 +423,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 						scheduleCleanup(job.asyncId);
 					}
 				}
-				return widgetRenderKey(job) !== widgetStateBefore;
+				return widgetRenderKey(job, widgetExpanded) !== widgetStateBefore;
 			}
 			if (job.status === "queued") {
 				job.status = "running";
@@ -439,7 +440,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			rememberFleetJob(state, job);
 			if (!hasLiveNestedDescendants(job.nestedChildren) && !state.cleanupTimers.has(job.asyncId)) scheduleCleanup(job.asyncId);
 		}
-		return widgetRenderKey(job) !== widgetStateBefore;
+		return widgetRenderKey(job, widgetExpanded) !== widgetStateBefore;
 	};
 
 	const scheduleJobRefresh = (asyncId: string, delayMs = EVENT_REFRESH_DEBOUNCE_MS) => {

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -27,6 +27,17 @@ type FleetStatusEntry = {
 	state: string;
 	external?: true;
 	nestedChildren?: NestedRunSummary[];
+	workflowRows?: FleetWorkflowRow[];
+};
+
+type FleetWorkflowRow = {
+	name: string;
+	state: AsyncJobStep["status"];
+	modelThinking?: string;
+	activity?: string;
+	startedAt?: number;
+	tokens?: number;
+	overflow?: number;
 };
 
 type FleetNestedRow = {
@@ -42,6 +53,7 @@ type FleetNestedRow = {
 type FleetTreeRow =
 	| { kind: "owner"; entry: FleetStatusEntry }
 	| { kind: "child"; entry: FleetStatusEntry; last: boolean }
+	| { kind: "workflow"; ownerKey: string; row: FleetWorkflowRow; last: boolean }
 	| { kind: "nested"; ownerKey: string; row: FleetNestedRow; last: boolean };
 
 export interface FleetStatusOptions {
@@ -90,6 +102,51 @@ function nestedActivity(node: NestedRunSummary | NestedStepSummary): string | un
 	if (node.activityState === "needs_attention") return "needs attention";
 	if (node.activityState === "active_long_running") return "long-running";
 	return undefined;
+}
+
+function workflowStepActivity(step: AsyncJobStep): string | undefined {
+	if (step.currentTool) return `tool ${step.currentTool}`;
+	if (step.currentPath) return step.currentPath.split(/[\\/]/).at(-1);
+	if (step.activityState === "needs_attention") return "needs attention";
+	if (step.activityState === "active_long_running") return "long-running";
+	if (step.turnCount !== undefined) return `${step.turnCount} turns`;
+	if (step.toolCount !== undefined) return `${step.toolCount} tools`;
+	return undefined;
+}
+
+function workflowStepName(step: AsyncJobStep, index: number): string {
+	const key = step.workflowKey ?? `step ${index + 1}`;
+	const label = step.label && step.label !== key ? ` · ${step.label}` : "";
+	const phase = step.phase ? `${step.phase}: ` : "";
+	return `${phase}${key}${label} (${step.agent})`;
+}
+
+function workflowFleetRows(steps: AsyncJobStep[] | undefined): FleetWorkflowRow[] {
+	return (steps ?? []).map((step, index) => {
+		const modelThinking = formatModelThinking(step.model, step.thinking) || undefined;
+		const activity = workflowStepActivity(step);
+		return {
+			name: workflowStepName(step, index),
+			state: step.status,
+			...(modelThinking ? { modelThinking } : {}),
+			...(activity ? { activity } : {}),
+			...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),
+			...(step.tokens?.total !== undefined ? { tokens: step.tokens.total } : {}),
+		};
+	});
+}
+
+function visibleWorkflowRows(rows: FleetWorkflowRow[] | undefined, visibleLimit: number): FleetWorkflowRow[] {
+	if (!rows?.length) return [];
+	if (rows.length <= visibleLimit) return rows;
+	const selected = new Set<number>();
+	for (const [index, row] of rows.entries()) {
+		if (row.state !== "complete" && row.state !== "completed") selected.add(index);
+		if (selected.size >= visibleLimit) break;
+	}
+	for (let index = rows.length - 1; index >= 0 && selected.size < visibleLimit; index--) selected.add(index);
+	const visible = [...selected].sort((left, right) => left - right).map((index) => rows[index]!);
+	return [{ name: `… +${rows.length - visible.length} hidden workflow steps`, state: "complete", overflow: rows.length - visible.length }, ...visible];
 }
 
 function nestedStatusGlyph(state: FleetNestedRow["state"], theme: Theme): string {
@@ -194,9 +251,10 @@ function fleetTreeRows(entries: FleetStatusEntry[]): FleetTreeRow[] {
 		if (entry.parentKey && entryKeys.has(entry.parentKey)) continue;
 		rows.push({ kind: "owner", entry });
 		const attached = childrenByParent.get(entry.key) ?? [];
+		const workflowRows = visibleWorkflowRows(entry.workflowRows, attached.length > 0 ? 2 : 4);
 		for (const [index, child] of attached.entries()) {
 			const nested = nestedFleetRows(child.nestedChildren, 3);
-			const laterRows = index < attached.length - 1 || Boolean(entry.nestedChildren?.length);
+			const laterRows = index < attached.length - 1 || workflowRows.length > 0 || Boolean(entry.nestedChildren?.length);
 			rows.push({ kind: "child", entry: child, last: !laterRows && nested.length === 0 });
 			for (const [nestedIndex, row] of nested.entries()) rows.push({
 				kind: "nested",
@@ -205,6 +263,7 @@ function fleetTreeRows(entries: FleetStatusEntry[]): FleetTreeRow[] {
 				last: nestedIndex === nested.length - 1 && !laterRows,
 			});
 		}
+		for (const [index, row] of workflowRows.entries()) rows.push({ kind: "workflow", ownerKey: entry.key, row, last: index === workflowRows.length - 1 && !entry.nestedChildren?.length });
 		const nested = nestedFleetRows(entry.nestedChildren, attached.length > 0 ? 3 : 4);
 		for (const [index, row] of nested.entries()) rows.push({ kind: "nested", ownerKey: entry.key, row, last: index === nested.length - 1 });
 	}
@@ -282,6 +341,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				startedAt,
 				tokens: job.totalTokens?.total ?? 0,
 				state: job.status,
+				...(job.steps?.length ? { workflowRows: workflowFleetRows(job.steps) } : {}),
 				...(job.nestedChildren?.length ? { nestedChildren: job.nestedChildren } : {}),
 			});
 			continue;
@@ -548,6 +608,8 @@ export class SubagentFleetStatus {
 			if (row.kind === "owner" || row.kind === "child") {
 				const ownerIndex = this.entries.findIndex((entry) => entry.key === row.entry.key);
 				lines.push(this.renderEntry(ownerIndex + 1, selectedIndex, row.entry, width, theme, row.kind === "child" ? (row.last ? "└─" : "├─") : undefined));
+			} else if (row.kind === "workflow") {
+				lines.push(this.renderWorkflowRow(row.row, row.last, width, theme));
 			} else {
 				lines.push(this.renderNestedRow(row.row, row.last, width, theme));
 			}
@@ -574,6 +636,20 @@ export class SubagentFleetStatus {
 		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${theme.fg("muted", `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
 		const elapsed = row.startedAt !== undefined ? ` · ${formatFleetElapsed(Date.now() - row.startedAt)}` : "";
 		return truncateToWidth(`${left}${theme.fg("dim", elapsed)}`, width);
+	}
+
+	private renderWorkflowRow(row: FleetWorkflowRow, last: boolean, width: number, theme: Theme): string {
+		const marker = last ? "└─" : "├─";
+		const indent = "    ";
+		if (row.overflow !== undefined) return truncateToWidth(`${indent}${marker} ${theme.fg("dim", `+${row.overflow} hidden workflow steps`)}`, width);
+		const modelThinking = row.modelThinking ? ` (${row.modelThinking})` : "";
+		const activity = row.activity ? ` · ${row.activity}` : "";
+		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${theme.fg("muted", `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
+		const details = [
+			row.startedAt !== undefined ? formatFleetElapsed(Date.now() - row.startedAt) : undefined,
+			row.tokens !== undefined ? formatFleetTokens(row.tokens) : undefined,
+		].filter(Boolean).join(" · ");
+		return truncateToWidth(`${left}${details ? theme.fg("dim", ` · ${details}`) : ""}`, width);
 	}
 
 	private bullet(rosterIndex: number, selectedIndex: number, theme: Theme): string {
@@ -624,6 +700,15 @@ export class SubagentFleetStatus {
 					entry.external,
 					Math.round((now - entry.startedAt) / 1000),
 					entry.tokens,
+					visibleWorkflowRows(entry.workflowRows, entry.parentKey ? 2 : 4).map((row) => [
+						row.name,
+						row.state,
+						row.modelThinking,
+						row.activity,
+						row.startedAt,
+						row.tokens,
+						row.overflow,
+					]),
 					nestedFleetRows(entry.nestedChildren, entry.parentKey ? 3 : 4).map((row) => [
 						row.name,
 						row.state,

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -6,7 +6,7 @@ import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Compo
 import { snapshotExternalRuns, type ExternalRun } from "../api/external-runs.ts";
 import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../shared/formatters.ts";
-import { DIRS, type AsyncJobState, type Details, type FleetKeybindingAction, type FleetKeybindingsConfig, type ForegroundChildControl, type ForegroundResumeChild, type ForegroundResumeRun, type ForegroundRunControl, type SubagentState } from "../shared/types.ts";
+import { DIRS, type AsyncJobState, type AsyncJobStep, type Details, type FleetKeybindingAction, type FleetKeybindingsConfig, type ForegroundChildControl, type ForegroundResumeChild, type ForegroundResumeRun, type ForegroundRunControl, type SubagentState } from "../shared/types.ts";
 import { decodeUtf8Tail } from "../shared/utf8.ts";
 import { readStatus } from "../shared/utils.ts";
 import { formatAsyncRunTranscript } from "../runs/background/fleet-view.ts";
@@ -494,15 +494,68 @@ function externalElapsedEnd(run: ExternalRun): number {
 	return terminal ? (run.endedAt ?? run.updatedAt ?? Date.now()) : Date.now();
 }
 
+function workflowStepLabel(step: AsyncJobStep, index: number): string {
+	const key = step.workflowKey ?? `step ${index + 1}`;
+	const label = step.label && step.label !== key ? ` · ${step.label}` : "";
+	const phase = step.phase ? `${step.phase}: ` : "";
+	return `${phase}${key}${label} (${step.agent})`;
+}
+
+function workflowStepActivity(step: AsyncJobStep): string | undefined {
+	if (step.currentTool) return `tool ${step.currentTool}`;
+	if (step.currentPath) return shortenPath(step.currentPath);
+	if (step.activityState === "needs_attention") return "needs attention";
+	if (step.activityState === "active_long_running") return "long-running";
+	if (step.turnCount !== undefined) return `${step.turnCount} turns`;
+	if (step.toolCount !== undefined) return `${step.toolCount} tools`;
+	return undefined;
+}
+
+function visibleWorkflowProgressSteps(steps: AsyncJobStep[], visibleLimit: number): Array<{ step: AsyncJobStep; index: number } | { hidden: number }> {
+	if (steps.length <= visibleLimit) return steps.map((step, index) => ({ step, index }));
+	const selected = new Set<number>();
+	for (const [index, step] of steps.entries()) {
+		if (step.status !== "complete" && step.status !== "completed") selected.add(index);
+		if (selected.size >= visibleLimit) break;
+	}
+	for (let index = steps.length - 1; index >= 0 && selected.size < visibleLimit; index--) selected.add(index);
+	const visible = [...selected].sort((left, right) => left - right).map((index) => ({ step: steps[index]!, index }));
+	return [{ hidden: steps.length - visible.length }, ...visible];
+}
+
+function workflowProgressLines(steps: AsyncJobStep[] | undefined): string[] {
+	if (!steps?.length) return [];
+	const lines = ["Workflow progress:"];
+	for (const row of visibleWorkflowProgressSteps(steps, 8)) {
+		if ("hidden" in row) {
+			lines.push(`  +${row.hidden} hidden workflow steps`);
+			continue;
+		}
+		const activity = workflowStepActivity(row.step);
+		const context = contextModeLabel(row.step.context);
+		const details = [row.step.status, activity, context, row.step.tokens?.total !== undefined ? formatTokens(row.step.tokens.total) : undefined].filter(Boolean).join(" · ");
+		lines.push(`  ${row.index + 1}. ${workflowStepLabel(row.step, row.index)}${details ? ` — ${details}` : ""}`);
+	}
+	return lines;
+}
+
 function asyncDetail(item: Extract<FleetItem, { kind: "async" }>, state: SubagentState): string[] {
 	const status = readStatus(item.run.asyncDir);
 	if (status) {
 		const trackedJob = state.fleetJobs?.get(item.runId) ?? state.asyncJobs.get(item.runId);
-		return formatAsyncRunTranscript(status, item.run.asyncDir, {
+		const lines = formatAsyncRunTranscript(status, item.run.asyncDir, {
 			index: item.index,
 			lines: TRANSCRIPT_LINES,
 			sessionRoots: uniquePaths([...(state.trustedSessionRoots ?? []), trackedJob?.sessionRoot]),
 		}).split("\n");
+		if (status.mode === "workflow" && item.index === undefined) {
+			const progress = workflowProgressLines((status.steps ?? item.run.steps) as AsyncJobStep[]);
+			if (progress.length) {
+				const modeIndex = lines.findIndex((line) => line.startsWith("Mode:"));
+				lines.splice(modeIndex >= 0 ? modeIndex + 1 : 0, 0, "", ...progress);
+			}
+		}
+		return lines;
 	}
 	const outputPath = item.index !== undefined ? path.join(item.run.asyncDir, `output-${item.index}.log`) : undefined;
 	return [

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -3,6 +3,7 @@
  */
 
 import * as path from "node:path";
+import { createHash } from "node:crypto";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { getMarkdownTheme, keyText, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Container, Markdown, Spacer, Text, visibleWidth, type Component } from "@earendil-works/pi-tui";
@@ -535,7 +536,76 @@ function compactCurrentActivity(progress: AgentProgress): string {
 	return formatCurrentToolLine(progress, getTermWidth() - 4, false, snapshotNow) ?? buildLiveStatusLine(progress, snapshotNow) ?? "thinking…";
 }
 
-export function widgetRenderKey(job: AsyncJobState): string {
+function textDigest(text: string): string {
+	return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+function displayTextRenderKey(text: string): unknown[] {
+	const normalized = sanitizeDisplayText(text);
+	return [normalized.length, textDigest(normalized)];
+}
+
+function expandedStepActivityRenderKey(step: AsyncJobStep): unknown[] {
+	return [
+		step.recentTools?.slice(-3).map((tool) => [tool.tool, displayTextRenderKey(tool.args), tool.endMs]),
+		compactRecentOutputLines(step.recentOutput).map(displayTextRenderKey),
+	];
+}
+
+function widgetStepRenderKey(step: AsyncJobStep, index: number, expanded = false): unknown[] {
+	return [
+		step.index ?? index,
+		step.agent,
+		step.workflowKey,
+		step.phase,
+		step.label,
+		step.status,
+		step.activityState,
+		step.lastActivityAt,
+		step.currentTool,
+		step.currentToolArgs,
+		step.currentToolStartedAt,
+		step.currentPath,
+		step.turnCount,
+		step.toolCount,
+		step.startedAt,
+		step.endedAt,
+		step.durationMs,
+		step.tokens?.total,
+		step.model,
+		step.thinking,
+		step.context,
+		step.error,
+		expanded ? expandedStepActivityRenderKey(step) : undefined,
+		nestedRenderKey(step.children, expanded),
+	];
+}
+
+function nestedRenderKey(children: NestedRunSummary[] | undefined, expanded = false): unknown[] {
+	return (children ?? []).map((child) => [
+		child.id,
+		child.state,
+		child.agent,
+		child.model,
+		child.thinking,
+		child.activityState,
+		child.lastActivityAt,
+		child.currentTool,
+		child.currentToolStartedAt,
+		child.currentPath,
+		child.turnCount,
+		child.toolCount,
+		child.startedAt,
+		child.endedAt,
+		child.lastUpdate,
+		child.error,
+		child.totalTokens?.total,
+		child.steps?.map((step, index) => widgetStepRenderKey({ ...step, agent: step.agent, status: step.status }, index, expanded)),
+		nestedRenderKey(child.children, expanded),
+	]);
+}
+
+export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 	return JSON.stringify({
 		asyncDir: job.asyncDir,
 		status: job.status,
@@ -551,8 +621,8 @@ export function widgetRenderKey(job: AsyncJobState): string {
 		currentStep: job.currentStep,
 		chainStepCount: job.chainStepCount,
 		parallelGroups: job.parallelGroups,
-		steps: job.steps,
-		nestedChildren: job.nestedChildren,
+		steps: job.steps?.map((step, index) => widgetStepRenderKey(step, index, expanded)),
+		nestedChildren: nestedRenderKey(job.nestedChildren, expanded),
 		stepsTotal: job.stepsTotal,
 		runningSteps: job.runningSteps,
 		completedSteps: job.completedSteps,

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -776,6 +776,55 @@ describe("below-editor subagent FleetView", () => {
 		}
 	});
 
+	it("renders bounded workflow progress rows under the workflow parent", () => {
+		const state = stateForTest();
+		const workflowJob = {
+			asyncId: "workflow-1",
+			asyncDir: "/tmp/workflow-1",
+			sessionId: "session-current",
+			status: "running" as const,
+			mode: "workflow" as const,
+			startedAt: 10,
+			updatedAt: 20,
+			steps: [
+				{ agent: "scout", workflowKey: "scan", phase: "Plan", label: "Find seams", status: "complete" as const, index: 0, tokens: { input: 10, output: 5, total: 15 } },
+				{ agent: "reviewer", workflowKey: "review", phase: "Review", status: "running" as const, index: 1, currentTool: "grep", tokens: { input: 20, output: 5, total: 25 } },
+				{ agent: "tester", workflowKey: "test", phase: "Verify", status: "pending" as const, index: 2 },
+			],
+		};
+		state.asyncJobs.set("workflow-1", workflowJob);
+		state.fleetJobs!.set("workflow-1", workflowJob);
+
+		assert.deepEqual(collectFleetStatusEntries(state).map((entry) => entry.key), ["async:workflow-1"]);
+		assert.deepEqual(collectFleetSnapshot(state).items.map((item) => item.key), ["async:workflow-1"]);
+
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000, maxAgentRows: 8 });
+		try {
+			fleet.setContext(ctx);
+			const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
+			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
+			const lines = component.render(140).join("\n");
+			assert.match(lines, /workflow · running/);
+			assert.match(lines, /Plan: scan · Find seams \(scout\) · complete/);
+			assert.match(lines, /Review: review \(reviewer\) · running · tool grep/);
+			assert.match(lines, /Verify: test \(tester\) · pending/);
+		} finally {
+			fleet.dispose();
+		}
+	});
+
 	it("renders recursive nested runs and steps within the existing row budget", () => {
 		const state = stateForTest();
 		state.asyncJobs.set("supervisor", {

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -486,26 +486,61 @@ describe("native subagent fleet", () => {
 	});
 
 	it("shows a scripted workflow as one fleet parent instead of unrelated children", () => {
-		const state = stateForTest();
-		state.fleetJobs = new Map([["workflow-1", {
-			asyncId: "workflow-1",
-			asyncDir: path.join(os.tmpdir(), "workflow-1"),
-			sessionId: "session-current",
-			status: "running",
-			mode: "workflow",
-			agents: ["scan", "review"],
-			steps: [
-				{ agent: "scan", workflowKey: "scan", status: "completed", index: 0 },
-				{ agent: "review", workflowKey: "review", status: "running", index: 1 },
-			],
-			workflow: { trace: [], emits: ["reviewing"], console: [] },
-			startedAt: 10,
-			updatedAt: 20,
-		}]]);
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-workflow-parent-"));
+		try {
+			const state = stateForTest();
+			const asyncDir = path.join(root, "workflow-1");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "workflow-1",
+				sessionId: "session-current",
+				mode: "workflow",
+				state: "running",
+				startedAt: 10,
+				lastUpdate: 20,
+				steps: [
+					{ agent: "scan", workflowKey: "scan", phase: "Plan", label: "Find seams", status: "completed", index: 0 },
+					{ agent: "review", workflowKey: "review", phase: "Review", status: "running", index: 1, currentTool: "grep" },
+				],
+			}, null, 2));
+			state.fleetJobs = new Map([["workflow-1", {
+				asyncId: "workflow-1",
+				asyncDir,
+				sessionId: "session-current",
+				status: "running",
+				mode: "workflow",
+				agents: ["scan", "review"],
+				steps: [
+					{ agent: "scan", workflowKey: "scan", status: "completed", index: 0 },
+					{ agent: "review", workflowKey: "review", status: "running", index: 1 },
+				],
+				workflow: { trace: [], emits: ["reviewing"], console: [] },
+				startedAt: 10,
+				updatedAt: 20,
+			}]]);
 
-		const snapshot = collectFleetSnapshot(state);
-		assert.deepEqual(snapshot.items.map((item) => item.key), ["async:workflow-1"]);
-		assert.equal(snapshot.items[0]?.agent, "workflow");
+			const snapshot = collectFleetSnapshot(state);
+			assert.deepEqual(snapshot.items.map((item) => item.key), ["async:workflow-1"]);
+			assert.equal(snapshot.items[0]?.agent, "workflow");
+
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
+				theme as never,
+				state,
+				() => {},
+				{ initialKey: "async:workflow-1", refreshMs: 60_000 },
+			);
+			try {
+				const lines = component.render(120).join("\n");
+				assert.match(lines, /Workflow progress:/);
+				assert.match(lines, /Plan: scan · Find seams \(scan\) — completed/);
+				assert.match(lines, /Review: review \(review\) — running · tool grep/);
+			} finally {
+				component.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("shows selectable workflow children only when multiple are live", async () => {

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { row } from "../../src/tui/render-helpers.ts";
-import { renderSubagentResult, truncLine } from "../../src/tui/render.ts";
+import { renderSubagentResult, truncLine, widgetRenderKey } from "../../src/tui/render.ts";
+import type { AsyncJobState } from "../../src/shared/types.ts";
 
 const theme = {
 	fg(_name: string, text: string): string {
@@ -63,6 +64,53 @@ test("truncLine respects grapheme display width", () => {
 
 test("truncLine emits no marker at zero width", () => {
 	assert.equal(truncLine("abcdef", 0), "");
+});
+
+test("widget render keys keep compact payloads quiet and expanded payloads fresh", () => {
+	const job: AsyncJobState = {
+		asyncId: "workflow-1",
+		asyncDir: "/tmp/workflow-1",
+		status: "running",
+		mode: "workflow",
+		startedAt: 100,
+		updatedAt: 200,
+		steps: [{
+			agent: "reviewer",
+			workflowKey: "review",
+			status: "running",
+			currentTool: "grep",
+			recentOutput: ["started", "x".repeat(20_000)],
+			recentTools: [
+				{ tool: "read", args: "hidden", endMs: 100 },
+				{ tool: "grep", args: "visible", endMs: 150 },
+			],
+		}],
+	};
+	const noisy = structuredClone(job);
+	noisy.steps![0]!.recentOutput = ["started", "y".repeat(20_000)];
+	noisy.steps![0]!.recentTools = [
+		{ tool: "read", args: "changed-hidden", endMs: 100 },
+		{ tool: "grep", args: "visible", endMs: 150 },
+	];
+	assert.equal(widgetRenderKey(noisy), widgetRenderKey(job));
+	assert.notEqual(widgetRenderKey(noisy, true), widgetRenderKey(job, true));
+
+	const expandedVisibleChange = structuredClone(job);
+	expandedVisibleChange.steps![0]!.recentTools![1]!.args = "changed-visible";
+	assert.equal(widgetRenderKey(expandedVisibleChange), widgetRenderKey(job));
+	assert.notEqual(widgetRenderKey(expandedVisibleChange, true), widgetRenderKey(job, true));
+
+	const visibleChange = structuredClone(job);
+	visibleChange.steps![0]!.currentTool = "bash";
+	assert.notEqual(widgetRenderKey(visibleChange), widgetRenderKey(job));
+
+	const visibleArgsChange = structuredClone(job);
+	visibleArgsChange.steps![0]!.currentToolArgs = "{\"pattern\":\"workflow\"}";
+	assert.notEqual(widgetRenderKey(visibleArgsChange), widgetRenderKey(job));
+
+	const nestedVisibleChange = structuredClone(job);
+	nestedVisibleChange.nestedChildren = [{ id: "nested-1", parentRunId: "workflow-1", depth: 1, path: [{ runId: "workflow-1" }], state: "failed", agent: "nested", error: "failed" }];
+	assert.notEqual(widgetRenderKey(nestedVisibleChange), widgetRenderKey(job));
 });
 
 test("multiline rendering omits two-column graphemes at one-column width", () => {


### PR DESCRIPTION
Closes #1304.

This keeps workflow parents as the only actionable Fleet item, but shows bounded display-only workflow progress rows in Fleet views. It also makes the compact async widget render key ignore hidden `recentOutput` and `recentTools` payloads while still tracking visible progress state.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/fleet-status.test.ts test/unit/fleet.test.ts test/unit/render-helpers.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- `git diff --check`
- Fresh review: no unresolved findings
