### PR TITLE
fix: load permission bridge only for native rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Simplify Council Mode advisor selection so model-based profiles provide the perspective and the question supplies the decision frame.
 
 ### Fixed
+- Avoid child tool-call hangs by loading the external permission-system bridge only for explicit native permission rules and by failing stalled ask decisions closed. Thanks to [@moekyo](https://github.com/moekyo) for #1339.
 - Keep foreground workflow children from timing out after a tool result is backfilled without a separate execution-end event. Thanks to [@moekyo](https://github.com/moekyo) for #1339.
 - Mark completed foreground workflow children as resumable in keyed receipts when their persisted session file is available (#1335).
 - Avoid loading the parent extension graph in subagent child processes. Thanks to [@ccharname](https://github.com/ccharname) for #1330.

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -15,6 +15,7 @@ import { resolveEffectiveThinking } from "../shared/model-info.ts";
 import { SUBAGENT_LIFECYCLE_ARTIFACT_VERSION, type ArtifactDirPreference, type ArtifactPaths, type JsonSchemaObject, type OutputMode } from "../shared/types.ts";
 import { capabilityCeilingAgentRestrictionMessage, intersectSubagentCapabilityCeilings, type ResolvedSubagentCapabilityCeiling, type SubagentCapabilityAudit } from "../runs/shared/capability-ceiling.ts";
 import { appendTurnBudgetSystemPrompt } from "../runs/shared/turn-budget.ts";
+import { resolvePermissionRules } from "../runs/shared/permissions.ts";
 import type { ResolvedTurnBudget } from "../shared/types.ts";
 import type { ResolvedMcpDirectToolSelection } from "../runs/shared/mcp-direct-tool-allowlist.ts";
 import { resolveStepBehavior } from "../shared/settings.ts";
@@ -303,6 +304,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		})
 			.map((candidate) => applyThinkingSuffix(candidate, effectiveThinkingConfig, input.thinking !== undefined) ?? candidate);
 	let toolPlan: PiLaunchToolPlan;
+	const permissionRules = resolvePermissionRules(loadConfig().permissions, agent.permissions);
 	try {
 		toolPlan = resolvePiLaunchToolPlan({
 			tools: agent.tools,
@@ -314,6 +316,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 			structuredOutput: Boolean(input.outputSchema),
 			capabilityCeiling: effectiveCapabilityCeiling,
 			agentName: agent.name,
+			permissionRules,
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -804,6 +804,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		const effectiveThinking = externalRunner ? undefined : thinkingOverride ?? a.thinking;
 		const model = externalRunner ? undefined : applyThinkingSuffix(primaryModel, effectiveThinking, thinkingOverride !== undefined);
 		const agentContract = s.agentContract ?? params.agentContract;
+		const permissionRules = resolvePermissionRules(ctx.permissions, a.permissions);
 		const toolPlan = resolvePiLaunchToolPlan({
 			tools: a.tools,
 			extensions: a.extensions,
@@ -815,9 +816,9 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			capabilityCeiling: params.capabilityCeiling,
 			inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
 			agentName: a.name,
+			permissionRules,
 		});
 		const launchResolvedExtensions = externalRunner ? undefined : projectLaunchResolvedChildExtensions(toolPlan);
-		const permissionRules = resolvePermissionRules(ctx.permissions, a.permissions);
 		if (externalRunner && permissionRules) {
 			throw new AsyncStartValidationError(`Agent '${a.name}' uses runner.type='${externalRunnerType}', which cannot enforce native Pi child permission rules.`);
 		}
@@ -1475,6 +1476,7 @@ export function executeAsyncSingle(
 		capabilityCeiling,
 		inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
 		agentName: agentConfig.name,
+		permissionRules: resolvePermissionRules(ctx.permissions, agentConfig.permissions),
 	});
 	const launchResolvedExtensions = externalRunner ? undefined : projectLaunchResolvedChildExtensions(toolPlan);
 	const launchContractDigest = launchBindingDigest({

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1540,6 +1540,7 @@ async function runSingleStepInner(
 				structuredOutput: Boolean(effectiveStructuredOutput),
 				capabilityCeiling: step.capabilityCeiling ?? ctx.capabilityCeiling,
 				inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
+				permissionRules: step.permissionRules,
 			}));
 			launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
 			actualLaunchContractDigest = launchBindingDigest(omitUndefinedProperties({

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -383,6 +383,7 @@ async function runSingleAttempt(
 		capabilityCeiling: options.capabilityCeiling,
 		inheritedCapabilityCeiling: decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV]),
 		agentName: agent.name,
+		permissionRules,
 	});
 	const launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
 	const launchContractDigest = launchBindingDigest({

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -251,6 +251,7 @@ export interface ResolvePiLaunchToolPlanInput {
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	inheritedCapabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	agentName?: string;
+	permissionRules?: PermissionRules;
 }
 
 export interface PiLaunchToolPlan {
@@ -286,6 +287,10 @@ function boundedExtensionIdentifiers(values: string[]): {
 		ids: ids.slice(0, MAX_LAUNCH_RESOLVED_EXTENSION_IDS),
 		omitted: Math.max(0, ids.length - MAX_LAUNCH_RESOLVED_EXTENSION_IDS),
 	};
+}
+
+function hasPermissionRules(rules: PermissionRules | undefined): boolean {
+	return rules !== undefined && Object.keys(rules).length > 0;
 }
 
 export function projectLaunchResolvedChildExtensions(
@@ -451,7 +456,9 @@ export function resolvePiLaunchToolPlan(
 		: [];
 	const permSystemExt = capabilityCeiling?.denyExtensions
 		? undefined
-		: resolvePermissionSystemExtension();
+		: hasPermissionRules(input.permissionRules)
+			? resolvePermissionSystemExtension()
+			: undefined;
 	const runtimeExtensions = [
 		PROMPT_RUNTIME_EXTENSION_PATH,
 		...(fanoutAuthorized ? [FANOUT_CHILD_EXTENSION_PATH] : []),
@@ -587,6 +594,7 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 			process.env[SUBAGENT_CAPABILITY_CEILING_ENV],
 		),
 		agentName: input.childAgentName,
+		permissionRules: input.permissionRules,
 	});
 	if (toolPlan.explicitToolAllowlist) {
 		args.push(

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -21,7 +21,7 @@ import type { JsonSchemaObject, ResolvedToolBudget, SubagentState } from "../../
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { resolveWatchPath } from "../../shared/utils.ts";
 import { registerChildWatchdog } from "../../watchdog/register-child.ts";
-import { CHILD_WATCHDOG_CONFIG_ENV } from "../../watchdog/child-status.ts";
+import { CHILD_WATCHDOG_CONFIG_ENV, decodeChildWatchdogConfig } from "../../watchdog/child-status.ts";
 import { requestWatchdogPermission, type WatchdogPermissionRequest, type WatchdogPermissionResult } from "../../watchdog/permission-arbiter.ts";
 import { SUBAGENT_WATCHDOG_WARNING_TYPE } from "../../watchdog/types.ts";
 import { resolveWaitToolConfig } from "../background/wait-config.ts";
@@ -296,14 +296,41 @@ export function registerPermissionGate(
 		const decision = permissionDecision(rules, toolName);
 		if (decision === "allow") return undefined;
 		if (decision === "deny") return { block: true, reason: `Blocked by pi-subagents permission rule: '${toolName}' is denied.` };
-		const result = await requestPermission({
-			ctx,
-			toolName,
-			args: event.input ?? {},
-			rawWatchdogConfig: process.env[CHILD_WATCHDOG_CONFIG_ENV],
-			auditPath: process.env[PERMISSION_AUDIT_PATH_ENV],
-			...(ctx.signal ? { signal: ctx.signal } : {}),
-		});
+		const rawWatchdogConfig = process.env[CHILD_WATCHDOG_CONFIG_ENV];
+		let timeoutMs = 30_000;
+		try {
+			timeoutMs = decodeChildWatchdogConfig(rawWatchdogConfig)?.agentEndTimeoutMs ?? timeoutMs;
+		} catch {
+			// The arbiter reports invalid configuration with the concrete decode error.
+		}
+		if (ctx.signal?.aborted) return { block: true, reason: "Blocked by pi-subagents permission rule: Watchdog permission decision was cancelled." };
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		let abort: (() => void) | undefined;
+		let result: WatchdogPermissionResult;
+		try {
+			result = await Promise.race([
+				requestPermission({
+					ctx,
+					toolName,
+					args: event.input ?? {},
+					rawWatchdogConfig,
+					auditPath: process.env[PERMISSION_AUDIT_PATH_ENV],
+					...(ctx.signal ? { signal: ctx.signal } : {}),
+				}),
+				new Promise<WatchdogPermissionResult>((resolve) => {
+					if (!ctx.signal) return;
+					abort = () => resolve({ approved: false, reason: "Watchdog permission decision was cancelled.", source: "watchdog" });
+					ctx.signal.addEventListener("abort", abort, { once: true });
+				}),
+				new Promise<never>((_, reject) => { timeout = setTimeout(() => reject(new Error(`Watchdog permission decision timed out after ${timeoutMs}ms.`)), timeoutMs); }),
+			]);
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+			return { block: true, reason: `Blocked by pi-subagents permission rule: Watchdog permission arbiter failed closed: ${reason}` };
+		} finally {
+			if (timeout) clearTimeout(timeout);
+			if (abort) ctx.signal?.removeEventListener("abort", abort);
+		}
 		if (result.approved) return undefined;
 		return { block: true, reason: `Blocked by pi-subagents permission rule: ${result.reason}` };
 	});

--- a/src/watchdog/permission-arbiter.ts
+++ b/src/watchdog/permission-arbiter.ts
@@ -45,7 +45,10 @@ export function createWatchdogPermissionArbiter(options: WatchdogPermissionArbit
 		const createdAt = Date.now();
 		const auditBase = { type: "permission.request", createdAt, toolName: request.toolName, preview, matchedRule: "ask", decisionSource: "watchdog" };
 		appendPermissionAudit(request.auditPath, auditBase);
+		let completed = false;
 		const finish = (approved: boolean, reason: string, decision: string): WatchdogPermissionResult => {
+			if (completed) return { approved, reason: conciseReason(reason), source: "watchdog" };
+			completed = true;
 			appendPermissionAudit(request.auditPath, {
 				type: "permission.decision",
 				createdAt: Date.now(),
@@ -84,61 +87,74 @@ export function createWatchdogPermissionArbiter(options: WatchdogPermissionArbit
 
 		let timeout: ReturnType<typeof setTimeout> | undefined;
 		let agent: Agent | undefined;
+		let abort: (() => void) | undefined;
 		try {
-			const config = childResolvedConfig(childConfig);
-			const selection = await resolveWatchdogReviewModel(request.ctx, config);
-			const auth = selection.auth;
-			const registeredProvider = (request.ctx.modelRegistry as {
-				getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
-			}).getRegisteredProviderConfig?.(selection.model.provider);
-			const baseStreamFn = options.streamFn ?? (registeredProvider?.streamSimple && registeredProvider.api === selection.model.api
-				? registeredProvider.streamSimple
-				: streamSimple);
-			const streamFn: StreamFn = (model, context, streamOptions) => baseStreamFn(model, context, {
-				...streamOptions,
-				...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
-				env: auth.env || streamOptions?.env ? { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } : undefined,
-				headers: { ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
-			});
-			agent = new Agent({
-				initialState: {
-					systemPrompt: [
-						"You are the pi-subagents watchdog permission arbiter.",
-						"Decide only whether this exact non-bash child tool call should proceed.",
-						"Call watchdog_permission_decision exactly once with approve or deny and a concise reason.",
-						"Deny when uncertain. Do not produce freeform advice or ask the parent orchestrator.",
-					].join("\n"),
-					model: selection.model,
-					thinkingLevel: selection.thinkingLevel,
-					tools: [tool],
-				},
-				convertToLlm,
-				...agentStreamOptions(streamFn),
-				getApiKey: (providerName) => providerName === selection.model.provider ? auth.apiKey : undefined,
-				beforeToolCall: async ({ toolCall }) => toolCall.name === tool.name ? undefined : { block: true, reason: `Permission arbiter tool '${toolCall.name}' is not allowed.` },
-				toolExecution: "sequential",
-			});
-			const abort = () => agent?.abort();
-			request.signal?.addEventListener("abort", abort, { once: true });
-			request.ctx.signal?.addEventListener("abort", abort, { once: true });
-			try {
-				const prompt = `Tool: ${request.toolName}\nRedacted arguments: ${preview}`;
-				await Promise.race([
-					agent.prompt(prompt),
-					new Promise<never>((_, reject) => { timeout = setTimeout(() => { agent?.abort(); reject(new Error("Watchdog permission decision timed out.")); }, childConfig.agentEndTimeoutMs); }),
-				]);
-			} finally {
-				request.signal?.removeEventListener("abort", abort);
-				request.ctx.signal?.removeEventListener("abort", abort);
-			}
-			if (!decision) return finish(false, "Watchdog permission arbiter returned no decision.", "malformed");
-			const approved = decision.decision === "approve";
-			return finish(approved, decision.reason, decision.decision);
+			const run = async (): Promise<WatchdogPermissionResult> => {
+				const config = childResolvedConfig(childConfig);
+				const selection = await resolveWatchdogReviewModel(request.ctx, config);
+				const auth = selection.auth;
+				const registeredProvider = (request.ctx.modelRegistry as {
+					getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
+				}).getRegisteredProviderConfig?.(selection.model.provider);
+				const baseStreamFn = options.streamFn ?? (registeredProvider?.streamSimple && registeredProvider.api === selection.model.api
+					? registeredProvider.streamSimple
+					: streamSimple);
+				const streamFn: StreamFn = (model, context, streamOptions) => baseStreamFn(model, context, {
+					...streamOptions,
+					...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
+					env: auth.env || streamOptions?.env ? { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } : undefined,
+					headers: { ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
+				});
+				agent = new Agent({
+					initialState: {
+						systemPrompt: [
+							"You are the pi-subagents watchdog permission arbiter.",
+							"Decide only whether this exact non-bash child tool call should proceed.",
+							"Call watchdog_permission_decision exactly once with approve or deny and a concise reason.",
+							"Deny when uncertain. Do not produce freeform advice or ask the parent orchestrator.",
+						].join("\n"),
+						model: selection.model,
+						thinkingLevel: selection.thinkingLevel,
+						tools: [tool],
+					},
+					convertToLlm,
+					...agentStreamOptions(streamFn),
+					getApiKey: (providerName) => providerName === selection.model.provider ? auth.apiKey : undefined,
+					beforeToolCall: async ({ toolCall }) => toolCall.name === tool.name ? undefined : { block: true, reason: `Permission arbiter tool '${toolCall.name}' is not allowed.` },
+					toolExecution: "sequential",
+				});
+				const abort = () => agent?.abort();
+				request.signal?.addEventListener("abort", abort, { once: true });
+				request.ctx.signal?.addEventListener("abort", abort, { once: true });
+				try {
+					const prompt = `Tool: ${request.toolName}\nRedacted arguments: ${preview}`;
+					await agent.prompt(prompt);
+				} finally {
+					request.signal?.removeEventListener("abort", abort);
+					request.ctx.signal?.removeEventListener("abort", abort);
+				}
+				if (!decision) return finish(false, "Watchdog permission arbiter returned no decision.", "malformed");
+				const approved = decision.decision === "approve";
+				return finish(approved, decision.reason, decision.decision);
+			};
+			return await Promise.race([
+				run(),
+				new Promise<WatchdogPermissionResult>((resolve) => { timeout = setTimeout(() => { agent?.abort(); resolve(finish(false, "Watchdog permission decision timed out.", "timeout")); }, childConfig.agentEndTimeoutMs); }),
+				new Promise<WatchdogPermissionResult>((resolve) => {
+					abort = () => { agent?.abort(); resolve(finish(false, "Watchdog permission decision was cancelled.", "cancelled")); };
+					request.signal?.addEventListener("abort", abort, { once: true });
+					request.ctx.signal?.addEventListener("abort", abort, { once: true });
+				}),
+			]);
 		} catch (error) {
 			const reason = error instanceof Error ? error.message : String(error);
 			return finish(false, `Watchdog permission arbiter failed closed: ${reason}`, reason.includes("timed out") ? "timeout" : "error");
 		} finally {
 			if (timeout) clearTimeout(timeout);
+			if (abort) {
+				request.signal?.removeEventListener("abort", abort);
+				request.ctx.signal?.removeEventListener("abort", abort);
+			}
 		}
 	};
 }

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -615,37 +615,50 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const agentName = `contract-worker-${Date.now().toString(36)}`;
 		const task = "Compare the resolved launch inputs.";
 		const turnBudget = { maxTurns: 2, graceTurns: 1 } as const;
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const agentDir = path.join(tempDir, "agent-home");
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const permissionExtDir = path.join(agentDir, "extensions", "pi-permission-system");
+		fs.mkdirSync(path.join(permissionExtDir, "src"), { recursive: true });
+		fs.writeFileSync(path.join(permissionExtDir, "src", "index.ts"), "export default () => {};", "utf-8");
+		fs.writeFileSync(path.join(permissionExtDir, "package.json"), JSON.stringify({ name: "test", pi: { extensions: ["./src/index.ts"] } }), "utf-8");
 		const agentPath = path.join(tempDir, ".pi", "agents", `${agentName}.md`);
 		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
-		fs.writeFileSync(agentPath, `---\nname: ${agentName}\ndescription: Contract comparison worker\n---\n`, "utf-8");
-		const discovered = discoverAgents(tempDir).agents.find((agent) => agent.name === agentName);
-		assert.ok(discovered, "expected temporary agent definition to be discovered");
-		const preflight = await resolveSubagentLaunchContract({ agent: agentName, cwd: tempDir, task, turnBudget, runId: "contract-preflight" });
-		assert.equal(preflight.ok, true);
+		fs.writeFileSync(agentPath, `---\nname: ${agentName}\ndescription: Contract comparison worker\npermissions:\n  write: ask\n---\n`, "utf-8");
+		try {
+			const discovered = discoverAgents(tempDir).agents.find((agent) => agent.name === agentName);
+			assert.ok(discovered, "expected temporary agent definition to be discovered");
+			const preflight = await resolveSubagentLaunchContract({ agent: agentName, cwd: tempDir, task, turnBudget, runId: "contract-preflight" });
+			assert.equal(preflight.ok, true);
+			assert.ok(preflight.contract.tools.extensionArgs.some((entry) => entry.endsWith(path.join("pi-permission-system", "src", "index.ts"))));
 
-		mockPi.onCall({ output: "foreground contract comparison" });
-		const foreground = await runSync(tempDir, [discovered], agentName, task, { runId: "contract-foreground", acceptance: false, turnBudget });
-		assert.equal(foreground.exitCode, 0);
-		assert.equal(foreground.launchContractDigest, preflight.contract.launchContractDigest);
+			mockPi.onCall({ output: "foreground contract comparison" });
+			const foreground = await runSync(tempDir, [discovered], agentName, task, { runId: "contract-foreground", acceptance: false, turnBudget });
+			assert.equal(foreground.exitCode, 0);
+			assert.equal(foreground.launchContractDigest, preflight.contract.launchContractDigest);
 
-		mockPi.onCall({ output: "async contract comparison" });
-		const asyncId = `async-contract-equivalence-${Date.now().toString(36)}`;
-		const launch = executeAsyncSingle(asyncId, {
-			agent: agentName,
-			task,
-			agentConfig: discovered,
-			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
-			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
-			shareEnabled: false,
-			sessionRoot: path.join(tempDir, "sessions"),
-			maxSubagentDepth: 2,
-			acceptance: false,
-			turnBudget,
-		});
-		const payload = await readAsyncPayload(asyncId);
-		assert.equal(launch.details.launchContractDigest, preflight.contract.launchContractDigest);
-		assert.equal(payload.launchContractDigest, preflight.contract.launchContractDigest);
-		assert.equal(payload.results[0]?.launchContractDigest, preflight.contract.launchContractDigest);
+			mockPi.onCall({ output: "async contract comparison" });
+			const asyncId = `async-contract-equivalence-${Date.now().toString(36)}`;
+			const launch = executeAsyncSingle(asyncId, {
+				agent: agentName,
+				task,
+				agentConfig: discovered,
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false,
+				sessionRoot: path.join(tempDir, "sessions"),
+				maxSubagentDepth: 2,
+				acceptance: false,
+				turnBudget,
+			});
+			const payload = await readAsyncPayload(asyncId);
+			assert.equal(launch.details.launchContractDigest, preflight.contract.launchContractDigest);
+			assert.equal(payload.launchContractDigest, preflight.contract.launchContractDigest);
+			assert.equal(payload.results[0]?.launchContractDigest, preflight.contract.launchContractDigest);
+		} finally {
+			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		}
 	});
 
 	it("persists the actual launch digest in async status and result metadata", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -438,7 +438,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		const result = await executor.executePublic(
 			"structured-single-tool-backfill",
-			{ agent: "bash-worker", task: "Run exactly one tool: bash with command echo PROBE_OK.", async: false, toolTimeoutMs: 100, timeoutMs: 1_000 },
+			{ agent: "bash-worker", task: "Run exactly one tool: bash with command echo PROBE_OK.", async: false, toolTimeoutMs: 100, timeoutMs: 5_000 },
 			new AbortController().signal,
 			undefined,
 			makeMinimalCtx(tempDir),

--- a/test/unit/pi-args-permission-system.test.ts
+++ b/test/unit/pi-args-permission-system.test.ts
@@ -221,7 +221,7 @@ describe("resolvePermissionSystemExtension", () => {
 });
 
 describe("resolvePiLaunchToolPlan with permission system", () => {
-	it("adds the permission system extension to buildPiArgs when installed", () => {
+	it("does not inject the permission system when no native permission rules are set", () => {
 		const { agentDir } = createFixture();
 		process.env.PI_CODING_AGENT_DIR = agentDir;
 		const extDir = path.join(agentDir, "extensions", "pi-permission-system");
@@ -245,9 +245,41 @@ describe("resolvePiLaunchToolPlan with permission system", () => {
 		const extensionArgs = args.filter(
 			(arg, index) => args[index - 1] === "--extension",
 		);
+		assert.equal(
+			extensionArgs.includes(path.join(extDir, "src", "index.ts")),
+			false,
+			"permission system extension should not be emitted without native rules",
+		);
+	});
+
+	it("injects the permission system when explicit native permission rules are set", () => {
+		const { agentDir } = createFixture();
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const extDir = path.join(agentDir, "extensions", "pi-permission-system");
+		fs.mkdirSync(path.join(extDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(extDir, "src", "index.ts"),
+			"export default () => {};",
+		);
+		fs.writeFileSync(
+			path.join(extDir, "package.json"),
+			JSON.stringify({ name: "test", pi: { extensions: ["./src/index.ts"] } }),
+		);
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "test task",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			permissionRules: { write: "ask" },
+		});
+		const extensionArgs = args.filter(
+			(arg, index) => args[index - 1] === "--extension",
+		);
 		assert.ok(
 			extensionArgs.includes(path.join(extDir, "src", "index.ts")),
-			"permission system extension should be emitted as an extension argument",
+			"permission system extension should be emitted when native rules are active",
 		);
 	});
 

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -164,6 +164,40 @@ describe("subagent prompt runtime", () => {
 		assert.equal(await askHandlers[0]!({ toolName: "write", input: { path: "out.txt" } }, { signal: undefined }), undefined);
 		assert.deepEqual(requests, [{ toolName: "write", args: { path: "out.txt" } }]);
 	});
+
+	it("fails closed when an ask permission decision stalls", async () => {
+		try {
+			process.env[PERMISSION_POLICY_ENV] = JSON.stringify({ write: "ask" });
+			process.env[CHILD_WATCHDOG_CONFIG_ENV] = JSON.stringify({
+				enabled: true,
+				watchdogTailTimeoutMs: 1_000,
+				agentEndTimeoutMs: 5,
+				maxWarnings: null,
+				lsp: { enabled: false, timeoutMs: 100, maxFiles: 1, maxDiagnostics: 1 },
+				autoFollowBlockers: false,
+				autoFollowMaxAttempts: null,
+				stalemateRepeats: 2,
+			});
+			const handlers: Array<(event: { toolName?: string; input?: unknown }, ctx: { signal?: AbortSignal }) => unknown> = [];
+			registerPermissionGate({ on(event: string, handler: (event: { toolName?: string; input?: unknown }, ctx: { signal?: AbortSignal }) => unknown) { if (event === "tool_call") handlers.push(handler); } } as never, async () => new Promise(() => undefined));
+
+			const result = await Promise.race([
+				handlers[0]!({ toolName: "write", input: { path: "out.txt" } }, { signal: undefined }),
+				new Promise((resolve) => setTimeout(() => resolve("hung"), 100)),
+			]);
+
+			assert.notEqual(result, "hung");
+			assert.deepEqual(result, {
+				block: true,
+				reason: "Blocked by pi-subagents permission rule: Watchdog permission arbiter failed closed: Watchdog permission decision timed out after 5ms.",
+			});
+		} finally {
+			if (envSnapshot.PI_SUBAGENT_PERMISSION_POLICY === undefined) delete process.env[PERMISSION_POLICY_ENV];
+			else process.env[PERMISSION_POLICY_ENV] = envSnapshot.PI_SUBAGENT_PERMISSION_POLICY;
+			if (envSnapshot.PI_SUBAGENT_WATCHDOG_CHILD_CONFIG === undefined) delete process.env[CHILD_WATCHDOG_CONFIG_ENV];
+			else process.env[CHILD_WATCHDOG_CONFIG_ENV] = envSnapshot.PI_SUBAGENT_WATCHDOG_CHILD_CONFIG;
+		}
+	});
 	it("collects runtime extension acknowledgements until terminal serialization", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-runtime-ack-"));
 		try {
@@ -634,6 +668,9 @@ describe("subagent prompt runtime", () => {
 		// Clear the ack capture env explicitly: when this test suite itself runs inside a
 		// pi-subagents child, the runner sets it and an extra agent_end handler registers.
 		delete process.env[RUNTIME_EXTENSION_ACK_PATH_ENV];
+		delete process.env[SUBAGENT_STEER_INBOX_ENV];
+		delete process.env[SUBAGENT_STEER_CAPABILITY_ENV];
+		delete process.env[SUBAGENT_STEER_ACK_DIR_ENV];
 		const handlersWithout = new Map<string, unknown[]>();
 		registerSubagentPromptRuntime({
 			on(event: string, handler: unknown) {

--- a/test/unit/watchdog-permission-arbiter.test.ts
+++ b/test/unit/watchdog-permission-arbiter.test.ts
@@ -76,4 +76,40 @@ describe("watchdog permission arbiter", () => {
 			fs.rmSync(dir, { recursive: true, force: true });
 		}
 	});
+
+	it("fails closed when watchdog model auth resolution stalls", async () => {
+		const stalledCtx = {
+			...ctx(),
+			modelRegistry: {
+				...ctx().modelRegistry,
+				getApiKeyAndHeaders: async () => new Promise(() => undefined),
+			},
+		} as never;
+
+		const result = await Promise.race([
+			createWatchdogPermissionArbiter()({
+				ctx: stalledCtx,
+				toolName: "write",
+				args: { path: "out.txt" },
+				rawWatchdogConfig: JSON.stringify({
+					enabled: true,
+					watchdogTailTimeoutMs: 1_000,
+					agentEndTimeoutMs: 5,
+					maxWarnings: null,
+					lsp: { enabled: false, timeoutMs: 100, maxFiles: 1, maxDiagnostics: 1 },
+					autoFollowBlockers: false,
+					autoFollowMaxAttempts: null,
+					stalemateRepeats: 2,
+				}),
+			}),
+			new Promise((resolve) => setTimeout(() => resolve("hung"), 100)),
+		]);
+
+		assert.notEqual(result, "hung");
+		assert.deepEqual(result, {
+			approved: false,
+			reason: "Watchdog permission decision timed out.",
+			source: "watchdog",
+		});
+	});
 });


### PR DESCRIPTION
Refs #1339.

This keeps the external permission-system bridge out of child launches unless native permission rules are configured. It also bounds ask-rule watchdog decisions so stalled permission paths fail closed instead of leaving child tool calls pending.

This PR removes the in-repo launch vector that can explain the reported hang when the external permission bridge is installed. The issue should stay open until the reporter confirms whether that bridge was present in their environment or verifies the repro on this branch.

Validation:
- node --test --experimental-strip-types --import ./test/support/register-loader.mjs --test-name-pattern 'matches preflight launch digest in equivalent foreground and async execution' test/integration/async-execution.test.ts
- node --test --experimental-strip-types --import ./test/support/register-loader.mjs test/unit/preflight.test.ts test/unit/pi-args-permission-system.test.ts test/unit/subagent-prompt-runtime.test.ts test/unit/watchdog-permission-arbiter.test.ts
- node --test --experimental-strip-types --import ./test/support/register-loader.mjs --test-name-pattern 'keeps public structured children alive when tool results backfill without execution_end|keeps async workflows failed when a detached child is mixed with a real failure' test/integration/single-execution.test.ts
- npm run typecheck
- git diff --check
