### PR TITLE
feat: carry contextWindow, maxTokens, input, and cost from the model registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- Carry full model registry metadata, including tiered pricing, into normalized
+  model information. Thanks to [@srcKod](https://github.com/srcKod) for #1317.
 - Let agent definitions and `agentOverrides` set a default `outputMode`, while
   call-level output mode stays higher priority. Thanks to [@bbbRye007](https://github.com/bbbRye007) for #1305.
 - Add `context: "profile"` for workflow children that should use the selected

--- a/src/shared/model-info.ts
+++ b/src/shared/model-info.ts
@@ -1,3 +1,5 @@
+import type { ModelCost } from "@earendil-works/pi-ai";
+
 export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 export type ThinkingLevel = typeof THINKING_LEVELS[number];
 export type ThinkingLevelMap = Partial<Record<ThinkingLevel, string | null>>;
@@ -9,6 +11,14 @@ export interface ModelInfo {
 	api?: string;
 	reasoning?: boolean;
 	thinkingLevelMap?: ThinkingLevelMap;
+	/** Context window in tokens, when the host model registry reports one. */
+	contextWindow?: number;
+	/** Maximum output tokens, when the host model registry reports one. */
+	maxTokens?: number;
+	/** Input modalities reported by the registry, e.g. ["text", "image"]. */
+	input?: string[];
+	/** Per-token pricing from the registry (USD per 1M tokens). */
+	cost?: ModelCost;
 }
 
 interface RegistryModelLike {
@@ -17,6 +27,10 @@ interface RegistryModelLike {
 	api?: string;
 	reasoning?: boolean;
 	thinkingLevelMap?: ThinkingLevelMap;
+	contextWindow?: number;
+	maxTokens?: number;
+	input?: string[];
+	cost?: ModelCost;
 }
 
 export function toModelInfo(model: RegistryModelLike): ModelInfo {
@@ -27,6 +41,12 @@ export function toModelInfo(model: RegistryModelLike): ModelInfo {
 		api: model.api,
 		reasoning: model.reasoning,
 		thinkingLevelMap: model.thinkingLevelMap,
+		...(typeof model.contextWindow === "number" && Number.isFinite(model.contextWindow) && model.contextWindow > 0 ? { contextWindow: model.contextWindow } : {}),
+		...(typeof model.maxTokens === "number" && Number.isFinite(model.maxTokens) && model.maxTokens > 0 ? { maxTokens: model.maxTokens } : {}),
+		...(Array.isArray(model.input) && model.input.length > 0 ? { input: [...model.input] } : {}),
+		...(model.cost && Number.isFinite(model.cost.input) && Number.isFinite(model.cost.output)
+			? { cost: { ...model.cost, ...(model.cost.tiers ? { tiers: model.cost.tiers.map((tier) => ({ ...tier })) } : {}) } }
+			: {}),
 	};
 }
 

--- a/test/unit/model-info.test.ts
+++ b/test/unit/model-info.test.ts
@@ -98,3 +98,65 @@ describe("model info helpers", () => {
 		);
 	});
 });
+
+describe("toModelInfo registry fields", () => {
+	it("carries contextWindow, maxTokens, input, and cost from the registry", () => {
+		const info = toModelInfo({
+			provider: "openai",
+			id: "gpt-5-mini",
+			api: "openai-responses",
+			reasoning: true,
+			contextWindow: 272000,
+			maxTokens: 128000,
+			input: ["text", "image"],
+			cost: { input: 0.25, output: 2, cacheRead: 0.025, cacheWrite: 0.25 },
+		});
+		assert.equal(info.contextWindow, 272000);
+		assert.equal(info.maxTokens, 128000);
+		assert.deepEqual(info.input, ["text", "image"]);
+		assert.deepEqual(info.cost, { input: 0.25, output: 2, cacheRead: 0.025, cacheWrite: 0.25 });
+	});
+
+	it("omits fields the registry does not report", () => {
+		const info = toModelInfo({ provider: "local", id: "custom-model" });
+		assert.equal(info.fullId, "local/custom-model");
+		assert.equal("contextWindow" in info, false);
+		assert.equal("maxTokens" in info, false);
+		assert.equal("input" in info, false);
+		assert.equal("cost" in info, false);
+	});
+
+	it("ignores non-positive or malformed registry values", () => {
+		const info = toModelInfo({
+			provider: "local",
+			id: "broken",
+			contextWindow: 0,
+			maxTokens: -1,
+			input: [],
+			cost: { input: Number.NaN, output: 1 },
+		});
+		assert.equal("contextWindow" in info, false);
+		assert.equal("maxTokens" in info, false);
+		assert.equal("input" in info, false);
+		assert.equal("cost" in info, false);
+	});
+
+	it("copies the input array instead of aliasing the registry entry", () => {
+		const registryInput = ["text"];
+		const info = toModelInfo({ provider: "local", id: "m", input: registryInput });
+		assert.notEqual(info.input, registryInput);
+		assert.deepEqual(info.input, ["text"]);
+	});
+
+	it("preserves and copies tiered registry cost", () => {
+		const tiers = [{ inputTokensAbove: 100_000, input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 }];
+		const info = toModelInfo({
+			provider: "openai",
+			id: "tiered",
+			cost: { input: 0.5, output: 1, cacheRead: 0.05, cacheWrite: 0.1, tiers },
+		});
+		assert.deepEqual(info.cost?.tiers, tiers);
+		assert.notEqual(info.cost?.tiers, tiers);
+		assert.notEqual(info.cost?.tiers?.[0], tiers[0]);
+	});
+});


### PR DESCRIPTION
## What this does

Extends `ModelInfo` with registry metadata that was previously dropped in `toModelInfo()`: `contextWindow`, `maxTokens`, `input`, and `cost`.

The maintainer rework also preserves tiered cost metadata from the host `ModelCost` contract and copies the tier array and tier objects to avoid aliasing.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-info.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
