### PR TITLE
fix: resolve bare HTTPS git URLs from Pi settings for package agent discovery

### DIFF
--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -382,6 +382,13 @@ function resolveSettingsPackageRoot(source: string, baseDir: string): string | u
 	if (normalized === "." || normalized === ".." || normalized.startsWith("./") || normalized.startsWith("../")) {
 		return path.resolve(baseDir, normalized);
 	}
+	// Pi stores git-installed packages as bare HTTPS/HTTP URLs (e.g.
+	// "https://github.com/user/repo.git"). Treat those as git package roots so
+	// they resolve to the same git cache directory as "git:" prefixed sources.
+	const parsedGit = parseGitPackagePath(`git:${trimmed}`);
+	if (parsedGit) {
+		return path.join(baseDir, "git", parsedGit.host, parsedGit.repoPath);
+	}
 	return undefined;
 }
 

--- a/test/unit/package-agent-git-url-discovery.test.ts
+++ b/test/unit/package-agent-git-url-discovery.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { discoverAgentsAll } from "../../src/agents/agents.ts";
+
+const MANAGED_ENV = ["PI_CODING_AGENT_DIR", "HOME", "USERPROFILE"];
+
+function writeAgent(dir: string, name: string): void {
+	const filePath = path.join(dir, `${name}.md`);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(
+		filePath,
+		`---\nname: ${name}\ndescription: ${name} agent\n---\n\nDo ${name} work.\n`,
+		"utf-8",
+	);
+}
+
+describe("package agent discovery from user settings", () => {
+	let tempDir = "";
+	let agentDir = "";
+	let homeDir = "";
+	let cwd = "";
+	const saved: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of MANAGED_ENV) saved[key] = process.env[key];
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-package-git-url-"));
+		agentDir = path.join(tempDir, "agent");
+		homeDir = path.join(tempDir, "home");
+		cwd = path.join(tempDir, "workspace");
+		fs.mkdirSync(cwd, { recursive: true });
+		fs.mkdirSync(homeDir, { recursive: true });
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env.HOME = homeDir;
+		process.env.USERPROFILE = homeDir;
+	});
+
+	afterEach(() => {
+		for (const key of MANAGED_ENV) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
+		}
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("discovers agents from git packages installed via bare HTTPS URL", () => {
+		// Simulate Pi installing a package from a git URL.
+		const packageRoot = path.join(agentDir, "git", "github.com", "test-org", "test-repo");
+		const agentsDir = path.join(packageRoot, "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(packageRoot, "package.json"),
+			JSON.stringify({ name: "test-git-package", "pi-subagents": { agents: ["./agents"] } }),
+		);
+		writeAgent(agentsDir, "https-git-agent");
+
+		// Pi stores the source in user settings as a bare HTTPS URL.
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(agentDir, "settings.json"),
+			JSON.stringify({ packages: ["https://github.com/test-org/test-repo.git"] }),
+		);
+
+		const all = discoverAgentsAll(cwd);
+		const agent = all.package.find((a) => a.name === "https-git-agent");
+		assert.ok(agent, "expected agent from HTTPS git package to be discovered");
+		assert.equal(agent?.packageSourceName, "test-git-package");
+	});
+});


### PR DESCRIPTION
## Summary

Pi stores git-installed packages in `~/.pi/agent/settings.json` as bare HTTPS URLs like `https://github.com/user/repo.git`. `pi-subagents` only resolved `git:` prefixed sources, so agent directories exposed by git-installed packages (e.g. `gsd-package`) were never discovered.

## Root cause

In `src/agents/agents.ts`, `resolveSettingsPackageRoot` only handled sources starting with `git:`, `npm:`, `file:`, absolute paths, or relative paths. Bare HTTPS/HTTP git URLs fell through to `return undefined`, so `collectSettingsPackageRoots` skipped them.

## Fix

Add a fallback that reuses the existing `parseGitPackagePath` helper for bare HTTPS/HTTP git URLs, mapping them to the same git cache directory (`~/.pi/agent/git/<host>/<repo>`) as `git:` prefixed sources. The fallback also handles SSH-style URLs such as `git@host:repo.git`.

This is an additive change that only activates for strings that previously returned `undefined`; existing `git:`, `npm:`, and path sources are unaffected.

## Verification

- `npm run typecheck` passes.
- Added regression test `test/unit/package-agent-git-url-discovery.test.ts` which asserts that an agent from a package installed via `https://github.com/...` is discovered.
- Manually verified that all 21 `gsd-*` agents from `https://github.com/trancikk/gsd-package.git` are now discovered.

## Test notes

Running the full unit suite on Windows shows several unrelated pre-existing failures (symlink permission errors and package-agent management tests that also fail on clean `main`). This change does not introduce new failures.
