### PR TITLE
test: retry Windows shared-cwd cleanup

### DIFF
--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -3750,7 +3750,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			assert.equal(payload.results[1]?.effects?.fileMutation?.attempted, false);
 			assert.match(payload.results[1]?.error ?? "", /completed without making edits/);
 		} finally {
-			fs.rmSync(repo, { recursive: true, force: true });
+			fs.rmSync(repo, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 		}
 	});
 


### PR DESCRIPTION
Fixes the Windows post-merge CI cleanup failure seen on main after #1413.

The failed test had already completed its assertions. Windows returned `EPERM` while removing the temporary project directory. This adds the same bounded retry cleanup options used by nearby tests.

Validation:
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'does not use shared-cwd sibling tracked edits as parallel completion-guard proof' test/integration/async-execution.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review: `reports/main-ci-windows-cleanup-review.md` found no blockers.
