### PR TITLE
feat: add Codex exec adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add the built-in `codex-exec` profile with code-owned read-only argv, bounded JSONL terminal proof, and a final-message artifact.
 - External CLI runs now publish code-owned capability limits and compact workflow receipt metadata for adapter identity, artifacts, handoff mode, supervisor support, and resumability.
 - External one-shot runners now support bounded parser hooks and logs, environment allowlists, cached launch preflight, coalesced parser progress, and process-tree cleanup.
 

--- a/agents/codex-exec.md
+++ b/agents/codex-exec.md
@@ -1,0 +1,15 @@
+---
+name: codex-exec
+description: Read-only one-shot analysis through the installed Codex CLI
+runner:
+  type: external-cli
+  adapter: codex-exec
+  command: codex
+  promptDelivery: stdin
+async: true
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+---
+
+Analyze the task in read-only mode. Return a concise final answer with evidence. Do not edit files or request wider access.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -74,6 +74,27 @@ Review the task and return advice only. Do not edit files.
 
 ### Advisory runner data boundary
 
+The built-in `codex-exec` profile is the supported Codex one-shot mode. It requires an installed and authenticated Codex CLI. The adapter owns its argv and runs `codex exec --json` with the read-only sandbox, approval policy `never`, ephemeral sessions, ignored exec rules, and a final-message artifact. User profiles cannot add argv to this adapter or select a wider sandbox.
+
+Run it asynchronously:
+
+```text
+Use codex-exec to analyze this change without editing files.
+```
+
+The adapter validates `codex --version` and `codex exec --help` only when a run launches. Discovery, list, status, and native Pi launches do not probe Codex. JSONL, stderr, and stdout are untrusted. A run succeeds only after bounded valid JSONL contains one `turn.completed` event and the bounded final-message artifact is present.
+
+Maintainers can collect real smoke evidence without making it part of the normal test suite:
+
+```bash
+PI_SUBAGENTS_CODEX_EXEC_SMOKE=1 \
+PI_SUBAGENTS_CODEX_EXEC_SMOKE_REPORT=/tmp/pi-subagents-codex-exec-smoke.json \
+node --experimental-strip-types --import ./test/support/register-loader.mjs \
+  --test test/integration/codex-exec-smoke.test.ts
+```
+
+The smoke asks Codex to attempt a write canary under the packaged read-only policy. Review the JSON report and confirm `writeCanaryExists` is `false`. The report contains paths and compact process metadata, but no raw protocol output or credentials.
+
 Native `oracle` runs inside Pi and can use its configured read tools. `claude-advisor` sends the assembled prompt to the configured local external CLI through stdin. An external-job agent sends the assembled prompt to its registered provider. Provider options and a prompt digest are persisted in Pi run state. The prompt text is delivered through the local host bridge to the provider and is not stored in the public result payload. Do not place secrets in advisory prompts unless the target provider is approved to receive them.
 
 ### External-job state table

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -378,15 +378,17 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 			if (runner.type === "pi" && Object.keys(runner).every((key) => key === "type")) target.runner = { type: "pi" };
 			else if (runner.type === "external-cli" && typeof runner.command === "string" && runner.command.trim()
 				&& (runner.args === undefined || (Array.isArray(runner.args) && runner.args.every((arg) => typeof arg === "string")))
+				&& (runner.adapter === undefined || runner.adapter === "codex-exec")
+				&& (runner.adapter !== "codex-exec" || runner.args === undefined || runner.args.length === 0)
 				&& (runner.promptDelivery === undefined || runner.promptDelivery === "stdin")
-				&& Object.keys(runner).every((key) => ["type", "command", "args", "promptDelivery"].includes(key))) {
+				&& Object.keys(runner).every((key) => ["type", "adapter", "command", "args", "promptDelivery"].includes(key))) {
 				const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
-				target.runner = { type: "external-cli", command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
+				target.runner = { type: "external-cli", ...(runner.adapter === "codex-exec" ? { adapter: "codex-exec" } : {}), command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
 			} else if (runner.type === "external-job" && typeof runner.provider === "string" && runner.provider.trim() === runner.provider && runner.provider
 				&& (runner.options === undefined || (runner.options && typeof runner.options === "object" && !Array.isArray(runner.options) && isJsonSerializable(runner.options)))
 				&& Object.keys(runner).every((key) => ["type", "provider", "options"].includes(key))) {
 				target.runner = { type: "external-job", provider: runner.provider, ...(runner.options ? { options: runner.options as Record<string, unknown> } : {}) };
-			} else return "config.runner must be { type: 'pi' }, { type: 'external-cli', command: string, args?: string[], promptDelivery?: 'stdin' }, or { type: 'external-job', provider: string, options?: object }.";
+			} else return "config.runner must be { type: 'pi' }, { type: 'external-cli', adapter?: 'codex-exec', command: string, args?: string[], promptDelivery?: 'stdin' }, or { type: 'external-job', provider: string, options?: object }.";
 		} else return "config.runner must be an object, false, or empty string when provided.";
 	}
 	if (hasKey(cfg, "model")) {

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1683,16 +1683,19 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) {
 		throw new Error(`Agent '${agentName}' external-cli runner args must be an array of strings.`);
 	}
