### PR TITLE
docs: simplify council advisor selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Show package names, versions, and external-job provider status in subagent list and detail output so package agents such as Surf's `gpt-pro` are easier to find and use.
 - Document Council Mode routing in the main `pi-subagents` skill so natural-language requests for advisor councils, plan critique, cross-exam, or multiple model perspectives load the Council Mode protocol.
+- Simplify Council Mode advisor selection so model-based profiles provide the perspective and the question supplies the decision frame.
 
 ### Fixed
 - Stop model fallback on context-overflow failures and surface `contextOverflow`. Thanks to [@srcKod](https://github.com/srcKod) for #1323.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The package includes `/council` and `council-mode`, plus documented model-based
 | Solve a hard problem | "Use oracle to investigate this bug before we edit." |
 | Review a diff | "Use reviewer to review this diff." |
 | Run parallel reviewers | "Run reviewers for correctness, tests, and cleanup." |
-| Debate a material decision | "Use `/council` to convene architect and skeptic advisors." |
+| Debate a material decision | "Use `/council` with model-based advisors to compare this decision." |
 | Implement then review | "Implement this, then review it." |
 | Review until clean | "Run a review loop on this change with a max of 3 rounds." |
 | Execute a plan carefully | "Have worker implement this approved plan, then run reviewers and apply the feedback." |

--- a/prompts/council.md
+++ b/prompts/council.md
@@ -1,6 +1,6 @@
 ---
 description: Run a bounded supervisor-mediated council of advisors and write a decision memo
-argument-hint: "<question> [--advisors name:role,name:role] [--max-passes 2|3] [--scope ...] [--non-goals ...]"
+argument-hint: "<question> [--advisors name,name] [--max-passes 2|3] [--scope ...] [--non-goals ...]"
 ---
 
 Run a bounded, supervisor-mediated council on this question. You, the parent
@@ -13,13 +13,14 @@ Before you orchestrate, read `skills/council-mode/SKILL.md` and
 
 Parse the invocation yourself. The flags below are conventions, not runtime
 options. Record a brief with the question, scope, non-goals, evidence targets,
-roster, roles, and pass cap. Default `--max-passes` to 2. Clamp it to 2 or 3. If
-the question is trivial or settled, answer directly instead of convening a council.
+roster, known advisor context modes, and pass cap. Default `--max-passes` to 2.
+Clamp it to 2 or 3. If the question is trivial or settled, answer directly instead
+of convening a council.
 
 ## Roster
 
-- If `--advisors` is given, use exactly those `name:role` pairs. Fail clearly on an
-  unknown agent.
+- If `--advisors` is given, use exactly those agent names. Fail clearly on an
+  unknown agent. Do not require or invent per-advisor role labels.
 - Otherwise list agents with `subagent({ action: "list" })`, then prefer 2–3
   executable names that start with `council-`.
 - If fewer than two profiles are available, fill the roster with `oracle`, then
@@ -30,8 +31,10 @@ the question is trivial or settled, answer directly instead of convening a counc
 - Use the normal single-oracle loop only when a requested roster or unavailable
   builtins leaves fewer than two advisors. Label the memo as degraded mode.
 
-Roles belong to this request, not to the profiles. Keep the roster at 2–3 and never
-exceed 4.
+Profiles provide the model, tools, context, and advisor stance. The council
+question and scope provide the decision frame. If the user wants a specific lens,
+they should put it in the question, scope, or profile definition. Keep the roster
+at 2–3 and never exceed 4.
 
 ## Run the protocol
 

--- a/skills/council-mode/SKILL.md
+++ b/skills/council-mode/SKILL.md
@@ -16,13 +16,12 @@ trivial or settled question, or for implementation work. Read
 
 ## Roster and limits
 
-Roles such as architect, skeptic, operator, and performance reviewer belong to the
-`/council` request. A `council-*` profile defines only model, tools, context, and
-output defaults. Its profile configuration or explicit invocation owns its context
-choice.
+Use advisor profile names directly. A `council-*` profile defines model, tools,
+context, output defaults, and any persistent stance in the profile body. Its
+profile configuration or explicit invocation owns its context choice.
 
 Create model-based profiles in your user or project agent directory. Do not add
-them to this package. This is a valid example; roles still come from `/council`:
+them to this package. This is a valid example:
 
 ```markdown
 ---
@@ -38,9 +37,9 @@ defaultContext: fresh
 acceptanceRole: read-only
 ---
 
-Analyze only the assigned council role. Inspect evidence directly. Do not edit,
-run mutating commands, commit, push, contact peers, or spawn subagents. Return
-concise, cited advice using the report contract in the council task.
+Analyze the council question independently. Inspect evidence directly. Do not
+edit, run mutating commands, commit, push, contact peers, or spawn subagents.
+Return concise, cited advice using the report contract in the council task.
 ```
 
 After `subagent({ action: "list" })`, prefer 2–3 executable names that start with
@@ -60,9 +59,11 @@ be settled by evidence an advisor can produce. Never run an unbounded loop.
 ## Protocol
 
 1. The parent writes a brief with the question, scope, non-goals, evidence targets,
-   roster, roles, and pass cap.
-2. Before Pass 1, tell the user the roster, roles, requested or known context
-   modes, and pass cap. Use a stable key, `phase`, and concise `label` for every
+   roster, known advisor context modes, and pass cap. If the user wants a specific
+   lens, keep it in the question, scope, or profile body instead of inventing a
+   per-advisor label.
+2. Before Pass 1, tell the user the roster, requested or known context modes, and
+   pass cap. Use a stable key, `phase`, and concise `label` for every
    workflow child. For example, use `advisor-oracle`, `phase: "Council pass 1"`,
    and `label: "Oracle — intent and consistency"`.
 3. Launch one async `workflowScript` with `runs.all` for independent advisor
@@ -162,7 +163,6 @@ return {
   advisors: results.map((result, index) => ({
     key: result.key,
     agent: result.agent,
-    role: roster[index].role,
     requestedContext: roster[index].context ?? "runtime-default-unknown",
     runId: result.runId,
     report: result.structuredOutput
@@ -221,9 +221,10 @@ decisions. Never add a round for polish or symmetry.
 
 The parent memo states the question and scope, recommendation, rationale, accepted
 and rejected feedback with reasons, owner decisions, evidence and run ids,
-confidence, what would change the decision, and the roster, roles, passes,
-fallbacks, and known advisor context modes. State that fallback `oracle` is
-context-aware and forked.
+confidence, what would change the decision, and the roster, passes, fallbacks, and
+known advisor context modes. Identify advisors by profile name or model-based
+profile, not by invented role labels. State that fallback `oracle` is context-aware
+and forked.
 
 Council mode is not agent-to-agent chat, a transcript dump, mutation authority,
 auto-escalation to writer lanes, or a council UI. Escalate to a writer only after

--- a/skills/pi-subagents/references/prompting-and-roles.md
+++ b/skills/pi-subagents/references/prompting-and-roles.md
@@ -54,7 +54,7 @@ The prompt templates in `prompts/` encode workflows the parent agent can run on 
 
 Use Council Mode when the user asks to convene advisors, debate a material decision, cross-examine recommendations, or critique and improve a plan with several model perspectives. This includes requests such as “run a council on this architecture,” “have Sol, Fable, and Kimi critique this plan,” or “get multiple oracles to debate the tradeoffs.” Read `../council-mode/SKILL.md` and follow its bounded parent-supervised protocol instead of launching ad hoc parallel oracle calls.
 
-Council advisors are read-only. The parent assigns temporary roles such as architect, skeptic, operator, or product reviewer. User or project `council-*` profiles can pin models such as GPT 5.6 Sol, Fable, or Kimi while the `/council` request supplies the role for that run. The parent collects independent reports, optionally sends curated cross-exam packets, and writes the final memo. Do not treat the council as agent-to-agent chat, implementation authority, or a writer swarm.
+Council advisors are read-only. User or project `council-*` profiles can pin models such as GPT 5.6 Sol, Fable, or Kimi and define any persistent stance in the profile body. The council question and scope provide the decision frame; do not invent per-advisor role labels. The parent collects independent reports, optionally sends curated cross-exam packets, and writes the final memo. Do not treat the council as agent-to-agent chat, implementation authority, or a writer swarm.
 
 ### Parallel review technique
 


### PR DESCRIPTION
Simplifies Council Mode docs so advisor selection uses profile names instead of invented per-run role labels. Model-based council profiles now provide the perspective, while the council question and scope provide the decision frame.

Validation:
- git diff --check
- stale role-label wording check
- npm pack --dry-run --json package resource check
- fresh docs review: No issues found