### PR TITLE
fix: avoid fatal ReadFileUtf8 path in retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Bypass repository fsmonitor hooks when collecting mutation evidence. Thanks to [@jpriverar](https://github.com/jpriverar) for #1497.
+- Avoid the fatal Node `ReadFileUtf8` retention path. Thanks to [@pgoodjohn](https://github.com/pgoodjohn) for #1501.
 - Preserve bounded async child failure context after compaction, including missing file-only output, instead of leaving failed run summaries empty. See #1495.
 - Base64-encode the `--session-roots` argument passed to the Herdr inspector runner so `inspector.open` no longer corrupts session roots on Windows, where PowerShell's `\"` is not a recognized quote escape and truncates the JSON-stringified array mid-argument. Thanks to [@stavg91](https://github.com/stavg91) for #1499.
 - Distinguish same-agent parallel children in Fleet with their explicit task labels. Thanks to [@ljie-PI](https://github.com/ljie-PI) for #1487.

--- a/src/runs/background/async-retention.ts
+++ b/src/runs/background/async-retention.ts
@@ -138,7 +138,7 @@ function listDir(dir: string): fs.Dirent[] {
 
 function readJson(filePath: string): Record<string, unknown> | undefined {
 	try {
-		const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
+		const parsed = JSON.parse(fs.readFileSync(filePath).toString("utf8")) as unknown;
 		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : undefined;
 	} catch {
 		return undefined;
@@ -323,7 +323,7 @@ function readCursor(root: string): RetentionCursor {
 function processStartIdentity(pid: number): string | undefined {
 	if (process.platform === "linux") {
 		try {
-			const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf-8");
+			const stat = fs.readFileSync(`/proc/${pid}/stat`).toString("utf8");
 			const commandEnd = stat.lastIndexOf(")");
 			if (commandEnd === -1) return undefined;
 			const fields = stat.slice(commandEnd + 1).trim().split(/\s+/);


### PR DESCRIPTION
## Summary

- read retention JSON as a Buffer and decode it explicitly
- avoid Node's specialized native `ReadFileUtf8` path, which can abort the whole Pi process if its internal `uv_fs_close()` assertion fails
- preserve the existing UTF-8 decoding, JSON parsing, and fail-closed behavior

Closes #1500.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/async-retention.test.ts` — 18/18 passed
- `npm run typecheck` — passed
- `git diff --check` — passed

## Caveat

This is a containment fix. The underlying reason the native close returned non-zero is not yet reproducible, and the fatal assertion itself is in Node.