### PR TITLE
fix: observe chained workflow child launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Use bounded tracked-file mutation evidence for implementation completion guards, including files that were already dirty when the child started. Thanks to [@rtbe](https://github.com/rtbe) for #1407.
 - Add timeout recovery summaries with changed tracked files, active child state, and session/artifact paths. Thanks to [@rtbe](https://github.com/rtbe) for #1409.
 - Fail closed when reviewer runs are interrupted or detached workflow children settle without persisted top-level continuation proof. Thanks to [@rtbe](https://github.com/rtbe) for #1408.
+- Stop flagging awaited `.then()` workflow chains as unawaited when a handler returns another child launch.
 
 ## [0.55.0] - 2026-08-23
 

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -150,7 +150,15 @@ function trackObservationTracker(tracker, promise, allowFutureObservations = fal
     get(promiseTarget, prop) {
       if (prop === "then") return function promiseThen(onFulfilled, onRejected) {
         consumeTrackedObservations(tracker);
-        return trackObservationTracker({ observations: tracker.observations, consumed: false, dependencies: [tracker] }, promiseTarget.then(onFulfilled, onRejected), true);
+        const chainTracker = { observations: tracker.observations, consumed: false, dependencies: [tracker] };
+        const wrapHandler = (handler) => typeof handler === "function"
+          ? function trackedThenHandler(...args) {
+            const value = handler.apply(this, args);
+            addTrackerDependency(chainTracker, promiseObservationTracker(value));
+            return trackedPromiseTarget(value);
+          }
+          : handler;
+        return trackObservationTracker(chainTracker, promiseTarget.then(wrapHandler(onFulfilled), wrapHandler(onRejected)), true);
       };
       if (prop === "catch") return function promiseCatch(onRejected) {
         consumeTrackedObservations(tracker);

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -933,6 +933,27 @@ describe("scripted workflow runtime", () => {
 		assert.equal(result.value, "helper all output");
 	});
 
+	it("accepts awaited Promise.all over then chains that return child launches", async () => {
+		const result = await runWorkflowScript({
+			script: `
+				function patchLane(key) {
+					return runs.run(key + "-writer", { agent: "worker", task: "write " + key })
+						.then((writer) => runs.run(key + "-review", { agent: "reviewer", task: "review " + writer.output }));
+				}
+				const reviews = await Promise.all([patchLane("alpha"), patchLane("beta")]);
+				return reviews.map((review) => review.key);
+			`,
+			timeoutMs: 2_000,
+			async launch(key, params) {
+				if (key.endsWith("-review")) assert.match(String(params.task), /review .* writer output/);
+				return { key, ok: true, output: key + " writer output", artifactPaths: [] };
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.deepEqual(result.value, ["alpha-review", "beta-review"]);
+		assert.deepEqual(result.children.map((child) => child.key), ["alpha-writer", "beta-writer", "alpha-review", "beta-review"]);
+	});
+
 	it("accepts awaited and returned handlers on portable plain helper wrappers", async () => {
 		const handlers = [
 			{ name: "then", chain: "then((value) => value)" },


### PR DESCRIPTION
Fixes #1418.

This keeps workflow child launch observation intact when an awaited `.then()` chain returns another `runs.run(...)` launch. It also keeps true fire-and-forget child launches rejected.

Validation:
- `node --experimental-strip-types --test --test-name-pattern 'accepts awaited Promise.all over then chains that return child launches|rejects fire-and-forget callbacks on a runs.run promise|rejects detached promise handlers after an await|rejects an unawaited native Promise.all over runs.run|accepts an awaited native Promise combinator over launches' test/unit/scripted-workflow.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review: `reports/issue-1418-workflow-observation-review.md` returned OK.
