### PR TITLE
docs: add task profile skill guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- Add bundled skill guidance for lightweight task profiles before subagent
+  fanout. Thanks to [@srcKod](https://github.com/srcKod) for #1395.
 - Add `subagents.defaultProvider` and per-agent `defaultProvider` overrides so bare subagent model ids can prefer a configured provider. Thanks to [@swingtempo](https://github.com/swingtempo) for #1393.
 - Add external-job follow-ups through `subagent({ action: "resume" })` for
   completed provider jobs that expose `followUp(input)`, with duplicate request

--- a/skills/pi-subagents/references/constraints-and-recipes.md
+++ b/skills/pi-subagents/references/constraints-and-recipes.md
@@ -62,6 +62,15 @@ user explicitly requests forked context.
 Give subagents specific tasks rather than vague mandates.
 `Review auth.ts for null-check gaps` works better than `Review everything`.
 
+Before fanout, assign each child a lightweight task profile in the parent prompt:
+work kind, required input, expected output, acceptance check, and context mode.
+Keep the profile prose-only; do not invent runtime fields. Use coarse kinds such
+as `code-write`, `code-read`, `transform`, `summarize`, and `search` only to
+shape the task and choose an existing agent/model setting. If a child task is not
+standalone enough for fresh context, add the missing facts to the prompt, switch
+to forked context, or ask the user. Do not launch vague tasks and rely on
+supervisor round-trips to recover missing context.
+
 ### Escalate decisions upward
 
 If a subagent encounters an unapproved product, architecture, scope, merge, release, credential, or authority choice, it should use `contact_supervisor` and wait for the reply instead of deciding alone. Generic `intercom` is external or provider-supplied only. Use it only when external bridge instructions provide an explicit safe target. External checks, receipts, and review bots provide evidence only; they do not grant authority.


### PR DESCRIPTION
Closes #1395.

This follows the owner decision to keep task semantics in the bundled skill only. It adds a small prose-only task profile checklist for fanout prompts and avoids new runtime fields, APIs, or task-manager behavior.

Validation:
- `git diff --check`
- Fresh review: no issues found

Credit: thanks @srcKod for #1395.
