### PR TITLE
fix: base64-encode --session-roots to survive Windows PowerShell quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Bypass repository fsmonitor hooks when collecting mutation evidence. Thanks to [@jpriverar](https://github.com/jpriverar) for #1497.
 - Preserve bounded async child failure context after compaction, including missing file-only output, instead of leaving failed run summaries empty. See #1495.
+- Base64-encode the `--session-roots` argument passed to the Herdr inspector runner so `inspector.open` no longer corrupts session roots on Windows, where PowerShell's `\"` is not a recognized quote escape and truncates the JSON-stringified array mid-argument. Thanks to [@stavg91](https://github.com/stavg91) for #1499.
 - Distinguish same-agent parallel children in Fleet with their explicit task labels. Thanks to [@ljie-PI](https://github.com/ljie-PI) for #1487.
 - Keep async runner process-terminal event delivery from crashing the session when the captured extension context is stale after a session replacement or reload. Thanks to [@AdrianAcala](https://github.com/AdrianAcala) for #1485.
 - Preserve parent model inheritance for workflow children when workflow setup reads session data before launch, and avoid carrying a stale live-session model into scheduled owners. Thanks to [@alexei-led](https://github.com/alexei-led) for #1489 and #1490.

--- a/src/inspectors/herdr/actions.ts
+++ b/src/inspectors/herdr/actions.ts
@@ -12,6 +12,7 @@ import { readStatus } from "../../shared/utils.ts";
 import { resolveSubagentRunId } from "../../runs/background/run-id-resolver.ts";
 import { resolveNodeExecutable } from "../../shared/node-executable.ts";
 import { createHerdrClient, detectHerdr, type HerdrClient, type HerdrErrorCode, type HerdrResult } from "./client.ts";
+import { encodeSessionRoots } from "./session-roots-codec.ts";
 import { formatShellCommand } from "./shell-command.ts";
 
 export const HERDR_INSPECTOR_ACTIONS = ["inspector.open", "inspector.status", "inspector.close"] as const;
@@ -88,7 +89,7 @@ function extractPaneId(value: unknown): string | undefined {
 }
 
 function inspectorCommand(input: { runnerPath: string; asyncDir: string; runId: string; index?: number; missionPath?: string; allowSteer: boolean; allowStop: boolean; sessionRoots: string[] }): string {
-	const args = [input.runnerPath, "--async-dir", input.asyncDir, "--run-id", input.runId, "--allow-steer", String(input.allowSteer), "--allow-stop", String(input.allowStop), "--session-roots", JSON.stringify(input.sessionRoots)];
+	const args = [input.runnerPath, "--async-dir", input.asyncDir, "--run-id", input.runId, "--allow-steer", String(input.allowSteer), "--allow-stop", String(input.allowStop), "--session-roots", encodeSessionRoots(input.sessionRoots)];
 	if (input.index !== undefined) args.push("--index", String(input.index));
 	if (input.missionPath) args.push("--mission-path", input.missionPath);
 	return formatShellCommand(resolveNodeExecutable(), args);

--- a/src/inspectors/herdr/inspector-runner.ts
+++ b/src/inspectors/herdr/inspector-runner.ts
@@ -9,6 +9,7 @@ import { formatAsyncRunTranscript } from "../../runs/background/fleet-view.ts";
 import { steeringReceipt } from "../../runs/background/steering.ts";
 import type { AsyncStatus } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
+import { decodeSessionRoots } from "./session-roots-codec.ts";
 
 export interface RunnerOptions {
 	asyncDir: string;
@@ -60,16 +61,7 @@ function parseArgs(argv: string[]): RunnerOptions {
 	const childIndex = indexRaw === undefined ? undefined : Number(indexRaw);
 	if (childIndex !== undefined && (!Number.isInteger(childIndex) || childIndex < 0)) throw new Error("--index must be a non-negative integer.");
 	const sessionRootsRaw = values.get("--session-roots");
-	let sessionRoots: string[] = [];
-	if (sessionRootsRaw !== undefined) {
-		try {
-			const parsed = JSON.parse(sessionRootsRaw) as unknown;
-			if (!Array.isArray(parsed) || parsed.some((root) => typeof root !== "string")) throw new Error();
-			sessionRoots = parsed;
-		} catch {
-			throw new Error("--session-roots must be a JSON array of strings.");
-		}
-	}
+	const sessionRoots = sessionRootsRaw === undefined ? [] : decodeSessionRoots(sessionRootsRaw);
 	const refreshRaw = values.get("--refresh-ms");
 	const refreshMs = refreshRaw === undefined ? 1_500 : Number(refreshRaw);
 	if (!Number.isInteger(refreshMs) || refreshMs < 250) throw new Error("--refresh-ms must be an integer >= 250.");

--- a/src/inspectors/herdr/session-roots-codec.ts
+++ b/src/inspectors/herdr/session-roots-codec.ts
@@ -1,0 +1,42 @@
+/**
+ * Windows PowerShell has no backslash-escape for embedded double quotes: a
+ * double-quoted string literal only recognizes `` `" `` or `""` to embed a
+ * literal quote, so a naively-quoted JSON array (which is full of `"` and
+ * `\` characters) gets truncated or split into multiple argv tokens the
+ * moment PowerShell tokenizes the `pane run` command line.
+ *
+ * Base64 has no quotes, backslashes, or spaces for any shell to mangle, so
+ * encoding the `--session-roots` payload sidesteps quoting entirely. It is
+ * also plain ASCII, so it never hits shellQuote's Windows quoting branch in
+ * a way that could still fail as new characters are added upstream.
+ */
+export function encodeSessionRoots(roots: readonly string[]): string {
+	return Buffer.from(JSON.stringify(roots), "utf-8").toString("base64");
+}
+
+function parseStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || value.some((root) => typeof root !== "string")) return undefined;
+	return value;
+}
+
+/**
+ * Decodes a `--session-roots` argument produced by {@link encodeSessionRoots}.
+ * Falls back to parsing the value as raw JSON so any externally-launched
+ * inspector runner (a cached copy, or a manual invocation) that still passes
+ * the legacy unencoded form keeps working.
+ */
+export function decodeSessionRoots(raw: string): string[] {
+	try {
+		const decoded = parseStringArray(JSON.parse(Buffer.from(raw, "base64").toString("utf-8")));
+		if (decoded) return decoded;
+	} catch {
+		// fall through to legacy raw-JSON parsing below
+	}
+	try {
+		const parsed = parseStringArray(JSON.parse(raw));
+		if (parsed) return parsed;
+	} catch {
+		// fall through to the shared error below
+	}
+	throw new Error("--session-roots must be a base64-encoded or raw JSON array of strings.");
+}

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -9,9 +9,19 @@ import { handleHerdrInspectorAction, readHerdrInspectorBinding } from "../../src
 import { createHerdrClient, detectHerdr, parseHerdrVersion, supportsRawPanes, type HerdrClient } from "../../src/inspectors/herdr/client.ts";
 import { formatInspectorDashboard, submitInspectorControl } from "../../src/inspectors/herdr/inspector-runner.ts";
 import { createProjectPaneManager, handleHerdrProjectPaneAction, listHerdrProjectPaneRoots, readHerdrProjectPaneBinding, restoreHerdrProjectPaneSnapshots } from "../../src/inspectors/herdr/project-panes.ts";
+import { decodeSessionRoots } from "../../src/inspectors/herdr/session-roots-codec.ts";
 import { consumeSteerRequests, consumeStopRequest } from "../../src/runs/background/control-channel.ts";
 import { PI_SUBAGENT_PI_BINARY_ENV } from "../../src/runs/shared/pi-spawn.ts";
 import type { AsyncStatus, SubagentState } from "../../src/shared/types.ts";
+
+// `pane run` commands quote the whole --session-roots value (base64, so it has
+// no spaces/quotes of its own); pull it back out and decode it the same way
+// the inspector runner does, rather than pattern-matching on the raw text.
+function sessionRootsFromRunCommand(command: string): string[] {
+	const match = /--session-roots\S*\s+['"]?([A-Za-z0-9+/=]+)/.exec(command);
+	assert.ok(match, `--session-roots argument not found in command: ${command}`);
+	return decodeSessionRoots(match[1]);
+}
 
 function fakeChild(): EventEmitter & { stdout: PassThrough; stderr: PassThrough; kill(): boolean } {
 	const child = new EventEmitter() as EventEmitter & { stdout: PassThrough; stderr: PassThrough; kill(): boolean };
@@ -120,7 +130,7 @@ describe("Herdr inspector", () => {
 				assert.ok(!/^[']/.test(runCall[3] ?? ""), `pane run command must not open with a quoted executable; Nushell parses it as a string expression: ${runCall[3]}`);
 			}
 			assert.match(runCall[3] ?? "", /--allow-steer.*true.*--allow-stop.*true/);
-			assert.match(runCall[3] ?? "", /--session-roots.*sessions/);
+			assert.deepEqual(sessionRootsFromRunCommand(runCall[3] ?? ""), [sessionRoot]);
 
 			const closed = await handleHerdrInspectorAction("inspector.close", { dir: asyncDir }, { cwd: root, asyncDirRoot: root, client });
 			assert.equal(closed.isError, undefined, text(closed));
@@ -180,8 +190,7 @@ describe("Herdr inspector", () => {
 			});
 			assert.equal(opened.isError, undefined, text(opened));
 			const runCall = calls.find((args) => args[0] === "pane" && args[1] === "run" && args[2] === "w1:p11");
-			assert.match(runCall?.[3] ?? "", /--session-roots/);
-			assert.match(runCall?.[3] ?? "", /custom-sessions/);
+			assert.deepEqual(sessionRootsFromRunCommand(runCall?.[3] ?? ""), [sessionRoot]);
 
 			state.asyncJobs.clear();
 			fs.rmSync(path.join(asyncDir, "inspectors"), { recursive: true, force: true });
@@ -195,7 +204,7 @@ describe("Herdr inspector", () => {
 			});
 			assert.equal(reopened.isError, undefined, text(reopened));
 			const untrustedRunCall = calls.find((args) => args[0] === "pane" && args[1] === "run" && args[2] === "w1:p11");
-			assert.doesNotMatch(untrustedRunCall?.[3] ?? "", /custom-sessions/);
+			assert.deepEqual(sessionRootsFromRunCommand(untrustedRunCall?.[3] ?? ""), []);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/herdr-session-roots-codec.test.ts
+++ b/test/unit/herdr-session-roots-codec.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { describe, it } from "node:test";
+import { decodeSessionRoots, encodeSessionRoots } from "../../src/inspectors/herdr/session-roots-codec.ts";
+import { formatShellCommand } from "../../src/inspectors/herdr/shell-command.ts";
+
+describe("session roots codec", () => {
+	it("round-trips an empty array, plain paths, and paths with spaces/quotes", () => {
+		for (const roots of [[], ["/tmp/a"], ["C:\\Users\\a b\\.pi", "D:\\work"], ['has "quotes"', "has\\backslashes\\"]]) {
+			assert.deepEqual(decodeSessionRoots(encodeSessionRoots(roots)), roots);
+		}
+	});
+
+	it("still accepts raw JSON for backward compatibility with unpatched callers", () => {
+		assert.deepEqual(decodeSessionRoots(JSON.stringify(["/tmp/a", "/tmp/b"])), ["/tmp/a", "/tmp/b"]);
+		assert.deepEqual(decodeSessionRoots(JSON.stringify([])), []);
+	});
+
+	it("rejects malformed input from either encoding", () => {
+		assert.throws(() => decodeSessionRoots("not base64 and not json"), /base64-encoded or raw JSON array of strings/);
+		assert.throws(() => decodeSessionRoots(Buffer.from(JSON.stringify({ not: "an array" })).toString("base64")), /base64-encoded or raw JSON array of strings/);
+		assert.throws(() => decodeSessionRoots(Buffer.from(JSON.stringify([1, 2])).toString("base64")), /base64-encoded or raw JSON array of strings/);
+	});
+
+	it("produces plain-ASCII base64 output with no quote, backslash, or space characters for a shell to mangle", () => {
+		const encoded = encodeSessionRoots(["C:\\Users\\a b\\.pi\\sessions", 'contains "quotes"', "D:\\work"]);
+		assert.match(encoded, /^[A-Za-z0-9+/=]+$/);
+	});
+
+	// This is the actual regression: Windows PowerShell has no backslash-escape for
+	// embedded double quotes (only `` `" `` or `""`), so shellQuote's win32 branch
+	// (which escapes `"` as `\"`) corrupts any argument containing a literal `"` -
+	// exactly what `JSON.stringify(sessionRoots)` produces. Spawn real powershell.exe
+	// to prove the old approach breaks and the new approach survives.
+	describe("end-to-end through real powershell.exe", { skip: process.platform !== "win32" }, () => {
+		function echoArgvCommand(sessionRootsArg: string): string {
+			const script = "process.stdout.write(JSON.stringify(process.argv.slice(1)));";
+			return formatShellCommand(process.execPath, ["-e", script, "--", "--session-roots", sessionRootsArg], "win32");
+		}
+
+		function runThroughPowerShell(command: string): string[] {
+			return JSON.parse(execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command], { encoding: "utf-8" }));
+		}
+
+		it("mangles a raw JSON.stringify payload (documents the bug this PR fixes)", () => {
+			const sessionRoots = ["C:\\Users\\sgerashe\\.pi\\sessions", "D:\\work\\proj"];
+			const rawJson = JSON.stringify(sessionRoots);
+			const argv = runThroughPowerShell(echoArgvCommand(rawJson));
+			const received = argv[argv.indexOf("--session-roots") + 1];
+			assert.notEqual(received, rawJson, "expected PowerShell to corrupt the unescaped JSON payload");
+			assert.throws(() => JSON.parse(received ?? ""), /Unexpected token/, "corrupted payload should no longer be valid JSON");
+		});
+
+		it("survives base64 encoding byte-for-byte", () => {
+			const sessionRoots = ["C:\\Users\\sgerashe\\.pi\\sessions", "D:\\work\\proj", 'C:\\has "quotes"\\dir'];
+			const encoded = encodeSessionRoots(sessionRoots);
+			const argv = runThroughPowerShell(echoArgvCommand(encoded));
+			const received = argv[argv.indexOf("--session-roots") + 1];
+			assert.equal(received, encoded);
+			assert.deepEqual(decodeSessionRoots(received ?? ""), sessionRoots);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

`inspector.open` builds its `pane run` command with a raw `JSON.stringify(sessionRoots)` payload for `--session-roots`, then quotes it for the target shell in `formatShellCommand`/`shellQuote`. On Windows, `shellQuote`'s `win32` branch escapes embedded `"` as `\"` — but PowerShell has no backslash-escape for double quotes inside a double-quoted string; it only recognizes `` `" `` or `""`. The literal `\"` does not escape anything: it terminates the string early and the remainder of the JSON payload spills into extra, corrupted argv tokens before `inspector-runner.ts` ever sees it.

Every Windows `inspector.open` call is affected, since `--session-roots` always carries a JSON-stringified array full of `"` and `\` (from Windows paths). This can fail the whole `pane run` invocation, or open a pane whose `--session-roots` fails to parse, silently degrading it to an untrusted/empty root — so the standalone inspector [can't read the child session transcript at all](https://github.com/nicobailon/pi-subagents/issues/1069) on Windows even after #1069's trusted-root propagation fix.

This is a genuine, reproducible bug, not a theoretical one. I confirmed it against real `powershell.exe` before writing the fix (see "Verification" below) — the corrupted argument and the parse failure are exactly what a user hitting this in the wild would see.

## Root cause

```ts
// src/inspectors/herdr/actions.ts (before)
const args = [..., "--session-roots", JSON.stringify(input.sessionRoots)];
```
```ts
// src/inspectors/herdr/shell-command.ts
function shellQuote(value: string, platform: NodeJS.Platform): string {
	if (platform === "win32") return `"${value.replaceAll('"', '\\"')}"`; // \" is not a PowerShell escape
	return `'${value.replaceAll("'", "'\\''")}'`;
}
```

A `--session-roots` value like `["C:\\Users\\me\\.pi\\sessions"]` becomes, after `shellQuote`:

```
"[\"C:\\Users\\me\\.pi\\sessions\"]"
```

PowerShell tokenizes this as: the string opens at the first `"`, hits `\` (literal backslash, no meaning), then hits the unescaped `"` right after it and **closes the string there** — splitting the rest of the payload into separate, unquoted tokens.

## Fix

Base64-encode the `--session-roots` payload in `actions.ts` before it's quoted, and decode it in `inspector-runner.ts`. Base64 output is plain ASCII with no quotes, backslashes, or spaces — nothing for any shell (PowerShell, POSIX sh, Nushell) to mangle, so this closes the bug class entirely rather than special-casing PowerShell's quoting rules.

The encode/decode logic lives in a new shared module, `src/inspectors/herdr/session-roots-codec.ts`, so both call sites can't drift out of sync and the codec is independently unit-testable:

- `encodeSessionRoots(roots: readonly string[]): string`
- `decodeSessionRoots(raw: string): string[]` — tries base64 first, then **falls back to raw JSON** for backward compatibility with any already-cached/unpatched inspector-runner copy or manual invocation.

```ts
// src/inspectors/herdr/actions.ts (after)
const args = [..., "--session-roots", encodeSessionRoots(input.sessionRoots)];
```

## Verification

### 1. Reproduced the bug against real `powershell.exe` before writing any fix

```
$ node repro.mjs
=== OLD generated command ===
& "C:\Program Files\nodejs\node.exe" "C:\tmp\bugrepro\echo-argv.mjs" "--session-roots" "[\"C:\\Users\\sgerashe\\.pi\\sessions\",\"D:\\work\\proj\"]"

=== OLD result: argv the child process actually received ===
["--session-roots","[\\","C:\\\\Users\\\\sgerashe\\\\.pi\\\\sessions\\,\\D:\\\\work\\\\proj\\]"]

Expected --session-roots value : ["C:\\Users\\sgerashe\\.pi\\sessions","D:\\work\\proj"]
Received --session-roots value  : [\
Byte-for-byte match?            : false
JSON.parse(received) FAILED (BUG REPRODUCED): Unexpected token '\', "[\" is not valid JSON

=== NEW generated command (base64) ===
& "C:\Program Files\nodejs\node.exe" "C:\tmp\bugrepro\echo-argv.mjs" "--session-roots" "WyJDOlxcVXNlcnNcXHNnZXJhc2hlXFwucGlcXHNlc3Npb25zIiwiRDpcXHdvcmtcXHByb2oiXQ=="

Received --session-roots value (base64): WyJDOlxcVXNlcnNcXHNnZXJhc2hlXFwucGlcXHNlc3Npb25zIiwiRDpcXHdvcmtcXHByb2oiXQ==
Byte-for-byte match to encoded?          : true
Decoded back to original array?          : true
```

The `--session-roots` value is literally split into two separate argv tokens (`"[\\"` and the rest), confirming the corruption is not just a JSON.parse edge case but a genuine argv-splitting bug.

### 2. Verified live in a running Pi + Herdr session (Windows)

Installed the fix locally, reloaded Pi, launched an async subagent, and ran `inspector.open` against it — the pane opened cleanly with no errors, and the child's session transcript rendered correctly (proving `--session-roots` round-tripped and decoded).

### 3. Added regression tests

- `test/unit/herdr-session-roots-codec.test.ts` (new):
  - Round-trips empty arrays, plain paths, and paths containing spaces/quotes/backslashes.
  - Confirms `decodeSessionRoots` still accepts raw JSON (backward compatibility).
  - Confirms malformed input from either encoding is rejected with a clear error.
  - Confirms `encodeSessionRoots` output is plain ASCII base64 (no quote/backslash/space characters).
  - **End-to-end, Windows-only** (`describe(..., { skip: process.platform !== "win32" })`): spawns real `powershell.exe` to prove (a) the old `JSON.stringify` approach corrupts the argument exactly as described above, and (b) the base64 approach survives byte-for-byte and decodes back to the original array.
- Updated `test/unit/herdr-inspector.test.ts`'s existing `inspector.open` assertions, which previously pattern-matched readable substrings inside the raw `--session-roots` value (e.g. `/--session-roots.*sessions/`). Since the value is now base64, these now extract and decode the argument the same way the runner does, and assert on the decoded array instead of raw text.

### 4. Full test suite

```
npm run typecheck   # clean
npm run test:unit   # 2510 tests, 2459 pass, 20 fail, 31 skipped
```

The 20 failures are **pre-existing on `main`** and unrelated to this change (Windows `EPERM` on symlink-based tests requiring elevated permissions, plus one flaky watchdog timing assertion) — confirmed by running the exact same suite against unmodified `main` before making any changes, which produces the identical 20 failures. This PR adds 6 new passing tests and introduces 0 new failures.

## Files changed

- `src/inspectors/herdr/session-roots-codec.ts` (new) — shared encode/decode helpers
- `src/inspectors/herdr/actions.ts` — use `encodeSessionRoots` for `--session-roots`
- `src/inspectors/herdr/inspector-runner.ts` — use `decodeSessionRoots` to parse `--session-roots`
- `test/unit/herdr-session-roots-codec.test.ts` (new) — codec unit tests + real-PowerShell regression test
- `test/unit/herdr-inspector.test.ts` — updated `--session-roots` assertions for the new encoding
- `CHANGELOG.md` — added entry under `[Unreleased] / Fixed`

No public API changes. `RunnerOptions.sessionRoots` and all downstream consumers (`formatInspectorDashboard`, `formatAsyncRunTranscript`) are unchanged — only the wire format of the `--session-roots` CLI argument between `actions.ts` and `inspector-runner.ts` changes, and it's backward compatible via the raw-JSON fallback.
