### PR TITLE
fix: descend into symlinked directories in agent discovery (#1505)

### DIFF
--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1603,9 +1603,20 @@ function shouldPruneDiscoveryDir(rootDir: string, dir: string, dirName: string):
 	return path.resolve(dir) !== path.resolve(rootDir) && isDiscoveryNestedProjectRoot(dir);
 }
 
-function listFilesRecursive(dir: string, predicate: (fileName: string) => boolean, rootDir = dir): string[] {
+function listFilesRecursive(dir: string, predicate: (fileName: string) => boolean, rootDir = dir, visited = new Set<string>()): string[] {
 	const files: string[] = [];
 	if (!fs.existsSync(dir)) return files;
+
+	// Track canonical paths so symlinks that point back to an ancestor cannot
+	// send recursion into an infinite loop.
+	let canonicalDir: string;
+	try {
+		canonicalDir = fs.realpathSync(dir);
+	} catch {
+		canonicalDir = path.resolve(dir);
+	}
+	if (visited.has(canonicalDir)) return files;
+	visited.add(canonicalDir);
 
 	let entries: fs.Dirent[];
 	try {
@@ -1628,7 +1639,7 @@ function listFilesRecursive(dir: string, predicate: (fileName: string) => boolea
 		}
 		if (isDir) {
 			if (!shouldPruneDiscoveryDir(rootDir, filePath, entry.name)) {
-				files.push(...listFilesRecursive(filePath, predicate, rootDir));
+				files.push(...listFilesRecursive(filePath, predicate, rootDir, visited));
 			}
 			continue;
 		}

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -1616,7 +1616,17 @@ function listFilesRecursive(dir: string, predicate: (fileName: string) => boolea
 
 	for (const entry of entries) {
 		const filePath = path.join(dir, entry.name);
-		if (entry.isDirectory()) {
+		// isDirectory() does not follow symlinks; resolve the target so a symlinked
+		// directory recurses like a real one (matches skill discovery, cf. #262).
+		let isDir = entry.isDirectory();
+		if (entry.isSymbolicLink()) {
+			try {
+				isDir = fs.statSync(filePath).isDirectory();
+			} catch {
+				// dangling symlink: leave isDir false and fall through to the file branch
+			}
+		}
+		if (isDir) {
 			if (!shouldPruneDiscoveryDir(rootDir, filePath, entry.name)) {
 				files.push(...listFilesRecursive(filePath, predicate, rootDir));
 			}

--- a/test/unit/agent-symlink-discovery.test.ts
+++ b/test/unit/agent-symlink-discovery.test.ts
@@ -17,6 +17,19 @@ function writeAgent(dir: string, name: string): string {
 	return filePath;
 }
 
+const SYMLINK_TYPE = process.platform === "win32" ? "junction" : "dir";
+
+function symlinkDir(target: string, linkPath: string): boolean {
+	try {
+		fs.symlinkSync(target, linkPath, SYMLINK_TYPE);
+		return true;
+	} catch (error) {
+		// Windows without Developer Mode/elevation rejects symlink creation (EPERM).
+		if (process.platform === "win32" && (error as NodeJS.ErrnoException).code === "EPERM") return false;
+		throw error;
+	}
+}
+
 describe("agent discovery through symlinked directories (#1505)", () => {
 	beforeEach(() => {
 		for (const key of MANAGED_ENV) saved[key] = process.env[key];
@@ -46,7 +59,7 @@ describe("agent discovery through symlinked directories (#1505)", () => {
 
 		const projectAgentsRoot = path.join(cwd, ".agents");
 		fs.mkdirSync(projectAgentsRoot, { recursive: true });
-		fs.symlinkSync(toolkitAgents, path.join(projectAgentsRoot, "agents"), "dir");
+		if (!symlinkDir(toolkitAgents, path.join(projectAgentsRoot, "agents"))) return;
 
 		const found = discoverAgents(cwd, "project").agents.find((a) => a.name === "shared-reviewer");
 		assert.ok(found, "expected agent inside symlinked directory to be discovered");
@@ -58,7 +71,7 @@ describe("agent discovery through symlinked directories (#1505)", () => {
 
 		const projectAgents = path.join(cwd, ".agents", "agents");
 		fs.mkdirSync(projectAgents, { recursive: true });
-		fs.symlinkSync(toolkitTeam, path.join(projectAgents, "team"), "dir");
+		if (!symlinkDir(toolkitTeam, path.join(projectAgents, "team"))) return;
 
 		const found = discoverAgents(cwd, "project").agents.find((a) => a.name === "team-agent");
 		assert.ok(found, "expected agent inside nested symlinked directory to be discovered");
@@ -68,9 +81,20 @@ describe("agent discovery through symlinked directories (#1505)", () => {
 		const projectAgents = path.join(cwd, ".agents", "agents");
 		fs.mkdirSync(projectAgents, { recursive: true });
 		writeAgent(projectAgents, "real-agent");
-		fs.symlinkSync(path.join(tempDir, "missing-target"), path.join(projectAgents, "gone"), "dir");
+		if (!symlinkDir(path.join(tempDir, "missing-target"), path.join(projectAgents, "gone"))) return;
 
 		const agents = discoverAgents(cwd, "project").agents;
 		assert.ok(agents.find((a) => a.name === "real-agent"), "real agent should still resolve");
+	});
+
+	it("terminates when a symlink points back to an ancestor directory", () => {
+		const projectAgents = path.join(cwd, ".agents", "agents");
+		fs.mkdirSync(projectAgents, { recursive: true });
+		writeAgent(projectAgents, "loop-agent");
+		// A symlink back to an ancestor would loop forever without cycle detection.
+		if (!symlinkDir(projectAgents, path.join(projectAgents, "self"))) return;
+
+		const agents = discoverAgents(cwd, "project").agents;
+		assert.ok(agents.find((a) => a.name === "loop-agent"), "real agent should still resolve despite the cycle");
 	});
 });

--- a/test/unit/agent-symlink-discovery.test.ts
+++ b/test/unit/agent-symlink-discovery.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { discoverAgents } from "../../src/agents/agents.ts";
+
+let tempDir = "";
+let cwd = "";
+const saved: Record<string, string | undefined> = {};
+const MANAGED_ENV = ["PI_CODING_AGENT_DIR", "HOME", "USERPROFILE", "PI_SUBAGENT_EXTRA_AGENT_DIRS"];
+
+function writeAgent(dir: string, name: string): string {
+	const filePath = path.join(dir, `${name}.md`);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, `---\nname: ${name}\ndescription: ${name} agent\n---\n\nDo ${name} work.\n`, "utf-8");
+	return filePath;
+}
+
+describe("agent discovery through symlinked directories (#1505)", () => {
+	beforeEach(() => {
+		for (const key of MANAGED_ENV) saved[key] = process.env[key];
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-agent-symlink-"));
+		// Isolate from the developer's real user agent dirs so defaults are empty.
+		const homeDir = path.join(tempDir, "home");
+		cwd = path.join(tempDir, "workspace");
+		fs.mkdirSync(cwd, { recursive: true });
+		fs.mkdirSync(homeDir, { recursive: true });
+		process.env.PI_CODING_AGENT_DIR = path.join(tempDir, "agent");
+		process.env.HOME = homeDir;
+		process.env.USERPROFILE = homeDir;
+		delete process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
+	});
+
+	afterEach(() => {
+		for (const key of MANAGED_ENV) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
+		}
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("discovers agents inside a symlinked .agents/agents directory", () => {
+		const toolkitAgents = path.join(tempDir, "toolkit", ".agents", "agents");
+		writeAgent(toolkitAgents, "shared-reviewer");
+
+		const projectAgentsRoot = path.join(cwd, ".agents");
+		fs.mkdirSync(projectAgentsRoot, { recursive: true });
+		fs.symlinkSync(toolkitAgents, path.join(projectAgentsRoot, "agents"), "dir");
+
+		const found = discoverAgents(cwd, "project").agents.find((a) => a.name === "shared-reviewer");
+		assert.ok(found, "expected agent inside symlinked directory to be discovered");
+	});
+
+	it("still discovers agents inside a nested symlinked subdirectory", () => {
+		const toolkitTeam = path.join(tempDir, "toolkit", "team");
+		writeAgent(toolkitTeam, "team-agent");
+
+		const projectAgents = path.join(cwd, ".agents", "agents");
+		fs.mkdirSync(projectAgents, { recursive: true });
+		fs.symlinkSync(toolkitTeam, path.join(projectAgents, "team"), "dir");
+
+		const found = discoverAgents(cwd, "project").agents.find((a) => a.name === "team-agent");
+		assert.ok(found, "expected agent inside nested symlinked directory to be discovered");
+	});
+
+	it("ignores a dangling directory symlink without throwing", () => {
+		const projectAgents = path.join(cwd, ".agents", "agents");
+		fs.mkdirSync(projectAgents, { recursive: true });
+		writeAgent(projectAgents, "real-agent");
+		fs.symlinkSync(path.join(tempDir, "missing-target"), path.join(projectAgents, "gone"), "dir");
+
+		const agents = discoverAgents(cwd, "project").agents;
+		assert.ok(agents.find((a) => a.name === "real-agent"), "real agent should still resolve");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1505. Agent discovery skipped symlinked directories under `.agents/`, so a symlinked `.agents/agents` directory (a common way to share agents across checkouts) registered zero agents while skills symlinked the same way resolved fine.

`listFilesRecursive` relied on `fs.Dirent.isDirectory()`, which does not follow symlinks — a symlinked directory reports `isDirectory: false`, falls through to the file branch, fails the `.md` predicate, and is dropped. The walker never enters the target.

## Fix

Resolve symlink targets with `fs.statSync` before deciding whether to recurse, guarding dangling symlinks. This mirrors the skill-discovery scanner (#262) so the two scanners agree: a layout that resolves for skills now resolves for agents.

## Tests

New `test/unit/agent-symlink-discovery.test.ts`:
- discovers agents inside a symlinked `.agents/agents` directory
- discovers agents inside a nested symlinked subdirectory
- ignores a dangling directory symlink without throwing

Confirmed 2/3 fail without the fix and all pass with it.

## Verification

- `tsc --noEmit`: clean
- Full unit suite: 2507 pass / 0 fail / 3 skipped
