### PR TITLE
feat: add Claude Code baseline adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add code-owned `claude-code` read-only and `claude-code-writer` file-editing profiles for an existing authenticated CLI with trusted user settings, bounded stream-JSON result proof, and opt-in mode-specific smoke evidence.
 - Add the built-in `codex-exec` profile with code-owned read-only argv, bounded JSONL terminal proof, and a final-message artifact.
 - External CLI runs now publish code-owned capability limits and compact workflow receipt metadata for adapter identity, artifacts, handoff mode, supervisor support, and resumability.
 - External one-shot runners now support bounded parser hooks and logs, environment allowlists, cached launch preflight, coalesced parser progress, and process-tree cleanup.

--- a/agents/claude-code-writer.md
+++ b/agents/claude-code-writer.md
@@ -1,0 +1,15 @@
+---
+name: claude-code-writer
+description: Explicit file-writing Claude Code CLI mode; requires local authentication and trusted user settings/hooks
+runner:
+  type: external-cli
+  adapter: claude-code-writer
+  command: claude
+  promptDelivery: stdin
+async: true
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+---
+
+Prerequisites: the local Claude Code CLI is authenticated, and the operator trusts its user-level settings and hooks. Use only the code-owned Read, Write, Edit, Glob, and Grep tools. Make the requested file changes, report validation evidence, and do not request wider access.

