### PR TITLE
fix: exclude completed schedules from pending limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Exclude completed one-shot schedules from the pending schedule limit without deleting their durable history. Thanks to [@rafafortes](https://github.com/rafafortes) for #1478.
 - Preserve the local user identity and temporary-directory environment needed by authenticated Claude Code adapter runs.
 - Preserve structured-output and related bounded child contract fields when foreground workflow children resume. Thanks to [@Livan-pro](https://github.com/Livan-pro) for #1460.
 - Preview runtime-recorded workflow child sessions in Fleet and inspect without trusting sibling transcripts. Thanks to [@JHa13y](https://github.com/JHa13y) for #1441.

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -294,6 +294,10 @@ function resolveMaxPending(config: ExtensionConfig): number {
 	return typeof value === "number" && Number.isInteger(value) && value >= 1 ? value : DEFAULT_MAX_PENDING;
 }
 
+function hasPendingScheduleWork(schedule: ScheduleRecord): boolean {
+	return schedule.activeRunId !== undefined || schedule.trigger.nextRunAt !== undefined;
+}
+
 function nextAfter(trigger: ScheduleTrigger, plannedAt: number, now: number): string | undefined {
 	if (trigger.kind === "once") return undefined;
 	let next = plannedAt + trigger.everyMs;
@@ -479,7 +483,9 @@ export class ScheduledRunManager {
 		if (params.on !== undefined || params.timezone !== undefined || every === "day" || every === "week" || every === "month" || every === "year") return textResult("Calendar schedules are deferred from this first safe slice. Use a fixed interval such as every:'24h' or every:'7d'.", undefined, undefined, true);
 		const sessionId = ctx.sessionManager.getSessionId() ?? "unknown";
 		if (this.deps.resolveCapabilityCeiling?.(sessionId)) return textResult("Cannot persist a schedule while a capability ceiling is active.", undefined, undefined, true);
-		if (store.list().length >= resolveMaxPending(this.deps.config)) return textResult(`Schedule limit reached (${resolveMaxPending(this.deps.config)}).`, undefined, undefined, true);
+		const pendingCount = store.list().filter(hasPendingScheduleWork).length;
+		const maxPending = resolveMaxPending(this.deps.config);
+		if (pendingCount >= maxPending) return textResult(`Schedule limit reached (${maxPending}).`, undefined, undefined, true);
 		const id = validateScheduleId((params.id?.trim() || this.randomId()));
 		if (store.ids().includes(id)) return textResult(`Schedule '${id}' already exists.`, undefined, undefined, true);
 		const now = this.now();

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -153,6 +153,28 @@ describe("project schedule management", () => {
 		assert.match(text(shown), /Night review/);
 	});
 
+	it("does not let completed one-shot schedules consume maxPending capacity", async () => {
+		const h = harness({ config: { scheduledRuns: { enabled: true, maxPending: 1 } } });
+		await h.manager.handleToolCall({ action: "schedule.create", id: "completed", at: "+1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		h.clock.now += 3_600_000;
+		h.timers.fireAll();
+		await flush();
+		assert.equal(h.launches.length, 1);
+		const activeResult = await h.manager.handleToolCall({ action: "schedule.create", id: "active-blocked", at: "+2h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		assert.equal(activeResult.isError, true);
+		h.launches[0]!.resolve({ content: [{ type: "text", text: "Async" }], details: { mode: "single", results: [], asyncId: "completed-async" } });
+		await flush();
+		h.manager.handleAsyncCompletion({ runId: "completed-async", success: true });
+
+		const result = await h.manager.handleToolCall({ action: "schedule.create", id: "replacement", at: "+2h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		assert.equal(result.isError, undefined);
+		const completedDir = path.join(scheduledRunStorePath(h.ctx.cwd, undefined, path.join(h.root, "stores")), "completed");
+		assert.equal(fs.existsSync(path.join(completedDir, "history.json")), true);
+		assert.equal(fs.existsSync(path.join(completedDir, "events.jsonl")), true);
+		const completedHistory = await h.manager.handleToolCall({ action: "schedule.history", id: "completed" }, h.ctx);
+		assert.match(text(completedHistory), /completed.*async completed-async/);
+	});
+
 	it("stores explicit cwd schedules in the target project", async () => {
 		const h = harness();
 		const target = path.join(h.root, "other-project");


### PR DESCRIPTION
Fixes #1478.

Completed one-shot schedules no longer count against `scheduledRuns.maxPending`. Active one-shots, future one-shots, and recurring schedules still count, so capacity is only released after the scheduled work finishes.

This keeps the schedule directory, `history.json`, and `events.jsonl` intact. It does not add automatic deletion, archiving, retention policy, or a background sweep.

Validation:
- `test/unit/scheduled-runs.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`

Thanks to [@rafafortes](https://github.com/rafafortes) for #1478.
