### PR TITLE
feat: show live context window usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 - Expose a bounded, versioned workflow-child summary across workflow results, status, receipts, and completion replay. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #1453.
+- Show live context-window usage separately from cumulative token spend in status and Fleet views. Thanks to [@nazzeDe](https://github.com/nazzeDe) for #1444.
 - Add `modelExclusions.defaultTtlMs` configuration for controlling the lifetime of model exclusions, including shorter limits for active cached entries, with launch diagnostics for excluded candidates. Thanks to [@mithyer](https://github.com/mithyer) for #1439 and #1438.
 - Add code-owned `cursor-agent` read-only and `cursor-agent-writer` workspace-writing profiles with private prompt-file handoff, bounded stream-JSON terminal proof, and opt-in mode-specific smoke evidence.
 - Add code-owned `claude-code` read-only and `claude-code-writer` file-editing profiles for an existing authenticated CLI with trusted user settings, bounded stream-JSON result proof, and opt-in mode-specific smoke evidence.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -40,7 +40,7 @@ To inspect one background child in text, use `subagent({ action: "status", id: "
 In the TUI, a persistent FleetView below the editor keeps active work visible as a compact summary. Set `fleetViewPlacement` to `"aboveEditor"` to move it above the editor.
 
 ```text
-2 active agents · 1 pane · ↓ 4.2k tokens · ↓/← to inspect
+2 active agents · 1 pane · ↓ 3.1k window · 4.2k spent · ↓/← to inspect
 ```
 
 After you expand it:
@@ -49,11 +49,11 @@ After you expand it:
 ↑↓/jk select · enter inspect · esc back
 
 > main
-    scout · running                  1m 12s · ↓ 2.8k tokens
-    reviewer · running                 38s · ↓ 1.4k tokens
+    scout · running         1m 12s · ↓ 2.0k window · 2.8k spent
+    reviewer · running        38s · ↓ 1.1k window · 1.4k spent
 ```
 
-When the focused editor is empty, press `↓` or `←` to expand the summary into `main` plus active children with agent name, state, elapsed time, and token totals. The compact line counts active current-session work and Herdr project panes. Then use `↑`/`↓` or `j`/`k` to select a child and `Enter` to inspect it. Printable navigation keys are never intercepted before activation.
+When the focused editor is empty, press `↓` or `←` to expand the summary into `main` plus active children with agent name, state, elapsed time, and token usage. When providers report usage, `window` is the latest assistant turn's input plus cache-read tokens, while `spent` keeps the cumulative input-plus-output total. Old run artifacts without window data keep the existing token-total label. The compact line counts active current-session work and Herdr project panes. Then use `↑`/`↓` or `j`/`k` to select a child and `Enter` to inspect it. Printable navigation keys are never intercepted before activation.
 
 FleetView replaces the legacy above-editor async widget by default. Successful background completions stay quiet so inactive Pi tabs are not marked unread, while failed or paused completions still notify the originating session. Parallel runs show every active child independently. Chains with parallel groups keep their grouped shape in progress and results, so failed or paused agents stay visible next to completed ones. When a child is explicitly allowed to fan out with `tools: subagent`, its nested runs appear under that parent child in the main status tree instead of being hidden inside the child process.
 

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -11,6 +11,7 @@ import {
 	type AsyncJobStep,
 	type Details,
 	type SubagentState,
+	type TokenUsage,
 	DIRS,
 	SUBAGENT_ASYNC_COMPLETE_EVENT,
 	SUBAGENT_CHILD_STATUS_EVENT,
@@ -97,7 +98,7 @@ export interface SubagentRpcFleetEntry {
 	model?: string;
 	effort?: string;
 	startedAt: number;
-	tokens: { input: number; output: number; total: number };
+	tokens: TokenUsage;
 	goal?: string;
 }
 
@@ -122,7 +123,7 @@ function displayText(value: unknown, maxLength: number): string | undefined {
 	return normalized ? truncateDisplayText(normalized, maxLength) : undefined;
 }
 
-function publicTokens(value: unknown): { input: number; output: number; total: number } {
+function publicTokens(value: unknown): TokenUsage {
 	const record = isRecord(value) ? value : {};
 	const count = (field: "input" | "output" | "total") => {
 		const raw = record[field];
@@ -133,7 +134,21 @@ function publicTokens(value: unknown): { input: number; output: number; total: n
 	const input = count("input");
 	const output = count("output");
 	const sum = Math.min(Number.MAX_SAFE_INTEGER, input + output);
-	return { input, output, total: Math.max(sum, count("total")) };
+	const optionalCount = (field: "window" | "windowPeak") => {
+		const raw = record[field];
+		return typeof raw === "number" && Number.isFinite(raw) && raw >= 0
+			? Math.min(Number.MAX_SAFE_INTEGER, Math.floor(raw))
+			: undefined;
+	};
+	const window = optionalCount("window");
+	const windowPeak = optionalCount("windowPeak");
+	return {
+		input,
+		output,
+		total: Math.max(sum, count("total")),
+		...(window !== undefined ? { window } : {}),
+		...(windowPeak !== undefined ? { windowPeak } : {}),
+	};
 }
 
 function activeState(value: unknown): boolean {
@@ -188,7 +203,7 @@ function buildFleetStatus(
 				model: child.model,
 				effort: child.thinking,
 				startedAt: child.startedAt,
-				tokens: { input: child.inputTokens ?? 0, output: child.outputTokens ?? 0, total: child.tokens ?? 0 },
+				tokens: { input: child.inputTokens ?? 0, output: child.outputTokens ?? 0, total: child.tokens ?? 0, ...(child.window !== undefined ? { window: child.window } : {}), ...(child.windowPeak !== undefined ? { windowPeak: child.windowPeak } : {}) },
 			});
 		} else {
 			addCandidate({
@@ -197,7 +212,7 @@ function buildFleetStatus(
 				model: control.model,
 				effort: control.thinking,
 				startedAt: control.startedAt,
-				tokens: { input: control.inputTokens ?? 0, output: control.outputTokens ?? 0, total: control.tokens ?? 0 },
+				tokens: { input: control.inputTokens ?? 0, output: control.outputTokens ?? 0, total: control.tokens ?? 0, ...(control.window !== undefined ? { window: control.window } : {}), ...(control.windowPeak !== undefined ? { windowPeak: control.windowPeak } : {}) },
 			});
 		}
 	}

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -500,6 +500,7 @@ interface ChildUsage {
 	output?: number;
 	outputTokens?: number;
 	cacheRead?: number;
+	cacheReadTokens?: number;
 	cacheWrite?: number;
 	cost?: { total?: number };
 }
@@ -3585,12 +3586,13 @@ async function runSubagent(
 			if (usage) {
 				const input = usage.input ?? usage.inputTokens ?? 0;
 				const output = usage.output ?? usage.outputTokens ?? 0;
+				const window = input + (usage.cacheRead ?? usage.cacheReadTokens ?? 0);
 				const previousInput = step.tokens?.input ?? 0;
 				const previousOutput = step.tokens?.output ?? 0;
-				step.tokens = { input: previousInput + input, output: previousOutput + output, total: previousInput + previousOutput + input + output };
+				step.tokens = { input: previousInput + input, output: previousOutput + output, total: previousInput + previousOutput + input + output, window, windowPeak: Math.max(step.tokens?.windowPeak ?? 0, window) };
 				const totalInput = statusPayload.totalTokens?.input ?? 0;
 				const totalOutput = statusPayload.totalTokens?.output ?? 0;
-				statusPayload.totalTokens = { input: totalInput + input, output: totalOutput + output, total: totalInput + totalOutput + input + output };
+				statusPayload.totalTokens = { input: totalInput + input, output: totalOutput + output, total: totalInput + totalOutput + input + output, window, windowPeak: Math.max(statusPayload.totalTokens?.windowPeak ?? 0, window) };
 				refreshUsageBudget();
 			}
 			statusPayload.turnCount = Math.max(statusPayload.turnCount ?? 0, step.turnCount);
@@ -4649,13 +4651,21 @@ async function runSubagent(
 					const sessionTokens = config.sessionDir
 						? parseSessionTokens(path.join(config.sessionDir, `parallel-${t}`))
 						: null;
-					const taskTokens = sessionTokens ?? tokenUsageFromAttempts(parallelResults[t]?.modelAttempts);
+					const fallbackTokens = tokenUsageFromAttempts(parallelResults[t]?.modelAttempts);
+					const observedTokens = requiredStatusStep(statusPayload, fi).tokens;
+					const taskTokens = sessionTokens ?? (fallbackTokens
+						? { ...fallbackTokens, ...(observedTokens?.window !== undefined ? { window: observedTokens.window } : {}), ...(observedTokens?.windowPeak !== undefined ? { windowPeak: observedTokens.windowPeak } : {}) }
+						: null);
 					if (!taskTokens) continue;
 					requiredStatusStep(statusPayload, fi).tokens = taskTokens;
 					previousCumulativeTokens = {
 						input: previousCumulativeTokens.input + taskTokens.input,
 						output: previousCumulativeTokens.output + taskTokens.output,
 						total: previousCumulativeTokens.total + taskTokens.total,
+						...(taskTokens.window !== undefined ? { window: taskTokens.window } : {}),
+						...(previousCumulativeTokens.windowPeak !== undefined || taskTokens.windowPeak !== undefined
+							? { windowPeak: Math.max(previousCumulativeTokens.windowPeak ?? 0, taskTokens.windowPeak ?? 0) }
+							: {}),
 					};
 				}
 				statusPayload.totalTokens = { ...previousCumulativeTokens };
@@ -4972,17 +4982,27 @@ async function runSubagent(
 						input: cumulativeTokens.input - previousCumulativeTokens.input,
 						output: cumulativeTokens.output - previousCumulativeTokens.output,
 						total: cumulativeTokens.total - previousCumulativeTokens.total,
+						...(cumulativeTokens.window !== undefined ? { window: cumulativeTokens.window } : {}),
+						...(cumulativeTokens.windowPeak !== undefined ? { windowPeak: cumulativeTokens.windowPeak } : {}),
 					}
 				: null;
 			if (cumulativeTokens) {
 				previousCumulativeTokens = cumulativeTokens;
 			} else {
-				stepTokens = tokenUsageFromAttempts(singleResult.modelAttempts);
+				const fallbackTokens = tokenUsageFromAttempts(singleResult.modelAttempts);
+				const observedTokens = requiredStatusStep(statusPayload, flatIndex).tokens;
+				stepTokens = fallbackTokens
+					? { ...fallbackTokens, ...(observedTokens?.window !== undefined ? { window: observedTokens.window } : {}), ...(observedTokens?.windowPeak !== undefined ? { windowPeak: observedTokens.windowPeak } : {}) }
+					: null;
 				if (stepTokens) {
 					previousCumulativeTokens = {
 						input: previousCumulativeTokens.input + stepTokens.input,
 						output: previousCumulativeTokens.output + stepTokens.output,
 						total: previousCumulativeTokens.total + stepTokens.total,
+						...(stepTokens.window !== undefined ? { window: stepTokens.window } : {}),
+						...(previousCumulativeTokens.windowPeak !== undefined || stepTokens.windowPeak !== undefined
+							? { windowPeak: Math.max(previousCumulativeTokens.windowPeak ?? 0, stepTokens.windowPeak ?? 0) }
+							: {}),
 					};
 				}
 			}

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -1079,6 +1079,7 @@ async function runSingleAttempt(
 					updateTurnBudget(result.usage.turns, terminalAssistantStop || terminalStructuredOutputCall, hasToolCall || Boolean(progress.currentTool));
 					const u = evt.message.usage;
 					if (u) {
+						const window = (u.input || 0) + (u.cacheRead || 0);
 						result.usage.input += u.input || 0;
 						result.usage.output += u.output || 0;
 						result.usage.cacheRead += u.cacheRead || 0;
@@ -1087,6 +1088,8 @@ async function runSingleAttempt(
 						progress.tokens = result.usage.input + result.usage.output;
 						progress.inputTokens = result.usage.input;
 						progress.outputTokens = result.usage.output;
+						progress.window = window;
+						progress.windowPeak = Math.max(progress.windowPeak ?? 0, window);
 					}
 					if (evt.message.model) {
 						progress.model = evt.message.model;

--- a/src/runs/foreground/foreground-control.ts
+++ b/src/runs/foreground/foreground-control.ts
@@ -27,6 +27,8 @@ function copyProgress(target: ForegroundChildControl, progress: AgentProgress | 
 	target.tokens = progress.tokens;
 	target.inputTokens = progress.inputTokens;
 	target.outputTokens = progress.outputTokens;
+	target.window = progress.window;
+	target.windowPeak = progress.windowPeak;
 	target.model = progress.model;
 	target.thinking = progress.thinking;
 	target.toolCount = progress.toolCount;
@@ -45,6 +47,8 @@ function syncCurrentChild(control: ForegroundRunControl, child: ForegroundChildC
 	control.tokens = child.tokens;
 	control.inputTokens = child.inputTokens;
 	control.outputTokens = child.outputTokens;
+	control.window = child.window;
+	control.windowPeak = child.windowPeak;
 	control.model = child.model;
 	control.thinking = child.thinking;
 	control.toolCount = child.toolCount;
@@ -65,6 +69,8 @@ function clearCurrentChild(control: ForegroundRunControl): void {
 	control.tokens = undefined;
 	control.inputTokens = undefined;
 	control.outputTokens = undefined;
+	control.window = undefined;
+	control.windowPeak = undefined;
 	control.model = undefined;
 	control.thinking = undefined;
 	control.toolCount = undefined;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -647,6 +647,8 @@ function foregroundChildActivityFromProgress(progress: SingleResult["progress"] 
 		...(progress?.currentPath ? { currentPath: progress.currentPath } : {}),
 		...(progress?.turnCount !== undefined ? { turnCount: progress.turnCount } : {}),
 		...(progress?.tokens !== undefined ? { tokens: progress.tokens } : {}),
+		...(progress?.window !== undefined ? { window: progress.window } : {}),
+		...(progress?.windowPeak !== undefined ? { windowPeak: progress.windowPeak } : {}),
 		...(progress?.toolCount !== undefined ? { toolCount: progress.toolCount } : {}),
 	};
 }

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -199,8 +199,10 @@ function sanitizeTokenUsage(value: unknown): NestedRunSummary["totalTokens"] | u
 	const input = clampNumber(raw.input);
 	const output = clampNumber(raw.output);
 	const total = clampNumber(raw.total);
+	const window = clampNumber(raw.window);
+	const windowPeak = clampNumber(raw.windowPeak);
 	return input !== undefined && output !== undefined && total !== undefined
-		? { input, output, total }
+		? { input, output, total, ...(window !== undefined ? { window } : {}), ...(windowPeak !== undefined ? { windowPeak } : {}) }
 		: undefined;
 }
 

--- a/src/runs/shared/nested-render.ts
+++ b/src/runs/shared/nested-render.ts
@@ -1,4 +1,4 @@
-import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../../shared/formatters.ts";
+import { formatDuration, formatModelThinking, formatTokenUsage, shortenPath } from "../../shared/formatters.ts";
 import { formatActivityLabel } from "../../shared/status-format.ts";
 import type { ActivityState, NestedRunSummary, NestedStepSummary } from "../../shared/types.ts";
 
@@ -68,7 +68,7 @@ function formatNestedActivity(input: {
 	if (input.currentPath) facts.push(shortenPath(input.currentPath));
 	if (input.turnCount !== undefined) facts.push(`${input.turnCount} turns`);
 	if (input.toolCount !== undefined) facts.push(`${input.toolCount} tools`);
-	if (input.totalTokens) facts.push(`${formatTokens(input.totalTokens.total)} tok`);
+	if (input.totalTokens) facts.push(formatTokenUsage(input.totalTokens));
 	const activity = formatActivityLabel(input.lastActivityAt, input.activityState as ActivityState | undefined);
 	return activity || facts.length ? [activity, ...facts].filter(Boolean).join(" | ") : undefined;
 }

--- a/src/shared/formatters.ts
+++ b/src/shared/formatters.ts
@@ -4,7 +4,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { Usage, SingleResult } from "./types.ts";
+import type { Usage, SingleResult, TokenUsage } from "./types.ts";
 import type { ChainStep } from "./settings.ts";
 import { isDynamicParallelStep, isParallelStep } from "./settings.ts";
 import { previewDisplayText, sanitizeDisplayText } from "./display-text.ts";
@@ -15,6 +15,12 @@ import { splitKnownThinkingSuffix, THINKING_LEVELS } from "./model-info.ts";
  */
 export function formatTokens(n: number): string {
 	return n < 1000 ? String(n) : n < 10000 ? `${(n / 1000).toFixed(1)}k` : `${Math.round(n / 1000)}k`;
+}
+
+export function formatTokenUsage(usage: TokenUsage, legacyLabel = "tok"): string {
+	return usage.window !== undefined
+		? `${formatTokens(usage.window)} window · ${formatTokens(usage.total)} spent`
+		: `${formatTokens(usage.total)} ${legacyLabel}`;
 }
 
 export function formatModelThinking(model?: string, thinking?: string): string {

--- a/src/shared/session-tokens.ts
+++ b/src/shared/session-tokens.ts
@@ -23,20 +23,31 @@ export function parseSessionTokens(sessionDir: string): TokenUsage | null {
 		const content = fs.readFileSync(sessionFile, "utf-8");
 		let input = 0;
 		let output = 0;
+		let window: number | undefined;
+		let windowPeak: number | undefined;
 		for (const line of content.split("\n")) {
 			if (!line.trim()) continue;
 			try {
 				const entry = JSON.parse(line);
 				const usage = entry.usage ?? entry.message?.usage;
 				if (usage) {
-					input += usage.inputTokens ?? usage.input ?? 0;
-					output += usage.outputTokens ?? usage.output ?? 0;
+					const inputValue = usage.inputTokens ?? usage.input;
+					const outputValue = usage.outputTokens ?? usage.output;
+					const cacheReadValue = usage.cacheReadTokens ?? usage.cacheRead;
+					const turnInput = typeof inputValue === "number" && Number.isFinite(inputValue) ? inputValue : 0;
+					const turnOutput = typeof outputValue === "number" && Number.isFinite(outputValue) ? outputValue : 0;
+					const cacheRead = typeof cacheReadValue === "number" && Number.isFinite(cacheReadValue) ? cacheReadValue : 0;
+					const turnWindow = turnInput + cacheRead;
+					input += turnInput;
+					output += turnOutput;
+					window = turnWindow;
+					windowPeak = Math.max(windowPeak ?? 0, turnWindow);
 				}
 			} catch {
 				// Ignore malformed lines while scanning usage entries.
 			}
 		}
-		return { input, output, total: input + output };
+		return { input, output, total: input + output, ...(window !== undefined ? { window, windowPeak } : {}) };
 	} catch {
 		// Usage extraction should not fail the run.
 		return null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -184,6 +184,10 @@ export interface TokenUsage {
 	input: number;
 	output: number;
 	total: number;
+	/** Input plus cache-read tokens for the latest assistant turn. */
+	window?: number;
+	/** Largest window observed in this usage scope. */
+	windowPeak?: number;
 }
 
 export type ActivityState = "active_long_running" | "needs_attention";
@@ -721,6 +725,8 @@ export interface AgentProgress {
 	thinking?: string;
 	inputTokens?: number;
 	outputTokens?: number;
+	window?: number;
+	windowPeak?: number;
 	durationMs: number;
 	error?: string;
 	failedTool?: string;
@@ -1730,6 +1736,8 @@ export interface ForegroundResumeChild {
 	currentPath?: string;
 	turnCount?: number;
 	tokens?: number;
+	window?: number;
+	windowPeak?: number;
 	toolCount?: number;
 	exitCode?: number;
 	error?: string;
@@ -1782,6 +1790,8 @@ export interface ForegroundChildControl {
 	tokens?: number;
 	inputTokens?: number;
 	outputTokens?: number;
+	window?: number;
+	windowPeak?: number;
 	model?: string;
 	thinking?: string;
 	toolCount?: number;
@@ -1817,6 +1827,8 @@ export interface ForegroundRunControl {
 	tokens?: number;
 	inputTokens?: number;
 	outputTokens?: number;
+	window?: number;
+	windowPeak?: number;
 	model?: string;
 	thinking?: string;
 	toolCount?: number;

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -25,6 +25,7 @@ type FleetStatusEntry = {
 	description?: string;
 	startedAt: number;
 	tokens: number;
+	window?: number;
 	state: string;
 	external?: true;
 	projectPane?: HerdrProjectPaneSnapshot;
@@ -39,6 +40,7 @@ type FleetWorkflowRow = {
 	activity?: string;
 	startedAt?: number;
 	tokens?: number;
+	window?: number;
 	overflow?: number;
 };
 
@@ -72,12 +74,15 @@ export function formatFleetElapsed(ms: number): string {
 	return `${Math.max(0, Math.round(ms / 1000))}s`;
 }
 
-export function formatFleetTokens(count: number): string {
-	let compact: string;
-	if (count >= 1_000_000) compact = `${(count / 1_000_000).toFixed(1)}M`;
-	else if (count >= 1_000) compact = `${(count / 1_000).toFixed(1)}k`;
-	else compact = `${Math.max(0, Math.round(count))}`;
-	return `↓ ${compact} tokens`;
+export function formatFleetTokens(count: number, window?: number): string {
+	const compact = (value: number): string => value >= 1_000_000
+		? `${(value / 1_000_000).toFixed(1)}M`
+		: value >= 1_000
+			? `${(value / 1_000).toFixed(1)}k`
+			: `${Math.max(0, Math.round(value))}`;
+	return window !== undefined
+		? `↓ ${compact(window)} window · ${compact(count)} spent`
+		: `↓ ${compact(count)} tokens`;
 }
 
 function rightAlign(left: string, right: string, width: number): string {
@@ -134,6 +139,7 @@ function workflowFleetRows(steps: AsyncJobStep[] | undefined): FleetWorkflowRow[
 			...(activity ? { activity } : {}),
 			...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),
 			...(step.tokens?.total !== undefined ? { tokens: step.tokens.total } : {}),
+			...(step.tokens?.window !== undefined ? { window: step.tokens.window } : {}),
 		};
 	});
 }
@@ -332,7 +338,8 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 					...(modelThinking ? { modelThinking } : {}),
 					description: foregroundDescription(control, child.description),
 					startedAt: child.startedAt,
-					tokens: child.tokens ?? 0,
+				tokens: child.tokens ?? 0,
+				...(child.window !== undefined ? { window: child.window } : {}),
 					state: "running",
 					...((control.nestedChildren?.filter((nested) => nested.parentStepIndex === child.index).length ?? 0) > 0
 						? { nestedChildren: control.nestedChildren!.filter((nested) => nested.parentStepIndex === child.index) }
@@ -350,6 +357,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 			description: foregroundDescription(control, control.description),
 			startedAt: control.startedAt,
 			tokens: control.tokens ?? 0,
+			...(control.window !== undefined ? { window: control.window } : {}),
 			state: "running",
 			...(control.nestedChildren?.length ? { nestedChildren: control.nestedChildren } : {}),
 		});
@@ -367,6 +375,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				description: latestEmit !== undefined ? `latest emit: ${latestEmit}` : job.description,
 				startedAt,
 				tokens: job.totalTokens?.total ?? 0,
+				...(job.totalTokens?.window !== undefined ? { window: job.totalTokens.window } : {}),
 				state: job.status,
 				...(job.steps?.length ? { workflowRows: workflowFleetRows(job.steps) } : {}),
 				...(job.nestedChildren?.length ? { nestedChildren: job.nestedChildren } : {}),
@@ -387,6 +396,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				description: job.description,
 				startedAt,
 				tokens: job.totalTokens?.total ?? 0,
+				...(job.totalTokens?.window !== undefined ? { window: job.totalTokens.window } : {}),
 				state: job.status,
 				...(job.nestedChildren?.length ? { nestedChildren: job.nestedChildren } : {}),
 			});
@@ -404,6 +414,9 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				description: step.description ?? job.description,
 				startedAt: step.startedAt ?? startedAt,
 				tokens: step.tokens?.total ?? (steps.length === 1 ? job.totalTokens?.total ?? 0 : 0),
+				...((step.tokens?.window ?? (steps.length === 1 ? job.totalTokens?.window : undefined)) !== undefined
+					? { window: step.tokens?.window ?? job.totalTokens?.window }
+					: {}),
 				state: step.status,
 				...((step.children?.length ?? 0) > 0
 					? { nestedChildren: step.children }
@@ -611,6 +624,10 @@ export class SubagentFleetStatus {
 			const workEntries = this.entries.filter((entry) => !entry.surface);
 			const projectEntries = this.entries.filter((entry) => entry.surface === "project-pane");
 			const tokens = workEntries.reduce((total, entry) => total + entry.tokens, 0);
+			const nativeEntries = workEntries.filter((entry) => !entry.external);
+			const window = nativeEntries.length > 0 && nativeEntries.every((entry) => entry.window !== undefined)
+				? nativeEntries.reduce((total, entry) => total + entry.window!, 0)
+				: undefined;
 			const capacity = this.state.activeAsyncCapacity;
 			const hasNativeRows = workEntries.some((entry) => !entry.external);
 			const showNativeSummary = hasNativeRows || Boolean(capacity?.used);
@@ -621,7 +638,7 @@ export class SubagentFleetStatus {
 			const paneAttention = projectEntries.filter((entry) => entry.projectPane && projectPaneNeedsAttention(entry.projectPane)).length;
 			const panes = projectEntries.length > 0 ? `${projectEntries.length} pane${projectEntries.length === 1 ? "" : "s"}${paneAttention ? ` (${paneAttention} ⚠)` : ""}` : "";
 			const label = [agents, asyncRuns, panes].filter(Boolean).join(" · ");
-			const detail = [showNativeSummary ? formatFleetTokens(tokens) : undefined, "↓/← to inspect"].filter(Boolean).join(" · ");
+			const detail = [showNativeSummary ? formatFleetTokens(tokens, window) : undefined, "↓/← to inspect"].filter(Boolean).join(" · ");
 			return [truncateToWidth(`  ${theme.fg("muted", label)}${label && detail ? " · " : ""}${theme.fg("dim", detail)}`, width)];
 		}
 		const roster = this.rosterKeys();
@@ -670,7 +687,7 @@ export class SubagentFleetStatus {
 		const elapsed = Date.now() - entry.startedAt;
 		const rightText = entry.projectPane
 			? `${entry.projectPane.summary ?? "—"} · ${formatFleetElapsed(Date.now() - entry.projectPane.refreshedAt)} ago`
-				: entry.external ? formatFleetElapsed(elapsed) : `${formatFleetElapsed(elapsed)} · ${formatFleetTokens(entry.tokens)}`;
+				: entry.external ? formatFleetElapsed(elapsed) : `${formatFleetElapsed(elapsed)} · ${formatFleetTokens(entry.tokens, entry.window)}`;
 		const right = theme.fg("dim", rightText);
 		return rightAlign(left, right, width);
 	}
@@ -695,7 +712,7 @@ export class SubagentFleetStatus {
 		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${theme.fg("muted", `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
 		const details = [
 			row.startedAt !== undefined ? formatFleetElapsed(Date.now() - row.startedAt) : undefined,
-			row.tokens !== undefined ? formatFleetTokens(row.tokens) : undefined,
+			row.tokens !== undefined ? formatFleetTokens(row.tokens, row.window) : undefined,
 		].filter(Boolean).join(" · ");
 		return truncateToWidth(`${left}${details ? theme.fg("dim", ` · ${details}`) : ""}`, width);
 	}

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -5,7 +5,7 @@ import { getMarkdownTheme, type ExtensionContext } from "@earendil-works/pi-codi
 import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type MarkdownTheme } from "@earendil-works/pi-tui";
 import { snapshotExternalRuns, type ExternalRun } from "../api/external-runs.ts";
 import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
-import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../shared/formatters.ts";
+import { formatDuration, formatModelThinking, formatTokens, formatTokenUsage, shortenPath } from "../shared/formatters.ts";
 import { DIRS, type AsyncJobState, type AsyncJobStep, type Details, type FleetKeybindingAction, type FleetKeybindingsConfig, type ForegroundChildControl, type ForegroundResumeChild, type ForegroundResumeRun, type ForegroundRunControl, type SubagentState } from "../shared/types.ts";
 import { decodeUtf8Tail } from "../shared/utf8.ts";
 import { readStatus } from "../shared/utils.ts";
@@ -403,7 +403,9 @@ function foregroundActiveDetail(item: Extract<FleetItem, { kind: "foreground-act
 		live.currentTool ? `Current tool: ${live.currentTool}${live.currentPath ? ` · ${shortenPath(live.currentPath)}` : ""}` : undefined,
 		live.turnCount !== undefined ? `Turns: ${live.turnCount}` : undefined,
 		live.toolCount !== undefined ? `Tools: ${live.toolCount}` : undefined,
-		live.tokens !== undefined ? `Tokens: ${formatTokens(live.tokens)}` : undefined,
+		live.tokens !== undefined
+			? `Tokens: ${formatTokenUsage({ input: live.inputTokens ?? 0, output: live.outputTokens ?? 0, total: live.tokens, ...(live.window !== undefined ? { window: live.window } : {}), ...(live.windowPeak !== undefined ? { windowPeak: live.windowPeak } : {}) }, "tokens")}`
+			: undefined,
 		promptAuditCount > 0 ? `Prompt audit: ${promptAuditCount} live · 3 views · p opens` : undefined,
 		"",
 		"Transcript",
@@ -533,7 +535,7 @@ function workflowProgressLines(steps: AsyncJobStep[] | undefined): string[] {
 		}
 		const activity = workflowStepActivity(row.step);
 		const context = contextModeLabel(row.step.context);
-		const details = [row.step.status, activity, context, row.step.tokens?.total !== undefined ? formatTokens(row.step.tokens.total) : undefined].filter(Boolean).join(" · ");
+		const details = [row.step.status, activity, context, row.step.tokens ? formatTokenUsage(row.step.tokens) : undefined].filter(Boolean).join(" · ");
 		lines.push(`  ${row.index + 1}. ${workflowStepLabel(row.step, row.index)}${details ? ` — ${details}` : ""}`);
 	}
 	return lines;
@@ -692,23 +694,27 @@ function itemSource(item: FleetItem): string {
 function itemStats(item: FleetItem): string[] {
 	let model: string | undefined;
 	let tokens: number | undefined;
+	let tokenUsage: AsyncJobStep["tokens"];
 	let tools: number | undefined;
 	let durationMs: number | undefined;
 	if (item.kind === "foreground-active") {
 		const live = item.activeChild ?? item.control;
 		model = formatModelThinking(live.model, live.thinking) || undefined;
 		tokens = live.tokens;
+		if (tokens !== undefined) tokenUsage = { input: live.inputTokens ?? 0, output: live.outputTokens ?? 0, total: tokens, ...(live.window !== undefined ? { window: live.window } : {}), ...(live.windowPeak !== undefined ? { windowPeak: live.windowPeak } : {}) };
 		tools = live.toolCount;
 		durationMs = Math.max(0, Date.now() - live.startedAt);
 	} else if (item.kind === "foreground-recent") {
 		model = formatModelThinking(item.child.model, item.child.thinking) || undefined;
 		tokens = item.child.tokens;
+		if (tokens !== undefined) tokenUsage = { input: 0, output: 0, total: tokens, ...(item.child.window !== undefined ? { window: item.child.window } : {}), ...(item.child.windowPeak !== undefined ? { windowPeak: item.child.windowPeak } : {}) };
 		tools = item.child.toolCount;
 	} else if (item.kind === "external") {
 		durationMs = Math.max(0, externalElapsedEnd(item.run) - item.run.startedAt);
 	} else {
 		model = formatModelThinking(item.step?.model, item.step?.thinking) || undefined;
-		tokens = item.step?.tokens?.total ?? (item.index === undefined ? item.run.totalTokens?.total : undefined);
+		tokenUsage = item.step?.tokens ?? (item.index === undefined ? item.run.totalTokens : undefined);
+		tokens = tokenUsage?.total;
 		tools = item.step?.toolCount ?? (item.index === undefined ? item.run.toolCount : undefined);
 		const terminalRun = item.state !== "queued" && item.state !== "running" && item.state !== "pending";
 		const endTime = item.run.endedAt ?? (terminalRun ? item.run.lastUpdate : undefined) ?? Date.now();
@@ -716,7 +722,7 @@ function itemStats(item: FleetItem): string[] {
 	}
 	return [
 		model,
-		tokens !== undefined ? `${formatTokens(tokens)} tok` : undefined,
+		tokenUsage ? formatTokenUsage(tokenUsage) : tokens !== undefined ? `${formatTokens(tokens)} tok` : undefined,
 		tools !== undefined ? `${tools} tool${tools === 1 ? "" : "s"}` : undefined,
 		durationMs !== undefined ? formatDuration(durationMs) : undefined,
 	].filter((value): value is string => Boolean(value));

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -22,7 +22,7 @@ import {
 	WIDGET_KEY,
 } from "../shared/types.ts";
 import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
-import { formatTokens, formatUsage, formatDuration, formatModelThinking, formatToolCall, shortenPath } from "../shared/formatters.ts";
+import { formatTokens, formatUsage, formatDuration, formatModelThinking, formatToolCall, formatTokenUsage, shortenPath } from "../shared/formatters.ts";
 import { getDisplayItems, getSingleResultOutput } from "../shared/utils.ts";
 import { flatToLogicalStepIndex } from "../runs/background/parallel-groups.ts";
 import { formatNestedAggregate } from "../runs/shared/nested-render.ts";
@@ -740,7 +740,7 @@ function widgetStepActivity(step: NonNullable<AsyncJobState["steps"]>[number], s
 	if (step.currentPath) facts.push(shortenPath(step.currentPath));
 	if (step.turnCount !== undefined) facts.push(`${step.turnCount} turns`);
 	if (step.toolCount !== undefined) facts.push(`${step.toolCount} tools`);
-	if (step.tokens?.total) facts.push(formatTokenStat(step.tokens.total));
+	if (step.tokens?.total) facts.push(formatTokenUsage(step.tokens, "token"));
 	const activity = buildLiveStatusLine(step, snapshotNow);
 	if (activity && facts.length) return `${activity} · ${facts.join(" · ")}`;
 	if (activity) return activity;
@@ -1058,7 +1058,7 @@ function widgetStats(job: AsyncJobState, theme: Theme): string {
 		parts.push(`steps ${stepsTotal}`);
 	}
 	if (job.toolCount !== undefined) parts.push(formatToolUseStat(job.toolCount));
-	if (job.totalTokens?.total) parts.push(formatTokenStat(job.totalTokens.total));
+	if (job.totalTokens?.total) parts.push(formatTokenUsage(job.totalTokens, "token"));
 	if (job.startedAt !== undefined && job.updatedAt !== undefined) parts.push(formatDuration(Math.max(0, job.updatedAt - job.startedAt)));
 	return statJoin(theme, parts);
 }
@@ -1067,7 +1067,7 @@ function widgetStepStats(theme: Theme, step: NonNullable<AsyncJobState["steps"]>
 	return statJoin(theme, [
 		step.turnCount !== undefined ? `${step.turnCount} turns` : "",
 		step.toolCount !== undefined ? formatToolUseStat(step.toolCount) : "",
-		step.tokens?.total ? formatTokenStat(step.tokens.total) : "",
+		step.tokens?.total ? formatTokenUsage(step.tokens, "token") : "",
 		step.durationMs !== undefined ? formatDuration(step.durationMs) : "",
 	]);
 }

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -3014,7 +3014,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 					content: [{ type: "text", text: "primary failed" }],
 					model: "openai/gpt-5-mini",
 					errorMessage: "rate limit exceeded",
-					usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } },
+					usage: { input: 10, output: 5, cacheRead: 300, cacheWrite: 0, cost: { total: 0.01 } },
 				},
 			}],
 			exitCode: 1,
@@ -3097,6 +3097,10 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(statusPayload.steps[0]?.thinking, "low");
 		assert.ok(statusPayload.totalTokens!.total > 0);
 		assert.ok(statusPayload.steps[0]?.tokens!.total > 0);
+		assert.equal(statusPayload.totalTokens!.window, 100);
+		assert.equal(statusPayload.totalTokens!.windowPeak, 310);
+		assert.equal(statusPayload.steps[0]?.tokens!.window, 100);
+		assert.equal(statusPayload.steps[0]?.tokens!.windowPeak, 310);
 		assert.deepEqual(statusPayload.steps[0]?.totalCost, { inputTokens: 110, outputTokens: 55, costUsd: 0.011 });
 		assert.deepEqual(statusPayload.totalCost, { inputTokens: 110, outputTokens: 55, costUsd: 0.011 });
 		const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line));

--- a/test/integration/session-tokens.test.ts
+++ b/test/integration/session-tokens.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from "node:test";
 import { createTempDir, removeTempDir, tryImport } from "../support/helpers.ts";
 
 interface SessionTokensModule {
-	parseSessionTokens(sessionDir: string): { input: number; output: number; total: number } | null;
+	parseSessionTokens(sessionDir: string): { input: number; output: number; total: number; window?: number; windowPeak?: number } | null;
 }
 
 const tokensMod = await tryImport<SessionTokensModule>("./src/shared/session-tokens.ts");
@@ -21,21 +21,21 @@ describe("session tokens", { skip: !available ? "pi packages not available" : un
 					type: "message",
 					message: {
 						role: "assistant",
-						usage: { input: 120, output: 30 },
+						usage: { input: 120, output: 30, cacheRead: 500 },
 					},
 				}),
 				JSON.stringify({
 					type: "message",
 					message: {
 						role: "assistant",
-						usage: { inputTokens: 80, outputTokens: 20 },
+						usage: { inputTokens: 80, outputTokens: 20, cacheReadTokens: 30 },
 					},
 				}),
 			].join("\n");
 			fs.writeFileSync(sessionFile, lines + "\n", "utf-8");
 
 			const tokens = tokensMod!.parseSessionTokens(sessionDir);
-			assert.deepEqual(tokens, { input: 200, output: 50, total: 250 });
+			assert.deepEqual(tokens, { input: 200, output: 50, total: 250, window: 110, windowPeak: 620 });
 		} finally {
 			removeTempDir(sessionDir);
 		}
@@ -54,7 +54,7 @@ describe("session tokens", { skip: !available ? "pi packages not available" : un
 			fs.utimesSync(newerFile, newerTime, newerTime);
 
 			const tokens = tokensMod!.parseSessionTokens(sessionDir);
-			assert.deepEqual(tokens, { input: 90, output: 10, total: 100 });
+			assert.deepEqual(tokens, { input: 90, output: 10, total: 100, window: 90, windowPeak: 90 });
 		} finally {
 			removeTempDir(sessionDir);
 		}

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -5193,6 +5193,27 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok((runningUpdates.at(-1)?.durationMs ?? 0) > (runningUpdates[0]?.durationMs ?? 0), "expected heartbeat duration to advance");
 	});
 
+	it("reports foreground context window usage without changing cumulative spend", async () => {
+		mockPi.onCall({
+			jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "Done" }],
+					model: "mock/test-model",
+					stopReason: "stop",
+					usage: { input: 11, output: 7, cacheRead: 30, cacheWrite: 0, cost: { total: 0.001 } },
+				},
+			}],
+		});
+
+		const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {});
+
+		assert.equal(result.progress.tokens, 18);
+		assert.equal(result.progress.window, 41);
+		assert.equal(result.progress.windowPeak, 41);
+	});
+
 	it("tracks live activity updates and exposes artifact paths while running", async () => {
 		const updates: Array<{ details?: { results?: Array<{ artifactPaths?: ArtifactPaths }>; progress?: ProgressSummary[] } }> = [];
 		mockPi.onCall({

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -50,6 +50,7 @@ describe("below-editor subagent FleetView", () => {
 		assert.equal(formatFleetTokens(999), "↓ 999 tokens");
 		assert.equal(formatFleetTokens(13_100), "↓ 13.1k tokens");
 		assert.equal(formatFleetTokens(1_250_000), "↓ 1.3M tokens");
+		assert.equal(formatFleetTokens(484_000, 129_000), "↓ 129.0k window · 484.0k spent");
 	});
 
 	it("renders cached external jobs with an external marker and elapsed time", () => {
@@ -230,7 +231,7 @@ describe("below-editor subagent FleetView", () => {
 			mode: "single",
 			startedAt: 10,
 			updatedAt: 20,
-			totalTokens: { input: 40, output: 2, total: 42 },
+			totalTokens: { input: 40, output: 2, total: 42, window: 30, windowPeak: 35 },
 		});
 		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
 		const ctx = {
@@ -250,7 +251,7 @@ describe("below-editor subagent FleetView", () => {
 			const lines = widgetFactory!({ requestRender() {} }, theme).render(50);
 			assert.equal(lines.length, 1);
 			assert.ok(lines[0]!.includes("1 active agent"));
-			assert.ok(lines[0]!.includes("↓ 42 tokens"));
+			assert.ok(lines[0]!.includes("↓ 30 window · 42 spent"));
 			assert.ok(visibleWidth(lines[0]!) <= 50);
 		} finally {
 			fleet.dispose();

--- a/test/unit/foreground-control.test.ts
+++ b/test/unit/foreground-control.test.ts
@@ -25,6 +25,8 @@ function progress(index: number, agent: string, tokens: number): AgentProgress {
 		thinking: "high",
 		inputTokens: tokens - 20,
 		outputTokens: 20,
+		window: 75,
+		windowPeak: 90,
 		durationMs: 10,
 	};
 }
@@ -70,6 +72,8 @@ describe("foreground child control", () => {
 		assert.equal(control.tokens, 120);
 		assert.equal(control.inputTokens, 100);
 		assert.equal(control.outputTokens, 20);
+		assert.equal(control.window, 75);
+		assert.equal(control.windowPeak, 90);
 		assert.equal(control.model, "openai/gpt-5.6-terra:high");
 		assert.equal(control.thinking, "high");
 		assert.equal(control.activeChildren?.get(1)?.tokens, undefined);
@@ -92,6 +96,8 @@ describe("foreground child control", () => {
 		assert.equal(control.model, undefined);
 		assert.equal(control.inputTokens, undefined);
 		assert.equal(control.outputTokens, undefined);
+		assert.equal(control.window, undefined);
+		assert.equal(control.windowPeak, undefined);
 		assert.equal(control.interrupt, undefined);
 		assert.equal(control.detach, undefined);
 	});

--- a/test/unit/nested-events.test.ts
+++ b/test/unit/nested-events.test.ts
@@ -333,7 +333,7 @@ describe("nested event parsing and projection", () => {
 			ts: 100,
 			parentRunId: "root-run",
 			parentStepIndex: 1,
-			child: { ...child("nested-valid-tokens", "running", 100), totalTokens: { input: 10, output: 15, total: 25 } },
+			child: { ...child("nested-valid-tokens", "running", 100), totalTokens: { input: 10, output: 15, total: 25, window: 30, windowPeak: 40 } },
 		});
 		fs.writeFileSync(path.join(route.eventSink, "0000000000200-invalid-tokens.json"), `${JSON.stringify({
 			type: "subagent.nested.updated",
@@ -347,7 +347,7 @@ describe("nested event parsing and projection", () => {
 
 		const registry = projectNestedEvents(route);
 
-		assert.deepEqual(registry.children.find((item) => item.id === "nested-valid-tokens")?.totalTokens, { input: 10, output: 15, total: 25 });
+		assert.deepEqual(registry.children.find((item) => item.id === "nested-valid-tokens")?.totalTokens, { input: 10, output: 15, total: 25, window: 30, windowPeak: 40 });
 		assert.equal(registry.children.find((item) => item.id === "nested-invalid-tokens")?.totalTokens, undefined);
 	});
 

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -203,7 +203,7 @@ describe("subagent extension RPC bridge", () => {
 			asyncJobs: new Map([["async-private-id", {
 				asyncId: "async-private-id", sessionId: "/sessions/parent.jsonl", status: "running", mode: "single",
 				description: ["Review", "\u001b]8;;hostile\u0007", "the diff"].join("\n"),
-				startedAt: 100, steps: [{ agent: "reviewer", label: "opaque label", status: "running", startedAt: 120, model: "anthropic/claude-opus-4-8:high", thinking: "high", tokens: { input: 12, output: 34, total: 46 } }],
+				startedAt: 100, steps: [{ agent: "reviewer", label: "opaque label", status: "running", startedAt: 120, model: "anthropic/claude-opus-4-8:high", thinking: "high", tokens: { input: 12, output: 34, total: 46, window: 40, windowPeak: 44 } }],
 			}]]),
 		} as any;
 		const bridge = registerSubagentRpcBridge({
@@ -217,7 +217,7 @@ describe("subagent extension RPC bridge", () => {
 		assert.equal((fleet as { omitted?: number }).omitted, 0);
 		assert.deepEqual(fleet.entries[0], {
 			key: "fleet-1", agent: "reviewer", role: "opaque label", model: "anthropic/claude-opus-4-8:high", effort: "high",
-			startedAt: 120, tokens: { input: 12, output: 34, total: 46 },
+			startedAt: 120, tokens: { input: 12, output: 34, total: 46, window: 40, windowPeak: 44 },
 		});
 		assert.equal(JSON.stringify(fleet).includes("Review the diff"), false);
 		assert.equal(JSON.stringify(fleet).includes("async-private-id"), false);


### PR DESCRIPTION
Fixes #1444.

This adds optional `window` and `windowPeak` token fields for live context-window usage while keeping `input`, `output`, and `total` as cumulative spend. UI labels now show window usage first and spent tokens explicitly when the new data is present.

Validation:
- `npm run test:unit -- test/unit/foreground-control.test.ts test/unit/fleet-status.test.ts test/unit/fleet.test.ts test/unit/nested-events.test.ts test/unit/render-helpers.test.ts test/unit/render-fork-badge.test.ts`
- `npm run test:integration -- test/integration/single-execution.test.ts test/integration/async-execution.test.ts test/integration/session-tokens.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh review: no issues found