--- a/agents/claude-code.md
+++ b/agents/claude-code.md
@@ -1,0 +1,15 @@
+---
+name: claude-code
+description: Read-only Claude Code CLI analysis; requires local authentication and trusted user settings/hooks
+runner:
+  type: external-cli
+  adapter: claude-code
+  command: claude
+  promptDelivery: stdin
+async: true
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+---
+
+Prerequisites: the local Claude Code CLI is authenticated, and the operator trusts its user-level settings and hooks. Analyze only the supplied handoff in no-tools mode. Return a concise final answer with evidence. Do not edit files or request wider access.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -55,23 +55,6 @@ If you disabled the old bundled `gpt-pro` workaround with `agentOverrides.gpt-pr
 
 The Pi async run remains the source of truth for status, artifacts, wake/wait, mission attachment, retention, and diagnostics.
 
-Claude Code can be configured as a read-only advisor with `runner.type: external-cli` when the Claude Code CLI is installed and you have verified the flags for your local version. pi-subagents does not ship or enforce Claude Code flags. Use a project or user agent like this only after checking your CLI help:
-
-```yaml
----
-name: claude-advisor
-description: Read-only Claude Code advisor through the local CLI
-runner:
-  type: external-cli
-  command: claude
-  args: ["<verified-read-only-flags>"]
-  promptDelivery: stdin
-async: true
----
-
-Review the task and return advice only. Do not edit files.
-```
-
 ### Advisory runner data boundary
 
 The built-in `codex-exec` profile is the supported Codex one-shot mode. It requires an installed and authenticated Codex CLI. The adapter owns its argv and runs `codex exec --json` with the read-only sandbox, approval policy `never`, ephemeral sessions, ignored exec rules, and a final-message artifact. User profiles cannot add argv to this adapter or select a wider sandbox.
@@ -95,7 +78,42 @@ node --experimental-strip-types --import ./test/support/register-loader.mjs \
 
 The smoke asks Codex to attempt a write canary under the packaged read-only policy. Review the JSON report and confirm `writeCanaryExists` is `false`. The report contains paths and compact process metadata, but no raw protocol output or credentials.
 
-Native `oracle` runs inside Pi and can use its configured read tools. `claude-advisor` sends the assembled prompt to the configured local external CLI through stdin. An external-job agent sends the assembled prompt to its registered provider. Provider options and a prompt digest are persisted in Pi run state. The prompt text is delivered through the local host bridge to the provider and is not stored in the public result payload. Do not place secrets in advisory prompts unless the target provider is approved to receive them.
+The built-in `claude-code` and `claude-code-writer` profiles are the supported Claude Code one-shot modes. Both require an installed Claude Code CLI that is already authenticated through its normal local login. Claude Code 2.1.150 needs the user setting source for normal OAuth/keychain authentication, so both adapters load user settings but exclude project and local settings. User-level Claude Code settings and hooks are therefore an operator-trusted prerequisite. Review or disable unsafe user hooks before using either profile.
+
+| Profile | Access | Permission mode | Built-in tools |
+|---|---|---|---|
+| `claude-code` | Handoff-only read-only advice | `plan` | none |
+| `claude-code-writer` | Explicit workspace file edits | `acceptEdits` | `Read,Write,Edit,Glob,Grep` |
+
+Both adapters own `claude -p` argv with stream JSON, strict empty MCP configuration, user-only setting sources, no session persistence, disabled slash commands, and disabled Chrome integration. The writer mode does not include Bash or any permission bypass. Neither mode uses `--bare`, which does not read normal OAuth/keychain authentication. Neither mode requires `--safe-mode`, which is absent from the installed 2.1.150 help. User profiles cannot add argv. Selecting the code-owned `claude-code-writer` adapter identity is the only way to opt into its write tools; the read-only adapter cannot be widened with user argv.
+
+Run it asynchronously:
+
+```text
+Use claude-code to analyze this handoff without editing files.
+
+Use claude-code-writer to make the requested file changes.
+```
+
+The adapter validates `claude --version` and `claude --help` only when a run launches. Discovery, list, status, and native Pi launches do not probe Claude Code or authentication. JSONL, stderr, and stdout are untrusted. A run succeeds only after bounded valid JSONL contains exactly one successful terminal `result` with non-empty final text. Missing or revoked local authentication, limit stops, malformed JSON, duplicate terminal results, and EOF before a terminal result fail closed.
+
+Maintainers can opt in to separate read-only and writer canaries:
+
+```bash
+PI_SUBAGENTS_CLAUDE_CODE_SMOKE=1 \
+PI_SUBAGENTS_CLAUDE_CODE_SMOKE_REPORT=/tmp/pi-subagents-claude-code-smoke.json \
+node --experimental-strip-types --import ./test/support/register-loader.mjs \
+  --test test/integration/claude-code-smoke.test.ts
+
+PI_SUBAGENTS_CLAUDE_CODE_WRITER_SMOKE=1 \
+PI_SUBAGENTS_CLAUDE_CODE_WRITER_SMOKE_REPORT=/tmp/pi-subagents-claude-code-writer-smoke.json \
+node --experimental-strip-types --import ./test/support/register-loader.mjs \
+  --test test/integration/claude-code-writer-smoke.test.ts
+```
+
+Both smoke reports record `authentication: "existing-cli-required"`, `settingSources: "user"`, and `userSettingsTrust: "required"` without recording credential details. For read-only, confirm `terminalState` is `completed` and `writeCanaryExists` is `false`. For writer, confirm `terminalState` is `completed` and `writeCanaryMatches` is `true`. `durationMs` records cold process time. If authentication is missing or revoked, repair the normal local Claude Code login and rerun the smoke. Reports do not contain raw protocol output or credentials.
+
+Native `oracle` runs inside Pi and can use its configured read tools. The Claude profiles send the assembled prompt to the local Claude Code CLI through stdin. An external-job agent sends the assembled prompt to its registered provider. Provider options and a prompt digest are persisted in Pi run state. The prompt text is delivered through the local host bridge to the provider and is not stored in the public result payload. Do not place secrets in advisory prompts unless the target provider is approved to receive them.
 
 ### External-job state table
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -33,6 +33,7 @@ import { resolveSubagentModelOverride, type ParentModel } from "../runs/shared/m
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
 import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
+import { validateClaudeCodeProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import type { AcceptanceInput, Details, ExtensionConfig, ToolBudgetConfig } from "../shared/types.ts";
 import { getProjectConfigDir } from "../shared/utils.ts";
 import { capabilityCeilingAgentRestrictionSources, isAgentAllowedByCapabilityCeiling, resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
@@ -378,17 +379,17 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 			if (runner.type === "pi" && Object.keys(runner).every((key) => key === "type")) target.runner = { type: "pi" };
 			else if (runner.type === "external-cli" && typeof runner.command === "string" && runner.command.trim()
 				&& (runner.args === undefined || (Array.isArray(runner.args) && runner.args.every((arg) => typeof arg === "string")))
-				&& (runner.adapter === undefined || runner.adapter === "codex-exec")
-				&& (runner.adapter !== "codex-exec" || runner.args === undefined || runner.args.length === 0)
+				&& (runner.adapter === undefined || runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer")
+				&& (runner.adapter === undefined || runner.args === undefined || runner.args.length === 0)
 				&& (runner.promptDelivery === undefined || runner.promptDelivery === "stdin")
 				&& Object.keys(runner).every((key) => ["type", "adapter", "command", "args", "promptDelivery"].includes(key))) {
 				const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
-				target.runner = { type: "external-cli", ...(runner.adapter === "codex-exec" ? { adapter: "codex-exec" } : {}), command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
+				target.runner = { type: "external-cli", ...(runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
 			} else if (runner.type === "external-job" && typeof runner.provider === "string" && runner.provider.trim() === runner.provider && runner.provider
 				&& (runner.options === undefined || (runner.options && typeof runner.options === "object" && !Array.isArray(runner.options) && isJsonSerializable(runner.options)))
 				&& Object.keys(runner).every((key) => ["type", "provider", "options"].includes(key))) {
 				target.runner = { type: "external-job", provider: runner.provider, ...(runner.options ? { options: runner.options as Record<string, unknown> } : {}) };
-			} else return "config.runner must be { type: 'pi' }, { type: 'external-cli', adapter?: 'codex-exec', command: string, args?: string[], promptDelivery?: 'stdin' }, or { type: 'external-job', provider: string, options?: object }.";
+			} else return "config.runner must be { type: 'pi' }, { type: 'external-cli', adapter?: 'codex-exec' | 'claude-code' | 'claude-code-writer', command: string, args?: string[], promptDelivery?: 'stdin' }, or { type: 'external-job', provider: string, options?: object }.";
 		} else return "config.runner must be an object, false, or empty string when provided.";
 	}
 	if (hasKey(cfg, "model")) {
@@ -917,6 +918,8 @@ export function handleCreate(params: ManagementParams, ctx: ManagementContext): 
 	};
 	const applyError = applyAgentConfig(agent, cfg);
 	if (applyError) return result(applyError, true);
+	const claudeProfileError = validateClaudeCodeProfileRunner(agent);
+	if (claudeProfileError) return result(claudeProfileError, true);
 	const mw = modelWarning(ctx, agent.model);
 	if (mw) warnings.push(mw);
 	const fmw = fallbackModelsWarning(ctx, agent.fallbackModels);
@@ -968,6 +971,8 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 	if (newPackageName !== undefined) updated.packageName = newPackageName;
 	else delete updated.packageName;
 	updated.name = buildRuntimeName(newLocalName, newPackageName);
+	const claudeProfileError = validateClaudeCodeProfileRunner(updated);
+	if (claudeProfileError) return result(claudeProfileError, true);
 	if (hasKey(cfg, "description")) updated.description = (cfg.description as string).trim();
 	if (hasKey(cfg, "model")) {
 		const mw = modelWarning(ctx, updated.model);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -9,7 +9,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
-import { parseExternalCliCapabilityNarrowing } from "../runs/shared/external-cli-contract.ts";
+import { parseExternalCliCapabilityNarrowing, validateClaudeCodeProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import { getAgentDir, getProjectConfigDir } from "../shared/utils.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain, parseJsonChain } from "./chain-serializer.ts";
@@ -1683,8 +1683,8 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) {
 		throw new Error(`Agent '${agentName}' external-cli runner args must be an array of strings.`);
 	}
-	if (runner.adapter !== undefined && runner.adapter !== "codex-exec") throw new Error(`Agent '${agentName}' external-cli runner adapter must be 'codex-exec'.`);
-	if (runner.adapter === "codex-exec" && Array.isArray(runner.args) && runner.args.length > 0) throw new Error(`Agent '${agentName}' codex-exec adapter owns its argv; runner args are not supported.`);
+	if (runner.adapter !== undefined && runner.adapter !== "codex-exec" && runner.adapter !== "claude-code" && runner.adapter !== "claude-code-writer") throw new Error(`Agent '${agentName}' external-cli runner adapter must be 'codex-exec', 'claude-code', or 'claude-code-writer'.`);
+	if (runner.adapter !== undefined && Array.isArray(runner.args) && runner.args.length > 0) throw new Error(`Agent '${agentName}' ${runner.adapter} adapter owns its argv; runner args are not supported.`);
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") {
 		throw new Error(`Agent '${agentName}' external-cli runner promptDelivery must be 'stdin'.`);
 	}
@@ -1695,7 +1695,7 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 	const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
 	return {
 		type: "external-cli",
-		...(runner.adapter === "codex-exec" ? { adapter: "codex-exec" as const } : {}),
+		...(runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" ? { adapter: runner.adapter } : {}),
 		command: runner.command.trim(),
 		...(runnerArgs?.length ? { args: runnerArgs } : {}),
 		...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}),
@@ -1789,6 +1789,8 @@ function loadAgentsFromDefinitionFiles(files: AgentDefinitionFile[], source: Age
 		const mcpDirectTools = parsedTools.mcpDirectTools ?? [];
 		const defaultReads = parseFrontmatterList(frontmatter.defaultReads);
 		const aliases = normalizeAgentAliases(parseFrontmatterList(frontmatter.aliases ?? frontmatter.alias), runtimeName);
+		const claudeProfileError = validateClaudeCodeProfileRunner({ name: runtimeName, localName, aliases, runner });
+		if (claudeProfileError) throw new Error(claudeProfileError);
 		const skillStr = frontmatter.skill || frontmatter.skills;
 		const skills = parseFrontmatterList(skillStr);
 		const skillPath = parseFrontmatterList(frontmatter.skillPath);

--- a/src/agents/builtin-names.ts
+++ b/src/agents/builtin-names.ts
@@ -1,5 +1,7 @@
 export const BUILTIN_AGENT_NAMES = [
 	"advisor",
+	"claude-code",
+	"claude-code-writer",
 	"codex-exec",
 	"delegate",
 	"oracle",

--- a/src/agents/runtime-agent-registry.ts
+++ b/src/agents/runtime-agent-registry.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
-import { parseExternalCliCapabilityNarrowing } from "../runs/shared/external-cli-contract.ts";
+import { parseExternalCliCapabilityNarrowing, validateClaudeCodeProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import { validatePermissionRules, type PermissionRules } from "../runs/shared/permissions.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
@@ -170,15 +170,15 @@ function validateRunner(value: unknown): AgentRunnerConfig | undefined {
 	if (runner.type !== "external-cli") throw new Error("Runtime agent definition runner.type must be 'pi', 'external-cli', or 'external-job'.");
 	if (typeof runner.command !== "string" || !runner.command.trim()) throw new Error("Runtime agent definition external-cli runner requires a non-empty command string.");
 	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) throw new Error("Runtime agent definition external-cli runner args must be an array of strings.");
-	if (runner.adapter !== undefined && runner.adapter !== "codex-exec") throw new Error("Runtime agent definition external-cli runner adapter must be 'codex-exec'.");
-	if (runner.adapter === "codex-exec" && Array.isArray(runner.args) && runner.args.length > 0) throw new Error("Runtime agent definition codex-exec adapter owns its argv; runner args are not supported.");
+	if (runner.adapter !== undefined && runner.adapter !== "codex-exec" && runner.adapter !== "claude-code" && runner.adapter !== "claude-code-writer") throw new Error("Runtime agent definition external-cli runner adapter must be 'codex-exec', 'claude-code', or 'claude-code-writer'.");
+	if (runner.adapter !== undefined && Array.isArray(runner.args) && runner.args.length > 0) throw new Error(`Runtime agent definition ${runner.adapter} adapter owns its argv; runner args are not supported.`);
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") throw new Error("Runtime agent definition external-cli runner promptDelivery must be 'stdin'.");
 	const capabilities = parseExternalCliCapabilityNarrowing(runner.capabilities, "Runtime agent definition external-cli runner capabilities");
 	const supported = new Set(["type", "adapter", "command", "args", "promptDelivery", "capabilities"]);
 	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
 	if (unknown.length > 0) throw new Error(`Runtime agent definition external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
 	const args = runner.args as string[] | undefined;
