### PR TITLE
fix: trust recorded workflow session previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Preview runtime-recorded workflow child sessions in Fleet and inspect without trusting sibling transcripts. Thanks to [@JHa13y](https://github.com/JHa13y) for #1441.
 - Keep inline workflow children resumable from their foreground runs without mistaking a missing async directory for lost state. Thanks to [@lancegui](https://github.com/lancegui) for #1442.
 - Resolve package subagents from bare HTTP(S) Git URLs stored in Pi settings. Thanks to [@trancikk](https://github.com/trancikk) for #1452.
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -24,6 +24,7 @@ import { clearRuntimeAgentsForPi, listRuntimeAgentConfigs, mergeRuntimeAgents } 
 import { ensureAccessibleDir } from "../shared/accessible-dir.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
+import { getAgentDir } from "../shared/utils.ts";
 import { currentCompletionOwnerId } from "../shared/completion-owner.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
 import { clearLegacyResultAnimationTimer, renderSubagentResult, renderSubagentSummary } from "../tui/render.ts";
@@ -848,6 +849,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		goalTurnId = 0;
 		state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
 		state.parentSessionFile = ctx.sessionManager.getSessionFile();
+		state.trustedSessionFileRoot = state.parentSessionFile ? path.join(getAgentDir(), "sessions") : undefined;
 		state.trustedSessionRoots = [...new Set([
 			...(config.defaultSessionDir ? [path.resolve(expandTilde(config.defaultSessionDir))] : []),
 			...(state.parentSessionFile ? [getSubagentSessionRoot(state.parentSessionFile)] : []),

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -18,6 +18,7 @@ import { readStatus } from "../../shared/utils.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { contextModeLabel, summarizeContextModes } from "../shared/context-mode.ts";
 import { formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
+import { isTrustedRecordedSessionFile } from "../../shared/session-file-trust.ts";
 
 const DEFAULT_TRANSCRIPT_LINES = 80;
 const MAX_TRANSCRIPT_LINES = 500;
@@ -43,6 +44,8 @@ interface TranscriptOptions {
 	index?: number;
 	lines?: number;
 	sessionRoots?: string[];
+	trustedSessionFiles?: string[];
+	trustedSessionFileRoot?: string;
 }
 
 interface TextTailResult {
@@ -120,10 +123,13 @@ function readTextTail(filePath: string, maxLines: number): TextTailResult {
 	}
 }
 
-function readContainedTextTail(filePath: string, maxLines: number, trustedRoots: string[], label: string): TextTailResult {
-	if (trustedRoots.length === 0) return { path: filePath, lines: [], truncated: false, error: `Refusing to read ${label} transcript path without a trusted root: ${filePath}` };
+function readContainedTextTail(filePath: string, maxLines: number, trustedRoots: string[], label: string, trustedFiles: string[] = [], trustedFileRoot?: string): TextTailResult {
+	if (trustedRoots.length === 0 && (!trustedFileRoot || trustedFiles.length === 0)) return { path: filePath, lines: [], truncated: false, error: `Refusing to read ${label} transcript path without a trusted root: ${filePath}` };
 	const resolvedPath = path.resolve(filePath);
-	if (!trustedRoots.some((root) => pathWithin(root, resolvedPath))) {
+	const recordedCandidate = trustedFileRoot
+		&& pathWithin(trustedFileRoot, resolvedPath)
+		&& trustedFiles.some((file) => path.resolve(file) === resolvedPath);
+	if (!trustedRoots.some((root) => pathWithin(root, resolvedPath)) && !recordedCandidate) {
 		return { path: filePath, lines: [], truncated: false, error: `Refusing to read ${label} transcript path outside trusted roots: ${filePath}` };
 	}
 	let lstat: fs.Stats;
@@ -143,7 +149,7 @@ function readContainedTextTail(filePath: string, maxLines: number, trustedRoots:
 	} catch (error) {
 		return { path: filePath, lines: [], truncated: false, error: getErrorMessage(error) };
 	}
-	if (!realRoots.some((root) => pathWithin(root, realPath))) {
+	if (!realRoots.some((root) => pathWithin(root, realPath)) && !isTrustedRecordedSessionFile(realPath, trustedFiles, trustedFileRoot)) {
 		return { path: filePath, lines: [], truncated: false, error: `Refusing to read ${label} transcript path outside trusted roots: ${filePath}` };
 	}
 	return readTextTail(resolvedPath, maxLines);
@@ -213,8 +219,8 @@ function sessionMessageLine(record: unknown): string | undefined {
 
 /** Structured session tail: parsed content parts, newest last, bounded by
  *  maxMessages. Same trusted-root containment as the prose transcript tail. */
-export function readSessionMessagesTail(sessionFile: string, maxMessages: number, trustedRoots: string[]): { messages: SessionTranscriptMessage[]; warnings: string[]; truncated: boolean } {
-	const tail = readContainedTextTail(sessionFile, Math.max(maxMessages * 4, maxMessages), trustedRoots, "session");
+export function readSessionMessagesTail(sessionFile: string, maxMessages: number, trustedRoots: string[], trustedFiles: string[] = [], trustedFileRoot?: string): { messages: SessionTranscriptMessage[]; warnings: string[]; truncated: boolean } {
+	const tail = readContainedTextTail(sessionFile, Math.max(maxMessages * 4, maxMessages), trustedRoots, "session", trustedFiles, trustedFileRoot);
 	const warnings: string[] = [];
 	if (tail.error) warnings.push(`Session read failed for ${sessionFile}: ${tail.error}`);
 	const parsedMessages: SessionTranscriptMessage[] = [];
@@ -235,8 +241,8 @@ export function readSessionMessagesTail(sessionFile: string, maxMessages: number
 	return { messages, warnings, truncated: tail.truncated || parsedMessages.length > messages.length };
 }
 
-function readSessionTranscriptTail(sessionFile: string, maxLines: number, trustedRoots: string[]): { lines: string[]; warnings: string[] } {
-	const tail = readContainedTextTail(sessionFile, Math.max(maxLines * 4, maxLines), trustedRoots, "session");
+function readSessionTranscriptTail(sessionFile: string, maxLines: number, trustedRoots: string[], trustedFiles: string[] = [], trustedFileRoot?: string): { lines: string[]; warnings: string[] } {
+	const tail = readContainedTextTail(sessionFile, Math.max(maxLines * 4, maxLines), trustedRoots, "session", trustedFiles, trustedFileRoot);
 	const warnings: string[] = [];
 	if (tail.error) warnings.push(`Session read failed for ${sessionFile}: ${tail.error}`);
 	const lines: string[] = [];
@@ -523,7 +529,7 @@ export function formatAsyncRunTranscript(status: AsyncStatus, asyncDir: string, 
 		transcriptSource = "Recent output from status.json";
 	}
 	if (transcriptLines.length === 0 && sessionFile) {
-		const sessionTail = readSessionTranscriptTail(sessionFile, lineLimit, options.sessionRoots ?? []);
+		const sessionTail = readSessionTranscriptTail(sessionFile, lineLimit, options.sessionRoots ?? [], options.trustedSessionFiles, options.trustedSessionFileRoot);
 		transcriptLines = sessionTail.lines;
 		warnings.push(...sessionTail.warnings);
 		if (transcriptLines.length > 0) transcriptSource = `Session transcript tail from ${sessionFile}`;
@@ -554,7 +560,7 @@ export function formatNestedRunTranscript(run: NestedRunSummary, options: Transc
 		appendTranscriptBody(lines, "Transcript tail", [], false);
 		return safeTranscriptLines(lines);
 	}
-	const sessionTail = readSessionTranscriptTail(run.sessionFile, lineLimit, options.sessionRoots ?? []);
+	const sessionTail = readSessionTranscriptTail(run.sessionFile, lineLimit, options.sessionRoots ?? [], options.trustedSessionFiles, options.trustedSessionFileRoot);
 	if (sessionTail.warnings.length) {
 		lines.push("Warnings:");
 		for (const warning of sessionTail.warnings) lines.push(`  ${warning}`);

--- a/src/runs/background/inspect-rpc.ts
+++ b/src/runs/background/inspect-rpc.ts
@@ -218,19 +218,19 @@ function readOutputArtifact(outputPath: string): { output?: string; errorText?: 
 	}
 }
 
-function readSessionBackedOutput(sessionPath: string, trustedRoots: string[]): { output?: string } {
-	if (trustedRoots.length === 0) return {};
+function readSessionBackedOutput(sessionPath: string, trustedRoots: string[], trustedSessionFileRoot?: string): { output?: string } {
+	if (trustedRoots.length === 0 && !trustedSessionFileRoot) return {};
 	// The archive retains the child's session file as its output record. The
 	// final answer is the terminal assistant message's text — all text parts
 	// of that one session record, not just the last part.
-	const tail = readSessionMessagesTail(sessionPath, MAX_MESSAGE_LINES, trustedRoots);
+	const tail = readSessionMessagesTail(sessionPath, MAX_MESSAGE_LINES, trustedRoots, [sessionPath], trustedSessionFileRoot);
 	const last = tail.messages.findLast((message) => message.role === "assistant" && message.kind === "text");
 	if (!last) return {};
 	const parts = tail.messages.filter((message) => message.recordIndex === last.recordIndex && message.kind === "text");
 	return { output: parts.map((part) => part.text).join("\n") };
 }
 
-function readResultOutput(resultsDir: string, sessionId: string, runId: string, stepIndex: number | undefined, trustedRoots: string[], stepAgent: string | undefined, now: () => number): { output?: string; errorText?: string } {
+function readResultOutput(resultsDir: string, sessionId: string, runId: string, stepIndex: number | undefined, trustedRoots: string[], stepAgent: string | undefined, now: () => number, trustedSessionFileRoot?: string): { output?: string; errorText?: string } {
 	const resultPath = resultPayloadPathForSessionRun(resultsDir, sessionId, runId);
 	if (resultPath) return resultOutput(JSON.parse(fs.readFileSync(resultPath, "utf-8")) as unknown, stepIndex);
 	// Read the raw record first: readCompletionReplay best-effort deletes
@@ -284,7 +284,7 @@ function readResultOutput(resultsDir: string, sessionId: string, runId: string, 
 	if (artifactPath) return readOutputArtifact(artifactPath);
 	const sessionEntry = archive?.entries.find((entry) => entry.source === "session" && matches(entry));
 	const sessionPath = sessionEntry?.source === "session" ? sessionEntry.path : undefined;
-	if (sessionPath) return readSessionBackedOutput(sessionPath, trustedRoots);
+	if (sessionPath) return readSessionBackedOutput(sessionPath, trustedRoots, trustedSessionFileRoot);
 	const output = archive?.entries.find((entry) => entry.source === "result-tail" && matches(entry))?.text;
 	return output ? { output } : {};
 }
@@ -377,8 +377,8 @@ export function buildInspectReply(request: InspectRequest, deps: InspectDeps = {
 
 		let messages: InspectReplyMessage[] | undefined;
 		let task: string | undefined;
-		if (sessionFile && trustedRoots.length > 0) {
-			const tail = readSessionMessagesTail(sessionFile, lineLimit, trustedRoots);
+		if (sessionFile && (trustedRoots.length > 0 || deps.state?.trustedSessionFileRoot)) {
+			const tail = readSessionMessagesTail(sessionFile, lineLimit, trustedRoots, [sessionFile], deps.state?.trustedSessionFileRoot);
 			if (tail.messages.length > 0) {
 				messages = tail.messages.map(toReplyMessage);
 				// The delegated task is the child session's first user message, but
@@ -393,7 +393,7 @@ export function buildInspectReply(request: InspectRequest, deps: InspectDeps = {
 			}
 		}
 
-		const result = readResultOutput(resultsDir, currentSessionId, node.status.runId, node.stepIndex, trustedRoots, step?.agent, deps.now ?? Date.now);
+		const result = readResultOutput(resultsDir, currentSessionId, node.status.runId, node.stepIndex, trustedRoots, step?.agent, deps.now ?? Date.now, deps.state?.trustedSessionFileRoot);
 		const failedText = step?.error ?? node.status.error;
 		if (result.output === undefined && result.errorText === undefined && failedText !== undefined) {
 			return errorReply(request, "internal", "Inspection could not read the async run artifacts.");

--- a/src/shared/session-file-trust.ts
+++ b/src/shared/session-file-trust.ts
@@ -1,0 +1,19 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+function pathWithin(base: string, candidate: string): boolean {
+	const resolvedBase = path.resolve(base);
+	const resolvedCandidate = path.resolve(candidate);
+	return resolvedCandidate === resolvedBase || resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`);
+}
+
+export function isTrustedRecordedSessionFile(realPath: string, recordedFiles: string[], sessionsBase: string | undefined): boolean {
+	if (!sessionsBase || recordedFiles.length === 0) return false;
+	try {
+		const realSessionsBase = fs.realpathSync(sessionsBase);
+		if (!pathWithin(realSessionsBase, realPath)) return false;
+		return recordedFiles.some((file) => fs.realpathSync(path.resolve(file)) === realPath);
+	} catch {
+		return false;
+	}
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1846,6 +1846,8 @@ export interface SubagentState {
 	parentSessionFile?: string | null;
 	/** Extension-owned roots trusted for child session transcript reads. */
 	trustedSessionRoots?: string[];
+	/** Pi sessions base that caps exact runtime-recorded session file trust. */
+	trustedSessionFileRoot?: string;
 	/** Live async session roots created by this parent executor, keyed by run id. */
 	liveAsyncSessionRoots?: Map<string, string>;
 	/** Last valid parent session model observed for this session; used when continuation contexts omit ctx.model. */

--- a/src/tui/fleet-transcript.ts
+++ b/src/tui/fleet-transcript.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { getLanguageFromPath, highlightCode, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Markdown, truncateToWidth, visibleWidth, wrapTextWithAnsi, type MarkdownTheme } from "@earendil-works/pi-tui";
 import { safeTerminalText as safeDisplayText } from "../shared/display-text.ts";
+import { isTrustedRecordedSessionFile } from "../shared/session-file-trust.ts";
 
 const DEFAULT_MAX_RECORDS = 240;
 const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
@@ -61,6 +62,8 @@ export interface FleetTranscript {
 
 interface FleetTranscriptReadOptions {
 	trustedRoots: string[];
+	trustedFiles?: string[];
+	trustedFileRoot?: string;
 	maxRecords?: number;
 	maxBytes?: number;
 }
@@ -109,10 +112,13 @@ function isNotFoundError(error: unknown): boolean {
 	return Boolean(objectValue(error)?.code === "ENOENT");
 }
 
-function validateTranscriptPath(filePath: string, trustedRoots: string[]): { resolvedPath?: string; warning?: string } {
-	if (trustedRoots.length === 0) return { warning: `Transcript preview has no trusted root: ${filePath}` };
+function validateTranscriptPath(filePath: string, trustedRoots: string[], trustedFiles: string[] = [], trustedFileRoot?: string): { resolvedPath?: string; warning?: string } {
+	if (trustedRoots.length === 0 && (!trustedFileRoot || trustedFiles.length === 0)) return { warning: `Transcript preview has no trusted root: ${filePath}` };
 	const resolvedPath = path.resolve(filePath);
-	if (!trustedRoots.some((root) => pathWithin(root, resolvedPath))) {
+	const recordedCandidate = trustedFileRoot
+		&& pathWithin(trustedFileRoot, resolvedPath)
+		&& trustedFiles.some((file) => path.resolve(file) === resolvedPath);
+	if (!trustedRoots.some((root) => pathWithin(root, resolvedPath)) && !recordedCandidate) {
 		return { warning: `Transcript is outside trusted roots: ${filePath}` };
 	}
 	let stat: fs.Stats;
@@ -129,7 +135,7 @@ function validateTranscriptPath(filePath: string, trustedRoots: string[]): { res
 		const realRoots = trustedRoots
 			.filter((root) => fs.existsSync(root))
 			.map((root) => fs.realpathSync(root));
-		if (!realRoots.some((root) => pathWithin(root, realPath))) {
+		if (!realRoots.some((root) => pathWithin(root, realPath)) && !isTrustedRecordedSessionFile(realPath, trustedFiles, trustedFileRoot)) {
 			return { warning: `Transcript resolves outside trusted roots: ${filePath}` };
 		}
 		return { resolvedPath: realPath };
@@ -335,7 +341,7 @@ function parseTranscriptLines(lines: string[], conversationStarted = false): { e
 }
 
 export function readFleetTranscript(filePath: string, options: FleetTranscriptReadOptions): FleetTranscript {
-	const validated = validateTranscriptPath(filePath, options.trustedRoots);
+	const validated = validateTranscriptPath(filePath, options.trustedRoots, options.trustedFiles, options.trustedFileRoot);
 	if (!validated.resolvedPath) {
 		return { path: filePath, events: [], truncated: false, ...(validated.warning ? { warning: safeDisplayText(validated.warning) } : {}) };
 	}

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -547,6 +547,8 @@ function asyncDetail(item: Extract<FleetItem, { kind: "async" }>, state: Subagen
 			index: item.index,
 			lines: TRANSCRIPT_LINES,
 			sessionRoots: uniquePaths([...(state.trustedSessionRoots ?? []), trackedJob?.sessionRoot]),
+			trustedSessionFiles: [item.step?.sessionFile ?? item.run.sessionFile].filter((value): value is string => Boolean(value)),
+			trustedSessionFileRoot: state.trustedSessionFileRoot,
 		}).split("\n");
 		if (status.mode === "workflow" && item.index === undefined) {
 			const progress = workflowProgressLines((status.steps ?? item.run.steps) as AsyncJobStep[]);
@@ -628,7 +630,7 @@ function fleetArtifactsRoot(state: SubagentState, cwd: string): string {
 	);
 }
 
-function transcriptTarget(item: FleetItem, state: SubagentState): { path: string; trustedRoots: string[] } | undefined {
+function transcriptTarget(item: FleetItem, state: SubagentState): { path: string; trustedRoots: string[]; trustedFiles?: string[]; trustedFileRoot?: string } | undefined {
 	if (item.kind === "external") return undefined;
 	if (item.kind === "foreground-active") {
 		const artifactsRoot = fleetArtifactsRoot(state, item.control.cwd ?? state.baseCwd);
@@ -651,10 +653,12 @@ function transcriptTarget(item: FleetItem, state: SubagentState): { path: string
 		};
 	}
 	const step = item.step ?? (item.run.steps.length === 1 ? item.run.steps[0] : undefined);
-	if (!step?.transcriptPath) return undefined;
-	const transcriptPath = path.isAbsolute(step.transcriptPath)
-		? step.transcriptPath
-		: path.resolve(item.run.asyncDir, step.transcriptPath);
+	const recordedSessionFile = step?.sessionFile ?? item.run.sessionFile;
+	const recordedPath = step?.transcriptPath ?? recordedSessionFile;
+	if (!recordedPath) return undefined;
+	const transcriptPath = path.isAbsolute(recordedPath)
+		? recordedPath
+		: path.resolve(item.run.asyncDir, recordedPath);
 	const trackedJob = state.fleetJobs?.get(item.runId) ?? state.asyncJobs.get(item.runId);
 	return {
 		path: transcriptPath,
@@ -664,6 +668,7 @@ function transcriptTarget(item: FleetItem, state: SubagentState): { path: string
 			trackedJob?.cwd ? fleetArtifactsRoot(state, trackedJob.cwd) : undefined,
 			item.run.sessionFile ? getArtifactsDir(item.run.sessionFile, item.run.cwd ?? state.baseCwd, state.artifactDirPreference) : undefined,
 		]),
+		...(!step?.transcriptPath && recordedSessionFile ? { trustedFiles: [recordedSessionFile], trustedFileRoot: state.trustedSessionFileRoot } : {}),
 	};
 }
 
@@ -1201,8 +1206,8 @@ export class SubagentFleetComponent implements Component {
 		});
 	}
 
-	private renderedTranscript(target: { path: string; trustedRoots: string[] }, width: number): { transcript: FleetTranscript; body: string[] } {
-		const fingerprint = `${target.trustedRoots.join("\0")}|${transcriptFingerprint(target.path)}`;
+	private renderedTranscript(target: { path: string; trustedRoots: string[]; trustedFiles?: string[]; trustedFileRoot?: string }, width: number): { transcript: FleetTranscript; body: string[] } {
+		const fingerprint = `${target.trustedRoots.join("\0")}|${target.trustedFiles?.join("\0") ?? ""}|${target.trustedFileRoot ?? ""}|${transcriptFingerprint(target.path)}`;
 		if (this.transcriptCache
 			&& this.transcriptCache.path === target.path
 			&& this.transcriptCache.fingerprint === fingerprint
@@ -1210,7 +1215,11 @@ export class SubagentFleetComponent implements Component {
 			&& this.transcriptCache.expandedTools === this.expandedTools) {
 			return { transcript: this.transcriptCache.transcript, body: [...this.transcriptCache.body] };
 		}
-		const transcript = readFleetTranscript(target.path, { trustedRoots: target.trustedRoots });
+		const transcript = readFleetTranscript(target.path, {
+			trustedRoots: target.trustedRoots,
+			...(target.trustedFiles ? { trustedFiles: target.trustedFiles } : {}),
+			...(target.trustedFileRoot ? { trustedFileRoot: target.trustedFileRoot } : {}),
+		});
 		const body = transcript.events.length > 0
 			? renderFleetTranscript(transcript, width, this.theme, this.markdownTheme, { expandedTools: this.expandedTools })
 			: [];

--- a/test/unit/fleet-transcript.test.ts
+++ b/test/unit/fleet-transcript.test.ts
@@ -363,7 +363,8 @@ describe("Fleet inspector structured transcript", () => {
 			assert.deepEqual(directLink.events, []);
 			assert.match(directLink.warning ?? "", /refused a symlink/);
 
-			const parentLink = readFleetTranscript(path.join(trustedRoot, "directory-link", path.basename(outsideTranscript)), { trustedRoots: [trustedRoot] });
+			const linkedPath = path.join(trustedRoot, "directory-link", path.basename(outsideTranscript));
+			const parentLink = readFleetTranscript(linkedPath, { trustedRoots: [trustedRoot], trustedFiles: [linkedPath], trustedFileRoot: trustedRoot });
 			assert.deepEqual(parentLink.events, []);
 			assert.match(parentLink.warning ?? "", /resolves outside trusted roots/);
 		} finally {
@@ -383,6 +384,33 @@ describe("Fleet inspector structured transcript", () => {
 		} finally {
 			fs.rmSync(trustedRoot, { recursive: true, force: true });
 			fs.rmSync(outsideRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("trusts only the recorded session file inside the Pi sessions base", () => {
+		const sessionsBase = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-recorded-session-"));
+		const outsideBase = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-recorded-outside-"));
+		try {
+			const projectDir = path.join(sessionsBase, "project");
+			fs.mkdirSync(projectDir);
+			const recorded = writeTranscript(projectDir, [{ recordType: "message", role: "assistant", text: "recorded child" }]);
+			const sibling = path.join(projectDir, "sibling.jsonl");
+			fs.copyFileSync(recorded, sibling);
+
+			const trusted = readFleetTranscript(recorded, { trustedRoots: [], trustedFiles: [recorded], trustedFileRoot: sessionsBase });
+			assert.equal(trusted.events.find((event) => event.kind === "assistant")?.text, "recorded child");
+
+			const refused = readFleetTranscript(sibling, { trustedRoots: [], trustedFiles: [recorded], trustedFileRoot: sessionsBase });
+			assert.deepEqual(refused.events, []);
+			assert.match(refused.warning ?? "", /outside trusted roots/);
+
+			const outside = writeTranscript(outsideBase, [{ recordType: "message", role: "assistant", text: "outside" }]);
+			const outsideRefused = readFleetTranscript(outside, { trustedRoots: [], trustedFiles: [outside], trustedFileRoot: sessionsBase });
+			assert.deepEqual(outsideRefused.events, []);
+			assert.match(outsideRefused.warning ?? "", /outside trusted roots/);
+		} finally {
+			fs.rmSync(sessionsBase, { recursive: true, force: true });
+			fs.rmSync(outsideBase, { recursive: true, force: true });
 		}
 	});
 

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -978,6 +978,44 @@ describe("native subagent fleet", () => {
 		}
 	});
 
+	it("previews an exact runtime-recorded workflow session under the Pi sessions base", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-recorded-session-"));
+		try {
+			const asyncDir = writeAsyncRun(root, { id: "async-recorded-session" });
+			const sessionsBase = path.join(root, "sessions");
+			const projectDir = path.join(sessionsBase, "project");
+			fs.mkdirSync(projectDir, { recursive: true });
+			const sessionFile = path.join(projectDir, "workflow-child.jsonl");
+			fs.writeFileSync(sessionFile, `${JSON.stringify({ role: "assistant", content: "RECORDED WORKFLOW SESSION" })}\n`, "utf-8");
+			const statusPath = path.join(asyncDir, "status.json");
+			const status = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as { sessionFile?: string; steps?: Array<{ sessionFile?: string; transcriptPath?: string }> };
+			status.sessionFile = sessionFile;
+			status.steps![0]!.sessionFile = sessionFile;
+			delete status.steps![0]!.transcriptPath;
+			fs.writeFileSync(statusPath, JSON.stringify(status, null, 2), "utf-8");
+
+			const state = stateForTest();
+			state.trustedSessionRoots = [];
+			state.trustedSessionFileRoot = sessionsBase;
+			const component = new SubagentFleetComponent(
+				{ terminal: { rows: 32, columns: 100 }, requestRender() {} } as never,
+				theme as never,
+				state,
+				() => {},
+				{ asyncDirRoot: root, resultsDir: path.join(root, "results"), refreshMs: 60_000 },
+			);
+			try {
+				const rendered = component.render(100).join("\n");
+				assert.match(rendered, /RECORDED WORKFLOW SESSION/);
+				assert.doesNotMatch(rendered, /without a trusted root|Session read failed/);
+			} finally {
+				component.dispose();
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("renders structured tool activity and assistant Markdown when a child transcript is available", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-structured-"));
 		try {

--- a/test/unit/inspect-rpc.test.ts
+++ b/test/unit/inspect-rpc.test.ts
@@ -146,6 +146,27 @@ describe("inspect-rpc resolution and ownership", () => {
 });
 
 describe("inspect-rpc reply content", () => {
+	it("reads an exact runtime-recorded session under the Pi sessions base", () => {
+		const sessionsBase = fs.mkdtempSync(path.join(os.tmpdir(), "pi-inspect-recorded-session-"));
+		const root = path.join(sessionsBase, "project");
+		try {
+			fs.mkdirSync(root);
+			const { resultsDir } = makeRun(root, {
+				runId: "run-recorded",
+				sessionMessages: [userMessage("recorded task"), assistantMessage("recorded answer")],
+				resultPayload: { summary: "done", results: [{ agent: "worker", output: "recorded answer", success: true }] },
+			});
+			const state = makeState(path.join(sessionsBase, "unrelated"));
+			state.trustedSessionFileRoot = sessionsBase;
+			const reply = buildInspectReply({ requestId: "r-recorded", asyncId: "run-recorded" }, makeDeps(root, resultsDir, state));
+			assert.equal(reply.error, undefined);
+			assert.equal(reply.task, "recorded task");
+			assert.equal(reply.messages?.at(-1)?.text, "recorded answer");
+		} finally {
+			fs.rmSync(sessionsBase, { recursive: true, force: true });
+		}
+	});
+
 	it("returns task, messages, and final output without leaking paths", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-inspect-full-"));
 		const sessionFile = path.join(root, "run-1-session.jsonl");


### PR DESCRIPTION
Fixes #1441.

This adds exact-file trust for runtime-recorded workflow child session previews. The read remains capped to Pi's sessions base or existing trusted roots, and it does not grant directory trust, add config, move sessions, or change resume/write authority paths.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/fleet-transcript.test.ts test/unit/fleet.test.ts test/unit/inspect-rpc.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh review: no issues found
