### PR TITLE
fix: record terminal run outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Exclude completed one-shot schedules from the pending schedule limit without deleting their durable history. Thanks to [@rafafortes](https://github.com/rafafortes) for #1478.
 - Repair bounded dead async run candidates before retention classifies them, so existing terminal retention guards can reclaim stale run directories without deleting ambiguous worktrees or branches. Thanks to [@rafafortes](https://github.com/rafafortes) for #1477.
 - Make async runs visible to exact status lookup as soon as launch succeeds, and deliver one completion when a runner dies before its normal status write. Thanks to [@rafafortes](https://github.com/rafafortes) for #1471 and [@VincentHanxiaoDu](https://github.com/VincentHanxiaoDu) for #1480.
+- Record explicit completed, failed, timed-out, stopped, and interrupted outcomes in run history. Thanks to [@rafafortes](https://github.com/rafafortes) for #1474.
 - Preserve the local user identity and temporary-directory environment needed by authenticated Claude Code adapter runs.
 - Preserve structured-output and related bounded child contract fields when foreground workflow children resume. Thanks to [@Livan-pro](https://github.com/Livan-pro) for #1460.
 - Preview runtime-recorded workflow child sessions in Fleet and inspect without trusting sibling transcripts. Thanks to [@JHa13y](https://github.com/JHa13y) for #1441.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3749,7 +3749,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 						}
 					}
 				}
-				recordRun(params.agent!, cleanTask, result.exitCode, result.progressSummary?.durationMs ?? 0);
+				recordRun(params.agent!, cleanTask, result.exitCode, result.progressSummary?.durationMs ?? 0, result);
 			},
 			timeoutMs: data.timeoutMs,
 			deadlineAt,
@@ -3774,7 +3774,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		}
 	}
 	if (!r.detached) {
-		recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0);
+		recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0, r);
 	}
 
 	let worktreeHandoff: ReturnType<typeof finalizeSingleWorktreeHandoff> | undefined;

--- a/src/runs/shared/run-history.ts
+++ b/src/runs/shared/run-history.ts
@@ -2,6 +2,9 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAgentDir } from "../../shared/utils.ts";
+import { isUnexplainedProcessSignal } from "./process-signal.ts";
+
+export type RunOutcome = "completed" | "failed" | "timed_out" | "stopped" | "interrupted";
 
 export interface RunEntry {
 	agent: string;
@@ -9,6 +12,7 @@ export interface RunEntry {
 	taskHash?: string;
 	ts: number;
 	status: "ok" | "error";
+	outcome?: RunOutcome;
 	duration: number;
 	exit?: number;
 }
@@ -129,14 +133,30 @@ function appendPrivateHistoryLine(historyPath: string, line: string): void {
 	}
 }
 
-export function recordRun(agent: string, task: string, exitCode: number, durationMs: number): void {
+export function recordRun(
+	agent: string,
+	task: string,
+	exitCode: number,
+	durationMs: number,
+	terminal: { interrupted?: boolean; processSignal?: string | null; stopped?: boolean; timedOut?: boolean; turnBudgetExceeded?: boolean } = {},
+): void {
 	try {
+		const outcome: RunOutcome = terminal.stopped
+			? "stopped"
+			: terminal.interrupted
+				? "interrupted"
+				: terminal.timedOut
+					? "timed_out"
+					: exitCode !== 0 && isUnexplainedProcessSignal(terminal)
+						? "stopped"
+						: exitCode === 0 ? "completed" : "failed";
 		const entry: RunEntry = {
 			agent,
 			task: REDACTED_TASK,
 			taskHash: hashTask(task),
 			ts: Math.floor(Date.now() / 1000),
 			status: exitCode === 0 ? "ok" : "error",
+			outcome,
 			duration: durationMs,
 			...(exitCode !== 0 ? { exit: exitCode } : {}),
 		};

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -222,6 +222,21 @@ Package skill content.
 		assert.equal(fs.existsSync(artifactPath), false);
 	});
 
+	it("records explicit run outcomes without guessing legacy outcomes", () => {
+		const historyPath = path.join(agentDir, "run-history.jsonl");
+		writeFile(historyPath, `${JSON.stringify({ agent: "outcome-agent", task: "[redacted]", ts: 1, status: "error", duration: 1, exit: 143 })}\n`);
+		recordRun("outcome-agent", "failed", 1, 2);
+		recordRun("outcome-agent", "timed out", 1, 3, { timedOut: true });
+		recordRun("outcome-agent", "interrupted", 1, 4, { interrupted: true });
+		recordRun("outcome-agent", "stopped", 1, 5, { stopped: true });
+		recordRun("outcome-agent", "completed", 0, 6);
+		recordRun("outcome-agent", "signalled", 143, 7, { processSignal: "SIGTERM" });
+
+		const history = loadRunsForAgent("outcome-agent");
+		assert.deepEqual(history.map((entry) => entry.outcome), ["stopped", "completed", "stopped", "interrupted", "timed_out", "failed", undefined]);
+		assert.equal(history.at(-1)?.exit, 143);
+	});
+
 	it("resolves configured artifact directory preferences", () => {
 		const sessionFile = path.join(agentDir, "sessions", "session-1", "session.jsonl");
 


### PR DESCRIPTION
Fixes #1474.

This adds an optional `outcome` field to new `run-history.jsonl` entries. New records derive it from existing terminal result fields: stopped, interrupted, timed out, then exit code to completed or failed.

Legacy history entries remain readable without guessing outcomes from old exit codes. This PR intentionally does not change #1472 capacity release behavior; that issue remains blocked until there is durable proof that writer descendant process trees are gone, not only that the runner PID died.

Validation:
- `test/unit/pi-coding-agent-dir.test.ts`
- `test/unit/active-async-capacity.test.ts`
- `test/unit/stale-run-reconciler.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`

Thanks to [@rafafortes](https://github.com/rafafortes) for #1474.
