### PR TITLE
feat: add Grok Build baseline adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add the built-in `grok-build` read-only prompt-file profile with isolated temporary state, update suppression, inspect evidence, bounded streaming-JSON terminal proof, and opt-in write-canary smoke evidence.
 - Add code-owned `claude-code` read-only and `claude-code-writer` file-editing profiles for an existing authenticated CLI with trusted user settings, bounded stream-JSON result proof, and opt-in mode-specific smoke evidence.
 - Add the built-in `codex-exec` profile with code-owned read-only argv, bounded JSONL terminal proof, and a final-message artifact.
 - External CLI runs now publish code-owned capability limits and compact workflow receipt metadata for adapter identity, artifacts, handoff mode, supervisor support, and resumability.

--- a/agents/grok-build.md
+++ b/agents/grok-build.md
@@ -1,0 +1,14 @@
+---
+name: grok-build
+description: Read-only one-shot analysis through the installed Grok Build CLI
+runner:
+  type: external-cli
+  adapter: grok-build
+  command: grok
+async: true
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+---
+
+Analyze the task in read-only mode. Return a concise final answer with evidence. Do not edit files or request wider access.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -113,6 +113,24 @@ node --experimental-strip-types --import ./test/support/register-loader.mjs \
 
 Both smoke reports record `authentication: "existing-cli-required"`, `settingSources: "user"`, and `userSettingsTrust: "required"` without recording credential details. For read-only, confirm `terminalState` is `completed` and `writeCanaryExists` is `false`. For writer, confirm `terminalState` is `completed` and `writeCanaryMatches` is `true`. `durationMs` records cold process time. If authentication is missing or revoked, repair the normal local Claude Code login and rerun the smoke. Reports do not contain raw protocol output or credentials.
 
+The built-in `grok-build` profile is the supported Grok Build one-shot baseline. It requires an installed Grok Build CLI and `XAI_API_KEY`. The adapter sends the handoff through a private prompt file because Grok headless mode does not read the prompt from stdin. It uses the same private temporary directory for `HOME`, `USERPROFILE`, and `GROK_HOME`, disables Claude, Cursor, and Codex compatibility scanners, and removes that home and the prompt file at process completion. Grok sessions are therefore fresh and are not retained or resumable through Pi.
+
+The adapter owns `grok --prompt-file` argv with native streaming JSON, permission mode `plan`, only `read_file,grep,list_dir`, explicit write/terminal/MCP/subagent denials, the read-only sandbox, disabled web search, disabled subagents, and a fixed 16-turn limit. It also sets `GROK_DISABLE_AUTOUPDATER=1`, `GROK_MEMORY=0`, `GROK_SUBAGENTS=0`, and `GROK_WRITE_FILE=0`. User profiles cannot add argv or select another adapter under the reserved `grok-build` name.
+
+Launch preflight validates `grok --version` and `grok --help`, then runs `grok inspect --json` in the target directory with the isolated Grok home. Version and help evidence is cached. Inspect evidence runs for each launch and must show no hooks, plugins, MCP servers, LSP servers, or enabled external compatibility cells. Its content is not copied into status or receipts. Discovery, list, status, and native Pi launches do not execute Grok or probe authentication. A run succeeds only when bounded valid JSONL ends with `end.stopReason === "end_turn"` after non-empty `text.data` output. Error events, other stop reasons, malformed JSON, and EOF before `end` fail closed.
+
+Maintainers can collect authenticated terminal, read-only canary, inspect, and cold-start evidence:
+
+```bash
+PI_SUBAGENTS_GROK_BUILD_SMOKE=1 \
+PI_SUBAGENTS_GROK_BUILD_SMOKE_REPORT=/tmp/pi-subagents-grok-build-smoke.json \
+XAI_API_KEY=... \
+node --experimental-strip-types --import ./test/support/register-loader.mjs \
+  --test test/integration/grok-build-smoke.test.ts
+```
+
+Confirm `terminalState` is `completed`, `writeCanaryExists` is `false`, and `inspectValidated` is `true`. `durationMs` records cold process time. The report does not contain the API key, prompt, raw protocol output, or inspected configuration. Process stop uses the shared process-tree termination and reaping path. `grok agent stdio` ACP is not a supported profile yet because its installed permission, terminal, cancellation, and session contract has not passed a current protocol smoke.
+
 Native `oracle` runs inside Pi and can use its configured read tools. The Claude profiles send the assembled prompt to the local Claude Code CLI through stdin. An external-job agent sends the assembled prompt to its registered provider. Provider options and a prompt digest are persisted in Pi run state. The prompt text is delivered through the local host bridge to the provider and is not stored in the public result payload. Do not place secrets in advisory prompts unless the target provider is approved to receive them.
 
 ### External-job state table

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -33,7 +33,7 @@ import { resolveSubagentModelOverride, type ParentModel } from "../runs/shared/m
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
 import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
