### PR TITLE
feat(rpc): expose schedule management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   name and alias collision checks. Thanks to [@fmoda3](https://github.com/fmoda3) for #1310.
 - Skip recently failed fallback models for a TTL-backed window during model
   fallback selection. Thanks to [@srcKod](https://github.com/srcKod) for #1318.
-- Add a schedule-only `manage` method to extension RPC, advertising and accepting list/show/history/pause/resume/run/delete while rejecting arbitrary management actions.
+- Add a schedule-only `manage` method to extension RPC, advertising and accepting list/show/history/pause/resume/run/delete while rejecting arbitrary management actions. Thanks to [@aboubakrine](https://github.com/aboubakrine) for #1319.
 - Let agent definitions and `agentOverrides` set a default `outputMode`, while
   call-level output mode stays higher priority. Thanks to [@bbbRye007](https://github.com/bbbRye007) for #1305.
 - Add `context: "profile"` for workflow children that should use the selected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   name and alias collision checks. Thanks to [@fmoda3](https://github.com/fmoda3) for #1310.
 - Skip recently failed fallback models for a TTL-backed window during model
   fallback selection. Thanks to [@srcKod](https://github.com/srcKod) for #1318.
+- Add a schedule-only `manage` method to extension RPC, advertising and accepting list/show/history/pause/resume/run/delete while rejecting arbitrary management actions.
 - Let agent definitions and `agentOverrides` set a default `outputMode`, while
   call-level output mode stays higher priority. Thanks to [@bbbRye007](https://github.com/bbbRye007) for #1305.
 - Add `context: "profile"` for workflow children that should use the selected

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -23,10 +23,11 @@ pi.events.emit("subagents:rpc:v1:request", {
 });
 ```
 
-The RPC methods are `ping`, `status`, `spawn`, `steer`, `interrupt`, `stop`, and `resume`. `status`, `steer`, `interrupt`, and `resume` reuse the normal package-owned actions.
+The RPC methods are `ping`, `status`, `manage`, `spawn`, `steer`, `interrupt`, `stop`, and `resume`. `status`, `manage`, `steer`, `interrupt`, and `resume` reuse normal package-owned actions.
 
 Method notes:
 
+- `manage` exposes a narrow schedule-only allowlist: `schedule.list`, `schedule.show`, `schedule.history`, `schedule.pause`, `schedule.resume`, `schedule.run`, and `schedule.delete`. All actions except `schedule.list` require `id`. Mission, agent, config, worktree, and arbitrary management actions are rejected before executor dispatch. `ping.capabilities.managementActions` advertises the exact allowlist.
 - `spawn` requires `workflowScript` and is async-only: omit `async` or set `async: true`, omit `clarify`, and do not pass management `action` values. It goes through the same executor as the `subagent` tool, so agent discovery, validation, session attribution, configured spawn caps, child-safety depth, artifacts, and async status all behave the same.
 - `steer` requires an async run `id` (plus optional child `index`) and a non-empty `message`; its reply preserves the normal acknowledged-delivery result. Optional `mode` values are `steer` (default), `follow_up`, and `auto`, and receipts include `deliveryStatus: "delivered" | "queued"`. RPC steering disables the direct tool's pause-and-revive recovery in every mode so an extension keeps authority over the exact child it spawned; `ping.capabilities.nonRecoveringSteer` advertises this guarantee.
 - `resume` requires a run target and non-empty `message`. It delegates to the existing revival path, which validates current-session ownership, persisted session/recovery metadata, stopped/live state, capability ceilings, and the exclusive session lease before returning the new async run details. Callers may request a `file-only` output path for the revived result without overriding its model, tools, or budgets. `ping.capabilities.resume` advertises this seam.
@@ -35,6 +36,7 @@ Method notes:
 Capability advertisements on `ping`:
 
 - `events.asyncComplete` — exact process-local completion correlation after RPC `spawn`.
+- `managementActions` — exact schedule management actions accepted by RPC `manage`.
 - `launchResolvedExtensions` — the optional launch-resolved extension projection in status details.
 - `runtimeAcknowledgedExtensions` — the optional child-runtime acknowledgement projection and event name.
 - `processTerminalProof` — the process-terminal proof status (see [observability.md](observability.md#process-terminal-proof)).

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -27,7 +27,7 @@ export const SUBAGENT_RPC_REQUEST_EVENT = "subagents:rpc:v1:request";
 export const SUBAGENT_RPC_READY_EVENT = "subagents:rpc:v1:ready";
 export const SUBAGENT_RPC_REPLY_EVENT_PREFIX = "subagents:rpc:v1:reply:";
 
-export const SUBAGENT_RPC_METHODS = ["ping", "status", "spawn", "steer", "interrupt", "stop", "resume"] as const;
+export const SUBAGENT_RPC_METHODS = ["ping", "status", "manage", "spawn", "steer", "interrupt", "stop", "resume"] as const;
 export type SubagentRpcMethod = typeof SUBAGENT_RPC_METHODS[number];
 
 export interface SubagentRpcRequestEnvelope {
@@ -57,6 +57,18 @@ export type SubagentRpcReplyEnvelope<T = unknown> = {
 		message: string;
 	};
 };
+
+export const SUBAGENT_RPC_MANAGEMENT_ACTIONS = [
+	"schedule.list",
+	"schedule.show",
+	"schedule.history",
+	"schedule.pause",
+	"schedule.resume",
+	"schedule.run",
+	"schedule.delete",
+] as const;
+
+type SubagentRpcManagementAction = typeof SUBAGENT_RPC_MANAGEMENT_ACTIONS[number];
 
 type SubagentRpcErrorCode =
 	| "invalid_request"
@@ -375,6 +387,7 @@ function pingData(ctx: ExtensionContext | null) {
 		methods: [...SUBAGENT_RPC_METHODS],
 		capabilities: {
 			status: true,
+			managementActions: [...SUBAGENT_RPC_MANAGEMENT_ACTIONS],
 			fleetStatus: { version: 1 },
 			asyncStatusSnapshot: { kind: ASYNC_STATUS_SNAPSHOT_KIND, version: ASYNC_STATUS_SNAPSHOT_VERSION },
 			asyncSpawn: true,
@@ -410,6 +423,30 @@ async function executeChecked(
 	const result = await options.execute(`rpc-${method}-${requestId}`, params, controller.signal, undefined, ctx);
 	failIfToolError(result);
 	return dataFromToolResult(result);
+}
+
+function manageParams(params: unknown): SubagentParamsLike {
+	const input = assertRecordParams(params, "manage");
+	if (typeof input.action !== "string" || !(SUBAGENT_RPC_MANAGEMENT_ACTIONS as readonly string[]).includes(input.action)) {
+		throw new SubagentRpcError(
+			"invalid_params",
+			`RPC manage action must be one of: ${SUBAGENT_RPC_MANAGEMENT_ACTIONS.join(", ")}.`,
+		);
+	}
+	if (input.id !== undefined && (typeof input.id !== "string" || !input.id.trim())) {
+		throw new SubagentRpcError("invalid_params", "RPC manage id must be a non-empty string.");
+	}
+	const action = input.action as SubagentRpcManagementAction;
+	const requiresId = action !== "schedule.list";
+	if (requiresId && typeof input.id !== "string") {
+		throw new SubagentRpcError("invalid_params", `RPC manage ${action} requires id.`);
+	}
+	const output: SubagentParamsLike = {
+		action,
+		...(typeof input.id === "string" ? { id: input.id.trim() } : {}),
+	};
+	assertSubagentParams(output, "RPC manage params");
+	return output;
 }
 
 function spawnParams(params: unknown): SubagentParamsLike {
@@ -535,6 +572,9 @@ async function handleRequest(
 	if (request.method === "ping") return pingData(ctx);
 	if (!ctx) throw new SubagentRpcError("no_active_session", "No active extension context for subagent RPC.");
 
+	if (request.method === "manage") {
+		return executeChecked(options, ctx, request.requestId, request.method, manageParams(request.params));
+	}
 	if (request.method === "spawn") {
 		return executeChecked(options, ctx, request.requestId, request.method, spawnParams(request.params));
 	}

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -96,6 +96,10 @@ describe("subagent extension RPC bridge", () => {
 			true,
 		);
 		assert.deepEqual(
+			(reply as { data: { capabilities?: { managementActions?: unknown } } }).data.capabilities?.managementActions,
+			["schedule.list", "schedule.show", "schedule.history", "schedule.pause", "schedule.resume", "schedule.run", "schedule.delete"],
+		);
+		assert.deepEqual(
 			(reply as { data: { capabilities?: { fleetStatus?: unknown } } }).data.capabilities?.fleetStatus,
 			{ version: 1 },
 		);
@@ -152,6 +156,35 @@ describe("subagent extension RPC bridge", () => {
 		assert.deepEqual((reply as { data: { fleet?: unknown } }).data.fleet, {
 			version: 1, entries: [], totalActive: 0, topLevelAsyncCapacity: { used: 0, limit: 0 }, omitted: 0,
 		});
+
+		bridge.dispose();
+	});
+
+	it("delegates allowlisted schedule management through the active session", async () => {
+		const events = new FakeEvents();
+		const executed: unknown[] = [];
+		const bridge = registerSubagentRpcBridge({
+			events,
+			getContext: () => ctx(),
+			execute: async (_id, params) => {
+				executed.push(params);
+				return { content: [{ type: "text", text: "ok" }], details: { mode: "management", results: [] } } as any;
+			},
+		});
+
+		assert.equal((await request(events, "manage-list", "manage", { action: "schedule.list" })).success, true);
+		assert.equal((await request(events, "manage-pause", "manage", { action: "schedule.pause", id: "nightly" })).success, true);
+		assert.deepEqual(executed, [
+			{ action: "schedule.list" },
+			{ action: "schedule.pause", id: "nightly" },
+		]);
+
+		const denied = await request(events, "manage-denied", "manage", { action: "mission.close", id: "mission-1" });
+		assert.equal(denied.success, false);
+		assert.equal((denied as { error: { code: string } }).error.code, "invalid_params");
+		const missingId = await request(events, "manage-missing", "manage", { action: "schedule.run" });
+		assert.equal(missingId.success, false);
+		assert.equal((missingId as { error: { code: string } }).error.code, "invalid_params");
 
 		bridge.dispose();
 	});


### PR DESCRIPTION
## Summary
- add schedule-only `manage` method to extension RPC
- advertise exact allowlist through `ping.capabilities.managementActions`
- reject mission, agent, config, worktree, and arbitrary management actions
- document RPC contract and changelog

## Validation
- `npm run typecheck`
- `node --experimental-strip-types --test test/unit/rpc.test.ts`
- `npm run test:unit` (2247 passed, 3 skipped)