### PR TITLE
fix: tolerate stale process terminal events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Keep async runner process-terminal event delivery from crashing the session when the captured extension context is stale after a session replacement or reload. Thanks to [@AdrianAcala](https://github.com/AdrianAcala) for #1485.
 - Exclude completed one-shot schedules from the pending schedule limit without deleting their durable history. Thanks to [@rafafortes](https://github.com/rafafortes) for #1478.
 - Repair bounded dead async run candidates before retention classifies them, so existing terminal retention guards can reclaim stale run directories without deleting ambiguous worktrees or branches. Thanks to [@rafafortes](https://github.com/rafafortes) for #1477.
 - Make async runs visible to exact status lookup as soon as launch succeeds, and deliver one completion when a runner dies before its normal status write. Thanks to [@rafafortes](https://github.com/rafafortes) for #1471 and [@VincentHanxiaoDu](https://github.com/VincentHanxiaoDu) for #1480.

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -495,6 +495,19 @@ interface SpawnRunnerResult {
 	startupDidNotProceed?: boolean;
 }
 
+function isStaleExtensionContextError(error: unknown): boolean {
+	return error instanceof Error && /extension ctx is stale|stale after session replacement or reload/i.test(error.message);
+}
+
+export function emitProcessTerminalEvent(ctx: AsyncExecutionContext, proof: unknown): void {
+	try {
+		ctx.pi.events.emit(SUBAGENT_PROCESS_TERMINAL_EVENT, proof);
+	} catch (error) {
+		if (isStaleExtensionContextError(error)) return;
+		console.error("Failed to emit subagent process-terminal event:", error);
+	}
+}
+
 function spawnRunner(cfg: object, suffix: string, cwd: string, initialStatus: Omit<AsyncStatus, "pid" | "processTerminal">, initialStatusPath: string, onProcessTerminal?: (proof: unknown) => void): SpawnRunnerResult {
 	if (!jitiCliPath) {
 		return { error: "upstream jiti for TypeScript execution could not be found; ensure package dependencies are installed" };
@@ -1297,7 +1310,7 @@ export function executeAsyncChain(
 				steps: initialStatusSteps,
 			},
 			path.join(asyncDir, "status.json"),
-			(proof) => ctx.pi.events.emit(SUBAGENT_PROCESS_TERMINAL_EVENT, proof),
+			(proof) => emitProcessTerminalEvent(ctx, proof),
 		);
 	} catch (error) {
 		params.activeAsyncCapacity?.rollback();
@@ -1846,7 +1859,7 @@ export function executeAsyncSingle(
 				steps: [{ agent, status: "pending" }],
 			},
 			path.join(asyncDir, "status.json"),
-			(proof) => ctx.pi.events.emit(SUBAGENT_PROCESS_TERMINAL_EVENT, proof),
+			(proof) => emitProcessTerminalEvent(ctx, proof),
 		);
 	} catch (error) {
 		params.activeAsyncCapacity?.rollback();

--- a/test/unit/async-execution.test.ts
+++ b/test/unit/async-execution.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { buildAsyncRunnerSteps, DEFAULT_ASYNC_TIMEOUT_MS, formatAsyncStartedMessage, resolveAsyncRunnerLogPaths } from "../../src/runs/background/async-execution.ts";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { buildAsyncRunnerSteps, DEFAULT_ASYNC_TIMEOUT_MS, emitProcessTerminalEvent, formatAsyncStartedMessage, resolveAsyncRunnerLogPaths } from "../../src/runs/background/async-execution.ts";
 import type { AgentConfig } from "../../src/agents/agents.ts";
+import { SUBAGENT_PROCESS_TERMINAL_EVENT } from "../../src/shared/types.ts";
 
 const agent = (name: string, toolBudget?: AgentConfig["toolBudget"]): AgentConfig => ({
 	name,
@@ -146,5 +148,43 @@ describe("async runner execution", () => {
 
 		assert.ok("steps" in result, "expected successful step build");
 		assert.deepEqual(result.steps[0]?.toolBudget, { hard: 5, block: ["ls"] });
+	});
+});
+
+describe("async runner process terminal events", () => {
+	const proof = { version: 1, runId: "run-terminal", runnerProcessInstanceId: "runner-1", state: "unknown", reason: "writer-close-unverified" };
+	const staleMessage = "This extension ctx is stale after session replacement or reload.";
+
+	const makeCtx = (emit: (name: string, payload?: unknown) => unknown) => ({
+		...ctx,
+		pi: { events: { emit } } as unknown as ExtensionAPI,
+	});
+
+	it("emits the process terminal proof on a live event bus", () => {
+		const emitted: Array<[string, unknown]> = [];
+		emitProcessTerminalEvent(makeCtx((name, payload) => { emitted.push([name, payload]); }), proof);
+
+		assert.deepEqual(emitted, [[SUBAGENT_PROCESS_TERMINAL_EVENT, proof]]);
+	});
+
+	it("drops stale extension ctx failures without throwing", () => {
+		assert.doesNotThrow(() => emitProcessTerminalEvent(makeCtx(() => {
+			throw new Error(staleMessage);
+		}), proof));
+	});
+
+	it("logs non-stale event bus failures without throwing", () => {
+		const originalError = console.error;
+		let logged: unknown[] | undefined;
+		console.error = (...args: unknown[]) => { logged = args; };
+		try {
+			assert.doesNotThrow(() => emitProcessTerminalEvent(makeCtx(() => {
+				throw new Error("event bus unavailable");
+			}), proof));
+		} finally {
+			console.error = originalError;
+		}
+
+		assert.ok(logged?.some((arg) => arg instanceof Error && arg.message === "event bus unavailable"));
 	});
 });


### PR DESCRIPTION
Supersedes #1485.

This preserves the useful stale session-context process-terminal fix from @AdrianAcala while rebasing it on top of the merged async-start work from #1482.

The process-terminal proof is still written to disk before advisory event delivery. Stale extension-context failures from the captured event bus are dropped because disk is authoritative and the replacement session reconciles from disk. Non-stale event-bus failures are logged.

This does not change capacity release behavior, raw runner PID proof, public APIs, or cleanup policy.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/async-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/process-terminal.test.ts test/unit/active-async-capacity.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`

Credit: thanks to @AdrianAcala for #1485.
