### PR TITLE
fix: diagnose child exits during active tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - Make workflow validation and return serialization failures easier to recover from with no-child-launch diagnostics, portable rewrite guidance, workflow ids, and completed-child output references (#1432, #1434).
+- Report child processes that exit during tool execution as mid-tool failures instead of cold starts, even when earlier assistant text exists. Thanks to [@cyzlmh](https://github.com/cyzlmh) for #1437.
 
 ## [0.56.0] - 2026-08-23
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -81,7 +81,7 @@ import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolved
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { outputEntryFromAsyncResult, resolveOutputReferences } from "../shared/chain-outputs.ts";
 import { createStructuredOutputRuntime, MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
-import { formatProcessSignalError, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
+import { formatMidToolExitError, formatProcessSignalError, isOrdinaryToolForMidToolExit, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
 import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
 import { buildTimeoutRecoverySummary, collectTrackedMutationEvidence, snapshotTrackedMutations } from "../shared/mutation-evidence.ts";
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection } from "../shared/dynamic-fanout.ts";
@@ -624,6 +624,47 @@ function runPiStreaming(
 		let currentToolArgs: string | undefined;
 		let currentPath: string | undefined;
 		let toolCount = 0;
+		type ActiveToolCall = { key: string; tool: string; args?: string; path?: string };
+		let activeToolSequence = 0;
+		const activeToolCalls = new Map<string, ActiveToolCall>();
+		const activeToolKeysByName = new Map<string, string[]>();
+		const refreshCurrentTool = (): void => {
+			const active = [...activeToolCalls.values()].at(-1);
+			currentTool = active?.tool;
+			currentToolArgs = active?.args;
+			currentPath = active?.path;
+		};
+		const recordActiveToolCall = (event: { toolCallId?: unknown; toolName: string; args?: Record<string, unknown> }): void => {
+			const key = toolTimeoutCallKey(event, ++activeToolSequence);
+			const active = omitUndefinedProperties({
+				key,
+				tool: event.toolName,
+				args: extractToolArgsPreview(event.args ?? {}),
+				path: resolveCurrentPath(event.toolName, event.args),
+			});
+			activeToolCalls.set(key, active);
+			const keys = activeToolKeysByName.get(active.tool) ?? [];
+			keys.push(key);
+			activeToolKeysByName.set(active.tool, keys);
+			refreshCurrentTool();
+		};
+		const removeActiveToolCall = (event: { toolCallId?: unknown; toolName?: unknown }): void => {
+			const key = typeof event.toolCallId === "string" && event.toolCallId.length > 0
+				? `id:${event.toolCallId}`
+				: typeof event.toolName === "string"
+					? activeToolKeysByName.get(event.toolName)?.[0]
+					: activeToolCalls.size === 1
+						? [...activeToolCalls.keys()][0]
+						: undefined;
+			if (!key) return;
+			const active = activeToolCalls.get(key);
+			if (!active) return;
+			activeToolCalls.delete(key);
+			const keys = activeToolKeysByName.get(active.tool)?.filter((candidate) => candidate !== key) ?? [];
+			if (keys.length > 0) activeToolKeysByName.set(active.tool, keys);
+			else activeToolKeysByName.delete(active.tool);
+			refreshCurrentTool();
+		};
 		const childWatchdogConfig = decodeChildWatchdogConfig(env?.[CHILD_WATCHDOG_CONFIG_ENV]);
 		let childWatchdogState: ChildWatchdogStateSnapshot | undefined;
 		let applyChildLifecycle = (_action: ChildLifecycleAction): void => {};
@@ -714,18 +755,14 @@ function runPiStreaming(
 
 			if (event.type === "tool_execution_end") {
 				clearActiveToolTimeout(event);
-				currentTool = undefined;
-				currentToolArgs = undefined;
-				currentPath = undefined;
+				removeActiveToolCall(event);
 				return;
 			}
 
 			if (event.type === "tool_execution_start" && event.toolName) {
 				toolCount += 1;
 				armToolTimeout({ toolCallId: (event as { toolCallId?: unknown }).toolCallId, toolName: event.toolName });
-				currentTool = event.toolName;
-				currentToolArgs = extractToolArgsPreview(event.args ?? {});
-				currentPath = resolveCurrentPath(event.toolName, event.args);
+				recordActiveToolCall({ toolCallId: (event as { toolCallId?: unknown }).toolCallId, toolName: event.toolName, args: event.args });
 				if (event.toolName === "structured_output") {
 					structuredOutputToolInvoked = true;
 					structuredOutputMessageStartIndex = messages.length;
@@ -737,6 +774,13 @@ function runPiStreaming(
 			}
 
 			if ((event.type === "message_end" || event.type === "tool_result_end") && event.message) {
+				if (event.type === "tool_result_end") {
+					clearActiveToolTimeout(event);
+					removeActiveToolCall({
+						toolCallId: (event.message as { toolCallId?: unknown }).toolCallId ?? (event as { toolCallId?: unknown }).toolCallId,
+						toolName: (event.message as { toolName?: unknown }).toolName ?? event.toolName,
+					});
+				}
 				messages.push(event.message);
 				const text = extractTextFromContent(event.message.content);
 				if (text) writeOutputText(text);
@@ -763,6 +807,10 @@ function runPiStreaming(
 				if (isTerminalAssistantStop(event.message)) {
 					if (!event.message.errorMessage && extractTextFromContent(event.message.content).trim()) assistantError = undefined;
 					cleanTerminalAssistantStopReceived ||= !event.message.errorMessage;
+					clearAllToolTimeouts();
+					activeToolCalls.clear();
+					activeToolKeysByName.clear();
+					refreshCurrentTool();
 					applyChildLifecycle(projectChildLifecycle(event, true));
 				}
 			}
@@ -1735,11 +1783,25 @@ async function runSingleStepInner(
 			: undefined;
 		const runtimeAcknowledgedExtensions = readRuntimeAcknowledgedExtensions(runtimeAcknowledgedExtensionsPath);
 		cleanupTempDir(tempDir);
+		const midToolExitError = run.currentTool
+			&& isOrdinaryToolForMidToolExit(run.currentTool)
+			&& !run.interrupted
+			&& !run.timedOut
+			&& !run.stopped
+			&& !run.turnBudgetExceeded
+			&& !run.protocolError
+			&& !toolAvailabilityError
+			? formatMidToolExitError({
+				toolName: run.currentTool,
+				exitCode: run.exitCode,
+				processSignal: run.processSignal,
+			})
+			: undefined;
 
 		let structuredOutput: unknown;
 		let structuredError: string | undefined;
 		let validatedStructuredOutput = false;
-		if (effectiveStructuredOutput && run.exitCode === 0 && !run.error && !toolAvailabilityError) {
+		if (effectiveStructuredOutput && run.exitCode === 0 && !run.error && !toolAvailabilityError && !midToolExitError) {
 			if (!run.structuredOutputToolInvoked) {
 				structuredError = MISSING_STRUCTURED_OUTPUT_CALL_ERROR;
 			} else {
@@ -1761,7 +1823,7 @@ async function runSingleStepInner(
 		const errorMessages = validatedStructuredOutput
 			? run.messages.slice(run.structuredOutputMessageStartIndex ?? run.messages.length)
 			: run.messages;
-		const hiddenError = run.exitCode === 0 && !run.error && !toolAvailabilityError && !structuredError
+		const hiddenError = run.exitCode === 0 && !run.error && !toolAvailabilityError && !structuredError && !midToolExitError
 			? detectSubagentError(errorMessages)
 			: null;
 		const emptyOutputError = run.exitCode === 0
@@ -1778,7 +1840,7 @@ async function runSingleStepInner(
 		const mutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, step.cwd ?? ctx.cwd);
 		finalMutationEvidence = mutationEvidence;
 		const completionMutationEvidence = ctx.trackedMutationEvidenceForCompletionGuard === false ? undefined : mutationEvidence;
-		const completionGuard = run.exitCode === 0 && !run.error && !structuredError && !hiddenError?.hasError && !emptyOutputError && completionGuardEnabled
+		const completionGuard = run.exitCode === 0 && !run.error && !structuredError && !hiddenError?.hasError && !midToolExitError && !emptyOutputError && completionGuardEnabled
 			? evaluateCompletionMutationGuard(omitUndefinedProperties({
 				agent: step.agent,
 				task: taskForCompletionGuard,
@@ -1805,7 +1867,7 @@ async function runSingleStepInner(
 		const completionGuardError = completionGuardTriggered && !isAgentContractV1(step.agentContract)
 			? "Subagent completed without making edits for an implementation task.\nIt appears to have returned planning or scratchpad output instead of applying changes."
 			: undefined;
-		const effectiveExitCode = toolAvailabilityError || (completionGuardTriggered && !isAgentContractV1(step.agentContract)) || structuredError || emptyOutputError
+		const effectiveExitCode = toolAvailabilityError || (completionGuardTriggered && !isAgentContractV1(step.agentContract)) || midToolExitError || structuredError || emptyOutputError
 			? 1
 			: hiddenError?.hasError
 				? (hiddenError.exitCode ?? 1)
@@ -1822,6 +1884,7 @@ async function runSingleStepInner(
 		const error = formatSubagentExtensionConflictError(
 			toolAvailabilityError
 				?? completionGuardError
+				?? midToolExitError
 				?? structuredError
 				?? emptyOutputError
 				?? (hiddenError?.hasError

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -68,7 +68,7 @@ import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling,
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { assertThinkingWithinCeiling, decodeThinkingCeiling, intersectThinkingCeilings, SUBAGENT_THINKING_CEILING_ENV } from "../../shared/thinking-ceiling.ts";
 import { MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
-import { formatProcessSignalError, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
+import { formatMidToolExitError, formatProcessSignalError, isOrdinaryToolForMidToolExit, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
 import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
 import { buildTimeoutRecoverySummary, collectTrackedMutationEvidence, snapshotTrackedMutations } from "../shared/mutation-evidence.ts";
 import { captureSingleOutputSnapshot, extractChildWrittenOutput, finalizeSingleOutput, formatSavedOutputReference, injectOutputPathSystemPrompt, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
@@ -538,6 +538,7 @@ async function runSingleAttempt(
 	let structuredOutputToolInvoked = false;
 	let structuredOutputMessageStartIndex: number | undefined;
 	let toolAvailabilityError: string | undefined;
+	let abortedBySignal = options.signal?.aborted === true;
 
 	const exitCode = await new Promise<number>((resolve) => {
 		const spawnSpec = getPiSpawnCommand(args);
@@ -1102,6 +1103,10 @@ async function runSingleAttempt(
 					if (terminalAssistantStop) {
 						if (!evt.message.errorMessage && assistantText.trim()) assistantError = undefined;
 						cleanTerminalAssistantStopReceived ||= !evt.message.errorMessage;
+						clearAllToolTimeouts();
+						activeToolCalls.clear();
+						activeToolKeysByName.clear();
+						refreshCurrentTool();
 						applyChildLifecycle(projectChildLifecycle(evt, true));
 					}
 				}
@@ -1369,6 +1374,7 @@ async function runSingleAttempt(
 		if (options.signal) {
 			const kill = () => {
 				if (processClosed || lifecycleFinished) return;
+				abortedBySignal = true;
 				proc.kill("SIGTERM");
 				setTimeout(() => !proc.killed && proc.kill("SIGKILL"), 3000);
 			};
@@ -1430,6 +1436,22 @@ async function runSingleAttempt(
 			durationMs: progress.durationMs,
 		};
 		return result;
+	}
+	if (progress.currentTool
+		&& isOrdinaryToolForMidToolExit(progress.currentTool)
+		&& !abortedBySignal
+		&& !result.timedOut
+		&& !result.stopped
+		&& !result.turnBudgetExceeded
+		&& !result.protocolError
+		&& !toolAvailabilityError) {
+		const processExitCode = result.exitCode;
+		result.exitCode = 1;
+		result.error = formatMidToolExitError({
+			toolName: progress.currentTool,
+			exitCode: processExitCode,
+			processSignal: result.processSignal,
+		});
 	}
 	result.error = formatSubagentExtensionConflictError(result.error, {
 		agent: agent.name,

--- a/src/runs/shared/process-signal.ts
+++ b/src/runs/shared/process-signal.ts
@@ -2,6 +2,19 @@ export function formatProcessSignalError(signal: string): string {
 	return `Subagent process terminated by signal ${signal}.`;
 }
 
+export function formatMidToolExitError(input: {
+	toolName: string;
+	exitCode: number | null;
+	processSignal?: string | null;
+}): string {
+	const terminal = [`exit ${input.exitCode ?? "unknown"}`, ...(input.processSignal ? [`signal ${input.processSignal}`] : [])].join(", ");
+	return `Subagent process exited during '${input.toolName}' tool execution (${terminal}) before the tool completed. Earlier assistant output is not a terminal result.`;
+}
+
+export function isOrdinaryToolForMidToolExit(toolName: string): boolean {
+	return toolName !== "intercom" && toolName !== "contact_supervisor";
+}
+
 export function isUnexplainedProcessSignal(input: {
 	processSignal?: string | null;
 	interrupted?: boolean;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -1556,6 +1556,36 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		}
 	});
 
+	it("background keeps a terminal answer authoritative over an earlier tool timeout", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("bash")] },
+				{ delay: 50, jsonl: [events.assistantMessage("Done")] },
+			],
+			keepAliveAfterFinalMessageMs: 1_500,
+		});
+		const id = `async-terminal-tool-timeout-${Date.now().toString(36)}`;
+		process.env.PI_SUBAGENT_TOOL_TIMEOUT_MS = "600";
+		try {
+			executeAsyncChain(id, {
+				chain: [{ agent: "one", task: "Do work" }],
+				agents: [makeAgent("one")],
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false,
+				maxSubagentDepth: 2,
+				timeoutMs: 5_000,
+			});
+
+			const payload = await readAsyncPayload(id);
+			assert.equal(payload.success, true);
+			assert.equal(payload.results[0]?.timedOut, undefined);
+			assert.equal(payload.results[0]?.output, "Done");
+		} finally {
+			delete process.env.PI_SUBAGENT_TOOL_TIMEOUT_MS;
+		}
+	});
+
 	it("keeps an earlier wedged tool armed when another tool starts and ends", { skip: !isAsyncAvailable() ? "jiti not available" : process.platform === "win32" ? "timeout signal delivery intermittent on Windows CI" : undefined }, async () => {
 		mockPi.onCall({
 			steps: [
@@ -3341,6 +3371,68 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(payload.results[0]?.modelAttempts?.[0]?.error ?? "", /no output/i);
 		assert.deepEqual(payload.results[0]?.modelAttempts?.map((attempt) => attempt.success), [false, true]);
 		assert.equal(mockPi.callCount(), 2);
+	});
+
+	it("background fails a zero-exit child that stops during a tool after earlier assistant output", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [
+				events.assistantMessage("Work is in progress"),
+				events.toolStart("bash", { command: "write files" }),
+			],
+			exitCode: 0,
+		});
+		const id = `async-mid-tool-exit-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", { model: "openai/gpt-5-mini" }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		assert.equal(payload.success, false);
+		assert.equal(payload.results[0]?.success, false);
+		assert.match(payload.results[0]?.error ?? "", /exited during 'bash' tool execution \(exit 0\)/);
+		assert.match(payload.results[0]?.error ?? "", /Earlier assistant output is not a terminal result/);
+		assert.doesNotMatch(payload.results[0]?.error ?? "", /cold-start/);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("background retains an earlier open tool when a later overlapping tool completes", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [
+				{ type: "tool_execution_start", toolCallId: "bash-1", toolName: "bash", args: { command: "wait" } },
+				{ type: "tool_execution_start", toolCallId: "read-1", toolName: "read", args: { path: "README.md" } },
+				{ type: "tool_execution_end", toolCallId: "read-1", toolName: "read" },
+			],
+			exitCode: 0,
+		});
+		const id = `async-overlap-mid-tool-exit-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", { model: "openai/gpt-5-mini" }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		assert.equal(payload.success, false);
+		assert.match(payload.results[0]?.error ?? "", /exited during 'bash' tool execution \(exit 0\)/);
 	});
 
 	it("background runs prefer empty-output fallback over an earlier tool error", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/error-handling.test.ts
+++ b/test/integration/error-handling.test.ts
@@ -157,6 +157,58 @@ describe("runSync error handling", { skip: !piAvailable ? "pi packages not avail
 		assert.ok(result.error?.includes("connection refused"));
 	});
 
+	it("fails a zero-exit child that stops during a tool after earlier assistant output", async () => {
+		mockPi.onCall({
+			jsonl: [
+				events.assistantMessage("Work is in progress"),
+				events.toolStart("bash", { command: "write files" }),
+			],
+			exitCode: 0,
+		});
+		const agents = makeAgentConfigs(["worker"]);
+
+		const result = await runSync(tempDir, agents, "worker", "Do work", {});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /exited during 'bash' tool execution \(exit 0\)/);
+		assert.match(result.error ?? "", /Earlier assistant output is not a terminal result/);
+		assert.doesNotMatch(result.error ?? "", /cold-start/);
+	});
+
+	it("includes an unexpected process signal in a mid-tool exit diagnosis", { skip: process.platform === "win32" ? "signal delivery differs on Windows" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [events.toolStart("bash", { command: "wait" })],
+			signal: "SIGTERM",
+		});
+		const agents = makeAgentConfigs(["worker"]);
+
+		const result = await runSync(tempDir, agents, "worker", "Do work", {});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /exited during 'bash' tool execution/);
+		assert.match(result.error ?? "", /signal SIGTERM/);
+	});
+
+	it("keeps a terminal answer authoritative over an earlier tool timeout", async () => {
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("bash")] },
+				{ delay: 50, jsonl: [events.assistantMessage("Done")] },
+			],
+			keepAliveAfterFinalMessageMs: 1_500,
+		});
+		const agents = makeAgentConfigs(["worker"]);
+
+		const result = await runSync(tempDir, agents, "worker", "Do work", {
+			toolTimeoutMs: 600,
+			timeoutMs: 5_000,
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.timedOut, undefined);
+		assert.equal(result.finalOutput, "Done");
+	});
+
 	it("kills a wedged foreground tool at the configured per-tool timeout", { skip: process.platform === "win32" ? "timeout signal delivery intermittent on Windows CI" : undefined }, async () => {
 		mockPi.onCall({
 			steps: [
@@ -207,7 +259,10 @@ describe("runSync error handling", { skip: !piAvailable ? "pi packages not avail
 	});
 
 	it("handles abort signal (completes faster than delay)", async () => {
-		mockPi.onCall({ delay: 10000 });
+		mockPi.onCall({ steps: [
+			{ jsonl: [events.toolStart("bash", { command: "wait" })] },
+			{ delay: 10000 },
+		] });
 		const agents = makeAgentConfigs(["slow"]);
 		const controller = new AbortController();
 
@@ -221,5 +276,6 @@ describe("runSync error handling", { skip: !piAvailable ? "pi packages not avail
 
 		// Key: should complete much faster than the 10s delay
 		assert.ok(elapsed < 5000, `should abort early, took ${elapsed}ms`);
+		assert.doesNotMatch(result.error ?? "", /exited during 'bash' tool execution/);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1437.

This PR reports a distinct child-exited-during-tool diagnosis when a native child process exits while a tool call is still active. The message includes the active tool name plus exit code or signal when available.

It also prevents earlier assistant text from making a run look successful after the child exits mid-tool.

## Validation

- `test/integration/error-handling.test.ts`: 12 passed.
- Focused `test/integration/async-execution.test.ts` mid-tool, timeout, and overlapping-tool cases: 5 passed.
- `npm run typecheck`: passed.
- `git diff --check origin/main..HEAD`: passed.

Thanks to [@cyzlmh](https://github.com/cyzlmh) for #1437.