### PR TITLE
feat: show active task labels in status surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 - Expose a bounded, versioned workflow-child summary across workflow results, status, receipts, and completion replay. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #1453.
 - Show live context-window usage separately from cumulative token spend in status and Fleet views. Thanks to [@nazzeDe](https://github.com/nazzeDe) for #1444.
+- Show active workflow task labels in compact status surfaces and Herdr pane metadata. Thanks to [@phoenixdam](https://github.com/phoenixdam) for #1459.
 - Add `modelExclusions.defaultTtlMs` configuration for controlling the lifetime of model exclusions, including shorter limits for active cached entries, with launch diagnostics for excluded candidates. Thanks to [@mithyer](https://github.com/mithyer) for #1439 and #1438.
 - Add code-owned `cursor-agent` read-only and `cursor-agent-writer` workspace-writing profiles with private prompt-file handoff, bounded stream-JSON terminal proof, and opt-in mode-specific smoke evidence.
 - Add code-owned `claude-code` read-only and `claude-code-writer` file-editing profiles for an existing authenticated CLI with trusted user settings, bounded stream-JSON result proof, and opt-in mode-specific smoke evidence.

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -295,7 +295,7 @@ When Pi runs inside [Herdr](https://herdr.dev), pi-subagents automatically repor
 - The bridge is enabled only when Herdr supplies `HERDR_ENV=1` and `HERDR_PANE_ID`; outside Herdr it registers no listeners or timers.
 - It restores current-session active runs after `/reload` or `/resume`, refreshes metadata while work is active, and clears it on completion or shutdown.
 - The bridge uses Herdr's existing `herdr:blocked` sibling event when an async child needs attention, and emits `herdr:busy` while async work remains. Herdr versions that support the sibling event keep the pane's semantic state `working`; older versions ignore it safely and still display the metadata label while the Pi integration remains the lifecycle authority.
-- The owning Pi session is the only publisher for its own pane metadata. While active subagents exist, it reports a compact `title-suffix` token: one active run uses that agent name, two or more use the active-run count, and attention adds `⚠`. The suffix is cleared when active work reaches zero.
+- The owning Pi session is the only publisher for its own pane metadata. When an active workflow has an explicit bounded `label`, the newest active label appears in the summary and compact `title-suffix`; overlapping completion restores the previous active label. Raw task and goal prompts never enter Herdr metadata. Without a label, one active run uses its agent name and two or more use the active-run count. Attention adds `⚠`, and the suffix is cleared when active work reaches zero.
 
 To show the reported label in the expanded Agent sidebar, include `state_text` or `$summary` in its row layout:
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,9 +6,9 @@ Where running subagents show up, how to inspect them, and the files and events t
 
 Foreground runs stream progress in the conversation while they run. They default to a generous 30-minute wall-clock timeout when neither the call nor the selected agent provides a timeout; a global [`timeoutMs`](configuration.md#timeoutms) config replaces that default, and explicit `timeoutMs`/`maxRuntimeMs` and agent defaults win.
 
-Live progress shows compact detail for single, chain, and parallel modes: current tool, recent output, token counts, aggregate cost, duration, activity freshness, current-tool duration, and chain graph metadata when available.
+Live progress shows compact detail for single, chain, and parallel modes: a bounded one-line task, current tool, recent output, token counts, aggregate cost, duration, activity freshness, current-tool duration, and chain graph metadata when available. Workflow `label` metadata wins over raw task text in compact multi-child cards.
 
-Press Pi's configured expand key (`Ctrl+O` by default) to expand the full streaming view with complete output per step.
+Press Pi's configured expand key (`Ctrl+O` by default) to expand the full streaming view with complete output per step. Running-card hints also advertise `Ctrl+Alt+F` for the Fleet inspector.
 
 Sequential chains show a flow line like `done scout → running worker`. Chains with parallel steps show per-step cards instead. Chain status uses `label` and `phase` metadata when present, while falling back to agent names for older chains.
 
@@ -29,8 +29,9 @@ The under-editor async widget gives a short view while work runs. Its expand key
 async subagent worker · background
 ● worker
   ● Step 1/1: worker · running
+    task: Review authentication boundaries
     ⎿  read: src/auth.ts | 2.0s
-    Press configured-expand-key for live detail
+    Press configured-expand-key for live detail · Ctrl+Alt+F Fleet
 ```
 
 To inspect one background child in text, use `subagent({ action: "status", id: "...", view: "transcript" })`; add `index` for a specific child in a parallel or chain run.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -383,9 +383,13 @@ export function projectActiveHerdrRuns(state: SubagentState): HerdrStatusRun[] {
 		.filter((job) => active(job.status))
 		.map((job) => {
 			const children = job.mode === "workflow" ? foregroundChildrenByWorkflow.get(job.asyncId) : undefined;
+			const currentStep = job.steps?.find((step) => step.status === "running")
+				?? (job.currentStep !== undefined ? job.steps?.[job.currentStep] : undefined)
+				?? job.steps?.find((step) => step.status === "pending");
 			return {
 				id: job.asyncId,
 				agents: children?.length ? children.map((child) => child.agent) : job.agents,
+				...(currentStep?.label ? { taskLabel: currentStep.label } : {}),
 				needsAttention: job.activityState === "needs_attention" || children?.some((child) => child.needsAttention),
 			};
 		});

--- a/src/integrations/herdr-status.ts
+++ b/src/integrations/herdr-status.ts
@@ -3,10 +3,15 @@ import {
 	SUBAGENT_ASYNC_STARTED_EVENT,
 	SUBAGENT_CONTROL_EVENT,
 } from "../shared/types.ts";
+import { previewDisplayText, sanitizeDisplayText } from "../shared/display-text.ts";
 
 const DEFAULT_SOURCE = "pi-subagents:herdr";
 const DEFAULT_TTL_MS = 120_000;
 const DEFAULT_REFRESH_MS = 45_000;
+const MAX_TASK_LABEL_CHARS = 80;
+const MAX_TITLE_TASK_CHARS = 42;
+const MAX_WORKFLOW_LABEL_NODES = 128;
+const MAX_WORKFLOW_LABEL_DEPTH = 8;
 
 let metadataReportSeq = Date.now() * 1000;
 
@@ -24,6 +29,8 @@ export interface HerdrStatusRun {
 	id: string;
 	agent?: string;
 	agents?: string[];
+	/** Explicit launch/workflow label only; raw prompts never enter pane metadata. */
+	taskLabel?: string;
 	needsAttention?: boolean;
 	attentionLabel?: string;
 }
@@ -61,12 +68,42 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function boundedTaskLabel(value: unknown, maxChars = MAX_TASK_LABEL_CHARS): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = sanitizeDisplayText(value).trim();
+	if (!normalized) return undefined;
+	return previewDisplayText(normalized, maxChars);
+}
+
+function workflowTaskLabel(data: Record<string, unknown>): string | undefined {
+	const explicit = boundedTaskLabel(data.taskLabel);
+	if (explicit) return explicit;
+	if (!isRecord(data.workflowGraph) || !Array.isArray(data.workflowGraph.nodes)) return undefined;
+	const currentNodeId = typeof data.workflowGraph.currentNodeId === "string" ? data.workflowGraph.currentNodeId : undefined;
+	const nodes: Record<string, unknown>[] = [];
+	const collect = (values: unknown[], depth: number): void => {
+		if (depth > MAX_WORKFLOW_LABEL_DEPTH || nodes.length >= MAX_WORKFLOW_LABEL_NODES) return;
+		for (const value of values) {
+			if (nodes.length >= MAX_WORKFLOW_LABEL_NODES) return;
+			if (!isRecord(value)) continue;
+			nodes.push(value);
+			if (Array.isArray(value.children)) collect(value.children, depth + 1);
+		}
+	};
+	collect(data.workflowGraph.nodes, 0);
+	const current = currentNodeId ? nodes.find((node) => node.id === currentNodeId) : undefined;
+	const active = current ?? nodes.find((node) => node.status === "running") ?? nodes.find((node) => node.status === "pending");
+	return boundedTaskLabel(active?.label);
+}
+
 function startedRun(data: unknown): HerdrStatusRun | undefined {
 	if (!isRecord(data) || typeof data.id !== "string" || !data.id) return undefined;
+	const taskLabel = workflowTaskLabel(data);
 	return {
 		id: data.id,
 		...(typeof data.agent === "string" ? { agent: data.agent } : {}),
 		...(Array.isArray(data.agents) && data.agents.every((agent) => typeof agent === "string") ? { agents: data.agents as string[] } : {}),
+		...(taskLabel ? { taskLabel } : {}),
 	};
 }
 
@@ -113,6 +150,7 @@ export function registerHerdrStatusBridge(options: HerdrStatusBridgeOptions): He
 
 	const activeAgentNames = (): string[] => [...new Set([...runs.values()].flatMap((run) => run.agents?.length ? run.agents : run.agent ? [run.agent] : []))];
 	const activeSubagentCount = (): number => [...runs.values()].reduce((total, run) => total + Math.max(1, run.agents?.length ?? (run.agent ? 1 : 0)), 0);
+	const activeTaskLabel = (): string | undefined => [...runs.values()].reverse().find((run) => run.taskLabel)?.taskLabel;
 
 	const label = (includeAttention = false): string => {
 		const agents = activeAgentNames();
@@ -122,15 +160,18 @@ export function registerHerdrStatusBridge(options: HerdrStatusBridgeOptions): He
 			: "";
 		const panes = Math.max(0, options.getProjectPaneCount?.() ?? 0);
 		const paneText = panes > 0 ? ` · ${panes} pane${panes === 1 ? "" : "s"}` : "";
+		const task = activeTaskLabel();
+		const taskText = task ? ` · ${task}` : "";
 		const attention = includeAttention && attentionLabels.size > 0 ? " ⚠" : "";
-		return `⏳ ${activeCount} subagent${activeCount === 1 ? "" : "s"}${who}${paneText}${attention}`;
+		return `⏳ ${activeCount} subagent${activeCount === 1 ? "" : "s"}${who}${paneText}${taskText}${attention}`;
 	};
 
 	const titleSuffix = (): string | undefined => {
 		if (runs.size === 0) return undefined;
 		const agentNames = activeAgentNames();
 		const activeCount = activeSubagentCount();
-		const target = activeCount === 1 && agentNames.length === 1 ? agentNames[0]! : String(activeCount);
+		const task = boundedTaskLabel(activeTaskLabel(), MAX_TITLE_TASK_CHARS);
+		const target = task ?? (activeCount === 1 && agentNames.length === 1 ? agentNames[0]! : String(activeCount));
 		return `⏳${target}${attentionLabels.size > 0 ? "⚠" : ""}`;
 	};
 
@@ -255,11 +296,14 @@ export function registerHerdrStatusBridge(options: HerdrStatusBridgeOptions): He
 	const replaceRuns = (nextRuns: Iterable<HerdrStatusRun>): void => {
 		const nextAttention = new Map<string, string>();
 		const activeIds = new Set<string>();
+		const previousRuns = new Map(runs);
 		runs.clear();
 		for (const run of nextRuns) {
 			if (!run || typeof run.id !== "string" || !run.id) continue;
 			activeIds.add(run.id);
-			runs.set(run.id, { ...run });
+			const taskLabel = boundedTaskLabel(run.taskLabel) ?? previousRuns.get(run.id)?.taskLabel;
+			const { taskLabel: _rawTaskLabel, ...sanitizedRun } = run;
+			runs.set(run.id, { ...sanitizedRun, ...(taskLabel ? { taskLabel } : {}) });
 			if (!run.needsAttention) {
 				acknowledgedAttention.delete(run.id);
 			} else if (!acknowledgedAttention.has(run.id)) {

--- a/src/integrations/herdr-status.ts
+++ b/src/integrations/herdr-status.ts
@@ -296,12 +296,11 @@ export function registerHerdrStatusBridge(options: HerdrStatusBridgeOptions): He
 	const replaceRuns = (nextRuns: Iterable<HerdrStatusRun>): void => {
 		const nextAttention = new Map<string, string>();
 		const activeIds = new Set<string>();
-		const previousRuns = new Map(runs);
 		runs.clear();
 		for (const run of nextRuns) {
 			if (!run || typeof run.id !== "string" || !run.id) continue;
 			activeIds.add(run.id);
-			const taskLabel = boundedTaskLabel(run.taskLabel) ?? previousRuns.get(run.id)?.taskLabel;
+			const taskLabel = boundedTaskLabel(run.taskLabel);
 			const { taskLabel: _rawTaskLabel, ...sanitizedRun } = run;
 			runs.set(run.id, { ...sanitizedRun, ...(taskLabel ? { taskLabel } : {}) });
 			if (!run.needsAttention) {

--- a/src/shared/shortcuts.ts
+++ b/src/shared/shortcuts.ts
@@ -1,0 +1,17 @@
+import { Key, type KeyId } from "@earendil-works/pi-tui";
+
+export const FLEET_OPEN_SHORTCUT: KeyId = Key.ctrlAlt("f");
+
+export function formatShortcutLabel(shortcut: string): string {
+	return shortcut
+		.split("+")
+		.map((part) => {
+			const normalized = part.trim().toLowerCase();
+			if (normalized === "ctrl") return "Ctrl";
+			if (normalized === "alt") return "Alt";
+			if (normalized === "shift") return "Shift";
+			if (normalized === "super") return "Super";
+			return normalized.length === 1 ? normalized.toUpperCase() : part.trim();
+		})
+		.join("+");
+}

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -22,6 +22,7 @@ import { listAsyncRuns, formatAsyncRunProgressLabel, type AsyncRunSummary } from
 import { encodeInspectReply, handleInspectRpcArgs, INSPECT_WIDGET_KEY } from "../runs/background/inspect-rpc.ts";
 import { listScheduledRunSummaries } from "../runs/background/scheduled-runs.ts";
 import { SUBAGENT_FANOUT_CHILD_ENV } from "../runs/shared/pi-args.ts";
+import { FLEET_OPEN_SHORTCUT } from "../shared/shortcuts.ts";
 import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.ts";
 import { registerPromptWorkflowCommands } from "./prompt-workflows.ts";
 import { openSubagentsAdmin } from "./subagents-admin.ts";
@@ -776,7 +777,7 @@ export function registerSlashCommands(
 		handler: async (_args, ctx) => showFleet(ctx),
 	});
 
-	pi.registerShortcut(Key.ctrlAlt("f"), {
+	pi.registerShortcut(FLEET_OPEN_SHORTCUT, {
 		description: "Open subagent fleet inspector",
 		handler: async (ctx) => showFleet(ctx),
 	});

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -21,9 +21,10 @@ import {
 	WIDGET_ANIMATION_INTERVAL_MS,
 	WIDGET_KEY,
 } from "../shared/types.ts";
-import { sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
+import { previewDisplayText, sanitizeDisplayText, truncateDisplayText } from "../shared/display-text.ts";
+import { FLEET_OPEN_SHORTCUT, formatShortcutLabel } from "../shared/shortcuts.ts";
 import { formatTokens, formatUsage, formatDuration, formatModelThinking, formatToolCall, formatTokenUsage, shortenPath } from "../shared/formatters.ts";
-import { getDisplayItems, getSingleResultOutput } from "../shared/utils.ts";
+import { getDisplayItems, getSingleResultOutput, PROMPT_REDACTED } from "../shared/utils.ts";
 import { flatToLogicalStepIndex } from "../runs/background/parallel-groups.ts";
 import { formatNestedAggregate } from "../runs/shared/nested-render.ts";
 import { aggregateStepStatus, formatActivityLabel, formatAgentRunningLabel, formatParallelOutcome } from "../shared/status-format.ts";
@@ -69,23 +70,13 @@ function liveDetailKeyText(): string {
 	return keyText("app.tools.expand");
 }
 
-function liveDetailHintText(): string {
-	return `Press ${liveDetailKeyText()} for live detail`;
+export function liveDetailHintText(): string {
+	return `Press ${liveDetailKeyText()} for live detail · ${formatShortcutLabel(FLEET_OPEN_SHORTCUT)} Fleet`;
 }
 
 function foregroundSingleHintText(shortcut?: string): string {
 	if (!shortcut) return liveDetailHintText();
-	const label = shortcut
-		.split("+")
-		.map((part) => {
-			const normalized = part.trim().toLowerCase();
-			if (normalized === "ctrl") return "Ctrl";
-			if (normalized === "alt") return "Alt";
-			if (normalized === "shift") return "Shift";
-			if (normalized === "super") return "Super";
-			return normalized.length === 1 ? normalized.toUpperCase() : part.trim();
-		})
-		.join("+");
+	const label = formatShortcutLabel(shortcut);
 	return `${liveDetailHintText()} · ${label} to run in background`;
 }
 
@@ -271,6 +262,29 @@ const liveOutputCodeSignalPattern = /\bE[A-Z0-9_]{2,}\b/;
 
 function oneLine(text: string): string {
 	return text.replace(ansiEscapePattern, "").replace(/\s+/g, " ").trim();
+}
+
+const COMPACT_TASK_MAX_CHARS = 96;
+
+export function compactTaskText(task: string | undefined, label?: string): string | undefined {
+	const source = label?.trim() || task?.trim();
+	if (!source || source === PROMPT_REDACTED) return undefined;
+	const normalized = oneLine(source);
+	if (!normalized) return undefined;
+	return previewDisplayText(normalized, COMPACT_TASK_MAX_CHARS);
+}
+
+function workflowLabelForResult(details: Details, resultIndex: number): string | undefined {
+	const flatIndex = details.results[resultIndex]?.progress?.index ?? resultIndex;
+	const visit = (nodes: NonNullable<Details["workflowGraph"]>["nodes"]): string | undefined => {
+		for (const node of nodes) {
+			if (node.flatIndex === flatIndex && node.label.trim()) return node.label;
+			const nested = node.children ? visit(node.children) : undefined;
+			if (nested) return nested;
+		}
+		return undefined;
+	};
+	return details.workflowGraph ? visit(details.workflowGraph.nodes) : undefined;
 }
 
 function hasLiveOutputSignal(line: string): boolean {
@@ -1259,6 +1273,8 @@ function foregroundStyleWidgetStepLines(
 	const stats = widgetStepStats(theme, step);
 	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
 	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), frame)} ${itemTitle} ${index}/${total}: ${themeBold(theme, step.agent)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
+	const task = compactTaskText(step.description, step.label);
+	if (task) lines.push(`    ${theme.fg("dim", `task: ${task}`)}`);
 	const activity = widgetStepActivityLine(step, width, expanded, job.updatedAt);
 	if (activity) lines.push(`    ${theme.fg("dim", `⎿  ${activity}`)}`);
 	for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, expanded ? 12 : 6)) {
@@ -1329,7 +1345,9 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 		const stepStats = widgetStepStats(theme, step);
 		const activitySuffix = activity ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", activity)}` : "";
 		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
-		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, step.agent)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
+		const task = compactTaskText(step.description, step.label);
+		const taskSuffix = task ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", `task: ${task}`)}` : "";
+		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, step.agent)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${taskSuffix}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt, 6)) lines.push(`    ${nestedLine}`);
 	}
 	if (job.steps.some((step) => step.status === "running")) lines.push(theme.fg("accent", `  ${liveDetailHintText()}`));
