### PR TITLE
fix: fail closed on interrupted workflow children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Keep checked acceptance compatible with strict workflow child `outputSchema` results. Thanks to [@rtbe](https://github.com/rtbe) for #1406.
 - Use bounded tracked-file mutation evidence for implementation completion guards, including files that were already dirty when the child started. Thanks to [@rtbe](https://github.com/rtbe) for #1407.
 - Add timeout recovery summaries with changed tracked files, active child state, and session/artifact paths. Thanks to [@rtbe](https://github.com/rtbe) for #1409.
+- Fail closed when reviewer runs are interrupted or detached workflow children settle without persisted top-level continuation proof. Thanks to [@rtbe](https://github.com/rtbe) for #1408.
 
 ## [0.55.0] - 2026-08-23
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3894,8 +3894,9 @@ function workflowChildResult(
 		? result.details.results[0].finalOutput
 		: receiptOutput;
 	const detached = result.details.results.some((child) => child.detached);
+	const interrupted = result.details.results.some((child) => child.interrupted);
 	const stopped = result.details.results.some((child) => child.stopped);
-	const ok = result.isError !== true && !detached && !stopped;
+	const ok = result.isError !== true && !detached && !interrupted && !stopped;
 	const artifactPaths = new Set<string>();
 	if (result.details.asyncDir) artifactPaths.add(result.details.asyncDir);
 	if (result.details.parallelHandoff?.path) artifactPaths.add(result.details.parallelHandoff.path);
@@ -3935,6 +3936,7 @@ function workflowChildResult(
 		output,
 		...(!ok ? { error: receiptOutput || output || "Child run failed." } : {}),
 		...(detached ? { detached: true } : {}),
+		...(interrupted ? { interrupted: true } : {}),
 		...(stopped ? { stopped: true } : {}),
 		...(structured.length === 1 ? { structuredOutput: structured[0] } : structured.length > 1 ? { structuredOutput: structured } : {}),
 		...(requestedContext ? { requestedContext } : {}),
@@ -4740,7 +4742,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						} catch (receiptError) {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
-						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.stopped ? { stopped: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(status.error ? { error: status.error } : {}) });
@@ -4780,7 +4782,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						} catch (receiptError) {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
-						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: status.state === "complete", state: status.state, summary: resultSummary, error: status.state === "complete" ? undefined : status.error, stopped: status.stopped, activityState: status.activityState, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.stopped ? { stopped: true } : {}), ...(child.detached && status.state !== "complete" ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: status.state === "complete", state: status.state, summary: resultSummary, error: status.state === "complete" ? undefined : status.error, stopped: status.stopped, activityState: status.activityState, results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.detached && status.state !== "complete" ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(status.error ? { error: status.error } : {}), ...(status.activityState ? { activityState: status.activityState } : {}) });

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -23,13 +23,15 @@ function cloneWorkflowStatus(status: AsyncStatus): AsyncStatus {
 	};
 }
 
-function childSucceeded(result: Pick<SingleResult, "exitCode" | "error">): boolean {
-	return result.exitCode === 0 && !result.error;
+function childSucceeded(result: Pick<SingleResult, "exitCode" | "error" | "interrupted">): boolean {
+	return result.exitCode === 0 && !result.error && !result.interrupted;
 }
+
+const UNSUPPORTED_DETACHED_WORKFLOW_CONTINUATION = "unsupported-continuation: detached workflow child settled, but JavaScript workflow continuation was not persisted. Resume the workflow explicitly instead of treating the completed child as top-level workflow completion.";
 
 export function applyDetachedChildToPausedWorkflow(
 	status: AsyncStatus,
-	input: { childRunId: string; result: Pick<SingleResult, "exitCode" | "error" | "sessionFile">; workflowKey?: string },
+	input: { childRunId: string; result: Pick<SingleResult, "exitCode" | "error" | "interrupted" | "sessionFile">; workflowKey?: string },
 ): AsyncStatus | undefined {
 	if (status.mode !== "workflow" || status.state !== "paused") return undefined;
 	const next = cloneWorkflowStatus(status);
@@ -63,10 +65,11 @@ export function promotePausedWorkflowIfSettled(status: AsyncStatus): AsyncStatus
 	const failed = next.steps.some((candidate) => candidate.status === "failed");
 	const updatedAt = Date.now();
 	next.lastUpdate = updatedAt;
-	next.state = failed ? "failed" : "complete";
+	next.state = "failed";
 	next.endedAt = updatedAt;
 	delete next.activityState;
-	if (!failed) delete next.error;
+	if (failed) return next;
+	next.error = UNSUPPORTED_DETACHED_WORKFLOW_CONTINUATION;
 	return next;
 }
 
@@ -83,6 +86,7 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 				output,
 				outputState: output.trim() ? "present" : "absent",
 				detached: undefined,
+				...(result.interrupted ? { interrupted: true } : {}),
 				...(result.error ? { error: result.error } : {}),
 			};
 		});
