### PR TITLE
refactor: polish unreleased code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
   as Surf's `gpt-pro` when the `surf-cli` Pi extension has registered
   `surf-oracle`, with text JSON reports instead of `outputSchema`.
 
+### Changed
+- Simplify unreleased Herdr snapshot and thinking-ceiling internals by removing
+  unused helpers and exports.
+
 ## [0.54.0] - 2026-08-21
 
 ### Highlights

--- a/src/inspectors/herdr/project-panes.ts
+++ b/src/inspectors/herdr/project-panes.ts
@@ -284,7 +284,7 @@ export function readProjectPaneBinding(projectRoot: string): ProjectPaneResult<H
 	return { ok: true, data: read.binding };
 }
 
-export function herdrProjectPaneSnapshotFromBinding(binding: HerdrProjectPaneBinding, now = Date.now()): HerdrProjectPaneSnapshot {
+function herdrProjectPaneSnapshotFromBinding(binding: HerdrProjectPaneBinding, now = Date.now()): HerdrProjectPaneSnapshot {
 	return {
 		projectRoot: binding.projectRoot,
 		bindingPath: projectPaneBindingPath(binding.projectRoot),
@@ -354,7 +354,7 @@ function projectPaneRuntime(value: unknown): ProjectPaneRuntime | undefined {
 	};
 }
 
-export function herdrProjectPaneSnapshotFromStatus(data: ProjectPaneStatusData, now: number): HerdrProjectPaneSnapshot | undefined {
+function herdrProjectPaneSnapshotFromStatus(data: ProjectPaneStatusData, now: number): HerdrProjectPaneSnapshot | undefined {
 	if (data.state === "absent" || !data.binding) return undefined;
 	return {
 		projectRoot: data.projectRoot,
@@ -630,7 +630,6 @@ function createProjectPaneManagerInternal(options: InternalProjectPaneManagerOpt
 			if (!bindingResult.ok) return bindingResult;
 			const existing = bindingResult.data;
 			if (!existing) return { ok: true, data: { ...common(projectRoot), disposition: "absent" } };
-			let runtime: ProjectPaneRuntime | undefined;
 			const live = await inspectPane(client, existing.paneId, input.signal);
 			if (!live.ok) {
 				if (live.error.code === "NOT_FOUND" || live.error.code === "PANE_GONE") {
@@ -640,7 +639,7 @@ function createProjectPaneManagerInternal(options: InternalProjectPaneManagerOpt
 				}
 				return { ok: false, error: { ...live.error, projectRoot, bindingPath: projectPaneBindingPath(projectRoot) } };
 			}
-			runtime = live.data;
+			const runtime = live.data;
 			const ownership = projectPaneOwnership(runtime, existing, projectRoot);
 			if (ownership !== "verified") {
 				return projectPaneError("PANE_OWNERSHIP_UNVERIFIED", `Project pane '${existing.paneId}' ownership is '${ownership}' for '${projectRoot}'.`, {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -26,7 +26,7 @@ import {
 	type RunFanoutBudgetDescriptor,
 } from "../../shared/types.ts";
 import { THINKING_LEVELS } from "../../shared/model-info.ts";
-import { decodeThinkingCeiling, encodeThinkingCeiling, intersectThinkingCeilings, SUBAGENT_THINKING_CEILING_ENV } from "../../shared/thinking-ceiling.ts";
+import { decodeThinkingCeiling, intersectThinkingCeilings, SUBAGENT_THINKING_CEILING_ENV } from "../../shared/thinking-ceiling.ts";
 import { encodeRunFanoutBudgetDescriptor, RUN_FANOUT_BUDGET_ENV } from "./run-fanout-budget.ts";
 import {
 	TOOL_BUDGET_ENV,
@@ -840,8 +840,7 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		input.thinkingCeiling,
 		decodeThinkingCeiling(process.env[SUBAGENT_THINKING_CEILING_ENV]),
 	);
-	const encodedThinkingCeiling = encodeThinkingCeiling(thinkingCeiling);
-	if (encodedThinkingCeiling) env[SUBAGENT_THINKING_CEILING_ENV] = encodedThinkingCeiling;
+	if (thinkingCeiling) env[SUBAGENT_THINKING_CEILING_ENV] = thinkingCeiling;
 	if (encodedCapabilityCeiling)
 		env[SUBAGENT_CAPABILITY_CEILING_ENV] = encodedCapabilityCeiling;
 	if (encodedPermissionRules)

--- a/src/shared/thinking-ceiling.ts
+++ b/src/shared/thinking-ceiling.ts
@@ -26,10 +26,6 @@ export function intersectThinkingCeilings(...ceilings: Array<ThinkingLevel | und
 	return active.reduce((lowest, ceiling) => compareThinkingLevels(ceiling, lowest) < 0 ? ceiling : lowest);
 }
 
-export function encodeThinkingCeiling(ceiling: ThinkingLevel | undefined): string | undefined {
-	return ceiling;
-}
-
 export function decodeThinkingCeiling(value: string | undefined): ThinkingLevel | undefined {
 	if (value === undefined || value === "") return undefined;
 	return parseThinkingLevel(value, "inherited thinking ceiling");


### PR DESCRIPTION
This removes unused API surface from the unreleased project-pane and thinking-ceiling changes. Project-pane close still verifies ownership and requires an explicitly idle pane.

Validation: focused unit tests, `npm run typecheck`, `fallow audit`, `git diff --check`, and a fresh review with no findings.