### PR TITLE
fix: quiet empty result scan warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Stop model fallback on context-overflow failures and surface `contextOverflow`. Thanks to [@srcKod](https://github.com/srcKod) for #1323.
+- Stop empty slow result scans from spamming the session transcript. Thanks to [@afrodao2394](https://github.com/afrodao2394) for #1329.
 
 ## [0.53.0] - 2026-08-20
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,9 +170,9 @@ This is different from `waitTool.enabled=false`, which returns immediately witho
 { "resultScanLogging": "activity" }
 ```
 
-Controls how slow result-index scans are logged. Defaults to `"all"`; valid values are `"all"`, `"activity"`, and `"off"`.
+Controls how slow result-index scans are logged. Defaults to `"activity"`; valid values are `"all"`, `"activity"`, and `"off"`.
 
-The watcher logs `Subagent result scan inspected … scheduled …` through `console.error` whenever a result-index scan passes the slow threshold (500ms). With `"all"` (default) every slow scan is logged, including the periodic healthy rescan that inspects zero files while no async runs are pending. Those empty scans add noise to the session transcript with no signal; choose `"activity"` to log only scans that inspected or scheduled actual work, or `"off"` to silence slow-scan logging entirely. `"off"` does not disable result delivery or the watcher itself, only its slow-scan log line.
+The watcher logs `Subagent result scan inspected … scheduled …` through `console.error` whenever a result-index scan passes the slow threshold (500ms). With `"activity"` (default), it logs only scans that inspected or scheduled actual work. Use `"all"` to log every slow scan, including the periodic healthy rescan that inspects zero files while no async runs are pending, or `"off"` to silence slow-scan logging entirely. `"off"` does not disable result delivery or the watcher itself, only its slow-scan log line.
 
 ## `forceTopLevelAsync`
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -517,7 +517,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			observedCompletionRunIds: () => scheduledRunManager.observedCompletionRunIds(),
 			hasDeliveryDemand: hasResultDeliveryDemand,
 			deliverIntercomResults: config.intercomBridge?.resultDelivery === true,
-			resultScanLogging: config.resultScanLogging ?? "all",
+			resultScanLogging: config.resultScanLogging,
 		},
 	);
 	const { startResultWatcher, primeExistingResults, stopResultWatcher } = resultWatcher;

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -57,7 +57,7 @@ type ResultWatcherDeps = {
 	coalesceDelayMs?: number;
 	/** Returns true while a durable completion source needs periodic delivery checks. */
 	hasDeliveryDemand?: () => boolean;
-	/** Control how slow result-index scans are logged. Defaults to \"all\". */
+	/** Control how slow result-index scans are logged. Defaults to \"activity\". */
 	resultScanLogging?: "all" | "activity" | "off";
 	platform?: NodeJS.Platform;
 };
@@ -606,12 +606,13 @@ export function createResultWatcher(
 	const logScanStats = (stats: ResultScanStats) => {
 		const elapsed = Date.now() - stats.startedAt;
 		if (elapsed < SLOW_RESULT_SCAN_MS) return;
-		if (deps.resultScanLogging === "off") return;
+		const resultScanLogging = deps.resultScanLogging ?? "activity";
+		if (resultScanLogging === "off") return;
 		// A scan that inspected and scheduled nothing is a quiet no-op (e.g. the
 		// healthy periodic rescan while no async runs are pending). Under
 		// "activity", skip it so empty scans do not burn context tokens in the
 		// session transcript.
-		if (deps.resultScanLogging === "activity" && stats.files === 0 && stats.scheduled === 0) return;
+		if (resultScanLogging === "activity" && stats.files === 0 && stats.scheduled === 0) return;
 		console.error(`Subagent result scan inspected ${stats.files} indexed result file(s), scheduled ${stats.scheduled} in ${elapsed}ms (${resultsDir}).`);
 	};
 	const indexedResultCandidates = (observed: ReadonlySet<string>): string[] => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2064,7 +2064,7 @@ export interface ExtensionConfig {
 	/** Artifact cleanup retention. Set cleanupDays to 0 to disable cleanup. */
 	artifactConfig?: Pick<ArtifactConfig, "cleanupDays">;
 	intercomBridge?: IntercomBridgeConfig;
-	/** Control how slow result-index scans are logged. Defaults to \"all\".
+	/** Control how slow result-index scans are logged. Defaults to \"activity\".
 	 *  - \"all\": log every slow scan, including scans that find nothing.
 	 *  - \"activity\": log only slow scans that found or scheduled work. Silences
 	 *    the periodic healthy rescan that inspects zero files while no async runs

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -2218,10 +2218,20 @@ describe("result watcher", () => {
 			}
 		};
 
-		it('logs empty slow scans with the default "all" mode', () => {
+		it('silences empty slow scans with the default "activity" mode', () => {
 			const { errors, restore } = captureScanErrors();
 			try {
 				runScan({});
+				assert.equal(errors.length, 0);
+			} finally {
+				restore();
+			}
+		});
+
+		it('logs empty slow scans under explicit "all" mode', () => {
+			const { errors, restore } = captureScanErrors();
+			try {
+				runScan({ resultScanLogging: "all" });
 				assert.equal(errors.length, 1);
 				assert.match(errors[0], /inspected 0 indexed result file\(s\), scheduled 0/);
 			} finally {


### PR DESCRIPTION
## Summary

- default result scan logging to activity so empty slow scans stay quiet
- preserve explicit all/off logging controls and real-work slow scan diagnostics
- document the default and add focused result-watcher coverage

Fixes #1329.

## Validation

- git diff --check
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='resultScanLogging' test/integration/result-watcher.test.ts\n- npm run typecheck\n\nThanks to [@afrodao2394](https://github.com/afrodao2394) for #1329.