### PR TITLE
fix: bound oversized Cursor tool events

### DIFF
--- a/src/runs/shared/cursor-agent-adapter.ts
+++ b/src/runs/shared/cursor-agent-adapter.ts
@@ -4,6 +4,7 @@ import type { ExternalCliPreflightSpec } from "./external-cli-preflight.ts";
 
 const MAX_EVENT_TYPE_LENGTH = 128;
 const MAX_ERROR_LENGTH = 4_096;
+const MAX_OVERSIZED_TOOL_CALL_BYTES = 1024 * 1024;
 
 export const CURSOR_AGENT_ADAPTER_ID = "cursor-agent" as const;
 export const CURSOR_AGENT_WRITER_ADAPTER_ID = "cursor-agent-writer" as const;
@@ -50,6 +51,11 @@ export function createCursorAgentJsonlParser(): ExternalCliParser {
 				} else terminal = { state: "failed", error: terminalError(event) };
 			}
 			return { phase: terminal ? terminal.state : "streaming", eventCount };
+		},
+		skipOversizedLine(prefix, byteLength): ExternalCliParserProgress | undefined {
+			if (terminal || byteLength > MAX_OVERSIZED_TOOL_CALL_BYTES || !/^\s*\{\s*"type"\s*:\s*"tool_call"\s*,/.test(prefix)) return undefined;
+			eventCount += 1;
+			return { phase: "streaming", eventCount };
 		},
 		finish(): ExternalCliParserTerminal | undefined {
 			return terminal;

--- a/src/runs/shared/external-cli-runner.ts
+++ b/src/runs/shared/external-cli-runner.ts
@@ -19,6 +19,8 @@ const MAX_RAW_LOG_BYTES = 8 * 1024 * 1024;
 const MAX_PARSER_LINE_BYTES = 256 * 1024;
 const MAX_PARSER_STREAM_BYTES = 32 * 1024 * 1024;
 const MAX_PARSER_OUTPUT_BYTES = 1024 * 1024;
+const MAX_OVERSIZED_LINE_PREFIX_BYTES = 512;
+const MAX_SKIPPABLE_LINE_BYTES = 1024 * 1024;
 const PARSER_PROGRESS_INTERVAL_MS = 100;
 
 export function buildExternalCliPrompt(systemInstructions: string, task: string): string {
@@ -39,6 +41,8 @@ export interface ExternalCliParserTerminal {
 
 export interface ExternalCliParser {
 	parseLine(line: string): ExternalCliParserProgress | undefined;
+	/** Inspect only a bounded prefix when a non-terminal event exceeds the normal line cap. */
+	skipOversizedLine?(prefix: string, byteLength: number): ExternalCliParserProgress | undefined;
 	finish(): ExternalCliParserTerminal | undefined;
 }
 
@@ -211,6 +215,8 @@ export function runExternalCli(input: {
 		const stderrLog = { bytes: 0, total: 0 };
 		let parserBytes = 0;
 		let pendingLine = Buffer.alloc(0);
+		let pendingLineBytes = 0;
+		let pendingLineOversizedAccepted = false;
 		let parserError: Error | undefined;
 		let parserTerminal: ExternalCliParserTerminal | undefined;
 		let latestProgress: ExternalCliParserProgress | undefined;
@@ -251,12 +257,46 @@ export function runExternalCli(input: {
 			if (input.preflight) invalidateExternalCliPreflight(input.command, input.preflight, "parser");
 			if (processTree && processPid !== undefined) termination = terminateExternalProcessTree(processPid, processTree);
 		};
-		const parseLine = (line: Buffer) => {
-			if (!input.parser || parserError) return;
+		const parseLine = (line: Buffer, byteLength = line.length): boolean => {
+			if (!input.parser || parserError) return false;
+			if (byteLength > limits.parserLineBytes) {
+				const progress = input.limits?.parserLineBytes === undefined
+					? input.parser.skipOversizedLine?.(line.subarray(0, MAX_OVERSIZED_LINE_PREFIX_BYTES).toString("utf-8"), byteLength)
+					: undefined;
+				if (progress) { reportProgress(progress); return true; }
+				failParser(new Error("External CLI parser line exceeded its byte limit."));
+				return false;
+			}
 			try {
 				const progress = input.parser.parseLine(line.toString("utf-8"));
 				if (progress) reportProgress(progress);
 			} catch (error) { failParser(error); }
+			return false;
+		};
+		const appendPendingLine = (chunk: Buffer) => {
+			pendingLineBytes += chunk.length;
+			if (pendingLineOversizedAccepted) {
+				if (pendingLineBytes > MAX_SKIPPABLE_LINE_BYTES) failParser(new Error("External CLI parser line exceeded its byte limit."));
+				return;
+			}
+			if (pendingLineBytes <= limits.parserLineBytes) {
+				pendingLine = Buffer.concat([pendingLine, chunk]);
+				return;
+			}
+			if (pendingLineBytes > MAX_SKIPPABLE_LINE_BYTES) {
+				failParser(new Error("External CLI parser line exceeded its byte limit."));
+				return;
+			}
+			if (pendingLine.length > MAX_OVERSIZED_LINE_PREFIX_BYTES) pendingLine = pendingLine.subarray(0, MAX_OVERSIZED_LINE_PREFIX_BYTES);
+			const remainingPrefixBytes = MAX_OVERSIZED_LINE_PREFIX_BYTES - pendingLine.length;
+			if (remainingPrefixBytes > 0) pendingLine = Buffer.concat([pendingLine, chunk.subarray(0, remainingPrefixBytes)]);
+			pendingLineOversizedAccepted = parseLine(pendingLine, pendingLineBytes);
+		};
+		const finishPendingLine = () => {
+			if (!pendingLineOversizedAccepted) parseLine(pendingLine, pendingLineBytes);
+			pendingLine = Buffer.alloc(0);
+			pendingLineBytes = 0;
+			pendingLineOversizedAccepted = false;
 		};
 		const parseChunk = (chunk: Buffer) => {
 			if (!input.parser || parserError) return;
@@ -268,14 +308,11 @@ export function runExternalCli(input: {
 			let start = 0;
 			for (let index = 0; index < chunk.length; index++) {
 				if (chunk[index] !== 0x0a) continue;
-				pendingLine = Buffer.concat([pendingLine, chunk.subarray(start, index)]);
-				if (pendingLine.length > limits.parserLineBytes) return failParser(new Error("External CLI parser line exceeded its byte limit."));
-				parseLine(pendingLine);
-				pendingLine = Buffer.alloc(0);
+				appendPendingLine(chunk.subarray(start, index));
+				finishPendingLine();
 				start = index + 1;
 			}
-			pendingLine = Buffer.concat([pendingLine, chunk.subarray(start)]);
-			if (pendingLine.length > limits.parserLineBytes) failParser(new Error("External CLI parser line exceeded its byte limit."));
+			appendPendingLine(chunk.subarray(start));
 		};
 		const child = spawn(preflight?.binaryPath ?? input.command, input.args ?? [], {
 			cwd: input.cwd,
@@ -316,7 +353,7 @@ export function runExternalCli(input: {
 		child.once("error", (error) => { spawnError = error; });
 		child.stdout.once("end", () => {
 			if (!input.parser || parserError) return;
-			if (pendingLine.length > 0) parseLine(pendingLine);
+			if (pendingLineBytes > 0) finishPendingLine();
 			try {
 				parserTerminal = input.parser.finish();
 				if (!parserTerminal) failParser(new Error("External CLI parser did not produce a terminal state."));

--- a/test/unit/cursor-agent-adapter.test.ts
+++ b/test/unit/cursor-agent-adapter.test.ts
@@ -42,6 +42,8 @@ function fakeCursorScript(dir: string): string {
 +  if (prompt.includes("hang")) return setInterval(() => {}, 1000);
 +  if (prompt.includes("malformed")) return process.stdout.write("{bad json}\n");
 +  if (prompt.includes("missing-terminal")) return process.stdout.write(JSON.stringify({type:"assistant",message:{content:[{type:"text",text:"partial"}]}}) + "\n");
++  if (prompt.includes("oversized-tool-call") && !prompt.includes("post-terminal-oversized-tool-call")) process.stdout.write(JSON.stringify({type:"tool_call",subtype:"completed",tool_call:{name:"write",args:"x".repeat(300 * 1024)}}) + "\n");
++  if (prompt.includes("post-terminal-oversized-tool-call")) return process.stdout.write(JSON.stringify({type:"result",subtype:"success",is_error:false,result:"trusted final result"}) + "\n" + JSON.stringify({type:"tool_call",subtype:"completed",tool_call:{name:"write",args:"x".repeat(300 * 1024)}}) + "\n");
 +  if (prompt.includes("error-event")) return process.stdout.write(JSON.stringify({type:"error",message:"fake auth failure"}) + "\n");
 +  if (prompt.includes("failed-result")) return process.stdout.write(JSON.stringify({type:"result",subtype:"error_during_execution",is_error:true,result:"fake failure"}) + "\n");
 +  if (prompt.includes("missing-text")) return process.stdout.write(JSON.stringify({type:"result",subtype:"success",is_error:false,result:""}) + "\n");
@@ -96,6 +98,24 @@ describe("Cursor Agent adapter", () => {
 		assert.equal(result.exitCode, 0);
 		assert.equal(result.output, "trusted final result");
 		assert.equal(fs.existsSync(launch.temporaryDirectories[0]!), false);
+	});
+
+	it("skips a bounded oversized non-terminal tool call before terminal proof", async () => {
+		const workspace = tempDir();
+		const stateDir = tempDir();
+		const { result } = await runFake(workspace, stateDir, 2, "oversized-tool-call", CURSOR_AGENT_WRITER_ADAPTER_ID);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.output, "trusted final result");
+		assert.deepEqual(result.parserTerminal, { state: "completed", output: "trusted final result" });
+	});
+
+	it("fails closed on an oversized tool call after terminal proof", async () => {
+		const workspace = tempDir();
+		const stateDir = tempDir();
+		const { result } = await runFake(workspace, stateDir, 3, "post-terminal-oversized-tool-call", CURSOR_AGENT_WRITER_ADAPTER_ID);
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /line exceeded/);
+		assert.equal(result.parserTerminal, undefined);
 	});
 
 	it("adds no extra root when the prompt directory is inside the workspace", () => {

--- a/test/unit/external-cli-runner.test.ts
+++ b/test/unit/external-cli-runner.test.ts
@@ -137,6 +137,27 @@ describe("external CLI runner", () => {
 		assert.equal(oversized.exitCode, 1);
 		assert.match(oversized.error ?? "", /line exceeded/);
 
+		let settleTimer: NodeJS.Timeout | undefined;
+		try {
+			const unterminated = await Promise.race([
+				runExternalCli({
+					command: process.execPath,
+					args: ["-e", "process.stdout.write('x'.repeat(128));setInterval(()=>{},1000)"],
+					cwd: dir,
+					prompt: "x",
+					asyncDir: dir,
+					stepIndex: 16,
+					limits: { parserLineBytes: 64 },
+					parser: { parseLine() { return undefined; }, finish() { return { state: "completed" }; } },
+				}),
+				new Promise<never>((_, reject) => { settleTimer = setTimeout(() => reject(new Error("unterminated oversized line did not fail promptly")), 1_000); }),
+			]);
+			assert.equal(unterminated.exitCode, 1);
+			assert.match(unterminated.error ?? "", /line exceeded/);
+		} finally {
+			if (settleTimer) clearTimeout(settleTimer);
+		}
+
 		const missing = await runExternalCli({
 			command: process.execPath, args: ["-e", "process.stdout.write('event\\n')"], cwd: dir, prompt: "x", asyncDir: dir, stepIndex: 11,
 			parser: { parseLine() { return undefined; }, finish() { return undefined; } },


### PR DESCRIPTION
This is the Cursor parser slice for #1426.

It keeps Cursor Agent stream parsing bounded when Cursor emits very large non-terminal `tool_call` events. It skips only bounded pre-terminal Cursor `tool_call` lines, rejects unsupported oversized lines at the parser limit, and rejects any post-terminal event even when it is oversized.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/cursor-agent-adapter.test.ts test/unit/external-cli-runner.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`
- Real Cursor read smoke: exit 0, terminal completed, no write canary
- Real Cursor writer smoke: exit 0, terminal completed, write canary created

Fresh exact-head review found no issues.

Note: #1426 is an umbrella issue and should stay open after this parser fix merges.
