### PR TITLE
fix: distinguish Fleet parallel child labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Distinguish same-agent parallel children in Fleet with their explicit task labels. Thanks to [@ljie-PI](https://github.com/ljie-PI) for #1487.
 - Keep async runner process-terminal event delivery from crashing the session when the captured extension context is stale after a session replacement or reload. Thanks to [@AdrianAcala](https://github.com/AdrianAcala) for #1485.
 - Preserve parent model inheritance for workflow children when workflow setup reads session data before launch, and avoid carrying a stale live-session model into scheduled owners. Thanks to [@alexei-led](https://github.com/alexei-led) for #1489 and #1490.
 - Exclude completed one-shot schedules from the pending schedule limit without deleting their durable history. Thanks to [@rafafortes](https://github.com/rafafortes) for #1478.

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -794,7 +794,9 @@ function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded =
 		const activity = widgetStepActivity(step, job.updatedAt);
 		const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
 		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
-		lines.push(`  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${step.agent} · ${widgetStepStatus(step.status, theme)}${modelDisplay}${activity ? ` · ${activity}` : ""}`)}`);
+		const label = compactTaskText(undefined, step.label);
+		const display = label ? `${label} (${step.agent})` : step.agent;
+		lines.push(`  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${display} · ${widgetStepStatus(step.status, theme)}${modelDisplay}${activity ? ` · ${activity}` : ""}`)}`);
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, expanded ? 8 : 6)) lines.push(`    ${nestedLine}`);
 	}
 	return lines;

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -176,6 +176,37 @@ describe("subagent async widget rendering", () => {
 		assert.doesNotMatch(text, /reviewer → reviewer → reviewer/);
 	});
 
+	it("distinguishes same-agent parallel rows with explicit labels", () => {
+		const lines = buildWidgetLines([{
+			asyncId: "run-labels",
+			asyncDir: "/tmp/labels",
+			status: "running",
+			mode: "parallel",
+			agents: ["reviewer", "reviewer"],
+			activeParallelGroup: true,
+			runningSteps: 2,
+			completedSteps: 0,
+			stepsTotal: 2,
+			steps: [
+				{ index: 0, agent: "reviewer", label: "Review auth", description: "private auth task", status: "running" },
+				{ index: 1, agent: "reviewer", label: "Review billing", description: "private billing task", status: "running" },
+			],
+		}, {
+			asyncId: "done",
+			asyncDir: "/tmp/done",
+			status: "complete",
+			mode: "single",
+			agents: ["worker"],
+			startedAt: 0,
+			updatedAt: 1,
+		}], theme, 120);
+
+		const text = lines.join("\n");
+		assert.match(text, /Agent 1\/2: Review auth \(reviewer\) · running/);
+		assert.match(text, /Agent 2\/2: Review billing \(reviewer\) · running/);
+		assert.doesNotMatch(text, /private auth task|private billing task/);
+	});
+
 	it("renders a compact component widget for three active parallel agents without core truncation", () => {
 		const now = Date.now();
 		const ui = createUiContext();


### PR DESCRIPTION
## Summary

Fix Fleet parallel rows so same-agent children with explicit labels render as distinct work.

The change is intentionally narrow. It only updates the Fleet widget row display to use the existing bounded label text and keeps the agent name as context. It does not expose task descriptions, change Herdr metadata, or change any public status contract.

Fixes #1487.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Thanks to [@ljie-PI](https://github.com/ljie-PI) for the report in #1487.
