### PR TITLE
refactor: deslop unreleased cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - Add a separate classifier for model context-overflow errors. Thanks to [@srcKod](https://github.com/srcKod) for #1312.
 - Normalize child result metadata before workflow return persistence (#1307).
 - Quote only confidently identified leading Windows executable paths in acceptance verification commands. Thanks to [@srcKod](https://github.com/srcKod) for #1294.
+- Keep forked subagent sessions out of top-level `pi -c` discovery by storing them under the parent session root. Thanks to [@xz-dev](https://github.com/xz-dev) for #1297.
+- Preserve `/council` advisor context defaults during fallback and cross-exam runs (#1298).
 
 ### Changed
 - Show bounded workflow progress in Fleet detail views while keeping workflow
@@ -35,10 +37,6 @@
 - Reuse validated workflow launch fingerprints during `runs.all` batch setup, reducing focused fingerprint bookkeeping time by 48.7% (#1287).
 - Speed up recent terminal run history reads when the marker history is large and the requested limit is small.
 - Reduce repeated serialization while applying async status snapshot byte caps (#1288).
-
-### Fixed
-- Keep forked subagent sessions out of top-level `pi -c` discovery by storing them under the parent session root. Thanks to [@xz-dev](https://github.com/xz-dev) for #1297.
-- Preserve `/council` advisor context defaults during fallback and cross-exam runs (#1298).
 
 ## [0.52.1] - 2026-08-20
 

--- a/src/agents/runtime-agent-registry.ts
+++ b/src/agents/runtime-agent-registry.ts
@@ -173,7 +173,7 @@ function validateRunner(value: unknown): AgentRunnerConfig | undefined {
 	const supported = new Set(["type", "command", "args", "promptDelivery"]);
 	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
 	if (unknown.length > 0) throw new Error(`Runtime agent definition external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
-	const args = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
+	const args = runner.args as string[] | undefined;
 	return { type: "external-cli", command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}) };
 }
 

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -144,18 +144,28 @@ function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, resul
 		resumability = { state: "not-resumable", reason: error instanceof Error ? error.message : String(error) };
 	}
 	const outputReference = result.savedOutputPath ?? result.outputReference?.path ?? entry.outputReference;
+	const updatedEntry: WorkflowReceipt["entries"][string] = resumability.state === "resumable"
+		? {
+			...entry,
+			...(step.agent ? { agent: step.agent } : {}),
+			...(step.context ? { resolvedContext: step.context } : {}),
+			latestRunId: entry.latestRunId ?? childRunId,
+			resumability,
+			...(outputReference ? { outputReference } : {}),
+		}
+		: {
+			...entry,
+			...(step.agent ? { agent: step.agent } : {}),
+			...(step.context ? { resolvedContext: step.context } : {}),
+			resumability,
+			...(outputReference ? { outputReference } : {}),
+		};
 	const next: WorkflowReceipt = {
 		...receipt,
 		state: status.state === "complete" ? "complete" : status.state === "stopped" ? "stopped" : status.state === "paused" ? "paused" : "failed",
 		entries: {
 			...receipt.entries,
-			[key]: {
-				...entry,
-				...(step.agent ? { agent: step.agent } : {}),
-				...(step.context ? { resolvedContext: step.context } : {}),
-				resumability,
-				...(outputReference ? { outputReference } : {}),
-			},
+			[key]: updatedEntry,
 		},
 	};
 	writeWorkflowReceipt(asyncDir, next);

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -4,13 +4,18 @@ import { TEMP_ROOT_DIR } from "../../shared/types.ts";
 
 export const EXCLUSIONS_PATH_ENV = "PI_MODEL_EXCLUSIONS_PATH";
 
-export interface ModelExclusion {
-	modelId?: string;
-	provider?: string;
+type ModelExclusionTarget = { modelId: string; provider?: string } | { provider: string; modelId?: never };
+
+export type ModelExclusion = ModelExclusionTarget & {
 	reason?: string;
 	recordedAt: number;
 	expiresAt: number;
-}
+};
+
+type RecordModelFailureOptions = ModelExclusionTarget & {
+	reason?: string;
+	ttlMs?: number;
+};
 
 let exclusions: ModelExclusion[] = [];
 let loaded = false;
@@ -18,11 +23,10 @@ let defaultTTLMs = 24 * 60 * 60_000; // 24 hours, overridable via setDefaultTTL
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
 let persistSeq = 0;
 
-/**
- * Override the default exclusion TTL. Invalid or non-positive values are ignored.
- */
+/** Override the default exclusion TTL. */
 export function setDefaultTTL(ms: number): void {
-	if (Number.isFinite(ms) && ms > 0) defaultTTLMs = ms;
+	if (!Number.isFinite(ms) || ms <= 0) throw new Error("Default model exclusion TTL must be a finite positive number.");
+	defaultTTLMs = ms;
 }
 
 /**
@@ -106,18 +110,15 @@ function deduplicate(items: ModelExclusion[]): ModelExclusion[] {
  * the provider when modelId is omitted), and {@link filterFallbackCandidates}
  * removes matching candidates from fallback lists.
  */
-export function recordModelFailure(options: {
-	modelId?: string;
-	provider?: string;
-	reason?: string;
-	ttlMs?: number;
-}): void {
+export function recordModelFailure(options: RecordModelFailureOptions): void {
 	ensureLoaded();
 	const ttl = options.ttlMs ?? defaultTTLMs;
 	const now = Date.now();
+	const target: ModelExclusionTarget = options.modelId !== undefined
+		? { modelId: options.modelId, ...(options.provider ? { provider: options.provider } : {}) }
+		: { provider: options.provider };
 	const exclusion: ModelExclusion = {
-		modelId: options.modelId,
-		provider: options.provider,
+		...target,
 		reason: options.reason ?? "runtime-failure",
 		recordedAt: now,
 		expiresAt: now + ttl,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -73,16 +73,18 @@ export interface WorkflowGraphSnapshot {
 
 export type WorkflowReceiptState = "complete" | "failed" | "paused" | "stopped";
 
-export interface WorkflowReceiptEntry {
+type WorkflowReceiptEntryResumability =
+	| { latestRunId: string; resumability: { state: "resumable" } }
+	| { latestRunId?: string; resumability: { state: "not-resumable"; reason: string } };
+
+export type WorkflowReceiptEntry = WorkflowReceiptEntryResumability & {
 	key: string;
 	agent?: string;
 	requestedContext?: "fresh" | "fork";
 	resolvedContext?: "fresh" | "fork" | "mixed";
-	latestRunId?: string;
-	resumability: { state: "resumable" } | { state: "not-resumable"; reason: string };
 	outputReference?: string;
 	continuation: { runIds: string[] };
-}
+};
 
 export interface WorkflowReceipt {
 	version: 1;

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -41,16 +41,19 @@ export function buildWorkflowReceipt(input: {
 		if (entries[key]) throw new Error(`Workflow receipt has duplicate child key '${key}'.`);
 		const runIds = [...new Set((child.continuation?.runIds ?? (child.runId ? [child.runId] : [])).filter((runId) => typeof runId === "string" && runId.trim()).map((runId) => runId.trim()))];
 		const latestRunId = runIds.at(-1);
-		entries[key] = {
+		const resumability = child.resumability ?? { state: "not-resumable", reason: child.runId ? "resumability was not recorded" : "child produced no run id" };
+		if (resumability.state === "resumable" && !latestRunId) throw new Error(`Workflow receipt child '${key}' is resumable but has no retained run id.`);
+		const base = {
 			key,
 			...(child.agent ? { agent: child.agent } : {}),
 			...(child.requestedContext ? { requestedContext: child.requestedContext } : {}),
 			...(child.resolvedContext ? { resolvedContext: child.resolvedContext } : {}),
-			...(latestRunId ? { latestRunId } : {}),
-			resumability: child.resumability ?? { state: "not-resumable", reason: child.runId ? "resumability was not recorded" : "child produced no run id" },
 			...(child.outputReference ? { outputReference: child.outputReference } : {}),
 			continuation: { runIds },
 		};
+		entries[key] = resumability.state === "resumable"
+			? { ...base, latestRunId: latestRunId!, resumability }
+			: { ...base, ...(latestRunId ? { latestRunId } : {}), resumability };
 	}
 	return { version: WORKFLOW_RECEIPT_VERSION, workflowRunId, state: input.state, createdAt: input.createdAt ?? Date.now(), entries };
 }
@@ -79,6 +82,7 @@ function parseEntry(value: unknown, key: string, source: string): WorkflowReceip
 	const state = (resumability as Record<string, unknown>).state;
 	if (state !== "resumable" && state !== "not-resumable") throw new Error(`Invalid workflow receipt '${source}': entry '${key}' resumability state is invalid.`);
 	const reason = (resumability as Record<string, unknown>).reason;
+	if (state === "resumable" && latestRunId === undefined) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' resumable entry has no retained run id.`);
 	if (state === "not-resumable" && (typeof reason !== "string" || !reason.trim())) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' non-resumable reason is missing.`);
 	return value as WorkflowReceiptEntry;
 }
@@ -110,17 +114,20 @@ export function resolveWorkflowReceiptResumeEntry(input: {
 	reference: WorkflowReceiptResumeReference;
 	asyncDirRoot: string;
 	assertResumable?: (runId: string) => void;
-}): WorkflowReceiptEntry {
+}): WorkflowReceiptEntry & { latestRunId: string; resumability: { state: "resumable" } } {
 	if (input.reference.latest !== true) throw new Error("Keyed workflow receipt resume requires latest: true.");
 	const key = assertKey(input.reference.key, "keyed resume key");
 	const receipt = readWorkflowReceipt(input.asyncDirRoot, input.reference.workflowRunId.trim());
 	const entry = receipt.entries[key];
 	if (!entry) throw new Error(`Workflow receipt '${receipt.workflowRunId}' has no child key '${key}'.`);
-	if (entry.resumability.state !== "resumable") throw new Error(`Workflow receipt '${receipt.workflowRunId}' child '${key}' is not resumable: ${entry.resumability.reason}.`);
-	const runId = entry.latestRunId;
-	if (!runId) throw new Error(`Workflow receipt '${receipt.workflowRunId}' child '${key}' has no retained run id.`);
-	input.assertResumable?.(runId);
+	assertResumableEntry(entry, receipt.workflowRunId, key);
+	input.assertResumable?.(entry.latestRunId);
 	return entry;
+}
+
+function assertResumableEntry(entry: WorkflowReceiptEntry, workflowRunId: string, key: string): asserts entry is WorkflowReceiptEntry & { latestRunId: string; resumability: { state: "resumable" } } {
+	if (entry.resumability.state !== "resumable") throw new Error(`Workflow receipt '${workflowRunId}' child '${key}' is not resumable: ${entry.resumability.reason}.`);
+	if (!entry.latestRunId) throw new Error(`Workflow receipt '${workflowRunId}' child '${key}' has no retained run id.`);
 }
 
 export function resolveWorkflowReceiptResume(input: {
@@ -129,7 +136,5 @@ export function resolveWorkflowReceiptResume(input: {
 	assertResumable?: (runId: string) => void;
 }): string {
 	const entry = resolveWorkflowReceiptResumeEntry(input);
-	const runId = entry.latestRunId;
-	if (!runId) throw new Error(`Workflow receipt child '${entry.key}' has no retained run id.`);
-	return runId;
+	return entry.latestRunId;
 }

--- a/test/unit/model-exclusions.test.ts
+++ b/test/unit/model-exclusions.test.ts
@@ -11,12 +11,16 @@ import {
 	parseModelKey,
 	recordModelFailure,
 	reloadFromDisk,
+	setDefaultTTL,
 } from "../../src/runs/shared/model-exclusions.ts";
 
 // The exclusion store is a process-wide singleton persisted under TEMP_ROOT_DIR
 // (isolated per test run by test/support/isolated-temp-root.mjs). Clear it
 // before/after each test so cases don't leak state into each other.
-beforeEach(() => clearExclusions());
+beforeEach(() => {
+	fs.rmSync(getExclusionsFilePath(), { force: true });
+	clearExclusions();
+});
 afterEach(() => clearExclusions());
 
 describe("model exclusions — record & query", () => {
@@ -54,6 +58,11 @@ describe("model exclusions — record & query", () => {
 });
 
 describe("model exclusions — TTL expiry", () => {
+	it("rejects invalid default TTLs", () => {
+		assert.throws(() => setDefaultTTL(0), /finite positive/);
+		assert.throws(() => setDefaultTTL(Number.POSITIVE_INFINITY), /finite positive/);
+	});
+
 	it("drops an exclusion after its TTL elapses", async () => {
 		recordModelFailure({ modelId: "gpt-4", provider: "openai", ttlMs: 100 });
 		assert.equal(isExcluded("gpt-4", "openai"), true);

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { stopRequestPath } from "../../src/runs/background/control-channel.ts";
 import {
 	SUBAGENT_RPC_PROTOCOL_VERSION,
@@ -12,6 +13,7 @@ import {
 	subagentRpcReplyEvent,
 	type SubagentRpcReplyEnvelope,
 } from "../../src/extension/rpc.ts";
+import type { Details } from "../../src/shared/types.ts";
 
 class FakeEvents {
 	readonly emitted: Array<{ event: string; data: unknown }> = [];
@@ -168,7 +170,7 @@ describe("subagent extension RPC bridge", () => {
 			getContext: () => ctx(),
 			execute: async (_id, params) => {
 				executed.push(params);
-				return { content: [{ type: "text", text: "ok" }], details: { mode: "management", results: [] } } as any;
+				return { content: [{ type: "text", text: "ok" }], details: { mode: "management", results: [] } } satisfies AgentToolResult<Details>;
 			},
 		});
 


### PR DESCRIPTION
## Summary

Cleans up concrete slop in the current Unreleased changes.

- merges the duplicate Unreleased `Fixed` changelog sections while preserving contributor credits
- makes model exclusion records require a model or provider target and rejects invalid default TTLs
- encodes `latestRunId` as required for resumable workflow receipt entries
- removes redundant external-cli args filtering and a broad RPC test cast

## Validation

- `node --experimental-strip-types --test test/unit/model-exclusions.test.ts test/unit/rpc.test.ts test/unit/workflow-receipt.test.ts test/unit/runtime-agent-registration.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh cleanup review: no issues found