### PR TITLE
refactor: deslop unreleased cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Keep structured single-child execution receipts quiet by removing an internal conversion log from public workflow output.
 - Add per-agent model restrictions and a current-parent `inherit` allow-list alias. Thanks to [@hieudmg](https://github.com/hieudmg) for #1328.
 - Show package names, versions, and external-job provider status in subagent list and detail output so package agents such as Surf's `gpt-pro` are easier to find and use.
 - Document Council Mode routing in the main `pi-subagents` skill so natural-language requests for advisor councils, plan critique, cross-exam, or multiple model perspectives load the Council Mode protocol.

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -596,10 +596,9 @@ function packageSourceLabel(agent: AgentConfig): string {
 	return agent.packageSourceVersion ? `${agent.packageSourceName}@${agent.packageSourceVersion}` : agent.packageSourceName;
 }
 
-interface ExternalJobProviderStatus {
-	names?: Set<string>;
-	error?: string;
-}
+type ExternalJobProviderStatus =
+	| { ok: true; names: Set<string> }
+	| { ok: false; error: string };
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -607,9 +606,9 @@ function errorMessage(error: unknown): string {
 
 function registeredExternalJobProviderStatus(): ExternalJobProviderStatus {
 	try {
-		return { names: new Set(listExternalJobProviders().map((provider) => provider.name)) };
+		return { ok: true, names: new Set(listExternalJobProviders().map((provider) => provider.name)) };
 	} catch (error) {
-		return { error: errorMessage(error) };
+		return { ok: false, error: errorMessage(error) };
 	}
 }
 
@@ -680,10 +679,10 @@ function formatAgentDetail(agent: AgentConfig): string {
 	if (agent.skills?.length) lines.push(`Skills: ${agent.skills.join(", ")}`);
 	if (agent.skillPath?.length) lines.push(`Skill paths: ${agent.skillPath.join(", ")}`);
 	lines.push(`System prompt mode: ${agent.systemPromptMode}`);
-	const runnerDetail = formatRunnerDetail(agent, providerStatus.names);
+	const runnerDetail = formatRunnerDetail(agent, providerStatus.ok ? providerStatus.names : undefined);
 	if (runnerDetail) {
 		lines.push(runnerDetail);
-		if (agent.runner?.type === "external-job" && providerStatus.error) lines.push(`External-job provider registry unavailable: ${providerStatus.error}`);
+		if (agent.runner?.type === "external-job" && !providerStatus.ok) lines.push(`External-job provider registry unavailable: ${providerStatus.error}`);
 		if (agent.runner?.type === "external-job" && agent.runner.options) lines.push(`Runner options: ${JSON.stringify(agent.runner.options)}`);
 	}
 	lines.push(`Inherit project context: ${agent.inheritProjectContext ? "true" : "false"}`);
@@ -738,13 +737,13 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 	const providerStatus = registeredExternalJobProviderStatus();
 	const lines = [
 		"Executable agents:",
-		...formatAgentListSections(agents, providerStatus.names),
+		...formatAgentListSections(agents, providerStatus.ok ? providerStatus.names : undefined),
 		...(restrictedAgents.length ? [
 			"",
 			`Restricted agents (not executable in this session${restrictedSources?.length ? `; capability ceiling: ${restrictedSources.join(", ")}` : ""}):`,
-			...restrictedAgents.map((a) => formatAgentListLine(a, providerStatus.names)),
+			...restrictedAgents.map((a) => formatAgentListLine(a, providerStatus.ok ? providerStatus.names : undefined)),
 		] : []),
-		...(providerStatus.error && [...agents, ...restrictedAgents].some((agent) => agent.runner?.type === "external-job") ? ["", `External-job provider registry unavailable: ${providerStatus.error}`] : []),
+		...(!providerStatus.ok && [...agents, ...restrictedAgents].some((agent) => agent.runner?.type === "external-job") ? ["", `External-job provider registry unavailable: ${providerStatus.error}`] : []),
 		...(d.agentDiagnostics?.length ? [
 			"",
 			"Invalid agent definitions:",

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -415,15 +415,16 @@ function extractSubagentPathsFromPackageRoot(packageRoot: string): PackageSubage
 	const packageJsonPath = path.join(packageRoot, "package.json");
 	const pkg = readJsonFileBestEffort(packageJsonPath);
 	if (!pkg || typeof pkg !== "object" || Array.isArray(pkg)) return { agents: [], chains: [] };
-	const metadata = packageMetadata(pkg as Record<string, unknown>, packageRoot);
+	const pkgRecord = pkg as Record<string, unknown>;
+	const metadata = packageMetadata(pkgRecord, packageRoot);
 
 	const roots: Record<string, unknown>[] = [];
-	const piSubagents = (pkg as { "pi-subagents"?: unknown })["pi-subagents"];
+	const piSubagents = pkgRecord["pi-subagents"];
 	if (piSubagents && typeof piSubagents === "object" && !Array.isArray(piSubagents)) {
 		roots.push(piSubagents as Record<string, unknown>);
 	}
 
-	const pi = (pkg as { pi?: unknown }).pi;
+	const pi = pkgRecord.pi;
 	if (pi && typeof pi === "object" && !Array.isArray(pi)) {
 		const subagents = (pi as { subagents?: unknown }).subagents;
 		if (subagents && typeof subagents === "object" && !Array.isArray(subagents)) {

--- a/src/extension/public-execution.ts
+++ b/src/extension/public-execution.ts
@@ -122,7 +122,7 @@ export function normalizePublicSubagentExecution<T extends PublicSubagentExecuti
 			params: {
 				...workflowDefaults,
 				...(params.async === undefined && options.asyncByDefault === false ? { async: false } : {}),
-				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", ${JSON.stringify(child)})`,
+				workflowScript: `return runs.run("main", ${JSON.stringify(child)})`,
 			} as T,
 		};
 	}

--- a/src/extension/tool-result.ts
+++ b/src/extension/tool-result.ts
@@ -11,11 +11,7 @@ export function finalizeToolResult<T>(result: AgentToolResult<T>): AgentToolResu
 	if (result.isError !== true) return result;
 
 	const message = result.content
-		.filter(
-			(item): item is { type: "text"; text: string } =>
-				item.type === "text" && typeof item.text === "string",
-		)
-		.map((item) => item.text)
+		.flatMap((item) => item.type === "text" && typeof item.text === "string" ? [item.text] : [])
 		.join("\n")
 		.trim();
 

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -1,7 +1,7 @@
 import type { ModelInfo as AvailableModelInfo } from "../../shared/model-info.ts";
 import type { Usage } from "../../shared/types.ts";
 import { filterFallbackCandidates, parseModelKey, recordModelFailure } from "./model-exclusions.ts";
-import { checkModelScope, type ModelScopeRule, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
+import { checkModelScope, type ModelScopeCheckRule, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
 
 export type { AvailableModelInfo };
 
@@ -236,7 +236,7 @@ function resolveRequiredSubagentModelCandidate(
 
 export interface ResolveSubagentModelOverrideOptions {
 	/** When set with `enforce: true`, out-of-scope models are rejected. */
-	scope?: ModelScopeRule | ModelScopeRule[];
+	scope?: ModelScopeCheckRule | ModelScopeCheckRule[];
 	/** Origin of the requested model: explicit caller-supplied (hard error) vs inherited (warn). Defaults to `"inherited"`. */
 	source?: ModelSource;
 	/** Called for warn-severity violations instead of `console.warn`. */
@@ -247,23 +247,21 @@ function defaultScopeWarn(violation: ModelScopeViolation): void {
 	console.warn(`[pi-subagents] ${violation.message}`);
 }
 
-function configuredScopes(scope: ModelScopeRule | ModelScopeRule[] | undefined): ModelScopeRule[] {
+function configuredScopes(scope: ModelScopeCheckRule | ModelScopeCheckRule[] | undefined): ModelScopeCheckRule[] {
 	return scope ? (Array.isArray(scope) ? scope : [scope]) : [];
 }
 
-function throwForUnresolvedEnforcedInheritScope(scope: ModelScopeRule | ModelScopeRule[] | undefined, includeMixed = false): void {
+function throwForUnresolvedEnforcedInheritScope(scope: ModelScopeCheckRule | ModelScopeCheckRule[] | undefined, includeMixed = false): void {
 	const unresolvedInheritScope = configuredScopes(scope)
 		.find((entry) => entry.enforce === true && (includeMixed ? entry.allow?.includes(INHERIT_MODEL) : entry.allow?.length === 1 && entry.allow[0] === INHERIT_MODEL));
 	if (!unresolvedInheritScope) return;
-	const origin = "origin" in unresolvedInheritScope && typeof unresolvedInheritScope.origin === "string"
-		? unresolvedInheritScope.origin
-		: "modelScope";
+	const origin = unresolvedInheritScope.origin ?? "modelScope";
 	throw new Error(`Cannot enforce subagent model scope (${origin}): 'inherit' requires a current parent session model.`);
 }
 
 function enforceModelScopes(
 	model: string,
-	scope: ModelScopeRule | ModelScopeRule[] | undefined,
+	scope: ModelScopeCheckRule | ModelScopeCheckRule[] | undefined,
 	source: ModelSource,
 	onWarn: ((violation: ModelScopeViolation) => void) | undefined,
 ): void {
@@ -343,7 +341,7 @@ export function resolveEffectiveSubagentModel(
 
 export interface BuildModelCandidatesOptions {
 	/** Fallback models warn by default and throw when strict scope enforcement is enabled. */
-	scope?: ModelScopeRule | ModelScopeRule[];
+	scope?: ModelScopeCheckRule | ModelScopeCheckRule[];
 	onWarn?: (violation: ModelScopeViolation) => void;
 	/** The primary model came from the running parent session, not configuration. */
 	primaryModelFromParent?: boolean;

--- a/src/runs/shared/model-scope.ts
+++ b/src/runs/shared/model-scope.ts
@@ -28,7 +28,11 @@ export interface ModelScopeConfig extends ModelScopeRule {
 	agents?: Record<string, ModelScopeRule>;
 }
 
-export interface ResolvedModelScope extends ModelScopeRule {
+export interface ModelScopeCheckRule extends ModelScopeRule {
+	origin?: string;
+}
+
+export interface ResolvedModelScope extends ModelScopeCheckRule {
 	origin: string;
 }
 
@@ -71,7 +75,7 @@ export function matchesScopePattern(model: string, pattern: string): boolean {
  */
 export function checkModelScope(
 	model: string | undefined,
-	scope: ModelScopeRule | undefined,
+	scope: ModelScopeCheckRule | undefined,
 	source: ModelSource,
 ): ModelScopeViolation | undefined {
 	if (!model || !scope?.enforce) return undefined;
@@ -81,7 +85,7 @@ export function checkModelScope(
 
 	const baseModel = stripThinkingSuffix(model);
 	const severity: ModelScopeViolation["severity"] = source === "explicit" || scope.strict === true ? "error" : "warn";
-	const origin = "origin" in scope && typeof scope.origin === "string" ? scope.origin : "modelScope";
+	const origin = scope.origin ?? "modelScope";
 	return {
 		model: baseModel,
 		severity,
@@ -95,6 +99,45 @@ export function checkModelScope(
 
 function expandInheritPattern(pattern: string, parentModel: { provider: string; id: string } | undefined): string {
 	return pattern === "inherit" && parentModel ? `${parentModel.provider}/${parentModel.id}` : pattern;
+}
+
+function assertRecord(value: unknown, field: string, meta: { filePath: string }, expected = "an object"): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}'; expected ${expected}.`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function parseAllowList(value: unknown, field: string, meta: { filePath: string }): string[] {
+	if (!Array.isArray(value)) {
+		throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}'; expected an array of strings.`);
+	}
+	const allow: string[] = [];
+	for (const entry of value) {
+		if (typeof entry !== "string") {
+			throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}'; expected an array of strings.`);
+		}
+		const trimmed = entry.trim();
+		if (trimmed) allow.push(trimmed);
+	}
+	if (allow.length === 0) {
+		throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}'; expected a non-empty array of patterns.`);
+	}
+	return allow;
+}
+
+function parseScopeRule(input: Record<string, unknown>, field: string, meta: { filePath: string }): ModelScopeRule {
+	const rule: ModelScopeRule = {};
+	if ("enforce" in input) {
+		if (typeof input.enforce !== "boolean") throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.enforce'; expected a boolean.`);
+		rule.enforce = input.enforce;
+	}
+	if ("strict" in input) {
+		if (typeof input.strict !== "boolean") throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.strict'; expected a boolean.`);
+		rule.strict = input.strict;
+	}
+	if ("allow" in input) rule.allow = parseAllowList(input.allow, `${field}.allow`, meta);
+	return rule;
 }
 
 /** Resolve the global and matching agent policies into independent launch-time checks. */
@@ -135,79 +178,20 @@ export function parseModelScopeConfig(
 	meta: { filePath: string },
 ): ModelScopeConfig | undefined {
 	if (value === undefined) return undefined;
-	if (!value || typeof value !== "object" || Array.isArray(value)) {
-		throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope'; expected an object.`);
-	}
-
-	const input = value as Record<string, unknown>;
-	const config: ModelScopeConfig = {};
-
-	if ("enforce" in input) {
-		if (typeof input.enforce !== "boolean") {
-			throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.enforce'; expected a boolean.`);
-		}
-		config.enforce = input.enforce;
-	}
-
-	if ("strict" in input) {
-		if (typeof input.strict !== "boolean") {
-			throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.strict'; expected a boolean.`);
-		}
-		config.strict = input.strict;
-	}
-
-	if ("allow" in input) {
-		if (!Array.isArray(input.allow)) {
-			throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.allow'; expected an array of strings.`);
-		}
-		const allow: string[] = [];
-		for (const entry of input.allow) {
-			if (typeof entry !== "string") {
-				throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.allow'; expected an array of strings.`);
-			}
-			const trimmed = entry.trim();
-			if (trimmed) allow.push(trimmed);
-		}
-		if (allow.length === 0) {
-			throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.allow'; expected a non-empty array of patterns.`);
-		}
-		config.allow = allow;
-	}
+	const input = assertRecord(value, "modelScope", meta);
+	const config: ModelScopeConfig = parseScopeRule(input, "modelScope", meta);
 
 	if ("agents" in input) {
-		if (!input.agents || typeof input.agents !== "object" || Array.isArray(input.agents)) {
-			throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.agents'; expected an object keyed by agent name.`);
-		}
 		const agents: Record<string, ModelScopeRule> = {};
-		for (const [rawName, rawScope] of Object.entries(input.agents as Record<string, unknown>)) {
+		for (const [rawName, rawScope] of Object.entries(assertRecord(input.agents, "modelScope.agents", meta, "an object keyed by agent name"))) {
 			const name = rawName.trim();
 			const field = `modelScope.agents.${name}`;
 			if (!name) throw new Error(`Subagent settings in '${meta.filePath}' have invalid 'modelScope.agents' key; expected a non-empty agent name.`);
-			if (!rawScope || typeof rawScope !== "object" || Array.isArray(rawScope)) {
-				throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}'; expected an object.`);
-			}
-			const agentInput = rawScope as Record<string, unknown>;
+			const agentInput = assertRecord(rawScope, field, meta);
 			if ("agents" in agentInput) {
 				throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.agents'; nested agent scopes are not supported.`);
 			}
-			const rule: ModelScopeRule = {};
-			if ("enforce" in agentInput) {
-				if (typeof agentInput.enforce !== "boolean") throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.enforce'; expected a boolean.`);
-				rule.enforce = agentInput.enforce;
-			}
-			if ("strict" in agentInput) {
-				if (typeof agentInput.strict !== "boolean") throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.strict'; expected a boolean.`);
-				rule.strict = agentInput.strict;
-			}
-			if ("allow" in agentInput) {
-				if (!Array.isArray(agentInput.allow) || agentInput.allow.some((entry) => typeof entry !== "string")) {
-					throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.allow'; expected an array of strings.`);
-				}
-				const allow = agentInput.allow.map((entry) => (entry as string).trim()).filter(Boolean);
-				if (allow.length === 0) throw new Error(`Subagent settings in '${meta.filePath}' have invalid '${field}.allow'; expected a non-empty array of patterns.`);
-				rule.allow = allow;
-			}
-			agents[name] = rule;
+			agents[name] = parseScopeRule(agentInput, field, meta);
 		}
 		config.agents = agents;
 	}

--- a/src/watchdog/permission-arbiter.ts
+++ b/src/watchdog/permission-arbiter.ts
@@ -47,7 +47,8 @@ export function createWatchdogPermissionArbiter(options: WatchdogPermissionArbit
 		appendPermissionAudit(request.auditPath, auditBase);
 		let completed = false;
 		const finish = (approved: boolean, reason: string, decision: string): WatchdogPermissionResult => {
-			if (completed) return { approved, reason: conciseReason(reason), source: "watchdog" };
+			const concise = conciseReason(reason);
+			if (completed) return { approved, reason: concise, source: "watchdog" };
 			completed = true;
 			appendPermissionAudit(request.auditPath, {
 				type: "permission.decision",
@@ -57,9 +58,9 @@ export function createWatchdogPermissionArbiter(options: WatchdogPermissionArbit
 				decision,
 				approved,
 				decisionSource: "watchdog",
-				reason: conciseReason(reason),
+				reason: concise,
 			});
-			return { approved, reason: conciseReason(reason), source: "watchdog" };
+			return { approved, reason: concise, source: "watchdog" };
 		};
 
 		let childConfig;
@@ -123,16 +124,7 @@ export function createWatchdogPermissionArbiter(options: WatchdogPermissionArbit
 					beforeToolCall: async ({ toolCall }) => toolCall.name === tool.name ? undefined : { block: true, reason: `Permission arbiter tool '${toolCall.name}' is not allowed.` },
 					toolExecution: "sequential",
 				});
-				const abort = () => agent?.abort();
-				request.signal?.addEventListener("abort", abort, { once: true });
-				request.ctx.signal?.addEventListener("abort", abort, { once: true });
-				try {
-					const prompt = `Tool: ${request.toolName}\nRedacted arguments: ${preview}`;
-					await agent.prompt(prompt);
-				} finally {
-					request.signal?.removeEventListener("abort", abort);
-					request.ctx.signal?.removeEventListener("abort", abort);
-				}
+				await agent.prompt(`Tool: ${request.toolName}\nRedacted arguments: ${preview}`);
 				if (!decision) return finish(false, "Watchdog permission arbiter returned no decision.", "malformed");
 				const approved = decision.decision === "approve";
 				return finish(approved, decision.reason, decision.decision);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -420,7 +420,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.isError, undefined);
 		assert.equal(result.details.mode, "workflow");
 		assert.equal(mockPi.callCount(), 1);
-		assert.match(JSON.stringify(result.details), /Converted structured single-child request/);
+		assert.doesNotMatch(result.content[0]?.text ?? "", /Console:/);
 	});
 
 	it("keeps public structured children alive when tool results backfill without execution_end", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/unit/public-execution.test.ts
+++ b/test/unit/public-execution.test.ts
@@ -11,40 +11,40 @@ describe("public subagent execution normalization", () => {
 			params: {
 				context: "fresh",
 				async: false,
-				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", ${JSON.stringify({ agent: "worker", task, output: true })})`,
+				workflowScript: `return runs.run("main", ${JSON.stringify({ agent: "worker", task, output: true })})`,
 			},
 		});
 		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker" }), {
 			ok: true,
 			params: {
-				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":true})`,
+				workflowScript: `return runs.run("main", {"agent":"worker","output":true})`,
 			},
 		});
 		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker" }, { asyncByDefault: false }), {
 			ok: true,
 			params: {
 				async: false,
-				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":true})`,
+				workflowScript: `return runs.run("main", {"agent":"worker","output":true})`,
 			},
 		});
 		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker", async: true }, { asyncByDefault: false }), {
 			ok: true,
 			params: {
 				async: true,
-				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":true})`,
+				workflowScript: `return runs.run("main", {"agent":"worker","output":true})`,
 			},
 		});
 		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker", output: false }), {
 			ok: true,
 			params: {
-				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":false})`,
+				workflowScript: `return runs.run("main", {"agent":"worker","output":false})`,
 			},
 		});
 		assert.deepEqual(normalizePublicSubagentExecution({ agent: "worker", isolation: "none" }), {
 			ok: true,
 			params: {
 				worktree: false,
-				workflowScript: `console.info("Converted structured single-child request to workflow runs.run('main', ...)."); return runs.run("main", {"agent":"worker","output":true})`,
+				workflowScript: `return runs.run("main", {"agent":"worker","output":true})`,
 			},
 		});
 		assert.deepEqual(normalizePublicSubagentExecution({ action: " list " }), { ok: true, params: { action: "list" } });


### PR DESCRIPTION
## Summary

This cleans up unreleased changes since `v0.53.0` without changing the release intent.

- deduplicate `modelScope` config parsing while preserving validation errors
- make provider-status and model-scope origin states explicit in types
- remove the structured single-child conversion log from public workflow output
- simplify package-manifest probing, logical tool-result text extraction, and watchdog arbiter listener cleanup

## Validation

- node --test --experimental-strip-types --import ./test/support/register-loader.mjs test/unit/agent-management.test.ts test/unit/model-scope.test.ts test/unit/model-scope-settings.test.ts test/unit/model-fallback.test.ts test/unit/public-execution.test.ts test/unit/watchdog-permission-arbiter.test.ts test/unit/subagent-prompt-runtime.test.ts
- node --test --experimental-strip-types --import ./test/support/register-loader.mjs --test-name-pattern 'runs structured single-child requests through the workflow runtime|keeps public structured children alive when tool results backfill without execution_end' test/integration/single-execution.test.ts
- npm run typecheck
- git diff --check

Fresh review: `reports/unreleased-deslop-final-review.md` reported no issues found.
