### PR TITLE
feat(config): add configurable model exclusion TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Add `modelExclusions.defaultTtlMs` configuration for controlling the default lifetime of newly recorded model exclusions.
+- Add `modelExclusions.defaultTtlMs` configuration for controlling the default lifetime of newly recorded model exclusions. Thanks to @mithyer for #1439.
 - Add the built-in `codex-exec` profile with code-owned read-only argv, bounded JSONL terminal proof, and a final-message artifact.
 - External CLI runs now publish code-owned capability limits and compact workflow receipt metadata for adapter identity, artifacts, handoff mode, supervisor support, and resumability.
 - External one-shot runners now support bounded parser hooks and logs, environment allowlists, cached launch preflight, coalesced parser progress, and process-tree cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add `modelExclusions.defaultTtlMs` configuration for controlling the default lifetime of newly recorded model exclusions.
 - Add the built-in `codex-exec` profile with code-owned read-only argv, bounded JSONL terminal proof, and a final-message artifact.
 - External CLI runs now publish code-owned capability limits and compact workflow receipt metadata for adapter identity, artifacts, handoff mode, supervisor support, and resumability.
 - External one-shot runners now support bounded parser hooks and logs, environment allowlists, cached launch preflight, coalesced parser progress, and process-tree cleanup.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,18 @@ By default, project settings resolve from the nearest parent directory that cont
 
 `"git-root"` keeps package discovery, project agents, chains, and `agentOverrides` anchored to the git worktree root when that root also has Pi project config. A nested project can still opt back into nearest-root behavior by setting `"projectRootResolution": "nearest"` in its own `.pi/settings.json`.
 
