### PR TITLE
fix: surface logical tool failures to Pi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Avoid loading the parent extension graph in subagent child processes. Thanks to [@ccharname](https://github.com/ccharname) for #1330.
 - Stop model fallback on context-overflow failures and surface `contextOverflow`. Thanks to [@srcKod](https://github.com/srcKod) for #1323.
 - Stop empty slow result scans from spamming the session transcript. Thanks to [@afrodao2394](https://github.com/afrodao2394) for #1329.
+- Surface logical tool failures so subagent tool results backfill correctly. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for #1332 and [@moekyo](https://github.com/moekyo) for #1331.
 
 ## [0.53.0] - 2026-08-20
 

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {} from "./src/types/pi-runtime-compat.d.ts";
 
 const registerParentExtension = process.env.PI_SUBAGENT_CHILD === "1"
 	? undefined

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -11,6 +11,7 @@ import { readNestedControlRequests, resolveNestedRouteFromEnv, type NestedRoute,
 import { deliverSubagentIntercomMessageEvent } from "../intercom/result-intercom.ts";
 import { resolveSubagentIntercomTarget } from "../intercom/intercom-bridge.ts";
 import { createSubagentParamsSchema } from "./schemas.ts";
+import { finalizeToolResult } from "./tool-result.ts";
 import { loadConfig, resolveAsyncByDefault } from "./config.ts";
 import { type Details, type SubagentState } from "../shared/types.ts";
 
@@ -181,8 +182,8 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 			"Mutating management actions (create, update, delete, eject, disable, enable, reset, grant-spawn-budget) are blocked in this mode.",
 		].join("\n"),
 		parameters: params,
-		execute(id, params, signal, onUpdate, ctx) {
-			return executor.executePublic(id, params as SubagentParamsLike, signal ?? new AbortController().signal, onUpdate, ctx);
+		async execute(id, params, signal, onUpdate, ctx) {
+			return finalizeToolResult(await executor.executePublic(id, params as SubagentParamsLike, signal ?? new AbortController().signal, onUpdate, ctx));
 		},
 	};
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -57,6 +57,7 @@ import { resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capabili
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import { loadConfig, resolveAsyncByDefault, resolveScheduledStoreRoot } from "./config.ts";
 import { buildSubagentToolDescription, buildSubagentToolPromptMetadata } from "./tool-description.ts";
+import { finalizeToolResult } from "./tool-result.ts";
 import { collectGoalContinuationNotices } from "../missions/goal-driver.ts";
 import { restoreForegroundRunHistory } from "../runs/foreground/foreground-history.ts";
 import { resolveMissionStoreLocation } from "../missions/store.ts";
@@ -658,8 +659,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		...buildSubagentToolPromptMetadata(config),
 		parameters,
 
-		execute(id, params, signal, onUpdate, ctx) {
-			return executeSubagentCollapsed(id, params as SubagentParamsLike, signal ?? new AbortController().signal, onUpdate, ctx);
+		async execute(id, params, signal, onUpdate, ctx) {
+			return finalizeToolResult(await executeSubagentCollapsed(id, params as SubagentParamsLike, signal ?? new AbortController().signal, onUpdate, ctx));
 		},
 
 		renderCall(args, theme) {

--- a/src/extension/tool-result.ts
+++ b/src/extension/tool-result.ts
@@ -1,0 +1,23 @@
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+
+/**
+ * Convert pi-subagents' internal logical-error result into the rejection Pi's
+ * public tool boundary uses to emit a canonical errored ToolResult.
+ *
+ * Keep this at registered tool boundaries. Internal workflows intentionally
+ * retain their return-based error handling.
+ */
+export function finalizeToolResult<T>(result: AgentToolResult<T>): AgentToolResult<T> {
+	if (result.isError !== true) return result;
+
+	const message = result.content
+		.filter(
+			(item): item is { type: "text"; text: string } =>
+				item.type === "text" && typeof item.text === "string",
+		)
+		.map((item) => item.text)
+		.join("\n")
+		.trim();
+
+	throw new Error(message || "pi-subagents reported a logical tool failure.");
+}

--- a/src/inspectors/herdr/client.ts
+++ b/src/inspectors/herdr/client.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
 
 export type HerdrErrorCode =
 	| "HERDR_UNAVAILABLE"
@@ -16,7 +16,7 @@ export interface HerdrClient {
 	run<T = unknown>(args: string[], options?: { timeoutMs?: number; signal?: AbortSignal; textOk?: boolean }): Promise<HerdrResult<T>>;
 }
 
-type SpawnHerdr = (command: string, args: readonly string[], options: { shell: false; windowsHide: true; env: NodeJS.ProcessEnv }) => ChildProcess;
+type SpawnHerdr = (command: string, args: readonly string[], options: { shell: false; windowsHide: true; env: NodeJS.ProcessEnv }) => ReturnType<typeof spawn>;
 
 function error(code: HerdrErrorCode, message: string, details?: unknown): HerdrResult<never> {
 	return { ok: false, error: { code, message, ...(details !== undefined ? { details } : {}) } };
@@ -46,7 +46,7 @@ export function createHerdrClient(options: { bin?: string; spawn?: SpawnHerdr } 
 	return {
 		run<T>(args: string[], runOptions: { timeoutMs?: number; signal?: AbortSignal; textOk?: boolean } = {}): Promise<HerdrResult<T>> {
 			return new Promise((resolve) => {
-				let child: ChildProcess;
+				let child: ReturnType<typeof spawn>;
 				try {
 					child = spawnImpl(bin, args, { shell: false, windowsHide: true, env: process.env });
 				} catch (cause) {

--- a/src/runs/background/async-retention.ts
+++ b/src/runs/background/async-retention.ts
@@ -600,7 +600,7 @@ function runRetentionDiscovery(input: {
 		};
 		const onAbort = (): void => fail(new RetentionCancelledError("Retention discovery was cancelled."));
 		input.signal?.addEventListener("abort", onAbort, { once: true });
-		worker.once("error", (error) => fail(error));
+		worker.once("error", (error) => fail(error instanceof Error ? error : new Error(String(error))));
 		worker.once("exit", (code) => {
 			if (!settled) fail(new Error(`Retention discovery worker exited before replying (${code}).`));
 		});

--- a/src/runs/background/wait-tool.ts
+++ b/src/runs/background/wait-tool.ts
@@ -3,6 +3,7 @@ import { SubagentWaitParams } from "../../extension/schemas.ts";
 import type { Details, SubagentState } from "../../shared/types.ts";
 import { resolveWaitToolConfig, waitForSubagents } from "./subagent-wait.ts";
 import type { WaitSubscriptionManager } from "./wait-subscriptions.ts";
+import { finalizeToolResult } from "../../extension/tool-result.ts";
 
 export function registerWaitTool(pi: ExtensionAPI, state: SubagentState, enabled = resolveWaitToolConfig().enabled, subscriptions?: Pick<WaitSubscriptionManager, "arm">): void {
 	const tool: ToolDefinition<typeof SubagentWaitParams, Details> = {
@@ -21,14 +22,14 @@ In an interactive chat, do not call this merely to wait: return control to the u
 
 Non-blocking subscriptions are visible in subagent status and differ from disabling waitTool: waitTool.enabled=false returns immediately without registering any future wake. Provider jobs are session-scoped and identified exactly, so replacing one job with another cannot hide a completion. Provider extensions must be explicitly loaded in this process. In a child agent, keep \`subagent_wait\` in the child tool allowlist and load each provider through the agent's extensions or subagentOnlyExtensions; this tool never loads providers or grants tools itself.${enabled ? "" : "\n\nConfigured behavior: subagent_wait is disabled by config.waitTool or PI_SUBAGENT_WAIT_TOOL_ENABLED and returns immediately without blocking."}`,
 		parameters: SubagentWaitParams,
-		execute(_id, params, signal, onUpdate, ctx) {
-			return waitForSubagents(params, signal, {
+		async execute(_id, params, signal, onUpdate, ctx) {
+			return finalizeToolResult(await waitForSubagents(params, signal, {
 				state,
 				events: pi.events,
 				enabled,
 				onUpdate,
 				...(subscriptions && ctx?.hasUI ? { subscribe: (input) => subscriptions.arm(input) } : {}),
-			});
+			}));
 		},
 	};
 	pi.registerTool(tool);

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -183,6 +183,7 @@ describe("subagent extension child mode", () => {
 
 	it("rejects blank action at the public executor boundary", () => {
 		const script = String.raw`
+			import assert from "node:assert/strict";
 			import registerSubagentExtension from "./index.ts";
 			const events = { on() { return () => {}; }, emit() {} };
 			let registeredTool;
@@ -193,10 +194,10 @@ describe("subagent extension child mode", () => {
 			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
 			registerSubagentExtension(fakePi);
 			if (!registeredTool) throw new Error("tool not registered");
-			const result = await registeredTool.execute("blank-action", { action: "", agent: "reviewer" }, new AbortController().signal, undefined, { cwd: process.cwd(), hasUI: false });
-			if (!result.isError) throw new Error("blank action should be rejected");
-			const text = result.content?.[0]?.text ?? "";
-			if (!text.includes("action must be a non-empty")) throw new Error("unexpected blank action error: " + text);
+			await assert.rejects(
+				registeredTool.execute("blank-action", { action: "", agent: "reviewer" }, new AbortController().signal, undefined, { cwd: process.cwd(), hasUI: false }),
+				/action must be a non-empty/,
+			);
 		`;
 
 		execFileSync(
@@ -1104,6 +1105,7 @@ describe("subagent extension child mode", () => {
 
 	it("lets fanout children call read-only list but blocks mutating management actions", () => {
 		const script = String.raw`
+			import assert from "node:assert/strict";
 			import registerFanoutChildSubagentExtension from "./src/extension/fanout-child.ts";
 			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
 			process.env[SUBAGENT_CHILD_ENV] = "1";
@@ -1124,18 +1126,18 @@ describe("subagent extension child mode", () => {
 			};
 			const list = await registeredTool.execute("list-check", { action: "list" }, new AbortController().signal, undefined, ctx);
 			if (list.isError) throw new Error("list should be allowed: " + JSON.stringify(list.content));
-			const create = await registeredTool.execute("create-check", { action: "create", config: { name: "x" } }, new AbortController().signal, undefined, ctx);
-			if (!create.isError) throw new Error("create should be blocked");
-			const text = create.content?.[0]?.text ?? "";
-			if (!text.includes("not available from child-safe subagent fanout mode")) throw new Error("unexpected create error: " + text);
-			const refine = await registeredTool.execute("refine-check", { action: "refine", agent: "worker" }, new AbortController().signal, undefined, ctx);
-			if (!refine.isError) throw new Error("refine should be blocked");
-			const refineText = refine.content?.[0]?.text ?? "";
-			if (!refineText.includes("not available from child-safe subagent fanout mode")) throw new Error("unexpected refine error: " + refineText);
-			const grant = await registeredTool.execute("grant-check", { action: "grant-spawn-budget", additional: 1 }, new AbortController().signal, undefined, { ...ctx, hasUI: true });
-			if (!grant.isError) throw new Error("grant-spawn-budget should be blocked");
-			const grantText = grant.content?.[0]?.text ?? "";
-			if (!grantText.includes("root interactive parent session")) throw new Error("unexpected grant error: " + grantText);
+			await assert.rejects(
+				registeredTool.execute("create-check", { action: "create", config: { name: "x" } }, new AbortController().signal, undefined, ctx),
+				/not available from child-safe subagent fanout mode/,
+			);
+			await assert.rejects(
+				registeredTool.execute("refine-check", { action: "refine", agent: "worker" }, new AbortController().signal, undefined, ctx),
+				/not available from child-safe subagent fanout mode/,
+			);
+			await assert.rejects(
+				registeredTool.execute("grant-check", { action: "grant-spawn-budget", additional: 1 }, new AbortController().signal, undefined, { ...ctx, hasUI: true }),
+				/root interactive parent session/,
+			);
 		`;
 
 		execFileSync(

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
@@ -29,6 +31,50 @@ const expectedHostDevVersions = {
 	"@earendil-works/pi-tui": "0.81.0",
 } satisfies Record<Exclude<(typeof hostPeerPackages)[number], "@earendil-works/pi-coding-agent">, string>;
 
+test("the root entrypoint exposes the runtime error flag to TypeScript consumers", () => {
+	const consumerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-types-"));
+	try {
+		fs.writeFileSync(path.join(consumerRoot, "consumer.ts"), `
+import "pi-subagents";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+
+const result: AgentToolResult<undefined> = {
+	content: [],
+	details: undefined,
+	isError: true,
+};
+
+void result.isError;
+`, "utf-8");
+		fs.writeFileSync(path.join(consumerRoot, "tsconfig.json"), JSON.stringify({
+			compilerOptions: {
+				target: "ES2023",
+				module: "NodeNext",
+				moduleResolution: "NodeNext",
+				strict: true,
+				noEmit: true,
+				types: ["node"],
+				typeRoots: [path.join(projectRoot, "node_modules", "@types")],
+				skipLibCheck: true,
+				allowImportingTsExtensions: true,
+				baseUrl: consumerRoot,
+				paths: {
+					"pi-subagents": [path.join(projectRoot, "index.ts")],
+				"@earendil-works/pi-agent-core": [path.join(projectRoot, "node_modules", "@earendil-works", "pi-agent-core", "dist", "index.d.ts")],
+				},
+			},
+			files: [path.join(consumerRoot, "consumer.ts")],
+		}, null, 2), "utf-8");
+
+		execFileSync(process.execPath, [path.join(projectRoot, "node_modules", "typescript", "bin", "tsc"), "--project", path.join(consumerRoot, "tsconfig.json")], {
+			cwd: consumerRoot,
+			stdio: "pipe",
+		});
+	} finally {
+		fs.rmSync(consumerRoot, { recursive: true, force: true });
+	}
+});
+
 function collectSourceFiles(dir: string): string[] {
 	const files: string[] = [];
 	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -50,6 +96,7 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.equal(packageJson.files?.includes("*.mjs"), true);
 	assert.equal(fs.existsSync(path.join(projectRoot, "async-retention-discovery-worker.mjs")), true);
 	const entrySource = fs.readFileSync(path.join(projectRoot, "index.ts"), "utf-8");
+	assert.match(entrySource, /import type \{\} from "\.\/src\/types\/pi-runtime-compat\.d\.ts";/);
 	assert.equal(entrySource.includes('export { default } from "./src/extension/index.ts";'), false);
 	assert.match(entrySource, /process\.env\.PI_SUBAGENT_CHILD === "1"/);
 	assert.match(entrySource, /await import\("\.\/src\/extension\/index\.ts"\)/);

--- a/test/unit/wait-subscriptions.test.ts
+++ b/test/unit/wait-subscriptions.test.ts
@@ -125,9 +125,10 @@ describe("non-blocking wait subscriptions", () => {
 			} as never, state, true, {
 				arm() { throw new Error("headless calls must not arm subscriptions"); },
 			});
-			const result = await tool!.execute("wait", { id: "run-headless", nonBlocking: true }, undefined, undefined, { hasUI: false });
-			assert.equal(result.isError, true);
-			assert.match(textOf(result), /long-lived interactive subagent runtime/);
+			await assert.rejects(
+				tool!.execute("wait", { id: "run-headless", nonBlocking: true }, undefined, undefined, { hasUI: false }),
+				/long-lived interactive subagent runtime/,
+			);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

- convert logical `isError: true` results into public Pi tool failures at the `subagent`, fanout-child, and `subagent_wait` boundaries while preserving the internal return-value flow
- load the `AgentToolResult.isError` augmentation from the package root for TypeScript consumers
- align the Herdr process type with `spawn()` and normalize worker-thread errors at the host type boundary

## Validation

- `npm run typecheck`
- changed boundary and consumer tests: 48 passed
- async-retention unit tests: 17 passed
- full unit suite with `TMPDIR=/tmp TEMP=/tmp`: 2288 passed, 2 failed, 4 skipped; both failures reproduce unchanged on `upstream/main` (`agent-frontmatter.test.ts`, `compaction-resume.test.ts`)
- full integration suite: 696 passed, 5 timing-sensitive failures under concurrent load; all five passed when rerun in isolation
- official E2E command completed with its real Pi-session suite skipped because runtime packages are unavailable in the clean test install
- external Pi 0.84.2 consumer smoke verified canonical failure and success results
