### PR TITLE
test: preserve trusted Cursor prompt root

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -140,7 +140,7 @@ The adapters do not pass force, yolo, auto-review, MCP approval, plugin, session
 
 Launch preflight validates `cursor-agent --version` and `cursor-agent --help` only when a run starts. Discovery, list, status, and native Pi launches do not execute Cursor or probe authentication. A run succeeds only when bounded valid JSONL ends with one successful `result` event that has non-empty final text. Error events, failed results, malformed JSON, output after the terminal event, and EOF before a result fail closed.
 
-These headless smokes rely on saved workspace trust. Cursor documents no passive command that checks workspace trust, so the smoke cannot verify it before launch. The operator must use Cursor's interactive trust flow for the exact disposable workspace and the exact derived prompt directory, `<state-root>/external-0.cursor-prompt`. Create that prompt directory for the trust step, then remove it before the smoke so pi-subagents can create it privately and remove it after the run. Cursor does not document saved-trust behavior for an added directory that is removed and recreated, so only a successful smoke proves this setup for the installed CLI. Repeat the trust setup if either exact path changes.
+These headless smokes rely on saved workspace trust. Cursor documents no passive command that checks workspace trust, so the smoke cannot verify it before launch. The operator must use Cursor's interactive trust flow for the exact disposable workspace and the exact derived prompt directory, `<state-root>/external-0.cursor-prompt`. Keep that prompt directory after the trust step. It must be empty, owned by the operator who runs the smoke, and must not be a symlink. The harness preserves this directory but creates its private handoff with exclusive `0600` access and removes the handoff after every run. Repeat the trust setup if either exact path changes.
 
 The smoke requires two existing, separate operator-managed directories and an explicit disposable-workspace attestation:
 
@@ -149,9 +149,10 @@ export PI_SUBAGENTS_CURSOR_SMOKE_WORKSPACE=/tmp/pi-subagents-cursor-smoke-worksp
 export PI_SUBAGENTS_CURSOR_SMOKE_STATE_ROOT=/tmp/pi-subagents-cursor-smoke-state
 export PI_SUBAGENTS_CURSOR_SMOKE_DISPOSABLE=1
 mkdir -p "$PI_SUBAGENTS_CURSOR_SMOKE_WORKSPACE" "$PI_SUBAGENTS_CURSOR_SMOKE_STATE_ROOT"