@@ -1703,6 +1721,8 @@ function renderSingleCompact(
 	c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
 
 	if (isRunning && r.progress) {
+		const task = compactTaskText(r.task);
+		if (task) c.addChild(new Text(truncLine(theme.fg("dim", `${detailIndent}task: ${task}`), width), 0, 0));
 		const progressSnapshotNow = snapshotNowForProgress(r.progress);
 		const activity = compactCurrentActivity(r.progress);
 		c.addChild(new Text(truncLine(theme.fg("dim", `${detailIndent}⎿  ${activity}`), width), 0, 0));
@@ -1872,6 +1892,10 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 		const rowModelDisplay = modelThinkingBadge(theme, r.model ?? rowProgressModel?.model, r.thinking ?? rowProgressModel?.thinking);
 		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${contextModeBadge(theme, r.context)}${rowModelDisplay}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
 		c.addChild(new Text(truncLine(`${rowIndent}${line}`, width), 0, 0));
+		if (rRunning || rPending) {
+			const task = compactTaskText(r.task, workflowLabelForResult(d, i));
+			if (task) c.addChild(new Text(truncLine(theme.fg("dim", `${detailIndent}task: ${task}`), width), 0, 0));
+		}
 		if (rRunning && rProg && "status" in rProg) {
 			const liveProgress = rProg as AgentProgress;
 			const activity = compactCurrentActivity(liveProgress);

--- a/test/unit/herdr-status-bridge.test.ts
+++ b/test/unit/herdr-status-bridge.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
 	registerHerdrStatusBridge,
 	type HerdrStatusBridgeEvents,
+	type HerdrStatusRun,
 } from "../../src/integrations/herdr-status.ts";
 import { projectActiveHerdrRuns } from "../../src/extension/index.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
@@ -492,6 +493,34 @@ describe("Herdr status bridge", () => {
 		assert.ok(commands[0]?.includes("summary=⏳ 1 subagent (worker)"));
 		assert.ok(commands[0]?.includes("title-suffix=⏳worker"));
 		assert.doesNotMatch(commands.flat().join("\n"), /\u001b\[31m/);
+
+		bridge.dispose();
+	});
+
+	it("clears a completed step label when the authoritative active step is unlabeled", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const intervals = new FakeIntervals();
+		let authoritativeRuns: HerdrStatusRun[] = [{ id: "run-1", agent: "worker", taskLabel: "Build auth" }];
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			getRuns: () => authoritativeRuns,
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 45_000,
+			timers: intervals.timers,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: authoritativeRuns });
+		await bridge.flush();
+
+		authoritativeRuns = [{ id: "run-1", agent: "worker" }];
+		intervals.fireAll();
+		await bridge.flush();
+
+		assert.ok(commands[0]?.includes("title-suffix=⏳Build auth"));
+		assert.ok(commands[1]?.includes("summary=⏳ 1 subagent (worker)"));
+		assert.ok(commands[1]?.includes("title-suffix=⏳worker"));
+		assert.doesNotMatch(commands[1]?.join("\n") ?? "", /Build auth/);
 
 		bridge.dispose();
 	});

