### PR TITLE
fix: tolerate unaddressable result aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 - Make workflow validation and return serialization failures easier to recover from with no-child-launch diagnostics, portable rewrite guidance, workflow ids, and completed-child output references (#1432, #1434).
 - Report child processes that exit during tool execution as mid-tool failures instead of cold starts, even when earlier assistant text exists. Thanks to [@cyzlmh](https://github.com/cyzlmh) for #1437.
+- Keep unaddressable legacy result aliases and overlong public result filenames from blocking canonical hashed or pending fallbacks. Thanks to [@LeonardBode](https://github.com/LeonardBode) for #1440.
 
 ## [0.56.0] - 2026-08-23
 

--- a/src/runs/background/result-files.ts
+++ b/src/runs/background/result-files.ts
@@ -40,6 +40,11 @@ function nonEmptyString(value: unknown): string | undefined {
 	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+/** A legacy alias can be valid metadata while still being unaddressable on the current filesystem. */
+function isUnaddressableResultCandidate(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException)?.code === "ENAMETOOLONG";
+}
+
 export function resultFileName(runId: string): string {
 	return `${runId}${JSON_EXTENSION}`;
 }
@@ -227,7 +232,7 @@ function existingResultFile(resultPath: string): boolean {
 	try {
 		return fs.statSync(resultPath).isFile();
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Failed to inspect async result payload '${resultPath}':`, error);
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT" && !isUnaddressableResultCandidate(error)) console.error(`Failed to inspect async result payload '${resultPath}':`, error);
 		return false;
 	}
 }
@@ -241,7 +246,7 @@ function pendingResultPayloadMatches(filePath: string, sessionId: string, runId:
 		const data = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, unknown>;
 		return (nonEmptyString(data.runId) ?? nonEmptyString(data.id)) === runId && nonEmptyString(data.sessionId) === sessionId;
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid pending async result '${filePath}':`, error);
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT" && !isUnaddressableResultCandidate(error)) console.error(`Ignoring invalid pending async result '${filePath}':`, error);
 		return false;
 	}
 }
@@ -263,11 +268,11 @@ export function promotePendingResultFile(resultsDir: string, sessionId: string, 
 		return existingResultFile(resultPath) ? "promoted" : "pending";
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code;
-		if (code === "ENOENT" || code === "EEXIST" || code === "EPERM" || code === "EACCES") {
+		if (code === "ENOENT" || code === "EEXIST" || code === "EPERM" || code === "EACCES" || isUnaddressableResultCandidate(error)) {
 			const pendingExists = existingResultFile(pendingPath);
 			const resultExists = existingResultFile(resultPath);
 			if (pendingExists) {
-				if (!resultExists && options.logFailure !== false) console.error(`Failed to promote pending async result '${pendingPath}' to '${resultPath}':`, error);
+				if (!resultExists && options.logFailure !== false && !isUnaddressableResultCandidate(error)) console.error(`Failed to promote pending async result '${pendingPath}' to '${resultPath}':`, error);
 				return "pending";
 			}
 			if (resultExists) return "promoted";
@@ -318,7 +323,7 @@ function readResultIndexForSessionRun(resultsDir: string, sessionId: string, run
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code === "EPERM" || code === "EACCES") throw error;
-			if (code !== "ENOENT" && code !== "ENOTDIR") {
+			if (code !== "ENOENT" && code !== "ENOTDIR" && !isUnaddressableResultCandidate(error)) {
 				console.error(`Ignoring invalid async result index for '${runId}':`, error);
 			}
 		}
@@ -338,7 +343,7 @@ export function resultPayloadPathForMissionObserverRun(resultsDir: string, runId
 		if (!entry || entry.runId !== runId) return undefined;
 		return resultPayloadLocationFromIndex(resultsDir, entry)?.path;
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result observer index for '${runId}':`, error);
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT" && !isUnaddressableResultCandidate(error)) console.error(`Ignoring invalid async result observer index for '${runId}':`, error);
 		return undefined;
 	}
 }
@@ -356,9 +361,12 @@ export function resultPayloadPathForIndexedRun(resultsDir: string, runId: string
 		fs.rmSync(entryPath, { force: true });
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code;
+		if (isUnaddressableResultCandidate(error)) return undefined;
 		if (code !== "ENOENT" && code !== "ENOTDIR") {
 			console.error(`Ignoring invalid async result run index '${entryPath}':`, error);
-			try { fs.rmSync(entryPath, { force: true }); } catch {}
+			try { fs.rmSync(entryPath, { force: true }); } catch {
+				// Invalid optional run-index cleanup is best-effort.
+			}
 		}
 	}
 	return undefined;
@@ -378,7 +386,7 @@ function listIndexFiles(dir: string): string[] {
 			.map((entry) => path.join(dir, entry.name));
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code;
-		if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES") return [];
+		if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES" || isUnaddressableResultCandidate(error)) return [];
 		throw error;
 	}
 	return files;
@@ -396,7 +404,7 @@ function resultFilesFromIndexDir(resultsDir: string, dir: string, includePending
 			const resultFile = indexedResultFile(resultsDir, entry, includePending);
 			if (resultFile) candidates.add(resultFile);
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result index '${entryPath}':`, error);
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT" && !isUnaddressableResultCandidate(error)) console.error(`Ignoring invalid async result index '${entryPath}':`, error);
 		}
 	}
 	return [...candidates];
@@ -418,7 +426,7 @@ function pendingResultFilesForSession(resultsDir: string, sessionId: string): st
 			entries = fs.readdirSync(dir, { withFileTypes: true });
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
-			if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES") continue;
+			if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES" || isUnaddressableResultCandidate(error)) continue;
 			throw error;
 		}
 		for (const entry of entries) {
@@ -429,7 +437,7 @@ function pendingResultFilesForSession(resultsDir: string, sessionId: string): st
 				const runId = nonEmptyString(data.runId) ?? nonEmptyString(data.id);
 				if (runId && nonEmptyString(data.sessionId) === sessionId) files.add(resultFileName(runId));
 			} catch (error) {
-				if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid pending async result '${pendingPath}':`, error);
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT" && !isUnaddressableResultCandidate(error)) console.error(`Ignoring invalid pending async result '${pendingPath}':`, error);
 			}
 		}
 	}
@@ -471,14 +479,16 @@ export function cleanupResultIndexes(resultsDir: string, now = Date.now(), maxAg
 			entries = fs.readdirSync(dir, { withFileTypes: true });
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
-			if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES") return;
+			if (code === "ENOENT" || code === "ENOTDIR" || code === "EPERM" || code === "EACCES" || isUnaddressableResultCandidate(error)) return;
 			throw error;
 		}
 		for (const entry of entries) {
 			const fullPath = path.join(dir, entry.name);
 			if (entry.isDirectory()) {
 				visit(fullPath);
-				try { fs.rmdirSync(fullPath); } catch {}
+				try { fs.rmdirSync(fullPath); } catch {
+					// Non-empty or concurrently removed index directories are left in place.
+				}
 				continue;
 			}
 			if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
@@ -492,11 +502,14 @@ export function cleanupResultIndexes(resultsDir: string, now = Date.now(), maxAg
 					removed += 1;
 				}
 			} catch (error) {
+				if (isUnaddressableResultCandidate(error)) continue;
 				if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Ignoring invalid async result index '${fullPath}':`, error);
 				try {
 					fs.rmSync(fullPath, { force: true });
 					removed += 1;
-				} catch {}
+				} catch {
+					// Invalid optional index cleanup is best-effort.
+				}
 			}
 		}
 	};

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -148,6 +148,10 @@ function isNotFound(error: unknown): boolean {
 	return errorCode(error) === "ENOENT";
 }
 