@@ -94,6 +98,7 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 		success: step.status === "completed" || step.status === "complete",
 		output: step.runId === childRunId ? output : "",
 		outputState: step.runId === childRunId && output.trim() ? "present" : "absent",
+		...(step.runId === childRunId && result.interrupted ? { interrupted: true } : {}),
 		...(step.error ? { error: step.error } : {}),
 	}));
 }

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -28,6 +28,7 @@ function childSucceeded(result: Pick<SingleResult, "exitCode" | "error" | "inter
 }
 
 const UNSUPPORTED_DETACHED_WORKFLOW_CONTINUATION = "unsupported-continuation: detached workflow child settled, but JavaScript workflow continuation was not persisted. Resume the workflow explicitly instead of treating the completed child as top-level workflow completion.";
+const INTERRUPTED_DETACHED_CHILD = "Interrupted. Waiting for explicit next action.";
 
 export function applyDetachedChildToPausedWorkflow(
 	status: AsyncStatus,
@@ -47,9 +48,11 @@ export function applyDetachedChildToPausedWorkflow(
 	delete step.currentToolStartedAt;
 	if (input.result.sessionFile) step.sessionFile = input.result.sessionFile;
 	if (succeeded) delete step.error;
+	else if (input.result.interrupted) step.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
 	else if (input.result.error) step.error = input.result.error;
 	next.lastUpdate = updatedAt;
 	const promoted = promotePausedWorkflowIfSettled(next);
+	if (promoted?.state === "failed" && input.result.interrupted) promoted.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
 	if (promoted?.state === "failed" && input.result.error) promoted.error = input.result.error;
 	return promoted ?? next;
 }

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -40,6 +40,7 @@ export function applyDetachedChildToPausedWorkflow(
 		?? (input.workflowKey ? next.steps?.find((candidate) => candidate.workflowKey === input.workflowKey) : undefined);
 	if (!step) return undefined;
 	const succeeded = childSucceeded(input.result);
+	const failedSiblingError = next.steps?.find((candidate) => candidate !== step && candidate.status === "failed" && candidate.error)?.error;
 	const updatedAt = Date.now();
 	step.status = succeeded ? "completed" : "failed";
 	step.endedAt = updatedAt;
@@ -52,8 +53,8 @@ export function applyDetachedChildToPausedWorkflow(
 	else if (input.result.error) step.error = input.result.error;
 	next.lastUpdate = updatedAt;
 	const promoted = promotePausedWorkflowIfSettled(next);
-	if (promoted?.state === "failed" && input.result.interrupted) promoted.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
-	if (promoted?.state === "failed" && input.result.error) promoted.error = input.result.error;
+	if (promoted?.state === "failed" && input.result.interrupted && !failedSiblingError) promoted.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
+	else if (promoted?.state === "failed" && input.result.error) promoted.error = input.result.error;
 	return promoted ?? next;
 }
 

--- a/src/runs/shared/agent-contract.ts
+++ b/src/runs/shared/agent-contract.ts
@@ -12,7 +12,7 @@ export function buildExecutionProjection(result: Pick<SingleResult, "exitCode" |
 		return { status: "stopped", success: false, exitCode: result.exitCode, stopped: true, ...(result.error ? { error: result.error } : {}) };
 	}
 	if (result.interrupted) {
-		return { status: "paused", success: true, exitCode: result.exitCode, interrupted: true, ...(result.error ? { error: result.error } : {}) };
+		return { status: "paused", success: false, exitCode: result.exitCode, interrupted: true, ...(result.error ? { error: result.error } : {}) };
 	}
 	const success = result.exitCode === 0 && !result.error && !result.timedOut;
 	return {

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -613,6 +613,7 @@ export interface WorkflowScriptChildResult {
 	output: string;
 	error?: string;
 	detached?: boolean;
+	interrupted?: boolean;
 	structuredOutput?: unknown;
 	requestedContext?: "fresh" | "fork";
 	resolvedContext?: "fresh" | "fork" | "mixed";

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -2777,15 +2777,17 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			if (reconciled.state === "complete" || reconciled.state === "failed") break;
 			await new Promise((resolve) => setTimeout(resolve, 20));
 		}
-		assert.equal(reconciled?.state, "complete", reconciled?.error);
+		assert.equal(reconciled?.state, "failed", reconciled?.error);
+		assert.match(reconciled?.error ?? "", /unsupported-continuation/);
 		assert.equal(reconciled?.activityState, undefined);
 		assert.equal(reconciled?.steps?.[0]?.status, "completed");
 		assert.equal(reconciled?.steps?.[0]?.activityState, undefined);
-		assert.equal(asyncJobs.get(workflowRunId)?.status, "complete");
+		assert.equal(asyncJobs.get(workflowRunId)?.status, "failed");
 
 		persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
-		assert.equal(persistedResult.state, "complete");
+		assert.equal(persistedResult.state, "failed");
 		assert.equal(persistedResult.activityState, undefined);
+		assert.match(persistedResult.error ?? "", /unsupported-continuation/);
 		execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: tempDir });
 		execFileSync("git", ["branch", "-D", branch], { cwd: tempDir, stdio: "ignore" });
 		fs.rmSync(started.details.asyncDir, { recursive: true, force: true });
@@ -2888,7 +2890,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		fs.rmSync(resultPath, { force: true });
 	});
 
