### PR TITLE
fix: fail when child write tools are unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Fixed
 - Report helpful workflow errors when `runs.all(...)` results are read as keyed
   objects instead of ordered arrays. Thanks to [@ravshansbox](https://github.com/ravshansbox) for #1351.
+- Fail child launch attempts when the runtime lacks requested core write tools,
+  instead of letting implementation workers continue as read-only runs.
 
 ## [0.54.0] - 2026-08-21
 

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -11,6 +11,7 @@ import { RUNTIME_EXTENSION_ACK_EVENT, RUNTIME_EXTENSION_ACK_PATH_ENV, isRuntimeA
 import { createStructuredOutputToolParameters, STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV, validateStructuredOutputValue } from "./structured-output.ts";
 import {
 	CHILD_TOOL_DIAGNOSTIC_PATH_ENV,
+	formatChildToolDiagnostic,
 	MCP_DIRECT_CHILD_TOOLS_ENV,
 	REQUIRED_CHILD_TOOLS_ENV,
 	writeChildToolDiagnostic,
@@ -625,7 +626,8 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		registerNativeSupervisorClientOnce();
 	});
 	onRuntimeEvent("agent_start", () => {
-		refreshChildToolDiagnostic(pi);
+		const diagnostic = refreshChildToolDiagnostic(pi);
+		if (diagnostic) throw new Error(formatChildToolDiagnostic(diagnostic));
 	});
 	onRuntimeEvent("agent_end", async (_event: unknown, ctx: unknown) => {
 		if ((ctx as { hasUI?: boolean } | undefined)?.hasUI === true) return;

--- a/src/runs/shared/tool-availability.ts
+++ b/src/runs/shared/tool-availability.ts
@@ -13,8 +13,6 @@ export interface ChildToolDiagnostic {
 	missingMcpDirectTools?: string[];
 }
 
-const PI_CORE_CHILD_TOOLS = new Set(["bash", "edit", "find", "grep", "ls", "read", "write"]);
-
 export function writeChildToolDiagnostic(
 	filePath: string,
 	required: string[],
@@ -22,7 +20,7 @@ export function writeChildToolDiagnostic(
 	agent?: string,
 	mcpDirectTools?: string[],
 ): ChildToolDiagnostic | undefined {
-	const availableNames = new Set([...available, ...PI_CORE_CHILD_TOOLS]);
+	const availableNames = new Set(available);
 	const missing = required.filter((name) => !availableNames.has(name));
 	if (missing.length === 0) {
 		fs.rmSync(filePath, { force: true });

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -1018,12 +1018,41 @@ describe("subagent prompt runtime", () => {
 
 			handlers.get("session_start")?.({});
 			assert.deepEqual(registered, ["subagent_wait", "contact_supervisor"]);
-			handlers.get("agent_start")?.({});
+			assert.throws(() => handlers.get("agent_start")?.({}), /requested unavailable child tools: read, grep, find, ls, bash, edit, write, intercom/);
 			assert.deepEqual(readChildToolDiagnostic(diagnosticPath), {
 				agent: "scout",
 				required: ["read", "grep", "find", "ls", "bash", "edit", "write", "intercom"],
 				available: ["subagent_wait", "contact_supervisor"],
-				missing: ["intercom"],
+				missing: ["read", "grep", "find", "ls", "bash", "edit", "write", "intercom"],
+			});
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("records missing core write tools from the actual child registry", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-core-tool-diagnostic-"));
+		try {
+			const diagnosticPath = path.join(dir, "tools.json");
+			const handlers = new Map<string, (payload?: unknown) => unknown>();
+			process.env[REQUIRED_CHILD_TOOLS_ENV] = JSON.stringify(["read", "grep", "find", "ls", "bash", "edit", "write"]);
+			process.env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV] = diagnosticPath;
+			process.env[SUBAGENT_CHILD_AGENT_ENV] = "worker";
+
+			registerSubagentPromptRuntime({
+				on(event: string, handler: (payload?: unknown) => unknown) {
+					handlers.set(event, handler);
+				},
+				getAllTools: () => ["read", "grep", "find", "ls", "contact_supervisor"].map((name) => ({ name })),
+				registerTool() {},
+			} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(): void });
+
+			assert.throws(() => handlers.get("agent_start")?.({}), /requested unavailable child tools: bash, edit, write/);
+			assert.deepEqual(readChildToolDiagnostic(diagnosticPath), {
+				agent: "worker",
+				required: ["read", "grep", "find", "ls", "bash", "edit", "write"],
+				available: ["read", "grep", "find", "ls", "contact_supervisor"],
+				missing: ["bash", "edit", "write"],
 			});
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });
@@ -1102,7 +1131,7 @@ describe("subagent prompt runtime", () => {
 			assert.equal(fs.existsSync(diagnosticPath), false);
 			assert.doesNotMatch(promptRewrite?.systemPrompt ?? "", /requested unavailable child tools/);
 
-			handlers.get("agent_start")?.({});
+			assert.throws(() => handlers.get("agent_start")?.({}), /requested unavailable child tools: fixture_search/);
 			assert.deepEqual(readChildToolDiagnostic(diagnosticPath), {
 				agent: "extension-worker",
 				required: ["read", "fixture_search"],
@@ -1136,7 +1165,7 @@ describe("subagent prompt runtime", () => {
 				registerTool() {},
 			} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(): void });
 
-			assert.doesNotThrow(() => handlers.get("agent_start")?.({}));
+			assert.throws(() => handlers.get("agent_start")?.({}), /requested unavailable child tools: fixture_search/);
 			assert.deepEqual(readChildToolDiagnostic(diagnosticPath), {
 				agent: "worker",
 				required: ["read", "fixture_search"],
@@ -1166,7 +1195,7 @@ describe("subagent prompt runtime", () => {
 				registerTool() {},
 			} as { on(event: string, handler: (payload?: unknown) => unknown): void; getAllTools(): Array<{ name: string }>; registerTool(): void });
 
-			handlers.get("agent_start")?.({});
+			assert.throws(() => handlers.get("agent_start")?.({}), /requested unavailable child tools: rust_symbols_workspace_symbols, fixture_search/);
 			const diagnostic = readChildToolDiagnostic(diagnosticPath);
 			assert.deepEqual(diagnostic, {
 				agent: "worker",


### PR DESCRIPTION
Closes #1354.

This makes the child tool diagnostic trust the actual child runtime registry instead of assuming core tools are available. `agent_start` now refreshes that diagnostic and fails before the agent begins when required write tools are missing, so implementation lanes do not proceed into a read-only runtime and return a misleading no-edit handoff.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/subagent-prompt-runtime.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh exact-head review on `a4e2880e8ce46fea7c3776f791faf4032419af60`: no issues found, merge verdict OK

Note: the parent applied this candidate directly because the delegated writer failure is the issue being fixed.
