### PR TITLE
feat: expose model exclusions as a public package export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Make scripted-workflow helper support and stale-session recovery visible in `doctor` and the workflow guide (#1344).
 - Keep structured single-child execution receipts quiet by removing an internal conversion log from public workflow output.
+- Expose the TTL-backed model exclusion store as a public `pi-subagents/model-exclusions` package export so extensions can record model failures and skip excluded models in their own fallback selection.
 - Add per-agent model restrictions and a current-parent `inherit` allow-list alias. Thanks to [@hieudmg](https://github.com/hieudmg) for #1328.
 - Show package names, versions, and external-job provider status in subagent list and detail output so package agents such as Surf's `gpt-pro` are easier to find and use.
 - Document Council Mode routing in the main `pi-subagents` skill so natural-language requests for advisor councils, plan critique, cross-exam, or multiple model perspectives load the Council Mode protocol.

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -238,6 +238,29 @@ Semantics:
 
 Schedules created while a ceiling is active are rejected until durable schedule persistence is available; unrestricted schedules remain subject to any policy active when they fire. Public status exposes bounded audit counts and sources, never full extension paths.
 
+## Model exclusions
+
+Extensions that run their own model-backed work can share the package's TTL-backed model exclusion store, so a model that just failed is skipped by both the extension and the package's own fallback selection:
+
+```ts
+import { recordModelFailure, isExcluded, filterFallbackCandidates } from "pi-subagents/model-exclusions";
+
+// After a failed model call:
+recordModelFailure({ modelId: "gpt-5", provider: "openai", reason: "429 rate limit" });
+
+// Before picking a model:
+if (!isExcluded("gpt-5", "openai")) { /* use it */ }
+
+// Or filter a candidate list of "provider/model" keys:
+const usable = filterFallbackCandidates(["openai/gpt-5", "anthropic/claude-sonnet-4-6"]);
+```
+
+Semantics:
+
+- Exclusions are keyed by `modelId`, `provider`, or both, and expire after a TTL (default 24 hours; override per call with `ttlMs` or globally with `setDefaultTTL`).
+- The store is process-wide and persisted to disk (`PI_MODEL_EXCLUSIONS_PATH` overrides the location), so exclusions recorded by an extension are visible to the package's model fallback selection in the same process.
+- `recordModelFailure` is additive and never throws on duplicates; `clearExclusions` removes all entries (intended for tests and admin tooling).
+
 ## Background-work provider API
 
 Other Pi extensions can make their current-session jobs visible to `subagent_wait` through the process-local provider contract:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./agents": "./src/api/agents.ts",
     "./delegation": "./src/api/delegation.ts",
     "./capability-ceiling": "./src/api/capability-ceiling.ts",
+    "./model-exclusions": "./src/api/model-exclusions.ts",
     "./preflight": "./src/api/preflight.ts",
     "./control-channel": "./src/api/control-channel.ts",
     "./intercom-bridge": "./src/api/intercom-bridge.ts",

--- a/src/api/model-exclusions.ts
+++ b/src/api/model-exclusions.ts
@@ -1,0 +1,16 @@
+export {
+	EXCLUSIONS_PATH_ENV,
+	clearExclusions,
+	clearExpiredExclusions,
+	filterFallbackCandidates,
+	flushPersist,
+	getExcludedCount,
+	getExclusionsFilePath,
+	isExcluded,
+	parseModelKey,
+	recordModelFailure,
+	reloadFromDisk,
+	setDefaultTTL,
+	type ModelExclusion,
+	type RecordModelFailureOptions,
+} from "../runs/shared/model-exclusions.ts";

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -12,7 +12,7 @@ export type ModelExclusion = ModelExclusionTarget & {
 	expiresAt: number;
 };
 
-type RecordModelFailureOptions = ModelExclusionTarget & {
+export type RecordModelFailureOptions = ModelExclusionTarget & {
 	reason?: string;
 	ttlMs?: number;
 };

--- a/test/unit/model-exclusions-public-api.test.ts
+++ b/test/unit/model-exclusions-public-api.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+	EXCLUSIONS_PATH_ENV,
+	clearExclusions,
+	clearExpiredExclusions,
+	filterFallbackCandidates,
+	flushPersist,
+	getExcludedCount,
+	getExclusionsFilePath,
+	isExcluded,
+	parseModelKey,
+	recordModelFailure,
+	reloadFromDisk,
+	setDefaultTTL,
+	type ModelExclusion,
+	type RecordModelFailureOptions,
+} from "pi-subagents/model-exclusions";
+import * as internal from "../../src/runs/shared/model-exclusions.ts";
+
+// The exclusion store is a process-wide singleton; clear it before/after each
+// test so cases don't leak state into each other (same pattern as
+// test/unit/model-exclusions.test.ts).
+beforeEach(() => {
+	fs.rmSync(getExclusionsFilePath(), { force: true });
+	clearExclusions();
+});
+afterEach(() => clearExclusions());
+
+describe("public model-exclusions package export", () => {
+	it("exposes the exclusion store surface", () => {
+		assert.equal(EXCLUSIONS_PATH_ENV, "PI_MODEL_EXCLUSIONS_PATH");
+		assert.equal(typeof clearExclusions, "function");
+		assert.equal(typeof clearExpiredExclusions, "function");
+		assert.equal(typeof filterFallbackCandidates, "function");
+		assert.equal(typeof flushPersist, "function");
+		assert.equal(typeof getExcludedCount, "function");
+		assert.equal(typeof getExclusionsFilePath, "function");
+		assert.equal(typeof isExcluded, "function");
+		assert.equal(typeof parseModelKey, "function");
+		assert.equal(typeof recordModelFailure, "function");
+		assert.equal(typeof reloadFromDisk, "function");
+		assert.equal(typeof setDefaultTTL, "function");
+	});
+
+	it("shares the same store instance as the internal module", () => {
+		const options: RecordModelFailureOptions = { modelId: "gpt-5", provider: "openai", reason: "429" };
+		recordModelFailure(options);
+		assert.equal(internal.isExcluded("gpt-5", "openai"), true);
+		assert.equal(internal.getExcludedCount(), 1);
+		internal.clearExclusions();
+		assert.equal(getExcludedCount(), 0);
+	});
+
+	it("records and filters excluded candidates through the public surface", () => {
+		recordModelFailure({ modelId: "gpt-5", provider: "openai", reason: "rate limit" });
+		assert.equal(isExcluded("gpt-5", "openai"), true);
+		assert.deepEqual(filterFallbackCandidates(["openai/gpt-5", "anthropic/claude-sonnet-4-6"]), [
+			"anthropic/claude-sonnet-4-6",
+		]);
+	});
+
+	it("persists exclusions to the public file path", () => {
+		recordModelFailure({ provider: "anthropic", reason: "timeout" });
+		flushPersist();
+		const raw = fs.readFileSync(getExclusionsFilePath(), "utf-8");
+		const parsed = JSON.parse(raw) as { exclusions: ModelExclusion[] };
+		assert.equal(parsed.exclusions.length, 1);
+		assert.equal(parsed.exclusions[0]?.provider, "anthropic");
+	});
+
+	it("parses provider/model keys", () => {
+		assert.deepEqual(parseModelKey("openrouter/google/gemini-flash"), {
+			provider: "openrouter",
+			modelId: "google/gemini-flash",
+		});
+		assert.deepEqual(parseModelKey("gpt-5"), { modelId: "gpt-5" });
+	});
+});

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -108,6 +108,7 @@ test("published extension APIs use supported package entrypoints", async () => {
 		"./external-job-provider": "./src/api/external-job-provider.ts",
 		"./external-runs": "./src/api/external-runs.ts",
 		"./capability-ceiling": "./src/api/capability-ceiling.ts",
+		"./model-exclusions": "./src/api/model-exclusions.ts",
 		"./delegation": "./src/api/delegation.ts",
 		"./preflight": "./src/api/preflight.ts",
 		"./control-channel": "./src/api/control-channel.ts",


### PR DESCRIPTION
The TTL-backed model exclusion store (#1318) is exercised inside the dispatch pipeline, but extensions that run their own model-backed work have no way to reach it: nothing in the package `exports` map surfaces the store, so external dispatchers must fork a parallel exclusion system that drifts from the package's own fallback selection.

This adds a `pi-subagents/model-exclusions` subpath (mirroring the `pi-subagents/capability-ceiling` pattern from #1317) that re-exports the existing, already-tested store. A failure recorded by an extension lands in the same `<TEMP_ROOT_DIR>/model-exclusions.json` store the dispatcher filters against, so a 429 observed by an extension also protects the built-in fallback pool.

Purely additive: new `src/api/model-exclusions.ts` re-export file, one exports-map entry, a docs section, a CHANGELOG entry, a public-API unit test, and the `RecordModelFailureOptions` type gaining an `export`. No runtime behavior changes.

## Changes

- `src/api/model-exclusions.ts` (new): re-exports `recordModelFailure`, `isExcluded`, `filterFallbackCandidates`, `parseModelKey`, `getExcludedCount`, `clearExclusions`, `clearExpiredExclusions`, `setDefaultTTL`, `flushPersist`, `reloadFromDisk`, `EXCLUSIONS_PATH_ENV`, and the `ModelExclusion` / `RecordModelFailureOptions` types.
- `src/runs/shared/model-exclusions.ts`: `RecordModelFailureOptions` type gains an `export` so public callers can type their options object.
- `package.json`: `"./model-exclusions"` exports entry.
- `docs/extension-api.md`: "Model exclusions" section with usage example and semantics.
- `CHANGELOG.md`: entry under `[Unreleased] → Changed`.
- `test/unit/model-exclusions-public-api.test.ts` (new): 5 tests covering the public surface, shared store instance with the internal module, record/filter behavior, persistence, and provider/model key parsing.
- `test/unit/package-manifest.test.ts`: expected exports map updated with the new entry.

## Verification

- `npm run typecheck` clean.
- 33/33 tests pass across the new public-API suite, the existing `model-exclusions.test.ts` (19 tests), and `package-manifest.test.ts`.