-	it("completes a paused async workflow after a detached child finishes while a sibling is aborted", { skip: !createSubagentExecutor ? "executor unavailable" : undefined }, async () => {
+	it("fails closed after a detached child finishes while a sibling is aborted", { skip: !createSubagentExecutor ? "executor unavailable" : undefined }, async () => {
 		mockPi.onCall({
 			matchArgIncludes: "Ask then continue",
 			steps: [
@@ -2958,10 +2960,11 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			if (reconciled.state === "complete" || reconciled.state === "failed") break;
 			await new Promise((resolve) => setTimeout(resolve, 20));
 		}
-		assert.equal(reconciled?.state, "complete", reconciled?.error);
+		assert.equal(reconciled?.state, "failed", reconciled?.error);
+		assert.match(reconciled?.error ?? "", /unsupported-continuation/);
 		assert.equal(reconciled?.steps?.find((step) => step.workflowKey === "detaches")?.status, "completed");
 		assert.equal(reconciled?.steps?.find((step) => step.workflowKey === "slow")?.status, "stopped");
-		assert.equal(asyncJobs.get(workflowRunId)?.status, "complete");
+		assert.equal(asyncJobs.get(workflowRunId)?.status, "failed");
 		fs.rmSync(started.details.asyncDir, { recursive: true, force: true });
 		fs.rmSync(path.join(DIRS.results, `${workflowRunId}.json`), { force: true });
 	});

--- a/test/unit/agent-contract.test.ts
+++ b/test/unit/agent-contract.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildExecutionProjection } from "../../src/runs/shared/agent-contract.ts";
+
+describe("buildExecutionProjection", () => {
+	it("does not mark interrupted runs successful", () => {
+		assert.deepEqual(buildExecutionProjection({ exitCode: 0, interrupted: true }), {
+			status: "paused",
+			success: false,
+			exitCode: 0,
+			interrupted: true,
+		});
+	});
+});

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -62,6 +62,25 @@ describe("applyDetachedChildToPausedWorkflow", () => {
 		assert.equal(next?.steps?.[0]?.error, "Interrupted. Waiting for explicit next action.");
 	});
 
+	it("preserves a sibling failure when a detached child is interrupted", () => {
+		const status = pausedWorkflow("child-1");
+		status.error = "sibling boom";
+		status.steps!.push({
+			agent: "other",
+			workflowKey: "fails",
+			runId: "child-2",
+			status: "failed",
+			error: "sibling boom",
+		});
+		const next = applyDetachedChildToPausedWorkflow(status, {
+			childRunId: "child-1",
+			result: { exitCode: 0, interrupted: true },
+		});
+		assert.equal(next?.state, "failed");
+		assert.equal(next?.error, "sibling boom");
+		assert.equal(next?.steps?.find((step) => step.workflowKey === "detaches")?.error, "Interrupted. Waiting for explicit next action.");
+	});
+
 	it("keeps the workflow paused while another detached child still needs attention", () => {
 		const status = pausedWorkflow("child-1");
 		status.steps!.push({

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -27,14 +27,14 @@ function pausedWorkflow(childRunId: string, extra?: Partial<NonNullable<AsyncSta
 }
 
 describe("applyDetachedChildToPausedWorkflow", () => {
-	it("completes a paused workflow when its detached child succeeds", () => {
+	it("fails closed when a detached child succeeds without persisted workflow continuation", () => {
 		const next = applyDetachedChildToPausedWorkflow(pausedWorkflow("child-1"), {
 			childRunId: "child-1",
 			result: { exitCode: 0, sessionFile: "/tmp/child.jsonl" },
 		});
-		assert.equal(next?.state, "complete");
+		assert.equal(next?.state, "failed");
 		assert.equal(next?.activityState, undefined);
-		assert.equal(next?.error, undefined);
+		assert.match(next?.error ?? "", /unsupported-continuation/);
 		assert.equal(next?.steps?.[0]?.status, "completed");
 		assert.equal(next?.steps?.[0]?.activityState, undefined);
 		assert.equal(next?.steps?.[0]?.sessionFile, "/tmp/child.jsonl");
@@ -81,7 +81,7 @@ describe("applyDetachedChildToPausedWorkflow", () => {
 		}), undefined);
 	});
 
-	it("completes a paused workflow when the matching step already settled", () => {
+	it("fails closed when the matching step already settled", () => {
 		const status = pausedWorkflow("child-1");
 		status.steps![0]!.status = "completed";
 		delete status.steps![0]!.activityState;
@@ -89,11 +89,12 @@ describe("applyDetachedChildToPausedWorkflow", () => {
 			childRunId: "child-1",
 			result: { exitCode: 0, sessionFile: "/tmp/child.jsonl" },
 		});
-		assert.equal(next?.state, "complete");
-		assert.equal(promotePausedWorkflowIfSettled(status)?.state, "complete");
+		assert.equal(next?.state, "failed");
+		assert.match(next?.error ?? "", /unsupported-continuation/);
+		assert.equal(promotePausedWorkflowIfSettled(status)?.state, "failed");
 	});
 
-	it("completes after a detached child settles when an aborted sibling is stopped", () => {
+	it("fails closed after a detached child settles when an aborted sibling is stopped", () => {
 		const status = pausedWorkflow("child-1");
 		status.steps!.push({
 			agent: "other",
@@ -106,7 +107,8 @@ describe("applyDetachedChildToPausedWorkflow", () => {
 			childRunId: "child-1",
 			result: { exitCode: 0 },
 		});
-		assert.equal(next?.state, "complete");
+		assert.equal(next?.state, "failed");
+		assert.match(next?.error ?? "", /unsupported-continuation/);
 		assert.equal(next?.steps?.[1]?.status, "stopped");
 	});
 });
@@ -143,16 +145,17 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			childRunId: "child-1",
 			result: { index: 0, agent: "worker", task: "t", exitCode: 0, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
 		}), true);
-		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; sessionId?: string; workflowReceipt?: { receipt?: { state?: string; entries?: Record<string, { resumability?: { state?: string; reason?: string } }> } } };
-		assert.equal(published.state, "complete");
-		assert.equal(published.success, true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; error?: string; sessionId?: string; workflowReceipt?: { receipt?: { state?: string; entries?: Record<string, { resumability?: { state?: string; reason?: string } }> } } };
+		assert.equal(published.state, "failed");
+		assert.equal(published.success, false);
+		assert.match(published.error ?? "", /unsupported-continuation/);
 		assert.equal(published.sessionId, "session-1");
-		assert.equal(published.workflowReceipt?.receipt?.state, "complete");
+		assert.equal(published.workflowReceipt?.receipt?.state, "failed");
 		assert.equal(published.workflowReceipt?.receipt?.entries?.detaches?.resumability?.state, "not-resumable");
 		assert.match(published.workflowReceipt?.receipt?.entries?.detaches?.resumability?.reason ?? "", /not found|Status file|too short/);
 		const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
 		assert.match(events, /"type":"subagent.workflow.completed"/);
-		assert.match(events, /"state":"complete"/);
+		assert.match(events, /"state":"failed"/);
 	});
 
 	it("publishes detached completion when the workflow receipt is malformed", () => {
@@ -174,9 +177,10 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			result: { index: 0, agent: "worker", task: "t", exitCode: 0, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
 		}), true);
 
-		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; workflowReceipt?: unknown };
-		assert.equal(published.state, "complete");
-		assert.equal(published.success, true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; error?: string; workflowReceipt?: unknown };
+		assert.equal(published.state, "failed");
+		assert.equal(published.success, false);
+		assert.match(published.error ?? "", /unsupported-continuation/);
 		assert.equal(published.workflowReceipt, undefined);
 		const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
 		assert.match(events, /"type":"subagent.workflow.receipt_write_failed"/);
@@ -211,9 +215,10 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			console.error = originalConsoleError;
 		}
 
-		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; workflowReceipt?: unknown; reconciledFromDetachedChild?: string };
-		assert.equal(published.state, "complete");
-		assert.equal(published.success, true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; error?: string; workflowReceipt?: unknown; reconciledFromDetachedChild?: string };
+		assert.equal(published.state, "failed");
+		assert.equal(published.success, false);
+		assert.match(published.error ?? "", /unsupported-continuation/);
 		assert.equal(published.workflowReceipt, undefined);
 		assert.equal(published.reconciledFromDetachedChild, "child-1");
 		assert.equal(emitted?.name, "subagent:async-complete");
@@ -223,9 +228,9 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			source: "async",
 			mode: "workflow",
 			agent: "workflow",
-			success: true,
-			state: "complete",
-			summary: "Workflow completed after detached child child-1 finished.",
+			success: false,
+			state: "failed",
+			summary: "unsupported-continuation: detached workflow child settled, but JavaScript workflow continuation was not persisted. Resume the workflow explicitly instead of treating the completed child as top-level workflow completion.",
 			reconciledFromDetachedChild: "child-1",
 			results: [{ workflowKey: "detaches", agent: "worker", runId: "child-1", success: true, output: "", outputState: "absent" }],
 			sessionId: "session-1",

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -51,6 +51,17 @@ describe("applyDetachedChildToPausedWorkflow", () => {
 		assert.equal(next?.steps?.[0]?.error, "boom");
 	});
 
+	it("replaces stale detach errors when a detached child is interrupted", () => {
+		const next = applyDetachedChildToPausedWorkflow(pausedWorkflow("child-1"), {
+			childRunId: "child-1",
+			result: { exitCode: 0, interrupted: true },
+		});
+		assert.equal(next?.state, "failed");
+		assert.equal(next?.error, "Interrupted. Waiting for explicit next action.");
+		assert.equal(next?.steps?.[0]?.status, "failed");
+		assert.equal(next?.steps?.[0]?.error, "Interrupted. Waiting for explicit next action.");
+	});
+
 	it("keeps the workflow paused while another detached child still needs attention", () => {
 		const status = pausedWorkflow("child-1");
 		status.steps!.push({


### PR DESCRIPTION
Fixes #1403.
Fixes #1408.

This makes interrupted child results non-successful and fails closed when a detached workflow child settles without persisted top-level continuation proof. It does not add broad JavaScript workflow continuation resume.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-detach-reconcile.test.ts test/unit/agent-contract.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts --test-name-pattern 'pauses an async workflow when its child detaches|fails closed after a detached child finishes'`\n- `npm run typecheck`\n- `git diff --check`\n\nFresh review: `backlog-followup-repair-review-20260823.issues1403-1408-followup-review.json` returned OK.\n\nCredit: changelog credits [@rtbe](https://github.com/rtbe) for #1408.