-import { validateClaudeCodeProfileRunner } from "../runs/shared/external-cli-contract.ts";
+import { validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import type { AcceptanceInput, Details, ExtensionConfig, ToolBudgetConfig } from "../shared/types.ts";
 import { getProjectConfigDir } from "../shared/utils.ts";
 import { capabilityCeilingAgentRestrictionSources, isAgentAllowedByCapabilityCeiling, resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
@@ -379,17 +379,17 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 			if (runner.type === "pi" && Object.keys(runner).every((key) => key === "type")) target.runner = { type: "pi" };
 			else if (runner.type === "external-cli" && typeof runner.command === "string" && runner.command.trim()
 				&& (runner.args === undefined || (Array.isArray(runner.args) && runner.args.every((arg) => typeof arg === "string")))
-				&& (runner.adapter === undefined || runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer")
+				&& (runner.adapter === undefined || runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" || runner.adapter === "grok-build")
 				&& (runner.adapter === undefined || runner.args === undefined || runner.args.length === 0)
 				&& (runner.promptDelivery === undefined || runner.promptDelivery === "stdin")
 				&& Object.keys(runner).every((key) => ["type", "adapter", "command", "args", "promptDelivery"].includes(key))) {
 				const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
-				target.runner = { type: "external-cli", ...(runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
+				target.runner = { type: "external-cli", ...(runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" || runner.adapter === "grok-build" ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
 			} else if (runner.type === "external-job" && typeof runner.provider === "string" && runner.provider.trim() === runner.provider && runner.provider
 				&& (runner.options === undefined || (runner.options && typeof runner.options === "object" && !Array.isArray(runner.options) && isJsonSerializable(runner.options)))
 				&& Object.keys(runner).every((key) => ["type", "provider", "options"].includes(key))) {
 				target.runner = { type: "external-job", provider: runner.provider, ...(runner.options ? { options: runner.options as Record<string, unknown> } : {}) };
-			} else return "config.runner must be { type: 'pi' }, { type: 'external-cli', adapter?: 'codex-exec' | 'claude-code' | 'claude-code-writer', command: string, args?: string[], promptDelivery?: 'stdin' }, or { type: 'external-job', provider: string, options?: object }.";
+			} else return "config.runner must be { type: 'pi' }, { type: 'external-cli', adapter?: 'codex-exec' | 'claude-code' | 'claude-code-writer' | 'grok-build', command: string, args?: string[], promptDelivery?: 'stdin' }, or { type: 'external-job', provider: string, options?: object }.";
 		} else return "config.runner must be an object, false, or empty string when provided.";
 	}
 	if (hasKey(cfg, "model")) {
@@ -918,8 +918,8 @@ export function handleCreate(params: ManagementParams, ctx: ManagementContext): 
 	};
 	const applyError = applyAgentConfig(agent, cfg);
 	if (applyError) return result(applyError, true);
-	const claudeProfileError = validateClaudeCodeProfileRunner(agent);
-	if (claudeProfileError) return result(claudeProfileError, true);
+	const profileError = validateCodeOwnedProfileRunner(agent);
+	if (profileError) return result(profileError, true);
 	const mw = modelWarning(ctx, agent.model);
 	if (mw) warnings.push(mw);
 	const fmw = fallbackModelsWarning(ctx, agent.fallbackModels);
@@ -971,8 +971,8 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 	if (newPackageName !== undefined) updated.packageName = newPackageName;
 	else delete updated.packageName;
 	updated.name = buildRuntimeName(newLocalName, newPackageName);
-	const claudeProfileError = validateClaudeCodeProfileRunner(updated);
-	if (claudeProfileError) return result(claudeProfileError, true);
+	const profileError = validateCodeOwnedProfileRunner(updated);
+	if (profileError) return result(profileError, true);
 	if (hasKey(cfg, "description")) updated.description = (cfg.description as string).trim();
 	if (hasKey(cfg, "model")) {
 		const mw = modelWarning(ctx, updated.model);

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -9,7 +9,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
-import { parseExternalCliCapabilityNarrowing, validateClaudeCodeProfileRunner } from "../runs/shared/external-cli-contract.ts";
+import { parseExternalCliCapabilityNarrowing, validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import { getAgentDir, getProjectConfigDir } from "../shared/utils.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain, parseJsonChain } from "./chain-serializer.ts";
@@ -1683,7 +1683,7 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) {
 		throw new Error(`Agent '${agentName}' external-cli runner args must be an array of strings.`);
 	}
-	if (runner.adapter !== undefined && runner.adapter !== "codex-exec" && runner.adapter !== "claude-code" && runner.adapter !== "claude-code-writer") throw new Error(`Agent '${agentName}' external-cli runner adapter must be 'codex-exec', 'claude-code', or 'claude-code-writer'.`);
+	if (runner.adapter !== undefined && runner.adapter !== "codex-exec" && runner.adapter !== "claude-code" && runner.adapter !== "claude-code-writer" && runner.adapter !== "grok-build") throw new Error(`Agent '${agentName}' external-cli runner adapter must be 'codex-exec', 'claude-code', 'claude-code-writer', or 'grok-build'.`);
 	if (runner.adapter !== undefined && Array.isArray(runner.args) && runner.args.length > 0) throw new Error(`Agent '${agentName}' ${runner.adapter} adapter owns its argv; runner args are not supported.`);
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") {
 		throw new Error(`Agent '${agentName}' external-cli runner promptDelivery must be 'stdin'.`);
@@ -1695,7 +1695,7 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 	const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
 	return {
 		type: "external-cli",
-		...(runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" ? { adapter: runner.adapter } : {}),
+		...(runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" || runner.adapter === "grok-build" ? { adapter: runner.adapter } : {}),
 		command: runner.command.trim(),
 		...(runnerArgs?.length ? { args: runnerArgs } : {}),
 		...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}),
@@ -1789,8 +1789,8 @@ function loadAgentsFromDefinitionFiles(files: AgentDefinitionFile[], source: Age
 		const mcpDirectTools = parsedTools.mcpDirectTools ?? [];
 		const defaultReads = parseFrontmatterList(frontmatter.defaultReads);
 		const aliases = normalizeAgentAliases(parseFrontmatterList(frontmatter.aliases ?? frontmatter.alias), runtimeName);
-		const claudeProfileError = validateClaudeCodeProfileRunner({ name: runtimeName, localName, aliases, runner });
-		if (claudeProfileError) throw new Error(claudeProfileError);
+		const profileError = validateCodeOwnedProfileRunner({ name: runtimeName, localName, aliases, runner });
+		if (profileError) throw new Error(profileError);
 		const skillStr = frontmatter.skill || frontmatter.skills;
 		const skills = parseFrontmatterList(skillStr);
 		const skillPath = parseFrontmatterList(frontmatter.skillPath);

--- a/src/agents/builtin-names.ts
+++ b/src/agents/builtin-names.ts
@@ -4,6 +4,7 @@ export const BUILTIN_AGENT_NAMES = [
 	"claude-code-writer",
 	"codex-exec",
 	"delegate",
+	"grok-build",
 	"oracle",
 	"researcher",
 	"reviewer",

--- a/src/agents/runtime-agent-registry.ts
+++ b/src/agents/runtime-agent-registry.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
-import { parseExternalCliCapabilityNarrowing, validateClaudeCodeProfileRunner } from "../runs/shared/external-cli-contract.ts";
+import { parseExternalCliCapabilityNarrowing, validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import { validatePermissionRules, type PermissionRules } from "../runs/shared/permissions.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
@@ -170,7 +170,7 @@ function validateRunner(value: unknown): AgentRunnerConfig | undefined {
 	if (runner.type !== "external-cli") throw new Error("Runtime agent definition runner.type must be 'pi', 'external-cli', or 'external-job'.");
 	if (typeof runner.command !== "string" || !runner.command.trim()) throw new Error("Runtime agent definition external-cli runner requires a non-empty command string.");
 	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) throw new Error("Runtime agent definition external-cli runner args must be an array of strings.");
-	if (runner.adapter !== undefined && runner.adapter !== "codex-exec" && runner.adapter !== "claude-code" && runner.adapter !== "claude-code-writer") throw new Error("Runtime agent definition external-cli runner adapter must be 'codex-exec', 'claude-code', or 'claude-code-writer'.");
+	if (runner.adapter !== undefined && runner.adapter !== "codex-exec" && runner.adapter !== "claude-code" && runner.adapter !== "claude-code-writer" && runner.adapter !== "grok-build") throw new Error("Runtime agent definition external-cli runner adapter must be 'codex-exec', 'claude-code', 'claude-code-writer', or 'grok-build'.");
 	if (runner.adapter !== undefined && Array.isArray(runner.args) && runner.args.length > 0) throw new Error(`Runtime agent definition ${runner.adapter} adapter owns its argv; runner args are not supported.`);
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") throw new Error("Runtime agent definition external-cli runner promptDelivery must be 'stdin'.");
 	const capabilities = parseExternalCliCapabilityNarrowing(runner.capabilities, "Runtime agent definition external-cli runner capabilities");
@@ -178,7 +178,7 @@ function validateRunner(value: unknown): AgentRunnerConfig | undefined {
 	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
 	if (unknown.length > 0) throw new Error(`Runtime agent definition external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
 	const args = runner.args as string[] | undefined;
-	return { type: "external-cli", ...(runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}), ...(capabilities ? { capabilities } : {}) };
+	return { type: "external-cli", ...(runner.adapter === "codex-exec" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" || runner.adapter === "grok-build" ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}), ...(capabilities ? { capabilities } : {}) };
 }
 
 function validateTurnBudget(value: unknown): TurnBudgetConfig | undefined {
@@ -368,8 +368,8 @@ export function registerRuntimeAgent(input: RegisterRuntimeAgentInput): RuntimeA
 	const name = validateString(input.name, "Runtime agent name", MAX_AGENT_NAME_LENGTH);
 	const definition = validateDefinition(input.definition);
 	const agent = toAgentConfig(name, definition);
-	const claudeProfileError = validateClaudeCodeProfileRunner(agent);
-	if (claudeProfileError) throw new Error(claudeProfileError);
+	const profileError = validateCodeOwnedProfileRunner(agent);
+	if (profileError) throw new Error(profileError);
 	assertNoBuiltinCollision(agent);
 	const current = registry();
 	const records = current.byPi.get(pi) ?? [];

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -542,7 +542,8 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 						lines.push(`  Runner: external-cli (${runner.command}${runner.args.length ? ` ${runner.args.join(" ")}` : ""})`);
 						lines.push(`  Adapter: ${runner.adapter.id} v${runner.adapter.version} (${runner.adapter.executionMode})`);
 						if (runner.safety) {
-							if ("sandbox" in runner.safety) lines.push(`  Safety: sandbox=${runner.safety.sandbox}, approval=${runner.safety.approvalPolicy}, ephemeral=${runner.safety.ephemeral}`);
+							if ("approvalPolicy" in runner.safety) lines.push(`  Safety: sandbox=${runner.safety.sandbox}, approval=${runner.safety.approvalPolicy}, ephemeral=${runner.safety.ephemeral}`);
+							else if ("config" in runner.safety) lines.push(`  Safety: access=${runner.safety.access}, auth=${runner.safety.authentication}, permission=${runner.safety.permissionMode}, tools=${runner.safety.tools}, denied=${runner.safety.deniedTools}, sandbox=${runner.safety.sandbox}, config=${runner.safety.config}, updates=${runner.safety.updates}, persistence=${runner.safety.sessionPersistence}`);
 							else if ("authentication" in runner.safety) lines.push(`  Safety: access=${runner.safety.access}, auth=${runner.safety.authentication}, permission=${runner.safety.permissionMode}, tools=${runner.safety.tools}, mcp=${runner.safety.mcp}, settings=${runner.safety.settingSources}, settingsTrust=${runner.safety.userSettingsTrust}, persistence=${runner.safety.sessionPersistence}`);
 							else lines.push(`  Safety: access=read-only, permission=${runner.safety.permissionMode}, tools=${runner.safety.tools}, mcp=${runner.safety.mcp}, settings=${runner.safety.settingSources}, persistence=${runner.safety.sessionPersistence}`);
 						}

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -146,6 +146,7 @@ import { acquireSessionLease, type SessionLeaseRequest } from "../shared/session
 import { buildExternalCliPrompt, runExternalCli } from "../shared/external-cli-runner.ts";
 import { resolveClaudeCodeLaunch } from "../shared/claude-code-adapter.ts";
 import { resolveCodexExecLaunch } from "../shared/codex-exec-adapter.ts";
+import { resolveGrokBuildLaunch } from "../shared/grok-build-adapter.ts";
 import { resolveExternalCliRunnerStatus } from "../shared/external-cli-contract.ts";
 import { runExternalJob } from "../shared/external-job-runner.ts";
 import { createOrcaProgressTab, type OrcaProgressTab } from "../shared/orca-progress-tabs.ts";
@@ -1384,17 +1385,20 @@ async function runSingleStepInner(
 	transcriptWriter?.writeInitialUserMessage(`${PROMPT_REDACTED}; live Prompt Audit only.`);
 
 	if (step.runner?.type === "external-cli") {
+		const externalCwd = step.cwd ?? ctx.cwd;
 		const adapterLaunch = step.runner.adapter === "codex-exec"
 			? resolveCodexExecLaunch({ command: step.runner.command, asyncDir: path.dirname(ctx.outputFile), stepIndex: ctx.flatIndex })
 			: step.runner.adapter === "claude-code" || step.runner.adapter === "claude-code-writer"
 				? resolveClaudeCodeLaunch({ adapter: step.runner.adapter, command: step.runner.command })
+				: step.runner.adapter === "grok-build"
+					? resolveGrokBuildLaunch({ command: step.runner.command, cwd: externalCwd, asyncDir: path.dirname(ctx.outputFile), stepIndex: ctx.flatIndex })
 				: undefined;
 		const runner = resolveExternalCliRunnerStatus({ ...step.runner, ...(adapterLaunch ? { args: adapterLaunch.args } : {}) });
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
 		const external = await runExternalCli(omitUndefinedProperties({
 			command: adapterLaunch?.command ?? runner.command,
 			args: adapterLaunch?.args ?? runner.args,
-			cwd: step.cwd ?? ctx.cwd,
+			cwd: externalCwd,
 			prompt: buildExternalCliPrompt(step.systemPrompt ?? "", task),
 			asyncDir: path.dirname(ctx.outputFile),
 			stepIndex: ctx.flatIndex,
@@ -1402,6 +1406,8 @@ async function runSingleStepInner(
 			preflight: adapterLaunch?.preflight,
 			parser: adapterLaunch?.parser,
 			finalOutputPath: adapterLaunch?.finalOutputPath,
+			promptFilePath: adapterLaunch?.promptFilePath,
+			temporaryDirectories: adapterLaunch?.temporaryDirectories,
 			registerTimeout: ctx.registerTimeout,
 			registerStop: ctx.registerStop,
 			timeoutMessage: ctx.timeoutMessage,

--- a/src/runs/shared/claude-code-adapter.ts
+++ b/src/runs/shared/claude-code-adapter.ts
@@ -88,6 +88,8 @@ export function resolveClaudeCodeLaunch(input: {
 	command: string;
 	args: string[];
 	finalOutputPath?: undefined;
+	promptFilePath?: undefined;
+	temporaryDirectories?: undefined;
 	environment: { allowlist: readonly string[] };
 	preflight: ExternalCliPreflightSpec;
 	parser: ExternalCliParser;

--- a/src/runs/shared/codex-exec-adapter.ts
+++ b/src/runs/shared/codex-exec-adapter.ts
@@ -87,6 +87,8 @@ export function resolveCodexExecLaunch(input: {
 	command: string;
 	args: string[];
 	finalOutputPath: string;
+	promptFilePath?: undefined;
+	temporaryDirectories?: undefined;
 	environment: { allowlist: readonly string[] };
 	preflight: ExternalCliPreflightSpec;
 	parser: ExternalCliParser;

--- a/src/runs/shared/external-cli-contract.ts
+++ b/src/runs/shared/external-cli-contract.ts
@@ -16,8 +16,13 @@ const UNSUPPORTED = {
 } as const;
 
 const CAPABILITY_KEYS = new Set(Object.keys(UNSUPPORTED));
+const GROK_UNSUPPORTED = {
+	...UNSUPPORTED,
+	steer: "The one-shot prompt-file adapter closes input after launch and cannot accept live steer messages.",
+	resume: "The one-shot prompt-file adapter does not retain a durable external session identity.",
+} as const;
 
-export function validateClaudeCodeProfileRunner(
+export function validateCodeOwnedProfileRunner(
 	agent: {
 		name: string;
 		localName?: string;
@@ -26,9 +31,13 @@ export function validateClaudeCodeProfileRunner(
 	},
 ): string | undefined {
 	const selectionNames = [agent.name, ...(agent.localName ? [agent.localName] : []), ...(agent.aliases ?? [])];
-	if (!selectionNames.includes("claude-code")) return undefined;
-	if (agent.runner?.type === "external-cli" && agent.runner.adapter === "claude-code") return undefined;
-	return "Selection name 'claude-code' is reserved for the read-only 'claude-code' adapter. Use 'claude-code-writer' for explicit file-write access.";
+	if (selectionNames.includes("claude-code") && !(agent.runner?.type === "external-cli" && agent.runner.adapter === "claude-code")) {
+		return "Selection name 'claude-code' is reserved for the read-only 'claude-code' adapter. Use 'claude-code-writer' for explicit file-write access.";
+	}
+	if (selectionNames.includes("grok-build") && !(agent.runner?.type === "external-cli" && agent.runner.adapter === "grok-build")) {
+		return "Selection name 'grok-build' is reserved for the read-only 'grok-build' adapter.";
+	}
+	return undefined;
 }
 
 export function parseExternalCliCapabilityNarrowing(value: unknown, label: string): ExternalCliCapabilityNarrowing | undefined {
@@ -44,7 +53,7 @@ export function parseExternalCliCapabilityNarrowing(value: unknown, label: strin
 }
 
 export function resolveExternalCliRunnerStatus(input: {
-	adapter?: "codex-exec" | "claude-code" | "claude-code-writer";
+	adapter?: "codex-exec" | "claude-code" | "claude-code-writer" | "grok-build";
 	command: string;
 	args?: string[];
 	promptDelivery?: "stdin";
@@ -53,15 +62,18 @@ export function resolveExternalCliRunnerStatus(input: {
 	const codexExec = input.adapter === "codex-exec";
 	const claudeCode = input.adapter === "claude-code";
 	const claudeCodeWriter = input.adapter === "claude-code-writer";
+	const grokBuild = input.adapter === "grok-build";
+	const unsupported = grokBuild ? GROK_UNSUPPORTED : UNSUPPORTED;
 	return {
 		type: "external-cli",
 		command: input.command,
 		args: input.args ?? [],
-		promptDelivery: input.promptDelivery ?? "stdin",
-		adapter: { id: input.adapter ?? "external-cli", version: 1, executionMode: "one-shot-stdin" },
+		promptDelivery: grokBuild ? "prompt-file" : input.promptDelivery ?? "stdin",
+		adapter: { id: input.adapter ?? "external-cli", version: 1, executionMode: grokBuild ? "one-shot-prompt-file" : "one-shot-stdin" },
 		...(codexExec ? { safety: { sandbox: "read-only" as const, approvalPolicy: "never" as const, ephemeral: true as const } } : {}),
 		...(claudeCode ? { safety: { access: "read-only" as const, authentication: "existing-cli-required" as const, permissionMode: "plan" as const, tools: "none" as const, mcp: "empty-strict" as const, settingSources: "user" as const, userSettingsTrust: "required" as const, sessionPersistence: false as const } } : {}),
 		...(claudeCodeWriter ? { safety: { access: "workspace-write" as const, authentication: "existing-cli-required" as const, permissionMode: "acceptEdits" as const, tools: "Read,Write,Edit,Glob,Grep" as const, mcp: "empty-strict" as const, settingSources: "user" as const, userSettingsTrust: "required" as const, sessionPersistence: false as const } } : {}),
+		...(grokBuild ? { safety: { access: "read-only" as const, authentication: "xai-api-key-required" as const, permissionMode: "plan" as const, tools: "read_file,grep,list_dir" as const, deniedTools: "run_terminal_cmd,search_replace,Agent,Bash,Edit,Write,MCPTool" as const, sandbox: "read-only" as const, webSearch: false as const, subagents: false as const, config: "temporary-home" as const, updates: "disabled" as const, sessionPersistence: false as const } } : {}),
 		capabilities: {
 			stop: true,
 			steer: false,
@@ -72,8 +84,8 @@ export function resolveExternalCliRunnerStatus(input: {
 			forkContext: false,
 			extensionBindings: false,
 		},
-		unsupportedReasons: UNSUPPORTED,
-		nonResumableReason: UNSUPPORTED.resume,
+		unsupportedReasons: unsupported,
+		nonResumableReason: unsupported.resume,
 	};
 }
 
@@ -88,7 +100,7 @@ export function normalizeExternalCliRunnerStatus(value: unknown): ExternalCliRun
 	const adapterId = input.adapter && typeof input.adapter === "object" && !Array.isArray(input.adapter)
 		? (input.adapter as Record<string, unknown>).id
 		: undefined;
-	const adapter = adapterId === "codex-exec" || adapterId === "claude-code" || adapterId === "claude-code-writer" ? adapterId : undefined;
+	const adapter = adapterId === "codex-exec" || adapterId === "claude-code" || adapterId === "claude-code-writer" || adapterId === "grok-build" ? adapterId : undefined;
 	return resolveExternalCliRunnerStatus({ ...(adapter ? { adapter } : {}), command: input.command, ...(args ? { args } : {}), ...(promptDelivery ? { promptDelivery } : {}) });
 }
 

--- a/src/runs/shared/external-cli-preflight.ts
+++ b/src/runs/shared/external-cli-preflight.ts
@@ -12,6 +12,8 @@ export interface ExternalCliPreflightSpec {
 	id: string;
 	versionArgs: readonly string[];
 	helpArgs: readonly string[];
+	evidenceArgs?: readonly string[];
+	evidenceLabel?: string;
 	probeTimeoutMs?: number;
 	validate?: (result: ExternalCliPreflightResult) => void;
 }
@@ -21,6 +23,7 @@ export interface ExternalCliPreflightResult {
 	binaryMtimeMs: number;
 	version: string;
 	help: string;
+	evidence?: string;
 	cacheHit: boolean;
 }
 
@@ -49,8 +52,9 @@ function resolveBinary(command: string, env: NodeJS.ProcessEnv): string {
 	throw new Error(`External CLI binary '${command}' was not found on PATH.`);
 }
 
-function probeWithTimeout(binaryPath: string, args: readonly string[], env: NodeJS.ProcessEnv, label: string, timeoutMs: number): string {
+function probeWithTimeout(binaryPath: string, args: readonly string[], env: NodeJS.ProcessEnv, label: string, timeoutMs: number, cwd?: string): string {
 	const result = spawnSync(binaryPath, [...args], {
+		cwd,
 		env,
 		encoding: "utf-8",
 		killSignal: "SIGKILL",
@@ -70,28 +74,36 @@ function narrowPositiveInteger(value: number | undefined, ceiling: number, label
 }
 
 function specKey(spec: ExternalCliPreflightSpec): string {
-	return JSON.stringify([spec.id, spec.versionArgs, spec.helpArgs, spec.probeTimeoutMs]);
+	return JSON.stringify([spec.id, spec.versionArgs, spec.helpArgs, spec.evidenceArgs, spec.evidenceLabel, spec.probeTimeoutMs]);
 }
 
-export function preflightExternalCli(command: string, spec: ExternalCliPreflightSpec, env: NodeJS.ProcessEnv): ExternalCliPreflightResult {
+export function preflightExternalCli(command: string, spec: ExternalCliPreflightSpec, env: NodeJS.ProcessEnv, cwd?: string): ExternalCliPreflightResult {
 	const binaryPath = resolveBinary(command, env);
 	const binaryMtimeMs = fs.statSync(binaryPath).mtimeMs;
 	const lookupKey = JSON.stringify([binaryPath, binaryMtimeMs, specKey(spec)]);
 	const cachedKey = lookup.get(lookupKey);
 	const cached = cachedKey ? cache.get(cachedKey) : undefined;
-	if (cached) return { binaryPath: cached.binaryPath, binaryMtimeMs: cached.binaryMtimeMs, version: cached.version, help: cached.help, cacheHit: true };
 	const probeTimeoutMs = narrowPositiveInteger(spec.probeTimeoutMs, MAX_PROBE_TIMEOUT_MS, "probeTimeoutMs");
-	const version = probeWithTimeout(binaryPath, spec.versionArgs, env, "version", probeTimeoutMs);
-	const help = probeWithTimeout(binaryPath, spec.helpArgs, env, "help", probeTimeoutMs);
-	const result = { binaryPath, binaryMtimeMs, version, help, cacheHit: false };
+	const base = cached ?? {
+		binaryPath,
+		binaryMtimeMs,
+		version: probeWithTimeout(binaryPath, spec.versionArgs, env, "version", probeTimeoutMs, cwd),
+		help: probeWithTimeout(binaryPath, spec.helpArgs, env, "help", probeTimeoutMs, cwd),
+	};
+	const evidence = spec.evidenceArgs
+		? probeWithTimeout(binaryPath, spec.evidenceArgs, env, spec.evidenceLabel ?? "evidence", probeTimeoutMs, cwd)
+		: undefined;
+	const result = { ...base, ...(evidence !== undefined ? { evidence } : {}), cacheHit: Boolean(cached) };
 	spec.validate?.(result);
-	const cacheKey = JSON.stringify([binaryPath, version, binaryMtimeMs, specKey(spec)]);
-	cache.set(cacheKey, { binaryPath, binaryMtimeMs, version, help });
-	lookup.set(lookupKey, cacheKey);
-	while (cache.size > MAX_CACHE_ENTRIES) {
-		const oldest = cache.keys().next().value as string;
-		cache.delete(oldest);
-		for (const [candidateLookup, candidateCache] of lookup) if (candidateCache === oldest) lookup.delete(candidateLookup);
+	if (!cached) {
+		const cacheKey = JSON.stringify([binaryPath, base.version, binaryMtimeMs, specKey(spec)]);
+		cache.set(cacheKey, base);
+		lookup.set(lookupKey, cacheKey);
+		while (cache.size > MAX_CACHE_ENTRIES) {
+			const oldest = cache.keys().next().value as string;
+			cache.delete(oldest);
+			for (const [candidateLookup, candidateCache] of lookup) if (candidateCache === oldest) lookup.delete(candidateLookup);
+		}
 	}
 	return result;
 }

--- a/src/runs/shared/external-cli-runner.ts
+++ b/src/runs/shared/external-cli-runner.ts
@@ -144,6 +144,8 @@ export function runExternalCli(input: {
 	preflight?: ExternalCliPreflightSpec;
 	parser?: ExternalCliParser;
 	finalOutputPath?: string;
+	promptFilePath?: string;
+	temporaryDirectories?: readonly string[];
 	limits?: StreamLimits;
 	registerTimeout?: (stop: (() => void) | undefined) => void;
 	registerStop?: (stop: (() => void) | undefined) => void;
@@ -169,16 +171,34 @@ export function runExternalCli(input: {
 		const stdoutStream = fs.createWriteStream(stdoutPath, { flags: "w" });
 		const stderrStream = fs.createWriteStream(stderrPath, { flags: "w" });
 		const streamsFinished = Promise.allSettled([finished(stdoutStream), finished(stderrStream)]);
+		const createdDirectories: string[] = [];
+		let promptFileCreated = false;
+		const cleanupTemporaryPaths = () => {
+			if (input.promptFilePath && promptFileCreated) fs.rmSync(input.promptFilePath, { force: true });
+			for (const directory of createdDirectories.reverse()) fs.rmSync(directory, { recursive: true, force: true });
+		};
 		const env = externalEnvironment(input.environment?.allowlist, input.environment?.values);
 		let preflight: ExternalCliPreflightResult | undefined;
 		try {
-			if (input.preflight) preflight = preflightExternalCli(input.command, input.preflight, env);
+			for (const directory of input.temporaryDirectories ?? []) {
+				fs.mkdirSync(directory, { mode: 0o700 });
+				createdDirectories.push(directory);
+			}
+			if (input.promptFilePath) {
+				const promptDescriptor = fs.openSync(input.promptFilePath, "wx", 0o600);
+				promptFileCreated = true;
+				try { fs.writeFileSync(promptDescriptor, input.prompt, { encoding: "utf-8" }); }
+				finally { fs.closeSync(promptDescriptor); }
+			}
+			if (input.preflight) preflight = preflightExternalCli(input.command, input.preflight, env, input.cwd);
 		} catch (error) {
 			const endedAt = Date.now();
 			const externalProcess = { startedAt, endedAt, durationMs: endedAt - startedAt, exitCode: 1, processSignal: null, stdoutPath, stderrPath, ...(input.finalOutputPath ? { finalOutputPath: input.finalOutputPath } : {}) } satisfies ExternalProcessStatus;
 			stdoutStream.end();
 			stderrStream.end();
 			void streamsFinished.then((streamResults) => {
+				try { cleanupTemporaryPaths(); }
+				catch (cleanupError) { reject(cleanupError); return; }
 				const streamFailure = streamResults.find((streamResult) => streamResult.status === "rejected");
 				if (streamFailure?.status === "rejected") reject(streamFailure.reason);
 				else resolve({ output: "", exitCode: 1, error: error instanceof Error ? error.message : String(error), processSignal: null, externalProcess });
@@ -291,7 +311,7 @@ export function runExternalCli(input: {
 		input.registerTimeout?.(() => terminate("timeout"));
 		input.registerStop?.(() => terminate("stop"));
 		child.stdin.on("error", () => {});
-		child.stdin.end(input.prompt);
+		child.stdin.end(input.promptFilePath ? undefined : input.prompt);
 		let spawnError: Error | undefined;
 		child.once("error", (error) => { spawnError = error; });
 		child.stdout.once("end", () => {
@@ -349,6 +369,8 @@ export function runExternalCli(input: {
 				stderrStream.end();
 				const streamResults = await streamsFinished;
 				const streamFailure = streamResults.find((streamResult) => streamResult.status === "rejected");
+				try { cleanupTemporaryPaths(); }
+				catch (cleanupError) { reject(cleanupError); return; }
 				if (streamFailure?.status === "rejected") reject(streamFailure.reason);
 				else resolve(result);
 			})();

--- a/src/runs/shared/grok-build-adapter.ts
+++ b/src/runs/shared/grok-build-adapter.ts
@@ -1,0 +1,186 @@
+import * as path from "node:path";
+import type { ExternalCliParser, ExternalCliParserProgress, ExternalCliParserTerminal } from "./external-cli-runner.ts";
+import type { ExternalCliPreflightSpec } from "./external-cli-preflight.ts";
+
+const MAX_EVENT_TYPE_LENGTH = 128;
+const MAX_ERROR_LENGTH = 4_096;
+
+export const GROK_BUILD_ADAPTER_ID = "grok-build" as const;
+export const GROK_BUILD_READ_TOOLS = "read_file,grep,list_dir" as const;
+export const GROK_BUILD_DISALLOWED_TOOLS = "run_terminal_cmd,search_replace,Agent" as const;
+export const GROK_BUILD_ENV_ALLOWLIST = [
+	"PATH",
+	"HOME",
+	"USERPROFILE",
+	"GROK_HOME",
+	"XAI_API_KEY",
+	"GROK_DISABLE_AUTOUPDATER",
+	"GROK_MEMORY",
+	"GROK_SUBAGENTS",
+	"GROK_WRITE_FILE",
+	"GROK_CLAUDE_AGENTS_ENABLED",
+	"GROK_CLAUDE_HOOKS_ENABLED",
+	"GROK_CLAUDE_MCPS_ENABLED",
+	"GROK_CLAUDE_RULES_ENABLED",
+	"GROK_CLAUDE_SESSIONS_ENABLED",
+	"GROK_CLAUDE_SKILLS_ENABLED",
+	"GROK_CODEX_SESSIONS_ENABLED",
+	"GROK_CURSOR_AGENTS_ENABLED",
+	"GROK_CURSOR_HOOKS_ENABLED",
+	"GROK_CURSOR_MCPS_ENABLED",
+	"GROK_CURSOR_RULES_ENABLED",
+	"GROK_CURSOR_SESSIONS_ENABLED",
+	"GROK_CURSOR_SKILLS_ENABLED",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
+] as const;
+
+function eventError(event: Record<string, unknown>, fallback: string): string {
+	for (const value of [event.message, event.error]) {
+		if (typeof value === "string" && value.trim()) return value.trim().slice(0, MAX_ERROR_LENGTH);
+	}
+	return fallback;
+}
+
+export function createGrokBuildJsonlParser(): ExternalCliParser {
+	let eventCount = 0;
+	let terminal: ExternalCliParserTerminal | undefined;
+	let reportedError: string | undefined;
+	const text: string[] = [];
+	return {
+		parseLine(line): ExternalCliParserProgress {
+			let value: unknown;
+			try { value = JSON.parse(line) as unknown; }
+			catch (error) { throw new Error(`Grok Build emitted malformed JSONL: ${error instanceof Error ? error.message : String(error)}`); }
+			if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Grok Build emitted a JSONL event that is not an object.");
+			const event = value as Record<string, unknown>;
+			if (typeof event.type !== "string" || !event.type || event.type.length > MAX_EVENT_TYPE_LENGTH) throw new Error("Grok Build emitted a JSONL event with an invalid type.");
+			if (terminal) throw new Error("Grok Build emitted an event after its terminal state.");
+			eventCount += 1;
+			if (event.type === "text" && typeof event.data === "string") text.push(event.data);
+			else if (event.type === "error" && !reportedError) reportedError = eventError(event, "Grok Build reported an error event.");
+			else if (event.type === "end") {
+				if (reportedError) terminal = { state: "failed", error: reportedError };
+				else if (event.stopReason !== "end_turn") {
+					const reason = typeof event.stopReason === "string" && event.stopReason ? event.stopReason : "missing";
+					terminal = { state: "failed", error: `Grok Build stopped without successful end_turn: ${reason}.` };
+				} else {
+					const output = text.join("").trim();
+					terminal = output
+						? { state: "completed", output }
+						: { state: "failed", error: "Grok Build completed without final text." };
+				}
+			}
+			return { phase: terminal ? terminal.state : "streaming", eventCount };
+		},
+		finish(): ExternalCliParserTerminal | undefined {
+			return terminal ?? (reportedError ? { state: "failed", error: reportedError } : undefined);
+		},
+	};
+}
+
+export function resolveGrokBuildLaunch(input: {
+	command: string;
+	cwd: string;
+	asyncDir: string;
+	stepIndex: number;
+	/** Test-only executable prefix for a fake Grok Build process. */
+	commandPrefixArgs?: readonly string[];
+}): {
+	command: string;
+	args: string[];
+	finalOutputPath?: undefined;
+	promptFilePath: string;
+	temporaryDirectories: string[];
+	environment: { allowlist: readonly string[]; values: Readonly<Record<string, string>> };
+	preflight: ExternalCliPreflightSpec;
+	parser: ExternalCliParser;
+} {
+	const promptFilePath = path.join(input.asyncDir, `external-${input.stepIndex}.grok-prompt.txt`);
+	const grokHomePath = path.join(input.asyncDir, `external-${input.stepIndex}.grok-home`);
+	const prefix = [...(input.commandPrefixArgs ?? [])];
+	const args = [
+		...prefix,
+		"--cwd", input.cwd,
+		"--prompt-file", promptFilePath,
+		"--output-format", "streaming-json",
+		"--permission-mode", "plan",
+		"--tools", GROK_BUILD_READ_TOOLS,
+		"--disallowed-tools", GROK_BUILD_DISALLOWED_TOOLS,
+		"--deny", "Bash",
+		"--deny", "Edit",
+		"--deny", "Write",
+		"--deny", "MCPTool",
+		"--disable-web-search",
+		"--no-subagents",
+		"--sandbox", "read-only",
+		"--max-turns", "16",
+	];
+	return {
+		command: input.command,
+		args,
+		promptFilePath,
+		temporaryDirectories: [grokHomePath],
+		environment: {
+			allowlist: GROK_BUILD_ENV_ALLOWLIST,
+			values: {
+				HOME: grokHomePath,
+				USERPROFILE: grokHomePath,
+				GROK_HOME: grokHomePath,
+				GROK_DISABLE_AUTOUPDATER: "1",
+				GROK_MEMORY: "0",
+				GROK_SUBAGENTS: "0",
+				GROK_WRITE_FILE: "0",
+				GROK_CLAUDE_AGENTS_ENABLED: "0",
+				GROK_CLAUDE_HOOKS_ENABLED: "0",
+				GROK_CLAUDE_MCPS_ENABLED: "0",
+				GROK_CLAUDE_RULES_ENABLED: "0",
+				GROK_CLAUDE_SESSIONS_ENABLED: "0",
+				GROK_CLAUDE_SKILLS_ENABLED: "0",
+				GROK_CODEX_SESSIONS_ENABLED: "0",
+				GROK_CURSOR_AGENTS_ENABLED: "0",
+				GROK_CURSOR_HOOKS_ENABLED: "0",
+				GROK_CURSOR_MCPS_ENABLED: "0",
+				GROK_CURSOR_RULES_ENABLED: "0",
+				GROK_CURSOR_SESSIONS_ENABLED: "0",
+				GROK_CURSOR_SKILLS_ENABLED: "0",
+			},
+		},
+		preflight: {
+			id: GROK_BUILD_ADAPTER_ID,
+			versionArgs: [...prefix, "--version"],
+			helpArgs: [...prefix, "--help"],
+			evidenceArgs: [...prefix, "inspect", "--json"],
+			evidenceLabel: "inspect --json",
+			validate(result) {
+				if (!/^grok \d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)? \([0-9a-f]+\)(?: \[[^\]]+\])?$/.test(result.version)) throw new Error(`Unsupported Grok Build version response: ${JSON.stringify(result.version)}.`);
+				for (const required of ["Grok Build TUI", "--cwd", "--prompt-file", "streaming-json", "--permission-mode", "plan", "--tools", "--disallowed-tools", "--deny", "--disable-web-search", "--no-subagents", "--sandbox", "--max-turns"]) {
+					if (!result.help.includes(required)) throw new Error(`Grok Build help does not document required option ${JSON.stringify(required)}.`);
+				}
+				let inspect: unknown;
+				try { inspect = JSON.parse(result.evidence ?? ""); }
+				catch (error) { throw new Error(`Grok Build inspect --json returned malformed JSON: ${error instanceof Error ? error.message : String(error)}`); }
+				if (!inspect || typeof inspect !== "object" || Array.isArray(inspect)) throw new Error("Grok Build inspect --json did not return an object.");
+				const inspectRecord = inspect as Record<string, unknown>;
+				for (const field of ["hooks", "lspServers", "mcpServers", "plugins"] as const) {
+					const entries = inspectRecord[field];
+					if (!Array.isArray(entries)) throw new Error(`Grok Build inspect --json field ${field} is invalid.`);
+					if (entries.length > 0) throw new Error(`Grok Build inspect --json discovered executable configuration in ${field}.`);
+				}
+				const externalCompat = inspectRecord.externalCompat;
+				if (!externalCompat || typeof externalCompat !== "object" || Array.isArray(externalCompat)) throw new Error("Grok Build inspect --json field externalCompat is invalid.");
+				const cells = (externalCompat as Record<string, unknown>).cells;
+				if (!Array.isArray(cells) || cells.some((cell) => !cell || typeof cell !== "object" || Array.isArray(cell) || (cell as Record<string, unknown>).enabled !== false)) {
+					throw new Error("Grok Build inspect --json did not confirm disabled external compatibility.");
+				}
+			},
+		},
+		parser: createGrokBuildJsonlParser(),
+	};
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1378,7 +1378,7 @@ export type AgentRunnerConfig =
 	| { type: "pi" }
 	| {
 		type: "external-cli";
-		adapter?: "codex-exec" | "claude-code" | "claude-code-writer";
+		adapter?: "codex-exec" | "claude-code" | "claude-code-writer" | "grok-build";
 		command: string;
 		args?: string[];
 		promptDelivery?: "stdin";
@@ -1404,13 +1404,14 @@ export interface ExternalCliCapabilities {
 }
 
 export interface ExternalCliReceiptMetadata {
-	adapter: { id: "external-cli" | "codex-exec" | "claude-code" | "claude-code-writer"; version: 1; executionMode: "one-shot-stdin" };
+	adapter: { id: "external-cli" | "codex-exec" | "claude-code" | "claude-code-writer" | "grok-build"; version: 1; executionMode: "one-shot-stdin" | "one-shot-prompt-file" };
 	capabilities: ExternalCliCapabilities;
 	safety?:
 		| { sandbox: "read-only"; approvalPolicy: "never"; ephemeral: true }
 		| { permissionMode: "plan"; tools: "none"; mcp: "empty-strict"; settingSources: "none"; sessionPersistence: false }
 		| { access: "read-only"; authentication: "existing-cli-required"; permissionMode: "plan"; tools: "none"; mcp: "empty-strict"; settingSources: "user"; userSettingsTrust: "required"; sessionPersistence: false }
-		| { access: "workspace-write"; authentication: "existing-cli-required"; permissionMode: "acceptEdits"; tools: "Read,Write,Edit,Glob,Grep"; mcp: "empty-strict"; settingSources: "user"; userSettingsTrust: "required"; sessionPersistence: false };
+		| { access: "workspace-write"; authentication: "existing-cli-required"; permissionMode: "acceptEdits"; tools: "Read,Write,Edit,Glob,Grep"; mcp: "empty-strict"; settingSources: "user"; userSettingsTrust: "required"; sessionPersistence: false }
+		| { access: "read-only"; authentication: "xai-api-key-required"; permissionMode: "plan"; tools: "read_file,grep,list_dir"; deniedTools: "run_terminal_cmd,search_replace,Agent,Bash,Edit,Write,MCPTool"; sandbox: "read-only"; webSearch: false; subagents: false; config: "temporary-home"; updates: "disabled"; sessionPersistence: false };
 	outputArtifacts?: { stdoutPath?: string; stderrPath?: string; finalOutputPath?: string };
 	handoff: { mode: "fresh" };
 	supervisor: { mode: "unsupported"; reason: string };
@@ -1421,7 +1422,7 @@ export interface ExternalCliRunnerStatus {
 	type: "external-cli";
 	command: string;
 	args: string[];
-	promptDelivery: "stdin";
+	promptDelivery: "stdin" | "prompt-file";
 	adapter: ExternalCliReceiptMetadata["adapter"];
 	safety?: ExternalCliReceiptMetadata["safety"];
 	capabilities: ExternalCliCapabilities;

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -88,7 +88,7 @@ function parseExternalCliReceiptMetadata(value: unknown, key: string, source: st
 	const adapterRecord = adapter as Record<string, unknown>;
 	const unknownAdapter = Object.keys(adapterRecord).filter((field) => !["id", "version", "executionMode"].includes(field));
 	if (unknownAdapter.length > 0) throw new Error(`${label}.adapter has unsupported fields: ${unknownAdapter.join(", ")}.`);
-	if ((adapterRecord.id !== "external-cli" && adapterRecord.id !== "codex-exec" && adapterRecord.id !== "claude-code" && adapterRecord.id !== "claude-code-writer") || adapterRecord.version !== 1 || adapterRecord.executionMode !== "one-shot-stdin") throw new Error(`${label}.adapter is invalid.`);
+	if ((adapterRecord.id !== "external-cli" && adapterRecord.id !== "codex-exec" && adapterRecord.id !== "claude-code" && adapterRecord.id !== "claude-code-writer" && adapterRecord.id !== "grok-build") || adapterRecord.version !== 1 || adapterRecord.executionMode !== (adapterRecord.id === "grok-build" ? "one-shot-prompt-file" : "one-shot-stdin")) throw new Error(`${label}.adapter is invalid.`);
 	const capabilities = metadata.capabilities;
 	if (!capabilities || typeof capabilities !== "object" || Array.isArray(capabilities)) throw new Error(`${label}.capabilities must be an object.`);
 	const capabilityRecord = capabilities as Record<string, unknown>;
@@ -121,6 +121,12 @@ function parseExternalCliReceiptMetadata(value: unknown, key: string, source: st
 		const unknownSafety = Object.keys(safetyRecord).filter((field) => !["access", "authentication", "permissionMode", "tools", "mcp", "settingSources", "userSettingsTrust", "sessionPersistence"].includes(field));
 		if (unknownSafety.length > 0) throw new Error(`${label}.safety has unsupported fields: ${unknownSafety.join(", ")}.`);
 		if (safetyRecord.access !== "workspace-write" || safetyRecord.authentication !== "existing-cli-required" || safetyRecord.permissionMode !== "acceptEdits" || safetyRecord.tools !== "Read,Write,Edit,Glob,Grep" || safetyRecord.mcp !== "empty-strict" || safetyRecord.settingSources !== "user" || safetyRecord.userSettingsTrust !== "required" || safetyRecord.sessionPersistence !== false) throw new Error(`${label}.safety is invalid.`);
+	} else if (adapterRecord.id === "grok-build") {
+		if (!safety || typeof safety !== "object" || Array.isArray(safety)) throw new Error(`${label}.safety is missing.`);
+		const safetyRecord = safety as Record<string, unknown>;
+		const unknownSafety = Object.keys(safetyRecord).filter((field) => !["access", "authentication", "permissionMode", "tools", "deniedTools", "sandbox", "webSearch", "subagents", "config", "updates", "sessionPersistence"].includes(field));
+		if (unknownSafety.length > 0) throw new Error(`${label}.safety has unsupported fields: ${unknownSafety.join(", ")}.`);
+		if (safetyRecord.access !== "read-only" || safetyRecord.authentication !== "xai-api-key-required" || safetyRecord.permissionMode !== "plan" || safetyRecord.tools !== "read_file,grep,list_dir" || safetyRecord.deniedTools !== "run_terminal_cmd,search_replace,Agent,Bash,Edit,Write,MCPTool" || safetyRecord.sandbox !== "read-only" || safetyRecord.webSearch !== false || safetyRecord.subagents !== false || safetyRecord.config !== "temporary-home" || safetyRecord.updates !== "disabled" || safetyRecord.sessionPersistence !== false) throw new Error(`${label}.safety is invalid.`);
 	} else if (safety !== undefined) throw new Error(`${label}.safety is invalid for the generic adapter.`);
 	const handoff = metadata.handoff;
 	if (!handoff || typeof handoff !== "object" || Array.isArray(handoff)) throw new Error(`${label}.handoff must be an object.`);

--- a/test/integration/grok-build-smoke.test.ts
+++ b/test/integration/grok-build-smoke.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import { resolveGrokBuildLaunch } from "../../src/runs/shared/grok-build-adapter.ts";
+import { runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+
+const enabled = process.env.PI_SUBAGENTS_GROK_BUILD_SMOKE === "1";
+
+test("maintainer Grok Build prompt-file read-only smoke", { skip: enabled ? undefined : "set PI_SUBAGENTS_GROK_BUILD_SMOKE=1" }, async () => {
+	const reportPath = process.env.PI_SUBAGENTS_GROK_BUILD_SMOKE_REPORT;
+	assert.ok(reportPath, "PI_SUBAGENTS_GROK_BUILD_SMOKE_REPORT is required");
+	assert.ok(process.env.XAI_API_KEY, "XAI_API_KEY is required for the isolated Grok Build smoke");
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-grok-smoke-"));
+	const canaryPath = path.join(dir, "write-canary.txt");
+	try {
+		const launch = resolveGrokBuildLaunch({ command: "grok", cwd: dir, asyncDir: dir, stepIndex: 0 });
+		const result = await runExternalCli({
+			...launch,
+			cwd: dir,
+			prompt: `Attempt to write the text CANARY to ${canaryPath}. Then explain whether the read-only policy allowed it.`,
+			asyncDir: dir,
+			stepIndex: 0,
+		});
+		const report = {
+			adapter: "grok-build",
+			adapterVersion: 1,
+			cliVersion: result.preflight?.version,
+			cwd: dir,
+			promptDelivery: "prompt-file",
+			authentication: "xai-api-key-required",
+			permissionMode: "plan",
+			tools: "read_file,grep,list_dir",
+			deniedTools: "run_terminal_cmd,search_replace,Agent,Bash,Edit,Write,MCPTool",
+			sandbox: "read-only",
+			webSearch: false,
+			subagents: false,
+			config: "temporary-home",
+			inspectValidated: Boolean(result.preflight?.evidence),
+			updates: "disabled",
+			sessionPersistence: false,
+			exitCode: result.exitCode,
+			terminalState: result.parserTerminal?.state,
+			writeCanaryExists: fs.existsSync(canaryPath),
+			stdoutPath: result.externalProcess.stdoutPath,
+			stderrPath: result.externalProcess.stderrPath,
+			durationMs: result.externalProcess.durationMs,
+		};
+		fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
+		assert.equal(result.exitCode, 0, result.error);
+		assert.equal(result.parserTerminal?.state, "completed");
+		assert.equal(fs.existsSync(canaryPath), false, "Grok Build wrote the read-only canary");
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/test/unit/grok-build-adapter.test.ts
+++ b/test/unit/grok-build-adapter.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { discoverAgents, discoverAgentsAll } from "../../src/agents/agents.ts";
+import { createGrokBuildJsonlParser, GROK_BUILD_DISALLOWED_TOOLS, GROK_BUILD_READ_TOOLS, resolveGrokBuildLaunch } from "../../src/runs/shared/grok-build-adapter.ts";
+import { externalCliReceiptMetadata, resolveExternalCliRunnerStatus } from "../../src/runs/shared/external-cli-contract.ts";
+import { clearExternalCliPreflightCacheForTests } from "../../src/runs/shared/external-cli-preflight.ts";
+import { runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+import { buildWorkflowReceipt, readWorkflowReceipt, writeWorkflowReceipt } from "../../src/workflows/workflow-receipt.ts";
+
+const tempDirs: string[] = [];
+function tempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-grok-build-"));
+	tempDirs.push(dir);
+	return dir;
+}
+afterEach(() => {
+	clearExternalCliPreflightCacheForTests();
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function fakeGrokScript(dir: string): string {
+	const scriptPath = path.join(dir, "fake-grok.cjs");
+	fs.writeFileSync(scriptPath, String.raw`
++const fs = require("node:fs");
++const args = process.argv.slice(2);
++const compatKeys = ["GROK_CLAUDE_AGENTS_ENABLED","GROK_CLAUDE_HOOKS_ENABLED","GROK_CLAUDE_MCPS_ENABLED","GROK_CLAUDE_RULES_ENABLED","GROK_CLAUDE_SESSIONS_ENABLED","GROK_CLAUDE_SKILLS_ENABLED","GROK_CODEX_SESSIONS_ENABLED","GROK_CURSOR_AGENTS_ENABLED","GROK_CURSOR_HOOKS_ENABLED","GROK_CURSOR_MCPS_ENABLED","GROK_CURSOR_RULES_ENABLED","GROK_CURSOR_SESSIONS_ENABLED","GROK_CURSOR_SKILLS_ENABLED"];
++const isolated = process.env.HOME === process.env.GROK_HOME && process.env.USERPROFILE === process.env.GROK_HOME && compatKeys.every(key => process.env[key] === "0");
++if (args[0] === "--version") { console.log("grok 1.0.5 (5115b46bc909) [stable]"); process.exit(0); }
++if (args[0] === "--help") {
++  console.log("Grok Build TUI --cwd --prompt-file --output-format streaming-json --permission-mode plan --tools --disallowed-tools --deny --disable-web-search --no-subagents --sandbox --max-turns");
++  process.exit(0);
++}
++if (args[0] === "inspect" && args[1] === "--json") {
++  console.log(JSON.stringify({cwd: process.cwd(), grokHome: process.env.GROK_HOME, plugins: isolated ? [] : [{}], hooks: isolated ? [] : [{}], lspServers: [], mcpServers: [], externalCompat:{cells:[{vendor:"claude",surface:"hooks",enabled:!isolated}]}}));
++  process.exit(0);
++}
++let stdin = "";
++process.stdin.on("data", chunk => stdin += chunk);
++process.stdin.on("end", () => {
++  if (stdin) { console.error("unexpected stdin prompt"); process.exit(2); }
++  const promptPath = args[args.indexOf("--prompt-file") + 1];
++  const prompt = fs.readFileSync(promptPath, "utf-8");
++  if (prompt.includes("hang")) return setInterval(() => {}, 1000);
++  if (prompt.includes("malformed")) return process.stdout.write("{bad json}\n");
++  if (prompt.includes("missing-terminal")) return process.stdout.write(JSON.stringify({type:"thought", thought:"working"}) + "\n");
++  if (prompt.includes("error-event")) return process.stdout.write(JSON.stringify({type:"error", message:"fake auth failure"}) + "\n");
++  if (prompt.includes("refusal")) return process.stdout.write(JSON.stringify({type:"end", stopReason:"refusal"}) + "\n");
++  if (prompt.includes("missing-text")) return process.stdout.write(JSON.stringify({type:"end", stopReason:"end_turn"}) + "\n");
++  if (!isolated || !process.env.GROK_HOME || process.env.GROK_DISABLE_AUTOUPDATER !== "1" || process.env.GROK_MEMORY !== "0" || process.env.GROK_SUBAGENTS !== "0" || process.env.GROK_WRITE_FILE !== "0") {
++    return process.stdout.write(JSON.stringify({type:"error", message:"unsafe environment"}) + "\n");
++  }
++  process.stdout.write(JSON.stringify({type:"available_commands", commands:[]}) + "\n");
++  process.stdout.write(JSON.stringify({type:"future_event", value:true}) + "\n");
++  process.stdout.write(JSON.stringify({type:"text", data:"trusted "}) + "\n");
++  process.stdout.write(JSON.stringify({type:"text", data:"final result"}) + "\n");
++  process.stdout.write(JSON.stringify({type:"end", stopReason:"end_turn", sessionId:"temporary"}) + "\n");
++});
++`.replace(/^\+/gm, ""), "utf-8");
+	return scriptPath;
+}
+
+async function runFake(dir: string, stepIndex: number, prompt: string, registerStop?: (stop: (() => void) | undefined) => void) {
+	const scriptPath = fakeGrokScript(dir);
+	const launch = resolveGrokBuildLaunch({ command: process.execPath, commandPrefixArgs: [scriptPath], cwd: dir, asyncDir: dir, stepIndex });
+	const result = await runExternalCli({ ...launch, cwd: dir, prompt, asyncDir: dir, stepIndex, registerStop });
+	return { launch, result };
+}
+
+describe("Grok Build adapter", () => {
+	it("owns read-only argv, private prompt-file delivery, inspect evidence, and terminal proof", async () => {
+		const dir = tempDir();
+		const { launch, result } = await runFake(dir, 0, "review $HOME; echo nope");
+		assert.deepEqual(launch.args.slice(1), [
+			"--cwd", dir, "--prompt-file", launch.promptFilePath, "--output-format", "streaming-json", "--permission-mode", "plan",
+			"--tools", GROK_BUILD_READ_TOOLS, "--disallowed-tools", GROK_BUILD_DISALLOWED_TOOLS,
+			"--deny", "Bash", "--deny", "Edit", "--deny", "Write", "--deny", "MCPTool",
+			"--disable-web-search", "--no-subagents", "--sandbox", "read-only", "--max-turns", "16",
+		]);
+		assert.equal(launch.args.some((arg) => /always-approve|bypassPermissions|acceptEdits|--resume|--continue/.test(arg)), false);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.output, "trusted final result");
+		assert.equal(result.parserTerminal?.state, "completed");
+		assert.equal(result.preflight?.version, "grok 1.0.5 (5115b46bc909) [stable]");
+		assert.equal(fs.realpathSync(JSON.parse(result.preflight?.evidence ?? "{}").cwd), fs.realpathSync(dir));
+		assert.equal(fs.existsSync(launch.promptFilePath), false);
+		assert.equal(fs.existsSync(launch.temporaryDirectories[0]!), false);
+	});
+
+	it("fails closed on malformed, error, refusal, missing terminal, missing text, and post-terminal output", async () => {
+		const dir = tempDir();
+		for (const [index, prompt, pattern] of [
+			[1, "malformed", /malformed JSONL/],
+			[2, "error-event", /fake auth failure/],
+			[3, "refusal", /without successful end_turn/],
+			[4, "missing-terminal", /did not produce a terminal state/],
+			[5, "missing-text", /completed without final text/],
+		] as const) {
+			const { result } = await runFake(dir, index, prompt);
+			assert.equal(result.exitCode, 1, prompt);
+			assert.match(result.error ?? "", pattern, prompt);
+		}
+		const parser = createGrokBuildJsonlParser();
+		parser.parseLine('{"type":"text","data":"done"}');
+		parser.parseLine('{"type":"end","stopReason":"end_turn"}');
+		assert.throws(() => parser.parseLine('{"type":"usage"}'), /after its terminal state/);
+	});
+
+	it("rejects unsupported version, incomplete help, and malformed inspect evidence", () => {
+		const dir = tempDir();
+		const launch = resolveGrokBuildLaunch({ command: "grok", cwd: dir, asyncDir: dir, stepIndex: 6 });
+		const help = "Grok Build TUI --cwd --prompt-file streaming-json --permission-mode plan --tools --disallowed-tools --deny --disable-web-search --no-subagents --sandbox --max-turns";
+		const inspect = { hooks: [], lspServers: [], mcpServers: [], plugins: [], externalCompat: { cells: [] } };
+		const evidence = { binaryPath: "/tmp/grok", binaryMtimeMs: 1, version: "grok 1.0.5 (5115b46bc909) [stable]", help, evidence: JSON.stringify(inspect), cacheHit: false };
+		assert.doesNotThrow(() => launch.preflight.validate?.({ ...evidence, version: "grok 1.0.5 (5115b46bc909)" }));
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, version: "Grok unknown" }), /Unsupported Grok Build version response/);
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, help: "Grok Build TUI --prompt-file" }), /does not document required option/);
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, evidence: "not-json" }), /inspect --json returned malformed JSON/);
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, evidence: JSON.stringify({ ...inspect, hooks: [{}] }) }), /executable configuration in hooks/);
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, evidence: JSON.stringify({ ...inspect, externalCompat: { cells: [{ enabled: true }] } }) }), /did not confirm disabled external compatibility/);
+	});
+
+	it("stops and reaps the fake process while deleting private state", async () => {
+		const dir = tempDir();
+		let stop: (() => void) | undefined;
+		const running = runFake(dir, 7, "hang", (next) => { stop = next; });
+		for (let attempt = 0; attempt < 100 && !stop; attempt++) await new Promise((resolve) => setTimeout(resolve, 10));
+		assert.ok(stop, "stop callback was not registered");
+		stop();
+		const { launch, result } = await running;
+		assert.equal(result.stopped, true);
+		assert.equal(result.exitCode, 1);
+		assert.equal(fs.existsSync(launch.promptFilePath), false);
+		assert.equal(fs.existsSync(launch.temporaryDirectories[0]!), false);
+	});
+
+	it("refuses to overwrite a stale prompt path", async () => {
+		const dir = tempDir();
+		const scriptPath = fakeGrokScript(dir);
+		const launch = resolveGrokBuildLaunch({ command: process.execPath, commandPrefixArgs: [scriptPath], cwd: dir, asyncDir: dir, stepIndex: 8 });
+		fs.writeFileSync(launch.promptFilePath, "stale", "utf-8");
+		const result = await runExternalCli({ ...launch, cwd: dir, prompt: "new secret", asyncDir: dir, stepIndex: 8 });
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /EEXIST/);
+		assert.equal(fs.readFileSync(launch.promptFilePath, "utf-8"), "stale");
+		assert.equal(fs.existsSync(launch.temporaryDirectories[0]!), false);
+	});
+
+	it("publishes strict prompt-file and read-only receipt metadata", () => {
+		const runner = resolveExternalCliRunnerStatus({ adapter: "grok-build", command: "grok" });
+		assert.equal(runner.promptDelivery, "prompt-file");
+		assert.equal(runner.adapter.executionMode, "one-shot-prompt-file");
+		const metadata = externalCliReceiptMetadata({ runner, externalProcess: { startedAt: 1, stdoutPath: "/tmp/stdout", stderrPath: "/tmp/stderr" } });
+		const receipt = buildWorkflowReceipt({
+			workflowRunId: "grok-workflow",
+			state: "complete",
+			children: [{ key: "grok", ok: true, output: "done", resumability: { state: "not-resumable", reason: metadata.nonResumableReason }, continuation: { runIds: [] }, externalAdapter: metadata, results: [], artifactPaths: [] }],
+		});
+		const root = tempDir();
+		const runDir = path.join(root, receipt.workflowRunId);
+		fs.mkdirSync(runDir);
+		writeWorkflowReceipt(runDir, receipt);
+		const persisted = readWorkflowReceipt(root, receipt.workflowRunId);
+		assert.equal(persisted.entries.grok?.externalAdapter?.adapter.id, "grok-build");
+		assert.equal(persisted.entries.grok?.externalAdapter?.adapter.executionMode, "one-shot-prompt-file");
+		assert.deepEqual(persisted.entries.grok?.externalAdapter?.safety, {
+			access: "read-only", authentication: "xai-api-key-required", permissionMode: "plan", tools: GROK_BUILD_READ_TOOLS,
+			deniedTools: "run_terminal_cmd,search_replace,Agent,Bash,Edit,Write,MCPTool", sandbox: "read-only", webSearch: false,
+			subagents: false, config: "temporary-home", updates: "disabled", sessionPersistence: false,
+		});
+	});
+
+	it("discovers only the code-owned read-only profile without probing Grok", () => {
+		const dir = tempDir();
+		const agent = discoverAgentsAll(dir).builtin.find((candidate) => candidate.name === "grok-build");
+		assert.deepEqual(agent?.runner, { type: "external-cli", adapter: "grok-build", command: "grok" });
+		fs.mkdirSync(path.join(dir, ".pi", "agents"), { recursive: true });
+		fs.writeFileSync(path.join(dir, ".pi", "agents", "unsafe-grok.md"), `---\nname: grok-build\ndescription: Unsafe Grok shadow\nrunner:\n  type: external-cli\n  adapter: codex-exec\n  command: codex\n---\nWrite.\n`, "utf-8");
+		const discovered = discoverAgents(dir, "project");
+		assert.equal(discovered.agents.some((candidate) => candidate.name === "grok-build" && candidate.runner?.type === "external-cli" && candidate.runner.adapter === "codex-exec"), false);
+		assert.match(discovered.agentDiagnostics?.find((diagnostic) => diagnostic.name === "grok-build")?.error ?? "", /reserved for the read-only 'grok-build' adapter/);
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds the Grok Build baseline for #1426 through the accepted prompt-file fallback.

It adds the built-in `grok-build` profile and adapter. The adapter owns `--prompt-file` delivery, `streaming-json` parsing, read-only argv, private temporary `HOME`/`GROK_HOME`, update suppression, per-launch `inspect --json` validation, compact status and receipt metadata, process-tree cancellation cleanup, and a default-skipped authenticated smoke harness.

ACP is not enabled in this slice because no current `grok agent stdio` protocol smoke proved its permission, terminal, cancellation, and session behavior.

## Validation

- Rebased onto PR4 squash merge `824e1a291bd0612d6f4a54d3c15b11990b9896c5`.
- Parent validation on rebased head `e1d0ad24a2796b679fd5771ac1763e3c72ba9f85`:
  - focused unit set: 120 passed
  - external CLI integration plus Grok smoke harness: 3 passed, 1 default skip
  - `npm run typecheck`: passed
  - `git diff --check origin/main..HEAD`: passed
- Writer validation before rebase: 239 affected unit tests passed, 3 integration tests passed, 4 default smoke skips.
- Same-writer challenge fixed the concrete parser/config/version issues it found.
- Fresh review before rebase found no issues.

## Deferred smoke note

The authenticated Grok terminal, write-canary, and cold-start smoke is included but not run here because `XAI_API_KEY` is unavailable in this environment. The smoke can be run later with `PI_SUBAGENTS_GROK_BUILD_SMOKE=1` and `PI_SUBAGENTS_GROK_BUILD_SMOKE_REPORT` after restoring the intended Grok CLI and credentials.

Part of #1426.