### PR TITLE
fix: preserve parent model across workflow handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## [Unreleased]
 
 ### Fixed
-- Preserve the parent model across workflow handoffs so delayed children cannot fall back to a different provider. Thanks to [@alexei-led](https://github.com/alexei-led) for #1489.
 - Exclude completed one-shot schedules from the pending schedule limit without deleting their durable history. Thanks to [@rafafortes](https://github.com/rafafortes) for #1478.
 - Repair bounded dead async run candidates before retention classifies them, so existing terminal retention guards can reclaim stale run directories without deleting ambiguous worktrees or branches. Thanks to [@rafafortes](https://github.com/rafafortes) for #1477.
 - Make async runs visible to exact status lookup as soon as launch succeeds, and deliver one completion when a runner dies before its normal status write. Thanks to [@rafafortes](https://github.com/rafafortes) for #1471 and [@VincentHanxiaoDu](https://github.com/VincentHanxiaoDu) for #1480.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - External one-shot runners now support bounded parser hooks and logs, environment allowlists, cached launch preflight, coalesced parser progress, and process-tree cleanup.
 
 ### Fixed
+- Preserve the parent model across workflow handoffs so delayed children cannot fall back to a different provider. Thanks to [@alexei-led](https://github.com/alexei-led) for #1489.
 - Make workflow validation and return serialization failures easier to recover from with no-child-launch diagnostics, portable rewrite guidance, workflow ids, and completed-child output references (#1432, #1434).
 - Report child processes that exit during tool execution as mid-tool failures instead of cold starts, even when earlier assistant text exists. Thanks to [@cyzlmh](https://github.com/cyzlmh) for #1437.
 - Keep unaddressable legacy result aliases and overlong public result filenames from blocking canonical hashed or pending fallbacks. Thanks to [@LeonardBode](https://github.com/LeonardBode) for #1440.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Preserve the parent model across workflow handoffs so delayed children cannot fall back to a different provider. Thanks to [@alexei-led](https://github.com/alexei-led) for #1489.
 - Exclude completed one-shot schedules from the pending schedule limit without deleting their durable history. Thanks to [@rafafortes](https://github.com/rafafortes) for #1478.
 - Repair bounded dead async run candidates before retention classifies them, so existing terminal retention guards can reclaim stale run directories without deleting ambiguous worktrees or branches. Thanks to [@rafafortes](https://github.com/rafafortes) for #1477.
 - Make async runs visible to exact status lookup as soon as launch succeeds, and deliver one completion when a runner dies before its normal status write. Thanks to [@rafafortes](https://github.com/rafafortes) for #1471 and [@VincentHanxiaoDu](https://github.com/VincentHanxiaoDu) for #1480.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4353,6 +4353,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		onUpdate: ((r: AgentToolResult<Details>) => void) | undefined,
 		ctx: ExtensionContext,
 		preserveActiveSession = false,
+		parentModelOverride?: ParentModel | null,
 	): Promise<AgentToolResult<Details>> => {
 		if (params.action?.trim() === "validate") {
 			const validation = validateWorkflowScript(params.workflowScript ?? "");
@@ -4376,6 +4377,19 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const normalizedAction = typeof requestParams.action === "string" ? requestParams.action.trim() : requestParams.action;
 		if (normalizedAction === "resume" && requestParams.extensionBindings !== undefined) return buildRequestedModeError(requestParams, "extensionBindings is not supported with action='resume'; resume uses the original retained child binding.");
 		if (requestParams.workflowScript !== undefined && normalizedAction === undefined) {
+			const workflowParentModel = parentModelOverride !== undefined
+				? parentModelOverride
+				: (() => {
+					try {
+						const parentModel = normalizeParentModel(ctx.model);
+						const sessionId = resolveCurrentSessionId(ctx.sessionManager);
+						return (preserveActiveSession
+							? parentModel
+							: rememberParentModel(deps.state, sessionId, parentModel)) ?? null;
+					} catch {
+						return normalizeParentModel(ctx.model) ?? null;
+					}
+				})();
 			if (requestParams.extensionBindings !== undefined) {
 				try {
 					requestParams.extensionBindings = normalizeExtensionBindings(requestParams.extensionBindings)!.value;
@@ -4834,7 +4848,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 											status: step.status,
 											heartbeat: { status: step.status, ...(childPhase ? { phase: childPhase } : {}) },
 										});
-									}, ctx, preserveActiveSession);
+									}, ctx, preserveActiveSession, workflowParentModel);
 								});
 								workflowResults.push(...result.details.results);
 								for (const childResult of result.details.results) {
@@ -4864,7 +4878,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								}
 								return child;
 							},
-							status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession)),
+							status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession, workflowParentModel)),
 							resolveResume: (reference) => resolveKeyedWorkflowResume(reference, deps.state),
 							steer: (key, message, options, workflowSignal) => steerWorkflowChildByKey({ state: deps.state, workflowRunId, key, message, options, signal: workflowSignal, resolveRunId: () => workflowChildRunIds.get(key) }),
 						});
@@ -5013,7 +5027,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 									status: progressStatus,
 									heartbeat: { status: progressStatus, ...(childPhase ? { phase: childPhase } : {}) },
 								});
-							}, ctx, preserveActiveSession);
+							}, ctx, preserveActiveSession, workflowParentModel);
 						});
 						workflowResults.push(...result.details.results);
 						for (const childResult of result.details.results) {
@@ -5034,7 +5048,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						});
 						return child;
 					},
