### PR TITLE
fix: bind launch provenance and mutation evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Render workflow child results as useful text when scripts stringify `runs.all` or awaited `runs.run` result objects.
+- Bind fast mode into launch contract provenance and keep oversize tracked mutation evidence fail-closed.
 - Keep checked acceptance compatible with strict workflow child `outputSchema` results. Thanks to [@rtbe](https://github.com/rtbe) for #1406.
 - Use bounded tracked-file mutation evidence for implementation completion guards, including files that were already dirty when the child started. Thanks to [@rtbe](https://github.com/rtbe) for #1407.
 - Add timeout recovery summaries with changed tracked files, active child state, and session/artifact paths. Thanks to [@rtbe](https://github.com/rtbe) for #1409.

--- a/docs/models.md
+++ b/docs/models.md
@@ -62,7 +62,7 @@ For a persistent role override with a backup model for provider failures:
 
 ## Fast mode
 
-Set `fast: true` on a run or in agent frontmatter to request the OpenAI priority service tier for supported native OpenAI-Codex children. This can use a higher quota tier or cost more. It is off by default.
+Set `fast: true` on a run, in agent frontmatter, or in `subagents.agentOverrides.<name>.fast` to request the OpenAI priority service tier for supported native OpenAI-Codex children. This can use a higher quota tier or cost more. It is off by default.
 
 Fast mode fails before launch unless every resolved model candidate is on the allowlist. The current allowlist is `openai-codex/gpt-5.6-luna` and `openai-codex/gpt-5.6-sol`. External runners, Anthropic models, and other providers do not use fast mode.
 

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -55,6 +55,7 @@ export interface SubagentLaunchContractInput {
 	agentScope?: AgentScope;
 	context?: "fresh" | "fork";
 	model?: string;
+	fast?: boolean;
 	thinking?: string | false;
 	thinkingCeiling?: ThinkingLevel;
 	inheritedThinkingCeiling?: ThinkingLevel;
@@ -325,6 +326,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 	}
 	let toolPlan: PiLaunchToolPlan;
 	const permissionRules = resolvePermissionRules(loadConfig().permissions, agent.permissions);
+	const fast = input.fast ?? agent.fast;
 	try {
 		toolPlan = resolvePiLaunchToolPlan({
 			tools: agent.tools,
@@ -334,6 +336,9 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 			cwd: effectiveCwd,
 			requireReadTool: resolvedSkills.resolved.length > 0,
 			structuredOutput: Boolean(input.outputSchema),
+			fast,
+			model,
+			modelCandidates,
 			capabilityCeiling: effectiveCapabilityCeiling,
 			agentName: agent.name,
 			permissionRules,
@@ -445,6 +450,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 			definitionDigest,
 			...(model ? { model } : {}),
 			modelCandidates,
+			...(fast !== undefined ? { fast } : {}),
 			...(resolveEffectiveThinking(model, effectiveThinkingConfig) ? { thinking: resolveEffectiveThinking(model, effectiveThinkingConfig) } : {}),
 			systemPrompt: effectiveSystemPrompt,
 			systemPromptMode: agent.systemPromptMode,

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -1595,6 +1595,7 @@ export function executeAsyncSingle(
 		task,
 		...(model ? { model } : {}),
 		modelCandidates,
+		...((params.fast ?? agentConfig.fast) !== undefined ? { fast: params.fast ?? agentConfig.fast } : {}),
 		...(resolveEffectiveThinking(model, effectiveThinking) ? { thinking: resolveEffectiveThinking(model, effectiveThinking) } : {}),
 		...(thinkingCeiling ? { thinkingCeiling } : {}),
 		systemPrompt: effectiveSystemPrompt,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1645,6 +1645,7 @@ async function runSingleStepInner(
 				task: step.launchBindingTask ?? task,
 				...(candidate ? { model: candidate } : {}),
 				modelCandidates: candidates as string[],
+				...(step.fast !== undefined ? { fast: step.fast } : {}),
 				...(resolveEffectiveThinking(candidate, step.thinking) ? { thinking: resolveEffectiveThinking(candidate, step.thinking) } : {}),
 				...(step.thinkingCeiling ? { thinkingCeiling: step.thinkingCeiling } : {}),
 				systemPrompt: appendTurnBudgetSystemPrompt(step.systemPrompt ?? "", ctx.turnBudget),

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -439,6 +439,7 @@ async function runSingleAttempt(
 		task: shared.originalTask ?? task,
 		...(modelArg ? { model: modelArg } : {}),
 		modelCandidates: shared.modelCandidates,
+		...((options.fast ?? agent.fast) !== undefined ? { fast: options.fast ?? agent.fast } : {}),
 		...(resolvedThinking ? { thinking: resolvedThinking } : {}),
 		...(options.thinkingCeiling ? { thinkingCeiling: options.thinkingCeiling } : {}),
 		systemPrompt: effectiveSystemPrompt,

--- a/src/runs/shared/mutation-evidence.ts
+++ b/src/runs/shared/mutation-evidence.ts
@@ -1,15 +1,13 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import type { ArtifactPaths, TimeoutRecoverySummary, TrackedMutationEvidence, TrackedMutationSnapshot } from "../../shared/types.ts";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ArtifactPaths, TimeoutRecoverySummary, TrackedMutationEvidence, TrackedMutationFingerprint, TrackedMutationSnapshot } from "../../shared/types.ts";
 
 const MAX_TRACKED_PATHS = 500;
 const MAX_HASH_BYTES = 1024 * 1024;
 const MAX_TIMEOUT_FILES = 20;
-
-interface FileFingerprint {
-	kind: "diff" | "oversize";
-	digest?: string;
-}
 
 function gitOutput(cwd: string, args: string[], maxBuffer = MAX_HASH_BYTES): string {
 	return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], maxBuffer });
@@ -19,29 +17,52 @@ function splitNul(output: string): string[] {
 	return output.split("\0").filter((part) => part.length > 0);
 }
 
+function hashLargeDiff(cwd: string, relativePath: string): string {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tracked-diff-"));
+	const diffPath = path.join(tempDir, "diff.patch");
+	try {
+		execFileSync("git", ["diff", "--no-ext-diff", "--binary", `--output=${diffPath}`, "HEAD", "--", relativePath], { cwd, stdio: "ignore" });
+		const hash = createHash("sha256");
+		const buffer = Buffer.allocUnsafe(64 * 1024);
+		const fd = fs.openSync(diffPath, "r");
+		try {
+			for (;;) {
+				const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+				if (bytesRead === 0) break;
+				hash.update(buffer.subarray(0, bytesRead));
+			}
+		} finally {
+			fs.closeSync(fd);
+		}
+		return hash.digest("hex");
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
 function listChangedTrackedFiles(cwd: string): { paths: string[]; truncated: boolean } {
 	const paths = splitNul(gitOutput(cwd, ["diff", "--no-ext-diff", "--name-only", "-z", "HEAD", "--"], MAX_HASH_BYTES));
 	return { paths: paths.slice(0, MAX_TRACKED_PATHS), truncated: paths.length > MAX_TRACKED_PATHS };
 }
 
-function fingerprintPath(cwd: string, relativePath: string): FileFingerprint {
+function fingerprintPath(cwd: string, relativePath: string): TrackedMutationFingerprint {
 	try {
 		const diff = gitOutput(cwd, ["diff", "--no-ext-diff", "--binary", "HEAD", "--", relativePath], MAX_HASH_BYTES);
 		return { kind: "diff", digest: createHash("sha256").update(diff).digest("hex") };
 	} catch {
-		return { kind: "oversize" };
+		return { kind: "diff", digest: hashLargeDiff(cwd, relativePath) };
 	}
 }
 
-function sameFingerprint(left: FileFingerprint | undefined, right: FileFingerprint): boolean {
-	return left?.kind === right.kind
-		&& left.digest === right.digest;
+function sameFingerprint(left: TrackedMutationFingerprint | undefined, right: TrackedMutationFingerprint): boolean {
+	if (!left || left.kind !== "diff" || right.kind !== "diff") return false;
+	return left.digest === right.digest;
 }
 
 export function snapshotTrackedMutations(cwd: string): TrackedMutationSnapshot {
 	try {
 		const changed = listChangedTrackedFiles(cwd);
-		const fingerprints: Record<string, FileFingerprint> = {};
+		const fingerprints: Record<string, TrackedMutationFingerprint> = {};
 		for (const file of changed.paths) fingerprints[file] = fingerprintPath(cwd, file);
 		return { source: "tracked-files", trackedOnly: true, cwd, dirtyFiles: changed.paths, fingerprints, truncated: changed.truncated };
 	} catch (error) {
@@ -63,7 +84,7 @@ export function collectTrackedMutationEvidence(snapshot: TrackedMutationSnapshot
 				if (!snapshot.truncated) changedFiles.push(file);
 				continue;
 			}
-			if (!sameFingerprint(snapshot.fingerprints[file] as FileFingerprint | undefined, fingerprintPath(cwd, file))) changedFiles.push(file);
+			if (!sameFingerprint(snapshot.fingerprints[file], fingerprintPath(cwd, file))) changedFiles.push(file);
 		}
 		changedFiles.sort();
 		return {

--- a/src/runs/shared/structured-output.ts
+++ b/src/runs/shared/structured-output.ts
@@ -180,7 +180,7 @@ export async function readStructuredOutput(runtime: StructuredOutputRuntime): Pr
 export function readStructuredOutputAcceptanceReport(runtime: StructuredOutputRuntime): { value?: unknown; error?: string } {
 	if (!runtime.acceptanceReportPath || !fs.existsSync(runtime.acceptanceReportPath)) return {};
 	try {
-		return { value: JSON.parse(fs.readFileSync(runtime.acceptanceReportPath, "utf-8")) as unknown };
+		return { value: JSON.parse(fs.readFileSync(runtime.acceptanceReportPath, "utf-8")) };
 	} catch (error) {
 		return { error: `Failed to read structured output acceptance report: ${error instanceof Error ? error.message : String(error)}` };
 	}

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -650,7 +650,7 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 			name: "structured_output",
 			label: "Structured Output",
 			description: "Submit the required final structured output for this subagent step. This terminates the step.",
-			parameters: parameters as never,
+			parameters,
 			async execute(_id: string, params: { value: unknown; acceptanceReport?: unknown }) {
 				const validation = await validateStructuredOutputValue(schema, params.value);
 				if (validation.status === "invalid") {

--- a/src/shared/launch-contract.ts
+++ b/src/shared/launch-contract.ts
@@ -47,6 +47,7 @@ export function projectAgentDefinition(agent: AgentConfig): Record<string, unkno
 		model: agent.model,
 		modelProvider: agent.modelProvider,
 		fallbackModels: agent.fallbackModels,
+		fast: agent.fast,
 		thinking: agent.thinking,
 		tools: agent.tools,
 		mcpDirectTools: agent.mcpDirectTools,
@@ -81,6 +82,7 @@ export interface LaunchBindingInput {
 	task?: string;
 	model?: string;
 	modelCandidates?: string[];
+	fast?: boolean;
 	thinking?: string;
 	systemPrompt?: string | null;
 	systemPromptMode?: AgentConfig["systemPromptMode"];
@@ -106,6 +108,7 @@ export function projectLaunchBinding(input: LaunchBindingInput): Record<string, 
 		// The ordered candidate set already contains each attempted model; keeping only
 		// this set makes retries correlate to the same preflight binding.
 		modelCandidates: input.modelCandidates,
+		fast: input.fast,
 		thinking: input.thinking,
 		systemPromptDigest: input.systemPrompt === undefined || input.systemPrompt === null ? undefined : stableJsonDigest(input.systemPrompt),
 		systemPromptMode: input.systemPromptMode,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -362,10 +362,12 @@ export interface TrackedMutationSnapshot {
 	cwd: string;
 	gitRoot?: string;
 	dirtyFiles: string[];
-	fingerprints: Record<string, unknown>;
+	fingerprints: Record<string, TrackedMutationFingerprint>;
 	truncated?: boolean;
 	unavailable?: string;
 }
+
+export type TrackedMutationFingerprint = { kind: "diff"; digest: string };
 
 export interface TrackedMutationEvidence {
 	source: "tracked-files";

--- a/test/unit/extension-bindings.test.ts
+++ b/test/unit/extension-bindings.test.ts
@@ -6,6 +6,7 @@ import {
 	MAX_EXTENSION_BINDING_NAMESPACES,
 	MAX_EXTENSION_BINDINGS_BYTES,
 	PI_SUBAGENT_EXTENSION_BINDINGS_ENV,
+	type ExtensionBindings,
 	normalizeExtensionBindings,
 	omitExtensionBindingsEnv,
 } from "../../src/runs/shared/extension-bindings.ts";
@@ -20,14 +21,15 @@ afterEach(() => {
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
-function childEnv(extensionBindings?: Record<string, unknown>): Record<string, string | undefined> {
+function childEnv(extensionBindings?: ExtensionBindings): Record<string, string | undefined> {
+	const normalizedExtensionBindings = normalizeExtensionBindings(extensionBindings)?.value;
 	const result = buildPiArgs({
 		baseArgs: [],
 		task: "test",
 		sessionEnabled: false,
 		inheritProjectContext: false,
 		inheritSkills: false,
-		extensionBindings: extensionBindings as never,
+		extensionBindings: normalizedExtensionBindings,
 	});
 	if (result.tempDir) tempDirs.push(result.tempDir);
 	return result.env;

--- a/test/unit/mutation-evidence.test.ts
+++ b/test/unit/mutation-evidence.test.ts
@@ -69,6 +69,25 @@ describe("tracked mutation evidence", () => {
 		});
 	});
 
+	it("distinguishes unchanged and changed tracked diffs that exceed the fast buffer", () => {
+		withRepo((repo) => {
+			const largeBefore = `${"before\n".repeat(180_000)}before-tail\n`;
+			const largeAfter = `${"after\n".repeat(180_000)}after-tail\n`;
+			fs.writeFileSync(path.join(repo, "tracked.txt"), largeBefore, "utf-8");
+			const snapshot = snapshotTrackedMutations(repo);
+			const unchangedEvidence = collectTrackedMutationEvidence(snapshot, repo);
+
+			assert.equal(unchangedEvidence.attemptedMutation, false);
+			assert.deepEqual(unchangedEvidence.changedFiles, []);
+
+			fs.writeFileSync(path.join(repo, "tracked.txt"), largeAfter, "utf-8");
+			const evidence = collectTrackedMutationEvidence(snapshot, repo);
+
+			assert.equal(evidence.attemptedMutation, true);
+			assert.deepEqual(evidence.changedFiles, ["tracked.txt"]);
+		});
+	});
+
 	it("uses tracked evidence as completion guard mutation proof", () => {
 		const guard = evaluateCompletionMutationGuard({
 			agent: "worker",

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -170,6 +170,30 @@ Project prompt.
 		if (!invalid.ok) assert.equal(invalid.code, "invalid_extension_bindings");
 	});
 
+	it("binds fast mode runtime extension into public preflight provenance", async () => {
+		const cwd = path.join(tempDir, "fast-repo");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "fast-worker.md"), `---
+name: fast-worker
+description: Fast worker
+model: openai-codex/gpt-5.6-luna
+fast: true
+---
+Worker.
+`);
+		const availableModels = [{ provider: "openai-codex", id: "gpt-5.6-luna", fullId: "openai-codex/gpt-5.6-luna" }];
+		const enabled = await resolveSubagentLaunchContract({ agent: "fast-worker", cwd, task: "Run", availableModels });
+		const disabled = await resolveSubagentLaunchContract({ agent: "fast-worker", cwd, task: "Run", availableModels, fast: false });
+
+		assert.equal(enabled.ok, true);
+		assert.equal(disabled.ok, true);
+		if (enabled.ok && disabled.ok) {
+			assert.ok(enabled.contract.tools.runtimeExtensions.some((entry) => entry.endsWith("fast-mode-extension.ts")));
+			assert.equal(disabled.contract.tools.runtimeExtensions.some((entry) => entry.endsWith("fast-mode-extension.ts")), false);
+			assert.notEqual(enabled.contract.launchContractDigest, disabled.contract.launchContractDigest);
+		}
+	});
+
 	it("enforces maxThinking before a child launch and accepts levels at the ceiling", async () => {
 		const cwd = path.join(tempDir, "thinking-repo");
 		fs.mkdirSync(cwd, { recursive: true });


### PR DESCRIPTION
## Summary

This lands the unreleased deslop fixes from the `v0.55.0..HEAD` pass.

It binds effective `fast` mode into preflight provenance and launch binding digests, keeps oversize tracked mutation evidence fail-closed, removes small type escapes, and documents the `agentOverrides.<name>.fast` setting.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/preflight.test.ts test/unit/mutation-evidence.test.ts test/unit/extension-bindings.test.ts test/unit/scripted-workflow.test.ts`
- `npm run typecheck`
- `git diff --check`
- `git diff --cached --quiet`
- Earlier before commit: `npm run test:unit`
- Earlier before commit: targeted fast/acceptance integration tests
- Earlier before commit: `npx --yes fallow audit --format json --quiet`
- Fresh exact-diff review: no issues found
