### PR TITLE
feat: add per-agent model scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Add per-agent model restrictions and a current-parent `inherit` allow-list alias. Thanks to [@hieudmg](https://github.com/hieudmg) for #1328.
 - Show package names, versions, and external-job provider status in subagent list and detail output so package agents such as Surf's `gpt-pro` are easier to find and use.
 - Document Council Mode routing in the main `pi-subagents` skill so natural-language requests for advisor councils, plan critique, cross-exam, or multiple model perspectives load the Council Mode protocol.
 - Simplify Council Mode advisor selection so model-based profiles provide the perspective and the question supplies the decision frame.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 `pi-subagents` reads optional JSON config from `~/.pi/agent/extensions/subagent/config.json`. This page lists every key, plus the environment variables and the settings-file keys that affect config resolution.
 
-Settings-level keys (`subagents.defaultModel`, `defaultThinking`, `defaultExtensions`, `agentOverrides`, `modelScope`, `disableThinking`, `disableBuiltins`, watchdog settings) live in Pi settings files, not this config file. See [models.md](models.md), [agents.md](agents.md), and [watchdog.md](watchdog.md).
+Settings-level keys (`subagents.defaultModel`, `defaultThinking`, `defaultExtensions`, `agentOverrides`, `modelScope`, `disableThinking`, `disableBuiltins`, watchdog settings) live in Pi settings files, not this config file. `modelScope.agents.<name>` adds per-agent restrictions, and `allow: ["inherit"]` permits the current parent model. See [models.md](models.md), [agents.md](agents.md), and [watchdog.md](watchdog.md).
 
 ## Project root resolution (settings)
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -10,6 +10,8 @@ Builtin agents inherit your current Pi default model. This keeps new installs fr
 
 Precedence, strongest first: per-run override → agent frontmatter `model` → `agentOverrides.<name>.model` → `subagents.defaultModel` → the parent session model.
 
+Use `model: "inherit"` in agent frontmatter or `agentOverrides.<name>.model` to select the current parent session model explicitly.
+
 ## Setting defaults and overrides
 
 In `~/.pi/agent/settings.json` (user) or the project config settings file (`.pi/settings.json` in standard Pi; project wins):
@@ -153,17 +155,29 @@ To keep subagents inside a budget or compliance profile, enforce a model scope. 
     "modelScope": {
       "enforce": true,
       "strict": true,
-      "allow": ["anthropic/*", "openai/gpt-5-*"]
+      "allow": ["inherit", "openai/gpt-5-*"],
+      "agents": {
+        "worker": { "allow": ["openai/gpt-5-mini"] },
+        "reviewer": { "allow": ["inherit"] }
+      }
     }
   }
 }
 ```
 
-- `allow` is a list of glob patterns matched against the resolved `provider/id` (only `*` is special, case-insensitive). A resolved model that matches none of the patterns is rejected.
+- `allow` is a list of glob patterns matched against the resolved `provider/id` (only `*` is special, case-insensitive). The literal `inherit` means the current parent session model.
+- `agents.<name>` adds a second allow-list for that agent. The model must pass both the global list and the matching agent list, so an agent rule cannot weaken the global rule. Agent rules inherit `enforce` and `strict` when those fields are absent.
+- A top-level `enforce: true` with only agent allow-lists restricts only those named agents. Unknown names are allowed so settings can be shared across projects and machines.
 - Models you pass explicitly — the tool-call `model`, `--model`, or a clarify pick — error and abort the run.
 - By default, models from agent frontmatter, `subagents.defaultModel`, the inherited parent session model, or fallback chains only warn and remain available, so existing configurations keep working while you tighten the scope.
 - Set `strict: true` with `enforce: true` to reject every resolved out-of-scope model. This includes inherited models and fallback candidates. An invalid fallback fails the run instead of being removed from the candidate chain.
-- `enforce: true` requires a non-empty `allow` list; otherwise the config is rejected at load time.
+- `enforce: true` requires at least one non-empty global or agent `allow` list; otherwise the config is rejected at load time.
+
+Model scope is policy only. It rejects or warns; it does not select a cheaper model. Set `agentOverrides.worker.model` to choose a worker model and use `modelScope.agents.worker` to prevent a per-run override or fallback from escaping that restriction.
+
+`inherit` expands in the parent process at each launch. It is never sent to the child as a model id. A nested child therefore inherits its immediate parent's current model, not the original top-level model. If no parent model is available, an enforced `inherit` entry does not match and fails closed.
+
+Project `modelScope` settings replace the complete user `modelScope`, as with the existing project-over-user settings precedence. Project settings are trusted and can therefore replace user restrictions.
 
 ## Profiles and provider model catalogs
 

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -7,6 +7,7 @@ import { resolveExecutionAgentScope } from "../agents/agent-scope.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../agents/agent-memory.ts";
 import { buildModelCandidates, inheritsParentModel, resolveEffectiveSubagentModel, type AvailableModelInfo, type ParentModel } from "../runs/shared/model-fallback.ts";
+import { resolveModelScopesForAgent } from "../runs/shared/model-scope.ts";
 import { applyThinkingSuffix, resolvePiLaunchToolPlan, type PiLaunchToolPlan } from "../runs/shared/pi-args.ts";
 import { injectOutputPathSystemPrompt, normalizeSingleOutputOverride, resolveSingleOutputPath } from "../runs/shared/single-output.ts";
 import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
@@ -288,15 +289,16 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 	const externalRunner = agent.runner?.type === "external-cli" || agent.runner?.type === "external-job";
 	const availableModels = normalizeAvailableModels(input.availableModels);
 	const preferredProvider = input.preferredProvider ?? input.parentModel?.provider;
+	const modelScopes = resolveModelScopesForAgent(discovered.modelScope, agent.name, input.parentModel);
 	const primaryModel = externalRunner
 		? undefined
-		: resolveEffectiveSubagentModel(input.model, agent.model, input.parentModel, availableModels, preferredProvider, { scope: discovered.modelScope });
+		: resolveEffectiveSubagentModel(input.model, agent.model, input.parentModel, availableModels, preferredProvider, { scope: modelScopes });
 	const effectiveThinkingConfig = input.thinking !== undefined ? input.thinking : agent.thinking;
 	const model = externalRunner ? undefined : applyThinkingSuffix(primaryModel, effectiveThinkingConfig, input.thinking !== undefined);
 	const modelCandidates = externalRunner
 		? []
 		: buildModelCandidates(primaryModel, agent.fallbackModels, availableModels, preferredProvider, {
-			scope: discovered.modelScope,
+			scope: modelScopes,
 			primaryModelFromParent: inheritsParentModel(input.model, agent.model, input.parentModel),
 		})
 			.map((candidate) => applyThinkingSuffix(candidate, effectiveThinkingConfig, input.thinking !== undefined) ?? candidate);

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -26,7 +26,7 @@ import { buildAgentMemoryInjection } from "../../agents/agent-memory.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV, PROMPT_REDACTED, resolveChildCwd } from "../../shared/utils.ts";
 import { buildModelCandidates, inheritsParentModel, resolveEffectiveSubagentModel, resolveModelCandidate, resolveSubagentModelOverride, type AvailableModelInfo, type ParentModel } from "../shared/model-fallback.ts";
 import { resolveToolTimeoutMs, toolTimeoutFromEnv } from "../shared/tool-timeout.ts";
-import type { ModelScopeConfig } from "../shared/model-scope.ts";
+import { resolveModelScopesForAgent, type ModelScopeConfig } from "../shared/model-scope.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { resolveExpectedWorktreeAgentCwd } from "../shared/worktree.ts";
 import { buildWorkflowGraphSnapshot } from "../shared/workflow-graph.ts";
@@ -791,13 +791,14 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		const taskText = `${readInstructions.prefix}${taskTemplate}${progressInstructions.suffix}`;
 		const task = namespaceOutputPath ? taskText : injectSingleOutputInstruction(taskText, outputPath, a);
 
+		const modelScopes = resolveModelScopesForAgent(ctx.modelScope, a.name, ctx.currentModel);
 		const primaryModel = externalRunner ? undefined : resolveEffectiveSubagentModel(
 			s.model,
 			a.model,
 			ctx.currentModel,
 			availableModels,
 			ctx.currentModelProvider,
-			{ scope: ctx.modelScope },
+			{ scope: modelScopes },
 		);
 		const thinkingOverride = flatIndex === undefined ? undefined : thinkingOverridesByFlatIndex?.[flatIndex];
 		const effectiveThinking = externalRunner ? undefined : thinkingOverride ?? a.thinking;
@@ -839,7 +840,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			thinking: resolveEffectiveThinking(model, effectiveThinking),
 			launchResolvedExtensions,
 			modelCandidates: externalRunner ? undefined : buildModelCandidates(primaryModel, a.fallbackModels, availableModels, ctx.currentModelProvider, {
-				scope: ctx.modelScope,
+				scope: modelScopes,
 				primaryModelFromParent: inheritsParentModel(s.model, a.model, ctx.currentModel),
 			}).map((candidate) =>
 				applyThinkingSuffix(candidate, effectiveThinking, thinkingOverride !== undefined),
@@ -1418,6 +1419,7 @@ export function executeAsyncSingle(
 		? `[Read from: ${readPaths.join(", ")}]\n\n`
 		: "";
 	const taskText = readsInstruction + taskWithOutputInstruction;
+	const modelScopes = resolveModelScopesForAgent(ctx.modelScope, agentConfig.name, ctx.currentModel);
 	const primaryModel = externalRunner ? undefined : params.modelOverrideFromParent
 		? params.modelOverride
 		: resolveSubagentModelOverride(
@@ -1425,6 +1427,7 @@ export function executeAsyncSingle(
 			ctx.currentModel,
 			availableModels,
 			ctx.currentModelProvider,
+			{ scope: modelScopes },
 		);
 	const effectiveThinking = externalRunner ? undefined : params.thinkingOverride ?? agentConfig.thinking;
 	const model = externalRunner ? undefined : applyThinkingSuffix(primaryModel, effectiveThinking, params.thinkingOverride !== undefined);
@@ -1453,7 +1456,7 @@ export function executeAsyncSingle(
 	const modelCandidates = externalRunner
 		? []
 		: buildModelCandidates(primaryModel, agentConfig.fallbackModels, availableModels, ctx.currentModelProvider, {
-			scope: ctx.modelScope,
+			scope: modelScopes,
 			primaryModelFromParent: params.modelOverrideFromParent,
 		})
 			.flatMap((candidate) => {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -30,7 +30,7 @@ import { handleWatchdogToolAction, WATCHDOG_TOOL_ACTIONS } from "../../watchdog/
 import type { MainWatchdogRuntime } from "../../watchdog/runtime.ts";
 import { buildModelCandidates, inheritsParentModel, normalizeParentModel, resolveEffectiveSubagentModel, resolveModelCandidate, type ParentModel } from "../shared/model-fallback.ts";
 import { formatRetainedChildren, listRetainedChildren } from "../background/retained-children.ts";
-import type { ModelScopeConfig } from "../shared/model-scope.ts";
+import { resolveModelScopesForAgent, type ModelScopeConfig } from "../shared/model-scope.ts";
 import { aggregateParallelOutputs } from "../shared/parallel-utils.ts";
 import { recordRun } from "../shared/run-history.ts";
 import {
@@ -2657,6 +2657,7 @@ function resolveStaticLaunchSummary(input: {
 }): StaticLaunchSummary {
 	const agentConfig = input.agents.find((agent) => agent.name === input.agent);
 	const externalRunner = agentConfig?.runner?.type === "external-cli" || agentConfig?.runner?.type === "external-job";
+	const modelScopes = resolveModelScopesForAgent(input.modelScope, input.agent, input.parentModel);
 	const model = externalRunner
 		? undefined
 		: resolveEffectiveSubagentModel(
@@ -2665,7 +2666,7 @@ function resolveStaticLaunchSummary(input: {
 			input.parentModel,
 			input.availableModels,
 			input.currentProvider,
-			input.modelScope === undefined ? {} : { scope: input.modelScope },
+			modelScopes.length === 0 ? {} : { scope: modelScopes },
 		);
 	const thinkingOverride = externalRunner ? undefined : input.thinkingOverrideForTask(input.agent, input.index, model);
 	const thinking = externalRunner ? undefined : resolveEffectiveThinking(model, thinkingOverride ?? agentConfig?.thinking);
@@ -2895,9 +2896,10 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const externalRunnerWithoutExplicitModel = (a.runner?.type === "external-cli" || a.runner?.type === "external-job")
 			&& params.model === undefined
 			&& (a.model === undefined || (a.modelSource?.type === "subagents.defaultModel" && a.model === a.modelSource.model));
+		const modelScopes = resolveModelScopesForAgent(data.modelScope, a.name, parentModel);
 		const modelOverride = a.runner?.type === "external-cli" || a.runner?.type === "external-job"
 			? params.model ?? (externalRunnerWithoutExplicitModel ? undefined : a.model)
-			: resolveEffectiveSubagentModel(params.model as string | undefined, a.model, parentModel, availableModels, currentProvider, data.modelScope === undefined ? {} : { scope: data.modelScope });
+			: resolveEffectiveSubagentModel(params.model as string | undefined, a.model, parentModel, availableModels, currentProvider, modelScopes.length === 0 ? {} : { scope: modelScopes });
 		const modelOverrideFromParent = inheritsParentModel(params.model as string | undefined, a.model, parentModel);
 		return executeAsyncSingle(id, compactOptional<Parameters<typeof executeAsyncSingle>[1]>({
 			agent: params.agent!,
@@ -3239,6 +3241,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const parentModel = data.parentModel;
 	const currentProvider = parentModel?.provider;
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
+	const modelScopes = resolveModelScopesForAgent(data.modelScope, agentConfig.name, parentModel);
 	let task = params.task ?? "";
 	let modelOverride: string | undefined = resolveEffectiveSubagentModel(
 		params.model as string | undefined,
@@ -3246,7 +3249,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		parentModel,
 		availableModels,
 		currentProvider,
-		data.modelScope === undefined ? {} : { scope: data.modelScope },
+		modelScopes.length === 0 ? {} : { scope: modelScopes },
 	);
 	const modelOverrideFromParent = inheritsParentModel(params.model as string | undefined, agentConfig.model, parentModel);
 	let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
@@ -3389,7 +3392,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			thinkingOverride: thinkingOverrideForTask(params.agent!, 0, modelOverride, modelOverrideFromParent),
 			availableModels,
 			preferredModelProvider: currentProvider,
-			modelScope: data.modelScope,
+			modelScope: modelScopes,
 			skills: effectiveSkills,
 			structuredOutput: structuredRuntime,
 			agentContract: params.agentContract,

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -251,9 +251,9 @@ function configuredScopes(scope: ModelScopeRule | ModelScopeRule[] | undefined):
 	return scope ? (Array.isArray(scope) ? scope : [scope]) : [];
 }
 
-function throwForUnresolvedEnforcedInheritScope(scope: ModelScopeRule | ModelScopeRule[] | undefined): void {
+function throwForUnresolvedEnforcedInheritScope(scope: ModelScopeRule | ModelScopeRule[] | undefined, includeMixed = false): void {
 	const unresolvedInheritScope = configuredScopes(scope)
-		.find((entry) => entry.enforce === true && entry.allow?.length === 1 && entry.allow[0] === INHERIT_MODEL);
+		.find((entry) => entry.enforce === true && (includeMixed ? entry.allow?.includes(INHERIT_MODEL) : entry.allow?.length === 1 && entry.allow[0] === INHERIT_MODEL));
 	if (!unresolvedInheritScope) return;
 	const origin = "origin" in unresolvedInheritScope && typeof unresolvedInheritScope.origin === "string"
 		? unresolvedInheritScope.origin
@@ -302,7 +302,7 @@ export function resolveSubagentModelOverride(
 ): string | undefined {
 	const trimmed = typeof requestedModel === "string" ? requestedModel.trim() : "";
 	const explicit = trimmed && trimmed !== INHERIT_MODEL ? trimmed : undefined;
-	if (!parentModel) throwForUnresolvedEnforcedInheritScope(options?.scope);
+	if (!parentModel) throwForUnresolvedEnforcedInheritScope(options?.scope, explicit === undefined);
 	let resolved: string | undefined;
 	if (explicit === undefined) {
 		resolved = parentModel ? `${parentModel.provider}/${parentModel.id}` : undefined;
@@ -366,7 +366,7 @@ export function buildModelCandidates(
 	preferredProvider?: string,
 	options?: BuildModelCandidatesOptions,
 ): string[] {
-	if (!primaryModel) throwForUnresolvedEnforcedInheritScope(options?.scope);
+	if (!primaryModel) throwForUnresolvedEnforcedInheritScope(options?.scope, true);
 	const seen = new Set<string>();
 	const candidates: string[] = [];
 	const rawCandidates = [primaryModel, ...(fallbackModels ?? [])];

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -302,7 +302,7 @@ export function resolveSubagentModelOverride(
 ): string | undefined {
 	const trimmed = typeof requestedModel === "string" ? requestedModel.trim() : "";
 	const explicit = trimmed && trimmed !== INHERIT_MODEL ? trimmed : undefined;
-	if (!parentModel) throwForUnresolvedEnforcedInheritScope(options?.scope, explicit === undefined);
+	if (!parentModel) throwForUnresolvedEnforcedInheritScope(options?.scope, explicit === undefined || options?.source === "inherited");
 	let resolved: string | undefined;
 	if (explicit === undefined) {
 		resolved = parentModel ? `${parentModel.provider}/${parentModel.id}` : undefined;

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -1,7 +1,7 @@
 import type { ModelInfo as AvailableModelInfo } from "../../shared/model-info.ts";
 import type { Usage } from "../../shared/types.ts";
 import { filterFallbackCandidates, parseModelKey, recordModelFailure } from "./model-exclusions.ts";
-import { checkModelScope, type ModelScopeConfig, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
+import { checkModelScope, type ModelScopeRule, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
 
 export type { AvailableModelInfo };
 
@@ -236,7 +236,7 @@ function resolveRequiredSubagentModelCandidate(
 
 export interface ResolveSubagentModelOverrideOptions {
 	/** When set with `enforce: true`, out-of-scope models are rejected. */
-	scope?: ModelScopeConfig;
+	scope?: ModelScopeRule | ModelScopeRule[];
 	/** Origin of the requested model: explicit caller-supplied (hard error) vs inherited (warn). Defaults to `"inherited"`. */
 	source?: ModelSource;
 	/** Called for warn-severity violations instead of `console.warn`. */
@@ -245,6 +245,34 @@ export interface ResolveSubagentModelOverrideOptions {
 
 function defaultScopeWarn(violation: ModelScopeViolation): void {
 	console.warn(`[pi-subagents] ${violation.message}`);
+}
+
+function configuredScopes(scope: ModelScopeRule | ModelScopeRule[] | undefined): ModelScopeRule[] {
+	return scope ? (Array.isArray(scope) ? scope : [scope]) : [];
+}
+
+function throwForUnresolvedEnforcedInheritScope(scope: ModelScopeRule | ModelScopeRule[] | undefined): void {
+	const unresolvedInheritScope = configuredScopes(scope)
+		.find((entry) => entry.enforce === true && entry.allow?.length === 1 && entry.allow[0] === INHERIT_MODEL);
+	if (!unresolvedInheritScope) return;
+	const origin = "origin" in unresolvedInheritScope && typeof unresolvedInheritScope.origin === "string"
+		? unresolvedInheritScope.origin
+		: "modelScope";
+	throw new Error(`Cannot enforce subagent model scope (${origin}): 'inherit' requires a current parent session model.`);
+}
+
+function enforceModelScopes(
+	model: string,
+	scope: ModelScopeRule | ModelScopeRule[] | undefined,
+	source: ModelSource,
+	onWarn: ((violation: ModelScopeViolation) => void) | undefined,
+): void {
+	const violations = configuredScopes(scope)
+		.map((entry) => checkModelScope(model, entry, source))
+		.filter((violation): violation is ModelScopeViolation => violation !== undefined);
+	const error = violations.find((violation) => violation.severity === "error");
+	if (error) throw new Error(error.message);
+	for (const violation of violations) (onWarn ?? defaultScopeWarn)(violation);
 }
 
 /**
@@ -274,19 +302,16 @@ export function resolveSubagentModelOverride(
 ): string | undefined {
 	const trimmed = typeof requestedModel === "string" ? requestedModel.trim() : "";
 	const explicit = trimmed && trimmed !== INHERIT_MODEL ? trimmed : undefined;
+	if (!parentModel) throwForUnresolvedEnforcedInheritScope(options?.scope);
 	let resolved: string | undefined;
 	if (explicit === undefined) {
 		resolved = parentModel ? `${parentModel.provider}/${parentModel.id}` : undefined;
 	} else {
 		resolved = resolveRequiredSubagentModelCandidate(explicit, availableModels, preferredProvider);
 	}
-	if (resolved && options?.scope?.enforce) {
+	if (resolved && options?.scope) {
 		const source: ModelSource = explicit === undefined ? "inherited" : (options.source ?? "inherited");
-		const violation = checkModelScope(resolved, options.scope, source);
-		if (violation) {
-			if (violation.severity === "error") throw new Error(violation.message);
-			(options.onWarn ?? defaultScopeWarn)(violation);
-		}
+		enforceModelScopes(resolved, options.scope, source, options.onWarn);
 	}
 	return resolved;
 }
@@ -318,7 +343,7 @@ export function resolveEffectiveSubagentModel(
 
 export interface BuildModelCandidatesOptions {
 	/** Fallback models warn by default and throw when strict scope enforcement is enabled. */
-	scope?: ModelScopeConfig;
+	scope?: ModelScopeRule | ModelScopeRule[];
 	onWarn?: (violation: ModelScopeViolation) => void;
 	/** The primary model came from the running parent session, not configuration. */
 	primaryModelFromParent?: boolean;
@@ -341,6 +366,7 @@ export function buildModelCandidates(
 	preferredProvider?: string,
 	options?: BuildModelCandidatesOptions,
 ): string[] {
+	if (!primaryModel) throwForUnresolvedEnforcedInheritScope(options?.scope);
 	const seen = new Set<string>();
 	const candidates: string[] = [];
 	const rawCandidates = [primaryModel, ...(fallbackModels ?? [])];
@@ -358,12 +384,9 @@ export function buildModelCandidates(
 			continue;
 		}
 		if (seen.has(normalized)) continue;
-		if ((index > 0 || options?.scope?.strict === true) && options?.scope?.enforce) {
-			const violation = checkModelScope(normalized, options.scope, "inherited");
-			if (violation) {
-				if (violation.severity === "error") throw new Error(violation.message);
-				(options.onWarn ?? defaultScopeWarn)(violation);
-			}
+		const scopes = configuredScopes(options?.scope);
+		if (index > 0 || scopes.some((scope) => scope.enforce === true && scope.strict === true)) {
+			enforceModelScopes(normalized, scopes, "inherited", options?.onWarn);
 		}
 		seen.add(normalized);
 		candidates.push(normalized);

--- a/src/runs/shared/model-scope.ts
+++ b/src/runs/shared/model-scope.ts
@@ -15,12 +15,21 @@
 
 import { splitKnownThinkingSuffix } from "../../shared/model-info.ts";
 
-export interface ModelScopeConfig {
+export interface ModelScopeRule {
 	enforce?: boolean;
 	/** Reject inherited and fallback models outside the allowlist instead of warning. */
 	strict?: boolean;
 	/** Glob-style allow patterns (only `*` is special), matched against `provider/id`. */
 	allow?: string[];
+}
+
+export interface ModelScopeConfig extends ModelScopeRule {
+	/** Additional restrictions keyed by canonical agent name. */
+	agents?: Record<string, ModelScopeRule>;
+}
+
+export interface ResolvedModelScope extends ModelScopeRule {
+	origin: string;
 }
 
 /** Where a resolved model originated, deciding enforcement severity. */
@@ -32,6 +41,7 @@ export interface ModelScopeViolation {
 	severity: "warn" | "error";
 	message: string;
 	allowedPatterns: string[];
+	origin: string;
 }
 
 function stripThinkingSuffix(model: string): string {
@@ -61,7 +71,7 @@ export function matchesScopePattern(model: string, pattern: string): boolean {
  */
 export function checkModelScope(
 	model: string | undefined,
-	scope: ModelScopeConfig | undefined,
+	scope: ModelScopeRule | undefined,
 	source: ModelSource,
 ): ModelScopeViolation | undefined {
 	if (!model || !scope?.enforce) return undefined;
@@ -71,14 +81,48 @@ export function checkModelScope(
 
 	const baseModel = stripThinkingSuffix(model);
 	const severity: ModelScopeViolation["severity"] = source === "explicit" || scope.strict === true ? "error" : "warn";
+	const origin = "origin" in scope && typeof scope.origin === "string" ? scope.origin : "modelScope";
 	return {
 		model: baseModel,
 		severity,
 		allowedPatterns: allow,
+		origin,
 		message:
-			`Model '${baseModel}' is outside the configured subagent model scope. ` +
+			`Model '${baseModel}' is outside the configured subagent model scope (${origin}). ` +
 			`Allowed patterns: ${allow.join(", ")}.`,
 	};
+}
+
+function expandInheritPattern(pattern: string, parentModel: { provider: string; id: string } | undefined): string {
+	return pattern === "inherit" && parentModel ? `${parentModel.provider}/${parentModel.id}` : pattern;
+}
+
+/** Resolve the global and matching agent policies into independent launch-time checks. */
+export function resolveModelScopesForAgent(
+	config: ModelScopeConfig | undefined,
+	agentName: string,
+	parentModel: { provider: string; id: string } | undefined,
+): ResolvedModelScope[] {
+	if (!config) return [];
+	const scopes: ResolvedModelScope[] = [];
+	if (config.allow) {
+		scopes.push({
+			...(config.enforce !== undefined ? { enforce: config.enforce } : {}),
+			...(config.strict !== undefined ? { strict: config.strict } : {}),
+			allow: config.allow.map((pattern) => expandInheritPattern(pattern, parentModel)),
+			origin: "modelScope",
+		});
+	}
+	const agentScope = config.agents?.[agentName];
+	if (agentScope?.allow) {
+		scopes.push({
+			enforce: agentScope.enforce ?? config.enforce,
+			strict: agentScope.strict ?? config.strict,
+			allow: agentScope.allow.map((pattern) => expandInheritPattern(pattern, parentModel)),
+			origin: `modelScope.agents.${agentName}`,
+		});
+	}
+	return scopes;
 }
 
 /**
@@ -130,7 +174,46 @@ export function parseModelScopeConfig(
 		config.allow = allow;
 	}
 
-	if (config.enforce === true && (!config.allow || config.allow.length === 0)) {
+	if ("agents" in input) {
+		if (!input.agents || typeof input.agents !== "object" || Array.isArray(input.agents)) {
+			throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.agents'; expected an object keyed by agent name.`);
+		}
+		const agents: Record<string, ModelScopeRule> = {};
+		for (const [rawName, rawScope] of Object.entries(input.agents as Record<string, unknown>)) {
+			const name = rawName.trim();
+			const field = `modelScope.agents.${name}`;
+			if (!name) throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.agents' key; expected a non-empty agent name.`);
+			if (!rawScope || typeof rawScope !== "object" || Array.isArray(rawScope)) {
+				throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}'; expected an object.`);
+			}
+			const agentInput = rawScope as Record<string, unknown>;
+			if ("agents" in agentInput) {
+				throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.agents'; nested agent scopes are not supported.`);
+			}
+			const rule: ModelScopeRule = {};
+			if ("enforce" in agentInput) {
+				if (typeof agentInput.enforce !== "boolean") throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.enforce'; expected a boolean.`);
+				rule.enforce = agentInput.enforce;
+			}
+			if ("strict" in agentInput) {
+				if (typeof agentInput.strict !== "boolean") throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.strict'; expected a boolean.`);
+				rule.strict = agentInput.strict;
+			}
+			if ("allow" in agentInput) {
+				if (!Array.isArray(agentInput.allow) || agentInput.allow.some((entry) => typeof entry !== "string")) {
+					throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.allow'; expected an array of strings.`);
+				}
+				const allow = agentInput.allow.map((entry) => (entry as string).trim()).filter(Boolean);
+				if (allow.length === 0) throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.allow'; expected a non-empty array of patterns.`);
+				rule.allow = allow;
+			}
+			agents[name] = rule;
+		}
+		config.agents = agents;
+	}
+
+	const hasAnyAllow = Boolean(config.allow?.length) || Object.values(config.agents ?? {}).some((scope) => Boolean(scope.allow?.length));
+	if (config.enforce === true && !hasAnyAllow) {
 		throw new Error(`Subagent settings in '${meta.filePath}' set modelScope.enforce without a non-empty 'allow' list; supply allowed model patterns or disable enforcement.`);
 	}
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,7 +8,7 @@ import type { Message } from "@earendil-works/pi-ai";
 import type { AgentConfig } from "../agents/agents.ts";
 import type { FSWatcher } from "node:fs";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { ModelScopeConfig } from "../runs/shared/model-scope.ts";
