### PR TITLE
test: rename stale code-reviewer fixture

### DIFF
--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -434,11 +434,11 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			],
 			keepAliveAfterFinalMessageMs: 400,
 		});
-		const executor = makeExecutor([makeAgent("code-reviewer")]);
+		const executor = makeExecutor([makeAgent("bash-worker")]);
 
 		const result = await executor.executePublic(
 			"structured-single-tool-backfill",
-			{ agent: "code-reviewer", task: "Run exactly one tool: bash with command echo PROBE_OK.", async: false, toolTimeoutMs: 100, timeoutMs: 1_000 },
+			{ agent: "bash-worker", task: "Run exactly one tool: bash with command echo PROBE_OK.", async: false, toolTimeoutMs: 100, timeoutMs: 1_000 },
 			new AbortController().signal,
 			undefined,
 			makeMinimalCtx(tempDir),


### PR DESCRIPTION
## Summary

- rename the local `code-reviewer` fixture in the #1340 regression to `bash-worker`
- avoid implying that `code-reviewer` is still a supported builtin agent

Closes #1341.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'keeps public structured children alive when tool results backfill without execution_end' test/integration/single-execution.test.ts`
- `git diff --check`
- focused fresh review: no issues found
