### PR TITLE
feat: harden one-shot external runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - External CLI runs now publish code-owned capability limits and compact workflow receipt metadata for adapter identity, artifacts, handoff mode, supervisor support, and resumability.
+- External one-shot runners now support bounded parser hooks and logs, environment allowlists, cached launch preflight, coalesced parser progress, and process-tree cleanup.
 
 ## [0.56.0] - 2026-08-23
 

--- a/src/runs/shared/external-cli-preflight.ts
+++ b/src/runs/shared/external-cli-preflight.ts
@@ -1,0 +1,110 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const MAX_PROBE_OUTPUT_BYTES = 256 * 1024;
+const MAX_PROBE_TIMEOUT_MS = 5_000;
+const MAX_CACHE_ENTRIES = 64;
+
+export type ExternalCliPreflightInvalidationReason = "launch" | "auth" | "parser" | "permission";
+
+export interface ExternalCliPreflightSpec {
+	id: string;
+	versionArgs: readonly string[];
+	helpArgs: readonly string[];
+	probeTimeoutMs?: number;
+	validate?: (result: ExternalCliPreflightResult) => void;
+}
+
+export interface ExternalCliPreflightResult {
+	binaryPath: string;
+	binaryMtimeMs: number;
+	version: string;
+	help: string;
+	cacheHit: boolean;
+}
+
+type CachedPreflight = Omit<ExternalCliPreflightResult, "cacheHit">;
+
+const cache = new Map<string, CachedPreflight>();
+const lookup = new Map<string, string>();
+
+function resolveBinary(command: string, env: NodeJS.ProcessEnv): string {
+	if (path.isAbsolute(command) || command.includes(path.sep)) {
+		const resolved = path.resolve(command);
+		fs.accessSync(resolved, fs.constants.X_OK);
+		return resolved;
+	}
+	const extensions = process.platform === "win32" ? (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";") : [""];
+	for (const directory of (env.PATH ?? "").split(path.delimiter)) {
+		if (!directory) continue;
+		for (const extension of extensions) {
+			const candidate = path.join(directory, `${command}${extension}`);
+			try {
+				fs.accessSync(candidate, fs.constants.X_OK);
+				return fs.realpathSync(candidate);
+			} catch {}
+		}
+	}
+	throw new Error(`External CLI binary '${command}' was not found on PATH.`);
+}
+
+function probeWithTimeout(binaryPath: string, args: readonly string[], env: NodeJS.ProcessEnv, label: string, timeoutMs: number): string {
+	const result = spawnSync(binaryPath, [...args], {
+		env,
+		encoding: "utf-8",
+		killSignal: "SIGKILL",
+		maxBuffer: MAX_PROBE_OUTPUT_BYTES,
+		timeout: timeoutMs,
+		windowsHide: true,
+	});
+	if (result.error) throw new Error(`External CLI ${label} preflight failed: ${result.error.message}`, { cause: result.error });
+	if (result.status !== 0) throw new Error(`External CLI ${label} preflight exited with code ${result.status}: ${(result.stderr || result.stdout).trim()}`);
+	return result.stdout.trim();
+}
+
+function narrowPositiveInteger(value: number | undefined, ceiling: number, label: string): number {
+	if (value === undefined) return ceiling;
+	if (!Number.isSafeInteger(value) || value <= 0 || value > ceiling) throw new Error(`${label} may only narrow the code-owned ceiling of ${ceiling}.`);
+	return value;
+}
+
+function specKey(spec: ExternalCliPreflightSpec): string {
+	return JSON.stringify([spec.id, spec.versionArgs, spec.helpArgs, spec.probeTimeoutMs]);
+}
+
+export function preflightExternalCli(command: string, spec: ExternalCliPreflightSpec, env: NodeJS.ProcessEnv): ExternalCliPreflightResult {
+	const binaryPath = resolveBinary(command, env);
+	const binaryMtimeMs = fs.statSync(binaryPath).mtimeMs;
+	const lookupKey = JSON.stringify([binaryPath, binaryMtimeMs, specKey(spec)]);
+	const cachedKey = lookup.get(lookupKey);
+	const cached = cachedKey ? cache.get(cachedKey) : undefined;
+	if (cached) return { binaryPath: cached.binaryPath, binaryMtimeMs: cached.binaryMtimeMs, version: cached.version, help: cached.help, cacheHit: true };
+	const probeTimeoutMs = narrowPositiveInteger(spec.probeTimeoutMs, MAX_PROBE_TIMEOUT_MS, "probeTimeoutMs");
+	const version = probeWithTimeout(binaryPath, spec.versionArgs, env, "version", probeTimeoutMs);
+	const help = probeWithTimeout(binaryPath, spec.helpArgs, env, "help", probeTimeoutMs);
+	const result = { binaryPath, binaryMtimeMs, version, help, cacheHit: false };
+	spec.validate?.(result);
+	const cacheKey = JSON.stringify([binaryPath, version, binaryMtimeMs, specKey(spec)]);
+	cache.set(cacheKey, { binaryPath, binaryMtimeMs, version, help });
+	lookup.set(lookupKey, cacheKey);
+	while (cache.size > MAX_CACHE_ENTRIES) {
+		const oldest = cache.keys().next().value as string;
+		cache.delete(oldest);
+		for (const [candidateLookup, candidateCache] of lookup) if (candidateCache === oldest) lookup.delete(candidateLookup);
+	}
+	return result;
+}
+
+export function invalidateExternalCliPreflight(command: string, spec: ExternalCliPreflightSpec, _reason: ExternalCliPreflightInvalidationReason): void {
+	const key = specKey(spec);
+	for (const [cacheKey, entry] of cache) {
+		if (entry.binaryPath === command || entry.binaryPath.endsWith(`${path.sep}${command}`) || cacheKey.includes(key)) cache.delete(cacheKey);
+	}
+	for (const [lookupKey, cacheKey] of lookup) if (!cache.has(cacheKey)) lookup.delete(lookupKey);
+}
+
+export function clearExternalCliPreflightCacheForTests(): void {
+	cache.clear();
+	lookup.clear();
+}

