### PR TITLE
feat: add TTL-based model exclusion store for fallback candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   model information. Thanks to [@srcKod](https://github.com/srcKod) for #1317.
 - Add runtime programmatic agent registration for Pi extensions, with fail-closed
   name and alias collision checks. Thanks to [@fmoda3](https://github.com/fmoda3) for #1310.
+- Skip recently failed fallback models for a TTL-backed window during model
+  fallback selection. Thanks to [@srcKod](https://github.com/srcKod) for #1318.
 - Let agent definitions and `agentOverrides` set a default `outputMode`, while
   call-level output mode stays higher priority. Thanks to [@bbbRye007](https://github.com/bbbRye007) for #1305.
 - Add `context: "profile"` for workflow children that should use the selected

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -85,7 +85,7 @@ import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection } from "../shared/dynamic-fanout.ts";
 import { claimRunFanoutBatch, getRunFanoutBudgetSnapshot } from "../shared/run-fanout-budget.ts";
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent } from "../shared/nested-events.ts";
-import { formatModelAttemptNote, isRetryableModelFailure } from "../shared/model-fallback.ts";
+import { formatModelAttemptNote, isRetryableModelFailure, recordRetryableModelFailure } from "../shared/model-fallback.ts";
 import {
 	SUBAGENT_STARTUP_RETRY_DELAYS_MS,
 	formatSubagentExtensionConflictError,
@@ -1432,8 +1432,8 @@ async function runSingleStepInner(
 		});
 	}
 
-	const candidates = step.modelCandidates && step.modelCandidates.length > 0
-		? step.modelCandidates
+	const candidates = step.modelCandidates !== undefined
+		? step.modelCandidates.length > 0 ? step.modelCandidates : [undefined]
 		: step.model
 			? [step.model]
 			: [undefined];
@@ -1769,7 +1769,9 @@ async function runSingleStepInner(
 			finalResult.finalOutput = startupError;
 			break modelAttemptsLoop;
 		}
-		if (!isRetryableModelFailure(error) || modelIndex === candidates.length - 1) break modelAttemptsLoop;
+		const retryableModelFailure = isRetryableModelFailure(error);
+		if (retryableModelFailure) recordRetryableModelFailure(candidate ?? run.model ?? step.model, error);
+		if (!retryableModelFailure || modelIndex === candidates.length - 1) break modelAttemptsLoop;
 		attemptNotes.push(formatModelAttemptNote(attempt, candidates[modelIndex + 1]));
 		modelIndex += 1;
 		startupAttemptIndex = 0;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -74,6 +74,7 @@ import {
 	buildModelCandidates,
 	formatModelAttemptNote,
 	isRetryableModelFailure,
+	recordRetryableModelFailure,
 } from "../shared/model-fallback.ts";
 import {
 	SUBAGENT_STARTUP_RETRY_DELAYS_MS,
@@ -1861,7 +1862,9 @@ async function runSyncCompletionInner(
 				attempt.error = startupError;
 				break modelAttemptsLoop;
 			}
-			if (!isRetryableModelFailure(result.error) || modelIndex === modelsToTry.length - 1) break modelAttemptsLoop;
+			const retryableModelFailure = isRetryableModelFailure(result.error);
+			if (retryableModelFailure) recordRetryableModelFailure(result.model ?? candidate, result.error);
+			if (!retryableModelFailure || modelIndex === modelsToTry.length - 1) break modelAttemptsLoop;
 			attemptNotes.push(formatModelAttemptNote(attempt, modelsToTry[modelIndex + 1]));
 			break;
 		}

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -1,0 +1,238 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { TEMP_ROOT_DIR } from "../../shared/types.ts";
+
+export const EXCLUSIONS_PATH_ENV = "PI_MODEL_EXCLUSIONS_PATH";
+
+export interface ModelExclusion {
+	modelId?: string;
+	provider?: string;
+	reason?: string;
+	recordedAt: number;
+	expiresAt: number;
+}
+
+let exclusions: ModelExclusion[] = [];
+let loaded = false;
+let defaultTTLMs = 24 * 60 * 60_000; // 24 hours, overridable via setDefaultTTL
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Override the default exclusion TTL. Invalid or non-positive values are ignored.
+ */
+export function setDefaultTTL(ms: number): void {
+	if (Number.isFinite(ms) && ms > 0) defaultTTLMs = ms;
+}
+
+/**
+ * Resolve the persistence path. Honors PI_MODEL_EXCLUSIONS_PATH; defaults to
+ * <TEMP_ROOT_DIR>/model-exclusions.json. Resolved lazily so tests can point the
+ * store at an isolated location after module load.
+ */
+export function getExclusionsFilePath(): string {
+	const envPath = process.env[EXCLUSIONS_PATH_ENV];
+	if (typeof envPath === "string" && envPath.trim()) return envPath.trim();
+	return path.join(TEMP_ROOT_DIR, "model-exclusions.json");
+}
+
+/**
+ * Persist exclusions to disk immediately (atomic write via tmp + rename).
+ * The store otherwise debounces writes; call this when durability matters
+ * (and in tests).
+ */
+export function flushPersist(): void {
+	const file = getExclusionsFilePath();
+	try {
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		const tmpPath = `${file}.tmp`;
+		fs.writeFileSync(tmpPath, JSON.stringify({
+			version: 1,
+			exclusions: deduplicate(exclusions),
+		}, null, 2), "utf-8");
+		fs.renameSync(tmpPath, file);
+	} catch (error) {
+		console.error(`[model-exclusions] Failed to persist exclusions to ${file}:`, error);
+	}
+}
+
+function schedulePersist(): void {
+	if (persistTimer) clearTimeout(persistTimer);
+	persistTimer = setTimeout(() => {
+		persistTimer = null;
+		flushPersist();
+	}, 5000);
+	// Never hold the process open just to flush exclusions.
+	persistTimer.unref?.();
+}
+
+function ensureLoaded(): void {
+	if (loaded) return;
+	loaded = true;
+	try {
+		const raw = fs.readFileSync(getExclusionsFilePath(), "utf-8");
+		const data = JSON.parse(raw);
+		if (data.version === 1) {
+			const now = Date.now();
+			exclusions = (data.exclusions ?? []).filter((e: ModelExclusion) => e.expiresAt > now);
+			exclusions = deduplicate(exclusions);
+		}
+	} catch {
+		// File missing, corrupt, or unreadable — start fresh.
+	}
+}
+
+function dedupKey(entry: ModelExclusion): string {
+	return `${entry.provider ?? ""}|${entry.modelId ?? ""}`;
+}
+
+function deduplicate(items: ModelExclusion[]): ModelExclusion[] {
+	const map = new Map<string, ModelExclusion>();
+	for (const entry of items) {
+		const key = dedupKey(entry);
+		const existing = map.get(key);
+		if (!existing || entry.recordedAt > existing.recordedAt) {
+			map.set(key, entry);
+		}
+	}
+	return Array.from(map.values());
+}
+
+/**
+ * Record a model failure as a temporary exclusion. While the exclusion is
+ * active, {@link isExcluded} returns true for the model (or for every model of
+ * the provider when modelId is omitted), and {@link filterFallbackCandidates}
+ * removes matching candidates from fallback lists.
+ */
+export function recordModelFailure(options: {
+	modelId?: string;
+	provider?: string;
+	reason?: string;
+	ttlMs?: number;
+}): void {
+	ensureLoaded();
+	const ttl = options.ttlMs ?? defaultTTLMs;
+	const now = Date.now();
+	const exclusion: ModelExclusion = {
+		modelId: options.modelId,
+		provider: options.provider,
+		reason: options.reason ?? "runtime-failure",
+		recordedAt: now,
+		expiresAt: now + ttl,
+	};
+	exclusions.unshift(exclusion);
+	exclusions = deduplicate(exclusions);
+	if (exclusions.length > 200) exclusions.length = 200;
+	schedulePersist();
+}
+
+/**
+ * Drop all expired exclusions from memory and schedule a persist.
+ */
+export function clearExpiredExclusions(): void {
+	ensureLoaded();
+	prune(exclusions, Date.now());
+	schedulePersist();
+}
+
+/**
+ * Remove every exclusion (e.g. after the operator fixes credentials).
+ */
+export function clearExclusions(): void {
+	ensureLoaded();
+	exclusions.length = 0;
+	schedulePersist();
+}
+
+/**
+ * Whether an exclusion entry matches a candidate.
+ *
+ * Semantics:
+ * - Entry with modelId: model-specific exclusion. Matches only that modelId;
+ *   when both the entry and the candidate carry a provider, the providers must
+ *   also agree so `openai/gpt-4` does not exclude `github-copilot/gpt-4`.
+ * - Entry without modelId: provider-wide exclusion (e.g. quota or auth failure).
+ *   Matches every model of that provider.
+ */
+function entryMatches(entry: ModelExclusion, candidateModelId: string, candidateProvider: string | undefined, now: number): boolean {
+	if (entry.expiresAt <= now) return false;
+	if (entry.modelId) {
+		if (entry.modelId !== candidateModelId) return false;
+		return !entry.provider || !candidateProvider || entry.provider === candidateProvider;
+	}
+	return Boolean(entry.provider) && entry.provider === candidateProvider;
+}
+
+/**
+ * Whether a model (or its provider) is currently excluded.
+ */
+export function isExcluded(modelId: string, provider: string): boolean {
+	ensureLoaded();
+	return exclusions.some((entry) => entryMatches(entry, modelId, provider, Date.now()));
+}
+
+/**
+ * Number of live (non-expired) exclusions.
+ */
+export function getExcludedCount(): number {
+	ensureLoaded();
+	clearExpiredExclusions();
+	return exclusions.length;
+}
+
+/**
+ * Split a candidate fullId into its provider + modelId components.
+ *
+ * A fullId may carry a thinking suffix (`provider/model:thinking`) which is
+ * stripped before parsing, and the modelId itself may contain slashes
+ * (e.g. `openrouter/google/gemini-flash`). The first `/`-segment is the
+ * provider; everything after is the modelId. This MUST stay in lock-step with
+ * the matching inside {@link isExcluded} so that a failure recorded via
+ * {@link recordModelFailure} is later recognised by the candidate filter.
+ */
+export function parseModelKey(fullId: string): { provider?: string; modelId: string } {
+	const base = fullId.includes(":") ? fullId.substring(0, fullId.lastIndexOf(":")) : fullId;
+	if (!base.includes("/")) return { modelId: base };
+	const slash = base.indexOf("/");
+	return { provider: base.slice(0, slash), modelId: base.slice(slash + 1) };
+}
+
+/**
+ * Filter a list of candidate fullIds, removing excluded models/providers and
+ * duplicates while preserving order.
+ */
+export function filterFallbackCandidates(candidates: string[], opts?: { now?: number }): string[] {
+	ensureLoaded();
+	const timestamp = opts?.now ?? Date.now();
+	const seen = new Set<string>();
+	const filtered: string[] = [];
+	for (const raw of candidates) {
+		if (!raw || seen.has(raw)) continue;
+		const { provider: candidateProvider, modelId: candidateModelId } = parseModelKey(raw);
+		const excluded = exclusions.some((entry) => entryMatches(entry, candidateModelId, candidateProvider, timestamp));
+		if (excluded) continue;
+		seen.add(raw);
+		filtered.push(raw);
+	}
+	return filtered;
+}
+
+/**
+ * Reload exclusions from disk (for tests and config hot-reload).
+ * Discards any in-memory-only exclusions that were not yet persisted.
+ */
+export function reloadFromDisk(): void {
+	loaded = false;
+	exclusions = [];
+	ensureLoaded();
+}
+
+function prune(items: ModelExclusion[], now: number): void {
+	let write = 0;
+	for (let i = 0; i < items.length; i++) {
+		const entry = items[i]!;
+		if (entry.expiresAt > now) {
+			items[write++] = entry;
+		}
+	}
+	items.length = write;
+}

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -16,6 +16,7 @@ let exclusions: ModelExclusion[] = [];
 let loaded = false;
 let defaultTTLMs = 24 * 60 * 60_000; // 24 hours, overridable via setDefaultTTL
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
+let persistSeq = 0;
 
 /**
  * Override the default exclusion TTL. Invalid or non-positive values are ignored.
@@ -44,7 +45,7 @@ export function flushPersist(): void {
 	const file = getExclusionsFilePath();
 	try {
 		fs.mkdirSync(path.dirname(file), { recursive: true });
-		const tmpPath = `${file}.tmp`;
+		const tmpPath = `${file}.${process.pid}.${persistSeq++}.tmp`;
 		fs.writeFileSync(tmpPath, JSON.stringify({
 			version: 1,
 			exclusions: deduplicate(exclusions),
@@ -76,8 +77,10 @@ function ensureLoaded(): void {
 			exclusions = (data.exclusions ?? []).filter((e: ModelExclusion) => e.expiresAt > now);
 			exclusions = deduplicate(exclusions);
 		}
-	} catch {
-		// File missing, corrupt, or unreadable — start fresh.
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			console.error(`[model-exclusions] Failed to load exclusions from ${getExclusionsFilePath()}:`, error);
+		}
 	}
 }
 
@@ -122,7 +125,7 @@ export function recordModelFailure(options: {
 	exclusions.unshift(exclusion);
 	exclusions = deduplicate(exclusions);
 	if (exclusions.length > 200) exclusions.length = 200;
-	schedulePersist();
+	flushPersist();
 }
 
 /**

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -1,5 +1,6 @@
 import type { ModelInfo as AvailableModelInfo } from "../../shared/model-info.ts";
 import type { Usage } from "../../shared/types.ts";
+import { filterFallbackCandidates, parseModelKey, recordModelFailure } from "./model-exclusions.ts";
 import { checkModelScope, type ModelScopeConfig, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
 
 export type { AvailableModelInfo };
@@ -367,7 +368,7 @@ export function buildModelCandidates(
 		seen.add(normalized);
 		candidates.push(normalized);
 	}
-	return candidates;
+	return filterFallbackCandidates(candidates);
 }
 
 const RETRYABLE_MODEL_FAILURE_PATTERNS = [
@@ -422,6 +423,12 @@ export function isRetryableModelFailure(error: string | undefined): boolean {
 	if (!error) return false;
 	if (TOOL_FAILURE_PREFIX.test(error.trim())) return false;
 	return RETRYABLE_MODEL_FAILURE_PATTERNS.some((pattern) => pattern.test(error));
+}
+
+export function recordRetryableModelFailure(model: string | undefined, error: string | undefined): void {
+	if (!model || !isRetryableModelFailure(error)) return;
+	const { provider, modelId } = parseModelKey(model);
+	recordModelFailure({ modelId, reason: error, ...(provider ? { provider } : {}) });
 }
 
 /**

--- a/test/integration/fork-context-execution.test.ts
+++ b/test/integration/fork-context-execution.test.ts
@@ -6,6 +6,7 @@ import type { MockPi } from "../support/helpers.ts";
 import { createEventBus, createMockPi, createTempDir, events, removeTempDir, tryImport } from "../support/helpers.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
 import { ACTIVE_ASYNC_CAPACITY_DIR, acquireActiveAsyncCapacity, activeAsyncCapacitySessionKey } from "../../src/runs/background/active-async-capacity.ts";
+import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
 import { DEFAULT_FORK_PREAMBLE, INTERCOM_DETACH_REQUEST_EVENT, SUBAGENT_ASYNC_STARTED_EVENT } from "../../src/shared/types.ts";
 
 interface ExecutorModule {
@@ -106,9 +107,11 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		tempDir = createTempDir("pi-subagent-fork-test-");
 		mockPi.reset();
 		mockPi.onCall({ output: "ok" });
+		clearExclusions();
 	});
 
 	afterEach(() => {
+		clearExclusions();
 		if (originalHome === undefined) delete process.env.HOME;
 		else process.env.HOME = originalHome;
 		if (originalUserProfile === undefined) delete process.env.USERPROFILE;

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -62,6 +62,7 @@ import { resolveMissionStoreLocation } from "../../src/missions/store.ts";
 import { missionStatePath } from "../../src/missions/workflow-state.ts";
 import { discardPreservedWorktrees } from "../../src/runs/shared/parallel-handoff.ts";
 import { resolveAsyncResumeTarget } from "../../src/runs/background/async-resume.ts";
+import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
 
 interface ModelAttempt {
 	success?: boolean;
@@ -320,9 +321,11 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 		process.env.PI_CODING_AGENT_DIR = agentDir;
 		mockPi.reset();
+		clearExclusions();
 	});
 
 	afterEach(() => {
+		clearExclusions();
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		removeTempDir(agentDir);

--- a/test/unit/model-exclusions.test.ts
+++ b/test/unit/model-exclusions.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+	clearExclusions,
+	filterFallbackCandidates,
+	flushPersist,
+	getExcludedCount,
+	isExcluded,
+	parseModelKey,
+	recordModelFailure,
+	reloadFromDisk,
+} from "../../src/runs/shared/model-exclusions.ts";
+
+// The exclusion store is a process-wide singleton persisted under TEMP_ROOT_DIR
+// (isolated per test run by test/support/isolated-temp-root.mjs). Clear it
+// before/after each test so cases don't leak state into each other.
+beforeEach(() => clearExclusions());
+afterEach(() => clearExclusions());
+
+describe("model exclusions — record & query", () => {
+	it("excludes a recorded model", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "429" });
+		assert.equal(isExcluded("gpt-4", "openai"), true);
+	});
+
+	it("does not exclude other models of the same provider when modelId is set", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai" });
+		assert.equal(isExcluded("gpt-4o", "openai"), false);
+	});
+
+	it("does not exclude the same modelId under a different provider", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai" });
+		assert.equal(isExcluded("gpt-4", "github-copilot"), false);
+	});
+
+	it("matches by provider when modelId is omitted", () => {
+		recordModelFailure({ provider: "openai", reason: "quota" });
+		assert.equal(isExcluded("any-model", "openai"), true);
+	});
+
+	it("deduplicates repeated recordings for the same key", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai" });
+		recordModelFailure({ modelId: "gpt-4", provider: "openai" });
+		assert.equal(getExcludedCount(), 1);
+	});
+
+	it("tracks distinct keys separately", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai" });
+		recordModelFailure({ modelId: "claude", provider: "anthropic" });
+		assert.equal(getExcludedCount(), 2);
+	});
+});
+
+describe("model exclusions — TTL expiry", () => {
+	it("drops an exclusion after its TTL elapses", async () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", ttlMs: 1 });
+		assert.equal(isExcluded("gpt-4", "openai"), true);
+		await new Promise((r) => setTimeout(r, 20));
+		assert.equal(isExcluded("gpt-4", "openai"), false);
+	});
+});
+
+describe("model exclusions — parseModelKey", () => {
+	it("splits provider and modelId", () => {
+		assert.deepEqual(parseModelKey("openai/gpt-4"), { provider: "openai", modelId: "gpt-4" });
+	});
+
+	it("strips a thinking suffix before parsing", () => {
+		assert.deepEqual(parseModelKey("openai/gpt-5:high"), { provider: "openai", modelId: "gpt-5" });
+	});
+
+	it("keeps slashes inside the modelId", () => {
+		assert.deepEqual(parseModelKey("openrouter/google/gemini-flash"), {
+			provider: "openrouter",
+			modelId: "google/gemini-flash",
+		});
+	});
+
+	it("handles a bare model id without a provider", () => {
+		assert.deepEqual(parseModelKey("gpt-4"), { modelId: "gpt-4" });
+	});
+});
+
+describe("model exclusions — filtering fallback candidates", () => {
+	it("removes excluded candidates from a candidate list", () => {
+		const candidates = ["anthropic/claude-3", "openai/gpt-4", "openai/gpt-4o"];
+		recordModelFailure({ provider: "openai" });
+		const filtered = filterFallbackCandidates(candidates);
+		assert.deepEqual(filtered, ["anthropic/claude-3"]);
+	});
+
+	it("removes a candidate recorded with a thinking suffix", () => {
+		const candidates = ["anthropic/claude-3", "openai/gpt-5:high"];
+		recordModelFailure({ modelId: "gpt-5", provider: "openai" });
+		const filtered = filterFallbackCandidates(candidates);
+		assert.deepEqual(filtered, ["anthropic/claude-3"]);
+	});
+
+	it("keeps unexcluded candidates and de-duplicates", () => {
+		const candidates = ["anthropic/claude-3", "anthropic/claude-3", "openai/gpt-4"];
+		const filtered = filterFallbackCandidates(candidates);
+		assert.deepEqual(filtered, ["anthropic/claude-3", "openai/gpt-4"]);
+	});
+});
+
+describe("model exclusions — persistence", () => {
+	it("survives a reload from disk", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "429" });
+		// Force an immediate flush (the store otherwise debounces writes by 5s).
+		flushPersist();
+		// Forget in-memory state, then reload from the persisted file.
+		reloadFromDisk();
+		assert.equal(isExcluded("gpt-4", "openai"), true);
+	});
+
+	it("does not reload expired exclusions", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", ttlMs: 1 });
+		flushPersist();
+		return new Promise<void>((resolve) => {
+			setTimeout(() => {
+				reloadFromDisk();
+				assert.equal(isExcluded("gpt-4", "openai"), false);
+				resolve();
+			}, 20);
+		});
+	});
+});

--- a/test/unit/model-exclusions.test.ts
+++ b/test/unit/model-exclusions.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import {
 	clearExclusions,
 	filterFallbackCandidates,
 	flushPersist,
 	getExcludedCount,
+	getExclusionsFilePath,
 	isExcluded,
 	parseModelKey,
 	recordModelFailure,
@@ -53,9 +55,9 @@ describe("model exclusions — record & query", () => {
 
 describe("model exclusions — TTL expiry", () => {
 	it("drops an exclusion after its TTL elapses", async () => {
-		recordModelFailure({ modelId: "gpt-4", provider: "openai", ttlMs: 1 });
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", ttlMs: 100 });
 		assert.equal(isExcluded("gpt-4", "openai"), true);
-		await new Promise((r) => setTimeout(r, 20));
+		await new Promise((r) => setTimeout(r, 150));
 		assert.equal(isExcluded("gpt-4", "openai"), false);
 	});
 });
@@ -106,9 +108,16 @@ describe("model exclusions — filtering fallback candidates", () => {
 describe("model exclusions — persistence", () => {
 	it("survives a reload from disk", () => {
 		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "429" });
-		// Force an immediate flush (the store otherwise debounces writes by 5s).
-		flushPersist();
-		// Forget in-memory state, then reload from the persisted file.
+		reloadFromDisk();
+		assert.equal(isExcluded("gpt-4", "openai"), true);
+	});
+
+	it("persists a recorded model failure before process exit", () => {
+		const file = getExclusionsFilePath();
+		fs.rmSync(file, { force: true });
+		reloadFromDisk();
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "429" });
+		assert.equal(fs.existsSync(file), true);
 		reloadFromDisk();
 		assert.equal(isExcluded("gpt-4", "openai"), true);
 	});
@@ -123,5 +132,20 @@ describe("model exclusions — persistence", () => {
 				resolve();
 			}, 20);
 		});
+	});
+
+	it("reports corrupt persisted exclusions and starts empty", () => {
+		fs.writeFileSync(getExclusionsFilePath(), "not json", "utf-8");
+		const originalError = console.error;
+		const errors: unknown[][] = [];
+		console.error = (...args: unknown[]) => errors.push(args);
+		try {
+			reloadFromDisk();
+		} finally {
+			console.error = originalError;
+		}
+		assert.equal(getExcludedCount(), 0);
+		assert.equal(errors.length, 1);
+		assert.match(String(errors[0]?.[0]), /Failed to load exclusions/);
 	});
 });

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -1,15 +1,20 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import {
 	buildModelCandidates,
 	fuzzyResolveModel,
 	isContextOverflow,
 	isRetryableModelFailure,
 	normalizeModelSegment,
+	recordRetryableModelFailure,
 	resolveEffectiveSubagentModel,
 	resolveModelCandidate,
 	resolveSubagentModelOverride,
 } from "../../src/runs/shared/model-fallback.ts";
+import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
+
+beforeEach(() => clearExclusions());
+afterEach(() => clearExclusions());
 
 describe("model fallback helpers", () => {
 	const availableModels = [
@@ -88,6 +93,24 @@ describe("model fallback helpers", () => {
 	it("builds a deduplicated ordered candidate list", () => {
 		assert.deepEqual(
 			buildModelCandidates("gpt-5-mini", ["openai/gpt-5-mini", "anthropic/claude-sonnet-4", "gpt-5-mini"], availableModels),
+			["openai/gpt-5-mini", "anthropic/claude-sonnet-4"],
+		);
+	});
+
+	it("excludes a candidate after a retryable model failure is recorded", () => {
+		recordRetryableModelFailure("openai/gpt-5-mini", "rate limit exceeded");
+
+		assert.deepEqual(
+			buildModelCandidates("gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels),
+			["anthropic/claude-sonnet-4"],
+		);
+	});
+
+	it("does not exclude a candidate after a task or tool failure", () => {
+		recordRetryableModelFailure("openai/gpt-5-mini", "bash failed (exit 1): command not found");
+
+		assert.deepEqual(
+			buildModelCandidates("gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels),
 			["openai/gpt-5-mini", "anthropic/claude-sonnet-4"],
 		);
 	});


### PR DESCRIPTION
## What this does

Adds a TTL-based model exclusion store and wires it into fallback candidate selection. Retryable foreground and background model failures are recorded at the existing retryability checks, and later candidate selection filters recently failed provider/model pairs.

The store persists under the existing temp-root path, uses bounded entries, and keeps filtering proportional to the resolved candidate list and bounded exclusion list.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-exclusions.test.ts test/unit/model-fallback.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
