### PR TITLE
fix: preserve variant model ids during verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add timeout recovery summaries with changed tracked files, active child state, and session/artifact paths. Thanks to [@rtbe](https://github.com/rtbe) for #1409.
 - Fail closed when reviewer runs are interrupted or detached workflow children settle without persisted top-level continuation proof. Thanks to [@rtbe](https://github.com/rtbe) for #1408.
 - Stop flagging awaited `.then()` workflow chains as unawaited when a handler returns another child launch.
+- Preserve variant-tagged model ids during verification and fallback exclusion parsing. Thanks to [@rafafortes](https://github.com/rafafortes) for #1420.
 
 ## [0.55.0] - 2026-08-23
 

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { splitKnownThinkingSuffix } from "../../shared/model-info.ts";
 import { TEMP_ROOT_DIR } from "../../shared/types.ts";
 
 export const EXCLUSIONS_PATH_ENV = "PI_MODEL_EXCLUSIONS_PATH";
@@ -194,7 +195,7 @@ export function getExcludedCount(): number {
  * {@link recordModelFailure} is later recognised by the candidate filter.
  */
 export function parseModelKey(fullId: string): { provider?: string; modelId: string } {
-	const base = fullId.includes(":") ? fullId.substring(0, fullId.lastIndexOf(":")) : fullId;
+	const base = splitKnownThinkingSuffix(fullId).baseModel;
 	if (!base.includes("/")) return { modelId: base };
 	const slash = base.indexOf("/");
 	return { provider: base.slice(0, slash), modelId: base.slice(slash + 1) };

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -1,4 +1,4 @@
-import type { ModelInfo as AvailableModelInfo } from "../../shared/model-info.ts";
+import { splitKnownThinkingSuffix, type ModelInfo as AvailableModelInfo } from "../../shared/model-info.ts";
 import type { Usage } from "../../shared/types.ts";
 import { filterFallbackCandidates, parseModelKey, recordModelFailure } from "./model-exclusions.ts";
 import { checkModelScope, type ModelScopeCheckRule, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
@@ -14,12 +14,7 @@ interface ModelAttemptSummary {
 }
 
 export function splitThinkingSuffix(model: string): { baseModel: string; thinkingSuffix: string } {
-	const colonIdx = model.lastIndexOf(":");
-	if (colonIdx === -1) return { baseModel: model, thinkingSuffix: "" };
-	return {
-		baseModel: model.substring(0, colonIdx),
-		thinkingSuffix: model.substring(colonIdx),
-	};
+	return splitKnownThinkingSuffix(model);
 }
 
 export function formatSubagentModelVerificationError(expectedModel: string, observedModel: string, availableModels: AvailableModelInfo[] | undefined): string | undefined {

--- a/test/unit/model-exclusions.test.ts
+++ b/test/unit/model-exclusions.test.ts
@@ -80,6 +80,13 @@ describe("model exclusions — parseModelKey", () => {
 		assert.deepEqual(parseModelKey("openai/gpt-5:high"), { provider: "openai", modelId: "gpt-5" });
 	});
 
+	it("preserves variant tags before stripping a known thinking suffix", () => {
+		assert.deepEqual(parseModelKey("ollama-cloud/deepseek-v4-flash:0731:high"), {
+			provider: "ollama-cloud",
+			modelId: "deepseek-v4-flash:0731",
+		});
+	});
+
 	it("keeps slashes inside the modelId", () => {
 		assert.deepEqual(parseModelKey("openrouter/google/gemini-flash"), {
 			provider: "openrouter",

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -42,6 +42,17 @@ describe("model fallback helpers", () => {
 		);
 	});
 
+	it("preserves variant tags when verifying provider-qualified model ids", () => {
+		assert.equal(
+			formatSubagentModelVerificationError(
+				"ollama-cloud/deepseek-v4-flash:0731:high",
+				"deepseek-v4-flash:0731",
+				[{ provider: "ollama-cloud", id: "deepseek-v4-flash:0731", fullId: "ollama-cloud/deepseek-v4-flash:0731" }],
+			),
+			undefined,
+		);
+	});
+
 	it("resolves unique owner/name ids when the owner is not a registered provider", () => {
 		const registry = [
 			...availableModels,


### PR DESCRIPTION
Fixes #1420.

This uses the shared known-thinking-suffix parser for model verification and exclusion keys. Variant tags such as `:0731` stay part of the model id, while real Pi thinking suffixes such as `:high` still strip normally.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts test/unit/model-exclusions.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review: `reports/issue-1420-model-verification-review.md` found no blockers.

Thanks to [@rafafortes](https://github.com/rafafortes) for the reproduction and root-cause analysis in #1420.
