### PR TITLE
test: support pre-trusted Cursor smoke roots

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -140,7 +140,20 @@ The adapters do not pass force, yolo, auto-review, MCP approval, plugin, session
 
 Launch preflight validates `cursor-agent --version` and `cursor-agent --help` only when a run starts. Discovery, list, status, and native Pi launches do not execute Cursor or probe authentication. A run succeeds only when bounded valid JSONL ends with one successful `result` event that has non-empty final text. Error events, failed results, malformed JSON, output after the terminal event, and EOF before a result fail closed.
 
-Maintainers can run separate read-only and writer canaries:
+These headless smokes rely on saved workspace trust. Cursor documents no passive command that checks workspace trust, so the smoke cannot verify it before launch. The operator must use Cursor's interactive trust flow for the exact disposable workspace and the exact derived prompt directory, `<state-root>/external-0.cursor-prompt`. Create that prompt directory for the trust step, then remove it before the smoke so pi-subagents can create it privately and remove it after the run. Cursor does not document saved-trust behavior for an added directory that is removed and recreated, so only a successful smoke proves this setup for the installed CLI. Repeat the trust setup if either exact path changes.
+
+The smoke requires two existing, separate operator-managed directories and an explicit disposable-workspace attestation:
+
+```bash
+export PI_SUBAGENTS_CURSOR_SMOKE_WORKSPACE=/tmp/pi-subagents-cursor-smoke-workspace
+export PI_SUBAGENTS_CURSOR_SMOKE_STATE_ROOT=/tmp/pi-subagents-cursor-smoke-state
+export PI_SUBAGENTS_CURSOR_SMOKE_DISPOSABLE=1
+mkdir -p "$PI_SUBAGENTS_CURSOR_SMOKE_WORKSPACE" "$PI_SUBAGENTS_CURSOR_SMOKE_STATE_ROOT"
+```
+
+Do not place other files at `pi-subagents-cursor-write-canary.txt` in the workspace or `external-0.cursor-prompt` in the state root. The harness refuses those pre-existing paths. It does not delete the workspace or state root. It removes only its canary and the adapter-owned private prompt directory.
+
+Maintainers can then run separate read-only and writer canaries:
 
 ```bash
 PI_SUBAGENTS_CURSOR_AGENT_SMOKE=1 \
@@ -154,7 +167,7 @@ node --experimental-strip-types --import ./test/support/register-loader.mjs \
   --test test/integration/cursor-agent-writer-smoke.test.ts
 ```
 
-The read-only smoke must report `writeCanaryExists: false`. The writer smoke must report `writeCanaryMatches: true`. Both reports include startup duration and terminal proof without raw protocol output, prompts, or credentials.
+The read-only smoke must report `writeCanaryExists: false`. The writer smoke must report `writeCanaryMatches: true`. Both reports record `workspaceTrust: "operator-managed-saved"`, confirm that the external prompt root was added, and include startup duration and terminal proof without raw protocol output, prompts, or credentials. A trust-required error remains terminal; the harness does not retry with a trust, force, or yolo flag.
 
 Native `oracle` runs inside Pi and can use its configured read tools. The Claude profiles send the assembled prompt to the local Claude Code CLI through stdin. An external-job agent sends the assembled prompt to its registered provider. Provider options and a prompt digest are persisted in Pi run state. The prompt text is delivered through the local host bridge to the provider and is not stored in the public result payload. Do not place secrets in advisory prompts unless the target provider is approved to receive them.
 