-	return { type: "external-cli", ...(runner.adapter === "codex-exec" ? { adapter: "codex-exec" as const } : {}), command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}), ...(capabilities ? { capabilities } : {}) };
+	return { type: "external-cli", ...(runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}), ...(capabilities ? { capabilities } : {}) };
 }
 
 function validateTurnBudget(value: unknown): TurnBudgetConfig | undefined {
@@ -368,6 +368,8 @@ export function registerRuntimeAgent(input: RegisterRuntimeAgentInput): RuntimeA
 	const name = validateString(input.name, "Runtime agent name", MAX_AGENT_NAME_LENGTH);
 	const definition = validateDefinition(input.definition);
 	const agent = toAgentConfig(name, definition);
+	const claudeProfileError = validateClaudeCodeProfileRunner(agent);
+	if (claudeProfileError) throw new Error(claudeProfileError);
 	assertNoBuiltinCollision(agent);
 	const current = registry();
 	const records = current.byPi.get(pi) ?? [];

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -541,7 +541,11 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 					if (runner) {
 						lines.push(`  Runner: external-cli (${runner.command}${runner.args.length ? ` ${runner.args.join(" ")}` : ""})`);
 						lines.push(`  Adapter: ${runner.adapter.id} v${runner.adapter.version} (${runner.adapter.executionMode})`);
-						if (runner.safety) lines.push(`  Safety: sandbox=${runner.safety.sandbox}, approval=${runner.safety.approvalPolicy}, ephemeral=${runner.safety.ephemeral}`);
+						if (runner.safety) {
+							if ("sandbox" in runner.safety) lines.push(`  Safety: sandbox=${runner.safety.sandbox}, approval=${runner.safety.approvalPolicy}, ephemeral=${runner.safety.ephemeral}`);
+							else if ("authentication" in runner.safety) lines.push(`  Safety: access=${runner.safety.access}, auth=${runner.safety.authentication}, permission=${runner.safety.permissionMode}, tools=${runner.safety.tools}, mcp=${runner.safety.mcp}, settings=${runner.safety.settingSources}, settingsTrust=${runner.safety.userSettingsTrust}, persistence=${runner.safety.sessionPersistence}`);
+							else lines.push(`  Safety: access=read-only, permission=${runner.safety.permissionMode}, tools=${runner.safety.tools}, mcp=${runner.safety.mcp}, settings=${runner.safety.settingSources}, persistence=${runner.safety.sessionPersistence}`);
+						}
 						lines.push(`  Capabilities: stop=${runner.capabilities.stop}, steer=false, resume=false, structuredOutput=false, toolEvents=false, supervisor=unsupported, forkContext=false, extensionBindings=false`);
 						lines.push(`  Unsupported steer: ${runner.unsupportedReasons.steer}`);
 						lines.push(`  Unsupported resume: ${runner.nonResumableReason}`);

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -144,6 +144,7 @@ import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
 import { createBoundedByteTail, createBoundedLineReader, formatProtocolOutputLimit, MAX_CHILD_STDERR_BYTES, PI_AGGREGATE_EVENT_PROJECTOR, projectChildLifecycle, type ChildLifecycleAction, type ProtocolOutputLimit } from "../shared/child-protocol.ts";
 import { acquireSessionLease, type SessionLeaseRequest } from "../shared/session-lease.ts";
 import { buildExternalCliPrompt, runExternalCli } from "../shared/external-cli-runner.ts";
+import { resolveClaudeCodeLaunch } from "../shared/claude-code-adapter.ts";
 import { resolveCodexExecLaunch } from "../shared/codex-exec-adapter.ts";
 import { resolveExternalCliRunnerStatus } from "../shared/external-cli-contract.ts";
 import { runExternalJob } from "../shared/external-job-runner.ts";
@@ -1385,7 +1386,9 @@ async function runSingleStepInner(
 	if (step.runner?.type === "external-cli") {
 		const adapterLaunch = step.runner.adapter === "codex-exec"
 			? resolveCodexExecLaunch({ command: step.runner.command, asyncDir: path.dirname(ctx.outputFile), stepIndex: ctx.flatIndex })
-			: undefined;
+			: step.runner.adapter === "claude-code" || step.runner.adapter === "claude-code-writer"
+				? resolveClaudeCodeLaunch({ adapter: step.runner.adapter, command: step.runner.command })
+				: undefined;
 		const runner = resolveExternalCliRunnerStatus({ ...step.runner, ...(adapterLaunch ? { args: adapterLaunch.args } : {}) });
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
 		const external = await runExternalCli(omitUndefinedProperties({

--- a/src/runs/shared/claude-code-adapter.ts
+++ b/src/runs/shared/claude-code-adapter.ts
@@ -1,0 +1,129 @@
+import type { ExternalCliParser, ExternalCliParserProgress, ExternalCliParserTerminal } from "./external-cli-runner.ts";
+import type { ExternalCliPreflightSpec } from "./external-cli-preflight.ts";
+
+const MAX_EVENT_TYPE_LENGTH = 128;
+const MAX_ERROR_LENGTH = 4_096;
+
+export const CLAUDE_CODE_ADAPTER_ID = "claude-code" as const;
+export const CLAUDE_CODE_WRITER_ADAPTER_ID = "claude-code-writer" as const;
+export const CLAUDE_CODE_WRITER_TOOLS = "Read,Write,Edit,Glob,Grep" as const;
+export const CLAUDE_CODE_ENV_ALLOWLIST = [
+	"PATH",
+	"HOME",
+	"USERPROFILE",
+	"CLAUDE_CONFIG_DIR",
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_AUTH_TOKEN",
+	"ANTHROPIC_BASE_URL",
+	"CLAUDE_CODE_OAUTH_TOKEN",
+	"CLAUDE_CODE_USE_BEDROCK",
+	"CLAUDE_CODE_USE_VERTEX",
+	"CLAUDE_CODE_USE_FOUNDRY",
+	"AWS_PROFILE",
+	"AWS_REGION",
+	"AWS_DEFAULT_REGION",
+	"AWS_ACCESS_KEY_ID",
+	"AWS_SECRET_ACCESS_KEY",
+	"AWS_SESSION_TOKEN",
+	"AWS_BEARER_TOKEN_BEDROCK",
+	"GOOGLE_APPLICATION_CREDENTIALS",
+	"CLOUD_ML_REGION",
+	"ANTHROPIC_VERTEX_PROJECT_ID",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
+] as const;
+
+function terminalError(event: Record<string, unknown>): string {
+	for (const value of [event.error, event.result]) {
+		if (typeof value === "string" && value.trim()) return value.trim().slice(0, MAX_ERROR_LENGTH);
+	}
+	if (Array.isArray(event.errors)) {
+		const messages = event.errors.filter((value): value is string => typeof value === "string" && Boolean(value.trim()));
+		if (messages.length > 0) return messages.join("; ").slice(0, MAX_ERROR_LENGTH);
+	}
+	const subtype = typeof event.subtype === "string" && event.subtype ? event.subtype : "unknown";
+	return `Claude Code reported terminal result ${subtype}.`;
+}
+
+export function createClaudeCodeJsonlParser(): ExternalCliParser {
+	let eventCount = 0;
+	let terminal: ExternalCliParserTerminal | undefined;
+	return {
+		parseLine(line): ExternalCliParserProgress {
+			let value: unknown;
+			try { value = JSON.parse(line) as unknown; }
+			catch (error) { throw new Error(`Claude Code emitted malformed JSONL: ${error instanceof Error ? error.message : String(error)}`); }
+			if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Claude Code emitted a JSONL event that is not an object.");
+			const event = value as Record<string, unknown>;
+			if (typeof event.type !== "string" || !event.type || event.type.length > MAX_EVENT_TYPE_LENGTH) throw new Error("Claude Code emitted a JSONL event with an invalid type.");
+			if (terminal && event.type === "result") throw new Error("Claude Code emitted a duplicate terminal result.");
+			eventCount += 1;
+			if (!terminal && event.type === "result") {
+				if (event.subtype === "success" && event.is_error === false && typeof event.result === "string" && event.result.trim()) {
+					terminal = { state: "completed", output: event.result.trim() };
+				} else {
+					terminal = { state: "failed", error: terminalError(event) };
+				}
+			}
+			return { phase: terminal ? terminal.state : "streaming", eventCount };
+		},
+		finish(): ExternalCliParserTerminal | undefined {
+			return terminal;
+		},
+	};
+}
+
+export function resolveClaudeCodeLaunch(input: {
+	adapter: typeof CLAUDE_CODE_ADAPTER_ID | typeof CLAUDE_CODE_WRITER_ADAPTER_ID;
+	command: string;
+	/** Test-only executable prefix for a fake Claude Code process. */
+	commandPrefixArgs?: readonly string[];
+}): {
+	command: string;
+	args: string[];
+	finalOutputPath?: undefined;
+	environment: { allowlist: readonly string[] };
+	preflight: ExternalCliPreflightSpec;
+	parser: ExternalCliParser;
+} {
+	const writer = input.adapter === CLAUDE_CODE_WRITER_ADAPTER_ID;
+	const prefix = [...(input.commandPrefixArgs ?? [])];
+	const args = [
+		...prefix,
+		"-p",
+		"--input-format", "text",
+		"--output-format", "stream-json",
+		"--verbose",
+		"--permission-mode", writer ? "acceptEdits" : "plan",
+		"--tools", writer ? CLAUDE_CODE_WRITER_TOOLS : "",
+		"--strict-mcp-config",
+		"--mcp-config", '{"mcpServers":{}}',
+		"--setting-sources", "user",
+		"--no-session-persistence",
+		"--disable-slash-commands",
+		"--no-chrome",
+	];
+	return {
+		command: input.command,
+		args,
+		environment: { allowlist: CLAUDE_CODE_ENV_ALLOWLIST },
+		preflight: {
+			id: input.adapter,
+			versionArgs: [...prefix, "--version"],
+			helpArgs: [...prefix, "--help"],
+			validate(result) {
+				if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)? \(Claude Code\)$/.test(result.version)) throw new Error(`Unsupported Claude Code version response: ${JSON.stringify(result.version)}.`);
+				for (const required of ["Claude Code - starts an interactive session", "--print", "--input-format", "stream-json", "--verbose", "--permission-mode", writer ? "acceptEdits" : "plan", "--tools", "--strict-mcp-config", "--mcp-config", "--setting-sources", "--no-session-persistence", "--disable-slash-commands", "--no-chrome"]) {
+					if (!result.help.includes(required)) throw new Error(`Claude Code help does not document required option ${JSON.stringify(required)}.`);
+				}
+			},
+		},
+		parser: createClaudeCodeJsonlParser(),
+	};
+}

--- a/src/runs/shared/external-cli-contract.ts
+++ b/src/runs/shared/external-cli-contract.ts
@@ -17,6 +17,20 @@ const UNSUPPORTED = {
 
 const CAPABILITY_KEYS = new Set(Object.keys(UNSUPPORTED));
 
+export function validateClaudeCodeProfileRunner(
+	agent: {
+		name: string;
+		localName?: string;
+		aliases?: readonly string[];
+		runner?: { type: string; adapter?: string };
+	},
+): string | undefined {
+	const selectionNames = [agent.name, ...(agent.localName ? [agent.localName] : []), ...(agent.aliases ?? [])];
+	if (!selectionNames.includes("claude-code")) return undefined;
+	if (agent.runner?.type === "external-cli" && agent.runner.adapter === "claude-code") return undefined;
+	return "Selection name 'claude-code' is reserved for the read-only 'claude-code' adapter. Use 'claude-code-writer' for explicit file-write access.";
+}
+
 export function parseExternalCliCapabilityNarrowing(value: unknown, label: string): ExternalCliCapabilityNarrowing | undefined {
 	if (value === undefined) return undefined;
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object.`);
@@ -30,20 +44,24 @@ export function parseExternalCliCapabilityNarrowing(value: unknown, label: strin
 }
 
 export function resolveExternalCliRunnerStatus(input: {
-	adapter?: "codex-exec";
+	adapter?: "codex-exec" | "claude-code" | "claude-code-writer";
 	command: string;
 	args?: string[];
 	promptDelivery?: "stdin";
 	capabilities?: ExternalCliCapabilityNarrowing;
 }): ExternalCliRunnerStatus {
 	const codexExec = input.adapter === "codex-exec";
+	const claudeCode = input.adapter === "claude-code";
+	const claudeCodeWriter = input.adapter === "claude-code-writer";
 	return {
 		type: "external-cli",
 		command: input.command,
 		args: input.args ?? [],
 		promptDelivery: input.promptDelivery ?? "stdin",
-		adapter: { id: codexExec ? "codex-exec" : "external-cli", version: 1, executionMode: "one-shot-stdin" },
+		adapter: { id: input.adapter ?? "external-cli", version: 1, executionMode: "one-shot-stdin" },
 		...(codexExec ? { safety: { sandbox: "read-only" as const, approvalPolicy: "never" as const, ephemeral: true as const } } : {}),
+		...(claudeCode ? { safety: { access: "read-only" as const, authentication: "existing-cli-required" as const, permissionMode: "plan" as const, tools: "none" as const, mcp: "empty-strict" as const, settingSources: "user" as const, userSettingsTrust: "required" as const, sessionPersistence: false as const } } : {}),
+		...(claudeCodeWriter ? { safety: { access: "workspace-write" as const, authentication: "existing-cli-required" as const, permissionMode: "acceptEdits" as const, tools: "Read,Write,Edit,Glob,Grep" as const, mcp: "empty-strict" as const, settingSources: "user" as const, userSettingsTrust: "required" as const, sessionPersistence: false as const } } : {}),
 		capabilities: {
 			stop: true,
 			steer: false,
@@ -67,9 +85,10 @@ export function normalizeExternalCliRunnerStatus(value: unknown): ExternalCliRun
 		? input.args
 		: undefined;
 	const promptDelivery = input.promptDelivery === "stdin" ? "stdin" : undefined;
-	const adapter = input.adapter && typeof input.adapter === "object" && !Array.isArray(input.adapter) && (input.adapter as Record<string, unknown>).id === "codex-exec"
-		? "codex-exec" as const
+	const adapterId = input.adapter && typeof input.adapter === "object" && !Array.isArray(input.adapter)
+		? (input.adapter as Record<string, unknown>).id
 		: undefined;
+	const adapter = adapterId === "codex-exec" || adapterId === "claude-code" || adapterId === "claude-code-writer" ? adapterId : undefined;
 	return resolveExternalCliRunnerStatus({ ...(adapter ? { adapter } : {}), command: input.command, ...(args ? { args } : {}), ...(promptDelivery ? { promptDelivery } : {}) });
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1378,7 +1378,7 @@ export type AgentRunnerConfig =
 	| { type: "pi" }
 	| {
 		type: "external-cli";
-		adapter?: "codex-exec";
+		adapter?: "codex-exec" | "claude-code" | "claude-code-writer";
 		command: string;
 		args?: string[];
 		promptDelivery?: "stdin";
@@ -1404,9 +1404,13 @@ export interface ExternalCliCapabilities {
 }
 
 export interface ExternalCliReceiptMetadata {
-	adapter: { id: "external-cli" | "codex-exec"; version: 1; executionMode: "one-shot-stdin" };
+	adapter: { id: "external-cli" | "codex-exec" | "claude-code" | "claude-code-writer"; version: 1; executionMode: "one-shot-stdin" };
 	capabilities: ExternalCliCapabilities;
-	safety?: { sandbox: "read-only"; approvalPolicy: "never"; ephemeral: true };
+	safety?:
+		| { sandbox: "read-only"; approvalPolicy: "never"; ephemeral: true }
+		| { permissionMode: "plan"; tools: "none"; mcp: "empty-strict"; settingSources: "none"; sessionPersistence: false }
+		| { access: "read-only"; authentication: "existing-cli-required"; permissionMode: "plan"; tools: "none"; mcp: "empty-strict"; settingSources: "user"; userSettingsTrust: "required"; sessionPersistence: false }
+		| { access: "workspace-write"; authentication: "existing-cli-required"; permissionMode: "acceptEdits"; tools: "Read,Write,Edit,Glob,Grep"; mcp: "empty-strict"; settingSources: "user"; userSettingsTrust: "required"; sessionPersistence: false };
 	outputArtifacts?: { stdoutPath?: string; stderrPath?: string; finalOutputPath?: string };
 	handoff: { mode: "fresh" };
 	supervisor: { mode: "unsupported"; reason: string };

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -88,7 +88,7 @@ function parseExternalCliReceiptMetadata(value: unknown, key: string, source: st
 	const adapterRecord = adapter as Record<string, unknown>;
 	const unknownAdapter = Object.keys(adapterRecord).filter((field) => !["id", "version", "executionMode"].includes(field));
 	if (unknownAdapter.length > 0) throw new Error(`${label}.adapter has unsupported fields: ${unknownAdapter.join(", ")}.`);
-	if ((adapterRecord.id !== "external-cli" && adapterRecord.id !== "codex-exec") || adapterRecord.version !== 1 || adapterRecord.executionMode !== "one-shot-stdin") throw new Error(`${label}.adapter is invalid.`);
+	if ((adapterRecord.id !== "external-cli" && adapterRecord.id !== "codex-exec" && adapterRecord.id !== "claude-code" && adapterRecord.id !== "claude-code-writer") || adapterRecord.version !== 1 || adapterRecord.executionMode !== "one-shot-stdin") throw new Error(`${label}.adapter is invalid.`);
 	const capabilities = metadata.capabilities;
 	if (!capabilities || typeof capabilities !== "object" || Array.isArray(capabilities)) throw new Error(`${label}.capabilities must be an object.`);
 	const capabilityRecord = capabilities as Record<string, unknown>;
@@ -104,6 +104,23 @@ function parseExternalCliReceiptMetadata(value: unknown, key: string, source: st
 		const unknownSafety = Object.keys(safetyRecord).filter((field) => !["sandbox", "approvalPolicy", "ephemeral"].includes(field));
 		if (unknownSafety.length > 0) throw new Error(`${label}.safety has unsupported fields: ${unknownSafety.join(", ")}.`);
 		if (safetyRecord.sandbox !== "read-only" || safetyRecord.approvalPolicy !== "never" || safetyRecord.ephemeral !== true) throw new Error(`${label}.safety is invalid.`);
+	} else if (adapterRecord.id === "claude-code") {
+		if (!safety || typeof safety !== "object" || Array.isArray(safety)) throw new Error(`${label}.safety is missing.`);
+		const safetyRecord = safety as Record<string, unknown>;
+		const legacy = safetyRecord.authentication === undefined;
+		const unknownSafety = Object.keys(safetyRecord).filter((field) => !(legacy
+			? ["permissionMode", "tools", "mcp", "settingSources", "sessionPersistence"]
+			: ["access", "authentication", "permissionMode", "tools", "mcp", "settingSources", "userSettingsTrust", "sessionPersistence"]).includes(field));
+		if (unknownSafety.length > 0) throw new Error(`${label}.safety has unsupported fields: ${unknownSafety.join(", ")}.`);
+		if (legacy) {
+			if (safetyRecord.permissionMode !== "plan" || safetyRecord.tools !== "none" || safetyRecord.mcp !== "empty-strict" || safetyRecord.settingSources !== "none" || safetyRecord.sessionPersistence !== false) throw new Error(`${label}.safety is invalid.`);
+		} else if (safetyRecord.access !== "read-only" || safetyRecord.authentication !== "existing-cli-required" || safetyRecord.permissionMode !== "plan" || safetyRecord.tools !== "none" || safetyRecord.mcp !== "empty-strict" || safetyRecord.settingSources !== "user" || safetyRecord.userSettingsTrust !== "required" || safetyRecord.sessionPersistence !== false) throw new Error(`${label}.safety is invalid.`);
+	} else if (adapterRecord.id === "claude-code-writer") {
+		if (!safety || typeof safety !== "object" || Array.isArray(safety)) throw new Error(`${label}.safety is missing.`);
+		const safetyRecord = safety as Record<string, unknown>;
+		const unknownSafety = Object.keys(safetyRecord).filter((field) => !["access", "authentication", "permissionMode", "tools", "mcp", "settingSources", "userSettingsTrust", "sessionPersistence"].includes(field));
+		if (unknownSafety.length > 0) throw new Error(`${label}.safety has unsupported fields: ${unknownSafety.join(", ")}.`);
+		if (safetyRecord.access !== "workspace-write" || safetyRecord.authentication !== "existing-cli-required" || safetyRecord.permissionMode !== "acceptEdits" || safetyRecord.tools !== "Read,Write,Edit,Glob,Grep" || safetyRecord.mcp !== "empty-strict" || safetyRecord.settingSources !== "user" || safetyRecord.userSettingsTrust !== "required" || safetyRecord.sessionPersistence !== false) throw new Error(`${label}.safety is invalid.`);
 	} else if (safety !== undefined) throw new Error(`${label}.safety is invalid for the generic adapter.`);
 	const handoff = metadata.handoff;
 	if (!handoff || typeof handoff !== "object" || Array.isArray(handoff)) throw new Error(`${label}.handoff must be an object.`);

--- a/test/integration/claude-code-smoke.test.ts
+++ b/test/integration/claude-code-smoke.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import { resolveClaudeCodeLaunch } from "../../src/runs/shared/claude-code-adapter.ts";
+import { runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+
+const enabled = process.env.PI_SUBAGENTS_CLAUDE_CODE_SMOKE === "1";
+
+test("maintainer Claude Code no-tools smoke", { skip: enabled ? undefined : "set PI_SUBAGENTS_CLAUDE_CODE_SMOKE=1" }, async () => {
+	const reportPath = process.env.PI_SUBAGENTS_CLAUDE_CODE_SMOKE_REPORT;
+	assert.ok(reportPath, "PI_SUBAGENTS_CLAUDE_CODE_SMOKE_REPORT is required");
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-claude-smoke-"));
+	const canaryPath = path.join(dir, "write-canary.txt");
+	try {
+		const launch = resolveClaudeCodeLaunch({ adapter: "claude-code", command: "claude" });
+		const result = await runExternalCli({
+			...launch,
+			cwd: dir,
+			prompt: `Attempt to write the text CANARY to ${canaryPath}. Then explain whether the no-tools policy allowed it.`,
+			asyncDir: dir,
+			stepIndex: 0,
+		});
+		const report = {
+			adapter: "claude-code",
+			adapterVersion: 1,
+			access: "read-only",
+			authentication: "existing-cli-required",
+			cliVersion: result.preflight?.version,
+			cwd: dir,
+			permissionMode: "plan",
+			tools: "none",
+			mcp: "empty-strict",
+			settingSources: "user",
+			userSettingsTrust: "required",
+			sessionPersistence: false,
+			exitCode: result.exitCode,
+			terminalState: result.parserTerminal?.state,
+			writeCanaryExists: fs.existsSync(canaryPath),
+			stdoutPath: result.externalProcess.stdoutPath,
+			stderrPath: result.externalProcess.stderrPath,
+			durationMs: result.externalProcess.durationMs,
+		};
+		fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
+		assert.equal(result.exitCode, 0, result.error);
+		assert.equal(result.parserTerminal?.state, "completed");
+		assert.equal(fs.existsSync(canaryPath), false, "Claude Code wrote the no-tools canary");
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/test/integration/claude-code-writer-smoke.test.ts
+++ b/test/integration/claude-code-writer-smoke.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import { CLAUDE_CODE_WRITER_TOOLS, resolveClaudeCodeLaunch } from "../../src/runs/shared/claude-code-adapter.ts";
+import { runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+
+const enabled = process.env.PI_SUBAGENTS_CLAUDE_CODE_WRITER_SMOKE === "1";
+
+test("maintainer Claude Code writer smoke", { skip: enabled ? undefined : "set PI_SUBAGENTS_CLAUDE_CODE_WRITER_SMOKE=1" }, async () => {
+	const reportPath = process.env.PI_SUBAGENTS_CLAUDE_CODE_WRITER_SMOKE_REPORT;
+	assert.ok(reportPath, "PI_SUBAGENTS_CLAUDE_CODE_WRITER_SMOKE_REPORT is required");
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-claude-writer-smoke-"));
+	const canaryPath = path.join(dir, "write-canary.txt");
+	try {
+		const launch = resolveClaudeCodeLaunch({ adapter: "claude-code-writer", command: "claude" });
+		const result = await runExternalCli({
+			...launch,
+			cwd: dir,
+			prompt: `Use the Write tool to write exactly CANARY to ${canaryPath}. Then report completion.`,
+			asyncDir: dir,
+			stepIndex: 0,
+		});
+		const writeCanaryExists = fs.existsSync(canaryPath);
+		const writeCanaryMatches = writeCanaryExists && fs.readFileSync(canaryPath, "utf-8").trim() === "CANARY";
+		const report = {
+			adapter: "claude-code-writer",
+			adapterVersion: 1,
+			access: "workspace-write",
+			authentication: "existing-cli-required",
+			cliVersion: result.preflight?.version,
+			cwd: dir,
+			permissionMode: "acceptEdits",
+			tools: CLAUDE_CODE_WRITER_TOOLS,
+			mcp: "empty-strict",
+			settingSources: "user",
+			userSettingsTrust: "required",
+			sessionPersistence: false,
+			exitCode: result.exitCode,
+			terminalState: result.parserTerminal?.state,
+			writeCanaryExists,
+			writeCanaryMatches,
+			stdoutPath: result.externalProcess.stdoutPath,
+			stderrPath: result.externalProcess.stderrPath,
+			durationMs: result.externalProcess.durationMs,
+		};
+		fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
+		assert.equal(result.exitCode, 0, result.error);
+		assert.equal(result.parserTerminal?.state, "completed");
+		assert.equal(writeCanaryMatches, true, "Claude Code did not write the expected canary");
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -60,6 +60,36 @@ describe("agent management config parsing", () => {
 		assert.doesNotMatch(readText(result), /- scout \(builtin/);
 	});
 
+	it("rejects management attempts to widen the reserved read-only Claude profile", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+		const writerRunner = { type: "external-cli", adapter: "claude-code-writer", command: "claude" };
+		const unsafeCreate = handleCreate({ config: { name: "claude-code", description: "Unsafe shadow", scope: "project", runner: writerRunner } }, ctx);
+		assert.equal(unsafeCreate.isError, true);
+		assert.match(readText(unsafeCreate), /reserved for the read-only 'claude-code' adapter/);
+		const unsafeLocalName = handleCreate({ config: { name: "claude-code", package: "custom", description: "Unsafe local name", scope: "project", runner: writerRunner } }, ctx);
+		assert.equal(unsafeLocalName.isError, true);
+		assert.match(readText(unsafeLocalName), /Selection name 'claude-code' is reserved/);
+		const unsafeAlias = handleCreate({ config: { name: "aliased-writer", aliases: ["claude-code"], description: "Unsafe alias", scope: "project", runner: writerRunner } }, ctx);
+		assert.equal(unsafeAlias.isError, true);
+		assert.match(readText(unsafeAlias), /Selection name 'claude-code' is reserved/);
+
+		const readOnlyCreate = handleCreate({ config: { name: "claude-code", description: "Narrow shadow", scope: "project", runner: { type: "external-cli", adapter: "claude-code", command: "claude" } } }, ctx);
+		assert.equal(readOnlyCreate.isError, false);
+		const unsafeUpdate = handleUpdate({ agent: "claude-code", agentScope: "project", config: { runner: writerRunner } }, ctx);
+		assert.equal(unsafeUpdate.isError, true);
+		assert.match(readText(unsafeUpdate), /reserved for the read-only 'claude-code' adapter/);
+		assert.match(fs.readFileSync(path.join(tempDir, ".pi", "agents", "claude-code.md"), "utf-8"), /adapter: claude-code\n/);
+
+		const writerCreate = handleCreate({ config: { name: "custom-writer", description: "Writer", scope: "project", runner: writerRunner } }, ctx);
+		assert.equal(writerCreate.isError, false);
+		const unsafeAliasUpdate = handleUpdate({ agent: "custom-writer", agentScope: "project", config: { aliases: ["claude-code"] } }, ctx);
+		assert.equal(unsafeAliasUpdate.isError, true);
+		assert.match(readText(unsafeAliasUpdate), /Selection name 'claude-code' is reserved/);
+		const unsafeRename = handleUpdate({ agent: "custom-writer", agentScope: "project", config: { name: "claude-code" } }, ctx);
+		assert.equal(unsafeRename.isError, true);
+		assert.match(readText(unsafeRename), /reserved for the read-only 'claude-code' adapter/);
+	});
+
 	it("lists valid agents and diagnoses malformed agent definitions", () => {
 		const agentsDir = path.join(tempDir, ".pi", "agents");
 		fs.mkdirSync(agentsDir, { recursive: true });

--- a/test/unit/claude-code-adapter.test.ts
+++ b/test/unit/claude-code-adapter.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { discoverAgents, discoverAgentsAll, resolveAgentName } from "../../src/agents/agents.ts";
+import { CLAUDE_CODE_ADAPTER_ID, CLAUDE_CODE_WRITER_ADAPTER_ID, CLAUDE_CODE_WRITER_TOOLS, createClaudeCodeJsonlParser, resolveClaudeCodeLaunch } from "../../src/runs/shared/claude-code-adapter.ts";
+import { externalCliReceiptMetadata, resolveExternalCliRunnerStatus } from "../../src/runs/shared/external-cli-contract.ts";
+import { clearExternalCliPreflightCacheForTests } from "../../src/runs/shared/external-cli-preflight.ts";
+import { runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+import { buildWorkflowReceipt, readWorkflowReceipt, writeWorkflowReceipt } from "../../src/workflows/workflow-receipt.ts";
+
+const tempDirs: string[] = [];
+function tempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-claude-code-"));
+	tempDirs.push(dir);
+	return dir;
+}
+afterEach(() => {
+	clearExternalCliPreflightCacheForTests();
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function fakeClaudeScript(dir: string): string {
+	const scriptPath = path.join(dir, "fake-claude.cjs");
+	fs.writeFileSync(scriptPath, String.raw`
++const args = process.argv.slice(2);
++if (args[0] === "--version") { console.log("2.1.150 (Claude Code)"); process.exit(0); }
++if (args[0] === "--help") {
++  console.log("Claude Code - starts an interactive session --print --input-format text --output-format stream-json --verbose --permission-mode plan acceptEdits --tools --strict-mcp-config --mcp-config --setting-sources --no-session-persistence --disable-slash-commands --no-chrome");
++  process.exit(0);
++}
++let prompt = "";
++process.stdin.on("data", chunk => prompt += chunk);
++process.stdin.on("end", () => {
++  if (prompt.includes("malformed")) return process.stdout.write("{bad json}\n");
++  if (prompt.includes("oversized")) return process.stdout.write(JSON.stringify({type:"assistant", value:"x".repeat(300000)}) + "\n");
++  process.stdout.write(JSON.stringify({type:"system", subtype:"init"}) + "\n");
++  if (prompt.includes("missing-terminal")) return;
++  if (prompt.includes("auth-error")) return process.stdout.write(JSON.stringify({type:"result", subtype:"error_during_execution", is_error:true, errors:["authentication required"]}) + "\n");
++  if (prompt.includes("max-turns")) return process.stdout.write(JSON.stringify({type:"result", subtype:"error_max_turns", is_error:true, result:"partial"}) + "\n");
++  if (prompt.includes("budget")) return process.stdout.write(JSON.stringify({type:"result", subtype:"error_max_budget_usd", is_error:true, result:"partial"}) + "\n");
++  if (prompt.includes("missing-text")) return process.stdout.write(JSON.stringify({type:"result", subtype:"success", is_error:false, result:""}) + "\n");
++  process.stdout.write(JSON.stringify({type:"assistant", message:{content:[{type:"text", text:"untrusted partial"}]}}) + "\n");
++  process.stdout.write(JSON.stringify({type:"result", subtype:"success", is_error:false, result:"trusted final result", session_id:"not-persisted"}) + "\n");
++  if (prompt.includes("duplicate-terminal")) process.stdout.write(JSON.stringify({type:"result", subtype:"success", is_error:false, result:"duplicate"}) + "\n");
++});
++`.replace(/^\+/gm, ""), "utf-8");
+	return scriptPath;
+}
+
+async function runFake(dir: string, stepIndex: number, prompt: string, adapter: typeof CLAUDE_CODE_ADAPTER_ID | typeof CLAUDE_CODE_WRITER_ADAPTER_ID = CLAUDE_CODE_ADAPTER_ID) {
+	const scriptPath = fakeClaudeScript(dir);
+	const launch = resolveClaudeCodeLaunch({ adapter, command: process.execPath, commandPrefixArgs: [scriptPath] });
+	const result = await runExternalCli({ ...launch, cwd: dir, prompt, asyncDir: dir, stepIndex });
+	return { launch, result };
+}
+
+describe("Claude Code adapter", () => {
+	it("owns no-tools argv, stdin delivery, launch preflight, and terminal result proof", async () => {
+		const dir = tempDir();
+		const { launch, result } = await runFake(dir, 0, "review $HOME; echo nope");
+		assert.deepEqual(launch.args.slice(1), [
+			"-p", "--input-format", "text", "--output-format", "stream-json", "--verbose", "--permission-mode", "plan",
+			"--tools", "", "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}', "--setting-sources", "user", "--no-session-persistence",
+			"--disable-slash-commands", "--no-chrome",
+		]);
+		assert.equal(launch.args.some((arg) => /dangerously|bypassPermissions|acceptEdits|--bare|--resume|--continue/.test(arg)), false);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.output, "trusted final result");
+		assert.equal(result.parserTerminal?.state, "completed");
+		assert.equal(result.preflight?.version, "2.1.150 (Claude Code)");
+	});
+
+	it("owns explicit file writer argv without permission bypass or MCP", async () => {
+		const dir = tempDir();
+		const { launch, result } = await runFake(dir, 9, "write the requested file", CLAUDE_CODE_WRITER_ADAPTER_ID);
+		assert.deepEqual(launch.args.slice(1), [
+			"-p", "--input-format", "text", "--output-format", "stream-json", "--verbose", "--permission-mode", "acceptEdits",
+			"--tools", CLAUDE_CODE_WRITER_TOOLS, "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}', "--setting-sources", "user", "--no-session-persistence",
+			"--disable-slash-commands", "--no-chrome",
+		]);
+		assert.equal(launch.args.some((arg) => /dangerously|bypassPermissions|--bare|--resume|--continue|\bBash\b/.test(arg)), false);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.output, "trusted final result");
+	});
+
+	it("fails closed on malformed, oversized, auth, limit, EOF, missing-text, and duplicate terminal output", async () => {
+		const dir = tempDir();
+		for (const [index, prompt, pattern] of [
+			[1, "malformed", /malformed JSONL/],
+			[2, "oversized", /line exceeded/],
+			[3, "auth-error", /authentication required/],
+			[4, "max-turns", /partial/],
+			[5, "budget", /partial/],
+			[6, "missing-terminal", /did not produce a terminal state/],
+			[7, "missing-text", /terminal result success/],
+			[8, "duplicate-terminal", /duplicate terminal result/],
+		] as const) {
+			const { result } = await runFake(dir, index, prompt);
+			assert.equal(result.exitCode, 1, prompt);
+			assert.match(result.error ?? "", pattern, prompt);
+		}
+	});
+
+	it("rejects unsupported version and incomplete help during launch preflight", () => {
+		const launch = resolveClaudeCodeLaunch({ adapter: CLAUDE_CODE_ADAPTER_ID, command: "claude" });
+		const help = "Claude Code - starts an interactive session --print --input-format stream-json --verbose --permission-mode plan --tools --strict-mcp-config --mcp-config --setting-sources --no-session-persistence --disable-slash-commands --no-chrome";
+		const evidence = { binaryPath: "/tmp/claude", binaryMtimeMs: 1, version: "2.1.150 (Claude Code)", help, cacheHit: false };
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, version: "Claude unknown" }), /Unsupported Claude Code version response/);
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, help: "Claude Code - starts an interactive session --print" }), /does not document required option/);
+	});
+
+	it("accepts non-terminal hook trailers but rejects duplicate result events", () => {
+		const parser = createClaudeCodeJsonlParser();
+		parser.parseLine('{"type":"result","subtype":"success","is_error":false,"result":"done"}');
+		assert.doesNotThrow(() => parser.parseLine('{"type":"system","subtype":"hook_response"}'));
+		assert.throws(() => parser.parseLine('{"type":"result","subtype":"success","is_error":false,"result":"again"}'), /duplicate terminal result/);
+	});
+
+	it("publishes compact Claude safety receipt metadata", () => {
+		const runner = resolveExternalCliRunnerStatus({ adapter: "claude-code", command: "claude" });
+		const metadata = externalCliReceiptMetadata({ runner, externalProcess: { startedAt: 1, stdoutPath: "/tmp/stdout", stderrPath: "/tmp/stderr" } });
+		const receipt = buildWorkflowReceipt({
+			workflowRunId: "claude-workflow",
+			state: "complete",
+			children: [{ key: "claude", ok: true, output: "done", resumability: { state: "not-resumable", reason: metadata.nonResumableReason }, continuation: { runIds: [] }, externalAdapter: metadata, results: [], artifactPaths: [] }],
+		});
+		const root = tempDir();
+		const runDir = path.join(root, receipt.workflowRunId);
+		fs.mkdirSync(runDir);
+		writeWorkflowReceipt(runDir, receipt);
+		const persisted = readWorkflowReceipt(root, receipt.workflowRunId);
+		assert.equal(persisted.entries.claude?.externalAdapter?.adapter.id, "claude-code");
+		assert.deepEqual(persisted.entries.claude?.externalAdapter?.safety, { access: "read-only", authentication: "existing-cli-required", permissionMode: "plan", tools: "none", mcp: "empty-strict", settingSources: "user", userSettingsTrust: "required", sessionPersistence: false });
+		assert.doesNotMatch(JSON.stringify(receipt), /trusted final result|session_id|rawOutput/);
+	});
+
+	it("publishes strict writer safety metadata and reads legacy local Claude receipts", () => {
+		const writer = externalCliReceiptMetadata({ runner: resolveExternalCliRunnerStatus({ adapter: "claude-code-writer", command: "claude" }) });
+		assert.deepEqual(writer.safety, { access: "workspace-write", authentication: "existing-cli-required", permissionMode: "acceptEdits", tools: CLAUDE_CODE_WRITER_TOOLS, mcp: "empty-strict", settingSources: "user", userSettingsTrust: "required", sessionPersistence: false });
+
+		const root = tempDir();
+		const writerDir = path.join(root, "writer");
+		fs.mkdirSync(writerDir);
+		const writerReceipt = buildWorkflowReceipt({
+			workflowRunId: "writer",
+			state: "complete",
+			children: [{ key: "claude", ok: true, output: "done", resumability: { state: "not-resumable", reason: writer.nonResumableReason }, continuation: { runIds: [] }, externalAdapter: writer, results: [], artifactPaths: [] }],
+		});
+		writeWorkflowReceipt(writerDir, writerReceipt);
+		assert.deepEqual(readWorkflowReceipt(root, "writer").entries.claude?.externalAdapter?.safety, writer.safety);
+		fs.writeFileSync(path.join(writerDir, "workflow-receipt.json"), JSON.stringify(writerReceipt, (key, value) => key === "tools" ? "Bash" : value), "utf-8");
+		assert.throws(() => readWorkflowReceipt(root, "writer"), /externalAdapter\.safety is invalid/);
+
+		const runDir = path.join(root, "legacy-claude");
+		fs.mkdirSync(runDir);
+		const legacy = buildWorkflowReceipt({
+			workflowRunId: "legacy-claude",
+			state: "complete",
+			children: [{ key: "claude", ok: true, output: "done", resumability: { state: "not-resumable", reason: writer.nonResumableReason }, continuation: { runIds: [] }, externalAdapter: externalCliReceiptMetadata({ runner: resolveExternalCliRunnerStatus({ adapter: "claude-code", command: "claude" }) }), results: [], artifactPaths: [] }],
+		});
+		fs.writeFileSync(path.join(runDir, "workflow-receipt.json"), JSON.stringify(legacy, (key, value) => key === "safety" ? { permissionMode: "plan", tools: "none", mcp: "empty-strict", settingSources: "none", sessionPersistence: false } : value), "utf-8");
+		assert.equal(readWorkflowReceipt(root, "legacy-claude").entries.claude?.externalAdapter?.adapter.id, "claude-code");
+	});
+
+	it("discovers the built-in profile without probing Claude Code", () => {
+		const agents = discoverAgentsAll(tempDir()).builtin;
+		assert.deepEqual(agents.find((candidate) => candidate.name === "claude-code")?.runner, { type: "external-cli", adapter: "claude-code", command: "claude", promptDelivery: "stdin" });
+		assert.deepEqual(agents.find((candidate) => candidate.name === "claude-code-writer")?.runner, { type: "external-cli", adapter: "claude-code-writer", command: "claude", promptDelivery: "stdin" });
+	});
+
+	it("rejects user and project shadows that widen the read-only profile", () => {
+		const project = tempDir();
+		const userRoot = tempDir();
+		const oldAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const definition = `---\nname: claude-code\ndescription: Unsafe Claude shadow\nrunner:\n  type: external-cli\n  adapter: claude-code-writer\n  command: claude\n---\nWrite.\n`;
+		try {
+			process.env.PI_CODING_AGENT_DIR = userRoot;
+			fs.mkdirSync(path.join(userRoot, "agents"), { recursive: true });
+			fs.mkdirSync(path.join(project, ".pi", "agents"), { recursive: true });
+			fs.writeFileSync(path.join(userRoot, "agents", "claude-code.md"), definition, "utf-8");
+			fs.writeFileSync(path.join(project, ".pi", "agents", "claude-code.md"), definition, "utf-8");
+
+			const discovered = discoverAgentsAll(project);
+			assert.equal(discovered.user.some((candidate) => candidate.name === "claude-code"), false);
+			assert.equal(discovered.project.some((candidate) => candidate.name === "claude-code"), false);
+			for (const source of ["user", "project"] as const) {
+				assert.match(discovered.agentDiagnostics?.find((diagnostic) => diagnostic.source === source && diagnostic.name === "claude-code")?.error ?? "", /reserved for the read-only 'claude-code' adapter/);
+			}
+		} finally {
+			if (oldAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = oldAgentDir;
+		}
+	});
+
+	it("keeps disabled read-only selection reserved across local names and aliases", () => {
+		const project = tempDir();
+		const userRoot = tempDir();
+		const oldAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const packageRoot = path.join(project, ".pi", "npm", "node_modules", "unsafe-claude-package");
+		try {
+			process.env.PI_CODING_AGENT_DIR = userRoot;
+			fs.mkdirSync(path.join(userRoot, "agents"), { recursive: true });
+			fs.mkdirSync(path.join(project, ".pi", "agents"), { recursive: true });
+			fs.mkdirSync(path.join(packageRoot, "agents"), { recursive: true });
+			fs.writeFileSync(path.join(project, ".pi", "settings.json"), JSON.stringify({ subagents: { agentOverrides: { "claude-code": { disabled: true } } } }), "utf-8");
+			fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: "unsafe-claude-package", "pi-subagents": { agents: ["./agents"] } }), "utf-8");
+			fs.writeFileSync(path.join(packageRoot, "agents", "claude-code.md"), `---\nname: claude-code\npackage: unsafe-mode\ndescription: Unsafe package local name\nrunner:\n  type: external-cli\n  adapter: claude-code-writer\n  command: claude\n---\nWrite.\n`, "utf-8");
+			fs.writeFileSync(path.join(project, ".pi", "agents", "project-writer.md"), `---\nname: project-writer\naliases: claude-code\ndescription: Unsafe project alias\nrunner:\n  type: external-cli\n  adapter: claude-code-writer\n  command: claude\n---\nWrite.\n`, "utf-8");
+			fs.writeFileSync(path.join(userRoot, "agents", "user-writer.md"), `---\nname: user-writer\naliases: claude-code\ndescription: Unsafe user alias\nrunner:\n  type: external-cli\n  adapter: claude-code-writer\n  command: claude\n---\nWrite.\n`, "utf-8");
+
+			const all = discoverAgentsAll(project);
+			for (const [source, name] of [["package", "claude-code"], ["project", "project-writer"], ["user", "user-writer"]] as const) {
+				assert.match(all.agentDiagnostics?.find((diagnostic) => diagnostic.source === source && diagnostic.name === name)?.error ?? "", /Selection name 'claude-code' is reserved/);
+			}
+			const effective = discoverAgents(project, "both").agents;
+			assert.equal(resolveAgentName("claude-code", effective).agent, undefined);
+			const writer = resolveAgentName("claude-code-writer", effective).agent;
+			assert.equal(writer?.runner?.type === "external-cli" ? writer.runner.adapter : undefined, "claude-code-writer");
+		} finally {
+			if (oldAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = oldAgentDir;
+		}
+	});
+
+	it("rejects frontmatter argv that would widen the packaged adapter", () => {
+		const dir = tempDir();
+		const agentsDir = path.join(dir, ".pi", "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(path.join(agentsDir, "unsafe.md"), `---\nname: unsafe\ndescription: Unsafe override\nrunner:\n  type: external-cli\n  adapter: claude-code\n  command: claude\n  args: ["--dangerously-skip-permissions"]\n---\nReview.\n`, "utf-8");
+		fs.writeFileSync(path.join(agentsDir, "unsafe-writer.md"), `---\nname: unsafe-writer\ndescription: Unsafe writer override\nrunner:\n  type: external-cli\n  adapter: claude-code-writer\n  command: claude\n  args: ["--tools", "Bash"]\n---\nWrite.\n`, "utf-8");
+		const discovered = discoverAgentsAll(dir);
+		assert.equal(discovered.project.some((candidate) => candidate.name === "unsafe"), false);
+		assert.match(discovered.agentDiagnostics?.find((diagnostic) => diagnostic.name === "unsafe")?.error ?? "", /claude-code adapter owns its argv/);
+		assert.equal(discovered.project.some((candidate) => candidate.name === "unsafe-writer"), false);
+		assert.match(discovered.agentDiagnostics?.find((diagnostic) => diagnostic.name === "unsafe-writer")?.error ?? "", /claude-code-writer adapter owns its argv/);
+	});
+});

--- a/test/unit/runtime-agent-registration.test.ts
+++ b/test/unit/runtime-agent-registration.test.ts
@@ -97,6 +97,14 @@ describe("runtime agent registration", () => {
 
 	it("fails closed for builtin and duplicate runtime identities", () => {
 		assert.throws(
+			() => registerAgent({ pi, name: "claude-code", definition: { description: "Unsafe", systemPrompt: "Write.", runner: { type: "external-cli", adapter: "claude-code-writer", command: "claude" } } }),
+			/reserved for the read-only 'claude-code' adapter/,
+		);
+		assert.throws(
+			() => registerAgent({ pi, name: "runtime-writer", definition: { description: "Unsafe alias", systemPrompt: "Write.", aliases: ["claude-code"], runner: { type: "external-cli", adapter: "claude-code-writer", command: "claude" } } }),
+			/Selection name 'claude-code' is reserved/,
+		);
+		assert.throws(
 			() => registerAgent({ pi, name: "worker", definition: { description: "Bad", systemPrompt: "Bad." } }),
 			/Worker|builtin agent 'worker'|collides with builtin agent 'worker'/i,
 		);


### PR DESCRIPTION
## Summary

This PR adds the Claude Code baseline for #1426 as two explicit external CLI profiles:

- `claude-code`: read-only analysis through Claude Code `stream-json` with plan/no-tools mode.
- `claude-code-writer`: explicit workspace-write mode through Claude Code with only `Read,Write,Edit,Glob,Grep`.

Both profiles use the normal locally authenticated Claude Code CLI. They require trusted user-level Claude settings/hooks, use an empty strict MCP config, disable session persistence and slash commands, and publish compact safety metadata in status and workflow receipts.

The read-only profile is reserved. User, project, package, and runtime agent definitions cannot make the selection identity `claude-code` resolve to `claude-code-writer`, including local-name and alias cases after the built-in profile is disabled.

## Validation

- `node --experimental-strip-types --import test/support/isolated-temp-root.mjs --test ...` affected PR4 unit set: 209 passed.
- `node --experimental-strip-types --import test/support/register-loader.mjs --test --test-name-pattern='external CLI' test/integration/single-execution.test.ts`: 9 passed.
- Default Claude smoke harnesses: 2 skipped unless opt-in env vars are set.
- `npm run typecheck`: passed.
- `git diff --check HEAD^..HEAD`: passed.
- Fresh targeted review of the reserved-selection fix: no issues found.

## Deferred smoke note

The authenticated Claude Code read-only and writer smokes are not run on this head yet because the local Claude CLI login is currently unavailable. The smoke harnesses are included and default-skipped. The owner approved deferring `claude auth login` and the opt-in smokes so the staged #1426 PR series can continue.

Part of #1426.