### PR TITLE
fix(runs): notify the parent when a runner dies before naming its session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -664,7 +664,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1463,7 +1462,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -351,8 +351,17 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 	const now = options.now?.() ?? Date.now();
 	const status = readStatus(asyncDir);
 	const startedStatus = !status && options.startedRun ? buildStartedStatus(asyncDir, options.startedRun, now) : undefined;
-	const effectiveStatus = status ?? startedStatus;
-	if (!effectiveStatus) return { status: null, repaired: false };
+	const started = status ?? startedStatus;
+	if (!started) return { status: null, repaired: false };
+	// A result file is addressed by session, so a repair without a sessionId
+	// cannot be written - and the completion notification is delivered from that
+	// file. A runner that died before its child session existed has no sessionId
+	// in status.json yet, which silently swallowed exactly the failures that
+	// most need reporting: the earlier the crash, the less it recorded. The
+	// session that started the run is known independently, so it stands in.
+	const effectiveStatus: AsyncStatus = started.sessionId || !options.startedRun?.sessionId
+		? started
+		: { ...started, sessionId: options.startedRun.sessionId };
 	const statusPath = path.join(asyncDir, "status.json");
 	for (const [index, step] of (effectiveStatus.steps ?? []).entries()) {
 		const stepRecord = step as Record<string, unknown>;

--- a/test/unit/stale-run-reconciler.test.ts
+++ b/test/unit/stale-run-reconciler.test.ts
@@ -29,6 +29,47 @@ describe("async stale-run reconciliation", () => {
 		assert.equal(checkPidLiveness(123, () => { throw new Error("boom"); }), "unknown");
 	});
 
+	it("still writes a result when the runner died before recording its session", () => {
+		// The reported failure: a runner that exits during startup has written a
+		// status with a pid but no sessionId yet. Result files are addressed by
+		// session and the completion notification is delivered from that file, so
+		// the run was marked failed and nobody was ever told - the earlier the
+		// crash, the more completely it was swallowed.
+		const root = tempRoot("pi-stale-run-early-death-");
+		try {
+			const asyncDir = path.join(root, "run-early");
+			const resultsDir = path.join(root, "results");
+			writeStatus(asyncDir, {
+				runId: "run-early",
+				mode: "single",
+				state: "running",
+				pid: 85090,
+				startedAt: 1000,
+				lastUpdate: 1000,
+				currentStep: 0,
+				steps: [{ agent: "reviewer", status: "running", startedAt: 1000 }],
+			});
+
+			const result = reconcileAsyncRun(asyncDir, {
+				resultsDir,
+				kill: () => { throw errno("ESRCH"); },
+				now: () => 2000,
+				startedRun: { runId: "run-early", pid: 85090, sessionId: "session-parent" },
+			});
+
+			assert.equal(result.repaired, true);
+			assert.equal(result.status?.state, "failed");
+			// The session that started the run stands in, so the failure is
+			// deliverable rather than merely recorded.
+			assert.equal(result.resultPath !== undefined, true);
+			const resultJson = JSON.parse(fs.readFileSync(path.join(resultsDir, "run-early.json"), "utf-8"));
+			assert.equal(resultJson.success, false);
+			assert.equal(resultJson.sessionId, "session-parent");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("marks a running async run failed when the runner pid is dead and no result exists", () => {
 		const root = tempRoot("pi-stale-run-");
 		try {


### PR DESCRIPTION
Fixes #1480.

## Problem

A completion notification is delivered from a run's result file, and result files are addressed by session (`writeIndexedPendingResultFile` throws without a `sessionId`). So `writeFailedRepair` only writes one when the status already carries a session:

```ts
if (repair.result.sessionId) writeAsyncResultFile(resultPath, repair.result);
```

A runner that exits during startup has not recorded a `sessionId` yet. Its run is correctly marked `failed` in `status.json`, but no result file is written and no notification is delivered — the parent, which had already handed back control on "N agents started", never hears anything again.

The guard drops exactly the failures that most need reporting: the earlier the crash, the less the runner recorded, and the more completely the failure is swallowed. A crash during startup is silent by construction.

Observed twice in one session (4 and 3 children), reported as:

```
Async runner process 85090 exited or disappeared before writing a result. Marked run as failed.
```

## Change

The session that started the run is already known independently — the tracker passes it in as `options.startedRun.sessionId`. It now stands in when the status has none, so the repaired failure is deliverable rather than merely recorded.

The invariant this restores: **a run that stops running produces exactly one completion signal, success or failure.** Today that holds only for runs that lived long enough to name themselves.

## Verification

One test added to `test/unit/stale-run-reconciler.test.ts`, covering a status with a pid and no session. It fails on `main` (the result file is absent) and passes with the change.

```
$ npm run typecheck    # clean
$ node --test test/unit/stale-run-reconciler.test.ts
  before: 10 pass, 1 fail
  after:  11 pass, 0 fail
$ npm run test:unit
  2476 pass, 17 fail
```

Those 17 failures are pre-existing and unrelated (agent enable/disable management); `main` at the same commit reports 2475 pass / 17 fail.
