### PR TITLE
fix: discover agents in symlinked directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Resolve the `advisor` builtin alias through the bundled `oracle` definition in model listings. Thanks to [@smileBeda](https://github.com/smileBeda) for #1502.
+- Follow symlinked directories during agent discovery without revisiting recursive links. Thanks to [@robsdudeson](https://github.com/robsdudeson) for #1505 and #1510.
 - Bypass repository fsmonitor hooks when collecting mutation evidence. Thanks to [@jpriverar](https://github.com/jpriverar) for #1497.
 - Avoid the fatal Node `ReadFileUtf8` retention path. Thanks to [@pgoodjohn](https://github.com/pgoodjohn) for #1501.
 - Preserve bounded async child failure context after compaction, including missing file-only output, instead of leaving failed run summaries empty. See #1495.

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1603,9 +1603,22 @@ function shouldPruneDiscoveryDir(rootDir: string, dir: string, dirName: string):
 	return path.resolve(dir) !== path.resolve(rootDir) && isDiscoveryNestedProjectRoot(dir);
 }
 
-function listFilesRecursive(dir: string, predicate: (fileName: string) => boolean, rootDir = dir): string[] {
+function listFilesRecursive(
+	dir: string,
+	predicate: (fileName: string) => boolean,
+	rootDir = dir,
+	visitedDirectories = new Set<string>(),
+): string[] {
 	const files: string[] = [];
 	if (!fs.existsSync(dir)) return files;
+	let realDir: string;
+	try {
+		realDir = fs.realpathSync(dir);
+	} catch {
+		return files;
+	}
+	if (visitedDirectories.has(realDir)) return files;
+	visitedDirectories.add(realDir);
 
 	let entries: fs.Dirent[];
 	try {
@@ -1616,9 +1629,17 @@ function listFilesRecursive(dir: string, predicate: (fileName: string) => boolea
 
 	for (const entry of entries) {
 		const filePath = path.join(dir, entry.name);
-		if (entry.isDirectory()) {
+		let isDirectory = entry.isDirectory();
+		if (entry.isSymbolicLink()) {
+			try {
+				isDirectory = fs.statSync(filePath).isDirectory();
+			} catch {
+				isDirectory = false;
+			}
+		}
+		if (isDirectory) {
 			if (!shouldPruneDiscoveryDir(rootDir, filePath, entry.name)) {
-				files.push(...listFilesRecursive(filePath, predicate, rootDir));
+				files.push(...listFilesRecursive(filePath, predicate, rootDir, visitedDirectories));
 			}
 			continue;
 		}

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -292,6 +292,25 @@ Review carefully.`);
 		assert.equal(discovered.agentDiagnostics?.[0]?.name, "broken");
 	}));
 
+	it("follows symlinked agent directories once without hiding diagnostics", () => withTempHome(() => {
+		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-symlinked-agent-dir-"));
+		tempDirs.push(project);
+		const legacyAgentsRoot = path.join(project, ".agents");
+		const sharedAgents = path.join(project, "shared-agents");
+		const linkedAgents = path.join(legacyAgentsRoot, "agents");
+		fs.mkdirSync(legacyAgentsRoot, { recursive: true });
+		fs.mkdirSync(sharedAgents, { recursive: true });
+		writeAgent(path.join(sharedAgents, "linked.md"), "---\nname: linked\ndescription: Linked agent\n---\nBody");
+		writeAgent(path.join(sharedAgents, "broken.md"), "---\nname: broken\ndescription: Broken\nrunner:\n  type: unknown\n---\nBody");
+		fs.symlinkSync(sharedAgents, linkedAgents, process.platform === "win32" ? "junction" : "dir");
+		fs.symlinkSync(path.join(sharedAgents, "missing"), path.join(sharedAgents, "dangling"), process.platform === "win32" ? "junction" : "dir");
+		if (process.platform !== "win32") fs.symlinkSync(sharedAgents, path.join(sharedAgents, "loop"), "dir");
+
+		const discovered = discoverAgents(project, "project");
+		assert.equal(discovered.agents.find((agent) => agent.name === "linked")?.filePath, path.join(linkedAgents, "linked.md"));
+		assert.equal(discovered.agentDiagnostics?.find((diagnostic) => diagnostic.name === "broken")?.filePath, path.join(linkedAgents, "broken.md"));
+	}));
+
 	it("keeps a lower-priority agent available when a project override is malformed", () => withTempHome(() => {
 		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-invalid-agent-shadow-"));
 		tempDirs.push(project);


### PR DESCRIPTION
Closes #1505.

This follows symlinked agent directories during agent discovery while keeping existing symlinked file support, prune rules, and cycle protection.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-frontmatter.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`

Fresh review found no issues.
