### PR TITLE
fix: repair stale runs during retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Exclude completed one-shot schedules from the pending schedule limit without deleting their durable history. Thanks to [@rafafortes](https://github.com/rafafortes) for #1478.
+- Repair bounded dead async run candidates before retention classifies them, so existing terminal retention guards can reclaim stale run directories without deleting ambiguous worktrees or branches. Thanks to [@rafafortes](https://github.com/rafafortes) for #1477.
 - Preserve the local user identity and temporary-directory environment needed by authenticated Claude Code adapter runs.
 - Preserve structured-output and related bounded child contract fields when foreground workflow children resume. Thanks to [@Livan-pro](https://github.com/Livan-pro) for #1460.
 - Preview runtime-recorded workflow child sessions in Fleet and inspect without trusting sibling transcripts. Thanks to [@JHa13y](https://github.com/JHa13y) for #1441.

--- a/src/runs/background/async-retention.ts
+++ b/src/runs/background/async-retention.ts
@@ -9,6 +9,7 @@ import type { AsyncStatus } from "../../shared/types.ts";
 import { MISSION_BINDING_FILE } from "../../missions/lifecycle.ts";
 import { ACTIVE_RUN_INDEX_DIR } from "./active-run-index.ts";
 import { encodeIndexSegment } from "./index-segment.ts";
+import { reconcileAsyncRun } from "./stale-run-reconciler.ts";
 
 export const ASYNC_RETENTION_DAYS = 30;
 export const ASYNC_RETENTION_BATCH_SIZE = 100;
@@ -96,11 +97,13 @@ export interface AsyncRetentionOptions {
 	lstatSync?: typeof fs.lstatSync;
 	signal?: AbortSignal;
 	discoveryWorkerUrl?: URL;
+	reconcileKill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 }
 
 export interface AsyncRetentionResult {
 	acquired: boolean;
 	scanned: number;
+	repairedRuns: number;
 	deletedRuns: number;
 	deletedResults: number;
 	reapedTombstones: number;
@@ -504,6 +507,7 @@ function appendMaintenanceLog(root: string, result: AsyncRetentionResult, now: n
 		at: new Date(now).toISOString(),
 		acquired: result.acquired,
 		scanned: result.scanned,
+		repairedRuns: result.repairedRuns,
 		deletedRuns: result.deletedRuns,
 		deletedResults: result.deletedResults,
 		reapedTombstones: result.reapedTombstones,
@@ -654,6 +658,7 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 	const result: AsyncRetentionResult = {
 		acquired: false,
 		scanned: 0,
+		repairedRuns: 0,
 		deletedRuns: 0,
 		deletedResults: 0,
 		reapedTombstones: 0,
@@ -750,7 +755,19 @@ export async function cleanupAsyncRetention(options: AsyncRetentionOptions): Pro
 					increment(result.skipped, "unsafe-run-path");
 					continue;
 				}
-				const status = readStatus(runDir);
+				let status = readStatus(runDir);
+				if (status?.state === "running"
+					&& validRunId(status.runId)
+					&& path.basename(runDir) === status.runId
+					&& !protectedRunIds.has(status.runId)) {
+					const reconciliation = reconcileAsyncRun(runDir, {
+						resultsDir: options.resultsDir,
+						kill: options.reconcileKill,
+						now,
+					});
+					status = reconciliation.status ?? undefined;
+					if (reconciliation.repaired) result.repairedRuns += 1;
+				}
 				const initialReason = runSkipReason({ runDir, status, asyncDirRoot: options.asyncDirRoot, resultsDir: options.resultsDir, cutoff, protectedRunIds, waitRunIds: waitReferences.runIds });
 				if (initialReason) {
 					increment(result.skipped, initialReason);

--- a/test/unit/async-retention.test.ts
+++ b/test/unit/async-retention.test.ts
@@ -47,6 +47,12 @@ function writeOldResult(resultsDir: string, runId: string, overrides: Record<str
 	return resultPath;
 }
 
+function errno(code: string): NodeJS.ErrnoException {
+	const error = new Error(code) as NodeJS.ErrnoException;
+	error.code = code;
+	return error;
+}
+
 function cleanupOptions(roots: ReturnType<typeof makeRoots>) {
 	return {
 		...roots,
@@ -64,6 +70,53 @@ function writeRunTombstoneMarker(roots: ReturnType<typeof makeRoots>, runId: str
 }
 
 describe("async retention cleanup", () => {
+	it("repairs bounded dead running candidates before retention classification", async () => {
+		const roots = makeRoots();
+		try {
+			const runDir = writeOldRun(roots.asyncDirRoot, "dead-running", {
+				state: "running",
+				endedAt: undefined,
+				lastUpdate: OLD,
+				pid: 12345,
+				sessionId: "session-a",
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			fs.mkdirSync(path.join(roots.asyncDirRoot, ".active-runs"));
+			fs.writeFileSync(path.join(roots.asyncDirRoot, ".active-runs", "dead-running"), "");
+			const protectedDir = writeOldRun(roots.asyncDirRoot, "protected-running", {
+				state: "running",
+				endedAt: undefined,
+				lastUpdate: OLD,
+				pid: 12346,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+
+			const repaired = await cleanupAsyncRetention({
+				...cleanupOptions(roots),
+				protectedRunIds: ["protected-running"],
+				reconcileKill: () => { throw errno("ESRCH"); },
+			});
+
+			assert.equal(repaired.repairedRuns, 1);
+			assert.equal(repaired.deletedRuns, 0);
+			assert.equal(repaired.skipped.recent, 1);
+			assert.equal(JSON.parse(fs.readFileSync(path.join(runDir, "status.json"), "utf-8")).state, "failed");
+			assert.equal(fs.existsSync(path.join(roots.asyncDirRoot, ".active-runs", "dead-running")), false);
+			assert.equal(fs.existsSync(path.join(roots.resultsDir, "dead-running.json")), true);
+			assert.equal(JSON.parse(fs.readFileSync(path.join(protectedDir, "status.json"), "utf-8")).state, "running");
+			assert.equal(repaired.skipped["runtime-reference"], 1);
+
+			const retained = await cleanupAsyncRetention({
+				...cleanupOptions(roots),
+				now: () => NOW + 45 * DAY_MS,
+			});
+			assert.equal(retained.deletedRuns, 1);
+			assert.equal(fs.existsSync(runDir), false);
+		} finally {
+			fs.rmSync(roots.root, { recursive: true, force: true });
+		}
+	});
+
 	it("deletes old proven-terminal runs and orphan results through tombstones", async () => {
 		const roots = makeRoots();
 		try {


### PR DESCRIPTION
Closes #1477.

This repairs stale async run directories during the existing bounded retention pass. Retention now reuses `reconcileAsyncRun()` for running candidates only after identity and runtime-protection guards pass, then lets the normal terminal/reference/age/tombstone guards decide later deletion.

It does not add automatic worktree deletion, branch deletion, cross-session pool eviction, force cleanup, or a new hot-path scan.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/async-retention.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`

Credit: thanks to @rafafortes for #1477.
