### PR TITLE
feat: expose bounded current-work projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Child launches fail fast with clear reasons when requested models or write tools are unavailable.
 
 ### Added
-- Add a bounded `currentWork` v1 RPC projection for SDK hosts, covering current-session direct foreground and async lifecycle, activity, timing, usage, and hierarchy while excluding workflow-owned work and private runtime data (#1404).
+- Add a bounded `currentWork` v1 RPC projection for SDK hosts, covering current-session direct foreground and async lifecycle, activity, timing, usage, and hierarchy while excluding workflow-owned work and private runtime data. Thanks to [@Tom2906](https://github.com/Tom2906) for #1405 (tracking issue #1404).
 - Add `subagents.maxThinking` to enforce a thinking ceiling across native subagent launches. Thanks to [@alex-real14](https://github.com/alex-real14) for #1397.
 - Add `subagents.defaultProvider` and per-agent `defaultProvider` overrides so bare subagent model ids can prefer a configured provider. Thanks to [@swingtempo](https://github.com/swingtempo) for #1393.
 - Add external-job follow-ups through `subagent({ action: "resume" })` for completed provider jobs that expose `followUp(input)`, with duplicate request dedupe, durable parent-job lineage (#1381), and clearer errors when a follow-up cannot start.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Child launches fail fast with clear reasons when requested models or write tools are unavailable.
 
 ### Added
+- Add a bounded `currentWork` v1 RPC projection for SDK hosts, covering current-session direct foreground and async lifecycle, activity, timing, usage, and hierarchy while excluding workflow-owned work and private runtime data (#1404).
 - Add `subagents.maxThinking` to enforce a thinking ceiling across native subagent launches. Thanks to [@alex-real14](https://github.com/alex-real14) for #1397.
 - Add `subagents.defaultProvider` and per-agent `defaultProvider` overrides so bare subagent model ids can prefer a configured provider. Thanks to [@swingtempo](https://github.com/swingtempo) for #1393.
 - Add external-job follow-ups through `subagent({ action: "resume" })` for completed provider jobs that expose `followUp(input)`, with duplicate request dedupe, durable parent-job lineage (#1381), and clearer errors when a follow-up cannot start.

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -43,6 +43,7 @@ Capability advertisements on `ping`:
 - `nonRecoveringSteer` — RPC steering never pauses-and-revives.
 - `resume` — the revival seam described above.
 - `fleetStatus: { version: 1 }` — successful `status` replies additionally include `data.fleet`.
+- `currentWork: { kind: "subagents.current-work", version: 1 }` — successful `status` replies include a bounded, current-session, read-only direct-work hierarchy.
 
 Structured delegation progress updates carry `runId` as soon as foreground execution allocates it, so a caller can retain the package-owned revival target even if its own tool turn is interrupted before the terminal response. Foreground `details.results[]` rows also include a numeric `index` that is unique within the run and stable across partial progress snapshots and the final result; use `(runId, index)` instead of row position to correlate single, counted parallel, and chain children.
 
@@ -53,6 +54,16 @@ When `ping.capabilities.fleetStatus` is `{ version: 1 }`, successful `status` re
 Entries are bounded, current-session public display records with an opaque reconciliation `key`, resolved `agent`, optional `role`, `model`, `effort`, caller-facing `goal`, safe `startedAt`, and `{ input, output, total }` tokens. `totalActive` and `omitted` preserve overflow information beyond the bounded entry window.
 
 The DTO intentionally never exposes run, async, or tool IDs. Clients must ignore unknown fields and fall back to status text when the capability is absent.
+
+### Current-work DTO
+
+When `ping.capabilities.currentWork` advertises `{ kind: "subagents.current-work", version: 1 }`, successful `status` replies include `data.currentWork`. The same constants and TypeScript contract are exported from `pi-subagents/current-work`.
+
+The projection contains bounded `roots` for direct foreground and async work in the current native session. Each node has an opaque session-local `key`, `mode`, authoritative lifecycle `state`, optional caller-facing `goal`, agent/role, timestamps, safe attention/current-tool activity, bounded token usage, and bounded child nodes for chain or parallel structure. `caps` records the active limits and `omitted` reports root, child, or serialized-byte truncation.
+
+Active, attention-requiring, and bounded recent terminal direct work are represented so a read-only host can reconcile completion, failure, pause, stop, or rejection without parsing status prose. Workflow runs and workflow-owned children are excluded at the source. The projection never contains internal run, async, tool, session, or workflow IDs; filesystem or transcript paths; prompt/reasoning/output text; current-tool arguments; credentials; or control callbacks.
+
+Consumers must derive display state only from the projection, ignore unknown fields, honor `caps` and `omitted`, and treat a missing root in a later snapshot as removal. The projection is observational and adds no execution controls.
 
 ### Scope
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "./intercom-bridge": "./src/api/intercom-bridge.ts",
     "./pi-args": "./src/api/pi-args.ts",
     "./shared-types": "./src/api/shared-types.ts",
-    "./project-panes": "./src/api/project-panes.ts"
+    "./project-panes": "./src/api/project-panes.ts",
+    "./current-work": "./src/api/current-work.ts"
   },
   "repository": {
     "type": "git",

--- a/src/api/current-work.ts
+++ b/src/api/current-work.ts
@@ -1,0 +1,67 @@
+/** Public, read-only current-work projection contract. */
+
+export const CURRENT_WORK_PROJECTION_VERSION = 1 as const;
+export const CURRENT_WORK_PROJECTION_KIND = "subagents.current-work" as const;
+export const CURRENT_WORK_MAX_ROOTS = 32 as const;
+export const CURRENT_WORK_MAX_CHILDREN = 32 as const;
+export const CURRENT_WORK_MAX_DEPTH = 4 as const;
+export const CURRENT_WORK_MAX_STRING_LENGTH = 160 as const;
+export const CURRENT_WORK_MAX_SERIALIZED_BYTES = 32768 as const;
+
+export type CurrentWorkState = "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
+export type CurrentWorkMode = "single" | "chain" | "parallel";
+export type CurrentWorkAttentionState = "active_long_running" | "needs_attention";
+
+export interface CurrentWorkTokensV1 {
+	input: number;
+	output: number;
+	total: number;
+}
+
+export interface CurrentWorkActivityV1 {
+	state?: CurrentWorkAttentionState;
+	currentTool?: string;
+	lastActivityAt?: number;
+	currentToolStartedAt?: number;
+	turnCount?: number;
+	toolCount?: number;
+}
+
+export interface CurrentWorkNodeV1 {
+	/** Opaque, session-local reconciliation key. */
+	key: string;
+	goal?: string;
+	agent?: string;
+	role?: string;
+	mode: CurrentWorkMode;
+	state: CurrentWorkState;
+	startedAt?: number;
+	updatedAt?: number;
+	endedAt?: number;
+	activity?: CurrentWorkActivityV1;
+	tokens?: CurrentWorkTokensV1;
+	children?: CurrentWorkNodeV1[];
+}
+
+export interface CurrentWorkCapsV1 {
+	maxRoots: number;
+	maxChildrenPerNode: number;
+	maxDepth: number;
+	maxStringLength: number;
+	maxSerializedBytes: number;
+}
+
+export interface CurrentWorkOmittedV1 {
+	roots: number;
+	children: number;
+	byteLimitExceeded: boolean;
+}
+
+export interface CurrentWorkProjectionV1 {
+	kind: typeof CURRENT_WORK_PROJECTION_KIND;
+	version: typeof CURRENT_WORK_PROJECTION_VERSION;
+	generatedAt: number;
+	caps: CurrentWorkCapsV1;
+	omitted: CurrentWorkOmittedV1;
+	roots: CurrentWorkNodeV1[];
+}

--- a/src/extension/current-work.ts
+++ b/src/extension/current-work.ts
@@ -1,0 +1,349 @@
+import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
+import type { AsyncJobState, AsyncJobStep, ForegroundChildControl, ForegroundRunControl, ForegroundResumeRun, SubagentState, TokenUsage } from "../shared/types.ts";
+import {
+	CURRENT_WORK_MAX_CHILDREN,
+	CURRENT_WORK_MAX_DEPTH,
+	CURRENT_WORK_MAX_ROOTS,
+	CURRENT_WORK_MAX_SERIALIZED_BYTES,
+	CURRENT_WORK_MAX_STRING_LENGTH,
+	CURRENT_WORK_PROJECTION_KIND,
+	CURRENT_WORK_PROJECTION_VERSION,
+	type CurrentWorkActivityV1,
+	type CurrentWorkCapsV1,
+	type CurrentWorkMode,
+	type CurrentWorkNodeV1,
+	type CurrentWorkProjectionV1,
+	type CurrentWorkState,
+	type CurrentWorkTokensV1,
+} from "../api/current-work.ts";
+import type { CurrentWorkAttentionState } from "../api/current-work.ts";
+
+export {
+	CURRENT_WORK_MAX_CHILDREN,
+	CURRENT_WORK_MAX_DEPTH,
+	CURRENT_WORK_MAX_ROOTS,
+	CURRENT_WORK_MAX_SERIALIZED_BYTES,
+	CURRENT_WORK_MAX_STRING_LENGTH,
+	CURRENT_WORK_PROJECTION_KIND,
+	CURRENT_WORK_PROJECTION_VERSION,
+	type CurrentWorkActivityV1,
+	type CurrentWorkCapsV1,
+	type CurrentWorkMode,
+	type CurrentWorkNodeV1,
+	type CurrentWorkOmittedV1,
+	type CurrentWorkProjectionV1,
+	type CurrentWorkState,
+	type CurrentWorkTokensV1,
+} from "../api/current-work.ts";
+export type { CurrentWorkAttentionState } from "../api/current-work.ts";
+
+export interface CurrentWorkKeyState {
+	sessionId: string | null;
+	next: number;
+	keys: Map<string, string>;
+}
+
+export interface CurrentWorkProjectionOptions {
+	generatedAt?: number;
+	maxRoots?: number;
+	maxChildrenPerNode?: number;
+	maxDepth?: number;
+	maxStringLength?: number;
+	maxSerializedBytes?: number;
+	keys?: CurrentWorkKeyState;
+}
+
+interface BuildContext {
+	caps: CurrentWorkCapsV1;
+	omitted: { roots: number; children: number; byteLimitExceeded: boolean };
+	keys: CurrentWorkKeyState;
+}
+
+interface SourceNode {
+	internalKey: string;
+	goal?: unknown;
+	agent?: unknown;
+	role?: unknown;
+	mode?: unknown;
+	state?: unknown;
+	startedAt?: unknown;
+	updatedAt?: unknown;
+	endedAt?: unknown;
+	activityState?: unknown;
+	currentTool?: unknown;
+	lastActivityAt?: unknown;
+	currentToolStartedAt?: unknown;
+	turnCount?: unknown;
+	toolCount?: unknown;
+	tokens?: unknown;
+	children?: SourceNode[];
+}
+
+const TERMINAL_STATES = new Set(["complete", "completed", "failed", "paused", "stopped", "rejected"]);
+const ACTIVE_STATES = new Set(["queued", "pending", "running"]);
+
+function caps(options: CurrentWorkProjectionOptions): CurrentWorkCapsV1 {
+	const nonNegative = (value: number | undefined, fallback: number) => Math.max(0, Math.floor(value ?? fallback));
+	return {
+		maxRoots: nonNegative(options.maxRoots, CURRENT_WORK_MAX_ROOTS),
+		maxChildrenPerNode: nonNegative(options.maxChildrenPerNode, CURRENT_WORK_MAX_CHILDREN),
+		maxDepth: nonNegative(options.maxDepth, CURRENT_WORK_MAX_DEPTH),
+		maxStringLength: nonNegative(options.maxStringLength, CURRENT_WORK_MAX_STRING_LENGTH),
+		maxSerializedBytes: Math.max(256, Math.floor(options.maxSerializedBytes ?? CURRENT_WORK_MAX_SERIALIZED_BYTES)),
+	};
+}
+
+function text(value: unknown, fallback: string | undefined, limit: number): string | undefined {
+	if (typeof value !== "string") return fallback;
+	const clean = sanitizeDisplayText(value.slice(0, Math.max(0, limit * 4)));
+	return clean ? truncateDisplayText(clean, limit) : fallback;
+}
+
+function time(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function count(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.min(Number.MAX_SAFE_INTEGER, Math.floor(value)) : undefined;
+}
+
+function tokens(value: unknown): CurrentWorkTokensV1 | undefined {
+	if (typeof value === "number") {
+		const total = count(value);
+		return total === undefined ? undefined : { input: 0, output: 0, total };
+	}
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const source = value as Partial<TokenUsage>;
+	const input = count(source.input) ?? 0;
+	const output = count(source.output) ?? 0;
+	const total = Math.max(input + output, count(source.total) ?? 0);
+	if (input === 0 && output === 0 && total === 0 && source.input === undefined && source.output === undefined && source.total === undefined) return undefined;
+	return { input, output, total: Math.min(Number.MAX_SAFE_INTEGER, total) };
+}
+
+function state(value: unknown, fallback: CurrentWorkState = "running"): CurrentWorkState {
+	if (value === "completed") return "complete";
+	if (value === "pending") return "queued";
+	if (value === "detached") return "running";
+	return value === "queued" || value === "running" || value === "complete" || value === "failed" || value === "paused" || value === "stopped" || value === "rejected" ? value : fallback;
+}
+
+function mode(value: unknown): CurrentWorkMode {
+	return value === "chain" || value === "parallel" ? value : "single";
+}
+
+function keyFor(ctx: BuildContext, internalKey: string): string {
+	let key = ctx.keys.keys.get(internalKey);
+	if (!key) {
+		key = `work-${++ctx.keys.next}`;
+		ctx.keys.keys.set(internalKey, key);
+	}
+	return key;
+}
+
+function activity(source: SourceNode, maxStringLength: number): CurrentWorkActivityV1 | undefined {
+	const currentTool = text(source.currentTool, undefined, maxStringLength);
+	const attentionState: CurrentWorkAttentionState | undefined = source.activityState === "active_long_running" || source.activityState === "needs_attention" ? source.activityState : undefined;
+	const output: CurrentWorkActivityV1 = {
+		...(attentionState ? { state: attentionState } : {}),
+		...(currentTool ? { currentTool } : {}),
+		...(time(source.lastActivityAt) !== undefined ? { lastActivityAt: time(source.lastActivityAt) } : {}),
+		...(time(source.currentToolStartedAt) !== undefined ? { currentToolStartedAt: time(source.currentToolStartedAt) } : {}),
+		...(count(source.turnCount) !== undefined ? { turnCount: count(source.turnCount) } : {}),
+		...(count(source.toolCount) !== undefined ? { toolCount: count(source.toolCount) } : {}),
+	};
+	return Object.keys(output).length ? output : undefined;
+}
+
+function node(source: SourceNode, depth: number, ctx: BuildContext): CurrentWorkNodeV1 {
+	const currentState = state(source.state);
+	const startedAt = time(source.startedAt);
+	const updatedAt = time(source.updatedAt) ?? time(source.lastActivityAt) ?? time(source.endedAt) ?? startedAt;
+	const endedAt = TERMINAL_STATES.has(String(source.state)) ? time(source.endedAt) ?? updatedAt : undefined;
+	const output: CurrentWorkNodeV1 = {
+		key: keyFor(ctx, source.internalKey),
+		...(text(source.goal, undefined, ctx.caps.maxStringLength) ? { goal: text(source.goal, undefined, ctx.caps.maxStringLength) } : {}),
+		...(text(source.agent, undefined, ctx.caps.maxStringLength) ? { agent: text(source.agent, undefined, ctx.caps.maxStringLength) } : {}),
+		...(text(source.role, undefined, ctx.caps.maxStringLength) ? { role: text(source.role, undefined, ctx.caps.maxStringLength) } : {}),
+		mode: mode(source.mode),
+		state: currentState,
+		...(startedAt !== undefined ? { startedAt } : {}),
+		...(updatedAt !== undefined ? { updatedAt } : {}),
+		...(endedAt !== undefined ? { endedAt } : {}),
+		...(activity(source, ctx.caps.maxStringLength) ? { activity: activity(source, ctx.caps.maxStringLength) } : {}),
+		...(tokens(source.tokens) ? { tokens: tokens(source.tokens) } : {}),
+	};
+	if (source.children?.length) {
+		if (depth >= ctx.caps.maxDepth) {
+			ctx.omitted.children += source.children.length;
+		} else {
+			const allowed = source.children.slice(0, ctx.caps.maxChildrenPerNode);
+			output.children = allowed.map((child) => node(child, depth + 1, ctx));
+			ctx.omitted.children += Math.max(0, source.children.length - allowed.length);
+		}
+	}
+	return output;
+}
+
+function childNode(internalKey: string, child: Record<string, unknown>, _rootMode: CurrentWorkMode): SourceNode {
+	const nested = Array.isArray(child.children)
+		? child.children.filter((value): value is Record<string, unknown> => Boolean(value) && typeof value === "object" && !Array.isArray(value) && !workflowOwned(value))
+			.map((value, index) => childNode(`${internalKey}:child:${index}`, value, "single"))
+		: undefined;
+	return {
+		internalKey,
+		goal: child.description,
+		agent: child.agent,
+		role: child.label,
+		mode: mode(child.mode),
+		state: child.status ?? child.state,
+		startedAt: child.startedAt,
+		endedAt: child.endedAt,
+		updatedAt: child.updatedAt ?? child.lastActivityAt,
+		activityState: child.activityState,
+		currentTool: child.currentTool,
+		lastActivityAt: child.lastActivityAt,
+		currentToolStartedAt: child.currentToolStartedAt,
+		turnCount: child.turnCount,
+		toolCount: child.toolCount,
+		tokens: child.tokens,
+		children: nested,
+	};
+}
+
+function foregroundControlSource(control: ForegroundRunControl): SourceNode {
+	const rootMode = mode(control.mode);
+	const children = control.activeChildren ? [...control.activeChildren.values()].map((child: ForegroundChildControl) => childNode(`foreground:${control.runId}:child:${child.index}`, child as unknown as Record<string, unknown>, rootMode)) : undefined;
+	return {
+		internalKey: `foreground:${control.runId}`,
+		goal: control.description,
+		agent: control.currentAgent,
+		mode: rootMode,
+		state: "running",
+		startedAt: control.startedAt,
+		updatedAt: control.updatedAt,
+		activityState: control.currentActivityState,
+		currentTool: control.currentTool,
+		lastActivityAt: control.lastActivityAt,
+		currentToolStartedAt: control.currentToolStartedAt,
+		turnCount: control.turnCount,
+		toolCount: control.toolCount,
+		tokens: { input: control.inputTokens ?? 0, output: control.outputTokens ?? 0, total: control.tokens ?? 0 },
+		children,
+	};
+}
+
+function asyncSource(job: AsyncJobState): SourceNode {
+	const rootMode = mode(job.mode);
+	const steps = job.steps?.length ? job.steps : job.agents?.map((agent, index) => ({ agent, index, status: job.status === "queued" ? "pending" : job.status } as AsyncJobStep));
+	const visibleSteps = steps?.filter((step) => !workflowOwned(step));
+	const children = visibleSteps?.map((step, index) => childNode(`async:${job.asyncId}:step:${step.index ?? index}`, step as unknown as Record<string, unknown>, rootMode));
+	const nested = job.nestedChildren?.filter((child) => !workflowOwned(child)).map((child, index) => childNode(`async:${job.asyncId}:nested:${index}`, child as unknown as Record<string, unknown>, rootMode));
+	return {
+		internalKey: `async:${job.asyncId}`,
+		goal: job.description,
+		agent: job.agents?.[job.currentStep ?? 0],
+		mode: rootMode,
+		state: job.status,
+		startedAt: job.startedAt,
+		updatedAt: job.updatedAt,
+		activityState: job.activityState,
+		currentTool: job.currentTool,
+		lastActivityAt: job.lastActivityAt,
+		currentToolStartedAt: job.currentToolStartedAt,
+		turnCount: job.turnCount,
+		toolCount: job.toolCount,
+		tokens: job.totalTokens,
+		children: [...(children ?? []), ...(nested ?? [])],
+	};
+}
+
+function foregroundHistorySource(run: ForegroundResumeRun): SourceNode {
+	const children = run.children.map((child) => childNode(`foreground:${run.runId}:child:${child.index}`, child as unknown as Record<string, unknown>, mode(run.mode)));
+	const childStates = children.map((child) => state(child.state, "complete"));
+	const aggregate = childStates.some((item) => item === "running") ? "running"
+		: childStates.some((item) => item === "failed") ? "failed"
+		: childStates.some((item) => item === "paused") ? "paused"
+		: childStates.some((item) => item === "stopped") ? "stopped"
+		: "complete";
+	return {
+		internalKey: `foreground:${run.runId}`,
+		mode: mode(run.mode),
+		state: aggregate,
+		updatedAt: run.updatedAt,
+		endedAt: run.updatedAt,
+		children,
+	};
+}
+
+function workflowOwned(source: { mode?: unknown; parentWorkflowRunId?: unknown; workflowKey?: unknown }): boolean {
+	return source.mode === "workflow" || typeof source.parentWorkflowRunId === "string" || typeof source.workflowKey === "string";
+}
+
+function rootPriority(source: SourceNode): number {
+	const normalized = state(source.state);
+	if (source.activityState === "needs_attention" || normalized === "paused") return 3;
+	if (normalized === "running") return 2;
+	if (normalized === "queued") return 1;
+	return 0;
+}
+
+function serializedBytes(value: CurrentWorkProjectionV1): number {
+	return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function resolveKeys(options: CurrentWorkProjectionOptions, sessionId: string | null): CurrentWorkKeyState {
+	const keys = options.keys ?? { sessionId: null, next: 0, keys: new Map<string, string>() };
+	if (keys.sessionId !== sessionId) {
+		keys.sessionId = sessionId;
+		keys.next = 0;
+		keys.keys.clear();
+	}
+	return keys;
+}
+
+export function buildCurrentWorkProjection(state: SubagentState | undefined, sessionId: string | null | undefined, options: CurrentWorkProjectionOptions = {}): CurrentWorkProjectionV1 {
+	const resolvedSessionId = sessionId ?? null;
+	const resolvedCaps = caps(options);
+	const projection: CurrentWorkProjectionV1 = {
+		kind: CURRENT_WORK_PROJECTION_KIND,
+		version: CURRENT_WORK_PROJECTION_VERSION,
+		generatedAt: Date.now(),
+		caps: resolvedCaps,
+		omitted: { roots: 0, children: 0, byteLimitExceeded: false },
+		roots: [],
+	};
+	if (options.generatedAt !== undefined && time(options.generatedAt) !== undefined) projection.generatedAt = options.generatedAt;
+	const ctx: BuildContext = { caps: resolvedCaps, omitted: projection.omitted, keys: resolveKeys(options, resolvedSessionId) };
+	if (!state || !resolvedSessionId || state.currentSessionId !== resolvedSessionId) return projection;
+
+	const sources: SourceNode[] = [];
+	const activeForeground = new Set<string>();
+	for (const control of state.foregroundControls.values()) {
+		if (control.sessionId !== resolvedSessionId || workflowOwned(control)) continue;
+		activeForeground.add(control.runId);
+		sources.push(foregroundControlSource(control));
+	}
+	const jobs = new Map<string, AsyncJobState>();
+	for (const job of state.asyncJobs.values()) jobs.set(job.asyncId, job);
+	for (const job of state.fleetJobs?.values() ?? []) if (!jobs.has(job.asyncId)) jobs.set(job.asyncId, job);
+	for (const job of jobs.values()) {
+		if (job.sessionId !== resolvedSessionId || workflowOwned(job) || ![...ACTIVE_STATES, ...TERMINAL_STATES].some((item) => item === job.status)) continue;
+		sources.push(asyncSource(job));
+	}
+	for (const run of state.foregroundRuns?.values() ?? []) {
+		if (run.sessionId !== resolvedSessionId || activeForeground.has(run.runId) || workflowOwned(run)) continue;
+		sources.push(foregroundHistorySource(run));
+	}
+	sources.sort((left, right) => (rootPriority(right) - rootPriority(left)) || ((time(right.updatedAt) ?? 0) - (time(left.updatedAt) ?? 0)) || left.internalKey.localeCompare(right.internalKey));
+	const allowed = sources.slice(0, resolvedCaps.maxRoots);
+	projection.roots = allowed.map((source) => node(source, 0, ctx));
+	projection.omitted.roots += Math.max(0, sources.length - allowed.length);
+	while (projection.roots.length && serializedBytes(projection) > resolvedCaps.maxSerializedBytes) {
+		projection.roots.pop();
+		projection.omitted.roots += 1;
+		projection.omitted.byteLimitExceeded = true;
+	}
+	if (serializedBytes(projection) > resolvedCaps.maxSerializedBytes) projection.omitted.byteLimitExceeded = true;
+	return projection;
+}

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -24,6 +24,8 @@ import { SubagentParams } from "./schemas.ts";
 import { normalizePublicSubagentExecution } from "./public-execution.ts";
 import { ASYNC_STATUS_SNAPSHOT_KIND, ASYNC_STATUS_SNAPSHOT_VERSION, buildAsyncStatusSnapshotForState } from "../runs/background/async-status-snapshot.ts";
 import { isStoppableAsyncStatusStep, resolveAsyncStatusChild, type ResolvedAsyncStatusChild } from "../runs/shared/child-identity.ts";
+import { CURRENT_WORK_PROJECTION_KIND, CURRENT_WORK_PROJECTION_VERSION } from "../api/current-work.ts";
+import { buildCurrentWorkProjection, type CurrentWorkKeyState } from "./current-work.ts";
 
 export const SUBAGENT_RPC_PROTOCOL_VERSION = 1;
 export const SUBAGENT_RPC_REQUEST_EVENT = "subagents:rpc:v1:request";
@@ -392,6 +394,7 @@ function pingData(ctx: ExtensionContext | null) {
 			status: true,
 			managementActions: [...SUBAGENT_RPC_MANAGEMENT_ACTIONS],
 			fleetStatus: { version: 1 },
+			currentWork: { kind: CURRENT_WORK_PROJECTION_KIND, version: CURRENT_WORK_PROJECTION_VERSION },
 			asyncStatusSnapshot: { kind: ASYNC_STATUS_SNAPSHOT_KIND, version: ASYNC_STATUS_SNAPSHOT_VERSION },
 			asyncSpawn: true,
 			steer: true,
@@ -641,6 +644,7 @@ async function handleRequest(
 	request: SubagentRpcRequestEnvelope,
 	options: RegisterSubagentRpcBridgeOptions,
 	fleetKeys: FleetKeyState,
+	currentWorkKeys: CurrentWorkKeyState,
 ): Promise<unknown> {
 	const ctx = options.getContext();
 	if (request.method === "ping") return pingData(ctx);
@@ -669,6 +673,7 @@ async function handleRequest(
 				sessionId,
 			),
 			asyncSnapshot: buildAsyncStatusSnapshotForState(options.state, sessionId),
+			currentWork: buildCurrentWorkProjection(options.state, sessionId, { keys: currentWorkKeys }),
 		};
 	}
 	if (request.method === "steer") {
@@ -737,11 +742,12 @@ export function registerSubagentRpcBridge(options: RegisterSubagentRpcBridgeOpti
 	dispose: () => void;
 } {
 	const fleetKeys: FleetKeyState = { sessionId: null, next: 0, keys: new Map() };
+	const currentWorkKeys: CurrentWorkKeyState = { sessionId: null, next: 0, keys: new Map() };
 	const unsubscribe = options.events.on(SUBAGENT_RPC_REQUEST_EVENT, async (raw) => {
 		let request: SubagentRpcRequestEnvelope | undefined;
 		try {
 			request = parseRequest(raw);
-			const data = await handleRequest(request, options, fleetKeys);
+			const data = await handleRequest(request, options, fleetKeys, currentWorkKeys);
 			options.events.emit(subagentRpcReplyEvent(request.requestId), {
 				version: SUBAGENT_RPC_PROTOCOL_VERSION,
 				requestId: request.requestId,

--- a/src/runs/foreground/foreground-history.ts
+++ b/src/runs/foreground/foreground-history.ts
@@ -66,6 +66,8 @@ function compactRun(run: ForegroundResumeRun): ForegroundResumeRun | undefined {
 	if (run.children.length === 0 || !run.children.every((child) => isRestorableForegroundStatus(child.status))) return undefined;
 	return {
 		runId: run.runId,
+		...(run.parentWorkflowRunId ? { parentWorkflowRunId: run.parentWorkflowRunId } : {}),
+		...(run.workflowKey ? { workflowKey: run.workflowKey } : {}),
 		mode: run.mode,
 		cwd: run.cwd,
 		sessionId: run.sessionId,
@@ -92,6 +94,8 @@ function isRestorableRun(value: unknown): value is ForegroundResumeRun {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
 	const run = value as Partial<ForegroundResumeRun>;
 	return typeof run.runId === "string" && Boolean(run.runId)
+		&& (run.parentWorkflowRunId === undefined || typeof run.parentWorkflowRunId === "string")
+		&& (run.workflowKey === undefined || typeof run.workflowKey === "string")
 		&& (run.mode === "single" || run.mode === "parallel" || run.mode === "chain")
 		&& typeof run.cwd === "string" && Boolean(run.cwd)
 		&& typeof run.sessionId === "string" && Boolean(run.sessionId)

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -644,12 +644,14 @@ function foregroundChildActivityFromProgress(progress: SingleResult["progress"] 
 	};
 }
 
-function rememberForegroundRun(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; results: SingleResult[] }): void {
+function rememberForegroundRun(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; parentWorkflowRunId?: string; workflowKey?: string; results: SingleResult[] }): void {
 	state.foregroundRuns ??= new Map();
 	const previous = state.foregroundRuns.get(input.runId);
 	const updatedAt = Date.now();
 	state.foregroundRuns.set(input.runId, {
 		runId: input.runId,
+		...(input.parentWorkflowRunId ? { parentWorkflowRunId: input.parentWorkflowRunId } : {}),
+		...(input.workflowKey ? { workflowKey: input.workflowKey } : {}),
 		mode: input.mode,
 		cwd: input.cwd,
 		...(input.sessionId ? { sessionId: input.sessionId } : {}),
@@ -3739,7 +3741,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		usageBudget: usageBudgetState(data.usageBudget, totalCost),
 		...(worktreeHandoff?.reference ? { parallelHandoff: worktreeHandoff.reference } : {}),
 	}));
-	rememberForegroundRun(deps.state, { runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, results: details.results });
+	rememberForegroundRun(deps.state, { runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, ...(params.workflowParentRunId ? { parentWorkflowRunId: params.workflowParentRunId } : {}), ...(params.workflowKey ? { workflowKey: params.workflowKey } : {}), results: details.results });
 
 	const suppressRoutineResultIntercom = shouldSuppressRoutineResultIntercom({ suppressRoutineResultIntercom: params.suppressRoutineResultIntercom, results: [r] });
 	if (!r.detached && !r.interrupted && !suppressRoutineResultIntercom) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1656,6 +1656,10 @@ export interface ForegroundResumeChild {
 
 export interface ForegroundResumeRun {
 	runId: string;
+	/** Workflow shell that owned this run; retained so public projections can exclude it after restart. */
+	parentWorkflowRunId?: string;
+	/** Stable workflow lane key retained with terminal history. */
+	workflowKey?: string;
 	mode: SubagentRunMode;
 	cwd: string;
 	/** Originating parent session. Detached exits can outlive the active session. */

--- a/test/unit/current-work.test.ts
+++ b/test/unit/current-work.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { buildCurrentWorkProjection } from "../../src/extension/current-work.ts";
+import { persistForegroundRunHistory, restoreForegroundRunHistory } from "../../src/runs/foreground/foreground-history.ts";
+
+function makeState(overrides: Record<string, unknown> = {}) {
+	return {
+		baseCwd: "/private/project",
+		currentSessionId: "session-a",
+		asyncJobs: new Map(),
+		fleetJobs: new Map(),
+		foregroundControls: new Map(),
+		foregroundRuns: new Map(),
+		...overrides,
+	} as any;
+}
+
+describe("current-work projection", () => {
+	it("scopes roots to the current native session and gives stable opaque keys", () => {
+		const state = makeState({
+			asyncJobs: new Map(),
+		foregroundRuns: new Map(),
+		foregroundControls: new Map([
+			["live", { runId: "internal-live", sessionId: "session-a", mode: "single", startedAt: 10, updatedAt: 20, currentAgent: "worker", description: "Review safely", currentPath: "/private/project/secret.ts", currentToolArgs: "PRIVATE_ARGS" }],
+			["foreign", { runId: "internal-foreign", sessionId: "session-b", mode: "single", startedAt: 10, updatedAt: 20, currentAgent: "secret" }],
+		]),
+		});
+	const keys = { sessionId: null, next: 0, keys: new Map<string, string>() };
+	const first = buildCurrentWorkProjection(state, "session-a", { keys, generatedAt: 30 });
+	const second = buildCurrentWorkProjection(state, "session-a", { keys, generatedAt: 31 });
+	assert.equal(first.roots.length, 1);
+	assert.equal(first.roots[0]?.agent, "worker");
+	assert.match(first.roots[0]?.key ?? "", /^work-/);
+	assert.equal(first.roots[0]?.key, second.roots[0]?.key);
+	assert.equal(first.roots[0]?.goal, "Review safely");
+	assert.equal(JSON.stringify(first).includes("internal-live"), false);
+	assert.equal(JSON.stringify(first).includes("/private/project"), false);
+	assert.equal(JSON.stringify(first).includes("PRIVATE_ARGS"), false);
+	});
+
+	it("projects lifecycle, activity, tokens, and bounded hierarchy", () => {
+		const state = makeState({ asyncJobs: new Map([
+			["async-internal", {
+				asyncId: "async-internal", sessionId: "session-a", mode: "parallel", status: "running", description: "Inspect", startedAt: 100, updatedAt: 140,
+				totalTokens: { input: 2, output: 3, total: 5 },
+				steps: Array.from({ length: 4 }, (_, index) => ({ agent: `agent-${index}`, label: `role-${index}`, status: "running", startedAt: 110 + index })),
+			}],
+		]) });
+		const projection = buildCurrentWorkProjection(state, "session-a", { maxChildrenPerNode: 2, generatedAt: 150 });
+		const root = projection.roots[0]!;
+		assert.equal(root.state, "running");
+		assert.equal(root.activity, undefined);
+		assert.deepEqual(root.tokens, { input: 2, output: 3, total: 5 });
+		assert.equal(root.children?.length, 2);
+		assert.equal(projection.omitted.children, 2);
+		assert.equal(root.children?.[0]?.role, "role-0");
+	});
+
+	it("excludes workflow roots and workflow-owned children before projection", () => {
+		const state = makeState({
+			foregroundControls: new Map([["workflow", { runId: "wf", sessionId: "session-a", mode: "single", parentWorkflowRunId: "workflow-root", startedAt: 1, updatedAt: 2 }]]),
+			asyncJobs: new Map([["direct", { asyncId: "direct", sessionId: "session-a", mode: "single", status: "running", startedAt: 1, steps: [
+				{ agent: "visible", status: "running", children: [
+					{ id: "nested-direct", agent: "nested-visible", state: "running" },
+					{ id: "nested-workflow", agent: "nested-hidden", state: "running", workflowKey: "workflow-lane" },
+				] },
+				{ agent: "hidden", status: "running", parentWorkflowRunId: "workflow-root" },
+			] }]]),
+		});
+		const projection = buildCurrentWorkProjection(state, "session-a", { generatedAt: 3 });
+		assert.equal(projection.roots.length, 1);
+		assert.equal(projection.roots[0]?.children?.length, 1);
+		assert.equal(projection.roots[0]?.children?.[0]?.agent, "visible");
+		assert.deepEqual(projection.roots[0]?.children?.[0]?.children?.map((child) => child.agent), ["nested-visible"]);
+	});
+
+	it("normalizes pending and detached, preserves foreground attention and terminal history, and omits owned history", () => {
+		const state = makeState({
+			foregroundControls: new Map([["live", { runId: "live", sessionId: "session-a", mode: "single", startedAt: 1, updatedAt: 2, currentAgent: "worker", currentActivityState: "needs_attention", currentTool: "read", currentToolStartedAt: 2, currentToolArgs: "SECRET TOOL INPUT", tokens: 9 }]]),
+			foregroundRuns: new Map([
+				["failed", { runId: "failed", sessionId: "session-a", mode: "single", cwd: "/private", updatedAt: 4, children: [{ index: 0, agent: "f", status: "failed" }]}],
+				["paused", { runId: "paused", sessionId: "session-a", mode: "single", cwd: "/private", updatedAt: 3, children: [{ index: 0, agent: "p", status: "paused" }]}],
+				["complete", { runId: "complete", sessionId: "session-a", mode: "single", cwd: "/private", updatedAt: 3, children: [{ index: 0, agent: "c", status: "completed" }]}],
+				["owned", { runId: "owned", sessionId: "session-a", parentWorkflowRunId: "private", mode: "single", cwd: "/private", updatedAt: 5, children: [{ index: 0, agent: "hidden", status: "completed" }]}],
+			]),
+			asyncJobs: new Map([["pending", { asyncId: "pending", sessionId: "session-a", mode: "chain", status: "pending", startedAt: 1, steps: [{ index: 0, agent: "one", status: "pending" }, { index: 1, agent: "two", status: "detached" }] }]]),
+		});
+		const projection = buildCurrentWorkProjection(state, "session-a", { generatedAt: 6 });
+		const live = projection.roots.find((root) => root.agent === "worker")!;
+		assert.equal(live.activity?.state, "needs_attention");
+		assert.equal(live.activity?.currentTool, "read");
+		assert.deepEqual(live.tokens, { input: 0, output: 0, total: 9 });
+		assert.equal(JSON.stringify(live).includes("SECRET TOOL INPUT"), false);
+		assert.equal(projection.roots.find((root) => root.children?.[0]?.agent === "f")?.state, "failed");
+		assert.equal(projection.roots.find((root) => root.children?.[0]?.agent === "p")?.state, "paused");
+		assert.equal(projection.roots.find((root) => root.children?.[0]?.agent === "c")?.state, "complete");
+		const chain = projection.roots.find((root) => root.mode === "chain")!;
+		assert.equal(chain.state, "queued");
+		assert.equal(chain.children?.[0]?.mode, "single");
+		assert.equal(chain.children?.[1]?.state, "running");
+		assert.equal(JSON.stringify(projection).includes("owned"), false);
+	});
+
+	it("keeps queued and attention-requiring work ahead of newer terminal history under root pressure", () => {
+		const state = makeState({
+			foregroundControls: new Map([["attention", { runId: "attention", sessionId: "session-a", mode: "single", startedAt: 1, updatedAt: 10, currentAgent: "reviewer", currentActivityState: "needs_attention" }]]),
+			asyncJobs: new Map([
+				["queued", { asyncId: "queued", sessionId: "session-a", mode: "single", status: "queued", description: "Queued work", startedAt: 2, updatedAt: 9, agents: ["worker"] }],
+				...Array.from({ length: 4 }, (_, index) => [`terminal-${index}`, { asyncId: `terminal-${index}`, sessionId: "session-a", mode: "single", status: "complete", startedAt: 20 + index, updatedAt: 30 + index, agents: ["done"] }]),
+			]),
+		});
+		const projection = buildCurrentWorkProjection(state, "session-a", { maxRoots: 2, generatedAt: 40 });
+		assert.deepEqual(projection.roots.map((root) => [root.state, root.activity?.state]), [["running", "needs_attention"], ["queued", undefined]]);
+		assert.equal(projection.omitted.roots, 4);
+	});
+
+	it("preserves workflow ownership through foreground history persistence", () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-current-work-history-"));
+		try {
+			const original = makeState({ foregroundRuns: new Map([["owned", {
+				runId: "owned", parentWorkflowRunId: "workflow-private", workflowKey: "lane-private", sessionId: "session-a", mode: "single", cwd: "/private", updatedAt: 5,
+				children: [{ index: 0, agent: "hidden", status: "completed" }],
+			}]]) });
+			persistForegroundRunHistory(original, { resultsDir });
+			const restored = makeState();
+			assert.equal(restoreForegroundRunHistory(restored, { resultsDir, sessionId: "session-a" }), 1);
+			assert.equal(buildCurrentWorkProjection(restored, "session-a", { generatedAt: 6 }).roots.length, 0);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("sanitizes strings and reports byte-bounded omissions", () => {
+		const state = makeState({ foregroundControls: new Map(Array.from({ length: 8 }, (_, index) => [`${index}`, {
+			runId: `internal-${index}`, sessionId: "session-a", mode: "single", startedAt: index, updatedAt: index,
+			description: "goal\u001b[31m" + "x".repeat(500), currentAgent: "agent",
+		}])) });
+		const projection = buildCurrentWorkProjection(state, "session-a", { maxRoots: 2, maxSerializedBytes: 500, generatedAt: 1 });
+		assert.equal(projection.roots.length, 0);
+		assert.equal(projection.omitted.byteLimitExceeded, true);
+		assert.equal(projection.omitted.roots, 8);
+	});
+});

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -115,7 +115,11 @@ test("published extension APIs use supported package entrypoints", async () => {
 		"./pi-args": "./src/api/pi-args.ts",
 		"./shared-types": "./src/api/shared-types.ts",
 		"./project-panes": "./src/api/project-panes.ts",
+		"./current-work": "./src/api/current-work.ts",
 	});
+	const currentWork = await import("pi-subagents/current-work");
+	assert.equal(currentWork.CURRENT_WORK_PROJECTION_KIND, "subagents.current-work");
+	assert.equal(currentWork.CURRENT_WORK_PROJECTION_VERSION, 1);
 	const backgroundWork = await import("pi-subagents/background-work");
 	assert.equal(backgroundWork.BACKGROUND_WORK_PROTOCOL_VERSION, 1);
 	assert.equal(backgroundWork.BACKGROUND_WORK_REGISTRY_KEY, "pi-subagents.background-work.v1");

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -110,6 +110,10 @@ describe("subagent extension RPC bridge", () => {
 			{ version: 1 },
 		);
 		assert.deepEqual(
+			(reply as { data: { capabilities?: { currentWork?: unknown } } }).data.capabilities?.currentWork,
+			{ kind: "subagents.current-work", version: 1 },
+		);
+		assert.deepEqual(
 			(reply as { data: { capabilities?: { asyncStatusSnapshot?: unknown } } }).data.capabilities?.asyncStatusSnapshot,
 			{ kind: "pi-subagents.async-status-snapshot", version: 1 },
 		);
@@ -145,9 +149,13 @@ describe("subagent extension RPC bridge", () => {
 	it("delegates status through the existing executor action", async () => {
 		const events = new FakeEvents();
 		let executedParams: unknown;
+		const state = { currentSessionId: "/sessions/parent.jsonl", foregroundControls: new Map(), asyncJobs: new Map([[
+			"private-run", { asyncId: "private-run", sessionId: "/sessions/parent.jsonl", mode: "single", status: "running", startedAt: 1, agents: ["worker"] },
+		]]) } as any;
 		const bridge = registerSubagentRpcBridge({
 			events,
 			getContext: () => ctx(),
+			state,
 			execute: async (_id, params) => {
 				executedParams = params;
 				return { content: [{ type: "text", text: "Run: abc123" }], details: { mode: "management", results: [] } } as any;
@@ -160,8 +168,13 @@ describe("subagent extension RPC bridge", () => {
 		assert.deepEqual(executedParams, { action: "status", id: "abc123" });
 		assert.equal((reply as { data: { text?: string } }).data.text, "Run: abc123");
 		assert.deepEqual((reply as { data: { fleet?: unknown } }).data.fleet, {
-			version: 1, entries: [], totalActive: 0, topLevelAsyncCapacity: { used: 0, limit: 0 }, omitted: 0,
+			version: 1, entries: [{ key: "fleet-1", agent: "worker", startedAt: 1, tokens: { input: 0, output: 0, total: 0 } }], totalActive: 1, topLevelAsyncCapacity: { used: 0, limit: 0 }, omitted: 0,
 		});
+		const currentWork = (reply as any).data.currentWork;
+		assert.equal(currentWork.kind, "subagents.current-work");
+		assert.equal(currentWork.roots.length, 1);
+		assert.equal(currentWork.roots[0].agent, "worker");
+		assert.equal(JSON.stringify(currentWork).includes("private-run"), false);
 
 		bridge.dispose();
 	});


### PR DESCRIPTION
## Summary
- add a public, bounded `currentWork` v1 status projection for SDK hosts
- cover current-session foreground and async lifecycle, activity, timing, usage, and hierarchy
- exclude workflows and workflow-owned children at the source, including restored foreground history
- export the contract and document the RPC capability

Closes #1404

## Validation
- `npm run typecheck`
- focused current-work/RPC/package/fleet suite: 72 passed
- `git diff --check`
- independent focused review: PASS

## Full-suite note
The full local unit command also exercised unrelated environment-sensitive tests and reported existing agent-discovery, symlink-permission, and acceptance-fixture failures. All tests covering this change and its direct integration surfaces pass.