### PR TITLE
fix: make model exclusions visible and configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Keep inline workflow children resumable from their foreground runs without mistaking a missing async directory for lost state. Thanks to [@lancegui](https://github.com/lancegui) for #1442.
 
 ### Added
+- Add `modelExclusions.defaultTtlMs` configuration for controlling the lifetime of model exclusions, including shorter limits for active cached entries, with launch diagnostics for excluded candidates. Thanks to [@mithyer](https://github.com/mithyer) for #1439 and #1438.
 - Add code-owned `cursor-agent` read-only and `cursor-agent-writer` workspace-writing profiles with private prompt-file handoff, bounded stream-JSON terminal proof, and opt-in mode-specific smoke evidence.
 - Add code-owned `claude-code` read-only and `claude-code-writer` file-editing profiles for an existing authenticated CLI with trusted user settings, bounded stream-JSON result proof, and opt-in mode-specific smoke evidence.
 - Add code-owned `codex-exec` read-only and `codex-exec-writer` workspace-writing profiles with bounded JSONL terminal proof, final-message artifacts, and opt-in mode-specific smoke evidence.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,18 @@ By default, project settings resolve from the nearest parent directory that cont
 
 `"git-root"` keeps package discovery, project agents, chains, and `agentOverrides` anchored to the git worktree root when that root also has Pi project config. A nested project can still opt back into nearest-root behavior by setting `"projectRootResolution": "nearest"` in its own `.pi/settings.json`.
 
+## `modelExclusions`
+
+```json
+{
+  "modelExclusions": {
+    "defaultTtlMs": 300000
+  }
+}
+```
+
+Controls the duration, in milliseconds, for model exclusions. The default is `86400000` (24 hours), and the maximum is `8000000000000000` so generated expiry timestamps remain valid JavaScript dates. The extension applies this value when it starts or reloads. A lower configured value shortens active cached exclusions from their original `recordedAt`; it never extends an existing expiry. Launches also warn when a candidate is skipped, including the cached reason and expiry. `PI_MODEL_EXCLUSIONS_PATH` changes the exclusion-store path but does not change this TTL.
+
 ## `toolDescriptionMode`
 
 ```json

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -6,6 +6,7 @@ import { FLEET_KEYBINDING_ACTIONS, type ArtifactDirPreference, type ExtensionCon
 import { validateMissionStoreConfig } from "../missions/store.ts";
 import { validateAuthorityPolicy } from "../policy/authority.ts";
 import { getAgentDir } from "../shared/utils.ts";
+import { DEFAULT_MODEL_EXCLUSION_TTL_MS, MAX_MODEL_EXCLUSION_TTL_MS, setDefaultTTL } from "../runs/shared/model-exclusions.ts";
 import { validatePermissionConfig } from "../runs/shared/permissions.ts";
 
 const ARTIFACT_DIR_PREFERENCES = new Set<ArtifactDirPreference>(["project", "session", "temp"]);
@@ -59,6 +60,17 @@ function validateArtifactConfig(value: unknown): void {
 	const cleanupDays = (value as Record<string, unknown>).cleanupDays;
 	if (cleanupDays !== undefined && (typeof cleanupDays !== "number" || !Number.isInteger(cleanupDays) || cleanupDays < 0)) {
 		throw new Error("config.artifactConfig.cleanupDays must be a non-negative integer");
+	}
+}
+
+/** Validate the user-controlled TTL policy before it reaches the exclusion store. */
+// TEST:test/unit/pi-coding-agent-dir.test.ts[loads and applies model exclusion TTL config]
+function validateModelExclusionsConfig(value: unknown): void {
+	if (value === undefined) return;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("config.modelExclusions must be a JSON object");
+	const defaultTtlMs = (value as Record<string, unknown>).defaultTtlMs;
+	if (defaultTtlMs !== undefined && (typeof defaultTtlMs !== "number" || !Number.isFinite(defaultTtlMs) || defaultTtlMs <= 0 || defaultTtlMs > MAX_MODEL_EXCLUSION_TTL_MS)) {
+		throw new Error(`config.modelExclusions.defaultTtlMs must be a finite positive number no greater than ${MAX_MODEL_EXCLUSION_TTL_MS}`);
 	}
 }
 
@@ -119,6 +131,7 @@ function validateConfig(config: Record<string, unknown>): void {
 	validateScheduledRunsConfig(config.scheduledRuns);
 	validateFleetKeybindingsConfig(config.fleetKeybindings);
 	validateArtifactConfig(config.artifactConfig);
+	validateModelExclusionsConfig(config.modelExclusions);
 	validateMainWindowRendererConfig(config.mainWindowRenderer);
 	validateOrcaProgressTabsConfig(config.orcaProgressTabs);
 }
@@ -148,6 +161,28 @@ export function updateConfig(updater: (config: ExtensionConfig) => ExtensionConf
 	validateConfig(next as Record<string, unknown>);
 	saveConfig(next, configPath);
 	return next;
+}
+
+/**
+ * Resolve the default TTL that the process-wide exclusion store should use.
+ *
+ * @param config Extension configuration after validation.
+ * @returns The configured TTL in milliseconds, or the built-in 24-hour default.
+ */
+// TEST:test/unit/pi-coding-agent-dir.test.ts[loads and applies model exclusion TTL config]
+export function resolveModelExclusionTTL(config: Pick<ExtensionConfig, "modelExclusions">): number {
+	return config.modelExclusions?.defaultTtlMs ?? DEFAULT_MODEL_EXCLUSION_TTL_MS;
+}
+
+/**
+ * Apply the configured exclusion policy to the process-wide model store.
+ *
+ * @param config Extension configuration after validation.
+ * @returns Nothing.
+ */
+// TEST:test/unit/pi-coding-agent-dir.test.ts[loads and applies model exclusion TTL config]
+export function applyModelExclusionsConfig(config: Pick<ExtensionConfig, "modelExclusions">): void {
+	setDefaultTTL(resolveModelExclusionTTL(config), { shortenExisting: config.modelExclusions?.defaultTtlMs !== undefined });
 }
 
 export function resolveAsyncByDefault(config: Pick<ExtensionConfig, "asyncByDefault">): boolean {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -56,7 +56,7 @@ import { formatSteeringNotice, handleSubagentSteeringNotice, SUBAGENT_STEERING_M
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
-import { loadConfig, resolveAsyncByDefault, resolveScheduledStoreRoot } from "./config.ts";
+import { applyModelExclusionsConfig, loadConfig, resolveAsyncByDefault, resolveScheduledStoreRoot } from "./config.ts";
 import { buildSubagentToolDescription, buildSubagentToolPromptMetadata } from "./tool-description.ts";
 import { finalizeToolResult } from "./tool-result.ts";
 import { collectGoalContinuationNotices } from "../missions/goal-driver.ts";
@@ -401,6 +401,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	cleanupOldChainDirs();
 
 	const config = loadConfig();
+	// Apply the process-wide exclusion TTL before any child launch can record a model failure.
+	applyModelExclusionsConfig(config);
 	const waitToolConfig = resolveWaitToolConfig(config.waitTool);
 	const asyncByDefault = resolveAsyncByDefault(config);
 	const fleetViewEnabled = config.fleetView !== false;

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -20,14 +20,30 @@ type RecordModelFailureOptions = ModelExclusionTarget & {
 
 let exclusions: ModelExclusion[] = [];
 let loaded = false;
-let defaultTTLMs = 24 * 60 * 60_000; // 24 hours, overridable via setDefaultTTL
+/** Default duration for a new model exclusion when no per-record TTL is supplied. */
+export const DEFAULT_MODEL_EXCLUSION_TTL_MS = 24 * 60 * 60_000;
+/** Keeps a new expiry safely below JavaScript's maximum Date timestamp. */
+export const MAX_MODEL_EXCLUSION_TTL_MS = 8_000_000_000_000_000;
+const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
+let defaultTTLMs = DEFAULT_MODEL_EXCLUSION_TTL_MS;
+let loadedTTLCeilingMs: number | undefined;
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
 let persistSeq = 0;
 
-/** Override the default exclusion TTL. */
-export function setDefaultTTL(ms: number): void {
-	if (!Number.isFinite(ms) || ms <= 0) throw new Error("Default model exclusion TTL must be a finite positive number.");
+/**
+ * Override the default TTL applied to newly recorded model exclusions.
+ *
+ * @param ms Duration in milliseconds. Must be finite and positive.
+ * @returns Nothing.
+ */
+// TEST:test/unit/model-exclusions.test.ts[model exclusions — TTL expiry]
+export function setDefaultTTL(ms: number, options?: { shortenExisting?: boolean }): void {
+	if (!Number.isFinite(ms) || ms <= 0 || ms > MAX_MODEL_EXCLUSION_TTL_MS) {
+		throw new Error(`Default model exclusion TTL must be a finite positive number no greater than ${MAX_MODEL_EXCLUSION_TTL_MS}.`);
+	}
 	defaultTTLMs = ms;
+	loadedTTLCeilingMs = options?.shortenExisting ? ms : undefined;
+	if (loaded && loadedTTLCeilingMs !== undefined && shortenExclusionsToTTL(exclusions, loadedTTLCeilingMs, Date.now())) schedulePersist();
 }
 
 /**
@@ -78,9 +94,23 @@ function ensureLoaded(): void {
 		const raw = fs.readFileSync(getExclusionsFilePath(), "utf-8");
 		const data = JSON.parse(raw);
 		if (data.version === 1) {
+			if (!Array.isArray(data.exclusions)) throw new Error("Model exclusion store version 1 must contain an exclusions array.");
+			for (let index = 0; index < data.exclusions.length; index++) {
+				const entry = data.exclusions[index];
+				if (!entry || typeof entry !== "object" || Array.isArray(entry)) throw new Error(`Model exclusion store entry ${index} must be an object.`);
+				if (entry.reason !== undefined && typeof entry.reason !== "string") throw new Error(`Model exclusion store entry ${index} has an invalid reason.`);
+				for (const field of ["recordedAt", "expiresAt"] as const) {
+					const timestamp = entry[field];
+					if (typeof timestamp !== "number" || !Number.isFinite(timestamp) || timestamp <= 0 || timestamp > MAX_DATE_TIMESTAMP_MS) {
+						throw new Error(`Model exclusion store entry ${index} has an invalid ${field}.`);
+					}
+				}
+			}
 			const now = Date.now();
 			exclusions = (data.exclusions ?? []).filter((e: ModelExclusion) => e.expiresAt > now);
+			const shortened = loadedTTLCeilingMs !== undefined && shortenExclusionsToTTL(exclusions, loadedTTLCeilingMs, now);
 			exclusions = deduplicate(exclusions);
+			if (shortened) schedulePersist();
 		}
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -205,7 +235,10 @@ export function parseModelKey(fullId: string): { provider?: string; modelId: str
  * Filter a list of candidate fullIds, removing excluded models/providers and
  * duplicates while preserving order.
  */
-export function filterFallbackCandidates(candidates: string[], opts?: { now?: number }): string[] {
+export function filterFallbackCandidates(candidates: string[], opts?: {
+	now?: number;
+	onExcluded?: (candidate: string, exclusion: Readonly<ModelExclusion>) => void;
+}): string[] {
 	ensureLoaded();
 	const timestamp = opts?.now ?? Date.now();
 	const seen = new Set<string>();
@@ -213,8 +246,11 @@ export function filterFallbackCandidates(candidates: string[], opts?: { now?: nu
 	for (const raw of candidates) {
 		if (!raw || seen.has(raw)) continue;
 		const { provider: candidateProvider, modelId: candidateModelId } = parseModelKey(raw);
-		const excluded = exclusions.some((entry) => entryMatches(entry, candidateModelId, candidateProvider, timestamp));
-		if (excluded) continue;
+		const exclusion = exclusions.find((entry) => entryMatches(entry, candidateModelId, candidateProvider, timestamp));
+		if (exclusion) {
+			opts?.onExcluded?.(raw, exclusion);
+			continue;
+		}
 		seen.add(raw);
 		filtered.push(raw);
 	}
@@ -240,4 +276,18 @@ function prune(items: ModelExclusion[], now: number): void {
 		}
 	}
 	items.length = write;
+}
+
+function shortenExclusionsToTTL(items: ModelExclusion[], ttlMs: number, now: number): boolean {
+	let changed = false;
+	for (const entry of items) {
+		const configuredExpiry = entry.recordedAt + ttlMs;
+		if (entry.expiresAt > configuredExpiry) {
+			entry.expiresAt = configuredExpiry;
+			changed = true;
+		}
+	}
+	const previousLength = items.length;
+	prune(items, now);
+	return changed || items.length !== previousLength;
 }

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -2,6 +2,7 @@ import { splitKnownThinkingSuffix, type ModelInfo as AvailableModelInfo } from "
 import type { Usage } from "../../shared/types.ts";
 import { filterFallbackCandidates, parseModelKey, recordModelFailure } from "./model-exclusions.ts";
 import { checkModelScope, type ModelScopeCheckRule, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
+import { redactSecretValues } from "./permissions.ts";
 
 export type { AvailableModelInfo };
 
@@ -394,7 +395,12 @@ export function buildModelCandidates(
 		seen.add(normalized);
 		candidates.push(normalized);
 	}
-	return filterFallbackCandidates(candidates);
+	return filterFallbackCandidates(candidates, {
+		onExcluded(candidate, exclusion) {
+			const reason = redactSecretValues((exclusion.reason ?? "runtime-failure").replace(/[\u0000-\u001f\u007f]+/g, " ")).slice(0, 240);
+			console.warn(`[pi-subagents] Skipping model '${candidate}' due to a cached exclusion (reason: ${reason}; expires: ${new Date(exclusion.expiresAt).toISOString()}).`);
+		},
+	});
 }
 
 const RETRYABLE_MODEL_FAILURE_PATTERNS = [

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2101,6 +2101,11 @@ export interface ScheduledRunsConfig {
 	storeRoot?: string;
 }
 
+export interface ModelExclusionsConfig {
+	/** Default duration in milliseconds. A lower configured value also shortens active cached exclusions. */
+	defaultTtlMs?: number;
+}
+
 export type FleetViewPlacement = "aboveEditor" | "belowEditor";
 
 export const FLEET_KEYBINDING_ACTIONS = [
@@ -2149,6 +2154,8 @@ export interface ExtensionConfig {
 	fleetKeybindings?: FleetKeybindingsConfig;
 	/** Show the under-editor async runs widget. Defaults to true, including when FleetView is enabled. */
 	asyncWidget?: boolean;
+	/** Configure the process-wide TTL policy for persisted model exclusions. */
+	modelExclusions?: ModelExclusionsConfig;
 	/** Tool description variant registered for the parent-facing subagent tool. Defaults to split metadata. */
 	toolDescriptionMode?: ToolDescriptionMode;
 	/** Inline chat rendering for the subagent tool. Defaults to rich. */

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -20,6 +20,76 @@ function parentToolEnv(agentDir?: string): NodeJS.ProcessEnv {
 }
 
 describe("subagent extension child mode", () => {
+	it("defers persistence when startup config expires a cached exclusion", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-model-exclusion-startup-"));
+		const exclusionPath = path.join(agentDir, "model-exclusions.json");
+		try {
+			const configDir = path.join(agentDir, "extensions", "subagent");
+			fs.mkdirSync(configDir, { recursive: true });
+			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ modelExclusions: { defaultTtlMs: 300_000 } }), "utf-8");
+			const recordedAt = Date.now() - 600_000;
+			const originalExpiry = Date.now() + 3_600_000;
+			fs.writeFileSync(exclusionPath, JSON.stringify({
+				version: 1,
+				exclusions: [{ provider: "openai", modelId: "old-model", reason: "503", recordedAt, expiresAt: originalExpiry }],
+			}), "utf-8");
+			const script = String.raw`
+				import registerSubagentExtension from "./index.ts";
+				import { isExcluded } from "./src/runs/shared/model-exclusions.ts";
+				const events = { on() { return () => {}; }, emit() {} };
+				const fakePi = new Proxy({
+					events,
+					registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {}, sendMessage() {}, getSessionName() {},
+				}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+				registerSubagentExtension(fakePi);
+				if (isExcluded("old-model", "openai")) throw new Error("startup TTL clamp did not expire the cached exclusion in memory");
+			`;
+			const env = parentToolEnv(agentDir);
+			env.PI_MODEL_EXCLUSIONS_PATH = exclusionPath;
+			execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+			const persisted = JSON.parse(fs.readFileSync(exclusionPath, "utf-8")).exclusions[0] as { expiresAt: number };
+			assert.equal(persisted.expiresAt, originalExpiry);
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
+	it("applies model exclusion TTL from extension config at registration", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-model-exclusion-config-"));
+		const exclusionPath = path.join(agentDir, "model-exclusions.json");
+		try {
+			const configDir = path.join(agentDir, "extensions", "subagent");
+			fs.mkdirSync(configDir, { recursive: true });
+			fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ modelExclusions: { defaultTtlMs: 300_000 } }), "utf-8");
+			const recordedAt = Date.now();
+			fs.writeFileSync(exclusionPath, JSON.stringify({
+				version: 1,
+				exclusions: [{ provider: "openai", modelId: "old-model", reason: "503", recordedAt, expiresAt: recordedAt + 3_600_000 }],
+			}), "utf-8");
+			const script = String.raw`
+				import * as fs from "node:fs";
+				import registerSubagentExtension from "./index.ts";
+				import { recordModelFailure } from "./src/runs/shared/model-exclusions.ts";
+				const events = { on() { return () => {}; }, emit() {} };
+				const fakePi = new Proxy({
+					events,
+					registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {}, sendMessage() {}, getSessionName() {},
+				}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+				registerSubagentExtension(fakePi);
+				recordModelFailure({ modelId: "gpt-5", provider: "openai", reason: "test" });
+				const entries = JSON.parse(fs.readFileSync(process.env.PI_MODEL_EXCLUSIONS_PATH, "utf-8")).exclusions;
+				for (const entry of entries) {
+					if (entry.expiresAt - entry.recordedAt !== 300_000) throw new Error("configured model exclusion TTL was not applied: " + JSON.stringify(entry));
+				}
+			`;
+			const env = parentToolEnv(agentDir);
+			env.PI_MODEL_EXCLUSIONS_PATH = exclusionPath;
+			execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
 	it("collapses tool detail before direct subagent tool execution", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./index.ts";

--- a/test/unit/model-exclusions.test.ts
+++ b/test/unit/model-exclusions.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import {
 	clearExclusions,
+	DEFAULT_MODEL_EXCLUSION_TTL_MS,
 	filterFallbackCandidates,
 	flushPersist,
 	getExcludedCount,
@@ -11,13 +12,16 @@ import {
 	parseModelKey,
 	recordModelFailure,
 	reloadFromDisk,
+	MAX_MODEL_EXCLUSION_TTL_MS,
 	setDefaultTTL,
+	type ModelExclusion,
 } from "../../src/runs/shared/model-exclusions.ts";
 
 // The exclusion store is a process-wide singleton persisted under TEMP_ROOT_DIR
 // (isolated per test run by test/support/isolated-temp-root.mjs). Clear it
 // before/after each test so cases don't leak state into each other.
 beforeEach(() => {
+	setDefaultTTL(DEFAULT_MODEL_EXCLUSION_TTL_MS);
 	fs.rmSync(getExclusionsFilePath(), { force: true });
 	clearExclusions();
 });
@@ -61,6 +65,16 @@ describe("model exclusions — TTL expiry", () => {
 	it("rejects invalid default TTLs", () => {
 		assert.throws(() => setDefaultTTL(0), /finite positive/);
 		assert.throws(() => setDefaultTTL(Number.POSITIVE_INFINITY), /finite positive/);
+		assert.throws(() => setDefaultTTL(MAX_MODEL_EXCLUSION_TTL_MS + 1), /no greater than/);
+	});
+
+	it("keeps the maximum configured expiry representable", () => {
+		setDefaultTTL(MAX_MODEL_EXCLUSION_TTL_MS);
+		recordModelFailure({ modelId: "gpt-4", provider: "openai" });
+		reloadFromDisk();
+		const entry = JSON.parse(fs.readFileSync(getExclusionsFilePath(), "utf-8")).exclusions[0] as ModelExclusion;
+		assert.doesNotThrow(() => new Date(entry.expiresAt).toISOString());
+		assert.equal(isExcluded("gpt-4", "openai"), true);
 	});
 
 	it("drops an exclusion after its TTL elapses", async () => {
@@ -68,6 +82,23 @@ describe("model exclusions — TTL expiry", () => {
 		assert.equal(isExcluded("gpt-4", "openai"), true);
 		await new Promise((r) => setTimeout(r, 150));
 		assert.equal(isExcluded("gpt-4", "openai"), false);
+	});
+
+	it("shortens active exclusions without synchronously persisting or extending expiries", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "503", ttlMs: 60_000 });
+		const before = JSON.parse(fs.readFileSync(getExclusionsFilePath(), "utf-8")).exclusions[0] as ModelExclusion;
+		setDefaultTTL(30_000, { shortenExisting: true });
+		const beforeFlush = JSON.parse(fs.readFileSync(getExclusionsFilePath(), "utf-8")).exclusions[0] as ModelExclusion;
+		assert.equal(beforeFlush.expiresAt, before.expiresAt);
+		flushPersist();
+		const shortened = JSON.parse(fs.readFileSync(getExclusionsFilePath(), "utf-8")).exclusions[0] as ModelExclusion;
+		assert.equal(shortened.expiresAt, shortened.recordedAt + 30_000);
+
+		setDefaultTTL(120_000, { shortenExisting: true });
+		flushPersist();
+		const notExtended = JSON.parse(fs.readFileSync(getExclusionsFilePath(), "utf-8")).exclusions[0] as ModelExclusion;
+		assert.equal(notExtended.expiresAt, shortened.expiresAt);
+		assert.ok(shortened.expiresAt < before.expiresAt);
 	});
 });
 
@@ -119,6 +150,18 @@ describe("model exclusions — filtering fallback candidates", () => {
 		const filtered = filterFallbackCandidates(candidates);
 		assert.deepEqual(filtered, ["anthropic/claude-3", "openai/gpt-4"]);
 	});
+
+	it("reports the cached reason and expiry for skipped candidates", () => {
+		const skipped: Array<{ candidate: string; exclusion: Readonly<ModelExclusion> }> = [];
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "503 unavailable" });
+		const filtered = filterFallbackCandidates(["openai/gpt-4", "anthropic/claude-3"], {
+			onExcluded: (candidate, exclusion) => skipped.push({ candidate, exclusion }),
+		});
+		assert.deepEqual(filtered, ["anthropic/claude-3"]);
+		assert.equal(skipped[0]?.candidate, "openai/gpt-4");
+		assert.equal(skipped[0]?.exclusion.reason, "503 unavailable");
+		assert.ok((skipped[0]?.exclusion.expiresAt ?? 0) > Date.now());
+	});
 });
 
 describe("model exclusions — persistence", () => {
@@ -163,5 +206,53 @@ describe("model exclusions — persistence", () => {
 		assert.equal(getExcludedCount(), 0);
 		assert.equal(errors.length, 1);
 		assert.match(String(errors[0]?.[0]), /Failed to load exclusions/);
+	});
+
+	it("rejects persisted exclusions with invalid timestamps", () => {
+		for (const [field, value] of [
+			["expiresAt", null],
+			["expiresAt", 0],
+			["expiresAt", 9_000_000_000_000_000],
+			["recordedAt", null],
+			["recordedAt", -1],
+			["recordedAt", 9_000_000_000_000_000],
+		] as const) {
+			const now = Date.now();
+			const entry = { modelId: "gpt-4", provider: "openai", reason: "503", recordedAt: now, expiresAt: now + 60_000, [field]: value };
+			fs.writeFileSync(getExclusionsFilePath(), JSON.stringify({ version: 1, exclusions: [entry] }), "utf-8");
+			const originalError = console.error;
+			const errors: unknown[][] = [];
+			console.error = (...args: unknown[]) => errors.push(args);
+			try {
+				reloadFromDisk();
+			} finally {
+				console.error = originalError;
+			}
+			assert.equal(getExcludedCount(), 0);
+			assert.equal(errors.length, 1);
+			assert.match(String(errors[0]?.[1]), new RegExp(`invalid ${field}`));
+		}
+	});
+
+	it("rejects persisted exclusions with non-string reasons", () => {
+		for (const reason of [null, 503, { bad: true }, ["503"]]) {
+			const now = Date.now();
+			fs.writeFileSync(getExclusionsFilePath(), JSON.stringify({
+				version: 1,
+				exclusions: [{ modelId: "gpt-4", provider: "openai", reason, recordedAt: now, expiresAt: now + 60_000 }],
+			}), "utf-8");
+			const originalError = console.error;
+			const errors: unknown[][] = [];
+			console.error = (...args: unknown[]) => errors.push(args);
+			try {
+				reloadFromDisk();
+			} finally {
+				console.error = originalError;
+			}
+			assert.equal(getExcludedCount(), 0);
+			assert.equal(errors.length, 1);
+			assert.match(String(errors[0]?.[1]), /invalid reason/);
+			assert.deepEqual(filterFallbackCandidates(["openai/gpt-4", "anthropic/claude-3"]), ["openai/gpt-4", "anthropic/claude-3"]);
+		}
 	});
 });

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -125,12 +125,21 @@ describe("model fallback helpers", () => {
 	});
 
 	it("excludes a candidate after a retryable model failure is recorded", () => {
-		recordRetryableModelFailure("openai/gpt-5-mini", "rate limit exceeded");
-
-		assert.deepEqual(
-			buildModelCandidates("gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels),
-			["anthropic/claude-sonnet-4"],
-		);
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message: unknown) => warnings.push(String(message));
+		try {
+			recordRetryableModelFailure("openai/gpt-5-mini", "rate limit exceeded for Bearer secret-token-value");
+			assert.deepEqual(
+				buildModelCandidates("gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels),
+				["anthropic/claude-sonnet-4"],
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+		assert.equal(warnings.length, 1);
+		assert.match(warnings[0]!, /Skipping model 'openai\/gpt-5-mini'.*reason: rate limit exceeded for \[redacted\]; expires: \d{4}-\d{2}-\d{2}T/);
+		assert.doesNotMatch(warnings[0]!, /secret-token-value/);
 	});
 
 	it("does not exclude a candidate after a task or tool failure", () => {

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -7,8 +7,9 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import { discoverAgentsAll } from "../../src/agents/agents.ts";
 import { handleCreate } from "../../src/agents/agent-management.ts";
 import { clearSkillCache, discoverAvailableSkills, resolveSkillPath } from "../../src/agents/skills.ts";
-import { loadConfig, updateConfig } from "../../src/extension/config.ts";
+import { applyModelExclusionsConfig, loadConfig, resolveModelExclusionTTL, updateConfig } from "../../src/extension/config.ts";
 import { diagnoseIntercomBridge, resolveIntercomBridge } from "../../src/intercom/intercom-bridge.ts";
+import { DEFAULT_MODEL_EXCLUSION_TTL_MS, MAX_MODEL_EXCLUSION_TTL_MS, clearExclusions, flushPersist, recordModelFailure, reloadFromDisk } from "../../src/runs/shared/model-exclusions.ts";
 import { loadRunsForAgent, recordRun } from "../../src/runs/shared/run-history.ts";
 import { cleanupAllArtifactDirs, getArtifactsDir, getProjectArtifactsDir } from "../../src/shared/artifacts.ts";
 import { TEMP_ARTIFACTS_DIR } from "../../src/shared/types.ts";
@@ -230,6 +231,40 @@ Package skill content.
 
 		writeFile(configPath, JSON.stringify({ defaultSubagentContext: "other" }));
 		assert.throws(() => updateConfig((config) => config), /config\.defaultSubagentContext must be "fresh" or "fork"/);
+	});
+
+	it("loads and applies model exclusion TTL config", () => {
+		const configPath = path.join(agentDir, "extensions", "subagent", "config.json");
+		const exclusionPath = path.join(tempDir, "model-exclusions.json");
+		const previousExclusionPath = process.env.PI_MODEL_EXCLUSIONS_PATH;
+		process.env.PI_MODEL_EXCLUSIONS_PATH = exclusionPath;
+		try {
+			writeFile(configPath, JSON.stringify({ modelExclusions: { defaultTtlMs: 300_000 } }));
+			const config = loadConfig();
+			assert.equal(config.modelExclusions?.defaultTtlMs, 300_000);
+			assert.equal(resolveModelExclusionTTL(config), 300_000);
+			assert.equal(resolveModelExclusionTTL({}), DEFAULT_MODEL_EXCLUSION_TTL_MS);
+
+			applyModelExclusionsConfig(config);
+			reloadFromDisk();
+			recordModelFailure({ modelId: "gpt-5", provider: "openai", reason: "test" });
+			const entry = (JSON.parse(fs.readFileSync(exclusionPath, "utf-8")).exclusions as Array<{ recordedAt: number; expiresAt: number }>)[0];
+			assert.ok(entry);
+			assert.equal(entry.expiresAt - entry.recordedAt, 300_000);
+
+			for (const invalidTtl of [0, -1, MAX_MODEL_EXCLUSION_TTL_MS + 1, "300000", true, null]) {
+				writeFile(configPath, JSON.stringify({ modelExclusions: { defaultTtlMs: invalidTtl } }));
+				assert.throws(() => updateConfig((current) => current), /config\.modelExclusions\.defaultTtlMs must be a finite positive number/);
+			}
+		} finally {
+			clearExclusions();
+			flushPersist();
+			reloadFromDisk();
+			applyModelExclusionsConfig({});
+			if (previousExclusionPath === undefined) delete process.env.PI_MODEL_EXCLUSIONS_PATH;
+			else process.env.PI_MODEL_EXCLUSIONS_PATH = previousExclusionPath;
+			fs.rmSync(exclusionPath, { force: true });
+		}
 	});
 
 	it("rejects invalid artifactDir config values", () => {


### PR DESCRIPTION
## Summary

Fixes #1438.

This PR replaces #1439 with a clean current-main version of the model-exclusion recovery work.

- Adds `modelExclusions.defaultTtlMs` config for newly recorded exclusions.
- Shortens active cached exclusions on load when the configured TTL is lower than their persisted expiry.
- Adds launch warnings when a model candidate is skipped due to a cached exclusion, including the cached reason and expiry.
- Does not add a new reset/list command or public management API.

## Validation

- Focused model-exclusion/config/model-fallback tests: 141 passed.
- `npm run typecheck`: passed.
- `git diff --check origin/main..HEAD`: passed.

Thanks to [@mithyer](https://github.com/mithyer) for #1438 and #1439.