--- a/src/runs/shared/external-cli-runner.ts
+++ b/src/runs/shared/external-cli-runner.ts
@@ -1,17 +1,45 @@
-import { spawn } from "node:child_process";
+import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { finished } from "node:stream/promises";
-import { trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import type { ExternalProcessStatus } from "../../shared/types.ts";
+import { createOwnedProcessTreeController, type OwnedProcessTreeController } from "../background/owned-process-tree.ts";
 import { omitExtensionBindingsEnv } from "./extension-bindings.ts";
+import {
+	invalidateExternalCliPreflight,
+	preflightExternalCli,
+	type ExternalCliPreflightResult,
+	type ExternalCliPreflightSpec,
+} from "./external-cli-preflight.ts";
 
-const HARD_KILL_DELAY_MS = 2_000;
 const MAX_OUTPUT_TAIL_BYTES = 64 * 1024;
 const MAX_ERROR_TAIL_BYTES = 64 * 1024;
+const MAX_RAW_LOG_BYTES = 8 * 1024 * 1024;
+const MAX_PARSER_LINE_BYTES = 256 * 1024;
+const MAX_PARSER_STREAM_BYTES = 32 * 1024 * 1024;
+const MAX_PARSER_OUTPUT_BYTES = 1024 * 1024;
+const PARSER_PROGRESS_INTERVAL_MS = 100;
 
 export function buildExternalCliPrompt(systemInstructions: string, task: string): string {
 	return `<System instructions>\n${systemInstructions.trim()}\n\n<Task>\n${task}`;
+}
+
+export interface ExternalCliParserProgress {
+	phase: string;
+	eventCount: number;
+	message?: string;
+}
+
+export interface ExternalCliParserTerminal {
+	state: "completed" | "failed";
+	output?: string;
+	error?: string;
+}
+
+export interface ExternalCliParser {
+	parseLine(line: string): ExternalCliParserProgress | undefined;
+	finish(): ExternalCliParserTerminal | undefined;
 }
 
 export interface ExternalCliRunResult {
@@ -22,6 +50,87 @@ export interface ExternalCliRunResult {
 	stopped?: boolean;
 	processSignal?: string | null;
 	externalProcess: ExternalProcessStatus;
+	parserTerminal?: ExternalCliParserTerminal;
+	preflight?: ExternalCliPreflightResult;
+}
+
+interface StreamLimits {
+	stdoutLogBytes?: number;
+	stderrLogBytes?: number;
+	parserLineBytes?: number;
+	parserStreamBytes?: number;
+	parserOutputBytes?: number;
+}
+
+function narrowLimit(value: number | undefined, ceiling: number, label: string): number {
+	if (value === undefined) return ceiling;
+	assert(Number.isInteger(value) && value > 0 && value <= ceiling, `${label} may only narrow the code-owned ${ceiling}-byte limit.`);
+	return value;
+}
+
+function externalEnvironment(allowlist: readonly string[] | undefined, values: Readonly<Record<string, string>> | undefined): NodeJS.ProcessEnv {
+	if (!allowlist) return omitExtensionBindingsEnv(process.env);
+	const allowed = new Set(allowlist);
+	const env: NodeJS.ProcessEnv = {};
+	for (const key of allowed) {
+		if (!key || key.includes("=") || key.includes("\0")) throw new Error(`Invalid external CLI environment key: ${JSON.stringify(key)}.`);
+		if (process.env[key] !== undefined) env[key] = process.env[key];
+	}
+	for (const [key, value] of Object.entries(values ?? {})) {
+		if (!allowed.has(key)) throw new Error(`External CLI environment value '${key}' is not in the adapter allowlist.`);
+		env[key] = value;
+	}
+	return omitExtensionBindingsEnv(env);
+}
+
+function createByteTail(maxBytes: number): { push(chunk: Buffer): void; text(): string } {
+	const chunks: Buffer[] = [];
+	let bytes = 0;
+	return {
+		push(chunk) {
+			chunks.push(chunk);
+			bytes += chunk.length;
+			while (bytes > maxBytes && chunks.length > 0) {
+				const first = chunks[0]!;
+				const excess = bytes - maxBytes;
+				if (first.length <= excess) {
+					chunks.shift();
+					bytes -= first.length;
+				} else {
+					chunks[0] = first.subarray(excess);
+					bytes -= excess;
+				}
+			}
+		},
+		text: () => Buffer.concat(chunks, bytes).toString("utf-8"),
+	};
+}
+
+function writeBoundedLog(source: NodeJS.ReadableStream, stream: fs.WriteStream, chunk: Buffer, state: { bytes: number; total: number }, limit: number): void {
+	state.total += chunk.length;
+	const remaining = limit - state.bytes;
+	if (remaining <= 0) return;
+	const bytes = chunk.length > remaining ? chunk.subarray(0, remaining) : chunk;
+	state.bytes += bytes.length;
+	if (!stream.write(bytes)) {
+		source.pause();
+		stream.once("drain", () => source.resume());
+	}
+}
+
+function classifyInvalidation(error: string): "auth" | "permission" | "launch" {
+	if (/auth|unauthori[sz]ed|credential|login/i.test(error)) return "auth";
+	if (/permission|forbidden|denied|read.?only/i.test(error)) return "permission";
+	return "launch";
+}
+
+function terminateExternalProcessTree(pid: number, controller: OwnedProcessTreeController): Promise<unknown> {
+	if (process.platform !== "win32") return controller.terminate();
+	return new Promise((resolve) => {
+		const cleanup = spawn("taskkill", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+		cleanup.once("error", () => { void controller.terminate().then(resolve); });
+		cleanup.once("close", () => { void controller.terminate().then(resolve); });
+	});
 }
 
 export function runExternalCli(input: {
@@ -31,14 +140,26 @@ export function runExternalCli(input: {
 	prompt: string;
 	asyncDir: string;
 	stepIndex: number;
+	environment?: { allowlist: readonly string[]; values?: Readonly<Record<string, string>> };
+	preflight?: ExternalCliPreflightSpec;
+	parser?: ExternalCliParser;
+	limits?: StreamLimits;
 	registerTimeout?: (stop: (() => void) | undefined) => void;
 	registerStop?: (stop: (() => void) | undefined) => void;
 	timeoutMessage?: string;
 	stopMessage?: string;
 	onProcess?: (process: ExternalProcessStatus) => void;
+	onParserProgress?: (progress: ExternalCliParserProgress) => void;
 	onStdout?: (chunk: Buffer) => void;
 	onStderr?: (chunk: Buffer) => void;
 }): Promise<ExternalCliRunResult> {
+	const limits = {
+		stdoutLogBytes: narrowLimit(input.limits?.stdoutLogBytes, MAX_RAW_LOG_BYTES, "stdoutLogBytes"),
+		stderrLogBytes: narrowLimit(input.limits?.stderrLogBytes, MAX_RAW_LOG_BYTES, "stderrLogBytes"),
+		parserLineBytes: narrowLimit(input.limits?.parserLineBytes, MAX_PARSER_LINE_BYTES, "parserLineBytes"),
+		parserStreamBytes: narrowLimit(input.limits?.parserStreamBytes, MAX_PARSER_STREAM_BYTES, "parserStreamBytes"),
+		parserOutputBytes: narrowLimit(input.limits?.parserOutputBytes, MAX_PARSER_OUTPUT_BYTES, "parserOutputBytes"),
+	};
 	return new Promise((resolve, reject) => {
 		const startedAt = Date.now();
 		const stdoutPath = path.join(input.asyncDir, `external-${input.stepIndex}.stdout.log`);
@@ -47,19 +168,106 @@ export function runExternalCli(input: {
 		const stdoutStream = fs.createWriteStream(stdoutPath, { flags: "w" });
 		const stderrStream = fs.createWriteStream(stderrPath, { flags: "w" });
 		const streamsFinished = Promise.allSettled([finished(stdoutStream), finished(stderrStream)]);
-		let stdoutTail = Buffer.alloc(0);
-		let stderrTail = Buffer.alloc(0);
+		const env = externalEnvironment(input.environment?.allowlist, input.environment?.values);
+		let preflight: ExternalCliPreflightResult | undefined;
+		try {
+			if (input.preflight) preflight = preflightExternalCli(input.command, input.preflight, env);
+		} catch (error) {
+			const endedAt = Date.now();
+			const externalProcess = { startedAt, endedAt, durationMs: endedAt - startedAt, exitCode: 1, processSignal: null, stdoutPath, stderrPath } satisfies ExternalProcessStatus;
+			stdoutStream.end();
+			stderrStream.end();
+			void streamsFinished.then((streamResults) => {
+				const streamFailure = streamResults.find((streamResult) => streamResult.status === "rejected");
+				if (streamFailure?.status === "rejected") reject(streamFailure.reason);
+				else resolve({ output: "", exitCode: 1, error: error instanceof Error ? error.message : String(error), processSignal: null, externalProcess });
+			});
+			return;
+		}
+		const stdoutTail = createByteTail(MAX_OUTPUT_TAIL_BYTES);
+		const stderrTail = createByteTail(MAX_ERROR_TAIL_BYTES);
+		const stdoutLog = { bytes: 0, total: 0 };
+		const stderrLog = { bytes: 0, total: 0 };
+		let parserBytes = 0;
+		let pendingLine = Buffer.alloc(0);
+		let parserError: Error | undefined;
+		let parserTerminal: ExternalCliParserTerminal | undefined;
+		let latestProgress: ExternalCliParserProgress | undefined;
+		let progressTimer: NodeJS.Timeout | undefined;
 		let timedOut = false;
 		let stopped = false;
 		let settled = false;
-		let hardKillTimer: NodeJS.Timeout | undefined;
-		const child = spawn(input.command, input.args ?? [], {
+		let processTree: OwnedProcessTreeController | undefined;
+		let processPid: number | undefined;
+		let termination: Promise<unknown> | undefined;
+		const flushProgress = () => {
+			if (!latestProgress) return;
+			input.onParserProgress?.(latestProgress);
+			latestProgress = undefined;
+		};
+		const reportProgress = (progress: ExternalCliParserProgress) => {
+			if (!progress.phase || progress.phase.length > 64 || !Number.isSafeInteger(progress.eventCount) || progress.eventCount < 0) {
+				failParser(new Error("External CLI parser returned invalid progress metadata."));
+				return;
+			}
+			latestProgress = { ...progress, ...(progress.message ? { message: progress.message.slice(0, 512) } : {}) };
+			if (progressTimer) return;
+			progressTimer = setTimeout(() => {
+				progressTimer = undefined;
+				flushProgress();
+			}, PARSER_PROGRESS_INTERVAL_MS);
+			progressTimer.unref?.();
+		};
+		const terminate = (reason: "timeout" | "stop") => {
+			if (settled || timedOut || stopped || parserError) return;
+			timedOut = reason === "timeout";
+			stopped = reason === "stop";
+			if (processTree && processPid !== undefined) termination = terminateExternalProcessTree(processPid, processTree);
+		};
+		const failParser = (error: unknown) => {
+			if (parserError) return;
+			parserError = error instanceof Error ? error : new Error(String(error));
+			if (input.preflight) invalidateExternalCliPreflight(input.command, input.preflight, "parser");
+			if (processTree && processPid !== undefined) termination = terminateExternalProcessTree(processPid, processTree);
+		};
+		const parseLine = (line: Buffer) => {
+			if (!input.parser || parserError) return;
+			try {
+				const progress = input.parser.parseLine(line.toString("utf-8"));
+				if (progress) reportProgress(progress);
+			} catch (error) { failParser(error); }
+		};
+		const parseChunk = (chunk: Buffer) => {
+			if (!input.parser || parserError) return;
+			parserBytes += chunk.length;
+			if (parserBytes > limits.parserStreamBytes) {
+				failParser(new Error("External CLI parser stream exceeded its byte limit."));
+				return;
+			}
+			let start = 0;
+			for (let index = 0; index < chunk.length; index++) {
+				if (chunk[index] !== 0x0a) continue;
+				pendingLine = Buffer.concat([pendingLine, chunk.subarray(start, index)]);
+				if (pendingLine.length > limits.parserLineBytes) return failParser(new Error("External CLI parser line exceeded its byte limit."));
+				parseLine(pendingLine);
+				pendingLine = Buffer.alloc(0);
+				start = index + 1;
+			}
+			pendingLine = Buffer.concat([pendingLine, chunk.subarray(start)]);
+			if (pendingLine.length > limits.parserLineBytes) failParser(new Error("External CLI parser line exceeded its byte limit."));
+		};
+		const child = spawn(preflight?.binaryPath ?? input.command, input.args ?? [], {
 			cwd: input.cwd,
-			env: omitExtensionBindingsEnv(process.env),
+			env,
 			stdio: ["pipe", "pipe", "pipe"],
 			shell: false,
 			windowsHide: true,
-		});
+			detached: process.platform !== "win32",
+		}) as ChildProcessWithoutNullStreams;
+		if (typeof child.pid === "number") {
+			processPid = child.pid;
+			processTree = createOwnedProcessTreeController(child.pid, { termGraceMs: 2_000 });
+		}
 		const initialProcess: ExternalProcessStatus = {
 			...(typeof child.pid === "number" ? { pid: child.pid } : {}),
 			startedAt,
@@ -68,69 +276,80 @@ export function runExternalCli(input: {
 		};
 		input.onProcess?.(initialProcess);
 		child.stdout.on("data", (chunk: Buffer) => {
-			stdoutStream.write(chunk);
+			parseChunk(chunk);
+			writeBoundedLog(child.stdout, stdoutStream, chunk, stdoutLog, limits.stdoutLogBytes);
 			input.onStdout?.(chunk);
-			stdoutTail = Buffer.concat([stdoutTail, chunk]);
-			if (stdoutTail.length > MAX_OUTPUT_TAIL_BYTES) stdoutTail = stdoutTail.subarray(stdoutTail.length - MAX_OUTPUT_TAIL_BYTES);
+			stdoutTail.push(chunk);
 		});
 		child.stderr.on("data", (chunk: Buffer) => {
-			stderrStream.write(chunk);
+			writeBoundedLog(child.stderr, stderrStream, chunk, stderrLog, limits.stderrLogBytes);
 			input.onStderr?.(chunk);
-			stderrTail = Buffer.concat([stderrTail, chunk]);
-			if (stderrTail.length > MAX_ERROR_TAIL_BYTES) stderrTail = stderrTail.subarray(stderrTail.length - MAX_ERROR_TAIL_BYTES);
+			stderrTail.push(chunk);
 		});
-		const terminate = (reason: "timeout" | "stop") => {
-			if (settled || timedOut || stopped) return;
-			timedOut = reason === "timeout";
-			stopped = reason === "stop";
-			trySignalChild(child, "SIGTERM");
-			hardKillTimer = setTimeout(() => {
-				if (!settled) trySignalChild(child, "SIGKILL");
-			}, HARD_KILL_DELAY_MS);
-			hardKillTimer.unref?.();
-		};
 		input.registerTimeout?.(() => terminate("timeout"));
 		input.registerStop?.(() => terminate("stop"));
 		child.stdin.on("error", () => {});
 		child.stdin.end(input.prompt);
 		let spawnError: Error | undefined;
 		child.once("error", (error) => { spawnError = error; });
+		child.stdout.once("end", () => {
+			if (!input.parser || parserError) return;
+			if (pendingLine.length > 0) parseLine(pendingLine);
+			try {
+				parserTerminal = input.parser.finish();
+				if (!parserTerminal) failParser(new Error("External CLI parser did not produce a terminal state."));
+				else if (Buffer.byteLength(parserTerminal.output ?? "", "utf-8") > limits.parserOutputBytes) failParser(new Error("External CLI parser terminal output exceeded its byte limit."));
+				else if (Buffer.byteLength(parserTerminal.error ?? "", "utf-8") > 4 * 1024) failParser(new Error("External CLI parser terminal error exceeded its byte limit."));
+			} catch (error) { failParser(error); }
+		});
 		child.once("close", (exitCode, signal) => {
 			settled = true;
-			if (hardKillTimer) clearTimeout(hardKillTimer);
+			if (progressTimer) clearTimeout(progressTimer);
+			flushProgress();
 			input.registerTimeout?.(undefined);
 			input.registerStop?.(undefined);
-			const endedAt = Date.now();
-			const externalProcess: ExternalProcessStatus = {
-				...initialProcess,
-				endedAt,
-				durationMs: endedAt - startedAt,
-				exitCode,
-				processSignal: signal,
-			};
-			input.onProcess?.(externalProcess);
-			const stderr = stderrTail.toString("utf-8").trim();
-			const error = stopped
-				? input.stopMessage ?? "Subagent stopped by user."
-				: timedOut
-					? input.timeoutMessage ?? "Subagent timed out."
-					: spawnError?.message ?? (exitCode === 0 ? undefined : stderr || `External CLI exited with code ${exitCode}.`);
-			const result: ExternalCliRunResult = {
-				output: stdoutTail.toString("utf-8").trim(),
-				exitCode: timedOut || stopped || spawnError ? 1 : exitCode,
-				...(error ? { error } : {}),
-				...(timedOut ? { timedOut: true } : {}),
-				...(stopped ? { stopped: true } : {}),
-				processSignal: signal,
-				externalProcess,
-			};
-			stdoutStream.end();
-			stderrStream.end();
-			void streamsFinished.then((streamResults) => {
+			void (async () => {
+				if (termination) await termination;
+				else if (processTree) await processTree.finishAfterWriterClose();
+				const endedAt = Date.now();
+				const externalProcess: ExternalProcessStatus = {
+					...initialProcess,
+					endedAt,
+					durationMs: endedAt - startedAt,
+					exitCode,
+					processSignal: signal,
+					stdoutBytes: stdoutLog.total,
+					stderrBytes: stderrLog.total,
+					...(stdoutLog.total > stdoutLog.bytes ? { stdoutTruncated: true } : {}),
+					...(stderrLog.total > stderrLog.bytes ? { stderrTruncated: true } : {}),
+				};
+				input.onProcess?.(externalProcess);
+				const stderr = stderrTail.text().trim();
+				const parserFailure = parserError?.message ?? (parserTerminal?.state === "failed" ? parserTerminal.error ?? "External CLI parser reported terminal failure." : undefined);
+				const error = stopped
+					? input.stopMessage ?? "Subagent stopped by user."
+					: timedOut
+						? input.timeoutMessage ?? "Subagent timed out."
+						: spawnError?.message ?? parserFailure ?? (exitCode === 0 ? undefined : stderr || `External CLI exited with code ${exitCode}.`);
+				if (error && input.preflight && !parserError) invalidateExternalCliPreflight(input.command, input.preflight, classifyInvalidation(error));
+				const result: ExternalCliRunResult = {
+					output: (!parserError && parserTerminal?.state === "completed" ? parserTerminal.output ?? "" : stdoutTail.text()).trim(),
+					exitCode: timedOut || stopped || spawnError || parserFailure ? 1 : exitCode,
+					...(error ? { error } : {}),
+					...(timedOut ? { timedOut: true } : {}),
+					...(stopped ? { stopped: true } : {}),
+					processSignal: signal,
+					externalProcess,
+					...(parserTerminal ? { parserTerminal } : {}),
+					...(preflight ? { preflight } : {}),
+				};
+				stdoutStream.end();
+				stderrStream.end();
+				const streamResults = await streamsFinished;
 				const streamFailure = streamResults.find((streamResult) => streamResult.status === "rejected");
 				if (streamFailure?.status === "rejected") reject(streamFailure.reason);
 				else resolve(result);
-			});
+			})();
 		});
 	});
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1466,6 +1466,10 @@ export interface ExternalProcessStatus {
 	processSignal?: string | null;
 	stdoutPath: string;
 	stderrPath: string;
+	stdoutBytes?: number;
+	stderrBytes?: number;
+	stdoutTruncated?: boolean;
+	stderrTruncated?: boolean;
 }
 
 export interface AsyncStatus {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -780,8 +780,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		}
 		assert.equal(workflowResult.state, "complete");
 		assert.match(workflowResult.results?.[0]?.output ?? "", /Async: external/);
-		for (let attempt = 0; attempt < 100 && !fs.existsSync(markerPath); attempt++) {
-			await new Promise((resolve) => setTimeout(resolve, 20));
+		for (let attempt = 0; attempt < 300 && !fs.existsSync(markerPath); attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
 		assert.equal(fs.readFileSync(markerPath, "utf-8"), "started");
 		assert.equal(mockPi.callCount(), 0);
@@ -834,8 +834,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.isError, undefined, result.content[0]?.text ?? "launch failed");
 		assert.ok(result.details.asyncId);
 		assert.match(result.content[0]?.text ?? "", /Async: external/);
-		for (let attempt = 0; attempt < 100 && !fs.existsSync(markerPath); attempt++) {
-			await new Promise((resolve) => setTimeout(resolve, 20));
+		for (let attempt = 0; attempt < 300 && !fs.existsSync(markerPath); attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
 		assert.equal(fs.readFileSync(markerPath, "utf-8"), "started");
 		assert.equal(mockPi.callCount(), 0);
@@ -883,8 +883,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.isError, undefined, result.content[0]?.text ?? "launch failed");
 		assert.ok(result.details.asyncId);
-		for (let attempt = 0; attempt < 100 && !fs.existsSync(markerPath); attempt++) {
-			await new Promise((resolve) => setTimeout(resolve, 20));
+		for (let attempt = 0; attempt < 300 && !fs.existsSync(markerPath); attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
 		assert.equal(fs.readFileSync(markerPath, "utf-8"), "started");
 		assert.equal(mockPi.callCount(), 0);
@@ -923,8 +923,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.isError, undefined);
 		assert.doesNotMatch(result.content[0]?.text ?? "", /Unknown subagent model/);
-		for (let attempt = 0; attempt < 100 && !fs.existsSync(markerPath); attempt++) {
-			await new Promise((resolve) => setTimeout(resolve, 20));
+		for (let attempt = 0; attempt < 300 && !fs.existsSync(markerPath); attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
 		assert.equal(fs.readFileSync(markerPath, "utf-8"), "started");
 		assert.equal(mockPi.callCount(), 0);

--- a/test/unit/external-cli-runner.test.ts
+++ b/test/unit/external-cli-runner.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { buildExternalCliPrompt, runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+import { clearExternalCliPreflightCacheForTests } from "../../src/runs/shared/external-cli-preflight.ts";
 import { resolveExternalCliRunnerStatus } from "../../src/runs/shared/external-cli-contract.ts";
 import { PI_SUBAGENT_EXTENSION_BINDINGS_ENV } from "../../src/runs/shared/extension-bindings.ts";
+import { writeNodeCommand } from "../support/node-command.ts";
 
 const tempDirs: string[] = [];
 function tempDir(): string {
@@ -14,6 +17,7 @@ function tempDir(): string {
 	return dir;
 }
 afterEach(() => {
+	clearExternalCliPreflightCacheForTests();
 	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -81,6 +85,165 @@ describe("external CLI runner", () => {
 		assert.equal(fs.readFileSync(result.externalProcess.stderrPath, "utf-8"), stderr);
 	});
 
+	it("parses the complete bounded stream separately from bounded raw logs and display tails", async () => {
+		const dir = tempDir();
+		let terminal = "";
+		const result = await runExternalCli({
+			command: process.execPath,
+			args: ["-e", "process.stdout.write('x'.repeat(100000)+'\\nFINAL:trusted result\\n')"],
+			cwd: dir,
+			prompt: "x",
+			asyncDir: dir,
+			stepIndex: 8,
+			limits: { stdoutLogBytes: 32 },
+			parser: {
+				parseLine(line) { if (line.startsWith("FINAL:")) terminal = line.slice(6); return undefined; },
+				finish() { return terminal ? { state: "completed", output: terminal } : undefined; },
+			},
+		});
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.output, "trusted result");
+		assert.equal(fs.statSync(result.externalProcess.stdoutPath).size, 32);
+		assert.equal(result.externalProcess.stdoutTruncated, true);
+		assert.equal(result.externalProcess.stdoutBytes, 100022);
+	});
+
+	it("allows parser and log limits to narrow but not widen code-owned bounds", () => {
+		const dir = tempDir();
+		assert.throws(() => runExternalCli({
+			command: process.execPath,
+			cwd: dir,
+			prompt: "x",
+			asyncDir: dir,
+			stepIndex: 20,
+			limits: { stdoutLogBytes: 9 * 1024 * 1024 },
+		}), /stdoutLogBytes may only narrow/);
+	});
+
+	it("fails closed on malformed, oversized, or missing parser terminal state", async () => {
+		const dir = tempDir();
+		const malformed = await runExternalCli({
+			command: process.execPath, args: ["-e", "process.stdout.write('bad\\n')"], cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 9,
+			parser: { parseLine() { throw new Error("malformed event"); }, finish() { return undefined; } },
+		});
+		assert.equal(malformed.exitCode, 1);
+		assert.match(malformed.error ?? "", /malformed event/);
+
+		const oversized = await runExternalCli({
+			command: process.execPath, args: ["-e", "process.stdout.write('x'.repeat(128))"], cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 10,
+			limits: { parserLineBytes: 64 },
+			parser: { parseLine() { return undefined; }, finish() { return { state: "completed" }; } },
+		});
+		assert.equal(oversized.exitCode, 1);
+		assert.match(oversized.error ?? "", /line exceeded/);
+
+		const missing = await runExternalCli({
+			command: process.execPath, args: ["-e", "process.stdout.write('event\\n')"], cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 11,
+			parser: { parseLine() { return undefined; }, finish() { return undefined; } },
+		});
+		assert.equal(missing.exitCode, 1);
+		assert.match(missing.error ?? "", /did not produce a terminal state/);
+	});
+
+	it("coalesces parser progress and flushes the terminal update", async () => {
+		const dir = tempDir();
+		const updates: number[] = [];
+		let count = 0;
+		const result = await runExternalCli({
+			command: process.execPath, args: ["-e", "process.stdout.write(Array.from({length:20},(_,i)=>String(i)).join('\\n')+'\\n')"], cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 12,
+			parser: {
+				parseLine() { count++; return { phase: "streaming", eventCount: count }; },
+				finish() { return { state: "completed", output: "done" }; },
+			},
+			onParserProgress: (progress) => updates.push(progress.eventCount),
+		});
+		assert.equal(result.exitCode, 0);
+		assert.deepEqual(updates, [20]);
+	});
+
+	it("passes only adapter-allowed environment keys", async () => {
+		const dir = tempDir();
+		const previousSecret = process.env.UNRELATED_SECRET;
+		const previousBinding = process.env[PI_SUBAGENT_EXTENSION_BINDINGS_ENV];
+		process.env.UNRELATED_SECRET = "hidden";
+		process.env[PI_SUBAGENT_EXTENSION_BINDINGS_ENV] = "hidden-binding";
+		try {
+			const result = await runExternalCli({
+				command: process.execPath,
+				args: ["-e", `process.stdout.write(JSON.stringify({allowed:process.env.ALLOWED_VALUE,secret:process.env.UNRELATED_SECRET,binding:process.env.${PI_SUBAGENT_EXTENSION_BINDINGS_ENV}}))`],
+				cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 13,
+				environment: { allowlist: ["ALLOWED_VALUE", PI_SUBAGENT_EXTENSION_BINDINGS_ENV], values: { ALLOWED_VALUE: "yes", [PI_SUBAGENT_EXTENSION_BINDINGS_ENV]: "still-hidden" } },
+			});
+			assert.deepEqual(JSON.parse(result.output), { allowed: "yes" });
+		} finally {
+			if (previousSecret === undefined) delete process.env.UNRELATED_SECRET; else process.env.UNRELATED_SECRET = previousSecret;
+			if (previousBinding === undefined) delete process.env[PI_SUBAGENT_EXTENSION_BINDINGS_ENV]; else process.env[PI_SUBAGENT_EXTENSION_BINDINGS_ENV] = previousBinding;
+		}
+	});
+
+	it("caches launch preflight and invalidates it after a launch failure", async () => {
+		const dir = tempDir();
+		const countPath = path.join(dir, "count.log");
+		const failPath = path.join(dir, "fail-once");
+		const scriptPath = path.join(dir, "preflight-cli.cjs");
+		fs.writeFileSync(scriptPath, `
+const fs=require('fs'); fs.appendFileSync(${JSON.stringify(countPath)}, 'x');
+if(process.argv[2]==='--version'){console.log('v1');process.exit(0)}
+if(process.argv[2]==='--help'){console.log('safe-help');process.exit(0)}
+if(fs.existsSync(${JSON.stringify(failPath)})){fs.rmSync(${JSON.stringify(failPath)});console.error('launch failed');process.exit(2)}
+process.stdout.write('ok');`);
+		const preflight = { id: "test-one-shot", versionArgs: [scriptPath, "--version"], helpArgs: [scriptPath, "--help"], validate: (value: { version: string; help: string }) => { assert.equal(value.version, "v1"); assert.match(value.help, /safe-help/); } };
+		const run = (stepIndex: number) => runExternalCli({ command: process.execPath, args: [scriptPath], cwd: dir, prompt: "x", asyncDir: dir, stepIndex, preflight });
+		assert.equal((await run(14)).preflight?.cacheHit, false);
+		assert.equal((await run(15)).preflight?.cacheHit, true);
+		assert.equal(fs.readFileSync(countPath, "utf-8").length, 4);
+		fs.writeFileSync(failPath, "1");
+		assert.equal((await run(16)).exitCode, 2);
+		assert.equal((await run(17)).preflight?.cacheHit, false);
+		assert.equal(fs.readFileSync(countPath, "utf-8").length, 8);
+	});
+
+	it("bounds launch preflight probes", async () => {
+		const dir = tempDir();
+		const scriptPath = path.join(dir, "hanging-preflight-cli.cjs");
+		fs.writeFileSync(scriptPath, `
+if(process.argv[2]==='--version') setInterval(()=>{}, 1000);
+if(process.argv[2]==='--help'){console.log('safe-help');process.exit(0)}
+process.stdout.write('ok');`);
+
+		const timedOut = await runExternalCli({
+			command: process.execPath,
+			args: [scriptPath],
+			cwd: dir,
+			prompt: "x",
+			asyncDir: dir,
+			stepIndex: 21,
+			preflight: { id: "hanging", versionArgs: [scriptPath, "--version"], helpArgs: [scriptPath, "--help"], probeTimeoutMs: 25 },
+		});
+		assert.equal(timedOut.exitCode, 1);
+		assert.match(timedOut.error ?? "", /version preflight failed|ETIMEDOUT|timed out/i);
+
+		const widened = await runExternalCli({
+			command: process.execPath,
+			args: [scriptPath],
+			cwd: dir,
+			prompt: "x",
+			asyncDir: dir,
+			stepIndex: 22,
+			preflight: { id: "wide-timeout", versionArgs: [scriptPath, "--version"], helpArgs: [scriptPath, "--help"], probeTimeoutMs: 6_000 },
+		});
+		assert.equal(widened.exitCode, 1);
+		assert.match(widened.error ?? "", /probeTimeoutMs may only narrow/);
+	});
+
+	it("does not probe an external binary while resolving status metadata", () => {
+		const dir = tempDir();
+		const marker = path.join(dir, "probed");
+		const command = writeNodeCommand(dir, "cold-cli", `require('fs').writeFileSync(${JSON.stringify(marker)}, 'yes')`);
+		resolveExternalCliRunnerStatus({ command });
+		assert.equal(fs.existsSync(marker), false);
+	});
+
 	it("rejects when a log stream cannot be written", async () => {
 		const dir = tempDir();
 		fs.mkdirSync(path.join(dir, "external-2.stdout.log"));
@@ -103,6 +266,13 @@ describe("external CLI runner", () => {
 		const result = await runExternalCli({ command: path.join(dir, "does-not-exist"), cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 2 });
 		assert.equal(result.exitCode, 1);
 		assert.match(result.error ?? "", /ENOENT|not found/i);
+		const preflighted = await runExternalCli({
+			command: "missing-preflight-cli", cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 19,
+			preflight: { id: "missing", versionArgs: ["--version"], helpArgs: ["--help"] },
+			environment: { allowlist: ["PATH"] },
+		});
+		assert.equal(preflighted.exitCode, 1);
+		assert.match(preflighted.error ?? "", /binary 'missing-preflight-cli' was not found on PATH/);
 	});
 
 	it("terminates on timeout", async () => {
@@ -125,5 +295,24 @@ describe("external CLI runner", () => {
 		const result = await pending;
 		assert.equal(result.stopped, true);
 		assert.equal(result.error, "stopped for test");
+	});
+
+	it("terminates descendants in the owned process group on stop", { skip: process.platform === "win32" ? "POSIX process-group assertion" : undefined }, async () => {
+		const dir = tempDir();
+		const descendantPath = path.join(dir, "descendant.pid");
+		let stop: (() => void) | undefined;
+		const script = `const {spawn}=require('child_process');const fs=require('fs');const c=spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{stdio:'ignore'});fs.writeFileSync(${JSON.stringify(descendantPath)},String(c.pid));setInterval(()=>{},1000)`;
+		const pending = runExternalCli({ command: process.execPath, args: ["-e", script], cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 18, registerStop: (handler) => { stop = handler; } });
+		const deadline = Date.now() + 2_000;
+		while (!fs.existsSync(descendantPath)) {
+			if (Date.now() > deadline) throw new Error("descendant did not start");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		const descendantPid = Number(fs.readFileSync(descendantPath, "utf-8"));
+		stop?.();
+		const result = await pending;
+		assert.equal(result.stopped, true);
+		const status = spawnSync("ps", ["-p", String(descendantPid), "-o", "stat="], { encoding: "utf-8" }).stdout.trim();
+		assert.ok(!status || status.startsWith("Z"), `descendant ${descendantPid} remained active (${status})`);
 	});
 });


### PR DESCRIPTION
## Summary

This is PR2 for #1426.

It hardens the one-shot `external-cli` runner substrate without adding Codex, Claude Code, Grok Build, SDK, app-server, ACP, fork handoff, live supervisor support, or packaged vendor support.

It adds:

- owned process-tree cleanup for stop, timeout, and parser failure;
- bounded complete-stream parser hooks that are separate from display tails;
- bounded raw stdout/stderr logs with byte counts and truncation flags;
- stdout/stderr backpressure handling for file logs;
- an adapter-owned environment allowlist seam;
- launch-only binary/version/help preflight with cache, bounded output, bounded timeout, and failure invalidation;
- coalesced parser progress callbacks;
- focused tests for parser bounds, terminal state, cleanup, preflight cache/invalidation, preflight timeout, env stripping, and cold status resolution.

## Scope boundaries

This PR still does not claim any vendor adapter is supported.

Follow-up slices still need to add Codex `exec --json`, Claude baseline coverage, and Grok baseline coverage before #1426 can close.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-frontmatter.test.ts test/unit/run-status.test.ts test/unit/workflow-receipt.test.ts test/unit/workflow-detach-reconcile.test.ts test/unit/async-interrupt-action.test.ts test/unit/external-cli-runner.test.ts test/unit/owned-process-tree.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/external-cli-runner.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`

Fresh 5.5 high review found one preflight timeout issue. It was fixed and the follow-up review returned `No issues found`.

## Notes

PR #1429 has textual overlap in `CHANGELOG.md`, `src/shared/types.ts`, and runner/workflow files. The semantic work is separate.