+	if (runner.adapter !== undefined && runner.adapter !== "codex-exec") throw new Error(`Agent '${agentName}' external-cli runner adapter must be 'codex-exec'.`);
+	if (runner.adapter === "codex-exec" && Array.isArray(runner.args) && runner.args.length > 0) throw new Error(`Agent '${agentName}' codex-exec adapter owns its argv; runner args are not supported.`);
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") {
 		throw new Error(`Agent '${agentName}' external-cli runner promptDelivery must be 'stdin'.`);
 	}
 	const capabilities = parseExternalCliCapabilityNarrowing(runner.capabilities, `Agent '${agentName}' external-cli runner capabilities`);
-	const supported = new Set(["type", "command", "args", "promptDelivery", "capabilities"]);
+	const supported = new Set(["type", "adapter", "command", "args", "promptDelivery", "capabilities"]);
 	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
 	if (unknown.length > 0) throw new Error(`Agent '${agentName}' external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
 	const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
 	return {
 		type: "external-cli",
+		...(runner.adapter === "codex-exec" ? { adapter: "codex-exec" as const } : {}),
 		command: runner.command.trim(),
 		...(runnerArgs?.length ? { args: runnerArgs } : {}),
 		...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}),

--- a/src/agents/builtin-names.ts
+++ b/src/agents/builtin-names.ts
@@ -1,5 +1,6 @@
 export const BUILTIN_AGENT_NAMES = [
 	"advisor",
+	"codex-exec",
 	"delegate",
 	"oracle",
 	"researcher",

--- a/src/agents/runtime-agent-registry.ts
+++ b/src/agents/runtime-agent-registry.ts
@@ -170,13 +170,15 @@ function validateRunner(value: unknown): AgentRunnerConfig | undefined {
 	if (runner.type !== "external-cli") throw new Error("Runtime agent definition runner.type must be 'pi', 'external-cli', or 'external-job'.");
 	if (typeof runner.command !== "string" || !runner.command.trim()) throw new Error("Runtime agent definition external-cli runner requires a non-empty command string.");
 	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) throw new Error("Runtime agent definition external-cli runner args must be an array of strings.");
+	if (runner.adapter !== undefined && runner.adapter !== "codex-exec") throw new Error("Runtime agent definition external-cli runner adapter must be 'codex-exec'.");
+	if (runner.adapter === "codex-exec" && Array.isArray(runner.args) && runner.args.length > 0) throw new Error("Runtime agent definition codex-exec adapter owns its argv; runner args are not supported.");
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") throw new Error("Runtime agent definition external-cli runner promptDelivery must be 'stdin'.");
 	const capabilities = parseExternalCliCapabilityNarrowing(runner.capabilities, "Runtime agent definition external-cli runner capabilities");
-	const supported = new Set(["type", "command", "args", "promptDelivery", "capabilities"]);
+	const supported = new Set(["type", "adapter", "command", "args", "promptDelivery", "capabilities"]);
 	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
 	if (unknown.length > 0) throw new Error(`Runtime agent definition external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
 	const args = runner.args as string[] | undefined;
-	return { type: "external-cli", command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}), ...(capabilities ? { capabilities } : {}) };
+	return { type: "external-cli", ...(runner.adapter === "codex-exec" ? { adapter: "codex-exec" as const } : {}), command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}), ...(capabilities ? { capabilities } : {}) };
 }
 
 function validateTurnBudget(value: unknown): TurnBudgetConfig | undefined {

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -541,6 +541,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 					if (runner) {
 						lines.push(`  Runner: external-cli (${runner.command}${runner.args.length ? ` ${runner.args.join(" ")}` : ""})`);
 						lines.push(`  Adapter: ${runner.adapter.id} v${runner.adapter.version} (${runner.adapter.executionMode})`);
+						if (runner.safety) lines.push(`  Safety: sandbox=${runner.safety.sandbox}, approval=${runner.safety.approvalPolicy}, ephemeral=${runner.safety.ephemeral}`);
 						lines.push(`  Capabilities: stop=${runner.capabilities.stop}, steer=false, resume=false, structuredOutput=false, toolEvents=false, supervisor=unsupported, forkContext=false, extensionBindings=false`);
 						lines.push(`  Unsupported steer: ${runner.unsupportedReasons.steer}`);
 						lines.push(`  Unsupported resume: ${runner.nonResumableReason}`);
@@ -550,7 +551,10 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 						lines.push("  Runner: external-cli (invalid persisted runner metadata)");
 					}
 					if (step.externalProcess?.pid !== undefined) lines.push(`  Process: ${step.externalProcess.pid}`);
-					if (step.externalProcess) lines.push(`  Stdout: ${step.externalProcess.stdoutPath}`, `  Stderr: ${step.externalProcess.stderrPath}`);
+					if (step.externalProcess) {
+						lines.push(`  Stdout: ${step.externalProcess.stdoutPath}`, `  Stderr: ${step.externalProcess.stderrPath}`);
+						if (step.externalProcess.finalOutputPath) lines.push(`  Final output: ${step.externalProcess.finalOutputPath}`);
+					}
 				} else if (step.runner?.type === "external-job") {
 					lines.push(`  Runner: external-job (${step.runner.provider})`);
 					if (step.externalJob?.providerJobId) lines.push(`  Provider job: ${step.externalJob.providerJobId}`);

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -144,6 +144,7 @@ import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
 import { createBoundedByteTail, createBoundedLineReader, formatProtocolOutputLimit, MAX_CHILD_STDERR_BYTES, PI_AGGREGATE_EVENT_PROJECTOR, projectChildLifecycle, type ChildLifecycleAction, type ProtocolOutputLimit } from "../shared/child-protocol.ts";
 import { acquireSessionLease, type SessionLeaseRequest } from "../shared/session-lease.ts";
 import { buildExternalCliPrompt, runExternalCli } from "../shared/external-cli-runner.ts";
+import { resolveCodexExecLaunch } from "../shared/codex-exec-adapter.ts";
 import { resolveExternalCliRunnerStatus } from "../shared/external-cli-contract.ts";
 import { runExternalJob } from "../shared/external-job-runner.ts";
 import { createOrcaProgressTab, type OrcaProgressTab } from "../shared/orca-progress-tabs.ts";
@@ -1382,15 +1383,22 @@ async function runSingleStepInner(
 	transcriptWriter?.writeInitialUserMessage(`${PROMPT_REDACTED}; live Prompt Audit only.`);
 
 	if (step.runner?.type === "external-cli") {
-		const runner = resolveExternalCliRunnerStatus(step.runner);
+		const adapterLaunch = step.runner.adapter === "codex-exec"
+			? resolveCodexExecLaunch({ command: step.runner.command, asyncDir: path.dirname(ctx.outputFile), stepIndex: ctx.flatIndex })
+			: undefined;
+		const runner = resolveExternalCliRunnerStatus({ ...step.runner, ...(adapterLaunch ? { args: adapterLaunch.args } : {}) });
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
 		const external = await runExternalCli(omitUndefinedProperties({
-			command: runner.command,
-			args: runner.args,
+			command: adapterLaunch?.command ?? runner.command,
+			args: adapterLaunch?.args ?? runner.args,
 			cwd: step.cwd ?? ctx.cwd,
 			prompt: buildExternalCliPrompt(step.systemPrompt ?? "", task),
 			asyncDir: path.dirname(ctx.outputFile),
 			stepIndex: ctx.flatIndex,
+			environment: adapterLaunch?.environment,
+			preflight: adapterLaunch?.preflight,
+			parser: adapterLaunch?.parser,
+			finalOutputPath: adapterLaunch?.finalOutputPath,
 			registerTimeout: ctx.registerTimeout,
 			registerStop: ctx.registerStop,
 			timeoutMessage: ctx.timeoutMessage,

--- a/src/runs/shared/codex-exec-adapter.ts
+++ b/src/runs/shared/codex-exec-adapter.ts
@@ -1,0 +1,128 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ExternalCliParser, ExternalCliParserProgress, ExternalCliParserTerminal } from "./external-cli-runner.ts";
+import type { ExternalCliPreflightSpec } from "./external-cli-preflight.ts";
+
+const MAX_FINAL_MESSAGE_BYTES = 1024 * 1024;
+const MAX_EVENT_TYPE_LENGTH = 128;
+
+export const CODEX_EXEC_ADAPTER_ID = "codex-exec" as const;
+export const CODEX_EXEC_ENV_ALLOWLIST = [
+	"PATH",
+	"HOME",
+	"USERPROFILE",
+	"CODEX_HOME",
+	"CODEX_API_KEY",
+	"OPENAI_API_KEY",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
+] as const;
+
+function eventError(event: Record<string, unknown>, fallback: string): string {
+	const error = event.error;
+	if (typeof error === "string" && error.trim()) return error.trim().slice(0, 4_096);
+	if (error && typeof error === "object" && !Array.isArray(error)) {
+		const message = (error as Record<string, unknown>).message;
+		if (typeof message === "string" && message.trim()) return message.trim().slice(0, 4_096);
+	}
+	const message = event.message;
+	return typeof message === "string" && message.trim() ? message.trim().slice(0, 4_096) : fallback;
+}
+
+export function createCodexExecJsonlParser(finalMessagePath: string): ExternalCliParser {
+	let eventCount = 0;
+	let terminal: ExternalCliParserTerminal | undefined;
+	return {
+		parseLine(line): ExternalCliParserProgress {
+			let value: unknown;
+			try { value = JSON.parse(line) as unknown; }
+			catch (error) { throw new Error(`Codex exec emitted malformed JSONL: ${error instanceof Error ? error.message : String(error)}`); }
+			if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Codex exec emitted a JSONL event that is not an object.");
+			const event = value as Record<string, unknown>;
+			if (typeof event.type !== "string" || !event.type || event.type.length > MAX_EVENT_TYPE_LENGTH) throw new Error("Codex exec emitted a JSONL event with an invalid type.");
+			if (terminal) throw new Error("Codex exec emitted an event after its terminal state.");
+			eventCount += 1;
+			if (event.type === "turn.completed") terminal = { state: "completed" };
+			else if (event.type === "turn.failed") terminal = { state: "failed", error: eventError(event, "Codex exec reported turn.failed.") };
+			else if (event.type === "error") terminal = { state: "failed", error: eventError(event, "Codex exec reported an error event.") };
+			return { phase: terminal ? terminal.state : "streaming", eventCount };
+		},
+		finish(): ExternalCliParserTerminal | undefined {
+			if (!terminal || terminal.state === "failed") return terminal;
+			let descriptor: number;
+			try { descriptor = fs.openSync(finalMessagePath, "r"); }
+			catch (error) { throw new Error(`Codex exec did not write its final-message artifact: ${error instanceof Error ? error.message : String(error)}`); }
+			try {
+				const stat = fs.fstatSync(descriptor);
+				if (!stat.isFile()) throw new Error("Codex exec final-message artifact is not a file.");
+				if (stat.size > MAX_FINAL_MESSAGE_BYTES) throw new Error("Codex exec final-message artifact exceeded its byte limit.");
+				const content = Buffer.alloc(stat.size);
+				let bytesRead = 0;
+				while (bytesRead < content.length) {
+					const count = fs.readSync(descriptor, content, bytesRead, content.length - bytesRead, bytesRead);
+					if (count === 0) break;
+					bytesRead += count;
+				}
+				const output = content.subarray(0, bytesRead).toString("utf-8").trim();
+				if (!output) throw new Error("Codex exec final-message artifact is empty.");
+				return { state: "completed", output };
+			} finally { fs.closeSync(descriptor); }
+		},
+	};
+}
+
+export function resolveCodexExecLaunch(input: {
+	command: string;
+	asyncDir: string;
+	stepIndex: number;
+	/** Test-only executable prefix for a fake Codex process. */
+	commandPrefixArgs?: readonly string[];
+}): {
+	command: string;
+	args: string[];
+	finalOutputPath: string;
+	environment: { allowlist: readonly string[] };
+	preflight: ExternalCliPreflightSpec;
+	parser: ExternalCliParser;
+} {
+	const finalMessagePath = path.join(input.asyncDir, `external-${input.stepIndex}.final-message.txt`);
+	fs.rmSync(finalMessagePath, { force: true });
+	const prefix = [...(input.commandPrefixArgs ?? [])];
+	const args = [
+		...prefix,
+		"exec",
+		"--json",
+		"--color", "never",
+		"--ephemeral",
+		"--ignore-rules",
+		"--skip-git-repo-check",
+		"-s", "read-only",
+		"-c", 'approval_policy="never"',
+		"--output-last-message", finalMessagePath,
+		"-",
+	];
+	return {
+		command: input.command,
+		args,
+		finalOutputPath: finalMessagePath,
+		environment: { allowlist: CODEX_EXEC_ENV_ALLOWLIST },
+		preflight: {
+			id: CODEX_EXEC_ADAPTER_ID,
+			versionArgs: [...prefix, "--version"],
+			helpArgs: [...prefix, "exec", "--help"],
+			validate(result) {
+				if (!/^codex-cli \d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(result.version)) throw new Error(`Unsupported Codex version response: ${JSON.stringify(result.version)}.`);
+				for (const required of ["Run Codex non-interactively", "--json", "--output-last-message", "--ephemeral", "--ignore-rules", "--skip-git-repo-check", "--sandbox", "read-only", "--config"]) {
+					if (!result.help.includes(required)) throw new Error(`Codex exec help does not document required option ${JSON.stringify(required)}.`);
+				}
+			},
+		},
+		parser: createCodexExecJsonlParser(finalMessagePath),
+	};
+}

--- a/src/runs/shared/external-cli-contract.ts
+++ b/src/runs/shared/external-cli-contract.ts
@@ -30,17 +30,20 @@ export function parseExternalCliCapabilityNarrowing(value: unknown, label: strin
 }
 
 export function resolveExternalCliRunnerStatus(input: {
+	adapter?: "codex-exec";
 	command: string;
 	args?: string[];
 	promptDelivery?: "stdin";
 	capabilities?: ExternalCliCapabilityNarrowing;
 }): ExternalCliRunnerStatus {
+	const codexExec = input.adapter === "codex-exec";
 	return {
 		type: "external-cli",
 		command: input.command,
 		args: input.args ?? [],
 		promptDelivery: input.promptDelivery ?? "stdin",
-		adapter: { id: "external-cli", version: 1, executionMode: "one-shot-stdin" },
+		adapter: { id: codexExec ? "codex-exec" : "external-cli", version: 1, executionMode: "one-shot-stdin" },
+		...(codexExec ? { safety: { sandbox: "read-only" as const, approvalPolicy: "never" as const, ephemeral: true as const } } : {}),
 		capabilities: {
 			stop: true,
 			steer: false,
@@ -64,7 +67,10 @@ export function normalizeExternalCliRunnerStatus(value: unknown): ExternalCliRun
 		? input.args
 		: undefined;
 	const promptDelivery = input.promptDelivery === "stdin" ? "stdin" : undefined;
-	return resolveExternalCliRunnerStatus({ command: input.command, ...(args ? { args } : {}), ...(promptDelivery ? { promptDelivery } : {}) });
+	const adapter = input.adapter && typeof input.adapter === "object" && !Array.isArray(input.adapter) && (input.adapter as Record<string, unknown>).id === "codex-exec"
+		? "codex-exec" as const
+		: undefined;
+	return resolveExternalCliRunnerStatus({ ...(adapter ? { adapter } : {}), command: input.command, ...(args ? { args } : {}), ...(promptDelivery ? { promptDelivery } : {}) });
 }
 
 export function externalCliReceiptMetadata(input: {
@@ -76,11 +82,12 @@ export function externalCliReceiptMetadata(input: {
 	return {
 		adapter: { ...runner.adapter },
 		capabilities: { ...runner.capabilities },
+		...(runner.safety ? { safety: { ...runner.safety } } : {}),
 		...(input.externalProcess ? {
 			outputArtifacts: {
 				stdoutPath: input.externalProcess.stdoutPath,
 				stderrPath: input.externalProcess.stderrPath,
-				...(input.outputReference ? { finalOutputPath: input.outputReference } : {}),
+				...(input.outputReference || input.externalProcess.finalOutputPath ? { finalOutputPath: input.outputReference ?? input.externalProcess.finalOutputPath } : {}),
 			},
 		} : input.outputReference ? { outputArtifacts: { finalOutputPath: input.outputReference } } : {}),
 		handoff: { mode: "fresh" },

--- a/src/runs/shared/external-cli-runner.ts
+++ b/src/runs/shared/external-cli-runner.ts
@@ -143,6 +143,7 @@ export function runExternalCli(input: {
 	environment?: { allowlist: readonly string[]; values?: Readonly<Record<string, string>> };
 	preflight?: ExternalCliPreflightSpec;
 	parser?: ExternalCliParser;
+	finalOutputPath?: string;
 	limits?: StreamLimits;
 	registerTimeout?: (stop: (() => void) | undefined) => void;
 	registerStop?: (stop: (() => void) | undefined) => void;
@@ -174,7 +175,7 @@ export function runExternalCli(input: {
 			if (input.preflight) preflight = preflightExternalCli(input.command, input.preflight, env);
 		} catch (error) {
 			const endedAt = Date.now();
-			const externalProcess = { startedAt, endedAt, durationMs: endedAt - startedAt, exitCode: 1, processSignal: null, stdoutPath, stderrPath } satisfies ExternalProcessStatus;
+			const externalProcess = { startedAt, endedAt, durationMs: endedAt - startedAt, exitCode: 1, processSignal: null, stdoutPath, stderrPath, ...(input.finalOutputPath ? { finalOutputPath: input.finalOutputPath } : {}) } satisfies ExternalProcessStatus;
 			stdoutStream.end();
 			stderrStream.end();
 			void streamsFinished.then((streamResults) => {
@@ -273,6 +274,7 @@ export function runExternalCli(input: {
 			startedAt,
 			stdoutPath,
 			stderrPath,
+			...(input.finalOutputPath ? { finalOutputPath: input.finalOutputPath } : {}),
 		};
 		input.onProcess?.(initialProcess);
 		child.stdout.on("data", (chunk: Buffer) => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1378,6 +1378,7 @@ export type AgentRunnerConfig =
 	| { type: "pi" }
 	| {
 		type: "external-cli";
+		adapter?: "codex-exec";
 		command: string;
 		args?: string[];
 		promptDelivery?: "stdin";
@@ -1403,8 +1404,9 @@ export interface ExternalCliCapabilities {
 }
 
 export interface ExternalCliReceiptMetadata {
-	adapter: { id: "external-cli"; version: 1; executionMode: "one-shot-stdin" };
+	adapter: { id: "external-cli" | "codex-exec"; version: 1; executionMode: "one-shot-stdin" };
 	capabilities: ExternalCliCapabilities;
+	safety?: { sandbox: "read-only"; approvalPolicy: "never"; ephemeral: true };
 	outputArtifacts?: { stdoutPath?: string; stderrPath?: string; finalOutputPath?: string };
 	handoff: { mode: "fresh" };
 	supervisor: { mode: "unsupported"; reason: string };
@@ -1417,6 +1419,7 @@ export interface ExternalCliRunnerStatus {
 	args: string[];
 	promptDelivery: "stdin";
 	adapter: ExternalCliReceiptMetadata["adapter"];
+	safety?: ExternalCliReceiptMetadata["safety"];
 	capabilities: ExternalCliCapabilities;
 	unsupportedReasons: Record<Exclude<keyof ExternalCliCapabilities, "stop">, string>;
 	nonResumableReason: string;
@@ -1466,6 +1469,7 @@ export interface ExternalProcessStatus {
 	processSignal?: string | null;
 	stdoutPath: string;
 	stderrPath: string;
+	finalOutputPath?: string;
 	stdoutBytes?: number;
 	stderrBytes?: number;
 	stdoutTruncated?: boolean;

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -81,14 +81,14 @@ function parseExternalCliReceiptMetadata(value: unknown, key: string, source: st
 	const label = `Invalid workflow receipt '${source}': entry '${key}' externalAdapter`;
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object.`);
 	const metadata = value as Record<string, unknown>;
-	const unknownMetadata = Object.keys(metadata).filter((field) => !["adapter", "capabilities", "outputArtifacts", "handoff", "supervisor", "nonResumableReason"].includes(field));
+	const unknownMetadata = Object.keys(metadata).filter((field) => !["adapter", "capabilities", "safety", "outputArtifacts", "handoff", "supervisor", "nonResumableReason"].includes(field));
 	if (unknownMetadata.length > 0) throw new Error(`${label} has unsupported fields: ${unknownMetadata.join(", ")}.`);
 	const adapter = metadata.adapter;
 	if (!adapter || typeof adapter !== "object" || Array.isArray(adapter)) throw new Error(`${label}.adapter must be an object.`);
 	const adapterRecord = adapter as Record<string, unknown>;
 	const unknownAdapter = Object.keys(adapterRecord).filter((field) => !["id", "version", "executionMode"].includes(field));
 	if (unknownAdapter.length > 0) throw new Error(`${label}.adapter has unsupported fields: ${unknownAdapter.join(", ")}.`);
-	if (adapterRecord.id !== "external-cli" || adapterRecord.version !== 1 || adapterRecord.executionMode !== "one-shot-stdin") throw new Error(`${label}.adapter is invalid.`);
+	if ((adapterRecord.id !== "external-cli" && adapterRecord.id !== "codex-exec") || adapterRecord.version !== 1 || adapterRecord.executionMode !== "one-shot-stdin") throw new Error(`${label}.adapter is invalid.`);
 	const capabilities = metadata.capabilities;
 	if (!capabilities || typeof capabilities !== "object" || Array.isArray(capabilities)) throw new Error(`${label}.capabilities must be an object.`);
 	const capabilityRecord = capabilities as Record<string, unknown>;
@@ -97,6 +97,14 @@ function parseExternalCliReceiptMetadata(value: unknown, key: string, source: st
 	for (const [capability, expected] of Object.entries(EXTERNAL_CLI_CAPABILITIES)) {
 		if (capabilityRecord[capability] !== expected) throw new Error(`${label}.capabilities.${capability} is invalid.`);
 	}
+	const safety = metadata.safety;
+	if (adapterRecord.id === "codex-exec") {
+		if (!safety || typeof safety !== "object" || Array.isArray(safety)) throw new Error(`${label}.safety is missing.`);
+		const safetyRecord = safety as Record<string, unknown>;
+		const unknownSafety = Object.keys(safetyRecord).filter((field) => !["sandbox", "approvalPolicy", "ephemeral"].includes(field));
+		if (unknownSafety.length > 0) throw new Error(`${label}.safety has unsupported fields: ${unknownSafety.join(", ")}.`);
+		if (safetyRecord.sandbox !== "read-only" || safetyRecord.approvalPolicy !== "never" || safetyRecord.ephemeral !== true) throw new Error(`${label}.safety is invalid.`);
+	} else if (safety !== undefined) throw new Error(`${label}.safety is invalid for the generic adapter.`);
 	const handoff = metadata.handoff;
 	if (!handoff || typeof handoff !== "object" || Array.isArray(handoff)) throw new Error(`${label}.handoff must be an object.`);
 	const handoffRecord = handoff as Record<string, unknown>;

--- a/test/integration/codex-exec-smoke.test.ts
+++ b/test/integration/codex-exec-smoke.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import { resolveCodexExecLaunch } from "../../src/runs/shared/codex-exec-adapter.ts";
+import { runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+
+const enabled = process.env.PI_SUBAGENTS_CODEX_EXEC_SMOKE === "1";
+
+test("maintainer Codex exec read-only smoke", { skip: enabled ? undefined : "set PI_SUBAGENTS_CODEX_EXEC_SMOKE=1" }, async () => {
+	const reportPath = process.env.PI_SUBAGENTS_CODEX_EXEC_SMOKE_REPORT;
+	assert.ok(reportPath, "PI_SUBAGENTS_CODEX_EXEC_SMOKE_REPORT is required");
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-codex-smoke-"));
+	const canaryPath = path.join(dir, "write-canary.txt");
+	try {
+		const launch = resolveCodexExecLaunch({ command: "codex", asyncDir: dir, stepIndex: 0 });
+		const result = await runExternalCli({
+			...launch,
+			cwd: dir,
+			prompt: `Attempt to write the text CANARY to ${canaryPath}. Then explain whether the read-only sandbox allowed it.`,
+			asyncDir: dir,
+			stepIndex: 0,
+		});
+		const report = {
+			adapter: "codex-exec",
+			adapterVersion: 1,
+			cliVersion: result.preflight?.version,
+			cwd: dir,
+			sandbox: "read-only",
+			approvalPolicy: "never",
+			ephemeral: true,
+			exitCode: result.exitCode,
+			terminalState: result.parserTerminal?.state,
+			writeCanaryExists: fs.existsSync(canaryPath),
+			finalMessagePath: result.externalProcess.finalOutputPath,
+			stdoutPath: result.externalProcess.stdoutPath,
+			stderrPath: result.externalProcess.stderrPath,
+			durationMs: result.externalProcess.durationMs,
+		};
+		fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
+		assert.equal(result.exitCode, 0, result.error);
+		assert.equal(result.parserTerminal?.state, "completed");
+		assert.equal(fs.existsSync(canaryPath), false, "Codex wrote the read-only canary");
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/test/unit/codex-exec-adapter.test.ts
+++ b/test/unit/codex-exec-adapter.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { discoverAgentsAll } from "../../src/agents/agents.ts";
+import { createCodexExecJsonlParser, resolveCodexExecLaunch } from "../../src/runs/shared/codex-exec-adapter.ts";
+import { externalCliReceiptMetadata, resolveExternalCliRunnerStatus } from "../../src/runs/shared/external-cli-contract.ts";
+import { clearExternalCliPreflightCacheForTests } from "../../src/runs/shared/external-cli-preflight.ts";
+import { runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+import { buildWorkflowReceipt } from "../../src/workflows/workflow-receipt.ts";
+
+const tempDirs: string[] = [];
+function tempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-codex-exec-"));
+	tempDirs.push(dir);
+	return dir;
+}
+afterEach(() => {
+	clearExternalCliPreflightCacheForTests();
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function fakeCodexScript(dir: string): string {
+	const scriptPath = path.join(dir, "fake-codex.cjs");
+	fs.writeFileSync(scriptPath, String.raw`
++const fs = require("node:fs");
++const args = process.argv.slice(2);
++if (args[0] === "--version") { console.log("codex-cli 0.147.0"); process.exit(0); }
++if (args[0] === "exec" && args[1] === "--help") {
++  console.log("Run Codex non-interactively --json --output-last-message --ephemeral --ignore-rules --skip-git-repo-check --sandbox read-only --config");
++  process.exit(0);
++}
++let prompt = "";
++process.stdin.on("data", chunk => prompt += chunk);
++process.stdin.on("end", () => {
++  const outputIndex = args.indexOf("--output-last-message");
++  const outputPath = args[outputIndex + 1];
++  if (prompt.includes("malformed")) return process.stdout.write("{bad json}\n");
++  if (prompt.includes("oversized")) return process.stdout.write(JSON.stringify({type:"item.completed", value:"x".repeat(300000)}) + "\n");
++  if (prompt.includes("missing-terminal")) return process.stdout.write(JSON.stringify({type:"turn.started"}) + "\n");
++  if (prompt.includes("failed")) return process.stdout.write(JSON.stringify({type:"turn.failed", error:{message:"fake failure"}}) + "\n");
++  if (!prompt.includes("missing-artifact")) fs.writeFileSync(outputPath, "trusted final message");
++  process.stdout.write(JSON.stringify({type:"thread.started", thread_id:"fake"}) + "\n" + JSON.stringify({type:"turn.completed", usage:{input_tokens:1}}) + "\n");
++});
++`.replace(/^\+/gm, ""), "utf-8");
+	return scriptPath;
+}
+
+async function runFake(dir: string, stepIndex: number, prompt: string) {
+	const scriptPath = fakeCodexScript(dir);
+	const launch = resolveCodexExecLaunch({ command: process.execPath, commandPrefixArgs: [scriptPath], asyncDir: dir, stepIndex });
+	const result = await runExternalCli({ ...launch, cwd: dir, prompt, asyncDir: dir, stepIndex });
+	return { launch, result };
+}
+
+describe("Codex exec adapter", () => {
+	it("owns safe argv, stdin delivery, preflight, terminal proof, and final-message output", async () => {
+		const dir = tempDir();
+		const { launch, result } = await runFake(dir, 0, "review $HOME; echo nope");
+		assert.deepEqual(launch.args.slice(1), [
+			"exec", "--json", "--color", "never", "--ephemeral", "--ignore-rules", "--skip-git-repo-check", "-s", "read-only",
+			"-c", 'approval_policy="never"', "--output-last-message", launch.finalOutputPath, "-",
+		]);
+		assert.equal(launch.args.some((arg) => /dangerously|danger-full-access|workspace-write|approve-for-me/.test(arg)), false);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.output, "trusted final message");
+		assert.equal(result.parserTerminal?.state, "completed");
+		assert.equal(result.preflight?.version, "codex-cli 0.147.0");
+		assert.equal(result.externalProcess.finalOutputPath, launch.finalOutputPath);
+		assert.equal(fs.readFileSync(launch.finalOutputPath, "utf-8"), "trusted final message");
+	});
+
+	it("fails closed on malformed, oversized, failed, missing terminal, and missing final artifacts", async () => {
+		const dir = tempDir();
+		for (const [index, prompt, pattern] of [
+			[1, "malformed", /malformed JSONL/],
+			[2, "oversized", /line exceeded/],
+			[3, "failed", /fake failure/],
+			[4, "missing-terminal", /did not produce a terminal state/],
+			[5, "missing-artifact", /did not write its final-message artifact/],
+		] as const) {
+			const { result } = await runFake(dir, index, prompt);
+			assert.equal(result.exitCode, 1, prompt);
+			assert.match(result.error ?? "", pattern, prompt);
+		}
+	});
+
+	it("rejects unsupported version and incomplete help during launch preflight", () => {
+		const dir = tempDir();
+		const launch = resolveCodexExecLaunch({ command: "codex", asyncDir: dir, stepIndex: 6 });
+		const evidence = { binaryPath: "/tmp/codex", binaryMtimeMs: 1, version: "codex-cli 0.147.0", help: "Run Codex non-interactively --json --output-last-message --ephemeral --ignore-rules --skip-git-repo-check --sandbox read-only --config", cacheHit: false };
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, version: "Codex unknown" }), /Unsupported Codex version response/);
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, help: "Run Codex non-interactively --json" }), /does not document required option/);
+	});
+
+	it("removes a stale final-message artifact before launch", () => {
+		const dir = tempDir();
+		const finalPath = path.join(dir, "external-7.final-message.txt");
+		fs.writeFileSync(finalPath, "stale output");
+		const launch = resolveCodexExecLaunch({ command: "codex", asyncDir: dir, stepIndex: 7 });
+		assert.equal(launch.finalOutputPath, finalPath);
+		assert.equal(fs.existsSync(finalPath), false);
+	});
+
+	it("rejects duplicate terminal events and oversized final-message artifacts", () => {
+		const dir = tempDir();
+		const finalPath = path.join(dir, "final.txt");
+		const duplicate = createCodexExecJsonlParser(finalPath);
+		duplicate.parseLine('{"type":"turn.completed"}');
+		assert.throws(() => duplicate.parseLine('{"type":"turn.completed"}'), /after its terminal state/);
+		fs.writeFileSync(finalPath, "x".repeat(1024 * 1024 + 1));
+		assert.throws(() => duplicate.finish(), /artifact exceeded/);
+	});
+
+	it("publishes compact Codex safety and final-message receipt metadata", () => {
+		const runner = resolveExternalCliRunnerStatus({ adapter: "codex-exec", command: "codex" });
+		const metadata = externalCliReceiptMetadata({
+			runner,
+			externalProcess: { startedAt: 1, stdoutPath: "/tmp/stdout", stderrPath: "/tmp/stderr", finalOutputPath: "/tmp/final" },
+		});
+		const receipt = buildWorkflowReceipt({
+			workflowRunId: "codex-workflow",
+			state: "complete",
+			children: [{ key: "codex", ok: true, output: "done", resumability: { state: "not-resumable", reason: metadata.nonResumableReason }, continuation: { runIds: [] }, externalAdapter: metadata, results: [], artifactPaths: [] }],
+		});
+		assert.equal(receipt.entries.codex?.externalAdapter?.adapter.id, "codex-exec");
+		assert.deepEqual(receipt.entries.codex?.externalAdapter?.safety, { sandbox: "read-only", approvalPolicy: "never", ephemeral: true });
+		assert.equal(receipt.entries.codex?.externalAdapter?.outputArtifacts?.finalOutputPath, "/tmp/final");
+		assert.doesNotMatch(JSON.stringify(receipt), /trusted final message|turn\.completed|rawOutput/);
+	});
+
+	it("discovers the built-in profile without probing Codex", () => {
+		const dir = tempDir();
+		const agent = discoverAgentsAll(dir).builtin.find((candidate) => candidate.name === "codex-exec");
+		assert.deepEqual(agent?.runner, { type: "external-cli", adapter: "codex-exec", command: "codex", promptDelivery: "stdin" });
+	});
+});


### PR DESCRIPTION
## Summary

This is PR3 for #1426.

It adds the first real packaged external CLI adapter mode: `codex-exec`.

The adapter uses the existing one-shot `external-cli` substrate with code-owned argv:

```text
codex exec --json --color never --ephemeral --ignore-rules --skip-git-repo-check -s read-only -c approval_policy="never" --output-last-message <managed-path> -
```

It adds:

- a built-in `codex-exec` profile;
- launch-only Codex version/help preflight;
- bounded JSONL terminal parsing;
- final-message artifact validation;
- compact status and receipt metadata for adapter identity, safety policy, and final-output artifact path;
- focused fake-process tests;
- an opt-in maintainer smoke test with read-only write-canary proof.

## Scope boundaries

This PR intentionally does not add Codex app-server, Claude Code, Grok Build, SDK, ACP, fork handoff, live supervisor support, warm pooling, resume, steer, or writer-capable defaults.

Follow-up slices still need Claude baseline coverage and Grok baseline coverage before #1426 can close.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/codex-exec-adapter.test.ts test/unit/external-cli-runner.test.ts test/unit/workflow-receipt.test.ts test/unit/workflow-detach-reconcile.test.ts test/unit/agent-frontmatter.test.ts test/unit/agent-management.test.ts test/unit/runtime-agent-registration.test.ts test/unit/run-status.test.ts test/unit/package-manifest.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/external-cli-runner.test.ts test/integration/codex-exec-smoke.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`
- Opt-in real Codex smoke: passed with `exitCode: 0`, `terminalState: completed`, and `writeCanaryExists: false`.

Fresh 5.5 high review returned `No issues found`. The follow-up review for `--skip-git-repo-check` also returned `No issues found`.

## Notes

PR #1429 has textual overlap in shared launch and runner files. The semantic work is separate.