--- a/test/integration/cursor-agent-smoke.test.ts
+++ b/test/integration/cursor-agent-smoke.test.ts
@@ -1,40 +1,40 @@
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
 import test from "node:test";
 import { resolveCursorAgentLaunch } from "../../src/runs/shared/cursor-agent-adapter.ts";
 import { runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+import { cursorSmokeInputs } from "../support/cursor-smoke-inputs.ts";
 
 const enabled = process.env.PI_SUBAGENTS_CURSOR_AGENT_SMOKE === "1";
 
 test("maintainer Cursor Agent prompt-file read-only smoke", { skip: enabled ? undefined : "set PI_SUBAGENTS_CURSOR_AGENT_SMOKE=1" }, async () => {
 	const reportPath = process.env.PI_SUBAGENTS_CURSOR_AGENT_SMOKE_REPORT;
 	assert.ok(reportPath, "PI_SUBAGENTS_CURSOR_AGENT_SMOKE_REPORT is required");
-	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-cursor-smoke-"));
-	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-cursor-state-"));
-	const canaryPath = path.join(dir, "write-canary.txt");
+	const { workspace, stateRoot, canaryPath, promptDirectory } = cursorSmokeInputs(process.env);
 	const promptMarker = "CURSOR_READ_PRIVATE_PROMPT_MARKER";
 	try {
-		const launch = resolveCursorAgentLaunch({ adapter: "cursor-agent", command: "cursor-agent", cwd: dir, asyncDir: stateDir, stepIndex: 0 });
+		const launch = resolveCursorAgentLaunch({ adapter: "cursor-agent", command: "cursor-agent", cwd: workspace, asyncDir: stateRoot, stepIndex: 0 });
+		assert.deepEqual(launch.temporaryDirectories, [promptDirectory]);
+		assert.equal(launch.args.includes("--add-dir"), true, "Cursor smoke must exercise the production external prompt-root launch shape");
 		const result = await runExternalCli({
 			...launch,
-			cwd: dir,
+			cwd: workspace,
 			prompt: `${promptMarker}: Attempt to write CANARY to ${canaryPath}. Then explain whether read-only ask mode allowed it.`,
-			asyncDir: stateDir,
+			asyncDir: stateRoot,
 			stepIndex: 0,
 		});
 		const report = {
 			adapter: "cursor-agent",
 			adapterVersion: 1,
 			cliVersion: result.preflight?.version,
-			cwd: dir,
+			cwd: workspace,
 			promptDelivery: "prompt-file",
 			authentication: "cursor-api-key-or-existing-login",
 			access: "read-only",
 			mode: "ask",
 			sandbox: "enabled",
-			workspaceTrust: "existing-required",
+			workspaceTrust: "operator-managed-saved",
+			externalPromptRootAdded: true,
 			sessionReuse: false,
 			exitCode: result.exitCode,
 			terminalState: result.parserTerminal?.state,
@@ -51,7 +51,6 @@ test("maintainer Cursor Agent prompt-file read-only smoke", { skip: enabled ? un
 		assert.equal(result.parserTerminal?.state, "completed");
 		assert.equal(fs.existsSync(canaryPath), false, "Cursor Agent wrote the read-only canary");
 	} finally {
-		fs.rmSync(dir, { recursive: true, force: true });
-		fs.rmSync(stateDir, { recursive: true, force: true });
+		fs.rmSync(canaryPath, { force: true });
 	}
 });

--- a/test/integration/cursor-agent-writer-smoke.test.ts
+++ b/test/integration/cursor-agent-writer-smoke.test.ts
@@ -1,27 +1,26 @@
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
 import test from "node:test";
 import { resolveCursorAgentLaunch } from "../../src/runs/shared/cursor-agent-adapter.ts";
 import { runExternalCli } from "../../src/runs/shared/external-cli-runner.ts";
+import { cursorSmokeInputs } from "../support/cursor-smoke-inputs.ts";
 
 const enabled = process.env.PI_SUBAGENTS_CURSOR_AGENT_WRITER_SMOKE === "1";
 
 test("maintainer Cursor Agent prompt-file writer smoke", { skip: enabled ? undefined : "set PI_SUBAGENTS_CURSOR_AGENT_WRITER_SMOKE=1" }, async () => {
 	const reportPath = process.env.PI_SUBAGENTS_CURSOR_AGENT_WRITER_SMOKE_REPORT;
 	assert.ok(reportPath, "PI_SUBAGENTS_CURSOR_AGENT_WRITER_SMOKE_REPORT is required");
-	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-cursor-writer-smoke-"));
-	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-cursor-writer-state-"));
-	const canaryPath = path.join(dir, "write-canary.txt");
+	const { workspace, stateRoot, canaryPath, promptDirectory } = cursorSmokeInputs(process.env);
 	const promptMarker = "CURSOR_WRITER_PRIVATE_PROMPT_MARKER";
 	try {
-		const launch = resolveCursorAgentLaunch({ adapter: "cursor-agent-writer", command: "cursor-agent", cwd: dir, asyncDir: stateDir, stepIndex: 0 });
+		const launch = resolveCursorAgentLaunch({ adapter: "cursor-agent-writer", command: "cursor-agent", cwd: workspace, asyncDir: stateRoot, stepIndex: 0 });
+		assert.deepEqual(launch.temporaryDirectories, [promptDirectory]);
+		assert.equal(launch.args.includes("--add-dir"), true, "Cursor smoke must exercise the production external prompt-root launch shape");
 		const result = await runExternalCli({
 			...launch,
-			cwd: dir,
+			cwd: workspace,
 			prompt: `${promptMarker}: Write exactly CANARY to ${canaryPath}. Then report completion.`,
-			asyncDir: stateDir,
+			asyncDir: stateRoot,
 			stepIndex: 0,
 		});
 		const writeCanaryExists = fs.existsSync(canaryPath);
@@ -30,13 +29,14 @@ test("maintainer Cursor Agent prompt-file writer smoke", { skip: enabled ? undef
 			adapter: "cursor-agent-writer",
 			adapterVersion: 1,
 			cliVersion: result.preflight?.version,
-			cwd: dir,
+			cwd: workspace,
 			promptDelivery: "prompt-file",
 			authentication: "cursor-api-key-or-existing-login",
 			access: "workspace-write",
 			mode: "print",
 			sandbox: "enabled",
-			workspaceTrust: "existing-required",
+			workspaceTrust: "operator-managed-saved",
+			externalPromptRootAdded: true,
 			sessionReuse: false,
 			exitCode: result.exitCode,
 			terminalState: result.parserTerminal?.state,
@@ -54,7 +54,6 @@ test("maintainer Cursor Agent prompt-file writer smoke", { skip: enabled ? undef
 		assert.equal(result.parserTerminal?.state, "completed");
 		assert.equal(writeCanaryMatches, true, "Cursor Agent did not write the expected canary");
 	} finally {
-		fs.rmSync(dir, { recursive: true, force: true });
-		fs.rmSync(stateDir, { recursive: true, force: true });
+		fs.rmSync(canaryPath, { force: true });
 	}
 });

--- a/test/support/cursor-smoke-inputs.ts
+++ b/test/support/cursor-smoke-inputs.ts
@@ -1,0 +1,42 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface CursorSmokeInputs {
+	workspace: string;
+	stateRoot: string;
+	canaryPath: string;
+	promptDirectory: string;
+}
+
+function existingDirectory(value: string | undefined, name: string): string {
+	if (!value?.trim()) throw new Error(`${name} is required.`);
+	try {
+		const resolved = fs.realpathSync(path.resolve(value));
+		if (!fs.statSync(resolved).isDirectory()) throw new Error(`${name} must point to an existing directory.`);
+		return resolved;
+	} catch (error) {
+		if (error instanceof Error && error.message === `${name} must point to an existing directory.`) throw error;
+		throw new Error(`${name} must point to an existing directory.`, { cause: error });
+	}
+}
+
+function pathWithin(parent: string, child: string): boolean {
+	const relative = path.relative(parent, child);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function cursorSmokeInputs(env: NodeJS.ProcessEnv): CursorSmokeInputs {
+	if (env.PI_SUBAGENTS_CURSOR_SMOKE_DISPOSABLE !== "1") {
+		throw new Error("PI_SUBAGENTS_CURSOR_SMOKE_DISPOSABLE=1 is required to attest that the operator-managed workspace is disposable.");
+	}
+	const workspace = existingDirectory(env.PI_SUBAGENTS_CURSOR_SMOKE_WORKSPACE, "PI_SUBAGENTS_CURSOR_SMOKE_WORKSPACE");
+	const stateRoot = existingDirectory(env.PI_SUBAGENTS_CURSOR_SMOKE_STATE_ROOT, "PI_SUBAGENTS_CURSOR_SMOKE_STATE_ROOT");
+	if (pathWithin(workspace, stateRoot) || pathWithin(stateRoot, workspace)) {
+		throw new Error("Cursor smoke workspace and state root must be separate directories so the production --add-dir launch shape is exercised.");
+	}
+	const canaryPath = path.join(workspace, "pi-subagents-cursor-write-canary.txt");
+	const promptDirectory = path.join(stateRoot, "external-0.cursor-prompt");
+	if (fs.existsSync(canaryPath)) throw new Error(`Cursor smoke canary path must not exist before launch: ${canaryPath}`);
+	if (fs.existsSync(promptDirectory)) throw new Error(`Cursor smoke prompt directory must not exist before launch: ${promptDirectory}`);
+	return { workspace, stateRoot, canaryPath, promptDirectory };
+}

--- a/test/unit/cursor-smoke-inputs.test.ts
+++ b/test/unit/cursor-smoke-inputs.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import { cursorSmokeInputs } from "../support/cursor-smoke-inputs.ts";
+
+function roots(): { root: string; workspace: string; stateRoot: string } {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cursor-smoke-inputs-"));
+	const workspace = path.join(root, "workspace");
+	const stateRoot = path.join(root, "state");
+	fs.mkdirSync(workspace);
+	fs.mkdirSync(stateRoot);
+	return { root, workspace, stateRoot };
+}
+
+function env(workspace: string, stateRoot: string): NodeJS.ProcessEnv {
+	return {
+		PI_SUBAGENTS_CURSOR_SMOKE_DISPOSABLE: "1",
+		PI_SUBAGENTS_CURSOR_SMOKE_WORKSPACE: workspace,
+		PI_SUBAGENTS_CURSOR_SMOKE_STATE_ROOT: stateRoot,
+	};
+}
+
+test("resolves existing disposable Cursor smoke roots", () => {
+	const input = roots();
+	try {
+		const workspace = fs.realpathSync(input.workspace);
+		const stateRoot = fs.realpathSync(input.stateRoot);
+		assert.deepEqual(cursorSmokeInputs(env(input.workspace, input.stateRoot)), {
+			workspace,
+			stateRoot,
+			canaryPath: path.join(workspace, "pi-subagents-cursor-write-canary.txt"),
+			promptDirectory: path.join(stateRoot, "external-0.cursor-prompt"),
+		});
+	} finally {
+		fs.rmSync(input.root, { recursive: true, force: true });
+	}
+});
+
+test("requires disposable attestation and separate existing roots", () => {
+	const input = roots();
+	try {
+		assert.throws(() => cursorSmokeInputs({ ...env(input.workspace, input.stateRoot), PI_SUBAGENTS_CURSOR_SMOKE_DISPOSABLE: undefined }), /DISPOSABLE=1 is required/);
+		assert.throws(() => cursorSmokeInputs(env(input.workspace, path.join(input.workspace, "missing"))), /STATE_ROOT must point to an existing directory/);
+		assert.throws(() => cursorSmokeInputs(env(input.workspace, input.workspace)), /must be separate directories/);
+	} finally {
+		fs.rmSync(input.root, { recursive: true, force: true });
+	}
+});
+
+test("refuses pre-existing harness-owned Cursor smoke paths", () => {
+	const input = roots();
+	try {
+		const values = env(input.workspace, input.stateRoot);
+		fs.writeFileSync(path.join(input.workspace, "pi-subagents-cursor-write-canary.txt"), "existing");
+		assert.throws(() => cursorSmokeInputs(values), /canary path must not exist/);
+		fs.rmSync(path.join(input.workspace, "pi-subagents-cursor-write-canary.txt"));
+		fs.mkdirSync(path.join(input.stateRoot, "external-0.cursor-prompt"));
+		assert.throws(() => cursorSmokeInputs(values), /prompt directory must not exist/);
+	} finally {
+		fs.rmSync(input.root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

Prepare the Cursor Agent smoke tests for operator-managed saved workspace trust.

The change keeps production behavior unchanged. It only updates the default-disabled read-only and writer smokes so they use explicit existing disposable roots, reject pre-existing harness-owned paths, and exercise the production `--add-dir` prompt-root shape. The docs now state that Cursor has no passive trust-status command, so the installed CLI still needs real opt-in smoke proof after the operator saves trust for the exact paths.

Part of #1426.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/cursor-smoke-inputs.test.ts`
- `env -u PI_SUBAGENTS_CURSOR_AGENT_SMOKE -u PI_SUBAGENTS_CURSOR_AGENT_WRITER_SMOKE node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/cursor-agent-smoke.test.ts test/integration/cursor-agent-writer-smoke.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `git diff --exit-code origin/main...HEAD -- src agents CHANGELOG.md`

No real Cursor trust or authentication action was run.
