### PR TITLE
test: stabilize external CLI async cleanup

### DIFF
--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -786,7 +786,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(fs.readFileSync(markerPath, "utf-8"), "started");
 		assert.equal(mockPi.callCount(), 0);
 
-		fs.rmSync(started.details.asyncDir!, { recursive: true, force: true });
+		fs.rmSync(started.details.asyncDir!, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 		fs.rmSync(workflowResultPath, { force: true });
 	});
 
@@ -839,7 +839,18 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		}
 		assert.equal(fs.readFileSync(markerPath, "utf-8"), "started");
 		assert.equal(mockPi.callCount(), 0);
-		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true });
+
+		const resultPath = path.join(DIRS.results, `${result.details.asyncId}.json`);
+		let runResult: { state?: string } = {};
+		for (let attempt = 0; attempt < 100; attempt++) {
+			if (fs.existsSync(resultPath)) runResult = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+			if (runResult.state === "complete" || runResult.state === "failed") break;
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		assert.equal(runResult.state, "complete");
+
+		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+		fs.rmSync(resultPath, { force: true });
 	});
 
 	it("runs external CLI agents with fallback models without registry validation", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {


### PR DESCRIPTION
## Summary

Stabilizes the Windows cleanup path in the external CLI async single-child integration test. The test now waits for the terminal async result before deleting the run directory and uses retrying removal for the affected async cleanup paths.

## Validation

- `node --test test/integration/single-execution.test.ts --test-name-pattern 'starts omitted external CLI single-child calls in async mode'`
- `node --test test/integration/external-cli-runner.test.ts`
- `npm run typecheck`
- `git diff --check`

Closes #1389.
