### PR TITLE
fix: throttle async widget animation renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   severity labels so first-pass reviews do not default to `blockers only`.
 
 ### Fixed
+- Slow async widget animation rerenders to 1 Hz so quiet running jobs do not
+  repaint the full TUI at the liveness tick rate. Thanks to
+  [@0xFlo](https://github.com/0xFlo) for #1376.
 - Report helpful workflow errors when `runs.all(...)` results are read as keyed
   objects instead of ordered arrays. Thanks to [@ravshansbox](https://github.com/ravshansbox) for #1351.
 - Fail child launch attempts when the runtime lacks requested core write tools or

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -10,12 +10,12 @@ import {
 	type SteeringNotice,
 	type SubagentChildStatusEvent,
 	type SubagentState,
-	POLL_INTERVAL_MS,
 	DIRS,
 	SUBAGENT_CHILD_STATUS_EVENT,
 	SUBAGENT_CONTROL_EVENT,
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 	SUBAGENT_STEERING_NOTICE_EVENT,
+	WIDGET_ANIMATION_INTERVAL_MS,
 } from "../../shared/types.ts";
 import { readStatus, resolveWatchPath } from "../../shared/utils.ts";
 import { normalizeParallelGroups } from "./parallel-groups.ts";
@@ -73,6 +73,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	const runningJobIds = new Set<string>();
 	let rootWatcher: fs.FSWatcher | undefined;
 	let nextLivenessAt = Date.now() + livenessIntervalMs;
+	let nextWidgetAnimationAt = Date.now() + WIDGET_ANIMATION_INTERVAL_MS;
 	const watch = options.watch ?? fs.watch;
 	const useNativeWatcher = () => shouldUseNativeFsWatch("async-job-tracker", options.platform);
 	const terminalStatus = (status: string) => status === "complete" || status === "failed" || status === "paused" || status === "stopped";
@@ -580,8 +581,11 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				}
 				if (widgetChanged) rerenderLastWidget();
 			}
-			if (runningJobIds.size > 0) requestLastWidgetRender();
-		}, Math.min(POLL_INTERVAL_MS, livenessIntervalMs));
+			if (runningJobIds.size > 0 && now >= nextWidgetAnimationAt) {
+				nextWidgetAnimationAt = now + WIDGET_ANIMATION_INTERVAL_MS;
+				requestLastWidgetRender();
+			}
+		}, Math.min(WIDGET_ANIMATION_INTERVAL_MS, livenessIntervalMs));
 		state.poller.unref?.();
 	};
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2223,6 +2223,7 @@ export const SLASH_SUBAGENT_RESPONSE_EVENT = "subagent:slash:response";
 export const SLASH_SUBAGENT_UPDATE_EVENT = "subagent:slash:update";
 export const SLASH_SUBAGENT_CANCEL_EVENT = "subagent:slash:cancel";
 export const POLL_INTERVAL_MS = 250;
+export const WIDGET_ANIMATION_INTERVAL_MS = 1000;
 export const MAX_WIDGET_JOBS = 4;
 export const DEFAULT_SUBAGENT_MAX_DEPTH = 2;
 export const SUBAGENT_ACTIONS = ["list", "get", "models", "children.list", "guide", "create", "update", "delete", "eject", "disable", "enable", "reset", "mission.create", "mission.list", "mission.show", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "worktree.discard", "refine", "refine.show", "refine.rollback", "inspector.open", "inspector.status", "inspector.close", "project.open", "project.status", "project.close", "status", "debug.run", "grant-spawn-budget", "interrupt", "resume", "steer", "stop", "dismiss", "doctor", "watchdog.status", "watchdog.check", "watchdog.configure", "watchdog.recommend-model", "schedule.create", "schedule.list", "schedule.show", "schedule.history", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"] as const;

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -18,7 +18,7 @@ import {
 	type WorkflowNodeStatus,
 	type MainWindowRendererConfig,
 	MAX_WIDGET_JOBS,
-	POLL_INTERVAL_MS,
+	WIDGET_ANIMATION_INTERVAL_MS,
 	WIDGET_KEY,
 } from "../shared/types.ts";
 import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
@@ -1580,7 +1580,7 @@ function buildWidgetComponent(jobs: AsyncJobState[], expanded: boolean): (_tui: 
 		const container = new Container();
 		container.render = (renderWidth: number): string[] => {
 			const width = Math.max(0, renderWidth - 2);
-			const frame = Math.floor(Date.now() / POLL_INTERVAL_MS);
+			const frame = Math.floor(Date.now() / WIDGET_ANIMATION_INTERVAL_MS);
 			const buildLines = (): string[] => expanded
 				? buildWidgetLines(jobs, theme, width, true, frame)
 				: jobs.length === 1

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -468,6 +468,36 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
+	it("does not request quiet running widget renders on every liveness tick", async () => {
+		const asyncRoot = createTempDir("pi-async-job-quiet-widget-");
+		try {
+			const runDir = path.join(asyncRoot, "quiet-run");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "quiet-run",
+				mode: "single",
+				state: "running",
+				startedAt: 1000,
+				lastUpdate: 1000,
+				steps: [{ agent: "worker", status: "running" }],
+			}), "utf-8");
+			const state = createState();
+			const ui = createUiContext();
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 10 });
+			tracker.resetJobs(ui.ctx as never);
+			tracker.handleStarted({ id: "quiet-run", asyncDir: runDir, agent: "worker" });
+
+			await waitForCondition(() => state.asyncJobs.get("quiet-run")?.status === "running", "quiet running job refresh");
+			const renderRequests = ui.renderRequests;
+			await new Promise((resolve) => setTimeout(resolve, 120));
+
+			assert.equal(ui.renderRequests, renderRequests);
+			tracker.resetJobs();
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
 	it("uses polling without native watchers on Darwin and fires terminal delivery hooks once", async () => {
 		const asyncRoot = createTempDir("pi-async-job-darwin-poll-");
 		try {

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -985,12 +985,12 @@ describe("subagent async widget rendering", () => {
 			);
 			const first = component.render(180);
 
-			Date.now = () => 1_250;
+			Date.now = () => 2_000;
 			const second = component.render(180);
 			const withoutRunningGlyphs = (lines: string[]) => lines.map((line) => line.replace(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/gu, ""));
 
 			assert.equal(renderRequests, 0, "the component must not own the repaint cadence");
-			assert.notDeepEqual(second, first, "the render clock should advance quiet running glyphs");
+			assert.notDeepEqual(second, first, "the animation clock should advance quiet running glyphs");
 			assert.deepEqual(withoutRunningGlyphs(second), withoutRunningGlyphs(first), "only running glyphs should change");
 			assert.notEqual(firstRunningGlyph(first[0] ?? ""), firstRunningGlyph(second[0] ?? ""), "header glyph should advance");
 			assert.notEqual(firstRunningGlyph(first[1] ?? ""), firstRunningGlyph(second[1] ?? ""), "job glyph should advance");


### PR DESCRIPTION
## Summary

Reduces quiet async-widget repaint pressure by moving spinner animation to a 1 Hz cadence while keeping status-driven rerenders immediate.

Closes #1376.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-job-tracker.test.ts --test-name-pattern "quiet running widget|repaints unchanged running widgets"`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/render-helpers.test.ts test/unit/widget-nested-render.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review: `reports/issue-1376-async-widget-render-review.md`

Thanks to @0xFlo for #1376 and the measurements.