### PR TITLE
fix: survive stale session ctx on async process-terminal delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Repair bounded dead async run candidates before retention classifies them, so existing terminal retention guards can reclaim stale run directories without deleting ambiguous worktrees or branches. Thanks to [@rafafortes](https://github.com/rafafortes) for #1477.
 - Make async runs visible to exact status lookup as soon as launch succeeds, and deliver one completion when a runner dies before its normal status write. Thanks to [@rafafortes](https://github.com/rafafortes) for #1471 and [@VincentHanxiaoDu](https://github.com/VincentHanxiaoDu) for #1480.
 - Record explicit completed, failed, timed-out, stopped, and interrupted outcomes in run history. Thanks to [@rafafortes](https://github.com/rafafortes) for #1474.
+- Keep async runner process-terminal event delivery from crashing the session when the captured extension context is stale after a session replacement or reload; the terminal proof is already persisted to the run directory before the event, and the replacement session reconciles run state from disk. Thanks to [@AdrianAcala](https://github.com/AdrianAcala) for #1485.
 - Preserve the local user identity and temporary-directory environment needed by authenticated Claude Code adapter runs.
 - Preserve structured-output and related bounded child contract fields when foreground workflow children resume. Thanks to [@Livan-pro](https://github.com/Livan-pro) for #1460.
 - Preview runtime-recorded workflow child sessions in Fleet and inspect without trusting sibling transcripts. Thanks to [@JHa13y](https://github.com/JHa13y) for #1441.

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -127,7 +127,7 @@ function resolveJitiCliPath(): string | undefined {
 
 const jitiCliPath = resolveJitiCliPath();
 
-interface AsyncExecutionContext {
+export interface AsyncExecutionContext {
 	pi: ExtensionAPI;
 	cwd: string;
 	currentSessionId: string;
@@ -495,6 +495,30 @@ interface SpawnRunnerResult {
 	startupDidNotProceed?: boolean;
 }
 
+function isStaleExtensionContextError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	return /extension ctx is stale|stale after session replacement or reload|extension context no longer active/i.test(error.message);
+}
+
+/**
+ * Emit the runner process-terminal proof as an advisory in-process event.
+ * The proof is already persisted to disk by the runner close handler before
+ * this runs, and the captured ctx is stale if the session was replaced
+ * (newSession/fork/switchSession) or reloaded while the async runner was
+ * still running. Dropping the event in that case is safe: the replacement
+ * session's extension instance reconciles run state from disk. Non-stale
+ * emit failures are logged instead of thrown so the detached child-process
+ * close path can never take down the host as an uncaught exception.
+ */
+export function emitProcessTerminalEvent(ctx: AsyncExecutionContext, proof: unknown): void {
+	try {
+		ctx.pi.events.emit(SUBAGENT_PROCESS_TERMINAL_EVENT, proof);
+	} catch (error) {
+		if (isStaleExtensionContextError(error)) return;
+		console.error("Failed to emit subagent process-terminal event:", error);
+	}
+}
+
 function spawnRunner(cfg: object, suffix: string, cwd: string, initialStatus: Omit<AsyncStatus, "pid" | "processTerminal">, initialStatusPath: string, onProcessTerminal?: (proof: unknown) => void): SpawnRunnerResult {
 	if (!jitiCliPath) {
 		return { error: "upstream jiti for TypeScript execution could not be found; ensure package dependencies are installed" };
@@ -606,7 +630,11 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, initialStatus: Om
 					console.error("Failed to emit final nested process-terminal status:", error);
 				}
 			}
-			onProcessTerminal?.(persisted);
+			try {
+				onProcessTerminal?.(persisted);
+			} catch (error) {
+				console.error("Failed to handle async runner process terminal:", error);
+			}
 		});
 		if (typeof proc.pid !== "number") {
 			return { error: `async runner did not produce a pid for cwd: ${cwd}` };
@@ -1297,7 +1325,7 @@ export function executeAsyncChain(
 				steps: initialStatusSteps,
 			},
 			path.join(asyncDir, "status.json"),
-			(proof) => ctx.pi.events.emit(SUBAGENT_PROCESS_TERMINAL_EVENT, proof),
+			(proof) => emitProcessTerminalEvent(ctx, proof),
 		);
 	} catch (error) {
 		params.activeAsyncCapacity?.rollback();
@@ -1846,7 +1874,7 @@ export function executeAsyncSingle(
 				steps: [{ agent, status: "pending" }],
 			},
 			path.join(asyncDir, "status.json"),
-			(proof) => ctx.pi.events.emit(SUBAGENT_PROCESS_TERMINAL_EVENT, proof),
+			(proof) => emitProcessTerminalEvent(ctx, proof),
 		);
 	} catch (error) {
 		params.activeAsyncCapacity?.rollback();

--- a/test/unit/async-execution.test.ts
+++ b/test/unit/async-execution.test.ts
@@ -169,10 +169,12 @@ describe("async runner process terminal events", () => {
 	});
 
 	it("drops the process terminal proof without throwing when the session ctx is stale after replacement or reload", () => {
-		const ctx = makeCtx(() => {
-			throw new Error(staleSessionMessage);
-		});
-		assert.doesNotThrow(() => emitProcessTerminalEvent(ctx, proof));
+		for (const message of [staleSessionMessage, "Extension context no longer active."]) {
+			const ctx = makeCtx(() => {
+				throw new Error(message);
+			});
+			assert.doesNotThrow(() => emitProcessTerminalEvent(ctx, proof));
+		}
 	});
 
 	it("logs instead of throwing when the event bus fails with a non-stale error", () => {

--- a/test/unit/async-execution.test.ts
+++ b/test/unit/async-execution.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { buildAsyncRunnerSteps, DEFAULT_ASYNC_TIMEOUT_MS, formatAsyncStartedMessage, resolveAsyncRunnerLogPaths } from "../../src/runs/background/async-execution.ts";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { buildAsyncRunnerSteps, DEFAULT_ASYNC_TIMEOUT_MS, emitProcessTerminalEvent, formatAsyncStartedMessage, resolveAsyncRunnerLogPaths } from "../../src/runs/background/async-execution.ts";
+import { SUBAGENT_PROCESS_TERMINAL_EVENT } from "../../src/shared/types.ts";
 import type { AgentConfig } from "../../src/agents/agents.ts";
 
 const agent = (name: string, toolBudget?: AgentConfig["toolBudget"]): AgentConfig => ({
@@ -146,5 +148,45 @@ describe("async runner execution", () => {
 
 		assert.ok("steps" in result, "expected successful step build");
 		assert.deepEqual(result.steps[0]?.toolBudget, { hard: 5, block: ["ls"] });
+	});
+});
+
+describe("async runner process terminal events", () => {
+	const proof = { version: 1, runId: "run-terminal", runnerProcessInstanceId: "runner-1", state: "unknown", reason: "writer-close-unverified" };
+	const staleSessionMessage = "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().";
+
+	const makeCtx = (emit: (name: string, payload?: unknown) => unknown) => ({
+		cwd: process.cwd(),
+		currentSessionId: "session-1",
+		pi: { events: { emit } } as unknown as ExtensionAPI,
+	});
+
+	it("emits the process terminal proof on the event bus for a live session ctx", () => {
+		const emitted: Array<[string, unknown]> = [];
+		const ctx = makeCtx((name, payload) => { emitted.push([name, payload]); });
+		emitProcessTerminalEvent(ctx, proof);
+		assert.deepEqual(emitted, [[SUBAGENT_PROCESS_TERMINAL_EVENT, proof]]);
+	});
+
+	it("drops the process terminal proof without throwing when the session ctx is stale after replacement or reload", () => {
+		const ctx = makeCtx(() => {
+			throw new Error(staleSessionMessage);
+		});
+		assert.doesNotThrow(() => emitProcessTerminalEvent(ctx, proof));
+	});
+
+	it("logs instead of throwing when the event bus fails with a non-stale error", () => {
+		const ctx = makeCtx(() => {
+			throw new Error("event bus unavailable");
+		});
+		const originalError = console.error;
+		let logged: unknown[] | undefined;
+		console.error = (...args: unknown[]) => { logged = args; };
+		try {
+			assert.doesNotThrow(() => emitProcessTerminalEvent(ctx, proof));
+		} finally {
+			console.error = originalError;
+		}
+		assert.ok(logged?.some((arg) => arg instanceof Error && arg.message === "event bus unavailable"), "expected the bus failure to be logged");
 	});
 });


### PR DESCRIPTION
## Problem

pi can exit with `uncaughtException` when an async runner exits after its owning session has been replaced or reloaded:

```
pi exiting due to uncaughtException:
Error: This extension ctx is stale after session replacement or reload. ...
    at Object.emit (.../chunk-*.js)
    at .../pi-subagents/src/runs/background/async-execution.ts:1776:32
    at ChildProcess.<anonymous> (.../async-execution.ts:603:26)
```

## Root cause

`spawnRunner()` registers a `proc.once("close", ...)` handler on the detached async runner. At the end of that handler it calls `onProcessTerminal?.(persisted)` (line 603), and both launch sites pass a callback that captures the extension command `ctx` from launch time:

```ts
(proof) => ctx.pi.events.emit(SUBAGENT_PROCESS_TERMINAL_EVENT, proof),  // lines 1243, 1776
```

If the session is replaced (`ctx.newSession()`, `ctx.fork()`, `ctx.switchSession()`) or reloaded while the runner is still running, pi-core invalidates the old ctx. When the runner later exits, the late `emit()` hits `assertActive()`, which throws — from inside a child-process close callback, outside any tool-handler call stack — so the error becomes an uncaughtException and takes the session down.

This is the same stale-ctx class of bug as the animation-timer crash fixed in v0.21 (#122), but the async process-terminal path was never guarded; the only existing guard (`subagent-executor.ts`) covers foreground runs.

## Fix

In `src/runs/background/async-execution.ts`:

1. Add `isStaleExtensionContextError()` using the same regex already used in `subagent-executor.ts`.
2. Add `emitProcessTerminalEvent(ctx, proof)` (exported for testing): when the ctx is stale, drop the event silently — the process-terminal proof is **already persisted to `process-terminal.json`** by the close handler before the emit, and the replacement session's extension instance reconciles run state from disk. Non-stale emit failures are logged instead of thrown.
3. Both launch sites (single + chain/workflow) use the helper instead of the raw `ctx.pi.events.emit`.
4. Wrap `onProcessTerminal?.(persisted)` in the close handler in try/catch so the detached child-process close path can never take down the host regardless of what the callback does.

No hot-path cost: this only touches the rare late-exit path after session replacement.

## Verification

- `npm run typecheck` — clean
- `npm test` — 2494 pass, 0 fail (includes 3 new unit tests for `emitProcessTerminalEvent`: live-ctx emit, stale-ctx drop, non-stale failure logged)
- End-to-end repro against the real `executeAsyncSingle` path: launch an async run, invalidate the ctx (simulated session replacement), SIGKILL the runner process group.
  - Unpatched v0.56.0: host dies with `uncaughtException: This extension ctx is stale after session replacement or reload.`
  - Patched: `process-terminal.json` proof written, stale event dropped, host process survives.
- Note: one pre-existing integration failure (`fork-context-execution.test.ts` — `uses request cwd for execution-time agent discovery`) also fails on unmodified upstream HEAD; unrelated to this change.

Closes the crash reported in #897's stack (that issue itself was attributed to pi-powerline-footer; this stack is the pi-subagents async path).