### PR TITLE
refactor: polish release-quality internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,8 @@
   `surf-oracle`, with text JSON reports instead of `outputSchema`.
 
 ### Changed
-- Simplify unreleased Herdr snapshot and thinking-ceiling internals by removing
-  unused helpers and exports.
+- Simplify launch-contract and external-job internals, and remove unused Herdr
+  snapshot and thinking-ceiling helpers while preserving released behavior.
 
 ## [0.54.0] - 2026-08-21
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1082,20 +1082,12 @@ function resolveSubagentDefaultModel(
 function applySubagentDefaultModel(agents: AgentConfig[], defaultModel: AgentModelSourceInfo | undefined, defaultProvider: string | undefined): AgentConfig[] {
 	if (!defaultModel && !defaultProvider) return agents;
 	return agents.map((agent) => {
-		if (agent.model !== undefined) {
-			if (agent.modelProvider !== undefined || !defaultProvider) return agent;
-			const next = { ...agent, modelProvider: defaultProvider };
-			const frontmatterFields = agentFrontmatterFields.get(agent);
-			if (frontmatterFields) agentFrontmatterFields.set(next, frontmatterFields);
-			return next;
-		}
-		if (!defaultModel) {
-			const next = { ...agent, ...(defaultProvider ? { modelProvider: defaultProvider } : {}) };
-			const frontmatterFields = agentFrontmatterFields.get(agent);
-			if (frontmatterFields) agentFrontmatterFields.set(next, frontmatterFields);
-			return next;
-		}
-		const next = { ...agent, model: defaultModel.model, ...(defaultProvider ? { modelProvider: defaultProvider } : {}), modelSource: defaultModel };
+		if (agent.model !== undefined && (agent.modelProvider !== undefined || !defaultProvider)) return agent;
+		const next = {
+			...agent,
+			...(agent.model === undefined && defaultModel ? { model: defaultModel.model, modelSource: defaultModel } : {}),
+			...(defaultProvider ? { modelProvider: defaultProvider } : {}),
+		};
 		const frontmatterFields = agentFrontmatterFields.get(agent);
 		if (frontmatterFields) agentFrontmatterFields.set(next, frontmatterFields);
 		return next;
@@ -1359,17 +1351,7 @@ function applyCustomAgentOverride(
 		fill("acceptanceRole", ["acceptanceRole"], override.acceptanceRole === false ? undefined : override.acceptanceRole);
 	}
 	if (override.disabled !== undefined) {
-		// Unconditional, matching applyBuiltinOverride: custom agents have no
-		// frontmatter concept of `disabled` to protect (unlike model/thinking/
-		// etc., which use `fill()` + agentHasFrontmatterField to defer to the
-		// agent's own file). A guard here previously read `agent.disabled ===
-		// undefined`, which was a no-op before user+project layering existed
-		// (this function only ever ran once, against the pristine base agent,
-		// whose `.disabled` is always undefined for custom agents) but became a
-		// real bug once a user-scope override could run first: the guard then
-		// silently blocked a later project-scope override from ever changing
-		// `disabled`, breaking this PR's own "project wins" precedence for this
-		// one field.
+		// Custom agent files cannot set `disabled`, so project overrides replace user overrides.
 		mutable().disabled = override.disabled;
 		anyFilled = true;
 	}
@@ -1411,13 +1393,7 @@ function applyCustomAgentOverrides(
 	userSettingsPath: string,
 	projectSettingsPath: string | null,
 ): AgentConfig[] {
-	// Both scopes are applied, user first then project, so a project override that
-	// only sets a subset of fields (e.g. just `extensions`) layers on top of the
-	// user's override instead of silently discarding it (#1341 / issue writeup:
-	// "agentOverrides project override drops user-only fields for custom agents").
-	// Per-field precedence still favors project over user: applyCustomAgentOverride
-	// only fills fields present in the override it's given, and project is applied
-	// last, so any field set at both scopes ends up with the project's value.
+	// Apply user then project so project fields win without dropping user-only fields.
 	return agents.map((agent) => {
 		const userOverride = userSettings.overrides[agent.name];
 		const withUserOverride = userOverride

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,7 +21,7 @@ import type { ResolvedMcpDirectToolSelection } from "../runs/shared/mcp-direct-t
 import { resolveStepBehavior } from "../shared/settings.ts";
 import { canPreferForkFromSnapshot, resolveSubagentLaunchContext } from "../shared/fork-context.ts";
 import { loadConfig } from "../extension/config.ts";
-import { agentDefinitionDigest, AGENT_DEFINITION_PROJECTION_VERSION, launchBindingDigest } from "../shared/launch-contract.ts";
+import { agentDefinitionDigest, AGENT_DEFINITION_PROJECTION_VERSION, launchBindingDigest, stableJsonDigest } from "../shared/launch-contract.ts";
 import { DIRS, TEMP_ROOT_DIR } from "../shared/types.ts";
 import { processTerminalCandidatePath, processTerminalPath } from "../runs/background/process-terminal.ts";
 import { resultFilePath } from "../runs/background/result-files.ts";
@@ -181,20 +180,8 @@ function packageVersion(): string {
 	return parsed.version;
 }
 
-function stableJson(value: unknown): string {
-	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
-	if (value && typeof value === "object") {
-		return `{${Object.entries(value as Record<string, unknown>)
-			.filter(([, entry]) => entry !== undefined)
-			.sort(([a], [b]) => a.localeCompare(b))
-			.map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
-			.join(",")}}`;
-	}
-	return JSON.stringify(value);
-}
-
 function digestContract(contract: Omit<SubagentLaunchContract, "digest">): string {
-	return createHash("sha256").update(stableJson(contract)).digest("hex");
+	return stableJsonDigest(contract);
 }
 
 function normalizeAvailableModels(models: SubagentLaunchContractInput["availableModels"]): AvailableModelInfo[] {
@@ -447,7 +434,6 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 			...(model ? { model } : {}),
 			modelCandidates,
 			...(resolveEffectiveThinking(model, effectiveThinkingConfig) ? { thinking: resolveEffectiveThinking(model, effectiveThinkingConfig) } : {}),
-			...(thinkingCeiling ? { thinkingCeiling } : {}),
 			systemPrompt: effectiveSystemPrompt,
 			systemPromptMode: agent.systemPromptMode,
 			inheritProjectContext: agent.inheritProjectContext,

--- a/src/runs/shared/external-job-bridge.ts
+++ b/src/runs/shared/external-job-bridge.ts
@@ -78,32 +78,32 @@ function isDispatchOperation(operation: ExternalJobOperation): boolean {
 	return operation === "start" || operation === "follow-up";
 }
 
-function startClaimDir(asyncDir: string, id: string): string {
+function dispatchClaimDir(asyncDir: string, id: string): string {
 	return path.join(requestDir(asyncDir), `${id}.claim`);
 }
 
-function startClaimTempDir(asyncDir: string, id: string): string {
+function dispatchClaimTempDir(asyncDir: string, id: string): string {
 	return path.join(requestDir(asyncDir), `${id}.claim.tmp-${randomUUID()}`);
 }
 
-function startClaimCompletedPath(claimDir: string): string {
+function dispatchClaimCompletedPath(claimDir: string): string {
 	return path.join(claimDir, "completed.json");
 }
 
-function startClaimHandlePath(claimDir: string): string {
+function dispatchClaimHandlePath(claimDir: string): string {
 	return path.join(claimDir, "handle.json");
 }
 
 function completedDispatchClaimExists(asyncDir: string, id: string): boolean {
-	return fs.existsSync(startClaimCompletedPath(startClaimDir(asyncDir, id)));
+	return fs.existsSync(dispatchClaimCompletedPath(dispatchClaimDir(asyncDir, id)));
 }
 
 function cancelDispatchRequest(asyncDir: string, request: ExternalJobBridgeRequest): boolean {
-	const claimDir = startClaimDir(asyncDir, request.id);
-	const tempClaimDir = startClaimTempDir(asyncDir, request.id);
+	const claimDir = dispatchClaimDir(asyncDir, request.id);
+	const tempClaimDir = dispatchClaimTempDir(asyncDir, request.id);
 	try {
 		fs.mkdirSync(tempClaimDir);
-		writeAtomicJson(startClaimCompletedPath(tempClaimDir), { completedAt: Date.now() });
+		writeAtomicJson(dispatchClaimCompletedPath(tempClaimDir), { completedAt: Date.now() });
 		fs.renameSync(tempClaimDir, claimDir);
 	} catch (error) {
 		fs.rmSync(tempClaimDir, { recursive: true, force: true });
@@ -242,7 +242,7 @@ async function executeBridgeRequest(request: ExternalJobBridgeRequest, claimDir?
 		const result = request.operation === "result"
 			? validateExternalJobResult(provider.name, raw, "External-job bridge result")
 			: validateExternalJobHandle(provider.name, raw, "External-job bridge handle");
-		if (isDispatchOperation(request.operation) && claimDir) writeAtomicJson(startClaimHandlePath(claimDir), result);
+		if (isDispatchOperation(request.operation) && claimDir) writeAtomicJson(dispatchClaimHandlePath(claimDir), result);
 		return { id: request.id, ok: true, operation: request.operation, provider: request.provider, result, completedAt: Date.now() };
 	} catch (error) {
 		const details = bridgeError(error);
@@ -257,11 +257,11 @@ async function executeBridgeRequest(request: ExternalJobBridgeRequest, claimDir?
 	}
 }
 
-function claimStartRequest(asyncDir: string, filePath: string, request: ExternalJobBridgeRequest): { request: ExternalJobBridgeRequest; filePath: string } | undefined {
+function claimDispatchRequest(asyncDir: string, filePath: string, request: ExternalJobBridgeRequest): { request: ExternalJobBridgeRequest; filePath: string } | undefined {
 	const owner = currentClaimOwner();
 	const claimed: ExternalJobBridgeRequest = { ...request, claimedAt: owner.claimedAt };
-	const claimDir = startClaimDir(asyncDir, request.id);
-	const tempClaimDir = startClaimTempDir(asyncDir, request.id);
+	const claimDir = dispatchClaimDir(asyncDir, request.id);
+	const tempClaimDir = dispatchClaimTempDir(asyncDir, request.id);
 	try {
 		fs.mkdirSync(tempClaimDir);
 		writeAtomicJson(path.join(tempClaimDir, "owner.json"), owner);
@@ -303,7 +303,7 @@ function readClaimOwner(claimDir: string): ExternalJobClaimOwner | undefined {
 
 function readClaimHandle(provider: string, claimDir: string): ExternalJobHandle | undefined {
 	try {
-		return validateExternalJobHandle(provider, readJson(startClaimHandlePath(claimDir)), "External-job bridge recovered start handle");
+		return validateExternalJobHandle(provider, readJson(dispatchClaimHandlePath(claimDir)), "External-job bridge recovered dispatch handle");
 	} catch {
 		return undefined;
 	}
@@ -313,7 +313,7 @@ export function serviceExternalJobBridgeRequests(asyncDir: string): void {
 	let files: string[];
 	try {
 		files = fs.readdirSync(requestDir(asyncDir), { withFileTypes: true })
-			.filter((entry) => (entry.isFile() && entry.name.endsWith(".json") && !completedDispatchClaimExists(asyncDir, entry.name.replace(/\.json$/, ""))) || (entry.isDirectory() && entry.name.endsWith(".claim") && !fs.existsSync(startClaimCompletedPath(path.join(requestDir(asyncDir), entry.name)))))
+			.filter((entry) => (entry.isFile() && entry.name.endsWith(".json") && !completedDispatchClaimExists(asyncDir, entry.name.replace(/\.json$/, ""))) || (entry.isDirectory() && entry.name.endsWith(".claim") && !fs.existsSync(dispatchClaimCompletedPath(path.join(requestDir(asyncDir), entry.name)))))
 			.map((entry) => entry.name)
 			.slice(0, MAX_REQUESTS_PER_SWEEP);
 	} catch (error) {
@@ -329,7 +329,7 @@ export function serviceExternalJobBridgeRequests(asyncDir: string): void {
 export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: string): void {
 	fs.mkdirSync(responseDir(asyncDir), { recursive: true });
 	if (file.endsWith(".claim")) {
-		serviceExternalJobStartClaim(asyncDir, file);
+		serviceExternalJobDispatchClaim(asyncDir, file);
 		return;
 	}
 	const filePath = path.join(requestDir(asyncDir), file);
@@ -357,14 +357,14 @@ export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: stri
 	}
 	if (inFlight.has(request.id) || fs.existsSync(responsePath(asyncDir, request.id))) return;
 	if (isDispatchOperation(request.operation) && request.claimedAt !== undefined) return;
-	const claimed = isDispatchOperation(request.operation) ? claimStartRequest(asyncDir, filePath, request) : { request, filePath };
+	const claimed = isDispatchOperation(request.operation) ? claimDispatchRequest(asyncDir, filePath, request) : { request, filePath };
 	if (!claimed) return;
 	const claimedRequest = claimed.request;
 	inFlight.add(claimedRequest.id);
 	void executeBridgeRequest(claimedRequest, isDispatchOperation(claimedRequest.operation) ? claimed.filePath : undefined).then((response) => {
 		writeAtomicJson(responsePath(asyncDir, claimedRequest.id), response);
 		if (isDispatchOperation(claimedRequest.operation)) {
-			writeAtomicJson(startClaimCompletedPath(claimed.filePath), { completedAt: Date.now() });
+			writeAtomicJson(dispatchClaimCompletedPath(claimed.filePath), { completedAt: Date.now() });
 		} else {
 			fs.rmSync(claimed.filePath, { recursive: true, force: true });
 		}
@@ -378,15 +378,15 @@ export function serviceExternalJobBridgeRequestFile(asyncDir: string, file: stri
 			message: error instanceof Error ? error.message : String(error),
 			completedAt: Date.now(),
 		} satisfies ExternalJobBridgeResponse);
-		if (isDispatchOperation(claimedRequest.operation)) writeAtomicJson(startClaimCompletedPath(claimed.filePath), { completedAt: Date.now() });
+		if (isDispatchOperation(claimedRequest.operation)) writeAtomicJson(dispatchClaimCompletedPath(claimed.filePath), { completedAt: Date.now() });
 	}).finally(() => {
 		inFlight.delete(claimedRequest.id);
 	});
 }
 
-function serviceExternalJobStartClaim(asyncDir: string, file: string): void {
+function serviceExternalJobDispatchClaim(asyncDir: string, file: string): void {
 	const claimDir = path.join(requestDir(asyncDir), file);
-	if (fs.existsSync(startClaimCompletedPath(claimDir))) return;
+	if (fs.existsSync(dispatchClaimCompletedPath(claimDir))) return;
 	const owner = readClaimOwner(claimDir);
 	if (!owner && fs.existsSync(requestPath(asyncDir, file.replace(/\.claim$/, ""))) && !fs.existsSync(responsePath(asyncDir, file.replace(/\.claim$/, "")))) {
 		fs.rmSync(claimDir, { recursive: true, force: true });
@@ -410,7 +410,7 @@ function serviceExternalJobStartClaim(asyncDir: string, file: string): void {
 			result: handle,
 			completedAt: Date.now(),
 		} satisfies ExternalJobBridgeResponse);
-		writeAtomicJson(startClaimCompletedPath(claimDir), { completedAt: Date.now() });
+		writeAtomicJson(dispatchClaimCompletedPath(claimDir), { completedAt: Date.now() });
 		fs.rmSync(requestPath(asyncDir, request.id), { force: true });
 		return;
 	}

--- a/src/runs/shared/external-job-runner.ts
+++ b/src/runs/shared/external-job-runner.ts
@@ -154,6 +154,25 @@ function readExistingExternalJob(asyncDir: string, stepIndex: number): ExternalJ
 	return parseExternalJobStatus(step.externalJob, statusPath);
 }
 
+function externalJobLineage(followUp: ExternalJobFollowUpDescriptor | undefined, previous: ExternalJobStatus | undefined) {
+	return {
+		operation: followUp ? "follow-up" as const : previous?.operation,
+		...(followUp ? {
+			sourceRunId: followUp.sourceRunId,
+			sourceStepIndex: followUp.sourceStepIndex,
+			parentProviderJobId: followUp.parentProviderJobId,
+			requestId: followUp.requestId,
+			requestDigest: followUp.requestDigest,
+		} : {
+			...(previous?.sourceRunId ? { sourceRunId: previous.sourceRunId } : {}),
+			...(previous?.sourceStepIndex !== undefined ? { sourceStepIndex: previous.sourceStepIndex } : {}),
+			...(previous?.parentProviderJobId ? { parentProviderJobId: previous.parentProviderJobId } : {}),
+			...(previous?.requestId ? { requestId: previous.requestId } : {}),
+			...(previous?.requestDigest ? { requestDigest: previous.requestDigest } : {}),
+		}),
+	};
+}
+
 function statusFromHandle(input: {
 	provider: string;
 	promptDigest: string;
@@ -168,20 +187,7 @@ function statusFromHandle(input: {
 		provider: input.provider,
 		providerJobId: input.handle.providerJobId,
 		promptDigest: input.promptDigest,
-		operation: input.followUp ? "follow-up" : input.previous?.operation,
-		...(input.followUp ? {
-			sourceRunId: input.followUp.sourceRunId,
-			sourceStepIndex: input.followUp.sourceStepIndex,
-			parentProviderJobId: input.followUp.parentProviderJobId,
-			requestId: input.followUp.requestId,
-			requestDigest: input.followUp.requestDigest,
-		} : {
-			...(input.previous?.sourceRunId ? { sourceRunId: input.previous.sourceRunId } : {}),
-			...(input.previous?.sourceStepIndex !== undefined ? { sourceStepIndex: input.previous.sourceStepIndex } : {}),
-			...(input.previous?.parentProviderJobId ? { parentProviderJobId: input.previous.parentProviderJobId } : {}),
-			...(input.previous?.requestId ? { requestId: input.previous.requestId } : {}),
-			...(input.previous?.requestDigest ? { requestDigest: input.previous.requestDigest } : {}),
-		}),
+		...externalJobLineage(input.followUp, input.previous),
 		options: input.options,
 		handleUrl: input.handle.handleUrl ?? input.previous?.handleUrl,
 		conversationUrl: input.handle.conversationUrl ?? input.previous?.conversationUrl,
@@ -209,20 +215,7 @@ function failureStatus(input: {
 		provider: input.provider,
 		providerJobId: input.previous?.providerJobId,
 		promptDigest: input.promptDigest,
-		operation: input.followUp ? "follow-up" : input.previous?.operation,
-		...(input.followUp ? {
-			sourceRunId: input.followUp.sourceRunId,
-			sourceStepIndex: input.followUp.sourceStepIndex,
-			parentProviderJobId: input.followUp.parentProviderJobId,
-			requestId: input.followUp.requestId,
-			requestDigest: input.followUp.requestDigest,
-		} : {
-			...(input.previous?.sourceRunId ? { sourceRunId: input.previous.sourceRunId } : {}),
-			...(input.previous?.sourceStepIndex !== undefined ? { sourceStepIndex: input.previous.sourceStepIndex } : {}),
-			...(input.previous?.parentProviderJobId ? { parentProviderJobId: input.previous.parentProviderJobId } : {}),
-			...(input.previous?.requestId ? { requestId: input.previous.requestId } : {}),
-			...(input.previous?.requestDigest ? { requestDigest: input.previous.requestDigest } : {}),
-		}),
+		...externalJobLineage(input.followUp, input.previous),
 		options: input.options,
 		handleUrl: input.previous?.handleUrl,
 		conversationUrl: input.previous?.conversationUrl,

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -275,12 +275,7 @@ export interface PiLaunchToolPlan {
 	extensionArgs: string[];
 	disableAmbientExtensions: boolean;
 	capabilityAudit?: SubagentCapabilityAudit;
-	/**
-	 * Non-fatal footguns surfaced during plan resolution (currently: an agent
-	 * `extensions: []` override, which disables ALL ambient extensions for the
-	 * child rather than "adding nothing" — see the empty-extensions-override
-	 * warning below). Callers may log these; they never change behavior.
-	 */
+	/** Non-fatal launch warnings; they do not change behavior. */
 	warnings: string[];
 }
 
@@ -478,12 +473,7 @@ export function resolvePiLaunchToolPlan(
 		capabilityCeiling?.denyExtensions === true ||
 		input.extensions !== undefined;
 	const warnings: string[] = [];
-	// An agent override that sets `extensions: []` reads like "add nothing", but
-	// any *defined* extensions list (including an empty one) disables every
-	// ambient extension for this child — not just skips adding extras. That
-	// silently strips load-bearing ambient extensions (e.g. a model provider
-	// extension), so a provider-qualified model pin becomes unresolvable in the
-	// child with no error pointing back at the override that caused it.
+	// An explicit empty list disables ambient extensions, including model providers.
 	if (capabilityCeiling?.denyExtensions !== true && Array.isArray(input.extensions) && input.extensions.length === 0) {
 		const agentLabel = input.agentName ? ` for agent '${input.agentName}'` : "";
 		warnings.push(

--- a/src/shared/launch-contract.ts
+++ b/src/shared/launch-contract.ts
@@ -17,7 +17,7 @@ function stableJson(value: unknown): string {
 	return JSON.stringify(value);
 }
 
-function sha256(value: unknown): string {
+export function stableJsonDigest(value: unknown): string {
 	return createHash("sha256").update(stableJson(value)).digest("hex");
 }
 
@@ -71,7 +71,7 @@ export function projectAgentDefinition(agent: AgentConfig): Record<string, unkno
 }
 
 export function agentDefinitionDigest(agent: AgentConfig): string {
-	return sha256(projectAgentDefinition(agent));
+	return stableJsonDigest(projectAgentDefinition(agent));
 }
 
 export interface LaunchBindingInput {
@@ -100,12 +100,12 @@ export function projectLaunchBinding(input: LaunchBindingInput): Record<string, 
 	return {
 		version: LAUNCH_BINDING_PROJECTION_VERSION,
 		definitionDigest: input.definitionDigest,
-		taskDigest: input.task === undefined ? undefined : sha256(input.task),
+		taskDigest: input.task === undefined ? undefined : stableJsonDigest(input.task),
 		// The ordered candidate set already contains each attempted model; keeping only
 		// this set makes retries correlate to the same preflight binding.
 		modelCandidates: input.modelCandidates,
 		thinking: input.thinking,
-		systemPromptDigest: input.systemPrompt === undefined || input.systemPrompt === null ? undefined : sha256(input.systemPrompt),
+		systemPromptDigest: input.systemPrompt === undefined || input.systemPrompt === null ? undefined : stableJsonDigest(input.systemPrompt),
 		systemPromptMode: input.systemPromptMode,
 		inheritProjectContext: input.inheritProjectContext,
 		inheritSkills: input.inheritSkills,
@@ -121,5 +121,5 @@ export function projectLaunchBinding(input: LaunchBindingInput): Record<string, 
 }
 
 export function launchBindingDigest(input: LaunchBindingInput): string {
-	return sha256(projectLaunchBinding(input));
+	return stableJsonDigest(projectLaunchBinding(input));
 }

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -2269,9 +2269,11 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 						{ key: "length", agent: "echo", task: "Length task" },
 						{ key: "map", agent: "echo", task: "Map task" }
 					]);
+					const [, second] = children;
 					return {
 						length: children.length,
 						first: children[0].output,
+						second: second.output,
 						outputs: children.map((child) => child.output),
 						children
 					};
@@ -2284,9 +2286,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
 		assert.equal(mockPi.callCount(), 2);
-		const value = result.details.workflow?.value as { length?: number; first?: string; outputs?: string[]; children?: Array<{ key?: string; ok?: boolean; output?: string }> } | undefined;
+		const value = result.details.workflow?.value as { length?: number; first?: string; second?: string; outputs?: string[]; children?: Array<{ key?: string; ok?: boolean; output?: string }> } | undefined;
 		assert.equal(value?.length, 2);
 		assert.equal(value?.first, "length child completed");
+		assert.equal(value?.second, "map child completed");
 		assert.deepEqual(value?.outputs, ["length child completed", "map child completed"]);
 		assert.deepEqual(value?.children?.map(({ key, ok, output }) => ({ key, ok, output })), [
 			{ key: "length", ok: true, output: "length child completed" },
@@ -2324,39 +2327,6 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			{ key: "second", output: "second child completed" },
 		]);
 		assert.deepEqual(result.details.workflow?.value, ["first child completed", "second child completed"]);
-	});
-
-	it("keeps normal runs.all array usage working", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
-		mockPi.onCall({ output: "first child completed", matchArgIncludes: "First task" });
-		mockPi.onCall({ output: "second child completed", matchArgIncludes: "Second task" });
-		const executor = makeExecutor([makeAgent("echo")]);
-
-		const result = await executor.execute(
-			"scripted-workflow-runs-all-array-result-access",
-			{
-				async: false,
-				workflowScript: `
-					const children = await runs.all([
-						{ key: "first", agent: "echo", task: "First task" },
-						{ key: "second", agent: "echo", task: "Second task" }
-					]);
-					const [first, second] = children;
-					return { length: children.length, first: children[0].output, second: second.output, outputs: children.map((child) => child.output) };
-				`,
-			},
-			new AbortController().signal,
-			undefined,
-			makeMinimalCtx(tempDir),
-		);
-
-		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
-		assert.equal(mockPi.callCount(), 2);
-		assert.deepEqual(result.details.workflow?.value, {
-			length: 2,
-			first: "first child completed",
-			second: "second child completed",
-			outputs: ["first child completed", "second child completed"],
-		});
 	});
 
 	it("rejects an over-limit runs.all batch before launching any workflow child", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -679,11 +679,6 @@ test("read-only agents and pure extension workers keep their launch contracts", 
 
 	assert.equal(validateImplementationToolContract({
 		agent: "worker",
-		task: "Implement the requested source fix.",
-	}), undefined);
-
-	assert.equal(validateImplementationToolContract({
-		agent: "worker",
 		task: "Task",
 		tools: ["read"],
 		requestedTools: ["read"],

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -1,6 +1,4 @@
 import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import { Editor, type EditorComponent, visibleWidth } from "@earendil-works/pi-tui";
@@ -260,63 +258,58 @@ describe("below-editor subagent FleetView", () => {
 	});
 
 	it("counts project panes in compact status", () => {
-		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-status-surfaces-"));
-		try {
-			const state = stateForTest();
-			const projectRoot = path.join(root, "peer-project");
-			const asyncDir = path.join(root, "async-run");
-			state.asyncJobs.set("run-view", {
-				asyncId: "run-view",
-				asyncDir,
-				status: "running",
-				mode: "single",
-				agents: ["worker"],
-				startedAt: Date.now() - 12_000,
-				updatedAt: Date.now() - 1_000,
-			});
-			state.herdrProjectPanes = new Map([[projectRoot, {
-				projectRoot,
-				bindingPath: path.join(projectRoot, ".pi/subagents/project-panes/herdr.json"),
-				paneId: "w1:p50",
-				openedAt: "2026-01-01T00:00:00.000Z",
-				state: "open",
-				agentStatus: "needs_attention",
-				ownership: "verified",
-				safeToClose: false,
-				refreshedAt: Date.now() - 2_000,
-				summary: "worker needs attention",
-			}]]);
+		const state = stateForTest();
+		const projectRoot = path.join("fixtures", "peer-project");
+		const asyncDir = path.join("fixtures", "async-run");
+		state.asyncJobs.set("run-view", {
+			asyncId: "run-view",
+			asyncDir,
+			status: "running",
+			mode: "single",
+			agents: ["worker"],
+			startedAt: Date.now() - 12_000,
+			updatedAt: Date.now() - 1_000,
+		});
+		state.herdrProjectPanes = new Map([[projectRoot, {
+			projectRoot,
+			bindingPath: path.join(projectRoot, ".pi/subagents/project-panes/herdr.json"),
+			paneId: "w1:p50",
+			openedAt: "2026-01-01T00:00:00.000Z",
+			state: "open",
+			agentStatus: "needs_attention",
+			ownership: "verified",
+			safeToClose: false,
+			refreshedAt: Date.now() - 2_000,
+			summary: "worker needs attention",
+		}]]);
 
-			let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
-			const ctx = {
-				hasUI: true,
-				ui: {
-					setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
-					onTerminalInput() { return () => {}; },
-					getEditorText() { return ""; },
-					requestRender() {},
-					notify() {},
-					theme,
-				},
-			} as unknown as ExtensionContext;
-			const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
-			try {
-				fleet.setContext(ctx);
-				const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
-				const compact = component.render(100)[0]!;
-				assert.match(compact, /1 active agent/);
-				assert.match(compact, /1 pane \(1 ⚠\)/);
-				assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
-				const expanded = component.render(100).join("\n");
-				assert.match(expanded, /project panes/);
-				assert.match(expanded, /peer-project · w1:p50/);
-				assert.match(expanded, /worker needs attention/);
-				assert.doesNotMatch(expanded, /views/);
-			} finally {
-				fleet.dispose();
-			}
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+		try {
+			fleet.setContext(ctx);
+			const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
+			const compact = component.render(100)[0]!;
+			assert.match(compact, /1 active agent/);
+			assert.match(compact, /1 pane \(1 ⚠\)/);
+			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
+			const expanded = component.render(100).join("\n");
+			assert.match(expanded, /project panes/);
+			assert.match(expanded, /peer-project · w1:p50/);
+			assert.match(expanded, /worker needs attention/);
+			assert.doesNotMatch(expanded, /views/);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			fleet.dispose();
 		}
 	});
 


### PR DESCRIPTION
This cleanup consolidates stable launch-contract digests, simplifies default model/provider mapping, and gives private external-job dispatch state clearer names. It also removes redundant test setup and duplicate behavior claims.

Released v0.54.0 APIs, digest values, durable paths, error codes, and runtime behavior remain unchanged.

Validation:
- `npm run typecheck`
- `npm run test:unit` (2,370 passed, 3 skipped)
- `npm run test:integration` (729 passed)
- `git diff --check`
- fresh exact-diff review: no issues
