### PR TITLE
test: wait for async runner terminal event

### DIFF
--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -3795,9 +3795,10 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			output: "Implemented second sibling change.",
 		});
 		const repo = createRepo("pi-subagents-shared-cwd-mutation-guard-");
+		const id = `async-parallel-shared-cwd-mutation-${Date.now().toString(36)}`;
+		let runnerStarted = false;
 		try {
-			const id = `async-parallel-shared-cwd-mutation-${Date.now().toString(36)}`;
-			executeAsyncChain(id, {
+			const launch = executeAsyncChain(id, {
 				chain: [{
 					parallel: [
 						{ agent: "first", task: "Edit tracked file" },
@@ -3812,6 +3813,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 				shareEnabled: false,
 				maxSubagentDepth: 2,
 			});
+			runnerStarted = !launch.isError;
 
 			const payload = await readAsyncPayload(id);
 			assert.equal(payload.results[0]?.success, true);
@@ -3821,6 +3823,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			assert.equal(payload.results[1]?.effects?.fileMutation?.attempted, false);
 			assert.match(payload.results[1]?.error ?? "", /completed without making edits/);
 		} finally {
+			if (runnerStarted) await waitForAsyncEvent(id, "subagent.run.process_terminal");
 			fs.rmSync(repo, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 		}
 	});


### PR DESCRIPTION
Fixes the repeated Windows cleanup race from the #1424 post-merge main CI run.

The failing test was deleting a temporary repo after the async result file was ready. On Windows, the detached runner can still hold that repo as its `cwd` until the runner close path records `subagent.run.process_terminal`.

This is test-harness only. It waits for that lifecycle event in `finally` before deleting the temp repo. It does not change product result timing and does not add more retry time.

Validation:
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts --test-name-pattern 'does not use shared-cwd sibling tracked edits as parallel completion-guard proof'`
- `npm run typecheck`
- `git diff --check`

Fresh review: no issues found.