### PR TITLE
fix: trust parent staged-file acceptance check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   severity labels so first-pass reviews do not default to `blockers only`.
 
 ### Fixed
+- Let read-only reviewer acceptance rely on the parent-side staged-file check
+  instead of requiring child-reported `noStagedFiles` evidence.
 - Slow async widget animation rerenders to 1 Hz so quiet running jobs do not
   repaint the full TUI at the liveness tick rate. Thanks to
   [@0xFlo](https://github.com/0xFlo) for #1376.

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -959,6 +959,7 @@ function checkNoStagedFiles(cwd: string): AcceptanceRuntimeCheck {
 function runStructuralChecks(acceptance: ResolvedAcceptanceConfig, report: AcceptanceReport, cwd: string): AcceptanceRuntimeCheck[] {
 	const checks: AcceptanceRuntimeCheck[] = [];
 	for (const kind of acceptance.evidence) {
+		if (kind === "no-staged-files" && report.noStagedFiles === undefined) continue;
 		const status = reportEvidenceStatus(report, kind);
 		checks.push({
 			id: `evidence:${kind}`,

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -606,6 +606,93 @@ describe("acceptance gates", () => {
 		}
 	});
 
+	it("accepts read-only reviewer reports that omit child no-staged-files evidence when the worktree is clean", async () => {
+		const cwd = tempGitRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "reviewer",
+				task: "Review-only. Do not edit.",
+				explicit: { level: "checked", evidence: ["review-findings", "commands-run", "validation-output", "residual-risks"] },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: report({
+					changedFiles: [],
+					testsAddedOrUpdated: [],
+					validationOutput: ["Read-only review completed."],
+					reviewFindings: [],
+					noStagedFiles: undefined,
+				}),
+				cwd,
+			});
+
+			assert.equal(ledger.status, "checked");
+			assert.equal(ledger.runtimeChecks.find((check) => check.id === "evidence:no-staged-files"), undefined);
+			assert.equal(ledger.runtimeChecks.find((check) => check.id === "no-staged-files")?.status, "passed");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("still rejects aggregate no-staged-files evidence when a child worktree reports staged files", async () => {
+		const cwd = tempGitRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "reviewer",
+				task: "Review-only. Do not edit.",
+				explicit: { level: "checked", evidence: ["review-findings", "commands-run", "validation-output", "residual-risks"] },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: report({
+					changedFiles: [],
+					testsAddedOrUpdated: [],
+					validationOutput: ["Dynamic fanout review completed."],
+					reviewFindings: [],
+					noStagedFiles: false,
+				}),
+				cwd,
+			});
+
+			assert.equal(ledger.status, "rejected");
+			assert.equal(ledger.runtimeChecks.find((check) => check.id === "evidence:no-staged-files")?.status, "failed");
+			assert.equal(ledger.runtimeChecks.find((check) => check.id === "no-staged-files")?.status, "passed");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("still rejects omitted child no-staged-files evidence when the parent git check finds staged files", async () => {
+		const cwd = tempGitRepo();
+		try {
+			fs.writeFileSync(path.join(cwd, "staged.txt"), "staged\n", "utf-8");
+			execFileSync("git", ["add", "staged.txt"], { cwd });
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "reviewer",
+				task: "Review-only. Do not edit.",
+				explicit: { level: "checked", evidence: ["review-findings", "commands-run", "validation-output", "residual-risks"] },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: report({
+					changedFiles: [],
+					testsAddedOrUpdated: [],
+					validationOutput: ["Read-only review completed."],
+					reviewFindings: [],
+					noStagedFiles: undefined,
+				}),
+				cwd,
+			});
+
+			assert.equal(ledger.status, "rejected");
+			assert.equal(ledger.runtimeChecks.find((check) => check.id === "evidence:no-staged-files"), undefined);
+			assert.equal(ledger.runtimeChecks.find((check) => check.id === "no-staged-files")?.status, "failed");
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /Staged files present/);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("still rejects missing changed and test evidence and empty required commands", async () => {
 		const cwd = tempRepo();
 		try {


### PR DESCRIPTION
## Summary

Fixes #1384 by making the parent-side Git staged-file check authoritative for `no-staged-files` acceptance evidence. Read-only reviewers no longer need to report `noStagedFiles` themselves when the parent can verify the worktree state.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/acceptance.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review: `reports/issue-1384-readonly-acceptance-review.md`
