### PR TITLE
fix: stringify workflow child results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Render workflow child results as useful text when scripts stringify `runs.all` or awaited `runs.run` result objects.
+
 ## [0.55.0] - 2026-08-23
 
 ### Highlights

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -276,6 +276,19 @@ function formatRef(result) {
   return "[" + parts.join("; ") + "]";
 }
 
+function formatChildResultString(result) {
+  const output = typeof result?.output === "string" ? result.output.trim() : "";
+  return output || formatRef(result);
+}
+
+function decorateWorkflowChildResult(result) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return result;
+  Object.defineProperties(result, {
+    toString: { value() { return formatChildResultString(this); }, enumerable: false, configurable: true },
+  });
+  return result;
+}
+
 let runFingerprints = new Map();
 
 function validateRunCall(key, params, label, fingerprints) {
@@ -312,7 +325,8 @@ function validateRunCall(key, params, label, fingerprints) {
 const runs = Object.freeze({
   run(key, params) {
     validateRunCall(key, params, "runs.run", runFingerprints);
-    return hostCall("run", { key, params }, { key, operation: "run" });
+    const launched = runHostCall(key, params, false);
+    return trackRunObservation([{ key, operation: "run", callId: launched.callId }], launched.promise.then(decorateWorkflowChildResult));
   },
   all(items) {
     if (!Array.isArray(items)) throw new Error("runs.all(items) requires an array.");
@@ -329,7 +343,7 @@ const runs = Object.freeze({
     runFingerprints = fingerprints;
     const batch = { id: "batch-" + (++nextCallId), calls };
     const launched = calls.map(({ key, params }) => runHostCall(key, params, true, batch));
-    return trackRunObservation(launched.map(({ key, callId }) => ({ key, operation: "run", callId })), Promise.all(launched.map(({ promise }) => promise)).then((results) => wrapRunsAllResults(results, calls.map(({ key }) => key))));
+    return trackRunObservation(launched.map(({ key, callId }) => ({ key, operation: "run", callId })), Promise.all(launched.map(({ promise }) => promise)).then((results) => wrapRunsAllResults(results.map(decorateWorkflowChildResult), calls.map(({ key }) => key))));
   },
   steer(key, message, options = {}) {
     if (typeof key !== "string" || !runKeyPattern.test(key)) throw new Error("runs.steer has an invalid key.");

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1782,6 +1782,61 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(mockPi.callCount(), 0);
 	});
 
+	it("stringifies workflow child results without object placeholders", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "first report", matchArgIncludes: "Review" });
+		mockPi.onCall({ output: "second report", matchArgIncludes: "Monitor" });
+		const executor = makeExecutor([makeAgent("echo")]);
+
+		const result = await executor.execute(
+			"scripted-workflow-stringified-child-results",
+			{
+				async: false,
+				workflowScript: `
+					const [review, monitor] = await runs.all([
+						{ key: "review", agent: "echo", task: "Review" },
+						{ key: "monitor", agent: "echo", task: "Monitor" }
+					]);
+					return "## Lane 1\\n" + review + "\\n\\n---\\n\\n## Lane 2\\n" + monitor;
+				`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		const text = result.content[0]?.text ?? "";
+		assert.equal(result.isError, undefined, text || "workflow failed");
+		assert.doesNotMatch(text, /\[object Object\]/);
+		assert.match(text, /## Lane 1\nfirst report/);
+		assert.match(text, /## Lane 2\nsecond report/);
+		assert.equal(result.details.workflow?.value, "## Lane 1\nfirst report\n\n---\n\n## Lane 2\nsecond report");
+	});
+
+	it("stringifies awaited workflow child results without object placeholders", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "single report", matchArgIncludes: "Review" });
+		const executor = makeExecutor([makeAgent("echo")]);
+
+		const result = await executor.execute(
+			"scripted-workflow-stringified-single-child-result",
+			{
+				async: false,
+				workflowScript: `
+					const review = await runs.run("review", { agent: "echo", task: "Review" });
+					return "## Lane\\n" + review;
+				`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		const text = result.content[0]?.text ?? "";
+		assert.equal(result.isError, undefined, text || "workflow failed");
+		assert.doesNotMatch(text, /\[object Object\]/);
+		assert.match(text, /## Lane\nsingle report/);
+		assert.equal(result.details.workflow?.value, "## Lane\nsingle report");
+	});
+
 	it("derives workflow child output paths from the workflow output", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "first report", matchArgIncludes: "Review" });
 		mockPi.onCall({ output: "second report", matchArgIncludes: "Monitor" });


### PR DESCRIPTION
Fixes #1402.

This keeps workflow child result stringification local to the WorkflowScript VM. Accidental string concatenation of `runs.all` or awaited `runs.run` results now uses child output text instead of `[object Object]`.

Validation:
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts --test-name-pattern 'stringifies.*object placeholders'`\n- `npm run typecheck`\n- `git diff --check`\n\nFresh review: `backlog-followup-repair-review-20260823.issue1402-followup-review.json` returned OK.
