### PR TITLE
fix(workflow): resolve an inline child's resumability from its foreground run

### DIFF
--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -884,8 +884,16 @@ function resolveResumeTarget(params: SubagentParamsLike, state: SubagentState, o
 		foregroundError = error;
 	}
 	try {
-		const asyncParams = options.exactOnly && requested && !params.dir
-			? { ...params, dir: path.join(DIRS.async, requested) }
+		// exactOnly pins the async probe to one directory so a short id cannot prefix-match a
+		// different run. A directory that does not exist pins nothing: injecting it turns a plain
+		// "Async run not found." into "Status file not found for async run 'X'", which reads as an
+		// async run whose state was lost and, through isExactResumeError, outranks a foreground run
+		// that resolved perfectly well. A run that never ran async has no such directory.
+		const exactAsyncDir = options.exactOnly && requested && !params.dir
+			? path.join(DIRS.async, requested)
+			: undefined;
+		const asyncParams = exactAsyncDir !== undefined && fs.existsSync(exactAsyncDir)
+			? { ...params, dir: exactAsyncDir }
 			: params;
 		asyncTarget = {
 			source: "async",
@@ -3638,6 +3646,18 @@ export function bindMissionWorkflowChildAsyncLaunch(
 	return { ...params, workflowChildAsyncId: id };
 }
 
+/**
+ * A workflow child that ran inline never had an async run of its own, so "Async run not found."
+ * is about a run that was never supposed to exist. Carried verbatim into the receipt it reads as
+ * lost state; what the receipt has to say is that this child retained nothing to resume from.
+ * Every other failure — including a real async run whose status file is missing — is reported as
+ * written, because those name something that genuinely went wrong.
+ */
+function workflowChildResumeFailureReason(error: unknown): string {
+	if (isAsyncRunNotFound(error)) return "child ran inline in the workflow and retained no separately resumable run";
+	return error instanceof Error ? error.message : String(error);
+}
+
 function workflowChildResult(
 	key: string,
 	result: AgentToolResult<Details>,
@@ -3672,7 +3692,7 @@ function workflowChildResult(
 				? { state: "resumable" }
 				: { state: "not-resumable", reason: "child is still running" };
 		} catch (error) {
-			resumability = { state: "not-resumable", reason: error instanceof Error ? error.message : String(error) };
+			resumability = { state: "not-resumable", reason: workflowChildResumeFailureReason(error) };
 		}
 	}
 	const requestedContext = childParams.context === "fresh" || childParams.context === "fork" ? childParams.context : undefined;

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -692,7 +692,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			{ key: "work", state: "completed" },
 		]);
 		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
-		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; cwd?: string; summary?: string; workflow?: { value?: unknown; receipt?: unknown }; workflowReceipt?: { path?: string; receipt?: { workflowRunId?: string; entries?: Record<string, { key?: string; agent?: string; latestRunId?: string; resumability?: { state?: string }; continuation?: { runIds?: string[] } }> } }; results?: Array<{ agent?: string; workflowKey?: string; runId?: string; output?: string }> };
+		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; cwd?: string; summary?: string; workflow?: { value?: unknown; receipt?: unknown }; workflowReceipt?: { path?: string; receipt?: { workflowRunId?: string; entries?: Record<string, { key?: string; agent?: string; latestRunId?: string; resumability?: { state?: string; reason?: string }; continuation?: { runIds?: string[] } }> } }; results?: Array<{ agent?: string; workflowKey?: string; runId?: string; output?: string }> };
 		assert.equal(persistedResult.id, workflowRunId);
 		assert.equal(persistedResult.runId, workflowRunId);
 		assert.equal(persistedResult.toolCallId, toolCallId);
@@ -715,7 +715,11 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(persistedResult.workflowReceipt?.receipt?.entries?.work?.agent, "echo");
 		assert.equal(persistedResult.workflowReceipt?.receipt?.entries?.work?.latestRunId, persistedResult.results?.[0]?.runId);
 		assert.deepEqual(persistedResult.workflowReceipt?.receipt?.entries?.work?.continuation?.runIds, [persistedResult.results?.[0]?.runId]);
-		assert.equal(typeof persistedResult.workflowReceipt?.receipt?.entries?.work?.resumability?.state, "string");
+		assert.deepEqual(
+			persistedResult.workflowReceipt?.receipt?.entries?.work?.resumability,
+			{ state: "resumable" },
+			"a completed inline workflow child is resumable from its foreground run; probing an async directory it never had reported it as an async run whose status file had vanished",
+		);
 		assert.deepEqual(JSON.parse(fs.readFileSync(persistedResult.workflowReceipt!.path!, "utf-8")), persistedResult.workflowReceipt?.receipt);
 		assert.equal(fs.existsSync(path.join(DIRS.results, `${toolCallId}.json`)), false);
 		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true });


### PR DESCRIPTION
## What happens

Every workflow receipt entry for a child that ran **inline** reports

```json
{ "state": "not-resumable", "reason": "Status file not found for async run '<childRunId>'." }
```

even when the child completed normally and is resumable from its foreground run. Reproduced on `v0.53.0` and pinned by the integration test in this PR: before the change the existing `starts workflow scripts asynchronously with a portable internal run id` test produces the string above; after it, `{ "state": "resumable" }`.

## Why

`resolveResumeTarget(..., { exactOnly: true })` pins the async probe to one directory so a short id cannot prefix-match a different run:

```ts
const asyncParams = options.exactOnly && requested && !params.dir
  ? { ...params, dir: path.join(DIRS.async, requested) }
  : params;
```

A child that ran inline has no such directory. `resolveAsyncRunLocation` returns an explicit `params.dir` **without checking that it exists**, which walks `resolveAsyncResumeTarget` straight past its `Async run not found. Provide id or dir.` guard and down to `Status file not found for async run '<id>'.`

That message is shaped like an *exact-run* error, so `isExactResumeError` matches it and `resolveResumeTarget` throws it — discarding the foreground target that had already resolved successfully:

```ts
if (foregroundTarget) {
  if (isExactResumeError(asyncError, "async", requested)) throw asyncError;  // ← wins over a valid target
  ...
  return foregroundTarget;
}
```

Consequences:

- `workflowChildResult` stamps every inline child `not-resumable`.
- `resolveKeyedWorkflowResume`'s `assertResumable` refuses children that are in fact resumable.
- Since `normalizePublicSubagentExecution` wraps every RPC spawn in a workflow, the reason reaches the model through the completion notice, where "status file not found" reads as lost run state. In our case a planner read three such notices and reported to its user that three background investigations had lost their reports — the reports had all been delivered.

## The change

1. Pin the exact async directory **only when it exists**. A child that never ran async now falls through to the ordinary not-found path, and the foreground target is returned as it should be. Exactness is unchanged wherever the directory does exist.
2. Report the remaining not-found case as what it is — a child that retained no separately resumable run — instead of quoting an async lookup about a run that was never supposed to exist. Every other failure, **including a real async run whose status file is genuinely missing**, is still reported verbatim.

`workflow-detach-reconcile.ts` computes resumability the same way but is unaffected and untouched: a detached child does own an async directory.

## Verification

- `npm run typecheck` — clean.
- `npm run test:integration` — 700/700.
- `npm run test:unit` — 2286/2291; the 2 failures (`continues an interactive parent after compaction while async work is active`, `restores indexed active status after a management tool result`) reproduce identically on unmodified `c91f4de5` in the same worktree, so they are pre-existing and unrelated.