### PR TITLE
fix: track child mutation evidence on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 - Render workflow child results as useful text when scripts stringify `runs.all` or awaited `runs.run` result objects.
 - Keep checked acceptance compatible with strict workflow child `outputSchema` results. Thanks to [@rtbe](https://github.com/rtbe) for #1406.
+- Use bounded tracked-file mutation evidence for implementation completion guards, including files that were already dirty when the child started. Thanks to [@rtbe](https://github.com/rtbe) for #1407.
+- Add timeout recovery summaries with changed tracked files, active child state, and session/artifact paths. Thanks to [@rtbe](https://github.com/rtbe) for #1409.
 
 ## [0.55.0] - 2026-08-23
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -83,6 +83,7 @@ import { outputEntryFromAsyncResult, resolveOutputReferences } from "../shared/c
 import { createStructuredOutputRuntime, MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
 import { formatProcessSignalError, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
 import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
+import { buildTimeoutRecoverySummary, collectTrackedMutationEvidence, snapshotTrackedMutations } from "../shared/mutation-evidence.ts";
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection } from "../shared/dynamic-fanout.ts";
 import { claimRunFanoutBatch, getRunFanoutBudgetSnapshot } from "../shared/run-fanout-budget.ts";
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent } from "../shared/nested-events.ts";
@@ -229,6 +230,7 @@ interface StepResult {
 	timedOut?: boolean;
 	stopped?: boolean;
 	processSignal?: string | null;
+	timeoutRecovery?: import("../../shared/types.ts").TimeoutRecoverySummary;
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
 	wrapUpRequested?: boolean;
@@ -540,6 +542,9 @@ interface RunPiStreamingResult {
 	processCloseObservedAt?: number;
 	processSignal?: string | null;
 	processTree: ProcessTreeTerminalV1;
+	currentTool?: string;
+	currentToolArgs?: string;
+	currentPath?: string;
 }
 
 function runPiStreaming(
@@ -610,6 +615,9 @@ function runPiStreaming(
 		let observedMutationAttempt = false;
 		let structuredOutputToolInvoked = false;
 		let structuredOutputMessageStartIndex: number | undefined;
+		let currentTool: string | undefined;
+		let currentToolArgs: string | undefined;
+		let currentPath: string | undefined;
 		let toolCount = 0;
 		const childWatchdogConfig = decodeChildWatchdogConfig(env?.[CHILD_WATCHDOG_CONFIG_ENV]);
 		let childWatchdogState: ChildWatchdogStateSnapshot | undefined;
@@ -701,12 +709,18 @@ function runPiStreaming(
 
 			if (event.type === "tool_execution_end") {
 				clearActiveToolTimeout(event);
+				currentTool = undefined;
+				currentToolArgs = undefined;
+				currentPath = undefined;
 				return;
 			}
 
 			if (event.type === "tool_execution_start" && event.toolName) {
 				toolCount += 1;
 				armToolTimeout({ toolCallId: (event as { toolCallId?: unknown }).toolCallId, toolName: event.toolName });
+				currentTool = event.toolName;
+				currentToolArgs = extractToolArgsPreview(event.args ?? {});
+				currentPath = resolveCurrentPath(event.toolName, event.args);
 				if (event.toolName === "structured_output") {
 					structuredOutputToolInvoked = true;
 					structuredOutputMessageStartIndex = messages.length;
@@ -1029,6 +1043,9 @@ function runPiStreaming(
 				processCloseObservedAt,
 				processSignal: signal,
 				processTree,
+				currentTool,
+				currentToolArgs,
+				currentPath,
 			}));
 		});
 
@@ -1507,6 +1524,8 @@ async function runSingleStepInner(
 	let toolBudget = step.toolBudget ? initialToolBudgetState(step.toolBudget) : undefined;
 	let toolBudgetBlocked = false;
 	let actualLaunchContractDigest = step.launchContractDigest;
+	const mutationSnapshot = snapshotTrackedMutations(step.cwd ?? ctx.cwd);
+	let finalMutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, step.cwd ?? ctx.cwd);
 
 	let modelIndex = 0;
 	let startupAttemptIndex = 0;
@@ -1729,6 +1748,8 @@ async function runSingleStepInner(
 			: undefined;
 		const completionGuardEnabled = isAgentContractV1(step.agentContract) ? step.completionGuard === true : step.completionGuard !== false;
 		const completionToolPlan = resolvedTaskToolPlan;
+		const mutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, step.cwd ?? ctx.cwd);
+		finalMutationEvidence = mutationEvidence;
 		const completionGuard = run.exitCode === 0 && !run.error && !structuredError && !hiddenError?.hasError && !emptyOutputError && completionGuardEnabled
 			? evaluateCompletionMutationGuard(omitUndefinedProperties({
 				agent: step.agent,
@@ -1737,15 +1758,18 @@ async function runSingleStepInner(
 				tools: completionToolPlan ? (completionToolPlan.explicitToolAllowlist ? completionToolPlan.effectiveToolAllowlist : undefined) : step.tools,
 				mcpDirectTools: completionToolPlan?.effectiveMcpTools ?? step.mcpDirectTools,
 				toolAvailabilityError,
+				mutationEvidence,
 			}))
 			: undefined;
-		const completionGuardTriggered = completionGuard?.triggered === true && !run.observedMutationAttempt;
+		const mutationAttemptObserved = run.observedMutationAttempt === true || mutationEvidence.attemptedMutation;
+		const completionGuardTriggered = completionGuard?.triggered === true && !mutationAttemptObserved;
 		const completionGuardBlocked = completionGuard?.blocked === true;
 		const fileMutationEffect = completionGuard
 			? {
 				status: completionGuardBlocked ? "blocked" as const : completionGuard.expectedMutation ? completionGuardTriggered ? "missing" as const : "observed" as const : "not-applicable" as const,
 				expected: completionGuard.expectedMutation,
-				attempted: completionGuardBlocked ? false : completionGuard.attemptedMutation || run.observedMutationAttempt === true,
+				attempted: completionGuardBlocked ? false : completionGuard.attemptedMutation || mutationAttemptObserved,
+				evidence: mutationEvidence,
 				...(completionGuardBlocked && completionGuard.message ? { message: completionGuard.message } : {}),
 				...(completionGuardTriggered ? { message: "Subagent completed without making edits for an implementation task." } : {}),
 			}
@@ -1895,6 +1919,21 @@ async function runSingleStepInner(
 		: resolvedOutput.savedPath
 			? "unknown"
 			: finalResult?.outputState ?? "unknown";
+	const timeoutRecovery = finalResult?.timedOut === true || ctx.timeoutSignal?.aborted === true
+		? buildTimeoutRecoverySummary({
+			termination: "timed-out",
+			evidence: finalMutationEvidence,
+			currentTool: finalResult?.currentTool,
+			currentToolArgs: finalResult?.currentToolArgs,
+			currentPath: finalResult?.currentPath,
+			sessionFile: step.sessionFile,
+			transcriptPath: transcriptWriter ? artifactPaths?.transcriptPath : undefined,
+			artifactPaths,
+		})
+		: undefined;
+	if (timeoutRecovery) outputForSummary = outputForSummary.trim()
+		? `${outputForSummary}\n\n${timeoutRecovery.message}`
+		: timeoutRecovery.message;
 	const finalizedOutput = finalizeSingleOutput(omitUndefinedProperties({
 		fullOutput: outputForSummary,
 		outputPath: step.outputPath,
@@ -2006,6 +2045,7 @@ async function runSingleStepInner(
 		timedOut: timedOutAfterAcceptance ? true : finalResult?.timedOut,
 		stopped: stoppedAfterAcceptance ? true : finalResult?.stopped,
 		processSignal: finalResult?.processSignal,
+		timeoutRecovery,
 		turnBudget,
 		turnBudgetExceeded: turnBudgetExceeded || undefined,
 		wrapUpRequested: finalResult?.wrapUpRequested || turnBudget?.outcome === "wrap-up-requested" || turnBudget?.outcome === "termination-deferred" || turnBudgetExceeded || undefined,
@@ -4079,6 +4119,7 @@ async function runSubagent(
 				setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutputPath", singleResult.structuredOutputPath);
 				setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutputSchemaPath", singleResult.structuredOutputSchemaPath);
 				setOptionalProperty(requiredStatusStep(statusPayload, fi), "acceptance", singleResult.acceptance);
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "timeoutRecovery", singleResult.timeoutRecovery);
 				setOptionalProperty(requiredStatusStep(statusPayload, fi), "watchdog", singleResult.watchdog);
 				setOptionalProperty(requiredStatusStep(statusPayload, fi), "capabilityCeiling", singleResult.capabilityCeiling);
 				setOptionalProperty(requiredStatusStep(statusPayload, fi), "capabilityAudit", singleResult.capabilityAudit);
@@ -4094,7 +4135,7 @@ async function runSubagent(
 		}));
 		if (stopped || childStopped) appendTerminalChildStatusEvent(fi, taskEndTime);
 		if (singleResult.exitCode !== 0 && failFast && !childStopped) aborted = true;
-				return stopped || childStopped ? { ...singleResult, output: stopMessage, error: stopMessage, exitCode: 1, interrupted: false, timedOut: false, stopped: true, skipped: false } : timedOut ? { ...singleResult, output: timeoutMessage ?? "Subagent timed out.", error: timeoutMessage ?? "Subagent timed out.", exitCode: 1, interrupted: false, timedOut: true, skipped: false } : { ...singleResult, skipped: false };
+				return stopped || childStopped ? { ...singleResult, output: stopMessage, error: stopMessage, exitCode: 1, interrupted: false, timedOut: false, stopped: true, skipped: false } : timedOut ? { ...singleResult, output: singleResult.output || (timeoutMessage ?? "Subagent timed out."), error: singleResult.error ?? timeoutMessage ?? "Subagent timed out.", exitCode: 1, interrupted: false, timedOut: true, skipped: false } : { ...singleResult, skipped: false };
 			}, globalSemaphore);
 
 			flatIndex += dynamicSteps.length;
@@ -4134,6 +4175,7 @@ async function runSubagent(
 					effects: pr.effects,
 					execution: pr.execution,
 					review: pr.review,
+					timeoutRecovery: pr.timeoutRecovery,
 					structuredOutput: pr.structuredOutput,
 					structuredOutputPath: pr.structuredOutputPath,
 					structuredOutputSchemaPath: pr.structuredOutputSchemaPath,
@@ -4477,6 +4519,7 @@ async function runSubagent(
 						setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutputPath", singleResult.structuredOutputPath);
 						setOptionalProperty(requiredStatusStep(statusPayload, fi), "structuredOutputSchemaPath", singleResult.structuredOutputSchemaPath);
 						setOptionalProperty(requiredStatusStep(statusPayload, fi), "acceptance", singleResult.acceptance);
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "timeoutRecovery", singleResult.timeoutRecovery);
 						setOptionalProperty(requiredStatusStep(statusPayload, fi), "watchdog", singleResult.watchdog);
 						setOptionalProperty(requiredStatusStep(statusPayload, fi), "capabilityCeiling", singleResult.capabilityCeiling);
 						setOptionalProperty(requiredStatusStep(statusPayload, fi), "capabilityAudit", singleResult.capabilityAudit);
@@ -4507,7 +4550,7 @@ async function runSubagent(
 						}
 
 						if (singleResult.exitCode !== 0 && failFast && !childStopped) aborted = true;
-						return stopped || childStopped ? { ...singleResult, output: stopMessage, error: stopMessage, exitCode: 1, interrupted: false, timedOut: false, stopped: true, skipped: false } : timedOut ? { ...singleResult, output: timeoutMessage ?? "Subagent timed out.", error: timeoutMessage ?? "Subagent timed out.", exitCode: 1, interrupted: false, timedOut: true, skipped: false } : { ...singleResult, skipped: false };
+						return stopped || childStopped ? { ...singleResult, output: stopMessage, error: stopMessage, exitCode: 1, interrupted: false, timedOut: false, stopped: true, skipped: false } : timedOut ? { ...singleResult, output: singleResult.output || (timeoutMessage ?? "Subagent timed out."), error: singleResult.error ?? timeoutMessage ?? "Subagent timed out.", exitCode: 1, interrupted: false, timedOut: true, skipped: false } : { ...singleResult, skipped: false };
 					},
 					globalSemaphore,
 				);
@@ -4564,10 +4607,11 @@ async function runSubagent(
 						artifactPaths: pr.artifactPaths,
 						transcriptPath: pr.transcriptPath,
 						transcriptError: pr.transcriptError,
-						effects: pr.effects,
-						execution: pr.execution,
-						review: pr.review,
-						structuredOutput: pr.structuredOutput,
+							effects: pr.effects,
+							execution: pr.execution,
+							review: pr.review,
+							timeoutRecovery: pr.timeoutRecovery,
+							structuredOutput: pr.structuredOutput,
 						structuredOutputPath: pr.structuredOutputPath,
 						structuredOutputSchemaPath: pr.structuredOutputSchemaPath,
 						acceptance: pr.acceptance,
@@ -4787,7 +4831,7 @@ async function runSubagent(
 				launchContractDigest: singleResult.launchContractDigest,
 				launchResolvedExtensions: singleResult.launchResolvedExtensions,
 				runtimeAcknowledgedExtensions: singleResult.runtimeAcknowledgedExtensions,
-				output: stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.output,
+				output: stopped || childStopped ? stopMessage : timedOut ? singleResult.output || (timeoutMessage ?? "Subagent timed out.") : singleResult.output,
 				outputState: singleResult.outputState,
 				error: stopped || childStopped ? stopMessage : timedOut ? (timeoutMessage ?? "Subagent timed out.") : singleResult.error,
 				protocolError: singleResult.protocolError,
@@ -4806,6 +4850,7 @@ async function runSubagent(
 				effects: singleResult.effects,
 				execution: singleResult.execution,
 				review: singleResult.review,
+				timeoutRecovery: singleResult.timeoutRecovery,
 				structuredOutput: singleResult.structuredOutput,
 				structuredOutputPath: singleResult.structuredOutputPath,
 				structuredOutputSchemaPath: singleResult.structuredOutputSchemaPath,
@@ -4892,6 +4937,7 @@ async function runSubagent(
 			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "structuredOutputPath", singleResult.structuredOutputPath);
 			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "structuredOutputSchemaPath", singleResult.structuredOutputSchemaPath);
 			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "acceptance", singleResult.acceptance);
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "timeoutRecovery", singleResult.timeoutRecovery);
 			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "watchdog", singleResult.watchdog);
 			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "capabilityCeiling", singleResult.capabilityCeiling);
 			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "capabilityAudit", singleResult.capabilityAudit);
@@ -5176,6 +5222,7 @@ async function runSubagent(
 				structuredOutputSchemaPath: r.structuredOutputSchemaPath,
 				acceptance: r.acceptance,
 				watchdog: r.watchdog,
+				timeoutRecovery: r.timeoutRecovery,
 				capabilityCeiling: r.capabilityCeiling,
 				capabilityAudit: r.capabilityAudit,
 			})),

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1224,6 +1224,8 @@ interface SingleStepContext {
 	onExternalProcess?: (process: ExternalProcessStatus) => void;
 	onExternalJob?: (status: ExternalJobStatus) => void;
 	skipAcceptance?: () => boolean;
+	/** False when sibling work in the same Git worktree could have caused the tracked diff. */
+	trackedMutationEvidenceForCompletionGuard?: boolean;
 	orcaProgressTab?: OrcaProgressTab;
 }
 
@@ -1750,6 +1752,7 @@ async function runSingleStepInner(
 		const completionToolPlan = resolvedTaskToolPlan;
 		const mutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, step.cwd ?? ctx.cwd);
 		finalMutationEvidence = mutationEvidence;
+		const completionMutationEvidence = ctx.trackedMutationEvidenceForCompletionGuard === false ? undefined : mutationEvidence;
 		const completionGuard = run.exitCode === 0 && !run.error && !structuredError && !hiddenError?.hasError && !emptyOutputError && completionGuardEnabled
 			? evaluateCompletionMutationGuard(omitUndefinedProperties({
 				agent: step.agent,
@@ -1758,10 +1761,10 @@ async function runSingleStepInner(
 				tools: completionToolPlan ? (completionToolPlan.explicitToolAllowlist ? completionToolPlan.effectiveToolAllowlist : undefined) : step.tools,
 				mcpDirectTools: completionToolPlan?.effectiveMcpTools ?? step.mcpDirectTools,
 				toolAvailabilityError,
-				mutationEvidence,
+				mutationEvidence: completionMutationEvidence,
 			}))
 			: undefined;
-		const mutationAttemptObserved = run.observedMutationAttempt === true || mutationEvidence.attemptedMutation;
+		const mutationAttemptObserved = run.observedMutationAttempt === true || completionMutationEvidence?.attemptedMutation === true;
 		const completionGuardTriggered = completionGuard?.triggered === true && !mutationAttemptObserved;
 		const completionGuardBlocked = completionGuard?.blocked === true;
 		const fileMutationEffect = completionGuard
@@ -1769,7 +1772,7 @@ async function runSingleStepInner(
 				status: completionGuardBlocked ? "blocked" as const : completionGuard.expectedMutation ? completionGuardTriggered ? "missing" as const : "observed" as const : "not-applicable" as const,
 				expected: completionGuard.expectedMutation,
 				attempted: completionGuardBlocked ? false : completionGuard.attemptedMutation || mutationAttemptObserved,
-				evidence: mutationEvidence,
+				...(completionMutationEvidence ? { evidence: completionMutationEvidence } : {}),
 				...(completionGuardBlocked && completionGuard.message ? { message: completionGuard.message } : {}),
 				...(completionGuardTriggered ? { message: "Subagent completed without making edits for an implementation task." } : {}),
 			}
@@ -4060,6 +4063,7 @@ async function runSubagent(
 					registerTurnBudgetAbort: (abort) => registerStepTurnBudgetAbort(fi, abort),
 					timeoutSignal: timeoutAbortController.signal,
 					stopSignal: stopAbortController.signal,
+					trackedMutationEvidenceForCompletionGuard: false,
 					timeoutMessage,
 					stopMessage,
 					turnBudget: config.turnBudget,
@@ -4455,6 +4459,7 @@ async function runSubagent(
 							registerTurnBudgetAbort: (abort) => registerStepTurnBudgetAbort(fi, abort),
 							timeoutSignal: timeoutAbortController.signal,
 							stopSignal: stopAbortController.signal,
+							trackedMutationEvidenceForCompletionGuard: Boolean(worktreeSetup),
 							timeoutMessage,
 							stopMessage,
 							turnBudget: config.turnBudget,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -70,6 +70,7 @@ import { assertThinkingWithinCeiling, decodeThinkingCeiling, intersectThinkingCe
 import { MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
 import { formatProcessSignalError, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
 import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
+import { buildTimeoutRecoverySummary, collectTrackedMutationEvidence, snapshotTrackedMutations } from "../shared/mutation-evidence.ts";
 import { captureSingleOutputSnapshot, extractChildWrittenOutput, finalizeSingleOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
 import {
 	buildModelCandidates,
@@ -524,6 +525,7 @@ async function runSingleAttempt(
 		return result;
 	}
 	const spawnEnv = { ...process.env, ...sharedEnv, ...getSubagentDepthEnv(options.maxSubagentDepth) };
+	const mutationSnapshot = snapshotTrackedMutations(options.cwd ?? runtimeCwd);
 	let observedMutationAttempt = false;
 	let structuredOutputToolInvoked = false;
 	let structuredOutputMessageStartIndex: number | undefined;
@@ -1488,6 +1490,7 @@ async function runSingleAttempt(
 		tokens: progress.tokens,
 		durationMs: progress.durationMs,
 	};
+	const mutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, options.cwd ?? runtimeCwd);
 
 	const acceptanceOutput = getFinalOutput(result.messages ?? []);
 	let fullOutput = stripAcceptanceReport(acceptanceOutput);
@@ -1495,9 +1498,19 @@ async function runSingleAttempt(
 	result.outputState = fullOutput.trim() || result.structuredOutput !== undefined ? "present" : "absent";
 	if (result.timedOut) {
 		const timeoutMessage = formatTimeoutMessage(options.timeoutMs ?? 0);
+		result.timeoutRecovery = buildTimeoutRecoverySummary({
+			termination: "timed-out",
+			evidence: mutationEvidence,
+			currentTool: progress.currentTool,
+			currentToolArgs: progress.currentToolArgs,
+			currentPath: progress.currentPath,
+			sessionFile: options.sessionFile,
+			transcriptPath: shared.transcriptWriter ? shared.artifactPaths?.transcriptPath : undefined,
+			artifactPaths: shared.artifactPaths,
+		});
 		fullOutput = fullOutput.trim()
-			? `${timeoutMessage}\n\nPartial output before timeout:\n${fullOutput}`
-			: timeoutMessage;
+			? `${timeoutMessage}\n\n${result.timeoutRecovery.message}\n\nPartial output before timeout:\n${fullOutput}`
+			: `${timeoutMessage}\n\n${result.timeoutRecovery.message}`;
 	} else if (result.turnBudgetExceeded && result.turnBudget) {
 		fullOutput = formatTurnBudgetOutput(turnBudgetExceededMessage(result.turnBudget, result.turnBudget.turnCount), fullOutput);
 	} else if (result.turnBudget?.outcome === "termination-deferred") {
@@ -1516,9 +1529,11 @@ async function runSingleAttempt(
 			tools: contractTools,
 			mcpDirectTools: toolPlan.effectiveMcpTools,
 			toolAvailabilityError,
+			mutationEvidence,
 		})
 		: undefined;
-	let completionGuardTriggered = completionGuard?.triggered === true && !observedMutationAttempt;
+	const mutationAttemptObserved = observedMutationAttempt || mutationEvidence.attemptedMutation;
+	let completionGuardTriggered = completionGuard?.triggered === true && !mutationAttemptObserved;
 	const completionGuardBlocked = completionGuard?.blocked === true;
 	// The classifier is deliberately narrow, so a read-only review task can
 	// still be misread as implementation. Arbitrate BEFORE any failure side
@@ -1550,7 +1565,8 @@ async function runSingleAttempt(
 							: "observed"
 					: "not-applicable",
 				expected: completionGuard.expectedMutation,
-				attempted: completionGuardBlocked ? false : completionGuard.attemptedMutation || observedMutationAttempt,
+				attempted: completionGuardBlocked ? false : completionGuard.attemptedMutation || mutationAttemptObserved,
+				evidence: mutationEvidence,
 				...(completionGuardBlocked && completionGuard.message ? { message: completionGuard.message } : {}),
 				...(completionGuardTriggered ? { message: "Subagent completed without making edits for an implementation task." } : {}),
 				...(arbiterRescued ? { resolvedBy: "llm-intent-arbiter" } : {}),

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -1,5 +1,5 @@
 import type { Message } from "@earendil-works/pi-ai";
-import type { AcceptanceRole } from "../../shared/types.ts";
+import type { AcceptanceRole, TrackedMutationEvidence } from "../../shared/types.ts";
 import { isMutatingTool } from "./long-running-guard.ts";
 import { classifyTaskMutationIntent, expectsImplementationMutation, taskMayMutate } from "./task-intent.ts";
 
@@ -48,6 +48,7 @@ interface CompletionMutationGuardInput {
 	tools?: string[];
 	mcpDirectTools?: string[];
 	toolAvailabilityError?: string;
+	mutationEvidence?: TrackedMutationEvidence;
 }
 
 interface CompletionMutationGuardResult {
@@ -238,7 +239,7 @@ export function evaluateCompletionMutationGuard(input: CompletionMutationGuardIn
 	const expectedMutation = hasMutationToolCapability(input.tools, input.mcpDirectTools)
 		? expectsImplementationMutation(input.agent, input.task)
 		: false;
-	const attemptedMutation = hasMutationToolCall(input.messages);
+	const attemptedMutation = hasMutationToolCall(input.messages) || input.mutationEvidence?.attemptedMutation === true;
 	const noEditChallengeComplete = isImplementationChallengeTask(input.task)
 		&& reportsNoBetterChallengeChange(input.messages);
 	return {

--- a/src/runs/shared/mutation-evidence.ts
+++ b/src/runs/shared/mutation-evidence.ts
@@ -1,0 +1,124 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import type { ArtifactPaths, TimeoutRecoverySummary, TrackedMutationEvidence, TrackedMutationSnapshot } from "../../shared/types.ts";
+
+const MAX_TRACKED_PATHS = 500;
+const MAX_HASH_BYTES = 1024 * 1024;
+const MAX_TIMEOUT_FILES = 20;
+
+interface FileFingerprint {
+	kind: "diff" | "oversize";
+	digest?: string;
+}
+
+function gitOutput(cwd: string, args: string[], maxBuffer = MAX_HASH_BYTES): string {
+	return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], maxBuffer });
+}
+
+function splitNul(output: string): string[] {
+	return output.split("\0").filter((part) => part.length > 0);
+}
+
+function listChangedTrackedFiles(cwd: string): { paths: string[]; truncated: boolean } {
+	const paths = splitNul(gitOutput(cwd, ["diff", "--no-ext-diff", "--name-only", "-z", "HEAD", "--"], MAX_HASH_BYTES));
+	return { paths: paths.slice(0, MAX_TRACKED_PATHS), truncated: paths.length > MAX_TRACKED_PATHS };
+}
+
+function fingerprintPath(cwd: string, relativePath: string): FileFingerprint {
+	try {
+		const diff = gitOutput(cwd, ["diff", "--no-ext-diff", "--binary", "HEAD", "--", relativePath], MAX_HASH_BYTES);
+		return { kind: "diff", digest: createHash("sha256").update(diff).digest("hex") };
+	} catch {
+		return { kind: "oversize" };
+	}
+}
+
+function sameFingerprint(left: FileFingerprint | undefined, right: FileFingerprint): boolean {
+	return left?.kind === right.kind
+		&& left.digest === right.digest;
+}
+
+export function snapshotTrackedMutations(cwd: string): TrackedMutationSnapshot {
+	try {
+		const changed = listChangedTrackedFiles(cwd);
+		const fingerprints: Record<string, FileFingerprint> = {};
+		for (const file of changed.paths) fingerprints[file] = fingerprintPath(cwd, file);
+		return { source: "tracked-files", trackedOnly: true, cwd, dirtyFiles: changed.paths, fingerprints, truncated: changed.truncated };
+	} catch (error) {
+		return { source: "tracked-files", trackedOnly: true, cwd, dirtyFiles: [], fingerprints: {}, unavailable: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+export function collectTrackedMutationEvidence(snapshot: TrackedMutationSnapshot, cwd = snapshot.cwd): TrackedMutationEvidence {
+	if (snapshot.unavailable) {
+		return { source: "tracked-files", trackedOnly: true, changedFiles: [], attemptedMutation: false, unavailable: snapshot.unavailable };
+	}
+	try {
+		const current = listChangedTrackedFiles(cwd);
+		const startDirty = new Set(snapshot.dirtyFiles);
+		const candidates = new Set([...snapshot.dirtyFiles, ...current.paths]);
+		const changedFiles: string[] = [];
+		for (const file of candidates) {
+			if (!startDirty.has(file)) {
+				if (!snapshot.truncated) changedFiles.push(file);
+				continue;
+			}
+			if (!sameFingerprint(snapshot.fingerprints[file] as FileFingerprint | undefined, fingerprintPath(cwd, file))) changedFiles.push(file);
+		}
+		changedFiles.sort();
+		return {
+			source: "tracked-files",
+			trackedOnly: true,
+			changedFiles,
+			attemptedMutation: changedFiles.length > 0,
+			truncated: snapshot.truncated || current.truncated || undefined,
+		};
+	} catch (error) {
+		return { source: "tracked-files", trackedOnly: true, changedFiles: [], attemptedMutation: false, unavailable: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function formatPathList(paths: string[]): string {
+	if (paths.length === 0) return "none";
+	const shown = paths.slice(0, MAX_TIMEOUT_FILES).join(", ");
+	return paths.length > MAX_TIMEOUT_FILES ? `${shown}, ... (${paths.length - MAX_TIMEOUT_FILES} more)` : shown;
+}
+
+export function buildTimeoutRecoverySummary(input: {
+	termination: "timed-out" | "stopped";
+	evidence: TrackedMutationEvidence;
+	currentTool?: string;
+	currentToolArgs?: string;
+	currentPath?: string;
+	sessionFile?: string;
+	transcriptPath?: string;
+	artifactPaths?: ArtifactPaths;
+}): TimeoutRecoverySummary {
+	const warning = "Inspect partial changes before retrying or resuming the child.";
+	const changedFiles = input.evidence.changedFiles.slice(0, MAX_TIMEOUT_FILES);
+	const lines = [
+		"Recovery summary:",
+		`- termination: ${input.termination}`,
+		`- changed tracked files: ${input.evidence.unavailable ? `unavailable (${input.evidence.unavailable})` : formatPathList(input.evidence.changedFiles)}`,
+	];
+	if (input.currentTool) lines.push(`- active tool: ${input.currentTool}${input.currentToolArgs ? ` — ${input.currentToolArgs}` : ""}`);
+	if (input.currentPath) lines.push(`- active path: ${input.currentPath}`);
+	if (input.sessionFile) lines.push(`- session file: ${input.sessionFile}`);
+	if (input.transcriptPath) lines.push(`- transcript: ${input.transcriptPath}`);
+	if (input.artifactPaths?.outputPath) lines.push(`- output artifact: ${input.artifactPaths.outputPath}`);
+	if (input.artifactPaths?.metadataPath) lines.push(`- metadata artifact: ${input.artifactPaths.metadataPath}`);
+	lines.push(`Warning: ${warning}`);
+	return {
+		termination: input.termination,
+		changedFiles,
+		truncated: input.evidence.changedFiles.length > changedFiles.length || input.evidence.truncated || undefined,
+		currentTool: input.currentTool,
+		currentToolArgs: input.currentToolArgs,
+		currentPath: input.currentPath,
+		sessionFile: input.sessionFile,
+		transcriptPath: input.transcriptPath,
+		artifactPaths: input.artifactPaths,
+		warning,
+		message: lines.join("\n"),
+	};
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -348,10 +348,45 @@ export interface FileMutationEffect {
 	attempted: boolean;
 	message?: string;
 	resolvedBy?: "llm-intent-arbiter";
+	evidence?: TrackedMutationEvidence;
 }
 
 export interface EffectsProjection {
 	fileMutation?: FileMutationEffect;
+}
+
+export interface TrackedMutationSnapshot {
+	source: "tracked-files";
+	trackedOnly: true;
+	cwd: string;
+	gitRoot?: string;
+	dirtyFiles: string[];
+	fingerprints: Record<string, unknown>;
+	truncated?: boolean;
+	unavailable?: string;
+}
+
+export interface TrackedMutationEvidence {
+	source: "tracked-files";
+	trackedOnly: true;
+	changedFiles: string[];
+	attemptedMutation: boolean;
+	truncated?: boolean;
+	unavailable?: string;
+}
+
+export interface TimeoutRecoverySummary {
+	termination: "timed-out" | "stopped";
+	changedFiles: string[];
+	truncated?: boolean;
+	currentTool?: string;
+	currentToolArgs?: string;
+	currentPath?: string;
+	sessionFile?: string;
+	transcriptPath?: string;
+	artifactPaths?: ArtifactPaths;
+	warning: string;
+	message: string;
 }
 
 export const SUBAGENT_LIFECYCLE_ARTIFACT_VERSION = 3;
@@ -941,6 +976,7 @@ export interface SingleResult {
 	context?: "fresh" | "fork";
 	exitCode: number;
 	processSignal?: string | null;
+	timeoutRecovery?: TimeoutRecoverySummary;
 	detached?: boolean;
 	detachedReason?: string;
 	interrupted?: boolean;
@@ -1505,6 +1541,7 @@ export interface AsyncStatus {
 		durationMs?: number;
 		exitCode?: number | null;
 		timedOut?: boolean;
+		timeoutRecovery?: TimeoutRecoverySummary;
 		stopped?: boolean;
 		turnBudget?: TurnBudgetState;
 		turnBudgetExceeded?: boolean;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -80,7 +80,7 @@ interface AsyncResultPayload {
 	totalTokens?: { input: number; output: number; total: number };
 	totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
 	usageBudget?: UsageBudgetState;
-	results: Array<{ agent?: string; launchContractDigest?: string; launchResolvedExtensions?: LaunchResolvedExtensions; runtimeAcknowledgedExtensions?: RuntimeAcknowledgedExtensions; output?: string; outputState?: "present" | "absent" | "unknown"; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean; message?: string } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string; transcriptPath?: string }; outputSaveError?: string; metadataSaveError?: string; capabilityCeiling?: { version?: number; allowedTools?: string[]; denyExtensions?: boolean; sources?: string[] }; capabilityAudit?: { effectiveTools?: string[]; removedTools?: string[]; extensionsDenied?: boolean } }>;
+	results: Array<{ agent?: string; launchContractDigest?: string; launchResolvedExtensions?: LaunchResolvedExtensions; runtimeAcknowledgedExtensions?: RuntimeAcknowledgedExtensions; output?: string; outputState?: "present" | "absent" | "unknown"; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; timeoutRecovery?: { changedFiles?: string[]; message?: string; warning?: string }; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean; message?: string } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string; transcriptPath?: string }; outputSaveError?: string; metadataSaveError?: string; capabilityCeiling?: { version?: number; allowedTools?: string[]; denyExtensions?: boolean; sources?: string[] }; capabilityAudit?: { effectiveTools?: string[]; removedTools?: string[]; extensionsDenied?: boolean } }>;
 	outputs?: Record<string, { text?: string; structured?: unknown }>;
 	workflowGraph?: { nodes?: Array<{ kind?: string; label?: string; phase?: string; status?: string; acceptanceStatus?: string; error?: string; outputName?: string; structured?: boolean; children?: Array<{ label?: string; outputName?: string; itemKey?: string; status?: string; acceptanceStatus?: string; error?: string }> }> };
 	parallelHandoff?: { version?: number; path?: string; groupCount?: number; childCount?: number; changedPatches?: number; cleanupState?: string };
@@ -126,6 +126,7 @@ interface AsyncStatusPayload {
 		status?: string;
 		exitCode?: number;
 		timedOut?: boolean;
+		timeoutRecovery?: { changedFiles?: string[]; message?: string; warning?: string };
 		error?: string;
 		model?: string;
 		thinking?: string;
@@ -1326,50 +1327,59 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	it("marks async parallel runs that exceed timeoutMs as timed out", { skip: !isAsyncAvailable() ? "jiti not available" : process.platform === "win32" ? "timeout signal delivery intermittent on Windows CI" : undefined }, async () => {
 		mockPi.onCall({ delay: 5_000, output: "one done" });
 		mockPi.onCall({ delay: 5_000, output: "two done" });
-		const id = `async-timeout-parallel-${Date.now().toString(36)}`;
-		executeAsyncChain(id, {
-			chain: [{
-				parallel: [
-					{ agent: "one", task: "Wait" },
-					{ agent: "two", task: "Wait" },
-				],
-				concurrency: 2,
-			}],
-			resultMode: "parallel",
-			agents: [makeAgent("one"), makeAgent("two")],
-			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
-			artifactConfig: {
-				enabled: false,
-				includeInput: false,
-				includeOutput: false,
-				includeJsonl: false,
-				includeMetadata: false,
-				cleanupDays: 7,
-			},
-			shareEnabled: false,
-			maxSubagentDepth: 2,
-			timeoutMs: 1_500,
-		});
+		const repo = createRepo("pi-subagents-parallel-timeout-recovery-");
+		try {
+			const id = `async-timeout-parallel-${Date.now().toString(36)}`;
+			executeAsyncChain(id, {
+				chain: [{
+					parallel: [
+						{ agent: "one", task: "Wait" },
+						{ agent: "two", task: "Wait" },
+					],
+					concurrency: 2,
+				}],
+				resultMode: "parallel",
+				agents: [makeAgent("one"), makeAgent("two")],
+				ctx: { pi: { events: { emit() {} } }, cwd: repo, currentSessionId: "session-1" },
+				artifactConfig: {
+					enabled: false,
+					includeInput: false,
+					includeOutput: false,
+					includeJsonl: false,
+					includeMetadata: false,
+					cleanupDays: 7,
+				},
+				shareEnabled: false,
+				maxSubagentDepth: 2,
+				timeoutMs: 1_500,
+			});
 
-		await waitForMockPiCall(mockPi, 1, 10_000);
-		const resultPath = await waitForAsyncResultFile(id, 8_000);
-		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
-		const status = await waitForAsyncState(id, (candidate) => candidate.state === "failed");
-		assert.equal(payload.state, "failed");
-		assert.equal(payload.success, false);
-		assert.equal(payload.exitCode, 1);
-		assert.equal(payload.timeoutMs, 1_500);
-		assert.equal(payload.timedOut, true);
-		assert.match(payload.summary ?? "", /Subagent timed out after 1500ms\./);
-		assert.equal(status.state, "failed");
-		assert.equal(status.timeoutMs, 1_500);
-		assert.equal(status.timedOut, true);
-		assert.match(status.error ?? "", /Subagent timed out after 1500ms\./);
-		assert.deepEqual(status.steps?.map((step) => step.status), ["failed", "failed"]);
-		assert.deepEqual(status.steps?.map((step) => step.timedOut), [true, true]);
-		assert.deepEqual(status.steps?.map((step) => step.error), ["Subagent timed out after 1500ms.", "Subagent timed out after 1500ms."]);
-		assert.deepEqual(payload.results.map((result) => result.timedOut), [true, true]);
-		assert.equal(mockPi.callCount(), 2);
+			await waitForMockPiCall(mockPi, 1, 10_000);
+			fs.writeFileSync(path.join(repo, "input.md"), "parallel partial child change\n", "utf-8");
+			const resultPath = await waitForAsyncResultFile(id, 8_000);
+			const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+			const status = await waitForAsyncState(id, (candidate) => candidate.state === "failed");
+			assert.equal(payload.state, "failed");
+			assert.equal(payload.success, false);
+			assert.equal(payload.exitCode, 1);
+			assert.equal(payload.timeoutMs, 1_500);
+			assert.equal(payload.timedOut, true);
+			assert.match(payload.summary ?? "", /Subagent timed out after 1500ms\./);
+			assert.equal(status.state, "failed");
+			assert.equal(status.timeoutMs, 1_500);
+			assert.equal(status.timedOut, true);
+			assert.match(status.error ?? "", /Subagent timed out after 1500ms\./);
+			assert.deepEqual(status.steps?.map((step) => step.status), ["failed", "failed"]);
+			assert.deepEqual(status.steps?.map((step) => step.timedOut), [true, true]);
+			assert.deepEqual(status.steps?.map((step) => step.error), ["Subagent timed out after 1500ms.", "Subagent timed out after 1500ms."]);
+			assert.deepEqual(status.steps?.map((step) => step.timeoutRecovery?.changedFiles), [["input.md"], ["input.md"]]);
+			assert.deepEqual(payload.results.map((result) => result.timedOut), [true, true]);
+			assert.deepEqual(payload.results.map((result) => result.timeoutRecovery?.changedFiles), [["input.md"], ["input.md"]]);
+			assert.ok(payload.results.every((result) => /Recovery summary:/.test(result.output ?? "")));
+			assert.equal(mockPi.callCount(), 2);
+		} finally {
+			fs.rmSync(repo, { recursive: true, force: true });
+		}
 	});
 
 	it("enforces an agent-level timeout on an async serial child without a composite deadline", { skip: !isAsyncAvailable() ? "jiti not available" : process.platform === "win32" ? "timeout signal delivery intermittent on Windows CI" : undefined }, async () => {
@@ -1396,6 +1406,44 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.state, "failed");
 		assert.equal(payload.results[0]?.timedOut, true);
 		assert.equal(payload.results[0]?.error, "Subagent timed out after 150ms.");
+	});
+
+	it("preserves async timeout recovery summaries in final results", { skip: !isAsyncAvailable() ? "jiti not available" : process.platform === "win32" ? "timeout signal delivery intermittent on Windows CI" : undefined }, async () => {
+		mockPi.onCall({ delay: 5_000, output: "too late" });
+		const repo = createRepo("pi-subagents-timeout-recovery-");
+		try {
+			const id = `async-timeout-recovery-${Date.now().toString(36)}`;
+			executeAsyncChain(id, {
+				chain: [{ agent: "slow", task: "Wait" }],
+				agents: [makeAgent("slow")],
+				ctx: { pi: { events: { emit() {} } }, cwd: repo, currentSessionId: "session-1" },
+				artifactConfig: {
+					enabled: true,
+					includeInput: false,
+					includeOutput: true,
+					includeJsonl: true,
+					includeMetadata: true,
+					cleanupDays: 7,
+				},
+				shareEnabled: false,
+				maxSubagentDepth: 2,
+				timeoutMs: 1200,
+			});
+
+			await waitForMockPiCall(mockPi, 0, 10_000);
+			fs.writeFileSync(path.join(repo, "input.md"), "partial child change\n", "utf-8");
+			const payload = await readAsyncPayload(id);
+			const status = await waitForAsyncState(id, (candidate) => candidate.state === "failed");
+			const result = payload.results[0];
+			assert.equal(result?.timedOut, true);
+			assert.deepEqual(result?.timeoutRecovery?.changedFiles, ["input.md"]);
+			assert.match(result?.timeoutRecovery?.message ?? "", /changed tracked files: input\.md/);
+			assert.match(result?.output ?? "", /Recovery summary:/);
+			assert.match(result?.output ?? "", /Warning: Inspect partial changes before retrying/);
+			assert.deepEqual(status.steps?.[0]?.timeoutRecovery?.changedFiles, ["input.md"]);
+		} finally {
+			fs.rmSync(repo, { recursive: true, force: true });
+		}
 	});
 
 	it("kills a wedged tool at the per-tool timeout with a tool-specific error before the run-level timeout", { skip: !isAsyncAvailable() ? "jiti not available" : process.platform === "win32" ? "timeout signal delivery intermittent on Windows CI" : undefined }, async () => {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -3708,6 +3708,52 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.doesNotMatch(eventsText, /Interrupt:/);
 	});
 
+	it("does not use shared-cwd sibling tracked edits as parallel completion-guard proof", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			matchArgIncludes: "Edit tracked file",
+			delay: 50,
+			writeFiles: [{ path: "input.md", content: "changed by first sibling\n" }],
+			jsonl: [
+				...events.completedWrite("input.md", "changed by first sibling\n"),
+				events.assistantMessage("Implemented first sibling change."),
+			],
+		});
+		mockPi.onCall({
+			matchArgIncludes: "Implement second sibling change",
+			delay: 500,
+			output: "Implemented second sibling change.",
+		});
+		const repo = createRepo("pi-subagents-shared-cwd-mutation-guard-");
+		try {
+			const id = `async-parallel-shared-cwd-mutation-${Date.now().toString(36)}`;
+			executeAsyncChain(id, {
+				chain: [{
+					parallel: [
+						{ agent: "first", task: "Edit tracked file" },
+						{ agent: "second", task: "Implement second sibling change" },
+					],
+					concurrency: 2,
+				}],
+				resultMode: "parallel",
+				agents: [makeAgent("first"), makeAgent("second")],
+				ctx: { pi: { events: { emit() {} } }, cwd: repo, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false,
+				maxSubagentDepth: 2,
+			});
+
+			const payload = await readAsyncPayload(id);
+			assert.equal(payload.results[0]?.success, true);
+			assert.equal(payload.results[0]?.effects?.fileMutation?.status, "observed");
+			assert.equal(payload.results[1]?.success, false);
+			assert.equal(payload.results[1]?.effects?.fileMutation?.status, "missing");
+			assert.equal(payload.results[1]?.effects?.fileMutation?.attempted, false);
+			assert.match(payload.results[1]?.error ?? "", /completed without making edits/);
+		} finally {
+			fs.rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
 	it("background implementation challenges keep explicit no-change reports successful", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ output: [
 			"Kept the current implementation. No new code or test changes were made in this challenge pass.",

--- a/test/unit/mutation-evidence.test.ts
+++ b/test/unit/mutation-evidence.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildTimeoutRecoverySummary, collectTrackedMutationEvidence, snapshotTrackedMutations } from "../../src/runs/shared/mutation-evidence.ts";
+import { evaluateCompletionMutationGuard } from "../../src/runs/shared/completion-guard.ts";
+
+function git(cwd: string, args: string[]): void {
+	execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function withRepo(run: (repo: string) => void): void {
+	const repo = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-mutation-evidence-"));
+	try {
+		git(repo, ["init"]);
+		git(repo, ["config", "user.email", "test@example.com"]);
+		git(repo, ["config", "user.name", "Test User"]);
+		fs.writeFileSync(path.join(repo, "tracked.txt"), "base\n", "utf-8");
+		git(repo, ["add", "tracked.txt"]);
+		git(repo, ["commit", "-m", "base"]);
+		run(repo);
+	} finally {
+		fs.rmSync(repo, { recursive: true, force: true });
+	}
+}
+
+describe("tracked mutation evidence", () => {
+	it("detects edits to a tracked file that was already dirty at child start", () => {
+		withRepo((repo) => {
+			fs.writeFileSync(path.join(repo, "tracked.txt"), "dirty before child\n", "utf-8");
+			const snapshot = snapshotTrackedMutations(repo);
+
+			fs.writeFileSync(path.join(repo, "tracked.txt"), "dirty after child\n", "utf-8");
+			fs.writeFileSync(path.join(repo, "untracked.txt"), "ignored by evidence\n", "utf-8");
+			const evidence = collectTrackedMutationEvidence(snapshot, repo);
+
+			assert.equal(evidence.attemptedMutation, true);
+			assert.deepEqual(evidence.changedFiles, ["tracked.txt"]);
+		});
+	});
+
+	it("detects a child reverting a tracked file that was dirty at child start", () => {
+		withRepo((repo) => {
+			fs.writeFileSync(path.join(repo, "tracked.txt"), "dirty before child\n", "utf-8");
+			const snapshot = snapshotTrackedMutations(repo);
+
+			fs.writeFileSync(path.join(repo, "tracked.txt"), "base\n", "utf-8");
+			const evidence = collectTrackedMutationEvidence(snapshot, repo);
+
+			assert.equal(evidence.attemptedMutation, true);
+			assert.deepEqual(evidence.changedFiles, ["tracked.txt"]);
+		});
+	});
+
+	it("detects staged edits to a tracked file that was already staged dirty at child start", () => {
+		withRepo((repo) => {
+			fs.writeFileSync(path.join(repo, "tracked.txt"), "staged before child\n", "utf-8");
+			git(repo, ["add", "tracked.txt"]);
+			const snapshot = snapshotTrackedMutations(repo);
+
+			fs.writeFileSync(path.join(repo, "tracked.txt"), "staged after child\n", "utf-8");
+			git(repo, ["add", "tracked.txt"]);
+			const evidence = collectTrackedMutationEvidence(snapshot, repo);
+
+			assert.equal(evidence.attemptedMutation, true);
+			assert.deepEqual(evidence.changedFiles, ["tracked.txt"]);
+		});
+	});
+
+	it("uses tracked evidence as completion guard mutation proof", () => {
+		const guard = evaluateCompletionMutationGuard({
+			agent: "worker",
+			task: "Implement the requested fix.",
+			messages: [{ role: "assistant", content: [{ type: "text", text: "Implemented." }] }],
+			tools: ["edit"],
+			mutationEvidence: {
+				source: "tracked-files",
+				trackedOnly: true,
+				changedFiles: ["tracked.txt"],
+				attemptedMutation: true,
+			},
+		});
+
+		assert.equal(guard.expectedMutation, true);
+		assert.equal(guard.attemptedMutation, true);
+		assert.equal(guard.triggered, false);
+	});
+
+	it("formats bounded timeout recovery data", () => {
+		const summary = buildTimeoutRecoverySummary({
+			termination: "timed-out",
+			evidence: {
+				source: "tracked-files",
+				trackedOnly: true,
+				changedFiles: ["tracked.txt"],
+				attemptedMutation: true,
+			},
+			currentTool: "edit",
+			currentPath: "tracked.txt",
+			sessionFile: "session.jsonl",
+		});
+
+		assert.deepEqual(summary.changedFiles, ["tracked.txt"]);
+		assert.match(summary.message, /termination: timed-out/);
+		assert.match(summary.message, /changed tracked files: tracked\.txt/);
+		assert.match(summary.message, /active tool: edit/);
+	});
+});


### PR DESCRIPTION
Fixes #1407.
Fixes #1409.

This records bounded git-tracked mutation evidence for child runs, uses it in completion guards, and carries timeout recovery summaries through foreground and async results. The evidence intentionally stays limited to tracked files.

Validation:
- `node --import ./test/support/ts-loader.mjs --test test/unit/mutation-evidence.test.ts`
- `node --import ./test/support/ts-loader.mjs --test --test-name-pattern 'timeout recovery|parallel runs that exceed' test/integration/async-execution.test.ts`\n- `npm run typecheck`\n- `git diff --check`\n\nFresh review: `backlog-final-followups-20260823.issues1407-1409-parallel-timeout-review.json` returned no issues.\n\nCredit: changelog credits [@rtbe](https://github.com/rtbe) for #1407 and #1409.