-					status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession)),
+					status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession, workflowParentModel)),
 					resolveResume: (reference) => resolveKeyedWorkflowResume(reference, deps.state),
 					steer: (key, message, options, workflowSignal) => steerWorkflowChildByKey({ state: deps.state, workflowRunId: _id, key, message, options, signal: workflowSignal, resolveRunId: () => workflowChildRunIds.get(key) }),
 				});
@@ -5082,9 +5096,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		try {
 			requestSessionId = resolveCurrentSessionId(ctx.sessionManager);
 			requestPiSessionId = ctx.sessionManager.getSessionId() ?? undefined;
-			requestParentModel = preserveActiveSession
-				? normalizeParentModel(ctx.model)
-				: rememberParentModel(deps.state, requestSessionId, ctx.model);
+			requestParentModel = parentModelOverride !== undefined
+				? parentModelOverride ?? undefined
+				: preserveActiveSession
+					? normalizeParentModel(ctx.model)
+					: rememberParentModel(deps.state, requestSessionId, ctx.model);
 		} catch (error) {
 			if (action?.toLowerCase() !== "doctor" && action?.toLowerCase() !== "guide") throw error;
 			requestParentModel = normalizeParentModel(ctx.model);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4380,15 +4380,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const workflowParentModel = parentModelOverride !== undefined
 				? parentModelOverride
 				: (() => {
-					try {
-						const parentModel = normalizeParentModel(ctx.model);
-						const sessionId = resolveCurrentSessionId(ctx.sessionManager);
-						return (preserveActiveSession
-							? parentModel
-							: rememberParentModel(deps.state, sessionId, parentModel)) ?? null;
-					} catch {
-						return normalizeParentModel(ctx.model) ?? null;
-					}
+					const parentModel = normalizeParentModel(ctx.model);
+					const sessionId = resolveCurrentSessionId(ctx.sessionManager);
+					return (preserveActiveSession
+						? parentModel
+						: rememberParentModel(deps.state, sessionId, parentModel)) ?? null;
 				})();
 			if (requestParams.extensionBindings !== undefined) {
 				try {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -4347,6 +4347,53 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 
 
 
+	it("async workflows snapshot the parent model before the workflow child launches", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		mockPi.onCall({ output: "Done asynchronously" });
+		const events = createEventBus();
+		const state = {
+			baseCwd: tempDir,
+			currentSessionId: null,
+			asyncJobs: new Map(),
+			foregroundControls: new Map(),
+			lastForegroundControlId: null,
+		};
+		const executor = createSubagentExecutor!({
+			pi: { events, getSessionName: () => undefined },
+			state,
+			config: {},
+			asyncByDefault: false,
+			tempArtifactsDir: tempDir,
+			getSubagentSessionRoot: () => path.join(tempDir, "sessions"),
+			expandTilde: (p: string) => p,
+			discoverAgents: () => ({ agents: [makeAgent("worker")] }),
+		});
+		const context = makeMinimalCtx(tempDir);
+		context.sessionManager.getSessionId = () => "session-workflow-parent-model";
+		context.model = { provider: "router", id: "openai-personal" };
+		context.sessionManager.getSessionFile = () => {
+			// Simulate the parent model leaving the live context during the async workflow handoff.
+			context.model = undefined;
+			return null;
+		};
+
+		const launch = await executor.execute(
+			"workflow-parent-model",
+			{ workflowScript: `return runs.run("child", { agent: "worker", task: "Do work" })`, async: true },
+			new AbortController().signal,
+			undefined,
+			context,
+		) as AsyncExecutionResult;
+		assert.equal(launch.isError, undefined);
+		assert.ok(launch.details.asyncId);
+
+		const payload = await readAsyncPayload(launch.details.asyncId);
+		assert.equal(payload.success, true);
+		const args = readMockPiArgs(mockPi, 0);
+		const modelIndex = args.indexOf("--model");
+		assert.notEqual(modelIndex, -1);
+		assert.equal(args[modelIndex + 1], "router/openai-personal");
+	});
+
 	it("background single runs inherit the parent session model when no model is set", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ output: "Done asynchronously" });
 

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -4373,7 +4373,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		context.sessionManager.getSessionFile = () => {
 			// Simulate the parent model leaving the live context during the async workflow handoff.
 			context.model = undefined;
-			return null;
+			return path.join(tempDir, "parent-session.jsonl");
 		};
 
 		const launch = await executor.execute(


### PR DESCRIPTION
## Summary

Workflow children can start after the live extension context loses `ctx.model`. The child then starts without the parent model. Pi can select a different default model.

Thus, work can run on a provider that the parent did not select.

This change captures the parent model before the workflow handoff. It passes this snapshot to each workflow child. Existing model precedence does not change.

The regression test clears `ctx.model` during the handoff. The child still receives `router/openai-personal`.

## Validation

- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts test/unit/workflow-launch-params.test.ts test/unit/preflight.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='async workflows snapshot the parent model|continuation drops ctx.model|background single runs inherit the parent session model' test/integration/async-execution.test.ts`
- `npm run test:e2e`
- `git diff --check origin/main...HEAD`

## Known test failure

`npm run test:all` stops at `test/integration/async-execution.test.ts:2872`.

The same test fails on clean `origin/main`. It expects no acceptance result after a timeout, but it receives a rejected result.
