### PR TITLE
fix: skip parent extension imports in child mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Simplify Council Mode advisor selection so model-based profiles provide the perspective and the question supplies the decision frame.
 
 ### Fixed
+- Avoid loading the parent extension graph in subagent child processes. Thanks to [@ccharname](https://github.com/ccharname) for #1330.
 - Stop model fallback on context-overflow failures and surface `contextOverflow`. Thanks to [@srcKod](https://github.com/srcKod) for #1323.
 - Stop empty slow result scans from spamming the session transcript. Thanks to [@afrodao2394](https://github.com/afrodao2394) for #1329.
 

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,9 @@
-export { default } from "./src/extension/index.ts";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const registerParentExtension = process.env.PI_SUBAGENT_CHILD === "1"
+	? undefined
+	: (await import("./src/extension/index.ts")).default;
+
+export default function registerSubagentExtension(pi: ExtensionAPI): void {
+	registerParentExtension?.(pi);
+}

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -966,9 +966,6 @@ describe("subagent extension child mode", () => {
 	it("returns before registering anything for non-fanout children", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./index.ts";
-			import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "./src/runs/shared/pi-args.ts";
-			process.env[SUBAGENT_CHILD_ENV] = "1";
-			process.env[SUBAGENT_FANOUT_CHILD_ENV] = "0";
 			const calls = [];
 			const fakePi = new Proxy({}, {
 				get(_target, prop) {
@@ -994,7 +991,7 @@ describe("subagent extension child mode", () => {
 				"--eval",
 				script,
 			],
-			{ cwd: projectRoot, stdio: "pipe" },
+			{ cwd: projectRoot, env: { ...parentToolEnv(), [SUBAGENT_CHILD_ENV]: "1", [SUBAGENT_FANOUT_CHILD_ENV]: "0" }, stdio: "pipe" },
 		);
 	});
 

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -49,10 +49,10 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.equal(packageJson.files?.includes("index.ts"), true);
 	assert.equal(packageJson.files?.includes("*.mjs"), true);
 	assert.equal(fs.existsSync(path.join(projectRoot, "async-retention-discovery-worker.mjs")), true);
-	assert.equal(
-		fs.readFileSync(path.join(projectRoot, "index.ts"), "utf-8").trim(),
-		'export { default } from "./src/extension/index.ts";',
-	);
+	const entrySource = fs.readFileSync(path.join(projectRoot, "index.ts"), "utf-8");
+	assert.equal(entrySource.includes('export { default } from "./src/extension/index.ts";'), false);
+	assert.match(entrySource, /process\.env\.PI_SUBAGENT_CHILD === "1"/);
+	assert.match(entrySource, /await import\("\.\/src\/extension\/index\.ts"\)/);
 	assert.equal(fs.existsSync(path.join(projectRoot, "src", "api", "delegation.ts")), true);
 	assert.deepEqual(packageJson.exports, {
 		".": "./index.ts",


### PR DESCRIPTION
## Summary

- gate the package entry before loading the parent extension graph in subagent child processes
- preserve synchronous parent registration behavior
- update child/package entry tests and changelog credit

Fixes #1330.

## Validation

- git diff --check
- node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/index-child-registration.test.ts test/unit/package-manifest.test.ts
- npm run typecheck

Thanks to [@ccharname](https://github.com/ccharname) for #1330.