### PR TITLE
fix: bypass fsmonitor for mutation evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Bypass repository fsmonitor hooks when collecting mutation evidence. Thanks to [@jpriverar](https://github.com/jpriverar) for #1497.
 - Preserve bounded async child failure context after compaction, including missing file-only output, instead of leaving failed run summaries empty. See #1495.
 - Distinguish same-agent parallel children in Fleet with their explicit task labels. Thanks to [@ljie-PI](https://github.com/ljie-PI) for #1487.
 - Keep async runner process-terminal event delivery from crashing the session when the captured extension context is stale after a session replacement or reload. Thanks to [@AdrianAcala](https://github.com/AdrianAcala) for #1485.

--- a/src/runs/shared/mutation-evidence.ts
+++ b/src/runs/shared/mutation-evidence.ts
@@ -9,8 +9,13 @@ const MAX_TRACKED_PATHS = 500;
 const MAX_HASH_BYTES = 1024 * 1024;
 const MAX_TIMEOUT_FILES = 20;
 
+function gitArguments(args: string[]): string[] {
+	// Mutation evidence must not block child startup on a stale fsmonitor daemon.
+	return ["-c", "core.fsmonitor=false", ...args];
+}
+
 function gitOutput(cwd: string, args: string[], maxBuffer = MAX_HASH_BYTES): string {
-	return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], maxBuffer });
+	return execFileSync("git", gitArguments(args), { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], maxBuffer });
 }
 
 function splitNul(output: string): string[] {
@@ -21,7 +26,7 @@ function hashLargeDiff(cwd: string, relativePath: string): string {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tracked-diff-"));
 	const diffPath = path.join(tempDir, "diff.patch");
 	try {
-		execFileSync("git", ["diff", "--no-ext-diff", "--binary", `--output=${diffPath}`, "HEAD", "--", relativePath], { cwd, stdio: "ignore" });
+		execFileSync("git", gitArguments(["diff", "--no-ext-diff", "--binary", `--output=${diffPath}`, "HEAD", "--", relativePath]), { cwd, stdio: "ignore" });
 		const hash = createHash("sha256");
 		const buffer = Buffer.allocUnsafe(64 * 1024);
 		const fd = fs.openSync(diffPath, "r");

--- a/test/unit/mutation-evidence.test.ts
+++ b/test/unit/mutation-evidence.test.ts
@@ -88,6 +88,27 @@ describe("tracked mutation evidence", () => {
 		});
 	});
 
+	it("does not invoke repository fsmonitor while collecting mutation evidence", () => {
+		withRepo((repo) => {
+			const marker = path.join(repo, "fsmonitor-invoked");
+			const hook = path.join(repo, "fsmonitor-hook.cjs");
+			fs.writeFileSync(hook, `require("node:fs").appendFileSync(${JSON.stringify(marker)}, "invoked\\n");\n`, "utf-8");
+			git(repo, ["config", "core.fsmonitor", `${JSON.stringify(process.execPath)} ${JSON.stringify(hook)}`]);
+			git(repo, ["status", "--short"]);
+			assert.equal(fs.existsSync(marker), true);
+			fs.rmSync(marker);
+			fs.writeFileSync(path.join(repo, "tracked.txt"), "dirty before child\n", "utf-8");
+
+			const snapshot = snapshotTrackedMutations(repo);
+			fs.writeFileSync(path.join(repo, "tracked.txt"), "dirty after child\n", "utf-8");
+			const evidence = collectTrackedMutationEvidence(snapshot, repo);
+
+			assert.equal(snapshot.unavailable, undefined);
+			assert.equal(evidence.attemptedMutation, true);
+			assert.equal(fs.existsSync(marker), false);
+		});
+	});
+
 	it("uses tracked evidence as completion guard mutation proof", () => {
 		const guard = evaluateCompletionMutationGuard({
 			agent: "worker",


### PR DESCRIPTION
## Problem

`runSingleAttempt` snapshots tracked mutations before spawning the child. In a macOS linked worktree with a stale fsmonitor daemon, the read-only `git diff` blocks indefinitely, so the foreground subagent emits no child event and appears hung.

Bounded reproduction in the affected checkout:

- normal mutation snapshot command: timed out after 15.003s
- identical command with `-c core.fsmonitor=false`: completed cleanly in 1.900s

## Change

Disable fsmonitor command-locally for all mutation-evidence Git invocations, including the large-diff fallback. Tracked mutation semantics are unchanged and repository/global configuration is not modified.

## Validation

- regression test fails before the change by observing the configured fsmonitor hook
- focused mutation-evidence tests: 7/7 pass
- TypeScript typecheck passes
- patched snapshot against the affected dd-source pooled checkout completes in 1.456s

The full unit suite currently reports four unrelated baseline failures in Herdr inspector and pi-args active-agent/task-delivery tests; the focused suite and typecheck are clean.