+function isAbsentResultCandidate(error: unknown): boolean {
+	return isNotFound(error) || errorCode(error) === "ENAMETOOLONG";
+}
+
 function isAccessDenied(error: unknown): boolean {
 	const code = errorCode(error);
 	return code === "EPERM" || code === "EACCES";
@@ -235,7 +239,7 @@ export function createResultWatcher(
 		try {
 			return fsApi.statSync(publicResultPath(file)).isFile();
 		} catch (error) {
-			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${publicResultPath(file)}':`, error);
+			if (!isAbsentResultCandidate(error)) console.error(`Failed to inspect subagent result file '${publicResultPath(file)}':`, error);
 			return false;
 		}
 	};
@@ -265,7 +269,7 @@ export function createResultWatcher(
 		} catch (error) {
 			identityCache.delete(file);
 			if (isAccessDenied(error)) throw error;
-			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
+			if (!isAbsentResultCandidate(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
 			return undefined;
 		}
 	};
@@ -283,7 +287,7 @@ export function createResultWatcher(
 		} catch (error) {
 			identityCache.delete(file);
 			if (isAccessDenied(error)) throw error;
-			if (!isNotFound(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
+			if (!isAbsentResultCandidate(error)) console.error(`Failed to inspect subagent result file '${resultPath}':`, error);
 			return undefined;
 		}
 	};
@@ -317,7 +321,7 @@ export function createResultWatcher(
 			removeResultIndex(resultsDir, sessionId, runId, toolCallId);
 			return true;
 		} catch (error) {
-			if (!isNotFound(error)) {
+			if (!isAbsentResultCandidate(error)) {
 				console.error(`Failed to remove delivered subagent result '${publicResultPath(file)}'; will retry:`, error);
 				return false;
 			}
@@ -384,7 +388,7 @@ export function createResultWatcher(
 					if (!resultPayloadWasReplaced(data, readPublicResultIdentity())) return false;
 				} catch (error) {
 					if (isAccessDenied(error)) throw error;
-					if (isNotFound(error)) return false;
+					if (isAbsentResultCandidate(error)) return false;
 					console.error(`Failed to re-read subagent result file '${publicResultPath(file)}':`, error);
 				}
 				identityCache.delete(file);

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -8,6 +8,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { buildCompletionKey } from "../../src/runs/background/completion-dedupe.ts";
 import { createResultWatcher as createRawResultWatcher } from "../../src/runs/background/result-watcher.ts";
 import { writeAsyncResultFile, writePendingAsyncResultFile } from "../../src/runs/background/result-files.ts";
+import { encodeIndexSegment, MAX_INDEX_SEGMENT_BYTES } from "../../src/runs/background/index-segment.ts";
 import { createScheduledRunManager, scheduledRunStorePath } from "../../src/runs/background/scheduled-runs.ts";
 import { prepareMissionLaunch, writeMissionAsyncBinding } from "../../src/missions/lifecycle.ts";
 import { readMission, updateMission } from "../../src/missions/store.ts";
@@ -209,7 +210,7 @@ describe("result watcher", () => {
 				on() { return fakeWatcher; },
 				close() {},
 				unref() {},
-			} as fs.FSWatcher;
+			} as unknown as fs.FSWatcher;
 			const writeResult = (id: string, sessionId: string) => {
 				writeIndexedResult(path.join(resultsDir, `${id}.json`), {
 					id,
@@ -247,11 +248,11 @@ describe("result watcher", () => {
 				timers: {
 					setTimeout,
 					clearTimeout,
-					setInterval(handler: () => void, delay?: number) {
+					setInterval: ((handler: () => void, delay?: number) => {
 						safetyScan = handler;
 						safetyScanIntervalMs = delay;
 						return { unref() {} } as NodeJS.Timeout;
-					},
+					}) as typeof setInterval,
 					clearInterval() { safetyScan = undefined; },
 				},
 			});
@@ -353,6 +354,82 @@ describe("result watcher", () => {
 			assert.ok(child?.artifactPaths.includes(outputPath));
 			assert.ok(child?.artifactPaths.includes(path.join(asyncDir, "status.json")));
 		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("observes a hash-only mission result once when its public alias is unaddressable", async (t) => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-mission-enametoolong-"));
+		const resultsDir = path.join(root, "results");
+		const project = path.join(root, "project");
+		const asyncDir = path.join(root, "async-child");
+		fs.mkdirSync(resultsDir, { recursive: true });
+		fs.mkdirSync(project, { recursive: true });
+		fs.mkdirSync(asyncDir, { recursive: true });
+		const originalError = console.error;
+		const errors: unknown[][] = [];
+		try {
+			const runId = `mission-${"x".repeat(250)}`;
+			const publicResultPath = path.join(resultsDir, `${runId}.json`);
+			assert.ok(Buffer.byteLength(`${runId}.json`, "utf-8") > MAX_INDEX_SEGMENT_BYTES);
+			const originalRenameSync = fsDefault.renameSync;
+			const nameTooLong = new Error("public result alias is too long") as NodeJS.ErrnoException;
+			nameTooLong.code = "ENAMETOOLONG";
+			t.mock.method(fsDefault, "renameSync", ((source: fs.PathLike, destination: fs.PathLike) => {
+				if (String(destination) === publicResultPath) throw nameTooLong;
+				return originalRenameSync(source, destination);
+			}) as typeof fsDefault.renameSync);
+			syncBuiltinESMExports();
+			const binding = prepareMissionLaunch({
+				params: { mission: { title: "Long result mission" }, task: "Run async child" },
+				projectRoot: project,
+				config: { directory: path.join(root, "missions"), globalIndexDir: path.join(root, "global-index") },
+				ownerSessionId: "session-owner",
+			});
+			assert.ok(binding);
+			writeMissionAsyncBinding(asyncDir, binding);
+			console.error = (...args: unknown[]) => { errors.push(args); };
+			writeIndexedResult(publicResultPath, {
+				id: runId,
+				runId,
+				sessionId: "session-owner",
+				asyncDir,
+				state: "complete",
+				success: true,
+				summary: "Long mission result completed",
+			});
+			const pendingPath = path.join(resultsDir, "result-pending", encodeIndexSegment("session-owner"), `${encodeIndexSegment(runId, MAX_INDEX_SEGMENT_BYTES - Buffer.byteLength(".json"))}.json`);
+			assert.equal(fs.existsSync(pendingPath), true);
+			const state = createState();
+			state.currentSessionId = "different-session";
+			let parsed = 0;
+			let observed = 0;
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				parseResult(raw) {
+					parsed += 1;
+					return JSON.parse(raw);
+				},
+				observeCompletion() { observed += 1; },
+			});
+			try {
+				watcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => observed === 1), true);
+				watcher.primeExistingResults();
+				await new Promise((resolve) => setTimeout(resolve, 25));
+			} finally {
+				watcher.stopResultWatcher();
+			}
+
+			assert.equal(parsed, 1);
+			assert.equal(observed, 1);
+			assert.equal(fs.existsSync(pendingPath), true);
+			assert.equal((JSON.parse(fs.readFileSync(pendingPath, "utf-8")) as { notificationDeliveredAt?: unknown }).notificationDeliveredAt, undefined);
+			assert.equal(readMission(binding.location, binding.missionId).runs.some((run) => run.runId === runId), true);
+			assert.equal(errors.some((entry) => /Failed to (?:promote|inspect|process).*result/i.test(String(entry[0] ?? ""))), false);
+		} finally {
+			console.error = originalError;
+			t.mock.restoreAll();
+			syncBuiltinESMExports();
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});
@@ -907,6 +984,39 @@ describe("result watcher", () => {
 		}
 	});
 
+	it("diagnoses non-filesystem ENAMETOOLONG from parser and notifier callbacks", async () => {
+		for (const source of ["parser", "notifier"] as const) {
+			const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-result-watcher-${source}-enametoolong-`));
+			const originalError = console.error;
+			const logged: unknown[][] = [];
+			try {
+				const runId = `${source}-enametoolong`;
+				const resultPath = path.join(resultsDir, `${runId}.json`);
+				writeIndexedResult(resultPath, { id: runId, runId, sessionId: "session-current", success: true, summary: "done" });
+				const state = createState();
+				state.currentSessionId = "session-current";
+				const failure = new Error(`${source} rejected payload`) as NodeJS.ErrnoException;
+				failure.code = "ENAMETOOLONG";
+				console.error = (...args: unknown[]) => { logged.push(args); };
+				const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, source === "parser"
+					? { parseResult: () => { throw failure; } }
+					: { notifier: { deliver: async () => { throw failure; } } });
+				try {
+					watcher.primeExistingResults();
+					assert.equal(await waitForPredicate(() => logged.some((entry) => entry[1] === failure)), true);
+				} finally {
+					watcher.stopResultWatcher();
+				}
+
+				assert.equal(fs.existsSync(resultPath), true);
+				assert.equal(logged.some((entry) => entry[1] === failure && /Failed to process subagent result file/.test(String(entry[0] ?? ""))), true);
+			} finally {
+				console.error = originalError;
+				fs.rmSync(resultsDir, { recursive: true, force: true });
+			}
+		}
+	});
+
 	it("normalizes the native fs.watch path before watching result files", () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-"));
 		try {
@@ -925,7 +1035,7 @@ describe("result watcher", () => {
 				},
 				close() {},
 				unref() {},
-			} as fs.FSWatcher;
+			} as unknown as fs.FSWatcher;
 			const realpathSync = ((target: fs.PathLike, options?: unknown) => fs.realpathSync(target, options as BufferEncoding)) as typeof fs.realpathSync;
 			realpathSync.native = ((target: fs.PathLike) => target === resultsDir ? nativeResultsDir : fs.realpathSync.native(target)) as typeof fs.realpathSync.native;
 			const watcher = createResultWatcher(pi, state, resultsDir, 60_000, {
@@ -971,17 +1081,17 @@ describe("result watcher", () => {
 				},
 				close() {},
 				unref() {},
-			} as fs.FSWatcher;
+			} as unknown as fs.FSWatcher;
 			const watcher = createResultWatcher(pi, state, resultsDir, 60_000, {
 				fs: { ...fs, watch: () => fakeWatcher },
 				deliverIntercomResults: false,
 				timers: {
 					setTimeout,
 					clearTimeout,
-					setInterval(handler: () => void) {
+					setInterval: ((handler: () => void) => {
 						scan = handler;
 						return { unref() {} } as NodeJS.Timeout;
-					},
+					}) as typeof setInterval,
 					clearInterval() {
 						scan = undefined;
 					},
@@ -2101,7 +2211,7 @@ describe("result watcher", () => {
 				on() { return fakeWatcher; },
 				close() {},
 				unref() {},
-			} as fs.FSWatcher;
+			} as unknown as fs.FSWatcher;
 			let watchEvent: ((event: string, file: string | Buffer | null) => void) | undefined;
 			const resultPath = path.join(resultsDir, "index-retry.json");
 			writeIndexedResult(resultPath, { id: "index-retry", runId: "index-retry", sessionId: "session-1", agent: "worker", success: true, summary: "done", timestamp: 1 });
@@ -2120,7 +2230,7 @@ describe("result watcher", () => {
 			syncBuiltinESMExports();
 
 			const watcher = createResultWatcher({ events: { on: () => () => {}, emit(event) { emitted.push(event); } } }, state, resultsDir, 60_000, {
-				fs: { ...fs, watch: (_path, callback) => { watchEvent = callback; return fakeWatcher; } },
+				fs: { ...fs, watch: (_path, callback) => { watchEvent = callback as typeof watchEvent; return fakeWatcher; } },
 			});
 			try {
 				watcher.startResultWatcher();

--- a/test/unit/index-segment.test.ts
+++ b/test/unit/index-segment.test.ts
@@ -21,6 +21,7 @@ describe("bounded index segments", () => {
 		assert.equal(first, encodeIndexSegment(longId));
 		assert.match(first, /^~sha256-[a-f0-9]{64}$/);
 		assert.ok(Buffer.byteLength(first, "utf-8") <= MAX_INDEX_SEGMENT_BYTES);
+		assert.deepEqual(indexSegmentAliases(longId), [first]);
 		assert.notEqual(first, encodeIndexSegment(`${longId}other`));
 	});
 

--- a/test/unit/result-files.test.ts
+++ b/test/unit/result-files.test.ts
@@ -308,6 +308,88 @@ describe("result file indexes", () => {
 		}
 	});
 
+	it("treats an unaddressable legacy session alias as absent and keeps canonical fallback candidates", (t) => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-legacy-enametoolong-"));
+		const sessionId = String.raw`C:\Users\theap\.pi\agent\sessions\leaf.jsonl`;
+		const runId = "legacy-alias-fallback";
+		const resultPath = path.join(resultsDir, `${runId}.json`);
+		const legacyDir = path.join(resultsDir, "result-index", "sessions", encodeURIComponent(sessionId));
+		const originalReadFileSync = fsDefault.readFileSync;
+		const originalReaddirSync = fsDefault.readdirSync;
+		const originalError = console.error;
+		const errors: unknown[][] = [];
+		try {
+			writeAsyncResultFile(resultPath, { id: runId, runId, sessionId, success: true });
+			const canonicalDir = path.join(resultsDir, "result-index", "sessions", encodeIndexSegment(sessionId));
+			const [canonicalIndexFile] = fs.readdirSync(canonicalDir);
+			assert.ok(canonicalIndexFile);
+			const canonicalPendingPath = pendingPath(resultsDir, sessionId, runId);
+			fs.mkdirSync(path.dirname(canonicalPendingPath), { recursive: true });
+			fs.copyFileSync(resultPath, canonicalPendingPath);
+
+			const nameTooLong = new Error("legacy alias is too long") as NodeJS.ErrnoException;
+			nameTooLong.code = "ENAMETOOLONG";
+			fsDefault.readFileSync = ((filePath: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+				if (String(filePath).startsWith(legacyDir)) throw nameTooLong;
+				return (originalReadFileSync as (...input: unknown[]) => unknown)(filePath, ...args);
+			}) as typeof fsDefault.readFileSync;
+			fsDefault.readdirSync = ((dirPath: fs.PathLike, ...args: unknown[]) => {
+				if (String(dirPath) === legacyDir) throw nameTooLong;
+				return (originalReaddirSync as (...input: unknown[]) => unknown)(dirPath, ...args);
+			}) as typeof fsDefault.readdirSync;
+			console.error = (...args: unknown[]) => { errors.push(args); };
+			syncBuiltinESMExports();
+
+			assert.deepEqual(resultCandidateFilesForSession(resultsDir, sessionId), [`${runId}.json`]);
+			fs.copyFileSync(resultPath, canonicalPendingPath);
+			fs.rmSync(path.join(canonicalDir, canonicalIndexFile));
+			assert.equal(resultPayloadPathForSessionRun(resultsDir, sessionId, runId), canonicalPendingPath);
+			assert.deepEqual(errors, []);
+		} finally {
+			fsDefault.readFileSync = originalReadFileSync;
+			fsDefault.readdirSync = originalReaddirSync;
+			console.error = originalError;
+			t.mock.restoreAll();
+			syncBuiltinESMExports();
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("leaves an unaddressable legacy index untouched during cleanup", (t) => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-cleanup-enametoolong-"));
+		const sessionId = String.raw`C:\Users\theap\.pi\agent\sessions\leaf.jsonl`;
+		const runId = "legacy-cleanup";
+		const originalStatSync = fsDefault.statSync;
+		const originalError = console.error;
+		const errors: unknown[][] = [];
+		try {
+			writeAsyncResultFile(path.join(resultsDir, `${runId}.json`), { id: runId, runId, sessionId, success: true });
+			const canonicalDir = path.join(resultsDir, "result-index", "sessions", encodeIndexSegment(sessionId));
+			const legacyDir = path.join(resultsDir, "result-index", "sessions", encodeURIComponent(sessionId));
+			fs.renameSync(canonicalDir, legacyDir);
+			const [legacyIndexFile] = fs.readdirSync(legacyDir);
+			assert.ok(legacyIndexFile);
+			const legacyIndexPath = path.join(legacyDir, legacyIndexFile);
+			const nameTooLong = new Error("legacy alias is too long") as NodeJS.ErrnoException;
+			nameTooLong.code = "ENAMETOOLONG";
+			t.mock.method(fsDefault, "statSync", ((filePath: fs.PathLike) => {
+				if (String(filePath) === legacyIndexPath) throw nameTooLong;
+				return originalStatSync(filePath);
+			}) as typeof fsDefault.statSync);
+			console.error = (...args: unknown[]) => { errors.push(args); };
+			syncBuiltinESMExports();
+
+			assert.equal(cleanupResultIndexes(resultsDir, Date.now() + 86_400_001, 86_400_000), 0);
+			assert.equal(fs.existsSync(legacyIndexPath), true);
+			assert.deepEqual(errors, []);
+		} finally {
+			console.error = originalError;
+			t.mock.restoreAll();
+			syncBuiltinESMExports();
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
 	it("reads a pre-hash URI-encoded session index after the encoding change", () => {
 		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-files-legacy-session-"));
 		try {


### PR DESCRIPTION
## Summary

Supersedes #1440.

This PR preserves #1440 on current `main` with contributor credit added.

It treats `ENAMETOOLONG` as an absent candidate only for constructed result/index filesystem paths. Canonical hashed and pending fallbacks can still be found when a legacy alias or public filename is unaddressable. `EPERM`, `EACCES`, parser failures, and notifier failures stay diagnostic.

## Validation

- `test/unit/result-files.test.ts` and `test/unit/index-segment.test.ts`: 27 passed.
- `test/integration/result-watcher.test.ts`: 47 passed.
- `npm run typecheck`: passed.
- `git diff --check origin/main..HEAD`: passed.

Thanks to [@LeonardBode](https://github.com/LeonardBode) for #1440.