--- a/test/unit/herdr-status-bridge.test.ts
+++ b/test/unit/herdr-status-bridge.test.ts
@@ -82,6 +82,7 @@ describe("Herdr status bridge", () => {
 			status: "running",
 			mode: "workflow",
 			agents: ["workflow"],
+			steps: [{ agent: "reviewer", status: "running", label: "Review auth" }],
 		});
 		state.foregroundControls.set("child-1", {
 			runId: "child-1",
@@ -102,6 +103,7 @@ describe("Herdr status bridge", () => {
 		assert.deepEqual(projectActiveHerdrRuns(state), [{
 			id: "workflow-1",
 			agents: ["reviewer"],
+			taskLabel: "Review auth",
 			needsAttention: true,
 		}]);
 	});
@@ -424,6 +426,72 @@ describe("Herdr status bridge", () => {
 		assert.ok(commands[2]?.includes("title-suffix=⏳2⚠"));
 		assert.ok(commands.at(-1)?.includes("--clear-token"));
 		assert.ok(commands.at(-1)?.includes("title-suffix"));
+
+		bridge.dispose();
+	});
+
+	it("publishes bounded workflow labels without leaking raw prompts and restores the previous overlapping task", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 0,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, {
+			id: "run-1",
+			agent: "worker",
+			goal: "raw secret prompt",
+			workflowGraph: {
+				currentNodeId: "build",
+				nodes: [{ id: "build", status: "running", label: "Build auth\nflow\u001b[31m" }],
+			},
+		});
+		await bridge.flush();
+		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, {
+			id: "run-2",
+			agent: "reviewer",
+			task: "another raw prompt",
+			workflowGraph: {
+				nodes: [{ id: "review", status: "pending", label: `Review ${"x".repeat(120)}` }],
+			},
+		});
+		await bridge.flush();
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { runId: "run-2" });
+		await bridge.flush();
+		events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, { runId: "run-1" });
+		await bridge.flush();
+
+		assert.ok(commands[0]?.includes("summary=⏳ 1 subagent (worker) · Build auth flow"));
+		assert.ok(commands[0]?.includes("title-suffix=⏳Build auth flow"));
+		assert.ok(commands[1]?.some((argument) => argument.startsWith("summary=⏳ 2 subagents") && argument.length < 180));
+		assert.ok(commands[1]?.some((argument) => argument.startsWith("title-suffix=⏳Review ") && argument.length < 70));
+		assert.ok(commands[2]?.includes("title-suffix=⏳Build auth flow"));
+		assert.ok(commands[3]?.includes("--clear-state-labels"));
+		assert.doesNotMatch(commands.flat().join("\n"), /raw secret prompt|another raw prompt/);
+
+		bridge.dispose();
+	});
+
+	it("omits refreshed task labels when sanitization removes all content", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 0,
+		});
+
+		bridge.sessionStarted({ hasUI: true, runs: [{ id: "run-1", agent: "worker", taskLabel: "\u001b[31m" }] });
+		await bridge.flush();
+
+		assert.ok(commands[0]?.includes("summary=⏳ 1 subagent (worker)"));
+		assert.ok(commands[0]?.includes("title-suffix=⏳worker"));
+		assert.doesNotMatch(commands.flat().join("\n"), /\u001b\[31m/);
 
 		bridge.dispose();
 	});

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -146,6 +146,8 @@ test("running single-subagent cards show the configured detach shortcut", () => 
 		undefined,
 		"ctrl+b",
 	));
