### PR TITLE
fix: discover agents from bare git URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Keep inline workflow children resumable from their foreground runs without mistaking a missing async directory for lost state. Thanks to [@lancegui](https://github.com/lancegui) for #1442.
+- Resolve package subagents from bare HTTP(S) Git URLs stored in Pi settings. Thanks to [@trancikk](https://github.com/trancikk) for #1452.
 
 ### Added
 - Add `modelExclusions.defaultTtlMs` configuration for controlling the lifetime of model exclusions, including shorter limits for active cached entries, with launch diagnostics for excluded candidates. Thanks to [@mithyer](https://github.com/mithyer) for #1439 and #1438.

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -382,6 +382,10 @@ function resolveSettingsPackageRoot(source: string, baseDir: string): string | u
 	if (normalized === "." || normalized === ".." || normalized.startsWith("./") || normalized.startsWith("../")) {
 		return path.resolve(baseDir, normalized);
 	}
+	if (/^https?:\/\//i.test(trimmed)) {
+		const parsed = parseGitPackagePath(`git:${trimmed}`);
+		return parsed ? path.join(baseDir, "git", parsed.host, parsed.repoPath) : undefined;
+	}
 	return undefined;
 }
 

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -889,6 +889,59 @@ Plan the work.
 		assert.equal(agent.source, "package");
 	}));
 
+	it("loads bare HTTPS git packages from project Pi settings", () => withTempHome(() => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-settings-bare-git-package-"));
+		tempDirs.push(dir);
+		const packageRoot = path.join(dir, ".pi", "git", "github.com", "user", "repo");
+		writeJson(path.join(dir, ".pi", "settings.json"), {
+			packages: ["https://github.com/user/repo.git"],
+		});
+		writeJson(path.join(packageRoot, "package.json"), {
+			name: "bare-git-workflow",
+			"pi-subagents": { agents: ["./agents"] },
+		});
+		writeAgent(path.join(packageRoot, "agents", "planner.md"), `---
+name: planner
+package: bare-git-workflow
+description: Plan from a bare HTTPS git package.
+---
+
+Plan the work.
+`);
+
+		const agent = discoverAgents(dir, "both").agents.find((candidate) => candidate.name === "bare-git-workflow.planner");
+		assert.ok(agent);
+		assert.equal(agent.source, "package");
+		assert.equal(agent.packageSourceRoot, packageRoot);
+	}));
+
+	it("loads bare HTTP git packages from user Pi settings", () => withTempHome((home) => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-user-settings-bare-git-package-"));
+		tempDirs.push(dir);
+		const agentDir = path.join(home, ".pi", "agent");
+		const packageRoot = path.join(agentDir, "git", "git.example.com", "team", "repo");
+		writeJson(path.join(agentDir, "settings.json"), {
+			packages: ["http://git.example.com/team/repo.git"],
+		});
+		writeJson(path.join(packageRoot, "package.json"), {
+			name: "user-bare-git-workflow",
+			"pi-subagents": { agents: ["./agents"] },
+		});
+		writeAgent(path.join(packageRoot, "agents", "reviewer.md"), `---
+name: reviewer
+package: user-bare-git-workflow
+description: Review from a bare HTTP git package.
+---
+
+Review the work.
+`);
+
+		const agent = discoverAgents(dir, "both").agents.find((candidate) => candidate.name === "user-bare-git-workflow.reviewer");
+		assert.ok(agent);
+		assert.equal(agent.source, "package");
+		assert.equal(agent.packageSourceRoot, packageRoot);
+	}));
+
 	it("discovers project package agents when cwd is nested below the project root", () => withTempHome(() => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-nested-package-discovery-"));
 		tempDirs.push(dir);


### PR DESCRIPTION
## Summary

Fixes #1452.

Pi settings can store git-installed packages as bare HTTP(S) Git URLs. This change resolves those sources through the existing git package parser and maps them to the cached `git/<host>/<owner>/<repo>` package root so package agents are discovered.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-frontmatter.test.ts`
- `npm run typecheck`
- `git diff --check origin/main..HEAD`

## Notes

Thanks to [@trancikk](https://github.com/trancikk) for #1452.