+import type { ModelScopeRule } from "../runs/shared/model-scope.ts";
 import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../runs/shared/capability-ceiling.ts";
 import type { AuthorityPolicyConfig } from "../policy/authority.ts";
 import type { GlobalMissionIndexRecord, MissionRecord, MissionStoreConfig } from "../missions/types.ts";
@@ -1900,7 +1900,7 @@ export interface RunSyncOptions {
 	/** Current parent-session provider to prefer for ambiguous bare model ids */
 	preferredModelProvider?: string;
 	/** Optional subagent model-scope enforcement for fallback candidates */
-	modelScope?: ModelScopeConfig;
+	modelScope?: ModelScopeRule | ModelScopeRule[];
 	/** Skills to make available (overrides agent default if provided) */
 	skills?: string[];
 	structuredOutput?: {

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -12,6 +12,7 @@ import {
 	resolveSubagentModelOverride,
 } from "../../src/runs/shared/model-fallback.ts";
 import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
+import { resolveModelScopesForAgent } from "../../src/runs/shared/model-scope.ts";
 
 beforeEach(() => clearExclusions());
 afterEach(() => clearExclusions());
@@ -458,6 +459,79 @@ describe("resolveSubagentModelOverride scope enforcement", () => {
 		);
 	});
 
+	it("identifies the per-agent scope that rejects an explicit model", () => {
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, allow: ["openai/*", "deepseek/*"], agents: { worker: { allow: ["openai/gpt-5-mini"] } } },
+			"worker",
+			parentModel,
+		);
+		assert.throws(
+			() => resolveEffectiveSubagentModel("deepseek/deepseek-v4", undefined, parentModel, availableModels, undefined, { scope: scopes }),
+			/modelScope\.agents\.worker/,
+		);
+	});
+
+	it("allows an inherited parent model through an inherit agent scope", () => {
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, agents: { reviewer: { allow: ["inherit"] } } },
+			"reviewer",
+			parentModel,
+		);
+		assert.equal(resolveEffectiveSubagentModel(undefined, undefined, parentModel, availableModels, undefined, { scope: scopes }), "deepseek/deepseek-v4");
+	});
+
+	it("fails closed when enforced inherit cannot resolve a parent model", () => {
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, agents: { reviewer: { allow: ["inherit"] } } },
+			"reviewer",
+			undefined,
+		);
+		assert.throws(
+			() => resolveEffectiveSubagentModel(undefined, undefined, undefined, availableModels, undefined, { scope: scopes }),
+			/modelScope\.agents\.reviewer.*requires a current parent session model/,
+		);
+	});
+
+	it("fails closed before using an agent fallback when enforced inherit has no parent model", () => {
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, agents: { reviewer: { allow: ["inherit"] } } },
+			"reviewer",
+			undefined,
+		);
+		for (const explicitModel of [undefined, "inherit"] as const) {
+			assert.throws(
+				() => resolveEffectiveSubagentModel(explicitModel, "openai/gpt-5-mini", undefined, availableModels, undefined, { scope: scopes }),
+				/modelScope\.agents\.reviewer.*requires a current parent session model/,
+			);
+		}
+	});
+
+	it("fails closed before using fallback candidates when enforced inherit has no parent model", () => {
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, agents: { worker: { allow: ["inherit"] } } },
+			"worker",
+			undefined,
+		);
+		assert.throws(
+			() => buildModelCandidates(undefined, ["openai/gpt-5-mini"], availableModels, undefined, { scope: scopes }),
+			/modelScope\.agents\.worker.*requires a current parent session model/,
+		);
+	});
+
+	it("throws the strict agent violation before emitting a global warning", () => {
+		const warnings: string[] = [];
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, allow: ["openai/*"], agents: { worker: { strict: true, allow: ["anthropic/*"] } } },
+			"worker",
+			parentModel,
+		);
+		assert.throws(
+			() => resolveEffectiveSubagentModel(undefined, undefined, parentModel, availableModels, undefined, { scope: scopes, onWarn: (violation) => warnings.push(violation.message) }),
+			/modelScope\.agents\.worker/,
+		);
+		assert.deepEqual(warnings, []);
+	});
+
 	it("warns (and still returns the model) for an inherited out-of-scope model", () => {
 		const warnings: string[] = [];
 		const resolved = resolveSubagentModelOverride("deepseek/deepseek-v4", parentModel, availableModels, undefined, {
@@ -550,6 +624,18 @@ describe("resolveSubagentModelOverride scope enforcement", () => {
 				scope: { ...scope, strict: true },
 			}),
 			/deepseek\/deepseek-v4.*outside the configured subagent model scope/,
+		);
+	});
+
+	it("applies a strict per-agent scope to fallback candidates", () => {
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, strict: true, agents: { worker: { allow: ["openai/*"] } } },
+			"worker",
+			parentModel,
+		);
+		assert.throws(
+			() => buildModelCandidates("openai/gpt-5-mini", ["deepseek/deepseek-v4"], availableModels, undefined, { scope: scopes }),
+			/modelScope\.agents\.worker/,
 		);
 	});
 });

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -518,6 +518,31 @@ describe("resolveSubagentModelOverride scope enforcement", () => {
 		);
 	});
 
