### PR TITLE
fix: resolve advisor builtin alias in model listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Resolve the `advisor` builtin alias through the bundled `oracle` definition in model listings. Thanks to [@smileBeda](https://github.com/smileBeda) for #1502.
 - Bypass repository fsmonitor hooks when collecting mutation evidence. Thanks to [@jpriverar](https://github.com/jpriverar) for #1497.
 - Avoid the fatal Node `ReadFileUtf8` retention path. Thanks to [@pgoodjohn](https://github.com/pgoodjohn) for #1501.
 - Preserve bounded async child failure context after compaction, including missing file-only output, instead of leaving failed run summaries empty. See #1495.

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -787,13 +787,14 @@ function handleModels(params: ManagementParams, ctx: ManagementContext): AgentTo
 
 	const discovered = discoverAgentsAll(ctx.cwd);
 	const builtinByName = new Map(discovered.builtin.map((agent) => [agent.name, agent]));
+	const resolveBuiltinModelAgent = (name: string): AgentConfig | undefined => builtinByName.get(name) ?? resolveAgentName(name, discovered.builtin).agent;
 	const availableModels = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const currentModel = ctx.model ? { provider: ctx.model.provider, id: ctx.model.id } : undefined;
 	const preferredProvider = ctx.model?.provider;
 	const names = requestedAgent ? [requestedAgent] : [...BUILTIN_AGENT_NAMES];
 
 	if (requestedAgent) {
-		const agent = builtinByName.get(requestedAgent);
+		const agent = resolveBuiltinModelAgent(requestedAgent);
 		if (!agent) return result(`Builtin agent '${requestedAgent}' not found.`, true);
 		const resolvedModel = resolveSubagentModelOverride(agent.model, currentModel, availableModels, preferredProvider);
 		const lines = [
@@ -827,7 +828,7 @@ function handleModels(params: ManagementParams, ctx: ManagementContext): AgentTo
 	];
 
 	for (const name of names) {
-		const agent = builtinByName.get(name);
+		const agent = resolveBuiltinModelAgent(name);
 		if (!agent) {
 			lines.push(name);
 			lines.push("  model:");

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -1007,9 +1007,24 @@ Drive the failing test first.
 		assert.match(text, /^Builtin subagent models/m);
 		assert.match(text, /Current session model:\n  openai\/gpt-5-mini/);
 		assert.match(text, /(?:^|\n)scout\n  model:\n    openai\/gpt-5-mini\n  source: inherits current session model(?:\n|$)/);
+		assert.match(text, /(?:^|\n)advisor\n  model:\n    openai\/gpt-5-mini\n  source: inherits current session model(?:\n|$)/);
+		assert.doesNotMatch(text, /advisor\n  model:\n    \(builtin definition not found\)/);
 		assert.match(text, /Available models in this session's registry/);
 		assert.match(text, /  anthropic\/claude-sonnet-4\n  openai\/gpt-5-mini/);
 		assert.match(text, /Use an exact provider\/id from this list when you pass model/);
+	});
+
+	it("resolves the advisor builtin alias in a filtered model mapping", () => {
+		const result = handleManagementAction("models", { agent: "advisor" }, {
+			cwd: tempDir,
+			modelRegistry: { getAvailable: () => [{ provider: "openai", id: "gpt-5-mini" }] },
+			model: { provider: "openai", id: "gpt-5-mini" },
+		});
+		const text = readText(result);
+		assert.equal(result.isError, false);
+		assert.match(text, /Agent: advisor/);
+		assert.match(text, /Effective model:\n  openai\/gpt-5-mini/);
+		assert.doesNotMatch(text, /Builtin agent 'advisor' not found|source: missing/);
 	});
 
 	it("reports override source and disabled builtin state in runtime model mappings", () => {


### PR DESCRIPTION
## Summary

Resolve `advisor` through the bundled `oracle` alias when `/subagents-models` renders builtin model mappings.

This keeps `advisor` as an alias instead of adding a duplicate builtin definition, and it removes the `(builtin definition not found)` output for the existing alias.

Fixes #1502.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-management.test.ts`
- `npm run typecheck`
- `git diff --check`