+	assert.match(configured, /task: reviewer task/);
+	assert.match(configured, /Ctrl\+Alt\+F Fleet/);
 	assert.match(configured, /Ctrl\+B to run in background/);
 
 	const unconfigured = componentText(renderSubagentResult(toolResult as never, { expanded: false }, theme as any));
@@ -170,6 +172,33 @@ test("running single-subagent cards show the configured detach shortcut", () => 
 		"ctrl+b",
 	));
 	assert.doesNotMatch(pendingBackground, /run in background/);
+});
+
+test("compact multi-result cards prefer bounded workflow labels over raw tasks", () => {
+	const longLabel = `Review auth flow\n${"x".repeat(140)}`;
+	const running = {
+		...result("reviewer", ""),
+		task: "raw task that should not win",
+		progress: { status: "running", index: 0, agent: "reviewer", toolCount: 0, tokens: 0, durationMs: 0 },
+	};
+	const text = componentText(renderSubagentResult({
+		content: [{ type: "text", text: "running" }],
+		details: {
+			mode: "parallel",
+			results: [running],
+			workflowGraph: {
+				runId: "workflow-task-label",
+				mode: "parallel",
+				phases: [],
+				nodes: [{ id: "review", kind: "agent", agent: "reviewer", label: longLabel, status: "running", flatIndex: 0 }],
+			},
+		},
+	}, { expanded: false }, theme as any));
+
+	assert.match(text, /task: Review auth flow x+/);
+	assert.doesNotMatch(text, /raw task that should not win/);
+	assert.match(text, /\.\.\.$/m);
+	assert.match(text, /Ctrl\+Alt\+F Fleet/);
 });
 
 test("compact chain rendering uses workflow graph spans for dynamic fanout results", () => {


### PR DESCRIPTION
## Summary

- show a bounded one-line task in compact foreground cards and prefer explicit workflow labels in multi-child and Fleet status
- share the Fleet shortcut constant so live-detail hints accurately advertise `Ctrl+Alt+F`
- propagate only bounded, sanitized workflow labels into Herdr summary/title metadata, restore the prior task after overlapping runs finish, and clear metadata at zero active runs
- keep raw task and goal prompts out of Herdr metadata

## Validation

- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/render-helpers.test.ts test/unit/herdr-status-bridge.test.ts` (32 passing)
- `git diff --check`

The complete unit suite was also compared against an untouched `origin/main` worktree under the same Node 26 host. Existing environment-sensitive failures reproduce on the baseline; the focused changed-path tests above are green.