+mkdir -p "$PI_SUBAGENTS_CURSOR_SMOKE_STATE_ROOT/external-0.cursor-prompt"
 ```
 
-Do not place other files at `pi-subagents-cursor-write-canary.txt` in the workspace or `external-0.cursor-prompt` in the state root. The harness refuses those pre-existing paths. It does not delete the workspace or state root. It removes only its canary and the adapter-owned private prompt directory.
+Do not place a file at `pi-subagents-cursor-write-canary.txt` in the workspace or any file, including `handoff.txt`, in the prompt directory. The harness refuses the pre-existing canary and any non-empty prompt directory. It does not delete the workspace, state root, or operator-owned prompt directory. It removes only its canary and private handoff file.
 
 Maintainers can then run separate read-only and writer canaries:
 

--- a/test/integration/cursor-agent-smoke.test.ts
+++ b/test/integration/cursor-agent-smoke.test.ts
@@ -18,6 +18,7 @@ test("maintainer Cursor Agent prompt-file read-only smoke", { skip: enabled ? un
 		assert.equal(launch.args.includes("--add-dir"), true, "Cursor smoke must exercise the production external prompt-root launch shape");
 		const result = await runExternalCli({
 			...launch,
+			temporaryDirectories: [],
 			cwd: workspace,
 			prompt: `${promptMarker}: Attempt to write CANARY to ${canaryPath}. Then explain whether read-only ask mode allowed it.`,
 			asyncDir: stateRoot,
@@ -50,6 +51,8 @@ test("maintainer Cursor Agent prompt-file read-only smoke", { skip: enabled ? un
 		assert.equal(result.exitCode, 0, result.error);
 		assert.equal(result.parserTerminal?.state, "completed");
 		assert.equal(fs.existsSync(canaryPath), false, "Cursor Agent wrote the read-only canary");
+		assert.equal(fs.existsSync(promptDirectory), true, "Cursor smoke removed the operator-owned prompt directory");
+		assert.deepEqual(fs.readdirSync(promptDirectory), [], "Cursor smoke left private prompt files behind");
 	} finally {
 		fs.rmSync(canaryPath, { force: true });
 	}

--- a/test/integration/cursor-agent-writer-smoke.test.ts
+++ b/test/integration/cursor-agent-writer-smoke.test.ts
@@ -18,6 +18,7 @@ test("maintainer Cursor Agent prompt-file writer smoke", { skip: enabled ? undef
 		assert.equal(launch.args.includes("--add-dir"), true, "Cursor smoke must exercise the production external prompt-root launch shape");
 		const result = await runExternalCli({
 			...launch,
+			temporaryDirectories: [],
 			cwd: workspace,
 			prompt: `${promptMarker}: Write exactly CANARY to ${canaryPath}. Then report completion.`,
 			asyncDir: stateRoot,
@@ -53,6 +54,8 @@ test("maintainer Cursor Agent prompt-file writer smoke", { skip: enabled ? undef
 		assert.equal(result.exitCode, 0, result.error);
 		assert.equal(result.parserTerminal?.state, "completed");
 		assert.equal(writeCanaryMatches, true, "Cursor Agent did not write the expected canary");
+		assert.equal(fs.existsSync(promptDirectory), true, "Cursor smoke removed the operator-owned prompt directory");
+		assert.deepEqual(fs.readdirSync(promptDirectory), [], "Cursor smoke left private prompt files behind");
 	} finally {
 		fs.rmSync(canaryPath, { force: true });
 	}

--- a/test/support/cursor-smoke-inputs.ts
+++ b/test/support/cursor-smoke-inputs.ts
@@ -37,6 +37,15 @@ export function cursorSmokeInputs(env: NodeJS.ProcessEnv): CursorSmokeInputs {
 	const canaryPath = path.join(workspace, "pi-subagents-cursor-write-canary.txt");
 	const promptDirectory = path.join(stateRoot, "external-0.cursor-prompt");
 	if (fs.existsSync(canaryPath)) throw new Error(`Cursor smoke canary path must not exist before launch: ${canaryPath}`);
-	if (fs.existsSync(promptDirectory)) throw new Error(`Cursor smoke prompt directory must not exist before launch: ${promptDirectory}`);
+	let promptDirectoryStatus: fs.Stats;
+	try { promptDirectoryStatus = fs.lstatSync(promptDirectory); }
+	catch (error) { throw new Error(`Cursor smoke prompt directory must be an existing operator-trusted directory: ${promptDirectory}`, { cause: error }); }
+	if (promptDirectoryStatus.isSymbolicLink() || !promptDirectoryStatus.isDirectory()) {
+		throw new Error(`Cursor smoke prompt directory must be an existing directory, not a symlink: ${promptDirectory}`);
+	}
+	if (process.getuid && promptDirectoryStatus.uid !== process.getuid()) {
+		throw new Error(`Cursor smoke prompt directory must be owned by the current operator: ${promptDirectory}`);
+	}
+	if (fs.readdirSync(promptDirectory).length > 0) throw new Error(`Cursor smoke prompt directory must be empty before launch: ${promptDirectory}`);
 	return { workspace, stateRoot, canaryPath, promptDirectory };
 }

--- a/test/unit/cursor-agent-adapter.test.ts
+++ b/test/unit/cursor-agent-adapter.test.ts
@@ -162,6 +162,19 @@ describe("Cursor Agent adapter", () => {
 		assert.equal(fs.readFileSync(launch.promptFilePath, "utf-8"), "stale");
 	});
 
+	it("removes the private prompt file but preserves an existing prompt directory", async () => {
+		const workspace = tempDir();
+		const stateDir = tempDir();
+		const scriptPath = fakeCursorScript(stateDir);
+		const launch = resolveCursorAgentLaunch({ adapter: CURSOR_AGENT_ADAPTER_ID, command: process.execPath, commandPrefixArgs: [scriptPath], cwd: workspace, asyncDir: stateDir, stepIndex: 11 });
+		const promptDirectory = path.dirname(launch.promptFilePath);
+		fs.mkdirSync(promptDirectory, { mode: 0o700 });
+		const result = await runExternalCli({ ...launch, temporaryDirectories: [], cwd: workspace, prompt: "private prompt", asyncDir: stateDir, stepIndex: 11 });
+		assert.equal(result.exitCode, 0);
+		assert.equal(fs.existsSync(launch.promptFilePath), false);
+		assert.deepEqual(fs.readdirSync(promptDirectory), []);
+	});
+
 	it("publishes strict read and writer metadata and loads legacy Grok status", () => {
 		const read = externalCliReceiptMetadata({ runner: resolveExternalCliRunnerStatus({ adapter: "cursor-agent", command: "cursor-agent" }) });
 		const writer = externalCliReceiptMetadata({ runner: resolveExternalCliRunnerStatus({ adapter: "cursor-agent-writer", command: "cursor-agent" }) });

--- a/test/unit/cursor-smoke-inputs.test.ts
+++ b/test/unit/cursor-smoke-inputs.test.ts
@@ -11,6 +11,7 @@ function roots(): { root: string; workspace: string; stateRoot: string } {
 	const stateRoot = path.join(root, "state");
 	fs.mkdirSync(workspace);
 	fs.mkdirSync(stateRoot);
+	fs.mkdirSync(path.join(stateRoot, "external-0.cursor-prompt"));
 	return { root, workspace, stateRoot };
 }
 
@@ -49,15 +50,27 @@ test("requires disposable attestation and separate existing roots", () => {
 	}
 });
 
-test("refuses pre-existing harness-owned Cursor smoke paths", () => {
+test("refuses pre-existing Cursor smoke handoff and canary paths", () => {
 	const input = roots();
 	try {
 		const values = env(input.workspace, input.stateRoot);
 		fs.writeFileSync(path.join(input.workspace, "pi-subagents-cursor-write-canary.txt"), "existing");
 		assert.throws(() => cursorSmokeInputs(values), /canary path must not exist/);
 		fs.rmSync(path.join(input.workspace, "pi-subagents-cursor-write-canary.txt"));
-		fs.mkdirSync(path.join(input.stateRoot, "external-0.cursor-prompt"));
-		assert.throws(() => cursorSmokeInputs(values), /prompt directory must not exist/);
+		fs.writeFileSync(path.join(input.stateRoot, "external-0.cursor-prompt", "handoff.txt"), "existing");
+		assert.throws(() => cursorSmokeInputs(values), /prompt directory must be empty/);
+	} finally {
+		fs.rmSync(input.root, { recursive: true, force: true });
+	}
+});
+
+test("refuses a symlink as the trusted Cursor prompt directory", { skip: process.platform === "win32" }, () => {
+	const input = roots();
+	try {
+		const promptDirectory = path.join(input.stateRoot, "external-0.cursor-prompt");
+		fs.rmSync(promptDirectory, { recursive: true });
+		fs.symlinkSync(input.workspace, promptDirectory, "dir");
+		assert.throws(() => cursorSmokeInputs(env(input.workspace, input.stateRoot)), /not a symlink/);
 	} finally {
 		fs.rmSync(input.root, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

Refs #1426.

This updates the opt-in Cursor smoke harness and docs after the real smoke showed that deleting and recreating the derived `--add-dir` prompt directory does not preserve Cursor workspace trust. The harness now requires that exact prompt directory to exist, be empty, not be a symlink, and be owned by the current operator. The smoke preserves that directory and still removes only its private `handoff.txt`.

This does not change production adapter behavior and does not add `--trust`, `--force`, or `--yolo`.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/cursor-smoke-inputs.test.ts test/unit/cursor-agent-adapter.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/cursor-agent-smoke.test.ts test/integration/cursor-agent-writer-smoke.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review found no issues. Real Cursor read/write smokes still need the local operator to trust the exact prompt directory and run the opt-in tests.