+## `modelExclusions`
+
+```json
+{
+  "modelExclusions": {
+    "defaultTtlMs": 300000
+  }
+}
+```
+
+Controls the default duration, in milliseconds, for newly recorded model exclusions. The default is `86400000` (24 hours). This value is applied when the extension starts or reloads and affects only new exclusion records; existing entries keep their persisted `expiresAt` value. `PI_MODEL_EXCLUSIONS_PATH` changes the exclusion-store path but does not change this TTL.
+
 ## `toolDescriptionMode`
 
 ```json

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -6,6 +6,7 @@ import { FLEET_KEYBINDING_ACTIONS, type ArtifactDirPreference, type ExtensionCon
 import { validateMissionStoreConfig } from "../missions/store.ts";
 import { validateAuthorityPolicy } from "../policy/authority.ts";
 import { getAgentDir } from "../shared/utils.ts";
+import { DEFAULT_MODEL_EXCLUSION_TTL_MS, setDefaultTTL } from "../runs/shared/model-exclusions.ts";
 import { validatePermissionConfig } from "../runs/shared/permissions.ts";
 
 const ARTIFACT_DIR_PREFERENCES = new Set<ArtifactDirPreference>(["project", "session", "temp"]);
@@ -59,6 +60,17 @@ function validateArtifactConfig(value: unknown): void {
 	const cleanupDays = (value as Record<string, unknown>).cleanupDays;
 	if (cleanupDays !== undefined && (typeof cleanupDays !== "number" || !Number.isInteger(cleanupDays) || cleanupDays < 0)) {
 		throw new Error("config.artifactConfig.cleanupDays must be a non-negative integer");
+	}
+}
+
+/** Validate the user-controlled TTL policy before it reaches the exclusion store. */
+// TEST:test/unit/pi-coding-agent-dir.test.ts[loads and applies model exclusion TTL config]
+function validateModelExclusionsConfig(value: unknown): void {
+	if (value === undefined) return;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("config.modelExclusions must be a JSON object");
+	const defaultTtlMs = (value as Record<string, unknown>).defaultTtlMs;
+	if (defaultTtlMs !== undefined && (typeof defaultTtlMs !== "number" || !Number.isFinite(defaultTtlMs) || defaultTtlMs <= 0)) {
+		throw new Error("config.modelExclusions.defaultTtlMs must be a finite positive number");
 	}
 }
 
@@ -119,6 +131,7 @@ function validateConfig(config: Record<string, unknown>): void {
 	validateScheduledRunsConfig(config.scheduledRuns);
 	validateFleetKeybindingsConfig(config.fleetKeybindings);
 	validateArtifactConfig(config.artifactConfig);
+	validateModelExclusionsConfig(config.modelExclusions);
 	validateMainWindowRendererConfig(config.mainWindowRenderer);
 	validateOrcaProgressTabsConfig(config.orcaProgressTabs);
 }
@@ -148,6 +161,28 @@ export function updateConfig(updater: (config: ExtensionConfig) => ExtensionConf
 	validateConfig(next as Record<string, unknown>);
 	saveConfig(next, configPath);
 	return next;
+}
+
+/**
+ * Resolve the default TTL that the process-wide exclusion store should use.
+ *
+ * @param config Extension configuration after validation.
+ * @returns The configured TTL in milliseconds, or the built-in 24-hour default.
+ */
+// TEST:test/unit/pi-coding-agent-dir.test.ts[loads and applies model exclusion TTL config]
+export function resolveModelExclusionTTL(config: Pick<ExtensionConfig, "modelExclusions">): number {
+	return config.modelExclusions?.defaultTtlMs ?? DEFAULT_MODEL_EXCLUSION_TTL_MS;
+}
+
+/**
+ * Apply the configured exclusion policy to the process-wide model store.
+ *
+ * @param config Extension configuration after validation.
+ * @returns Nothing.
+ */
+// TEST:test/unit/pi-coding-agent-dir.test.ts[loads and applies model exclusion TTL config]
+export function applyModelExclusionsConfig(config: Pick<ExtensionConfig, "modelExclusions">): void {
+	setDefaultTTL(resolveModelExclusionTTL(config));
 }
 
 export function resolveAsyncByDefault(config: Pick<ExtensionConfig, "asyncByDefault">): boolean {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -56,7 +56,7 @@ import { formatSteeringNotice, handleSubagentSteeringNotice, SUBAGENT_STEERING_M
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
-import { loadConfig, resolveAsyncByDefault, resolveScheduledStoreRoot } from "./config.ts";
+import { applyModelExclusionsConfig, loadConfig, resolveAsyncByDefault, resolveScheduledStoreRoot } from "./config.ts";
 import { buildSubagentToolDescription, buildSubagentToolPromptMetadata } from "./tool-description.ts";
 import { finalizeToolResult } from "./tool-result.ts";
 import { collectGoalContinuationNotices } from "../missions/goal-driver.ts";
@@ -401,6 +401,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	cleanupOldChainDirs();
 
 	const config = loadConfig();
+	// Apply the process-wide exclusion TTL before any child launch can record a model failure.
+	applyModelExclusionsConfig(config);
 	const waitToolConfig = resolveWaitToolConfig(config.waitTool);
 	const asyncByDefault = resolveAsyncByDefault(config);
 	const fleetViewEnabled = config.fleetView !== false;

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -20,11 +20,19 @@ type RecordModelFailureOptions = ModelExclusionTarget & {
 
 let exclusions: ModelExclusion[] = [];
 let loaded = false;
-let defaultTTLMs = 24 * 60 * 60_000; // 24 hours, overridable via setDefaultTTL
+/** Default duration for a new model exclusion when no per-record TTL is supplied. */
+export const DEFAULT_MODEL_EXCLUSION_TTL_MS = 24 * 60 * 60_000;
+let defaultTTLMs = DEFAULT_MODEL_EXCLUSION_TTL_MS;
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
 let persistSeq = 0;
 
-/** Override the default exclusion TTL. */
+/**
+ * Override the default TTL applied to newly recorded model exclusions.
+ *
+ * @param ms Duration in milliseconds. Must be finite and positive.
+ * @returns Nothing.
+ */
+// TEST:test/unit/model-exclusions.test.ts[model exclusions — TTL expiry]
 export function setDefaultTTL(ms: number): void {
 	if (!Number.isFinite(ms) || ms <= 0) throw new Error("Default model exclusion TTL must be a finite positive number.");
 	defaultTTLMs = ms;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2094,6 +2094,11 @@ export interface ScheduledRunsConfig {
 	storeRoot?: string;
 }
 
+export interface ModelExclusionsConfig {
+	/** Default duration in milliseconds for newly recorded model exclusions. */
+	defaultTtlMs?: number;
+}
+
 export type FleetViewPlacement = "aboveEditor" | "belowEditor";
 
 export const FLEET_KEYBINDING_ACTIONS = [
@@ -2142,6 +2147,8 @@ export interface ExtensionConfig {
 	fleetKeybindings?: FleetKeybindingsConfig;
 	/** Show the under-editor async runs widget. Defaults to true, including when FleetView is enabled. */
 	asyncWidget?: boolean;
+	/** Configure the process-wide TTL policy for persisted model exclusions. */
+	modelExclusions?: ModelExclusionsConfig;
 	/** Tool description variant registered for the parent-facing subagent tool. Defaults to split metadata. */
 	toolDescriptionMode?: ToolDescriptionMode;
 	/** Inline chat rendering for the subagent tool. Defaults to rich. */

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -20,6 +20,35 @@ function parentToolEnv(agentDir?: string): NodeJS.ProcessEnv {
 }
 
 describe("subagent extension child mode", () => {
+	it("applies model exclusion TTL from extension config at registration", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-model-exclusion-config-"));
+		const exclusionPath = path.join(agentDir, "model-exclusions.json");
+		try {
+			const configDir = path.join(agentDir, "extensions", "subagent");
+			fs.mkdirSync(configDir, { recursive: true });
+			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ modelExclusions: { defaultTtlMs: 300_000 } }), "utf-8");
+			const script = String.raw`
+				import * as fs from "node:fs";
+				import registerSubagentExtension from "./index.ts";
+				import { recordModelFailure } from "./src/runs/shared/model-exclusions.ts";
+				const events = { on() { return () => {}; }, emit() {} };
+				const fakePi = new Proxy({
+					events,
+					registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {}, sendMessage() {}, getSessionName() {},
+				}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+				registerSubagentExtension(fakePi);
+				recordModelFailure({ modelId: "gpt-5", provider: "openai", reason: "test" });
+				const entry = JSON.parse(fs.readFileSync(process.env.PI_MODEL_EXCLUSIONS_PATH, "utf-8")).exclusions[0];
+				if (entry.expiresAt - entry.recordedAt !== 300_000) throw new Error("configured model exclusion TTL was not applied: " + JSON.stringify(entry));
+			`;
+			const env = parentToolEnv(agentDir);
+			env.PI_MODEL_EXCLUSIONS_PATH = exclusionPath;
+			execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
 	it("collapses tool detail before direct subagent tool execution", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./index.ts";

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -7,8 +7,9 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import { discoverAgentsAll } from "../../src/agents/agents.ts";
 import { handleCreate } from "../../src/agents/agent-management.ts";
 import { clearSkillCache, discoverAvailableSkills, resolveSkillPath } from "../../src/agents/skills.ts";
-import { loadConfig, updateConfig } from "../../src/extension/config.ts";
+import { applyModelExclusionsConfig, loadConfig, resolveModelExclusionTTL, updateConfig } from "../../src/extension/config.ts";
 import { diagnoseIntercomBridge, resolveIntercomBridge } from "../../src/intercom/intercom-bridge.ts";
+import { DEFAULT_MODEL_EXCLUSION_TTL_MS, clearExclusions, flushPersist, recordModelFailure, reloadFromDisk } from "../../src/runs/shared/model-exclusions.ts";
 import { loadRunsForAgent, recordRun } from "../../src/runs/shared/run-history.ts";
 import { cleanupAllArtifactDirs, getArtifactsDir, getProjectArtifactsDir } from "../../src/shared/artifacts.ts";
 import { TEMP_ARTIFACTS_DIR } from "../../src/shared/types.ts";
@@ -230,6 +231,40 @@ Package skill content.
 
 		writeFile(configPath, JSON.stringify({ defaultSubagentContext: "other" }));
 		assert.throws(() => updateConfig((config) => config), /config\.defaultSubagentContext must be "fresh" or "fork"/);
+	});
+
+	it("loads and applies model exclusion TTL config", () => {
+		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
+		const exclusionPath = path.join(tempDir, "model-exclusions.json");
+		const previousExclusionPath = process.env.PI_MODEL_EXCLUSIONS_PATH;
+		process.env.PI_MODEL_EXCLUSIONS_PATH = exclusionPath;
+		try {
+			writeFile(configPath, JSON.stringify({ modelExclusions: { defaultTtlMs: 300_000 } }));
+			const config = loadConfig();
+			assert.equal(config.modelExclusions?.defaultTtlMs, 300_000);
+			assert.equal(resolveModelExclusionTTL(config), 300_000);
+			assert.equal(resolveModelExclusionTTL({}), DEFAULT_MODEL_EXCLUSION_TTL_MS);
+
+			applyModelExclusionsConfig(config);
+			reloadFromDisk();
+			recordModelFailure({ modelId: "gpt-5", provider: "openai", reason: "test" });
+			const entry = (JSON.parse(fs.readFileSync(exclusionPath, "utf-8")).exclusions as Array<{ recordedAt: number; expiresAt: number }>)[0];
+			assert.ok(entry);
+			assert.equal(entry.expiresAt - entry.recordedAt, 300_000);
+
+			for (const invalidTtl of [0, -1, "300000", true, null]) {
+				writeFile(configPath, JSON.stringify({ modelExclusions: { defaultTtlMs: invalidTtl } }));
+				assert.throws(() => updateConfig((current) => current), /config\.modelExclusions\.defaultTtlMs must be a finite positive number/);
+			}
+		} finally {
+			clearExclusions();
+			flushPersist();
+			reloadFromDisk();
+			applyModelExclusionsConfig({});
+			if (previousExclusionPath === undefined) delete process.env.PI_MODEL_EXCLUSIONS_PATH;
+			else process.env.PI_MODEL_EXCLUSIONS_PATH = previousExclusionPath;
+			fs.rmSync(exclusionPath, { force: true });
+		}
 	});
 
 	it("rejects invalid artifactDir config values", () => {


### PR DESCRIPTION
## Summary

- Add `modelExclusions.defaultTtlMs` to the extension config at `~/.pi/agent/extensions/subagent/config.json`.
- Apply the configured TTL when the extension starts or reloads, before child launches can record model failures.
- Validate the value, document its scope and existing-cache behavior, and add unit/integration coverage.

The setting controls only newly recorded exclusions. Existing `model-exclusions.json` entries retain their persisted `expiresAt` values.

## Configuration

```json
{
  "modelExclusions": {
    "defaultTtlMs": 300000
  }
}
```

## Testing

- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/pi-coding-agent-dir.test.ts test/unit/model-exclusions.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/index-child-registration.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/orca-progress-tabs.test.ts`

The full unit/integration runs also contain existing failures in unrelated watchdog/fork-context tests; those same failures reproduce on the base commit. See issue #1438 for the motivating behavior.

Closes #1438