### PR TITLE
feat: define external CLI capability contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- External CLI runs now publish code-owned capability limits and compact workflow receipt metadata for adapter identity, artifacts, handoff mode, supervisor support, and resumability.
+
 ## [0.56.0] - 2026-08-23
 
 ### Highlights

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -9,6 +9,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
+import { parseExternalCliCapabilityNarrowing } from "../runs/shared/external-cli-contract.ts";
 import { getAgentDir, getProjectConfigDir } from "../shared/utils.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain, parseJsonChain } from "./chain-serializer.ts";
@@ -1685,7 +1686,8 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") {
 		throw new Error(`Agent '${agentName}' external-cli runner promptDelivery must be 'stdin'.`);
 	}
-	const supported = new Set(["type", "command", "args", "promptDelivery"]);
+	const capabilities = parseExternalCliCapabilityNarrowing(runner.capabilities, `Agent '${agentName}' external-cli runner capabilities`);
+	const supported = new Set(["type", "command", "args", "promptDelivery", "capabilities"]);
 	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
 	if (unknown.length > 0) throw new Error(`Agent '${agentName}' external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
 	const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
@@ -1694,6 +1696,7 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 		command: runner.command.trim(),
 		...(runnerArgs?.length ? { args: runnerArgs } : {}),
 		...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}),
+		...(capabilities ? { capabilities } : {}),
 	};
 }
 

--- a/src/agents/runtime-agent-registry.ts
+++ b/src/agents/runtime-agent-registry.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
+import { parseExternalCliCapabilityNarrowing } from "../runs/shared/external-cli-contract.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import { validatePermissionRules, type PermissionRules } from "../runs/shared/permissions.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
@@ -170,11 +171,12 @@ function validateRunner(value: unknown): AgentRunnerConfig | undefined {
 	if (typeof runner.command !== "string" || !runner.command.trim()) throw new Error("Runtime agent definition external-cli runner requires a non-empty command string.");
 	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) throw new Error("Runtime agent definition external-cli runner args must be an array of strings.");
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") throw new Error("Runtime agent definition external-cli runner promptDelivery must be 'stdin'.");
-	const supported = new Set(["type", "command", "args", "promptDelivery"]);
+	const capabilities = parseExternalCliCapabilityNarrowing(runner.capabilities, "Runtime agent definition external-cli runner capabilities");
+	const supported = new Set(["type", "command", "args", "promptDelivery", "capabilities"]);
 	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
 	if (unknown.length > 0) throw new Error(`Runtime agent definition external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
 	const args = runner.args as string[] | undefined;
-	return { type: "external-cli", command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}) };
+	return { type: "external-cli", command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}), ...(capabilities ? { capabilities } : {}) };
 }
 
 function validateTurnBudget(value: unknown): TurnBudgetConfig | undefined {

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -11,6 +11,7 @@ import { DIRS, type AsyncStatus, type Details, type ForegroundResumeRun, type Ne
 import { inspectActiveAsyncCapacityOwner, type ActiveAsyncCapacityInspection } from "./active-async-capacity.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
+import { normalizeExternalCliRunnerStatus } from "../shared/external-cli-contract.ts";
 import { resolveSubagentResultStatus } from "../../intercom/result-intercom.ts";
 import { readProcessTerminal, sanitizeProcessTerminal } from "./process-terminal.ts";
 import { formatWaitSubscriptions } from "./wait-subscriptions.ts";
@@ -536,7 +537,18 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				const phase = step.phase ? `[${step.phase}] ` : "";
 				lines.push(`${stepLineLabel(status, index)}: ${phase}${display} ${step.status}${modelText}${stepActivityText ? `, ${stepActivityText}` : ""}${steeringSuffix}${acceptanceText}${budgetText}${errorText}`);
 				if (step.runner?.type === "external-cli") {
-					lines.push(`  Runner: external-cli (${step.runner.command}${step.runner.args.length ? ` ${step.runner.args.join(" ")}` : ""})`);
+					const runner = normalizeExternalCliRunnerStatus(step.runner);
+					if (runner) {
+						lines.push(`  Runner: external-cli (${runner.command}${runner.args.length ? ` ${runner.args.join(" ")}` : ""})`);
+						lines.push(`  Adapter: ${runner.adapter.id} v${runner.adapter.version} (${runner.adapter.executionMode})`);
+						lines.push(`  Capabilities: stop=${runner.capabilities.stop}, steer=false, resume=false, structuredOutput=false, toolEvents=false, supervisor=unsupported, forkContext=false, extensionBindings=false`);
+						lines.push(`  Unsupported steer: ${runner.unsupportedReasons.steer}`);
+						lines.push(`  Unsupported resume: ${runner.nonResumableReason}`);
+						lines.push(`  Unsupported supervisor: ${runner.unsupportedReasons.supervisor}`);
+						lines.push(`  Context handoff: fresh only (${runner.unsupportedReasons.forkContext})`);
+					} else {
+						lines.push("  Runner: external-cli (invalid persisted runner metadata)");
+					}
 					if (step.externalProcess?.pid !== undefined) lines.push(`  Process: ${step.externalProcess.pid}`);
 					if (step.externalProcess) lines.push(`  Stdout: ${step.externalProcess.stdoutPath}`, `  Stderr: ${step.externalProcess.stderrPath}`);
 				} else if (step.runner?.type === "external-job") {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -144,6 +144,7 @@ import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
 import { createBoundedByteTail, createBoundedLineReader, formatProtocolOutputLimit, MAX_CHILD_STDERR_BYTES, PI_AGGREGATE_EVENT_PROJECTOR, projectChildLifecycle, type ChildLifecycleAction, type ProtocolOutputLimit } from "../shared/child-protocol.ts";
 import { acquireSessionLease, type SessionLeaseRequest } from "../shared/session-lease.ts";
 import { buildExternalCliPrompt, runExternalCli } from "../shared/external-cli-runner.ts";
+import { resolveExternalCliRunnerStatus } from "../shared/external-cli-contract.ts";
 import { runExternalJob } from "../shared/external-job-runner.ts";
 import { createOrcaProgressTab, type OrcaProgressTab } from "../shared/orca-progress-tabs.ts";
 import { decodeSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
@@ -1381,13 +1382,7 @@ async function runSingleStepInner(
 	transcriptWriter?.writeInitialUserMessage(`${PROMPT_REDACTED}; live Prompt Audit only.`);
 
 	if (step.runner?.type === "external-cli") {
-		const runner: ExternalCliRunnerStatus = {
-			type: "external-cli",
-			command: step.runner.command,
-			args: step.runner.args ?? [],
-			promptDelivery: step.runner.promptDelivery ?? "stdin",
-			capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false },
-		};
+		const runner = resolveExternalCliRunnerStatus(step.runner);
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
 		const external = await runExternalCli(omitUndefinedProperties({
 			command: runner.command,
@@ -2098,13 +2093,7 @@ type RunnerStatusStep = NonNullable<AsyncStatus["steps"]>[number] & {
 
 function externalRunnerStatus(runner: SubagentStep["runner"]): ExternalCliRunnerStatus | ExternalJobRunnerStatus | undefined {
 	if (runner?.type === "external-cli") {
-		return {
-			type: "external-cli",
-			command: runner.command,
-			args: runner.args ?? [],
-			promptDelivery: runner.promptDelivery ?? "stdin",
-			capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false },
-		};
+		return resolveExternalCliRunnerStatus(runner);
 	}
 	if (runner?.type === "external-job") {
 		return {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -113,6 +113,7 @@ import { isStoppableAsyncStatusStep, resolveAsyncStatusChild } from "../shared/c
 import { inspectSubagentStatus } from "../background/run-status.ts";
 import { getExternalJobProvider } from "../../api/external-job-provider.ts";
 import { externalJobFollowUpRequestDigest, externalJobFollowUpRequestId, externalJobFollowUpRunId, externalJobPromptDigest, externalJobStableJson } from "../shared/external-job-runner.ts";
+import { externalCliReceiptMetadata, normalizeExternalCliRunnerStatus } from "../shared/external-cli-contract.ts";
 import { applyForceTopLevelAsyncOverride } from "../background/top-level-async.ts";
 import { handleMissionAction, MISSION_ACTIONS } from "../../missions/actions.ts";
 import { attachMissionToLaunchResult, prepareMissionLaunch, writeMissionAsyncBinding, type MissionLaunchBinding } from "../../missions/lifecycle.ts";
@@ -1514,9 +1515,14 @@ function externalJobFollowUpStarted(input: { sourceRunId: string; runId: string;
 function externalRunnerControlError(asyncDir: string, action: "steer" | "resume"): AgentToolResult<Details> | undefined {
 	const status = readStatus(asyncDir);
 	if (!status?.steps?.length || !status.steps.every((step) => step.runner?.type === "external-cli" || step.runner?.type === "external-job")) return undefined;
-	const message = action === "steer"
-		? "External runners do not accept live steer messages."
-		: "External runners do not persist Pi sessions and cannot be resumed.";
+	const externalCli = normalizeExternalCliRunnerStatus(status.steps.find((step) => step.runner?.type === "external-cli")?.runner);
+	const message = externalCli
+		? action === "steer"
+			? `External adapter '${externalCli.adapter.id}' does not support runs.steer: ${externalCli.unsupportedReasons.steer}`
+			: `External adapter '${externalCli.adapter.id}' cannot resume: ${externalCli.nonResumableReason}`
+		: action === "steer"
+			? "External runners do not accept live steer messages."
+			: "External runners do not persist Pi sessions and cannot be resumed.";
 	return { content: [{ type: "text", text: message }], isError: true, details: { mode: "management", results: [] } };
 }
 
@@ -1762,7 +1768,11 @@ async function resumeAsyncRun(input: {
 		};
 	}
 	if (target.source === "async" && target.runner?.type === "external-cli") {
-		return { content: [{ type: "text", text: "External runners do not persist Pi sessions and cannot be resumed." }], isError: true, details: { mode: "management", results: [] } };
+		const runner = normalizeExternalCliRunnerStatus(target.runner);
+		const message = runner
+			? `External adapter '${runner.adapter.id}' cannot resume: ${runner.nonResumableReason}`
+			: "External runners do not persist Pi sessions and cannot be resumed.";
+		return { content: [{ type: "text", text: message }], isError: true, details: { mode: "management", results: [] } };
 	}
 	if (target.source === "async" && target.runner?.type === "external-job") {
 		if (attachChain) return { content: [{ type: "text", text: "External-job follow-up does not support chain attachment. Use action='resume' with message instead." }], isError: true, details: { mode: "management", results: [] } };
@@ -3965,6 +3975,13 @@ function workflowChildResult(
 	const continuationRunIds = [...new Set([resumeSourceRunId, runId].filter((value): value is string => Boolean(value)))];
 	const outputReference = result.details.results.find((child) => child.savedOutputPath)?.savedOutputPath
 		?? result.details.results.find((child) => child.outputReference?.path)?.outputReference?.path;
+	const externalResult = result.details.results.length === 1 && result.details.results[0]?.runner?.type === "external-cli" ? result.details.results[0] : undefined;
+	const externalStatus = result.details.asyncDir ? readStatus(result.details.asyncDir) : undefined;
+	const externalStatusStep = externalStatus?.steps?.length === 1 && externalStatus.steps[0]?.runner?.type === "external-cli" ? externalStatus.steps[0] : undefined;
+	const externalRunner = normalizeExternalCliRunnerStatus(externalResult?.runner ?? externalStatusStep?.runner);
+	const externalProcess = externalResult?.externalProcess ?? externalStatusStep?.externalProcess;
+	const externalAdapter = externalRunner ? externalCliReceiptMetadata({ runner: externalRunner, externalProcess, outputReference }) : undefined;
+	if (externalAdapter) resumability = { state: "not-resumable", reason: externalAdapter.nonResumableReason };
 	return {
 		key,
 		ok,
@@ -3979,6 +3996,7 @@ function workflowChildResult(
 		...(requestedContext ? { requestedContext } : {}),
 		...(resolvedContext ? { resolvedContext } : {}),
 		...(outputReference ? { outputReference } : {}),
+		...(externalAdapter ? { externalAdapter } : {}),
 		resumability,
 		continuation: { runIds: continuationRunIds },
 		artifactPaths: [...artifactPaths],
@@ -4068,6 +4086,8 @@ export async function steerWorkflowChildByKey(input: {
 				return { key: input.key, state: "missed", error: `Workflow child '${input.key}' is ${childStatus.state}.` };
 			}
 			if (childStatus) {
+				const unsupported = externalRunnerControlError(asyncDir, "steer");
+				if (unsupported) return workflowSteerReceipt(input.key, unsupported);
 				const result = await steerAsyncRun({
 					state: input.state,
 					runId: childRunId,

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -13,6 +13,7 @@ import {
 import { updateActiveRunIndex } from "../background/active-run-index.ts";
 import { resultFilePath, writeAsyncResultFile } from "../background/result-files.ts";
 import { resolveAsyncResumeTarget } from "../background/async-resume.ts";
+import { externalCliReceiptMetadata, normalizeExternalCliRunnerStatus } from "../shared/external-cli-contract.ts";
 import { readWorkflowReceipt, workflowReceiptPath, writeWorkflowReceipt, type WorkflowReceipt } from "../../workflows/workflow-receipt.ts";
 
 function cloneWorkflowStatus(status: AsyncStatus): AsyncStatus {
@@ -154,6 +155,12 @@ function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, resul
 		resumability = { state: "not-resumable", reason: error instanceof Error ? error.message : String(error) };
 	}
 	const outputReference = result.savedOutputPath ?? result.outputReference?.path ?? entry.outputReference;
+	const childStatus = readStatus(path.join(DIRS.async, childRunId));
+	const externalStep = childStatus?.steps?.length === 1 && childStatus.steps[0]?.runner?.type === "external-cli" ? childStatus.steps[0] : undefined;
+	const externalRunner = normalizeExternalCliRunnerStatus(result.runner?.type === "external-cli" ? result.runner : externalStep?.runner);
+	const externalProcess = result.externalProcess ?? externalStep?.externalProcess;
+	const externalAdapter = externalRunner ? externalCliReceiptMetadata({ runner: externalRunner, externalProcess, outputReference }) : entry.externalAdapter;
+	if (externalAdapter) resumability = { state: "not-resumable", reason: externalAdapter.nonResumableReason };
 	const updatedEntry: WorkflowReceipt["entries"][string] = resumability.state === "resumable"
 		? {
 			...entry,
@@ -162,6 +169,7 @@ function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, resul
 			latestRunId: entry.latestRunId ?? childRunId,
 			resumability,
 			...(outputReference ? { outputReference } : {}),
+			...(externalAdapter ? { externalAdapter } : {}),
 		}
 		: {
 			...entry,
@@ -169,6 +177,7 @@ function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, resul
 			...(step.context ? { resolvedContext: step.context } : {}),
 			resumability,
 			...(outputReference ? { outputReference } : {}),
+			...(externalAdapter ? { externalAdapter } : {}),
 		};
 	const next: WorkflowReceipt = {
 		...receipt,

--- a/src/runs/shared/external-cli-contract.ts
+++ b/src/runs/shared/external-cli-contract.ts
@@ -1,0 +1,90 @@
+import type {
+	ExternalCliReceiptMetadata,
+	ExternalCliCapabilityNarrowing,
+	ExternalCliRunnerStatus,
+	ExternalProcessStatus,
+} from "../../shared/types.ts";
+
+const UNSUPPORTED = {
+	steer: "The one-shot stdin adapter closes input after launch and cannot accept live steer messages.",
+	resume: "The one-shot stdin adapter has no durable external session identity.",
+	structuredOutput: "The generic external CLI adapter does not parse a trusted structured result.",
+	toolEvents: "The generic external CLI adapter treats stdout as untrusted text, not native Pi tool events.",
+	supervisor: "The generic external CLI adapter has no trusted supervisor event transport.",
+	forkContext: "Native Pi fork context is not available without an adapter-owned handoff artifact.",
+	extensionBindings: "Native Pi extension bindings are never passed to external runners.",
+} as const;
+
+const CAPABILITY_KEYS = new Set(Object.keys(UNSUPPORTED));
+
+export function parseExternalCliCapabilityNarrowing(value: unknown, label: string): ExternalCliCapabilityNarrowing | undefined {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object.`);
+	const input = value as Record<string, unknown>;
+	const unknown = Object.keys(input).filter((key) => !CAPABILITY_KEYS.has(key));
+	if (unknown.length > 0) throw new Error(`${label} has unsupported fields: ${unknown.join(", ")}.`);
+	for (const [key, setting] of Object.entries(input)) {
+		if (setting !== false) throw new Error(`${label}.${key} may only be false; user config cannot widen code-owned external adapter capabilities.`);
+	}
+	return input as ExternalCliCapabilityNarrowing;
+}
+
+export function resolveExternalCliRunnerStatus(input: {
+	command: string;
+	args?: string[];
+	promptDelivery?: "stdin";
+	capabilities?: ExternalCliCapabilityNarrowing;
+}): ExternalCliRunnerStatus {
+	return {
+		type: "external-cli",
+		command: input.command,
+		args: input.args ?? [],
+		promptDelivery: input.promptDelivery ?? "stdin",
+		adapter: { id: "external-cli", version: 1, executionMode: "one-shot-stdin" },
+		capabilities: {
+			stop: true,
+			steer: false,
+			resume: false,
+			structuredOutput: false,
+			toolEvents: false,
+			supervisor: "unsupported",
+			forkContext: false,
+			extensionBindings: false,
+		},
+		unsupportedReasons: UNSUPPORTED,
+		nonResumableReason: UNSUPPORTED.resume,
+	};
+}
+
+export function normalizeExternalCliRunnerStatus(value: unknown): ExternalCliRunnerStatus | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const input = value as Record<string, unknown>;
+	if (input.type !== "external-cli" || typeof input.command !== "string" || !input.command.trim()) return undefined;
+	const args = Array.isArray(input.args) && input.args.every((arg) => typeof arg === "string")
+		? input.args
+		: undefined;
+	const promptDelivery = input.promptDelivery === "stdin" ? "stdin" : undefined;
+	return resolveExternalCliRunnerStatus({ command: input.command, ...(args ? { args } : {}), ...(promptDelivery ? { promptDelivery } : {}) });
+}
+
+export function externalCliReceiptMetadata(input: {
+	runner: ExternalCliRunnerStatus;
+	externalProcess?: ExternalProcessStatus;
+	outputReference?: string;
+}): ExternalCliReceiptMetadata {
+	const { runner } = input;
+	return {
+		adapter: { ...runner.adapter },
+		capabilities: { ...runner.capabilities },
+		...(input.externalProcess ? {
+			outputArtifacts: {
+				stdoutPath: input.externalProcess.stdoutPath,
+				stderrPath: input.externalProcess.stderrPath,
+				...(input.outputReference ? { finalOutputPath: input.outputReference } : {}),
+			},
+		} : input.outputReference ? { outputArtifacts: { finalOutputPath: input.outputReference } } : {}),
+		handoff: { mode: "fresh" },
+		supervisor: { mode: "unsupported", reason: runner.unsupportedReasons.supervisor },
+		nonResumableReason: runner.nonResumableReason,
+	};
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -85,6 +85,7 @@ export type WorkflowReceiptEntry = WorkflowReceiptEntryResumability & {
 	requestedContext?: "fresh" | "fork";
 	resolvedContext?: "fresh" | "fork" | "mixed";
 	outputReference?: string;
+	externalAdapter?: ExternalCliReceiptMetadata;
 	continuation: { runIds: string[] };
 };
 
@@ -1044,6 +1045,8 @@ export interface SingleResult {
 	watchdog?: ChildWatchdogProgress;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	capabilityAudit?: SubagentCapabilityAudit;
+	runner?: ExternalCliRunnerStatus | ExternalJobRunnerStatus;
+	externalProcess?: ExternalProcessStatus;
 }
 
 export interface SpawnBudgetGrant {
@@ -1378,6 +1381,7 @@ export type AgentRunnerConfig =
 		command: string;
 		args?: string[];
 		promptDelivery?: "stdin";
+		capabilities?: ExternalCliCapabilityNarrowing;
 	}
 	| {
 		type: "external-job";
@@ -1385,18 +1389,37 @@ export type AgentRunnerConfig =
 		options?: Record<string, unknown>;
 	};
 
+export type ExternalCliCapabilityNarrowing = Partial<Record<"steer" | "resume" | "structuredOutput" | "toolEvents" | "supervisor" | "forkContext" | "extensionBindings", false>>;
+
+export interface ExternalCliCapabilities {
+	stop: true;
+	steer: false;
+	resume: false;
+	structuredOutput: false;
+	toolEvents: false;
+	supervisor: "unsupported";
+	forkContext: false;
+	extensionBindings: false;
+}
+
+export interface ExternalCliReceiptMetadata {
+	adapter: { id: "external-cli"; version: 1; executionMode: "one-shot-stdin" };
+	capabilities: ExternalCliCapabilities;
+	outputArtifacts?: { stdoutPath?: string; stderrPath?: string; finalOutputPath?: string };
+	handoff: { mode: "fresh" };
+	supervisor: { mode: "unsupported"; reason: string };
+	nonResumableReason: string;
+}
+
 export interface ExternalCliRunnerStatus {
 	type: "external-cli";
 	command: string;
 	args: string[];
 	promptDelivery: "stdin";
-	capabilities: {
-		stop: true;
-		steer: false;
-		resume: false;
-		structuredOutput: false;
-		toolEvents: false;
-	};
+	adapter: ExternalCliReceiptMetadata["adapter"];
+	capabilities: ExternalCliCapabilities;
+	unsupportedReasons: Record<Exclude<keyof ExternalCliCapabilities, "stop">, string>;
+	nonResumableReason: string;
 }
 
 export interface ExternalJobRunnerStatus {

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -650,6 +650,7 @@ export interface WorkflowScriptChildResult {
 	requestedContext?: "fresh" | "fork";
 	resolvedContext?: "fresh" | "fork" | "mixed";
 	outputReference?: string;
+	externalAdapter?: import("../shared/types.ts").ExternalCliReceiptMetadata;
 	resumability?: { state: "resumable" } | { state: "not-resumable"; reason: string };
 	continuation?: { runIds: string[] };
 	artifactPaths: string[];

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writePrivateAtomicJson } from "../shared/atomic-json.ts";
-import type { WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState } from "../shared/types.ts";
+import type { ExternalCliReceiptMetadata, WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState } from "../shared/types.ts";
 import type { WorkflowReceiptResumeReference, WorkflowScriptChildResult } from "./scripted-workflow.ts";
 
 export type { WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState } from "../shared/types.ts";
@@ -49,6 +49,7 @@ export function buildWorkflowReceipt(input: {
 			...(child.requestedContext ? { requestedContext: child.requestedContext } : {}),
 			...(child.resolvedContext ? { resolvedContext: child.resolvedContext } : {}),
 			...(child.outputReference ? { outputReference: child.outputReference } : {}),
+			...(child.externalAdapter ? { externalAdapter: child.externalAdapter } : {}),
 			continuation: { runIds },
 		};
 		entries[key] = resumability.state === "resumable"
@@ -62,6 +63,64 @@ export function writeWorkflowReceipt(asyncDir: string, receipt: WorkflowReceipt)
 	const receiptPath = path.join(asyncDir, WORKFLOW_RECEIPT_FILE);
 	writePrivateAtomicJson(receiptPath, receipt);
 	return receiptPath;
+}
+
+const EXTERNAL_CLI_CAPABILITIES = {
+	stop: true,
+	steer: false,
+	resume: false,
+	structuredOutput: false,
+	toolEvents: false,
+	supervisor: "unsupported",
+	forkContext: false,
+	extensionBindings: false,
+} as const;
+
+function parseExternalCliReceiptMetadata(value: unknown, key: string, source: string): ExternalCliReceiptMetadata | undefined {
+	if (value === undefined) return undefined;
+	const label = `Invalid workflow receipt '${source}': entry '${key}' externalAdapter`;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object.`);
+	const metadata = value as Record<string, unknown>;
+	const unknownMetadata = Object.keys(metadata).filter((field) => !["adapter", "capabilities", "outputArtifacts", "handoff", "supervisor", "nonResumableReason"].includes(field));
+	if (unknownMetadata.length > 0) throw new Error(`${label} has unsupported fields: ${unknownMetadata.join(", ")}.`);
+	const adapter = metadata.adapter;
+	if (!adapter || typeof adapter !== "object" || Array.isArray(adapter)) throw new Error(`${label}.adapter must be an object.`);
+	const adapterRecord = adapter as Record<string, unknown>;
+	const unknownAdapter = Object.keys(adapterRecord).filter((field) => !["id", "version", "executionMode"].includes(field));
+	if (unknownAdapter.length > 0) throw new Error(`${label}.adapter has unsupported fields: ${unknownAdapter.join(", ")}.`);
+	if (adapterRecord.id !== "external-cli" || adapterRecord.version !== 1 || adapterRecord.executionMode !== "one-shot-stdin") throw new Error(`${label}.adapter is invalid.`);
+	const capabilities = metadata.capabilities;
+	if (!capabilities || typeof capabilities !== "object" || Array.isArray(capabilities)) throw new Error(`${label}.capabilities must be an object.`);
+	const capabilityRecord = capabilities as Record<string, unknown>;
+	const unknownCapabilities = Object.keys(capabilityRecord).filter((field) => !(field in EXTERNAL_CLI_CAPABILITIES));
+	if (unknownCapabilities.length > 0) throw new Error(`${label}.capabilities has unsupported fields: ${unknownCapabilities.join(", ")}.`);
+	for (const [capability, expected] of Object.entries(EXTERNAL_CLI_CAPABILITIES)) {
+		if (capabilityRecord[capability] !== expected) throw new Error(`${label}.capabilities.${capability} is invalid.`);
+	}
+	const handoff = metadata.handoff;
+	if (!handoff || typeof handoff !== "object" || Array.isArray(handoff)) throw new Error(`${label}.handoff must be an object.`);
+	const handoffRecord = handoff as Record<string, unknown>;
+	const unknownHandoff = Object.keys(handoffRecord).filter((field) => field !== "mode");
+	if (unknownHandoff.length > 0) throw new Error(`${label}.handoff has unsupported fields: ${unknownHandoff.join(", ")}.`);
+	if (handoffRecord.mode !== "fresh") throw new Error(`${label}.handoff is invalid.`);
+	const supervisor = metadata.supervisor;
+	if (!supervisor || typeof supervisor !== "object" || Array.isArray(supervisor)) throw new Error(`${label}.supervisor must be an object.`);
+	const supervisorRecord = supervisor as Record<string, unknown>;
+	const unknownSupervisor = Object.keys(supervisorRecord).filter((field) => !["mode", "reason"].includes(field));
+	if (unknownSupervisor.length > 0) throw new Error(`${label}.supervisor has unsupported fields: ${unknownSupervisor.join(", ")}.`);
+	if (supervisorRecord.mode !== "unsupported" || typeof supervisorRecord.reason !== "string" || !supervisorRecord.reason.trim()) throw new Error(`${label}.supervisor is invalid.`);
+	if (typeof metadata.nonResumableReason !== "string" || !metadata.nonResumableReason.trim()) throw new Error(`${label}.nonResumableReason is missing.`);
+	const outputArtifacts = metadata.outputArtifacts;
+	if (outputArtifacts !== undefined) {
+		if (!outputArtifacts || typeof outputArtifacts !== "object" || Array.isArray(outputArtifacts)) throw new Error(`${label}.outputArtifacts must be an object.`);
+		const unknownArtifacts = Object.keys(outputArtifacts).filter((field) => !["stdoutPath", "stderrPath", "finalOutputPath"].includes(field));
+		if (unknownArtifacts.length > 0) throw new Error(`${label}.outputArtifacts has unsupported fields: ${unknownArtifacts.join(", ")}.`);
+		for (const field of ["stdoutPath", "stderrPath", "finalOutputPath"] as const) {
+			const artifactPath = (outputArtifacts as Record<string, unknown>)[field];
+			if (artifactPath !== undefined && (typeof artifactPath !== "string" || !artifactPath.trim())) throw new Error(`${label}.outputArtifacts.${field} must be a non-empty string.`);
+		}
+	}
+	return value as ExternalCliReceiptMetadata;
 }
 
 function parseEntry(value: unknown, key: string, source: string): WorkflowReceiptEntry {
@@ -84,6 +143,7 @@ function parseEntry(value: unknown, key: string, source: string): WorkflowReceip
 	const reason = (resumability as Record<string, unknown>).reason;
 	if (state === "resumable" && latestRunId === undefined) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' resumable entry has no retained run id.`);
 	if (state === "not-resumable" && (typeof reason !== "string" || !reason.trim())) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' non-resumable reason is missing.`);
+	parseExternalCliReceiptMetadata(entry.externalAdapter, key, source);
 	return value as WorkflowReceiptEntry;
 }
 

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -215,6 +215,28 @@ Review carefully.`.replace(" description:", "description:"));
 		assert.deepEqual(discoverAgents(project, "project").agents.find((agent) => agent.name === "external")?.runner, external.runner);
 	}));
 
+	it("keeps external-cli stop code-owned while refusing capability widening", () => withTempHome(() => {
+		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-runner-capabilities-"));
+		tempDirs.push(project);
+		const agentPath = path.join(project, ".pi", "agents", "external.md");
+		writeAgent(agentPath, `---\nname: external\ndescription: External runner\nrunner:\n  type: external-cli\n  command: node\n  capabilities:\n    steer: false\n---\nReview.`);
+		assert.deepEqual(discoverAgents(project, "project").agents.find((agent) => agent.name === "external")?.runner, {
+			type: "external-cli",
+			command: "node",
+			capabilities: { steer: false },
+		});
+
+		writeAgent(agentPath, `---\nname: external\ndescription: External runner\nrunner:\n  type: external-cli\n  command: node\n  capabilities:\n    stop: false\n---\nReview.`);
+		const narrowedStop = discoverAgents(project, "project");
+		assert.equal(narrowedStop.agents.some((agent) => agent.name === "external"), false);
+		assert.match(narrowedStop.agentDiagnostics?.[0]?.error ?? "", /capabilities has unsupported fields: stop/);
+
+		writeAgent(agentPath, `---\nname: external\ndescription: External runner\nrunner:\n  type: external-cli\n  command: node\n  capabilities:\n    steer: true\n---\nReview.`);
+		const widened = discoverAgents(project, "project");
+		assert.equal(widened.agents.some((agent) => agent.name === "external"), false);
+		assert.match(widened.agentDiagnostics?.[0]?.error ?? "", /steer may only be false; user config cannot widen code-owned external adapter capabilities/);
+	}));
+
 	it("parses and serializes an external-job runner", () => withTempHome(() => {
 		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-external-job-agent-"));
 		tempDirs.push(project);

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -8,6 +8,7 @@ import { consumeSteerRequests, consumeSteerRequestsFromDir, consumeStopRequestPa
 import { listAsyncRuns } from "../../src/runs/background/async-status.ts";
 import { inspectSubagentStatus } from "../../src/runs/background/run-status.ts";
 import { createSubagentExecutor, steerWorkflowChildByKey } from "../../src/runs/foreground/subagent-executor.ts";
+import { resolveExternalCliRunnerStatus } from "../../src/runs/shared/external-cli-contract.ts";
 import { steerWorkflowForegroundTarget, workflowForegroundSteeringDir } from "../../src/runs/foreground/workflow-foreground-steering.ts";
 import { ASYNC_DIR, RESULTS_DIR, type SubagentState } from "../../src/shared/types.ts";
 
@@ -260,6 +261,30 @@ describe("async interrupt action", () => {
 			controller.abort();
 			assert.equal((await action).state, "queued");
 			assert.equal(fs.existsSync(path.join(childDir, "control", "steer-recovery")), false);
+		} finally {
+			cleanup(workflowRunId, workflowDir);
+			cleanup(childRunId, childDir);
+		}
+	});
+
+	it("rejects workflow-key steering for a one-shot external CLI child", async () => {
+		const state = createState();
+		const workflowRunId = `workflow-key-external-${Date.now().toString(36)}`;
+		const childRunId = `${workflowRunId}-child`;
+		const workflowDir = createRunningAsync(state, workflowRunId, { track: false, mode: "workflow" });
+		const childDir = createRunningAsync(state, childRunId, { track: false });
+		const workflowStatus = JSON.parse(fs.readFileSync(path.join(workflowDir, "status.json"), "utf-8"));
+		workflowStatus.steps = [{ agent: "external", status: "running", workflowKey: "external", runId: childRunId, async: true }];
+		writeJson(path.join(workflowDir, "status.json"), workflowStatus);
+		const childStatus = JSON.parse(fs.readFileSync(path.join(childDir, "status.json"), "utf-8"));
+		childStatus.pid = process.pid;
+		childStatus.steps[0].runner = resolveExternalCliRunnerStatus({ command: "review-cli" });
+		writeJson(path.join(childDir, "status.json"), childStatus);
+		try {
+			const result = await steerWorkflowChildByKey({ state, workflowRunId, key: "external", message: "Do not deliver.", options: { ackTimeoutMs: 20 } });
+			assert.equal(result.state, "failed");
+			assert.match(result.error ?? "", /External adapter 'external-cli' does not support runs\.steer/);
+			assert.equal(consumeSteerRequests(childDir).length, 0);
 		} finally {
 			cleanup(workflowRunId, workflowDir);
 			cleanup(childRunId, childDir);
@@ -540,6 +565,44 @@ describe("async interrupt action", () => {
 				.execute("steer", { action: "steer", id: runId, message: "do not deliver" }, new AbortController().signal, undefined, ctx());
 			assert.equal(result.isError, true);
 			assert.match(text(result), /active session/);
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "steer-requests")), false);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("rejects runs.steer for the one-shot external CLI with its adapter reason", async () => {
+		const state = createState();
+		const runId = `steer-external-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false });
+		const statusPath = path.join(asyncDir, "status.json");
+		const status = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as { steps: Array<Record<string, unknown>> };
+		status.steps[0]!.runner = resolveExternalCliRunnerStatus({ command: "review-cli" });
+		writeJson(statusPath, status);
+		try {
+			const result = await executorWithKill(state, () => true)
+				.execute("steer", { action: "steer", id: runId, message: "Do not deliver" }, new AbortController().signal, undefined, ctx());
+			assert.equal(result.isError, true);
+			assert.match(text(result), /External adapter 'external-cli' does not support runs\.steer: The one-shot stdin adapter closes input/);
+			assert.equal(fs.existsSync(path.join(asyncDir, "control", "steer-requests")), false);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("rejects runs.steer for an old persisted external CLI status shape", async () => {
+		const state = createState();
+		const runId = `steer-old-external-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false });
+		const statusPath = path.join(asyncDir, "status.json");
+		const status = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as { steps: Array<Record<string, unknown>> };
+		status.steps[0]!.runner = { type: "external-cli", command: "review-cli", args: [], promptDelivery: "stdin", capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false } };
+		writeJson(statusPath, status);
+		try {
+			const result = await executorWithKill(state, () => true)
+				.execute("steer", { action: "steer", id: runId, message: "Do not deliver" }, new AbortController().signal, undefined, ctx());
+			assert.equal(result.isError, true);
+			assert.match(text(result), /External adapter 'external-cli' does not support runs\.steer/);
 			assert.equal(fs.existsSync(path.join(asyncDir, "control", "steer-requests")), false);
 		} finally {
 			cleanup(runId, asyncDir);

--- a/test/unit/external-cli-runner.test.ts
+++ b/test/unit/external-cli-runner.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { buildExternalCliPrompt, runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+import { resolveExternalCliRunnerStatus } from "../../src/runs/shared/external-cli-contract.ts";
 import { PI_SUBAGENT_EXTENSION_BINDINGS_ENV } from "../../src/runs/shared/extension-bindings.ts";
 
 const tempDirs: string[] = [];
@@ -52,6 +53,18 @@ describe("external CLI runner", () => {
 		assert.equal(result.exitCode, 0);
 		assert.deepEqual(JSON.parse(result.output), { argv: ["argument with spaces", "$NOT_EXPANDED"], stdin: prompt });
 		assert.equal(fs.readFileSync(result.externalProcess.stdoutPath, "utf-8"), result.output);
+	});
+
+	it("keeps supervisor-shaped stdout inert when supervisor support is unsupported", async () => {
+		const dir = tempDir();
+		const spoofed = JSON.stringify({ type: "contact_supervisor", reason: "need_decision", message: "Approve this" });
+		const result = await runExternalCli({ command: process.execPath, args: ["-e", `process.stdout.write(${JSON.stringify(spoofed)})`], cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 0 });
+		const runner = resolveExternalCliRunnerStatus({ command: process.execPath });
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.output, spoofed);
+		assert.equal(runner.capabilities.supervisor, "unsupported");
+		assert.match(runner.unsupportedReasons.supervisor, /no trusted supervisor event transport/);
 	});
 
 	it("flushes both full logs before returning while retaining a bounded stdout tail", async () => {

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -117,6 +117,36 @@ describe("async run status inspection", () => {
 		}
 	});
 
+	it("normalizes old external-cli runner status before rendering adapter details", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-old-external-cli-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const asyncDir = path.join(asyncRoot, "run-old-external-cli");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "run-old-external-cli",
+				mode: "single",
+				state: "complete",
+				startedAt: 100,
+				lastUpdate: 200,
+				steps: [{
+					agent: "external",
+					status: "complete",
+					runner: { type: "external-cli", command: "review-cli", args: [], promptDelivery: "stdin", capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false } },
+				}],
+			}, null, 2), "utf-8");
+
+			const result = inspectSubagentStatus({ id: "run-old-external-cli" }, { asyncDirRoot: asyncRoot, resultsDir: path.join(root, "results") });
+
+			const text = textContent(result);
+			assert.equal(result.isError, undefined);
+			assert.match(text, /Adapter: external-cli v1 \(one-shot-stdin\)/);
+			assert.match(text, /Unsupported resume: The one-shot stdin adapter has no durable external session identity/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("shows parallel mode and aggregate progress for top-level async parallel runs", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-parallel-"));
 		try {

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -270,6 +270,91 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 		});
 	});
 
+	it("normalizes old external-cli child status while reconciling workflow receipts", () => {
+		const workflowRunId = "workflow-old-external-receipt";
+		const childRunId = "child-old-external";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const childDir = path.join(DIRS.async, childRunId);
+		fs.rmSync(asyncDir, { recursive: true, force: true });
+		fs.rmSync(childDir, { recursive: true, force: true });
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(childDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		const status = { ...pausedWorkflow(childRunId), runId: workflowRunId, sessionId: "session-1" };
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		fs.writeFileSync(path.join(childDir, "status.json"), JSON.stringify({
+			runId: childRunId,
+			mode: "single",
+			state: "complete",
+			startedAt: 1,
+			lastUpdate: 2,
+			steps: [{ agent: "external", status: "complete", runner: { type: "external-cli", command: "review-cli", args: [], promptDelivery: "stdin", capabilities: { stop: true, steer: false, resume: false, structuredOutput: false, toolEvents: false } } }],
+		}), "utf-8");
+		writeWorkflowReceipt(asyncDir, buildWorkflowReceipt({
+			workflowRunId,
+			state: "paused",
+			children: [{ key: "detaches", ok: false, agent: "external", runId: childRunId, output: "paused", detached: true, artifactPaths: [], resumability: { state: "not-resumable", reason: "child detached" }, continuation: { runIds: [childRunId] } }],
+		}));
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId,
+			result: { index: 0, agent: "external", task: "t", exitCode: 0, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+		}), true);
+
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowReceipt?: { receipt?: { entries?: Record<string, { externalAdapter?: { adapter?: { id?: string }; nonResumableReason?: string } }> } } };
+		assert.equal(published.workflowReceipt?.receipt?.entries?.detaches?.externalAdapter?.adapter?.id, "external-cli");
+		assert.match(published.workflowReceipt?.receipt?.entries?.detaches?.externalAdapter?.nonResumableReason ?? "", /no durable external session identity/);
+		assert.doesNotMatch(fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8"), /receipt_write_failed/);
+	});
+
+	it("keeps mixed Pi and external workflow receipt entries on their computed resumability", () => {
+		const workflowRunId = "workflow-mixed-receipt";
+		const childRunId = "child-mixed";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const childDir = path.join(DIRS.async, childRunId);
+		fs.rmSync(asyncDir, { recursive: true, force: true });
+		fs.rmSync(childDir, { recursive: true, force: true });
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(childDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		const status = { ...pausedWorkflow(childRunId), runId: workflowRunId, sessionId: "session-1" };
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		const sessionFile = path.join(childDir, "pi-session.jsonl");
+		fs.writeFileSync(sessionFile, "", "utf-8");
+		fs.writeFileSync(path.join(childDir, "status.json"), JSON.stringify({
+			runId: childRunId,
+			mode: "parallel",
+			state: "complete",
+			startedAt: 1,
+			lastUpdate: 2,
+			steps: [
+				{ agent: "worker", status: "complete", sessionFile },
+				{ agent: "external", status: "complete", runner: { type: "external-cli", command: "review-cli", args: [], promptDelivery: "stdin" } },
+			],
+		}), "utf-8");
+		writeWorkflowReceipt(asyncDir, buildWorkflowReceipt({
+			workflowRunId,
+			state: "paused",
+			children: [{ key: "detaches", ok: false, agent: "worker", runId: childRunId, output: "paused", detached: true, artifactPaths: [], resumability: { state: "not-resumable", reason: "child detached" }, continuation: { runIds: [childRunId] } }],
+		}));
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId,
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, sessionFile, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+		}), true);
+
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowReceipt?: { receipt?: { entries?: Record<string, { resumability?: { state?: string; reason?: string }; externalAdapter?: unknown }> } } };
+		assert.equal(published.workflowReceipt?.receipt?.entries?.detaches?.resumability?.state, "not-resumable");
+		assert.doesNotMatch(published.workflowReceipt?.receipt?.entries?.detaches?.resumability?.reason ?? "", /no durable external session identity/);
+		assert.equal(published.workflowReceipt?.receipt?.entries?.detaches?.externalAdapter, undefined);
+	});
+
 	it("does not log workflow completion while another detached child is still open", () => {
 		const workflowRunId = "workflow-still-paused";
 		const asyncDir = path.join(DIRS.async, workflowRunId);

--- a/test/unit/workflow-receipt.test.ts
+++ b/test/unit/workflow-receipt.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { buildWorkflowReceipt, readWorkflowReceipt, resolveWorkflowReceiptResume, workflowReceiptPath, writeWorkflowReceipt } from "../../src/workflows/workflow-receipt.ts";
+import { externalCliReceiptMetadata, resolveExternalCliRunnerStatus } from "../../src/runs/shared/external-cli-contract.ts";
 import type { WorkflowScriptChildResult } from "../../src/workflows/scripted-workflow.ts";
 
 const roots: string[] = [];
@@ -37,6 +38,21 @@ function child(key: string, overrides: Partial<WorkflowScriptChildResult> = {}):
 }
 
 describe("workflow receipts", () => {
+	it("reads old receipt-v1 files without external adapter metadata", () => {
+		const asyncRoot = tempRoot();
+		const asyncDir = path.join(asyncRoot, "workflow-old");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "workflow-receipt.json"), JSON.stringify({
+			version: 1,
+			workflowRunId: "workflow-old",
+			state: "complete",
+			createdAt: 10,
+			entries: { advisor: { key: "advisor", latestRunId: "run-old", resumability: { state: "resumable" }, continuation: { runIds: ["run-old"] } } },
+		}));
+
+		assert.equal(readWorkflowReceipt(asyncRoot, "workflow-old").entries.advisor?.externalAdapter, undefined);
+	});
+
 	it("builds one metadata-only entry per workflow child", () => {
 		const children = Array.from({ length: 1_000 }, (_, index) => child(`child-${index}`));
 		const receipt = buildWorkflowReceipt({ workflowRunId: "workflow-1", state: "complete", children, createdAt: 10 });
@@ -55,6 +71,58 @@ describe("workflow receipts", () => {
 		const serialized = JSON.stringify(receipt);
 		assert.doesNotMatch(serialized, /structuredOutput|artifactPaths|"output"/);
 		assert.ok(serialized.length < 400_000, `receipt metadata unexpectedly large: ${serialized.length}`);
+	});
+
+	it("adds bounded external adapter metadata without raw output or handoff content", () => {
+		const runner = resolveExternalCliRunnerStatus({ command: "review-cli" });
+		const externalAdapter = externalCliReceiptMetadata({
+			runner,
+			externalProcess: { startedAt: 1, stdoutPath: "/tmp/stdout.log", stderrPath: "/tmp/stderr.log" },
+			outputReference: "/tmp/final.md",
+		});
+		const receipt = buildWorkflowReceipt({
+			workflowRunId: "workflow-external",
+			state: "complete",
+			children: [child("advisor", { resumability: { state: "not-resumable", reason: externalAdapter.nonResumableReason }, externalAdapter })],
+		});
+		const serialized = JSON.stringify(receipt);
+
+		assert.equal(receipt.entries.advisor?.externalAdapter?.adapter.id, "external-cli");
+		assert.equal(receipt.entries.advisor?.externalAdapter?.capabilities.stop, true);
+		assert.equal(receipt.entries.advisor?.externalAdapter?.capabilities.supervisor, "unsupported");
+		assert.equal(receipt.entries.advisor?.externalAdapter?.handoff.mode, "fresh");
+		assert.match(receipt.entries.advisor?.resumability.state === "not-resumable" ? receipt.entries.advisor.resumability.reason : "", /no durable external session identity/);
+		assert.doesNotMatch(serialized, /artifactPaths|rawOutput|handoffText|contact_supervisor/);
+		assert.ok(Buffer.byteLength(serialized) < 2_000, `external receipt metadata unexpectedly large: ${Buffer.byteLength(serialized)}`);
+	});
+
+	it("fails closed for malformed external adapter receipt metadata", () => {
+		const asyncRoot = tempRoot();
+		const asyncDir = path.join(asyncRoot, "workflow-external-bad");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		const runner = resolveExternalCliRunnerStatus({ command: "review-cli" });
+		const externalAdapter = externalCliReceiptMetadata({ runner });
+		fs.writeFileSync(path.join(asyncDir, "workflow-receipt.json"), JSON.stringify({
+			version: 1,
+			workflowRunId: "workflow-external-bad",
+			state: "complete",
+			createdAt: 10,
+			entries: {
+				advisor: {
+					key: "advisor",
+					latestRunId: "run-advisor",
+					resumability: { state: "not-resumable", reason: externalAdapter.nonResumableReason },
+					continuation: { runIds: ["run-advisor"] },
+					externalAdapter: { ...externalAdapter, nonResumableReason: "" },
+				},
+			},
+		}));
+
+		assert.throws(() => readWorkflowReceipt(asyncRoot, "workflow-external-bad"), /externalAdapter\.nonResumableReason is missing/);
+		const badRaw = JSON.parse(fs.readFileSync(path.join(asyncDir, "workflow-receipt.json"), "utf-8"));
+		badRaw.entries.advisor.externalAdapter = { ...externalAdapter, rawOutput: "do not persist" };
+		fs.writeFileSync(path.join(asyncDir, "workflow-receipt.json"), JSON.stringify(badRaw));
+		assert.throws(() => readWorkflowReceipt(asyncRoot, "workflow-external-bad"), /externalAdapter has unsupported fields: rawOutput/);
 	});
 
 	it("writes and resolves one exact terminal receipt", () => {
@@ -108,6 +176,24 @@ describe("workflow receipts", () => {
 		assert.throws(
 			() => resolveWorkflowReceiptResume({ reference: { workflowRunId: "workflow-1", key: "advisor", latest: false } as never, asyncDirRoot: asyncRoot }),
 			/requires latest: true/,
+		);
+	});
+
+	it("refuses keyed resume for a one-shot external CLI with its adapter reason", () => {
+		const asyncRoot = tempRoot();
+		const asyncDir = path.join(asyncRoot, "workflow-external");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		const runner = resolveExternalCliRunnerStatus({ command: "review-cli" });
+		const externalAdapter = externalCliReceiptMetadata({ runner });
+		writeWorkflowReceipt(asyncDir, buildWorkflowReceipt({
+			workflowRunId: "workflow-external",
+			state: "complete",
+			children: [child("advisor", { externalAdapter, resumability: { state: "not-resumable", reason: externalAdapter.nonResumableReason } })],
+		}));
+
+		assert.throws(
+			() => resolveWorkflowReceiptResume({ reference: { workflowRunId: "workflow-external", key: "advisor", latest: true }, asyncDirRoot: asyncRoot }),
+			/not resumable: The one-shot stdin adapter has no durable external session identity/,
 		);
 	});
 });


### PR DESCRIPTION
## Summary

This is PR1 for #1426.

It hardens the current generic `external-cli` path without adding Codex, Claude Code, Grok Build, SDK, app-server, ACP, fork handoff, or live supervisor support.

It adds:

- a code-owned `external-cli` capability descriptor;
- config validation that can keep unsupported capabilities false but cannot widen them;
- `stop` as a code-owned non-narrowable capability because it owns cancellation and cleanup;
- compact additive receipt-v1 external adapter metadata;
- status projection for adapter identity, capability state, unsupported reasons, and non-resumable reason;
- adapter-specific refusal text for external CLI steer and resume;
- regression coverage for receipt compatibility, bounded metadata, unsupported resume/steer, and supervisor-shaped stdout staying inert.

## Scope boundaries

This PR intentionally does not add vendor adapters or richer runner substrate.

Follow-up slices still need to add the safe one-shot runner substrate, Codex `exec --json`, Claude baseline coverage, and Grok baseline coverage before #1426 can close.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-frontmatter.test.ts test/unit/workflow-receipt.test.ts test/unit/external-cli-runner.test.ts test/unit/async-interrupt-action.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`

Fresh review after the stop-capability fix returned `No issues found`.

## Notes

PR #1429 has textual overlap in `CHANGELOG.md`, `src/shared/types.ts`, `src/runs/foreground/subagent-executor.ts`, and `src/workflows/scripted-workflow.ts`. The semantic work is separate.
