### PR TITLE
feat: add runtime agent registration API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 - Carry full model registry metadata, including tiered pricing, into normalized
   model information. Thanks to [@srcKod](https://github.com/srcKod) for #1317.
+- Add runtime programmatic agent registration for Pi extensions, with fail-closed
+  name and alias collision checks. Thanks to [@fmoda3](https://github.com/fmoda3) for #1310.
 - Let agent definitions and `agentOverrides` set a default `outputMode`, while
   call-level output mode stays higher priority. Thanks to [@bbbRye007](https://github.com/bbbRye007) for #1305.
 - Add `context: "profile"` for workflow children that should use the selected

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "./background-work": "./src/api/background-work.ts",
     "./external-job-provider": "./src/api/external-job-provider.ts",
     "./external-runs": "./src/api/external-runs.ts",
+    "./agents": "./src/api/agents.ts",
     "./delegation": "./src/api/delegation.ts",
     "./capability-ceiling": "./src/api/capability-ceiling.ts",
     "./preflight": "./src/api/preflight.ts",

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -36,10 +36,11 @@ import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import type { AcceptanceInput, Details, ExtensionConfig, ToolBudgetConfig } from "../shared/types.ts";
 import { getProjectConfigDir } from "../shared/utils.ts";
 import { capabilityCeilingAgentRestrictionSources, isAgentAllowedByCapabilityCeiling, resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
+import { listRuntimeAgentConfigs, mergeRuntimeAgents, type RuntimeAgentOwner } from "./runtime-agent-registry.ts";
 
 type ManagementAction = "list" | "get" | "models" | "create" | "update" | "delete" | "eject" | "disable" | "enable" | "reset";
 type ManagementScope = "user" | "project";
-type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry"> & { model?: ExtensionContext["model"]; config?: ExtensionConfig; currentSessionId?: string };
+type ManagementContext = Pick<ExtensionContext, "cwd" | "modelRegistry"> & { model?: ExtensionContext["model"]; config?: ExtensionConfig; currentSessionId?: string; runtimeAgentOwner?: RuntimeAgentOwner };
 
 interface ManagementParams {
 	action?: string;
@@ -142,7 +143,7 @@ function diagnosticsForScope(diagnostics: AgentDiscoveryDiagnostic[] | undefined
 	return diagnostics?.filter((diagnostic) => diagnostic.source !== excludedSource);
 }
 
-const AGENT_SOURCE_PRECEDENCE: Record<AgentSource, number> = { builtin: 0, package: 1, user: 2, project: 3 };
+const AGENT_SOURCE_PRECEDENCE: Record<AgentSource, number> = { builtin: 0, package: 1, user: 2, project: 3, runtime: 4 };
 
 // Returns the highest-precedence definition for a resolved canonical name (project > user > package > builtin),
 // matching mergeAgentsForScope for "both", including disabled agents so disable/enable can locate hidden targets.
@@ -631,7 +632,17 @@ function formatAgentDetail(agent: AgentConfig): string {
 export function handleList(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
 	const scope = normalizeListScope(params.agentScope) ?? "both";
 	const d = discoverAgentsAll(ctx.cwd);
-	const scopedAgents = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package)
+	let scopedAgents = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package);
+	if (ctx.runtimeAgentOwner && listRuntimeAgentConfigs(ctx.runtimeAgentOwner).length > 0) {
+		const configuredAgents: AgentConfig[] = [
+			...d.builtin,
+			...d.package,
+			...d.user,
+			...d.project,
+		];
+		scopedAgents = mergeRuntimeAgents(ctx.runtimeAgentOwner, { agents: scopedAgents }, configuredAgents).agents;
+	}
+	scopedAgents = scopedAgents
 		.sort((a, b) => a.name.localeCompare(b.name));
 	const capabilityCeiling = resolveCurrentSubagentCapabilityCeiling(ctx.currentSessionId);
 	const visibleAgents = scopedAgents.filter((a) => !a.disabled);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -16,6 +16,7 @@ import { mergeAgentsForScope } from "./agent-selection.ts";
 import { parseFrontmatter, parseFrontmatterList } from "./frontmatter.ts";
 import { buildRuntimeName, parsePackageName } from "./identity.ts";
 import { parseModelScopeConfig, type ModelScopeConfig } from "../runs/shared/model-scope.ts";
+export { BUILTIN_AGENT_NAMES } from "./builtin-names.ts";
 export { buildRuntimeName, frontmatterNameForConfig, parsePackageName } from "./identity.ts";
 import { parseMemoryFrontmatter } from "./agent-memory.ts";
 import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
@@ -24,7 +25,7 @@ import { validatePermissionRules, type PermissionRules } from "../runs/shared/pe
 
 export type AgentScope = "user" | "project" | "both";
 
-export type AgentSource = "builtin" | "package" | "user" | "project";
+export type AgentSource = "builtin" | "package" | "user" | "project" | "runtime";
 type SystemPromptMode = "append" | "replace";
 export type AgentDefaultContext = "fresh" | "fork";
 
@@ -34,16 +35,6 @@ export interface AgentMemoryConfig {
 	scope: AgentMemoryScope;
 	path: string;
 }
-
-export const BUILTIN_AGENT_NAMES = [
-	"advisor",
-	"delegate",
-	"oracle",
-	"researcher",
-	"reviewer",
-	"scout",
-	"worker",
-] as const;
 
 export function defaultSystemPromptMode(name: string): SystemPromptMode {
 	return name === "delegate" ? "append" : "replace";
@@ -228,6 +219,7 @@ const AGENT_SOURCE_PRIORITY: Record<AgentSource, number> = {
 	package: 1,
 	user: 2,
 	project: 3,
+	runtime: 4,
 };
 
 function agentDefinitionPriority(definition: Pick<AgentConfig | AgentDiscoveryDiagnostic, "source" | "discoveryPriority">): number {
@@ -543,7 +535,7 @@ function normalizeAgentAliases(rawAliases: string[] | undefined, agentName: stri
 function effectiveAgentMatch(matches: AgentConfig[]): { agent?: AgentConfig; error?: string } {
 	const distinctNames = [...new Set(matches.map((agent) => agent.name))];
 	if (distinctNames.length === 1) {
-		const sourceRank = new Map<AgentConfig["source"], number>([["builtin", 0], ["package", 1], ["user", 2], ["project", 3]]);
+		const sourceRank = new Map<AgentConfig["source"], number>([["builtin", 0], ["package", 1], ["user", 2], ["project", 3], ["runtime", 4]]);
 		const agent = [...matches].sort((a, b) => (sourceRank.get(b.source) ?? 0) - (sourceRank.get(a.source) ?? 0))[0];
 		return agent ? { agent } : {};
 	}

--- a/src/agents/builtin-names.ts
+++ b/src/agents/builtin-names.ts
@@ -1,0 +1,9 @@
+export const BUILTIN_AGENT_NAMES = [
+	"advisor",
+	"delegate",
+	"oracle",
+	"researcher",
+	"reviewer",
+	"scout",
+	"worker",
+] as const;

--- a/src/agents/runtime-agent-registry.ts
+++ b/src/agents/runtime-agent-registry.ts
@@ -1,0 +1,418 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
+import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
+import { validatePermissionRules, type PermissionRules } from "../runs/shared/permissions.ts";
+import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
+import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
+import { BUILTIN_AGENT_NAMES } from "./builtin-names.ts";
+import type { AgentConfig, AgentDefaultContext, AgentDiscoveryDiagnostic } from "./agents.ts";
+
+export const RUNTIME_AGENT_REGISTRY_KEY = "pi-subagents.runtime-agents.v1";
+
+const MAX_RUNTIME_AGENTS_PER_PI = 200;
+const MAX_AGENT_NAME_LENGTH = 128;
+const MAX_DESCRIPTION_LENGTH = 4_096;
+const MAX_SYSTEM_PROMPT_LENGTH = 1024 * 1024;
+const MAX_FIELD_STRING_LENGTH = 8_192;
+
+export interface RuntimeAgentDefinition {
+	description: string;
+	systemPrompt: string;
+	aliases?: readonly string[];
+	tools?: readonly string[];
+	mcpDirectTools?: readonly string[];
+	model?: string;
+	fallbackModels?: readonly string[];
+	thinking?: string | false;
+	systemPromptMode?: "append" | "replace";
+	inheritProjectContext?: boolean;
+	inheritSkills?: boolean;
+	defaultContext?: AgentDefaultContext;
+	defaultAsync?: boolean;
+	defaultTimeoutMs?: number;
+	defaultToolTimeoutMs?: number;
+	defaultTurnBudget?: TurnBudgetConfig;
+	defaultAcceptance?: AcceptanceInput;
+	acceptanceRole?: AcceptanceRole;
+	runner?: AgentRunnerConfig;
+	skills?: readonly string[];
+	skillPath?: readonly string[];
+	extensions?: readonly string[];
+	subagentOnlyExtensions?: readonly string[];
+	output?: string;
+	outputMode?: OutputMode;
+	defaultReads?: readonly string[];
+	defaultProgress?: boolean;
+	interactive?: boolean;
+	maxSubagentDepth?: number;
+	completionGuard?: boolean;
+	toolBudget?: ToolBudgetConfig;
+	permissions?: PermissionRules;
+}
+
+export interface RegisterRuntimeAgentInput {
+	pi: ExtensionAPI;
+	name: string;
+	definition: RuntimeAgentDefinition;
+}
+
+export interface RuntimeAgentRegistration {
+	dispose(): void;
+}
+
+interface RuntimeAgentRecord {
+	pi: ExtensionAPI;
+	agent: AgentConfig;
+}
+
+interface RuntimeAgentRegistry {
+	version: 1;
+	byPi: WeakMap<ExtensionAPI, RuntimeAgentRecord[]>;
+}
+
+export type RuntimeAgentOwner = ExtensionAPI;
+
+function defaultSystemPromptMode(name: string): "append" | "replace" {
+	return name === "delegate" ? "append" : "replace";
+}
+
+function defaultInheritProjectContext(name: string): boolean {
+	return name === "delegate";
+}
+
+function defaultInheritSkills(): boolean {
+	return false;
+}
+
+function registry(): RuntimeAgentRegistry {
+	const key = Symbol.for(RUNTIME_AGENT_REGISTRY_KEY);
+	const globalObject = globalThis as Record<PropertyKey, unknown>;
+	const existing = globalObject[key];
+	if (existing === undefined) {
+		const created: RuntimeAgentRegistry = { version: 1, byPi: new WeakMap() };
+		globalObject[key] = created;
+		return created;
+	}
+	if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+		throw new Error(`Malformed runtime agent registry at Symbol.for("${RUNTIME_AGENT_REGISTRY_KEY}").`);
+	}
+	const candidate = existing as Partial<RuntimeAgentRegistry>;
+	if (candidate.version !== 1 || !(candidate.byPi instanceof WeakMap)) {
+		throw new Error(`Unsupported runtime agent registry at Symbol.for("${RUNTIME_AGENT_REGISTRY_KEY}").`);
+	}
+	return candidate as RuntimeAgentRegistry;
+}
+
+function validatePi(value: unknown): ExtensionAPI {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Runtime agent pi must be an ExtensionAPI object.");
+	const pi = value as Partial<ExtensionAPI>;
+	if (typeof pi.on !== "function" || typeof pi.registerTool !== "function") throw new Error("Runtime agent pi must be an ExtensionAPI object.");
+	return value as ExtensionAPI;
+}
+
+function validateString(value: unknown, field: string, maxLength: number): string {
+	if (typeof value !== "string" || value.length === 0 || value.trim() !== value) {
+		throw new Error(`${field} must be a non-empty string without leading or trailing whitespace.`);
+	}
+	if (value.length > maxLength) throw new Error(`${field} must be at most ${maxLength} characters.`);
+	if (value.includes("\0")) throw new Error(`${field} must not contain NUL characters.`);
+	return value;
+}
+
+function validateOptionalString(value: unknown, field: string, maxLength = MAX_FIELD_STRING_LENGTH): string | undefined {
+	if (value === undefined) return undefined;
+	return validateString(value, field, maxLength);
+}
+
+function validateStringList(value: unknown, field: string): string[] | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value)) throw new Error(`${field} must be an array of strings when provided.`);
+	return [...new Set(value.map((entry, index) => validateString(entry, `${field}[${index}]`, MAX_FIELD_STRING_LENGTH)))];
+}
+
+function validatePositiveInteger(value: unknown, field: string): number | undefined {
+	if (value === undefined) return undefined;
+	if (!Number.isInteger(value) || (value as number) <= 0) throw new Error(`${field} must be a positive integer when provided.`);
+	return value as number;
+}
+
+function validateBoolean(value: unknown, field: string): boolean | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "boolean") throw new Error(`${field} must be a boolean when provided.`);
+	return value;
+}
+
+function isJsonSerializable(value: unknown): boolean {
+	if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+	if (typeof value === "number") return Number.isFinite(value);
+	if (Array.isArray(value)) return value.every(isJsonSerializable);
+	if (value && typeof value === "object") return Object.values(value).every(isJsonSerializable);
+	return false;
+}
+
+function validateRunner(value: unknown): AgentRunnerConfig | undefined {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Runtime agent definition runner must be an object when provided.");
+	const runner = value as Record<string, unknown>;
+	if (runner.type === "pi") {
+		if (Object.keys(runner).some((key) => key !== "type")) throw new Error("Runtime agent definition Pi runner supports only 'type'.");
+		return { type: "pi" };
+	}
+	if (runner.type === "external-job") {
+		if (typeof runner.provider !== "string" || !runner.provider.trim() || runner.provider.trim() !== runner.provider) throw new Error("Runtime agent definition external-job runner requires a non-empty trimmed provider string.");
+		if (runner.options !== undefined && (!runner.options || typeof runner.options !== "object" || Array.isArray(runner.options) || !isJsonSerializable(runner.options))) throw new Error("Runtime agent definition external-job runner options must be a JSON-serializable object.");
+		const supported = new Set(["type", "provider", "options"]);
+		const unknown = Object.keys(runner).filter((key) => !supported.has(key));
+		if (unknown.length > 0) throw new Error(`Runtime agent definition external-job runner has unsupported fields: ${unknown.join(", ")}.`);
+		return { type: "external-job", provider: runner.provider, ...(runner.options ? { options: runner.options as Record<string, unknown> } : {}) };
+	}
+	if (runner.type !== "external-cli") throw new Error("Runtime agent definition runner.type must be 'pi', 'external-cli', or 'external-job'.");
+	if (typeof runner.command !== "string" || !runner.command.trim()) throw new Error("Runtime agent definition external-cli runner requires a non-empty command string.");
+	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) throw new Error("Runtime agent definition external-cli runner args must be an array of strings.");
+	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") throw new Error("Runtime agent definition external-cli runner promptDelivery must be 'stdin'.");
+	const supported = new Set(["type", "command", "args", "promptDelivery"]);
+	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
+	if (unknown.length > 0) throw new Error(`Runtime agent definition external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
+	const args = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
+	return { type: "external-cli", command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}) };
+}
+
+function validateTurnBudget(value: unknown): TurnBudgetConfig | undefined {
+	const result = resolveTurnBudgetConfig(value, "Runtime agent definition defaultTurnBudget");
+	if (result.error) throw new Error(result.error);
+	return result.turnBudget;
+}
+
+function validateAcceptance(value: unknown): AcceptanceInput | undefined {
+	const errors = validateAcceptanceInput(value, "Runtime agent definition defaultAcceptance");
+	if (errors.length > 0) throw new Error(errors.join(" "));
+	return value as AcceptanceInput | undefined;
+}
+
+function validateToolBudget(value: unknown): ToolBudgetConfig | undefined {
+	const result = validateToolBudgetConfig(value, "Runtime agent definition toolBudget");
+	if (result.error) throw new Error(result.error);
+	return result.budget;
+}
+
+function validateDefinition(value: unknown): RuntimeAgentDefinition {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Runtime agent definition must be an object.");
+	const definition = value as Record<string, unknown>;
+	const supported = new Set([
+		"description", "systemPrompt", "aliases", "tools", "mcpDirectTools", "model", "fallbackModels", "thinking",
+		"systemPromptMode", "inheritProjectContext", "inheritSkills", "defaultContext", "defaultAsync", "defaultTimeoutMs",
+		"defaultToolTimeoutMs", "defaultTurnBudget", "defaultAcceptance", "acceptanceRole", "runner", "skills", "skillPath",
+		"extensions", "subagentOnlyExtensions", "output", "outputMode", "defaultReads", "defaultProgress", "interactive",
+		"maxSubagentDepth", "completionGuard", "toolBudget", "permissions",
+	]);
+	const unknown = Object.keys(definition).filter((key) => !supported.has(key));
+	if (unknown.length > 0) throw new Error(`Runtime agent definition has unknown fields: ${unknown.join(", ")}.`);
+	const systemPromptMode = definition.systemPromptMode;
+	if (systemPromptMode !== undefined && systemPromptMode !== "append" && systemPromptMode !== "replace") throw new Error("Runtime agent definition systemPromptMode must be 'append' or 'replace'.");
+	const defaultContext = definition.defaultContext;
+	if (defaultContext !== undefined && defaultContext !== "fresh" && defaultContext !== "fork") throw new Error("Runtime agent definition defaultContext must be 'fresh' or 'fork'.");
+	const thinking = definition.thinking;
+	if (thinking !== undefined && thinking !== false && typeof thinking !== "string") throw new Error("Runtime agent definition thinking must be a string or false when provided.");
+	const acceptanceRole = definition.acceptanceRole;
+	if (acceptanceRole !== undefined && acceptanceRole !== "read-only" && acceptanceRole !== "writer") throw new Error("Runtime agent definition acceptanceRole must be 'read-only' or 'writer'.");
+	const outputMode = definition.outputMode;
+	if (outputMode !== undefined && outputMode !== "inline" && outputMode !== "file-only") throw new Error("Runtime agent definition outputMode must be 'inline' or 'file-only'.");
+	const aliases = validateStringList(definition.aliases, "Runtime agent definition aliases");
+	const tools = validateStringList(definition.tools, "Runtime agent definition tools");
+	const mcpDirectTools = validateStringList(definition.mcpDirectTools, "Runtime agent definition mcpDirectTools");
+	const model = validateOptionalString(definition.model, "Runtime agent definition model");
+	const fallbackModels = validateStringList(definition.fallbackModels, "Runtime agent definition fallbackModels");
+	const inheritProjectContext = validateBoolean(definition.inheritProjectContext, "Runtime agent definition inheritProjectContext");
+	const inheritSkills = validateBoolean(definition.inheritSkills, "Runtime agent definition inheritSkills");
+	const defaultAsync = validateBoolean(definition.defaultAsync, "Runtime agent definition defaultAsync");
+	const defaultTimeoutMs = validatePositiveInteger(definition.defaultTimeoutMs, "Runtime agent definition defaultTimeoutMs");
+	const defaultToolTimeoutMs = validatePositiveInteger(definition.defaultToolTimeoutMs, "Runtime agent definition defaultToolTimeoutMs");
+	const defaultTurnBudget = validateTurnBudget(definition.defaultTurnBudget);
+	const defaultAcceptance = validateAcceptance(definition.defaultAcceptance);
+	const runner = validateRunner(definition.runner);
+	const skills = validateStringList(definition.skills, "Runtime agent definition skills");
+	const skillPath = validateStringList(definition.skillPath, "Runtime agent definition skillPath");
+	const extensions = validateStringList(definition.extensions, "Runtime agent definition extensions");
+	const subagentOnlyExtensions = validateStringList(definition.subagentOnlyExtensions, "Runtime agent definition subagentOnlyExtensions");
+	const output = validateOptionalString(definition.output, "Runtime agent definition output");
+	const defaultReads = validateStringList(definition.defaultReads, "Runtime agent definition defaultReads");
+	const defaultProgress = validateBoolean(definition.defaultProgress, "Runtime agent definition defaultProgress");
+	const interactive = validateBoolean(definition.interactive, "Runtime agent definition interactive");
+	const maxSubagentDepth = validatePositiveInteger(definition.maxSubagentDepth, "Runtime agent definition maxSubagentDepth");
+	const completionGuard = validateBoolean(definition.completionGuard, "Runtime agent definition completionGuard");
+	const toolBudget = validateToolBudget(definition.toolBudget);
+	const permissions = validatePermissionRules(definition.permissions, "Runtime agent definition permissions");
+	return {
+		description: validateString(definition.description, "Runtime agent definition description", MAX_DESCRIPTION_LENGTH),
+		systemPrompt: validateString(definition.systemPrompt, "Runtime agent definition systemPrompt", MAX_SYSTEM_PROMPT_LENGTH),
+		...(aliases ? { aliases } : {}),
+		...(tools ? { tools } : {}),
+		...(mcpDirectTools ? { mcpDirectTools } : {}),
+		...(model ? { model } : {}),
+		...(fallbackModels ? { fallbackModels } : {}),
+		...(thinking !== undefined ? { thinking: thinking as string | false } : {}),
+		...(systemPromptMode !== undefined ? { systemPromptMode: systemPromptMode as "append" | "replace" } : {}),
+		...(inheritProjectContext !== undefined ? { inheritProjectContext } : {}),
+		...(inheritSkills !== undefined ? { inheritSkills } : {}),
+		...(defaultContext !== undefined ? { defaultContext: defaultContext as AgentDefaultContext } : {}),
+		...(defaultAsync !== undefined ? { defaultAsync } : {}),
+		...(defaultTimeoutMs !== undefined ? { defaultTimeoutMs } : {}),
+		...(defaultToolTimeoutMs !== undefined ? { defaultToolTimeoutMs } : {}),
+		...(defaultTurnBudget !== undefined ? { defaultTurnBudget } : {}),
+		...(defaultAcceptance !== undefined ? { defaultAcceptance } : {}),
+		...(acceptanceRole !== undefined ? { acceptanceRole: acceptanceRole as AcceptanceRole } : {}),
+		...(runner !== undefined ? { runner } : {}),
+		...(skills ? { skills } : {}),
+		...(skillPath ? { skillPath } : {}),
+		...(extensions ? { extensions } : {}),
+		...(subagentOnlyExtensions ? { subagentOnlyExtensions } : {}),
+		...(output ? { output } : {}),
+		...(outputMode !== undefined ? { outputMode: outputMode as OutputMode } : {}),
+		...(defaultReads ? { defaultReads } : {}),
+		...(defaultProgress !== undefined ? { defaultProgress } : {}),
+		...(interactive !== undefined ? { interactive } : {}),
+		...(maxSubagentDepth !== undefined ? { maxSubagentDepth } : {}),
+		...(completionGuard !== undefined ? { completionGuard } : {}),
+		...(toolBudget !== undefined ? { toolBudget } : {}),
+		...(permissions !== undefined ? { permissions } : {}),
+	};
+}
+
+function normalizeAliases(rawAliases: readonly string[] | undefined, agentName: string): string[] | undefined {
+	const aliases = [...new Set((rawAliases ?? []).map((alias) => alias.trim()).filter(Boolean))]
+		.filter((alias) => alias !== agentName);
+	return aliases.length > 0 ? aliases : undefined;
+}
+
+function identityKeys(agent: Pick<AgentConfig, "name" | "localName" | "aliases">): string[] {
+	return [agent.name, ...(agent.localName ? [agent.localName] : []), ...(agent.aliases ?? [])];
+}
+
+function assertNoIdentityCollisions(agents: readonly AgentConfig[], context: string): void {
+	const seen = new Map<string, string>();
+	for (const agent of agents) {
+		for (const key of identityKeys(agent)) {
+			const previous = seen.get(key);
+			if (previous !== undefined) throw new Error(`${context} collision for '${key}' between '${previous}' and '${agent.name}'.`);
+			seen.set(key, agent.name);
+		}
+	}
+}
+
+function assertNoRuntimeCollision(agent: AgentConfig, existing: readonly AgentConfig[]): void {
+	const existingKeys = new Map<string, string>();
+	for (const registered of existing) {
+		for (const key of identityKeys(registered)) existingKeys.set(key, registered.name);
+	}
+	for (const key of identityKeys(agent)) {
+		const previous = existingKeys.get(key);
+		if (previous !== undefined) throw new Error(`Runtime agent '${agent.name}' collides with runtime agent '${previous}' on name or alias '${key}'.`);
+	}
+}
+
+function assertNoBuiltinCollision(agent: AgentConfig): void {
+	for (const key of identityKeys(agent)) {
+		if ((BUILTIN_AGENT_NAMES as readonly string[]).includes(key)) throw new Error(`Runtime agent '${agent.name}' collides with builtin agent '${key}'.`);
+	}
+}
+
+function toAgentConfig(name: string, definition: RuntimeAgentDefinition): AgentConfig {
+	const aliases = normalizeAliases(definition.aliases, name);
+	const agent: AgentConfig = {
+		name,
+		description: definition.description,
+		...(aliases ? { aliases } : {}),
+		...(definition.runner !== undefined ? { runner: definition.runner } : {}),
+		...(definition.tools !== undefined ? { tools: [...definition.tools] } : {}),
+		...(definition.mcpDirectTools !== undefined ? { mcpDirectTools: [...definition.mcpDirectTools] } : {}),
+		...(definition.model !== undefined ? { model: definition.model } : {}),
+		...(definition.fallbackModels !== undefined ? { fallbackModels: [...definition.fallbackModels] } : {}),
+		...(definition.thinking !== undefined ? { thinking: definition.thinking } : {}),
+		systemPromptMode: definition.systemPromptMode ?? defaultSystemPromptMode(name),
+		inheritProjectContext: definition.inheritProjectContext ?? defaultInheritProjectContext(name),
+		inheritSkills: definition.inheritSkills ?? defaultInheritSkills(),
+		...(definition.defaultContext !== undefined ? { defaultContext: definition.defaultContext } : {}),
+		...(definition.defaultAsync !== undefined ? { defaultAsync: definition.defaultAsync } : {}),
+		...(definition.defaultTimeoutMs !== undefined ? { defaultTimeoutMs: definition.defaultTimeoutMs } : {}),
+		...(definition.defaultToolTimeoutMs !== undefined ? { defaultToolTimeoutMs: definition.defaultToolTimeoutMs } : {}),
+		...(definition.defaultTurnBudget !== undefined ? { defaultTurnBudget: definition.defaultTurnBudget } : {}),
+		...(definition.defaultAcceptance !== undefined ? { defaultAcceptance: definition.defaultAcceptance } : {}),
+		...(definition.acceptanceRole !== undefined ? { acceptanceRole: definition.acceptanceRole } : {}),
+		systemPrompt: definition.systemPrompt,
+		source: "runtime",
+		filePath: `runtime:${name}`,
+		...(definition.skills !== undefined ? { skills: [...definition.skills] } : {}),
+		...(definition.skillPath !== undefined ? { skillPath: [...definition.skillPath] } : {}),
+		...(definition.extensions !== undefined ? { extensions: [...definition.extensions] } : {}),
+		...(definition.subagentOnlyExtensions !== undefined ? { subagentOnlyExtensions: [...definition.subagentOnlyExtensions] } : {}),
+		...(definition.output !== undefined ? { output: definition.output } : {}),
+		...(definition.outputMode !== undefined ? { outputMode: definition.outputMode } : {}),
+		...(definition.defaultReads !== undefined ? { defaultReads: [...definition.defaultReads] } : {}),
+		...(definition.defaultProgress !== undefined ? { defaultProgress: definition.defaultProgress } : {}),
+		...(definition.interactive !== undefined ? { interactive: definition.interactive } : {}),
+		...(definition.maxSubagentDepth !== undefined ? { maxSubagentDepth: definition.maxSubagentDepth } : {}),
+		...(definition.completionGuard !== undefined ? { completionGuard: definition.completionGuard } : {}),
+		...(definition.toolBudget !== undefined ? { toolBudget: definition.toolBudget } : {}),
+		...(definition.permissions !== undefined ? { permissions: definition.permissions } : {}),
+	};
+	assertNoIdentityCollisions([agent], `Runtime agent '${name}'`);
+	return agent;
+}
+
+export function registerRuntimeAgent(input: RegisterRuntimeAgentInput): RuntimeAgentRegistration {
+	const pi = validatePi(input.pi);
+	const name = validateString(input.name, "Runtime agent name", MAX_AGENT_NAME_LENGTH);
+	const definition = validateDefinition(input.definition);
+	const agent = toAgentConfig(name, definition);
+	assertNoBuiltinCollision(agent);
+	const current = registry();
+	const records = current.byPi.get(pi) ?? [];
+	if (records.length >= MAX_RUNTIME_AGENTS_PER_PI) throw new Error(`Runtime agent registry supports at most ${MAX_RUNTIME_AGENTS_PER_PI} agents per Pi runtime.`);
+	assertNoRuntimeCollision(agent, records.map((record) => record.agent));
+	const record: RuntimeAgentRecord = { pi, agent };
+	records.push(record);
+	current.byPi.set(pi, records);
+	let disposed = false;
+	return {
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			const latest = current.byPi.get(pi);
+			if (!latest) return;
+			const next = latest.filter((entry) => entry !== record);
+			if (next.length > 0) current.byPi.set(pi, next);
+			else current.byPi.delete(pi);
+		},
+	};
+}
+
+export function clearRuntimeAgentsForPi(pi: RuntimeAgentOwner): void {
+	registry().byPi.delete(pi);
+}
+
+export function listRuntimeAgentConfigs(pi: RuntimeAgentOwner): AgentConfig[] {
+	return (registry().byPi.get(pi) ?? []).map((record) => ({ ...record.agent, aliases: record.agent.aliases ? [...record.agent.aliases] : undefined }));
+}
+
+function assertNoConfiguredCollision(configuredAgents: readonly AgentConfig[], runtimeAgents: readonly AgentConfig[]): void {
+	const configured = new Map<string, string>();
+	for (const agent of configuredAgents) {
+		for (const key of identityKeys(agent)) configured.set(key, agent.name);
+	}
+	for (const agent of runtimeAgents) {
+		for (const key of identityKeys(agent)) {
+			const previous = configured.get(key);
+			if (previous !== undefined) {
+				throw new Error(`Runtime agent '${agent.name}' collides with configured agent '${previous}' on name or alias '${key}'.`);
+			}
+		}
+	}
+}
+
+export function mergeRuntimeAgents<T extends { agents: AgentConfig[]; agentDiagnostics?: AgentDiscoveryDiagnostic[] }>(pi: RuntimeAgentOwner, discovered: T, configuredAgents: readonly AgentConfig[] = discovered.agents): T {
+	const runtimeAgents = listRuntimeAgentConfigs(pi).filter((agent) => agent.disabled !== true);
+	if (runtimeAgents.length === 0) return discovered;
+	assertNoIdentityCollisions(runtimeAgents, "Runtime agent registration");
+	assertNoConfiguredCollision(configuredAgents, runtimeAgents);
+	return { ...discovered, agents: [...discovered.agents, ...runtimeAgents] };
+}

--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -1,0 +1,7 @@
+import { registerRuntimeAgent, type RegisterRuntimeAgentInput, type RuntimeAgentDefinition, type RuntimeAgentRegistration } from "../agents/runtime-agent-registry.ts";
+
+export type { RegisterRuntimeAgentInput, RuntimeAgentDefinition, RuntimeAgentRegistration };
+
+export function registerAgent(input: RegisterRuntimeAgentInput): RuntimeAgentRegistration {
+	return registerRuntimeAgent(input);
+}

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -141,6 +141,7 @@ function formatDiscovery(input: DoctorReportInput, deps: DoctorDeps): string[] {
 				package: discovered.package?.length ?? 0,
 				user: discovered.user.length,
 				project: discovered.project.length,
+				runtime: 0,
 			};
 			const diagnostics = discovered.agentDiagnostics ?? [];
 			return [

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -19,7 +19,8 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { keyText, type ExtensionAPI, type ExtensionContext, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Box, Container, Spacer, Text, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
-import { discoverAgents } from "../agents/agents.ts";
+import { discoverAgents, discoverAgentsAll, type AgentConfig, type AgentScope } from "../agents/agents.ts";
+import { clearRuntimeAgentsForPi, listRuntimeAgentConfigs, mergeRuntimeAgents } from "../agents/runtime-agent-registry.ts";
 import { ensureAccessibleDir } from "../shared/accessible-dir.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
@@ -489,6 +490,18 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		if (scheduledRunManager.observedCompletionRunIds().size > 0) return true;
 		return missionObserverResultCandidateFiles(DIRS.results).length > 0;
 	};
+	const discoverAgentsForRuntime = (cwd: string, scope: AgentScope) => {
+		const discovered = discoverAgents(cwd, scope);
+		if (listRuntimeAgentConfigs(pi).length === 0) return discovered;
+		const all = discoverAgentsAll(cwd);
+		const configuredAgents: AgentConfig[] = [
+			...all.builtin,
+			...all.package,
+			...all.user,
+			...all.project,
+		];
+		return mergeRuntimeAgents(pi, discovered, configuredAgents);
+	};
 	const { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs, dispose: disposeAsyncJobTracker } = createAsyncJobTracker(pi, state, DIRS.async, {
 		widgetEnabled: asyncWidgetEnabled,
 		onJobTerminal: () => refreshResultDelivery(),
@@ -539,7 +552,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		tempArtifactsDir,
 		getSubagentSessionRoot,
 		expandTilde,
-		discoverAgents,
+		discoverAgents: discoverAgentsForRuntime,
 		activateSupervisorTransport: () => supervisorChannel.activateTransport(),
 		refreshResultDelivery: () => refreshResultDelivery(),
 	});
@@ -882,6 +895,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			if (runtimeCleaned) return;
 			runtimeCleaned = true;
 			const shuttingDownParentSession = parentSessionEnvValue;
+			clearRuntimeAgentsForPi(pi);
 			clearTimeout(resultIndexCleanupTimer);
 			clearTimeout(asyncRetentionTimer);
 			asyncRetentionAbort.abort();

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5204,6 +5204,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				cwd: requestCwd,
 				config: deps.config,
 				currentSessionId: deps.state.currentSessionId ?? ctx.sessionManager.getSessionId() ?? undefined,
+				runtimeAgentOwner: deps.pi,
 			});
 		}
 

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -3,7 +3,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { keyText, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Key, matchesKey, truncateToWidth, type Component, type KeyId, type TUI } from "@earendil-works/pi-tui";
-import { BUILTIN_AGENT_NAMES, discoverAgents, findBlockingAgentDiagnostic, resolveAgentName } from "../agents/agents.ts";
+import { BUILTIN_AGENT_NAMES, discoverAgents, discoverAgentsAll, findBlockingAgentDiagnostic, resolveAgentName, type AgentConfig, type AgentDiscoveryDiagnostic, type AgentScope } from "../agents/agents.ts";
+import { listRuntimeAgentConfigs, mergeRuntimeAgents } from "../agents/runtime-agent-registry.ts";
 import { resolveExistingReadPaths } from "../shared/settings.ts";
 import {
 	DEFAULT_PROVIDER_MODELS_MAX_AGE_DAYS,
@@ -107,9 +108,22 @@ const extractExecutionFlags = (rawArgs: string): { args: string; bg: boolean; fo
 	return { args, bg, fork };
 };
 
-const makeAgentCompletions = (state: SubagentState) => (prefix: string) => {
+function discoverSlashAgents(pi: ExtensionAPI, cwd: string, scope: AgentScope): { agents: AgentConfig[]; agentDiagnostics?: AgentDiscoveryDiagnostic[] } {
+	const discovered = discoverAgents(cwd, scope);
+	if (listRuntimeAgentConfigs(pi).length === 0) return discovered;
+	const all = discoverAgentsAll(cwd);
+	const configuredAgents: AgentConfig[] = [
+		...all.builtin,
+		...all.package,
+		...(scope !== "project" ? all.user : []),
+		...(scope !== "user" ? all.project : []),
+	];
+	return mergeRuntimeAgents(pi, discovered, configuredAgents);
+}
+
+const makeAgentCompletions = (pi: ExtensionAPI, state: SubagentState) => (prefix: string) => {
 	if (!state.baseCwd || prefix.includes(" ")) return null;
-	return discoverAgents(state.baseCwd, "both").agents
+	return discoverSlashAgents(pi, state.baseCwd, "both").agents
 		.filter((agent) => agent.name.startsWith(prefix))
 		.map((agent) => ({ value: agent.name, label: agent.name }));
 };
@@ -662,7 +676,7 @@ export function registerSlashCommands(
 
 	pi.registerCommand("run", {
 		description: "Run one subagent through workflowScript: /run agent[output=file] [task] [--bg] [--fork]",
-		getArgumentCompletions: makeAgentCompletions(state),
+		getArgumentCompletions: makeAgentCompletions(pi, state),
 		handler: async (args, ctx) => {
 			const { args: cleanedArgs, bg, fork } = extractExecutionFlags(args);
 			const input = cleanedArgs.trim();
@@ -672,7 +686,7 @@ export function registerSlashCommands(
 			const task = firstSpace === -1 ? "" : input.slice(firstSpace + 1).trim();
 
 			if (!state.baseCwd) { ctx.ui.notify("Subagent session cwd is not initialized yet", "error"); return; }
-			const discovered = discoverAgents(state.baseCwd, "both");
+			const discovered = discoverSlashAgents(pi, state.baseCwd, "both");
 			const resolvedAgent = resolveAgentName(agentName, discovered.agents);
 			const candidates = resolvedAgent.error
 				? discovered.agents.filter((agent) => resolveAgentName(agentName, [agent]).agent)
@@ -746,7 +760,7 @@ export function registerSlashCommands(
 
 	pi.registerCommand("subagents-refine", {
 		description: "Generate a bounded project-local refinement overlay for one subagent",
-		getArgumentCompletions: makeAgentCompletions(state),
+		getArgumentCompletions: makeAgentCompletions(pi, state),
 		handler: async (args, ctx) => {
 			const parts = args.trim().split(/\s+/).filter(Boolean);
 			if (parts.length !== 1) {

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -5,6 +5,8 @@ import * as path from "node:path";
 import { beforeEach, describe, it } from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 
+import { registerAgent } from "../../src/api/agents.ts";
+import { clearRuntimeAgentsForPi } from "../../src/agents/runtime-agent-registry.ts";
 import { scheduledRunStorePath } from "../../src/runs/background/scheduled-runs.ts";
 import { SUBAGENT_FANOUT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
 import { ASYNC_DIR, DIRS } from "../../src/shared/types.ts";
@@ -18,6 +20,15 @@ const SLASH_SUBAGENT_RESPONSE_EVENT = "subagent:slash:response";
 interface EventBus {
 	on(event: string, handler: (data: unknown) => void): () => void;
 	emit(event: string, data: unknown): void;
+}
+
+interface RuntimeSlashPi {
+	events: EventBus;
+	on(event: string, handler: (data: unknown) => void): () => void;
+	registerTool(tool: unknown): void;
+	registerCommand(name: string, spec: RegisteredSlashCommand): void;
+	registerShortcut(key: string, spec: { handler(ctx: unknown): Promise<void> }): void;
+	sendMessage(message: unknown): void;
 }
 
 type RegisteredSlashCommand = { handler(args: string, ctx: unknown): Promise<void>; getArgumentCompletions?: (prefix: string) => unknown };
@@ -220,10 +231,9 @@ async function captureSlashCommandParams(
 	commandName: string,
 	args: string,
 	cwd: string,
-	setup?: () => void,
+	setup?: (pi: RuntimeSlashPi) => void,
 ): Promise<{ params: unknown; notifications: string[] }> {
 	return withIsolatedHome(async () => {
-		setup?.();
 		const commands = new Map<string, RegisteredSlashCommand>();
 		const events = createEventBus();
 		let requestedParams: unknown;
@@ -244,6 +254,8 @@ async function captureSlashCommandParams(
 
 		const pi = {
 			events,
+			on() { return () => {}; },
+			registerTool() {},
 			registerCommand(name: string, spec: RegisteredSlashCommand) {
 				commands.set(name, spec);
 			},
@@ -251,14 +263,19 @@ async function captureSlashCommandParams(
 			sendMessage(_message: unknown) {},
 		};
 
-		registerSlashCommands!(pi, createState(cwd));
-		await commands.get(commandName)!.handler(args, createCommandContext({
-			cwd,
-			notify: (message) => {
-				notifications.push(message);
-			},
-		}));
-		return { params: requestedParams, notifications };
+		try {
+			setup?.(pi);
+			registerSlashCommands!(pi, createState(cwd));
+			await commands.get(commandName)!.handler(args, createCommandContext({
+				cwd,
+				notify: (message) => {
+					notifications.push(message);
+				},
+			}));
+			return { params: requestedParams, notifications };
+		} finally {
+			clearRuntimeAgentsForPi(pi as never);
+		}
 	});
 }
 
@@ -663,6 +680,23 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 			const run = await captureSlashCommandParams("run", "code-analysis.zeta-worker", root);
 			assert.equal(run.params, undefined);
 			assert.match(run.notifications[0] ?? "", /Agent 'code-analysis\.zeta-worker' has invalid configuration: Agent 'zeta-worker' has invalid runner\.type/);
+		});
+	});
+
+	it("/run accepts runtime-registered agents", async () => {
+		await withTempProject("pi-slash-runtime-agent-", async (root) => {
+			const run = await captureSlashCommandParams("run", "runtime-helper Inspect", root, (pi) => {
+				registerAgent({
+					pi: pi as never,
+					name: "runtime-helper",
+					definition: { description: "Runtime helper", systemPrompt: "Help at runtime." },
+				});
+			});
+
+			assert.deepEqual(run.params, {
+				workflowScript: "return runs.run(\"run\", {\"agent\":\"runtime-helper\",\"task\":\"Inspect\",\"agentScope\":\"both\"})",
+				async: false,
+			});
 		});
 	});
 

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -56,6 +56,7 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.equal(fs.existsSync(path.join(projectRoot, "src", "api", "delegation.ts")), true);
 	assert.deepEqual(packageJson.exports, {
 		".": "./index.ts",
+		"./agents": "./src/api/agents.ts",
 		"./background-work": "./src/api/background-work.ts",
 		"./external-job-provider": "./src/api/external-job-provider.ts",
 		"./external-runs": "./src/api/external-runs.ts",

--- a/test/unit/runtime-agent-registration.test.ts
+++ b/test/unit/runtime-agent-registration.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { registerAgent } from "../../src/api/agents.ts";
+import { handleList } from "../../src/agents/agent-management.ts";
+import { discoverAgents, discoverAgentsAll } from "../../src/agents/agents.ts";
+import { clearRuntimeAgentsForPi, mergeRuntimeAgents } from "../../src/agents/runtime-agent-registry.ts";
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+let tempHome = "";
+let tempProject = "";
+let pi: ExtensionAPI;
+
+function makePi(): ExtensionAPI {
+	return {
+		on() {},
+		registerTool() {},
+	} as unknown as ExtensionAPI;
+}
+
+function writeProjectAgent(name: string, aliases: string[] = []): void {
+	const filePath = path.join(tempProject, ".pi", "agents", `${name}.md`);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, `---\nname: ${name}\ndescription: Project agent\n${aliases.length ? `aliases: ${aliases.join(", ")}\n` : ""}---\n\nProject prompt.\n`, "utf-8");
+}
+
+function writeUserAgent(name: string, aliases: string[] = []): void {
+	const filePath = path.join(tempHome, ".pi", "agent", "agents", `${name}.md`);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, `---\nname: ${name}\ndescription: User agent\n${aliases.length ? `aliases: ${aliases.join(", ")}\n` : ""}---\n\nUser prompt.\n`, "utf-8");
+}
+
+describe("runtime agent registration", () => {
+	beforeEach(() => {
+		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-runtime-agent-home-"));
+		tempProject = fs.mkdtempSync(path.join(os.tmpdir(), "pi-runtime-agent-project-"));
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+		delete process.env.PI_CODING_AGENT_DIR;
+		pi = makePi();
+	});
+
+	afterEach(() => {
+		clearRuntimeAgentsForPi(pi);
+		if (originalHome === undefined) delete process.env.HOME;
+		else process.env.HOME = originalHome;
+		if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = originalUserProfile;
+		if (originalPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+		fs.rmSync(tempHome, { recursive: true, force: true });
+		fs.rmSync(tempProject, { recursive: true, force: true });
+	});
+
+	it("adds runtime agents to extension discovery without writing config", () => {
+		const settingsPath = path.join(tempHome, ".pi", "agent", "settings.json");
+		const registration = registerAgent({
+			pi,
+			name: "runtime-helper",
+			definition: {
+				description: "Runtime helper",
+				systemPrompt: "Help at runtime.",
+				aliases: ["helper"],
+				model: "openai/gpt-5-mini",
+			},
+		});
+
+		const agents = mergeRuntimeAgents(pi, discoverAgents(tempProject, "both")).agents;
+		const agent = agents.find((candidate) => candidate.name === "runtime-helper");
+		assert.equal(agent?.source, "runtime");
+		assert.deepEqual(agent?.aliases, ["helper"]);
+		assert.equal(agent?.systemPrompt, "Help at runtime.");
+		assert.equal(fs.existsSync(settingsPath), false);
+
+		registration.dispose();
+		assert.equal(mergeRuntimeAgents(pi, discoverAgents(tempProject, "both")).agents.some((candidate) => candidate.name === "runtime-helper"), false);
+		registration.dispose();
+	});
+
+	it("lists runtime agents for the matching Pi runtime", () => {
+		registerAgent({
+			pi,
+			name: "runtime-helper",
+			definition: { description: "Runtime helper", systemPrompt: "Help at runtime.", aliases: ["helper"] },
+		});
+
+		const listed = handleList({}, { cwd: tempProject, modelRegistry: { getAvailable: () => [] }, runtimeAgentOwner: pi });
+		const text = listed.content.map((part) => part.type === "text" ? part.text ?? "" : "").join("\n");
+		assert.match(text, /- runtime-helper \(runtime, aliases: helper\): Runtime helper/);
+	});
+
+	it("fails closed for builtin and duplicate runtime identities", () => {
+		assert.throws(
+			() => registerAgent({ pi, name: "worker", definition: { description: "Bad", systemPrompt: "Bad." } }),
+			/Worker|builtin agent 'worker'|collides with builtin agent 'worker'/i,
+		);
+
+		registerAgent({ pi, name: "runtime-a", definition: { description: "A", systemPrompt: "A.", aliases: ["shared"] } });
+		assert.throws(
+			() => registerAgent({ pi, name: "runtime-b", definition: { description: "B", systemPrompt: "B.", aliases: ["shared"] } }),
+			/collides with runtime agent 'runtime-a' on name or alias 'shared'/,
+		);
+	});
+
+	it("rejects malformed nested runtime definition fields at registration", () => {
+		const cases: Array<[string, Record<string, unknown>, RegExp]> = [
+			["defaultTurnBudget", { defaultTurnBudget: { maxTurns: 0 } }, /defaultTurnBudget\.maxTurns must be an integer >= 1/],
+			["defaultAcceptance", { defaultAcceptance: { level: "verified" } }, /defaultAcceptance\.verify must contain at least one runtime command/],
+			["runner", { runner: { type: "external-cli" } }, /external-cli runner requires a non-empty command string/],
+			["toolBudget", { toolBudget: { hard: 0 } }, /toolBudget\.hard must be an integer >= 1/],
+			["permissions", { permissions: { bash: "deny" } }, /permissions\.bash is unsupported/],
+		];
+
+		for (const [name, extra, pattern] of cases) {
+			assert.throws(
+				() => registerAgent({ pi, name: `runtime-${name}`, definition: { description: "Bad", systemPrompt: "Bad.", ...extra } }),
+				pattern,
+			);
+		}
+	});
+
+	it("fails closed when cwd discovery introduces a configured collision", () => {
+		registerAgent({ pi, name: "runtime-helper", definition: { description: "Runtime helper", systemPrompt: "Help.", aliases: ["helper"] } });
+		writeProjectAgent("project-helper", ["helper"]);
+
+		assert.throws(
+			() => mergeRuntimeAgents(pi, discoverAgents(tempProject, "both")),
+			/collides with configured agent 'project-helper' on name or alias 'helper'/,
+		);
+	});
+
+	it("fails closed against configured definitions hidden by scope precedence", () => {
+		registerAgent({ pi, name: "hidden-user", definition: { description: "Runtime helper", systemPrompt: "Help." } });
+		writeUserAgent("hidden-user");
+		writeProjectAgent("hidden-user");
+		const discovered = discoverAgents(tempProject, "both");
+		assert.equal(discovered.agents.find((agent) => agent.name === "hidden-user")?.source, "project");
+
+		const allDiscovered = discoverAgentsAll(tempProject);
+		const all = [...allDiscovered.builtin, ...allDiscovered.package, ...allDiscovered.user, ...allDiscovered.project];
+		assert.throws(
+			() => mergeRuntimeAgents(pi, discovered, all),
+			/collides with configured agent 'hidden-user' on name or alias 'hidden-user'/,
+		);
+	});
+
+	it("fails closed against configured definitions hidden by explicit scope", () => {
+		registerAgent({ pi, name: "hidden-user", definition: { description: "Runtime helper", systemPrompt: "Help." } });
+		writeUserAgent("hidden-user");
+		const projectScoped = discoverAgents(tempProject, "project");
+		const allProject = discoverAgentsAll(tempProject);
+		assert.equal(projectScoped.agents.some((agent) => agent.name === "hidden-user"), false);
+		assert.throws(
+			() => mergeRuntimeAgents(pi, projectScoped, [...allProject.builtin, ...allProject.package, ...allProject.user, ...allProject.project]),
+			/collides with configured agent 'hidden-user' on name or alias 'hidden-user'/,
+		);
+	});
+
+	it("fails closed for management lists when scoped discovery hides a configured collision", () => {
+		registerAgent({ pi, name: "hidden-user", definition: { description: "Runtime hidden", systemPrompt: "Help." } });
+		writeUserAgent("hidden-user");
+
+		assert.throws(
+			() => handleList({ agentScope: "project" }, { cwd: tempProject, modelRegistry: { getAvailable: () => [] }, runtimeAgentOwner: pi }),
+			/collides with configured agent 'hidden-user' on name or alias 'hidden-user'/,
+		);
+	});
+});


### PR DESCRIPTION
Adds a runtime-scoped programmatic agent registration API for Pi extensions. Runtime agents stay in process memory, clean up with the extension runtime, and fail closed on builtin, configured, package, user, project, or alias collisions.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/runtime-agent-registration.test.ts test/integration/slash-commands.test.ts test/unit/agent-management.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Thanks to [@fmoda3](https://github.com/fmoda3) for #1310.

Closes #1310
