### PR TITLE
fix: preserve async abort diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Preserve bounded async child failure context after compaction, including missing file-only output, instead of leaving failed run summaries empty. See #1495.
 - Distinguish same-agent parallel children in Fleet with their explicit task labels. Thanks to [@ljie-PI](https://github.com/ljie-PI) for #1487.
 - Keep async runner process-terminal event delivery from crashing the session when the captured extension context is stale after a session replacement or reload. Thanks to [@AdrianAcala](https://github.com/AdrianAcala) for #1485.
 - Preserve parent model inheritance for workflow children when workflow setup reads session data before launch, and avoid carrying a stale live-session model into scheduled owners. Thanks to [@alexei-led](https://github.com/alexei-led) for #1489 and #1490.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -552,6 +552,25 @@ interface RunPiStreamingResult {
 	currentTool?: string;
 	currentToolArgs?: string;
 	currentPath?: string;
+	afterCompactionSettlement?: boolean;
+}
+
+const MAX_CHILD_FAILURE_DIAGNOSTIC_CHARS = 8_192;
+
+function formatChildFailureDiagnostic(input: {
+	error: string | undefined;
+	afterCompactionSettlement?: boolean;
+	missingFileOnlyOutput?: string;
+}): string | undefined {
+	if (!input.error) return undefined;
+	const notes = [
+		input.afterCompactionSettlement ? "Child failure followed session compaction and agent settlement." : undefined,
+		input.missingFileOnlyOutput ? `Required file-only output was not produced: ${input.missingFileOnlyOutput.slice(0, 2_048)}` : undefined,
+	].filter((note): note is string => Boolean(note));
+	if (notes.length === 0) return input.error;
+	const context = notes.join("\n");
+	const errorLimit = MAX_CHILD_FAILURE_DIAGNOSTIC_CHARS - (context ? context.length + 1 : 0);
+	return `${input.error.slice(0, Math.max(0, errorLimit))}${context ? `\n${context}` : ""}`;
 }
 
 function runPiStreaming(
@@ -719,6 +738,7 @@ function runPiStreaming(
 
 			appendChildEvent(event as unknown as Record<string, unknown>);
 			transcriptWriter?.writeChildEvent(event);
+			if (event.type === "compaction_start") compactionStartedReceived = true;
 			if (event.type === "agent_settled") agentSettledReceived = true;
 			applyChildLifecycle(projectChildLifecycle(event));
 
@@ -826,6 +846,7 @@ function runPiStreaming(
 		let forcedTerminationSignal = false;
 		let cleanTerminalAssistantStopReceived = false;
 		let agentSettledReceived = false;
+		let compactionStartedReceived = false;
 		let finalDrainTimer: NodeJS.Timeout | undefined;
 		let finalHardKillTimer: NodeJS.Timeout | undefined;
 		let watchdogTailTimer: NodeJS.Timeout | undefined;
@@ -1101,6 +1122,7 @@ function runPiStreaming(
 				currentTool,
 				currentToolArgs,
 				currentPath,
+				afterCompactionSettlement: (compactionStartedReceived && agentSettledReceived) || undefined,
 			}));
 		});
 
@@ -2070,7 +2092,7 @@ async function runSingleStepInner(
 	const acceptanceCanFailRun = acceptanceFailure && effectiveAcceptance?.explicit && (finalResult?.exitCode ?? 1) === 0 && !finalResult?.interrupted && !timedOutAfterAcceptance && !stoppedAfterAcceptance && !turnBudgetExceeded && !isAgentContractV1(step.agentContract);
 	const effectiveFinalExitCode = timedOutAfterAcceptance || stoppedAfterAcceptance || turnBudgetExceeded ? 1 : acceptanceCanFailRun ? 1 : finalResult?.exitCode ?? 1;
 	const intercomDetachReceipt = finalResult?.finalOutput === INTERCOM_DETACH_RECEIPT;
-	const effectiveFinalError = stoppedAfterAcceptance
+	const baseFinalError = stoppedAfterAcceptance
 		? ctx.stopMessage ?? "Subagent stopped by user."
 		: timedOutAfterAcceptance
 			? finalResult?.error ?? ctx.timeoutMessage ?? "Subagent timed out."
@@ -2079,6 +2101,17 @@ async function runSingleStepInner(
 				: acceptanceCanFailRun
 					? (finalResult?.error ? `${finalResult.error}\n${acceptanceFailure}` : acceptanceFailure)
 					: finalResult?.error ?? (intercomDetachReceipt ? INTERCOM_DETACH_RECEIPT : undefined);
+	const effectiveFinalError = formatChildFailureDiagnostic({
+		error: baseFinalError,
+		afterCompactionSettlement: finalResult?.afterCompactionSettlement,
+		missingFileOnlyOutput: effectiveFinalExitCode !== 0
+			&& finalResult?.afterCompactionSettlement
+			&& step.outputMode === "file-only"
+			&& step.outputPath
+			&& !fs.existsSync(step.outputPath)
+			? step.outputPath
+			: undefined,
+	});
 
 	const artifactErrors = artifactPaths && ctx.artifactConfig?.enabled !== false
 		? persistStepArtifacts({
@@ -5138,7 +5171,7 @@ async function runSubagent(
 		}
 	}
 
-	let summary = results.map((r) => `${r.agent}:\n${r.output}`).join("\n\n");
+	let summary = results.map((r) => `${r.agent}:\n${r.output || (r.exitCode !== 0 ? r.error : undefined) || "(no output)"}`).join("\n\n");
 	let truncated = false;
 
 	if (maxOutput) {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -5317,6 +5317,70 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.results[0].error, "provider exploded");
 	});
 
+	it("reports bounded compaction failure context when file-only output is missing", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const terminalError = `This operation was aborted${"x".repeat(12_000)}`;
+		mockPi.onCall({
+			jsonl: [
+				{ type: "compaction_start" },
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "mock/test-model",
+						stopReason: "error",
+						errorMessage: terminalError,
+						usage: { input: 100, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+					},
+				},
+				{ type: "agent_settled" },
+			],
+			exitCode: 0,
+		});
+
+		const id = `async-compaction-file-only-error-${Date.now().toString(36)}`;
+		const asyncDir = path.join(ASYNC_DIR, id);
+		const outputPath = path.join(tempDir, "missing-oracle-report.md");
+		executeAsyncSingle(id, {
+			agent: "oracle",
+			task: "Write a report",
+			agentConfig: makeAgent("oracle"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			output: outputPath,
+			outputMode: "file-only",
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		const child = payload.results[0] as (AsyncResultPayload["results"][number] & Record<string, unknown>) | undefined;
+		const diagnostic = child?.error ?? "";
+		assert.equal(payload.success, false);
+		assert.equal(child?.success, false);
+		assert.match(diagnostic, /^This operation was aborted/);
+		assert.match(diagnostic, /failure followed session compaction and agent settlement/);
+		assert.match(diagnostic, /Required file-only output was not produced/);
+		assert.ok(diagnostic.length <= 8_192);
+		assert.equal(fs.existsSync(outputPath), false);
+		assert.equal(child?.output, "");
+		assert.equal("savedOutputPath" in (child ?? {}), false);
+		assert.equal("outputReference" in (child ?? {}), false);
+		assert.equal(payload.summary, `oracle:\n${diagnostic}`);
+		const status = await waitForAsyncState(id, (candidate) => candidate.state === "failed");
+		assert.equal(status.steps?.[0]?.exitCode, 1);
+		assert.equal(status.steps?.[0]?.error, diagnostic);
+		const logPath = path.join(asyncDir, `subagent-log-${id}.md`);
+		const deadline = Date.now() + 10_000;
+		while (!fs.existsSync(logPath)) {
+			if (Date.now() > deadline) assert.fail(`Timed out waiting for async run log: ${logPath}`);
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+		assert.ok(fs.readFileSync(logPath, "utf-8").includes(`## Summary\noracle:\n${diagnostic}`));
+	});
+
 	it("background runs emit active-long-running control events from child turns", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			steps: [


### PR DESCRIPTION
## Summary

Fixes #1495.

This preserves a bounded async child failure diagnostic when a child fails after compaction and settlement, and when a required file-only report was not produced. It keeps runner process success and resumability separate from child failure.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='(background keeps only a bounded UTF-8 stderr tail|background final-drain cleanup preserves explicit assistant errors|reports bounded compaction failure context when file-only output is missing)' test/integration/async-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-execution.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review found no issues.