+	it("fails closed for mixed inherit scopes before omitting the model", () => {
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, agents: { worker: { allow: ["inherit", "openai/gpt-5-*"] } } },
+			"worker",
+			undefined,
+		);
+		assert.throws(
+			() => resolveEffectiveSubagentModel(undefined, undefined, undefined, availableModels, undefined, { scope: scopes }),
+			/modelScope\.agents\.worker.*requires a current parent session model/,
+		);
+		assert.throws(
+			() => buildModelCandidates(undefined, ["openai/gpt-5-mini"], availableModels, undefined, { scope: scopes }),
+			/modelScope\.agents\.worker.*requires a current parent session model/,
+		);
+	});
+
+	it("allows an explicit model through a mixed inherit scope without a parent", () => {
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, agents: { worker: { allow: ["inherit", "openai/gpt-5-*"] } } },
+			"worker",
+			undefined,
+		);
+		assert.equal(resolveEffectiveSubagentModel("openai/gpt-5-mini", undefined, undefined, availableModels, undefined, { scope: scopes }), "openai/gpt-5-mini");
+	});
+
 	it("throws the strict agent violation before emitting a global warning", () => {
 		const warnings: string[] = [];
 		const scopes = resolveModelScopesForAgent(

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -543,6 +543,18 @@ describe("resolveSubagentModelOverride scope enforcement", () => {
 		assert.equal(resolveEffectiveSubagentModel("openai/gpt-5-mini", undefined, undefined, availableModels, undefined, { scope: scopes }), "openai/gpt-5-mini");
 	});
 
+	it("fails closed before using an agent model through a mixed inherit scope without a parent", () => {
+		const scopes = resolveModelScopesForAgent(
+			{ enforce: true, agents: { worker: { allow: ["inherit", "openai/gpt-5-*"] } } },
+			"worker",
+			undefined,
+		);
+		assert.throws(
+			() => resolveEffectiveSubagentModel(undefined, "openai/gpt-5-mini", undefined, availableModels, undefined, { scope: scopes }),
+			/modelScope\.agents\.worker.*requires a current parent session model/,
+		);
+	});
+
 	it("throws the strict agent violation before emitting a global warning", () => {
 		const warnings: string[] = [];
 		const scopes = resolveModelScopesForAgent(

--- a/test/unit/model-scope-settings.test.ts
+++ b/test/unit/model-scope-settings.test.ts
@@ -42,10 +42,17 @@ describe("subagents.modelScope discovery", () => {
 
 	it("exposes a user modelScope from discoverAgents", () => {
 		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
-			subagents: { modelScope: { enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"] } },
+			subagents: { modelScope: { enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"], agents: { reviewer: { allow: ["inherit"] } } } },
 		});
 		const result = discoverAgents(tempProject, "both");
-		assert.deepEqual(result.modelScope, { enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"] });
+		assert.deepEqual(result.modelScope, { enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"], agents: { reviewer: { allow: ["inherit"] } } });
+	});
+
+	it("accepts enforcement with only named agent allow lists", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { modelScope: { enforce: true, agents: { worker: { allow: ["openai/gpt-5-mini"] } } } },
+		});
+		assert.deepEqual(discoverAgents(tempProject, "both").modelScope, { enforce: true, agents: { worker: { allow: ["openai/gpt-5-mini"] } } });
 	});
 
 	it("returns undefined when no modelScope is configured", () => {
@@ -54,13 +61,13 @@ describe("subagents.modelScope discovery", () => {
 
 	it("prefers project modelScope over user modelScope", () => {
 		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
-			subagents: { modelScope: { enforce: true, allow: ["anthropic/*"] } },
+			subagents: { modelScope: { enforce: true, allow: ["anthropic/*"], agents: { reviewer: { allow: ["inherit"] } } } },
 		});
 		writeJson(path.join(tempProject, ".pi", "settings.json"), {
-			subagents: { modelScope: { enforce: false, allow: ["deepseek/*"] } },
+			subagents: { modelScope: { enforce: true, agents: { worker: { allow: ["deepseek/*"] } } } },
 		});
 		const result = discoverAgents(tempProject, "both");
-		assert.deepEqual(result.modelScope, { enforce: false, allow: ["deepseek/*"] });
+		assert.deepEqual(result.modelScope, { enforce: true, agents: { worker: { allow: ["deepseek/*"] } } });
 	});
 
 	it("falls back to user modelScope when project does not set one", () => {
@@ -83,5 +90,12 @@ describe("subagents.modelScope discovery", () => {
 			subagents: { modelScope: "anthropic/*" },
 		});
 		assert.throws(() => discoverAgents(tempProject, "both"), /invalid 'modelScope'/);
+	});
+
+	it("rejects malformed per-agent scopes at discovery time", () => {
+		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
+			subagents: { modelScope: { agents: { worker: { allow: [] } } } },
+		});
+		assert.throws(() => discoverAgents(tempProject, "both"), /modelScope\.agents\.worker\.allow/);
 	});
 });

--- a/test/unit/model-scope.test.ts
+++ b/test/unit/model-scope.test.ts
@@ -4,6 +4,7 @@ import {
 	checkModelScope,
 	matchesScopePattern,
 	parseModelScopeConfig,
+	resolveModelScopesForAgent,
 	type ModelScopeConfig,
 } from "../../src/runs/shared/model-scope.ts";
 
@@ -73,6 +74,7 @@ describe("checkModelScope", () => {
 		assert.equal(violation?.severity, "error");
 		assert.equal(violation?.model, "deepseek/deepseek-v4");
 		assert.deepEqual(violation?.allowedPatterns, ["anthropic/*", "openai/gpt-5-*"]);
+		assert.equal(violation?.origin, "modelScope");
 		assert.match(violation?.message ?? "", /outside the configured subagent model scope/);
 	});
 
@@ -101,6 +103,34 @@ describe("checkModelScope", () => {
 	});
 });
 
+describe("resolveModelScopesForAgent", () => {
+	it("returns independent global and agent checks with inherited flags", () => {
+		assert.deepEqual(
+			resolveModelScopesForAgent({ enforce: true, strict: true, allow: ["openai/*"], agents: { worker: { allow: ["openai/gpt-5-mini"] } } }, "worker", { provider: "openai", id: "gpt-5" }),
+			[
+				{ enforce: true, strict: true, allow: ["openai/*"], origin: "modelScope" },
+				{ enforce: true, strict: true, allow: ["openai/gpt-5-mini"], origin: "modelScope.agents.worker" },
+			],
+		);
+	});
+
+	it("expands inherit against the current parent model", () => {
+		const scopes = resolveModelScopesForAgent({ enforce: true, allow: ["inherit"], agents: { reviewer: { allow: ["inherit"] } } }, "reviewer", { provider: "anthropic", id: "claude-sonnet-4" });
+		assert.deepEqual(scopes.map((scope) => scope.allow), [["anthropic/claude-sonnet-4"], ["anthropic/claude-sonnet-4"]]);
+	});
+
+	it("keeps inherit literal when no parent model is available so enforcement fails closed", () => {
+		const [scope] = resolveModelScopesForAgent({ enforce: true, allow: ["inherit"] }, "worker", undefined);
+		const violation = checkModelScope("openai/gpt-5-mini", scope, "explicit");
+		assert.equal(violation?.severity, "error");
+		assert.deepEqual(violation?.allowedPatterns, ["inherit"]);
+	});
+
+	it("does not apply another agent's scope", () => {
+		assert.deepEqual(resolveModelScopesForAgent({ enforce: true, agents: { reviewer: { allow: ["inherit"] } } }, "worker", { provider: "openai", id: "gpt-5" }), []);
+	});
+});
+
 describe("parseModelScopeConfig", () => {
 	const meta = { filePath: "~/.pi/agent/settings.json" };
 
@@ -112,6 +142,13 @@ describe("parseModelScopeConfig", () => {
 		assert.deepEqual(
 			parseModelScopeConfig({ enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"] }, meta),
 			{ enforce: true, strict: true, allow: ["anthropic/*", "openai/gpt-5-*"] },
+		);
+	});
+
+	it("parses per-agent scopes and permits agent-only enforcement", () => {
+		assert.deepEqual(
+			parseModelScopeConfig({ enforce: true, strict: true, agents: { worker: { allow: [" openai/gpt-5-mini "] }, unknown: { enforce: false } } }, meta),
+			{ enforce: true, strict: true, agents: { worker: { allow: ["openai/gpt-5-mini"] }, unknown: { enforce: false } } },
 		);
 	});
 
@@ -150,5 +187,12 @@ describe("parseModelScopeConfig", () => {
 	it("rejects enforce without a non-empty allow list", () => {
 		assert.throws(() => parseModelScopeConfig({ enforce: true }, meta), /without a non-empty 'allow'/);
 		assert.throws(() => parseModelScopeConfig({ enforce: true, allow: [] }, meta), /non-empty array of patterns/);
+	});
+
+	it("rejects invalid agent scope shapes with the full field path", () => {
+		assert.throws(() => parseModelScopeConfig({ enforce: true, agents: { worker: [] } }, meta), /modelScope\.agents\.worker/);
+		assert.throws(() => parseModelScopeConfig({ agents: { worker: { allow: [] } } }, meta), /modelScope\.agents\.worker\.allow/);
+		assert.throws(() => parseModelScopeConfig({ agents: { worker: { agents: {} } } }, meta), /modelScope\.agents\.worker\.agents/);
+		assert.throws(() => parseModelScopeConfig({ agents: { " ": { allow: ["inherit"] } } }, meta), /non-empty agent name/);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1328 by adding per-agent model-scope restrictions at `subagents.modelScope.agents.<agentName>` and treating `inherit` in allow lists as a parent-model alias.

The policy is cumulative: global scope and per-agent scope are checked independently, so an agent rule can only narrow the global rule. Per-agent entries inherit top-level `enforce` and `strict`. Enforced `inherit` without a current parent model fails closed, including agent/default fallback and fallback model candidate paths.

Thanks to [@hieudmg](https://github.com/hieudmg) for #1328.

## Validation

- `git diff --check`
- `npm exec -- tsx --test test/unit/model-fallback.test.ts test/unit/model-scope.test.ts test/unit/model-scope-settings.test.ts`
- `npm run typecheck`

## Review

Fresh high-risk review reports:

- `reports/issue-1328-model-scope-workflow.review.json`
- `reports/backlog-wave-20260821T1503.issue-1328-review.json`
- `reports/issue-1328-model-scope-fallback-candidate-fix-workflow.issue-1328-fallback-candidate-review.json`

Final result: No issues found after the fallback-candidate fail-closed fix.