### PR TITLE
feat: emit child stop status events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [Unreleased]
 
 ### Added
-- Add child-scoped stop support for async/workflow runs so one child can
-  be cancelled without stopping its siblings. Thanks to
-  [@yanqianglu](https://github.com/yanqianglu) for #1367.
+- Add child-scoped stop support and child stop observer events for
+  async/workflow runs. Thanks to [@yanqianglu](https://github.com/yanqianglu)
+  for #1367.
 - Create one passive Orca observer tab per top-level subagent call, with
   shared chain/parallel progress and project-local observer manifests. Thanks to
   [@hyein-cbio](https://github.com/hyein-cbio) for #1360.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -164,6 +164,17 @@ Nested fanout status is stored as compact sidecar event/registry metadata and me
 
 Consumers should read these JSON files instead of scraping terminal output. Unknown fields and event types should be ignored for forward compatibility.
 
+RPC hosts that need low-latency child-stop UI hints can subscribe to the
+`subagent:child-status` event advertised by RPC `ping` as `events.childStatus`.
+The payload uses `type: "subagent.child-status"`, `version: 1`, `runId`,
+`childId`, `status` (`"stopping"` or `"stopped"`), `ts`, and optional child
+metadata such as `stepIndex`, `agent`, `childRunId`, `workflowKey`, `phase`, and
+`label`. These events are observer hints only. They can duplicate across RPC and
+async replay paths, and they are not replayed after a host restart. Status
+snapshots remain authoritative for recovery and final state. Child stop control
+still uses the normal `stop` request with `childId`; there is no separate child
+stop API.
+
 ### Status and result fields
 
 The status/result fields are: `lifecycleArtifactVersion`, `runId`/`id`, `sessionId`, `mode`, `state`, `startedAt`, `lastUpdate`, `endedAt`, `durationMs`, `cwd`, `asyncDir`, `sessionFile`, `outputFile`, `workflowGraph`, `steps`, `results`, `totalTokens`, `totalCost`, `model`/`attemptedModels`/`modelAttempts`, `toolCount`, `turnCount`, optional `launchResolvedExtensions`, optional `runtimeAcknowledgedExtensions`, and nested `children` when a child is allowed to launch subagents.

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -137,7 +137,14 @@ Stop a current-session top-level async run with `stop` (or `/subagents-stop`). S
 
 ```typescript
 subagent({ action: "stop", id: "run-id" })
+subagent({ action: "stop", id: "run-id", childId: "child-id" })
 ```
+
+Use `childId` only for active async/workflow runs whose status snapshot shows a
+matching child. Observer hosts can listen for the advertised
+`subagent:child-status` event to update child-stop UI quickly, but status
+snapshots remain the source of truth after reconnects or duplicate event
+delivery.
 
 Use `steer` for top-level live async guidance and `resume` after a delegated run pauses or finishes. Routed nested runs retain their existing non-destructive live follow-up path:
 

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -13,8 +13,10 @@ import {
 	type SubagentState,
 	DIRS,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
+	SUBAGENT_CHILD_STATUS_EVENT,
 	SUBAGENT_PROCESS_TERMINAL_EVENT,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
+	type SubagentChildStatusEvent,
 } from "../shared/types.ts";
 import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
 import { readStatus } from "../shared/utils.ts";
@@ -406,6 +408,7 @@ function pingData(ctx: ExtensionContext | null) {
 			request: SUBAGENT_RPC_REQUEST_EVENT,
 			replyPrefix: SUBAGENT_RPC_REPLY_EVENT_PREFIX,
 			asyncComplete: SUBAGENT_ASYNC_COMPLETE_EVENT,
+			childStatus: SUBAGENT_CHILD_STATUS_EVENT,
 			processTerminal: SUBAGENT_PROCESS_TERMINAL_EVENT,
 		},
 		session: sessionData(ctx),
@@ -531,6 +534,25 @@ function stopAsyncRun(
 	}
 
 	let child: ResolvedAsyncStatusChild | undefined;
+	const emitChildStopping = (runId: string, asyncDir: string, stoppedChild: ResolvedAsyncStatusChild, ts = options.now?.() ?? Date.now()): void => {
+		options.events.emit(SUBAGENT_CHILD_STATUS_EVENT, {
+			type: "subagent.child-status",
+			version: 1,
+			runId,
+			childId: stoppedChild.id,
+			status: "stopping",
+			ts,
+			reason: "user",
+			source: "rpc",
+			asyncDir,
+			stepIndex: stoppedChild.index,
+			agent: stoppedChild.step.agent,
+			...(stoppedChild.step.runId ? { childRunId: stoppedChild.step.runId } : {}),
+			...(stoppedChild.step.workflowKey ? { workflowKey: stoppedChild.step.workflowKey } : {}),
+			...(stoppedChild.step.phase ? { phase: stoppedChild.step.phase } : {}),
+			...(stoppedChild.step.label ? { label: stoppedChild.step.label } : {}),
+		} satisfies SubagentChildStatusEvent);
+	};
 	if (childId !== undefined) {
 		const resolution = resolveAsyncStatusChild(initialStatus, childId);
 		if (!resolution.ok) throw new SubagentRpcError(resolution.code === "not_found" ? "not_found" : "invalid_params", resolution.message);
@@ -544,6 +566,7 @@ function stopAsyncRun(
 			const stopChild = options.state?.workflowChildStops?.get(initialRunId);
 			if (!stopChild) throw new SubagentRpcError("invalid_state", `Workflow ${initialRunId} is not controlled by this extension runtime; child stop is unavailable.`);
 			if (!stopChild(child.id, `Workflow child '${child.id}' stopped by RPC.`)) throw new SubagentRpcError("invalid_state", `Child '${childId}' in workflow ${initialRunId} is not available to stop.`);
+			emitChildStopping(initialRunId, location.asyncDir, child);
 			return {
 				runId: initialRunId,
 				asyncDir: location.asyncDir,
@@ -602,6 +625,7 @@ function stopAsyncRun(
 	} catch (error) {
 		throw new SubagentRpcError("execution_failed", error instanceof Error ? error.message : String(error));
 	}
+	if (child) emitChildStopping(runId, location.asyncDir, child);
 
 	return {
 		runId,

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -8,9 +8,11 @@ import {
 	type AsyncStartedEvent,
 	type ControlEvent,
 	type SteeringNotice,
+	type SubagentChildStatusEvent,
 	type SubagentState,
 	POLL_INTERVAL_MS,
 	DIRS,
+	SUBAGENT_CHILD_STATUS_EVENT,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_STEERING_NOTICE_EVENT,
@@ -227,6 +229,28 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 					return;
 				}
 				if (!parsed || typeof parsed !== "object") return;
+				if ((parsed as { type?: unknown }).type === "subagent.child-status") {
+					const event = parsed as Partial<SubagentChildStatusEvent>;
+					if (event.version !== 1 || typeof event.runId !== "string" || typeof event.childId !== "string" || (event.status !== "stopping" && event.status !== "stopped") || typeof event.ts !== "number") return;
+					pi.events.emit(SUBAGENT_CHILD_STATUS_EVENT, {
+						type: "subagent.child-status",
+						version: 1,
+						runId: event.runId,
+						childId: event.childId,
+						status: event.status,
+						ts: event.ts,
+						...(typeof event.reason === "string" ? { reason: event.reason } : {}),
+						source: event.source === "rpc" ? "rpc" : "async",
+						asyncDir: job.asyncDir,
+						...(typeof event.stepIndex === "number" ? { stepIndex: event.stepIndex } : {}),
+						...(typeof event.agent === "string" ? { agent: event.agent } : {}),
+						...(typeof event.childRunId === "string" ? { childRunId: event.childRunId } : {}),
+						...(typeof event.workflowKey === "string" ? { workflowKey: event.workflowKey } : {}),
+						...(typeof event.phase === "string" ? { phase: event.phase } : {}),
+						...(typeof event.label === "string" ? { label: event.label } : {}),
+					} satisfies SubagentChildStatusEvent);
+					return;
+				}
 				if ((parsed as { type?: unknown }).type === "subagent.steering.notice") {
 					const notice = parsed as Partial<SteeringNotice>;
 					if (typeof notice.requestId !== "string" || typeof notice.runId !== "string" || (notice.state !== "failed" && notice.state !== "partial" && notice.state !== "recovered") || typeof notice.message !== "string") return;

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -48,6 +48,7 @@ import {
 	type SteeringStatus,
 	type SteeringTargetState,
 	type SteeringTargetStatus,
+	type SubagentChildStatusEvent,
 	DEFAULT_MAX_OUTPUT,
 	type MaxOutputConfig,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
@@ -2612,6 +2613,29 @@ async function runSubagent(
 		writeStatusPayload();
 	};
 	const childStopTargetId = (index: number): string => asyncStatusChildIdentity(requiredStatusStep(statusPayload, index), index);
+	const appendChildStatusEvent = (index: number, childId: string, status: "stopping" | "stopped", now = Date.now()): void => {
+		const step = requiredStatusStep(statusPayload, index);
+		appendJsonl(eventsPath, JSON.stringify({
+			type: "subagent.child-status",
+			version: 1,
+			ts: now,
+			runId: id,
+			childId,
+			status,
+			reason: "user",
+			source: "async",
+			stepIndex: index,
+			agent: step.agent,
+			...(step.runId ? { childRunId: step.runId } : {}),
+			...(step.workflowKey ? { workflowKey: step.workflowKey } : {}),
+			...(step.phase ? { phase: step.phase } : {}),
+			...(step.label ? { label: step.label } : {}),
+		} satisfies SubagentChildStatusEvent));
+	};
+	const appendTerminalChildStatusEvent = (index: number, now = Date.now()): void => {
+		const request = childStopRequests.get(index);
+		if (request) appendChildStatusEvent(index, request.childId, "stopped", now);
+	};
 	const markChildStopRequested = (index: number, childId: string, now = Date.now()): boolean => {
 		const step = statusPayload.steps[index];
 		if (!step || (step.status !== "pending" && step.status !== "running")) return false;
@@ -2622,6 +2646,7 @@ async function runSubagent(
 		statusPayload.lastUpdate = now;
 		writeStatusPayload();
 		appendJsonl(eventsPath, JSON.stringify({ type: "subagent.step.stop_requested", ts: now, runId: id, stepIndex: index, childId, agent: step.agent }));
+		appendChildStatusEvent(index, childId, "stopping", now);
 		return true;
 	};
 	const markChildStopped = (index: number, now = Date.now()): void => {
@@ -2639,7 +2664,9 @@ async function runSubagent(
 		step.lastActivityAt = now;
 		statusPayload.lastUpdate = now;
 		writeStatusPayload();
-		appendJsonl(eventsPath, JSON.stringify({ type: "subagent.step.stopped", ts: now, runId: id, stepIndex: index, childId: childStopRequests.get(index)?.childId ?? childStopTargetId(index), agent: step.agent, exitCode: 1, durationMs: step.durationMs }));
+		const childId = childStopRequests.get(index)?.childId ?? childStopTargetId(index);
+		appendJsonl(eventsPath, JSON.stringify({ type: "subagent.step.stopped", ts: now, runId: id, stepIndex: index, childId, agent: step.agent, exitCode: 1, durationMs: step.durationMs }));
+		appendChildStatusEvent(index, childId, "stopped", now);
 	};
 	const childStopResult = (index: number, agent: string, context?: "fresh" | "fork"): SingleStepResult => {
 		markChildStopped(index);
@@ -4010,12 +4037,13 @@ async function runSubagent(
 				statusPayload.lastUpdate = taskEndTime;
 				writeStatusPayload();
 				appendCapabilityCeilingAppliedEvent(eventsPath, id, fi, task.agent, singleResult);
-				appendJsonl(eventsPath, JSON.stringify({
-					type: stopped || childStopped ? "subagent.step.stopped" : timedOut ? "subagent.step.failed" : childInterrupted ? "subagent.step.paused" : singleResult.exitCode === 0 ? "subagent.step.completed" : "subagent.step.failed",
-					ts: taskEndTime, runId: id, stepIndex: fi, agent: task.agent,
-					exitCode: stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode, durationMs: taskEndTime - taskStartTime,
-				}));
-				if (singleResult.exitCode !== 0 && failFast && !childStopped) aborted = true;
+		appendJsonl(eventsPath, JSON.stringify({
+			type: stopped || childStopped ? "subagent.step.stopped" : timedOut ? "subagent.step.failed" : childInterrupted ? "subagent.step.paused" : singleResult.exitCode === 0 ? "subagent.step.completed" : "subagent.step.failed",
+			ts: taskEndTime, runId: id, stepIndex: fi, agent: task.agent,
+			exitCode: stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode, durationMs: taskEndTime - taskStartTime,
+		}));
+		if (stopped || childStopped) appendTerminalChildStatusEvent(fi, taskEndTime);
+		if (singleResult.exitCode !== 0 && failFast && !childStopped) aborted = true;
 				return stopped || childStopped ? { ...singleResult, output: stopMessage, error: stopMessage, exitCode: 1, interrupted: false, timedOut: false, stopped: true, skipped: false } : timedOut ? { ...singleResult, output: timeoutMessage ?? "Subagent timed out.", error: timeoutMessage ?? "Subagent timed out.", exitCode: 1, interrupted: false, timedOut: true, skipped: false } : { ...singleResult, skipped: false };
 			}, globalSemaphore);
 
@@ -4413,6 +4441,7 @@ async function runSubagent(
 							ts: taskEndTime, runId: id, stepIndex: fi, agent: task.agent,
 							exitCode: stopped || childStopped ? 1 : timedOut ? 1 : childInterrupted ? 0 : singleResult.exitCode, durationMs: taskDuration,
 						}));
+						if (stopped || childStopped) appendTerminalChildStatusEvent(fi, taskEndTime);
 						if (singleResult.completionGuardTriggered) {
 							const event = buildControlEvent(omitUndefinedProperties({
 								from: requiredStatusStep(statusPayload, fi).activityState,
@@ -4836,6 +4865,7 @@ async function runSubagent(
 				durationMs: stepEndTime - stepStartTime,
 				tokens: stepTokens,
 			}));
+			if (stopped || childStopped) appendTerminalChildStatusEvent(flatIndex, stepEndTime);
 			if (singleWorktreeSetup && !singleResult.detached) {
 				const diffs = diffWorktrees(singleWorktreeSetup, [seqStep.agent], path.join(asyncDir, "worktree-diffs", `step-${stepIndex}`));
 				const diffSummary = formatWorktreeDiffSummary(diffs);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -155,6 +155,7 @@ import {
 	type ResolvedToolBudget,
 	type RunFanoutBudgetDescriptor,
 	type SingleResult,
+	type SubagentChildStatusEvent,
 	type ToolBudgetConfig,
 	type TurnBudgetConfig,
 	type UsageBudgetConfig,
@@ -4432,6 +4433,23 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								status.steps?.push(step);
 								workflowSteps.set(entry.key, step);
 							}
+							const projectedStep = workflowSteps.get(entry.key);
+							if (entry.state === "stopped" && projectedStep) {
+								appendWorkflowEvent({
+									type: "subagent.child-status",
+									version: 1,
+									childId: entry.key,
+									status: "stopped",
+									reason: "user",
+									source: "async",
+									stepIndex: status.steps?.indexOf(projectedStep),
+									agent: projectedStep.agent,
+									...(projectedStep.runId ? { childRunId: projectedStep.runId } : {}),
+									workflowKey: entry.key,
+									...(projectedStep.phase ? { phase: projectedStep.phase } : {}),
+									...(projectedStep.label ? { label: projectedStep.label } : {}),
+								});
+							}
 						}
 						projectedTraceLength = trace.length;
 						projectedTraceTail = trace.at(-1);
@@ -5211,16 +5229,38 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				const workflowController = targetRunId ? deps.state.workflowControllers?.get(targetRunId) : undefined;
 				if (workflowController) {
 					if (paramsWithResolvedCwd.childId !== undefined) {
-						const asyncJob = deps.state.asyncJobs.get(targetRunId!);
-						const status = asyncJob?.asyncDir ? readStatus(asyncJob.asyncDir) : undefined;
-						if (!status) return { content: [{ type: "text", text: `Status file not found for async workflow '${targetRunId}'.` }], isError: true, details: { mode: "management", results: [] } };
+						const workflowRunId = targetRunId!;
+						const asyncJob = deps.state.asyncJobs.get(workflowRunId);
+						if (!asyncJob?.asyncDir) return { content: [{ type: "text", text: `Status file not found for async workflow '${workflowRunId}'.` }], isError: true, details: { mode: "management", results: [] } };
+						const status = readStatus(asyncJob.asyncDir);
+						if (!status) return { content: [{ type: "text", text: `Status file not found for async workflow '${workflowRunId}'.` }], isError: true, details: { mode: "management", results: [] } };
 						const resolution = resolveAsyncStatusChild(status, paramsWithResolvedCwd.childId);
 						if (!resolution.ok) return { content: [{ type: "text", text: resolution.message }], isError: true, details: { mode: "management", results: [] } };
 						if (!isStoppableAsyncStatusStep(resolution.child.step)) return { content: [{ type: "text", text: `Child '${paramsWithResolvedCwd.childId}' in async run '${targetRunId}' is ${resolution.child.step.status}; stop only supports pending or running children.` }], isError: true, details: { mode: "management", results: [] } };
 						const stopChild = deps.state.workflowChildStops?.get(targetRunId!);
 						if (!stopChild) return { content: [{ type: "text", text: `Workflow ${targetRunId} child stop is unavailable in this extension runtime.` }], isError: true, details: { mode: "management", results: [] } };
-						if (!stopChild(resolution.child.id)) return { content: [{ type: "text", text: `Child '${paramsWithResolvedCwd.childId}' in workflow ${targetRunId} is not available to stop.` }], isError: true, details: { mode: "management", results: [] } };
-						return { content: [{ type: "text", text: `Stop requested for child ${resolution.child.id} in async workflow ${targetRunId}.` }], details: { mode: "management", results: [] } };
+						if (!stopChild(resolution.child.id)) return { content: [{ type: "text", text: `Child '${paramsWithResolvedCwd.childId}' in workflow ${workflowRunId} is not available to stop.` }], isError: true, details: { mode: "management", results: [] } };
+						try {
+							fs.appendFileSync(path.join(asyncJob.asyncDir, "events.jsonl"), `${JSON.stringify({
+								type: "subagent.child-status",
+								version: 1,
+								runId: workflowRunId,
+								childId: resolution.child.id,
+								status: "stopping",
+								ts: Date.now(),
+								reason: "user",
+								source: "async",
+								stepIndex: resolution.child.index,
+								agent: resolution.child.step.agent,
+								...(resolution.child.step.runId ? { childRunId: resolution.child.step.runId } : {}),
+								...(resolution.child.step.workflowKey ? { workflowKey: resolution.child.step.workflowKey } : {}),
+								...(resolution.child.step.phase ? { phase: resolution.child.step.phase } : {}),
+								...(resolution.child.step.label ? { label: resolution.child.step.label } : {}),
+							} satisfies SubagentChildStatusEvent)}\n`, "utf-8");
+						} catch (error) {
+							console.error(`Failed to append child status event for workflow ${workflowRunId}:`, error);
+						}
+						return { content: [{ type: "text", text: `Stop requested for child ${resolution.child.id} in async workflow ${workflowRunId}.` }], details: { mode: "management", results: [] } };
 					}
 					workflowController.abort(new Error("Workflow stopped by user."));
 					return { content: [{ type: "text", text: `Stop requested for async workflow ${targetRunId}.` }], details: { mode: "management", results: [] } };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1851,8 +1851,27 @@ export const SUBAGENT_FOREGROUND_COMPLETE_EVENT = "subagent:foreground-complete"
 export const SUBAGENT_CONTROL_EVENT = "subagent:control-event";
 export const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 export const SUBAGENT_STEERING_NOTICE_EVENT = "subagent:steering-notice";
+export const SUBAGENT_CHILD_STATUS_EVENT = "subagent:child-status";
 export const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
 export const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom-delivery";
+
+export interface SubagentChildStatusEvent {
+	type: "subagent.child-status";
+	version: 1;
+	runId: string;
+	childId: string;
+	status: "stopping" | "stopped";
+	ts: number;
+	reason?: string;
+	source?: "rpc" | "async";
+	asyncDir?: string;
+	stepIndex?: number;
+	agent?: string;
+	childRunId?: string;
+	workflowKey?: string;
+	phase?: string;
+	label?: string;
+}
 
 // ============================================================================
 // Execution Options

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -1263,6 +1263,49 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(mockPi.callCount(), 3);
 	});
 
+	it("journals terminal child status events for running async child stops", { skip: !isAsyncAvailable() ? "jiti not available" : process.platform === "win32" ? "cross-process stop delivery unreliable on Windows CI" : undefined }, async () => {
+		mockPi.onCall({ delay: 5_000, output: "one late" });
+		mockPi.onCall({ delay: 250, output: "two done" });
+		const id = `async-child-stop-parallel-${Date.now().toString(36)}`;
+		executeAsyncChain(id, {
+			chain: [{
+				parallel: [
+					{ agent: "one", task: "Wait" },
+					{ agent: "two", task: "Finish" },
+				],
+				concurrency: 2,
+			}],
+			resultMode: "parallel",
+			agents: [makeAgent("one"), makeAgent("two")],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		await waitForMockPiCall(mockPi, 1, 10_000);
+		const asyncDir = path.join(ASYNC_DIR, id);
+		const statusBeforeStop = await waitForAsyncState(id, (candidate) => candidate.steps?.[0]?.status === "running" && typeof candidate.pid === "number");
+		deliverStopRequest({ asyncDir, pid: statusBeforeStop.pid, source: "test", targetIndex: 0, childId: "step:0" });
+
+		await waitForAsyncResultFile(id, 30_000);
+		const status = await waitForAsyncState(id, (candidate) => candidate.state !== "running");
+		assert.equal(status.steps?.[0]?.status, "stopped");
+		const childStatusEvents = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as { type?: string; childId?: string; status?: string });
+		assert.ok(childStatusEvents.some((event) => event.type === "subagent.child-status" && event.childId === "step:0" && event.status === "stopping"));
+		assert.ok(childStatusEvents.some((event) => event.type === "subagent.child-status" && event.childId === "step:0" && event.status === "stopped"));
+	});
+
 	it("marks async parallel runs that exceed timeoutMs as timed out", { skip: !isAsyncAvailable() ? "jiti not available" : process.platform === "win32" ? "timeout signal delivery intermittent on Windows CI" : undefined }, async () => {
 		mockPi.onCall({ delay: 5_000, output: "one done" });
 		mockPi.onCall({ delay: 5_000, output: "two done" });

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { getArtifactsDir } from "../../src/shared/artifacts.ts";
+import { SUBAGENT_CHILD_STATUS_EVENT } from "../../src/shared/types.ts";
 import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { SubagentFleetComponent } from "../../src/tui/fleet.ts";
 import { createNestedRoute } from "../../src/runs/shared/nested-events.ts";
@@ -1605,6 +1606,64 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			assert.ok(controlEvent);
 			assert.match((controlEvent.data as { noticeText?: string }).noticeText ?? "", /subagent-worker-run-3-1/);
 			assert.equal(recorder.events.some((event) => event.channel === "subagent:control-intercom"), true);
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("bridges async child status events from events.jsonl to the parent event bus", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-");
+		try {
+			const runDir = path.join(asyncRoot, "run-child-status");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-child-status",
+				mode: "parallel",
+				state: "running",
+				startedAt: Date.now() - 1000,
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "running", workflowKey: "slow" }],
+			}), "utf-8");
+			fs.writeFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({
+				type: "subagent.child-status",
+				version: 1,
+				runId: "run-child-status",
+				childId: "slow",
+				status: "stopped",
+				ts: 123,
+				reason: "user",
+				stepIndex: 0,
+				agent: "worker",
+				workflowKey: "slow",
+			})}\n`, "utf-8");
+
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+			});
+			tracker.handleStarted({ id: "run-child-status", asyncDir: runDir, agent: "workflow" });
+
+			await waitForCondition(
+				() => recorder.events.some((event) => event.channel === SUBAGENT_CHILD_STATUS_EVENT),
+				"child status event",
+			);
+
+			const event = recorder.events.find((entry) => entry.channel === SUBAGENT_CHILD_STATUS_EVENT)!;
+			assert.deepEqual(event.data, {
+				type: "subagent.child-status",
+				version: 1,
+				runId: "run-child-status",
+				childId: "slow",
+				status: "stopped",
+				ts: 123,
+				reason: "user",
+				source: "async",
+				asyncDir: runDir,
+				stepIndex: 0,
+				agent: "worker",
+				workflowKey: "slow",
+			});
 		} finally {
 			removeTempDir(asyncRoot);
 		}

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1479,6 +1479,12 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(payload.stopped, undefined);
 		assert.equal(payload.results?.find((entry) => entry.workflowKey === "slow")?.stopped, true);
 		assert.equal(payload.results?.find((entry) => entry.workflowKey === "fast")?.success, true);
+		const childStatusEvents = fs.readFileSync(path.join(started.details.asyncDir, "events.jsonl"), "utf-8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as { type?: string; childId?: string; status?: string });
+		assert.ok(childStatusEvents.some((event) => event.type === "subagent.child-status" && event.childId === "slow" && event.status === "stopping"));
+		assert.ok(childStatusEvents.some((event) => event.type === "subagent.child-status" && event.childId === "slow" && event.status === "stopped"));
 		fs.rmSync(started.details.asyncDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 		fs.rmSync(resultPath, { force: true });
 	});

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -13,7 +13,7 @@ import {
 	subagentRpcReplyEvent,
 	type SubagentRpcReplyEnvelope,
 } from "../../src/extension/rpc.ts";
-import type { Details, SubagentState } from "../../src/shared/types.ts";
+import { SUBAGENT_CHILD_STATUS_EVENT, type Details, type SubagentChildStatusEvent, type SubagentState } from "../../src/shared/types.ts";
 
 class FakeEvents {
 	readonly emitted: Array<{ event: string; data: unknown }> = [];
@@ -88,6 +88,10 @@ describe("subagent extension RPC bridge", () => {
 		assert.equal(
 			(reply as { data: { events?: { asyncComplete?: string } } }).data.events?.asyncComplete,
 			"subagent:async-complete",
+		);
+		assert.equal(
+			(reply as { data: { events?: { childStatus?: string } } }).data.events?.childStatus,
+			SUBAGENT_CHILD_STATUS_EVENT,
 		);
 		assert.equal(
 			(reply as { data: { capabilities?: { nonRecoveringSteer?: boolean } } }).data.capabilities?.nonRecoveringSteer,
@@ -767,6 +771,21 @@ describe("subagent extension RPC bridge", () => {
 			assert.equal((reply as { data: { childId?: string } }).data.childId, "review");
 			assert.equal((reply as { data: { state?: string } }).data.state, "stopping");
 			assert.deepEqual(consumeStopRequestPayload(asyncDir), { type: "stop", ts: 150, source: "rpc-stop", targetIndex: 1, childId: "review" });
+			const childStatus = events.emitted.find((entry) => entry.event === SUBAGENT_CHILD_STATUS_EVENT)?.data as SubagentChildStatusEvent | undefined;
+			assert.deepEqual(childStatus, {
+				type: "subagent.child-status",
+				version: 1,
+				runId: "run-stop-child",
+				childId: "review",
+				status: "stopping",
+				ts: 150,
+				reason: "user",
+				source: "rpc",
+				asyncDir,
+				stepIndex: 1,
+				agent: "slow",
+				workflowKey: "review",
+			});
 
 			bridge.dispose();
 		} finally {
@@ -812,6 +831,12 @@ describe("subagent extension RPC bridge", () => {
 			assert.equal((reply as { data: { state?: string } }).data.state, "stopping");
 			assert.deepEqual(calls, [{ childId: "slow", message: "Workflow child 'slow' stopped by RPC." }]);
 			assert.equal(fs.existsSync(stopRequestPath(asyncDir)), false);
+			const childStatus = events.emitted.find((entry) => entry.event === SUBAGENT_CHILD_STATUS_EVENT)?.data as SubagentChildStatusEvent | undefined;
+			assert.equal(childStatus?.runId, "workflow-stop-child");
+			assert.equal(childStatus?.childId, "slow");
+			assert.equal(childStatus?.status, "stopping");
+			assert.equal(childStatus?.source, "rpc");
+			assert.equal(childStatus?.workflowKey, "slow");
 
 			bridge.dispose();
 		} finally {


### PR DESCRIPTION
## Summary

Adds a child-stop observer event for RPC/native hosts while keeping `stop({ id, childId })` as the only child stop control API. Status snapshots remain authoritative; the new events are low-latency UI hints.

Closes #1374.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts --test-name-pattern "journals terminal child status events"`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/rpc.test.ts --test-name-pattern "ping|child stop|workflow child"`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-job-tracker.test.ts --test-name-pattern "child status|control events"`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts --test-name-pattern "stops one live async workflow child"`
- `npm run typecheck`
- `git diff --check`
- Fresh review: `reports/issue-1374-child-status-review.md`
- Follow-up review: `reports/issue-1374-child-status-followup-review.md`

Thanks to @yanqianglu for #1367, which motivated this follow-up.